### PR TITLE
ci(temp): test jest failure annotations in PR CI

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -83,8 +83,8 @@ jobs:
   test-libraries:
     name: "Test Libraries"
     needs: determine-affected
-    if: ${{contains(needs.determine-affected.outputs.paths, 'libs') && !github.event.pull_request.head.repo.fork}}
-    uses: LedgerHQ/ledger-live/.github/workflows/test-libs-reusable.yml@develop
+    if: ${{!github.event.pull_request.head.repo.fork}}
+    uses: LedgerHQ/ledger-live/.github/workflows/test-libs-reusable.yml@feat/jest-github-step-summary
     secrets: inherit
 
   test-features:

--- a/.github/workflows/test-libs-reusable.yml
+++ b/.github/workflows/test-libs-reusable.yml
@@ -109,6 +109,42 @@ jobs:
           fi
         shell: bash
 
+      - name: Annotate test failures
+        if: always()
+        run: |
+          node - << 'EOF'
+          const fs = require('fs');
+          const { execSync } = require('child_process');
+
+          let xmlFiles;
+          try {
+            xmlFiles = execSync('find libs -name "sonar-executionTests-report.xml" 2>/dev/null')
+              .toString().trim().split('\n').filter(Boolean);
+          } catch (e) { process.exit(0); }
+
+          const REPO = process.cwd() + '/';
+          const unescapeXml = s => s.replace(/&lt;/g,'<').replace(/&gt;/g,'>').replace(/&amp;/g,'&').replace(/&quot;/g,'"').replace(/&apos;/g,"'");
+          const encProp = s => s.replace(/%/g,'%25').replace(/\r/g,'%0D').replace(/\n/g,'%0A').replace(/,/g,'%2C').replace(/:/g,'%3A');
+          const encMsg  = s => s.replace(/%/g,'%25').replace(/\r/g,'%0D').replace(/\n/g,'%0A');
+
+          let count = 0;
+          for (const xmlFile of xmlFiles) {
+            let content;
+            try { content = fs.readFileSync(xmlFile, 'utf8'); } catch (e) { continue; }
+
+            for (const [, filePath, fileContent] of content.matchAll(/<file path="([^"]+)">([\s\S]*?)<\/file>/g)) {
+              const relFile = filePath.replace(REPO, '');
+              for (const [, name, body] of fileContent.matchAll(/<testCase name="([^"]+)"[^>]*>[\s\S]*?<failure[^>]*>([\s\S]*?)<\/failure>/g)) {
+                const title = unescapeXml(name);
+                const msg = unescapeXml(body.trim()).slice(0, 1000);
+                console.log(`::error file=${relFile},title=${encProp(title)}::${encMsg(msg)}`);
+                count++;
+              }
+            }
+          }
+          if (count === 0) console.log('::notice::All library tests passed');
+          EOF
+
       - name: (On Failure) Upload live-common snapshots and source
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: failure()


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. <!-- N/A — temporary test PR, not for merging -->
- [ ] **Covered by automatic tests.**
- [ ] **Impact of the changes:**
  - **DO NOT MERGE** — temporary test PR to validate #16870

### 📝 Description

Pins `test-libs-reusable.yml` to `feat/jest-github-step-summary` and forces the Libraries Test to run (removes `libs`-affected guard).

Purpose: verify that the `::error::` annotation reporter (introduced in #16870) works correctly in the PR CI context — each failed test should appear as a GitHub annotation with the test name as title and full error body as message.

Discard after validation.

### ❓ Context

- **JIRA or GitHub link**: see #16870