### PR TITLE
test(e2e): retry provider list check on quote count mismatch

### DIFF
--- a/e2e/mobile/helpers/elementHelpers.ts
+++ b/e2e/mobile/helpers/elementHelpers.ts
@@ -352,23 +352,20 @@ export const WebElementHelpers = {
     return index > 0 ? base.atIndex(index) : base;
   },
 
-  async getWebElementsText(selector: string): Promise<string[]> {
-    const texts: string[] = [];
-    let i = 0;
-
-    while (true) {
-      try {
-        const el = WebElementHelpers.getWebElementByCssSelector(selector, i);
-        const text: string = await el.runScript((node: HTMLElement) =>
-          (node.innerText || node.textContent || "").trim(),
-        );
-        texts.push(text);
-        i++;
-      } catch {
-        break;
-      }
-    }
-
+  async getWebElementsText(
+    containerWebElement: WebElement,
+    childrenCssSelector: string,
+  ): Promise<string[]> {
+    const raw = await containerWebElement.runScript(
+      (el: HTMLElement, sel: string) =>
+        JSON.stringify(
+          Array.from(el.querySelectorAll<HTMLElement>(sel)).map(node =>
+            (node.innerText || node.textContent || "").trim(),
+          ),
+        ),
+      [childrenCssSelector],
+    );
+    const texts: string[] = JSON.parse(raw);
     return texts.filter(Boolean);
   },
 

--- a/e2e/mobile/page/liveApps/swapLiveApp.ts
+++ b/e2e/mobile/page/liveApps/swapLiveApp.ts
@@ -16,7 +16,7 @@ export default class SwapLiveAppPage {
   quotesButtonDisabled = "mobile-get-quotes-button-disabled";
   numberOfQuotes = "number-of-quotes";
   quotesCountDown = "quotes-countdown";
-  quoteCardProviderName = "compact-quote-card-provider-";
+  quoteCardProviderNameSelector = "[data-testid^='compact-quote-card-provider-']";
   executeSwapButton = "execute-button";
   executeSwapButtonStepApproval = "execute-swap-button-step-approval";
   deviceActionErrorDescriptionId = "error-description-deviceAction";
@@ -24,6 +24,8 @@ export default class SwapLiveAppPage {
   showDetailslink = "show-details-link";
   quotesContainerErrorIcon = "quotes-container-error-icon";
   insufficientFundsBuyButton = "insufficient-funds-buy-button";
+  swapMainContainerCssSelector = "main";
+  swapMainContainerWebElement = getWebElementByCssSelector(this.swapMainContainerCssSelector);
   swapMaxToggle = "from-account-max-toggle";
   switchButton = "to-account-switch-accounts";
   specificQuoteCardProviderName = (provider: string) =>
@@ -158,10 +160,22 @@ export default class SwapLiveAppPage {
   async getProviderList() {
     await detoxExpect(getWebElementByTestId(this.numberOfQuotes)).toExist();
     await detoxExpect(getWebElementByTestId(this.quotesCountDown)).toExist();
-    const numberOfQuotesText: string = await getWebElementText(this.numberOfQuotes);
-    const providerList = await getWebElementsText(`[data-testid^='${this.quoteCardProviderName}']`);
-    jestExpect(numberOfQuotesText).toMatch(new RegExp(`${providerList.length} quotes? found`));
-    return providerList;
+
+    return await retryUntilTimeout(async () => {
+      const numberOfQuotesText = await getWebElementText(this.numberOfQuotes);
+      const providerList = await getWebElementsText(
+        this.swapMainContainerWebElement,
+        this.quoteCardProviderNameSelector,
+      );
+
+      if (!numberOfQuotesText.match(new RegExp(`^${providerList.length} quotes? found$`))) {
+        throw new Error(
+          `Quote count mismatch: UI shows "${numberOfQuotesText}" but found ${providerList.length} cards`,
+        );
+      }
+
+      return providerList;
+    }, 30000);
   }
 
   @Step("Check error message: $0")
@@ -235,6 +249,7 @@ export default class SwapLiveAppPage {
   @Step("Get all swap providers available")
   async getAllSwapProviders() {
     return await getWebElementsText(
+      this.swapMainContainerWebElement,
       '[data-testid^="quote-container-"][data-testid$="-fixed"], [data-testid^="quote-container-"][data-testid$="-float"]',
     );
   }

--- a/e2e/mobile/page/trade/buySell.page.ts
+++ b/e2e/mobile/page/trade/buySell.page.ts
@@ -6,6 +6,7 @@ import { openDeeplink, normalizeText, isIos } from "../../helpers/commonHelpers"
 import { sanitizeError } from "@ledgerhq/live-common/e2e/index";
 
 export default class BuySellPage {
+  appContainerCssSelector = "#app-container";
   amountInputSectionBaseId = "amount-input-section";
   countryDrawerSearchInput = "countries-drawer-search-input";
   cryptoAccountSelector = "account-details";
@@ -20,6 +21,7 @@ export default class BuySellPage {
   paymentSelector = "payment_selector";
   providersList = "providers_list";
   saveRegionFiatOptionsSelector = "save-region-and-fiat-options";
+  providerTitleCssSelector = "[data-testid^='provider_title_'][data-testid$='_title_container']";
 
   currencyRow = (currencyId: string) => `currency-row-${currencyId}`;
   buyQuickAmountButtonId = (amount: "400" | "800" | "1600") => `buy-amount-button-${amount}`;
@@ -157,7 +159,8 @@ export default class BuySellPage {
       await tapWebElementByTestId(this.expandButtonId);
     }
     const providerNames = await getWebElementsText(
-      '[data-testid^="provider_title_"][data-testid$="_title_container"]',
+      getWebElementByCssSelector(this.appContainerCssSelector),
+      this.providerTitleCssSelector,
     );
     return providerNames;
   }

--- a/e2e/mobile/page/trade/earnDasboard.page.ts
+++ b/e2e/mobile/page/trade/earnDasboard.page.ts
@@ -7,6 +7,8 @@ export default class EarnDashboardPage {
   amountAvailableAssetsText = "Amount available to earn";
   amountAvailableToEarnBalanceCard = "Amount available to earn-balance-card";
   assetsTitleId = "assets-title-text";
+  earnMainContainerCssSelector = "body#root";
+  earnMainContainerWebElement = getWebElementByCssSelector(this.earnMainContainerCssSelector);
   getAssetsPlaceholderHero = "get-assets-placeholder-hero";
   rewardsPotentialBalanceCard = "Rewards you could earn-balance-card";
   rewardsPotentialText = "Rewards you could earn";
@@ -118,7 +120,10 @@ export default class EarnDashboardPage {
     });
     await detoxExpect(assetTitleElement).toExist();
     await detoxExpect(assetTitleElement).toHaveText(this.assetsTitleText(false));
-    const rowsContent = await getWebElementsText(this.tableEarnMoreSelector);
+    const rowsContent = await getWebElementsText(
+      this.earnMainContainerWebElement,
+      this.tableEarnMoreSelector,
+    );
     const normalizedText = normalizeText(rowsContent.join(" "));
     jestExpect(normalizedText).toContain(`${account.accountName} ${account.currency.ticker}`);
     const earnButton = getWebElementByCssSelector(this.earnButtonSelector(account.currency.ticker));
@@ -134,7 +139,10 @@ export default class EarnDashboardPage {
     await detoxExpect(assetTitleElement).toExist();
     await detoxExpect(assetTitleElement).toHaveText(this.assetsTitleText(true));
 
-    const rowsContent = await getWebElementsText(this.tableRewardsEarnedSelector);
+    const rowsContent = await getWebElementsText(
+      this.earnMainContainerWebElement,
+      this.tableRewardsEarnedSelector,
+    );
     jestExpect(normalizeText(rowsContent.join(" "))).toContain(
       `${account.accountName} ${account.currency.ticker}`,
     );


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- Replace `getWebElementsText`'s `while (true) atIndex(i)` probe with a single `runScript` + `JSON.stringify` call against a container WebElement. The old loop could spin when Detox's per-index retry didn't throw promptly.
- Update callers (`swapLiveApp`, `buySell`, `earnDashboard`) to pass a container WebElement instead of a global CSS selector.
<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [QAA-1201](https://ledgerhq.atlassian.net/browse/QAA-1201)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->
[@Mobile E2E • Manual • iOS & Android • support/fix-swap-provider-list-flakiness • cunhabruno](https://github.com/LedgerHQ/ledger-live/actions/runs/25554432794)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-1201]: https://ledgerhq.atlassian.net/browse/QAA-1201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ