### PR TITLE
[LWD] refactor(desktop): remove redundant tooltips and My Wallet title

### DIFF
--- a/.changeset/wicked-pans-punch.md
+++ b/.changeset/wicked-pans-punch.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Remove redundant tooltips from context menu trigger and history button, remove My Wallet top bar title

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/HistoryButton.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/HistoryButton.tsx
@@ -4,12 +4,11 @@ import { TopBarActionButton } from "./TopBarActionButton";
 import { useHistory } from "../hooks/useHistory";
 
 export function HistoryButton() {
-  const { handleHistory, historyIcon, hasUnread, tooltip, cta } = useHistory();
+  const { handleHistory, historyIcon, hasUnread, cta } = useHistory();
 
   const button = (
     <TopBarActionButton
       label="history"
-      tooltip={tooltip}
       icon={historyIcon}
       isInteractive={true}
       onClick={handleHistory}

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/__tests__/HistoryButton.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/__tests__/HistoryButton.test.tsx
@@ -13,7 +13,6 @@ const setupMock = (hasUnread: boolean) => {
     handleHistory: mockHandleHistory,
     historyIcon: Clock,
     hasUnread,
-    tooltip: "History",
     cta: "History",
   });
 };

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useHistory.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useHistory.test.ts
@@ -30,12 +30,11 @@ describe("useHistory", () => {
     mockUseLocation.mockReturnValue(createLocation("/history"));
   });
 
-  it("returns handleHistory, historyIcon, tooltip, and cta", () => {
+  it("returns handleHistory, historyIcon, hasUnread, and cta", () => {
     const { result } = renderHook(() => useHistory());
 
     expect(result.current.handleHistory).toBeDefined();
     expect(result.current.historyIcon).toBe(Clock);
-    expect(result.current.tooltip).toBeDefined();
     expect(result.current.cta).toBeDefined();
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useHistory.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useHistory.ts
@@ -11,7 +11,6 @@ export const useHistory = (): {
   handleHistory: () => void;
   historyIcon: typeof Clock;
   hasUnread: boolean;
-  tooltip: string;
   cta: string;
 } => {
   const { t } = useTranslation();
@@ -35,7 +34,6 @@ export const useHistory = (): {
     handleHistory,
     historyIcon: Clock,
     hasUnread,
-    tooltip: t("topBar.history.tooltip"),
     cta: t("topBar.history.cta"),
   };
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ContextMenu/ContextMenuView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ContextMenu/ContextMenuView.tsx
@@ -16,7 +16,7 @@ const align = "end";
 export function ContextMenuView({ open, onOpenChange, contextValue }: ContextMenuViewProps) {
   return (
     <Popover overlay open={open} onOpenChange={onOpenChange}>
-      <ContextMenuTrigger popoverOpen={open} />
+      <ContextMenuTrigger />
 
       <PopoverContent width="fixed" side={side} align={align} className="flex flex-col gap-24">
         <ContextMenuContext.Provider value={contextValue}>

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ContextMenuTrigger.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ContextMenuTrigger.tsx
@@ -1,13 +1,9 @@
 import React from "react";
-import { PopoverTrigger, Tooltip, TooltipTrigger, TooltipContent } from "@ledgerhq/lumen-ui-react";
+import { PopoverTrigger } from "@ledgerhq/lumen-ui-react";
 import { useTranslation } from "react-i18next";
 import { UserAvatar } from "./UserAvatar";
 
-type ContextMenuTriggerProps = Readonly<{
-  popoverOpen: boolean;
-}>;
-
-export function ContextMenuTrigger({ popoverOpen }: ContextMenuTriggerProps) {
+export function ContextMenuTrigger() {
   const { t } = useTranslation();
   const label = t("myWallet.title");
 
@@ -15,14 +11,9 @@ export function ContextMenuTrigger({ popoverOpen }: ContextMenuTriggerProps) {
     <PopoverTrigger
       render={
         <button aria-label={label} className="cursor-pointer items-center justify-center">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="inline-flex">
-                <UserAvatar showNotification size="sm" />
-              </span>
-            </TooltipTrigger>
-            {!popoverOpen && <TooltipContent side="bottom">{label}</TooltipContent>}
-          </Tooltip>
+          <span className="inline-flex">
+            <UserAvatar showNotification size="sm" />
+          </span>
         </button>
       }
     />

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/TopBar/TopBarView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/TopBar/TopBarView.tsx
@@ -3,12 +3,10 @@ import { TopBarActionButton } from "LLD/components/TopBar/components/TopBarActio
 import type { MyWalletTopBarViewProps } from "./types";
 import { UserAvatar } from "../UserAvatar";
 
-const TopBarView = ({ title, settingsAction, notificationAction }: MyWalletTopBarViewProps) => (
+const TopBarView = ({ settingsAction, notificationAction }: MyWalletTopBarViewProps) => (
   <div className="flex justify-between items-center">
-    <div className="flex items-center gap-12">
-      <UserAvatar showNotification={false} size="md" />
-      <p className="body-1-semi-bold text-base">{title}</p>
-    </div>
+    <UserAvatar showNotification={false} size="md" />
+
     <div className="flex gap-16">
       <TopBarActionButton {...notificationAction} />
       <TopBarActionButton {...settingsAction} />

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/TopBar/hooks/useTopBarViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/TopBar/hooks/useTopBarViewModel.ts
@@ -1,4 +1,3 @@
-import { useTranslation } from "react-i18next";
 import { useSettings } from "LLD/components/TopBar/hooks/useSettings";
 import { useNotificationIndicator } from "LLD/components/TopBar/hooks/useNotificationIndicator";
 import type { TopBarAction } from "LLD/components/TopBar/types";
@@ -7,7 +6,6 @@ import { useContextMenuClose } from "../../ContextMenuContext";
 import { MY_WALLET_TRACKING_BUTTON, MY_WALLET_TRACKING_PAGE_NAME } from "../../../constants";
 
 const useTopBarViewModel = () => {
-  const { t } = useTranslation();
   const close = useContextMenuClose();
   const {
     handleSettings,
@@ -56,7 +54,6 @@ const useTopBarViewModel = () => {
   };
 
   return {
-    title: t("myWallet.title"),
     settingsAction,
     notificationAction,
   };

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/TopBar/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/TopBar/index.tsx
@@ -3,14 +3,8 @@ import useTopBarViewModel from "./hooks/useTopBarViewModel";
 import TopBarView from "./TopBarView";
 
 const TopBar = () => {
-  const { title, settingsAction, notificationAction } = useTopBarViewModel();
-  return (
-    <TopBarView
-      title={title}
-      settingsAction={settingsAction}
-      notificationAction={notificationAction}
-    />
-  );
+  const { settingsAction, notificationAction } = useTopBarViewModel();
+  return <TopBarView settingsAction={settingsAction} notificationAction={notificationAction} />;
 };
 
 export default TopBar;

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/TopBar/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/TopBar/types.ts
@@ -1,7 +1,6 @@
 import type { TopBarAction } from "LLD/components/TopBar/types";
 
 export type MyWalletTopBarViewProps = {
-  title: string;
   settingsAction: TopBarAction;
   notificationAction: TopBarAction;
 };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Context menu trigger tooltip removed (no visual tooltip on avatar hover)
      - History button tooltip property removed from hook
      - My Wallet top bar title text removed
      - Verify avatar click still opens context menu correctly

### 📝 Description

Redundant tooltips on the context menu trigger and history button added unnecessary UI clutter. The My Wallet top bar also displayed a title that is no longer needed in the current design.

This PR removes the `Tooltip`/`TooltipTrigger`/`TooltipContent` wrapper from `ContextMenuTrigger`, drops the `tooltip` return value from `useHistory`, removes the `title` prop from the My Wallet `TopBarView`, and adapts all related tests.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30154](https://ledgerhq.atlassian.net/browse/LIVE-30154)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30154]: https://ledgerhq.atlassian.net/browse/LIVE-30154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ