### PR TITLE
Sent slack notification even when allure export fails

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -869,6 +869,7 @@ jobs:
           allure-results-path: ios-test-artifacts
           platform: iOS
       - name: Aggregate test results
+        if: ${{ !cancelled() }}
         id: aggregate
         uses: LedgerHQ/ledger-live/tools/actions/composites/aggregate-shard-results@develop
         with:
@@ -886,7 +887,7 @@ jobs:
           status_11: ${{ needs.detox-tests-ios.outputs.status_11 }}
           status_12: ${{ needs.detox-tests-ios.outputs.status_12 }}
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        if: ${{ github.event_name == 'schedule' || inputs.generate_ai_artifacts == true }}
+        if: ${{ !cancelled() && (github.event_name == 'schedule' || inputs.generate_ai_artifacts == true) }}
         with:
           ref: ${{ inputs.ref || github.sha }}
           repository: LedgerHQ/ledger-live
@@ -894,13 +895,13 @@ jobs:
           sparse-checkout: e2e/mobile/scripts
           path: repo
       - name: Build iOS AI artifact
-        if: ${{ github.event_name == 'schedule' || inputs.generate_ai_artifacts == true }}
+        if: ${{ !cancelled() && (github.event_name == 'schedule' || inputs.generate_ai_artifacts == true) }}
         env:
           ARTIFACTS: ios-test-artifacts
           OUT: ios-ai
         run: bash repo/e2e/mobile/scripts/build-ai-artifact.sh
       - name: Upload iOS AI artifact
-        if: ${{ github.event_name == 'schedule' || inputs.generate_ai_artifacts == true }}
+        if: ${{ !cancelled() && (github.event_name == 'schedule' || inputs.generate_ai_artifacts == true) }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: ios-ai-analysis
@@ -941,6 +942,7 @@ jobs:
           allure-results-path: android-test-artifacts
           platform: android
       - name: Aggregate test results
+        if: ${{ !cancelled() }}
         id: aggregate
         uses: LedgerHQ/ledger-live/tools/actions/composites/aggregate-shard-results@develop
         with:
@@ -958,7 +960,7 @@ jobs:
           status_11: ${{ needs.detox-tests-android.outputs.status_11 }}
           status_12: ${{ needs.detox-tests-android.outputs.status_12 }}
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        if: ${{ github.event_name == 'schedule' || inputs.generate_ai_artifacts == true }}
+        if: ${{ !cancelled() && (github.event_name == 'schedule' || inputs.generate_ai_artifacts == true) }}
         with:
           ref: ${{ inputs.ref || github.sha }}
           repository: LedgerHQ/ledger-live
@@ -966,13 +968,13 @@ jobs:
           sparse-checkout: e2e/mobile/scripts
           path: repo
       - name: Build Android AI artifact
-        if: ${{ github.event_name == 'schedule' || inputs.generate_ai_artifacts == true }}
+        if: ${{ !cancelled() && (github.event_name == 'schedule' || inputs.generate_ai_artifacts == true) }}
         env:
           ARTIFACTS: android-test-artifacts
           OUT: android-ai
         run: bash repo/e2e/mobile/scripts/build-ai-artifact.sh
       - name: Upload Android AI artifact
-        if: ${{ github.event_name == 'schedule' || inputs.generate_ai_artifacts == true }}
+        if: ${{ !cancelled() && (github.event_name == 'schedule' || inputs.generate_ai_artifacts == true) }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: android-ai-analysis
@@ -1049,7 +1051,7 @@ jobs:
     name: "Test Mobile E2E > Slack Report"
     runs-on: ubuntu-22.04
     needs: [allure-report-android, allure-report-ios]
-    if: ${{ !cancelled() && (needs.allure-report-ios.outputs.report-url || needs.allure-report-android.outputs.report-url) }}
+    if: ${{ !cancelled() && (needs.allure-report-ios.outputs.finalStatus || needs.allure-report-android.outputs.finalStatus) }}
     env:
       IOS_STATUS: ${{ needs.allure-report-ios.outputs.finalStatus }}
       IOS_REPORT_URL: ${{ needs.allure-report-ios.outputs.report-url }}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached. (no need)
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - E2E Mobile report 

### 📝 Description

Slack notification of E2E Mobile nightly tests are skipped if allure server export fails. ([Ex](https://github.com/LedgerHQ/ledger-live/actions/runs/25202203639/job/73910789592))
Changing conditions to not rely on allure export results


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- [Smoke](https://github.com/LedgerHQ/ledger-live/actions/runs/25310951960)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
