### PR TITLE
[LWD] fix(desktop): use main crypto icon in asset detail header

### DIFF
--- a/.changeset/olive-poets-yell.md
+++ b/.changeset/olive-poets-yell.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+only use main icon without network in asset detail

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/AssetDetailView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/AssetDetailView.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from "react";
 import { useNavigate } from "react-router";
-import CryptoCurrencyIcon from "~/renderer/components/CryptoCurrencyIcon";
+import { CryptoIcon } from "@ledgerhq/crypto-icons";
+import { getValidCryptoIconSize } from "~/renderer/utils/cryptoIconSize";
 import { AssetDetailSection } from "./components/AssetDetailSection";
 import { AssetHeader } from "./components/AssetHeader/AssetHeader";
 import { AddressListSection } from "./components/AddressList";
@@ -20,7 +21,13 @@ export function AssetDetailView({ distributionItem }: Readonly<AssetDetailViewMo
     <div className="flex min-h-0 flex-1 flex-col gap-32">
       <AssetHeader
         assetLabel={distributionItem.currency.name}
-        icon={<CryptoCurrencyIcon currency={distributionItem.currency} size={24} />}
+        icon={
+          <CryptoIcon
+            ledgerId={distributionItem.currency.id}
+            ticker={distributionItem.currency.ticker}
+            size={getValidCryptoIconSize(24)}
+          />
+        }
         onBack={onBack}
       />
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Existing Asset Detail integration tests do not assert the header icon; manual / visual check recommended._
- [x] **Impact of the changes:**
      - Desktop **Asset detail** screen: header crypto icon next to the asset name.
      - Multi-network / token assets where the previous icon showed a **network overlay**; the header should now show the **main asset icon only** (consistent with product intent in LIVE-30343).

### 📝 Description

**Problem:** On the asset detail view, the header used `CryptoCurrencyIcon`, which could display an extra network badge on the icon.

**Solution:** Replace it with `CryptoIcon` from `@ledgerhq/crypto-icons`, using `ledgerId`, `ticker`, and `getValidCryptoIconSize(24)` so the header shows the primary token artwork without the network overlay.

<img width="249" height="153" alt="Screenshot 2026-05-06 at 10 24 10" src="https://github.com/user-attachments/assets/7e764435-78df-4b12-9d1d-950fdee6ddbe" />
<img width="351" height="165" alt="Screenshot 2026-05-06 at 10 23 54" src="https://github.com/user-attachments/assets/db6e8860-bb64-4d4a-a5b2-7064b6919586" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-30343](https://ledgerhq.atlassian.net/browse/LIVE-30343)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30343]: https://ledgerhq.atlassian.net/browse/LIVE-30343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ