### PR TITLE
[LWM] fix(mobile): hide MyWallet top container during BLE pairing

### DIFF
--- a/.changeset/metal-cobras-sleep.md
+++ b/.changeset/metal-cobras-sleep.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Hide avatar and quick actions during BLE pairing flow in MyWallet screen

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { ScrollView } from "react-native";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { TrackScreen } from "~/analytics";
@@ -10,20 +10,25 @@ import { MyLedgerSection } from "./views/MyLedgerSection";
 
 export function MyWalletScreen() {
   const { shouldDisplayMyWallet } = useWalletFeaturesConfig("mobile");
+  const [isPairing, setIsPairing] = useState(false);
+
+  const onPairingStateChanged = (pairing: boolean) => setIsPairing(pairing);
 
   return (
     <Box style={{ flex: 1 }}>
       <TrackScreen category="My Wallet" />
-      <Box lx={{ paddingHorizontal: "s16", gap: "s24", paddingTop: "s16" }}>
-        <Box lx={{ alignItems: "center", gap: "s48" }}>
-          <ProfileSection />
-          <QuickActionsRow />
+      {!isPairing && (
+        <Box lx={{ paddingHorizontal: "s16", gap: "s24", paddingTop: "s16" }}>
+          <Box lx={{ alignItems: "center", gap: "s48" }}>
+            <ProfileSection />
+            <QuickActionsRow />
+          </Box>
         </Box>
-      </Box>
+      )}
       {/* temporary hide the new UI until it's ready */}
       {shouldDisplayMyWallet ? (
         <Box lx={{ paddingTop: "s24" }} style={{ flex: 1 }}>
-          <MyLedgerSection />
+          <MyLedgerSection onPairingStateChanged={onPairingStateChanged} />
         </Box>
       ) : (
         <ScrollView>

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/MyLedgerSection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/MyLedgerSection.tsx
@@ -23,9 +23,19 @@ import type { MyWalletNavigatorStackParamList } from "../types";
 import { ExploreDevicesItem } from "./DeviceSection/components/ExploreDevicesItem";
 import { MyWalletHeaderTrailing } from "./Header";
 
-function MyLedgerSectionContent() {
+type MyLedgerSectionProps = {
+  onPairingStateChanged?: (isPairing: boolean) => void;
+};
+
+function MyLedgerSectionContent({ onPairingStateChanged }: MyLedgerSectionProps) {
   const action = useManagerDeviceAction();
   const [device, setDevice] = useState<Device>();
+  const [isHeaderOverridden, setIsHeaderOverridden] = useState<boolean>(false);
+
+  useEffect(() => {
+    onPairingStateChanged?.(isHeaderOverridden);
+  }, [isHeaderOverridden, onPairingStateChanged]);
+
   const { params } =
     useRoute<RouteProp<MyWalletNavigatorStackParamList, typeof ScreenName.MyWallet>>();
 
@@ -83,23 +93,34 @@ function MyLedgerSectionContent() {
 
   const requestToSetHeaderOptions = useCallback(
     (request: SetHeaderOptionsRequest) => {
-      const opts: Partial<LumenNativeStackNavigationOptions> =
-        request.type === "set"
-          ? {
-              lumenNavBar: {
-                renderLeading: request.options.headerLeft,
-                renderTrailing: request.options.headerRight,
-                renderCenter: () => null,
-              },
-            }
-          : {
-              lumenNavBar: {
-                renderLeading: undefined,
-                renderCenter: () => null,
-                renderTrailing: () => <MyWalletHeaderTrailing />,
-              },
-            };
-      navigation.setOptions(opts);
+      if (request.type === "set") {
+        const HeaderLeft = request.options.headerLeft;
+        const opts: Partial<LumenNativeStackNavigationOptions> = {
+          lumenNavBar: {
+            renderLeading: HeaderLeft
+              ? () => (
+                  <Box style={{ paddingLeft: 12 }}>
+                    <HeaderLeft />
+                  </Box>
+                )
+              : undefined,
+            renderTrailing: request.options.headerRight,
+            renderCenter: () => null,
+          },
+        };
+        navigation.setOptions(opts);
+        setIsHeaderOverridden(true);
+      } else {
+        const opts: Partial<LumenNativeStackNavigationOptions> = {
+          lumenNavBar: {
+            renderLeading: undefined,
+            renderCenter: () => null,
+            renderTrailing: () => <MyWalletHeaderTrailing />,
+          },
+        };
+        navigation.setOptions(opts);
+        setIsHeaderOverridden(false);
+      }
     },
     [navigation],
   );
@@ -131,8 +152,8 @@ function MyLedgerSectionContent() {
   );
 }
 
-export function MyLedgerSection() {
+export function MyLedgerSection({ onPairingStateChanged }: MyLedgerSectionProps) {
   const isFocused = useIsFocused();
   if (!isFocused) return null;
-  return <MyLedgerSectionContent />;
+  return <MyLedgerSectionContent onPairingStateChanged={onPairingStateChanged} />;
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - MyWallet screen UI rendering during BLE pairing (top container visibility).
  - Back arrow alignment in the MyWallet BLE pairing flow.

### 📝 Description

This PR addresses UI issues in the MyWallet screen during the BLE pairing process.

**Problem**:
1. When entering BLE pairing via "Add new device" in MyWallet, the `ProfileSection` (avatar) and `QuickActionsRow` (entry points) remained visible above the pairing UI, preventing a full-screen pairing flow.
2. The back arrow button during BLE pairing was visually misaligned compared to the standard Lumen navigation bar back arrow.

**Solution** (replicates the existing MyLedger pattern):
1. `MyLedgerSection` tracks `isHeaderOverridden` state, toggled via `requestToSetHeaderOptions` callbacks from `SelectDevice2`.
2. This state is passed up to `MyWalletScreen` via `onPairingStateChanged`.
3. When `isPairing` is `true`, `ProfileSection` and `QuickActionsRow` are hidden.
4. The legacy `NavigationHeaderBackButton` is wrapped with `paddingLeft: 10` to match the Lumen `IconButton` alignment.
5. `paddingTop` on the `MyLedgerSection` wrapper is kept constant (`"s24"`) to prevent layout shifts.

https://github.com/user-attachments/assets/059102a0-2302-48ca-89bd-dd2f6a1d8694


### ❓ Context

- **JIRA**: [LIVE-30272](https://ledgerhq.atlassian.net/browse/LIVE-30272)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-30272]: https://ledgerhq.atlassian.net/browse/LIVE-30272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ