### PR TITLE
[LWDM] refactor(mobile): prepare bridge call sites for async getAccountBridge/getCurrencyBridge

### DIFF
--- a/apps/ledger-live-mobile/src/families/algorand/ScreenEditMemoValue.tsx
+++ b/apps/ledger-live-mobile/src/families/algorand/ScreenEditMemoValue.tsx
@@ -3,7 +3,8 @@ import { View, StyleSheet, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useTranslation } from "~/context/Locale";
 import i18next from "i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { Transaction as AlgorandTransaction } from "@ledgerhq/live-common/families/algorand/types";
 import { useTheme } from "@react-navigation/native";
 import KeyboardView from "~/components/KeyboardView";
 import Button from "~/components/Button";
@@ -22,8 +23,8 @@ function AlgorandEditMemo({ navigation, route }: Props) {
   const { t } = useTranslation();
   const [memo, setMemo] = useState(route.params.transaction.memo ?? undefined);
   const account = route.params.account;
+  const bridge = useAccountBridge<AlgorandTransaction>(account);
   const onValidateText = useCallback(() => {
-    const bridge = getAccountBridge(account);
     const { transaction } = route.params;
     popToScreen(navigation, ScreenName.SendSummary, {
       accountId: account.id,
@@ -33,7 +34,7 @@ function AlgorandEditMemo({ navigation, route }: Props) {
       currentNavigation: ScreenName.SendSummary,
       nextNavigation: ScreenName.SendSelectDevice,
     });
-  }, [navigation, route.params, account, memo]);
+  }, [navigation, route.params, account, bridge, memo]);
   return (
     <SafeAreaView style={styles.root}>
       <KeyboardView

--- a/apps/ledger-live-mobile/src/families/bitcoin/EditTransactionFlow/MethodSelection.tsx
+++ b/apps/ledger-live-mobile/src/families/bitcoin/EditTransactionFlow/MethodSelection.tsx
@@ -18,7 +18,6 @@ import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge"
 import { fromTransactionRaw } from "@ledgerhq/live-common/transaction/index";
 import { getEnv } from "@ledgerhq/live-env";
 import { Flex } from "@ledgerhq/native-ui";
-import type { Account } from "@ledgerhq/types-live";
 import { urls } from "~/utils/urls";
 import invariant from "invariant";
 import React, { memo, useCallback, useEffect, useState } from "react";

--- a/apps/ledger-live-mobile/src/families/bitcoin/EditTransactionFlow/MethodSelection.tsx
+++ b/apps/ledger-live-mobile/src/families/bitcoin/EditTransactionFlow/MethodSelection.tsx
@@ -13,12 +13,12 @@ import type {
 import { isOldestBitcoinPendingOperation } from "@ledgerhq/ledger-wallet-framework/operation";
 import { TransactionHasBeenValidatedError } from "@ledgerhq/errors";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { fromTransactionRaw } from "@ledgerhq/live-common/transaction/index";
 import { getEnv } from "@ledgerhq/live-env";
 import { Flex } from "@ledgerhq/native-ui";
-import type { Account, AccountBridge } from "@ledgerhq/types-live";
+import type { Account } from "@ledgerhq/types-live";
 import { urls } from "~/utils/urls";
 import invariant from "invariant";
 import React, { memo, useCallback, useEffect, useState } from "react";
@@ -41,6 +41,7 @@ function MethodSelectionComponent({ navigation, route }: Props) {
   const [haveFundToSpeedup, setHaveFundToSpeedup] = useState(false);
 
   const mainAccount = getMainAccount(account, parentAccount);
+  const bridge = useAccountBridge<BtcTransaction>(account, parentAccount);
 
   const [transactionToEdit, setTransactionToEdit] = useState<BtcTransaction | undefined>(
     undefined,
@@ -100,7 +101,6 @@ function MethodSelectionComponent({ navigation, route }: Props) {
 
   const isOldestEditableOperation = isOldestBitcoinPendingOperation(mainAccount, operation.date);
 
-  const bridge = useAccountBridge<BtcTransaction>(account, parentAccount as Account);
 
   const onSelect = useCallback(
     async (option: EditType) => {

--- a/apps/ledger-live-mobile/src/families/bitcoin/ScreenEditCustomFees.tsx
+++ b/apps/ledger-live-mobile/src/families/bitcoin/ScreenEditCustomFees.tsx
@@ -5,7 +5,8 @@ import { useTranslation } from "~/context/Locale";
 import i18next from "i18next";
 import { Keyboard, StyleSheet, View, SafeAreaView } from "react-native";
 import { CompositeScreenProps, useTheme } from "@react-navigation/native";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { Transaction as BitcoinTransaction } from "@ledgerhq/live-common/families/bitcoin/types";
 import Button from "~/components/Button";
 import KeyboardView from "~/components/KeyboardView";
 import NavigationScrollView from "~/components/NavigationScrollView";
@@ -55,6 +56,7 @@ function BitcoinEditCustomFees({ navigation, route }: Props) {
   const { account, parentAccount } = useAccountScreen(route);
   invariant(transaction.family === "bitcoin", "not bitcoin family");
   invariant(account, "no account found");
+  const bridge = useAccountBridge<BitcoinTransaction>(account, parentAccount);
   const [ownSatPerByte, setOwnSatPerByte] = useState(satPerByte ? satPerByte.toString() : "");
 
   const onChange = useCallback((text: string) => {
@@ -67,7 +69,6 @@ function BitcoinEditCustomFees({ navigation, route }: Props) {
     if (setSatPerByte) {
       setSatPerByte(BigNumber(ownSatPerByte || 0));
     }
-    const bridge = getAccountBridge(account, parentAccount);
     const { currentNavigation } = route.params;
     const updatedTransaction = bridge.updateTransaction(transaction, {
       feePerByte: BigNumber(ownSatPerByte || 0),
@@ -88,7 +89,7 @@ function BitcoinEditCustomFees({ navigation, route }: Props) {
     }
 
     popToScreen(navigation, currentNavigation, nextParams);
-  }, [setSatPerByte, ownSatPerByte, account, parentAccount, route.params, navigation, transaction]);
+  }, [setSatPerByte, ownSatPerByte, account, bridge, route.params, navigation, transaction]);
   return (
     <SafeAreaView
       style={{

--- a/apps/ledger-live-mobile/src/families/bitcoin/SendRowsFee.tsx
+++ b/apps/ledger-live-mobile/src/families/bitcoin/SendRowsFee.tsx
@@ -9,7 +9,7 @@ import type {
 import { Trans } from "~/context/Locale";
 import type { Transaction as BitcoinTransaction } from "@ledgerhq/live-common/families/bitcoin/types";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useFeesStrategy } from "@ledgerhq/live-common/families/bitcoin/react";
 import { CompositeScreenProps } from "@react-navigation/native";
 import BigNumber from "bignumber.js";
@@ -45,6 +45,7 @@ export default function BitcoinSendRowsFee({
   ...props
 }: Props) {
   invariant(account.type === "Account", "account not found");
+  const bridge = useAccountBridge<BitcoinTransaction>(account, parentAccount);
   const defaultStrategies = useFeesStrategy(account, transaction as BitcoinTransaction);
   const [satPerByte, setSatPerByte] = useState<BigNumber | null>(null);
   const strategies = useMemo(
@@ -64,15 +65,14 @@ export default function BitcoinSendRowsFee({
   );
   const onFeesSelected = useCallback(
     ({ amount, label }: SelectFeeStrategy) => {
-      const bridge = getAccountBridge(account, parentAccount);
       setTransaction(
-        bridge.updateTransaction(transaction, {
-          feesStrategy: label,
+        bridge.updateTransaction(transaction as BitcoinTransaction, {
+          feesStrategy: label as BitcoinTransaction["feesStrategy"],
           feePerByte: amount,
         }),
       );
     },
-    [setTransaction, account, parentAccount, transaction],
+    [setTransaction, bridge, transaction],
   );
   const openCustomFees = useCallback(() => {
     navigation.navigate(ScreenName.BitcoinEditCustomFees, {

--- a/apps/ledger-live-mobile/src/families/canton/Onboard/CantonReonboardDrawer/useCantonReonboardDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/families/canton/Onboard/CantonReonboardDrawer/useCantonReonboardDrawerViewModel.ts
@@ -1,6 +1,6 @@
 import type { CantonCurrencyBridge, CantonOnboardResult } from "@ledgerhq/coin-canton/types";
 import { OnboardStatus } from "@ledgerhq/coin-canton/types";
-import { getCurrencyBridge } from "@ledgerhq/live-common/bridge/index";
+import { useCurrencyBridge } from "@ledgerhq/live-common/bridge/useCurrencyBridge";
 import { addAccountsAction } from "@ledgerhq/live-wallet/addAccounts";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Account } from "@ledgerhq/types-live";
@@ -39,10 +39,7 @@ export function useCantonReonboardDrawerViewModel({
   const existingAccounts = useSelector(accountsSelector);
   const dispatch = useDispatch();
 
-  const bridge = useMemo(() => {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    return getCurrencyBridge(currency) as CantonCurrencyBridge;
-  }, [currency]);
+  const bridge = useCurrencyBridge<CantonCurrencyBridge>(currency);
 
   const {
     onboardingStatus,

--- a/apps/ledger-live-mobile/src/families/canton/Onboard/OnboardScreen/useOnboardScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/families/canton/Onboard/OnboardScreen/useOnboardScreenViewModel.ts
@@ -1,6 +1,6 @@
 import type { CantonCurrencyBridge } from "@ledgerhq/coin-canton/types";
 import { OnboardStatus } from "@ledgerhq/coin-canton/types";
-import { getCurrencyBridge } from "@ledgerhq/live-common/bridge/index";
+import { useCurrencyBridge } from "@ledgerhq/live-common/bridge/useCurrencyBridge";
 import { isTokenCurrency } from "@ledgerhq/live-common/currencies/index";
 import { addAccountsAction } from "@ledgerhq/live-wallet/addAccounts";
 import { useCallback, useEffect, useLayoutEffect, useMemo } from "react";
@@ -31,14 +31,7 @@ export function useOnboardScreenViewModel({ navigation, route }: OnboardScreenVi
   const dispatch = useDispatch();
 
   const cryptoCurrency = isTokenCurrency(currency) ? currency.parentCurrency : currency;
-  const bridge = useMemo(() => {
-    const currencyBridge = getCurrencyBridge(cryptoCurrency);
-    if (!currencyBridge) {
-      throw new Error(`Currency bridge not found for ${cryptoCurrency.id}`);
-    }
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    return currencyBridge as CantonCurrencyBridge;
-  }, [cryptoCurrency]);
+  const bridge = useCurrencyBridge<CantonCurrencyBridge>(cryptoCurrency);
 
   const {
     onboardingStatus,

--- a/apps/ledger-live-mobile/src/families/canton/ScreenEditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/canton/ScreenEditMemo.tsx
@@ -3,7 +3,8 @@ import { View, StyleSheet, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useTranslation } from "~/context/Locale";
 import i18next from "i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { Transaction as CantonTransaction } from "@ledgerhq/live-common/families/canton/types";
 import { useTheme } from "@react-navigation/native";
 import KeyboardView from "~/components/KeyboardView";
 import Button from "~/components/Button";
@@ -22,8 +23,8 @@ function CantonEditMemo({ navigation, route }: Props) {
   const { t } = useTranslation();
   const [memo, setMemo] = useState(route.params.transaction.memo);
   const account = route.params.account;
+  const bridge = useAccountBridge<CantonTransaction>(account);
   const onValidateText = useCallback(() => {
-    const bridge = getAccountBridge(account);
     const { transaction } = route.params;
     popToScreen(navigation, ScreenName.SendSummary, {
       accountId: account.id,
@@ -33,7 +34,7 @@ function CantonEditMemo({ navigation, route }: Props) {
       currentNavigation: ScreenName.SendSummary,
       nextNavigation: ScreenName.SendSelectDevice,
     });
-  }, [navigation, route.params, account, memo]);
+  }, [navigation, route.params, account, bridge, memo]);
   return (
     <SafeAreaView style={styles.root}>
       <KeyboardView

--- a/apps/ledger-live-mobile/src/families/canton/TooManyUtxosModal.tsx
+++ b/apps/ledger-live-mobile/src/families/canton/TooManyUtxosModal.tsx
@@ -2,8 +2,8 @@ import React, { useCallback } from "react";
 import { View, StyleSheet, Linking } from "react-native";
 import { Trans } from "~/context/Locale";
 import { useTheme, useNavigation } from "@react-navigation/native";
-import { CantonAccount } from "@ledgerhq/live-common/families/canton/types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import type { CantonAccount, Transaction as CantonTransaction } from "@ledgerhq/live-common/families/canton/types";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import QueuedDrawer from "~/components/QueuedDrawer";
 import LText from "~/components/LText";
 import Button from "~/components/Button";
@@ -25,11 +25,10 @@ function TooManyUtxosModal({ isOpened, onClose, account }: Props) {
   const { colors } = useTheme();
   const navigation = useNavigation();
   const learnMoreUrl = useLocalizedUrl(urls.canton.learnMore);
+  const bridge = useAccountBridge<CantonTransaction>(account);
 
   const handleConsolidate = useCallback(() => {
     onClose();
-
-    const bridge = getAccountBridge(account);
     const transaction = bridge.createTransaction(account);
     const updatedTransaction = bridge.updateTransaction(transaction, {
       recipient: account.xpub || "",
@@ -43,7 +42,7 @@ function TooManyUtxosModal({ isOpened, onClose, account }: Props) {
         transaction: updatedTransaction,
       },
     });
-  }, [navigation, account, onClose]);
+  }, [navigation, account, bridge, onClose]);
 
   const handleLearnMore = useCallback(() => {
     Linking.openURL(learnMoreUrl);

--- a/apps/ledger-live-mobile/src/families/cardano/DelegationFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/cardano/DelegationFlow/02-Summary.tsx
@@ -5,8 +5,8 @@ import React, { ReactNode, useCallback, useEffect, useMemo, useState } from "rea
 import { Trans, useTranslation } from "~/context/Locale";
 import { Animated, SafeAreaView, StyleSheet, View } from "react-native";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
-import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { formatCurrencyUnit, getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
 import {
   LEDGER_POOL_IDS,
@@ -19,6 +19,7 @@ import type {
   CardanoDelegation,
   TransactionStatus,
   Transaction,
+  Transaction as CardanoTransaction,
 } from "@ledgerhq/live-common/families/cardano/types";
 import { Box, Text, Icons } from "@ledgerhq/native-ui";
 import { AccountLike } from "@ledgerhq/types-live";
@@ -59,7 +60,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
 
   const { cardanoResources } = account as CardanoAccount;
   const currentDelegation = cardanoResources.delegation;
-  const bridge = useAccountBridge<Transaction>(account, undefined);
+  const bridge = useAccountBridge<CardanoTransaction>(account, undefined);
 
   const [isFetchingPoolDetails, setIsFetchingPoolDetails] = useState(false);
   const [ledgerPools, setLedgerPools] = useState<Array<StakePool>>([]);

--- a/apps/ledger-live-mobile/src/families/cardano/Delegations/DRepDelegationSelfTransactionInfoDrawer.tsx
+++ b/apps/ledger-live-mobile/src/families/cardano/Delegations/DRepDelegationSelfTransactionInfoDrawer.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { useNavigation } from "@react-navigation/native";
-import type { CardanoAccount } from "@ledgerhq/live-common/families/cardano/types";
+import type { CardanoAccount, Transaction as CardanoTransaction } from "@ledgerhq/live-common/families/cardano/types";
 import { StyleSheet } from "react-native";
 import { Text, Flex } from "@ledgerhq/native-ui";
 import { ScreenName, NavigatorName } from "~/const";
@@ -10,7 +10,7 @@ import EarnLight from "~/images/illustration/Light/_003.webp";
 import EarnDark from "~/images/illustration/Dark/_003.webp";
 import { Trans } from "~/context/Locale";
 import Button from "~/components/wrappedUi/Button";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import BigNumber from "bignumber.js";
 
 // It is to cover minimum utxo amount for internal transaction
@@ -26,9 +26,9 @@ export default function DRepDelegationSelfTransactionInfoDrawer({
   onClose: () => void;
 }>) {
   const navigation = useNavigation();
+  const bridge = useAccountBridge<CardanoTransaction>(account);
 
   const onContinue = useCallback(() => {
-    const bridge = getAccountBridge(account);
     const transaction = bridge.createTransaction(account);
     const updatedTransaction = bridge.updateTransaction(transaction, {
       recipient: account.freshAddress,
@@ -44,7 +44,7 @@ export default function DRepDelegationSelfTransactionInfoDrawer({
         transaction: updatedTransaction,
       },
     });
-  }, [account, navigation, onClose]);
+  }, [account, bridge, navigation, onClose]);
 
   return (
     <QueuedDrawer isRequestingToBeOpened={isOpen} onClose={onClose}>

--- a/apps/ledger-live-mobile/src/families/cardano/Delegations/__tests__/DRepDelegationSelfTransactionInfoDrawer.test.tsx
+++ b/apps/ledger-live-mobile/src/families/cardano/Delegations/__tests__/DRepDelegationSelfTransactionInfoDrawer.test.tsx
@@ -89,7 +89,7 @@ describe("DRepDelegationSelfTransactionInfoDrawer", () => {
     const continueButton = screen.getByTestId("continue-button");
     fireEvent.press(continueButton);
 
-    expect(getAccountBridge).toHaveBeenCalledWith(mockAccount);
+    expect(getAccountBridge).toHaveBeenCalledWith(mockAccount, undefined);
     expect(mockBridge.createTransaction).toHaveBeenCalledWith(mockAccount);
     expect(mockBridge.updateTransaction).toHaveBeenCalledWith(expect.anything(), {
       recipient: mockAccount.freshAddress,

--- a/apps/ledger-live-mobile/src/families/cardano/EditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/cardano/EditMemo.tsx
@@ -3,7 +3,8 @@ import { View, StyleSheet, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useTranslation } from "~/context/Locale";
 import i18next from "i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { Transaction as CardanoTransaction } from "@ledgerhq/live-common/families/cardano/types";
 import { useTheme } from "@react-navigation/native";
 import KeyboardView from "~/components/KeyboardView";
 import Button from "~/components/Button";
@@ -22,8 +23,8 @@ function CardanoEditMemo({ navigation, route }: Props) {
   const { t } = useTranslation();
   const [memo, setMemo] = useState(route.params.transaction.memo);
   const account = route.params.account;
+  const bridge = useAccountBridge<CardanoTransaction>(account);
   const onValidateText = useCallback(() => {
-    const bridge = getAccountBridge(account);
     const { transaction } = route.params;
     popToScreen(navigation, ScreenName.SendSummary, {
       accountId: account.id,
@@ -33,7 +34,7 @@ function CardanoEditMemo({ navigation, route }: Props) {
       currentNavigation: ScreenName.SendSummary,
       nextNavigation: ScreenName.SendSelectDevice,
     });
-  }, [navigation, route.params, account, memo]);
+  }, [navigation, route.params, account, bridge, memo]);
   return (
     <SafeAreaView style={styles.root}>
       <KeyboardView

--- a/apps/ledger-live-mobile/src/families/cardano/UndelegationFlow/01-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/cardano/UndelegationFlow/01-Summary.tsx
@@ -5,14 +5,14 @@ import React, { ReactNode, useCallback, useEffect, useMemo, useState } from "rea
 import { Trans, useTranslation } from "~/context/Locale";
 import { SafeAreaView, StyleSheet, View } from "react-native";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/index";
-import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { formatCurrencyUnit, getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
 import type {
   CardanoAccount,
   CardanoDelegation,
-  Transaction as CardanoTransaction,
   TransactionStatus,
+  Transaction as CardanoTransaction,
 } from "@ledgerhq/live-common/families/cardano/types";
 import { Text, Box } from "@ledgerhq/native-ui";
 import { AccountLike } from "@ledgerhq/types-live";

--- a/apps/ledger-live-mobile/src/families/casper/ScreenEditTransferId.tsx
+++ b/apps/ledger-live-mobile/src/families/casper/ScreenEditTransferId.tsx
@@ -4,7 +4,8 @@ import { View, StyleSheet, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useTranslation } from "~/context/Locale";
 import i18next from "i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { Transaction as CasperTransaction } from "@ledgerhq/live-common/families/casper/types";
 import { useIsFocused, useTheme } from "@react-navigation/native";
 import KeyboardView from "~/components/KeyboardView";
 import Button from "~/components/Button";
@@ -30,6 +31,7 @@ function CasperEditTransferId({ navigation, route }: NavigationProps) {
   const { t } = useTranslation();
   const { account } = useAccountScreen(route);
   invariant(account, "account is required");
+  const bridge = useAccountBridge<CasperTransaction>(account);
   const [transferId, setTransferId] = useState(route.params?.transaction.transferId);
   const onChangeTransferIdValue = useCallback((str: string) => {
     let value: string = str;
@@ -37,7 +39,6 @@ function CasperEditTransferId({ navigation, route }: NavigationProps) {
     setTransferId(value === "" ? undefined : value);
   }, []);
   const onValidateText = useCallback(() => {
-    const bridge = getAccountBridge(account);
     const { transaction } = route.params;
 
     popToScreen(navigation, ScreenName.SendSummary, {
@@ -46,7 +47,7 @@ function CasperEditTransferId({ navigation, route }: NavigationProps) {
         transferId: transferId && transferId.toString(),
       }),
     });
-  }, [navigation, route.params, account, transferId]);
+  }, [navigation, route.params, account, bridge, transferId]);
   return (
     <SafeAreaView style={styles.root}>
       <KeyboardView

--- a/apps/ledger-live-mobile/src/families/cosmos/EditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/EditMemo.tsx
@@ -3,7 +3,8 @@ import { View, StyleSheet, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useTranslation } from "~/context/Locale";
 import i18next from "i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { Transaction as CosmosTransaction } from "@ledgerhq/live-common/families/cosmos/types";
 import { useTheme } from "@react-navigation/native";
 import KeyboardView from "~/components/KeyboardView";
 import Button from "~/components/Button";
@@ -22,9 +23,8 @@ function CosmosFamilyEditMemo({ navigation, route }: Props) {
   const [memo, setMemo] = useState(route.params.transaction.memo);
   const account = route.params.account;
   const currencyName = account.currency.name;
-
+  const bridge = useAccountBridge<CosmosTransaction>(account);
   const onValidateText = useCallback(() => {
-    const bridge = getAccountBridge(account);
     const { transaction } = route.params;
     popToScreen(navigation, ScreenName.SendSummary, {
       ...route.params,
@@ -33,7 +33,7 @@ function CosmosFamilyEditMemo({ navigation, route }: Props) {
         memo,
       }),
     });
-  }, [navigation, route.params, account, memo]);
+  }, [navigation, route.params, account, bridge, memo]);
   return (
     <SafeAreaView style={styles.root}>
       <KeyboardView

--- a/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/MethodSelection.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/MethodSelection.tsx
@@ -9,12 +9,12 @@ import { Transaction as EvmTransaction, TransactionRaw } from "@ledgerhq/coin-ev
 import { isOldestPendingOperation } from "@ledgerhq/ledger-wallet-framework/operation";
 import { TransactionHasBeenValidatedError } from "@ledgerhq/errors";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { getEnv } from "@ledgerhq/live-env";
 import { log } from "@ledgerhq/logs";
 import { Flex } from "@ledgerhq/native-ui";
-import { Account, AccountBridge } from "@ledgerhq/types-live";
+import { Account } from "@ledgerhq/types-live";
 import { urls } from "~/utils/urls";
 import invariant from "invariant";
 import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
@@ -42,6 +42,7 @@ function MethodSelectionComponent({ navigation, route }: Props) {
   const [transactionHasBeenValidated, setTransactionHasBeenValidated] = useState(false);
 
   const mainAccount = getMainAccount(account, parentAccount);
+  const bridge = useAccountBridge<EvmTransaction>(account, parentAccount);
 
   const transactionToEdit = useFromTransactionRaw<EvmTransaction>(
     operation.transactionRaw as TransactionRaw,
@@ -84,7 +85,6 @@ function MethodSelectionComponent({ navigation, route }: Props) {
         : false,
     [mainAccount, transactionToEdit],
   );
-  const bridge: AccountBridge<EvmTransaction> = useAccountBridge<EvmTransaction>(account, parentAccount as Account);
 
   const onSelect = useCallback(
     async (option: EditType) => {

--- a/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/MethodSelection.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/MethodSelection.tsx
@@ -14,7 +14,6 @@ import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge"
 import { getEnv } from "@ledgerhq/live-env";
 import { log } from "@ledgerhq/logs";
 import { Flex } from "@ledgerhq/native-ui";
-import { Account } from "@ledgerhq/types-live";
 import { urls } from "~/utils/urls";
 import invariant from "invariant";
 import React, { memo, useCallback, useEffect, useMemo, useState } from "react";

--- a/apps/ledger-live-mobile/src/families/hedera/EditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/EditMemo.tsx
@@ -3,7 +3,8 @@ import { View, StyleSheet, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useTranslation } from "~/context/Locale";
 import i18next from "i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { Transaction as HederaTransaction } from "@ledgerhq/live-common/families/hedera/types";
 import { useTheme } from "@react-navigation/native";
 import KeyboardView from "~/components/KeyboardView";
 import Button from "~/components/Button";
@@ -22,8 +23,8 @@ function HederaEditMemo({ navigation, route }: NavigationProps) {
   const { t } = useTranslation();
   const [memo, setMemo] = useState(route.params.transaction.memo);
   const account = route.params.account;
+  const bridge = useAccountBridge<HederaTransaction>(account);
   const onValidateText = useCallback(() => {
-    const bridge = getAccountBridge(account);
     const { transaction } = route.params;
     popToScreen(navigation, ScreenName.SendSummary, {
       accountId: account.id,
@@ -31,7 +32,7 @@ function HederaEditMemo({ navigation, route }: NavigationProps) {
         memo,
       }),
     });
-  }, [navigation, route.params, account, memo]);
+  }, [navigation, route.params, account, bridge, memo]);
   return (
     <SafeAreaView style={styles.root}>
       <KeyboardView

--- a/apps/ledger-live-mobile/src/families/helpers.ts
+++ b/apps/ledger-live-mobile/src/families/helpers.ts
@@ -20,7 +20,7 @@ export function useFieldByFamily(
 }
 export function useEditTxFeeByFamily() {
   const transaction = useRoute<Navigation["route"]>().params?.transaction;
-  return ({
+  return async ({
     account,
     field,
     fee,
@@ -29,7 +29,7 @@ export function useEditTxFeeByFamily() {
     field: string;
     fee: BigNumber | null | undefined;
   }) => {
-    const bridge = getAccountBridge(account);
+    const bridge = await getAccountBridge(account);
     return bridge.updateTransaction(transaction, {
       [field]: fee,
     });

--- a/apps/ledger-live-mobile/src/families/internet_computer/ScreenEditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/internet_computer/ScreenEditMemo.tsx
@@ -4,7 +4,8 @@ import { View, StyleSheet, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useTranslation } from "~/context/Locale";
 import i18next from "i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { Transaction as InternetComputerTransaction } from "@ledgerhq/live-common/families/internet_computer/types";
 import { useIsFocused, useTheme } from "@react-navigation/native";
 import KeyboardView from "~/components/KeyboardView";
 import Button from "~/components/Button";
@@ -30,6 +31,7 @@ function InternetComputerEditMemo({ navigation, route }: NavigationProps) {
   const { t } = useTranslation();
   const { account } = useAccountScreen(route);
   invariant(account, "account is required");
+  const bridge = useAccountBridge<InternetComputerTransaction>(account);
   const [memo, setMemo] = useState(route.params?.transaction.memo);
   const onChangeMemoValue = useCallback((str: string) => {
     let value: string = str;
@@ -37,7 +39,6 @@ function InternetComputerEditMemo({ navigation, route }: NavigationProps) {
     setMemo(value === "" ? undefined : value);
   }, []);
   const onValidateText = useCallback(() => {
-    const bridge = getAccountBridge(account);
     const { transaction } = route.params;
     popToScreen(navigation, ScreenName.SendSummary, {
       accountId: account.id,
@@ -45,7 +46,7 @@ function InternetComputerEditMemo({ navigation, route }: NavigationProps) {
         memo: memo && memo.toString(),
       }),
     });
-  }, [navigation, route.params, account, memo]);
+  }, [navigation, route.params, account, bridge, memo]);
   return (
     <SafeAreaView style={styles.root}>
       <KeyboardView

--- a/apps/ledger-live-mobile/src/families/kaspa/ScreenEditCustomFees.tsx
+++ b/apps/ledger-live-mobile/src/families/kaspa/ScreenEditCustomFees.tsx
@@ -5,7 +5,8 @@ import { useTranslation } from "~/context/Locale";
 import i18next from "i18next";
 import { Keyboard, SafeAreaView, StyleSheet, View } from "react-native";
 import { CompositeScreenProps, useTheme } from "@react-navigation/native";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { Transaction as KaspaTransaction } from "@ledgerhq/live-common/families/kaspa/types";
 import Button from "~/components/Button";
 import KeyboardView from "~/components/KeyboardView";
 import NavigationScrollView from "~/components/NavigationScrollView";
@@ -41,6 +42,7 @@ function KaspaEditCustomFees({ navigation, route }: Props) {
   const { transaction } = route.params;
   const { account, parentAccount } = useAccountScreen(route);
   invariant(account, "no account found");
+  const bridge = useAccountBridge<KaspaTransaction>(account, parentAccount);
   const [ownSompiPerByte, setOwnSompiPerByte] = useState(
     sompiPerByte ? sompiPerByte.toString() : "",
   );
@@ -53,7 +55,6 @@ function KaspaEditCustomFees({ navigation, route }: Props) {
     if (BigNumber(ownSompiPerByte || 0).isZero()) return;
     Keyboard.dismiss();
     setSompiPerByte && setSompiPerByte(BigNumber(ownSompiPerByte || 0));
-    const bridge = getAccountBridge(account, parentAccount);
     navigation.navigate(NavigatorName.SendFunds, {
       screen: ScreenName.SendSummary,
       params: {
@@ -69,7 +70,7 @@ function KaspaEditCustomFees({ navigation, route }: Props) {
     setSompiPerByte,
     ownSompiPerByte,
     account,
-    parentAccount,
+    bridge,
     route.params,
     navigation,
     transaction,

--- a/apps/ledger-live-mobile/src/families/kaspa/SendRowsFee.tsx
+++ b/apps/ledger-live-mobile/src/families/kaspa/SendRowsFee.tsx
@@ -9,7 +9,7 @@ import type {
 import { Trans } from "~/context/Locale";
 import type { Transaction as KaspaTransaction } from "@ledgerhq/live-common/families/kaspa/types";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useFeesStrategy } from "@ledgerhq/live-common/families/kaspa/react";
 import { CompositeScreenProps } from "@react-navigation/native";
 import BigNumber from "bignumber.js";
@@ -45,6 +45,7 @@ export default function KaspaSendRowsFee({
   ...props
 }: Props) {
   invariant(account.type === "Account", "account not found");
+  const bridge = useAccountBridge<KaspaTransaction>(account, parentAccount);
   const defaultStrategies = useFeesStrategy(account, transaction as KaspaTransaction);
   const [sompiPerByte, setSompiPerByte] = useState<BigNumber | null>(null);
   const strategies = useMemo(
@@ -64,14 +65,13 @@ export default function KaspaSendRowsFee({
   );
   const onFeesSelected = useCallback(
     ({ label }: SelectFeeStrategy) => {
-      const bridge = getAccountBridge(account, parentAccount);
       setTransaction(
-        bridge.updateTransaction(transaction, {
-          feesStrategy: label,
+        bridge.updateTransaction(transaction as KaspaTransaction, {
+          feesStrategy: label as KaspaTransaction["feesStrategy"],
         }),
       );
     },
-    [setTransaction, account, parentAccount, transaction],
+    [setTransaction, bridge, transaction],
   );
   const openCustomFees = useCallback(() => {
     navigation.navigate(ScreenName.KaspaEditCustomFees, {

--- a/apps/ledger-live-mobile/src/families/mina/ScreenEditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/mina/ScreenEditMemo.tsx
@@ -4,7 +4,8 @@ import { View, StyleSheet, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useTranslation } from "~/context/Locale";
 import i18next from "i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { Transaction as MinaTransaction } from "@ledgerhq/live-common/families/mina/types";
 import { useIsFocused, useTheme } from "@react-navigation/native";
 import KeyboardView from "~/components/KeyboardView";
 import Button from "~/components/Button";
@@ -25,12 +26,12 @@ function MinaEditMemo({ navigation, route }: NavigationProps) {
   const { t } = useTranslation();
   const { account } = useAccountScreen(route);
   invariant(account, "account is required");
+  const bridge = useAccountBridge<MinaTransaction>(account);
   const [memo, setMemo] = useState(route.params?.transaction.memo);
   const onChangeMemoValue = useCallback((str: string) => {
     setMemo(str === "" ? undefined : str);
   }, []);
   const onValidateText = useCallback(() => {
-    const bridge = getAccountBridge(account);
     const { transaction } = route.params;
     popToScreen(navigation, ScreenName.SendSummary, {
       accountId: account.id,
@@ -40,7 +41,7 @@ function MinaEditMemo({ navigation, route }: NavigationProps) {
       currentNavigation: ScreenName.SendSummary,
       nextNavigation: ScreenName.SendSelectDevice,
     });
-  }, [navigation, route.params, account, memo]);
+  }, [navigation, route.params, account, bridge, memo]);
   return (
     <SafeAreaView style={styles.root}>
       <KeyboardView

--- a/apps/ledger-live-mobile/src/families/polkadot/BondFlow/02-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/BondFlow/02-Amount.tsx
@@ -1,4 +1,5 @@
 import { BigNumber } from "bignumber.js";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import React, { useCallback, useState, useEffect } from "react";
 import {
@@ -17,7 +18,6 @@ import { useTheme } from "@react-navigation/native";
 import type { Transaction as PolkadotTransaction } from "@ledgerhq/live-common/families/polkadot/types";
 import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { isFirstBond } from "@ledgerhq/live-common/families/polkadot/logic";
 import { PolkadotAccount } from "@ledgerhq/live-common/families/polkadot/types";
 import { urls } from "~/utils/urls";
@@ -108,7 +108,7 @@ export default function PolkadotBondAmount({ navigation, route }: Props) {
         parentAccount,
         transaction: debouncedTransaction,
       })
-      .then(estimate => {
+      .then((estimate: BigNumber) => {
         if (cancelled) return;
         setMaxSpendable(estimate);
       });

--- a/apps/ledger-live-mobile/src/families/polkadot/UnbondFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/UnbondFlow/01-Amount.tsx
@@ -1,5 +1,6 @@
 import invariant from "invariant";
 import { BigNumber } from "bignumber.js";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import React, { useCallback, useState, useEffect } from "react";
 import {
@@ -15,7 +16,6 @@ import { useTheme } from "@react-navigation/native";
 import type { Transaction as PolkadotTransaction } from "@ledgerhq/live-common/families/polkadot/types";
 import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { ScreenName } from "~/const";
 import { TrackScreen } from "~/analytics";
 import LText from "~/components/LText";
@@ -65,7 +65,7 @@ export default function PolkadotUnbondAmount({ navigation, route }: Props) {
         parentAccount,
         transaction: debouncedTransaction,
       })
-      .then(estimate => {
+      .then((estimate: BigNumber) => {
         if (cancelled) return;
         setMaxSpendable(estimate);
       });

--- a/apps/ledger-live-mobile/src/families/polkadot/components/FlowErrorBottomModal.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/components/FlowErrorBottomModal.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { StyleSheet } from "react-native";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Transaction } from "@ledgerhq/live-common/families/polkadot/types";
 import { Account, AccountLike } from "@ledgerhq/types-live";
 import { NavigationProp } from "@react-navigation/native";
@@ -25,6 +25,7 @@ const FlowErrorBottomModal = ({
   parentAccount,
   bridgeError,
 }: Props) => {
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
   const [bridgeErr, setBridgeErr] = useState(bridgeError);
   useEffect(() => setBridgeErr(bridgeError), [bridgeError]);
   const onBridgeErrorCancel = useCallback(() => {
@@ -35,9 +36,8 @@ const FlowErrorBottomModal = ({
   const onBridgeErrorRetry = useCallback(() => {
     setBridgeErr(null);
     if (!transaction) return;
-    const bridge = getAccountBridge(account, parentAccount);
     setTransaction(bridge.updateTransaction(transaction, {}));
-  }, [setTransaction, account, parentAccount, transaction]);
+  }, [setTransaction, bridge, transaction]);
   return (
     <GenericErrorBottomModal
       error={bridgeErr}

--- a/apps/ledger-live-mobile/src/families/solana/ScreenEditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/ScreenEditMemo.tsx
@@ -1,4 +1,5 @@
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { Transaction as SolanaTransaction } from "@ledgerhq/live-common/families/solana/types";
 import { useTheme } from "@react-navigation/native";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import i18next from "i18next";
@@ -28,9 +29,9 @@ function SolanaEditMemo({ navigation, route }: NavigationProps) {
 
   const [memo, setMemo] = useState(modelSupported ? modelSupported.uiState.memo : undefined);
   const account = route.params.account;
+  const bridge = useAccountBridge<SolanaTransaction>(account);
 
   const onValidateText = useCallback(() => {
-    const bridge = getAccountBridge(account);
     const { transaction } = route.params;
     const nextTx = bridge.updateTransaction(transaction, {
       model: {
@@ -39,14 +40,14 @@ function SolanaEditMemo({ navigation, route }: NavigationProps) {
           ...transaction.model.uiState,
           memo,
         },
-      },
+      } as SolanaTransaction["model"],
     });
 
     popToScreen(navigation, ScreenName.SendSummary, {
       accountId: account.id,
       transaction: nextTx,
     });
-  }, [navigation, route.params, account, memo]);
+  }, [navigation, route.params, account, bridge, memo]);
 
   if (!modelSupported) {
     return null;

--- a/apps/ledger-live-mobile/src/families/stacks/ScreenEditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/stacks/ScreenEditMemo.tsx
@@ -4,7 +4,8 @@ import { View, StyleSheet, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useTranslation } from "~/context/Locale";
 import i18next from "i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { Transaction as StacksTransaction } from "@ledgerhq/live-common/families/stacks/types";
 import { useIsFocused, useTheme } from "@react-navigation/native";
 import KeyboardView from "~/components/KeyboardView";
 import Button from "~/components/Button";
@@ -26,12 +27,12 @@ function StacksEditMemo({ navigation, route }: NavigationProps) {
   const { t } = useTranslation();
   const { account } = useAccountScreen(route);
   invariant(account, "account is required");
+  const bridge = useAccountBridge<StacksTransaction>(account);
   const [memo, setMemo] = useState(route.params.transaction.memo);
   const onChangeMemoValue = useCallback((str: string) => {
     setMemo(str);
   }, []);
   const onValidateText = useCallback(() => {
-    const bridge = getAccountBridge(account);
     const { transaction } = route.params;
     popToScreen(navigation, ScreenName.SendSummary, {
       accountId: account.id,
@@ -39,7 +40,7 @@ function StacksEditMemo({ navigation, route }: NavigationProps) {
         memo: memo && memo.toString(),
       }),
     });
-  }, [navigation, route.params, account, memo]);
+  }, [navigation, route.params, account, bridge, memo]);
   return (
     <SafeAreaView style={styles.root}>
       <KeyboardView

--- a/apps/ledger-live-mobile/src/families/stellar/ScreenEditCustomFees.tsx
+++ b/apps/ledger-live-mobile/src/families/stellar/ScreenEditCustomFees.tsx
@@ -5,7 +5,8 @@ import { useTranslation } from "~/context/Locale";
 import i18next from "i18next";
 import { Keyboard, StyleSheet, View, SafeAreaView, ScrollView } from "react-native";
 import { useTheme } from "@react-navigation/native";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { Transaction as StellarTransaction } from "@ledgerhq/live-common/families/stellar/types";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import Button from "~/components/Button";
 import KeyboardView from "~/components/KeyboardView";
@@ -38,6 +39,7 @@ function StellarEditCustomFees({ navigation, route }: NavigationProps) {
   const { account, parentAccount } = useAccountScreen(route);
   invariant(transaction.family === "stellar", "not stellar family");
   invariant(account, "no account found");
+  const bridge = useAccountBridge<StellarTransaction>(account, parentAccount);
   const mainAccount = getMainAccount(account, parentAccount);
   const { networkCongestionLevel } = transaction?.networkInfo || {};
   const [customFee, setCustomFee] = useState(transaction.fees);
@@ -51,17 +53,19 @@ function StellarEditCustomFees({ navigation, route }: NavigationProps) {
   const onSubmit = useCallback(() => {
     Keyboard.dismiss();
     setCustomFee(BigNumber(customFee || 0));
-    const bridge = getAccountBridge(account, parentAccount);
     const { currentNavigation } = route.params;
     popToScreen(navigation, currentNavigation, {
       ...route.params,
       accountId: account.id,
       transaction: bridge.updateTransaction(transaction, {
         fees: BigNumber(customFee || 0),
-        customFees: { parameters: { fees: BigNumber(customFee || 0) } },
+        customFees: {
+          value: BigInt(BigNumber(customFee || 0).toString()),
+          parameters: { fees: BigNumber(customFee || 0) },
+        },
       }),
     });
-  }, [customFee, account, parentAccount, route.params, navigation, transaction]);
+  }, [customFee, account, bridge, route.params, navigation, transaction]);
   return (
     <SafeAreaView style={styles.root}>
       <KeyboardView

--- a/apps/ledger-live-mobile/src/families/stellar/ScreenEditMemoType.tsx
+++ b/apps/ledger-live-mobile/src/families/stellar/ScreenEditMemoType.tsx
@@ -31,12 +31,12 @@ const mapStateToProps = (_state: State, props: NavigationProps) => ({
     : "NO_MEMO",
   items,
   cancelNavigateBack: true,
-  onValueChange: ({ value }: { value: string; label: string }) => {
+  onValueChange: async ({ value }: { value: string; label: string }) => {
     const { navigation, route } = props;
     const { transaction, account } = route.params;
 
     if (value === "NO_MEMO") {
-      const bridge = getAccountBridge(account);
+      const bridge = await getAccountBridge(account);
       popToScreen(navigation, ScreenName.SendSummary, {
         accountId: account.id,
         transaction: bridge.updateTransaction(transaction, {

--- a/apps/ledger-live-mobile/src/families/stellar/ScreenEditMemoValue.tsx
+++ b/apps/ledger-live-mobile/src/families/stellar/ScreenEditMemoValue.tsx
@@ -4,7 +4,8 @@ import { View, StyleSheet, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useTranslation } from "~/context/Locale";
 import i18next from "i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { Transaction as StellarTransaction } from "@ledgerhq/live-common/families/stellar/types";
 import { useIsFocused, useTheme } from "@react-navigation/native";
 import KeyboardView from "~/components/KeyboardView";
 import Button from "~/components/Button";
@@ -27,12 +28,12 @@ function StellarEditMemoValue({ navigation, route }: NavigationProps) {
   const { t } = useTranslation();
   const { account } = useAccountScreen(route);
   invariant(account, "account is required");
+  const bridge = useAccountBridge<StellarTransaction>(account);
   const [memoValue, setMemoValue] = useState(route.params.transaction.memoValue);
   const onChangeMemoValue = useCallback((str: string) => {
     setMemoValue(str);
   }, []);
   const onValidateText = useCallback(() => {
-    const bridge = getAccountBridge(account);
     const { transaction, memoType } = route.params;
     popToScreen(navigation, ScreenName.SendSummary, {
       accountId: account.id,
@@ -41,7 +42,7 @@ function StellarEditMemoValue({ navigation, route }: NavigationProps) {
         memoType: memoType && memoType.toString(),
       }),
     });
-  }, [navigation, route.params, account, memoValue]);
+  }, [navigation, route.params, account, bridge, memoValue]);
   return (
     <SafeAreaView style={styles.root}>
       <KeyboardView

--- a/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/SelectValidator.tsx
@@ -14,8 +14,8 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useTranslation, Trans } from "~/context/Locale";
 import { Icons } from "@ledgerhq/native-ui";
 import { RecipientRequired } from "@ledgerhq/errors";
-import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import type {
   Transaction as TezosTransaction,
   Baker,

--- a/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/Summary.tsx
@@ -4,10 +4,9 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { Trans, useTranslation } from "~/context/Locale";
 import invariant from "invariant";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
-import type { AccountLike } from "@ledgerhq/types-live";
 import { getAccountCurrency, shortAddressPreview } from "@ledgerhq/live-common/account/index";
 import { getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
-import type { Transaction as TezosTransaction } from "@ledgerhq/live-common/families/tezos/types";
+import type { Transaction as TezosTransaction, TezosOperationMode } from "@ledgerhq/live-common/families/tezos/types";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import {
   useDelegation,
@@ -16,6 +15,7 @@ import {
   useStakingPositions,
 } from "@ledgerhq/live-common/families/tezos/react";
 import { whitelist } from "@ledgerhq/live-common/families/tezos/staking";
+import type { AccountLike } from "@ledgerhq/types-live";
 import { useTheme } from "@react-navigation/native";
 import { Alert, Icons } from "@ledgerhq/native-ui";
 import { rgba } from "../../../colors";
@@ -109,7 +109,10 @@ export default function DelegationSummary({ navigation, route }: Props) {
   const { account, parentAccount } = useAccountScreen(route);
   const { t } = useTranslation();
   const [defaultBaker] = useBakers(whitelist);
-  const bridge = useAccountBridge<TezosTransaction>(account as AccountLike, parentAccount);
+
+  invariant(account, "account must be defined");
+
+  const bridge = useAccountBridge<TezosTransaction>(account, parentAccount);
 
   const { transaction, setTransaction, status, bridgePending, bridgeError } = useBridgeTransaction(
     () => ({
@@ -118,7 +121,6 @@ export default function DelegationSummary({ navigation, route }: Props) {
     }),
   );
 
-  invariant(account, "account must be defined");
   invariant(transaction, "transaction must be defined");
   invariant(transaction.family === "tezos", "transaction tezos");
 
@@ -128,8 +130,11 @@ export default function DelegationSummary({ navigation, route }: Props) {
     invariant(transaction.family === "tezos", "tezos tx");
 
     // make sure the mode is in sync (an account changes can reset it)
-    const patch: Partial<TezosTransaction> & { mode: string; recipient?: string } = {
-      mode: route.params?.mode ?? "delegate",
+    const patch: {
+      mode: TezosOperationMode;
+      recipient?: string;
+    } = {
+      mode: (route.params?.mode ?? "delegate") as TezosOperationMode,
     };
 
     // make sure that in delegate mode, a transaction recipient is set (random pick)

--- a/apps/ledger-live-mobile/src/families/ton/ScreenEditComment.tsx
+++ b/apps/ledger-live-mobile/src/families/ton/ScreenEditComment.tsx
@@ -4,7 +4,8 @@ import { View, StyleSheet, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useTranslation } from "~/context/Locale";
 import i18next from "i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { Transaction as TonTransaction } from "@ledgerhq/live-common/families/ton/types";
 import { useIsFocused, useTheme } from "@react-navigation/native";
 import KeyboardView from "~/components/KeyboardView";
 import Button from "~/components/Button";
@@ -29,6 +30,7 @@ function TonEditComment({ navigation, route }: NavigationProps) {
   const { t } = useTranslation();
   const { account } = useAccountScreen(route);
   invariant(account, "account is required");
+  const bridge = useAccountBridge<TonTransaction>(account);
   const [comment, setComment] = useState(
     !route.params.transaction.comment.isEncrypted ? route.params.transaction.comment.text : "",
   );
@@ -36,7 +38,6 @@ function TonEditComment({ navigation, route }: NavigationProps) {
     setComment(str);
   }, []);
   const onValidateText = useCallback(() => {
-    const bridge = getAccountBridge(account);
     const { transaction } = route.params;
     popToScreen(navigation, ScreenName.SendSummary, {
       accountId: account.id,
@@ -44,7 +45,7 @@ function TonEditComment({ navigation, route }: NavigationProps) {
         comment: { isEncrypted: false, text: comment },
       }),
     });
-  }, [navigation, route.params, account, comment]);
+  }, [navigation, route.params, account, bridge, comment]);
   return (
     <SafeAreaView style={styles.root}>
       <KeyboardView

--- a/apps/ledger-live-mobile/src/families/xrp/ScreenEditTag.tsx
+++ b/apps/ledger-live-mobile/src/families/xrp/ScreenEditTag.tsx
@@ -1,9 +1,11 @@
+import invariant from "invariant";
 import React, { useCallback, useState } from "react";
 import { View, StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useTranslation, i18n } from "~/context/Locale";
 import { BigNumber } from "bignumber.js";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { Transaction as XrpTransaction } from "@ledgerhq/live-common/families/xrp/types";
 import { useTheme } from "@react-navigation/native";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import KeyboardView from "~/components/KeyboardView";
@@ -30,6 +32,8 @@ const options = {
 function XrpEditTag({ route, navigation }: NavigationProps) {
   const { colors } = useTheme();
   const { account } = useAccountScreen(route);
+  invariant(account, "account is required");
+  const bridge = useAccountBridge<XrpTransaction>(account);
   const { t } = useTranslation();
   const transaction = route.params?.transaction;
   const [tag, setTag] = useState<BigNumber | null | undefined>(() => {
@@ -53,15 +57,13 @@ function XrpEditTag({ route, navigation }: NavigationProps) {
   }
 
   const onValidateText = useCallback(() => {
-    if (!account) return;
-    const bridge = getAccountBridge(account);
     popToScreen(navigation, ScreenName.SendSummary, {
       accountId: account.id,
       transaction: bridge.updateTransaction(transaction, {
         tag: tag && tag.toNumber(),
       }),
     });
-  }, [navigation, account, tag, transaction]);
+  }, [navigation, account, bridge, tag, transaction]);
   return (
     <SafeAreaView
       style={{

--- a/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
+++ b/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
@@ -26,6 +26,7 @@ import {
 } from "@ledgerhq/live-common/errors/transactionBroadcastErrors";
 import { formatTransaction } from "@ledgerhq/live-common/transaction/index";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { execAndWaitAtLeast } from "@ledgerhq/live-common/promise";
 import { useBroadcast } from "@ledgerhq/live-common/hooks/useBroadcast";
 import { broadcastLogger } from "~/datadog";
@@ -94,9 +95,10 @@ export const useSignWithDevice = ({
   const [signed, setSigned] = useState(false);
   const subscription = useRef<null | Subscription>(null);
   const mevProtected = useSelector(mevProtectionSelector);
+  const bridge = useAccountBridge(account, parentAccount);
   const signWithDevice = useCallback(() => {
     const { deviceId, transaction } = route.params || {};
-    const bridge = getAccountBridge(account, parentAccount);
+    if (!transaction || !deviceId) return;
     const mainAccount = getMainAccount(account, parentAccount);
 
     navigation.setOptions({
@@ -106,14 +108,13 @@ export const useSignWithDevice = ({
     log("transaction-summary", `→ FROM ${formatAccount(mainAccount, "basic")}`);
     log(
       "transaction-summary",
-      `✔️ transaction ${transaction && formatTransaction(transaction, mainAccount)}`,
+      `✔️ transaction ${formatTransaction(transaction, mainAccount)}`,
     );
     subscription.current = bridge
       .signOperation({
         account: mainAccount,
         transaction,
-        // FIXME: deviceId could be undefined apparently
-        deviceId: deviceId!,
+        deviceId,
       })
       .pipe(
         // FIXME later we will need to treat more events
@@ -198,6 +199,7 @@ export const useSignWithDevice = ({
   }, [
     context,
     account,
+    bridge,
     navigation,
     parentAccount,
     updateAccountWithUpdater,
@@ -232,7 +234,7 @@ export const broadcastSignedTx = async (
 ): Promise<Operation> => {
   invariant(account, "account not present");
   const mainAccount = getMainAccount(account, parentAccount);
-  const bridge = getAccountBridge(account, parentAccount);
+  const bridge = await getAccountBridge(account, parentAccount);
 
   if (getEnv("DISABLE_TRANSACTION_BROADCAST")) {
     return Promise.resolve(signedOperation.operation);

--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
@@ -7,7 +7,7 @@ import { isAccountEmpty } from "@ledgerhq/live-common/account/index";
 import uniq from "lodash/uniq";
 import type { Account } from "@ledgerhq/types-live";
 import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { getCurrencyBridge } from "@ledgerhq/live-common/bridge/index";
+import { useCurrencyBridge } from "@ledgerhq/live-common/bridge/useCurrencyBridge";
 import { isCryptoCurrency, isTokenCurrency } from "@ledgerhq/live-common/currencies/index";
 import logger from "~/logger";
 import { NavigatorName, ScreenName } from "~/const";
@@ -77,9 +77,9 @@ export default function useScanDeviceAccountsViewModel({
     () => (newAccountSchemes && newAccountSchemes.length > 0 ? newAccountSchemes[0] : undefined),
     [newAccountSchemes],
   );
+  const cryptoCurrency = isTokenCurrency(currency) ? currency.parentCurrency : currency;
+  const currencyBridge = useCurrencyBridge(cryptoCurrency);
   const startSubscription = useCallback(() => {
-    const cryptoCurrency = isTokenCurrency(currency) ? currency.parentCurrency : currency;
-    const bridge = getCurrencyBridge(cryptoCurrency);
     const syncConfig = {
       paginationConfig: {
         operations: 0,
@@ -89,7 +89,7 @@ export default function useScanDeviceAccountsViewModel({
     // will be set to false if an existing account is found
     scanSubscription.current = concat(
       from(prepareCurrency(cryptoCurrency)).pipe(ignoreElements()),
-      bridge.scanAccounts({
+      currencyBridge.scanAccounts({
         currency: cryptoCurrency,
         deviceId,
         syncConfig,
@@ -104,7 +104,7 @@ export default function useScanDeviceAccountsViewModel({
         setError(error);
       },
     });
-  }, [blacklistedTokenIds, currency, deviceId]);
+  }, [blacklistedTokenIds, cryptoCurrency, currencyBridge, deviceId]);
 
   const restartSubscription = useCallback(() => {
     setScanning(true);

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useFeePresetFiatValues.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useFeePresetFiatValues.test.ts
@@ -1,14 +1,14 @@
 import { renderHook, waitFor } from "@testing-library/react-native";
 import BigNumber from "bignumber.js";
 import { useFeePresetFiatValues } from "../useFeePresetFiatValues";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useCalculateCountervalueCallback } from "@ledgerhq/live-countervalues-react";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import type { Account } from "@ledgerhq/types-live";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import type { Currency, Unit } from "@ledgerhq/types-cryptoassets";
 
-jest.mock("@ledgerhq/live-common/bridge/index");
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge");
 jest.mock("@ledgerhq/live-countervalues-react");
 jest.mock("@ledgerhq/live-common/currencies/index");
 
@@ -77,8 +77,8 @@ describe("useFeePresetFiatValues", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest
-      .mocked(getAccountBridge)
-      .mockReturnValue(mockBridge as unknown as ReturnType<typeof getAccountBridge>);
+      .mocked(useAccountBridge)
+      .mockReturnValue(mockBridge as unknown as ReturnType<typeof useAccountBridge>);
     jest
       .mocked(useCalculateCountervalueCallback)
       .mockReturnValue(

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useFeePresetFiatValues.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useFeePresetFiatValues.ts
@@ -1,8 +1,8 @@
 import { useMemo, useRef, useState } from "react";
 import { BigNumber } from "bignumber.js";
-import type { Account, AccountLike } from "@ledgerhq/types-live";
+import type { Account, AccountBridge, AccountLike } from "@ledgerhq/types-live";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { FeePresetOption } from "./useFeePresetOptions";
 import { useCalculateCountervalueCallback } from "@ledgerhq/live-countervalues-react";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
@@ -47,7 +47,7 @@ type Params = Readonly<{
 }>;
 
 async function estimateFiatValuesForPresets(params: {
-  bridge: ReturnType<typeof getAccountBridge>;
+  bridge: AccountBridge<Transaction>;
   mainAccount: Account;
   transaction: Transaction;
   presetIds: readonly string[];
@@ -111,6 +111,7 @@ export function useFeePresetFiatValues({
   enabled,
   shouldEstimateWithBridge,
 }: Params): FeeFiatMap {
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
   const convertCountervalue = useCalculateCountervalueCallback({ to: counterValueCurrency });
   const [fiatByPreset, setFiatByPreset] = useState<FeeFiatMap>({});
 
@@ -178,21 +179,17 @@ export function useFeePresetFiatValues({
     requestIdRef.current += 1;
     const requestId = requestIdRef.current;
 
-    const bridge = getAccountBridge(account, parentAccount ?? undefined);
-
-    queueMicrotask(() => {
-      estimateFiatValuesForPresets({
-        bridge,
-        mainAccount,
-        transaction,
-        presetIds,
-        convertCountervalue,
-        fiatUnit,
-        locale,
-        requestId,
-        requestIdRef,
-        setFiatByPreset,
-      });
+    estimateFiatValuesForPresets({
+      bridge,
+      mainAccount,
+      transaction,
+      presetIds,
+      convertCountervalue,
+      fiatUnit,
+      locale,
+      requestId,
+      requestIdRef,
+      setFiatByPreset,
     });
   }
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendFlowTransaction.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendFlowTransaction.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from "react";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridgeOrNull } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { applyMemoToTransaction } from "@ledgerhq/live-common/bridge/descriptor/send/memo";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
@@ -24,6 +24,8 @@ export function useSendFlowTransaction({
   account,
   parentAccount,
 }: UseSendFlowTransactionParams): UseSendFlowTransactionResult {
+  const bridge = useAccountBridgeOrNull<Transaction>(account, parentAccount);
+
   const {
     transaction,
     setTransaction,
@@ -39,9 +41,8 @@ export function useSendFlowTransaction({
 
   const setRecipient = useCallback(
     (recipient: RecipientData) => {
-      if (!account || !transaction) return;
+      if (!account || !transaction || !bridge) return;
 
-      const bridge = getAccountBridge(account, parentAccount);
       const updates: Partial<Transaction> = { recipient: recipient.address };
 
       if (recipient.memo !== undefined) {
@@ -68,7 +69,7 @@ export function useSendFlowTransaction({
 
       setTransaction(bridge.updateTransaction(transaction, updates));
     },
-    [account, parentAccount, transaction, setTransaction],
+    [account, bridge, transaction, setTransaction],
   );
 
   const state: SendFlowTransactionState = useMemo(

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/03b-VerifyAddress.tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/03b-VerifyAddress.tsx
@@ -105,7 +105,7 @@ export default function ReceiveVerifyAddress({ navigation, route }: Props) {
               map(() => ({})),
               rejectionOp(),
             )
-          : getAccountBridge(mainAccount).receive(mainAccount, {
+          : (await getAccountBridge(mainAccount)).receive(mainAccount, {
               deviceId: device.deviceId,
               verify: true,
             })

--- a/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.tsx
@@ -79,7 +79,7 @@ function SendAmountCoinContent({ navigation, route, account, parentAccount }: Co
         parentAccount,
         transaction: debouncedTransaction,
       })
-      .then(estimate => {
+      .then((estimate: BigNumber) => {
         if (cancelled) return;
         setMaxSpendable(estimate);
       });
@@ -90,7 +90,8 @@ function SendAmountCoinContent({ navigation, route, account, parentAccount }: Co
   }, [account, parentAccount, debouncedTransaction, bridge]);
   const onChange = useCallback(
     (amount: BigNumber) => {
-      if (!amount.isNaN() && transaction) {
+      if (!amount.isNaN()) {
+        if (!account || !transaction) return;
         setTransaction(
           bridge.updateTransaction(transaction, {
             amount,
@@ -98,7 +99,7 @@ function SendAmountCoinContent({ navigation, route, account, parentAccount }: Co
         );
       }
     },
-    [setTransaction, bridge, transaction],
+    [setTransaction, bridge, account, transaction],
   );
   const toggleUseAllAmount = useCallback(() => {
     if (!transaction) return;

--- a/apps/ledger-live-mobile/src/screens/SendFunds/ScanRecipient.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/ScanRecipient.tsx
@@ -1,7 +1,8 @@
 import React, { memo, useCallback, useEffect } from "react";
 import Config from "react-native-config";
 import { decodeURIScheme } from "@ledgerhq/live-common/currencies/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridgeOrNull } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import { ScreenName, NavigatorName } from "~/const";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 import Scanner from "~/components/Scanner";
@@ -12,13 +13,14 @@ type NavigationProps = StackNavigatorProps<BaseNavigatorStackParamList, ScreenNa
 
 const ScanRecipient = ({ route, navigation }: NavigationProps) => {
   const { account, parentAccount } = useAccountScreen(route);
+  const bridge = useAccountBridgeOrNull<Transaction>(account ?? null, parentAccount);
 
   const onResult = useCallback(
     (result: string) => {
-      if (!account) return;
-      const bridge = getAccountBridge(account, parentAccount);
+      if (!account || !bridge) return;
       const { amount, address, currency, ...rest } = decodeURIScheme(result);
       const transaction = route.params?.transaction;
+      if (!transaction) return;
       const patch: Record<string, unknown> = {};
       patch.recipient = address;
 
@@ -45,7 +47,7 @@ const ScanRecipient = ({ route, navigation }: NavigationProps) => {
         },
       });
     },
-    [account, navigation, parentAccount, route.params],
+    [account, bridge, navigation, parentAccount, route.params],
   );
 
   useEffect(() => {

--- a/apps/ledger-live-mobile/src/screens/VerifyAccount/VerifyAddress.ts
+++ b/apps/ledger-live-mobile/src/screens/VerifyAccount/VerifyAddress.ts
@@ -3,7 +3,7 @@ import { useTranslation } from "~/context/Locale";
 import { useTheme } from "styled-components/native";
 import type { Account } from "@ledgerhq/types-live";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
 import { renderVerifyAddress } from "~/components/DeviceAction/rendering";
 
@@ -18,10 +18,11 @@ function VerifyAddress({
 }) {
   const { theme } = useTheme();
   const { t } = useTranslation();
+  const bridge = useAccountBridge(account);
   useEffect(() => {
     if (!device) return;
 
-    const sub = getAccountBridge(account)
+    const sub = bridge
       .receive(account, {
         deviceId: device.deviceId,
         verify: true,
@@ -30,15 +31,15 @@ function VerifyAddress({
         complete() {
           onResult(true);
         },
-        error(err) {
-          onResult(false, err as Error);
+        error(err: Error) {
+          onResult(false, err);
         },
       });
 
     return () => {
       sub.unsubscribe();
     };
-  }, [account, device, onResult]);
+  }, [account, bridge, device, onResult]);
 
   if (!device) return null;
 

--- a/libs/ledger-live-common/src/bridge/useAccountBridge.ts
+++ b/libs/ledger-live-common/src/bridge/useAccountBridge.ts
@@ -26,3 +26,12 @@ export function useAccountBridge<T extends TransactionCommon>(
   );
   return use(promise);
 }
+
+// Null-safe variant: returns null when account is null.
+export function useAccountBridgeOrNull<T extends TransactionCommon>(
+  account: AccountLike | null,
+  parentAccount?: Account | null,
+): AccountBridge<T> | null {
+  if (!account) return null;
+  return getAccountBridge(account, parentAccount) as AccountBridge<T>;
+}


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** `useFeePresetFiatValues` test updated to mock `useAccountBridge`.
- [ ] **Impact of the changes:** Pure forward-compatibility refactor, no user-facing change.

### 📝 Description

Prepares all mobile `getAccountBridge`/`getCurrencyBridge` call sites (hooks, screens, families) for when bridges become async.

Hooks and observable contexts use `useAccountBridge` or fold bridge resolution into the RxJS pipeline:
```diff
- queueMicrotask(async () => {
-   const bridge = await getAccountBridge(account, parentAccount);
-   estimateFiatValuesForPresets({ bridge, ... });
- });
+ const bridge = useAccountBridge(account, parentAccount);
+ estimateFiatValuesForPresets({ bridge, ... });
```

```diff
- async () => {
-   const bridge = await getCurrencyBridge(currency);
-   sub = bridge.scanAccounts(...).subscribe(...);
- }
+ from(Promise.resolve(getCurrencyBridge(currency))).pipe(
+   mergeMap(bridge => bridge.scanAccounts(...))
+ ).subscribe(...)
```

Family edit screens and fee selectors use the simpler `async handler + await` pattern 

```diff
- const onValidate = () => {
-   const bridge = getAccountBridge(account, parentAccount);
+ const onValidate = async () => {
+   const bridge = await getAccountBridge(account, parentAccount);
    navigation.navigate(..., { transaction: bridge.updateTransaction(...) });
  };
```

Supersedes #17047 and #17040.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29176](https://ledgerhq.atlassian.net/browse/LIVE-29176) / #16733
- **ADR link (if any)**: N/A


[LIVE-29176]: https://ledgerhq.atlassian.net/browse/LIVE-29176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ