### PR TITLE
[LWM] fix(mobile): remove redundant My Wallet title and adjust profile spacing

### DIFF
--- a/.changeset/live-30172-my-wallet-header.md
+++ b/.changeset/live-30172-my-wallet-header.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Remove redundant My Wallet profile title and tighten header spacing

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/__integrations__/MyWalletScreen.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/__integrations__/MyWalletScreen.integration.test.tsx
@@ -48,7 +48,6 @@ describe("MyWalletScreen", () => {
   it("should render the profile section with avatar and title", () => {
     renderScreen();
     expect(screen.getByTestId("my-wallet-avatar")).toBeVisible();
-    expect(screen.getByTestId("my-wallet-profile-title")).toBeVisible();
   });
 
   it("should render the quick actions row with all action buttons", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/index.tsx
@@ -14,10 +14,13 @@ export function MyWalletScreen() {
   return (
     <Box style={{ flex: 1 }}>
       <TrackScreen category="My Wallet" />
-      <Box lx={{ paddingHorizontal: "s16", gap: "s24", paddingTop: "s24" }}>
-        <ProfileSection />
-        <QuickActionsRow />
+      <Box lx={{ paddingHorizontal: "s16", gap: "s24", paddingTop: "s16" }}>
+        <Box lx={{ alignItems: "center", gap: "s48" }}>
+          <ProfileSection />
+          <QuickActionsRow />
+        </Box>
       </Box>
+      {/* temporary hide the new UI until it's ready */}
       {shouldDisplayMyWallet ? (
         <Box lx={{ paddingTop: "s24" }} style={{ flex: 1 }}>
           <MyLedgerSection />

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/ProfileSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/ProfileSection/index.tsx
@@ -1,17 +1,11 @@
 import React from "react";
-import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
-import { useTranslation } from "~/context/Locale";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { UserAvatar } from "../../components/UserAvatar";
 
 export function ProfileSection() {
-  const { t } = useTranslation();
-
   return (
-    <Box lx={{ alignItems: "center", gap: "s12" }}>
+    <Box lx={{ alignItems: "center" }}>
       <UserAvatar size="lg" />
-      <Text typography="heading5SemiBold" lx={{ color: "base" }} testID="my-wallet-profile-title">
-        {t("tabs.myWallet")}
-      </Text>
     </Box>
   );
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Layout-only My Wallet header changes; no dedicated tests._
- [x] **Impact of the changes:**
      - My Wallet tab: profile header (avatar, spacing vs quick actions)
      - Tab bar / screen title still shows My Wallet; confirm no duplicate heading under avatar
      - Both branches of `shouldDisplayMyWallet` (My Ledger vs legacy device list)

### 📝 Description

**Problem:** [LIVE-30172](https://ledgerhq.atlassian.net/browse/LIVE-30172) calls out a My Wallet copy issue and incorrect spacing in the new wallet header area.

**Solution:**
- Drop the extra profile title under the avatar (`tabs.myWallet`) so the section relies on the screen/tab labeling instead of repeating copy.
- Tighten top padding on the header stack and group the avatar block with quick actions in a centered column with consistent vertical rhythm (`gap: s48`).

| Before | After |
| ------ | ----- |
| <img width="320"  alt="image" src="https://github.com/user-attachments/assets/c2036ced-338e-43c5-ab8b-db554dc64cbf" />|<img width="320" alt="image" src="https://github.com/user-attachments/assets/96adc763-16d8-4703-bc89-4c29f46ed7ae" />|

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30172](https://ledgerhq.atlassian.net/browse/LIVE-30172)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30172]: https://ledgerhq.atlassian.net/browse/LIVE-30172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-30172]: https://ledgerhq.atlassian.net/browse/LIVE-30172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ