### PR TITLE
[LWDM] fix(LIVE-29568): sort aleo records during sync + ignore transitions in listOperations

### DIFF
--- a/.changeset/shaggy-zebras-tan.md
+++ b/.changeset/shaggy-zebras-tan.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-aleo": minor
+"ledger-live-desktop": minor
+---
+
+fix: ignore unnecessary transitions in aleo listOperations 
+fix: sort aleo records during sync

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepRecordPicker.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepRecordPicker.tsx
@@ -111,7 +111,6 @@ const AleoStepRecordPicker = ({ account, transaction, status, updateTransaction 
     () =>
       (account.aleoResources?.unspentPrivateRecords ?? [])
         .filter(r => new BigNumber(r.microcredits).isGreaterThan(0))
-        .sort((a, b) => new BigNumber(b.microcredits).comparedTo(new BigNumber(a.microcredits)))
         .slice(0, MAX_RECORDS_DISPLAYED),
     [account.aleoResources?.unspentPrivateRecords],
   );

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/shared/QuickAmountSelector.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/shared/QuickAmountSelector.tsx
@@ -112,9 +112,9 @@ const QuickAmountSelector = ({ account, transaction, updateTransaction, onSelect
 
   const sortedRecords: AleoUnspentRecord[] = useMemo(
     () =>
-      [...(account.aleoResources?.unspentPrivateRecords ?? [])]
-        .filter(r => new BigNumber(r.microcredits).isGreaterThan(0))
-        .sort((a, b) => new BigNumber(b.microcredits).comparedTo(a.microcredits)),
+      [...(account.aleoResources?.unspentPrivateRecords ?? [])].filter(r =>
+        new BigNumber(r.microcredits).isGreaterThan(0),
+      ),
     [account.aleoResources?.unspentPrivateRecords],
   );
 

--- a/libs/coin-modules/coin-aleo/src/bridge/sync.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/sync.test.ts
@@ -939,6 +939,44 @@ describe("sync.ts", () => {
       );
     });
 
+    it("should store unspentPrivateRecords sorted DESC by microcredits", async () => {
+      mockAccessProvableApi.mockResolvedValueOnce(configuredProvableApi);
+
+      const makeUnspentRecord = (microcredits: string, tag: string) => ({
+        ...getMockedRecord({ tag }),
+        microcredits,
+        decryptedData: { owner: "", data: {}, nonce: "", version: 0 as const },
+      });
+
+      const lowRecord = makeUnspentRecord("100000", "tag-low");
+      const midRecord = makeUnspentRecord("500000", "tag-mid");
+      const highRecord = makeUnspentRecord("900000", "tag-high");
+
+      mockGetPrivateBalance.mockResolvedValueOnce({
+        balance: new BigNumber(1500000),
+        unspentRecords: [lowRecord, highRecord, midRecord],
+      });
+
+      const result = await performPrivateSync(
+        {
+          index: mockAccount.index,
+          derivationPath: mockAccount.freshAddressPath,
+          address: mockAccount.freshAddress,
+          currency: mockCurrency,
+          derivationMode: mockDerivationMode,
+          initialAccount: mockInitialAccount,
+        },
+        mockSyncConfig,
+        [],
+      );
+
+      expect(result?.aleoResources?.unspentPrivateRecords).toEqual([
+        expect.objectContaining({ microcredits: highRecord.microcredits }),
+        expect.objectContaining({ microcredits: midRecord.microcredits }),
+        expect.objectContaining({ microcredits: lowRecord.microcredits }),
+      ]);
+    });
+
     it("should filter unspent records whose tags appear in consumedRecordTags before passing to getPrivateBalance", async () => {
       mockAccessProvableApi.mockResolvedValueOnce(configuredProvableApi);
       const consumedTag = "consumed-record-tag";

--- a/libs/coin-modules/coin-aleo/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/sync.ts
@@ -309,7 +309,12 @@ export async function performPrivateSync(
     ...(signal && { signal }),
   });
   const privateBalance = privateBalanceResult.balance;
-  const unspentPrivateRecords: AleoUnspentRecord[] = privateBalanceResult.unspentRecords;
+  const unspentPrivateRecords: AleoUnspentRecord[] = privateBalanceResult.unspentRecords
+    .slice()
+    .sort((a, b) => {
+      const diff = BigInt(b.microcredits) - BigInt(a.microcredits);
+      return diff > 0n ? 1 : diff < 0n ? -1 : 0;
+    });
 
   // merge old and new private operations — same incremental pattern as public ops;
   // deduplication is by operation id (encodeOperationId(accountId, txHash, type))

--- a/libs/coin-modules/coin-aleo/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/listOperations.test.ts
@@ -24,6 +24,41 @@ describe("listOperations", () => {
     jest.clearAllMocks();
   });
 
+  it("should skip transitions with empty sender and recipient", async () => {
+    const batcherTx = getMockedTransaction({
+      transaction_id: "tx1",
+      sender_address: "",
+      recipient_address: "",
+      program_id: "ldgbatcher_ppub_28.aleo",
+      amount: 0,
+    });
+    const innerTx = getMockedTransaction({
+      transaction_id: "tx1",
+      sender_address: "",
+      recipient_address: mockAddress,
+      amount: 5,
+    });
+    const mockOp = getMockedOperation({ id: "op1" });
+
+    mockFetchAccountTransactionsFromHeight.mockResolvedValue({
+      transactions: [batcherTx, innerTx],
+      nextCursor: null,
+    });
+    mockToBridgeOperation.mockReturnValue(mockOp);
+
+    const result = await listOperations({
+      currency: mockCurrency,
+      address: mockAddress,
+      ledgerAccountId: mockLedgerAccountId,
+      mode: "bridge",
+      options: { minHeight: 0 },
+    });
+
+    expect(mockToBridgeOperation).toHaveBeenCalledTimes(1);
+    expect(mockToBridgeOperation).toHaveBeenCalledWith(mockLedgerAccountId, innerTx, mockAddress);
+    expect(result.operations).toEqual([mockOp]);
+  });
+
   describe("bridge mode", () => {
     it("should fetch and parse transactions in bridge mode", async () => {
       const mockTx1 = getMockedTransaction({ transaction_id: "tx1", block_number: 100 });

--- a/libs/coin-modules/coin-aleo/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/listOperations.ts
@@ -44,6 +44,11 @@ export async function listOperations(
   });
 
   for (const rawTx of result.transactions) {
+    // Skip transitions that have no direct account involvement (e.g. outer call in a batching contract).
+    // Other transition, sharing the same transaction_id, will carry the real amount and addresses.
+    // Testnet transaction showing this issue: at1lqugdt847uwnfem2xhzwq6ewrnd6ysjv2gumvglytskutxj3kcpsmc3rrf
+    if (rawTx.sender_address === "" && rawTx.recipient_address === "") continue;
+
     if (mode === "alpaca") {
       operations.push(toAlpacaOperation(rawTx, address));
     } else {

--- a/libs/coin-modules/coin-aleo/src/logic/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.ts
@@ -625,6 +625,9 @@ export function extractViewKey(account: AleoAccount): string {
 /**
  * Selects the minimum set of private records needed to cover `targetAmount` using a greedy largest-first strategy.
  *
+ * **Precondition**: `unspentRecords` must be sorted by value descending.
+ * This function runs very often during transaction construction, so we avoid the overhead of sorting by requiring the caller to pass in sorted records.
+ *
  * - If `targetAmount` is `null`, returns the top `MAX_PRIVATE_RECORDS_PER_TRANSACTION` records by value (useAllAmount mode).
  * - If `targetAmount` is provided and positive:
  *   1. Prefer the **smallest single record** that alone covers the target (fewest records, least overshoot).
@@ -643,8 +646,7 @@ export function selectPrivateRecordsForAmount({
 }): AleoUnspentRecord[] {
   const rankedRecords = unspentRecords
     .map(record => ({ record, value: new BigNumber(record.microcredits) }))
-    .filter(({ value }) => value.isGreaterThan(0))
-    .sort((a, b) => b.value.comparedTo(a.value));
+    .filter(({ value }) => value.isGreaterThan(0));
 
   if (rankedRecords.length === 0) {
     return [];

--- a/libs/coin-modules/coin-aleo/src/types/bridge.ts
+++ b/libs/coin-modules/coin-aleo/src/types/bridge.ts
@@ -76,6 +76,9 @@ export interface AleoResources {
   transparentBalance: BigNumber;
   provableApi: ProvableApi | null;
   privateBalance: BigNumber | null;
+  /**
+   * List of unspent private records, sorted by microcredits in descending order.
+   */
   unspentPrivateRecords: AleoUnspentRecord[] | null;
   lastPrivateSyncDate: Date | null;
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Aleo private records are sorted by value in DESC order during sync
  - Unnecessary transitions are ignored in listOperations

### 📝 Description

This PR optimizes Aleo logic around records sorting + prepares listOperations for incoming smart contract integration.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-29568


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
