### PR TITLE
fix(wallet-cli): verified indicator in receive + show address before device confirmation

### DIFF
--- a/apps/wallet-cli/src/commands/receive.ts
+++ b/apps/wallet-cli/src/commands/receive.ts
@@ -47,16 +47,34 @@ export default defineCommand({
       ctx.account = serializeV1(v1);
       const currencyId = currencyIdFromNetwork(v1.network);
       const managerAppName = getManagerAppNameForCurrencyId(currencyId);
+      const address =
+        v1.type === "address"
+          ? v1.address
+          : await out.withActivity(
+              `Scanning ${v1.network.name} blockchain for fresh address…`,
+              "Fresh address resolved",
+              () => wallet.getFreshAddress(toV0(v1)),
+            );
       if (flags.verify) {
+        out.preVerifyAddress(address);
         const spin = out.spin(`Connect device and open ${colors.bold(managerAppName)} app…`);
         await withCurrencyDeviceSession(
           currencyId,
           async () => {
             out.deviceState({ code: "awaiting_approval", reason: "verify_address" });
             try {
-              const address = await wallet.verifyAddress(toV0(v1), WALLET_CLI_DMK_DEVICE_ID);
+              const deviceAddress = await wallet.verifyAddress(toV0(v1), WALLET_CLI_DMK_DEVICE_ID);
+              const hexAddress = address.toLowerCase().startsWith("0x");
+              const match = hexAddress
+                ? deviceAddress.toLowerCase() === address.toLowerCase()
+                : deviceAddress === address;
+              if (!match) {
+                throw new Error(
+                  `Address mismatch: device returned ${deviceAddress}, expected ${address}`,
+                );
+              }
               spin?.success("Address verified");
-              out.address(address);
+              out.address(address, true);
             } catch (e) {
               throw WalletCliDeviceError.fromUnknown(e, {
                 expectedApp: managerAppName,
@@ -70,15 +88,7 @@ export default defineCommand({
           },
         );
       } else {
-        const address =
-          v1.type === "address"
-            ? v1.address
-            : await out.withActivity(
-                `Scanning ${v1.network.name} blockchain for fresh address…`,
-                "Fresh address resolved",
-                () => wallet.getFreshAddress(toV0(v1)),
-              );
-        out.address(address);
+        out.address(address, false);
       }
     });
   },

--- a/apps/wallet-cli/src/output-json.test.ts
+++ b/apps/wallet-cli/src/output-json.test.ts
@@ -42,7 +42,7 @@ describe("JsonCommandOutput", () => {
       });
 
       out.deviceState({ code: "awaiting_approval", reason: "unlock" });
-      out.address("0xabc");
+      out.address("0xabc", true);
     } finally {
       restore();
     }
@@ -63,6 +63,36 @@ describe("JsonCommandOutput", () => {
     });
     expect(lines[1]).toMatchObject({
       status: "success",
+      command: "receive",
+      network: "ethereum:main",
+      account: "js:2:ethereum:0x123",
+      address: "0xabc",
+      verified: true,
+      source: "device",
+    });
+  });
+
+  it("emits a pre-verify-address NDJSON event so agents can surface the address", () => {
+    try {
+      const out = createCommandOutput("json", {
+        command: "receive",
+        network: "ethereum:main",
+        account: "js:2:ethereum:0x123",
+      });
+
+      out.preVerifyAddress("0xabc");
+    } finally {
+      restore();
+    }
+
+    const lines = writes
+      .join("")
+      .trim()
+      .split("\n")
+      .map(line => JSON.parse(line));
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toEqual({
+      type: "pre-verify-address",
       command: "receive",
       network: "ethereum:main",
       account: "js:2:ethereum:0x123",

--- a/apps/wallet-cli/src/output.ts
+++ b/apps/wallet-cli/src/output.ts
@@ -68,8 +68,14 @@ export interface CommandOutput {
 
   balances(items: Balance[]): Promise<void>;
   operations(items: Operation[], currencyId: string, nextCursor?: string): Promise<void>;
-  /** Output a receive / fresh address. */
-  address(addr: string): void;
+  /** Output a receive / fresh address. `verified` indicates whether the device attested it. */
+  address(addr: string, verified: boolean): void;
+  /**
+   * Surface the derived address before device confirmation so the user (or an agent
+   * watching the stream) can compare it with what the Ledger displays.
+   * Human: stderr line. Json: NDJSON `pre-verify-address` event.
+   */
+  preVerifyAddress(addr: string): void;
   /** Output the result of a successful device genuine check. */
   genuineCheck(): void;
 
@@ -221,8 +227,16 @@ class HumanCommandOutput implements CommandOutput {
     }
   }
 
-  address(addr: string): void {
+  address(addr: string, verified: boolean): void {
+    if (!verified) {
+      writeStderr("Warning: address was NOT verified on device\n");
+    }
     writeStdout(addr);
+  }
+
+  preVerifyAddress(addr: string): void {
+    writeStderr(addr + "\n");
+    writeStderr("Compare the address above with what's shown on your Ledger…\n");
   }
 
   genuineCheck(): void {
@@ -533,8 +547,24 @@ class JsonCommandOutput implements CommandOutput {
     this._writeNdjson(this._envelope({ operations, nextCursor }));
   }
 
-  address(addr: string): void {
-    this._writeNdjson(this._envelope({ address: addr }));
+  address(addr: string, verified: boolean): void {
+    this._writeNdjson(
+      this._envelope({
+        address: addr,
+        verified,
+        source: verified ? "device" : "software-derivation",
+      }),
+    );
+  }
+
+  preVerifyAddress(addr: string): void {
+    this._writeNdjson({
+      type: "pre-verify-address",
+      command: this._ctx.command,
+      network: this._ctx.network,
+      ...(this._ctx.account == null ? {} : { account: this._ctx.account }),
+      address: addr,
+    });
   }
 
   genuineCheck(): void {

--- a/apps/wallet-cli/src/test/commands/receive.test.ts
+++ b/apps/wallet-cli/src/test/commands/receive.test.ts
@@ -16,7 +16,7 @@ describe("receive --verify command (mock DMK)", () => {
     sessionCleanup = undefined;
   });
 
-  it("json output: returns the verified address from mock device", async () => {
+  it("json output: returns verified address with verified=true and source=device", async () => {
     const fixture = makeSessionDir([{ label: "ethereum-1", descriptor: MOCK_ETH_DESCRIPTOR }]);
     sessionCleanup = fixture.cleanup;
     const { stdout, exitCode, stderr } = await runCli(
@@ -33,7 +33,19 @@ describe("receive --verify command (mock DMK)", () => {
     expect(exitCode, `stderr: ${stderr}`).toBe(0);
 
     const lines = stdout.split("\n").map(line => JSON.parse(line));
-    expect(lines[0]).toMatchObject({
+
+    const preVerify = lines.find(l => l.type === "pre-verify-address");
+    expect(preVerify).toMatchObject({
+      type: "pre-verify-address",
+      command: "receive",
+      network: "ethereum:main",
+      address: MOCK_ETH_ADDRESS,
+    });
+
+    const deviceState = lines.find(
+      l => l.type === "device-state" && l.state?.reason === "verify_address",
+    );
+    expect(deviceState).toMatchObject({
       type: "device-state",
       command: "receive",
       network: "ethereum:main",
@@ -44,9 +56,34 @@ describe("receive --verify command (mock DMK)", () => {
     const data = lines.at(-1);
     expect(data.command).toBe("receive");
     expect(data.network).toBe("ethereum:main");
-    expect(lines[0].account).toBe(data.account);
-    expect(typeof data.address).toBe("string");
-    // The mock device returns our known address
+    expect(deviceState.account).toBe(data.account);
     expect(data.address.toLowerCase()).toBe(MOCK_ETH_ADDRESS.toLowerCase());
+    expect(data.verified).toBe(true);
+    expect(data.source).toBe("device");
+  });
+
+  it("json output: verified=false and source=software-derivation when --verify=false", async () => {
+    const fixture = makeSessionDir([{ label: "ethereum-1", descriptor: MOCK_ETH_DESCRIPTOR }]);
+    sessionCleanup = fixture.cleanup;
+    const { stdout, exitCode, stderr } = await runCli(
+      ["receive", "--account", "ethereum-1", "--verify=false", "--output", "json"],
+      { WALLET_CLI_MOCK_PORT: String(server.port), ...fixture.env },
+    );
+    expect(exitCode, `stderr: ${stderr}`).toBe(0);
+    const data = JSON.parse(stdout);
+    expect(data.verified).toBe(false);
+    expect(data.source).toBe("software-derivation");
+  });
+
+  it("human output: warns when --verify=false", async () => {
+    const fixture = makeSessionDir([{ label: "ethereum-1", descriptor: MOCK_ETH_DESCRIPTOR }]);
+    sessionCleanup = fixture.cleanup;
+    const { stdout, stderr, exitCode } = await runCli(
+      ["receive", "--account", "ethereum-1", "--verify=false", "--output", "human"],
+      { WALLET_CLI_MOCK_PORT: String(server.port), ...fixture.env },
+    );
+    expect(exitCode, `stderr: ${stderr}`).toBe(0);
+    expect(stdout).toBe(MOCK_ETH_ADDRESS);
+    expect(stderr).toContain("Warning: address was NOT verified on device");
   });
 });


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - wallet-cli

### 📝 Description

Fixes two audit findings in the `receive` command:

**Finding 4** — JSON and human output were identical whether `--verify` was used or not. Downstream agents and scripts had no way to know if an address was device-attested.
- JSON envelope now carries `verified: boolean` and `source: "device" | "software-derivation"`
- Human mode prints a stderr warning when the address was not verified on device

**Finding 10** — With `--verify`, the address was only revealed *after* device confirmation, leaving the user nothing to compare against on the Ledger screen.
- New flow: derive address from software first and print it to stderr, then open device session for confirmation — matching the Ledger Live desktop pattern

TLDR — new JSON output shape:
```diff
-{ "address": "0xf39F…" }
+{ "address": "0xf39F…", "verified": true,  "source": "device" }
+{ "address": "0xf39F…", "verified": false, "source": "software-derivation" }
```

### ❓ Context

- **JIRA or GitHub link**: wallet-cli security audit findings #4 and #10
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.