### PR TITLE
ci(rsdoctor): don't cancel runs on push to develop/main

### DIFF
--- a/.github/workflows/rsdoctor-pr.yml
+++ b/.github/workflows/rsdoctor-pr.yml
@@ -18,8 +18,8 @@ on:
         required: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   id-token: write


### PR DESCRIPTION
### ✅ Checklist

- [ ] npx changeset was attached. _(workflow-only change, no package code)_
- [x] **Covered by automatic tests.** _(workflow-only change)_
- [x] **Impact of the changes:**
  - Rsdoctor PR workflow only — runs on push to develop/main now run to completion instead of being cancelled by the next push.

### 📝 Description

Push runs to develop/main upload the rsdoctor baseline artifacts that PR runs compare against. The previous concurrency group cancelled them on every new merge, so most commits had no baselines and PRs fell back to _No baseline data found_.

Now the group keys on github.sha for non-PR events, and cancel-in-progress is restricted to pull_request events.

### ❓ Context

- **JIRA or GitHub link**: —
- **ADR link (if any)**: —

🤖 Generated with [Claude Code](https://claude.com/claude-code)