### PR TITLE
[LWDM] fix(locale): adjust mev protection copy

### DIFF
--- a/.changeset/early-forks-prepare.md
+++ b/.changeset/early-forks-prepare.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"ledger-live-desktop": minor
+---
+
+Fix MEV Protection settings copy to remove Ethereum-only wording.

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -4721,7 +4721,7 @@
       "walletSyncDesc": "Sync your Ledger Wallet crypto accounts across different phones and computers.",
       "walletSyncDescription": "Keep your portfolio up to date when switching computers or using a phone",
       "mevProtection": "MEV Protection",
-      "mevProtectionDesc": "Enable MEV Protection for more reliable transactions on Ethereum.",
+      "mevProtectionDesc": "Enable MEV Protection for more reliable transactions.",
       "mevProtectionLearnMore": "Privacy notice"
     },
     "developer": {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -3364,7 +3364,7 @@
       "analytics": "App performance",
       "analyticsDesc": "Enable Ledger to collect app usage to enhance the experience",
       "mevProtection": "MEV Protection",
-      "mevProtectionDesc": "Enable MEV Protection for more reliable transactions on Ethereum.",
+      "mevProtectionDesc": "Enable MEV Protection for more reliable transactions.",
       "mevProtectionLearnMore": "Privacy notice",
       "personalizedRecommendations": "Personalized experience",
       "personalizedRecommendationsDesc": "Enable Ledger to collect app usage to provide personalized contents",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No automated tests were added because this PR only updates static locale copy._
- [x] **Impact of the changes:**
      - Desktop Settings > General > MEV Protection description
      - Mobile Settings > General > MEV Protection description
      - Consistency of wording across apps

### 📝 Description

The MEV Protection description currently mentions Ethereum specifically, which is too restrictive for the intended feature messaging.

This PR updates the English locale string in both Desktop and Mobile apps to remove the Ethereum-only wording and keep the text accurate and consistent. A changeset is included for `ledger-live-desktop` and `live-mobile`.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29934](https://ledgerhq.atlassian.net/browse/LIVE-29934)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29934]: https://ledgerhq.atlassian.net/browse/LIVE-29934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ