### PR TITLE
docs(agents): add ongoing rework rule for async bridge migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,3 +14,10 @@
 
 - Before finishing any agentic code change, run static checks for the affected scope
 - See [/docs/dev/validate-before-finishing.md](/docs/dev/validate-before-finishing.md)
+
+## Ongoing Rework
+
+- `getAccountBridge` and `getCurrencyBridge` must not be called synchronously (becoming async, PR #17155).
+  - React: use `useAccountBridge` / `useCurrencyBridge` hooks
+  - RxJS: `from(Promise.resolve(getAccountBridge(...))).pipe(mergeMap(bridge => ...))`
+  - async: `const bridge = await getAccountBridge(...)`


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** N/A — docs only
- [x] **Impact of the changes:**
  - Agents and contributors are now guided to avoid synchronous calls to `getAccountBridge` / `getCurrencyBridge`

### 📝 Description

Adds an "Ongoing Rework" section to `AGENTS.md` to document that `getAccountBridge` and `getCurrencyBridge` are being migrated to async (tracked in PR #17155). Agents and contributors must use the appropriate pattern depending on context:

- React: `useAccountBridge` / `useCurrencyBridge` hooks
- RxJS: `from(Promise.resolve(getAccountBridge(...))).pipe(mergeMap(bridge => ...))`
- async: `const bridge = await getAccountBridge(...)`

### ❓ Context

- **JIRA or GitHub link**: #17155
- **ADR link (if any)**: N/A