### PR TITLE
[LWM] feat(mobile): add Market Stats and Price Performance to Asset Detail

### DIFF
--- a/.changeset/bright-market-stats.md
+++ b/.changeset/bright-market-stats.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add Market Stats and Price Performance sections to Asset Detail screen

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8462,6 +8462,29 @@
       "title": "Addresses",
       "addAccount": "Add",
       "empty": "No addresses yet. Tap Add to get started."
+    },
+    "marketStats": {
+      "title": "Market stats",
+      "marketCap": "Market cap",
+      "marketRank": "Market rank",
+      "circulatingSupply": "Circulating supply",
+      "circulatingSupplyTooltip": "The number of coins currently available for trading and circulating in the market.",
+      "maxSupply": "Max supply",
+      "maxSupplyTooltip": "The maximum number of coins that will ever exist for this cryptocurrency.",
+      "tradingVolume": "24h trading volume",
+      "error": "Unable to load market stats"
+    },
+    "pricePerformance": {
+      "title": "Price performance",
+      "allTimeHigh": "All-time high",
+      "allTimeLow": "All-time low",
+      "yearsAgo": "{{count}}y ago",
+      "monthsAgo": "{{count}}m ago",
+      "daysAgo": "{{count}}d ago",
+      "hoursAgo": "{{count}}h ago",
+      "minutesAgo": "{{count}}min ago",
+      "justNow": "just now",
+      "error": "Unable to load price performance"
     }
   },
   "assetSelection": {

--- a/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/__tests__/usePrecomputedAssetListData.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/__tests__/usePrecomputedAssetListData.test.ts
@@ -79,6 +79,21 @@ describe("usePrecomputedAssetListData", () => {
     expect(ethData).toBeDefined();
   });
 
+  it("should always pass 'day' as the range to getCurrencyPortfolio regardless of global time range", () => {
+    const btcAccount = genAccount("btc-range", { currency: getCryptoCurrencyById("bitcoin") });
+
+    const assets: Asset[] = [{ ...createCryptoAsset(bitcoin, 100_000), accounts: [btcAccount] }];
+
+    renderHook(() => usePrecomputedAssetListData(assets));
+
+    expect(mockedGetCurrencyPortfolio).toHaveBeenCalledWith(
+      [btcAccount],
+      "day",
+      mockState,
+      expect.objectContaining({ ticker: "USD" }),
+    );
+  });
+
   it("should preserve stable references when computed data has not changed", () => {
     const assets: Asset[] = [createCryptoAsset(bitcoin, 100_000)];
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
@@ -10,6 +10,7 @@ import { SectionPlaceholder } from "./components/SectionPlaceholder";
 import { BalanceGraph } from "./components/BalanceGraph";
 import { Addresses } from "./components/Addresses";
 import { Footer } from "./components/Footer";
+import { MarketData } from "./components/MarketData";
 import { CTAS_HEIGHT, SECTION_HEIGHT, PLACEHOLDER_COLORS } from "./utils/constants";
 
 type Props = Readonly<{
@@ -38,11 +39,7 @@ export function AssetDetailView({ currency, source, isRefreshing, onRefresh }: P
             height={SECTION_HEIGHT}
           />
           <Addresses currency={currency} />
-          <SectionPlaceholder
-            testID={ASSET_DETAIL_TEST_IDS.marketStats}
-            backgroundColor={PLACEHOLDER_COLORS.marketStats}
-            height={SECTION_HEIGHT}
-          />
+          <MarketData currency={currency} />
           <SectionPlaceholder
             testID={ASSET_DETAIL_TEST_IDS.transactions}
             backgroundColor={PLACEHOLDER_COLORS.transactions}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/__fixtures__/marketCurrencyData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/__fixtures__/marketCurrencyData.ts
@@ -1,0 +1,32 @@
+import { KeysPriceChange } from "@ledgerhq/live-common/market/utils/types";
+
+export const marketCurrencyData = {
+  id: "bitcoin",
+  name: "Bitcoin",
+  ticker: "BTC",
+  price: 50000,
+  marketcap: 1000000000000,
+  marketcapRank: 1,
+  circulatingSupply: 19500000,
+  maxSupply: 21000000,
+  totalVolume: 25000000000,
+  totalSupply: 19500000,
+  high24h: 51000,
+  low24h: 49000,
+  ath: 69000,
+  athDate: new Date("2021-11-10"),
+  atl: 67.81,
+  atlDate: new Date("2013-07-06"),
+  priceChangePercentage: {
+    [KeysPriceChange.hour]: 0.5,
+    [KeysPriceChange.day]: 2.35,
+    [KeysPriceChange.week]: -5.12,
+    [KeysPriceChange.month]: 10,
+    [KeysPriceChange.year]: 150,
+  },
+  marketCapChangePercentage24h: 1.5,
+  sparklineIn7d: undefined,
+  chartData: {},
+  image: "",
+  ledgerIds: [],
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/useBalanceGraphViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/useBalanceGraphViewModel.test.ts
@@ -3,7 +3,6 @@ import { useBalanceGraphViewModel } from "../useBalanceGraphViewModel";
 import { track } from "~/analytics";
 import { useGetCurrencyDataQuery } from "@ledgerhq/live-common/market/state-manager/marketApi";
 import { useOpenReceiveDrawer } from "LLM/features/Receive";
-import { KeysPriceChange } from "@ledgerhq/live-common/market/utils/types";
 import {
   mockBtcCryptoCurrency,
   mockEthCryptoCurrency,
@@ -11,6 +10,7 @@ import {
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import BigNumber from "bignumber.js";
 import type { State } from "~/reducers/types";
+import { marketCurrencyData } from "../../../__fixtures__/marketCurrencyData";
 
 jest.mock("@ledgerhq/live-common/market/state-manager/marketApi", () => ({
   ...jest.requireActual("@ledgerhq/live-common/market/state-manager/marketApi"),
@@ -21,18 +21,6 @@ jest.mock("LLM/features/Receive");
 const mockUseGetCurrencyDataQuery = jest.mocked(useGetCurrencyDataQuery);
 const mockUseOpenReceiveDrawer = jest.mocked(useOpenReceiveDrawer);
 const mockHandleOpenReceiveDrawer = jest.fn();
-
-const marketCurrencyData = {
-  id: "bitcoin",
-  price: 50000,
-  priceChangePercentage: {
-    [KeysPriceChange.hour]: 0.5,
-    [KeysPriceChange.day]: 2.35,
-    [KeysPriceChange.week]: -5.12,
-    [KeysPriceChange.month]: 10.0,
-    [KeysPriceChange.year]: 150.0,
-  },
-};
 
 function withAccounts(accounts: Array<{ currencyId: string; balance: number }>) {
   return {

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
@@ -1,11 +1,8 @@
 import { useCallback, useMemo, useState } from "react";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import type { FormattedValue } from "@ledgerhq/lumen-ui-rnative";
-import { useGetCurrencyDataQuery } from "@ledgerhq/live-common/market/state-manager/marketApi";
-import { REFETCH_TIME_ONE_MINUTE, BASIC_REFETCH } from "@ledgerhq/live-common/market/utils/timers";
 import { useSelector } from "~/context/hooks";
 import { shallowAccountsSelector } from "~/reducers/accounts";
-import { marketParamsSelector } from "~/reducers/market";
 import { track } from "~/analytics";
 import { RANGES } from "LLM/features/Market/utils";
 import { rangeDataTable } from "@ledgerhq/live-common/cg-client/utils/rangeDataTable";
@@ -13,23 +10,14 @@ import { useTranslation, useLocale } from "~/context/Locale";
 import { useOpenReceiveDrawer } from "LLM/features/Receive";
 import { parseCurrencyString } from "../../utils/currencyFormatter";
 import { RANGE_TO_PRICE_CHANGE_KEY, type RangeKey } from "../../utils/rangeMapping";
+import { useAssetMarketData } from "../../hooks/useAssetMarketData";
 
 export function useBalanceGraphViewModel(currency: CryptoCurrency | undefined) {
   const { t } = useTranslation();
   const { locale } = useLocale();
-
-  const marketParams = useSelector(marketParamsSelector);
-  const { counterCurrency = "usd" } = marketParams;
+  const { marketCurrency, counterCurrency, isLoading } = useAssetMarketData(currency);
 
   const [range, setRange] = useState<RangeKey>("24h");
-
-  const { data: marketCurrency, isFetching: isLoading } = useGetCurrencyDataQuery(
-    { id: currency?.id ?? "", counterCurrency },
-    {
-      pollingInterval: REFETCH_TIME_ONE_MINUTE * BASIC_REFETCH,
-      skip: !currency?.id,
-    },
-  );
 
   const ranges = useMemo(
     () =>

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketData/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketData/index.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { MarketStats } from "../MarketStats";
+import { PricePerformance } from "../PricePerformance";
+
+type Props = Readonly<{
+  currency: CryptoCurrency | undefined;
+}>;
+
+export function MarketData({ currency }: Props) {
+  return (
+    <Box lx={containerStyle}>
+      <MarketStats currency={currency} />
+      <PricePerformance currency={currency} />
+    </Box>
+  );
+}
+
+const containerStyle: LumenViewStyle = {
+  gap: "s32",
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/MarketStatsView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/MarketStatsView.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { Box, Text, Tooltip, TooltipTrigger, TooltipContent } from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { Information } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { useTranslation } from "~/context/Locale";
+import { ASSET_DETAIL_TEST_IDS } from "LLM/features/AssetDetail/testIds";
+import { SectionContentState } from "../SectionContentState";
+import { STAT_KEYS } from "./useMarketStatsViewModel";
+
+type StatRow = {
+  key: string;
+  label: string;
+  value: string;
+  tooltip?: { title: string; content: string };
+};
+
+type Props = Readonly<{
+  stats: readonly StatRow[];
+  isLoading: boolean;
+  isError: boolean;
+  hasData: boolean;
+  onTooltipOpen: (statName: string, open: boolean) => void;
+}>;
+
+export function MarketStatsView({ stats, isLoading, isError, hasData, onTooltipOpen }: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <Box testID={ASSET_DETAIL_TEST_IDS.marketStats} lx={containerStyle}>
+      <Text typography="heading5SemiBold" lx={{ color: "base" }}>
+        {t("assetDetail.marketStats.title")}
+      </Text>
+      <SectionContentState
+        isLoading={isLoading}
+        isError={isError}
+        hasData={hasData}
+        errorMessage={t("assetDetail.marketStats.error")}
+        skeletonKeys={STAT_KEYS}
+        listStyle={listStyle}
+        skeletonStyle={skeletonRowStyle}
+      >
+        <Box lx={listStyle}>
+          {stats.map(stat => (
+            <Box key={stat.key} lx={rowStyle}>
+              <Box lx={labelContainerStyle}>
+                <Text typography="body2" lx={{ color: "muted" }}>
+                  {stat.label}
+                </Text>
+                {stat.tooltip && (
+                  <Tooltip onOpenChange={open => onTooltipOpen(stat.key, open)}>
+                    <TooltipTrigger>
+                      <Information size={16} color="muted" />
+                    </TooltipTrigger>
+                    <TooltipContent
+                      title={stat.tooltip.title}
+                      content={
+                        <Text typography="body2" lx={{ color: "muted" }}>
+                          {stat.tooltip.content}
+                        </Text>
+                      }
+                    />
+                  </Tooltip>
+                )}
+              </Box>
+              <Text typography="body2SemiBold" lx={{ color: "base" }}>
+                {stat.value}
+              </Text>
+            </Box>
+          ))}
+        </Box>
+      </SectionContentState>
+    </Box>
+  );
+}
+
+const containerStyle: LumenViewStyle = {
+  gap: "s16",
+};
+
+const listStyle: LumenViewStyle = {
+  gap: "s12",
+};
+
+const rowStyle: LumenViewStyle = {
+  flexDirection: "row",
+  justifyContent: "space-between",
+  alignItems: "center",
+};
+
+const labelContainerStyle: LumenViewStyle = {
+  flexDirection: "row",
+  alignItems: "center",
+  gap: "s4",
+};
+
+const skeletonRowStyle: LumenViewStyle = {
+  height: "s24",
+  backgroundColor: "surface",
+  borderRadius: "sm",
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/__tests__/useMarketStatsViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/__tests__/useMarketStatsViewModel.test.ts
@@ -1,0 +1,125 @@
+import { renderHook } from "@tests/test-renderer";
+import { useMarketStatsViewModel } from "../useMarketStatsViewModel";
+import { track } from "~/analytics";
+import { useAssetMarketData } from "../../../hooks/useAssetMarketData";
+import { mockBtcCryptoCurrency } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
+import { marketCurrencyData } from "../../../__fixtures__/marketCurrencyData";
+
+jest.mock("../../../hooks/useAssetMarketData");
+
+const mockUseAssetMarketData = jest.mocked(useAssetMarketData);
+
+function mockMarketData(overrides?: Partial<ReturnType<typeof useAssetMarketData>>) {
+  mockUseAssetMarketData.mockReturnValue({
+    marketCurrency: marketCurrencyData as any,
+    counterCurrency: "usd",
+    isLoading: false,
+    isError: false,
+    ...overrides,
+  });
+}
+
+describe("useMarketStatsViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockMarketData();
+  });
+
+  describe("stats", () => {
+    it("returns 5 stat rows with correct labels", () => {
+      const { result } = renderHook(() => useMarketStatsViewModel(mockBtcCryptoCurrency));
+
+      expect(result.current.stats).toHaveLength(5);
+      expect(result.current.stats[0].label).toMatch(/market cap/i);
+      expect(result.current.stats[1].label).toMatch(/market rank/i);
+      expect(result.current.stats[2].label).toMatch(/circulating supply/i);
+      expect(result.current.stats[3].label).toMatch(/max supply/i);
+      expect(result.current.stats[4].label).toMatch(/trading volume/i);
+    });
+
+    it("formats market rank with # prefix", () => {
+      const { result } = renderHook(() => useMarketStatsViewModel(mockBtcCryptoCurrency));
+
+      const rankStat = result.current.stats.find(s => s.key === "market_rank");
+      expect(rankStat?.value).toBe("#1");
+    });
+
+    it("provides tooltip only for circulating supply and max supply", () => {
+      const { result } = renderHook(() => useMarketStatsViewModel(mockBtcCryptoCurrency));
+
+      const withTooltip = result.current.stats.filter(s => s.tooltip);
+      expect(withTooltip).toHaveLength(2);
+      expect(withTooltip.map(s => s.key)).toEqual(["circulating_supply", "max_supply"]);
+    });
+
+    it("returns an empty array when no market data", () => {
+      mockMarketData({ marketCurrency: undefined });
+
+      const { result } = renderHook(() => useMarketStatsViewModel(mockBtcCryptoCurrency));
+
+      expect(result.current.stats).toEqual([]);
+    });
+
+    it("returns '-' for missing values", () => {
+      mockMarketData({
+        marketCurrency: { ...marketCurrencyData, marketcap: undefined, maxSupply: 0 } as any,
+      });
+
+      const { result } = renderHook(() => useMarketStatsViewModel(mockBtcCryptoCurrency));
+
+      expect(result.current.stats.find(s => s.key === "market_cap")?.value).toBe("-");
+      expect(result.current.stats.find(s => s.key === "max_supply")?.value).toBe("-");
+    });
+  });
+
+  describe("loading state", () => {
+    it("reflects isFetching from the query", () => {
+      mockMarketData({ marketCurrency: undefined, isLoading: true });
+
+      const { result } = renderHook(() => useMarketStatsViewModel(mockBtcCryptoCurrency));
+
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.hasData).toBe(false);
+    });
+  });
+
+  describe("error state", () => {
+    it("reflects isError from the query", () => {
+      mockMarketData({ marketCurrency: undefined, isError: true });
+
+      const { result } = renderHook(() => useMarketStatsViewModel(mockBtcCryptoCurrency));
+
+      expect(result.current.isError).toBe(true);
+    });
+  });
+
+  describe("onTooltipOpen", () => {
+    it("tracks info_bubble_pressed when tooltip opens", () => {
+      const { result } = renderHook(() => useMarketStatsViewModel(mockBtcCryptoCurrency));
+
+      result.current.onTooltipOpen("circulating_supply", true);
+
+      expect(track).toHaveBeenCalledWith("info_bubble_pressed", {
+        currency: "bitcoin",
+        stat_name: "circulating_supply",
+        page: "Asset Detail",
+      });
+    });
+
+    it("does not track when tooltip closes", () => {
+      const { result } = renderHook(() => useMarketStatsViewModel(mockBtcCryptoCurrency));
+
+      result.current.onTooltipOpen("circulating_supply", false);
+
+      expect(track).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("skip query", () => {
+    it("passes undefined currency to useAssetMarketData", () => {
+      renderHook(() => useMarketStatsViewModel(undefined));
+
+      expect(mockUseAssetMarketData).toHaveBeenCalledWith(undefined);
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/index.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { useMarketStatsViewModel } from "./useMarketStatsViewModel";
+import { MarketStatsView } from "./MarketStatsView";
+
+type Props = Readonly<{
+  currency: CryptoCurrency | undefined;
+}>;
+
+export function MarketStats({ currency }: Props) {
+  const viewModel = useMarketStatsViewModel(currency);
+  return <MarketStatsView {...viewModel} />;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/useMarketStatsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/useMarketStatsViewModel.ts
@@ -1,0 +1,126 @@
+import { useCallback, useMemo } from "react";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { useTranslation, useLocale } from "~/context/Locale";
+import { track } from "~/analytics";
+import { counterValueFormatter } from "LLM/features/Market/utils";
+import { useAssetMarketData } from "../../hooks/useAssetMarketData";
+
+export const STAT_KEYS = [
+  "market_cap",
+  "market_rank",
+  "circulating_supply",
+  "max_supply",
+  "trading_volume",
+] as const;
+
+type StatRow = {
+  key: string;
+  label: string;
+  value: string;
+  tooltip?: { title: string; content: string };
+};
+
+export function useMarketStatsViewModel(currency: CryptoCurrency | undefined) {
+  const { t } = useTranslation();
+  const { locale } = useLocale();
+  const { marketCurrency, counterCurrency, isLoading, isError } = useAssetMarketData(currency);
+
+  const stats: StatRow[] = useMemo(() => {
+    if (!marketCurrency) return [];
+
+    const { marketcap, marketcapRank, circulatingSupply, maxSupply, totalVolume, ticker } =
+      marketCurrency;
+
+    return [
+      {
+        key: "market_cap",
+        label: t("assetDetail.marketStats.marketCap"),
+        value:
+          marketcap !== undefined && marketcap !== null
+            ? counterValueFormatter({
+                currency: counterCurrency,
+                value: marketcap,
+                shorten: true,
+                locale,
+                t,
+              })
+            : "-",
+      },
+      {
+        key: "market_rank",
+        label: t("assetDetail.marketStats.marketRank"),
+        value: marketcapRank ? `#${marketcapRank}` : "-",
+      },
+      {
+        key: "circulating_supply",
+        label: t("assetDetail.marketStats.circulatingSupply"),
+        value: circulatingSupply
+          ? counterValueFormatter({
+              value: circulatingSupply,
+              shorten: true,
+              locale,
+              t,
+              ticker,
+            })
+          : "-",
+        tooltip: {
+          title: t("assetDetail.marketStats.circulatingSupply"),
+          content: t("assetDetail.marketStats.circulatingSupplyTooltip"),
+        },
+      },
+      {
+        key: "max_supply",
+        label: t("assetDetail.marketStats.maxSupply"),
+        value: maxSupply
+          ? counterValueFormatter({
+              value: maxSupply,
+              shorten: true,
+              locale,
+              t,
+              ticker,
+            })
+          : "-",
+        tooltip: {
+          title: t("assetDetail.marketStats.maxSupply"),
+          content: t("assetDetail.marketStats.maxSupplyTooltip"),
+        },
+      },
+      {
+        key: "trading_volume",
+        label: t("assetDetail.marketStats.tradingVolume"),
+        value: totalVolume
+          ? counterValueFormatter({
+              currency: counterCurrency,
+              value: totalVolume,
+              shorten: true,
+              locale,
+              t,
+            })
+          : "-",
+      },
+    ];
+  }, [marketCurrency, counterCurrency, locale, t]);
+
+  const onTooltipOpen = useCallback(
+    (statName: string, open: boolean) => {
+      if (open) {
+        track("info_bubble_pressed", {
+          currency: currency?.id,
+          stat_name: statName,
+          page: "Asset Detail",
+        });
+      }
+    },
+    [currency?.id],
+  );
+
+  return {
+    stats,
+    isLoading,
+    isError,
+    hasData: !!marketCurrency,
+    onTooltipOpen,
+  };
+}
+
+export type MarketStatsViewModelResult = ReturnType<typeof useMarketStatsViewModel>;

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/PricePerformanceView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/PricePerformanceView.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { useTranslation } from "~/context/Locale";
+import { ASSET_DETAIL_TEST_IDS } from "LLM/features/AssetDetail/testIds";
+import { SectionContentState } from "../SectionContentState";
+import { RECORD_KEYS } from "./usePricePerformanceViewModel";
+
+type PriceRecord = {
+  id: string;
+  label: string;
+  value: string;
+  date: string;
+  relativeTime: string;
+  changePercentage: string;
+};
+
+type Props = Readonly<{
+  records: readonly PriceRecord[];
+  isLoading: boolean;
+  isError: boolean;
+  hasData: boolean;
+}>;
+
+export function PricePerformanceView({ records, isLoading, isError, hasData }: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <Box testID={ASSET_DETAIL_TEST_IDS.pricePerformance} lx={containerStyle}>
+      <Text typography="heading5SemiBold" lx={{ color: "base" }}>
+        {t("assetDetail.pricePerformance.title")}
+      </Text>
+      <SectionContentState
+        isLoading={isLoading}
+        isError={isError}
+        hasData={hasData && records.length > 0}
+        errorMessage={t("assetDetail.pricePerformance.error")}
+        skeletonKeys={RECORD_KEYS}
+        listStyle={listStyle}
+        skeletonStyle={skeletonRowStyle}
+      >
+        <Box lx={listStyle}>
+          {records.map(record => (
+            <Box key={record.id} lx={recordStyle}>
+              <Box lx={recordLeftStyle}>
+                <Text typography="body2" lx={{ color: "muted" }}>
+                  {record.label}
+                </Text>
+                <Text typography="body3" lx={{ color: "muted" }}>
+                  {record.date} ({record.relativeTime})
+                </Text>
+              </Box>
+              <Box lx={recordRightStyle}>
+                <Text typography="body2SemiBold" lx={{ color: "base" }}>
+                  {record.value}
+                </Text>
+                <Text typography="body3" lx={{ color: "muted" }}>
+                  {record.changePercentage}
+                </Text>
+              </Box>
+            </Box>
+          ))}
+        </Box>
+      </SectionContentState>
+    </Box>
+  );
+}
+
+const containerStyle: LumenViewStyle = {
+  gap: "s16",
+};
+
+const listStyle: LumenViewStyle = {
+  gap: "s16",
+};
+
+const recordStyle: LumenViewStyle = {
+  flexDirection: "row",
+  justifyContent: "space-between",
+  alignItems: "flex-start",
+};
+
+const recordLeftStyle: LumenViewStyle = {
+  gap: "s2",
+};
+
+const recordRightStyle: LumenViewStyle = {
+  alignItems: "flex-end",
+  gap: "s2",
+};
+
+const skeletonRowStyle: LumenViewStyle = {
+  height: "s40",
+  backgroundColor: "surface",
+  borderRadius: "sm",
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/__tests__/usePricePerformanceViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/__tests__/usePricePerformanceViewModel.test.ts
@@ -1,0 +1,101 @@
+import { renderHook } from "@tests/test-renderer";
+import { usePricePerformanceViewModel, getRelativeTime } from "../usePricePerformanceViewModel";
+import { useAssetMarketData } from "../../../hooks/useAssetMarketData";
+import { mockBtcCryptoCurrency } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
+import { marketCurrencyData } from "../../../__fixtures__/marketCurrencyData";
+
+jest.mock("../../../hooks/useAssetMarketData");
+
+const mockUseAssetMarketData = jest.mocked(useAssetMarketData);
+
+function mockMarketData(overrides?: Partial<ReturnType<typeof useAssetMarketData>>) {
+  mockUseAssetMarketData.mockReturnValue({
+    marketCurrency: marketCurrencyData as any,
+    counterCurrency: "usd",
+    isLoading: false,
+    isError: false,
+    ...overrides,
+  });
+}
+
+describe("usePricePerformanceViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockMarketData();
+  });
+
+  describe("records", () => {
+    it("returns ATH and ATL records with correct labels", () => {
+      const { result } = renderHook(() => usePricePerformanceViewModel(mockBtcCryptoCurrency));
+
+      expect(result.current.records).toHaveLength(2);
+      expect(result.current.records[0].label).toMatch(/all.time high/i);
+      expect(result.current.records[1].label).toMatch(/all.time low/i);
+    });
+
+    it("computes negative ATH change and positive ATL change", () => {
+      const { result } = renderHook(() => usePricePerformanceViewModel(mockBtcCryptoCurrency));
+
+      expect(result.current.records[0].changePercentage).toMatch(/^-/);
+      expect(result.current.records[1].changePercentage).toMatch(/^\+/);
+    });
+
+    it("returns an empty array when no market data", () => {
+      mockMarketData({ marketCurrency: undefined });
+
+      const { result } = renderHook(() => usePricePerformanceViewModel(mockBtcCryptoCurrency));
+
+      expect(result.current.records).toEqual([]);
+    });
+  });
+
+  describe("loading state", () => {
+    it("reflects isFetching from the query", () => {
+      mockMarketData({ marketCurrency: undefined, isLoading: true });
+
+      const { result } = renderHook(() => usePricePerformanceViewModel(mockBtcCryptoCurrency));
+
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.hasData).toBe(false);
+    });
+  });
+
+  describe("error state", () => {
+    it("reflects isError from the query", () => {
+      mockMarketData({ marketCurrency: undefined, isError: true });
+
+      const { result } = renderHook(() => usePricePerformanceViewModel(mockBtcCryptoCurrency));
+
+      expect(result.current.isError).toBe(true);
+    });
+  });
+
+  describe("skip query", () => {
+    it("passes undefined currency to useAssetMarketData", () => {
+      renderHook(() => usePricePerformanceViewModel(undefined));
+
+      expect(mockUseAssetMarketData).toHaveBeenCalledWith(undefined);
+    });
+  });
+});
+
+describe("getRelativeTime", () => {
+  const t = (key: string, opts?: Record<string, unknown>) =>
+    opts?.count != null ? `${key}:${opts.count}` : key;
+  const now = new Date("2026-05-05T12:00:00");
+
+  it.each([
+    { date: "2021-05-05", expected: "assetDetail.pricePerformance.yearsAgo:5" },
+    { date: "2026-02-05", expected: /monthsAgo:/ },
+    { date: "2026-05-02", expected: /daysAgo:/ },
+    { date: "2026-05-05T12:00:00", expected: "assetDetail.pricePerformance.justNow" },
+  ])("returns correct label for date=$date", ({ date, expected }) => {
+    const result = getRelativeTime(new Date(date), now, t);
+
+    if (expected instanceof RegExp) {
+      expect(result).toMatch(expected);
+    } else {
+      expect(result).toBe(expected);
+    }
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/index.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { usePricePerformanceViewModel } from "./usePricePerformanceViewModel";
+import { PricePerformanceView } from "./PricePerformanceView";
+
+type Props = Readonly<{
+  currency: CryptoCurrency | undefined;
+}>;
+
+export function PricePerformance({ currency }: Props) {
+  const viewModel = usePricePerformanceViewModel(currency);
+  return <PricePerformanceView {...viewModel} />;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/usePricePerformanceViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/usePricePerformanceViewModel.ts
@@ -1,0 +1,115 @@
+import { useMemo } from "react";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { useTranslation, useLocale } from "~/context/Locale";
+import { counterValueFormatter } from "LLM/features/Market/utils";
+import { useAssetMarketData } from "../../hooks/useAssetMarketData";
+
+export const RECORD_KEYS = ["ath", "atl"] as const;
+
+type PriceRecord = {
+  id: string;
+  label: string;
+  value: string;
+  date: string;
+  relativeTime: string;
+  changePercentage: string;
+};
+
+type TFunc = (key: string, options?: Record<string, unknown>) => string;
+
+export function getRelativeTime(date: Date, now: Date, t: TFunc): string {
+  const diffMs = now.getTime() - date.getTime();
+  const diffMinutes = Math.floor(diffMs / (1000 * 60));
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  const diffMonths = Math.floor(diffDays / 30);
+  const diffYears = Math.floor(diffDays / 365);
+
+  if (diffYears > 0) return t("assetDetail.pricePerformance.yearsAgo", { count: diffYears });
+  if (diffMonths > 0) return t("assetDetail.pricePerformance.monthsAgo", { count: diffMonths });
+  if (diffDays > 0) return t("assetDetail.pricePerformance.daysAgo", { count: diffDays });
+  if (diffHours > 0) return t("assetDetail.pricePerformance.hoursAgo", { count: diffHours });
+  if (diffMinutes > 0) return t("assetDetail.pricePerformance.minutesAgo", { count: diffMinutes });
+  return t("assetDetail.pricePerformance.justNow");
+}
+
+function computeChangePercentage(currentPrice: number, referencePrice: number): number {
+  if (referencePrice === 0) return 0;
+  return ((currentPrice - referencePrice) / referencePrice) * 100;
+}
+
+function formatPercentage(value: number): string {
+  const sign = value >= 0 ? "+" : "";
+  return `${sign}${value.toFixed(2)}%`;
+}
+
+export function usePricePerformanceViewModel(currency: CryptoCurrency | undefined) {
+  const { t } = useTranslation();
+  const { locale } = useLocale();
+  const { marketCurrency, counterCurrency, isLoading, isError } = useAssetMarketData(currency);
+
+  const dateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        month: "short",
+        day: "2-digit",
+        year: "numeric",
+      }),
+    [locale],
+  );
+
+  const records: PriceRecord[] = useMemo(() => {
+    if (!marketCurrency) return [];
+
+    const now = new Date();
+    const { ath, athDate, atl, atlDate, price } = marketCurrency;
+    const result: PriceRecord[] = [];
+
+    if (ath != null && athDate) {
+      const athDateObj = athDate instanceof Date ? athDate : new Date(athDate);
+      const athChange = computeChangePercentage(price, ath);
+      result.push({
+        id: "ath",
+        label: t("assetDetail.pricePerformance.allTimeHigh"),
+        value: counterValueFormatter({
+          currency: counterCurrency,
+          value: ath,
+          locale,
+          t,
+        }),
+        date: dateFormatter.format(athDateObj),
+        relativeTime: getRelativeTime(athDateObj, now, t),
+        changePercentage: formatPercentage(athChange),
+      });
+    }
+
+    if (atl != null && atlDate) {
+      const atlDateObj = atlDate instanceof Date ? atlDate : new Date(atlDate);
+      const atlChange = computeChangePercentage(price, atl);
+      result.push({
+        id: "atl",
+        label: t("assetDetail.pricePerformance.allTimeLow"),
+        value: counterValueFormatter({
+          currency: counterCurrency,
+          value: atl,
+          locale,
+          t,
+        }),
+        date: dateFormatter.format(atlDateObj),
+        relativeTime: getRelativeTime(atlDateObj, now, t),
+        changePercentage: formatPercentage(atlChange),
+      });
+    }
+
+    return result;
+  }, [marketCurrency, counterCurrency, locale, t, dateFormatter]);
+
+  return {
+    records,
+    isLoading,
+    isError,
+    hasData: !!marketCurrency,
+  };
+}
+
+export type PricePerformanceViewModelResult = ReturnType<typeof usePricePerformanceViewModel>;

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/SectionContentState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/SectionContentState.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { Box, Text, Spot } from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { Warning } from "@ledgerhq/lumen-ui-rnative/symbols";
+
+type Props = Readonly<{
+  isLoading: boolean;
+  isError: boolean;
+  hasData: boolean;
+  errorMessage: string;
+  skeletonKeys: readonly string[];
+  listStyle: LumenViewStyle;
+  skeletonStyle: LumenViewStyle;
+  children: React.ReactNode;
+}>;
+
+export function SectionContentState({
+  isLoading,
+  isError,
+  hasData,
+  errorMessage,
+  skeletonKeys,
+  listStyle,
+  skeletonStyle,
+  children,
+}: Props) {
+  if (isLoading && !hasData) {
+    return (
+      <Box lx={listStyle}>
+        {skeletonKeys.map(key => (
+          <Box key={key} lx={skeletonStyle} />
+        ))}
+      </Box>
+    );
+  }
+
+  if (isError && !hasData) {
+    return (
+      <Box lx={errorContainerStyle}>
+        <Spot appearance="icon" icon={Warning} size={40} />
+        <Text
+          typography="body2SemiBold"
+          lx={{ color: "base", textAlign: "center", marginTop: "s8" }}
+        >
+          {errorMessage}
+        </Text>
+      </Box>
+    );
+  }
+
+  if (!hasData) return null;
+
+  return <>{children}</>;
+}
+
+const errorContainerStyle: LumenViewStyle = {
+  alignItems: "center",
+  justifyContent: "center",
+  paddingVertical: "s16",
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/__tests__/useAssetMarketData.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/__tests__/useAssetMarketData.test.ts
@@ -1,0 +1,85 @@
+import { renderHook } from "@tests/test-renderer";
+import { useAssetMarketData } from "../useAssetMarketData";
+import { useGetCurrencyDataQuery } from "@ledgerhq/live-common/market/state-manager/marketApi";
+import { mockBtcCryptoCurrency } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
+import { marketCurrencyData } from "../../__fixtures__/marketCurrencyData";
+
+jest.mock("@ledgerhq/live-common/market/state-manager/marketApi", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/market/state-manager/marketApi"),
+  useGetCurrencyDataQuery: jest.fn(),
+}));
+
+const mockUseGetCurrencyDataQuery = jest.mocked(useGetCurrencyDataQuery);
+
+describe("useAssetMarketData", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseGetCurrencyDataQuery.mockReturnValue({
+      data: marketCurrencyData,
+      isFetching: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useGetCurrencyDataQuery>);
+  });
+
+  describe("data forwarding", () => {
+    it("returns marketCurrency from the query", () => {
+      const { result } = renderHook(() => useAssetMarketData(mockBtcCryptoCurrency));
+
+      expect(result.current.marketCurrency).toBe(marketCurrencyData);
+    });
+
+    it("returns counterCurrency from market params", () => {
+      const { result } = renderHook(() => useAssetMarketData(mockBtcCryptoCurrency));
+
+      expect(result.current.counterCurrency).toBe("USD");
+    });
+  });
+
+  describe("loading state", () => {
+    it("reflects isFetching from the query", () => {
+      mockUseGetCurrencyDataQuery.mockReturnValue({
+        data: undefined,
+        isFetching: true,
+        isError: false,
+      } as unknown as ReturnType<typeof useGetCurrencyDataQuery>);
+
+      const { result } = renderHook(() => useAssetMarketData(mockBtcCryptoCurrency));
+
+      expect(result.current.isLoading).toBe(true);
+    });
+  });
+
+  describe("error state", () => {
+    it("reflects isError from the query", () => {
+      mockUseGetCurrencyDataQuery.mockReturnValue({
+        data: undefined,
+        isFetching: false,
+        isError: true,
+      } as unknown as ReturnType<typeof useGetCurrencyDataQuery>);
+
+      const { result } = renderHook(() => useAssetMarketData(mockBtcCryptoCurrency));
+
+      expect(result.current.isError).toBe(true);
+    });
+  });
+
+  describe("skip query", () => {
+    it("skips the query when currency is undefined", () => {
+      renderHook(() => useAssetMarketData(undefined));
+
+      expect(mockUseGetCurrencyDataQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "" }),
+        expect.objectContaining({ skip: true }),
+      );
+    });
+
+    it("passes the currency id to the query", () => {
+      renderHook(() => useAssetMarketData(mockBtcCryptoCurrency));
+
+      expect(mockUseGetCurrencyDataQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "bitcoin" }),
+        expect.objectContaining({ skip: false }),
+      );
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/useAssetMarketData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/useAssetMarketData.ts
@@ -1,0 +1,25 @@
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { useGetCurrencyDataQuery } from "@ledgerhq/live-common/market/state-manager/marketApi";
+import { REFETCH_TIME_ONE_MINUTE, BASIC_REFETCH } from "@ledgerhq/live-common/market/utils/timers";
+import { useSelector } from "~/context/hooks";
+import { marketParamsSelector } from "~/reducers/market";
+
+export function useAssetMarketData(currency: CryptoCurrency | undefined) {
+  const marketParams = useSelector(marketParamsSelector);
+  const { counterCurrency = "usd" } = marketParams;
+
+  const { data, isFetching, isError } = useGetCurrencyDataQuery(
+    { id: currency?.id ?? "", counterCurrency },
+    {
+      pollingInterval: REFETCH_TIME_ONE_MINUTE * BASIC_REFETCH,
+      skip: !currency?.id,
+    },
+  );
+
+  return {
+    marketCurrency: data,
+    counterCurrency,
+    isLoading: isFetching,
+    isError,
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/testIds.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/testIds.ts
@@ -8,6 +8,7 @@ export const ASSET_DETAIL_TEST_IDS = {
   addresses: "asset-detail-addresses",
   addAccount: "asset-detail-add-account",
   marketStats: "asset-detail-market-stats",
+  pricePerformance: "asset-detail-price-performance",
   transactions: "asset-detail-transactions",
   ctas: "asset-detail-ctas",
 } as const;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Asset Detail screen: Market Stats section (market cap, rank, supplies, volume with tooltips)
  - Asset Detail screen: Price Performance section (ATH/ATL with dates, relative time, percentage change)
  - Error states for both sections (warning card with Lumen Spot component)
  - Loading skeletons for both sections

### 📝 Description

**Problem**: The Asset Detail screen under the `lwmWallet40` feature flag was missing Market Stats and Price Performance sections, showing placeholder blocks instead.

**Solution**: Implemented two new MVVM components:

- **MarketStats** — Displays market cap, rank, circulating supply (with tooltip), max supply (with tooltip), and 24h trading volume. Data is fetched via RTK Query (`useGetCurrencyDataQuery`) and formatted with `counterValueFormatter`.
- **PricePerformance** — Displays all-time high and all-time low with formatted prices, dates, relative time ("5y ago"), and percentage change from current price.

Both components are grouped under a `MarketData` wrapper in `AssetDetailView` for cleaner composition.

**Additional improvements:**
- Extracted a shared `useAssetMarketData` hook to deduplicate RTK Query boilerplate across BalanceGraph, MarketStats, and PricePerformance ViewModels
- Shared test fixture (`__fixtures__/marketCurrencyData.ts`) across all AssetDetail tests
- Stable analytics keys for tooltip tracking (locale-independent)
- Error state with Lumen `Spot` + `Warning` icon, matching the portfolio pattern

<img width="350" height="750" alt="Simulator Screenshot - Test Ios - 2026-05-05 at 11 50 11" src="https://github.com/user-attachments/assets/b564e3ed-c62a-4d3c-8de3-501fd112d6ba" />
<img width="606" height="231" alt="image-45b6475d-f722-49b6-aace-c8ae6f0c6ab1" src="https://github.com/user-attachments/assets/f5b3caf8-5fb8-4f56-a543-de8c75cfb751" />
<img width="612" height="369" alt="image-bd828933-cf86-4de1-ab34-899fe9fdd5ab" src="https://github.com/user-attachments/assets/cc435f23-7c6d-40bc-9380-80622f34515b" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29726](https://ledgerhq.atlassian.net/browse/LIVE-29726)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29726]: https://ledgerhq.atlassian.net/browse/LIVE-29726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ