### PR TITLE
feat(mobile): [W4.0] LWM - Pending transactions

### DIFF
--- a/.changeset/pending-operations-section.md
+++ b/.changeset/pending-operations-section.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add pending transactions section at top of MVVM operations list, failed tx icon, and remove "Yesterday" date label

--- a/apps/ledger-live-mobile/src/hooks/__tests__/useDateFormatter.test.ts
+++ b/apps/ledger-live-mobile/src/hooks/__tests__/useDateFormatter.test.ts
@@ -148,10 +148,21 @@ describe("useFormatDaySection", () => {
     expect(result.current(lateToday)).toBe("Today");
   });
 
-  it("returns 'Yesterday' for the previous calendar day", () => {
+  it("returns a formatted long date for the previous calendar day (no 'Yesterday' label)", () => {
     const yesterday = new Date(2024, 0, 14);
-    const { result } = renderHook(() => useFormatDaySection());
-    expect(result.current(yesterday)).toBe("Yesterday");
+    const { result } = renderHook(() => useFormatDaySection(), {
+      overrideInitialState: (state: State) => ({
+        ...state,
+        settings: { ...state.settings, language: "en" },
+      }),
+    });
+    const expected = new Intl.DateTimeFormat("en", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    }).format(yesterday);
+    expect(result.current(yesterday)).toBe(expected);
+    expect(result.current(yesterday)).not.toBe("Yesterday");
   });
 
   it("returns a formatted long date for 2 days ago", () => {

--- a/apps/ledger-live-mobile/src/hooks/useDateFormatter.ts
+++ b/apps/ledger-live-mobile/src/hooks/useDateFormatter.ts
@@ -43,7 +43,6 @@ export function useFormatDaySection() {
     (day: Date): string => {
       const dayDiff = differenceInCalendarDays(Date.now(), day);
       if (dayDiff === 0) return t("common.today");
-      if (dayDiff === 1) return t("common.yesterday");
       return longDateFormatter.format(day);
     },
     [t, longDateFormatter],

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -2946,7 +2946,8 @@
   },
   "operationsList": {
     "to": "To",
-    "from": "From"
+    "from": "From",
+    "pending": "Pending"
   },
   "operationDetails": {
     "title": "Transaction details",

--- a/apps/ledger-live-mobile/src/mvvm/components/TransactionalIcon/__tests__/TransactionalIcon.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TransactionalIcon/__tests__/TransactionalIcon.test.tsx
@@ -8,12 +8,7 @@ const bitcoin = getCryptoCurrencyById("bitcoin");
 describe("TransactionalIcon", () => {
   it("should render dot wrapper and crypto icon when operation type has a transactional dot config", () => {
     render(
-      <TransactionalIcon
-        operationType="IN"
-        isOptimistic={false}
-        currency={bitcoin}
-        mediaSize={48}
-      />,
+      <TransactionalIcon operationType="IN" isPending={false} currency={bitcoin} mediaSize={48} />,
     );
 
     expect(screen.getByTestId(`transactional-icon-dot-IN`)).toBeVisible();
@@ -21,14 +16,23 @@ describe("TransactionalIcon", () => {
   });
 
   it("should render only crypto icon when operation type has no dot config", () => {
-    render(<TransactionalIcon operationType="NONE" isOptimistic={false} currency={bitcoin} />);
+    render(<TransactionalIcon operationType="NONE" isPending={false} currency={bitcoin} />);
 
     expect(screen.queryByTestId(`transactional-icon-dot-NONE`)).toBeNull();
     expect(screen.getByTestId(`transactional-icon-crypto-bitcoin`)).toBeVisible();
   });
 
-  it("should render dot wrapper and crypto icon when optimistic regardless of operation type", () => {
-    render(<TransactionalIcon operationType="NONE" isOptimistic currency={bitcoin} />);
+  it("should render dot wrapper and crypto icon when pending regardless of operation type", () => {
+    render(<TransactionalIcon operationType="NONE" isPending currency={bitcoin} />);
+
+    expect(screen.getByTestId(`transactional-icon-dot-NONE`)).toBeVisible();
+    expect(screen.getByTestId(`transactional-icon-crypto-bitcoin`)).toBeVisible();
+  });
+
+  it("should render dot wrapper when hasFailed regardless of operation type", () => {
+    render(
+      <TransactionalIcon operationType="NONE" isPending={false} hasFailed currency={bitcoin} />,
+    );
 
     expect(screen.getByTestId(`transactional-icon-dot-NONE`)).toBeVisible();
     expect(screen.getByTestId(`transactional-icon-crypto-bitcoin`)).toBeVisible();

--- a/apps/ledger-live-mobile/src/mvvm/components/TransactionalIcon/__tests__/getTransactionalDotConfig.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TransactionalIcon/__tests__/getTransactionalDotConfig.test.ts
@@ -2,6 +2,7 @@ import {
   ArrowDown,
   ArrowUp,
   Clock,
+  Close,
   Invoice,
   Link,
   Mailbox,
@@ -39,5 +40,19 @@ describe("getTransactionalDotConfig", () => {
 
   it("returns null for operation types without a transactional dot", () => {
     expect(getTransactionalDotConfig("NONE", false)).toBeNull();
+  });
+
+  it("returns close icon with error appearance when hasFailed", () => {
+    expect(getTransactionalDotConfig("OUT", false, true)).toEqual({
+      icon: Close,
+      appearance: "error",
+    });
+  });
+
+  it("hasFailed takes priority over isOptimistic", () => {
+    expect(getTransactionalDotConfig("OUT", true, true)).toEqual({
+      icon: Close,
+      appearance: "error",
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/TransactionalIcon/getTransactionalDotConfig.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TransactionalIcon/getTransactionalDotConfig.ts
@@ -6,6 +6,7 @@ import {
   ArrowDown,
   ArrowUp,
   Clock,
+  Close,
   Invoice,
   Link,
   Mailbox,
@@ -27,9 +28,13 @@ type TransactionalDotConfig = {
 
 export function getTransactionalDotConfig(
   operationType: OperationType,
-  isOptimistic: boolean,
+  isPending: boolean,
+  hasFailed?: boolean,
 ): TransactionalDotConfig | null {
-  if (isOptimistic) {
+  if (hasFailed) {
+    return { icon: Close, appearance: "error" };
+  }
+  if (isPending) {
     return { icon: Clock, appearance: "muted" };
   }
 

--- a/apps/ledger-live-mobile/src/mvvm/components/TransactionalIcon/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TransactionalIcon/index.tsx
@@ -7,18 +7,20 @@ import type { OperationType } from "@ledgerhq/types-live";
 
 export type TransactionalIconProps = {
   operationType: OperationType;
-  isOptimistic: boolean;
+  isPending: boolean;
+  hasFailed?: boolean;
   currency: CryptoCurrency | TokenCurrency;
   mediaSize?: keyof typeof mediaImageDotIconSizeMap;
 };
 
 function TransactionalIcon({
   operationType,
-  isOptimistic,
+  isPending,
+  hasFailed,
   currency,
   mediaSize = 48,
 }: Readonly<TransactionalIconProps>) {
-  const dot = getTransactionalDotConfig(operationType, isOptimistic);
+  const dot = getTransactionalDotConfig(operationType, isPending, hasFailed);
   const cryptoIcon = (
     <CryptoIcon
       testID={`transactional-icon-crypto-${currency.name.toLowerCase()}`}

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListItem/__tests__/OperationsListItem.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListItem/__tests__/OperationsListItem.test.tsx
@@ -42,13 +42,14 @@ function buildOperation(overrides: Partial<Operation>): Operation {
   };
 }
 
-function renderItem(operation: Operation, accountByAddress = emptyMap) {
+function renderItem(operation: Operation, accountByAddress = emptyMap, isPending = false) {
   return render(
     <OperationsListItem
       operation={operation}
       account={account}
       parentAccount={undefined}
       accountByAddress={accountByAddress}
+      isPending={isPending}
     />,
   );
 }
@@ -172,13 +173,12 @@ describe("OperationsListItem", () => {
           account={tokenAccount}
           parentAccount={ownerEthAccount}
           accountByAddress={accountByAddress}
+          isPending={false}
         />,
       );
 
       expect(getByText(`From ${counterpartyName}`)).toBeVisible();
-      expect(
-        queryByText(new RegExp(counterpartyEthAccount.freshAddress.slice(0, 6))),
-      ).toBeNull();
+      expect(queryByText(new RegExp(counterpartyEthAccount.freshAddress.slice(0, 6)))).toBeNull();
     });
   });
 
@@ -221,17 +221,40 @@ describe("OperationsListItem", () => {
     });
   });
 
-  it("should not navigate when the operation is optimistic", async () => {
+  it("should navigate to operation details when the operation is failed", async () => {
+    const operation = buildOperation({
+      type: "IN",
+      value: new BigNumber(1),
+      senders: ["s"],
+      hasFailed: true,
+    });
+    const { getByText, user } = renderItem(operation);
+    await user.press(getByText("Received"));
+    expect(track).toHaveBeenCalledWith("transaction_clicked", { transaction: "IN" });
+    expect(mockNavigate).toHaveBeenCalledWith(ScreenName.OperationDetails, {
+      accountId: account.id,
+      parentId: undefined,
+      operation,
+      key: operation.id,
+    });
+  });
+
+  it("should navigate to operation details when the operation is optimistic (pending)", async () => {
     const operation = buildOperation({
       type: "IN",
       value: new BigNumber(1),
       senders: ["s"],
       blockHeight: null,
     });
-    const { getByText, user } = renderItem(operation);
+    const { getByText, user } = renderItem(operation, emptyMap, true);
     await user.press(getByText("Received"));
-    expect(track).not.toHaveBeenCalled();
-    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(track).toHaveBeenCalledWith("transaction_clicked", { transaction: "IN" });
+    expect(mockNavigate).toHaveBeenCalledWith(ScreenName.OperationDetails, {
+      accountId: account.id,
+      parentId: undefined,
+      operation,
+      key: operation.id,
+    });
   });
 
   it("should pass parentId when parentAccount is provided", async () => {
@@ -243,6 +266,7 @@ describe("OperationsListItem", () => {
         account={account}
         parentAccount={parentAccount}
         accountByAddress={emptyMap}
+        isPending={false}
       />,
     );
     await user.press(getByText("Received"));

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListItem/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListItem/index.tsx
@@ -22,6 +22,7 @@ type Props = {
   account: AccountLike;
   parentAccount: Account | undefined;
   accountByAddress: Map<string, AccountLike>;
+  isPending: boolean;
 };
 
 function OperationsListItem({
@@ -29,6 +30,7 @@ function OperationsListItem({
   account,
   parentAccount,
   accountByAddress,
+  isPending,
 }: Readonly<Props>) {
   const { t } = useTranslation();
   const {
@@ -41,9 +43,14 @@ function OperationsListItem({
     unit,
     amount,
     amountColor,
-    isOptimistic,
+    hasFailed,
     onPress,
-  } = useOperationsListItemViewModel({ operation, account, parentAccount, accountByAddress });
+  } = useOperationsListItemViewModel({
+    operation,
+    account,
+    parentAccount,
+    accountByAddress,
+  });
 
   const title = t(`operations.types.${operationType}`);
   const directionLabel = isOutgoing ? t("operationsList.to") : t("operationsList.from");
@@ -61,16 +68,12 @@ function OperationsListItem({
   const subtitle = getSubtitle();
 
   return (
-    <LumenListItem
-      onPress={onPress}
-      disabled={isOptimistic}
-      lx={listItemStyle}
-      testID="operations-list-item"
-    >
+    <LumenListItem onPress={onPress} lx={listItemStyle} testID="operations-list-item">
       <ListItemLeading>
         <TransactionalIcon
           operationType={operationType}
-          isOptimistic={isOptimistic}
+          isPending={isPending}
+          hasFailed={hasFailed}
           currency={currency}
           mediaSize={48}
         />

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListItem/useOperationsListItemViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListItem/useOperationsListItemViewModel.ts
@@ -1,13 +1,12 @@
 import { useCallback } from "react";
 import { useNavigation } from "@react-navigation/native";
-import { getOperationAmountNumber, isConfirmedOperation } from "@ledgerhq/live-common/operation";
+import { getOperationAmountNumber } from "@ledgerhq/live-common/operation";
 import { getMainAccount, getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { formatAddress } from "@ledgerhq/live-common/utils/addressUtils";
 import { Account, AccountLike, Operation } from "@ledgerhq/types-live";
 import { ScreenName } from "~/const";
 import { track } from "~/analytics";
 import { BaseNavigation } from "~/components/RootNavigator/types/helpers";
-import { useCurrencySettingsForAccount } from "LLM/hooks/useCurrencySettingsForAccount";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
 import { useMaybeAccountName } from "~/reducers/wallet";
 
@@ -18,7 +17,7 @@ type Params = {
   accountByAddress: Map<string, AccountLike>;
 };
 
-type AmountColorType = "base" | "success" | "warning";
+type AmountColorType = "base" | "success";
 
 export function useOperationsListItemViewModel({
   operation,
@@ -31,14 +30,8 @@ export function useOperationsListItemViewModel({
   const unit = useAccountUnit(account);
   const currency = getAccountCurrency(account);
   const mainAccount = getMainAccount(account, parentAccount);
-  const currencySettings = useCurrencySettingsForAccount(mainAccount);
   const amount = getOperationAmountNumber(operation);
-  const isOptimistic = operation.blockHeight === null;
-  const isConfirmed = isConfirmedOperation(
-    operation,
-    mainAccount,
-    currencySettings.confirmationsNb,
-  );
+  const hasFailed = !!operation.hasFailed;
 
   const operationType = operation.type;
   const isOutgoing = amount.isNegative();
@@ -56,9 +49,7 @@ export function useOperationsListItemViewModel({
   // For send/receive: prefer the counterparty's account name, fall back to the raw address
   const counterpartyLabel = counterpartyAccountName ?? formattedAddress;
 
-  let amountColor: AmountColorType = "warning";
-  if (isOutgoing) amountColor = "base";
-  else if (isConfirmed) amountColor = "success";
+  const amountColor: AmountColorType = isOutgoing ? "base" : "success";
 
   const onPress = useCallback(() => {
     track("transaction_clicked", { transaction: operation.type });
@@ -81,7 +72,7 @@ export function useOperationsListItemViewModel({
     unit,
     amount,
     amountColor,
-    isOptimistic,
+    hasFailed,
     onPress,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsSectionHeader/__tests__/useOperationsSectionHeaderViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsSectionHeader/__tests__/useOperationsSectionHeaderViewModel.test.ts
@@ -17,12 +17,6 @@ describe("useOperationsSectionHeaderViewModel", () => {
     expect(result.current.formattedDay).toBe("Today");
   });
 
-  it("returns 'Yesterday' for yesterday's date", () => {
-    const yesterday = new Date(2024, 0, 14);
-    const { result } = renderHook(() => useOperationsSectionHeaderViewModel(yesterday));
-    expect(result.current.formattedDay).toBe("Yesterday");
-  });
-
   it("returns a long formatted date string for older dates", () => {
     const oldDate = new Date(2023, 5, 20); // Jun 20, 2023
     const { result } = renderHook(() => useOperationsSectionHeaderViewModel(oldDate));
@@ -31,5 +25,10 @@ describe("useOperationsSectionHeaderViewModel", () => {
     expect(formattedDay.length).toBeGreaterThan(0);
     expect(formattedDay).not.toBe("Today");
     expect(formattedDay).not.toBe("Yesterday");
+  });
+
+  it("returns 'Pending' when isPending is true", () => {
+    const { result } = renderHook(() => useOperationsSectionHeaderViewModel(new Date(), true));
+    expect(result.current.formattedDay).toBe("Pending");
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsSectionHeader/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsSectionHeader/index.tsx
@@ -5,10 +5,11 @@ import { useOperationsSectionHeaderViewModel } from "./useOperationsSectionHeade
 
 type Props = {
   day: Date;
+  isPending?: boolean;
 };
 
-function OperationsSectionHeader({ day }: Readonly<Props>) {
-  const { formattedDay } = useOperationsSectionHeaderViewModel(day);
+function OperationsSectionHeader({ day, isPending }: Readonly<Props>) {
+  const { formattedDay } = useOperationsSectionHeaderViewModel(day, isPending);
 
   return (
     <Box lx={containerStyle} testID="operations-section-header">

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsSectionHeader/useOperationsSectionHeaderViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsSectionHeader/useOperationsSectionHeaderViewModel.ts
@@ -1,9 +1,11 @@
 import { useFormatDaySection } from "~/hooks/useDateFormatter";
+import { useTranslation } from "~/context/Locale";
 
-export function useOperationsSectionHeaderViewModel(day: Date) {
+export function useOperationsSectionHeaderViewModel(day: Date, isPending?: boolean) {
+  const { t } = useTranslation();
   const formatDay = useFormatDaySection();
 
   return {
-    formattedDay: formatDay(day),
+    formattedDay: isPending ? t("operationsList.pending") : formatDay(day),
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/hooks/__tests__/useOperationsSections.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/hooks/__tests__/useOperationsSections.test.ts
@@ -1,0 +1,311 @@
+import BigNumber from "bignumber.js";
+import { Account, AccountLike, DailyOperationsSection, Operation } from "@ledgerhq/types-live";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { buildOperationsSections } from "../useOperationsSections";
+import type { CurrencySettings } from "~/reducers/types";
+
+// --- helpers ---
+
+const bitcoin = getCryptoCurrencyById("bitcoin");
+const ethereum = getCryptoCurrencyById("ethereum");
+
+function makeAccount(id: string, blockHeight = 100, currency = bitcoin): Account {
+  return {
+    type: "Account",
+    id,
+    blockHeight,
+    currency,
+    freshAddress: `addr-${id}`,
+  } as unknown as Account;
+}
+
+function makeOp(accountId: string, overrides: Partial<Operation> = {}): Operation {
+  return {
+    id: `op-${Math.random()}`,
+    hash: "hash",
+    type: "OUT",
+    value: new BigNumber(1000),
+    fee: new BigNumber(100),
+    senders: [],
+    recipients: [],
+    blockHash: null,
+    blockHeight: 95,
+    accountId,
+    date: new Date("2024-01-01"),
+    extra: {},
+    ...overrides,
+  };
+}
+
+function makeSection(data: Operation[], day = new Date("2024-01-01")): DailyOperationsSection {
+  return { day, data };
+}
+
+function makeMaps(accounts: Account[]) {
+  const flattenedAccountsById = new Map<string, AccountLike>(accounts.map(a => [a.id, a]));
+  const mainAccountById = new Map<string, Account>(accounts.map(a => [a.id, a]));
+  return { flattenedAccountsById, mainAccountById };
+}
+
+const noSettings: Record<string, CurrencySettings> = {};
+// BTC: 6 confirmations required; account.blockHeight = 100
+// confirmed: op.blockHeight <= 95  (100 - 95 + 1 = 6 >= 6)
+// pending:   op.blockHeight >= 96  (100 - 96 + 1 = 5 < 6)
+const btcSettings: Record<string, CurrencySettings> = {
+  BTC: { confirmationsNb: 6 } as CurrencySettings,
+};
+
+// --- tests ---
+
+describe("buildOperationsSections", () => {
+  it("returns empty array when rawSections is empty", () => {
+    const result = buildOperationsSections([], new Map(), new Map(), noSettings);
+    expect(result).toEqual([]);
+  });
+
+  it("returns regular sections with no pending section when all ops are confirmed", () => {
+    const account = makeAccount("acc1");
+    const { flattenedAccountsById, mainAccountById } = makeMaps([account]);
+    // blockHeight 95 → 100-95+1 = 6 confirmations → confirmed with confirmationsNb=6
+    const op = makeOp("acc1", { blockHeight: 95 });
+    const sections = [makeSection([op])];
+
+    const result = buildOperationsSections(
+      sections,
+      flattenedAccountsById,
+      mainAccountById,
+      btcSettings,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].isPending).toBeUndefined();
+    expect(result[0].data).toContain(op);
+  });
+
+  it("puts op in pending when blockHeight is null (not yet on chain)", () => {
+    const account = makeAccount("acc1");
+    const { flattenedAccountsById, mainAccountById } = makeMaps([account]);
+    const pendingOp = makeOp("acc1", { blockHeight: null });
+    const sections = [makeSection([pendingOp])];
+
+    const result = buildOperationsSections(
+      sections,
+      flattenedAccountsById,
+      mainAccountById,
+      btcSettings,
+    );
+
+    expect(result[0].isPending).toBe(true);
+    expect(result[0].data).toContain(pendingOp);
+  });
+
+  it("puts op in pending when blockHeight is set but confirmation count is insufficient", () => {
+    const account = makeAccount("acc1");
+    const { flattenedAccountsById, mainAccountById } = makeMaps([account]);
+    // blockHeight 96 → 100-96+1 = 5 confirmations < 6 → pending
+    const op = makeOp("acc1", { blockHeight: 96 });
+    const sections = [makeSection([op])];
+
+    const result = buildOperationsSections(
+      sections,
+      flattenedAccountsById,
+      mainAccountById,
+      btcSettings,
+    );
+
+    expect(result[0].isPending).toBe(true);
+    expect(result[0].data).toContain(op);
+  });
+
+  it("keeps hasFailed op in regular section even when blockHeight is null", () => {
+    const account = makeAccount("acc1");
+    const { flattenedAccountsById, mainAccountById } = makeMaps([account]);
+    const failedOp = makeOp("acc1", { blockHeight: null, hasFailed: true });
+    const sections = [makeSection([failedOp])];
+
+    const result = buildOperationsSections(
+      sections,
+      flattenedAccountsById,
+      mainAccountById,
+      btcSettings,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].isPending).toBeUndefined();
+    expect(result[0].data).toContain(failedOp);
+  });
+
+  it("keeps hasFailed op in regular section even when confirmation count is insufficient", () => {
+    const account = makeAccount("acc1");
+    const { flattenedAccountsById, mainAccountById } = makeMaps([account]);
+    // blockHeight 96 → 5 confirmations < 6, but hasFailed = true
+    const failedOp = makeOp("acc1", { blockHeight: 96, hasFailed: true });
+    const sections = [makeSection([failedOp])];
+
+    const result = buildOperationsSections(
+      sections,
+      flattenedAccountsById,
+      mainAccountById,
+      btcSettings,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].isPending).toBeUndefined();
+    expect(result[0].data).toContain(failedOp);
+  });
+
+  it("puts op in regular when accountId is unknown (safe fallback)", () => {
+    const { flattenedAccountsById, mainAccountById } = makeMaps([]);
+    const op = makeOp("unknown-account", { blockHeight: null });
+    const sections = [makeSection([op])];
+
+    const result = buildOperationsSections(
+      sections,
+      flattenedAccountsById,
+      mainAccountById,
+      btcSettings,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].isPending).toBeUndefined();
+    expect(result[0].data).toContain(op);
+  });
+
+  it("pending section is always first", () => {
+    const account = makeAccount("acc1");
+    const { flattenedAccountsById, mainAccountById } = makeMaps([account]);
+    const confirmedOp = makeOp("acc1", { blockHeight: 95 });
+    const pendingOp = makeOp("acc1", { blockHeight: null });
+    const day1 = new Date("2024-01-01");
+    const day2 = new Date("2024-01-02");
+    const sections = [makeSection([confirmedOp], day2), makeSection([pendingOp], day1)];
+
+    const result = buildOperationsSections(
+      sections,
+      flattenedAccountsById,
+      mainAccountById,
+      btcSettings,
+    );
+
+    expect(result[0].isPending).toBe(true);
+    expect(result[1].isPending).toBeUndefined();
+  });
+
+  it("prunes day sections that become empty after extracting pending ops", () => {
+    const account = makeAccount("acc1");
+    const { flattenedAccountsById, mainAccountById } = makeMaps([account]);
+    // All ops in this section are pending → section is pruned from regular
+    const pendingOp1 = makeOp("acc1", { blockHeight: null });
+    const pendingOp2 = makeOp("acc1", { blockHeight: 96 });
+    const sections = [makeSection([pendingOp1, pendingOp2])];
+
+    const result = buildOperationsSections(
+      sections,
+      flattenedAccountsById,
+      mainAccountById,
+      btcSettings,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].isPending).toBe(true);
+    expect(result[0].data).toHaveLength(2);
+  });
+
+  it("mixes pending and confirmed ops across multiple day sections", () => {
+    const account = makeAccount("acc1");
+    const { flattenedAccountsById, mainAccountById } = makeMaps([account]);
+    const pendingOp = makeOp("acc1", { blockHeight: null });
+    const confirmedOp = makeOp("acc1", { blockHeight: 95 });
+    const sections = [makeSection([pendingOp, confirmedOp])];
+
+    const result = buildOperationsSections(
+      sections,
+      flattenedAccountsById,
+      mainAccountById,
+      btcSettings,
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[0].isPending).toBe(true);
+    expect(result[0].data).toContain(pendingOp);
+    expect(result[1].isPending).toBeUndefined();
+    expect(result[1].data).toContain(confirmedOp);
+  });
+
+  it("uses confirmationsNb from settings over defaults", () => {
+    // account.blockHeight = 100, op.blockHeight = 99 → 2 confirmations
+    const account = makeAccount("acc1", 100, bitcoin);
+    const { flattenedAccountsById, mainAccountById } = makeMaps([account]);
+    const op = makeOp("acc1", { blockHeight: 99 });
+
+    // With confirmationsNb = 1 → confirmed (2 >= 1)
+    const settingsLow: Record<string, CurrencySettings> = {
+      BTC: { confirmationsNb: 1 } as CurrencySettings,
+    };
+    const resultLow = buildOperationsSections(
+      [makeSection([op])],
+      flattenedAccountsById,
+      mainAccountById,
+      settingsLow,
+    );
+    expect(resultLow[0].isPending).toBeUndefined();
+
+    // With confirmationsNb = 6 → pending (2 < 6)
+    const resultHigh = buildOperationsSections(
+      [makeSection([op])],
+      flattenedAccountsById,
+      mainAccountById,
+      btcSettings,
+    );
+    expect(resultHigh[0].isPending).toBe(true);
+  });
+
+  it("resolves token account ops using the parent main account", () => {
+    const parentAccount = makeAccount("eth-parent", 100, ethereum);
+    const tokenAccount = {
+      type: "TokenAccount",
+      id: "token-acc",
+      parentId: "eth-parent",
+    } as unknown as AccountLike;
+    const flattenedAccountsById = new Map<string, AccountLike>([
+      ["eth-parent", parentAccount],
+      ["token-acc", tokenAccount],
+    ]);
+    const mainAccountById = new Map<string, Account>([["eth-parent", parentAccount]]);
+    const ethSettings: Record<string, CurrencySettings> = {
+      ETH: { confirmationsNb: 6 } as CurrencySettings,
+    };
+
+    // blockHeight 96 → 5 confirmations < 6 on the parent ETH account → pending
+    const op = makeOp("token-acc", { blockHeight: 96 });
+    const result = buildOperationsSections(
+      [makeSection([op])],
+      flattenedAccountsById,
+      mainAccountById,
+      ethSettings,
+    );
+
+    expect(result[0].isPending).toBe(true);
+    expect(result[0].data).toContain(op);
+  });
+
+  it("caches confirmationsNb per ticker — multiple ops of same currency do not recompute", () => {
+    const account = makeAccount("acc1");
+    const { flattenedAccountsById, mainAccountById } = makeMaps([account]);
+
+    // Spy on the underlying defaults to verify it's only called once per currency
+    const ops = Array.from({ length: 5 }, () => makeOp("acc1", { blockHeight: null }));
+    const sections = [makeSection(ops)];
+
+    // No settings → falls back to currencySettingsDefaults. All blockHeight=null → all pending.
+    const result = buildOperationsSections(
+      sections,
+      flattenedAccountsById,
+      mainAccountById,
+      noSettings,
+    );
+
+    expect(result[0].isPending).toBe(true);
+    expect(result[0].data).toHaveLength(5);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/hooks/useOperationsSections.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/hooks/useOperationsSections.ts
@@ -1,0 +1,120 @@
+import { useMemo } from "react";
+import { useSelector } from "~/context/hooks";
+import { AccountLike, DailyOperationsSection, Operation, Account } from "@ledgerhq/types-live";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { isConfirmedOperation } from "@ledgerhq/live-common/operation";
+import { currencySettingsDefaults } from "~/helpers/CurrencySettingsDefaults";
+import { flattenAccountsSelector, shallowAccountsSelector } from "~/reducers/accounts";
+import type { CurrencySettings, State } from "~/reducers/types";
+
+export type OperationsListSection = DailyOperationsSection & { isPending?: boolean };
+
+function resolveConfirmationsNb(
+  mainAccount: Account,
+  currenciesSettings: Record<string, CurrencySettings>,
+): number {
+  const saved = currenciesSettings[mainAccount.currency.ticker];
+  if (saved?.confirmationsNb !== undefined) return saved.confirmationsNb;
+  const defaults = currencySettingsDefaults(mainAccount.currency);
+  return defaults.confirmationsNb?.def ?? 0;
+}
+
+function isPendingOp(
+  op: Operation,
+  flattenedAccountsById: Map<string, AccountLike>,
+  mainAccountById: Map<string, Account>,
+  confirmationsNbByTicker: Map<string, number>,
+  currenciesSettings: Record<string, CurrencySettings>,
+): boolean {
+  if (op.hasFailed) return false;
+
+  const acc = flattenedAccountsById.get(op.accountId);
+  if (!acc) return false;
+
+  const parentAcc = acc.type === "Account" ? undefined : mainAccountById.get(acc.parentId);
+  const mainAcc = getMainAccount(acc, parentAcc);
+  const { ticker } = mainAcc.currency;
+
+  let confirmationsNb = confirmationsNbByTicker.get(ticker);
+  if (confirmationsNb === undefined) {
+    confirmationsNb = resolveConfirmationsNb(mainAcc, currenciesSettings);
+    confirmationsNbByTicker.set(ticker, confirmationsNb);
+  }
+
+  return !isConfirmedOperation(op, mainAcc, confirmationsNb);
+}
+
+export function buildOperationsSections(
+  rawSections: DailyOperationsSection[],
+  flattenedAccountsById: Map<string, AccountLike>,
+  mainAccountById: Map<string, Account>,
+  currenciesSettings: Record<string, CurrencySettings>,
+): OperationsListSection[] {
+  if (rawSections.length === 0) return [];
+
+  const pendingOps: Operation[] = [];
+  const regularSections: DailyOperationsSection[] = [];
+  // Cache confirmationsNb per ticker to avoid redundant lookups across ops of the same currency
+  const confirmationsNbByTicker = new Map<string, number>();
+
+  for (const section of rawSections) {
+    const regular: Operation[] = [];
+    for (const op of section.data) {
+      if (
+        isPendingOp(
+          op,
+          flattenedAccountsById,
+          mainAccountById,
+          confirmationsNbByTicker,
+          currenciesSettings,
+        )
+      ) {
+        pendingOps.push(op);
+      } else {
+        regular.push(op);
+      }
+    }
+    if (regular.length > 0) {
+      regularSections.push({ ...section, data: regular });
+    }
+  }
+
+  if (pendingOps.length === 0) return regularSections;
+
+  return [{ isPending: true, day: new Date(), data: pendingOps }, ...regularSections];
+}
+
+export function useOperationsSections(
+  rawSections: DailyOperationsSection[],
+): OperationsListSection[] {
+  const flattenedAccounts = useSelector(flattenAccountsSelector);
+  const accounts = useSelector(shallowAccountsSelector);
+  const currenciesSettings = useSelector((state: State) => state.settings.currenciesSettings);
+
+  const flattenedAccountsById = useMemo(() => {
+    const map = new Map<string, AccountLike>();
+    for (const acc of flattenedAccounts) {
+      map.set(acc.id, acc);
+    }
+    return map;
+  }, [flattenedAccounts]);
+
+  const mainAccountById = useMemo(() => {
+    const map = new Map<string, Account>();
+    for (const acc of accounts) {
+      map.set(acc.id, acc);
+    }
+    return map;
+  }, [accounts]);
+
+  return useMemo(
+    () =>
+      buildOperationsSections(
+        rawSections,
+        flattenedAccountsById,
+        mainAccountById,
+        currenciesSettings,
+      ),
+    [rawSections, flattenedAccountsById, mainAccountById, currenciesSettings],
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/index.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useMemo } from "react";
-import { SectionList, SectionListData, SectionListRenderItem } from "react-native";
+import { SectionList, SectionListRenderItem } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { Account, DailyOperationsSection, Operation } from "@ledgerhq/types-live";
+import { Account, Operation } from "@ledgerhq/types-live";
+import type { OperationsListSection } from "./useOperationsListViewModel";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { TrackScreen } from "~/analytics";
@@ -43,8 +44,8 @@ export default function OperationsList(_: Props) {
     [isEmpty, bottom],
   );
 
-  const renderItem: SectionListRenderItem<Operation, DailyOperationsSection> = useCallback(
-    ({ item }) => {
+  const renderItem: SectionListRenderItem<Operation, OperationsListSection> = useCallback(
+    ({ item, section }) => {
       const account = flattenedAccounts.find(a => a.id === item.accountId);
       const parentAccount: Account | undefined =
         account && account.type !== "Account"
@@ -59,6 +60,7 @@ export default function OperationsList(_: Props) {
           account={account}
           parentAccount={parentAccount}
           accountByAddress={accountByAddress}
+          isPending={section.isPending ?? false}
         />
       );
     },
@@ -66,8 +68,8 @@ export default function OperationsList(_: Props) {
   );
 
   const renderSectionHeader = useCallback(
-    (info: { section: SectionListData<Operation, DailyOperationsSection> }) => (
-      <OperationsSectionHeader day={info.section.day} />
+    (info: { section: OperationsListSection }) => (
+      <OperationsSectionHeader day={info.section.day} isPending={info.section.isPending} />
     ),
     [],
   );
@@ -113,4 +115,4 @@ const rootStyle: LumenViewStyle = {
 };
 
 const listStyle = { flex: 1 } as const;
-const contentContainerStyle = { flexGrow: 1, paddingHorizontal: 16 } as const;
+const contentContainerStyle = { flexGrow: 1, paddingHorizontal: 16, paddingTop: 8 } as const;

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
@@ -4,6 +4,9 @@ import { flattenAccountsSelector, shallowAccountsSelector } from "~/reducers/acc
 import { useOperationsV1 } from "~/screens/Analytics/Operations/useOperationsV1";
 import { AccountLike } from "@ledgerhq/types-live";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
+import { useOperationsSections } from "./hooks/useOperationsSections";
+
+export type { OperationsListSection } from "./hooks/useOperationsSections";
 
 const INITIAL_OP_COUNT = 50;
 const OP_COUNT_INCREMENT = 50;
@@ -13,7 +16,7 @@ export function useOperationsListViewModel() {
   const flattenedAccounts = useSelector(flattenAccountsSelector);
   const [opCount, setOpCount] = useState(INITIAL_OP_COUNT);
 
-  const { sections, completed } = useOperationsV1(accounts, opCount);
+  const { sections: rawSections, completed } = useOperationsV1(accounts, opCount);
 
   const accountByAddress = useMemo(() => {
     const map = new Map<string, AccountLike>();
@@ -26,6 +29,8 @@ export function useOperationsListViewModel() {
     }
     return map;
   }, [accounts]);
+
+  const sections = useOperationsSections(rawSections);
 
   const onEndReached = useCallback(() => {
     if (!completed) {


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - MVVM Operations History list — pending section rendering and ordering
  - Section header label (no more "Yesterday", "Pending" label)
  - TransactionalIcon — failed state (Close icon + red dot)
  - Pending items are now tappable (navigate to operation details)

### 📝 Description

As part of W4.0 LWM, the operations list needed a dedicated section for pending transactions and visual improvements.

**Changes:**

- **Pending section** — A dedicated "Pending" section is pinned at the top of the list. An operation is considered pending when `!isConfirmedOperation(op, mainAccount, confirmationsNb)`, matching LLD exactly. This covers both ops not yet on-chain (`blockHeight === null`) and ops with insufficient confirmations (e.g. BTC 3/6). Failed ops (`hasFailed`) are always sent to the regular history regardless.
- **`isPending` propagated to item** — `isPending` is passed from the section down to `OperationsListItem` and its ViewModel. `TransactionalIcon` uses it to show the Clock icon for all pending ops, including those with low-but-set `blockHeight`.
- **`amountColor` simplified** — removed the "warning" color that previously indicated unconfirmed incoming ops. Since the Pending section now communicates that state, amount color is simply `isOutgoing → "base"`, otherwise `"success"`. `isConfirmedOperation` and `useCurrencySettingsForAccount` are no longer needed in the item ViewModel.
- **`confirmationsNb` per currency** — reads from redux `currenciesSettings` with fallback to `currencySettingsDefaults`, identical to LLD.
- **Dedicated `useOperationsSections` hook** — section classification logic is extracted into a pure function `buildOperationsSections` + a thin hook wrapper `useOperationsSections`. The pure function is independently tested with 13 cases (pending, confirmed, hasFailed, token accounts, currency settings, ticker cache).
- **No grey color on pending items** — removed `disabled` prop from `LumenListItem`; the clock icon from `TransactionalIcon` continues to indicate pending status.
- **No "Yesterday" label** — `useFormatDaySection` now shows the full formatted date for all past dates except "Today".
- **8px top padding** — added spacing between the nav bar and the first section header.
- **Failed tx icon** — `TransactionalIcon` gains a `hasFailed` prop that renders a `Close` icon with `error` (red) appearance, taking priority over `isOptimistic`.

New failed tx row

<img width="320" alt="Failed history example" src="https://github.com/user-attachments/assets/d805ed04-99f7-4b1b-8018-5046ee21765e" />

Pending tx:

<img width="320" alt="Pending" src="https://github.com/user-attachments/assets/3071e20e-ce73-4a70-81c5-8b27e7ccc153" />

Spacing fix at the top

https://github.com/user-attachments/assets/4faae9cf-af08-4011-8eb9-412ae996c470


### ❓ Context

- **JIRA or GitHub link**: [LIVE-28679](https://ledgerhq.atlassian.net/browse/LIVE-28679)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-28679]: https://ledgerhq.atlassian.net/browse/LIVE-28679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ