### PR TITLE
[LWDM] fix(asset-aggregation): normalize EVM grouped asset to Ethereum

### DIFF
--- a/.changeset/hungry-geese-cover.md
+++ b/.changeset/hungry-geese-cover.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/asset-aggregation": minor
+---
+
+Canonicalize EVM meta-currency asset distribution to Ethereum (currency label, market id) when grouped networks omit mainnet from assets data

--- a/libs/asset-aggregation/package.json
+++ b/libs/asset-aggregation/package.json
@@ -21,6 +21,7 @@
   "types": "lib/index.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
+    "@ledgerhq/cryptoassets": "workspace:*",
     "@ledgerhq/types-live": "workspace:*",
     "@ledgerhq/types-cryptoassets": "workspace:*",
     "@ledgerhq/live-countervalues": "workspace:*",
@@ -35,7 +36,6 @@
     }
   },
   "devDependencies": {
-    "@ledgerhq/cryptoassets": "workspace:*",
     "@types/node": "catalog:",
     "@types/jest": "catalog:",
     "jest": "catalog:",

--- a/libs/asset-aggregation/src/assetDistribution/__tests__/buildAssetDistribution.test.ts
+++ b/libs/asset-aggregation/src/assetDistribution/__tests__/buildAssetDistribution.test.ts
@@ -5,6 +5,12 @@ import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import BigNumber from "bignumber.js";
 import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
 
+const mockFindCryptoCurrencyById = jest.fn();
+
+jest.mock("@ledgerhq/cryptoassets", () => ({
+  findCryptoCurrencyById: (...args: unknown[]) => mockFindCryptoCurrencyById(...args),
+}));
+
 jest.mock("@ledgerhq/live-countervalues/logic", () => ({
   calculate: jest.fn((_state, { value }: { value: number }) => value * 2),
 }));
@@ -36,13 +42,27 @@ describe("buildAssetDistribution", () => {
   const ethMainnet = makeCurrency("ethereum", "Ethereum");
   const ethArbitrum = makeCurrency("arbitrum", "Arbitrum");
   const ethBase = makeCurrency("base", "Base");
+  const ethOptimism = makeCurrency("optimism", "Optimism");
   const btcCurrency = makeCurrency("bitcoin", "Bitcoin");
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFindCryptoCurrencyById.mockImplementation((id: string) => {
+      if (id === "ethereum") return ethMainnet;
+      return undefined;
+    });
+  });
 
   const assetsData: AssetsDataLike = {
     cryptoAssets: {
       "urn:crypto:meta-currency:ethereum": {
         id: "urn:crypto:meta-currency:ethereum",
-        assetsIds: { ethereum: "ethereum", arbitrum: "arbitrum", base: "base" },
+        assetsIds: {
+          ethereum: "ethereum",
+          arbitrum: "arbitrum",
+          base: "base",
+          optimism: "optimism",
+        },
       },
       "urn:crypto:meta-currency:bitcoin": {
         id: "urn:crypto:meta-currency:bitcoin",
@@ -52,11 +72,15 @@ describe("buildAssetDistribution", () => {
     markets: {
       ethereum: { id: "ethereum" },
       bitcoin: { id: "bitcoin" },
+      optimism: { id: "optimism" },
     },
   };
 
-  const distribute = (accounts: Account[], opts?: BuildAssetDistributionOpts) =>
-    buildAssetDistribution(accounts, cvState, usd, assetsData, opts);
+  const distribute = (
+    accounts: Account[],
+    opts?: BuildAssetDistributionOpts,
+    data: AssetsDataLike = assetsData,
+  ) => buildAssetDistribution(accounts, cvState, usd, data, opts);
 
   it("should group ETH across multiple networks into a single item", () => {
     const result = distribute([
@@ -68,6 +92,7 @@ describe("buildAssetDistribution", () => {
     expect(result.isAvailable).toBe(true);
     expect(result.list).toHaveLength(1);
     expect(result.list[0].metaCurrencyId).toBe("urn:crypto:meta-currency:ethereum");
+    expect(result.list[0].currency.id).toBe("ethereum");
     expect(result.list[0].amount).toBe(1800);
     expect(result.list[0].accounts).toHaveLength(3);
   });
@@ -96,7 +121,39 @@ describe("buildAssetDistribution", () => {
     const result = distribute([makeAccount("arb-1", ethArbitrum, 500)]);
 
     expect(result.list[0].metaCurrencyId).toBe("urn:crypto:meta-currency:ethereum");
+    expect(result.list[0].currency.id).toBe("ethereum");
     expect(result.list[0].marketId).toBe("ethereum");
+  });
+
+  it("should canonicalize Base and Optimism-only ETH groups to Ethereum", () => {
+    const partialEthereumAssetsData: AssetsDataLike = {
+      cryptoAssets: {
+        ...assetsData.cryptoAssets,
+        "urn:crypto:meta-currency:ethereum": {
+          id: "urn:crypto:meta-currency:ethereum",
+          assetsIds: { base: "base", optimism: "optimism" },
+        },
+      },
+      markets: {
+        base: { id: "base" },
+        optimism: { id: "optimism" },
+      },
+    };
+
+    const result = distribute(
+      [makeAccount("base-1", ethBase, 300), makeAccount("op-1", ethOptimism, 200)],
+      undefined,
+      partialEthereumAssetsData,
+    );
+
+    expect(result.list).toHaveLength(1);
+    expect(result.list[0].metaCurrencyId).toBe("urn:crypto:meta-currency:ethereum");
+    expect(result.list[0].currency.id).toBe("ethereum");
+    expect(result.list[0].marketId).toBe("ethereum");
+    expect(result.list[0].networks?.map(network => network.currency.id)).toEqual([
+      "base",
+      "optimism",
+    ]);
   });
 
   it("should build bySlug lookup", () => {

--- a/libs/asset-aggregation/src/assetDistribution/buildAssetDistribution.ts
+++ b/libs/asset-aggregation/src/assetDistribution/buildAssetDistribution.ts
@@ -1,3 +1,4 @@
+import { findCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 import type { CryptoCurrency, Currency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
@@ -34,6 +35,10 @@ function buildCurrencyLookups(cryptoAssets: AssetsDataLike["cryptoAssets"]): Cur
     for (const assetId of assetIds) currencyToMetaId[assetId] = metaId;
   }
   return { currencyToMetaId, primaryAssets };
+}
+
+function resolveNormalizedCurrency(metaCurrencyId: string): CryptoCurrency | undefined {
+  return findCryptoCurrencyById(toSlug(metaCurrencyId));
 }
 
 function computeDistribution(countervalue: number, sum: number, fallback: number): number {
@@ -117,9 +122,15 @@ export function buildAssetDistribution(
   let sum = 0;
   for (const group of groups.values()) {
     const primaryAssetId = primaryAssets[group.metaCurrencyId];
+    const normalizedCurrency = resolveNormalizedCurrency(group.metaCurrencyId);
     const primaryCurrency = currencyById.get(primaryAssetId);
-    if (primaryCurrency) group.currency = primaryCurrency;
-    group.marketId ??= assetsData.markets[primaryAssetId]?.id;
+    if (normalizedCurrency) {
+      group.currency = normalizedCurrency;
+      group.marketId = assetsData.markets[normalizedCurrency.id]?.id ?? normalizedCurrency.id;
+    } else {
+      if (primaryCurrency) group.currency = primaryCurrency;
+      group.marketId ??= assetsData.markets[primaryAssetId]?.id;
+    }
 
     let groupCountervalue = 0;
     for (const network of group.networks.values()) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3193,6 +3193,9 @@ importers:
 
   libs/asset-aggregation:
     dependencies:
+      '@ledgerhq/cryptoassets':
+        specifier: workspace:*
+        version: link:../ledgerjs/packages/cryptoassets
       '@ledgerhq/live-countervalues':
         specifier: workspace:*
         version: link:../live-countervalues
@@ -3206,9 +3209,6 @@ importers:
         specifier: 9.1.2
         version: 9.1.2
     devDependencies:
-      '@ledgerhq/cryptoassets':
-        specifier: workspace:*
-        version: link:../ledgerjs/packages/cryptoassets
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -45157,6 +45157,14 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
       styled-components: 6.1.19(patch_hash=810073718ccefe69fd016893be54d80d86cc6e5ee521455028b93c7cbf3103d7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
 
+  '@ledgerhq/crypto-icons@2.0.1(@ledgerhq/lumen-design-core@0.1.11)(@ledgerhq/lumen-ui-react@0.1.24(1685647331cab8b81ae5bae9e8b32b81))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@ledgerhq/lumen-design-core': 0.1.11
+      '@ledgerhq/lumen-ui-react': 0.1.24(1685647331cab8b81ae5bae9e8b32b81)
+      react-dom: 19.0.0(react@19.0.0)
+
   '@ledgerhq/crypto-icons@2.0.1(@ledgerhq/lumen-design-core@0.1.11)(@ledgerhq/lumen-ui-rnative@0.1.25(09ada5ee5ea348474dad2c68ccdb1c21))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
     dependencies:
       react: 19.0.0
@@ -45173,14 +45181,6 @@ snapshots:
       '@ledgerhq/lumen-ui-rnative': 0.1.25(1dd0e7412354a1878032940528d87280)
       react-dom: 19.0.0(react@19.0.0)
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0)
-
-  '@ledgerhq/crypto-icons@2.0.1(@ledgerhq/lumen-design-core@0.1.11)(@ledgerhq/lumen-ui-react@0.1.24(1685647331cab8b81ae5bae9e8b32b81))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
-    dependencies:
-      react: 19.0.0
-    optionalDependencies:
-      '@ledgerhq/lumen-design-core': 0.1.11
-      '@ledgerhq/lumen-ui-react': 0.1.24(1685647331cab8b81ae5bae9e8b32b81)
-      react-dom: 19.0.0(react@19.0.0)
 
   '@ledgerhq/cryptoassets-evm-signatures@13.5.2':
     dependencies:


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Asset distribution grouping for EVM L2 chains (Base, Optimism, Arbitrum)
      - Portfolio currency label and market data lookup for cross-network ETH holdings

### 📝 Description

**Problem**: When a user only holds ETH on L2 networks (e.g. Base, Optimism), the asset distribution displays the L2 chain name (e.g. "Base") instead of "Ethereum". Adding accounts from other L2s (e.g. Optimism) incorrectly aggregates them under the first L2 chain seen. The display only corrects itself once an Ethereum mainnet account is added.

**Solution**: Introduce a `resolveCanonicalCurrency` step during asset distribution build. When a meta-currency group is identified (e.g. `urn:crypto:meta-currency:ethereum`), the canonical currency is resolved via `findCryptoCurrencyById` using the meta-currency slug. This ensures the group always displays as "Ethereum" with the correct `marketId`, regardless of which L2 accounts are present.

```ts
function resolveCanonicalCurrency(metaCurrencyId: string): CryptoCurrency | undefined {
  return findCryptoCurrencyById(toSlug(metaCurrencyId));
}
```

Also moved `@ledgerhq/cryptoassets` from `devDependencies` to `dependencies` since production code now imports `findCryptoCurrencyById`.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30113](https://ledgerhq.atlassian.net/browse/LIVE-30113)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30113]: https://ledgerhq.atlassian.net/browse/LIVE-30113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ