### PR TITLE
[LWDM] feat(LIVE-28592): algorithm for aleo auto record picking

### DIFF
--- a/.changeset/late-starfishes-fetch.md
+++ b/.changeset/late-starfishes-fetch.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+feat: algorithm for aleo auto record picking

--- a/libs/coin-modules/coin-aleo/src/constants.ts
+++ b/libs/coin-modules/coin-aleo/src/constants.ts
@@ -21,7 +21,8 @@ export const TRANSACTION_TYPE = {
 export const RECIPIENT_ARG_INDEX = 1;
 export const AMOUNT_ARG_INDEX = 2;
 
-// The maximum amount of records to fetch in a single API call when fetching owned records. This is not a limit on the total number of records that can be fetched, but rather a pagination parameter for the API calls.
+// The maximum amount of records to fetch in a single API call when fetching owned records.
+// This is not a limit on the total number of records that can be fetched, but rather a pagination parameter for the API calls.
 export const DEFAULT_RECORDS_PAGE_SIZE = 1000;
 
 /**
@@ -37,3 +38,6 @@ export const PROGRESS_AFTER_LIST_OPS = PROGRESS_AFTER_SCANNER + 35; // 65
 export const PROGRESS_AFTER_PARSING_RECORDS = 30; // 65 → 95
 export const PROGRESS_DONE = 100;
 export const PROGRESS_THROTTLE_MIN_STEP = 5;
+
+// The maximum number of private records that can be included in a single transaction.
+export const MAX_PRIVATE_RECORDS_PER_TRANSACTION = 14;

--- a/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
@@ -2,7 +2,11 @@ import BigNumber from "bignumber.js";
 import type { TransactionIntent } from "@ledgerhq/coin-module-framework/api/types";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import aleoConfig from "../config";
-import { EXPLORER_TRANSFER_TYPES, TRANSACTION_TYPE } from "../constants";
+import {
+  EXPLORER_TRANSFER_TYPES,
+  MAX_PRIVATE_RECORDS_PER_TRANSACTION,
+  TRANSACTION_TYPE,
+} from "../constants";
 import { getMockedCurrency } from "../__tests__/fixtures/currency.fixture";
 import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
 import {
@@ -58,6 +62,7 @@ import {
   getNextSequenceNumber,
   extractViewKey,
   findBestRecordForFee,
+  selectPrivateRecordsForAmount,
 } from "./utils";
 
 jest.mock("../config");
@@ -1489,5 +1494,211 @@ describe("findBestRecordForFee", () => {
       selectedAmountRecordCommitment: null,
     });
     expect(result).toBe(mockUnspentRecord1);
+  });
+});
+
+describe("selectPrivateRecordsForAmount", () => {
+  it("should return top MAX_PRIVATE_RECORDS_PER_TRANSACTION records by value descending when targetAmount is null", () => {
+    const records = Array.from({ length: MAX_PRIVATE_RECORDS_PER_TRANSACTION + 2 }, (_, i) => ({
+      ...mockUnspentRecord1,
+      commitment: `r${i}`,
+      microcredits: `${(i + 1) * 10}`,
+    }));
+
+    const result = selectPrivateRecordsForAmount({ unspentRecords: records, targetAmount: null });
+    const expectedMicrocredits = [...records]
+      .sort((a, b) => new BigNumber(b.microcredits).comparedTo(new BigNumber(a.microcredits)))
+      .slice(0, MAX_PRIVATE_RECORDS_PER_TRANSACTION)
+      .map(r => r.microcredits);
+
+    expect(result.map(r => r.microcredits)).toEqual(expectedMicrocredits);
+  });
+
+  it("should return empty array when targetAmount is null and input is empty", () => {
+    const result = selectPrivateRecordsForAmount({ unspentRecords: [], targetAmount: null });
+
+    expect(result).toEqual([]);
+  });
+
+  it("should pick the smallest single record that covers the target", () => {
+    const unspentRecords = [
+      { ...mockUnspentRecord1, microcredits: "50" },
+      { ...mockUnspentRecord2, microcredits: "5" },
+    ];
+
+    const result = selectPrivateRecordsForAmount({
+      unspentRecords,
+      targetAmount: new BigNumber(1),
+    });
+
+    expect(result.map(r => r.microcredits)).toEqual(["5"]);
+  });
+
+  it("should skip records below the target and pick the next sufficient one", () => {
+    // [1000, 500, 1, 1]: target 2 -> dust (1) is insufficient, so smallest sufficient is 500
+    const unspentRecords = [
+      { ...mockUnspentRecord1, commitment: "r0", microcredits: "1000" },
+      { ...mockUnspentRecord1, commitment: "r1", microcredits: "500" },
+      { ...mockUnspentRecord2, commitment: "r2", microcredits: "1" },
+      { ...mockUnspentRecord2, commitment: "r3", microcredits: "1" },
+    ];
+
+    const result = selectPrivateRecordsForAmount({
+      unspentRecords,
+      targetAmount: new BigNumber(2),
+    });
+
+    expect(result.map(r => r.microcredits)).toEqual(["500"]);
+  });
+
+  it("should skip 500 when the target is 501 and only 1000 is sufficient", () => {
+    const unspentRecords = [
+      { ...mockUnspentRecord1, commitment: "r0", microcredits: "1000" },
+      { ...mockUnspentRecord1, commitment: "r1", microcredits: "500" },
+    ];
+
+    const result = selectPrivateRecordsForAmount({
+      unspentRecords,
+      targetAmount: new BigNumber(501),
+    });
+
+    expect(result.map(r => r.microcredits)).toEqual(["1000"]);
+  });
+
+  it("should accumulate largest records first when no single record covers the target", () => {
+    const unspentRecords = [
+      { ...mockUnspentRecord1, microcredits: "7" },
+      { ...mockUnspentRecord2, microcredits: "5" },
+    ];
+
+    const result = selectPrivateRecordsForAmount({
+      unspentRecords,
+      targetAmount: new BigNumber(10),
+    });
+
+    expect(result.map(r => r.microcredits)).toEqual(["7", "5"]);
+  });
+
+  it("should stop accumulating once the running total meets the target", () => {
+    const records = Array.from({ length: 10 }, (_, i) => ({
+      ...mockUnspentRecord1,
+      commitment: `r${i}`,
+      microcredits: "10",
+    }));
+
+    const result = selectPrivateRecordsForAmount({
+      unspentRecords: records,
+      targetAmount: new BigNumber(50),
+    });
+
+    expect(result.map(r => r.microcredits)).toEqual(["10", "10", "10", "10", "10"]);
+  });
+
+  it("should cap selection at maxRecords and overshoot rather than exceed the limit", () => {
+    const singleRecordValue = 10;
+    const records = Array.from({ length: MAX_PRIVATE_RECORDS_PER_TRANSACTION + 2 }, (_, i) => ({
+      ...mockUnspentRecord1,
+      commitment: `r${i}`,
+      microcredits: singleRecordValue.toString(),
+    }));
+
+    const result = selectPrivateRecordsForAmount({
+      unspentRecords: records,
+      // just under the sum of max records
+      targetAmount: new BigNumber(MAX_PRIVATE_RECORDS_PER_TRANSACTION * singleRecordValue).minus(1),
+    });
+
+    const expectedMicrocredits = records
+      .slice(0, MAX_PRIVATE_RECORDS_PER_TRANSACTION)
+      .map(r => r.microcredits);
+
+    expect(result.map(r => r.microcredits)).toEqual(expectedMicrocredits);
+  });
+
+  it("should stop accumulating before recruiting dust when larger records already cover the target", () => {
+    const unspentRecords = [
+      { ...mockUnspentRecord1, commitment: "r0", microcredits: "1000" },
+      { ...mockUnspentRecord1, commitment: "r1", microcredits: "500" },
+      { ...mockUnspentRecord2, commitment: "r2", microcredits: "1" },
+      { ...mockUnspentRecord2, commitment: "r3", microcredits: "1" },
+    ];
+
+    const result = selectPrivateRecordsForAmount({
+      unspentRecords,
+      targetAmount: new BigNumber(1001),
+    });
+
+    expect(result.map(r => r.microcredits)).toEqual(["1000", "500"]);
+  });
+
+  it("should return empty array for target ≤ 0", () => {
+    const unspentRecords = [{ ...mockUnspentRecord1, microcredits: "100" }];
+
+    expect(
+      selectPrivateRecordsForAmount({ unspentRecords, targetAmount: new BigNumber(0) }),
+    ).toEqual([]);
+    expect(
+      selectPrivateRecordsForAmount({ unspentRecords, targetAmount: new BigNumber(-1) }),
+    ).toEqual([]);
+  });
+
+  it("should filter out zero-value records before selection", () => {
+    const unspentRecords = [
+      { ...mockUnspentRecord1, commitment: "r0", microcredits: "0" },
+      { ...mockUnspentRecord1, commitment: "r1", microcredits: "0" },
+      { ...mockUnspentRecord2, commitment: "r2", microcredits: "10" },
+    ];
+
+    const result = selectPrivateRecordsForAmount({
+      unspentRecords,
+      targetAmount: new BigNumber(5),
+    });
+
+    expect(result.map(r => r.microcredits)).toEqual(["10"]);
+  });
+
+  it("should return empty array when the record cap is exhausted before the target is covered", () => {
+    const recordsCount = MAX_PRIVATE_RECORDS_PER_TRANSACTION + 2;
+    const recordValue = 10;
+    const unspentRecords = Array.from({ length: recordsCount }, (_, i) => ({
+      ...mockUnspentRecord1,
+      commitment: `r${i}`,
+      microcredits: recordValue.toString(),
+    }));
+
+    const result = selectPrivateRecordsForAmount({
+      unspentRecords,
+      targetAmount: new BigNumber(recordsCount * recordValue),
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("should return all records when their total exactly meets the target", () => {
+    const unspentRecords = [
+      { ...mockUnspentRecord1, commitment: "r0", microcredits: "300" },
+      { ...mockUnspentRecord2, commitment: "r1", microcredits: "200" },
+    ];
+
+    const result = selectPrivateRecordsForAmount({
+      unspentRecords,
+      targetAmount: new BigNumber(500),
+    });
+
+    expect(result.map(r => r.microcredits)).toEqual(["300", "200"]);
+  });
+
+  it("should return empty array when total funds are insufficient to meet the target", () => {
+    const unspentRecords = [
+      { ...mockUnspentRecord1, commitment: "r0", microcredits: "100" },
+      { ...mockUnspentRecord2, commitment: "r1", microcredits: "50" },
+    ];
+
+    const result = selectPrivateRecordsForAmount({
+      unspentRecords,
+      targetAmount: new BigNumber(999),
+    });
+
+    expect(result).toEqual([]);
   });
 });

--- a/libs/coin-modules/coin-aleo/src/logic/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.ts
@@ -14,7 +14,12 @@ import {
 } from "@ledgerhq/ledger-wallet-framework/account/accountId";
 import { decodeOperationId, encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import aleoConfig from "../config";
-import { EXPLORER_TRANSFER_TYPES, PROGRAM_ID, TRANSACTION_TYPE } from "../constants";
+import {
+  EXPLORER_TRANSFER_TYPES,
+  MAX_PRIVATE_RECORDS_PER_TRANSACTION,
+  PROGRAM_ID,
+  TRANSACTION_TYPE,
+} from "../constants";
 import type {
   AleoOperation,
   AleoTransactionType,
@@ -614,4 +619,70 @@ export function extractViewKey(account: AleoAccount): string {
   const viewKey = decodeAccountId(account.id).customData;
   invariant(viewKey, `aleo: view key is missing in ${account.freshAddress} account`);
   return viewKey;
+}
+
+/**
+ * Selects the minimum set of private records needed to cover `targetAmount` using a greedy largest-first strategy.
+ *
+ * - If `targetAmount` is `null`, returns the top `MAX_PRIVATE_RECORDS_PER_TRANSACTION` records by value (useAllAmount mode).
+ * - If `targetAmount` is provided and positive:
+ *   1. Prefer the **smallest single record** that alone covers the target (fewest records, least overshoot).
+ *   2. Otherwise accumulate the **largest records first** until the running total meets the target or
+ *      `MAX_PRIVATE_RECORDS_PER_TRANSACTION` is exhausted.
+ *
+ * Returns `[]` when the target cannot be covered — either because total funds are insufficient
+ * or the record cap is exhausted before the running total reaches the target.
+ */
+export function selectPrivateRecordsForAmount({
+  unspentRecords,
+  targetAmount,
+}: {
+  unspentRecords: AleoUnspentRecord[];
+  targetAmount: BigNumber | null;
+}): AleoUnspentRecord[] {
+  const rankedRecords = unspentRecords
+    .map(record => ({ record, value: new BigNumber(record.microcredits) }))
+    .filter(({ value }) => value.isGreaterThan(0))
+    .sort((a, b) => b.value.comparedTo(a.value));
+
+  if (rankedRecords.length === 0) {
+    return [];
+  }
+
+  // no target amount supplied -> useAllAmount mode, return top N records.
+  if (targetAmount === null) {
+    return rankedRecords.slice(0, MAX_PRIVATE_RECORDS_PER_TRANSACTION).map(({ record }) => record);
+  }
+
+  if (targetAmount.lte(0)) {
+    return [];
+  }
+
+  // Step 1: Find the smallest single record that covers the target (least overshoot).
+  // Scanning from the end of the descending array gives us the smallest candidate first.
+  for (let i = rankedRecords.length - 1; i >= 0; i--) {
+    if (rankedRecords[i].value.gte(targetAmount)) {
+      return [rankedRecords[i].record];
+    }
+  }
+
+  // Step 2: No single record is sufficient - accumulate largest-first.
+  const selected: AleoUnspentRecord[] = [];
+  let runningTotal = new BigNumber(0);
+
+  for (const { record, value } of rankedRecords) {
+    if (selected.length >= MAX_PRIVATE_RECORDS_PER_TRANSACTION) {
+      break;
+    }
+
+    selected.push(record);
+    runningTotal = runningTotal.plus(value);
+
+    if (runningTotal.gte(targetAmount)) {
+      return selected;
+    }
+  }
+
+  // Target could not be covered within the record cap or with the available funds.
+  return [];
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - added `selectPrivateRecordsForAmount` to coin-aleo, not used anywhere yet

### 📝 Description

This PR implements greedy max-to-min auto-selection algorithm in coin-aleo module. Integration is currently in a prototype stage.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-28592

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
