### PR TITLE
[LWD] refactor(desktop): prepare bridge call sites for async getAccountBridge

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/steps/StepImport.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/steps/StepImport.tsx
@@ -119,14 +119,14 @@ class StepImport extends PureComponent<
     }
   };
 
-  startScanAccountsDevice() {
+  async startScanAccountsDevice() {
     this.unsub();
     try {
       const { currency, device, setScanStatus, setScannedAccounts, blacklistedTokenIds } =
         this.props;
       if (!currency || !device) throw new UnresponsiveDeviceError();
       const mainCurrency = currency.type === "TokenCurrency" ? currency.parentCurrency : currency;
-      const bridge = getCurrencyBridge(mainCurrency);
+      const bridge = await getCurrencyBridge(mainCurrency);
 
       // will be set to false if an existing account is found
       let onlyNewAccounts = true;

--- a/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveFunds.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveFunds.tsx
@@ -220,8 +220,9 @@ const StepReceiveFunds = (props: StepProps) => {
         if (!device) {
           throw new DisconnectedDevice();
         }
+        const bridge = await getAccountBridge(mainAccount);
         await firstValueFrom(
-          getAccountBridge(mainAccount).receive(mainAccount, {
+          bridge.receive(mainAccount, {
             deviceId: device.deviceId,
             verify: true,
           }),

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/Body.tsx
@@ -190,27 +190,29 @@ const Body = ({
   useEffect(() => {
     if (!transaction) return;
 
-    const bridge = getAccountBridge(account, parentAccount);
-    let updatedTransaction = transaction;
-    let hasChanges = false;
+    (async () => {
+      const bridge = await getAccountBridge(account, parentAccount);
+      let updatedTransaction = transaction;
+      let hasChanges = false;
 
-    if (maybeRecipient && !transaction.recipient) {
-      updatedTransaction = bridge.updateTransaction(updatedTransaction, {
-        recipient: maybeRecipient,
-      });
-      hasChanges = true;
-      onResetMaybeRecipient();
-    }
+      if (maybeRecipient && !transaction.recipient) {
+        updatedTransaction = bridge.updateTransaction(updatedTransaction, {
+          recipient: maybeRecipient,
+        });
+        hasChanges = true;
+        onResetMaybeRecipient();
+      }
 
-    if (maybeAmount && !maybeAmount.eq(transaction.amount || new BigNumber(0))) {
-      updatedTransaction = bridge.updateTransaction(updatedTransaction, { amount: maybeAmount });
-      hasChanges = true;
-      onResetMaybeAmount();
-    }
+      if (maybeAmount && !maybeAmount.eq(transaction.amount || new BigNumber(0))) {
+        updatedTransaction = bridge.updateTransaction(updatedTransaction, { amount: maybeAmount });
+        hasChanges = true;
+        onResetMaybeAmount();
+      }
 
-    if (hasChanges) {
-      setTransaction(updatedTransaction);
-    }
+      if (hasChanges) {
+        setTransaction(updatedTransaction);
+      }
+    })();
   }, [
     maybeRecipient,
     maybeAmount,

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/Body.tsx
@@ -14,8 +14,8 @@ import {
 } from "@ledgerhq/live-common/account/index";
 import { isCryptoCurrency } from "@ledgerhq/live-common/currencies/helpers";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Account, AccountLike, Operation } from "@ledgerhq/types-live";
 import { Transaction } from "@ledgerhq/live-common/generated/types";
 import logger from "~/renderer/logger";
@@ -180,6 +180,8 @@ const Body = ({
 
   invariant(account, "account required");
 
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
+
   // make sure step id is in sync
   useEffect(() => {
     const stepId = params?.startWithWarning ? "warning" : null;
@@ -190,35 +192,31 @@ const Body = ({
   useEffect(() => {
     if (!transaction) return;
 
-    (async () => {
-      const bridge = await getAccountBridge(account, parentAccount);
-      let updatedTransaction = transaction;
-      let hasChanges = false;
+    let updatedTransaction = transaction;
+    let hasChanges = false;
 
-      if (maybeRecipient && !transaction.recipient) {
-        updatedTransaction = bridge.updateTransaction(updatedTransaction, {
-          recipient: maybeRecipient,
-        });
-        hasChanges = true;
-        onResetMaybeRecipient();
-      }
+    if (maybeRecipient && !transaction.recipient) {
+      updatedTransaction = bridge.updateTransaction(updatedTransaction, {
+        recipient: maybeRecipient,
+      });
+      hasChanges = true;
+      onResetMaybeRecipient();
+    }
 
-      if (maybeAmount && !maybeAmount.eq(transaction.amount || new BigNumber(0))) {
-        updatedTransaction = bridge.updateTransaction(updatedTransaction, { amount: maybeAmount });
-        hasChanges = true;
-        onResetMaybeAmount();
-      }
+    if (maybeAmount && !maybeAmount.eq(transaction.amount || new BigNumber(0))) {
+      updatedTransaction = bridge.updateTransaction(updatedTransaction, { amount: maybeAmount });
+      hasChanges = true;
+      onResetMaybeAmount();
+    }
 
-      if (hasChanges) {
-        setTransaction(updatedTransaction);
-      }
-    })();
+    if (hasChanges) {
+      setTransaction(updatedTransaction);
+    }
   }, [
+    bridge,
     maybeRecipient,
     maybeAmount,
     transaction,
-    account,
-    parentAccount,
     setTransaction,
     onResetMaybeRecipient,
     onResetMaybeAmount,

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
@@ -242,7 +242,7 @@ const SwapWebView = ({ manifest, isEmbedded = false, Loader = SwapLoader }: Swap
         const fromParentAccount = getParentAccount(fromAccount, accounts);
 
         let mainAccount = getMainAccount(fromAccount, fromParentAccount);
-        const bridge = getAccountBridge(fromAccount, fromParentAccount);
+        const bridge = await getAccountBridge(fromAccount, fromParentAccount);
 
         const subAccountId = fromAccount.type !== "Account" && fromAccount.id;
 

--- a/apps/wallet-cli/src/wallet/compatibility/bridge.ts
+++ b/apps/wallet-cli/src/wallet/compatibility/bridge.ts
@@ -41,9 +41,10 @@ export class BridgeAdapter {
       let sub: Subscription | null = null;
       let torn = false;
       BridgeAdapter.cache.prepareCurrency(currency).then(
-        () => {
+        async () => {
           if (torn) return;
-          sub = getCurrencyBridge(currency)
+          const currencyBridge = await getCurrencyBridge(currency);
+          sub = currencyBridge
             .scanAccounts({ currency, deviceId, syncConfig: BridgeAdapter.SYNC_CONFIG })
             .pipe(
               filter((e): e is { type: "discovered"; account: Account } => e.type === "discovered"),

--- a/apps/wallet-cli/src/wallet/compatibility/bridge.ts
+++ b/apps/wallet-cli/src/wallet/compatibility/bridge.ts
@@ -41,10 +41,9 @@ export class BridgeAdapter {
       let sub: Subscription | null = null;
       let torn = false;
       BridgeAdapter.cache.prepareCurrency(currency).then(
-        async () => {
+        () => {
           if (torn) return;
-          const currencyBridge = await getCurrencyBridge(currency);
-          sub = currencyBridge
+          sub = getCurrencyBridge(currency)
             .scanAccounts({ currency, deviceId, syncConfig: BridgeAdapter.SYNC_CONFIG })
             .pipe(
               filter((e): e is { type: "discovered"; account: Account } => e.type === "discovered"),


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** No behaviour change — `await` on a sync value is a no-op today.
- [ ] **Impact of the changes:** Pure forward-compatibility refactor, no user-facing change.

### 📝 Description

Prepares desktop modal call sites for async bridges. React components switch to `useAccountBridge` (landed in #16726); class components and one-shot async handlers use `await`.

`Send/Body` now reads the bridge from the hook instead of an ad-hoc async IIFE:
```diff
- useEffect(() => {
-   (async () => { const bridge = await getAccountBridge(account, parentAccount); ... })();
- }, [...]);
+ const bridge = useAccountBridge(account, parentAccount);
+ useEffect(() => { ...(bridge)... }, [bridge, ...]);
```

`StepImport.startScanAccountsDevice` and `StepReceiveFunds` use `await getCurrencyBridge`/`await getAccountBridge` before starting their respective observables.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29176](https://ledgerhq.atlassian.net/browse/LIVE-29176) / #16733
- **ADR link (if any)**: N/A


[LIVE-29176]: https://ledgerhq.atlassian.net/browse/LIVE-29176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ