### PR TITLE
[LWDM] feat(LIVE-29574): add multi-record private intent mapping and tests

### DIFF
--- a/.changeset/afraid-beers-cough.md
+++ b/.changeset/afraid-beers-cough.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+Support multi-record private transfer intents in coin-aleo

--- a/libs/coin-modules/coin-aleo/src/__tests__/fixtures/transaction.fixture.ts
+++ b/libs/coin-modules/coin-aleo/src/__tests__/fixtures/transaction.fixture.ts
@@ -46,7 +46,17 @@ export const mockTxIntentTransferPrivate: AleoTransactionIntent = {
   type: TRANSACTION_TYPE.TRANSFER_PRIVATE,
   data: {
     type: TRANSACTION_TYPE.TRANSFER_PRIVATE,
-    record: mockUnspentRecord1.decryptedData,
+    records: [mockUnspentRecord1.decryptedData],
+  },
+};
+
+export const mockTxIntentTransferPrivate2: AleoTransactionIntent = {
+  ...baseTxIntentFields,
+  amount: 200n,
+  type: TRANSACTION_TYPE.TRANSFER_PRIVATE,
+  data: {
+    type: TRANSACTION_TYPE.TRANSFER_PRIVATE,
+    records: [mockUnspentRecord1.decryptedData, mockUnspentRecord2.decryptedData],
   },
 };
 
@@ -62,7 +72,17 @@ export const mockTxIntentSelfTransferToPublic: AleoTransactionIntent = {
   type: TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC,
   data: {
     type: TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC,
-    record: mockUnspentRecord1.decryptedData,
+    records: [mockUnspentRecord1.decryptedData],
+  },
+};
+
+export const mockTxIntentSelfTransferToPublic2: AleoTransactionIntent = {
+  ...baseTxIntentFields,
+  amount: 400n,
+  type: TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC,
+  data: {
+    type: TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC,
+    records: [mockUnspentRecord1.decryptedData, mockUnspentRecord2.decryptedData],
   },
 };
 

--- a/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
@@ -27,7 +27,9 @@ import {
   mockTxIntentFeePublic,
   mockTxIntentSelfTransferToPrivate,
   mockTxIntentSelfTransferToPublic,
+  mockTxIntentSelfTransferToPublic2,
   mockTxIntentTransferPrivate,
+  mockTxIntentTransferPrivate2,
   mockTxIntentTransferPublic,
 } from "../__tests__/fixtures/transaction.fixture";
 import type { AleoOperationExtra, ProvableApi } from "../types";
@@ -922,6 +924,78 @@ describe("mapTransactionIntentToSdkIntent", () => {
     });
   });
 
+  it("should map transfer_private intent to transfer_private_2 SDK intent for two records", () => {
+    const intent = mockTxIntentTransferPrivate2;
+
+    const result = mapTransactionIntentToSdkIntent(intent);
+
+    expect(result).toEqual({
+      type: "transfer_private_2",
+      amount: intent.amount.toString(),
+      to: intent.recipient,
+      records: [mockUnspentRecord1.decryptedData, mockUnspentRecord2.decryptedData],
+    });
+  });
+
+  it("should map convert_private_to_public intent to transfer_private_to_public_2 SDK intent for two records", () => {
+    const intent = mockTxIntentSelfTransferToPublic2;
+
+    const result = mapTransactionIntentToSdkIntent(intent);
+
+    expect(result).toEqual({
+      type: "transfer_private_to_public_2",
+      amount: intent.amount.toString(),
+      to: intent.recipient,
+      records: [mockUnspentRecord1.decryptedData, mockUnspentRecord2.decryptedData],
+    });
+  });
+
+  it("should throw when private transfer intent contains an empty records array", () => {
+    const intent = {
+      ...mockTxIntentTransferPrivate,
+      data: {
+        type: TRANSACTION_TYPE.TRANSFER_PRIVATE,
+        records: [],
+      },
+    };
+
+    expect(() => mapTransactionIntentToSdkIntent(intent)).toThrow(
+      `aleo: at least one record is required for ${TRANSACTION_TYPE.TRANSFER_PRIVATE}`,
+    );
+  });
+
+  it("should throw when private_to_public intent contains an empty records array", () => {
+    const intent = {
+      ...mockTxIntentSelfTransferToPublic,
+      data: {
+        type: TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC,
+        records: [],
+      },
+    };
+
+    expect(() => mapTransactionIntentToSdkIntent(intent)).toThrow(
+      `aleo: at least one record is required for ${TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC}`,
+    );
+  });
+
+  it("should throw when private transfer intent contains too many records", () => {
+    const records = Array.from(
+      { length: MAX_PRIVATE_RECORDS_PER_TRANSACTION + 1 },
+      () => mockUnspentRecord1.decryptedData,
+    );
+    const intent = {
+      ...mockTxIntentTransferPrivate,
+      data: {
+        type: TRANSACTION_TYPE.TRANSFER_PRIVATE,
+        records,
+      },
+    };
+
+    expect(() => mapTransactionIntentToSdkIntent(intent)).toThrow(
+      `aleo: too many records for ${TRANSACTION_TYPE.TRANSFER_PRIVATE} (max: ${MAX_PRIVATE_RECORDS_PER_TRANSACTION})`,
+    );
+  });
+
   it("should map fee_private intent to SDK intent with correct fields", () => {
     const intent = mockTxIntentFeePrivate;
     if (!hasSpecificIntentData(intent, "fee_private")) {
@@ -1037,20 +1111,23 @@ describe("getOperationDetailsExtraFields", () => {
 
 describe("getAvailableBalance", () => {
   const mockTransparentBalance = new BigNumber(100);
-  const mockPrivateBalance = new BigNumber(200);
+  const expectedPrivateSpendableBalance = new BigNumber(mockUnspentRecord1.microcredits).plus(
+    new BigNumber(mockUnspentRecord2.microcredits),
+  );
   const mockAccount = getMockedAccount({
     aleoResources: {
       ...mockAleoResources,
       transparentBalance: mockTransparentBalance,
-      privateBalance: mockPrivateBalance,
+      privateBalance: new BigNumber(200),
+      unspentPrivateRecords: [mockUnspentRecord1, mockUnspentRecord2],
     },
   });
 
   it.each([
     [TRANSACTION_TYPE.TRANSFER_PUBLIC, mockTransparentBalance],
     [TRANSACTION_TYPE.CONVERT_PUBLIC_TO_PRIVATE, mockTransparentBalance],
-    [TRANSACTION_TYPE.TRANSFER_PRIVATE, mockPrivateBalance],
-    [TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC, mockPrivateBalance],
+    [TRANSACTION_TYPE.TRANSFER_PRIVATE, expectedPrivateSpendableBalance],
+    [TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC, expectedPrivateSpendableBalance],
   ])("should return correct balance for %s", (mode, expected) => {
     const transaction = getMockedTransaction({ mode });
 
@@ -1170,7 +1247,7 @@ describe("createTransactionIntent", () => {
       type: transaction.mode,
       data: {
         type: transaction.mode,
-        record: mockUnspentRecord1.decryptedData,
+        records: [mockUnspentRecord1.decryptedData],
       },
     });
   });
@@ -1185,7 +1262,7 @@ describe("createTransactionIntent", () => {
     });
 
     expect(() => createTransactionIntent({ account: mockAccount, transaction })).toThrow(
-      "aleo: missing amount record commitment",
+      "aleo: missing amount record commitments",
     );
   });
 
@@ -1199,7 +1276,40 @@ describe("createTransactionIntent", () => {
     });
 
     expect(() => createTransactionIntent({ account: mockAccount, transaction })).toThrow(
-      "aleo: no amount record found for commitment non-existent-commitment",
+      "aleo: no amount records found for given commitments: non-existent-commitment",
+    );
+  });
+
+  it("should throw when at least one commitment is missing even if others resolve", () => {
+    const missingCommitment = "non-existent-commitment";
+    const transaction = getMockedTransaction({
+      mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
+      properties: {
+        amountRecordCommitments: [mockUnspentRecord1.commitment, missingCommitment],
+        feeRecordCommitment: null,
+      },
+    });
+
+    expect(() => createTransactionIntent({ account: mockAccount, transaction })).toThrow(
+      `aleo: no amount records found for given commitments: ${missingCommitment}`,
+    );
+  });
+
+  it("should throw when selected amount record commitments exceed supported max", () => {
+    const amountRecordCommitments = Array.from(
+      { length: MAX_PRIVATE_RECORDS_PER_TRANSACTION + 1 },
+      (_, index) => `commitment-${index}`,
+    );
+    const transaction = getMockedTransaction({
+      mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
+      properties: {
+        amountRecordCommitments,
+        feeRecordCommitment: null,
+      },
+    });
+
+    expect(() => createTransactionIntent({ account: mockAccount, transaction })).toThrow(
+      `aleo: too many amount record commitments selected (max: ${MAX_PRIVATE_RECORDS_PER_TRANSACTION})`,
     );
   });
 });

--- a/libs/coin-modules/coin-aleo/src/logic/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.ts
@@ -386,6 +386,14 @@ export function hasSpecificIntentData<Type extends AleoTransactionIntentData["ty
   return "data" in txIntent && txIntent.data.type === expectedType;
 }
 
+function validateRecordsCount(transactionType: TransactionType, recordsCount: number): void {
+  invariant(recordsCount > 0, `aleo: at least one record is required for ${transactionType}`);
+  invariant(
+    recordsCount <= MAX_PRIVATE_RECORDS_PER_TRANSACTION,
+    `aleo: too many records for ${transactionType} (max: ${MAX_PRIVATE_RECORDS_PER_TRANSACTION})`,
+  );
+}
+
 export function mapTransactionIntentToSdkIntent(
   txIntent: TransactionIntent<MemoNotSupported, AleoTransactionIntentData>,
 ): Intent {
@@ -403,12 +411,23 @@ export function mapTransactionIntentToSdkIntent(
     }
     case TRANSACTION_TYPE.TRANSFER_PRIVATE: {
       invariant(hasSpecificIntentData(txIntent, type), `aleo: intent data is required for ${type}`);
+      const records = txIntent.data.records;
+      validateRecordsCount(type, records.length);
+
+      if (records.length === 1) {
+        return {
+          type: "transfer_private",
+          amount,
+          to,
+          record: records[0],
+        };
+      }
 
       return {
-        type: "transfer_private",
+        type: `transfer_private_${records.length}`,
         amount,
         to,
-        record: txIntent.data.record,
+        records,
       };
     }
     case TRANSACTION_TYPE.CONVERT_PUBLIC_TO_PRIVATE: {
@@ -420,12 +439,23 @@ export function mapTransactionIntentToSdkIntent(
     }
     case TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC: {
       invariant(hasSpecificIntentData(txIntent, type), `aleo: intent data is required for ${type}`);
+      const records = txIntent.data.records;
+      validateRecordsCount(type, records.length);
+
+      if (records.length === 1) {
+        return {
+          type: "transfer_private_to_public",
+          amount,
+          to,
+          record: records[0],
+        };
+      }
 
       return {
-        type: "transfer_private_to_public",
+        type: `transfer_private_to_public_${records.length}`,
         amount,
         to,
-        record: txIntent.data.record,
+        records,
       };
     }
     case "fee_public": {
@@ -484,8 +514,16 @@ export function getAvailableBalance(account: AleoAccount, transaction: Transacti
       return account.aleoResources?.transparentBalance ?? new BigNumber(0);
     // spending private balance
     case TRANSACTION_TYPE.TRANSFER_PRIVATE:
-    case TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC:
-      return account.aleoResources?.privateBalance ?? new BigNumber(0);
+    case TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC: {
+      const unspentPrivateRecords = account.aleoResources?.unspentPrivateRecords ?? [];
+
+      return sumPrivateRecords(
+        selectPrivateRecordsForAmount({
+          unspentRecords: unspentPrivateRecords,
+          targetAmount: null,
+        }),
+      );
+    }
     default:
       // @ts-expect-error - runtime check to ensure all transaction types are handled
       throw new Error(`aleo: unsupported tx mode for balance calculation: ${transaction.mode}`);
@@ -511,16 +549,35 @@ export function createTransactionIntent({
   } as const;
 
   if (isPrivateTx) {
-    const commitment = transaction.properties.amountRecordCommitments[0];
-    invariant(commitment, "aleo: missing amount record commitment");
-    const amountRecord = getRecordByCommitment({ account, commitment });
-    invariant(amountRecord, `aleo: no amount record found for commitment ${commitment}`);
+    const selectedCommitments = transaction.properties.amountRecordCommitments;
+    invariant(selectedCommitments.length > 0, "aleo: missing amount record commitments");
+    invariant(
+      selectedCommitments.length <= MAX_PRIVATE_RECORDS_PER_TRANSACTION,
+      `aleo: too many amount record commitments selected (max: ${MAX_PRIVATE_RECORDS_PER_TRANSACTION})`,
+    );
+    const missingCommitments: string[] = [];
+    const decryptedAmountRecords: AleoUnspentRecord["decryptedData"][] = [];
+
+    for (const commitment of selectedCommitments) {
+      const record = getRecordByCommitment({ account, commitment });
+      if (record) {
+        decryptedAmountRecords.push(record.decryptedData);
+      } else {
+        missingCommitments.push(commitment);
+      }
+    }
+
+    invariant(
+      missingCommitments.length === 0,
+      `aleo: no amount records found for given commitments: ${missingCommitments.join(", ")}`,
+    );
+    invariant(decryptedAmountRecords.length > 0, "aleo: missing amount records");
 
     return {
       ...commonFields,
       data: {
         type: transaction.mode,
-        record: amountRecord.decryptedData,
+        records: decryptedAmountRecords,
       },
     };
   }
@@ -591,6 +648,13 @@ export function getRecordByCommitment({
   const unspentPrivateRecords = account.aleoResources?.unspentPrivateRecords ?? [];
 
   return unspentPrivateRecords.find(record => record.commitment === commitment) ?? null;
+}
+
+export function sumPrivateRecords(records: AleoUnspentRecord[]): BigNumber {
+  return records.reduce(
+    (sum, record) => sum.plus(new BigNumber(record.microcredits)),
+    new BigNumber(0),
+  );
 }
 
 export const getNextSequenceNumber = (account: AleoAccount): BigNumber => {
@@ -704,10 +768,3 @@ export const getEstimatedSigningTime = (
   const minutes = flooredSeconds / 60;
   return `~${minutes} ${minuteShort}`;
 };
-
-export function sumPrivateRecords(records: AleoUnspentRecord[]): BigNumber {
-  return records.reduce(
-    (sum, record) => sum.plus(new BigNumber(record.microcredits)),
-    new BigNumber(0),
-  );
-}

--- a/libs/coin-modules/coin-aleo/src/types/logic.ts
+++ b/libs/coin-modules/coin-aleo/src/types/logic.ts
@@ -38,11 +38,11 @@ export type AleoTransactionIntentData =
   | TxDataNotSupported
   | {
       type: typeof TRANSACTION_TYPE.TRANSFER_PRIVATE;
-      record: AleoDecryptedRecordResponse;
+      records: AleoDecryptedRecordResponse[];
     }
   | {
       type: typeof TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC;
-      record: AleoDecryptedRecordResponse;
+      records: AleoDecryptedRecordResponse[];
     }
   | {
       type: "fee_public";

--- a/libs/coin-modules/coin-aleo/src/types/sdk.ts
+++ b/libs/coin-modules/coin-aleo/src/types/sdk.ts
@@ -21,12 +21,19 @@ export interface PreparedRequestResponse {
   tlv: string;
 }
 
-interface TransferPrivateIntent {
-  type: "transfer_private";
-  amount: string;
-  to: string;
-  record: AleoDecryptedRecordResponse;
-}
+type TransferPrivateIntent =
+  | {
+      type: "transfer_private";
+      amount: string;
+      to: string;
+      record: AleoDecryptedRecordResponse;
+    }
+  | {
+      type: `transfer_private_${number}`;
+      amount: string;
+      to: string;
+      records: AleoDecryptedRecordResponse[];
+    };
 
 interface TransferPublicIntent {
   type: "transfer_public";
@@ -34,12 +41,19 @@ interface TransferPublicIntent {
   to: string;
 }
 
-interface TransferPrivateToPublicIntent {
-  type: "transfer_private_to_public";
-  amount: string;
-  to: string;
-  record: AleoDecryptedRecordResponse;
-}
+type TransferPrivateToPublicIntent =
+  | {
+      type: "transfer_private_to_public";
+      amount: string;
+      to: string;
+      record: AleoDecryptedRecordResponse;
+    }
+  | {
+      type: `transfer_private_to_public_${number}`;
+      amount: string;
+      to: string;
+      records: AleoDecryptedRecordResponse[];
+    };
 
 interface TransferPublicToPrivateIntent {
   type: "transfer_public_to_private";


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Support multi-record private transfer intents in coin-aleo

### 📝 Description

This PR adds support multi-record private transfer intents in coin-aleo

### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-29574

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
