### PR TITLE
chore: set nx parallel to 8

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,4 +1,5 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
-  "extends": "./nx.cache-config.json"
+  "extends": "./nx.cache-config.json",
+  "parallel": 8
 }


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. <!-- N/A: config-only change, no published packages affected -->
- [x] **Covered by automatic tests.** <!-- N/A: build config change -->
- [x] **Impact of the changes:**
  - Increases Nx task parallelism from default to 8, speeding up local and CI builds

### 📝 Description

Sets `parallel: 8` in `nx.json` to allow Nx to run up to 8 tasks concurrently. The default Nx parallelism is 3; raising it to 8 makes full use of modern multi-core machines and CI runners to reduce build times.

<img width="1182" height="334" alt="Screenshot 2026-05-05 at 13 52 59" src="https://github.com/user-attachments/assets/718049f7-10ec-42cd-a064-0e625d0048c8" />


### ❓ Context

- **JIRA or GitHub link**: N/A
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)