### PR TITLE
test(desktop): strengthen ledger sync e2e checks

### DIFF
--- a/e2e/desktop/tests/component/layout.component.ts
+++ b/e2e/desktop/tests/component/layout.component.ts
@@ -62,6 +62,13 @@ export class Layout extends Component {
     await this.topbarSynchronizeButton.click();
   }
 
+  @step("Synchronize accounts if available")
+  async syncAccountsIfAvailable() {
+    if (await this.topbarSynchronizeButton.isEnabled()) {
+      await this.syncAccounts();
+    }
+  }
+
   @step("Wait for accounts sync to be finished")
   async waitForAccountsSyncToBeDone() {
     await expect(this.topbarSynchronizeButton).not.toHaveText("Synchronizing");

--- a/e2e/desktop/tests/page/accounts.page.ts
+++ b/e2e/desktop/tests/page/accounts.page.ts
@@ -88,25 +88,31 @@ export class AccountsPage extends AppPage {
     await expect(this.visibleAccountsList).toHaveCount(count, { timeout });
   }
 
+  private async getReduxAccountIds(): Promise<string[]> {
+    return this.page.evaluate(() => {
+      const store = window.__STORE__;
+      if (!store?.getState) return [];
+      const state: { accounts?: { id?: string }[] } = store.getState();
+      return (
+        state.accounts
+          ?.map(account => account.id)
+          .filter((accountId): accountId is string => Boolean(accountId)) ?? []
+      );
+    });
+  }
+
   /**
    * Waits until the in-app Redux store has the expected number of accounts.
    * Use after Ledger Sync / bridge merges (CI can show the success screen before all rows exist).
    */
   @step("Expect Redux accounts length to be $0")
   async expectReduxAccountsLength(count: number) {
-    await expect
-      .poll(
-        async () =>
-          this.page.evaluate(() => {
-            const store = // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-              (globalThis as { __STORE__?: { getState?: () => { accounts?: unknown[] } } })
-                .__STORE__;
-            if (!store?.getState) return -1;
-            return store.getState().accounts?.length ?? 0;
-          }),
-        { timeout: 60_000 },
-      )
-      .toBe(count);
+    await expect.poll(async () => (await this.getReduxAccountIds()).length).toBe(count);
+  }
+
+  @step("Expect Redux account ids to be $0")
+  async expectReduxAccountIds(expectedAccountIds: string[]) {
+    await expect.poll(async () => await this.getReduxAccountIds()).toEqual(expectedAccountIds);
   }
 
   @step("Expect crypto account row for $0 to be visible")

--- a/e2e/desktop/tests/page/accounts.page.ts
+++ b/e2e/desktop/tests/page/accounts.page.ts
@@ -90,7 +90,7 @@ export class AccountsPage extends AppPage {
 
   private async getReduxAccountIds(): Promise<string[]> {
     return this.page.evaluate(() => {
-      const store = window.__STORE__;
+      const store = globalThis.window.__STORE__;
       if (!store?.getState) return [];
       const state: { accounts?: { id?: string }[] } = store.getState();
       return (
@@ -99,6 +99,14 @@ export class AccountsPage extends AppPage {
           .filter((accountId): accountId is string => Boolean(accountId)) ?? []
       );
     });
+  }
+
+  private async hasReduxAccountIds(expectedAccountIds: string[]): Promise<boolean> {
+    const accountIds = await this.getReduxAccountIds();
+    return (
+      accountIds.length === expectedAccountIds.length &&
+      expectedAccountIds.every(accountId => accountIds.includes(accountId))
+    );
   }
 
   /**
@@ -112,7 +120,7 @@ export class AccountsPage extends AppPage {
 
   @step("Expect Redux account ids to be $0")
   async expectReduxAccountIds(expectedAccountIds: string[]) {
-    await expect.poll(async () => await this.getReduxAccountIds()).toEqual(expectedAccountIds);
+    await expect.poll(async () => await this.hasReduxAccountIds(expectedAccountIds)).toBe(true);
   }
 
   @step("Expect crypto account row for $0 to be visible")

--- a/e2e/desktop/tests/page/accounts.page.ts
+++ b/e2e/desktop/tests/page/accounts.page.ts
@@ -93,20 +93,15 @@ export class AccountsPage extends AppPage {
       const store = globalThis.window.__STORE__;
       if (!store?.getState) return [];
       const state: { accounts?: { id?: string }[] } = store.getState();
-      return (
-        state.accounts
-          ?.map(account => account.id)
-          .filter((accountId): accountId is string => Boolean(accountId)) ?? []
-      );
-    });
-  }
 
-  private async hasReduxAccountIds(expectedAccountIds: string[]): Promise<boolean> {
-    const accountIds = await this.getReduxAccountIds();
-    return (
-      accountIds.length === expectedAccountIds.length &&
-      expectedAccountIds.every(accountId => accountIds.includes(accountId))
-    );
+      if (state.accounts) {
+        return state.accounts
+          .map(account => account.id)
+          .filter((accountId): accountId is string => Boolean(accountId));
+      }
+
+      return [];
+    });
   }
 
   /**
@@ -115,12 +110,25 @@ export class AccountsPage extends AppPage {
    */
   @step("Expect Redux accounts length to be $0")
   async expectReduxAccountsLength(count: number) {
-    await expect.poll(async () => (await this.getReduxAccountIds()).length).toBe(count);
+    await expect
+      .poll(async () => (await this.getReduxAccountIds()).length, { timeout: 60_000 })
+      .toBe(count);
   }
 
   @step("Expect Redux account ids to be $0")
   async expectReduxAccountIds(expectedAccountIds: string[]) {
-    await expect.poll(async () => await this.hasReduxAccountIds(expectedAccountIds)).toBe(true);
+    await expect
+      .poll(
+        async () => {
+          const accountIds = await this.getReduxAccountIds();
+          return (
+            accountIds.length === expectedAccountIds.length &&
+            expectedAccountIds.every(accountId => accountIds.includes(accountId))
+          );
+        },
+        { timeout: 60_000 },
+      )
+      .toBe(true);
   }
 
   @step("Expect crypto account row for $0 to be visible")

--- a/e2e/desktop/tests/page/drawer/ledger.sync.drawer.ts
+++ b/e2e/desktop/tests/page/drawer/ledger.sync.drawer.ts
@@ -20,8 +20,11 @@ export class LedgerSyncDrawer extends Drawer {
     "Your Ledger Wallet app on CLI is no longer connected to Ledger Sync",
   );
   private displayInstances = this.page.getByTestId("walletSync-manage-instances-label");
-  private removeCLI = this.page.getByTestId("walletSync-manage-instance-CLI").getByText("Remove");
-  private fromNowOnYourPortfolioIsSyncedText = this.page.getByText("From now on, your portfolio");
+  private cliMember = this.page.getByTestId("walletSync-manage-instance-CLI");
+  private removeCLI = this.cliMember.getByText("Remove");
+  private synchronizationSuccessText = this.page.getByText(
+    /From now on, your portfolio|Sync successful!/,
+  );
 
   @step("Synchronize accounts")
   async syncAccounts() {
@@ -52,6 +55,12 @@ export class LedgerSyncDrawer extends Drawer {
 
   async waitForDeleteSyncButton() {
     await this.deleteSyncButton.waitFor({ state: "visible" });
+  }
+
+  @step("Check if Ledger Sync management drawer is visible")
+  async expectLedgerSyncManagementVisible() {
+    await expect(this.deleteSyncButton).toBeVisible();
+    await expect(this.displayInstances).toBeVisible();
   }
 
   @step("Delete Sync")
@@ -86,7 +95,7 @@ export class LedgerSyncDrawer extends Drawer {
 
   @step("Check if synchronization was successful")
   async expectSynchronizationSuccess() {
-    await expect(this.fromNowOnYourPortfolioIsSyncedText).toBeVisible();
+    await expect(this.synchronizationSuccessText).toBeVisible();
   }
 
   @step("Check if the backup deletion was successful")
@@ -109,6 +118,16 @@ export class LedgerSyncDrawer extends Drawer {
   @step("Remove ClI member")
   async removeCLIMember() {
     await this.removeCLI.click();
+  }
+
+  @step("Check if the CLI member is visible")
+  async expectCLIMemberVisible() {
+    await expect(this.cliMember).toBeVisible();
+  }
+
+  @step("Check if the CLI member was removed")
+  async expectCLIMemberRemoved() {
+    await expect(this.cliMember).not.toBeVisible();
   }
 
   @step("Check if the member removal was successful")

--- a/e2e/desktop/tests/page/drawer/ledger.sync.drawer.ts
+++ b/e2e/desktop/tests/page/drawer/ledger.sync.drawer.ts
@@ -20,9 +20,9 @@ export class LedgerSyncDrawer extends Drawer {
     "Your Ledger Wallet app on CLI is no longer connected to Ledger Sync",
   );
   private displayInstances = this.page.getByTestId("walletSync-manage-instances-label");
-  private cliMember = this.page.getByTestId("walletSync-manage-instance-CLI");
-  private removeCLI = this.cliMember.getByText("Remove");
-  private synchronizationSuccessText = this.page.getByText(
+  private readonly cliMember = this.page.getByTestId("walletSync-manage-instance-CLI");
+  private readonly removeCLI = this.cliMember.getByText("Remove");
+  private readonly synchronizationSuccessText = this.page.getByText(
     /From now on, your portfolio|Sync successful!/,
   );
 

--- a/e2e/desktop/tests/page/drawer/ledger.sync.drawer.ts
+++ b/e2e/desktop/tests/page/drawer/ledger.sync.drawer.ts
@@ -125,7 +125,7 @@ export class LedgerSyncDrawer extends Drawer {
     await expect(this.cliMember).toBeVisible();
   }
 
-  @step("Check if the CLI member was removed")
+  @step("Check if the CLI member is not visible")
   async expectCLIMemberRemoved() {
     await expect(this.cliMember).not.toBeVisible();
   }

--- a/e2e/desktop/tests/page/settings.page.ts
+++ b/e2e/desktop/tests/page/settings.page.ts
@@ -102,6 +102,11 @@ export class SettingsPage extends AppPage {
     await this.manageWalletSyncButton.click();
   }
 
+  @step("Expect Ledger Sync settings entry point to be visible")
+  async expectLedgerSyncSettingsEntryPoint() {
+    await expect(this.manageWalletSyncButton.or(this.syncWalletSyncButton)).toBeVisible();
+  }
+
   @step("Enable Wallet Sync")
   async enableWalletSync() {
     if (await this.turnOnLedgerSyncButton.isVisible()) {

--- a/e2e/desktop/tests/specs/ledgerSync.spec.ts
+++ b/e2e/desktop/tests/specs/ledgerSync.spec.ts
@@ -4,7 +4,6 @@ import { AppInfos } from "@ledgerhq/live-common/e2e/enum/AppInfos";
 import { addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
 import { CLI } from "tests/utils/cliUtils";
-import { expect } from "@playwright/test";
 import { LedgerSyncCliHelper } from "tests/utils/ledgerSyncCliUtils";
 import { accountNames, accounts } from "tests/testdata/ledgerSyncTestData";
 import { getEnv, setEnv } from "@ledgerhq/live-env";
@@ -14,6 +13,7 @@ const firstAccountId = accounts[0].id;
 const firstAccountName = accountNames[firstAccountId];
 const secondAccountId = accounts[1].id;
 const secondAccountName = accountNames[secondAccountId];
+const renamedSecondAccountName = `${secondAccountName}_renamed`;
 
 function setupSeed() {
   const prevSeed = getEnv("SEED");
@@ -92,61 +92,66 @@ test.describe(`[${app.name}] Sync Accounts`, () => {
 
       // Success copy can appear before the watch loop finishes importing every descriptor (retries use backoff).
       await app.accounts.expectReduxAccountsLength(2);
+      await app.accounts.expectReduxAccountIds([firstAccountId, secondAccountId]);
 
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.accounts.expectAccountsCount(2, 60_000);
+      await app.accounts.expectCryptoAccountRowVisible(firstAccountName);
+      await app.accounts.expectCryptoAccountRowVisible(secondAccountName);
 
       await app.accounts.navigateToAccountByName(firstAccountName);
       await app.account.expectAccountVisibility(firstAccountName);
       await app.account.deleteAccount();
+      await app.accounts.expectReduxAccountIds([secondAccountId]);
+      await app.accounts.expectAccountAbsence(firstAccountName);
+
       await app.accounts.navigateToAccountByName(secondAccountName);
       await app.account.expectAccountVisibility(secondAccountName);
-      await app.account.renameAccount(secondAccountName + "_renamed");
+      await app.account.renameAccount(renamedSecondAccountName);
+      await app.account.expectAccountVisibility(renamedSecondAccountName);
 
-      if (await app.layout.topbarSynchronizeButton.isEnabled()) {
-        // trigger sync if not triggered automatically
-        await app.layout.syncAccounts();
-      }
-
-      expect(await LedgerSyncCliHelper.checkSynchronizationSuccess(page, app)).toBeDefined();
+      await app.layout.syncAccountsIfAvailable();
+      await LedgerSyncCliHelper.checkSynchronizationSuccess(page, app);
 
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.accounts.expectReduxAccountsLength(1);
+      await app.accounts.expectReduxAccountIds([secondAccountId]);
       await app.accounts.expectAccountsCount(1, 60_000);
+      await app.accounts.expectCryptoAccountRowVisible(renamedSecondAccountName);
+      await app.accounts.expectAccountAbsence(firstAccountName);
 
       const pulledData = await CLI.ledgerSync({
         ...LedgerSyncCliHelper.ledgerKeyRingProtocolArgs,
         ...LedgerSyncCliHelper.ledgerSyncPullDataArgs,
       });
 
-      const parsedData = LedgerSyncCliHelper.parseData(pulledData);
+      LedgerSyncCliHelper.expectPulledDataToMatchAccountChanges(pulledData, {
+        deletedAccountId: firstAccountId,
+        remainingAccountId: secondAccountId,
+        expectedRemainingAccountName: renamedSecondAccountName,
+      });
 
       await app.mainNavigation.openSettings();
       await app.settings.openManageLedgerSync();
       await app.ledgerSync.manageInstances();
+      await app.ledgerSync.expectCLIMemberVisible();
       await app.ledgerSync.removeCLIMember();
       await app.speculos.removeMemberFromLedgerSync();
       await app.ledgerSync.expectMemberRemoval();
+      await app.ledgerSync.expectCLIMemberRemoved();
       await app.drawer.closeDrawer();
 
       await app.mainNavigation.openSettings();
       await app.settings.openManageLedgerSync();
+      await app.ledgerSync.manageInstances();
+      await app.ledgerSync.expectCLIMemberRemoved();
+      await app.drawer.closeDrawer();
+      await app.ledgerSync.expectLedgerSyncManagementVisible();
+
       await app.ledgerSync.destroyTrustchain();
       await app.ledgerSync.expectBackupDeletion();
       await app.drawer.closeDrawer();
-
-      expect(
-        await LedgerSyncCliHelper.checkAccountDeletion(parsedData, firstAccountId),
-        "Account should not be present",
-      ).toBeUndefined();
-      expect(
-        LedgerSyncCliHelper.isAccountRenamedCorrectly(
-          parsedData,
-          secondAccountId,
-          secondAccountName + "_renamed",
-        ),
-        "Account should be renamed correctly",
-      ).toBeDefined();
+      await app.settings.expectLedgerSyncSettingsEntryPoint();
     },
   );
 });

--- a/e2e/desktop/tests/specs/ledgerSync.spec.ts
+++ b/e2e/desktop/tests/specs/ledgerSync.spec.ts
@@ -5,6 +5,7 @@ import { addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
 import { CLI } from "tests/utils/cliUtils";
 import { LedgerSyncCliHelper } from "tests/utils/ledgerSyncCliUtils";
+import { expectPulledDataToMatchAccountChanges } from "tests/utils/ledgerSyncPulledDataUtils";
 import { accountNames, accounts } from "tests/testdata/ledgerSyncTestData";
 import { getEnv, setEnv } from "@ledgerhq/live-env";
 
@@ -125,7 +126,7 @@ test.describe(`[${app.name}] Sync Accounts`, () => {
         ...LedgerSyncCliHelper.ledgerSyncPullDataArgs,
       });
 
-      LedgerSyncCliHelper.expectPulledDataToMatchAccountChanges(pulledData, {
+      expectPulledDataToMatchAccountChanges(pulledData, {
         deletedAccountId: firstAccountId,
         remainingAccountId: secondAccountId,
         expectedRemainingAccountName: renamedSecondAccountName,

--- a/e2e/desktop/tests/specs/ledgerSync.spec.ts
+++ b/e2e/desktop/tests/specs/ledgerSync.spec.ts
@@ -111,8 +111,9 @@ test.describe(`[${app.name}] Sync Accounts`, () => {
       await app.account.renameAccount(renamedSecondAccountName);
       await app.account.expectAccountVisibility(renamedSecondAccountName);
 
+      const cloudSyncResponse = LedgerSyncCliHelper.getCloudSyncResponse(page);
       await app.layout.syncAccountsIfAvailable();
-      await LedgerSyncCliHelper.checkSynchronizationSuccess(page, app);
+      await LedgerSyncCliHelper.checkSynchronizationSuccess(cloudSyncResponse, app);
 
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.accounts.expectReduxAccountsLength(1);

--- a/e2e/desktop/tests/utils/ledgerSyncCliUtils.ts
+++ b/e2e/desktop/tests/utils/ledgerSyncCliUtils.ts
@@ -4,7 +4,7 @@ import { accountNames, accounts } from "tests/testdata/ledgerSyncTestData";
 import { expect, Page, Response } from "@playwright/test";
 import { Application } from "tests/page";
 import { getEnv } from "@ledgerhq/live-env";
-import invariant from "invariant";
+
 interface LedgerKeyRingProtocolArgs {
   pubKey: string;
   privateKey: string;
@@ -38,27 +38,6 @@ interface LedgerOutput {
   rootId?: string;
   walletSyncEncryptionKey?: string;
   applicationPath?: string;
-}
-
-interface LedgerSyncAccountData {
-  id?: string;
-  currencyId?: string;
-  index?: number;
-}
-
-interface LedgerSyncPulledData {
-  updateEvent?: {
-    data?: {
-      accounts?: LedgerSyncAccountData[];
-      accountNames?: Record<string, string>;
-    };
-  };
-}
-
-interface ExpectedSyncedAccountData {
-  deletedAccountId: string;
-  remainingAccountId: string;
-  expectedRemainingAccountName: string;
 }
 
 function isLedgerOutput(output: unknown): output is LedgerOutput {
@@ -139,16 +118,6 @@ export class LedgerSyncCliHelper {
     }
   }
 
-  static parseData(pulledData: string | void): LedgerSyncPulledData {
-    invariant(pulledData, "Ledger Sync: pulledData is undefined");
-    try {
-      const parsedData: LedgerSyncPulledData = JSON.parse(pulledData);
-      return parsedData;
-    } catch (error) {
-      throw new Error(`Failed to parse pulledData: ${error}`);
-    }
-  }
-
   static getCloudSyncResponse(page: Page): Promise<Response> {
     return page.waitForResponse(
       response =>
@@ -190,75 +159,10 @@ export class LedgerSyncCliHelper {
     });
   }
 
-  static async checkSynchronizationSuccess(page: Page, app: Application): Promise<Response> {
+  static async checkSynchronizationSuccess(page: Page, app: Application): Promise<void> {
     const cloudSyncResponse = LedgerSyncCliHelper.getCloudSyncResponse(page);
     await app.layout.waitForAccountsSyncToBeDone();
-    return cloudSyncResponse;
-  }
-
-  private static findSyncedAccount(
-    parsedData: LedgerSyncPulledData,
-    accountId: string,
-  ): LedgerSyncAccountData | undefined {
-    return parsedData.updateEvent?.data?.accounts?.find(account => account.id === accountId);
-  }
-
-  private static getSyncedAccountIds(parsedData: LedgerSyncPulledData): string[] {
-    return (
-      parsedData.updateEvent?.data?.accounts
-        ?.map(account => account.id)
-        .filter((accountId): accountId is string => Boolean(accountId)) ?? []
-    );
-  }
-
-  private static getSyncedAccountName(
-    parsedData: LedgerSyncPulledData,
-    accountId: string,
-  ): string | undefined {
-    return parsedData.updateEvent?.data?.accountNames?.[accountId];
-  }
-
-  private static isAccountDeleted(parsedData: LedgerSyncPulledData, accountId: string): boolean {
-    return !LedgerSyncCliHelper.findSyncedAccount(parsedData, accountId);
-  }
-
-  private static isAccountRenamedCorrectly(
-    parsedData: LedgerSyncPulledData,
-    accountId: string,
-    expectedName: string,
-  ): boolean {
-    return LedgerSyncCliHelper.getSyncedAccountName(parsedData, accountId) === expectedName;
-  }
-
-  static expectPulledDataToMatchAccountChanges(
-    pulledData: string | void,
-    {
-      deletedAccountId,
-      remainingAccountId,
-      expectedRemainingAccountName,
-    }: ExpectedSyncedAccountData,
-  ) {
-    const parsedData = LedgerSyncCliHelper.parseData(pulledData);
-
-    expect(
-      LedgerSyncCliHelper.getSyncedAccountIds(parsedData),
-      "Backend data should only contain the remaining account",
-    ).toEqual([remainingAccountId]);
-    expect(
-      LedgerSyncCliHelper.isAccountDeleted(parsedData, deletedAccountId),
-      "Deleted account should not be present in backend accounts",
-    ).toBe(true);
-    expect(
-      LedgerSyncCliHelper.getSyncedAccountName(parsedData, remainingAccountId),
-      "Backend account name should match the renamed account",
-    ).toBe(expectedRemainingAccountName);
-    expect(
-      LedgerSyncCliHelper.isAccountRenamedCorrectly(
-        parsedData,
-        remainingAccountId,
-        expectedRemainingAccountName,
-      ),
-      "Account should be renamed correctly",
-    ).toBe(true);
+    const response = await cloudSyncResponse;
+    await expect(response, "Cloud Sync response should complete").toBeDefined();
   }
 }

--- a/e2e/desktop/tests/utils/ledgerSyncCliUtils.ts
+++ b/e2e/desktop/tests/utils/ledgerSyncCliUtils.ts
@@ -123,6 +123,7 @@ export class LedgerSyncCliHelper {
       response =>
         response.url().startsWith(LedgerSyncCliHelper.cloudSyncApiBaseUrl + "/atomic/v1/live") &&
         response.status() === 200,
+      { timeout: 60_000 },
     );
   }
 
@@ -159,10 +160,12 @@ export class LedgerSyncCliHelper {
     });
   }
 
-  static async checkSynchronizationSuccess(page: Page, app: Application): Promise<void> {
-    const cloudSyncResponse = LedgerSyncCliHelper.getCloudSyncResponse(page);
+  static async checkSynchronizationSuccess(
+    cloudSyncResponse: Promise<Response>,
+    app: Application,
+  ): Promise<void> {
     await app.layout.waitForAccountsSyncToBeDone();
     const response = await cloudSyncResponse;
-    await expect(response, "Cloud Sync response should complete").toBeDefined();
+    expect(response.ok(), "Cloud Sync response should complete").toBe(true);
   }
 }

--- a/e2e/desktop/tests/utils/ledgerSyncCliUtils.ts
+++ b/e2e/desktop/tests/utils/ledgerSyncCliUtils.ts
@@ -150,16 +150,11 @@ export class LedgerSyncCliHelper {
   }
 
   static getCloudSyncResponse(page: Page): Promise<Response> {
-    return new Promise(resolve => {
-      page.on("response", response => {
-        if (
-          response.url().startsWith(LedgerSyncCliHelper.cloudSyncApiBaseUrl + "/atomic/v1/live") &&
-          response.status() === 200
-        ) {
-          resolve(response);
-        }
-      });
-    });
+    return page.waitForResponse(
+      response =>
+        response.url().startsWith(LedgerSyncCliHelper.cloudSyncApiBaseUrl + "/atomic/v1/live") &&
+        response.status() === 200,
+    );
   }
 
   static async initializeLedgerKeyRingProtocol() {

--- a/e2e/desktop/tests/utils/ledgerSyncCliUtils.ts
+++ b/e2e/desktop/tests/utils/ledgerSyncCliUtils.ts
@@ -1,7 +1,7 @@
 import { CLI } from "tests/utils/cliUtils";
 import { activateLedgerSync } from "@ledgerhq/live-common/e2e/speculos";
 import { accountNames, accounts } from "tests/testdata/ledgerSyncTestData";
-import { Page } from "@playwright/test";
+import { expect, Page, Response } from "@playwright/test";
 import { Application } from "tests/page";
 import { getEnv } from "@ledgerhq/live-env";
 import invariant from "invariant";
@@ -38,6 +38,31 @@ interface LedgerOutput {
   rootId?: string;
   walletSyncEncryptionKey?: string;
   applicationPath?: string;
+}
+
+interface LedgerSyncAccountData {
+  id?: string;
+  currencyId?: string;
+  index?: number;
+}
+
+interface LedgerSyncPulledData {
+  updateEvent?: {
+    data?: {
+      accounts?: LedgerSyncAccountData[];
+      accountNames?: Record<string, string>;
+    };
+  };
+}
+
+interface ExpectedSyncedAccountData {
+  deletedAccountId: string;
+  remainingAccountId: string;
+  expectedRemainingAccountName: string;
+}
+
+function isLedgerOutput(output: unknown): output is LedgerOutput {
+  return typeof output === "object" && output !== null;
 }
 
 export class LedgerSyncCliHelper {
@@ -83,8 +108,8 @@ export class LedgerSyncCliHelper {
     cloudSyncApiBaseUrl: LedgerSyncCliHelper.cloudSyncApiBaseUrl,
   };
 
-  private static updateKeysAndArgs(output: LedgerOutput) {
-    if (!output) return;
+  private static updateKeysAndArgs(output: unknown) {
+    if (!isLedgerOutput(output)) return;
     LedgerSyncCliHelper.updateKeyRingCredentials(output);
     LedgerSyncCliHelper.updateSyncArgs(output);
   }
@@ -114,16 +139,17 @@ export class LedgerSyncCliHelper {
     }
   }
 
-  static parseData(pulledData: string | void) {
+  static parseData(pulledData: string | void): LedgerSyncPulledData {
     invariant(pulledData, "Ledger Sync: pulledData is undefined");
     try {
-      return JSON.parse(pulledData);
+      const parsedData: LedgerSyncPulledData = JSON.parse(pulledData);
+      return parsedData;
     } catch (error) {
       throw new Error(`Failed to parse pulledData: ${error}`);
     }
   }
 
-  static getCloudSyncResponse(page: Page) {
+  static getCloudSyncResponse(page: Page): Promise<Response> {
     return new Promise(resolve => {
       page.on("response", response => {
         if (
@@ -138,7 +164,7 @@ export class LedgerSyncCliHelper {
 
   static async initializeLedgerKeyRingProtocol() {
     return CLI.ledgerKeyRingProtocol({ initMemberCredentials: true }).then(output => {
-      LedgerSyncCliHelper.updateKeysAndArgs(output as LedgerOutput);
+      LedgerSyncCliHelper.updateKeysAndArgs(output);
       return output;
     });
   }
@@ -148,7 +174,7 @@ export class LedgerSyncCliHelper {
       getKeyRingTree: true,
       ...LedgerSyncCliHelper.ledgerKeyRingProtocolArgs,
     }).then(out => {
-      LedgerSyncCliHelper.updateKeysAndArgs(out as LedgerOutput);
+      LedgerSyncCliHelper.updateKeysAndArgs(out);
       return out;
     });
     await activateLedgerSync();
@@ -169,23 +195,75 @@ export class LedgerSyncCliHelper {
     });
   }
 
-  static checkSynchronizationSuccess(page: Page, app: Application) {
-    app.layout.waitForAccountsSyncToBeDone();
-    return LedgerSyncCliHelper.getCloudSyncResponse(page);
+  static async checkSynchronizationSuccess(page: Page, app: Application): Promise<Response> {
+    const cloudSyncResponse = LedgerSyncCliHelper.getCloudSyncResponse(page);
+    await app.layout.waitForAccountsSyncToBeDone();
+    return cloudSyncResponse;
   }
 
-  static checkAccountDeletion(parsedData: any, accountId: string): any {
-    return parsedData.updateEvent.data.accounts?.find(
-      (account: { id: string }) => account.id === accountId,
+  private static findSyncedAccount(
+    parsedData: LedgerSyncPulledData,
+    accountId: string,
+  ): LedgerSyncAccountData | undefined {
+    return parsedData.updateEvent?.data?.accounts?.find(account => account.id === accountId);
+  }
+
+  private static getSyncedAccountIds(parsedData: LedgerSyncPulledData): string[] {
+    return (
+      parsedData.updateEvent?.data?.accounts
+        ?.map(account => account.id)
+        .filter((accountId): accountId is string => Boolean(accountId)) ?? []
     );
   }
 
-  static isAccountRenamedCorrectly(
-    parsedData: any,
+  private static getSyncedAccountName(
+    parsedData: LedgerSyncPulledData,
+    accountId: string,
+  ): string | undefined {
+    return parsedData.updateEvent?.data?.accountNames?.[accountId];
+  }
+
+  private static isAccountDeleted(parsedData: LedgerSyncPulledData, accountId: string): boolean {
+    return !LedgerSyncCliHelper.findSyncedAccount(parsedData, accountId);
+  }
+
+  private static isAccountRenamedCorrectly(
+    parsedData: LedgerSyncPulledData,
     accountId: string,
     expectedName: string,
   ): boolean {
-    const data = parsedData.updateEvent.data;
-    return data.accountNames?.[accountId] === expectedName;
+    return LedgerSyncCliHelper.getSyncedAccountName(parsedData, accountId) === expectedName;
+  }
+
+  static expectPulledDataToMatchAccountChanges(
+    pulledData: string | void,
+    {
+      deletedAccountId,
+      remainingAccountId,
+      expectedRemainingAccountName,
+    }: ExpectedSyncedAccountData,
+  ) {
+    const parsedData = LedgerSyncCliHelper.parseData(pulledData);
+
+    expect(
+      LedgerSyncCliHelper.getSyncedAccountIds(parsedData),
+      "Backend data should only contain the remaining account",
+    ).toEqual([remainingAccountId]);
+    expect(
+      LedgerSyncCliHelper.isAccountDeleted(parsedData, deletedAccountId),
+      "Deleted account should not be present in backend accounts",
+    ).toBe(true);
+    expect(
+      LedgerSyncCliHelper.getSyncedAccountName(parsedData, remainingAccountId),
+      "Backend account name should match the renamed account",
+    ).toBe(expectedRemainingAccountName);
+    expect(
+      LedgerSyncCliHelper.isAccountRenamedCorrectly(
+        parsedData,
+        remainingAccountId,
+        expectedRemainingAccountName,
+      ),
+      "Account should be renamed correctly",
+    ).toBe(true);
   }
 }

--- a/e2e/desktop/tests/utils/ledgerSyncPulledDataUtils.ts
+++ b/e2e/desktop/tests/utils/ledgerSyncPulledDataUtils.ts
@@ -54,16 +54,6 @@ function getSyncedAccountIds(parsedData: LedgerSyncPulledData): string[] {
   return [];
 }
 
-function expectSyncedAccountName(
-  parsedData: LedgerSyncPulledData,
-  accountId: string,
-  expectedName: string,
-) {
-  const accountName = parsedData.updateEvent?.data?.accountNames?.[accountId];
-
-  expect(accountName, "Backend account name should match the renamed account").toBe(expectedName);
-}
-
 function isAccountDeleted(parsedData: LedgerSyncPulledData, accountId: string): boolean {
   return !hasSyncedAccount(parsedData, accountId);
 }
@@ -82,5 +72,8 @@ export function expectPulledDataToMatchAccountChanges(
     isAccountDeleted(parsedData, deletedAccountId),
     "Deleted account should not be present in backend accounts",
   ).toBe(true);
-  expectSyncedAccountName(parsedData, remainingAccountId, expectedRemainingAccountName);
+  const remainingAccountName = parsedData.updateEvent?.data?.accountNames?.[remainingAccountId];
+  expect(remainingAccountName, "Backend account name should match the renamed account").toBe(
+    expectedRemainingAccountName,
+  );
 }

--- a/e2e/desktop/tests/utils/ledgerSyncPulledDataUtils.ts
+++ b/e2e/desktop/tests/utils/ledgerSyncPulledDataUtils.ts
@@ -1,0 +1,86 @@
+import { expect } from "@playwright/test";
+import invariant from "invariant";
+
+export interface LedgerSyncAccountData {
+  id?: string;
+  currencyId?: string;
+  index?: number;
+}
+
+export interface LedgerSyncPulledData {
+  updateEvent?: {
+    data?: {
+      accounts?: LedgerSyncAccountData[];
+      accountNames?: Record<string, string>;
+    };
+  };
+}
+
+export interface ExpectedSyncedAccountData {
+  deletedAccountId: string;
+  remainingAccountId: string;
+  expectedRemainingAccountName: string;
+}
+
+function parseLedgerSyncPulledData(pulledData: string | void): LedgerSyncPulledData {
+  invariant(pulledData, "Ledger Sync: pulledData is undefined");
+  try {
+    const parsedData: LedgerSyncPulledData = JSON.parse(pulledData);
+    return parsedData;
+  } catch (error) {
+    throw new Error(`Failed to parse pulledData: ${error}`, { cause: error });
+  }
+}
+
+function hasSyncedAccount(parsedData: LedgerSyncPulledData, accountId: string): boolean {
+  const accounts = parsedData.updateEvent?.data?.accounts;
+
+  if (!accounts) {
+    return false;
+  }
+
+  return accounts.some(account => account.id === accountId);
+}
+
+function getSyncedAccountIds(parsedData: LedgerSyncPulledData): string[] {
+  const accounts = parsedData.updateEvent?.data?.accounts;
+
+  if (accounts) {
+    return accounts
+      .map(account => account.id)
+      .filter((accountId): accountId is string => Boolean(accountId));
+  }
+
+  return [];
+}
+
+function expectSyncedAccountName(
+  parsedData: LedgerSyncPulledData,
+  accountId: string,
+  expectedName: string,
+) {
+  const accountName = parsedData.updateEvent?.data?.accountNames?.[accountId];
+
+  expect(accountName, "Backend account name should match the renamed account").toBe(expectedName);
+}
+
+function isAccountDeleted(parsedData: LedgerSyncPulledData, accountId: string): boolean {
+  return !hasSyncedAccount(parsedData, accountId);
+}
+
+export function expectPulledDataToMatchAccountChanges(
+  pulledData: string | void,
+  { deletedAccountId, remainingAccountId, expectedRemainingAccountName }: ExpectedSyncedAccountData,
+) {
+  const parsedData = parseLedgerSyncPulledData(pulledData);
+
+  expect(
+    getSyncedAccountIds(parsedData),
+    "Backend data should only contain the remaining account",
+  ).toEqual([remainingAccountId]);
+  expect(
+    isAccountDeleted(parsedData, deletedAccountId),
+    "Deleted account should not be present in backend accounts",
+  ).toBe(true);
+  expectSyncedAccountName(parsedData, remainingAccountId, expectedRemainingAccountName);
+}


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _Not required: private desktop E2E test-only changes._
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Ledger Sync desktop E2E account import checks
  - Account rename and deletion synchronization checks
  - CLI member removal and backup deletion coverage

### 📝 Description

This PR addresses weak assertions in the Ledger Sync desktop E2E spec where boolean results could pass with `.toBeDefined()` even when the underlying validation returned `false`.

The spec now keeps the user flow readable while moving backend payload checks into the Ledger Sync CLI helper and using page-object assertions for UI and Redux state. It validates the linked Xray coverage for account import, rename, deletion, member removal, and backup deletion.

https://github.com/LedgerHQ/ledger-live/actions/runs/25319312566

### ❓ Context

- **JIRA or GitHub link**: [QAA-1084](https://ledgerhq.atlassian.net/browse/QAA-1084)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-1084]: https://ledgerhq.atlassian.net/browse/QAA-1084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ