### PR TITLE
[LWD] test(lwd): fix send confirmation tracking assertion missing currency fields

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Confirmation/hooks/__tests__/useConfirmationViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Confirmation/hooks/__tests__/useConfirmationViewModel.test.tsx
@@ -177,6 +177,8 @@ describe("useConfirmationViewModel", () => {
     expect(trackPage).toHaveBeenCalledWith("Modal send - action rejected", null, {
       flow: "send",
       blockchain: "",
+      currency: "",
+      currency_id: "",
     });
 
     expect(latestVM?.status).toBe("IDLE");


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [ ] **Impact of the changes:**
  - Test-only fix, no runtime impact

### 📝 Description

`getSendFlowTrackingProperties` was updated to include `currency` and `currency_id` fields (in d5e0e0f), but one test assertion in `useConfirmationViewModel` was not updated to match, causing the test to fail.

### ❓ Context

- **JIRA or GitHub link**: N/A