### PR TITLE
[LWM] fix(mobile): correct analytics page value for My Wallet button_clicked events

### DIFF
--- a/.changeset/hip-pens-agree.md
+++ b/.changeset/hip-pens-agree.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Update tracking for my wallet and help page

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/constants.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/constants.ts
@@ -1,0 +1,5 @@
+/** Segment `page` on `button_clicked` for actions inside My Wallet */
+export const MY_WALLET_TRACKING_PAGE_NAME = "My Wallet";
+
+/** Segment `page` on `button_clicked` for actions inside My Wallet Help */
+export const MY_WALLET_HELP_TRACKING_PAGE_NAME = "Help";

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/screens/Help/useMyWalletHelpViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/screens/Help/useMyWalletHelpViewModel.ts
@@ -8,7 +8,7 @@ import { useDispatch } from "~/context/hooks";
 import useExportLogs from "~/components/useExportLogs";
 import { urls } from "~/utils/urls";
 import { track } from "~/analytics";
-import { ScreenName } from "~/const";
+import { MY_WALLET_HELP_TRACKING_PAGE_NAME } from "../../constants";
 
 export function useMyWalletHelpViewModel() {
   const chatbotSupportFeature = useFeature("llmChatbotSupport");
@@ -25,27 +25,27 @@ export function useMyWalletHelpViewModel() {
   const [isClearCacheDrawerOpen, setIsClearCacheDrawerOpen] = useState(false);
 
   const onLedgerSupportPress = useCallback(() => {
-    track("button_clicked", { button: "LedgerSupport", page: ScreenName.MyWalletHelp });
+    track("button_clicked", { button: "LedgerSupport", page: MY_WALLET_HELP_TRACKING_PAGE_NAME });
     Linking.openURL(isChatbotEnabled ? localizedChatbotUrl : localizedFaqUrl);
   }, [isChatbotEnabled, localizedChatbotUrl, localizedFaqUrl]);
 
   const onLedgerAcademyPress = useCallback(() => {
-    track("button_clicked", { button: "LedgerAcademy", page: ScreenName.MyWalletHelp });
+    track("button_clicked", { button: "LedgerAcademy", page: MY_WALLET_HELP_TRACKING_PAGE_NAME });
     Linking.openURL(localizedAcademyUrl);
   }, [localizedAcademyUrl]);
 
   const onSaveLogsPress = useCallback(() => {
-    track("button_clicked", { button: "SaveLogs", page: ScreenName.MyWalletHelp });
+    track("button_clicked", { button: "SaveLogs", page: MY_WALLET_HELP_TRACKING_PAGE_NAME });
     exportLogs();
   }, [exportLogs]);
 
   const onLedgerStatusPress = useCallback(() => {
-    track("button_clicked", { button: "LedgerStatus", page: ScreenName.MyWalletHelp });
+    track("button_clicked", { button: "LedgerStatus", page: MY_WALLET_HELP_TRACKING_PAGE_NAME });
     Linking.openURL(urls.resources.status);
   }, []);
 
   const onClearCachePress = useCallback(() => {
-    track("button_clicked", { button: "ClearCache", page: ScreenName.MyWalletHelp });
+    track("button_clicked", { button: "ClearCache", page: MY_WALLET_HELP_TRACKING_PAGE_NAME });
     setIsClearCacheDrawerOpen(true);
   }, []);
 

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/__tests__/useDeviceSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/__tests__/useDeviceSectionViewModel.test.ts
@@ -7,6 +7,7 @@ import { act, renderHook } from "@tests/test-renderer";
 import { ScreenName } from "~/const";
 import { track } from "~/analytics";
 import { urls } from "~/utils/urls";
+import { MY_WALLET_TRACKING_PAGE_NAME } from "../../../constants";
 import { useDeviceSectionViewModel, type DeviceSectionDevice } from "../useDeviceSectionViewModel";
 import type { State } from "~/reducers/types";
 
@@ -97,7 +98,7 @@ describe("useDeviceSectionViewModel", () => {
       expect(mockNavigate).toHaveBeenCalledWith(ScreenName.BleDevicePairingFlow);
       expect(track).toHaveBeenCalledWith("button_clicked", {
         button: "Add",
-        page: ScreenName.MyWallet,
+        page: MY_WALLET_TRACKING_PAGE_NAME,
       });
     });
   });
@@ -111,7 +112,7 @@ describe("useDeviceSectionViewModel", () => {
       expect(Linking.openURL).toHaveBeenCalledWith(urls.exploreLedgerDevices);
       expect(track).toHaveBeenCalledWith("button_clicked", {
         button: "ExploreDevices",
-        page: ScreenName.MyWallet,
+        page: MY_WALLET_TRACKING_PAGE_NAME,
       });
     });
   });
@@ -132,7 +133,7 @@ describe("useDeviceSectionViewModel", () => {
       });
       expect(track).toHaveBeenCalledWith("button_clicked", {
         button: "Device",
-        page: ScreenName.MyWallet,
+        page: MY_WALLET_TRACKING_PAGE_NAME,
         deviceModelId: DeviceModelId.europa,
       });
     });

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/useDeviceSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/useDeviceSectionViewModel.ts
@@ -15,6 +15,7 @@ import { NavigatorName, ScreenName } from "~/const";
 import { urls } from "~/utils/urls";
 import { track } from "~/analytics";
 import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
+import { MY_WALLET_TRACKING_PAGE_NAME } from "../../constants";
 import { useManagerDeviceAction } from "~/hooks/deviceActions";
 
 export interface DeviceSectionDevice {
@@ -69,21 +70,21 @@ export const useDeviceSectionViewModel = (): DeviceSectionViewModel => {
   const hasDevices = devices.length > 0;
 
   const onAddDevice = useCallback(() => {
-    track("button_clicked", { button: "Add", page: ScreenName.MyWallet });
+    track("button_clicked", { button: "Add", page: MY_WALLET_TRACKING_PAGE_NAME });
     navigation.navigate(ScreenName.BleDevicePairingFlow);
   }, [navigation]);
 
   const exploreDevicesUrl = useLocalizedUrl(urls.exploreLedgerDevices);
 
   const onExploreDevices = useCallback(() => {
-    track("button_clicked", { button: "ExploreDevices", page: ScreenName.MyWallet });
+    track("button_clicked", { button: "ExploreDevices", page: MY_WALLET_TRACKING_PAGE_NAME });
     Linking.openURL(exploreDevicesUrl);
   }, [exploreDevicesUrl]);
 
   const onDevicePress = useCallback((device: DeviceSectionDevice) => {
     track("button_clicked", {
       button: "Device",
-      page: ScreenName.MyWallet,
+      page: MY_WALLET_TRACKING_PAGE_NAME,
       deviceModelId: device.modelId,
     });
     setSelectedDevice({

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/Header/__tests__/useMyWalletHeaderViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/Header/__tests__/useMyWalletHeaderViewModel.test.ts
@@ -2,6 +2,7 @@ import { act } from "@testing-library/react-native";
 import { renderHook } from "@tests/test-renderer";
 import { NavigatorName, ScreenName } from "~/const";
 import { track } from "~/analytics";
+import { MY_WALLET_TRACKING_PAGE_NAME } from "../../../constants";
 import { useMyWalletHeaderViewModel } from "../useMyWalletHeaderViewModel";
 
 const mockNavigate = jest.fn();
@@ -39,7 +40,7 @@ describe("useMyWalletHeaderViewModel", () => {
     });
     expect(track).toHaveBeenCalledWith("button_clicked", {
       button: "Notifications",
-      page: ScreenName.MyWallet,
+      page: MY_WALLET_TRACKING_PAGE_NAME,
     });
   });
 
@@ -49,7 +50,7 @@ describe("useMyWalletHeaderViewModel", () => {
     expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Settings);
     expect(track).toHaveBeenCalledWith("button_clicked", {
       button: "Settings",
-      page: ScreenName.MyWallet,
+      page: MY_WALLET_TRACKING_PAGE_NAME,
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/Header/useMyWalletHeaderViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/Header/useMyWalletHeaderViewModel.ts
@@ -3,6 +3,7 @@ import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { NavigatorName, ScreenName } from "~/const";
 import { track } from "~/analytics";
+import { MY_WALLET_TRACKING_PAGE_NAME } from "../../constants";
 import useDynamicContent from "~/dynamicContent/useDynamicContent";
 
 export function useMyWalletHeaderViewModel() {
@@ -20,14 +21,14 @@ export function useMyWalletHeaderViewModel() {
   }, [navigation]);
 
   const onNotificationsPress = useCallback(() => {
-    track("button_clicked", { button: "Notifications", page: ScreenName.MyWallet });
+    track("button_clicked", { button: "Notifications", page: MY_WALLET_TRACKING_PAGE_NAME });
     navigation.navigate(NavigatorName.NotificationCenter, {
       screen: ScreenName.NotificationCenter,
     });
   }, [navigation]);
 
   const onSettingsPress = useCallback(() => {
-    track("button_clicked", { button: "Settings", page: ScreenName.MyWallet });
+    track("button_clicked", { button: "Settings", page: MY_WALLET_TRACKING_PAGE_NAME });
     navigation.navigate(NavigatorName.Settings);
   }, [navigation]);
 

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/MyLedgerSection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/MyLedgerSection.tsx
@@ -11,6 +11,7 @@ import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/inde
 import { NavigatorName, ScreenName } from "~/const";
 import SelectDevice2, { SetHeaderOptionsRequest } from "~/components/SelectDevice2";
 import { track } from "~/analytics";
+import { MY_WALLET_TRACKING_PAGE_NAME } from "../constants";
 import DeviceActionModal from "~/components/DeviceActionModal";
 import { useManagerDeviceAction } from "~/hooks/deviceActions";
 import { useAutoRedirectToPostOnboarding } from "~/hooks/useAutoRedirectToPostOnboarding";
@@ -43,7 +44,7 @@ function MyLedgerSectionContent() {
   const exploreDevicesUrl = useLocalizedUrl(urls.exploreLedgerDevices);
 
   const onExploreDevices = useCallback(() => {
-    track("button_clicked", { button: "ExploreDevices", page: ScreenName.MyWallet });
+    track("button_clicked", { button: "ExploreDevices", page: MY_WALLET_TRACKING_PAGE_NAME });
     Linking.openURL(exploreDevicesUrl);
   }, [exploreDevicesUrl]);
 

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/__tests__/useQuickActionsRowViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/__tests__/useQuickActionsRowViewModel.test.ts
@@ -7,6 +7,7 @@ import type { State } from "~/reducers/types";
 import { NavigatorName, ScreenName } from "~/const";
 import { track } from "~/analytics";
 import { urls } from "~/utils/urls";
+import { MY_WALLET_TRACKING_PAGE_NAME } from "../../../constants";
 import { useQuickActionsRowViewModel } from "../useQuickActionsRowViewModel";
 
 const mockNavigate = jest.fn();
@@ -56,7 +57,7 @@ describe("useQuickActionsRowViewModel", () => {
       });
       expect(track).toHaveBeenCalledWith("button_clicked", {
         button: "Help",
-        page: ScreenName.MyWallet,
+        page: MY_WALLET_TRACKING_PAGE_NAME,
       });
     });
   });
@@ -71,7 +72,7 @@ describe("useQuickActionsRowViewModel", () => {
       expect(Linking.openURL).toHaveBeenCalledWith(urls.referralProgram);
       expect(track).toHaveBeenCalledWith("button_clicked", {
         button: "Referral",
-        page: ScreenName.MyWallet,
+        page: MY_WALLET_TRACKING_PAGE_NAME,
       });
     });
   });
@@ -89,7 +90,7 @@ describe("useQuickActionsRowViewModel", () => {
       });
       expect(track).toHaveBeenCalledWith("button_clicked", {
         button: "Recover",
-        page: ScreenName.MyWallet,
+        page: MY_WALLET_TRACKING_PAGE_NAME,
       });
     });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/useQuickActionsRowViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/useQuickActionsRowViewModel.ts
@@ -17,6 +17,7 @@ import { urls } from "~/utils/urls";
 import { lastConnectedDeviceSelector, hasClickedRecoverSelector } from "~/reducers/settings";
 import { setHasClickedRecover } from "~/actions/settings";
 import { track } from "~/analytics";
+import { MY_WALLET_TRACKING_PAGE_NAME } from "../../constants";
 
 export interface QuickActionRowItem {
   readonly id: string;
@@ -51,7 +52,7 @@ export const useQuickActionsRowViewModel = (): QuickActionsRowViewModel => {
     if (!hasClickedRecover) {
       dispatch(setHasClickedRecover(true));
     }
-    track("button_clicked", { button: "Recover", page: ScreenName.MyWallet });
+    track("button_clicked", { button: "Recover", page: MY_WALLET_TRACKING_PAGE_NAME });
     navigation.navigate(ScreenName.Recover, {
       platform: protectId,
       device: lastConnectedDevice ?? undefined,
@@ -59,12 +60,12 @@ export const useQuickActionsRowViewModel = (): QuickActionsRowViewModel => {
   }, [navigation, protectId, lastConnectedDevice, hasClickedRecover, dispatch]);
 
   const handleHelpPress = useCallback(() => {
-    track("button_clicked", { button: "Help", page: ScreenName.MyWallet });
+    track("button_clicked", { button: "Help", page: MY_WALLET_TRACKING_PAGE_NAME });
     navigation.navigate(NavigatorName.MyWallet, { screen: ScreenName.MyWalletHelp });
   }, [navigation]);
 
   const handleReferralPress = useCallback(() => {
-    track("button_clicked", { button: "Referral", page: ScreenName.MyWallet });
+    track("button_clicked", { button: "Referral", page: MY_WALLET_TRACKING_PAGE_NAME });
     Linking.openURL(urls.referralProgram);
   }, []);
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Analytics `button_clicked` events in My Wallet feature now send correct `page` value
  - Verify Segment events contain `"My Wallet"` (with space) instead of `"MyWallet"`
  - Verify Help page events contain `"Help"` instead of `"MyWalletHelp"`

### 📝 Description

**Problem**: The `button_clicked` analytics events in the My Wallet mobile feature were sending `page: "MyWallet"` (the raw `ScreenName` enum value) instead of `"My Wallet"` (with a space) as specified in the tracking plan.

**Solution**: Introduced dedicated tracking constants (`MY_WALLET_TRACKING_PAGE_NAME` and `MY_WALLET_HELP_TRACKING_PAGE_NAME`) — aligned with the existing desktop pattern — and replaced all `ScreenName.MyWallet` / `ScreenName.MyWalletHelp` usages in analytics calls.

**Files changed:**
- New `constants.ts` with tracking page name constants
- `useDeviceSectionViewModel.ts` — 3 events fixed
- `useMyWalletHeaderViewModel.ts` — 2 events fixed
- `useQuickActionsRowViewModel.ts` — 3 events fixed
- `MyLedgerSection.tsx` — 1 event fixed
- `useMyWalletHelpViewModel.ts` — 5 events fixed
- All corresponding test files updated

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26562](https://ledgerhq.atlassian.net/browse/LIVE-26562)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26562]: https://ledgerhq.atlassian.net/browse/LIVE-26562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ