### PR TITLE
[LWDM] feat(desktop): my wallet user avatar CDN and contextual sizes

### DIFF
--- a/.changeset/bright-balloons-rule.md
+++ b/.changeset/bright-balloons-rule.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add My Wallet user avatar CDN image, optional Avatar size, and context-specific sizes (TopBar vs menu)

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ContextMenuTrigger.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ContextMenuTrigger.tsx
@@ -14,14 +14,11 @@ export function ContextMenuTrigger({ popoverOpen }: ContextMenuTriggerProps) {
   return (
     <PopoverTrigger
       render={
-        <button
-          aria-label={label}
-          className="cursor-pointer items-center justify-center rounded-full hover:bg-muted-hover"
-        >
+        <button aria-label={label} className="cursor-pointer items-center justify-center">
           <Tooltip>
             <TooltipTrigger asChild>
               <span className="inline-flex">
-                <UserAvatar showNotification />
+                <UserAvatar showNotification size="sm" />
               </span>
             </TooltipTrigger>
             {!popoverOpen && <TooltipContent side="bottom">{label}</TooltipContent>}

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/TopBar/TopBarView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/TopBar/TopBarView.tsx
@@ -6,7 +6,7 @@ import { UserAvatar } from "../UserAvatar";
 const TopBarView = ({ title, settingsAction, notificationAction }: MyWalletTopBarViewProps) => (
   <div className="flex justify-between items-center">
     <div className="flex items-center gap-12">
-      <UserAvatar showNotification={false} />
+      <UserAvatar showNotification={false} size="md" />
       <p className="body-1-semi-bold text-base">{title}</p>
     </div>
     <div className="flex gap-16">

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/UserAvatar/UserAvatarView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/UserAvatar/UserAvatarView.tsx
@@ -1,9 +1,14 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { Avatar } from "@ledgerhq/lumen-ui-react";
+import { MY_WALLET_AVATAR_USER_URL } from "./useUserAvatarViewModel";
 import { UserAvatarViewProps } from "./types";
 
-export function UserAvatarView({ showNotification, unseenCount }: UserAvatarViewProps) {
+export function UserAvatarView({
+  showNotification,
+  unseenCount,
+  size = "sm",
+}: UserAvatarViewProps) {
   const { t } = useTranslation();
 
   const ariaLabel =
@@ -13,10 +18,10 @@ export function UserAvatarView({ showNotification, unseenCount }: UserAvatarView
 
   return (
     <Avatar
-      size="sm"
+      size={size}
+      src={MY_WALLET_AVATAR_USER_URL}
       aria-label={ariaLabel}
       data-testid="my-wallet-avatar"
-      className="text-black dark:text-white"
       showNotification={showNotification}
     />
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/UserAvatar/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/UserAvatar/types.ts
@@ -1,6 +1,8 @@
+import { AvatarProps } from "@ledgerhq/lumen-ui-react";
 export type UserAvatarViewProps = {
   showNotification: boolean;
   unseenCount: number;
+  size?: AvatarProps["size"];
 };
 
 export type UserAvatarProps = Partial<UserAvatarViewProps>;

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/UserAvatar/useUserAvatarViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/UserAvatar/useUserAvatarViewModel.ts
@@ -1,9 +1,13 @@
+import { getEnv } from "@ledgerhq/live-env";
 import { useNotificationIndicator } from "LLD/components/TopBar/hooks/useNotificationIndicator";
 import type { UserAvatarProps, UserAvatarViewProps } from "./types";
+
+export const MY_WALLET_AVATAR_USER_URL = `${getEnv("LW_ICONS_AVATARS_CDN_BASE_URL")}/black/user.png`;
 
 export function useUserAvatarViewModel({
   showNotification,
   unseenCount,
+  size,
 }: UserAvatarProps): UserAvatarViewProps {
   const { totalNotifCount } = useNotificationIndicator();
 
@@ -13,5 +17,6 @@ export function useUserAvatarViewModel({
   return {
     showNotification: resolvedShow,
     unseenCount: resolvedShow ? resolvedCount : 0,
+    size,
   };
 }

--- a/libs/env/src/env.ts
+++ b/libs/env/src/env.ts
@@ -1028,6 +1028,11 @@ const envDefinitions = {
     parser: boolParser,
     desc: "Enable logs for drawers",
   },
+  LW_ICONS_AVATARS_CDN_BASE_URL: {
+    def: "https://lw-icons.ledger.com/icons/cdn/Avatars/v1/64x64",
+    parser: stringParser,
+    desc: "Base URL for Ledger Wallet icons CDN",
+  },
   SANCTIONED_ADDRESSES_URL: {
     def: "https://compliance.ledger.com/all_sanctioned_addresses_without_ticker.json",
     parser: stringParser,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No new or updated tests in this PR._
- [x] **Impact of the changes:**
      - My Wallet **TopBar** avatar (medium size)
      - **Account / context menu** trigger avatar (small size)
      - Avatar **image asset** from CDN and **light/dark** appearance where applicable

### 📝 Description

**Problem:** My Wallet user avatars needed a consistent asset from the Ledger CDN and different **Lumen Avatar** sizes depending on placement (top bar vs. menu trigger).

**Solution:**
- Introduce **MY_WALLET_AVATAR_USER_URL** (CDN) and optional **`size`** on `UserAvatar` (`sm` \| `md` \| `lg`), aligned with `@ledgerhq/lumen-ui-react` `Avatar`.
- Set **TopBar** to **`md`** and **ContextMenuTrigger** to **`sm`**.
- Minor trigger styling tweaks (removed redundant hover/rounded classes where superseded).

https://github.com/user-attachments/assets/2120555e-6130-41dc-b863-c73972cdc5e5



### ❓ Context

- **JIRA or GitHub link**: [LIVE-30015](https://ledgerhq.atlassian.net/browse/LIVE-30015)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30015]: https://ledgerhq.atlassian.net/browse/LIVE-30015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ