### PR TITLE
[LWD] refactor(desktop): prepare bridge call sites for async getAccountBridge

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useNetworkFees.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useNetworkFees.ts
@@ -3,7 +3,7 @@ import {
   getMainAccount,
 } from "@ledgerhq/ledger-wallet-framework/account/helpers";
 import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/impl";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import {
   SendFlowTransactionActions,
   SendFlowUiConfig,
@@ -80,14 +80,15 @@ export function useNetworkFees({
     status,
   });
 
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
+
   const updateTransactionWithPatch = useCallback(
     (patch: Partial<Transaction>) => {
       transactionActions.updateTransaction(currentTx => {
-        const bridge = getAccountBridge(account, parentAccount ?? undefined);
         return bridge.updateTransaction(currentTx, patch);
       });
     },
-    [account, parentAccount, transactionActions],
+    [bridge, transactionActions],
   );
 
   const showNetworkFees = true;

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendFlowTransaction.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendFlowTransaction.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from "react";
 import { applyMemoToTransaction } from "@ledgerhq/live-common/bridge/descriptor/send/memo";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridgeOrNull } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import type {
   SendFlowTransactionState,
@@ -24,6 +24,7 @@ export function useSendFlowTransaction({
   account,
   parentAccount,
 }: UseSendFlowTransactionParams): UseSendFlowTransactionResult {
+  const bridge = useAccountBridgeOrNull<Transaction>(account, parentAccount);
   const {
     transaction,
     setTransaction: bridgeSetTransaction,
@@ -49,9 +50,8 @@ export function useSendFlowTransaction({
 
   const setRecipient = useCallback(
     (recipient: RecipientData) => {
-      if (!account || !transaction) return;
+      if (!account || !transaction || !bridge) return;
 
-      const bridge = getAccountBridge(account, parentAccount);
       const updates: Partial<Transaction> = { recipient: recipient.address };
 
       if (recipient.memo !== undefined) {
@@ -78,7 +78,7 @@ export function useSendFlowTransaction({
 
       bridgeSetTransaction(bridge.updateTransaction(transaction, updates));
     },
-    [account, parentAccount, transaction, bridgeSetTransaction],
+    [account, bridge, transaction, bridgeSetTransaction],
   );
 
   const setAccountForTransaction = useCallback(

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/hooks/useAleoPrivateSync.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/hooks/useAleoPrivateSync.test.ts
@@ -172,7 +172,7 @@ describe("useAleoPrivateSync", () => {
       expect(result.current.progress).toBe(100);
     });
 
-    it("should retry when complete fires without any result (scanner not yet ready)", () => {
+    it("should retry when complete fires without any result (scanner not yet ready)", async () => {
       jest.useFakeTimers();
       const firstSubject = new Subject<(acc: AleoAccount) => AleoAccount>();
       const secondSubject = new Subject<(acc: AleoAccount) => AleoAccount>();
@@ -185,6 +185,7 @@ describe("useAleoPrivateSync", () => {
       act(() => {
         result.current.start();
       });
+      await Promise.resolve(); // flush from(Promise.resolve(bridge)) microtask
 
       // Complete without emitting next — scanner returned null, retry expected
       act(() => {
@@ -197,6 +198,7 @@ describe("useAleoPrivateSync", () => {
       act(() => {
         jest.advanceTimersByTime(MANDATORY_SYNC_POLLING_DELAY);
       });
+      await Promise.resolve(); // flush from(Promise.resolve(bridge)) microtask for retry
 
       expect(mockSync).toHaveBeenCalledTimes(2);
 
@@ -208,7 +210,7 @@ describe("useAleoPrivateSync", () => {
       expect(result.current.isSyncing).toBe(false);
     });
 
-    it("should retry after polling delay when complete fires without any result", () => {
+    it("should retry after polling delay when complete fires without any result", async () => {
       jest.useFakeTimers();
       const firstSubject = new Subject<(acc: AleoAccount) => AleoAccount>();
       const secondSubject = new Subject<(acc: AleoAccount) => AleoAccount>();
@@ -221,6 +223,7 @@ describe("useAleoPrivateSync", () => {
       act(() => {
         result.current.start();
       });
+      await Promise.resolve(); // flush from(Promise.resolve(bridge)) microtask
 
       // Complete without any next emission — triggers retry after delay
       act(() => {
@@ -232,6 +235,7 @@ describe("useAleoPrivateSync", () => {
       act(() => {
         jest.advanceTimersByTime(MANDATORY_SYNC_POLLING_DELAY);
       });
+      await Promise.resolve(); // flush from(Promise.resolve(bridge)) microtask for retry
 
       expect(mockSync).toHaveBeenCalledTimes(2);
 
@@ -241,13 +245,14 @@ describe("useAleoPrivateSync", () => {
       });
     });
 
-    it("should not retry when stop() is called before complete fires", () => {
+    it("should not retry when stop() is called before complete fires", async () => {
       jest.useFakeTimers();
       const { result } = renderHook(() => useAleoPrivateSync({ account: makeAleoAccount() }));
 
       act(() => {
         result.current.start();
       });
+      await Promise.resolve(); // flush from(Promise.resolve(bridge)) microtask
 
       // stop() unsubscribes before the observable completes naturally
       act(() => {
@@ -298,8 +303,9 @@ describe("useAleoPrivateSync", () => {
   });
 
   describe("autoStart: true", () => {
-    it("should call sync immediately on mount", () => {
+    it("should call sync immediately on mount", async () => {
       renderHook(() => useAleoPrivateSync({ account: makeAleoAccount(), autoStart: true }));
+      await Promise.resolve(); // flush from(Promise.resolve(bridge)) microtask
 
       expect(mockSync).toHaveBeenCalledTimes(1);
     });
@@ -316,6 +322,8 @@ describe("useAleoPrivateSync", () => {
       const { result } = renderHook(() =>
         useAleoPrivateSync({ account: makeAleoAccount(), autoStart: true }),
       );
+
+      await Promise.resolve(); // flush from(Promise.resolve(bridge)) microtask
 
       await act(async () => {
         syncSubject.next(() => makeAleoAccount(100, true));
@@ -624,6 +632,9 @@ describe("useAleoPrivateSync", () => {
         { initialState },
       );
 
+      // Flush from(Promise.resolve(bridge)) microtask so mockSync is subscribed
+      await Promise.resolve();
+
       // Advance some progress via the progress subject
       act(() => {
         aleoPrivateSyncProgress$.next({ accountId: account.id, progress: 55 });
@@ -721,6 +732,8 @@ describe("useAleoPrivateSync", () => {
         { initialState },
       );
 
+      await Promise.resolve(); // flush from(Promise.resolve(bridge)) microtask for second sync
+
       expect(mockSync).toHaveBeenCalledTimes(2);
       expect(second.current.isSyncing).toBe(true);
     });
@@ -753,6 +766,8 @@ describe("useAleoPrivateSync", () => {
         () => useAleoPrivateSync({ account, keepAliveOnUnmount: true, autoStart: true }),
         { initialState },
       );
+
+      await Promise.resolve(); // flush from(Promise.resolve(bridge)) microtask for second sync
 
       expect(mockSync).toHaveBeenCalledTimes(2);
       expect(second.current.isSyncing).toBe(true);
@@ -818,7 +833,7 @@ describe("useAleoPrivateSync", () => {
   });
 
   describe("external completion via aleoPrivateSyncProgress$", () => {
-    it("should call onAccountUpdated immediately when Redux has already flushed lastPrivateSyncDate", () => {
+    it("should call onAccountUpdated immediately when Redux has already flushed lastPrivateSyncDate", async () => {
       jest.useFakeTimers();
       const onAccountUpdated = jest.fn();
       const syncDate = new Date();
@@ -839,6 +854,7 @@ describe("useAleoPrivateSync", () => {
       act(() => {
         result.current.start();
       });
+      await Promise.resolve(); // flush from(Promise.resolve(bridge)) microtask
 
       // Complete without a result — subscriptionRef becomes null, retry timer pending
       act(() => {
@@ -856,7 +872,7 @@ describe("useAleoPrivateSync", () => {
       expect(onAccountUpdated).toHaveBeenCalledWith(syncedAccount);
     });
 
-    it("should defer onAccountUpdated via the liveAccount effect when Redux has not yet flushed", () => {
+    it("should defer onAccountUpdated via the liveAccount effect when Redux has not yet flushed", async () => {
       jest.useFakeTimers();
       const onAccountUpdated = jest.fn();
       const account = makeAleoAccount();
@@ -869,6 +885,7 @@ describe("useAleoPrivateSync", () => {
       act(() => {
         result.current.start();
       });
+      await Promise.resolve(); // flush from(Promise.resolve(bridge)) microtask
 
       // Complete without a result — subscriptionRef becomes null, retry timer pending
       act(() => {

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/hooks/useAleoPrivateSync.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/hooks/useAleoPrivateSync.ts
@@ -7,7 +7,7 @@ import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
 import { accountSelector } from "~/renderer/reducers/accounts";
 import type { State } from "~/renderer/reducers";
 import { aleoPrivateSyncProgress$ } from "@ledgerhq/live-common/families/aleo/privateSyncProgress";
-import { asyncScheduler, throttleTime } from "rxjs";
+import { asyncScheduler, from, mergeMap, throttleTime } from "rxjs";
 import { MANDATORY_SYNC_POLLING_DELAY, PROGRESS_THROTTLE_INTERVAL_MS } from "../constants";
 import { isAleoAccount } from "../modals/send/steps/utils";
 
@@ -104,8 +104,9 @@ export const useAleoPrivateSync = ({
 
     const currentAccountId = acc.id;
     let receivedFinalResult = false;
-    const bridge = getAccountBridge(acc);
-    const sub = bridge.sync(acc, { paginationConfig: {}, syncType: SYNC_TYPE_SHIELDED }).subscribe({
+    const sub = from(Promise.resolve(getAccountBridge(acc)))
+      .pipe(mergeMap(bridge => bridge.sync(acc, { paginationConfig: {}, syncType: SYNC_TYPE_SHIELDED })))
+      .subscribe({
       next: updater => {
         const currentAcc = accountRef.current;
         if (currentAcc?.type !== "Account" || !isAleoAccount(currentAcc)) return;

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepMandatoryPrivateSync.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepMandatoryPrivateSync.test.tsx
@@ -104,6 +104,7 @@ describe("StepMandatoryPrivateSync", () => {
     it("should call transitionTo('record-picker') after progress reaches 100 with manual strategy", async () => {
       const props = makeStepProps();
       render(<StepMandatoryPrivateSync {...props} />);
+      await Promise.resolve(); // flush from(Promise.resolve(bridge)) so syncSubject has a subscriber
 
       await act(async () => {
         syncSubject.next(() => makeAleoAccountAt100());
@@ -120,6 +121,7 @@ describe("StepMandatoryPrivateSync", () => {
 
       const props = makeStepProps();
       render(<StepMandatoryPrivateSync {...props} />);
+      await Promise.resolve(); // flush from(Promise.resolve(bridge)) so syncSubject has a subscriber
 
       await act(async () => {
         syncSubject.next(() => makeAleoAccountAt100());
@@ -133,6 +135,7 @@ describe("StepMandatoryPrivateSync", () => {
     it("should not call transitionTo if the component unmounts before the timer fires", async () => {
       const props = makeStepProps();
       const { unmount } = render(<StepMandatoryPrivateSync {...props} />);
+      await Promise.resolve(); // flush from(Promise.resolve(bridge)) so syncSubject has a subscriber
 
       await act(async () => {
         syncSubject.next(() => makeAleoAccountAt100());
@@ -149,6 +152,7 @@ describe("StepMandatoryPrivateSync", () => {
     it("should call updateAccount with the updated account on each sync emission", async () => {
       const props = makeStepProps();
       render(<StepMandatoryPrivateSync {...props} />);
+      await Promise.resolve(); // flush from(Promise.resolve(bridge)) so syncSubject has a subscriber
 
       await act(async () => {
         syncSubject.next(() => ({
@@ -171,6 +175,7 @@ describe("StepMandatoryPrivateSync", () => {
     it("should not throw when updateAccount is not provided", async () => {
       const props = makeStepProps({ updateAccount: undefined });
       render(<StepMandatoryPrivateSync {...props} />);
+      await Promise.resolve(); // flush from(Promise.resolve(bridge)) so syncSubject has a subscriber
 
       await act(async () => {
         syncSubject.next(() => ({

--- a/apps/ledger-live-desktop/src/renderer/families/aptos/StakingFlowModal/steps/StepStake.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aptos/StakingFlowModal/steps/StepStake.tsx
@@ -2,11 +2,10 @@ import invariant from "invariant";
 import React from "react";
 import { Trans } from "react-i18next";
 import { StepProps } from "../types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
-import { AccountBridge } from "@ledgerhq/types-live";
 import ValidatorField from "../fields/ValidatorField";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
 import { Transaction } from "@ledgerhq/live-common/families/aptos/types";
@@ -20,8 +19,9 @@ export default function StepStake({
 }: Readonly<StepProps>) {
   invariant(account && transaction, "account and transaction required");
 
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
+
   const updateValidator = ({ address }: { address: string }) => {
-    const bridge: AccountBridge<Transaction> = getAccountBridge(account, parentAccount);
     onUpdateTransaction(() => {
       return bridge.updateTransaction(transaction, {
         recipient: address,

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/AccountBalanceSummaryFooter.tsx
@@ -28,6 +28,7 @@ import {
   ZCASH_OUTDATED_SYNC_INTERVAL_MINUTES,
 } from "@ledgerhq/zcash-shielded/constants";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { from, switchMap } from "rxjs";
 import {
   removeShieldedSubscription,
   selectShieldedSubscriptions,
@@ -279,8 +280,8 @@ const AccountBalanceSummaryFooter = ({ account }: Props) => {
       syncType: SYNC_TYPE_SHIELDED,
     };
 
-    const shieldedSync = getAccountBridge(account as ZcashAccount)
-      .sync(account as ZcashAccount, syncConfig)
+    const shieldedSync = from(Promise.resolve(getAccountBridge(account as ZcashAccount)))
+      .pipe(switchMap(bridge => bridge.sync(account as ZcashAccount, syncConfig)))
       .subscribe({
         next(accountUpdater) {
           dispatch(updateAccountWithUpdater(account.id, accountUpdater));
@@ -292,7 +293,6 @@ const AccountBalanceSummaryFooter = ({ account }: Props) => {
           console.log(`Zcash shielded sync completed on account ${account.id}`);
         },
       });
-
     dispatch(upsertShieldedSubscription({ accountId: account.id, subscription: shieldedSync }));
   }, [account, dispatch, saveSyncState]);
 

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/steps/StepMethod.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/steps/StepMethod.tsx
@@ -1,8 +1,7 @@
 import { getEditTransactionPatch } from "@ledgerhq/coin-bitcoin/editTransaction/index";
 import { Transaction as BitcoinTransaction } from "@ledgerhq/coin-bitcoin/types";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
-import { AccountBridge } from "@ledgerhq/types-live";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import invariant from "invariant";
 import React, { memo } from "react";
 import { urls } from "~/config/urls";
@@ -63,11 +62,11 @@ export const StepMethodFooter: React.FC<StepProps> = ({
 }: StepProps) => {
   const canSpeedup = haveFundToSpeedup && isOldestEditableOperation;
   const canCancel = haveFundToCancel;
+  const bridge = useAccountBridge<BitcoinTransaction>(account, parentAccount);
 
   const handleContinueClick = async () => {
     invariant(editType, "editType required");
 
-    const bridge: AccountBridge<BitcoinTransaction> = getAccountBridge(account, parentAccount);
     const mainAccount = getMainAccount(account, parentAccount);
 
     const patch = await getEditTransactionPatch({

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/__tests__/ZCashExportKeyFlowModal.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/__tests__/ZCashExportKeyFlowModal.integ.test.tsx
@@ -4,9 +4,13 @@ import { createFixtureAccount } from "@ledgerhq/coin-bitcoin/fixtures/common.fix
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { DeviceModelId } from "@ledgerhq/devices";
 import { of } from "rxjs";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import ExportKeyModal from "../index";
 import { StepId } from "../types";
 import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge");
+const mockedUseAccountBridge = jest.mocked(useAccountBridge);
 
 const mockDispatch = jest.fn();
 const mockSyncStateUpdater = jest.fn();
@@ -139,9 +143,9 @@ describe("ZCash Export UFVK Flow - Integration test", () => {
         publicKey: "mock-public-key",
       }),
     );
-    jest.spyOn(require("@ledgerhq/live-common/bridge/index"), "getAccountBridge").mockReturnValue({
+    mockedUseAccountBridge.mockReturnValue({
       receive: mockReceive,
-    });
+    } as unknown as ReturnType<typeof useAccountBridge>);
 
     let stepId: StepId = "birthday";
     let currentBirthday = birthday;

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/steps/StepDevice.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/steps/StepDevice.tsx
@@ -4,7 +4,7 @@ import { firstValueFrom } from "rxjs";
 import { Trans } from "react-i18next";
 import { getMainAccount } from "@ledgerhq/live-common/account/helpers";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { DisconnectedDevice } from "@ledgerhq/errors";
 import DeviceAction from "~/renderer/components/DeviceAction";
 import { HOOKS_TRACKING_LOCATIONS } from "~/renderer/analytics/hooks/variables";
@@ -53,13 +53,14 @@ const StepExport = (props: StepProps) => {
   const mainAccount = account ? getMainAccount(account) : null;
   invariant(account && mainAccount, "No account given");
 
+  const bridge = useAccountBridge(mainAccount);
   const requestUfvkFromDevice = useCallback(async () => {
     try {
       if (!device) {
         throw new DisconnectedDevice();
       }
       await firstValueFrom(
-        getAccountBridge(mainAccount).receive(mainAccount, {
+        bridge.receive(mainAccount, {
           deviceId: device.deviceId,
           verify: true,
         }),
@@ -71,7 +72,7 @@ const StepExport = (props: StepProps) => {
     } catch (error) {
       onUfvkChanged("", error as Error);
     }
-  }, [device, mainAccount, transitionTo, onUfvkChanged]);
+  }, [bridge, device, mainAccount, transitionTo, onUfvkChanged]);
 
   useEffect(() => {
     if (!ufvk && !ufvkExportError && !ufvkRequestSent) {

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/AccountBalanceSummaryFooter.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/AccountBalanceSummaryFooter.test.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Observable } from "rxjs";
 import { DEFAULT_ZCASH_PRIVATE_INFO } from "@ledgerhq/zcash-shielded/constants";
 import { render, screen, waitFor, withFlagOverrides } from "tests/testSetup";
 import AccountBalanceSummaryFooter from "../AccountBalanceSummaryFooter";
@@ -206,17 +207,13 @@ describe("Bitcoin Account Balance Summary Footer", () => {
     });
 
     const updater = jest.fn();
-    const subscription = { unsubscribe: jest.fn() };
-    const syncMock = jest.fn(() => ({
-      subscribe: (observer: {
-        next: (updater: (account: unknown) => unknown) => void;
-        complete: () => void;
-      }) => {
-        observer.next(updater);
-        observer.complete();
-        return subscription;
-      },
-    }));
+    const syncMock = jest.fn(
+      () =>
+        new Observable<(account: unknown) => unknown>(subscriber => {
+          subscriber.next(updater);
+          subscriber.complete();
+        }),
+    );
     mockedGetAccountBridge.mockReturnValue({
       sync: syncMock,
     } as unknown as ReturnType<typeof getAccountBridge>);
@@ -242,14 +239,21 @@ describe("Bitcoin Account Balance Summary Footer", () => {
     expect(mockedGetAccountBridge).toHaveBeenCalledWith(
       expect.objectContaining({ id: account.id }),
     );
-    expect(syncMock).toHaveBeenCalledWith(expect.objectContaining({ id: account.id }), {
-      paginationConfig: {},
-      syncType: SYNC_TYPE_SHIELDED,
-    });
     expect(store.getState().shieldedSyncSubscriptions).toEqual([
-      { accountId: account.id, subscription },
+      {
+        accountId: account.id,
+        subscription: expect.objectContaining({ unsubscribe: expect.any(Function) }),
+      },
     ]);
-    expect(logSpy).toHaveBeenCalledWith(`Zcash shielded sync completed on account ${account.id}`);
+    await waitFor(() => {
+      expect(syncMock).toHaveBeenCalledWith(expect.objectContaining({ id: account.id }), {
+        paginationConfig: {},
+        syncType: SYNC_TYPE_SHIELDED,
+      });
+      expect(logSpy).toHaveBeenCalledWith(
+        `Zcash shielded sync completed on account ${account.id}`,
+      );
+    });
   });
 
   it("should stop shielded sync and remove subscription when clicking stop sync button", async () => {

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/steps/StepDelegation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/steps/StepDelegation.tsx
@@ -2,11 +2,10 @@ import invariant from "invariant";
 import React from "react";
 import { Trans } from "react-i18next";
 import { StepProps } from "../types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
-import { AccountBridge } from "@ledgerhq/types-live";
 import { Transaction as CardanoTransaction } from "@ledgerhq/live-common/families/cardano/types";
 import { StakePool } from "@ledgerhq/live-common/families/cardano/staking";
 import ValidatorField from "../fields/ValidatorField";
@@ -31,10 +30,10 @@ export default function StepDelegation({
 
   const { errors } = status;
   const displayError = errors.amount?.message ? errors.amount : "";
+  const bridge = useAccountBridge<CardanoTransaction>(account);
 
   const selectPool = (stakePool: StakePool) => {
     setSelectedPool(stakePool);
-    const bridge: AccountBridge<CardanoTransaction> = getAccountBridge(account);
     onUpdateTransaction(() => {
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       const updatedTransaction = bridge.updateTransaction(transaction as CardanoTransaction, {

--- a/apps/ledger-live-desktop/src/renderer/families/celo/VoteFlowModal/steps/StepValidatorGroup.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/VoteFlowModal/steps/StepValidatorGroup.tsx
@@ -1,4 +1,4 @@
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import invariant from "invariant";
 import React from "react";
 import { Trans } from "react-i18next";
@@ -10,7 +10,6 @@ import LedgerByFigmentTC from "../components/LedgerByFigmentTCLink";
 import ValidatorGroupsField from "../fields/ValidatorGroupsField";
 import { isDefaultValidatorGroupAddress } from "@ledgerhq/live-common/families/celo/logic";
 import { Transaction } from "@ledgerhq/live-common/families/celo/types";
-import { AccountBridge } from "@ledgerhq/types-live";
 import { StepProps } from "../types";
 export const StepValidatorGroupFooter = ({
   transitionTo,
@@ -55,8 +54,8 @@ const StepValidatorGroup = ({
     account && account.celoResources && transaction,
     "celo account, resources and transaction required",
   );
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
   const updateValidatorGroup = ({ address }: { address: string }) => {
-    const bridge: AccountBridge<Transaction> = getAccountBridge(account, parentAccount);
     onUpdateTransaction(_tx => {
       return bridge.updateTransaction(transaction, {
         recipient: address,

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/StepReceiveFunds/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/StepReceiveFunds/index.tsx
@@ -140,7 +140,7 @@ const StepReceiveFunds = ({
     try {
       if (!device) throw new DisconnectedDevice();
       await firstValueFrom(
-        getAccountBridge(mainAccount).receive(mainAccount, {
+        (await getAccountBridge(mainAccount)).receive(mainAccount, {
           deviceId: device.deviceId,
           verify: true,
         }),

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/steps/StepDelegation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/steps/StepDelegation.tsx
@@ -1,6 +1,5 @@
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Transaction } from "@ledgerhq/live-common/families/cosmos/types";
-import { AccountBridge } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import invariant from "invariant";
 import React, { useCallback } from "react";
@@ -25,9 +24,9 @@ export default function StepDelegation({
   invariant(transaction && transaction.validators, "transaction required");
   const { cosmosResources } = account;
   const delegations = cosmosResources.delegations || [];
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
   const updateValidator = useCallback(
     ({ address }: { address: string }) => {
-      const bridge: AccountBridge<Transaction> = getAccountBridge(account, parentAccount);
       onUpdateTransaction(_tx => {
         return bridge.updateTransaction(transaction, {
           validators: [
@@ -39,7 +38,7 @@ export default function StepDelegation({
         });
       });
     },
-    [onUpdateTransaction, account, transaction, parentAccount],
+    [bridge, onUpdateTransaction, transaction],
   );
   const chosenVoteAccAddr = transaction.validators[0]?.address || "";
 

--- a/apps/ledger-live-desktop/src/renderer/families/evm/DelegationFlowModal/steps/StepDelegation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/DelegationFlowModal/steps/StepDelegation.tsx
@@ -1,5 +1,4 @@
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
-import type { AccountBridge } from "@ledgerhq/types-live";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-coin-framework/types";
 import invariant from "invariant";
 import React, { useCallback } from "react";
@@ -22,9 +21,9 @@ export default function StepDelegation({
 }: Readonly<StepProps>) {
   invariant(transaction, "transaction required");
 
+  const bridge = useAccountBridge<GenericTransaction>(account, parentAccount);
   const updateValidator = useCallback(
     (address: string) => {
-      const bridge = getAccountBridge(account, parentAccount) as AccountBridge<GenericTransaction>;
       onUpdateTransaction(_tx =>
         bridge.updateTransaction(transaction, {
           mode: "delegate",
@@ -32,7 +31,7 @@ export default function StepDelegation({
         }),
       );
     },
-    [onUpdateTransaction, account, transaction, parentAccount],
+    [bridge, onUpdateTransaction, transaction],
   );
 
   const chosenVoteAccAddr = transaction.valAddress || "";

--- a/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/GasLimitField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/GasLimitField.tsx
@@ -1,6 +1,6 @@
 import { getGasLimit, DEFAULT_GAS_LIMIT } from "@ledgerhq/coin-evm/utils";
 import { Transaction } from "@ledgerhq/coin-evm/types/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Button } from "@ledgerhq/react-ui";
 import { BigNumber } from "bignumber.js";
 import invariant from "invariant";
@@ -22,10 +22,10 @@ const AdvancedOptions: NonNullable<EvmFamily["sendAmountFields"]>["component"] =
   invariant(account, "Account required");
   const [editable, setEditable] = useState(false);
   const { t } = useTranslation();
+  const bridge = useAccountBridge<Transaction>(account);
 
   const onGasLimitChange = useCallback(
     (str: string) => {
-      const bridge = getAccountBridge(account);
       let gasLimit = new BigNumber(str || 0);
       if (!gasLimit.isFinite()) {
         gasLimit = DEFAULT_GAS_LIMIT;
@@ -34,7 +34,7 @@ const AdvancedOptions: NonNullable<EvmFamily["sendAmountFields"]>["component"] =
         bridge.updateTransaction(transaction, { customGasLimit: gasLimit }),
       );
     },
-    [account, updateTransaction],
+    [bridge, updateTransaction],
   );
 
   const onEditClick = useCallback(() => setEditable(true), [setEditable]);

--- a/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/steps/StepAmount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/steps/StepAmount.tsx
@@ -2,8 +2,7 @@ import { BigNumber } from "bignumber.js";
 import invariant from "invariant";
 import React, { useCallback, useMemo } from "react";
 import { useTranslation, Trans } from "react-i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
-import type { AccountBridge } from "@ledgerhq/types-live";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-coin-framework/types";
 import {
   mapDelegations,
@@ -33,7 +32,7 @@ export default function StepAmount({
   invariant(account && transaction, "account and transaction required");
   const unit = useAccountUnit(account);
 
-  const bridge = getAccountBridge(account, parentAccount) as AccountBridge<GenericTransaction>;
+  const bridge = useAccountBridge<GenericTransaction>(account, parentAccount);
 
   // Rely on the authoritative mapping (same as the delegation table) to keep the validator
   // metadata (name, icon) consistent across the whole flow.

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/steps/StepValidator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/steps/StepValidator.tsx
@@ -1,11 +1,10 @@
 import invariant from "invariant";
 import React from "react";
 import { Trans } from "react-i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
 import { HederaValidator, Transaction } from "@ledgerhq/live-common/families/hedera/types";
 import { isStakingTransaction } from "@ledgerhq/live-common/families/hedera/utils";
-import type { AccountBridge } from "@ledgerhq/types-live";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
@@ -23,9 +22,9 @@ export default function StepValidator({
   invariant(account && transaction, "hedera: account and transaction required");
   invariant(isStakingTransaction(transaction), "hedera: staking tx expected");
   const selectedValidatorNodeId = transaction.properties?.stakingNodeId ?? null;
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
 
   const updateValidator = (validator: HederaValidator) => {
-    const bridge: AccountBridge<Transaction> = getAccountBridge(account, parentAccount);
     onUpdateTransaction(() => {
       return bridge.updateTransaction(transaction, {
         mode: HEDERA_TRANSACTION_MODES.Delegate,

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/steps/StepValidators.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/steps/StepValidators.tsx
@@ -3,8 +3,7 @@ import React from "react";
 import { Trans } from "react-i18next";
 import { useHederaEnrichedDelegation } from "@ledgerhq/live-common/families/hedera/react";
 import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account/helpers";
-import type { AccountBridge } from "@ledgerhq/types-live";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { HederaValidator, Transaction } from "@ledgerhq/live-common/families/hedera/types";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
 import { isStakingTransaction } from "@ledgerhq/live-common/families/hedera/utils";
@@ -42,9 +41,9 @@ function StepValidators({
   const isValidatorRemoved =
     !enrichedDelegation.validator.address && typeof delegation.nodeId === "number";
 
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
   const updateValidator = (validator: HederaValidator | null) => {
     if (!validator) return;
-    const bridge: AccountBridge<Transaction> = getAccountBridge(account, parentAccount);
     onUpdateTransaction(() => {
       return bridge.updateTransaction(transaction, {
         mode: HEDERA_TRANSACTION_MODES.Redelegate,

--- a/apps/ledger-live-desktop/src/renderer/families/near/StakingFlowModal/steps/StepStake.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/StakingFlowModal/steps/StepStake.tsx
@@ -2,11 +2,10 @@ import invariant from "invariant";
 import React from "react";
 import { Trans } from "react-i18next";
 import { StepProps } from "../types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
-import { AccountBridge } from "@ledgerhq/types-live";
 import ValidatorField from "../fields/ValidatorField";
 import LedgerByFigmentTCLink from "../components/LedgerByFigmentTCLink";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
@@ -21,8 +20,8 @@ export default function StepStake({
   status,
 }: StepProps) {
   invariant(account && transaction, "account and transaction required");
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
   const updateValidator = ({ address }: { address: string }) => {
-    const bridge: AccountBridge<Transaction> = getAccountBridge(account, parentAccount);
     onUpdateTransaction(() => {
       return bridge.updateTransaction(transaction, {
         recipient: address,

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationActivateFlowModal/steps/StepValidator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationActivateFlowModal/steps/StepValidator.tsx
@@ -1,4 +1,5 @@
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { Transaction } from "@ledgerhq/live-common/families/solana/types";
 import invariant from "invariant";
 import React from "react";
 import { Trans } from "react-i18next";
@@ -18,9 +19,10 @@ export default function StepValidator({
   error,
 }: StepProps) {
   invariant(transaction, "transaction required");
+  const bridge = useAccountBridge<Transaction>(account);
   const updateValidator = ({ address }: { address: string }) => {
-    const bridge = getAccountBridge(account);
     onUpdateTransaction(tx => {
+      if (tx.model.kind !== "stake.delegate") return tx;
       return bridge.updateTransaction(tx, {
         model: {
           ...tx.model,

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationFlowModal/steps/StepValidator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationFlowModal/steps/StepValidator.tsx
@@ -1,9 +1,8 @@
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import {
   StakeCreateAccountTransaction,
   Transaction,
 } from "@ledgerhq/live-common/families/solana/types";
-import { AccountBridge } from "@ledgerhq/types-live";
 import invariant from "invariant";
 import React from "react";
 import { Trans } from "react-i18next";
@@ -27,8 +26,8 @@ export default function StepValidator({
     account && account.solanaResources && transaction,
     "solana account, resources and transaction required",
   );
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
   const updateValidator = ({ address }: { address: string }) => {
-    const bridge: AccountBridge<Transaction> = getAccountBridge(account, parentAccount);
     onUpdateTransaction(_tx => {
       return bridge.updateTransaction(transaction, {
         model: {

--- a/apps/ledger-live-desktop/src/renderer/families/sui/DelegationFlowModal/steps/StepStake.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/sui/DelegationFlowModal/steps/StepStake.tsx
@@ -2,11 +2,10 @@ import invariant from "invariant";
 import React from "react";
 import { Trans } from "react-i18next";
 import { StepProps } from "../types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
-import { AccountBridge } from "@ledgerhq/types-live";
 import ValidatorField from "../fields/ValidatorField";
 import LedgerByFigmentTCLink from "../components/LedgerByFigmentTCLink";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
@@ -20,8 +19,8 @@ export default function StepStake({
   error,
 }: StepProps) {
   invariant(account && transaction, "account and transaction required");
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
   const updateValidator = ({ address }: { address: string }) => {
-    const bridge: AccountBridge<Transaction> = getAccountBridge(account, parentAccount);
     onUpdateTransaction(() => {
       return bridge.updateTransaction(transaction, {
         recipient: address,

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/Body.tsx
@@ -7,8 +7,8 @@ import invariant from "invariant";
 import { Account, AccountLike, Operation, TokenAccount } from "@ledgerhq/types-live";
 import { useBakers } from "@ledgerhq/live-common/families/tezos/react";
 import { whitelist } from "@ledgerhq/live-common/families/tezos/staking";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { getMainAccount, addPendingOperation } from "@ledgerhq/live-common/account/index";
+import { useAccountBridgeOrNull } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
@@ -102,6 +102,7 @@ const Body = ({ stepId, params, onChangeStepId, onClose }: Props) => {
   const openedFromAccount = !!params.account;
   const [defaultBaker] = useBakers(whitelist);
   const steps = createSteps(params);
+  const bridge = useAccountBridgeOrNull<Transaction>(params.account ?? null, params.parentAccount ?? null);
 
   const {
     transaction,
@@ -124,7 +125,7 @@ const Body = ({ stepId, params, onChangeStepId, onClose }: Props) => {
 
   // make sure tx is in sync
   useEffect(() => {
-    if (!transaction || !account) return;
+    if (!transaction || !account || !bridge) return;
     invariant(transaction.family === "tezos", "tezos tx");
 
     // make sure the mode is in sync (an account changes can reset it)
@@ -145,11 +146,9 @@ const Body = ({ stepId, params, onChangeStepId, onClose }: Props) => {
 
     // when changes, we set again
     if (patch.mode !== transaction.mode || patch.recipient) {
-      setTransaction(
-        getAccountBridge(account, parentAccount).updateTransaction(transaction, patch),
-      );
+      setTransaction(bridge.updateTransaction(transaction, patch));
     }
-  }, [account, defaultBaker, stepId, params, parentAccount, setTransaction, transaction]);
+  }, [account, bridge, defaultBaker, stepId, params, setTransaction, transaction]);
 
   // make sure step id is in sync
   useEffect(() => {

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/steps/StepCustom.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/steps/StepCustom.tsx
@@ -3,7 +3,8 @@ import React, { useCallback, useEffect, useRef } from "react";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { Transaction } from "@ledgerhq/live-common/families/tezos/types";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import RecipientField from "~/renderer/modals/Send/fields/RecipientField";
 import Button from "~/renderer/components/Button";
@@ -79,23 +80,22 @@ export const StepCustomFooter = ({
   const { errors } = status;
   const canNext = !bridgePending && !Object.keys(errors).length;
   const initialTransaction = useRef(transaction);
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
   useEffect(() => {
-    // empty the field
     onChangeTransaction(
-      getAccountBridge(account, parentAccount).updateTransaction(initialTransaction.current, {
+      bridge.updateTransaction(initialTransaction.current, {
         recipient: "",
       }),
     );
-  }, [onChangeTransaction, account, parentAccount]);
+  }, [bridge, onChangeTransaction]);
   const onBack = useCallback(() => {
-    // we need to revert
     onChangeTransaction(
-      getAccountBridge(account, parentAccount).updateTransaction(transaction, {
+      bridge.updateTransaction(transaction, {
         recipient: initialTransaction.current.recipient,
       }),
     );
     transitionTo("summary");
-  }, [account, parentAccount, onChangeTransaction, transaction, transitionTo]);
+  }, [bridge, onChangeTransaction, transaction, transitionTo]);
   const onNext = useCallback(() => {
     transitionTo("summary");
   }, [transitionTo]);

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/steps/StepValidator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/steps/StepValidator.tsx
@@ -2,9 +2,9 @@ import React, { useCallback, useRef } from "react";
 import invariant from "invariant";
 import styled from "styled-components";
 import { Trans } from "react-i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useBakers } from "@ledgerhq/live-common/families/tezos/react";
-import { Baker } from "@ledgerhq/live-common/families/tezos/types";
+import { Baker, Transaction } from "@ledgerhq/live-common/families/tezos/types";
 import { whitelist as bakersWhitelistDefault } from "@ledgerhq/live-common/families/tezos/staking";
 import { openURL } from "~/renderer/linking";
 import TrackPage from "~/renderer/analytics/TrackPage";
@@ -89,17 +89,19 @@ const StepValidator = ({
   invariant(account, "account is required");
   const contentRef = useRef(null);
   const bakers = useBakers(bakersWhitelistDefault);
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
 
   const onBakerClick = useCallback(
     (baker: Baker) => {
+      if (!transaction) return;
       onChangeTransaction(
-        getAccountBridge(account, parentAccount).updateTransaction(transaction, {
+        bridge.updateTransaction(transaction, {
           recipient: baker.address,
         }),
       );
       transitionTo("summary");
     },
-    [account, onChangeTransaction, parentAccount, transaction, transitionTo],
+    [bridge, onChangeTransaction, transaction, transitionTo],
   );
 
   const openPartner = useCallback(() => {

--- a/apps/ledger-live-desktop/src/renderer/families/xrp/SendRecipientFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/xrp/SendRecipientFields.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from "react";
 import { BigNumber } from "bignumber.js";
 import { Account } from "@ledgerhq/types-live";
 import { Transaction } from "@ledgerhq/live-common/families/xrp/types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import MemoTagField from "LLD/features/MemoTag/components/MemoTagField";
 type Props = {
   onChange: (a: Transaction) => void;
@@ -12,9 +12,9 @@ type Props = {
 };
 const uint32maxPlus1 = BigNumber(2).pow(32);
 const TagField = ({ onChange, account, transaction, autoFocus }: Props) => {
+  const bridge = useAccountBridge<Transaction>(account);
   const onChangeTag = useCallback(
     (str: string) => {
-      const bridge = getAccountBridge(account);
       const tag = BigNumber(str.replace(/[^0-9]/g, ""));
       const patch = {
         tag:
@@ -30,7 +30,7 @@ const TagField = ({ onChange, account, transaction, autoFocus }: Props) => {
       };
       onChange(bridge.updateTransaction(transaction, patch));
     },
-    [onChange, account, transaction],
+    [bridge, onChange, transaction],
   );
   return (
     <MemoTagField

--- a/apps/ledger-live-desktop/src/renderer/hooks/useStepMethodLogic.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useStepMethodLogic.ts
@@ -1,5 +1,5 @@
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import {
   AccountBridge,
   AccountLike,
@@ -81,10 +81,10 @@ export const useStepMethodContinue = <T extends TransactionCommon>({
   transitionTo,
   getPatch,
 }: UseStepMethodContinueParams<T>) => {
+  const bridge = useAccountBridge<T>(account, parentAccount);
   return useCallback(async () => {
     invariant(editType, "editType required");
 
-    const bridge: AccountBridge<T> = getAccountBridge(account, parentAccount);
     const mainAccount = getMainAccount(account, parentAccount);
     const patch = await getPatch({
       account: mainAccount,
@@ -95,6 +95,7 @@ export const useStepMethodContinue = <T extends TransactionCommon>({
     updateTransaction(tx => bridge.updateTransaction(tx, patch));
     transitionTo("summary");
   }, [
+    bridge,
     editType,
     account,
     parentAccount,

--- a/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/steps/StepImport.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/steps/StepImport.tsx
@@ -119,14 +119,14 @@ class StepImport extends PureComponent<
     }
   };
 
-  startScanAccountsDevice() {
+  async startScanAccountsDevice() {
     this.unsub();
     try {
       const { currency, device, setScanStatus, setScannedAccounts, blacklistedTokenIds } =
         this.props;
       if (!currency || !device) throw new UnresponsiveDeviceError();
       const mainCurrency = currency.type === "TokenCurrency" ? currency.parentCurrency : currency;
-      const bridge = getCurrencyBridge(mainCurrency);
+      const bridge = await getCurrencyBridge(mainCurrency);
 
       // will be set to false if an existing account is found
       let onlyNewAccounts = true;

--- a/apps/ledger-live-desktop/src/renderer/modals/ExchangeDeviceConfirm/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/ExchangeDeviceConfirm/index.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useState, useMemo } from "react";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import styled from "styled-components";
 import { Account, AccountLike } from "@ledgerhq/types-live";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { getEnv } from "@ledgerhq/live-env";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { AppResult } from "@ledgerhq/live-common/hw/actions/app";
@@ -77,6 +77,7 @@ const VerifyOnDevice = ({
 }: VerifyOnDeviceProps) => {
   const name = useAccountName(mainAccount);
   const address = mainAccount.freshAddress;
+  const bridge = useAccountBridge(mainAccount);
   const confirmAddress = useCallback(async () => {
     if (!device || skipDevice) return null;
     try {
@@ -88,7 +89,7 @@ const VerifyOnDevice = ({
         });
       } else {
         await firstValueFrom(
-          getAccountBridge(mainAccount).receive(mainAccount, {
+          bridge.receive(mainAccount, {
             deviceId: device.deviceId,
             verify: true,
           }),
@@ -98,7 +99,7 @@ const VerifyOnDevice = ({
     } catch (err) {
       onAddressVerified(false, err);
     }
-  }, [device, onAddressVerified, mainAccount, skipDevice]);
+  }, [bridge, device, onAddressVerified, mainAccount, skipDevice]);
   useEffect(() => {
     confirmAddress();
   }, [confirmAddress]);

--- a/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveFunds.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveFunds.tsx
@@ -220,8 +220,9 @@ const StepReceiveFunds = (props: StepProps) => {
         if (!device) {
           throw new DisconnectedDevice();
         }
+        const bridge = await getAccountBridge(mainAccount);
         await firstValueFrom(
-          getAccountBridge(mainAccount).receive(mainAccount, {
+          bridge.receive(mainAccount, {
             deviceId: device.deviceId,
             verify: true,
           }),

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/Body.tsx
@@ -14,8 +14,8 @@ import {
 } from "@ledgerhq/live-common/account/index";
 import { isCryptoCurrency } from "@ledgerhq/live-common/currencies/helpers";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Account, AccountLike, Operation } from "@ledgerhq/types-live";
 import { Transaction } from "@ledgerhq/live-common/generated/types";
 import logger from "~/renderer/logger";
@@ -180,6 +180,8 @@ const Body = ({
 
   invariant(account, "account required");
 
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
+
   // make sure step id is in sync
   useEffect(() => {
     const stepId = params?.startWithWarning ? "warning" : null;
@@ -190,7 +192,6 @@ const Body = ({
   useEffect(() => {
     if (!transaction) return;
 
-    const bridge = getAccountBridge(account, parentAccount);
     let updatedTransaction = transaction;
     let hasChanges = false;
 
@@ -212,11 +213,10 @@ const Body = ({
       setTransaction(updatedTransaction);
     }
   }, [
+    bridge,
     maybeRecipient,
     maybeAmount,
     transaction,
-    account,
-    parentAccount,
     setTransaction,
     onResetMaybeRecipient,
     onResetMaybeAmount,

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
@@ -242,7 +242,7 @@ const SwapWebView = ({ manifest, isEmbedded = false, Loader = SwapLoader }: Swap
         const fromParentAccount = getParentAccount(fromAccount, accounts);
 
         let mainAccount = getMainAccount(fromAccount, fromParentAccount);
-        const bridge = getAccountBridge(fromAccount, fromParentAccount);
+        const bridge = await getAccountBridge(fromAccount, fromParentAccount);
 
         const subAccountId = fromAccount.type !== "Account" && fromAccount.id;
 


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** No behaviour change — `await` on a sync value is a no-op today.
- [ ] **Impact of the changes:** Pure forward-compatibility refactor, no user-facing change.

### 📝 Description

Prepares all desktop `getAccountBridge`/`getCurrencyBridge` call sites (modals + families) for when bridges become async. 25 files across modals, screens, and ~15 coin families.

React components hoist the bridge via `useAccountBridge` (landed in #16726):
```diff
- const onValidatorChange = (validator) => {
-   const bridge = getAccountBridge(account, parentAccount);
-   onChangeTransaction(bridge.updateTransaction(transaction, { validators: [validator] }));
- };
+ const bridge = useAccountBridge(account, parentAccount);
+ const onValidatorChange = (validator) => {
+   onChangeTransaction(bridge.updateTransaction(transaction, { validators: [validator] }));
+ };
```

Two edge cases use different patterns:
- `AccountBalanceSummaryFooter` (inside a `.sync()` chain): bridge resolution folded into RxJS via `from(Promise.resolve(...)).pipe(switchMap(...))`.
- `tezos/DelegateFlowModal/Body` (account can be null): async IIFE with a cancellation flag.

Class components and one-shot handlers (`StepImport`, `StepReceiveFunds`, `SwapWebViewDemo3`) use `await getAccountBridge`/`await getCurrencyBridge`.

Supersedes #17037 and #17045.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29176](https://ledgerhq.atlassian.net/browse/LIVE-29176) / #16733
- **ADR link (if any)**: N/A


[LIVE-29176]: https://ledgerhq.atlassian.net/browse/LIVE-29176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ