### PR TITLE
[LWDM] feat(mobile): add debug Asset Detail FAB toggle

### DIFF
--- a/.changeset/golden-debug-float.md
+++ b/.changeset/golden-debug-float.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@ledgerhq/live-env": patch
+---
+
+Add debug FAB toggle to quickly open Asset Detail screen

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -39,6 +39,7 @@ import LoadingApp from "~/components/LoadingApp";
 import StyledStatusBar from "~/components/StyledStatusBar";
 import AnalyticsConsole from "~/components/AnalyticsConsole";
 import DebugTheme from "~/components/DebugTheme";
+import AssetDetailFab from "~/screens/Settings/Debug/Features/AssetDetailFab";
 import SyncNewAccounts from "~/bridge/SyncNewAccounts";
 import SegmentSetup from "~/analytics/SegmentSetup";
 import HookNotifications from "~/notifications/HookNotifications";
@@ -257,6 +258,7 @@ function App() {
       <AnalyticsConsole />
 
       <DebugTheme />
+      <AssetDetailFab />
       <JsThreadMonitor />
       <Modals />
       <FeatureToggle featureId="llmMmkvMigration">

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Configuration/AssetDetailFabRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Configuration/AssetDetailFabRow.tsx
@@ -1,0 +1,20 @@
+import React, { useCallback } from "react";
+import useEnv from "@ledgerhq/live-common/hooks/useEnv";
+import { setEnv } from "@ledgerhq/live-env";
+import SettingsRow from "~/components/SettingsRow";
+import Switch from "~/components/Switch";
+
+const AssetDetailFabRow = () => {
+  const enabled = useEnv("DEBUG_ASSET_DETAIL_FAB");
+  const toggle = useCallback(() => {
+    setEnv("DEBUG_ASSET_DETAIL_FAB", !enabled);
+  }, [enabled]);
+
+  return (
+    <SettingsRow title="Asset Detail FAB" desc="Show floating button to open BTC Asset Detail">
+      <Switch value={enabled} onValueChange={toggle} />
+    </SettingsRow>
+  );
+};
+
+export default AssetDetailFabRow;

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Configuration/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Configuration/index.tsx
@@ -19,6 +19,7 @@ import ResetOnboardingStateRow from "./ResetOnboardingStateRow";
 import HasStaxEuropaRows from "./HasStaxEuropaRows";
 import SkipOnboardingRow from "./SkipOnboardingRow";
 import { RecoverUpsellRow } from "./RecoverUpsellRow";
+import AssetDetailFabRow from "./AssetDetailFabRow";
 
 export default function Configuration() {
   const navigation = useNavigation<StackNavigatorNavigation<SettingsNavigatorStackParamList>>();
@@ -51,6 +52,7 @@ export default function Configuration() {
       <ThemeToggleRow />
       <JsThreadMonitorRow />
       <CountervaluesStagingRow />
+      <AssetDetailFabRow />
       <SkipLock />
     </SettingsNavigationScrollView>
   );

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/AssetDetailFab.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/AssetDetailFab.tsx
@@ -1,0 +1,25 @@
+import React, { useCallback } from "react";
+import { IconsLegacy } from "@ledgerhq/native-ui";
+import { useNavigation } from "@react-navigation/native";
+import useEnv from "@ledgerhq/live-common/hooks/useEnv";
+import { NavigatorName, ScreenName } from "~/const";
+import type { BaseNavigation } from "~/components/RootNavigator/types/helpers";
+import FloatingDebugButton from "~/components/FloatingDebugButton";
+
+const AssetDetailFab = () => {
+  const enabled = useEnv("DEBUG_ASSET_DETAIL_FAB");
+  const navigation = useNavigation<BaseNavigation>();
+
+  const onPress = useCallback(() => {
+    navigation.navigate(NavigatorName.AssetDetail, {
+      screen: ScreenName.AssetDetail,
+      params: { currencyId: "bitcoin" },
+    });
+  }, [navigation]);
+
+  if (!enabled) return null;
+
+  return <FloatingDebugButton onPress={onPress} Icon={IconsLegacy.CoinsMedium} />;
+};
+
+export default AssetDetailFab;

--- a/libs/env/src/env.ts
+++ b/libs/env/src/env.ts
@@ -52,6 +52,11 @@ const envDefinitions = {
     parser: boolParser,
     desc: "Show tracking overlays on the app UI",
   },
+  DEBUG_ASSET_DETAIL_FAB: {
+    def: false,
+    parser: boolParser,
+    desc: "Show floating button to open Asset Detail (BTC)",
+  },
   DEBUG_THEME: {
     def: false,
     parser: boolParser,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Debug-only feature, no business logic to test._
- [x] **Impact of the changes:**
  - Debug Settings > Configuration screen (new toggle row)
  - Floating overlay button visibility on all screens when enabled

### 📝 Description

**Problem**: During development and QA of the Asset Detail screen, there is no quick way to navigate to it without going through the full app flow.

**Solution**: Added a debug FAB (Floating Action Button) toggle in Settings > Debug > Configuration that, when enabled, shows a draggable floating button on all screens. Tapping it navigates directly to the BTC Asset Detail screen. Follows the existing `ANALYTICS_CONSOLE` / `DEBUG_THEME` env var pattern:

- New `DEBUG_ASSET_DETAIL_FAB` env var in `@ledgerhq/live-env`
- Toggle row in Debug > Configuration using `useEnv` / `setEnv`
- Overlay mounted in `src/index.tsx` using the existing `FloatingDebugButton` component

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29727](https://ledgerhq.atlassian.net/browse/LIVE-29727)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29727]: https://ledgerhq.atlassian.net/browse/LIVE-29727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ