### PR TITLE
[LWDM] fix(coin-aptos): extract validation logic + fix token balance validation

### DIFF
--- a/.changeset/old-walls-deliver.md
+++ b/.changeset/old-walls-deliver.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-aptos": patch
+---
+
+Refactor Aptos transaction validation and fix token send balance checks (fixes #17285)  
+

--- a/.changeset/old-walls-deliver.md
+++ b/.changeset/old-walls-deliver.md
@@ -2,5 +2,4 @@
 "@ledgerhq/coin-aptos": patch
 ---
 
-Refactor Aptos transaction validation and fix token send balance checks (fixes #17285)  
-
+Refactor Aptos transaction validation and fix token send balance checks (fixes #17285)

--- a/libs/coin-modules/coin-aptos/src/__tests__/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-aptos/src/__tests__/bridge/getTransactionStatus.test.ts
@@ -4,6 +4,7 @@ import {
   InvalidAddress,
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
+  NotEnoughBalanceFees,
   NotEnoughToRestake,
   NotEnoughToStake,
   NotEnoughToUnstake,
@@ -82,7 +83,6 @@ describe("getTransactionStatus Test", () => {
     const expected = {
       errors: {
         fees: new FeeNotLoaded(),
-        amount: new NotEnoughBalance(),
       },
       warnings: {},
       estimatedFees: BigNumber(0),
@@ -93,9 +93,9 @@ describe("getTransactionStatus Test", () => {
     expect(result).toEqual(expected);
   });
 
-  it("should return error for NotEnoughBalance", async () => {
+  it("should return error for NotEnoughBalance when native currency insufficient for amount and fees", async () => {
     const account = createFixtureAccount();
-    account.spendableBalance = BigNumber(1);
+    account.spendableBalance = BigNumber(3);
 
     const transaction = createFixtureTransaction();
     transaction.recipient = "0x" + "0".repeat(64);
@@ -191,7 +191,7 @@ describe("getTransactionStatus Test", () => {
     expect(result).toEqual(expected);
   });
 
-  it("should return error for NotEnoughBalance for token account with use all amount option when not enough fees", async () => {
+  it("should return error for NotEnoughBalanceFees for token account with use all amount option when not enough fees", async () => {
     const account = createFixtureAccountWithSubAccount("coin");
     account.spendableBalance = BigNumber(10);
 
@@ -205,7 +205,7 @@ describe("getTransactionStatus Test", () => {
 
     const expected = {
       errors: {
-        amount: new NotEnoughBalance(),
+        amount: new NotEnoughBalanceFees(),
       },
       warnings: {},
       estimatedFees: BigNumber(200),
@@ -216,7 +216,7 @@ describe("getTransactionStatus Test", () => {
     expect(result).toEqual(expected);
   });
 
-  it("should return error for NotEnoughBalanceFees", async () => {
+  it("should return error for NotEnoughBalanceFees when maxGasAmount has GasInsufficientBalance error", async () => {
     const account = createFixtureAccountWithSubAccount("coin");
     account.spendableBalance = BigNumber(1);
 
@@ -230,12 +230,36 @@ describe("getTransactionStatus Test", () => {
 
     const expected = {
       errors: {
-        amount: new NotEnoughBalance(),
+        amount: new NotEnoughBalanceFees(),
       },
       warnings: {},
       estimatedFees: BigNumber(0),
       amount: BigNumber(2),
       totalSpent: BigNumber(2),
+    };
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should return error for NotEnoughBalanceFees for token account when insufficient fee balance", async () => {
+    const account = createFixtureAccountWithSubAccount("coin");
+    account.spendableBalance = BigNumber(1);
+
+    const transaction = createFixtureTransactionWithSubAccount();
+    transaction.recipient = "0x" + "0".repeat(64);
+    transaction.amount = BigNumber(500);
+    transaction.fees = BigNumber(2);
+
+    const result = await getTransactionStatus(account, transaction);
+
+    const expected = {
+      errors: {
+        amount: new NotEnoughBalanceFees(),
+      },
+      warnings: {},
+      estimatedFees: BigNumber(2),
+      amount: BigNumber(500),
+      totalSpent: BigNumber(500),
     };
 
     expect(result).toEqual(expected);
@@ -255,7 +279,6 @@ describe("getTransactionStatus Test", () => {
     const expected = {
       errors: {
         recipient: new RecipientRequired(),
-        amount: new NotEnoughBalance(),
       },
       warnings: {},
       estimatedFees: BigNumber(2),
@@ -317,6 +340,8 @@ describe("getTransactionStatus Test", () => {
 
   it("should return error for RecipientRequired", async () => {
     const account = createFixtureAccount();
+    account.spendableBalance = BigNumber(10);
+
     const transaction = createFixtureTransaction();
 
     transaction.amount = BigNumber(2);
@@ -329,7 +354,6 @@ describe("getTransactionStatus Test", () => {
     const expected = {
       errors: {
         recipient: new RecipientRequired(),
-        amount: new NotEnoughBalance(),
       },
       warnings: {},
       estimatedFees: BigNumber(2),

--- a/libs/coin-modules/coin-aptos/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-aptos/src/bridge/getTransactionStatus.ts
@@ -29,6 +29,48 @@ import { getStakingPosition } from "../logic/staking";
 import type { AptosAccount, AptosStakingPosition, Transaction, TransactionStatus } from "../types";
 import { getTokenAccount } from "./logic";
 
+const validateSendRecipient = (t: Transaction, a: AptosAccount): Error | null => {
+  if (!t.recipient) {
+    return new RecipientRequired();
+  }
+  if (t.recipient === a.freshAddress) {
+    return new InvalidAddressBecauseDestinationIsAlsoSource();
+  }
+  if (!AccountAddress.isValid({ input: t.recipient }).valid) {
+    return new InvalidAddress("", { currencyName: a.currency.name });
+  }
+  return null;
+};
+
+const validateSendTokenAmount = (
+  t: Transaction,
+  a: AptosAccount,
+  tokenAccount: TokenAccount,
+  estimatedFees: BigNumber,
+): Error | null => {
+  if (
+    t.errors?.maxGasAmount === "GasInsufficientBalance" ||
+    a.spendableBalance.isLessThan(estimatedFees)
+  ) {
+    return new NotEnoughBalanceFees();
+  }
+  if (tokenAccount.spendableBalance.isLessThan(t.amount)) {
+    return new NotEnoughBalance();
+  }
+  return null;
+};
+
+const validateSendNativeAmount = (
+  t: Transaction,
+  a: AptosAccount,
+  estimatedFees: BigNumber,
+): Error | null => {
+  if (a.spendableBalance.isLessThan(t.amount.plus(estimatedFees))) {
+    return new NotEnoughBalance();
+  }
+  return null;
+};
+
 const checkSendTransaction = (
   t: Transaction,
   a: AptosAccount,
@@ -38,34 +80,18 @@ const checkSendTransaction = (
 ): Record<string, Error> => {
   const newErrors = { ...errors };
 
-  if (!t.recipient) {
-    newErrors.recipient = new RecipientRequired();
+  const recipientError = validateSendRecipient(t, a);
+  if (recipientError) {
+    newErrors.recipient = recipientError;
   }
 
-  if (!AccountAddress.isValid({ input: t.recipient }).valid && !newErrors.recipient) {
-    newErrors.recipient = new InvalidAddress("", { currencyName: a.currency.name });
-  }
-
-  if (t.recipient === a.freshAddress && !newErrors.recipient) {
-    newErrors.recipient = new InvalidAddressBecauseDestinationIsAlsoSource();
-  }
-
-  if (t.amount.gt(a.balance) && !newErrors.amount) {
-    newErrors.amount = new NotEnoughBalance();
-  }
-
-  if (tokenAccount && t.errors?.maxGasAmount === "GasInsufficientBalance" && !newErrors.amount) {
-    newErrors.amount = new NotEnoughBalanceFees();
-  }
-
-  if (
-    (tokenAccount
-      ? tokenAccount.spendableBalance.isLessThan(t.amount) ||
-        a.spendableBalance.isLessThan(estimatedFees)
-      : a.spendableBalance.isLessThan(t.amount.plus(estimatedFees))) &&
-    !newErrors.amount
-  ) {
-    newErrors.amount = new NotEnoughBalance();
+  if (!newErrors.amount) {
+    const amountError = tokenAccount
+      ? validateSendTokenAmount(t, a, tokenAccount, estimatedFees)
+      : validateSendNativeAmount(t, a, estimatedFees);
+    if (amountError) {
+      newErrors.amount = amountError;
+    }
   }
 
   return newErrors;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.  
- [x] **Covered by automatic tests.** 
- [x] **Impact of the changes:** 
 - Token send validation now correctly compares the token amount against the token balance, not the native APT balance. Previously the token amount (in raw units) was compared against the APT    
  balance (in raw units), which caused valid token sends to be incorrectly rejected with "insufficient funds".                                                                                      
  - Native APT send validation was also corrected: the check now uses spendableBalance instead of balance, and fees are included in the comparison (amount + fees vs spendableBalance).
  - QA should verify: token sends (e.g. USDT on Aptos) are accepted when token balance is sufficient; native APT sends correctly reject when amount + fees exceeds spendable balance; fee errors are
   correctly surfaced when APT balance is insufficient to cover gas.   

### 📝 Description
  Fixes #17285 — Aptos token sends (e.g. USDT) were incorrectly rejected with "Sorry, insufficient funds" even when the token balance was sufficient.                                               
   
  Previous behaviour: The token amount (in raw units) was compared against the native APT balance (also in raw units) instead of the token's own balance. These are amounts of different assets, so the comparison was meaningless and caused false-positive validation errors.
                                                                                                                                                                                                    
  Fix:                                                      
  - Extracted send validation into dedicated helpers — validateSendTokenAmount and validateSendNativeAmount — so token sends are validated against tokenAccount.spendableBalance and native APT sends are validated against account.spendableBalance including fees.                                                                                                                              
  - Native APT validation was also corrected to use spendableBalance (instead of balance) and to account for fees in the comparison (amount + fees vs spendableBalance).
                                                                                                                                                                                                    
  Tests:                                                                                                                                                                                            
  - The existing test "should return error for NotEnoughBalance" was updated: spendableBalance was raised from 1 to 3 to make the test meaningful — with amount = 2 and fees = 2, the balance of 3 is greater than either value individually but less than their sum (2 + 2 = 4). This ensures the test only passes if the validation correctly checks amount + fees together, not each value in     
  isolation.                                                                                                                                                                                   
  - amount: new NotEnoughBalance() was removed from the expected errors in three tests — "should return error for FeeNotLoaded" and two "should return error for RecipientRequired" tests.          
  Previously spendableBalance was set lower than the transaction amount, so the amount error appeared as a side effect alongside the primary error. The tests were narrowed so that only the intended error (fees or recipient) is returned, making each test verify a single validation concern. 
  
<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: #17285
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
