### PR TITLE
[LWM] fix(LWM): Patch redirection upon FW update request

### DIFF
--- a/.changeset/giant-turkeys-camp.md
+++ b/.changeset/giant-turkeys-camp.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Patch redirection to My Ledger upon FW update request

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -38,6 +38,7 @@ import { TrackScreen, track, useTrack } from "~/analytics";
 import { NavigatorName, ScreenName } from "~/const";
 import { MANAGER_TABS } from "~/const/manager";
 import { getDeviceAnimation, getDeviceAnimationStyles } from "~/helpers/getDeviceAnimation";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import { lastSeenDeviceSelector } from "~/reducers/settings";
 import { SettingsState } from "~/reducers/types";
 import { urls } from "~/utils/urls";
@@ -772,6 +773,7 @@ export function RequiredFirmwareUpdate({
   const { t } = useTranslation();
   const track = useTrack();
   const lastSeenDevice: DeviceModelInfo | null | undefined = useSelector(lastSeenDeviceSelector);
+  const { shouldDisplayWallet40MainNav } = useWalletFeaturesConfig("mobile");
 
   const usbFwUpdateActivated = !!lastSeenDevice;
   const deviceName = getDeviceModel(device.modelId).productName;
@@ -784,36 +786,35 @@ export function RequiredFirmwareUpdate({
       button: "OpenMyLedger",
       page: "Update_OS_To_Continue",
     });
-    navigation.reset({
-      index: 0,
+    const myLedgerState = {
       routes: [
         {
-          name: NavigatorName.Base,
-          state: {
-            routes: [
-              {
-                name: NavigatorName.Main,
-                state: {
-                  routes: [
-                    {
-                      name: NavigatorName.MyLedger,
-                      state: {
-                        routes: [
-                          {
-                            name: ScreenName.MyLedgerChooseDevice,
-                            params: { device, firmwareUpdate: isDeviceConnectedViaUSB },
-                          },
-                        ],
-                      },
-                    },
-                  ],
-                },
-              },
-            ],
-          },
+          name: ScreenName.MyLedgerChooseDevice,
+          params: { device, firmwareUpdate: isDeviceConnectedViaUSB },
         },
       ],
-    });
+    };
+    if (shouldDisplayWallet40MainNav) {
+      navigation.reset({
+        index: 1,
+        routes: [
+          { name: NavigatorName.Main },
+          { name: NavigatorName.MyLedger, state: myLedgerState },
+        ],
+      });
+    } else {
+      navigation.reset({
+        index: 0,
+        routes: [
+          {
+            name: NavigatorName.Main,
+            state: {
+              routes: [{ name: NavigatorName.MyLedger, state: myLedgerState }],
+            },
+          },
+        ],
+      });
+    }
   };
 
   return (

--- a/apps/ledger-live-mobile/src/components/DeviceAction/requiredFirmwareUpdate.test.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/requiredFirmwareUpdate.test.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import { RequiredFirmwareUpdate } from "./rendering";
+import { NavigatorName, ScreenName } from "~/const";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import * as useWalletFeaturesConfigModule from "@ledgerhq/live-common/featureFlags/index";
+import type { WalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/walletFeaturesConfig/types";
+import type { State } from "~/reducers/types";
+
+jest.mock("@ledgerhq/live-common/featureFlags/index");
+
+jest.mock("~/analytics", () => ({
+  TrackScreen: () => null,
+  useTrack: () => jest.fn(),
+  track: jest.fn(),
+}));
+
+const mockUseWalletFeaturesConfig = jest.mocked(
+  useWalletFeaturesConfigModule.useWalletFeaturesConfig,
+);
+
+const nanoX = {
+  modelId: DeviceModelId.nanoX,
+  deviceId: "nanoX",
+  wired: true,
+};
+
+const mockReset = jest.fn();
+const mockNavigation = { reset: mockReset } as never;
+
+const stateWithLastSeenDevice = (state: State): State => ({
+  ...state,
+  settings: {
+    ...state.settings,
+    seenDevices: [{ modelId: DeviceModelId.nanoX } as never],
+  },
+});
+
+describe("RequiredFirmwareUpdate", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("should navigate to MyLedger via Main (not Base) when shouldDisplayWallet40MainNav is false", async () => {
+    mockUseWalletFeaturesConfig.mockReturnValue({
+      shouldDisplayWallet40MainNav: false,
+    } as WalletFeaturesConfig);
+
+    const { user } = render(
+      <RequiredFirmwareUpdate navigation={mockNavigation} device={nanoX} />,
+      { overrideInitialState: stateWithLastSeenDevice },
+    );
+
+    await user.press(screen.getByText("Go to My Ledger"));
+
+    expect(mockReset).toHaveBeenCalledWith({
+      index: 0,
+      routes: [
+        {
+          name: NavigatorName.Main,
+          state: {
+            routes: [
+              {
+                name: NavigatorName.MyLedger,
+                state: {
+                  routes: [
+                    {
+                      name: ScreenName.MyLedgerChooseDevice,
+                      params: { device: nanoX, firmwareUpdate: true },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
+    expect(mockReset.mock.calls[0][0].routes[0].name).not.toBe(NavigatorName.Base);
+  });
+
+  it("should navigate to MyLedger with wallet40 layout when shouldDisplayWallet40MainNav is true", async () => {
+    mockUseWalletFeaturesConfig.mockReturnValue({
+      shouldDisplayWallet40MainNav: true,
+    } as WalletFeaturesConfig);
+
+    const { user } = render(
+      <RequiredFirmwareUpdate navigation={mockNavigation} device={nanoX} />,
+      { overrideInitialState: stateWithLastSeenDevice },
+    );
+
+    await user.press(screen.getByText("Go to My Ledger"));
+
+    expect(mockReset).toHaveBeenCalledWith({
+      index: 1,
+      routes: [
+        { name: NavigatorName.Main },
+        {
+          name: NavigatorName.MyLedger,
+          state: {
+            routes: [
+              {
+                name: ScreenName.MyLedgerChooseDevice,
+                params: { device: nanoX, firmwareUpdate: true },
+              },
+            ],
+          },
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->


### Issue
`RequiredFirmwareUpdate.onPress()` called `navigation.reset()` with `NavigatorName.Base` as the top-level route. But navigation (from `useNavigation()`) belongs to `BaseNavigator` and `NavigatorName.Base` is not a screen inside `BaseNavigator` (it's the name of `BaseNavigator` itself, registered in the root navigator). 

React Navigation can't find it, falls back to the initial screen, which is Home. 

### Fix

Removed the incorrect `NavigatorName.Base` wrapper and replaced the single `reset()` call with a `shouldDisplayWallet40MainNav`-aware pair that resets directly to `NavigatorName.Main`


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29661](https://ledgerhq.atlassian.net/browse/LIVE-29661)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-29661]: https://ledgerhq.atlassian.net/browse/LIVE-29661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ