### PR TITLE
[LWM] fix(mobile): reduce help center top spacing to 8px

### DIFF
--- a/.changeset/swift-titles-shrink.md
+++ b/.changeset/swift-titles-shrink.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix help center top spacing to 8px between top bar and Support and learning title

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/screens/Help/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/screens/Help/index.tsx
@@ -38,7 +38,7 @@ export function MyWalletHelpScreen() {
     <>
       <ScrollView testID="my-wallet-help-screen">
         <TrackScreen category="MyWallet" name="Help" />
-        <Box lx={{ paddingHorizontal: "s16", paddingTop: "s24", gap: "s24" }}>
+        <Box lx={{ paddingHorizontal: "s16", paddingTop: "s8", gap: "s24" }}>
           <Box lx={{ gap: "s8" }}>
             <Subheader>
               <SubheaderRow testID="my-wallet-help-section-support">


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [ ] **Covered by automatic tests.** _Visual spacing fix, no logic change — not covered by automated tests._
- [x] **Impact of the changes:**
  - Help center screen top spacing between navigation bar and "Support and learning" title

### 📝 Description

The spacing between the top bar and the "Support and learning" title in the Help Center screen was set to 24px instead of the required 8px.

Changed `paddingTop` from `s24` to `s8` on the outer `Box` in `MyWalletHelpScreen`.

| Before | After |
| ------ | ----- |
|<img width="320" alt="Before" src="https://github.com/user-attachments/assets/c0374dd4-1d40-45f3-a95d-923ec9dcfa22" />|<img width="320" alt="Fixed" src="https://github.com/user-attachments/assets/4d01710f-8ad5-4498-a9f7-511eb48affc2" />|

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30152](https://ledgerhq.atlassian.net/browse/LIVE-30152)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30152]: https://ledgerhq.atlassian.net/browse/LIVE-30152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ