### PR TITLE
[LWD] feat(lwd): exclude currency ids to use the new send flow

### DIFF
--- a/.changeset/quick-hotels-double.md
+++ b/.changeset/quick-hotels-double.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+feat(lwd): exclude currency ids to use the new send flow

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useNewSendFlowFeature.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useNewSendFlowFeature.test.ts
@@ -1,0 +1,47 @@
+import { isCurrencyAllowedForNewSendFlow } from "../useNewSendFlowFeature";
+
+describe("isCurrencyAllowedForNewSendFlow", () => {
+  const allowedFamilies = ["bitcoin", "evm"];
+
+  it("should return true when family is allowed and currency is not excluded", () => {
+    expect(
+      isCurrencyAllowedForNewSendFlow({
+        family: "bitcoin",
+        currencyId: "bitcoin",
+        allowedFamilies,
+        excludedCurrencyIds: ["zcash"],
+      }),
+    ).toBe(true);
+  });
+
+  it("should return false when currency is excluded even if family is allowed", () => {
+    expect(
+      isCurrencyAllowedForNewSendFlow({
+        family: "bitcoin",
+        currencyId: "zcash",
+        allowedFamilies,
+        excludedCurrencyIds: ["zcash"],
+      }),
+    ).toBe(false);
+  });
+
+  it("should return false when family is not allowed", () => {
+    expect(
+      isCurrencyAllowedForNewSendFlow({
+        family: "solana",
+        currencyId: "solana",
+        allowedFamilies,
+        excludedCurrencyIds: [],
+      }),
+    ).toBe(false);
+  });
+
+  it("should return true when family is missing", () => {
+    expect(
+      isCurrencyAllowedForNewSendFlow({
+        allowedFamilies,
+        excludedCurrencyIds: [],
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useNewSendFlowFeature.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useNewSendFlowFeature.ts
@@ -4,20 +4,43 @@ import type { Account, AccountLike } from "@ledgerhq/types-live";
 
 /**
  * Centralizes newSendFlow feature flag logic
- * FF format: { enabled: true, params: { families: ["bitcoin", "solana"] } }
+ * FF format: { enabled: true, params: { families: ["bitcoin"], excludedCurrencyIds: ["zcash"] } }
  */
+type NewSendFlowCurrencyFilter = {
+  family?: string;
+  currencyId?: string;
+  allowedFamilies: readonly string[];
+  excludedCurrencyIds: readonly string[];
+};
+
+export function isCurrencyAllowedForNewSendFlow({
+  family,
+  currencyId,
+  allowedFamilies,
+  excludedCurrencyIds,
+}: NewSendFlowCurrencyFilter): boolean {
+  if (currencyId && excludedCurrencyIds.includes(currencyId)) return false;
+  if (!family) return true; // Opening flow without account - use new flow if feature flag is enabled
+  return allowedFamilies.includes(family);
+}
+
 export function useNewSendFlowFeature() {
   const feature = useFeature("newSendFlow");
 
-  const allowedFamilies = feature?.params?.families ?? [];
-  const isValidConfig =
-    feature?.enabled && Array.isArray(allowedFamilies) && allowedFamilies.length > 0;
+  const families = feature?.params?.families;
+  const excludedCurrencies = feature?.params?.excludedCurrencyIds;
+  const allowedFamilies = Array.isArray(families) ? families : [];
+  const excludedCurrencyIds = Array.isArray(excludedCurrencies) ? excludedCurrencies : [];
+  const isValidConfig = Boolean(feature?.enabled && allowedFamilies.length > 0);
 
-  const isEnabledForFamily = (family?: string): boolean => {
-    if (!isValidConfig) return false;
-    if (!family) return true; // Opening flow without account - use new flow if feature flag is enabled
-    return allowedFamilies.includes(family);
-  };
+  const isEnabledForFamily = (family?: string, currencyId?: string): boolean =>
+    isValidConfig &&
+    isCurrencyAllowedForNewSendFlow({
+      family,
+      currencyId,
+      allowedFamilies,
+      excludedCurrencyIds,
+    });
 
   const getFamilyFromAccount = (
     account?: AccountLike,
@@ -26,11 +49,20 @@ export function useNewSendFlowFeature() {
     return account ? getMainAccount(account, parentAccount ?? null).currency.family : undefined;
   };
 
+  const getCurrencyIdFromAccount = (
+    account?: AccountLike,
+    parentAccount?: Account | null,
+  ): string | undefined => {
+    return account ? getMainAccount(account, parentAccount ?? null).currency.id : undefined;
+  };
+
   return {
     feature,
     isEnabled: feature?.enabled ?? false,
     isEnabledForFamily,
     getFamilyFromAccount,
+    getCurrencyIdFromAccount,
     allowedFamilies,
+    excludedCurrencyIds,
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useOpenSendFlow.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useOpenSendFlow.ts
@@ -29,7 +29,8 @@ type WorkflowParams = {
 export function useOpenSendFlow() {
   const dispatch = useDispatch();
   const hasNoAccounts = useSelector(state => accountsSelector(state).length === 0);
-  const { isEnabledForFamily, getFamilyFromAccount } = useNewSendFlowFeature();
+  const { isEnabledForFamily, getFamilyFromAccount, getCurrencyIdFromAccount } =
+    useNewSendFlowFeature();
 
   const openSendFlow = useCallback(
     (params?: WorkflowParams) => {
@@ -74,7 +75,11 @@ export function useOpenSendFlow() {
         }
 
         const family = getFamilyFromAccount(nextParams.account, nextParams.parentAccount ?? null);
-        const shouldUseNewFlow = isEnabledForFamily(family);
+        const currencyId = getCurrencyIdFromAccount(
+          nextParams.account,
+          nextParams.parentAccount ?? null,
+        );
+        const shouldUseNewFlow = isEnabledForFamily(family, currencyId);
 
         if (shouldUseNewFlow) {
           let normalizedAmount: string | undefined;
@@ -111,7 +116,7 @@ export function useOpenSendFlow() {
 
       openSendFlowImpl(params);
     },
-    [hasNoAccounts, dispatch, isEnabledForFamily, getFamilyFromAccount],
+    [hasNoAccounts, dispatch, isEnabledForFamily, getFamilyFromAccount, getCurrencyIdFromAccount],
   );
 
   return openSendFlow;

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/index.tsx
@@ -32,7 +32,8 @@ const SendModal = ({ stepId: initialStepId, onClose }: Props) => {
   const isModalLocked = MODAL_LOCKED[stepId];
   const dispatch = useDispatch();
 
-  const { isEnabledForFamily, getFamilyFromAccount } = useNewSendFlowFeature();
+  const { isEnabledForFamily, getFamilyFromAccount, getCurrencyIdFromAccount } =
+    useNewSendFlowFeature();
   const isOpened = useSelector((state: State) => isModalOpened(state, "MODAL_SEND"));
   const modalData = useSelector((state: State) => getModalData(state, "MODAL_SEND"));
 
@@ -40,7 +41,11 @@ const SendModal = ({ stepId: initialStepId, onClose }: Props) => {
     modalData?.account ?? undefined,
     modalData?.parentAccount ?? null,
   );
-  const shouldRedirectToNewFlow = isEnabledForFamily(family);
+  const currencyId = getCurrencyIdFromAccount(
+    modalData?.account ?? undefined,
+    modalData?.parentAccount ?? null,
+  );
+  const shouldRedirectToNewFlow = isEnabledForFamily(family, currencyId);
 
   const handleModalClose = useCallback(() => {
     dispatch(

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/GenericStepConnectDevice.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/GenericStepConnectDevice.tsx
@@ -62,7 +62,18 @@ export default function StepConnectDevice({
   const mevProtected = useSelector(mevProtectionSelector);
   const dispatch = useDispatch();
   const newSendFlowFeature = useNewSendFlowFeature();
-  const newSendFlow = newSendFlowFeature.isEnabledForFamily(parentAccount?.currency.family);
+  const newSendFlowFamily = newSendFlowFeature.getFamilyFromAccount(
+    account ?? undefined,
+    parentAccount ?? null,
+  );
+  const newSendFlowCurrencyId = newSendFlowFeature.getCurrencyIdFromAccount(
+    account ?? undefined,
+    parentAccount ?? null,
+  );
+  const newSendFlow = newSendFlowFeature.isEnabledForFamily(
+    newSendFlowFamily,
+    newSendFlowCurrencyId,
+  );
   const broadcastConfig = useMemo(
     () => ({
       mevProtected,

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepRecipient.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepRecipient.tsx
@@ -63,7 +63,7 @@ export const DefaultStepRecipient = ({
   const accountFilter = useMemo(
     () => (acc: Account) => {
       const family = acc.currency.family;
-      return !isEnabledForFamily(family);
+      return !isEnabledForFamily(family, acc.currency.id);
     },
     [isEnabledForFamily],
   );


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

We want to have some families to use the new send flow, but to block it on some specific currencies (eg bitcoin has the new send flow but not zcash)
This PR fixes this by using the `excludedCurrencyIds` FF param on LWD

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **[JIRA or GitHub link](https://ledgerhq.atlassian.net/browse/LIVE-30185)**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
