### PR TITLE
[LWDM] fix(common): centralize earn ui version computation

### DIFF
--- a/.changeset/flat-cups-mix.md
+++ b/.changeset/flat-cups-mix.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+compute earn ui version centrally and reuse it in desktop and mobile earn flows

--- a/apps/ledger-live-desktop/src/mvvm/features/LiveAppModal/useEarnLiveAppModalContentViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LiveAppModal/useEarnLiveAppModalContentViewModel.test.ts
@@ -1,0 +1,97 @@
+import { renderHook, withFlagOverrides } from "tests/testSetup";
+import useEarnLiveAppModalContentViewModel from "./useEarnLiveAppModalContentViewModel";
+
+const makeStakeProgramsFeature = (
+  redirects: Record<
+    string,
+    {
+      platform: "stakekit" | "kiln-widget" | "earn";
+      name: string;
+      queryParams?: Record<string, string>;
+    }
+  >,
+  list: string[],
+) =>
+  ({
+    enabled: true,
+    params: {
+      list,
+      redirects,
+    },
+  }) as unknown as Parameters<typeof withFlagOverrides>[0]["stakePrograms"];
+
+describe("useEarnLiveAppModalContentViewModel (desktop)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns computed uiVersion and lw40enabled=true when wallet 40 is enabled", () => {
+    const { result } = renderHook(() => useEarnLiveAppModalContentViewModel(), {
+      initialState: withFlagOverrides({
+        ptxEarnUi: { enabled: true, params: { value: "v2" } },
+        lwdWallet40: { enabled: true },
+        stakePrograms: makeStakeProgramsFeature(
+          {
+            ethereum: {
+              platform: "earn",
+              name: "",
+              queryParams: { ethDepositCohort: "cohort-a" },
+            },
+            bitcoin: {
+              platform: "stakekit",
+              name: "",
+            },
+          },
+          ["ethereum", "bitcoin"],
+        ),
+      }),
+    });
+
+    expect(result.current.extraInputs).toEqual({
+      uiVersion: "v2",
+      lw40enabled: "true",
+      ethDepositCohort: "cohort-a",
+      stakeProgramsParam: JSON.stringify({ ethereum: "earn", bitcoin: "stakekit" }),
+      stakeCurrenciesParam: JSON.stringify(["ethereum", "bitcoin"]),
+    });
+  });
+
+  it("returns fallback v1 and lw40enabled=false when wallet 40 is disabled", () => {
+    const { result } = renderHook(() => useEarnLiveAppModalContentViewModel(), {
+      initialState: withFlagOverrides({
+        ptxEarnUi: { enabled: true, params: { value: "v2" } },
+        lwdWallet40: { enabled: false },
+        stakePrograms: makeStakeProgramsFeature({}, []),
+      }),
+    });
+
+    expect(result.current.extraInputs?.uiVersion).toBe("v1");
+    expect(result.current.extraInputs?.lw40enabled).toBe("false");
+  });
+
+  it("returns v3 when earn upselling is enabled", () => {
+    const { result } = renderHook(() => useEarnLiveAppModalContentViewModel(), {
+      initialState: withFlagOverrides({
+        ptxEarnUi: { enabled: true, params: { value: "v1" } },
+        lwdWallet40: { enabled: true, params: { earnUpselling: true } as never },
+        stakePrograms: makeStakeProgramsFeature({}, []),
+      }),
+    });
+
+    expect(result.current.extraInputs?.uiVersion).toBe("v3");
+    expect(result.current.extraInputs?.lw40enabled).toBe("true");
+  });
+
+  it("returns v4 when earn simulator is enabled", () => {
+    const { result } = renderHook(() => useEarnLiveAppModalContentViewModel(), {
+      initialState: withFlagOverrides({
+        ptxEarnUi: { enabled: true, params: { value: "v1" } },
+        lwdWallet40: { enabled: true, params: { earnSimulator: true } as never },
+        stakePrograms: makeStakeProgramsFeature({}, []),
+      }),
+    });
+
+    expect(result.current.extraInputs?.uiVersion).toBe("v4");
+    expect(result.current.extraInputs?.lw40enabled).toBe("true");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/LiveAppModal/useEarnLiveAppModalContentViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LiveAppModal/useEarnLiveAppModalContentViewModel.ts
@@ -6,28 +6,37 @@ import {
 import { useFeature, useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import { useVersionedStakePrograms } from "LLD/hooks/useVersionedStakePrograms";
 import type { ExtraInputs } from "./useLiveAppModalContentViewModel";
+import { computeEarnUiVersion } from "@ledgerhq/live-common/domain/computeEarnUiVersion";
 
 export interface EarnLiveAppModalContentViewModel {
   extraInputs: ExtraInputs;
 }
 
 const useEarnLiveAppModalContentViewModel = (): EarnLiveAppModalContentViewModel => {
-  const { isEnabled: isLwd40Enabled } = useWalletFeaturesConfig("desktop");
+  const {
+    isEnabled: isLwd40Enabled,
+    shouldDisplayEarnSimulator,
+    shouldDisplayEarnUpselling,
+  } = useWalletFeaturesConfig("desktop");
   const earnUiFlag = useFeature("ptxEarnUi");
-  const earnUiVersion = earnUiFlag?.params?.value ?? "v1";
+  const computedUiVersion = computeEarnUiVersion({
+    baseUiVersion: earnUiFlag?.params?.value ?? "v2",
+    shouldDisplayEarnUpselling,
+    shouldDisplayEarnSimulator,
+  });
   const stakePrograms = useVersionedStakePrograms();
 
   const extraInputs = useMemo<ExtraInputs>(() => {
     const { stakeProgramsParam, stakeCurrenciesParam } = stakeProgramsToEarnParam(stakePrograms);
     const ethDepositCohort = getEthDepositScreenSetting(stakePrograms);
     return {
-      uiVersion: isLwd40Enabled ? earnUiVersion : "v1",
+      uiVersion: isLwd40Enabled ? computedUiVersion : "v1",
       lw40enabled: isLwd40Enabled ? "true" : "false",
       ethDepositCohort,
       stakeProgramsParam: stakeProgramsParam ? JSON.stringify(stakeProgramsParam) : undefined,
       stakeCurrenciesParam: stakeCurrenciesParam ? JSON.stringify(stakeCurrenciesParam) : undefined,
     };
-  }, [stakePrograms, isLwd40Enabled, earnUiVersion]);
+  }, [stakePrograms, isLwd40Enabled, computedUiVersion]);
 
   return { extraInputs };
 };

--- a/apps/ledger-live-desktop/src/renderer/screens/earn/index.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/earn/index.test.tsx
@@ -5,6 +5,7 @@ import {
   useRemoteLiveAppManifest,
 } from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
 import { useLocalLiveAppManifest } from "@ledgerhq/live-common/wallet-api/LocalLiveAppProvider/index";
+import { useDeepLinkListener } from "./useDeepLinkListener";
 import Earn from ".";
 
 const mockWebPlatformPlayer = jest.fn((_props: unknown) => (
@@ -18,6 +19,10 @@ jest.mock("@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index"
 jest.mock("@ledgerhq/live-common/wallet-api/LocalLiveAppProvider/index", () => ({
   useLocalLiveAppManifest: jest.fn(),
 }));
+
+jest.mock("./useDeepLinkListener", () => ({
+  useDeepLinkListener: jest.fn(),
+}));
 jest.mock("~/renderer/components/WebPlatformPlayer", () => ({
   __esModule: true,
   default: (props: unknown) => mockWebPlatformPlayer(props),
@@ -26,6 +31,7 @@ jest.mock("~/renderer/components/WebPlatformPlayer", () => ({
 const mockedUseRemoteLiveAppManifest = jest.mocked(useRemoteLiveAppManifest);
 const mockedUseRemoteLiveAppContext = jest.mocked(useRemoteLiveAppContext);
 const mockedUseLocalLiveAppManifest = jest.mocked(useLocalLiveAppManifest);
+const mockedUseDeepLinkListener = jest.mocked(useDeepLinkListener);
 
 const manifest = {
   id: "earn-manifest-id",
@@ -39,6 +45,7 @@ describe("Earn screen", () => {
     mockedUseRemoteLiveAppManifest.mockReturnValue(manifest);
     mockedUseLocalLiveAppManifest.mockReturnValue(undefined);
     mockedUseRemoteLiveAppContext.mockReturnValue({ updateManifests: jest.fn() } as never);
+    mockedUseDeepLinkListener.mockImplementation(jest.fn());
   });
 
   it("passes enabled uiVersion and lw40enabled=true when feature is enabled", () => {

--- a/apps/ledger-live-desktop/src/renderer/screens/earn/index.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/earn/index.test.tsx
@@ -1,0 +1,142 @@
+import React from "react";
+import { render, screen, withFlagOverrides } from "tests/testSetup";
+import {
+  useRemoteLiveAppContext,
+  useRemoteLiveAppManifest,
+} from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
+import { useLocalLiveAppManifest } from "@ledgerhq/live-common/wallet-api/LocalLiveAppProvider/index";
+import Earn from ".";
+
+const mockWebPlatformPlayer = jest.fn((_props: unknown) => (
+  <div data-testid="earn-web-platform-player" />
+));
+
+jest.mock("@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index", () => ({
+  useRemoteLiveAppManifest: jest.fn(),
+  useRemoteLiveAppContext: jest.fn(),
+}));
+jest.mock("@ledgerhq/live-common/wallet-api/LocalLiveAppProvider/index", () => ({
+  useLocalLiveAppManifest: jest.fn(),
+}));
+jest.mock("~/renderer/components/WebPlatformPlayer", () => ({
+  __esModule: true,
+  default: (props: unknown) => mockWebPlatformPlayer(props),
+}));
+
+const mockedUseRemoteLiveAppManifest = jest.mocked(useRemoteLiveAppManifest);
+const mockedUseRemoteLiveAppContext = jest.mocked(useRemoteLiveAppContext);
+const mockedUseLocalLiveAppManifest = jest.mocked(useLocalLiveAppManifest);
+
+const manifest = {
+  id: "earn-manifest-id",
+  name: "Earn",
+  url: "https://earn.example",
+} as never;
+
+describe("Earn screen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseRemoteLiveAppManifest.mockReturnValue(manifest);
+    mockedUseLocalLiveAppManifest.mockReturnValue(undefined);
+    mockedUseRemoteLiveAppContext.mockReturnValue({ updateManifests: jest.fn() } as never);
+  });
+
+  it("passes enabled uiVersion and lw40enabled=true when feature is enabled", () => {
+    render(<Earn />, {
+      initialState: withFlagOverrides({
+        ptxEarnLiveApp: { enabled: true, params: { manifest_id: "earn-manifest-id" } },
+        ptxEarnUi: { enabled: true, params: { value: "v2" } },
+        lwdWallet40: { enabled: true },
+        stakePrograms: {
+          enabled: true,
+          params: {
+            list: ["ethereum", "bitcoin"],
+            redirects: {
+              ethereum: {
+                platform: "earn",
+                name: "",
+                queryParams: { ethDepositCohort: "cohort-a" },
+              },
+              bitcoin: {
+                platform: "stakekit",
+                name: "",
+              },
+            },
+          },
+        } as never,
+      }),
+    });
+
+    expect(mockWebPlatformPlayer).toHaveBeenCalled();
+    const lastCall = mockWebPlatformPlayer.mock.calls.at(-1)?.[0] as unknown as {
+      inputs: Record<string, string | undefined>;
+    };
+
+    expect(screen.getByTestId("earn-web-platform-player")).toBeVisible();
+    expect(lastCall.inputs.uiVersion).toBe("v2");
+    expect(lastCall.inputs.lw40enabled).toBe("true");
+    expect(lastCall.inputs.stakeProgramsParam).toBe(
+      JSON.stringify({ ethereum: "earn", bitcoin: "stakekit" }),
+    );
+    expect(lastCall.inputs.stakeCurrenciesParam).toBe(JSON.stringify(["ethereum", "bitcoin"]));
+    expect(lastCall.inputs.ethDepositCohort).toBe("cohort-a");
+  });
+
+  it("passes fallback uiVersion and lw40enabled=false when feature is disabled", () => {
+    render(<Earn />, {
+      initialState: withFlagOverrides({
+        ptxEarnLiveApp: { enabled: true, params: { manifest_id: "earn-manifest-id" } },
+        ptxEarnUi: { enabled: true, params: { value: "v2" } },
+        lwdWallet40: { enabled: false },
+        stakePrograms: {
+          enabled: true,
+          params: { list: [], redirects: {} },
+        } as never,
+      }),
+    });
+
+    expect(mockWebPlatformPlayer).toHaveBeenCalled();
+    const lastCall = mockWebPlatformPlayer.mock.calls.at(-1)?.[0] as unknown as {
+      inputs: Record<string, string | undefined>;
+    };
+
+    expect(lastCall.inputs.uiVersion).toBe("v1");
+    expect(lastCall.inputs.lw40enabled).toBe("false");
+  });
+
+  it("passes uiVersion v3 when earn upselling is enabled", () => {
+    render(<Earn />, {
+      initialState: withFlagOverrides({
+        ptxEarnLiveApp: { enabled: true, params: { manifest_id: "earn-manifest-id" } },
+        ptxEarnUi: { enabled: true, params: { value: "v1" } },
+        lwdWallet40: { enabled: true, params: { earnUpselling: true } as never },
+        stakePrograms: { enabled: true, params: { list: [], redirects: {} } } as never,
+      }),
+    });
+
+    const lastCall = mockWebPlatformPlayer.mock.calls.at(-1)?.[0] as unknown as {
+      inputs: Record<string, string | undefined>;
+    };
+
+    expect(lastCall.inputs.uiVersion).toBe("v3");
+    expect(lastCall.inputs.lw40enabled).toBe("true");
+  });
+
+  it("passes uiVersion v4 when earn simulator is enabled", () => {
+    render(<Earn />, {
+      initialState: withFlagOverrides({
+        ptxEarnLiveApp: { enabled: true, params: { manifest_id: "earn-manifest-id" } },
+        ptxEarnUi: { enabled: true, params: { value: "v1" } },
+        lwdWallet40: { enabled: true, params: { earnSimulator: true } as never },
+        stakePrograms: { enabled: true, params: { list: [], redirects: {} } } as never,
+      }),
+    });
+
+    const lastCall = mockWebPlatformPlayer.mock.calls.at(-1)?.[0] as unknown as {
+      inputs: Record<string, string | undefined>;
+    };
+
+    expect(lastCall.inputs.uiVersion).toBe("v4");
+    expect(lastCall.inputs.lw40enabled).toBe("true");
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/screens/earn/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/earn/index.tsx
@@ -30,6 +30,7 @@ import { useLocation } from "react-router";
 import { useVersionedStakePrograms } from "LLD/hooks/useVersionedStakePrograms";
 import { NetworkErrorScreen } from "~/renderer/components/Web3AppWebview/NetworkError";
 import Box from "~/renderer/components/Box";
+import { computeEarnUiVersion } from "@ledgerhq/live-common/domain/computeEarnUiVersion";
 
 const DEFAULT_MANIFEST_ID =
   process.env.DEFAULT_EARN_MANIFEST_ID || DEFAULT_FEATURES.ptxEarnLiveApp.params?.manifest_id;
@@ -49,7 +50,18 @@ const Earn = () => {
   const themeType = useTheme().theme;
   const discreetMode = useDiscreetMode();
   const countryLocale = getParsedSystemDeviceLocale().region;
-  const { isEnabled: isLwd40Enabled } = useWalletFeaturesConfig("desktop");
+  const {
+    isEnabled: isLwd40Enabled,
+    shouldDisplayEarnUpselling,
+    shouldDisplayEarnSimulator,
+  } = useWalletFeaturesConfig("desktop");
+
+  const computedUiVersion = computeEarnUiVersion({
+    baseUiVersion: earnUiVersion,
+    shouldDisplayEarnUpselling,
+    shouldDisplayEarnSimulator,
+  });
+
   useDeepLinkListener();
 
   const stakePrograms = useVersionedStakePrograms();
@@ -98,7 +110,7 @@ const Earn = () => {
             ? JSON.stringify(stakeCurrenciesParam)
             : undefined,
           ethDepositCohort,
-          uiVersion: isLwd40Enabled ? earnUiVersion : "v1",
+          uiVersion: isLwd40Enabled ? computedUiVersion: "v1",
           lw40enabled: isLwd40Enabled ? "true" : "false",
         }}
       />

--- a/apps/ledger-live-desktop/src/renderer/screens/earn/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/earn/index.tsx
@@ -110,7 +110,7 @@ const Earn = () => {
             ? JSON.stringify(stakeCurrenciesParam)
             : undefined,
           ethDepositCohort,
-          uiVersion: isLwd40Enabled ? computedUiVersion: "v1",
+          uiVersion: isLwd40Enabled ? computedUiVersion : "v1",
           lw40enabled: isLwd40Enabled ? "true" : "false",
         }}
       />

--- a/apps/ledger-live-desktop/src/renderer/screens/earn/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/earn/index.tsx
@@ -43,7 +43,7 @@ const Earn = () => {
   const devMode = useSelector(developerModeSelector);
   const earnFlag = useFeature("ptxEarnLiveApp");
   const earnManifestId = earnFlag?.enabled ? earnFlag.params?.manifest_id : DEFAULT_MANIFEST_ID;
-  const earnUiVersion = useFeature("ptxEarnUi")?.params?.value ?? "v1";
+  const earnUiVersion = useFeature("ptxEarnUi")?.params?.value ?? "v2";
   const localManifest = useLocalLiveAppManifest(earnManifestId);
   const remoteManifest = useRemoteLiveAppManifest(earnManifestId);
   const manifest = localManifest || remoteManifest;

--- a/apps/ledger-live-mobile/src/mvvm/features/LiveAppModal/__tests__/useEarnLiveAppModalContentViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LiveAppModal/__tests__/useEarnLiveAppModalContentViewModel.test.ts
@@ -1,0 +1,109 @@
+import { renderHook, withFlagOverrides } from "@tests/test-renderer";
+import { useVersionedStakePrograms } from "LLM/hooks/useStake/useVersionedStakePrograms";
+import useEarnLiveAppModalContentViewModel from "../useEarnLiveAppModalContentViewModel";
+
+jest.mock("LLM/hooks/useStake/useVersionedStakePrograms", () => ({
+  useVersionedStakePrograms: jest.fn(),
+}));
+
+const mockedUseVersionedStakePrograms = jest.mocked(useVersionedStakePrograms);
+
+describe("useEarnLiveAppModalContentViewModel (mobile)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns serialized params and enabled values when wallet 40 is enabled", () => {
+    mockedUseVersionedStakePrograms.mockReturnValue({
+      enabled: true,
+      params: {
+        list: ["ethereum", "bitcoin"],
+        redirects: {
+          ethereum: {
+            platform: "earn",
+            name: "",
+            queryParams: { ethDepositCohort: "cohort-a" },
+          },
+          bitcoin: {
+            platform: "stakekit",
+            name: "",
+          },
+        },
+      },
+    } as never);
+
+    const { result } = renderHook(() => useEarnLiveAppModalContentViewModel(), {
+      overrideInitialState: withFlagOverrides({
+        ptxEarnUi: { enabled: true, params: { value: "v2" } },
+        lwmWallet40: { enabled: true },
+      }),
+    });
+
+    expect(result.current.extraInputs).toEqual({
+      uiVersion: "v2",
+      lw40enabled: "true",
+      ethDepositCohort: "cohort-a",
+      stakeProgramsParam: JSON.stringify({ ethereum: "earn", bitcoin: "stakekit" }),
+      stakeCurrenciesParam: JSON.stringify(["ethereum", "bitcoin"]),
+    });
+  });
+
+  it("omits empty stakeCurrencies and falls back to v1 when wallet 40 is disabled", () => {
+    mockedUseVersionedStakePrograms.mockReturnValue({
+      enabled: true,
+      params: { list: [], redirects: {} },
+    } as never);
+
+    const { result } = renderHook(() => useEarnLiveAppModalContentViewModel(), {
+      overrideInitialState: withFlagOverrides({
+        ptxEarnUi: { enabled: true, params: { value: "v2" } },
+        lwmWallet40: { enabled: false },
+      }),
+    });
+
+    expect(result.current.extraInputs?.uiVersion).toBe("v1");
+    expect(result.current.extraInputs?.lw40enabled).toBe("false");
+    expect(result.current.extraInputs?.stakeProgramsParam).toBeUndefined();
+    expect(result.current.extraInputs?.stakeCurrenciesParam).toBeUndefined();
+  });
+
+  it("returns v3 when earn upselling is enabled", () => {
+    mockedUseVersionedStakePrograms.mockReturnValue({
+      enabled: true,
+      params: {
+        list: [],
+        redirects: {},
+      },
+    } as never);
+
+    const { result } = renderHook(() => useEarnLiveAppModalContentViewModel(), {
+      overrideInitialState: withFlagOverrides({
+        ptxEarnUi: { enabled: true, params: { value: "v1" } },
+        lwmWallet40: { enabled: true, params: { earnUpselling: true } as never },
+      }),
+    });
+
+    expect(result.current.extraInputs?.uiVersion).toBe("v3");
+    expect(result.current.extraInputs?.lw40enabled).toBe("true");
+  });
+
+  it("returns v4 when earn simulator is enabled", () => {
+    mockedUseVersionedStakePrograms.mockReturnValue({
+      enabled: true,
+      params: {
+        list: [],
+        redirects: {},
+      },
+    } as never);
+
+    const { result } = renderHook(() => useEarnLiveAppModalContentViewModel(), {
+      overrideInitialState: withFlagOverrides({
+        ptxEarnUi: { enabled: true, params: { value: "v1" } },
+        lwmWallet40: { enabled: true, params: { earnSimulator: true } as never },
+      }),
+    });
+
+    expect(result.current.extraInputs?.uiVersion).toBe("v4");
+    expect(result.current.extraInputs?.lw40enabled).toBe("true");
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/LiveAppModal/useEarnLiveAppModalContentViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LiveAppModal/useEarnLiveAppModalContentViewModel.ts
@@ -7,22 +7,32 @@ import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/inde
 import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 import { useVersionedStakePrograms } from "LLM/hooks/useStake/useVersionedStakePrograms";
 import type { ExtraInputs } from "./useLiveAppModalContentViewModel";
+import { computeEarnUiVersion } from "@ledgerhq/live-common/domain/computeEarnUiVersion";
 
 export interface EarnLiveAppModalContentViewModel {
   extraInputs: ExtraInputs;
 }
 
 const useEarnLiveAppModalContentViewModel = (): EarnLiveAppModalContentViewModel => {
-  const { isEnabled: isLwm40Enabled } = useWalletFeaturesConfig("mobile");
+  const {
+    isEnabled: isLwm40Enabled,
+    shouldDisplayEarnSimulator,
+    shouldDisplayEarnUpselling,
+  } = useWalletFeaturesConfig("mobile");
   const stakePrograms = useVersionedStakePrograms();
-  const earnUiVersion = useFeature("ptxEarnUi")?.params?.value ?? "v1";
+  const earnUiVersion = useFeature("ptxEarnUi");
+  const computedUiVersion = computeEarnUiVersion({
+    baseUiVersion: earnUiVersion?.params?.value ?? "v2",
+    shouldDisplayEarnUpselling,
+    shouldDisplayEarnSimulator,
+  });
 
   const extraInputs = useMemo<ExtraInputs>(() => {
     const { stakeProgramsParam } = stakeProgramsToEarnParam(stakePrograms);
     const stakeCurrenciesParam = stakePrograms?.params?.list;
     const ethDepositCohort = getEthDepositScreenSetting(stakePrograms);
     return {
-      uiVersion: earnUiVersion,
+      uiVersion: isLwm40Enabled ? computedUiVersion : "v1",
       lw40enabled: isLwm40Enabled ? "true" : "false",
       ethDepositCohort,
       stakeProgramsParam: stakeProgramsParam ? JSON.stringify(stakeProgramsParam) : undefined,
@@ -30,7 +40,7 @@ const useEarnLiveAppModalContentViewModel = (): EarnLiveAppModalContentViewModel
         ? JSON.stringify(stakeCurrenciesParam)
         : undefined,
     };
-  }, [stakePrograms, isLwm40Enabled, earnUiVersion]);
+  }, [stakePrograms, isLwm40Enabled, computedUiVersion]);
 
   return { extraInputs };
 };

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/index.tsx
@@ -13,6 +13,7 @@ import { useNavigationBarHeights } from "LLM/hooks/useNavigationBarHeights";
 import { EarnWebview } from "../EarnWebview";
 import { LiveAppBackground } from "LLM/components/LiveAppBackground";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig";
+import { computeEarnUiVersion } from "@ledgerhq/live-common/domain/computeEarnUiVersion";
 
 type Props = {
   manifest?: LiveAppManifest;
@@ -42,15 +43,11 @@ export const EarnV2Webview = ({
 
   const earnUiVersion = useFeature("ptxEarnUi")?.params?.value ?? "v1";
 
-  const computedUiVersion = useMemo(() => {
-    if (shouldDisplayEarnUpselling) {
-      return "v3";
-    }
-    if (shouldDisplayEarnSimulator) {
-      return "v4";
-    }
-    return earnUiVersion;
-  }, [shouldDisplayEarnUpselling, shouldDisplayEarnSimulator, earnUiVersion]);
+  const computedUiVersion = computeEarnUiVersion({
+    baseUiVersion: earnUiVersion,
+    shouldDisplayEarnUpselling,
+    shouldDisplayEarnSimulator,
+  });
 
   const isPtxUiMinV2 = isMinEarnUiVersion(computedUiVersion, "v2");
 

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/index.tsx
@@ -3,7 +3,7 @@ import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 import { useRemoteLiveAppContext } from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import { Flex } from "@ledgerhq/native-ui";
-import React, { ComponentProps, Fragment, useRef, useCallback, useMemo } from "react";
+import React, { ComponentProps, Fragment, useRef, useCallback } from "react";
 import { Animated, StyleSheet, View } from "react-native";
 import type WebView from "react-native-webview";
 import { useSafeAreaInsets } from "react-native-safe-area-context";

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/index.tsx
@@ -41,7 +41,7 @@ export const EarnV2Webview = ({
   const { shouldDisplayEarnUpselling, shouldDisplayEarnSimulator } =
     useWalletFeaturesConfig("mobile");
 
-  const earnUiVersion = useFeature("ptxEarnUi")?.params?.value ?? "v1";
+  const earnUiVersion = useFeature("ptxEarnUi")?.params?.value ?? "v2";
 
   const computedUiVersion = computeEarnUiVersion({
     baseUiVersion: earnUiVersion,

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -338,7 +338,8 @@
     "src/wallet-api/validation/validateUrl.ts",
     "src/wallet-api/validation/validateInfoDialogParams.ts",
     "src/wallet-api/validation/actionDialogParams.ts",
-    "src/domain/isMinEarnUiVersion.ts"
+    "src/domain/isMinEarnUiVersion.ts",
+    "src/domain/computeEarnUiVersion.ts"
   ],
   "extensions": [
     ".ts",

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -339,7 +339,8 @@
     "src/wallet-api/validation/validateInfoDialogParams.ts",
     "src/wallet-api/validation/actionDialogParams.ts",
     "src/domain/isMinEarnUiVersion.ts",
-    "src/domain/computeEarnUiVersion.ts"
+    "src/domain/computeEarnUiVersion.ts",
+    "src/domain/earnUiVersion.ts"
   ],
   "extensions": [
     ".ts",

--- a/libs/ledger-live-common/src/domain/computeEarnUiVersion.test.ts
+++ b/libs/ledger-live-common/src/domain/computeEarnUiVersion.test.ts
@@ -1,0 +1,25 @@
+import { computeEarnUiVersion } from "./computeEarnUiVersion";
+
+describe("computeEarnUiVersion", () => {
+  it.each([
+    [{ baseUiVersion: "v1", shouldDisplayEarnUpselling: true }, "v3"],
+    [{ baseUiVersion: "v2", shouldDisplayEarnSimulator: true }, "v4"],
+    [
+      { baseUiVersion: "v2", shouldDisplayEarnUpselling: true, shouldDisplayEarnSimulator: true },
+      "v4",
+    ],
+  ])("applies feature precedence for %p => %s", (input, expected) => {
+    expect(computeEarnUiVersion(input)).toBe(expected);
+  });
+
+  it.each([
+    [{ baseUiVersion: "v2" }, "v2"],
+    [{ baseUiVersion: "2" }, "v2"],
+    [{ baseUiVersion: 3 }, "v3"],
+    [{ baseUiVersion: null }, "v1"],
+    [{ baseUiVersion: undefined }, "v1"],
+    [{ baseUiVersion: "garbage" }, "v1"],
+  ])("normalizes baseUiVersion for %p => %s", (input, expected) => {
+    expect(computeEarnUiVersion(input)).toBe(expected);
+  });
+});

--- a/libs/ledger-live-common/src/domain/computeEarnUiVersion.test.ts
+++ b/libs/ledger-live-common/src/domain/computeEarnUiVersion.test.ts
@@ -16,9 +16,9 @@ describe("computeEarnUiVersion", () => {
     [{ baseUiVersion: "v2" }, "v2"],
     [{ baseUiVersion: "2" }, "v2"],
     [{ baseUiVersion: 3 }, "v3"],
-    [{ baseUiVersion: null }, "v1"],
-    [{ baseUiVersion: undefined }, "v1"],
-    [{ baseUiVersion: "garbage" }, "v1"],
+    [{ baseUiVersion: null }, "v2"],
+    [{ baseUiVersion: undefined }, "v2"],
+    [{ baseUiVersion: "garbage" }, "v2"],
   ])("normalizes baseUiVersion for %p => %s", (input, expected) => {
     expect(computeEarnUiVersion(input)).toBe(expected);
   });

--- a/libs/ledger-live-common/src/domain/computeEarnUiVersion.ts
+++ b/libs/ledger-live-common/src/domain/computeEarnUiVersion.ts
@@ -1,16 +1,6 @@
-import { z } from "zod";
-
-type EarnUiVersion = `v${number}`;
+import { EarnUiVersion, normalizeEarnUiVersionOrNull } from "./earnUiVersion";
 
 const DEFAULT: EarnUiVersion = "v2";
-
-const coercedString = z.coerce.string();
-
-function parseEarnUiVersionOrNull(raw: string): EarnUiVersion | null {
-  const bare = raw.startsWith("v") ? raw.slice(1) : raw;
-  const n = z.coerce.number().int().positive().safeParse(bare);
-  return n.success ? `v${n.data}` : null;
-}
 
 export type ComputeEarnUiVersionInput = {
   baseUiVersion: string | number | null | undefined;
@@ -30,6 +20,5 @@ export function computeEarnUiVersion({
   if (shouldDisplayEarnSimulator) return "v4";
   if (shouldDisplayEarnUpselling) return "v3";
 
-  const baseRaw = baseUiVersion == null ? DEFAULT : coercedString.parse(baseUiVersion);
-  return parseEarnUiVersionOrNull(baseRaw) ?? DEFAULT;
+  return normalizeEarnUiVersionOrNull(baseUiVersion) ?? DEFAULT;
 }

--- a/libs/ledger-live-common/src/domain/computeEarnUiVersion.ts
+++ b/libs/ledger-live-common/src/domain/computeEarnUiVersion.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 type EarnUiVersion = `v${number}`;
 
-const DEFAULT: EarnUiVersion = "v1";
+const DEFAULT: EarnUiVersion = "v2";
 
 const coercedString = z.coerce.string();
 

--- a/libs/ledger-live-common/src/domain/computeEarnUiVersion.ts
+++ b/libs/ledger-live-common/src/domain/computeEarnUiVersion.ts
@@ -20,7 +20,7 @@ export type ComputeEarnUiVersionInput = {
 
 /**
  * Computes the final Earn UI version from Wallet40 toggles and ptxEarnUi value.
- * Precedence: simulator (v4) > upselling (v3) > baseUiVersion (normalized, fallback to v1).
+ * Precedence: simulator (v4) > upselling (v3) > baseUiVersion (normalized, fallback to v2).
  */
 export function computeEarnUiVersion({
   baseUiVersion,

--- a/libs/ledger-live-common/src/domain/computeEarnUiVersion.ts
+++ b/libs/ledger-live-common/src/domain/computeEarnUiVersion.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+type EarnUiVersion = `v${number}`;
+
+const DEFAULT: EarnUiVersion = "v1";
+
+const coercedString = z.coerce.string();
+
+function parseEarnUiVersionOrNull(raw: string): EarnUiVersion | null {
+  const bare = raw.startsWith("v") ? raw.slice(1) : raw;
+  const n = z.coerce.number().int().positive().safeParse(bare);
+  return n.success ? `v${n.data}` : null;
+}
+
+export type ComputeEarnUiVersionInput = {
+  baseUiVersion: string | number | null | undefined;
+  shouldDisplayEarnUpselling?: boolean;
+  shouldDisplayEarnSimulator?: boolean;
+};
+
+/**
+ * Computes the final Earn UI version from Wallet40 toggles and ptxEarnUi value.
+ * Precedence: simulator (v4) > upselling (v3) > baseUiVersion (normalized, fallback to v1).
+ */
+export function computeEarnUiVersion({
+  baseUiVersion,
+  shouldDisplayEarnUpselling = false,
+  shouldDisplayEarnSimulator = false,
+}: ComputeEarnUiVersionInput): EarnUiVersion {
+  if (shouldDisplayEarnSimulator) return "v4";
+  if (shouldDisplayEarnUpselling) return "v3";
+
+  const baseRaw = baseUiVersion == null ? DEFAULT : coercedString.parse(baseUiVersion);
+  return parseEarnUiVersionOrNull(baseRaw) ?? DEFAULT;
+}

--- a/libs/ledger-live-common/src/domain/earnUiVersion.test.ts
+++ b/libs/ledger-live-common/src/domain/earnUiVersion.test.ts
@@ -1,0 +1,30 @@
+import { normalizeEarnUiVersionOrNull } from "./earnUiVersion";
+
+describe("normalizeEarnUiVersionOrNull", () => {
+  it.each([
+    ["v1", "v1"],
+    ["v2", "v2"],
+    ["1", "v1"],
+    ["2", "v2"],
+    [1, "v1"],
+    [2, "v2"],
+    ["01", "v1"],
+    ["v01", "v1"],
+  ])("normalizes valid value %p => %s", (raw, expected) => {
+    expect(normalizeEarnUiVersionOrNull(raw)).toBe(expected);
+  });
+
+  it.each([
+    [null, null],
+    [undefined, null],
+    ["v0", null],
+    ["0", null],
+    [0, null],
+    [-1, null],
+    [1.5, null],
+    ["v1.5", null],
+    ["garbage", null],
+  ])("returns null for invalid value %p", raw => {
+    expect(normalizeEarnUiVersionOrNull(raw)).toBeNull();
+  });
+});

--- a/libs/ledger-live-common/src/domain/earnUiVersion.test.ts
+++ b/libs/ledger-live-common/src/domain/earnUiVersion.test.ts
@@ -15,15 +15,15 @@ describe("normalizeEarnUiVersionOrNull", () => {
   });
 
   it.each([
-    [null, null],
-    [undefined, null],
-    ["v0", null],
-    ["0", null],
-    [0, null],
-    [-1, null],
-    [1.5, null],
-    ["v1.5", null],
-    ["garbage", null],
+    [null],
+    [undefined],
+    ["v0"],
+    ["0"],
+    [0],
+    [-1],
+    [1.5],
+    ["v1.5"],
+    ["garbage"],
   ])("returns null for invalid value %p", raw => {
     expect(normalizeEarnUiVersionOrNull(raw)).toBeNull();
   });

--- a/libs/ledger-live-common/src/domain/earnUiVersion.ts
+++ b/libs/ledger-live-common/src/domain/earnUiVersion.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+export type EarnUiVersion = `v${number}`;
+
+const coercedString = z.coerce.string();
+
+function parseEarnUiVersionStringOrNull(raw: string): EarnUiVersion | null {
+  const bare = raw.startsWith("v") ? raw.slice(1) : raw;
+  const n = z.coerce.number().int().positive().safeParse(bare);
+  return n.success ? `v${n.data}` : null;
+}
+
+export function normalizeEarnUiVersionOrNull(
+  raw: string | number | null | undefined,
+): EarnUiVersion | null {
+  if (raw == null) return null;
+  return parseEarnUiVersionStringOrNull(coercedString.parse(raw));
+}

--- a/libs/ledger-live-common/src/domain/isMinEarnUiVersion.ts
+++ b/libs/ledger-live-common/src/domain/isMinEarnUiVersion.ts
@@ -1,16 +1,6 @@
-import { z } from "zod";
-
-type EarnUiVersion = `v${number}`;
+import { EarnUiVersion, normalizeEarnUiVersionOrNull } from "./earnUiVersion";
 
 const DEFAULT: EarnUiVersion = "v1";
-
-function parseEarnUiVersionOrNull(raw: string): EarnUiVersion | null {
-  const bare = raw.startsWith("v") ? raw.slice(1) : raw;
-  const n = z.coerce.number().int().positive().safeParse(bare);
-  return n.success ? `v${n.data}` : null;
-}
-
-const coercedString = z.coerce.string();
 
 /**
  * Integer-based minimum version check for the ptxEarnUi feature flag.
@@ -21,11 +11,9 @@ export function isMinEarnUiVersion(
   actual: string | number | null | undefined,
   minimum: string | number,
 ): boolean {
-  const actualRaw = actual == null ? DEFAULT : coercedString.parse(actual);
-  const a = parseEarnUiVersionOrNull(actualRaw) ?? DEFAULT;
+  const a = normalizeEarnUiVersionOrNull(actual) ?? DEFAULT;
 
-  const minimumRaw = coercedString.parse(minimum);
-  const b = parseEarnUiVersionOrNull(minimumRaw);
+  const b = normalizeEarnUiVersionOrNull(minimum);
   if (b === null) return false;
 
   return Number.parseInt(a.slice(1), 10) >= Number.parseInt(b.slice(1), 10);

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -522,7 +522,7 @@ export const DEFAULT_FEATURES: Features = {
   ptxEarnUi: {
     enabled: false,
     params: {
-      value: "v1",
+      value: "v2",
     },
   },
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Partial: unit tests were added for `computeEarnUiVersion`, but no dedicated desktop/mobile integration test was added in this PR._
- [x] **Impact of the changes:**
  - Earn `uiVersion` query parameter generation in desktop Earn screen
  - Earn V2 webview version selection logic on mobile
  - Wallet feature flag precedence between upselling (`v3`) and simulator (`v4`)

### 📝 Description

The Earn flow currently computes UI version logic in multiple places, which can drift and cause inconsistent behavior between mobile and desktop when wallet feature flags are enabled.

This PR centralizes the version computation in `@ledgerhq/live-common` via `computeEarnUiVersion`, adds unit coverage for parsing and precedence rules, and updates desktop/mobile Earn entry points to reuse this shared logic.

**Demo:**

**Desktop**
*Upselling disable*
<img width="2560" height="1440" alt="disable earn screen" src="https://github.com/user-attachments/assets/744dc043-277a-4356-8b1d-3201feaef0e6" />
<img width="445" height="436" alt="ff disable" src="https://github.com/user-attachments/assets/a1da800a-be69-49bd-a346-39edc4439013" />

*Upselling enable:*
<img width="2560" height="1440" alt="enable earn screen" src="https://github.com/user-attachments/assets/ab2b0fd5-9a60-4e1c-9c74-60431c55d7a4" />
<img width="438" height="436" alt="ff enable" src="https://github.com/user-attachments/assets/bea14bc1-b609-40b8-bc76-1bc4cf25c189" />

**Mobile**
*Upselling disable*
<img width="906" height="1368" alt="Screenshot 2026-05-07 at 11 11 28" src="https://github.com/user-attachments/assets/18cca1a9-54c9-41b0-adc6-1fb9d19d6efd" />
<img width="624" height="1314" alt="Screenshot 2026-05-07 at 11 11 11" src="https://github.com/user-attachments/assets/6a53b01b-e141-467a-8627-9c5746696c18" />

*upselling enable*
<img width="704" height="902" alt="Screenshot 2026-05-07 at 11 23 04" src="https://github.com/user-attachments/assets/4d663998-f91d-4a7d-b1a1-b02f54af5a89" />

<img width="728" height="1302" alt="Screenshot 2026-05-07 at 11 24 19" src="https://github.com/user-attachments/assets/13fbab12-26cd-4483-8fb8-8226c7b0477d" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-30333](https://ledgerhq.atlassian.net/browse/LIVE-30333)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-30333]: https://ledgerhq.atlassian.net/browse/LIVE-30333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ