### PR TITLE
[LWDM] fix(mobile,desktop): sanitise order and pass displayedPosition in content card tracking

### DIFF
--- a/.changeset/fair-rats-give.md
+++ b/.changeset/fair-rats-give.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+fix: update order and displayedPosition property reporting

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -306,11 +306,17 @@ apps/ledger-live-desktop/src/renderer/hooks/useBuyDeviceIntercept.ts            
 apps/ledger-live-desktop/src/renderer/hooks/useBuyDeviceIntercept.test.ts                      @ledgerhq/engagement
 apps/ledger-live-desktop/src/renderer/hooks/useNavigateToMyLedger.ts                           @ledgerhq/engagement
 apps/ledger-live-desktop/src/renderer/hooks/useActionCards.tsx                                 @ledgerhq/engagement
+apps/ledger-live-desktop/src/renderer/hooks/useNotifications.ts                                @ledgerhq/engagement
+apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts                                        @ledgerhq/engagement
+apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/BrazeTools/          @ledgerhq/engagement
 apps/ledger-live-desktop/src/renderer/screens/dashboard/ActionContentCards.tsx                 @ledgerhq/engagement
 apps/ledger-live-desktop/src/renderer/screens/dashboard/components/Banners/hooks/**/useBannersVisibility*.ts @ledgerhq/engagement
 apps/ledger-live-desktop/src/renderer/screens/dashboard/components/Banners/PortfolioBannerContent/ @ledgerhq/engagement
 apps/ledger-live-desktop/src/renderer/components/ContentCards/                                 @ledgerhq/engagement
-apps/ledger-live-desktop/src/reducers/dynamicContent.ts                                        @ledgerhq/engagement
+apps/ledger-live-desktop/src/renderer/reducers/dynamicContent.ts                               @ledgerhq/engagement
+apps/ledger-live-desktop/src/renderer/actions/dynamicContent.ts                                @ledgerhq/engagement
+apps/ledger-live-desktop/src/types/dynamicContent.ts                                           @ledgerhq/engagement
+apps/ledger-live-desktop/src/braze-setup.ts                                                    @ledgerhq/engagement
 apps/ledger-live-desktop/src/mvvm/features/DynamicContent/                                     @ledgerhq/engagement
 apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/                                          @ledgerhq/engagement
 apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/                               @ledgerhq/engagement
@@ -345,7 +351,7 @@ apps/ledger-live-mobile/src/mvvm/features/PostOnboardingHubDrawer/              
 apps/ledger-live-mobile/src/mvvm/features/DynamicContent/                                      @ledgerhq/engagement
 apps/ledger-live-mobile/src/mvvm/features/LandingPages/                                        @ledgerhq/engagement
 apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/                                 @ledgerhq/engagement
-apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/                               @ledgerhq/engagement
+apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/                              @ledgerhq/engagement
 apps/ledger-live-mobile/src/mvvm/features/WalletV4Tour/                                        @ledgerhq/engagement
 apps/ledger-live-mobile/src/mvvm/features/Reborn/                                              @ledgerhq/engagement
 apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/OnboardingWidget/               @ledgerhq/engagement
@@ -354,9 +360,10 @@ apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCarousel
 apps/ledger-live-mobile/src/mvvm/features/Portfolio/hooks/**/useOnboardingWidgetVisibility*.ts @ledgerhq/engagement
 apps/ledger-live-mobile/src/reducers/dynamicContent.ts                                         @ledgerhq/engagement
 apps/ledger-live-mobile/src/reducers/largeMover.ts                                             @ledgerhq/engagement
-apps/ledger-live-mobile/src/screens/Settings/AnalyticsPreferencesSettings/                                     @ledgerhq/engagement
+apps/ledger-live-mobile/src/screens/Settings/AnalyticsPreferencesSettings/                     @ledgerhq/engagement
 
 # Common
+libs/ledger-live-common/src/braze/                                                             @ledgerhq/engagement
 libs/ledger-live-common/src/analyticsConsent/                                                  @ledgerhq/engagement
 libs/ledger-live-common/src/analytics/                                                         @ledgerhq/engagement
 libs/ledger-live-common/src/onboarding/                                                        @ledgerhq/engagement

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/BottomCarouselContentCards/BottomCarouselSlide.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/BottomCarouselContentCards/BottomCarouselSlide.tsx
@@ -54,7 +54,7 @@ function BottomCarouselSlide({
   }
 
   return (
-    <LogContentCardWrapper id={id} location={location}>
+    <LogContentCardWrapper id={id} displayedPosition={index} location={location}>
       <MediaCard
         imageUrl={image ?? ""}
         onClick={hasClickTarget ? handleClick : undefined}

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/LogContentCardWrapper.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/LogContentCardWrapper.tsx
@@ -11,6 +11,7 @@ import { Box } from "@ledgerhq/react-ui";
 import { updateAnonymousUserNotifications } from "~/renderer/actions/settings";
 import { OFFLINE_SEEN_DELAY } from "../utils/constants";
 import { currentRouteNameRef } from "~/renderer/analytics/screenRefs";
+import { sanitizeExtras } from "~/renderer/hooks/useBraze";
 
 interface LogContentCardWrapperProps {
   id: string;
@@ -56,7 +57,7 @@ const LogContentCardWrapper: React.FC<LogContentCardWrapperProps> = ({
             braze.logContentCardImpressions([currentCard]);
             track("contentcard_impression", {
               id: currentCard.id,
-              ...currentCard.extras,
+              ...sanitizeExtras(currentCard.extras),
               ...additionalProps,
               displayedPosition,
             });

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/Slide.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/Slide.tsx
@@ -54,7 +54,7 @@ function Slide({
 
   return (
     <SlideContainer $isWallet40Enabled={isWallet40Enabled}>
-      <LogContentCardWrapper id={id} location={location}>
+      <LogContentCardWrapper id={id} displayedPosition={index} location={location}>
         <Card
           title={title}
           cta={cta}

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/index.tsx
@@ -75,7 +75,7 @@ const PortfolioBrazePlacementSlide = memo(function PortfolioBrazePlacementSlide(
   const imageBackground = lumenImageBackgroundForPortfolio(card);
 
   return (
-    <LogContentCardWrapper id={card.id} location={card.location}>
+    <LogContentCardWrapper id={card.id} displayedPosition={index} location={card.location}>
       <ContentBannerActionCard
         title={card.title}
         description={card.description}

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hooks/usePortfolioCarouselCards.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hooks/usePortfolioCarouselCards.ts
@@ -14,6 +14,7 @@ import {
 import { trackingEnabledSelector } from "~/renderer/reducers/settings";
 import type { PortfolioContentCard } from "~/types/dynamicContent";
 import type { CarouselActions } from "../types";
+import { sanitizeExtras } from "~/renderer/hooks/useBraze";
 
 export type PortfolioCarouselVariant = "top" | "bottom";
 
@@ -55,11 +56,12 @@ export function usePortfolioCarouselCards(
         if (isTrackedUser) {
           braze.logCardDismissal(currentCard);
           track("contentcard_dismissed", {
-            ...currentCard.extras,
+            ...sanitizeExtras(currentCard.extras),
             card: slide.id,
             page: "Portfolio",
             type: "portfolio_carousel",
             location: slide.location,
+            displayedPosition: index,
           });
         } else if (currentCard.id) {
           dispatch(setDismissedContentCards({ id: currentCard.id, timestamp: Date.now() }));
@@ -74,7 +76,8 @@ export function usePortfolioCarouselCards(
     cardId => {
       if (!isTrackedUser) return;
 
-      const slide = portfolioCards.find(card => card.id === cardId);
+      const slideIndex = portfolioCards.findIndex(card => card.id === cardId);
+      const slide = slideIndex >= 0 ? portfolioCards[slideIndex] : undefined;
       if (!slide) return;
       const currentCard = getBrazeCard(cardId);
 
@@ -84,13 +87,14 @@ export function usePortfolioCarouselCards(
       currentCard.url = currentCard.id;
       braze.logContentCardClick(currentCard);
       track("contentcard_clicked", {
-        ...currentCard.extras,
+        ...sanitizeExtras(currentCard.extras),
         contentcard: slide.title,
         link: slide.path || slide.url,
         campaign: cardId,
         page: "Portfolio",
         type: "portfolio_carousel",
         location: slide.location,
+        displayedPosition: slideIndex,
       });
     },
     [portfolioCards, getBrazeCard, isTrackedUser],

--- a/apps/ledger-live-desktop/src/renderer/hooks/useActionCards.tsx
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useActionCards.tsx
@@ -13,6 +13,7 @@ import { track } from "../analytics/segment";
 import { trackingEnabledSelector } from "../reducers/settings";
 import { setDismissedContentCards } from "../actions/settings";
 import { ActionContentCard } from "~/types/dynamicContent";
+import { sanitizeExtras } from "./useBraze";
 
 const useActionCards = () => {
   const dispatch = useDispatch();
@@ -44,7 +45,7 @@ const useActionCards = () => {
 
     if (actionCard && !actionCard.isMock) {
       track("contentcard_dismissed", {
-        ...currentCard?.extras,
+        ...sanitizeExtras(currentCard?.extras),
         contentcard: actionCard.title,
         campaign: actionCard.id,
         page: "Portfolio",
@@ -70,7 +71,7 @@ const useActionCards = () => {
     }
     if (actionCard) {
       track("contentcard_clicked", {
-        ...currentCard?.extras,
+        ...sanitizeExtras(currentCard?.extras),
         contentcard: actionCard.title,
         link: actionCard.link,
         campaign: actionCard.id,

--- a/apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts
@@ -1,6 +1,7 @@
 import * as braze from "@braze/web-sdk";
 import { ClassicCard } from "@braze/web-sdk";
 import { generateAnonymousId } from "@ledgerhq/live-common/braze/anonymousUsers";
+import { parseOrder, sanitizeExtras } from "@ledgerhq/live-common/braze/contentCardExtras";
 import { appendDeeplinkLocationIfDefined } from "@ledgerhq/live-common/deeplinks/index";
 import { getEnv } from "@ledgerhq/live-env";
 import { useCallback, useEffect, useRef } from "react";
@@ -54,10 +55,7 @@ export const compareCards = (a: LedgerContentCard, b: LedgerContentCard) => {
   return (a.order || 0) - (b.order || 0);
 };
 
-const parseOrder = (value: string | undefined): number | undefined => {
-  const parsed = Number.parseInt(value ?? "", 10);
-  return Number.isNaN(parsed) ? undefined : parsed;
-};
+export { parseOrder, sanitizeExtras };
 
 export const mapAsActionContentCard = (card: ClassicCard): ActionContentCard => ({
   created: card.updated ?? null,

--- a/apps/ledger-live-desktop/src/renderer/hooks/useNotifications.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useNotifications.ts
@@ -10,6 +10,7 @@ import {
 } from "~/renderer/reducers/dynamicContent";
 import { track } from "../analytics/segment";
 import { trackingEnabledSelector } from "../reducers/settings";
+import { sanitizeExtras } from "./useBraze";
 
 export function useNotifications() {
   const desktopCards = useSelector(desktopContentCardSelector);
@@ -70,7 +71,7 @@ export function useNotifications() {
         if (isTrackedUser) {
           braze.logContentCardClick(currentCard);
           track("contentcard_clicked", {
-            ...currentCard.extras,
+            ...sanitizeExtras(currentCard.extras),
             contentcard: card.title,
             link: card.path || card.url,
             campaign: card.id,

--- a/apps/ledger-live-mobile/src/contentCards/layouts/carousel/index.tsx
+++ b/apps/ledger-live-mobile/src/contentCards/layouts/carousel/index.tsx
@@ -75,10 +75,16 @@ const Carousel = ContentLayoutBuilder<Props>(
     const isContainerVisibleRef = useRef(false);
     const visibleCardsRef = useRef<string[]>([]);
     const { logImpressionCard } = useDynamicContent();
+    const findDisplayedPosition = useCallback(
+      (id: string) => items.find(i => i.props.metadata.id === id)?.props.metadata.displayedPosition,
+      [items],
+    );
+
     useInViewContext(
       ({ isInView, progressRatio }) => {
         isInViewRef.current = isInView;
-        if (isInView) visibleCardsRef.current.forEach(id => logImpressionCard(id));
+        if (isInView)
+          visibleCardsRef.current.forEach(id => logImpressionCard(id, findDisplayedPosition(id)));
 
         const isNowVisible = progressRatio >= CONTAINER_IMPRESSION_THRESHOLD;
         if (isNowVisible && !isContainerVisibleRef.current) {
@@ -92,7 +98,7 @@ const Carousel = ContentLayoutBuilder<Props>(
         }
         isContainerVisibleRef.current = isNowVisible;
       },
-      [logImpressionCard, items],
+      [logImpressionCard, findDisplayedPosition, items],
       viewRef,
     );
     const handleViewableItemsChanged = useCallback(
@@ -100,9 +106,10 @@ const Carousel = ContentLayoutBuilder<Props>(
         const visibleCards = viewableItems.map(({ item }) => item.props.metadata.id);
         const newlyVisibleCards = visibleCards.filter(id => !visibleCardsRef.current.includes(id));
         visibleCardsRef.current = visibleCards;
-        if (isInViewRef.current) newlyVisibleCards.forEach(id => logImpressionCard(id));
+        if (isInViewRef.current)
+          newlyVisibleCards.forEach(id => logImpressionCard(id, findDisplayedPosition(id)));
       },
-      [logImpressionCard],
+      [logImpressionCard, findDisplayedPosition],
     );
 
     return (

--- a/apps/ledger-live-mobile/src/contentCards/layouts/grid/index.tsx
+++ b/apps/ledger-live-mobile/src/contentCards/layouts/grid/index.tsx
@@ -47,6 +47,7 @@ const Grid = ContentLayoutBuilder<Props>(({ items, styles: _styles = defaultStyl
           <LogContentCardWrapper
             key={item.props.metadata.id}
             id={item.props.metadata.id}
+            displayedPosition={item.props.metadata.displayedPosition}
             location={item.props.location}
           >
             <Flex style={{ width: cardWidth }}>

--- a/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.tsx
@@ -22,6 +22,7 @@ import {
   mapAsMediumSquareContentCard,
   mapAsBigSquareContentCard,
   mapAsHeroContentCard,
+  sanitizeExtras,
 } from "~/dynamicContent/utils";
 import Carousel from "../../contentCards/layouts/carousel";
 import { WidthFactor } from "~/contentCards/layouts/types";
@@ -89,7 +90,7 @@ const Layout = ({ category, cards }: LayoutProps) => {
 
   const onCardClick = async (card: AnyContentCard, displayedPosition?: number) => {
     await trackContentCardEvent("contentcard_clicked", {
-      ...card.extras,
+      ...sanitizeExtras(card.extras),
       page: card.location,
       campaign: card.id,
       contentcard: card.title,
@@ -109,7 +110,7 @@ const Layout = ({ category, cards }: LayoutProps) => {
 
   const onCardDismiss = (card: AnyContentCard, displayedPosition?: number) => {
     trackContentCardEvent("contentcard_dismissed", {
-      ...card.extras,
+      ...sanitizeExtras(card.extras),
       page: card.location,
       campaign: card.id,
       contentcard: card.title,

--- a/apps/ledger-live-mobile/src/dynamicContent/brazeContentCard.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/brazeContentCard.ts
@@ -5,6 +5,7 @@ import { track } from "~/analytics";
 import { setDismissedContentCard } from "~/actions/settings";
 import { trackingEnabledSelector } from "~/reducers/settings";
 import { localMobileCardsSelector, localWalletCardsSelector } from "~/reducers/dynamicContent";
+import { sanitizeExtras } from "~/dynamicContent/utils";
 
 const isLocalCard = (
   cardId: string,
@@ -60,7 +61,7 @@ export const useBrazeContentCard = (mobileCards: Braze.ContentCard[]) => {
 
       if (!card) return;
       track("contentcard_impression", {
-        ...card.extras,
+        ...sanitizeExtras(card.extras),
         page: card.extras.location,
         displayedPosition,
       });

--- a/apps/ledger-live-mobile/src/dynamicContent/utils.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/utils.tsx
@@ -1,4 +1,5 @@
 import { appendDeeplinkLocationIfDefined } from "@ledgerhq/live-common/deeplinks/index";
+import { parseOrder, sanitizeExtras } from "@ledgerhq/live-common/braze/contentCardExtras";
 import { Size } from "~/contentCards/cards/vertical/types";
 import { WidthFactor } from "~/contentCards/layouts/types";
 import {
@@ -19,6 +20,8 @@ import {
   LandingPageStickyCtaContentCard,
   LandingPageUseCase,
 } from "~/dynamicContent/types";
+
+export { parseOrder, sanitizeExtras };
 
 export const getMobileContentCards = (array: BrazeContentCard[]) =>
   array.filter(elem => !elem.extras.platform || elem.extras.platform === "mobile");
@@ -92,7 +95,7 @@ export const mapAsCategoryContentCard = (card: BrazeContentCard): CategoryConten
   location: card.extras.location as ContentCardLocation,
   createdAt: card.created,
   viewed: card.viewed,
-  order: parseInt(card.extras.order) ?? undefined,
+  order: parseOrder(card.extras.order),
   cardsLayout: card.extras.cardsLayout as ContentCardsLayout,
   cardsType: card.extras.cardsType as ContentCardsType,
   type: card.extras.type as ContentCardsType.category,
@@ -118,7 +121,7 @@ export const mapAsWalletContentCard = (card: BrazeContentCard): WalletContentCar
   background: Background[card.extras.background as Background] || Background.purple,
   viewed: card.viewed,
   createdAt: card.created,
-  order: parseInt(card.extras.order) ?? undefined,
+  order: parseOrder(card.extras.order),
   extras: card.extras,
 });
 
@@ -134,7 +137,7 @@ export const mapAsAssetContentCard = (card: BrazeContentCard): AssetContentCard 
   displayOnEveryAssets: Boolean(card.extras.displayOnEveryAssets),
   createdAt: card.created,
   viewed: card.viewed,
-  order: parseInt(card.extras.order) ?? undefined,
+  order: parseOrder(card.extras.order),
   extras: card.extras,
 });
 
@@ -148,7 +151,7 @@ export const mapAsNotificationContentCard = (card: BrazeContentCard): Notificati
   cta: card.extras.cta,
   createdAt: card.created,
   viewed: card.viewed,
-  order: parseInt(card.extras.order) ?? undefined,
+  order: parseOrder(card.extras.order),
   extras: card.extras,
 });
 
@@ -164,7 +167,7 @@ export const mapAsHorizontalContentCard = (card: BrazeContentCard): HorizontalCo
   link: appendDeeplinkLocationIfDefined(card.extras.link, card.extras.location),
   createdAt: card.created,
   viewed: card.viewed,
-  order: parseInt(card.extras.order) ?? undefined,
+  order: parseOrder(card.extras.order),
   gridWidthFactor: WidthFactor.Full,
   extras: card.extras,
 });
@@ -189,7 +192,7 @@ const mapAsSquareContentCard = (
   link: appendDeeplinkLocationIfDefined(card.extras.link, card.extras.location),
   createdAt: card.created,
   viewed: card.viewed,
-  order: parseInt(card.extras.order) ?? undefined,
+  order: parseOrder(card.extras.order),
   carouselWidthFactor,
   gridWidthFactor,
   mediaType: card.extras.mediaType as VerticalContentCard["mediaType"],
@@ -210,7 +213,7 @@ export const mapAsHeroContentCard = (card: BrazeContentCard): HeroContentCard =>
   link: appendDeeplinkLocationIfDefined(card.extras.link, card.extras.location),
   createdAt: card.created,
   viewed: card.viewed,
-  order: parseInt(card.extras.order) ?? undefined,
+  order: parseOrder(card.extras.order),
   extras: card.extras,
 });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/GenericLandingPage/useGeneralLandingPageViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/GenericLandingPage/useGeneralLandingPageViewModel.ts
@@ -10,7 +10,7 @@ import {
   LandingPageUseCase,
 } from "~/dynamicContent/types";
 import useDynamicContent from "~/dynamicContent/useDynamicContent";
-import { filterCategoriesByLocation } from "~/dynamicContent/utils";
+import { filterCategoriesByLocation, sanitizeExtras } from "~/dynamicContent/utils";
 import { isDynamicContentLoadingSelector } from "~/reducers/dynamicContent";
 
 export type NavigationProps = BaseComposite<
@@ -35,7 +35,7 @@ export const useGeneralLandingPage = (props: NavigationProps) => {
 
   const openLink = async (card: LandingPageStickyCtaContentCard) => {
     await trackContentCardEvent("contentcard_clicked", {
-      ...card.extras,
+      ...sanitizeExtras(card.extras),
       campaign: card.id,
       contentcard: card.cta,
       landingPage: useCase,

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -358,6 +358,7 @@
     "src/api/ofacGeoBlockApi.ts",
     "src/bot/specs.ts",
     "src/braze/anonymousUsers.ts",
+    "src/braze/contentCardExtras.ts",
     "src/bridge/descriptor/registry.ts",
     "src/bridge/descriptor/send/features.ts",
     "src/bridge/descriptor/send/memo.ts",

--- a/libs/ledger-live-common/src/braze/contentCardExtras.test.ts
+++ b/libs/ledger-live-common/src/braze/contentCardExtras.test.ts
@@ -1,0 +1,86 @@
+import { parseOrder, sanitizeExtras } from "./contentCardExtras";
+
+describe("parseOrder", () => {
+  it("should parse a valid numeric string", () => {
+    expect(parseOrder("3")).toBe(3);
+  });
+
+  it("should parse zero", () => {
+    expect(parseOrder("0")).toBe(0);
+  });
+
+  it("should parse a negative number", () => {
+    expect(parseOrder("-1")).toBe(-1);
+  });
+
+  it("should return undefined for undefined input", () => {
+    expect(parseOrder(undefined)).toBeUndefined();
+  });
+
+  it("should return undefined for an empty string", () => {
+    expect(parseOrder("")).toBeUndefined();
+  });
+
+  it("should return undefined for a non-numeric string", () => {
+    expect(parseOrder("abc")).toBeUndefined();
+  });
+
+  it("should return undefined for 'NaN'", () => {
+    expect(parseOrder("NaN")).toBeUndefined();
+  });
+
+  it("should return undefined for 'undefined'", () => {
+    expect(parseOrder("undefined")).toBeUndefined();
+  });
+
+  it("should truncate a float string to an integer", () => {
+    expect(parseOrder("2.7")).toBe(2);
+  });
+
+  it("should parse a string with leading whitespace", () => {
+    expect(parseOrder(" 5")).toBe(5);
+  });
+});
+
+describe("sanitizeExtras", () => {
+  it("should return an empty object for undefined extras", () => {
+    expect(sanitizeExtras(undefined)).toEqual({});
+  });
+
+  it("should convert a valid order string to a number", () => {
+    const result = sanitizeExtras({ order: "2", title: "Hello" });
+    expect(result).toEqual({ order: 2, title: "Hello" });
+  });
+
+  it("should omit order when the value is not numeric", () => {
+    const result = sanitizeExtras({ order: "abc", title: "Hello" });
+    expect(result).toEqual({ title: "Hello" });
+    expect(result).not.toHaveProperty("order");
+  });
+
+  it("should omit order when it is missing from extras", () => {
+    const result = sanitizeExtras({ title: "Hello" });
+    expect(result).toEqual({ title: "Hello" });
+    expect(result).not.toHaveProperty("order");
+  });
+
+  it("should preserve all other extras as strings", () => {
+    const result = sanitizeExtras({
+      order: "1",
+      title: "Title",
+      location: "top_wallet",
+      type: "hero",
+    });
+    expect(result).toEqual({
+      order: 1,
+      title: "Title",
+      location: "top_wallet",
+      type: "hero",
+    });
+  });
+
+  it("should handle order of zero", () => {
+    const result = sanitizeExtras({ order: "0" });
+    expect(result).toEqual({ order: 0 });
+  });
+});

--- a/libs/ledger-live-common/src/braze/contentCardExtras.ts
+++ b/libs/ledger-live-common/src/braze/contentCardExtras.ts
@@ -1,0 +1,19 @@
+/**
+ * Braze extras are always Record<string, string>. These helpers convert the
+ * `order` field to a number so that sorting and analytics tracking receive a
+ * consistent numeric value instead of a raw string, "NaN", or undefined.
+ */
+
+export const parseOrder = (value: string | undefined): number | undefined => {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+};
+
+export const sanitizeExtras = (
+  extras: Record<string, string> | undefined,
+): Record<string, string | number> => {
+  if (!extras) return {};
+  const { order, ...rest } = extras;
+  const parsed = parseOrder(order);
+  return parsed !== undefined ? { ...rest, order: parsed } : { ...rest };
+};


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Content card analytics events (`contentcard_impression`, `contentcard_clicked`, `contentcard_dismissed`) now report `order` as a numeric integer (or omit it) instead of a raw string, `"NaN"`, or `"undefined"`.
  - `displayedPosition` is now included in impression events for all content card placements (portfolio carousel, bottom carousel, Braze placement grid, mobile carousel, mobile grid) where it was previously missing.
  - QA should focus on verifying Mixpanel/Segment event payloads for content card interactions across all placements on both desktop and mobile.

### 📝 Description
<img width="1809" height="1102" alt="Screenshot 2026-05-05 at 14 20 01" src="https://github.com/user-attachments/assets/b0010dc1-96d2-4263-b728-15ec7e1d345e" />

Fixes three interconnected issues causing incorrect `order`/`displayedPosition` values in content card tracking events:

**1. Mobile `parseInt(x) ?? undefined` silently produced `NaN`**

All mobile `mapAs*ContentCard` functions used `parseInt(card.extras.order) ?? undefined`. Because `parseInt(undefined)` returns `NaN` and the `??` operator does not catch `NaN` (only `null`/`undefined`), the `order` field silently became `NaN` at runtime. This broke sorting (`compareCards` with `NaN` is unreliable) and leaked `"NaN"` into analytics. Fixed by introducing a proper `parseOrder` helper that explicitly checks for `NaN` and returns `undefined`.

**2. Raw string `extras.order` leaked into tracking events**

All tracking callsites spread `...currentCard.extras` into event payloads. Since Braze extras are always `Record<string, string>`, the `order` property was sent as a raw string to Mixpanel. Added a `sanitizeExtras` helper that parses `order` to a number before spreading, and applied it at all 6 tracking callsites across both platforms.

**3. `displayedPosition` missing from most impression events**

Several rendering components omitted `displayedPosition` when wrapping cards in `LogContentCardWrapper`:
- Desktop: `Slide.tsx`, `BottomCarouselSlide.tsx`, `PortfolioBrazePlacementSlide` (all had `index` as a prop but didn't pass it)
- Desktop: `usePortfolioCarouselCards` click/dismiss events
- Mobile: carousel layout called `logImpressionCard(id)` without position
- Mobile: grid layout's `LogContentCardWrapper` lacked `displayedPosition`

All paths now consistently pass `displayedPosition`.

**Shared utility extraction**

`parseOrder` and `sanitizeExtras` were extracted to `@ledgerhq/live-common/braze/contentCardExtras` (alongside the existing `anonymousUsers` module) to eliminate duplication between desktop and mobile. Both platforms re-export from this shared module.

### ❓ Context

- **JIRA or GitHub link**: LIVE-27516
- **ADR link (if any)**: N/A

Made with [Cursor](https://cursor.com)