### PR TITLE
[LWDM] feat(feature-flags): extend middleware with fetchRemoteFlags (LIVE-30190)

### DIFF
--- a/apps/ledger-live-desktop/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-desktop/src/state-manager/configureStore.ts
@@ -29,7 +29,11 @@ const customCreateStore = ({ state, dbMiddleware, analyticsMiddleware }: Props) 
             getAnalyticsConsent: (state: State) => trackingEnabledSelector(state),
           }),
         )
-        .concat(createFeatureFlagsMiddleware({ platform: "desktop", appVersion: __APP_VERSION__ })),
+        .concat(
+          createFeatureFlagsMiddleware({
+            resolutionConfig: { platform: "desktop", appVersion: __APP_VERSION__ },
+          }),
+        ),
     devTools: __DEV__,
   });
   return store;

--- a/apps/ledger-live-mobile/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-mobile/src/state-manager/configureStore.ts
@@ -31,8 +31,10 @@ export const store = configureStore({
       )
       .concat(
         createFeatureFlagsMiddleware({
-          platform: Platform.OS === "ios" ? "ios" : "android",
-          appVersion: VersionNumber.appVersion ?? undefined,
+          resolutionConfig: {
+            platform: Platform.OS === "ios" ? "ios" : "android",
+            appVersion: VersionNumber.appVersion ?? undefined,
+          },
         }),
       ),
 

--- a/apps/web-tools/src/store/index.ts
+++ b/apps/web-tools/src/store/index.ts
@@ -6,7 +6,7 @@ export const store = configureStore({
     featureFlags: featureFlagsReducer,
   },
   middleware: getDefaultMiddleware =>
-    getDefaultMiddleware().concat(createFeatureFlagsMiddleware({})),
+    getDefaultMiddleware().concat(createFeatureFlagsMiddleware({ resolutionConfig: {} })),
 });
 
 export type RootState = ReturnType<typeof store.getState>;

--- a/shared/feature-flags/README.md
+++ b/shared/feature-flags/README.md
@@ -15,28 +15,37 @@ const rootReducer = combineReducers({
 });
 ```
 
-### 2. Configure resolution at app startup
+### 2. Wire the middleware at store creation
 
 ```ts
-import { setResolutionConfig } from "@shared/feature-flags";
+import { createFeatureFlagsMiddleware } from "@shared/feature-flags";
 
-setResolutionConfig({
-  platform: "desktop", // "desktop" | "ios" | "android"
-  appVersion: "2.80.0",
-  appLanguage: "en",
-  envFlags: parsedEnvFlags, // from FEATURE_FLAGS env variable
+const store = configureStore({
+  reducer: rootReducer,
+  middleware: getDefault =>
+    getDefault().concat(
+      createFeatureFlagsMiddleware({
+        resolutionConfig: {
+          platform: "desktop", // "desktop" | "ios" | "android"
+          appVersion: "2.80.0",
+          appLanguage: "en",
+          envFlags: parsedEnvFlags, // from FEATURE_FLAGS env variable
+        },
+        // Optional — when provided, the middleware fires this on creation and
+        // every `refreshInterval` ms (default: 5 min), then dispatches
+        // `syncRemoteConfig` so reducers can re-resolve.
+        fetchRemoteFlags: async () => {
+          await fetchAndActivate(remoteConfig);
+          return Object.fromEntries(
+            Object.entries(getAll(remoteConfig)).map(([k, v]) => [k, JSON.parse(v.asString())]),
+          );
+        },
+      }),
+    ),
 });
 ```
 
-### 3. Sync remote config (Firebase / LiveConfig)
-
-```ts
-import { syncRemoteConfig } from "@shared/feature-flags";
-
-dispatch(syncRemoteConfig(remoteFlags));
-```
-
-### 4. Read flags in components
+### 3. Read flags in components
 
 ```ts
 import { selectFeature } from "@shared/feature-flags";
@@ -94,7 +103,7 @@ When a flag is resolved, the following priority chain applies (highest first):
 
 1. **Local overrides** — user-set via dev tools (`setOverride`)
 2. **Env overrides** — from `FEATURE_FLAGS` environment variable
-3. **Remote config** — from Firebase / LiveConfig (`syncRemoteConfig`)
+3. **Remote config** — from a third-party service (fetched by the middleware via `fetchRemoteFlags`)
 4. **Default** — from the flag's Zod schema default
 
 After resolution, **version filtering** (`desktop_version` / `mobile_version`) and **language filtering** (`languages_whitelisted` / `languages_blacklisted`) are applied.

--- a/shared/feature-flags/src/constants.ts
+++ b/shared/feature-flags/src/constants.ts
@@ -1,4 +1,4 @@
-import type { Feature, Features } from "./data/schema";
+import type { Feature, Features, FeatureFlagsState } from "./data/schema";
 import * as flags from "./flags";
 
 /**
@@ -18,3 +18,13 @@ export const FEATURE_FLAGS_DEFAULTS = Object.fromEntries<Feature>(
     featureSchema.parse(undefined),
   ]),
 ) as Features;
+
+/** Initial state for the `featureFlags` slice — every flag set to its registered default. */
+export const FEATURE_FLAGS_INITIAL_STATE: FeatureFlagsState = {
+  overrides: {},
+  resolved: FEATURE_FLAGS_DEFAULTS,
+  bannerVisible: false,
+};
+
+/** Default polling interval for fetching remote flags, in milliseconds: 5 minutes. */
+export const FEATURE_FLAGS_REMOTE_POLLING_INTERVAL_MS = 5 * 60 * 1000;

--- a/shared/feature-flags/src/data/middleware.ts
+++ b/shared/feature-flags/src/data/middleware.ts
@@ -1,30 +1,63 @@
-import type { Action, Middleware } from "@reduxjs/toolkit";
-import { isAction } from "@reduxjs/toolkit";
-import type { ResolutionConfig } from "./schema";
+import { type Action, type Middleware, isAction } from "@reduxjs/toolkit";
+import type { PartialFeatures, ResolutionConfig } from "./schema";
+import { FEATURE_FLAGS_REMOTE_POLLING_INTERVAL_MS } from "../constants";
+import { syncRemoteConfig } from "./slice";
 
-/** Feature-flags metadata that is dispatched by the middleware for each reducer actions. */
+/** Feature-flags metadata that the middleware injects into every `featureFlags/*` action. */
 export interface FeatureFlagsMeta {
   resolutionConfig: ResolutionConfig;
+  remoteFlags: PartialFeatures;
+}
+
+/** Configuration for {@link createFeatureFlagsMiddleware}, bound at store creation. */
+export interface FeatureFlagsMiddlewareConfig {
+  /** Static context used by reducers to resolve flags (platform, version, language, env overrides). */
+  resolutionConfig: ResolutionConfig;
+  /**
+   * Optional async callback that returns the latest remote feature flags. When
+   * provided, the middleware fires it once on creation and on every
+   * `refreshInterval` tick, caching the result in a closure for injection into
+   * `action.meta.remoteFlags`.
+   */
+  fetchRemoteFlags?: () => Promise<PartialFeatures>;
+  /** Polling interval for `fetchRemoteFlags`. Defaults to {@link FEATURE_FLAGS_REMOTE_POLLING_INTERVAL_MS}. */
+  refreshInterval?: number;
 }
 
 /**
- * Creates a Redux middleware that injects `resolutionConfig` into the meta of
- * every `featureFlags/*` action, so reducers can read it as plain action data
- * instead of pulling from a global singleton.
+ * Creates a Redux middleware that owns remote-flag fetching and injects
+ * `resolutionConfig` + `remoteFlags` into the meta of every `featureFlags/*`
+ * action, so reducers can re-resolve from action data instead of pulling from
+ * a global singleton or persisted state.
+ *
+ * Remote flags are transient — held in a closure-private cache that is rebuilt
+ * on each fetch and never persisted. Before the first fetch resolves, the cache
+ * is `{}` and resolution falls back to local overrides + env + defaults.
  *
  * @param config
- * Platform, version, language, and env-flag overrides. Bound at store creation
- * and closed over for the lifetime of the store.
+ * Resolution context plus optional fetcher + interval. Bound at store creation.
  */
-export function createFeatureFlagsMiddleware(config: ResolutionConfig): Middleware {
-  return () => next => action => {
-    if (isAction(action) && action.type.startsWith("featureFlags/")) {
-      return next({
-        ...action,
-        meta: { ...getMeta(action), resolutionConfig: config },
-      });
+export function createFeatureFlagsMiddleware(config: FeatureFlagsMiddlewareConfig): Middleware {
+  const remoteFlagsRef: RemoteFlagsRef = { current: {} };
+  return ({ dispatch }) => {
+    const { resolutionConfig, fetchRemoteFlags, refreshInterval } = config;
+    if (fetchRemoteFlags) {
+      const dispatchRemoteFlags = () => dispatch(syncRemoteConfig());
+      void pollRemoteFlags(fetchRemoteFlags, remoteFlagsRef, dispatchRemoteFlags, refreshInterval);
     }
-    return next(action);
+    return next => action => {
+      if (isAction(action) && action.type.startsWith("featureFlags/")) {
+        return next({
+          ...action,
+          meta: {
+            ...getMeta(action),
+            resolutionConfig,
+            remoteFlags: remoteFlagsRef.current,
+          },
+        });
+      }
+      return next(action);
+    };
   };
 }
 
@@ -44,3 +77,47 @@ function getMeta(action: Action<string>) {
     ? action.meta
     : {};
 }
+
+/**
+ * Self-rescheduling poll loop: fetches remote flags, writes them to the ref on
+ * success, dispatches the update, then schedules the next iteration. A failed
+ * fetch resolves to `null` (via `.catch`), leaves the ref untouched, and still
+ * re-schedules so transient errors don't kill the loop.
+ *
+ * @param fetch
+ * Async callback that returns the latest remote flags map.
+ *
+ * @param ref
+ * Mutable container that receives each successful fetch result. Read by the
+ * middleware when injecting `action.meta.remoteFlags`.
+ *
+ * @param dispatch
+ * Callback fired after each successful fetch — used to dispatch
+ * `syncRemoteConfig()` so reducers re-resolve.
+ *
+ * @param ms
+ * Delay between iterations, in milliseconds. Defaults to
+ * {@link FEATURE_FLAGS_REMOTE_POLLING_INTERVAL_MS}.
+ */
+async function pollRemoteFlags(
+  fetch: () => Promise<PartialFeatures>,
+  ref: RemoteFlagsRef,
+  dispatch: () => void,
+  ms: number = FEATURE_FLAGS_REMOTE_POLLING_INTERVAL_MS,
+) {
+  const remote = await fetch().catch(() => null);
+  if (remote !== null) {
+    ref.current = remote;
+    dispatch();
+  }
+  setTimeout(pollRemoteFlags, ms, fetch, ref, dispatch, ms);
+}
+
+/**
+ * Mutable single-slot container for the latest remote flags. Modeled after a
+ * React ref: the middleware reads `current` on every action dispatch, while
+ * {@link pollRemoteFlags} writes to it after each successful fetch.
+ */
+type RemoteFlagsRef = {
+  current: PartialFeatures;
+};

--- a/shared/feature-flags/src/data/schema.test.ts
+++ b/shared/feature-flags/src/data/schema.test.ts
@@ -36,7 +36,6 @@ describe("FeatureFlagsStateSchema", () => {
   it("parses a valid state with overrides and resolved", () => {
     const input = {
       overrides: { mockFeature: { enabled: true } },
-      remote: {},
       resolved: { ...FEATURE_FLAGS_DEFAULTS, mockFeature: { enabled: true } },
       bannerVisible: false,
     };
@@ -46,7 +45,6 @@ describe("FeatureFlagsStateSchema", () => {
   it("parses state with empty overrides and default resolved", () => {
     const input = {
       overrides: {},
-      remote: {},
       resolved: FEATURE_FLAGS_DEFAULTS,
       bannerVisible: false,
     };

--- a/shared/feature-flags/src/data/schema.ts
+++ b/shared/feature-flags/src/data/schema.ts
@@ -25,8 +25,6 @@ export type PartialFeatures = { [K in FeatureId]?: Features[K] };
 export interface FeatureFlagsState {
   /** User-set local overrides that take priority over remote and env values during resolution. */
   overrides: PartialFeatures;
-  /** Raw remote values. Used internally to re-resolve correctly. */
-  remote: PartialFeatures;
   /** Final computed value for every flag after applying the resolution chain (override > env > remote > default). */
   resolved: Features;
   /** Whether the developer feature flags banner/button is visible in the UI. */
@@ -39,7 +37,6 @@ export const OverrideValueSchema = FeatureSchema.extend({ params: z.unknown().op
 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 export const FeatureFlagsStateSchema = z.object({
   overrides: z.record(z.string(), OverrideValueSchema.optional()).default({}),
-  remote: z.record(z.string(), OverrideValueSchema.optional()).default({}),
   resolved: FlagRegistrySchema,
   bannerVisible: z.boolean(),
 }) as z.ZodType<FeatureFlagsState>;

--- a/shared/feature-flags/src/data/selectors.test.ts
+++ b/shared/feature-flags/src/data/selectors.test.ts
@@ -12,7 +12,6 @@ const state: { featureFlags: FeatureFlagsState } = {
     overrides: {
       mockFeature: { enabled: true, params: { color: "blue" } },
     },
-    remote: {},
     resolved: {
       ...FEATURE_FLAGS_DEFAULTS,
       mockFeature: { enabled: true, params: { color: "blue" } },

--- a/shared/feature-flags/src/data/slice.test.ts
+++ b/shared/feature-flags/src/data/slice.test.ts
@@ -4,23 +4,57 @@ import {
   featureFlagsReducer,
   setOverride,
   setAllOverrides,
-  syncRemoteConfig,
   setBannerVisible,
   importState,
 } from "./slice";
-import { createFeatureFlagsMiddleware } from "./middleware";
-import type { ResolutionConfig, FeatureFlagsState } from "./schema";
-import { FEATURE_FLAGS_DEFAULTS } from "../constants";
+import { createFeatureFlagsMiddleware, type FeatureFlagsMiddlewareConfig } from "./middleware";
+import type { ResolutionConfig, FeatureFlagsState, PartialFeatures } from "./schema";
+import { FEATURE_FLAGS_DEFAULTS, FEATURE_FLAGS_REMOTE_POLLING_INTERVAL_MS } from "../constants";
 
 const defaults = FEATURE_FLAGS_DEFAULTS;
 
-function createStore(preloadedState?: FeatureFlagsState, resolutionConfig?: ResolutionConfig) {
+// Yields several times to drain multi-await chains (e.g. the middleware's `tick()`
+// fetches and then dispatches inside the same async function). Uses Promise.resolve()
+// rather than queueMicrotask/setImmediate so it works under jest.useFakeTimers().
+const flushPromises = async () => {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+};
+
+// Fake timers are enabled globally so the middleware's setInterval doesn't leak
+// real timers into Jest's worker (otherwise the process can't exit cleanly).
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.clearAllTimers();
+  jest.useRealTimers();
+});
+
+function createStore(
+  preloadedState?: FeatureFlagsState,
+  middlewareConfig: Partial<FeatureFlagsMiddlewareConfig> = {},
+) {
   return configureStore({
     reducer: { featureFlags: featureFlagsReducer },
     preloadedState: preloadedState ? { featureFlags: preloadedState } : undefined,
     middleware: getDefaultMiddleware =>
-      getDefaultMiddleware().concat(createFeatureFlagsMiddleware(resolutionConfig ?? {})),
+      getDefaultMiddleware().concat(
+        createFeatureFlagsMiddleware({ resolutionConfig: {}, ...middlewareConfig }),
+      ),
   });
+}
+
+async function createStoreWithRemote(
+  remote: PartialFeatures = {},
+  resolutionConfig: ResolutionConfig = {},
+) {
+  const store = createStore(undefined, {
+    resolutionConfig,
+    fetchRemoteFlags: () => Promise.resolve(remote),
+  });
+  await flushPromises();
+  return store;
 }
 
 describe("featureFlagsSlice reducers", () => {
@@ -28,7 +62,6 @@ describe("featureFlagsSlice reducers", () => {
     const store = createStore();
     expect(store.getState().featureFlags).toEqual({
       overrides: {},
-      remote: {},
       resolved: defaults,
       bannerVisible: false,
     });
@@ -45,7 +78,6 @@ describe("featureFlagsSlice reducers", () => {
     it("updates an existing override", () => {
       const store = createStore({
         overrides: { mockFeature: { enabled: true } },
-        remote: {},
         resolved: { ...defaults, mockFeature: { enabled: true } },
         bannerVisible: false,
       });
@@ -61,12 +93,18 @@ describe("featureFlagsSlice reducers", () => {
     it("removes an override when value is undefined", () => {
       const store = createStore({
         overrides: { mockFeature: { enabled: true } },
-        remote: {},
         resolved: { ...defaults, mockFeature: { enabled: true } },
         bannerVisible: false,
       });
       store.dispatch(setOverride({ key: "mockFeature", value: undefined }));
       expect(store.getState().featureFlags.overrides.mockFeature).toBeUndefined();
+    });
+
+    it("removing an override falls back to default when no remote exists", () => {
+      const store = createStore();
+      store.dispatch(setOverride({ key: "mockFeature", value: { enabled: true } }));
+      store.dispatch(setOverride({ key: "mockFeature", value: undefined }));
+      expect(store.getState().featureFlags.resolved.mockFeature).toEqual(defaults.mockFeature);
     });
   });
 
@@ -74,42 +112,12 @@ describe("featureFlagsSlice reducers", () => {
     it("replaces the entire overrides map and re-resolves", () => {
       const store = createStore({
         overrides: { mockFeature: { enabled: true } },
-        remote: {},
         resolved: { ...defaults, mockFeature: { enabled: true } },
         bannerVisible: false,
       });
       store.dispatch(setAllOverrides({ ptxCard: { enabled: false } }));
       expect(store.getState().featureFlags.overrides).toEqual({ ptxCard: { enabled: false } });
       expect(store.getState().featureFlags.overrides.mockFeature).toBeUndefined();
-    });
-  });
-
-  describe("syncRemoteConfig", () => {
-    it("stores remote flags into resolved", () => {
-      const store = createStore();
-      store.dispatch(
-        syncRemoteConfig({
-          mockFeature: { enabled: true, params: { v: 1 } },
-          ptxCard: { enabled: false },
-        }),
-      );
-      const { resolved } = store.getState().featureFlags;
-      expect(resolved.mockFeature).toEqual({ enabled: true, params: { v: 1 } });
-      expect(resolved.ptxCard).toEqual({ enabled: false });
-    });
-
-    it("local overrides take priority over remote", () => {
-      const store = createStore({
-        overrides: { mockFeature: { enabled: false, overridesRemote: true } },
-        remote: {},
-        resolved: defaults,
-        bannerVisible: false,
-      });
-      store.dispatch(syncRemoteConfig({ mockFeature: { enabled: true } }));
-      expect(store.getState().featureFlags.resolved.mockFeature).toEqual({
-        enabled: false,
-        overridesRemote: true,
-      });
     });
   });
 
@@ -126,7 +134,6 @@ describe("featureFlagsSlice reducers", () => {
       const store = createStore();
       const newState: FeatureFlagsState = {
         overrides: { mockFeature: { enabled: true, params: "test" } },
-        remote: {},
         resolved: { ...defaults, mockFeature: { enabled: true, params: "test" } },
         bannerVisible: true,
       };
@@ -136,124 +143,177 @@ describe("featureFlagsSlice reducers", () => {
   });
 });
 
-describe("resolution logic", () => {
-  it("version filtering disables flag when version does not match", () => {
-    const store = createStore(undefined, { platform: "desktop", appVersion: "1.0.0" });
+describe("resolution via meta", () => {
+  it("remote flags from middleware are reflected in resolved state", async () => {
+    const store = await createStoreWithRemote({
+      mockFeature: { enabled: true, params: { v: 1 } },
+      ptxCard: { enabled: false },
+    });
+    const { resolved } = store.getState().featureFlags;
+    expect(resolved.mockFeature).toEqual({ enabled: true, params: { v: 1 } });
+    expect(resolved.ptxCard).toEqual({ enabled: false });
+  });
+
+  it("local overrides take priority over remote", async () => {
+    const store = await createStoreWithRemote({ mockFeature: { enabled: true } });
     store.dispatch(
-      syncRemoteConfig({
-        mockFeature: { enabled: true, desktop_version: ">=2.0.0" },
+      setOverride({
+        key: "mockFeature",
+        value: { enabled: false, overridesRemote: true },
       }),
+    );
+    expect(store.getState().featureFlags.resolved.mockFeature).toEqual({
+      enabled: false,
+      overridesRemote: true,
+    });
+  });
+
+  it("version filtering disables flag when version does not match", async () => {
+    const store = await createStoreWithRemote(
+      { mockFeature: { enabled: true, desktop_version: ">=2.0.0" } },
+      { platform: "desktop", appVersion: "1.0.0" },
     );
     const resolved = store.getState().featureFlags.resolved.mockFeature;
     expect(resolved.enabled).toBe(false);
     expect(resolved.enabledOverriddenForCurrentVersion).toBe(true);
   });
 
-  it("version filtering keeps flag when version matches", () => {
-    const store = createStore(undefined, { platform: "desktop", appVersion: "3.0.0" });
-    store.dispatch(
-      syncRemoteConfig({
-        mockFeature: { enabled: true, desktop_version: ">=2.0.0" },
-      }),
+  it("version filtering keeps flag when version matches", async () => {
+    const store = await createStoreWithRemote(
+      { mockFeature: { enabled: true, desktop_version: ">=2.0.0" } },
+      { platform: "desktop", appVersion: "3.0.0" },
     );
     expect(store.getState().featureFlags.resolved.mockFeature.enabled).toBe(true);
   });
 
-  it("mobile_version is used for ios/android platforms", () => {
-    const store = createStore(undefined, { platform: "ios", appVersion: "1.0.0" });
-    store.dispatch(
-      syncRemoteConfig({
-        mockFeature: { enabled: true, mobile_version: ">=2.0.0" },
-      }),
+  it("mobile_version is used for ios/android platforms", async () => {
+    const store = await createStoreWithRemote(
+      { mockFeature: { enabled: true, mobile_version: ">=2.0.0" } },
+      { platform: "ios", appVersion: "1.0.0" },
     );
     expect(store.getState().featureFlags.resolved.mockFeature.enabled).toBe(false);
   });
 
-  it("language whitelist disables flag when language is not whitelisted", () => {
-    const store = createStore(undefined, { appLanguage: "de" });
-    store.dispatch(
-      syncRemoteConfig({
-        mockFeature: { enabled: true, languages_whitelisted: ["en", "fr"] },
-      }),
+  it("language whitelist disables flag when language is not whitelisted", async () => {
+    const store = await createStoreWithRemote(
+      { mockFeature: { enabled: true, languages_whitelisted: ["en", "fr"] } },
+      { appLanguage: "de" },
     );
     const resolved = store.getState().featureFlags.resolved.mockFeature;
     expect(resolved.enabled).toBe(false);
     expect(resolved.enabledOverriddenForCurrentLanguage).toBe(true);
   });
 
-  it("language blacklist disables flag when language is blacklisted", () => {
-    const store = createStore(undefined, { appLanguage: "de" });
-    store.dispatch(
-      syncRemoteConfig({
-        mockFeature: { enabled: true, languages_blacklisted: ["de"] },
-      }),
+  it("language blacklist disables flag when language is blacklisted", async () => {
+    const store = await createStoreWithRemote(
+      { mockFeature: { enabled: true, languages_blacklisted: ["de"] } },
+      { appLanguage: "de" },
     );
     expect(store.getState().featureFlags.resolved.mockFeature.enabled).toBe(false);
   });
 
   it("language filtering does not apply to local overrides", () => {
-    const store = createStore(
-      {
-        overrides: { mockFeature: { enabled: true, languages_whitelisted: ["en"] } },
-        remote: {},
-        resolved: defaults,
-        bannerVisible: false,
-      },
-      { appLanguage: "de" },
+    const store = createStore(undefined, { resolutionConfig: { appLanguage: "de" } });
+    store.dispatch(
+      setOverride({
+        key: "mockFeature",
+        value: { enabled: true, languages_whitelisted: ["en"] },
+      }),
     );
-    store.dispatch(syncRemoteConfig({}));
     expect(store.getState().featureFlags.resolved.mockFeature.enabled).toBe(true);
   });
 
-  it("env flags override remote config", () => {
-    const store = createStore(undefined, {
-      envFlags: { mockFeature: { enabled: true, params: { envOverride: true } } },
-    });
-    store.dispatch(syncRemoteConfig({ mockFeature: { enabled: false } }));
+  it("env flags override remote config", async () => {
+    const store = await createStoreWithRemote(
+      { mockFeature: { enabled: false } },
+      { envFlags: { mockFeature: { enabled: true, params: { envOverride: true } } } },
+    );
     const resolved = store.getState().featureFlags.resolved.mockFeature;
     expect(resolved.enabled).toBe(true);
     expect(resolved.overriddenByEnv).toBe(true);
     expect(resolved.overridesRemote).toBe(true);
   });
 
-  it("resolution priority: local override > env > remote", () => {
-    const store = createStore(
-      {
-        overrides: { mockFeature: { enabled: true, overridesRemote: true } },
-        remote: {},
-        resolved: defaults,
-        bannerVisible: false,
-      },
+  it("resolution priority: local override > env > remote", async () => {
+    const store = await createStoreWithRemote(
+      { mockFeature: { enabled: false } },
       { envFlags: { mockFeature: { enabled: false } } },
     );
-    store.dispatch(syncRemoteConfig({ mockFeature: { enabled: false } }));
+    store.dispatch(
+      setOverride({
+        key: "mockFeature",
+        value: { enabled: true, overridesRemote: true },
+      }),
+    );
     expect(store.getState().featureFlags.resolved.mockFeature.enabled).toBe(true);
   });
 });
 
-describe("remote state management", () => {
-  it("syncRemoteConfig persists raw remote values in state.remote", () => {
-    const store = createStore();
-    const remotePayload = {
-      mockFeature: { enabled: true, params: { v: 1 } },
-      ptxCard: { enabled: false },
-    };
-    store.dispatch(syncRemoteConfig(remotePayload));
-    expect(store.getState().featureFlags.remote).toEqual(remotePayload);
+describe("middleware behavior", () => {
+  it("dispatches an initial fetch and updates resolved state", async () => {
+    const fetcher = jest.fn().mockResolvedValue({ mockFeature: { enabled: true } });
+    const store = createStore(undefined, { fetchRemoteFlags: fetcher });
+    await flushPromises();
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(store.getState().featureFlags.resolved.mockFeature.enabled).toBe(true);
   });
 
-  it("syncRemoteConfig replaces previous remote values", () => {
-    const store = createStore();
-    store.dispatch(syncRemoteConfig({ mockFeature: { enabled: true } }));
-    store.dispatch(syncRemoteConfig({ mockFeature: { enabled: false, params: { v: 2 } } }));
-    expect(store.getState().featureFlags.remote).toEqual({
-      mockFeature: { enabled: false, params: { v: 2 } },
+  it("polls every refreshInterval", async () => {
+    const fetcher = jest.fn().mockResolvedValue({ mockFeature: { enabled: true } });
+    createStore(undefined, { fetchRemoteFlags: fetcher, refreshInterval: 1_000 });
+    await flushPromises();
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(1_000);
+    await flushPromises();
+    expect(fetcher).toHaveBeenCalledTimes(2);
+
+    jest.advanceTimersByTime(1_000);
+    await flushPromises();
+    expect(fetcher).toHaveBeenCalledTimes(3);
+  });
+
+  it("uses FEATURE_FLAGS_REMOTE_POLLING_INTERVAL_MS when refreshInterval is omitted", async () => {
+    const fetcher = jest.fn().mockResolvedValue({});
+    createStore(undefined, { fetchRemoteFlags: fetcher });
+    await flushPromises();
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(FEATURE_FLAGS_REMOTE_POLLING_INTERVAL_MS - 1);
+    await flushPromises();
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(1);
+    await flushPromises();
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not crash and keeps last good cache when fetchRemoteFlags rejects", async () => {
+    const fetcher = jest
+      .fn()
+      .mockResolvedValueOnce({ mockFeature: { enabled: true } })
+      .mockRejectedValueOnce(new Error("network down"));
+    const store = createStore(undefined, { fetchRemoteFlags: fetcher, refreshInterval: 1_000 });
+
+    await flushPromises();
+    expect(store.getState().featureFlags.resolved.mockFeature.enabled).toBe(true);
+
+    jest.advanceTimersByTime(1_000);
+    await flushPromises();
+    // Reducer state is unchanged because syncRemoteConfig is not dispatched on failure;
+    // the previous resolved value remains visible.
+    expect(store.getState().featureFlags.resolved.mockFeature.enabled).toBe(true);
+  });
+
+  it("does not schedule any timer when fetchRemoteFlags is omitted", () => {
+    createStore();
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it("setOverride uses remote flags from middleware cache", async () => {
+    const store = await createStoreWithRemote({
+      mockFeature: { enabled: true, params: { remote: true } },
     });
-  });
-
-  it("removing an override reverts to stored remote value", () => {
-    const store = createStore();
-    store.dispatch(syncRemoteConfig({ mockFeature: { enabled: true, params: { remote: true } } }));
     store.dispatch(setOverride({ key: "mockFeature", value: { enabled: false } }));
     expect(store.getState().featureFlags.resolved.mockFeature.enabled).toBe(false);
 
@@ -264,53 +324,15 @@ describe("remote state management", () => {
     });
   });
 
-  it("removing an override falls back to default when no remote exists", () => {
-    const store = createStore();
-    store.dispatch(setOverride({ key: "mockFeature", value: { enabled: true } }));
-    store.dispatch(setOverride({ key: "mockFeature", value: undefined }));
-    expect(store.getState().featureFlags.resolved.mockFeature).toEqual(defaults.mockFeature);
-  });
-
-  it("setAllOverrides uses stored remote values for non-overridden flags", () => {
-    const store = createStore();
-    store.dispatch(syncRemoteConfig({ mockFeature: { enabled: true, params: { v: 1 } } }));
+  it("setAllOverrides uses remote flags for non-overridden keys", async () => {
+    const store = await createStoreWithRemote({
+      mockFeature: { enabled: true, params: { v: 1 } },
+    });
     store.dispatch(setAllOverrides({ ptxCard: { enabled: true } }));
     expect(store.getState().featureFlags.resolved.mockFeature).toEqual({
       enabled: true,
       params: { v: 1 },
     });
     expect(store.getState().featureFlags.resolved.ptxCard.enabled).toBe(true);
-  });
-
-  it("clearing all overrides reverts every flag to remote or default", () => {
-    const store = createStore();
-    store.dispatch(syncRemoteConfig({ mockFeature: { enabled: true, params: { v: 1 } } }));
-    store.dispatch(setOverride({ key: "mockFeature", value: { enabled: false } }));
-    store.dispatch(setAllOverrides({}));
-    expect(store.getState().featureFlags.resolved.mockFeature).toEqual({
-      enabled: true,
-      params: { v: 1 },
-    });
-  });
-
-  it("remote values are not mutated by override operations", () => {
-    const store = createStore();
-    const remoteValue = { enabled: true, params: { original: true } };
-    store.dispatch(syncRemoteConfig({ mockFeature: remoteValue }));
-    store.dispatch(setOverride({ key: "mockFeature", value: { enabled: false } }));
-    store.dispatch(setOverride({ key: "mockFeature", value: undefined }));
-    expect(store.getState().featureFlags.remote.mockFeature).toEqual(remoteValue);
-  });
-
-  it("importState preserves the remote field", () => {
-    const store = createStore();
-    const newState: FeatureFlagsState = {
-      overrides: {},
-      remote: { mockFeature: { enabled: true, params: { imported: true } } },
-      resolved: { ...defaults, mockFeature: { enabled: true, params: { imported: true } } },
-      bannerVisible: false,
-    };
-    store.dispatch(importState(newState));
-    expect(store.getState().featureFlags.remote).toEqual(newState.remote);
   });
 });

--- a/shared/feature-flags/src/data/slice.ts
+++ b/shared/feature-flags/src/data/slice.ts
@@ -1,59 +1,72 @@
 import { createSlice, type PayloadAction, type WritableDraft } from "@reduxjs/toolkit";
 import type { FeatureFlagsMeta } from "./middleware";
-import type { FeatureId, FeatureFlagsState, PartialFeatures, ResolutionConfig } from "./schema";
-import { FEATURE_FLAGS_DEFAULTS } from "../constants";
+import type { FeatureId, FeatureFlagsState, PartialFeatures } from "./schema";
+import { FEATURE_FLAGS_INITIAL_STATE } from "../constants";
 import { resolveFeature, resolveAll } from "./utils";
-
-export const FEATURE_FLAGS_INITIAL_STATE: FeatureFlagsState = {
-  overrides: {},
-  remote: {},
-  resolved: FEATURE_FLAGS_DEFAULTS,
-  bannerVisible: false,
-};
 
 const featureFlagsSlice = createSlice({
   name: "featureFlags",
   initialState: FEATURE_FLAGS_INITIAL_STATE,
   reducers: {
+    /**
+     * Sets or clears a single local override and re-resolves that key. Pass
+     * `value: undefined` to remove the override and revert to the remote/default
+     * value. Local overrides take priority over env overrides and remote flags.
+     */
     setOverride: {
       prepare,
       reducer<T extends FeatureId>(
         state: WritableDraft<FeatureFlagsState>,
         action: PayloadActionWithMeta<{ key: T; value: PartialFeatures[T] | undefined }>,
       ) {
-        const config: ResolutionConfig = action.meta.resolutionConfig;
+        const { resolutionConfig, remoteFlags } = action.meta;
         const { key, value } = action.payload;
         if (value === undefined) {
           delete state.overrides[key];
         } else {
           state.overrides[key] = value;
         }
-        state.resolved[key] = resolveFeature(key, state.overrides, state.remote, config);
+        state.resolved[key] = resolveFeature(key, state.overrides, remoteFlags, resolutionConfig);
       },
     },
 
+    /**
+     * Replaces the entire local-overrides map and re-resolves every flag.
+     * Used for bulk operations like restoring overrides on hydration or
+     * clearing all developer overrides at once.
+     */
     setAllOverrides: {
       prepare,
       reducer(state, action: PayloadActionWithMeta<FeatureFlagsState["overrides"]>) {
-        const config: ResolutionConfig = action.meta.resolutionConfig;
+        const { resolutionConfig, remoteFlags } = action.meta;
         state.overrides = action.payload;
-        state.resolved = resolveAll(state.overrides, state.remote, config);
+        state.resolved = resolveAll(state.overrides, remoteFlags, resolutionConfig);
       },
     },
 
+    /**
+     * Re-resolves every flag against the latest remote values. Payload-less:
+     * the middleware injects the freshly fetched remote map via
+     * `action.meta.remoteFlags`. Dispatched by `createFeatureFlagsMiddleware`
+     * after each successful Firebase fetch.
+     */
     syncRemoteConfig: {
-      prepare,
-      reducer(state, action: PayloadActionWithMeta<PartialFeatures>) {
-        const config: ResolutionConfig = action.meta.resolutionConfig;
-        state.remote = action.payload;
-        state.resolved = resolveAll(state.overrides, state.remote, config);
+      prepare: prepareWithoutPayload,
+      reducer(state, action: PayloadActionWithMeta<void>) {
+        const { resolutionConfig, remoteFlags } = action.meta;
+        state.resolved = resolveAll(state.overrides, remoteFlags, resolutionConfig);
       },
     },
 
+    /** Toggles visibility of the developer feature-flags banner/button in the UI. */
     setBannerVisible(state, action: PayloadAction<boolean>) {
       state.bannerVisible = action.payload;
     },
 
+    /**
+     * Replaces the entire feature-flags state. Used during hydration from
+     * persisted storage to restore the slice in a single step.
+     */
     importState(_, action: PayloadAction<FeatureFlagsState>) {
       return action.payload;
     },
@@ -62,15 +75,25 @@ const featureFlagsSlice = createSlice({
 
 export const { setOverride, setAllOverrides, syncRemoteConfig, setBannerVisible, importState } =
   featureFlagsSlice.actions;
+
+/** Reducer for the `featureFlags` slice — register under `state.featureFlags`. */
 export const featureFlagsReducer = featureFlagsSlice.reducer;
 
 /**
  * Ensure valid typing for metadata — see https://redux.js.org/usage/usage-with-typescript#typing-prepare-callbacks.
- * Explicit meta type keeps reducer bodies cast-free. `error: false as const` satisfies RTK's FSA Omit constraint.
+ * The placeholder meta is overwritten by `createFeatureFlagsMiddleware` on every dispatch; it stays
+ * here so direct dispatches in tests remain FSA-valid. `error: false as const` satisfies RTK's
+ * Omit constraint on FSA actions.
  */
 function prepare<P>(payload: P) {
-  const meta: FeatureFlagsMeta = { resolutionConfig: {} };
+  const meta: FeatureFlagsMeta = { resolutionConfig: {}, remoteFlags: {} };
   return { payload, meta, error: false as const };
+}
+
+/** Variant of {@link prepare} for payload-less actions (e.g. {@link syncRemoteConfig}). */
+function prepareWithoutPayload() {
+  const meta: FeatureFlagsMeta = { resolutionConfig: {}, remoteFlags: {} };
+  return { payload: undefined, meta, error: false as const };
 }
 
 /** Typed action shape for reducers that receive meta via middleware. */


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. <!-- intentionally skipped — `@shared/feature-flags` is private, all consumers are in-monorepo and updated atomically; LLD / LLM / web-tools are app packages. -->
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - **Behaviour preserved end-to-end.** No fetcher is wired here, so `cachedRemoteFlags` stays `{}` and reducers see `action.meta.remoteFlags = {}` — identical to today's `state.featureFlags.remote` which was always `{}`.
  - **Firebase Context path untouched.** `useFeature()` from `@ledgerhq/live-common/featureFlags` still reads from `FirebaseFeatureFlagsProvider` context. Users on LLD and LLM continue to receive their Firebase remote flags via the Context path exactly as before.
  - **Redux selector path** (`selectFeature` from `@shared/feature-flags`, currently used in 3 spots for `addressPoisoningOperationsFilter`) was already returning defaults + overrides only (since `syncRemoteConfig` was never dispatched). Same behaviour after this PR — until DA-105a/b wires the callback.
  - **State shape change:** `state.featureFlags.remote` is dropped. Verified persistence in `apps/ledger-live-desktop/src/renderer/init.tsx` and `apps/ledger-live-mobile/src/context/LedgerStore.tsx` only rehydrates `overrides` + `bannerVisible`, so no migration shim needed. Zod schema (`FeatureFlagsStateSchema`) used to silently strip extra keys (default object mode), so any leftover persisted `remote` field would simply drop.
  - **Middleware signature change** (breaking shape): `createFeatureFlagsMiddleware(resolutionConfig)` → `createFeatureFlagsMiddleware({ resolutionConfig })`. Three call sites updated atomically (LLD, LLM, web-tools).
  - **QA focus:** smoke-test that LLD and LLM boot, settings/dev-tools feature-flag overrides still work, and any Firebase-driven flag (e.g. `lldWalletSync`, `brazePushNotifications`) still resolves the same way via Context.

### 📝 Description

Extends `createFeatureFlagsMiddleware` so it owns Firebase fetching/polling and pipes remote flags through `action.meta.remoteFlags` instead of state. This is the foundation for **DA-105a/b** (LIVE-30191), which will wire the actual Firebase fetchers and remove the React Context providers.

#### What changed

**Package internals** (`shared/feature-flags/src/data`):
- `middleware.ts` — `FeatureFlagsMiddlewareConfig` now wraps `resolutionConfig` and accepts an optional `fetchRemoteFlags` callback + `refreshInterval`. When a fetcher is provided, the middleware fires it once on creation, then self-reschedules via a recursive `setTimeout` loop. Fetch failures (`.catch(() => null)`) keep the last good cache and re-schedule — transient errors don't kill the loop.
- The poll loop is externalised to a private `pollRemoteFlags(fetch, ref, dispatch, ms)` helper. The cached map lives in a single-slot `RemoteFlagsRef` (`{ current: PartialFeatures }`), read by the middleware on every action dispatch and written by `pollRemoteFlags` after each successful fetch.
- `slice.ts` — `state.remote` is dropped. All reducers (`setOverride`, `setAllOverrides`, `syncRemoteConfig`) read `action.meta.remoteFlags` for re-resolution. `syncRemoteConfig` becomes payload-less — the middleware injects the freshly fetched remote map via meta on dispatch.
- `schema.ts` — `remote: PartialFeatures` removed from `FeatureFlagsState` and the Zod schema.
- `constants.ts` — adds `FEATURE_FLAGS_INITIAL_STATE` (moved from slice) and `FEATURE_FLAGS_REMOTE_POLLING_INTERVAL_MS` (5 min).

**Call sites** (mechanical, due to signature change):
- `apps/ledger-live-desktop/src/state-manager/configureStore.ts`
- `apps/ledger-live-mobile/src/state-manager/configureStore.ts`
- `apps/web-tools/src/store/index.ts`

#### Tests

`shared/feature-flags/src/data/slice.test.ts` was restructured into three suites (76 tests total, all passing):
1. **`featureFlagsSlice reducers`** — direct reducer behaviour without the middleware injecting remote flags.
2. **`resolution via meta`** — uses a `createStoreWithRemote(remote, config)` helper that wires the middleware with `fetchRemoteFlags: () => Promise.resolve(remote)` and awaits a microtask flush. Covers version filtering, language filtering, env override priority, override-vs-remote priority.
3. **`middleware behavior`** — fake-timer suite verifying initial fetch, polling cadence with custom + default intervals, no-poll when fetcher omitted, and resilience to a rejecting fetcher (state unchanged, loop continues).

`flushPromises` uses `Promise.resolve()` chained 5× rather than `queueMicrotask` so it works under `jest.useFakeTimers()`.

### ❓ Context

- **JIRA**: [LIVE-30190](https://ledgerhq.atlassian.net/browse/LIVE-30190)
- **Depends on**: [LIVE-29501](https://ledgerhq.atlassian.net/browse/LIVE-29501) (`createFeatureFlagsMiddleware` introduced) — already merged.
- **Unblocks**: [LIVE-30191](https://ledgerhq.atlassian.net/browse/LIVE-30191) (drop Firebase Context providers, wire `fetchRemoteFlags` in both apps).
- **ADR**: Data Layer Structure & Flow (Iteration 5).

[LIVE-30190]: https://ledgerhq.atlassian.net/browse/LIVE-30190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ