### PR TITLE
[LWDM] feat(common): add earn wallet feature config flags

### DIFF
--- a/.changeset/green-buttons-rise.md
+++ b/.changeset/green-buttons-rise.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Add earn wallet feature config flags for upselling and simulator UI gating.

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/index.tsx
@@ -3,7 +3,7 @@ import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 import { useRemoteLiveAppContext } from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import { Flex } from "@ledgerhq/native-ui";
-import React, { ComponentProps, Fragment, useRef, useCallback } from "react";
+import React, { ComponentProps, Fragment, useRef, useCallback, useMemo } from "react";
 import { Animated, StyleSheet, View } from "react-native";
 import type WebView from "react-native-webview";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -12,6 +12,7 @@ import GenericErrorView from "~/components/GenericErrorView";
 import { useNavigationBarHeights } from "LLM/hooks/useNavigationBarHeights";
 import { EarnWebview } from "../EarnWebview";
 import { LiveAppBackground } from "LLM/components/LiveAppBackground";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig";
 
 type Props = {
   manifest?: LiveAppManifest;
@@ -36,8 +37,22 @@ export const EarnV2Webview = ({
   const { state: remoteLiveAppState } = useRemoteLiveAppContext();
   const insets = useSafeAreaInsets();
   const { topBarHeight, bottomBarHeight } = useNavigationBarHeights();
+  const { shouldDisplayEarnUpselling, shouldDisplayEarnSimulator } =
+    useWalletFeaturesConfig("mobile");
+
   const earnUiVersion = useFeature("ptxEarnUi")?.params?.value ?? "v1";
-  const isPtxUiMinV2 = isMinEarnUiVersion(earnUiVersion, "v2");
+
+  const computedUiVersion = useMemo(() => {
+    if (shouldDisplayEarnUpselling) {
+      return "v3";
+    }
+    if (shouldDisplayEarnSimulator) {
+      return "v4";
+    }
+    return earnUiVersion;
+  }, [shouldDisplayEarnUpselling, shouldDisplayEarnSimulator, earnUiVersion]);
+
+  const isPtxUiMinV2 = isMinEarnUiVersion(computedUiVersion, "v2");
 
   const scrollY = useRef(new Animated.Value(0)).current;
   const handleScroll = useCallback<NonNullable<ComponentProps<typeof WebView>["onScroll"]>>(

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/index.tsx
@@ -70,7 +70,7 @@ export const EarnV2Webview = ({
     safeAreaRight: insets.right.toString(),
     topNavigationHeightOffset: topBarHeight.toString(),
     bottomNavigationHeightOffset: bottomBarHeight.toString(),
-    uiVersion: earnUiVersion,
+    uiVersion: computedUiVersion,
     lw40enabled: isLwm40Enabled ? "true" : "false",
   };
 

--- a/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/types.ts
+++ b/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/types.ts
@@ -17,6 +17,8 @@ export type Wallet40Params = {
   readonly aggregatedAssets?: boolean;
   readonly myWallet?: boolean;
   readonly finishOnboardingWidget?: boolean;
+  readonly earnUpselling?: boolean;
+  readonly earnSimulator?: boolean;
 };
 
 export const FEATURE_FLAG_KEYS = {
@@ -60,4 +62,8 @@ export interface WalletFeaturesConfig {
   readonly shouldDisplayMyWallet: boolean;
   /** Whether to show the Finish Onboarding widget on Portfolio (desktop / lwdWallet40) */
   readonly shouldDisplayFinishOnboardingWidget: boolean;
+  /** Whether to show the Earn Upselling component */
+  readonly shouldDisplayEarnUpselling: boolean;
+  /** Whether to show the Earn Simulator component */
+  readonly shouldDisplayEarnSimulator: boolean;
 }

--- a/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.test.ts
+++ b/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.test.ts
@@ -52,6 +52,8 @@ const makeConfig = (
   shouldDisplayMyWallet: value,
   shouldDisplayAggregatedAssets: value,
   shouldDisplayFinishOnboardingWidget: value,
+  shouldDisplayEarnUpselling: value,
+  shouldDisplayEarnSimulator: value,
   ...overrides,
 });
 
@@ -72,6 +74,8 @@ const makeParams = (value: boolean): Wallet40Params => ({
   aggregatedAssets: value,
   myWallet: value,
   finishOnboardingWidget: value,
+  earnUpselling: value,
+  earnSimulator: value,
 });
 
 const DISABLED_CONFIG = makeConfig(false);
@@ -140,6 +144,8 @@ describe("useWalletFeaturesConfig hook", () => {
         ["aggregatedAssets", { aggregatedAssets: true }, { shouldDisplayAggregatedAssets: true }],
         ["myWallet", { myWallet: true }, { shouldDisplayMyWallet: true }],
         ["finishOnboardingWidget", { finishOnboardingWidget: true }, { shouldDisplayFinishOnboardingWidget: true }],
+        ["earnUpselling", { earnUpselling: true }, { shouldDisplayEarnUpselling: true }],
+        ["earnSimulator", { earnSimulator: true }, { shouldDisplayEarnSimulator: true }],
       ])("should return correct config when only %s is enabled", (_, params, expectedOverrides) => {
         const { result } = renderWalletFeaturesConfig(platform, {
           [flagKey]: createFeatureFlag(true, params),

--- a/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.ts
+++ b/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.ts
@@ -51,6 +51,10 @@ export const useWalletFeaturesConfig = (platform: WalletPlatform): WalletFeature
       shouldDisplayFinishOnboardingWidget:
         isEnabled &&
         Boolean(params && "finishOnboardingWidget" in params && params.finishOnboardingWidget),
+      shouldDisplayEarnUpselling:
+        isEnabled && Boolean(params && "earnUpselling" in params && params.earnUpselling),
+      shouldDisplayEarnSimulator:
+        isEnabled && Boolean(params && "earnSimulator" in params && params.earnSimulator),
     };
   }, [walletFeatureFlag]);
 };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Partial: `live-mobile` and `@ledgerhq/live-common` typecheck were run, plus `@ledgerhq/live-common` unit tests; no dedicated mobile Jest test was added for this screen-level wiring._
- [x] **Impact of the changes:**
      - Earn mobile webview version gating (`v2` and above) based on wallet feature config flags.
      - Wallet feature flag parsing in `@ledgerhq/live-common` for `earnUpselling` and `earnSimulator`.
      - Earn UI rollout behavior when toggling feature flag params for mobile.

### 📝 Description

The Earn mobile flow needs feature-config-driven rollouts for new UI variants, but the wallet feature config did not expose earn-related toggles.

This PR adds `earnUpselling` and `earnSimulator` support in `useWalletFeaturesConfig`, covers them in unit tests, and wires those booleans into `EarnV2Webview` to compute the effective Earn UI version (`v3` for upselling, `v4` for simulator) before applying the existing minimum-version check.


Demo:

https://github.com/user-attachments/assets/23b05a8f-48b7-45fc-bb07-2f8323437128



### ❓ Context

- **JIRA or GitHub link**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)