### PR TITLE
[LWDM] fix(missing fees): add gas price in prefetched block transaction

### DIFF
--- a/.changeset/smart-dancers-know.md
+++ b/.changeset/smart-dancers-know.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": minor
+---
+
+Fix: Cronos missing fees in block receipt

--- a/libs/coin-modules/coin-evm/src/api/index.cronos.integ.test.ts
+++ b/libs/coin-modules/coin-evm/src/api/index.cronos.integ.test.ts
@@ -49,4 +49,20 @@ describe("EVM Cronos Network (blockscout explorer)", () => {
       expect(page2.next).not.toEqual(page1.next);
     });
   });
+
+  describe("getBlock", () => {
+    it("should return block 61398731 without failing on unsigned typed transactions", async () => {
+      const block = await module.getBlock(61398731);
+      const transaction = block.transactions.find(
+        tx => tx.hash === "0x49a46bf29edb4faf38d062ea8d799915209f45dc96c0ff1f4c919d260c76642c",
+      );
+
+      expect(block.info.height).toBe(61398731);
+      expect(block.info.hash).toBe(
+        "0x95332a689b2409de3f8c88e87d0ad4c9317fb84cd864ca0adb771abddf717f89",
+      );
+      expect(block.transactions.length).toBeGreaterThan(0);
+      expect(transaction?.fees).toBe(7959000000000000n);
+    });
+  });
 });

--- a/libs/coin-modules/coin-evm/src/logic/getBlock.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/getBlock.test.ts
@@ -54,6 +54,7 @@ describe("getBlock", () => {
       value: "1000",
       from: address1,
       to: address2,
+      gasPrice: "20000000000",
       ...overrides,
     };
   }
@@ -942,6 +943,67 @@ describe("getBlock", () => {
 
     expect(mockGetInternalTransactionsByBlock).toHaveBeenCalledWith(expect.anything(), 12345);
     expect(mockTraceBlock).toHaveBeenCalledWith(expect.anything(), 12345);
+  });
+
+  it("uses prefetched tx gasPrice as fallback when Cronos receipt omits effectiveGasPrice and gasPrice", async () => {
+    setCoinConfig(
+      () =>
+        ({
+          info: { node: { type: "external" as const, retries: 0 } },
+        }) as unknown as EvmCoinConfig,
+    );
+    const gasUsed = 21000n;
+    const txGasPrice = "568125000000";
+    const mockGetNodeApi = jest.mocked(getNodeApi);
+    mockGetNodeApi.mockReturnValue({
+      getBlockByHeight: jest.fn().mockResolvedValueOnce(
+        makeNodeBlock({
+          transactions: [makeNodeBlockTx({ hash: "0xtx1", gasPrice: txGasPrice })],
+        }),
+      ),
+      getBlockReceipts: jest.fn().mockResolvedValueOnce([
+        makeNodeBlockReceipt({
+          hash: "0xtx1",
+          gasUsed: gasUsed.toString(),
+          gasPrice: "0", // what getBlockReceipts returns for a Cronos receipt
+          erc20Transfers: [],
+        }),
+      ]),
+      getTransaction: jest.fn(),
+    } as any);
+    const result = await getBlock({} as CryptoCurrency, 12345);
+    expect(result.transactions[0].fees).toEqual(21000n * 568125000000n);
+  });
+
+  it("uses receipt effectiveGasPrice over prefetched tx gasPrice on mainnet-shaped receipts", async () => {
+    setCoinConfig(
+      () =>
+        ({
+          info: { node: { type: "external" as const, retries: 0 } },
+        }) as unknown as EvmCoinConfig,
+    );
+    const gasUsed = 21000n;
+    const receiptEffectiveGasPrice = "1000000000"; // 1 Gwei — resolved from effectiveGasPrice by getBlockReceipts
+    const txGasPrice = "568125000000"; // higher value in the prefetched tx — must NOT win
+    const mockGetNodeApi = jest.mocked(getNodeApi);
+    mockGetNodeApi.mockReturnValue({
+      getBlockByHeight: jest.fn().mockResolvedValueOnce(
+        makeNodeBlock({
+          transactions: [makeNodeBlockTx({ hash: "0xtx1", gasPrice: txGasPrice })],
+        }),
+      ),
+      getBlockReceipts: jest.fn().mockResolvedValueOnce([
+        makeNodeBlockReceipt({
+          hash: "0xtx1",
+          gasUsed: gasUsed.toString(),
+          gasPrice: receiptEffectiveGasPrice, // non-zero → receipt wins over tx.gasPrice
+          erc20Transfers: [],
+        }),
+      ]),
+      getTransaction: jest.fn(),
+    } as any);
+    const result = await getBlock({} as CryptoCurrency, 12345);
+    expect(result.transactions[0].fees).toEqual(21000n * 1000000000n);
   });
 });
 

--- a/libs/coin-modules/coin-evm/src/logic/getBlock.ts
+++ b/libs/coin-modules/coin-evm/src/logic/getBlock.ts
@@ -204,7 +204,12 @@ function prefetchedTransactionToBlockTransaction(
   receipt: BlockReceiptInfo,
 ): BlockTransaction {
   const failed = receipt.status === 0;
-  const fees = BigInt(receipt.gasUsed) * BigInt(receipt.gasPrice);
+  // Some EVM chains (e.g. Cronos) omit `gasPrice` from transaction
+  // receipts. In that case, fall back to the prefetched tx's normalized `gasPrice`
+  // (the node layer provides `0` when the raw `eth_getBlockByNumber(_, true)` payload omits it).
+  const receiptGasPrice = BigInt(receipt.gasPrice);
+  const gasPrice = receiptGasPrice > 0n ? receiptGasPrice : BigInt(tx.gasPrice);
+  const fees = BigInt(receipt.gasUsed) * gasPrice;
   const operations = rpcTransactionToBlockOperations({
     from: tx.from,
     to: tx.to,

--- a/libs/coin-modules/coin-evm/src/network/node/rpc.common.ts
+++ b/libs/coin-modules/coin-evm/src/network/node/rpc.common.ts
@@ -444,7 +444,13 @@ async function getBlockByHeight(
         `Block ${blockHeight} contains malformed prefetched transaction at index ${index}`,
       );
 
-    const rawTx = tx as { data?: string };
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const rawTx = tx as unknown as {
+      data?: string;
+      // ethers v6: gasPrice is null for EIP-1559 (type-2) transactions
+      gasPrice?: bigint | null;
+      maxFeePerGas?: bigint | null;
+    };
     return {
       hash: tx.hash,
       value: tx.value.toString(),
@@ -453,6 +459,8 @@ async function getBlockByHeight(
       ...(rawTx.data !== null && rawTx.data !== undefined && isSmartContractInput(rawTx.data)
         ? { input: rawTx.data }
         : {}),
+      // EIP-1559 transactions have gasPrice: null; fall back to maxFeePerGas then 0
+      gasPrice: (rawTx.gasPrice ?? rawTx.maxFeePerGas ?? 0n).toString(),
     };
   });
 
@@ -546,6 +554,10 @@ async function getBlockByHeightFromRawRpc(
             throw new Error(
               "Malformed prefetched transaction value in eth_getBlockByNumber response",
             );
+          if ("gasPrice" in tx && tx.gasPrice !== undefined && typeof tx.gasPrice !== "string")
+            throw new Error(
+              "Malformed prefetched transaction gasPrice in eth_getBlockByNumber response",
+            );
           if (
             "input" in tx &&
             tx.input !== undefined &&
@@ -564,6 +576,7 @@ async function getBlockByHeightFromRawRpc(
             ...("input" in tx && typeof tx.input === "string" && isSmartContractInput(tx.input)
               ? { input: tx.input }
               : {}),
+            gasPrice: BigInt(tx.gasPrice ?? "0x0").toString(),
           };
         })
       : undefined;
@@ -703,6 +716,13 @@ function isPrefetchedBlockTransaction(value: unknown): value is PrefetchedBlockT
     "hash" in value &&
     "value" in value &&
     "from" in value &&
+    // gasPrice is intentionally not required: EIP-1559 (type-2) transactions have gasPrice: null
+    // in ethers v6, and the mapping falls back to maxFeePerGas ?? 0n
+    ("gasPrice" in value
+      ? value.gasPrice === null ||
+        typeof value.gasPrice === "bigint" ||
+        typeof value.gasPrice === "string"
+      : true) &&
     ("to" in value
       ? typeof value.to === "string" || value.to === null || value.to === undefined
       : true) &&

--- a/libs/coin-modules/coin-evm/src/network/node/rpc.test.ts
+++ b/libs/coin-modules/coin-evm/src/network/node/rpc.test.ts
@@ -802,6 +802,7 @@ describe("EVM Family", () => {
             value: 1n,
             from: "0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d",
             to: "0xc2907efcce4011c491bbeda8a0fa63ba7aab596c",
+            gasPrice: "0",
           },
         ],
       } as any);
@@ -817,6 +818,7 @@ describe("EVM Family", () => {
             value: "1",
             from: "0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d",
             to: "0xc2907efcce4011c491bbeda8a0fa63ba7aab596c",
+            gasPrice: "0",
           },
         ],
         transactionHashes: ["0xtx1"],
@@ -890,6 +892,7 @@ describe("EVM Family", () => {
             value: "0",
             from: "0x993aad80e425c646dab305381ff105169feedf67",
             to: "0x0000000000000000000000000000000000010003",
+            gasPrice: "0",
           },
         ],
       });
@@ -918,6 +921,32 @@ describe("EVM Family", () => {
           hash: "0x435b00d28a10febbcfefbdea080134d08ef843df122d5bc9174b09de7fce6a59",
           gasUsed: "500000",
           gasPrice: "1000000000",
+          status: 1,
+          erc20Transfers: [],
+        },
+      ]);
+    });
+
+    it("should resolve gasPrice to '0' when receipt has neither effectiveGasPrice nor gasPrice (Cronos-shaped receipt)", async () => {
+      jest.spyOn(JsonRpcProvider.prototype, "send").mockImplementationOnce(async method => {
+        if (method === "eth_getBlockReceipts") {
+          return [
+            {
+              transactionHash: "0x435b00d28a10febbcfefbdea080134d08ef843df122d5bc9174b09de7fce6a59",
+              gasUsed: "0x5208", // 21000
+              // no effectiveGasPrice, no gasPrice
+              status: "0x1",
+              logs: [],
+            },
+          ];
+        }
+        throw new Error(`Method not mocked: ${method}`);
+      });
+      expect(await nodeApi.getBlockReceipts!(fakeCurrency as CryptoCurrency, 1)).toEqual([
+        {
+          hash: "0x435b00d28a10febbcfefbdea080134d08ef843df122d5bc9174b09de7fce6a59",
+          gasUsed: "21000",
+          gasPrice: "0", // zeroed because neither effectiveGasPrice nor gasPrice were present
           status: 1,
           erc20Transfers: [],
         },

--- a/libs/coin-modules/coin-evm/src/network/node/types.ts
+++ b/libs/coin-modules/coin-evm/src/network/node/types.ts
@@ -144,7 +144,7 @@ export type TransactionInfo = {
 
 export type PrefetchedBlockTransaction = Pick<
   TransactionInfo,
-  "hash" | "value" | "from" | "to" | "input"
+  "hash" | "value" | "from" | "to" | "input" | "gasPrice"
 >;
 
 export type BlockReceiptInfo = Pick<


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Here's a concrete, minimal fix in @ledgerhq/coin-evm. It keeps the receipt as the primary source of truth (so EIP-1559 effectiveGasPrice still wins) and adds a fall back to the tx's gasPrice — which is always present on the prefetched tx object returned by eth_getBlockByNumber(_, true), even on Cronos.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29711](https://ledgerhq.atlassian.net/browse/LIVE-29711)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-29711]: https://ledgerhq.atlassian.net/browse/LIVE-29711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ