### PR TITLE
[LWM] fix(mobile): muted icons on My Wallet Help list rows

### DIFF
--- a/.changeset/live-30153-my-wallet-help-icons-muted.md
+++ b/.changeset/live-30153-my-wallet-help-icons-muted.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Use muted icon color for My Wallet Help list rows (leading and trailing icons)

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/screens/Help/components/HelpListItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/screens/Help/components/HelpListItem.tsx
@@ -31,9 +31,9 @@ export const HelpListItem = memo(
       </ListItemLeading>
       <ListItemTrailing>
         {trailing === "externalLink" ? (
-          <ExternalLink size={24} color="base" />
+          <ExternalLink size={24} color="muted" />
         ) : (
-          <ChevronRight size={24} color="base" />
+          <ChevronRight size={24} color="muted" />
         )}
       </ListItemTrailing>
     </ListItem>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No dedicated tests for HelpListItem; change is prop-only (icon colors)._
- [x] **Impact of the changes:**
      - My Wallet → Help screen
      - Trailing external-link and chevron icons

### 📝 Description

**Problem**: [LIVE-30153](https://ledgerhq.atlassian.net/browse/LIVE-30153) asks for Help section icons to use grey treatment on Ledger Wallet Mobile (My Wallet).

**Solution**: Set Lumen symbol icons on Help rows to `color="muted"` for both the trailing `ExternalLink` / `ChevronRight` indicators so they match the intended secondary visual weight.

| Before | After |
| ------ | ----- |
|<img width="320"  alt="image" src="https://github.com/user-attachments/assets/d40f1cd7-ee04-431d-9d48-37dc3928ed2f" />|<img width="320"  alt="After" src="https://github.com/user-attachments/assets/11b7c2c8-1d20-4cce-8cff-a0881f8a3c32" />|

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30153](https://ledgerhq.atlassian.net/browse/LIVE-30153)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30153]: https://ledgerhq.atlassian.net/browse/LIVE-30153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-30153]: https://ledgerhq.atlassian.net/browse/LIVE-30153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ