### PR TITLE
[LWM] chore(mobile,desktop): bump lumen-ui-react to 0.1.25 and lumen-ui-rnative to 0.1.26

### DIFF
--- a/.changeset/brave-tigers-jump.md
+++ b/.changeset/brave-tigers-jump.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": patch
+"ledger-live-desktop": patch
+---
+
+bump @ledgerhq/lumen-ui-react to 0.1.25 and @ledgerhq/lumen-ui-rnative to 0.1.26

--- a/apps/ledger-live-mobile/__tests__/jest-setup.js
+++ b/apps/ledger-live-mobile/__tests__/jest-setup.js
@@ -96,9 +96,9 @@ jest.mock("react-native-haptic-feedback", () => ({
 }));
 
 jest.mock("expo-haptics", () => ({
-  impactAsync: jest.fn(),
-  notificationAsync: jest.fn(),
-  selectionAsync: jest.fn(),
+  impactAsync: jest.fn().mockResolvedValue(undefined),
+  notificationAsync: jest.fn().mockResolvedValue(undefined),
+  selectionAsync: jest.fn().mockResolvedValue(undefined),
   ImpactFeedbackStyle: {
     Light: "light",
     Medium: "medium",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,11 +55,11 @@ catalogs:
       specifier: 0.1.11
       version: 0.1.11
     '@ledgerhq/lumen-ui-react':
-      specifier: 0.1.24
-      version: 0.1.24
-    '@ledgerhq/lumen-ui-rnative':
       specifier: 0.1.25
       version: 0.1.25
+    '@ledgerhq/lumen-ui-rnative':
+      specifier: 0.1.26
+      version: 0.1.26
     '@ledgerhq/speculos-device-controller':
       specifier: 0.2.3
       version: 0.2.3
@@ -920,7 +920,7 @@ importers:
         version: 2.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/crypto-icons':
         specifier: 2.0.1
-        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.11)(@ledgerhq/lumen-ui-react@0.1.24(1685647331cab8b81ae5bae9e8b32b81))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.11)(@ledgerhq/lumen-ui-react@0.1.25(1685647331cab8b81ae5bae9e8b32b81))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/cryptoassets
@@ -992,7 +992,7 @@ importers:
         version: 0.1.11
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.24(1685647331cab8b81ae5bae9e8b32b81)
+        version: 0.1.25(1685647331cab8b81ae5bae9e8b32b81)
       '@ledgerhq/react-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/react
@@ -1573,7 +1573,7 @@ importers:
         version: 1.16.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
       '@ledgerhq/crypto-icons':
         specifier: 2.0.1
-        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.11)(@ledgerhq/lumen-ui-rnative@0.1.25(09ada5ee5ea348474dad2c68ccdb1c21))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.11)(@ledgerhq/lumen-ui-rnative@0.1.26(09ada5ee5ea348474dad2c68ccdb1c21))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/cryptoassets
@@ -1657,7 +1657,7 @@ importers:
         version: 0.1.11
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.25(09ada5ee5ea348474dad2c68ccdb1c21)
+        version: 0.1.26(09ada5ee5ea348474dad2c68ccdb1c21)
       '@ledgerhq/native-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/native
@@ -2451,7 +2451,7 @@ importers:
         version: 0.1.11
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.24(1685647331cab8b81ae5bae9e8b32b81)
+        version: 0.1.25(1685647331cab8b81ae5bae9e8b32b81)
       '@ledgerhq/react-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/react
@@ -3098,10 +3098,10 @@ importers:
         version: 0.1.11
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.24(@ledgerhq/lumen-design-core@0.1.11)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
+        version: 0.1.25(@ledgerhq/lumen-design-core@0.1.11)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.25(02bfafa6d2e17a2ae78959fdea772f82)
+        version: 0.1.26(02bfafa6d2e17a2ae78959fdea772f82)
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -11487,7 +11487,7 @@ importers:
     dependencies:
       '@ledgerhq/crypto-icons':
         specifier: 2.0.1
-        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.11)(@ledgerhq/lumen-ui-rnative@0.1.25(1dd0e7412354a1878032940528d87280))(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
+        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.11)(@ledgerhq/lumen-ui-rnative@0.1.26(1dd0e7412354a1878032940528d87280))(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
       '@ledgerhq/icons-ui':
         specifier: workspace:^
         version: link:../icons
@@ -11554,7 +11554,7 @@ importers:
         version: 0.1.11
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.25(1dd0e7412354a1878032940528d87280)
+        version: 0.1.26(1dd0e7412354a1878032940528d87280)
       '@react-native-async-storage/async-storage':
         specifier: 2.1.2
         version: 2.1.2(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))
@@ -16993,8 +16993,8 @@ packages:
   '@ledgerhq/lumen-design-core@0.1.11':
     resolution: {integrity: sha512-X+nwcaPtBX7yuoq/06/zr/pPd96xgX1zxdxFgFtI/8gx/rhfYj50GRcZ8114JxsExrmcOHK4CVpG/7tG0SOkIQ==}
 
-  '@ledgerhq/lumen-ui-react@0.1.24':
-    resolution: {integrity: sha512-qkJAhC69BBFYBBXPhTp4cuNFsm4rhaomDQSzX59/7WJBtTCgG+rA0457+Yx7kjNOFhxfDcGT0om8Osc/6DS7XQ==}
+  '@ledgerhq/lumen-ui-react@0.1.25':
+    resolution: {integrity: sha512-lbq2JCZnhokwkgrK/quxuP7wXGf2FvSGzXsMHBOFt4l7ML0fUCnzeCK/KpTUtDBXVYI5cJCvsnOesPasO4sqlA==}
     peerDependencies:
       '@base-ui/react': ^1.3.0
       '@ledgerhq/lumen-design-core': 0.1.11
@@ -17011,8 +17011,8 @@ packages:
       react-dom: 19.0.0
       tailwind-merge: ^2.6.0
 
-  '@ledgerhq/lumen-ui-rnative@0.1.25':
-    resolution: {integrity: sha512-86+8JFBwqBBKv6NuVjSnoMOt64zDh8c6/cN626I42yquz4Lm+L64Lv7KXNTspqMBhfOjOK60Sy2L/iqCwX4XVQ==}
+  '@ledgerhq/lumen-ui-rnative@0.1.26':
+    resolution: {integrity: sha512-5X/tHk3G8RkqyZszJ0/sr3xMYl9SrifsW0RezlHSiQQuqQN+LSl+I2V2hjPns952mmOtQaxWAqT4nb0IytI3GA==}
     peerDependencies:
       '@gorhom/bottom-sheet': ^5.0.0
       '@ledgerhq/lumen-design-core': 0.1.11
@@ -21188,7 +21188,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.0.0
       react-dom: 19.0.0
-      webpack: '*'
+      webpack: ^5.89.0
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -32912,7 +32912,6 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qrcode-terminal@0.11.0:
@@ -36196,6 +36195,7 @@ packages:
 
   uuid@7.0.3:
     resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
@@ -45157,28 +45157,28 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
       styled-components: 6.1.19(patch_hash=810073718ccefe69fd016893be54d80d86cc6e5ee521455028b93c7cbf3103d7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
 
-  '@ledgerhq/crypto-icons@2.0.1(@ledgerhq/lumen-design-core@0.1.11)(@ledgerhq/lumen-ui-react@0.1.24(1685647331cab8b81ae5bae9e8b32b81))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@ledgerhq/crypto-icons@2.0.1(@ledgerhq/lumen-design-core@0.1.11)(@ledgerhq/lumen-ui-react@0.1.25(1685647331cab8b81ae5bae9e8b32b81))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       react: 19.0.0
     optionalDependencies:
       '@ledgerhq/lumen-design-core': 0.1.11
-      '@ledgerhq/lumen-ui-react': 0.1.24(1685647331cab8b81ae5bae9e8b32b81)
+      '@ledgerhq/lumen-ui-react': 0.1.25(1685647331cab8b81ae5bae9e8b32b81)
       react-dom: 19.0.0(react@19.0.0)
 
-  '@ledgerhq/crypto-icons@2.0.1(@ledgerhq/lumen-design-core@0.1.11)(@ledgerhq/lumen-ui-rnative@0.1.25(09ada5ee5ea348474dad2c68ccdb1c21))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
+  '@ledgerhq/crypto-icons@2.0.1(@ledgerhq/lumen-design-core@0.1.11)(@ledgerhq/lumen-ui-rnative@0.1.26(09ada5ee5ea348474dad2c68ccdb1c21))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
     dependencies:
       react: 19.0.0
     optionalDependencies:
       '@ledgerhq/lumen-design-core': 0.1.11
-      '@ledgerhq/lumen-ui-rnative': 0.1.25(09ada5ee5ea348474dad2c68ccdb1c21)
+      '@ledgerhq/lumen-ui-rnative': 0.1.26(09ada5ee5ea348474dad2c68ccdb1c21)
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
 
-  '@ledgerhq/crypto-icons@2.0.1(@ledgerhq/lumen-design-core@0.1.11)(@ledgerhq/lumen-ui-rnative@0.1.25(1dd0e7412354a1878032940528d87280))(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)':
+  '@ledgerhq/crypto-icons@2.0.1(@ledgerhq/lumen-design-core@0.1.11)(@ledgerhq/lumen-ui-rnative@0.1.26(1dd0e7412354a1878032940528d87280))(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)':
     dependencies:
       react: 19.0.0
     optionalDependencies:
       '@ledgerhq/lumen-design-core': 0.1.11
-      '@ledgerhq/lumen-ui-rnative': 0.1.25(1dd0e7412354a1878032940528d87280)
+      '@ledgerhq/lumen-ui-rnative': 0.1.26(1dd0e7412354a1878032940528d87280)
       react-dom: 19.0.0(react@19.0.0)
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0)
 
@@ -45444,7 +45444,7 @@ snapshots:
       tailwindcss: 4.1.18
       tslib: 2.6.2
 
-  '@ledgerhq/lumen-ui-react@0.1.24(1685647331cab8b81ae5bae9e8b32b81)':
+  '@ledgerhq/lumen-ui-react@0.1.25(1685647331cab8b81ae5bae9e8b32b81)':
     dependencies:
       '@ledgerhq/lumen-design-core': 0.1.11
       '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
@@ -45465,7 +45465,7 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-react@0.1.24(@ledgerhq/lumen-design-core@0.1.11)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)':
+  '@ledgerhq/lumen-ui-react@0.1.25(@ledgerhq/lumen-design-core@0.1.11)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)':
     dependencies:
       '@ledgerhq/lumen-design-core': 0.1.11
       '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
@@ -45478,7 +45478,7 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-rnative@0.1.25(02bfafa6d2e17a2ae78959fdea772f82)':
+  '@ledgerhq/lumen-ui-rnative@0.1.26(02bfafa6d2e17a2ae78959fdea772f82)':
     dependencies:
       '@gorhom/bottom-sheet': 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.1.6(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@ledgerhq/lumen-design-core': 0.1.11
@@ -45494,7 +45494,7 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  '@ledgerhq/lumen-ui-rnative@0.1.25(09ada5ee5ea348474dad2c68ccdb1c21)':
+  '@ledgerhq/lumen-ui-rnative@0.1.26(09ada5ee5ea348474dad2c68ccdb1c21)':
     dependencies:
       '@gorhom/bottom-sheet': 5.2.6(beb07f7799bea5989bf46dbe8fcef3d9)
       '@ledgerhq/lumen-design-core': 0.1.11
@@ -45513,7 +45513,7 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  '@ledgerhq/lumen-ui-rnative@0.1.25(1dd0e7412354a1878032940528d87280)':
+  '@ledgerhq/lumen-ui-rnative@0.1.26(1dd0e7412354a1878032940528d87280)':
     dependencies:
       '@ledgerhq/lumen-design-core': 0.1.11
       '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,8 +33,8 @@ catalog:
   "@ledgerhq/device-transport-kit-web-hid": 1.2.3
   "@ledgerhq/speculos-device-controller": 0.2.3
   "@ledgerhq/lumen-design-core": 0.1.11
-  "@ledgerhq/lumen-ui-react": 0.1.24
-  "@ledgerhq/lumen-ui-rnative": 0.1.25
+  "@ledgerhq/lumen-ui-react": 0.1.25
+  "@ledgerhq/lumen-ui-rnative": 0.1.26
   "@ledgerhq/zcash-utils": 0.1.5
   # React Native
   react-native: 0.79.7


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [ ] **Covered by automatic tests.** _Dependency version bump — no logic changes to test._
- [x] **Impact of the changes:**
  - All screens using Lumen components on mobile (`lumen-ui-rnative` 0.1.25 → 0.1.26)
  - All screens using Lumen components on desktop (`lumen-ui-react` 0.1.24 → 0.1.25)

### 📝 Description

The Lumen UI libraries shipped new minor versions. This PR bumps both packages in the monorepo catalog so all consuming apps pick up the latest releases.

- `@ledgerhq/lumen-ui-react`: `0.1.24` → `0.1.25`
- `@ledgerhq/lumen-ui-rnative`: `0.1.25` → `0.1.26`

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30122](https://ledgerhq.atlassian.net/browse/LIVE-30122)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30122]: https://ledgerhq.atlassian.net/browse/LIVE-30122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ