### PR TITLE
feat(nx-plugin): infer feature-platform/feature-flow tags + enforce ADR boundaries

### DIFF
--- a/tools/nx-plugins/enforce-boundaries/constraints.js
+++ b/tools/nx-plugins/enforce-boundaries/constraints.js
@@ -25,6 +25,19 @@ const DEP_CONSTRAINTS = [
     sourceTag: "type:domain-api",
     onlyDependOnLibsWithTags: ["type:domain-entity", "type:domain-api", "scope:shared"],
   },
+  {
+    sourceTag: "type:feature-platform",
+    onlyDependOnLibsWithTags: ["type:feature-platform", "scope:domain", "scope:shared"],
+  },
+  {
+    sourceTag: "type:feature-flow",
+    onlyDependOnLibsWithTags: [
+      "type:feature-flow",
+      "type:feature-platform",
+      "scope:domain",
+      "scope:shared",
+    ],
+  },
 ];
 
 module.exports = { DEP_CONSTRAINTS };

--- a/tools/nx-plugins/enforce-boundaries/validate.test.js
+++ b/tools/nx-plugins/enforce-boundaries/validate.test.js
@@ -197,6 +197,86 @@ test("multi-tag source emits one deduped violation per edge", () => {
   assert.ok(v[0].sourceTags.includes("type:domain-api"));
 });
 
+test("feature-platform -> feature-platform is allowed", () => {
+  const graph = buildGraph(
+    [
+      { name: "a", tags: ["scope:features", "type:feature-platform"] },
+      { name: "b", tags: ["scope:features", "type:feature-platform"] },
+    ],
+    [{ source: "a", target: "b" }],
+  );
+  assert.deepEqual(findViolations(graph), []);
+});
+
+test("feature-platform -> feature-flow is forbidden (platform sits below flow)", () => {
+  const graph = buildGraph(
+    [
+      { name: "a", tags: ["scope:features", "type:feature-platform"] },
+      { name: "b", tags: ["scope:features", "type:feature-flow"] },
+    ],
+    [{ source: "a", target: "b" }],
+  );
+  const v = findViolations(graph);
+  assert.equal(v.length, 1);
+  assert.equal(v[0].sourceName, "a");
+  // scope:features rule is satisfied (target carries scope:features) — only
+  // type:feature-platform fails, so just that tag accrues to the violation.
+  assert.deepEqual(v[0].sourceTags, ["type:feature-platform"]);
+});
+
+test("feature-flow -> feature-platform is allowed", () => {
+  const graph = buildGraph(
+    [
+      { name: "a", tags: ["scope:features", "type:feature-flow"] },
+      { name: "b", tags: ["scope:features", "type:feature-platform"] },
+    ],
+    [{ source: "a", target: "b" }],
+  );
+  assert.deepEqual(findViolations(graph), []);
+});
+
+test("feature-flow -> feature-flow is allowed (sibling flows can compose)", () => {
+  const graph = buildGraph(
+    [
+      { name: "a", tags: ["scope:features", "type:feature-flow"] },
+      { name: "b", tags: ["scope:features", "type:feature-flow"] },
+    ],
+    [{ source: "a", target: "b" }],
+  );
+  assert.deepEqual(findViolations(graph), []);
+});
+
+test("feature-platform -> domain / shared is allowed", () => {
+  const graph = buildGraph(
+    [
+      { name: "a", tags: ["scope:features", "type:feature-platform"] },
+      { name: "b", tags: ["scope:domain", "type:domain-api"] },
+      { name: "c", tags: ["scope:shared"] },
+    ],
+    [
+      { source: "a", target: "b" },
+      { source: "a", target: "c" },
+    ],
+  );
+  assert.deepEqual(findViolations(graph), []);
+});
+
+test("feature-platform -> legacy libs is forbidden", () => {
+  const graph = buildGraph(
+    [
+      { name: "a", tags: ["scope:features", "type:feature-platform"] },
+      { name: "b", tags: ["scope:libs", "scope:libs-non-ui"] },
+    ],
+    [{ source: "a", target: "b" }],
+  );
+  const v = findViolations(graph);
+  assert.equal(v.length, 1);
+  // Both scope:features and type:feature-platform rules fire and both fail —
+  // findViolations dedupes per edge and accumulates both source tags.
+  assert.ok(v[0].sourceTags.includes("scope:features"));
+  assert.ok(v[0].sourceTags.includes("type:feature-platform"));
+});
+
 test("missing tags default to empty array (no crash)", () => {
   const graph = {
     nodes: {

--- a/tools/nx-plugins/project-tags/plugin.js
+++ b/tools/nx-plugins/project-tags/plugin.js
@@ -31,6 +31,11 @@ function inferTags(projectRoot, packageName) {
 
   if (projectRoot.startsWith("features/")) {
     tags.add("scope:features");
+    if (projectRoot.startsWith("features/platform/")) {
+      tags.add("type:feature-platform");
+    } else if (projectRoot.startsWith("features/flow/")) {
+      tags.add("type:feature-flow");
+    }
   }
 
   if (projectRoot.startsWith("domain/")) {

--- a/tools/nx-plugins/project-tags/plugin.test.js
+++ b/tools/nx-plugins/project-tags/plugin.test.js
@@ -36,10 +36,34 @@ test("shared/* gets scope:shared", () => {
   ]);
 });
 
-test("features/* gets scope:features (regression)", () => {
-  assert.deepEqual(inferTags("features/market-banner", "@features/market-banner"), [
+test("features/* (unclassified sub-path) gets scope:features only — no type tag (regression)", () => {
+  const tags = inferTags("features/market-banner", "@features/market-banner");
+  assert.deepEqual(tags, ["scope:features", "scope:no-apps"]);
+  assert.ok(!tags.includes("type:feature-platform"));
+  assert.ok(!tags.includes("type:feature-flow"));
+});
+
+test("features/platform/* gets scope:features + type:feature-platform", () => {
+  assert.deepEqual(
+    inferTags("features/platform/feature-flags", "@features/platform-feature-flags"),
+    ["scope:features", "scope:no-apps", "type:feature-platform"],
+  );
+  assert.deepEqual(
+    inferTags("features/platform/observability", "@features/platform-observability"),
+    ["scope:features", "scope:no-apps", "type:feature-platform"],
+  );
+});
+
+test("features/flow/* gets scope:features + type:feature-flow", () => {
+  assert.deepEqual(inferTags("features/flow/wallet", "@features/flow-wallet"), [
     "scope:features",
     "scope:no-apps",
+    "type:feature-flow",
+  ]);
+  assert.deepEqual(inferTags("features/flow/market-banner", "@features/flow-market-banner"), [
+    "scope:features",
+    "scope:no-apps",
+    "type:feature-flow",
   ]);
 });
 


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. <!-- N/A — pure build tooling under tools/nx-plugins/. Neither directory has a package.json and prior commits in the same files (e.g. ed40779f34 "feat(nx-plugin): infer boundary tags for new-arch packages") shipped without a changeset. -->
- [x] **Covered by automatic tests.** 8 new `node:test` cases (3 in `plugin.test.js`, 5 in `validate.test.js`) covering the new tag inference and the new boundary matrix. Existing 23 tests still pass.
- [x] **Impact of the changes:**
  - **Build/CI only** — no app or library runtime code touched. No published package version bumps.
  - QA focus: none required from product QA. Reviewers should confirm `pnpm nx run enforce-boundaries:lint:boundaries` is green on this branch (it is locally) and that no existing package picks up an unintended `type:feature-*` tag (regression test on `@features/market-banner` is included).

### 📝 Description

Implements the Nx plumbing required by the Iteration 5 ADR before any new package can land under `features/platform/` or before `features/*` packages move under `features/flow/`.

**1. `tools/nx-plugins/project-tags/plugin.js`** — extends the existing `features/` block to infer a sub-type tag:

| path | tags |
| --- | --- |
| `features/<unclassified>/*` | `scope:features` (unchanged) |
| `features/platform/*` | `scope:features`, `type:feature-platform` |
| `features/flow/*` | `scope:features`, `type:feature-flow` |

The umbrella `scope:features` tag is kept as the catch-all so unclassified packages remain governed by the existing `scope:features` rule.

**2. `tools/nx-plugins/enforce-boundaries/constraints.js`** — appends two ADR-matrix entries:

| source | may depend on |
| --- | --- |
| `type:feature-platform` | `type:feature-platform`, `scope:domain`, `scope:shared` |
| `type:feature-flow` | `type:feature-flow`, `type:feature-platform`, `scope:domain`, `scope:shared` |

i.e. flow may compose platform; platform must **not** reach upward into flow. Sibling flow→flow composition is allowed per the ADR.

The kept `scope:features` rule overlaps with both new type rules. `findViolations` (in `validate.js`) already de-dupes per-edge violations and accumulates source tags across matched rules — covered by the existing `multi-tag source emits one deduped violation per edge` test.

**Verification**

- `node --test tools/nx-plugins/...` — 31/31 pass
- `pnpm nx run enforce-boundaries:lint:boundaries` — `✓ module boundaries ok`
- `pnpm nx show project @features/market-banner --json | jq .tags` — `["scope:features", "scope:no-apps", "npm:private"]` (no spurious type tag, regression held)

### ❓ Context

- **JIRA**: [LIVE-30362](https://ledgerhq.atlassian.net/browse/LIVE-30362)
- **ADR**: [Guideline — Data Layer: Data Layer Structure & Flow (Iteration 4)](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/6111232117/Guideline+Data+Layer+Data+Layer+Structure+Flow)
- **Unblocks**:
  - [LIVE-30360](https://ledgerhq.atlassian.net/browse/LIVE-30360) — `@features/platform-feature-flags` package will pick up `type:feature-platform` automatically on next graph refresh
  - [LIVE-30363](https://ledgerhq.atlassian.net/browse/LIVE-30363) — moving `features/market-banner/` into `features/flow/` will pick up `type:feature-flow` automatically

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in LIVE-30362 (verbatim implementation of the snippets in the ticket).
- **The PR description clearly documents the changes** and references the ADR matrix.
- **There are no undocumented trade-offs** — the kept `scope:features` umbrella rule is intentional (safety net for unclassified packages, doesn't fight the new type rules thanks to per-edge de-duping).
- **The PR has been tested** — 8 new unit tests + live boundary check + tag-inspection regression on the only existing `features/*` package.
- **Any new dependencies** — none.
- **Performance** — N/A, build tooling only.

[LIVE-30362]: https://ledgerhq.atlassian.net/browse/LIVE-30362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ