### PR TITLE
refactor(wallet-cli): prepare getCurrencyBridge call site for async

### DIFF
--- a/apps/wallet-cli/src/wallet/compatibility/bridge.ts
+++ b/apps/wallet-cli/src/wallet/compatibility/bridge.ts
@@ -41,9 +41,10 @@ export class BridgeAdapter {
       let sub: Subscription | null = null;
       let torn = false;
       BridgeAdapter.cache.prepareCurrency(currency).then(
-        () => {
+        async () => {
           if (torn) return;
-          sub = getCurrencyBridge(currency)
+          const currencyBridge = await getCurrencyBridge(currency);
+          sub = currencyBridge
             .scanAccounts({ currency, deviceId, syncConfig: BridgeAdapter.SYNC_CONFIG })
             .pipe(
               filter((e): e is { type: "discovered"; account: Account } => e.type === "discovered"),


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** No behaviour change — `await` on a sync value is a no-op today.
- [ ] **Impact of the changes:** Pure forward-compatibility refactor, no user-facing change.

### 📝 Description

Prepares the `wallet-cli` `BridgeAdapter.discoverAccounts` for async `getCurrencyBridge`:

```diff
- BridgeAdapter.cache.prepareCurrency(currency).then(() => {
-   sub = getCurrencyBridge(currency).scanAccounts(...).subscribe(subscriber);
+ BridgeAdapter.cache.prepareCurrency(currency).then(async () => {
+   const currencyBridge = await getCurrencyBridge(currency);
+   sub = currencyBridge.scanAccounts(...).subscribe(subscriber);
  });
```

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29176](https://ledgerhq.atlassian.net/browse/LIVE-29176) / #16733
- **ADR link (if any)**: N/A


[LIVE-29176]: https://ledgerhq.atlassian.net/browse/LIVE-29176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ