### PR TITLE
[LWDM] refactor(mobile): prepare Web3AppWebview for async getAccountBridge

### DIFF
--- a/.changeset/async-ready-mobile-webview.md
+++ b/.changeset/async-ready-mobile-webview.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Prepare Web3AppWebview signing flows for async getAccountBridge. Widen UiHook return types for `transaction.sign` and `custom.acre.transactionSign` to `void | Promise<void>` so consumers can use async implementations safely.

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
@@ -222,8 +222,14 @@ export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
           { manifest, accounts, tracking },
           accountId,
           transaction,
-          (account, parentAccount, { liveTx }) => {
-            const tx = prepareSignTransaction(account, parentAccount, liveTx);
+          async (account, parentAccount, { liveTx }) => {
+            let tx: Transaction;
+            try {
+              tx = await prepareSignTransaction(account, parentAccount, liveTx);
+            } catch (error) {
+              tracking.platformSignTransactionFail(manifest);
+              throw error;
+            }
 
             return new Promise((resolve, reject) => {
               let done = false;

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/helpers.ts
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/helpers.ts
@@ -558,7 +558,7 @@ function useUiHook({ manifest, onTransactionBroadcast }: Props): UiHook {
       "storage.set": ({ key, value, storeId }) => {
         storage.save(`${storeId}-${key}`, value);
       },
-      "transaction.sign": ({
+      "transaction.sign": async ({
         account,
         parentAccount,
         signFlowInfos: { liveTx },
@@ -566,23 +566,26 @@ function useUiHook({ manifest, onTransactionBroadcast }: Props): UiHook {
         onSuccess,
         onError,
       }) => {
-        const tx = prepareSignTransaction(account, parentAccount, liveTx);
-
-        navigation.navigate(NavigatorName.SignTransaction, {
-          screen: ScreenName.SignTransactionSummary,
-          params: {
-            currentNavigation: ScreenName.SignTransactionSummary,
-            nextNavigation: ScreenName.SignTransactionSelectDevice,
-            transaction: tx,
-            accountId: account.id,
-            parentId: parentAccount ? parentAccount.id : undefined,
-            appName: options?.hwAppId,
-            dependencies: options?.dependencies,
-            onSuccess,
+        try {
+          const tx = await prepareSignTransaction(account, parentAccount, liveTx);
+          navigation.navigate(NavigatorName.SignTransaction, {
+            screen: ScreenName.SignTransactionSummary,
+            params: {
+              currentNavigation: ScreenName.SignTransactionSummary,
+              nextNavigation: ScreenName.SignTransactionSelectDevice,
+              transaction: tx,
+              accountId: account.id,
+              parentId: parentAccount ? parentAccount.id : undefined,
+              appName: options?.hwAppId,
+              dependencies: options?.dependencies,
+              onSuccess,
+              onError,
+            },
             onError,
-          },
-          onError,
-        });
+          });
+        } catch (err) {
+          onError(err as Error);
+        }
       },
       "transaction.signRaw": ({
         account,

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/liveSDKLogic.test.ts
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/liveSDKLogic.test.ts
@@ -48,7 +48,7 @@ describe("prepareSignTransaction", () => {
 
     const { liveTx } = await getPlatformTransactionSignFlowInfos(tx);
 
-    const result = prepareSignTransaction(childAccount, parentAccount, liveTx);
+    const result = await prepareSignTransaction(childAccount, parentAccount, liveTx);
 
     // Then
     expect(result).toEqual(expectedResult);
@@ -85,7 +85,7 @@ describe("prepareSignTransaction", () => {
       account: childAccount,
     });
 
-    const result = prepareSignTransaction(childAccount, parentAccount, liveTx);
+    const result = await prepareSignTransaction(childAccount, parentAccount, liveTx);
 
     // Then
     expect(result).toEqual(expectedResult);

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/liveSDKLogic.ts
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/liveSDKLogic.ts
@@ -3,12 +3,12 @@ import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { Transaction } from "@ledgerhq/live-common/generated/types";
 import { Account, AccountBridge, AccountLike } from "@ledgerhq/types-live";
 
-export default function prepareSignTransaction(
+export default async function prepareSignTransaction(
   account: AccountLike,
   parentAccount: Account | undefined,
   liveTx: Partial<Transaction>,
 ) {
-  const bridge: AccountBridge<Transaction> = getAccountBridge(account, parentAccount);
+  const bridge: AccountBridge<Transaction> = await getAccountBridge(account, parentAccount);
   const t = bridge.createTransaction(account);
   const { recipient, ...txData } = liveTx;
   const t2 = bridge.updateTransaction(t, {

--- a/apps/ledger-live-mobile/src/components/WebPlatformPlayer/CustomHandlers.ts
+++ b/apps/ledger-live-mobile/src/components/WebPlatformPlayer/CustomHandlers.ts
@@ -70,7 +70,7 @@ export function useACRECustomHandlers(manifest: WebviewProps["manifest"], accoun
               onClose: onCancel,
             });
           },
-          "custom.acre.transactionSign": ({
+          "custom.acre.transactionSign": async ({
             account,
             parentAccount,
             signFlowInfos: { liveTx },
@@ -78,24 +78,27 @@ export function useACRECustomHandlers(manifest: WebviewProps["manifest"], accoun
             onSuccess,
             onError,
           }) => {
-            const tx = prepareSignTransaction(account, parentAccount, liveTx);
-
-            navigation.navigate(NavigatorName.SignTransaction, {
-              screen: ScreenName.SignTransactionSummary,
-              params: {
-                currentNavigation: ScreenName.SignTransactionSummary,
-                nextNavigation: ScreenName.SignTransactionSelectDevice,
-                transaction: tx,
-                accountId: account.id,
-                parentId: parentAccount ? parentAccount.id : undefined,
-                appName: options?.hwAppId,
-                dependencies: options?.dependencies,
-                isACRE: true,
-                onSuccess,
+            try {
+              const tx = await prepareSignTransaction(account, parentAccount, liveTx);
+              navigation.navigate(NavigatorName.SignTransaction, {
+                screen: ScreenName.SignTransactionSummary,
+                params: {
+                  currentNavigation: ScreenName.SignTransactionSummary,
+                  nextNavigation: ScreenName.SignTransactionSelectDevice,
+                  transaction: tx,
+                  accountId: account.id,
+                  parentId: parentAccount ? parentAccount.id : undefined,
+                  appName: options?.hwAppId,
+                  dependencies: options?.dependencies,
+                  isACRE: true,
+                  onSuccess,
+                  onError,
+                },
                 onError,
-              },
-              onError,
-            });
+              });
+            } catch (err) {
+              onError(err as Error);
+            }
           },
           "custom.acre.registerAccount": ({
             parentAccount,

--- a/libs/ledger-live-common/src/wallet-api/ACRE/server.ts
+++ b/libs/ledger-live-common/src/wallet-api/ACRE/server.ts
@@ -68,7 +68,7 @@ export type ACREUiHooks = {
     options?: TransactionOptions;
     onSuccess: (signedOperation: SignedOperation) => void;
     onError: (error: Error) => void;
-  }) => void;
+  }) => void | Promise<void>;
   "custom.acre.transactionBroadcast"?: (
     account: AccountLike,
     parentAccount: Account | undefined,

--- a/libs/ledger-live-common/src/wallet-api/react.ts
+++ b/libs/ledger-live-common/src/wallet-api/react.ts
@@ -139,7 +139,7 @@ export interface UiHook {
     options: Parameters<WalletHandlers["transaction.sign"]>[0]["options"];
     onSuccess: (signedOperation: SignedOperation) => void;
     onError: (error: Error) => void;
-  }) => void;
+  }) => void | Promise<void>;
   "transaction.broadcast": (
     account: AccountLike,
     parentAccount: Account | undefined,


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** `liveSDKLogic.test.ts` updated for the async signature.
- [ ] **Impact of the changes:** Pure forward-compatibility refactor, no user-facing change.

### 📝 Description

Prepares mobile Web3AppWebview and WebPlatformPlayer signing flows for async `getAccountBridge` by making `prepareSignTransaction` async. Call sites that rely on `onSuccess`/`onError` callbacks wrap the `await` in `try/catch` to route failures to `onError`.

```diff
- function prepareSignTransaction(...): Transaction {
-   const bridge = getAccountBridge(account, parentAccount);
+ async function prepareSignTransaction(...): Promise<Transaction> {
+   const bridge = await getAccountBridge(account, parentAccount);
```

```diff
  uiHook["transaction.sign"] = async ({ account, parentAccount, ... }) => {
+   try {
      const tx = await prepareSignTransaction(...);
      onSuccess(tx);
+   } catch (err) {
+     onError(err);
+   }
  };
```

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29176](https://ledgerhq.atlassian.net/browse/LIVE-29176) / #16733
- **ADR link (if any)**: N/A


[LIVE-29176]: https://ledgerhq.atlassian.net/browse/LIVE-29176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ