### PR TITLE
[LWDM] fix(common): use latest Speculos firmware for Nano S

### DIFF
--- a/.changeset/calm-nanos-select.md
+++ b/.changeset/calm-nanos-select.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Fix Speculos firmware selection for Nano S E2E flows

--- a/libs/ledger-live-common/src/e2e/speculosAppVersion.ts
+++ b/libs/ledger-live-common/src/e2e/speculosAppVersion.ts
@@ -98,14 +98,15 @@ export async function getDeviceFirmwareVersion(device: DeviceModelId): Promise<s
     );
   }
 
-  // Second-latest is chosen by second-highest numeric ID (falls back to sole entry if only one exists)
+  // Nano S uses latest firmware; other devices use n-1.
   const sortedByIdDesc = [...providerFirmwares].sort((a, b) => b.id - a.id);
-  const firmwareBeforeLatest = sortedByIdDesc.length >= 2 ? sortedByIdDesc[1]! : sortedByIdDesc[0]!;
+  const firmwareIndex = device === DeviceModelId.nanoS ? 0 : 1;
+  const firmware = sortedByIdDesc[firmwareIndex] ?? sortedByIdDesc[0]!;
 
-  firmwareVersionCache.set(device, firmwareBeforeLatest.version);
-  process.env.SPECULOS_FIRMWARE_VERSION = firmwareBeforeLatest.version;
+  firmwareVersionCache.set(device, firmware.version);
+  process.env.SPECULOS_FIRMWARE_VERSION = firmware.version;
 
-  return firmwareBeforeLatest.version;
+  return firmware.version;
 }
 
 export async function createNanoAppJsonFile(nanoAppFilePath: string): Promise<void> {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Validated with typecheck/format locally; Desktop E2E executions are linked below._
- [x] **Impact of the changes:**
  - Nano S Speculos firmware selection for E2E flows
  - Other Speculos devices should keep using the n-1 firmware version

### 📝 Description

The Speculos E2E helper currently selects the firmware version before the latest one for every device. That behavior breaks Nano S/LNS flows, which need to use the production/latest firmware version.

This PR keeps the existing n-1 behavior for non-Nano S devices, but selects the latest firmware when the Speculos model is Nano S.

CI executions:

- Desktop E2E nanoSP: https://github.com/LedgerHQ/ledger-live/actions/runs/25107960502
- Desktop E2E nanoS: https://github.com/LedgerHQ/ledger-live/actions/runs/25107884115

### ❓ Context

- **JIRA or GitHub link**: https://github.com/LedgerHQ/ledger-live/pull/16853

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)