### PR TITLE
[LWDM] fix(wallet-cli): send wallet-cli user agent [LIVE-29628]

### DIFF
--- a/.changeset/warm-agents-identify.md
+++ b/.changeset/warm-agents-identify.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-network": minor
+---
+
+Set Axios User-Agent from LEDGER_CLIENT_VERSION in Node and Bun runtimes

--- a/apps/wallet-cli/src/live-common-setup.ts
+++ b/apps/wallet-cli/src/live-common-setup.ts
@@ -8,6 +8,7 @@ import { WALLET_API_VERSION } from "@ledgerhq/live-common/wallet-api/constants";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { setEnv } from "@ledgerhq/live-env";
 import { registerWalletCliDmkTransport } from "./device/register-dmk-transport";
+import pkg from "../package.json" with { type: "json" };
 
 /**
  * Ensure USER_ID is set so DMK firmware distribution salt is stable for this CLI.
@@ -15,6 +16,13 @@ import { registerWalletCliDmkTransport } from "./device/register-dmk-transport";
 if (!process.env.USER_ID) {
   process.env.USER_ID = "wallet-cli";
 }
+
+const ledgerClientVersion = `wallet-cli/${pkg.version}`;
+setEnv("LEDGER_CLIENT_VERSION", ledgerClientVersion);
+process.env.LEDGER_CLIENT_VERSION = ledgerClientVersion;
+// Bun can resolve ESM imports to lib-es/ and require() calls to lib/, creating
+// separate live-env singletons. Keep both aligned for lazy CJS coin modules.
+require("@ledgerhq/live-env").setEnv("LEDGER_CLIENT_VERSION", ledgerClientVersion);
 
 /**
  * Wallet-cli-specific coin-module loaders (bitcoin, evm, solana only).
@@ -86,5 +94,3 @@ require("@ledgerhq/live-config/LiveConfig").LiveConfig.setConfig(walletCliConfig
 // instead of relying on setupCalClientStore from @ledgerhq/cryptoassets/cal-client (test-helpers).
 setupCalClientStore();
 registerWalletCliDmkTransport();
-
-setEnv("LEDGER_CLIENT_VERSION", "wallet-cli/0.1.0");

--- a/libs/live-network/src/network.test.ts
+++ b/libs/live-network/src/network.test.ts
@@ -10,6 +10,7 @@ const mockedAxios = jest.mocked(axios);
 describe("network", () => {
   const DEFAULT_ENABLE_NETWORK_LOGS = getEnv("ENABLE_NETWORK_LOGS");
   const DEFAULT_GET_CALLS_RETRY = getEnv("GET_CALLS_RETRY");
+  const DEFAULT_LEDGER_CLIENT_VERSION = getEnv("LEDGER_CLIENT_VERSION");
 
   afterEach(() => {
     // restore the spy created with spyOn
@@ -18,6 +19,7 @@ describe("network", () => {
 
     // Restore DEFAULT_ENABLE_NETWORK_LOGS
     setEnv("ENABLE_NETWORK_LOGS", DEFAULT_ENABLE_NETWORK_LOGS);
+    setEnv("LEDGER_CLIENT_VERSION", DEFAULT_LEDGER_CLIENT_VERSION);
   });
 
   describe("requestInterceptor", () => {
@@ -171,6 +173,23 @@ describe("network", () => {
         // eslint-disable-next-line no-empty
       } catch {}
       expect(mockedAxios).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("ledger client version headers", () => {
+    test("should set ledger client version as axios client headers", () => {
+      setEnv("LEDGER_CLIENT_VERSION", "wallet-cli/0.1.1");
+
+      expect(axios.defaults.headers.common["X-Ledger-Client-Version"]).toBe("wallet-cli/0.1.1");
+      expect(axios.defaults.headers.common["User-Agent"]).toBe("wallet-cli/0.1.1");
+    });
+
+    test("should clear ledger client version headers when env is empty", () => {
+      setEnv("LEDGER_CLIENT_VERSION", "wallet-cli/0.1.1");
+      setEnv("LEDGER_CLIENT_VERSION", "");
+
+      expect(axios.defaults.headers.common["X-Ledger-Client-Version"]).toBeUndefined();
+      expect(axios.defaults.headers.common["User-Agent"]).toBeUndefined();
     });
   });
 });

--- a/libs/live-network/src/network.ts
+++ b/libs/live-network/src/network.ts
@@ -251,12 +251,23 @@ const implementation = <T = any>(arg: AxiosRequestConfig): AxiosPromise<T> => {
   return promise;
 };
 
+const canSetUserAgentHeader = (): boolean =>
+  typeof globalThis?.window === "undefined" &&
+  typeof process !== "undefined" &&
+  process.release?.name === "node";
+
 // attach the env "LEDGER_CLIENT_VERSION" to set the header globally for axios
 function setAxiosLedgerClientVersionHeader(value: string) {
   if (value) {
     axios.defaults.headers.common["X-Ledger-Client-Version"] = value;
+    if (canSetUserAgentHeader()) {
+      axios.defaults.headers.common["User-Agent"] = value;
+    }
   } else {
     delete axios.defaults.headers.common["X-Ledger-Client-Version"];
+    if (canSetUserAgentHeader()) {
+      delete axios.defaults.headers.common["User-Agent"];
+    }
   }
 }
 setAxiosLedgerClientVersionHeader(getEnv("LEDGER_CLIENT_VERSION"));


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - wallet-cli, network user-agent with axios

### 📝 Description

Set the wallet-cli client version from package metadata and propagate it across both ESM and CJS live-env instances so lazy coin modules use the same value.

Map `LEDGER_CLIENT_VERSION` to Axios' `User-Agent` header in Node and Bun runtimes, alongside `X-Ledger-Client-Version`, so backend logs identify wallet-cli.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29628]
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-29628]: https://ledgerhq.atlassian.net/browse/LIVE-29628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ