### PR TITLE
fix(wallet-cli): harden swap execute output

### DIFF
--- a/.changeset/quiet-swaps-guard.md
+++ b/.changeset/quiet-swaps-guard.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-cli": patch
+---
+
+Harden wallet-cli swap execute flags and zero-amount rate output

--- a/apps/wallet-cli/src/commands/swap/cli-swap-pipeline.test.ts
+++ b/apps/wallet-cli/src/commands/swap/cli-swap-pipeline.test.ts
@@ -18,6 +18,7 @@ import type { CommandOutput } from "../../output";
  */
 
 const events: string[] = [];
+let updatedTransactionAmount = new BigNumber("1000000000000000000");
 
 mock.module("../../session/exchange-device-session", () => ({
   withLedgerManagerAppSession: async <T>(_app: string, fn: () => Promise<T>): Promise<T> => {
@@ -121,7 +122,7 @@ function getAccountBridge(): ReturnType<typeof getLiveAccountBridge> {
     updateTransaction: (
       tx: Record<string, unknown>,
       patch: Record<string, unknown>,
-    ): Record<string, unknown> => ({ ...tx, ...patch }),
+    ): Record<string, unknown> => ({ ...tx, ...patch, amount: updatedTransactionAmount }),
   } as unknown as ReturnType<typeof getLiveAccountBridge>;
 }
 
@@ -132,6 +133,7 @@ async function getDeviceModelId() {
 describe("runFullSwapPipeline session lifecycle", () => {
   afterEach(() => {
     events.length = 0;
+    updatedTransactionAmount = new BigNumber("1000000000000000000");
     retrieveSwapPayloadMock.mockClear();
   });
 
@@ -154,6 +156,25 @@ describe("runFullSwapPipeline session lifecycle", () => {
     expect(result.dryRun).toBe(true);
     expect(result.operationHash).toBeUndefined();
     expect(retrieveSwapPayloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits magnitudeAwareRate when the prepared transaction amount is zero", async () => {
+    updatedTransactionAmount = new BigNumber(0);
+
+    const result = await runFullSwapPipeline({
+      out: makeOutput(),
+      provider: "changelly",
+      amount: "1",
+      amountInAtomicUnit: new BigNumber("1000000000000000000"),
+      feeStrategy: "medium",
+      dryRun: true,
+      fromAccount: makeAccount("from"),
+      toAccount: makeAccount("to"),
+      getAccountBridge,
+    });
+
+    expect(result.magnitudeAwareRate).toBeUndefined();
+    expect(result).not.toHaveProperty("magnitudeAwareRate");
   });
 
   it("closes the session even when the swap API call throws", async () => {

--- a/apps/wallet-cli/src/commands/swap/cli-swap-pipeline.ts
+++ b/apps/wallet-cli/src/commands/swap/cli-swap-pipeline.ts
@@ -334,7 +334,10 @@ export async function runFullSwapPipeline(
 
     const decodePayload = await decodeSwapPayload(payload.binaryPayload);
     const amountExpectedTo = new BigNumber(decodePayload.amountToWallet.toString());
-    const magnitudeAwareRate = tx.amount && amountExpectedTo.dividedBy(tx.amount);
+    const magnitudeAwareRate =
+      tx.amount && new BigNumber(tx.amount).gt(0)
+        ? amountExpectedTo.dividedBy(tx.amount)
+        : undefined;
     tx.amount = new BigNumber(tx.amount);
 
     const rateType = quoteId != null && quoteId !== "" ? RATE_FIXED : RATE_FLOATING;

--- a/apps/wallet-cli/src/commands/swap/execute.ts
+++ b/apps/wallet-cli/src/commands/swap/execute.ts
@@ -14,19 +14,22 @@ import {
   resolveOutputFormat,
 } from "../inputs";
 import { networkStringFromCurrencyId } from "../../shared/accountDescriptor";
+import { OutputFormatSchema } from "../../wallet/models";
 import { runFullSwapPipeline as runFullSwapPipelineDefault } from "./cli-swap-pipeline";
 
 type RunFullSwapPipeline = typeof runFullSwapPipelineDefault;
 
-export type SwapExecuteFlags = {
-  provider: string;
-  amount: string;
-  "to-account"?: string;
-  account?: string;
-  "fee-strategy": "slow" | "medium" | "fast";
-  "dry-run": boolean;
-  output?: "human" | "json";
-};
+const swapExecuteFlagsSchema = z.object({
+  provider: z.string().min(1, "Provider is required (--provider <name>)"),
+  amount: z.string().min(1, "Amount is required (--amount <value>)"),
+  "to-account": z.string().optional(),
+  account: z.string().min(1).optional(),
+  "fee-strategy": z.enum(["slow", "medium", "fast"]).default("medium"),
+  "dry-run": z.boolean().default(false),
+  output: OutputFormatSchema.optional(),
+});
+
+export type SwapExecuteFlags = z.infer<typeof swapExecuteFlagsSchema>;
 
 export type SwapExecuteDependencies = {
   runFullSwapPipeline: RunFullSwapPipeline;
@@ -114,20 +117,20 @@ export default defineCommand({
   description:
     "Swap flow with Ledger device + API pipeline (nonce → payload → complete exchange → sign/broadcast).",
   options: {
-    provider: option(z.string().min(1, "Provider is required (--provider <name>)"), {
+    provider: option(swapExecuteFlagsSchema.shape.provider, {
       description: "Swap provider name, e.g. changelly",
     }),
-    amount: option(z.string().min(1, "Amount is required (--amount <value>)"), {
+    amount: option(swapExecuteFlagsSchema.shape.amount, {
       description: "Swap source amount in human units",
     }),
-    "to-account": option(z.string().optional(), {
+    "to-account": option(swapExecuteFlagsSchema.shape["to-account"], {
       description: "Destination account descriptor or session label (required for full pipeline)",
     }),
     account: accountOption,
-    "fee-strategy": option(z.enum(["slow", "medium", "fast"]).default("medium"), {
+    "fee-strategy": option(swapExecuteFlagsSchema.shape["fee-strategy"], {
       description: "Fee strategy for the refund-chain transaction (full pipeline)",
     }),
-    "dry-run": option(z.boolean().default(false), {
+    "dry-run": option(swapExecuteFlagsSchema.shape["dry-run"], {
       description: "Run through exchange preparation but do not sign or broadcast",
       argumentKind: "flag",
     }),


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - wallet-cli swap

### 📝 Description

Derive swap execute flags from a shared zod schema so runtime validation and TypeScript types stay aligned.

Avoid serializing Infinity in swap execute results when rate calculation sees a zero transaction amount.

The PR is stacked on top of https://github.com/LedgerHQ/ledger-live/pull/17280 and will be rebased on develop when merged

### ❓ Context

- **JIRA or GitHub link**:
- **ADR link (if any)**:

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
