### PR TITLE
[LWM] feat: trigger swap prompt on confirmation exit

### DIFF
--- a/.changeset/tender-swaps-notify.md
+++ b/.changeset/tender-swaps-notify.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix swap notification prompt timing

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SwapNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SwapNavigator.tsx
@@ -24,6 +24,8 @@ import { SwapNavigatorParamList } from "./types/SwapNavigator";
 import { NavigationHeaderBackButton } from "../NavigationHeaderBackButton";
 import SwapCustomError from "~/screens/Swap/SubScreens/SwapCustomError";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { isGoingToSwapHistory } from "~/screens/Swap/navigation/navigateBackToSwapTab";
 
 // Constants for tracking sources
 const TRACKING_SOURCES = {
@@ -85,6 +87,7 @@ export default function SwapNavigator(
   const noNanoBuyNanoWallScreenOptions = useNoNanoBuyNanoWallScreenOptions();
   const track = useTrack();
   const navigation = useNavigation<StackNavigatorNavigation<SwapNavigatorParamList>>();
+  const { notifyFlowCompleted } = useNotificationsContext();
   const { isEnabled: isLwm40Enabled, shouldDisplayWallet40MainNav } =
     useWalletFeaturesConfig("mobile");
 
@@ -181,6 +184,14 @@ export default function SwapNavigator(
           headerTitle: t("transfer.swap.title"),
           headerLeft: NullHeader,
         }}
+        listeners={{
+          beforeRemove: ({ data }) => {
+            if (isGoingToSwapHistory(data.action.payload)) {
+              return;
+            }
+            notifyFlowCompleted("swap");
+          },
+        }}
       />
 
       <Stack.Screen
@@ -216,6 +227,11 @@ export default function SwapNavigator(
         options={{
           headerTitle: t("transfer.swap2.history.title"),
           headerRight: NullHeader,
+        }}
+        listeners={{
+          beforeRemove: () => {
+            notifyFlowCompleted("swap");
+          },
         }}
       />
     </Stack.Navigator>

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SwapSubScreensNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SwapSubScreensNavigator.tsx
@@ -10,7 +10,11 @@ import { OperationDetails, PendingOperation, SwapLoading } from "~/screens/Swap/
 import SwapCustomError from "~/screens/Swap/SubScreens/SwapCustomError";
 import { SwapSubScreensNavigatorParamList } from "./types/SwapSubScreensNavigator";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
-import { navigateBackToSwapTab } from "~/screens/Swap/navigation/navigateBackToSwapTab";
+import {
+  isGoingToSwapHistory,
+  navigateBackToSwapTab,
+} from "~/screens/Swap/navigation/navigateBackToSwapTab";
+import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
 
 const Stack = createNativeStackNavigator<SwapSubScreensNavigatorParamList>();
 
@@ -65,6 +69,7 @@ export default function SwapSubScreensNavigator() {
   const { colors } = useTheme();
   const { t } = useTranslation();
   const { shouldDisplayWallet40MainNav } = useWalletFeaturesConfig("mobile");
+  const { notifyFlowCompleted } = useNotificationsContext();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
 
   return (
@@ -76,6 +81,14 @@ export default function SwapSubScreensNavigator() {
           headerTitle: t("transfer.swap.title"),
           headerLeft: NullHeader,
         }}
+        listeners={{
+          beforeRemove: ({ data }) => {
+            if (isGoingToSwapHistory(data.action.payload)) {
+              return;
+            }
+            notifyFlowCompleted("swap");
+          },
+        }}
       />
       <Stack.Screen
         name={ScreenName.SwapHistory}
@@ -84,6 +97,11 @@ export default function SwapSubScreensNavigator() {
           headerTitle: t("transfer.swap2.history.title"),
           shouldDisplayWallet40MainNav,
         })}
+        listeners={{
+          beforeRemove: () => {
+            notifyFlowCompleted("swap");
+          },
+        }}
       />
       <Stack.Screen
         name={ScreenName.SwapLoading}

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/NotificationsPromptSwapFlow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/NotificationsPromptSwapFlow.test.tsx
@@ -1,0 +1,390 @@
+import React, { useEffect } from "react";
+import { View } from "react-native";
+import BigNumber from "bignumber.js";
+import { ABTestingVariants } from "@ledgerhq/types-live";
+import { AuthorizationStatus } from "@react-native-firebase/messaging";
+import { CommonActions, NavigationProp, useNavigation } from "@react-navigation/native";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import {
+  act,
+  renderWithReactQuery as render,
+  screen,
+  waitFor,
+  withFlagOverrides,
+} from "@tests/test-renderer";
+import storage from "LLM/storage";
+import SwapNavigator from "~/components/RootNavigator/SwapNavigator";
+import SwapSubScreensNavigator from "~/components/RootNavigator/SwapSubScreensNavigator";
+import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import { NavigatorName, ScreenName } from "~/const";
+import GlobalDrawers from "~/GlobalDrawers";
+import { track } from "~/analytics";
+import { MockedAccounts } from "LLM/features/Accounts/__integrations__/mockedAccounts";
+
+jest.mock("~/analytics", () => {
+  const track = jest.fn();
+
+  return {
+    track,
+    useTrack: () => track,
+    TrackScreen: () => null,
+    updateIdentify: jest.fn(),
+  };
+});
+
+// Exception: this test only needs native beforeRemove behavior; real SwapLiveApp
+// would boot the webview and require unrelated manifest/webview setup.
+jest.mock("~/screens/Swap/LiveApp", () => ({
+  SwapLiveApp: () => null,
+}));
+
+jest.mock("~/screens/Swap/LiveApp/SwapLiveAppWallet40", () => ({
+  SwapLiveAppWallet40: () => null,
+}));
+
+const featureFlagsForSwapPrompt = {
+  brazePushNotifications: {
+    enabled: true,
+    params: {
+      action_events: {
+        complete_onboarding: {
+          enabled: true,
+          timer: 0,
+        },
+        add_favorite_coin: {
+          enabled: true,
+          timer: 0,
+        },
+        send: {
+          enabled: true,
+          timer: 0,
+        },
+        receive: {
+          enabled: true,
+          timer: 0,
+        },
+        buy: {
+          enabled: true,
+          timer: 0,
+        },
+        swap: {
+          enabled: true,
+          timer: 0,
+        },
+        stake: {
+          enabled: true,
+          timer: 0,
+        },
+      },
+      reprompt_schedule: [{ months: 0, days: 7, hours: 0, minutes: 0, seconds: 0 }],
+      inactivity_enabled: false,
+      inactivity_reprompt: { months: 6, days: 0, hours: 0, minutes: 0, seconds: 0 },
+    },
+  },
+  lwmNewWordingOptInNotificationsDrawer: {
+    enabled: true,
+    params: {
+      variant: ABTestingVariants.variantB,
+    },
+  },
+};
+
+describe("NotificationsPrompt swap flow", () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  beforeEach(async () => {
+    jest.setSystemTime(new Date("2025-01-01T00:00:00.000Z"));
+    await storage.deleteAll();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const Stack = createNativeStackNavigator<{
+    [NavigatorName.Main]: undefined;
+    [NavigatorName.Swap]: BaseNavigatorStackParamList[NavigatorName.Swap];
+    [NavigatorName.SwapSubScreens]: BaseNavigatorStackParamList[NavigatorName.SwapSubScreens];
+  }>();
+  type SwapRedirectParams = NonNullable<BaseNavigatorStackParamList[NavigatorName.SwapSubScreens]>;
+  type LegacySwapRedirectParams = NonNullable<BaseNavigatorStackParamList[NavigatorName.Swap]>;
+
+  const swapOperation = {
+    swapId: "swap-123",
+    provider: "changelly",
+    status: "pending",
+    receiverAccountId: MockedAccounts.active[0].id,
+    operationId: "operation-123",
+    fromAmount: new BigNumber(1),
+    toAmount: new BigNumber(1),
+  };
+
+  const swapSuccessParams: SwapRedirectParams = {
+    screen: ScreenName.SwapPendingOperation,
+    params: {
+      swapOperation,
+    },
+  };
+
+  const legacySwapSuccessParams: LegacySwapRedirectParams = {
+    screen: ScreenName.SwapPendingOperation,
+    params: {
+      swapOperation,
+    },
+  };
+
+  const overrideSwapPromptInitialState = withFlagOverrides(featureFlagsForSwapPrompt, state => ({
+    ...state,
+    accounts: MockedAccounts,
+    notifications: {
+      ...state.notifications,
+      permissionStatus: AuthorizationStatus.NOT_DETERMINED,
+    },
+    settings: {
+      ...state.settings,
+      readOnlyModeEnabled: false,
+      notifications: {
+        ...state.settings.notifications,
+        areNotificationsAllowed: true,
+      },
+    },
+  }));
+
+  function SwapFlowTestWrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <GlobalDrawers>
+        <Stack.Navigator screenOptions={{ headerShown: false }}>
+          <Stack.Screen name={NavigatorName.Main}>{() => children}</Stack.Screen>
+          <Stack.Screen name={NavigatorName.SwapSubScreens} component={SwapSubScreensNavigator} />
+          <Stack.Screen name={NavigatorName.Swap} component={SwapNavigator} />
+        </Stack.Navigator>
+      </GlobalDrawers>
+    );
+  }
+
+  describe("Wallet V4", () => {
+    function HomeScreen({ swapParams }: { swapParams: SwapRedirectParams }) {
+      const navigation = useNavigation<NavigationProp<BaseNavigatorStackParamList>>();
+
+      // Keep a parent stack entry under the swap flow so the success screen can go back.
+      useEffect(() => {
+        navigation.dispatch(
+          CommonActions.navigate({
+            name: NavigatorName.SwapSubScreens,
+            params: swapParams,
+          }),
+        );
+      }, [navigation, swapParams]);
+
+      return <View />;
+    }
+
+    function renderWalletV4SwapFlow(swapParams: SwapRedirectParams) {
+      return render(
+        <SwapFlowTestWrapper>
+          <HomeScreen swapParams={swapParams} />
+        </SwapFlowTestWrapper>,
+        { overrideInitialState: overrideSwapPromptInitialState },
+      );
+    }
+
+    it("should prompt the notifications drawer after closing swap success", async () => {
+      const { user } = renderWalletV4SwapFlow(swapSuccessParams);
+
+      await waitFor(() => expect(screen.getByTestId("swap-success-title")).toBeVisible());
+      expect(screen.getAllByTestId("NavigationHeaderCloseButton")[0]).toBeVisible();
+      expect(track).not.toHaveBeenCalledWith(
+        "attempt_to_trigger_push_notification_drawer_after_action",
+        expect.any(Object),
+      );
+
+      await user.press(screen.getAllByTestId("NavigationHeaderCloseButton")[0]);
+      await act(async () => {
+        await jest.runOnlyPendingTimersAsync();
+      });
+
+      expect(track).toHaveBeenCalledWith(
+        "attempt_to_trigger_push_notification_drawer_after_action",
+        {
+          action: "swap",
+          shouldPrompt: true,
+          variant: ABTestingVariants.variantB,
+          repromptDelay: null,
+          dismissedCount: 0,
+          skipReason: undefined,
+        },
+      );
+      await waitFor(() => {
+        expect(screen.getByText(/allow notifications/i)).toBeVisible();
+      });
+
+      await user.press(screen.getByText(/allow notifications/i));
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "allow notifications",
+        page: "Drawer push notification opt-in",
+        source: "swap",
+        repromptDelay: null,
+        dismissedCount: 0,
+        variant: ABTestingVariants.variantB,
+      });
+    });
+
+    it("should prompt only after closing history when swap success opens history", async () => {
+      const { user } = renderWalletV4SwapFlow(swapSuccessParams);
+
+      await waitFor(() => expect(screen.getByTestId("swap-success-title")).toBeVisible());
+      expect(track).not.toHaveBeenCalledWith(
+        "attempt_to_trigger_push_notification_drawer_after_action",
+      );
+
+      await user.press(screen.getByText(/go to history/i));
+      await waitFor(() => {
+        expect(screen.getByText(/your previous swaps will appear here/i)).toBeVisible();
+      });
+      expect(track).not.toHaveBeenCalledWith(
+        "attempt_to_trigger_push_notification_drawer_after_action",
+      );
+
+      await user.press(screen.getAllByTestId("navigation-header-back-button")[0]);
+      await act(async () => {
+        await jest.runOnlyPendingTimersAsync();
+      });
+
+      expect(track).toHaveBeenCalledWith(
+        "attempt_to_trigger_push_notification_drawer_after_action",
+        {
+          action: "swap",
+          shouldPrompt: true,
+          variant: ABTestingVariants.variantB,
+          repromptDelay: null,
+          dismissedCount: 0,
+          skipReason: undefined,
+        },
+      );
+
+      await user.press(screen.getByText(/allow notifications/i));
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "allow notifications",
+        page: "Drawer push notification opt-in",
+        source: "swap",
+        repromptDelay: null,
+        dismissedCount: 0,
+        variant: ABTestingVariants.variantB,
+      });
+    });
+  });
+
+  describe("legacy", () => {
+    function LegacyHomeScreen({ swapParams }: { swapParams: LegacySwapRedirectParams }) {
+      const navigation = useNavigation<NavigationProp<BaseNavigatorStackParamList>>();
+
+      // Keep a parent stack entry under the legacy swap flow so the success screen can go back.
+      useEffect(() => {
+        navigation.dispatch(
+          CommonActions.navigate({
+            name: NavigatorName.Swap,
+            params: swapParams,
+          }),
+        );
+      }, [navigation, swapParams]);
+
+      return <View />;
+    }
+
+    function renderLegacySwapFlow(swapParams: LegacySwapRedirectParams) {
+      return render(
+        <SwapFlowTestWrapper>
+          <LegacyHomeScreen swapParams={swapParams} />
+        </SwapFlowTestWrapper>,
+        { overrideInitialState: overrideSwapPromptInitialState },
+      );
+    }
+
+    it("should prompt the notifications drawer when closing the swap success screen", async () => {
+      const { user } = renderLegacySwapFlow(legacySwapSuccessParams);
+
+      await waitFor(() => expect(screen.getByTestId("swap-success-title")).toBeVisible());
+      expect(screen.getAllByTestId("NavigationHeaderCloseButton")[0]).toBeVisible();
+      expect(track).not.toHaveBeenCalledWith(
+        "attempt_to_trigger_push_notification_drawer_after_action",
+        expect.any(Object),
+      );
+
+      await user.press(screen.getAllByTestId("NavigationHeaderCloseButton")[0]);
+      await act(async () => {
+        await jest.runOnlyPendingTimersAsync();
+      });
+
+      expect(track).toHaveBeenCalledWith(
+        "attempt_to_trigger_push_notification_drawer_after_action",
+        {
+          action: "swap",
+          shouldPrompt: true,
+          variant: ABTestingVariants.variantB,
+          repromptDelay: null,
+          dismissedCount: 0,
+          skipReason: undefined,
+        },
+      );
+      await user.press(screen.getByText(/allow notifications/i));
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "allow notifications",
+        page: "Drawer push notification opt-in",
+        source: "swap",
+        repromptDelay: null,
+        dismissedCount: 0,
+        variant: ABTestingVariants.variantB,
+      });
+    });
+
+    it("should wait for swap history to close when swap success continues to history", async () => {
+      const { user } = renderLegacySwapFlow(legacySwapSuccessParams);
+
+      await waitFor(() => expect(screen.getByTestId("swap-success-title")).toBeVisible());
+      expect(track).not.toHaveBeenCalledWith(
+        "attempt_to_trigger_push_notification_drawer_after_action",
+      );
+
+      await user.press(screen.getByText(/go to history/i));
+      await waitFor(() => {
+        expect(screen.getByText(/your previous swaps will appear here/i)).toBeVisible();
+      });
+      expect(track).not.toHaveBeenCalledWith(
+        "attempt_to_trigger_push_notification_drawer_after_action",
+      );
+
+      await user.press(screen.getAllByTestId("navigation-header-back-button")[0]);
+      await act(async () => {
+        await jest.runOnlyPendingTimersAsync();
+      });
+
+      expect(track).toHaveBeenCalledWith(
+        "attempt_to_trigger_push_notification_drawer_after_action",
+        {
+          action: "swap",
+          shouldPrompt: true,
+          variant: ABTestingVariants.variantB,
+          repromptDelay: null,
+          dismissedCount: 0,
+          skipReason: undefined,
+        },
+      );
+
+      await user.press(screen.getByText(/maybe later/i));
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "maybe later",
+        page: "Drawer push notification opt-in",
+        source: "swap",
+        repromptDelay: null,
+        dismissedCount: 0,
+        variant: ABTestingVariants.variantB,
+      });
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/Swap/SubScreens/PendingOperation.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/SubScreens/PendingOperation.tsx
@@ -13,7 +13,6 @@ import IconClock from "~/icons/Clock";
 import { rgba } from "../../../colors";
 import { useSyncAllAccounts } from "../LiveApp/hooks/useSyncAllAccounts";
 import { PendingOperationParamList } from "../types";
-import { useNotifications } from "LLM/features/NotificationsPrompt";
 import { SWAP_VERSION } from "../utils";
 import { NavigationHeaderCloseButton } from "~/components/NavigationHeaderCloseButton";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
@@ -24,7 +23,6 @@ export function PendingOperation({ route, navigation }: PendingOperationParamLis
   const { shouldDisplayWallet40MainNav } = useWalletFeaturesConfig("mobile");
   const { swapId, provider, toCurrency, fromCurrency } = route.params.swapOperation;
   const { isEmbeddedSwap, sponsored } = route.params;
-  const { tryTriggerPushNotificationDrawerAfterAction } = useNotifications();
   const syncAccounts = useSyncAllAccounts();
   const supportsSwapTabRoute = hasSwapTabRoute(navigation.getState());
 
@@ -49,7 +47,6 @@ export function PendingOperation({ route, navigation }: PendingOperationParamLis
 
   useEffect(() => {
     syncAccounts();
-    tryTriggerPushNotificationDrawerAfterAction("swap");
     // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/apps/ledger-live-mobile/src/screens/Swap/navigation/navigateBackToSwapTab.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/navigation/navigateBackToSwapTab.ts
@@ -90,3 +90,17 @@ export function navigateBackToSwapTab({
 
   parentNavigation.dispatch(getResetToSwapTabAction());
 }
+
+export function isGoingToSwapHistory(payload: unknown) {
+  if (!payload || typeof payload !== "object" || !("routes" in payload)) {
+    return false;
+  }
+
+  const routes = payload.routes;
+
+  if (!Array.isArray(routes)) {
+    return false;
+  }
+
+  return routes.some(route => route?.name === ScreenName.SwapHistory);
+}

--- a/apps/ledger-live-mobile/src/screens/__integrations__/pushNotificationOptIn.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/__integrations__/pushNotificationOptIn.integration.test.tsx
@@ -14,7 +14,6 @@ jest.mock("LLM/features/NotificationsPrompt/hooks/useNotifications", () => ({
   }),
 }));
 
-import { PendingOperation as SwapPendingOperation } from "~/screens/Swap/SubScreens/PendingOperation";
 import CosmosValidationSuccess from "~/families/cosmos/DelegationFlow/04-ValidationSuccess";
 
 const Stack = createNativeStackNavigator();
@@ -35,32 +34,6 @@ const INITIAL_STATE = {
 describe("Push Notification Opt-In on Success Screens", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-  });
-
-  it("should trigger notification drawer with 'swap' after SWAP success", async () => {
-    const swapParams = {
-      swapOperation: {
-        swapId: "swap-123",
-        provider: "changelly",
-        toCurrency: { id: "ethereum", name: "Ethereum" },
-        fromCurrency: { id: "bitcoin", name: "Bitcoin" },
-      },
-    };
-
-    render(
-      <Stack.Navigator>
-        <Stack.Screen name={ScreenName.SwapPendingOperation}>
-          {props => <SwapPendingOperation {...props} route={{ params: swapParams } as never} />}
-        </Stack.Screen>
-      </Stack.Navigator>,
-      INITIAL_STATE,
-    );
-
-    await waitFor(() => {
-      expect(screen.getByTestId("swap-success-title")).toBeOnTheScreen();
-    });
-
-    expect(mockTryTriggerPushNotificationDrawerAfterAction).toHaveBeenCalledWith("swap");
   });
 
   it("should trigger notification drawer with 'stake' after STAKE success (Cosmos)", async () => {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** `pnpm mobile typecheck` and `pnpm mobile test:jest "src/mvvm/features/NotificationsPrompt/NotificationsPromptSwapFlow.test.tsx"` pass.
- [x] **Impact of the changes:**
  - Mobile swap confirmation and success-screen exit behavior
  - Notification opt-in prompt timing after swap completion
  - Swap after-action prompt analytics
  - Wallet V4 and legacy swap navigation paths

### 📝 Description

The swap notification opt-in prompt should only become eligible after the user actually leaves the swap completion flow. Previously, the prompt could be evaluated while the user was still on swap confirmation/success screens, which made the timing depend on screen mount behavior instead of the user exiting the flow.

This PR moves the swap completion signal into the navigation layer. `SwapNavigator` and `SwapSubScreensNavigator` now trigger `notifyFlowCompleted("swap")` from `beforeRemove` handling, while `PendingOperation` no longer tries to open the notification prompt on mount. The swap return helper was also adjusted so the prompt is evaluated after navigating back to the swap tab for both Wallet V4 and legacy paths.

Focused coverage was added in `NotificationsPromptSwapFlow.test.tsx` to verify the notification drawer opens only after closing swap success, including the case where the user continues from swap success to swap history before leaving the flow.

<table>
<tr>
 <td><video src="https://github.com/user-attachments/assets/4a1723bc-3cac-4fa6-8319-0529d550ea98"/>
 <td><video src="https://github.com/user-attachments/assets/aa5120d1-f5e3-4632-9bed-5246e02844d8"/>
</table>

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29485](https://ledgerhq.atlassian.net/browse/LIVE-29485)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29485]: https://ledgerhq.atlassian.net/browse/LIVE-29485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ