### PR TITLE
[LWDM] fix(coin-concordium): set coverageProvider babel to fix Jest 30 coverage

### DIFF
--- a/libs/coin-modules/coin-concordium/jest.config.js
+++ b/libs/coin-modules/coin-concordium/jest.config.js
@@ -26,6 +26,7 @@ module.exports = {
     "node_modules/(?!(@walletconnect)/)",
   ],
   workerThreads: true,
+  coverageProvider: "babel",
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** (the fix restores passing coverage collection — 28 suites, 307 tests pass)
- [x] **Impact of the changes:**
  - Only affects `coin-concordium` Jest coverage collection in CI, no runtime impact.

### 📝 Description

`coin-concordium/jest.config.js` uses `workerThreads: true`. With Jest 30 + `@swc/jest`, this causes the coverage provider to fall back to V8, which returns coverage data wrapped as `{ data: ... }`. `istanbul-lib-coverage@3.2.2` (shipped with `@jest/reporters@30`) added a strict `assertValidObject` check and now rejects this format with:

```
Invalid file coverage object, missing keys, found:data
```

This only manifests on files listed in `collectCoverageFrom` that have no tests (`_addUntestedFiles` path in the reporter), e.g. `src/index.ts`.

Fix: explicitly set `coverageProvider: "babel"` to prevent the V8 fallback.

There is a separate unrelated warning about `cross-sha256@1.2.0` missing its `index.js.map` (packaging bug in that npm package, transitive dep via `@walletconnect`) — not addressed here, it's a warning only.

### ❓ Context

- **JIRA or GitHub link**: N/A — CI flakiness fix
- **ADR link (if any)**: N/A