### PR TITLE
[LWM] feat(mobile): update asset detail addresses section

### DIFF
--- a/.changeset/brown-seals-tie.md
+++ b/.changeset/brown-seals-tie.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Update the addresses list to match the new design

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { render, screen } from "@tests/test-renderer";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { mockBtcCryptoCurrency } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
 import { NavigatorName, ScreenName } from "~/const";
+import type { State } from "~/reducers/types";
 import AssetDetailNavigator from "../Navigator";
 import { ASSET_DETAIL_TEST_IDS } from "../testIds";
 
@@ -23,6 +26,20 @@ function AssetDetailTestNavigator() {
   );
 }
 
+function withBtcAccounts(count: number) {
+  return {
+    overrideInitialState: (state: State): State => ({
+      ...state,
+      accounts: {
+        ...state.accounts,
+        active: Array.from({ length: count }, (_, i) =>
+          genAccount(`bitcoin-${i}`, { currency: mockBtcCryptoCurrency, operationsSize: 0 }),
+        ),
+      },
+    }),
+  };
+}
+
 describe("AssetDetail screen layout", () => {
   it("renders all section placeholders and BalanceGraph", () => {
     render(<AssetDetailTestNavigator />);
@@ -30,7 +47,6 @@ describe("AssetDetail screen layout", () => {
     expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.screen)).toBeVisible();
     expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.balanceGraph)).toBeVisible();
     expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.balanceDetails)).toBeVisible();
-    expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.addresses)).toBeVisible();
     expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.marketStats)).toBeVisible();
     expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.transactions)).toBeVisible();
     expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.ctas)).toBeVisible();
@@ -44,8 +60,14 @@ describe("AssetDetail screen layout", () => {
     expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.receiveButton)).toBeNull();
   });
 
-  it("renders the addresses section with title and add button", () => {
+  it("hides the addresses section when there are no accounts", () => {
     render(<AssetDetailTestNavigator />);
+
+    expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.addresses)).toBeNull();
+  });
+
+  it("renders the addresses section when accounts exist", () => {
+    render(<AssetDetailTestNavigator />, withBtcAccounts(2));
 
     expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.addresses)).toBeVisible();
     expect(screen.getByText("Addresses")).toBeVisible();

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/AddressesView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/AddressesView.tsx
@@ -8,7 +8,6 @@ import {
   Text,
 } from "@ledgerhq/lumen-ui-rnative";
 import { PlusCircleFill } from "@ledgerhq/lumen-ui-rnative/symbols";
-import type { Account } from "@ledgerhq/types-live";
 import { useTranslation } from "~/context/Locale";
 import { ASSET_DETAIL_TEST_IDS } from "LLM/features/AssetDetail/testIds";
 import { AddressAccountItem } from "./components/AddressAccountItem";
@@ -16,12 +15,13 @@ import type { AddressAccountData } from "./useAddressesViewModel";
 
 type Props = Readonly<{
   accounts: readonly AddressAccountData[];
-  onAccountPress: (account: Account) => void;
   onAddAccount: () => void;
 }>;
 
-export function AddressesView({ accounts, onAccountPress, onAddAccount }: Props) {
+export function AddressesView({ accounts, onAddAccount }: Props) {
   const { t } = useTranslation();
+
+  if (accounts.length === 0) return null;
 
   return (
     <Box testID={ASSET_DETAIL_TEST_IDS.addresses}>
@@ -41,18 +41,10 @@ export function AddressesView({ accounts, onAccountPress, onAddAccount }: Props)
           </Pressable>
         </SubheaderRow>
       </Subheader>
-      <Box lx={{ backgroundColor: "surface", borderRadius: "md", paddingVertical: "s4" }}>
-        {accounts.length > 0 ? (
-          accounts.map(data => (
-            <AddressAccountItem key={data.id} data={data} onPress={onAccountPress} />
-          ))
-        ) : (
-          <Box lx={{ padding: "s16", alignItems: "center" }}>
-            <Text typography="body3" lx={{ color: "muted" }}>
-              {t("assetDetail.addresses.empty")}
-            </Text>
-          </Box>
-        )}
+      <Box lx={{ gap: "s8" }}>
+        {accounts.map(data => (
+          <AddressAccountItem key={data.id} data={data} />
+        ))}
       </Box>
     </Box>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/__tests__/useAddressesViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/__tests__/useAddressesViewModel.test.ts
@@ -68,27 +68,6 @@ describe("useAddressesViewModel", () => {
     });
   });
 
-  describe("onAccountPress", () => {
-    it("navigates to account screen and fires analytics", () => {
-      const { result } = renderHook(
-        () => useAddressesViewModel(mockBtcCryptoCurrency),
-        withAccounts("bitcoin", 1),
-      );
-
-      const account = result.current.accounts[0].account;
-      act(() => result.current.onAccountPress(account));
-
-      expect(mockNavigate).toHaveBeenCalledWith(ScreenName.Account, {
-        accountId: account.id,
-      });
-      expect(track).toHaveBeenCalledWith("account_clicked", {
-        currency: "bitcoin",
-        accountId: account.id,
-        page: "Asset Detail",
-      });
-    });
-  });
-
   describe("onAddAccount", () => {
     it("navigates to device selection and fires analytics", () => {
       const { result } = renderHook(

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/components/AddressAccountItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/components/AddressAccountItem.tsx
@@ -1,48 +1,45 @@
-import React, { memo, useCallback } from "react";
+import React, { memo } from "react";
 import {
   Box,
-  ListItem,
-  ListItemContent,
-  ListItemDescription,
-  ListItemLeading,
-  ListItemTitle,
-  ListItemTrailing,
+  Card,
+  CardContent,
+  CardContentDescription,
+  CardContentTitle,
+  CardHeader,
+  CardLeading,
+  CardTrailing,
 } from "@ledgerhq/lumen-ui-rnative";
-import type { Account } from "@ledgerhq/types-live";
 import CurrencyIcon from "~/components/CurrencyIcon";
 import { useFormattedAccountBalance } from "LLM/features/Send/screens/Recipient/hooks/useFormattedAccountBalance";
 import type { AddressAccountData } from "../useAddressesViewModel";
 
 type Props = Readonly<{
   data: AddressAccountData;
-  onPress: (account: Account) => void;
 }>;
 
-export const AddressAccountItem = memo(function AddressAccountItem({ data, onPress }: Props) {
+export const AddressAccountItem = memo(function AddressAccountItem({ data }: Props) {
   const { account, name, truncatedAddress } = data;
   const { formattedBalance, formattedCounterValue } = useFormattedAccountBalance(account);
 
-  const handlePress = useCallback(() => onPress(account), [account, onPress]);
-
   return (
-    <ListItem onPress={handlePress} testID={`asset-detail-address-item-${account.id}`}>
-      <ListItemLeading>
-        <ListItemContent>
-          <ListItemTitle numberOfLines={1}>{name}</ListItemTitle>
-          <Box lx={{ flexDirection: "row", alignItems: "center", gap: "s4" }}>
-            <ListItemDescription numberOfLines={1} ellipsizeMode="middle">
-              {truncatedAddress}
-            </ListItemDescription>
-            <CurrencyIcon currency={account.currency} size={16} squared />
-          </Box>
-        </ListItemContent>
-      </ListItemLeading>
-      <ListItemTrailing>
-        <ListItemContent>
-          <ListItemTitle>{formattedCounterValue}</ListItemTitle>
-          <ListItemDescription>{formattedBalance}</ListItemDescription>
-        </ListItemContent>
-      </ListItemTrailing>
-    </ListItem>
+    <Card type="info" testID={`asset-detail-address-item-${account.id}`}>
+      <CardHeader>
+        <CardLeading>
+          <CardContent>
+            <CardContentTitle>{name}</CardContentTitle>
+            <Box lx={{ flexDirection: "row", alignItems: "center", gap: "s4" }}>
+              <CardContentDescription>{truncatedAddress}</CardContentDescription>
+              <CurrencyIcon currency={account.currency} size={16} squared />
+            </Box>
+          </CardContent>
+        </CardLeading>
+        <CardTrailing>
+          <CardContent>
+            <CardContentTitle>{formattedCounterValue}</CardContentTitle>
+            <CardContentDescription>{formattedBalance}</CardContentDescription>
+          </CardContent>
+        </CardTrailing>
+      </CardHeader>
+    </Card>
   );
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/useAddressesViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/useAddressesViewModel.ts
@@ -46,20 +46,6 @@ export function useAddressesViewModel(currency: CryptoCurrency | undefined) {
     });
   }, [currency, accountTuples, walletState]);
 
-  const onAccountPress = useCallback(
-    (account: Account) => {
-      track("account_clicked", {
-        currency: currency?.id,
-        accountId: account.id,
-        page: "Asset Detail",
-      });
-      navigation.navigate(ScreenName.Account, {
-        accountId: account.id,
-      });
-    },
-    [navigation, currency?.id],
-  );
-
   const onAddAccount = useCallback(() => {
     if (!currency) return;
     track("button_clicked", {
@@ -78,7 +64,6 @@ export function useAddressesViewModel(currency: CryptoCurrency | undefined) {
 
   return {
     accounts,
-    onAccountPress,
     onAddAccount,
   };
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Asset detail screen — addresses section visibility when no accounts
  - Asset detail screen — visual rendering of address cards with separate backgrounds
  - Integration tests for the addresses section

### 📝 Description

**Problem**: The asset detail addresses section was always visible even when no accounts existed, showing an empty state. When multiple addresses were present, they were displayed in a single grouped surface container without visual separation.

**Solution**:
- Hide the entire addresses section (title + add button + list) when there are no accounts for the currency
- Replace `ListItem` with Lumen `Card` components (`type="info"`) so each address gets its own card with `surface` background and `borderRadius: lg`
- Separate cards with `gap: s8` spacing
- Remove `onAccountPress` handler (addresses are now non-interactive)
- Update integration tests to verify the section is hidden with no accounts and visible with accounts

### 🖼 Screenshots

<img width="350" height="750" alt="Simulator Screenshot - Test Ios - 2026-05-06 at 09 03 37" src="https://github.com/user-attachments/assets/bc7191fd-ab00-44e7-b5e6-c5f30c9fe3ba" />

<img width="350" height="750" alt="Simulator Screenshot - Test Ios - 2026-05-06 at 09 05 23" src="https://github.com/user-attachments/assets/cd8987f4-0ca9-44f8-8c18-9adbb09a5ab0" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-30316](https://ledgerhq.atlassian.net/browse/LIVE-30316)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30316]: https://ledgerhq.atlassian.net/browse/LIVE-30316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ