### PR TITLE
[LWDM] fix: sui delegate missing fields

### DIFF
--- a/.changeset/forty-crabs-fail.md
+++ b/.changeset/forty-crabs-fail.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-sui": patch
+---
+
+Fix missing validatorAddress and stakedObjectId in Sui delegate operation details

--- a/libs/coin-modules/coin-sui/src/network/sdk.integ.test.ts
+++ b/libs/coin-modules/coin-sui/src/network/sdk.integ.test.ts
@@ -6,6 +6,7 @@ import coinConfig from "../config";
 import { FIGMENT_SUI_VALIDATOR_ADDRESS } from "../constants";
 import { normalizeSuiAddressForComparison } from "../utils";
 import {
+  transactionToCoinFrameworkOperation,
   createTransaction,
   DEFAULT_COIN_TYPE,
   getAccountBalances,
@@ -501,8 +502,56 @@ describe("SUI SDK Integration tests", () => {
     });
   });
 
-  // Pin both transfer flows to immutable on-chain transactions and verify the
-  // SDK maps each correctly. Asserts flow-specific on-chain shape
+  // Regression guard for BACK-10134: STAKING_REQUEST_EVENT had the wrong
+  // module name (staking_pool instead of validator), causing validatorAddress
+  // and stakedObjectId to be silently dropped from DELEGATE operation details.
+  // UNSTAKING_REQUEST_EVENT was already correct. These tests fetch real
+  // on-chain transactions with showEvents:true and assert the detail fields
+  // survive the full pipeline, catching any future constant drift that unit
+  // tests cannot.
+  describe("staking operation details (BACK-10134 regression)", () => {
+    // https://suiscan.xyz/mainnet/account/0x13d73cab19d2cf14e39289b122ed93fb0f9edd00e4c829e0cefb1f0611c54a8f
+    const STAKING_ADDRESS = "0x13d73cab19d2cf14e39289b122ed93fb0f9edd00e4c829e0cefb1f0611c54a8f";
+    // https://suiscan.xyz/mainnet/tx/4UtCqCH3oNEdaprZR9UjaMGg6HgLn3V3q3FEcvs5vieM
+    const UNDELEGATE_TX_DIGEST = "4UtCqCH3oNEdaprZR9UjaMGg6HgLn3V3q3FEcvs5vieM";
+    // https://suiscan.xyz/mainnet/tx/EkJbwk9R2pmJhxfAVpRqbfDYQN1yiNap1qMPVrKedwZf
+    const DELEGATE_TX_DIGEST = "EkJbwk9R2pmJhxfAVpRqbfDYQN1yiNap1qMPVrKedwZf";
+
+    it("UNDELEGATE: validatorAddress, rewardAmount and withdrawnAmount are populated from live events", async () => {
+      const raw = await withApi(api =>
+        api.getTransactionBlock({
+          digest: UNDELEGATE_TX_DIGEST,
+          options: { showInput: true, showBalanceChanges: true, showEffects: true, showEvents: true },
+        }),
+      );
+      const op = transactionToCoinFrameworkOperation(STAKING_ADDRESS, raw, undefined);
+      expect(op.type).toBe("UNDELEGATE");
+      expect(op.details).toMatchObject({
+        validatorAddress: expect.stringMatching(/^0x[0-9a-f]+$/i),
+      });
+      expect(typeof op.details!.rewardAmount).toBe("bigint");
+      expect(typeof op.details!.withdrawnAmount).toBe("bigint");
+    });
+
+    it("DELEGATE: validatorAddress is populated from live events", async () => {
+      const raw = await withApi(api =>
+        api.getTransactionBlock({
+          digest: DELEGATE_TX_DIGEST,
+          options: { showInput: true, showBalanceChanges: true, showEffects: true, showEvents: true },
+        }),
+      );
+      const op = transactionToCoinFrameworkOperation(STAKING_ADDRESS, raw, undefined);
+      expect(op.type).toBe("DELEGATE");
+      // validatorAddress is the field that was silently dropped by the bug.
+      // stakedObjectId is not asserted as it is absent from real on-chain events.
+      expect(op.details).toMatchObject({
+        validatorAddress: expect.stringMatching(/^0x[0-9a-f]+$/i),
+      });
+    });
+  });
+
+  // Pin both transfer flows to immutable on-chain testnet transactions and
+  // verify the SDK maps each correctly. Asserts flow-specific on-chain shape
   // (gasData.payment, accumulatorEvents) AND the resulting Operation values,
   // so both code paths in sdk.ts are exercised end-to-end against live RPC.
   //

--- a/libs/coin-modules/coin-sui/src/network/sdk.test.ts
+++ b/libs/coin-modules/coin-sui/src/network/sdk.test.ts
@@ -327,7 +327,7 @@ function mockStakingTx(address: string, amount: string) {
     ],
     events: [
       {
-        type: "0x3::staking_pool::StakingRequestEvent",
+        type: "0x3::validator::StakingRequestEvent",
         parsedJson: {
           validator_address: validatorAddress,
           staked_sui_id: "0xstaked_object_id_123",
@@ -1346,7 +1346,7 @@ describe("Staking Operations", () => {
       const tx = mockStakingTx(address, "-1001050000");
       (tx as any).events = [
         {
-          type: "0x3::staking_pool::StakingRequestEvent",
+          type: "0x3::validator::StakingRequestEvent",
           parsedJson: { validator_address: "0xabc" },
         },
       ];
@@ -1411,7 +1411,7 @@ describe("getStakingEventDetails", () => {
   it("should extract all fields from StakingRequestEvent", () => {
     const tx = makeTx([
       {
-        type: "0x3::staking_pool::StakingRequestEvent",
+        type: "0x3::validator::StakingRequestEvent",
         parsedJson: {
           validator_address: "0xabc",
           staked_sui_id: "0xobj123",
@@ -1445,7 +1445,7 @@ describe("getStakingEventDetails", () => {
   it("should handle partial StakingRequestEvent fields", () => {
     const tx = makeTx([
       {
-        type: "0x3::staking_pool::StakingRequestEvent",
+        type: "0x3::validator::StakingRequestEvent",
         parsedJson: { validator_address: "0xabc" },
       },
     ]);

--- a/libs/coin-modules/coin-sui/src/network/sdk.ts
+++ b/libs/coin-modules/coin-sui/src/network/sdk.ts
@@ -73,7 +73,7 @@ const MULTI_GET_OBJECTS_LIMIT = 50;
 
 export const DEFAULT_COIN_TYPE = "0x2::sui::SUI";
 
-const STAKING_REQUEST_EVENT = "0x3::staking_pool::StakingRequestEvent";
+const STAKING_REQUEST_EVENT = "0x3::validator::StakingRequestEvent";
 const UNSTAKING_REQUEST_EVENT = "0x3::validator::UnstakingRequestEvent";
 
 /** Default options for querying transactions. */


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description
Fix wrong module in STAKING_REQUEST_EVENT constant (staking_pool → validator), which caused delegate operations to silently drop validatorAddress and stakedObjectId from their details. 
Adds regression tests asserting all staking detail fields are populated for both DELEGATE and UNDELEGATE operations.                                                                        

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/BACK-10134

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
