### PR TITLE
test(desktop): clean up earn e2e specs

### DIFF
--- a/.changeset/gorgeous-balloons-grin.md
+++ b/.changeset/gorgeous-balloons-grin.md
@@ -1,4 +1,5 @@
 ---
+"ledger-live-desktop-e2e-tests": patch
 ---
 
 Clean up Earn desktop E2E coverage.

--- a/.changeset/gorgeous-balloons-grin.md
+++ b/.changeset/gorgeous-balloons-grin.md
@@ -1,0 +1,4 @@
+---
+---
+
+Clean up Earn desktop E2E coverage.

--- a/e2e/desktop/tests/specs/earn.spec.ts
+++ b/e2e/desktop/tests/specs/earn.spec.ts
@@ -34,11 +34,6 @@ const ethEarn = [
   },
   {
     account: Account.ETH_1,
-    provider: Provider.STADER_LABS,
-    xrayTicket: "B2CQA-3677",
-  },
-  {
-    account: Account.ETH_1,
     provider: Provider.KILN,
     xrayTicket: "B2CQA-3678",
   },
@@ -116,7 +111,7 @@ for (const { account, provider, xrayTicket } of ethEarn) {
 }
 
 // Skipping this suite as legacy is not visible on prod anymore
-test.describe.skip("Inline Add Account", () => {
+test.describe.skip("Earn live app Add Account", () => {
   const account = Account.ETH_1;
   setupEnv(true);
   test.use({
@@ -127,7 +122,7 @@ test.describe.skip("Inline Add Account", () => {
   });
 
   test(
-    "Inline Add Account",
+    "Earn live app Add Account",
     {
       tag: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@ethereum", "@family-evm"],
       annotation: [
@@ -188,12 +183,11 @@ const earnDashboardCurrencies = [
     xrayTicket: "B2CQA-3683",
     staking: true,
   },
-  // FIXME: Solana is delegated but we need to wait for BE to be updated
-  // {
-  //   account: Account.SOL_2,
-  //   xrayTicket: "B2CQA-3684",
-  //   staking: true,
-  // },
+  {
+    account: Account.SOL_2,
+    xrayTicket: "B2CQA-3684",
+    staking: true,
+  },
   {
     account: Account.ATOM_1,
     xrayTicket: "B2CQA-3685",

--- a/e2e/desktop/tests/specs/earn.v2.spec.ts
+++ b/e2e/desktop/tests/specs/earn.v2.spec.ts
@@ -175,9 +175,9 @@ test.describe("Earn [v2]", () => {
     });
   }
 
-  // --- Inline Add Account ---
+  // --- Earn v2 inline Add Account ---
 
-  test.describe("Inline Add Account", () => {
+  test.describe("Earn v2 inline Add Account", () => {
     const account = Account.ETH_1;
     const xrayTicket = "B2CQA-4642";
 
@@ -267,7 +267,6 @@ test.describe("Earn [v2]", () => {
 
   const ethProviders = [
     { provider: Provider.LIDO, xrayTickets: ["B2CQA-4722", "B2CQA-4644"] },
-    { provider: Provider.STADER_LABS, xrayTickets: ["B2CQA-4723"] },
     { provider: Provider.KILN, xrayTickets: ["B2CQA-4724"] },
   ];
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Scoped typecheck and lint passed; Playwright E2E was not run locally._
- [x] **Impact of the changes:**
  - Desktop Earn v1 and v2 E2E provider coverage
  - Earn Add Account E2E suite naming
  - Solana staking coverage in the Earn dashboard scenario

### 📝 Description

This PR cleans up the desktop Earn E2E specs as requested in QAA-1103. The existing specs still referenced stale provider coverage and legacy naming around the Add Account scenarios.

The changes remove `STADER_LABS` from Earn provider matrices, restore the Solana staking dashboard case, and rename the Add Account suites to make the Earn live app context explicit. The `stakePrograms` feature flag override remains in place until Firebase testing/prod parity is confirmed.

### ❓ Context

- **JIRA or GitHub link**: [QAA-1103](https://ledgerhq.atlassian.net/browse/QAA-1103)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-1103]: https://ledgerhq.atlassian.net/browse/QAA-1103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ