### PR TITLE
[LWM] feat(mobile): add Swap/Receive second button in Asset Detail floating bar

### DIFF
--- a/.changeset/tender-tables-smash.md
+++ b/.changeset/tender-tables-smash.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add receive and swap button on asset details

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
@@ -2,16 +2,21 @@ import React from "react";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { render, screen } from "@tests/test-renderer";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { mockBtcCryptoCurrency } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { NavigatorName, ScreenName } from "~/const";
 import type { State } from "~/reducers/types";
 import AssetDetailNavigator from "../Navigator";
 import { ASSET_DETAIL_TEST_IDS } from "../testIds";
 
 const mockIsCurrencyAvailable = jest.fn().mockReturnValue(false);
+const mockIsAcceptedCurrency = jest.fn().mockReturnValue(false);
 
 jest.mock("@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog", () => ({
   useRampCatalog: () => ({ isCurrencyAvailable: mockIsCurrencyAvailable }),
+}));
+
+jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency", () => ({
+  useAcceptedCurrency: () => mockIsAcceptedCurrency,
 }));
 
 const Stack = createNativeStackNavigator();
@@ -32,23 +37,41 @@ function AssetDetailTestNavigator() {
   );
 }
 
-function withBtcAccounts(count: number, operationsSize = 0) {
+function withAccounts(
+  accounts: { seed: string; currencyId: string; balance?: number; operationsSize?: number }[],
+) {
   return {
     overrideInitialState: (state: State): State => ({
       ...state,
       accounts: {
         ...state.accounts,
-        active: Array.from({ length: count }, (_, i) =>
-          genAccount(`bitcoin-${i}`, { currency: mockBtcCryptoCurrency, operationsSize }),
-        ),
+        active: accounts.map(({ seed, currencyId, balance, operationsSize = 0 }) => {
+          const currency = getCryptoCurrencyById(currencyId);
+          const account = genAccount(seed, { currency, operationsSize });
+          if (balance !== undefined) {
+            account.balance = account.balance.times(0).plus(balance);
+          }
+          return account;
+        }),
       },
     }),
   };
 }
 
+function withBtcAccounts(count: number, operationsSize = 0) {
+  return withAccounts(
+    Array.from({ length: count }, (_, i) => ({
+      seed: `bitcoin-${i}`,
+      currencyId: "bitcoin",
+      operationsSize,
+    })),
+  );
+}
+
 describe("AssetDetail screen layout", () => {
   beforeEach(() => {
     mockIsCurrencyAvailable.mockReturnValue(false);
+    mockIsAcceptedCurrency.mockReturnValue(false);
   });
 
   it("renders all section placeholders and BalanceGraph", () => {
@@ -111,21 +134,97 @@ describe("AssetDetail screen layout", () => {
   });
 
   describe("floating bar CTAs", () => {
-    it("hides the floating bar when Buy is unavailable", () => {
+    it("shows Receive button when wallet has no funds (no Buy, no Swap)", () => {
       render(<AssetDetailTestNavigator />);
 
-      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.ctas)).toBeNull();
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.ctas)).toBeVisible();
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.footerReceiveButton)).toBeVisible();
+      expect(screen.getByText("Receive")).toBeVisible();
       expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.buyButton)).toBeNull();
+      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.swapButton)).toBeNull();
     });
 
-    it("renders the Buy button when Buy is available", () => {
+    it("shows Buy + Receive when Buy is available but wallet has no funds", () => {
       mockIsCurrencyAvailable.mockReturnValue(true);
 
       render(<AssetDetailTestNavigator />);
 
       expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.ctas)).toBeVisible();
       expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.buyButton)).toBeVisible();
-      expect(screen.getByText("Buy")).toBeVisible();
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.footerReceiveButton)).toBeVisible();
+      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.swapButton)).toBeNull();
+    });
+
+    it("shows Buy + Swap when Buy available and asset has funds with swap available", () => {
+      mockIsCurrencyAvailable.mockReturnValue(true);
+      mockIsAcceptedCurrency.mockReturnValue(true);
+
+      render(
+        <AssetDetailTestNavigator />,
+        withAccounts([{ seed: "btc-0", currencyId: "bitcoin", balance: 1000 }]),
+      );
+
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.ctas)).toBeVisible();
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.buyButton)).toBeVisible();
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.swapButton)).toBeVisible();
+      expect(screen.getByText("Swap")).toBeVisible();
+      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.footerReceiveButton)).toBeNull();
+    });
+
+    it("shows only Buy when wallet has funds but swap is unavailable", () => {
+      mockIsCurrencyAvailable.mockReturnValue(true);
+
+      render(
+        <AssetDetailTestNavigator />,
+        withAccounts([{ seed: "btc-0", currencyId: "bitcoin", balance: 1000 }]),
+      );
+
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.ctas)).toBeVisible();
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.buyButton)).toBeVisible();
+      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.swapButton)).toBeNull();
+      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.footerReceiveButton)).toBeNull();
+    });
+
+    it("hides the floating bar when wallet has funds, swap unavailable, and buy unavailable", () => {
+      render(
+        <AssetDetailTestNavigator />,
+        withAccounts([{ seed: "btc-0", currencyId: "bitcoin", balance: 1000 }]),
+      );
+
+      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.ctas)).toBeNull();
+    });
+
+    it("shows Swap when another asset has funds and swap is available (no Buy)", () => {
+      mockIsAcceptedCurrency.mockReturnValue(true);
+
+      render(
+        <AssetDetailTestNavigator />,
+        withAccounts([{ seed: "eth-0", currencyId: "ethereum", balance: 500 }]),
+      );
+
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.ctas)).toBeVisible();
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.swapButton)).toBeVisible();
+      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.buyButton)).toBeNull();
+    });
+
+    it("hides BalanceGraph Receive when footer shows Receive (no funds)", () => {
+      render(<AssetDetailTestNavigator />);
+
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.footerReceiveButton)).toBeVisible();
+      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.receiveButton)).toBeNull();
+    });
+
+    it("shows BalanceGraph Receive when footer shows Swap (funds elsewhere)", () => {
+      mockIsAcceptedCurrency.mockReturnValue(true);
+
+      render(
+        <AssetDetailTestNavigator />,
+        withAccounts([{ seed: "eth-0", currencyId: "ethereum", balance: 500 }]),
+      );
+
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.swapButton)).toBeVisible();
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.receiveButton)).toBeVisible();
+      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.footerReceiveButton)).toBeNull();
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
@@ -12,7 +12,6 @@ import { Addresses } from "./components/Addresses";
 import { Transactions } from "./components/Transactions";
 import { Footer } from "./components/Footer";
 import { MarketData } from "./components/MarketData";
-import { useIsBuyAvailable } from "./components/Footer/useFooterViewModel";
 import { CTAS_HEIGHT } from "./utils/constants";
 
 type Props = Readonly<{
@@ -20,11 +19,19 @@ type Props = Readonly<{
   source?: string;
   isRefreshing: boolean;
   onRefresh: () => void;
+  hasFooter: boolean;
+  hideReceiveInBalanceGraph: boolean;
 }>;
 
-export function AssetDetailView({ currency, source, isRefreshing, onRefresh }: Props) {
+export function AssetDetailView({
+  currency,
+  source,
+  isRefreshing,
+  onRefresh,
+  hasFooter,
+  hideReceiveInBalanceGraph,
+}: Props) {
   const { bottom } = useSafeAreaInsets();
-  const hasFooter = useIsBuyAvailable(currency);
   const scrollPaddingBottom = useMemo(
     () => (hasFooter ? CTAS_HEIGHT + bottom : bottom),
     [hasFooter, bottom],
@@ -39,7 +46,7 @@ export function AssetDetailView({ currency, source, isRefreshing, onRefresh }: P
         refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={onRefresh} />}
       >
         <Box lx={contentStyle}>
-          <BalanceGraph currency={currency} />
+          <BalanceGraph currency={currency} hideReceive={hideReceiveInBalanceGraph} />
           <BalanceDetails currency={currency} />
           <Addresses currency={currency} />
           <MarketData currency={currency} />

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/useBalanceGraphViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/useBalanceGraphViewModel.test.ts
@@ -196,6 +196,18 @@ describe("useBalanceGraphViewModel", () => {
 
       expect(result.current.showReceive).toBe(false);
     });
+
+    it("is false when hideReceive is true even if conditions are met", () => {
+      const { result } = renderHook(
+        () => useBalanceGraphViewModel(mockBtcCryptoCurrency, true),
+        withAccounts([
+          { currencyId: "bitcoin", balance: 0 },
+          { currencyId: "ethereum", balance: 1000 },
+        ]),
+      );
+
+      expect(result.current.showReceive).toBe(false);
+    });
   });
 
   describe("onReceivePress", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/index.tsx
@@ -3,7 +3,12 @@ import type { AssetDetailCurrencyProps } from "LLM/features/AssetDetail/types";
 import { useBalanceGraphViewModel } from "./useBalanceGraphViewModel";
 import { BalanceGraphView } from "./BalanceGraphView";
 
-export function BalanceGraph({ currency }: Readonly<{ currency: AssetDetailCurrencyProps }>) {
-  const viewModel = useBalanceGraphViewModel(currency);
+type Props = Readonly<{
+  currency?: AssetDetailCurrencyProps;
+  hideReceive?: boolean;
+}>;
+
+export function BalanceGraph({ currency, hideReceive }: Props) {
+  const viewModel = useBalanceGraphViewModel(currency, hideReceive);
   return <BalanceGraphView {...viewModel} />;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
@@ -12,7 +12,10 @@ import { parseCurrencyString } from "../../utils/currencyFormatter";
 import { RANGE_TO_PRICE_CHANGE_KEY, type RangeKey } from "../../utils/rangeMapping";
 import { useAssetMarketData } from "../../hooks/useAssetMarketData";
 
-export function useBalanceGraphViewModel(currency: AssetDetailCurrencyProps) {
+export function useBalanceGraphViewModel(
+  currency?: AssetDetailCurrencyProps,
+  hideReceive?: boolean,
+) {
   const { t } = useTranslation();
   const { locale } = useLocale();
   const { marketCurrency, counterCurrency, isLoading } = useAssetMarketData(currency);
@@ -83,11 +86,11 @@ export function useBalanceGraphViewModel(currency: AssetDetailCurrencyProps) {
   const accounts = useSelector(shallowAccountsSelector);
 
   const showReceive = useMemo(() => {
-    if (!currency) return false;
+    if (hideReceive || !currency) return false;
     const hasAssetFunds = accounts.some(a => a.currency.id === currency.id && a.balance.gt(0));
     const hasFundsElsewhere = accounts.some(a => a.currency.id !== currency.id && a.balance.gt(0));
     return !hasAssetFunds && hasFundsElsewhere;
-  }, [accounts, currency]);
+  }, [hideReceive, accounts, currency]);
 
   const { handleOpenReceiveDrawer } = useOpenReceiveDrawer({
     currency,

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/FooterView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/FooterView.tsx
@@ -3,18 +3,28 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Box, Button } from "@ledgerhq/lumen-ui-rnative";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { useTranslation } from "~/context/Locale";
+import type { SecondaryButtonType } from "./useFooterViewModel";
 import { ASSET_DETAIL_TEST_IDS } from "../../../../testIds";
 
 type Props = Readonly<{
   isBuyAvailable: boolean;
+  secondaryButton: SecondaryButtonType;
   onBuyPress: () => void;
+  onSwapPress: () => void;
+  onReceivePress: () => void;
 }>;
 
-export function FooterView({ isBuyAvailable, onBuyPress }: Props) {
+export function FooterView({
+  isBuyAvailable,
+  secondaryButton,
+  onBuyPress,
+  onSwapPress,
+  onReceivePress,
+}: Props) {
   const { bottom } = useSafeAreaInsets();
   const { t } = useTranslation();
 
-  if (!isBuyAvailable) return null;
+  if (!isBuyAvailable && !secondaryButton) return null;
 
   return (
     <Box
@@ -23,17 +33,47 @@ export function FooterView({ isBuyAvailable, onBuyPress }: Props) {
       style={{ paddingBottom: bottom + 16 }}
     >
       <Box lx={rowStyle}>
-        <Box style={buttonSlotStyle}>
-          <Button
-            appearance="gray"
-            size="lg"
-            isFull
-            onPress={onBuyPress}
-            testID={ASSET_DETAIL_TEST_IDS.buyButton}
-          >
-            {t("exchange.buy.tabTitle")}
-          </Button>
-        </Box>
+        {isBuyAvailable && (
+          <Box style={buttonSlotStyle}>
+            <Button
+              appearance="gray"
+              size="lg"
+              isFull
+              onPress={onBuyPress}
+              testID={ASSET_DETAIL_TEST_IDS.buyButton}
+            >
+              {t("exchange.buy.tabTitle")}
+            </Button>
+          </Box>
+        )}
+
+        {secondaryButton === "swap" && (
+          <Box style={buttonSlotStyle}>
+            <Button
+              appearance="base"
+              size="lg"
+              isFull
+              onPress={onSwapPress}
+              testID={ASSET_DETAIL_TEST_IDS.swapButton}
+            >
+              {t("transfer.swap.title")}
+            </Button>
+          </Box>
+        )}
+
+        {secondaryButton === "receive" && (
+          <Box style={buttonSlotStyle}>
+            <Button
+              appearance="base"
+              size="lg"
+              isFull
+              onPress={onReceivePress}
+              testID={ASSET_DETAIL_TEST_IDS.footerReceiveButton}
+            >
+              {t("transfer.receive.title")}
+            </Button>
+          </Box>
+        )}
       </Box>
     </Box>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/__tests__/useFooterViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/__tests__/useFooterViewModel.test.ts
@@ -4,14 +4,29 @@ import { track } from "~/analytics";
 import { useFooterViewModel } from "../useFooterViewModel";
 
 const mockHandleOpenBuySell = jest.fn();
+const mockHandleOpenSwap = jest.fn();
+const mockHandleOpenReceiveDrawer = jest.fn();
 const mockIsCurrencyAvailable = jest.fn();
+const mockIsAcceptedCurrency = jest.fn().mockReturnValue(true);
 
 jest.mock("@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog", () => ({
   useRampCatalog: () => ({ isCurrencyAvailable: mockIsCurrencyAvailable }),
 }));
 
+jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency", () => ({
+  useAcceptedCurrency: () => mockIsAcceptedCurrency,
+}));
+
 jest.mock("LLM/features/Buy", () => ({
   useOpenBuySell: () => ({ handleOpenBuySell: mockHandleOpenBuySell }),
+}));
+
+jest.mock("LLM/features/Swap", () => ({
+  useOpenSwap: () => ({ handleOpenSwap: mockHandleOpenSwap }),
+}));
+
+jest.mock("LLM/features/Receive", () => ({
+  useOpenReceiveDrawer: () => ({ handleOpenReceiveDrawer: mockHandleOpenReceiveDrawer }),
 }));
 
 const bitcoin = getCryptoCurrencyById("bitcoin");
@@ -24,7 +39,6 @@ describe("useFooterViewModel", () => {
   describe("isBuyAvailable", () => {
     it("returns true when the ramp catalog supports the currency", () => {
       mockIsCurrencyAvailable.mockReturnValue(true);
-
       const { result } = renderHook(() => useFooterViewModel(bitcoin));
 
       expect(result.current.isBuyAvailable).toBe(true);
@@ -33,7 +47,6 @@ describe("useFooterViewModel", () => {
 
     it("returns false when the ramp catalog does not support the currency", () => {
       mockIsCurrencyAvailable.mockReturnValue(false);
-
       const { result } = renderHook(() => useFooterViewModel(bitcoin));
 
       expect(result.current.isBuyAvailable).toBe(false);
@@ -46,10 +59,9 @@ describe("useFooterViewModel", () => {
     });
   });
 
-  describe("onBuyPress", () => {
-    it("fires tracking event and opens buy flow", () => {
+  describe("press handlers", () => {
+    it("onBuyPress fires tracking and opens buy flow", () => {
       mockIsCurrencyAvailable.mockReturnValue(true);
-
       const { result } = renderHook(() => useFooterViewModel(bitcoin));
 
       act(() => result.current.onBuyPress());
@@ -62,13 +74,41 @@ describe("useFooterViewModel", () => {
       expect(mockHandleOpenBuySell).toHaveBeenCalledWith("buy");
     });
 
-    it("does nothing when currency is undefined", () => {
-      const { result } = renderHook(() => useFooterViewModel(undefined));
+    it("onSwapPress fires tracking and opens swap flow", () => {
+      const { result } = renderHook(() => useFooterViewModel(bitcoin));
 
-      act(() => result.current.onBuyPress());
+      act(() => result.current.onSwapPress());
 
-      expect(track).not.toHaveBeenCalled();
-      expect(mockHandleOpenBuySell).not.toHaveBeenCalled();
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "swap",
+        currency: "bitcoin",
+        page: "Asset Detail",
+      });
+      expect(mockHandleOpenSwap).toHaveBeenCalled();
     });
+
+    it("onReceivePress fires tracking and opens receive flow", () => {
+      const { result } = renderHook(() => useFooterViewModel(bitcoin));
+
+      act(() => result.current.onReceivePress());
+
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "receive",
+        currency: "bitcoin",
+        page: "Asset Detail",
+      });
+      expect(mockHandleOpenReceiveDrawer).toHaveBeenCalled();
+    });
+
+    it.each(["onBuyPress", "onSwapPress", "onReceivePress"] as const)(
+      "%s does nothing when currency is undefined",
+      handler => {
+        const { result } = renderHook(() => useFooterViewModel(undefined));
+
+        act(() => result.current[handler]());
+
+        expect(track).not.toHaveBeenCalled();
+      },
+    );
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/useFooterViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/useFooterViewModel.ts
@@ -1,13 +1,37 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { useRampCatalog } from "@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog";
+import { useAcceptedCurrency } from "@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency";
+import { useSelector } from "~/context/hooks";
+import { shallowAccountsSelector } from "~/reducers/accounts";
 import { track } from "~/analytics";
 import { useOpenBuySell } from "LLM/features/Buy";
+import { useOpenSwap } from "LLM/features/Swap";
+import { useOpenReceiveDrawer } from "LLM/features/Receive";
 import type { AssetDetailCurrencyProps } from "LLM/features/AssetDetail/types";
+
+export type SecondaryButtonType = "swap" | "receive" | null;
 
 export function useIsBuyAvailable(currency: AssetDetailCurrencyProps): boolean {
   const { isCurrencyAvailable } = useRampCatalog();
 
   return !!currency && isCurrencyAvailable(currency.id, "onRamp");
+}
+
+export function useSecondaryButtonType(currency: AssetDetailCurrencyProps): SecondaryButtonType {
+  const accounts = useSelector(shallowAccountsSelector);
+  const isAcceptedCurrency = useAcceptedCurrency();
+
+  return useMemo(() => {
+    if (!currency) return null;
+
+    const walletHasFunds = accounts.some(a => a.balance.gt(0));
+
+    if (walletHasFunds) {
+      return isAcceptedCurrency(currency) ? "swap" : null;
+    }
+
+    return "receive";
+  }, [accounts, currency, isAcceptedCurrency]);
 }
 
 export function useFooterViewModel(currency: AssetDetailCurrencyProps) {
@@ -16,7 +40,18 @@ export function useFooterViewModel(currency: AssetDetailCurrencyProps) {
     sourceScreenName: "Asset Detail",
   });
 
+  const { handleOpenSwap } = useOpenSwap({
+    currency,
+    sourceScreenName: "Asset Detail",
+  });
+
+  const { handleOpenReceiveDrawer } = useOpenReceiveDrawer({
+    currency,
+    sourceScreenName: "Asset Detail",
+  });
+
   const isBuyAvailable = useIsBuyAvailable(currency);
+  const secondaryButton = useSecondaryButtonType(currency);
 
   const onBuyPress = useCallback(() => {
     if (!currency) return;
@@ -28,8 +63,31 @@ export function useFooterViewModel(currency: AssetDetailCurrencyProps) {
     handleOpenBuySell("buy");
   }, [currency, handleOpenBuySell]);
 
+  const onSwapPress = useCallback(() => {
+    if (!currency) return;
+    track("button_clicked", {
+      button: "swap",
+      currency: currency.id,
+      page: "Asset Detail",
+    });
+    handleOpenSwap();
+  }, [currency, handleOpenSwap]);
+
+  const onReceivePress = useCallback(() => {
+    if (!currency) return;
+    track("button_clicked", {
+      button: "receive",
+      currency: currency.id,
+      page: "Asset Detail",
+    });
+    handleOpenReceiveDrawer();
+  }, [currency, handleOpenReceiveDrawer]);
+
   return {
     isBuyAvailable,
+    secondaryButton,
     onBuyPress,
+    onSwapPress,
+    onReceivePress,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
@@ -4,6 +4,7 @@ import { useRoute } from "@react-navigation/native";
 import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { ScreenName } from "~/const";
 import type { AssetDetailNavigatorParamsList } from "../../types";
+import { useIsBuyAvailable, useSecondaryButtonType } from "./components/Footer/useFooterViewModel";
 
 type Route = StackNavigatorProps<AssetDetailNavigatorParamsList, ScreenName.AssetDetail>["route"];
 
@@ -18,10 +19,17 @@ export function useAssetDetailViewModel() {
     setIsRefreshing(false);
   }, []);
 
+  const isBuyAvailable = useIsBuyAvailable(currency);
+  const secondaryButton = useSecondaryButtonType(currency);
+  const hasFooter = isBuyAvailable || secondaryButton !== null;
+  const hideReceiveInBalanceGraph = secondaryButton === "receive";
+
   return {
     currency,
     source,
     isRefreshing,
     onRefresh,
+    hasFooter,
+    hideReceiveInBalanceGraph,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/testIds.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/testIds.ts
@@ -17,4 +17,6 @@ export const ASSET_DETAIL_TEST_IDS = {
   transactions: "asset-detail-transactions",
   ctas: "asset-detail-ctas",
   buyButton: "asset-detail-buy-button",
+  swapButton: "asset-detail-swap-button",
+  footerReceiveButton: "asset-detail-footer-receive-button",
 } as const;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Floating bar on the Asset Detail screen: second button rendering (Swap vs Receive)
      - Matrix logic: wallet funds state determines which button appears
      - Mutual exclusion between footer Receive and BalanceGraph Receive
      - Tracking events for Swap and Receive taps

### 📝 Description

**Problem**: The Asset Detail floating bar only had a Buy button. Users need quick access to Swap or Receive actions depending on their wallet state.

**Solution**: Implements the second button slot in the floating bar following a matrix logic:

| Wallet state | Second button |
|---|---|
| Any account has funds + Swap available | **Swap** (`appearance="base"`) |
| Any account has funds + Swap unavailable | _(absent)_ |
| No funds anywhere | **Receive** (`appearance="base"`) |

Key behaviors:
- **Swap availability gate**: if Swap is unavailable for the currency, the button is absent (not disabled)
- **Receive is always available** — no gate needed
- **Single entry point rule**: Receive never appears in both the floating bar and the BalanceGraph simultaneously. An explicit `hideReceive` guard is passed from `AssetDetailView` to `BalanceGraph`
- **Tracking**: `button_clicked` events fire with `button: "swap"` or `button: "receive"`, `currency`, and `page: "Asset Detail"`

|
<img width="350" height="750" alt="Simulator Screenshot - iOS Simulator - 2026-05-07 at 15 34 45" src="https://github.com/user-attachments/assets/b7ea3158-87d2-47b9-a1a9-d7776eada635" />
<img width="350" height="750" alt="Simulator Screenshot - iOS Simulator - 2026-05-07 at 15 23 18" src="https://github.com/user-attachments/assets/40e5bf71-1a50-48dc-ada9-7dff772e272a" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-29730](https://ledgerhq.atlassian.net/browse/LIVE-29730)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29730]: https://ledgerhq.atlassian.net/browse/LIVE-29730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ