### PR TITLE
ci: add jest-github-actions-reporter to all lib/app jest configs

### DIFF
--- a/.github/workflows/test-libs-reusable.yml
+++ b/.github/workflows/test-libs-reusable.yml
@@ -109,6 +109,42 @@ jobs:
           fi
         shell: bash
 
+      - name: Annotate test failures
+        if: always()
+        run: |
+          node - << 'EOF'
+          const fs = require('fs');
+          const { execSync } = require('child_process');
+
+          let xmlFiles;
+          try {
+            xmlFiles = execSync('find libs -name "sonar-executionTests-report.xml" 2>/dev/null')
+              .toString().trim().split('\n').filter(Boolean);
+          } catch (e) { process.exit(0); }
+
+          const REPO = process.cwd() + '/';
+          const unescapeXml = s => s.replace(/&lt;/g,'<').replace(/&gt;/g,'>').replace(/&amp;/g,'&').replace(/&quot;/g,'"').replace(/&apos;/g,"'");
+          const encProp = s => s.replace(/%/g,'%25').replace(/\r/g,'%0D').replace(/\n/g,'%0A').replace(/,/g,'%2C').replace(/:/g,'%3A');
+          const encMsg  = s => s.replace(/%/g,'%25').replace(/\r/g,'%0D').replace(/\n/g,'%0A');
+
+          let count = 0;
+          for (const xmlFile of xmlFiles) {
+            let content;
+            try { content = fs.readFileSync(xmlFile, 'utf8'); } catch (e) { continue; }
+
+            for (const [, filePath, fileContent] of content.matchAll(/<file path="([^"]+)">([\s\S]*?)<\/file>/g)) {
+              const relFile = filePath.replace(REPO, '');
+              for (const [, name, body] of fileContent.matchAll(/<testCase name="([^"]+)"[^>]*>[\s\S]*?<failure[^>]*>([\s\S]*?)<\/failure>/g)) {
+                const title = unescapeXml(name);
+                const msg = unescapeXml(body.trim()).slice(0, 1000);
+                console.log(`::error file=${relFile},title=${encProp(title)}::${encMsg(msg)}`);
+                count++;
+              }
+            }
+          }
+          if (count === 0) console.log('::notice::All library tests passed');
+          EOF
+
       - name: (On Failure) Upload live-common snapshots and source
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: failure()


### PR DESCRIPTION
### ✅ Checklist

- [ ] \`npx changeset\` was attached. <!-- N/A — CI/dev tooling only, no published package change -->
- [x] **Covered by automatic tests.** <!-- The reporter itself is the test mechanism -->
- [ ] **Impact of the changes:**
  - When a jest test fails in CI, a GitHub Actions \`::error::\` annotation is emitted for that test
  - Annotations appear in the PR **Files** tab (inline next to the failing file) and in the job **Summary → Annotations** section
  - Works for all libs and apps — no more grepping through walls of console noise
  - Zero runtime overhead vs. a post-processing step

### 📝 Description

Test failures in the Libraries Test CI job were invisible without scrolling through hundreds of lines of console errors and warnings.

This adds \`jest-github-actions-reporter\` to every jest config in \`libs/\` and \`apps/\`, active only in CI via \`process.env.CI\`. The reporter emits GitHub Actions [workflow commands](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message) directly during the jest run:

\`\`\`
::error file=libs/foo/src/bar.test.ts,line=42,title=MyTest > should do X::Expected true to be false
\`\`\`

**Changes:**
- 123 \`jest.config.{js,ts}\` files: \`...(process.env.CI ? ["github-actions"] : [])\` inserted after \`"default"\` in \`reporters\`
- 2 JSON configs (\`device-core\`, \`device-react\`) converted to JS (JSON can't have \`process.env\` checks)
- \`package.json\`: \`jest-github-actions-reporter@1.0.3\` added to \`devDependencies\`
- Existing \`jest-sonar\` reporter preserved in all files

### ❓ Context

- **JIRA or GitHub link**: internal DX — see noisy CI run https://github.com/LedgerHQ/ledger-live/actions/runs/25013053380/job/73253767454
- **ADR link (if any)**: N/A