### PR TITLE
[LWDM] fix(LIVE-29568): ignore unnecessary aleo transitions in listOperations

### DIFF
--- a/.changeset/late-students-return.md
+++ b/.changeset/late-students-return.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+fix: ignore unnecessary aleo transitions in listOperations

--- a/libs/coin-modules/coin-aleo/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.test.ts
@@ -331,6 +331,59 @@ describe("network/utils", () => {
           order: "desc",
         });
       });
+
+      it("should skip batcher outer call transitions that have transfer in function_id but empty addresses", async () => {
+        const minBlockHeight = 100;
+        const commonTxId = "at1batcher";
+
+        // batcher outer call: function_id contains "transfer" but no account involvement
+        // testnet example: at1lqugdt847uwnfem2xhzwq6ewrnd6ysjv2gumvglytskutxj3kcpsmc3rrf
+        const batcherOuterCall = getMockedPublicTransaction({
+          block_number: 150,
+          transaction_id: commonTxId,
+          function_id: "transfer_private_to_public_8",
+          sender_address: "",
+          recipient_address: "",
+          amount: 0,
+        });
+
+        // inner transition for the same tx — carries the real amount and addresses
+        const realTransfer = getMockedPublicTransaction({
+          block_number: 150,
+          transaction_id: commonTxId,
+          function_id: "transfer_private_to_public",
+          sender_address: "",
+          recipient_address: "aleo1recipient",
+          amount: 1000000,
+        });
+
+        // standalone NONE operation with empty addresses — must NOT be filtered
+        const initializeTx = getMockedPublicTransaction({
+          block_number: 150,
+          transaction_id: "at1initialize",
+          function_id: "initialize",
+          sender_address: "",
+          recipient_address: "",
+          amount: 0,
+        });
+
+        jest.mocked(apiClient.getAccountPublicTransactions).mockResolvedValueOnce({
+          address: mockAddress,
+          transactions: [batcherOuterCall, realTransfer, initializeTx],
+        });
+
+        const result = await fetchAccountTransactionsFromHeight({
+          currency: mockCurrency,
+          address: mockAddress,
+          fetchAllPages: true,
+          minBlockHeight,
+        });
+
+        expect(result.transactions).toHaveLength(2);
+        expect(result.transactions).toContainEqual(realTransfer);
+        expect(result.transactions).toContainEqual(initializeTx);
+        expect(result.transactions).not.toContainEqual(batcherOuterCall);
+      });
     });
   });
 

--- a/libs/coin-modules/coin-aleo/src/network/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.ts
@@ -77,7 +77,19 @@ export async function fetchAccountTransactionsFromHeight({
     const nextCursorBlockNumber = page.next_cursor?.block_number.toString() ?? null;
     hasMorePages = nextCursorBlockNumber !== null;
 
-    const recentTxs = page.transactions.filter(tx => tx.block_number >= minBlockHeight);
+    const recentTxs = page.transactions.filter(tx => {
+      const hasValidBlockNumber = tx.block_number >= minBlockHeight;
+
+      // Skip transitions that have no direct account involvement (e.g. outer call in a batching contract).
+      // Other transition, sharing the same transaction_id, will carry the real amount and addresses.
+      // Testnet transaction showing this issue: at1lqugdt847uwnfem2xhzwq6ewrnd6ysjv2gumvglytskutxj3kcpsmc3rrf
+      const isInvalidTransition =
+        tx.function_id.includes("transfer") &&
+        tx.sender_address === "" &&
+        tx.recipient_address === "";
+
+      return hasValidBlockNumber && !isInvalidTransition;
+    });
     transactions.push(...recentTxs);
 
     // stop if DESC order hit the min height boundary


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Unnecessary transitions are ignored in listOperations

### 📝 Description

This PR adds logic to ignore unnecessary `transfer_*` transitions coming from the API behind Aleo's listOperations. This is related to incoming batching smart contract integration. Example transaction that causes issue: https://testnet.explorer.provable.com/transaction/at148f0uwm3vae2vdvzxygfdud5tnu6yudg3h070fhdmqgd9px3ws8skq5dfq

<img width="783" height="580" alt="image" src="https://github.com/user-attachments/assets/79723336-cd96-4cff-b372-985f1eea8c00" />


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-29568


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
