### PR TITLE
[LWDM] Feat tezos feature branch

### DIFF
--- a/.changeset/many-geckos-applaud.md
+++ b/.changeset/many-geckos-applaud.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tezos": minor
+---
+
+validateIntent staking

--- a/.changeset/sharp-drinks-drum.md
+++ b/.changeset/sharp-drinks-drum.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tezos": minor
+---
+
+Add support for the `finalize_unstake` Tezos intent in transaction crafting, and fix stake-related amount handling so stake, unstake, and finalize_unstake intents are passed through correctly.

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -6988,6 +6988,9 @@
     "RecommendUndelegation": {
       "title": "Please undelegate the account before emptying it"
     },
+    "MustDelegateBeforeStaking": {
+      "title": "Please delegate your account before staking"
+    },
     "RecommendSubAccountsToEmpty": {
       "title": "Please empty all subaccounts first"
     },

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -892,6 +892,9 @@
     "RecommendUndelegation": {
       "title": "Please undelegate the account before emptying it"
     },
+    "MustDelegateBeforeStaking": {
+      "title": "Please delegate your account before staking"
+    },
     "RecommendSubAccountsToEmpty": {
       "title": "Please empty all subaccounts first"
     },

--- a/libs/coin-modules/coin-tezos/src/api/index.test.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.test.ts
@@ -19,7 +19,7 @@ const logicCraftTransactionMock = jest.fn(
 
 jest.mock("../logic", () => ({
   listOperations: async () => logicGetTransactions(),
-  estimateFees: async () => logicEstimateFees(),
+  estimateFees: (...args: unknown[]) => logicEstimateFees(...args),
   craftTransaction: (account: unknown, transaction: { fee: { fees: string } }) =>
     logicCraftTransactionMock(account, transaction),
   rawEncode: () => Promise.resolve("tz1heMGVHQnx7ALDcDKqez8fan64Eyicw4DJ"),
@@ -305,6 +305,58 @@ describe("craftTransaction", () => {
       );
     });
   });
+  it.each(["stake", "unstake"] as const)(
+    "passes %s mode and explicit amount through to craftTransaction",
+    async type => {
+      logicEstimateFees.mockResolvedValue({
+        estimatedFees: DEFAULT_ESTIMATED_FEES,
+        fees: DEFAULT_ESTIMATED_FEES,
+        gasLimit: DEFAULT_GAS_LIMIT,
+        storageLimit: DEFAULT_STORAGE_LIMIT,
+      });
+
+      await api.craftTransaction({
+        intentType: "staking",
+        type,
+        sender: "tz1test",
+        recipient: "",
+        amount: 1234n,
+      } as TransactionIntent);
+
+      expect(logicCraftTransactionMock).toHaveBeenCalledWith(
+        expect.objectContaining({ address: "tz1test" }),
+        expect.objectContaining({
+          type,
+          amount: 1234n,
+        }),
+      );
+    },
+  );
+
+  it("passes finalize_unstake mode with zero amount through to craftTransaction", async () => {
+    logicEstimateFees.mockResolvedValue({
+      estimatedFees: DEFAULT_ESTIMATED_FEES,
+      fees: DEFAULT_ESTIMATED_FEES,
+      gasLimit: DEFAULT_GAS_LIMIT,
+      storageLimit: DEFAULT_STORAGE_LIMIT,
+    });
+
+    await api.craftTransaction({
+      intentType: "staking",
+      type: "finalize_unstake",
+      sender: "tz1test",
+      recipient: "",
+      amount: 999n,
+    } as TransactionIntent);
+
+    expect(logicCraftTransactionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ address: "tz1test" }),
+      expect.objectContaining({
+        type: "finalize_unstake",
+        amount: 0n,
+      }),
+    );
+  });
 });
 
 describe("estimateFees", () => {
@@ -468,6 +520,37 @@ describe("estimateFees", () => {
     expect(result.value).toBe(expectedTotalFees);
     expect(result.parameters.gasLimit).toBe(DEFAULT_GAS_LIMIT);
     expect(result.parameters.storageLimit).toBe(DEFAULT_STORAGE_LIMIT);
+  });
+
+  it.each([
+    ["stake", 1234n, 1234n],
+    ["unstake", 1234n, 1234n],
+    ["finalize_unstake", 999n, 0n],
+  ] as const)("delegates %s estimation to the logic layer", async (type, intentAmount, amount) => {
+    logicEstimateFees.mockResolvedValue({
+      estimatedFees: DEFAULT_ESTIMATED_FEES,
+      fees: DEFAULT_ESTIMATED_FEES,
+      gasLimit: DEFAULT_GAS_LIMIT,
+      storageLimit: DEFAULT_STORAGE_LIMIT,
+    });
+
+    const result = await api.estimateFees({
+      intentType: "staking",
+      type,
+      sender: "tz1test",
+      recipient: "",
+      amount: intentAmount,
+    } as TransactionIntent);
+
+    expect(result.value).toBe(DEFAULT_ESTIMATED_FEES);
+    expect(logicEstimateFees).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transaction: expect.objectContaining({
+          mode: type,
+          amount,
+        }),
+      }),
+    );
   });
 
   it("fallback when Taquito throws Public key not found returns total with minFees for reveal (unrevealed)", async () => {

--- a/libs/coin-modules/coin-tezos/src/api/index.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.ts
@@ -15,6 +15,7 @@ import type {
   FeeEstimation,
   TransactionIntent,
 } from "@ledgerhq/coin-module-framework/api/types";
+import type { BridgeApi } from "@ledgerhq/ledger-wallet-framework/api/types";
 import { craftTransactionData } from "@ledgerhq/coin-module-framework/logic/craftTransactionData";
 import { RecommendUndelegation } from "@ledgerhq/errors";
 import { log } from "@ledgerhq/logs";
@@ -42,7 +43,6 @@ import api from "../network/tzkt";
 import {
   DUST_MARGIN_MUTEZ,
   hasEmptyBalance,
-  mapIntentTypeToTezosMode,
   normalizePublicKeyForAddress,
   parseTezosTokenAsset,
   resolveTezosOperationMode,
@@ -50,10 +50,22 @@ import {
 import type { TezosFeeEstimation } from "./types";
 import type { TezosOperationMode } from "../types/model";
 
-export function createApi(config: TezosConfig): AlpacaApi {
+export function createApi(config: TezosConfig): AlpacaApi & BridgeApi {
   coinConfig.setCoinConfig(() => ({ ...config, status: { type: "active" } }));
 
   return {
+    computeIntentType: (transaction: Record<string, unknown>): string => {
+      switch (transaction.mode) {
+        case "delegate":
+        case "undelegate":
+        case "stake":
+        case "unstake":
+        case "finalize_unstake":
+          return transaction.mode;
+        default:
+          return "send";
+      }
+    },
     broadcast,
     combine,
     craftTransaction: craft,
@@ -91,10 +103,9 @@ export function createApi(config: TezosConfig): AlpacaApi {
 
 function isTezosTransactionType(
   type: string,
-): type is "send" | "delegate" | "undelegate" | "stake" | "unstake" {
-  return ["send", "delegate", "undelegate", "stake", "unstake"].includes(type);
+): type is "send" | "delegate" | "undelegate" | "stake" | "unstake" | "finalize_unstake" {
+  return ["send", "delegate", "undelegate", "stake", "unstake", "finalize_unstake"].includes(type);
 }
-
 async function craft(
   transactionIntent: TransactionIntent,
   customFees?: FeeEstimation,
@@ -113,12 +124,12 @@ async function craft(
 
   const tezosMode = resolveTezosOperationMode(transactionIntent.type, transactionIntent.asset);
   const mappedType: TezosOperationMode =
-    tezosMode === "send_token" ? "send_token" : mapIntentTypeToTezosMode(transactionIntent.type);
+    tezosMode === "send_token" ? "send_token" : (transactionIntent.type as TezosOperationMode);
   const tokenCraftInfo =
     tezosMode === "send_token" ? parseTezosTokenAsset(transactionIntent.asset)! : undefined;
 
   // Guard: send max is incompatible with delegated accounts (native XTZ only)
-  let amountToUse = transactionIntent.amount;
+  let amountToUse = tezosMode === "finalize_unstake" ? 0n : transactionIntent.amount;
   if (tezosMode === "send" && transactionIntent.useAllAmount) {
     const senderInfo = await api.getAccountByAddress(transactionIntent.sender);
     if (senderInfo.type === "user" && senderInfo.delegate?.address) {
@@ -254,7 +265,7 @@ async function estimate(transactionIntent: TransactionIntent): Promise<TezosFeeE
   const transaction: CoreTransactionInfo = {
     mode: tezosModeForEstimate,
     recipient: transactionIntent.recipient,
-    amount: transactionIntent.amount,
+    amount: tezosModeForEstimate === "finalize_unstake" ? 0n : transactionIntent.amount,
     useAllAmount: !!transactionIntent.useAllAmount,
     ...(tokenEstimationInfo && {
       contractAddress: tokenEstimationInfo.contractAddress,

--- a/libs/coin-modules/coin-tezos/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/craftTransaction.ts
@@ -3,6 +3,7 @@ import { type OperationContents, OpKind } from "@taquito/rpc";
 import { getRevealFee, getRevealGasLimit } from "@taquito/taquito";
 import coinConfig from "../config";
 import { UnsupportedTransactionMode } from "../types/errors";
+import type { TezosOperationMode } from "../types/model";
 import { createMockSigner } from "../utils";
 import { getTezosToolkit } from "./tezosToolkit";
 

--- a/libs/coin-modules/coin-tezos/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/craftTransaction.ts
@@ -3,7 +3,6 @@ import { type OperationContents, OpKind } from "@taquito/rpc";
 import { getRevealFee, getRevealGasLimit } from "@taquito/taquito";
 import coinConfig from "../config";
 import { UnsupportedTransactionMode } from "../types/errors";
-import type { TezosOperationMode } from "../types/model";
 import { createMockSigner } from "../utils";
 import { getTezosToolkit } from "./tezosToolkit";
 

--- a/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
@@ -1,3 +1,4 @@
+import type { TransactionIntent } from "@ledgerhq/coin-module-framework/api/types";
 import {
   RecipientRequired,
   InvalidAddress,
@@ -8,10 +9,9 @@ import {
   NotEnoughBalanceToDelegate,
 } from "@ledgerhq/errors";
 import coinConfig from "../config";
-import { InvalidAddressBecauseAlreadyDelegated } from "../types/errors";
+import { InvalidAddressBecauseAlreadyDelegated, MustDelegateBeforeStaking } from "../types/errors";
 import { validateIntent } from "./validateIntent";
 
-// Module-level mocks
 const mockEstimateFees = jest.fn();
 jest.mock("./estimateFees", () => ({
   estimateFees: (...args: unknown[]) => mockEstimateFees(...args),
@@ -31,6 +31,20 @@ describe("validateIntent", () => {
   const senderAddress = "tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8";
   const validRecipient = "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx";
 
+  const makeUserAccount = (overrides: Record<string, unknown> = {}) => ({
+    type: "user" as const,
+    address: senderAddress,
+    publicKey: "edpk...",
+    balance: 5000000,
+    revealed: true,
+    counter: 0,
+    delegationLevel: 0,
+    delegationTime: "2021-01-01T00:00:00Z",
+    numTransactions: 0,
+    firstActivityTime: "2021-01-01T00:00:00Z",
+    ...overrides,
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
 
@@ -49,25 +63,13 @@ describe("validateIntent", () => {
     }));
 
     mockEstimateFees.mockResolvedValue({
-      fees: BigInt(1000),
-      gasLimit: BigInt(10000),
-      storageLimit: BigInt(0),
-      estimatedFees: BigInt(1000),
+      fees: 1000n,
+      gasLimit: 10000n,
+      storageLimit: 0n,
+      estimatedFees: 1000n,
     });
 
-    mockGetAccountByAddress.mockResolvedValue({
-      type: "user",
-      address: senderAddress,
-      publicKey: "edpk...",
-      balance: 5000000,
-      revealed: true,
-      counter: 0,
-      delegationLevel: 0,
-      delegationTime: "2021-01-01T00:00:00Z",
-      numTransactions: 0,
-      firstActivityTime: "2021-01-01T00:00:00Z",
-    });
-
+    mockGetAccountByAddress.mockResolvedValue(makeUserAccount());
     mockGetTokensBalances.mockResolvedValue([]);
   });
 
@@ -79,7 +81,7 @@ describe("validateIntent", () => {
         type: "send",
         sender: senderAddress,
         recipient: "",
-        amount: BigInt(1000),
+        amount: 1000n,
       });
 
       expect(result.errors.recipient).toBeInstanceOf(RecipientRequired);
@@ -92,7 +94,7 @@ describe("validateIntent", () => {
         type: "send",
         sender: senderAddress,
         recipient: "invalid_address",
-        amount: BigInt(1000),
+        amount: 1000n,
       });
 
       expect(result.errors.recipient).toBeInstanceOf(InvalidAddress);
@@ -105,7 +107,7 @@ describe("validateIntent", () => {
         type: "send",
         sender: senderAddress,
         recipient: senderAddress,
-        amount: BigInt(1000),
+        amount: 1000n,
       });
 
       expect(result.errors.recipient).toBeInstanceOf(InvalidAddressBecauseDestinationIsAlsoSource);
@@ -120,7 +122,7 @@ describe("validateIntent", () => {
         type: "send",
         sender: senderAddress,
         recipient: validRecipient,
-        amount: BigInt(0),
+        amount: 0n,
         useAllAmount: false,
       });
 
@@ -134,7 +136,7 @@ describe("validateIntent", () => {
         type: "send",
         sender: senderAddress,
         recipient: validRecipient,
-        amount: BigInt(0),
+        amount: 0n,
         useAllAmount: true,
       });
 
@@ -154,45 +156,83 @@ describe("validateIntent", () => {
       expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
     });
 
-    it.each([["stake"], ["unstake"]])(
-      "returns 0 as amount when the transaction intent is '%s'",
-      async intentType => {
-        const result = await validateIntent({
-          intentType: "transaction",
-          asset: { type: "native" },
-          type: intentType,
-          sender: "tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8",
-          recipient: "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx",
-          amount: BigInt(0),
-          useAllAmount: true,
-        });
+    it("uses the staked amount as amount and amount + fees as totalSpent for stake", async () => {
+      mockGetAccountByAddress.mockResolvedValue(
+        makeUserAccount({
+          delegate: { alias: "baker", address: validRecipient, active: true },
+          delegationLevel: 1,
+        }),
+      );
 
-        expect(result).toEqual({
-          errors: {},
-          warnings: {},
-          estimatedFees: 1000n,
-          amount: 0n,
-          totalSpent: 1000n,
-        });
-      },
-    );
+      const result = await validateIntent({
+        intentType: "staking",
+        asset: { type: "native" },
+        type: "stake",
+        sender: senderAddress,
+        recipient: "",
+        amount: 2500n,
+      });
+
+      expect(result).toEqual({
+        errors: {},
+        warnings: {},
+        estimatedFees: 1000n,
+        amount: 2500n,
+        totalSpent: 3500n,
+      });
+    });
+
+    it("uses only fees as totalSpent for unstake", async () => {
+      mockGetAccountByAddress.mockResolvedValue(makeUserAccount({ stakedBalance: 4000 }));
+
+      const result = await validateIntent({
+        intentType: "staking",
+        asset: { type: "native" },
+        type: "unstake",
+        sender: senderAddress,
+        recipient: "",
+        amount: 2500n,
+      });
+
+      expect(result).toEqual({
+        errors: {},
+        warnings: {},
+        estimatedFees: 1000n,
+        amount: 2500n,
+        totalSpent: 1000n,
+      });
+    });
+
+    it("uses amount 0 and only fees as totalSpent for finalize_unstake", async () => {
+      mockGetAccountByAddress.mockResolvedValue(makeUserAccount({ unstakedFinalizable: 1234 }));
+
+      const result = await validateIntent({
+        intentType: "staking",
+        asset: { type: "native" },
+        type: "finalize_unstake",
+        sender: senderAddress,
+        recipient: "",
+        amount: 0n,
+      } satisfies TransactionIntent);
+
+      expect(result).toEqual({
+        errors: {},
+        warnings: {},
+        estimatedFees: 1000n,
+        amount: 0n,
+        totalSpent: 1000n,
+      });
+    });
   });
 
   describe("transaction constraints", () => {
     it("should return RecommendUndelegation when send-max native XTZ on a delegated account", async () => {
-      mockGetAccountByAddress.mockResolvedValue({
-        type: "user",
-        address: senderAddress,
-        publicKey: "edpk...",
-        balance: 5000000,
-        revealed: true,
-        counter: 0,
-        delegate: { alias: "baker", address: validRecipient, active: true },
-        delegationLevel: 1,
-        delegationTime: "2021-01-01T00:00:00Z",
-        numTransactions: 0,
-        firstActivityTime: "2021-01-01T00:00:00Z",
-      });
+      mockGetAccountByAddress.mockResolvedValue(
+        makeUserAccount({
+          delegate: { alias: "baker", address: validRecipient, active: true },
+          delegationLevel: 1,
+        }),
+      );
 
       const result = await validateIntent({
         intentType: "transaction",
@@ -208,51 +248,112 @@ describe("validateIntent", () => {
       expect(mockEstimateFees).not.toHaveBeenCalled();
     });
 
-    it("should return NotEnoughBalanceToDelegate when stake intent and balance is zero", async () => {
-      mockGetAccountByAddress.mockResolvedValue({
-        type: "user",
-        address: senderAddress,
-        publicKey: "edpk...",
-        balance: 0,
-        revealed: true,
-        counter: 0,
-        delegationLevel: 0,
-        delegationTime: "2021-01-01T00:00:00Z",
-        numTransactions: 0,
-        firstActivityTime: "2021-01-01T00:00:00Z",
+    it("should return MustDelegateBeforeStaking when stake intent has no delegate", async () => {
+      const result = await validateIntent({
+        intentType: "staking",
+        asset: { type: "native" },
+        type: "stake",
+        sender: senderAddress,
+        recipient: "",
+        amount: 1n,
       });
+
+      expect(result.errors.amount).toBeInstanceOf(MustDelegateBeforeStaking);
+      expect(mockEstimateFees).not.toHaveBeenCalled();
+    });
+
+    it("should return AmountRequired when stake amount is zero", async () => {
+      mockGetAccountByAddress.mockResolvedValue(
+        makeUserAccount({
+          delegate: { alias: "baker", address: validRecipient, active: true },
+          delegationLevel: 1,
+        }),
+      );
 
       const result = await validateIntent({
         intentType: "staking",
         asset: { type: "native" },
         type: "stake",
         sender: senderAddress,
-        recipient: validRecipient,
-        amount: BigInt(0),
+        recipient: "",
+        amount: 0n,
       });
 
-      expect(result.errors.amount).toBeInstanceOf(NotEnoughBalanceToDelegate);
+      expect(result.errors.amount).toBeInstanceOf(AmountRequired);
+      expect(mockEstimateFees).not.toHaveBeenCalled();
+    });
+
+    it("should return NotEnoughBalance when unstake has no staked balance", async () => {
+      mockGetAccountByAddress.mockResolvedValue(makeUserAccount({ stakedBalance: 0 }));
+
+      const result = await validateIntent({
+        intentType: "staking",
+        asset: { type: "native" },
+        type: "unstake",
+        sender: senderAddress,
+        recipient: "",
+        amount: 1n,
+      });
+
+      expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+      expect(mockEstimateFees).not.toHaveBeenCalled();
+    });
+
+    it("should return AmountRequired when unstake amount is zero", async () => {
+      mockGetAccountByAddress.mockResolvedValue(makeUserAccount({ stakedBalance: 4000 }));
+
+      const result = await validateIntent({
+        intentType: "staking",
+        asset: { type: "native" },
+        type: "unstake",
+        sender: senderAddress,
+        recipient: "",
+        amount: 0n,
+      });
+
+      expect(result.errors.amount).toBeInstanceOf(AmountRequired);
+      expect(mockEstimateFees).not.toHaveBeenCalled();
+    });
+
+    it("should return NotEnoughBalance when unstake amount exceeds staked balance", async () => {
+      mockGetAccountByAddress.mockResolvedValue(makeUserAccount({ stakedBalance: 4000 }));
+
+      const result = await validateIntent({
+        intentType: "staking",
+        asset: { type: "native" },
+        type: "unstake",
+        sender: senderAddress,
+        recipient: "",
+        amount: 5000n,
+      });
+
+      expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+      expect(mockEstimateFees).not.toHaveBeenCalled();
+    });
+
+    it("should return NotEnoughBalance when finalize_unstake has nothing finalizable", async () => {
+      mockGetAccountByAddress.mockResolvedValue(makeUserAccount({ unstakedFinalizable: 0 }));
+
+      const result = await validateIntent({
+        intentType: "staking",
+        asset: { type: "native" },
+        type: "finalize_unstake",
+        sender: senderAddress,
+        recipient: "",
+        amount: 0n,
+      } satisfies TransactionIntent);
+
+      expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
       expect(mockEstimateFees).not.toHaveBeenCalled();
     });
   });
 
   describe("balance validation", () => {
     it("should return NotEnoughBalance error when amount exceeds balance", async () => {
-      const balance = 1000000; // 1 XTZ
-      const amount = 2000000; // 2 XTZ
+      const balance = 1000000;
+      const amount = 2000000;
 
-      mockGetAccountByAddress.mockResolvedValue({
-        type: "user",
-        address: senderAddress,
-        publicKey: "edpk...",
-        balance,
-        revealed: true,
-        counter: 0,
-        delegationLevel: 0,
-        delegationTime: "2021-01-01T00:00:00Z",
-        numTransactions: 0,
-        firstActivityTime: "2021-01-01T00:00:00Z",
-      });
+      mockGetAccountByAddress.mockResolvedValue(makeUserAccount({ balance }));
 
       const result = await validateIntent({
         intentType: "transaction",
@@ -267,33 +368,18 @@ describe("validateIntent", () => {
     });
 
     it("should pass validation when amount is within balance", async () => {
-      const balance = 5000000; // 5 XTZ
-      const amount = 1000000; // 1 XTZ
-
-      mockGetAccountByAddress.mockResolvedValue({
-        type: "user",
-        address: senderAddress,
-        publicKey: "edpk...",
-        balance,
-        revealed: true,
-        counter: 0,
-        delegationLevel: 0,
-        delegationTime: "2021-01-01T00:00:00Z",
-        numTransactions: 0,
-        firstActivityTime: "2021-01-01T00:00:00Z",
-      });
-
+      const amount = 1000000n;
       const result = await validateIntent({
         intentType: "transaction",
         asset: { type: "native" },
         type: "send",
         sender: senderAddress,
         recipient: validRecipient,
-        amount: BigInt(amount),
+        amount,
       });
 
       expect(result.errors.amount).toBeUndefined();
-      expect(result.amount).toBe(BigInt(amount));
+      expect(result.amount).toBe(amount);
     });
   });
 
@@ -305,7 +391,7 @@ describe("validateIntent", () => {
         type: "delegate",
         sender: senderAddress,
         recipient: validRecipient,
-        amount: BigInt(0),
+        amount: 0n,
       });
 
       expect(result.errors).toEqual({});
@@ -318,34 +404,58 @@ describe("validateIntent", () => {
         type: "undelegate",
         sender: senderAddress,
         recipient: "",
-        amount: BigInt(0),
+        amount: 0n,
       });
 
       expect(result.errors).toEqual({});
     });
 
-    it("should handle stake intent (mapped to delegate)", async () => {
+    it("should pass validation for stake transaction when already delegated", async () => {
+      mockGetAccountByAddress.mockResolvedValue(
+        makeUserAccount({
+          delegate: { alias: "baker", address: validRecipient, active: true },
+          delegationLevel: 1,
+        }),
+      );
+
       const result = await validateIntent({
         intentType: "staking",
         asset: { type: "native" },
         type: "stake",
         sender: senderAddress,
-        recipient: validRecipient,
-        amount: BigInt(0),
+        recipient: "",
+        amount: 1000n,
       });
 
       expect(result.errors).toEqual({});
     });
 
-    it("should handle unstake intent (mapped to undelegate)", async () => {
+    it("should pass validation for unstake transaction", async () => {
+      mockGetAccountByAddress.mockResolvedValue(makeUserAccount({ stakedBalance: 4000 }));
+
       const result = await validateIntent({
         intentType: "staking",
         asset: { type: "native" },
         type: "unstake",
         sender: senderAddress,
         recipient: "",
-        amount: BigInt(0),
+        amount: 1000n,
       });
+
+      expect(result.errors).toEqual({});
+    });
+
+    it("should pass validation for finalize_unstake transaction", async () => {
+      mockGetAccountByAddress.mockResolvedValue(makeUserAccount({ unstakedFinalizable: 4000 }));
+
+      const result = await validateIntent({
+        intentType: "staking",
+        asset: { type: "native" },
+        type: "finalize_unstake",
+        sender: senderAddress,
+        recipient: "",
+        amount: 0n,
+      } satisfies TransactionIntent);
 
       expect(result.errors).toEqual({});
     });
@@ -374,6 +484,13 @@ describe("validateIntent", () => {
     });
 
     it("maps balance_too_low to NotEnoughBalanceToDelegate for stake", async () => {
+      mockGetAccountByAddress.mockResolvedValue(
+        makeUserAccount({
+          delegate: { alias: "baker", address: validRecipient, active: true },
+          delegationLevel: 1,
+        }),
+      );
+
       mockEstimateFees.mockResolvedValue({
         fees: 0n,
         gasLimit: 0n,
@@ -387,8 +504,8 @@ describe("validateIntent", () => {
         asset: { type: "native" },
         type: "stake",
         sender: senderAddress,
-        recipient: validRecipient,
-        amount: 0n,
+        recipient: "",
+        amount: 1n,
       });
 
       expect(result.errors.amount).toBeInstanceOf(NotEnoughBalanceToDelegate);
@@ -416,6 +533,13 @@ describe("validateIntent", () => {
     });
 
     it("maps delegate.unchanged to InvalidAddressBecauseAlreadyDelegated for stake", async () => {
+      mockGetAccountByAddress.mockResolvedValue(
+        makeUserAccount({
+          delegate: { alias: "baker", address: validRecipient, active: true },
+          delegationLevel: 1,
+        }),
+      );
+
       mockEstimateFees.mockResolvedValue({
         fees: 0n,
         gasLimit: 0n,
@@ -429,8 +553,8 @@ describe("validateIntent", () => {
         asset: { type: "native" },
         type: "stake",
         sender: senderAddress,
-        recipient: validRecipient,
-        amount: 0n,
+        recipient: "",
+        amount: 1n,
       });
 
       expect(result.errors.recipient).toBeInstanceOf(InvalidAddressBecauseAlreadyDelegated);
@@ -455,6 +579,55 @@ describe("validateIntent", () => {
       });
 
       expect(result.errors.amount).toBeInstanceOf(NotEnoughBalanceToDelegate);
+    });
+
+    it("maps staking.too_much_unstaked to NotEnoughBalance for unstake", async () => {
+      mockGetAccountByAddress.mockResolvedValue(makeUserAccount({ stakedBalance: 4000 }));
+      mockEstimateFees.mockResolvedValue({
+        fees: 0n,
+        gasLimit: 0n,
+        storageLimit: 0n,
+        estimatedFees: 500n,
+        taquitoError: "proto.alpha.staking.too_much_unstaked",
+      });
+
+      const result = await validateIntent({
+        intentType: "staking",
+        asset: { type: "native" },
+        type: "unstake",
+        sender: senderAddress,
+        recipient: "",
+        amount: 1000n,
+      });
+
+      expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+    });
+
+    it("maps contract.must_be_delegated_to_stake to MustDelegateBeforeStaking", async () => {
+      mockGetAccountByAddress.mockResolvedValue(
+        makeUserAccount({
+          delegate: { alias: "baker", address: validRecipient, active: true },
+          delegationLevel: 1,
+        }),
+      );
+      mockEstimateFees.mockResolvedValue({
+        fees: 0n,
+        gasLimit: 0n,
+        storageLimit: 0n,
+        estimatedFees: 500n,
+        taquitoError: "proto.alpha.contract.must_be_delegated_to_stake",
+      });
+
+      const result = await validateIntent({
+        intentType: "staking",
+        asset: { type: "native" },
+        type: "stake",
+        sender: senderAddress,
+        recipient: "",
+        amount: 1000n,
+      });
+
+      expect(result.errors.amount).toBeInstanceOf(MustDelegateBeforeStaking);
     });
 
     it("maps unknown taquito errors to a generic Error on amount", async () => {
@@ -482,18 +655,7 @@ describe("validateIntent", () => {
 
   describe("account fetch and reveal", () => {
     it("uses fixed estimated fees when account is not revealed and skips estimateFees", async () => {
-      mockGetAccountByAddress.mockResolvedValue({
-        type: "user",
-        address: senderAddress,
-        publicKey: "edpk...",
-        balance: 5000000,
-        revealed: false,
-        counter: 0,
-        delegationLevel: 0,
-        delegationTime: "2021-01-01T00:00:00Z",
-        numTransactions: 0,
-        firstActivityTime: "2021-01-01T00:00:00Z",
-      });
+      mockGetAccountByAddress.mockResolvedValue(makeUserAccount({ revealed: false }));
 
       const amount = 1000000n;
       const result = await validateIntent({
@@ -610,7 +772,7 @@ describe("validateIntent", () => {
         type: "send",
         sender: senderAddress,
         recipient: validRecipient,
-        amount: BigInt(1_000_000),
+        amount: 1000000n,
       });
 
       expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
@@ -638,10 +800,10 @@ describe("validateIntent", () => {
   describe("native XTZ send max", () => {
     it("should fall back to balance minus fees when estimateFees returns amount 0n", async () => {
       mockEstimateFees.mockResolvedValue({
-        fees: BigInt(1000),
-        gasLimit: BigInt(10000),
-        storageLimit: BigInt(0),
-        estimatedFees: BigInt(1000),
+        fees: 1000n,
+        gasLimit: 10000n,
+        storageLimit: 0n,
+        estimatedFees: 1000n,
         amount: 0n,
       });
 
@@ -661,12 +823,12 @@ describe("validateIntent", () => {
     });
 
     it("should prefer positive estimatedAmount from estimateFees over balance minus fees", async () => {
-      const estimatedFromTaquito = 3_000_000n;
+      const estimatedFromTaquito = 3000000n;
       mockEstimateFees.mockResolvedValue({
-        fees: BigInt(1000),
-        gasLimit: BigInt(10000),
-        storageLimit: BigInt(0),
-        estimatedFees: BigInt(1000),
+        fees: 1000n,
+        gasLimit: 10000n,
+        storageLimit: 0n,
+        estimatedFees: 1000n,
         amount: estimatedFromTaquito,
       });
 
@@ -687,13 +849,13 @@ describe("validateIntent", () => {
 
   describe("successful validation", () => {
     it("should return valid result with correct values", async () => {
-      const amount = BigInt(1000000);
-      const estimatedFees = BigInt(1500);
+      const amount = 1000000n;
+      const estimatedFees = 1500n;
 
       mockEstimateFees.mockResolvedValue({
-        fees: BigInt(1000),
-        gasLimit: BigInt(10000),
-        storageLimit: BigInt(0),
+        fees: 1000n,
+        gasLimit: 10000n,
+        storageLimit: 0n,
         estimatedFees,
       });
 

--- a/libs/coin-modules/coin-tezos/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/validateIntent.ts
@@ -14,11 +14,35 @@ import {
 import { validateAddress, ValidationResult } from "@taquito/utils";
 import api from "../network/tzkt";
 import type { APIAccount } from "../network/types";
-import { InvalidAddressBecauseAlreadyDelegated } from "../types/errors";
+import { InvalidAddressBecauseAlreadyDelegated, MustDelegateBeforeStaking } from "../types/errors";
 import { parseTezosTokenAsset, resolveTezosOperationMode } from "../utils";
 import { estimateFees } from "./estimateFees";
+import type { TezosOperationMode } from "../types/model";
 
 type APIUserAccount = Extract<APIAccount, { type: "user" }>;
+
+function resolveValidationOperationMode(intent: TransactionIntent): TezosOperationMode {
+  switch (intent.type) {
+    case "stake":
+    case "unstake":
+    case "finalize_unstake":
+      return intent.type;
+    default:
+      return resolveTezosOperationMode(intent.type, intent.asset);
+  }
+}
+
+function validateStrictlyPositiveAmount(amount: bigint): Error | undefined {
+  if (amount === 0n) {
+    return new AmountRequired();
+  }
+
+  if (amount < 0n) {
+    return new NotEnoughBalance();
+  }
+
+  return undefined;
+}
 
 /**
  * Validates basic recipient and amount for send transactions
@@ -60,17 +84,46 @@ function validateTransactionConstraints(
   if (
     intent.type === "send" &&
     intent.useAllAmount &&
-    resolveTezosOperationMode(intent.type, intent.asset) === "send" &&
+    resolveValidationOperationMode(intent) === "send" &&
     senderInfo.delegate?.address
   ) {
     errors.amount = new RecommendUndelegation();
   }
 
-  // stake requires non-zero balance
   if (intent.type === "stake") {
-    const balance = BigInt(senderInfo.balance || "0");
-    if (balance === 0n) {
-      errors.amount = new NotEnoughBalanceToDelegate();
+    if (!senderInfo.delegate?.address) {
+      errors.amount = new MustDelegateBeforeStaking();
+      return errors;
+    }
+
+    const amountError = validateStrictlyPositiveAmount(intent.amount);
+    if (amountError) {
+      errors.amount = amountError;
+    }
+  }
+
+  if (intent.type === "unstake") {
+    const stakedBalance = BigInt(senderInfo.stakedBalance ?? 0);
+    if (stakedBalance <= 0n) {
+      errors.amount = new NotEnoughBalance();
+      return errors;
+    }
+
+    const amountError = validateStrictlyPositiveAmount(intent.amount);
+    if (amountError) {
+      errors.amount = amountError;
+      return errors;
+    }
+
+    if (intent.amount > stakedBalance) {
+      errors.amount = new NotEnoughBalance();
+    }
+  }
+
+  if (intent.type === "finalize_unstake") {
+    const unstakedFinalizable = BigInt(senderInfo.unstakedFinalizable ?? 0);
+    if (unstakedFinalizable <= 0n) {
+      errors.amount = new NotEnoughBalance();
     }
   }
 
@@ -89,6 +142,10 @@ function mapTaquitoErrors(taquitoError: string, intentType: string): Record<stri
     } else {
       errors.amount = new NotEnoughBalance();
     }
+  } else if (taquitoError.endsWith("staking.too_much_unstaked")) {
+    errors.amount = new NotEnoughBalance();
+  } else if (taquitoError.endsWith("contract.must_be_delegated_to_stake")) {
+    errors.amount = new MustDelegateBeforeStaking();
   } else if (taquitoError.endsWith("delegate.unchanged") && intentType === "stake") {
     errors.recipient = new InvalidAddressBecauseAlreadyDelegated();
   } else if (taquitoError.includes("empty_implicit_contract")) {
@@ -124,7 +181,15 @@ function calculateAmounts(
   estimatedAmount: bigint | undefined,
   tokenBalanceForSendMax?: bigint,
 ): { amount: bigint; totalSpent: bigint } {
-  if (intent.type === "stake" || intent.type === "unstake") {
+  if (intent.type === "stake") {
+    return { amount: intent.amount, totalSpent: intent.amount + estimatedFees };
+  }
+
+  if (intent.type === "unstake") {
+    return { amount: intent.amount, totalSpent: estimatedFees };
+  }
+
+  if (intent.type === "finalize_unstake") {
     return { amount: 0n, totalSpent: estimatedFees };
   }
 
@@ -170,7 +235,7 @@ async function estimateFeesForIntent(
     return { estimatedFees: 2000n, estimatedAmount: undefined, errors: {} };
   }
 
-  const tezosMode = resolveTezosOperationMode(intent.type, intent.asset);
+  const tezosMode = resolveValidationOperationMode(intent);
   const tokenInfo = tezosMode === "send_token" ? parseTezosTokenAsset(intent.asset)! : undefined;
   const estimation = await estimateFees({
     account: {
@@ -182,7 +247,9 @@ async function estimateFeesForIntent(
     transaction: {
       mode: tezosMode,
       recipient: intent.recipient,
-      amount: intent.amount,
+      // finalize_unstake is a parameter-less operation; normalize amount to 0n so
+      // fee estimation and the returned validation amount stay consistent.
+      amount: intent.type === "finalize_unstake" ? 0n : intent.amount,
       useAllAmount: !!intent.useAllAmount,
       ...(tokenInfo && {
         contractAddress: tokenInfo.contractAddress,

--- a/libs/coin-modules/coin-tezos/src/types/errors.ts
+++ b/libs/coin-modules/coin-tezos/src/types/errors.ts
@@ -8,3 +8,6 @@ export const UnsupportedTransactionMode = createCustomErrorClass<
   { mode: string },
   LedgerErrorConstructor<{ mode: string }>
 >("UnsupportedTransactionMode");
+export const MustDelegateBeforeStaking = createCustomErrorClass(
+  "MustDelegateBeforeStaking",
+);

--- a/libs/coin-modules/coin-tezos/src/utils.test.ts
+++ b/libs/coin-modules/coin-tezos/src/utils.test.ts
@@ -65,13 +65,23 @@ describe("resolveTezosOperationMode", () => {
     expect(resolveTezosOperationMode("send", { type: "native" })).toBe("send");
   });
 
-  it("maps stake to delegate regardless of asset", () => {
+  it("maps staking intents to real staking modes regardless of asset", () => {
     expect(
       resolveTezosOperationMode("stake", {
         type: "token",
         assetReference: "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU:0",
       }),
-    ).toBe("delegate");
+    ).toBe("stake");
+
+    expect(resolveTezosOperationMode("unstake", { type: "native" })).toBe("unstake");
+    expect(resolveTezosOperationMode("finalize_unstake", { type: "native" })).toBe(
+      "finalize_unstake",
+    );
+  });
+
+  it("maps delegation intents to delegation modes", () => {
+    expect(resolveTezosOperationMode("delegate", { type: "native" })).toBe("delegate");
+    expect(resolveTezosOperationMode("undelegate", { type: "native" })).toBe("undelegate");
   });
 });
 

--- a/libs/coin-modules/coin-tezos/src/utils.ts
+++ b/libs/coin-modules/coin-tezos/src/utils.ts
@@ -27,16 +27,20 @@ export const MIN_SUGGESTED_FEE_SMALL_TRANSFER = 489;
 export const OP_SIZE_XTZ_TRANSFER = 154;
 
 /**
- * Helper function to map generic staking intents to Tezos operation modes
+ * Helper function to map generic intents to Tezos operation modes.
  */
-export function mapIntentTypeToTezosMode(intentType: string): "send" | "delegate" | "undelegate" {
+export function mapIntentTypeToTezosMode(intentType: string): TezosOperationMode {
   switch (intentType) {
-    case "stake":
     case "delegate":
       return "delegate";
-    case "unstake":
     case "undelegate":
       return "undelegate";
+    case "stake":
+      return "stake";
+    case "unstake":
+      return "unstake";
+    case "finalize_unstake":
+      return "finalize_unstake";
     default:
       return "send";
   }

--- a/libs/coin-modules/coin-tezos/src/utils.ts
+++ b/libs/coin-modules/coin-tezos/src/utils.ts
@@ -26,26 +26,6 @@ export const MIN_SUGGESTED_FEE_SMALL_TRANSFER = 489;
  */
 export const OP_SIZE_XTZ_TRANSFER = 154;
 
-/**
- * Helper function to map generic intents to Tezos operation modes.
- */
-export function mapIntentTypeToTezosMode(intentType: string): TezosOperationMode {
-  switch (intentType) {
-    case "delegate":
-      return "delegate";
-    case "undelegate":
-      return "undelegate";
-    case "stake":
-      return "stake";
-    case "unstake":
-      return "unstake";
-    case "finalize_unstake":
-      return "finalize_unstake";
-    default:
-      return "send";
-  }
-}
-
 /** Minimal asset shape from `TransactionIntent` for FA2 detection */
 export type TezosAssetLike = {
   type: string;
@@ -81,7 +61,7 @@ export function resolveTezosOperationMode(
   intentType: string,
   asset: TezosAssetLike | undefined,
 ): TezosOperationMode {
-  const base = mapIntentTypeToTezosMode(intentType);
+  const base = intentType as TezosOperationMode;
   if (base === "send" && parseTezosTokenAsset(asset) !== null) {
     return "send_token";
   }


### PR DESCRIPTION
consists of:

1. https://github.com/LedgerHQ/ledger-live/pull/16815
2. https://github.com/LedgerHQ/ledger-live/pull/16980
3. https://github.com/LedgerHQ/ledger-live/pull/16981

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This PR fixes Tezos staking intent handling across the API, logic, and utility layers so that `stake`, `unstake`, and `finalize_unstake` correctly flow end-to-end.

**`api/index.ts`**
- Adds `"finalize_unstake"` to `isTezosTransactionType` so it is accepted by `craft` instead of throwing `IncorrectTypeError`.
- Forces `amountToUse = 0n` for `finalize_unstake` in `craft` and `amount = 0n` in `estimate` (no XTZ amount is needed to finalize unstaking).

**`utils.ts`**
- `mapIntentTypeToTezosMode` now returns the full `TezosOperationMode` union and maps `stake`, `unstake`, and `finalize_unstake` to their own modes instead of collapsing them onto `delegate`/`undelegate`.

**`logic/craftTransaction.ts`**
- Widens the `transaction.type` parameter from a narrow string union to `TezosOperationMode` so all modes (including staking) can be crafted without a type error.

**`logic/validateIntent.ts`**
- Adds staking-specific constraint checks (must be delegated to stake, positive amount for stake/unstake, staked/finalizable balance checks).
- Updates fee/amount/totalSpent calculations to reflect staking semantics: stake spends amount+fees; unstake and finalize_unstake spend fees only.
- Extends Taquito error mapping for staking-related protocol errors.

**Tests**
- `api/index.test.ts` — asserts that `stake`/`unstake` forward the intent amount unchanged and `finalize_unstake` forwards `0n`; covers `estimate` delegation for all staking modes.
- `utils.test.ts` — extends `resolveTezosOperationMode` tests to assert correct passthrough for all staking and delegation modes.
- `logic/validateIntent.test.ts` — expands unit tests for new staking validation rules, amount/totalSpent semantics, and new Taquito error mappings.

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-28766
- https://ledgerhq.atlassian.net/browse/LIVE-28757
- https://ledgerhq.atlassian.net/browse/LIVE-28764

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
