### PR TITLE
[LWD] fix(desktop): prevent MainAppContent remount when navigating to account pages

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/components/Page/__tests__/utils.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/Page/__tests__/utils.test.ts
@@ -20,6 +20,8 @@ describe("Page utils", () => {
       expect(isWallet40Page("/swap/bridge")).toBe(true);
       expect(isWallet40Page("/exchange")).toBe(true);
       expect(isWallet40Page("/exchange/foo")).toBe(true);
+      expect(isWallet40Page("/account/js:2:ethereum:0x1234:")).toBe(true);
+      expect(isWallet40Page("/asset/bitcoin")).toBe(true);
     });
 
     it("returns false for routes outside wallet 4.0", () => {

--- a/apps/ledger-live-desktop/src/mvvm/components/Page/utils.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/Page/utils.ts
@@ -15,7 +15,7 @@ const WALLET_40_PAGES = new Set([
   "/history",
 ]);
 
-const WALLET_40_PREFIXES = ["/card", "/swap", "/exchange"];
+const WALLET_40_PREFIXES = ["/card", "/swap", "/exchange", "/account/", "/asset/"];
 
 /**
  * Pages that display the right panel (swap sidebar)


### PR DESCRIPTION
High number of automated UI e2e desktop tests started to fail because account view didn't load (please see attached screenshot). This fix prevents MainAppContent remount when navigating to account pages.
CI execution: https://github.com/LedgerHQ/ledger-live/actions/runs/25064871190
Allure report: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/cbad1463-1e42-40a2-ab6a-20b19f4e6432/#

<img width="1017" height="763" alt="image" src="https://github.com/user-attachments/assets/d78969c9-7ef7-4caa-848d-f72326521ba7" />
