### PR TITLE
[LWD] feat(desktop): apply wallet 4.0 background to asset detail page

### DIFF
--- a/.changeset/pretty-plums-vanish.md
+++ b/.changeset/pretty-plums-vanish.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Apply the Wallet 4.0 background and layout to the Asset Detail page (`/asset/*`) when the aggregated assets feature flag is enabled.

--- a/apps/ledger-live-desktop/src/mvvm/components/Page/__tests__/utils.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/Page/__tests__/utils.test.ts
@@ -32,6 +32,23 @@ describe("Page utils", () => {
       expect(isWallet40Page("/market/trending")).toBe(false);
       expect(isWallet40Page("/cryptos/extra")).toBe(false);
     });
+
+    describe("/asset prefix (conditional on shouldDisplayAggregatedAssets)", () => {
+      it("returns false for /asset routes when shouldDisplayAggregatedAssets is not provided", () => {
+        expect(isWallet40Page("/asset")).toBe(false);
+        expect(isWallet40Page("/asset/btc")).toBe(false);
+      });
+
+      it("returns false for /asset routes when shouldDisplayAggregatedAssets is false", () => {
+        expect(isWallet40Page("/asset", { shouldDisplayAggregatedAssets: false })).toBe(false);
+        expect(isWallet40Page("/asset/btc", { shouldDisplayAggregatedAssets: false })).toBe(false);
+      });
+
+      it("returns true for /asset routes when shouldDisplayAggregatedAssets is true", () => {
+        expect(isWallet40Page("/asset", { shouldDisplayAggregatedAssets: true })).toBe(true);
+        expect(isWallet40Page("/asset/btc", { shouldDisplayAggregatedAssets: true })).toBe(true);
+      });
+    });
   });
 
   describe("shouldDisplayRightPanel", () => {

--- a/apps/ledger-live-desktop/src/mvvm/components/Page/utils.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/Page/utils.ts
@@ -1,10 +1,27 @@
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface IsWallet40PageOptions {
+  readonly shouldDisplayAggregatedAssets?: boolean;
+}
+
+interface ConditionalPrefix {
+  readonly prefix: string;
+  readonly isEnabled: (options: IsWallet40PageOptions) => boolean;
+}
+
+// =============================================================================
+// Wallet 4.0 layout
+// =============================================================================
+
 /**
  * Pages that use the Wallet 4.0 experience:
  * - Tailwind background color
  * - RightPanel (swap sidebar)
  * - Wallet40Layout with pt-32 spacing
  */
-const WALLET_40_PAGES = new Set([
+const WALLET_40_PAGES = new Set<string>([
   "/",
   "/market",
   "/analytics",
@@ -16,21 +33,44 @@ const WALLET_40_PAGES = new Set([
   "/history",
 ]);
 
-const WALLET_40_PREFIXES = ["/card", "/swap", "/exchange"];
-
 /**
- * Pages that display the right panel (swap sidebar)
+ * Path prefixes that always belong to Wallet 4.0 (e.g. `/swap/foo`).
  */
-const RIGHT_PANEL_PAGES = new Set(["/", "/analytics", "/cryptos"]);
+const WALLET_40_PREFIXES: readonly string[] = ["/card", "/swap", "/exchange"];
 
 /**
- * Check if a pathname uses the Wallet 4.0 layout
+ * Path prefixes that belong to Wallet 4.0 only when their associated
+ * feature flag is enabled.
  */
-export const isWallet40Page = (pathname: string): boolean =>
-  WALLET_40_PAGES.has(pathname) || WALLET_40_PREFIXES.some(prefix => pathname.startsWith(prefix));
+const CONDITIONAL_WALLET_40_PREFIXES: readonly ConditionalPrefix[] = [
+  {
+    prefix: "/asset",
+    isEnabled: ({ shouldDisplayAggregatedAssets }) => !!shouldDisplayAggregatedAssets,
+  },
+];
 
 /**
- * Check if a pathname should display the right panel (swap sidebar)
+ * Check if a pathname uses the Wallet 4.0 layout.
+ */
+export const isWallet40Page = (pathname: string, options: IsWallet40PageOptions = {}): boolean => {
+  if (WALLET_40_PAGES.has(pathname)) return true;
+  if (WALLET_40_PREFIXES.some(prefix => pathname.startsWith(prefix))) return true;
+  return CONDITIONAL_WALLET_40_PREFIXES.some(
+    ({ prefix, isEnabled }) => isEnabled(options) && pathname.startsWith(prefix),
+  );
+};
+
+// =============================================================================
+// Right panel (swap sidebar)
+// =============================================================================
+
+/**
+ * Pages that display the right panel (swap sidebar).
+ */
+const RIGHT_PANEL_PAGES = new Set<string>(["/", "/analytics", "/cryptos"]);
+
+/**
+ * Check if a pathname should display the right panel (swap sidebar).
  */
 export const shouldDisplayRightPanel = (pathname: string): boolean =>
   RIGHT_PANEL_PAGES.has(pathname);

--- a/apps/ledger-live-desktop/src/renderer/Default.tsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -316,7 +316,8 @@ export const MainAppLayout = () => {
     ? getPageBackground(pathname, theme)
     : undefined;
 
-  const useWallet40Layout = isWallet40Enabled && isWallet40Page(pathname);
+  const useWallet40Layout =
+    isWallet40Enabled && isWallet40Page(pathname, { shouldDisplayAggregatedAssets });
 
   useEffect(() => {
     if (shouldDisplayWallet40MainNav) preloadBackgrounds();


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Asset Detail page (`/asset/*`) background and layout when the **aggregated assets** feature flag is **ON** (must use the Wallet 4.0 background and `pt-32` layout).
  - Asset Detail page when the FF is **OFF** (must keep the legacy `Asset` page styling — no regression).
  - Other Wallet 4.0 pages (`/`, `/market`, `/swap/*`, etc.) — no regression.

### Description

When the `shouldDisplayAggregatedAssets` feature flag is enabled, the `/asset/*` route renders the new `AssetDetails` (Wallet 4.0) component, but the `MainAppLayout` was still applying the legacy background and layout because `/asset` was not registered as a Wallet 4.0 path.

This PR makes `/asset` a **conditional** Wallet 4.0 prefix:

- Added a `CONDITIONAL_WALLET_40_PREFIXES` list in `Page/utils.ts` that pairs a path prefix with a feature-flag predicate.
- `isWallet40Page` now accepts an `IsWallet40PageOptions` argument so callers can forward the relevant feature flags.
- `Default.tsx` (`MainAppLayout`) forwards `shouldDisplayAggregatedAssets` to the helper.

The file was also reorganized into clearly separated sections (Types / Wallet 4.0 / Right panel) for readability. No behavior change for any other route.



https://github.com/user-attachments/assets/fadbab29-11a2-4450-8b9d-7a21ccf924bf



### Context

- **JIRA or GitHub link**: [LIVE-30285](https://ledgerhq.atlassian.net/browse/LIVE-30285)

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-30285]: https://ledgerhq.atlassian.net/browse/LIVE-30285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ