### PR TITLE
[LWDM] fix(coin-sui): normalize address in alpacaGetOperationAmount

### DIFF
--- a/.changeset/fix-coin-sui-alpaca-address-normalize.md
+++ b/.changeset/fix-coin-sui-alpaca-address-normalize.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-sui": patch
+---
+
+fix(coin-sui): normalize address in `alpacaGetOperationAmount` so that AlpacaApi.listOperations resolves operation amounts when the account address omits `0x` or differs in hex casing from RPC `AddressOwner` values

--- a/libs/coin-modules/coin-sui/src/network/sdk.test.ts
+++ b/libs/coin-modules/coin-sui/src/network/sdk.test.ts
@@ -688,6 +688,38 @@ describe("SDK Functions", () => {
     expect(op.value.toString()).toBe("9998990120");
   });
 
+  test("alpacaTransactionToOp resolves amount when account address omits 0x or casing differs from RPC", () => {
+    const addressNoPrefix = "6e143fe0a8ca010a86580dafac44298e5b1b7d73efc345356a59a15f0d7824f0";
+
+    const suiTx = {
+      ...mockTransaction,
+      balanceChanges: [
+        {
+          owner: {
+            AddressOwner: "0x65449f57946938c84c512732f1d69405d1fce417d9c9894696ddf4522f479e24",
+          },
+          coinType: sdk.DEFAULT_COIN_TYPE,
+          amount: "-10000000000",
+        },
+        {
+          owner: {
+            AddressOwner:
+              "0x6E143FE0A8CA010A86580DAFAC44298E5B1B7D73EFC345356A59A15F0D7824F0",
+          },
+          coinType: sdk.DEFAULT_COIN_TYPE,
+          amount: "9998990120",
+        },
+      ],
+    };
+
+    const op = sdk.alpacaTransactionToOp(
+      addressNoPrefix,
+      suiTx as SuiTransactionBlockResponse,
+      "mockCheckpointHash",
+    );
+    expect(op.value).toBe(9998990120n);
+  });
+
   test("transactionToOp should map token transaction to operation", () => {
     const address = "0x6e143fe0a8ca010a86580dafac44298e5b1b7d73efc345356a59a15f0d7824f0";
 

--- a/libs/coin-modules/coin-sui/src/network/sdk.ts
+++ b/libs/coin-modules/coin-sui/src/network/sdk.ts
@@ -535,12 +535,14 @@ export const alpacaGetOperationAmount = (
       return removeFeesFromAmountForNative(changes[0], getOperationFee(transaction)).abs();
     return BigNumber(0);
   } else {
+    const normalizedAddress = normalizeSuiAddressForComparison(address);
     return changes
       .filter(
         balanceChange =>
           typeof balanceChange.owner !== "string" &&
           "AddressOwner" in balanceChange.owner &&
-          balanceChange.owner.AddressOwner === address &&
+          normalizeSuiAddressForComparison(balanceChange.owner.AddressOwner) ===
+            normalizedAddress &&
           balanceChange.coinType === coinType,
       )
       .map(change => {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Added a regression test in sdk.test.ts parallel to the one introduced for `transactionToOperation` in 23e4e441fb. Verified the test fails on the pre-fix code (`Expected: 9998990120n, Received: 0n`) and passes on the patched code (full sdk.test.ts suite: 161/161 green).
- [x] **Impact of the changes:**
  - Affects only `@ledgerhq/coin-sui`'s Alpaca path: `AlpacaApi.listOperations` → `getListOperations` → `alpacaTransactionToOp` → `alpacaGetOperationAmount`.
  - QA focus: SUI operation history through the Alpaca bridge — verify per-operation `value` is correct (non-zero) for native SUI and token transfers, including when the local account address derivation differs from the RPC's `AddressOwner` casing/prefix.
  - No change to the legacy bridge path (`transactionToOperation`), no API surface change, no schema or storage change.

### 📝 Description

PR 23e4e441fb ("fix: account address omits 0x from rpc call") introduced `normalizeSuiAddressForComparison` and applied it inside the legacy `getOperationAmount` so that the caller-supplied account address can match RPC `BalanceChange.owner.AddressOwner` values that differ in `0x` prefix or hex casing.

The fix was not propagated to the parallel Alpaca-path function `alpacaGetOperationAmount` in the same file, which still used a raw `balanceChange.owner.AddressOwner === address` filter. As a consequence, every consumer of the SUI Alpaca API silently received `value: 0n` for the user's own balance changes whenever the caller-derived address did not byte-equal the RPC payload — producing zero-value operations in operation history.

The data path of the bug:

```
AlpacaApi.listOperations
  → libs/coin-modules/coin-sui/src/logic/listOperations.ts
  → getListOperations              (network/sdk.ts)
  → alpacaTransactionToOp          (network/sdk.ts:601)
  → alpacaGetOperationAmount       (network/sdk.ts, the buggy filter)
```

#### Before

```ts
return changes
  .filter(
    balanceChange =>
      typeof balanceChange.owner !== "string" &&
      "AddressOwner" in balanceChange.owner &&
      balanceChange.owner.AddressOwner === address &&        // raw ===
      balanceChange.coinType === coinType,
  )
  ...
```

#### After

```ts
const normalizedAddress = normalizeSuiAddressForComparison(address);
return changes
  .filter(
    balanceChange =>
      typeof balanceChange.owner !== "string" &&
      "AddressOwner" in balanceChange.owner &&
      normalizeSuiAddressForComparison(balanceChange.owner.AddressOwner) ===
        normalizedAddress &&
      balanceChange.coinType === coinType,
  )
  ...
```

This mirrors the existing fix already applied to `getOperationAmount` so both paths handle the same inputs identically.

#### Test (regression)

Added in sdk.test.ts, parallel to the one introduced in 23e4e441fb:

```ts
test("alpacaTransactionToOp resolves amount when account address omits 0x or casing differs from RPC", () => {
  const addressNoPrefix = "6e143fe0a8ca010a86580dafac44298e5b1b7d73efc345356a59a15f0d7824f0";

  const suiTx = {
    ...mockTransaction,
    balanceChanges: [
      { owner: { AddressOwner: "0x65449f57...e24" }, coinType: sdk.DEFAULT_COIN_TYPE, amount: "-10000000000" },
      { owner: { AddressOwner: "0x6E143FE0A8CA010A86580DAFAC44298E5B1B7D73EFC345356A59A15F0D7824F0" }, coinType: sdk.DEFAULT_COIN_TYPE, amount: "9998990120" },
    ],
  };

  const op = sdk.alpacaTransactionToOp(addressNoPrefix, suiTx as SuiTransactionBlockResponse, "mockCheckpointHash");
  expect(op.value).toBe(9998990120n);
});
```

Pre-fix run: `Expected: 9998990120n, Received: 0n`. Post-fix run: passes alongside all 160 other tests in the suite.

### ❓ Context

- **JIRA or GitHub link**: follow-up to the merged commit 23e4e441fb ("fix: account address omits 0x from rpc call") which patched the legacy `getOperationAmount` but left the parallel Alpaca-path function unchanged.
- **ADR link (if any)**: n/a

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)