### PR TITLE
[LWDM] fix(device-core): prevent malformed manager api requests

### DIFF
--- a/.changeset/quiet-badgers-guard.md
+++ b/.changeset/quiet-badgers-guard.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-core": minor
+---
+
+Prevent malformed Manager API requests when device metadata is missing

--- a/libs/device-core/src/managerApi/repositories/HttpManagerApiRepository.test.ts
+++ b/libs/device-core/src/managerApi/repositories/HttpManagerApiRepository.test.ts
@@ -32,6 +32,20 @@ const createAxiosResponse = <T>(data: T): Awaited<ReturnType<typeof network>> =>
     config: {},
   }) as Awaited<ReturnType<typeof network>>;
 
+const createDeviceInfo = (overrides: Partial<DeviceInfoEntity> = {}): DeviceInfoEntity => ({
+  mcuVersion: "mockedMcuVersion",
+  version: "mockedVersion",
+  majMin: "1.2",
+  targetId: 123,
+  isBootloader: false,
+  isOSU: false,
+  providerName: null,
+  managerAllowed: true,
+  pinValidated: true,
+  seFlags: Buffer.alloc(0),
+  ...overrides,
+});
+
 describe("HttpManagerApiRepository", () => {
   let httpManagerApiRepository: HttpManagerApiRepository;
 
@@ -196,6 +210,17 @@ describe("HttpManagerApiRepository", () => {
     expect(result).toBe("mockedData");
   });
 
+  test("getDeviceVersion should reject before calling network if targetId is missing", async () => {
+    await expect(
+      httpManagerApiRepository.getDeviceVersion({
+        targetId: "",
+        providerId: 12,
+      }),
+    ).rejects.toThrow("targetId is required");
+
+    expect(mockedNetwork).not.toHaveBeenCalled();
+  });
+
   test("getCurrentOSU should call network() with the correct parameters", async () => {
     const params: Parameters<typeof httpManagerApiRepository.getCurrentOSU>[0] = {
       deviceId: 123,
@@ -228,6 +253,18 @@ describe("HttpManagerApiRepository", () => {
     });
 
     expect(result).toBe("mockedData");
+  });
+
+  test("getCurrentOSU should reject before calling network if version is missing", async () => {
+    await expect(
+      httpManagerApiRepository.getCurrentOSU({
+        deviceId: 123,
+        providerId: 12,
+        version: "",
+      }),
+    ).rejects.toThrow("version is required");
+
+    expect(mockedNetwork).not.toHaveBeenCalled();
   });
 
   test("getCurrentFirmware should call network() with the correct parameters", async () => {
@@ -292,6 +329,18 @@ describe("HttpManagerApiRepository", () => {
     });
 
     expect(result).toBe("mockedData");
+  });
+
+  test("getCurrentFirmware should reject before calling network if version is missing", async () => {
+    await expect(
+      httpManagerApiRepository.getCurrentFirmware({
+        deviceId: 123,
+        providerId: 12,
+        version: "",
+      }),
+    ).rejects.toThrow("version is required");
+
+    expect(mockedNetwork).not.toHaveBeenCalled();
   });
 
   test("getFinalFirmwareById should call network() with the correct parameters", async () => {
@@ -403,6 +452,18 @@ describe("HttpManagerApiRepository", () => {
     expect(result).toEqual(["mockedData"]);
   });
 
+  test("catalogForDevice should reject before calling network if targetId is missing", async () => {
+    await expect(
+      httpManagerApiRepository.catalogForDevice({
+        targetId: "",
+        provider: 12,
+        firmwareVersion: "mockedFirmwareVersion",
+      }),
+    ).rejects.toThrow("targetId is required");
+
+    expect(mockedNetwork).not.toHaveBeenCalled();
+  });
+
   test("getLanguagePackagesForDevice should call network() and other methods with the correct parameters", async () => {
     const getDeviceVersionSpy = jest
       .spyOn(httpManagerApiRepository, "getDeviceVersion")
@@ -413,11 +474,10 @@ describe("HttpManagerApiRepository", () => {
 
     await httpManagerApiRepository
       .getLanguagePackagesForDevice(
-        {
-          version: 1,
+        createDeviceInfo({
+          version: "1",
           targetId: 2,
-          id: 3,
-        } as unknown as DeviceInfoEntity,
+        }),
         12,
       )
       .catch(() => {
@@ -425,12 +485,32 @@ describe("HttpManagerApiRepository", () => {
       });
 
     expect(getDeviceVersionSpy).toHaveBeenCalledWith({ targetId: 2, providerId: 12 });
-    expect(getCurrentFirmwareSpy).toHaveBeenCalledWith({ deviceId: 4, providerId: 12, version: 1 });
+    expect(getCurrentFirmwareSpy).toHaveBeenCalledWith({
+      deviceId: 4,
+      providerId: 12,
+      version: "1",
+    });
 
     expect(mockedNetwork).toHaveBeenCalledWith({
       method: "GET",
       url: "http://managerApiBase.com/language-package?livecommonversion=1.2.3",
     });
+  });
+
+  test("getLanguagePackagesForDevice should reject before calling network if device targetId is missing", async () => {
+    await expect(
+      httpManagerApiRepository.getLanguagePackagesForDevice(createDeviceInfo({ targetId: "" })),
+    ).rejects.toThrow("targetId is required");
+
+    expect(mockedNetwork).not.toHaveBeenCalled();
+  });
+
+  test("getLanguagePackagesForDevice should reject before calling network if device version is missing", async () => {
+    await expect(
+      httpManagerApiRepository.getLanguagePackagesForDevice(createDeviceInfo({ version: "" })),
+    ).rejects.toThrow("version is required");
+
+    expect(mockedNetwork).not.toHaveBeenCalled();
   });
 
   test("getLanguagePackagesForDevice should return language packages", async () => {
@@ -480,7 +560,10 @@ describe("HttpManagerApiRepository", () => {
     );
 
     const result = await httpManagerApiRepository.getLanguagePackagesForDevice(
-      {} as unknown as DeviceInfoEntity,
+      createDeviceInfo({
+        targetId: 123,
+        version: "mockedVersion",
+      }),
     );
 
     expect(result).toEqual([

--- a/libs/device-core/src/managerApi/repositories/HttpManagerApiRepository.test.ts
+++ b/libs/device-core/src/managerApi/repositories/HttpManagerApiRepository.test.ts
@@ -216,7 +216,7 @@ describe("HttpManagerApiRepository", () => {
         targetId: "",
         providerId: 12,
       }),
-    ).rejects.toThrow("targetId is required");
+    ).rejects.toThrow(TypeError);
 
     expect(mockedNetwork).not.toHaveBeenCalled();
   });
@@ -262,7 +262,7 @@ describe("HttpManagerApiRepository", () => {
         providerId: 12,
         version: "",
       }),
-    ).rejects.toThrow("version is required");
+    ).rejects.toThrow(TypeError);
 
     expect(mockedNetwork).not.toHaveBeenCalled();
   });
@@ -338,7 +338,7 @@ describe("HttpManagerApiRepository", () => {
         providerId: 12,
         version: "",
       }),
-    ).rejects.toThrow("version is required");
+    ).rejects.toThrow(TypeError);
 
     expect(mockedNetwork).not.toHaveBeenCalled();
   });
@@ -459,7 +459,19 @@ describe("HttpManagerApiRepository", () => {
         provider: 12,
         firmwareVersion: "mockedFirmwareVersion",
       }),
-    ).rejects.toThrow("targetId is required");
+    ).rejects.toThrow(TypeError);
+
+    expect(mockedNetwork).not.toHaveBeenCalled();
+  });
+
+  test("catalogForDevice should reject before calling network if firmwareVersion is missing", async () => {
+    await expect(
+      httpManagerApiRepository.catalogForDevice({
+        targetId: 123,
+        provider: 12,
+        firmwareVersion: "",
+      }),
+    ).rejects.toThrow(TypeError);
 
     expect(mockedNetwork).not.toHaveBeenCalled();
   });
@@ -500,7 +512,7 @@ describe("HttpManagerApiRepository", () => {
   test("getLanguagePackagesForDevice should reject before calling network if device targetId is missing", async () => {
     await expect(
       httpManagerApiRepository.getLanguagePackagesForDevice(createDeviceInfo({ targetId: "" })),
-    ).rejects.toThrow("targetId is required");
+    ).rejects.toThrow(TypeError);
 
     expect(mockedNetwork).not.toHaveBeenCalled();
   });
@@ -508,7 +520,7 @@ describe("HttpManagerApiRepository", () => {
   test("getLanguagePackagesForDevice should reject before calling network if device version is missing", async () => {
     await expect(
       httpManagerApiRepository.getLanguagePackagesForDevice(createDeviceInfo({ version: "" })),
-    ).rejects.toThrow("version is required");
+    ).rejects.toThrow(TypeError);
 
     expect(mockedNetwork).not.toHaveBeenCalled();
   });

--- a/libs/device-core/src/managerApi/repositories/HttpManagerApiRepository.ts
+++ b/libs/device-core/src/managerApi/repositories/HttpManagerApiRepository.ts
@@ -83,6 +83,8 @@ export class HttpManagerApiRepository implements ManagerApiRepository {
 
   readonly getDeviceVersion: ManagerApiRepository["getDeviceVersion"] = makeLRUCache(
     async ({ targetId, providerId }) => {
+      if (!targetId) throw new Error("targetId is required");
+
       const {
         data,
       }: {
@@ -114,6 +116,8 @@ export class HttpManagerApiRepository implements ManagerApiRepository {
 
   readonly getCurrentOSU: ManagerApiRepository["getCurrentOSU"] = makeLRUCache(
     async input => {
+      if (!input.version) throw new Error("version is required");
+
       const { data } = await network({
         method: "GET",
         url: URL.format({
@@ -133,6 +137,8 @@ export class HttpManagerApiRepository implements ManagerApiRepository {
 
   readonly getCurrentFirmware: ManagerApiRepository["getCurrentFirmware"] = makeLRUCache(
     async input => {
+      if (!input.version) throw new Error("version is required");
+
       const {
         data,
       }: {
@@ -209,6 +215,9 @@ export class HttpManagerApiRepository implements ManagerApiRepository {
   readonly catalogForDevice: ManagerApiRepository["catalogForDevice"] = makeLRUCache(
     async params => {
       const { provider, targetId, firmwareVersion } = params;
+      if (!targetId) throw new Error("targetId is required");
+      if (!firmwareVersion) throw new Error("firmwareVersion is required");
+
       const {
         data,
       }: {
@@ -239,15 +248,20 @@ export class HttpManagerApiRepository implements ManagerApiRepository {
     deviceInfo: DeviceInfoEntity,
     forceProvider?: number,
   ) => {
+    if (!deviceInfo.targetId) throw new Error("targetId is required");
+    if (!deviceInfo.version) throw new Error("version is required");
+
+    const providerId = getProviderIdUseCase({ deviceInfo, forceProvider });
+
     const deviceVersion = await this.getDeviceVersion({
       targetId: deviceInfo.targetId,
-      providerId: getProviderIdUseCase({ deviceInfo, forceProvider }),
+      providerId,
     });
 
     const seFirmwareVersion = await this.getCurrentFirmware({
       version: deviceInfo.version,
       deviceId: deviceVersion.id,
-      providerId: getProviderIdUseCase({ deviceInfo, forceProvider }),
+      providerId,
     });
 
     const { data }: { data: LanguagePackageResponseEntity[] } = await network({
@@ -260,7 +274,7 @@ export class HttpManagerApiRepository implements ManagerApiRepository {
       }),
     });
 
-    const allPackages: LanguagePackageEntity[] = data.reduce(
+    const allPackages = data.reduce<LanguagePackageEntity[]>(
       (acc, response) => [
         ...acc,
         ...response.language_package_version.map(p => ({
@@ -268,7 +282,7 @@ export class HttpManagerApiRepository implements ManagerApiRepository {
           language: response.language,
         })),
       ],
-      [] as LanguagePackageEntity[],
+      [],
     );
 
     const packages = allPackages.filter(

--- a/libs/device-core/src/managerApi/repositories/HttpManagerApiRepository.ts
+++ b/libs/device-core/src/managerApi/repositories/HttpManagerApiRepository.ts
@@ -83,7 +83,7 @@ export class HttpManagerApiRepository implements ManagerApiRepository {
 
   readonly getDeviceVersion: ManagerApiRepository["getDeviceVersion"] = makeLRUCache(
     async ({ targetId, providerId }) => {
-      if (!targetId) throw new Error("targetId is required");
+      if (!targetId) throw new TypeError("targetId is required");
 
       const {
         data,
@@ -116,7 +116,7 @@ export class HttpManagerApiRepository implements ManagerApiRepository {
 
   readonly getCurrentOSU: ManagerApiRepository["getCurrentOSU"] = makeLRUCache(
     async input => {
-      if (!input.version) throw new Error("version is required");
+      if (!input.version) throw new TypeError("version is required");
 
       const { data } = await network({
         method: "GET",
@@ -137,7 +137,7 @@ export class HttpManagerApiRepository implements ManagerApiRepository {
 
   readonly getCurrentFirmware: ManagerApiRepository["getCurrentFirmware"] = makeLRUCache(
     async input => {
-      if (!input.version) throw new Error("version is required");
+      if (!input.version) throw new TypeError("version is required");
 
       const {
         data,
@@ -215,8 +215,8 @@ export class HttpManagerApiRepository implements ManagerApiRepository {
   readonly catalogForDevice: ManagerApiRepository["catalogForDevice"] = makeLRUCache(
     async params => {
       const { provider, targetId, firmwareVersion } = params;
-      if (!targetId) throw new Error("targetId is required");
-      if (!firmwareVersion) throw new Error("firmwareVersion is required");
+      if (!targetId) throw new TypeError("targetId is required");
+      if (!firmwareVersion) throw new TypeError("firmwareVersion is required");
 
       const {
         data,
@@ -248,8 +248,8 @@ export class HttpManagerApiRepository implements ManagerApiRepository {
     deviceInfo: DeviceInfoEntity,
     forceProvider?: number,
   ) => {
-    if (!deviceInfo.targetId) throw new Error("targetId is required");
-    if (!deviceInfo.version) throw new Error("version is required");
+    if (!deviceInfo.targetId) throw new TypeError("targetId is required");
+    if (!deviceInfo.version) throw new TypeError("version is required");
 
     const providerId = getProviderIdUseCase({ deviceInfo, forceProvider });
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Manager API firmware and app catalog requests built from persisted device metadata
  - Language package lookup for devices with incomplete `deviceInfo`
  - Regression coverage ensuring malformed inputs do not call AppStore endpoints

### 📝 Description

Some persisted device metadata can be incomplete, especially when `lastSeenDevice.deviceInfo` is empty or missing fields. Firmware, app catalog, and language package checks could then build Manager API requests with malformed query parameters such as an empty `target_id` or `version_name`, causing AppStore 400 responses.

This PR adds simple repository-level guards before the affected Manager API calls so missing `targetId`, `version`, or `firmwareVersion` fails locally instead of sending malformed requests.

```ts
if (!targetId) throw new Error("targetId is required");
if (!input.version) throw new Error("version is required");
```

Before: incomplete device metadata could produce malformed AppStore requests.

After: incomplete device metadata is rejected before `network()` is called, with Jest regressions covering the affected paths.

### ❓ Context

- **JIRA or GitHub link**: [#17192](https://github.com/LedgerHQ/ledger-live/pull/17192)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)