### PR TITLE
[LWDM] fix(coin-aptos): fix fee estimation being skipped when token send amount exceeds native APT balance in raw units

### DIFF
--- a/.changeset/heavy-carrots-talk.md
+++ b/.changeset/heavy-carrots-talk.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aptos": patch
+---
+
+Fix network fees not displayed when token send amount (in raw units) exceeds native APT balance but is within token balance

--- a/libs/coin-modules/coin-aptos/src/__tests__/bridge/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-aptos/src/__tests__/bridge/prepareTransaction.test.ts
@@ -3,7 +3,12 @@ import { getEstimatedGas } from "../../bridge/getFeesForTransaction";
 import { getMaxSendBalance } from "../../bridge/logic";
 import prepareTransaction from "../../bridge/prepareTransaction";
 import { AptosAPI } from "../../network";
+
 import type { AptosAccount, Transaction } from "../../types";
+import {
+  createFixtureAccountWithSubAccount,
+  createFixtureTransactionWithSubAccount,
+} from "../../bridge/bridge.fixture";
 
 jest.mock("../../network");
 jest.mock("../../bridge/getFeesForTransaction");
@@ -15,6 +20,7 @@ describe("Aptos prepareTransaction", () => {
     let transaction: Transaction;
 
     beforeEach(() => {
+      jest.clearAllMocks();
       account = {
         id: "test-account-id",
         name: "Test Account",
@@ -126,6 +132,66 @@ describe("Aptos prepareTransaction", () => {
         ...transaction,
         fees: null,
       });
+    });
+
+    it("should estimate fees for native APT send when amount is within native APT balance", async () => {
+      transaction.recipient = "test-recipient";
+      transaction.amount = new BigNumber(500); // send amount (500) < native balance (1000)
+
+      (getEstimatedGas as jest.Mock).mockResolvedValue({
+        fees: new BigNumber(20_000),
+        estimate: { maxGasAmount: new BigNumber(200), gasUnitPrice: new BigNumber(100) },
+        errors: {},
+      });
+
+      const result = await prepareTransaction(account, transaction);
+
+      expect(result.fees?.isEqualTo(new BigNumber(20_000))).toBe(true);
+    });
+
+    it("should skip fee estimation for native APT send when amount exceeds native APT balance", async () => {
+      transaction.recipient = "test-recipient";
+      transaction.amount = new BigNumber(2000); // send amount (2000) > native balance (1000)
+
+      await prepareTransaction(account, transaction);
+
+      expect(getEstimatedGas).not.toHaveBeenCalled();
+    });
+
+    it("should estimate fees for token send when amount (in raw units) is within token balance — even if it exceeds native APT balance", async () => {
+      const account = createFixtureAccountWithSubAccount("coin");
+      account.spendableBalance = new BigNumber(100_000);
+      account.subAccounts![0].spendableBalance = new BigNumber(300_000);
+
+      const transaction = createFixtureTransactionWithSubAccount();
+      transaction.recipient = "test-recipient";
+      // native balance (100_000) < send amount (200_000) < token balance (300_000)
+      transaction.amount = new BigNumber(200_000);
+
+      (getEstimatedGas as jest.Mock).mockResolvedValue({
+        fees: new BigNumber(20_000),
+        estimate: { maxGasAmount: new BigNumber(200), gasUnitPrice: new BigNumber(100) },
+        errors: {},
+      });
+
+      const result = await prepareTransaction(account, transaction);
+
+      expect(result.fees?.isEqualTo(new BigNumber(20_000))).toBe(true);
+    });
+
+    it("should skip fee estimation for token send when amount (in raw units) exceeds token balance — even if it is within native APT balance", async () => {
+      const account = createFixtureAccountWithSubAccount("coin");
+      account.spendableBalance = new BigNumber(300_000);
+      account.subAccounts![0].spendableBalance = new BigNumber(100_000);
+
+      const transaction = createFixtureTransactionWithSubAccount();
+      transaction.recipient = "test-recipient";
+      // token balance (100_000) < send amount (200_000) < native balance (300_000)
+      transaction.amount = new BigNumber(200_000);
+
+      await prepareTransaction(account, transaction);
+
+      expect(getEstimatedGas).not.toHaveBeenCalled();
     });
   });
 });

--- a/libs/coin-modules/coin-aptos/src/bridge/prepareTransaction.ts
+++ b/libs/coin-modules/coin-aptos/src/bridge/prepareTransaction.ts
@@ -11,9 +11,18 @@ import {
 } from "./../constants";
 import { getEstimatedGas } from "./getFeesForTransaction";
 import { getMaxSendBalance } from "./logic";
+import { TokenAccount } from "@ledgerhq/types-live";
 
-const checkSendConditions = (transaction: Transaction, account: AptosAccount) =>
-  transaction.mode === "send" && transaction.amount.gt(account.spendableBalance);
+const checkSendConditions = (
+  transaction: Transaction,
+  account: AptosAccount,
+  tokenAccount: TokenAccount | undefined,
+) => {
+  if (transaction.mode !== "send") return false;
+  const spendableBalance = tokenAccount ? tokenAccount.spendableBalance : account.spendableBalance;
+
+  return transaction.amount.gt(spendableBalance);
+};
 
 const checkStakeConditions = (transaction: Transaction, account: AptosAccount) => {
   const txAmount = transaction.useAllAmount ? account.spendableBalance : transaction.amount;
@@ -52,9 +61,11 @@ const prepareTransaction = async (
   account: AptosAccount,
   transaction: Transaction,
 ): Promise<Transaction> => {
+  const tokenAccount = findSubAccountById(account, transaction?.subAccountId ?? "");
+
   if (
     !transaction.recipient ||
-    checkSendConditions(transaction, account) ||
+    checkSendConditions(transaction, account, tokenAccount) ||
     checkStakeConditions(transaction, account) ||
     checkRestakeConditions(transaction, account) ||
     checkUnstakeConditions(transaction, account) ||
@@ -72,7 +83,6 @@ const prepareTransaction = async (
   }
 
   const aptosClient = new AptosAPI(account.currency.id);
-  const tokenAccount = findSubAccountById(account, transaction?.subAccountId ?? "");
 
   try {
     const { fees, estimate, errors } = await getEstimatedGas(account, transaction, aptosClient);

--- a/libs/coin-modules/coin-aptos/src/bridge/prepareTransaction.ts
+++ b/libs/coin-modules/coin-aptos/src/bridge/prepareTransaction.ts
@@ -3,6 +3,7 @@ import BigNumber from "bignumber.js";
 
 import { getDelegationOpMaxAmount, getStakingPosition } from "../logic/staking";
 import { AptosAPI } from "../network";
+import type { TokenAccount } from "@ledgerhq/types-live";
 import type { AptosAccount, Transaction } from "../types";
 import {
   APTOS_DELEGATION_RESERVE_IN_OCTAS,
@@ -11,7 +12,6 @@ import {
 } from "./../constants";
 import { getEstimatedGas } from "./getFeesForTransaction";
 import { getMaxSendBalance } from "./logic";
-import { TokenAccount } from "@ledgerhq/types-live";
 
 const checkSendConditions = (
   transaction: Transaction,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** 
  - Fee estimation in the Aptos send flow now correctly uses the token balance (instead of native APT balance) to decide whether to skip simulation
  - Network fees are now correctly displayed when sending tokens with a valid token amount, regardless of the native APT balance 
  - QA should focus on: sending USDT (or other Aptos tokens) from an account with a low native APT balance — fees should be displayed correctly on the amount step

### 📝 Description

Network fees showed as 0 when sending tokens (e.g. USDT) with an amount that exceeded the native APT balance in raw units — even if the token balance was sufficient.

  Root cause: fee estimation was skipped when transaction.amount > account.spendableBalance (native APT), but for token sends the comparison should be against the token balance.

Fix: compare send amount against token balance for token sends, and native APT balance for native sends.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: #17304
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
