### PR TITLE
[LWM] fix(mobile): increase operations history section separator spacing

### DIFF
--- a/.changeset/live-30151-operations-history-spacing.md
+++ b/.changeset/live-30151-operations-history-spacing.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Increase spacing for operations history section separators

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/SectionSeparator.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/SectionSeparator.tsx
@@ -25,9 +25,9 @@ export function SectionSeparator({ leadingItem, trailingItem, trailingSection }:
 }
 
 const afterSectionHeaderSpacingStyle: LumenViewStyle = {
-  height: "s4",
+  height: "s12",
 };
 
 const betweenSectionsSpacingStyle: LumenViewStyle = {
-  height: "s16",
+  height: "s24",
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/__tests__/SectionSeparator.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/__tests__/SectionSeparator.test.tsx
@@ -31,7 +31,7 @@ describe("SectionSeparator", () => {
     );
     expect(screen.getByTestId("operations-list-section-separator")).toBeVisible();
     expect(screen.getByTestId("operations-list-section-separator")).toHaveStyle({
-      height: 4,
+      height: 12,
     });
   });
 
@@ -41,7 +41,7 @@ describe("SectionSeparator", () => {
     );
     expect(screen.getByTestId("operations-list-section-separator")).toBeVisible();
     expect(screen.getByTestId("operations-list-section-separator")).toHaveStyle({
-      height: 16,
+      height: 24,
     });
   });
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Operations History list layout and vertical rhythm between date sections
      - Spacing after a section header versus spacing between two sections

### 📝 Description

**Problem**: Section separators in the mobile Operations History list used spacing that felt too tight relative to the target layout ([LIVE-30151](https://ledgerhq.atlassian.net/browse/LIVE-30151)).

**Solution**: Updated `SectionSeparator` to use larger Lumen spacing tokens:

- After a section header: `s4` → `s12`
- Between sections: `s16` → `s24`

Jest expectations were updated to match the resolved spacer heights.

| Before | After |
| ------ | ----- |
|<img width="320" alt="image" src="https://github.com/user-attachments/assets/0a4083b3-364c-44a9-bf06-5fb3b3668d3b" />|<img width="320" alt="image" src="https://github.com/user-attachments/assets/79e68031-acc2-498d-9a3b-ccfee45ec9f0" />|

https://github.com/user-attachments/assets/79e68031-acc2-498d-9a3b-ccfee45ec9f0

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30151](https://ledgerhq.atlassian.net/browse/LIVE-30151)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30151]: https://ledgerhq.atlassian.net/browse/LIVE-30151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-30151]: https://ledgerhq.atlassian.net/browse/LIVE-30151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ