### PR TITLE
[LWDM] feat(coin-tezos): getBalance stake for paris upgrade

### DIFF
--- a/.changeset/nasty-rockets-shake.md
+++ b/.changeset/nasty-rockets-shake.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tezos": patch
+---
+
+Reflect Paris staking positions in `getBalance` and `getStakes`. Both now expose up to three native staking entries per account: a delegation position (uid `delegation-{address}`, amount = `balance - stakedBalance`) when a delegate is set, an active staking position (uid `stake-{address}`, amount = `stakedBalance`) when `stakedBalance > 0`, and a deactivating unstake position (uid `unstaking-{address}`, amount = `unstakedBalance`, state `deactivating`) when `unstakedBalance > 0`. The native `Balance.value` continues to reflect `apiAccount.balance`.

--- a/libs/coin-modules/coin-tezos/src/logic/getBalance.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBalance.test.ts
@@ -122,8 +122,12 @@ describe("getBalance", () => {
       {
         value: 15n,
         asset: { type: "native" },
+      },
+      {
+        value: 15n,
+        asset: { type: "native" },
         stake: {
-          uid: "tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oMMM",
+          uid: "delegation-tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oMMM",
           address: "tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oMMM",
           delegate: "tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oMMM",
           state: "active",
@@ -148,5 +152,146 @@ describe("getBalance", () => {
         },
       },
     ]);
+  });
+
+  describe("staking positions (Paris upgrade)", () => {
+    const address = "tz1StakingAddr";
+    const delegateAddress = "tz1BakerAddr";
+
+    function mockAccount(account: Record<string, unknown>) {
+      mockServer.use(
+        http.get(`http://tezos.explorer.com/v1/accounts/${address}`, () =>
+          HttpResponse.json({ type: "user", ...account }),
+        ),
+        http.get("http://tezos.explorer.com/v1/tokens/balances", () => HttpResponse.json([])),
+      );
+    }
+
+    it("attaches a delegation Stake when only delegate is set", async () => {
+      mockAccount({ balance: 100, delegate: { address: delegateAddress } });
+
+      expect(await getBalance(address)).toEqual([
+        { value: 100n, asset: { type: "native" } },
+        {
+          value: 100n,
+          asset: {
+            type: "native",
+          },
+          stake: {
+            uid: `delegation-${address}`,
+            address,
+            delegate: delegateAddress,
+            state: "active",
+            asset: {
+              type: "native",
+            },
+            amount: 100n,
+          },
+        },
+      ]);
+    });
+
+    it("attaches a stake Stake when stakedBalance > 0 (no delegate)", async () => {
+      mockAccount({ balance: 100, stakedBalance: 30 });
+
+      expect(await getBalance(address)).toEqual([
+        { value: 100n, asset: { type: "native" } },
+        {
+          value: 30n,
+          asset: {
+            type: "native",
+          },
+          stake: {
+            uid: `stake-${address}`,
+            address,
+            state: "active",
+            asset: {
+              type: "native",
+            },
+            amount: 30n,
+          },
+        },
+      ]);
+    });
+
+    it("splits delegation and stake amounts when both delegate and stakedBalance are set", async () => {
+      mockAccount({
+        balance: 100,
+        stakedBalance: 30,
+        delegate: { address: delegateAddress },
+      });
+
+      expect(await getBalance(address)).toEqual([
+        { value: 100n, asset: { type: "native" } },
+        {
+          value: 70n,
+          asset: {
+            type: "native",
+          },
+          stake: {
+            uid: `delegation-${address}`,
+            address,
+            delegate: delegateAddress,
+            state: "active",
+            asset: {
+              type: "native",
+            },
+            amount: 70n,
+          },
+        },
+        {
+          value: 30n,
+          asset: {
+            type: "native",
+          },
+          stake: {
+            uid: `stake-${address}`,
+            address,
+            delegate: delegateAddress,
+            state: "active",
+            asset: {
+              type: "native",
+            },
+            amount: 30n,
+          },
+        },
+      ]);
+    });
+
+    it("attaches an unstaking Stake with state 'deactivating' when unstakedBalance > 0", async () => {
+      mockAccount({
+        balance: 100,
+        stakedBalance: 30,
+        unstakedBalance: 10,
+        delegate: { address: delegateAddress },
+      });
+
+      const result = await getBalance(address);
+
+      expect(result).toHaveLength(4);
+      expect(result[0]).toEqual({ value: 100n, asset: { type: "native" } });
+      expect(result[3]).toEqual({
+        value: 10n,
+        asset: {
+          type: "native",
+        },
+        stake: {
+          uid: `unstaking-${address}`,
+          address,
+          delegate: delegateAddress,
+          state: "deactivating",
+          asset: {
+            type: "native",
+          },
+          amount: 10n,
+        },
+      });
+    });
+
+    it("returns only the primary native Balance when no staking activity", async () => {
+      mockAccount({ balance: 50 });
+
+      expect(await getBalance(address)).toEqual([{ value: 50n, asset: { type: "native" } }]);
+    });
   });
 });

--- a/libs/coin-modules/coin-tezos/src/logic/getBalance.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBalance.ts
@@ -1,10 +1,13 @@
-import type { Balance, Stake } from "@ledgerhq/coin-module-framework/api/index";
+import type { Balance } from "@ledgerhq/coin-module-framework/api/index";
 import api from "../network/tzkt";
+import { buildStakesForAccount } from "./getStakes";
 
 /**
  * Returns the balances of the given address as an array of Balance objects.
- * The first entry represents the native balance (with value 0n for empty accounts),
- * followed by any token balances associated with the address.
+ * The first entry represents the native balance (with value 0n for empty accounts).
+ * For delegated/staked accounts, additional native entries are appended carrying each
+ * staking position (delegation, active staking, deactivating unstake) per the Paris upgrade.
+ * Token balances are appended after.
  */
 export async function getBalance(address: string): Promise<Balance[]> {
   const [apiAccountResult, tokensBalancesResult] = await Promise.allSettled([
@@ -21,17 +24,14 @@ export async function getBalance(address: string): Promise<Balance[]> {
     tokensBalancesResult.status === "fulfilled" ? tokensBalancesResult.value : [];
   const normalized = apiAccount.type === "user" ? BigInt(apiAccount.balance) : 0n;
 
-  const stake: Stake | undefined =
-    apiAccount.type === "user" && apiAccount.delegate?.address
-      ? {
-          uid: address,
-          address,
-          delegate: apiAccount.delegate.address,
-          state: "active",
+  const stakeBalances: Balance[] =
+    apiAccount.type === "user"
+      ? buildStakesForAccount(address, apiAccount).map(stake => ({
+          value: stake.amount,
           asset: { type: "native" },
-          amount: normalized,
-        }
-      : undefined;
+          stake,
+        }))
+      : [];
 
   const tokensBalance: Balance[] = tokensBalancesRaw.map(({ balance, token }) => {
     const magnitude = Number.parseInt(token.metadata?.decimals || "0", 10);
@@ -61,8 +61,8 @@ export async function getBalance(address: string): Promise<Balance[]> {
     {
       value: normalized,
       asset: { type: "native" },
-      ...(stake && { stake }),
     },
+    ...stakeBalances,
     ...tokensBalance,
   ];
 }

--- a/libs/coin-modules/coin-tezos/src/logic/getStakes.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getStakes.test.ts
@@ -67,63 +67,18 @@ describe("getStakes", () => {
 
       expect(result.items).toEqual([]);
     });
-  });
 
-  describe("delegated accounts", () => {
-    it("should return stake for delegated account", async () => {
-      const address = "tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8";
-      const delegateAddress = "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx";
-      const balance = 5000000;
-
+    it("should return stake position for non-delegated account with stakedBalance > 0", async () => {
+      const address = "tz1NoDelegateStaker";
       mockGetAccountByAddress.mockResolvedValue({
         type: "user",
         address,
         publicKey: "edpk...",
-        balance,
+        balance: 100,
+        stakedBalance: 30,
         revealed: true,
         counter: 0,
-        delegate: {
-          alias: "Test Delegate",
-          address: delegateAddress,
-          active: true,
-        },
-        delegationLevel: 100,
-        delegationTime: "2021-01-01T00:00:00Z",
-        numTransactions: 10,
-        firstActivityTime: "2021-01-01T00:00:00Z",
-      });
-
-      const result = await api.getStakes(address);
-
-      expect(result.items).toEqual([
-        expect.objectContaining({
-          uid: address,
-          address,
-          delegate: delegateAddress,
-          state: "active",
-          asset: { type: "native" },
-          amount: BigInt(balance),
-        }),
-      ]);
-    });
-
-    it("should handle account with zero balance but delegation", async () => {
-      const address = "tz1ZeroBalanceAccount";
-      const delegateAddress = "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx";
-
-      mockGetAccountByAddress.mockResolvedValue({
-        type: "user",
-        address,
-        publicKey: "edpk...",
-        balance: 0,
-        revealed: true,
-        counter: 0,
-        delegate: {
-          alias: "Test Delegate",
-          address: delegateAddress,
-          active: true,
-        },
-        delegationLevel: 100,
+        delegationLevel: 0,
         delegationTime: "2021-01-01T00:00:00Z",
         numTransactions: 0,
         firstActivityTime: "2021-01-01T00:00:00Z",
@@ -131,15 +86,185 @@ describe("getStakes", () => {
 
       const result = await api.getStakes(address);
 
-      expect(result.items).toHaveLength(1);
-      expect(result.items[0]).toMatchObject({
-        uid: address,
+      expect(result.items).toEqual([
+        {
+          uid: `stake-${address}`,
+          address,
+          state: "active",
+          asset: { type: "native" },
+          amount: 30n,
+        },
+      ]);
+    });
+
+    it("should return unstaking position for non-delegated account with unstakedBalance > 0", async () => {
+      const address = "tz1NoDelegateUnstaker";
+      mockGetAccountByAddress.mockResolvedValue({
+        type: "user",
         address,
-        delegate: delegateAddress,
-        state: "active",
-        asset: { type: "native" },
-        amount: BigInt(0),
+        publicKey: "edpk...",
+        balance: 100,
+        unstakedBalance: 10,
+        revealed: true,
+        counter: 0,
+        delegationLevel: 0,
+        delegationTime: "2021-01-01T00:00:00Z",
+        numTransactions: 0,
+        firstActivityTime: "2021-01-01T00:00:00Z",
       });
+
+      const result = await api.getStakes(address);
+
+      expect(result.items).toEqual([
+        {
+          uid: `unstaking-${address}`,
+          address,
+          state: "deactivating",
+          asset: { type: "native" },
+          amount: 10n,
+        },
+      ]);
+    });
+  });
+
+  describe("delegated accounts", () => {
+    const address = "tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8";
+    const delegateAddress = "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx";
+
+    function makeAccount(overrides: Record<string, unknown> = {}) {
+      return {
+        type: "user" as const,
+        address,
+        publicKey: "edpk...",
+        balance: 5000000,
+        revealed: true,
+        counter: 0,
+        delegate: { alias: "Test Delegate", address: delegateAddress, active: true },
+        delegationLevel: 100,
+        delegationTime: "2021-01-01T00:00:00Z",
+        numTransactions: 10,
+        firstActivityTime: "2021-01-01T00:00:00Z",
+        ...overrides,
+      };
+    }
+
+    it("should return delegation stake for delegated account with no staking", async () => {
+      mockGetAccountByAddress.mockResolvedValue(makeAccount());
+
+      const result = await api.getStakes(address);
+
+      expect(result.items).toEqual([
+        {
+          uid: `delegation-${address}`,
+          address,
+          delegate: delegateAddress,
+          state: "active",
+          asset: { type: "native" },
+          amount: 5000000n,
+        },
+      ]);
+    });
+
+    it("should handle account with zero balance but delegation", async () => {
+      mockGetAccountByAddress.mockResolvedValue(makeAccount({ balance: 0 }));
+
+      const result = await api.getStakes(address);
+
+      expect(result.items).toEqual([
+        {
+          uid: `delegation-${address}`,
+          address,
+          delegate: delegateAddress,
+          state: "active",
+          asset: { type: "native" },
+          amount: 0n,
+        },
+      ]);
+    });
+
+    it("should return delegation + stake when stakedBalance > 0", async () => {
+      mockGetAccountByAddress.mockResolvedValue(makeAccount({ balance: 100, stakedBalance: 30 }));
+
+      const result = await api.getStakes(address);
+
+      expect(result.items).toEqual([
+        {
+          uid: `delegation-${address}`,
+          address,
+          delegate: delegateAddress,
+          state: "active",
+          asset: { type: "native" },
+          amount: 70n,
+        },
+        {
+          uid: `stake-${address}`,
+          address,
+          delegate: delegateAddress,
+          state: "active",
+          asset: { type: "native" },
+          amount: 30n,
+        },
+      ]);
+    });
+
+    it("should return delegation + unstaking when unstakedBalance > 0", async () => {
+      mockGetAccountByAddress.mockResolvedValue(makeAccount({ balance: 100, unstakedBalance: 10 }));
+
+      const result = await api.getStakes(address);
+
+      expect(result.items).toEqual([
+        {
+          uid: `delegation-${address}`,
+          address,
+          delegate: delegateAddress,
+          state: "active",
+          asset: { type: "native" },
+          amount: 100n,
+        },
+        {
+          uid: `unstaking-${address}`,
+          address,
+          delegate: delegateAddress,
+          state: "deactivating",
+          asset: { type: "native" },
+          amount: 10n,
+        },
+      ]);
+    });
+
+    it("should return all three positions when delegate, stakedBalance and unstakedBalance are set", async () => {
+      mockGetAccountByAddress.mockResolvedValue(
+        makeAccount({ balance: 100, stakedBalance: 30, unstakedBalance: 10 }),
+      );
+
+      const result = await api.getStakes(address);
+
+      expect(result.items).toEqual([
+        {
+          uid: `delegation-${address}`,
+          address,
+          delegate: delegateAddress,
+          state: "active",
+          asset: { type: "native" },
+          amount: 70n,
+        },
+        {
+          uid: `stake-${address}`,
+          address,
+          delegate: delegateAddress,
+          state: "active",
+          asset: { type: "native" },
+          amount: 30n,
+        },
+        {
+          uid: `unstaking-${address}`,
+          address,
+          delegate: delegateAddress,
+          state: "deactivating",
+          asset: { type: "native" },
+          amount: 10n,
+        },
+      ]);
     });
   });
 });

--- a/libs/coin-modules/coin-tezos/src/logic/getStakes.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getStakes.ts
@@ -1,20 +1,64 @@
 import type { Cursor, Page, Stake } from "@ledgerhq/coin-module-framework/api/types";
 import api from "../network/tzkt";
+import type { APIAccount } from "../network/types";
+
+type APIUserAccount = Extract<APIAccount, { type: "user" }>;
+
+/**
+ * Build the staking positions exposed by a Tezos account, per Paris upgrade semantics:
+ * - delegation position (when a delegate is set) for the non-staked, delegated amount
+ * - active staking position (when `stakedBalance > 0`)
+ * - deactivating unstake position (when `unstakedBalance > 0`)
+ *
+ * Each entry inherits the account `delegate` when set, since on Tezos a staked or unstaked
+ * portion is necessarily delegated to the same baker as the rest of the balance.
+ */
+export function buildStakesForAccount(address: string, account: APIUserAccount): Stake[] {
+  const balance = BigInt(account.balance ?? 0);
+  const stakedBalance = BigInt(account.stakedBalance ?? 0);
+  const unstakedBalance = BigInt(account.unstakedBalance ?? 0);
+  const delegateAddress = account.delegate?.address;
+
+  const stakes: Stake[] = [];
+
+  if (delegateAddress) {
+    stakes.push({
+      uid: `delegation-${address}`,
+      address,
+      delegate: delegateAddress,
+      state: "active",
+      asset: { type: "native" },
+      amount: balance - stakedBalance,
+    });
+  }
+
+  if (stakedBalance > 0n) {
+    stakes.push({
+      uid: `stake-${address}`,
+      address,
+      ...(delegateAddress && { delegate: delegateAddress }),
+      state: "active",
+      asset: { type: "native" },
+      amount: stakedBalance,
+    });
+  }
+
+  if (unstakedBalance > 0n) {
+    stakes.push({
+      uid: `unstaking-${address}`,
+      address,
+      ...(delegateAddress && { delegate: delegateAddress }),
+      state: "deactivating",
+      asset: { type: "native" },
+      amount: unstakedBalance,
+    });
+  }
+
+  return stakes;
+}
 
 export async function getStakes(address: string, _cursor?: Cursor): Promise<Page<Stake>> {
-  // tezos exposes a single staking position via delegation when a delegate is set
   const accountInfo = await api.getAccountByAddress(address);
-  if (accountInfo.type !== "user" || !accountInfo.delegate?.address) return { items: [] };
-  return {
-    items: [
-      {
-        uid: address,
-        address,
-        delegate: accountInfo.delegate.address,
-        state: "active",
-        asset: { type: "native" },
-        amount: BigInt(accountInfo.balance ?? 0),
-      },
-    ],
-  };
+  if (accountInfo.type !== "user") return { items: [] };
+  return { items: buildStakesForAccount(address, accountInfo) };
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - getStakes may return up to 3 items per account (previously 1).
  - getBalance appends one extra native Balance per staking position alongside the primary balance and token entries.
  - Stake uid is now namespaced: delegation-{address} / stake-{address} / unstaking-{address} (previously {address}) — verify any consumer keying on Stake.uid.
  - Native Balance.value (apiAccount.balance) and token-balance shape unchanged.

### 📝 Description

Reflect Paris adaptive-issuance staking positions in getStakes and getBalance. Each user account now exposes up to three native entries derived from TzKT stakedBalance
  / unstakedBalance / delegate: delegation (balance - stakedBalance), active staking (stakedBalance), and deactivating unstake (unstakedBalance, state deactivating).

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28760](https://ledgerhq.atlassian.net/browse/LIVE-28760?atlOrigin=eyJpIjoiYjVhMDU3ODkyNjhkNDA3ZDg0YTI2MzM0MmIxNTZiOWYiLCJwIjoiaiJ9), [LIVE-28762](https://ledgerhq.atlassian.net/browse/LIVE-28762?atlOrigin=eyJpIjoiYWQ2Y2YwZTAwM2VmNDZlYWE4MzBhMjNjZGJhYWVlMmUiLCJwIjoiaiJ9)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-28760]: https://ledgerhq.atlassian.net/browse/LIVE-28760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ