### PR TITLE
[LWDM] feat(LIVE-29571): migrate Aleo private transaction field to amountRecordCommitments

### DIFF
--- a/.changeset/pretty-mice-cover.md
+++ b/.changeset/pretty-mice-cover.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-aleo": minor
+"ledger-live-desktop": minor
+---
+
+feat: migrate aleo private transaction field to amountRecordCommitments

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/SelfTransferModal/SelfTransferStepRecipient.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/SelfTransferModal/SelfTransferStepRecipient.test.tsx
@@ -108,7 +108,7 @@ describe("SelfTransferStepRecipient", () => {
     const updaterFn = updateTransaction.mock.calls[0][0];
     const result = updaterFn(aleoTransaction);
     expect(result.mode).toBe(TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC);
-    expect(result.properties).toEqual({ amountRecordCommitment: null, feeRecordCommitment: null });
+    expect(result.properties).toEqual({ amountRecordCommitments: [], feeRecordCommitment: null });
   });
 
   it("should call updateTransaction with CONVERT_PUBLIC_TO_PRIVATE when balance selector switches to public", async () => {

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/SelfTransferModal/SelfTransferStepRecipient.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/SelfTransferModal/SelfTransferStepRecipient.tsx
@@ -87,7 +87,7 @@ export const SelfTransferStepRecipient = ({
                   ...t,
                   mode: TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC,
                   properties: {
-                    amountRecordCommitment: null,
+                    amountRecordCommitments: [],
                     feeRecordCommitment: null,
                   },
                 };

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/SendTransferModal/AleoSendStepRecipient.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/SendTransferModal/AleoSendStepRecipient.test.tsx
@@ -173,7 +173,7 @@ describe("AleoSendStepRecipient", () => {
     const updaterFn = updateTransaction.mock.calls[0][0];
     const result = updaterFn(aleoTransaction);
     expect(result.mode).toBe(TRANSACTION_TYPE.TRANSFER_PRIVATE);
-    expect(result.properties).toEqual({ amountRecordCommitment: null, feeRecordCommitment: null });
+    expect(result.properties).toEqual({ amountRecordCommitments: [], feeRecordCommitment: null });
   });
 
   it("should call updateTransaction with TRANSFER_PUBLIC when switching to public balance", async () => {

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/SendTransferModal/AleoSendStepRecipient.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/SendTransferModal/AleoSendStepRecipient.tsx
@@ -77,7 +77,7 @@ export const AleoSendStepRecipient = ({
                   ...t,
                   mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
                   properties: {
-                    amountRecordCommitment: null,
+                    amountRecordCommitments: [],
                     feeRecordCommitment: null,
                   },
                 };

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/createSendSteps.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/createSendSteps.test.tsx
@@ -140,10 +140,10 @@ describe("createSendSteps", () => {
     const privateTransaction = {
       family: "aleo",
       mode: "transfer_private",
-      properties: { amountRecordCommitment: "some-commitment", feeRecordCommitment: "some-fee" },
+      properties: { amountRecordCommitments: ["some-commitment"], feeRecordCommitment: "some-fee" },
     };
     const result = updater(privateTransaction);
-    expect(result.properties).toEqual({ amountRecordCommitment: null, feeRecordCommitment: null });
+    expect(result.properties).toEqual({ amountRecordCommitments: [], feeRecordCommitment: null });
   });
 
   it("should not clear record when going back from record-picker on non-private tx", () => {

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/createSendSteps.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/createSendSteps.tsx
@@ -46,7 +46,7 @@ const createSendSteps: NonNullable<AleoFamily["createSendSteps"]> = () => {
           return {
             ...t,
             properties: {
-              amountRecordCommitment: null,
+              amountRecordCommitments: [],
               feeRecordCommitment: null,
             },
           };

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepRecordPicker.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepRecordPicker.test.tsx
@@ -101,8 +101,8 @@ describe("StepRecordPicker", () => {
     fees: new BigNumber(0),
     useAllAmount: false,
     properties: {
+      amountRecordCommitments: [],
       feeRecordCommitment: null,
-      amountRecordCommitment: null,
     },
   };
 
@@ -296,7 +296,7 @@ describe("StepRecordPicker", () => {
     expect(updateTransaction).toHaveBeenCalledTimes(1);
     const updaterFn = updateTransaction.mock.calls[0][0];
     const result = updaterFn(privateTransaction);
-    expect(result.properties?.amountRecordCommitment).toBe(record2.commitment);
+    expect(result.properties?.amountRecordCommitments).toEqual([record2.commitment]);
     expect(result.properties?.feeRecordCommitment).toBeNull();
   });
 
@@ -318,7 +318,7 @@ describe("StepRecordPicker", () => {
     expect(updateTransaction).toHaveBeenCalledTimes(1);
     const updaterFn = updateTransaction.mock.calls[0][0];
     const result = updaterFn(privateTransaction);
-    expect(result.properties?.amountRecordCommitment).toBe(record1.commitment);
+    expect(result.properties?.amountRecordCommitments).toEqual([record1.commitment]);
     expect(result.properties?.feeRecordCommitment).toBeNull();
   });
 

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepRecordPicker.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepRecordPicker.tsx
@@ -133,8 +133,8 @@ const AleoStepRecordPicker = ({ account, transaction, status, updateTransaction 
       return {
         ...transactionToUpdate,
         properties: {
+          amountRecordCommitments: [record.commitment],
           feeRecordCommitment: transactionToUpdate.properties?.feeRecordCommitment,
-          amountRecordCommitment: record.commitment,
         },
       };
     });
@@ -173,7 +173,9 @@ const AleoStepRecordPicker = ({ account, transaction, status, updateTransaction 
       >
         {unspentRecords.map(record => {
           const date = new Date(record.block_timestamp * 1000);
-          const isSelected = record.commitment === transaction.properties?.amountRecordCommitment;
+          const isSelected = (transaction.properties?.amountRecordCommitments ?? []).includes(
+            record.commitment,
+          );
 
           return (
             <StyledButton

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepRecordPickerFooter.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepRecordPickerFooter.test.tsx
@@ -25,12 +25,12 @@ const mockStatus: TransactionStatus = {
 
 const privateTransaction = makeAleoTransaction({
   mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
-  properties: { amountRecordCommitment: null, feeRecordCommitment: null },
+  properties: { amountRecordCommitments: [], feeRecordCommitment: null },
 });
 
 const privateTransactionWithRecord = makeAleoTransaction({
   mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
-  properties: { amountRecordCommitment: "some-commitment", feeRecordCommitment: null },
+  properties: { amountRecordCommitments: ["some-commitment"], feeRecordCommitment: null },
 });
 
 const defaultProps: StepProps = {

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepRecordPickerFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepRecordPickerFooter.tsx
@@ -22,7 +22,7 @@ const StepRecordPickerFooter = ({
   const isPrivateWithoutRecord =
     transaction?.family === "aleo" &&
     isPrivateTransaction(transaction) &&
-    !transaction.properties?.amountRecordCommitment;
+    (transaction.properties?.amountRecordCommitments ?? []).length === 0;
   const hasRecordError = !!status.errors.amountRecord || !!status.errors.feeRecord;
 
   return (

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/useAccountChangeGuard.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/useAccountChangeGuard.test.ts
@@ -76,7 +76,7 @@ describe("useAccountChangeGuard", () => {
     const updater = updateTransaction.mock.calls[0][0];
     const tx = makeAleoTransaction({
       mode: TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC,
-      properties: { amountRecordCommitment: "abc", feeRecordCommitment: null },
+      properties: { amountRecordCommitments: ["abc"], feeRecordCommitment: null },
     });
     const nextTx = updater(tx);
 
@@ -94,7 +94,7 @@ describe("useAccountChangeGuard", () => {
     const updater = updateTransaction.mock.calls[0][0];
     const tx = makeAleoTransaction({
       mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
-      properties: { amountRecordCommitment: "xyz", feeRecordCommitment: null },
+      properties: { amountRecordCommitments: ["xyz"], feeRecordCommitment: null },
     });
     const nextTx = updater(tx);
 
@@ -113,7 +113,7 @@ describe("useAccountChangeGuard", () => {
     const tx = makeAleoTransaction({
       mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
       recipient: "aleo1recipient",
-      properties: { amountRecordCommitment: "xyz", feeRecordCommitment: null },
+      properties: { amountRecordCommitments: ["xyz"], feeRecordCommitment: null },
     });
     const nextTx = updater(tx);
 

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/useAccountChangeGuard.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/useAccountChangeGuard.ts
@@ -13,7 +13,7 @@ import type { StepProps } from "~/renderer/modals/Send/types";
  * Background: `useBridgeTransaction.setAccount` calls `bridge.createTransaction()` (which returns
  * a default public tx with no `properties`), then shallow-patches the `mode` from the previous
  * transaction. This leaves TRANSFER_PRIVATE / CONVERT_PRIVATE_TO_PUBLIC without `properties`,
- * causing crashes on anything that reads `transaction.properties.amountRecordCommitment`.
+ * causing crashes on anything that reads `transaction.properties.amountRecordCommitments`.
  */
 export const useAccountChangeGuard = (
   onChangeAccount: StepProps["onChangeAccount"],

--- a/libs/coin-modules/coin-aleo/src/bridge/estimateMaxSpendable.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/estimateMaxSpendable.test.ts
@@ -92,13 +92,13 @@ describe("estimateMaxSpendable", () => {
     expect(mockCreateTransaction).toHaveBeenCalledWith(mockAccount);
   });
 
-  it("should return zero for private tx when amountRecordCommitment is missing", async () => {
+  it("should return zero for private tx when amountRecordCommitments is empty", async () => {
     mockPrepareTransaction.mockResolvedValue({
       ...mockPreparedTransaction,
       amount: new BigNumber(0),
       mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
       properties: {
-        amountRecordCommitment: null,
+        amountRecordCommitments: [],
         feeRecordCommitment: null,
       },
     });
@@ -110,7 +110,7 @@ describe("estimateMaxSpendable", () => {
         ...mockPreparedTransaction,
         mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
         properties: {
-          amountRecordCommitment: null,
+          amountRecordCommitments: [],
           feeRecordCommitment: null,
         },
       },
@@ -119,7 +119,7 @@ describe("estimateMaxSpendable", () => {
     expect(result).toEqual(new BigNumber(0));
   });
 
-  it("should return microcredits value for private tx when amountRecordCommitment exists", async () => {
+  it("should return microcredits value for private tx when amountRecordCommitments has an entry", async () => {
     const commitment = "record-1-commitment";
     const privateRecordAmount = "12345";
     const aleoResources = mockAccount.aleoResources!;
@@ -141,7 +141,7 @@ describe("estimateMaxSpendable", () => {
       amount: new BigNumber(privateRecordAmount),
       mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
       properties: {
-        amountRecordCommitment: commitment,
+        amountRecordCommitments: [commitment],
         feeRecordCommitment: null,
       },
     });
@@ -153,7 +153,7 @@ describe("estimateMaxSpendable", () => {
         ...mockPreparedTransaction,
         mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
         properties: {
-          amountRecordCommitment: commitment,
+          amountRecordCommitments: [commitment],
           feeRecordCommitment: null,
         },
       },
@@ -162,7 +162,7 @@ describe("estimateMaxSpendable", () => {
     expect(result).toEqual(new BigNumber(privateRecordAmount));
   });
 
-  it("should return zero for private tx when amountRecordCommitment exists but no record matches", async () => {
+  it("should return zero for private tx when amountRecordCommitments has an entry but no record matches", async () => {
     const commitment = "record-1-commitment";
     const aleoResources = mockAccount.aleoResources!;
     const accountWithoutMatchingRecord = getMockedAccount({
@@ -182,7 +182,7 @@ describe("estimateMaxSpendable", () => {
       amount: new BigNumber(0),
       mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
       properties: {
-        amountRecordCommitment: commitment,
+        amountRecordCommitments: [commitment],
         feeRecordCommitment: null,
       },
     });
@@ -195,7 +195,7 @@ describe("estimateMaxSpendable", () => {
           ...mockPreparedTransaction,
           mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
           properties: {
-            amountRecordCommitment: commitment,
+            amountRecordCommitments: [commitment],
             feeRecordCommitment: null,
           },
         },

--- a/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.test.ts
@@ -159,7 +159,7 @@ describe("getTransactionStatus", () => {
         recipient: account.freshAddress,
         mode: TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC,
         properties: {
-          amountRecordCommitment: null,
+          amountRecordCommitments: [],
           feeRecordCommitment: null,
         },
       };
@@ -282,7 +282,7 @@ describe("getTransactionStatus", () => {
       ...mockTransaction,
       mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
       properties: {
-        amountRecordCommitment: mockUnspentRecord1.commitment,
+        amountRecordCommitments: [mockUnspentRecord1.commitment],
         feeRecordCommitment: mockUnspentRecord2.commitment,
       },
     };
@@ -292,7 +292,7 @@ describe("getTransactionStatus", () => {
         ...privateTransaction,
         properties: {
           ...privateTransaction.properties,
-          amountRecordCommitment: null,
+          amountRecordCommitments: [],
         },
       };
 
@@ -306,7 +306,7 @@ describe("getTransactionStatus", () => {
         ...privateTransaction,
         properties: {
           ...privateTransaction.properties,
-          amountRecordCommitment: "missing-amount-record",
+          amountRecordCommitments: ["missing-amount-record"],
         },
       };
 
@@ -394,7 +394,7 @@ describe("getTransactionStatus", () => {
       const transaction: Transaction = {
         ...privateTransaction,
         properties: {
-          amountRecordCommitment: mockUnspentRecord1.commitment,
+          amountRecordCommitments: [mockUnspentRecord1.commitment],
           feeRecordCommitment: null,
         },
       };
@@ -428,7 +428,7 @@ describe("getTransactionStatus", () => {
       const transaction: Transaction = {
         ...privateTransaction,
         properties: {
-          amountRecordCommitment: mockUnspentRecord1.commitment,
+          amountRecordCommitments: [mockUnspentRecord1.commitment],
           feeRecordCommitment: smallFeeRecord.commitment,
         },
       };

--- a/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.ts
@@ -39,7 +39,7 @@ function getValidRecord({
   commitment,
 }: {
   account: AleoAccount;
-  commitment: TransactionPrivate["properties"]["amountRecordCommitment"];
+  commitment: string | null;
 }) {
   if (!commitment) {
     return null;
@@ -70,8 +70,8 @@ function validatePrivateTransaction({
   isFeeSponsored: boolean;
 }): Errors {
   const errors: Errors = {};
-  const { amountRecordCommitment, feeRecordCommitment } = transaction.properties;
-  const amountRecord = getValidRecord({ account, commitment: amountRecordCommitment });
+  const { amountRecordCommitments, feeRecordCommitment } = transaction.properties;
+  const amountRecord = getValidRecord({ account, commitment: amountRecordCommitments[0] ?? null });
 
   if (!amountRecord) {
     errors.amountRecord = new AleoAmountRecordRequired();
@@ -90,7 +90,7 @@ function validatePrivateTransaction({
 
   if (availableRecords.length <= 1) {
     errors.feeRecord = new AleoTwoRecordsRequired();
-  } else if (!feeRecord || feeRecord.commitment === amountRecordCommitment) {
+  } else if (!feeRecord || amountRecordCommitments.includes(feeRecord.commitment)) {
     errors.feeRecord = new AleoFeeRecordRequired();
   } else if (estimatedFees.gt(new BigNumber(feeRecord.microcredits))) {
     errors.feeRecord = new AleoFeeRecordInsufficientBalance();

--- a/libs/coin-modules/coin-aleo/src/bridge/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/prepareTransaction.test.ts
@@ -75,7 +75,7 @@ describe("prepareTransaction", () => {
       ...mockTransaction,
       mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
       properties: {
-        amountRecordCommitment: mockUnspentRecord1.commitment,
+        amountRecordCommitments: [mockUnspentRecord1.commitment],
         feeRecordCommitment: null,
       },
     };
@@ -100,14 +100,14 @@ describe("prepareTransaction", () => {
     expect(mockFindBestRecordForFee).toHaveBeenCalledTimes(1);
     expect(mockFindBestRecordForFee).toHaveBeenCalledWith({
       unspentRecords: accountWithPrivateRecords.aleoResources?.unspentPrivateRecords ?? [],
-      selectedAmountRecordCommitment: mockPrivateTransaction.properties.amountRecordCommitment,
+      selectedAmountRecordCommitments: mockPrivateTransaction.properties.amountRecordCommitments,
       targetFee: mockFees,
     });
     expect(result).toMatchObject({
       amount: mockAmount,
       fees: mockFees,
       properties: {
-        amountRecordCommitment: mockPrivateTransaction.properties.amountRecordCommitment,
+        amountRecordCommitments: mockPrivateTransaction.properties.amountRecordCommitments,
         feeRecordCommitment: mockUnspentRecord2.commitment,
       },
     });
@@ -118,7 +118,7 @@ describe("prepareTransaction", () => {
       ...mockTransaction,
       mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
       properties: {
-        amountRecordCommitment: mockUnspentRecord1.commitment,
+        amountRecordCommitments: [mockUnspentRecord1.commitment],
         feeRecordCommitment: mockUnspentRecord2.commitment,
       },
     };
@@ -146,7 +146,7 @@ describe("prepareTransaction", () => {
       amount: mockAmount,
       fees: mockFees,
       properties: {
-        amountRecordCommitment: mockPrivateTransaction.properties.amountRecordCommitment,
+        amountRecordCommitments: mockPrivateTransaction.properties.amountRecordCommitments,
         feeRecordCommitment: mockUnspentRecord2.commitment,
       },
     });
@@ -157,7 +157,7 @@ describe("prepareTransaction", () => {
       ...mockTransaction,
       mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
       properties: {
-        amountRecordCommitment: mockUnspentRecord1.commitment,
+        amountRecordCommitments: [mockUnspentRecord1.commitment],
         feeRecordCommitment: null,
       },
     };
@@ -185,7 +185,7 @@ describe("prepareTransaction", () => {
       amount: mockAmount,
       fees: mockFees,
       properties: {
-        amountRecordCommitment: mockPrivateTransaction.properties.amountRecordCommitment,
+        amountRecordCommitments: mockPrivateTransaction.properties.amountRecordCommitments,
         feeRecordCommitment: null,
       },
     });
@@ -196,7 +196,7 @@ describe("prepareTransaction", () => {
       ...mockTransaction,
       mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
       properties: {
-        amountRecordCommitment: mockUnspentRecord1.commitment,
+        amountRecordCommitments: [mockUnspentRecord1.commitment],
         feeRecordCommitment: null,
       },
     };
@@ -213,7 +213,7 @@ describe("prepareTransaction", () => {
       amount: mockAmount,
       fees: mockFees,
       properties: {
-        amountRecordCommitment: mockPrivateTransaction.properties.amountRecordCommitment,
+        amountRecordCommitments: mockPrivateTransaction.properties.amountRecordCommitments,
         feeRecordCommitment: null,
       },
     });

--- a/libs/coin-modules/coin-aleo/src/bridge/prepareTransaction.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/prepareTransaction.ts
@@ -22,11 +22,11 @@ export const prepareTransaction: AccountBridge<
   if (
     isPrivateTransaction(transaction) &&
     !config.isFeeSponsored &&
-    transaction.properties.amountRecordCommitment
+    transaction.properties.amountRecordCommitments.length > 0
   ) {
     const feeRecord = findBestRecordForFee({
       unspentRecords: account.aleoResources?.unspentPrivateRecords ?? [],
-      selectedAmountRecordCommitment: transaction.properties.amountRecordCommitment,
+      selectedAmountRecordCommitments: transaction.properties.amountRecordCommitments,
       targetFee: estimatedFees,
     });
     const nextFeeRecordCommitment =
@@ -37,7 +37,6 @@ export const prepareTransaction: AccountBridge<
       fees: estimatedFees,
       properties: {
         ...transaction.properties,
-        amountRecordCommitment: transaction.properties.amountRecordCommitment,
         ...(nextFeeRecordCommitment && { feeRecordCommitment: nextFeeRecordCommitment }),
       },
     });

--- a/libs/coin-modules/coin-aleo/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/signOperation.test.ts
@@ -205,7 +205,7 @@ describe("buildSignOperation", () => {
     const privateTransaction = getMockedTransaction({
       mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
       properties: {
-        amountRecordCommitment: mockUnspentRecord1.commitment,
+        amountRecordCommitments: [mockUnspentRecord1.commitment],
         feeRecordCommitment: mockUnspentRecord2.commitment,
       },
     });
@@ -230,7 +230,7 @@ describe("buildSignOperation", () => {
     const privateSponsoredTransaction = getMockedTransaction({
       mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
       properties: {
-        amountRecordCommitment: mockUnspentRecord1.commitment,
+        amountRecordCommitments: [mockUnspentRecord1.commitment],
         feeRecordCommitment: mockUnspentRecord2.commitment,
       },
     });

--- a/libs/coin-modules/coin-aleo/src/bridge/transaction.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/transaction.test.ts
@@ -18,11 +18,11 @@ describe("transaction", () => {
     fees: mockedTransaction.fees.toString(),
   });
   const fullPrivateProperties = {
-    amountRecordCommitment: "abc123",
+    amountRecordCommitments: ["abc123"],
     feeRecordCommitment: "def456",
   };
   const emptyPrivateProperties = {
-    amountRecordCommitment: null,
+    amountRecordCommitments: [],
     feeRecordCommitment: null,
   };
 

--- a/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
@@ -501,15 +501,15 @@ describe("calculateAmount", () => {
     });
   });
 
-  it("should use the full amount record for private transactions with useAllAmount", () => {
+  it("should sum multiple amount records for private transactions with useAllAmount", () => {
     const estimatedFees = new BigNumber(5000);
     const mockTransaction = getMockedTransaction({
       amount: new BigNumber(0),
       useAllAmount: true,
       mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
       properties: {
-        amountRecordCommitment: mockUnspentRecord1.commitment,
-        feeRecordCommitment: mockUnspentRecord2.commitment,
+        amountRecordCommitments: [mockUnspentRecord1.commitment, mockUnspentRecord2.commitment],
+        feeRecordCommitment: null,
       },
     });
     const mockAccount = getMockedAccount({
@@ -526,9 +526,13 @@ describe("calculateAmount", () => {
       estimatedFees,
     });
 
+    const expectedAmount = new BigNumber(mockUnspentRecord1.microcredits).plus(
+      mockUnspentRecord2.microcredits,
+    );
+
     expect(result).toMatchObject({
-      amount: new BigNumber(mockUnspentRecord1.microcredits),
-      totalSpent: new BigNumber(mockUnspentRecord1.microcredits).plus(estimatedFees),
+      amount: expectedAmount,
+      totalSpent: expectedAmount.plus(estimatedFees),
     });
   });
 
@@ -539,7 +543,7 @@ describe("calculateAmount", () => {
       useAllAmount: true,
       mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
       properties: {
-        amountRecordCommitment: null,
+        amountRecordCommitments: [],
         feeRecordCommitment: mockUnspentRecord2.commitment,
       },
     });
@@ -1153,7 +1157,7 @@ describe("createTransactionIntent", () => {
     const transaction = getMockedTransaction({
       mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
       properties: {
-        amountRecordCommitment: mockUnspentRecord1.commitment,
+        amountRecordCommitments: [mockUnspentRecord1.commitment],
         feeRecordCommitment: null,
       },
     });
@@ -1169,11 +1173,11 @@ describe("createTransactionIntent", () => {
     });
   });
 
-  it("should throw when amountRecordCommitment is null for a private transaction", () => {
+  it("should throw when amountRecordCommitments is empty for a private transaction", () => {
     const transaction = getMockedTransaction({
       mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
       properties: {
-        amountRecordCommitment: null,
+        amountRecordCommitments: [],
         feeRecordCommitment: null,
       },
     });
@@ -1183,11 +1187,11 @@ describe("createTransactionIntent", () => {
     );
   });
 
-  it("should throw when amountRecordCommitment does not match any unspent record", () => {
+  it("should throw when amountRecordCommitments entry does not match any unspent record", () => {
     const transaction = getMockedTransaction({
       mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
       properties: {
-        amountRecordCommitment: "non-existent-commitment",
+        amountRecordCommitments: ["non-existent-commitment"],
         feeRecordCommitment: null,
       },
     });
@@ -1243,7 +1247,7 @@ describe("createFeeTransactionIntent", () => {
     const transaction = getMockedTransaction({
       mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
       properties: {
-        amountRecordCommitment: null,
+        amountRecordCommitments: [],
         feeRecordCommitment: mockUnspentRecord2.commitment,
       },
     });
@@ -1279,7 +1283,7 @@ describe("createFeeTransactionIntent", () => {
     const transaction = getMockedTransaction({
       mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
       properties: {
-        amountRecordCommitment: null,
+        amountRecordCommitments: [],
         feeRecordCommitment: null,
       },
     });
@@ -1300,7 +1304,7 @@ describe("createFeeTransactionIntent", () => {
     const transaction = getMockedTransaction({
       mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
       properties: {
-        amountRecordCommitment: null,
+        amountRecordCommitments: [],
         feeRecordCommitment: null,
       },
     });
@@ -1450,7 +1454,7 @@ describe("findBestRecordForFee", () => {
     const result = findBestRecordForFee({
       unspentRecords: [mockUnspentRecord1, mockUnspentRecord2],
       targetFee,
-      selectedAmountRecordCommitment: null,
+      selectedAmountRecordCommitments: [],
     });
     // mockUnspentRecord2 (600000) is smaller than mockUnspentRecord1 (800000), both cover 500000
     expect(result).toBe(mockUnspentRecord2);
@@ -1461,7 +1465,7 @@ describe("findBestRecordForFee", () => {
     const result = findBestRecordForFee({
       unspentRecords: [mockUnspentRecord1, mockUnspentRecord2],
       targetFee,
-      selectedAmountRecordCommitment: mockUnspentRecord2.commitment,
+      selectedAmountRecordCommitments: [mockUnspentRecord2.commitment],
     });
     // mockUnspentRecord2 is excluded; only mockUnspentRecord1 (800000) remains
     expect(result).toBe(mockUnspentRecord1);
@@ -1472,7 +1476,7 @@ describe("findBestRecordForFee", () => {
     const result = findBestRecordForFee({
       unspentRecords: [mockUnspentRecord1, mockUnspentRecord2],
       targetFee,
-      selectedAmountRecordCommitment: null,
+      selectedAmountRecordCommitments: [],
     });
     expect(result).toBeNull();
   });
@@ -1481,7 +1485,7 @@ describe("findBestRecordForFee", () => {
     const result = findBestRecordForFee({
       unspentRecords: [],
       targetFee: new BigNumber(1000),
-      selectedAmountRecordCommitment: null,
+      selectedAmountRecordCommitments: [],
     });
     expect(result).toBeNull();
   });
@@ -1491,7 +1495,7 @@ describe("findBestRecordForFee", () => {
     const result = findBestRecordForFee({
       unspentRecords: [mockUnspentRecord1],
       targetFee,
-      selectedAmountRecordCommitment: null,
+      selectedAmountRecordCommitments: [],
     });
     expect(result).toBe(mockUnspentRecord1);
   });

--- a/libs/coin-modules/coin-aleo/src/logic/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.ts
@@ -252,10 +252,10 @@ function getAmountToSpend({
   }
 
   if (isPrivateTransaction(transaction)) {
-    const commitment = transaction.properties.amountRecordCommitment;
-    const amountRecord = commitment ? getRecordByCommitment({ account, commitment }) : null;
-
-    return new BigNumber(amountRecord?.microcredits ?? "0");
+    return transaction.properties.amountRecordCommitments.reduce((sum, commitment) => {
+      const record = getRecordByCommitment({ account, commitment });
+      return record ? sum.plus(record.microcredits) : sum;
+    }, new BigNumber(0));
   }
 
   const transparentBalance = account.aleoResources?.transparentBalance ?? new BigNumber(0);
@@ -328,15 +328,15 @@ export function isPrivateTransaction(transaction: Transaction): transaction is T
 export function findBestRecordForFee({
   unspentRecords,
   targetFee,
-  selectedAmountRecordCommitment,
+  selectedAmountRecordCommitments,
 }: {
   unspentRecords: AleoUnspentRecord[];
   targetFee: BigNumber;
-  selectedAmountRecordCommitment: string | null;
+  selectedAmountRecordCommitments: string[];
 }): AleoUnspentRecord | null {
   const recordsSufficientForFee = unspentRecords.filter(
     r =>
-      r.commitment !== selectedAmountRecordCommitment &&
+      !selectedAmountRecordCommitments.includes(r.commitment) &&
       new BigNumber(r.microcredits).gte(targetFee),
   );
 
@@ -510,7 +510,7 @@ export function createTransactionIntent({
   } as const;
 
   if (isPrivateTx) {
-    const commitment = transaction.properties.amountRecordCommitment;
+    const commitment = transaction.properties.amountRecordCommitments[0];
     invariant(commitment, "aleo: missing amount record commitment");
     const amountRecord = getRecordByCommitment({ account, commitment });
     invariant(amountRecord, `aleo: no amount record found for commitment ${commitment}`);

--- a/libs/coin-modules/coin-aleo/src/types/bridge.ts
+++ b/libs/coin-modules/coin-aleo/src/types/bridge.ts
@@ -23,7 +23,7 @@ export type Transaction = TransactionCommon & {
     | {
         mode: typeof TRANSACTION_TYPE.TRANSFER_PRIVATE;
         properties: {
-          amountRecordCommitment: string | null;
+          amountRecordCommitments: string[];
           feeRecordCommitment: string | null;
         };
       }
@@ -34,7 +34,7 @@ export type Transaction = TransactionCommon & {
     | {
         mode: typeof TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC;
         properties: {
-          amountRecordCommitment: string | null;
+          amountRecordCommitments: string[];
           feeRecordCommitment: string | null;
         };
       }
@@ -51,7 +51,7 @@ export type TransactionRaw = TransactionCommonRaw & {
     | {
         mode: typeof TRANSACTION_TYPE.TRANSFER_PRIVATE;
         properties: {
-          amountRecordCommitment: string | null;
+          amountRecordCommitments: string[];
           feeRecordCommitment: string | null;
         };
       }
@@ -62,7 +62,7 @@ export type TransactionRaw = TransactionCommonRaw & {
     | {
         mode: typeof TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC;
         properties: {
-          amountRecordCommitment: string | null;
+          amountRecordCommitments: string[];
           feeRecordCommitment: string | null;
         };
       }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Changed `amountRecordCommitment` to `amountRecordCommitments` (array-based) in Aleo private transaction shape

### 📝 Description

This PR migrates Aleo private transaction field from `amountRecordCommitment` to `amountRecordCommitments` (array-based), while preserving existing transaction flow and validation behavior.

### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-29571

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
