### PR TITLE
[LWD] refactor(desktop): migrate @ledgerhq/crypto-icons to v2

### DIFF
--- a/.changeset/wild-pears-explain.md
+++ b/.changeset/wild-pears-explain.md
@@ -1,0 +1,16 @@
+---
+"ledger-live-desktop": minor
+---
+
+Migrate `@ledgerhq/crypto-icons` to v2 (desktop only).
+
+Bumps `@ledgerhq/crypto-icons` from `1.4.0` to `2.0.1` for `ledger-live-desktop`. The catalog version (`1.4.0`) is preserved for mobile, web-tools and the UI packages, which can migrate later.
+
+Adapts every `CryptoIcon` and `SquaredCryptoIcon` callsite to the v2 API:
+
+- `size` is now numeric (`12 | 16 | 20 | 24 | 32 | 40 | 48 | 56 | 64`) instead of pixel strings.
+- `overridesRadius` is replaced by `shape="square" | "circle"`. The `SquaredCryptoIcon` wrapper now sets `shape="square"` explicitly; everywhere else relies on the new default `shape="circle"`.
+- `ticker` is now required — guarded the only optional callsite (`AccountListItem`).
+- Local `getValidCryptoIconSize` re-export now returns numbers (`getValidCryptoIconSizeNative`) to match the new size type.
+
+No visual or behavioral change is expected: icons rendered as circles stay circles, squared icons stay squared via the dedicated wrapper.

--- a/apps/ledger-live-desktop/jest.config.js
+++ b/apps/ledger-live-desktop/jest.config.js
@@ -57,6 +57,8 @@ const moduleNameMapper = {
 const transformIncludePatterns = [
   "ky",
   "@ledgerhq\\+lumen-ui-react",
+  "@ledgerhq\\+lumen-design-core",
+  "@ledgerhq\\+crypto-icons",
   "@mysten\\+",
   "@scure\\+",
   "@noble\\+",

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -72,7 +72,7 @@
     "@ledgerhq/zcash-shielded": "workspace:^",
     "@ledgerhq/zcash-utils": "catalog:",
     "@ledgerhq/coin-module-framework": "catalog:",
-    "@ledgerhq/crypto-icons": "catalog:",
+    "@ledgerhq/crypto-icons": "2.0.1",
     "@ledgerhq/cryptoassets": "workspace:^",
     "@ledgerhq/devices": "workspace:*",
     "@ledgerhq/domain-service": "workspace:^",

--- a/apps/ledger-live-desktop/src/mvvm/components/SquaredCryptoIcon/SquaredCryptoIcon.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/SquaredCryptoIcon/SquaredCryptoIcon.test.tsx
@@ -21,56 +21,47 @@ describe("SquaredCryptoIcon", () => {
     ticker: "ETH",
   };
 
-  it("should render CryptoIcon with correct radius for each size", () => {
-    const sizeToRadiusMap: Record<string, string> = {
-      "16px": "4px",
-      "20px": "5px",
-      "24px": "6px",
-      "32px": "8px",
-      "40px": "10px",
-      "48px": "12px",
-      "56px": "14px",
-    };
-
-    Object.entries(sizeToRadiusMap).forEach(([size, expectedRadius]) => {
+  it.each<CryptoIconSize>([16, 20, 24, 32, 40, 48, 56])(
+    "should render CryptoIcon with shape='square' for size %s",
+    size => {
       mockedCryptoIcon.mockClear();
 
-      render(<SquaredCryptoIcon {...defaultProps} size={size as CryptoIconSize} />);
+      render(<SquaredCryptoIcon {...defaultProps} size={size} />);
 
       expect(mockedCryptoIcon).toHaveBeenCalledWith(
         expect.objectContaining({
           size,
-          overridesRadius: expectedRadius,
+          shape: "square",
           ledgerId: "ethereum",
           ticker: "ETH",
         }),
         undefined,
       );
-    });
-  });
+    },
+  );
 
-  it("should use 48px as default size with 12px radius", () => {
+  it("should use 48 as default size with square shape", () => {
     render(<SquaredCryptoIcon {...defaultProps} />);
 
     expect(mockedCryptoIcon).toHaveBeenCalledWith(
       expect.objectContaining({
-        size: "48px",
-        overridesRadius: "12px",
+        size: 48,
+        shape: "square",
       }),
       undefined,
     );
   });
 
   it("should forward additional props to CryptoIcon", () => {
-    render(<SquaredCryptoIcon {...defaultProps} size="32px" network="polygon" />);
+    render(<SquaredCryptoIcon {...defaultProps} size={32} network="polygon" />);
 
     expect(mockedCryptoIcon).toHaveBeenCalledWith(
       expect.objectContaining({
         ledgerId: "ethereum",
         ticker: "ETH",
-        size: "32px",
+        size: 32,
         network: "polygon",
-        overridesRadius: "8px",
+        shape: "square",
       }),
       undefined,
     );

--- a/apps/ledger-live-desktop/src/mvvm/components/SquaredCryptoIcon/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/SquaredCryptoIcon/index.tsx
@@ -1,22 +1,10 @@
 import React from "react";
-import { CryptoIcon } from "@ledgerhq/crypto-icons";
+import { CryptoIcon, type CryptoIconProps } from "@ledgerhq/crypto-icons";
 
-export type CryptoIconSize = "16px" | "20px" | "24px" | "32px" | "40px" | "48px" | "56px";
+export type CryptoIconSize = NonNullable<CryptoIconProps["size"]>;
 
-const SIZE_TO_RADIUS: Record<CryptoIconSize, string> = {
-  "16px": "4px",
-  "20px": "5px",
-  "24px": "6px",
-  "32px": "8px",
-  "40px": "10px",
-  "48px": "12px",
-  "56px": "14px",
-};
+type SquaredCryptoIconProps = Omit<CryptoIconProps, "shape">;
 
-type SquaredCryptoIconProps = Omit<Parameters<typeof CryptoIcon>[0], "overridesRadius">;
-
-export const SquaredCryptoIcon = ({ size = "48px", ...props }: SquaredCryptoIconProps) => {
-  const radius = SIZE_TO_RADIUS[size];
-
-  return <CryptoIcon size={size} overridesRadius={radius} {...props} />;
+export const SquaredCryptoIcon = ({ size = 48, ...props }: SquaredCryptoIconProps) => {
+  return <CryptoIcon size={size} shape="square" {...props} />;
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useTable.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useTable.tsx
@@ -52,22 +52,22 @@ export const useTable = (assets: AssetTableItem[], options?: UseAssetTableOption
           );
           return (
             <div data-testid={`w40-asset-row-${assetTestId}`}>
-            <TableCellContent
-              leadingContent={
-                row.original.isPlaceholder || shouldDisplayAggregatedAssets ? (
-                  <CryptoIcon
-                    ledgerId={row.original.currency.id}
-                    ticker={row.original.currency.ticker}
-                    size={getValidCryptoIconSize(32)}
-                  />
-                ) : (
-                  <CryptoCurrencyIcon currency={row.original.currency} size={32} />
-                )
-              }
-              title={row.original.currency.name}
-              description={row.original.currency.ticker}
-            />
-          </div>
+              <TableCellContent
+                leadingContent={
+                  row.original.isPlaceholder || shouldDisplayAggregatedAssets ? (
+                    <CryptoIcon
+                      ledgerId={row.original.currency.id}
+                      ticker={row.original.currency.ticker}
+                      size={getValidCryptoIconSize(32)}
+                    />
+                  ) : (
+                    <CryptoCurrencyIcon currency={row.original.currency} size={32} />
+                  )
+                }
+                title={row.original.currency.name}
+                description={row.original.currency.ticker}
+              />
+            </div>
           );
         },
       },

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Banner/components/IconsList.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Banner/components/IconsList.tsx
@@ -3,7 +3,7 @@ import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets
 import { SquaredCryptoIcon } from "LLD/components/SquaredCryptoIcon";
 import useTheme from "~/renderer/hooks/useTheme";
 
-const ICON_SIZE = "16px";
+const ICON_SIZE = 16;
 const LEFT_STEP_PX = 14.5;
 
 export const IconsList = memo(function IconsList({

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AggregatedAccountNameCell.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AggregatedAccountNameCell.tsx
@@ -18,7 +18,7 @@ export function AggregatedAccountNameCell({
         <SquaredCryptoIcon
           ledgerId={account.currency.id}
           ticker={account.currency.ticker}
-          size="32px"
+          size={32}
         />
       }
       title={displayName}

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryExportDialog/components/ExportAccountListItem.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryExportDialog/components/ExportAccountListItem.tsx
@@ -24,7 +24,7 @@ export function ExportAccountListItem({ account, checked, onToggle }: ExportAcco
     <ListItem onClick={onToggle}>
       <ListItemLeading>
         <Checkbox checked={checked} />
-        <CryptoIcon ledgerId={account.currency.id} ticker={account.currency.ticker} size="48px" />
+        <CryptoIcon ledgerId={account.currency.id} ticker={account.currency.ticker} size={48} />
         <ListItemContent>
           <ListItemTitle>{account.name}</ListItemTitle>
         </ListItemContent>

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/OperationRow.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/OperationRow.tsx
@@ -70,7 +70,7 @@ function OperationRow({ row, onRowClick }: OperationRowProps) {
                 <SquaredCryptoIcon
                   ledgerId={iconCurrency.id}
                   ticker={iconCurrency.ticker}
-                  size="20px"
+                  size={20}
                   network={iconNetwork}
                 />
               )}

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/RowItem/RowItemView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/RowItem/RowItemView.tsx
@@ -44,7 +44,7 @@ export const RowItemView = memo<RowItemViewProps>(function RowItemView({
         <TableCell>
           <CryptoCurrencyIconWrapper>
             {currency.ledgerIds && currency.ledgerIds.length > 0 && currency.ticker ? (
-              <CryptoIcon ledgerId={currency.ledgerIds[0]} ticker={currency.ticker} size="32px" />
+              <CryptoIcon ledgerId={currency.ledgerIds[0]} ticker={currency.ticker} size={32} />
             ) : (
               <img width="32px" height="32px" src={currency.image} alt={"currency logo"} />
             )}

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/AssetIcon.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/AssetIcon.tsx
@@ -10,7 +10,7 @@ type AssetIconProps = {
 
 export const AssetIcon = ({ ledgerId, ticker, image, capitalizedTicker }: AssetIconProps) => {
   if (ledgerId && ticker) {
-    return <CryptoIcon ledgerId={ledgerId} ticker={ticker} size="40px" />;
+    return <CryptoIcon ledgerId={ledgerId} ticker={ticker} size={40} />;
   }
 
   return (

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/AccountSelector/components/AccountListItem/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/AccountSelector/components/AccountListItem/index.tsx
@@ -53,7 +53,9 @@ export const AccountListItem = ({ onClick, account }: AccountListItemProps) => {
           <ListItemTitle>{name}</ListItemTitle>
           <ListItemDescription className="flex gap-6">
             {formattedAddress}
-            <SquaredCryptoIcon size="16px" ledgerId={networkId} ticker={ticker} />
+            {ticker && networkId && (
+              <SquaredCryptoIcon size={16} ledgerId={networkId} ticker={ticker} />
+            )}
           </ListItemDescription>
         </ListItemContent>
       </ListItemLeading>

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/AssetSelector/components/AssetListItem/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/AssetSelector/components/AssetListItem/index.tsx
@@ -72,7 +72,7 @@ export const AssetListItem = ({
       data-testid={`asset-item-ticker-${ticker.toLowerCase()}`}
     >
       <ListItemLeading>
-        <CryptoIcon size="48px" ledgerId={id} ticker={ticker} />
+        <CryptoIcon size={48} ledgerId={id} ticker={ticker} />
         <ListItemContent>
           <ListItemTitle>{name}</ListItemTitle>
           <ListItemDescription className="flex gap-6">

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/NetworkSelector/components/NetworkListItem/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/NetworkSelector/components/NetworkListItem/index.tsx
@@ -36,7 +36,7 @@ export const NetworkListItem = ({
       className="-outline-offset-2"
     >
       <ListItemLeading>
-        <SquaredCryptoIcon size="48px" ledgerId={currency.id} ticker={currency.ticker} />
+        <SquaredCryptoIcon size={48} ledgerId={currency.id} ticker={currency.ticker} />
         <ListItemContent>
           <ListItemTitle>{currency.name}</ListItemTitle>
           <ListItemDescription className="flex gap-6">

--- a/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/component/ProviderItem.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/component/ProviderItem.tsx
@@ -43,10 +43,10 @@ function StakingIcon({ icon }: { icon?: string }) {
     if (currency) {
       const ledgerId = currency.id;
       const ticker = currency.ticker;
-      return <CryptoIcon ledgerId={ledgerId} ticker={ticker} size="56px" />;
+      return <CryptoIcon ledgerId={ledgerId} ticker={ticker} size={56} />;
     }
     // Fallback: if currency not found, just use the ticker (library will handle fallback)
-    return <CryptoIcon ledgerId={iconName.toLowerCase()} ticker={iconName} size="56px" />;
+    return <CryptoIcon ledgerId={iconName.toLowerCase()} ticker={iconName} size={56} />;
   }
   if (iconType === "provider") {
     return (

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/AppsList/AppIcon.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/AppsList/AppIcon.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from "react";
 import styled from "styled-components";
 import manager from "@ledgerhq/live-common/manager/index";
 import { findCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
-import { getValidCryptoIconSize } from "@ledgerhq/live-common/helpers/cryptoIconSize";
+import { getValidCryptoIconSize } from "~/renderer/utils/cryptoIconSize";
 import { App } from "@ledgerhq/types-live";
 import Image from "~/renderer/components/Image";
 import ManagerAppIconPlaceholder from "~/renderer/icons/ManagerAppIcon";

--- a/apps/ledger-live-desktop/src/renderer/screens/market/MarketCoin/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/market/MarketCoin/index.tsx
@@ -94,7 +94,7 @@ export default function MarketCoinScreen() {
                 <InfiniteLoader />
               </Flex>
             ) : ledgerIds && ledgerIds.length > 0 && ticker ? (
-              <CryptoIcon ledgerId={ledgerIds[0]} ticker={ticker} size="56px" />
+              <CryptoIcon ledgerId={ledgerIds[0]} ticker={ticker} size={56} />
             ) : (
               <img width="56px" height="56px" src={currency?.image} alt={"currency logo"} />
             )}

--- a/apps/ledger-live-desktop/src/renderer/screens/market/MarketList/components/MarketRowItem/MarketRowItemView.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/market/MarketList/components/MarketRowItem/MarketRowItemView.tsx
@@ -55,7 +55,7 @@ export const MarketRowItemView = memo<MarketRowItemViewProps>(function MarketRow
           <TableCell>
             <CryptoCurrencyIconWrapper>
               {currency.ledgerIds && currency.ledgerIds.length > 0 ? (
-                <CryptoIcon ledgerId={currency.ledgerIds[0]} ticker={currency.ticker} size="32px" />
+                <CryptoIcon ledgerId={currency.ledgerIds[0]} ticker={currency.ticker} size={32} />
               ) : (
                 <img width="32px" height="32px" src={currency.image} alt={"currency logo"} />
               )}

--- a/apps/ledger-live-desktop/src/renderer/styles/shouldForwardProp.ts
+++ b/apps/ledger-live-desktop/src/renderer/styles/shouldForwardProp.ts
@@ -188,7 +188,6 @@ const INVALID_DOM_PROPS = new Set([
   "short",
   "separator",
   "focused",
-  "overridesRadius",
   "lighterPrimary",
   "loading",
   "currentRef",

--- a/apps/ledger-live-desktop/src/renderer/utils/cryptoIconSize.ts
+++ b/apps/ledger-live-desktop/src/renderer/utils/cryptoIconSize.ts
@@ -1,2 +1,2 @@
-// Re-export from shared location
-export { getValidCryptoIconSize } from "@ledgerhq/live-common/helpers/cryptoIconSize";
+// Numeric sizes are required by @ledgerhq/crypto-icons v2 (Lumen MediaImage).
+export { getValidCryptoIconSizeNative as getValidCryptoIconSize } from "@ledgerhq/live-common/helpers/cryptoIconSize";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -919,8 +919,8 @@ importers:
         specifier: 'catalog:'
         version: 2.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/crypto-icons':
-        specifier: 'catalog:'
-        version: 1.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.19(patch_hash=810073718ccefe69fd016893be54d80d86cc6e5ee521455028b93c7cbf3103d7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+        specifier: 2.0.1
+        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.11)(@ledgerhq/lumen-ui-react@0.1.24(1685647331cab8b81ae5bae9e8b32b81))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/cryptoassets
@@ -45164,6 +45164,14 @@ snapshots:
       '@ledgerhq/lumen-ui-rnative': 0.1.25(1dd0e7412354a1878032940528d87280)
       react-dom: 19.0.0(react@19.0.0)
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0)
+
+  '@ledgerhq/crypto-icons@2.0.1(@ledgerhq/lumen-design-core@0.1.11)(@ledgerhq/lumen-ui-react@0.1.24(1685647331cab8b81ae5bae9e8b32b81))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@ledgerhq/lumen-design-core': 0.1.11
+      '@ledgerhq/lumen-ui-react': 0.1.24(1685647331cab8b81ae5bae9e8b32b81)
+      react-dom: 19.0.0(react@19.0.0)
 
   '@ledgerhq/cryptoassets-evm-signatures@13.5.2':
     dependencies:


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Only the `SquaredCryptoIcon` unit test was updated for the new shape API. Visual regressions on icon rendering are not covered by automated tests and must be validated manually._
- [x] **Impact of the changes:**
  - Crypto icon rendering across the desktop app: Market list, Market coin page, Market banner, Assets table, Analytics allocation table, History operations, History export dialog, Modular Dialogs (Asset/Account/Network selectors), EVM staking provider list, Manager device dashboard, Crypto Addresses table & banner.
  - Squared crypto icons (rounded-corner variant) wherever `SquaredCryptoIcon` is used.
  - `CurrencyBadge` / `CryptoCurrencyIcon` / `ParentCryptoCurrencyIcon` shared components.

### 📝 Description

`@ledgerhq/crypto-icons@2.0.0` was released with a full migration to the Lumen design system: `styled-components` is dropped, the component is now backed by `MediaImage` / `DotSymbol` / `Skeleton` from `@ledgerhq/lumen-ui-react`, and the prop API has breaking changes.

This PR migrates **only `ledger-live-desktop`** to v2 (`2.0.1`). The catalog version stays on `1.4.0` for `ledger-live-mobile`, `web-tools`, and the `@ledgerhq/react-ui` / `@ledgerhq/native-ui` packages, which can migrate independently later.

**Adapted to the v2 API:**

- `size`: pixel string (`"32px"`) → numeric token (`32`) per Lumen `MediaImage`.
- `overridesRadius` removed → replaced by `shape="square" | "circle"`. The local `SquaredCryptoIcon` wrapper now sets `shape="square"` explicitly; everywhere else relies on the new default `shape="circle"`.
- `ticker` is now required → guarded the only optional callsite (`AccountListItem`).
- The local `getValidCryptoIconSize` re-export now returns numbers (it forwards to `getValidCryptoIconSizeNative` from `live-common`) to match the new size type.
- `theme` and `backgroundColor` (RN) props were not used in desktop — nothing to remove on that front.

The Lumen `ThemeProvider` (required by v2) already wraps the desktop app via `renderer/App.tsx`, so no setup change is needed.

| Before (v1) | After (v2) |
| --- | --- |
| `<CryptoIcon ticker="BTC" size="56px" />` | `<CryptoIcon ticker="BTC" size={56} />` |
| `<CryptoIcon ticker="BTC" overridesRadius="16px" />` | `<CryptoIcon ticker="BTC" shape="square" />` |
| Default: implicit circle | Default: `shape="circle"` (explicit) |

### 🖼 Screenshots

| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

> Worth checking visually: Market list/coin page, Assets table, History operations row, Modular Dialogs (Asset/Account/Network selectors), Crypto Addresses banner, Manager App icons, EVM Staking providers.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29863](https://ledgerhq.atlassian.net/browse/LIVE-29863)
- Library: [@ledgerhq/crypto-icons v2.0.1 on npm](https://www.npmjs.com/package/@ledgerhq/crypto-icons)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29863]: https://ledgerhq.atlassian.net/browse/LIVE-29863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ