### PR TITLE
[LWDM] feat(LIVE-29571): add Aleo private record-picking support in prepareTransaction

### DIFF
--- a/.changeset/twenty-papayas-talk.md
+++ b/.changeset/twenty-papayas-talk.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+This adds Aleo private record-picking support in `prepareTransaction` with `recordPickingStrategy`, where `manual` keeps the selected `amountRecordCommitment`, `auto` derives it from available private records based on amount (including `useAllAmount`), and both paths are covered by unit tests.

--- a/libs/coin-modules/coin-aleo/src/bridge/estimateMaxSpendable.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/estimateMaxSpendable.test.ts
@@ -92,7 +92,7 @@ describe("estimateMaxSpendable", () => {
     expect(mockCreateTransaction).toHaveBeenCalledWith(mockAccount);
   });
 
-  it("should return zero for private tx when amountRecordCommitment is missing", async () => {
+  it("should return zero for private tx when amountRecordCommitment is empty", async () => {
     mockPrepareTransaction.mockResolvedValue({
       ...mockPreparedTransaction,
       amount: new BigNumber(0),
@@ -119,7 +119,7 @@ describe("estimateMaxSpendable", () => {
     expect(result).toEqual(new BigNumber(0));
   });
 
-  it("should return microcredits value for private tx when amountRecordCommitment exists", async () => {
+  it("should return microcredits value for private tx when amountRecordCommitment has an entry", async () => {
     const commitment = "record-1-commitment";
     const privateRecordAmount = "12345";
     const aleoResources = mockAccount.aleoResources!;
@@ -162,7 +162,7 @@ describe("estimateMaxSpendable", () => {
     expect(result).toEqual(new BigNumber(privateRecordAmount));
   });
 
-  it("should return zero for private tx when amountRecordCommitment exists but no record matches", async () => {
+  it("should return zero for private tx when amountRecordCommitment has an entry but no record matches", async () => {
     const commitment = "record-1-commitment";
     const aleoResources = mockAccount.aleoResources!;
     const accountWithoutMatchingRecord = getMockedAccount({

--- a/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.ts
@@ -39,7 +39,7 @@ function getValidRecord({
   commitment,
 }: {
   account: AleoAccount;
-  commitment: TransactionPrivate["properties"]["amountRecordCommitment"];
+  commitment: string | null | undefined;
 }) {
   if (!commitment) {
     return null;

--- a/libs/coin-modules/coin-aleo/src/bridge/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/prepareTransaction.test.ts
@@ -218,4 +218,126 @@ describe("prepareTransaction", () => {
       },
     });
   });
+
+  it("should keep selected amount record when recordPickingStrategy is manual", async () => {
+    const mockPrivateTransaction: Transaction = {
+      ...mockTransaction,
+      mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
+      properties: {
+        amountRecordCommitment: mockUnspentRecord1.commitment,
+        feeRecordCommitment: null,
+      },
+    };
+
+    const accountWithPrivateRecords = getMockedAccount({
+      aleoResources: {
+        transparentBalance: mockAccount.aleoResources?.transparentBalance ?? new BigNumber(0),
+        provableApi: mockAccount.aleoResources?.provableApi ?? null,
+        privateBalance: mockAccount.aleoResources?.privateBalance ?? null,
+        unspentPrivateRecords: [mockUnspentRecord1, mockUnspentRecord2],
+        lastPrivateSyncDate: mockAccount.aleoResources?.lastPrivateSyncDate ?? null,
+      },
+    });
+
+    mockAleoConfig.getCoinConfig.mockReturnValue({
+      ...mockConfig,
+      recordPickingStrategy: "manual",
+      isFeeSponsored: true,
+    });
+
+    const result = await prepareTransaction(accountWithPrivateRecords, mockPrivateTransaction);
+
+    expect(mockCalculateAmount).toHaveBeenCalledWith({
+      transaction: mockPrivateTransaction,
+      account: accountWithPrivateRecords,
+      estimatedFees: mockFees,
+    });
+    expect(result).toMatchObject({
+      properties: {
+        amountRecordCommitment: mockUnspentRecord1.commitment,
+      },
+    });
+  });
+
+  it("should auto-select the smallest sufficient amount record when recordPickingStrategy is auto", async () => {
+    const mockPrivateTransaction: Transaction = {
+      ...mockTransaction,
+      mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
+      amount: new BigNumber(550000),
+      properties: {
+        amountRecordCommitment: null,
+        feeRecordCommitment: null,
+      },
+    };
+
+    const accountWithPrivateRecords = getMockedAccount({
+      aleoResources: {
+        transparentBalance: mockAccount.aleoResources?.transparentBalance ?? new BigNumber(0),
+        provableApi: mockAccount.aleoResources?.provableApi ?? null,
+        privateBalance: mockAccount.aleoResources?.privateBalance ?? null,
+        unspentPrivateRecords: [mockUnspentRecord1, mockUnspentRecord2],
+        lastPrivateSyncDate: mockAccount.aleoResources?.lastPrivateSyncDate ?? null,
+      },
+    });
+
+    mockAleoConfig.getCoinConfig.mockReturnValue({
+      ...mockConfig,
+      recordPickingStrategy: "auto",
+      isFeeSponsored: true,
+    });
+
+    const result = await prepareTransaction(accountWithPrivateRecords, mockPrivateTransaction);
+
+    expect(mockCalculateAmount).toHaveBeenCalledWith({
+      transaction: expect.objectContaining({
+        mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
+        properties: expect.objectContaining({
+          amountRecordCommitment: mockUnspentRecord2.commitment,
+        }),
+      }),
+      account: accountWithPrivateRecords,
+      estimatedFees: mockFees,
+    });
+    expect(result).toMatchObject({
+      properties: {
+        amountRecordCommitment: mockUnspentRecord2.commitment,
+      },
+    });
+  });
+
+  it("should keep the first selected amount record when no single record can fully cover amount", async () => {
+    const mockPrivateTransaction: Transaction = {
+      ...mockTransaction,
+      mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
+      amount: new BigNumber(900000),
+      properties: {
+        amountRecordCommitment: null,
+        feeRecordCommitment: null,
+      },
+    };
+
+    const accountWithPrivateRecords = getMockedAccount({
+      aleoResources: {
+        transparentBalance: mockAccount.aleoResources?.transparentBalance ?? new BigNumber(0),
+        provableApi: mockAccount.aleoResources?.provableApi ?? null,
+        privateBalance: mockAccount.aleoResources?.privateBalance ?? null,
+        unspentPrivateRecords: [mockUnspentRecord1, mockUnspentRecord2],
+        lastPrivateSyncDate: mockAccount.aleoResources?.lastPrivateSyncDate ?? null,
+      },
+    });
+
+    mockAleoConfig.getCoinConfig.mockReturnValue({
+      ...mockConfig,
+      recordPickingStrategy: "auto",
+      isFeeSponsored: true,
+    });
+
+    const result = await prepareTransaction(accountWithPrivateRecords, mockPrivateTransaction);
+
+    expect(result).toMatchObject({
+      properties: {
+        amountRecordCommitment: mockUnspentRecord1.commitment,
+      },
+    });
+  });
 });

--- a/libs/coin-modules/coin-aleo/src/bridge/prepareTransaction.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/prepareTransaction.ts
@@ -3,8 +3,33 @@ import type { AccountBridge } from "@ledgerhq/types-live";
 import { updateTransaction } from "@ledgerhq/ledger-wallet-framework/bridge/jsHelpers";
 import aleoCoinConfig from "../config";
 import { estimateFees } from "../logic";
-import { calculateAmount, findBestRecordForFee, isPrivateTransaction } from "../logic/utils";
-import type { AleoAccount, Transaction as AleoTransaction } from "../types";
+import {
+  calculateAmount,
+  findBestRecordForFee,
+  isPrivateTransaction,
+  selectPrivateRecordsForAmount,
+} from "../logic/utils";
+import type { AleoAccount, AleoUnspentRecord, Transaction as AleoTransaction } from "../types";
+
+function resolveAmountRecord(
+  transaction: AleoTransaction,
+  unspentPrivateRecords: AleoUnspentRecord[],
+  strategy: "manual" | "auto",
+): AleoTransaction {
+  if (!isPrivateTransaction(transaction) || strategy !== "auto") {
+    return transaction;
+  }
+  const selectedRecords = selectPrivateRecordsForAmount({
+    unspentRecords: unspentPrivateRecords,
+    targetAmount: transaction.useAllAmount ? null : transaction.amount,
+  });
+  return updateTransaction(transaction, {
+    properties: {
+      ...transaction.properties,
+      amountRecordCommitment: selectedRecords[0]?.commitment ?? null,
+    },
+  });
+}
 
 export const prepareTransaction: AccountBridge<
   AleoTransaction,
@@ -17,33 +42,44 @@ export const prepareTransaction: AccountBridge<
   });
 
   const estimatedFees = new BigNumber(feeEstimation.value.toString());
-  const calculatedAmount = calculateAmount({ transaction, account, estimatedFees });
+  const unspentPrivateRecords = account.aleoResources?.unspentPrivateRecords ?? [];
+
+  const transactionWithAmountRecord = resolveAmountRecord(
+    transaction,
+    unspentPrivateRecords,
+    config.recordPickingStrategy,
+  );
+
+  const calculatedAmount = calculateAmount({
+    transaction: transactionWithAmountRecord,
+    account,
+    estimatedFees,
+  });
 
   if (
-    isPrivateTransaction(transaction) &&
+    isPrivateTransaction(transactionWithAmountRecord) &&
     !config.isFeeSponsored &&
-    transaction.properties.amountRecordCommitment
+    transactionWithAmountRecord.properties.amountRecordCommitment
   ) {
-    const feeRecord = findBestRecordForFee({
-      unspentRecords: account.aleoResources?.unspentPrivateRecords ?? [],
-      selectedAmountRecordCommitment: transaction.properties.amountRecordCommitment,
-      targetFee: estimatedFees,
-    });
     const nextFeeRecordCommitment =
-      feeRecord?.commitment ?? transaction.properties.feeRecordCommitment;
+      findBestRecordForFee({
+        unspentRecords: unspentPrivateRecords,
+        selectedAmountRecordCommitment:
+          transactionWithAmountRecord.properties.amountRecordCommitment,
+        targetFee: estimatedFees,
+      })?.commitment ?? transactionWithAmountRecord.properties.feeRecordCommitment;
 
-    return updateTransaction(transaction, {
+    return updateTransaction(transactionWithAmountRecord, {
       amount: calculatedAmount.amount,
       fees: estimatedFees,
       properties: {
-        ...transaction.properties,
-        amountRecordCommitment: transaction.properties.amountRecordCommitment,
+        ...transactionWithAmountRecord.properties,
         ...(nextFeeRecordCommitment && { feeRecordCommitment: nextFeeRecordCommitment }),
       },
     });
   }
 
-  return updateTransaction(transaction, {
+  return updateTransaction(transactionWithAmountRecord, {
     amount: calculatedAmount.amount,
     fees: estimatedFees,
   });

--- a/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
@@ -1169,7 +1169,7 @@ describe("createTransactionIntent", () => {
     });
   });
 
-  it("should throw when amountRecordCommitment is null for a private transaction", () => {
+  it("should throw when amountRecordCommitment is empty for a private transaction", () => {
     const transaction = getMockedTransaction({
       mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
       properties: {
@@ -1183,7 +1183,7 @@ describe("createTransactionIntent", () => {
     );
   });
 
-  it("should throw when amountRecordCommitment does not match any unspent record", () => {
+  it("should throw when amountRecordCommitment entry does not match any unspent record", () => {
     const transaction = getMockedTransaction({
       mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
       properties: {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - This adds Aleo private record-picking support in prepareTransaction with recordPickingStrategy, where manual keeps the selected amountRecordCommitment, auto derives it from available private records based on amount (including useAllAmount), and both paths are covered by unit tests.

### 📝 Description

This PR adds Aleo private record-picking support in `prepareTransaction` with `recordPickingStrategy`, where `manual` keeps the selected `amountRecordCommitment`, `auto` derives it from available private records based on amount (including `useAllAmount`), and both paths are covered by unit tests.

### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-29571

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
