### PR TITLE
test(mobile): add swap UI and config e2e coverage

### DIFF
--- a/.changeset/qaa-swap-coverage.md
+++ b/.changeset/qaa-swap-coverage.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-mobile-e2e-tests": patch
+---
+
+Add mobile swap E2E coverage for QAA-1127.

--- a/e2e/mobile/page/liveApps/swapLiveApp.ts
+++ b/e2e/mobile/page/liveApps/swapLiveApp.ts
@@ -16,6 +16,8 @@ export default class SwapLiveAppPage {
   numberOfQuotes = "number-of-quotes";
   quotesCountDown = "quotes-countdown";
   quoteCardProviderNameSelector = "[data-testid^='compact-quote-card-provider-']";
+  quoteAmountLabelSelector = '[data-testid^="quote-container-"][data-testid$="-amount-label"]';
+  bestQuoteHeadingXpath = "//*[contains(normalize-space(.), 'Best quote')]";
   executeSwapButton = "execute-button";
   executeSwapButtonStepApproval = "execute-swap-button-step-approval";
   deviceActionErrorDescriptionId = "error-description-deviceAction";
@@ -42,6 +44,13 @@ export default class SwapLiveAppPage {
     await detoxExpect(getWebElementByTestId(this.fromSelector)).toExist();
     await detoxExpect(getWebElementByTestId(this.toSelector)).toExist();
     await detoxExpect(getWebElementByTestId(this.quotesButtonDisabled)).toExist();
+  }
+
+  @Step("Expect swap live app form")
+  async expectSwapLiveAppForm() {
+    await waitWebElementByTestId(this.fromSelector);
+    await detoxExpect(getWebElementByTestId(this.fromSelector)).toExist();
+    await detoxExpect(getWebElementByTestId(this.toSelector)).toExist();
   }
 
   @Step("Check if the from currency is already selected")
@@ -243,64 +252,46 @@ export default class SwapLiveAppPage {
   @Step("Check best-value quote corresponds to the best quote")
   async checkBestOffer() {
     await retryUntilTimeout(async () => {
-      const quoteContainers = await this.getAllSwapProviders();
-      const quotes = await this.extractQuoteAmounts(quoteContainers);
-      const bestQuote = quotes.reduce<{ amount: number; quote: string } | null>(
-        (max, current) => (!max || current.amount > max.amount ? current : max),
-        null,
-      );
+      const amountLabels = await this.getQuoteAmountLabels();
+      const quoteAmounts = this.extractQuoteAmounts(amountLabels);
 
-      jestExpect(quoteContainers[0]).toMatch(/Best (Offer|quote|Value)/i);
-      jestExpect(bestQuote?.quote).toEqual(quoteContainers[0]);
+      await detoxExpect(getWebElementByXpath(this.bestQuoteHeadingXpath)).toExist();
+      jestExpect(quoteAmounts[0]).toBe(Math.max(...quoteAmounts));
     });
   }
 
-  @Step("Get all swap providers available")
-  async getAllSwapProviders() {
+  @Step("Get quote receive amount labels")
+  async getQuoteAmountLabels() {
     return await getWebElementsText(
       this.swapMainContainerWebElement,
-      '[data-testid^="quote-container-"][data-testid$="-fixed"], [data-testid^="quote-container-"][data-testid$="-float"]',
+      this.quoteAmountLabelSelector,
     );
   }
 
   @Step("Extract quote receive amounts")
-  async extractQuoteAmounts(quoteContainers: string[]) {
-    const quotes: Array<{ amount: number; quote: string }> = quoteContainers.flatMap(quote => {
-      const tokens = quote.split(/\s+/).filter(Boolean);
+  extractQuoteAmounts(amountLabels: string[]) {
+    const amounts = amountLabels.map(amountLabel => this.parseQuoteAmountLabel(amountLabel));
 
-      for (let index = 0; index < tokens.length - 1; index++) {
-        const amountToken = tokens[index] === "~" ? tokens[index + 1] : tokens[index];
-        const tickerToken = tokens[tokens[index] === "~" ? index + 2 : index + 1];
-        const amount = this.parseQuoteAmountToken(amountToken);
-
-        if (amount !== null && tickerToken && this.isQuoteCurrencyTicker(tickerToken)) {
-          return [{ amount, quote }];
-        }
-      }
-
-      return [];
-    });
-
-    if (quotes.length === 0) {
+    if (amounts.length === 0) {
       throw new Error("No quotes found");
     }
-    return quotes;
+    return amounts;
   }
 
-  private parseQuoteAmountToken(token: string): number | null {
-    const amountToken = (token.startsWith("~") ? token.slice(1) : token).split(",").join("");
+  private parseQuoteAmountLabel(amountLabel: string): number {
+    const amountMatch = /~?\s*([\d,]+(?:\.\d+)?)/.exec(amountLabel);
 
-    if (!/^\d+(\.\d+)?$/.test(amountToken)) {
-      return null;
+    if (!amountMatch) {
+      throw new Error(`Could not parse quote amount label: ${amountLabel}`);
     }
 
-    const amount = Number(amountToken);
+    const amount = Number(amountMatch[1].split(",").join(""));
 
-    return Number.isFinite(amount) ? amount : null;
-  }
+    if (!Number.isFinite(amount)) {
+      throw new TypeError(`Parsed quote amount is not finite: ${amountLabel}`);
+    }
 
-  private isQuoteCurrencyTicker(token: string): boolean {
-    return /^[A-Z0-9]{2,10}$/.test(token);
+    return amount;
   }
 
   @Step("Verify swap amount error message match: $0")
@@ -355,9 +346,9 @@ export default class SwapLiveAppPage {
   }
 
   @Step("Check currency to swap from contains $0")
-  async checkAssetFromContains(currency: string) {
+  async checkAssetFromContains(expectedAssetText: string) {
     const fromAccount: string = await getWebElementText(this.fromSelector);
-    jestExpect(fromAccount).toContain(currency);
+    jestExpect(fromAccount).toContain(expectedAssetText);
   }
 
   @Step("Check currency to swap to is $0 with amount $1")
@@ -373,12 +364,12 @@ export default class SwapLiveAppPage {
   }
 
   @Step("Check currency to swap to contains $0")
-  async checkAssetToContains(currency: string) {
+  async checkAssetToContains(expectedAssetText: string) {
     const assetTo: string = await getWebElementText(this.toSelector);
-    if (currency === "") {
+    if (expectedAssetText === "") {
       jestExpect(assetTo).toContain("Choose asset");
     } else {
-      jestExpect(assetTo).toContain(currency);
+      jestExpect(assetTo).toContain(expectedAssetText);
     }
   }
 

--- a/e2e/mobile/page/liveApps/swapLiveApp.ts
+++ b/e2e/mobile/page/liveApps/swapLiveApp.ts
@@ -4,9 +4,6 @@ import { getMinimumSwapAmount } from "@ledgerhq/live-common/e2e/swap";
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { retryUntilTimeout } from "../../utils/retry";
 import { floatNumberRegex } from "@ledgerhq/live-common/e2e/data/regexes";
-import { sanitizeError } from "@ledgerhq/live-common/e2e/index";
-
-type QuoteWithFees = { rate: number; fees: number; quote: string };
 
 export default class SwapLiveAppPage {
   fromSelector = "from-account-coin-selector";
@@ -30,6 +27,8 @@ export default class SwapLiveAppPage {
   swapMainContainerWebElement = getWebElementByCssSelector(this.swapMainContainerCssSelector);
   swapMaxToggle = "from-account-max-toggle";
   switchButton = "to-account-switch-accounts";
+  lnsUnsupportedBannerPattern =
+    /Ledger Nano S[\s\S]*(not supported|unsupported|does not support|not compatible)/i;
   specificQuoteCardProviderName = (provider: string) =>
     `compact-quote-card-provider-name-${provider}`;
   baseProviderCssSelector = (provider: string) =>
@@ -241,20 +240,19 @@ export default class SwapLiveAppPage {
     return actualButtonText;
   }
 
-  @Step('Check "Best Offer" corresponds to the best quote')
+  @Step("Check best-value quote corresponds to the best quote")
   async checkBestOffer() {
-    const quoteContainers = await this.getAllSwapProviders();
-    try {
-      const quotes = await this.extractQuotesAndFees(quoteContainers);
-      const bestOffer = quotes.reduce<{ rate: number; fees: number; quote: string } | null>(
-        (max, current) =>
-          current && (!max || current.rate - current.fees > max.rate - max.fees) ? current : max,
+    await retryUntilTimeout(async () => {
+      const quoteContainers = await this.getAllSwapProviders();
+      const quotes = await this.extractQuoteAmounts(quoteContainers);
+      const bestQuote = quotes.reduce<{ amount: number; quote: string } | null>(
+        (max, current) => (!max || current.amount > max.amount ? current : max),
         null,
       );
-      jestExpect(bestOffer?.quote).toContain("Best Offer");
-    } catch (error) {
-      console.error("Error checking Best offer:", sanitizeError(error));
-    }
+
+      jestExpect(quoteContainers[0]).toMatch(/Best (Offer|quote|Value)/i);
+      jestExpect(bestQuote?.quote).toEqual(quoteContainers[0]);
+    });
   }
 
   @Step("Get all swap providers available")
@@ -265,24 +263,44 @@ export default class SwapLiveAppPage {
     );
   }
 
-  @Step("Extract quotes and fees")
-  async extractQuotesAndFees(quoteContainers: string[]) {
-    const quotePattern = /\$(\d+\.\d+)[\s\S]*?Network Fees[\s\S]*?\$(\d+\.\d+)/;
+  @Step("Extract quote receive amounts")
+  async extractQuoteAmounts(quoteContainers: string[]) {
+    const quotes: Array<{ amount: number; quote: string }> = quoteContainers.flatMap(quote => {
+      const tokens = quote.split(/\s+/).filter(Boolean);
 
-    const quotes = quoteContainers
-      .map(q => {
-        const match = q.match(quotePattern);
-        if (match) {
-          return { rate: parseFloat(match[1]), fees: parseFloat(match[2]), quote: q };
+      for (let index = 0; index < tokens.length - 1; index++) {
+        const amountToken = tokens[index] === "~" ? tokens[index + 1] : tokens[index];
+        const tickerToken = tokens[tokens[index] === "~" ? index + 2 : index + 1];
+        const amount = this.parseQuoteAmountToken(amountToken);
+
+        if (amount !== null && tickerToken && this.isQuoteCurrencyTicker(tickerToken)) {
+          return [{ amount, quote }];
         }
-        return undefined;
-      })
-      .filter((quote): quote is QuoteWithFees => quote !== undefined);
+      }
+
+      return [];
+    });
 
     if (quotes.length === 0) {
       throw new Error("No quotes found");
     }
     return quotes;
+  }
+
+  private parseQuoteAmountToken(token: string): number | null {
+    const amountToken = (token.startsWith("~") ? token.slice(1) : token).split(",").join("");
+
+    if (!/^\d+(\.\d+)?$/.test(amountToken)) {
+      return null;
+    }
+
+    const amount = Number(amountToken);
+
+    return Number.isFinite(amount) ? amount : null;
+  }
+
+  private isQuoteCurrencyTicker(token: string): boolean {
+    return /^[A-Z0-9]{2,10}$/.test(token);
   }
 
   @Step("Verify swap amount error message match: $0")
@@ -336,6 +354,12 @@ export default class SwapLiveAppPage {
     jestExpect(amountToSend).toEqual(amount);
   }
 
+  @Step("Check currency to swap from contains $0")
+  async checkAssetFromContains(currency: string) {
+    const fromAccount: string = await getWebElementText(this.fromSelector);
+    jestExpect(fromAccount).toContain(currency);
+  }
+
   @Step("Check currency to swap to is $0 with amount $1")
   async checkAssetTo(currency: string, amount: string) {
     const assetTo: string = await getWebElementText(this.toSelector);
@@ -346,6 +370,26 @@ export default class SwapLiveAppPage {
     }
     const amountToReceive = await app.swapLiveApp.getAmountToReceive();
     jestExpect(amountToReceive).toEqual(amount);
+  }
+
+  @Step("Check currency to swap to contains $0")
+  async checkAssetToContains(currency: string) {
+    const assetTo: string = await getWebElementText(this.toSelector);
+    if (currency === "") {
+      jestExpect(assetTo).toContain("Choose asset");
+    } else {
+      jestExpect(assetTo).toContain(currency);
+    }
+  }
+
+  @Step("Check Ledger Nano S not supported banner")
+  async checkLnsNotSupportedBanner() {
+    await retryUntilTimeout(async () => {
+      const bodyText = await getWebElementByCssSelector("body").runScript((body: HTMLElement) =>
+        (body.innerText || body.textContent || "").trim(),
+      );
+      jestExpect(bodyText).toMatch(this.lnsUnsupportedBannerPattern);
+    }, 20000);
   }
 
   @Step("Select specific provider $0")

--- a/e2e/mobile/page/liveApps/swapLiveApp.ts
+++ b/e2e/mobile/page/liveApps/swapLiveApp.ts
@@ -16,8 +16,6 @@ export default class SwapLiveAppPage {
   numberOfQuotes = "number-of-quotes";
   quotesCountDown = "quotes-countdown";
   quoteCardProviderNameSelector = "[data-testid^='compact-quote-card-provider-']";
-  quoteAmountLabelSelector = '[data-testid^="quote-container-"][data-testid$="-amount-label"]';
-  bestQuoteHeadingXpath = "//*[contains(normalize-space(.), 'Best quote')]";
   executeSwapButton = "execute-button";
   executeSwapButtonStepApproval = "execute-swap-button-step-approval";
   deviceActionErrorDescriptionId = "error-description-deviceAction";
@@ -25,6 +23,7 @@ export default class SwapLiveAppPage {
   showDetailslink = "show-details-link";
   quotesContainerErrorIcon = "quotes-container-error-icon";
   insufficientFundsBuyButton = "insufficient-funds-buy-button";
+  incompatibilityBannerPartnerId = "incompatibility-banner-partner";
   swapMainContainerCssSelector = "main";
   swapMainContainerWebElement = getWebElementByCssSelector(this.swapMainContainerCssSelector);
   swapMaxToggle = "from-account-max-toggle";
@@ -37,6 +36,10 @@ export default class SwapLiveAppPage {
     `[data-testid^="quote-container-${Provider.getNameByUiName(provider)}"]`;
   providerExecuteButtonCss = (provider: string) =>
     `${this.baseProviderCssSelector(provider)} [data-testid="${this.executeSwapButton}"]`;
+  providerQuoteContainerSelector = (provider: string) =>
+    `${this.baseProviderCssSelector(provider)}[data-testid$="-fixed"], ${this.baseProviderCssSelector(provider)}[data-testid$="-float"]`;
+  incompatibilityBannerPartnerSelector = (provider: string) =>
+    `${this.baseProviderCssSelector(provider)} [data-testid="${this.incompatibilityBannerPartnerId}"]`;
 
   @Step("Expect swap live app page")
   async expectSwapLiveApp() {
@@ -249,49 +252,53 @@ export default class SwapLiveAppPage {
     return actualButtonText;
   }
 
-  @Step("Check best-value quote corresponds to the best quote")
-  async checkBestOffer() {
+  @Step('Check "Best Offer" corresponds to the best quote')
+  async checkBestOffer(providerList: string[]) {
     await retryUntilTimeout(async () => {
-      const amountLabels = await this.getQuoteAmountLabels();
-      const quoteAmounts = this.extractQuoteAmounts(amountLabels);
+      const quotes = [];
+      for (const provider of providerList) {
+        quotes.push(await this.getProviderQuote(provider));
+      }
+      const bestOffer = quotes.reduce<{ provider: string; rate: number; fees: number } | null>(
+        (max, current) =>
+          current && (!max || current.rate - current.fees > max.rate - max.fees) ? current : max,
+        null,
+      );
 
-      await detoxExpect(getWebElementByXpath(this.bestQuoteHeadingXpath)).toExist();
-      jestExpect(quoteAmounts[0]).toBe(Math.max(...quoteAmounts));
+      jestExpect(bestOffer?.provider).toBe(providerList[0]);
     });
   }
 
-  @Step("Get quote receive amount labels")
-  async getQuoteAmountLabels() {
-    return await getWebElementsText(
-      this.swapMainContainerWebElement,
-      this.quoteAmountLabelSelector,
-    );
-  }
+  async getProviderQuote(provider: string) {
+    const quoteText =
+      (
+        await getWebElementsText(
+          this.swapMainContainerWebElement,
+          this.providerQuoteContainerSelector(provider),
+        )
+      )[0] ?? "";
+    const networkFeesIndex = quoteText.search(/Network Fees/i);
+    const feesMatch =
+      networkFeesIndex >= 0 ? /\$\s*(\d[\d,.]*)/.exec(quoteText.slice(networkFeesIndex)) : null;
+    const usdAmountRegex = /\$\s*(\d[\d,.]*)/g;
+    const usdAmounts = [];
+    let usdAmountMatch: RegExpExecArray | null;
 
-  @Step("Extract quote receive amounts")
-  extractQuoteAmounts(amountLabels: string[]) {
-    const amounts = amountLabels.map(amountLabel => this.parseQuoteAmountLabel(amountLabel));
-
-    if (amounts.length === 0) {
-      throw new Error("No quotes found");
-    }
-    return amounts;
-  }
-
-  private parseQuoteAmountLabel(amountLabel: string): number {
-    const amountMatch = /~?\s*([\d,]+(?:\.\d+)?)/.exec(amountLabel);
-
-    if (!amountMatch) {
-      throw new Error(`Could not parse quote amount label: ${amountLabel}`);
+    while ((usdAmountMatch = usdAmountRegex.exec(quoteText)) !== null) {
+      usdAmounts.push(usdAmountMatch[1]);
     }
 
-    const amount = Number(amountMatch[1].split(",").join(""));
-
-    if (!Number.isFinite(amount)) {
-      throw new TypeError(`Parsed quote amount is not finite: ${amountLabel}`);
+    if (!feesMatch || usdAmounts.length === 0) {
+      throw new Error(`No parsable quote found for provider ${provider}`);
     }
 
-    return amount;
+    const parseAmount = (amount: string) => Number.parseFloat(amount.replace(/,/g, ""));
+
+    return {
+      provider,
+      fees: parseAmount(feesMatch[1]),
+      rate: parseAmount(usdAmounts[usdAmounts.length - 1]),
+    };
   }
 
   @Step("Verify swap amount error message match: $0")
@@ -351,6 +358,13 @@ export default class SwapLiveAppPage {
     jestExpect(fromAccount).toContain(expectedAssetText);
   }
 
+  @Step("Check currency to swap from matches account $0")
+  async checkAssetFromMatchesAccount(account: Account) {
+    const selectedAccountText: string = await getWebElementText(this.fromSelector);
+    jestExpect(selectedAccountText).toContain(account.currency.ticker);
+    jestExpect(selectedAccountText).toContain(account.accountName);
+  }
+
   @Step("Check currency to swap to is $0 with amount $1")
   async checkAssetTo(currency: string, amount: string) {
     const assetTo: string = await getWebElementText(this.toSelector);
@@ -373,13 +387,23 @@ export default class SwapLiveAppPage {
     }
   }
 
-  @Step("Check Ledger Nano S not supported banner")
-  async checkLnsNotSupportedBanner() {
+  @Step("Check currency to swap to matches account $0")
+  async checkAssetToMatchesAccount(account: Account) {
+    const selectedAccountText: string = await getWebElementText(this.toSelector);
+    const expectedAccountName = account.parentAccount?.accountName ?? account.accountName;
+
+    jestExpect(selectedAccountText).toContain(account.currency.ticker);
+    jestExpect(selectedAccountText).toContain(expectedAccountName);
+  }
+
+  @Step("Check Ledger Nano S not supported banner for $0")
+  async checkLnsNotSupportedBanner(provider: string) {
     await retryUntilTimeout(async () => {
-      const bodyText = await getWebElementByCssSelector("body").runScript((body: HTMLElement) =>
-        (body.innerText || body.textContent || "").trim(),
+      const bannerText = await getWebElementsText(
+        this.swapMainContainerWebElement,
+        this.incompatibilityBannerPartnerSelector(provider),
       );
-      jestExpect(bodyText).toMatch(this.lnsUnsupportedBannerPattern);
+      jestExpect(bannerText.join(" ")).toMatch(this.lnsUnsupportedBannerPattern);
     }, 20000);
   }
 

--- a/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
@@ -163,13 +163,13 @@ export function runSwapLandingPageTest(
       );
       const providerList = await app.swapLiveApp.getProviderList();
       await app.swapLiveApp.checkFirstQuoteContainerInfos(providerList);
-      await app.swapLiveApp.checkBestOffer();
+      await app.swapLiveApp.checkBestOffer(providerList);
 
       await app.portfolio.openViaDeeplink();
       await app.swap.openViaDeeplink();
       await app.swapLiveApp.expectSwapLiveAppForm();
-      await app.swapLiveApp.checkAssetFromContains(fromAccount.currency.ticker);
-      await app.swapLiveApp.checkAssetToContains(toAccount.currency.ticker);
+      await app.swapLiveApp.checkAssetFromMatchesAccount(fromAccount);
+      await app.swapLiveApp.checkAssetToMatchesAccount(toAccount);
     });
   });
 }
@@ -219,7 +219,7 @@ export function runSwapLnsNotSupportedBannerTest(
 
         await performSwapUntilQuoteSelectionStep(fromAccount, toAccount, minAmount);
         await app.swapLiveApp.selectSpecificProvider(unsupportedProvider.uiName);
-        await app.swapLiveApp.checkLnsNotSupportedBanner();
+        await app.swapLiveApp.checkLnsNotSupportedBanner(unsupportedProvider.uiName);
       });
     },
   );
@@ -521,28 +521,6 @@ async function openSwapFromPortfolioEntryPoint() {
     await app.transferMenuDrawer.open();
     await app.transferMenuDrawer.navigateToSwap();
   }
-}
-
-export function runSwapDefaultCurrencyNoSetupTest(
-  defaultSendAccount: Account,
-  tmsLinks: string[],
-  tags: string[],
-) {
-  describe("Swap - Default currency without previous setup", () => {
-    beforeAll(async () => {
-      await beforeAllFunctionSwap({
-        userdata: "speculos-tests-app",
-        speculosApp: AppInfos.EXCHANGE,
-      });
-    });
-
-    tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
-    tags.forEach(tag => $Tag(tag));
-    it("Defaults You send to the account with most funds and leaves You receive empty", async () => {
-      await openSwapFromPortfolioEntryPoint();
-      await validateSwapAssetsPage(defaultSendAccount.currency.ticker, "");
-    });
-  });
 }
 
 export function runSwapEntryPoints(account: Account, tmsLinks: string[], tags: string[]) {

--- a/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
@@ -1,4 +1,5 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { Device } from "@ledgerhq/live-common/e2e/enum/Device";
 import { SwapType } from "@ledgerhq/live-common/e2e/models/Swap";
 import { performSwapUntilQuoteSelectionStep } from "../../../utils/swapUtils";
 import { AppInfos } from "@ledgerhq/live-common/e2e/enum/AppInfos";
@@ -9,6 +10,35 @@ import { isWallet40 } from "../../../helpers/commonHelpers";
 
 setEnv("DISABLE_TRANSACTION_BROADCAST", true);
 
+async function handleAssetSwap(asset: Account, hasAccount: boolean) {
+  const isModularDrawer = await app.modularDrawer.isFlowEnabled("live_app");
+  if (isModularDrawer) {
+    await app.modularDrawer.performSearchByTicker(asset.currency.ticker);
+    await app.modularDrawer.selectCurrencyByTicker(asset.currency.ticker);
+    const networkName = asset?.parentAccount
+      ? asset.parentAccount.currency.name
+      : asset.currency.speculosApp.name;
+    await app.modularDrawer.selectNetworkIfAsked(networkName);
+
+    if (hasAccount) {
+      await app.modularDrawer.selectFirstAccount();
+    } else {
+      await app.modularDrawer.tapAddNewOrExistingAccountButtonMAD();
+      await app.addAccount.addAccountAtIndex(`${asset.currency.name} 1`, asset.currency.id, 0);
+    }
+  } else {
+    await app.common.performSearch(asset.currency.name);
+    await app.stake.selectCurrency(asset.currency.id);
+    if (hasAccount) {
+      await app.common.selectFirstAccount();
+    } else {
+      await app.common.tapProceedButton();
+      await app.addAccount.addAccountAtIndex(`${asset.currency.name} 1`, asset.currency.id, 0);
+      await app.common.selectFirstAccount();
+    }
+  }
+}
+
 export function runSwapWithoutAccountTest(
   asset1: Account,
   asset2: Account,
@@ -17,35 +47,6 @@ export function runSwapWithoutAccountTest(
   event: "noAccountTo" | "noAccountFrom" | "noAccountFromAndTo",
   tags: string[],
 ) {
-  const handleAssetSwap = async (asset: Account, hasAccount: boolean) => {
-    const isModularDrawer = await app.modularDrawer.isFlowEnabled("live_app");
-    if (isModularDrawer) {
-      await app.modularDrawer.performSearchByTicker(asset.currency.ticker);
-      await app.modularDrawer.selectCurrencyByTicker(asset.currency.ticker);
-      const networkName = asset?.parentAccount
-        ? asset.parentAccount.currency.name
-        : asset.currency.speculosApp.name;
-      await app.modularDrawer.selectNetworkIfAsked(networkName);
-
-      if (hasAccount) {
-        await app.modularDrawer.selectFirstAccount();
-      } else {
-        await app.modularDrawer.tapAddNewOrExistingAccountButtonMAD();
-        await app.addAccount.addAccountAtIndex(`${asset.currency.name} 1`, asset.currency.id, 0);
-      }
-    } else {
-      await app.common.performSearch(asset.currency.name);
-      await app.stake.selectCurrency(asset.currency.id);
-      if (hasAccount) {
-        await app.common.selectFirstAccount();
-      } else {
-        await app.common.tapProceedButton();
-        await app.addAccount.addAccountAtIndex(`${asset.currency.name} 1`, asset.currency.id, 0);
-        await app.common.selectFirstAccount();
-      }
-    }
-  };
-
   describe("Swap a coin for which you have no account yet", () => {
     beforeAll(async () => {
       await beforeAllFunctionSwap({
@@ -151,7 +152,7 @@ export function runSwapLandingPageTest(
 
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
-    test("Swap landing page", async () => {
+    it("Swap landing page", async () => {
       const minAmount = await app.swapLiveApp.getMinimumAmount(fromAccount, toAccount);
       const swap = new Swap(fromAccount, toAccount, minAmount);
 
@@ -163,8 +164,66 @@ export function runSwapLandingPageTest(
       const providerList = await app.swapLiveApp.getProviderList();
       await app.swapLiveApp.checkFirstQuoteContainerInfos(providerList);
       await app.swapLiveApp.checkBestOffer();
+
+      await app.portfolio.openViaDeeplink();
+      await app.portfolio.waitForPortfolioPageToLoad();
+      await app.swap.openViaDeeplink();
+      await app.swapLiveApp.expectSwapLiveApp();
+      await app.swapLiveApp.checkAssetFromContains(fromAccount.currency.ticker);
+      await app.swapLiveApp.checkAssetToContains(toAccount.currency.ticker);
     });
   });
+}
+
+async function setupSwapAccounts(
+  fromAccount: Account,
+  toAccount: Account,
+  userdata = "skip-onboarding",
+) {
+  await app.speculos.setExchangeDependencies(fromAccount, toAccount);
+  await beforeAllFunctionSwap({
+    userdata,
+    speculosApp: AppInfos.EXCHANGE,
+    cliCommandsOnApp: [
+      {
+        app: fromAccount.currency.speculosApp,
+        cmd: liveDataWithAddressCommand(fromAccount),
+      },
+      {
+        app: toAccount.currency.speculosApp,
+        cmd: liveDataWithAddressCommand(toAccount),
+      },
+    ],
+  });
+}
+
+export function runSwapLnsNotSupportedBannerTest(
+  fromAccount: Account,
+  toAccount: Account,
+  unsupportedProvider: Provider,
+  tmsLinks: string[],
+  tags: string[],
+) {
+  (process.env.SPECULOS_DEVICE === Device.LNS.name ? describe : describe.skip)(
+    "Swap - LNS not supported banner",
+    () => {
+      beforeAll(async () => {
+        await setupSwapAccounts(fromAccount, toAccount, "skip-onboarding-with-last-seen-device");
+      });
+
+      tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
+      tags.forEach(tag => $Tag(tag));
+      it(`Shows LNS not supported banner for ${unsupportedProvider.uiName}`, async () => {
+        const minAmount = await app.swapLiveApp.getMinimumAmount(fromAccount, toAccount, [
+          unsupportedProvider.name,
+        ]);
+
+        await performSwapUntilQuoteSelectionStep(fromAccount, toAccount, minAmount);
+        await app.swapLiveApp.selectSpecificProvider(unsupportedProvider.uiName);
+        await app.swapLiveApp.checkLnsNotSupportedBanner();
+      });
+    },
+  );
 }
 
 export function runTooLowAmountForQuoteSwapsTest(
@@ -449,13 +508,45 @@ export function runSwapSwitchSendAndReceiveCurrenciesTest(
   });
 }
 
-export function runSwapEntryPoints(account: Account, tmsLinks: string[], tags: string[]) {
-  const validateSwapAssetsPage = async (accountFrom: string, accountTo: string) => {
-    await app.swapLiveApp.expectSwapLiveApp();
-    await app.swapLiveApp.checkAssetFrom(accountFrom, "");
-    await app.swapLiveApp.checkAssetTo(accountTo, "-");
-  };
+async function validateSwapAssetsPage(accountFrom: string, accountTo: string) {
+  await app.swapLiveApp.expectSwapLiveApp();
+  await app.swapLiveApp.checkAssetFrom(accountFrom, "");
+  await app.swapLiveApp.checkAssetTo(accountTo, "-");
+}
 
+async function openSwapFromPortfolioEntryPoint() {
+  await app.portfolio.openViaDeeplink();
+  if (isWallet40) {
+    await app.mainNavigation.tapWallet40Tab("swap");
+  } else {
+    await app.transferMenuDrawer.open();
+    await app.transferMenuDrawer.navigateToSwap();
+  }
+}
+
+export function runSwapDefaultCurrencyNoSetupTest(
+  defaultSendAccount: Account,
+  tmsLinks: string[],
+  tags: string[],
+) {
+  describe("Swap - Default currency without previous setup", () => {
+    beforeAll(async () => {
+      await beforeAllFunctionSwap({
+        userdata: "speculos-tests-app",
+        speculosApp: AppInfos.EXCHANGE,
+      });
+    });
+
+    tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
+    tags.forEach(tag => $Tag(tag));
+    it("Defaults You send to the account with most funds and leaves You receive empty", async () => {
+      await openSwapFromPortfolioEntryPoint();
+      await validateSwapAssetsPage(defaultSendAccount.currency.ticker, "");
+    });
+  });
+}
+
+export function runSwapEntryPoints(account: Account, tmsLinks: string[], tags: string[]) {
   describe("Swap - Entry Points", () => {
     beforeAll(async () => {
       await beforeAllFunctionSwap({
@@ -467,13 +558,7 @@ export function runSwapEntryPoints(account: Account, tmsLinks: string[], tags: s
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it("Access Swap from different entry points", async () => {
-      await app.portfolio.openViaDeeplink();
-      if (isWallet40) {
-        await app.mainNavigation.tapWallet40Tab("swap");
-      } else {
-        await app.transferMenuDrawer.open();
-        await app.transferMenuDrawer.navigateToSwap();
-      }
+      await openSwapFromPortfolioEntryPoint();
       await validateSwapAssetsPage(account.currency.ticker, "");
 
       await app.account.openViaDeeplink();

--- a/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
@@ -166,9 +166,8 @@ export function runSwapLandingPageTest(
       await app.swapLiveApp.checkBestOffer();
 
       await app.portfolio.openViaDeeplink();
-      await app.portfolio.waitForPortfolioPageToLoad();
       await app.swap.openViaDeeplink();
-      await app.swapLiveApp.expectSwapLiveApp();
+      await app.swapLiveApp.expectSwapLiveAppForm();
       await app.swapLiveApp.checkAssetFromContains(fromAccount.currency.ticker);
       await app.swapLiveApp.checkAssetToContains(toAccount.currency.ticker);
     });

--- a/e2e/mobile/specs/swap/otherTestCases/swapDefaultCurrencyNoSetup.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapDefaultCurrencyNoSetup.spec.ts
@@ -1,8 +1,0 @@
-import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
-import { runSwapDefaultCurrencyNoSetupTest } from "./swap.other";
-
-runSwapDefaultCurrencyNoSetupTest(
-  Account.BTC_NATIVE_SEGWIT_1,
-  ["B2CQA-3079"],
-  ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@bitcoin", "@family-bitcoin"],
-);

--- a/e2e/mobile/specs/swap/otherTestCases/swapDefaultCurrencyNoSetup.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapDefaultCurrencyNoSetup.spec.ts
@@ -1,0 +1,8 @@
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { runSwapDefaultCurrencyNoSetupTest } from "./swap.other";
+
+runSwapDefaultCurrencyNoSetupTest(
+  Account.BTC_NATIVE_SEGWIT_1,
+  ["B2CQA-3079"],
+  ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@bitcoin", "@family-bitcoin"],
+);

--- a/e2e/mobile/specs/swap/otherTestCases/swapEntryPoints.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapEntryPoints.spec.ts
@@ -3,7 +3,7 @@ import { runSwapEntryPoints } from "./swap.other";
 
 const swapEntryPointsConfig = {
   account: Account.BTC_NATIVE_SEGWIT_1,
-  tmsLinks: ["B2CQA-2784"],
+  tmsLinks: ["B2CQA-2784", "B2CQA-3079"],
   tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@bitcoin", "@family-bitcoin"],
 };
 

--- a/e2e/mobile/specs/swap/otherTestCases/swapLandingPage.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapLandingPage.spec.ts
@@ -1,10 +1,10 @@
-import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { Account, TokenAccount } from "@ledgerhq/live-common/e2e/enum/Account";
 import { runSwapLandingPageTest } from "./swap.other";
 
 const swapTestConfig = {
   fromAccount: Account.ETH_1,
-  toAccount: TokenAccount.ETH_USDC_1,
-  tmsLinks: ["B2CQA-2918"],
+  toAccount: TokenAccount.ETH_USDT_1,
+  tmsLinks: ["B2CQA-2918", "B2CQA-2327", "B2CQA-3080"],
   tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@ethereum", "@family-evm"],
 };
 

--- a/e2e/mobile/specs/swap/otherTestCases/swapLnsNotSupportedBanner.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapLnsNotSupportedBanner.spec.ts
@@ -1,0 +1,11 @@
+import { Account, TokenAccount } from "@ledgerhq/live-common/e2e/enum/Account";
+import { Provider } from "@ledgerhq/live-common/e2e/enum/Provider";
+import { runSwapLnsNotSupportedBannerTest } from "./swap.other";
+
+runSwapLnsNotSupportedBannerTest(
+  Account.ETH_1,
+  TokenAccount.ETH_USDT_1,
+  Provider.LIFI,
+  ["B2CQA-3389"],
+  ["@LNS", "@ethereum", "@family-evm"],
+);

--- a/e2e/mobile/userdata/skip-onboarding-with-last-seen-device.json
+++ b/e2e/mobile/userdata/skip-onboarding-with-last-seen-device.json
@@ -42,8 +42,36 @@
       "seenDevices": [
         {
           "modelId": "nanoS",
-          "deviceInfo": {},
-          "apps": []
+          "deviceInfo": {
+            "version": "2.1.0",
+            "mcuVersion": "1.12",
+            "seVersion": "2.1.0",
+            "majMin": "2.1.0",
+            "providerName": null,
+            "targetId": 823132164,
+            "hasDevFirmware": false,
+            "seTargetId": 823132164,
+            "isOSU": false,
+            "isBootloader": false,
+            "isRecoveryMode": false,
+            "managerAllowed": false,
+            "pinValidated": true,
+            "onboarded": true,
+            "bootloaderVersion": "0.11",
+            "hardwareVersion": 0,
+            "languageId": 0,
+            "seFlags": []
+          },
+          "apps": [
+            {
+              "name": "Bitcoin",
+              "version": "2.1.2"
+            },
+            {
+              "name": "Ethereum",
+              "version": "1.10.2"
+            }
+          ]
         }
       ],
       "blacklistedTokenIds": [],

--- a/e2e/mobile/userdata/skip-onboarding-with-last-seen-device.json
+++ b/e2e/mobile/userdata/skip-onboarding-with-last-seen-device.json
@@ -1,0 +1,64 @@
+{
+  "data": {
+    "SPECTRON_RUN": {
+      "localStorage": {
+        "acceptedTermsVersion": "2019-12-04"
+      }
+    },
+    "settings": {
+      "hasCompletedOnboarding": true,
+      "counterValue": "USD",
+      "language": "en",
+      "theme": "light",
+      "region": null,
+      "locale": "en-US",
+      "orderAccounts": "balance|desc",
+      "countervalueFirst": false,
+      "autoLockTimeout": 10,
+      "marketIndicator": "western",
+      "currenciesSettings": {},
+      "pairExchanges": {},
+      "developerMode": false,
+      "loaded": true,
+      "shareAnalytics": false,
+      "sharePersonalizedRecommandations": false,
+      "hasSeenAnalyticsOptInPrompt": true,
+      "analyticsEnabled": false,
+      "personalizedRecommendationsEnabled": false,
+      "trackingEnabled": false,
+      "sentryLogs": true,
+      "readOnlyModeEnabled": false,
+      "hasOrderedNano": true,
+      "lastUsedVersion": "99.99.99",
+      "dismissedBanners": [],
+      "accountsViewMode": "list",
+      "showAccountsHelperBanner": true,
+      "hideEmptyTokenAccounts": false,
+      "sidebarCollapsed": false,
+      "discreetMode": false,
+      "preferredDeviceModel": "nanoS",
+      "hasInstalledApps": true,
+      "dismissedDynamicCards": [],
+      "seenDevices": [
+        {
+          "modelId": "nanoS",
+          "deviceInfo": {},
+          "apps": []
+        }
+      ],
+      "blacklistedTokenIds": [],
+      "swapAcceptedProviderIds": [],
+      "deepLinkUrl": null,
+      "firstTimeLend": false,
+      "swapProviders": [],
+      "showClearCacheBanner": false,
+      "starredAccountIds": [],
+      "hasPassword": false
+    },
+    "user": {
+      "id": "08cf3393-c5eb-4ea7-92de-0deea22e3971"
+    },
+    "accounts": [],
+    "countervalues": {}
+  }
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Mobile Swap Live App landing page assertions
  - Mobile Swap quote selection and best-value display
  - Mobile Swap default currency behavior with and without previous setup
  - Mobile Swap Ledger Nano S unsupported-provider banner

### 📝 Description

This PR adds Mobile E2E coverage for the Swap UI and configuration gaps tracked by QAA-1127. The covered scenarios include landing on the Swap exchange window, best-value quote ordering, default currency behavior when opening Swap for the first time, persistence of selected currencies after reopening Swap, and the Ledger Nano S unsupported banner.

The implementation reuses the existing Mobile Swap E2E structure, keeps each Xray link attached only to scenarios that assert its requirement, and adds a focused changeset for the mobile E2E package.

https://github.com/LedgerHQ/ledger-live/actions/runs/25157378188
https://github.com/LedgerHQ/ledger-live/actions/runs/25129330347/job/73654340301

### ❓ Context

- **JIRA or GitHub link**: [QAA-1127](https://ledgerhq.atlassian.net/browse/QAA-1127)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-1127]: https://ledgerhq.atlassian.net/browse/QAA-1127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ