### PR TITLE
[LWM] fix(mobile): track top wallet deeplink location

### DIFF
--- a/.changeset/live-30385-top-wallet-deeplink.md
+++ b/.changeset/live-30385-top-wallet-deeplink.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix top wallet content card deeplink location tracking

--- a/apps/ledger-live-mobile/src/dynamicContent/utils.test.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/utils.test.tsx
@@ -1,0 +1,46 @@
+import type { ContentCard } from "@braze/react-native-sdk";
+import { mapAsCategoryContentCard } from "./utils";
+
+const createCategoryCard = (extras: ContentCard["extras"]): ContentCard => ({
+  id: "card-id",
+  created: 1690112400,
+  expiresAt: -1,
+  viewed: false,
+  clicked: false,
+  pinned: false,
+  dismissed: false,
+  dismissible: true,
+  openURLInWebView: true,
+  isControl: false,
+  extras,
+  type: "Classic",
+  title: "Action card",
+  cardDescription: "Action card description",
+});
+
+describe("mapAsCategoryContentCard", () => {
+  it("should use top_wallet location when category id is alwayson", () => {
+    const card = createCategoryCard({
+      id: "alwayson",
+      link: "ledgerlive://discover/app",
+    });
+
+    const category = mapAsCategoryContentCard(card);
+
+    expect(category.location).toBe("top_wallet");
+    expect(category.link).toBe("ledgerlive://discover/app?deeplinkLocation=top_wallet");
+  });
+
+  it("should fall back to extras location for other category ids", () => {
+    const card = createCategoryCard({
+      id: "my-ledger-category",
+      location: "my_ledger",
+      link: "ledgerlive://discover/app",
+    });
+
+    const category = mapAsCategoryContentCard(card);
+
+    expect(category.location).toBe("my_ledger");
+    expect(category.link).toBe("ledgerlive://discover/app?deeplinkLocation=my_ledger");
+  });
+});

--- a/apps/ledger-live-mobile/src/dynamicContent/utils.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/utils.tsx
@@ -89,25 +89,32 @@ export const formatCategories = (
   return categoriesWithAtLeastOneCard;
 };
 
-export const mapAsCategoryContentCard = (card: BrazeContentCard): CategoryContentCard => ({
-  id: card.id,
-  categoryId: card.extras.id,
-  location: card.extras.location as ContentCardLocation,
-  createdAt: card.created,
-  viewed: card.viewed,
-  order: parseOrder(card.extras.order),
-  cardsLayout: card.extras.cardsLayout as ContentCardsLayout,
-  cardsType: card.extras.cardsType as ContentCardsType,
-  type: card.extras.type as ContentCardsType.category,
-  title: card.extras.title,
-  description: card.extras.description,
-  link: appendDeeplinkLocationIfDefined(card.extras.link, card.extras.location),
-  cta: card.extras.cta,
-  isDismissable: Boolean(card.extras?.isDismissable === "true"),
-  hasPagination: Boolean(card.extras?.hasPagination === "true"),
-  centeredText: Boolean(card.extras?.centeredText === "true"),
-  extras: card.extras,
-});
+export const mapAsCategoryContentCard = (card: BrazeContentCard): CategoryContentCard => {
+  const location =
+    card.extras.id === "alwayson"
+      ? ContentCardLocation.TopWallet
+      : (card.extras.location as ContentCardLocation);
+
+  return {
+    id: card.id,
+    categoryId: card.extras.id,
+    location: location,
+    createdAt: card.created,
+    viewed: card.viewed,
+    order: parseOrder(card.extras.order),
+    cardsLayout: card.extras.cardsLayout as ContentCardsLayout,
+    cardsType: card.extras.cardsType as ContentCardsType,
+    type: card.extras.type as ContentCardsType.category,
+    title: card.extras.title,
+    description: card.extras.description,
+    link: appendDeeplinkLocationIfDefined(card.extras.link, location),
+    cta: card.extras.cta,
+    isDismissable: Boolean(card.extras?.isDismissable === "true"),
+    hasPagination: Boolean(card.extras?.hasPagination === "true"),
+    centeredText: Boolean(card.extras?.centeredText === "true"),
+    extras: card.extras,
+  };
+};
 
 export const mapAsWalletContentCard = (card: BrazeContentCard): WalletContentCard => ({
   id: card.id,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Top wallet Braze content card deeplink tracking
  - `deeplinkLocation` query parameter appended to top wallet card links
  - Existing category content cards that rely on their configured location

### 📝 Description

`deeplinklocation` is missing from `deeplink_clicked` analytics events for top wallet content cards, which prevents the engagement team from attributing those deeplink clicks correctly.

This PR maps the `alwayson` content card category to the `top_wallet` dynamic content location in mobile, so generated deeplinks include `deeplinkLocation=top_wallet`. It also adds Jest coverage for the top wallet mapping and for the existing fallback behavior that uses the card's configured location.


https://github.com/user-attachments/assets/6bf317cc-f9eb-4877-b951-4e45bc0d2959

my_ledger still working
<img width="517" height="566" alt="image" src="https://github.com/user-attachments/assets/5f6a147d-53f7-40ef-9d1b-2b19f1cf2e6d" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-30385](https://ledgerhq.atlassian.net/browse/LIVE-30385)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-30385]: https://ledgerhq.atlassian.net/browse/LIVE-30385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ