### PR TITLE
[LWM] fix(mobile): fix tracking on portfolio page

### DIFF
--- a/.changeset/gorgeous-candles-glow.md
+++ b/.changeset/gorgeous-candles-glow.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Update the tracking for the portfolio page

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/index.tsx
@@ -12,6 +12,7 @@ import { ScreenName } from "~/const";
 import { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { WalletTabNavigatorStackParamList } from "~/components/RootNavigator/types/WalletTabNavigator";
 import { AnalyticsConsentDrawer } from "LLM/features/AnalyticsConsentDrawer";
+import TrackScreen from "~/analytics/TrackScreen";
 import { usePortfolioBorrowSectionViewModel } from "../../components/PortfolioBorrowSection/usePortfolioBorrowSectionViewModel";
 import {
   PROGRESS_VIEW_OFFSET_LEGACY_ANDROID,
@@ -108,6 +109,8 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
       );
       return sections;
     }
+
+    sections.push(<TrackScreen key="trackWallet" category="Wallet" />);
 
     if (shouldDisplayQuickActionCtas && !shouldDisplayGraphRework) {
       sections.push(

--- a/apps/ledger-live-mobile/src/screens/Portfolio/PortfolioAssets.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/PortfolioAssets.tsx
@@ -6,7 +6,7 @@ import { GestureResponderEvent } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import { Button, IconsLegacy, Box } from "@ledgerhq/native-ui";
 import { useDistribution } from "~/actions/general";
-import { track, TrackScreen } from "~/analytics";
+import { track } from "~/analytics";
 import { NavigatorName, ScreenName } from "~/const";
 import {
   blacklistedTokenIdsSelector,
@@ -141,11 +141,6 @@ const PortfolioAssets = ({ hideEmptyTokenAccount, openAddModal }: Props) => {
 
   return (
     <>
-      <TrackScreen
-        category="Wallet"
-        accountsLength={distribution.list && distribution.list.length}
-        discreet={discreetMode}
-      />
 
       {!shouldDisplayQuickActionCtas && (
         <Box my={24}>

--- a/apps/ledger-live-mobile/src/screens/Portfolio/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/index.tsx
@@ -9,7 +9,7 @@ import { useTheme } from "styled-components/native";
 import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 
 import WalletTabSafeAreaView from "~/components/WalletTab/WalletTabSafeAreaView";
-import { useRefreshAccountsOrdering } from "~/actions/general";
+import { useDistribution, useRefreshAccountsOrdering } from "~/actions/general";
 import Carousel from "~/components/Carousel";
 import { ScreenName } from "~/const";
 import FirmwareUpdateBanner from "LLM/features/FirmwareUpdate/components/UpdateBanner";
@@ -19,7 +19,7 @@ import PortfolioEmptyState from "./PortfolioEmptyState";
 import SectionTitle from "../WalletCentricSections/SectionTitle";
 import SectionContainer from "../WalletCentricSections/SectionContainer";
 import AllocationsSection from "../WalletCentricSections/Allocations";
-import { track } from "~/analytics";
+import { track, TrackScreen } from "~/analytics";
 import { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { WalletTabNavigatorStackParamList } from "~/components/RootNavigator/types/WalletTabNavigator";
 import CollapsibleHeaderFlatList from "~/components/WalletTab/CollapsibleHeaderFlatList";
@@ -33,6 +33,7 @@ import {
   hasTokenAccountsNotBlacklistedSelector,
   hasTokenAccountsNotBlackListedWithPositiveBalanceSelector,
 } from "~/reducers/accounts";
+import { discreetModeSelector } from "~/reducers/settings";
 import PortfolioAssets from "./PortfolioAssets";
 import { UpdateStep } from "../FirmwareUpdate";
 import ContentCardsLocation from "~/dynamicContent/ContentCardsLocation";
@@ -145,12 +146,21 @@ function PortfolioScreen({ navigation }: NavigationProps) {
 
   const isLNSUpsellBannerShown = useLNSUpsellBannerState("wallet").isShown;
 
+  const distribution = useDistribution({ showEmptyAccounts: true, hideEmptyTokenAccount });
+  const discreetMode = useSelector(discreetModeSelector);
+
   const onPressAllocations = useCallback(() => {
     navigation.navigate(ScreenName.AnalyticsAllocation);
   }, [navigation]);
 
   const data = useMemo(
     () => [
+      <TrackScreen
+        key="trackWallet"
+        category="Wallet"
+        accountsLength={distribution.list?.length}
+        discreet={discreetMode}
+      />,
       <WalletTabSafeAreaView key="portfolioHeaderElements" edges={["left", "right"]}>
         <Flex px={6} key="FirmwareUpdateBanner">
           <FirmwareUpdateBanner onBackFromUpdate={onBackFromUpdate} />
@@ -244,6 +254,8 @@ function PortfolioScreen({ navigation }: NavigationProps) {
       hideEmptyTokenAccount,
       openAddModal,
       isAWalletCardDisplayed,
+      distribution.list?.length,
+      discreetMode,
       t,
     ],
   );


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Tracking events are verified via analytics dashboards, not unit tests._
- [x] **Impact of the changes:**
  - Portfolio page view tracking event ("Page Wallet") should fire correctly
  - Verify tracking works on both MVVM and legacy portfolio screens

### 📝 Description

**Problem**: The portfolio page view tracking event ("Page Wallet") was missing on nightly builds. The `TrackScreen` component was placed inside `PortfolioAssets` (a child component) which caused it to not fire reliably when the portfolio screen was displayed.

**Solution**: Moved the `TrackScreen` component from `PortfolioAssets` to the top-level portfolio screen components — both the MVVM version (`mvvm/features/Portfolio/screens/Portfolio`) and the legacy version (`screens/Portfolio`). This ensures the tracking event fires consistently when the portfolio page is rendered, regardless of which implementation is active.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30339](https://ledgerhq.atlassian.net/browse/LIVE-30339)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30339]: https://ledgerhq.atlassian.net/browse/LIVE-30339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ