### PR TITLE
[LWDM] feat(live-common,coin-tezos): Staking account data

### DIFF
--- a/.changeset/rich-rockets-explain.md
+++ b/.changeset/rich-rockets-explain.md
@@ -4,4 +4,4 @@
 "@ledgerhq/live-common": minor
 ---
 
-Surface Tezos staking positions on the synced account: the generic alpaca `getAccountShape` now branches on a new opt-in `BridgeApi.usesStakingPositions` flag and emits the raw `Stake[]` (with `delegation-*` / `stake-*` / `unstaking-*` uid prefixes from the Paris upgrade) on `account.stakingPositions` instead of the EVM-shaped `stakingResources` aggregate. Adds `coin-tezos` `assignTo/FromAccountRaw` hooks to round-trip these positions through persistence.
+Surface Tezos staking positions on the synced account: the generic alpaca `getAccountShape` now branches on a new opt-in `BridgeApi.usesStakingPositions` flag and emits per-position entries (with `delegation-*` / `stake-*` / `unstaking-*` / `finalizable-*` uid prefixes from the Paris upgrade) on `account.stakingPositions` instead of the EVM-shaped `stakingResources` aggregate. Amounts are exposed as `BigNumber` to match the Account-side convention used by `balance`, `spendableBalance`, and `stakingResources`. Adds `coin-tezos` `assignTo/FromAccountRaw` hooks to round-trip these positions through persistence.

--- a/.changeset/rich-rockets-explain.md
+++ b/.changeset/rich-rockets-explain.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-tezos": minor
+"@ledgerhq/ledger-wallet-framework": minor
+"@ledgerhq/live-common": minor
+---
+
+Surface Tezos staking positions on the synced account: the generic alpaca `getAccountShape` now branches on a new opt-in `BridgeApi.usesStakingPositions` flag and emits the raw `Stake[]` (with `delegation-*` / `stake-*` / `unstaking-*` uid prefixes from the Paris upgrade) on `account.stakingPositions` instead of the EVM-shaped `stakingResources` aggregate. Adds `coin-tezos` `assignTo/FromAccountRaw` hooks to round-trip these positions through persistence.

--- a/libs/coin-modules/coin-tezos/src/index.ts
+++ b/libs/coin-modules/coin-tezos/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./types";
 export * from "./transaction";
+export * from "./serialization";

--- a/libs/coin-modules/coin-tezos/src/logic/getBalance.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBalance.test.ts
@@ -164,6 +164,9 @@ describe("getBalance", () => {
           HttpResponse.json({ type: "user", ...account }),
         ),
         http.get("http://tezos.explorer.com/v1/tokens/balances", () => HttpResponse.json([])),
+        http.get("http://tezos.explorer.com/v1/staking/unstake_requests", () =>
+          HttpResponse.json([]),
+        ),
       );
     }
 
@@ -286,6 +289,53 @@ describe("getBalance", () => {
           amount: 10n,
         },
       });
+    });
+
+    it("splits unstakedBalance into deactivating and finalizable Stakes when finalizable > 0", async () => {
+      mockServer.use(
+        http.get(`http://tezos.explorer.com/v1/accounts/${address}`, () =>
+          HttpResponse.json({
+            type: "user",
+            balance: 100,
+            unstakedBalance: 50,
+            delegate: { address: delegateAddress },
+          }),
+        ),
+        http.get("http://tezos.explorer.com/v1/staking/unstake_requests", () =>
+          HttpResponse.json([20, 10]),
+        ),
+        http.get("http://tezos.explorer.com/v1/tokens/balances", () => HttpResponse.json([])),
+      );
+
+      const result = await getBalance(address);
+
+      const stakes = result.filter(b => b.stake).map(b => b.stake);
+      expect(stakes).toEqual([
+        {
+          uid: `delegation-${address}`,
+          address,
+          delegate: delegateAddress,
+          state: "active",
+          asset: { type: "native" },
+          amount: 100n,
+        },
+        {
+          uid: `unstaking-${address}`,
+          address,
+          delegate: delegateAddress,
+          state: "deactivating",
+          asset: { type: "native" },
+          amount: 20n,
+        },
+        {
+          uid: `finalizable-${address}`,
+          address,
+          delegate: delegateAddress,
+          state: "inactive",
+          asset: { type: "native" },
+          amount: 30n,
+        },
+      ]);
     });
 
     it("returns only the primary native Balance when no staking activity", async () => {

--- a/libs/coin-modules/coin-tezos/src/logic/getBalance.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBalance.ts
@@ -6,8 +6,8 @@ import { buildStakesForAccount } from "./getStakes";
  * Returns the balances of the given address as an array of Balance objects.
  * The first entry represents the native balance (with value 0n for empty accounts).
  * For delegated/staked accounts, additional native entries are appended carrying each
- * staking position (delegation, active staking, deactivating unstake) per the Paris upgrade.
- * Token balances are appended after.
+ * staking position (delegation, active staking, deactivating unstake, finalizable
+ * unstake) per the Paris upgrade. Token balances are appended after.
  */
 export async function getBalance(address: string): Promise<Balance[]> {
   const [apiAccountResult, tokensBalancesResult] = await Promise.allSettled([
@@ -24,9 +24,16 @@ export async function getBalance(address: string): Promise<Balance[]> {
     tokensBalancesResult.status === "fulfilled" ? tokensBalancesResult.value : [];
   const normalized = apiAccount.type === "user" ? BigInt(apiAccount.balance) : 0n;
 
+  // Finalizable unstakes are not on the account endpoint; query them only when the
+  // account has an unstaked balance, otherwise the result is necessarily 0n.
+  const finalizable =
+    apiAccount.type === "user" && (apiAccount.unstakedBalance ?? 0) > 0
+      ? await api.getUnstakeRequestsFinalizable(address)
+      : 0n;
+
   const stakeBalances: Balance[] =
     apiAccount.type === "user"
-      ? buildStakesForAccount(address, apiAccount).map(stake => ({
+      ? buildStakesForAccount(address, apiAccount, finalizable).map(stake => ({
           value: stake.amount,
           asset: { type: "native" },
           stake,

--- a/libs/coin-modules/coin-tezos/src/logic/getStakes.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getStakes.test.ts
@@ -17,9 +17,11 @@ describe("getStakes", () => {
   });
 
   const mockGetAccountByAddress = jest.spyOn(tzktApi, "getAccountByAddress");
+  const mockGetUnstakeRequestsFinalizable = jest.spyOn(tzktApi, "getUnstakeRequestsFinalizable");
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetUnstakeRequestsFinalizable.mockResolvedValue(0n);
 
     coinConfig.setCoinConfig(() => ({
       status: { type: "active" },
@@ -265,6 +267,117 @@ describe("getStakes", () => {
           amount: 10n,
         },
       ]);
+    });
+  });
+
+  describe("finalizable unstakes", () => {
+    const address = "tz1FinalizableStaker";
+    const delegateAddress = "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx";
+
+    function makeAccount(overrides: Record<string, unknown> = {}) {
+      return {
+        type: "user" as const,
+        address,
+        publicKey: "edpk...",
+        balance: 1000,
+        revealed: true,
+        counter: 0,
+        delegationLevel: 0,
+        delegationTime: "2026-01-01T00:00:00Z",
+        numTransactions: 0,
+        firstActivityTime: "2026-01-01T00:00:00Z",
+        ...overrides,
+      };
+    }
+
+    it("splits unstakedBalance into deactivating and finalizable when finalizable > 0", async () => {
+      mockGetAccountByAddress.mockResolvedValue(
+        makeAccount({
+          balance: 1000,
+          unstakedBalance: 100,
+          delegate: { alias: "B", address: delegateAddress, active: true },
+        }),
+      );
+      mockGetUnstakeRequestsFinalizable.mockResolvedValue(40n);
+
+      const result = await api.getStakes(address);
+
+      expect(result.items).toEqual([
+        {
+          uid: `delegation-${address}`,
+          address,
+          delegate: delegateAddress,
+          state: "active",
+          asset: { type: "native" },
+          amount: 1000n,
+        },
+        {
+          uid: `unstaking-${address}`,
+          address,
+          delegate: delegateAddress,
+          state: "deactivating",
+          asset: { type: "native" },
+          amount: 60n,
+        },
+        {
+          uid: `finalizable-${address}`,
+          address,
+          delegate: delegateAddress,
+          state: "inactive",
+          asset: { type: "native" },
+          amount: 40n,
+        },
+      ]);
+    });
+
+    it("emits only finalizable when the entire unstakedBalance is finalizable", async () => {
+      mockGetAccountByAddress.mockResolvedValue(
+        makeAccount({ balance: 1000, unstakedBalance: 100 }),
+      );
+      mockGetUnstakeRequestsFinalizable.mockResolvedValue(100n);
+
+      const result = await api.getStakes(address);
+
+      expect(result.items).toEqual([
+        {
+          uid: `finalizable-${address}`,
+          address,
+          state: "inactive",
+          asset: { type: "native" },
+          amount: 100n,
+        },
+      ]);
+    });
+
+    it("clamps finalizable to unstakedBalance when the two endpoints momentarily disagree", async () => {
+      // A `finalize_unstake` landing between the two TzKT calls could make
+      // `finalizable` exceed the still-cached `unstakedBalance`. Prevent a negative
+      // `unstaking-*` amount.
+      mockGetAccountByAddress.mockResolvedValue(
+        makeAccount({ balance: 1000, unstakedBalance: 30 }),
+      );
+      mockGetUnstakeRequestsFinalizable.mockResolvedValue(50n);
+
+      const result = await api.getStakes(address);
+
+      expect(result.items).toEqual([
+        {
+          uid: `finalizable-${address}`,
+          address,
+          state: "inactive",
+          asset: { type: "native" },
+          amount: 30n,
+        },
+      ]);
+    });
+
+    it("skips the finalizable endpoint entirely when unstakedBalance is 0", async () => {
+      mockGetAccountByAddress.mockResolvedValue(makeAccount({ balance: 1000 }));
+
+      const result = await api.getStakes(address);
+
+      expect(result.items).toEqual([]);
+      expect(mockGetUnstakeRequestsFinalizable).not.toHaveBeenCalled();
     });
   });
 });

--- a/libs/coin-modules/coin-tezos/src/logic/getStakes.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getStakes.test.ts
@@ -372,7 +372,7 @@ describe("getStakes", () => {
     });
 
     it("skips the finalizable endpoint entirely when unstakedBalance is 0", async () => {
-      mockGetAccountByAddress.mockResolvedValue(makeAccount({ balance: 1000 }));
+      mockGetAccountByAddress.mockResolvedValue(makeAccount({ balance: 1000, unstakedBalance: 0 }));
 
       const result = await api.getStakes(address);
 

--- a/libs/coin-modules/coin-tezos/src/logic/getStakes.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getStakes.ts
@@ -23,7 +23,7 @@ type APIUserAccount = Extract<APIAccount, { type: "user" }>;
 export function buildStakesForAccount(
   address: string,
   account: APIUserAccount,
-  finalizable: bigint = 0n,
+  finalizable: bigint,
 ): Stake[] {
   const balance = BigInt(account.balance ?? 0);
   const stakedBalance = BigInt(account.stakedBalance ?? 0);
@@ -85,8 +85,6 @@ export async function getStakes(address: string, _cursor?: Cursor): Promise<Page
   const accountInfo = await api.getAccountByAddress(address);
   if (accountInfo.type !== "user") return { items: [] };
   const finalizable =
-    (accountInfo.unstakedBalance ?? 0) > 0
-      ? await api.getUnstakeRequestsFinalizable(address)
-      : 0n;
+    (accountInfo.unstakedBalance ?? 0) > 0 ? await api.getUnstakeRequestsFinalizable(address) : 0n;
   return { items: buildStakesForAccount(address, accountInfo, finalizable) };
 }

--- a/libs/coin-modules/coin-tezos/src/logic/getStakes.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getStakes.ts
@@ -8,15 +8,28 @@ type APIUserAccount = Extract<APIAccount, { type: "user" }>;
  * Build the staking positions exposed by a Tezos account, per Paris upgrade semantics:
  * - delegation position (when a delegate is set) for the non-staked, delegated amount
  * - active staking position (when `stakedBalance > 0`)
- * - deactivating unstake position (when `unstakedBalance > 0`)
+ * - deactivating unstake position (still in the unlock-cycle delay)
+ * - finalizable unstake position (delay elapsed; ready for `finalize_unstake`)
+ *
+ * `account.unstakedBalance` (per TzKT) is the SUPERSET of pending + finalizable unstakes.
+ * `finalizable` is queried separately (see `api.getUnstakeRequestsFinalizable`); the
+ * `unstaking-*` position carries the still-locked remainder. Clamping guards against the
+ * non-transactional gap between the two TzKT calls (a `finalize_unstake` landing in
+ * between could otherwise drive `unstakedBalance - finalizable` negative).
  *
  * Each entry inherits the account `delegate` when set, since on Tezos a staked or unstaked
  * portion is necessarily delegated to the same baker as the rest of the balance.
  */
-export function buildStakesForAccount(address: string, account: APIUserAccount): Stake[] {
+export function buildStakesForAccount(
+  address: string,
+  account: APIUserAccount,
+  finalizable: bigint = 0n,
+): Stake[] {
   const balance = BigInt(account.balance ?? 0);
   const stakedBalance = BigInt(account.stakedBalance ?? 0);
-  const unstakedBalance = BigInt(account.unstakedBalance ?? 0);
+  const unstakedTotal = BigInt(account.unstakedBalance ?? 0);
+  const finalizableAmount = finalizable < unstakedTotal ? finalizable : unstakedTotal;
+  const stillDeactivating = unstakedTotal - finalizableAmount;
   const delegateAddress = account.delegate?.address;
 
   const stakes: Stake[] = [];
@@ -43,14 +56,25 @@ export function buildStakesForAccount(address: string, account: APIUserAccount):
     });
   }
 
-  if (unstakedBalance > 0n) {
+  if (stillDeactivating > 0n) {
     stakes.push({
       uid: `unstaking-${address}`,
       address,
       ...(delegateAddress && { delegate: delegateAddress }),
       state: "deactivating",
       asset: { type: "native" },
-      amount: unstakedBalance,
+      amount: stillDeactivating,
+    });
+  }
+
+  if (finalizableAmount > 0n) {
+    stakes.push({
+      uid: `finalizable-${address}`,
+      address,
+      ...(delegateAddress && { delegate: delegateAddress }),
+      state: "inactive",
+      asset: { type: "native" },
+      amount: finalizableAmount,
     });
   }
 
@@ -60,5 +84,9 @@ export function buildStakesForAccount(address: string, account: APIUserAccount):
 export async function getStakes(address: string, _cursor?: Cursor): Promise<Page<Stake>> {
   const accountInfo = await api.getAccountByAddress(address);
   if (accountInfo.type !== "user") return { items: [] };
-  return { items: buildStakesForAccount(address, accountInfo) };
+  const finalizable =
+    (accountInfo.unstakedBalance ?? 0) > 0
+      ? await api.getUnstakeRequestsFinalizable(address)
+      : 0n;
+  return { items: buildStakesForAccount(address, accountInfo, finalizable) };
 }

--- a/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
@@ -19,11 +19,14 @@ jest.mock("./estimateFees", () => ({
 
 const mockGetAccountByAddress = jest.fn();
 const mockGetTokensBalances = jest.fn();
+const mockGetUnstakeRequestsFinalizable = jest.fn();
 jest.mock("../network/tzkt", () => ({
   __esModule: true,
   default: {
     getAccountByAddress: (...args: unknown[]) => mockGetAccountByAddress(...args),
     getTokensBalances: (...args: unknown[]) => mockGetTokensBalances(...args),
+    getUnstakeRequestsFinalizable: (...args: unknown[]) =>
+      mockGetUnstakeRequestsFinalizable(...args),
   },
 }));
 
@@ -71,6 +74,7 @@ describe("validateIntent", () => {
 
     mockGetAccountByAddress.mockResolvedValue(makeUserAccount());
     mockGetTokensBalances.mockResolvedValue([]);
+    mockGetUnstakeRequestsFinalizable.mockResolvedValue(0n);
   });
 
   describe("recipient validation", () => {
@@ -204,7 +208,7 @@ describe("validateIntent", () => {
     });
 
     it("uses amount 0 and only fees as totalSpent for finalize_unstake", async () => {
-      mockGetAccountByAddress.mockResolvedValue(makeUserAccount({ unstakedFinalizable: 1234 }));
+      mockGetUnstakeRequestsFinalizable.mockResolvedValue(1234n);
 
       const result = await validateIntent({
         intentType: "staking",
@@ -332,7 +336,7 @@ describe("validateIntent", () => {
     });
 
     it("should return NotEnoughBalance when finalize_unstake has nothing finalizable", async () => {
-      mockGetAccountByAddress.mockResolvedValue(makeUserAccount({ unstakedFinalizable: 0 }));
+      mockGetUnstakeRequestsFinalizable.mockResolvedValue(0n);
 
       const result = await validateIntent({
         intentType: "staking",
@@ -446,7 +450,7 @@ describe("validateIntent", () => {
     });
 
     it("should pass validation for finalize_unstake transaction", async () => {
-      mockGetAccountByAddress.mockResolvedValue(makeUserAccount({ unstakedFinalizable: 4000 }));
+      mockGetUnstakeRequestsFinalizable.mockResolvedValue(4000n);
 
       const result = await validateIntent({
         intentType: "staking",

--- a/libs/coin-modules/coin-tezos/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/validateIntent.ts
@@ -71,63 +71,67 @@ function validateBasicSendParams(intent: TransactionIntent): Record<string, Erro
   return errors;
 }
 
-/**
- * Validates specific transaction constraints based on account state
- */
-function validateTransactionConstraints(
+// send max not allowed on delegated accounts (must undelegate acc first); native XTZ only
+function validateSendConstraints(
   intent: TransactionIntent,
   senderInfo: APIUserAccount,
 ): Record<string, Error> {
-  const errors: Record<string, Error> = {};
-
-  // send max not allowed on delegated accounts (must undelegate acc first); native XTZ only
   if (
-    intent.type === "send" &&
     intent.useAllAmount &&
     resolveValidationOperationMode(intent) === "send" &&
     senderInfo.delegate?.address
   ) {
-    errors.amount = new RecommendUndelegation();
+    return { amount: new RecommendUndelegation() };
   }
+  return {};
+}
 
-  if (intent.type === "stake") {
-    if (!senderInfo.delegate?.address) {
-      errors.amount = new MustDelegateBeforeStaking();
-      return errors;
-    }
-
-    const amountError = validateStrictlyPositiveAmount(intent.amount);
-    if (amountError) {
-      errors.amount = amountError;
-    }
+function validateStakeConstraints(
+  intent: TransactionIntent,
+  senderInfo: APIUserAccount,
+): Record<string, Error> {
+  if (!senderInfo.delegate?.address) {
+    return { amount: new MustDelegateBeforeStaking() };
   }
+  const amountError = validateStrictlyPositiveAmount(intent.amount);
+  return amountError ? { amount: amountError } : {};
+}
 
-  if (intent.type === "unstake") {
-    const stakedBalance = BigInt(senderInfo.stakedBalance ?? 0);
-    if (stakedBalance <= 0n) {
-      errors.amount = new NotEnoughBalance();
-      return errors;
-    }
-
-    const amountError = validateStrictlyPositiveAmount(intent.amount);
-    if (amountError) {
-      errors.amount = amountError;
-      return errors;
-    }
-
-    if (intent.amount > stakedBalance) {
-      errors.amount = new NotEnoughBalance();
-    }
+function validateUnstakeConstraints(
+  intent: TransactionIntent,
+  senderInfo: APIUserAccount,
+): Record<string, Error> {
+  const stakedBalance = BigInt(senderInfo.stakedBalance ?? 0);
+  if (stakedBalance <= 0n) {
+    return { amount: new NotEnoughBalance() };
   }
-
-  if (intent.type === "finalize_unstake") {
-    const unstakedFinalizable = BigInt(senderInfo.unstakedFinalizable ?? 0);
-    if (unstakedFinalizable <= 0n) {
-      errors.amount = new NotEnoughBalance();
-    }
+  const amountError = validateStrictlyPositiveAmount(intent.amount);
+  if (amountError) {
+    return { amount: amountError };
   }
+  if (intent.amount > stakedBalance) {
+    return { amount: new NotEnoughBalance() };
+  }
+  return {};
+}
 
-  return errors;
+function validateTransactionConstraints(
+  intent: TransactionIntent,
+  senderInfo: APIUserAccount,
+  finalizable: bigint,
+): Record<string, Error> {
+  switch (intent.type) {
+    case "send":
+      return validateSendConstraints(intent, senderInfo);
+    case "stake":
+      return validateStakeConstraints(intent, senderInfo);
+    case "unstake":
+      return validateUnstakeConstraints(intent, senderInfo);
+    case "finalize_unstake":
+      return finalizable <= 0n ? { amount: new NotEnoughBalance() } : {};
+    default:
+      return {};
+  }
 }
 
 /**
@@ -316,7 +320,14 @@ export async function validateIntent(intent: TransactionIntent): Promise<Transac
     const senderInfo = await api.getAccountByAddress(intent.sender);
     if (senderInfo.type !== "user") throw new Error("unexpected account type");
 
-    const constraintErrors = validateTransactionConstraints(intent, senderInfo);
+    // Finalizable amount lives on /v1/staking/unstake_requests, not the account
+    // endpoint; only `finalize_unstake` validation needs it.
+    const finalizable =
+      intent.type === "finalize_unstake"
+        ? await api.getUnstakeRequestsFinalizable(intent.sender)
+        : 0n;
+
+    const constraintErrors = validateTransactionConstraints(intent, senderInfo, finalizable);
     Object.assign(errors, constraintErrors);
 
     if (Object.keys(errors).length > 0) {

--- a/libs/coin-modules/coin-tezos/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/validateIntent.ts
@@ -115,6 +115,10 @@ function validateUnstakeConstraints(
   return {};
 }
 
+function validateFinalizeUnstakeConstraints(finalizable: bigint): Record<string, Error> {
+  return finalizable <= 0n ? { amount: new NotEnoughBalance() } : {};
+}
+
 function validateTransactionConstraints(
   intent: TransactionIntent,
   senderInfo: APIUserAccount,
@@ -128,7 +132,7 @@ function validateTransactionConstraints(
     case "unstake":
       return validateUnstakeConstraints(intent, senderInfo);
     case "finalize_unstake":
-      return finalizable <= 0n ? { amount: new NotEnoughBalance() } : {};
+      return validateFinalizeUnstakeConstraints(finalizable);
     default:
       return {};
   }

--- a/libs/coin-modules/coin-tezos/src/network/types.ts
+++ b/libs/coin-modules/coin-tezos/src/network/types.ts
@@ -12,7 +12,6 @@ export type APIAccount =
       balance: number;
       stakedBalance?: number;
       unstakedBalance?: number;
-      unstakedFinalizable?: number;
       stakingUpdatesCount?: number;
       counter: number;
       delegate?: {

--- a/libs/coin-modules/coin-tezos/src/network/tzkt.test.ts
+++ b/libs/coin-modules/coin-tezos/src/network/tzkt.test.ts
@@ -613,6 +613,39 @@ describe("tzkt network API", () => {
   });
 
   // -------------------------------------------------------------------------
+  // api.getUnstakeRequestsFinalizable
+  // -------------------------------------------------------------------------
+
+  describe("api.getUnstakeRequestsFinalizable", () => {
+    it("queries finalizable unstake requests and sums actualAmount", async () => {
+      mockedNetwork.mockReturnValue(networkResponse([100, 250, 7]) as ReturnType<typeof network>);
+
+      const result = await api.getUnstakeRequestsFinalizable("tz1abc");
+
+      expect(result).toEqual(357n);
+      expect(mockedNetwork).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: expect.stringContaining("/v1/staking/unstake_requests"),
+          params: {
+            "staker.eq": "tz1abc",
+            status: "finalizable",
+            "select.values": "actualAmount",
+            limit: 1000,
+          },
+        }),
+      );
+    });
+
+    it("returns 0n when no finalizable requests exist", async () => {
+      mockedNetwork.mockReturnValue(networkResponse([]) as ReturnType<typeof network>);
+
+      const result = await api.getUnstakeRequestsFinalizable("tz1empty");
+
+      expect(result).toEqual(0n);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // api.getTokensBalances
   // -------------------------------------------------------------------------
 

--- a/libs/coin-modules/coin-tezos/src/network/tzkt.ts
+++ b/libs/coin-modules/coin-tezos/src/network/tzkt.ts
@@ -81,6 +81,31 @@ const api = {
     });
     return data;
   },
+
+  /**
+   * Returns the total `actualAmount` (mutez) summed over the account's `finalizable`
+   * unstake requests — the portion of `unstakedBalance` whose unlock cycle has been
+   * reached and that can be reclaimed via `finalize_unstake`. The complementary
+   * `unstakedBalance - finalizable` portion is still in the deactivation delay window.
+   *
+   * TzKT's account endpoint does not expose this split, so we sum from
+   * `/v1/staking/unstake_requests`. https://api.tzkt.io/#operation/Staking_GetUnstakeRequests
+   *
+   * `limit=1000` covers any realistic number of concurrent finalizable requests for
+   * a single staker — we do not paginate.
+   */
+  async getUnstakeRequestsFinalizable(address: string): Promise<bigint> {
+    const { data } = await network<number[]>({
+      url: `${getExplorerUrl()}/v1/staking/unstake_requests`,
+      params: {
+        "staker.eq": address,
+        status: "finalizable",
+        "select.values": "actualAmount",
+        limit: 1000,
+      },
+    });
+    return data.reduce<bigint>((sum, n) => sum + BigInt(n), 0n);
+  },
   // https://api.tzkt.io/#operation/Accounts_GetOperations
   async getAccountOperations(
     address: string,

--- a/libs/coin-modules/coin-tezos/src/serialization.test.ts
+++ b/libs/coin-modules/coin-tezos/src/serialization.test.ts
@@ -1,0 +1,111 @@
+import type { Account, AccountRaw } from "@ledgerhq/types-live";
+import { assignFromAccountRaw, assignToAccountRaw } from "./serialization";
+import type { StakingPosition, TezosAccount, TezosAccountRaw } from "./types/bridge";
+
+const ADDRESS = "tz1WvvbEGpBXGeTVbLiR6DYBe1izmgiYuZbq";
+const DELEGATE = "tz1baker";
+
+const positions: StakingPosition[] = [
+  {
+    uid: `delegation-${ADDRESS}`,
+    address: ADDRESS,
+    delegate: DELEGATE,
+    state: "active",
+    asset: { type: "native" },
+    amount: 1234567890n,
+  },
+  {
+    uid: `stake-${ADDRESS}`,
+    address: ADDRESS,
+    delegate: DELEGATE,
+    state: "active",
+    asset: { type: "native" },
+    amount: 9_999_999_999_999_999_999n,
+  },
+  {
+    uid: `unstaking-${ADDRESS}`,
+    address: ADDRESS,
+    delegate: DELEGATE,
+    state: "deactivating",
+    asset: { type: "native" },
+    amount: 42n,
+  },
+];
+
+function makeAccount(positions: StakingPosition[]): TezosAccount {
+  return { stakingPositions: positions } as unknown as TezosAccount;
+}
+
+describe("coin-tezos serialization", () => {
+  test("assignToAccountRaw writes positions when present", () => {
+    const account = makeAccount(positions);
+    const raw = {} as AccountRaw;
+    assignToAccountRaw(account as unknown as Account, raw);
+    const persisted = (raw as TezosAccountRaw).stakingPositions;
+    expect(persisted).toHaveLength(3);
+    expect(persisted?.map(p => p.uid)).toEqual([
+      `delegation-${ADDRESS}`,
+      `stake-${ADDRESS}`,
+      `unstaking-${ADDRESS}`,
+    ]);
+    expect(persisted?.[1].amount).toEqual("9999999999999999999");
+  });
+
+  test("assignToAccountRaw skips writing when positions array is empty", () => {
+    const account = makeAccount([]);
+    const raw = {} as AccountRaw;
+    assignToAccountRaw(account as unknown as Account, raw);
+    expect((raw as TezosAccountRaw).stakingPositions).toBeUndefined();
+  });
+
+  test("assignFromAccountRaw rehydrates positions and reconstructs native asset", () => {
+    const raw = {
+      stakingPositions: [
+        {
+          uid: `delegation-${ADDRESS}`,
+          address: ADDRESS,
+          delegate: DELEGATE,
+          state: "active" as const,
+          amount: "1234567890",
+        },
+        {
+          uid: `unstaking-${ADDRESS}`,
+          address: ADDRESS,
+          state: "deactivating" as const,
+          amount: "42",
+        },
+      ],
+    } as AccountRaw;
+    const account = {} as Account;
+    assignFromAccountRaw(raw, account);
+    const got = (account as TezosAccount).stakingPositions;
+    expect(got).toHaveLength(2);
+    expect(got[0]).toEqual({
+      uid: `delegation-${ADDRESS}`,
+      address: ADDRESS,
+      delegate: DELEGATE,
+      state: "active",
+      asset: { type: "native" },
+      amount: 1234567890n,
+    });
+    // Stake without delegate: delegate field is omitted, not set to undefined
+    expect(got[1]).not.toHaveProperty("delegate");
+    expect(got[1].amount).toEqual(42n);
+  });
+
+  test("assignFromAccountRaw defaults to empty array when raw lacks the field", () => {
+    const raw = {} as AccountRaw;
+    const account = {} as Account;
+    assignFromAccountRaw(raw, account);
+    expect((account as TezosAccount).stakingPositions).toEqual([]);
+  });
+
+  test("round-trip preserves uid prefixes and bigint amounts exactly", () => {
+    const account = makeAccount(positions);
+    const raw = {} as AccountRaw;
+    assignToAccountRaw(account as unknown as Account, raw);
+    const restored = {} as Account;
+    assignFromAccountRaw(raw, restored);
+    expect((restored as TezosAccount).stakingPositions).toEqual(positions);
+  });
+});

--- a/libs/coin-modules/coin-tezos/src/serialization.test.ts
+++ b/libs/coin-modules/coin-tezos/src/serialization.test.ts
@@ -30,6 +30,14 @@ const positions: StakingPosition[] = [
     asset: { type: "native" },
     amount: 42n,
   },
+  {
+    uid: `finalizable-${ADDRESS}`,
+    address: ADDRESS,
+    delegate: DELEGATE,
+    state: "inactive",
+    asset: { type: "native" },
+    amount: 7n,
+  },
 ];
 
 function makeAccount(positions: StakingPosition[]): TezosAccount {
@@ -42,11 +50,12 @@ describe("coin-tezos serialization", () => {
     const raw = {} as AccountRaw;
     assignToAccountRaw(account as unknown as Account, raw);
     const persisted = (raw as TezosAccountRaw).stakingPositions;
-    expect(persisted).toHaveLength(3);
+    expect(persisted).toHaveLength(4);
     expect(persisted?.map(p => p.uid)).toEqual([
       `delegation-${ADDRESS}`,
       `stake-${ADDRESS}`,
       `unstaking-${ADDRESS}`,
+      `finalizable-${ADDRESS}`,
     ]);
     expect(persisted?.[1].amount).toEqual("9999999999999999999");
   });

--- a/libs/coin-modules/coin-tezos/src/serialization.test.ts
+++ b/libs/coin-modules/coin-tezos/src/serialization.test.ts
@@ -1,4 +1,5 @@
 import type { Account, AccountRaw } from "@ledgerhq/types-live";
+import { BigNumber } from "bignumber.js";
 import { assignFromAccountRaw, assignToAccountRaw } from "./serialization";
 import type { StakingPosition, TezosAccount, TezosAccountRaw } from "./types/bridge";
 
@@ -12,7 +13,7 @@ const positions: StakingPosition[] = [
     delegate: DELEGATE,
     state: "active",
     asset: { type: "native" },
-    amount: 1234567890n,
+    amount: new BigNumber("1234567890"),
   },
   {
     uid: `stake-${ADDRESS}`,
@@ -20,7 +21,7 @@ const positions: StakingPosition[] = [
     delegate: DELEGATE,
     state: "active",
     asset: { type: "native" },
-    amount: 9_999_999_999_999_999_999n,
+    amount: new BigNumber("9999999999999999999"),
   },
   {
     uid: `unstaking-${ADDRESS}`,
@@ -28,7 +29,7 @@ const positions: StakingPosition[] = [
     delegate: DELEGATE,
     state: "deactivating",
     asset: { type: "native" },
-    amount: 42n,
+    amount: new BigNumber("42"),
   },
   {
     uid: `finalizable-${ADDRESS}`,
@@ -36,7 +37,7 @@ const positions: StakingPosition[] = [
     delegate: DELEGATE,
     state: "inactive",
     asset: { type: "native" },
-    amount: 7n,
+    amount: new BigNumber("7"),
   },
 ];
 
@@ -95,11 +96,11 @@ describe("coin-tezos serialization", () => {
       delegate: DELEGATE,
       state: "active",
       asset: { type: "native" },
-      amount: 1234567890n,
+      amount: new BigNumber("1234567890"),
     });
     // Stake without delegate: delegate field is omitted, not set to undefined
     expect(got[1]).not.toHaveProperty("delegate");
-    expect(got[1].amount).toEqual(42n);
+    expect(got[1].amount).toEqual(new BigNumber("42"));
   });
 
   test("assignFromAccountRaw defaults to empty array when raw lacks the field", () => {

--- a/libs/coin-modules/coin-tezos/src/serialization.ts
+++ b/libs/coin-modules/coin-tezos/src/serialization.ts
@@ -1,0 +1,40 @@
+import type { Account, AccountRaw } from "@ledgerhq/types-live";
+import type {
+  StakingPosition,
+  StakingPositionRaw,
+  TezosAccount,
+  TezosAccountRaw,
+} from "./types/bridge";
+
+function toStakingPositionRaw(p: StakingPosition): StakingPositionRaw {
+  return {
+    uid: p.uid,
+    address: p.address,
+    ...(p.delegate && { delegate: p.delegate }),
+    state: p.state,
+    amount: p.amount.toString(),
+  };
+}
+
+function fromStakingPositionRaw(r: StakingPositionRaw): StakingPosition {
+  return {
+    uid: r.uid,
+    address: r.address,
+    ...(r.delegate && { delegate: r.delegate }),
+    state: r.state,
+    asset: { type: "native" },
+    amount: BigInt(r.amount),
+  };
+}
+
+export function assignToAccountRaw(account: Account, accountRaw: AccountRaw): void {
+  const positions = (account as TezosAccount).stakingPositions;
+  if (positions?.length) {
+    (accountRaw as TezosAccountRaw).stakingPositions = positions.map(toStakingPositionRaw);
+  }
+}
+
+export function assignFromAccountRaw(accountRaw: AccountRaw, account: Account): void {
+  const raw = (accountRaw as TezosAccountRaw).stakingPositions;
+  (account as TezosAccount).stakingPositions = raw ? raw.map(fromStakingPositionRaw) : [];
+}

--- a/libs/coin-modules/coin-tezos/src/serialization.ts
+++ b/libs/coin-modules/coin-tezos/src/serialization.ts
@@ -1,4 +1,5 @@
 import type { Account, AccountRaw } from "@ledgerhq/types-live";
+import { BigNumber } from "bignumber.js";
 import type {
   StakingPosition,
   StakingPositionRaw,
@@ -23,7 +24,7 @@ function fromStakingPositionRaw(r: StakingPositionRaw): StakingPosition {
     ...(r.delegate && { delegate: r.delegate }),
     state: r.state,
     asset: { type: "native" },
-    amount: BigInt(r.amount),
+    amount: new BigNumber(r.amount),
   };
 }
 

--- a/libs/coin-modules/coin-tezos/src/types/bridge.ts
+++ b/libs/coin-modules/coin-tezos/src/types/bridge.ts
@@ -98,9 +98,9 @@ export function isTezosAccount(account: Account): account is TezosAccount {
 /**
  * Persistable shape of a Tezos {@link StakingPosition}. Mirrors the framework
  * `Stake` fields populated by `buildStakesForAccount` (uid prefix encodes the
- * staking kind: delegation-* / stake-* / unstaking-*); `bigint` amounts are
- * serialized as decimal strings, and `asset` is omitted because Tezos stakes
- * are always native and the field is reconstructed on read.
+ * staking kind: delegation-* / stake-* / unstaking-* / finalizable-*); `bigint`
+ * amounts are serialized as decimal strings, and `asset` is omitted because Tezos
+ * stakes are always native and the field is reconstructed on read.
  */
 export type StakingPositionRaw = {
   uid: string;

--- a/libs/coin-modules/coin-tezos/src/types/bridge.ts
+++ b/libs/coin-modules/coin-tezos/src/types/bridge.ts
@@ -86,7 +86,18 @@ export type Delegation = {
   sendShouldWarnDelegation: boolean;
 };
 
-export type StakingPosition = Stake;
+/**
+ * Tezos staking position as exposed on the synced account (front-side shape).
+ * Mirrors the framework `Stake` populated by `buildStakesForAccount` but uses
+ * `BigNumber` to match the Account-side convention shared with `balance`,
+ * `spendableBalance`, and the `stakingResources` aggregate used by other coins.
+ */
+export type StakingPosition = Omit<Stake, "amount" | "amountDeposited" | "amountRewarded"> & {
+  amount: BigNumber;
+  amountDeposited?: BigNumber;
+  amountRewarded?: BigNumber;
+};
+
 export type TezosAccount = Account & {
   tezosResources: TezosResources;
   stakingPositions: StakingPosition[];
@@ -96,9 +107,8 @@ export function isTezosAccount(account: Account): account is TezosAccount {
 }
 
 /**
- * Persistable shape of a Tezos {@link StakingPosition}. Mirrors the framework
- * `Stake` fields populated by `buildStakesForAccount` (uid prefix encodes the
- * staking kind: delegation-* / stake-* / unstaking-* / finalizable-*); `bigint`
+ * Persistable shape of a Tezos {@link StakingPosition}. uid prefix encodes the
+ * staking kind: delegation-* / stake-* / unstaking-* / finalizable-*; `BigNumber`
  * amounts are serialized as decimal strings, and `asset` is omitted because Tezos
  * stakes are always native and the field is reconstructed on read.
  */

--- a/libs/coin-modules/coin-tezos/src/types/bridge.ts
+++ b/libs/coin-modules/coin-tezos/src/types/bridge.ts
@@ -95,8 +95,24 @@ export function isTezosAccount(account: Account): account is TezosAccount {
   return "tezosResources" in account;
 }
 
+/**
+ * Persistable shape of a Tezos {@link StakingPosition}. Mirrors the framework
+ * `Stake` fields populated by `buildStakesForAccount` (uid prefix encodes the
+ * staking kind: delegation-* / stake-* / unstaking-*); `bigint` amounts are
+ * serialized as decimal strings, and `asset` is omitted because Tezos stakes
+ * are always native and the field is reconstructed on read.
+ */
+export type StakingPositionRaw = {
+  uid: string;
+  address: string;
+  delegate?: string;
+  state: "inactive" | "activating" | "active" | "deactivating";
+  amount: string;
+};
+
 export type TezosAccountRaw = AccountRaw & {
   tezosResources: TezosResourcesRaw;
+  stakingPositions?: StakingPositionRaw[];
 };
 
 export type TransactionStatus = TransactionStatusCommon;

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/accountRawAssign.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/accountRawAssign.ts
@@ -1,5 +1,6 @@
 import type { AccountBridge } from "@ledgerhq/types-live";
 import evmAccountRawAssign from "./families/evm/accountRawAssign";
+import tezosAccountRawAssign from "./families/tezos/accountRawAssign";
 import type { GenericTransaction } from "./types";
 
 type AccountRawAssignHooks = {
@@ -18,6 +19,8 @@ export function getAccountRawAssignHooks(network: string): AccountRawAssignHooks
   switch (network) {
     case "evm":
       return evmAccountRawAssign;
+    case "tezos":
+      return tezosAccountRawAssign;
     default:
       return {};
   }

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/families/tezos/accountRawAssign.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/families/tezos/accountRawAssign.ts
@@ -1,0 +1,14 @@
+import { assignFromAccountRaw, assignToAccountRaw } from "@ledgerhq/coin-tezos/serialization";
+
+/**
+ * Tezos-specific hooks that persist `stakingPositions` through the
+ * `fromAccountRaw` / `toAccountRaw` cycle (the default generic-coin-framework
+ * pipeline does not serialize family-specific account resources).
+ *
+ * Mirrors the EVM adapter pattern (`families/evm/accountRawAssign.ts`),
+ * keeping `generic-coin-framework/accountRawAssign.ts` family-agnostic.
+ */
+export default {
+  assignFromAccountRaw,
+  assignToAccountRaw,
+};

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/families/tezos/bridge.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/families/tezos/bridge.ts
@@ -25,4 +25,5 @@ export function getAssetFromToken(token: TokenCurrency, owner: string): AssetInf
 export default {
   getTokenFromAsset,
   getAssetFromToken,
+  usesStakingPositions: true,
 } satisfies BridgeApi;

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
@@ -160,7 +160,7 @@ function syntheticParentForTokenOnlyTx(
   // In the case of smart contract interaction, the contract must be the recipient of the parent operation => this
   // is why we need to extract this information from the operation details.
   const contract = getTokenContract(referenceOp);
-  const parentRecipients = contract !== undefined ? [contract] : (referenceOp.recipients ?? []);
+  const parentRecipients = contract === undefined ? (referenceOp.recipients ?? []) : [contract];
   const parentSenders = referenceOp.senders ?? [];
   return cleanedOperation({
     id: encodeOperationId(accountId, referenceOp.hash, parentType),
@@ -373,17 +373,24 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
         0n,
       );
 
-      const delegations: StakingDelegation[] = activeStakes.filter(hasStakeDelegate).map(b => ({
-        validatorAddress: b.stake.delegate,
-        amount: new BigNumber(delegatedAmountForStakingResources(b).toString()),
-        pendingRewards: new BigNumber((b.stake.amountRewarded ?? 0n).toString()),
-        status: "bonded" as const,
-      }));
-      const unbondings: StakingUnbonding[] = deactivatingStakes.filter(hasStakeDelegate).map(b => ({
-        validatorAddress: b.stake.delegate,
-        amount: new BigNumber(delegatedAmountForStakingResources(b).toString()),
-        completionDate: b.stake.stateUpdatedAt ?? new Date(),
-      }));
+      const delegations: StakingDelegation[] = activeStakes.filter(hasStakeDelegate).map(b => {
+        const delegated: bigint = delegatedAmountForStakingResources(b);
+        const rewarded: bigint = b.stake.amountRewarded ?? 0n;
+        return {
+          validatorAddress: b.stake.delegate,
+          amount: new BigNumber(delegated.toString()),
+          pendingRewards: new BigNumber(rewarded.toString()),
+          status: "bonded" as const,
+        };
+      });
+      const unbondings: StakingUnbonding[] = deactivatingStakes.filter(hasStakeDelegate).map(b => {
+        const delegated: bigint = delegatedAmountForStakingResources(b);
+        return {
+          validatorAddress: b.stake.delegate,
+          amount: new BigNumber(delegated.toString()),
+          completionDate: b.stake.stateUpdatedAt ?? new Date(),
+        };
+      });
       stakingResources = {
         delegations,
         redelegations: [],

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
@@ -63,6 +63,31 @@ function delegatedAmountForStakingResources(b: Balance): bigint {
   return b.stake?.amount ?? 0n;
 }
 
+/**
+ * On-Account shape for `stakingPositions`: framework `Stake` with `bigint`
+ * amounts converted to `BigNumber`, matching the convention used elsewhere on
+ * the Account (`balance`, `spendableBalance`, `stakingResources.*`).
+ */
+type StakingPositionOnAccount = Omit<Stake, "amount" | "amountDeposited" | "amountRewarded"> & {
+  amount: BigNumber;
+  amountDeposited?: BigNumber;
+  amountRewarded?: BigNumber;
+};
+
+function toStakingPositionOnAccount(stake: Stake): StakingPositionOnAccount {
+  const { amount, amountDeposited, amountRewarded, ...rest } = stake;
+  return {
+    ...rest,
+    amount: new BigNumber(amount.toString()),
+    ...(amountDeposited !== undefined && {
+      amountDeposited: new BigNumber(amountDeposited.toString()),
+    }),
+    ...(amountRewarded !== undefined && {
+      amountRewarded: new BigNumber(amountRewarded.toString()),
+    }),
+  };
+}
+
 /** True when the op is a main-account (native) op, not a token/sub-account op */
 function isNativeLiveOp(operation: OperationCommon): boolean {
   const assetReference = operation.extra?.assetReference;
@@ -160,7 +185,7 @@ function syntheticParentForTokenOnlyTx(
   // In the case of smart contract interaction, the contract must be the recipient of the parent operation => this
   // is why we need to extract this information from the operation details.
   const contract = getTokenContract(referenceOp);
-  const parentRecipients = contract === undefined ? (referenceOp.recipients ?? []) : [contract];
+  const parentRecipients = contract === undefined ? referenceOp.recipients ?? [] : [contract];
   const parentSenders = referenceOp.senders ?? [];
   return cleanedOperation({
     id: encodeOperationId(accountId, referenceOp.hash, parentType),
@@ -349,13 +374,15 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
     const spendableBalance = nativeBalance - nativeLocked;
 
     let stakingResources: StakingResources | undefined;
-    let stakingPositions: Stake[] = [];
+    let stakingPositions: StakingPositionOnAccount[] = [];
     let delegationsCount = 0;
     let unbondingsCount = 0;
     if (usesStakingPositions) {
-      // Per-stake positions preserved as-is so the UI can group by uid prefix
-      // (delegation-* / stake-* / unstaking-*).
-      stakingPositions = balanceRes.filter(hasStake).map(b => b.stake);
+      // Per-stake positions preserved so the UI can group by uid prefix
+      // (delegation-* / stake-* / unstaking-* / finalizable-*). `bigint` framework
+      // amounts are converted to `BigNumber` to match the Account-side convention
+      // (balance, spendableBalance, stakingResources also use BigNumber).
+      stakingPositions = balanceRes.filter(hasStake).map(b => toStakingPositionOnAccount(b.stake));
     } else {
       const activeStakes = balanceRes.filter(hasActiveStake);
       const deactivatingStakes = balanceRes.filter(hasDeactivatingStake);
@@ -473,7 +500,10 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
     const operations = mergeOps(syncFromScratch ? [] : oldOps, newOperations) as OperationCommon[];
     const stakingEnabled =
       alpacaApi.stakingSupported ?? (delegationsCount > 0 || unbondingsCount > 0);
-    let stakingShape: { stakingResources?: StakingResources; stakingPositions?: Stake[] } = {};
+    let stakingShape: {
+      stakingResources?: StakingResources;
+      stakingPositions?: StakingPositionOnAccount[];
+    } = {};
     if (usesStakingPositions) {
       stakingShape = { stakingPositions };
     } else if (stakingEnabled) {
@@ -481,7 +511,7 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
     }
     const res: Partial<Account> & {
       stakingResources?: StakingResources;
-      stakingPositions?: Stake[];
+      stakingPositions?: StakingPositionOnAccount[];
     } = {
       id: accountId,
       xpub: address,

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
@@ -37,6 +37,10 @@ function isInternalLiveOp(operation: OperationCommon): boolean {
   return !!operation.extra?.internal;
 }
 
+function hasStake(balance: Balance): balance is Balance & { stake: Stake } {
+  return balance.stake !== undefined;
+}
+
 function hasActiveStake(balance: Balance): balance is Balance & {
   stake: Stake & { state: "active" | "activating" };
 } {
@@ -56,8 +60,7 @@ function hasStakeDelegate<T extends Balance & { stake: Stake }>(
 }
 
 function delegatedAmountForStakingResources(b: Balance): bigint {
-  if (!b.stake) return 0n;
-  return typeof b.stake.amount === "bigint" ? b.stake.amount : 0n;
+  return b.stake?.amount ?? 0n;
 }
 
 /** True when the op is a main-account (native) op, not a token/sub-account op */
@@ -336,49 +339,63 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
     const nativeAsset = extractBalance(balanceRes, "native");
     const allTokenAssetsBalances = balanceRes.filter(b => b.asset.type !== "native");
 
-    const activeStakes = balanceRes.filter(hasActiveStake);
-    const deactivatingStakes = balanceRes.filter(hasDeactivatingStake);
-
-    const delegatedBalance = activeStakes.reduce(
-      (acc, b) => acc + delegatedAmountForStakingResources(b),
-      0n,
-    );
-    const unbondingBalance = deactivatingStakes.reduce(
-      (acc, b) => acc + delegatedAmountForStakingResources(b),
-      0n,
-    );
-    const pendingRewardsBalance = activeStakes.reduce(
-      (acc, b) => acc + (b.stake.amountRewarded ?? 0n),
-      0n,
-    );
+    const usesStakingPositions = bridgeApi.usesStakingPositions === true;
 
     const nativeBalance = nativeAsset?.value ?? 0n;
     const nativeLocked = nativeAsset?.locked ?? 0n;
 
     // balance reflects only the native available balance.
-    // Staked/unbonding amounts are tracked separately in stakingResources.
+    // Staked/unbonding amounts are tracked separately (stakingResources or stakingPositions).
     const spendableBalance = nativeBalance - nativeLocked;
 
-    const delegations: StakingDelegation[] = activeStakes.filter(hasStakeDelegate).map(b => ({
-      validatorAddress: b.stake.delegate,
-      amount: new BigNumber(delegatedAmountForStakingResources(b).toString()),
-      pendingRewards: new BigNumber((b.stake.amountRewarded ?? 0n).toString()),
-      status: "bonded" as const,
-    }));
-    const unbondings: StakingUnbonding[] = deactivatingStakes.filter(hasStakeDelegate).map(b => ({
-      validatorAddress: b.stake.delegate,
-      amount: new BigNumber(delegatedAmountForStakingResources(b).toString()),
-      completionDate: b.stake.stateUpdatedAt ?? new Date(),
-    }));
-    const stakingResources: StakingResources = {
-      delegations,
-      redelegations: [],
-      unbondings,
-      delegatedBalance: new BigNumber(delegatedBalance.toString()),
-      pendingRewardsBalance: new BigNumber(pendingRewardsBalance.toString()),
-      unbondingBalance: new BigNumber(unbondingBalance.toString()),
-      ...(validators.length > 0 ? { validators } : {}),
-    };
+    let stakingResources: StakingResources | undefined;
+    let stakingPositions: Stake[] = [];
+    let delegationsCount = 0;
+    let unbondingsCount = 0;
+    if (usesStakingPositions) {
+      // Per-stake positions preserved as-is so the UI can group by uid prefix
+      // (delegation-* / stake-* / unstaking-*).
+      stakingPositions = balanceRes.filter(hasStake).map(b => b.stake);
+    } else {
+      const activeStakes = balanceRes.filter(hasActiveStake);
+      const deactivatingStakes = balanceRes.filter(hasDeactivatingStake);
+
+      const delegatedBalance = activeStakes.reduce(
+        (acc, b) => acc + delegatedAmountForStakingResources(b),
+        0n,
+      );
+      const unbondingBalance = deactivatingStakes.reduce(
+        (acc, b) => acc + delegatedAmountForStakingResources(b),
+        0n,
+      );
+      const pendingRewardsBalance = activeStakes.reduce(
+        (acc, b) => acc + (b.stake.amountRewarded ?? 0n),
+        0n,
+      );
+
+      const delegations: StakingDelegation[] = activeStakes.filter(hasStakeDelegate).map(b => ({
+        validatorAddress: b.stake.delegate,
+        amount: new BigNumber(delegatedAmountForStakingResources(b).toString()),
+        pendingRewards: new BigNumber((b.stake.amountRewarded ?? 0n).toString()),
+        status: "bonded" as const,
+      }));
+      const unbondings: StakingUnbonding[] = deactivatingStakes.filter(hasStakeDelegate).map(b => ({
+        validatorAddress: b.stake.delegate,
+        amount: new BigNumber(delegatedAmountForStakingResources(b).toString()),
+        completionDate: b.stake.stateUpdatedAt ?? new Date(),
+      }));
+      stakingResources = {
+        delegations,
+        redelegations: [],
+        unbondings,
+        delegatedBalance: new BigNumber(delegatedBalance.toString()),
+        pendingRewardsBalance: new BigNumber(pendingRewardsBalance.toString()),
+        unbondingBalance: new BigNumber(unbondingBalance.toString()),
+        ...(validators.length > 0 ? { validators } : {}),
+      };
+      delegationsCount = delegations.length;
+      unbondingsCount = unbondings.length;
+    }
 
     // Normalize pre-alpaca operations to the new accountId to keep UI rendering consistent
     const oldOps = ((initialAccount?.operations || []) as OperationCommon[]).map(op =>
@@ -448,8 +465,17 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
     const newOperations = [...confirmedOperations, ...newOpsWithSubs];
     const operations = mergeOps(syncFromScratch ? [] : oldOps, newOperations) as OperationCommon[];
     const stakingEnabled =
-      alpacaApi.stakingSupported ?? (delegations.length > 0 || unbondings.length > 0);
-    const res: Partial<Account> & { stakingResources?: StakingResources } = {
+      alpacaApi.stakingSupported ?? (delegationsCount > 0 || unbondingsCount > 0);
+    let stakingShape: { stakingResources?: StakingResources; stakingPositions?: Stake[] } = {};
+    if (usesStakingPositions) {
+      stakingShape = { stakingPositions };
+    } else if (stakingEnabled) {
+      stakingShape = { stakingResources };
+    }
+    const res: Partial<Account> & {
+      stakingResources?: StakingResources;
+      stakingPositions?: Stake[];
+    } = {
       id: accountId,
       xpub: address,
       blockHeight: operations.length === 0 ? 0 : blockInfo.height || initialAccount?.blockHeight,
@@ -459,7 +485,7 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
       subAccounts,
       operationsCount: operations.length,
       syncHash,
-      ...(stakingEnabled ? { stakingResources } : {}),
+      ...stakingShape,
     };
     return res;
   };

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getAccountShape.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getAccountShape.test.ts
@@ -27,14 +27,17 @@ jest.mock("../api", () => ({
     refreshOperations: (...a: any[]) => refreshOperationsMock(...a),
   }),
 }));
+const getBridgeApiMock = jest.fn();
 jest.mock("../bridge", () => ({
-  getBridgeApi: () => ({
-    getTokenFromAsset: getTokenFromAssetMock,
-    getChainSpecificRules: () => ({
-      getAccountShape: (...a: any[]) => chainSpecificGetAccountShapeMock(...a),
-    }),
-  }),
+  getBridgeApi: (...a: any[]) => getBridgeApiMock(...a),
 }));
+const defaultBridgeApi = () => ({
+  getTokenFromAsset: getTokenFromAssetMock,
+  getChainSpecificRules: () => ({
+    getAccountShape: (...a: any[]) => chainSpecificGetAccountShapeMock(...a),
+  }),
+});
+getBridgeApiMock.mockImplementation(defaultBridgeApi);
 
 const adaptCoreOperationToLiveOperationMock = jest.fn();
 const extractBalanceMock = jest.fn();
@@ -988,6 +991,210 @@ describe("genericGetAccountShape", () => {
       // delegatedBalance and delegation.amount use stake.amount (80), not b.value (100)
       expect((result as any).stakingResources?.delegatedBalance).toEqual(new BigNumber(80));
       expect((result as any).stakingResources?.delegations[0]?.amount).toEqual(new BigNumber(80));
+    });
+
+    test("usesStakingPositions: surfaces raw Stake[] preserving uid prefixes; no stakingResources", async () => {
+      getSyncHashMock.mockReturnValue("sync-hash");
+      extractBalanceMock.mockReturnValue({ value: 1000n, locked: 0n });
+      // Three balance rows mirroring buildStakesForAccount output: delegation-* / stake-* / unstaking-*
+      const stakes = [
+        {
+          uid: "delegation-tz1abc",
+          address: "tz1abc",
+          delegate: "tz1baker",
+          state: "active" as const,
+          asset: { type: "native" as const },
+          amount: 700n,
+        },
+        {
+          uid: "stake-tz1abc",
+          address: "tz1abc",
+          delegate: "tz1baker",
+          state: "active" as const,
+          asset: { type: "native" as const },
+          amount: 300n,
+        },
+        {
+          uid: "unstaking-tz1abc",
+          address: "tz1abc",
+          delegate: "tz1baker",
+          state: "deactivating" as const,
+          asset: { type: "native" as const },
+          amount: 50n,
+        },
+      ];
+      getBalanceMock.mockResolvedValue([
+        { asset: { type: "native" }, value: 1000n },
+        ...stakes.map(stake => ({ asset: { type: "native" }, value: stake.amount, stake })),
+      ]);
+      listOperationsMock.mockResolvedValue({ items: [], next: undefined });
+      buildSubAccountsMock.mockReturnValue([]);
+      inferSubOperationsMock.mockReturnValue([]);
+      lastBlockMock.mockResolvedValue({ height: 1 });
+      mergeOpsMock.mockImplementation((_old: unknown[], newOps: unknown[]) => newOps);
+      cleanedOperationMock.mockImplementation((op: unknown) => op);
+      chainSpecificGetAccountShapeMock.mockImplementation(() => {});
+
+      // Override the bridge mock to opt into the stakingPositions shape (Tezos config)
+      getBridgeApiMock.mockImplementationOnce(() => ({
+        ...defaultBridgeApi(),
+        usesStakingPositions: true,
+      }));
+
+      const getShape = genericGetAccountShape("mainnet", "tezos");
+      const result = await getShape(
+        {
+          address: "tz1abc",
+          initialAccount: undefined,
+          currency: { id: "tezos", name: "Tezos", family: "tezos" },
+          derivationMode: "",
+        } as any,
+        { paginationConfig: {} as any },
+      );
+
+      const positions = (result as any).stakingPositions;
+      expect(positions).toHaveLength(3);
+      expect(positions.map((p: any) => p.uid)).toEqual([
+        "delegation-tz1abc",
+        "stake-tz1abc",
+        "unstaking-tz1abc",
+      ]);
+      // bigint amounts preserved exactly, not coerced
+      expect(positions[0].amount).toBe(700n);
+      expect(positions[1].amount).toBe(300n);
+      expect(positions[2].amount).toBe(50n);
+      // Tezos opts out of the EVM-shaped aggregate
+      expect((result as any).stakingResources).toBeUndefined();
+    });
+
+    test("usesStakingPositions: empty stakes => empty stakingPositions, no stakingResources", async () => {
+      // Account has never delegated/staked: balanceRes carries only the primary native row.
+      getSyncHashMock.mockReturnValue("sync-hash");
+      extractBalanceMock.mockReturnValue({ value: 1000n, locked: 0n });
+      getBalanceMock.mockResolvedValue([{ asset: { type: "native" }, value: 1000n }]);
+      listOperationsMock.mockResolvedValue({ items: [], next: undefined });
+      buildSubAccountsMock.mockReturnValue([]);
+      inferSubOperationsMock.mockReturnValue([]);
+      lastBlockMock.mockResolvedValue({ height: 1 });
+      mergeOpsMock.mockImplementation((_old: unknown[], newOps: unknown[]) => newOps);
+      cleanedOperationMock.mockImplementation((op: unknown) => op);
+      chainSpecificGetAccountShapeMock.mockImplementation(() => {});
+
+      getBridgeApiMock.mockImplementationOnce(() => ({
+        ...defaultBridgeApi(),
+        usesStakingPositions: true,
+      }));
+
+      const getShape = genericGetAccountShape("mainnet", "tezos");
+      const result = await getShape(
+        {
+          address: "tz1empty",
+          initialAccount: undefined,
+          currency: { id: "tezos", name: "Tezos", family: "tezos" },
+          derivationMode: "",
+        } as any,
+        { paginationConfig: {} as any },
+      );
+
+      // Field is always emitted (the synced TezosAccount type requires it), even when empty
+      expect((result as any).stakingPositions).toEqual([]);
+      expect((result as any).stakingResources).toBeUndefined();
+    });
+
+    test("usesStakingPositions: preserves the available subset when only some kinds are present", async () => {
+      // Account has delegated but never opted into staking: only `delegation-*` is present.
+      // The `stake-*` and `unstaking-*` prefixes are absent and must NOT be synthesized.
+      getSyncHashMock.mockReturnValue("sync-hash");
+      extractBalanceMock.mockReturnValue({ value: 1000n, locked: 0n });
+      const delegation = {
+        uid: "delegation-tz1abc",
+        address: "tz1abc",
+        delegate: "tz1baker",
+        state: "active" as const,
+        asset: { type: "native" as const },
+        amount: 1000n,
+      };
+      getBalanceMock.mockResolvedValue([
+        { asset: { type: "native" }, value: 1000n },
+        { asset: { type: "native" }, value: delegation.amount, stake: delegation },
+      ]);
+      listOperationsMock.mockResolvedValue({ items: [], next: undefined });
+      buildSubAccountsMock.mockReturnValue([]);
+      inferSubOperationsMock.mockReturnValue([]);
+      lastBlockMock.mockResolvedValue({ height: 1 });
+      mergeOpsMock.mockImplementation((_old: unknown[], newOps: unknown[]) => newOps);
+      cleanedOperationMock.mockImplementation((op: unknown) => op);
+      chainSpecificGetAccountShapeMock.mockImplementation(() => {});
+
+      getBridgeApiMock.mockImplementationOnce(() => ({
+        ...defaultBridgeApi(),
+        usesStakingPositions: true,
+      }));
+
+      const getShape = genericGetAccountShape("mainnet", "tezos");
+      const result = await getShape(
+        {
+          address: "tz1abc",
+          initialAccount: undefined,
+          currency: { id: "tezos", name: "Tezos", family: "tezos" },
+          derivationMode: "",
+        } as any,
+        { paginationConfig: {} as any },
+      );
+
+      const positions = (result as any).stakingPositions;
+      expect(positions).toHaveLength(1);
+      expect(positions[0].uid).toBe("delegation-tz1abc");
+      expect(positions[0].amount).toBe(1000n);
+      expect((result as any).stakingResources).toBeUndefined();
+    });
+
+    test("usesStakingPositions: passes through stakes without `delegate` (e.g. unstake after redelegate)", async () => {
+      // Per buildStakesForAccount: `stake-*` and `unstaking-*` only carry `delegate` when
+      // `delegateAddress` is currently set; the field is omitted otherwise. Verify the
+      // pass-through preserves that omission rather than synthesizing it.
+      getSyncHashMock.mockReturnValue("sync-hash");
+      extractBalanceMock.mockReturnValue({ value: 1000n, locked: 0n });
+      const unstaking = {
+        uid: "unstaking-tz1abc",
+        address: "tz1abc",
+        // no delegate
+        state: "deactivating" as const,
+        asset: { type: "native" as const },
+        amount: 50n,
+      };
+      getBalanceMock.mockResolvedValue([
+        { asset: { type: "native" }, value: 1000n },
+        { asset: { type: "native" }, value: unstaking.amount, stake: unstaking },
+      ]);
+      listOperationsMock.mockResolvedValue({ items: [], next: undefined });
+      buildSubAccountsMock.mockReturnValue([]);
+      inferSubOperationsMock.mockReturnValue([]);
+      lastBlockMock.mockResolvedValue({ height: 1 });
+      mergeOpsMock.mockImplementation((_old: unknown[], newOps: unknown[]) => newOps);
+      cleanedOperationMock.mockImplementation((op: unknown) => op);
+      chainSpecificGetAccountShapeMock.mockImplementation(() => {});
+
+      getBridgeApiMock.mockImplementationOnce(() => ({
+        ...defaultBridgeApi(),
+        usesStakingPositions: true,
+      }));
+
+      const getShape = genericGetAccountShape("mainnet", "tezos");
+      const result = await getShape(
+        {
+          address: "tz1abc",
+          initialAccount: undefined,
+          currency: { id: "tezos", name: "Tezos", family: "tezos" },
+          derivationMode: "",
+        } as any,
+        { paginationConfig: {} as any },
+      );
+
+      const positions = (result as any).stakingPositions;
+      expect(positions).toHaveLength(1);
+      expect(positions[0]).not.toHaveProperty("delegate");
+      expect(positions[0].uid).toBe("unstaking-tz1abc");
     });
 
     test("Case 1: simple native transfer between EOAs", async () => {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getAccountShape.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getAccountShape.test.ts
@@ -1059,10 +1059,10 @@ describe("genericGetAccountShape", () => {
         "stake-tz1abc",
         "unstaking-tz1abc",
       ]);
-      // bigint amounts preserved exactly, not coerced
-      expect(positions[0].amount).toBe(700n);
-      expect(positions[1].amount).toBe(300n);
-      expect(positions[2].amount).toBe(50n);
+      // bigint framework amounts converted to BigNumber to match Account-side convention
+      expect(positions[0].amount).toEqual(new BigNumber(700));
+      expect(positions[1].amount).toEqual(new BigNumber(300));
+      expect(positions[2].amount).toEqual(new BigNumber(50));
       // Tezos opts out of the EVM-shaped aggregate
       expect((result as any).stakingResources).toBeUndefined();
     });
@@ -1145,7 +1145,7 @@ describe("genericGetAccountShape", () => {
       const positions = (result as any).stakingPositions;
       expect(positions).toHaveLength(1);
       expect(positions[0].uid).toBe("delegation-tz1abc");
-      expect(positions[0].amount).toBe(1000n);
+      expect(positions[0].amount).toEqual(new BigNumber(1000));
       expect((result as any).stakingResources).toBeUndefined();
     });
 

--- a/libs/ledger-live-common/src/families/tezos/react.ts
+++ b/libs/ledger-live-common/src/families/tezos/react.ts
@@ -69,7 +69,7 @@ export function useStakingPositions(account: AccountLike): StakingPosition[] {
         delegate: delegation.address,
         state: "active" as const,
         asset: { type: "native" as const },
-        amount: BigInt(account.balance.toString()),
+        amount: account.balance,
       },
     ];
   }, [account, delegation]);

--- a/libs/ledger-wallet-framework/src/api/types.ts
+++ b/libs/ledger-wallet-framework/src/api/types.ts
@@ -20,5 +20,13 @@ export type BridgeApi = {
    * Whether the chain surfaces staking data through `getBalance`
    */
   stakingSupported?: boolean;
+  /**
+   * When true, the chain consumes per-stake positions via
+   * `account.stakingPositions` (raw `Stake[]` from `getBalance`) instead of
+   * the EVM-style `stakingResources` aggregate. Used by chains where each
+   * stake position must be preserved individually (e.g., Tezos Paris upgrade
+   * distinguishes delegation vs staking vs unstaking via uid prefix).
+   */
+  usesStakingPositions?: boolean;
   balanceOptions?: BalanceOptions;
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Tezos accounts: synced TezosAccount now exposes stakingPositions: Stake[] (one entry per delegation-* / stake-* / unstaking-* / finalizable-* uid prefix) instead of the EVM-shaped stakingResources aggregate. Positions persist through account save/restore.
  - New TzKT call: GET /v1/staking/unstake_requests?status=finalizable is fired conditionally during getBalance / getStakes when unstakedBalance > 0, to split the finalizable amount out of the still-deactivating remainder.
  - Other chains: no behavioral change — BridgeApi.usesStakingPositions is opt-in and defaults off; only Tezos sets it.
  - QA focus: Tezos sync (delegation only / staked only / unstaking only / finalizable only / mixed / empty), Tezos persist+reload preserves all 4 uid prefixes and bigint amounts, accounts with no unstaked balance must NOT trigger the new /v1/staking/unstake_requests call, regression check on EVM-family staking unchanged. Note: in practice finalizable-* is rarely populated on mainnet because auto-staking auto-finalizes at the unlock cycle; the position primarily materializes for fully-undelegated unstakers.

### 📝 Description

Phase 2 of the Tezos Paris-upgrade staking integration (LIVE-30016). Surfaces the per-position Stake[] produced by Phase 1's getStakes (and embedded in getBalance rows) onto the synced TezosAccount, so UI hooks (LIVE-29472) can group by uid prefix.

The generic alpaca getAccountShape now branches on a new opt-in BridgeApi.usesStakingPositions flag. When set, it emits raw Stake[] on account.stakingPositions (uid prefixes intact, bigint amounts preserved). When unset, the existing EVM aggregation into stakingResources is unchanged. Tezos opts in via families/tezos/bridge.ts. Persistence is wired through new coin-tezos/serialization.ts hooks dispatched from families/tezos/accountRawAssign.ts, mirroring the EVM adapter pattern.

TzKT does not expose the finalizable portion of unstakedBalance on its account endpoint, so a separate query against /v1/staking/unstake_requests?status=finalizable is summed into a 4th finalizable-* Stake (state "inactive"); the existing unstaking-* carries the still-locked remainder (unstakedBalance - finalizable, clamped). The query is gated on unstakedBalance > 0, so non-staking accounts pay no extra round-trip.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29471](https://ledgerhq.atlassian.net/browse/LIVE-29471?atlOrigin=eyJpIjoiYjM3NDk4ZWFlMDVhNGVjYzhmMGE3NGY5ZTA2NjdiN2QiLCJwIjoiaiJ9)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-30016]: https://ledgerhq.atlassian.net/browse/LIVE-30016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LIVE-29471]: https://ledgerhq.atlassian.net/browse/LIVE-29471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ