### PR TITLE
[LWD] refactor(desktop): prepare useScanAccounts for async getCurrencyBridge

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/ScanAccounts/useScanAccounts.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/ScanAccounts/useScanAccounts.ts
@@ -87,31 +87,38 @@ export function useScanAccounts({
   }, []);
 
   useEffect(() => {
-    const bridge = getCurrencyBridge(currency);
-    scanSubscriptionRef.current = concat(
-      from(prepareCurrency(currency)).pipe(RX.ignoreElements()),
-      bridge.scanAccounts({
-        currency,
-        deviceId,
-        syncConfig: {
-          paginationConfig: {
-            operations: 0,
+    let cancelled = false;
+    (async () => {
+      const bridge = await getCurrencyBridge(currency);
+      if (cancelled) return;
+      scanSubscriptionRef.current = concat(
+        from(prepareCurrency(currency)).pipe(RX.ignoreElements()),
+        bridge.scanAccounts({
+          currency,
+          deviceId,
+          syncConfig: {
+            paginationConfig: {
+              operations: 0,
+            },
+            blacklistedTokenIds: blacklistedTokenIds || [],
           },
-          blacklistedTokenIds: blacklistedTokenIds || [],
-        },
-      }),
-    )
-      .pipe(RX.scan((acc: Account[], { account }) => [...acc, account], []))
-      .subscribe({
-        next: accounts => {
-          setScannedAccounts(accounts);
-          setScanning(true);
-        },
-        error: setError,
-        complete: () => setScanning(false),
-      });
+        }),
+      )
+        .pipe(RX.scan((acc: Account[], { account }) => [...acc, account], []))
+        .subscribe({
+          next: (accounts: Account[]) => {
+            setScannedAccounts(accounts);
+            setScanning(true);
+          },
+          error: setError,
+          complete: () => setScanning(false),
+        });
+    })();
 
-    return () => stopSubscription(false);
+    return () => {
+      cancelled = true;
+      stopSubscription(false);
+    };
   }, [blacklistedTokenIds, currency, deviceId, stopSubscription]);
 
   useEffect(() => {


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** No behaviour change — `await` on a sync value is a no-op today.
- [ ] **Impact of the changes:** Pure forward-compatibility refactor, no user-facing change.

### 📝 Description

Prepares desktop `useScanAccounts` `getCurrencyBridge` call site for when the bridge becomes async. No behaviour change today.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29176](https://ledgerhq.atlassian.net/browse/LIVE-29176) / #16733
- **ADR link (if any)**: N/A


[LIVE-29176]: https://ledgerhq.atlassian.net/browse/LIVE-29176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ