### PR TITLE
fix(wallet-cli): register top-level commands explicitly to fix bunli generate subcommand aliases

### DIFF
--- a/apps/wallet-cli/src/cli.ts
+++ b/apps/wallet-cli/src/cli.ts
@@ -11,6 +11,13 @@ import "../.bunli/commands.gen";
 import bunliConfig from "../bunli.config";
 import { CliProcessExitError } from "./cli-process-exit-error";
 import { disposeWalletCliDmkTransportFully } from "./device/register-dmk-transport";
+import AccountGroup from "./commands/account/index";
+import SessionGroup from "./commands/session/index";
+import BalancesCommand from "./commands/balances";
+import OperationsCommand from "./commands/operations";
+import ReceiveCommand from "./commands/receive";
+import SendCommand from "./commands/send";
+import SwapGroup from "./commands/swap/index";
 
 emitTestingBuildBannerIfNeeded();
 
@@ -23,6 +30,13 @@ emitTestingBuildBannerIfNeeded();
  */
 export async function runMain(argv: string[] = process.argv.slice(2)): Promise<number> {
   const cli = await createCLI(bunliConfig as unknown as Parameters<typeof createCLI>[0]);
+  cli.command(AccountGroup);
+  cli.command(SessionGroup);
+  cli.command(BalancesCommand);
+  cli.command(OperationsCommand);
+  cli.command(ReceiveCommand);
+  cli.command(SendCommand);
+  cli.command(SwapGroup);
   const code = await cli.run(argv, { noExit: true });
   return code ?? 0;
 }

--- a/apps/wallet-cli/src/test/commands/quote.test.ts
+++ b/apps/wallet-cli/src/test/commands/quote.test.ts
@@ -55,6 +55,7 @@ describe("quote command", () => {
   it("human output: prints quote summary", async () => {
     const { stdout, exitCode, stderr } = await runCli(
       [
+        "swap",
         "quote",
         "--from",
         "ethereum",
@@ -79,6 +80,7 @@ describe("quote command", () => {
   it("json output: returns a valid swap quote envelope", async () => {
     const { stdout, exitCode, stderr } = await runCli(
       [
+        "swap",
         "quote",
         "--from",
         "ethereum",

--- a/apps/wallet-cli/src/test/integration/swap-execute.test.ts
+++ b/apps/wallet-cli/src/test/integration/swap-execute.test.ts
@@ -37,6 +37,7 @@ mock.module(pipelineUrl, () => ({
 }));
 
 const baseExecuteArgs = [
+  "swap",
   "execute",
   "--provider",
   "changelly",
@@ -58,6 +59,7 @@ describe("swap execute command", () => {
   it("json: exits 1 when --to-account is missing", async () => {
     const { exitCode, stderr } = await runCli(
       [
+        "swap",
         "execute",
         "--provider",
         "changelly",


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:** wallet-cli

### 📝 Description

`bunli generate` fallback directory scan was registering subcommand files as top-level aliases. Fix: explicit `cli.command()` registration in `cli.ts` bypasses the fallback.

```diff
 Commands:
   account     Account management commands
   balances    ...
-  discover    (alias: account discover)
-  execute     (alias: swap execute)
   operations  ...
-  quote       (alias: swap quote)
   receive     ...
-  reset       (alias: session reset)
   send        ...
   session     Session management commands
   swap        Swap-related commands
-  view        (alias: session view)
```

**Breaking:** `wallet-cli quote` / `wallet-cli execute` → `wallet-cli swap quote` / `wallet-cli swap execute`

### ❓ Context

- **JIRA or GitHub link**: wallet-cli security audit finding #13