### PR TITLE
[LWM] refactor(mobile): prepare bridge call sites for async getAccountBridge/getCurrencyBridge

### DIFF
--- a/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
+++ b/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
@@ -1,6 +1,6 @@
 import invariant from "invariant";
 import { concat, of, from, Subscription } from "rxjs";
-import { concatMap, filter } from "rxjs/operators";
+import { concatMap, filter, mergeMap } from "rxjs/operators";
 import { useState, useCallback, useEffect, useRef } from "react";
 import { Platform } from "react-native";
 import { log } from "@ledgerhq/logs";
@@ -95,7 +95,6 @@ export const useSignWithDevice = ({
   const mevProtected = useSelector(mevProtectionSelector);
   const signWithDevice = useCallback(() => {
     const { deviceId, transaction } = route.params || {};
-    const bridge = getAccountBridge(account, parentAccount);
     const mainAccount = getMainAccount(account, parentAccount);
 
     navigation.setOptions({
@@ -107,36 +106,42 @@ export const useSignWithDevice = ({
       "transaction-summary",
       `✔️ transaction ${transaction && formatTransaction(transaction, mainAccount)}`,
     );
-    subscription.current = bridge
-      .signOperation({
-        account: mainAccount,
-        transaction,
-        // FIXME: deviceId could be undefined apparently
-        deviceId: deviceId!,
-      })
+    subscription.current = from(Promise.resolve(getAccountBridge(account, parentAccount)))
       .pipe(
-        // FIXME later we will need to treat more events
-        filter(e => e.type === "signed"),
-        concatMap(
-          (
-            e, // later we will have more events
-          ) =>
-            concat(
-              of(e),
-              from(
-                bridge
-                  .broadcast({
-                    account: mainAccount,
-                    signedOperation: (e as { signedOperation: SignedOperation }).signedOperation,
-                    broadcastConfig: {
-                      mevProtected,
-                      source: { type: "coin-module", name: "ledger-live-mobile" },
-                    },
-                  })
-                  .then(operation => ({
-                    type: "broadcasted",
-                    operation,
-                  })),
+        mergeMap(bridge =>
+          bridge
+            .signOperation({
+              account: mainAccount,
+              transaction,
+              // FIXME: deviceId could be undefined apparently
+              deviceId: deviceId!,
+            })
+            .pipe(
+              // FIXME later we will need to treat more events
+              filter(e => e.type === "signed"),
+              concatMap(
+                (
+                  e, // later we will have more events
+                ) =>
+                  concat(
+                    of(e),
+                    from(
+                      bridge
+                        .broadcast({
+                          account: mainAccount,
+                          signedOperation: (e as { signedOperation: SignedOperation })
+                            .signedOperation,
+                          broadcastConfig: {
+                            mevProtected,
+                            source: { type: "coin-module", name: "ledger-live-mobile" },
+                          },
+                        })
+                        .then(operation => ({
+                          type: "broadcasted",
+                          operation,
+                        })),
+                    ),
+                  ),
               ),
             ),
         ),
@@ -231,7 +236,7 @@ export const broadcastSignedTx = async (
 ): Promise<Operation> => {
   invariant(account, "account not present");
   const mainAccount = getMainAccount(account, parentAccount);
-  const bridge = getAccountBridge(account, parentAccount);
+  const bridge = await getAccountBridge(account, parentAccount);
 
   if (getEnv("DISABLE_TRANSACTION_BROADCAST")) {
     return Promise.resolve(signedOperation.operation);

--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
@@ -1,7 +1,7 @@
 import { useNavigation, useRoute } from "@react-navigation/core";
 import { useEffect, useCallback, useState, useRef, useMemo } from "react";
 import { concat, from, Subscription } from "rxjs";
-import { ignoreElements } from "rxjs/operators";
+import { ignoreElements, mergeMap } from "rxjs/operators";
 import { useDispatch } from "~/context/hooks";
 import { isAccountEmpty } from "@ledgerhq/live-common/account/index";
 import uniq from "lodash/uniq";
@@ -79,7 +79,6 @@ export default function useScanDeviceAccountsViewModel({
   );
   const startSubscription = useCallback(() => {
     const cryptoCurrency = isTokenCurrency(currency) ? currency.parentCurrency : currency;
-    const bridge = getCurrencyBridge(cryptoCurrency);
     const syncConfig = {
       paginationConfig: {
         operations: 0,
@@ -87,23 +86,29 @@ export default function useScanDeviceAccountsViewModel({
       blacklistedTokenIds,
     };
     // will be set to false if an existing account is found
-    scanSubscription.current = concat(
-      from(prepareCurrency(cryptoCurrency)).pipe(ignoreElements()),
-      bridge.scanAccounts({
-        currency: cryptoCurrency,
-        deviceId,
-        syncConfig,
-      }),
-    ).subscribe({
-      next: ({ account }) => {
-        setLatestScannedAccount(account);
-      },
-      complete: () => setScanning(false),
-      error: error => {
-        logger.critical(error);
-        setError(error);
-      },
-    });
+    scanSubscription.current = from(Promise.resolve(getCurrencyBridge(cryptoCurrency)))
+      .pipe(
+        mergeMap(bridge =>
+          concat(
+            from(prepareCurrency(cryptoCurrency)).pipe(ignoreElements()),
+            bridge.scanAccounts({
+              currency: cryptoCurrency,
+              deviceId,
+              syncConfig,
+            }),
+          ),
+        ),
+      )
+      .subscribe({
+        next: ({ account }) => {
+          setLatestScannedAccount(account);
+        },
+        complete: () => setScanning(false),
+        error: error => {
+          logger.critical(error);
+          setError(error);
+        },
+      });
   }, [blacklistedTokenIds, currency, deviceId]);
 
   const restartSubscription = useCallback(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useFeePresetFiatValues.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useFeePresetFiatValues.test.ts
@@ -1,14 +1,14 @@
 import { renderHook, waitFor } from "@testing-library/react-native";
 import BigNumber from "bignumber.js";
 import { useFeePresetFiatValues } from "../useFeePresetFiatValues";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useCalculateCountervalueCallback } from "@ledgerhq/live-countervalues-react";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import type { Account } from "@ledgerhq/types-live";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import type { Currency, Unit } from "@ledgerhq/types-cryptoassets";
 
-jest.mock("@ledgerhq/live-common/bridge/index");
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge");
 jest.mock("@ledgerhq/live-countervalues-react");
 jest.mock("@ledgerhq/live-common/currencies/index");
 
@@ -77,8 +77,8 @@ describe("useFeePresetFiatValues", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest
-      .mocked(getAccountBridge)
-      .mockReturnValue(mockBridge as unknown as ReturnType<typeof getAccountBridge>);
+      .mocked(useAccountBridge)
+      .mockReturnValue(mockBridge as unknown as ReturnType<typeof useAccountBridge>);
     jest
       .mocked(useCalculateCountervalueCallback)
       .mockReturnValue(

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useFeePresetFiatValues.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useFeePresetFiatValues.ts
@@ -2,7 +2,7 @@ import { useMemo, useRef, useState } from "react";
 import { BigNumber } from "bignumber.js";
 import type { Account, AccountBridge, AccountLike } from "@ledgerhq/types-live";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { FeePresetOption } from "./useFeePresetOptions";
 import { useCalculateCountervalueCallback } from "@ledgerhq/live-countervalues-react";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
@@ -111,6 +111,7 @@ export function useFeePresetFiatValues({
   enabled,
   shouldEstimateWithBridge,
 }: Params): FeeFiatMap {
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
   const convertCountervalue = useCalculateCountervalueCallback({ to: counterValueCurrency });
   const [fiatByPreset, setFiatByPreset] = useState<FeeFiatMap>({});
 
@@ -178,21 +179,17 @@ export function useFeePresetFiatValues({
     requestIdRef.current += 1;
     const requestId = requestIdRef.current;
 
-    queueMicrotask(() => {
-      Promise.resolve(getAccountBridge(account, parentAccount ?? undefined)).then(bridge =>
-        estimateFiatValuesForPresets({
-          bridge,
-          mainAccount,
-          transaction,
-          presetIds,
-          convertCountervalue,
-          fiatUnit,
-          locale,
-          requestId,
-          requestIdRef,
-          setFiatByPreset,
-        }),
-      );
+    estimateFiatValuesForPresets({
+      bridge,
+      mainAccount,
+      transaction,
+      presetIds,
+      convertCountervalue,
+      fiatUnit,
+      locale,
+      requestId,
+      requestIdRef,
+      setFiatByPreset,
     });
   }
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useFeePresetFiatValues.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useFeePresetFiatValues.ts
@@ -1,6 +1,6 @@
 import { useMemo, useRef, useState } from "react";
 import { BigNumber } from "bignumber.js";
-import type { Account, AccountLike } from "@ledgerhq/types-live";
+import type { Account, AccountBridge, AccountLike } from "@ledgerhq/types-live";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import type { FeePresetOption } from "./useFeePresetOptions";
@@ -47,7 +47,7 @@ type Params = Readonly<{
 }>;
 
 async function estimateFiatValuesForPresets(params: {
-  bridge: ReturnType<typeof getAccountBridge>;
+  bridge: AccountBridge<Transaction>;
   mainAccount: Account;
   transaction: Transaction;
   presetIds: readonly string[];
@@ -178,21 +178,21 @@ export function useFeePresetFiatValues({
     requestIdRef.current += 1;
     const requestId = requestIdRef.current;
 
-    const bridge = getAccountBridge(account, parentAccount ?? undefined);
-
     queueMicrotask(() => {
-      estimateFiatValuesForPresets({
-        bridge,
-        mainAccount,
-        transaction,
-        presetIds,
-        convertCountervalue,
-        fiatUnit,
-        locale,
-        requestId,
-        requestIdRef,
-        setFiatByPreset,
-      });
+      Promise.resolve(getAccountBridge(account, parentAccount ?? undefined)).then(bridge =>
+        estimateFiatValuesForPresets({
+          bridge,
+          mainAccount,
+          transaction,
+          presetIds,
+          convertCountervalue,
+          fiatUnit,
+          locale,
+          requestId,
+          requestIdRef,
+          setFiatByPreset,
+        }),
+      );
     });
   }
 

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/03b-VerifyAddress.tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/03b-VerifyAddress.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { Subscription } from "rxjs";
-import { filter, first, map } from "rxjs/operators";
+import { from, Subscription } from "rxjs";
+import { filter, first, map, mergeMap } from "rxjs/operators";
 import { TouchableOpacity, Linking, LayoutChangeEvent } from "react-native";
 import { useSelector } from "~/context/hooks";
 import { useTranslation, Trans } from "~/context/Locale";
@@ -92,7 +92,7 @@ export default function ReceiveVerifyAddress({ navigation, route }: Props) {
   const { onSuccess, onError, device } = route.params;
 
   const verifyOnDevice = useCallback(
-    async (device: Device): Promise<void> => {
+    (device: Device): void => {
       if (!account) return;
       const mainAccount = getMainAccount(account, parentAccount);
 
@@ -104,10 +104,14 @@ export default function ReceiveVerifyAddress({ navigation, route }: Props) {
               map(() => ({})),
               rejectionOp(),
             )
-          : getAccountBridge(mainAccount).receive(mainAccount, {
-              deviceId: device.deviceId,
-              verify: true,
-            })
+          : from(Promise.resolve(getAccountBridge(mainAccount))).pipe(
+              mergeMap(bridge =>
+                bridge.receive(mainAccount, {
+                  deviceId: device.deviceId,
+                  verify: true,
+                }),
+              ),
+            )
       ).subscribe({
         complete: () => {
           if (onSuccess) onSuccess(mainAccount.freshAddress);


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** `useFeePresetFiatValues` test updated to mock `useAccountBridge`.
- [ ] **Impact of the changes:** Pure forward-compatibility refactor, no user-facing change.

### 📝 Description

Prepares mobile hook call sites for async bridges, choosing the idiom that fits each context:

- `useFeePresetFiatValues` — uses `useAccountBridge` hook directly (landed in #16726):
```diff
- queueMicrotask(async () => {
-   const bridge = await getAccountBridge(account, parentAccount);
-   estimateFiatValuesForPresets({ bridge, ... });
- });
+ const bridge = useAccountBridge(account, parentAccount);
+ estimateFiatValuesForPresets({ bridge, ... });
```

- Observable contexts (`useScanDeviceAccountsViewModel`, `screenTransactionHooks`, `VerifyAddress`) — bridge resolution folded into the RxJS pipeline rather than making the callback async:
```diff
- async () => {
-   const bridge = await getCurrencyBridge(currency);
-   sub = bridge.scanAccounts(...).subscribe(...);
- }
+ from(Promise.resolve(getCurrencyBridge(currency))).pipe(
+   mergeMap(bridge => bridge.scanAccounts(...))
+ ).subscribe(...)
```

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29176](https://ledgerhq.atlassian.net/browse/LIVE-29176) / #16733
- **ADR link (if any)**: N/A


[LIVE-29176]: https://ledgerhq.atlassian.net/browse/LIVE-29176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ