### PR TITLE
[LWDM] fix(coin-celo): fix fee transaction estimation when eth_estimateGas called with encoded value

### DIFF
--- a/.changeset/lemon-cobras-destroy.md
+++ b/.changeset/lemon-cobras-destroy.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-celo": patch
+---
+
+fix fee transaction estimation when eth_estimateGas called with encoded value

--- a/libs/coin-modules/coin-celo/src/__tests__/bridge/getFeesForTransaction.test.ts
+++ b/libs/coin-modules/coin-celo/src/__tests__/bridge/getFeesForTransaction.test.ts
@@ -4,6 +4,8 @@ import {
   transactionFixture,
   transactionWithUsdcFeeFixture,
   tokenTransactionWithUsdcFeeFixture,
+  accountWithTokenAccountFixture,
+  tokenTransactionWithUsdtFeeFixture,
 } from "../../bridge/fixtures";
 import getFeesForTransaction from "../../bridge/getFeesForTransaction";
 
@@ -97,6 +99,13 @@ jest.mock("../../network/sdk", () => {
         estimateGasWithInflationFactor: jest.fn().mockReturnValue(3),
         gasPrice: gasPriceMock,
         getMaxPriorityFeePerGas: jest.fn().mockResolvedValue(1),
+        web3: {
+          eth: {
+            getBlock: jest.fn().mockResolvedValue({
+              baseFeePerGas: undefined,
+            }),
+          },
+        },
       },
     })),
   };
@@ -282,8 +291,27 @@ describe("getFeesForTransaction", () => {
 
   it("should return the correct fees for a token transaction with USDC fee currency", async () => {
     const fees = await getFeesForTransaction({
-      account: { ...accountFixture, balance: BigNumber(123), spendableBalance: BigNumber(123) },
+      account: {
+        ...accountWithTokenAccountFixture,
+        balance: BigNumber(123),
+        spendableBalance: BigNumber(123),
+      },
       transaction: tokenTransactionWithUsdcFeeFixture,
+    });
+
+    // Fees should still be calculated correctly when feeCurrency is provided
+    expect(fees).toBeInstanceOf(BigNumber);
+    expect(fees.gt(0)).toBe(true);
+  });
+
+  it("should return the correct fees for a token transaction with USDT fee currency", async () => {
+    const fees = await getFeesForTransaction({
+      account: {
+        ...accountWithTokenAccountFixture,
+        balance: BigNumber(123),
+        spendableBalance: BigNumber(123),
+      },
+      transaction: tokenTransactionWithUsdtFeeFixture,
     });
 
     // Fees should still be calculated correctly when feeCurrency is provided

--- a/libs/coin-modules/coin-celo/src/bridge/getFeesForTransaction.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/getFeesForTransaction.ts
@@ -1,11 +1,6 @@
 import { findSubAccountById } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { BigNumber } from "bignumber.js";
-import {
-  CELO_STABLE_TOKENS,
-  getStableTokenEnum,
-  MAX_FEES_THRESHOLD_MULTIPLIER,
-  MIN_GAS_FOR_NATIVE_TRANSFER,
-} from "../constants";
+import { MAX_FEES_THRESHOLD_MULTIPLIER, MIN_GAS_FOR_NATIVE_TRANSFER } from "../constants";
 import { getPendingStakingOperationAmounts, getVote } from "../logic";
 import { celoKit } from "../network/sdk";
 import type { CeloAccount, RevokeTxo, Transaction } from "../types";
@@ -123,20 +118,11 @@ const getFeesForTransaction = async ({
     const baseFee = BigInt(block.baseFeePerGas || maxPriorityFeePerGas);
     const maxFeePerGas = baseFee + BigInt(maxPriorityFeePerGas);
 
-    let token;
-    if (CELO_STABLE_TOKENS.includes(tokenAccount.token.id)) {
-      token = await kit.contracts.getStableToken(getStableTokenEnum(tokenAccount.token.id));
-    } else {
-      token = await kit.contracts.getErc20(tokenAccount.token.contractAddress);
-    }
-
     const celoTransaction = {
       from: account.freshAddress,
       to: transaction.recipient,
-      data: token.transfer(transaction.recipient, value.toFixed()).txo.encodeABI(),
       maxFeePerGas: maxFeePerGas.toString(),
       maxPriorityFeePerGas,
-      value: valueToHex(value),
       ...(transaction.feeCurrency
         ? {
             feeCurrency: transaction.feeCurrency,


### PR DESCRIPTION


<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - `"@ledgerhq/coin-celo": patch`

### 📝 Description

coin-celo's `getFeesForTransaction` calls celo's `connection.estimateGasWithInflationFactor` to estimate fees for a transaction. Eventually this leads to a JSON RPC request to Celo node to executed method `eth_estimateGas`.

This method returns an `execution reverted` error: the EVM reverts the transaction without providing a reason.
```bash
curl 'https://<celo_node_url>/archive/' \
  --data-raw '{"jsonrpc":"2.0","id":8833879681157626,"method":"eth_estimateGas","params":[{"from":"0x0a...e33","to":"0x9...0d6","data":"0xa90...00","maxFeePerGas":"0x2eabe5d462","maxPriorityFeePerGas":"0xf4240","value":"0x0"}]}'       
{"jsonrpc":"2.0","id":8833879681157626,"error":{"code":3,"message":"execution reverted","data":"0x"}}
```

Removing the optional request fields `value` and removing the `value` from the encoded `data` field seems to fix the issue. This seems to be the only way to avoid the `execution reverted` error, even though it might lead to underestimate the fees for the transaction.

See https://docs.metamask.io/services/reference/celo/json-rpc-methods/eth_estimategas/

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA link**: [LIVE-30176](https://ledgerhq.atlassian.net/browse/LIVE-30176)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-30176]: https://ledgerhq.atlassian.net/browse/LIVE-30176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ