### PR TITLE
[LWM] feat(mobile): add addresses section to asset detail screen

### DIFF
--- a/.changeset/bold-addresses-appear.md
+++ b/.changeset/bold-addresses-appear.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add addresses section to asset detail screen with account list and add account flow

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8433,6 +8433,11 @@
         "1y": "1 year"
       },
       "chartPlaceholder": "Graphic"
+    },
+    "addresses": {
+      "title": "Addresses",
+      "addAccount": "Add",
+      "empty": "No addresses yet. Tap Add to get started."
     }
   },
   "assetSelection": {

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
@@ -43,4 +43,13 @@ describe("AssetDetail screen layout", () => {
     expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.chartPlaceholder)).toBeVisible();
     expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.receiveButton)).toBeNull();
   });
+
+  it("renders the addresses section with title and add button", () => {
+    render(<AssetDetailTestNavigator />);
+
+    expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.addresses)).toBeVisible();
+    expect(screen.getByText("Addresses")).toBeVisible();
+    expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.addAccount)).toBeVisible();
+    expect(screen.getByText("Add")).toBeVisible();
+  });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
@@ -8,6 +8,7 @@ import { TrackScreen } from "~/analytics";
 import { ASSET_DETAIL_TEST_IDS } from "../../testIds";
 import { SectionPlaceholder } from "./components/SectionPlaceholder";
 import { BalanceGraph } from "./components/BalanceGraph";
+import { Addresses } from "./components/Addresses";
 import { Footer } from "./components/Footer";
 import { CTAS_HEIGHT, SECTION_HEIGHT, PLACEHOLDER_COLORS } from "./utils/constants";
 
@@ -36,11 +37,7 @@ export function AssetDetailView({ currency, source, isRefreshing, onRefresh }: P
             backgroundColor={PLACEHOLDER_COLORS.balanceDetails}
             height={SECTION_HEIGHT}
           />
-          <SectionPlaceholder
-            testID={ASSET_DETAIL_TEST_IDS.addresses}
-            backgroundColor={PLACEHOLDER_COLORS.addresses}
-            height={SECTION_HEIGHT}
-          />
+          <Addresses currency={currency} />
           <SectionPlaceholder
             testID={ASSET_DETAIL_TEST_IDS.marketStats}
             backgroundColor={PLACEHOLDER_COLORS.marketStats}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/AddressesView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/AddressesView.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import {
+  Box,
+  Pressable,
+  Subheader,
+  SubheaderRow,
+  SubheaderTitle,
+  Text,
+} from "@ledgerhq/lumen-ui-rnative";
+import { PlusCircleFill } from "@ledgerhq/lumen-ui-rnative/symbols";
+import type { Account } from "@ledgerhq/types-live";
+import { useTranslation } from "~/context/Locale";
+import { ASSET_DETAIL_TEST_IDS } from "LLM/features/AssetDetail/testIds";
+import { AddressAccountItem } from "./components/AddressAccountItem";
+import type { AddressAccountData } from "./useAddressesViewModel";
+
+type Props = Readonly<{
+  accounts: readonly AddressAccountData[];
+  onAccountPress: (account: Account) => void;
+  onAddAccount: () => void;
+}>;
+
+export function AddressesView({ accounts, onAccountPress, onAddAccount }: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <Box testID={ASSET_DETAIL_TEST_IDS.addresses}>
+      <Subheader>
+        <SubheaderRow lx={{ marginBottom: "s12" }}>
+          <SubheaderTitle>{t("assetDetail.addresses.title")}</SubheaderTitle>
+          <Box lx={{ flex: 1 }} />
+          <Pressable
+            lx={{ flexDirection: "row", alignItems: "center", gap: "s8" }}
+            onPress={onAddAccount}
+            testID={ASSET_DETAIL_TEST_IDS.addAccount}
+          >
+            <PlusCircleFill size={20} color="interactive" />
+            <Text typography="body2SemiBold" lx={{ color: "active" }}>
+              {t("assetDetail.addresses.addAccount")}
+            </Text>
+          </Pressable>
+        </SubheaderRow>
+      </Subheader>
+      <Box lx={{ backgroundColor: "surface", borderRadius: "md", paddingVertical: "s4" }}>
+        {accounts.length > 0 ? (
+          accounts.map(data => (
+            <AddressAccountItem key={data.id} data={data} onPress={onAccountPress} />
+          ))
+        ) : (
+          <Box lx={{ padding: "s16", alignItems: "center" }}>
+            <Text typography="body3" lx={{ color: "muted" }}>
+              {t("assetDetail.addresses.empty")}
+            </Text>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/__tests__/useAddressesViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/__tests__/useAddressesViewModel.test.ts
@@ -1,0 +1,124 @@
+import { renderHook, act } from "@tests/test-renderer";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import {
+  mockBtcCryptoCurrency,
+  mockEthCryptoCurrency,
+} from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
+import { track } from "~/analytics";
+import { NavigatorName, ScreenName } from "~/const";
+import { AddAccountContexts } from "LLM/features/Accounts/screens/AddAccount/enums";
+import type { State } from "~/reducers/types";
+import { useAddressesViewModel } from "../useAddressesViewModel";
+
+const mockNavigate = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+function withAccounts(currencyId: string, count: number) {
+  const currency = currencyId === "bitcoin" ? mockBtcCryptoCurrency : mockEthCryptoCurrency;
+  return {
+    overrideInitialState: (state: State): State => ({
+      ...state,
+      accounts: {
+        ...state.accounts,
+        active: Array.from({ length: count }, (_, i) =>
+          genAccount(`${currencyId}-${i}`, { currency, operationsSize: 0 }),
+        ),
+      },
+    }),
+  };
+}
+
+describe("useAddressesViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("accounts", () => {
+    it("returns an empty array when currency is undefined", () => {
+      const { result } = renderHook(() => useAddressesViewModel(undefined));
+
+      expect(result.current.accounts).toEqual([]);
+    });
+
+    it("returns accounts matching the currency", () => {
+      const { result } = renderHook(
+        () => useAddressesViewModel(mockBtcCryptoCurrency),
+        withAccounts("bitcoin", 2),
+      );
+
+      expect(result.current.accounts).toHaveLength(2);
+      result.current.accounts.forEach(acc => {
+        expect(acc.name).toBeDefined();
+        expect(acc.truncatedAddress).toBeDefined();
+        expect(acc.account).toBeDefined();
+      });
+    });
+
+    it("returns no accounts when none match the currency", () => {
+      const { result } = renderHook(
+        () => useAddressesViewModel(mockBtcCryptoCurrency),
+        withAccounts("ethereum", 2),
+      );
+
+      expect(result.current.accounts).toHaveLength(0);
+    });
+  });
+
+  describe("onAccountPress", () => {
+    it("navigates to account screen and fires analytics", () => {
+      const { result } = renderHook(
+        () => useAddressesViewModel(mockBtcCryptoCurrency),
+        withAccounts("bitcoin", 1),
+      );
+
+      const account = result.current.accounts[0].account;
+      act(() => result.current.onAccountPress(account));
+
+      expect(mockNavigate).toHaveBeenCalledWith(ScreenName.Account, {
+        accountId: account.id,
+      });
+      expect(track).toHaveBeenCalledWith("account_clicked", {
+        currency: "bitcoin",
+        accountId: account.id,
+        page: "Asset Detail",
+      });
+    });
+  });
+
+  describe("onAddAccount", () => {
+    it("navigates to device selection and fires analytics", () => {
+      const { result } = renderHook(
+        () => useAddressesViewModel(mockBtcCryptoCurrency),
+        withAccounts("bitcoin", 1),
+      );
+
+      act(() => result.current.onAddAccount());
+
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.DeviceSelection, {
+        screen: ScreenName.SelectDevice,
+        params: {
+          currency: mockBtcCryptoCurrency,
+          context: AddAccountContexts.AddAccounts,
+        },
+      });
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "add_account",
+        currency: "bitcoin",
+        page: "Asset Detail",
+      });
+    });
+
+    it("does nothing when currency is undefined", () => {
+      const { result } = renderHook(() => useAddressesViewModel(undefined));
+
+      act(() => result.current.onAddAccount());
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(track).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/components/AddressAccountItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/components/AddressAccountItem.tsx
@@ -1,0 +1,48 @@
+import React, { memo, useCallback } from "react";
+import {
+  Box,
+  ListItem,
+  ListItemContent,
+  ListItemDescription,
+  ListItemLeading,
+  ListItemTitle,
+  ListItemTrailing,
+} from "@ledgerhq/lumen-ui-rnative";
+import type { Account } from "@ledgerhq/types-live";
+import CurrencyIcon from "~/components/CurrencyIcon";
+import { useFormattedAccountBalance } from "LLM/features/Send/screens/Recipient/hooks/useFormattedAccountBalance";
+import type { AddressAccountData } from "../useAddressesViewModel";
+
+type Props = Readonly<{
+  data: AddressAccountData;
+  onPress: (account: Account) => void;
+}>;
+
+export const AddressAccountItem = memo(function AddressAccountItem({ data, onPress }: Props) {
+  const { account, name, truncatedAddress } = data;
+  const { formattedBalance, formattedCounterValue } = useFormattedAccountBalance(account);
+
+  const handlePress = useCallback(() => onPress(account), [account, onPress]);
+
+  return (
+    <ListItem onPress={handlePress} testID={`asset-detail-address-item-${account.id}`}>
+      <ListItemLeading>
+        <ListItemContent>
+          <ListItemTitle numberOfLines={1}>{name}</ListItemTitle>
+          <Box lx={{ flexDirection: "row", alignItems: "center", gap: "s4" }}>
+            <ListItemDescription numberOfLines={1} ellipsizeMode="middle">
+              {truncatedAddress}
+            </ListItemDescription>
+            <CurrencyIcon currency={account.currency} size={16} squared />
+          </Box>
+        </ListItemContent>
+      </ListItemLeading>
+      <ListItemTrailing>
+        <ListItemContent>
+          <ListItemTitle>{formattedCounterValue}</ListItemTitle>
+          <ListItemDescription>{formattedBalance}</ListItemDescription>
+        </ListItemContent>
+      </ListItemTrailing>
+    </ListItem>
+  );
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/index.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { useAddressesViewModel } from "./useAddressesViewModel";
+import { AddressesView } from "./AddressesView";
+
+type Props = Readonly<{
+  currency: CryptoCurrency | undefined;
+}>;
+
+export function Addresses({ currency }: Props) {
+  const viewModel = useAddressesViewModel(currency);
+  return <AddressesView {...viewModel} />;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/useAddressesViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/useAddressesViewModel.ts
@@ -1,0 +1,84 @@
+import { useCallback, useMemo } from "react";
+import { useNavigation } from "@react-navigation/native";
+import { shallowEqual } from "react-redux";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import type { Account } from "@ledgerhq/types-live";
+import { accountNameWithDefaultSelector } from "@ledgerhq/live-wallet/store";
+import { formatAddress } from "@ledgerhq/live-common/utils/addressUtils";
+import { useSelector } from "~/context/hooks";
+import { walletSelector } from "~/reducers/wallet";
+import { accountsByCryptoCurrencyScreenSelector } from "~/reducers/accounts";
+import { NavigatorName, ScreenName } from "~/const";
+import { track } from "~/analytics";
+import { AddAccountContexts } from "LLM/features/Accounts/screens/AddAccount/enums";
+
+export type AddressAccountData = Readonly<{
+  id: string;
+  account: Account;
+  name: string;
+  truncatedAddress: string;
+}>;
+
+export function useAddressesViewModel(currency: CryptoCurrency | undefined) {
+  const navigation = useNavigation();
+  const walletState = useSelector(walletSelector);
+
+  const accountsSelector = useMemo(
+    () => (currency ? accountsByCryptoCurrencyScreenSelector(currency) : () => []),
+    [currency],
+  );
+  const accountTuples = useSelector(accountsSelector, shallowEqual);
+
+  const accounts: AddressAccountData[] = useMemo(() => {
+    if (!currency) return [];
+    return accountTuples.map(tuple => {
+      const acc = tuple.subAccount ?? tuple.account;
+      const mainAccount = tuple.account as Account;
+      return {
+        id: acc.id,
+        account: mainAccount,
+        name: tuple.name || accountNameWithDefaultSelector(walletState, mainAccount),
+        truncatedAddress: formatAddress(mainAccount.freshAddress, {
+          prefixLength: 4,
+          suffixLength: 4,
+        }),
+      };
+    });
+  }, [currency, accountTuples, walletState]);
+
+  const onAccountPress = useCallback(
+    (account: Account) => {
+      track("account_clicked", {
+        currency: currency?.id,
+        accountId: account.id,
+        page: "Asset Detail",
+      });
+      navigation.navigate(ScreenName.Account, {
+        accountId: account.id,
+      });
+    },
+    [navigation, currency?.id],
+  );
+
+  const onAddAccount = useCallback(() => {
+    if (!currency) return;
+    track("button_clicked", {
+      button: "add_account",
+      currency: currency.id,
+      page: "Asset Detail",
+    });
+    navigation.navigate(NavigatorName.DeviceSelection, {
+      screen: ScreenName.SelectDevice,
+      params: {
+        currency,
+        context: AddAccountContexts.AddAccounts,
+      },
+    });
+  }, [navigation, currency]);
+
+  return {
+    accounts,
+    onAccountPress,
+    onAddAccount,
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/testIds.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/testIds.ts
@@ -6,6 +6,7 @@ export const ASSET_DETAIL_TEST_IDS = {
   receiveButton: "asset-detail-receive-button",
   balanceDetails: "asset-detail-balance-details",
   addresses: "asset-detail-addresses",
+  addAccount: "asset-detail-add-account",
   marketStats: "asset-detail-market-stats",
   transactions: "asset-detail-transactions",
   ctas: "asset-detail-ctas",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Asset detail screen: Addresses section rendering (empty state, single account, multiple accounts)
  - Account row tap navigates to existing account screen
  - "+ Add" button opens the DeviceSelection > SelectDevice flow (MAD)
  - Analytics events fire on row tap and add account actions

### 📝 Description

The asset detail screen was missing the "Addresses" section, which should list all accounts for the viewed cryptocurrency asset, allow navigation to individual account screens, and provide an entry point to add new accounts.

**Solution**: Implemented the Addresses section following the MVVM pattern (Container > ViewModel > View):

- **Subheader** with "Addresses" title and a "+ Add" pressable link (same pattern as MyWallet's DeviceSection)
- **Account list** using Lumen `ListItem` components, each showing: account name, truncated `freshAddress` with a small squared `CurrencyIcon`, fiat countervalue, and crypto balance
- **Empty state** with a centered muted message when no accounts exist
- **Surface background card** around list items with rounded corners
- **Analytics**: `account_clicked` on row tap, `button_clicked` on add account
- **Navigation**: row tap → `ScreenName.Account`, add → `DeviceSelection > SelectDevice` with `AddAccountContexts.AddAccounts`

<img width="350" height="750" alt="Simulator Screenshot - Test Ios - 2026-04-29 at 15 40 22" src="https://github.com/user-attachments/assets/b0dcd4ca-20c7-41c4-8de6-96ee87a839ec" />

<img width="350" height="750" alt="Simulator Screenshot - Test Ios - 2026-04-29 at 16 25 14" src="https://github.com/user-attachments/assets/59ba3b1f-b920-4a4d-b83a-4895360f8a10" />

<img width="350" height="750" alt="image" src="https://github.com/user-attachments/assets/2b7c12c6-498f-4b00-9a33-e999065e1da5" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-29725](https://ledgerhq.atlassian.net/browse/LIVE-29725)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29725]: https://ledgerhq.atlassian.net/browse/LIVE-29725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ