### PR TITLE
[LWM] feat(live-dmk-mobile): add device discovery service with preflight checks

### DIFF
--- a/.changeset/bright-discovery-checks.md
+++ b/.changeset/bright-discovery-checks.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-dmk-mobile": minor
+---
+
+Add discovery service with BLE preflight checks

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
@@ -41,6 +41,7 @@ import DebugStore from "~/screens/Settings/Debug/Debugging/Store";
 import DebugSwap from "~/screens/Settings/Debug/Features/Swap";
 import DebugVideos from "~/screens/Settings/Debug/Features/Videos";
 import TooltipDemo from "~/screens/Settings/Debug/Features/TooltipDemo";
+import DebugDeviceIntentExecutorDiscovery from "~/screens/Settings/Debug/Features/DeviceIntentExecutor/DiscoveryScreen";
 import DebugDeviceIntentExecutorInitialization from "~/screens/Settings/Debug/Features/DeviceIntentExecutor/InitializationScreen";
 import DebugDeviceIntentExecutorOrchestration from "~/screens/Settings/Debug/Features/DeviceIntentExecutor/OrchestrationScreen";
 import Settings from "~/screens/Settings";
@@ -138,7 +139,7 @@ export default function SettingsNavigator() {
           title: "",
           headerStyle: {
             backgroundColor: colors.neutral.c00,
-          }
+          },
         }}
       />
       <Stack.Screen
@@ -314,6 +315,13 @@ export default function SettingsNavigator() {
         component={DebugDeviceIntentExecutorInitialization}
         options={{
           title: "DIE Initialization",
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.DebugDeviceIntentExecutorDiscovery}
+        component={DebugDeviceIntentExecutorDiscovery}
+        options={{
+          title: "DIE Discovery",
         }}
       />
       <Stack.Screen

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/SettingsNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/SettingsNavigator.ts
@@ -35,6 +35,7 @@ export type SettingsNavigatorStackParamList = {
   [ScreenName.DebugPerformance]: undefined;
   [ScreenName.DebugDebugging]: undefined;
   [ScreenName.DebugDeviceIntentExecutor]: undefined;
+  [ScreenName.DebugDeviceIntentExecutorDiscovery]: undefined;
   [ScreenName.DebugDeviceIntentExecutorInitialization]: undefined;
   [ScreenName.DebugDeviceIntentExecutorOrchestration]: undefined;
   [ScreenName.DebugConfiguration]: undefined;

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -40,6 +40,7 @@ export enum ScreenName {
   DebugCustomImageGraphics = "DebugCustomImageGraphics",
   DebugDebugging = "DebugDebugging",
   DebugDeviceIntentExecutor = "DebugDeviceIntentExecutor",
+  DebugDeviceIntentExecutorDiscovery = "DebugDeviceIntentExecutorDiscovery",
   DebugDeviceIntentExecutorInitialization = "DebugDeviceIntentExecutorInitialization",
   DebugDeviceIntentExecutorOrchestration = "DebugDeviceIntentExecutorOrchestration",
   DebugQueuedDrawers = "DebugQueuedDrawers",

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/DiscoveryScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/DiscoveryScreen.tsx
@@ -1,0 +1,320 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ScrollView, StyleSheet } from "react-native";
+import type { DiscoveredDevice } from "@ledgerhq/device-management-kit";
+import {
+  DefaultDeviceDiscoveryService,
+  DiscoveryErrors,
+  type DiscoveryError,
+  type DiscoveryErrorResolution,
+  useDeviceManagementKit,
+} from "@ledgerhq/live-dmk-mobile";
+import { Text, Flex, Button } from "@ledgerhq/native-ui";
+import { Subscription } from "rxjs";
+
+type ErrorDescription = {
+  title: string;
+  description: string;
+  details?: string[];
+};
+
+export default function DebugDeviceIntentExecutorDiscovery() {
+  const dmk = useDeviceManagementKit();
+  const service = useMemo(() => (dmk ? new DefaultDeviceDiscoveryService(dmk) : null), [dmk]);
+  const subscriptionsRef = useRef<Subscription | null>(null);
+
+  const [isRunning, setIsRunning] = useState(false);
+  const [isRetrying, setIsRetrying] = useState(false);
+  const [devices, setDevices] = useState<DiscoveredDevice[]>([]);
+  const [discoveryError, setDiscoveryError] = useState<DiscoveryError | null>(null);
+
+  const stopDiscovery = useCallback(() => {
+    service?.stop();
+    subscriptionsRef.current?.unsubscribe();
+    subscriptionsRef.current = null;
+    setDevices([]);
+    setIsRunning(false);
+  }, [service]);
+
+  const startDiscovery = useCallback(() => {
+    if (!service || subscriptionsRef.current) return;
+
+    setDevices([]);
+    setDiscoveryError(null);
+
+    const subscriptions = new Subscription();
+    subscriptionsRef.current = subscriptions;
+
+    subscriptions.add(service.discoveredDevices.subscribe(setDevices));
+    subscriptions.add(
+      service.errors.subscribe(error => {
+        service.stop();
+        subscriptions.unsubscribe();
+        subscriptionsRef.current = null;
+        setIsRunning(false);
+        setDiscoveryError(error);
+      }),
+    );
+
+    setIsRunning(true);
+    service.start();
+  }, [service]);
+
+  useEffect(() => stopDiscovery, [stopDiscovery]);
+
+  const retry = getRetry(discoveryError?.resolution);
+
+  const handleRetry = useCallback(async () => {
+    if (!retry) return;
+
+    setIsRetrying(true);
+    try {
+      const retryResult = await retry();
+
+      if (retryResult === true) {
+        startDiscovery();
+        return;
+      }
+
+      setDiscoveryError(retryResult);
+    } catch (error) {
+      setDiscoveryError({
+        type: DiscoveryErrors.Unknown,
+        error,
+      });
+    } finally {
+      setIsRetrying(false);
+    }
+  }, [retry, startDiscovery]);
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <Flex p={3} backgroundColor="primary.c10" borderRadius={8} mb={4}>
+        <Text variant="subtitle" mb={2}>
+          DIE Discovery Playground
+        </Text>
+        <Text variant="small" color="neutral.c70">
+          Exercises DefaultDeviceDiscoveryService directly. It discovers with all configured mobile
+          DMK transports, stops on discovery errors, and lets you retry the service&apos;s own
+          resolution callback.
+        </Text>
+      </Flex>
+
+      <Flex p={3} backgroundColor="neutral.c20" borderRadius={8} mb={4}>
+        <Text variant="subtitle" mb={2}>
+          Controls
+        </Text>
+        <StateRow label="DMK" value={dmk ? "ready" : "unavailable"} />
+        <StateRow label="Discovery" value={isRunning ? "running" : "stopped"} />
+        <StateRow label="Discovered devices" value={String(devices.length)} />
+        <Flex flexDirection="row" columnGap={12} mt={3}>
+          <Button type="main" flex={1} onPress={startDiscovery} disabled={!service || isRunning}>
+            Start
+          </Button>
+          <Button type="error" flex={1} onPress={stopDiscovery} disabled={!service || !isRunning}>
+            Stop
+          </Button>
+        </Flex>
+      </Flex>
+
+      {discoveryError ? (
+        <DiscoveryErrorCard error={discoveryError} isRetrying={isRetrying} onRetry={handleRetry} />
+      ) : null}
+
+      <Flex p={3} backgroundColor="neutral.c20" borderRadius={8}>
+        <Text variant="subtitle" mb={2}>
+          Discovered Devices
+        </Text>
+        {devices.length === 0 ? (
+          <Text variant="body" color="neutral.c70">
+            {isRunning ? "Looking for devices..." : "No discovered devices."}
+          </Text>
+        ) : (
+          devices.map(device => <DiscoveredDeviceCard key={device.id} device={device} />)
+        )}
+      </Flex>
+    </ScrollView>
+  );
+}
+
+function DiscoveryErrorCard({
+  error,
+  isRetrying,
+  onRetry,
+}: {
+  error: DiscoveryError;
+  isRetrying: boolean;
+  onRetry: () => void;
+}) {
+  const errorDescription = getDiscoveryErrorDescription(error);
+  const retry = getRetry(error.resolution);
+
+  return (
+    <Flex p={3} backgroundColor="error.c10" borderRadius={8} mb={4}>
+      <Text variant="subtitle" mb={2}>
+        {errorDescription.title}
+      </Text>
+      <Text variant="body" color="neutral.c100" mb={3}>
+        {errorDescription.description}
+      </Text>
+      <StateRow label="Type" value={error.type} />
+      <StateRow label="Transport" value={error.transportID ?? "-"} />
+      <StateRow label="Resolution" value={error.resolution?.type ?? "none"} />
+      {errorDescription.details?.map(detail => (
+        <Text key={detail} variant="small" color="neutral.c70" mt={2}>
+          {detail}
+        </Text>
+      ))}
+      {retry ? (
+        <Button type="main" mt={3} onPress={onRetry} disabled={isRetrying}>
+          {isRetrying ? "Retrying..." : "Retry"}
+        </Button>
+      ) : null}
+    </Flex>
+  );
+}
+
+function DiscoveredDeviceCard({ device }: { device: DiscoveredDevice }) {
+  return (
+    <Flex p={3} backgroundColor="neutral.c30" borderRadius={8} mb={3}>
+      <Text variant="body" fontWeight="semiBold" mb={2}>
+        {device.name || "Unnamed device"}
+      </Text>
+      <StateRow label="ID" value={device.id} />
+      <StateRow label="Model" value={String(device.deviceModel.model)} />
+      <StateRow label="Model name" value={device.deviceModel.name} />
+      <Text variant="small" color="neutral.c70" mt={2} mb={1}>
+        Raw device
+      </Text>
+      <Text variant="small" fontFamily="monospace" color="neutral.c70">
+        {JSON.stringify(device, null, 2)}
+      </Text>
+    </Flex>
+  );
+}
+
+function StateRow({ label, value }: { label: string; value: string }) {
+  return (
+    <Flex flexDirection="row" justifyContent="space-between" mb={1} columnGap={12}>
+      <Text variant="small" color="neutral.c70" flexShrink={0}>
+        {label}
+      </Text>
+      <Text variant="small" fontWeight="semiBold" flexShrink={1} textAlign="right">
+        {value}
+      </Text>
+    </Flex>
+  );
+}
+
+function getRetry(
+  resolution?: DiscoveryErrorResolution,
+): (() => Promise<true | DiscoveryError>) | null {
+  if (!resolution || resolution.type === "none") return null;
+  return resolution.retry;
+}
+
+function getDiscoveryErrorDescription(error: DiscoveryError): ErrorDescription {
+  switch (error.type) {
+    case DiscoveryErrors.BluetoothPermissionDeniedPromptable:
+      return {
+        title: "Bluetooth permission denied",
+        description:
+          "Android Bluetooth runtime permissions are denied, but the app can request them again.",
+        details: [`Permissions: ${error.permissions.join(", ")}`],
+      };
+    case DiscoveryErrors.BluetoothPermissionDeniedManualSettings:
+      return {
+        title: "Bluetooth permission denied in settings",
+        description:
+          "Android Bluetooth runtime permissions are denied and cannot be requested again from the app. Enable them manually in system settings.",
+        details: [`Permissions: ${error.permissions.join(", ")}`],
+      };
+    case DiscoveryErrors.BluetoothPermissionUnauthorizedManualSettings:
+      return {
+        title: "Bluetooth access unauthorized",
+        description:
+          "The OS reports Bluetooth access as unauthorized. The app cannot show the permission prompt again, so Bluetooth access must be restored from system settings.",
+      };
+    case DiscoveryErrors.BluetoothDisabledPromptable:
+      return {
+        title: "Bluetooth disabled",
+        description:
+          "Bluetooth is disabled and the platform can show a native enable prompt from the retry action.",
+      };
+    case DiscoveryErrors.BluetoothDisabledManualAction:
+      return {
+        title: "Bluetooth disabled manually",
+        description:
+          "Bluetooth is disabled and cannot be enabled through an in-app prompt. Enable Bluetooth manually, then retry.",
+        details: formatOptionalError(error.error),
+      };
+    case DiscoveryErrors.BluetoothStateUnknownCheckOnly:
+      return {
+        title: "Bluetooth state unknown",
+        description:
+          "Bluetooth is in an indeterminate state, such as Unknown or Resetting. Retry re-runs the state check.",
+        details: error.state ? [`State: ${error.state}`] : undefined,
+      };
+    case DiscoveryErrors.BluetoothUnsupported:
+      return {
+        title: "Bluetooth unsupported",
+        description:
+          "This device or platform does not support BLE. This is not recoverable through retry.",
+      };
+    case DiscoveryErrors.LocationPermissionDeniedPromptable:
+      return {
+        title: "Location permission denied",
+        description:
+          "Android location permission is required for BLE scanning and can be requested again from retry.",
+        details: [`Permission: ${error.permission}`],
+      };
+    case DiscoveryErrors.LocationPermissionDeniedManualSettings:
+      return {
+        title: "Location permission denied in settings",
+        description:
+          "Android location permission is required for BLE scanning but cannot be requested again from the app. Enable it manually in settings, then retry.",
+        details: [`Permission: ${error.permission}`],
+      };
+    case DiscoveryErrors.LocationDisabledPromptable:
+      return {
+        title: "Location services disabled",
+        description:
+          "Android location services are disabled and the platform can show a native enable prompt from retry.",
+      };
+    case DiscoveryErrors.LocationDisabledManualAction:
+      return {
+        title: "Location services disabled manually",
+        description:
+          "Android location services are disabled and cannot be enabled through an in-app prompt. Enable them manually, then retry.",
+        details: formatOptionalError(error.error),
+      };
+    case DiscoveryErrors.LocationServicePermissionMissing:
+      return {
+        title: "Location service permission missing",
+        description:
+          "Android location services could not be checked because location permission is missing unexpectedly. Retry re-runs the preflight checks.",
+      };
+    case DiscoveryErrors.Unknown:
+      return {
+        title: "Unknown discovery error",
+        description:
+          "An unexpected discovery or preflight failure occurred. Retry re-runs the discovery preflight when a retry action is available.",
+        details: formatOptionalError(error.error),
+      };
+  }
+}
+
+function formatOptionalError(error: unknown): string[] | undefined {
+  if (!error) return undefined;
+  if (error instanceof Error) return [`Error: ${error.message}`];
+
+  try {
+    return [`Error: ${JSON.stringify(error)}`];
+  } catch {
+    return [`Error: ${String(error)}`];
+  }
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  content: { padding: 16 },
+});

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/index.tsx
@@ -30,6 +30,11 @@ export default function DebugDeviceIntentExecutor() {
         description="Run one echo intent after initialization to inspect the extracted device context."
         onPress={() => navigation.navigate(ScreenName.DebugDeviceIntentExecutorInitialization)}
       />
+      <DebugEntry
+        title="Discovery"
+        description="Run DefaultDeviceDiscoveryService directly to inspect devices and retryable discovery errors."
+        onPress={() => navigation.navigate(ScreenName.DebugDeviceIntentExecutorDiscovery)}
+      />
     </ScrollView>
   );
 }

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/DefaultDeviceDiscoveryService.test.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/DefaultDeviceDiscoveryService.test.ts
@@ -1,0 +1,251 @@
+import type {
+  DeviceManagementKit,
+  DiscoveredDevice,
+  TransportIdentifier,
+} from "@ledgerhq/device-management-kit";
+import { Subject, type Observable } from "rxjs";
+import { DiscoveryErrors, type DiscoveryError } from "../types";
+import { DefaultDeviceDiscoveryService } from "./DefaultDeviceDiscoveryService";
+import type {
+  DeviceDiscoverySource,
+  DeviceDiscoverySourceEvent,
+} from "./sources/DeviceDiscoverySource";
+import { RnBleDeviceDiscoverySource } from "./sources/RnBleDeviceDiscoverySource";
+import { RnHidDeviceDiscoverySource } from "./sources/RnHidDeviceDiscoverySource";
+
+jest.mock("./sources/RnBleDeviceDiscoverySource", () => ({
+  RnBleDeviceDiscoverySource: jest.fn().mockImplementation(() => ({
+    listen: jest.fn(),
+    transportId: "ble",
+  })),
+}));
+
+jest.mock("./sources/RnHidDeviceDiscoverySource", () => ({
+  RnHidDeviceDiscoverySource: jest.fn().mockImplementation(() => ({
+    listen: jest.fn(),
+    transportId: "hid",
+  })),
+}));
+
+const createDiscoveredDevice = (id: string, transport: TransportIdentifier): DiscoveredDevice =>
+  ({
+    id,
+    name: id,
+    deviceModel: { id: "model", model: "model", name: "model" },
+    transport,
+  }) as unknown as DiscoveredDevice;
+
+const createSource = (
+  transportId: TransportIdentifier,
+  subject: Subject<DeviceDiscoverySourceEvent> = new Subject<DeviceDiscoverySourceEvent>(),
+): DeviceDiscoverySource & { subject: Subject<DeviceDiscoverySourceEvent>; listen: jest.Mock } => ({
+  transportId,
+  subject,
+  listen: jest.fn((): Observable<DeviceDiscoverySourceEvent> => subject.asObservable()),
+});
+
+const unknownErrorFor = (transportID: TransportIdentifier, error: unknown): DiscoveryError => ({
+  type: DiscoveryErrors.Unknown,
+  transportID,
+  error,
+});
+
+describe("DefaultDeviceDiscoveryService", () => {
+  it("GIVEN discovery has not started, WHEN subscribing to discovered devices, THEN it should emit an empty list", () => {
+    // GIVEN
+    const source = createSource("transport-1");
+    const service = new DefaultDeviceDiscoveryService(
+      {} as DeviceManagementKit,
+      new Map([[source.transportId, source]]),
+    );
+    const discoveredDevices: DiscoveredDevice[][] = [];
+
+    // WHEN
+    const subscription = service.discoveredDevices.subscribe(devices =>
+      discoveredDevices.push(devices),
+    );
+
+    // THEN
+    expect(discoveredDevices).toEqual([[]]);
+    subscription.unsubscribe();
+  });
+
+  it("GIVEN no source map is provided, WHEN creating the service, THEN it should build the default discovery source map", () => {
+    // GIVEN
+    const dmk = {
+      listenToAvailableDevices: jest.fn(() => new Subject<DiscoveredDevice[]>().asObservable()),
+    } as unknown as DeviceManagementKit;
+
+    // WHEN
+    const service = new DefaultDeviceDiscoveryService(dmk);
+
+    // THEN
+    expect(service.discoveredDevices).toBeDefined();
+    expect(RnBleDeviceDiscoverySource).toHaveBeenCalledWith(dmk);
+    expect(RnHidDeviceDiscoverySource).toHaveBeenCalledWith(dmk);
+  });
+
+  it("GIVEN all sources are started, WHEN they emit devices, THEN it should aggregate discovered devices", () => {
+    // GIVEN
+    const sourceA = createSource("transport-a");
+    const sourceB = createSource("transport-b");
+    const service = new DefaultDeviceDiscoveryService(
+      {} as DeviceManagementKit,
+      new Map([
+        [sourceA.transportId, sourceA],
+        [sourceB.transportId, sourceB],
+      ]),
+    );
+    const discoveredDevices: DiscoveredDevice[][] = [];
+    service.discoveredDevices.subscribe(devices => discoveredDevices.push(devices));
+    const deviceA = createDiscoveredDevice("a", sourceA.transportId);
+    const deviceB = createDiscoveredDevice("b", sourceB.transportId);
+
+    // WHEN
+    service.start();
+    sourceA.subject.next({ type: "devices", devices: [deviceA] });
+    sourceB.subject.next({ type: "devices", devices: [deviceB] });
+
+    // THEN
+    expect(discoveredDevices).toEqual([[], [], [deviceA], [deviceA, deviceB]]);
+  });
+
+  it("GIVEN transports are ignored, WHEN discovery starts, THEN it should not listen to ignored sources", () => {
+    // GIVEN
+    const sourceA = createSource("transport-a");
+    const sourceB = createSource("transport-b");
+    const service = new DefaultDeviceDiscoveryService(
+      {} as DeviceManagementKit,
+      new Map([
+        [sourceA.transportId, sourceA],
+        [sourceB.transportId, sourceB],
+      ]),
+    );
+
+    // WHEN
+    service.start({ ignoreTransportIdentifiers: [sourceB.transportId] });
+
+    // THEN
+    expect(sourceA.listen).toHaveBeenCalledTimes(1);
+    expect(sourceB.listen).not.toHaveBeenCalled();
+  });
+
+  it("GIVEN a source has devices, WHEN it emits an error, THEN it should clear that source and emit the error", () => {
+    // GIVEN
+    const sourceA = createSource("transport-a");
+    const sourceB = createSource("transport-b");
+    const service = new DefaultDeviceDiscoveryService(
+      {} as DeviceManagementKit,
+      new Map([
+        [sourceA.transportId, sourceA],
+        [sourceB.transportId, sourceB],
+      ]),
+    );
+    const discoveredDevices: DiscoveredDevice[][] = [];
+    const errors: DiscoveryError[] = [];
+    service.discoveredDevices.subscribe(devices => discoveredDevices.push(devices));
+    service.errors.subscribe(error => errors.push(error));
+    const deviceA = createDiscoveredDevice("a", sourceA.transportId);
+    const deviceB = createDiscoveredDevice("b", sourceB.transportId);
+    const discoveryError = unknownErrorFor(sourceA.transportId, new Error("source error"));
+
+    // WHEN
+    service.start();
+    sourceA.subject.next({ type: "devices", devices: [deviceA] });
+    sourceB.subject.next({ type: "devices", devices: [deviceB] });
+    sourceA.subject.next({ type: "error", error: discoveryError });
+
+    // THEN
+    expect(errors).toEqual([discoveryError]);
+    expect(discoveredDevices[discoveredDevices.length - 1]).toEqual([deviceB]);
+  });
+
+  it("GIVEN a source observable throws, WHEN discovery is running, THEN it should emit an unknown discovery error", () => {
+    // GIVEN
+    const source = createSource("transport-a");
+    const service = new DefaultDeviceDiscoveryService(
+      {} as DeviceManagementKit,
+      new Map([[source.transportId, source]]),
+    );
+    const errors: DiscoveryError[] = [];
+    service.errors.subscribe(error => errors.push(error));
+    const error = new Error("observable error");
+
+    // WHEN
+    service.start();
+    source.subject.error(error);
+
+    // THEN
+    expect(errors).toEqual([unknownErrorFor(source.transportId, error)]);
+  });
+
+  it("GIVEN a source has devices, WHEN it completes, THEN it should clear that source devices", () => {
+    // GIVEN
+    const source = createSource("transport-a");
+    const service = new DefaultDeviceDiscoveryService(
+      {} as DeviceManagementKit,
+      new Map([[source.transportId, source]]),
+    );
+    const discoveredDevices: DiscoveredDevice[][] = [];
+    service.discoveredDevices.subscribe(devices => discoveredDevices.push(devices));
+    const device = createDiscoveredDevice("a", source.transportId);
+
+    // WHEN
+    service.start();
+    source.subject.next({ type: "devices", devices: [device] });
+    source.subject.complete();
+
+    // THEN
+    expect(discoveredDevices[discoveredDevices.length - 1]).toEqual([]);
+  });
+
+  it("GIVEN discovery is already started, WHEN starting again before stop, THEN it should not subscribe twice", () => {
+    // GIVEN
+    const source = createSource("transport-a");
+    const service = new DefaultDeviceDiscoveryService(
+      {} as DeviceManagementKit,
+      new Map([[source.transportId, source]]),
+    );
+
+    // WHEN
+    service.start();
+    service.start();
+
+    // THEN
+    expect(source.listen).toHaveBeenCalledTimes(1);
+  });
+
+  it("GIVEN discovery has devices from multiple sources, WHEN stopping discovery, THEN it should unsubscribe all sources and emit an empty list", () => {
+    // GIVEN
+    const sourceA = createSource("transport-a");
+    const sourceB = createSource("transport-b");
+    const service = new DefaultDeviceDiscoveryService(
+      {} as DeviceManagementKit,
+      new Map([
+        [sourceA.transportId, sourceA],
+        [sourceB.transportId, sourceB],
+      ]),
+    );
+    const discoveredDevices: DiscoveredDevice[][] = [];
+    service.discoveredDevices.subscribe(devices => discoveredDevices.push(devices));
+    const deviceA = createDiscoveredDevice("a", sourceA.transportId);
+    const deviceB = createDiscoveredDevice("b", sourceB.transportId);
+
+    // WHEN
+    service.start();
+    sourceA.subject.next({ type: "devices", devices: [deviceA] });
+    sourceB.subject.next({ type: "devices", devices: [deviceB] });
+    service.stop();
+    sourceA.subject.next({
+      type: "devices",
+      devices: [createDiscoveredDevice("c", sourceA.transportId)],
+    });
+    sourceB.subject.next({
+      type: "devices",
+      devices: [createDiscoveredDevice("d", sourceB.transportId)],
+    });
+
+    // THEN
+    expect(discoveredDevices).toEqual([[], [], [deviceA], [deviceA, deviceB], []]);
+  });
+});

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/DefaultDeviceDiscoveryService.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/DefaultDeviceDiscoveryService.ts
@@ -1,0 +1,104 @@
+import type {
+  DeviceManagementKit,
+  DiscoveredDevice,
+  TransportIdentifier,
+} from "@ledgerhq/device-management-kit";
+import { BehaviorSubject, Subject, Subscription, type Observable } from "rxjs";
+import {
+  DiscoveryErrors,
+  type DeviceDiscoveryService,
+  type DeviceDiscoveryStartArgs,
+  type DiscoveryError,
+} from "../types";
+import { type DeviceDiscoverySource } from "./sources/DeviceDiscoverySource";
+import { RnBleDeviceDiscoverySource } from "./sources/RnBleDeviceDiscoverySource";
+import { RnHidDeviceDiscoverySource } from "./sources/RnHidDeviceDiscoverySource";
+
+const createDefaultDeviceDiscoverySources = (
+  dmk: DeviceManagementKit,
+): Map<TransportIdentifier, DeviceDiscoverySource> => {
+  const sources = [new RnHidDeviceDiscoverySource(dmk), new RnBleDeviceDiscoverySource(dmk)];
+
+  return new Map(sources.map(source => [source.transportId, source]));
+};
+
+/**
+ * Note: this logic should be part of the DMK, but for now the API of the DMK is not designed to handle:
+ * - discovery of a given set of transports at the same time (it's either all or 1 transport at a time)
+ * - preflight checks (BLE enabled, BLE permissions, android location services enabled, etc.),
+ * and related error management and retry logic.
+ */
+export class DefaultDeviceDiscoveryService implements DeviceDiscoveryService {
+  private subscription: Subscription | null = null;
+  private readonly discoveredDevicesSubject = new BehaviorSubject<DiscoveredDevice[]>([]);
+  private readonly errorsSubject = new Subject<DiscoveryError>();
+
+  readonly discoveredDevices: Observable<DiscoveredDevice[]> =
+    this.discoveredDevicesSubject.asObservable();
+  readonly errors: Observable<DiscoveryError> = this.errorsSubject.asObservable();
+
+  constructor(
+    dmk: DeviceManagementKit,
+    private readonly discoverySources = createDefaultDeviceDiscoverySources(dmk),
+  ) {}
+
+  start({ ignoreTransportIdentifiers = [] }: DeviceDiscoveryStartArgs = {}): void {
+    if (this.subscription) {
+      return;
+    }
+
+    const ignoredTransportIds = new Set(ignoreTransportIdentifiers);
+    const devicesByTransport = new Map<TransportIdentifier, DiscoveredDevice[]>();
+    const subscription = new Subscription();
+
+    this.discoverySources.forEach(source => {
+      if (ignoredTransportIds.has(source.transportId)) {
+        return;
+      }
+
+      subscription.add(
+        source.listen().subscribe({
+          next: event => {
+            if (event.type === "devices") {
+              devicesByTransport.set(source.transportId, event.devices);
+              this.emitDiscoveredDevices(devicesByTransport);
+              return;
+            }
+
+            devicesByTransport.set(source.transportId, []);
+            this.emitDiscoveredDevices(devicesByTransport);
+            this.errorsSubject.next(event.error);
+          },
+          error: error => {
+            devicesByTransport.set(source.transportId, []);
+            this.emitDiscoveredDevices(devicesByTransport);
+            this.errorsSubject.next({
+              type: DiscoveryErrors.Unknown,
+              transportID: source.transportId,
+              error,
+            });
+          },
+          complete: () => {
+            devicesByTransport.set(source.transportId, []);
+            this.emitDiscoveredDevices(devicesByTransport);
+          },
+        }),
+      );
+    });
+
+    this.subscription = subscription;
+    this.emitDiscoveredDevices(devicesByTransport);
+  }
+
+  stop(): void {
+    this.subscription?.unsubscribe();
+    this.subscription = null;
+    this.discoveredDevicesSubject.next([]);
+  }
+
+  private emitDiscoveredDevices(
+    devicesByTransport: Map<TransportIdentifier, DiscoveredDevice[]>,
+  ): void {
+    this.discoveredDevicesSubject.next([...devicesByTransport.values()].flat());
+  }
+}

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/DefaultBleDiscoveryPreflightChecks.test.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/DefaultBleDiscoveryPreflightChecks.test.ts
@@ -1,0 +1,86 @@
+import { Platform } from "react-native";
+import { AndroidBleDiscoveryPreflightChecks } from "./android/AndroidBleDiscoveryPreflightChecks";
+import { DefaultBleDiscoveryPreflightChecks } from "./DefaultBleDiscoveryPreflightChecks";
+import { IosBleDiscoveryPreflightChecks } from "./ios/IosBleDiscoveryPreflightChecks";
+import type { DiscoveryPreflightChecks, DiscoveryPreflightResult } from "./preflightResult";
+
+jest.mock("./android/AndroidBleDiscoveryPreflightChecks", () => ({
+  AndroidBleDiscoveryPreflightChecks: jest.fn().mockImplementation(() => ({
+    getPreflight: jest.fn().mockResolvedValue({ success: true }),
+  })),
+}));
+
+jest.mock("./ios/IosBleDiscoveryPreflightChecks", () => ({
+  IosBleDiscoveryPreflightChecks: jest.fn().mockImplementation(() => ({
+    getPreflight: jest.fn().mockResolvedValue({ success: true }),
+  })),
+}));
+
+describe("DefaultBleDiscoveryPreflightChecks", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  it("GIVEN Android platform, WHEN running default preflight, THEN it should use Android preflight checks", async () => {
+    // GIVEN
+    const preflightChecks = new DefaultBleDiscoveryPreflightChecks(undefined, "android");
+
+    // WHEN
+    const result = preflightChecks.getPreflight();
+
+    // THEN
+    await expect(result).resolves.toEqual({
+      success: true,
+    });
+    expect(AndroidBleDiscoveryPreflightChecks).toHaveBeenCalledTimes(1);
+    expect(IosBleDiscoveryPreflightChecks).not.toHaveBeenCalled();
+  });
+
+  it("GIVEN iOS platform, WHEN running default preflight, THEN it should use iOS preflight checks", async () => {
+    // GIVEN
+    const preflightChecks = new DefaultBleDiscoveryPreflightChecks(undefined, "ios");
+
+    // WHEN
+    const result = preflightChecks.getPreflight();
+
+    // THEN
+    await expect(result).resolves.toEqual({
+      success: true,
+    });
+    expect(IosBleDiscoveryPreflightChecks).toHaveBeenCalledTimes(1);
+    expect(AndroidBleDiscoveryPreflightChecks).not.toHaveBeenCalled();
+  });
+
+  it("GIVEN an unsupported platform, WHEN running default preflight, THEN it should resolve successfully", async () => {
+    // GIVEN
+    const preflightChecks = new DefaultBleDiscoveryPreflightChecks(
+      undefined,
+      "windows" as typeof Platform.OS,
+    );
+
+    // WHEN
+    const result = preflightChecks.getPreflight();
+
+    // THEN
+    await expect(result).resolves.toEqual({ success: true });
+    expect(AndroidBleDiscoveryPreflightChecks).not.toHaveBeenCalled();
+    expect(IosBleDiscoveryPreflightChecks).not.toHaveBeenCalled();
+  });
+
+  it("GIVEN injected preflight checks, WHEN running default preflight, THEN it should delegate to them", async () => {
+    // GIVEN
+    const result: DiscoveryPreflightResult = { success: true };
+    const injectedPreflightChecks: DiscoveryPreflightChecks = {
+      getPreflight: jest.fn().mockResolvedValue(result),
+    };
+    const preflightChecks = new DefaultBleDiscoveryPreflightChecks(injectedPreflightChecks);
+
+    // WHEN
+    const preflightResult = preflightChecks.getPreflight();
+
+    // THEN
+    await expect(preflightResult).resolves.toBe(result);
+    expect(injectedPreflightChecks.getPreflight).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/DefaultBleDiscoveryPreflightChecks.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/DefaultBleDiscoveryPreflightChecks.ts
@@ -1,0 +1,37 @@
+import { Platform } from "react-native";
+import { AndroidBleDiscoveryPreflightChecks } from "./android/AndroidBleDiscoveryPreflightChecks";
+import { IosBleDiscoveryPreflightChecks } from "./ios/IosBleDiscoveryPreflightChecks";
+import type { DiscoveryPreflightChecks, DiscoveryPreflightResult } from "./preflightResult";
+
+const successPreflightChecks: DiscoveryPreflightChecks = {
+  getPreflight: async (): Promise<DiscoveryPreflightResult> => ({ success: true }),
+};
+
+const createPlatformPreflightChecks = (
+  platformOS: typeof Platform.OS,
+): DiscoveryPreflightChecks => {
+  if (platformOS === "android") {
+    return new AndroidBleDiscoveryPreflightChecks();
+  }
+
+  if (platformOS === "ios") {
+    return new IosBleDiscoveryPreflightChecks();
+  }
+
+  return successPreflightChecks;
+};
+
+export class DefaultBleDiscoveryPreflightChecks implements DiscoveryPreflightChecks {
+  private readonly preflightChecks: DiscoveryPreflightChecks;
+
+  constructor(
+    preflightChecks?: DiscoveryPreflightChecks,
+    platformOS: typeof Platform.OS = Platform.OS,
+  ) {
+    this.preflightChecks = preflightChecks ?? createPlatformPreflightChecks(platformOS);
+  }
+
+  getPreflight(): Promise<DiscoveryPreflightResult> {
+    return this.preflightChecks.getPreflight();
+  }
+}

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/AndroidBleDiscoveryPreflightChecks.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/AndroidBleDiscoveryPreflightChecks.ts
@@ -1,0 +1,60 @@
+import type { DiscoveryError } from "../../../types";
+import { AndroidBluetoothPermissionPreflightCheck } from "./AndroidBluetoothPermissionPreflightCheck";
+import { AndroidBluetoothServicePreflightCheck } from "./AndroidBluetoothServicePreflightCheck";
+import { AndroidLocationPermissionPreflightCheck } from "./AndroidLocationPermissionPreflightCheck";
+import { AndroidLocationServicePreflightCheck } from "./AndroidLocationServicePreflightCheck";
+import {
+  getAndroidPreflightRequirements,
+  type AndroidPreflightCheckId,
+  type AndroidPreflightRequirements,
+} from "./androidPreflightRequirements";
+import {
+  retryPreflightCheck,
+  successPreflightResult,
+  type DiscoveryPreflightChecks,
+  type DiscoveryPreflightResult,
+} from "../preflightResult";
+
+type PreflightRetry = () => Promise<true | DiscoveryError>;
+
+type AndroidPreflightCheckRunner = {
+  run(requirements: AndroidPreflightRequirements): Promise<DiscoveryPreflightResult>;
+};
+
+type AndroidPreflightCheckFactory = (
+  retry: PreflightRetry,
+) => Record<AndroidPreflightCheckId, AndroidPreflightCheckRunner>;
+
+const createDefaultChecks: AndroidPreflightCheckFactory = retry => ({
+  "bluetooth-permission": new AndroidBluetoothPermissionPreflightCheck(retry),
+  "bluetooth-service": new AndroidBluetoothServicePreflightCheck(retry),
+  "location-permission": new AndroidLocationPermissionPreflightCheck(retry),
+  "location-service": new AndroidLocationServicePreflightCheck(retry),
+});
+
+export class AndroidBleDiscoveryPreflightChecks implements DiscoveryPreflightChecks {
+  constructor(
+    private readonly makeChecks = createDefaultChecks,
+    private readonly getRequirements = getAndroidPreflightRequirements,
+  ) {}
+
+  async getPreflight(): Promise<DiscoveryPreflightResult> {
+    const requirements = this.getRequirements();
+    /**
+     * If one of the checks fails, we retry the entire chain so that it moves on to the next check
+     * and so on until all checks are completed or one fails.
+     */
+    const retry = () => retryPreflightCheck(() => this.getPreflight());
+    const checks = this.makeChecks(retry);
+
+    for (const check of requirements.checks) {
+      const result = await checks[check].run(requirements);
+
+      if (!result.success) {
+        return result;
+      }
+    }
+
+    return successPreflightResult;
+  }
+}

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/AndroidBluetoothPermissionPreflightCheck.test.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/AndroidBluetoothPermissionPreflightCheck.test.ts
@@ -1,0 +1,59 @@
+import type { Permission } from "react-native";
+import type { DiscoveryError } from "../../../types";
+import { AndroidBluetoothPermissionPreflightCheck } from "./AndroidBluetoothPermissionPreflightCheck";
+import type { AndroidPreflightRequirements } from "./androidPreflightRequirements";
+import {
+  buildBluetoothPermissionManualSettingsError,
+  buildBluetoothPermissionPromptableError,
+} from "../discoveryErrorBuilders";
+import { runPermissionPreflight } from "./permissionHelpers";
+import type { DiscoveryPreflightResult } from "../preflightResult";
+
+jest.mock("./permissionHelpers", () => ({
+  runPermissionPreflight: jest.fn(),
+}));
+
+const retry = jest.fn<Promise<true | DiscoveryError>, []>();
+
+describe("AndroidBluetoothPermissionPreflightCheck", () => {
+  beforeEach(() => {
+    retry.mockReset();
+    jest.mocked(runPermissionPreflight).mockReset();
+  });
+
+  it("GIVEN Bluetooth permissions, WHEN running preflight, THEN it should delegate to the permission helper", async () => {
+    // GIVEN
+    const result: DiscoveryPreflightResult = { success: true };
+    const bluetoothPermissions = [
+      "android.permission.BLUETOOTH_SCAN",
+      "android.permission.BLUETOOTH_CONNECT",
+    ] as Permission[];
+    const requirements = makeRequirements({ bluetoothPermissions });
+    jest.mocked(runPermissionPreflight).mockResolvedValue(result);
+
+    // WHEN
+    const preflightResult = await new AndroidBluetoothPermissionPreflightCheck(retry).run(
+      requirements,
+    );
+
+    // THEN
+    expect(preflightResult).toBe(result);
+    expect(runPermissionPreflight).toHaveBeenCalledWith({
+      permissions: bluetoothPermissions,
+      retry,
+      buildPromptableError: buildBluetoothPermissionPromptableError,
+      buildManualSettingsError: buildBluetoothPermissionManualSettingsError,
+    });
+  });
+});
+
+const makeRequirements = (
+  override: Partial<AndroidPreflightRequirements> = {},
+): AndroidPreflightRequirements => ({
+  sdk: "test",
+  matches: () => true,
+  checks: ["bluetooth-permission"],
+  bluetoothPermissions: [],
+  locationPermission: null,
+  ...override,
+});

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/AndroidBluetoothPermissionPreflightCheck.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/AndroidBluetoothPermissionPreflightCheck.ts
@@ -1,0 +1,27 @@
+import type { DiscoveryError } from "../../../types";
+import type { AndroidPreflightRequirements } from "./androidPreflightRequirements";
+import {
+  buildBluetoothPermissionManualSettingsError,
+  buildBluetoothPermissionPromptableError,
+} from "../discoveryErrorBuilders";
+import { runPermissionPreflight } from "./permissionHelpers";
+import { type DiscoveryPreflightResult } from "../preflightResult";
+
+/**
+ * Checks the Android Bluetooth runtime permissions required before BLE discovery can start.
+ *
+ * The requirements object provides the SDK-specific permission list, and missing permissions are
+ * requested through the shared permission preflight helper.
+ */
+export class AndroidBluetoothPermissionPreflightCheck {
+  constructor(private readonly retry: () => Promise<true | DiscoveryError>) {}
+
+  async run(requirements: AndroidPreflightRequirements): Promise<DiscoveryPreflightResult> {
+    return runPermissionPreflight({
+      permissions: requirements.bluetoothPermissions,
+      retry: this.retry,
+      buildPromptableError: buildBluetoothPermissionPromptableError,
+      buildManualSettingsError: buildBluetoothPermissionManualSettingsError,
+    });
+  }
+}

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/AndroidBluetoothServicePreflightCheck.test.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/AndroidBluetoothServicePreflightCheck.test.ts
@@ -1,0 +1,205 @@
+import { State as BlePlxState } from "react-native-ble-plx";
+import type { DiscoveryError } from "../../../types";
+import { DiscoveryErrors } from "../../../types";
+import {
+  AndroidBluetoothServicePreflightCheck,
+  type BleStateProvider,
+} from "./AndroidBluetoothServicePreflightCheck";
+import type { AndroidPreflightRequirements } from "./androidPreflightRequirements";
+import type { BluetoothHelperModule } from "../nativeModules";
+import type { DiscoveryPreflightResult } from "../preflightResult";
+
+jest.mock("react-native-ble-plx", () => ({
+  BleManager: jest.fn(),
+  State: {
+    PoweredOn: "PoweredOn",
+    PoweredOff: "PoweredOff",
+    Resetting: "Resetting",
+    Unauthorized: "Unauthorized",
+    Unknown: "Unknown",
+    Unsupported: "Unsupported",
+  },
+}));
+
+const retry = jest.fn<Promise<true | DiscoveryError>, []>();
+
+describe("AndroidBluetoothServicePreflightCheck", () => {
+  beforeEach(() => {
+    retry.mockReset();
+  });
+
+  it("GIVEN Bluetooth is powered on, WHEN running preflight, THEN it should succeed without prompting", async () => {
+    // GIVEN
+    const { check, getBluetoothHelper, getState } = makeCheck({
+      states: [BlePlxState.PoweredOn],
+    });
+
+    // WHEN
+    const result = await check.run(makeRequirements());
+
+    // THEN
+    expect(result).toEqual({ success: true });
+    expect(getState).toHaveBeenCalledTimes(1);
+    expect(getBluetoothHelper).not.toHaveBeenCalled();
+  });
+
+  it("GIVEN Bluetooth is in an unknown state, WHEN running preflight, THEN it should return a check-only Bluetooth state error", async () => {
+    // GIVEN
+    const { check } = makeCheck({ states: [BlePlxState.Unknown] });
+
+    // WHEN
+    const result = await check.run(makeRequirements());
+
+    // THEN
+    expect(getError(result)).toMatchObject({
+      type: DiscoveryErrors.BluetoothStateUnknownCheckOnly,
+      state: BlePlxState.Unknown,
+      resolution: { type: "check-only", retry },
+    });
+  });
+
+  it("GIVEN Bluetooth is powered off and no prompt helper exists, WHEN running preflight, THEN it should require manual action", async () => {
+    // GIVEN
+    const { check } = makeCheck({ states: [BlePlxState.PoweredOff] });
+
+    // WHEN
+    const result = await check.run(makeRequirements());
+
+    // THEN
+    expect(getError(result)).toMatchObject({
+      type: DiscoveryErrors.BluetoothDisabledManualAction,
+      resolution: { type: "manual-action", retry },
+    });
+  });
+
+  it("GIVEN Bluetooth is powered off and the prompt enables it, WHEN running preflight, THEN it should succeed", async () => {
+    // GIVEN
+    const prompt = jest.fn().mockResolvedValue(undefined);
+    const { check, getState } = makeCheck({
+      states: [BlePlxState.PoweredOff, BlePlxState.PoweredOn],
+      bluetoothHelper: { prompt },
+    });
+
+    // WHEN
+    const result = await check.run(makeRequirements());
+
+    // THEN
+    expect(result).toEqual({ success: true });
+    expect(prompt).toHaveBeenCalledTimes(1);
+    expect(getState).toHaveBeenCalledTimes(2);
+  });
+
+  it("GIVEN Bluetooth stays powered off after the prompt, WHEN running preflight, THEN it should require manual action", async () => {
+    // GIVEN
+    const prompt = jest.fn().mockResolvedValue(undefined);
+    const { check } = makeCheck({
+      states: [BlePlxState.PoweredOff, BlePlxState.PoweredOff],
+      bluetoothHelper: { prompt },
+    });
+
+    // WHEN
+    const result = await check.run(makeRequirements());
+
+    // THEN
+    expect(getError(result)).toMatchObject({
+      type: DiscoveryErrors.BluetoothDisabledManualAction,
+      resolution: { type: "manual-action", retry },
+    });
+  });
+
+  it("GIVEN Bluetooth enters an unknown state after the prompt, WHEN running preflight, THEN it should return a state error", async () => {
+    // GIVEN
+    const prompt = jest.fn().mockResolvedValue(undefined);
+    const { check } = makeCheck({
+      states: [BlePlxState.PoweredOff, BlePlxState.Resetting],
+      bluetoothHelper: { prompt },
+    });
+
+    // WHEN
+    const result = await check.run(makeRequirements());
+
+    // THEN
+    expect(getError(result)).toMatchObject({
+      type: DiscoveryErrors.BluetoothStateUnknownCheckOnly,
+      state: BlePlxState.Resetting,
+      resolution: { type: "check-only", retry },
+    });
+  });
+
+  it("GIVEN the user cancels the Bluetooth prompt, WHEN running preflight, THEN it should return a promptable Bluetooth disabled error", async () => {
+    // GIVEN
+    const prompt = jest.fn().mockRejectedValue({ code: "E_BLE_CANCELLED" });
+    const { check } = makeCheck({
+      states: [BlePlxState.PoweredOff],
+      bluetoothHelper: { E_BLE_CANCELLED: "E_BLE_CANCELLED", prompt },
+    });
+
+    // WHEN
+    const result = await check.run(makeRequirements());
+
+    // THEN
+    expect(getError(result)).toMatchObject({
+      type: DiscoveryErrors.BluetoothDisabledPromptable,
+      resolution: { type: "prompt", retry },
+    });
+  });
+
+  it("GIVEN the Bluetooth prompt fails unexpectedly, WHEN running preflight, THEN it should require manual action with the native error", async () => {
+    // GIVEN
+    const nativeError = new Error("prompt failure");
+    const prompt = jest.fn().mockRejectedValue(nativeError);
+    const { check } = makeCheck({
+      states: [BlePlxState.PoweredOff],
+      bluetoothHelper: { E_BLE_CANCELLED: "E_BLE_CANCELLED", prompt },
+    });
+
+    // WHEN
+    const result = await check.run(makeRequirements());
+
+    // THEN
+    expect(getError(result)).toMatchObject({
+      type: DiscoveryErrors.BluetoothDisabledManualAction,
+      error: nativeError,
+      resolution: { type: "manual-action", retry },
+    });
+  });
+});
+
+const makeCheck = ({
+  states,
+  bluetoothHelper,
+}: {
+  states: BlePlxState[];
+  bluetoothHelper?: BluetoothHelperModule;
+}) => {
+  const getState = jest.fn<Promise<BlePlxState>, []>();
+  for (const state of states) {
+    getState.mockResolvedValueOnce(state);
+  }
+
+  const bleStateProvider: BleStateProvider = { getState };
+  const getBluetoothHelper = jest.fn(() => bluetoothHelper);
+  const check = new AndroidBluetoothServicePreflightCheck(
+    retry,
+    bleStateProvider,
+    getBluetoothHelper,
+  );
+
+  return { check, getBluetoothHelper, getState };
+};
+
+const makeRequirements = (): AndroidPreflightRequirements => ({
+  sdk: "test",
+  matches: () => true,
+  checks: ["bluetooth-service"],
+  bluetoothPermissions: [],
+  locationPermission: null,
+});
+
+const getError = (result: DiscoveryPreflightResult): DiscoveryError => {
+  if (result.success) {
+    throw new Error("Expected a failed preflight result");
+  }
+
+  return result.discoveryError;
+};

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/AndroidBluetoothServicePreflightCheck.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/AndroidBluetoothServicePreflightCheck.ts
@@ -1,0 +1,88 @@
+import { State as BlePlxState } from "react-native-ble-plx";
+import { BlePlxManager } from "../../../../transport/BlePlxManager";
+import type { DiscoveryError } from "../../../types";
+import type { AndroidPreflightRequirements } from "./androidPreflightRequirements";
+import {
+  buildBluetoothDisabledManualActionError,
+  buildBluetoothDisabledPromptableError,
+  buildBluetoothStateError,
+} from "../discoveryErrorBuilders";
+import { getBluetoothHelperModule, getNativeErrorCode } from "../nativeModules";
+import {
+  mapDiscoveryErrorToPreflightResult,
+  successPreflightResult,
+  type DiscoveryPreflightResult,
+} from "../preflightResult";
+
+export type BleStateProvider = {
+  getState(): Promise<BlePlxState>;
+};
+
+const defaultBleStateProvider: BleStateProvider = {
+  getState: () => BlePlxManager.state(),
+};
+
+/**
+ * Checks whether the Android Bluetooth service is enabled before BLE discovery starts.
+ *
+ * If Bluetooth is powered off, the check uses the native helper prompt when available and then
+ * verifies the state again before deciding whether the user must act manually.
+ */
+export class AndroidBluetoothServicePreflightCheck {
+  constructor(
+    private readonly retry: () => Promise<true | DiscoveryError>,
+    private readonly bleStateProvider = defaultBleStateProvider,
+    private readonly getBluetoothHelper = getBluetoothHelperModule,
+  ) {}
+
+  async run(_requirements: AndroidPreflightRequirements): Promise<DiscoveryPreflightResult> {
+    const state = await this.bleStateProvider.getState();
+
+    if (state === BlePlxState.PoweredOn) {
+      return successPreflightResult;
+    }
+
+    if (state === BlePlxState.PoweredOff) {
+      return this.promptBluetoothService();
+    }
+
+    return mapDiscoveryErrorToPreflightResult(buildBluetoothStateError(state, this.retry));
+  }
+
+  /**
+   * Prompt the user to enable Bluetooth and check the state again.
+   */
+  private async promptBluetoothService(): Promise<DiscoveryPreflightResult> {
+    const bluetoothHelperModule = this.getBluetoothHelper();
+
+    if (!bluetoothHelperModule?.prompt) {
+      return mapDiscoveryErrorToPreflightResult(
+        buildBluetoothDisabledManualActionError(this.retry),
+      );
+    }
+
+    try {
+      await bluetoothHelperModule.prompt();
+      const state = await this.bleStateProvider.getState();
+      return this.mapStateAfterBluetoothPrompt(state);
+    } catch (error) {
+      return mapDiscoveryErrorToPreflightResult(
+        getNativeErrorCode(error) === bluetoothHelperModule.E_BLE_CANCELLED
+          ? buildBluetoothDisabledPromptableError(this.retry)
+          : buildBluetoothDisabledManualActionError(this.retry, error),
+      );
+    }
+  }
+
+  private mapStateAfterBluetoothPrompt(state: BlePlxState): DiscoveryPreflightResult {
+    if (state === BlePlxState.PoweredOn) {
+      return successPreflightResult;
+    }
+
+    return mapDiscoveryErrorToPreflightResult(
+      state === BlePlxState.PoweredOff
+        ? buildBluetoothDisabledManualActionError(this.retry)
+        : buildBluetoothStateError(state, this.retry),
+    );
+  }
+}

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/AndroidLocationPermissionPreflightCheck.test.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/AndroidLocationPermissionPreflightCheck.test.ts
@@ -1,0 +1,77 @@
+import type { Permission } from "react-native";
+import type { DiscoveryError } from "../../../types";
+import { AndroidLocationPermissionPreflightCheck } from "./AndroidLocationPermissionPreflightCheck";
+import type { AndroidPreflightRequirements } from "./androidPreflightRequirements";
+import {
+  buildLocationPermissionManualSettingsError,
+  buildLocationPermissionPromptableError,
+} from "../discoveryErrorBuilders";
+import { runPermissionPreflight } from "./permissionHelpers";
+import type { DiscoveryPreflightResult } from "../preflightResult";
+
+jest.mock("./permissionHelpers", () => ({
+  runPermissionPreflight: jest.fn(),
+}));
+
+const retry = jest.fn<Promise<true | DiscoveryError>, []>();
+
+describe("AndroidLocationPermissionPreflightCheck", () => {
+  beforeEach(() => {
+    retry.mockReset();
+    jest.mocked(runPermissionPreflight).mockReset();
+  });
+
+  it("GIVEN a location permission requirement, WHEN running preflight, THEN it should delegate that permission to the helper", async () => {
+    // GIVEN
+    const result: DiscoveryPreflightResult = { success: true };
+    const locationPermission = "android.permission.ACCESS_FINE_LOCATION" as Permission;
+    const requirements = makeRequirements({ locationPermission });
+    jest.mocked(runPermissionPreflight).mockResolvedValue(result);
+
+    // WHEN
+    const preflightResult = await new AndroidLocationPermissionPreflightCheck(retry).run(
+      requirements,
+    );
+
+    // THEN
+    expect(preflightResult).toBe(result);
+    expect(runPermissionPreflight).toHaveBeenCalledWith({
+      permissions: [locationPermission],
+      retry,
+      buildPromptableError: buildLocationPermissionPromptableError,
+      buildManualSettingsError: buildLocationPermissionManualSettingsError,
+    });
+  });
+
+  it("GIVEN no location permission requirement, WHEN running preflight, THEN it should delegate an empty permission list", async () => {
+    // GIVEN
+    const result: DiscoveryPreflightResult = { success: true };
+    const requirements = makeRequirements({ locationPermission: null });
+    jest.mocked(runPermissionPreflight).mockResolvedValue(result);
+
+    // WHEN
+    const preflightResult = await new AndroidLocationPermissionPreflightCheck(retry).run(
+      requirements,
+    );
+
+    // THEN
+    expect(preflightResult).toBe(result);
+    expect(runPermissionPreflight).toHaveBeenCalledWith({
+      permissions: [],
+      retry,
+      buildPromptableError: buildLocationPermissionPromptableError,
+      buildManualSettingsError: buildLocationPermissionManualSettingsError,
+    });
+  });
+});
+
+const makeRequirements = (
+  override: Partial<AndroidPreflightRequirements> = {},
+): AndroidPreflightRequirements => ({
+  sdk: "test",
+  matches: () => true,
+  checks: ["location-permission"],
+  bluetoothPermissions: [],
+  locationPermission: null,
+  ...override,
+});

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/AndroidLocationPermissionPreflightCheck.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/AndroidLocationPermissionPreflightCheck.ts
@@ -1,0 +1,27 @@
+import type { DiscoveryError } from "../../../types";
+import type { AndroidPreflightRequirements } from "./androidPreflightRequirements";
+import {
+  buildLocationPermissionManualSettingsError,
+  buildLocationPermissionPromptableError,
+} from "../discoveryErrorBuilders";
+import { runPermissionPreflight } from "./permissionHelpers";
+import { type DiscoveryPreflightResult } from "../preflightResult";
+
+/**
+ * Checks the Android location permission required by BLE scanning on SDKs that still depend on it.
+ *
+ * When the current SDK has no location permission requirement, the check delegates an empty list to
+ * the shared permission preflight helper so the chain can continue successfully.
+ */
+export class AndroidLocationPermissionPreflightCheck {
+  constructor(private readonly retry: () => Promise<true | DiscoveryError>) {}
+
+  async run(requirements: AndroidPreflightRequirements): Promise<DiscoveryPreflightResult> {
+    return runPermissionPreflight({
+      permissions: requirements.locationPermission ? [requirements.locationPermission] : [],
+      retry: this.retry,
+      buildPromptableError: buildLocationPermissionPromptableError,
+      buildManualSettingsError: buildLocationPermissionManualSettingsError,
+    });
+  }
+}

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/AndroidLocationServicePreflightCheck.test.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/AndroidLocationServicePreflightCheck.test.ts
@@ -1,0 +1,136 @@
+import type { DiscoveryError } from "../../../types";
+import { DiscoveryErrors } from "../../../types";
+import { AndroidLocationServicePreflightCheck } from "./AndroidLocationServicePreflightCheck";
+import type { AndroidPreflightRequirements } from "./androidPreflightRequirements";
+import type { LocationHelperModule, LocationServiceResponse } from "../nativeModules";
+import type { DiscoveryPreflightResult } from "../preflightResult";
+
+const retry = jest.fn<Promise<true | DiscoveryError>, []>();
+
+describe("AndroidLocationServicePreflightCheck", () => {
+  beforeEach(() => {
+    retry.mockReset();
+  });
+
+  it("GIVEN no location helper exists, WHEN running preflight, THEN it should require manual action", async () => {
+    // GIVEN
+    const check = new AndroidLocationServicePreflightCheck(retry, () => undefined);
+
+    // WHEN
+    const result = await check.run(makeRequirements());
+
+    // THEN
+    expect(getError(result)).toMatchObject({
+      type: DiscoveryErrors.LocationDisabledManualAction,
+      resolution: { type: "manual-action", retry },
+    });
+  });
+
+  it.each<LocationServiceResponse>([
+    "SUCCESS_LOCATION_ALREADY_ENABLED",
+    "SUCCESS_LOCATION_ENABLED",
+  ])(
+    "GIVEN native location service response %s, WHEN running preflight, THEN it should succeed",
+    async response => {
+      // GIVEN
+      const { check } = makeCheck(response);
+
+      // WHEN
+      const result = await check.run(makeRequirements());
+
+      // THEN
+      expect(result).toEqual({ success: true });
+    },
+  );
+
+  it("GIVEN the user denies the native location prompt, WHEN running preflight, THEN it should return a promptable location disabled error", async () => {
+    // GIVEN
+    const { check } = makeCheck("ERROR_USER_DENIED_LOCATION");
+
+    // WHEN
+    const result = await check.run(makeRequirements());
+
+    // THEN
+    expect(getError(result)).toMatchObject({
+      type: DiscoveryErrors.LocationDisabledPromptable,
+      resolution: { type: "prompt", retry },
+    });
+  });
+
+  it("GIVEN native location service needs permission, WHEN running preflight, THEN it should return a permission missing error", async () => {
+    // GIVEN
+    const { check } = makeCheck("ERROR_LOCATION_PERMISSIONS_NEEDED");
+
+    // WHEN
+    const result = await check.run(makeRequirements());
+
+    // THEN
+    expect(getError(result)).toMatchObject({
+      type: DiscoveryErrors.LocationServicePermissionMissing,
+      resolution: { type: "check-only", retry },
+    });
+  });
+
+  it.each<LocationServiceResponse>(["ERROR_ACTIVITY_DOES_NOT_EXIST", "ERROR_UNKNOWN"])(
+    "GIVEN native location service response %s, WHEN running preflight, THEN it should require manual action",
+    async response => {
+      // GIVEN
+      const { check } = makeCheck(response);
+
+      // WHEN
+      const result = await check.run(makeRequirements());
+
+      // THEN
+      expect(getError(result)).toMatchObject({
+        type: DiscoveryErrors.LocationDisabledManualAction,
+        error: response,
+        resolution: { type: "manual-action", retry },
+      });
+    },
+  );
+
+  it("GIVEN the native location helper fails unexpectedly, WHEN running preflight, THEN it should return an unknown discovery error", async () => {
+    // GIVEN
+    const nativeError = new Error("native failure");
+    const checkAndRequestEnablingLocationServices = jest.fn().mockRejectedValue(nativeError);
+    const check = new AndroidLocationServicePreflightCheck(retry, () => ({
+      checkAndRequestEnablingLocationServices,
+    }));
+
+    // WHEN
+    const result = await check.run(makeRequirements());
+
+    // THEN
+    expect(getError(result)).toMatchObject({
+      type: DiscoveryErrors.Unknown,
+      error: nativeError,
+      resolution: { type: "check-only", retry },
+    });
+  });
+});
+
+const makeCheck = (response: LocationServiceResponse) => {
+  const checkAndRequestEnablingLocationServices = jest.fn<Promise<LocationServiceResponse>, []>();
+  checkAndRequestEnablingLocationServices.mockResolvedValue(response);
+
+  const locationHelper: LocationHelperModule = { checkAndRequestEnablingLocationServices };
+  const check = new AndroidLocationServicePreflightCheck(retry, () => locationHelper);
+
+  return { check, checkAndRequestEnablingLocationServices };
+};
+
+const makeRequirements = (): AndroidPreflightRequirements => ({
+  sdk: "test",
+  matches: () => true,
+  checks: ["location-service"],
+  bluetoothPermissions: [],
+  locationPermission: null,
+});
+
+const getError = (result: DiscoveryPreflightResult): DiscoveryError => {
+  if (result.success) {
+    throw new Error("Expected a failed preflight result");
+  }
+
+  return result.discoveryError;
+};

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/AndroidLocationServicePreflightCheck.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/AndroidLocationServicePreflightCheck.ts
@@ -1,0 +1,68 @@
+import type { DiscoveryError } from "../../../types";
+import type { AndroidPreflightRequirements } from "./androidPreflightRequirements";
+import {
+  buildLocationDisabledManualActionError,
+  buildLocationDisabledPromptableError,
+  buildLocationServicePermissionMissingError,
+  buildUnknownDiscoveryError,
+} from "../discoveryErrorBuilders";
+import { getLocationHelperModule, type LocationServiceResponse } from "../nativeModules";
+import {
+  mapDiscoveryErrorToPreflightResult,
+  successPreflightResult,
+  type DiscoveryPreflightResult,
+} from "../preflightResult";
+
+/**
+ * Checks whether Android location services are enabled when the current SDK requires them for BLE.
+ *
+ * The native helper may enable location services, report a user denial, or surface permission and
+ * activity errors that are mapped into discovery preflight failures.
+ */
+export class AndroidLocationServicePreflightCheck {
+  constructor(
+    private readonly retry: () => Promise<true | DiscoveryError>,
+    private readonly getLocationHelper = getLocationHelperModule,
+  ) {}
+
+  async run(_requirements: AndroidPreflightRequirements): Promise<DiscoveryPreflightResult> {
+    const locationHelperModule = this.getLocationHelper();
+
+    if (!locationHelperModule?.checkAndRequestEnablingLocationServices) {
+      return mapDiscoveryErrorToPreflightResult(this.buildLocationDisabledManualActionError());
+    }
+
+    try {
+      const response = await locationHelperModule.checkAndRequestEnablingLocationServices();
+
+      return this.resultFromLocationServiceResponse(response);
+    } catch (error) {
+      return mapDiscoveryErrorToPreflightResult(buildUnknownDiscoveryError(error, this.retry));
+    }
+  }
+
+  private resultFromLocationServiceResponse(
+    response: LocationServiceResponse,
+  ): DiscoveryPreflightResult {
+    switch (response) {
+      case "SUCCESS_LOCATION_ALREADY_ENABLED":
+      case "SUCCESS_LOCATION_ENABLED":
+        return successPreflightResult;
+      case "ERROR_USER_DENIED_LOCATION":
+        return mapDiscoveryErrorToPreflightResult(buildLocationDisabledPromptableError(this.retry));
+      case "ERROR_LOCATION_PERMISSIONS_NEEDED":
+        return mapDiscoveryErrorToPreflightResult(
+          buildLocationServicePermissionMissingError(this.retry),
+        );
+      case "ERROR_ACTIVITY_DOES_NOT_EXIST":
+      case "ERROR_UNKNOWN":
+        return mapDiscoveryErrorToPreflightResult(
+          this.buildLocationDisabledManualActionError(response),
+        );
+    }
+  }
+
+  private buildLocationDisabledManualActionError(error?: unknown) {
+    return buildLocationDisabledManualActionError(this.retry, error);
+  }
+}

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/androidPreflightRequirements.test.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/androidPreflightRequirements.test.ts
@@ -1,0 +1,117 @@
+import { PermissionsAndroid } from "react-native";
+import { getAndroidPreflightRequirements } from "./androidPreflightRequirements";
+
+jest.mock("react-native", () => ({
+  PermissionsAndroid: {
+    PERMISSIONS: {
+      ACCESS_COARSE_LOCATION: "android.permission.ACCESS_COARSE_LOCATION",
+      ACCESS_FINE_LOCATION: "android.permission.ACCESS_FINE_LOCATION",
+      BLUETOOTH_CONNECT: "android.permission.BLUETOOTH_CONNECT",
+      BLUETOOTH_SCAN: "android.permission.BLUETOOTH_SCAN",
+    },
+  },
+  Platform: {
+    Version: 31,
+  },
+}));
+
+const { PERMISSIONS } = PermissionsAndroid;
+
+describe("androidPreflightRequirements", () => {
+  it("GIVEN Android API 28, WHEN getting requirements, THEN it should require coarse location checks", () => {
+    // GIVEN
+    const apiLevel = 28;
+
+    // WHEN
+    const requirements = getAndroidPreflightRequirements(apiLevel);
+
+    // THEN
+    expect(requirements).toMatchObject({
+      sdk: "lte28",
+      checks: ["bluetooth-service", "location-permission", "location-service"],
+      bluetoothPermissions: [],
+      locationPermission: PERMISSIONS.ACCESS_COARSE_LOCATION,
+    });
+    expect(requirements.matches(28)).toBe(true);
+    expect(requirements.matches(29)).toBe(false);
+  });
+
+  it("GIVEN Android API 29 string, WHEN getting requirements, THEN it should require fine location checks", () => {
+    // GIVEN
+    const apiLevel = "29";
+
+    // WHEN
+    const requirements = getAndroidPreflightRequirements(apiLevel);
+
+    // THEN
+    expect(requirements).toMatchObject({
+      sdk: "29-30",
+      checks: ["bluetooth-service", "location-permission", "location-service"],
+      bluetoothPermissions: [],
+      locationPermission: PERMISSIONS.ACCESS_FINE_LOCATION,
+    });
+    expect(requirements.matches(29)).toBe(true);
+    expect(requirements.matches(31)).toBe(false);
+  });
+
+  it("GIVEN Android API 30, WHEN getting requirements, THEN it should require fine location checks", () => {
+    // GIVEN
+    const apiLevel = 30;
+
+    // WHEN
+    const requirements = getAndroidPreflightRequirements(apiLevel);
+
+    // THEN
+    expect(requirements).toMatchObject({
+      sdk: "29-30",
+      checks: ["bluetooth-service", "location-permission", "location-service"],
+      bluetoothPermissions: [],
+      locationPermission: PERMISSIONS.ACCESS_FINE_LOCATION,
+    });
+    expect(requirements.matches(30)).toBe(true);
+    expect(requirements.matches(28)).toBe(false);
+  });
+
+  it("GIVEN Android API 31, WHEN getting requirements, THEN it should require Bluetooth permissions", () => {
+    // GIVEN
+    const apiLevel = 31;
+
+    // WHEN
+    const requirements = getAndroidPreflightRequirements(apiLevel);
+
+    // THEN
+    expect(requirements).toMatchObject({
+      sdk: "gte31",
+      checks: ["bluetooth-permission", "bluetooth-service"],
+      bluetoothPermissions: [PERMISSIONS.BLUETOOTH_SCAN, PERMISSIONS.BLUETOOTH_CONNECT],
+      locationPermission: null,
+    });
+    expect(requirements.matches(31)).toBe(true);
+    expect(requirements.matches(30)).toBe(false);
+  });
+
+  it("GIVEN no explicit platform version, WHEN getting requirements, THEN it should use Platform.Version", () => {
+    // GIVEN / WHEN
+    const requirements = getAndroidPreflightRequirements();
+
+    // THEN
+    expect(requirements).toMatchObject({
+      sdk: "gte31",
+      checks: ["bluetooth-permission", "bluetooth-service"],
+    });
+  });
+
+  it("GIVEN an unknown platform version, WHEN getting requirements, THEN it should fallback to latest requirements", () => {
+    // GIVEN
+    const apiLevel = "unknown";
+
+    // WHEN
+    const requirements = getAndroidPreflightRequirements(apiLevel);
+
+    // THEN
+    expect(requirements).toMatchObject({
+      sdk: "gte31",
+      checks: ["bluetooth-permission", "bluetooth-service"],
+    });
+  });
+});

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/androidPreflightRequirements.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/androidPreflightRequirements.ts
@@ -1,0 +1,50 @@
+import { PermissionsAndroid, Platform, type Permission } from "react-native";
+
+const { PERMISSIONS } = PermissionsAndroid;
+
+export type AndroidPreflightCheckId =
+  | "bluetooth-permission"
+  | "bluetooth-service"
+  | "location-permission"
+  | "location-service";
+
+export type AndroidPreflightRequirements = {
+  sdk: string;
+  matches: (version: number) => boolean;
+  checks: AndroidPreflightCheckId[];
+  bluetoothPermissions: Permission[];
+  locationPermission: Permission | null;
+};
+
+const androidPreflightRequirements: AndroidPreflightRequirements[] = [
+  {
+    sdk: "lte28",
+    matches: version => version <= 28,
+    checks: ["bluetooth-service", "location-permission", "location-service"],
+    bluetoothPermissions: [],
+    locationPermission: PERMISSIONS.ACCESS_COARSE_LOCATION,
+  },
+  {
+    sdk: "29-30",
+    matches: version => version >= 29 && version <= 30,
+    checks: ["bluetooth-service", "location-permission", "location-service"],
+    bluetoothPermissions: [],
+    locationPermission: PERMISSIONS.ACCESS_FINE_LOCATION,
+  },
+  {
+    sdk: "gte31",
+    matches: version => version >= 31,
+    checks: ["bluetooth-permission", "bluetooth-service"],
+    bluetoothPermissions: [PERMISSIONS.BLUETOOTH_SCAN, PERMISSIONS.BLUETOOTH_CONNECT],
+    locationPermission: null,
+  },
+];
+
+export const getAndroidPreflightRequirements = (
+  platformVersion: string | number = Platform.Version,
+): AndroidPreflightRequirements => {
+  const version = typeof platformVersion === "number" ? platformVersion : Number(platformVersion);
+  const requirements = androidPreflightRequirements.find(candidate => candidate.matches(version));
+
+  return requirements ?? androidPreflightRequirements[androidPreflightRequirements.length - 1];
+};

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/permissionHelpers.test.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/permissionHelpers.test.ts
@@ -1,0 +1,89 @@
+import { PermissionsAndroid, type Permission } from "react-native";
+import {
+  DEFAULT_PERMISSION_REQUEST_TIMEOUT_MS,
+  requestPermission,
+  requestPermissions,
+} from "./permissionHelpers";
+
+jest.mock("react-native", () => ({
+  PermissionsAndroid: {
+    PERMISSIONS: {
+      BLUETOOTH_CONNECT: "android.permission.BLUETOOTH_CONNECT",
+      BLUETOOTH_SCAN: "android.permission.BLUETOOTH_SCAN",
+    },
+    RESULTS: {
+      GRANTED: "granted",
+      DENIED: "denied",
+      NEVER_ASK_AGAIN: "never_ask_again",
+    },
+    check: jest.fn(),
+    request: jest.fn(),
+    requestMultiple: jest.fn(),
+  },
+}));
+
+const { RESULTS } = PermissionsAndroid;
+const bluetoothScanPermission: Permission = PermissionsAndroid.PERMISSIONS.BLUETOOTH_SCAN;
+const bluetoothConnectPermission: Permission = PermissionsAndroid.PERMISSIONS.BLUETOOTH_CONNECT;
+
+describe("permissionHelpers", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.mocked(PermissionsAndroid.request).mockReset();
+    jest.mocked(PermissionsAndroid.requestMultiple).mockReset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("GIVEN a single permission request does not resolve, WHEN the timeout is reached, THEN it should require manual settings", async () => {
+    // GIVEN
+    jest.mocked(PermissionsAndroid.request).mockImplementation(() => new Promise(() => undefined));
+
+    // WHEN
+    const resultPromise = requestPermission(bluetoothScanPermission);
+    await jest.advanceTimersByTimeAsync(DEFAULT_PERMISSION_REQUEST_TIMEOUT_MS);
+
+    // THEN
+    await expect(resultPromise).resolves.toEqual({
+      granted: false,
+      neverAskAgain: true,
+      deniedPermissions: [bluetoothScanPermission],
+    });
+  });
+
+  it("GIVEN a multiple permissions request does not resolve, WHEN the timeout is reached, THEN it should require manual settings", async () => {
+    // GIVEN
+    const permissions = [bluetoothScanPermission, bluetoothConnectPermission];
+    jest
+      .mocked(PermissionsAndroid.requestMultiple)
+      .mockImplementation(() => new Promise(() => undefined));
+
+    // WHEN
+    const resultPromise = requestPermissions(permissions);
+    await jest.advanceTimersByTimeAsync(DEFAULT_PERMISSION_REQUEST_TIMEOUT_MS);
+
+    // THEN
+    await expect(resultPromise).resolves.toEqual({
+      granted: false,
+      neverAskAgain: true,
+      deniedPermissions: permissions,
+    });
+  });
+
+  it("GIVEN a permission request resolves before the timeout, WHEN requesting, THEN it should keep the native status", async () => {
+    // GIVEN
+    jest.mocked(PermissionsAndroid.request).mockResolvedValue(RESULTS.DENIED);
+
+    // WHEN
+    const result = await requestPermission(bluetoothScanPermission);
+
+    // THEN
+    expect(result).toEqual({
+      granted: false,
+      neverAskAgain: false,
+      deniedPermissions: [bluetoothScanPermission],
+    });
+  });
+});

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/permissionHelpers.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/permissionHelpers.ts
@@ -1,0 +1,109 @@
+import { PermissionsAndroid, type Permission } from "react-native";
+import type { DiscoveryError } from "../../../types";
+import {
+  mapDiscoveryErrorToPreflightResult,
+  successPreflightResult,
+  type DiscoveryPreflightResult,
+} from "../preflightResult";
+
+const { RESULTS } = PermissionsAndroid;
+
+export const shouldUseManualActionForPermissionDenial = true;
+
+export type PermissionRequestResult = {
+  granted: boolean;
+  neverAskAgain: boolean;
+  deniedPermissions: Permission[];
+};
+
+type PermissionPreflightConfig = {
+  permissions: Permission[];
+  retry: () => Promise<true | DiscoveryError>;
+  buildPromptableError: (
+    permissions: Permission[],
+    retry: () => Promise<true | DiscoveryError>,
+  ) => DiscoveryError;
+  buildManualSettingsError: (
+    permissions: Permission[],
+    retry: () => Promise<true | DiscoveryError>,
+  ) => DiscoveryError;
+};
+
+export const arePermissionsGranted = async (permissions: Permission[]): Promise<boolean> => {
+  const results = await Promise.all(
+    permissions.map(permission => PermissionsAndroid.check(permission)),
+  );
+
+  return results.every(Boolean);
+};
+
+export const requestPermissions = async (
+  permissions: Permission[],
+): Promise<PermissionRequestResult> => {
+  const requestResult = await PermissionsAndroid.requestMultiple(permissions);
+  const deniedPermissions = permissions.filter(
+    permission => requestResult[permission] !== RESULTS.GRANTED,
+  );
+
+  return {
+    granted: deniedPermissions.length === 0,
+    neverAskAgain: permissions.some(
+      permission => requestResult[permission] === RESULTS.NEVER_ASK_AGAIN,
+    ),
+    deniedPermissions,
+  };
+};
+
+export const requestPermission = async (
+  permission: Permission,
+): Promise<PermissionRequestResult> => {
+  const status = await PermissionsAndroid.request(permission);
+
+  return {
+    granted: status === RESULTS.GRANTED,
+    neverAskAgain: status === RESULTS.NEVER_ASK_AGAIN,
+    deniedPermissions: status === RESULTS.GRANTED ? [] : [permission],
+  };
+};
+
+export const runPermissionPreflight = async (
+  config: PermissionPreflightConfig,
+): Promise<DiscoveryPreflightResult> => {
+  const { permissions } = config;
+
+  if (permissions.length === 0) {
+    return successPreflightResult;
+  }
+
+  const missingPermissions = await getMissingPermissions(permissions);
+
+  if (missingPermissions.length === 0) {
+    return successPreflightResult;
+  }
+
+  const requestResult =
+    missingPermissions.length === 1
+      ? await requestPermission(missingPermissions[0])
+      : await requestPermissions(missingPermissions);
+
+  if (requestResult.granted) {
+    return successPreflightResult;
+  }
+
+  return mapDiscoveryErrorToPreflightResult(
+    shouldUseManualActionForPermissionDenial || requestResult.neverAskAgain
+      ? config.buildManualSettingsError(requestResult.deniedPermissions, config.retry)
+      : config.buildPromptableError(requestResult.deniedPermissions, config.retry),
+  );
+};
+
+const getMissingPermissions = async (permissions: Permission[]): Promise<Permission[]> => {
+  const results = await Promise.all(
+    permissions.map(async permission => ({
+      permission,
+      granted: await PermissionsAndroid.check(permission),
+    })),
+  );
+
+  return results.filter(({ granted }) => !granted).map(({ permission }) => permission);
+};

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/permissionHelpers.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/permissionHelpers.ts
@@ -1,4 +1,4 @@
-import { PermissionsAndroid, type Permission } from "react-native";
+import { PermissionsAndroid, type Permission, type PermissionStatus } from "react-native";
 import type { DiscoveryError } from "../../../types";
 import {
   mapDiscoveryErrorToPreflightResult,
@@ -8,7 +8,10 @@ import {
 
 const { RESULTS } = PermissionsAndroid;
 
+export const DEFAULT_PERMISSION_REQUEST_TIMEOUT_MS = 10_000;
 export const shouldUseManualActionForPermissionDenial = true;
+
+type PermissionRequestStatuses = Partial<Record<Permission, PermissionStatus>>;
 
 export type PermissionRequestResult = {
   granted: boolean;
@@ -40,7 +43,10 @@ export const arePermissionsGranted = async (permissions: Permission[]): Promise<
 export const requestPermissions = async (
   permissions: Permission[],
 ): Promise<PermissionRequestResult> => {
-  const requestResult = await PermissionsAndroid.requestMultiple(permissions);
+  const requestResult = await withPermissionRequestTimeout<PermissionRequestStatuses>(
+    PermissionsAndroid.requestMultiple(permissions),
+    getPermissionRequestTimeoutStatuses(permissions),
+  );
   const deniedPermissions = permissions.filter(
     permission => requestResult[permission] !== RESULTS.GRANTED,
   );
@@ -57,7 +63,10 @@ export const requestPermissions = async (
 export const requestPermission = async (
   permission: Permission,
 ): Promise<PermissionRequestResult> => {
-  const status = await PermissionsAndroid.request(permission);
+  const status = await withPermissionRequestTimeout(
+    PermissionsAndroid.request(permission),
+    RESULTS.NEVER_ASK_AGAIN,
+  );
 
   return {
     granted: status === RESULTS.GRANTED,
@@ -106,4 +115,39 @@ const getMissingPermissions = async (permissions: Permission[]): Promise<Permiss
   );
 
   return results.filter(({ granted }) => !granted).map(({ permission }) => permission);
+};
+
+/**
+ * TODO(LIVE-23757): This workaround for never resolving permission request
+ * can be removed once React Native is upgraded to 0.81.6
+ */
+const withPermissionRequestTimeout = async <T>(
+  request: Promise<T>,
+  timeoutValue: T,
+  timeoutMs = DEFAULT_PERMISSION_REQUEST_TIMEOUT_MS,
+): Promise<T> => {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<T>(resolve => {
+    timeoutId = setTimeout(() => resolve(timeoutValue), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([request, timeout]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+};
+
+const getPermissionRequestTimeoutStatuses = (
+  permissions: Permission[],
+): PermissionRequestStatuses => {
+  const statuses: PermissionRequestStatuses = {};
+
+  permissions.forEach(permission => {
+    statuses[permission] = RESULTS.NEVER_ASK_AGAIN;
+  });
+
+  return statuses;
 };

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/discoveryErrorBuilders.test.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/discoveryErrorBuilders.test.ts
@@ -1,0 +1,232 @@
+import { PermissionsAndroid } from "react-native";
+import { State as BlePlxState } from "react-native-ble-plx";
+import { rnBleTransportIdentifier } from "@ledgerhq/device-transport-kit-react-native-ble";
+import { DiscoveryErrors, type DiscoveryError } from "../../types";
+import {
+  buildBluetoothDisabledManualActionError,
+  buildBluetoothDisabledPromptableError,
+  buildBluetoothPermissionManualSettingsError,
+  buildBluetoothPermissionPromptableError,
+  buildBluetoothStateError,
+  buildLocationDisabledManualActionError,
+  buildLocationDisabledPromptableError,
+  buildLocationPermissionManualSettingsError,
+  buildLocationPermissionPromptableError,
+  buildLocationServicePermissionMissingError,
+  buildUnknownDiscoveryError,
+} from "./discoveryErrorBuilders";
+
+jest.mock("react-native", () => ({
+  PermissionsAndroid: {
+    PERMISSIONS: {
+      ACCESS_FINE_LOCATION: "android.permission.ACCESS_FINE_LOCATION",
+      BLUETOOTH_CONNECT: "android.permission.BLUETOOTH_CONNECT",
+      BLUETOOTH_SCAN: "android.permission.BLUETOOTH_SCAN",
+    },
+  },
+}));
+
+jest.mock("react-native-ble-plx", () => ({
+  State: {
+    PoweredOn: "PoweredOn",
+    PoweredOff: "PoweredOff",
+    Resetting: "Resetting",
+    Unauthorized: "Unauthorized",
+    Unknown: "Unknown",
+    Unsupported: "Unsupported",
+  },
+}));
+
+const retry = jest.fn<Promise<true | DiscoveryError>, []>();
+const { PERMISSIONS } = PermissionsAndroid;
+
+describe("discoveryErrorBuilders", () => {
+  beforeEach(() => {
+    retry.mockReset();
+  });
+
+  it("GIVEN Bluetooth permissions can be prompted, WHEN building the error, THEN it should include prompt resolution", () => {
+    // GIVEN
+    const permissions = [PERMISSIONS.BLUETOOTH_SCAN, PERMISSIONS.BLUETOOTH_CONNECT];
+
+    // WHEN
+    const error = buildBluetoothPermissionPromptableError(permissions, retry);
+
+    // THEN
+    expect(error).toEqual({
+      type: DiscoveryErrors.BluetoothPermissionDeniedPromptable,
+      transportID: rnBleTransportIdentifier,
+      permissions,
+      resolution: { type: "prompt", retry },
+    });
+  });
+
+  it("GIVEN Bluetooth permissions require settings, WHEN building the error, THEN it should include manual action resolution", () => {
+    // GIVEN
+    const permissions = [PERMISSIONS.BLUETOOTH_SCAN, PERMISSIONS.BLUETOOTH_CONNECT];
+
+    // WHEN
+    const error = buildBluetoothPermissionManualSettingsError(permissions, retry);
+
+    // THEN
+    expect(error).toEqual({
+      type: DiscoveryErrors.BluetoothPermissionDeniedManualSettings,
+      transportID: rnBleTransportIdentifier,
+      permissions,
+      resolution: { type: "manual-action", retry },
+    });
+  });
+
+  it("GIVEN Bluetooth can be prompted, WHEN building disabled error, THEN it should include prompt resolution", () => {
+    // GIVEN / WHEN
+    const error = buildBluetoothDisabledPromptableError(retry);
+
+    // THEN
+    expect(error).toEqual({
+      type: DiscoveryErrors.BluetoothDisabledPromptable,
+      transportID: rnBleTransportIdentifier,
+      resolution: { type: "prompt", retry },
+    });
+  });
+
+  it("GIVEN Bluetooth requires manual action, WHEN building disabled error, THEN it should include the original error", () => {
+    // GIVEN
+    const nativeError = new Error("native failure");
+
+    // WHEN
+    const error = buildBluetoothDisabledManualActionError(retry, nativeError);
+
+    // THEN
+    expect(error).toEqual({
+      type: DiscoveryErrors.BluetoothDisabledManualAction,
+      transportID: rnBleTransportIdentifier,
+      error: nativeError,
+      resolution: { type: "manual-action", retry },
+    });
+  });
+
+  it("GIVEN Bluetooth is unauthorized, WHEN building state error, THEN it should require manual settings", () => {
+    // GIVEN / WHEN
+    const error = buildBluetoothStateError(BlePlxState.Unauthorized, retry);
+
+    // THEN
+    expect(error).toEqual({
+      type: DiscoveryErrors.BluetoothPermissionUnauthorizedManualSettings,
+      transportID: rnBleTransportIdentifier,
+      resolution: { type: "manual-action", retry },
+    });
+  });
+
+  it("GIVEN Bluetooth is unsupported, WHEN building state error, THEN it should not expose retry", () => {
+    // GIVEN / WHEN
+    const error = buildBluetoothStateError(BlePlxState.Unsupported, retry);
+
+    // THEN
+    expect(error).toEqual({
+      type: DiscoveryErrors.BluetoothUnsupported,
+      transportID: rnBleTransportIdentifier,
+      resolution: { type: "none" },
+    });
+  });
+
+  it("GIVEN Bluetooth state is unknown, WHEN building state error, THEN it should include check-only resolution", () => {
+    // GIVEN / WHEN
+    const error = buildBluetoothStateError(BlePlxState.Unknown, retry);
+
+    // THEN
+    expect(error).toEqual({
+      type: DiscoveryErrors.BluetoothStateUnknownCheckOnly,
+      transportID: rnBleTransportIdentifier,
+      state: BlePlxState.Unknown,
+      resolution: { type: "check-only", retry },
+    });
+  });
+
+  it("GIVEN location permission can be prompted, WHEN building the error, THEN it should include prompt resolution", () => {
+    // GIVEN
+    const permission = PERMISSIONS.ACCESS_FINE_LOCATION;
+
+    // WHEN
+    const error = buildLocationPermissionPromptableError([permission], retry);
+
+    // THEN
+    expect(error).toEqual({
+      type: DiscoveryErrors.LocationPermissionDeniedPromptable,
+      transportID: rnBleTransportIdentifier,
+      permission,
+      resolution: { type: "prompt", retry },
+    });
+  });
+
+  it("GIVEN location permission requires settings, WHEN building the error, THEN it should include manual action resolution", () => {
+    // GIVEN
+    const permission = PERMISSIONS.ACCESS_FINE_LOCATION;
+
+    // WHEN
+    const error = buildLocationPermissionManualSettingsError([permission], retry);
+
+    // THEN
+    expect(error).toEqual({
+      type: DiscoveryErrors.LocationPermissionDeniedManualSettings,
+      transportID: rnBleTransportIdentifier,
+      permission,
+      resolution: { type: "manual-action", retry },
+    });
+  });
+
+  it("GIVEN location service can be prompted, WHEN building disabled error, THEN it should include prompt resolution", () => {
+    // GIVEN / WHEN
+    const error = buildLocationDisabledPromptableError(retry);
+
+    // THEN
+    expect(error).toEqual({
+      type: DiscoveryErrors.LocationDisabledPromptable,
+      transportID: rnBleTransportIdentifier,
+      resolution: { type: "prompt", retry },
+    });
+  });
+
+  it("GIVEN location service requires manual action, WHEN building disabled error, THEN it should include the original error", () => {
+    // GIVEN
+    const nativeError = new Error("native failure");
+
+    // WHEN
+    const error = buildLocationDisabledManualActionError(retry, nativeError);
+
+    // THEN
+    expect(error).toEqual({
+      type: DiscoveryErrors.LocationDisabledManualAction,
+      transportID: rnBleTransportIdentifier,
+      error: nativeError,
+      resolution: { type: "manual-action", retry },
+    });
+  });
+
+  it("GIVEN location service misses permission, WHEN building the error, THEN it should include check-only resolution", () => {
+    // GIVEN / WHEN
+    const error = buildLocationServicePermissionMissingError(retry);
+
+    // THEN
+    expect(error).toEqual({
+      type: DiscoveryErrors.LocationServicePermissionMissing,
+      transportID: rnBleTransportIdentifier,
+      resolution: { type: "check-only", retry },
+    });
+  });
+
+  it("GIVEN unknown failure, WHEN building the error, THEN it should include check-only resolution and original error", () => {
+    // GIVEN
+    const unknownError = new Error("unknown");
+
+    // WHEN
+    const error = buildUnknownDiscoveryError(unknownError, retry);
+
+    // THEN
+    expect(error).toEqual({
+      type: DiscoveryErrors.Unknown,
+      transportID: rnBleTransportIdentifier,
+      error: unknownError,
+      resolution: { type: "check-only", retry },
+    });
+  });
+});

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/discoveryErrorBuilders.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/discoveryErrorBuilders.ts
@@ -1,0 +1,160 @@
+import { type Permission } from "react-native";
+import { State as BlePlxState } from "react-native-ble-plx";
+import { rnBleTransportIdentifier } from "@ledgerhq/device-transport-kit-react-native-ble";
+import { DiscoveryErrors, type DiscoveryError } from "../../types";
+
+type DiscoveryRetry = () => Promise<true | DiscoveryError>;
+
+export const buildBluetoothPermissionPromptableError = (
+  permissions: Permission[],
+  retry: DiscoveryRetry,
+): DiscoveryError => ({
+  type: DiscoveryErrors.BluetoothPermissionDeniedPromptable,
+  transportID: rnBleTransportIdentifier,
+  permissions,
+  resolution: {
+    type: "prompt",
+    retry,
+  },
+});
+
+export const buildBluetoothPermissionManualSettingsError = (
+  permissions: Permission[],
+  retry: DiscoveryRetry,
+): DiscoveryError => ({
+  type: DiscoveryErrors.BluetoothPermissionDeniedManualSettings,
+  transportID: rnBleTransportIdentifier,
+  permissions,
+  resolution: {
+    type: "manual-action",
+    retry,
+  },
+});
+
+export const buildBluetoothDisabledPromptableError = (retry: DiscoveryRetry): DiscoveryError => ({
+  type: DiscoveryErrors.BluetoothDisabledPromptable,
+  transportID: rnBleTransportIdentifier,
+  resolution: {
+    type: "prompt",
+    retry,
+  },
+});
+
+export const buildBluetoothDisabledManualActionError = (
+  retry: DiscoveryRetry,
+  error?: unknown,
+): DiscoveryError => ({
+  type: DiscoveryErrors.BluetoothDisabledManualAction,
+  transportID: rnBleTransportIdentifier,
+  error,
+  resolution: {
+    type: "manual-action",
+    retry,
+  },
+});
+
+export const buildBluetoothStateError = (
+  state: BlePlxState,
+  retry: DiscoveryRetry,
+): DiscoveryError => {
+  if (state === BlePlxState.Unauthorized) {
+    return {
+      type: DiscoveryErrors.BluetoothPermissionUnauthorizedManualSettings,
+      transportID: rnBleTransportIdentifier,
+      resolution: {
+        type: "manual-action",
+        retry,
+      },
+    };
+  }
+
+  if (state === BlePlxState.Unsupported) {
+    return {
+      type: DiscoveryErrors.BluetoothUnsupported,
+      transportID: rnBleTransportIdentifier,
+      resolution: { type: "none" },
+    };
+  }
+
+  return {
+    type: DiscoveryErrors.BluetoothStateUnknownCheckOnly,
+    transportID: rnBleTransportIdentifier,
+    state,
+    resolution: {
+      type: "check-only",
+      retry,
+    },
+  };
+};
+
+export const buildLocationPermissionPromptableError = (
+  permissions: Permission[],
+  retry: DiscoveryRetry,
+): DiscoveryError => ({
+  type: DiscoveryErrors.LocationPermissionDeniedPromptable,
+  transportID: rnBleTransportIdentifier,
+  permission: permissions[0],
+  resolution: {
+    type: "prompt",
+    retry,
+  },
+});
+
+export const buildLocationPermissionManualSettingsError = (
+  permissions: Permission[],
+  retry: DiscoveryRetry,
+): DiscoveryError => ({
+  type: DiscoveryErrors.LocationPermissionDeniedManualSettings,
+  transportID: rnBleTransportIdentifier,
+  permission: permissions[0],
+  resolution: {
+    type: "manual-action",
+    retry,
+  },
+});
+
+export const buildLocationDisabledPromptableError = (retry: DiscoveryRetry): DiscoveryError => ({
+  type: DiscoveryErrors.LocationDisabledPromptable,
+  transportID: rnBleTransportIdentifier,
+  resolution: {
+    type: "prompt",
+    retry,
+  },
+});
+
+export const buildLocationDisabledManualActionError = (
+  retry: DiscoveryRetry,
+  error?: unknown,
+): DiscoveryError => ({
+  type: DiscoveryErrors.LocationDisabledManualAction,
+  transportID: rnBleTransportIdentifier,
+  error,
+  resolution: {
+    type: "manual-action",
+    retry,
+  },
+});
+
+export const buildLocationServicePermissionMissingError = (
+  retry: DiscoveryRetry,
+): DiscoveryError => ({
+  type: DiscoveryErrors.LocationServicePermissionMissing,
+  transportID: rnBleTransportIdentifier,
+  resolution: {
+    type: "check-only",
+    retry,
+  },
+});
+
+export const buildUnknownDiscoveryError = (
+  error: unknown,
+  retry: DiscoveryRetry,
+): DiscoveryError => ({
+  type: DiscoveryErrors.Unknown,
+  transportID: rnBleTransportIdentifier,
+  error,
+  resolution: {
+    type: "check-only",
+    retry,
+  },
+});

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/ios/IosBleDiscoveryPreflightChecks.test.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/ios/IosBleDiscoveryPreflightChecks.test.ts
@@ -1,0 +1,177 @@
+import { State as BlePlxState } from "react-native-ble-plx";
+import { rnBleTransportIdentifier } from "@ledgerhq/device-transport-kit-react-native-ble";
+import { DiscoveryErrors } from "../../../types";
+import { BlePlxManager } from "../../../../transport/BlePlxManager";
+import { getBluetoothHelperModule } from "../nativeModules";
+import { IosBleDiscoveryPreflightChecks } from "./IosBleDiscoveryPreflightChecks";
+import type { DiscoveryPreflightResult } from "../preflightResult";
+
+jest.mock("react-native-ble-plx", () => ({
+  BleManager: jest.fn(),
+  State: {
+    PoweredOn: "PoweredOn",
+    PoweredOff: "PoweredOff",
+    Resetting: "Resetting",
+    Unauthorized: "Unauthorized",
+    Unknown: "Unknown",
+    Unsupported: "Unsupported",
+  },
+}));
+
+jest.mock("../nativeModules", () => ({
+  getBluetoothHelperModule: jest.fn(),
+}));
+
+describe("IosBleDiscoveryPreflightChecks", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.mocked(getBluetoothHelperModule).mockReset();
+  });
+
+  it("GIVEN Bluetooth prompt and powered-on state, WHEN running preflight, THEN it should succeed", async () => {
+    // GIVEN
+    const prompt = jest.fn().mockResolvedValue(undefined);
+    jest.mocked(getBluetoothHelperModule).mockReturnValue({ prompt });
+    jest.spyOn(BlePlxManager, "state").mockResolvedValue(BlePlxState.PoweredOn);
+
+    // WHEN
+    const result = await new IosBleDiscoveryPreflightChecks().getPreflight();
+
+    // THEN
+    expect(result).toEqual({ success: true });
+    expect(prompt).toHaveBeenCalledTimes(1);
+  });
+
+  it("GIVEN Bluetooth prompt fails, WHEN running preflight, THEN it should still check state", async () => {
+    // GIVEN
+    jest.mocked(getBluetoothHelperModule).mockReturnValue({
+      prompt: jest.fn().mockRejectedValue(new Error("prompt failure")),
+    });
+    jest.spyOn(BlePlxManager, "state").mockResolvedValue(BlePlxState.PoweredOn);
+
+    // WHEN
+    const result = await new IosBleDiscoveryPreflightChecks().getPreflight();
+
+    // THEN
+    expect(result).toEqual({ success: true });
+    expect(BlePlxManager.state).toHaveBeenCalledTimes(1);
+  });
+
+  it("GIVEN no Bluetooth prompt helper, WHEN running preflight, THEN it should still check state", async () => {
+    // GIVEN
+    jest.mocked(getBluetoothHelperModule).mockReturnValue(undefined);
+    jest.spyOn(BlePlxManager, "state").mockResolvedValue(BlePlxState.PoweredOn);
+
+    // WHEN
+    const result = await new IosBleDiscoveryPreflightChecks().getPreflight();
+
+    // THEN
+    expect(result).toEqual({ success: true });
+    expect(BlePlxManager.state).toHaveBeenCalledTimes(1);
+  });
+
+  it("GIVEN powered-off state, WHEN running preflight, THEN it should return Bluetooth disabled manual action error", async () => {
+    // GIVEN
+    jest.mocked(getBluetoothHelperModule).mockReturnValue(undefined);
+    jest.spyOn(BlePlxManager, "state").mockResolvedValue(BlePlxState.PoweredOff);
+
+    // WHEN
+    const result = await new IosBleDiscoveryPreflightChecks().getPreflight();
+
+    // THEN
+    expect(result).toMatchObject({
+      success: false,
+      discoveryError: {
+        type: DiscoveryErrors.BluetoothDisabledManualAction,
+        transportID: rnBleTransportIdentifier,
+        resolution: { type: "manual-action" },
+      },
+    });
+    await expect(callRetry(result)).resolves.toMatchObject({
+      type: DiscoveryErrors.BluetoothDisabledManualAction,
+    });
+  });
+
+  it("GIVEN unauthorized state, WHEN running preflight, THEN it should return Bluetooth permission error", async () => {
+    // GIVEN
+    jest.mocked(getBluetoothHelperModule).mockReturnValue(undefined);
+    jest.spyOn(BlePlxManager, "state").mockResolvedValue(BlePlxState.Unauthorized);
+
+    // WHEN
+    const result = await new IosBleDiscoveryPreflightChecks().getPreflight();
+
+    // THEN
+    expect(result).toMatchObject({
+      success: false,
+      discoveryError: {
+        type: DiscoveryErrors.BluetoothPermissionUnauthorizedManualSettings,
+        transportID: rnBleTransportIdentifier,
+        resolution: { type: "manual-action" },
+      },
+    });
+    await expect(callRetry(result)).resolves.toMatchObject({
+      type: DiscoveryErrors.BluetoothPermissionUnauthorizedManualSettings,
+    });
+  });
+
+  it("GIVEN unknown state, WHEN running preflight, THEN it should return check-only Bluetooth state error", async () => {
+    // GIVEN
+    jest.mocked(getBluetoothHelperModule).mockReturnValue(undefined);
+    jest.spyOn(BlePlxManager, "state").mockResolvedValue(BlePlxState.Unknown);
+
+    // WHEN
+    const result = await new IosBleDiscoveryPreflightChecks().getPreflight();
+
+    // THEN
+    expect(result).toMatchObject({
+      success: false,
+      discoveryError: {
+        type: DiscoveryErrors.BluetoothStateUnknownCheckOnly,
+        transportID: rnBleTransportIdentifier,
+        state: BlePlxState.Unknown,
+        resolution: { type: "check-only" },
+      },
+    });
+    await expect(callRetry(result)).resolves.toMatchObject({
+      type: DiscoveryErrors.BluetoothStateUnknownCheckOnly,
+    });
+  });
+
+  it("GIVEN state check fails, WHEN running preflight, THEN it should return unknown discovery error", async () => {
+    // GIVEN
+    const error = new Error("state failure");
+    jest.mocked(getBluetoothHelperModule).mockReturnValue(undefined);
+    jest.spyOn(BlePlxManager, "state").mockRejectedValue(error);
+
+    // WHEN
+    const result = await new IosBleDiscoveryPreflightChecks().getPreflight();
+
+    // THEN
+    expect(result).toMatchObject({
+      success: false,
+      discoveryError: {
+        type: DiscoveryErrors.Unknown,
+        transportID: rnBleTransportIdentifier,
+        error,
+        resolution: { type: "check-only" },
+      },
+    });
+    await expect(callRetry(result)).resolves.toMatchObject({
+      type: DiscoveryErrors.Unknown,
+    });
+  });
+});
+
+const callRetry = (result: DiscoveryPreflightResult) => {
+  if (result.success || !result.discoveryError.resolution) {
+    throw new Error("Expected a failed preflight result with retryable resolution");
+  }
+
+  const { resolution } = result.discoveryError;
+
+  if (resolution.type === "none") {
+    throw new Error("Expected a retryable resolution");
+  }
+
+  return resolution.retry();
+};

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/ios/IosBleDiscoveryPreflightChecks.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/ios/IosBleDiscoveryPreflightChecks.ts
@@ -1,0 +1,54 @@
+import { State as BlePlxState } from "react-native-ble-plx";
+import { BlePlxManager } from "../../../../transport/BlePlxManager";
+import { type DiscoveryError } from "../../../types";
+import {
+  buildBluetoothDisabledManualActionError,
+  buildBluetoothStateError,
+  buildUnknownDiscoveryError,
+} from "../discoveryErrorBuilders";
+import { getBluetoothHelperModule } from "../nativeModules";
+import {
+  mapDiscoveryErrorToPreflightResult,
+  retryPreflightCheck,
+  successPreflightResult,
+  type DiscoveryPreflightChecks,
+  type DiscoveryPreflightResult,
+} from "../preflightResult";
+
+export class IosBleDiscoveryPreflightChecks implements DiscoveryPreflightChecks {
+  async getPreflight(): Promise<DiscoveryPreflightResult> {
+    await this.promptBluetoothState();
+
+    return this.checkBluetoothState();
+  }
+
+  private async promptBluetoothState(): Promise<void> {
+    await getBluetoothHelperModule()
+      ?.prompt?.()
+      .catch(() => undefined);
+  }
+
+  private async checkBluetoothState(): Promise<DiscoveryPreflightResult> {
+    try {
+      const state = await BlePlxManager.state();
+
+      if (state === BlePlxState.PoweredOn) {
+        return successPreflightResult;
+      }
+
+      return mapDiscoveryErrorToPreflightResult(this.buildBluetoothStateError(state));
+    } catch (error) {
+      return mapDiscoveryErrorToPreflightResult(
+        buildUnknownDiscoveryError(error, () => retryPreflightCheck(() => this.getPreflight())),
+      );
+    }
+  }
+
+  private buildBluetoothStateError(state: BlePlxState): DiscoveryError {
+    const retry = () => retryPreflightCheck(() => this.getPreflight());
+
+    return state === BlePlxState.PoweredOff
+      ? buildBluetoothDisabledManualActionError(retry)
+      : buildBluetoothStateError(state, retry);
+  }
+}

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/nativeModules.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/nativeModules.ts
@@ -1,0 +1,57 @@
+import { NativeModules } from "react-native";
+
+export type BluetoothHelperModule = {
+  E_BLE_CANCELLED?: string;
+  prompt?: () => Promise<unknown>;
+};
+
+export type LocationServiceResponse =
+  | "SUCCESS_LOCATION_ALREADY_ENABLED"
+  | "SUCCESS_LOCATION_ENABLED"
+  | "ERROR_ACTIVITY_DOES_NOT_EXIST"
+  | "ERROR_USER_DENIED_LOCATION"
+  | "ERROR_LOCATION_PERMISSIONS_NEEDED"
+  | "ERROR_UNKNOWN";
+
+export type LocationHelperModule = {
+  checkAndRequestEnablingLocationServices?: () => Promise<LocationServiceResponse>;
+};
+
+export const getBluetoothHelperModule = (): BluetoothHelperModule | undefined => {
+  const bluetoothHelperModule = NativeModules.BluetoothHelperModule;
+
+  if (typeof bluetoothHelperModule !== "object" || bluetoothHelperModule === null) {
+    return undefined;
+  }
+
+  const prompt = bluetoothHelperModule.prompt;
+
+  return {
+    E_BLE_CANCELLED:
+      typeof bluetoothHelperModule.E_BLE_CANCELLED === "string"
+        ? bluetoothHelperModule.E_BLE_CANCELLED
+        : undefined,
+    prompt: typeof prompt === "function" ? () => prompt() : undefined,
+  };
+};
+
+export const getLocationHelperModule = (): LocationHelperModule | undefined => {
+  const locationHelperModule = NativeModules.LocationHelperModule;
+
+  if (typeof locationHelperModule !== "object" || locationHelperModule === null) {
+    return undefined;
+  }
+
+  const checkAndRequestEnablingLocationServices =
+    locationHelperModule.checkAndRequestEnablingLocationServices;
+
+  return {
+    checkAndRequestEnablingLocationServices:
+      typeof checkAndRequestEnablingLocationServices === "function"
+        ? () => checkAndRequestEnablingLocationServices()
+        : undefined,
+  };
+};
+
+export const getNativeErrorCode = (error: unknown): string | undefined =>
+  typeof error === "object" && error !== null && "code" in error ? String(error.code) : undefined;

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/preflightResult.test.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/preflightResult.test.ts
@@ -1,0 +1,62 @@
+import { DiscoveryErrors, type DiscoveryError } from "../../types";
+import {
+  mapDiscoveryErrorToPreflightResult,
+  retryPreflightCheck,
+  successPreflightResult,
+} from "./preflightResult";
+
+const discoveryError: DiscoveryError = {
+  type: DiscoveryErrors.Unknown,
+  error: new Error("failure"),
+};
+
+describe("preflightResult", () => {
+  it("GIVEN success preflight result, WHEN reading it, THEN it should be successful", () => {
+    // GIVEN
+    const result = successPreflightResult;
+
+    // WHEN
+    const success = result.success;
+
+    // THEN
+    expect(success).toBe(true);
+  });
+
+  it("GIVEN discovery error, WHEN building failure result, THEN it should contain the error", () => {
+    // GIVEN
+    const error = discoveryError;
+
+    // WHEN
+    const result = mapDiscoveryErrorToPreflightResult(error);
+
+    // THEN
+    expect(result).toEqual({
+      success: false,
+      discoveryError: error,
+    });
+  });
+
+  it("GIVEN retry check succeeds, WHEN retrying preflight, THEN it should return true", async () => {
+    // GIVEN
+    const check = jest.fn().mockResolvedValue(successPreflightResult);
+
+    // WHEN
+    const result = await retryPreflightCheck(check);
+
+    // THEN
+    expect(result).toBe(true);
+    expect(check).toHaveBeenCalledTimes(1);
+  });
+
+  it("GIVEN retry check fails, WHEN retrying preflight, THEN it should return the discovery error", async () => {
+    // GIVEN
+    const check = jest.fn().mockResolvedValue(mapDiscoveryErrorToPreflightResult(discoveryError));
+
+    // WHEN
+    const result = await retryPreflightCheck(check);
+
+    // THEN
+    expect(result).toBe(discoveryError);
+    expect(check).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/preflightResult.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/preflightResult.ts
@@ -1,0 +1,31 @@
+import type { DiscoveryError } from "../../types";
+
+export type DiscoveryPreflightResult =
+  | {
+      success: true;
+    }
+  | {
+      success: false;
+      discoveryError: DiscoveryError;
+    };
+
+export interface DiscoveryPreflightChecks {
+  getPreflight(): Promise<DiscoveryPreflightResult>;
+}
+
+export const successPreflightResult: DiscoveryPreflightResult = { success: true };
+
+export const mapDiscoveryErrorToPreflightResult = (
+  discoveryError: DiscoveryError,
+): DiscoveryPreflightResult => ({
+  success: false,
+  discoveryError,
+});
+
+export const retryPreflightCheck = async (
+  check: () => Promise<DiscoveryPreflightResult>,
+): Promise<true | DiscoveryError> => {
+  const result = await check();
+
+  return result.success ? true : result.discoveryError;
+};

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/sources/DeviceDiscoverySource.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/sources/DeviceDiscoverySource.ts
@@ -1,0 +1,18 @@
+import type { DiscoveredDevice, TransportIdentifier } from "@ledgerhq/device-management-kit";
+import type { Observable } from "rxjs";
+import type { DiscoveryError } from "../../types";
+
+export type DeviceDiscoverySourceEvent =
+  | {
+      type: "devices";
+      devices: DiscoveredDevice[];
+    }
+  | {
+      type: "error";
+      error: DiscoveryError;
+    };
+
+export interface DeviceDiscoverySource {
+  readonly transportId: TransportIdentifier;
+  listen(): Observable<DeviceDiscoverySourceEvent>;
+}

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/sources/RnBleDeviceDiscoverySource.test.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/sources/RnBleDeviceDiscoverySource.test.ts
@@ -1,0 +1,134 @@
+import type { DeviceManagementKit, DiscoveredDevice } from "@ledgerhq/device-management-kit";
+import { rnBleTransportIdentifier } from "@ledgerhq/device-transport-kit-react-native-ble";
+import { firstValueFrom, of, throwError } from "rxjs";
+import { DiscoveryErrors, type DiscoveryError } from "../../types";
+import type { DiscoveryPreflightChecks } from "../preflight/preflightResult";
+import { RnBleDeviceDiscoverySource } from "./RnBleDeviceDiscoverySource";
+
+jest.mock("../preflight/DefaultBleDiscoveryPreflightChecks", () => ({
+  DefaultBleDiscoveryPreflightChecks: jest.fn().mockImplementation(() => ({
+    getPreflight: jest.fn().mockResolvedValue({ success: true }),
+  })),
+}));
+
+const createMockDMK = (listenToAvailableDevices: jest.Mock): DeviceManagementKit =>
+  ({ listenToAvailableDevices }) as unknown as DeviceManagementKit;
+
+const createPreflightChecks = (
+  getPreflight: DiscoveryPreflightChecks["getPreflight"],
+): DiscoveryPreflightChecks => ({
+  getPreflight,
+});
+
+const createDiscoveredDevice = (id: string): DiscoveredDevice =>
+  ({
+    id,
+    name: id,
+    deviceModel: { id: "model", model: "model", name: "model" },
+    transport: rnBleTransportIdentifier,
+  }) as unknown as DiscoveredDevice;
+
+const discoveryError: DiscoveryError = {
+  type: DiscoveryErrors.BluetoothUnsupported,
+  transportID: rnBleTransportIdentifier,
+  resolution: { type: "none" },
+};
+
+describe("RnBleDeviceDiscoverySource", () => {
+  it("GIVEN a BLE discovery source, WHEN reading its transport id, THEN it should expose the RN BLE transport identifier", () => {
+    // GIVEN
+    const source = new RnBleDeviceDiscoverySource(createMockDMK(jest.fn()));
+
+    // WHEN
+    const transportId = source.transportId;
+
+    // THEN
+    expect(transportId).toBe(rnBleTransportIdentifier);
+  });
+
+  it("GIVEN preflight fails, WHEN listening, THEN it should emit the preflight error without starting BLE discovery", async () => {
+    // GIVEN
+    const listenToAvailableDevices = jest.fn();
+    const source = new RnBleDeviceDiscoverySource(
+      createMockDMK(listenToAvailableDevices),
+      createPreflightChecks(async () => ({ success: false, discoveryError })),
+    );
+
+    // WHEN
+    const event = firstValueFrom(source.listen());
+
+    // THEN
+    await expect(event).resolves.toEqual({
+      type: "error",
+      error: discoveryError,
+    });
+    expect(listenToAvailableDevices).not.toHaveBeenCalled();
+  });
+
+  it("GIVEN preflight succeeds, WHEN BLE discovery emits devices, THEN it should emit discovered devices", async () => {
+    // GIVEN
+    const devices = [createDiscoveredDevice("ble-1")];
+    const listenToAvailableDevices = jest.fn().mockReturnValue(of(devices));
+    const source = new RnBleDeviceDiscoverySource(
+      createMockDMK(listenToAvailableDevices),
+      createPreflightChecks(async () => ({ success: true })),
+    );
+
+    // WHEN
+    const event = firstValueFrom(source.listen());
+
+    // THEN
+    await expect(event).resolves.toEqual({
+      type: "devices",
+      devices,
+    });
+    expect(listenToAvailableDevices).toHaveBeenCalledWith({ transport: rnBleTransportIdentifier });
+  });
+
+  it("GIVEN preflight throws, WHEN listening, THEN it should emit an unknown discovery error", async () => {
+    // GIVEN
+    const error = new Error("preflight failure");
+    const source = new RnBleDeviceDiscoverySource(
+      createMockDMK(jest.fn()),
+      createPreflightChecks(async () => {
+        throw error;
+      }),
+    );
+
+    // WHEN
+    const event = firstValueFrom(source.listen());
+
+    // THEN
+    await expect(event).resolves.toEqual({
+      type: "error",
+      error: {
+        type: DiscoveryErrors.Unknown,
+        transportID: rnBleTransportIdentifier,
+        error,
+      },
+    });
+  });
+
+  it("GIVEN BLE discovery fails, WHEN listening, THEN it should emit an unknown discovery error", async () => {
+    // GIVEN
+    const error = new Error("ble failure");
+    const listenToAvailableDevices = jest.fn().mockReturnValue(throwError(() => error));
+    const source = new RnBleDeviceDiscoverySource(
+      createMockDMK(listenToAvailableDevices),
+      createPreflightChecks(async () => ({ success: true })),
+    );
+
+    // WHEN
+    const event = firstValueFrom(source.listen());
+
+    // THEN
+    await expect(event).resolves.toEqual({
+      type: "error",
+      error: {
+        type: DiscoveryErrors.Unknown,
+        transportID: rnBleTransportIdentifier,
+        error,
+      },
+    });
+  });
+});

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/sources/RnBleDeviceDiscoverySource.test.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/sources/RnBleDeviceDiscoverySource.test.ts
@@ -1,5 +1,9 @@
 import type { DeviceManagementKit, DiscoveredDevice } from "@ledgerhq/device-management-kit";
-import { rnBleTransportIdentifier } from "@ledgerhq/device-transport-kit-react-native-ble";
+import {
+  BlePoweredOff,
+  rnBleTransportIdentifier,
+} from "@ledgerhq/device-transport-kit-react-native-ble";
+import { BleError, BleErrorCode } from "react-native-ble-plx";
 import { firstValueFrom, of, throwError } from "rxjs";
 import { DiscoveryErrors, type DiscoveryError } from "../../types";
 import type { DiscoveryPreflightChecks } from "../preflight/preflightResult";
@@ -130,5 +134,66 @@ describe("RnBleDeviceDiscoverySource", () => {
         error,
       },
     });
+  });
+
+  it("GIVEN a BleError with BluetoothPoweredOff is thrown mid-scan, WHEN listening, THEN it should re-run preflight and emit the typed BluetoothDisabled error", async () => {
+    // GIVEN
+    const bleError = Object.assign(new BleError("Bluetooth powered off", {} as never), {
+      errorCode: BleErrorCode.BluetoothPoweredOff,
+    });
+    const bluetoothDisabledError: DiscoveryError = {
+      type: DiscoveryErrors.BluetoothDisabledManualAction,
+      transportID: rnBleTransportIdentifier,
+      resolution: { type: "manual-action", retry: jest.fn() },
+    };
+    const getPreflight = jest
+      .fn()
+      .mockResolvedValueOnce({ success: true })
+      .mockResolvedValueOnce({ success: false, discoveryError: bluetoothDisabledError });
+    const listenToAvailableDevices = jest.fn().mockReturnValue(throwError(() => bleError));
+    const source = new RnBleDeviceDiscoverySource(
+      createMockDMK(listenToAvailableDevices),
+      createPreflightChecks(getPreflight),
+    );
+
+    // WHEN
+    const event = firstValueFrom(source.listen());
+
+    // THEN
+    await expect(event).resolves.toEqual({
+      type: "error",
+      error: bluetoothDisabledError,
+    });
+    expect(getPreflight).toHaveBeenCalledTimes(2);
+  });
+
+  it("GIVEN a typed BlePoweredOff is thrown mid-scan, WHEN listening, THEN it should re-run preflight and emit the typed BluetoothDisabled error", async () => {
+    // GIVEN
+    const bluetoothDisabledError: DiscoveryError = {
+      type: DiscoveryErrors.BluetoothDisabledPromptable,
+      transportID: rnBleTransportIdentifier,
+      resolution: { type: "prompt", retry: jest.fn() },
+    };
+    const getPreflight = jest
+      .fn()
+      .mockResolvedValueOnce({ success: true })
+      .mockResolvedValueOnce({ success: false, discoveryError: bluetoothDisabledError });
+    const listenToAvailableDevices = jest
+      .fn()
+      .mockReturnValue(throwError(() => new BlePoweredOff("powered off")));
+    const source = new RnBleDeviceDiscoverySource(
+      createMockDMK(listenToAvailableDevices),
+      createPreflightChecks(getPreflight),
+    );
+
+    // WHEN
+    const event = firstValueFrom(source.listen());
+
+    // THEN
+    await expect(event).resolves.toEqual({
+      type: "error",
+      error: bluetoothDisabledError,
+    });
+    expect(getPreflight).toHaveBeenCalledTimes(2);
   });
 });

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/sources/RnBleDeviceDiscoverySource.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/sources/RnBleDeviceDiscoverySource.ts
@@ -1,5 +1,9 @@
 import type { DeviceManagementKit } from "@ledgerhq/device-management-kit";
-import { rnBleTransportIdentifier } from "@ledgerhq/device-transport-kit-react-native-ble";
+import {
+  BlePoweredOff,
+  rnBleTransportIdentifier,
+} from "@ledgerhq/device-transport-kit-react-native-ble";
+import { BleError, BleErrorCode } from "react-native-ble-plx";
 import { catchError, from, map, mergeMap, of, type Observable } from "rxjs";
 import { DiscoveryErrors } from "../../types";
 import { DefaultBleDiscoveryPreflightChecks } from "../preflight/DefaultBleDiscoveryPreflightChecks";
@@ -37,13 +41,24 @@ export class RnBleDeviceDiscoverySource implements DeviceDiscoverySource {
                 devices,
               }) as const,
           ),
+          catchError((error: unknown) => {
+            // BLE was turned off mid-scan: re-run the preflight pipeline so the
+            // consumer receives the proper platform-specific BluetoothDisabled*
+            // error (with the right resolution + retry) instead of a generic
+            // Unknown error. Works for both Android and iOS.
+            if (isBluetoothPoweredOffError(error)) {
+              return this.listen();
+            }
+
+            return of(this.mapUnknownErrorToDiscoveryEvent(error));
+          }),
         );
       }),
-      catchError(error => of(this.getUnknownDiscoveryErrorEvent(error))),
+      catchError(error => of(this.mapUnknownErrorToDiscoveryEvent(error))),
     );
   }
 
-  private getUnknownDiscoveryErrorEvent(error: unknown): DeviceDiscoverySourceEvent {
+  private mapUnknownErrorToDiscoveryEvent(error: unknown): DeviceDiscoverySourceEvent {
     return {
       type: "error",
       error: {
@@ -54,3 +69,15 @@ export class RnBleDeviceDiscoverySource implements DeviceDiscoverySource {
     };
   }
 }
+
+const isBluetoothPoweredOffError = (error: unknown): boolean => {
+  if (error instanceof BlePoweredOff) {
+    return true;
+  }
+
+  if (error instanceof BleError && error.errorCode === BleErrorCode.BluetoothPoweredOff) {
+    return true;
+  }
+
+  return false;
+};

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/sources/RnBleDeviceDiscoverySource.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/sources/RnBleDeviceDiscoverySource.ts
@@ -1,0 +1,56 @@
+import type { DeviceManagementKit } from "@ledgerhq/device-management-kit";
+import { rnBleTransportIdentifier } from "@ledgerhq/device-transport-kit-react-native-ble";
+import { catchError, from, map, mergeMap, of, type Observable } from "rxjs";
+import { DiscoveryErrors } from "../../types";
+import { DefaultBleDiscoveryPreflightChecks } from "../preflight/DefaultBleDiscoveryPreflightChecks";
+import type { DiscoveryPreflightChecks } from "../preflight/preflightResult";
+import {
+  type DeviceDiscoverySource,
+  type DeviceDiscoverySourceEvent,
+} from "./DeviceDiscoverySource";
+
+export class RnBleDeviceDiscoverySource implements DeviceDiscoverySource {
+  readonly transportId = rnBleTransportIdentifier;
+
+  constructor(
+    private readonly dmk: DeviceManagementKit,
+    private readonly preflightChecks: DiscoveryPreflightChecks = new DefaultBleDiscoveryPreflightChecks(),
+  ) {}
+
+  listen(): Observable<DeviceDiscoverySourceEvent> {
+    return from(this.preflightChecks.getPreflight()).pipe(
+      mergeMap(preflightResult => {
+        if (!preflightResult.success) {
+          const event: DeviceDiscoverySourceEvent = {
+            type: "error",
+            error: preflightResult.discoveryError,
+          };
+
+          return of(event);
+        }
+
+        return this.dmk.listenToAvailableDevices({ transport: this.transportId }).pipe(
+          map(
+            devices =>
+              ({
+                type: "devices",
+                devices,
+              }) as const,
+          ),
+        );
+      }),
+      catchError(error => of(this.getUnknownDiscoveryErrorEvent(error))),
+    );
+  }
+
+  private getUnknownDiscoveryErrorEvent(error: unknown): DeviceDiscoverySourceEvent {
+    return {
+      type: "error",
+      error: {
+        type: DiscoveryErrors.Unknown,
+        transportID: this.transportId,
+        error,
+      },
+    };
+  }
+}

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/sources/RnHidDeviceDiscoverySource.test.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/sources/RnHidDeviceDiscoverySource.test.ts
@@ -1,0 +1,55 @@
+import type { DeviceManagementKit, DiscoveredDevice } from "@ledgerhq/device-management-kit";
+import { rnHidTransportIdentifier } from "@ledgerhq/device-transport-kit-react-native-hid";
+import { firstValueFrom, of, throwError } from "rxjs";
+import { DiscoveryErrors } from "../../types";
+import { RnHidDeviceDiscoverySource } from "./RnHidDeviceDiscoverySource";
+
+const createMockDMK = (listenToAvailableDevices: jest.Mock): DeviceManagementKit =>
+  ({ listenToAvailableDevices }) as unknown as DeviceManagementKit;
+
+const createDiscoveredDevice = (id: string): DiscoveredDevice =>
+  ({
+    id,
+    name: id,
+    deviceModel: { id: "model", model: "model", name: "model" },
+    transport: rnHidTransportIdentifier,
+  }) as unknown as DiscoveredDevice;
+
+describe("RnHidDeviceDiscoverySource", () => {
+  it("GIVEN HID discovery emits devices, WHEN listening, THEN it should emit discovered devices", async () => {
+    // GIVEN
+    const devices = [createDiscoveredDevice("hid-1")];
+    const listenToAvailableDevices = jest.fn().mockReturnValue(of(devices));
+    const source = new RnHidDeviceDiscoverySource(createMockDMK(listenToAvailableDevices));
+
+    // WHEN
+    const event = firstValueFrom(source.listen());
+
+    // THEN
+    await expect(event).resolves.toEqual({
+      type: "devices",
+      devices,
+    });
+    expect(listenToAvailableDevices).toHaveBeenCalledWith({ transport: rnHidTransportIdentifier });
+  });
+
+  it("GIVEN HID discovery fails, WHEN listening, THEN it should emit an unknown discovery error", async () => {
+    // GIVEN
+    const error = new Error("hid failure");
+    const listenToAvailableDevices = jest.fn().mockReturnValue(throwError(() => error));
+    const source = new RnHidDeviceDiscoverySource(createMockDMK(listenToAvailableDevices));
+
+    // WHEN
+    const event = firstValueFrom(source.listen());
+
+    // THEN
+    await expect(event).resolves.toEqual({
+      type: "error",
+      error: {
+        type: DiscoveryErrors.Unknown,
+        transportID: rnHidTransportIdentifier,
+        error,
+      },
+    });
+  });
+});

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/sources/RnHidDeviceDiscoverySource.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/sources/RnHidDeviceDiscoverySource.ts
@@ -1,0 +1,38 @@
+import type { DeviceManagementKit } from "@ledgerhq/device-management-kit";
+import { rnHidTransportIdentifier } from "@ledgerhq/device-transport-kit-react-native-hid";
+import { catchError, map, of, type Observable } from "rxjs";
+import { DiscoveryErrors } from "../../types";
+import {
+  type DeviceDiscoverySource,
+  type DeviceDiscoverySourceEvent,
+} from "./DeviceDiscoverySource";
+
+export class RnHidDeviceDiscoverySource implements DeviceDiscoverySource {
+  readonly transportId = rnHidTransportIdentifier;
+
+  constructor(private readonly dmk: DeviceManagementKit) {}
+
+  listen(): Observable<DeviceDiscoverySourceEvent> {
+    return this.dmk.listenToAvailableDevices({ transport: this.transportId }).pipe(
+      map(
+        devices =>
+          ({
+            type: "devices",
+            devices,
+          }) as const,
+      ),
+      catchError(error => {
+        const event: DeviceDiscoverySourceEvent = {
+          type: "error" as const,
+          error: {
+            type: DiscoveryErrors.Unknown,
+            transportID: this.transportId,
+            error,
+          },
+        };
+
+        return of(event);
+      }),
+    );
+  }
+}

--- a/libs/live-dmk-mobile/src/connectDevice/types.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/types.ts
@@ -1,4 +1,4 @@
-import type { DiscoveredDevice } from "@ledgerhq/device-management-kit";
+import type { DiscoveredDevice, TransportIdentifier } from "@ledgerhq/device-management-kit";
 import type { DeviceModelId } from "@ledgerhq/types-devices";
 import type { Observable } from "rxjs";
 
@@ -40,27 +40,159 @@ export type ConnectionError =
     };
 
 export enum DiscoveryErrors {
-  BleNotEnabled = "ble-not-enabled",
-  PermissionMissing = "permission-missing",
+  /**
+   * Android Bluetooth runtime permissions are denied but can be requested again.
+   * Concerned permissions: `BLUETOOTH_SCAN` and `BLUETOOTH_CONNECT` on Android 12+ (API >= 31).
+   * UI should show Bluetooth permission instructions and call `resolution.retry()` only when the user
+   * presses a retry CTA to re-prompt.
+   */
+  BluetoothPermissionDeniedPromptable = "bluetooth-permission-denied-promptable",
+  /**
+   * Android Bluetooth runtime permissions are denied and cannot be re-prompted from the app.
+   * Concerned permissions: `BLUETOOTH_SCAN` and `BLUETOOTH_CONNECT` on Android 12+ (API >= 31).
+   * UI should explain how to enable the permissions manually in system settings. If the user presses
+   * a retry CTA after returning, call `resolution.retry()` only to re-check.
+   */
+  BluetoothPermissionDeniedManualSettings = "bluetooth-permission-denied-manual-settings",
+  /**
+   * The OS reports Bluetooth access as unauthorized, typically on iOS.
+   * UI should direct the user to system settings because the app cannot show the permission prompt again.
+   */
+  BluetoothPermissionUnauthorizedManualSettings = "bluetooth-permission-unauthorized-manual-settings",
+  /**
+   * Bluetooth is disabled and the platform can show a native enable prompt.
+   * UI should show a Bluetooth disabled message and call `resolution.retry()` only when the user
+   * presses a retry CTA to trigger the prompt again.
+   */
+  BluetoothDisabledPromptable = "bluetooth-disabled-promptable",
+  /**
+   * Bluetooth is disabled but cannot be enabled through an in-app prompt.
+   * UI should ask the user to enable Bluetooth manually. If the user presses a retry CTA after doing
+   * so, call `resolution.retry()` to re-check.
+   */
+  BluetoothDisabledManualAction = "bluetooth-disabled-manual-action",
+  /**
+   * Bluetooth is in an indeterminate state such as Unknown or Resetting.
+   * UI should show a transient/check-again state and call `resolution.retry()` only when the user
+   * presses a retry CTA to re-run the check.
+   */
+  BluetoothStateUnknownCheckOnly = "bluetooth-state-unknown-check-only",
+  /**
+   * The device or platform does not support BLE.
+   * UI should show a non-recoverable unsupported-device message and should not offer retry as a fix.
+   */
+  BluetoothUnsupported = "bluetooth-unsupported",
+  /**
+   * Android location permission is required for BLE scanning and can be requested again.
+   * Concerned permission: `ACCESS_COARSE_LOCATION` on Android 9 and below (API <= 28), or
+   * `ACCESS_FINE_LOCATION` on Android 10 and 11 (API 29-30).
+   * UI should show location permission instructions and call `resolution.retry()` only when the user
+   * presses a retry CTA to re-prompt.
+   */
+  LocationPermissionDeniedPromptable = "location-permission-denied-promptable",
+  /**
+   * Android location permission is required for BLE scanning but cannot be re-prompted from the app.
+   * Concerned permission: `ACCESS_COARSE_LOCATION` on Android 9 and below (API <= 28), or
+   * `ACCESS_FINE_LOCATION` on Android 10 and 11 (API 29-30).
+   * UI should explain how to enable the permission manually in settings. If the user presses a retry
+   * CTA after returning, call `resolution.retry()` only to re-check.
+   */
+  LocationPermissionDeniedManualSettings = "location-permission-denied-manual-settings",
+  /**
+   * Android location services are disabled and the platform can show a native enable prompt.
+   * UI should show a location services disabled message and call `resolution.retry()` only when the
+   * user presses a retry CTA to trigger the prompt.
+   */
+  LocationDisabledPromptable = "location-disabled-promptable",
+  /**
+   * Android location services are disabled but cannot be enabled through an in-app prompt.
+   * UI should ask the user to enable location services manually. If the user presses a retry CTA after
+   * doing so, call `resolution.retry()` to re-check.
+   */
+  LocationDisabledManualAction = "location-disabled-manual-action",
+  /**
+   * Android location services cannot be checked because location permission is missing unexpectedly.
+   * UI should route the user back to the location permission instructions, or call `resolution.retry()`
+   * from a retry CTA to re-run the full preflight.
+   */
+  LocationServicePermissionMissing = "location-service-permission-missing",
+  /**
+   * An unexpected discovery or preflight failure occurred.
+   * UI should show a generic error and use `resolution.retry()` from a retry CTA when present.
+   */
   Unknown = "unknown",
 }
 
-// TODO: more errors possible
+export type DiscoveryErrorResolution =
+  | {
+      type: "prompt";
+      retry: () => Promise<true | DiscoveryError>;
+    }
+  | {
+      type: "manual-action";
+      retry: () => Promise<true | DiscoveryError>;
+    }
+  | {
+      type: "check-only";
+      retry: () => Promise<true | DiscoveryError>;
+    }
+  | {
+      type: "none";
+    };
+
+type ResolvableDiscoveryError = {
+  transportID: TransportIdentifier;
+  resolution: DiscoveryErrorResolution;
+};
+
 export type DiscoveryError =
-  | {
-      type: DiscoveryErrors.BleNotEnabled;
-      transportID: string;
-      retry: () => Promise<true | DiscoveryError>;
-    }
-  | {
-      type: DiscoveryErrors.PermissionMissing;
-      transportID: string;
-      retry: () => Promise<true | DiscoveryError>;
-    }
+  | ({
+      type: DiscoveryErrors.BluetoothPermissionDeniedPromptable;
+      permissions: string[];
+    } & ResolvableDiscoveryError)
+  | ({
+      type: DiscoveryErrors.BluetoothPermissionDeniedManualSettings;
+      permissions: string[];
+    } & ResolvableDiscoveryError)
+  | ({
+      type: DiscoveryErrors.BluetoothPermissionUnauthorizedManualSettings;
+    } & ResolvableDiscoveryError)
+  | ({
+      type: DiscoveryErrors.BluetoothDisabledPromptable;
+    } & ResolvableDiscoveryError)
+  | ({
+      type: DiscoveryErrors.BluetoothDisabledManualAction;
+      error?: unknown;
+    } & ResolvableDiscoveryError)
+  | ({
+      type: DiscoveryErrors.BluetoothStateUnknownCheckOnly;
+      state?: string;
+    } & ResolvableDiscoveryError)
+  | ({
+      type: DiscoveryErrors.BluetoothUnsupported;
+    } & ResolvableDiscoveryError)
+  | ({
+      type: DiscoveryErrors.LocationPermissionDeniedPromptable;
+      permission: string;
+    } & ResolvableDiscoveryError)
+  | ({
+      type: DiscoveryErrors.LocationPermissionDeniedManualSettings;
+      permission: string;
+    } & ResolvableDiscoveryError)
+  | ({
+      type: DiscoveryErrors.LocationDisabledPromptable;
+    } & ResolvableDiscoveryError)
+  | ({
+      type: DiscoveryErrors.LocationDisabledManualAction;
+      error?: unknown;
+    } & ResolvableDiscoveryError)
+  | ({
+      type: DiscoveryErrors.LocationServicePermissionMissing;
+    } & ResolvableDiscoveryError)
   | {
       type: DiscoveryErrors.Unknown;
-      transportID?: string;
-      retry?: () => Promise<true | DiscoveryError>;
+      transportID?: TransportIdentifier;
+      resolution?: DiscoveryErrorResolution;
       error?: unknown;
     };
 
@@ -106,8 +238,12 @@ export type ConnectDeviceUIState =
       type: UIStateType.Connected;
     };
 
+export type DeviceDiscoveryStartArgs = {
+  ignoreTransportIdentifiers?: TransportIdentifier[];
+};
+
 export interface DeviceDiscoveryService {
-  start(): void;
+  start(args?: DeviceDiscoveryStartArgs): void;
   stop(): void;
   discoveredDevices: Observable<DiscoveredDevice[]>;
   errors: Observable<DiscoveryError>;

--- a/libs/live-dmk-mobile/src/index.ts
+++ b/libs/live-dmk-mobile/src/index.ts
@@ -2,6 +2,14 @@ import { useDeviceSessionState } from "@ledgerhq/live-dmk-shared";
 
 export { DeviceManagementKitBLETransport } from "./transport/DeviceManagementKitBLETransport";
 export { DeviceManagementKitHIDTransport } from "./transport/DeviceManagementKitHIDTransport";
+export { DefaultDeviceDiscoveryService } from "./connectDevice/discoveryService/DefaultDeviceDiscoveryService";
+export {
+  DiscoveryErrors,
+  type DeviceDiscoveryService,
+  type DeviceDiscoveryStartArgs,
+  type DiscoveryError,
+  type DiscoveryErrorResolution,
+} from "./connectDevice/types";
 export * from "./errors";
 export * from "./hooks";
 export * from "./utils/matchDevicesByNameOrId";

--- a/libs/live-dmk-mobile/tests.setup.ts
+++ b/libs/live-dmk-mobile/tests.setup.ts
@@ -27,6 +27,10 @@ jest.mock("react-native-ble-plx", () => ({
       this.reason = message;
     }
     reason: string;
+    errorCode?: number;
+  },
+  BleErrorCode: {
+    BluetoothPoweredOff: 102,
   },
   State: {
     PoweredOn: "PoweredOn",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Mobile DIE connect device discovery flow
  - BLE and HID discovery source lifecycle
  - Android and iOS BLE permission/service preflight error handling

### 📝 Description

This PR adds the device discovery layer of `@ledgerhq/live-dmk-mobile` that the DIE (Device Intent Executor) connect-device flow relies on. The previous branch introduced the connect-device types and use-case interfaces; this one wires up the actual discovery runtime and the BLE preflight checks that turn low-level platform issues into actionable, retryable errors.

#### `DefaultDeviceDiscoveryService`

A small RxJS-based orchestrator whose responsibility is to:

- aggregate devices coming from several transport sources (currently RN HID and RN BLE) into a single `discoveredDevices` stream,
- run each source's preflight checks before scanning and forward any failure as a structured `DiscoveryError` on a dedicated `errors` stream,
- expose a uniform `start` / `stop` API with optional per-call `ignoreTransportIdentifiers`, so callers can opt out of a transport (e.g. to keep an already-connected device's transport untouched).

The preflight checks make sure the platform is actually in a state where BLE scanning can succeed, and translate whatever is missing into a typed error the UI can render and recover from. Concretely, before starting a BLE scan the service verifies:

- on Android: that the required runtime Bluetooth permissions are granted (`BLUETOOTH_SCAN` / `BLUETOOTH_CONNECT` on Android 12+, legacy Bluetooth permissions otherwise), that the location permission is granted and location services are enabled when the OS version still requires them for BLE scanning, and that the Bluetooth adapter itself is supported and turned on,
- on iOS: that the CoreBluetooth central manager has reached a usable state (`poweredOn`), and otherwise distinguishes between recoverable cases (Bluetooth turned off, state still resolving) and non-recoverable ones (unsupported hardware, unauthorized).

Each resulting error carries a `resolution` describing how the UI can recover (`prompt`, `manualSettings`, or `none`) and a `retry` callback that re-runs the relevant preflight step or triggers the matching system prompt (permission request, "enable Bluetooth" dialog, etc.). This logic eventually belongs in the DMK itself, but the current DMK API does not yet support proper preflight orchestration, hence the dedicated service.

```ts
service.start({ ignoreTransportIdentifiers: [transportId] });

service.discoveredDevices.subscribe(devices => {
  // Render aggregated devices from all active discovery sources.
});

service.errors.subscribe(error => {
  // Display the matching permission/service resolution UI.
});
```

#### Debug screen

A new "DIE Discovery Playground" screen is added under Settings → Debug → Device Intent Executor. Its sole purpose is to drive `DefaultDeviceDiscoveryService` directly, without going through any feature flow:

- start / stop discovery and watch the live list of discovered devices,
- inspect each emitted `DiscoveryError` (type, transport, resolution),
- trigger the error's own `retry` callback to validate the recovery path on a real device.

This is meant for development and QA of the discovery + preflight pipeline, not for end users.

#### Temporary BLE workaround

Android's `PermissionsAndroid.request*` is wrapped in a `withPermissionRequestTimeout` helper (`permissionHelpers.ts`). Some permission requests never resolve on the current React Native version, which would freeze the BLE preflight indefinitely; the helper times out after a few seconds and treats the request as denied so the discovery flow can surface a regular permission error.

This is a temporary workaround tied to [LIVE-23757] and can be removed once the React Native upgrade to 0.81.6 lands via #16345.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30328](https://ledgerhq.atlassian.net/browse/LIVE-30328)
- **Target branch**: `feat/live-29082-die-connect-device`
- **Related PR**: #16345 (RN 0.81.6 upgrade — unblocks removing the permission-request timeout workaround)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30328]: https://ledgerhq.atlassian.net/browse/LIVE-30328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-23757]: https://ledgerhq.atlassian.net/browse/LIVE-23757

