### PR TITLE
[LWD] Feat/live 28816 portfolio

### DIFF
--- a/.changeset/neat-assets-orchestrate.md
+++ b/.changeset/neat-assets-orchestrate.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add an Asset Detail portfolio orchestrator that composes total balance, addresses, and transactions with account-based visibility.

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/AssetDetailView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/AssetDetailView.tsx
@@ -4,9 +4,7 @@ import { CryptoIcon } from "@ledgerhq/crypto-icons";
 import { getValidCryptoIconSize } from "~/renderer/utils/cryptoIconSize";
 import { AssetDetailSection } from "./components/AssetDetailSection";
 import { AssetHeader } from "./components/AssetHeader/AssetHeader";
-import { AddressListSection } from "./components/AddressList";
-import { TotalBalance } from "./components/PortfolioSection/TotalBalance";
-import { TransactionsSection } from "./components/TransactionsSection";
+import { PortfolioSection } from "./components/PortfolioSection/PortfolioSection";
 import { useAssetDetailSections } from "./hooks/useAssetDetailSections";
 import type { AssetDetailReady } from "./types";
 
@@ -40,13 +38,7 @@ export function AssetDetailView({ viewModel }: AssetDetailViewProps) {
         onBack={onBack}
       />
 
-      {distributionItem && (
-        <>
-          <TotalBalance distributionItem={distributionItem} />
-          <AddressListSection distributionItem={distributionItem} />
-          <TransactionsSection distributionItem={distributionItem} />
-        </>
-      )}
+      {distributionItem && <PortfolioSection distributionItem={distributionItem} />}
 
       {marketInfo && (
         <>

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/__integrations__/AssetDetail.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/__integrations__/AssetDetail.integration.test.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { render, renderWithMockedCounterValuesProvider, screen, waitFor } from "tests/testSetup";
 import { MarketMockedResponse } from "tests/handlers/fixtures/market";
 import {
@@ -7,6 +8,7 @@ import {
   setupDistributionRouteMocks,
 } from "tests/utils/distributionTestUtils";
 import { mockMarket, mockDada } from "tests/utils/assetDetailMocks";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import type { DistributionItem } from "@ledgerhq/types-live";
 import AssetDetail from "../index";
 
@@ -35,6 +37,7 @@ jest.mock("~/renderer/actions/general", () => ({
 
 const { useParams, useLocation } = jest.requireMock("react-router");
 const { useDistribution } = jest.requireMock("~/renderer/actions/general");
+const btc = getCryptoCurrencyById("bitcoin");
 
 const setupRoute = (
   routeId: string,
@@ -77,7 +80,8 @@ const OWNED_ASSETS: OwnedAsset[] = [
     displayName: "Bitcoin",
     marketResponse: MarketMockedResponse.bitcoinDetail,
     buildDistribution: () => {
-      const item = buildDistributionItem();
+      const account = genAccount("asset-detail-btc-account", { currency: btc });
+      const item = buildDistributionItem({ accounts: [account] });
       return { bySlug: { bitcoin: item }, list: [item] };
     },
   },
@@ -87,8 +91,10 @@ const OWNED_ASSETS: OwnedAsset[] = [
     displayName: "USD Coin",
     marketResponse: MarketMockedResponse.usdcDetail,
     buildDistribution: () => {
+      const account = genAccount("asset-detail-usdc-account", { currency: btc });
       const item = buildDistributionItem({
         currency: makeIntegrationTokenCurrency("ethereum/erc20/usd__coin", "USDC", "USD Coin"),
+        accounts: [account],
       });
       return { bySlug: {}, list: [item] };
     },
@@ -327,8 +333,10 @@ describe("AssetDetail integration", () => {
   describe("route params", () => {
     it("resolves a token when route id is URL-encoded", async () => {
       mockMarket.withData(MarketMockedResponse.bitcoinDetail);
+      const account = genAccount("asset-detail-token-encoded-account", { currency: btc });
       const item = buildDistributionItem({
         currency: makeIntegrationTokenCurrency("bitcoin/test", "TBTC", "Bitcoin Test"),
+        accounts: [account],
       });
       setupRoute("bitcoin%2Ftest", { bySlug: {}, list: [item] });
 
@@ -345,8 +353,10 @@ describe("AssetDetail integration", () => {
   describe("token route with slashes", () => {
     it("resolves a token with slashes in its route id", async () => {
       mockMarket.withData(MarketMockedResponse.bitcoinDetail);
+      const account = genAccount("asset-detail-token-slashed-account", { currency: btc });
       const item = buildDistributionItem({
         currency: makeIntegrationTokenCurrency("bitcoin/test", "TBTC", "Bitcoin Test"),
+        accounts: [account],
       });
       setupRoute("bitcoin/test", { bySlug: {}, list: [item] });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/PortfolioSection/PortfolioSection.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/PortfolioSection/PortfolioSection.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import type { DistributionItem } from "@ledgerhq/types-live";
+import { AddressListSection } from "../AddressList";
+import { TransactionsSection } from "../TransactionsSection";
+import { TotalBalance } from "./TotalBalance";
+import { usePortfolioSectionViewModel } from "./usePortfolioSectionViewModel";
+
+type PortfolioSectionProps = Readonly<{
+  distributionItem: DistributionItem;
+}>;
+
+export function PortfolioSection({ distributionItem }: PortfolioSectionProps) {
+  const { visible } = usePortfolioSectionViewModel(distributionItem);
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <>
+      <TotalBalance distributionItem={distributionItem} />
+      <AddressListSection distributionItem={distributionItem} />
+      <TransactionsSection distributionItem={distributionItem} />
+    </>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/PortfolioSection/usePortfolioSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/PortfolioSection/usePortfolioSectionViewModel.ts
@@ -1,0 +1,13 @@
+import type { DistributionItem } from "@ledgerhq/types-live";
+
+export type PortfolioSectionViewModel = Readonly<{
+  visible: boolean;
+}>;
+
+export function usePortfolioSectionViewModel(
+  distributionItem: DistributionItem,
+): PortfolioSectionViewModel {
+  return {
+    visible: distributionItem.accounts.length > 0,
+  };
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request introduces a new "Asset Detail portfolio orchestrator" to the Ledger Live Desktop app, significantly enhancing the asset detail view by composing total balance, addresses, and a new transactions preview section with account-based visibility. It also improves the integration and test coverage, adds the ability to filter history by account IDs via URL, and ensures correct navigation behavior when returning from scoped history views.


### ❓ Context

[LIVE-28816](https://ledgerhq.atlassian.net/browse/LIVE-28816)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-28816]: https://ledgerhq.atlassian.net/browse/LIVE-28816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ