### PR TITLE
[LWD] feat: add asset detail page header

### DIFF
--- a/.changeset/clear-pandas-accept.md
+++ b/.changeset/clear-pandas-accept.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add asset detail header with Lumen NavBar coin capsule, icon, and back navigation

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/AssetDetailView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/AssetDetailView.tsx
@@ -1,13 +1,29 @@
-import React from "react";
+import React, { useCallback } from "react";
+import { useNavigate } from "react-router";
+import CryptoCurrencyIcon from "~/renderer/components/CryptoCurrencyIcon";
 import { AssetDetailSection } from "./components/AssetDetailSection";
+import { AssetHeader } from "./components/AssetHeader/AssetHeader";
 import { useAssetDetailSections } from "./hooks/useAssetDetailSections";
 import type { AssetDetailViewModel } from "./hooks/useAssetDetailViewModel";
 
 export function AssetDetailView({ distributionItem }: Readonly<AssetDetailViewModel>) {
+  const navigate = useNavigate();
+  const onBack = useCallback(() => {
+    navigate(-1);
+  }, [navigate]);
+
   const { topSections, sections, notFoundContent } = useAssetDetailSections(distributionItem);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-32">
+      {distributionItem ? (
+        <AssetHeader
+          assetLabel={distributionItem.currency.name}
+          icon={<CryptoCurrencyIcon currency={distributionItem.currency} size={24} />}
+          onBack={onBack}
+        />
+      ) : null}
+
       <section className="grid grid-cols-2 gap-24">
         {topSections.map(section => (
           <AssetDetailSection

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/__integrations__/AssetDetail.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/__integrations__/AssetDetail.integration.test.tsx
@@ -34,6 +34,8 @@ describe("AssetDetail integration", () => {
 
     render(<AssetDetail />);
 
+    expect(screen.getByTestId("asset-detail-header")).toBeVisible();
+    expect(screen.getByText("Bitcoin")).toBeVisible();
     expect(screen.getByText("Market stats")).toBeVisible();
     expect(screen.getByText("Price performance")).toBeVisible();
     expect(screen.getByText("Placeholder market stats content")).toBeVisible();
@@ -60,6 +62,8 @@ describe("AssetDetail integration", () => {
 
     render(<AssetDetail />);
 
+    expect(screen.getByTestId("asset-detail-header")).toBeVisible();
+    expect(screen.getByText("Bitcoin Test")).toBeVisible();
     expect(screen.getByText("Market stats")).toBeVisible();
     expect(screen.getByText("Price performance")).toBeVisible();
     expect(screen.queryByText("Asset distribution item not found.")).not.toBeInTheDocument();

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AssetHeader/AssetHeader.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AssetHeader/AssetHeader.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import {
+  NavBar,
+  NavBarBackButton,
+  NavBarCoinCapsule,
+  NavBarTrailing,
+  IconButton,
+} from "@ledgerhq/lumen-ui-react";
+import { MoreVertical } from "@ledgerhq/lumen-ui-react/symbols";
+
+export type AssetHeaderProps = Readonly<{
+  /** Displayed in the coin capsule next to the icon. */
+  assetLabel: string;
+  icon: React.ReactNode;
+  onBack: () => void;
+}>;
+
+export function AssetHeader({ assetLabel, icon, onBack }: AssetHeaderProps) {
+  return (
+    <NavBar data-testid="asset-detail-header" className="w-full min-w-0 items-center gap-4">
+      <NavBarBackButton onClick={onBack} />
+      <NavBarCoinCapsule className="min-w-0 max-w-full" ticker={assetLabel} icon={icon} />
+      <NavBarTrailing>
+        <IconButton appearance="gray" size="sm" icon={MoreVertical} aria-label="Action" />
+      </NavBarTrailing>
+    </NavBar>
+  );
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Introduces a dedicated AssetHeader for the MVVM Asset Detail screen, using the Lumen NavBar pattern with NavBarCoinCapsule so the top of the page shows the asset icon, label (full asset name), and a back control. The header is only rendered when a matching distributionItem exists; the not-found state is unchanged.


https://github.com/user-attachments/assets/880dd351-ddfe-45a1-a338-60e47c3a1ac5


### ❓ Context

[LIVE-28841](https://ledgerhq.atlassian.net/browse/LIVE-28841)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-28841]: https://ledgerhq.atlassian.net/browse/LIVE-28841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ