### PR TITLE
[LWDM] fix(live-common): replace console.error with @ledgerhq/logs in wallet-api helpers

### DIFF
--- a/libs/ledger-live-common/src/wallet-api/helpers.ts
+++ b/libs/ledger-live-common/src/wallet-api/helpers.ts
@@ -1,3 +1,4 @@
+import { log } from "@ledgerhq/logs";
 import { isCryptoCurrency, isTokenCurrency } from "../currencies";
 import { Currency } from "@ledgerhq/types-cryptoassets";
 import type {
@@ -86,22 +87,22 @@ const isWhitelistedDomain = (url: string, manifestUrl: string): boolean => {
 
     // Only allow HTTPS scheme
     if (parsedUrl.protocol !== "https:") {
-      console.error(
-        `#isWhitelistedDomain:: invalid URL: non-HTTPS scheme '${parsedUrl.protocol}' is not allowed`,
-      );
+      log("wallet-api/helpers", "isWhitelistedDomain: non-HTTPS scheme blocked", {
+        protocol: parsedUrl.protocol,
+      });
       return false;
     }
 
     // Check if URL is on the same domain as manifest URL
     if (!isSameDomain(url, manifestUrl)) {
-      console.error(`#isWhitelistedDomain:: invalid URL: not on the same domain as manifest URL`);
+      log("wallet-api/helpers", "isWhitelistedDomain: URL not on same domain as manifest");
       return false;
     }
 
     return true;
   } catch (error) {
     // Invalid URL format
-    console.error(`#isWhitelistedDomain:: invalid URL format: ${error}`);
+    log("wallet-api/helpers", "isWhitelistedDomain: invalid URL format", { error: String(error) });
     return false;
   }
 };
@@ -132,7 +133,7 @@ export const getInitialURL = (
 
     return url.toString();
   } catch (e) {
-    if (e instanceof Error) console.error(e.message);
+    if (e instanceof Error) log("wallet-api/helpers", "getInitialURL error", { message: e.message });
 
     return manifest.url.toString();
   }


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [ ] **Impact of the changes:**
  - Internal logging change only — no behaviour change for callers

### 📝 Description

`libs/ledger-live-common/src/wallet-api/helpers.ts` was calling `console.error` directly in `isWhitelistedDomain` and `getInitialURL`. Those calls polluted Jest output and coupled the code to the global console rather than the Ledger logging infrastructure.

This replaces all four `console.error` calls with structured `log(...)` calls from `@ledgerhq/logs`, matching the pattern already used in `wallet-api/validation/validateUrl.ts`.

Side-effect: Jest tests no longer produce console noise for rejection paths, making PR #16874 (`fix/test-wallet-api-helpers-console-noise`) obsolete — that PR was patching the symptom; this PR fixes the root cause.

### ❓ Context

- **GitHub link**: closes #16874 (supersedes it)
- Suggested by @francois-guerin-ledger and @Justkant in PR #16874 review