### PR TITLE
[LWDM] feat(perps): add deeplink entry point for perpetuals trading

### DIFF
--- a/.changeset/small-doors-yawn.md
+++ b/.changeset/small-doors-yawn.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+feat: perps deeplink

--- a/apps/ledger-live-desktop/deeplinks-test-page.html
+++ b/apps/ledger-live-desktop/deeplinks-test-page.html
@@ -175,6 +175,11 @@
     <deeplink-button pathname="swap"></deeplink-button>
 
     <div class="separator"></div>
+
+    <h3>Perps</h3>
+    <deeplink-button pathname="perps"></deeplink-button>
+
+    <div class="separator"></div>
     <h3>MyLedger</h3>
     <deeplink-button pathname="myledger"></deeplink-button>
     <deeplink-button pathname="myledger?installApp=CURRENCY_PARAM"></deeplink-button>

--- a/apps/ledger-live-desktop/ledger-live-desktop-deeplinks.html
+++ b/apps/ledger-live-desktop/ledger-live-desktop-deeplinks.html
@@ -472,6 +472,16 @@
                     ]
                 },
                 {
+                    section: "Perps",
+                    title: "Perpetuals Trading",
+                    url: "ledgerwallet://perps",
+                    description: "Opens the perpetuals trading page.",
+                    examples: [
+                        "ledgerwallet://perps",
+                        "ledgerlive://perps"
+                    ]
+                },
+                {
                     section: "MyLedger",
                     title: "Device Management Flow",
                     url: "ledgerwallet://myledger",

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/perps.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/perps.handler.test.ts
@@ -1,0 +1,18 @@
+import { perpsHandler } from "../perps.handler";
+import { createMockContext } from "./test-utils";
+
+describe("perps.handler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("perpsHandler", () => {
+    it("navigates to /perps", () => {
+      const context = createMockContext();
+
+      perpsHandler({ type: "perps" }, context);
+
+      expect(context.navigate).toHaveBeenCalledWith("/perps");
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/perps.handler.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/perps.handler.ts
@@ -1,0 +1,5 @@
+import { DeeplinkHandler } from "../types";
+
+export const perpsHandler: DeeplinkHandler<"perps"> = (_route, { navigate }) => {
+  navigate("/perps");
+};

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/parseDeepLink.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/parseDeepLink.ts
@@ -19,6 +19,7 @@ import {
   WalletConnectRoute,
   MarketRoute,
   AssetRoute,
+  PerpsRoute,
   RecoverRoute,
   RecoverRestoreFlowRoute,
   PostOnboardingRoute,
@@ -247,6 +248,13 @@ export function createRoute(parsed: ParsedDeeplink): DeeplinkRoute {
       const route: AssetRoute = {
         type: "asset",
         path,
+      };
+      return route;
+    }
+
+    case "perps": {
+      const route: PerpsRoute = {
+        type: "perps",
       };
       return route;
     }

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/registry.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/registry.ts
@@ -12,6 +12,7 @@ import { settingsHandler } from "./handlers/settings.handler";
 import { cardHandler, discoverHandler, walletConnectHandler } from "./handlers/discover.handler";
 import { marketHandler, assetHandler } from "./handlers/market.handler";
 import { recoverHandler, recoverRestoreFlowHandler } from "./handlers/recover.handler";
+import { perpsHandler } from "./handlers/perps.handler";
 import { postOnboardingHandler } from "./handlers/postOnboarding.handler";
 import { ledgerSyncHandler } from "./handlers/ledgerSync.handler";
 import { defaultHandler } from "./handlers/default.handler";
@@ -34,6 +35,7 @@ export const deeplinkRegistry: DeeplinkHandlerRegistry = {
   wc: walletConnectHandler,
   market: marketHandler,
   asset: assetHandler,
+  perps: perpsHandler,
   recover: recoverHandler,
   "recover-restore-flow": recoverRestoreFlowHandler,
   "post-onboarding": postOnboardingHandler,

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/types.ts
@@ -193,6 +193,10 @@ export interface PostOnboardingRoute {
   device?: string;
 }
 
+export interface PerpsRoute {
+  type: "perps";
+}
+
 export interface LedgerSyncRoute {
   type: "ledgersync";
 }
@@ -221,6 +225,7 @@ export type DeeplinkRoute =
   | AssetRoute
   | RecoverRoute
   | RecoverRestoreFlowRoute
+  | PerpsRoute
   | PostOnboardingRoute
   | LedgerSyncRoute
   | DefaultRoute;

--- a/apps/ledger-live-mobile/ledger-live-mobile-deeplinks.html
+++ b/apps/ledger-live-mobile/ledger-live-mobile-deeplinks.html
@@ -479,6 +479,13 @@
                     examples: ["ledgerwallet://swap", "ledgerlive://swap"]
                 },
                 {
+                    section: "Perps",
+                    title: "Perpetuals Trading",
+                    url: "ledgerwallet://perps",
+                    description: "Opens the perpetuals trading page.",
+                    examples: ["ledgerwallet://perps", "ledgerlive://perps"]
+                },
+                {
                     section: "Market",
                     title: "Market Detail Page",
                     url: "ledgerlive://market/:currencyId",

--- a/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
+++ b/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
@@ -420,6 +420,14 @@ export const DeeplinksProvider = ({
                           },
                         },
                       }),
+                      /**
+                       * ie: "ledgerlive://perps" -> will redirect to the perps page
+                       */
+                      [NavigatorName.Perps]: {
+                        screens: {
+                          [ScreenName.PerpsTab]: "perps",
+                        },
+                      },
                       [NavigatorName.Main]: {
                         initialRouteName: ScreenName.Portfolio,
                         screens: {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Desktop handler is covered; mobile deeplink routing is not unit-tested (relies on React Navigation link config)._
- [x] **Impact of the changes:**
      - Deeplink routing on both desktop and mobile (`ledgerlive://perps`)
      - Existing deeplinks remain unaffected
      - Navigation to the `/perps` route on desktop and `PerpsTab` screen on mobile

### 📝 Description

**Problem**: There is no way to open the perpetuals trading page directly via a deeplink, making it harder to share entry points or integrate with external flows.

**Solution**: Added a `perps` deeplink on both desktop and mobile:

- **Desktop**: New `PerpsRoute` type, `perpsHandler` that navigates to `/perps`, parser case in `createRoute`, and registry entry. Includes a unit test for the handler.
- **Mobile**: Linked `NavigatorName.Perps` / `ScreenName.PerpsTab` to the `perps` deeplink path in `DeeplinksProvider`.
- Updated both deeplinks test pages with the new `perps` entry.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29678](https://ledgerhq.atlassian.net/browse/LIVE-29678)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-29678]: https://ledgerhq.atlassian.net/browse/LIVE-29678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ