### PR TITLE
test(e2e-desktop): decouple wait for data in teardown from ui

### DIFF
--- a/e2e/desktop/tests/utils/global.teardown.ts
+++ b/e2e/desktop/tests/utils/global.teardown.ts
@@ -1,7 +1,6 @@
 import { formatFlagsData, formatEnvData } from "@ledgerhq/live-common/e2e/index";
 import { writeFileSync } from "fs";
-import { ElectronApplication } from "@playwright/test";
-import { OnboardingPage } from "tests/page/onboarding.page";
+import { ElectronApplication, expect } from "@playwright/test";
 import { launchApp } from "./electronUtils";
 import { getFeatureFlags } from "./featureFlagUtils";
 
@@ -24,15 +23,47 @@ export default async function globalTeardown() {
     await page.waitForLoadState("domcontentloaded");
     await page.waitForSelector("#loader-container", { state: "hidden" });
 
-    await new OnboardingPage(page).waitForLaunch();
+    // wait for app envs to be available
+    let appEnvsString = "";
+    try {
+      await expect
+        .poll(
+          async () => {
+            const appEnvs = await page.evaluate(() => {
+              return window.getAllEnvs();
+            });
+            if (Object.keys(appEnvs).length > 0) {
+              appEnvsString = formatEnvData(appEnvs);
+            }
+            return appEnvsString.length;
+          },
+          { timeout: 30_000, intervals: [1_000] },
+        )
+        .toBeGreaterThan(0);
+    } catch (error) {
+      console.log("Failed to retrieve app envs,", error);
+    }
 
-    const featureFlags = await getFeatureFlags(page);
+    // wait for feature flags to be available
+    let featureFlagsString = "";
+    try {
+      await expect
+        .poll(
+          async () => {
+            const featureFlags = await getFeatureFlags(page);
+            if (Object.keys(featureFlags).length > 0) {
+              featureFlagsString = formatFlagsData(featureFlags);
+            }
+            return featureFlagsString.length;
+          },
+          { timeout: 30_000, intervals: [1_000] },
+        )
+        .toBeGreaterThan(0);
+    } catch (error) {
+      console.log("Failed to retrieve feature flags,", error);
+    }
 
-    const appEnvs = await page.evaluate(() => {
-      return window.getAllEnvs();
-    });
-
-    writeFileSync(environmentFilePath, formatFlagsData(featureFlags) + formatEnvData(appEnvs), {
+    writeFileSync(environmentFilePath, featureFlagsString + appEnvsString, {
       encoding: "utf8",
       flag: "a",
     });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Decouple waiting for data in the global teardown from the UI.

Testing env [regression](https://github.com/LedgerHQ/ledger-live/actions/runs/25390715473) and [report](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/d5f3721d-b361-4f22-b846-fc75b4d5264c/).
Prod env [regression](https://github.com/LedgerHQ/ledger-live/actions/runs/25390737545) and [report](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/a4581d90-d151-4a1f-8c10-e1a7a01be2a2/).

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/QAA-1196


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
