### PR TITLE
[LWD] refactor(desktop/aleo): prepare useAleoPrivateSync for async getAccountBridge

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/families/aleo/hooks/useAleoPrivateSync.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/hooks/useAleoPrivateSync.ts
@@ -104,7 +104,8 @@ export const useAleoPrivateSync = ({
 
     const currentAccountId = acc.id;
     let receivedFinalResult = false;
-    const bridge = getAccountBridge(acc);
+    (async () => {
+    const bridge = await getAccountBridge(acc);
     const sub = bridge.sync(acc, { paginationConfig: {}, syncType: SYNC_TYPE_SHIELDED }).subscribe({
       next: updater => {
         const currentAcc = accountRef.current;
@@ -164,6 +165,7 @@ export const useAleoPrivateSync = ({
         if (entry) entry.sub = sub;
       }
     }
+    })();
   }, [dispatch]);
 
   const start = useCallback(() => {


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** No behaviour change — `await` on a sync value is a no-op today.
- [ ] **Impact of the changes:** Pure forward-compatibility refactor, no user-facing change.

### 📝 Description

Prepares `useAleoPrivateSync` `getAccountBridge` call site for when the bridge becomes async. No behaviour change today.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29176](https://ledgerhq.atlassian.net/browse/LIVE-29176) / #16733
- **ADR link (if any)**: N/A


[LIVE-29176]: https://ledgerhq.atlassian.net/browse/LIVE-29176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ