### PR TITLE
[LWM] refactor(mobile): prepare bridge call sites for async bridges

### DIFF
--- a/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
+++ b/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
@@ -93,9 +93,9 @@ export const useSignWithDevice = ({
   const [signed, setSigned] = useState(false);
   const subscription = useRef<null | Subscription>(null);
   const mevProtected = useSelector(mevProtectionSelector);
-  const signWithDevice = useCallback(() => {
+  const signWithDevice = useCallback(async () => {
     const { deviceId, transaction } = route.params || {};
-    const bridge = getAccountBridge(account, parentAccount);
+    const bridge = await getAccountBridge(account, parentAccount);
     const mainAccount = getMainAccount(account, parentAccount);
 
     navigation.setOptions({
@@ -231,7 +231,7 @@ export const broadcastSignedTx = async (
 ): Promise<Operation> => {
   invariant(account, "account not present");
   const mainAccount = getMainAccount(account, parentAccount);
-  const bridge = getAccountBridge(account, parentAccount);
+  const bridge = await getAccountBridge(account, parentAccount);
 
   if (getEnv("DISABLE_TRANSACTION_BROADCAST")) {
     return Promise.resolve(signedOperation.operation);

--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
@@ -77,9 +77,9 @@ export default function useScanDeviceAccountsViewModel({
     () => (newAccountSchemes && newAccountSchemes.length > 0 ? newAccountSchemes[0] : undefined),
     [newAccountSchemes],
   );
-  const startSubscription = useCallback(() => {
+  const startSubscription = useCallback(async () => {
     const cryptoCurrency = isTokenCurrency(currency) ? currency.parentCurrency : currency;
-    const bridge = getCurrencyBridge(cryptoCurrency);
+    const bridge = await getCurrencyBridge(cryptoCurrency);
     const syncConfig = {
       paginationConfig: {
         operations: 0,

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useFeePresetFiatValues.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useFeePresetFiatValues.ts
@@ -1,6 +1,6 @@
 import { useMemo, useRef, useState } from "react";
 import { BigNumber } from "bignumber.js";
-import type { Account, AccountLike } from "@ledgerhq/types-live";
+import type { Account, AccountBridge, AccountLike } from "@ledgerhq/types-live";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import type { FeePresetOption } from "./useFeePresetOptions";
@@ -47,7 +47,7 @@ type Params = Readonly<{
 }>;
 
 async function estimateFiatValuesForPresets(params: {
-  bridge: ReturnType<typeof getAccountBridge>;
+  bridge: AccountBridge<Transaction>;
   mainAccount: Account;
   transaction: Transaction;
   presetIds: readonly string[];
@@ -178,9 +178,8 @@ export function useFeePresetFiatValues({
     requestIdRef.current += 1;
     const requestId = requestIdRef.current;
 
-    const bridge = getAccountBridge(account, parentAccount ?? undefined);
-
-    queueMicrotask(() => {
+    queueMicrotask(async () => {
+      const bridge = await getAccountBridge(account, parentAccount ?? undefined);
       estimateFiatValuesForPresets({
         bridge,
         mainAccount,

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/03b-VerifyAddress.tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/03b-VerifyAddress.tsx
@@ -104,7 +104,7 @@ export default function ReceiveVerifyAddress({ navigation, route }: Props) {
               map(() => ({})),
               rejectionOp(),
             )
-          : getAccountBridge(mainAccount).receive(mainAccount, {
+          : (await getAccountBridge(mainAccount)).receive(mainAccount, {
               deviceId: device.deviceId,
               verify: true,
             })


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Existing tests cover these call sites; mocks will need updating when async bridges land.
- [ ] **Impact of the changes:** No runtime change on `develop` — `getAccountBridge`/`getCurrencyBridge` are still sync. This is a forward-compatibility preparation.
  - Mobile send flow, broadcast, scan accounts, fee estimation, receive/verify remain functionally identical.

### 📝 Description

Backport of the mobile call-site changes from `ae59a2f` onto `develop`. Adds `await` at all 4 mobile call sites where `getAccountBridge` or `getCurrencyBridge` are called, so the code is ready when those functions become async (returning `Promise`).

Files changed:

- `screenTransactionHooks.ts` — `signWithDevice` callback and `broadcastSignedTx` function
- `useScanDeviceAccountsViewModel.ts` — `startSubscription` callback
- `useFeePresetFiatValues.ts` — `bridge` param type (`AccountBridge<Transaction>`) + bridge fetch moved inside `queueMicrotask(async () => { ... })`
- `03b-VerifyAddress.tsx` — `(await getAccountBridge(mainAccount)).receive(...)`

Consumer TLDR after async bridges are activated:

```diff
- const bridge = getAccountBridge(account, parentAccount);
+ const bridge = await getAccountBridge(account, parentAccount);
```

### ❓ Context

- **JIRA or GitHub link**: Related to `ae59a2f04ee21bbcc77719ab357d68a83089cfb7`
- **ADR link (if any)**: N/A