### PR TITLE
[LWDM] feat(zcash-shielded): [LIVE-30085] sync: identify block height from date

### DIFF
--- a/.changeset/nasty-snails-fold.md
+++ b/.changeset/nasty-snails-fold.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/zcash-shielded": minor
+"@ledgerhq/coin-bitcoin": minor
+---
+
+Use findBlockHeight method in zcash-shielded module to identify start block during synchronization

--- a/libs/coin-modules/coin-bitcoin/src/familyConfig.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/familyConfig.test.ts
@@ -15,20 +15,24 @@ import type { ShieldedSyncResult } from "@ledgerhq/zcash-shielded/types";
 // We mock that module so no Rust addon or live gRPC endpoint is needed.
 
 const mockSyncShielded = jest.fn<Observable<ShieldedSyncResult>, [unknown]>();
+const mockFindBlockHeight = jest.fn<Promise<number>, [number]>();
 
 jest.mock("@ledgerhq/zcash-shielded/ZCashNative", () => ({
   ZCashNative: jest.fn().mockImplementation(() => ({
     syncShielded: mockSyncShielded,
+    findBlockHeight: mockFindBlockHeight,
   })),
 }));
 
 // ─── Mock ZCash (JSON-RPC fallback) ──────────────────────────────────────────
 
 const mockJsonRpcSyncShielded = jest.fn<Observable<ShieldedSyncResult>, [unknown]>();
+const mockJsonRpcFindBlockHeight = jest.fn<Promise<number | undefined>, [number]>();
 
 jest.mock("@ledgerhq/zcash-shielded/ZCash", () => ({
   ZCash: jest.fn().mockImplementation(() => ({
     syncShielded: mockJsonRpcSyncShielded,
+    findBlockHeight: mockJsonRpcFindBlockHeight,
   })),
   ZCASH_JSON_RPC_SERVER_MAINNET: "https://default-json-rpc.example.com",
 }));
@@ -182,7 +186,7 @@ describe("findFamilyConfigById", () => {
       );
     });
 
-    test("starts at block 0 when lastProcessedBlock is null (first sync)", async () => {
+    test("starts at block 0 when lastProcessedBlock is null and birthday is null (first sync)", async () => {
       mockSyncShielded.mockReturnValue(of(makeSyncResult()));
       const familyConfig = findFamilyConfigById("zcash")!;
 
@@ -195,7 +199,7 @@ describe("findFamilyConfigById", () => {
           derivationMode: "",
           initialAccount: {
             ...createFixtureAccount(),
-            privateInfo: makePrivateInfo({ lastProcessedBlock: null }),
+            privateInfo: makePrivateInfo({ lastProcessedBlock: null, birthday: null }),
           },
         },
         defaultSyncConfig,
@@ -203,8 +207,65 @@ describe("findFamilyConfigById", () => {
 
       await firstValueFrom(obs);
 
+      expect(mockFindBlockHeight).not.toHaveBeenCalled();
       expect(mockSyncShielded).toHaveBeenCalledWith(
         expect.objectContaining({ startBlockHeight: 0 }),
+      );
+    });
+
+    test("calls findBlockHeight with birthday timestamp when lastProcessedBlock is null", async () => {
+      mockFindBlockHeight.mockResolvedValue(1_800_000);
+      mockSyncShielded.mockReturnValue(of(makeSyncResult()));
+      const familyConfig = findFamilyConfigById("zcash")!;
+
+      const obs = familyConfig.sync!(
+        {
+          currency,
+          address: "",
+          index: 0,
+          derivationPath: "",
+          derivationMode: "",
+          initialAccount: {
+            ...createFixtureAccount(),
+            privateInfo: makePrivateInfo({ lastProcessedBlock: null, birthday: "2024-01-01" }),
+          },
+        },
+        defaultSyncConfig,
+      );
+
+      await firstValueFrom(obs);
+
+      const expectedTs = Math.floor(new Date("2024-01-01").getTime() / 1000);
+      expect(mockFindBlockHeight).toHaveBeenCalledWith(expectedTs);
+      expect(mockSyncShielded).toHaveBeenCalledWith(
+        expect.objectContaining({ startBlockHeight: 1_800_000 }),
+      );
+    });
+
+    test("lastProcessedBlock takes priority over birthday when both are set", async () => {
+      mockSyncShielded.mockReturnValue(of(makeSyncResult()));
+      const familyConfig = findFamilyConfigById("zcash")!;
+
+      const obs = familyConfig.sync!(
+        {
+          currency,
+          address: "",
+          index: 0,
+          derivationPath: "",
+          derivationMode: "",
+          initialAccount: {
+            ...createFixtureAccount(),
+            privateInfo: makePrivateInfo({ lastProcessedBlock: 500, birthday: "2024-01-01" }),
+          },
+        },
+        defaultSyncConfig,
+      );
+
+      await firstValueFrom(obs);
+
+      expect(mockFindBlockHeight).not.toHaveBeenCalled();
+      expect(mockSyncShielded).toHaveBeenCalledWith(
+        expect.objectContaining({ startBlockHeight: 501 }),
       );
     });
 
@@ -473,6 +534,89 @@ describe("findFamilyConfigById", () => {
 
       expect(mockJsonRpcSyncShielded).toHaveBeenCalledWith(
         expect.objectContaining({ startBlockHeight: 201 }),
+      );
+    });
+
+    test("calls findBlockHeight with birthday timestamp when lastProcessedBlock is null", async () => {
+      mockJsonRpcFindBlockHeight.mockResolvedValue(2_000_000);
+      mockJsonRpcSyncShielded.mockReturnValue(of(makeSyncResult()));
+      const familyConfig = findFamilyConfigById("zcash")!;
+
+      const obs = familyConfig.sync!(
+        {
+          currency,
+          address: "",
+          index: 0,
+          derivationPath: "",
+          derivationMode: "",
+          initialAccount: {
+            ...createFixtureAccount(),
+            privateInfo: makePrivateInfo({ lastProcessedBlock: null, birthday: "2024-06-01" }),
+          },
+        },
+        defaultSyncConfig,
+      );
+
+      await firstValueFrom(obs);
+
+      const expectedTs = Math.floor(new Date("2024-06-01").getTime() / 1000);
+      expect(mockJsonRpcFindBlockHeight).toHaveBeenCalledWith(expectedTs);
+      expect(mockJsonRpcSyncShielded).toHaveBeenCalledWith(
+        expect.objectContaining({ startBlockHeight: 2_000_000 }),
+      );
+    });
+
+    test("falls back to 0 when findBlockHeight returns undefined", async () => {
+      mockJsonRpcFindBlockHeight.mockResolvedValue(undefined);
+      mockJsonRpcSyncShielded.mockReturnValue(of(makeSyncResult()));
+      const familyConfig = findFamilyConfigById("zcash")!;
+
+      const obs = familyConfig.sync!(
+        {
+          currency,
+          address: "",
+          index: 0,
+          derivationPath: "",
+          derivationMode: "",
+          initialAccount: {
+            ...createFixtureAccount(),
+            privateInfo: makePrivateInfo({ lastProcessedBlock: null, birthday: "2024-06-01" }),
+          },
+        },
+        defaultSyncConfig,
+      );
+
+      await firstValueFrom(obs);
+
+      expect(mockJsonRpcSyncShielded).toHaveBeenCalledWith(
+        expect.objectContaining({ startBlockHeight: 0 }),
+      );
+    });
+
+    test("lastProcessedBlock takes priority over birthday when both are set", async () => {
+      mockJsonRpcSyncShielded.mockReturnValue(of(makeSyncResult()));
+      const familyConfig = findFamilyConfigById("zcash")!;
+
+      const obs = familyConfig.sync!(
+        {
+          currency,
+          address: "",
+          index: 0,
+          derivationPath: "",
+          derivationMode: "",
+          initialAccount: {
+            ...createFixtureAccount(),
+            privateInfo: makePrivateInfo({ lastProcessedBlock: 300, birthday: "2024-06-01" }),
+          },
+        },
+        defaultSyncConfig,
+      );
+
+      await firstValueFrom(obs);
+
+      expect(mockJsonRpcFindBlockHeight).not.toHaveBeenCalled();
+      expect(mockJsonRpcSyncShielded).toHaveBeenCalledWith(
+        expect.objectContaining({ startBlockHeight: 301 }),
       );
     });
 

--- a/libs/coin-modules/coin-bitcoin/src/familyConfig.ts
+++ b/libs/coin-modules/coin-bitcoin/src/familyConfig.ts
@@ -64,6 +64,21 @@ const getJsonRpcModule = () => {
   return jsonRpcModuleCache;
 };
 
+async function resolveStartBlockHeight(
+  lastProcessedBlock: number | null | undefined,
+  birthday: string | null | undefined,
+  findBlockHeight: (timestamp: number) => Promise<number>,
+): Promise<number> {
+  if (lastProcessedBlock !== null && lastProcessedBlock !== undefined) {
+    return lastProcessedBlock + 1;
+  }
+  if (birthday) {
+    const ts = Math.floor(new Date(birthday).getTime() / 1000);
+    return findBlockHeight(ts);
+  }
+  return 0;
+}
+
 const zcashSyncShielded = (
   acc: AccountShapeInfo<ZcashAccount>,
   _syncConfig: SyncConfig,
@@ -73,22 +88,27 @@ const zcashSyncShielded = (
     if (!viewingKey) {
       throw new Error("Missing unified full viewing key (ufvk) for ZCash shielded sync");
     }
-    const startBlockHeight = (() => {
-      const blockHeight = acc.initialAccount?.privateInfo?.lastProcessedBlock;
-      return blockHeight !== null && blockHeight !== undefined ? blockHeight + 1 : 0;
-    })();
+    const { lastProcessedBlock, birthday } = acc.initialAccount?.privateInfo ?? {};
+
     if (useNative) {
       // Native Rust engine: only loads ZCashNative — no WASM dependency
       return from(getNativeModule()).pipe(
-        mergeMap(({ ZCashNative }) =>
-          new ZCashNative({
+        mergeMap(({ ZCashNative }) => {
+          const client = new ZCashNative({
             grpcUrl: ZCASH_GRPC_URL_CUSTOM ?? ZCASH_GRPC_URL_MAINNET,
-          }).syncShielded({
-            startBlockHeight,
-            viewingKey,
-            maxBatchSize: ZCASH_NATIVE_CHUNK_SIZE,
-          }),
-        ),
+          });
+          return from(
+            resolveStartBlockHeight(lastProcessedBlock, birthday, ts => client.findBlockHeight(ts)),
+          ).pipe(
+            mergeMap(startBlockHeight =>
+              client.syncShielded({
+                startBlockHeight,
+                viewingKey,
+                maxBatchSize: ZCASH_NATIVE_CHUNK_SIZE,
+              }),
+            ),
+          );
+        }),
       );
     }
 
@@ -98,11 +118,20 @@ const zcashSyncShielded = (
         const zcash = new ZCash({
           nodeUrl: ZCASH_JSON_RPC_SERVER_CUSTOM ?? ZCASH_JSON_RPC_SERVER_MAINNET,
         });
-        return zcash.syncShielded({
-          startBlockHeight,
-          viewingKey,
-          maxBatchSize: ZCASH_MAX_BATCH_SIZE,
-        });
+        return from(
+          resolveStartBlockHeight(lastProcessedBlock, birthday, async ts => {
+            const height = await zcash.findBlockHeight(ts);
+            return height ?? 0;
+          }),
+        ).pipe(
+          mergeMap(startBlockHeight =>
+            zcash.syncShielded({
+              startBlockHeight,
+              viewingKey,
+              maxBatchSize: ZCASH_MAX_BATCH_SIZE,
+            }),
+          ),
+        );
       }),
     );
   });

--- a/libs/coin-modules/zcash-shielded/jest.config.js
+++ b/libs/coin-modules/zcash-shielded/jest.config.js
@@ -2,8 +2,9 @@ module.exports = {
   collectCoverageFrom: ["src/**/*.ts"],
   coveragePathIgnorePatterns: [
     "test/cli.ts",
-    "src/stubs/",
-    "src/ipc/",
+    "/src/stubs/",
+    "/src/ipc/",
+    "/src/types\\.ts",
     ".*\\.integration\\.test\\.[tj]s",
     ".*\\.integ\\.test\\.[tj]s",
   ],
@@ -11,7 +12,12 @@ module.exports = {
   coverageDirectory: "coverage",
   testEnvironment: "node",
   roots: ["<rootDir>/src", "<rootDir>/tests"],
-  testPathIgnorePatterns: ["lib/", "lib-es/", ".*\\.integration\\.test\\.[tj]s", ".*\\.integ\\.test\\.[tj]s"],
+  testPathIgnorePatterns: [
+    "lib/",
+    "lib-es/",
+    ".*\\.integration\\.test\\.[tj]s",
+    ".*\\.integ\\.test\\.[tj]s",
+  ],
   reporters: [
     "default",
     ...(process.env.CI ? ["github-actions"] : []),

--- a/libs/coin-modules/zcash-shielded/src/ZCashNative.ts
+++ b/libs/coin-modules/zcash-shielded/src/ZCashNative.ts
@@ -28,6 +28,7 @@ import { ZCASH_LOG_TYPE } from "./constants";
 import type { ShieldedSyncResult, SyncEstimatedTime, ZCashNativeClient } from "./types";
 import type { SyncShieldedArgs } from "./types";
 import {
+  findBlockHeightJob,
   getChainTipJob,
   startSyncJob,
   validateStartSyncArgs,
@@ -52,6 +53,14 @@ export class ZCashNative implements ZCashNativeClient {
    */
   async getChainTip(): Promise<number> {
     return getChainTipJob(this.grpcUrl);
+  }
+
+  /**
+   * Returns the block height corresponding to the given Unix timestamp,
+   * via the native gRPC client (interpolation search + streaming range).
+   */
+  async findBlockHeight(timestamp: number): Promise<number> {
+    return findBlockHeightJob(this.grpcUrl, timestamp);
   }
 
   /**

--- a/libs/coin-modules/zcash-shielded/src/ZCashNativeIPC.ts
+++ b/libs/coin-modules/zcash-shielded/src/ZCashNativeIPC.ts
@@ -39,6 +39,7 @@ import type { SyncShieldedArgs } from "./types";
 import {
   ZCASH_IPC,
   type CancelSyncArgs,
+  type FindBlockHeightArgs,
   type GetChainTipArgs,
   type RequestId,
   type StartSyncArgs,
@@ -106,6 +107,20 @@ export class ZCashNativeIPC implements ZCashNativeClient {
     const ipc = getIpcRenderer();
     const payload: GetChainTipArgs = { requestId: nextRequestId(), grpcUrl: this.grpcUrl };
     return (await ipc.invoke(ZCASH_IPC.getChainTip, payload)) as number;
+  }
+
+  /**
+   * Returns the block height corresponding to the given Unix timestamp,
+   * via the UtilityProcess (interpolation search + streaming range).
+   */
+  async findBlockHeight(timestamp: number): Promise<number> {
+    const ipc = getIpcRenderer();
+    const payload: FindBlockHeightArgs = {
+      requestId: nextRequestId(),
+      grpcUrl: this.grpcUrl,
+      timestamp,
+    };
+    return (await ipc.invoke(ZCASH_IPC.findBlockHeight, payload)) as number;
   }
 
   /**

--- a/libs/coin-modules/zcash-shielded/src/ipc/contract.ts
+++ b/libs/coin-modules/zcash-shielded/src/ipc/contract.ts
@@ -42,6 +42,8 @@ export type RequestId = string;
 export const ZCASH_IPC = {
   /** invoke → number (chain tip height) */
   getChainTip: "zcash:getChainTip",
+  /** invoke → number (block height for a given timestamp) */
+  findBlockHeight: "zcash:findBlockHeight",
   /** invoke → void once the start-sync message has been posted to the utility. Chunks arrive on `stream`. */
   startSync: "zcash:startSync",
   /** invoke → void. Propagates a cancel signal to the utility. */
@@ -57,6 +59,12 @@ export type ZcashIpcChannel = (typeof ZCASH_IPC)[keyof typeof ZCASH_IPC];
 export type GetChainTipArgs = {
   requestId: RequestId;
   grpcUrl: string;
+};
+
+export type FindBlockHeightArgs = {
+  requestId: RequestId;
+  grpcUrl: string;
+  timestamp: number;
 };
 
 export type StartSyncArgs = {
@@ -93,10 +101,13 @@ export type StreamEvent =
 
 export type UtilityInboundMessage =
   | { type: "get-chain-tip"; args: GetChainTipArgs }
+  | { type: "find-block-height"; args: FindBlockHeightArgs }
   | { type: "start-sync"; args: StartSyncArgs }
   | { type: "cancel-sync"; args: CancelSyncArgs };
 
 export type UtilityOutboundMessage =
   | { type: "chain-tip"; requestId: RequestId; height: number }
   | { type: "chain-tip-error"; requestId: RequestId; message: string }
+  | { type: "block-height"; requestId: RequestId; height: number }
+  | { type: "block-height-error"; requestId: RequestId; message: string }
   | { type: "stream"; event: StreamEvent };

--- a/libs/coin-modules/zcash-shielded/src/ipc/main-host.ts
+++ b/libs/coin-modules/zcash-shielded/src/ipc/main-host.ts
@@ -29,6 +29,7 @@ import { log } from "@ledgerhq/logs";
 import {
   ZCASH_IPC,
   type CancelSyncArgs,
+  type FindBlockHeightArgs,
   type GetChainTipArgs,
   type RequestId,
   type StartSyncArgs,
@@ -138,6 +139,7 @@ type HostState = {
    */
   resolvers: {
     chainTip: OneShotResolver<number>;
+    blockHeight: OneShotResolver<number>;
   };
 };
 
@@ -147,6 +149,7 @@ const state: HostState = {
   pendingSyncs: new Map(),
   resolvers: {
     chainTip: new OneShotResolver<number>("chain-tip"),
+    blockHeight: new OneShotResolver<number>("block-height"),
   },
 };
 
@@ -230,6 +233,18 @@ function handleUtilityMessage(msg: UtilityOutboundMessage): void {
       }
       return;
     }
+    case "block-height": {
+      if (!state.resolvers.blockHeight.resolve(msg.requestId, msg.height)) {
+        log(LOG_TYPE, "block-height reply for unknown requestId", { requestId: msg.requestId });
+      }
+      return;
+    }
+    case "block-height-error": {
+      if (!state.resolvers.blockHeight.reject(msg.requestId, new Error(msg.message))) {
+        log(LOG_TYPE, "block-height-error for unknown requestId", { requestId: msg.requestId });
+      }
+      return;
+    }
     case "stream": {
       const sync = state.pendingSyncs.get(msg.event.requestId);
       if (!sync) {
@@ -282,6 +297,14 @@ function registerHandlers(): void {
     (_event, args): Promise<number> =>
       state.resolvers.chainTip.register(args.requestId, () =>
         postToUtility({ type: "get-chain-tip", args }),
+      ),
+  );
+
+  ipcMain.handle<FindBlockHeightArgs, number>(
+    ZCASH_IPC.findBlockHeight,
+    (_event, args): Promise<number> =>
+      state.resolvers.blockHeight.register(args.requestId, () =>
+        postToUtility({ type: "find-block-height", args }),
       ),
   );
 

--- a/libs/coin-modules/zcash-shielded/src/ipc/utility-entry.ts
+++ b/libs/coin-modules/zcash-shielded/src/ipc/utility-entry.ts
@@ -14,9 +14,10 @@
 
 import { log } from "@ledgerhq/logs";
 import { ZCASH_LOG_TYPE } from "../constants";
-import { getChainTipJob, startSyncJob } from "../native-engine/engine";
+import { findBlockHeightJob, getChainTipJob, startSyncJob } from "../native-engine/engine";
 import type {
   CancelSyncArgs,
+  FindBlockHeightArgs,
   GetChainTipArgs,
   StartSyncArgs,
   UtilityInboundMessage,
@@ -52,6 +53,19 @@ async function handleGetChainTip(port: ParentPort, args: GetChainTipArgs): Promi
   } catch (err) {
     send(port, {
       type: "chain-tip-error",
+      requestId: args.requestId,
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+async function handleFindBlockHeight(port: ParentPort, args: FindBlockHeightArgs): Promise<void> {
+  try {
+    const height = await findBlockHeightJob(args.grpcUrl, args.timestamp);
+    send(port, { type: "block-height", requestId: args.requestId, height });
+  } catch (err) {
+    send(port, {
+      type: "block-height-error",
       requestId: args.requestId,
       message: err instanceof Error ? err.message : String(err),
     });
@@ -126,6 +140,9 @@ export function bootstrapUtility(port: ParentPort): void {
     switch (message.type) {
       case "get-chain-tip":
         void handleGetChainTip(port, message.args);
+        break;
+      case "find-block-height":
+        void handleFindBlockHeight(port, message.args);
         break;
       case "start-sync":
         void handleStartSync(port, message.args);

--- a/libs/coin-modules/zcash-shielded/src/native-engine/engine.ts
+++ b/libs/coin-modules/zcash-shielded/src/native-engine/engine.ts
@@ -61,6 +61,18 @@ export async function getChainTipJob(grpcUrl: string): Promise<number> {
 }
 
 /**
+ * Returns the block height corresponding to the given Unix timestamp
+ * using the native gRPC client (interpolation search + streaming range).
+ *
+ * @param timestamp - Unix timestamp in **seconds** (not milliseconds).
+ *   Use `Math.floor(Date.getTime() / 1000)` to convert from a JS `Date`.
+ */
+export async function findBlockHeightJob(grpcUrl: string, timestamp: number): Promise<number> {
+  const native = await getNativeModule();
+  return native.findBlockHeight(grpcUrl, timestamp);
+}
+
+/**
  * Runs the shielded sync loop.
  *
  * Drives the native tonic gRPC stream in `maxBatchSize`-block chunks, emitting

--- a/libs/coin-modules/zcash-shielded/src/stubs/ZCashNative.native.ts
+++ b/libs/coin-modules/zcash-shielded/src/stubs/ZCashNative.native.ts
@@ -40,6 +40,10 @@ export class ZCashNative implements ZCashNativeClient {
     throw new Error(UNSUPPORTED_ERROR_MESSAGE);
   }
 
+  async findBlockHeight(_timestamp: number): Promise<number> {
+    throw new Error(UNSUPPORTED_ERROR_MESSAGE);
+  }
+
   syncShielded(_args: SyncShieldedArgs): Observable<ShieldedSyncResult> {
     return throwError(() => new Error(UNSUPPORTED_ERROR_MESSAGE));
   }

--- a/libs/coin-modules/zcash-shielded/src/types.ts
+++ b/libs/coin-modules/zcash-shielded/src/types.ts
@@ -25,6 +25,8 @@ export interface ZCashNativeClient {
   readonly grpcUrl: string;
   readonly network: string;
   getChainTip(): Promise<number>;
+  /** @param timestamp - Unix timestamp in **seconds** (not milliseconds). */
+  findBlockHeight(timestamp: number): Promise<number>;
   estimatedSyncTime(totalBlocks: number): Promise<(processedBlocks: number) => SyncEstimatedTime>;
   syncShielded(args: SyncShieldedArgs): Observable<ShieldedSyncResult>;
 }

--- a/libs/coin-modules/zcash-shielded/tests/ZCashNative.test.ts
+++ b/libs/coin-modules/zcash-shielded/tests/ZCashNative.test.ts
@@ -14,11 +14,13 @@ import { BigNumber } from "bignumber.js";
 import { makeRawChunk } from "./helpers/fixtures";
 
 const getChainTipJobMock = jest.fn();
+const findBlockHeightJobMock = jest.fn();
 const startSyncJobMock = jest.fn();
 const validateStartSyncArgsMock = jest.fn();
 
 jest.mock("../src/native-engine/engine", () => ({
   getChainTipJob: (...args: unknown[]) => getChainTipJobMock(...args),
+  findBlockHeightJob: (...args: unknown[]) => findBlockHeightJobMock(...args),
   startSyncJob: (...args: unknown[]) => startSyncJobMock(...args),
   validateStartSyncArgs: (...args: unknown[]) => validateStartSyncArgsMock(...args),
 }));
@@ -30,6 +32,7 @@ import { ZCashNative } from "../src/ZCashNative";
 
 beforeEach(() => {
   getChainTipJobMock.mockReset();
+  findBlockHeightJobMock.mockReset();
   startSyncJobMock.mockReset();
   validateStartSyncArgsMock.mockReset().mockReturnValue(null);
 });
@@ -42,6 +45,15 @@ describe("ZCashNative (in-process wrapper)", () => {
 
     expect(height).toBe(2_700_000);
     expect(getChainTipJobMock).toHaveBeenCalledWith("grpc://node");
+  });
+
+  it("findBlockHeight delegates to findBlockHeightJob with the configured grpcUrl and timestamp", async () => {
+    findBlockHeightJobMock.mockResolvedValueOnce(1_800_000);
+
+    const height = await new ZCashNative({ grpcUrl: "grpc://node" }).findBlockHeight(1_700_000_000);
+
+    expect(height).toBe(1_800_000);
+    expect(findBlockHeightJobMock).toHaveBeenCalledWith("grpc://node", 1_700_000_000);
   });
 
   it("syncShielded rehydrates BigNumber amounts for every engine chunk", async () => {

--- a/libs/coin-modules/zcash-shielded/tests/ZCashNativeIPC.test.ts
+++ b/libs/coin-modules/zcash-shielded/tests/ZCashNativeIPC.test.ts
@@ -50,7 +50,8 @@ import { ZCashNativeIPC } from "../src/ZCashNativeIPC";
  * can drive stream events without caring about how many times `on` was called.
  */
 function getLatestStreamListener(ipc: IpcRendererLike): (event: unknown, payload: unknown) => void {
-  const call = ipc.on.mock.calls.findLast(([channel]) => channel === ZCASH_IPC.stream);
+  const filtered = ipc.on.mock.calls.filter(([channel]) => channel === ZCASH_IPC.stream);
+  const call = filtered[filtered.length - 1];
   if (!call) throw new Error("no stream listener registered");
   return call[1] as (event: unknown, payload: unknown) => void;
 }
@@ -80,6 +81,23 @@ describe("ZCashNativeIPC (renderer IPC client)", () => {
       grpcUrl: string;
     };
     expect(payload.grpcUrl).toBe("grpc://node.example");
+    expect(payload.requestId).toMatch(/^zcash-/);
+  });
+
+  it("findBlockHeight forwards the grpcUrl and timestamp and returns the height", async () => {
+    mockIpcRenderer.invoke.mockResolvedValueOnce(1_800_000);
+
+    const native = new ZCashNativeIPC({ grpcUrl: "grpc://node.example", network: "mainnet" });
+    const height = await native.findBlockHeight(1_700_000_000);
+
+    expect(height).toBe(1_800_000);
+    const payload = expectInvoke(mockIpcRenderer, ZCASH_IPC.findBlockHeight) as {
+      requestId: string;
+      grpcUrl: string;
+      timestamp: number;
+    };
+    expect(payload.grpcUrl).toBe("grpc://node.example");
+    expect(payload.timestamp).toBe(1_700_000_000);
     expect(payload.requestId).toMatch(/^zcash-/);
   });
 

--- a/libs/coin-modules/zcash-shielded/tests/engine.integ.test.ts
+++ b/libs/coin-modules/zcash-shielded/tests/engine.integ.test.ts
@@ -12,7 +12,7 @@
  * string) — BigNumber rehydration is verified in the client-side test.
  */
 
-import { getChainTipJob, startSyncJob } from "../src/native-engine/engine";
+import { getChainTipJob, findBlockHeightJob, startSyncJob } from "../src/native-engine/engine";
 import { ZCASH_GRPC_URL_MAINNET } from "../src/constants";
 import type { ShieldedSyncResultRaw, ShieldedTransactionRaw } from "../src/types";
 
@@ -88,6 +88,16 @@ describe("ZCash native engine integration (real gRPC, mainnet)", () => {
     });
   });
 
+  describe("findBlockHeightJob", () => {
+    it("should return the block height closest to the given timestamp", async () => {
+      const height = await findBlockHeightJob(
+        ZCASH_GRPC_URL_MAINNET,
+        Math.floor(new Date("2024-01-01T00:00:00Z").getTime() / 1000),
+      );
+      expect(height).toBe(2_351_031);
+    });
+  });
+
   describe("startSyncJob — empty range", () => {
     it("should emit one chunk with no transactions when already at tip", async () => {
       const tip = await getChainTipJob(ZCASH_GRPC_URL_MAINNET);
@@ -114,7 +124,7 @@ describe("ZCash native engine integration (real gRPC, mainnet)", () => {
         maxBatchSize: 10_000,
       });
       txMap = new Map(result.transactions.map(tx => [tx.id, tx]));
-    }, 30_000);
+    }, 60_000);
 
     it("should find all three known Orchard transactions", () => {
       expect(txMap.has(TX1.txid)).toBe(true);

--- a/libs/coin-modules/zcash-shielded/tests/engine.test.ts
+++ b/libs/coin-modules/zcash-shielded/tests/engine.test.ts
@@ -11,21 +11,25 @@
 jest.mock("@ledgerhq/zcash-utils", () => ({
   startSync: jest.fn(),
   getChainTip: jest.fn(),
+  findBlockHeight: jest.fn(),
   deriveKeys: jest.fn(),
 }));
 
 import {
   getChainTipJob,
+  findBlockHeightJob,
   startSyncJob,
   validateStartSyncArgs,
   type StartSyncJobArgs,
 } from "../src/native-engine/engine";
 import * as nativeUtils from "@ledgerhq/zcash-utils";
+import type { ShieldedNote } from "@ledgerhq/zcash-utils";
 import { ZCASH_GRPC_URL_TESTNET } from "../src/constants";
 import type { ShieldedSyncResultRaw } from "../src/types";
 
-const mockGetChainTip = nativeUtils.getChainTip as jest.Mock;
-const mockStartSync = nativeUtils.startSync as jest.Mock;
+const mockGetChainTip = jest.mocked(nativeUtils.getChainTip);
+const mockFindBlockHeight = jest.mocked(nativeUtils.findBlockHeight);
+const mockStartSync = jest.mocked(nativeUtils.startSync);
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -45,7 +49,7 @@ function baseNativeTx() {
     blockHash: "blockhash1",
     blockTime: 1700000000,
     fee: 5000,
-    saplingNotes: [] as { amount: number; transferType: string; memo: string }[],
+    saplingNotes: new Array<ShieldedNote>(),
     orchardNotes: [{ amount: 5000, transferType: "incoming", memo: "hello" }],
   };
 }
@@ -54,7 +58,7 @@ function makeStream(txs: ReturnType<typeof makeNativeTx>[], blocksScanned = 100)
   let index = 0;
   return {
     next: jest.fn(() => Promise.resolve(index < txs.length ? txs[index++] : null)),
-    stats: jest.fn(() => Promise.resolve({ blocksScanned })),
+    stats: jest.fn(() => Promise.resolve({ blocksScanned, elapsedMs: 0 })),
     cancel: jest.fn(),
   };
 }
@@ -71,7 +75,7 @@ function makeHangingStream() {
   return {
     stream: {
       next: jest.fn(() => pending),
-      stats: jest.fn(() => Promise.resolve({ blocksScanned: 0 })),
+      stats: jest.fn(() => Promise.resolve({ blocksScanned: 0, elapsedMs: 0 })),
       cancel: jest.fn(),
     },
     release: () => release(null),
@@ -133,6 +137,17 @@ describe("getChainTipJob", () => {
     const tip = await getChainTipJob(ZCASH_GRPC_URL_TESTNET);
     expect(tip).toBe(3_936_000);
     expect(mockGetChainTip).toHaveBeenCalledWith(ZCASH_GRPC_URL_TESTNET);
+  });
+});
+
+// ─── findBlockHeightJob ──────────────────────────────────────────────────────
+
+describe("findBlockHeightJob", () => {
+  it("should return the block height for the given timestamp", async () => {
+    mockFindBlockHeight.mockResolvedValue(2_634_000);
+    const height = await findBlockHeightJob(ZCASH_GRPC_URL_TESTNET, 1_700_000_000);
+    expect(height).toBe(2_634_000);
+    expect(mockFindBlockHeight).toHaveBeenCalledWith(ZCASH_GRPC_URL_TESTNET, 1_700_000_000);
   });
 });
 
@@ -326,17 +341,13 @@ describe("startSyncJob — onActiveStream hook", () => {
     mockStartSync.mockResolvedValue(stream);
 
     let cancelled = false;
-    let activeStream: { cancel: jest.Mock } | null = null;
-    const jobPromise = startSyncJob(
-      makeArgs({ maxBatchSize: 100 }),
-      () => {},
-      {
-        isCancelled: () => cancelled,
-        onActiveStream: s => {
-          activeStream = s as typeof activeStream;
-        },
+    let activeStream: { cancel: () => void } | null = null;
+    const jobPromise = startSyncJob(makeArgs({ maxBatchSize: 100 }), () => {}, {
+      isCancelled: () => cancelled,
+      onActiveStream: s => {
+        activeStream = s;
       },
-    );
+    });
 
     // Wait for the engine to enter stream.next()
     await waitFor(() => expect(stream.next).toHaveBeenCalled());

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,8 +64,8 @@ catalogs:
       specifier: 0.2.3
       version: 0.2.3
     '@ledgerhq/zcash-utils':
-      specifier: 0.1.5
-      version: 0.1.5
+      specifier: 0.2.0
+      version: 0.2.0
     '@playwright/test':
       specifier: 1.53.0
       version: 1.53.0
@@ -1013,7 +1013,7 @@ importers:
         version: link:../../libs/coin-modules/zcash-shielded
       '@ledgerhq/zcash-utils':
         specifier: 'catalog:'
-        version: 0.1.5
+        version: 0.2.0
       '@lottiefiles/dotlottie-react':
         specifier: 0.17.13
         version: 0.17.13(react@19.0.0)
@@ -6203,7 +6203,7 @@ importers:
         version: 0.2.0
       '@ledgerhq/zcash-utils':
         specifier: 'catalog:'
-        version: 0.1.5
+        version: 0.2.0
       bignumber.js:
         specifier: 9.1.2
         version: 9.1.2
@@ -17090,8 +17090,8 @@ packages:
   '@ledgerhq/zcash-decrypt@0.2.0':
     resolution: {integrity: sha512-9UpIbA7KTLv/WJTua9mPF5Gvasjn4LbyBir2zIKATJkbPbUMv3ngfZrW8PP8f0RwvpgHUIKXEUqqKpJJGUIyFA==}
 
-  '@ledgerhq/zcash-utils@0.1.5':
-    resolution: {integrity: sha512-Aim30vuAIsiciRuXfQSI5qhS5ufhPnlH2gE9mma6Q1fSBJQFWkQWJuyp4S0M0vscFNjzAdNnsYYD+tP03xx4Rg==}
+  '@ledgerhq/zcash-utils@0.2.0':
+    resolution: {integrity: sha512-nyM8HTmh/85NBOyDmoGNQ1XhoWDsZjDIptuy2VE2bju0cQlAqVKRR9b2lXtJaVG+UkriIDSMIeEvEmPNHtxLnQ==}
 
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
@@ -45804,7 +45804,7 @@ snapshots:
 
   '@ledgerhq/zcash-decrypt@0.2.0': {}
 
-  '@ledgerhq/zcash-utils@0.1.5': {}
+  '@ledgerhq/zcash-utils@0.2.0': {}
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,7 +35,7 @@ catalog:
   "@ledgerhq/lumen-design-core": 0.1.11
   "@ledgerhq/lumen-ui-react": 0.1.25
   "@ledgerhq/lumen-ui-rnative": 0.1.26
-  "@ledgerhq/zcash-utils": 0.1.5
+  "@ledgerhq/zcash-utils": 0.2.0
   # React Native
   react-native: 0.79.7
   "@react-native/assets-registry": 0.79.7


### PR DESCRIPTION
  ✅ Checklist                                                                                                                                                                                     

  [x] npx changeset was attached.                                                                                                                                                                    
  [x] Covered by automatic tests. 6 new unit tests in familyConfig.test.ts covering both paths (native gRPC + JSON-RPC fallback).
  [x] Impact of the changes:                                                                                                                                                                         
    - @ledgerhq/zcash-shielded: new public method findBlockHeight available on ZCashNativeClient (interface, ZCashNative, ZCashNativeIPC, React Native stub), with full IPC wiring (contract → main-host → utility-entry → engine).                                                                                                                                                             
    - @ledgerhq/coin-bitcoin: the ZCash shielded sync now uses the account birthday to compute the initial startBlockHeight instead of always scanning from block 0.
    - QA should focus on: first sync of a ZCash shielded account with a birthday set → verify the scan starts at the correct block height rather than 0. Also verify incremental sync (with lastProcessedBlock set) remains unchanged.                                                                                                                                                       
                                                                                                                                                                                                   
  📝 Description                                                                                                                                                                                   
                  
Prior to this PR, the first ZCash shielded sync always started scanning from block 0, even when the user had entered a birthday date in the activation modal. The birthday value was correctly persisted in privateInfo.birthday but ignored when computing startBlockHeight.
                                                                                                                                                                                                   
This PR wires the findBlockHeight method from @ledgerhq/zcash-utils 0.2.0 across the full ZCash stack:                                                                                           
                                                                                                                                     
  ❓ Context                                                                                                                                                                                       
   
  - JIRA: LIVE-30085                                                                                                                                                                               
                  
  ---
  🧐 Checklist for the PR Reviewers
                                   
  - The code aligns with the requirements described in the linked JIRA or GitHub issue.
  - The PR description clearly documents the changes made and explains any technical trade-offs or design decisions.                                                                               
  - There are no undocumented trade-offs, technical debt, or maintainability issues.
  - The PR has been tested thoroughly, and any potential edge cases have been considered and handled.                                                                                              
  - Any new dependencies have been justified and documented.
  - Performance considerations have been taken into account. (changes have been profiled or benchmarked if necessary)                                                                              
     