### PR TITLE
fix(wallet-cli): restrict session file to owner-only permissions

### DIFF
--- a/apps/wallet-cli/src/commands/account/discover.ts
+++ b/apps/wallet-cli/src/commands/account/discover.ts
@@ -101,7 +101,7 @@ export default defineCommand({
           try {
             const session = await Session.read();
             added = session.addDescriptors(discoveredDescriptors);
-            if (added > 0) await session.write();
+            if (added > 0) session.write();
           } catch {
             // Session persistence failure is non-fatal; discovery output is already flushed.
           }

--- a/apps/wallet-cli/src/commands/session/reset.ts
+++ b/apps/wallet-cli/src/commands/session/reset.ts
@@ -24,7 +24,7 @@ export default defineCommand({
         session = Session.from([]);
       }
       const count = session.clear();
-      await session.write(); // always write: fixes corrupt files too
+      session.write(); // always write: fixes corrupt files too
       out.sessionReset(count);
     });
   },

--- a/apps/wallet-cli/src/session/session-store.test.ts
+++ b/apps/wallet-cli/src/session/session-store.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, afterEach } from "bun:test";
 import { YAML } from "bun";
-import { generateLabel, Session } from "./session-store";
+import { statSync, mkdtempSync, mkdirSync, writeFileSync, chmodSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { generateLabel, getSessionPath, Session } from "./session-store";
 import type { AccountDescriptorV1 } from "../shared/accountDescriptor";
 
 const btcNative: AccountDescriptorV1 = {
@@ -180,5 +183,46 @@ describe("YAML round-trip", () => {
     const yaml = YAML.stringify({ accounts: entries });
     const parsed = YAML.parse(yaml);
     expect(parsed).toEqual({ accounts: entries });
+  });
+});
+
+describe("Session.write() permissions", () => {
+  let tmpDir: string | undefined;
+  let savedEnv: string | undefined;
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env.XDG_STATE_HOME;
+    else process.env.XDG_STATE_HOME = savedEnv;
+    if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("creates state dir 0700 and session file 0600", () => {
+    savedEnv = process.env.XDG_STATE_HOME;
+    tmpDir = mkdtempSync(join(tmpdir(), "wallet-cli-perm-"));
+    process.env.XDG_STATE_HOME = tmpDir;
+
+    Session.from([]).write();
+
+    const sessionFile = getSessionPath();
+    expect(statSync(dirname(sessionFile)).mode & 0o777).toBe(0o700);
+    expect(statSync(sessionFile).mode & 0o777).toBe(0o600);
+  });
+
+  it("corrects too-permissive existing dir and file to 0700/0600", () => {
+    savedEnv = process.env.XDG_STATE_HOME;
+    tmpDir = mkdtempSync(join(tmpdir(), "wallet-cli-perm-"));
+    process.env.XDG_STATE_HOME = tmpDir;
+
+    // Pre-create with permissive modes (simulating a prior installation)
+    const stateDirectory = dirname(getSessionPath());
+    mkdirSync(stateDirectory, { recursive: true });
+    chmodSync(stateDirectory, 0o755);
+    writeFileSync(getSessionPath(), "", { mode: 0o644 });
+    chmodSync(getSessionPath(), 0o644);
+
+    Session.from([]).write();
+
+    expect(statSync(stateDirectory).mode & 0o777).toBe(0o700);
+    expect(statSync(getSessionPath()).mode & 0o777).toBe(0o600);
   });
 });

--- a/apps/wallet-cli/src/session/session-store.ts
+++ b/apps/wallet-cli/src/session/session-store.ts
@@ -1,7 +1,7 @@
 import { YAML } from "bun";
 import { stateDir } from "@bunli/utils";
 import { join } from "node:path";
-import { mkdirSync } from "node:fs";
+import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
 import { z } from "zod";
 import type { AccountDescriptorV1 } from "../shared/accountDescriptor";
 import { serializeV1 } from "../shared/accountDescriptor";
@@ -45,10 +45,13 @@ async function readEntries(): Promise<SessionEntry[]> {
   return parseSessionData(content);
 }
 
-async function writeEntries(entries: SessionEntry[]): Promise<void> {
+function writeEntries(entries: SessionEntry[]): void {
   const dir = stateDir(APP_NAME);
-  mkdirSync(dir, { recursive: true });
-  await Bun.write(getSessionPath(), YAML.stringify({ accounts: entries }));
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  chmodSync(dir, 0o700); // enforce on existing dirs created by prior versions
+  const sessionPath = getSessionPath();
+  writeFileSync(sessionPath, YAML.stringify({ accounts: entries }), { mode: 0o600 });
+  chmodSync(sessionPath, 0o600); // enforce on existing files created by prior versions
 }
 
 function derivationLabel(path: string): string {
@@ -122,7 +125,7 @@ export class Session {
     return added;
   }
 
-  async write(): Promise<void> {
-    await writeEntries(this.entries);
+  write(): void {
+    writeEntries(this.entries);
   }
 }


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - wallet-cli

### 📝 Description

Fixes audit finding #8: the session YAML file was written without explicit filesystem permissions, leaving it world-readable on systems with the default umask (022).

- State directory now created with mode `0700` (owner-only)
- Session file now written with mode `0600` (owner read/write only) via `writeFileSync` replacing `Bun.write`
- `writeEntries` simplified from `async` to sync (no async operations remain after removing `Bun.write`)

### ❓ Context

- **JIRA or GitHub link**: wallet-cli security audit finding #8
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.