### PR TITLE
[LWM] refactor(mobile): prepare families for async getAccountBridge

### DIFF
--- a/apps/ledger-live-mobile/src/families/algorand/ScreenEditMemoValue.tsx
+++ b/apps/ledger-live-mobile/src/families/algorand/ScreenEditMemoValue.tsx
@@ -22,8 +22,8 @@ function AlgorandEditMemo({ navigation, route }: Props) {
   const { t } = useTranslation();
   const [memo, setMemo] = useState(route.params.transaction.memo ?? undefined);
   const account = route.params.account;
-  const onValidateText = useCallback(() => {
-    const bridge = getAccountBridge(account);
+  const onValidateText = useCallback(async () => {
+    const bridge = await getAccountBridge(account);
     const { transaction } = route.params;
     popToScreen(navigation, ScreenName.SendSummary, {
       accountId: account.id,

--- a/apps/ledger-live-mobile/src/families/bitcoin/ScreenEditCustomFees.tsx
+++ b/apps/ledger-live-mobile/src/families/bitcoin/ScreenEditCustomFees.tsx
@@ -61,13 +61,13 @@ function BitcoinEditCustomFees({ navigation, route }: Props) {
     setOwnSatPerByte(text.replace(/\D/g, ""));
   }, []);
 
-  const onValidateText = useCallback(() => {
+  const onValidateText = useCallback(async () => {
     if (BigNumber(ownSatPerByte || 0).isZero()) return;
     Keyboard.dismiss();
     if (setSatPerByte) {
       setSatPerByte(BigNumber(ownSatPerByte || 0));
     }
-    const bridge = getAccountBridge(account, parentAccount);
+    const bridge = await getAccountBridge(account, parentAccount);
     const { currentNavigation } = route.params;
     const updatedTransaction = bridge.updateTransaction(transaction, {
       feePerByte: BigNumber(ownSatPerByte || 0),

--- a/apps/ledger-live-mobile/src/families/bitcoin/SendRowsFee.tsx
+++ b/apps/ledger-live-mobile/src/families/bitcoin/SendRowsFee.tsx
@@ -63,8 +63,8 @@ export default function BitcoinSendRowsFee({
     [defaultStrategies, transaction],
   );
   const onFeesSelected = useCallback(
-    ({ amount, label }: SelectFeeStrategy) => {
-      const bridge = getAccountBridge(account, parentAccount);
+    async ({ amount, label }: SelectFeeStrategy) => {
+      const bridge = await getAccountBridge(account, parentAccount);
       setTransaction(
         bridge.updateTransaction(transaction, {
           feesStrategy: label,

--- a/apps/ledger-live-mobile/src/families/canton/ScreenEditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/canton/ScreenEditMemo.tsx
@@ -22,8 +22,8 @@ function CantonEditMemo({ navigation, route }: Props) {
   const { t } = useTranslation();
   const [memo, setMemo] = useState(route.params.transaction.memo);
   const account = route.params.account;
-  const onValidateText = useCallback(() => {
-    const bridge = getAccountBridge(account);
+  const onValidateText = useCallback(async () => {
+    const bridge = await getAccountBridge(account);
     const { transaction } = route.params;
     popToScreen(navigation, ScreenName.SendSummary, {
       accountId: account.id,

--- a/apps/ledger-live-mobile/src/families/canton/TooManyUtxosModal.tsx
+++ b/apps/ledger-live-mobile/src/families/canton/TooManyUtxosModal.tsx
@@ -26,10 +26,10 @@ function TooManyUtxosModal({ isOpened, onClose, account }: Props) {
   const navigation = useNavigation();
   const learnMoreUrl = useLocalizedUrl(urls.canton.learnMore);
 
-  const handleConsolidate = useCallback(() => {
+  const handleConsolidate = useCallback(async () => {
     onClose();
 
-    const bridge = getAccountBridge(account);
+    const bridge = await getAccountBridge(account);
     const transaction = bridge.createTransaction(account);
     const updatedTransaction = bridge.updateTransaction(transaction, {
       recipient: account.xpub || "",

--- a/apps/ledger-live-mobile/src/families/cardano/EditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/cardano/EditMemo.tsx
@@ -22,8 +22,8 @@ function CardanoEditMemo({ navigation, route }: Props) {
   const { t } = useTranslation();
   const [memo, setMemo] = useState(route.params.transaction.memo);
   const account = route.params.account;
-  const onValidateText = useCallback(() => {
-    const bridge = getAccountBridge(account);
+  const onValidateText = useCallback(async () => {
+    const bridge = await getAccountBridge(account);
     const { transaction } = route.params;
     popToScreen(navigation, ScreenName.SendSummary, {
       accountId: account.id,

--- a/apps/ledger-live-mobile/src/families/casper/ScreenEditTransferId.tsx
+++ b/apps/ledger-live-mobile/src/families/casper/ScreenEditTransferId.tsx
@@ -36,8 +36,8 @@ function CasperEditTransferId({ navigation, route }: NavigationProps) {
     value = str.replace(/\D/g, "");
     setTransferId(value === "" ? undefined : value);
   }, []);
-  const onValidateText = useCallback(() => {
-    const bridge = getAccountBridge(account);
+  const onValidateText = useCallback(async () => {
+    const bridge = await getAccountBridge(account);
     const { transaction } = route.params;
 
     popToScreen(navigation, ScreenName.SendSummary, {

--- a/apps/ledger-live-mobile/src/families/cosmos/EditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/EditMemo.tsx
@@ -23,8 +23,8 @@ function CosmosFamilyEditMemo({ navigation, route }: Props) {
   const account = route.params.account;
   const currencyName = account.currency.name;
 
-  const onValidateText = useCallback(() => {
-    const bridge = getAccountBridge(account);
+  const onValidateText = useCallback(async () => {
+    const bridge = await getAccountBridge(account);
     const { transaction } = route.params;
     popToScreen(navigation, ScreenName.SendSummary, {
       ...route.params,

--- a/apps/ledger-live-mobile/src/families/hedera/EditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/EditMemo.tsx
@@ -22,8 +22,8 @@ function HederaEditMemo({ navigation, route }: NavigationProps) {
   const { t } = useTranslation();
   const [memo, setMemo] = useState(route.params.transaction.memo);
   const account = route.params.account;
-  const onValidateText = useCallback(() => {
-    const bridge = getAccountBridge(account);
+  const onValidateText = useCallback(async () => {
+    const bridge = await getAccountBridge(account);
     const { transaction } = route.params;
     popToScreen(navigation, ScreenName.SendSummary, {
       accountId: account.id,

--- a/apps/ledger-live-mobile/src/families/helpers.ts
+++ b/apps/ledger-live-mobile/src/families/helpers.ts
@@ -20,7 +20,7 @@ export function useFieldByFamily(
 }
 export function useEditTxFeeByFamily() {
   const transaction = useRoute<Navigation["route"]>().params?.transaction;
-  return ({
+  return async ({
     account,
     field,
     fee,
@@ -29,7 +29,7 @@ export function useEditTxFeeByFamily() {
     field: string;
     fee: BigNumber | null | undefined;
   }) => {
-    const bridge = getAccountBridge(account);
+    const bridge = await getAccountBridge(account);
     return bridge.updateTransaction(transaction, {
       [field]: fee,
     });

--- a/apps/ledger-live-mobile/src/families/internet_computer/ScreenEditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/internet_computer/ScreenEditMemo.tsx
@@ -36,8 +36,8 @@ function InternetComputerEditMemo({ navigation, route }: NavigationProps) {
     value = str.replace(/\D/g, "");
     setMemo(value === "" ? undefined : value);
   }, []);
-  const onValidateText = useCallback(() => {
-    const bridge = getAccountBridge(account);
+  const onValidateText = useCallback(async () => {
+    const bridge = await getAccountBridge(account);
     const { transaction } = route.params;
     popToScreen(navigation, ScreenName.SendSummary, {
       accountId: account.id,

--- a/apps/ledger-live-mobile/src/families/kaspa/ScreenEditCustomFees.tsx
+++ b/apps/ledger-live-mobile/src/families/kaspa/ScreenEditCustomFees.tsx
@@ -49,11 +49,11 @@ function KaspaEditCustomFees({ navigation, route }: Props) {
     setOwnSompiPerByte(text.replace(/\D/g, ""));
   }, []);
 
-  const onValidateText = useCallback(() => {
+  const onValidateText = useCallback(async () => {
     if (BigNumber(ownSompiPerByte || 0).isZero()) return;
     Keyboard.dismiss();
     setSompiPerByte && setSompiPerByte(BigNumber(ownSompiPerByte || 0));
-    const bridge = getAccountBridge(account, parentAccount);
+    const bridge = await getAccountBridge(account, parentAccount);
     navigation.navigate(NavigatorName.SendFunds, {
       screen: ScreenName.SendSummary,
       params: {

--- a/apps/ledger-live-mobile/src/families/kaspa/SendRowsFee.tsx
+++ b/apps/ledger-live-mobile/src/families/kaspa/SendRowsFee.tsx
@@ -63,8 +63,8 @@ export default function KaspaSendRowsFee({
     [defaultStrategies, transaction],
   );
   const onFeesSelected = useCallback(
-    ({ label }: SelectFeeStrategy) => {
-      const bridge = getAccountBridge(account, parentAccount);
+    async ({ label }: SelectFeeStrategy) => {
+      const bridge = await getAccountBridge(account, parentAccount);
       setTransaction(
         bridge.updateTransaction(transaction, {
           feesStrategy: label,

--- a/apps/ledger-live-mobile/src/families/mina/ScreenEditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/mina/ScreenEditMemo.tsx
@@ -29,8 +29,8 @@ function MinaEditMemo({ navigation, route }: NavigationProps) {
   const onChangeMemoValue = useCallback((str: string) => {
     setMemo(str === "" ? undefined : str);
   }, []);
-  const onValidateText = useCallback(() => {
-    const bridge = getAccountBridge(account);
+  const onValidateText = useCallback(async () => {
+    const bridge = await getAccountBridge(account);
     const { transaction } = route.params;
     popToScreen(navigation, ScreenName.SendSummary, {
       accountId: account.id,

--- a/apps/ledger-live-mobile/src/families/polkadot/components/FlowErrorBottomModal.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/components/FlowErrorBottomModal.tsx
@@ -32,10 +32,10 @@ const FlowErrorBottomModal = ({
     if (parent) parent.goBack();
     setBridgeErr(null);
   }, [navigation]);
-  const onBridgeErrorRetry = useCallback(() => {
+  const onBridgeErrorRetry = useCallback(async () => {
     setBridgeErr(null);
     if (!transaction) return;
-    const bridge = getAccountBridge(account, parentAccount);
+    const bridge = await getAccountBridge(account, parentAccount);
     setTransaction(bridge.updateTransaction(transaction, {}));
   }, [setTransaction, account, parentAccount, transaction]);
   return (

--- a/apps/ledger-live-mobile/src/families/solana/ScreenEditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/ScreenEditMemo.tsx
@@ -29,8 +29,8 @@ function SolanaEditMemo({ navigation, route }: NavigationProps) {
   const [memo, setMemo] = useState(modelSupported ? modelSupported.uiState.memo : undefined);
   const account = route.params.account;
 
-  const onValidateText = useCallback(() => {
-    const bridge = getAccountBridge(account);
+  const onValidateText = useCallback(async () => {
+    const bridge = await getAccountBridge(account);
     const { transaction } = route.params;
     const nextTx = bridge.updateTransaction(transaction, {
       model: {

--- a/apps/ledger-live-mobile/src/families/stacks/ScreenEditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/stacks/ScreenEditMemo.tsx
@@ -30,8 +30,8 @@ function StacksEditMemo({ navigation, route }: NavigationProps) {
   const onChangeMemoValue = useCallback((str: string) => {
     setMemo(str);
   }, []);
-  const onValidateText = useCallback(() => {
-    const bridge = getAccountBridge(account);
+  const onValidateText = useCallback(async () => {
+    const bridge = await getAccountBridge(account);
     const { transaction } = route.params;
     popToScreen(navigation, ScreenName.SendSummary, {
       accountId: account.id,

--- a/apps/ledger-live-mobile/src/families/stellar/ScreenEditCustomFees.tsx
+++ b/apps/ledger-live-mobile/src/families/stellar/ScreenEditCustomFees.tsx
@@ -48,10 +48,10 @@ function StellarEditCustomFees({ navigation, route }: NavigationProps) {
     setCustomFee(fee);
   };
 
-  const onSubmit = useCallback(() => {
+  const onSubmit = useCallback(async () => {
     Keyboard.dismiss();
     setCustomFee(BigNumber(customFee || 0));
-    const bridge = getAccountBridge(account, parentAccount);
+    const bridge = await getAccountBridge(account, parentAccount);
     const { currentNavigation } = route.params;
     popToScreen(navigation, currentNavigation, {
       ...route.params,

--- a/apps/ledger-live-mobile/src/families/stellar/ScreenEditMemoType.tsx
+++ b/apps/ledger-live-mobile/src/families/stellar/ScreenEditMemoType.tsx
@@ -31,12 +31,12 @@ const mapStateToProps = (_state: State, props: NavigationProps) => ({
     : "NO_MEMO",
   items,
   cancelNavigateBack: true,
-  onValueChange: ({ value }: { value: string; label: string }) => {
+  onValueChange: async ({ value }: { value: string; label: string }) => {
     const { navigation, route } = props;
     const { transaction, account } = route.params;
 
     if (value === "NO_MEMO") {
-      const bridge = getAccountBridge(account);
+      const bridge = await getAccountBridge(account);
       popToScreen(navigation, ScreenName.SendSummary, {
         accountId: account.id,
         transaction: bridge.updateTransaction(transaction, {

--- a/apps/ledger-live-mobile/src/families/stellar/ScreenEditMemoValue.tsx
+++ b/apps/ledger-live-mobile/src/families/stellar/ScreenEditMemoValue.tsx
@@ -31,8 +31,8 @@ function StellarEditMemoValue({ navigation, route }: NavigationProps) {
   const onChangeMemoValue = useCallback((str: string) => {
     setMemoValue(str);
   }, []);
-  const onValidateText = useCallback(() => {
-    const bridge = getAccountBridge(account);
+  const onValidateText = useCallback(async () => {
+    const bridge = await getAccountBridge(account);
     const { transaction, memoType } = route.params;
     popToScreen(navigation, ScreenName.SendSummary, {
       accountId: account.id,

--- a/apps/ledger-live-mobile/src/families/ton/ScreenEditComment.tsx
+++ b/apps/ledger-live-mobile/src/families/ton/ScreenEditComment.tsx
@@ -35,8 +35,8 @@ function TonEditComment({ navigation, route }: NavigationProps) {
   const onChangeCommentValue = useCallback((str: string) => {
     setComment(str);
   }, []);
-  const onValidateText = useCallback(() => {
-    const bridge = getAccountBridge(account);
+  const onValidateText = useCallback(async () => {
+    const bridge = await getAccountBridge(account);
     const { transaction } = route.params;
     popToScreen(navigation, ScreenName.SendSummary, {
       accountId: account.id,

--- a/apps/ledger-live-mobile/src/families/xrp/ScreenEditTag.tsx
+++ b/apps/ledger-live-mobile/src/families/xrp/ScreenEditTag.tsx
@@ -52,9 +52,9 @@ function XrpEditTag({ route, navigation }: NavigationProps) {
     setTag(newTag);
   }
 
-  const onValidateText = useCallback(() => {
+  const onValidateText = useCallback(async () => {
     if (!account) return;
-    const bridge = getAccountBridge(account);
+    const bridge = await getAccountBridge(account);
     popToScreen(navigation, ScreenName.SendSummary, {
       accountId: account.id,
       transaction: bridge.updateTransaction(transaction, {


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** No behaviour change — `await` on a sync value is a no-op today.
- [ ] **Impact of the changes:** Pure forward-compatibility refactor, no user-facing change.

### 📝 Description

Prepares mobile `families/` edit screens and fee selectors for async `getAccountBridge`. 22 files across 14 coin families, same mechanical pattern throughout:

```diff
- const onValidate = () => {
-   const bridge = getAccountBridge(account, parentAccount);
+ const onValidate = async () => {
+   const bridge = await getAccountBridge(account, parentAccount);
    navigation.navigate(..., { transaction: bridge.updateTransaction(...) });
  };
```

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29176](https://ledgerhq.atlassian.net/browse/LIVE-29176) / #16733
- **ADR link (if any)**: N/A


[LIVE-29176]: https://ledgerhq.atlassian.net/browse/LIVE-29176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ