### PR TITLE
[LWM] fix(mobile): use spinner for pending transactional dot

### DIFF
--- a/.changeset/live-30156-pending-transactional-spinner.md
+++ b/.changeset/live-30156-pending-transactional-spinner.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Use spinner instead of clock for pending transactional operation dots

--- a/apps/ledger-live-mobile/src/mvvm/components/TransactionalIcon/__tests__/getTransactionalDotConfig.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TransactionalIcon/__tests__/getTransactionalDotConfig.test.ts
@@ -1,7 +1,6 @@
 import {
   ArrowDown,
   ArrowUp,
-  Clock,
   Close,
   Invoice,
   Link,
@@ -11,12 +10,13 @@ import {
   Star,
   Unlink,
 } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { Spinner } from "@ledgerhq/lumen-ui-rnative";
 import { getTransactionalDotConfig } from "../getTransactionalDotConfig";
 
 describe("getTransactionalDotConfig", () => {
-  it("returns clock with muted appearance when optimistic", () => {
+  it("returns spinner with muted appearance when pending", () => {
     const config = getTransactionalDotConfig("OUT", true);
-    expect(config).toEqual({ icon: Clock, appearance: "muted" });
+    expect(config).toEqual({ icon: Spinner, appearance: "muted" });
   });
 
   it.each([

--- a/apps/ledger-live-mobile/src/mvvm/components/TransactionalIcon/getTransactionalDotConfig.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TransactionalIcon/getTransactionalDotConfig.ts
@@ -5,7 +5,6 @@ import type { OperationType } from "@ledgerhq/types-live";
 import {
   ArrowDown,
   ArrowUp,
-  Clock,
   Close,
   Invoice,
   Link,
@@ -15,6 +14,7 @@ import {
   Star,
   Unlink,
 } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { Spinner } from "@ledgerhq/lumen-ui-rnative";
 
 type TransactionalDotIcon = ComponentType<{
   size?: IconSize;
@@ -35,7 +35,7 @@ export function getTransactionalDotConfig(
     return { icon: Close, appearance: "error" };
   }
   if (isPending) {
-    return { icon: Clock, appearance: "muted" };
+    return { icon: Spinner, appearance: "muted" };
   }
 
   switch (operationType) {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Transaction list and any screen using `TransactionalIcon` with pending operations
      - Pending-state dot: animated spinner instead of static clock

### 📝 Description

**Problem:** Pending operations showed a static clock on the transactional dot, which did not clearly communicate an in-progress state.

**Solution:** For `isPending`, `getTransactionalDotConfig` now returns the Lumen `Spinner` component with the same muted appearance. `getTransactionalDotConfig` unit tests were updated to assert the spinner mapping.

https://github.com/user-attachments/assets/0be238e1-4b9e-47ed-8f30-9e59c253bd89



### ❓ Context

- **JIRA or GitHub link**: [LIVE-30156](https://ledgerhq.atlassian.net/browse/LIVE-30156)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-30156]: https://ledgerhq.atlassian.net/browse/LIVE-30156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ