### PR TITLE
[LWDM] feat(LIVE-29571): add Aleo private record-picking support in prepareTransaction

### DIFF
--- a/.changeset/twenty-papayas-talk.md
+++ b/.changeset/twenty-papayas-talk.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+feat: support auto record picking strategy in aleo prepareTransaction

--- a/libs/coin-modules/coin-aleo/src/bridge/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/prepareTransaction.test.ts
@@ -218,4 +218,244 @@ describe("prepareTransaction", () => {
       },
     });
   });
+
+  it("should keep selected amount record when recordPickingStrategy is manual", async () => {
+    mockAleoConfig.getCoinConfig.mockReturnValue({
+      ...mockConfig,
+      recordPickingStrategy: "manual",
+      isFeeSponsored: true,
+    });
+
+    const mockPrivateTransaction: Transaction = {
+      ...mockTransaction,
+      mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
+      properties: {
+        amountRecordCommitments: [mockUnspentRecord1.commitment],
+        feeRecordCommitment: null,
+      },
+    };
+
+    const accountWithPrivateRecords = getMockedAccount({
+      aleoResources: {
+        transparentBalance: mockAccount.aleoResources?.transparentBalance ?? new BigNumber(0),
+        provableApi: mockAccount.aleoResources?.provableApi ?? null,
+        privateBalance: mockAccount.aleoResources?.privateBalance ?? null,
+        unspentPrivateRecords: [mockUnspentRecord1, mockUnspentRecord2],
+        lastPrivateSyncDate: mockAccount.aleoResources?.lastPrivateSyncDate ?? null,
+      },
+    });
+
+    const result = await prepareTransaction(accountWithPrivateRecords, mockPrivateTransaction);
+
+    expect(mockCalculateAmount).toHaveBeenCalledTimes(1);
+    expect(mockCalculateAmount).toHaveBeenCalledWith({
+      transaction: mockPrivateTransaction,
+      account: accountWithPrivateRecords,
+      estimatedFees: mockFees,
+    });
+    expect(result).toMatchObject({
+      properties: {
+        amountRecordCommitments: [mockUnspentRecord1.commitment],
+      },
+    });
+  });
+
+  it("should auto-select the smallest sufficient amount record when recordPickingStrategy is auto", async () => {
+    mockAleoConfig.getCoinConfig.mockReturnValue({
+      ...mockConfig,
+      recordPickingStrategy: "auto",
+      isFeeSponsored: true,
+    });
+
+    const mockPrivateTransaction: Transaction = {
+      ...mockTransaction,
+      mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
+      amount: new BigNumber(550000),
+      properties: {
+        amountRecordCommitments: [],
+        feeRecordCommitment: null,
+      },
+    };
+
+    const accountWithPrivateRecords = getMockedAccount({
+      aleoResources: {
+        transparentBalance: mockAccount.aleoResources?.transparentBalance ?? new BigNumber(0),
+        provableApi: mockAccount.aleoResources?.provableApi ?? null,
+        privateBalance: mockAccount.aleoResources?.privateBalance ?? null,
+        unspentPrivateRecords: [mockUnspentRecord1, mockUnspentRecord2],
+        lastPrivateSyncDate: mockAccount.aleoResources?.lastPrivateSyncDate ?? null,
+      },
+    });
+
+    const result = await prepareTransaction(accountWithPrivateRecords, mockPrivateTransaction);
+
+    expect(mockCalculateAmount).toHaveBeenCalledTimes(1);
+    expect(mockCalculateAmount).toHaveBeenCalledWith({
+      transaction: expect.objectContaining({
+        mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
+        properties: expect.objectContaining({
+          amountRecordCommitments: [mockUnspentRecord2.commitment],
+        }),
+      }),
+      account: accountWithPrivateRecords,
+      estimatedFees: mockFees,
+    });
+    expect(result).toMatchObject({
+      properties: {
+        amountRecordCommitments: [mockUnspentRecord2.commitment],
+      },
+    });
+  });
+
+  it("should accumulate multiple records when no single record can cover the amount", async () => {
+    mockAleoConfig.getCoinConfig.mockReturnValue({
+      ...mockConfig,
+      recordPickingStrategy: "auto",
+      isFeeSponsored: true,
+    });
+
+    const mockPrivateTransaction: Transaction = {
+      ...mockTransaction,
+      mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
+      amount: new BigNumber(900000),
+      properties: {
+        amountRecordCommitments: [],
+        feeRecordCommitment: null,
+      },
+    };
+
+    const accountWithPrivateRecords = getMockedAccount({
+      aleoResources: {
+        transparentBalance: mockAccount.aleoResources?.transparentBalance ?? new BigNumber(0),
+        provableApi: mockAccount.aleoResources?.provableApi ?? null,
+        privateBalance: mockAccount.aleoResources?.privateBalance ?? null,
+        unspentPrivateRecords: [mockUnspentRecord1, mockUnspentRecord2],
+        lastPrivateSyncDate: mockAccount.aleoResources?.lastPrivateSyncDate ?? null,
+      },
+    });
+
+    const result = await prepareTransaction(accountWithPrivateRecords, mockPrivateTransaction);
+
+    expect(result).toMatchObject({
+      properties: {
+        amountRecordCommitments: [mockUnspentRecord1.commitment, mockUnspentRecord2.commitment],
+      },
+    });
+  });
+
+  it("should return empty amount records when available funds cannot cover the amount", async () => {
+    mockAleoConfig.getCoinConfig.mockReturnValue({
+      ...mockConfig,
+      recordPickingStrategy: "auto",
+      isFeeSponsored: true,
+    });
+
+    const mockPrivateTransaction: Transaction = {
+      ...mockTransaction,
+      mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
+      amount: new BigNumber(1500000),
+      properties: {
+        amountRecordCommitments: [],
+        feeRecordCommitment: null,
+      },
+    };
+
+    const accountWithPrivateRecords = getMockedAccount({
+      aleoResources: {
+        transparentBalance: mockAccount.aleoResources?.transparentBalance ?? new BigNumber(0),
+        provableApi: mockAccount.aleoResources?.provableApi ?? null,
+        privateBalance: mockAccount.aleoResources?.privateBalance ?? null,
+        unspentPrivateRecords: [mockUnspentRecord1, mockUnspentRecord2],
+        lastPrivateSyncDate: mockAccount.aleoResources?.lastPrivateSyncDate ?? null,
+      },
+    });
+
+    const result = await prepareTransaction(accountWithPrivateRecords, mockPrivateTransaction);
+
+    expect(result).toMatchObject({
+      properties: {
+        amountRecordCommitments: [],
+      },
+    });
+  });
+
+  it("should auto-select amount and fee records when recordPickingStrategy is auto and fees are not sponsored", async () => {
+    mockAleoConfig.getCoinConfig.mockReturnValue({
+      ...mockConfig,
+      recordPickingStrategy: "auto",
+      isFeeSponsored: false,
+    });
+    mockFindBestRecordForFee.mockReturnValue(mockUnspentRecord1);
+
+    const mockPrivateTransaction: Transaction = {
+      ...mockTransaction,
+      mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
+      amount: new BigNumber(550000),
+      properties: {
+        amountRecordCommitments: [],
+        feeRecordCommitment: null,
+      },
+    };
+
+    const accountWithPrivateRecords = getMockedAccount({
+      aleoResources: {
+        transparentBalance: mockAccount.aleoResources?.transparentBalance ?? new BigNumber(0),
+        provableApi: mockAccount.aleoResources?.provableApi ?? null,
+        privateBalance: mockAccount.aleoResources?.privateBalance ?? null,
+        unspentPrivateRecords: [mockUnspentRecord1, mockUnspentRecord2],
+        lastPrivateSyncDate: mockAccount.aleoResources?.lastPrivateSyncDate ?? null,
+      },
+    });
+
+    const result = await prepareTransaction(accountWithPrivateRecords, mockPrivateTransaction);
+
+    expect(mockFindBestRecordForFee).toHaveBeenCalledTimes(1);
+    expect(mockFindBestRecordForFee).toHaveBeenCalledWith({
+      unspentRecords: accountWithPrivateRecords.aleoResources?.unspentPrivateRecords ?? [],
+      selectedAmountRecordCommitments: [mockUnspentRecord2.commitment],
+      targetFee: mockFees,
+    });
+    expect(result).toMatchObject({
+      properties: {
+        amountRecordCommitments: [mockUnspentRecord2.commitment],
+        feeRecordCommitment: mockUnspentRecord1.commitment,
+      },
+    });
+  });
+
+  it("should auto-select top records for useAllAmount with auto record picking strategy", async () => {
+    mockAleoConfig.getCoinConfig.mockReturnValue({
+      ...mockConfig,
+      recordPickingStrategy: "auto",
+      isFeeSponsored: true,
+    });
+
+    const mockPrivateTransaction: Transaction = {
+      ...mockTransaction,
+      mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
+      useAllAmount: true,
+      properties: {
+        amountRecordCommitments: [],
+        feeRecordCommitment: null,
+      },
+    };
+
+    const accountWithPrivateRecords = getMockedAccount({
+      aleoResources: {
+        transparentBalance: mockAccount.aleoResources?.transparentBalance ?? new BigNumber(0),
+        provableApi: mockAccount.aleoResources?.provableApi ?? null,
+        privateBalance: mockAccount.aleoResources?.privateBalance ?? null,
+        unspentPrivateRecords: [mockUnspentRecord1, mockUnspentRecord2],
+        lastPrivateSyncDate: mockAccount.aleoResources?.lastPrivateSyncDate ?? null,
+      },
+    });
+
+    const result = await prepareTransaction(accountWithPrivateRecords, mockPrivateTransaction);
+
+    expect(result).toMatchObject({
+      properties: {
+        amountRecordCommitments: [mockUnspentRecord1.commitment, mockUnspentRecord2.commitment],
+      },
+    });
+  });
 });

--- a/libs/coin-modules/coin-aleo/src/bridge/prepareTransaction.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/prepareTransaction.ts
@@ -3,8 +3,39 @@ import type { AccountBridge } from "@ledgerhq/types-live";
 import { updateTransaction } from "@ledgerhq/ledger-wallet-framework/bridge/jsHelpers";
 import aleoCoinConfig from "../config";
 import { estimateFees } from "../logic";
-import { calculateAmount, findBestRecordForFee, isPrivateTransaction } from "../logic/utils";
-import type { AleoAccount, Transaction as AleoTransaction } from "../types";
+import {
+  calculateAmount,
+  findBestRecordForFee,
+  isPrivateTransaction,
+  selectPrivateRecordsForAmount,
+} from "../logic/utils";
+import type {
+  AleoAccount,
+  AleoCoinConfig,
+  Transaction as AleoTransaction,
+  TransactionPrivate as AleoTransactionPrivate,
+  AleoUnspentRecord,
+} from "../types";
+
+function getAmountRecordCommitments({
+  transaction,
+  config,
+  unspentRecords,
+}: {
+  transaction: AleoTransactionPrivate;
+  config: AleoCoinConfig;
+  unspentRecords: AleoUnspentRecord[];
+}): string[] {
+  if (config.recordPickingStrategy === "manual") {
+    return transaction.properties.amountRecordCommitments;
+  }
+
+  const targetAmount = transaction.useAllAmount ? null : transaction.amount;
+  const selectedAmountRecords = selectPrivateRecordsForAmount({ unspentRecords, targetAmount });
+  const selectedAmountRecordCommitments = selectedAmountRecords.map(record => record.commitment);
+
+  return selectedAmountRecordCommitments;
+}
 
 export const prepareTransaction: AccountBridge<
   AleoTransaction,
@@ -17,33 +48,55 @@ export const prepareTransaction: AccountBridge<
   });
 
   const estimatedFees = new BigNumber(feeEstimation.value.toString());
-  const calculatedAmount = calculateAmount({ transaction, account, estimatedFees });
 
-  if (
-    isPrivateTransaction(transaction) &&
-    !config.isFeeSponsored &&
-    transaction.properties.amountRecordCommitments.length > 0
-  ) {
-    const feeRecord = findBestRecordForFee({
-      unspentRecords: account.aleoResources?.unspentPrivateRecords ?? [],
-      selectedAmountRecordCommitments: transaction.properties.amountRecordCommitments,
-      targetFee: estimatedFees,
-    });
-    const nextFeeRecordCommitment =
-      feeRecord?.commitment ?? transaction.properties.feeRecordCommitment;
+  // public transactions don't use records - amount and fees are resolved directly.
+  if (!isPrivateTransaction(transaction)) {
+    const calculatedAmount = calculateAmount({ transaction, account, estimatedFees });
 
     return updateTransaction(transaction, {
       amount: calculatedAmount.amount,
       fees: estimatedFees,
-      properties: {
-        ...transaction.properties,
-        ...(nextFeeRecordCommitment && { feeRecordCommitment: nextFeeRecordCommitment }),
-      },
     });
   }
 
-  return updateTransaction(transaction, {
+  const unspentRecords = account.aleoResources?.unspentPrivateRecords ?? [];
+  const newAmountRecordCommitments = getAmountRecordCommitments({
+    transaction,
+    config,
+    unspentRecords,
+  });
+  const privateTransactionWithRecords = updateTransaction(transaction, {
+    properties: {
+      ...transaction.properties,
+      amountRecordCommitments: newAmountRecordCommitments,
+    },
+  });
+  const calculatedAmount = calculateAmount({
+    transaction: privateTransactionWithRecords,
+    account,
+    estimatedFees,
+  });
+
+  // when fee sponsorship is off, pick the smallest record that covers the fee
+  let selectedFeeRecordCommitment: string | null = null;
+
+  if (!config.isFeeSponsored && newAmountRecordCommitments.length > 0) {
+    const feeRecord = findBestRecordForFee({
+      unspentRecords,
+      selectedAmountRecordCommitments: newAmountRecordCommitments,
+      targetFee: estimatedFees,
+    });
+
+    selectedFeeRecordCommitment =
+      feeRecord?.commitment ?? privateTransactionWithRecords.properties.feeRecordCommitment;
+  }
+
+  return updateTransaction(privateTransactionWithRecords, {
     amount: calculatedAmount.amount,
     fees: estimatedFees,
+    properties: {
+      ...privateTransactionWithRecords.properties,
+      feeRecordCommitment: config.isFeeSponsored ? null : selectedFeeRecordCommitment,
+    },
   });
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - support for auto `recordPickingStrategy` in prepareTransaction of coin-aleo module

### 📝 Description

This PR adds support for "auto" recordPickingStrategy to prepareTransaction in coin-aleo module.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-29571

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
