### PR TITLE
[LWDM] feat: add recordPickingStrategy to config and skip auto fee-record se…

### DIFF
--- a/.changeset/lazy-gorillas-dress.md
+++ b/.changeset/lazy-gorillas-dress.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-aleo": minor
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
+---
+
+Add Aleo record-picking strategy config and update send back-navigation behavior

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/__mocks__/config.mock.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/__mocks__/config.mock.ts
@@ -14,4 +14,5 @@ export const mockAleoCoinConfig: AleoCoinConfig = {
   feeSafetyMultiplier: 1,
   isFeeSponsored: true,
   useEncryptedProve: false,
+  recordPickingStrategy: "manual",
 };

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/createSendSteps.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/createSendSteps.test.tsx
@@ -1,10 +1,20 @@
 import { isPrivateTransaction } from "@ledgerhq/live-common/families/aleo/utils";
+import type { AleoCoinConfig } from "@ledgerhq/live-common/families/aleo/types";
 import createSendSteps from "./createSendSteps";
+import { getAleoCurrencyConfig } from "./shared/utils";
+import { mockAleoCoinConfig } from "./__mocks__/config.mock";
+import { ALEO_ACCOUNT_1 } from "./__mocks__/account.mock";
 import type { StepProps } from "~/renderer/modals/Send/types";
 
 jest.mock("@ledgerhq/live-common/families/aleo/utils", () => ({
   isPrivateTransaction: jest.fn(),
 }));
+
+jest.mock("./shared/utils", () => ({
+  getAleoCurrencyConfig: jest.fn(),
+}));
+
+const mockGetAleoCurrencyConfig = jest.mocked(getAleoCurrencyConfig);
 
 jest.mock("~/renderer/modals/Send/steps/StepAmount", () => ({
   __esModule: true,
@@ -47,6 +57,11 @@ jest.mock("./modals/send/steps/StepRecordPickerFooter", () => ({
 describe("createSendSteps", () => {
   const steps = createSendSteps();
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // default: config returns undefined → isManualStrategy = true (manual behaviour)
+    mockGetAleoCurrencyConfig.mockReturnValue(undefined);
+  });
   it("should return all expected step ids in correct order", () => {
     const ids = steps.map(s => s.id);
 
@@ -149,5 +164,42 @@ describe("createSendSteps", () => {
     const publicTransaction = { family: "aleo", mode: "transfer_public" };
     const result = updater(publicTransaction);
     expect(result).toBe(publicTransaction);
+  });
+
+  it("should navigate to record-picker when going back from amount on a private tx with manual strategy", () => {
+    jest.mocked(isPrivateTransaction).mockReturnValue(true);
+    mockGetAleoCurrencyConfig.mockReturnValue(mockAleoCoinConfig);
+
+    const step = steps.find(s => s.id === "amount");
+    const transitionTo = jest.fn();
+    const stepProps = {
+      transitionTo,
+      updateTransaction: jest.fn(),
+      transaction: { family: "aleo" },
+      account: ALEO_ACCOUNT_1,
+      parentAccount: null,
+    } as unknown as StepProps;
+    step?.onBack?.(stepProps);
+
+    expect(transitionTo).toHaveBeenCalledWith("record-picker");
+  });
+
+  it("should navigate to recipient when going back from amount on a private tx with auto strategy", () => {
+    jest.mocked(isPrivateTransaction).mockReturnValue(true);
+    const autoConfig: AleoCoinConfig = { ...mockAleoCoinConfig, recordPickingStrategy: "auto" };
+    mockGetAleoCurrencyConfig.mockReturnValue(autoConfig);
+
+    const step = steps.find(s => s.id === "amount");
+    const transitionTo = jest.fn();
+    const stepProps = {
+      transitionTo,
+      updateTransaction: jest.fn(),
+      transaction: { family: "aleo" },
+      account: ALEO_ACCOUNT_1,
+      parentAccount: null,
+    } as unknown as StepProps;
+    step?.onBack?.(stepProps);
+
+    expect(transitionTo).toHaveBeenCalledWith("recipient");
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/createSendSteps.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/createSendSteps.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Trans } from "react-i18next";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { isPrivateTransaction } from "@ledgerhq/live-common/families/aleo/utils";
 import { StepAmountFooter as DefaultStepAmountFooter } from "~/renderer/modals/Send/steps/StepAmount";
 import DefaultStepSummary, {
@@ -15,6 +16,7 @@ import StepRecipientFooter from "./modals/send/steps/StepRecipientFooter";
 import StepMandatoryPrivateSync from "./modals/send/steps/StepMandatoryPrivateSync";
 import StepRecordPicker from "./modals/send/steps/StepRecordPicker";
 import StepRecordPickerFooter from "./modals/send/steps/StepRecordPickerFooter";
+import { getAleoCurrencyConfig } from "./shared/utils";
 import type { St } from "./modals/send/types";
 import type { AleoFamily } from "./types";
 
@@ -58,10 +60,17 @@ const createSendSteps: NonNullable<AleoFamily["createSendSteps"]> = () => {
       label: <Trans i18nKey="send.steps.amount.title" />,
       component: StepAmount,
       footer: DefaultStepAmountFooter,
-      onBack: ({ transitionTo, transaction }) => {
-        if (transaction?.family !== "aleo") return null;
-        const targetStep = isPrivateTransaction(transaction) ? "record-picker" : "recipient";
-        transitionTo(targetStep);
+      onBack: ({ transitionTo, transaction, account, parentAccount }) => {
+        if (transaction?.family !== "aleo") return;
+        if (!isPrivateTransaction(transaction)) {
+          transitionTo("recipient");
+          return;
+        }
+
+        const mainAccount = account ? getMainAccount(account, parentAccount ?? undefined) : null;
+        const config = mainAccount ? getAleoCurrencyConfig(mainAccount.currency) : undefined;
+        const isManualStrategy = !config || config.recordPickingStrategy === "manual";
+        transitionTo(isManualStrategy ? "record-picker" : "recipient");
       },
     },
     {

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepMandatoryPrivateSync.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepMandatoryPrivateSync.test.tsx
@@ -2,8 +2,10 @@ import React from "react";
 import BigNumber from "bignumber.js";
 import { Subject } from "rxjs";
 import { act, render, screen, waitFor } from "tests/testSetup";
-import type { AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
+import type { AleoAccount, AleoCoinConfig } from "@ledgerhq/live-common/families/aleo/types";
 import { ALEO_ACCOUNT_1 } from "../../../__mocks__/account.mock";
+import { mockAleoCoinConfig } from "../../../__mocks__/config.mock";
+import { getAleoCurrencyConfig } from "../../../shared/utils";
 import StepMandatoryPrivateSync from "./StepMandatoryPrivateSync";
 import { makeStepProps } from "../../../__mocks__/stepProps.mock";
 
@@ -18,7 +20,12 @@ jest.mock("~/renderer/actions/accounts", () => ({
     })),
 }));
 
+jest.mock("../../../shared/utils", () => ({
+  getAleoCurrencyConfig: jest.fn(),
+}));
+
 const { getAccountBridge } = jest.requireMock("@ledgerhq/live-common/bridge/impl");
+const mockGetAleoCurrencyConfig = jest.mocked(getAleoCurrencyConfig);
 
 describe("StepMandatoryPrivateSync", () => {
   let syncSubject: Subject<(acc: AleoAccount) => AleoAccount>;
@@ -29,6 +36,7 @@ describe("StepMandatoryPrivateSync", () => {
     syncSubject = new Subject();
     mockSync = jest.fn().mockReturnValue(syncSubject.asObservable());
     getAccountBridge.mockReturnValue({ sync: mockSync });
+    mockGetAleoCurrencyConfig.mockReturnValue(mockAleoCoinConfig);
   });
 
   afterEach(() => {
@@ -81,7 +89,7 @@ describe("StepMandatoryPrivateSync", () => {
     expect(mockSync).not.toHaveBeenCalled();
   });
 
-  describe("transition to record-picker when progress reaches 100%", () => {
+  describe("transition when progress reaches 100%", () => {
     const makeAleoAccountAt100 = (): AleoAccount => ({
       ...ALEO_ACCOUNT_1,
       aleoResources: {
@@ -93,7 +101,7 @@ describe("StepMandatoryPrivateSync", () => {
       },
     });
 
-    it("should call transitionTo('record-picker') after progress reaches 100", async () => {
+    it("should call transitionTo('record-picker') after progress reaches 100 with manual strategy", async () => {
       const props = makeStepProps();
       render(<StepMandatoryPrivateSync {...props} />);
 
@@ -102,6 +110,22 @@ describe("StepMandatoryPrivateSync", () => {
       });
 
       await waitFor(() => expect(props.transitionTo).toHaveBeenCalledWith("record-picker"), {
+        timeout: 1000,
+      });
+    });
+
+    it("should call transitionTo('amount') after progress reaches 100 with auto strategy", async () => {
+      const autoConfig: AleoCoinConfig = { ...mockAleoCoinConfig, recordPickingStrategy: "auto" };
+      mockGetAleoCurrencyConfig.mockReturnValue(autoConfig);
+
+      const props = makeStepProps();
+      render(<StepMandatoryPrivateSync {...props} />);
+
+      await act(async () => {
+        syncSubject.next(() => makeAleoAccountAt100());
+      });
+
+      await waitFor(() => expect(props.transitionTo).toHaveBeenCalledWith("amount"), {
         timeout: 1000,
       });
     });

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepMandatoryPrivateSync.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepMandatoryPrivateSync.tsx
@@ -1,12 +1,14 @@
 import React, { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
 import { ErrorBody } from "~/renderer/components/ErrorBody";
 import { Flex, IconsLegacy, InfiniteLoader } from "@ledgerhq/react-ui";
 import type { StepProps } from "~/renderer/modals/Send/types";
 import { useAleoPrivateSync } from "../../../hooks/useAleoPrivateSync";
+import { getAleoCurrencyConfig } from "../../../shared/utils";
 
 const TitleText = styled.p`
   font-size: 20px;
@@ -25,8 +27,18 @@ const ErrorIcon = ({ size }: { size?: number }) => (
   <IconsLegacy.WarningMedium size={size} color="error.c60" />
 );
 
-const StepMandatoryPrivateSync = ({ transitionTo, account, updateAccount }: StepProps) => {
+const StepMandatoryPrivateSync = ({
+  transitionTo,
+  account,
+  parentAccount,
+  updateAccount,
+}: StepProps) => {
   const { t } = useTranslation();
+  const mainAccount = account ? getMainAccount(account, parentAccount ?? undefined) : null;
+  const config = mainAccount ? getAleoCurrencyConfig(mainAccount.currency) : undefined;
+  const nextStep =
+    !config || config.recordPickingStrategy === "manual" ? "record-picker" : "amount";
+
   const {
     progress,
     isSyncing,
@@ -40,9 +52,9 @@ const StepMandatoryPrivateSync = ({ transitionTo, account, updateAccount }: Step
 
   useEffect(() => {
     if (progress < 100 || isSyncing) return;
-    const timer = setTimeout(() => transitionTo("record-picker"), 500);
+    const timer = setTimeout(() => transitionTo(nextStep), 500);
     return () => clearTimeout(timer);
-  }, [progress, isSyncing, transitionTo]);
+  }, [progress, isSyncing, transitionTo, nextStep]);
 
   if (privateSyncError) {
     return (

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepRecordPicker.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepRecordPicker.test.tsx
@@ -13,6 +13,7 @@ import type {
   AleoAccount,
   AleoUnspentRecord,
   AleoDecryptedRecordResponse,
+  AleoCoinConfig,
   TransactionPrivate,
   TransactionStatus,
 } from "@ledgerhq/live-common/families/aleo/types";
@@ -21,11 +22,18 @@ import { useDateFormatter } from "~/renderer/hooks/useDateFormatter";
 import i18n from "~/renderer/i18n/init";
 import type { StepProps } from "~/renderer/modals/Send/types";
 import StepRecordPicker from "./StepRecordPicker";
+import { getAleoCurrencyConfig } from "../../../shared/utils";
 import { ALEO_ACCOUNT_1 } from "../../../__mocks__/account.mock";
+import { mockAleoCoinConfig } from "../../../__mocks__/config.mock";
 
 jest.mock("~/renderer/hooks/useAccountUnit");
 jest.mock("~/renderer/hooks/useDateFormatter");
 jest.mock("@ledgerhq/live-common/currencies/index");
+jest.mock("../../../shared/utils", () => ({
+  getAleoCurrencyConfig: jest.fn(),
+}));
+
+const mockGetAleoCurrencyConfig = jest.mocked(getAleoCurrencyConfig);
 
 const mockUseDateFormatter = jest.mocked(useDateFormatter);
 
@@ -135,6 +143,8 @@ describe("StepRecordPicker", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // default: manual strategy — picker renders normally
+    mockGetAleoCurrencyConfig.mockReturnValue(mockAleoCoinConfig);
     mockUseAccountUnit.mockReturnValue({
       code: "ALEO",
       name: "Aleo",
@@ -617,5 +627,34 @@ describe("StepRecordPicker", () => {
 
     expect(screen.getByTestId("aleo-empty-records-alert")).toBeInTheDocument();
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("should render nothing when recordPickingStrategy is auto", () => {
+    const autoConfig: AleoCoinConfig = { ...mockAleoCoinConfig, recordPickingStrategy: "auto" };
+    mockGetAleoCurrencyConfig.mockReturnValue(autoConfig);
+
+    const { container } = render(
+      <StepRecordPicker
+        {...defaultProps}
+        account={mockAleoAccount}
+        transaction={privateTransaction}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("should render the record picker when recordPickingStrategy is manual", () => {
+    mockGetAleoCurrencyConfig.mockReturnValue(mockAleoCoinConfig);
+
+    render(
+      <StepRecordPicker
+        {...defaultProps}
+        account={mockAleoAccount}
+        transaction={privateTransaction}
+      />,
+    );
+
+    expect(screen.getAllByRole("button")).toHaveLength(2);
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepRecordPicker.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepRecordPicker.tsx
@@ -20,6 +20,7 @@ import { Flex } from "@ledgerhq/react-ui/index";
 import { dayFormat, hourFormat, useDateFormatter } from "~/renderer/hooks/useDateFormatter";
 import Alert from "~/renderer/components/Alert";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
+import { getAleoCurrencyConfig } from "../../../shared/utils";
 import { isAleoAccount } from "./utils";
 
 interface Props extends Pick<StepProps, "status" | "updateTransaction"> {
@@ -200,6 +201,9 @@ const AleoStepRecordPicker = ({ account, transaction, status, updateTransaction 
 
 const StepRecordPicker = ({ account, transaction, status, updateTransaction }: StepProps) => {
   if (transaction?.family !== "aleo" || !account || !isAleoAccount(account)) return null;
+
+  const config = getAleoCurrencyConfig(account.currency);
+  if (config?.recordPickingStrategy === "auto") return null;
 
   return (
     <AleoStepRecordPicker

--- a/libs/coin-modules/coin-aleo/src/__tests__/fixtures/config.fixture.ts
+++ b/libs/coin-modules/coin-aleo/src/__tests__/fixtures/config.fixture.ts
@@ -17,6 +17,7 @@ export const getMockedConfig = (networkType: "mainnet" | "testnet"): AleoCoinCon
     feeSafetyMultiplier: 1,
     isFeeSponsored: true,
     useEncryptedProve: false,
+    recordPickingStrategy: "manual",
     status: { type: "active" },
   };
 };

--- a/libs/coin-modules/coin-aleo/src/logic/craftTransaction.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/craftTransaction.integ.test.ts
@@ -45,6 +45,7 @@ describe("craftTransaction", () => {
       feeSafetyMultiplier: 1,
       isFeeSponsored: true,
       useEncryptedProve: false,
+      recordPickingStrategy: "manual",
     }));
   });
 

--- a/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.integ.test.ts
@@ -29,6 +29,7 @@ describe("getPrivateBalance", () => {
       feeSafetyMultiplier: 1,
       isFeeSponsored: true,
       useEncryptedProve: false,
+      recordPickingStrategy: "manual",
     }));
   });
 

--- a/libs/coin-modules/coin-aleo/src/types/config.ts
+++ b/libs/coin-modules/coin-aleo/src/types/config.ts
@@ -1,5 +1,5 @@
 import type { CurrencyConfig } from "@ledgerhq/coin-module-framework/config";
-import type { TransactionType } from "./logic";
+import type { RecordPickingStrategy, TransactionType } from "./logic";
 
 export type AleoConfig = {
   networkType: "mainnet" | "testnet";
@@ -11,6 +11,7 @@ export type AleoConfig = {
   feeSafetyMultiplier: number;
   isFeeSponsored: boolean;
   useEncryptedProve: boolean;
+  recordPickingStrategy: RecordPickingStrategy;
 };
 
 export type AleoCoinConfig = CurrencyConfig & AleoConfig;

--- a/libs/coin-modules/coin-aleo/src/types/logic.ts
+++ b/libs/coin-modules/coin-aleo/src/types/logic.ts
@@ -30,6 +30,8 @@ export interface ProvableApi {
   scannerStatus?: AleoRecordScannerStatusResponse;
 }
 
+export type RecordPickingStrategy = "manual" | "auto";
+
 export type TransactionType = (typeof TRANSACTION_TYPE)[keyof typeof TRANSACTION_TYPE];
 
 export type AleoTransactionIntentData =

--- a/libs/ledger-live-common/src/families/aleo/config.ts
+++ b/libs/ledger-live-common/src/families/aleo/config.ts
@@ -1,5 +1,5 @@
 import { TRANSACTION_TYPE } from "@ledgerhq/coin-aleo/constants";
-import type { TransactionType } from "@ledgerhq/coin-aleo/types";
+import type { RecordPickingStrategy, TransactionType } from "@ledgerhq/coin-aleo/types";
 import type { ConfigInfo } from "@ledgerhq/live-config/LiveConfig";
 import { getEnv } from "@ledgerhq/live-env";
 
@@ -28,6 +28,14 @@ const IS_FEE_SPONSORED = true;
  */
 const USE_ENCRYPTED_PROVE = true;
 
+/**
+ * Controls how private transaction records are selected.
+ * - "manual": user picks records explicitly via the record picker UI step.
+ * - "auto": records are selected automatically (manual picker step is skipped).
+ * Default is "manual" to preserve existing behaviour.
+ */
+const RECORD_PICKING_STRATEGY: RecordPickingStrategy = "manual";
+
 export const aleoConfig: Record<string, ConfigInfo> = {
   config_currency_aleo: {
     type: "object",
@@ -44,6 +52,7 @@ export const aleoConfig: Record<string, ConfigInfo> = {
       feeSafetyMultiplier: DEFAULT_FEE_SAFETY_MULTIPLIER,
       isFeeSponsored: IS_FEE_SPONSORED,
       useEncryptedProve: USE_ENCRYPTED_PROVE,
+      recordPickingStrategy: RECORD_PICKING_STRATEGY,
     },
   },
   config_currency_aleo_testnet: {
@@ -61,6 +70,7 @@ export const aleoConfig: Record<string, ConfigInfo> = {
       feeSafetyMultiplier: DEFAULT_FEE_SAFETY_MULTIPLIER,
       isFeeSponsored: IS_FEE_SPONSORED,
       useEncryptedProve: USE_ENCRYPTED_PROVE,
+      recordPickingStrategy: RECORD_PICKING_STRATEGY,
     },
   },
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Add Aleo record-picking strategy config and update send back-navigation behavior.

### 📝 Description

This PR adds Aleo record-picking strategy config and update send back-navigation behavior.

### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-29566

Changes also cover [[ALEO][LWD] Smart contract management :: hide record picking step from UI based on config](https://ledgerhq.atlassian.net/browse/LIVE-29573)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
