### PR TITLE
[LWDM] fix: sui delegate operation details missing

### DIFF
--- a/.changeset/real-flowers-sparkle.md
+++ b/.changeset/real-flowers-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-sui": patch
+---
+
+Fix sui delegate operation details missing

--- a/libs/coin-modules/coin-sui/src/network/sdk.test.ts
+++ b/libs/coin-modules/coin-sui/src/network/sdk.test.ts
@@ -1244,7 +1244,7 @@ describe("Staking Operations", () => {
         asset: { type: "native" },
         tx: { block: expect.any(Object), feesPayer: address },
         details: {
-          stakedAmount: 1000000000n,
+          stakedAmount: "1000000000",
           validatorAddress: "0x3d9fb148e35ef4d74fcfc36995da14fc504b885d5f2bfeca37d6ea2cc044a32d",
           stakedObjectId: "0xstaked_object_id_123",
         },
@@ -1268,10 +1268,10 @@ describe("Staking Operations", () => {
         asset: { type: "native" },
         tx: { block: expect.any(Object), feesPayer: address },
         details: {
-          stakedAmount: 1000000000n,
+          stakedAmount: "1000000000",
           validatorAddress: "0x3d9fb148e35ef4d74fcfc36995da14fc504b885d5f2bfeca37d6ea2cc044a32d",
-          rewardAmount: 50000000n,
-          withdrawnAmount: 1200000000n,
+          rewardAmount: "50000000",
+          withdrawnAmount: "1200000000",
         },
       });
     });
@@ -1283,7 +1283,7 @@ describe("Staking Operations", () => {
 
       const operation = sdk.alpacaTransactionToOp(address, tx, "mockCheckpointHash");
 
-      expect(operation.details).toEqual({ stakedAmount: 1000000000n });
+      expect(operation.details).toEqual({ stakedAmount: "1000000000" });
     });
 
     test("transactionToOp should return unstaking details without events", () => {
@@ -1293,7 +1293,7 @@ describe("Staking Operations", () => {
 
       const operation = sdk.alpacaTransactionToOp(address, tx, "mockCheckpointHash");
 
-      expect(operation.details).toEqual({ stakedAmount: 1000000000n });
+      expect(operation.details).toEqual({ stakedAmount: "1000000000" });
     });
 
     test("transactionToOp should handle partial staking event fields", () => {
@@ -1309,7 +1309,7 @@ describe("Staking Operations", () => {
       const operation = sdk.alpacaTransactionToOp(address, tx, "mockCheckpointHash");
 
       expect(operation.details).toEqual({
-        stakedAmount: 1000000000n,
+        stakedAmount: "1000000000",
         validatorAddress: "0xabc",
       });
     });
@@ -1327,7 +1327,7 @@ describe("Staking Operations", () => {
       const operation = sdk.alpacaTransactionToOp(address, tx, "mockCheckpointHash");
 
       expect(operation.details).toEqual({
-        stakedAmount: 1000000000n,
+        stakedAmount: "1000000000",
         validatorAddress: "0xdef",
       });
     });
@@ -1392,8 +1392,8 @@ describe("getStakingEventDetails", () => {
     ]);
     expect(sdk.getStakingEventDetails(tx)).toEqual({
       validatorAddress: "0xdef",
-      rewardAmount: 50000000n,
-      withdrawnAmount: 1200000000n,
+      rewardAmount: "50000000",
+      withdrawnAmount: "1200000000",
     });
   });
 

--- a/libs/coin-modules/coin-sui/src/network/sdk.ts
+++ b/libs/coin-modules/coin-sui/src/network/sdk.ts
@@ -578,13 +578,9 @@ export function getStakingEventDetails(
   if (unstakingDetails) {
     return Object.fromEntries(
       Object.entries({
-        rewardAmount: unstakingDetails.reward_amount
-          ? BigInt(unstakingDetails.reward_amount)
-          : undefined,
+        rewardAmount: unstakingDetails.reward_amount ?? undefined,
         validatorAddress: unstakingDetails.validator_address,
-        withdrawnAmount: unstakingDetails.principal_amount
-          ? BigInt(unstakingDetails.principal_amount)
-          : undefined,
+        withdrawnAmount: unstakingDetails.principal_amount ?? undefined,
       }).filter(([, v]) => v !== undefined),
     );
   }
@@ -636,7 +632,7 @@ export function alpacaTransactionToOp(
 
   if (type === "DELEGATE" || type === "UNDELEGATE") {
     op.details = {
-      stakedAmount: op.value,
+      stakedAmount: op.value.toString(),
       ...getStakingEventDetails(transaction),
     };
     // for staking, the amount is stored in the details


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
getStakingEventDetails() was already extracting validatorAddress, rewardAmount, and withdrawnAmount from the SUI RPC UnstakingRequestEvent, but the amounts were stored as BigInt. Since op.details has no explicit schema, Fastify falls back to JSON.stringify which throws on BigInt — silently dropping the entire details object.
Fix: keep amounts as strings (they come as strings from the RPC anyway). Newly indexed UNDELEGATE operations will now include these fields in operation.details. Existing A4-indexed operations need a re-index to pick up the change.


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/BACK-10134
---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
