### PR TITLE
[LWM] fix(mobile): update evm DelegationFlow imports after alpaca renaming

### DIFF
--- a/apps/ledger-live-mobile/src/families/evm/DelegationFlow/01-SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/DelegationFlow/01-SelectValidator.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
-import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-alpaca/types";
+import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-coin-framework/types";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { useEvmStakingValidators } from "@ledgerhq/live-common/families/evm/staking/react";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";

--- a/apps/ledger-live-mobile/src/families/evm/DelegationFlow/02-SelectAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/DelegationFlow/02-SelectAmount.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
-import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-alpaca/types";
+import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-coin-framework/types";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";

--- a/apps/ledger-live-mobile/src/families/evm/DelegationFlow/03-ValidationSuccess.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/DelegationFlow/03-ValidationSuccess.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
-import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-alpaca/types";
+import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-coin-framework/types";
 import React, { useCallback, useEffect } from "react";
 import { StyleSheet, View } from "react-native";
 import { useTheme } from "@react-navigation/native";


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.**
- [ ] **Impact of the changes:**
  - Fixes mobile typecheck CI failure introduced by #16952

### 📝 Description

Three files in `apps/ledger-live-mobile/src/families/evm/DelegationFlow/` were missed in the `generic-alpaca` → `generic-coin-framework` renaming from #16952, causing 3 TS2307 typecheck errors.

### ❓ Context

- **JIRA or GitHub link**: follow-up to #16952
- **ADR link (if any)**: N/A