### PR TITLE
refactor(cli): prepare call sites for async getAccountBridge/getCurrencyBridge

### DIFF
--- a/apps/cli/src/commands/blockchain/botPortfolio.ts
+++ b/apps/cli/src/commands/blockchain/botPortfolio.ts
@@ -21,24 +21,28 @@ export default {
       filter(c => !blacklist.includes(c.id) && !c.isTestnetFor),
       map(currency =>
         defer(() =>
-          getCurrencyBridge(currency)
-            .scanAccounts({
-              currency,
-              deviceId: `speculos:nanos:${currency.id}`,
-              syncConfig: {
-                paginationConfig: {},
-              },
-            })
-            .pipe(
-              timeout({
-                each: 200 * 1000,
-                with: () => throwError(() => new Error("scan account timeout")),
-              }),
-              catchError(e => {
-                console.error("scan accounts failed for " + currency.id, e);
-                return from([]);
-              }),
+          defer(() => Promise.resolve(getCurrencyBridge(currency))).pipe(
+            mergeMap(bridge =>
+              bridge
+                .scanAccounts({
+                  currency,
+                  deviceId: `speculos:nanos:${currency.id}`,
+                  syncConfig: {
+                    paginationConfig: {},
+                  },
+                })
+                .pipe(
+                  timeout({
+                    each: 200 * 1000,
+                    with: () => throwError(() => new Error("scan account timeout")),
+                  }),
+                  catchError(e => {
+                    console.error("scan accounts failed for " + currency.id, e);
+                    return from([]);
+                  }),
+                ),
             ),
+          ),
         ),
       ),
       mergeAll(5),

--- a/apps/cli/src/commands/blockchain/botPortfolio.ts
+++ b/apps/cli/src/commands/blockchain/botPortfolio.ts
@@ -20,28 +20,26 @@ export default {
     return from(listSupportedCurrencies()).pipe(
       filter(c => !blacklist.includes(c.id) && !c.isTestnetFor),
       map(currency =>
-        defer(() =>
-          defer(() => Promise.resolve(getCurrencyBridge(currency))).pipe(
-            mergeMap(bridge =>
-              bridge
-                .scanAccounts({
-                  currency,
-                  deviceId: `speculos:nanos:${currency.id}`,
-                  syncConfig: {
-                    paginationConfig: {},
-                  },
-                })
-                .pipe(
-                  timeout({
-                    each: 200 * 1000,
-                    with: () => throwError(() => new Error("scan account timeout")),
-                  }),
-                  catchError(e => {
-                    console.error("scan accounts failed for " + currency.id, e);
-                    return from([]);
-                  }),
-                ),
-            ),
+        defer(() => Promise.resolve(getCurrencyBridge(currency))).pipe(
+          mergeMap(bridge =>
+            bridge
+              .scanAccounts({
+                currency,
+                deviceId: `speculos:nanos:${currency.id}`,
+                syncConfig: {
+                  paginationConfig: {},
+                },
+              })
+              .pipe(
+                timeout({
+                  each: 200 * 1000,
+                  with: () => throwError(() => new Error("scan account timeout")),
+                }),
+                catchError(e => {
+                  console.error("scan accounts failed for " + currency.id, e);
+                  return from([]);
+                }),
+              ),
           ),
         ),
       ),

--- a/apps/cli/src/commands/blockchain/broadcast.ts
+++ b/apps/cli/src/commands/blockchain/broadcast.ts
@@ -16,10 +16,14 @@ export default {
         inferSignedOperations(account, opts).pipe(
           concatMap(signedOperation =>
             from(
-              getAccountBridge(account).broadcast({
-                account,
-                signedOperation,
-              }),
+              Promise.resolve()
+                .then(() => getAccountBridge(account))
+                .then(bridge =>
+                  bridge.broadcast({
+                    account,
+                    signedOperation,
+                  }),
+                ),
             ),
           ),
         ),

--- a/apps/cli/src/commands/blockchain/estimateMaxSpendable.ts
+++ b/apps/cli/src/commands/blockchain/estimateMaxSpendable.ts
@@ -1,5 +1,5 @@
-import { concat, from } from "rxjs";
-import { concatMap } from "rxjs/operators";
+import { concat, defer, from } from "rxjs";
+import { concatMap, mergeMap } from "rxjs/operators";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
@@ -26,28 +26,31 @@ export default {
   args: [...scanCommonOpts],
   job: (opts: EstimateMaxSpendableJobOpts) =>
     scan(opts).pipe(
-      concatMap(account => {
-        const bridge = getAccountBridge(account);
-        return concat(
-          from(
-            bridge
-              .estimateMaxSpendable({
-                account,
-                parentAccount: null,
-              })
-              .then(maxSpendable => format(account, maxSpendable)),
-          ),
-          ...(account.subAccounts || []).map(subAccount =>
-            from(
-              bridge
-                .estimateMaxSpendable({
-                  account: subAccount,
-                  parentAccount: account,
-                })
-                .then(maxSpendable => "  " + format(subAccount, maxSpendable)),
+      concatMap(account =>
+        defer(() => Promise.resolve(getAccountBridge(account))).pipe(
+          mergeMap(bridge =>
+            concat(
+              from(
+                bridge
+                  .estimateMaxSpendable({
+                    account,
+                    parentAccount: null,
+                  })
+                  .then(maxSpendable => format(account, maxSpendable)),
+              ),
+              ...(account.subAccounts || []).map(subAccount =>
+                from(
+                  bridge
+                    .estimateMaxSpendable({
+                      account: subAccount,
+                      parentAccount: account,
+                    })
+                    .then(maxSpendable => "  " + format(subAccount, maxSpendable)),
+                ),
+              ),
             ),
           ),
-        );
-      }),
+        ),
+      ),
     ),
 };

--- a/apps/cli/src/commands/blockchain/generateTestTransaction.ts
+++ b/apps/cli/src/commands/blockchain/generateTestTransaction.ts
@@ -60,40 +60,40 @@ export default {
               (acc, [t]) =>
                 concat(
                   acc,
-                  from(
-                    defer(() => {
-                      const apdus: string[] = [];
-                      const unsubscribe = listen(log => {
-                        if (log.type === "apdu" && log.message) {
-                          apdus.push(log.message);
-                        }
-                      });
-                      const bridge = getAccountBridge(account);
-                      return bridge
-                        .signOperation({
-                          account,
-                          transaction: t,
-                          deviceId: opts.device || "",
-                        })
-                        .pipe(
-                          filter(e => e.type === "signed"),
-                          map(e => {
-                            // FIXME: will always be true because of filter above
-                            // but ts can't infer the right type for SignOperationEvent
-                            if (e.type === "signed") {
-                              return e.signedOperation;
-                            }
-                          }),
-                          concatMap(signedOperation =>
-                            from(
-                              bridge
-                                .getTransactionStatus(account, t)
-                                .then(s => [signedOperation, s]),
+                  defer(() => {
+                    const apdus: string[] = [];
+                    const unsubscribe = listen(log => {
+                      if (log.type === "apdu" && log.message) {
+                        apdus.push(log.message);
+                      }
+                    });
+                    return defer(() => Promise.resolve(getAccountBridge(account))).pipe(
+                      mergeMap(bridge =>
+                        bridge
+                          .signOperation({
+                            account,
+                            transaction: t,
+                            deviceId: opts.device || "",
+                          })
+                          .pipe(
+                            filter(e => e.type === "signed"),
+                            map(e => {
+                              // FIXME: will always be true because of filter above
+                              // but ts can't infer the right type for SignOperationEvent
+                              if (e.type === "signed") {
+                                return e.signedOperation;
+                              }
+                            }),
+                            concatMap(signedOperation =>
+                              from(
+                                bridge
+                                  .getTransactionStatus(account, t)
+                                  .then(s => [signedOperation, s]),
+                              ),
                             ),
-                          ),
-                          mergeMap(async ([signedOperation, status]) => {
-                            unsubscribe();
-                            return `
+                            mergeMap(async ([signedOperation, status]) => {
+                              unsubscribe();
+                              return `
 {
   name: "NO_NAME",
   transaction: fromTransactionRaw(${JSON.stringify(await toTransactionRaw(t))}),
@@ -111,10 +111,11 @@ export default {
 ${apdus.map(a => "  " + a).join("\n")}
   \`
 }`;
-                          }),
-                        );
-                    }),
-                  ),
+                            }),
+                          ),
+                      ),
+                    );
+                  }),
                 ),
               EMPTY as Observable<any>,
             ),

--- a/apps/cli/src/commands/blockchain/receive.ts
+++ b/apps/cli/src/commands/blockchain/receive.ts
@@ -1,5 +1,5 @@
-import { of, concat, EMPTY } from "rxjs";
-import { ignoreElements, concatMap } from "rxjs/operators";
+import { of, concat, EMPTY, from, defer } from "rxjs";
+import { ignoreElements, concatMap, mergeMap } from "rxjs/operators";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { scan, scanCommonOpts } from "../../scan";
 import type { ScanCommonOpts } from "../../scan";
@@ -24,12 +24,16 @@ export default {
         concat(
           of(account.freshAddress),
           opts.qr ? asQR(account.freshAddress) : EMPTY,
-          getAccountBridge(account)
-            .receive(account, {
-              deviceId: opts.device || "",
-              verify: true,
-            })
-            .pipe(ignoreElements()),
+          defer(() => Promise.resolve(getAccountBridge(account))).pipe(
+            mergeMap(bridge =>
+              bridge
+                .receive(account, {
+                  deviceId: opts.device || "",
+                  verify: true,
+                })
+                .pipe(ignoreElements()),
+            ),
+          ),
         ),
       ),
     ),

--- a/apps/cli/src/commands/blockchain/receive.ts
+++ b/apps/cli/src/commands/blockchain/receive.ts
@@ -1,4 +1,4 @@
-import { of, concat, EMPTY, from, defer } from "rxjs";
+import { of, concat, EMPTY, defer } from "rxjs";
 import { ignoreElements, concatMap, mergeMap } from "rxjs/operators";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { scan, scanCommonOpts } from "../../scan";

--- a/apps/cli/src/commands/blockchain/send.ts
+++ b/apps/cli/src/commands/blockchain/send.ts
@@ -75,80 +75,83 @@ export default {
               (acc, [t, status]) =>
                 concat(
                   acc,
-                  from(
-                    defer(() => {
-                      formatTransaction(t, account).then(str => l(`✔️ transaction ${str}`));
-                      formatTransactionStatus(t, status, account).then(str =>
-                        l(`STATUS ${str}`),
-                      );
-                      const bridge = getAccountBridge(account);
-                      return bridge
-                        .signOperation({
-                          account,
-                          transaction: t,
-                          deviceId: opts.device || "",
-                        })
-                        .pipe(
-                          map(toSignOperationEventRaw),
-                          // @ts-expect-error more voodoo stuff
-                          ...(opts["disable-broadcast"] || getEnv("DISABLE_TRANSACTION_BROADCAST")
-                            ? []
-                            : [
-                                concatMap((e: any) => {
-                                  if (e.type === "signed") {
-                                    l(`✔️ has been signed! ${JSON.stringify(e.signedOperation)}`);
-                                    return from(
-                                      bridge
-                                        .broadcast({
-                                          account,
-                                          signedOperation: e.signedOperation,
-                                        })
-                                        .then(async op => {
-                                          l(
-                                            `✔️ broadcasted! optimistic operation: ${formatOperation(
-                                              account,
-                                            )(
-                                              // @ts-expect-error we are supposed to give an OperationRaw and yet it's an Operation
-                                              await fromOperationRaw(op, account.id),
-                                            )}`,
-                                          );
-                                          if (
-                                            opts["wait-confirmation"] &&
-                                            op.hash &&
-                                            getMainAccount(account).currency.family === "evm"
-                                          ) {
-                                            const timeoutMs = opts["wait-confirmation-timeout"];
-                                            await waitForTransactionConfirmation(
-                                              getMainAccount(account),
-                                              op.hash,
-                                              timeoutMs ? { timeoutMs } : {},
-                                            );
+                  defer(() => {
+                    formatTransaction(t, account).then(str => l(`✔️ transaction ${str}`));
+                    formatTransactionStatus(t, status, account).then(str => l(`STATUS ${str}`));
+                    return defer(() => Promise.resolve(getAccountBridge(account))).pipe(
+                      mergeMap(bridge =>
+                        bridge
+                          .signOperation({
+                            account,
+                            transaction: t,
+                            deviceId: opts.device || "",
+                          })
+                          .pipe(
+                            map(toSignOperationEventRaw),
+                            // @ts-expect-error more voodoo stuff
+                            ...(opts["disable-broadcast"] ||
+                            getEnv("DISABLE_TRANSACTION_BROADCAST")
+                              ? []
+                              : [
+                                  concatMap((e: any) => {
+                                    if (e.type === "signed") {
+                                      l(
+                                        `✔️ has been signed! ${JSON.stringify(e.signedOperation)}`,
+                                      );
+                                      return from(
+                                        bridge
+                                          .broadcast({
+                                            account,
+                                            signedOperation: e.signedOperation,
+                                          })
+                                          .then(async op => {
                                             l(
-                                              `✔️ transaction confirmed on-chain (hash: ${op.hash})`,
+                                              `✔️ broadcasted! optimistic operation: ${formatOperation(
+                                                account,
+                                              )(
+                                                // @ts-expect-error we are supposed to give an OperationRaw and yet it's an Operation
+                                                await fromOperationRaw(op, account.id),
+                                              )}`,
                                             );
-                                          }
-                                          return op;
-                                        }),
-                                    );
-                                  }
+                                            if (
+                                              opts["wait-confirmation"] &&
+                                              op.hash &&
+                                              getMainAccount(account).currency.family === "evm"
+                                            ) {
+                                              const timeoutMs =
+                                                opts["wait-confirmation-timeout"];
+                                              await waitForTransactionConfirmation(
+                                                getMainAccount(account),
+                                                op.hash,
+                                                timeoutMs ? { timeoutMs } : {},
+                                              );
+                                              l(
+                                                `✔️ transaction confirmed on-chain (hash: ${op.hash})`,
+                                              );
+                                            }
+                                            return op;
+                                          }),
+                                      );
+                                    }
 
-                                  return of(e);
-                                }),
-                              ]),
-                          ...(opts["ignore-errors"]
-                            ? [
-                                catchError(e => {
-                                  return of({
-                                    type: "error",
-                                    error: e,
-                                    transaction: t,
-                                  });
-                                }),
-                              ]
-                            : []),
-                        );
-                    }),
-                  ),
+                                    return of(e);
+                                  }),
+                                ]),
+                            ...(opts["ignore-errors"]
+                              ? [
+                                  catchError(e => {
+                                    return of({
+                                      type: "error",
+                                      error: e,
+                                      transaction: t,
+                                    });
+                                  }),
+                                ]
+                              : []),
+                          ),
+                      ),
+                    );
+                  }),
                 ),
               EMPTY as Observable<any>,
             ),

--- a/apps/cli/src/scan.ts
+++ b/apps/cli/src/scan.ts
@@ -248,9 +248,10 @@ export function scan(arg: ScanCommonOpts): Observable<Account> {
       map(fromAccountRaw),
       prepareCurrency((a: any) => a.currency),
       concatMap((account: Account) =>
-        getAccountBridge(account, null)
-          .sync(account, syncConfig)
-          .pipe(reduce((a, f: (arg: any) => any) => f(a), account)),
+        defer(() => Promise.resolve(getAccountBridge(account, null))).pipe(
+          mergeMap(bridge => bridge.sync(account, syncConfig)),
+          reduce((a, f: (arg: any) => any) => f(a), account),
+        ),
       ),
     ) as Observable<Account>;
   }
@@ -372,9 +373,10 @@ export function scan(arg: ScanCommonOpts): Observable<Account> {
         ).pipe(
           prepareCurrency((a: Account) => a.currency),
           concatMap((account: Account) =>
-            getAccountBridge(account, null)
-              .sync(account, syncConfig)
-              .pipe(reduce((a: Account, f: any) => f(a), account)),
+            defer(() => Promise.resolve(getAccountBridge(account, null))).pipe(
+              mergeMap(bridge => bridge.sync(account, syncConfig)),
+              reduce((a: Account, f: any) => f(a), account),
+            ),
           ),
         );
       }
@@ -383,12 +385,16 @@ export function scan(arg: ScanCommonOpts): Observable<Account> {
       // otherwise we just scan for accounts
       return concat(
         of(currency).pipe(prepareCurrency((a: any) => a)),
-        getCurrencyBridge(currency).scanAccounts({
-          currency,
-          deviceId: device || "",
-          scheme: scheme && asDerivationMode(scheme),
-          syncConfig,
-        }),
+        defer(() => Promise.resolve(getCurrencyBridge(currency))).pipe(
+          mergeMap(bridge =>
+            bridge.scanAccounts({
+              currency,
+              deviceId: device || "",
+              scheme: scheme && asDerivationMode(scheme),
+              syncConfig,
+            }),
+          ),
+        ),
       ).pipe(
         filter((e: any) => e.type === "discovered"),
         map(e => e.account),


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** No behaviour change — `from()` on a sync value resolves immediately.
- [ ] **Impact of the changes:** Pure forward-compatibility refactor, no user-facing change.

### 📝 Description

Prepares CLI `getAccountBridge`/`getCurrencyBridge` call sites for when the bridges become async, using `from(getBridge()).pipe(mergeMap(...))` in RxJS pipelines. No behaviour change today.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29176](https://ledgerhq.atlassian.net/browse/LIVE-29176) / #16733
- **ADR link (if any)**: N/A


[LIVE-29176]: https://ledgerhq.atlassian.net/browse/LIVE-29176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ