### PR TITLE
[LWD] chore: remove right panel from /cryptos and rename 'add address' button

### DIFF
--- a/.changeset/silent-hats-jam.md
+++ b/.changeset/silent-hats-jam.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix cryptos page account CTA key and hide swap sidebar on /cryptos

--- a/apps/ledger-live-desktop/src/mvvm/components/Page/__tests__/utils.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/Page/__tests__/utils.test.ts
@@ -55,7 +55,7 @@ describe("Page utils", () => {
     it("returns true only for routes that show the swap sidebar", () => {
       expect(shouldDisplayRightPanel("/")).toBe(true);
       expect(shouldDisplayRightPanel("/analytics")).toBe(true);
-      expect(shouldDisplayRightPanel("/cryptos")).toBe(true);
+      expect(shouldDisplayRightPanel("/cryptos")).toBe(false);
     });
 
     it("returns false for other wallet 4.0 pages", () => {

--- a/apps/ledger-live-desktop/src/mvvm/components/Page/utils.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/Page/utils.ts
@@ -67,7 +67,7 @@ export const isWallet40Page = (pathname: string, options: IsWallet40PageOptions 
 /**
  * Pages that display the right panel (swap sidebar).
  */
-const RIGHT_PANEL_PAGES = new Set<string>(["/", "/analytics", "/cryptos"]);
+const RIGHT_PANEL_PAGES = new Set<string>(["/", "/analytics"]);
 
 /**
  * Check if a pathname should display the right panel (swap sidebar).

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/CryptoAddressesView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/CryptoAddressesView.tsx
@@ -55,7 +55,7 @@ export function CryptoAddressesView({
               data-testid="crypto-add-address-button"
               className="shrink-0 whitespace-nowrap"
             >
-              {t("cryptoAddresses.tableActions.addAddress")}
+              {t("cryptoAddresses.tableActions.addAccount")}
             </Button>
           </TableActionBarTrailing>
         </TableActionBar>

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8453,7 +8453,7 @@
     "title": "Accounts",
     "tableActions": {
       "searchAddress": "Search by name, address",
-      "addAddress": "Add address"
+      "addAccount": "Add account"
     },
     "table": {
       "columns": {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request makes minor improvements to the cryptos page in Ledger Live Desktop. The main changes are updating the call-to-action label from "Add address" to "Add account" and ensuring the swap sidebar (right panel) is hidden on the `/cryptos` route.

https://github.com/user-attachments/assets/ea0598dc-2e9a-4df1-8b83-5208091d967b

### ❓ Context

[LIVE-30286](https://ledgerhq.atlassian.net/browse/LIVE-30286)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)




[LIVE-30286]: https://ledgerhq.atlassian.net/browse/LIVE-30286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ