### PR TITLE
test(e2e): fix false retries in Allure report for mobile e2e

### DIFF
--- a/e2e/mobile/jest.config.js
+++ b/e2e/mobile/jest.config.js
@@ -23,6 +23,8 @@ function pathsToModuleNameMapper(paths, { prefix = "<rootDir>/" } = {}) {
   return jestPaths;
 }
 
+const platform = process.env.DETOX_CONFIGURATION?.startsWith("ios") ? "ios" : "android";
+
 const jestAllure2ReporterOptions = {
   extends: "detox-allure2-adapter/preset-detox",
   resultsDir: "artifacts",
@@ -35,6 +37,7 @@ const jestAllure2ReporterOptions = {
       host: process.env.RUNNER_NAME,
     },
     status: ({ value }) => (value === "broken" ? "failed" : value),
+    historyId: ({ value }) => `${value}:${platform}`,
   },
   overwrite: false,
   environment: async ({ $ }) => ({

--- a/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
@@ -175,7 +175,7 @@ export function runTooLowAmountForQuoteSwapsTest(
   quotesVisible: boolean,
   tags: string[],
 ) {
-  describe("Swap - with too low amount (throwing UI errors)", () => {
+  describe(`Swap - with too low amount (throwing UI errors) - ${swap.amount} ${swap.accountToDebit.currency.name} to ${swap.accountToCredit.currency.name}`, () => {
     beforeAll(async () => {
       await app.speculos.setExchangeDependencies(swap);
       await beforeAllFunctionSwap({

--- a/e2e/mobile/specs/verifyAddress/verifyEmptyAddressTRX.spec.ts
+++ b/e2e/mobile/specs/verifyAddress/verifyEmptyAddressTRX.spec.ts
@@ -23,7 +23,7 @@ describe("Verify Address warnings", () => {
     "@family-tron",
   ];
   tags.forEach(tag => $Tag(tag));
-  it(`Verify address warning for ${account.currency.name}`, async () => {
+  it(`Verify empty address warning for ${account.currency.name}`, async () => {
     await app.account.openViaDeeplink();
     await app.account.goToAccountByName(account.accountName);
     await app.account.tapReceive();


### PR DESCRIPTION


<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- add platform historyId customizer in jest.config.js so iOS and Android results get distinct historyIds, preventing cross-platform collision when a test fails+retries on one platform but passes on the other
- rename duplicate describe/it strings in swap.other.ts and verifyEmptyAddressTRX.spec.ts that caused naming collisions treated as retries

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
