### PR TITLE
[LWM] fix(mobile): keep portfolio crypto lines on 1-day time range

### DIFF
--- a/.changeset/steady-ranges-stay.md
+++ b/.changeset/steady-ranges-stay.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix portfolio crypto lines to always display 1-day percentage change regardless of asset detail time range selection

--- a/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/usePrecomputedAssetListData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/usePrecomputedAssetListData.ts
@@ -8,11 +8,7 @@ import { ValueChange } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { useLocale } from "~/context/Locale";
 import { useSelector } from "~/context/hooks";
-import {
-  counterValueCurrencySelector,
-  discreetModeSelector,
-  selectedTimeRangeSelector,
-} from "~/reducers/settings";
+import { counterValueCurrencySelector, discreetModeSelector } from "~/reducers/settings";
 import { Asset } from "~/types/asset";
 
 export interface AssetListItemViewModelResult {
@@ -30,7 +26,7 @@ const CV_THROTTLE_MS = 5_000;
 interface SharedState {
   cvState: ReturnType<typeof useCountervaluesState>;
   counterValueCurrency: ReturnType<typeof counterValueCurrencySelector>;
-  range: ReturnType<typeof selectedTimeRangeSelector>;
+  range: "day";
   locale: string;
   discreet: boolean;
 }
@@ -120,7 +116,7 @@ export function usePrecomputedAssetListData(
   const { locale } = useLocale();
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
   const discreet = useSelector(discreetModeSelector);
-  const range = useSelector(selectedTimeRangeSelector);
+  const range = "day" as const;
 
   const rawCvState = useCountervaluesState();
   const cvState = useThrottledValue(rawCvState, CV_THROTTLE_MS);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Portfolio crypto list percentage changes (+x%) must always reflect the 1-day range
      - Changing the time range in the AssetDetail view must not affect the portfolio lines

### 📝 Description

**Problem**: When navigating to an asset detail screen and changing the time range (e.g., from 1 day to 1 week), the percentage change displayed on each crypto line in the portfolio list was also affected. This happened because `usePrecomputedAssetListData` read the global `selectedTimeRangeSelector` from Redux to compute `countervalueChange`, and the AssetDetail view updates that same Redux state.

**Solution**: Hardcoded the range to `"day"` in `usePrecomputedAssetListData` so portfolio crypto lines always show 1-day percentage change regardless of what time range is selected in the asset detail view. Also reverted a previous incorrect fix in `usePortfolioBalance` that had synced the portfolio balance graph to the global time range.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-30112

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)