### PR TITLE
[LWDM] feat(common): add pnl param to wallet40 feature flags

### DIFF
--- a/.changeset/lucky-panthers-flow.md
+++ b/.changeset/lucky-panthers-flow.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/types-live": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+"@shared/feature-flags": minor
+---
+
+Add PnL feature flag param to wallet40 feature flags

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/constants.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/constants.ts
@@ -19,6 +19,7 @@ export const WALLET_FEATURES_PARAMS = [
   { key: "aggregatedAssets", label: "Aggregated Assets" },
   { key: "myWallet", label: "My Wallet" },
   { key: "finishOnboardingWidget", label: "Finish Onboarding Widget" },
+  { key: "pnl", label: "PnL" },
 ] as const;
 
 export type WalletFeatureParamKey = (typeof WALLET_FEATURES_PARAMS)[number]["key"];

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Wallet40/useWallet40ViewModel.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Wallet40/useWallet40ViewModel.ts
@@ -18,6 +18,7 @@ export const WALLET_40_PARAMS = [
   { key: "operationsList", label: "TX History" },
   { key: "aggregatedAssets", label: "Aggregated Assets" },
   { key: "myWallet", label: "My Wallet" },
+  { key: "pnl", label: "PnL" },
 ] as const;
 
 type WalletFeatureParamKey = (typeof WALLET_40_PARAMS)[number]["key"];

--- a/e2e/mobile/utils/constants.ts
+++ b/e2e/mobile/utils/constants.ts
@@ -17,6 +17,7 @@ export const WALLET_40_FEATURE_FLAGS = {
       operationsList: true,
       aggregatedAssets: true,
       myWallet: false,
+      pnl: false,
     },
   },
 } as const;

--- a/e2e/mobile/utils/initUtil.ts
+++ b/e2e/mobile/utils/initUtil.ts
@@ -334,6 +334,7 @@ export class InitializationManager {
           operationsList: false,
           aggregatedAssets: false,
           myWallet: isWallet40,
+          pnl: false,
         },
       },
       llmModularDrawer: {

--- a/libs/ledger-live-common/src/analytics/featureFlagHelpers/wallet40.ts
+++ b/libs/ledger-live-common/src/analytics/featureFlagHelpers/wallet40.ts
@@ -31,5 +31,6 @@ export const getWallet40Attributes = (
     operationsList: wallet40FeatureFlag?.params?.operationsList ?? false,
     myWallet: wallet40FeatureFlag?.params?.myWallet ?? false,
     aggregatedAssets: wallet40FeatureFlag?.params?.aggregatedAssets ?? false,
+    pnl: wallet40FeatureFlag?.params?.pnl ?? false,
   };
 };

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -834,6 +834,7 @@ export const DEFAULT_FEATURES: Features = {
       operationsList: true,
       aggregatedAssets: true,
       myWallet: true,
+      pnl: true,
     },
   },
   lwdWallet40: {
@@ -853,6 +854,7 @@ export const DEFAULT_FEATURES: Features = {
       brazePlacement: true,
       aggregatedAssets: true,
       myWallet: true,
+      pnl: true,
       finishOnboardingWidget: false,
     },
   },

--- a/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/types.ts
+++ b/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/types.ts
@@ -16,6 +16,7 @@ export type Wallet40Params = {
   readonly operationsList?: boolean;
   readonly aggregatedAssets?: boolean;
   readonly myWallet?: boolean;
+  readonly pnl?: boolean;
   readonly finishOnboardingWidget?: boolean;
   readonly earnUpselling?: boolean;
   readonly earnSimulator?: boolean;
@@ -60,6 +61,8 @@ export interface WalletFeaturesConfig {
   readonly shouldDisplayAggregatedAssets: boolean;
   /** Whether to show the My Wallet component */
   readonly shouldDisplayMyWallet: boolean;
+  /** Whether to show the PNL component */
+  readonly shouldDisplayPnl: boolean;
   /** Whether to show the Finish Onboarding widget on Portfolio (desktop / lwdWallet40) */
   readonly shouldDisplayFinishOnboardingWidget: boolean;
   /** Whether to show the Earn Upselling component */

--- a/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.test.ts
+++ b/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.test.ts
@@ -51,6 +51,7 @@ const makeConfig = (
   shouldDisplayOperationsList: value,
   shouldDisplayMyWallet: value,
   shouldDisplayAggregatedAssets: value,
+  shouldDisplayPnl: value,
   shouldDisplayFinishOnboardingWidget: value,
   shouldDisplayEarnUpselling: value,
   shouldDisplayEarnSimulator: value,
@@ -73,6 +74,7 @@ const makeParams = (value: boolean): Wallet40Params => ({
   operationsList: value,
   aggregatedAssets: value,
   myWallet: value,
+  pnl: value,
   finishOnboardingWidget: value,
   earnUpselling: value,
   earnSimulator: value,
@@ -143,9 +145,14 @@ describe("useWalletFeaturesConfig hook", () => {
         ["operationsList", { operationsList: true }, { shouldDisplayOperationsList: true }],
         ["aggregatedAssets", { aggregatedAssets: true }, { shouldDisplayAggregatedAssets: true }],
         ["myWallet", { myWallet: true }, { shouldDisplayMyWallet: true }],
-        ["finishOnboardingWidget", { finishOnboardingWidget: true }, { shouldDisplayFinishOnboardingWidget: true }],
+        [
+          "finishOnboardingWidget",
+          { finishOnboardingWidget: true },
+          { shouldDisplayFinishOnboardingWidget: true },
+        ],
         ["earnUpselling", { earnUpselling: true }, { shouldDisplayEarnUpselling: true }],
         ["earnSimulator", { earnSimulator: true }, { shouldDisplayEarnSimulator: true }],
+        ["pnl", { pnl: true }, { shouldDisplayPnl: true }],
       ])("should return correct config when only %s is enabled", (_, params, expectedOverrides) => {
         const { result } = renderWalletFeaturesConfig(platform, {
           [flagKey]: createFeatureFlag(true, params),

--- a/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.ts
+++ b/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.ts
@@ -48,6 +48,7 @@ export const useWalletFeaturesConfig = (platform: WalletPlatform): WalletFeature
       shouldDisplayOperationsList: isEnabled && Boolean(params?.operationsList),
       shouldDisplayAggregatedAssets: isEnabled && Boolean(params?.aggregatedAssets),
       shouldDisplayMyWallet: isEnabled && Boolean(params?.myWallet),
+      shouldDisplayPnl: isEnabled && Boolean(params?.pnl),
       shouldDisplayFinishOnboardingWidget:
         isEnabled &&
         Boolean(params && "finishOnboardingWidget" in params && params.finishOnboardingWidget),

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -872,6 +872,7 @@ type Feature_Wallet40_Params = {
   operationsList: boolean;
   aggregatedAssets: boolean;
   myWallet: boolean;
+  pnl: boolean;
   // Specifics
   brazePlacement?: boolean;
   newReceiveDialog?: boolean;

--- a/shared/feature-flags/src/flags/team-wallet-xp/lwdWallet40.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/lwdWallet40.ts
@@ -17,6 +17,7 @@ export const lwdWallet40 = flagWith(
     aggregatedAssets: z.boolean(),
     myWallet: z.boolean(),
     finishOnboardingWidget: z.boolean().optional(),
+    pnl: z.boolean(),
   },
   {
     enabled: false,
@@ -35,6 +36,7 @@ export const lwdWallet40 = flagWith(
       aggregatedAssets: true,
       myWallet: true,
       finishOnboardingWidget: false,
+      pnl: true,
     },
   },
 );

--- a/shared/feature-flags/src/flags/team-wallet-xp/lwmWallet40.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/lwmWallet40.ts
@@ -18,6 +18,7 @@ export const lwmWallet40 = flagWith(
     myWallet: z.boolean(),
     quickActionsCtasVariant: z.boolean().optional(),
     brazePlacement: z.boolean().optional(),
+    pnl: z.boolean(),
   },
   {
     enabled: false,
@@ -34,6 +35,7 @@ export const lwmWallet40 = flagWith(
       operationsList: true,
       aggregatedAssets: true,
       myWallet: true,
+      pnl: true,
     },
   },
 );


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Wallet40 feature flag configuration across desktop and mobile
      - PnL component visibility controlled by new `pnl` param
      - Analytics attributes for wallet40 now include `pnl`

### 📝 Description

This PR adds a new `pnl` (Profit and Loss) feature flag parameter to the wallet40 feature flags, enabling feature-flagged control of the PnL component across both desktop and mobile platforms.

**Changes include:**
- Added `pnl` boolean param to `Wallet40Params` type and `Feature_Wallet40_Params`
- Added `shouldDisplayPnl` to `WalletFeaturesConfig` interface
- Updated `useWalletFeaturesConfig` hook to map the new param
- Added Zod schema validation for `pnl` in both `lwdWallet40` and `lwmWallet40` flags
- Updated default features with `pnl: true`
- Added `pnl` to analytics wallet40 attributes
- Added `pnl` to desktop and mobile dev tool params
- Updated unit tests with full coverage

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30293](https://ledgerhq.atlassian.net/browse/LIVE-30293)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30293]: https://ledgerhq.atlassian.net/browse/LIVE-30293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ