### PR TITLE
[LWD] fix(desktop): mount wallet sync drawer in GlobalDialogs

### DIFF
--- a/.changeset/fresh-drawers-mount.md
+++ b/.changeset/fresh-drawers-mount.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Mount Ledger Sync activation drawer globally and derive analytics page from the current route

--- a/apps/ledger-live-desktop/src/mvvm/features/GlobalDialogs/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GlobalDialogs/index.tsx
@@ -1,38 +1,13 @@
-import React, { Suspense, lazy, useMemo } from "react";
-import { useLocation } from "react-router";
+import React, { Suspense, lazy } from "react";
 import ModularDialogRoot from "LLD/features/ModularDialog/ModularDialogRoot";
 import SendFlowRoot from "LLD/features/Send/SendFlowRoot";
 import PerpsSignRoot from "LLD/features/Perps/screens/PerpsSign/PerpsSignDialog";
 import ActionConfirmationDialog from "LLD/features/ActionConfirmationDialog";
-import WalletSyncDrawer from "LLD/features/WalletSync/components/Drawer";
-import { AnalyticsPage } from "LLD/features/WalletSync/hooks/useLedgerSyncAnalytics";
-import { useActivationDrawer } from "LLD/features/LedgerSyncEntryPoints/hooks/useActivationDrawer";
 
 const ReleaseNotes = lazy(() => import("LLD/features/ReleaseNotes"));
 const BuyDevice = lazy(() => import("LLD/features/BuyDevice"));
 const FinishOnboardingDialog = lazy(() => import("LLD/features/FinishOnboarding/FinishOnboardingDialog"));
 const PtxInfoDialog = lazy(() => import("LLD/features/PtxInfoDialog"));
-
-/** Ledger Sync activation analytics context — keep in sync with legacy per-screen drawers. */
-function walletSyncAnalyticsPageFromPath(pathname: string): AnalyticsPage {
-  if (pathname.startsWith("/settings")) return AnalyticsPage.SettingsGeneral;
-  if (pathname.startsWith("/accounts")) return AnalyticsPage.Accounts;
-  if (pathname.startsWith("/manager")) return AnalyticsPage.Manager;
-  if (pathname.startsWith("/sync-onboarding")) return AnalyticsPage.OnboardingSync;
-  if (pathname.startsWith("/onboarding")) return AnalyticsPage.Onboarding;
-  if (pathname.startsWith("/post-onboarding")) return AnalyticsPage.PostOnboarding;
-  return AnalyticsPage.PostOnboarding;
-}
-
-function GlobalWalletSyncDrawer() {
-  const { pathname } = useLocation();
-  const { closeDrawer } = useActivationDrawer();
-  const currentPage = useMemo(
-    () => walletSyncAnalyticsPageFromPath(pathname),
-    [pathname],
-  );
-  return <WalletSyncDrawer currentPage={currentPage} onClose={closeDrawer} />;
-}
 
 /** Mounts all root-level dialogs and flows. Add new global dialogs here. */
 const GlobalDialogs = () => (
@@ -41,7 +16,6 @@ const GlobalDialogs = () => (
     <SendFlowRoot />
     <PerpsSignRoot />
     <ActionConfirmationDialog />
-    <GlobalWalletSyncDrawer />
     <Suspense fallback={null}>
       <ReleaseNotes />
     </Suspense>

--- a/apps/ledger-live-desktop/src/mvvm/features/GlobalDialogs/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GlobalDialogs/index.tsx
@@ -1,13 +1,38 @@
-import React, { Suspense, lazy } from "react";
+import React, { Suspense, lazy, useMemo } from "react";
+import { useLocation } from "react-router";
 import ModularDialogRoot from "LLD/features/ModularDialog/ModularDialogRoot";
 import SendFlowRoot from "LLD/features/Send/SendFlowRoot";
 import PerpsSignRoot from "LLD/features/Perps/screens/PerpsSign/PerpsSignDialog";
 import ActionConfirmationDialog from "LLD/features/ActionConfirmationDialog";
+import WalletSyncDrawer from "LLD/features/WalletSync/components/Drawer";
+import { AnalyticsPage } from "LLD/features/WalletSync/hooks/useLedgerSyncAnalytics";
+import { useActivationDrawer } from "LLD/features/LedgerSyncEntryPoints/hooks/useActivationDrawer";
 
 const ReleaseNotes = lazy(() => import("LLD/features/ReleaseNotes"));
 const BuyDevice = lazy(() => import("LLD/features/BuyDevice"));
 const FinishOnboardingDialog = lazy(() => import("LLD/features/FinishOnboarding/FinishOnboardingDialog"));
 const PtxInfoDialog = lazy(() => import("LLD/features/PtxInfoDialog"));
+
+/** Ledger Sync activation analytics context — keep in sync with legacy per-screen drawers. */
+function walletSyncAnalyticsPageFromPath(pathname: string): AnalyticsPage {
+  if (pathname.startsWith("/settings")) return AnalyticsPage.SettingsGeneral;
+  if (pathname.startsWith("/accounts")) return AnalyticsPage.Accounts;
+  if (pathname.startsWith("/manager")) return AnalyticsPage.Manager;
+  if (pathname.startsWith("/sync-onboarding")) return AnalyticsPage.OnboardingSync;
+  if (pathname.startsWith("/onboarding")) return AnalyticsPage.Onboarding;
+  if (pathname.startsWith("/post-onboarding")) return AnalyticsPage.PostOnboarding;
+  return AnalyticsPage.PostOnboarding;
+}
+
+function GlobalWalletSyncDrawer() {
+  const { pathname } = useLocation();
+  const { closeDrawer } = useActivationDrawer();
+  const currentPage = useMemo(
+    () => walletSyncAnalyticsPageFromPath(pathname),
+    [pathname],
+  );
+  return <WalletSyncDrawer currentPage={currentPage} onClose={closeDrawer} />;
+}
 
 /** Mounts all root-level dialogs and flows. Add new global dialogs here. */
 const GlobalDialogs = () => (
@@ -16,6 +41,7 @@ const GlobalDialogs = () => (
     <SendFlowRoot />
     <PerpsSignRoot />
     <ActionConfirmationDialog />
+    <GlobalWalletSyncDrawer />
     <Suspense fallback={null}>
       <ReleaseNotes />
     </Suspense>

--- a/apps/ledger-live-desktop/src/mvvm/features/GlobalDrawers/__integrations__/GlobalDrawers.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GlobalDrawers/__integrations__/GlobalDrawers.integration.test.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { render, screen, waitFor, act } from "tests/testSetup";
+import GlobalDrawers from "../index";
+import { setDrawerVisibility } from "~/renderer/actions/walletSync";
+
+describe("GlobalDrawers Integration", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should render without crashing when all drawers are closed", () => {
+    const { container } = render(
+      <>
+        <div id="modals" />
+        <GlobalDrawers />
+      </>,
+      { initialRoute: "/settings/general" },
+    );
+    expect(container).toBeInTheDocument();
+  });
+
+  it("should show wallet sync side drawer when opened", async () => {
+    const { store } = render(
+      <>
+        <div id="modals" />
+        <GlobalDrawers />
+      </>,
+      { initialRoute: "/settings/general" },
+    );
+
+    act(() => {
+      store.dispatch(setDrawerVisibility(true));
+    });
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId("side-drawer-container")).toBeVisible();
+      },
+      { timeout: 3000 },
+    );
+  });
+
+  it("should hide wallet sync side drawer when closed", async () => {
+    const { store } = render(
+      <>
+        <div id="modals" />
+        <GlobalDrawers />
+      </>,
+      { initialRoute: "/settings/general" },
+    );
+
+    act(() => {
+      store.dispatch(setDrawerVisibility(true));
+    });
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId("side-drawer-container")).toBeVisible();
+      },
+      { timeout: 3000 },
+    );
+
+    act(() => {
+      store.dispatch(setDrawerVisibility(false));
+    });
+
+    await waitFor(
+      () => {
+        expect(screen.queryByTestId("side-drawer-container")).not.toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+  });
+
+  it.each([
+    "/settings/general",
+    "/accounts",
+    "/manager",
+    "/sync-onboarding/step",
+    "/onboarding",
+    "/post-onboarding",
+    "/portfolio",
+  ])("should mount for route %s", pathname => {
+    const { container } = render(
+      <>
+        <div id="modals" />
+        <GlobalDrawers />
+      </>,
+      { initialRoute: pathname },
+    );
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/GlobalDrawers/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GlobalDrawers/index.tsx
@@ -1,0 +1,22 @@
+import React, { useMemo } from "react";
+import { useLocation } from "react-router";
+import WalletSyncDrawer from "LLD/features/WalletSync/components/Drawer";
+import { useActivationDrawer } from "LLD/features/LedgerSyncEntryPoints/hooks/useActivationDrawer";
+import { walletSyncAnalyticsPageFromPath } from "../WalletSync/walletSyncAnalyticsPageFromPath";
+
+const GlobalWalletSyncDrawer = () => {
+  const { pathname } = useLocation();
+  const { closeDrawer } = useActivationDrawer();
+  const currentPage = useMemo(() => walletSyncAnalyticsPageFromPath(pathname), [pathname]);
+
+  return <WalletSyncDrawer currentPage={currentPage} onClose={closeDrawer} />;
+};
+
+/** Mounts all root-level drawers. Add new global drawers here. */
+const GlobalDrawers = () => (
+  <>
+    <GlobalWalletSyncDrawer />
+  </>
+);
+
+export default GlobalDrawers;

--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/components/SyncStep/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/components/SyncStep/index.tsx
@@ -6,8 +6,6 @@ import { SeedOriginType } from "@ledgerhq/types-live";
 import useLedgerSyncEntryPointViewModel from "LLD/features/LedgerSyncEntryPoints/useLedgerSyncEntryPointViewModel";
 import { EntryPoint } from "LLD/features/LedgerSyncEntryPoints/types";
 import { LogoWrapper } from "LLD/features/WalletSync/components/LogoWrapper";
-import WalletSyncDrawer from "LLD/features/WalletSync/components/Drawer";
-import { AnalyticsPage } from "LLD/features/WalletSync/hooks/useLedgerSyncAnalytics";
 import SkipSyncDrawer from "../SkipSyncDrawer";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { setSkipDrawerVisibility } from "~/renderer/reducers/onboarding";
@@ -32,7 +30,7 @@ const SyncStep = ({
   const dispatch = useDispatch();
   const isSyncDrawerOpen = useSelector(walletSyncDrawerVisibilitySelector);
 
-  const { openDrawer: openSyncDrawer, closeDrawer } = useLedgerSyncEntryPointViewModel({
+  const { openDrawer: openSyncDrawer } = useLedgerSyncEntryPointViewModel({
     entryPoint: EntryPoint.onboarding,
     needEligibleDevice: true,
     onboardingNewDevice: true,
@@ -124,12 +122,6 @@ const SyncStep = ({
         </>
       )}
 
-      <WalletSyncDrawer
-        currentPage={AnalyticsPage.OnboardingSync}
-        onClose={() => {
-          closeDrawer();
-        }}
-      />
       <SkipSyncDrawer
         onSkip={handleContinue}
         handleSync={openDrawer}

--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/Welcome/hooks/useWelcomeViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/Welcome/hooks/useWelcomeViewModel.ts
@@ -128,7 +128,7 @@ export function useWelcomeViewModel() {
   );
 
   // Ledger Sync activation
-  const { openDrawer, closeDrawer } = useActivationDrawer();
+  const { openDrawer } = useActivationDrawer();
 
   const setupLedgerSync = useCallback(() => {
     acceptTerms();
@@ -197,8 +197,5 @@ export function useWelcomeViewModel() {
     // Analytics opt-in
     isFeatureFlagsAnalyticsPrefDisplayed,
     extendedAnalyticsOptInPromptProps,
-
-    // Ledger Sync
-    closeDrawer,
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/Welcome/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/Welcome/index.tsx
@@ -5,8 +5,6 @@ import { useTheme } from "styled-components";
 import AnalyticsOptInPrompt from "LLD/features/AnalyticsOptInPrompt/screens";
 import LedgerSyncEntryPoint from "LLD/features/LedgerSyncEntryPoints";
 import { EntryPoint as LSEntryPoint } from "LLD/features/LedgerSyncEntryPoints/types";
-import WalletSyncDrawer from "LLD/features/WalletSync/components/Drawer";
-import { AnalyticsPage } from "LLD/features/WalletSync/hooks/useLedgerSyncAnalytics";
 
 import { useWelcomeViewModel } from "./hooks/useWelcomeViewModel";
 import { useVideoCarousel } from "./hooks/useVideoCarousel";
@@ -38,7 +36,6 @@ export function Welcome() {
     handleSetupLedgerSync,
     isFeatureFlagsAnalyticsPrefDisplayed,
     extendedAnalyticsOptInPromptProps,
-    closeDrawer,
   } = useWelcomeViewModel();
 
   const {
@@ -165,7 +162,6 @@ export function Welcome() {
       {isFeatureFlagsAnalyticsPrefDisplayed && (
         <AnalyticsOptInPrompt {...extendedAnalyticsOptInPromptProps} />
       )}
-      <WalletSyncDrawer currentPage={AnalyticsPage.Onboarding} onClose={closeDrawer} />
     </WelcomeContainer>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/walletSyncAnalyticsPageFromPath.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/walletSyncAnalyticsPageFromPath.ts
@@ -1,0 +1,12 @@
+import { AnalyticsPage } from "LLD/features/WalletSync/hooks/useLedgerSyncAnalytics";
+
+/** Ledger Sync activation analytics context — keep in sync with legacy per-screen drawers. */
+export function walletSyncAnalyticsPageFromPath(pathname: string): AnalyticsPage {
+  if (pathname.startsWith("/settings")) return AnalyticsPage.SettingsGeneral;
+  if (pathname.startsWith("/accounts")) return AnalyticsPage.Accounts;
+  if (pathname.startsWith("/manager")) return AnalyticsPage.Manager;
+  if (pathname.startsWith("/sync-onboarding")) return AnalyticsPage.OnboardingSync;
+  if (pathname.startsWith("/onboarding")) return AnalyticsPage.Onboarding;
+  if (pathname.startsWith("/post-onboarding")) return AnalyticsPage.PostOnboarding;
+  return AnalyticsPage.PostOnboarding;
+}

--- a/apps/ledger-live-desktop/src/renderer/Default.tsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -67,6 +67,7 @@ import { setCosmosLdmkEnabled } from "@ledgerhq/live-common/families/cosmos/setu
 import { themeSelector } from "./actions/general";
 import useCheckAccountWithFunds from "./components/PostOnboardingHub/logic/useCheckAccountWithFunds";
 import GlobalDialogs from "LLD/features/GlobalDialogs";
+import GlobalDrawers from "LLD/features/GlobalDrawers";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig";
 import { useShouldShowDeferredModals } from "~/renderer/hooks/useShouldShowDeferredModals";
 import {
@@ -495,6 +496,7 @@ export default function Default() {
                   ) : null}
 
                   <GlobalDialogs />
+                  <GlobalDrawers />
 
                   <Routes>
                     <Route

--- a/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/Tutorial/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/Tutorial/index.tsx
@@ -71,8 +71,6 @@ import { EnableSync } from "~/renderer/components/Onboarding/Screens/Tutorial/sc
 import { trustchainSelector } from "@ledgerhq/ledger-key-ring-protocol/store";
 import useLedgerSyncEntryPointViewModel from "LLD/features/LedgerSyncEntryPoints/useLedgerSyncEntryPointViewModel";
 import { EntryPoint } from "LLD/features/LedgerSyncEntryPoints/types";
-import WalletSyncDrawer from "LLD/features/WalletSync/components/Drawer";
-import { AnalyticsPage } from "LLD/features/WalletSync/hooks/useLedgerSyncAnalytics";
 import { walletSyncDrawerVisibilitySelector } from "~/renderer/reducers/walletSync";
 
 const FlowStepperContainer = styled(Flex)`
@@ -382,7 +380,7 @@ export default function Tutorial({ useCase, deviceModelId }: Props) {
     "MODAL_RECEIVE",
   );
 
-  const { openDrawer, closeDrawer } = useLedgerSyncEntryPointViewModel({
+  const { openDrawer } = useLedgerSyncEntryPointViewModel({
     entryPoint: EntryPoint.onboarding,
     needEligibleDevice: true,
     onboardingNewDevice: true,
@@ -1021,13 +1019,6 @@ export default function Tutorial({ useCase, deviceModelId }: Props) {
           <RecoveryWarning />
         </Flex>
       </Drawer>
-
-      <WalletSyncDrawer
-        currentPage={AnalyticsPage.Onboarding}
-        onClose={() => {
-          closeDrawer();
-        }}
-      />
 
       <FlowStepper
         illustration={CurrentScreen.Illustration}

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingScreen/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingScreen/index.tsx
@@ -8,16 +8,12 @@ import {
 import PostOnboardingHubContent from "~/renderer/components/PostOnboardingHub/PostOnboardingHubContent";
 import { withV3StyleProvider } from "~/renderer/styles/StyleProviderV3";
 import TrackPage from "~/renderer/analytics/TrackPage";
-import WalletSyncDrawer from "LLD/features/WalletSync/components/Drawer";
-import { AnalyticsPage } from "LLD/features/WalletSync/hooks/useLedgerSyncAnalytics";
-import { useActivationDrawer } from "LLD/features/LedgerSyncEntryPoints/hooks/useActivationDrawer";
 
 const PostOnboardingScreen = () => {
   const { t } = useTranslation();
   const areAllPostOnboardingActionsCompleted = useAllPostOnboardingActionsCompleted();
 
   const { deviceModelId } = usePostOnboardingHubState();
-  const { closeDrawer } = useActivationDrawer();
 
   return (
     <Flex
@@ -59,7 +55,6 @@ const PostOnboardingScreen = () => {
       <Flex flex={1} paddingRight={100} paddingLeft={50} paddingTop={50} overflow="auto">
         <PostOnboardingHubContent />
       </Flex>
-      <WalletSyncDrawer currentPage={AnalyticsPage.PostOnboarding} onClose={closeDrawer} />
     </Flex>
   );
 };

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/index.tsx
@@ -21,9 +21,6 @@ import MevProtectionRow from "./MevProtection";
 import { useEntryPoint } from "LLD/features/LedgerSyncEntryPoints/hooks/useEntryPoint";
 import { EntryPoint } from "LLD/features/LedgerSyncEntryPoints/types";
 import LedgerSyncEntryPoint from "LLD/features/LedgerSyncEntryPoints";
-import WalletSyncDrawer from "LLD/features/WalletSync/components/Drawer";
-import { AnalyticsPage } from "LLD/features/WalletSync/hooks/useLedgerSyncAnalytics";
-import { useActivationDrawer } from "LLD/features/LedgerSyncEntryPoints/hooks/useActivationDrawer";
 import { useLocalizedUrl } from "~/renderer/hooks/useLocalizedUrls";
 import { urls } from "~/config/urls";
 
@@ -33,7 +30,6 @@ const SectionGeneral = () => {
   useInitSupportedCounterValues();
   const lldAnalyticsOptInPromptFlag = useFeature("lldAnalyticsOptInPrompt");
   const { shouldDisplayEntryPoint } = useEntryPoint(EntryPoint.settings);
-  const { closeDrawer } = useActivationDrawer();
   const ledgerSyncOptimisationFlag = useFeature("lwdLedgerSyncOptimisation");
   const mevProtectionUrl = useLocalizedUrl(urls.mevProtection);
 
@@ -146,7 +142,6 @@ const SectionGeneral = () => {
           </Row>
         )}
       </Body>
-      <WalletSyncDrawer currentPage={AnalyticsPage.SettingsGeneral} onClose={closeDrawer} />
     </>
   );
 };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No new automated tests for route-to-analytics mapping; regression coverage relies on existing Wallet Sync flows and manual QA._
- [x] **Impact of the changes:**
  - Finish onboarding → Ledger Sync / “Next, finish wallet setup” opens the activation drawer
  - Post-onboarding hub and sync-onboarding companion step
  - Settings → General → Wallet Sync entry still opens the drawer
  - Ledger Sync analytics `currentPage` matches the screen the user came from (pathname-based mapping)

### 📝 Description

**Problem:** The Ledger Sync activation drawer was mounted in several screens (Welcome, Tutorial, sync companion, post-onboarding, settings). That duplicated mounts and activation state, so flows such as finishing onboarding into Sync could fail to open the drawer reliably.

**Solution:** Mount `WalletSyncDrawer` once in `GlobalDialogs`, wire it to `useActivationDrawer` for close, and derive `currentPage` for analytics from `useLocation().pathname` via `walletSyncAnalyticsPageFromPath`. Remove the redundant local drawer mounts from the affected screens.

https://www.loom.com/share/54009efb31a4417fb48bc7954f5a1164

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30278](https://ledgerhq.atlassian.net/browse/LIVE-30278)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-30278]: https://ledgerhq.atlassian.net/browse/LIVE-30278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ