### PR TITLE
fix(wallet-cli): recover Windows WebUSB discovery after late device attach

### DIFF
--- a/.changeset/gentle-usbs-recover.md
+++ b/.changeset/gentle-usbs-recover.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-cli": minor
+---
+
+Fix Windows WebUSB discovery when devices are connected after wallet-cli startup

--- a/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.test.ts
+++ b/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import type {
+  ApduReceiverServiceFactory,
+  ApduSenderServiceFactory,
+  DeviceModelDataSource,
+  LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
+import type { Subscription } from "rxjs";
+import { NodeWebUsbTransport } from "./NodeWebUsbTransport";
+
+function flushTasks(): Promise<void> {
+  return new Promise(resolve => queueMicrotask(resolve));
+}
+
+function createLogger(): LoggerPublisherService {
+  return {
+    subscribers: [],
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  } as unknown as LoggerPublisherService;
+}
+
+describe("NodeWebUsbTransport", () => {
+  let subscriptions: Subscription[] = [];
+
+  afterEach(() => {
+    subscriptions.forEach(subscription => subscription.unsubscribe());
+    subscriptions = [];
+  });
+
+  it("refreshes discovered devices from the Windows polling fallback when hotplug attach is missed", async () => {
+    const nativeDevice = {
+      deviceDescriptor: {
+        idVendor: 0x2c97,
+        idProduct: 0x5011,
+      },
+    };
+    const webUsbDevice = {
+      vendorId: 0x2c97,
+      productId: 0x5011,
+      serialNumber: "ledger-1",
+      configurations: [
+        {
+          interfaces: [
+            {
+              interfaceNumber: 1,
+              alternates: [{ interfaceClass: 255 }],
+            },
+          ],
+        },
+      ],
+    };
+
+    let currentDeviceList: (typeof nativeDevice)[] = [];
+    let pollCallback: (() => void) | undefined;
+    let clearedInterval: ReturnType<typeof globalThis.setInterval> | null = null;
+
+    const transport = new NodeWebUsbTransport(
+      {
+        getAllDeviceModels: () => [
+          {
+            id: "nanoSP",
+            productName: "Ledger Nano S Plus",
+            usbProductId: 0x50,
+            bootloaderUsbProductId: 0x5011,
+          },
+        ],
+      } as DeviceModelDataSource,
+      () => createLogger(),
+      (() => {
+        throw new Error("unused apdu sender factory");
+      }) as ApduSenderServiceFactory,
+      (() => {
+        throw new Error("unused apdu receiver factory");
+      }) as ApduReceiverServiceFactory,
+      undefined,
+      undefined,
+      {
+        platform: "win32",
+        getDeviceList: () => currentDeviceList as never[],
+        createWebUsbDevice: async () => webUsbDevice as never,
+        usbBindings: {
+          on: () => {},
+          removeListener: () => {},
+          unrefHotplugEvents: () => {},
+        },
+        setInterval: callback => {
+          pollCallback = callback;
+          return 0 as unknown as ReturnType<typeof globalThis.setInterval>;
+        },
+        clearInterval: handle => {
+          clearedInterval = handle;
+        },
+      },
+    );
+
+    const emissions: Array<{ id: string; transport: string }> = [];
+    subscriptions.push(
+      transport.listenToAvailableDevices().subscribe(devices => {
+        emissions.push(...devices.map(device => ({ id: device.id, transport: device.transport })));
+      }),
+    );
+
+    await flushTasks();
+    expect(emissions).toHaveLength(0);
+    expect(pollCallback).toBeDefined();
+
+    currentDeviceList = [nativeDevice];
+    pollCallback?.();
+    await flushTasks();
+
+    expect(emissions).toHaveLength(1);
+    expect(emissions[0]?.transport).toBe("NODE-WEBUSB");
+    expect(typeof emissions[0]?.id).toBe("string");
+
+    transport.destroy();
+    expect(clearedInterval).not.toBeNull();
+  });
+});

--- a/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.test.ts
+++ b/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.test.ts
@@ -531,6 +531,151 @@ describe("NodeWebUsbTransport", () => {
     transport.destroy();
   });
 
+  it("keeps a machine pending and not active when eventDeviceConnected throws during reconnection", async () => {
+    const nativeDevice = {
+      deviceDescriptor: {
+        idVendor: 0x2c97,
+        idProduct: 0x5011,
+      },
+    };
+    const webUsbDevice = {
+      vendorId: 0x2c97,
+      productId: 0x5011,
+      serialNumber: "ledger-1",
+      configurations: [
+        {
+          interfaces: [
+            {
+              interfaceNumber: 1,
+              alternates: [{ interfaceClass: 255 }],
+            },
+          ],
+        },
+      ],
+    };
+
+    const currentDeviceList: (typeof nativeDevice)[] = [nativeDevice];
+    let tryToReconnect:
+      | DeviceConnectionStateMachineParams<NodeWebUsbApduSenderDependencies>["tryToReconnect"]
+      | undefined;
+    let connectedDeviceId: DeviceId | undefined;
+    let setupConnectionCalls = 0;
+    let eventDeviceConnectedCalls = 0;
+    let eventDeviceDisconnectedCalls = 0;
+    let closeConnectionCalls = 0;
+
+    const transport = new NodeWebUsbTransport(
+      {
+        getAllDeviceModels: () => [
+          {
+            id: "nanoSP",
+            productName: "Ledger Nano S Plus",
+            usbProductId: 0x50,
+            bootloaderUsbProductId: 0x5011,
+          },
+        ],
+      } as DeviceModelDataSource,
+      () => createLogger(),
+      (() => {
+        throw new Error("unused apdu sender factory");
+      }) as ApduSenderServiceFactory,
+      (() => {
+        throw new Error("unused apdu receiver factory");
+      }) as ApduReceiverServiceFactory,
+      params => {
+        tryToReconnect = params.tryToReconnect;
+
+        return {
+          setupConnection: async () => {
+            setupConnectionCalls += 1;
+          },
+          sendApdu: async () => Right(new Uint8Array()) as never,
+          getDeviceId: () => params.deviceId,
+          getDependencies: () => ({
+            device: webUsbDevice as never,
+            interfaceNumber: 1,
+          }),
+          setDependencies: () => {},
+          eventDeviceDisconnected: () => {
+            eventDeviceDisconnectedCalls += 1;
+          },
+          eventDeviceConnected: () => {
+            eventDeviceConnectedCalls += 1;
+            // eventDeviceConnected is only invoked from the reconnect path —
+            // configure it to always fail to keep the machine pending and
+            // expose any leak into the active map.
+            throw new Error("state machine refused connected event");
+          },
+          closeConnection: () => {
+            closeConnectionCalls += 1;
+          },
+        } as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>;
+      },
+      () => createStubApduSender() as never,
+      {
+        platform: "win32",
+        getDeviceList: () => currentDeviceList as never[],
+        createWebUsbDevice: async () => webUsbDevice as never,
+        usbBindings: {
+          on: () => {},
+          removeListener: () => {},
+          unrefHotplugEvents: () => {},
+        },
+        setInterval: callback => {
+          queueMicrotask(callback);
+          return 0 as unknown as ReturnType<typeof globalThis.setInterval>;
+        },
+        clearInterval: () => {},
+      },
+    );
+
+    const emissions: Array<Array<{ id: string; transport: string }>> = [];
+    subscriptions.push(
+      transport.listenToAvailableDevices().subscribe(devices => {
+        emissions.push(devices.map(device => ({ id: device.id, transport: device.transport })));
+      }),
+    );
+
+    await waitFor(() => {
+      connectedDeviceId = emissions.at(-1)?.[0]?.id;
+      expect(connectedDeviceId).toBeDefined();
+    });
+
+    const connected = await transport.connect({
+      deviceId: connectedDeviceId!,
+      onDisconnect: () => {},
+    });
+
+    expect(setupConnectionCalls).toBe(1);
+    expect(eventDeviceConnectedCalls).toBe(0);
+    expect(tryToReconnect).toBeDefined();
+    expect(connected.isRight()).toBe(true);
+
+    // Trigger pending reconnection. handleDeviceReconnection will run
+    // setupConnection (success) then eventDeviceConnected (throws).
+    tryToReconnect?.(0);
+
+    await waitFor(() => {
+      expect(setupConnectionCalls).toBe(2);
+      expect(eventDeviceConnectedCalls).toBe(1);
+    });
+
+    // After the failed publish, the machine must NOT remain in the active
+    // device-by-webusb map. We probe that map externally via a detach event:
+    // handleDeviceDisconnection iterates _deviceConnectionsByWebUsbDevice and
+    // would call eventDeviceDisconnected on any entry it finds. With the leak,
+    // the broken machine would still be there and would receive the event;
+    // with the fix it has been removed and the detach is a no-op.
+    await transport.handleDeviceDisconnection(nativeDevice as never);
+    expect(eventDeviceDisconnectedCalls).toBe(0);
+
+    // The machine was never closed: the reconnect path should leave it
+    // recoverable rather than tearing it down on a transient failure.
+    expect(closeConnectionCalls).toBe(0);
+
+    transport.destroy();
+  });
+
   it("serializes APDU calls sent through the same connected device", async () => {
     const nativeDevice = {
       deviceDescriptor: {

--- a/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.test.ts
+++ b/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.test.ts
@@ -1,13 +1,14 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import type {
-  ApduReceiverServiceFactory,
-  ApduSenderServiceFactory,
-  DeviceConnectionStateMachine,
-  DeviceConnectionStateMachineParams,
-  DeviceModelDataSource,
-  DeviceId,
-  LoggerPublisherService,
-  TransportConnectedDevice,
+import {
+  DeviceDisconnectedBeforeSendingApdu,
+  type ApduReceiverServiceFactory,
+  type ApduSenderServiceFactory,
+  type DeviceConnectionStateMachine,
+  type DeviceConnectionStateMachineParams,
+  type DeviceModelDataSource,
+  type DeviceId,
+  type LoggerPublisherService,
+  type TransportConnectedDevice,
 } from "@ledgerhq/device-management-kit";
 import { Right } from "purify-ts";
 import type { Subscription } from "rxjs";
@@ -507,16 +508,19 @@ describe("NodeWebUsbTransport", () => {
       onDisconnect: () => {},
     });
 
-    currentDeviceList = [];
     tryToReconnect?.(0);
 
-    await transport.handleDeviceConnection(nativeDevice as never);
-    expect(setupConnectionCalls).toBe(2);
+    await waitFor(() => {
+      expect(setupConnectionCalls).toBe(2);
+    });
     expect(eventDeviceConnectedCalls).toBe(0);
     expect(closeConnectionCalls).toBe(0);
 
-    currentDeviceList = [nativeDevice];
-    await transport.updateTransportDiscoveredDevices();
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      await transport.updateTransportDiscoveredDevices();
+      if (setupConnectionCalls === 3) break;
+      await flushTasks();
+    }
     await waitFor(() => {
       expect(setupConnectionCalls).toBe(3);
       expect(eventDeviceConnectedCalls).toBe(1);
@@ -716,6 +720,7 @@ describe("NodeWebUsbTransport", () => {
           eventDeviceConnected: () => {},
           closeConnection: () => {
             closeConnectionCalls += 1;
+            params.onTerminated();
           },
         }) as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>,
       () => createStubApduSender() as never,
@@ -748,9 +753,12 @@ describe("NodeWebUsbTransport", () => {
       expect(connectedDeviceId).toBeDefined();
     });
 
+    const onDisconnectCalls: DeviceId[] = [];
     const firstConnect = await transport.connect({
       deviceId: connectedDeviceId!,
-      onDisconnect: () => {},
+      onDisconnect: id => {
+        onDisconnectCalls.push(id);
+      },
     });
     let connectedDevice: TransportConnectedDevice | undefined;
     firstConnect.ifRight(device => {
@@ -761,12 +769,302 @@ describe("NodeWebUsbTransport", () => {
 
     await transport.disconnect({ connectedDevice: connectedDevice! });
     expect(closeConnectionCalls).toBe(1);
+    expect(onDisconnectCalls).toEqual([connectedDeviceId!]);
 
     await transport.connect({
       deviceId: connectedDeviceId!,
       onDisconnect: () => {},
     });
     expect(setupConnectionCalls).toBe(2);
+
+    transport.destroy();
+  });
+
+  it("rejects sendApdu with DeviceDisconnectedBeforeSendingApdu after the machine is unrouted", async () => {
+    const nativeDevice = {
+      deviceDescriptor: {
+        idVendor: 0x2c97,
+        idProduct: 0x5011,
+      },
+    };
+    const webUsbDevice = {
+      vendorId: 0x2c97,
+      productId: 0x5011,
+      serialNumber: "ledger-1",
+      configurations: [
+        {
+          interfaces: [
+            {
+              interfaceNumber: 1,
+              alternates: [{ interfaceClass: 255 }],
+            },
+          ],
+        },
+      ],
+    };
+
+    let connectedDeviceId: DeviceId | undefined;
+    let machineSendApduCalls = 0;
+
+    const transport = new NodeWebUsbTransport(
+      {
+        getAllDeviceModels: () => [
+          {
+            id: "nanoSP",
+            productName: "Ledger Nano S Plus",
+            usbProductId: 0x50,
+            bootloaderUsbProductId: 0x5011,
+          },
+        ],
+      } as DeviceModelDataSource,
+      () => createLogger(),
+      (() => {
+        throw new Error("unused apdu sender factory");
+      }) as ApduSenderServiceFactory,
+      (() => {
+        throw new Error("unused apdu receiver factory");
+      }) as ApduReceiverServiceFactory,
+      params =>
+        ({
+          setupConnection: async () => {},
+          sendApdu: async () => {
+            machineSendApduCalls += 1;
+            return Right({
+              data: new Uint8Array(),
+              statusCode: new Uint8Array([0x90, 0x00]),
+            }) as never;
+          },
+          getDeviceId: () => params.deviceId,
+          getDependencies: () => ({
+            device: webUsbDevice as never,
+            interfaceNumber: 1,
+          }),
+          setDependencies: () => {},
+          eventDeviceDisconnected: () => {},
+          eventDeviceConnected: () => {},
+          closeConnection: () => {
+            params.onTerminated();
+          },
+        }) as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>,
+      () => createStubApduSender() as never,
+      {
+        platform: "win32",
+        getDeviceList: () => [nativeDevice] as never[],
+        createWebUsbDevice: async () => webUsbDevice as never,
+        usbBindings: {
+          on: () => {},
+          removeListener: () => {},
+          unrefHotplugEvents: () => {},
+        },
+        setInterval: callback => {
+          queueMicrotask(callback);
+          return 0 as unknown as ReturnType<typeof globalThis.setInterval>;
+        },
+        clearInterval: () => {},
+      },
+    );
+
+    const emissions: Array<Array<{ id: string; transport: string }>> = [];
+    subscriptions.push(
+      transport.listenToAvailableDevices().subscribe(devices => {
+        emissions.push(devices.map(device => ({ id: device.id, transport: device.transport })));
+      }),
+    );
+
+    await waitFor(() => {
+      connectedDeviceId = emissions.at(-1)?.[0]?.id;
+      expect(connectedDeviceId).toBeDefined();
+    });
+
+    const connectResult = await transport.connect({
+      deviceId: connectedDeviceId!,
+      onDisconnect: () => {},
+    });
+    let connectedDevice: TransportConnectedDevice | undefined;
+    connectResult.ifRight(device => {
+      connectedDevice = device;
+    });
+    expect(connectedDevice).toBeDefined();
+
+    await transport.disconnect({ connectedDevice: connectedDevice! });
+
+    const callsBefore = machineSendApduCalls;
+    const result = await connectedDevice!.sendApdu(new Uint8Array([0xb0, 0x01]));
+
+    expect(machineSendApduCalls).toBe(callsBefore);
+    let leftError: unknown;
+    result.ifLeft(error => {
+      leftError = error;
+    });
+    expect(leftError).toBeInstanceOf(DeviceDisconnectedBeforeSendingApdu);
+
+    transport.destroy();
+  });
+
+  it("isolates onDisconnect callbacks and APDU routing per connected device", async () => {
+    const nativeDeviceA = {
+      deviceDescriptor: {
+        idVendor: 0x2c97,
+        idProduct: 0x5011,
+      },
+    };
+    const nativeDeviceB = {
+      deviceDescriptor: {
+        idVendor: 0x2c97,
+        idProduct: 0x5011,
+      },
+    };
+    const webUsbDeviceA = {
+      vendorId: 0x2c97,
+      productId: 0x5011,
+      serialNumber: "ledger-A",
+      configurations: [
+        {
+          interfaces: [
+            {
+              interfaceNumber: 1,
+              alternates: [{ interfaceClass: 255 }],
+            },
+          ],
+        },
+      ],
+    };
+    const webUsbDeviceB = {
+      vendorId: 0x2c97,
+      productId: 0x5011,
+      serialNumber: "ledger-B",
+      configurations: [
+        {
+          interfaces: [
+            {
+              interfaceNumber: 1,
+              alternates: [{ interfaceClass: 255 }],
+            },
+          ],
+        },
+      ],
+    };
+
+    const nativeToWeb = new Map<unknown, unknown>([
+      [nativeDeviceA, webUsbDeviceA],
+      [nativeDeviceB, webUsbDeviceB],
+    ]);
+
+    const machineSendApduCounts = new Map<DeviceId, number>();
+
+    const transport = new NodeWebUsbTransport(
+      {
+        getAllDeviceModels: () => [
+          {
+            id: "nanoSP",
+            productName: "Ledger Nano S Plus",
+            usbProductId: 0x50,
+            bootloaderUsbProductId: 0x5011,
+          },
+        ],
+      } as DeviceModelDataSource,
+      () => createLogger(),
+      (() => {
+        throw new Error("unused apdu sender factory");
+      }) as ApduSenderServiceFactory,
+      (() => {
+        throw new Error("unused apdu receiver factory");
+      }) as ApduReceiverServiceFactory,
+      params => {
+        let dependencies: NodeWebUsbApduSenderDependencies = {
+          device: webUsbDeviceA as never,
+          interfaceNumber: 1,
+        };
+        return {
+          setupConnection: async () => {},
+          sendApdu: async () => {
+            machineSendApduCounts.set(
+              params.deviceId,
+              (machineSendApduCounts.get(params.deviceId) ?? 0) + 1,
+            );
+            return Right({
+              data: new Uint8Array(),
+              statusCode: new Uint8Array([0x90, 0x00]),
+            }) as never;
+          },
+          getDeviceId: () => params.deviceId,
+          getDependencies: () => dependencies,
+          setDependencies: (next: NodeWebUsbApduSenderDependencies) => {
+            dependencies = next;
+          },
+          eventDeviceDisconnected: () => {},
+          eventDeviceConnected: () => {},
+          closeConnection: () => {
+            params.onTerminated();
+          },
+        } as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>;
+      },
+      () => createStubApduSender() as never,
+      {
+        platform: "linux",
+        getDeviceList: () => [nativeDeviceA, nativeDeviceB] as never[],
+        createWebUsbDevice: async native => nativeToWeb.get(native) as never,
+        usbBindings: {
+          on: () => {},
+          removeListener: () => {},
+          unrefHotplugEvents: () => {},
+        },
+        setInterval: callback => {
+          queueMicrotask(callback);
+          return 0 as unknown as ReturnType<typeof globalThis.setInterval>;
+        },
+        clearInterval: () => {},
+      },
+    );
+
+    const emissions: Array<Array<{ id: string; transport: string }>> = [];
+    subscriptions.push(
+      transport.listenToAvailableDevices().subscribe(devices => {
+        emissions.push(devices.map(device => ({ id: device.id, transport: device.transport })));
+      }),
+    );
+
+    let deviceIdA: DeviceId | undefined;
+    let deviceIdB: DeviceId | undefined;
+    await waitFor(() => {
+      const last = emissions.at(-1) ?? [];
+      expect(last).toHaveLength(2);
+      [deviceIdA, deviceIdB] = [last[0]!.id, last[1]!.id];
+    });
+
+    const onDisconnectA: DeviceId[] = [];
+    const onDisconnectB: DeviceId[] = [];
+
+    const connectA = await transport.connect({
+      deviceId: deviceIdA!,
+      onDisconnect: id => onDisconnectA.push(id),
+    });
+    let connectedA: TransportConnectedDevice | undefined;
+    connectA.ifRight(d => {
+      connectedA = d;
+    });
+
+    const connectB = await transport.connect({
+      deviceId: deviceIdB!,
+      onDisconnect: id => onDisconnectB.push(id),
+    });
+    let connectedB: TransportConnectedDevice | undefined;
+    connectB.ifRight(d => {
+      connectedB = d;
+    });
+
+    expect(connectedA).toBeDefined();
+    expect(connectedB).toBeDefined();
+
+    await transport.disconnect({ connectedDevice: connectedA! });
+
+    expect(onDisconnectA).toEqual([deviceIdA!]);
+    expect(onDisconnectB).toEqual([]);
+
+    const apduOnB = await connectedB!.sendApdu(new Uint8Array([0xb0, 0x01]));
+    expect(apduOnB.isRight()).toBe(true);
+    expect(machineSendApduCounts.get(deviceIdB!)).toBe(1);
+    expect(machineSendApduCounts.get(deviceIdA!) ?? 0).toBe(0);
 
     transport.destroy();
   });

--- a/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.test.ts
+++ b/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.test.ts
@@ -2,14 +2,36 @@ import { afterEach, describe, expect, it } from "bun:test";
 import type {
   ApduReceiverServiceFactory,
   ApduSenderServiceFactory,
+  DeviceConnectionStateMachine,
+  DeviceConnectionStateMachineParams,
   DeviceModelDataSource,
+  DeviceId,
   LoggerPublisherService,
+  TransportConnectedDevice,
 } from "@ledgerhq/device-management-kit";
+import { Right } from "purify-ts";
 import type { Subscription } from "rxjs";
 import { NodeWebUsbTransport } from "./NodeWebUsbTransport";
+import type { NodeWebUsbApduSenderDependencies } from "./NodeWebUsbApduSender";
 
 function flushTasks(): Promise<void> {
   return new Promise(resolve => queueMicrotask(resolve));
+}
+
+async function waitFor(assertion: () => void, attempts = 20): Promise<void> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await flushTasks();
+    }
+  }
+
+  throw lastError;
 }
 
 function createLogger(): LoggerPublisherService {
@@ -20,6 +42,16 @@ function createLogger(): LoggerPublisherService {
     warn: () => {},
     error: () => {},
   } as unknown as LoggerPublisherService;
+}
+
+function createStubApduSender() {
+  return {
+    sendApdu: async () => Right(new Uint8Array()) as never,
+    setupConnection: async () => {},
+    closeConnection: async () => {},
+    getDependencies: () => ({}) as NodeWebUsbApduSenderDependencies,
+    setDependencies: () => {},
+  };
 }
 
 describe("NodeWebUsbTransport", () => {
@@ -109,13 +141,633 @@ describe("NodeWebUsbTransport", () => {
 
     currentDeviceList = [nativeDevice];
     pollCallback?.();
-    await flushTasks();
-
-    expect(emissions).toHaveLength(1);
+    await waitFor(() => {
+      expect(emissions).toHaveLength(1);
+    });
     expect(emissions[0]?.transport).toBe("NODE-WEBUSB");
     expect(typeof emissions[0]?.id).toBe("string");
 
     transport.destroy();
     expect(clearedInterval).not.toBeNull();
+  });
+
+  it("restarts Windows discovery polling when the connection state machine asks to reconnect", async () => {
+    const nativeDevice = {
+      deviceDescriptor: {
+        idVendor: 0x2c97,
+        idProduct: 0x5011,
+      },
+    };
+    const webUsbDevice = {
+      vendorId: 0x2c97,
+      productId: 0x5011,
+      serialNumber: "ledger-1",
+      configurations: [
+        {
+          interfaces: [
+            {
+              interfaceNumber: 1,
+              alternates: [{ interfaceClass: 255 }],
+            },
+          ],
+        },
+      ],
+    };
+
+    let currentDeviceList: (typeof nativeDevice)[] = [nativeDevice];
+    let nextHandle = 0;
+    let activePollCallback: (() => void) | undefined;
+    const intervalHandles: number[] = [];
+    const clearedHandles: number[] = [];
+    let tryToReconnect:
+      | DeviceConnectionStateMachineParams<NodeWebUsbApduSenderDependencies>["tryToReconnect"]
+      | undefined;
+    let connectedDeviceId: DeviceId | undefined;
+
+    const transport = new NodeWebUsbTransport(
+      {
+        getAllDeviceModels: () => [
+          {
+            id: "nanoSP",
+            productName: "Ledger Nano S Plus",
+            usbProductId: 0x50,
+            bootloaderUsbProductId: 0x5011,
+          },
+        ],
+      } as DeviceModelDataSource,
+      () => createLogger(),
+      (() => {
+        throw new Error("unused apdu sender factory");
+      }) as ApduSenderServiceFactory,
+      (() => {
+        throw new Error("unused apdu receiver factory");
+      }) as ApduReceiverServiceFactory,
+      params => {
+        tryToReconnect = params.tryToReconnect;
+
+        return {
+          setupConnection: async () => {},
+          sendApdu: async () => Right(new Uint8Array()) as never,
+          getDeviceId: () => params.deviceId,
+          getDependencies: () => ({
+            device: webUsbDevice as never,
+            interfaceNumber: 1,
+          }),
+          setDependencies: () => {},
+          eventDeviceDisconnected: () => {},
+          eventDeviceConnected: () => {},
+          closeConnection: () => {},
+        } as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>;
+      },
+      () => createStubApduSender() as never,
+      {
+        platform: "win32",
+        getDeviceList: () => currentDeviceList as never[],
+        createWebUsbDevice: async () => webUsbDevice as never,
+        usbBindings: {
+          on: () => {},
+          removeListener: () => {},
+          unrefHotplugEvents: () => {},
+        },
+        setInterval: callback => {
+          nextHandle += 1;
+          intervalHandles.push(nextHandle);
+          activePollCallback = callback;
+          return nextHandle as unknown as ReturnType<typeof globalThis.setInterval>;
+        },
+        clearInterval: handle => {
+          clearedHandles.push(handle as unknown as number);
+        },
+      },
+    );
+
+    const emissions: Array<Array<{ id: string; transport: string }>> = [];
+    subscriptions.push(
+      transport.listenToAvailableDevices().subscribe(devices => {
+        emissions.push(devices.map(device => ({ id: device.id, transport: device.transport })));
+      }),
+    );
+
+    await waitFor(() => {
+      connectedDeviceId = emissions.at(-1)?.[0]?.id;
+      expect(connectedDeviceId).toBeDefined();
+    });
+    expect(tryToReconnect).toBeUndefined();
+    expect(intervalHandles).toEqual([1]);
+    expect(clearedHandles).toEqual([1]);
+
+    await transport.connect({
+      deviceId: connectedDeviceId!,
+      onDisconnect: () => {},
+    });
+
+    expect(tryToReconnect).toBeDefined();
+
+    currentDeviceList = [];
+    tryToReconnect?.(0);
+    await waitFor(() => {
+      expect(intervalHandles).toEqual([1, 2]);
+      expect(activePollCallback).toBeDefined();
+    });
+
+    activePollCallback?.();
+    await waitFor(() => {
+      expect(emissions.at(-1)).toEqual([]);
+    });
+
+    transport.destroy();
+    expect(clearedHandles).toContain(2);
+  });
+
+  it("reconnects a pending machine from a rescan even if attach arrived before pending mode", async () => {
+    const nativeDevice = {
+      deviceDescriptor: {
+        idVendor: 0x2c97,
+        idProduct: 0x5011,
+      },
+    };
+    const webUsbDevice = {
+      vendorId: 0x2c97,
+      productId: 0x5011,
+      serialNumber: "ledger-1",
+      configurations: [
+        {
+          interfaces: [
+            {
+              interfaceNumber: 1,
+              alternates: [{ interfaceClass: 255 }],
+            },
+          ],
+        },
+      ],
+    };
+
+    let currentDeviceList: (typeof nativeDevice)[] = [nativeDevice];
+    let tryToReconnect:
+      | DeviceConnectionStateMachineParams<NodeWebUsbApduSenderDependencies>["tryToReconnect"]
+      | undefined;
+    let connectedDeviceId: DeviceId | undefined;
+    let setupConnectionCalls = 0;
+    let eventDeviceConnectedCalls = 0;
+
+    const transport = new NodeWebUsbTransport(
+      {
+        getAllDeviceModels: () => [
+          {
+            id: "nanoSP",
+            productName: "Ledger Nano S Plus",
+            usbProductId: 0x50,
+            bootloaderUsbProductId: 0x5011,
+          },
+        ],
+      } as DeviceModelDataSource,
+      () => createLogger(),
+      (() => {
+        throw new Error("unused apdu sender factory");
+      }) as ApduSenderServiceFactory,
+      (() => {
+        throw new Error("unused apdu receiver factory");
+      }) as ApduReceiverServiceFactory,
+      params => {
+        tryToReconnect = params.tryToReconnect;
+
+        return {
+          setupConnection: async () => {
+            setupConnectionCalls += 1;
+          },
+          sendApdu: async () => Right(new Uint8Array()) as never,
+          getDeviceId: () => params.deviceId,
+          getDependencies: () => ({
+            device: webUsbDevice as never,
+            interfaceNumber: 1,
+          }),
+          setDependencies: () => {},
+          eventDeviceDisconnected: () => {},
+          eventDeviceConnected: () => {
+            eventDeviceConnectedCalls += 1;
+          },
+          closeConnection: () => {},
+        } as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>;
+      },
+      () => createStubApduSender() as never,
+      {
+        platform: "win32",
+        getDeviceList: () => currentDeviceList as never[],
+        createWebUsbDevice: async () => webUsbDevice as never,
+        usbBindings: {
+          on: () => {},
+          removeListener: () => {},
+          unrefHotplugEvents: () => {},
+        },
+        setInterval: callback => {
+          queueMicrotask(callback);
+          return 0 as unknown as ReturnType<typeof globalThis.setInterval>;
+        },
+        clearInterval: () => {},
+      },
+    );
+
+    const emissions: Array<Array<{ id: string; transport: string }>> = [];
+    subscriptions.push(
+      transport.listenToAvailableDevices().subscribe(devices => {
+        emissions.push(devices.map(device => ({ id: device.id, transport: device.transport })));
+      }),
+    );
+
+    await waitFor(() => {
+      connectedDeviceId = emissions.at(-1)?.[0]?.id;
+      expect(connectedDeviceId).toBeDefined();
+    });
+
+    await transport.connect({
+      deviceId: connectedDeviceId!,
+      onDisconnect: () => {},
+    });
+
+    expect(setupConnectionCalls).toBe(1);
+    expect(tryToReconnect).toBeDefined();
+
+    tryToReconnect?.(0);
+    await waitFor(() => {
+      expect(setupConnectionCalls).toBe(2);
+      expect(eventDeviceConnectedCalls).toBe(1);
+    });
+
+    transport.destroy();
+  });
+
+  it("keeps a machine pending when an early reconnect attempt fails before a later scan succeeds", async () => {
+    const nativeDevice = {
+      deviceDescriptor: {
+        idVendor: 0x2c97,
+        idProduct: 0x5011,
+      },
+    };
+    const webUsbDevice = {
+      vendorId: 0x2c97,
+      productId: 0x5011,
+      serialNumber: "ledger-1",
+      configurations: [
+        {
+          interfaces: [
+            {
+              interfaceNumber: 1,
+              alternates: [{ interfaceClass: 255 }],
+            },
+          ],
+        },
+      ],
+    };
+
+    let currentDeviceList: (typeof nativeDevice)[] = [nativeDevice];
+    let tryToReconnect:
+      | DeviceConnectionStateMachineParams<NodeWebUsbApduSenderDependencies>["tryToReconnect"]
+      | undefined;
+    let connectedDeviceId: DeviceId | undefined;
+    let setupConnectionCalls = 0;
+    let eventDeviceConnectedCalls = 0;
+    let closeConnectionCalls = 0;
+
+    const transport = new NodeWebUsbTransport(
+      {
+        getAllDeviceModels: () => [
+          {
+            id: "nanoSP",
+            productName: "Ledger Nano S Plus",
+            usbProductId: 0x50,
+            bootloaderUsbProductId: 0x5011,
+          },
+        ],
+      } as DeviceModelDataSource,
+      () => createLogger(),
+      (() => {
+        throw new Error("unused apdu sender factory");
+      }) as ApduSenderServiceFactory,
+      (() => {
+        throw new Error("unused apdu receiver factory");
+      }) as ApduReceiverServiceFactory,
+      params => {
+        tryToReconnect = params.tryToReconnect;
+
+        return {
+          setupConnection: async () => {
+            setupConnectionCalls += 1;
+            if (setupConnectionCalls === 2) {
+              throw new Error("LIBUSB_ERROR_NO_DEVICE");
+            }
+          },
+          sendApdu: async () => Right(new Uint8Array()) as never,
+          getDeviceId: () => params.deviceId,
+          getDependencies: () => ({
+            device: webUsbDevice as never,
+            interfaceNumber: 1,
+          }),
+          setDependencies: () => {},
+          eventDeviceDisconnected: () => {},
+          eventDeviceConnected: () => {
+            eventDeviceConnectedCalls += 1;
+          },
+          closeConnection: () => {
+            closeConnectionCalls += 1;
+          },
+        } as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>;
+      },
+      () => createStubApduSender() as never,
+      {
+        platform: "win32",
+        getDeviceList: () => currentDeviceList as never[],
+        createWebUsbDevice: async () => webUsbDevice as never,
+        usbBindings: {
+          on: () => {},
+          removeListener: () => {},
+          unrefHotplugEvents: () => {},
+        },
+        setInterval: callback => {
+          queueMicrotask(callback);
+          return 0 as unknown as ReturnType<typeof globalThis.setInterval>;
+        },
+        clearInterval: () => {},
+      },
+    );
+
+    const emissions: Array<Array<{ id: string; transport: string }>> = [];
+    subscriptions.push(
+      transport.listenToAvailableDevices().subscribe(devices => {
+        emissions.push(devices.map(device => ({ id: device.id, transport: device.transport })));
+      }),
+    );
+
+    await waitFor(() => {
+      connectedDeviceId = emissions.at(-1)?.[0]?.id;
+      expect(connectedDeviceId).toBeDefined();
+    });
+
+    await transport.connect({
+      deviceId: connectedDeviceId!,
+      onDisconnect: () => {},
+    });
+
+    currentDeviceList = [];
+    tryToReconnect?.(0);
+
+    await transport.handleDeviceConnection(nativeDevice as never);
+    expect(setupConnectionCalls).toBe(2);
+    expect(eventDeviceConnectedCalls).toBe(0);
+    expect(closeConnectionCalls).toBe(0);
+
+    currentDeviceList = [nativeDevice];
+    await transport.updateTransportDiscoveredDevices();
+    await waitFor(() => {
+      expect(setupConnectionCalls).toBe(3);
+      expect(eventDeviceConnectedCalls).toBe(1);
+    });
+
+    expect(closeConnectionCalls).toBe(0);
+
+    transport.destroy();
+  });
+
+  it("serializes APDU calls sent through the same connected device", async () => {
+    const nativeDevice = {
+      deviceDescriptor: {
+        idVendor: 0x2c97,
+        idProduct: 0x5011,
+      },
+    };
+    const webUsbDevice = {
+      vendorId: 0x2c97,
+      productId: 0x5011,
+      serialNumber: "ledger-1",
+      configurations: [
+        {
+          interfaces: [
+            {
+              interfaceNumber: 1,
+              alternates: [{ interfaceClass: 255 }],
+            },
+          ],
+        },
+      ],
+    };
+
+    let connectedDeviceId: DeviceId | undefined;
+    let sendApduCalls = 0;
+    let resolveFirstApdu: (() => void) | undefined;
+
+    const transport = new NodeWebUsbTransport(
+      {
+        getAllDeviceModels: () => [
+          {
+            id: "nanoSP",
+            productName: "Ledger Nano S Plus",
+            usbProductId: 0x50,
+            bootloaderUsbProductId: 0x5011,
+          },
+        ],
+      } as DeviceModelDataSource,
+      () => createLogger(),
+      (() => {
+        throw new Error("unused apdu sender factory");
+      }) as ApduSenderServiceFactory,
+      (() => {
+        throw new Error("unused apdu receiver factory");
+      }) as ApduReceiverServiceFactory,
+      params =>
+        ({
+          setupConnection: async () => {},
+          sendApdu: async () => {
+            sendApduCalls += 1;
+            if (sendApduCalls === 1) {
+              await new Promise<void>(resolve => {
+                resolveFirstApdu = resolve;
+              });
+            }
+            return Right({
+              data: new Uint8Array(),
+              statusCode: new Uint8Array([0x90, 0x00]),
+            }) as never;
+          },
+          getDeviceId: () => params.deviceId,
+          getDependencies: () => ({
+            device: webUsbDevice as never,
+            interfaceNumber: 1,
+          }),
+          setDependencies: () => {},
+          eventDeviceDisconnected: () => {},
+          eventDeviceConnected: () => {},
+          closeConnection: () => {},
+        }) as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>,
+      () => createStubApduSender() as never,
+      {
+        platform: "win32",
+        getDeviceList: () => [nativeDevice] as never[],
+        createWebUsbDevice: async () => webUsbDevice as never,
+        usbBindings: {
+          on: () => {},
+          removeListener: () => {},
+          unrefHotplugEvents: () => {},
+        },
+        setInterval: callback => {
+          queueMicrotask(callback);
+          return 0 as unknown as ReturnType<typeof globalThis.setInterval>;
+        },
+        clearInterval: () => {},
+      },
+    );
+
+    const emissions: Array<Array<{ id: string; transport: string }>> = [];
+    subscriptions.push(
+      transport.listenToAvailableDevices().subscribe(devices => {
+        emissions.push(devices.map(device => ({ id: device.id, transport: device.transport })));
+      }),
+    );
+
+    await waitFor(() => {
+      connectedDeviceId = emissions.at(-1)?.[0]?.id;
+      expect(connectedDeviceId).toBeDefined();
+    });
+
+    const connectResult = await transport.connect({
+      deviceId: connectedDeviceId!,
+      onDisconnect: () => {},
+    });
+    let connectedDevice: TransportConnectedDevice | undefined;
+    connectResult.ifRight(device => {
+      connectedDevice = device;
+    });
+    expect(connectedDevice).toBeDefined();
+
+    const firstApdu = connectedDevice!.sendApdu(new Uint8Array([0xb0, 0x01]));
+    const secondApdu = connectedDevice!.sendApdu(new Uint8Array([0xb0, 0x01]));
+
+    await waitFor(() => {
+      expect(sendApduCalls).toBe(1);
+      expect(resolveFirstApdu).toBeDefined();
+    });
+    await flushTasks();
+    expect(sendApduCalls).toBe(1);
+
+    resolveFirstApdu?.();
+    await Promise.all([firstApdu, secondApdu]);
+
+    expect(sendApduCalls).toBe(2);
+
+    transport.destroy();
+  });
+
+  it("creates a fresh connection state machine after disconnecting a session", async () => {
+    const nativeDevice = {
+      deviceDescriptor: {
+        idVendor: 0x2c97,
+        idProduct: 0x5011,
+      },
+    };
+    const webUsbDevice = {
+      vendorId: 0x2c97,
+      productId: 0x5011,
+      serialNumber: "ledger-1",
+      configurations: [
+        {
+          interfaces: [
+            {
+              interfaceNumber: 1,
+              alternates: [{ interfaceClass: 255 }],
+            },
+          ],
+        },
+      ],
+    };
+
+    let connectedDeviceId: DeviceId | undefined;
+    let setupConnectionCalls = 0;
+    let closeConnectionCalls = 0;
+
+    const transport = new NodeWebUsbTransport(
+      {
+        getAllDeviceModels: () => [
+          {
+            id: "nanoSP",
+            productName: "Ledger Nano S Plus",
+            usbProductId: 0x50,
+            bootloaderUsbProductId: 0x5011,
+          },
+        ],
+      } as DeviceModelDataSource,
+      () => createLogger(),
+      (() => {
+        throw new Error("unused apdu sender factory");
+      }) as ApduSenderServiceFactory,
+      (() => {
+        throw new Error("unused apdu receiver factory");
+      }) as ApduReceiverServiceFactory,
+      params =>
+        ({
+          setupConnection: async () => {
+            setupConnectionCalls += 1;
+          },
+          sendApdu: async () => Right(new Uint8Array()) as never,
+          getDeviceId: () => params.deviceId,
+          getDependencies: () => ({
+            device: webUsbDevice as never,
+            interfaceNumber: 1,
+          }),
+          setDependencies: () => {},
+          eventDeviceDisconnected: () => {},
+          eventDeviceConnected: () => {},
+          closeConnection: () => {
+            closeConnectionCalls += 1;
+          },
+        }) as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>,
+      () => createStubApduSender() as never,
+      {
+        platform: "win32",
+        getDeviceList: () => [nativeDevice] as never[],
+        createWebUsbDevice: async () => webUsbDevice as never,
+        usbBindings: {
+          on: () => {},
+          removeListener: () => {},
+          unrefHotplugEvents: () => {},
+        },
+        setInterval: callback => {
+          queueMicrotask(callback);
+          return 0 as unknown as ReturnType<typeof globalThis.setInterval>;
+        },
+        clearInterval: () => {},
+      },
+    );
+
+    const emissions: Array<Array<{ id: string; transport: string }>> = [];
+    subscriptions.push(
+      transport.listenToAvailableDevices().subscribe(devices => {
+        emissions.push(devices.map(device => ({ id: device.id, transport: device.transport })));
+      }),
+    );
+
+    await waitFor(() => {
+      connectedDeviceId = emissions.at(-1)?.[0]?.id;
+      expect(connectedDeviceId).toBeDefined();
+    });
+
+    const firstConnect = await transport.connect({
+      deviceId: connectedDeviceId!,
+      onDisconnect: () => {},
+    });
+    let connectedDevice: TransportConnectedDevice | undefined;
+    firstConnect.ifRight(device => {
+      connectedDevice = device;
+    });
+    expect(connectedDevice).toBeDefined();
+    expect(setupConnectionCalls).toBe(1);
+
+    await transport.disconnect({ connectedDevice: connectedDevice! });
+    expect(closeConnectionCalls).toBe(1);
+
+    await transport.connect({
+      deviceId: connectedDeviceId!,
+      onDisconnect: () => {},
+    });
+    expect(setupConnectionCalls).toBe(2);
+
+    transport.destroy();
   });
 });

--- a/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.test.ts
+++ b/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.test.ts
@@ -1068,4 +1068,103 @@ describe("NodeWebUsbTransport", () => {
 
     transport.destroy();
   });
+
+  it("does not return an empty list to a concurrent caller while a refresh is in-flight", async () => {
+    // Regression: previously, updateTransportDiscoveredDevices() returned []
+    // when a refresh was already running, which caused promptDeviceAccess() to
+    // throw NoAccessibleDeviceError when a Windows polling tick (or attach
+    // handler) overlapped with startDiscovering().
+    const nativeDevice = {
+      deviceDescriptor: {
+        idVendor: 0x2c97,
+        idProduct: 0x5011,
+      },
+    };
+    const webUsbDevice = {
+      vendorId: 0x2c97,
+      productId: 0x5011,
+      serialNumber: "ledger-1",
+      configurations: [
+        {
+          interfaces: [
+            {
+              interfaceNumber: 1,
+              alternates: [{ interfaceClass: 255 }],
+            },
+          ],
+        },
+      ],
+    };
+
+    let releaseFirstScan: (() => void) | undefined;
+    const firstScanGate = new Promise<void>(resolve => {
+      releaseFirstScan = resolve;
+    });
+    let createWebUsbDeviceCalls = 0;
+    let deviceListCalls = 0;
+
+    const transport = new NodeWebUsbTransport(
+      {
+        getAllDeviceModels: () => [
+          {
+            id: "nanoSP",
+            productName: "Ledger Nano S Plus",
+            usbProductId: 0x50,
+            bootloaderUsbProductId: 0x5011,
+          },
+        ],
+      } as DeviceModelDataSource,
+      () => createLogger(),
+      (() => {
+        throw new Error("unused apdu sender factory");
+      }) as ApduSenderServiceFactory,
+      (() => {
+        throw new Error("unused apdu receiver factory");
+      }) as ApduReceiverServiceFactory,
+      undefined,
+      undefined,
+      {
+        platform: "linux",
+        getDeviceList: () => {
+          deviceListCalls += 1;
+          return [nativeDevice] as never[];
+        },
+        createWebUsbDevice: async () => {
+          createWebUsbDeviceCalls += 1;
+          if (createWebUsbDeviceCalls === 1) {
+            await firstScanGate;
+          }
+          return webUsbDevice as never;
+        },
+        usbBindings: {
+          on: () => {},
+          removeListener: () => {},
+          unrefHotplugEvents: () => {},
+        },
+        setInterval: () => 0 as unknown as ReturnType<typeof globalThis.setInterval>,
+        clearInterval: () => {},
+      },
+    );
+
+    const first = transport.updateTransportDiscoveredDevices();
+    const secondConcurrent = transport.updateTransportDiscoveredDevices();
+    const thirdConcurrent = transport.updateTransportDiscoveredDevices();
+
+    releaseFirstScan?.();
+
+    const [firstResult, secondResult, thirdResult] = await Promise.all([
+      first,
+      secondConcurrent,
+      thirdConcurrent,
+    ]);
+
+    expect(firstResult).toHaveLength(1);
+    expect(secondResult).toHaveLength(1);
+    expect(thirdResult).toHaveLength(1);
+    // Concurrent callers coalesce onto a single fresh follow-up scan rather
+    // than triggering one rescan per caller.
+    expect(deviceListCalls).toBe(2);
+
+    transport.destroy();
+  });
 });

--- a/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.ts
+++ b/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.ts
@@ -159,7 +159,13 @@ export class NodeWebUsbTransport implements Transport {
   private _usbAttachHandler: ((d: NativeUsbDevice) => void) | null = null;
   private _usbDetachHandler: ((d: NativeUsbDevice) => void) | null = null;
   private _discoveryPollInterval: NodeWebUsbIntervalHandle | null = null;
-  private _isRefreshingDiscoveredDevices = false;
+  // In-flight discovery refresh promise. While a scan is running, additional
+  // callers (e.g. a Windows polling tick overlapping with startDiscovering()
+  // or with the attach handler) get a queued follow-up scan instead of an
+  // empty result — preventing promptDeviceAccess() from spuriously throwing
+  // NoAccessibleDeviceError when a refresh is already in progress.
+  private _refreshDiscoveredDevicesInFlight: Promise<ScannedWebUsbDevice[]> | null = null;
+  private _refreshDiscoveredDevicesQueued: Promise<ScannedWebUsbDevice[]> | null = null;
 
   constructor(
     deviceModelDataSource: DeviceModelDataSource,
@@ -256,7 +262,10 @@ export class NodeWebUsbTransport implements Transport {
       sendApdu: async (...args) => {
         const previous = this._sendApduQueues.get(machine) ?? Promise.resolve();
         const queued = previous.catch(() => undefined).then(() => sendApduToMachine(...args));
-        this._sendApduQueues.set(machine, queued.catch(() => undefined));
+        this._sendApduQueues.set(
+          machine,
+          queued.catch(() => undefined),
+        );
         return queued;
       },
       transport: this.identifier,
@@ -387,11 +396,38 @@ export class NodeWebUsbTransport implements Transport {
   }
 
   async updateTransportDiscoveredDevices(): Promise<ScannedWebUsbDevice[]> {
-    if (this._isRefreshingDiscoveredDevices) {
-      return [];
+    if (this._refreshDiscoveredDevicesInFlight) {
+      // Coalesce concurrent callers onto a single fresh scan that starts
+      // *after* the in-flight one completes, so they don't observe stale
+      // results captured before their call.
+      if (!this._refreshDiscoveredDevicesQueued) {
+        const queued = this._refreshDiscoveredDevicesInFlight
+          .catch(() => undefined)
+          .then(() => {
+            if (this._refreshDiscoveredDevicesQueued === queued) {
+              this._refreshDiscoveredDevicesQueued = null;
+            }
+            return this.runDiscoveryRefresh();
+          });
+        this._refreshDiscoveredDevicesQueued = queued;
+      }
+      return this._refreshDiscoveredDevicesQueued;
     }
 
-    this._isRefreshingDiscoveredDevices = true;
+    return this.runDiscoveryRefresh();
+  }
+
+  private runDiscoveryRefresh(): Promise<ScannedWebUsbDevice[]> {
+    const refresh = this.scanAndPublishDiscoveredDevices().finally(() => {
+      if (this._refreshDiscoveredDevicesInFlight === refresh) {
+        this._refreshDiscoveredDevicesInFlight = null;
+      }
+    });
+    this._refreshDiscoveredDevicesInFlight = refresh;
+    return refresh;
+  }
+
+  private async scanAndPublishDiscoveredDevices(): Promise<ScannedWebUsbDevice[]> {
     try {
       const scanned = await this.scanLedgerWebUsbDevices();
       await this.reconnectPendingMachines(scanned);
@@ -421,8 +457,6 @@ export class NodeWebUsbTransport implements Transport {
     } catch (e) {
       this._logger.error("Error while scanning Ledger WebUSB devices", { data: { error: e } });
       return [];
-    } finally {
-      this._isRefreshingDiscoveredDevices = false;
     }
   }
 

--- a/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.ts
+++ b/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.ts
@@ -653,6 +653,11 @@ export class NodeWebUsbTransport implements Transport {
       machine.eventDeviceConnected();
     } catch (e) {
       this._logger.error("Error while reconnecting to device", { data: { error: e } });
+      // If we failed after publishing to the active maps (e.g. eventDeviceConnected
+      // threw), undo the publish so the machine isn't both "active" and "pending"
+      // and APDUs aren't routed to a machine whose dependencies were reverted.
+      // deleteActiveConnection is a no-op if the entry was never inserted.
+      this.deleteActiveConnection(web);
       machine.setDependencies(previousDependencies);
       this._deviceConnectionsPendingReconnection.add(machine);
     }

--- a/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.ts
+++ b/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.ts
@@ -140,6 +140,11 @@ export class NodeWebUsbTransport implements Transport {
     WebUSBDevice,
     DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>
   >();
+  // Mirrors the values of _deviceConnectionsByWebUsbDevice so that membership
+  // checks (e.g. isConnectionMachineRoutable) are O(1) instead of O(n).
+  private readonly _activeConnectionMachines = new Set<
+    DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>
+  >();
   private readonly _deviceConnectionsPendingReconnection = new Set<
     DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>
   >();
@@ -198,8 +203,32 @@ export class NodeWebUsbTransport implements Transport {
   ): boolean {
     return (
       this._deviceConnectionsPendingReconnection.has(machine) ||
-      this._deviceConnectionsByWebUsbDevice.values().some(active => active === machine)
+      this._activeConnectionMachines.has(machine)
     );
+  }
+
+  private setActiveConnection(
+    device: WebUSBDevice,
+    machine: DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>,
+  ): void {
+    this._deviceConnectionsByWebUsbDevice.set(device, machine);
+    this._activeConnectionMachines.add(machine);
+  }
+
+  private deleteActiveConnection(device: WebUSBDevice): void {
+    const machine = this._deviceConnectionsByWebUsbDevice.get(device);
+    if (!machine) {
+      return;
+    }
+    this._deviceConnectionsByWebUsbDevice.delete(device);
+    // The same machine could (in transient states) sit under multiple keys; only
+    // drop the routable flag once no key references it anymore.
+    const stillReferenced = this._deviceConnectionsByWebUsbDevice
+      .values()
+      .some(other => other === machine);
+    if (!stillReferenced) {
+      this._activeConnectionMachines.delete(machine);
+    }
   }
 
   private makeTransportConnectedDevice({
@@ -497,13 +526,12 @@ export class NodeWebUsbTransport implements Transport {
         this._deviceConnectionsByWebUsbDevice.forEach((sm, dev) => {
           if (sm.getDeviceId() === deviceId) {
             this._deviceConnectionsPendingReconnection.add(sm);
-            this._deviceConnectionsByWebUsbDevice.delete(dev);
+            this.deleteActiveConnection(dev);
           }
         });
         this.resumeDiscoveryAfterDisconnect();
       },
       onTerminated: () => {
-        this.resumeDiscoveryAfterDisconnect();
         this._deviceConnectionsPendingReconnection.forEach(sm => {
           if (sm.getDeviceId() === deviceId) {
             this._deviceConnectionsPendingReconnection.delete(sm);
@@ -512,10 +540,11 @@ export class NodeWebUsbTransport implements Transport {
         });
         this._deviceConnectionsByWebUsbDevice.forEach((sm, dev) => {
           if (sm.getDeviceId() === deviceId) {
-            this._deviceConnectionsByWebUsbDevice.delete(dev);
+            this.deleteActiveConnection(dev);
             onDisconnect(sm.getDeviceId());
           }
         });
+        this.resumeDiscoveryAfterDisconnect();
       },
     });
 
@@ -526,7 +555,7 @@ export class NodeWebUsbTransport implements Transport {
       return Left(new OpeningConnectionError(e));
     }
 
-    this._deviceConnectionsByWebUsbDevice.set(row.webUsbDevice, machine);
+    this.setActiveConnection(row.webUsbDevice, machine);
 
     return Right(this.makeTransportConnectedDevice({ row, machine }));
   }
@@ -542,14 +571,7 @@ export class NodeWebUsbTransport implements Transport {
       });
       return Left(new UnknownDeviceError(`Unknown device ${params.connectedDevice.id}`));
     }
-    this._deviceConnectionsByWebUsbDevice.forEach((connection, device) => {
-      if (connection.getDeviceId() === params.connectedDevice.id) {
-        this._deviceConnectionsByWebUsbDevice.delete(device);
-      }
-    });
-    this._deviceConnectionsPendingReconnection.delete(sm);
     sm.closeConnection();
-    void this.updateTransportDiscoveredDevices();
     return Right(undefined);
   }
 
@@ -593,7 +615,7 @@ export class NodeWebUsbTransport implements Transport {
       this._deviceConnectionsPendingReconnection.delete(machine);
       machine.setDependencies({ device: web, interfaceNumber });
       await machine.setupConnection();
-      this._deviceConnectionsByWebUsbDevice.set(web, machine);
+      this.setActiveConnection(web, machine);
       machine.eventDeviceConnected();
     } catch (e) {
       this._logger.error("Error while reconnecting to device", { data: { error: e } });
@@ -613,19 +635,15 @@ export class NodeWebUsbTransport implements Transport {
 
     try {
       const web = await this._platformBindings.createWebUsbDevice(native);
-      const iface = getVendorInterfaceNumber(web);
-      if (iface === null) {
+      if (getVendorInterfaceNumber(web) === null) {
         this._logger.debug("[handleDeviceConnection] No Ledger WebUSB interface", {
           data: { vendorId: idVendor, productId: idProduct },
         });
         return;
       }
 
-      const pending = this.findPendingReconnectionMachine(web);
-
-      if (pending) {
-        await this.handleDeviceReconnection(pending, web, iface);
-      }
+      // Reconnection of any pending machines happens inside the rescan via
+      // reconnectPendingMachines(), so the rescan is the single source of truth.
       await this.updateTransportDiscoveredDevices();
     } catch (e) {
       this._logger.error("Error while handling WebUSB connection event", { data: { error: e } });
@@ -636,6 +654,7 @@ export class NodeWebUsbTransport implements Transport {
     this.stopListeningToConnectionEvents();
     this._deviceConnectionsByWebUsbDevice.forEach(sm => sm.closeConnection());
     this._deviceConnectionsPendingReconnection.clear();
+    this._activeConnectionMachines.clear();
   }
 }
 

--- a/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.ts
+++ b/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.ts
@@ -33,7 +33,10 @@ import {
   type NodeWebUsbApduSenderConstructorArgs,
   type NodeWebUsbApduSenderDependencies,
 } from "./NodeWebUsbApduSender";
-import { RECONNECT_DEVICE_TIMEOUT_MS } from "./node-webusb-constants";
+import {
+  RECONNECT_DEVICE_TIMEOUT_MS,
+  WINDOWS_WEBUSB_DISCOVERY_POLL_INTERVAL_MS,
+} from "./node-webusb-constants";
 
 export const nodeWebUsbIdentifier: TransportIdentifier = "NODE-WEBUSB";
 
@@ -57,6 +60,28 @@ function getVendorInterfaceNumber(device: WebUSBDevice): number | null {
 
 type ScannedWebUsbDevice = { device: WebUSBDevice; interfaceNumber: number };
 
+type NodeWebUsbBindings = Pick<typeof usbBindings, "on" | "removeListener" | "unrefHotplugEvents">;
+
+type NodeWebUsbIntervalHandle = ReturnType<typeof globalThis.setInterval>;
+
+type NodeWebUsbTransportPlatform = {
+  platform: NodeJS.Platform;
+  getDeviceList: typeof getDeviceList;
+  createWebUsbDevice: typeof WebUSBDevice.createInstance;
+  usbBindings: NodeWebUsbBindings;
+  setInterval: (callback: () => void, delay: number) => NodeWebUsbIntervalHandle;
+  clearInterval: (handle: NodeWebUsbIntervalHandle) => void;
+};
+
+const defaultNodeWebUsbTransportPlatform: NodeWebUsbTransportPlatform = {
+  platform: process.platform,
+  getDeviceList,
+  createWebUsbDevice: native => WebUSBDevice.createInstance(native),
+  usbBindings,
+  setInterval: globalThis.setInterval,
+  clearInterval: globalThis.clearInterval,
+};
+
 /** Uses serialNumber when available so two same-model devices are distinguishable. */
 function deviceIdentityKey(device: WebUSBDevice): string {
   const serial = device.serialNumber;
@@ -67,6 +92,28 @@ function deviceIdentityKey(device: WebUSBDevice): string {
 
 function dedupeLedgerWebUsbDevices(devices: ScannedWebUsbDevice[]): ScannedWebUsbDevice[] {
   return [...new Map(devices.map(d => [deviceIdentityKey(d.device), d])).values()];
+}
+
+function areSameDiscoveredDevices(
+  previous: WebUsbDiscoveredInternal[],
+  next: WebUsbDiscoveredInternal[],
+): boolean {
+  if (previous.length !== next.length) {
+    return false;
+  }
+
+  return previous.every((device, index) => {
+    const nextDevice = next[index];
+    if (!nextDevice) {
+      return false;
+    }
+
+    return (
+      device.id === nextDevice.id &&
+      device.interfaceNumber === nextDevice.interfaceNumber &&
+      deviceIdentityKey(device.webUsbDevice) === deviceIdentityKey(nextDevice.webUsbDevice)
+    );
+  });
 }
 
 /**
@@ -83,6 +130,7 @@ export class NodeWebUsbTransport implements Transport {
   private readonly _deviceApduSenderFactory: (
     args: NodeWebUsbApduSenderConstructorArgs,
   ) => NodeWebUsbApduSender;
+  private readonly _platformBindings: NodeWebUsbTransportPlatform;
 
   private readonly _transportDiscoveredDevices = new BehaviorSubject<WebUsbDiscoveredInternal[]>(
     [],
@@ -100,6 +148,8 @@ export class NodeWebUsbTransport implements Transport {
   private readonly identifier = nodeWebUsbIdentifier;
   private _usbAttachHandler: ((d: NativeUsbDevice) => void) | null = null;
   private _usbDetachHandler: ((d: NativeUsbDevice) => void) | null = null;
+  private _discoveryPollInterval: NodeWebUsbIntervalHandle | null = null;
+  private _isRefreshingDiscoveredDevices = false;
 
   constructor(
     deviceModelDataSource: DeviceModelDataSource,
@@ -113,6 +163,7 @@ export class NodeWebUsbTransport implements Transport {
     deviceApduSenderFactory: (
       args: NodeWebUsbApduSenderConstructorArgs,
     ) => NodeWebUsbApduSender = a => new NodeWebUsbApduSender(a),
+    platformBindings: NodeWebUsbTransportPlatform = defaultNodeWebUsbTransportPlatform,
   ) {
     this._deviceModelDataSource = deviceModelDataSource;
     this._loggerServiceFactory = loggerServiceFactory;
@@ -120,6 +171,7 @@ export class NodeWebUsbTransport implements Transport {
     this._apduReceiverFactory = apduReceiverFactory;
     this._deviceConnectionStateMachineFactory = deviceConnectionStateMachineFactory;
     this._deviceApduSenderFactory = deviceApduSenderFactory;
+    this._platformBindings = platformBindings;
     this._logger = loggerServiceFactory("NodeWebUsbTransport");
     this.startListeningToConnectionEvents();
   }
@@ -130,6 +182,30 @@ export class NodeWebUsbTransport implements Transport {
 
   isSupported(): boolean {
     return true;
+  }
+
+  private shouldUseWindowsDiscoveryPolling(): boolean {
+    return this._platformBindings.platform === "win32";
+  }
+
+  private startWindowsDiscoveryPolling(): void {
+    if (!this.shouldUseWindowsDiscoveryPolling() || this._discoveryPollInterval !== null) {
+      return;
+    }
+
+    this._discoveryPollInterval = this._platformBindings.setInterval(() => {
+      void this.updateTransportDiscoveredDevices();
+    }, WINDOWS_WEBUSB_DISCOVERY_POLL_INTERVAL_MS);
+    this._discoveryPollInterval.unref?.();
+  }
+
+  private stopWindowsDiscoveryPolling(): void {
+    if (this._discoveryPollInterval === null) {
+      return;
+    }
+
+    this._platformBindings.clearInterval(this._discoveryPollInterval);
+    this._discoveryPollInterval = null;
   }
 
   private getDeviceModel(device: WebUSBDevice): Maybe<TransportDeviceModel> {
@@ -149,11 +225,11 @@ export class NodeWebUsbTransport implements Transport {
 
   private async scanLedgerWebUsbDevices(): Promise<ScannedWebUsbDevice[]> {
     const collected: ScannedWebUsbDevice[] = [];
-    for (const native of getDeviceList()) {
+    for (const native of this._platformBindings.getDeviceList()) {
       if (native.deviceDescriptor.idVendor !== LEDGER_VENDOR_ID) {
         continue;
       }
-      const device = await WebUSBDevice.createInstance(native);
+      const device = await this._platformBindings.createWebUsbDevice(native);
       const interfaceNumber = getVendorInterfaceNumber(device);
       if (interfaceNumber === null) {
         continue;
@@ -207,6 +283,11 @@ export class NodeWebUsbTransport implements Transport {
   }
 
   async updateTransportDiscoveredDevices(): Promise<ScannedWebUsbDevice[]> {
+    if (this._isRefreshingDiscoveredDevices) {
+      return [];
+    }
+
+    this._isRefreshingDiscoveredDevices = true;
     try {
       const scanned = await this.scanLedgerWebUsbDevices();
       const next: WebUsbDiscoveredInternal[] = [];
@@ -220,11 +301,23 @@ export class NodeWebUsbTransport implements Transport {
           throw e;
         }
       }
-      this._transportDiscoveredDevices.next(next);
+
+      if (next.length > 0) {
+        this.stopWindowsDiscoveryPolling();
+      } else {
+        this.startWindowsDiscoveryPolling();
+      }
+
+      if (!areSameDiscoveredDevices(this._transportDiscoveredDevices.getValue(), next)) {
+        this._transportDiscoveredDevices.next(next);
+      }
+
       return scanned;
     } catch (e) {
       this._logger.error("Error while scanning Ledger WebUSB devices", { data: { error: e } });
       return [];
+    } finally {
+      this._isRefreshingDiscoveredDevices = false;
     }
   }
 
@@ -271,24 +364,27 @@ export class NodeWebUsbTransport implements Transport {
     this._usbDetachHandler = (d: NativeUsbDevice) => {
       void this.handleDeviceDisconnection(d);
     };
-    usbBindings.on("attach", this._usbAttachHandler);
-    usbBindings.on("detach", this._usbDetachHandler);
+    this._platformBindings.usbBindings.on("attach", this._usbAttachHandler);
+    this._platformBindings.usbBindings.on("detach", this._usbDetachHandler);
+    this.startWindowsDiscoveryPolling();
+
     process.on("exit", () => {
       this.stopListeningToConnectionEvents();
-      usbBindings.unrefHotplugEvents();
+      this._platformBindings.usbBindings.unrefHotplugEvents();
     });
   }
 
   private stopListeningToConnectionEvents(): void {
     this._logger.debug("stopListeningToConnectionEvents (WebUSB)");
     if (this._usbAttachHandler) {
-      usbBindings.removeListener("attach", this._usbAttachHandler);
+      this._platformBindings.usbBindings.removeListener("attach", this._usbAttachHandler);
       this._usbAttachHandler = null;
     }
     if (this._usbDetachHandler) {
-      usbBindings.removeListener("detach", this._usbDetachHandler);
+      this._platformBindings.usbBindings.removeListener("detach", this._usbDetachHandler);
       this._usbDetachHandler = null;
     }
+    this.stopWindowsDiscoveryPolling();
   }
 
   async connect({
@@ -445,7 +541,7 @@ export class NodeWebUsbTransport implements Transport {
     });
 
     try {
-      const web = await WebUSBDevice.createInstance(native);
+      const web = await this._platformBindings.createWebUsbDevice(native);
       const iface = getVendorInterfaceNumber(web);
       if (iface === null) {
         this._logger.debug("[handleDeviceConnection] No Ledger WebUSB interface", {

--- a/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.ts
+++ b/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.ts
@@ -1,5 +1,6 @@
 import {
   DeviceConnectionStateMachine,
+  DeviceDisconnectedBeforeSendingApdu,
   DeviceNotRecognizedError,
   LEDGER_VENDOR_ID,
   NoAccessibleDeviceError,
@@ -142,6 +143,10 @@ export class NodeWebUsbTransport implements Transport {
   private readonly _deviceConnectionsPendingReconnection = new Set<
     DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>
   >();
+  private readonly _sendApduQueues = new WeakMap<
+    DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>,
+    Promise<unknown>
+  >();
 
   private readonly _logger: LoggerPublisherService;
   private readonly connectionType = "USB" as const;
@@ -188,6 +193,47 @@ export class NodeWebUsbTransport implements Transport {
     return this._platformBindings.platform === "win32";
   }
 
+  private isConnectionMachineRoutable(
+    machine: DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>,
+  ): boolean {
+    return (
+      this._deviceConnectionsPendingReconnection.has(machine) ||
+      this._deviceConnectionsByWebUsbDevice.values().some(active => active === machine)
+    );
+  }
+
+  private makeTransportConnectedDevice({
+    row,
+    machine,
+  }: {
+    row: WebUsbDiscoveredInternal;
+    machine: DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>;
+  }): TransportConnectedDevice {
+    const deviceId = row.id;
+
+    const sendApduToMachine: TransportConnectedDevice["sendApdu"] = async (...args) => {
+      if (!this.isConnectionMachineRoutable(machine)) {
+        return Left(
+          new DeviceDisconnectedBeforeSendingApdu(`${deviceId} is no longer active or pending`),
+        );
+      }
+      return machine.sendApdu(...args);
+    };
+
+    return new TransportConnectedDevice({
+      id: deviceId,
+      deviceModel: row.deviceModel,
+      type: this.connectionType,
+      sendApdu: async (...args) => {
+        const previous = this._sendApduQueues.get(machine) ?? Promise.resolve();
+        const queued = previous.catch(() => undefined).then(() => sendApduToMachine(...args));
+        this._sendApduQueues.set(machine, queued.catch(() => undefined));
+        return queued;
+      },
+      transport: this.identifier,
+    });
+  }
+
   private startWindowsDiscoveryPolling(): void {
     if (!this.shouldUseWindowsDiscoveryPolling() || this._discoveryPollInterval !== null) {
       return;
@@ -208,6 +254,11 @@ export class NodeWebUsbTransport implements Transport {
     this._discoveryPollInterval = null;
   }
 
+  private resumeDiscoveryAfterDisconnect(): void {
+    this.startWindowsDiscoveryPolling();
+    void this.updateTransportDiscoveredDevices();
+  }
+
   private getDeviceModel(device: WebUSBDevice): Maybe<TransportDeviceModel> {
     const { productId } = device;
     const model = this._deviceModelDataSource
@@ -221,6 +272,30 @@ export class NodeWebUsbTransport implements Transport {
       Just: m => m.usbProductId,
       Nothing: () => device.productId >> 8,
     });
+  }
+
+  private findPendingReconnectionMachine(
+    web: WebUSBDevice,
+  ): DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies> | undefined {
+    return this._deviceConnectionsPendingReconnection.values().find(sm => {
+      const previousDevice = sm.getDependencies().device;
+      if (previousDevice.serialNumber && web.serialNumber) {
+        return previousDevice.serialNumber === web.serialNumber;
+      }
+
+      return this.getUsbProductIdForMatch(previousDevice) === this.getUsbProductIdForMatch(web);
+    });
+  }
+
+  private async reconnectPendingMachines(scanned: ScannedWebUsbDevice[]): Promise<void> {
+    for (const { device, interfaceNumber } of scanned) {
+      const pending = this.findPendingReconnectionMachine(device);
+      if (!pending) {
+        continue;
+      }
+
+      await this.handleDeviceReconnection(pending, device, interfaceNumber);
+    }
   }
 
   private async scanLedgerWebUsbDevices(): Promise<ScannedWebUsbDevice[]> {
@@ -290,6 +365,7 @@ export class NodeWebUsbTransport implements Transport {
     this._isRefreshingDiscoveredDevices = true;
     try {
       const scanned = await this.scanLedgerWebUsbDevices();
+      await this.reconnectPendingMachines(scanned);
       const next: WebUsbDiscoveredInternal[] = [];
       for (const { device, interfaceNumber } of scanned) {
         try {
@@ -403,15 +479,7 @@ export class NodeWebUsbTransport implements Transport {
 
     const existing = this._deviceConnectionsByWebUsbDevice.get(row.webUsbDevice);
     if (existing) {
-      return Right(
-        new TransportConnectedDevice({
-          id: deviceId,
-          deviceModel: row.deviceModel,
-          type: this.connectionType,
-          sendApdu: (...args) => existing.sendApdu(...args),
-          transport: this.identifier,
-        }),
-      );
+      return Right(this.makeTransportConnectedDevice({ row, machine: existing }));
     }
 
     const apduSender = this._deviceApduSenderFactory({
@@ -425,15 +493,17 @@ export class NodeWebUsbTransport implements Transport {
       deviceId,
       deviceApduSender: apduSender,
       timeoutDuration: RECONNECT_DEVICE_TIMEOUT_MS,
-      tryToReconnect: (_timeoutDuration: number) => {
+      tryToReconnect: () => {
         this._deviceConnectionsByWebUsbDevice.forEach((sm, dev) => {
           if (sm.getDeviceId() === deviceId) {
             this._deviceConnectionsPendingReconnection.add(sm);
             this._deviceConnectionsByWebUsbDevice.delete(dev);
           }
         });
+        this.resumeDiscoveryAfterDisconnect();
       },
       onTerminated: () => {
+        this.resumeDiscoveryAfterDisconnect();
         this._deviceConnectionsPendingReconnection.forEach(sm => {
           if (sm.getDeviceId() === deviceId) {
             this._deviceConnectionsPendingReconnection.delete(sm);
@@ -458,15 +528,7 @@ export class NodeWebUsbTransport implements Transport {
 
     this._deviceConnectionsByWebUsbDevice.set(row.webUsbDevice, machine);
 
-    return Right(
-      new TransportConnectedDevice({
-        sendApdu: machine.sendApdu.bind(machine),
-        deviceModel: row.deviceModel,
-        id: deviceId,
-        type: this.connectionType,
-        transport: this.identifier,
-      }),
-    );
+    return Right(this.makeTransportConnectedDevice({ row, machine }));
   }
 
   async disconnect(params: { connectedDevice: TransportConnectedDevice }) {
@@ -480,7 +542,14 @@ export class NodeWebUsbTransport implements Transport {
       });
       return Left(new UnknownDeviceError(`Unknown device ${params.connectedDevice.id}`));
     }
+    this._deviceConnectionsByWebUsbDevice.forEach((connection, device) => {
+      if (connection.getDeviceId() === params.connectedDevice.id) {
+        this._deviceConnectionsByWebUsbDevice.delete(device);
+      }
+    });
+    this._deviceConnectionsPendingReconnection.delete(sm);
     sm.closeConnection();
+    void this.updateTransportDiscoveredDevices();
     return Right(undefined);
   }
 
@@ -492,7 +561,7 @@ export class NodeWebUsbTransport implements Transport {
     this._logger.info("[handleDeviceDisconnection] Device disconnected (WebUSB)", {
       data: { vendorId: idVendor, productId: idProduct },
     });
-    void this.updateTransportDiscoveredDevices();
+    this.resumeDiscoveryAfterDisconnect();
 
     // Native detach events only expose vendorId/productId — serialNumber is
     // unavailable for a disconnecting device, so same-model disambiguation
@@ -519,6 +588,7 @@ export class NodeWebUsbTransport implements Transport {
     web: WebUSBDevice,
     interfaceNumber: number,
   ): Promise<void> {
+    const previousDependencies = machine.getDependencies();
     try {
       this._deviceConnectionsPendingReconnection.delete(machine);
       machine.setDependencies({ device: web, interfaceNumber });
@@ -527,7 +597,8 @@ export class NodeWebUsbTransport implements Transport {
       machine.eventDeviceConnected();
     } catch (e) {
       this._logger.error("Error while reconnecting to device", { data: { error: e } });
-      machine.closeConnection();
+      machine.setDependencies(previousDependencies);
+      this._deviceConnectionsPendingReconnection.add(machine);
     }
   }
 
@@ -550,13 +621,7 @@ export class NodeWebUsbTransport implements Transport {
         return;
       }
 
-      const pending = this._deviceConnectionsPendingReconnection.values().find(sm => {
-        const prev = sm.getDependencies().device;
-        if (prev.serialNumber && web.serialNumber) {
-          return prev.serialNumber === web.serialNumber;
-        }
-        return this.getUsbProductIdForMatch(prev) === this.getUsbProductIdForMatch(web);
-      });
+      const pending = this.findPendingReconnectionMachine(web);
 
       if (pending) {
         await this.handleDeviceReconnection(pending, web, iface);

--- a/apps/wallet-cli/src/device/node-webusb/node-webusb-constants.ts
+++ b/apps/wallet-cli/src/device/node-webusb/node-webusb-constants.ts
@@ -4,6 +4,9 @@ export const FRAME_SIZE = 64;
 /** Device reconnect window for DMK state machine (matches node-hid kit). */
 export const RECONNECT_DEVICE_TIMEOUT_MS = 6000;
 
+/** Windows hotplug can miss late WebUSB attach notifications; rescan periodically as a fallback. */
+export const WINDOWS_WEBUSB_DISCOVERY_POLL_INTERVAL_MS = 1000;
+
 /** Ledger WebUSB configuration (see @ledgerhq/hw-transport-webusb). */
 export const LEDGER_WEBUSB_CONFIGURATION_VALUE = 1;
 


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - wallet-cli

### 📝 Description

Add a Windows-only discovery fallback in the Node WebUSB transport for the case where the CLI starts before the Ledger is connected and node-usb does not reliably emit the later attach event.

Keep the fallback limited to the "no device discovered yet" phase and stop polling as soon as a Ledger is found, so discovery does not churn the device list or interfere with DMK session establishment.

Also add a regression test covering the Windows late-attach flow.

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
