### PR TITLE
[LWDM] feat(tezos): refine operation mode mapping and validation for staking…

### DIFF
--- a/libs/coin-modules/coin-tezos/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/craftTransaction.ts
@@ -3,6 +3,7 @@ import { type OperationContents, OpKind } from "@taquito/rpc";
 import { getRevealFee, getRevealGasLimit } from "@taquito/taquito";
 import coinConfig from "../config";
 import { UnsupportedTransactionMode } from "../types/errors";
+import type { TezosOperationMode } from "../types/model";
 import { createMockSigner } from "../utils";
 import { getTezosToolkit } from "./tezosToolkit";
 
@@ -19,7 +20,7 @@ export async function craftTransaction(
     counter?: number;
   },
   transaction: {
-    type: "send" | "delegate" | "undelegate" | "send_token";
+    type: TezosOperationMode;
     recipient: string;
     amount: bigint;
     fee: TransactionFee;

--- a/libs/coin-modules/coin-tezos/src/utils.test.ts
+++ b/libs/coin-modules/coin-tezos/src/utils.test.ts
@@ -65,13 +65,23 @@ describe("resolveTezosOperationMode", () => {
     expect(resolveTezosOperationMode("send", { type: "native" })).toBe("send");
   });
 
-  it("maps stake to delegate regardless of asset", () => {
+  it("maps staking intents to real staking modes regardless of asset", () => {
     expect(
       resolveTezosOperationMode("stake", {
         type: "token",
         assetReference: "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU:0",
       }),
-    ).toBe("delegate");
+    ).toBe("stake");
+
+    expect(resolveTezosOperationMode("unstake", { type: "native" })).toBe("unstake");
+    expect(resolveTezosOperationMode("finalize_unstake", { type: "native" })).toBe(
+      "finalize_unstake",
+    );
+  });
+
+  it("maps delegation intents to delegation modes", () => {
+    expect(resolveTezosOperationMode("delegate", { type: "native" })).toBe("delegate");
+    expect(resolveTezosOperationMode("undelegate", { type: "native" })).toBe("undelegate");
   });
 });
 

--- a/libs/coin-modules/coin-tezos/src/utils.ts
+++ b/libs/coin-modules/coin-tezos/src/utils.ts
@@ -27,16 +27,20 @@ export const MIN_SUGGESTED_FEE_SMALL_TRANSFER = 489;
 export const OP_SIZE_XTZ_TRANSFER = 154;
 
 /**
- * Helper function to map generic staking intents to Tezos operation modes
+ * Helper function to map generic intents to Tezos operation modes.
  */
-export function mapIntentTypeToTezosMode(intentType: string): "send" | "delegate" | "undelegate" {
+export function mapIntentTypeToTezosMode(intentType: string): TezosOperationMode {
   switch (intentType) {
-    case "stake":
     case "delegate":
       return "delegate";
-    case "unstake":
     case "undelegate":
       return "undelegate";
+    case "stake":
+      return "stake";
+    case "unstake":
+      return "unstake";
+    case "finalize_unstake":
+      return "finalize_unstake";
     default:
       return "send";
   }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - `mapIntentTypeToTezosMode` now returns the actual staking modes (`stake`, `unstake`, `finalize_unstake`) directly instead of collapsing them onto `delegate`/`undelegate`. Downstream callers (craft, estimate, validateIntent) receive the precise mode and can dispatch correctly.

### 📝 Description

Fixes incorrect mode mapping for Tezos staking intents and ensures the logic layer accepts all valid operation modes.

**Changes:**
- `utils.ts` — `mapIntentTypeToTezosMode` now returns `TezosOperationMode` (the full union) and maps `stake`, `unstake`, and `finalize_unstake` to their own modes instead of collapsing them onto `delegate`/`undelegate`.
- `logic/craftTransaction.ts` — Widens the `transaction.type` parameter from a narrow string union to `TezosOperationMode` so all modes (including staking) can be crafted without a type error.
- `utils.test.ts` — Extends `resolveTezosOperationMode` tests to assert correct passthrough for all staking and delegation modes.

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-28757


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
