### PR TITLE
[LWDM] feat(LIVE-29572): support validation for more than one aleo record

### DIFF
--- a/.changeset/real-clocks-burn.md
+++ b/.changeset/real-clocks-burn.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-aleo": minor
+"ledger-live-desktop": minor
+---
+
+feat: support validation for more than one aleo record

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7433,6 +7433,14 @@
       "title": "Select a valid private record for the amount.",
       "description": "Choose one of your available private records to fund the transfer amount."
     },
+    "AleoTooManyRecordsSelected": {
+      "title": "Too many private records selected",
+      "description": "You can use at most {{count}} private records per transaction."
+    },
+    "AleoAmountTooLargeForTransaction": {
+      "title": "Amount too large for one transaction",
+      "description": "Your private records can't cover this amount in a single transaction. Try a smaller amount."
+    },
     "AleoFeeRecordRequired": {
       "title": "Another private record is required to cover the network fee.",
       "description": "Top up your balance if needed. One private record is used for the transfer amount, and you must have another record that can cover the network fee."

--- a/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.test.ts
@@ -17,11 +17,13 @@ import { estimateFees, validateAddress } from "../logic";
 import { calculateAmount } from "../logic/utils";
 import type { Transaction } from "../types";
 import aleoCoinConfig from "../config";
-import { TRANSACTION_TYPE } from "../constants";
+import { MAX_PRIVATE_RECORDS_PER_TRANSACTION, TRANSACTION_TYPE } from "../constants";
 import {
   AleoAmountRecordRequired,
+  AleoAmountTooLargeForTransaction,
   AleoFeeRecordInsufficientBalance,
   AleoFeeRecordRequired,
+  AleoTooManyRecordsSelected,
   AleoTwoRecordsRequired,
 } from "../errors";
 import { getTransactionStatus } from "./getTransactionStatus";
@@ -332,6 +334,37 @@ describe("getTransactionStatus", () => {
       expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
     });
 
+    it("adds error when more than MAX_PRIVATE_RECORDS_PER_TRANSACTION records are selected", async () => {
+      const manyRecords = Array.from(
+        { length: MAX_PRIVATE_RECORDS_PER_TRANSACTION + 1 },
+        (_, i) => ({
+          ...mockUnspentRecord1,
+          commitment: `multi-record-${i}`,
+        }),
+      );
+
+      const manyRecordsAccount = getMockedAccount({
+        aleoResources: {
+          ...mockAleoResources,
+          privateBalance: new BigNumber(9999999),
+          unspentPrivateRecords: manyRecords,
+        },
+      });
+
+      const transaction: Transaction = {
+        ...privateTransaction,
+        properties: {
+          amountRecordCommitments: manyRecords.map(r => r.commitment),
+          feeRecordCommitment: null,
+        },
+      };
+
+      const result = await getTransactionStatus(manyRecordsAccount, transaction);
+
+      expect(result.errors.amount).toBeInstanceOf(AleoTooManyRecordsSelected);
+      expect(result.errors.amount).toMatchObject({ count: MAX_PRIVATE_RECORDS_PER_TRANSACTION });
+    });
+
     it("adds error when private fee record is missing and fee is not sponsored", async () => {
       mockAleoConfig.getCoinConfig.mockReturnValue({ ...mockConfig, isFeeSponsored: false });
 
@@ -452,6 +485,90 @@ describe("getTransactionStatus", () => {
       const result = await getTransactionStatus(privateAccount, transaction);
 
       expect(result.errors.feeRecord).toBeUndefined();
+    });
+
+    it("adds error when auto-picking finds no records and private balance is zero", async () => {
+      mockAleoConfig.getCoinConfig.mockReturnValue({
+        ...mockConfig,
+        recordPickingStrategy: "auto",
+      });
+
+      const emptyAccount = getMockedAccount({
+        aleoResources: {
+          ...mockAleoResources,
+          privateBalance: new BigNumber(0),
+          unspentPrivateRecords: [],
+        },
+      });
+
+      const transaction: Transaction = {
+        ...privateTransaction,
+        properties: { amountRecordCommitments: [], feeRecordCommitment: null },
+      };
+
+      const result = await getTransactionStatus(emptyAccount, transaction);
+
+      expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+    });
+
+    it("adds error when auto-picking finds no records and amount exceeds private balance", async () => {
+      mockAleoConfig.getCoinConfig.mockReturnValue({
+        ...mockConfig,
+        recordPickingStrategy: "auto",
+      });
+
+      const smallBalanceAccount = getMockedAccount({
+        aleoResources: {
+          ...mockAleoResources,
+          privateBalance: new BigNumber(100),
+          unspentPrivateRecords: [mockUnspentRecord1],
+        },
+      });
+
+      const transaction: Transaction = {
+        ...privateTransaction,
+        properties: { amountRecordCommitments: [], feeRecordCommitment: null },
+      };
+
+      const result = await getTransactionStatus(smallBalanceAccount, transaction);
+
+      expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+    });
+
+    it("adds error when auto-picking finds no records but balance would cover amount", async () => {
+      mockAleoConfig.getCoinConfig.mockReturnValue({
+        ...mockConfig,
+        recordPickingStrategy: "auto",
+      });
+
+      const transaction: Transaction = {
+        ...privateTransaction,
+        properties: { amountRecordCommitments: [], feeRecordCommitment: null },
+      };
+
+      const result = await getTransactionStatus(privateAccount, transaction);
+
+      expect(result.errors.amount).toBeInstanceOf(AleoAmountTooLargeForTransaction);
+    });
+
+    it("does not add errors when auto-picked records cover the amount", async () => {
+      mockAleoConfig.getCoinConfig.mockReturnValue({
+        ...mockConfig,
+        recordPickingStrategy: "auto",
+      });
+
+      const transaction: Transaction = {
+        ...privateTransaction,
+        properties: {
+          amountRecordCommitments: [mockUnspentRecord1.commitment],
+          feeRecordCommitment: null,
+        },
+      };
+
+      const result = await getTransactionStatus(privateAccount, transaction);
+
+      expect(result.errors.amount).toBeUndefined();
+      expect(result.errors.amountRecord).toBeUndefined();
     });
   });
 

--- a/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.ts
@@ -14,6 +14,7 @@ import type {
   TransactionStatus as AleoTransactionStatus,
   TransactionSelfTransfer,
   TransactionTransfer,
+  AleoCoinConfig,
 } from "../types";
 import { estimateFees, validateAddress } from "../logic";
 import {
@@ -24,10 +25,13 @@ import {
   isSelfTransferTransaction,
 } from "../logic/utils";
 import aleoCoinConfig from "../config";
+import { MAX_PRIVATE_RECORDS_PER_TRANSACTION } from "../constants";
 import {
   AleoAmountRecordRequired,
+  AleoAmountTooLargeForTransaction,
   AleoFeeRecordInsufficientBalance,
   AleoFeeRecordRequired,
+  AleoTooManyRecordsSelected,
   AleoTwoRecordsRequired,
 } from "../errors";
 
@@ -49,6 +53,20 @@ function getValidRecord({
 }
 
 /**
+ * Returns the appropriate error when auto-picking selected no records, possible reasons are:
+ * - no private balance (no records)
+ * - insufficient balance to cover given amount
+ * - more than MAX_PRIVATE_RECORDS_PER_TRANSACTION records would be needed to cover the amount
+ */
+function resolveAutoPickingAmountError(amount: BigNumber, privateBalance: BigNumber): Error {
+  if (privateBalance.isZero() || amount.gt(privateBalance)) {
+    return new NotEnoughBalance();
+  }
+
+  return new AleoAmountTooLargeForTransaction();
+}
+
+/**
  * Validation rules with fee sponsorship:
  *  - amount record must be valid and have sufficient balance to cover amount
  *  - fee record can be ignored as fees are not paid by the user
@@ -61,25 +79,41 @@ function validatePrivateTransaction({
   transaction,
   amount,
   estimatedFees,
-  isFeeSponsored,
+  config,
 }: {
   account: AleoAccount;
   transaction: TransactionPrivate;
   amount: BigNumber;
   estimatedFees: BigNumber;
-  isFeeSponsored: boolean;
+  config: AleoCoinConfig;
 }): Errors {
   const errors: Errors = {};
-  const { amountRecordCommitments, feeRecordCommitment } = transaction.properties;
-  const amountRecord = getValidRecord({ account, commitment: amountRecordCommitments[0] ?? null });
+  const { feeRecordCommitment, amountRecordCommitments } = transaction.properties;
+  const amountRecords = amountRecordCommitments
+    .map(commitment => getValidRecord({ account, commitment }))
+    .filter((record): record is NonNullable<typeof record> => !!record);
 
-  if (!amountRecord) {
+  const totalAmountRecordsValue = amountRecords.reduce(
+    (sum, record) => sum.plus(new BigNumber(record.microcredits)),
+    new BigNumber(0),
+  );
+
+  const privateBalance = account.aleoResources?.privateBalance ?? new BigNumber(0);
+  const hasSelectedRecord = amountRecords.length > 0;
+
+  if (config.recordPickingStrategy === "manual" && !hasSelectedRecord) {
     errors.amountRecord = new AleoAmountRecordRequired();
-  } else if (amount.gt(new BigNumber(amountRecord.microcredits))) {
+  } else if (config.recordPickingStrategy === "auto" && !hasSelectedRecord) {
+    errors.amount = resolveAutoPickingAmountError(amount, privateBalance);
+  } else if (amountRecords.length > MAX_PRIVATE_RECORDS_PER_TRANSACTION) {
+    errors.amount = new AleoTooManyRecordsSelected(undefined, {
+      count: MAX_PRIVATE_RECORDS_PER_TRANSACTION,
+    });
+  } else if (amount.gt(totalAmountRecordsValue)) {
     errors.amount = new NotEnoughBalance();
   }
 
-  if (isFeeSponsored) {
+  if (config.isFeeSponsored) {
     return errors;
   }
 
@@ -173,7 +207,7 @@ async function handleTransferTransaction({
         transaction,
         amount: calculatedAmount.amount,
         estimatedFees,
-        isFeeSponsored: config.isFeeSponsored,
+        config,
       }),
     );
   }

--- a/libs/coin-modules/coin-aleo/src/errors.ts
+++ b/libs/coin-modules/coin-aleo/src/errors.ts
@@ -9,3 +9,7 @@ export const AleoFeeRecordInsufficientBalance = createCustomErrorClass(
 export const AleoApiConfigurationResetError = createCustomErrorClass(
   "AleoApiConfigurationResetError",
 );
+export const AleoTooManyRecordsSelected = createCustomErrorClass("AleoTooManyRecordsSelected");
+export const AleoAmountTooLargeForTransaction = createCustomErrorClass(
+  "AleoAmountTooLargeForTransaction",
+);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - validation for more than one auto-picked private record should be supported in Aleo (up to 14 records)

### 📝 Description

This PR updates `getTransactionStatus` in coin-aleo module to support more than one private record.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-29572

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
