### PR TITLE
[LWM] fix(mobile): fix Help page tracking category

### DIFF
--- a/.changeset/swift-carrots-jam.md
+++ b/.changeset/swift-carrots-jam.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+update the page tracking help apge

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/screens/Help/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/screens/Help/index.tsx
@@ -37,7 +37,7 @@ export function MyWalletHelpScreen() {
   return (
     <>
       <ScrollView testID="my-wallet-help-screen">
-        <TrackScreen category="MyWallet" name="Help" />
+        <TrackScreen category="My Wallet" name="Help" />
         <Box lx={{ paddingHorizontal: "s16", paddingTop: "s8", gap: "s24" }}>
           <Box lx={{ gap: "s8" }}>
             <Subheader>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Help page tracking event: category should be "My Wallet" instead of "MyWallet"

### 📝 Description

**Problem**: On the My Wallet Help page, the `TrackScreen` component used `category="MyWallet"` (camelCase), which produced a page tracker name of "myWallet Help" instead of "My Wallet Help". This was inconsistent with the main My Wallet page which correctly uses `category="My Wallet"`.

**Solution**: Updated the `TrackScreen` category prop from `"MyWallet"` to `"My Wallet"` in the Help screen component to match the expected tracking convention.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26562](https://ledgerhq.atlassian.net/browse/LIVE-26562)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26562]: https://ledgerhq.atlassian.net/browse/LIVE-26562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ