### PR TITLE
fix(dmk): bump device-management-kit to 1.4.0 for react-native compat

### DIFF
--- a/.changeset/tidy-gorillas-admire.md
+++ b/.changeset/tidy-gorillas-admire.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Bump dmk dependency

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ catalogs:
       specifier: 2.0.1
       version: 2.0.1
     '@ledgerhq/device-management-kit':
-      specifier: 1.3.0
-      version: 1.3.0
+      specifier: 1.4.0
+      version: 1.4.0
     '@ledgerhq/device-signer-kit-concordium':
       specifier: 0.3.0
       version: 0.3.0
@@ -1603,7 +1603,7 @@ importers:
         version: link:../../libs/coin-modules/coin-stacks
       '@ledgerhq/context-module':
         specifier: 1.17.1
-        version: 1.17.1(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))
+        version: 1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
         version: 2.0.1(@ledgerhq/lumen-design-core@0.1.12)(@ledgerhq/lumen-ui-rnative@0.1.26(aaef53925dd57879e30bd9df42ba0adb))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
@@ -1615,13 +1615,13 @@ importers:
         version: link:../../libs/device-intent
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.3.0(rxjs@7.8.2)
+        version: 1.4.0(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-ethereum':
         specifier: 'catalog:'
-        version: 1.15.0(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))
+        version: 1.15.0(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
       '@ledgerhq/device-transport-kit-react-native-hid':
         specifier: 'catalog:'
-        version: 1.0.3(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(rxjs@7.8.2)
+        version: 1.0.3(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(rxjs@7.8.2)
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../libs/ledgerjs/packages/devices
@@ -2315,7 +2315,7 @@ importers:
         version: link:../../libs/ledgerjs/packages/cryptoassets
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.3.0(rxjs@7.8.2)
+        version: 1.4.0(rxjs@7.8.2)
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/errors
@@ -6771,7 +6771,7 @@ importers:
         version: link:../client-ids
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.3.0(rxjs@7.8.2)
+        version: 1.4.0(rxjs@7.8.2)
       '@ledgerhq/types-devices':
         specifier: workspace:^
         version: link:../ledgerjs/packages/types-devices
@@ -7359,7 +7359,7 @@ importers:
         version: link:../device-intent
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.3.0(rxjs@7.8.2)
+        version: 1.4.0(rxjs@7.8.2)
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../ledgerjs/packages/devices
@@ -7497,7 +7497,7 @@ importers:
         version: link:../ledgerjs/packages/logs
       '@ledgerhq/speculos-device-controller':
         specifier: 'catalog:'
-        version: 0.2.3(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))
+        version: 0.2.3(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
       '@ledgerhq/speculos-transport':
         specifier: workspace:^
         version: link:../speculos-transport
@@ -8689,7 +8689,7 @@ importers:
     dependencies:
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.3.0
+        version: 1.4.0
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../errors
@@ -10485,10 +10485,10 @@ importers:
     dependencies:
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.3.0(rxjs@7.8.2)
+        version: 1.4.0(rxjs@7.8.2)
       '@ledgerhq/device-transport-kit-web-hid':
         specifier: 'catalog:'
-        version: 1.2.3(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))(rxjs@7.8.2)
+        version: 1.2.3(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))(rxjs@7.8.2)
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../ledgerjs/packages/hw-transport
@@ -10552,10 +10552,10 @@ importers:
     dependencies:
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.3.0(rxjs@7.8.2)
+        version: 1.4.0(rxjs@7.8.2)
       '@ledgerhq/device-transport-kit-react-native-ble':
         specifier: 'catalog:'
-        version: 1.3.2(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))(react-native-ble-plx@3.4.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(react@19.0.0))(rxjs@7.8.2)
+        version: 1.3.2(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))(react-native-ble-plx@3.4.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(react@19.0.0))(rxjs@7.8.2)
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../ledgerjs/packages/devices
@@ -10580,7 +10580,7 @@ importers:
     devDependencies:
       '@ledgerhq/device-transport-kit-react-native-hid':
         specifier: 'catalog:'
-        version: 1.0.3(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(react@19.0.0))(rxjs@7.8.2)
+        version: 1.0.3(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(react@19.0.0))(rxjs@7.8.2)
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -10631,7 +10631,7 @@ importers:
     dependencies:
       '@ledgerhq/context-module':
         specifier: 1.17.1
-        version: 1.17.1(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))
+        version: 1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../ledgerjs/packages/hw-transport
@@ -10659,7 +10659,7 @@ importers:
     devDependencies:
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.3.0(rxjs@7.8.2)
+        version: 1.4.0(rxjs@7.8.2)
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -10704,10 +10704,10 @@ importers:
     dependencies:
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.3.0(rxjs@7.8.2)
+        version: 1.4.0(rxjs@7.8.2)
       '@ledgerhq/device-transport-kit-speculos':
         specifier: 'catalog:'
-        version: 1.2.0(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))(rxjs@7.8.2)
+        version: 1.2.0(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))(rxjs@7.8.2)
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../ledgerjs/packages/hw-transport
@@ -10719,7 +10719,7 @@ importers:
         version: link:../ledgerjs/packages/logs
       '@ledgerhq/speculos-device-controller':
         specifier: 'catalog:'
-        version: 0.2.3(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))
+        version: 0.2.3(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
     devDependencies:
       '@swc/core':
         specifier: 'catalog:'
@@ -10841,13 +10841,13 @@ importers:
         version: link:../coin-modules/coin-aleo
       '@ledgerhq/context-module':
         specifier: 1.17.1
-        version: 1.17.1(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))
+        version: 1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.3.0(rxjs@7.8.2)
+        version: 1.4.0(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-aleo':
         specifier: 0.2.0
-        version: 0.2.0(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))
+        version: 0.2.0(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../ledgerjs/packages/errors
@@ -10985,13 +10985,13 @@ importers:
         version: link:../concordium-core
       '@ledgerhq/context-module':
         specifier: 1.17.1
-        version: 1.17.1(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))
+        version: 1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.3.0(rxjs@7.8.2)
+        version: 1.4.0(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-concordium':
         specifier: 'catalog:'
-        version: 0.3.0(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))
+        version: 0.3.0(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../ledgerjs/packages/errors
@@ -11028,10 +11028,10 @@ importers:
         version: link:../coin-modules/coin-cosmos
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.3.0(rxjs@7.8.2)
+        version: 1.4.0(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-cosmos':
         specifier: 'catalog:'
-        version: 1.0.0(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))
+        version: 1.0.0(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../ledgerjs/packages/errors
@@ -11086,13 +11086,13 @@ importers:
         version: link:../coin-modules/coin-evm
       '@ledgerhq/context-module':
         specifier: 1.17.1
-        version: 1.17.1(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))
+        version: 1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.3.0(rxjs@7.8.2)
+        version: 1.4.0(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-ethereum':
         specifier: 'catalog:'
-        version: 1.15.0(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))
+        version: 1.15.0(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../ledgerjs/packages/errors
@@ -11138,10 +11138,10 @@ importers:
     dependencies:
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.3.0(rxjs@7.8.2)
+        version: 1.4.0(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-hyperliquid':
         specifier: 'catalog:'
-        version: 1.0.2(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))
+        version: 1.0.2(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../ledgerjs/packages/devices
@@ -11187,10 +11187,10 @@ importers:
         version: link:../coin-modules/coin-solana
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.3.0(rxjs@7.8.2)
+        version: 1.4.0(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-solana':
         specifier: 'catalog:'
-        version: 1.8.0(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))(typescript@6.0.2)
+        version: 1.8.0(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))(typescript@6.0.2)
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../ledgerjs/packages/devices
@@ -16925,8 +16925,8 @@ packages:
   '@ledgerhq/cryptoassets-evm-signatures@13.5.2':
     resolution: {integrity: sha512-OjjzuiMMEIYEbXeueJB6mXwlvYhru28b43buAVOeggZ2XmdlT0kBvt7Cjn4bDPqff/glWR7vQdytIr7b77m2EQ==}
 
-  '@ledgerhq/device-management-kit@1.3.0':
-    resolution: {integrity: sha512-3ZBz/KcC/DYn+5OeRxEm/Li/Go8paIQYBPe3URTfEf3Wt3oW4wdETWNlyCX7bQ94qBFzmqlp2YS0Gz2LzF1FlA==}
+  '@ledgerhq/device-management-kit@1.4.0':
+    resolution: {integrity: sha512-CISA5PY79H5lEEbQ21kuDV8RC28xeVWH6UcKA1w41E/baOZEsFuvsQKTThAEwGsyg9/B9jitkaWYYuyi3cKsrQ==}
     peerDependencies:
       rxjs: 7.8.2
 
@@ -36464,7 +36464,7 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@7.0.3:
@@ -45418,9 +45418,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))':
+  '@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.3.0(rxjs@7.8.2)
+      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
       crypto-js: 4.2.0
       ethers: 6.15.0
       inversify: 7.5.1(reflect-metadata@0.2.2)
@@ -45468,7 +45468,7 @@ snapshots:
       '@ledgerhq/live-env': 2.22.0
       axios: 1.7.7
 
-  '@ledgerhq/device-management-kit@1.3.0':
+  '@ledgerhq/device-management-kit@1.4.0':
     dependencies:
       '@noble/hashes': 1.8.0
       '@sentry/minimal': 6.19.7
@@ -45485,7 +45485,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2)':
+  '@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2)':
     dependencies:
       '@noble/hashes': 1.8.0
       '@sentry/minimal': 6.19.7
@@ -45503,40 +45503,40 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/device-signer-kit-aleo@0.2.0(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-aleo@0.2.0(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/context-module': 1.17.1(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))
-      '@ledgerhq/device-management-kit': 1.3.0(rxjs@7.8.2)
-      '@ledgerhq/signer-utils': 1.1.3(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))
+      '@ledgerhq/context-module': 1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
+      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
+      '@ledgerhq/signer-utils': 1.1.3(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
       inversify: 7.5.1(reflect-metadata@0.2.2)
       purify-ts: 2.1.0
       reflect-metadata: 0.2.2
       xstate: 5.19.2
 
-  '@ledgerhq/device-signer-kit-concordium@0.3.0(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-concordium@0.3.0(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/context-module': 1.17.1(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))
-      '@ledgerhq/device-management-kit': 1.3.0(rxjs@7.8.2)
-      '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))
+      '@ledgerhq/context-module': 1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
+      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
+      '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
       inversify: 7.5.1(reflect-metadata@0.2.2)
       purify-ts: 2.1.0
       reflect-metadata: 0.2.2
       xstate: 5.19.2
 
-  '@ledgerhq/device-signer-kit-cosmos@1.0.0(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-cosmos@1.0.0(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.3.0(rxjs@7.8.2)
-      '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))
+      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
+      '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
       inversify: 7.5.1(reflect-metadata@0.2.2)
       purify-ts: 2.1.0
       reflect-metadata: 0.2.2
       xstate: 5.19.2
 
-  '@ledgerhq/device-signer-kit-ethereum@1.15.0(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-ethereum@1.15.0(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/context-module': 1.17.1(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))
-      '@ledgerhq/device-management-kit': 1.3.0(rxjs@7.8.2)
-      '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))
+      '@ledgerhq/context-module': 1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
+      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
+      '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
       ethers: 6.15.0
       inversify: 7.5.1(reflect-metadata@0.2.2)
       purify-ts: 2.1.0
@@ -45547,11 +45547,11 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/device-signer-kit-hyperliquid@1.0.2(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-hyperliquid@1.0.2(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/context-module': 1.17.1(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))
-      '@ledgerhq/device-management-kit': 1.3.0(rxjs@7.8.2)
-      '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))
+      '@ledgerhq/context-module': 1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
+      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
+      '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
       inversify: 7.5.1(reflect-metadata@0.2.2)
       purify-ts: 2.1.0
       reflect-metadata: 0.2.2
@@ -45560,11 +45560,11 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/device-signer-kit-solana@1.8.0(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))(typescript@6.0.2)':
+  '@ledgerhq/device-signer-kit-solana@1.8.0(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))(typescript@6.0.2)':
     dependencies:
-      '@ledgerhq/context-module': 1.17.1(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))
-      '@ledgerhq/device-management-kit': 1.3.0(rxjs@7.8.2)
-      '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))
+      '@ledgerhq/context-module': 1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
+      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
+      '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(typescript@6.0.2))(typescript@6.0.2)
       '@solana/web3.js': 1.98.4(typescript@6.0.2)
       bs58: 6.0.0
@@ -45581,9 +45581,9 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@ledgerhq/device-transport-kit-react-native-ble@1.3.2(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))(react-native-ble-plx@3.4.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(react@19.0.0))(rxjs@7.8.2)':
+  '@ledgerhq/device-transport-kit-react-native-ble@1.3.2(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))(react-native-ble-plx@3.4.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(react@19.0.0))(rxjs@7.8.2)':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.3.0(rxjs@7.8.2)
+      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
       '@sentry/minimal': 6.19.7
       js-base64: 3.7.8
       purify-ts: 2.1.0
@@ -45592,35 +45592,35 @@ snapshots:
       rxjs: 7.8.2
       uuid: 11.0.3
 
-  '@ledgerhq/device-transport-kit-react-native-hid@1.0.3(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(rxjs@7.8.2)':
+  '@ledgerhq/device-transport-kit-react-native-hid@1.0.3(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(rxjs@7.8.2)':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.3.0(rxjs@7.8.2)
+      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
       '@sentry/minimal': 6.19.7
       purify-ts: 2.1.0
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
       rxjs: 7.8.2
       uuid: 11.0.3
 
-  '@ledgerhq/device-transport-kit-react-native-hid@1.0.3(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(react@19.0.0))(rxjs@7.8.2)':
+  '@ledgerhq/device-transport-kit-react-native-hid@1.0.3(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(react@19.0.0))(rxjs@7.8.2)':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.3.0(rxjs@7.8.2)
+      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
       '@sentry/minimal': 6.19.7
       purify-ts: 2.1.0
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(react@19.0.0)
       rxjs: 7.8.2
       uuid: 11.0.3
 
-  '@ledgerhq/device-transport-kit-speculos@1.2.0(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))(rxjs@7.8.2)':
+  '@ledgerhq/device-transport-kit-speculos@1.2.0(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))(rxjs@7.8.2)':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.3.0(rxjs@7.8.2)
+      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
       '@sentry/minimal': 6.19.7
       axios: 1.13.5
       purify-ts: 2.1.0
       rxjs: 7.8.2
 
-  '@ledgerhq/device-transport-kit-web-hid@1.2.3(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))(rxjs@7.8.2)':
+  '@ledgerhq/device-transport-kit-web-hid@1.2.3(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))(rxjs@7.8.2)':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.3.0(rxjs@7.8.2)
+      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
       '@sentry/minimal': 6.19.7
       purify-ts: 2.1.0
       rxjs: 7.8.2
@@ -45836,19 +45836,19 @@ snapshots:
       react: 19.0.0
       tailwind-merge: 2.6.0
 
-  '@ledgerhq/signer-utils@1.1.3(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))':
+  '@ledgerhq/signer-utils@1.1.3(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.3.0(rxjs@7.8.2)
+      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
       semver: 7.7.2
 
-  '@ledgerhq/signer-utils@1.2.0(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))':
+  '@ledgerhq/signer-utils@1.2.0(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.3.0(rxjs@7.8.2)
+      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
       semver: 7.7.2
 
-  '@ledgerhq/speculos-device-controller@0.2.3(@ledgerhq/device-management-kit@1.3.0(rxjs@7.8.2))':
+  '@ledgerhq/speculos-device-controller@0.2.3(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.3.0(rxjs@7.8.2)
+      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
       '@sentry/minimal': 6.19.7
       axios: 1.13.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ catalog:
   "@jest/globals": 30.2.0
   "@ledgerhq/context-module": 1.17.1
   "@ledgerhq/crypto-icons": "2.0.1"
-  "@ledgerhq/device-management-kit": 1.3.0
+  "@ledgerhq/device-management-kit": 1.4.0
   "@ledgerhq/device-signer-kit-concordium": 0.3.0
   "@ledgerhq/device-signer-kit-ethereum": 1.15.0
   "@ledgerhq/device-signer-kit-hyperliquid": 1.0.2


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Dependency bump only — relies on existing test coverage in Desktop and Mobile apps._
- [x] **Impact of the changes:**
  - General regression on hardware device interactions (USB on Desktop, BLE on Mobile)
  - Device connection / disconnection flows
  - Transaction signing flows across coin families
  - App opening / firmware update flows

### 📝 Description

Bumps `@ledgerhq/device-management-kit` from `1.3.0` to `1.4.0` in the workspace catalog.

**Problem**: The previous DMK version had compatibility issues with the network client on React Native, impacting Ledger Live Mobile.

**Solution**: Upgrade to DMK `1.4.0`, which ships the React Native–compatible network client. The bump is centralized via the pnpm workspace catalog, so both `ledger-live-desktop` and `live-mobile` pick up the new version through the lockfile.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30216](https://ledgerhq.atlassian.net/browse/LIVE-30216)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-30216]: https://ledgerhq.atlassian.net/browse/LIVE-30216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ