### PR TITLE
[LWM] feat(lwm): exclude currency ids to use the new send flow

### DIFF
--- a/.changeset/selfish-needles-raise.md
+++ b/.changeset/selfish-needles-raise.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+feat(lwm): adapt newSendFlow FF for the excludeCurrencyIds params on LWM

--- a/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
+++ b/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
@@ -264,8 +264,9 @@ export function useSignedTxHandler({
   const mevProtected = useSelector(mevProtectionSelector);
   const navigation = useNavigation();
   const route = useRoute();
-  const newSendFlowFeature = useNewSendFlowFeature();
-  const newSendFlow = newSendFlowFeature.isEnabledForFamily(parentAccount?.currency.family);
+  const mainAccount = getMainAccount(account, parentAccount);
+  const { isEnabledForFamily } = useNewSendFlowFeature();
+  const newSendFlow = isEnabledForFamily(mainAccount.currency.family, mainAccount.currency.id);
   const broadcast = useBroadcast({
     account,
     parentAccount,
@@ -275,7 +276,6 @@ export function useSignedTxHandler({
     },
   });
   const dispatch = useDispatch();
-  const mainAccount = getMainAccount(account, parentAccount);
   return useCallback(
     // TODO: fix type error
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useNewSendFlowFeature.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useNewSendFlowFeature.ts
@@ -3,6 +3,7 @@ import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 import {
   getNewSendFlowAllowedFamilies,
+  getNewSendFlowExcludedCurrencyIds,
   isFamilyAllowedForNewSendFlow,
   isValidNewSendFlowConfig,
 } from "../utils/newSendFlowConfig";
@@ -11,10 +12,17 @@ export function useNewSendFlowFeature() {
   const feature = useFeature("newSendFlow");
 
   const allowedFamilies = getNewSendFlowAllowedFamilies(feature);
+  const excludedCurrencyIds = getNewSendFlowExcludedCurrencyIds(feature);
   const isValidConfig = isValidNewSendFlowConfig(feature);
 
-  const isEnabledForFamily = (family?: string): boolean =>
-    isFamilyAllowedForNewSendFlow(family, allowedFamilies, isValidConfig);
+  const isEnabledForFamily = (family?: string, currencyId?: string): boolean =>
+    isValidConfig &&
+    isFamilyAllowedForNewSendFlow(
+      family,
+      allowedFamilies,
+      currencyId,
+      excludedCurrencyIds,
+    );
 
   const getFamilyFromAccount = (
     account?: AccountLike,
@@ -23,11 +31,20 @@ export function useNewSendFlowFeature() {
     return account ? getMainAccount(account, parentAccount ?? null).currency.family : undefined;
   };
 
+  const getCurrencyIdFromAccount = (
+    account?: AccountLike,
+    parentAccount?: Account | null,
+  ): string | undefined => {
+    return account ? getMainAccount(account, parentAccount ?? null).currency.id : undefined;
+  };
+
   return {
     feature,
     isEnabled: feature?.enabled ?? false,
     isEnabledForFamily,
     getFamilyFromAccount,
+    getCurrencyIdFromAccount,
     allowedFamilies,
+    excludedCurrencyIds,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/utils/__tests__/newSendFlowConfig.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/utils/__tests__/newSendFlowConfig.test.ts
@@ -1,5 +1,6 @@
 import {
   getNewSendFlowAllowedFamilies,
+  getNewSendFlowExcludedCurrencyIds,
   isFamilyAllowedForNewSendFlow,
   isValidNewSendFlowConfig,
 } from "../newSendFlowConfig";
@@ -60,27 +61,54 @@ describe("newSendFlowConfig", () => {
     });
   });
 
+  describe("getNewSendFlowExcludedCurrencyIds", () => {
+    it("should return empty array when feature is null or undefined", () => {
+      expect(getNewSendFlowExcludedCurrencyIds(null)).toEqual([]);
+      expect(getNewSendFlowExcludedCurrencyIds(undefined)).toEqual([]);
+    });
+
+    it("should return empty array when excludedCurrencyIds is not an array", () => {
+      expect(
+        getNewSendFlowExcludedCurrencyIds({ params: { excludedCurrencyIds: "zcash" } }),
+      ).toEqual([]);
+      expect(getNewSendFlowExcludedCurrencyIds({ params: {} })).toEqual([]);
+    });
+
+    it("should return excluded currency ids array when valid", () => {
+      expect(
+        getNewSendFlowExcludedCurrencyIds({ params: { excludedCurrencyIds: ["zcash"] } }),
+      ).toEqual(["zcash"]);
+    });
+  });
+
   describe("isFamilyAllowedForNewSendFlow", () => {
     const allowedFamilies = ["ethereum", "bitcoin"];
 
-    it("should return false when config is invalid", () => {
-      expect(isFamilyAllowedForNewSendFlow("ethereum", allowedFamilies, false)).toBe(false);
-      expect(isFamilyAllowedForNewSendFlow(undefined, allowedFamilies, false)).toBe(false);
-    });
-
     it("should return true when family is undefined or empty (no filter)", () => {
-      expect(isFamilyAllowedForNewSendFlow(undefined, allowedFamilies, true)).toBe(true);
-      expect(isFamilyAllowedForNewSendFlow("", allowedFamilies, true)).toBe(true);
+      expect(isFamilyAllowedForNewSendFlow(undefined, allowedFamilies)).toBe(true);
+      expect(isFamilyAllowedForNewSendFlow("", allowedFamilies)).toBe(true);
     });
 
     it("should return true when family is in allowedFamilies", () => {
-      expect(isFamilyAllowedForNewSendFlow("ethereum", allowedFamilies, true)).toBe(true);
-      expect(isFamilyAllowedForNewSendFlow("bitcoin", allowedFamilies, true)).toBe(true);
+      expect(isFamilyAllowedForNewSendFlow("ethereum", allowedFamilies)).toBe(true);
+      expect(isFamilyAllowedForNewSendFlow("bitcoin", allowedFamilies)).toBe(true);
     });
 
     it("should return false when family is not in allowedFamilies", () => {
-      expect(isFamilyAllowedForNewSendFlow("solana", allowedFamilies, true)).toBe(false);
-      expect(isFamilyAllowedForNewSendFlow("cosmos", allowedFamilies, true)).toBe(false);
+      expect(isFamilyAllowedForNewSendFlow("solana", allowedFamilies)).toBe(false);
+      expect(isFamilyAllowedForNewSendFlow("cosmos", allowedFamilies)).toBe(false);
+    });
+
+    it("should return false when currency is excluded even if family is allowed", () => {
+      expect(isFamilyAllowedForNewSendFlow("bitcoin", allowedFamilies, "zcash", ["zcash"])).toBe(
+        false,
+      );
+    });
+
+    it("should return true when family is allowed and currency is not excluded", () => {
+      expect(isFamilyAllowedForNewSendFlow("bitcoin", allowedFamilies, "bitcoin", ["zcash"])).toBe(
+        true,
+      );
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/utils/newSendFlowConfig.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/utils/newSendFlowConfig.ts
@@ -5,7 +5,7 @@
 
 export type NewSendFlowFeatureParams = {
   enabled?: boolean;
-  params?: { families?: unknown };
+  params?: { families?: unknown; excludedCurrencyIds?: unknown };
 };
 
 /**
@@ -30,17 +30,28 @@ export function getNewSendFlowAllowedFamilies(
 }
 
 /**
- * Returns true if the new send flow is enabled for the given family.
- * When config is invalid: false.
+ * Returns the list of excluded currency ids (empty array if not an array).
+ */
+export function getNewSendFlowExcludedCurrencyIds(
+  feature: NewSendFlowFeatureParams | null | undefined,
+): readonly string[] {
+  const excludedCurrencyIds = feature?.params?.excludedCurrencyIds;
+  return Array.isArray(excludedCurrencyIds) ? excludedCurrencyIds : [];
+}
+
+/**
+ * Returns true if the given family and currency match the new send flow filters.
+ * When currency is excluded: false.
  * When family is undefined: true (no filter).
  * Otherwise: true iff family is in allowedFamilies.
  */
 export function isFamilyAllowedForNewSendFlow(
   family: string | undefined,
   allowedFamilies: readonly string[],
-  isConfigValid: boolean,
+  currencyId?: string,
+  excludedCurrencyIds: readonly string[] = [],
 ): boolean {
-  if (!isConfigValid) return false;
+  if (currencyId && excludedCurrencyIds.includes(currencyId)) return false;
   if (family === undefined || family === "") return true;
   return allowedFamilies.includes(family);
 }

--- a/apps/ledger-live-mobile/src/screens/Account/hooks/useAccountActions.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/hooks/useAccountActions.tsx
@@ -174,9 +174,8 @@ export default function useAccountActions({ account, parentAccount, colors }: Pr
     [isPtxServiceCtaScreensDisabled, currency, account, t, isZeroBalance],
   );
 
-  const { isEnabledForFamily, getFamilyFromAccount } = useNewSendFlowFeature();
-  const accountFamily = getFamilyFromAccount(account, parentAccount);
-  const shouldUseNewFlow = isEnabledForFamily(accountFamily);
+  const { isEnabledForFamily } = useNewSendFlowFeature();
+  const shouldUseNewFlow = isEnabledForFamily(mainAccount.currency.family, mainAccount.currency.id);
 
   const SendAction = useMemo(
     () => ({

--- a/apps/ledger-live-mobile/src/screens/SelectAccount.tsx
+++ b/apps/ledger-live-mobile/src/screens/SelectAccount.tsx
@@ -68,7 +68,8 @@ function ReceiveFunds({ navigation, route }: Props) {
     ? enhancedAccounts.filter(account => !isAccountEmpty(account))
     : enhancedAccounts;
 
-  const { isEnabledForFamily, getFamilyFromAccount } = useNewSendFlowFeature();
+  const { isEnabledForFamily, getFamilyFromAccount, getCurrencyIdFromAccount } =
+    useNewSendFlowFeature();
 
   const handleSelectAccount = useCallback(
     (account: AccountLike) => {
@@ -81,7 +82,8 @@ function ReceiveFunds({ navigation, route }: Props) {
         if (next === ScreenName.SendSelectRecipient) {
           const parentAccount = getParentAccount(account, accounts);
           const accountFamily = getFamilyFromAccount(account, parentAccount);
-          const shouldUseNewFlow = isEnabledForFamily(accountFamily);
+          const accountCurrencyId = getCurrencyIdFromAccount(account, parentAccount);
+          const shouldUseNewFlow = isEnabledForFamily(accountFamily, accountCurrencyId);
 
           if (shouldUseNewFlow) {
             const mainAccount = getMainAccount(account, parentAccount);
@@ -121,6 +123,7 @@ function ReceiveFunds({ navigation, route }: Props) {
       route.params,
       isEnabledForFamily,
       getFamilyFromAccount,
+      getCurrencyIdFromAccount,
     ],
   );
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

We want to have some families to use the new send flow, but to block it on some specific currencies (eg bitcoin has the new send flow but not zcash)
This PR fixes this by using the excludedCurrencyIds FF param on LWM

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **[JIRA or GitHub link](https://ledgerhq.atlassian.net/browse/LIVE-30185)** <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
