### PR TITLE
[LWM] fix(mobile): portfolio wallet banners section layout

### DIFF
--- a/.changeset/smooth-banners-tweak.md
+++ b/.changeset/smooth-banners-tweak.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix portfolio wallet banners layout: optional Recover wrapper, always show content cards with assets, and explicit fallback for onboarding/recover stack

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBannersSection/__tests__/PortfolioBannersSection.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBannersSection/__tests__/PortfolioBannersSection.test.tsx
@@ -79,6 +79,17 @@ describe("PortfolioBannersSection", () => {
       expect(screen.queryByTestId("mock-onboarding-widget")).toBeNull();
       expect(screen.queryByTestId("banners-page-indicator")).toBeNull();
     });
+
+    it("renders content cards without recover when recover banner is off", () => {
+      mockUseViewModel.mockReturnValue({
+        ...baseViewModel,
+        hasAssets: true,
+        shouldDisplayRecover: false,
+      });
+      renderSection({ showAssets: true });
+      expect(screen.getByTestId("mock-content-cards")).toBeVisible();
+      expect(screen.queryByTestId("mock-recover-banner")).toBeNull();
+    });
   });
 
   describe("carousel layout", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBannersSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBannersSection/index.tsx
@@ -80,8 +80,12 @@ export const PortfolioBannersSection = ({
         key="BannersSection"
         testID="portfolio-banners-section"
       >
-        <Box lx={{ paddingTop: "s12" }}>
-          <RecoverBanner paddingHorizontal="s0" />
+        <Box>
+          {shouldDisplayRecover && (
+            <Box lx={{ paddingTop: "s12" }}>
+              <RecoverBanner paddingHorizontal="s0" />
+            </Box>
+          )}
           <ContentCardsLocation
             key="contentCardsLocationPortfolio"
             locationId={ContentCardLocation.TopWallet}
@@ -129,18 +133,23 @@ export const PortfolioBannersSection = ({
     );
   }
 
-  return (
-    <SectionContainer
-      py="0"
-      mt={0}
-      isFirst={isFirst}
-      key="BannersSection"
-      testID="portfolio-banners-section"
-    >
-      <Box lx={{ paddingTop: "s12" }}>
-        {shouldShowOnboardingWidget && <OnboardingWidget />}
-        {shouldDisplayRecover && <RecoverBanner paddingHorizontal="s0" />}
-      </Box>
-    </SectionContainer>
-  );
+  if (shouldShowOnboardingWidget || shouldDisplayRecover) {
+    return (
+      <SectionContainer 
+        py="0"
+        mt={0}
+        isFirst={isFirst}
+        key="BannersSection"
+        testID="portfolio-banners-section"
+      >
+        <Box>
+          {shouldShowOnboardingWidget && 
+            <Box lx={{ paddingTop: "s12" }}><OnboardingWidget /></Box>}
+          {shouldDisplayRecover && 
+            <Box lx={{ paddingTop: "s12" }}><RecoverBanner paddingHorizontal="s0" /></Box>}
+        </Box>
+      </SectionContainer>
+    );
+  }
+  return null;
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBannersSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBannersSection/index.tsx
@@ -135,7 +135,7 @@ export const PortfolioBannersSection = ({
 
   if (shouldShowOnboardingWidget || shouldDisplayRecover) {
     return (
-      <SectionContainer 
+      <SectionContainer
         py="0"
         mt={0}
         isFirst={isFirst}

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBannersSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBannersSection/index.tsx
@@ -143,10 +143,16 @@ export const PortfolioBannersSection = ({
         testID="portfolio-banners-section"
       >
         <Box>
-          {shouldShowOnboardingWidget && 
-            <Box lx={{ paddingTop: "s12" }}><OnboardingWidget /></Box>}
-          {shouldDisplayRecover && 
-            <Box lx={{ paddingTop: "s12" }}><RecoverBanner paddingHorizontal="s0" /></Box>}
+          {shouldShowOnboardingWidget && (
+            <Box lx={{ paddingTop: "s12" }}>
+              <OnboardingWidget />
+            </Box>
+          )}
+          {shouldDisplayRecover && (
+            <Box lx={{ paddingTop: "s12" }}>
+              <RecoverBanner paddingHorizontal="s0" />
+            </Box>
+          )}
         </Box>
       </SectionContainer>
     );


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Portfolio wallet: banners section (Recover, flexible content cards, onboarding/recover stack and carousel)
  - Vertical spacing when Recover is off but Top Wallet content cards are shown

### 📝 Description

**Problem:** The portfolio banners area mixed padding for Recover and flexible content cards, and the fallback branch always mounted a section even when neither onboarding nor Recover applied.

**Solution:**
- For users with assets and no onboarding widget, always render `ContentCardsLocation`; render `RecoverBanner` inside its own top-padded wrapper only when `shouldDisplayRecover` is true.
- Gate the stacked onboarding/recover layout behind `if (shouldShowOnboardingWidget || shouldDisplayRecover)` and return `null` otherwise.
- Add a Jest case for “content cards only” (no Recover) and a `live-mobile` patch changeset.

| Before | After |
| ------ | ----- |
| <img width="229" height="470" alt="image" src="https://github.com/user-attachments/assets/080b6f81-e943-46ee-b9c4-40c2c8f14f6a" />| <img width="214" height="443" alt="image" src="https://github.com/user-attachments/assets/bb7ca66a-a862-423a-963d-f09d7b2ac3eb" /> |

_After opening the PR, use **⋯ → Edit** on the description and drop screenshots into the table if you have them._

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-30336

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)