### PR TITLE
[LWDM] fix(analytics): track consent screens as mandatory

### DIFF
--- a/.changeset/calm-consents-track.md
+++ b/.changeset/calm-consents-track.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Fix mandatory analytics consent tracking for desktop and mobile.

--- a/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/__tests__/addAccountFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/__tests__/addAccountFlow.test.tsx
@@ -176,7 +176,7 @@ function expectTrackPage(
   props: { flow?: string; reason?: string } = {},
   source = "MADSource",
 ) {
-  expect(trackPage).toHaveBeenNthCalledWith(n, page, undefined, { ...props, source }, true, true);
+  expect(trackPage).toHaveBeenNthCalledWith(n, page, undefined, { ...props, source }, true, true, false);
 }
 
 describe("ModularDrawerAddAccountFlowManager", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/__integrations__/AnalyticsConsentDialog.portfolio.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/__integrations__/AnalyticsConsentDialog.portfolio.integration.test.tsx
@@ -3,6 +3,7 @@ import { Route, Routes } from "react-router";
 import { render, screen, waitFor, within } from "tests/testSetup";
 import { FEATURE_FLAGS_INITIAL_STATE } from "@shared/feature-flags";
 import { INITIAL_STATE } from "~/renderer/reducers/settings";
+import { trackPage } from "~/renderer/analytics/segment";
 import { AnalyticsConsentDialog } from "../index";
 
 const featureFlagsWithAnalyticsOptIn = {
@@ -49,6 +50,10 @@ function TestRouter() {
 }
 
 describe("AnalyticsConsentDialog on portfolio route", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("shows fresh consent when renewal is needed and share analytics is off", async () => {
     render(<TestRouter />, {
       initialRoute: "/",
@@ -65,7 +70,52 @@ describe("AnalyticsConsentDialog on portfolio route", () => {
       await screen.findByRole("heading", { name: "Help us improve Ledger" }),
     ).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /close/i })).not.toBeInTheDocument();
+    expect(trackPage).toHaveBeenCalledWith(
+      "AnalyticsConsentDialog",
+      "Analytics consent",
+      {
+        type: "modal",
+        phase: "consentFresh",
+      },
+      true,
+      false,
+      true,
+    );
   });
+
+  it.each([
+    { shareAnalytics: false, sharePersonalizedRecommandations: false },
+    { shareAnalytics: true, sharePersonalizedRecommandations: false },
+    { shareAnalytics: false, sharePersonalizedRecommandations: true },
+    { shareAnalytics: true, sharePersonalizedRecommandations: true },
+  ])(
+    "tracks the consent dialog page as mandatory telemetry when consent is $shareAnalytics/$sharePersonalizedRecommandations",
+    async ({ shareAnalytics, sharePersonalizedRecommandations }) => {
+      render(<TestRouter />, {
+        initialRoute: "/",
+        initialState: {
+          featureFlags: featureFlagsWithAnalyticsOptIn,
+          settings: baseSettings({
+            shareAnalytics,
+            sharePersonalizedRecommandations,
+          }),
+        },
+      });
+
+      await screen.findByTestId("analytics-consent-dialog");
+
+      expect(trackPage).toHaveBeenCalledWith(
+        "AnalyticsConsentDialog",
+        "Analytics consent",
+        expect.objectContaining({
+          type: "modal",
+        }),
+        true,
+        false,
+        true,
+      );
+    },
+  );
 
   it("shows reconfirm copy when renewal is needed and share analytics is on", async () => {
     render(<TestRouter />, {

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/screens/AnalyticsConsentDialogView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/screens/AnalyticsConsentDialogView.tsx
@@ -69,6 +69,7 @@ export function AnalyticsConsentDialogView({
             type="modal"
             phase={phase}
             refreshSource={false}
+            mandatory
           />
           {phase === "preferences" ? (
             <AnalyticsConsentPreferencesView

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/__tests__/selectAccountFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/__tests__/selectAccountFlow.test.tsx
@@ -329,6 +329,7 @@ describe("ModularDialogFlowManager - Select Account Flow", () => {
       },
       true,
       true,
+      false,
     );
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/analytics/__tests__/TrackDialogScreen.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/analytics/__tests__/TrackDialogScreen.test.tsx
@@ -6,6 +6,10 @@ import { MODULAR_DIALOG_PAGE_NAME } from "../modularDialog.types";
 import { trackPage } from "~/renderer/analytics/segment";
 
 describe("TrackDialogScreen", () => {
+  beforeEach(() => {
+    jest.mocked(trackPage).mockReset();
+  });
+
   it("calls track page with flow and source", () => {
     const page = MODULAR_DIALOG_PAGE_NAME.MODULAR_ASSET_SELECTION;
     const params = { flow: "flowtest", source: "sourcetest" };
@@ -18,6 +22,7 @@ describe("TrackDialogScreen", () => {
       { flow: "flowtest", source: "sourcetest" },
       true,
       true,
+      false,
     );
   });
 
@@ -42,6 +47,7 @@ describe("TrackDialogScreen", () => {
       },
       true,
       true,
+      false,
     );
   });
 
@@ -70,6 +76,7 @@ describe("TrackDialogScreen", () => {
       },
       true,
       true,
+      false,
     );
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/analytics/TrackPage.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/analytics/TrackPage.test.tsx
@@ -1,0 +1,94 @@
+jest.unmock("./segment");
+jest.unmock("~/renderer/analytics/segment");
+jest.unmock("src/renderer/analytics/segment");
+
+jest.mock("~/renderer/logger", () => ({
+  __esModule: true,
+  default: {
+    analyticsPage: jest.fn(),
+    analyticsStart: jest.fn(),
+    analyticsTrack: jest.fn(),
+    onReduxAction: jest.fn(),
+  },
+}));
+
+import React from "react";
+import { render, waitFor } from "tests/testSetup";
+import createStore from "~/state-manager/configureStore";
+import type { State } from "~/renderer/reducers";
+import { INITIAL_STATE as SETTINGS_INITIAL_STATE } from "~/renderer/reducers/settings";
+import logger from "~/renderer/logger";
+import TrackPage from "./TrackPage";
+import { startAnalytics, trackSubject, type LoggableEvent } from "./segment";
+
+const createStoreWithAnalyticsDisabled = () =>
+  createStore({
+    state: {
+      settings: {
+        ...SETTINGS_INITIAL_STATE,
+        shareAnalytics: false,
+        sharePersonalizedRecommandations: false,
+        lastAnalyticsConsentDate: null,
+      },
+    } as State,
+  });
+
+describe("TrackPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should only send page tracking without consent when mandatory", async () => {
+    const events: LoggableEvent[] = [];
+    const subscription = trackSubject.subscribe(event => events.push(event));
+    events.length = 0;
+
+    try {
+      const store = createStoreWithAnalyticsDisabled();
+      await startAnalytics(store);
+
+      const { rerender } = render(
+        <TrackPage category="Analytics Consent" name="Optional" flow="test-flow" />,
+        { store },
+      );
+
+      expect(events).toEqual([]);
+      expect(logger.analyticsPage).not.toHaveBeenCalled();
+
+      rerender(
+        <TrackPage category="Analytics Consent" name="Mandatory" flow="test-flow" mandatory />,
+      );
+
+      await waitFor(() => expect(events).toHaveLength(1));
+      expect(events[0]).toEqual(
+        expect.objectContaining({
+          eventName: "Page Analytics Consent Mandatory",
+          eventProperties: expect.objectContaining({
+            flow: "test-flow",
+            optInAnalytics: false,
+            optInPersonalRecommendations: false,
+            analyticsInfo: {
+              consentDate: null,
+              privacyPolicyVersion: null,
+            },
+          }),
+          eventPropertiesWithoutExtra: {
+            source: undefined,
+            flow: "test-flow",
+          },
+        }),
+      );
+      expect(logger.analyticsPage).toHaveBeenCalledWith(
+        "Analytics Consent",
+        "Mandatory",
+        expect.objectContaining({
+          flow: "test-flow",
+          optInAnalytics: false,
+          optInPersonalRecommendations: false,
+        }),
+      );
+    } finally {
+      subscription.unsubscribe();
+    }
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/analytics/TrackPage.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/TrackPage.ts
@@ -28,6 +28,10 @@ type Props = {
    * name should not override the "source".
    */
   refreshSource?: boolean;
+  /**
+   * When true, send the page event even if standard analytics tracking is disabled.
+   */
+  mandatory?: boolean;
   [key: string]: unknown;
 };
 
@@ -35,10 +39,16 @@ type Props = {
  * On mount, this component will track an event which will have the name
  * `Page ${category}${name ? " " + name : ""}`.
  */
-const TrackPage: React.FC<Props> = ({ category, name, refreshSource = true, ...properties }) => {
+const TrackPage: React.FC<Props> = ({
+  category,
+  name,
+  refreshSource = true,
+  mandatory = false,
+  ...properties
+}) => {
   useEffect(() => {
-    trackPage(category, name, properties, true, refreshSource);
-  }, [category, name, properties, refreshSource]);
+    trackPage(category, name, properties, true, refreshSource, mandatory);
+  }, [category, name, properties, refreshSource, mandatory]);
   return null;
 };
 

--- a/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
@@ -543,8 +543,12 @@ export const trackPage = (
    * any effect.
    */
   refreshSource?: boolean,
+  /**
+   * When true, event will be sent even if standard analytics tracking is disabled.
+   */
+  mandatory?: boolean,
 ) => {
-  if (!storeInstance || !trackingEnabledSelector(storeInstance.getState())) {
+  if (!storeInstance || (!mandatory && !trackingEnabledSelector(storeInstance.getState()))) {
     return;
   }
 
@@ -563,7 +567,7 @@ export const trackPage = (
   };
   const allProperties = {
     ...eventPropertiesWithoutExtra,
-    ...extraProperties(storeInstance),
+    ...(mandatory ? getMandatoryProperties(storeInstance) : extraProperties(storeInstance)),
   };
   logger.analyticsPage(category, name, allProperties);
   sendTrack(eventName, allProperties);

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/SelfTransferModal/SelfTransferStepRecipient.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/SelfTransferModal/SelfTransferStepRecipient.test.tsx
@@ -83,6 +83,7 @@ describe("SelfTransferStepRecipient", () => {
       expect.objectContaining({ currencyName: "Aleo" }),
       true,
       true,
+      false,
     );
   });
 

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/SendTransferModal/AleoSendStepRecipient.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/SendTransferModal/AleoSendStepRecipient.test.tsx
@@ -117,6 +117,7 @@ describe("AleoSendStepRecipient", () => {
       expect.objectContaining({ currencyName: "Aleo" }),
       true,
       true,
+      false,
     );
   });
 

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/__tests__/addAccountFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/__tests__/addAccountFlow.test.tsx
@@ -172,7 +172,7 @@ function expectTrackPage(
   props: { flow?: string; reason?: string } = {},
   source = "MADSource",
 ) {
-  expect(trackPage).toHaveBeenNthCalledWith(n, page, undefined, { ...props, source }, true, true);
+  expect(trackPage).toHaveBeenNthCalledWith(n, page, undefined, { ...props, source }, true, true, false);
 }
 
 describe("ModularDrawerAddAccountFlowManager", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/__integrations__/AnalyticsConsentDrawer.portfolio.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/__integrations__/AnalyticsConsentDrawer.portfolio.integration.test.tsx
@@ -97,6 +97,14 @@ const overridePortfolioWithPrivacySheet = composePortfolioOverrides({
 });
 
 describe("AnalyticsConsentDrawer on Portfolio", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   describe("needs fresh consent", () => {
     it("should opt in and close the drawer when the user taps Accept all on the fresh consent sheet", async () => {
       const { user, store } = renderWithReactQuery(<IntegrationNavigator />, {
@@ -114,6 +122,53 @@ describe("AnalyticsConsentDrawer on Portfolio", () => {
       expect(store.getState().settings.analyticsEnabled).toBe(true);
       expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
     });
+
+    it.each([
+      {
+        analyticsEnabled: false,
+        personalizedRecommendationsEnabled: false,
+      },
+      {
+        analyticsEnabled: true,
+        personalizedRecommendationsEnabled: false,
+      },
+      {
+        analyticsEnabled: false,
+        personalizedRecommendationsEnabled: true,
+      },
+      {
+        analyticsEnabled: true,
+        personalizedRecommendationsEnabled: true,
+      },
+    ])(
+      "should track the consent drawer page as mandatory telemetry when consent is $analyticsEnabled/$personalizedRecommendationsEnabled",
+      async ({ analyticsEnabled, personalizedRecommendationsEnabled }) => {
+        renderWithReactQuery(<IntegrationNavigator />, {
+          overrideInitialState: composePortfolioOverrides({
+            hasCompletedOnboarding: true,
+            analyticsOptInEnabled: true,
+            analyticsEnabled,
+            personalizedRecommendationsEnabled,
+            consentDate: null,
+            privacyPolicyVersion: 1,
+          }),
+        });
+
+        await waitFor(() => {
+          expect(analytics.screen).toHaveBeenCalledWith(
+            "AnalyticsConsentDrawer",
+            "Analytics consent",
+            expect.objectContaining({
+              type: "drawer",
+            }),
+            true,
+            false,
+            false,
+            true,
+          );
+        });
+      },
+    );
 
     it("should opt out and close the drawer when the user taps Refuse all on the fresh consent sheet", async () => {
       const { user, store } = renderWithReactQuery(<IntegrationNavigator />, {
@@ -146,35 +201,41 @@ describe("AnalyticsConsentDrawer on Portfolio", () => {
         expect(screen.queryByText("Help us improve Ledger")).toBeNull();
       });
       expect(await screen.findByTestId("analytics-preferences-screen-title")).toBeVisible();
+      expect(analytics.screen).toHaveBeenCalledWith(
+        "Analytics preferences settings",
+        "Set preferences",
+        {},
+        true,
+        true,
+        false,
+        true,
+      );
     });
 
     it("should return to Portfolio after Set preferences and Confirm with toggles left off", async () => {
-      const updateIdentifySpy = jest.spyOn(analytics, "updateIdentify").mockResolvedValue(undefined);
-      try {
-        const { user, store } = renderWithReactQuery(<IntegrationNavigator />, {
-          overrideInitialState: overridePortfolioWithAnalyticsConsentDrawer,
-        });
+      jest.spyOn(analytics, "updateIdentify").mockResolvedValue(undefined);
 
-        await screen.findByTestId("PortfolioEmptyList");
-        await screen.findByText("Help us improve Ledger");
+      const { user, store } = renderWithReactQuery(<IntegrationNavigator />, {
+        overrideInitialState: overridePortfolioWithAnalyticsConsentDrawer,
+      });
 
-        await user.press(screen.getByText("Set preferences"));
+      await screen.findByTestId("PortfolioEmptyList");
+      await screen.findByText("Help us improve Ledger");
 
-        expect(await screen.findByTestId("analytics-preferences-screen-title")).toBeVisible();
+      await user.press(screen.getByText("Set preferences"));
 
-        await user.press(screen.getByRole("button", { name: "Confirm" }));
+      expect(await screen.findByTestId("analytics-preferences-screen-title")).toBeVisible();
 
-        await waitFor(() => {
-          expect(screen.queryByTestId("analytics-preferences-screen-title")).toBeNull();
-        });
-        expect(await screen.findByTestId("PortfolioEmptyList")).toBeVisible();
+      await user.press(screen.getByRole("button", { name: "Confirm" }));
 
-        expect(store.getState().settings.analyticsEnabled).toBe(false);
-        expect(store.getState().settings.personalizedRecommendationsEnabled).toBe(false);
-        expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
-      } finally {
-        updateIdentifySpy.mockRestore();
-      }
+      await waitFor(() => {
+        expect(screen.queryByTestId("analytics-preferences-screen-title")).toBeNull();
+      });
+      expect(await screen.findByTestId("PortfolioEmptyList")).toBeVisible();
+
+      expect(store.getState().settings.analyticsEnabled).toBe(false);
+      expect(store.getState().settings.personalizedRecommendationsEnabled).toBe(false);
+      expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/screens/AnalyticsConsentDrawerView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/screens/AnalyticsConsentDrawerView.tsx
@@ -101,6 +101,7 @@ export function AnalyticsConsentDrawerView(props: AnalyticsConsentDrawerViewProp
             type="drawer"
             phase={phase}
             refreshSource={false}
+            mandatory
           />
           {sheetChrome}
         </>

--- a/apps/ledger-live-mobile/src/screens/Settings/AnalyticsPreferencesSettings/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/AnalyticsPreferencesSettings/index.tsx
@@ -8,7 +8,12 @@ import {
   analyticsEnabledSelector,
   personalizedRecommendationsEnabledSelector,
 } from "~/reducers/settings";
-import { setAnalytics, setAnalyticsConsentInfo, setHasSeenAnalyticsOptInPrompt, setPersonalizedRecommendations } from "~/actions/settings";
+import {
+  setAnalytics,
+  setAnalyticsConsentInfo,
+  setHasSeenAnalyticsOptInPrompt,
+  setPersonalizedRecommendations,
+} from "~/actions/settings";
 import { ScreenName } from "~/const";
 import { TrackScreen, track, updateIdentify } from "~/analytics";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
@@ -19,7 +24,10 @@ import { ConsentFooter } from "LLM/features/AnalyticsConsentDrawer/components/Co
 import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import type { SettingsNavigatorStackParamList } from "~/components/RootNavigator/types/SettingsNavigator";
 
-type Props = StackNavigatorProps<SettingsNavigatorStackParamList, ScreenName.AnalyticsPreferencesSettings>;
+type Props = StackNavigatorProps<
+  SettingsNavigatorStackParamList,
+  ScreenName.AnalyticsPreferencesSettings
+>;
 
 export default function AnalyticsPreferencesSettings({ navigation, route }: Props) {
   const { t } = useTranslation();
@@ -81,7 +89,7 @@ export default function AnalyticsPreferencesSettings({ navigation, route }: Prop
 
   return (
     <Box lx={{ flex: 1, backgroundColor: "canvas" }}>
-      <TrackScreen category="Analytics preferences settings" name="Set preferences" />
+      <TrackScreen category="Analytics preferences settings" name="Set preferences" mandatory />
       <Box lx={{ paddingHorizontal: "s16", paddingBottom: "s12" }}>
         <Text
           typography="heading3SemiBold"


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Analytics consent dialog tracking on Ledger Wallet Desktop
  - Analytics consent drawer tracking on Ledger Wallet Mobile
  - Analytics preferences settings tracking on Ledger Wallet Mobile
  - Mandatory analytics events when standard analytics consent is disabled

### 📝 Description

Mandatory analytics consent screens need to be tracked even when the user has not opted into standard analytics. Before this change, desktop page tracking returned early when analytics tracking was disabled, so consent screen impressions could be missed.

This PR adds mandatory page tracking support on desktop and applies it to the analytics consent dialog. It also marks the mobile consent drawer and analytics preferences settings tracking as mandatory, with focused tests covering consent-on and consent-off states on both desktop and mobile.

<table>
<tr>
 <td>

https://github.com/user-attachments/assets/ddd73e09-85c2-4e3f-b2a7-b1a7d59734b4


 <td>

https://github.com/user-attachments/assets/81311ff9-548b-40bb-a3d0-2d91eab4409a


</table>

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30023](https://ledgerhq.atlassian.net/browse/LIVE-30023)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-30023]: https://ledgerhq.atlassian.net/browse/LIVE-30023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ