### PR TITLE
fix: disable broken scheduled CI workflows (76% / 100% failure rate)

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -1,8 +1,8 @@
 name: "[Common] - Integration - Scheduled"
 
 on:
-  schedule:
-    - cron: 20 9 * * *
+  # schedule:  # DISABLED 2026-05-04: 100% failure rate since Apr 23 (27 runs), re-enable after root cause fixed
+  #   - cron: 20 9 * * *
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -10,8 +10,8 @@ concurrency:
   cancel-in-progress: false
 
 on:
-  schedule:
-    - cron: "0 3 * * 1-5" # Mon–Fri → Wallet 4.0 (default)
+  # schedule:  # DISABLED 2026-05-04: 76% failure rate (Apr 22–May 1), re-enable after root cause fixed
+  #   - cron: "0 3 * * 1-5" # Mon–Fri → Wallet 4.0 (default)
   workflow_dispatch:
     inputs:
       ref:


### PR DESCRIPTION
## Summary

Two scheduled workflows have been silently burning CI budget for 9+ days with near-100% failure rates. This PR comments out the `schedule:` triggers until the root cause is fixed.

| Workflow | Failure rate | Period | Daily cost est. |
|----------|-------------|--------|----------------|
| `test-mobile-e2e-reusable.yml` (Mobile E2E Scheduled) | **76%** | Apr 22–May 1 | ~$10/day (macOS 10× multiplier) |
| `test-integration.yml` (Integration Scheduled) | **100%** | Apr 23–May 1 (27 runs) | ~$3.5/day (macos-14 matrix) |

**Both workflows remain available via `workflow_dispatch`** — no test coverage is lost. Manual runs can continue while the failure is investigated.

## Why now

Identified by Platform Engineering CI cost audit. `test-integration.yml` has had zero successful runs in 9 consecutive days with no automated alerting. `test-mobile-e2e-reusable.yml` runs Mon–Fri 3am UTC on iOS + Android + macOS-14 (10× GitHub billing multiplier).

## To re-enable

Uncomment the `schedule:` blocks after the root cause is fixed and a manual run passes.

## Test plan

- [ ] Verify no new scheduled runs trigger after merge
- [ ] Trigger each workflow manually via `workflow_dispatch` to confirm it still works
- [ ] After root cause fix: uncomment schedule and verify pass rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)