### PR TITLE
test(desktop): simplify portfolio e2e setup

### DIFF
--- a/e2e/desktop/tests/page/portfolio.page.ts
+++ b/e2e/desktop/tests/page/portfolio.page.ts
@@ -155,6 +155,13 @@ export class PortfolioPage extends AppPage {
     await expect(this.portfolioTotalBalance).toContainText(counterValue);
   }
 
+  @step("Expect total balance to be zero")
+  async expectTotalBalanceToBeZero() {
+    await expect(this.portfolioTotalBalance).toBeVisible();
+    // DisplayAmount animation pollutes textContent with hidden digits; aria-label keeps the clean amount.
+    await expect(this.portfolioTotalBalance).toHaveAttribute("aria-label", "$ 0.00");
+  }
+
   @step("Expect balance diff to display the correct counter value $0")
   async expectBalanceDiffCounterValue(counterValue: string) {
     await expect(this.portfolioTrendPercentage).toBeVisible();

--- a/e2e/desktop/tests/specs/portfolio.spec.ts
+++ b/e2e/desktop/tests/specs/portfolio.spec.ts
@@ -2,8 +2,6 @@ import { test } from "tests/fixtures/common";
 import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
-import { Currency } from "@ledgerhq/live-common/e2e/enum/Currency";
-import { CLI } from "tests/utils/cliUtils";
 import { LWD_WALLET_40_FF_DISABLED, LWD_WALLET_40_FF_ENABLED } from "tests/utils/featureFlagUtils";
 
 // Skipping this suite as legacy is not visible on prod anymore
@@ -40,7 +38,6 @@ test.describe("Portfolio Wallet 4.0 - Zero balance state", () => {
   test.use({
     teamOwner: Team.WALLET_XP,
     userdata: "skip-onboarding-with-last-seen-device",
-    // to-do remove when wallet 4.0 is default
     featureFlags: LWD_WALLET_40_FF_ENABLED,
   });
 
@@ -73,27 +70,14 @@ test.describe("Portfolio Wallet 4.0 - Zero balance state", () => {
 });
 
 test.describe("Portfolio Wallet 4.0 - With Account", () => {
-  const currency = Currency.BTC;
   test.use({
     teamOwner: Team.WALLET_XP,
-    userdata: "skip-onboarding-with-last-seen-device",
-    speculosApp: currency.speculosApp,
-    cliCommands: [
-      (userdataPath?: string) => {
-        return CLI.liveData({
-          currency: currency.id,
-          index: 0,
-          add: true,
-          appjson: userdataPath,
-        });
-      },
-    ],
-    // to-do remove when wallet 4.0 is default
+    userdata: "1AccountBTC1AccountETH",
     featureFlags: LWD_WALLET_40_FF_ENABLED,
   });
 
   test(
-    "Portfolio happy path: zero balance state, add account, then verify balance and analytics",
+    "Portfolio happy path: with account, then verify balance and analytics",
     {
       tag: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"],
       annotation: {
@@ -108,7 +92,7 @@ test.describe("Portfolio Wallet 4.0 - With Account", () => {
       await app.portfolio.checkSellButtonEnabled();
       await app.portfolio.checkSendButtonEnabled();
 
-      await app.portfolio.expectTotalBalanceCounterValue("0");
+      await app.portfolio.expectBalanceVisibility();
       await app.portfolio.checkOneDayPerformanceIndicatorVisibility();
       await app.portfolio.clickOnPerformancePill();
       await app.analytics.expectAnalyticsScreenToBeVisible();
@@ -122,7 +106,6 @@ test.describe("Portfolio Wallet 4.0 - No seen device (Reborn mode)", () => {
   test.use({
     teamOwner: Team.WALLET_XP,
     userdata: "skip-onboarding",
-    // to-do remove when wallet 4.0 is default
     featureFlags: LWD_WALLET_40_FF_ENABLED,
   });
 

--- a/e2e/desktop/tests/specs/portfolio.spec.ts
+++ b/e2e/desktop/tests/specs/portfolio.spec.ts
@@ -37,11 +37,9 @@ test.describe.skip("Portfolio - legacy", () => {
 });
 
 test.describe("Portfolio Wallet 4.0 - Zero balance state", () => {
-  const currency = Currency.BTC;
   test.use({
     teamOwner: Team.WALLET_XP,
     userdata: "skip-onboarding-with-last-seen-device",
-    speculosApp: currency.speculosApp,
     // to-do remove when wallet 4.0 is default
     featureFlags: LWD_WALLET_40_FF_ENABLED,
   });

--- a/e2e/desktop/tests/specs/portfolio.spec.ts
+++ b/e2e/desktop/tests/specs/portfolio.spec.ts
@@ -47,8 +47,7 @@ test.describe("Portfolio Wallet 4.0 - Zero balance state", () => {
       tag: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"],
       annotation: {
         type: "TMS",
-        description:
-          "B2CQA-4343, B2CQA-4350, B2CQA-4351, B2CQA-4347, B2CQA-4339, B2CQA-4340, B2CQA-4342",
+        description: "B2CQA-4343",
       },
     },
     async ({ app }) => {
@@ -82,8 +81,7 @@ test.describe("Portfolio Wallet 4.0 - With Account", () => {
       tag: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"],
       annotation: {
         type: "TMS",
-        description:
-          "B2CQA-4343, B2CQA-4350, B2CQA-4351, B2CQA-4347, B2CQA-4339, B2CQA-4340, B2CQA-4345",
+        description: "B2CQA-4350, B2CQA-4340, B2CQA-4342, B2CQA-4345",
       },
     },
     async ({ app }) => {
@@ -100,6 +98,33 @@ test.describe("Portfolio Wallet 4.0 - With Account", () => {
       await app.analytics.expectAnalyticsScreenToBeVisible();
       await app.analytics.clickBackButton();
       await app.portfolio.expectPortfolioScreenToBeVisible();
+    },
+  );
+});
+
+test.describe("Portfolio Wallet 4.0 - With Funds", () => {
+  test.use({
+    teamOwner: Team.WALLET_XP,
+    userdata: "1AccountBTC1AccountETH",
+    featureFlags: LWD_WALLET_40_FF_ENABLED,
+  });
+
+  test(
+    "Portfolio happy path: with funds, then verify balance and quick actions",
+    {
+      tag: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"],
+      annotation: {
+        type: "TMS",
+        description: "B2CQA-4347, B2CQA-4339",
+      },
+    },
+    async ({ app }) => {
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+
+      await app.portfolio.checkSellButtonEnabled();
+      await app.portfolio.checkSendButtonEnabled();
+      await app.portfolio.expectBalanceVisibility();
+      await app.portfolio.checkOneDayPerformanceIndicatorVisibility();
     },
   );
 });

--- a/e2e/desktop/tests/specs/portfolio.spec.ts
+++ b/e2e/desktop/tests/specs/portfolio.spec.ts
@@ -72,12 +72,12 @@ test.describe("Portfolio Wallet 4.0 - Zero balance state", () => {
 test.describe("Portfolio Wallet 4.0 - With Account", () => {
   test.use({
     teamOwner: Team.WALLET_XP,
-    userdata: "1AccountBTC1AccountETH",
+    userdata: "1AccountSOL0Balance",
     featureFlags: LWD_WALLET_40_FF_ENABLED,
   });
 
   test(
-    "Portfolio happy path: with account, then verify balance and analytics",
+    "Portfolio happy path: with zero-balance account, then verify balance and analytics",
     {
       tag: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"],
       annotation: {
@@ -89,10 +89,12 @@ test.describe("Portfolio Wallet 4.0 - With Account", () => {
     async ({ app }) => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
-      await app.portfolio.checkSellButtonEnabled();
-      await app.portfolio.checkSendButtonEnabled();
+      await app.portfolio.checkReceiveButtonVisibility();
+      await app.portfolio.checkBuyButtonVisibility();
+      await app.portfolio.checkSellButtonDisabled();
+      await app.portfolio.checkSendButtonDisabled();
 
-      await app.portfolio.expectBalanceVisibility();
+      await app.portfolio.expectTotalBalanceToBeZero();
       await app.portfolio.checkOneDayPerformanceIndicatorVisibility();
       await app.portfolio.clickOnPerformancePill();
       await app.analytics.expectAnalyticsScreenToBeVisible();

--- a/e2e/desktop/tests/userdata/1AccountSOL0Balance.json
+++ b/e2e/desktop/tests/userdata/1AccountSOL0Balance.json
@@ -1,0 +1,229 @@
+{
+  "data": {
+    "PLAYWRIGHT_RUN": {
+      "localStorage": {
+        "acceptedTermsVersion": "2042-01-01"
+      }
+    },
+    "settings": {
+      "hasCompletedOnboarding": true,
+      "counterValue": "USD",
+      "language": "en",
+      "locale": "en-US",
+      "theme": null,
+      "region": null,
+      "orderAccounts": "balance|desc",
+      "countervalueFirst": false,
+      "autoLockTimeout": 10,
+      "selectedTimeRange": "month",
+      "currenciesSettings": {},
+      "pairExchanges": {},
+      "developerMode": false,
+      "loaded": true,
+      "shareAnalytics": false,
+      "sharePersonalizedRecommandations": false,
+      "hasSeenAnalyticsOptInPrompt": true,
+      "sentryLogs": true,
+      "lastUsedVersion": "99.99.99",
+      "dismissedBanners": [],
+      "accountsViewMode": "list",
+      "showAccountsHelperBanner": true,
+      "hideEmptyTokenAccounts": false,
+      "filterTokenOperationsZeroAmount": true,
+      "sidebarCollapsed": false,
+      "discreetMode": false,
+      "preferredDeviceModel": "stax",
+      "hasInstalledApps": true,
+      "lastSeenDevice": {
+        "modelId": "stax",
+        "deviceInfo": {
+          "version": "1.9.1",
+          "mcuVersion": "5.31.3",
+          "seVersion": "1.9.1",
+          "majMin": "1.9.1",
+          "providerName": null,
+          "targetId": 857735172,
+          "hasDevFirmware": false,
+          "seTargetId": 857735172,
+          "isOSU": false,
+          "isBootloader": false,
+          "isRecoveryMode": false,
+          "managerAllowed": true,
+          "pinValidated": true,
+          "onboarded": true,
+          "bootloaderVersion": "4.55.3",
+          "hardwareVersion": 0,
+          "languageId": 0,
+          "seFlags": {
+            "0": 238,
+            "1": 0,
+            "2": 0,
+            "3": 0
+          }
+        },
+        "apps": []
+      },
+      "mevProtection": true,
+      "devicesModelList": ["stax"],
+      "lastSeenCustomImage": {
+        "size": 0,
+        "hash": ""
+      },
+      "latestFirmware": {
+        "osu": {
+          "id": 1091,
+          "perso": "perso_11",
+          "firmware": "stax/1.10.0/fw_1.9.1/upgrade_osu_1.10.0",
+          "firmware_key": "stax/1.10.0/fw_1.9.1/upgrade_osu_1.10.0_key",
+          "hash": "",
+          "next_se_firmware_final_version": 559,
+          "name": "",
+          "date_creation": "",
+          "date_last_modified": "",
+          "device_versions": [],
+          "providers": [],
+          "previous_se_firmware_final_version": []
+        },
+        "final": {
+          "id": 559,
+          "name": "1.10.0",
+          "version": "1.10.0",
+          "perso": "perso_11",
+          "firmware": "",
+          "firmware_key": "",
+          "hash": "",
+          "bytes": 494080,
+          "mcu_versions": [245],
+          "se_firmware": 0,
+          "date_creation": "",
+          "date_last_modified": "",
+          "device_versions": [],
+          "application_versions": [],
+          "osu_versions": [],
+          "providers": []
+        },
+        "shouldFlashMCU": true
+      },
+      "blacklistedTokenIds": [],
+      "deepLinkUrl": null,
+      "firstTimeLend": false,
+      "showClearCacheBanner": false,
+      "allowDebugApps": false,
+      "allowReactQueryDebug": false,
+      "allowExperimentalApps": false,
+      "enablePlatformDevTools": false,
+      "catalogProvider": "production",
+      "enableLearnPageStagingUrl": false,
+      "swap": {
+        "hasAcceptedIPSharing": false,
+        "acceptedProviders": [],
+        "selectableCurrencies": []
+      },
+      "overriddenFeatureFlags": {},
+      "featureFlagsButtonVisible": false,
+      "vaultSigner": {
+        "enabled": false,
+        "host": "",
+        "token": "",
+        "workspace": ""
+      },
+      "supportedCounterValues": [],
+      "dismissedContentCards": {},
+      "anonymousBrazeId": "anonymous_id_10",
+      "starredMarketCoins": [],
+      "hasBeenUpsoldRecover": true,
+      "hasBeenRedirectedToPostOnboarding": true,
+      "onboardingUseCase": null,
+      "lastOnboardedDevice": {
+        "deviceId": "",
+        "modelId": "stax",
+        "wired": false
+      },
+      "alwaysShowMemoTagInfo": true,
+      "anonymousUserNotifications": {},
+      "hasSeenWalletV4Tour": true,
+      "doNotAskAgainSkipMemo": false,
+      "deprecationDoNotRemind": []
+    },
+    "accounts": [
+      {
+        "data": {
+          "id": "js:2:solana:fF5MNTvjSTomYN1CdC5NgeNj1hK7kSczvJqkSTaDzKu:solanaSub",
+          "seedIdentifier": "3LxBt1bxrv2GXy43gpq5sbewy1bewxP4yArPqJnh2ZAe",
+          "used": false,
+          "derivationMode": "solanaSub",
+          "index": 0,
+          "freshAddress": "fF5MNTvjSTomYN1CdC5NgeNj1hK7kSczvJqkSTaDzKu",
+          "freshAddressPath": "44'/501'/0'",
+          "blockHeight": 419019196,
+          "creationDate": "2026-05-11T10:04:28.237Z",
+          "operationsCount": 0,
+          "operations": [],
+          "pendingOperations": [],
+          "currencyId": "solana",
+          "balance": "0",
+          "spendableBalance": "0",
+          "balanceHistoryCache": {
+            "HOUR": {
+              "latestDate": 1778493600000,
+              "balances": []
+            },
+            "DAY": {
+              "latestDate": 1778450400000,
+              "balances": []
+            },
+            "WEEK": {
+              "latestDate": 1778364000000,
+              "balances": []
+            }
+          },
+          "subAccounts": [],
+          "solanaResources": {
+            "stakes": "[]",
+            "unstakeReserve": "0"
+          },
+          "swapHistory": [],
+          "nfts": [],
+          "name": "Solana 1",
+          "starred": false
+        },
+        "version": 1
+      }
+    ],
+    "countervalues": {},
+    "postOnboarding": {
+      "deviceModelId": "stax",
+      "walletEntryPointDismissed": false,
+      "entryPointFirstDisplayedDate": "2026-05-11T10:01:39.965Z",
+      "walletEntryPointEligibleForPortfolio": null,
+      "actionsToComplete": ["assetsTransfer", "buyCrypto", "syncAccounts", "customImage"],
+      "actionsCompleted": {
+        "assetsTransfer": false,
+        "buyCrypto": false,
+        "syncAccounts": false,
+        "customImage": false
+      },
+      "lastActionCompleted": null,
+      "postOnboardingInProgress": true
+    },
+    "wallet": {
+      "walletSyncState": {
+        "data": null,
+        "version": 0
+      },
+      "nonImportedAccountInfos": [],
+      "accountsData": {
+        "accountNames": [],
+        "starredAccountIds": []
+      },
+      "recentAddresses": {}
+    },
+    "identities": {
+      "userId": "08cf3393-c5eb-4ea7-92de-0deea22e3971",
+      "datadogId": "4d0922a5-fed4-429c-b711-34b50f7917a7",
+      "deviceIds": ["e108d2a253aef4919c7647dd1082943573afd3003f5c9499ac77d6082dc51125"],
+      "pushDevicesSyncState": "unsynced",
+      "pushDevicesServiceUrl": null
+    }
+  }
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] No changeset required (E2E-only test cleanup).
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Desktop portfolio E2E coverage
  - Wallet 4.0 portfolio account-present scenario
  - Speculos usage in portfolio tests

### 📝 Description

This PR addresses the portfolio E2E cleanup requested in QAA-1104 by removing unnecessary Speculos setup from the Wallet 4.0 account-present portfolio test.

The test now reuses the existing `1AccountBTC1AccountETH` app.json userdata fixture instead of starting Speculos and generating account data through `CLI.liveData`. The assertion was adjusted to validate that the balance is visible for seeded account state, and stale local Wallet 4.0 TODO comments were removed.

### ✅ CI

- **Desktop E2E targeted run**: [specs/portfolio.spec.ts](https://github.com/LedgerHQ/ledger-live/actions/runs/25500533932)

### ❓ Context

- **JIRA or GitHub link**: [QAA-1104](https://ledgerhq.atlassian.net/browse/QAA-1104)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-1104]: https://ledgerhq.atlassian.net/browse/QAA-1104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ