### PR TITLE
[LWM] fix(mobile): add analytics info to mobile events

### DIFF
--- a/.changeset/bright-mobiles-consent.md
+++ b/.changeset/bright-mobiles-consent.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add analytics consent information to mobile analytics mandatory properties.

--- a/apps/ledger-live-mobile/src/analytics/__tests__/segment.readOnlyMode.test.ts
+++ b/apps/ledger-live-mobile/src/analytics/__tests__/segment.readOnlyMode.test.ts
@@ -15,6 +15,11 @@ const { _trackMock: mockTrack } = require("@segment/analytics-react-native") as 
   _trackMock: jest.Mock;
 };
 
+const analyticsConsentInfo = {
+  consentDate: "2026-04-29T00:00:00.000Z",
+  privacyPolicyVersion: 1,
+};
+
 const makeStore = (): AppStore =>
   configureStore({
     reducer: reducers,
@@ -39,12 +44,7 @@ describe("segment readOnlyMode", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     store = makeStore();
-    store.dispatch(
-      setAnalyticsConsentInfo({
-        consentDate: new Date().toISOString(),
-        privacyPolicyVersion: 1,
-      }),
-    );
+    store.dispatch(setAnalyticsConsentInfo(analyticsConsentInfo));
     store.dispatch(setAnalytics(true));
   });
 
@@ -89,6 +89,20 @@ describe("segment readOnlyMode", () => {
       expect(mockTrack).toHaveBeenCalledWith(
         "TestEvent",
         expect.objectContaining({ readOnlyMode: true }),
+      ),
+    );
+  });
+
+  it("track() includes analyticsInfo from consent state", async () => {
+    await segment.start(store);
+    mockTrack.mockClear();
+
+    segment.track("TestEvent", {});
+
+    await waitFor(() =>
+      expect(mockTrack).toHaveBeenCalledWith(
+        "TestEvent",
+        expect.objectContaining({ analyticsInfo: analyticsConsentInfo }),
       ),
     );
   });

--- a/apps/ledger-live-mobile/src/analytics/segment.ts
+++ b/apps/ledger-live-mobile/src/analytics/segment.ts
@@ -46,6 +46,7 @@ import {
   isRebornSelector,
   isOnboardingFlowSelector,
   isPostOnboardingFlowSelector,
+  analyticsConsentInfoSelector,
 } from "../reducers/settings";
 import { bleDevicesSelector } from "../reducers/ble";
 import { DeviceLike, State } from "../reducers/types";
@@ -189,6 +190,7 @@ const getMandatoryProperties = (store: AppStore) => {
   const hasSeenAnalyticsOptInPrompt = hasSeenAnalyticsOptInPromptSelector(state);
   const readOnlyMode = readOnlyModeEnabledSelector(state);
   const devModeEnabled = getEnv("MANAGER_DEV_MODE");
+  const analyticsInfo = analyticsConsentInfoSelector(state);
 
   return {
     userId: userIdStr,
@@ -198,6 +200,7 @@ const getMandatoryProperties = (store: AppStore) => {
     optInPersonalRecommendations: personalizedRecommendationsEnabled,
     hasSeenAnalyticsOptInPrompt,
     readOnlyMode,
+    analyticsInfo,
   };
 };
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Mobile analytics mandatory properties
  - Analytics Consent rollout reporting on LWM
  - Existing opt-in and read-only mandatory analytics properties

### 📝 Description

Mobile analytics was missing the mandatory `analyticsInfo` property, while desktop already sends it from `analyticsConsentInfoSelector`. This made LWM analytics incomplete for Analytics Consent rollout reporting compared with LWD.

This PR adds `analyticsInfo` to mobile mandatory analytics properties using the existing mobile `analyticsConsentInfoSelector`, while keeping the existing mandatory properties unchanged.

**Before**: LWM sent opt-in analytics properties but omitted `analyticsInfo`.

**After**: LWM sends `analyticsInfo` from consent state, matching LWD.

<img width="393" height="569" alt="image" src="https://github.com/user-attachments/assets/09c305fc-7823-4a60-8146-1213ccbe853f" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-30024](https://ledgerhq.atlassian.net/browse/LIVE-30024)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-30024]: https://ledgerhq.atlassian.net/browse/LIVE-30024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ