### PR TITLE
[LWDM] feat(lwm): add known devices slice

### DIFF
--- a/.changeset/known-devices-slice.md
+++ b/.changeset/known-devices-slice.md
@@ -1,0 +1,7 @@
+---
+"live-mobile": minor
+"@ledgerhq/live-dmk-mobile": minor
+"@ledgerhq/live-dmk-shared": minor
+---
+
+Add a persisted all-transport known devices slice for Ledger Live Mobile.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -253,6 +253,8 @@ apps/ledger-live-mobile/src/components/RequiresLocation/           @ledgerhq/liv
 apps/ledger-live-mobile/src/components/SelectDevice2/              @ledgerhq/live-devices
 apps/ledger-live-mobile/src/components/BleDevicePairingFlow/       @ledgerhq/live-devices
 **/BleDevicePairing*                                               @ledgerhq/live-devices
+apps/ledger-live-mobile/src/reducers/knownDevices.ts               @ledgerhq/live-devices
+apps/ledger-live-mobile/src/reducers/__tests__/knownDevices.test.ts @ledgerhq/live-devices
 apps/ledger-live-mobile/src/transport/                             @ledgerhq/live-devices
 apps/ledger-live-mobile/src/react-native-hw-transport-ble/         @ledgerhq/live-devices
 apps/ledger-live-mobile/src/screens/FirmwareUpdate/                @ledgerhq/live-devices

--- a/apps/ledger-live-mobile/e2e/bridge/client.ts
+++ b/apps/ledger-live-mobile/e2e/bridge/client.ts
@@ -7,7 +7,12 @@ import { setOverride, setAllOverrides, featureFlagsOverridesSelector } from "@sh
 import { importStore as importAccountsRaw } from "~/actions/accounts";
 import { acceptGeneralTerms } from "~/logic/terms";
 import { navigate } from "~/rootnavigation";
-import { addKnownDevice, importBle, removeKnownDevice, removeKnownDevices } from "~/actions/ble";
+import {
+  addKnownBleDevice,
+  importBle,
+  removeKnownBleDevice,
+  removeKnownBleDevices,
+} from "~/actions/ble";
 import { LaunchArguments } from "react-native-launch-arguments";
 import { DeviceEventEmitter } from "react-native";
 import logReport from "../../src/log-report";
@@ -161,7 +166,7 @@ async function onMessage(event: WebSocketMessageEvent) {
           .map(device => device.id)
           .filter(id => id.startsWith("speculos|"));
         if (knownSpeculosIds.length) {
-          store.dispatch(removeKnownDevices(knownSpeculosIds));
+          store.dispatch(removeKnownBleDevices(knownSpeculosIds));
         }
         store.dispatch(
           setLastConnectedDevice({
@@ -172,7 +177,7 @@ async function onMessage(event: WebSocketMessageEvent) {
           }),
         );
         store.dispatch(
-          addKnownDevice({
+          addKnownBleDevice({
             id: `speculos|${address}`,
             name: `${address}`,
             modelId: model,
@@ -184,7 +189,7 @@ async function onMessage(event: WebSocketMessageEvent) {
       case "removeKnownSpeculos": {
         const address = msg.payload;
         await disconnectAllSpeculosSessions();
-        store.dispatch(removeKnownDevice(`speculos|${address}`));
+        store.dispatch(removeKnownBleDevice(`speculos|${address}`));
         setEnv("DEVICE_PROXY_URL", "");
         break;
       }

--- a/apps/ledger-live-mobile/src/actions/ble.ts
+++ b/apps/ledger-live-mobile/src/actions/ble.ts
@@ -9,17 +9,19 @@ import type {
 } from "./types";
 import { BleActionTypes } from "./types";
 
-export const removeKnownDevice = createAction<BleRemoveKnownDevicePayload>(
+export const removeKnownBleDevice = createAction<BleRemoveKnownDevicePayload>(
   BleActionTypes.BLE_REMOVE_DEVICE,
 );
-export const removeKnownDevices = createAction<BleRemoveKnownDevicesPayload>(
+export const removeKnownBleDevices = createAction<BleRemoveKnownDevicesPayload>(
   BleActionTypes.BLE_REMOVE_DEVICES,
 );
-export const addKnownDevice = createAction<BleAddKnownDevicePayload>(BleActionTypes.BLE_ADD_DEVICE);
+export const addKnownBleDevice = createAction<BleAddKnownDevicePayload>(
+  BleActionTypes.BLE_ADD_DEVICE,
+);
 export const importBle = createAction<BleImportBlePayload>(BleActionTypes.BLE_IMPORT);
 export const saveBleDeviceName = createAction<BleSaveDeviceNamePayload>(
   BleActionTypes.BLE_SAVE_DEVICE_NAME,
 );
-export const updateKnownDevice = createAction<BleUpdateKnownDevicePayload>(
+export const updateKnownBleDevice = createAction<BleUpdateKnownDevicePayload>(
   BleActionTypes.BLE_UPDATE_DEVICE,
 );

--- a/apps/ledger-live-mobile/src/components/BleDevicePairingFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/components/BleDevicePairingFlow/index.tsx
@@ -4,7 +4,8 @@ import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { DiscoveredDevice } from "@ledgerhq/device-management-kit";
 
 import RequiresBLE from "../RequiresBLE";
-import { addKnownDevice } from "~/actions/ble";
+import { addKnownBleDevice } from "~/actions/ble";
+import { addKnownDevice, mapDeviceToKnownDevice } from "~/reducers/knownDevices";
 import type { BleDevicesScanningProps } from "./BleDevicesScanning";
 import { track } from "~/analytics";
 import { NavigationHeaderBackButton } from "../NavigationHeaderBackButton";
@@ -155,12 +156,13 @@ const BleDevicePairingFlow: React.FC<BleDevicePairingFlowProps> = ({
 
       if (onPairingSuccessAddToKnownDevices) {
         dispatchRedux(
-          addKnownDevice({
+          addKnownBleDevice({
             id: device.deviceId,
             name: device.deviceName ?? device.modelId,
             modelId: device.modelId,
           }),
         );
+        dispatchRedux(addKnownDevice(mapDeviceToKnownDevice(device)));
       }
     },
     [dispatchRedux, onPairingSuccessAddToKnownDevices],

--- a/apps/ledger-live-mobile/src/components/DBSave.ts
+++ b/apps/ledger-live-mobile/src/components/DBSave.ts
@@ -15,6 +15,7 @@ import {
   saveFeatureFlagsState,
   saveHistory,
   saveIdentities,
+  saveKnownDevices,
   saveLargeMoverState,
   saveMarketState,
   savePostOnboardingState,
@@ -25,6 +26,7 @@ import {
 import { exportSelector as accountsExportSelector } from "~/reducers/accounts";
 import { countervaluesStateSelector } from "~/reducers/countervalues";
 import { exportSelector as bleSelector } from "~/reducers/ble";
+import { exportSelector as knownDevicesExportSelector } from "~/reducers/knownDevices";
 import { exportLargeMoverSelector } from "~/reducers/largeMover";
 import { exportMarketSelector } from "~/reducers/market";
 import { settingsStoreSelector } from "~/reducers/settings";
@@ -166,6 +168,7 @@ const accountsDbSaveSliceSelector = createSelector(
   (accounts, wallet) => ({ accounts, wallet }),
 );
 const bleNotEquals = (a: State, b: State) => a.ble !== b.ble;
+const knownDevicesNotEquals = (a: State, b: State) => a.knownDevices !== b.knownDevices;
 
 const getPostOnboardingStateChanged = (a: State, b: State) =>
   !isEqual(a.postOnboarding, b.postOnboarding);
@@ -231,6 +234,14 @@ export const ConfigureDBSaveEffects = () => {
     throttle: 500,
     getChangesStats: bleNotEquals,
     lense: bleSelector,
+  });
+  useDBSaveEffect({
+    stateSelector: (state: State) => state.knownDevices,
+    save: saveKnownDevices,
+    throttle: 500,
+    getChangesStats: knownDevicesNotEquals,
+    lense: knownDevicesExportSelector,
+    saveAtStart: true,
   });
   useDBSaveEffect({
     stateSelector: (state: State) => state.postOnboarding,

--- a/apps/ledger-live-mobile/src/components/SelectDevice2/RemoveDeviceMenu.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice2/RemoveDeviceMenu.tsx
@@ -8,7 +8,8 @@ import { Flex } from "@ledgerhq/native-ui";
 import Button from "../Button";
 import Trash from "~/icons/Trash";
 import QueuedDrawer from "~/components/QueuedDrawer";
-import { removeKnownDevice } from "~/actions/ble";
+import { removeKnownBleDevice } from "~/actions/ble";
+import { removeKnownDevice } from "~/reducers/knownDevices";
 import { DeviceIllustration } from "~/components/DeviceIllustration";
 
 const RemoveDeviceMenu = ({
@@ -24,6 +25,7 @@ const RemoveDeviceMenu = ({
 
   const onRemoveDevice = useCallback(async () => {
     dispatch(removeKnownDevice(device.deviceId));
+    dispatch(removeKnownBleDevice(device.deviceId));
     onHideMenu();
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     await disconnect(device.deviceId).catch(() => {});

--- a/apps/ledger-live-mobile/src/components/SelectDevice2/index.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice2/index.tsx
@@ -13,7 +13,12 @@ import { TrackScreen, track } from "~/analytics";
 import { NavigatorName, ScreenName } from "~/const";
 import { bleDevicesSelector } from "~/reducers/ble";
 import Touchable from "../Touchable";
-import { saveBleDeviceName, updateKnownDevice } from "~/actions/ble";
+import { saveBleDeviceName, updateKnownBleDevice } from "~/actions/ble";
+import {
+  mapDiscoveredDeviceToKnownDevice,
+  saveKnownDeviceName,
+  updateKnownDevice,
+} from "~/reducers/knownDevices";
 import { setHasConnectedDevice, updateMainNavigatorVisibility } from "~/actions/appstate";
 import { setLastConnectedDevice, setReadOnlyMode } from "~/actions/settings";
 import { BaseComposite, StackNavigatorProps } from "../RootNavigator/types/helpers";
@@ -206,9 +211,10 @@ export default function SelectDevice({
       dispatch(setHasConnectedDevice(true));
       onSelect(device, discoveredDevice);
       dispatch(setReadOnlyMode(false));
+      dispatch(updateKnownDevice(mapDiscoveredDeviceToKnownDevice(discoveredDevice)));
       if (!device.wired) {
         dispatch(
-          updateKnownDevice({
+          updateKnownBleDevice({
             id: device.deviceId,
             name: device.deviceName ?? "",
             modelId: device.modelId,
@@ -421,6 +427,12 @@ export default function SelectDevice({
       ) {
         dispatch(
           saveBleDeviceName({
+            deviceId: knownDevice.id,
+            name: equivalentScannedDevice?.deviceName,
+          }),
+        );
+        dispatch(
+          saveKnownDeviceName({
             deviceId: knownDevice.id,
             name: equivalentScannedDevice?.deviceName,
           }),

--- a/apps/ledger-live-mobile/src/context/LedgerStore.tsx
+++ b/apps/ledger-live-mobile/src/context/LedgerStore.tsx
@@ -22,6 +22,7 @@ import {
   getSettings,
   getBle,
   getHistory,
+  getKnownDevices,
   getPostOnboardingState,
   getProtect,
   getMarketState,
@@ -34,6 +35,7 @@ import {
 import { importSettings, setSupportedCounterValues } from "~/actions/settings";
 import { importStore as importAccountsRaw } from "~/actions/accounts";
 import { importBle } from "~/actions/ble";
+import { importKnownDevices } from "~/reducers/knownDevices";
 import { updateProtectData, updateProtectStatus } from "~/actions/protect";
 import { INITIAL_STATE as settingsState } from "~/reducers/settings";
 import { listCachedCurrencyIds, hydrateCurrency } from "~/bridge/cache";
@@ -89,6 +91,7 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
       mmkvStorageWrapper.monitor(true);
       const [
         bleData,
+        persistedKnownDevices,
         settingsData,
         accountsData,
         postOnboardingState,
@@ -105,6 +108,7 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
         historyState,
       ] = await Promise.all([
         retry(getBle, MAX_RETRIES, RETRY_DELAY),
+        retry(getKnownDevices, MAX_RETRIES, RETRY_DELAY),
         retry(getSettings, MAX_RETRIES, RETRY_DELAY),
         retry(getAccounts, MAX_RETRIES, RETRY_DELAY),
         retry(getPostOnboardingState, MAX_RETRIES, RETRY_DELAY),
@@ -127,6 +131,9 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
       });
 
       store.dispatch(importBle(bleData));
+      if (persistedKnownDevices) {
+        store.dispatch(importKnownDevices(persistedKnownDevices));
+      }
 
       store.dispatch(importSettings(settingsData));
 

--- a/apps/ledger-live-mobile/src/db.ts
+++ b/apps/ledger-live-mobile/src/db.ts
@@ -18,6 +18,11 @@ import type {
   SettingsState,
 } from "./reducers/types";
 import type { HistoryState } from "./reducers/history";
+import {
+  mapPersistedKnownDeviceToKnownDevice,
+  type KnownDevicesState,
+  type PersistedKnownDevicesState,
+} from "./reducers/knownDevices";
 import type { FeatureFlagsState } from "@shared/feature-flags";
 import { TrustchainStore } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { ExportedWalletState } from "@ledgerhq/live-wallet/store";
@@ -100,6 +105,23 @@ export function getHistory(): Promise<HistoryState | null> {
 }
 export async function saveHistory(obj: HistoryState): Promise<void> {
   await storage.save("history", obj);
+}
+export async function getKnownDevices(): Promise<KnownDevicesState | null> {
+  const persistedKnownDevices = await storage.get<PersistedKnownDevicesState>("knownDevices");
+
+  if (!persistedKnownDevices || Array.isArray(persistedKnownDevices)) {
+    return null;
+  }
+
+  return {
+    knownDevices: persistedKnownDevices.knownDevices.flatMap(device => {
+      const knownDevice = mapPersistedKnownDeviceToKnownDevice(device);
+      return knownDevice ? [knownDevice] : [];
+    }),
+  };
+}
+export async function saveKnownDevices(obj: PersistedKnownDevicesState): Promise<void> {
+  await storage.save("knownDevices", obj);
 }
 
 const formatAccountDBKey = (id: string): string => `${ACCOUNTS_DB_PREFIX}${id}`;

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/__tests__/useDeviceSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/__tests__/useDeviceSectionViewModel.test.ts
@@ -19,6 +19,8 @@ jest.mock("@react-navigation/native", () => ({
 }));
 
 jest.mock("@ledgerhq/live-dmk-mobile", () => ({
+  rnBleTransportIdentifier: "react-native-ble",
+  rnHidTransportIdentifier: "react-native-hid",
   findMatchingNewDevice: jest.fn(() => null),
   useBleDevicesScanning: jest.fn(() => ({ scannedDevices: [] })),
 }));
@@ -39,6 +41,17 @@ const withKnownDevice = (state: State): State => ({
   ble: {
     ...state.ble,
     knownDevices: [{ id: "device-1", name: "Flex Pro", modelId: DeviceModelId.europa }],
+  },
+  knownDevices: {
+    ...state.knownDevices,
+    knownDevices: [
+      {
+        id: "device-1",
+        name: "Flex Pro",
+        deviceModelId: DeviceModelId.europa,
+        transport: "react-native-ble",
+      },
+    ],
   },
 });
 
@@ -218,6 +231,7 @@ describe("useDeviceSectionViewModel", () => {
       expect(result.current.isRemoveDrawerOpen).toBe(false);
       expect(result.current.deviceToRemove).toBeNull();
       expect(store.getState().ble.knownDevices).toEqual([]);
+      expect(store.getState().knownDevices.knownDevices).toEqual([]);
     });
 
     it("should do nothing when no device is selected", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/useDeviceSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/useDeviceSectionViewModel.ts
@@ -10,7 +10,8 @@ import type { Result } from "@ledgerhq/live-common/hw/actions/manager";
 import { findMatchingNewDevice, useBleDevicesScanning } from "@ledgerhq/live-dmk-mobile";
 import { useDispatch, useSelector } from "~/context/hooks";
 import { bleDevicesSelector } from "~/reducers/ble";
-import { removeKnownDevice } from "~/actions/ble";
+import { removeKnownBleDevice } from "~/actions/ble";
+import { removeKnownDevice } from "~/reducers/knownDevices";
 import { NavigatorName, ScreenName } from "~/const";
 import { urls } from "~/utils/urls";
 import { track } from "~/analytics";
@@ -120,6 +121,7 @@ export const useDeviceSectionViewModel = (): DeviceSectionViewModel => {
   const onRemoveDevice = useCallback(async () => {
     if (!deviceToRemove) return;
     dispatch(removeKnownDevice(deviceToRemove.id));
+    dispatch(removeKnownBleDevice(deviceToRemove.id));
     setIsRemoveDrawerOpen(false);
     try {
       await disconnect(deviceToRemove.id);

--- a/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/components/FirstStepSyncOnboarding/useFirstStepSyncOnboardingViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/components/FirstStepSyncOnboarding/useFirstStepSyncOnboardingViewModel.test.ts
@@ -38,6 +38,8 @@ jest.mock("@ledgerhq/live-common/onboarding/hooks/useOnboardingStatePolling", ()
 }));
 
 jest.mock("@ledgerhq/live-dmk-mobile", () => ({
+  rnBleTransportIdentifier: "react-native-ble",
+  rnHidTransportIdentifier: "react-native-hid",
   isAllowedOnboardingStatePollingErrorDmk: () => true,
 }));
 
@@ -61,7 +63,7 @@ jest.mock("~/actions/settings", () => ({
 }));
 
 jest.mock("~/actions/ble", () => ({
-  addKnownDevice: jest.fn((payload: unknown) => ({ type: "addKnownDevice", payload })),
+  addKnownBleDevice: jest.fn((payload: unknown) => ({ type: "addKnownBleDevice", payload })),
 }));
 
 const mockT = jest.fn(
@@ -232,17 +234,28 @@ describe("useFirstStepSyncOnboardingViewModel", () => {
 
     const { setIsReborn, setLastConnectedDevice, setOnboardingHasDevice } =
       jest.requireMock("~/actions/settings");
-    const { addKnownDevice } = jest.requireMock("~/actions/ble");
+    const { addKnownBleDevice } = jest.requireMock("~/actions/ble");
 
     expect(props.setIsPollingOn).toHaveBeenCalledWith(false);
     expect(setIsReborn).toHaveBeenCalledWith(false);
     expect(setOnboardingHasDevice).toHaveBeenCalledWith(true);
     expect(setLastConnectedDevice).toHaveBeenCalledWith(device);
-    expect(addKnownDevice).toHaveBeenCalledWith(
+    expect(addKnownBleDevice).toHaveBeenCalledWith(
       expect.objectContaining({
         id: "device-1",
         name: "My Ledger",
         modelId: "Europa",
+      }),
+    );
+    expect(dispatchRedux).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "knownDevices/addKnownDevice",
+        payload: expect.objectContaining({
+          id: "device-1",
+          name: "My Ledger",
+          deviceModelId: "Europa",
+          transport: "react-native-ble",
+        }),
       }),
     );
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/components/FirstStepSyncOnboarding/useFirstStepSyncOnboardingViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/components/FirstStepSyncOnboarding/useFirstStepSyncOnboardingViewModel.ts
@@ -15,7 +15,7 @@ import {
 import { useOnboardingStatePolling } from "@ledgerhq/live-common/onboarding/hooks/useOnboardingStatePolling";
 import { isAllowedOnboardingStatePollingErrorDmk } from "@ledgerhq/live-dmk-mobile";
 import { SeedPhraseType } from "@ledgerhq/types-live";
-import { addKnownDevice } from "~/actions/ble";
+import { addKnownBleDevice } from "~/actions/ble";
 import { setIsReborn, setLastConnectedDevice, setOnboardingHasDevice } from "~/actions/settings";
 import { useDispatch, useSelector } from "~/context/hooks";
 import { useTranslation } from "~/context/Locale";
@@ -31,6 +31,7 @@ import { screen } from "~/analytics";
 import { useTrackOnboardingFlow } from "~/analytics/hooks/useTrackOnboardingFlow";
 import { HOOKS_TRACKING_LOCATIONS } from "~/analytics/hooks/variables";
 import { SeedPathStatus, UseFirstStepSyncOnboardingViewModelProps } from "./types";
+import { addKnownDevice, mapDeviceToKnownDevice } from "~/reducers/knownDevices";
 
 const POLLING_PERIOD_MS = 1000;
 const OPACITY_DURATION = 400;
@@ -177,13 +178,16 @@ export const useFirstStepSyncOnboardingViewModel = ({
    */
   const addToKnownDevices = useCallback(() => {
     dispatchRedux(setLastConnectedDevice(device));
-    dispatchRedux(
-      addKnownDevice({
-        id: device.deviceId,
-        name: device.deviceName ?? device.modelId,
-        modelId: device.modelId,
-      }),
-    );
+    dispatchRedux(addKnownDevice(mapDeviceToKnownDevice(device)));
+    if (!device.wired) {
+      dispatchRedux(
+        addKnownBleDevice({
+          id: device.deviceId,
+          name: device.deviceName ?? device.modelId,
+          modelId: device.modelId,
+        }),
+      );
+    }
   }, [device, dispatchRedux]);
 
   const handleNextStep = useCallback(() => {

--- a/apps/ledger-live-mobile/src/reducers/__tests__/knownDevices.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/__tests__/knownDevices.test.ts
@@ -1,0 +1,545 @@
+import { rnBleTransportIdentifier, rnHidTransportIdentifier } from "@ledgerhq/live-dmk-mobile";
+import {
+  DeviceModelId as DMKDeviceModelId,
+  type DiscoveredDevice,
+} from "@ledgerhq/device-management-kit";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { importBle } from "~/actions/ble";
+import rootReducer from "../index";
+import reducer, {
+  INITIAL_STATE,
+  addKnownDevice,
+  exportSelector,
+  importKnownDevices,
+  knownDevicesSelector,
+  mapBleDeviceToKnownDevice,
+  mapDeviceToKnownDevice,
+  mapDiscoveredDeviceToKnownDevice,
+  mapKnownDeviceToPersistedKnownDevice,
+  mapPersistedKnownDeviceToKnownDevice,
+  type PersistedKnownDevice,
+  removeKnownDevice,
+  removeKnownDevices,
+  saveKnownDeviceName,
+  updateKnownDevice,
+} from "../knownDevices";
+
+jest.mock("@ledgerhq/live-dmk-mobile", () => ({
+  ...jest.requireActual("@ledgerhq/live-dmk-mobile"),
+  rnBleTransportIdentifier: "react-native-ble",
+  rnHidTransportIdentifier: "react-native-hid",
+}));
+
+describe("knownDevices reducer", () => {
+  const nanoX = {
+    id: "ble-id",
+    name: "Ledger Nano X 123A",
+    deviceModelId: DeviceModelId.nanoX,
+    transport: rnBleTransportIdentifier,
+  };
+
+  const flex = {
+    id: "usb-id",
+    name: "Ledger Flex",
+    deviceModelId: DeviceModelId.europa,
+    transport: rnHidTransportIdentifier,
+  };
+
+  const discoveredNanoX: DiscoveredDevice = {
+    id: "discovered-ble-id",
+    name: "Discovered Nano X",
+    deviceModel: {
+      id: DMKDeviceModelId.NANO_X,
+      model: DMKDeviceModelId.NANO_X,
+      name: "Ledger Nano X",
+    },
+    transport: rnBleTransportIdentifier,
+  };
+
+  describe("initialization", () => {
+    it("GIVEN no previous state WHEN the reducer initializes THEN it returns the initial state", () => {
+      // GIVEN
+      const state = undefined;
+
+      // WHEN
+      const nextState = reducer(state, { type: "@@INIT" });
+
+      // THEN
+      expect(nextState).toEqual(INITIAL_STATE);
+    });
+  });
+
+  describe("importKnownDevices", () => {
+    it("GIVEN persisted known devices WHEN importing them THEN it replaces the slice state", () => {
+      // GIVEN
+      const state = INITIAL_STATE;
+      const knownDevices = [nanoX];
+
+      // WHEN
+      const nextState = reducer(state, importKnownDevices({ knownDevices }));
+
+      // THEN
+      expect(nextState.knownDevices).toEqual(knownDevices);
+    });
+  });
+
+  describe("addKnownDevice", () => {
+    it("GIVEN no known devices WHEN adding a known device THEN it appends the device", () => {
+      // GIVEN
+      const state = INITIAL_STATE;
+
+      // WHEN
+      const nextState = reducer(state, addKnownDevice(nanoX));
+
+      // THEN
+      expect(nextState.knownDevices).toEqual([nanoX]);
+    });
+
+    it("GIVEN existing known devices WHEN adding a known device with an existing id THEN it replaces the device without changing order", () => {
+      // GIVEN
+      const state = { knownDevices: [flex, nanoX] };
+      const updatedDevice = {
+        ...nanoX,
+        name: "Custom Nano X",
+      };
+
+      // WHEN
+      const nextState = reducer(state, addKnownDevice(updatedDevice));
+
+      // THEN
+      expect(nextState.knownDevices).toEqual([flex, updatedDevice]);
+    });
+  });
+
+  describe("updateKnownDevice", () => {
+    it("GIVEN an existing known device WHEN updating a matching device THEN it updates the existing entry", () => {
+      // GIVEN
+      const state = { knownDevices: [flex, nanoX] };
+      const updatedDevice = {
+        ...nanoX,
+        id: "new-ble-id",
+        name: "123A",
+      };
+
+      // WHEN
+      const nextState = reducer(state, updateKnownDevice(updatedDevice));
+
+      // THEN
+      expect(nextState.knownDevices).toEqual([flex, updatedDevice]);
+    });
+
+    it("GIVEN no matching known device WHEN updating a device THEN it appends the device", () => {
+      // GIVEN
+      const state = { knownDevices: [flex] };
+
+      // WHEN
+      const nextState = reducer(state, updateKnownDevice(nanoX));
+
+      // THEN
+      expect(nextState.knownDevices).toEqual([flex, nanoX]);
+    });
+  });
+
+  describe("removeKnownDevice", () => {
+    it("GIVEN multiple known devices WHEN removing one known device THEN it removes only the matching device", () => {
+      // GIVEN
+      const state = { knownDevices: [nanoX, flex] };
+
+      // WHEN
+      const nextState = reducer(state, removeKnownDevice("ble-id"));
+
+      // THEN
+      expect(nextState.knownDevices).toEqual([flex]);
+    });
+  });
+
+  describe("removeKnownDevices", () => {
+    it("GIVEN multiple known devices WHEN removing several known devices THEN it removes all matching devices", () => {
+      // GIVEN
+      const state = { knownDevices: [nanoX, flex] };
+
+      // WHEN
+      const nextState = reducer(state, removeKnownDevices(["ble-id", "usb-id"]));
+
+      // THEN
+      expect(nextState.knownDevices).toEqual([]);
+    });
+  });
+
+  describe("saveKnownDeviceName", () => {
+    it("GIVEN multiple known devices WHEN saving a device name THEN it renames only the matching device", () => {
+      // GIVEN
+      const state = { knownDevices: [nanoX, flex] };
+
+      // WHEN
+      const nextState = reducer(
+        state,
+        saveKnownDeviceName({ deviceId: "ble-id", name: "Renamed" }),
+      );
+
+      // THEN
+      expect(nextState.knownDevices).toEqual([{ ...nanoX, name: "Renamed" }, flex]);
+    });
+  });
+
+  describe("BLE_IMPORT extra reducer", () => {
+    it("GIVEN an empty known devices state WHEN importing legacy BLE devices THEN it initializes known devices", () => {
+      // GIVEN
+      const state = INITIAL_STATE;
+      const action = importBle({
+        knownDevices: [{ id: "legacy-ble-id", name: "Legacy", modelId: DeviceModelId.nanoX }],
+      });
+
+      // WHEN
+      const nextState = reducer(state, action);
+
+      // THEN
+      expect(nextState.knownDevices).toEqual([
+        {
+          id: "legacy-ble-id",
+          name: "Legacy",
+          deviceModelId: DeviceModelId.nanoX,
+          transport: rnBleTransportIdentifier,
+        },
+      ]);
+    });
+
+    it("GIVEN an empty known devices state WHEN importing no legacy BLE devices THEN it keeps known devices empty", () => {
+      // GIVEN
+      const state = INITIAL_STATE;
+      const action = importBle({ knownDevices: [] });
+
+      // WHEN
+      const nextState = reducer(state, action);
+
+      // THEN
+      expect(nextState.knownDevices).toEqual([]);
+    });
+
+    it("GIVEN existing known devices WHEN importing legacy BLE devices THEN it keeps the existing known devices", () => {
+      // GIVEN
+      const state = { knownDevices: [flex] };
+      const action = importBle({
+        knownDevices: [{ id: "legacy-ble-id", name: "Legacy", modelId: DeviceModelId.nanoX }],
+      });
+
+      // WHEN
+      const nextState = reducer(state, action);
+
+      // THEN
+      expect(nextState.knownDevices).toEqual([flex]);
+    });
+  });
+
+  describe("mapDeviceToKnownDevice", () => {
+    it("GIVEN an unwired selected device WHEN mapping it THEN it returns a BLE known device", () => {
+      // GIVEN
+      const device = {
+        deviceId: "ble-id",
+        deviceName: "BLE Ledger",
+        modelId: DeviceModelId.nanoX,
+        wired: false,
+      };
+
+      // WHEN
+      const knownDevice = mapDeviceToKnownDevice(device);
+
+      // THEN
+      expect(knownDevice).toEqual({
+        id: "ble-id",
+        name: "BLE Ledger",
+        deviceModelId: DeviceModelId.nanoX,
+        transport: rnBleTransportIdentifier,
+      });
+    });
+
+    it("GIVEN a wired selected device WHEN mapping it THEN it returns a HID known device", () => {
+      // GIVEN
+      const device = {
+        deviceId: "usb-id",
+        deviceName: "USB Ledger",
+        modelId: DeviceModelId.europa,
+        wired: true,
+      };
+
+      // WHEN
+      const knownDevice = mapDeviceToKnownDevice(device);
+
+      // THEN
+      expect(knownDevice).toEqual({
+        id: "usb-id",
+        name: "USB Ledger",
+        deviceModelId: DeviceModelId.europa,
+        transport: rnHidTransportIdentifier,
+      });
+    });
+
+    it("GIVEN a selected device without a name WHEN mapping it THEN it uses a null name", () => {
+      // GIVEN
+      const device = {
+        deviceId: "ble-id",
+        modelId: DeviceModelId.nanoX,
+        wired: false,
+      };
+
+      // WHEN
+      const knownDevice = mapDeviceToKnownDevice(device);
+
+      // THEN
+      expect(knownDevice).toEqual({
+        id: "ble-id",
+        name: null,
+        deviceModelId: DeviceModelId.nanoX,
+        transport: rnBleTransportIdentifier,
+      });
+    });
+  });
+
+  describe("mapDiscoveredDeviceToKnownDevice", () => {
+    it("GIVEN a discovered device WHEN mapping it THEN it keeps the DMK transport", () => {
+      // GIVEN
+      const device = discoveredNanoX;
+
+      // WHEN
+      const knownDevice = mapDiscoveredDeviceToKnownDevice(device);
+
+      // THEN
+      expect(knownDevice).toEqual({
+        id: "discovered-ble-id",
+        name: "Discovered Nano X",
+        deviceModelId: DeviceModelId.nanoX,
+        transport: rnBleTransportIdentifier,
+      });
+    });
+
+    it("GIVEN a discovered debug device WHEN mapping it THEN it keeps the debug transport", () => {
+      // GIVEN
+      const device = {
+        ...discoveredNanoX,
+        id: "httpdebug|ws://127.0.0.1:8435",
+        name: "Debug proxy",
+        transport: "httpdebug",
+      };
+
+      // WHEN
+      const knownDevice = mapDiscoveredDeviceToKnownDevice(device);
+
+      // THEN
+      expect(knownDevice).toEqual({
+        id: "httpdebug|ws://127.0.0.1:8435",
+        name: "Debug proxy",
+        deviceModelId: DeviceModelId.nanoX,
+        transport: "httpdebug",
+      });
+    });
+  });
+
+  describe("mapBleDeviceToKnownDevice", () => {
+    it("GIVEN a legacy BLE device WHEN mapping it THEN it returns a BLE known device", () => {
+      // GIVEN
+      const device = {
+        id: "legacy-ble-id",
+        name: "Legacy",
+        modelId: DeviceModelId.nanoX,
+      };
+
+      // WHEN
+      const knownDevice = mapBleDeviceToKnownDevice(device);
+
+      // THEN
+      expect(knownDevice).toEqual({
+        id: "legacy-ble-id",
+        name: "Legacy",
+        deviceModelId: DeviceModelId.nanoX,
+        transport: rnBleTransportIdentifier,
+      });
+    });
+  });
+
+  describe("mapKnownDeviceToPersistedKnownDevice", () => {
+    it("GIVEN a BLE known device WHEN persisting it THEN it uses the persisted BLE transport name", () => {
+      // GIVEN
+      const device = nanoX;
+
+      // WHEN
+      const persistedDevice = mapKnownDeviceToPersistedKnownDevice(device);
+
+      // THEN
+      expect(persistedDevice).toEqual({
+        ...nanoX,
+        transport: "rnble",
+      });
+    });
+
+    it("GIVEN a HID known device WHEN persisting it THEN it uses the persisted HID transport name", () => {
+      // GIVEN
+      const device = flex;
+
+      // WHEN
+      const persistedDevice = mapKnownDeviceToPersistedKnownDevice(device);
+
+      // THEN
+      expect(persistedDevice).toEqual({
+        ...flex,
+        transport: "rnhid",
+      });
+    });
+
+    it("GIVEN an unsupported transport known device WHEN persisting it THEN it returns null", () => {
+      // GIVEN
+      const device = mapDiscoveredDeviceToKnownDevice({
+        ...discoveredNanoX,
+        id: "httpdebug|ws://127.0.0.1:8435",
+        name: "Debug proxy",
+        transport: "httpdebug",
+      });
+
+      // WHEN
+      const persistedDevice = mapKnownDeviceToPersistedKnownDevice(device);
+
+      // THEN
+      expect(persistedDevice).toBeNull();
+    });
+  });
+
+  describe("mapPersistedKnownDeviceToKnownDevice", () => {
+    it("GIVEN a persisted BLE known device WHEN hydrating it THEN it uses the runtime BLE transport identifier", () => {
+      // GIVEN
+      const device: PersistedKnownDevice = {
+        id: "persisted-ble-id",
+        name: "Persisted BLE",
+        deviceModelId: DeviceModelId.nanoX,
+        transport: "rnble",
+      };
+
+      // WHEN
+      const knownDevice = mapPersistedKnownDeviceToKnownDevice(device);
+
+      // THEN
+      expect(knownDevice).toEqual({
+        id: "persisted-ble-id",
+        name: "Persisted BLE",
+        deviceModelId: DeviceModelId.nanoX,
+        transport: rnBleTransportIdentifier,
+      });
+    });
+
+    it("GIVEN a persisted HID known device WHEN hydrating it THEN it uses the runtime HID transport identifier", () => {
+      // GIVEN
+      const device: PersistedKnownDevice = {
+        id: "persisted-hid-id",
+        name: "Persisted HID",
+        deviceModelId: DeviceModelId.europa,
+        transport: "rnhid",
+      };
+
+      // WHEN
+      const knownDevice = mapPersistedKnownDeviceToKnownDevice(device);
+
+      // THEN
+      expect(knownDevice).toEqual({
+        id: "persisted-hid-id",
+        name: "Persisted HID",
+        deviceModelId: DeviceModelId.europa,
+        transport: rnHidTransportIdentifier,
+      });
+    });
+
+    it("GIVEN an unsupported persisted transport WHEN hydrating it THEN it returns null", () => {
+      // GIVEN
+      const device = {
+        id: "persisted-unsupported-id",
+        name: "Persisted unsupported",
+        deviceModelId: DeviceModelId.nanoX,
+        transport: "unsupported",
+      };
+
+      // WHEN
+      const knownDevice = mapPersistedKnownDeviceToKnownDevice(device);
+
+      // THEN
+      expect(knownDevice).toBeNull();
+    });
+  });
+
+  describe("exportSelector", () => {
+    it("GIVEN supported runtime transports WHEN exporting known devices THEN it persists transport names", () => {
+      // GIVEN
+      const rootState = {
+        ...rootReducer(undefined, { type: "@@INIT" }),
+        knownDevices: { knownDevices: [nanoX, flex] },
+      };
+
+      // WHEN
+      const persistedState = exportSelector(rootState);
+
+      // THEN
+      expect(persistedState).toEqual({
+        knownDevices: [
+          {
+            ...nanoX,
+            transport: "rnble",
+          },
+          {
+            ...flex,
+            transport: "rnhid",
+          },
+        ],
+      });
+    });
+
+    it("GIVEN unsupported runtime transports WHEN exporting known devices THEN it excludes unsupported devices", () => {
+      // GIVEN
+      const rootState = {
+        ...rootReducer(undefined, { type: "@@INIT" }),
+        knownDevices: {
+          knownDevices: [
+            nanoX,
+            {
+              id: "httpdebug|ws://127.0.0.1:8435",
+              name: "Debug proxy",
+              deviceModelId: DeviceModelId.nanoX,
+              transport: "httpdebug",
+            },
+            {
+              id: "speculos|http://127.0.0.1:5000",
+              name: "Speculos",
+              deviceModelId: DeviceModelId.nanoX,
+              transport: "speculos",
+            },
+          ],
+        },
+      };
+
+      // WHEN
+      const persistedState = exportSelector(rootState);
+
+      // THEN
+      expect(persistedState).toEqual({
+        knownDevices: [
+          {
+            ...nanoX,
+            transport: "rnble",
+          },
+        ],
+      });
+    });
+  });
+
+  describe("knownDevicesSelector", () => {
+    it("GIVEN known devices in the slice WHEN selecting known devices THEN it returns the device list", () => {
+      // GIVEN
+      const slice = { knownDevices: [nanoX, flex] };
+      const rootState = {
+        ...rootReducer(undefined, { type: "@@INIT" }),
+        knownDevices: slice,
+      };
+
+      // WHEN
+      const knownDevices = knownDevicesSelector(rootState);
+
+      // THEN
+      expect(knownDevices).toBe(slice.knownDevices);
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/reducers/index.ts
+++ b/apps/ledger-live-mobile/src/reducers/index.ts
@@ -13,6 +13,7 @@ import dynamicContent from "./dynamicContent";
 import earn from "./earn";
 import history from "./history";
 import inView from "./inView";
+import knownDevices from "./knownDevices";
 import largeMover from "./largeMover";
 import market from "./market";
 import modularDrawer from "./modularDrawer";
@@ -52,6 +53,7 @@ const appReducer = combineReducers({
   history,
   identities: identitiesSlice.reducer,
   inView,
+  knownDevices,
   largeMover,
   market,
   modularDrawer,

--- a/apps/ledger-live-mobile/src/reducers/knownDevices.ts
+++ b/apps/ledger-live-mobile/src/reducers/knownDevices.ts
@@ -1,0 +1,205 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import type { DiscoveredDevice } from "@ledgerhq/device-management-kit";
+import type { Device } from "@ledgerhq/live-common/hw/actions/types";
+import {
+  rnBleTransportIdentifier,
+  rnHidTransportIdentifier,
+  type DeviceBaseInfo,
+  findMatchingOldDevice,
+} from "@ledgerhq/live-dmk-mobile";
+import { dmkToLedgerDeviceIdMap, type KnownDevice } from "@ledgerhq/live-dmk-shared";
+import type { BleImportBlePayload, BleSaveDeviceNamePayload } from "~/actions/types";
+import { BleActionTypes } from "~/actions/types";
+import type { DeviceLike, State } from "~/reducers/types";
+
+export type KnownDevicesState = {
+  knownDevices: KnownDevice[];
+};
+
+export type PersistedKnownDeviceTransport = "rnble" | "rnhid";
+
+export type PersistedKnownDevice = Omit<KnownDevice, "transport"> & {
+  transport: PersistedKnownDeviceTransport;
+};
+
+export type PersistedKnownDevicesState = {
+  knownDevices: PersistedKnownDevice[];
+};
+
+export const INITIAL_STATE: KnownDevicesState = {
+  knownDevices: [],
+};
+
+function mapKnownDeviceToDeviceBaseInfo(device: KnownDevice): DeviceBaseInfo {
+  return {
+    deviceId: device.id,
+    deviceName: device.name,
+    modelId: device.deviceModelId,
+  };
+}
+
+export function mapBleDeviceToKnownDevice(device: DeviceLike): KnownDevice {
+  return {
+    transport: rnBleTransportIdentifier,
+    deviceModelId: device.modelId,
+    id: device.id,
+    name: device.name,
+  };
+}
+
+export function mapDeviceToKnownDevice(device: Device): KnownDevice {
+  return {
+    transport: device.wired ? rnHidTransportIdentifier : rnBleTransportIdentifier,
+    deviceModelId: device.modelId,
+    id: device.deviceId,
+    name: device.deviceName ?? null,
+  };
+}
+
+export function mapDiscoveredDeviceToKnownDevice(device: DiscoveredDevice): KnownDevice {
+  return {
+    transport: device.transport,
+    deviceModelId: dmkToLedgerDeviceIdMap[device.deviceModel.model],
+    id: device.id,
+    name: device.name,
+  };
+}
+
+export function mapKnownDeviceToPersistedKnownDevice(
+  device: KnownDevice,
+): PersistedKnownDevice | null {
+  if (device.transport === rnBleTransportIdentifier) {
+    return {
+      ...device,
+      transport: "rnble",
+    };
+  }
+
+  if (device.transport === rnHidTransportIdentifier) {
+    return {
+      ...device,
+      transport: "rnhid",
+    };
+  }
+
+  return null;
+}
+
+export function mapPersistedKnownDeviceToKnownDevice(
+  device: Omit<KnownDevice, "transport"> & { transport: string },
+): KnownDevice | null {
+  if (device.transport === "rnble") {
+    return {
+      ...device,
+      transport: rnBleTransportIdentifier,
+    };
+  }
+
+  if (device.transport === "rnhid") {
+    return {
+      ...device,
+      transport: rnHidTransportIdentifier,
+    };
+  }
+
+  return null;
+}
+
+function upsertKnownDevice(state: KnownDevicesState, device: KnownDevice) {
+  const existingDeviceIndex = state.knownDevices.findIndex(d => d.id === device.id);
+
+  if (existingDeviceIndex === -1) {
+    state.knownDevices.push({ ...device });
+    return;
+  }
+
+  state.knownDevices[existingDeviceIndex] = { ...device };
+}
+
+function findMatchingKnownDevice(
+  newDevice: KnownDevice,
+  knownDevices: KnownDevice[],
+): KnownDevice | null {
+  const oldDevicesForTransport = knownDevices.filter(
+    device => device.transport === newDevice.transport,
+  );
+  const matchingOldDevice = findMatchingOldDevice(
+    mapKnownDeviceToDeviceBaseInfo(newDevice),
+    oldDevicesForTransport.map(mapKnownDeviceToDeviceBaseInfo),
+  );
+
+  return (
+    (matchingOldDevice &&
+      oldDevicesForTransport.find(device => device.id === matchingOldDevice.deviceId)) ??
+    null
+  );
+}
+
+const knownDevicesSlice = createSlice({
+  name: "knownDevices",
+  initialState: INITIAL_STATE,
+  reducers: {
+    importKnownDevices: (_state, action: PayloadAction<KnownDevicesState>) => action.payload,
+    addKnownDevice: (state, action: PayloadAction<KnownDevice>) => {
+      upsertKnownDevice(state, action.payload);
+    },
+    updateKnownDevice: (state, action: PayloadAction<KnownDevice>) => {
+      const newDevice = action.payload;
+      const deviceToUpdate = findMatchingKnownDevice(newDevice, state.knownDevices);
+
+      if (!deviceToUpdate) {
+        upsertKnownDevice(state, newDevice);
+        return;
+      }
+
+      state.knownDevices = state.knownDevices.map(device =>
+        device.id === deviceToUpdate.id ? { ...device, ...newDevice } : device,
+      );
+    },
+    removeKnownDevice: (state, action: PayloadAction<string>) => {
+      state.knownDevices = state.knownDevices.filter(device => device.id !== action.payload);
+    },
+    removeKnownDevices: (state, action: PayloadAction<string[]>) => {
+      state.knownDevices = state.knownDevices.filter(device => !action.payload.includes(device.id));
+    },
+    saveKnownDeviceName: (state, action: PayloadAction<BleSaveDeviceNamePayload>) => {
+      const { deviceId, name } = action.payload;
+      state.knownDevices = state.knownDevices.map(device =>
+        device.id === deviceId ? { ...device, name } : device,
+      );
+    },
+  },
+  extraReducers: builder => {
+    builder.addMatcher(
+      (action): action is PayloadAction<BleImportBlePayload> =>
+        action.type === BleActionTypes.BLE_IMPORT,
+      (state, action) => {
+        const payload = action.payload;
+        if (state.knownDevices.length > 0 || !payload?.knownDevices?.length) {
+          return;
+        }
+
+        state.knownDevices = payload.knownDevices.map(mapBleDeviceToKnownDevice);
+      },
+    );
+  },
+});
+
+export const {
+  importKnownDevices,
+  addKnownDevice,
+  updateKnownDevice,
+  removeKnownDevice,
+  removeKnownDevices,
+  saveKnownDeviceName,
+} = knownDevicesSlice.actions;
+
+export const exportSelector = (state: State): PersistedKnownDevicesState => ({
+  knownDevices: state.knownDevices.knownDevices.flatMap(device => {
+    const persistedDevice = mapKnownDeviceToPersistedKnownDevice(device);
+    return persistedDevice ? [persistedDevice] : [];
+  }),
+});
+export const knownDevicesSelector = (state: State) => state.knownDevices.knownDevices;
+
+export default knownDevicesSlice.reducer;

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -39,6 +39,7 @@ import type { PortfolioBalanceDisplayState } from "./portfolioBalanceDisplay";
 import type { HistoryState } from "./history";
 import type { RecoverStateSliceState } from "./recoverState";
 import type { LiveAppModalState } from "./liveAppModal";
+import type { KnownDevicesState } from "./knownDevices";
 
 // === ACCOUNT STATE ===
 
@@ -415,6 +416,7 @@ export type State = LLMRTKApiState & {
   history: HistoryState;
   identities: IdentitiesState;
   inView: InViewState;
+  knownDevices: KnownDevicesState;
   largeMover: LargeMoverState;
   market: MarketState;
   modularDrawer: ModularDrawerState;

--- a/apps/ledger-live-mobile/src/screens/EditDeviceName.tsx
+++ b/apps/ledger-live-mobile/src/screens/EditDeviceName.tsx
@@ -13,6 +13,7 @@ import TranslatedError from "~/components/TranslatedError";
 import DeviceActionModal from "~/components/DeviceActionModal";
 import KeyboardView from "~/components/KeyboardView";
 import { saveBleDeviceName } from "~/actions/ble";
+import { saveKnownDeviceName } from "~/reducers/knownDevices";
 import { RootComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { ScreenName } from "~/const";
@@ -24,6 +25,7 @@ import { useToastsActions } from "~/actions/toast";
 
 const mapDispatchToProps = {
   saveBleDeviceName,
+  saveKnownDeviceName,
 };
 
 type NavigationProps = RootComposite<
@@ -32,9 +34,10 @@ type NavigationProps = RootComposite<
 >;
 type Props = {
   saveBleDeviceName: ({ deviceId, name }: BleSaveDeviceNamePayload) => void;
+  saveKnownDeviceName: ({ deviceId, name }: BleSaveDeviceNamePayload) => void;
 } & NavigationProps;
 
-function EditDeviceName({ navigation, route, saveBleDeviceName }: Props) {
+function EditDeviceName({ navigation, route, saveBleDeviceName, saveKnownDeviceName }: Props) {
   const action = useRenameDeviceAction();
   const originalName = route.params?.deviceName;
   const device = route.params?.device;
@@ -89,6 +92,7 @@ function EditDeviceName({ navigation, route, saveBleDeviceName }: Props) {
     setCompleted(true);
     setRunning(false);
     saveBleDeviceName({ deviceId: device.deviceId, name });
+    saveKnownDeviceName({ deviceId: device.deviceId, name });
     onNameChange(name);
 
     pushToast({
@@ -99,7 +103,16 @@ function EditDeviceName({ navigation, route, saveBleDeviceName }: Props) {
     });
 
     navigation.goBack();
-  }, [device.deviceId, name, navigation, onNameChange, pushToast, saveBleDeviceName, t]);
+  }, [
+    device.deviceId,
+    name,
+    navigation,
+    onNameChange,
+    pushToast,
+    saveBleDeviceName,
+    saveKnownDeviceName,
+    t,
+  ]);
 
   const onClose = useCallback(() => {
     if (completed) {

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Configuration/ResetOnboardingStateRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Configuration/ResetOnboardingStateRow.tsx
@@ -12,12 +12,14 @@ import {
 } from "~/actions/settings";
 import { reboot } from "~/actions/appstate";
 import { bleDevicesSelector } from "~/reducers/ble";
-import { removeKnownDevices } from "~/actions/ble";
+import { removeKnownBleDevices } from "~/actions/ble";
+import { knownDevicesSelector, removeKnownDevices } from "~/reducers/knownDevices";
 import { useUnacceptGeneralTerms } from "~/logic/terms";
 
 export default function ResetOnboardingStateRow() {
   const dispatch = useDispatch();
-  const knownDevices = useSelector(bleDevicesSelector);
+  const knownBleDevices = useSelector(bleDevicesSelector);
+  const knownDevices = useSelector(knownDevicesSelector);
   const unacceptGeneralTerms = useUnacceptGeneralTerms();
   return (
     <SettingsRow
@@ -28,6 +30,7 @@ export default function ResetOnboardingStateRow() {
         dispatch(setReadOnlyMode(true));
         dispatch(setHasOrderedNano(false));
         dispatch(completeOnboarding(false));
+        dispatch(removeKnownBleDevices(knownBleDevices.map(d => d.id)));
         dispatch(removeKnownDevices(knownDevices.map(d => d.id)));
         dispatch(setHasBeenUpsoldProtect(false));
         dispatch(setHasBeenRedirectedToPostOnboarding(false));

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Connectivity/DebugHttpTransport.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Connectivity/DebugHttpTransport.tsx
@@ -6,7 +6,7 @@ import { useNavigation } from "@react-navigation/native";
 
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
-import { addKnownDevice } from "~/actions/ble";
+import { addKnownBleDevice } from "~/actions/ble";
 import TextInput from "~/components/TextInput";
 import Button from "~/components/Button";
 import NavigationScrollView from "~/components/NavigationScrollView";
@@ -34,7 +34,7 @@ const DebugHttpTransport = () => {
     if (!port) port = "8435";
 
     dispatch(
-      addKnownDevice({
+      addKnownBleDevice({
         id: `httpdebug|ws://${ip}:${port}`,
         name: name || address,
         modelId: model,

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/SyncOnboardingCompanion.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/SyncOnboardingCompanion.tsx
@@ -25,7 +25,8 @@ import { isAllowedOnboardingStatePollingErrorDmk } from "@ledgerhq/live-dmk-mobi
 
 import { SeedOriginType, SeedPhraseType } from "@ledgerhq/types-live";
 import { DeviceModelId } from "@ledgerhq/types-devices";
-import { addKnownDevice } from "~/actions/ble";
+import { addKnownBleDevice } from "~/actions/ble";
+import { addKnownDevice, mapDeviceToKnownDevice } from "~/reducers/knownDevices";
 import { NavigatorName, ScreenName } from "~/const";
 import HelpDrawer from "./HelpDrawer";
 import DesyncOverlay from "./DesyncOverlay";
@@ -262,9 +263,10 @@ export const SyncOnboardingCompanion: React.FC<SyncOnboardingCompanionProps> = (
    */
   const addToKnownDevices = useCallback(() => {
     dispatchRedux(setLastConnectedDevice(device));
+    dispatchRedux(addKnownDevice(mapDeviceToKnownDevice(device)));
     if (!device.wired) {
       dispatchRedux(
-        addKnownDevice({
+        addKnownBleDevice({
           id: device.deviceId,
           name: device.deviceName ?? device.modelId,
           modelId: device.modelId,

--- a/apps/ledger-live-mobile/src/transport/bleTransport/useMockBle.test.ts
+++ b/apps/ledger-live-mobile/src/transport/bleTransport/useMockBle.test.ts
@@ -1,5 +1,6 @@
 import { act, renderHook } from "@testing-library/react-native";
 import { DeviceModelId, getDeviceModel } from "@ledgerhq/devices";
+import { rnBleTransportIdentifier } from "@ledgerhq/live-dmk-mobile";
 import { __testUtils, useMockBleDevicesScanning } from "./useMockBle";
 import { DeviceLike } from "~/reducers/types";
 
@@ -95,7 +96,7 @@ describe("useMockBleDevicesScanning", () => {
         discoveredDevice: {
           id: knownDevice.id,
           name: knownDevice.name,
-          transport: "BLE",
+          transport: rnBleTransportIdentifier,
         },
       },
     ]);

--- a/apps/ledger-live-mobile/src/transport/mockDiscoveredDevice.ts
+++ b/apps/ledger-live-mobile/src/transport/mockDiscoveredDevice.ts
@@ -1,10 +1,26 @@
 import {
   DiscoveredDevice,
   DeviceModelId as DMKDeviceModelId,
+  type TransportIdentifier,
 } from "@ledgerhq/device-management-kit";
 import { ledgerToDmkDeviceIdMap } from "@ledgerhq/live-dmk-shared";
+import { rnBleTransportIdentifier, rnHidTransportIdentifier } from "@ledgerhq/live-dmk-mobile";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { getDeviceModel } from "@ledgerhq/devices";
+
+function getTransportIdentifier(device: Device): TransportIdentifier {
+  const [transportPrefix] = device.deviceId.split("|");
+
+  if (transportPrefix === "usb") {
+    return rnHidTransportIdentifier;
+  }
+
+  if (transportPrefix === "httpdebug" || transportPrefix === "speculos") {
+    return transportPrefix;
+  }
+
+  return device.wired ? rnHidTransportIdentifier : rnBleTransportIdentifier;
+}
 
 export function makeMockDiscoveredDevice(device: Device): DiscoveredDevice {
   const dmkDeviceModelId = ledgerToDmkDeviceIdMap[device.modelId] ?? DMKDeviceModelId.NANO_X;
@@ -16,6 +32,6 @@ export function makeMockDiscoveredDevice(device: Device): DiscoveredDevice {
       name: getDeviceModel(device.modelId).productName,
       model: dmkDeviceModelId,
     },
-    transport: "BLE",
+    transport: getTransportIdentifier(device),
   };
 }

--- a/apps/ledger-live-mobile/src/transport/useMockHidDiscovery.ts
+++ b/apps/ledger-live-mobile/src/transport/useMockHidDiscovery.ts
@@ -4,6 +4,7 @@ import { HIDDiscoveryState } from "@ledgerhq/live-dmk-mobile";
 import { DiscoveredDevice } from "@ledgerhq/device-management-kit";
 import { e2eBridgeClient } from "../../e2e/bridge/client";
 import { filter } from "rxjs/operators";
+import { makeMockDiscoveredDevice } from "./mockDiscoveredDevice";
 
 type MockHIDDiscoveredDevice = {
   deviceId: string;
@@ -50,14 +51,19 @@ export const useMockHidDevicesDiscovery = (enabled: boolean): HIDDiscoveryState 
         if (msg.type === "addUSB") {
           const descriptor = msg.payload;
           const deviceId = `usb|${JSON.stringify(descriptor)}`;
+          const device = {
+            deviceId,
+            deviceName: descriptor.deviceName,
+            wired: true,
+            modelId: descriptor.modelId as DeviceModelId,
+          };
 
           const newDevice: MockHIDDiscoveredDevice = {
             deviceId,
             deviceName: descriptor.deviceName,
             wired: true,
             modelId: descriptor.modelId as DeviceModelId,
-            // Not used in mock mode -- communication is mocked via mockDeviceEventSubject
-            discoveredDevice: undefined as unknown as DiscoveredDevice,
+            discoveredDevice: makeMockDiscoveredDevice(device),
           };
 
           setHidDevices(prev => {

--- a/libs/live-dmk-mobile/src/index.ts
+++ b/libs/live-dmk-mobile/src/index.ts
@@ -3,6 +3,8 @@ import { useDeviceSessionState } from "@ledgerhq/live-dmk-shared";
 export { DeviceManagementKitBLETransport } from "./transport/DeviceManagementKitBLETransport";
 export { DeviceManagementKitHIDTransport } from "./transport/DeviceManagementKitHIDTransport";
 export { DeviceManagementKitHTTPProxyTransport } from "./transport/DeviceManagementKitHTTPProxyTransport";
+export { rnBleTransportIdentifier } from "@ledgerhq/device-transport-kit-react-native-ble";
+export { rnHidTransportIdentifier } from "@ledgerhq/device-transport-kit-react-native-hid";
 export { DefaultDeviceDiscoveryService } from "./connectDevice/discoveryService/DefaultDeviceDiscoveryService";
 export {
   DiscoveryErrors,

--- a/libs/live-dmk-shared/src/connectDevice/types.ts
+++ b/libs/live-dmk-shared/src/connectDevice/types.ts
@@ -1,0 +1,9 @@
+import type { TransportIdentifier } from "@ledgerhq/device-management-kit";
+import type { DeviceModelId } from "@ledgerhq/types-devices";
+
+export type KnownDevice = {
+  transport: TransportIdentifier;
+  deviceModelId: DeviceModelId;
+  id: string;
+  name: string | null;
+};

--- a/libs/live-dmk-shared/src/index.ts
+++ b/libs/live-dmk-shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./hooks";
+export type { KnownDevice } from "./connectDevice/types";
 export { activeDeviceSessionSubject } from "./config/activeDeviceSession";
 export { dmkToLedgerDeviceIdMap, ledgerToDmkDeviceIdMap } from "./config/dmkToLedgerDeviceIdMap";
 export { LedgerLiveLogger } from "./services/LedgerLiveLogger";


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Focused reducer and hook coverage was added for the new slice initialization, transport-aware mapping, and explicit dual writes.
- [x] **Impact of the changes:**
  - Device selection and pairing flows on Ledger Live Mobile
  - Known-device persistence and boot-time initialization
  - BLE known-device actions while the legacy BLE slice remains in place

### 📝 Description

For the new device UX and new device connection flows, we need to have a single source of truth for devices that have been previously connected to Ledger Wallet Mobile, aka "known devices", regardless of their type of connectivity.

This PR introduces a new persisted `knownDevices` Redux slice for Ledger Wallet Mobile. Unlike the existing `ble.knownDevices` state, this slice is transport-agnostic and stores devices using the shared `KnownDevice` type so BLE and wired devices can be tracked in one place.

The legacy BLE slice is intentionally kept alive because it still carries BLE-specific state and richer metadata used elsewhere, such as `deviceInfo` with OS/device details.
For now, flows that add, update, rename, or remove a device explicitly update both slices where relevant: the BLE slice remains available for legacy BLE-specific behavior, and the new slice records every known device regardless of how it connects (BLE, USB/HID, and future transports).

For existing users, the new slice is initialized from the persisted BLE known-device list on boot when it has no data yet. After that first initialization, updates happen through explicit writes at the device flow call sites instead of hidden cross-slice mirroring.

Implementation choices:

- Add `KnownDevice` to `@ledgerhq/live-dmk-shared` for future desktop reuse.
- Added mobile persistence through the existing DB load/save pipeline and `DBSave` effects.
- Renamed legacy BLE action creators with a `Ble` suffix to make the two slice responsibilities explicit.
- Left debug HTTP transport and E2E speculos helpers behavior unchanged apart from the BLE action rename.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30326](https://ledgerhq.atlassian.net/browse/LIVE-30326)
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30326]: https://ledgerhq.atlassian.net/browse/LIVE-30326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ