### PR TITLE
fix(wallet-cli): require session alias for account args, reject xprv keys

### DIFF
--- a/.changeset/fix-wallet-cli-reject-raw-descriptors.md
+++ b/.changeset/fix-wallet-cli-reject-raw-descriptors.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-cli": patch
+---
+
+Reject raw account descriptors as CLI arguments (use session labels from `account discover`) and reject extended private keys (xprv/yprv/zprv/tprv/uprv/vprv) in descriptor parsing.

--- a/apps/wallet-cli/src/commands/inputs.test.ts
+++ b/apps/wallet-cli/src/commands/inputs.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { resolveAccountArg, resolveOutputFormat } from "./inputs";
+import { resolveAccountArg, resolveAccountInput, resolveOutputFormat } from "./inputs";
+import { makeSessionDir } from "../test/helpers/session-fixture";
+import { ETH_DESCRIPTOR } from "../test/helpers/constants";
 import { XPUB } from "../shared/accountDescriptor/test-fixtures";
 
 const SHORT = `js:2:bitcoin:${XPUB}:native_segwit:0`;
@@ -15,6 +17,54 @@ describe("resolveAccountArg", () => {
 
   it("throws when both are missing", () => {
     expect(() => resolveAccountArg(undefined, [])).toThrow(/Missing account/);
+  });
+});
+
+describe("resolveAccountInput", () => {
+  let sessionCleanup: (() => void) | undefined;
+  let savedXdgStateHome: string | undefined;
+
+  beforeEach(() => {
+    savedXdgStateHome = process.env.XDG_STATE_HOME;
+  });
+
+  afterEach(() => {
+    sessionCleanup?.();
+    sessionCleanup = undefined;
+    if (savedXdgStateHome === undefined) delete process.env.XDG_STATE_HOME;
+    else process.env.XDG_STATE_HOME = savedXdgStateHome;
+  });
+
+  it("resolves a known session label to its descriptor", async () => {
+    const fixture = makeSessionDir([{ label: "my-eth", descriptor: ETH_DESCRIPTOR }]);
+    sessionCleanup = fixture.cleanup;
+    process.env.XDG_STATE_HOME = fixture.env.XDG_STATE_HOME;
+    const result = await resolveAccountInput("my-eth");
+    expect(result).toBe(ETH_DESCRIPTOR);
+  });
+
+  it("throws when the label is not found in session", async () => {
+    const fixture = makeSessionDir([]);
+    sessionCleanup = fixture.cleanup;
+    process.env.XDG_STATE_HOME = fixture.env.XDG_STATE_HOME;
+    await expect(resolveAccountInput("unknown-label")).rejects.toThrow(
+      /No account labeled "unknown-label"/,
+    );
+  });
+
+  it("rejects a raw descriptor passed directly (contains ':')", async () => {
+    const fixture = makeSessionDir([]);
+    sessionCleanup = fixture.cleanup;
+    process.env.XDG_STATE_HOME = fixture.env.XDG_STATE_HOME;
+    let caught: Error | undefined;
+    try {
+      await resolveAccountInput(ETH_DESCRIPTOR);
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught?.message).toMatch(/Raw descriptors are not accepted/);
+    // Must not echo the descriptor back (would leak xpub/path into logs).
+    expect(caught?.message).not.toContain(ETH_DESCRIPTOR);
   });
 });
 

--- a/apps/wallet-cli/src/commands/inputs.ts
+++ b/apps/wallet-cli/src/commands/inputs.ts
@@ -32,8 +32,7 @@ export const deviceTimeoutOption = option(z.coerce.number().int().positive().def
 });
 
 export const accountOption = option(z.string().min(1).optional(), {
-  description:
-    "Account descriptor or session label (e.g. ethereum-1). Can also be the first positional arg.",
+  description: "Session label (e.g. ethereum-1). Can also be the first positional arg.",
   short: "a",
 });
 
@@ -44,20 +43,24 @@ export function resolveAccountArg(
   const arg = account ?? positional[0];
   if (!arg) {
     throw new Error(
-      "Missing account: use --account <descriptor-or-label> or pass it as the first positional argument.",
+      "Missing account: use --account <session-label> or pass the label as the first positional argument. Run `account discover` first to populate the session.",
     );
   }
   return arg;
 }
 
-// Contains ":" → descriptor passthrough; no ":" → session label lookup.
+// Session label lookup only — raw descriptors are not accepted as CLI arguments.
 export async function resolveAccountInput(input: string): Promise<string> {
-  if (input.includes(":")) return input;
+  if (input.includes(":")) {
+    throw new Error(
+      "Raw descriptors are not accepted as CLI arguments. Run `account discover` first, then reference the account by its session label (e.g. `--account ethereum-1`).",
+    );
+  }
   const session = await Session.read();
   const entry = session.accounts.find(e => e.label === input);
   if (!entry) {
     throw new Error(
-      `No account labeled "${input}" in session. Run \`account discover\` first or pass a full descriptor.`,
+      `No account labeled "${input}" in session. Run \`account discover\` first to populate the session.`,
     );
   }
   return entry.descriptor;

--- a/apps/wallet-cli/src/session/session-store.ts
+++ b/apps/wallet-cli/src/session/session-store.ts
@@ -10,7 +10,10 @@ export const APP_NAME = "ledger-wallet-cli";
 const SESSION_FILE = "session.yaml";
 
 const SessionEntrySchema = z.object({
-  label: z.string(),
+  label: z
+    .string()
+    .min(1)
+    .regex(/^[A-Za-z0-9_-]+$/, "Session label must not contain ':' or other special characters"),
   descriptor: z.string(),
 });
 

--- a/apps/wallet-cli/src/shared/accountDescriptor/adapters.ts
+++ b/apps/wallet-cli/src/shared/accountDescriptor/adapters.ts
@@ -39,7 +39,7 @@ export class UnsupportedFamilyError extends Error {
 // ---------------------------------------------------------------------------
 
 function isXpub(seedIdentifier: string): boolean {
-  return /^[xyz]pub/.test(seedIdentifier) || /^[xyz]prv/.test(seedIdentifier);
+  return /^[xyztuv]pub/.test(seedIdentifier) || /^[xyztuv]prv/.test(seedIdentifier);
 }
 
 /**

--- a/apps/wallet-cli/src/shared/accountDescriptor/v1.test.ts
+++ b/apps/wallet-cli/src/shared/accountDescriptor/v1.test.ts
@@ -103,4 +103,10 @@ describe("parseV1", () => {
   it("throws when utxo path has non-hardened segments", () => {
     expect(() => parseV1(`account:1:utxo:bitcoin:main:${XPUB}:m/84h/0h/0`)).toThrow();
   });
+
+  it.each(["xprv", "yprv", "zprv", "tprv", "uprv", "vprv"])("throws when xpub field contains a %s private extended key", prefix => {
+    expect(() => parseV1(`account:1:utxo:bitcoin:main:${prefix}SomeKey:m/84h/0h/0h`)).toThrow(
+      /private extended key/,
+    );
+  });
 });

--- a/apps/wallet-cli/src/shared/accountDescriptor/v1.ts
+++ b/apps/wallet-cli/src/shared/accountDescriptor/v1.ts
@@ -35,8 +35,10 @@ export const UtxoAccountDescriptorV1Schema = z.object({
   version: z.literal("1"),
   type: z.literal("utxo"),
   network: NetworkSchema,
-  /** Extended public key: xpub, ypub or zpub */
-  xpub: z.string().min(1),
+  /** Extended public key: mainnet xpub/ypub/zpub or testnet tpub/upub/vpub. */
+  xpub: z.string().min(1).refine(v => !/^[xyztuv]prv/.test(v), {
+    message: "xpub field must not contain a private extended key (xprv/yprv/zprv/tprv/uprv/vprv)",
+  }),
   /**
    * Hardened-only BIP32 path, e.g. "m/84h/0h/0h" (or legacy "m/84'/0'/0'").
    * All segments must be hardened. "h" is preferred (shell-safe); "'" is also accepted.

--- a/apps/wallet-cli/src/test/commands/balances.test.ts
+++ b/apps/wallet-cli/src/test/commands/balances.test.ts
@@ -35,18 +35,23 @@ describe("balances command", () => {
   });
 
   it("human output: prints ETH balance line", async () => {
-    const { stdout, exitCode, stderr } = await runCli(["balances", "--account", ETH_DESCRIPTOR], {
-      WALLET_CLI_MOCK_PORT: String(server.port),
-    });
+    const fixture = makeSessionDir([{ label: "ethereum-1", descriptor: ETH_DESCRIPTOR }]);
+    sessionCleanup = fixture.cleanup;
+    const { stdout, exitCode, stderr } = await runCli(
+      ["balances", "--account", "ethereum-1"],
+      { WALLET_CLI_MOCK_PORT: String(server.port), ...fixture.env },
+    );
     expect(exitCode, `stderr: ${stderr}`).toBe(0);
     expect(stdout).toMatch(/ETH/i);
     expect(stdout).toMatch(/1\.5/);
   });
 
   it("json output: returns a valid balances envelope", async () => {
+    const fixture = makeSessionDir([{ label: "ethereum-1", descriptor: ETH_DESCRIPTOR }]);
+    sessionCleanup = fixture.cleanup;
     const { stdout, exitCode, stderr } = await runCli(
-      ["balances", "--account", ETH_DESCRIPTOR, "--output", "json"],
-      { WALLET_CLI_MOCK_PORT: String(server.port) },
+      ["balances", "--account", "ethereum-1", "--output", "json"],
+      { WALLET_CLI_MOCK_PORT: String(server.port), ...fixture.env },
     );
     expect(exitCode, `stderr: ${stderr}`).toBe(0);
 
@@ -61,28 +66,28 @@ describe("balances command", () => {
     expect(native.amount).toMatch(/1\.5/);
   });
 
-  it("can resolve a session label to the matching account", async () => {
-    const fixture = makeSessionDir([{ label: "ethereum-1", descriptor: ETH_DESCRIPTOR }]);
+  it("json output: raw descriptor passed as --account is rejected with code 1", async () => {
+    const fixture = makeSessionDir([]);
     sessionCleanup = fixture.cleanup;
-    const { stdout, exitCode, stderr } = await runCli(
-      ["balances", "--account", "ethereum-1", "--output", "json"],
+    const { stdout, exitCode } = await runCli(
+      ["balances", "--account", ETH_DESCRIPTOR, "--output", "json"],
       { WALLET_CLI_MOCK_PORT: String(server.port), ...fixture.env },
     );
-    expect(exitCode, `stderr: ${stderr}`).toBe(0);
-    const data = JSON.parse(stdout);
-    expect(data.command).toBe("balances");
-    expect(data.network).toBe("ethereum:main");
-    const native = data.balances.find((b: { asset: string }) => b.asset === "ethereum");
-    expect(native?.amount).toMatch(/1\.5/);
+    expect(exitCode).toBe(1);
+    const err = JSON.parse(stdout);
+    expect(err.ok).toBe(false);
+    expect(err.error.command).toBe("balances");
+    expect(err.error.message).toStartWith("Raw descriptors are not accepted");
   });
 
-  it("json output: invalid descriptor exits with code 1", async () => {
+  it("json output: unknown session label exits with code 1", async () => {
+    const fixture = makeSessionDir([]);
+    sessionCleanup = fixture.cleanup;
     const { stdout, exitCode } = await runCli(
-      ["balances", "--account", "not-a-valid-descriptor", "--output", "json"],
-      { WALLET_CLI_MOCK_PORT: String(server.port) },
+      ["balances", "--account", "not-a-valid-label", "--output", "json"],
+      { WALLET_CLI_MOCK_PORT: String(server.port), ...fixture.env },
     );
     expect(exitCode).toBe(1);
-    // JSON mode routes all output to stdout; errors have { ok: false, ... }.
     const err = JSON.parse(stdout);
     expect(err.ok).toBe(false);
     expect(err.error.command).toBe("balances");

--- a/apps/wallet-cli/src/test/commands/operations.test.ts
+++ b/apps/wallet-cli/src/test/commands/operations.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "bun:test";
 import { MockServer } from "../helpers/mock-server";
 import { runCli } from "../helpers/cli-runner";
+import { makeSessionDir } from "../helpers/session-fixture";
 import { ETH_DESCRIPTOR, ETH_ADDRESS } from "../helpers/constants";
 
 const CURRENT_BLOCK = {
@@ -81,13 +82,20 @@ function baseRoutes(txsFixture: object) {
 describe("operations command — empty history", () => {
   const server = new MockServer(baseRoutes({ data: [], token: null }));
 
+  let sessionCleanup: (() => void) | undefined;
   beforeAll(() => server.start());
   afterAll(() => server.stop());
+  afterEach(() => {
+    sessionCleanup?.();
+    sessionCleanup = undefined;
+  });
 
   it("json output: returns empty operations array", async () => {
+    const fixture = makeSessionDir([{ label: "ethereum-1", descriptor: ETH_DESCRIPTOR }]);
+    sessionCleanup = fixture.cleanup;
     const { stdout, exitCode, stderr } = await runCli(
-      ["operations", "--account", ETH_DESCRIPTOR, "--output", "json"],
-      { WALLET_CLI_MOCK_PORT: String(server.port) },
+      ["operations", "--account", "ethereum-1", "--output", "json"],
+      { WALLET_CLI_MOCK_PORT: String(server.port), ...fixture.env },
     );
     expect(exitCode, `stderr: ${stderr}`).toBe(0);
 
@@ -102,13 +110,20 @@ describe("operations command — empty history", () => {
 describe("operations command — one OUT transaction", () => {
   const server = new MockServer(baseRoutes({ data: [POINT_ONE_ETH_OUT_TX], token: null }));
 
+  let sessionCleanup: (() => void) | undefined;
   beforeAll(() => server.start());
   afterAll(() => server.stop());
+  afterEach(() => {
+    sessionCleanup?.();
+    sessionCleanup = undefined;
+  });
 
   it("json output: returns one OUT operation", async () => {
+    const fixture = makeSessionDir([{ label: "ethereum-1", descriptor: ETH_DESCRIPTOR }]);
+    sessionCleanup = fixture.cleanup;
     const { stdout, exitCode, stderr } = await runCli(
-      ["operations", "--account", ETH_DESCRIPTOR, "--output", "json"],
-      { WALLET_CLI_MOCK_PORT: String(server.port) },
+      ["operations", "--account", "ethereum-1", "--output", "json"],
+      { WALLET_CLI_MOCK_PORT: String(server.port), ...fixture.env },
     );
     expect(exitCode, `stderr: ${stderr}`).toBe(0);
 

--- a/apps/wallet-cli/src/test/commands/receive.test.ts
+++ b/apps/wallet-cli/src/test/commands/receive.test.ts
@@ -1,24 +1,33 @@
-import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "bun:test";
 import { MockServer } from "../helpers/mock-server";
 import { runCli } from "../helpers/cli-runner";
+import { makeSessionDir } from "../helpers/session-fixture";
 import { ETH_SYNC_ROUTES } from "../helpers/eth-sync-routes";
 import { MOCK_ETH_DESCRIPTOR, MOCK_ETH_ADDRESS, MOCK_ETH_PUBKEY } from "../helpers/constants";
 
 describe("receive --verify command (mock DMK)", () => {
   const server = new MockServer(ETH_SYNC_ROUTES);
 
+  let sessionCleanup: (() => void) | undefined;
   beforeAll(() => server.start());
   afterAll(() => server.stop());
+  afterEach(() => {
+    sessionCleanup?.();
+    sessionCleanup = undefined;
+  });
 
   it("json output: returns the verified address from mock device", async () => {
+    const fixture = makeSessionDir([{ label: "ethereum-1", descriptor: MOCK_ETH_DESCRIPTOR }]);
+    sessionCleanup = fixture.cleanup;
     const { stdout, exitCode, stderr } = await runCli(
-      ["receive", "--account", MOCK_ETH_DESCRIPTOR, "--verify", "--output", "json"],
+      ["receive", "--account", "ethereum-1", "--verify", "--output", "json"],
       {
         WALLET_CLI_MOCK_PORT: String(server.port),
         WALLET_CLI_MOCK_DMK: "1",
         WALLET_CLI_MOCK_APP_RESULTS: JSON.stringify({
           Ethereum: { publicKey: MOCK_ETH_PUBKEY, address: MOCK_ETH_ADDRESS },
         }),
+        ...fixture.env,
       },
     );
     expect(exitCode, `stderr: ${stderr}`).toBe(0);

--- a/apps/wallet-cli/src/test/commands/send.test.ts
+++ b/apps/wallet-cli/src/test/commands/send.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "bun:test";
 import { MockServer } from "../helpers/mock-server";
 import { runCli } from "../helpers/cli-runner";
+import { makeSessionDir } from "../helpers/session-fixture";
 import { ETH_SYNC_ROUTES } from "../helpers/eth-sync-routes";
 import { MOCK_ETH_DESCRIPTOR, MOCK_ETH_ADDRESS, MOCK_ETH_PUBKEY } from "../helpers/constants";
 
@@ -34,15 +35,22 @@ const SEND_ROUTES = [
 describe("send (non-dry-run): device model resolution", () => {
   const server = new MockServer([]);
 
+  let sessionCleanup: (() => void) | undefined;
   beforeAll(() => server.start());
   afterAll(() => server.stop());
+  afterEach(() => {
+    sessionCleanup?.();
+    sessionCleanup = undefined;
+  });
 
   it("exits with a clear error when deviceModelId cannot be resolved from the DMK session", async () => {
+    const fixture = makeSessionDir([{ label: "ethereum-1", descriptor: MOCK_ETH_DESCRIPTOR }]);
+    sessionCleanup = fixture.cleanup;
     const { stdout, exitCode } = await runCli(
       [
         "send",
         "--account",
-        MOCK_ETH_DESCRIPTOR,
+        "ethereum-1",
         "--to",
         "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
         "--amount",
@@ -57,6 +65,7 @@ describe("send (non-dry-run): device model resolution", () => {
         WALLET_CLI_MOCK_APP_RESULTS: JSON.stringify({
           Ethereum: { publicKey: MOCK_ETH_PUBKEY, address: MOCK_ETH_ADDRESS },
         }),
+        ...fixture.env,
       },
     );
     expect(exitCode).toBe(1);
@@ -69,15 +78,22 @@ describe("send (non-dry-run): device model resolution", () => {
 describe("send --dry-run command", () => {
   const server = new MockServer(SEND_ROUTES);
 
+  let sessionCleanup: (() => void) | undefined;
   beforeAll(() => server.start());
   afterAll(() => server.stop());
+  afterEach(() => {
+    sessionCleanup?.();
+    sessionCleanup = undefined;
+  });
 
   it("json output: exits 0 and returns a dry-run send envelope for ETH", async () => {
+    const fixture = makeSessionDir([{ label: "ethereum-1", descriptor: MOCK_ETH_DESCRIPTOR }]);
+    sessionCleanup = fixture.cleanup;
     const { stdout, exitCode, stderr } = await runCli(
       [
         "send",
         "--account",
-        MOCK_ETH_DESCRIPTOR,
+        "ethereum-1",
         "--to",
         "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
         "--amount",
@@ -92,6 +108,7 @@ describe("send --dry-run command", () => {
         WALLET_CLI_MOCK_APP_RESULTS: JSON.stringify({
           Ethereum: { publicKey: MOCK_ETH_PUBKEY, address: MOCK_ETH_ADDRESS },
         }),
+        ...fixture.env,
       },
     );
     expect(exitCode, `stderr: ${stderr}`).toBe(0);


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - wallet-cli

### 📝 Description

Fixes two audit findings around account descriptor handling:

**Finding 7** — `--account` flags accepted raw descriptors (e.g. `account:1:utxo:bitcoin:main:xpub…:m/84h/0h/0h`) directly as CLI arguments, exposing wallet metadata (xpubs, derivation paths) in shell history, process listings, and CI logs.
- `resolveAccountInput()` now only accepts session labels — raw descriptors (containing `:`) are rejected with a clear error message
- All callers must use `account discover` first, then reference accounts by alias

**Finding 6** — `UtxoAccountDescriptorV1Schema.xpub` accepted any non-empty string, including private extended keys (`xprv`/`yprv`/`zprv`).
- Added `.refine()` validation rejecting any xpub value that starts with `[xyz]prv`

TLDR — breaking change for raw-descriptor consumers:
```diff
-wallet-cli balances --account 'account:1:utxo:bitcoin:main:xpub…:m/84h/0h/0h'
+wallet-cli account discover  # populate session first
+wallet-cli balances --account bitcoin-1   # then use the alias
```

### ❓ Context

- **JIRA or GitHub link**: wallet-cli security audit findings #6 and #7
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.