### PR TITLE
[LWDM] fix(coin-tezos): move `computeIntentType` to `BridgeApi`

### DIFF
--- a/.changeset/red-radios-fetch.md
+++ b/.changeset/red-radios-fetch.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-tezos": patch
+"@ledgerhq/live-common": patch
+---
+
+fix(coin-tezos): move `computeIntentType` to `BridgeApi`

--- a/libs/coin-modules/coin-tezos/src/api/index.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.ts
@@ -15,7 +15,6 @@ import type {
   FeeEstimation,
   TransactionIntent,
 } from "@ledgerhq/coin-module-framework/api/types";
-import type { BridgeApi } from "@ledgerhq/ledger-wallet-framework/api/types";
 import { craftTransactionData } from "@ledgerhq/coin-module-framework/logic/craftTransactionData";
 import { RecommendUndelegation } from "@ledgerhq/errors";
 import { log } from "@ledgerhq/logs";
@@ -50,22 +49,10 @@ import {
 import type { TezosFeeEstimation } from "./types";
 import type { TezosOperationMode } from "../types/model";
 
-export function createApi(config: TezosConfig): AlpacaApi & BridgeApi {
+export function createApi(config: TezosConfig): AlpacaApi {
   coinConfig.setCoinConfig(() => ({ ...config, status: { type: "active" } }));
 
   return {
-    computeIntentType: (transaction: Record<string, unknown>): string => {
-      switch (transaction.mode) {
-        case "delegate":
-        case "undelegate":
-        case "stake":
-        case "unstake":
-        case "finalize_unstake":
-          return transaction.mode;
-        default:
-          return "send";
-      }
-    },
     broadcast,
     combine,
     craftTransaction: craft,

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/families/tezos/bridge.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/families/tezos/bridge.test.ts
@@ -1,7 +1,7 @@
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import { setCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { getAssetFromToken, getTokenFromAsset } from "./bridge";
+import { computeIntentType, getAssetFromToken, getTokenFromAsset } from "./bridge";
 
 beforeAll(() => {
   const tezos = getCryptoCurrencyById("tezos");
@@ -95,6 +95,20 @@ describe("generic-coin-framework Tezos token", () => {
         name: "Tether USD",
         unit: { name: "Tether USD", code: "USDt", magnitude: 6 },
       });
+    });
+  });
+
+  describe("computeIntentType", () => {
+    it.each([
+      ["delegate", "delegate"],
+      ["undelegate", "undelegate"],
+      ["stake", "stake"],
+      ["unstake", "unstake"],
+      ["finalize_unstake", "finalize_unstake"],
+      ["send", "send"],
+      ["unknown", "send"],
+    ])("computes the intent type related to the '%s' mode", (mode, expectedIntentType) => {
+      expect(computeIntentType({ mode } as any)).toEqual(expectedIntentType);
     });
   });
 });

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/families/tezos/bridge.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/families/tezos/bridge.ts
@@ -22,8 +22,22 @@ export function getAssetFromToken(token: TokenCurrency, owner: string): AssetInf
   };
 }
 
+export function computeIntentType(transaction: Record<string, unknown>): string {
+  switch (transaction.mode) {
+    case "delegate":
+    case "undelegate":
+    case "stake":
+    case "unstake":
+    case "finalize_unstake":
+      return transaction.mode;
+    default:
+      return "send";
+  }
+}
+
 export default {
   getTokenFromAsset,
   getAssetFromToken,
   usesStakingPositions: true,
+  computeIntentType,
 } satisfies BridgeApi;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Tezos transaction flows

### 📝 Description

Clicking **Delegate to earn rewards** fails fee estimation with:

> Fees estimation failed: `proto.024-PtTALLiN.operations.stake_modification_with_no_delegate_set`

The cause is that `computeIntentType` was returned at the `AlpacaApi` level, but the generic adapter expects it at the `BridgeApi` level. The fallback to the default method is not suitable in that context.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-30426
- **ADR link (if any)**:

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.
