### PR TITLE
[LWDM] feat(tezos): streamline staking operation mode handling

### DIFF
--- a/.changeset/sharp-drinks-drum.md
+++ b/.changeset/sharp-drinks-drum.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tezos": minor
+---
+
+Add support for the `finalize_unstake` Tezos intent in transaction crafting, and fix stake-related amount handling so stake, unstake, and finalize_unstake intents are passed through correctly.

--- a/libs/coin-modules/coin-tezos/src/api/index.test.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.test.ts
@@ -19,7 +19,7 @@ const logicCraftTransactionMock = jest.fn(
 
 jest.mock("../logic", () => ({
   listOperations: async () => logicGetTransactions(),
-  estimateFees: async () => logicEstimateFees(),
+  estimateFees: (...args: unknown[]) => logicEstimateFees(...args),
   craftTransaction: (account: unknown, transaction: { fee: { fees: string } }) =>
     logicCraftTransactionMock(account, transaction),
   rawEncode: () => Promise.resolve("tz1heMGVHQnx7ALDcDKqez8fan64Eyicw4DJ"),
@@ -305,6 +305,58 @@ describe("craftTransaction", () => {
       );
     });
   });
+  it.each(["stake", "unstake"] as const)(
+    "passes %s mode and explicit amount through to craftTransaction",
+    async type => {
+      logicEstimateFees.mockResolvedValue({
+        estimatedFees: DEFAULT_ESTIMATED_FEES,
+        fees: DEFAULT_ESTIMATED_FEES,
+        gasLimit: DEFAULT_GAS_LIMIT,
+        storageLimit: DEFAULT_STORAGE_LIMIT,
+      });
+
+      await api.craftTransaction({
+        intentType: "staking",
+        type,
+        sender: "tz1test",
+        recipient: "",
+        amount: 1234n,
+      } as TransactionIntent);
+
+      expect(logicCraftTransactionMock).toHaveBeenCalledWith(
+        expect.objectContaining({ address: "tz1test" }),
+        expect.objectContaining({
+          type,
+          amount: 1234n,
+        }),
+      );
+    },
+  );
+
+  it("passes finalize_unstake mode with zero amount through to craftTransaction", async () => {
+    logicEstimateFees.mockResolvedValue({
+      estimatedFees: DEFAULT_ESTIMATED_FEES,
+      fees: DEFAULT_ESTIMATED_FEES,
+      gasLimit: DEFAULT_GAS_LIMIT,
+      storageLimit: DEFAULT_STORAGE_LIMIT,
+    });
+
+    await api.craftTransaction({
+      intentType: "staking",
+      type: "finalize_unstake",
+      sender: "tz1test",
+      recipient: "",
+      amount: 999n,
+    } as TransactionIntent);
+
+    expect(logicCraftTransactionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ address: "tz1test" }),
+      expect.objectContaining({
+        type: "finalize_unstake",
+        amount: 0n,
+      }),
+    );
+  });
 });
 
 describe("estimateFees", () => {
@@ -468,6 +520,37 @@ describe("estimateFees", () => {
     expect(result.value).toBe(expectedTotalFees);
     expect(result.parameters.gasLimit).toBe(DEFAULT_GAS_LIMIT);
     expect(result.parameters.storageLimit).toBe(DEFAULT_STORAGE_LIMIT);
+  });
+
+  it.each([
+    ["stake", 1234n, 1234n],
+    ["unstake", 1234n, 1234n],
+    ["finalize_unstake", 999n, 0n],
+  ] as const)("delegates %s estimation to the logic layer", async (type, intentAmount, amount) => {
+    logicEstimateFees.mockResolvedValue({
+      estimatedFees: DEFAULT_ESTIMATED_FEES,
+      fees: DEFAULT_ESTIMATED_FEES,
+      gasLimit: DEFAULT_GAS_LIMIT,
+      storageLimit: DEFAULT_STORAGE_LIMIT,
+    });
+
+    const result = await api.estimateFees({
+      intentType: "staking",
+      type,
+      sender: "tz1test",
+      recipient: "",
+      amount: intentAmount,
+    } as TransactionIntent);
+
+    expect(result.value).toBe(DEFAULT_ESTIMATED_FEES);
+    expect(logicEstimateFees).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transaction: expect.objectContaining({
+          mode: type,
+          amount,
+        }),
+      }),
+    );
   });
 
   it("fallback when Taquito throws Public key not found returns total with minFees for reveal (unrevealed)", async () => {

--- a/libs/coin-modules/coin-tezos/src/api/index.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.ts
@@ -15,6 +15,7 @@ import type {
   FeeEstimation,
   TransactionIntent,
 } from "@ledgerhq/coin-module-framework/api/types";
+import type { BridgeApi } from "@ledgerhq/ledger-wallet-framework/api/types";
 import { craftTransactionData } from "@ledgerhq/coin-module-framework/logic/craftTransactionData";
 import { RecommendUndelegation } from "@ledgerhq/errors";
 import { log } from "@ledgerhq/logs";
@@ -50,10 +51,22 @@ import {
 import type { TezosFeeEstimation } from "./types";
 import type { TezosOperationMode } from "../types/model";
 
-export function createApi(config: TezosConfig): AlpacaApi {
+export function createApi(config: TezosConfig): AlpacaApi & BridgeApi {
   coinConfig.setCoinConfig(() => ({ ...config, status: { type: "active" } }));
 
   return {
+    computeIntentType: (transaction: Record<string, unknown>): string => {
+      switch (transaction.mode) {
+        case "delegate":
+        case "undelegate":
+        case "stake":
+        case "unstake":
+        case "finalize_unstake":
+          return transaction.mode;
+        default:
+          return "send";
+      }
+    },
     broadcast,
     combine,
     craftTransaction: craft,
@@ -91,10 +104,9 @@ export function createApi(config: TezosConfig): AlpacaApi {
 
 function isTezosTransactionType(
   type: string,
-): type is "send" | "delegate" | "undelegate" | "stake" | "unstake" {
-  return ["send", "delegate", "undelegate", "stake", "unstake"].includes(type);
+): type is "send" | "delegate" | "undelegate" | "stake" | "unstake" | "finalize_unstake" {
+  return ["send", "delegate", "undelegate", "stake", "unstake", "finalize_unstake"].includes(type);
 }
-
 async function craft(
   transactionIntent: TransactionIntent,
   customFees?: FeeEstimation,
@@ -118,7 +130,7 @@ async function craft(
     tezosMode === "send_token" ? parseTezosTokenAsset(transactionIntent.asset)! : undefined;
 
   // Guard: send max is incompatible with delegated accounts (native XTZ only)
-  let amountToUse = transactionIntent.amount;
+  let amountToUse = tezosMode === "finalize_unstake" ? 0n : transactionIntent.amount;
   if (tezosMode === "send" && transactionIntent.useAllAmount) {
     const senderInfo = await api.getAccountByAddress(transactionIntent.sender);
     if (senderInfo.type === "user" && senderInfo.delegate?.address) {
@@ -254,7 +266,7 @@ async function estimate(transactionIntent: TransactionIntent): Promise<TezosFeeE
   const transaction: CoreTransactionInfo = {
     mode: tezosModeForEstimate,
     recipient: transactionIntent.recipient,
-    amount: transactionIntent.amount,
+    amount: tezosModeForEstimate === "finalize_unstake" ? 0n : transactionIntent.amount,
     useAllAmount: !!transactionIntent.useAllAmount,
     ...(tokenEstimationInfo && {
       contractAddress: tokenEstimationInfo.contractAddress,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - The `craft` and `estimate` API wrappers now correctly handle `finalize_unstake` in addition to `stake` and `unstake`. For `finalize_unstake`, amount is forced to `0n`; for `stake`/`unstake`, the explicit intent amount is forwarded as-is.
  - Maps mode from UI directly to tezos module. Before stake would map to delegate. Now just pass as is

### 📝 Description

Fixes the API layer's handling of staking operation modes so that `craft` and `estimate` correctly wire through `stake`, `unstake`, and `finalize_unstake` intents to the logic layer.

**Changes in `api/index.ts`:**
- Adds `"finalize_unstake"` to `isTezosTransactionType` so it is accepted by `craft` instead of throwing `IncorrectTypeError`.
- Forces `amountToUse = 0n` for `finalize_unstake` in `craft` (no XTZ amount is needed to finalize unstaking).
- Forces `amount = 0n` for `finalize_unstake` in `estimate` for the same reason.

**Changes in `api/index.test.ts`:**
- Adds unit tests asserting that `stake` and `unstake` forward the intent amount unchanged to `craftTransaction`.
- Adds a unit test asserting that `finalize_unstake` forwards `0n` as the amount to `craftTransaction`.
- Adds unit tests asserting that `estimate` delegates each staking mode to the logic layer with the correct amount semantics.


### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-28766

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
