### PR TITLE
[LWDM] fix(coin-vechain): fix valid vechain addresses rejected due to letter casing

### DIFF
--- a/.changeset/lovely-months-poke.md
+++ b/.changeset/lovely-months-poke.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-vechain": patch
+---
+
+Fix valid vechain addresses rejected due to letter casing.

--- a/libs/coin-modules/coin-vechain/src/common-logic/calculateClauses.test.ts
+++ b/libs/coin-modules/coin-vechain/src/common-logic/calculateClauses.test.ts
@@ -59,6 +59,8 @@ describe("calculateClauses", () => {
         "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
         "0x0000000000000000000000000000000000000000",
         "0xffffffffffffffffffffffffffffffffffffffff",
+        "0XABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCD", // all uppercase
+        "0XABcdEFABcdEFABcdEFABcdEFABcdEFABcdEFABcd", // mixed uppercase
       ];
 
       for (const recipient of recipients) {
@@ -69,7 +71,7 @@ describe("calculateClauses", () => {
 
         // Verify the recipient is encoded correctly in the data
         const expectedData = ABIContract.ofAbi(VIP180_ABI)
-          .encodeFunctionInput("transfer", [recipient, testAmount.toFixed()])
+          .encodeFunctionInput("transfer", [recipient.toLowerCase(), testAmount.toFixed()])
           .toString();
         expect(clauses[0].data).toBe(expectedData);
       }

--- a/libs/coin-modules/coin-vechain/src/common-logic/calculateClauses.ts
+++ b/libs/coin-modules/coin-vechain/src/common-logic/calculateClauses.ts
@@ -15,7 +15,7 @@ export const calculateClausesVtho = async (
     data: "0x",
   };
   updatedClause.data = ABIContract.ofAbi(VIP180_ABI)
-    .encodeFunctionInput("transfer", [recipient, amount.toFixed()])
+    .encodeFunctionInput("transfer", [recipient.toLowerCase(), amount.toFixed()])
     .toString();
 
   clauses.push(updatedClause);


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - `"@ledgerhq/coin-vechain": patch`

### 📝 Description

Fixes a bug where valid Vechain addresses would be rejected when the address includes uppercase characters - specifically when the f the casing doesn't match a specific EIP-55 checksum.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA link**: [LIVE-29271](https://ledgerhq.atlassian.net/browse/LIVE-29271)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-29271]: https://ledgerhq.atlassian.net/browse/LIVE-29271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ