### PR TITLE
[LWD] fix(desktop): sync Recover subscription state

### DIFF
--- a/.changeset/orange-spiders-repair.md
+++ b/.changeset/orange-spiders-repair.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix: use redux to monitor recover subscription state changes

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -311,6 +311,9 @@ apps/ledger-live-desktop/src/renderer/hooks/useActionCards.tsx                  
 apps/ledger-live-desktop/src/renderer/hooks/useNotifications.ts                                @ledgerhq/engagement
 apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts                                        @ledgerhq/engagement
 apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/BrazeTools/          @ledgerhq/engagement
+apps/ledger-live-desktop/src/renderer/hooks/useRecoverBannerState.ts                           @ledgerhq/engagement
+apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/syncRecoverStateFromStorageSet.ts @ledgerhq/engagement
+apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/__tests__/syncRecoverStateFromStorageSet.test.ts @ledgerhq/engagement
 apps/ledger-live-desktop/src/renderer/screens/dashboard/ActionContentCards.tsx                 @ledgerhq/engagement
 apps/ledger-live-desktop/src/renderer/screens/dashboard/components/Banners/hooks/**/useBannersVisibility*.ts @ledgerhq/engagement
 apps/ledger-live-desktop/src/renderer/screens/dashboard/components/Banners/PortfolioBannerContent/ @ledgerhq/engagement
@@ -319,6 +322,8 @@ apps/ledger-live-desktop/src/renderer/reducers/dynamicContent.ts                
 apps/ledger-live-desktop/src/renderer/actions/dynamicContent.ts                                @ledgerhq/engagement
 apps/ledger-live-desktop/src/types/dynamicContent.ts                                           @ledgerhq/engagement
 apps/ledger-live-desktop/src/braze-setup.ts                                                    @ledgerhq/engagement
+apps/ledger-live-desktop/src/renderer/reducers/recoverState.ts                                 @ledgerhq/engagement
+apps/ledger-live-desktop/src/renderer/reducers/dynamicContent.ts                               @ledgerhq/engagement
 apps/ledger-live-desktop/src/mvvm/features/DynamicContent/                                     @ledgerhq/engagement
 apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/                                          @ledgerhq/engagement
 apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/                               @ledgerhq/engagement

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__tests__/useRecoverWidgetViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__tests__/useRecoverWidgetViewModel.test.ts
@@ -9,7 +9,6 @@ import { DeviceModelId } from "@ledgerhq/types-devices";
 import { useRecoverWidgetViewModel } from "LLD/features/FinishOnboarding/RecoverWidget/useRecoverWidgetViewModel";
 import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
 
-/** Real `electron-store` is not usable in Jest; keep persistence at the boundary. */
 jest.mock("~/renderer/store", () => ({
   getStoreValue: jest.fn(),
   setStoreValue: jest.fn(),
@@ -30,13 +29,14 @@ const mockNavigate = jest.fn();
 const mockUseNavigate = jest.mocked(useNavigate);
 const mockUsePostOnboardingHubState = jest.mocked(usePostOnboardingHubState);
 const mockUseFeature = jest.mocked(useFeature);
-const mockGetStoreValue = jest.mocked(getStoreValue);
 const mockIsRecoverDisplayed = jest.mocked(isRecoverDisplayed);
 const mockUseUpsellPath = jest.mocked(useUpsellPath);
+const mockGetStoreValue = jest.mocked(getStoreValue);
+const PROTECT_ID = "protect-prod";
 const recoverFeature = {
   enabled: true,
   params: {
-    protectId: "protect-prod",
+    protectId: PROTECT_ID,
     compatibleDevices: [{ name: DeviceModelId.stax, available: true }],
   },
 };
@@ -53,6 +53,27 @@ function setHub(overrides: {
   });
 }
 
+function withRecoverState(
+  subscriptionState: LedgerRecoverSubscriptionStateEnum,
+  displayBanner = true,
+) {
+  return {
+    recoverState: {
+      protectIdState: {
+        [PROTECT_ID]: { subscriptionState, displayBanner },
+      },
+    },
+  };
+}
+
+function renderRecoverWidgetViewModel(
+  subscriptionState = LedgerRecoverSubscriptionStateEnum.STARGATE_SUBSCRIBE,
+) {
+  return renderHook(() => useRecoverWidgetViewModel(), {
+    initialState: withRecoverState(subscriptionState),
+  });
+}
+
 describe("useRecoverWidgetViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -60,13 +81,12 @@ describe("useRecoverWidgetViewModel", () => {
     mockUseFeature.mockReturnValue(recoverFeature);
     mockUseUpsellPath.mockReturnValue("/protect/upsell");
     mockIsRecoverDisplayed.mockReturnValue(true);
+    mockGetStoreValue.mockReturnValue(undefined);
     setHub({});
-
-    mockGetStoreValue.mockReturnValue(LedgerRecoverSubscriptionStateEnum.STARGATE_SUBSCRIBE);
   });
 
   it("returns isVisible true when recover flow is in progress and the offer is available", async () => {
-    const { result } = renderHook(() => useRecoverWidgetViewModel());
+    const { result } = renderRecoverWidgetViewModel();
 
     await waitFor(() => {
       expect(result.current.isVisible).toBe(true);
@@ -74,48 +94,59 @@ describe("useRecoverWidgetViewModel", () => {
   });
 
   it("returns isVisible false when subscription is NO_SUBSCRIPTION (never started recover)", async () => {
-    mockGetStoreValue.mockReturnValue(LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION);
-    const { result } = renderHook(() => useRecoverWidgetViewModel());
+    const { result } = renderRecoverWidgetViewModel(
+      LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION,
+    );
 
     await waitFor(() => {
-      expect(mockGetStoreValue).toHaveBeenCalled();
+      expect(result.current.isVisible).toBe(false);
     });
-    expect(result.current.isVisible).toBe(false);
   });
 
-  it("returns isVisible false when subscription state is undefined", async () => {
-    mockGetStoreValue.mockReturnValue(undefined);
+  it("returns isVisible false when subscription state is not hydrated", async () => {
     const { result } = renderHook(() => useRecoverWidgetViewModel());
 
     await waitFor(() => {
-      expect(mockGetStoreValue).toHaveBeenCalled();
+      expect(result.current.isVisible).toBe(false);
     });
-    expect(result.current.isVisible).toBe(false);
+  });
+
+  it("returns isVisible true after rehydrating subscription state from storage", async () => {
+    mockGetStoreValue.mockImplementation((key: string) => {
+      if (key === "SUBSCRIPTION_STATE") {
+        return LedgerRecoverSubscriptionStateEnum.STARGATE_SUBSCRIBE;
+      }
+      return undefined;
+    });
+
+    const { result } = renderHook(() => useRecoverWidgetViewModel());
+
+    await waitFor(() => {
+      expect(result.current.isVisible).toBe(true);
+    });
+    expect(mockGetStoreValue).toHaveBeenCalledWith("SUBSCRIPTION_STATE", PROTECT_ID);
   });
 
   it("returns isVisible true when post-onboarding hub is not in progress but recover criteria are met", async () => {
     setHub({ postOnboardingInProgress: false });
-    const { result } = renderHook(() => useRecoverWidgetViewModel());
+    const { result } = renderRecoverWidgetViewModel();
 
     await waitFor(() => {
-      expect(mockGetStoreValue).toHaveBeenCalled();
+      expect(result.current.isVisible).toBe(true);
     });
-    expect(result.current.isVisible).toBe(true);
   });
 
   it("returns isVisible false when recover is not offered for this device", async () => {
     mockIsRecoverDisplayed.mockReturnValue(false);
-    const { result } = renderHook(() => useRecoverWidgetViewModel());
+    const { result } = renderRecoverWidgetViewModel();
 
     await waitFor(() => {
-      expect(mockGetStoreValue).toHaveBeenCalled();
+      expect(result.current.isVisible).toBe(false);
     });
-    expect(result.current.isVisible).toBe(false);
   });
 
   it("returns isVisible false when backup is already done", async () => {
-    mockGetStoreValue.mockReturnValue(LedgerRecoverSubscriptionStateEnum.BACKUP_DONE);
-    const { result } = renderHook(() => useRecoverWidgetViewModel());
+    const { result } = renderRecoverWidgetViewModel(LedgerRecoverSubscriptionStateEnum.BACKUP_DONE);
 
     await waitFor(() => {
       expect(result.current.isVisible).toBe(false);
@@ -124,16 +155,15 @@ describe("useRecoverWidgetViewModel", () => {
 
   it("returns isVisible false when there is no upsell path", async () => {
     mockUseUpsellPath.mockReturnValue(undefined);
-    const { result } = renderHook(() => useRecoverWidgetViewModel());
+    const { result } = renderRecoverWidgetViewModel();
 
     await waitFor(() => {
-      expect(mockGetStoreValue).toHaveBeenCalled();
+      expect(result.current.isVisible).toBe(false);
     });
-    expect(result.current.isVisible).toBe(false);
   });
 
   it("navigates to the upsell path and tracks when the CTA is used", async () => {
-    const { result } = renderHook(() => useRecoverWidgetViewModel());
+    const { result } = renderRecoverWidgetViewModel();
     await waitFor(() => {
       expect(result.current.isVisible).toBe(true);
     });

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/useRecoverWidgetViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/useRecoverWidgetViewModel.ts
@@ -1,11 +1,10 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { useNavigate } from "react-router";
 import { isRecoverDisplayed, useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { useUpsellPath } from "@ledgerhq/live-common/hooks/recoverFeatureFlag";
 import { usePostOnboardingHubState } from "@ledgerhq/live-common/postOnboarding/hooks/index";
-import { getStoreValue } from "~/renderer/store";
+import { useRecoverBannerState } from "~/renderer/hooks/useRecoverBannerState";
 import { track } from "~/renderer/analytics/segment";
-import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
 import { shouldShowRecoverPortfolioWidget } from "./recoverPortfolioWidgetVisibility";
 
 const TRACK = {
@@ -31,25 +30,9 @@ export function useRecoverWidgetViewModel(): RecoverWidgetViewProps {
   const { deviceModelId } = usePostOnboardingHubState();
 
   const protectId = recoverServices?.params?.protectId ?? "protect-prod";
-  const [subscriptionState, setSubscriptionState] = useState<LedgerRecoverSubscriptionStateEnum | undefined>(
-    () => {
-      try {
-        return getStoreValue<LedgerRecoverSubscriptionStateEnum>("SUBSCRIPTION_STATE", protectId);
-      } catch {
-        return undefined;
-      }
-    },
-  );
-
-  useEffect(() => {
-    try {
-      setSubscriptionState(
-        getStoreValue<LedgerRecoverSubscriptionStateEnum>("SUBSCRIPTION_STATE", protectId),
-      );
-    } catch {
-      setSubscriptionState(undefined);
-    }
-  }, [protectId]);
+  const {
+    data: { subscriptionState },
+  } = useRecoverBannerState(protectId);
 
   const isRecoverOfferAvailable = isRecoverDisplayed(recoverServices, deviceModelId ?? undefined);
 

--- a/apps/ledger-live-desktop/src/renderer/components/MainSideBar/RecoverStatusDot.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/MainSideBar/RecoverStatusDot.tsx
@@ -1,10 +1,10 @@
-import React, { useCallback, useEffect, useState } from "react";
-import { getStoreValue } from "~/renderer/store";
+import React from "react";
 import { LedgerRecoverSubscriptionStateInProgressEnum } from "~/types/recoverSubscriptionState";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { Box, Icons } from "@ledgerhq/react-ui";
 import useTheme from "~/renderer/hooks/useTheme";
 import styled, { keyframes, css } from "styled-components";
+import { useRecoverBannerState } from "~/renderer/hooks/useRecoverBannerState";
 
 interface RecoverStatusNotificationProps {
   collapsed: boolean;
@@ -48,11 +48,11 @@ const StyledBox = styled(Box)<{
   transform: translateY(0);
   opacity: 0;
   animation: ${p =>
-    p.collapsed
-      ? css`
+      p.collapsed
+        ? css`
             ${collapseAnim}
           `
-      : css`
+        : css`
             ${openAnim}
           `}
     200ms 500ms ease forwards;
@@ -62,20 +62,10 @@ const RecoverStatusDot = ({ collapsed }: RecoverStatusNotificationProps) => {
   const { colors } = useTheme();
   const recoverServices = useFeature("protectServicesDesktop");
   const protectID = recoverServices?.params?.protectId ?? "protect-prod";
-  const [displayRecoverDot, setDisplayRecoverDot] = useState<boolean>();
-
-  const getRecoverSubscriptionState = useCallback(async () => {
-    const storage = await getStoreValue("SUBSCRIPTION_STATE", protectID);
-    setDisplayRecoverDot(
-      Object.values(LedgerRecoverSubscriptionStateInProgressEnum).includes(
-        storage as LedgerRecoverSubscriptionStateInProgressEnum,
-      ),
-    );
-  }, [protectID]);
-
-  useEffect(() => {
-    getRecoverSubscriptionState();
-  }, [getRecoverSubscriptionState]);
+  const {
+    data: { subscriptionState },
+  } = useRecoverBannerState(protectID);
+  const displayRecoverDot = subscriptionState in LedgerRecoverSubscriptionStateInProgressEnum;
 
   return displayRecoverDot ? (
     <StyledBox collapsed={collapsed}>

--- a/apps/ledger-live-desktop/src/renderer/components/RecoverBanner/RecoverBanner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/RecoverBanner/RecoverBanner.tsx
@@ -1,8 +1,7 @@
 import { Flex, ProgressLoader, Text, Icons } from "@ledgerhq/react-ui";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useMemo } from "react";
 import { useNavigate } from "react-router";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
-import { getStoreValue, setStoreValue } from "~/renderer/store";
 import { useCustomPath } from "@ledgerhq/live-common/hooks/recoverFeatureFlag";
 import { useTranslation } from "react-i18next";
 import { RecoverBannerType } from "./types";
@@ -11,6 +10,7 @@ import { Card } from "../Box";
 import styled from "styled-components";
 import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
 import useTheme from "~/renderer/hooks/useTheme";
+import { useRecoverBannerState } from "~/renderer/hooks/useRecoverBannerState";
 
 const maxStepNumber = Object.keys(LedgerRecoverSubscriptionStateEnum).length;
 
@@ -24,26 +24,11 @@ const Wrapper = styled(Card)`
  */
 export default function RecoverBanner({ children }: { children?: React.ReactNode }) {
   const { colors } = useTheme();
-  const [storageData, setStorageData] = useState<LedgerRecoverSubscriptionStateEnum>(
-    LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION,
-  );
-  const [displayBannerData, setDisplayBannerData] = useState<boolean>();
-  const [stepNumber, setStepNumber] = useState<number>(0);
 
   const recoverServices = useFeature("protectServicesDesktop");
   const recoverBannerIsEnabled = recoverServices?.params?.bannerSubscriptionNotification;
   const protectID = recoverServices?.params?.protectId ?? "protect-prod";
-
-  const getStorageSubscriptionState = useCallback(async () => {
-    const storage = await getStoreValue("SUBSCRIPTION_STATE", protectID);
-    const displayBanner = await getStoreValue("DISPLAY_BANNER", protectID);
-    setStorageData(storage as LedgerRecoverSubscriptionStateEnum);
-    setDisplayBannerData(displayBanner === "true");
-  }, [protectID]);
-
-  useEffect(() => {
-    getStorageSubscriptionState();
-  }, [getStorageSubscriptionState]);
+  const { data, dismissBanner } = useRecoverBannerState(protectID);
 
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -55,44 +40,39 @@ export default function RecoverBanner({ children }: { children?: React.ReactNode
     "recover-launch",
   );
 
-  const recoverBannerSelected: RecoverBannerType | undefined = useMemo(() => {
+  const { recoverBannerSelected, stepNumber } = useMemo<{
+    recoverBannerSelected?: RecoverBannerType;
+    stepNumber: number;
+  }>(() => {
     let recoverBannerWording: RecoverBannerType;
 
-    switch (storageData) {
+    switch (data.subscriptionState) {
       case LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION:
-        setStepNumber(1);
-        return undefined;
+        return { stepNumber: 1 };
       case LedgerRecoverSubscriptionStateEnum.STARGATE_SUBSCRIBE:
-        setStepNumber(2);
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         recoverBannerWording = t("dashboard.recoverBanner.subscribeDone", {
           returnObjects: true,
         }) as RecoverBannerType;
-        break;
+        return { recoverBannerSelected: recoverBannerWording, stepNumber: 2 };
       case LedgerRecoverSubscriptionStateEnum.BACKUP_VERIFY_IDENTITY:
-        setStepNumber(3);
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         recoverBannerWording = t("dashboard.recoverBanner.verifyIdentity", {
           returnObjects: true,
         }) as RecoverBannerType;
-        break;
+        return { recoverBannerSelected: recoverBannerWording, stepNumber: 3 };
       case LedgerRecoverSubscriptionStateEnum.BACKUP_DEVICE_CONNECTION:
-        setStepNumber(4);
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         recoverBannerWording = t("dashboard.recoverBanner.connectDevice", {
           returnObjects: true,
         }) as RecoverBannerType;
-        break;
+        return { recoverBannerSelected: recoverBannerWording, stepNumber: 4 };
       case LedgerRecoverSubscriptionStateEnum.BACKUP_DONE:
-        setStepNumber(5);
-        return undefined;
+        return { stepNumber: 5 };
       default:
-        setStepNumber(0);
-        return undefined;
+        return { stepNumber: 0 };
     }
-
-    return recoverBannerWording;
-  }, [storageData, t]);
+  }, [data.subscriptionState, t]);
 
   const onRedirectRecover = () => {
     if (recoverResumeActivatePath) {
@@ -101,12 +81,11 @@ export default function RecoverBanner({ children }: { children?: React.ReactNode
   };
 
   const onCloseBanner = () => {
-    setStoreValue("DISPLAY_BANNER", "false", protectID);
-    setDisplayBannerData(false);
+    dismissBanner();
   };
 
   const passthroughs = children || null;
-  if (!recoverBannerIsEnabled || !recoverBannerSelected || !displayBannerData) return passthroughs;
+  if (!recoverBannerIsEnabled || !recoverBannerSelected || !data.displayBanner) return passthroughs;
 
   const isWarning = stepNumber > 2;
 

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
@@ -43,6 +43,7 @@ import { useDrawerConfiguration } from "@ledgerhq/live-common/dada-client/hooks/
 import { useOpenAssetAndAccount } from "LLD/features/ModularDialog/Web3AppWebview/AssetAndAccountDrawer";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { setOriginFlow } from "~/renderer/analytics/originFlow";
+import { syncRecoverStateFromStorageSet } from "./syncRecoverStateFromStorageSet";
 
 const wallet = { name: "ledger-live-desktop", version: __APP_VERSION__ };
 
@@ -165,6 +166,7 @@ function useUiHook(manifest: AppManifest, tracking: TrackingAPI): UiHook {
       },
       "storage.set": ({ key, value, storeId }) => {
         setStoreValue(key, value, storeId);
+        syncRecoverStateFromStorageSet({ key, value, storeId, dispatch });
       },
       "transaction.sign": ({
         account,

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/__tests__/syncRecoverStateFromStorageSet.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/__tests__/syncRecoverStateFromStorageSet.test.ts
@@ -1,0 +1,79 @@
+import { setDisplayBanner, setRecoverState } from "~/renderer/reducers/recoverState";
+import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
+import { syncRecoverStateFromStorageSet } from "../syncRecoverStateFromStorageSet";
+
+const PROTECT_ID = "protect-test";
+
+describe("syncRecoverStateFromStorageSet", () => {
+  it("should dispatch Recover subscription state for valid SUBSCRIPTION_STATE values", () => {
+    const dispatch = jest.fn();
+
+    syncRecoverStateFromStorageSet({
+      key: "SUBSCRIPTION_STATE",
+      value: LedgerRecoverSubscriptionStateEnum.BACKUP_DONE,
+      storeId: PROTECT_ID,
+      dispatch,
+    });
+
+    expect(dispatch).toHaveBeenCalledWith(
+      setRecoverState({
+        protectId: PROTECT_ID,
+        subscriptionState: LedgerRecoverSubscriptionStateEnum.BACKUP_DONE,
+      }),
+    );
+  });
+
+  it("should no-op for invalid subscription values", () => {
+    const dispatch = jest.fn();
+
+    syncRecoverStateFromStorageSet({
+      key: "SUBSCRIPTION_STATE",
+      value: "unexpected-state",
+      storeId: PROTECT_ID,
+      dispatch,
+    });
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("should no-op for unrelated storage keys", () => {
+    const dispatch = jest.fn();
+
+    syncRecoverStateFromStorageSet({
+      key: "OTHER_KEY",
+      value: LedgerRecoverSubscriptionStateEnum.BACKUP_DONE,
+      storeId: PROTECT_ID,
+      dispatch,
+    });
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("should dispatch display banner state for DISPLAY_BANNER values", () => {
+    const dispatch = jest.fn();
+
+    syncRecoverStateFromStorageSet({
+      key: "DISPLAY_BANNER",
+      value: "false",
+      storeId: PROTECT_ID,
+      dispatch,
+    });
+
+    expect(dispatch).toHaveBeenCalledWith(
+      setDisplayBanner({ protectId: PROTECT_ID, displayBanner: false }),
+    );
+  });
+
+  it("should no-op for invalid display banner values", () => {
+    const dispatch = jest.fn();
+
+    syncRecoverStateFromStorageSet({
+      key: "DISPLAY_BANNER",
+      value: "invalid",
+      storeId: PROTECT_ID,
+      dispatch,
+    });
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/syncRecoverStateFromStorageSet.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/syncRecoverStateFromStorageSet.ts
@@ -1,0 +1,43 @@
+import { setDisplayBanner, setRecoverState } from "~/renderer/reducers/recoverState";
+import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
+
+const SUBSCRIPTION_STATE_STORAGE_KEY = "SUBSCRIPTION_STATE";
+const DISPLAY_BANNER_STORAGE_KEY = "DISPLAY_BANNER";
+
+type SyncRecoverStateFromStorageSetParams = {
+  key: string;
+  value: unknown;
+  storeId: string;
+  dispatch: (
+    action: ReturnType<typeof setRecoverState> | ReturnType<typeof setDisplayBanner>,
+  ) => void;
+};
+
+function isRecoverSubscriptionState(value: unknown): value is LedgerRecoverSubscriptionStateEnum {
+  return (
+    typeof value === "string" &&
+    Object.values(LedgerRecoverSubscriptionStateEnum).includes(
+      value as LedgerRecoverSubscriptionStateEnum,
+    )
+  );
+}
+
+function isDisplayBannerValue(value: unknown): value is "true" | "false" {
+  return value === "true" || value === "false";
+}
+
+export function syncRecoverStateFromStorageSet({
+  key,
+  value,
+  storeId,
+  dispatch,
+}: SyncRecoverStateFromStorageSetParams): void {
+  if (key === SUBSCRIPTION_STATE_STORAGE_KEY && isRecoverSubscriptionState(value)) {
+    dispatch(setRecoverState({ protectId: storeId, subscriptionState: value }));
+    return;
+  }
+
+  if (key === DISPLAY_BANNER_STORAGE_KEY && isDisplayBannerValue(value)) {
+    dispatch(setDisplayBanner({ protectId: storeId, displayBanner: value === "true" }));
+  }
+}

--- a/apps/ledger-live-desktop/src/renderer/hooks/__tests__/useRecoverBannerState.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/__tests__/useRecoverBannerState.test.ts
@@ -1,0 +1,108 @@
+import { act, renderHook, waitFor } from "tests/testSetup";
+import { getStoreValue, setStoreValue } from "~/renderer/store";
+import { setRecoverState } from "~/renderer/reducers/recoverState";
+import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
+import { useRecoverBannerState } from "../useRecoverBannerState";
+
+jest.mock("~/renderer/store", () => ({
+  getStoreValue: jest.fn(),
+  setStoreValue: jest.fn(),
+  resetStore: jest.fn(),
+}));
+
+const mockGetStoreValue = jest.mocked(getStoreValue);
+const mockSetStoreValue = jest.mocked(setStoreValue);
+const PROTECT_ID = "protect-test";
+
+function withRecoverState(
+  subscriptionState: LedgerRecoverSubscriptionStateEnum,
+  displayBanner = true,
+) {
+  return {
+    recoverState: {
+      protectIdState: {
+        [PROTECT_ID]: { subscriptionState, displayBanner },
+      },
+    },
+  };
+}
+
+describe("useRecoverBannerState", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetStoreValue.mockReturnValue(undefined);
+  });
+
+  it("should return default state when Redux and storage are empty", () => {
+    const { result } = renderHook(() => useRecoverBannerState(PROTECT_ID));
+
+    expect(result.current.data).toEqual({
+      subscriptionState: LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION,
+      displayBanner: true,
+    });
+  });
+
+  it("should rehydrate subscriptionState from storage on mount", async () => {
+    mockGetStoreValue.mockImplementation((key: string) => {
+      if (key === "SUBSCRIPTION_STATE") {
+        return LedgerRecoverSubscriptionStateEnum.STARGATE_SUBSCRIBE;
+      }
+      return undefined;
+    });
+
+    const { result } = renderHook(() => useRecoverBannerState(PROTECT_ID));
+
+    await waitFor(() =>
+      expect(result.current.data.subscriptionState).toBe(
+        LedgerRecoverSubscriptionStateEnum.STARGATE_SUBSCRIBE,
+      ),
+    );
+    expect(mockGetStoreValue).toHaveBeenCalledWith("SUBSCRIPTION_STATE", PROTECT_ID);
+  });
+
+  it("should rehydrate dismissed displayBanner state from storage on mount", async () => {
+    mockGetStoreValue.mockImplementation((key: string) => {
+      if (key === "DISPLAY_BANNER") return "false";
+      return undefined;
+    });
+
+    const { result } = renderHook(() => useRecoverBannerState(PROTECT_ID), {
+      initialState: withRecoverState(LedgerRecoverSubscriptionStateEnum.STARGATE_SUBSCRIBE),
+    });
+
+    await waitFor(() => expect(result.current.data.displayBanner).toBe(false));
+    expect(mockGetStoreValue).toHaveBeenCalledWith("DISPLAY_BANNER", PROTECT_ID);
+  });
+
+  it("should update Redux and persist when dismissBanner is called", () => {
+    const { result, store } = renderHook(() => useRecoverBannerState(PROTECT_ID), {
+      initialState: withRecoverState(LedgerRecoverSubscriptionStateEnum.STARGATE_SUBSCRIBE),
+    });
+
+    act(() => {
+      result.current.dismissBanner();
+    });
+
+    expect(store.getState().recoverState.protectIdState[PROTECT_ID]?.displayBanner).toBe(false);
+    expect(result.current.data.displayBanner).toBe(false);
+    expect(mockSetStoreValue).toHaveBeenCalledWith("DISPLAY_BANNER", "false", PROTECT_ID);
+  });
+
+  it("should reflect Redux subscription state changes reactively", () => {
+    const { result, store } = renderHook(() => useRecoverBannerState(PROTECT_ID));
+
+    act(() => {
+      store.dispatch(
+        setRecoverState({
+          protectId: PROTECT_ID,
+          subscriptionState: LedgerRecoverSubscriptionStateEnum.BACKUP_DEVICE_CONNECTION,
+        }),
+      );
+    });
+
+    expect(result.current.data).toEqual({
+      subscriptionState: LedgerRecoverSubscriptionStateEnum.BACKUP_DEVICE_CONNECTION,
+      displayBanner: true,
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/hooks/useRecoverBannerState.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useRecoverBannerState.ts
@@ -1,0 +1,55 @@
+import { useCallback, useEffect } from "react";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
+import {
+  selectRecoverStateByProtectId,
+  setDisplayBanner,
+  setRecoverState,
+} from "~/renderer/reducers/recoverState";
+import { getStoreValue, setStoreValue } from "~/renderer/store";
+import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
+
+export type RecoverBannerState = {
+  subscriptionState: LedgerRecoverSubscriptionStateEnum;
+  displayBanner: boolean;
+};
+
+const DISPLAY_BANNER_STORAGE_KEY = "DISPLAY_BANNER";
+const SUBSCRIPTION_STATE_STORAGE_KEY = "SUBSCRIPTION_STATE";
+
+export function useRecoverBannerState(protectId: string): {
+  data: RecoverBannerState;
+  dismissBanner: () => void;
+} {
+  const dispatch = useDispatch();
+  const data = useSelector(selectRecoverStateByProtectId(protectId));
+
+  useEffect(() => {
+    try {
+      const storedSubscriptionState = getStoreValue<LedgerRecoverSubscriptionStateEnum>(
+        SUBSCRIPTION_STATE_STORAGE_KEY,
+        protectId,
+      );
+      const storedDisplayBanner = getStoreValue<string>(DISPLAY_BANNER_STORAGE_KEY, protectId);
+
+      if (storedSubscriptionState !== undefined) {
+        dispatch(setRecoverState({ protectId, subscriptionState: storedSubscriptionState }));
+      }
+      if (storedDisplayBanner === "false") {
+        dispatch(setDisplayBanner({ protectId, displayBanner: false }));
+      }
+    } catch {
+      // Banner defaults to visible if storage read fails.
+    }
+  }, [dispatch, protectId]);
+
+  const dismissBanner = useCallback(() => {
+    dispatch(setDisplayBanner({ protectId, displayBanner: false }));
+    try {
+      setStoreValue(DISPLAY_BANNER_STORAGE_KEY, "false", protectId);
+    } catch {
+      // Ignore persistence failures; dismissal is already reflected in Redux for this session.
+    }
+  }, [dispatch, protectId]);
+
+  return { data, dismissBanner };
+}

--- a/apps/ledger-live-desktop/src/renderer/reducers/__tests__/recoverState.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/__tests__/recoverState.test.ts
@@ -1,0 +1,105 @@
+import {
+  INITIAL_STATE,
+  recoverStateReducer,
+  selectRecoverStateByProtectId,
+  setDisplayBanner,
+  setRecoverState,
+} from "../recoverState";
+import type { State } from "~/renderer/reducers";
+import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
+
+const PROTECT_ID = "protect-test";
+const OTHER_PROTECT_ID = "protect-other";
+
+describe("recoverState reducer", () => {
+  it("should return a default entry for an unknown protectId", () => {
+    const state = {
+      recoverState: INITIAL_STATE,
+    } as State;
+
+    expect(selectRecoverStateByProtectId(PROTECT_ID)(state)).toEqual({
+      subscriptionState: LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION,
+      displayBanner: true,
+    });
+  });
+
+  it("should set subscription state and default displayBanner to true", () => {
+    const state = recoverStateReducer(
+      INITIAL_STATE,
+      setRecoverState({
+        protectId: PROTECT_ID,
+        subscriptionState: LedgerRecoverSubscriptionStateEnum.STARGATE_SUBSCRIBE,
+      }),
+    );
+
+    expect(state.protectIdState[PROTECT_ID]).toEqual({
+      subscriptionState: LedgerRecoverSubscriptionStateEnum.STARGATE_SUBSCRIBE,
+      displayBanner: true,
+    });
+  });
+
+  it("should preserve displayBanner when setting subscription state", () => {
+    const dismissedState = recoverStateReducer(
+      INITIAL_STATE,
+      setDisplayBanner({ protectId: PROTECT_ID, displayBanner: false }),
+    );
+
+    const state = recoverStateReducer(
+      dismissedState,
+      setRecoverState({
+        protectId: PROTECT_ID,
+        subscriptionState: LedgerRecoverSubscriptionStateEnum.BACKUP_VERIFY_IDENTITY,
+      }),
+    );
+
+    expect(state.protectIdState[PROTECT_ID]).toEqual({
+      subscriptionState: LedgerRecoverSubscriptionStateEnum.BACKUP_VERIFY_IDENTITY,
+      displayBanner: false,
+    });
+  });
+
+  it("should preserve subscription state when setting displayBanner", () => {
+    const inProgressState = recoverStateReducer(
+      INITIAL_STATE,
+      setRecoverState({
+        protectId: PROTECT_ID,
+        subscriptionState: LedgerRecoverSubscriptionStateEnum.BACKUP_DEVICE_CONNECTION,
+      }),
+    );
+
+    const state = recoverStateReducer(
+      inProgressState,
+      setDisplayBanner({ protectId: PROTECT_ID, displayBanner: false }),
+    );
+
+    expect(state.protectIdState[PROTECT_ID]).toEqual({
+      subscriptionState: LedgerRecoverSubscriptionStateEnum.BACKUP_DEVICE_CONNECTION,
+      displayBanner: false,
+    });
+  });
+
+  it("should keep protectId entries isolated", () => {
+    const firstState = recoverStateReducer(
+      INITIAL_STATE,
+      setRecoverState({
+        protectId: PROTECT_ID,
+        subscriptionState: LedgerRecoverSubscriptionStateEnum.STARGATE_SUBSCRIBE,
+      }),
+    );
+
+    const state = recoverStateReducer(
+      firstState,
+      setRecoverState({
+        protectId: OTHER_PROTECT_ID,
+        subscriptionState: LedgerRecoverSubscriptionStateEnum.BACKUP_DONE,
+      }),
+    );
+
+    expect(state.protectIdState[PROTECT_ID]?.subscriptionState).toBe(
+      LedgerRecoverSubscriptionStateEnum.STARGATE_SUBSCRIBE,
+    );
+    expect(state.protectIdState[OTHER_PROTECT_ID]?.subscriptionState).toBe(
+      LedgerRecoverSubscriptionStateEnum.BACKUP_DONE,
+    );
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/reducers/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/index.ts
@@ -35,6 +35,7 @@ import shieldedSyncSubscriptions, {
 import countervaluesExtraTracking, {
   CountervaluesExtraTrackingState,
 } from "./countervaluesExtraTracking";
+import { recoverStateReducer, RecoverStateSliceState } from "./recoverState";
 
 export type State = LLDRTKApiState & {
   accounts: AccountsState;
@@ -63,6 +64,7 @@ export type State = LLDRTKApiState & {
   syncRefresh: SyncRefreshState;
   shieldedSyncSubscriptions: ShieldedSyncSubscriptionsState;
   countervaluesExtraTracking: CountervaluesExtraTrackingState;
+  recoverState: RecoverStateSliceState;
 };
 
 const appReducer = combineReducers({
@@ -92,6 +94,7 @@ const appReducer = combineReducers({
   syncRefresh,
   shieldedSyncSubscriptions,
   countervaluesExtraTracking,
+  recoverState: recoverStateReducer,
   ...lldRTKApiReducers,
   ...(getEnv("PLAYWRIGHT_RUN") && { lastAction: (_: unknown, action: PayloadAction) => action }),
 });

--- a/apps/ledger-live-desktop/src/renderer/reducers/recoverState.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/recoverState.ts
@@ -1,0 +1,56 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import type { State } from "~/renderer/reducers";
+import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
+
+export type RecoverStateEntry = {
+  subscriptionState: LedgerRecoverSubscriptionStateEnum;
+  displayBanner: boolean;
+};
+
+export type RecoverStateSliceState = {
+  protectIdState: Record<string, RecoverStateEntry>;
+};
+
+export const INITIAL_STATE: RecoverStateSliceState = {
+  protectIdState: {},
+};
+
+const DEFAULT_ENTRY: RecoverStateEntry = {
+  subscriptionState: LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION,
+  displayBanner: true,
+};
+
+const recoverStateSlice = createSlice({
+  name: "recoverState",
+  initialState: INITIAL_STATE,
+  reducers: {
+    setRecoverState: (
+      state,
+      action: PayloadAction<{ protectId: string } & Pick<RecoverStateEntry, "subscriptionState">>,
+    ) => {
+      state.protectIdState[action.payload.protectId] = {
+        subscriptionState: action.payload.subscriptionState,
+        displayBanner: state.protectIdState[action.payload.protectId]?.displayBanner ?? true,
+      };
+    },
+    setDisplayBanner: (
+      state,
+      action: PayloadAction<{ protectId: string; displayBanner: boolean }>,
+    ) => {
+      const existing = state.protectIdState[action.payload.protectId];
+      state.protectIdState[action.payload.protectId] = {
+        ...(existing ?? DEFAULT_ENTRY),
+        displayBanner: action.payload.displayBanner,
+      };
+    },
+  },
+});
+
+export const { setRecoverState, setDisplayBanner } = recoverStateSlice.actions;
+
+export const selectRecoverStateByProtectId =
+  (protectId: string) =>
+  (state: State): RecoverStateEntry =>
+    state.recoverState.protectIdState[protectId] ?? DEFAULT_ENTRY;
+
+export const recoverStateReducer = recoverStateSlice.reducer;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Ledger Recover banner, finish-onboarding Recover widget, and sidebar Recover status dot now react when the Recover web app updates subscription state through Wallet API storage.
  - QA should verify starting/progressing the Recover flow updates Recover UI without restarting the app.
  - QA should also verify closing and reopening Ledger Live preserves Recover UI state from persisted storage.

### 📝 Description

https://github.com/user-attachments/assets/bdec5011-b58e-46bc-9ede-bab02212b123

Fixes desktop Recover UI staying stale after the Ledger Recover web app updates persisted subscription state through Wallet API storage.

This adds a desktop `recoverState` Redux slice keyed by `protectId` and a shared `useRecoverBannerState` hook so Recover UI consumers can read one Redux-backed source of truth while still rehydrating from `electron-store` after app restart.

In-session updates now happen directly at the Wallet API `storage.set` boundary: after `setStoreValue` persists the write, `syncRecoverStateFromStorageSet` dispatches guarded Redux updates for Recover-specific `SUBSCRIPTION_STATE` and `DISPLAY_BANNER` writes. This replaces the previous WebRecoverPlayer unmount-based sync, so the UI updates as soon as the Recover web app writes storage instead of waiting for the player to close.

`RecoverBanner`, `RecoverWidget`, and `RecoverStatusDot` now consume the shared Redux-backed state instead of each doing one-off storage reads.

Coverage was added/updated for:
- Recover reducer behavior and protectId isolation.
- Storage-set sync helper dispatch/no-op behavior.
- Storage rehydration and banner dismissal persistence.
- RecoverWidget visibility after Redux state and cold-start storage rehydration.
- RecoverBanner integration behavior.

Validation run:
- `pnpm desktop test:jest "src/renderer/components/Web3AppWebview/__tests__/syncRecoverStateFromStorageSet.test.ts" "src/renderer/hooks/__tests__/useRecoverBannerState.test.ts" "src/mvvm/features/FinishOnboarding/RecoverWidget/__tests__/useRecoverWidgetViewModel.test.ts" "src/renderer/components/RecoverBanner/__integrations__/RecoverBanner.test.tsx" "src/renderer/reducers/__tests__/recoverState.test.ts"`
- `pnpm desktop typecheck`

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30279](https://ledgerhq.atlassian.net/browse/LIVE-30279)
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-30279]: https://ledgerhq.atlassian.net/browse/LIVE-30279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ