### PR TITLE
[LWD] refactor(desktop): prepare useScanAccounts for async getCurrencyBridge

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/ScanAccounts/useScanAccounts.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/ScanAccounts/useScanAccounts.ts
@@ -87,31 +87,38 @@ export function useScanAccounts({
   }, []);
 
   useEffect(() => {
-    const bridge = getCurrencyBridge(currency);
-    scanSubscriptionRef.current = concat(
-      from(prepareCurrency(currency)).pipe(RX.ignoreElements()),
-      bridge.scanAccounts({
-        currency,
-        deviceId,
-        syncConfig: {
-          paginationConfig: {
-            operations: 0,
+    let cancelled = false;
+    (async () => {
+      const bridge = await getCurrencyBridge(currency);
+      if (cancelled) return;
+      scanSubscriptionRef.current = concat(
+        from(prepareCurrency(currency)).pipe(RX.ignoreElements()),
+        bridge.scanAccounts({
+          currency,
+          deviceId,
+          syncConfig: {
+            paginationConfig: {
+              operations: 0,
+            },
+            blacklistedTokenIds: blacklistedTokenIds || [],
           },
-          blacklistedTokenIds: blacklistedTokenIds || [],
-        },
-      }),
-    )
-      .pipe(RX.scan((acc: Account[], { account }) => [...acc, account], []))
-      .subscribe({
-        next: accounts => {
-          setScannedAccounts(accounts);
-          setScanning(true);
-        },
-        error: setError,
-        complete: () => setScanning(false),
-      });
+        }),
+      )
+        .pipe(RX.scan((acc: Account[], { account }) => [...acc, account], []))
+        .subscribe({
+          next: (accounts: Account[]) => {
+            setScannedAccounts(accounts);
+            setScanning(true);
+          },
+          error: setError,
+          complete: () => setScanning(false),
+        });
+    })();
 
-    return () => stopSubscription(false);
+    return () => {
+      cancelled = true;
+      stopSubscription(false);
+    };
   }, [blacklistedTokenIds, currency, deviceId, stopSubscription]);
 
   useEffect(() => {


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** No dedicated unit test for this hook; the change is purely structural (async IIFE wrapping with no behavioural difference today).
- [ ] **Impact of the changes:** No runtime behaviour change on `develop` — `getCurrencyBridge` is still sync so `await` on a sync value is a no-op. Prepares the call site for when `getCurrencyBridge` becomes async.
  - QA focus: add-account scan flow still works as before.

### 📝 Description

Forward-compatibility backport for `useScanAccounts`: wraps the `useEffect` scan body in an async IIFE so the future async `getCurrencyBridge` can be awaited without restructuring React effect rules.

```ts
// Before
useEffect(() => {
  const bridge = getCurrencyBridge(currency);
  scanSubscriptionRef.current = concat(...).subscribe(...);
  return () => stopSubscription(false);
}, [...]);

// After
useEffect(() => {
  let cancelled = false;
  (async () => {
    const bridge = await getCurrencyBridge(currency);
    if (cancelled) return;
    scanSubscriptionRef.current = concat(...).subscribe(...);
  })();
  return () => { cancelled = true; stopSubscription(false); };
}, [...]);
```

`prepareCurrency` is kept because on `develop` the sync bridge does not handle currency preparation internally.

### ❓ Context

- **JIRA or GitHub link**: Backport preparation for `ae59a2f04ee21bbcc77719ab357d68a83089cfb7` (async coin-module loaders refactor).
- **ADR link (if any)**: N/A