### PR TITLE
[LWD] feat: add top coins banner

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/features/TopCoinBanner.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/TopCoinBanner.tsx
@@ -1,0 +1,25 @@
+import { useState, useEffect } from "react";
+
+export const TopCoinBanner = () => {
+  const [topCoins, setTopCoins] = useState<string[]>([]);
+
+  useEffect(() => {
+    const fetchTopCoins = async () => {
+      const res = await fetch("https://countervalues.live.ledger.com/v3/supported/crypto");
+      const data = await res.json();
+      setTopCoins(data.slice(0, 10));
+    };
+    fetchTopCoins();
+  }, []);
+
+  return (
+    <div>
+      <h1>Top Coin Banner</h1>
+      {topCoins.map(coin => (
+        <div key={coin}>
+          <h2>{coin}</h2>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/apps/ledger-live-desktop/src/renderer/screens/market/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/market/index.tsx
@@ -8,6 +8,7 @@ import MarketList from "./MarketList";
 import { useMarket } from "LLD/features/Market/hooks/useMarket";
 import SearchInputComponent from "./components/SearchInputComponent";
 import { useMarketListVirtualization } from "LLD/features/Market/hooks/useMarketListVirtualization";
+import { TopCoinBanner } from "../../../mvvm/features/TopCoinBanner";
 
 const Container = styled(Flex).attrs({
   flex: "1",
@@ -109,6 +110,7 @@ export default function Market() {
       <Title>{t("market.title")}</Title>
       <Flex flexDirection="row" pr="6px" my={2} alignItems="center" justifyContent="space-between">
         <SearchInputComponent search={search} updateSearch={updateSearch} />
+        <TopCoinBanner />
         <SelectBarContainer flexDirection="row" alignItems="center" justifyContent="flex-end">
           <Flex data-testid="market-countervalue-select" justifyContent="flex-end" mx={4}>
             <CounterValueSelect


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Mobile Market list standalone layout when `marketBanner` is enabled
  - Market banner rendering below search
  - Market banner tile navigation and analytics page attribution

### 📝 Description

Add a simple list of top coins to the market screen on desktop

### ❓ Context

- **JIRA or GitHub link**: N/A - no ticket link provided

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
