### PR TITLE
ci(temp): test jest failure summary step in PR CI

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -83,8 +83,8 @@ jobs:
   test-libraries:
     name: "Test Libraries"
     needs: determine-affected
-    if: ${{contains(needs.determine-affected.outputs.paths, 'libs') && !github.event.pull_request.head.repo.fork}}
-    uses: LedgerHQ/ledger-live/.github/workflows/test-libs-reusable.yml@develop
+    if: ${{!github.event.pull_request.head.repo.fork}}
+    uses: LedgerHQ/ledger-live/.github/workflows/test-libs-reusable.yml@feat/jest-github-step-summary
     secrets: inherit
 
   test-features:

--- a/.github/workflows/test-libs-reusable.yml
+++ b/.github/workflows/test-libs-reusable.yml
@@ -109,6 +109,52 @@ jobs:
           fi
         shell: bash
 
+      - name: Summarize test failures
+        if: always()
+        run: |
+          node - << 'EOF'
+          const fs = require('fs');
+          const { execSync } = require('child_process');
+          const summaryFile = process.env.GITHUB_STEP_SUMMARY;
+          if (!summaryFile) process.exit(0);
+
+          let xmlFiles;
+          try {
+            xmlFiles = execSync('find libs -name "sonar-executionTests-report.xml" 2>/dev/null')
+              .toString().trim().split('\n').filter(Boolean);
+          } catch (e) { process.exit(0); }
+
+          const unescape = s => s.replace(/&lt;/g,'<').replace(/&gt;/g,'>').replace(/&amp;/g,'&').replace(/&quot;/g,'"');
+          const failures = [];
+          for (const file of xmlFiles) {
+            let content;
+            try { content = fs.readFileSync(file, 'utf8'); } catch (e) { continue; }
+            const matches = [...content.matchAll(
+              /<testCase name="([^"]+)"[^>]*>[\s\S]*?<failure message="([^"]*)">([\s\S]*?)<\/failure>[\s\S]*?<\/testCase>/g
+            )];
+            if (matches.length) {
+              const lib = file.replace('/sonar-executionTests-report.xml', '').replace(/^\.\//, '');
+              failures.push(...matches.map(m => ({ lib, name: unescape(m[1]), msg: unescape(m[2]) })));
+            }
+          }
+
+          if (!failures.length) {
+            fs.appendFileSync(summaryFile, '## ✅ All tests passed\n');
+            process.exit(0);
+          }
+
+          const byLib = {};
+          for (const f of failures) (byLib[f.lib] ??= []).push(f);
+
+          let md = `## ❌ ${failures.length} test failure(s)\n\n`;
+          for (const [lib, tests] of Object.entries(byLib)) {
+            md += `### \`${lib}\`\n`;
+            for (const t of tests)
+              md += `<details><summary>❌ ${t.name}</summary>\n\n\`\`\`\n${t.msg.slice(0, 800)}\n\`\`\`\n</details>\n\n`;
+          }
+          fs.appendFileSync(summaryFile, md);
+          EOF
+
       - name: (On Failure) Upload live-common snapshots and source
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: failure()


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. <!-- N/A — temporary test PR, not for merging -->
- [ ] **Covered by automatic tests.**
- [ ] **Impact of the changes:**
  - **DO NOT MERGE** — this is a temporary test PR to validate #16870

### 📝 Description

This PR temporarily:
1. Pins `test-libs-reusable.yml` to `feat/jest-github-step-summary` instead of `@develop`
2. Removes the `libs`-affected guard so the Libraries Test always runs

Purpose: verify that the Step Summary failure reporter (introduced in #16870) works correctly in the PR CI context.

Once validated, this PR is discarded and #16870 is the actual thing to merge.

### ❓ Context

- **JIRA or GitHub link**: see #16870