### PR TITLE
[LWM] feat: trigger send prompt on confirmation exit

### DIFF
--- a/.changeset/quiet-pandas-send.md
+++ b/.changeset/quiet-pandas-send.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix send notification prompt timing

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SendFundsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SendFundsNavigator.tsx
@@ -16,6 +16,7 @@ import SendValidationError from "~/screens/SendFunds/07-ValidationError";
 import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
 import StepHeader from "../StepHeader";
 import type { SendFundsNavigatorStackParamList } from "./types/SendFundsNavigator";
+import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "5";
 
@@ -24,6 +25,7 @@ const Stack = createNativeStackNavigator<SendFundsNavigatorStackParamList>();
 export default function SendFundsNavigator() {
   const { t } = useTranslation();
   const { colors } = useTheme();
+  const { notifyFlowCompleted } = useNotificationsContext();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
 
   return (
@@ -141,6 +143,11 @@ export default function SendFundsNavigator() {
             headerShown: false,
             headerRight: undefined,
             gestureEnabled: false,
+          }}
+          listeners={{
+            beforeRemove: () => {
+              notifyFlowCompleted("send");
+            },
           }}
         />
         <Stack.Screen

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/NotificationsPromptSendFlow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/NotificationsPromptSendFlow.test.tsx
@@ -1,44 +1,23 @@
 import React from "react";
 import { View } from "react-native";
 import { ABTestingVariants } from "@ledgerhq/types-live";
+import { AuthorizationStatus } from "@react-native-firebase/messaging";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import { render, screen, waitFor, withFlagOverrides, act } from "@tests/test-renderer";
+import {
+  renderWithReactQuery,
+  screen,
+  waitFor,
+  withFlagOverrides,
+  act,
+} from "@tests/test-renderer";
 import storage from "LLM/storage";
-import ReceiveFundsNavigator from "~/components/RootNavigator/ReceiveFundsNavigator";
+import SendFundsNavigator from "~/components/RootNavigator/SendFundsNavigator";
 import { NavigatorName, ScreenName } from "~/const";
-import { BTC_ACCOUNT } from "@ledgerhq/live-common/modularDrawer/__mocks__/accounts.mock";
 import GlobalDrawers from "~/GlobalDrawers";
 import { track } from "~/analytics";
-import { AuthorizationStatus } from "@react-native-firebase/messaging";
+import { MockedAccounts } from "LLM/features/Accounts/__integrations__/mockedAccounts";
 
-type AuthorizationStatusType = (typeof AuthorizationStatus)[keyof typeof AuthorizationStatus];
-
-const mockRequestPermission = jest.fn<Promise<AuthorizationStatusType>, []>(() =>
-  Promise.resolve(AuthorizationStatus.NOT_DETERMINED),
-);
-const mockHasPermission = jest.fn<Promise<AuthorizationStatusType>, []>(() =>
-  Promise.resolve(AuthorizationStatus.NOT_DETERMINED),
-);
-
-jest.mock("@react-native-firebase/messaging", () => {
-  const AuthorizationStatus = {
-    NOT_DETERMINED: -1,
-    DENIED: 0,
-    AUTHORIZED: 1,
-    PROVISIONAL: 2,
-    EPHEMERAL: 3,
-  } as const;
-
-  return {
-    AuthorizationStatus,
-    getMessaging: jest.fn(() => ({
-      requestPermission: mockRequestPermission,
-      hasPermission: mockHasPermission,
-    })),
-  };
-});
-
-const featureFlagsForReceivePrompt = {
+const featureFlagsForSendPrompt = {
   brazePushNotifications: {
     enabled: true,
     params: {
@@ -85,15 +64,13 @@ const featureFlagsForReceivePrompt = {
   },
 };
 
-describe("NotificationsPrompt receive flow", () => {
+describe("NotificationsPrompt send flow", () => {
   beforeAll(() => {
     jest.useFakeTimers();
   });
 
   beforeEach(async () => {
     jest.setSystemTime(new Date("2025-01-01T00:00:00.000Z"));
-    mockRequestPermission.mockResolvedValue(AuthorizationStatus.NOT_DETERMINED);
-    mockHasPermission.mockResolvedValue(AuthorizationStatus.NOT_DETERMINED);
     await storage.deleteAll();
   });
 
@@ -113,21 +90,30 @@ describe("NotificationsPrompt receive flow", () => {
     return <View />;
   }
 
-  const receiveFlowNavigationState = {
+  const MOCK_ACCOUNT = MockedAccounts.active[0];
+  const sendFlowNavigationState = {
     index: 1,
     routes: [
       {
         name: HOME_SCREEN,
       },
       {
-        name: NavigatorName.ReceiveFunds,
+        name: NavigatorName.SendFunds,
         state: {
           index: 0,
           routes: [
             {
-              name: ScreenName.ReceiveConnectDevice,
+              name: ScreenName.SendValidationSuccess,
               params: {
-                accountId: BTC_ACCOUNT.id,
+                accountId: MOCK_ACCOUNT.id,
+                deviceId: "device-id",
+                result: {
+                  id: "op-123",
+                  hash: "0x123abc",
+                  type: "OUT",
+                  accountId: MOCK_ACCOUNT.id,
+                },
+                transaction: { family: MOCK_ACCOUNT.currency.family },
               },
             },
           ],
@@ -136,33 +122,30 @@ describe("NotificationsPrompt receive flow", () => {
     ],
   };
 
-  function ReceiveFlowTestApp() {
+  function SendFlowTestApp() {
     return (
       <GlobalDrawers>
         <Stack.Navigator screenOptions={{ headerShown: false }}>
           <Stack.Screen name={HOME_SCREEN} component={HomeScreen} />
-          <Stack.Screen name={NavigatorName.ReceiveFunds} component={ReceiveFundsNavigator} />
+          <Stack.Screen name={NavigatorName.SendFunds} component={SendFundsNavigator} />
         </Stack.Navigator>
       </GlobalDrawers>
     );
   }
 
-  it("should prompt the notifications drawer when leaving the receive flow", async () => {
-    const { user } = render(<ReceiveFlowTestApp />, {
-      navigationInitialState: receiveFlowNavigationState,
-      overrideInitialState: withFlagOverrides(featureFlagsForReceivePrompt, state => ({
+  it("should prompt the notifications drawer when leaving the send success screen", async () => {
+    const { user } = renderWithReactQuery(<SendFlowTestApp />, {
+      navigationInitialState: sendFlowNavigationState,
+      overrideInitialState: withFlagOverrides(featureFlagsForSendPrompt, state => ({
         ...state,
-        accounts: {
-          ...state.accounts,
-          active: [BTC_ACCOUNT],
-        },
+        accounts: MockedAccounts,
         notifications: {
           ...state.notifications,
           permissionStatus: AuthorizationStatus.NOT_DETERMINED,
         },
         settings: {
           ...state.settings,
-          readOnlyModeEnabled: true,
+          readOnlyModeEnabled: false,
           notifications: {
             ...state.settings.notifications,
             areNotificationsAllowed: true,
@@ -171,33 +154,35 @@ describe("NotificationsPrompt receive flow", () => {
       })),
     });
 
-    await user.press(await screen.findByText(/^continue$/i));
-    await waitFor(() => expect(screen.getByTestId("button-receive-confirmation")).toBeVisible());
+    await waitFor(() => expect(screen.getByTestId("validate-success-screen")).toBeVisible());
+    const closeButton = screen.getByTestId("enabled-success-close-button");
+    expect(track).not.toHaveBeenCalledWith(
+      "attempt_to_trigger_push_notification_drawer_after_action",
+    );
 
-    const backButtons = screen.getAllByTestId("navigation-header-back-button");
-    await user.press(backButtons[backButtons.length - 1]);
-    await act(async () => {
-      await jest.runOnlyPendingTimersAsync();
-    });
+    await user.press(closeButton);
+    act(() => jest.runOnlyPendingTimers());
 
     await waitFor(() => {
-      expect(screen.getByText(/maybe later/i)).toBeVisible();
+      expect(screen.getByText(/allow notifications/i)).toBeVisible();
     });
     expect(track).toHaveBeenCalledWith("attempt_to_trigger_push_notification_drawer_after_action", {
-      action: "receive",
+      action: "send",
       shouldPrompt: true,
       variant: ABTestingVariants.variantB,
       repromptDelay: null,
       dismissedCount: 0,
       skipReason: undefined,
     });
-    const allowNotificationsButton = screen.getByText(/allow notifications/i);
-    expect(allowNotificationsButton).toBeVisible();
-    await user.press(allowNotificationsButton);
+
+    const maybeLaterButton = screen.getByText(/maybe later/i);
+    expect(maybeLaterButton).toBeVisible();
+    await user.press(maybeLaterButton);
+
     expect(track).toHaveBeenCalledWith("button_clicked", {
-      button: "allow notifications",
+      button: "maybe later",
       page: "Drawer push notification opt-in",
-      source: "receive",
+      source: "send",
       repromptDelay: null,
       dismissedCount: 0,
       variant: ABTestingVariants.variantB,

--- a/apps/ledger-live-mobile/src/screens/SendFunds/07-ValidationSuccess.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/07-ValidationSuccess.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback } from "react";
 import { CompositeScreenProps, useTheme } from "@react-navigation/native";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
@@ -14,7 +14,6 @@ import {
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import SafeAreaViewFixed from "~/components/SafeAreaView";
 import Config from "react-native-config";
-import { useNotifications } from "LLM/features/NotificationsPrompt";
 
 type Props = CompositeScreenProps<
   StackNavigatorProps<SendFundsNavigatorStackParamList, ScreenName.SendValidationSuccess>,
@@ -24,21 +23,8 @@ type Props = CompositeScreenProps<
 export default function ValidationSuccess({ navigation, route }: Props) {
   const { colors } = useTheme();
   const { account, parentAccount } = useAccountScreen(route);
-  const { tryTriggerPushNotificationDrawerAfterAction } = useNotifications();
 
   const currency = account ? getAccountCurrency(account) : null;
-  useEffect(() => {
-    if (!account) return;
-    let result = route.params?.result;
-    if (!result) return;
-    result = result.subOperations && result.subOperations[0] ? result.subOperations[0] : result;
-
-    tryTriggerPushNotificationDrawerAfterAction("send");
-
-    // FIXME: IT LOOKS LIKE A COMPONENT DID MOUNT BUT NOT SURE AT ALL IF
-    // IT NEEDS TO BE RERUN WHEN DEPS CHANGE
-    // oxlint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
   const onClose = useCallback(() => {
     navigation.getParent<StackNavigatorNavigation<BaseNavigatorStackParamList>>().pop();
   }, [navigation]);

--- a/apps/ledger-live-mobile/src/screens/__integrations__/pushNotificationOptIn.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/__integrations__/pushNotificationOptIn.integration.test.tsx
@@ -14,7 +14,6 @@ jest.mock("LLM/features/NotificationsPrompt/hooks/useNotifications", () => ({
   }),
 }));
 
-import SendValidationSuccess from "~/screens/SendFunds/07-ValidationSuccess";
 import { PendingOperation as SwapPendingOperation } from "~/screens/Swap/SubScreens/PendingOperation";
 import CosmosValidationSuccess from "~/families/cosmos/DelegationFlow/04-ValidationSuccess";
 
@@ -36,33 +35,6 @@ const INITIAL_STATE = {
 describe("Push Notification Opt-In on Success Screens", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-  });
-
-  it("should trigger notification drawer with 'send' after SEND success", async () => {
-    const sendParams = {
-      accountId: MOCK_ACCOUNT.id,
-      result: {
-        id: "op-123",
-        hash: "0x123abc",
-        type: "OUT",
-        accountId: MOCK_ACCOUNT.id,
-      },
-    };
-
-    render(
-      <Stack.Navigator>
-        <Stack.Screen name={ScreenName.SendValidationSuccess}>
-          {props => <SendValidationSuccess {...props} route={{ params: sendParams } as never} />}
-        </Stack.Screen>
-      </Stack.Navigator>,
-      INITIAL_STATE,
-    );
-
-    await waitFor(() => {
-      expect(screen.getByTestId("validate-success-screen")).toBeOnTheScreen();
-    });
-
-    expect(mockTryTriggerPushNotificationDrawerAfterAction).toHaveBeenCalledWith("send");
   });
 
   it("should trigger notification drawer with 'swap' after SWAP success", async () => {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Mobile send confirmation exit behavior
  - Notifications prompt eligibility after leaving send confirmation

### 📝 Description

Users should first have time to see the send confirmation screen, then the notifications opt-in drawer should become eligible only when they leave that confirmation UI. Triggering the prompt from the send success screen mount made the drawer timing depend on the leaf screen lifecycle instead of the flow exit.

This PR wires `ScreenName.SendValidationSuccess` to the notifications prompt provider through a `beforeRemove` listener in `SendFundsNavigator`. The send success screen no longer triggers the drawer on mount, and integration coverage asserts the prompt appears only after leaving the send confirmation screen.


https://github.com/user-attachments/assets/676a5c5a-c251-47ff-99f7-0bbbc08e6dd9


### ❓ Context

- **JIRA or GitHub link**: [LIVE-29484](https://ledgerhq.atlassian.net/browse/LIVE-29484)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-29484]: https://ledgerhq.atlassian.net/browse/LIVE-29484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ