### PR TITLE
[LWD] fix: ensure My Ledger top bar analytics page property is current route

### DIFF
--- a/.changeset/calm-mice-report.md
+++ b/.changeset/calm-mice-report.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix My Ledger top bar `button_clicked` analytics to use current route path for the `page` property

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/__integrations__/MyWalletTopBar.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/__integrations__/MyWalletTopBar.integration.test.tsx
@@ -57,7 +57,7 @@ describe("MyWallet ContextMenu", () => {
 
     expect(mockTrack).toHaveBeenCalledWith("button_clicked", {
       button: MY_WALLET_TRACKING_BUTTON.menu,
-      page: MY_WALLET_TRACKING_PAGE_NAME,
+      page: "/",
     });
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ContextMenu/hooks/useContextMenuViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ContextMenu/hooks/useContextMenuViewModel.ts
@@ -1,19 +1,20 @@
 import { useCallback, useMemo, useState } from "react";
 import { track } from "~/renderer/analytics/segment";
 import type { ContextMenuViewProps } from "../types";
-import { MY_WALLET_TRACKING_BUTTON, MY_WALLET_TRACKING_PAGE_NAME } from "../../../constants";
+import { MY_WALLET_TRACKING_BUTTON } from "../../../constants";
+import { useLocation } from "react-router";
 
 export function useContextMenuViewModel(): ContextMenuViewProps {
   const [open, setOpen] = useState(false);
   const close = useCallback(() => setOpen(false), []);
   const contextValue = useMemo(() => ({ close }), [close]);
-
+  const location = useLocation();
   const onOpenChange = (nextOpen: boolean) => {
     setOpen(nextOpen);
     if (nextOpen) {
       track("button_clicked", {
         button: MY_WALLET_TRACKING_BUTTON.menu,
-        page: MY_WALLET_TRACKING_PAGE_NAME,
+        page: location.pathname,
       });
     }
   };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request addresses an analytics issue in the My Ledger top bar by ensuring that the correct page path is reported when the "button_clicked" event is tracked. The update simplifies the logic so that the current route path is always used for the page property.

### ❓ Context

[LIVE-25825](https://ledgerhq.atlassian.net/browse/LIVE-25825)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-25825]: https://ledgerhq.atlassian.net/browse/LIVE-25825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ