### PR TITLE
[LWDM] test(coin-tezos): move integ tests from Ghostnet to Shadownet

### DIFF
--- a/.changeset/silly-penguins-return.md
+++ b/.changeset/silly-penguins-return.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tezos": patch
+---
+
+Migrate Tezos integration tests off Ghostnet to Shadownet (Ghostnet was deprecated in early 2026, its TzKT and RPC endpoints stopped resolving). Pinned a persistent Shadownet test account (`tz1dKrT1...`) with reveal/delegation/stake/unstake history, plus a tz2 (`tz29GPjg...`) and a registered baker as a delegate target. `getBlock` and `getBlockInfo` integ tests now pin block 3113219. `craftTransaction.integ.test.ts` only had a stale Ghostnet docstring — updated to reflect that it actually runs against mainnet via the Ledger vault explorer.

--- a/libs/coin-modules/coin-tezos/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.integ.test.ts
@@ -56,20 +56,33 @@ describe("Tezos Api", () => {
     });
   });
 
-  // Multi-curve recipient handling — sender is the persistent tz1 staker.
-  // Each row picks a recipient with a different curve prefix to verify estimation
-  // doesn't reject any standard tz address shape.
+  // Multi-curve sender handling — each row exercises estimateFees with a sender
+  // address + matching senderPublicKey for a different curve, covering the
+  // pubkey-normalization + sender-derivation path in api/index.ts.
   it.each([
-    ["ed25519 / tz1 recipient", "tz1dKrT1h6d7wP8fEzMPptG6er7mLLeQjBBY"],
-    ["secp256k1 / tz2 recipient", "tz29GPjgeRQTRX6mcPQXkiuHnq7jbya1Abnq"],
-    ["P256 / tz3 recipient", "tz3Q67aMz7gSMiQRcW729sXSfuMtkyAHYfqc"],
-  ])("does not fail when providing a %s", async (_, recipient) => {
+    [
+      "ed25519 / tz1",
+      "tz1dKrT1h6d7wP8fEzMPptG6er7mLLeQjBBY",
+      "edpkv2EJVgdvaK8TB5mMttfN93jRhHwoyKcy9sehANdeMDNY27zkjz",
+    ],
+    [
+      "secp256k1 / tz2",
+      "tz29GPjgeRQTRX6mcPQXkiuHnq7jbya1Abnq",
+      "sppk7cWw2W2H9Uf7zWAju13smtbETcPbLpDGFZtpB7TAoDsVFiAizhf",
+    ],
+    [
+      "P256 / tz3",
+      "tz3Q67aMz7gSMiQRcW729sXSfuMtkyAHYfqc",
+      "p2pk66gP3wq6k9QgNwAgaGLeXc3YFfrxgYdC7cdYuJWAHYBw4hExVHW",
+    ],
+  ])("does not fail when providing a %s sender with pub key", async (_, sender, pubKey) => {
     const result = await module.estimateFees({
       intentType: "transaction",
       asset: { type: "native" },
       type: "send",
-      sender: address,
-      recipient,
+      sender,
+      senderPublicKey: pubKey,
+      recipient: address,
       amount: BigInt(100),
     } as SendTransactionIntent);
 

--- a/libs/coin-modules/coin-tezos/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.integ.test.ts
@@ -6,8 +6,8 @@ import { createApi } from ".";
 
 const defaultConfig: TezosConfig = {
   baker: { url: "https://baker.example.com" },
-  explorer: { url: "https://api.ghostnet.tzkt.io", maxTxQuery: 100 },
-  node: { url: "https://rpc.ghostnet.teztnets.com" },
+  explorer: { url: "https://api.shadownet.tzkt.io", maxTxQuery: 100 },
+  node: { url: "https://rpc.shadownet.teztnets.com" },
   fees: {
     minGasLimit: 600,
     minRevealGasLimit: 300,
@@ -18,13 +18,17 @@ const defaultConfig: TezosConfig = {
 };
 
 /**
- * Ghostnet-specific integration tests
- * https://teztnets.com/ghostnet-about
- * https://api.tzkt.io/#section/Get-Started/Free-TzKT-API
+ * Shadownet-specific integration tests (Ghostnet was deprecated in early 2026).
+ * https://teztnets.com/shadownet-about
+ * https://api.shadownet.tzkt.io
  */
 describe("Tezos Api", () => {
   let module: TezosApi;
-  const address = "tz1heMGVHQnx7ALDcDKqez8fan64Eyicw4DJ";
+  // Persistent Shadownet test account — see LIVE-28763 PR for chain-of-custody.
+  const address = "tz1dKrT1h6d7wP8fEzMPptG6er7mLLeQjBBY";
+  // Registered baker on Shadownet, distinct from `address`'s current delegate
+  // (TF Test Baker) — picked so `delegate` intents don't simulate as `delegate.unchanged`.
+  const baker = "tz1a28g3f7Eswy7XfX81sJSdhBHZqMjkfaf9";
 
   beforeAll(() => {
     module = createApi(defaultConfig);
@@ -41,7 +45,7 @@ describe("Tezos Api", () => {
         asset: { type: "native" },
         type: "send",
         sender: address,
-        recipient: "tz1heMGVHQnx7ALDcDKqez8fan64Eyicw4DJ",
+        recipient: address,
         amount,
       });
 
@@ -52,35 +56,23 @@ describe("Tezos Api", () => {
     });
   });
 
+  // Multi-curve recipient handling — sender is the persistent tz1 staker.
+  // Each row picks a recipient with a different curve prefix to verify estimation
+  // doesn't reject any standard tz address shape.
   it.each([
-    [
-      "ed25519 / tz1",
-      "tz1heMGVHQnx7ALDcDKqez8fan64Eyicw4DJ",
-      "6D9733FB7E27C56F032FAD41E4C0C90D58D0D5F1A253B2430B702071B57E47C1",
-    ],
-    [
-      "secp256k1 / tz2",
-      "tz2DvEBHrtFkq9pTXqt6yavnf4sPe2jut2XH",
-      "032fede4de54cf92381832a053f0787125fdc0d065d231585eb34d5eae327c0222",
-    ],
-    [
-      "P256 / tz3",
-      "tz3DvEBHrtFkq9pTXqt6yavnf4sPe2jut2XH",
-      "0466839a78481025e3613f65fcd4b492a492bedd1a3cba77ae48eaa1803611d8e5f4e23c0d0f3586e2095f4f83d09c841e1c17586b2356d5d3a3ed3f45bb3a857e",
-    ],
-  ])("does not fail when providing a %s address with pub key", async (_, sender, pubKey) => {
-    // When
+    ["ed25519 / tz1 recipient", "tz1dKrT1h6d7wP8fEzMPptG6er7mLLeQjBBY"],
+    ["secp256k1 / tz2 recipient", "tz29GPjgeRQTRX6mcPQXkiuHnq7jbya1Abnq"],
+    ["P256 / tz3 recipient", "tz3Q67aMz7gSMiQRcW729sXSfuMtkyAHYfqc"],
+  ])("does not fail when providing a %s", async (_, recipient) => {
     const result = await module.estimateFees({
       intentType: "transaction",
       asset: { type: "native" },
       type: "send",
-      sender: "tz3DvEBHrtFkq9pTXqt6yavnf4sPe2jut2XH",
-      senderPublicKey: pubKey,
-      recipient: sender,
+      sender: address,
+      recipient,
       amount: BigInt(100),
     } as SendTransactionIntent);
 
-    // Then
     expect(result.value).toBeGreaterThanOrEqual(BigInt(0));
     expect(result.parameters?.gasLimit).toBeGreaterThanOrEqual(BigInt(0));
     expect(result.parameters?.storageLimit).toBeGreaterThanOrEqual(BigInt(0));
@@ -182,7 +174,8 @@ describe("Tezos Api", () => {
     }
 
     it.each(["send", "delegate", "undelegate"])("returns a raw transaction with %s", async type => {
-      const recipient = "tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9";
+      // `delegate` requires a registered baker; the others accept any tz address.
+      const recipient = type === "delegate" ? baker : "tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9";
       const amount = BigInt(10);
       // When
       const { transaction: encodedTransaction } = await module.craftTransaction({
@@ -284,7 +277,7 @@ describe("Tezos Api", () => {
           asset: { type: "native" },
           type: "delegate",
           sender: address,
-          recipient: "tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9",
+          recipient: baker,
           amount: BigInt(0),
         });
         expect(result.value).toBeGreaterThanOrEqual(BigInt(minFees));
@@ -312,7 +305,7 @@ describe("Tezos Api", () => {
           asset: { type: "native" },
           type: "delegate",
           sender: address,
-          recipient: "tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9",
+          recipient: baker,
           amount: BigInt(0),
         });
         const decoded = await localForger.parse(encodedTransaction.slice(2));

--- a/libs/coin-modules/coin-tezos/src/logic/craftTransaction.integ.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/craftTransaction.integ.test.ts
@@ -4,7 +4,10 @@ import { mockConfig } from "../test/config";
 import { craftTransaction } from ".";
 
 /**
- * https://teztnets.com/ghostnet-about
+ * Runs against Tezos mainnet via Ledger's vault explorer (see `mockConfig`).
+ * Despite the directory's other integ tests using Shadownet, this file does
+ * not query a testnet — Taquito reaches the mainnet RPC for counter / reveal
+ * estimation while ops themselves are forged locally and never broadcast.
  * https://api.tzkt.io/#section/Get-Started/Free-TzKT-API
  */
 describe("Tezos Api", () => {

--- a/libs/coin-modules/coin-tezos/src/logic/getBlock.integ.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBlock.integ.test.ts
@@ -2,21 +2,22 @@ import coinConfig, { type TezosCoinConfig } from "../config";
 import { getBlock } from "./getBlock";
 
 /**
- * Integration tests for getBlock against Ghostnet (Tezos testnet).
- * https://ghostnet.tzkt.io
+ * Integration tests for getBlock against Shadownet (current Tezos testnet of record;
+ * Ghostnet was deprecated in early 2026).
+ * https://shadownet.tzkt.io
  *
- * Block 7000018 was chosen because it contains exactly one simple XTZ
- * transfer with no token transfers, making assertions deterministic.
+ * Block 3113219 was chosen because it contains exactly one simple XTZ transfer
+ * (1 mutez from a tz2 to a tz1), making the assertions deterministic.
  */
 
 let originalGetCoinConfig: () => TezosCoinConfig;
 
-const ghostnetConfig = (): TezosCoinConfig =>
+const shadownetConfig = (): TezosCoinConfig =>
   ({
     status: { type: "active" },
     baker: { url: "https://tezos-bakers.api.live.ledger.com" },
-    explorer: { url: "https://api.ghostnet.tzkt.io", maxTxQuery: 100 },
-    node: { url: "https://rpc.ghostnet.teztnets.com" },
+    explorer: { url: "https://api.shadownet.tzkt.io", maxTxQuery: 100 },
+    node: { url: "https://rpc.shadownet.teztnets.com" },
     fees: {
       minGasLimit: 0,
       minRevealGasLimit: 0,
@@ -29,7 +30,7 @@ const ghostnetConfig = (): TezosCoinConfig =>
 describe("getBlock", () => {
   beforeAll(() => {
     originalGetCoinConfig = coinConfig.getCoinConfig;
-    coinConfig.setCoinConfig(ghostnetConfig);
+    coinConfig.setCoinConfig(shadownetConfig);
   });
 
   afterAll(() => {
@@ -38,40 +39,40 @@ describe("getBlock", () => {
     }
   });
 
-  it("should fetch and parse block 7000018 correctly", async () => {
-    const block = await getBlock(7000018);
+  it("should fetch and parse block 3113219 correctly", async () => {
+    const block = await getBlock(3113219);
 
     expect(block.info).toMatchObject({
-      hash: "BMFAFwCfNXmnMhjawY2BDbUp9LP4dNvrPS8pG5hkidf3NaCQuYu",
-      height: 7000018,
-      time: new Date("2024-07-09T06:00:05.000Z"),
+      hash: "BLAf8kVQvpsgXNA914eLo3gJKauywozjuravm7cmdvZ9VEM4QyK",
+      height: 3113219,
+      time: new Date("2026-04-29T08:27:12Z"),
       parent: {
-        height: 7000017,
-        hash: "BLEATbXULXDWCpdzCbYVuRALsxHMvDta2rhYQQmrpqX9JWc5mJh",
+        height: 3113218,
+        hash: "BLtMGf5iBPGq2c98iXWVX6Z5xK4V227Sm7cCTjyiQ9ufRJRgBmf",
       },
     });
 
     expect(block.transactions).toHaveLength(1);
 
     const tx0 = block.transactions[0];
-    expect(tx0.hash).toBe("op4Ftafc4kmPXgTooA4DqaA9jdTWwSUZ39s5UkfqS13h6oM7gzh");
+    expect(tx0.hash).toBe("onktfPphnYKAm7yJ2DLWPn3ZHKmx9U6sAiSYSwrpUUimL6ivbr5");
     expect(tx0.failed).toBe(false);
-    expect(tx0.fees).toBe(1420n);
-    expect(tx0.feesPayer).toBe("tz1N4KaEsfMqSaKW8r1YdAvT5AdenZdPagDR");
+    expect(tx0.fees).toBe(1500n);
+    expect(tx0.feesPayer).toBe("tz29GPjgeRQTRX6mcPQXkiuHnq7jbya1Abnq");
 
     expect(tx0.operations).toEqual(
       expect.arrayContaining([
         {
           type: "transfer",
-          address: "tz1N4KaEsfMqSaKW8r1YdAvT5AdenZdPagDR",
-          peer: "tz1irUSoD75PVSkWzxMHjEzxwEVm8FaMLczu",
+          address: "tz29GPjgeRQTRX6mcPQXkiuHnq7jbya1Abnq",
+          peer: "tz1dKrT1h6d7wP8fEzMPptG6er7mLLeQjBBY",
           asset: { type: "native", name: "XTZ" },
           amount: -1n,
         },
         {
           type: "transfer",
-          address: "tz1irUSoD75PVSkWzxMHjEzxwEVm8FaMLczu",
-          peer: "tz1N4KaEsfMqSaKW8r1YdAvT5AdenZdPagDR",
+          address: "tz1dKrT1h6d7wP8fEzMPptG6er7mLLeQjBBY",
+          peer: "tz29GPjgeRQTRX6mcPQXkiuHnq7jbya1Abnq",
           asset: { type: "native", name: "XTZ" },
           amount: 1n,
         },

--- a/libs/coin-modules/coin-tezos/src/logic/getBlockInfo.integ.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBlockInfo.integ.test.ts
@@ -3,21 +3,22 @@ import { getBlock } from "./getBlock";
 import { getBlockInfo } from "./getBlockInfo";
 
 /**
- * Integration tests for getBlockInfo against Ghostnet (Tezos testnet).
- * https://ghostnet.tzkt.io
+ * Integration tests for getBlockInfo against Shadownet (current Tezos testnet
+ * of record; Ghostnet was deprecated in early 2026).
+ * https://shadownet.tzkt.io
  *
- * Uses the same block 7000018 as getBlock.integ.test.ts so both files
- * cover consistent, independently verifiable data.
+ * Uses the same block 3113219 as getBlock.integ.test.ts so both files cover
+ * consistent, independently verifiable data.
  */
 
 let originalGetCoinConfig: () => TezosCoinConfig;
 
-const ghostnetConfig = (): TezosCoinConfig =>
+const shadownetConfig = (): TezosCoinConfig =>
   ({
     status: { type: "active" },
     baker: { url: "https://tezos-bakers.api.live.ledger.com" },
-    explorer: { url: "https://api.ghostnet.tzkt.io", maxTxQuery: 100 },
-    node: { url: "https://rpc.ghostnet.teztnets.com" },
+    explorer: { url: "https://api.shadownet.tzkt.io", maxTxQuery: 100 },
+    node: { url: "https://rpc.shadownet.teztnets.com" },
     fees: {
       minGasLimit: 0,
       minRevealGasLimit: 0,
@@ -30,7 +31,7 @@ const ghostnetConfig = (): TezosCoinConfig =>
 describe("getBlockInfo", () => {
   beforeAll(() => {
     originalGetCoinConfig = coinConfig.getCoinConfig;
-    coinConfig.setCoinConfig(ghostnetConfig);
+    coinConfig.setCoinConfig(shadownetConfig);
   });
 
   afterAll(() => {
@@ -39,23 +40,23 @@ describe("getBlockInfo", () => {
     }
   });
 
-  it("should fetch and parse block info for block 7000018 correctly", async () => {
-    const blockInfo = await getBlockInfo(7000018);
+  it("should fetch and parse block info for block 3113219 correctly", async () => {
+    const blockInfo = await getBlockInfo(3113219);
 
     expect(blockInfo).toMatchObject({
-      height: 7000018,
-      hash: "BMFAFwCfNXmnMhjawY2BDbUp9LP4dNvrPS8pG5hkidf3NaCQuYu",
-      time: new Date("2024-07-09T06:00:05.000Z"),
+      height: 3113219,
+      hash: "BLAf8kVQvpsgXNA914eLo3gJKauywozjuravm7cmdvZ9VEM4QyK",
+      time: new Date("2026-04-29T08:27:12Z"),
       parent: {
-        height: 7000017,
-        hash: "BLEATbXULXDWCpdzCbYVuRALsxHMvDta2rhYQQmrpqX9JWc5mJh",
+        height: 3113218,
+        hash: "BLtMGf5iBPGq2c98iXWVX6Z5xK4V227Sm7cCTjyiQ9ufRJRgBmf",
       },
     });
   });
 
   it("should return consistent data with getBlock for the same block", async () => {
-    const blockInfo = await getBlockInfo(7000018);
-    const block = await getBlock(7000018);
+    const blockInfo = await getBlockInfo(3113219);
+    const block = await getBlock(3113219);
 
     expect(blockInfo).toMatchObject({
       height: block.info.height,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Test infrastructure only — no production code, no public API surface, no consumer-visible behavior.
  - `pnpm test-integ` for `@ledgerhq/coin-tezos` goes from 26 failing → 53/53 passing. Unit suite + lint baseline unchanged.
  - New long-lived fixture: account `tz1dKrT1h6d7wP8fEzMPptG6er7mLLeQjBBY` on Shadownet. Tests that assert `tx.length >= 1` / `balance > 0` would fail if it gets drained — same operational pattern as the existing mainnet FA2 fixture.
  - QA: just run the integ suite once against live Shadownet and confirm green; nothing to verify on desktop/mobile/LLM clients.

### 📝 Description

Ghostnet was deprecated in early 2026 — its TzKT and RPC endpoints no longer resolve, leaving 26 of 53 Tezos integ tests silently failing on \`pnpm test-integ\`. This PR repoints them at Shadownet (the current testnet of record), pins a faucet-funded persistent account + a registered baker + block 3113219 as ground truth, and corrects a stale Ghostnet docstring on \`craftTransaction.integ.test.ts\` (which actually runs against mainnet via the Ledger vault).

### ❓ Context

- **JIRA**: [LIVE-30074](https://ledgerhq.atlassian.net/browse/LIVE-30074?atlOrigin=eyJpIjoiYjZmZDJjNzhkYWNmNGU0ZWIxMTRmNzVmZDZjNzUwYTYiLCJwIjoiaiJ9)

[LIVE-30074]: https://ledgerhq.atlassian.net/browse/LIVE-30074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ