### PR TITLE
[LWDM] feat(desktop,mobile): bump lumen and align My Wallet avatar sizes

### DIFF
--- a/.changeset/smooth-humans-yell.md
+++ b/.changeset/smooth-humans-yell.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Bump Lumen catalog packages and align My Wallet user avatar sizes

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/UserAvatar/UserAvatarView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/UserAvatar/UserAvatarView.tsx
@@ -7,7 +7,7 @@ import { UserAvatarViewProps } from "./types";
 export function UserAvatarView({
   showNotification,
   unseenCount,
-  size = "sm",
+  size = "md",
 }: UserAvatarViewProps) {
   const { t } = useTranslation();
 

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/components/MyWalletTopBarAction.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/components/MyWalletTopBarAction.tsx
@@ -30,7 +30,7 @@ export function MyWalletTopBarAction({ onPress, showNotification }: Readonly<Pro
         backgroundColor: pressed ? theme.colors.bg[pressedBackgroundColor] : undefined,
       })}
     >
-      <UserAvatar size="md" lx={{ backgroundColor }} showNotification={showNotification} />
+      <UserAvatar size="lg" lx={{ backgroundColor }} showNotification={showNotification} />
     </Pressable>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/ProfileSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/ProfileSection/index.tsx
@@ -5,7 +5,7 @@ import { UserAvatar } from "../../components/UserAvatar";
 export function ProfileSection() {
   return (
     <Box lx={{ alignItems: "center" }}>
-      <UserAvatar size="lg" />
+      <UserAvatar size="xl" />
     </Box>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,11 +58,11 @@ catalogs:
       specifier: 0.1.12
       version: 0.1.12
     '@ledgerhq/lumen-ui-react':
-      specifier: 0.1.27
-      version: 0.1.27
+      specifier: 0.1.30
+      version: 0.1.30
     '@ledgerhq/lumen-ui-rnative':
-      specifier: 0.1.26
-      version: 0.1.26
+      specifier: 0.1.29
+      version: 0.1.29
     '@ledgerhq/speculos-device-controller':
       specifier: 0.2.3
       version: 0.2.3
@@ -956,7 +956,7 @@ importers:
         version: 2.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.12)(@ledgerhq/lumen-ui-react@0.1.27(dcbfab10dcd5417d898239a9a392543b))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.12)(@ledgerhq/lumen-ui-react@0.1.30(dcbfab10dcd5417d898239a9a392543b))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/cryptoassets
@@ -1028,7 +1028,7 @@ importers:
         version: 0.1.12
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.27(dcbfab10dcd5417d898239a9a392543b)
+        version: 0.1.30(dcbfab10dcd5417d898239a9a392543b)
       '@ledgerhq/react-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/react
@@ -1612,7 +1612,7 @@ importers:
         version: 1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.12)(@ledgerhq/lumen-ui-rnative@0.1.26(aaef53925dd57879e30bd9df42ba0adb))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.12)(@ledgerhq/lumen-ui-rnative@0.1.29(aaef53925dd57879e30bd9df42ba0adb))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/cryptoassets
@@ -1696,7 +1696,7 @@ importers:
         version: 0.1.12
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.26(aaef53925dd57879e30bd9df42ba0adb)
+        version: 0.1.29(aaef53925dd57879e30bd9df42ba0adb)
       '@ledgerhq/native-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/native
@@ -2442,7 +2442,7 @@ importers:
         version: 2.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.12)(@ledgerhq/lumen-ui-react@0.1.27(dcbfab10dcd5417d898239a9a392543b))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.12)(@ledgerhq/lumen-ui-react@0.1.30(dcbfab10dcd5417d898239a9a392543b))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/cryptoassets
@@ -2499,7 +2499,7 @@ importers:
         version: 0.1.12
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.27(dcbfab10dcd5417d898239a9a392543b)
+        version: 0.1.30(dcbfab10dcd5417d898239a9a392543b)
       '@ledgerhq/react-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/react
@@ -2726,10 +2726,10 @@ importers:
         version: 0.1.12
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.27(6d5eafba7705ee38ebc0331edc563a6c)
+        version: 0.1.30(6d5eafba7705ee38ebc0331edc563a6c)
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.26(064b1549be5bc617017e6a807f28758f)
+        version: 0.1.29(064b1549be5bc617017e6a807f28758f)
       '@radix-ui/react-checkbox':
         specifier: 'catalog:'
         version: 1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -3267,10 +3267,10 @@ importers:
         version: 0.1.12
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.27(@ledgerhq/lumen-design-core@0.1.12)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
+        version: 0.1.30(@ledgerhq/lumen-design-core@0.1.12)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.26(b0cfe5fc3887fb74414e017e41293ebc)
+        version: 0.1.29(b0cfe5fc3887fb74414e017e41293ebc)
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -11665,7 +11665,7 @@ importers:
     dependencies:
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.12)(@ledgerhq/lumen-ui-rnative@0.1.26(55b33773819c0a4362e83129f56cd9b4))(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
+        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.12)(@ledgerhq/lumen-ui-rnative@0.1.29(55b33773819c0a4362e83129f56cd9b4))(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
       '@ledgerhq/icons-ui':
         specifier: workspace:^
         version: link:../icons
@@ -11732,7 +11732,7 @@ importers:
         version: 0.1.12
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.26(55b33773819c0a4362e83129f56cd9b4)
+        version: 0.1.29(55b33773819c0a4362e83129f56cd9b4)
       '@react-native-async-storage/async-storage':
         specifier: 2.1.2
         version: 2.1.2(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))
@@ -11993,7 +11993,7 @@ importers:
     dependencies:
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.12)(@ledgerhq/lumen-ui-react@0.1.27(dcbfab10dcd5417d898239a9a392543b))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.12)(@ledgerhq/lumen-ui-react@0.1.30(dcbfab10dcd5417d898239a9a392543b))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@ledgerhq/icons-ui':
         specifier: workspace:^
         version: file:libs/ui/packages/icons(@types/react@19.0.14)(react@19.0.0)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@19.0.0(react@19.0.0))(react-is@17.0.2)(react@19.0.0))(styled-system@5.1.5)
@@ -12057,7 +12057,7 @@ importers:
         version: 0.1.12
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.27(dcbfab10dcd5417d898239a9a392543b)
+        version: 0.1.30(dcbfab10dcd5417d898239a9a392543b)
       '@radix-ui/react-checkbox':
         specifier: 'catalog:'
         version: 1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -17193,11 +17193,11 @@ packages:
   '@ledgerhq/lumen-design-core@0.1.12':
     resolution: {integrity: sha512-McBfYo5jZwhkBirtSQwmVAdc/YJuO/w7pw4h2zyxU5KHQiQfEUmJdg2/0h3oTSpKdtuHCl59+QHWLHQZf3SlcA==}
 
-  '@ledgerhq/lumen-ui-react@0.1.27':
-    resolution: {integrity: sha512-K1U5eoNes2auuYxkfp/8G/YIC4ERYJEhCklpdEEGFkuHZZdUqR5l5So9qA8WYw/+fh8BBi+hinNAhZLda6aPUw==}
+  '@ledgerhq/lumen-ui-react@0.1.30':
+    resolution: {integrity: sha512-QHkU+4u5eR6yMTBMYc4dRRyVkr6Xp2gombDtOu1KlgnhvCTdmkhr8QdVLhjhpj7rVsndYIqCmS8YNCyc9u34Rg==}
     peerDependencies:
       '@base-ui/react': ^1.3.0
-      '@ledgerhq/lumen-design-core': 0.1.12
+      '@ledgerhq/lumen-design-core': 0.1.13
       '@radix-ui/react-checkbox': ^1.3.2
       '@radix-ui/react-dialog': ^1.1.15
       '@radix-ui/react-dropdown-menu': ^2.1.2
@@ -17211,11 +17211,11 @@ packages:
       react-dom: 19.0.0
       tailwind-merge: ^2.6.0
 
-  '@ledgerhq/lumen-ui-rnative@0.1.26':
-    resolution: {integrity: sha512-5X/tHk3G8RkqyZszJ0/sr3xMYl9SrifsW0RezlHSiQQuqQN+LSl+I2V2hjPns952mmOtQaxWAqT4nb0IytI3GA==}
+  '@ledgerhq/lumen-ui-rnative@0.1.29':
+    resolution: {integrity: sha512-4tm2L1w/piK59pDLmS4i6WpgCdqvP6CE2H3mqzhPZYC7VC9znaYGFkvwuBMDhQLKKctr2qGymvg9DRMr6W9IYg==}
     peerDependencies:
       '@gorhom/bottom-sheet': ^5.0.0
-      '@ledgerhq/lumen-design-core': 0.1.11
+      '@ledgerhq/lumen-design-core': 0.1.12
       '@sbaiahmed1/react-native-blur': ^4.5.5
       '@types/react': ^19.0.0
       expo: '>=53.0.0'
@@ -45861,29 +45861,29 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/crypto-icons@2.0.1(@ledgerhq/lumen-design-core@0.1.12)(@ledgerhq/lumen-ui-react@0.1.27(dcbfab10dcd5417d898239a9a392543b))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@ledgerhq/crypto-icons@2.0.1(@ledgerhq/lumen-design-core@0.1.12)(@ledgerhq/lumen-ui-react@0.1.30(dcbfab10dcd5417d898239a9a392543b))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       react: 19.0.0
     optionalDependencies:
       '@ledgerhq/lumen-design-core': 0.1.12
-      '@ledgerhq/lumen-ui-react': 0.1.27(dcbfab10dcd5417d898239a9a392543b)
+      '@ledgerhq/lumen-ui-react': 0.1.30(dcbfab10dcd5417d898239a9a392543b)
       react-dom: 19.0.0(react@19.0.0)
 
-  '@ledgerhq/crypto-icons@2.0.1(@ledgerhq/lumen-design-core@0.1.12)(@ledgerhq/lumen-ui-rnative@0.1.26(55b33773819c0a4362e83129f56cd9b4))(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)':
+  '@ledgerhq/crypto-icons@2.0.1(@ledgerhq/lumen-design-core@0.1.12)(@ledgerhq/lumen-ui-rnative@0.1.29(55b33773819c0a4362e83129f56cd9b4))(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)':
     dependencies:
       react: 19.0.0
     optionalDependencies:
       '@ledgerhq/lumen-design-core': 0.1.12
-      '@ledgerhq/lumen-ui-rnative': 0.1.26(55b33773819c0a4362e83129f56cd9b4)
+      '@ledgerhq/lumen-ui-rnative': 0.1.29(55b33773819c0a4362e83129f56cd9b4)
       react-dom: 19.0.0(react@19.0.0)
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0)
 
-  '@ledgerhq/crypto-icons@2.0.1(@ledgerhq/lumen-design-core@0.1.12)(@ledgerhq/lumen-ui-rnative@0.1.26(aaef53925dd57879e30bd9df42ba0adb))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
+  '@ledgerhq/crypto-icons@2.0.1(@ledgerhq/lumen-design-core@0.1.12)(@ledgerhq/lumen-ui-rnative@0.1.29(aaef53925dd57879e30bd9df42ba0adb))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
     dependencies:
       react: 19.0.0
     optionalDependencies:
       '@ledgerhq/lumen-design-core': 0.1.12
-      '@ledgerhq/lumen-ui-rnative': 0.1.26(aaef53925dd57879e30bd9df42ba0adb)
+      '@ledgerhq/lumen-ui-rnative': 0.1.29(aaef53925dd57879e30bd9df42ba0adb)
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
 
   '@ledgerhq/cryptoassets-evm-signatures@13.5.2':
@@ -46147,7 +46147,7 @@ snapshots:
       tailwindcss: 4.1.18
       tslib: 2.6.2
 
-  '@ledgerhq/lumen-ui-react@0.1.27(6d5eafba7705ee38ebc0331edc563a6c)':
+  '@ledgerhq/lumen-ui-react@0.1.30(6d5eafba7705ee38ebc0331edc563a6c)':
     dependencies:
       '@ledgerhq/lumen-design-core': 0.1.12
       '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
@@ -46168,7 +46168,7 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-react@0.1.27(@ledgerhq/lumen-design-core@0.1.12)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)':
+  '@ledgerhq/lumen-ui-react@0.1.30(@ledgerhq/lumen-design-core@0.1.12)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)':
     dependencies:
       '@ledgerhq/lumen-design-core': 0.1.12
       '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
@@ -46181,7 +46181,7 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-react@0.1.27(dcbfab10dcd5417d898239a9a392543b)':
+  '@ledgerhq/lumen-ui-react@0.1.30(dcbfab10dcd5417d898239a9a392543b)':
     dependencies:
       '@ledgerhq/lumen-design-core': 0.1.12
       '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
@@ -46202,7 +46202,7 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-rnative@0.1.26(064b1549be5bc617017e6a807f28758f)':
+  '@ledgerhq/lumen-ui-rnative@0.1.29(064b1549be5bc617017e6a807f28758f)':
     dependencies:
       '@gorhom/bottom-sheet': 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.1.6(react-native-worklets@0.7.2(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@ledgerhq/lumen-design-core': 0.1.12
@@ -46219,7 +46219,7 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  '@ledgerhq/lumen-ui-rnative@0.1.26(55b33773819c0a4362e83129f56cd9b4)':
+  '@ledgerhq/lumen-ui-rnative@0.1.29(55b33773819c0a4362e83129f56cd9b4)':
     dependencies:
       '@ledgerhq/lumen-design-core': 0.1.12
       '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
@@ -46235,7 +46235,7 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  '@ledgerhq/lumen-ui-rnative@0.1.26(aaef53925dd57879e30bd9df42ba0adb)':
+  '@ledgerhq/lumen-ui-rnative@0.1.29(aaef53925dd57879e30bd9df42ba0adb)':
     dependencies:
       '@gorhom/bottom-sheet': 5.2.6(beb07f7799bea5989bf46dbe8fcef3d9)
       '@ledgerhq/lumen-design-core': 0.1.12
@@ -46254,7 +46254,7 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  '@ledgerhq/lumen-ui-rnative@0.1.26(b0cfe5fc3887fb74414e017e41293ebc)':
+  '@ledgerhq/lumen-ui-rnative@0.1.29(b0cfe5fc3887fb74414e017e41293ebc)':
     dependencies:
       '@gorhom/bottom-sheet': 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.1.6(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@ledgerhq/lumen-design-core': 0.1.12

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,8 +34,8 @@ catalog:
   "@ledgerhq/device-transport-kit-web-hid": 1.2.3
   "@ledgerhq/speculos-device-controller": 0.2.3
   "@ledgerhq/lumen-design-core": 0.1.12
-  "@ledgerhq/lumen-ui-react": 0.1.27
-  "@ledgerhq/lumen-ui-rnative": 0.1.26
+  "@ledgerhq/lumen-ui-react": 0.1.30
+  "@ledgerhq/lumen-ui-rnative": 0.1.29
   "@ledgerhq/zcash-utils": 0.2.0
   # React Native
   react-native: 0.79.7


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Visual sizing and catalog bump; no new unit tests._
- [x] **Impact of the changes:**
  - Desktop My Wallet top bar and context menu user avatars (`UserAvatar` sizes)
  - Mobile My Wallet top bar entry and profile section avatar
  - Lumen workspace catalog versions (`@ledgerhq/lumen-design-core`, `@ledgerhq/lumen-ui-react`, `@ledgerhq/lumen-ui-rnative`) and lockfile

### 📝 Description

After updating Lumen packages in the workspace catalog, My Wallet avatar tokens did not match the intended layout across desktop and mobile.

This change bumps those Lumen dependencies and aligns `UserAvatar` sizes: desktop defaults/context use `md`, top bar uses `lg`; mobile top bar uses `lg` and profile uses `xl`.

### 📸 Screenshots

| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30404](https://ledgerhq.atlassian.net/browse/LIVE-30404)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30404]: https://ledgerhq.atlassian.net/browse/LIVE-30404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ