### PR TITLE
[LWM] fix(mobile): fix EVM cross-chain account collision in operations list counterparty lookup

### DIFF
--- a/.changeset/tangled-chains-fix.md
+++ b/.changeset/tangled-chains-fix.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix EVM cross-chain account collision in MVVM operations list counterparty lookup

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
@@ -1,5 +1,8 @@
 import { act } from "@testing-library/react-native";
 import { renderHook } from "@tests/test-renderer";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import type { State } from "~/reducers/types";
 import { useOperationsListViewModel } from "../useOperationsListViewModel";
 
 // ─── Hook behaviours — mock needed because useOperationsV1 uses selectors ───
@@ -46,5 +49,36 @@ describe("useOperationsListViewModel", () => {
     act(() => result.current.onEndReached());
 
     expect(mockUseOperationsV1.mock.calls.length).toBe(callsBefore);
+  });
+
+  describe("accountByAddress", () => {
+    // EVM chains share the same address format — Base, OP Mainnet, and Ethereum accounts
+    // all have identical 0x addresses. The map must key by currencyId:address so that
+    // accounts on different chains coexist without overwriting each other.
+    it("gives each EVM account its own entry when multiple chains share the same address", () => {
+      const sharedAddress = "0xabcdef1234567890abcdef1234567890abcdef12";
+      const ethereum = getCryptoCurrencyById("ethereum");
+      const bitcoin = getCryptoCurrencyById("bitcoin");
+      const ethAccount = {
+        ...genAccount("eth-shared-addr", { currency: ethereum }),
+        freshAddress: sharedAddress,
+      };
+      const btcAccount = {
+        ...genAccount("btc-shared-addr", { currency: bitcoin }),
+        freshAddress: sharedAddress,
+      };
+
+      const { result } = renderHook(() => useOperationsListViewModel(), {
+        overrideInitialState: (state: State) => ({
+          ...state,
+          accounts: { ...state.accounts, active: [ethAccount, btcAccount] },
+        }),
+      });
+
+      const map = result.current.accountByAddress;
+      expect(map.size).toBe(2);
+      expect(map.get(`${ethereum.id}:${sharedAddress}`)).toBe(ethAccount);
+      expect(map.get(`${bitcoin.id}:${sharedAddress}`)).toBe(btcAccount);
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListItem/__tests__/OperationsListItem.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListItem/__tests__/OperationsListItem.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import BigNumber from "bignumber.js";
-import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { usdcToken } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
 import type { AccountLike, Operation } from "@ledgerhq/types-live";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
 import { render } from "@tests/test-renderer";
@@ -86,7 +87,9 @@ describe("OperationsListItem", () => {
     const counterpartyName = `${bitcoin.name} ${counterpartyAccount.index + 1}`;
 
     it("should show internal account name instead of address for an incoming transfer", () => {
-      const accountByAddress = new Map([[counterpartyAccount.freshAddress, counterpartyAccount]]);
+      const accountByAddress = new Map([
+        [`${bitcoin.id}:${counterpartyAccount.freshAddress}`, counterpartyAccount],
+      ]);
       const operation = buildOperation({
         type: "IN",
         value: new BigNumber(1),
@@ -100,7 +103,9 @@ describe("OperationsListItem", () => {
     });
 
     it("should show internal account name instead of address for an outgoing transfer", () => {
-      const accountByAddress = new Map([[counterpartyAccount.freshAddress, counterpartyAccount]]);
+      const accountByAddress = new Map([
+        [`${bitcoin.id}:${counterpartyAccount.freshAddress}`, counterpartyAccount],
+      ]);
       const operation = buildOperation({
         type: "OUT",
         value: new BigNumber(1),
@@ -111,6 +116,69 @@ describe("OperationsListItem", () => {
 
       expect(getByText(`To ${counterpartyName}`)).toBeVisible();
       expect(queryByText(new RegExp(counterpartyAccount.freshAddress.slice(0, 6)))).toBeNull();
+    });
+  });
+
+  describe("cross-chain EVM accounts", () => {
+    // EVM chains share addresses across networks (Base, OP Mainnet, Ethereum all use the same 0x address).
+    // An account on chain B keyed as "chainB:0xAddr" must NOT be returned when looking up "chainA:0xAddr".
+    it("should show raw address when the counterparty account is on a different chain", () => {
+      const ethereum = getCryptoCurrencyById("ethereum");
+      const sharedAddress = "0x1234567890abcdef1234567890abcdef12345678";
+      const ethAccount = {
+        ...genAccount("eth-cross-chain", { currency: ethereum }),
+        freshAddress: sharedAddress,
+      };
+      const ethAccountName = `${ethereum.name} ${ethAccount.index + 1}`;
+      // Map contains the Ethereum account — but the operation's account (and its lookup key) is Bitcoin
+      const accountByAddress = new Map([[`${ethereum.id}:${sharedAddress}`, ethAccount]]);
+      const operation = buildOperation({
+        type: "IN",
+        value: new BigNumber(1),
+        senders: [sharedAddress],
+      });
+
+      const { queryByText, getByText } = renderItem(operation, accountByAddress);
+
+      expect(queryByText(ethAccountName)).toBeNull();
+      expect(getByText(/From 0x1234/)).toBeVisible();
+    });
+  });
+
+  describe("token account operations", () => {
+    // For TokenAccount, getAccountCurrency returns the token id (e.g. "ethereum/erc20/usd_coin"),
+    // but the map is built from parent Account objects and keyed by the parent chain currency id
+    // (e.g. "ethereum"). The lookup must use mainAccount.currency.id to match correctly.
+    it("should resolve counterparty account name for an incoming token transfer", () => {
+      const ethereum = getCryptoCurrencyById("ethereum");
+      const ownerEthAccount = genAccount("eth-owner-token", { currency: ethereum });
+      const tokenAccount = genTokenAccount(0, ownerEthAccount, usdcToken);
+      const counterpartyEthAccount = genAccount("eth-counterparty-token", { currency: ethereum });
+      const counterpartyName = `${ethereum.name} ${counterpartyEthAccount.index + 1}`;
+
+      // Map is keyed by parent chain currency id — as built by useOperationsListViewModel
+      const accountByAddress = new Map([
+        [`${ethereum.id}:${counterpartyEthAccount.freshAddress}`, counterpartyEthAccount],
+      ]);
+      const operation = buildOperation({
+        type: "IN",
+        value: new BigNumber(1),
+        senders: [counterpartyEthAccount.freshAddress],
+      });
+
+      const { getByText, queryByText } = render(
+        <OperationsListItem
+          operation={operation}
+          account={tokenAccount}
+          parentAccount={ownerEthAccount}
+          accountByAddress={accountByAddress}
+        />,
+      );
+
+      expect(getByText(`From ${counterpartyName}`)).toBeVisible();
+      expect(
+        queryByText(new RegExp(counterpartyEthAccount.freshAddress.slice(0, 6))),
+      ).toBeNull();
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListItem/useOperationsListItemViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListItem/useOperationsListItemViewModel.ts
@@ -49,7 +49,9 @@ export function useOperationsListItemViewModel({
     ? formatAddress(address, { prefixLength: 6, suffixLength: 4 })
     : "";
 
-  const counterpartyAccount = address ? accountByAddress.get(address) : undefined;
+  const counterpartyAccount = address
+    ? accountByAddress.get(`${mainAccount.currency.id}:${address}`)
+    : undefined;
   const counterpartyAccountName = useMaybeAccountName(counterpartyAccount);
   // For send/receive: prefer the counterparty's account name, fall back to the raw address
   const counterpartyLabel = counterpartyAccountName ?? formattedAddress;

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
@@ -3,6 +3,7 @@ import { useSelector } from "~/context/hooks";
 import { flattenAccountsSelector, shallowAccountsSelector } from "~/reducers/accounts";
 import { useOperationsV1 } from "~/screens/Analytics/Operations/useOperationsV1";
 import { AccountLike } from "@ledgerhq/types-live";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 
 const INITIAL_OP_COUNT = 50;
 const OP_COUNT_INCREMENT = 50;
@@ -19,7 +20,8 @@ export function useOperationsListViewModel() {
     for (const account of accounts) {
       const { freshAddress } = account;
       if (freshAddress) {
-        map.set(freshAddress, account);
+        const currencyId = getAccountCurrency(account).id;
+        map.set(`${currencyId}:${freshAddress}`, account);
       }
     }
     return map;


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Operations list in MVVM (\`mvvm/features/OperationsHistory\`) — verify that the counterparty label on send/receive operations shows the correct account name (or raw address when the counterparty is external or on a different chain)
  - EVM accounts on multiple chains (Base, OP Mainnet, Ethereum, etc.) with the same wallet address — a send from one chain must not display another chain's account name as the recipient
  - Token operations (ERC-20, etc.) — verify that internal counterparty names still resolve correctly on token transfers

### 📝 Description

**Problem:** In the MVVM operations list, EVM chains (Base, OP Mainnet, Ethereum…) share the same `0x` address across networks. The `accountByAddress` map in `useOperationsListViewModel` was keyed by `freshAddress` only, so when a user has accounts on multiple EVM chains, later entries in the loop would silently overwrite earlier ones. This caused sends on e.g. a Base account to display "OP Mainnet account" as the counterparty label — which is factually wrong and confusing.

**Fix:** The map key is now `${mainAccount.currency.id}:${freshAddress}`, giving each chain its own independent slot. Using `mainAccount.currency.id` (the parent chain id) rather than `getAccountCurrency(account).id` is critical: for `TokenAccount`, `getAccountCurrency` returns the token id (e.g. `ethereum/erc20/usd_coin`) not the chain id — using it in the lookup would silently break counterparty resolution for all token transfers. `mainAccount.currency.id` is always the parent chain id regardless of account type.

```ts
// Before — collides across EVM chains
map.set(freshAddress, account);
accountByAddress.get(address);
```

wrong account name

<img width="300"  alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-04-29 at 00 05 34" src="https://github.com/user-attachments/assets/5a7bdbd2-915d-43a1-9d88-efabffd3dcc0" />


```ts
// After — keyed by parent chain id, safe for both Account and TokenAccount
map.set(`${mainAccount.currency.id}:${freshAddress}`, account);
accountByAddress.get(`${mainAccount.currency.id}:${address}`);
```

good account name

<img width="300" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-04-29 at 00 05 45" src="https://github.com/user-attachments/assets/031b43a0-9bcf-4251-a28d-c62672b636f0" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30049](https://ledgerhq.atlassian.net/browse/LIVE-30049)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30049]: https://ledgerhq.atlassian.net/browse/LIVE-30049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ