### PR TITLE
[LWM] feat(canton): add disclaimer step and terms modal to add-account mobi…

### DIFF
--- a/.changeset/warm-tables-look.md
+++ b/.changeset/warm-tables-look.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add a Canton Network disclaimer + terms gate to the mobile Canton onboarding flow.

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -366,6 +366,7 @@ export enum ScreenName {
   StellarAddAssetValidationError = "StellarAddAssetValidationError",
   StellarAddAssetValidationSuccess = "StellarAddAssetValidationSuccess",
   // Canton
+  CantonDisclaimer = "CantonDisclaimer",
   CantonOnboardAccount = "CantonOnboardAccount",
   // Concordium
   ConcordiumOnboardAccount = "ConcordiumOnboardAccount",

--- a/apps/ledger-live-mobile/src/families/canton/Onboard/CantonDisclaimer/CantonTermsDrawer.tsx
+++ b/apps/ledger-live-mobile/src/families/canton/Onboard/CantonDisclaimer/CantonTermsDrawer.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { Flex, Text } from "@ledgerhq/native-ui";
+import QueuedDrawer from "~/components/QueuedDrawer";
+import { useTranslation } from "~/context/Locale";
+
+type Props = Readonly<{
+  isOpen: boolean;
+  onClose: () => void;
+}>;
+
+export default function CantonTermsDrawer({ isOpen, onClose }: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <QueuedDrawer
+      isRequestingToBeOpened={isOpen}
+      onClose={onClose}
+      title={t("canton.disclaimer.terms.title")}
+    >
+      <Flex flexDirection="column" alignItems="stretch" px={4} pb={6}>
+        <Text variant="body" fontWeight="semiBold" color="neutral.c100" mb={3}>
+          {t("canton.disclaimer.terms.sectionTitle")}
+        </Text>
+        <Text variant="body" color="neutral.c80">
+          {t("canton.disclaimer.terms.body")}
+        </Text>
+      </Flex>
+    </QueuedDrawer>
+  );
+}

--- a/apps/ledger-live-mobile/src/families/canton/Onboard/CantonDisclaimer/__integrations__/CantonDisclaimer.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/families/canton/Onboard/CantonDisclaimer/__integrations__/CantonDisclaimer.integration.test.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { screen, render, waitFor } from "@tests/test-renderer";
+import CantonDisclaimer from "../index";
+
+describe("CantonDisclaimer integration", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("disables Agree until the checkbox is toggled, then calls onAgree", async () => {
+    const onAgree = jest.fn();
+    const onCancel = jest.fn();
+
+    const { user } = render(<CantonDisclaimer onAgree={onAgree} onCancel={onCancel} />);
+
+    const agreeButton = screen.getByText("Agree");
+    expect(agreeButton).toBeDisabled();
+
+    await user.press(screen.getByTestId("canton-disclaimer-agree-row"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Agree")).not.toBeDisabled();
+    });
+
+    await user.press(screen.getByText("Agree"));
+    expect(onAgree).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("calls onCancel when Cancel is pressed", async () => {
+    const onAgree = jest.fn();
+    const onCancel = jest.fn();
+
+    const { user } = render(<CantonDisclaimer onAgree={onAgree} onCancel={onCancel} />);
+
+    await user.press(screen.getByText("Cancel"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onAgree).not.toHaveBeenCalled();
+  });
+
+  it("opens the terms drawer when the inline link is pressed", async () => {
+    const onAgree = jest.fn();
+    const onCancel = jest.fn();
+
+    const { user } = render(<CantonDisclaimer onAgree={onAgree} onCancel={onCancel} />);
+
+    expect(screen.queryByText("Standard Token Liability & Recovery")).not.toBeOnTheScreen();
+
+    await user.press(screen.getByTestId("canton-disclaimer-terms-link"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Standard Token Liability & Recovery")).toBeOnTheScreen();
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/families/canton/Onboard/CantonDisclaimer/index.tsx
+++ b/apps/ledger-live-mobile/src/families/canton/Onboard/CantonDisclaimer/index.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import { Pressable } from "react-native";
+import { Button, Checkbox, Flex, Text } from "@ledgerhq/native-ui";
+import { Trans, useTranslation } from "~/context/Locale";
+import CantonTermsDrawer from "./CantonTermsDrawer";
+import { useCantonDisclaimerViewModel } from "./useCantonDisclaimerViewModel";
+
+type Props = Readonly<{
+  onAgree: () => void;
+  onCancel: () => void;
+}>;
+
+const BULLET_KEYS = ["utxo", "offers", "dualValidator", "tokenLiability"] as const;
+
+export default function CantonDisclaimer({ onAgree, onCancel }: Props) {
+  const { t } = useTranslation();
+  const { agreed, isTermsOpen, handleToggleAgreed, handleOpenTerms, handleCloseTerms } =
+    useCantonDisclaimerViewModel();
+
+  return (
+    <Flex flexDirection="column" px={6} pb={6} testID="canton-disclaimer">
+      <Text variant="h4" fontWeight="semiBold" color="neutral.c100" mb={3}>
+        {t("canton.disclaimer.title")}
+      </Text>
+      <Text variant="body" color="neutral.c80" mb={4}>
+        {t("canton.disclaimer.intro")}
+      </Text>
+
+      {BULLET_KEYS.map(key => (
+        <Flex key={key} flexDirection="row" alignItems="flex-start" mb={3}>
+          <Text variant="body" color="neutral.c100" mr={2} mt={1}>
+            •
+          </Text>
+          <Flex flex={1}>
+            <Text variant="body" fontWeight="semiBold" color="neutral.c100">
+              {t(`canton.disclaimer.bullets.${key}.title`)}
+            </Text>
+            <Text variant="body" color="neutral.c80">
+              {t(`canton.disclaimer.bullets.${key}.body`)}
+            </Text>
+          </Flex>
+        </Flex>
+      ))}
+
+      <Pressable
+        onPress={handleToggleAgreed}
+        testID="canton-disclaimer-agree-row"
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: agreed }}
+      >
+        <Flex flexDirection="row" alignItems="center" mt={4}>
+          <Checkbox checked={agreed} onChange={handleToggleAgreed} />
+          <Flex flex={1} ml={3}>
+            <Text variant="body" color="neutral.c80">
+              <Trans
+                i18nKey="canton.disclaimer.agreeLabel"
+                components={{
+                  1: (
+                    <Text
+                      variant="body"
+                      color="primary.c80"
+                      onPress={handleOpenTerms}
+                      testID="canton-disclaimer-terms-link"
+                    />
+                  ),
+                }}
+              />
+            </Text>
+          </Flex>
+        </Flex>
+      </Pressable>
+
+      <Flex flexDirection="row" justifyContent="space-between" mt={6}>
+        <Flex flex={1} mr={2}>
+          <Button type="default" onPress={onCancel} testID="canton-disclaimer-cancel">
+            {t("canton.disclaimer.cancel")}
+          </Button>
+        </Flex>
+        <Flex flex={1} ml={2}>
+          <Button
+            type="main"
+            onPress={onAgree}
+            disabled={!agreed}
+            testID="canton-disclaimer-agree"
+          >
+            {t("canton.disclaimer.agree")}
+          </Button>
+        </Flex>
+      </Flex>
+
+      <CantonTermsDrawer isOpen={isTermsOpen} onClose={handleCloseTerms} />
+    </Flex>
+  );
+}

--- a/apps/ledger-live-mobile/src/families/canton/Onboard/CantonDisclaimer/useCantonDisclaimerViewModel.ts
+++ b/apps/ledger-live-mobile/src/families/canton/Onboard/CantonDisclaimer/useCantonDisclaimerViewModel.ts
@@ -1,0 +1,18 @@
+import { useCallback, useState } from "react";
+
+export function useCantonDisclaimerViewModel() {
+  const [agreed, setAgreed] = useState(false);
+  const [isTermsOpen, setIsTermsOpen] = useState(false);
+
+  const handleToggleAgreed = useCallback(() => setAgreed(prev => !prev), []);
+  const handleOpenTerms = useCallback(() => setIsTermsOpen(true), []);
+  const handleCloseTerms = useCallback(() => setIsTermsOpen(false), []);
+
+  return {
+    agreed,
+    isTermsOpen,
+    handleToggleAgreed,
+    handleOpenTerms,
+    handleCloseTerms,
+  };
+}

--- a/apps/ledger-live-mobile/src/families/canton/Onboard/CantonDisclaimerScreen.tsx
+++ b/apps/ledger-live-mobile/src/families/canton/Onboard/CantonDisclaimerScreen.tsx
@@ -1,0 +1,32 @@
+import React, { useCallback } from "react";
+import { ScrollView, StyleSheet } from "react-native";
+import { ScreenName } from "~/const";
+import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import CantonDisclaimer from "./CantonDisclaimer";
+import type { CantonOnboardAccountParamList } from "./types";
+
+type Props = StackNavigatorProps<CantonOnboardAccountParamList, ScreenName.CantonDisclaimer>;
+
+export default function CantonDisclaimerScreen({ navigation, route }: Props) {
+  const handleAgree = useCallback(() => {
+    navigation.replace(ScreenName.CantonOnboardAccount, route.params);
+  }, [navigation, route.params]);
+
+  const handleCancel = useCallback(() => {
+    navigation.getParent()?.goBack();
+  }, [navigation]);
+
+  return (
+    <ScrollView contentContainerStyle={styles.content}>
+      <CantonDisclaimer onAgree={handleAgree} onCancel={handleCancel} />
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    flexGrow: 1,
+    paddingTop: 16,
+    paddingBottom: 24,
+  },
+});

--- a/apps/ledger-live-mobile/src/families/canton/Onboard/CantonReonboardDrawer/__integrations__/CantonReonboardDrawer.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/families/canton/Onboard/CantonReonboardDrawer/__integrations__/CantonReonboardDrawer.integration.test.tsx
@@ -102,6 +102,54 @@ describe("CantonReonboardDrawer integration", () => {
     jest.clearAllMocks();
   });
 
+  async function acceptDisclaimer(user: ReturnType<typeof render>["user"]) {
+    await user.press(screen.getByTestId("canton-disclaimer-agree-row"));
+    await waitFor(() => {
+      expect(screen.getByText("Agree")).not.toBeDisabled();
+    });
+    await user.press(screen.getByText("Agree"));
+  }
+
+  it("should show the disclaimer first and require agreement before reonboarding", async () => {
+    const onClose = jest.fn();
+
+    const { user } = render(
+      <CantonReonboardDrawer
+        isOpen
+        currency={currency}
+        accountToReonboard={accountToReonboard}
+        onClose={onClose}
+      />,
+      { overrideInitialState: overrideInitialStateWithDevice },
+    );
+
+    expect(screen.getByText("Setup Canton Network")).toBeOnTheScreen();
+    expect(screen.queryByText("Confirm")).not.toBeOnTheScreen();
+
+    await acceptDisclaimer(user);
+
+    await waitFor(() => {
+      expect(screen.getByText("Confirm")).toBeOnTheScreen();
+    });
+  });
+
+  it("Cancel from disclaimer closes the drawer without reonboarding", async () => {
+    const onClose = jest.fn();
+
+    const { user } = render(
+      <CantonReonboardDrawer
+        isOpen
+        currency={currency}
+        accountToReonboard={accountToReonboard}
+        onClose={onClose}
+      />,
+      { overrideInitialState: overrideInitialStateWithDevice },
+    );
+
+    await user.press(screen.getByText("Cancel"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
   it("should complete reonboarding and call onClose", async () => {
     const onClose = jest.fn();
 
@@ -114,6 +162,8 @@ describe("CantonReonboardDrawer integration", () => {
       />,
       { overrideInitialState: overrideInitialStateWithDevice },
     );
+
+    await acceptDisclaimer(user);
 
     await user.press(screen.getByText("Confirm"));
 
@@ -148,6 +198,8 @@ describe("CantonReonboardDrawer integration", () => {
       />,
       { overrideInitialState: overrideInitialStateWithDevice },
     );
+
+    await acceptDisclaimer(user);
 
     await user.press(screen.getByText("Confirm"));
 

--- a/apps/ledger-live-mobile/src/families/canton/Onboard/CantonReonboardDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/families/canton/Onboard/CantonReonboardDrawer/index.tsx
@@ -7,6 +7,7 @@ import DeviceActionModal from "~/components/DeviceActionModal";
 import QueuedDrawer from "~/components/QueuedDrawer";
 import { Trans, useTranslation } from "~/context/Locale";
 import type { NavigationSnapshot } from "../../utils/navigationSnapshot";
+import CantonDisclaimer from "../CantonDisclaimer";
 import { useCantonReonboardDrawerViewModel } from "./useCantonReonboardDrawerViewModel";
 
 interface CantonReonboardDrawerProps {
@@ -26,6 +27,7 @@ export default function CantonReonboardDrawer({
 }: CantonReonboardDrawerProps) {
   const { t } = useTranslation();
   const [hasStarted, setHasStarted] = useState(false);
+  const [hasAgreedDisclaimer, setHasAgreedDisclaimer] = useState(false);
 
   const viewModel = useCantonReonboardDrawerViewModel({
     currency,
@@ -125,12 +127,19 @@ export default function CantonReonboardDrawer({
       <QueuedDrawer
         isRequestingToBeOpened={isOpen && !showDeviceModal}
         onClose={onClose}
-        title={t("canton.onboard.reonboard.title")}
+        title={hasAgreedDisclaimer ? t("canton.onboard.reonboard.title") : undefined}
       >
-        <Flex flexDirection="column" alignItems="stretch" px={4} pb={6}>
-          {renderContent()}
-          {renderFooter()}
-        </Flex>
+        {hasAgreedDisclaimer ? (
+          <Flex flexDirection="column" alignItems="stretch" px={4} pb={6}>
+            {renderContent()}
+            {renderFooter()}
+          </Flex>
+        ) : (
+          <CantonDisclaimer
+            onAgree={() => setHasAgreedDisclaimer(true)}
+            onCancel={onClose}
+          />
+        )}
       </QueuedDrawer>
 
       {showDeviceModal && device && (

--- a/apps/ledger-live-mobile/src/families/canton/Onboard/Onboard.tsx
+++ b/apps/ledger-live-mobile/src/families/canton/Onboard/Onboard.tsx
@@ -6,6 +6,7 @@ import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
 import { ScreenName } from "~/const";
 import { CantonOnboardAccountParamList } from "./types";
 import OnboardScreen from "./OnboardScreen";
+import CantonDisclaimerScreen from "./CantonDisclaimerScreen";
 import { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 
 type OnboardProps = StackNavigatorProps<
@@ -18,11 +19,18 @@ function Onboard({ route }: OnboardProps) {
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
     <Stack.Navigator
+      initialRouteName={ScreenName.CantonDisclaimer}
       screenOptions={{
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
     >
+      <Stack.Screen
+        name={ScreenName.CantonDisclaimer}
+        component={CantonDisclaimerScreen}
+        initialParams={route.params}
+        options={{ headerTitle: "" }}
+      />
       <Stack.Screen
         name={ScreenName.CantonOnboardAccount}
         component={OnboardScreen}
@@ -37,4 +45,5 @@ const options = {
   headerShown: false,
 };
 export { Onboard as component, options };
+export default Onboard;
 const Stack = createNativeStackNavigator<CantonOnboardAccountParamList>();

--- a/apps/ledger-live-mobile/src/families/canton/Onboard/types.ts
+++ b/apps/ledger-live-mobile/src/families/canton/Onboard/types.ts
@@ -3,12 +3,15 @@ import type { Account } from "@ledgerhq/types-live";
 import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { NavigationSnapshot } from "../utils/navigationSnapshot";
 
+type CantonOnboardParams = {
+  accountsToAdd: Account[];
+  currency: CryptoOrTokenCurrency;
+  isReonboarding?: boolean;
+  accountToReonboard?: Account;
+  restoreState?: NavigationSnapshot;
+};
+
 export type CantonOnboardAccountParamList = {
-  [ScreenName.CantonOnboardAccount]: {
-    accountsToAdd: Account[];
-    currency: CryptoOrTokenCurrency;
-    isReonboarding?: boolean;
-    accountToReonboard?: Account;
-    restoreState?: NavigationSnapshot;
-  };
+  [ScreenName.CantonDisclaimer]: CantonOnboardParams;
+  [ScreenName.CantonOnboardAccount]: CantonOnboardParams;
 };

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8935,6 +8935,36 @@
       "withdrawableBalance": "Withdrawable",
       "withdrawableBalanceTooltip": "Funds you can reclaim from offers you sent that have expired. Withdraw to move these back to your available balance."
     },
+    "disclaimer": {
+      "title": "Setup Canton Network",
+      "intro": "Canton has unique properties that require your awareness before continuing:",
+      "bullets": {
+        "utxo": {
+          "title": "UTXO-based balance",
+          "body": "Balance exists as individual coin contracts, capped at 100 per transfer. Idle contracts lose value over time and expire if fees exceed their balance."
+        },
+        "offers": {
+          "title": "All transfers work via offers",
+          "body": "Nothing settles automatically. Sent transfers can be withdrawn; received transfers need manual accept or reject. Manage offers from your Canton dashboard."
+        },
+        "dualValidator": {
+          "title": "Dual-validator security",
+          "body": "Your account requires co-signing by both Ledger and Klin, an independent validator. Neither party can act on your behalf alone."
+        },
+        "tokenLiability": {
+          "title": "Standard token liability ⚠️",
+          "body": "In a disaster recovery scenario, token recovery is the responsibility of the token issuer, not Ledger."
+        }
+      },
+      "agreeLabel": "I agree to <1>Canton Network Terms and Ledger's liability exclusion</1>",
+      "cancel": "Cancel",
+      "agree": "Agree",
+      "terms": {
+        "title": "Canton Network Terms",
+        "sectionTitle": "Standard Token Liability & Recovery",
+        "body": "Ledger only supports standard tokens issued through the Digital Asset (DA) Registry. Ledger is not the issuer of these tokens and holds no liability for their value, management, or underlying smart contracts.\n\nIn the event of a Ledger service disruption or \"disaster recovery\" failure, Ledger cannot recover your assets. You must contact the specific Token Issuer (Asset Admin) directly to initiate recovery via their \"Asset Freeze\" or \"Registry Recovery\" protocols. Your recourse lies solely with the Token Issuer under their existing Service Level Agreements (SLAs). By proceeding, you acknowledge that Ledger and its affiliates are excluded from all liability arising from the loss, recovery, or inability to recover these tokens."
+      }
+    },
     "onboard": {
       "account": "Account",
       "authorize": "Authorize",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8944,19 +8944,19 @@
           "body": "Balance exists as individual coin contracts, capped at 100 per transfer. Idle contracts lose value over time and expire if fees exceed their balance."
         },
         "offers": {
-          "title": "All transfers work via offers",
+          "title": "Offer-based transfers",
           "body": "Nothing settles automatically. Sent transfers can be withdrawn; received transfers need manual accept or reject. Manage offers from your Canton dashboard."
         },
         "dualValidator": {
           "title": "Dual-validator security",
-          "body": "Your account requires co-signing by both Ledger and Klin, an independent validator. Neither party can act on your behalf alone."
+          "body": "Transactions require co-signing from both Ledger and Klin. Neither can act on your behalf alone."
         },
         "tokenLiability": {
           "title": "Standard token liability ⚠️",
-          "body": "In a disaster recovery scenario, token recovery is the responsibility of the token issuer, not Ledger."
+          "body": "Token recovery in a failure scenario is the token issuer's responsibility, not Ledger's."
         }
       },
-      "agreeLabel": "I agree to <1>Canton Network Terms and Ledger's liability exclusion</1>",
+      "agreeLabel": "I agree to <1>Canton Network Terms and Ledger’s liability exclusion</1>",
       "cancel": "Cancel",
       "agree": "Agree",
       "terms": {

--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/Navigator.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/Navigator.tsx
@@ -15,7 +15,7 @@ import { NavigationHeaderBackButton } from "~/components/NavigationHeaderBackBut
 import AddAccountsSuccess from "./screens/AddAccountSuccess";
 import AddAccountsWarning from "./screens/AddAccountWarning";
 import NoAssociatedAccountsView from "./screens/NoAssociatedAccountsView";
-import OnboardScreen from "~/families/canton/Onboard/OnboardScreen";
+import CantonOnboardNavigator from "~/families/canton/Onboard/Onboard";
 import CloseWithConfirmation from "LLM/components/CloseWithConfirmation";
 import {
   BaseComposite,
@@ -117,8 +117,8 @@ export default function Navigator() {
       )}
       <Stack.Screen
         name={ScreenName.CantonOnboardAccount}
-        component={OnboardScreen}
-        options={{ headerTitle: "" }}
+        component={CantonOnboardNavigator}
+        options={{ headerShown: false }}
       />
       <Stack.Screen
         name={ScreenName.AddAccountsSuccess}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - live-mobile

### 📝 Description

Add a disclaimer step at the start of the Canton add-account flow covering UTXO mechanics, offer-based transfers, dual-validator security, and standard-token liability. Users must agree before connecting a device, with a link to a new Canton Network Terms modal.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: 
- https://ledgerhq.atlassian.net/browse/LIVE-28191


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
