### PR TITLE
[LWD] fix(desktop): correct analytics consent defaults and boot ordering

### DIFF
--- a/.changeset/shy-pants-move.md
+++ b/.changeset/shy-pants-move.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Default analytics sharing to off until you explicitly opt in via the consent prompt. Existing preferences are preserved for returning users.

--- a/apps/ledger-live-desktop/src/renderer/Default.tsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, lazy, Suspense } from "react";
 import styled, { useTheme } from "styled-components";
 import { ipcRenderer } from "electron";
 import { Navigate, Route, Routes, useNavigate, useLocation, useParams } from "react-router";
-import { useDispatch, useSelector } from "LLD/hooks/redux";
+import { useSelector } from "LLD/hooks/redux";
 import TrackAppStart from "~/renderer/components/TrackAppStart";
 import { LiveApp } from "~/renderer/screens/platform";
 import { BridgeSyncProvider } from "~/renderer/bridge/BridgeSyncContext";
@@ -51,12 +51,9 @@ import { accountsSelector } from "./reducers/accounts";
 import { useRecoverRestoreOnboarding } from "~/renderer/hooks/useRecoverRestoreOnboarding";
 import {
   hasCompletedOnboardingSelector,
-  hasSeenAnalyticsOptInPromptSelector,
   areSettingsLoaded,
 } from "~/renderer/reducers/settings";
-import { isLocked as isLockedSelector } from "~/renderer/reducers/application";
 import { useAutoDismissPostOnboardingEntryPoint } from "@ledgerhq/live-common/postOnboarding/hooks/index";
-import { setShareAnalytics, setSharePersonalizedRecommendations } from "./actions/settings";
 import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import { useEnforceSupportedLanguage } from "./hooks/useEnforceSupportedLanguage";
 import { useDeviceManagementKit } from "@ledgerhq/live-dmk-desktop";
@@ -413,11 +410,6 @@ export default function Default() {
   useAutoDismissPostOnboardingEntryPoint();
   useEnforceSupportedLanguage();
 
-  const analyticsFF = useFeature("lldAnalyticsOptInPrompt");
-  const hasSeenAnalyticsOptInPrompt = useSelector(hasSeenAnalyticsOptInPromptSelector);
-  const isLocked = useSelector(isLockedSelector);
-  const dispatch = useDispatch();
-
   useEffect(() => {
     if (typeof ldmkSolanaSignerFeatureFlag?.enabled === "boolean") {
       setSolanaLdmkEnabled(ldmkSolanaSignerFeatureFlag?.enabled);
@@ -438,19 +430,6 @@ export default function Default() {
     // setting provider only at initialisation
     // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [dmk]);
-
-  useEffect(() => {
-    if (
-      !isLocked &&
-      analyticsFF?.enabled &&
-      (!hasCompletedOnboarding || analyticsFF?.params?.entryPoints.includes("Portfolio")) &&
-      !hasSeenAnalyticsOptInPrompt
-    ) {
-      dispatch(setShareAnalytics(false));
-      dispatch(setSharePersonalizedRecommendations(false));
-    }
-    // oxlint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLocked]);
 
   useEffect(() => {
     if (!areSettingsLoadedSelector) {

--- a/apps/ledger-live-desktop/src/renderer/__tests__/Default.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/__tests__/Default.test.tsx
@@ -1,6 +1,8 @@
 import React from "react";
+import { FEATURE_FLAGS_INITIAL_STATE } from "@shared/feature-flags";
 import { render, screen, waitFor } from "tests/testSetup";
 import Default from "../Default";
+import { updateIdentify } from "../analytics/segment";
 
 jest.mock("electron", () => {
   const base = jest.requireActual<typeof import("../../../tests/mocks/electron")>(
@@ -14,7 +16,11 @@ jest.mock("electron", () => {
   };
 });
 
-jest.mock("~/renderer/store", () => ({}));
+jest.mock("~/renderer/store", () => ({
+  getStoreValue: jest.fn(),
+  setStoreValue: jest.fn(),
+  resetStore: jest.fn(),
+}));
 
 jest.mock("@braze/web-sdk", () => ({
   getCachedContentCards: () => ({ cards: [] }),
@@ -24,6 +30,12 @@ jest.mock("LLD/features/AppBlockers/components/AppVersionBlocker", () => {
   const React = require("react");
   return { AppVersionBlocker: ({ children }: { children: React.ReactNode }) => <>{children}</> };
 });
+
+jest.mock("../analytics/segment", () => ({
+  ...jest.requireActual("../analytics/segment"),
+  updateIdentify: jest.fn(),
+  startAnalytics: jest.fn(),
+}));
 
 describe("Default", () => {
   beforeAll(() => {
@@ -57,5 +69,50 @@ describe("Default", () => {
       },
       { timeout: 3000 },
     );
+  });
+
+  describe("analytics consent", () => {
+    beforeEach(() => {
+      (updateIdentify as jest.Mock).mockClear();
+    });
+
+    it("retains consent flags on mount (test regression for LIVE-30334)", async () => {
+      const { store } = render(<Default />, {
+        initialState: {
+          devices: { currentDevice: null, devices: [] },
+          featureFlags: {
+            ...FEATURE_FLAGS_INITIAL_STATE,
+            overrides: {
+              ...FEATURE_FLAGS_INITIAL_STATE.overrides,
+              lldAnalyticsOptInPrompt: {
+                ...(FEATURE_FLAGS_INITIAL_STATE.overrides.lldAnalyticsOptInPrompt ?? {}),
+                enabled: true,
+                params: { variant: "A", entryPoints: ["Portfolio"] },
+              },
+            },
+          },
+          settings: {
+            loaded: true,
+            hasCompletedOnboarding: true,
+            hasSeenAnalyticsOptInPrompt: false,
+            shareAnalytics: true,
+            sharePersonalizedRecommandations: true,
+            lastUsedVersion: __APP_VERSION__,
+            vaultSigner: { enabled: false, host: "", token: "", workspace: "" },
+            devicesModelList: [],
+            anonymousUserNotifications: {},
+            orderAccounts: "balance|desc",
+          },
+        },
+        initialRoute: "/",
+      });
+
+      await waitFor(() => {
+        expect(updateIdentify).toHaveBeenCalled();
+      });
+
+      expect(store.getState().settings.shareAnalytics).toBe(true);
+      expect(store.getState().settings.sharePersonalizedRecommandations).toBe(true);
+    });
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -174,7 +174,6 @@ async function init() {
     deepLinkUrl = url;
   });
   const initialSettings = (await getKey("app", "settings")) || {};
-  startAnalytics(store);
 
   liveBlindSigningReporter.setConsentSource(() => trackingEnabledSelector(store.getState()));
 
@@ -189,6 +188,7 @@ async function init() {
   }
 
   fetchSettings(settingsToLoad)(store.dispatch);
+  startAnalytics(store);
   const state = store.getState();
   const language = languageSelector(state);
 

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.test.ts
@@ -122,6 +122,44 @@ describe("INITIAL_STATE defaults", () => {
   it("should default theme to dark", () => {
     expect(SETTINGS_INITIAL_STATE.theme).toBe("dark");
   });
+
+  it("should default analytics consent flags to false", () => {
+    expect(SETTINGS_INITIAL_STATE.shareAnalytics).toBe(false);
+    expect(SETTINGS_INITIAL_STATE.sharePersonalizedRecommandations).toBe(false);
+  });
+});
+
+describe("FETCH_SETTINGS preserves persisted analytics consent", () => {
+  it("should keep persisted shareAnalytics=true (returning opted-in users not regressed)", () => {
+    const initialState = SETTINGS_INITIAL_STATE;
+    const action = {
+      type: "FETCH_SETTINGS" as const,
+      payload: {
+        shareAnalytics: true,
+        sharePersonalizedRecommandations: true,
+      } as Partial<SettingsState>,
+    };
+    const newState = reducer(initialState, action);
+
+    expect(newState.shareAnalytics).toBe(true);
+    expect(newState.sharePersonalizedRecommandations).toBe(true);
+    expect(newState.loaded).toBe(true);
+  });
+
+  it("should keep persisted shareAnalytics=false for returning opted-out users", () => {
+    const initialState = SETTINGS_INITIAL_STATE;
+    const action = {
+      type: "FETCH_SETTINGS" as const,
+      payload: {
+        shareAnalytics: false,
+        sharePersonalizedRecommandations: false,
+      } as Partial<SettingsState>,
+    };
+    const newState = reducer(initialState, action);
+
+    expect(newState.shareAnalytics).toBe(false);
+    expect(newState.sharePersonalizedRecommandations).toBe(false);
+  });
 });
 
 describe("action: purgeAnonymousUserNotifications", () => {

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -178,8 +178,8 @@ export const INITIAL_STATE: SettingsState = {
   pairExchanges: {},
   developerMode: !!process.env.__DEV__,
   loaded: false,
-  shareAnalytics: true,
-  sharePersonalizedRecommandations: true,
+  shareAnalytics: false,
+  sharePersonalizedRecommandations: false,
   analyticsConsentInfo: {
     consentDate: null,
     privacyPolicyVersion: null,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Analytics consent state at boot — `INITIAL_STATE` defaults are now `false` for `shareAnalytics` and `sharePersonalizedRecommandations`. Persisted preferences are preserved via `FETCH_SETTINGS` merge.
  - Mixpanel `identify` calls now fire only when the user makes an explicit consent decision via the consent dialog (`persistAnalyticsConsentAck` already uses `force: true`). Boot-time identify is gated by `trackingEnabledSelector` as the spec intends.
  - QA focus areas:
    - **Fresh install:** no `identify` payload with `shareAnalytics: true` is sent before consent.
    - **Returning opted-in user:** `identify` fires once at boot with `shareAnalytics: true`.
    - **Returning opted-out user:** no `identify` at boot until the user makes a new explicit decision.
    - **Toggle in Settings → General:** flipping share-analytics on/off still pushes the change to Mixpanel via `force: true`.
    - **Hard reset → onboarding flow:** new userId is generated and stays unidentified to Mixpanel until the consent dialog is completed.

### 📝 Description

  ### Before — wrong defaults + wrong order                                                                                                                                
                                                                                                                                                                           
```mermaid                                                                                                                                                               
  sequenceDiagram                                                                                                                                                          
      autonumber
      participant init as init.tsx
      participant store as Redux store
      participant start as startAnalytics
      participant default as Default.tsx
      participant mp as Mixpanel
  
      init->>store: INITIAL_STATE.shareAnalytics = true
      init->>start: startAnalytics(store)
      start->>store: trackingEnabledSelector(state)
      store-->>start: true (from defaults)
      start->>mp: identify({ shareAnalytics: true }) ❌
      init->>store: fetchSettings(persisted)
      Note over default: corrective useEffect mounts
      default->>store: setShareAnalytics(false)
      Note right of default: no updateIdentify call
      Note over mp: still believes shareAnalytics: true
```                                                                   

### After — opt-out by default, settings dispatched first
```mermaid                                                                                    
  sequenceDiagram
      autonumber
      participant init as init.tsx
      participant store as Redux store
      participant start as startAnalytics
      participant dialog as ConsentDialog
      participant mp as Mixpanel

      init->>store: INITIAL_STATE.shareAnalytics = false
      init->>store: fetchSettings(persisted)
      init->>start: startAnalytics(store)
      start->>store: trackingEnabledSelector(state)
      store-->>start: false (no consent)
      Note over start: early return — no identify
      Note over mp: silent until explicit consent

      Note over dialog,mp: later, when user makes a choice
      dialog->>store: setShareAnalytics(true|false)
      dialog->>mp: updateIdentify({ force: true })
      mp-->>dialog: ✓ remote state matches local
  ```  

#### Problem

Both analytics consent flags (`shareAnalytics`, `sharePersonalizedRecommandations`) defaulted to `true` in Redux `INITIAL_STATE`, contradicting the original opt-in spec ([LIVE-11319](https://ledgerhq.atlassian.net/browse/LIVE-11319)). Combined with a boot-time race and a missing `updateIdentify` call, un-consented users were being reported to Mixpanel as opted-in, while Redux locally moved them to `false/false` once the corrective effect ran. The local Redux state and the remote Mixpanel state could disagree until the user explicitly toggled their preference or completed the consent dialog.

#### Solution

Three coordinated changes:

1. **Defaults flipped to `false`** in `apps/ledger-live-desktop/src/renderer/reducers/settings.ts`. New users and users who never made an explicit choice now start opted-out. Returning users who explicitly opted in or out keep their persisted preference via the `FETCH_SETTINGS` merge.

2. **Boot order fixed in `init.tsx`.** `startAnalytics(store)` now runs *after* `fetchSettings(...)(store.dispatch)` has dispatched, so `trackingEnabledSelector` reads the user's persisted consent rather than `INITIAL_STATE`. Previously `startAnalytics` ran first and observed the (incorrect) default `true/true` state for everyone.

3. **Dead corrective `useEffect` removed** from `Default.tsx`. With the new defaults the effect is redundant. It was also the source of the state-drift behavior because it dispatched flag changes to `false` without ever calling `updateIdentify`, so Mixpanel never learned about the correction.

#### Why no data migration

`FETCH_SETTINGS` merges persisted state on top of `INITIAL_STATE`, which means:
- Returning opted-in users keep their persisted `true`.
- Returning opted-out users keep their persisted `false`.
- Users with stale persisted `true` from the old buggy default will be re-prompted by the new MVVM `AnalyticsConsentDialog`, which uses `force: true` to push their explicit decision to Mixpanel.

A migration that flipped persisted `true` → `false` would risk regressing legitimate opt-ins. The bounded window (until the consent dialog re-prompts) is the safer trade-off.

#### Why no `force: true` on boot-time `updateIdentify` calls

The established pattern in the codebase is to force-identify only at moments of explicit consent change — the Settings toggle buttons (`ShareAnalyticsButton.tsx`, `ShareAnalyticsButtonFF.tsx`, `SharePersonalRecoButtonFF.tsx`) and `persistAnalyticsConsentAck` in the consent dialog. Forcing on every boot would send identify calls for users who have not consented, which goes against the intent of the opt-in flag itself.

Orphaned Mixpanel records (e.g. for users who opted in, then performed a hard reset) are an acceptable trade-off: UUIDs are not reused (`@ledgerhq/client-ids/store/slice.ts:23-36` generates a fresh `v4` UUID when persisted state is missing), and the properties attached to the orphaned record contain no directly-identifying information.

#### History

A May 2024 attempt at this fix ([`9ce66ffc48`](https://github.com/LedgerHQ/ledger-live/commit/9ce66ffc48)) flipped the defaults to `false` but missed the boot-order issue — `startAnalytics` ran via a Redux middleware on the first dispatched action, before any settings were loaded, so `trackingEnabledSelector` returned `false` and analytics never started for anyone. That commit reverted defaults back to `true` instead of fixing the ordering. This PR fixes the ordering directly and keeps the corrected defaults.

#### Tests

- **Reducer tests** (`reducers/settings.test.ts`) cover the new defaults and the `FETCH_SETTINGS` merge that preserves persisted opt-in for returning users.
- **`Default.test.tsx`** renders `Default` under the exact conditions that *would* have triggered the removed corrective `useEffect` (feature flag enabled, `entryPoints: ["Portfolio"]`, prompt unseen, `shareAnalytics: true` initially) and asserts the consent flags stay unchanged. Re-introducing the corrective effect would flip them and fail loudly.

### ❓ Context

- **JIRA**: [LIVE-30334](https://ledgerhq.atlassian.net/browse/LIVE-30334)
- **Related ticket**: [LIVE-11319](https://ledgerhq.atlassian.net/browse/LIVE-11319) (original opt-in spec)

[LIVE-11319]: https://ledgerhq.atlassian.net/browse/LIVE-11319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ