### PR TITLE
[LWM] test(mobile): add E2E tests for Wallet 4.0 Tx History

### DIFF
--- a/.changeset/silver-clocks-shine.md
+++ b/.changeset/silver-clocks-shine.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+add testID to OperationsList for E2E test automation

--- a/apps/ledger-live-mobile/src/screens/Analytics/Operations/OperationsList.tsx
+++ b/apps/ledger-live-mobile/src/screens/Analytics/Operations/OperationsList.tsx
@@ -77,6 +77,7 @@ export function OperationsList({
   return (
     <Flex flex={1} px={4}>
       <SectionList
+        testID="operations-list-section-list"
         sections={sections}
         style={{ flex: 1 }}
         contentContainerStyle={{ flexGrow: 1 }}

--- a/e2e/mobile/page/common.page.ts
+++ b/e2e/mobile/page/common.page.ts
@@ -19,10 +19,13 @@ export default class CommonPage {
   walletApiWebview = "wallet-api-webview";
   closeWithConfirmationButtonId = "button-close-add-account";
   errorPage = new ErrorPage();
+  seeAllTransactionButton = "portfolio-seeAll-transaction";
 
   searchBar = () => getElementById(this.searchBarId);
   closeButton = () => getElementById("NavigationHeaderCloseButton");
   backButton = () => getElementById("navigation-header-back-button");
+  seeAllOperationsButtonElement = () => getElementById(this.seeAllTransactionButton);
+  assetScreenFlatlistElement = () => getElementById(this.assetScreenFlatlistId);
   accountCardRegExp = (id = ".*") => new RegExp(this.accountCardPrefix + id);
   accountItemRegExp = (id = ".*(?<!-name)$") => new RegExp(`${this.accountItemId}${id}`);
   accountItem = (id: string) => getElementById(this.accountItemRegExp(id));
@@ -137,5 +140,12 @@ export default class CommonPage {
 
   async enableSynchronization() {
     await device.enableSynchronization();
+  }
+
+  @Step("Press on see all operations button")
+  async pressOnSeeAllOperationsButton() {
+    await detoxExpect(this.assetScreenFlatlistElement()).toBeVisible();
+    await scrollToId(this.seeAllTransactionButton, this.assetScreenFlatlistId);
+    await tapByElement(this.seeAllOperationsButtonElement());
   }
 }

--- a/e2e/mobile/page/index.ts
+++ b/e2e/mobile/page/index.ts
@@ -26,6 +26,7 @@ import SwapPage from "./trade/swap.page";
 import SwapLiveAppPage from "./liveApps/swapLiveApp";
 import WalletTabNavigatorPage from "./wallet/walletTabNavigator.page";
 import MainNavigationPage from "./wallet/mainNavigation.page";
+import OperationPage from "./wallet/operation.page";
 import CeloManageAssetsPage from "./trade/celoManageAssets.page";
 import TransferMenuDrawer from "./wallet/transferMenu.drawer";
 import BuySellPage from "./trade/buySell.page";
@@ -79,6 +80,7 @@ export class Application {
   private swapPageInstance = lazyInit(SwapPage);
   private walletTabNavigatorPageInstance = lazyInit(WalletTabNavigatorPage);
   private mainNavigationPageInstance = lazyInit(MainNavigationPage);
+  private operationPageInstance = lazyInit(OperationPage);
   private celoManageAssetsPageInstance = lazyInit(CeloManageAssetsPage);
   private TransferMenuDrawerInstance = lazyInit(TransferMenuDrawer);
   private buySellPageInstance = lazyInit(BuySellPage);
@@ -202,6 +204,10 @@ export class Application {
 
   public get mainNavigation() {
     return this.mainNavigationPageInstance();
+  }
+
+  public get operation() {
+    return this.operationPageInstance();
   }
 
   public get celoManageAssets() {

--- a/e2e/mobile/page/trade/operationDetails.page.ts
+++ b/e2e/mobile/page/trade/operationDetails.page.ts
@@ -110,10 +110,12 @@ export default class OperationDetailsPage {
   }
 
   @Step("Check that transaction details are displayed")
-  async checkTransactionDetailsVisibility(accountName: string) {
+  async checkTransactionDetailsVisibility(accountName?: string) {
     await this.waitForOperationDetails();
     await detoxExpect(this.account()).toBeVisible();
-    await detoxExpect(this.account()).toHaveText(accountName);
+    if (accountName) {
+      await detoxExpect(this.account()).toHaveText(accountName);
+    }
     await detoxExpect(this.amount()).toBeVisible();
     await scrollToId(this.operationDetailsIdentifier, this.operationDetailsScrollViewId);
     await detoxExpect(this.operation()).toBeVisible();

--- a/e2e/mobile/page/wallet/mainNavigation.page.ts
+++ b/e2e/mobile/page/wallet/mainNavigation.page.ts
@@ -13,6 +13,7 @@ export default class MainNavigationPage {
   topBarDiscoverId = "topbar-discover";
   topBarNotificationsId = "topbar-notifications";
   topBarSettingsId = "topbar-settings";
+  topBarTransactionHistoryId = "topbar-transaction-history";
 
   // --- Legacy bottom tabs ---
   legacyPortfolioTabId = "tab-bar-portfolio";
@@ -76,6 +77,11 @@ export default class MainNavigationPage {
   @Step("Tap Settings in top bar")
   async tapTopBarSettings() {
     await tapById(this.topBarSettingsId);
+  }
+
+  @Step("Tap Transaction History in top bar")
+  async tapTopBarTransactionHistory() {
+    await tapById(this.topBarTransactionHistoryId);
   }
 
   // =====================

--- a/e2e/mobile/page/wallet/operation.page.ts
+++ b/e2e/mobile/page/wallet/operation.page.ts
@@ -1,0 +1,37 @@
+import { element, by } from "detox";
+import { Step } from "jest-allure2-reporter/api";
+
+export default class OperationPage {
+  // MVVM OperationsList screen
+  operationsListId = "operations-list-section-list";
+  sectionHeaderId = "operations-section-header";
+  operationItemId = "operations-list-item";
+  emptyStateId = "operations-empty-state";
+
+  @Step("Expect Operations List to be visible")
+  async expectOperationsListVisible() {
+    await waitForElementById(this.operationsListId);
+  }
+
+  @Step("Expect at least one section header to be visible")
+  async expectSectionHeaderVisible() {
+    await detoxExpect(element(by.id(this.sectionHeaderId)).atIndex(0)).toBeVisible();
+  }
+
+  @Step("Expect at least one operation item to be visible")
+  async expectOperationItemVisible() {
+    await detoxExpect(element(by.id(this.operationItemId)).atIndex(0)).toBeVisible();
+  }
+
+  @Step("Tap first operation item")
+  async tapFirstOperationItem() {
+    await scrollToId(this.operationItemId, this.operationsListId);
+    await tapByElement(element(by.id(this.operationItemId)).atIndex(0));
+  }
+
+  @Step("Expect empty state to be visible")
+  async expectEmptyStateVisible() {
+    await waitForElementById(this.emptyStateId);
+    await detoxExpect(getElementById(this.emptyStateId)).toBeVisible();
+  }
+}

--- a/e2e/mobile/specs/wallet40/operationsHistory.spec.ts
+++ b/e2e/mobile/specs/wallet40/operationsHistory.spec.ts
@@ -26,8 +26,11 @@ describe("Wallet 4.0 - Operations History", () => {
   });
 
   it("should navigate to operation details from a transaction row", async () => {
+    await app.mainNavigation.openPortfolioViaDeeplink();
+    await app.mainNavigation.tapTopBarTransactionHistory();
+    await app.operation.expectOperationsListVisible();
     await app.operation.tapFirstOperationItem();
-    await app.operationDetails.waitForOperationDetails();
+    await app.operationDetails.checkTransactionDetailsVisibility();
   });
 
   // This test will evolve later once the asset/address page is implemented in W40

--- a/e2e/mobile/specs/wallet40/operationsHistory.spec.ts
+++ b/e2e/mobile/specs/wallet40/operationsHistory.spec.ts
@@ -1,0 +1,41 @@
+import { WALLET_40_FEATURE_FLAGS } from "../../utils/constants";
+
+$TmsLink("B2CQA-5256");
+$TmsLink("B2CQA-5263");
+$TmsLink("B2CQA-5266");
+const tags: string[] = ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"];
+tags.forEach(tag => $Tag(tag));
+
+const ACCOUNT = Account.ETH_1;
+const CURRENCY = ACCOUNT.currency;
+
+describe("Wallet 4.0 - Operations History", () => {
+  beforeAll(async () => {
+    await app.init({
+      userdata: "speculos-x-other-account",
+      featureFlags: WALLET_40_FEATURE_FLAGS,
+    });
+    await app.mainNavigation.waitForWallet40Ready();
+  });
+
+  it("should open Tx History from the top bar clock icon", async () => {
+    await app.mainNavigation.tapTopBarTransactionHistory();
+    await app.operation.expectOperationsListVisible();
+    await app.operation.expectSectionHeaderVisible();
+    await app.operation.expectOperationItemVisible();
+  });
+
+  it("should navigate to operation details from a transaction row", async () => {
+    await app.operation.tapFirstOperationItem();
+    await app.operationDetails.waitForOperationDetails();
+  });
+
+  // This test will evolve later once the asset/address page is implemented in W40
+  // For the moment, we are using the legacy account page to navigate to the transaction history
+  it("should open Tx History from within an asset page", async () => {
+    await app.mainNavigation.openPortfolioViaDeeplink();
+    await app.portfolio.goToAccountsW40(CURRENCY.name);
+    await app.common.pressOnSeeAllOperationsButton();
+    await app.operation.expectOperationsListVisible();
+  });
+});


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Opening the Tx History screen via the top bar clock icon
  - Navigating from a transaction row to the operation detail view
  - Opening Tx History from within an asset page (via "See All Operations")

### 📝 Description

No E2E coverage existed for the Wallet 4.0 Transaction History screen. As the new MVVM `OperationsList` screen was introduced, the test infrastructure needed to be wired up from scratch.

Added a new `OperationPage` page object and `operationsHistory` spec covering three scenarios: opening the history from the top bar icon, tapping a transaction row to reach operation details, and reaching the history from inside an asset page. Also added a `testID` to the `OperationsList` `SectionList` to make it addressable by Detox, and wired the `OperationPage` into the shared `Application` class.

E2E run: https://github.com/LedgerHQ/ledger-live/actions/runs/25114945240 and https://ledger.slack.com/archives/CTMQ0S5SB/p1777474624250769

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29332](https://ledgerhq.atlassian.net/browse/LIVE-29332)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29332]: https://ledgerhq.atlassian.net/browse/LIVE-29332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ