### PR TITLE
[LWDM] feat(LIVE-30355): add enableTokens config gate for token subaccounts

### DIFF
--- a/.changeset/shy-bears-sell.md
+++ b/.changeset/shy-bears-sell.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-aleo": minor
+"@ledgerhq/live-common": minor
+---
+
+Add an Aleo `enableTokens` config flag.

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/__mocks__/config.mock.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/__mocks__/config.mock.ts
@@ -14,5 +14,6 @@ export const mockAleoCoinConfig: AleoCoinConfig = {
   feeSafetyMultiplier: 1,
   isFeeSponsored: true,
   useEncryptedProve: false,
+  enableTokens: false,
   recordPickingStrategy: "manual",
 };

--- a/libs/coin-modules/coin-aleo/src/__tests__/fixtures/config.fixture.ts
+++ b/libs/coin-modules/coin-aleo/src/__tests__/fixtures/config.fixture.ts
@@ -16,6 +16,7 @@ export const getMockedConfig = (networkType: "mainnet" | "testnet"): AleoCoinCon
     },
     feeSafetyMultiplier: 1,
     isFeeSponsored: true,
+    enableTokens: false,
     useEncryptedProve: false,
     recordPickingStrategy: "manual",
     status: { type: "active" },

--- a/libs/coin-modules/coin-aleo/src/bridge/broadcast.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/broadcast.integ.test.ts
@@ -21,6 +21,7 @@ describe("Broadcast", () => {
       },
       feeSafetyMultiplier: 1.0,
       isFeeSponsored: false,
+      enableTokens: false,
       useEncryptedProve: true,
       recordPickingStrategy: "manual",
     }));

--- a/libs/coin-modules/coin-aleo/src/logic/craftTransaction.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/craftTransaction.integ.test.ts
@@ -44,6 +44,7 @@ describe("craftTransaction", () => {
       },
       feeSafetyMultiplier: 1,
       isFeeSponsored: true,
+      enableTokens: false,
       useEncryptedProve: false,
       recordPickingStrategy: "manual",
     }));

--- a/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.integ.test.ts
@@ -28,6 +28,7 @@ describe("getPrivateBalance", () => {
       },
       feeSafetyMultiplier: 1,
       isFeeSponsored: true,
+      enableTokens: false,
       useEncryptedProve: false,
       recordPickingStrategy: "manual",
     }));

--- a/libs/coin-modules/coin-aleo/src/types/config.ts
+++ b/libs/coin-modules/coin-aleo/src/types/config.ts
@@ -10,6 +10,7 @@ export type AleoConfig = {
   feeByTransactionType: Record<TransactionType, number>;
   feeSafetyMultiplier: number;
   isFeeSponsored: boolean;
+  enableTokens: boolean;
   useEncryptedProve: boolean;
   recordPickingStrategy: RecordPickingStrategy;
 };

--- a/libs/ledger-live-common/src/families/aleo/config.ts
+++ b/libs/ledger-live-common/src/families/aleo/config.ts
@@ -36,6 +36,11 @@ const USE_ENCRYPTED_PROVE = true;
  */
 const RECORD_PICKING_STRATEGY: RecordPickingStrategy = "manual";
 
+/**
+ * Controls whether Aleo token-related features are enabled.
+ */
+const ENABLE_TOKENS = false;
+
 export const aleoConfig: Record<string, ConfigInfo> = {
   config_currency_aleo: {
     type: "object",
@@ -51,6 +56,7 @@ export const aleoConfig: Record<string, ConfigInfo> = {
       feeByTransactionType: DEFAULT_FEE_BY_TRANSACTION_TYPE,
       feeSafetyMultiplier: DEFAULT_FEE_SAFETY_MULTIPLIER,
       isFeeSponsored: IS_FEE_SPONSORED,
+      enableTokens: ENABLE_TOKENS,
       useEncryptedProve: USE_ENCRYPTED_PROVE,
       recordPickingStrategy: RECORD_PICKING_STRATEGY,
     },
@@ -69,6 +75,7 @@ export const aleoConfig: Record<string, ConfigInfo> = {
       feeByTransactionType: DEFAULT_FEE_BY_TRANSACTION_TYPE,
       feeSafetyMultiplier: DEFAULT_FEE_SAFETY_MULTIPLIER,
       isFeeSponsored: IS_FEE_SPONSORED,
+      enableTokens: ENABLE_TOKENS,
       useEncryptedProve: USE_ENCRYPTED_PROVE,
       recordPickingStrategy: RECORD_PICKING_STRATEGY,
     },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Add enableTokens config gate for token subaccounts.

### 📝 Description

This PR adds enableTokens config gate for token subaccounts.

### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-30355

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
