### PR TITLE
test(mobile): add swap UI and config e2e coverage

### DIFF
--- a/e2e/mobile/page/liveApps/swapLiveApp.ts
+++ b/e2e/mobile/page/liveApps/swapLiveApp.ts
@@ -26,6 +26,8 @@ export default class SwapLiveAppPage {
   insufficientFundsBuyButton = "insufficient-funds-buy-button";
   swapMaxToggle = "from-account-max-toggle";
   switchButton = "to-account-switch-accounts";
+  lnsUnsupportedBannerPattern =
+    /Ledger Nano S[\s\S]*(not supported|unsupported|does not support|not compatible)/i;
   specificQuoteCardProviderName = (provider: string) =>
     `compact-quote-card-provider-name-${provider}`;
 
@@ -229,6 +231,7 @@ export default class SwapLiveAppPage {
       jestExpect(bestOffer?.quote).toContain("Best Offer");
     } catch (error) {
       console.error("Error checking Best offer:", sanitizeError(error));
+      throw error;
     }
   }
 
@@ -243,15 +246,15 @@ export default class SwapLiveAppPage {
   async extractQuotesAndFees(quoteContainers: string[]) {
     const quotePattern = /\$(\d+\.\d+)[\s\S]*?Network Fees[\s\S]*?\$(\d+\.\d+)/;
 
-    const quotes = quoteContainers
-      .map(q => {
+    const quotes: Array<{ rate: number; fees: number; quote: string }> = quoteContainers.flatMap(
+      q => {
         const match = q.match(quotePattern);
         if (match) {
-          return { rate: parseFloat(match[1]), fees: parseFloat(match[2]), quote: q };
+          return [{ rate: parseFloat(match[1]), fees: parseFloat(match[2]), quote: q }];
         }
-        return undefined;
-      })
-      .filter(Boolean) as Array<{ rate: number; fees: number; quote: string }>;
+        return [];
+      },
+    );
 
     if (quotes.length === 0) {
       throw new Error("No quotes found");
@@ -310,6 +313,12 @@ export default class SwapLiveAppPage {
     jestExpect(amountToSend).toEqual(amount);
   }
 
+  @Step("Check currency to swap from contains $0")
+  async checkAssetFromContains(currency: string) {
+    const fromAccount: string = await getWebElementText(this.fromSelector);
+    jestExpect(fromAccount).toContain(currency);
+  }
+
   @Step("Check currency to swap to is $0 with amount $1")
   async checkAssetTo(currency: string, amount: string) {
     const assetTo: string = await getWebElementText(this.toSelector);
@@ -320,6 +329,24 @@ export default class SwapLiveAppPage {
     }
     const amountToReceive = await app.swapLiveApp.getAmountToReceive();
     jestExpect(amountToReceive).toEqual(amount);
+  }
+
+  @Step("Check currency to swap to contains $0")
+  async checkAssetToContains(currency: string) {
+    const assetTo: string = await getWebElementText(this.toSelector);
+    if (currency === "") {
+      jestExpect(assetTo).toContain("Choose asset");
+    } else {
+      jestExpect(assetTo).toContain(currency);
+    }
+  }
+
+  @Step("Check Ledger Nano S not supported banner")
+  async checkLnsNotSupportedBanner() {
+    await retryUntilTimeout(async () => {
+      const bodyText = (await getWebElementsText("body")).join("\n");
+      jestExpect(bodyText).toMatch(this.lnsUnsupportedBannerPattern);
+    }, 20000);
   }
 
   @Step("Select specific provider $0")

--- a/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
@@ -1,4 +1,7 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { Addresses } from "@ledgerhq/live-common/e2e/enum/Addresses";
+import { Device } from "@ledgerhq/live-common/e2e/enum/Device";
+import { floatNumberRegex } from "@ledgerhq/live-common/e2e/data/regexes";
 import { SwapType } from "@ledgerhq/live-common/e2e/models/Swap";
 import { performSwapUntilQuoteSelectionStep } from "../../../utils/swapUtils";
 import { AppInfos } from "@ledgerhq/live-common/e2e/enum/AppInfos";
@@ -9,6 +12,35 @@ import { isWallet40 } from "../../../helpers/commonHelpers";
 
 setEnv("DISABLE_TRANSACTION_BROADCAST", true);
 
+async function handleAssetSwap(asset: Account, hasAccount: boolean) {
+  const isModularDrawer = await app.modularDrawer.isFlowEnabled("live_app");
+  if (isModularDrawer) {
+    await app.modularDrawer.performSearchByTicker(asset.currency.ticker);
+    await app.modularDrawer.selectCurrencyByTicker(asset.currency.ticker);
+    const networkName = asset?.parentAccount
+      ? asset.parentAccount.currency.name
+      : asset.currency.speculosApp.name;
+    await app.modularDrawer.selectNetworkIfAsked(networkName);
+
+    if (hasAccount) {
+      await app.modularDrawer.selectFirstAccount();
+    } else {
+      await app.modularDrawer.tapAddNewOrExistingAccountButtonMAD();
+      await app.addAccount.addAccountAtIndex(`${asset.currency.name} 1`, asset.currency.id, 0);
+    }
+  } else {
+    await app.common.performSearch(asset.currency.name);
+    await app.stake.selectCurrency(asset.currency.id);
+    if (hasAccount) {
+      await app.common.selectFirstAccount();
+    } else {
+      await app.common.tapProceedButton();
+      await app.addAccount.addAccountAtIndex(`${asset.currency.name} 1`, asset.currency.id, 0);
+      await app.common.selectFirstAccount();
+    }
+  }
+}
+
 export function runSwapWithoutAccountTest(
   asset1: Account,
   asset2: Account,
@@ -17,35 +49,6 @@ export function runSwapWithoutAccountTest(
   event: "noAccountTo" | "noAccountFrom" | "noAccountFromAndTo",
   tags: string[],
 ) {
-  const handleAssetSwap = async (asset: Account, hasAccount: boolean) => {
-    const isModularDrawer = await app.modularDrawer.isFlowEnabled("live_app");
-    if (isModularDrawer) {
-      await app.modularDrawer.performSearchByTicker(asset.currency.ticker);
-      await app.modularDrawer.selectCurrencyByTicker(asset.currency.ticker);
-      const networkName = asset?.parentAccount
-        ? asset.parentAccount.currency.name
-        : asset.currency.speculosApp.name;
-      await app.modularDrawer.selectNetworkIfAsked(networkName);
-
-      if (hasAccount) {
-        await app.modularDrawer.selectFirstAccount();
-      } else {
-        await app.modularDrawer.tapAddNewOrExistingAccountButtonMAD();
-        await app.addAccount.addAccountAtIndex(`${asset.currency.name} 1`, asset.currency.id, 0);
-      }
-    } else {
-      await app.common.performSearch(asset.currency.name);
-      await app.stake.selectCurrency(asset.currency.id);
-      if (hasAccount) {
-        await app.common.selectFirstAccount();
-      } else {
-        await app.common.tapProceedButton();
-        await app.addAccount.addAccountAtIndex(`${asset.currency.name} 1`, asset.currency.id, 0);
-        await app.common.selectFirstAccount();
-      }
-    }
-  };
-
   describe("Swap a coin for which you have no account yet", () => {
     beforeAll(async () => {
       await beforeAllFunctionSwap({
@@ -151,7 +154,7 @@ export function runSwapLandingPageTest(
 
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
-    test("Swap landing page", async () => {
+    it("Swap landing page", async () => {
       const minAmount = await app.swapLiveApp.getMinimumAmount(fromAccount, toAccount);
       const swap = new Swap(fromAccount, toAccount, minAmount);
 
@@ -163,6 +166,136 @@ export function runSwapLandingPageTest(
       const providerList = await app.swapLiveApp.getProviderList();
       await app.swapLiveApp.checkFirstQuoteContainerInfos(providerList);
       await app.swapLiveApp.checkBestOffer();
+
+      await app.portfolio.openViaDeeplink();
+      await app.portfolio.waitForPortfolioPageToLoad();
+      await app.swap.openViaDeeplink();
+      await app.swapLiveApp.expectSwapLiveApp();
+      await app.swapLiveApp.checkAssetFromContains(fromAccount.currency.ticker);
+      await app.swapLiveApp.checkAssetToContains(toAccount.currency.ticker);
+    });
+  });
+}
+
+async function setupSwapAccounts(
+  fromAccount: Account,
+  toAccount: Account,
+  userdata = "skip-onboarding",
+) {
+  await app.speculos.setExchangeDependencies(fromAccount, toAccount);
+  await beforeAllFunctionSwap({
+    userdata,
+    speculosApp: AppInfos.EXCHANGE,
+    cliCommandsOnApp: [
+      {
+        app: fromAccount.currency.speculosApp,
+        cmd: liveDataWithAddressCommand(fromAccount),
+      },
+      {
+        app: toAccount.currency.speculosApp,
+        cmd: liveDataWithAddressCommand(toAccount),
+      },
+    ],
+  });
+}
+
+async function selectSwapAccount(account: Account, isFromCurrency: boolean) {
+  if (isFromCurrency) {
+    await app.swapLiveApp.tapFromCurrency();
+  } else {
+    await app.swapLiveApp.tapToCurrency();
+  }
+
+  if (await app.modularDrawer.isFlowEnabled("live_app")) {
+    await app.modularDrawer.performSearchByTicker(account.currency.ticker);
+    await app.modularDrawer.selectCurrencyByTicker(account.currency.ticker);
+    await app.modularDrawer.selectNetworkIfAsked(
+      app.modularDrawer.getNetworkNameForAccount(account),
+    );
+    await app.modularDrawer.selectAccount(account.accountName);
+  } else {
+    await app.common.performSearch(account.currency.name);
+    await app.stake.selectCurrency(account.currency.id);
+    await app.common.selectAccount(account);
+  }
+
+  await app.swapLiveApp.verifyCurrencyIsSelected(account.currency.ticker, isFromCurrency);
+}
+
+async function performSwapWithSpecificAccounts(
+  fromAccount: Account,
+  toAccount: Account,
+  amount: string,
+) {
+  await selectSwapAccount(fromAccount, true);
+  await selectSwapAccount(toAccount, false);
+  await app.swapLiveApp.inputAmount(amount);
+  await waitForWebElementToMatchRegex(app.swapLiveApp.toAmountInput, floatNumberRegex, 20000);
+  await app.swapLiveApp.tapGetQuotesButton();
+  await app.swapLiveApp.waitForQuotes();
+}
+
+export function runSwapLnsNotSupportedBannerTest(
+  fromAccount: Account,
+  toAccount: Account,
+  unsupportedProvider: Provider,
+  tmsLinks: string[],
+  tags: string[],
+) {
+  (process.env.SPECULOS_DEVICE === Device.LNS.name ? describe : describe.skip)(
+    "Swap - LNS not supported banner",
+    () => {
+      beforeAll(async () => {
+        await setupSwapAccounts(fromAccount, toAccount, "skip-onboarding-with-last-seen-device");
+      });
+
+      tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
+      tags.forEach(tag => $Tag(tag));
+      it(`Shows LNS not supported banner for ${unsupportedProvider.uiName}`, async () => {
+        const minAmount = await app.swapLiveApp.getMinimumAmount(fromAccount, toAccount, [
+          unsupportedProvider.name,
+        ]);
+
+        await performSwapUntilQuoteSelectionStep(fromAccount, toAccount, minAmount);
+        await app.swapLiveApp.selectSpecificProvider(unsupportedProvider.uiName);
+        await app.swapLiveApp.checkLnsNotSupportedBanner();
+      });
+    },
+  );
+}
+
+export function runSwapBlacklistedAddressTest(
+  fromAccount: Account,
+  toAccount: Account,
+  tmsLinks: string[],
+  tags: string[],
+) {
+  describe("Swap - Block blacklisted address", () => {
+    beforeAll(async () => {
+      fromAccount.address = Addresses.SANCTIONED_ETHEREUM;
+      await app.speculos.setExchangeDependencies(fromAccount, toAccount);
+      await beforeAllFunctionSwap({
+        userdata: "EthAccountXrpAccountReadOnlyFalse",
+        speculosApp: AppInfos.EXCHANGE,
+      });
+    });
+
+    tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
+    tags.forEach(tag => $Tag(tag));
+    it(`Blocks sanctioned sender address - ${fromAccount.currency.name} to ${toAccount.currency.name}`, async () => {
+      if (!fromAccount.address) {
+        throw new Error(`Missing test address for ${fromAccount.accountName}`);
+      }
+
+      const minAmount = await app.swapLiveApp.getMinimumAmount(fromAccount, toAccount);
+
+      await performSwapWithSpecificAccounts(fromAccount, toAccount, minAmount);
+      await app.swapLiveApp.selectExchange();
+      await app.common.disableSynchronizationForiOS();
+      await app.swapLiveApp.tapExecuteSwap();
+      await app.swapLiveApp.checkErrorMessage(
+        `This transaction involves a sanctioned wallet address and cannot be processed.\n-- ${fromAccount.address}`,
+      );
     });
   });
 }
@@ -449,13 +582,45 @@ export function runSwapSwitchSendAndReceiveCurrenciesTest(
   });
 }
 
-export function runSwapEntryPoints(account: Account, tmsLinks: string[], tags: string[]) {
-  const validateSwapAssetsPage = async (accountFrom: string, accountTo: string) => {
-    await app.swapLiveApp.expectSwapLiveApp();
-    await app.swapLiveApp.checkAssetFrom(accountFrom, "");
-    await app.swapLiveApp.checkAssetTo(accountTo, "-");
-  };
+async function validateSwapAssetsPage(accountFrom: string, accountTo: string) {
+  await app.swapLiveApp.expectSwapLiveApp();
+  await app.swapLiveApp.checkAssetFrom(accountFrom, "");
+  await app.swapLiveApp.checkAssetTo(accountTo, "-");
+}
 
+async function openSwapFromPortfolioEntryPoint() {
+  await app.portfolio.openViaDeeplink();
+  if (isWallet40) {
+    await app.mainNavigation.tapWallet40Tab("swap");
+  } else {
+    await app.transferMenuDrawer.open();
+    await app.transferMenuDrawer.navigateToSwap();
+  }
+}
+
+export function runSwapDefaultCurrencyNoSetupTest(
+  defaultSendAccount: Account,
+  tmsLinks: string[],
+  tags: string[],
+) {
+  describe("Swap - Default currency without previous setup", () => {
+    beforeAll(async () => {
+      await beforeAllFunctionSwap({
+        userdata: "speculos-tests-app",
+        speculosApp: AppInfos.EXCHANGE,
+      });
+    });
+
+    tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
+    tags.forEach(tag => $Tag(tag));
+    it("Defaults You send to the account with most funds and leaves You receive empty", async () => {
+      await openSwapFromPortfolioEntryPoint();
+      await validateSwapAssetsPage(defaultSendAccount.currency.ticker, "");
+    });
+  });
+}
+
+export function runSwapEntryPoints(account: Account, tmsLinks: string[], tags: string[]) {
   describe("Swap - Entry Points", () => {
     beforeAll(async () => {
       await beforeAllFunctionSwap({
@@ -467,13 +632,7 @@ export function runSwapEntryPoints(account: Account, tmsLinks: string[], tags: s
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it("Access Swap from different entry points", async () => {
-      await app.portfolio.openViaDeeplink();
-      if (isWallet40) {
-        await app.mainNavigation.tapWallet40Tab("swap");
-      } else {
-        await app.transferMenuDrawer.open();
-        await app.transferMenuDrawer.navigateToSwap();
-      }
+      await openSwapFromPortfolioEntryPoint();
       await validateSwapAssetsPage(account.currency.ticker, "");
 
       await app.account.openViaDeeplink();

--- a/e2e/mobile/specs/swap/otherTestCases/swapBlacklistedAddress.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapBlacklistedAddress.spec.ts
@@ -1,0 +1,20 @@
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { runSwapBlacklistedAddressTest } from "./swap.other";
+
+runSwapBlacklistedAddressTest(
+  Account.SANCTIONED_ETH,
+  Account.XRP_1,
+  ["B2CQA-3655"],
+  [
+    "@NanoSP",
+    "@LNS",
+    "@NanoX",
+    "@Stax",
+    "@Flex",
+    "@NanoGen5",
+    "@ethereum",
+    "@family-evm",
+    "@ripple",
+    "@family-xrp",
+  ],
+);

--- a/e2e/mobile/specs/swap/otherTestCases/swapDefaultCurrencyNoSetup.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapDefaultCurrencyNoSetup.spec.ts
@@ -1,0 +1,8 @@
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { runSwapDefaultCurrencyNoSetupTest } from "./swap.other";
+
+runSwapDefaultCurrencyNoSetupTest(
+  Account.BTC_NATIVE_SEGWIT_1,
+  ["B2CQA-3079"],
+  ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@bitcoin", "@family-bitcoin"],
+);

--- a/e2e/mobile/specs/swap/otherTestCases/swapLandingPage.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapLandingPage.spec.ts
@@ -2,10 +2,21 @@ import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { runSwapLandingPageTest } from "./swap.other";
 
 const swapTestConfig = {
-  fromAccount: Account.ETH_1,
-  toAccount: TokenAccount.ETH_USDC_1,
-  tmsLinks: ["B2CQA-2918"],
-  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@ethereum", "@family-evm"],
+  fromAccount: Account.BTC_NATIVE_SEGWIT_1,
+  toAccount: Account.ETH_1,
+  tmsLinks: ["B2CQA-2918", "B2CQA-2327", "B2CQA-3080"],
+  tags: [
+    "@NanoSP",
+    "@LNS",
+    "@NanoX",
+    "@Stax",
+    "@Flex",
+    "@NanoGen5",
+    "@ethereum",
+    "@family-evm",
+    "@bitcoin",
+    "@family-bitcoin",
+  ],
 };
 
 runSwapLandingPageTest(

--- a/e2e/mobile/specs/swap/otherTestCases/swapLnsNotSupportedBanner.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapLnsNotSupportedBanner.spec.ts
@@ -1,0 +1,11 @@
+import { Account, TokenAccount } from "@ledgerhq/live-common/e2e/enum/Account";
+import { Provider } from "@ledgerhq/live-common/e2e/enum/Provider";
+import { runSwapLnsNotSupportedBannerTest } from "./swap.other";
+
+runSwapLnsNotSupportedBannerTest(
+  Account.ETH_1,
+  TokenAccount.ETH_USDT_1,
+  Provider.LIFI,
+  ["B2CQA-3389"],
+  ["@LNS", "@ethereum", "@family-evm"],
+);

--- a/e2e/mobile/userdata/skip-onboarding-with-last-seen-device.json
+++ b/e2e/mobile/userdata/skip-onboarding-with-last-seen-device.json
@@ -1,0 +1,64 @@
+{
+  "data": {
+    "SPECTRON_RUN": {
+      "localStorage": {
+        "acceptedTermsVersion": "2019-12-04"
+      }
+    },
+    "settings": {
+      "hasCompletedOnboarding": true,
+      "counterValue": "USD",
+      "language": "en",
+      "theme": "light",
+      "region": null,
+      "locale": "en-US",
+      "orderAccounts": "balance|desc",
+      "countervalueFirst": false,
+      "autoLockTimeout": 10,
+      "marketIndicator": "western",
+      "currenciesSettings": {},
+      "pairExchanges": {},
+      "developerMode": false,
+      "loaded": true,
+      "shareAnalytics": false,
+      "sharePersonalizedRecommandations": false,
+      "hasSeenAnalyticsOptInPrompt": true,
+      "analyticsEnabled": false,
+      "personalizedRecommendationsEnabled": false,
+      "trackingEnabled": false,
+      "sentryLogs": true,
+      "readOnlyModeEnabled": false,
+      "hasOrderedNano": true,
+      "lastUsedVersion": "99.99.99",
+      "dismissedBanners": [],
+      "accountsViewMode": "list",
+      "showAccountsHelperBanner": true,
+      "hideEmptyTokenAccounts": false,
+      "sidebarCollapsed": false,
+      "discreetMode": false,
+      "preferredDeviceModel": "nanoS",
+      "hasInstalledApps": true,
+      "dismissedDynamicCards": [],
+      "seenDevices": [
+        {
+          "modelId": "nanoS",
+          "deviceInfo": {},
+          "apps": []
+        }
+      ],
+      "blacklistedTokenIds": [],
+      "swapAcceptedProviderIds": [],
+      "deepLinkUrl": null,
+      "firstTimeLend": false,
+      "swapProviders": [],
+      "showClearCacheBanner": false,
+      "starredAccountIds": [],
+      "hasPassword": false
+    },
+    "user": {
+      "id": "08cf3393-c5eb-4ea7-92de-0deea22e3971"
+    },
+    "accounts": [],
+    "countervalues": {}
+  }
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Mobile Swap Live App landing page assertions
  - Mobile Swap quote selection and best quote display
  - Mobile Swap default currency behavior with and without previous setup
  - Mobile Swap Ledger Nano S unsupported-provider banner

### 📝 Description

This PR adds Mobile E2E coverage for the Swap UI and configuration gaps tracked by QAA-1127. The covered scenarios include best quote ordering, default currency behavior when opening Swap for the first time, persistence of selected currencies after reopening Swap, and the Ledger Nano S unsupported banner for LI.FI / Velora / OKX.

The implementation reuses the existing Mobile Swap E2E structure and keeps each new automated scenario in its own spec file. The blacklisted/sanctioned-address Swap scenario is intentionally not included in this PR.

### ✅ CI Executions

- Android Swap E2E execution: https://github.com/LedgerHQ/ledger-live/actions/runs/25110492828
- Android Swap E2E execution: https://github.com/LedgerHQ/ledger-live/actions/runs/25112738542

### ❓ Context

- **JIRA or GitHub link**: [QAA-1127](https://ledgerhq.atlassian.net/browse/QAA-1127)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-1127]: https://ledgerhq.atlassian.net/browse/QAA-1127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ