### PR TITLE
feat: add genuine check command to wallet-cli [LIVE-28247]

### DIFF
--- a/.agents/skills/ledger-wallet-cli/SKILL.md
+++ b/.agents/skills/ledger-wallet-cli/SKILL.md
@@ -11,7 +11,7 @@ Run from repo root: `pnpm --silent wallet-cli start <command> [flags]`
 
 > **Session first:** When invoked without a specific task, **immediately run `session view`** — do not ask the user what to do first. Show the result, then ask what to do next. If labels exist, skip `account discover`.
 
-> **Sandbox:** `account discover`, `receive`, `send` **must** use `dangerouslyDisableSandbox: true` — sandbox blocks USB (causes `Timeout has occurred`). Other commands are fine in sandbox.
+> **Sandbox:** `account discover`, `receive`, `send`, `genuine-check` **must** use `dangerouslyDisableSandbox: true` — sandbox blocks USB (causes `Timeout has occurred`). Other commands are fine in sandbox.
 
 > **Device contention:** Never run two device commands in parallel — they fail with `[object Object]` or garbled APDU. Run sequentially.
 
@@ -26,6 +26,7 @@ Run from repo root: `pnpm --silent wallet-cli start <command> [flags]`
 | `account discover` | Yes    | **Required** |
 | `receive`          | Yes    | **Required** |
 | `send`             | Yes*   | **Required** |
+| `genuine-check`    | Yes    | **Required** |
 | `balances`         | No     | No           |
 | `operations`       | No     | No           |
 
@@ -62,6 +63,13 @@ Networks: `bitcoin` (mainnet), `base`, `ethereum:sepolia`, `bitcoin:testnet`, `s
 pnpm --silent wallet-cli start receive ethereum-1
 pnpm --silent wallet-cli start receive ethereum-1 --no-verify  # skip device confirmation
 ```
+
+### genuine-check
+```bash
+pnpm --silent wallet-cli start genuine-check
+pnpm --silent wallet-cli start genuine-check --output json
+```
+Device must be unlocked and on the dashboard.
 
 ### balances
 ```bash

--- a/.changeset/proud-ledgers-check.md
+++ b/.changeset/proud-ledgers-check.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-cli": minor
+---
+
+Add genuine check command to wallet-cli

--- a/apps/wallet-cli/src/cli.ts
+++ b/apps/wallet-cli/src/cli.ts
@@ -18,6 +18,7 @@ import OperationsCommand from "./commands/operations";
 import ReceiveCommand from "./commands/receive";
 import SendCommand from "./commands/send";
 import SwapGroup from "./commands/swap/index";
+import GenuineCheckCommand from "./commands/genuine-check";
 
 emitTestingBuildBannerIfNeeded();
 
@@ -37,6 +38,7 @@ export async function runMain(argv: string[] = process.argv.slice(2)): Promise<n
   cli.command(ReceiveCommand);
   cli.command(SendCommand);
   cli.command(SwapGroup);
+  cli.command(GenuineCheckCommand);
   const code = await cli.run(argv, { noExit: true });
   return code ?? 0;
 }

--- a/apps/wallet-cli/src/commands/genuine-check.ts
+++ b/apps/wallet-cli/src/commands/genuine-check.ts
@@ -1,0 +1,111 @@
+import { defineCommand } from "@bunli/core";
+import { DeviceOnDashboardExpected, UserRefusedAllowManager } from "@ledgerhq/errors";
+import { getGenuineCheckFromDeviceId } from "@ledgerhq/live-common/hw/getGenuineCheckFromDeviceId";
+import type { GetGenuineCheckFromDeviceIdResult } from "@ledgerhq/live-common/hw/getGenuineCheckFromDeviceId";
+import { isCounterfeitError } from "@ledgerhq/live-common/hw/isCounterfeitError";
+import { TimeoutError, timeout } from "rxjs";
+import { createCommandOutput } from "../output";
+import { WALLET_CLI_DMK_DEVICE_ID } from "../device/register-dmk-transport";
+import { WalletCliDeviceError } from "../device/wallet-cli-device-error";
+import { withDmkDeviceSession } from "../session/bridge-device-session";
+import { deviceTimeoutOption, outputOption, resolveOutputFormat } from "./inputs";
+import { runObservable } from "./run-observable";
+
+const SOCKET_EVENT_PAYLOAD_GENUINE = "0000";
+
+class NonGenuineDeviceError extends Error {
+  constructor() {
+    super("Device is not genuine.");
+    this.name = "NonGenuineDeviceError";
+  }
+}
+
+function mapGenuineCheckError(error: unknown): unknown {
+  if (error instanceof TimeoutError) {
+    return new WalletCliDeviceError({ code: "timeout" }, { cause: error });
+  }
+  if (isCounterfeitError(error)) {
+    return new NonGenuineDeviceError();
+  }
+  if (error instanceof UserRefusedAllowManager) {
+    return new WalletCliDeviceError({ code: "rejected", context: "open_app" }, { cause: error });
+  }
+  if (error instanceof DeviceOnDashboardExpected) {
+    return new WalletCliDeviceError(
+      { code: "wrong_app", expected: "Ledger dashboard" },
+      { cause: error },
+    );
+  }
+  return (
+    WalletCliDeviceError.fromKnownDeviceError(error, {
+      expectedApp: "Ledger dashboard",
+      rejectedContext: "open_app",
+    }) ?? error
+  );
+}
+
+export default defineCommand({
+  name: "genuine-check",
+  description: "Check whether the connected Ledger device is genuine",
+  options: {
+    output: outputOption,
+    "device-timeout": deviceTimeoutOption,
+  },
+  handler: async ({ flags }) => {
+    const ctx = { command: "genuine-check", network: "device" };
+    const out = createCommandOutput(resolveOutputFormat(flags.output), ctx);
+
+    await out.run(async () => {
+      let isGenuine = false;
+      const spin = out.spin("Connect and unlock your Ledger on the dashboard…");
+
+      await withDmkDeviceSession(async () => {
+        await runObservable<GetGenuineCheckFromDeviceIdResult>({
+          source$: getGenuineCheckFromDeviceId({
+            deviceId: WALLET_CLI_DMK_DEVICE_ID,
+            deviceName: null,
+          }).pipe(timeout({ each: flags["device-timeout"] })),
+          onNext: ({ socketEvent, lockedDevice }) => {
+            if (lockedDevice) {
+              out.deviceState({ code: "awaiting_approval", reason: "unlock" });
+              return;
+            }
+            if (!socketEvent) {
+              if (spin) {
+                spin.text = "Ledger unlocked. Starting genuine check…";
+              }
+              return;
+            }
+
+            switch (socketEvent.type) {
+              case "device-permission-requested":
+                if (spin) {
+                  spin.text = "Allow Ledger Manager on device…";
+                } else {
+                  out.deviceState({ code: "awaiting_approval", reason: "open_app" });
+                }
+                break;
+              case "device-permission-granted":
+                if (spin) {
+                  spin.text = "Verifying device genuineness…";
+                }
+                break;
+              case "result":
+                if (socketEvent.payload !== SOCKET_EVENT_PAYLOAD_GENUINE) {
+                  throw new NonGenuineDeviceError();
+                }
+                isGenuine = true;
+                break;
+            }
+          },
+          mapError: mapGenuineCheckError,
+        });
+      });
+
+      if (!isGenuine) {
+        throw new Error("Genuine check completed without a result.");
+      }
+      out.genuineCheck();
+    });
+  },
+});

--- a/apps/wallet-cli/src/output-json.test.ts
+++ b/apps/wallet-cli/src/output-json.test.ts
@@ -112,6 +112,33 @@ describe("JsonCommandOutput", () => {
     });
   });
 
+  it("emits genuine check output as a success envelope", () => {
+    try {
+      const out = createCommandOutput("json", {
+        command: "genuine-check",
+        network: "device",
+      });
+
+      out.genuineCheck();
+    } finally {
+      restore();
+    }
+
+    const lines = writes
+      .join("")
+      .trim()
+      .split("\n")
+      .map(line => JSON.parse(line));
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatchObject({
+      status: "success",
+      command: "genuine-check",
+      network: "device",
+      genuine: true,
+    });
+    expect(lines[0].timestamp).toEqual(expect.any(String));
+  });
+
   it("emits swap quote output as NDJSON with provider errors", () => {
     try {
       const out = createCommandOutput("json", {

--- a/apps/wallet-cli/src/output.ts
+++ b/apps/wallet-cli/src/output.ts
@@ -70,6 +70,8 @@ export interface CommandOutput {
   operations(items: Operation[], currencyId: string, nextCursor?: string): Promise<void>;
   /** Output a receive / fresh address. */
   address(addr: string): void;
+  /** Output the result of a successful device genuine check. */
+  genuineCheck(): void;
 
   /** Stream one discovered account (human: print immediately; json: buffer). */
   discoveredAccount(d: DiscoveredAccount): void;
@@ -221,6 +223,15 @@ class HumanCommandOutput implements CommandOutput {
 
   address(addr: string): void {
     writeStdout(addr);
+  }
+
+  genuineCheck(): void {
+    if (this._activeSpin?.isSpinning) {
+      this._activeSpin.success("Device is genuine");
+      this._activeSpin = null;
+      return;
+    }
+    writeStdout("Device is genuine");
   }
 
   discoveredAccount(d: DiscoveredAccount): void {
@@ -524,6 +535,10 @@ class JsonCommandOutput implements CommandOutput {
 
   address(addr: string): void {
     this._writeNdjson(this._envelope({ address: addr }));
+  }
+
+  genuineCheck(): void {
+    this._writeNdjson(this._envelope({ genuine: true }));
   }
 
   discoveredAccount(d: DiscoveredAccount): void {

--- a/apps/wallet-cli/src/session/bridge-device-session.ts
+++ b/apps/wallet-cli/src/session/bridge-device-session.ts
@@ -46,6 +46,25 @@ export async function withCurrencyDeviceSession<T>(
 }
 
 /**
+ * Runs a callback with a DMK transport available, without opening or switching Ledger apps.
+ */
+export async function withDmkDeviceSession<T>(fn: () => Promise<T>): Promise<T> {
+  walletCliDebug("Ensuring DMK transport…");
+  try {
+    await ensureWalletCliDmkTransport();
+  } catch (e) {
+    throw WalletCliDeviceError.fromUnknown(e, { expectedApp: "Ledger dashboard" });
+  }
+  walletCliDebug("DMK device session ready.");
+  try {
+    return await fn();
+  } finally {
+    walletCliDebug("Resetting device session…");
+    await resetWalletCliDmkSession();
+  }
+}
+
+/**
  * Legacy helper for commands that still work with a currency family name.
  * Maps family → canonical currency ID, then delegates to withCurrencyDeviceSession.
  */

--- a/apps/wallet-cli/src/test/commands/genuine-check.test.ts
+++ b/apps/wallet-cli/src/test/commands/genuine-check.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { Observable } from "rxjs";
+import type { GetGenuineCheckFromDeviceIdResult } from "@ledgerhq/live-common/hw/getGenuineCheckFromDeviceId";
+import { runCli } from "../helpers/cli-runner";
+
+let genuineCheckImpl: () => Observable<GetGenuineCheckFromDeviceIdResult>;
+
+mock.module("@ledgerhq/live-common/hw/getGenuineCheckFromDeviceId", () => ({
+  getGenuineCheckFromDeviceId: () => genuineCheckImpl(),
+}));
+
+const MOCK_DMK_ENV = {
+  WALLET_CLI_MOCK_DMK: "1",
+};
+
+// runCli executes in non-TTY mode (CLAUDECODE=1), so the spinner is disabled
+// and intermediate device states surface as `device-state` NDJSON events
+// instead of being swallowed by `spin.text = ...`. Tests parse stdout as a
+// stream of JSON lines and look up events by content rather than position
+// to stay decoupled from the exact event ordering.
+function parseNdjson(stdout: string): Record<string, unknown>[] {
+  return stdout
+    .split("\n")
+    .filter(line => line.length > 0)
+    .map(line => JSON.parse(line) as Record<string, unknown>);
+}
+
+describe("genuine-check command (mock DMK)", () => {
+  beforeEach(() => {
+    genuineCheckImpl = () =>
+      new Observable<GetGenuineCheckFromDeviceIdResult>(subscriber => {
+        subscriber.next({ socketEvent: null, lockedDevice: false });
+        subscriber.next({
+          socketEvent: { type: "device-permission-requested" },
+          lockedDevice: false,
+        });
+        subscriber.next({
+          socketEvent: { type: "device-permission-granted" },
+          lockedDevice: false,
+        });
+        subscriber.next({ socketEvent: { type: "result", payload: "0000" }, lockedDevice: false });
+        subscriber.complete();
+      });
+  });
+
+  it("reports a genuine device through the json envelope", async () => {
+    const { stdout, stderr, exitCode } = await runCli(
+      ["genuine-check", "--output", "json"],
+      MOCK_DMK_ENV,
+    );
+
+    expect(exitCode, `stderr: ${stderr}`).toBe(0);
+    const lines = parseNdjson(stdout);
+
+    // The final envelope is the public success contract: status, command,
+    // network and a `genuine: true` flag.
+    expect(lines.at(-1)).toMatchObject({
+      status: "success",
+      command: "genuine-check",
+      network: "device",
+      genuine: true,
+    });
+
+    // While the run is in progress, the JSON consumer must be able to learn
+    // that the device is awaiting user approval to open the manager.
+    expect(lines).toContainEqual(
+      expect.objectContaining({
+        type: "device-state",
+        command: "genuine-check",
+        state: { code: "awaiting_approval", reason: "open_app" },
+      }),
+    );
+  });
+
+  it("surfaces a locked device through a device-state event without aborting the run", async () => {
+    genuineCheckImpl = () =>
+      new Observable<GetGenuineCheckFromDeviceIdResult>(subscriber => {
+        subscriber.next({ socketEvent: null, lockedDevice: true });
+        subscriber.next({ socketEvent: null, lockedDevice: false });
+        subscriber.next({ socketEvent: { type: "result", payload: "0000" }, lockedDevice: false });
+        subscriber.complete();
+      });
+
+    const { stdout, stderr, exitCode } = await runCli(
+      ["genuine-check", "--output", "json"],
+      MOCK_DMK_ENV,
+    );
+
+    expect(exitCode, `stderr: ${stderr}`).toBe(0);
+    const lines = parseNdjson(stdout);
+
+    expect(lines).toContainEqual(
+      expect.objectContaining({
+        type: "device-state",
+        command: "genuine-check",
+        state: { code: "awaiting_approval", reason: "unlock" },
+      }),
+    );
+    expect(lines.at(-1)).toMatchObject({ status: "success", genuine: true });
+  });
+
+  it("fails with a timeout when the genuine check stops making progress", async () => {
+    genuineCheckImpl = () => new Observable<GetGenuineCheckFromDeviceIdResult>(() => undefined);
+
+    const { stdout, exitCode } = await runCli(
+      ["genuine-check", "--output", "json", "--device-timeout", "1"],
+      MOCK_DMK_ENV,
+    );
+
+    expect(exitCode).toBe(6);
+    const lastLine = parseNdjson(stdout).at(-1);
+    expect(lastLine).toMatchObject({
+      ok: false,
+      error: {
+        command: "genuine-check",
+        code: "timeout",
+      },
+    });
+  });
+
+  it("fails when the device returns a non-genuine result", async () => {
+    genuineCheckImpl = () =>
+      new Observable<GetGenuineCheckFromDeviceIdResult>(subscriber => {
+        subscriber.next({ socketEvent: { type: "result", payload: "ffff" }, lockedDevice: false });
+        subscriber.complete();
+      });
+
+    const { stdout, exitCode } = await runCli(["genuine-check", "--output", "json"], MOCK_DMK_ENV);
+
+    expect(exitCode).toBe(1);
+    const lastLine = parseNdjson(stdout).at(-1);
+    expect(lastLine).toMatchObject({
+      ok: false,
+      error: {
+        command: "genuine-check",
+        message: "Device is not genuine.",
+      },
+    });
+  });
+
+  it("fails when the stream completes without a result event", async () => {
+    genuineCheckImpl = () =>
+      new Observable<GetGenuineCheckFromDeviceIdResult>(subscriber => {
+        subscriber.next({
+          socketEvent: { type: "device-permission-granted" },
+          lockedDevice: false,
+        });
+        subscriber.complete();
+      });
+
+    const { stdout, exitCode } = await runCli(["genuine-check", "--output", "json"], MOCK_DMK_ENV);
+
+    expect(exitCode).toBe(1);
+    const lastLine = parseNdjson(stdout).at(-1);
+    expect(lastLine).toMatchObject({
+      ok: false,
+      error: { command: "genuine-check" },
+    });
+  });
+});


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - wallet-cli

### 📝 Description

Add a wallet-cli command to run the Ledger genuine check from the dashboard.

Includes JSON output, device-state handling, command registration, docs, and command-level tests.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28247]
- **ADR link (if any)**: 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-28247]: https://ledgerhq.atlassian.net/browse/LIVE-28247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ