### PR TITLE
[LWDM] fix(e2e): atomic write for nano app catalog to prevent race condition

### DIFF
--- a/e2e/desktop/tests/utils/global.setup.ts
+++ b/e2e/desktop/tests/utils/global.setup.ts
@@ -2,6 +2,7 @@ import { FullConfig } from "@playwright/test";
 import { responseLogfilePath } from "./networkResponseLogger";
 import { mkdirSync, promises as fs, unlink, writeFileSync } from "fs";
 import {
+  createNanoAppJsonFile,
   getDeviceFirmwareVersion,
   getSpeculosModel,
 } from "@ledgerhq/live-common/e2e/speculosAppVersion";
@@ -23,6 +24,8 @@ export default async function globalSetup(_config: FullConfig) {
   }
   const SPECULOS_DEVICE = process.env.SPECULOS_DEVICE;
   const SPECULOS_FIRMWARE_VERSION = await getDeviceFirmwareVersion(getSpeculosModel());
+
+  await createNanoAppJsonFile(NANO_APP_CATALOG_PATH);
 
   const dir = path.dirname(environmentFilePath);
 

--- a/libs/ledger-live-common/src/e2e/speculosAppVersion.ts
+++ b/libs/ledger-live-common/src/e2e/speculosAppVersion.ts
@@ -123,7 +123,17 @@ export async function createNanoAppJsonFile(nanoAppFilePath: string): Promise<vo
     const firmware = await getDeviceFirmwareVersion(device);
     const appCatalog = await getNanoAppCatalog(device, firmware);
 
-    fs.writeFileSync(jsonFilePath, JSON.stringify(appCatalog, null, 2), "utf8");
+    const tmpPath = `${jsonFilePath}.${process.pid}.tmp`;
+    fs.writeFileSync(tmpPath, JSON.stringify(appCatalog, null, 2), "utf8");
+    try {
+      fs.renameSync(tmpPath, jsonFilePath);
+    } catch {
+      try {
+        fs.unlinkSync(tmpPath);
+      } catch {
+        // ignore
+      }
+    }
   } catch (error) {
     console.error("Unable to create app version file:", sanitizeError(error));
   }


### PR DESCRIPTION
## Summary                                                                                                                                                                                               
                                                                                                                                                                                                           
  - **Root cause:** `createNanoAppJsonFile` was called lazily per Playwright worker at test startup. With parallel workers (separate Node.js processes), all workers raced past the `existsSync` guard simultaneously and independently hit the Manager API — multiplying request volume by the worker count.                                                             
  - **Fix 1 (atomic write):** Replace `writeFileSync` to the target path with write-to-temp + `rename`. On Linux, `rename(2)` is atomic — readers never see a zero-byte or partially written file,         
  eliminating `SyntaxError: Unexpected end of JSON input` / `Unterminated string in JSON`.                                                                                                                 
  - **Fix 2 (pre-population in globalSetup):** Call `createNanoAppJsonFile` once in `globalSetup`, which runs in a single process before any workers start. Workers then hit `existsSync → true` and skip  
  the fetch entirely, reducing Manager API calls from `N_workers × requests` to `1 × requests` per CI run.                                                                                                 
                  
  ## Test plan                                                                                                                                                                                             
                  
  - [x] Trigger `test-ui-e2e-only-desktop.yml` on CI and verify no `Unable to get app version from catalog` warnings at test startup: [Smoke](https://github.com/LedgerHQ/ledger-live/actions/runs/25114384998) and [Full](https://github.com/LedgerHQ/ledger-live/actions/runs/25114778236) executions