### PR TITLE
[LWD] feat(desktop): align analytics balance and percentage with portfolio v4

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/__tests__/useAnalyticsViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/__tests__/useAnalyticsViewModel.test.ts
@@ -2,6 +2,8 @@ import { act, renderHook, withFlagOverrides } from "tests/testSetup";
 import { useNavigate } from "react-router";
 import { getFiatCurrencyByTicker } from "@ledgerhq/live-common/currencies/index";
 import { INITIAL_STATE } from "~/renderer/reducers/settings";
+import * as usePortfolioBalanceModule from "LLD/hooks/usePortfolioBalance";
+import { makePortfolioBalanceReturn } from "LLD/hooks/__tests__/fixtures";
 import useAnalyticsViewModel from "../useAnalyticsViewModel";
 
 jest.mock("react-router", () => ({
@@ -9,11 +11,15 @@ jest.mock("react-router", () => ({
   useNavigate: jest.fn(),
 }));
 
+jest.mock("LLD/hooks/usePortfolioBalance");
+
 const mockedUseNavigate = jest.mocked(useNavigate);
+const mockUsePortfolioBalance = jest.mocked(usePortfolioBalanceModule.usePortfolioBalance);
 
 describe("useAnalyticsViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUsePortfolioBalance.mockReturnValue(makePortfolioBalanceReturn());
   });
 
   it("should return expected values and navigate back to dashboard", () => {
@@ -34,11 +40,28 @@ describe("useAnalyticsViewModel", () => {
     expect(result.current.counterValue).toBe(getFiatCurrencyByTicker("USD"));
     expect(result.current.selectedTimeRange).toBe("day");
     expect(result.current.shouldDisplayGraphRework).toBe(true);
+    expect(result.current.portfolio).toBeDefined();
 
     act(() => {
       result.current.navigateToDashboard();
     });
 
     expect(navigate).toHaveBeenCalledWith("/");
+  });
+
+  it("should request the portfolio with the user-selected range so it stays consistent with the Portfolio page", () => {
+    mockedUseNavigate.mockReturnValue(jest.fn());
+
+    renderHook(() => useAnalyticsViewModel(), {
+      initialState: {
+        settings: {
+          ...INITIAL_STATE,
+          counterValue: "USD",
+          selectedTimeRange: "month",
+        },
+      },
+    });
+
+    expect(mockUsePortfolioBalance).toHaveBeenCalledWith({ legacyRange: true });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/index.tsx
@@ -20,6 +20,7 @@ function AnalyticsView({ viewModel }: { readonly viewModel: AnalyticsViewModel }
     navigateToDashboard,
     shouldDisplayGraphRework,
     shouldDisplayAssetSection,
+    portfolio,
   } = viewModel;
 
   const { t } = useTranslation();
@@ -36,6 +37,7 @@ function AnalyticsView({ viewModel }: { readonly viewModel: AnalyticsViewModel }
           range={selectedTimeRange}
           isWallet40
           shouldDisplayGraphRework={shouldDisplayGraphRework}
+          portfolio={portfolio}
         />
       </div>
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/types.ts
@@ -1,5 +1,5 @@
 import { CryptoOrTokenCurrency, Currency } from "@ledgerhq/types-cryptoassets";
-import { PortfolioRange } from "@ledgerhq/types-live";
+import { Portfolio, PortfolioRange } from "@ledgerhq/types-live";
 
 export type AllocationTableItem = {
   currency: CryptoOrTokenCurrency;
@@ -18,6 +18,7 @@ export type AnalyticsViewModel = {
   navigateToDashboard: () => void;
   counterValue: Currency;
   selectedTimeRange: PortfolioRange;
+  portfolio: Portfolio;
   shouldDisplayGraphRework?: boolean;
   shouldDisplayAssetSection?: boolean;
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/useAnalyticsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/useAnalyticsViewModel.ts
@@ -6,6 +6,7 @@ import {
   selectedTimeRangeSelector,
 } from "~/renderer/reducers/settings";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { usePortfolioBalance } from "LLD/hooks/usePortfolioBalance";
 import type { AnalyticsViewModel } from "./types";
 
 export default function useAnalyticsViewModel(): AnalyticsViewModel {
@@ -15,6 +16,8 @@ export default function useAnalyticsViewModel(): AnalyticsViewModel {
   const { shouldDisplayGraphRework, shouldDisplayAssetSection } =
     useWalletFeaturesConfig("desktop");
 
+  const { portfolio } = usePortfolioBalance();
+
   const navigateToDashboard = useCallback(() => {
     navigate("/");
   }, [navigate]);
@@ -23,6 +26,7 @@ export default function useAnalyticsViewModel(): AnalyticsViewModel {
     navigateToDashboard,
     counterValue,
     selectedTimeRange,
+    portfolio,
 
     shouldDisplayGraphRework,
     shouldDisplayAssetSection,

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/GlobalSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/GlobalSummary.tsx
@@ -3,7 +3,7 @@ import { useSelector } from "LLD/hooks/redux";
 import { BigNumber } from "bignumber.js";
 import { formatShort } from "@ledgerhq/live-common/currencies/index";
 import { Currency } from "@ledgerhq/types-cryptoassets";
-import { BalanceHistoryData, PortfolioRange } from "@ledgerhq/types-live";
+import { BalanceHistoryData, Portfolio, PortfolioRange } from "@ledgerhq/types-live";
 import Chart, { GraphTrackingScreenName } from "~/renderer/components/Chart";
 import Box, { Card } from "~/renderer/components/Box";
 import FormattedVal from "~/renderer/components/FormattedVal";
@@ -12,21 +12,45 @@ import { discreetModeSelector } from "~/renderer/reducers/settings";
 import BalanceInfos from "~/renderer/components/BalanceInfos";
 import { usePortfolio } from "~/renderer/actions/portfolio";
 import { hourFormat, dayFormat, useDateFormatter } from "~/renderer/hooks/useDateFormatter";
+
 type Props = {
   counterValue: Currency;
   chartColor: string;
   range: PortfolioRange;
   isWallet40?: boolean;
   shouldDisplayGraphRework?: boolean;
+  /**
+   * Optional pre-computed portfolio. When provided, the component skips its
+   * own `usePortfolio()` call and uses this portfolio instead. This lets
+   * callers (e.g. the Analytics page) share a single throttled portfolio
+   * source with other consumers (`usePortfolioBalance`) so the displayed
+   * balance and % stay consistent across pages during a sync.
+   */
+  portfolio?: Portfolio;
 };
-export default function PortfolioBalanceSummary({
+
+export default function PortfolioBalanceSummary({ portfolio, ...rest }: Props) {
+  if (portfolio) {
+    return <PortfolioBalanceSummaryView {...rest} portfolio={portfolio} />;
+  }
+  return <PortfolioBalanceSummaryContainer {...rest} />;
+}
+
+function PortfolioBalanceSummaryContainer(props: Omit<Props, "portfolio">) {
+  const portfolio = usePortfolio();
+  return <PortfolioBalanceSummaryView {...props} portfolio={portfolio} />;
+}
+
+type ViewProps = Omit<Props, "portfolio"> & { portfolio: Portfolio };
+
+function PortfolioBalanceSummaryView({
   range,
   chartColor,
   counterValue,
   isWallet40,
   shouldDisplayGraphRework,
-}: Props) {
-  const portfolio = usePortfolio();
+  portfolio,
+}: ViewProps) {
   const discreetMode = useSelector(discreetModeSelector);
   const renderTickY = useCallback(
     (val: number | string) => formatShort(counterValue.units[0], BigNumber(val)),
@@ -111,6 +135,7 @@ export default function PortfolioBalanceSummary({
     </Card>
   );
 }
+
 function Tooltip({
   data,
   counterValue,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description
The Analytics page displayed a different balance and percentage than Portfolio V4 when Wallet 4.0 was enabled.


### ❓ Context

- **JIRA or GitHub link**: [LIVE-29125](https://ledgerhq.atlassian.net/browse/LIVE-29125)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-29125]: https://ledgerhq.atlassian.net/browse/LIVE-29125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ