### PR TITLE
[LWDM] chore: async bridge prep — toOperationRaw and remaining callers (LIVE-29186)

### DIFF
--- a/.changeset/async-tooperationraw.md
+++ b/.changeset/async-tooperationraw.md
@@ -1,0 +1,18 @@
+---
+"@ledgerhq/live-common": minor
+"@ledgerhq/live-wallet": minor
+"@ledgerhq/coin-modules-monitoring": minor
+"@ledgerhq/coin-tester-evm": minor
+"@ledgerhq/coin-tester-solana": minor
+"@ledgerhq/web-tools": minor
+"@ledgerhq/wallet-cli": minor
+"@ledgerhq/live-cli": minor
+"live-mobile": minor
+---
+
+chore: async prep — toOperationRaw, toSignedOperationRaw and remaining bridge callers (LIVE-29186)
+
+Make `toOperationRaw`, `toSignedOperationRaw` and `toSignOperationEventRaw` async in `@ledgerhq/live-common`,
+widen `WalletSyncDataManagerResolutionContext.getAccountBridge` in `@ledgerhq/live-wallet` to accept a Promise,
+and update remaining callers (apps/cli, apps/wallet-cli, apps/web-tools, mobile concordium, coin-tester-evm/solana,
+coin-modules-monitoring) to `await` the bridge.

--- a/apps/cli/src/commands/blockchain/broadcast.ts
+++ b/apps/cli/src/commands/blockchain/broadcast.ts
@@ -1,5 +1,5 @@
 import { from } from "rxjs";
-import { map, concatMap } from "rxjs/operators";
+import { concatMap } from "rxjs/operators";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { toOperationRaw } from "@ledgerhq/live-common/account/index";
 import { scan, scanCommonOpts } from "../../scan";
@@ -28,6 +28,6 @@ export default {
           ),
         ),
       ),
-      map(obj => JSON.stringify(toOperationRaw(obj))),
+      concatMap(async obj => JSON.stringify(await toOperationRaw(obj))),
     ),
 };

--- a/apps/cli/src/commands/blockchain/confirmOp.ts
+++ b/apps/cli/src/commands/blockchain/confirmOp.ts
@@ -31,7 +31,7 @@ export default {
       switchMap(async account => {
         const op = findOperationInAccount(account, id);
         if (!op) throw new Error("operation was not found in account " + account.id);
-        return format === "text" ? formatOperation(account)(op) : toOperationRaw(op);
+        return format === "text" ? formatOperation(account)(op) : await toOperationRaw(op);
       }),
     );
   },

--- a/apps/cli/src/commands/blockchain/generateTestTransaction.ts
+++ b/apps/cli/src/commands/blockchain/generateTestTransaction.ts
@@ -105,8 +105,8 @@ export default {
     ${toTransactionStatusJS(status)}
   ),
   // WARNING: DO NOT commit this test publicly unless you're ok with possibility tx could leak out. (do self txs)
-  testSignedOperation: (expect, signedOperation) => {
-    expect(toSignedOperationRaw(signedOperation)).toMatchObject(${JSON.stringify(signedOpRaw)})
+  testSignedOperation: async (expect, signedOperation) => {
+    expect(await toSignedOperationRaw(signedOperation)).toMatchObject(${JSON.stringify(signedOpRaw)})
   },
   apdus: \`
 ${apdus.map(a => "  " + a).join("\n")}

--- a/apps/cli/src/commands/blockchain/generateTestTransaction.ts
+++ b/apps/cli/src/commands/blockchain/generateTestTransaction.ts
@@ -93,6 +93,9 @@ export default {
                             ),
                             mergeMap(async ([signedOperation, status]) => {
                               unsubscribe();
+                              const signedOpRaw = await toSignedOperationRaw(
+                                signedOperation as SignedOperation,
+                              );
                               return `
 {
   name: "NO_NAME",
@@ -103,9 +106,7 @@ export default {
   ),
   // WARNING: DO NOT commit this test publicly unless you're ok with possibility tx could leak out. (do self txs)
   testSignedOperation: (expect, signedOperation) => {
-    expect(toSignedOperationRaw(signedOperation)).toMatchObject(${JSON.stringify(
-      toSignedOperationRaw(signedOperation as SignedOperation),
-    )})
+    expect(toSignedOperationRaw(signedOperation)).toMatchObject(${JSON.stringify(signedOpRaw)})
   },
   apdus: \`
 ${apdus.map(a => "  " + a).join("\n")}

--- a/apps/cli/src/commands/blockchain/send.ts
+++ b/apps/cli/src/commands/blockchain/send.ts
@@ -1,5 +1,5 @@
 import { from, defer, of, concat, EMPTY, Observable } from "rxjs";
-import { map, switchMap, mergeMap, concatMap, catchError, tap } from "rxjs/operators";
+import { switchMap, mergeMap, concatMap, catchError, tap } from "rxjs/operators";
 import { getEnv } from "@ledgerhq/live-env";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import {
@@ -87,7 +87,7 @@ export default {
                             deviceId: opts.device || "",
                           })
                           .pipe(
-                            map(toSignOperationEventRaw),
+                            concatMap(toSignOperationEventRaw),
                             // @ts-expect-error more voodoo stuff
                             ...(opts["disable-broadcast"] ||
                             getEnv("DISABLE_TRANSACTION_BROADCAST")

--- a/apps/ledger-live-mobile/src/families/concordium/VerifyAddress.tsx
+++ b/apps/ledger-live-mobile/src/families/concordium/VerifyAddress.tsx
@@ -105,7 +105,7 @@ export default function ConcordiumReceiveVerifyAddress({ navigation, route }: Pr
               map(() => ({})),
               rejectionOp(),
             )
-          : getAccountBridge(mainAccount).receive(mainAccount, {
+          : (await getAccountBridge(mainAccount)).receive(mainAccount, {
               deviceId: device.deviceId,
               verify: true,
             })

--- a/apps/web-tools/src/trustchain/components/AppAccountsSync.tsx
+++ b/apps/web-tools/src/trustchain/components/AppAccountsSync.tsx
@@ -24,7 +24,7 @@ import walletsync, {
 } from "@ledgerhq/live-wallet/walletsync/index";
 import { getAccountBridge, getCurrencyBridge } from "@ledgerhq/live-common/bridge/index";
 import { getAccountCurrency } from "@ledgerhq/ledger-wallet-framework/account/helpers";
-import { Account, BridgeCacheSystem } from "@ledgerhq/types-live";
+import { Account, BridgeCacheSystem, ScanAccountEvent } from "@ledgerhq/types-live";
 import { makeBridgeCacheSystem } from "@ledgerhq/live-common/bridge/cache";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
@@ -302,7 +302,7 @@ function HeadlessAddAccounts({
   const [disabled, setDisabled] = useState(false);
 
   const onSubmit = useCallback(
-    (e: any) => {
+    async (e: any) => {
       e.preventDefault();
       if (!e.target) return;
       const data = new FormData(e.target);
@@ -310,7 +310,7 @@ function HeadlessAddAccounts({
       if (!currencyId) return;
       setDisabled(true);
       const currency = getCryptoCurrencyById(String(currencyId));
-      const currencyBridge = getCurrencyBridge(currency);
+      const currencyBridge = await getCurrencyBridge(currency);
       const sub = appForCurrency(deviceId, currency, () =>
         concat(
           from(bridgeCache.prepareCurrency(currency)).pipe(ignoreElements()),
@@ -324,7 +324,7 @@ function HeadlessAddAccounts({
           }),
         ),
       ).subscribe({
-        next: event => {
+        next: (event: ScanAccountEvent) => {
           if (event.type === "discovered") {
             addAccounts([event.account]);
           }

--- a/apps/web-tools/src/trustchain/components/AppAccountsSync.tsx
+++ b/apps/web-tools/src/trustchain/components/AppAccountsSync.tsx
@@ -1,5 +1,5 @@
 import React, { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Observable, concat, find, from, ignoreElements, mergeMap, tap } from "rxjs";
+import { Observable, concat, defer, find, from, ignoreElements, mergeMap, tap } from "rxjs";
 import { Button } from "@ledgerhq/lumen-ui-react";
 import { MemberCredentials, Trustchain } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { useTrustchainSDK } from "../context";
@@ -302,7 +302,7 @@ function HeadlessAddAccounts({
   const [disabled, setDisabled] = useState(false);
 
   const onSubmit = useCallback(
-    async (e: any) => {
+    (e: any) => {
       e.preventDefault();
       if (!e.target) return;
       const data = new FormData(e.target);
@@ -310,18 +310,21 @@ function HeadlessAddAccounts({
       if (!currencyId) return;
       setDisabled(true);
       const currency = getCryptoCurrencyById(String(currencyId));
-      const currencyBridge = await getCurrencyBridge(currency);
       const sub = appForCurrency(deviceId, currency, () =>
-        concat(
-          from(bridgeCache.prepareCurrency(currency)).pipe(ignoreElements()),
-          currencyBridge.scanAccounts({
-            currency,
-            deviceId,
-            syncConfig: {
-              paginationConfig: {},
-              blacklistedTokenIds: [],
-            },
-          }),
+        defer(() => Promise.resolve(getCurrencyBridge(currency))).pipe(
+          mergeMap(currencyBridge =>
+            concat(
+              from(bridgeCache.prepareCurrency(currency)).pipe(ignoreElements()),
+              currencyBridge.scanAccounts({
+                currency,
+                deviceId,
+                syncConfig: {
+                  paginationConfig: {},
+                  blacklistedTokenIds: [],
+                },
+              }),
+            ),
+          ),
         ),
       ).subscribe({
         next: (event: ScanAccountEvent) => {

--- a/libs/coin-modules-monitoring/src/run.ts
+++ b/libs/coin-modules-monitoring/src/run.ts
@@ -136,9 +136,9 @@ function toEmptyAccount(currency: CryptoCurrency, info: AccountInfo): Account {
 function getSync(currency: CryptoCurrency) {
   const bridge = getAccountBridgeByFamily(currency.family);
 
-  return (account: Account) =>
+  return async (account: Account) =>
     firstValueFrom(
-      bridge
+      (await bridge)
         .sync(account, { paginationConfig: {} })
         .pipe(reduce((a, f: (arg0: Account) => Account) => f(a), account)),
     );

--- a/libs/coin-tester-modules/coin-tester-evm/src/helpers.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/helpers.ts
@@ -45,8 +45,8 @@ export async function getBridges(signer: Signer): Promise<{
   const getAddress = resolver(context);
 
   return {
-    currencyBridge: getAlpacaCurrencyBridge("evm", "local", { context, getAddress }),
-    accountBridge: getAlpacaAccountBridge("evm", "local", { context, getAddress }),
+    currencyBridge: await getAlpacaCurrencyBridge("evm", "local", { context, getAddress }),
+    accountBridge: await getAlpacaAccountBridge("evm", "local", { context, getAddress }),
     getAddress,
   };
 }

--- a/libs/coin-tester-modules/coin-tester-solana/src/helpers.ts
+++ b/libs/coin-tester-modules/coin-tester-solana/src/helpers.ts
@@ -151,11 +151,11 @@ export async function getBridges(
   const alpacaGetAddress = solanaGetAddress(alpacaSignerContext);
 
   return {
-    currencyBridge: getAlpacaCurrencyBridge("solana", "local", {
+    currencyBridge: await getAlpacaCurrencyBridge("solana", "local", {
       context: alpacaSignerContext,
       getAddress: alpacaGetAddress,
     }),
-    accountBridge: getAlpacaAccountBridge("solana", "local", {
+    accountBridge: await getAlpacaAccountBridge("solana", "local", {
       context: alpacaSignerContext,
       getAddress: alpacaGetAddress,
     }),

--- a/libs/ledger-live-common/src/account/serialization.ts
+++ b/libs/ledger-live-common/src/account/serialization.ts
@@ -26,21 +26,22 @@ export function toBalanceHistoryRaw(b: BalanceHistory): BalanceHistoryRaw {
   return b.map(({ date, value }) => [date.toISOString(), value.toString()]);
 }
 
-export const toOperationRaw = (
+export const toOperationRaw = async (
   operation: Operation,
   preserveSubOperation?: boolean,
-): OperationRaw => {
-  let toOperationRaw: AccountBridge<TransactionCommon>["toOperationExtraRaw"] | undefined;
+): Promise<OperationRaw> => {
+  let toOperationExtraRaw: AccountBridge<TransactionCommon>["toOperationExtraRaw"] | undefined;
+
   if (operation.extra) {
     const family = inferFamilyFromAccountId(operation.accountId);
 
     if (family) {
-      const bridge = getAccountBridgeByFamily(family, operation.accountId);
-      toOperationRaw = bridge.toOperationExtraRaw;
+      const bridge = await getAccountBridgeByFamily(family, operation.accountId);
+      toOperationExtraRaw = bridge.toOperationExtraRaw;
     }
   }
 
-  return commonToOperationRaw(operation, preserveSubOperation, toOperationRaw);
+  return commonToOperationRaw(operation, preserveSubOperation, toOperationExtraRaw);
 };
 
 export const fromOperationRaw = async (
@@ -64,7 +65,7 @@ export const fromOperationRaw = async (
 
 export async function fromAccountRaw(rawAccount: AccountRaw): Promise<Account> {
   const currency = getCryptoCurrencyById(rawAccount.currencyId);
-  const bridge = getAccountBridgeByFamily(currency.family, rawAccount.id);
+  const bridge = await getAccountBridgeByFamily(currency.family, rawAccount.id);
 
   return await commonFromAccountRaw(rawAccount, {
     assignFromAccountRaw: bridge.assignFromAccountRaw,

--- a/libs/ledger-live-common/src/bot/formatters.ts
+++ b/libs/ledger-live-common/src/bot/formatters.ts
@@ -129,7 +129,7 @@ export async function formatReportForConsole<T extends Transaction>({
 
   if (signedOperation) {
     str += `✔️ has been signed! (${formatDt(statusTime, signedTime)}) ${
-      !optimisticOperation ? JSON.stringify(toSignedOperationRaw(signedOperation)) : ""
+      !optimisticOperation ? JSON.stringify(await toSignedOperationRaw(signedOperation)) : ""
     }\n`;
   }
 

--- a/libs/ledger-live-common/src/transaction/signOperation.ts
+++ b/libs/ledger-live-common/src/transaction/signOperation.ts
@@ -25,13 +25,13 @@ export const fromSignedOperationRaw = async (
 
   return out;
 };
-export const toSignedOperationRaw = (
+export const toSignedOperationRaw = async (
   signedOp: SignedOperation,
   preserveSubOperation?: boolean,
-): SignedOperationRaw => {
+): Promise<SignedOperationRaw> => {
   const { operation, signature, expirationDate, rawData } = signedOp;
   const out: SignedOperationRaw = {
-    operation: toOperationRaw(operation, preserveSubOperation),
+    operation: await toOperationRaw(operation, preserveSubOperation),
     signature,
   };
 
@@ -60,12 +60,12 @@ export const fromSignOperationEventRaw = async (
       return e;
   }
 };
-export const toSignOperationEventRaw = (e: SignOperationEvent): SignOperationEventRaw => {
+export const toSignOperationEventRaw = async (e: SignOperationEvent): Promise<SignOperationEventRaw> => {
   switch (e.type) {
     case "signed":
       return {
         type: "signed",
-        signedOperation: toSignedOperationRaw(e.signedOperation, true),
+        signedOperation: await toSignedOperationRaw(e.signedOperation, true),
       };
 
     default:

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/fetchNetworkFeeContext.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/fetchNetworkFeeContext.ts
@@ -40,7 +40,7 @@ export async function fetchNetworkFeeContext(
 
     const fromParentAccount = getParentAccount(fromAccount, args.accounts);
     let mainAccount = getMainAccount(fromAccount, fromParentAccount);
-    const bridge = getAccountBridge(fromAccount, fromParentAccount);
+    const bridge = await getAccountBridge(fromAccount, fromParentAccount);
 
     // Bitcoin requires a fresh sync before `prepareTransaction` can compute
     // fees because UTXO selection depends on confirmed inputs.

--- a/libs/live-wallet/src/walletsync/modules/accounts.ts
+++ b/libs/live-wallet/src/walletsync/modules/accounts.ts
@@ -260,7 +260,7 @@ export function diffWalletSyncState(
  */
 export async function integrateNewAccountDescriptor<T extends TransactionCommon>(
   accountDescriptor: AccountDescriptor,
-  getAccountBridge: (account: Account) => AccountBridge<T>,
+  getAccountBridge: (account: Account) => AccountBridge<T> | Promise<AccountBridge<T>>,
   bridgeCache: BridgeCacheSystem,
   blacklistedTokenIds?: string[],
 ): Promise<Account> {

--- a/libs/live-wallet/src/walletsync/modules/accounts.ts
+++ b/libs/live-wallet/src/walletsync/modules/accounts.ts
@@ -255,7 +255,7 @@ export function diffWalletSyncState(
  * make it work) and that it has all the necessary fields automatically filled.
  * in case of failure, the promise would fail and it's your responsability to re-try later in case of failure. we will have to implement a retrial strategy and minimize calls to integrateNewAccountDescriptor
  * @param account
- * @param getAccountBridge: implementation of live-common's getAccountBridge (since this lib don't depends on live-common)
+ * @param getAccountBridge: implementation of live-common's getAccountBridge (since this lib don't depends on live-common). May return AccountBridge or Promise<AccountBridge> — both are awaited.
  *
  */
 export async function integrateNewAccountDescriptor<T extends TransactionCommon>(

--- a/libs/live-wallet/src/walletsync/types.ts
+++ b/libs/live-wallet/src/walletsync/types.ts
@@ -61,7 +61,9 @@ export interface WalletSyncDataManager<
  * this provide the implementations needed by modules to be integrated at the final projects. This is typically because this library is independant from live-common and this context have all the necessary dependencies. Feel free to evolve and adds what modules need to resolve information. (Also note that LLD/LLM will have different implementations, for instance different backends for bridgeCache)
  */
 export type WalletSyncDataManagerResolutionContext = {
-  getAccountBridge: <T extends TransactionCommon>(account: Account) => AccountBridge<T>;
+  getAccountBridge: <T extends TransactionCommon>(
+    account: Account,
+  ) => AccountBridge<T> | Promise<AccountBridge<T>>;
   bridgeCache: BridgeCacheSystem;
   blacklistedTokenIds?: string[];
 };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [ ] **Impact of the changes:**
  - Public APIs in `@ledgerhq/live-common` made async: `toOperationRaw`, `toSignedOperationRaw`, `toSignOperationEventRaw`. All known callers in this repo are migrated; external consumers must `await`.
  - `WalletSyncDataManagerResolutionContext.getAccountBridge` (`@ledgerhq/live-wallet`) widened to also accept a Promise return.
  - QA focus: account/operation serialization paths (sync, send, swap), wallet-sync flow, web-tools headless add-account, mobile Concordium verify-address.

### 📝 Description

Follow-up to LIVE-29186 (async `getAccountBridge` / `getCurrencyBridge`). Propagates `await` through the remaining callers and flips `toOperationRaw` & friends to async so they can resolve the family bridge asynchronously.

For consumers of `@ledgerhq/live-common`:

```diff
- const raw = toOperationRaw(operation);
+ const raw = await toOperationRaw(operation);

- const rawSigned = toSignedOperationRaw(signedOp);
+ const rawSigned = await toSignedOperationRaw(signedOp);
```

For consumers of `@ledgerhq/live-wallet` `WalletSyncDataManagerResolutionContext`:

```diff
- getAccountBridge: (account) => AccountBridge<T>
+ getAccountBridge: (account) => AccountBridge<T> | Promise<AccountBridge<T>>
```

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29186](https://ledgerhq.atlassian.net/browse/LIVE-29186)
- **ADR link (if any)**: n/a

[LIVE-29186]: https://ledgerhq.atlassian.net/browse/LIVE-29186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ