### PR TITLE
test(desktop): add delete account coverage

### DIFF
--- a/.changeset/gentle-owls-delete.md
+++ b/.changeset/gentle-owls-delete.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Add desktop delete account E2E coverage for Aptos, Base, and Zcash.

--- a/e2e/desktop/tests/specs/delete.account.spec.ts
+++ b/e2e/desktop/tests/specs/delete.account.spec.ts
@@ -19,6 +19,9 @@ const accounts = [
   { account: Account.ALGO_1, xrayTicket: "B2CQA-2546" },
   { account: Account.ATOM_1, xrayTicket: "B2CQA-2550" },
   { account: Account.XTZ_1, xrayTicket: "B2CQA-2555" },
+  { account: Account.APTOS_1, xrayTicket: "B2CQA-5666" },
+  { account: Account.BASE_1, xrayTicket: "B2CQA-5667" },
+  { account: Account.ZEC_1, xrayTicket: "B2CQA-5668" },
 ];
 
 for (const account of accounts) {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Desktop typecheck passed; Desktop E2E delete-account execution triggered: [run 25487910354](https://github.com/LedgerHQ/ledger-live/actions/runs/25487910354).
- [x] **Impact of the changes:**
      - Ledger Live Desktop delete-account E2E coverage
      - Aptos, Base, and Zcash account deletion scenarios
      - TMS links for the new delete-account test cases

### 📝 Description

This PR adds missing Ledger Live Desktop delete-account E2E coverage for Aptos, Base, and Zcash, using the new B2CQA test cases created for these scenarios.

The second part of the ticket, extracting a shared coin list/common utility, is intentionally not done. Keeping the data local avoids complicating the codebase for a small alignment change.

### ❓ Context

- **JIRA or GitHub link**: [QAA-1105](https://ledgerhq.atlassian.net/browse/QAA-1105)
- **Desktop E2E execution**: [run 25487910354](https://github.com/LedgerHQ/ledger-live/actions/runs/25487910354)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-1105]: https://ledgerhq.atlassian.net/browse/QAA-1105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ