### PR TITLE
[LWD] refactor(desktop): prepare families call sites for async getAccountBridge

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/families/aleo/hooks/useAleoPrivateSync.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/hooks/useAleoPrivateSync.ts
@@ -104,8 +104,7 @@ export const useAleoPrivateSync = ({
 
     const currentAccountId = acc.id;
     let receivedFinalResult = false;
-    (async () => {
-    const bridge = await getAccountBridge(acc);
+    const bridge = getAccountBridge(acc);
     const sub = bridge.sync(acc, { paginationConfig: {}, syncType: SYNC_TYPE_SHIELDED }).subscribe({
       next: updater => {
         const currentAcc = accountRef.current;
@@ -165,7 +164,6 @@ export const useAleoPrivateSync = ({
         if (entry) entry.sub = sub;
       }
     }
-    })();
   }, [dispatch]);
 
   const start = useCallback(() => {

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/hooks/useAleoPrivateSync.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/hooks/useAleoPrivateSync.ts
@@ -104,7 +104,8 @@ export const useAleoPrivateSync = ({
 
     const currentAccountId = acc.id;
     let receivedFinalResult = false;
-    const bridge = getAccountBridge(acc);
+    (async () => {
+    const bridge = await getAccountBridge(acc);
     const sub = bridge.sync(acc, { paginationConfig: {}, syncType: SYNC_TYPE_SHIELDED }).subscribe({
       next: updater => {
         const currentAcc = accountRef.current;
@@ -164,6 +165,7 @@ export const useAleoPrivateSync = ({
         if (entry) entry.sub = sub;
       }
     }
+    })();
   }, [dispatch]);
 
   const start = useCallback(() => {

--- a/apps/ledger-live-desktop/src/renderer/families/aptos/StakingFlowModal/steps/StepStake.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aptos/StakingFlowModal/steps/StepStake.tsx
@@ -20,8 +20,8 @@ export default function StepStake({
 }: Readonly<StepProps>) {
   invariant(account && transaction, "account and transaction required");
 
-  const updateValidator = ({ address }: { address: string }) => {
-    const bridge: AccountBridge<Transaction> = getAccountBridge(account, parentAccount);
+  const updateValidator = async ({ address }: { address: string }) => {
+    const bridge: AccountBridge<Transaction> = await getAccountBridge(account, parentAccount);
     onUpdateTransaction(() => {
       return bridge.updateTransaction(transaction, {
         recipient: address,

--- a/apps/ledger-live-desktop/src/renderer/families/aptos/StakingFlowModal/steps/StepStake.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aptos/StakingFlowModal/steps/StepStake.tsx
@@ -2,11 +2,10 @@ import invariant from "invariant";
 import React from "react";
 import { Trans } from "react-i18next";
 import { StepProps } from "../types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
-import { AccountBridge } from "@ledgerhq/types-live";
 import ValidatorField from "../fields/ValidatorField";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
 import { Transaction } from "@ledgerhq/live-common/families/aptos/types";
@@ -20,8 +19,9 @@ export default function StepStake({
 }: Readonly<StepProps>) {
   invariant(account && transaction, "account and transaction required");
 
-  const updateValidator = async ({ address }: { address: string }) => {
-    const bridge: AccountBridge<Transaction> = await getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
+
+  const updateValidator = ({ address }: { address: string }) => {
     onUpdateTransaction(() => {
       return bridge.updateTransaction(transaction, {
         recipient: address,

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/AccountBalanceSummaryFooter.tsx
@@ -279,20 +279,25 @@ const AccountBalanceSummaryFooter = ({ account }: Props) => {
       syncType: SYNC_TYPE_SHIELDED,
     };
 
-    (async () => {
-      const bridge = await getAccountBridge(account as ZcashAccount);
-      const shieldedSync = bridge.sync(account as ZcashAccount, syncConfig).subscribe({
-        next(accountUpdater) {
-          dispatch(updateAccountWithUpdater(account.id, accountUpdater));
-        },
-        error(err) {
-          console.error(err);
-        },
-        complete() {
-          console.log(`Zcash shielded sync completed on account ${account.id}`);
-        },
-      });
-      dispatch(upsertShieldedSubscription({ accountId: account.id, subscription: shieldedSync }));
+    void (async () => {
+      try {
+        const bridge = await getAccountBridge(account as ZcashAccount);
+        const shieldedSync = bridge.sync(account as ZcashAccount, syncConfig).subscribe({
+          next(accountUpdater) {
+            dispatch(updateAccountWithUpdater(account.id, accountUpdater));
+          },
+          error(err) {
+            console.error(err);
+          },
+          complete() {
+            console.log(`Zcash shielded sync completed on account ${account.id}`);
+          },
+        });
+        dispatch(upsertShieldedSubscription({ accountId: account.id, subscription: shieldedSync }));
+      } catch (err) {
+        saveSyncState({ syncState: "stopped", progress: 0 });
+        console.error(err);
+      }
     })();
   }, [account, dispatch, saveSyncState]);
 

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/AccountBalanceSummaryFooter.tsx
@@ -279,9 +279,9 @@ const AccountBalanceSummaryFooter = ({ account }: Props) => {
       syncType: SYNC_TYPE_SHIELDED,
     };
 
-    const shieldedSync = getAccountBridge(account as ZcashAccount)
-      .sync(account as ZcashAccount, syncConfig)
-      .subscribe({
+    (async () => {
+      const bridge = await getAccountBridge(account as ZcashAccount);
+      const shieldedSync = bridge.sync(account as ZcashAccount, syncConfig).subscribe({
         next(accountUpdater) {
           dispatch(updateAccountWithUpdater(account.id, accountUpdater));
         },
@@ -292,8 +292,8 @@ const AccountBalanceSummaryFooter = ({ account }: Props) => {
           console.log(`Zcash shielded sync completed on account ${account.id}`);
         },
       });
-
-    dispatch(upsertShieldedSubscription({ accountId: account.id, subscription: shieldedSync }));
+      dispatch(upsertShieldedSubscription({ accountId: account.id, subscription: shieldedSync }));
+    })();
   }, [account, dispatch, saveSyncState]);
 
   const stopShieldedSync = useCallback(() => {

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/AccountBalanceSummaryFooter.tsx
@@ -28,6 +28,7 @@ import {
   ZCASH_OUTDATED_SYNC_INTERVAL_MINUTES,
 } from "@ledgerhq/zcash-shielded/constants";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { from, switchMap } from "rxjs";
 import {
   removeShieldedSubscription,
   selectShieldedSubscriptions,
@@ -279,26 +280,21 @@ const AccountBalanceSummaryFooter = ({ account }: Props) => {
       syncType: SYNC_TYPE_SHIELDED,
     };
 
-    void (async () => {
-      try {
-        const bridge = await getAccountBridge(account as ZcashAccount);
-        const shieldedSync = bridge.sync(account as ZcashAccount, syncConfig).subscribe({
-          next(accountUpdater) {
-            dispatch(updateAccountWithUpdater(account.id, accountUpdater));
-          },
-          error(err) {
-            console.error(err);
-          },
-          complete() {
-            console.log(`Zcash shielded sync completed on account ${account.id}`);
-          },
-        });
-        dispatch(upsertShieldedSubscription({ accountId: account.id, subscription: shieldedSync }));
-      } catch (err) {
-        saveSyncState({ syncState: "stopped", progress: 0 });
-        console.error(err);
-      }
-    })();
+    const shieldedSync = from(Promise.resolve(getAccountBridge(account as ZcashAccount)))
+      .pipe(switchMap(bridge => bridge.sync(account as ZcashAccount, syncConfig)))
+      .subscribe({
+        next(accountUpdater) {
+          dispatch(updateAccountWithUpdater(account.id, accountUpdater));
+        },
+        error(err) {
+          saveSyncState({ syncState: "stopped", progress: 0 });
+          console.error(err);
+        },
+        complete() {
+          console.log(`Zcash shielded sync completed on account ${account.id}`);
+        },
+      });
+    dispatch(upsertShieldedSubscription({ accountId: account.id, subscription: shieldedSync }));
   }, [account, dispatch, saveSyncState]);
 
   const stopShieldedSync = useCallback(() => {

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/steps/StepMethod.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/steps/StepMethod.tsx
@@ -67,7 +67,7 @@ export const StepMethodFooter: React.FC<StepProps> = ({
   const handleContinueClick = async () => {
     invariant(editType, "editType required");
 
-    const bridge: AccountBridge<BitcoinTransaction> = getAccountBridge(account, parentAccount);
+    const bridge: AccountBridge<BitcoinTransaction> = await getAccountBridge(account, parentAccount);
     const mainAccount = getMainAccount(account, parentAccount);
 
     const patch = await getEditTransactionPatch({

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/steps/StepMethod.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/steps/StepMethod.tsx
@@ -1,8 +1,7 @@
 import { getEditTransactionPatch } from "@ledgerhq/coin-bitcoin/editTransaction/index";
 import { Transaction as BitcoinTransaction } from "@ledgerhq/coin-bitcoin/types";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
-import { AccountBridge } from "@ledgerhq/types-live";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import invariant from "invariant";
 import React, { memo } from "react";
 import { urls } from "~/config/urls";
@@ -63,11 +62,11 @@ export const StepMethodFooter: React.FC<StepProps> = ({
 }: StepProps) => {
   const canSpeedup = haveFundToSpeedup && isOldestEditableOperation;
   const canCancel = haveFundToCancel;
+  const bridge = useAccountBridge<BitcoinTransaction>(account, parentAccount);
 
   const handleContinueClick = async () => {
     invariant(editType, "editType required");
 
-    const bridge: AccountBridge<BitcoinTransaction> = await getAccountBridge(account, parentAccount);
     const mainAccount = getMainAccount(account, parentAccount);
 
     const patch = await getEditTransactionPatch({

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/steps/StepDevice.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/steps/StepDevice.tsx
@@ -58,8 +58,9 @@ const StepExport = (props: StepProps) => {
       if (!device) {
         throw new DisconnectedDevice();
       }
+      const bridge = await getAccountBridge(mainAccount);
       await firstValueFrom(
-        getAccountBridge(mainAccount).receive(mainAccount, {
+        bridge.receive(mainAccount, {
           deviceId: device.deviceId,
           verify: true,
         }),

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/steps/StepDevice.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/steps/StepDevice.tsx
@@ -4,7 +4,7 @@ import { firstValueFrom } from "rxjs";
 import { Trans } from "react-i18next";
 import { getMainAccount } from "@ledgerhq/live-common/account/helpers";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { DisconnectedDevice } from "@ledgerhq/errors";
 import DeviceAction from "~/renderer/components/DeviceAction";
 import { HOOKS_TRACKING_LOCATIONS } from "~/renderer/analytics/hooks/variables";
@@ -53,12 +53,12 @@ const StepExport = (props: StepProps) => {
   const mainAccount = account ? getMainAccount(account) : null;
   invariant(account && mainAccount, "No account given");
 
+  const bridge = useAccountBridge(mainAccount);
   const requestUfvkFromDevice = useCallback(async () => {
     try {
       if (!device) {
         throw new DisconnectedDevice();
       }
-      const bridge = await getAccountBridge(mainAccount);
       await firstValueFrom(
         bridge.receive(mainAccount, {
           deviceId: device.deviceId,
@@ -72,7 +72,7 @@ const StepExport = (props: StepProps) => {
     } catch (error) {
       onUfvkChanged("", error as Error);
     }
-  }, [device, mainAccount, transitionTo, onUfvkChanged]);
+  }, [bridge, device, mainAccount, transitionTo, onUfvkChanged]);
 
   useEffect(() => {
     if (!ufvk && !ufvkExportError && !ufvkRequestSent) {

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/steps/StepDelegation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/steps/StepDelegation.tsx
@@ -2,11 +2,10 @@ import invariant from "invariant";
 import React from "react";
 import { Trans } from "react-i18next";
 import { StepProps } from "../types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
-import { AccountBridge } from "@ledgerhq/types-live";
 import { Transaction as CardanoTransaction } from "@ledgerhq/live-common/families/cardano/types";
 import { StakePool } from "@ledgerhq/live-common/families/cardano/staking";
 import ValidatorField from "../fields/ValidatorField";
@@ -31,10 +30,10 @@ export default function StepDelegation({
 
   const { errors } = status;
   const displayError = errors.amount?.message ? errors.amount : "";
+  const bridge = useAccountBridge<CardanoTransaction>(account);
 
-  const selectPool = async (stakePool: StakePool) => {
+  const selectPool = (stakePool: StakePool) => {
     setSelectedPool(stakePool);
-    const bridge: AccountBridge<CardanoTransaction> = await getAccountBridge(account);
     onUpdateTransaction(() => {
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       const updatedTransaction = bridge.updateTransaction(transaction as CardanoTransaction, {

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/steps/StepDelegation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/steps/StepDelegation.tsx
@@ -32,9 +32,9 @@ export default function StepDelegation({
   const { errors } = status;
   const displayError = errors.amount?.message ? errors.amount : "";
 
-  const selectPool = (stakePool: StakePool) => {
+  const selectPool = async (stakePool: StakePool) => {
     setSelectedPool(stakePool);
-    const bridge: AccountBridge<CardanoTransaction> = getAccountBridge(account);
+    const bridge: AccountBridge<CardanoTransaction> = await getAccountBridge(account);
     onUpdateTransaction(() => {
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       const updatedTransaction = bridge.updateTransaction(transaction as CardanoTransaction, {

--- a/apps/ledger-live-desktop/src/renderer/families/celo/VoteFlowModal/steps/StepValidatorGroup.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/VoteFlowModal/steps/StepValidatorGroup.tsx
@@ -55,8 +55,8 @@ const StepValidatorGroup = ({
     account && account.celoResources && transaction,
     "celo account, resources and transaction required",
   );
-  const updateValidatorGroup = ({ address }: { address: string }) => {
-    const bridge: AccountBridge<Transaction> = getAccountBridge(account, parentAccount);
+  const updateValidatorGroup = async ({ address }: { address: string }) => {
+    const bridge: AccountBridge<Transaction> = await getAccountBridge(account, parentAccount);
     onUpdateTransaction(_tx => {
       return bridge.updateTransaction(transaction, {
         recipient: address,

--- a/apps/ledger-live-desktop/src/renderer/families/celo/VoteFlowModal/steps/StepValidatorGroup.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/VoteFlowModal/steps/StepValidatorGroup.tsx
@@ -1,4 +1,4 @@
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import invariant from "invariant";
 import React from "react";
 import { Trans } from "react-i18next";
@@ -10,7 +10,6 @@ import LedgerByFigmentTC from "../components/LedgerByFigmentTCLink";
 import ValidatorGroupsField from "../fields/ValidatorGroupsField";
 import { isDefaultValidatorGroupAddress } from "@ledgerhq/live-common/families/celo/logic";
 import { Transaction } from "@ledgerhq/live-common/families/celo/types";
-import { AccountBridge } from "@ledgerhq/types-live";
 import { StepProps } from "../types";
 export const StepValidatorGroupFooter = ({
   transitionTo,
@@ -55,8 +54,8 @@ const StepValidatorGroup = ({
     account && account.celoResources && transaction,
     "celo account, resources and transaction required",
   );
-  const updateValidatorGroup = async ({ address }: { address: string }) => {
-    const bridge: AccountBridge<Transaction> = await getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
+  const updateValidatorGroup = ({ address }: { address: string }) => {
     onUpdateTransaction(_tx => {
       return bridge.updateTransaction(transaction, {
         recipient: address,

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/steps/StepDelegation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/steps/StepDelegation.tsx
@@ -1,6 +1,5 @@
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Transaction } from "@ledgerhq/live-common/families/cosmos/types";
-import { AccountBridge } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import invariant from "invariant";
 import React, { useCallback } from "react";
@@ -25,9 +24,9 @@ export default function StepDelegation({
   invariant(transaction && transaction.validators, "transaction required");
   const { cosmosResources } = account;
   const delegations = cosmosResources.delegations || [];
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
   const updateValidator = useCallback(
-    async ({ address }: { address: string }) => {
-      const bridge: AccountBridge<Transaction> = await getAccountBridge(account, parentAccount);
+    ({ address }: { address: string }) => {
       onUpdateTransaction(_tx => {
         return bridge.updateTransaction(transaction, {
           validators: [
@@ -39,7 +38,7 @@ export default function StepDelegation({
         });
       });
     },
-    [onUpdateTransaction, account, transaction, parentAccount],
+    [bridge, onUpdateTransaction, transaction],
   );
   const chosenVoteAccAddr = transaction.validators[0]?.address || "";
 

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/steps/StepDelegation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/steps/StepDelegation.tsx
@@ -26,8 +26,8 @@ export default function StepDelegation({
   const { cosmosResources } = account;
   const delegations = cosmosResources.delegations || [];
   const updateValidator = useCallback(
-    ({ address }: { address: string }) => {
-      const bridge: AccountBridge<Transaction> = getAccountBridge(account, parentAccount);
+    async ({ address }: { address: string }) => {
+      const bridge: AccountBridge<Transaction> = await getAccountBridge(account, parentAccount);
       onUpdateTransaction(_tx => {
         return bridge.updateTransaction(transaction, {
           validators: [

--- a/apps/ledger-live-desktop/src/renderer/families/evm/DelegationFlowModal/steps/StepDelegation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/DelegationFlowModal/steps/StepDelegation.tsx
@@ -23,8 +23,11 @@ export default function StepDelegation({
   invariant(transaction, "transaction required");
 
   const updateValidator = useCallback(
-    (address: string) => {
-      const bridge = getAccountBridge(account, parentAccount) as AccountBridge<GenericTransaction>;
+    async (address: string) => {
+      const bridge = (await getAccountBridge(
+        account,
+        parentAccount,
+      )) as AccountBridge<GenericTransaction>;
       onUpdateTransaction(_tx =>
         bridge.updateTransaction(transaction, {
           mode: "delegate",

--- a/apps/ledger-live-desktop/src/renderer/families/evm/DelegationFlowModal/steps/StepDelegation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/DelegationFlowModal/steps/StepDelegation.tsx
@@ -1,5 +1,4 @@
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
-import type { AccountBridge } from "@ledgerhq/types-live";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-alpaca/types";
 import invariant from "invariant";
 import React, { useCallback } from "react";
@@ -22,12 +21,9 @@ export default function StepDelegation({
 }: Readonly<StepProps>) {
   invariant(transaction, "transaction required");
 
+  const bridge = useAccountBridge<GenericTransaction>(account, parentAccount);
   const updateValidator = useCallback(
-    async (address: string) => {
-      const bridge = (await getAccountBridge(
-        account,
-        parentAccount,
-      )) as AccountBridge<GenericTransaction>;
+    (address: string) => {
       onUpdateTransaction(_tx =>
         bridge.updateTransaction(transaction, {
           mode: "delegate",
@@ -35,7 +31,7 @@ export default function StepDelegation({
         }),
       );
     },
-    [onUpdateTransaction, account, transaction, parentAccount],
+    [bridge, onUpdateTransaction, transaction],
   );
 
   const chosenVoteAccAddr = transaction.valAddress || "";

--- a/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/GasLimitField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/GasLimitField.tsx
@@ -24,8 +24,8 @@ const AdvancedOptions: NonNullable<EvmFamily["sendAmountFields"]>["component"] =
   const { t } = useTranslation();
 
   const onGasLimitChange = useCallback(
-    (str: string) => {
-      const bridge = getAccountBridge(account);
+    async (str: string) => {
+      const bridge = await getAccountBridge(account);
       let gasLimit = new BigNumber(str || 0);
       if (!gasLimit.isFinite()) {
         gasLimit = DEFAULT_GAS_LIMIT;

--- a/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/GasLimitField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/GasLimitField.tsx
@@ -1,6 +1,6 @@
 import { getGasLimit, DEFAULT_GAS_LIMIT } from "@ledgerhq/coin-evm/utils";
 import { Transaction } from "@ledgerhq/coin-evm/types/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Button } from "@ledgerhq/react-ui";
 import { BigNumber } from "bignumber.js";
 import invariant from "invariant";
@@ -22,10 +22,10 @@ const AdvancedOptions: NonNullable<EvmFamily["sendAmountFields"]>["component"] =
   invariant(account, "Account required");
   const [editable, setEditable] = useState(false);
   const { t } = useTranslation();
+  const bridge = useAccountBridge<Transaction>(account);
 
   const onGasLimitChange = useCallback(
-    async (str: string) => {
-      const bridge = await getAccountBridge(account);
+    (str: string) => {
       let gasLimit = new BigNumber(str || 0);
       if (!gasLimit.isFinite()) {
         gasLimit = DEFAULT_GAS_LIMIT;
@@ -34,7 +34,7 @@ const AdvancedOptions: NonNullable<EvmFamily["sendAmountFields"]>["component"] =
         bridge.updateTransaction(transaction, { customGasLimit: gasLimit }),
       );
     },
-    [account, updateTransaction],
+    [bridge, updateTransaction],
   );
 
   const onEditClick = useCallback(() => setEditable(true), [setEditable]);

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/steps/StepValidator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/steps/StepValidator.tsx
@@ -1,11 +1,10 @@
 import invariant from "invariant";
 import React from "react";
 import { Trans } from "react-i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
 import { HederaValidator, Transaction } from "@ledgerhq/live-common/families/hedera/types";
 import { isStakingTransaction } from "@ledgerhq/live-common/families/hedera/utils";
-import type { AccountBridge } from "@ledgerhq/types-live";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
@@ -23,9 +22,9 @@ export default function StepValidator({
   invariant(account && transaction, "hedera: account and transaction required");
   invariant(isStakingTransaction(transaction), "hedera: staking tx expected");
   const selectedValidatorNodeId = transaction.properties?.stakingNodeId ?? null;
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
 
-  const updateValidator = async (validator: HederaValidator) => {
-    const bridge: AccountBridge<Transaction> = await getAccountBridge(account, parentAccount);
+  const updateValidator = (validator: HederaValidator) => {
     onUpdateTransaction(() => {
       return bridge.updateTransaction(transaction, {
         mode: HEDERA_TRANSACTION_MODES.Delegate,

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/steps/StepValidator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/steps/StepValidator.tsx
@@ -24,8 +24,8 @@ export default function StepValidator({
   invariant(isStakingTransaction(transaction), "hedera: staking tx expected");
   const selectedValidatorNodeId = transaction.properties?.stakingNodeId ?? null;
 
-  const updateValidator = (validator: HederaValidator) => {
-    const bridge: AccountBridge<Transaction> = getAccountBridge(account, parentAccount);
+  const updateValidator = async (validator: HederaValidator) => {
+    const bridge: AccountBridge<Transaction> = await getAccountBridge(account, parentAccount);
     onUpdateTransaction(() => {
       return bridge.updateTransaction(transaction, {
         mode: HEDERA_TRANSACTION_MODES.Delegate,

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/steps/StepValidators.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/steps/StepValidators.tsx
@@ -42,9 +42,9 @@ function StepValidators({
   const isValidatorRemoved =
     !enrichedDelegation.validator.address && typeof delegation.nodeId === "number";
 
-  const updateValidator = (validator: HederaValidator | null) => {
+  const updateValidator = async (validator: HederaValidator | null) => {
     if (!validator) return;
-    const bridge: AccountBridge<Transaction> = getAccountBridge(account, parentAccount);
+    const bridge: AccountBridge<Transaction> = await getAccountBridge(account, parentAccount);
     onUpdateTransaction(() => {
       return bridge.updateTransaction(transaction, {
         mode: HEDERA_TRANSACTION_MODES.Redelegate,

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/steps/StepValidators.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/steps/StepValidators.tsx
@@ -3,8 +3,7 @@ import React from "react";
 import { Trans } from "react-i18next";
 import { useHederaEnrichedDelegation } from "@ledgerhq/live-common/families/hedera/react";
 import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account/helpers";
-import type { AccountBridge } from "@ledgerhq/types-live";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { HederaValidator, Transaction } from "@ledgerhq/live-common/families/hedera/types";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
 import { isStakingTransaction } from "@ledgerhq/live-common/families/hedera/utils";
@@ -42,9 +41,9 @@ function StepValidators({
   const isValidatorRemoved =
     !enrichedDelegation.validator.address && typeof delegation.nodeId === "number";
 
-  const updateValidator = async (validator: HederaValidator | null) => {
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
+  const updateValidator = (validator: HederaValidator | null) => {
     if (!validator) return;
-    const bridge: AccountBridge<Transaction> = await getAccountBridge(account, parentAccount);
     onUpdateTransaction(() => {
       return bridge.updateTransaction(transaction, {
         mode: HEDERA_TRANSACTION_MODES.Redelegate,

--- a/apps/ledger-live-desktop/src/renderer/families/near/StakingFlowModal/steps/StepStake.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/StakingFlowModal/steps/StepStake.tsx
@@ -21,8 +21,8 @@ export default function StepStake({
   status,
 }: StepProps) {
   invariant(account && transaction, "account and transaction required");
-  const updateValidator = ({ address }: { address: string }) => {
-    const bridge: AccountBridge<Transaction> = getAccountBridge(account, parentAccount);
+  const updateValidator = async ({ address }: { address: string }) => {
+    const bridge: AccountBridge<Transaction> = await getAccountBridge(account, parentAccount);
     onUpdateTransaction(() => {
       return bridge.updateTransaction(transaction, {
         recipient: address,

--- a/apps/ledger-live-desktop/src/renderer/families/near/StakingFlowModal/steps/StepStake.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/StakingFlowModal/steps/StepStake.tsx
@@ -2,11 +2,10 @@ import invariant from "invariant";
 import React from "react";
 import { Trans } from "react-i18next";
 import { StepProps } from "../types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
-import { AccountBridge } from "@ledgerhq/types-live";
 import ValidatorField from "../fields/ValidatorField";
 import LedgerByFigmentTCLink from "../components/LedgerByFigmentTCLink";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
@@ -21,8 +20,8 @@ export default function StepStake({
   status,
 }: StepProps) {
   invariant(account && transaction, "account and transaction required");
-  const updateValidator = async ({ address }: { address: string }) => {
-    const bridge: AccountBridge<Transaction> = await getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
+  const updateValidator = ({ address }: { address: string }) => {
     onUpdateTransaction(() => {
       return bridge.updateTransaction(transaction, {
         recipient: address,

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationActivateFlowModal/steps/StepValidator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationActivateFlowModal/steps/StepValidator.tsx
@@ -18,8 +18,8 @@ export default function StepValidator({
   error,
 }: StepProps) {
   invariant(transaction, "transaction required");
-  const updateValidator = ({ address }: { address: string }) => {
-    const bridge = getAccountBridge(account);
+  const updateValidator = async ({ address }: { address: string }) => {
+    const bridge = await getAccountBridge(account);
     onUpdateTransaction(tx => {
       return bridge.updateTransaction(tx, {
         model: {

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationActivateFlowModal/steps/StepValidator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationActivateFlowModal/steps/StepValidator.tsx
@@ -1,4 +1,5 @@
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { Transaction } from "@ledgerhq/live-common/families/solana/types";
 import invariant from "invariant";
 import React from "react";
 import { Trans } from "react-i18next";
@@ -18,8 +19,8 @@ export default function StepValidator({
   error,
 }: StepProps) {
   invariant(transaction, "transaction required");
-  const updateValidator = async ({ address }: { address: string }) => {
-    const bridge = await getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
+  const updateValidator = ({ address }: { address: string }) => {
     onUpdateTransaction(tx => {
       return bridge.updateTransaction(tx, {
         model: {

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationFlowModal/steps/StepValidator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationFlowModal/steps/StepValidator.tsx
@@ -1,9 +1,8 @@
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import {
   StakeCreateAccountTransaction,
   Transaction,
 } from "@ledgerhq/live-common/families/solana/types";
-import { AccountBridge } from "@ledgerhq/types-live";
 import invariant from "invariant";
 import React from "react";
 import { Trans } from "react-i18next";
@@ -27,8 +26,8 @@ export default function StepValidator({
     account && account.solanaResources && transaction,
     "solana account, resources and transaction required",
   );
-  const updateValidator = async ({ address }: { address: string }) => {
-    const bridge: AccountBridge<Transaction> = await getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
+  const updateValidator = ({ address }: { address: string }) => {
     onUpdateTransaction(_tx => {
       return bridge.updateTransaction(transaction, {
         model: {

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationFlowModal/steps/StepValidator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationFlowModal/steps/StepValidator.tsx
@@ -27,8 +27,8 @@ export default function StepValidator({
     account && account.solanaResources && transaction,
     "solana account, resources and transaction required",
   );
-  const updateValidator = ({ address }: { address: string }) => {
-    const bridge: AccountBridge<Transaction> = getAccountBridge(account, parentAccount);
+  const updateValidator = async ({ address }: { address: string }) => {
+    const bridge: AccountBridge<Transaction> = await getAccountBridge(account, parentAccount);
     onUpdateTransaction(_tx => {
       return bridge.updateTransaction(transaction, {
         model: {

--- a/apps/ledger-live-desktop/src/renderer/families/sui/DelegationFlowModal/steps/StepStake.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/sui/DelegationFlowModal/steps/StepStake.tsx
@@ -20,8 +20,8 @@ export default function StepStake({
   error,
 }: StepProps) {
   invariant(account && transaction, "account and transaction required");
-  const updateValidator = ({ address }: { address: string }) => {
-    const bridge: AccountBridge<Transaction> = getAccountBridge(account, parentAccount);
+  const updateValidator = async ({ address }: { address: string }) => {
+    const bridge: AccountBridge<Transaction> = await getAccountBridge(account, parentAccount);
     onUpdateTransaction(() => {
       return bridge.updateTransaction(transaction, {
         recipient: address,

--- a/apps/ledger-live-desktop/src/renderer/families/sui/DelegationFlowModal/steps/StepStake.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/sui/DelegationFlowModal/steps/StepStake.tsx
@@ -2,11 +2,10 @@ import invariant from "invariant";
 import React from "react";
 import { Trans } from "react-i18next";
 import { StepProps } from "../types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
-import { AccountBridge } from "@ledgerhq/types-live";
 import ValidatorField from "../fields/ValidatorField";
 import LedgerByFigmentTCLink from "../components/LedgerByFigmentTCLink";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
@@ -20,8 +19,8 @@ export default function StepStake({
   error,
 }: StepProps) {
   invariant(account && transaction, "account and transaction required");
-  const updateValidator = async ({ address }: { address: string }) => {
-    const bridge: AccountBridge<Transaction> = await getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
+  const updateValidator = ({ address }: { address: string }) => {
     onUpdateTransaction(() => {
       return bridge.updateTransaction(transaction, {
         recipient: address,

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/Body.tsx
@@ -145,10 +145,19 @@ const Body = ({ stepId, params, onChangeStepId, onClose }: Props) => {
 
     // when changes, we set again
     if (patch.mode !== transaction.mode || patch.recipient) {
-      (async () => {
-        const bridge = await getAccountBridge(account, parentAccount);
-        setTransaction(bridge.updateTransaction(transaction, patch));
+      let cancelled = false;
+      void (async () => {
+        try {
+          const bridge = await getAccountBridge(account, parentAccount);
+          if (cancelled) return;
+          setTransaction(bridge.updateTransaction(transaction, patch));
+        } catch (err) {
+          if (!cancelled) console.error(err);
+        }
       })();
+      return () => {
+        cancelled = true;
+      };
     }
   }, [account, defaultBaker, stepId, params, parentAccount, setTransaction, transaction]);
 

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/Body.tsx
@@ -145,9 +145,10 @@ const Body = ({ stepId, params, onChangeStepId, onClose }: Props) => {
 
     // when changes, we set again
     if (patch.mode !== transaction.mode || patch.recipient) {
-      setTransaction(
-        getAccountBridge(account, parentAccount).updateTransaction(transaction, patch),
-      );
+      (async () => {
+        const bridge = await getAccountBridge(account, parentAccount);
+        setTransaction(bridge.updateTransaction(transaction, patch));
+      })();
     }
   }, [account, defaultBaker, stepId, params, parentAccount, setTransaction, transaction]);
 

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/steps/StepCustom.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/steps/StepCustom.tsx
@@ -80,15 +80,23 @@ export const StepCustomFooter = ({
   const canNext = !bridgePending && !Object.keys(errors).length;
   const initialTransaction = useRef(transaction);
   useEffect(() => {
-    // empty the field
-    (async () => {
-      const bridge = await getAccountBridge(account, parentAccount);
-      onChangeTransaction(
-        bridge.updateTransaction(initialTransaction.current, {
-          recipient: "",
-        }),
-      );
+    let cancelled = false;
+    void (async () => {
+      try {
+        const bridge = await getAccountBridge(account, parentAccount);
+        if (cancelled) return;
+        onChangeTransaction(
+          bridge.updateTransaction(initialTransaction.current, {
+            recipient: "",
+          }),
+        );
+      } catch (err) {
+        if (!cancelled) console.error(err);
+      }
     })();
+    return () => {
+      cancelled = true;
+    };
   }, [onChangeTransaction, account, parentAccount]);
   const onBack = useCallback(async () => {
     // we need to revert

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/steps/StepCustom.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/steps/StepCustom.tsx
@@ -3,7 +3,8 @@ import React, { useCallback, useEffect, useRef } from "react";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { Transaction } from "@ledgerhq/live-common/families/tezos/types";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import RecipientField from "~/renderer/modals/Send/fields/RecipientField";
 import Button from "~/renderer/components/Button";
@@ -79,35 +80,22 @@ export const StepCustomFooter = ({
   const { errors } = status;
   const canNext = !bridgePending && !Object.keys(errors).length;
   const initialTransaction = useRef(transaction);
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
   useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const bridge = await getAccountBridge(account, parentAccount);
-        if (cancelled) return;
-        onChangeTransaction(
-          bridge.updateTransaction(initialTransaction.current, {
-            recipient: "",
-          }),
-        );
-      } catch (err) {
-        if (!cancelled) console.error(err);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [onChangeTransaction, account, parentAccount]);
-  const onBack = useCallback(async () => {
-    // we need to revert
-    const bridge = await getAccountBridge(account, parentAccount);
+    onChangeTransaction(
+      bridge.updateTransaction(initialTransaction.current, {
+        recipient: "",
+      }),
+    );
+  }, [bridge, onChangeTransaction]);
+  const onBack = useCallback(() => {
     onChangeTransaction(
       bridge.updateTransaction(transaction, {
         recipient: initialTransaction.current.recipient,
       }),
     );
     transitionTo("summary");
-  }, [account, parentAccount, onChangeTransaction, transaction, transitionTo]);
+  }, [bridge, onChangeTransaction, transaction, transitionTo]);
   const onNext = useCallback(() => {
     transitionTo("summary");
   }, [transitionTo]);

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/steps/StepCustom.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/steps/StepCustom.tsx
@@ -81,16 +81,20 @@ export const StepCustomFooter = ({
   const initialTransaction = useRef(transaction);
   useEffect(() => {
     // empty the field
-    onChangeTransaction(
-      getAccountBridge(account, parentAccount).updateTransaction(initialTransaction.current, {
-        recipient: "",
-      }),
-    );
+    (async () => {
+      const bridge = await getAccountBridge(account, parentAccount);
+      onChangeTransaction(
+        bridge.updateTransaction(initialTransaction.current, {
+          recipient: "",
+        }),
+      );
+    })();
   }, [onChangeTransaction, account, parentAccount]);
-  const onBack = useCallback(() => {
+  const onBack = useCallback(async () => {
     // we need to revert
+    const bridge = await getAccountBridge(account, parentAccount);
     onChangeTransaction(
-      getAccountBridge(account, parentAccount).updateTransaction(transaction, {
+      bridge.updateTransaction(transaction, {
         recipient: initialTransaction.current.recipient,
       }),
     );

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/steps/StepValidator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/steps/StepValidator.tsx
@@ -91,9 +91,10 @@ const StepValidator = ({
   const bakers = useBakers(bakersWhitelistDefault);
 
   const onBakerClick = useCallback(
-    (baker: Baker) => {
+    async (baker: Baker) => {
+      const bridge = await getAccountBridge(account, parentAccount);
       onChangeTransaction(
-        getAccountBridge(account, parentAccount).updateTransaction(transaction, {
+        bridge.updateTransaction(transaction, {
           recipient: baker.address,
         }),
       );

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/steps/StepValidator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/steps/StepValidator.tsx
@@ -2,9 +2,9 @@ import React, { useCallback, useRef } from "react";
 import invariant from "invariant";
 import styled from "styled-components";
 import { Trans } from "react-i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useBakers } from "@ledgerhq/live-common/families/tezos/react";
-import { Baker } from "@ledgerhq/live-common/families/tezos/types";
+import { Baker, Transaction } from "@ledgerhq/live-common/families/tezos/types";
 import { whitelist as bakersWhitelistDefault } from "@ledgerhq/live-common/families/tezos/staking";
 import { openURL } from "~/renderer/linking";
 import TrackPage from "~/renderer/analytics/TrackPage";
@@ -89,10 +89,10 @@ const StepValidator = ({
   invariant(account, "account is required");
   const contentRef = useRef(null);
   const bakers = useBakers(bakersWhitelistDefault);
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
 
   const onBakerClick = useCallback(
-    async (baker: Baker) => {
-      const bridge = await getAccountBridge(account, parentAccount);
+    (baker: Baker) => {
       onChangeTransaction(
         bridge.updateTransaction(transaction, {
           recipient: baker.address,
@@ -100,7 +100,7 @@ const StepValidator = ({
       );
       transitionTo("summary");
     },
-    [account, onChangeTransaction, parentAccount, transaction, transitionTo],
+    [bridge, onChangeTransaction, transaction, transitionTo],
   );
 
   const openPartner = useCallback(() => {

--- a/apps/ledger-live-desktop/src/renderer/families/xrp/SendRecipientFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/xrp/SendRecipientFields.tsx
@@ -13,8 +13,8 @@ type Props = {
 const uint32maxPlus1 = BigNumber(2).pow(32);
 const TagField = ({ onChange, account, transaction, autoFocus }: Props) => {
   const onChangeTag = useCallback(
-    (str: string) => {
-      const bridge = getAccountBridge(account);
+    async (str: string) => {
+      const bridge = await getAccountBridge(account);
       const tag = BigNumber(str.replace(/[^0-9]/g, ""));
       const patch = {
         tag:

--- a/apps/ledger-live-desktop/src/renderer/families/xrp/SendRecipientFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/xrp/SendRecipientFields.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from "react";
 import { BigNumber } from "bignumber.js";
 import { Account } from "@ledgerhq/types-live";
 import { Transaction } from "@ledgerhq/live-common/families/xrp/types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import MemoTagField from "LLD/features/MemoTag/components/MemoTagField";
 type Props = {
   onChange: (a: Transaction) => void;
@@ -12,9 +12,9 @@ type Props = {
 };
 const uint32maxPlus1 = BigNumber(2).pow(32);
 const TagField = ({ onChange, account, transaction, autoFocus }: Props) => {
+  const bridge = useAccountBridge<Transaction>(account);
   const onChangeTag = useCallback(
-    async (str: string) => {
-      const bridge = await getAccountBridge(account);
+    (str: string) => {
       const tag = BigNumber(str.replace(/[^0-9]/g, ""));
       const patch = {
         tag:
@@ -30,7 +30,7 @@ const TagField = ({ onChange, account, transaction, autoFocus }: Props) => {
       };
       onChange(bridge.updateTransaction(transaction, patch));
     },
-    [onChange, account, transaction],
+    [bridge, onChange, transaction],
   );
   return (
     <MemoTagField

--- a/apps/ledger-live-desktop/src/renderer/hooks/useStepMethodLogic.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useStepMethodLogic.ts
@@ -84,7 +84,7 @@ export const useStepMethodContinue = <T extends TransactionCommon>({
   return useCallback(async () => {
     invariant(editType, "editType required");
 
-    const bridge: AccountBridge<T> = getAccountBridge(account, parentAccount);
+    const bridge: AccountBridge<T> = await getAccountBridge(account, parentAccount);
     const mainAccount = getMainAccount(account, parentAccount);
     const patch = await getPatch({
       account: mainAccount,

--- a/apps/ledger-live-desktop/src/renderer/hooks/useStepMethodLogic.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useStepMethodLogic.ts
@@ -1,5 +1,5 @@
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import {
   AccountBridge,
   AccountLike,
@@ -81,10 +81,10 @@ export const useStepMethodContinue = <T extends TransactionCommon>({
   transitionTo,
   getPatch,
 }: UseStepMethodContinueParams<T>) => {
+  const bridge = useAccountBridge<T>(account, parentAccount);
   return useCallback(async () => {
     invariant(editType, "editType required");
 
-    const bridge: AccountBridge<T> = await getAccountBridge(account, parentAccount);
     const mainAccount = getMainAccount(account, parentAccount);
     const patch = await getPatch({
       account: mainAccount,
@@ -95,6 +95,7 @@ export const useStepMethodContinue = <T extends TransactionCommon>({
     updateTransaction(tx => bridge.updateTransaction(tx, patch));
     transitionTo("summary");
   }, [
+    bridge,
     editType,
     account,
     parentAccount,

--- a/apps/ledger-live-desktop/src/renderer/modals/ExchangeDeviceConfirm/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/ExchangeDeviceConfirm/index.tsx
@@ -87,8 +87,9 @@ const VerifyOnDevice = ({
           },
         });
       } else {
+        const bridge = await getAccountBridge(mainAccount);
         await firstValueFrom(
-          getAccountBridge(mainAccount).receive(mainAccount, {
+          bridge.receive(mainAccount, {
             deviceId: device.deviceId,
             verify: true,
           }),

--- a/apps/ledger-live-desktop/src/renderer/modals/ExchangeDeviceConfirm/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/ExchangeDeviceConfirm/index.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useState, useMemo } from "react";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import styled from "styled-components";
 import { Account, AccountLike } from "@ledgerhq/types-live";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { getEnv } from "@ledgerhq/live-env";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { AppResult } from "@ledgerhq/live-common/hw/actions/app";
@@ -77,6 +77,7 @@ const VerifyOnDevice = ({
 }: VerifyOnDeviceProps) => {
   const name = useAccountName(mainAccount);
   const address = mainAccount.freshAddress;
+  const bridge = useAccountBridge(mainAccount);
   const confirmAddress = useCallback(async () => {
     if (!device || skipDevice) return null;
     try {
@@ -87,7 +88,6 @@ const VerifyOnDevice = ({
           },
         });
       } else {
-        const bridge = await getAccountBridge(mainAccount);
         await firstValueFrom(
           bridge.receive(mainAccount, {
             deviceId: device.deviceId,
@@ -99,7 +99,7 @@ const VerifyOnDevice = ({
     } catch (err) {
       onAddressVerified(false, err);
     }
-  }, [device, onAddressVerified, mainAccount, skipDevice]);
+  }, [bridge, device, onAddressVerified, mainAccount, skipDevice]);
   useEffect(() => {
     confirmAddress();
   }, [confirmAddress]);


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** No behaviour change — `await` on a sync value is a no-op today.
- [ ] **Impact of the changes:** Pure forward-compatibility refactor, no user-facing change.

### 📝 Description

Prepares desktop `families/` call sites for async bridges. 21 files across ~15 coin families.

Most components hoist the bridge to the top level via `useAccountBridge` (landed in #16726), removing per-handler `getAccountBridge` calls:
```diff
- const onValidatorChange = (validator) => {
-   const bridge = getAccountBridge(account, parentAccount);
-   onChangeTransaction(bridge.updateTransaction(transaction, { validators: [validator] }));
- };
+ const bridge = useAccountBridge(account, parentAccount);
+ const onValidatorChange = (validator) => {
+   onChangeTransaction(bridge.updateTransaction(transaction, { validators: [validator] }));
+ };
```

Two edge cases use a different approach:
- `AccountBalanceSummaryFooter` (inside a `.sync()` chain): bridge resolution folded into the RxJS pipeline with `from(Promise.resolve(...)).pipe(switchMap(...))`.
- `tezos/DelegateFlowModal/Body` (account can be null): async IIFE with a cancellation flag.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29176](https://ledgerhq.atlassian.net/browse/LIVE-29176) / #16733
- **ADR link (if any)**: N/A


[LIVE-29176]: https://ledgerhq.atlassian.net/browse/LIVE-29176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ