### PR TITLE
[LWM] test(mobile): fix notifications prompt receive flow test

### DIFF
--- a/.changeset/clean-ravens-prompt.md
+++ b/.changeset/clean-ravens-prompt.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix notifications prompt receive flow test to render with React Query context.

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/NotificationsPromptReceiveFlow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/NotificationsPromptReceiveFlow.test.tsx
@@ -2,7 +2,13 @@ import React from "react";
 import { View } from "react-native";
 import { ABTestingVariants } from "@ledgerhq/types-live";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import { render, screen, waitFor, withFlagOverrides, act } from "@tests/test-renderer";
+import {
+  renderWithReactQuery,
+  screen,
+  waitFor,
+  withFlagOverrides,
+  act,
+} from "@tests/test-renderer";
 import storage from "LLM/storage";
 import ReceiveFundsNavigator from "~/components/RootNavigator/ReceiveFundsNavigator";
 import { NavigatorName, ScreenName } from "~/const";
@@ -148,7 +154,7 @@ describe("NotificationsPrompt receive flow", () => {
   }
 
   it("should prompt the notifications drawer when leaving the receive flow", async () => {
-    const { user } = render(<ReceiveFlowTestApp />, {
+    const { user } = renderWithReactQuery(<ReceiveFlowTestApp />, {
       navigationInitialState: receiveFlowNavigationState,
       overrideInitialState: withFlagOverrides(featureFlagsForReceivePrompt, state => ({
         ...state,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Mobile notifications prompt receive flow test reliability
      - Wallet Sync drawer rendering in mobile test setup

### 📝 Description

The mobile notifications prompt receive flow test was failing because the receive flow renders the Wallet Sync activation drawer, which calls React Query hooks without a `QueryClientProvider` in the test tree.

This PR switches the test to the existing `renderWithReactQuery` helper so the integration path keeps using the shared mobile test providers while also supplying React Query context. A patch changeset is included for `live-mobile`.

### ❓ Context

- **JIRA or GitHub link**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)