### PR TITLE
[LWDM] feat(live-common,desktop): add useCurrencyBridge hook and migrate canton families

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/families/canton/AddAccountDrawer/hooks/useCantonOnboardViewModel.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/AddAccountDrawer/hooks/useCantonOnboardViewModel.ts
@@ -1,7 +1,7 @@
 import type { CantonCurrencyBridge } from "@ledgerhq/coin-canton/types";
 import { OnboardStatus } from "@ledgerhq/coin-canton/types";
 import { isCantonAccount } from "@ledgerhq/coin-canton/bridge/serialization";
-import { getCurrencyBridge } from "@ledgerhq/live-common/bridge/index";
+import { useCurrencyBridge } from "@ledgerhq/live-common/bridge/useCurrencyBridge";
 import { addAccountsAction } from "@ledgerhq/live-wallet/addAccounts";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Account } from "@ledgerhq/types-live";
@@ -43,11 +43,7 @@ export function useCantonOnboardViewModel({
   const existingAccounts = useSelector(accountsSelector);
   const dispatch = useDispatch();
 
-  const bridge = useMemo(
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    () => getCurrencyBridge(currency) as CantonCurrencyBridge,
-    [currency],
-  );
+  const bridge = useCurrencyBridge<CantonCurrencyBridge>(currency);
 
   const {
     onboardingStatus,

--- a/apps/ledger-live-desktop/src/renderer/families/canton/OnboardModal/hooks/useOnboardModalViewModel.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/OnboardModal/hooks/useOnboardModalViewModel.ts
@@ -1,6 +1,6 @@
 import type { CantonCurrencyBridge } from "@ledgerhq/coin-canton/types";
 import { OnboardStatus } from "@ledgerhq/coin-canton/types";
-import { getCurrencyBridge } from "@ledgerhq/live-common/bridge/index";
+import { useCurrencyBridge } from "@ledgerhq/live-common/bridge/useCurrencyBridge";
 import { useSelector } from "LLD/hooks/redux";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { accountsSelector } from "~/renderer/reducers/accounts";
@@ -29,11 +29,7 @@ export function useOnboardModalViewModel({
 
   const [stepId, setStepId] = useState<StepId>(StepId.ONBOARD);
 
-  const bridge = useMemo(() => {
-    if (!currency) return null;
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    return getCurrencyBridge(currency) as CantonCurrencyBridge;
-  }, [currency]);
+  const bridge = useCurrencyBridge<CantonCurrencyBridge>(currency);
 
   const {
     onboardingStatus,
@@ -56,15 +52,10 @@ export function useOnboardModalViewModel({
     [selectedAccounts],
   );
 
-  const accountName = useMemo(() => {
-    if (!currency) return "";
-    return resolveCreatableAccountName(
-      creatableAccount,
-      currency,
-      editedNames,
-      importableAccounts.length,
-    );
-  }, [creatableAccount, currency, editedNames, importableAccounts.length]);
+  const accountName = useMemo(
+    () => resolveCreatableAccountName(creatableAccount, currency, editedNames, importableAccounts.length),
+    [creatableAccount, currency, editedNames, importableAccounts.length],
+  );
 
   const transitionTo = useCallback((id: StepId) => {
     setStepId(id);

--- a/apps/ledger-live-desktop/src/renderer/families/canton/OnboardModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/OnboardModal/index.tsx
@@ -10,7 +10,8 @@ import type { UserProps, StepProps, StepId } from "./types";
 import { StepId as StepIdEnum } from "./types";
 export type { UserProps } from "./types";
 
-function OnboardModalView(viewModel: ReturnType<typeof useOnboardModalViewModel>) {
+export default function OnboardModal(props: UserProps) {
+  const viewModel = useOnboardModalViewModel(props);
   const {
     device,
     currency,
@@ -31,7 +32,6 @@ function OnboardModalView(viewModel: ReturnType<typeof useOnboardModalViewModel>
   } = viewModel;
 
   invariant(device, "device is required");
-  invariant(currency, "currency is required");
   invariant(creatableAccount, "creatableAccount is required");
 
   const steps: Step<StepId, StepProps>[] = useMemo(
@@ -102,8 +102,4 @@ function OnboardModalView(viewModel: ReturnType<typeof useOnboardModalViewModel>
       )}
     />
   );
-}
-
-export default function OnboardModal(props: UserProps) {
-  return <OnboardModalView {...useOnboardModalViewModel(props)} />;
 }

--- a/apps/ledger-live-desktop/src/renderer/families/canton/OnboardModal/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/OnboardModal/types.ts
@@ -38,7 +38,7 @@ export type StepProps = {
 
 // Props passed to OnboardModal from parent (e.g., modal data).
 export type UserProps = {
-  currency: CryptoCurrency | null;
+  currency: CryptoCurrency;
   editedNames: { [accountId: string]: string };
   selectedAccounts: Account[];
   isReonboarding?: boolean;

--- a/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/steps/StepImport.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/steps/StepImport.tsx
@@ -421,6 +421,7 @@ export const StepImportFooter = ({
   const goCantonOnboard = () => {
     onCloseModal();
     const mainCurrency = currency?.type === "TokenCurrency" ? currency.parentCurrency : currency;
+    if (!mainCurrency) return;
     dispatch(
       openModal("MODAL_CANTON_ONBOARD_ACCOUNT", {
         currency: mainCurrency,
@@ -435,6 +436,7 @@ export const StepImportFooter = ({
   const goConcordiumOnboard = () => {
     onCloseModal();
     const mainCurrency = currency?.type === "TokenCurrency" ? currency.parentCurrency : currency;
+    if (!mainCurrency) return;
     dispatch(
       openModal("MODAL_CONCORDIUM_ONBOARD_ACCOUNT", {
         currency: mainCurrency,

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -29,6 +29,7 @@
     "src/bridge/index.ts",
     "src/bridge/react/index.ts",
     "src/bridge/useBridgeTransaction.ts",
+    "src/bridge/useCurrencyBridge.ts",
     "src/counterValues/state-manager/api.ts",
     "src/counterValues/state-manager/onSchemaFailure.ts",
     "src/counterValues/state-manager/schema.ts",

--- a/libs/ledger-live-common/src/bridge/useCurrencyBridge.ts
+++ b/libs/ledger-live-common/src/bridge/useCurrencyBridge.ts
@@ -1,0 +1,20 @@
+import { use, useMemo } from "react";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import type { CurrencyBridge } from "@ledgerhq/types-live";
+import { getCurrencyBridge } from "./index";
+
+// Temporary: pre-annotates a fulfilled Promise so React.use() returns synchronously today.
+// Remove once getCurrencyBridge returns a Promise natively (LIVE-29176).
+function makeSuspensePromise<T>(value: T): Promise<T> & { status: string; value: T } {
+  const p = Promise.resolve(value) as Promise<T> & { status: string; value: T };
+  p.status = "fulfilled";
+  p.value = value;
+  return p;
+}
+
+export function useCurrencyBridge<T extends CurrencyBridge = CurrencyBridge>(
+  currency: CryptoCurrency,
+): T {
+  const promise = useMemo(() => makeSuspensePromise(getCurrencyBridge(currency)), [currency]);
+  return use(promise) as T;
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.** No behaviour change — hook is a thin synchronous wrapper today.
- [x] **Impact of the changes:** New \`useCurrencyBridge\` hook in \`live-common\`; canton desktop families migrated to use it.

### 📝 Description

Adds `useCurrencyBridge` to `@ledgerhq/live-common/bridge/useCurrencyBridge` — a React hook wrapping
`getCurrencyBridge` via a pre-fulfilled thenable so `React.use()` returns synchronously today while
being Suspense-ready for when `getCurrencyBridge` becomes async (LIVE-29176).

```ts
// before
const bridge = useMemo(() => getCurrencyBridge(currency), [currency]);
// after
const bridge = useCurrencyBridge(currency);
```

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29176](https://ledgerhq.atlassian.net/browse/LIVE-29176) / #16733
- **ADR link (if any)**: N/A


[LIVE-29176]: https://ledgerhq.atlassian.net/browse/LIVE-29176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ