### PR TITLE
[LWDM] chore(llm): wire Datadog to `useBroadcast`

### DIFF
--- a/.changeset/little-nails-sip.md
+++ b/.changeset/little-nails-sip.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-common": minor
+"live-mobile": patch
+---
+
+chore(llm): wire Datadog in `useBroadcast`

--- a/apps/ledger-live-mobile/__mocks__/react-native-config.ts
+++ b/apps/ledger-live-mobile/__mocks__/react-native-config.ts
@@ -1,6 +1,14 @@
 // Mirror runtime: env vars are strings when set. DETOX undefined = disabled (use "1" in Detox test env).
+// Use undefined so (1) DETOX_ENABLED stays false and (2) truthiness checks (Config.DETOX) are falsy in unit tests.
+// MOCK: false so isDatadogEnabled can be true in tests when token fields are set.
 export default {
   DEVICE_PROXY_URL: null,
-  MOCK: true,
+  ANALYTICS_TOKEN: "test-token",
+  ANALYTICS_LOGS: "false",
+  DATADOG_CLIENT_TOKEN_VAR: "DATADOG_CLIENT_TOKEN_VAR",
+  DATADOG_APPLICATION_ID_VAR: "DATADOG_APPLICATION_ID_VAR",
+  DD_CLIENT_TOKEN: "DD_CLIENT_TOKEN",
+  DD_APP_ID: "DD_APP_ID",
+  MOCK: false,
   DETOX: undefined,
 };

--- a/apps/ledger-live-mobile/__tests__/jest-setup.js
+++ b/apps/ledger-live-mobile/__tests__/jest-setup.js
@@ -140,21 +140,7 @@ jest.mock("lottie-react-native", () => {
   return MockLottie;
 });
 
-// Mirror runtime: react-native-config exposes env as strings (e.g. "1"/"true" for DETOX).
-// Use undefined so (1) DETOX_ENABLED stays false and (2) truthiness checks (Config.DETOX) are falsy in unit tests.
-jest.mock("react-native-config", () => {
-  const config = {
-    DETOX: undefined,
-    ANALYTICS_TOKEN: "test-token",
-    ANALYTICS_LOGS: "false",
-  };
-  return {
-    __esModule: true,
-    get default() {
-      return config;
-    },
-  };
-});
+jest.mock("react-native-config");
 
 export const mockSimulateBarcodeScanned = jest.fn();
 export const mockGetCameraPermissionStatus = jest.fn(() => "granted");

--- a/apps/ledger-live-mobile/src/datadog.test.ts
+++ b/apps/ledger-live-mobile/src/datadog.test.ts
@@ -1,10 +1,8 @@
-import { DdLogs, DdRum } from "@datadog/mobile-react-native";
+import { DdLogs } from "@datadog/mobile-react-native";
 import { broadcastLogger } from "./datadog";
 
 jest.mock("@datadog/mobile-react-native", () => ({
-  DdLogs: { info: jest.fn() },
-  DdRum: { addError: jest.fn() },
-  ErrorSource: { SOURCE: "SOURCE" },
+  DdLogs: { info: jest.fn(), error: jest.fn() },
   TrackingConsent: {},
   DatadogProvider: { initialize: jest.fn() },
 }));
@@ -24,8 +22,8 @@ describe("broadcastLogger", () => {
     });
   });
 
-  it("calls DdRum.addError with correct parameters on failure event", () => {
-    const addErrorSpy = jest.spyOn(DdRum, "addError");
+  it("calls DdLogs.error with correct parameters on failure event", () => {
+    const errorSpy = jest.spyOn(DdLogs, "error");
     const error = new Error("tx broadcast failed");
     error.stack = "Error: tx broadcast failed\n  at test:1:1";
 
@@ -37,9 +35,10 @@ describe("broadcastLogger", () => {
       currencyId: "ethereum",
     });
 
-    expect(addErrorSpy).toHaveBeenCalledWith(
+    expect(errorSpy).toHaveBeenCalledWith(
       "broadcast_failure",
-      "SOURCE",
+      "Error",
+      "tx broadcast failed",
       "Error: tx broadcast failed\n  at test:1:1",
       {
         event: {
@@ -47,7 +46,6 @@ describe("broadcastLogger", () => {
           txPayload: "payload",
           appVersion: "1.0.0",
           currencyId: "ethereum",
-          error: { name: "Error", message: "tx broadcast failed" },
         },
       },
     );

--- a/apps/ledger-live-mobile/src/datadog.test.ts
+++ b/apps/ledger-live-mobile/src/datadog.test.ts
@@ -1,0 +1,55 @@
+import { DdLogs, DdRum } from "@datadog/mobile-react-native";
+import { broadcastLogger } from "./datadog";
+
+jest.mock("@datadog/mobile-react-native", () => ({
+  DdLogs: { info: jest.fn() },
+  DdRum: { addError: jest.fn() },
+  ErrorSource: { SOURCE: "SOURCE" },
+  TrackingConsent: {},
+  DatadogProvider: { initialize: jest.fn() },
+}));
+
+jest.mock("@datadog/mobile-react-navigation", () => ({}));
+jest.mock("./const", () => ({ ScreenName: {} }));
+jest.mock("./utils/datadogUtils", () => ({ buildFeatureFlagTags: jest.fn(() => ({})) }));
+
+describe("broadcastLogger", () => {
+  it("calls DdLogs.info with correct parameters on success event", () => {
+    const infoSpy = jest.spyOn(DdLogs, "info");
+
+    broadcastLogger({ status: "success", appVersion: "1.0.0", currencyId: "bitcoin" });
+
+    expect(infoSpy).toHaveBeenCalledWith("broadcast_success", {
+      event: { status: "success", appVersion: "1.0.0", currencyId: "bitcoin" },
+    });
+  });
+
+  it("calls DdRum.addError with correct parameters on failure event", () => {
+    const addErrorSpy = jest.spyOn(DdRum, "addError");
+    const error = new Error("tx broadcast failed");
+    error.stack = "Error: tx broadcast failed\n  at test:1:1";
+
+    broadcastLogger({
+      status: "failure",
+      error,
+      txPayload: "payload",
+      appVersion: "1.0.0",
+      currencyId: "ethereum",
+    });
+
+    expect(addErrorSpy).toHaveBeenCalledWith(
+      "broadcast_failure",
+      "SOURCE",
+      "Error: tx broadcast failed\n  at test:1:1",
+      {
+        event: {
+          status: "failure",
+          txPayload: "payload",
+          appVersion: "1.0.0",
+          currencyId: "ethereum",
+          error: { name: "Error", message: "tx broadcast failed" },
+        },
+      },
+    );
+  });
+});

--- a/apps/ledger-live-mobile/src/datadog.ts
+++ b/apps/ledger-live-mobile/src/datadog.ts
@@ -1,6 +1,13 @@
 import Config from "react-native-config";
-import { TrackingConsent, DatadogProvider } from "@datadog/mobile-react-native";
+import {
+  TrackingConsent,
+  DatadogProvider,
+  DdLogs,
+  DdRum,
+  ErrorSource,
+} from "@datadog/mobile-react-native";
 import { PartialInitializationConfiguration } from "@datadog/mobile-react-native/lib/typescript/DdSdkReactNativeConfiguration";
+import type { LogEvent } from "@ledgerhq/live-common/hooks/useBroadcast";
 import { ScreenName } from "./const";
 import { ViewNamePredicate } from "@datadog/mobile-react-navigation";
 import { ErrorEventMapper } from "@datadog/mobile-react-native/lib/typescript/rum/eventMappers/errorEventMapper";
@@ -132,6 +139,22 @@ export const customLogEventMapper: LogEventMapper = event => {
     },
   };
 };
+
+export function broadcastLogger(event: LogEvent): void {
+  if (!isDatadogEnabled) return;
+
+  if (event.status === "success") {
+    DdLogs.info("broadcast_success", { event });
+  } else {
+    const { error, ...rest } = event;
+    DdRum.addError("broadcast_failure", ErrorSource.SOURCE, error.stack ?? "", {
+      event: {
+        ...rest,
+        error: { name: error.name, message: error.message },
+      },
+    });
+  }
+}
 
 /**
  * A predicate function to determine the view name for tracking purposes.

--- a/apps/ledger-live-mobile/src/datadog.ts
+++ b/apps/ledger-live-mobile/src/datadog.ts
@@ -1,11 +1,5 @@
 import Config from "react-native-config";
-import {
-  TrackingConsent,
-  DatadogProvider,
-  DdLogs,
-  DdRum,
-  ErrorSource,
-} from "@datadog/mobile-react-native";
+import { TrackingConsent, DatadogProvider, DdLogs } from "@datadog/mobile-react-native";
 import { PartialInitializationConfiguration } from "@datadog/mobile-react-native/lib/typescript/DdSdkReactNativeConfiguration";
 import type { LogEvent } from "@ledgerhq/live-common/hooks/useBroadcast";
 import { ScreenName } from "./const";
@@ -147,10 +141,9 @@ export function broadcastLogger(event: LogEvent): void {
     DdLogs.info("broadcast_success", { event });
   } else {
     const { error, ...rest } = event;
-    DdRum.addError("broadcast_failure", ErrorSource.SOURCE, error.stack ?? "", {
+    DdLogs.error("broadcast_failure", error.name, error.message, error.stack ?? "", {
       event: {
         ...rest,
-        error: { name: error.name, message: error.message },
       },
     });
   }

--- a/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
+++ b/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
@@ -28,6 +28,7 @@ import { formatTransaction } from "@ledgerhq/live-common/transaction/index";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { execAndWaitAtLeast } from "@ledgerhq/live-common/promise";
 import { useBroadcast } from "@ledgerhq/live-common/hooks/useBroadcast";
+import { broadcastLogger } from "~/datadog";
 import { getEnv } from "@ledgerhq/live-env";
 import { useSelector, useDispatch } from "~/context/hooks";
 import { TransactionRefusedOnDevice } from "@ledgerhq/live-common/errors";
@@ -273,6 +274,7 @@ export function useSignedTxHandler({
       mevProtected,
       source: { type: "coin-module", name: "ledger-live-mobile", flags: { newSendFlow } },
     },
+    logger: broadcastLogger,
   });
   const dispatch = useDispatch();
   const mainAccount = getMainAccount(account, parentAccount);

--- a/apps/ledger-live-mobile/src/screens/Platform/exchange/CompleteExchange.tsx
+++ b/apps/ledger-live-mobile/src/screens/Platform/exchange/CompleteExchange.tsx
@@ -4,6 +4,7 @@ import { useSelector } from "~/context/hooks";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { useBroadcast } from "@ledgerhq/live-common/hooks/useBroadcast";
+import { broadcastLogger } from "~/datadog";
 import DeviceActionModal from "~/components/DeviceActionModal";
 import { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { PlatformExchangeNavigatorParamList } from "~/components/RootNavigator/types/PlatformExchangeNavigator";
@@ -42,6 +43,7 @@ const PlatformCompleteExchange: React.FC<Props> = ({
       sponsored: request.sponsored,
       source: { type: "swap", name: request.provider },
     },
+    logger: broadcastLogger,
   });
   const [transaction, setTransaction] = useState<Transaction>();
   const [signedOperation, setSignedOperation] = useState<SignedOperation>();

--- a/libs/ledger-live-common/src/hooks/useBroadcast.ts
+++ b/libs/ledger-live-common/src/hooks/useBroadcast.ts
@@ -24,7 +24,7 @@ type ErrorLogEvent = { status: "failure"; error: Error; txPayload: string } & Co
 
 type SuccessLogEvent = { status: "success" } & CommonLogEvent;
 
-type LogEvent = SuccessLogEvent | ErrorLogEvent;
+export type LogEvent = SuccessLogEvent | ErrorLogEvent;
 
 export type SignTransactionArgs = {
   account?: AccountLike | null;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LWM broadcast

### 📝 Description

Wires Datadog observability into the `useBroadcast` hook for Ledger Live Mobile.

- Adds a `broadcastLogger` function that logs broadcast outcomes to Datadog.
- Passes `broadcastLogger` to `useBroadcast`.
- Adds unit tests covering success and failure events.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
