### PR TITLE
[LWM] feat(mobile): transactional icons on operation history

### DIFF
--- a/.changeset/calm-otters-wave.md
+++ b/.changeset/calm-otters-wave.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Show transactional dot icons on operation history list items

--- a/apps/ledger-live-mobile/src/mvvm/components/TransactionalIcon/__tests__/TransactionalIcon.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TransactionalIcon/__tests__/TransactionalIcon.test.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { render, screen } from "@tests/test-renderer";
+import TransactionalIcon from "../index";
+
+const bitcoin = getCryptoCurrencyById("bitcoin");
+
+describe("TransactionalIcon", () => {
+  it("should render dot wrapper and crypto icon when operation type has a transactional dot config", () => {
+    render(
+      <TransactionalIcon
+        operationType="IN"
+        isOptimistic={false}
+        currency={bitcoin}
+        mediaSize={48}
+      />,
+    );
+
+    expect(screen.getByTestId(`transactional-icon-dot-IN`)).toBeVisible();
+    expect(screen.getByTestId(`transactional-icon-crypto-bitcoin`)).toBeVisible();
+  });
+
+  it("should render only crypto icon when operation type has no dot config", () => {
+    render(<TransactionalIcon operationType="NONE" isOptimistic={false} currency={bitcoin} />);
+
+    expect(screen.queryByTestId(`transactional-icon-dot-NONE`)).toBeNull();
+    expect(screen.getByTestId(`transactional-icon-crypto-bitcoin`)).toBeVisible();
+  });
+
+  it("should render dot wrapper and crypto icon when optimistic regardless of operation type", () => {
+    render(<TransactionalIcon operationType="NONE" isOptimistic currency={bitcoin} />);
+
+    expect(screen.getByTestId(`transactional-icon-dot-NONE`)).toBeVisible();
+    expect(screen.getByTestId(`transactional-icon-crypto-bitcoin`)).toBeVisible();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/TransactionalIcon/__tests__/getTransactionalDotConfig.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TransactionalIcon/__tests__/getTransactionalDotConfig.test.ts
@@ -1,0 +1,43 @@
+import {
+  ArrowDown,
+  ArrowUp,
+  Clock,
+  Invoice,
+  Link,
+  Mailbox,
+  PenEdit,
+  Snow,
+  Star,
+  Unlink,
+} from "@ledgerhq/lumen-ui-rnative/symbols";
+import { getTransactionalDotConfig } from "../getTransactionalDotConfig";
+
+describe("getTransactionalDotConfig", () => {
+  it("returns clock with muted appearance when optimistic", () => {
+    const config = getTransactionalDotConfig("OUT", true);
+    expect(config).toEqual({ icon: Clock, appearance: "muted" });
+  });
+
+  it.each([
+    ["IN", ArrowDown, "success"],
+    ["OUT", ArrowUp, "muted"],
+    ["FEES", Invoice, "muted"],
+    ["REWARD", Star, "success"],
+    ["WITHDRAW", Star, "success"],
+    ["DELEGATE", Link, "muted"],
+    ["UNDELEGATE", Unlink, "muted"],
+    ["APPROVE", PenEdit, "muted"],
+    ["FREEZE", Snow, "muted"],
+    ["VOTE", Mailbox, "muted"],
+  ] as const)(
+    "maps %s to the expected icon and appearance",
+    (operationType, expectedIcon, expectedAppearance) => {
+      const config = getTransactionalDotConfig(operationType, false);
+      expect(config).toEqual({ icon: expectedIcon, appearance: expectedAppearance });
+    },
+  );
+
+  it("returns null for operation types without a transactional dot", () => {
+    expect(getTransactionalDotConfig("NONE", false)).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/TransactionalIcon/getTransactionalDotConfig.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TransactionalIcon/getTransactionalDotConfig.ts
@@ -1,0 +1,59 @@
+import type { ComponentType } from "react";
+import type { StyleProp, TextStyle } from "react-native";
+import type { DotIconAppearance, IconSize } from "@ledgerhq/lumen-ui-rnative";
+import type { OperationType } from "@ledgerhq/types-live";
+import {
+  ArrowDown,
+  ArrowUp,
+  Clock,
+  Invoice,
+  Link,
+  Mailbox,
+  PenEdit,
+  Snow,
+  Star,
+  Unlink,
+} from "@ledgerhq/lumen-ui-rnative/symbols";
+
+type TransactionalDotIcon = ComponentType<{
+  size?: IconSize;
+  style?: StyleProp<TextStyle>;
+}>;
+
+type TransactionalDotConfig = {
+  icon: TransactionalDotIcon;
+  appearance: DotIconAppearance;
+};
+
+export function getTransactionalDotConfig(
+  operationType: OperationType,
+  isOptimistic: boolean,
+): TransactionalDotConfig | null {
+  if (isOptimistic) {
+    return { icon: Clock, appearance: "muted" };
+  }
+
+  switch (operationType) {
+    case "IN":
+      return { icon: ArrowDown, appearance: "success" };
+    case "OUT":
+      return { icon: ArrowUp, appearance: "muted" };
+    case "FEES":
+      return { icon: Invoice, appearance: "muted" };
+    case "REWARD":
+    case "WITHDRAW":
+      return { icon: Star, appearance: "success" };
+    case "DELEGATE":
+      return { icon: Link, appearance: "muted" };
+    case "UNDELEGATE":
+      return { icon: Unlink, appearance: "muted" };
+    case "APPROVE":
+      return { icon: PenEdit, appearance: "muted" };
+    case "FREEZE":
+      return { icon: Snow, appearance: "muted" };
+    case "VOTE":
+      return { icon: Mailbox, appearance: "muted" };
+    default:
+      return null;
+  }
+}

--- a/apps/ledger-live-mobile/src/mvvm/components/TransactionalIcon/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TransactionalIcon/index.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { DotIcon, mediaImageDotIconSizeMap } from "@ledgerhq/lumen-ui-rnative";
+import CryptoIcon from "@ledgerhq/crypto-icons/native";
+import type { TokenCurrency, CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { getTransactionalDotConfig } from "./getTransactionalDotConfig";
+import type { OperationType } from "@ledgerhq/types-live";
+
+export type TransactionalIconProps = {
+  operationType: OperationType;
+  isOptimistic: boolean;
+  currency: CryptoCurrency | TokenCurrency;
+  mediaSize?: keyof typeof mediaImageDotIconSizeMap;
+};
+
+function TransactionalIcon({
+  operationType,
+  isOptimistic,
+  currency,
+  mediaSize = 48,
+}: Readonly<TransactionalIconProps>) {
+  const dot = getTransactionalDotConfig(operationType, isOptimistic);
+  const cryptoIcon = (
+    <CryptoIcon
+      testID={`transactional-icon-crypto-${currency.name.toLowerCase()}`}
+      ledgerId={currency.id}
+      ticker={currency.ticker}
+      size={mediaSize}
+    />
+  );
+
+  if (!dot) {
+    return cryptoIcon;
+  }
+
+  return (
+    <DotIcon
+      testID={`transactional-icon-dot-${operationType}`}
+      icon={dot.icon}
+      appearance={dot.appearance}
+      size={mediaImageDotIconSizeMap[mediaSize]}
+      pin="top-end"
+    >
+      {cryptoIcon}
+    </DotIcon>
+  );
+}
+
+export default React.memo(TransactionalIcon);

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListItem/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListItem/index.tsx
@@ -12,9 +12,9 @@ import {
 import type { LumenViewStyle, LumenTextStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { Account, AccountLike, Operation } from "@ledgerhq/types-live";
 import { useTranslation } from "~/context/Locale";
-import CurrencyIcon from "~/components/CurrencyIcon";
 import CurrencyUnitValue from "~/components/CurrencyUnitValue";
 import CounterValue from "~/components/CounterValue";
+import TransactionalIcon from "LLM/components/TransactionalIcon";
 import { useOperationsListItemViewModel } from "./useOperationsListItemViewModel";
 
 type Props = {
@@ -68,7 +68,12 @@ function OperationsListItem({
       testID="operations-list-item"
     >
       <ListItemLeading>
-        <CurrencyIcon currency={currency} size={48} hideNetwork />
+        <TransactionalIcon
+          operationType={operationType}
+          isOptimistic={isOptimistic}
+          currency={currency}
+          mediaSize={48}
+        />
         <ListItemContent>
           <ListItemTitle>{title}</ListItemTitle>
           <ListItemDescription>{subtitle}</ListItemDescription>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Operations history list: leading icon per operation (send, receive, fees, staking actions, etc.)
      - Optimistic / pending operations: clock dot treatment
      - Operation types without a mapped dot: unchanged crypto-only icon

### 📝 Description

Operation history rows previously showed only the asset `CurrencyIcon`, so users could not quickly distinguish receive vs send vs other operation categories or in-flight optimistic operations.

This change introduces `TransactionalIcon`, which keeps the crypto icon and, when relevant, wraps it with Lumen `DotIcon` and symbols driven by `getTransactionalDotConfig` (direction, fees, delegation, rewards, freeze, vote, approve, and a clock state for optimistic operations). `OperationsListItem` now uses this component instead of a plain currency icon.
Not all the operations have been mapped yet. It'll be done later


https://github.com/user-attachments/assets/f8e6668b-d86c-4b9e-86f2-29dbd5e04ea3


### ❓ Context

- **JIRA or GitHub link**: [LIVE-29925](https://ledgerhq.atlassian.net/browse/LIVE-29925)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-29925]: https://ledgerhq.atlassian.net/browse/LIVE-29925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ