### PR TITLE
[LWM] fix(mobile): stop recover banner conflicting with post onboarding widget

### DIFF
--- a/.changeset/light-files-share.md
+++ b/.changeset/light-files-share.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix: stop recover banner conflicting with post onboarding widget

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBannersSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBannersSection/index.tsx
@@ -119,7 +119,14 @@ export const PortfolioBannersSection = ({
       key="BannersSection"
       testID="portfolio-banners-section"
     >
-      <Box style={{ width: WIDTH }} lx={{ marginTop: sectionMarginTop, marginBottom: "s24" }}>
+      <Box
+        style={{ width: WIDTH }}
+        lx={{
+          marginTop: sectionMarginTop,
+          marginBottom: "s24",
+          marginLeft: shouldShowOnboardingWidget ? "s12" : "s0",
+        }}
+      >
         {shouldShowOnboardingWidget && <OnboardingWidget />}
         {shouldDisplayRecover && <RecoverBanner paddingHorizontal="s0" />}
       </Box>

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/RecoverBanner/__tests__/useAddRecoverPostOnboardingAction.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/RecoverBanner/__tests__/useAddRecoverPostOnboardingAction.test.ts
@@ -1,0 +1,194 @@
+import React from "react";
+import { render, waitFor, withFlagOverrides } from "@tests/test-renderer";
+import { PostOnboardingProvider } from "@ledgerhq/live-common/postOnboarding/PostOnboardingProvider";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { PostOnboardingAction, PostOnboardingActionId } from "@ledgerhq/types-live";
+import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
+import type { State } from "~/reducers/types";
+import { useAddRecoverPostOnboardingAction } from "../useAddRecoverPostOnboardingAction";
+
+const mockUsePostOnboardingHubStepperDisplay = jest.fn();
+jest.mock("~/logic/postOnboarding/usePostOnboardingHubStepperDisplay", () => ({
+  usePostOnboardingHubStepperDisplay: (...args: unknown[]) =>
+    mockUsePostOnboardingHubStepperDisplay(...args),
+}));
+
+const makeAction = (id: PostOnboardingActionId): PostOnboardingAction => ({
+  id,
+  Icon: () => null,
+  title: "title",
+  titleCompleted: "titleCompleted",
+  startAction: jest.fn(),
+});
+
+const assetsTransferAction = makeAction(PostOnboardingActionId.assetsTransfer);
+const recoverAction = makeAction(PostOnboardingActionId.recover);
+
+const withPostOnboardingWidgetEnabled = withFlagOverrides({
+  lwmWallet40: { enabled: true, params: { onboardingWidget: true } },
+});
+
+type TestHookProps = {
+  readonly subscriptionState?: LedgerRecoverSubscriptionStateEnum;
+  readonly actionsById?: Partial<Record<PostOnboardingActionId, PostOnboardingAction>>;
+};
+
+function TestHookConsumer({
+  subscriptionState = LedgerRecoverSubscriptionStateEnum.STARGATE_SUBSCRIBE,
+}: Pick<TestHookProps, "subscriptionState">) {
+  useAddRecoverPostOnboardingAction(subscriptionState);
+
+  return null;
+}
+
+function TestHook({
+  subscriptionState = LedgerRecoverSubscriptionStateEnum.STARGATE_SUBSCRIBE,
+  actionsById = { [PostOnboardingActionId.assetsTransfer]: assetsTransferAction },
+}: TestHookProps) {
+  return React.createElement(
+    PostOnboardingProvider,
+    {
+      navigateToPostOnboardingHub: jest.fn(),
+      getPostOnboardingActionsForDevice: () => [],
+      getPostOnboardingAction: (actionId: PostOnboardingActionId) => actionsById[actionId],
+    },
+    React.createElement(TestHookConsumer, { subscriptionState }),
+  );
+}
+
+function withPostOnboardingActions(
+  actionsCompleted: State["postOnboarding"]["actionsCompleted"],
+  baseTransform: (state: State) => State = withPostOnboardingWidgetEnabled,
+) {
+  const actionsToComplete = Object.values(PostOnboardingActionId).filter(
+    actionId => actionsCompleted[actionId] !== undefined,
+  );
+
+  return (state: State): State => {
+    const baseState = baseTransform(state);
+
+    return {
+      ...baseState,
+      postOnboarding: {
+        ...baseState.postOnboarding,
+        deviceModelId: DeviceModelId.nanoX,
+        actionsToComplete,
+        actionsCompleted,
+      },
+    };
+  };
+}
+
+const expectRecoverAction = (store: ReturnType<typeof render>["store"], expected: boolean) => {
+  expect(
+    store.getState().postOnboarding.actionsToComplete.includes(PostOnboardingActionId.recover),
+  ).toBe(expected);
+};
+
+describe("useAddRecoverPostOnboardingAction", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePostOnboardingHubStepperDisplay.mockReturnValue({
+      areAllActionsCompleted: false,
+      loading: false,
+    });
+  });
+
+  it("should dispatch recover action when existing post-onboarding actions are incomplete", async () => {
+    const { store } = render(React.createElement(TestHook), {
+      overrideInitialState: withPostOnboardingActions({
+        [PostOnboardingActionId.assetsTransfer]: false,
+      }),
+    });
+
+    await waitFor(() => expectRecoverAction(store, true));
+  });
+
+  it("should dispatch recover action when recover backup is done and existing actions are incomplete", async () => {
+    const { store } = render(
+      React.createElement(TestHook, {
+        subscriptionState: LedgerRecoverSubscriptionStateEnum.BACKUP_DONE,
+      }),
+      {
+        overrideInitialState: withPostOnboardingActions({
+          [PostOnboardingActionId.assetsTransfer]: false,
+        }),
+      },
+    );
+
+    await waitFor(() => expectRecoverAction(store, true));
+  });
+
+  it("should not dispatch recover action when existing post-onboarding actions are completed", () => {
+    mockUsePostOnboardingHubStepperDisplay.mockReturnValue({
+      areAllActionsCompleted: true,
+      loading: false,
+    });
+
+    const { store } = render(
+      React.createElement(TestHook, {
+        actionsById: { [PostOnboardingActionId.assetsTransfer]: assetsTransferAction },
+      }),
+      {
+        overrideInitialState: withPostOnboardingActions({
+          [PostOnboardingActionId.assetsTransfer]: true,
+        }),
+      },
+    );
+
+    expectRecoverAction(store, false);
+  });
+
+  it("should not dispatch recover action while post-onboarding completion is loading", () => {
+    mockUsePostOnboardingHubStepperDisplay.mockReturnValue({
+      areAllActionsCompleted: false,
+      loading: true,
+    });
+
+    const { store } = render(React.createElement(TestHook), {
+      overrideInitialState: withPostOnboardingActions({
+        [PostOnboardingActionId.assetsTransfer]: false,
+      }),
+    });
+
+    expectRecoverAction(store, false);
+  });
+
+  it("should not dispatch recover action when mobile post-onboarding widget is disabled", async () => {
+    const { store } = render(React.createElement(TestHook), {
+      overrideInitialState: withPostOnboardingActions(
+        { [PostOnboardingActionId.assetsTransfer]: false },
+        withFlagOverrides({
+          lwmWallet40: { enabled: true, params: { onboardingWidget: false } },
+        }),
+      ),
+    });
+
+    await waitFor(() => expectRecoverAction(store, false));
+  });
+
+  it("should not dispatch recover action when recover action already exists", () => {
+    const { store } = render(
+      React.createElement(TestHook, {
+        actionsById: {
+          [PostOnboardingActionId.assetsTransfer]: assetsTransferAction,
+          [PostOnboardingActionId.recover]: recoverAction,
+        },
+      }),
+      {
+        overrideInitialState: withPostOnboardingActions({
+          [PostOnboardingActionId.assetsTransfer]: false,
+          [PostOnboardingActionId.recover]: false,
+        }),
+      },
+    );
+
+    expect(
+      store
+        .getState()
+        .postOnboarding.actionsToComplete.filter(
+          actionId => actionId === PostOnboardingActionId.recover,
+        ),
+    ).toHaveLength(1);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/RecoverBanner/__tests__/useRecoverBannerViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/RecoverBanner/__tests__/useRecoverBannerViewModel.test.ts
@@ -1,7 +1,5 @@
 import { act, renderHook, waitFor, withFlagOverrides } from "@tests/test-renderer";
 import { Linking } from "react-native";
-import { addPostOnboardingAction } from "@ledgerhq/live-common/postOnboarding/actions";
-import { PostOnboardingActionId } from "@ledgerhq/types-live";
 import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
 import useRecoverBannerViewModel from "../useRecoverBannerViewModel";
 import { withBannerEnabled, withRecoverState } from "../../../utils/recoverTestHelpers";
@@ -11,16 +9,9 @@ jest.mock("@ledgerhq/live-common/hooks/recoverFeatureFlag", () => ({
   useCustomURI: () => mockUseCustomURI(),
 }));
 
-const mockActionsState = jest.fn();
-jest.mock("@ledgerhq/live-common/postOnboarding/hooks/index", () => ({
-  usePostOnboardingHubState: () => mockActionsState(),
+jest.mock("../useAddRecoverPostOnboardingAction", () => ({
+  useAddRecoverPostOnboardingAction: jest.fn(),
 }));
-
-jest.mock("@ledgerhq/live-common/postOnboarding/actions", () => ({
-  addPostOnboardingAction: jest.fn(args => ({ type: "ADD_POST_ONBOARDING_ACTION", ...args })),
-}));
-
-const mockAddPostOnboardingAction = jest.mocked(addPostOnboardingAction);
 
 const mockRecoverUri = "ledgerlive://recover/test";
 
@@ -28,7 +19,6 @@ describe("useRecoverBannerViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseCustomURI.mockReturnValue(mockRecoverUri);
-    mockActionsState.mockReturnValue({ actionsState: [] });
     jest.spyOn(Linking, "canOpenURL").mockResolvedValue(true);
     jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
   });
@@ -142,45 +132,6 @@ describe("useRecoverBannerViewModel", () => {
 
       expect(Linking.canOpenURL).not.toHaveBeenCalled();
       expect(Linking.openURL).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("addPostOnboardingAction dispatch", () => {
-    it.each([
-      LedgerRecoverSubscriptionStateEnum.STARGATE_SUBSCRIBE,
-      LedgerRecoverSubscriptionStateEnum.BACKUP_DONE,
-    ])("dispatches for valid state %s", async subscriptionState => {
-      renderHook(() => useRecoverBannerViewModel(), {
-        overrideInitialState: state => withRecoverState(subscriptionState, true)(state),
-      });
-
-      await waitFor(() =>
-        expect(mockAddPostOnboardingAction).toHaveBeenCalledWith({
-          actionId: PostOnboardingActionId.recover,
-        }),
-      );
-    });
-
-    it("does not dispatch when actionStateRecover already exists", () => {
-      mockActionsState.mockReturnValue({
-        actionsState: [{ id: PostOnboardingActionId.recover }],
-      });
-
-      renderHook(() => useRecoverBannerViewModel(), {
-        overrideInitialState: state =>
-          withRecoverState(LedgerRecoverSubscriptionStateEnum.STARGATE_SUBSCRIBE, true)(state),
-      });
-
-      expect(mockAddPostOnboardingAction).not.toHaveBeenCalled();
-    });
-
-    it("does not dispatch when subscriptionState is NO_SUBSCRIPTION", () => {
-      renderHook(() => useRecoverBannerViewModel(), {
-        overrideInitialState: state =>
-          withRecoverState(LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION, true)(state),
-      });
-
-      expect(mockAddPostOnboardingAction).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/RecoverBanner/__tests__/useShouldDisplayRecoverBanner.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/RecoverBanner/__tests__/useShouldDisplayRecoverBanner.test.ts
@@ -3,6 +3,10 @@ import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionS
 import useShouldDisplayRecoverBanner from "../useShouldDisplayRecoverBanner";
 import { withBannerEnabled, withRecoverState } from "../../../utils/recoverTestHelpers";
 
+jest.mock("../useAddRecoverPostOnboardingAction", () => ({
+  useAddRecoverPostOnboardingAction: jest.fn(),
+}));
+
 describe("useShouldDisplayRecoverBanner", () => {
   it("returns true when all conditions are met", async () => {
     const { result } = renderHook(() => useShouldDisplayRecoverBanner(), {

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/RecoverBanner/useAddRecoverPostOnboardingAction.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/RecoverBanner/useAddRecoverPostOnboardingAction.ts
@@ -1,0 +1,48 @@
+import { useEffect } from "react";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { addPostOnboardingAction } from "@ledgerhq/live-common/postOnboarding/actions";
+import { usePostOnboardingHubState } from "@ledgerhq/live-common/postOnboarding/hooks/index";
+import { PostOnboardingActionId } from "@ledgerhq/types-live";
+import { usePostOnboardingHubStepperDisplay } from "~/logic/postOnboarding/usePostOnboardingHubStepperDisplay";
+import { useDispatch } from "~/context/hooks";
+import {
+  LedgerRecoverSubscriptionStateEnum,
+  LedgerRecoverSubscriptionStateInProgressEnum,
+} from "~/types/recoverSubscriptionState";
+
+export function useAddRecoverPostOnboardingAction(
+  subscriptionState: LedgerRecoverSubscriptionStateEnum | undefined,
+) {
+  const dispatch = useDispatch();
+  const { shouldDisplayOnboardingWidget } = useWalletFeaturesConfig("mobile");
+  const { actionsState } = usePostOnboardingHubState();
+  const { areAllActionsCompleted, loading } = usePostOnboardingHubStepperDisplay(actionsState);
+
+  const actionStateRecover = actionsState.find(
+    action => action.id === PostOnboardingActionId.recover,
+  );
+
+  useEffect(() => {
+    const shouldAddRecoverToPostOnboarding =
+      shouldDisplayOnboardingWidget &&
+      subscriptionState !== undefined &&
+      (subscriptionState in LedgerRecoverSubscriptionStateInProgressEnum ||
+        subscriptionState === LedgerRecoverSubscriptionStateEnum.BACKUP_DONE) &&
+      actionStateRecover === undefined &&
+      actionsState.length > 0 &&
+      !loading &&
+      !areAllActionsCompleted;
+
+    if (shouldAddRecoverToPostOnboarding) {
+      dispatch(addPostOnboardingAction({ actionId: PostOnboardingActionId.recover }));
+    }
+  }, [
+    actionStateRecover,
+    actionsState.length,
+    areAllActionsCompleted,
+    dispatch,
+    loading,
+    shouldDisplayOnboardingWidget,
+    subscriptionState,
+  ]);
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/RecoverBanner/useRecoverBannerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/RecoverBanner/useRecoverBannerViewModel.ts
@@ -1,11 +1,6 @@
-import { useEffect } from "react";
 import { GestureResponderEvent, Linking } from "react-native";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { useCustomURI } from "@ledgerhq/live-common/hooks/recoverFeatureFlag";
-import { addPostOnboardingAction } from "@ledgerhq/live-common/postOnboarding/actions";
-import { usePostOnboardingHubState } from "@ledgerhq/live-common/postOnboarding/hooks/index";
-import { PostOnboardingActionId } from "@ledgerhq/types-live";
-import { useDispatch } from "~/context/hooks";
 import { useTranslation } from "~/context/Locale";
 import {
   LedgerRecoverSubscriptionStateEnum,
@@ -13,18 +8,13 @@ import {
 } from "~/types/recoverSubscriptionState";
 import { track } from "~/analytics";
 import useRecoverBannerState from "../../hooks/useRecoverBannerState";
+import { useAddRecoverPostOnboardingAction } from "./useAddRecoverPostOnboardingAction";
 
 function useRecoverBannerViewModel() {
   const { t } = useTranslation();
   const recoverServices = useFeature("protectServicesMobile");
-  const dispatch = useDispatch();
   const bannerIsEnabled = recoverServices?.params?.bannerSubscriptionNotification;
   const protectID = recoverServices?.params?.protectId ?? "protect-prod";
-
-  const { actionsState } = usePostOnboardingHubState();
-  const actionStateRecover = actionsState.find(
-    action => action.id === PostOnboardingActionId.recover,
-  );
 
   const recoverResumeActivatePath = useCustomURI(
     recoverServices,
@@ -38,17 +28,7 @@ function useRecoverBannerViewModel() {
   const subscriptionState =
     data?.subscriptionState ?? LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION;
   const isInProgress = subscriptionState in LedgerRecoverSubscriptionStateInProgressEnum;
-
-  useEffect(() => {
-    if (
-      data?.subscriptionState !== undefined &&
-      (data.subscriptionState in LedgerRecoverSubscriptionStateInProgressEnum ||
-        data.subscriptionState === LedgerRecoverSubscriptionStateEnum.BACKUP_DONE) &&
-      actionStateRecover === undefined
-    ) {
-      dispatch(addPostOnboardingAction({ actionId: PostOnboardingActionId.recover }));
-    }
-  }, [data?.subscriptionState, actionStateRecover, dispatch]);
+  useAddRecoverPostOnboardingAction(data?.subscriptionState);
 
   const onRedirectRecover = async () => {
     track("banner_clicked", {

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/RecoverBanner/useShouldDisplayRecoverBanner.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/RecoverBanner/useShouldDisplayRecoverBanner.ts
@@ -1,39 +1,18 @@
-import { useEffect } from "react";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
-import { addPostOnboardingAction } from "@ledgerhq/live-common/postOnboarding/actions";
-import { usePostOnboardingHubState } from "@ledgerhq/live-common/postOnboarding/hooks/index";
-import { PostOnboardingActionId } from "@ledgerhq/types-live";
-import { useDispatch } from "~/context/hooks";
 import {
   LedgerRecoverSubscriptionStateEnum,
   LedgerRecoverSubscriptionStateInProgressEnum,
 } from "~/types/recoverSubscriptionState";
 import useRecoverBannerState from "../../hooks/useRecoverBannerState";
+import { useAddRecoverPostOnboardingAction } from "./useAddRecoverPostOnboardingAction";
 
 function useShouldDisplayRecoverBanner() {
   const recoverServices = useFeature("protectServicesMobile");
   const bannerIsEnabled = recoverServices?.params?.bannerSubscriptionNotification;
   const protectID = recoverServices?.params?.protectId ?? "protect-prod";
 
-  const dispatch = useDispatch();
-
-  const { actionsState } = usePostOnboardingHubState();
-  const actionStateRecover = actionsState.find(
-    action => action.id === PostOnboardingActionId.recover,
-  );
-
   const { data } = useRecoverBannerState(protectID);
-
-  useEffect(() => {
-    if (
-      data?.subscriptionState !== undefined &&
-      (data.subscriptionState in LedgerRecoverSubscriptionStateInProgressEnum ||
-        data.subscriptionState === LedgerRecoverSubscriptionStateEnum.BACKUP_DONE) &&
-      actionStateRecover === undefined
-    ) {
-      dispatch(addPostOnboardingAction({ actionId: PostOnboardingActionId.recover }));
-    }
-  }, [data?.subscriptionState, actionStateRecover, dispatch]);
+  useAddRecoverPostOnboardingAction(data?.subscriptionState);
 
   const inProgress =
     (data?.subscriptionState ?? LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION) in


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Unit tests were added/updated for the recover banner and portfolio banner section view models.
- [x] **Impact of the changes:**
  - This PR stops the post-onboarding widget re-appearing after it has already been dismissed or completed.

### 📝 Description

This PR stops the post-onboarding widget re-appearing after it has already been dismissed or completed. It adds the Recover post-onboarding action wiring and updates the related view model tests to cover the new banner visibility behaviour.

### ❓ Context

- **JIRA or GitHub link**: LIVE-30337
- **ADR link (if any)**: N/A


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)