### PR TITLE
[LWDM] docs(live-common): add JSDoc on getAccountBridge/getCurrencyBridge for async migration

### DIFF
--- a/libs/ledger-live-common/src/bridge/impl.ts
+++ b/libs/ledger-live-common/src/bridge/impl.ts
@@ -32,6 +32,18 @@ const currencyBridgeCache: Record<string, CurrencyBridge> = {};
 // All account bridges are wrapped (wrapAccountBridge); cache ensures referential stability.
 const accountBridgeCache: Record<string, AccountBridge<any>> = {};
 
+/**
+ * Returns the CurrencyBridge for a given CryptoCurrency.
+ *
+ * **Ongoing migration**: this function will become async as part of the ESM coin modules migration
+ * (dynamic `import()` replacing synchronous `require()`). Write call sites that are async-compatible today:
+ *
+ * - **React component**: use the `useCurrencyBridge(currency)` hook instead — it handles loading states.
+ * - **RxJS observable**: wrap with `from(Promise.resolve(getCurrencyBridge(currency))).pipe(mergeMap(bridge => ...))`
+ * - **async function**:
+ *   - ❌ `const bridge = getCurrencyBridge(currency)` — not forward-compatible
+ *   - ✅ `const bridge = await Promise.resolve(getCurrencyBridge(currency))` — compatible with both sync and future async forms.
+ */
 export const getCurrencyBridge = (currency: CryptoCurrency): CurrencyBridge => {
   if (getEnv("MOCK")) {
     const mockBridge = loadMockBridgeForFamily(currency.family);
@@ -61,6 +73,18 @@ export const getCurrencyBridge = (currency: CryptoCurrency): CurrencyBridge => {
   return setup.bridge.currencyBridge;
 };
 
+/**
+ * Returns the AccountBridge for a given account (and optional parent account).
+ *
+ * **Ongoing migration**: this function will become async as part of the ESM coin modules migration
+ * (dynamic `import()` replacing synchronous `require()`). Write call sites that are async-compatible today:
+ *
+ * - **React component**: use the `useAccountBridge(account)` hook instead — it handles loading states.
+ * - **RxJS observable**: wrap with `from(Promise.resolve(getAccountBridge(account))).pipe(mergeMap(bridge => ...))`
+ * - **async function**:
+ *   - ❌ `const bridge = getAccountBridge(account)` — not forward-compatible
+ *   - ✅ `const bridge = await Promise.resolve(getAccountBridge(account))` — compatible with both sync and future async forms.
+ */
 export const getAccountBridge = (
   account: AccountLike,
   parentAccount?: Account | null,


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** N/A — docs only
- [x] **Impact of the changes:**
  - LLMs and contributors reading the source code will know not to call these functions synchronously and what the correct patterns are

### 📝 Description

Adds JSDoc comments directly on `getAccountBridge` and `getCurrencyBridge` in `bridge/impl.ts` documenting the correct async-compatible usage patterns ahead of the ESM coin modules migration (dynamic `import()` replacing `require()`).

Each doc includes an explicit ❌/✅ for the async function case to make the correct pattern obvious when copying from source or via autocomplete.

### ❓ Context

- **JIRA or GitHub link**: #17155, #17245
- **ADR link (if any)**: N/A