### PR TITLE
[LWD] fix(desktop): wallet v4 tour slide transitions

### DIFF
--- a/.changeset/smooth-slides-reset.md
+++ b/.changeset/smooth-slides-reset.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix Wallet V4 tour slide transitions and reset behavior

--- a/apps/ledger-live-desktop/src/mvvm/components/Slides/Slides.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/Slides/Slides.tsx
@@ -1,12 +1,10 @@
-import React, { ReactNode, useRef, useState, useEffect } from "react";
+import React, { ReactNode, useState } from "react";
 import { isValidReactElement } from "@ledgerhq/react-ui";
 import { cn } from "LLD/utils/cn";
 import { SlidesContext } from "./context";
 import { Content } from "./components/Content";
 import { StaticSection } from "./components/StaticSection";
 import { useSlidesViewModel } from "./useSlidesViewModel";
-
-const SLIDE_DURATION_MS = 300;
 
 const SLIDE_CLASSES = {
   forward: {
@@ -47,21 +45,9 @@ export function Slides({
   });
 
   const [displayedIndex, setDisplayedIndex] = useState(contextValue.initialIndex);
-  const isExiting = displayedIndex !== contextValue.currentIndex;
-  const transitionDirectionRef = useRef<1 | -1>(1);
+  const direction = contextValue.currentIndex > displayedIndex ? 1 : -1;
 
-  if (isExiting) {
-    transitionDirectionRef.current = contextValue.currentIndex > displayedIndex ? 1 : -1;
-  }
-  const direction = transitionDirectionRef.current;
   const slideClasses = direction > 0 ? SLIDE_CLASSES.forward : SLIDE_CLASSES.backward;
-
-  useEffect(() => {
-    if (displayedIndex !== contextValue.currentIndex) {
-      const t = setTimeout(() => setDisplayedIndex(contextValue.currentIndex), SLIDE_DURATION_MS);
-      return () => clearTimeout(t);
-    }
-  }, [contextValue.currentIndex, displayedIndex]);
 
   return (
     <SlidesContext.Provider value={contextValue}>
@@ -70,8 +56,9 @@ export function Slides({
           if (isContentElement(child)) {
             const slideItems = React.Children.toArray(child.props.children);
             const activeSlide = slideItems[displayedIndex];
-            const contentClassName = "className" in child.props ? child.props.className : undefined;
-            const contentStyle = "style" in child.props ? child.props.style : undefined;
+            const contentClassName = child.props.className;
+            const contentStyle = child.props.style;
+            const isAnimating = displayedIndex !== contextValue.currentIndex;
 
             return (
               <div
@@ -80,11 +67,19 @@ export function Slides({
               >
                 {activeSlide != null && (
                   <div
-                    key={displayedIndex}
                     className={cn(
-                      isExiting ? slideClasses.exit : slideClasses.enter,
+                      {
+                        [slideClasses.enter]: isAnimating && direction < 0,
+                        [slideClasses.exit]: isAnimating && direction > 0,
+                      },
                       "col-start-1 row-start-1 min-h-0 flex-1 overflow-hidden",
                     )}
+                    onAnimationStart={({ animationName }) => {
+                      // We need to wait for the CSS slide-out animation to start before we can display the next slide
+                      if (animationName.startsWith("slide-out")) {
+                        setDisplayedIndex(contextValue.currentIndex);
+                      }
+                    }}
                   >
                     {activeSlide}
                   </div>

--- a/apps/ledger-live-desktop/src/mvvm/components/Slides/__tests__/Slides.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/Slides/__tests__/Slides.test.tsx
@@ -1,103 +1,97 @@
 import React from "react";
-import { render, screen, waitFor } from "tests/testSetup";
-import userEvent from "@testing-library/user-event";
+import { fireEvent, render, screen } from "tests/testSetup";
 import { Slides, useSlidesContext } from "../index";
 
-function TestFooter() {
-  const { goToNext } = useSlidesContext();
-  return (
-    <div>
-      <button type="button" onClick={goToNext}>
-        Continue
-      </button>
-    </div>
-  );
-}
+type RenderComponentOptions = {
+  initialSlideIndex?: number;
+  onSlideChange?: (index: number) => void;
+  withProgressIndicator?: boolean;
+};
 
-function TestProgressIndicator() {
-  const { currentIndex, totalSlides } = useSlidesContext();
-  return (
-    <div data-testid="progress">
-      {currentIndex + 1} / {totalSlides}
-    </div>
+function renderComponent({
+  initialSlideIndex = 0,
+  onSlideChange,
+  withProgressIndicator = true,
+}: RenderComponentOptions = {}) {
+  function TestFooter() {
+    const { goToNext } = useSlidesContext();
+    return (
+      <div>
+        <button type="button" onClick={goToNext}>
+          Continue
+        </button>
+      </div>
+    );
+  }
+
+  function TestProgressIndicator() {
+    const { currentIndex, totalSlides } = useSlidesContext();
+    return (
+      <div>
+        {currentIndex + 1} / {totalSlides}
+      </div>
+    );
+  }
+
+  return render(
+    <Slides initialSlideIndex={initialSlideIndex} onSlideChange={onSlideChange}>
+      <Slides.Content>
+        <Slides.Content.Item>
+          <div>Slide 0</div>
+        </Slides.Content.Item>
+        <Slides.Content.Item>
+          <div>Slide 1</div>
+        </Slides.Content.Item>
+      </Slides.Content>
+      <Slides.Footer>
+        <TestFooter />
+      </Slides.Footer>
+      {withProgressIndicator ? (
+        <Slides.ProgressIndicator>
+          <TestProgressIndicator />
+        </Slides.ProgressIndicator>
+      ) : null}
+    </Slides>,
   );
 }
 
 describe("Slides", () => {
   it("renders first slide and exposes navigation via context", () => {
-    render(
-      <Slides initialSlideIndex={0}>
-        <Slides.Content>
-          <Slides.Content.Item>
-            <div data-testid="slide-0">Slide 0</div>
-          </Slides.Content.Item>
-          <Slides.Content.Item>
-            <div data-testid="slide-1">Slide 1</div>
-          </Slides.Content.Item>
-        </Slides.Content>
-        <Slides.Footer>
-          <TestFooter />
-        </Slides.Footer>
-        <Slides.ProgressIndicator>
-          <TestProgressIndicator />
-        </Slides.ProgressIndicator>
-      </Slides>,
-    );
+    renderComponent();
 
-    expect(screen.getByTestId("slide-0")).toBeInTheDocument();
-    expect(screen.queryByTestId("slide-1")).not.toBeInTheDocument();
-    expect(screen.getByTestId("progress")).toHaveTextContent("1 / 2");
+    expect(screen.getByText("Slide 0")).toBeInTheDocument();
+    expect(screen.queryByText("Slide 1")).not.toBeInTheDocument();
+    expect(screen.getByText("1 / 2")).toBeInTheDocument();
   });
 
   it("advances to next slide when Continue is clicked", async () => {
-    const user = userEvent.setup();
-    render(
-      <Slides initialSlideIndex={0}>
-        <Slides.Content>
-          <Slides.Content.Item>
-            <div data-testid="slide-0">Slide 0</div>
-          </Slides.Content.Item>
-          <Slides.Content.Item>
-            <div data-testid="slide-1">Slide 1</div>
-          </Slides.Content.Item>
-        </Slides.Content>
-        <Slides.Footer>
-          <TestFooter />
-        </Slides.Footer>
-        <Slides.ProgressIndicator>
-          <TestProgressIndicator />
-        </Slides.ProgressIndicator>
-      </Slides>,
-    );
+    const { user } = renderComponent();
 
     await user.click(screen.getByRole("button", { name: "Continue" }));
-
-    await waitFor(() => {
-      expect(screen.queryByTestId("slide-0")).not.toBeInTheDocument();
-      expect(screen.getByTestId("slide-1")).toBeInTheDocument();
+    const slideOutAnimationStart = new Event("animationstart", {
+      bubbles: true,
     });
-    expect(screen.getByTestId("progress")).toHaveTextContent("2 / 2");
+    Object.defineProperty(slideOutAnimationStart, "animationName", {
+      value: "slide-out-to-left",
+    });
+    fireEvent(screen.getByText("Slide 0"), slideOutAnimationStart);
+
+    expect(screen.queryByText("Slide 0")).not.toBeInTheDocument();
+    expect(screen.getByText("Slide 1")).toBeInTheDocument();
+    expect(screen.getByText("2 / 2")).toBeInTheDocument();
+  });
+
+  it("can start at index other than 0", () => {
+    renderComponent({ initialSlideIndex: 1, withProgressIndicator: false });
+
+    expect(screen.getByText("Slide 1")).toBeInTheDocument();
+    expect(screen.queryByText("Slide 0")).not.toBeInTheDocument();
   });
 
   it("calls onSlideChange when index changes", async () => {
-    const user = userEvent.setup();
     const onSlideChange = jest.fn();
 
-    render(
-      <Slides initialSlideIndex={0} onSlideChange={onSlideChange}>
-        <Slides.Content>
-          <Slides.Content.Item>
-            <div data-testid="slide-0">Slide 0</div>
-          </Slides.Content.Item>
-          <Slides.Content.Item>
-            <div data-testid="slide-1">Slide 1</div>
-          </Slides.Content.Item>
-        </Slides.Content>
-        <Slides.Footer>
-          <TestFooter />
-        </Slides.Footer>
-      </Slides>,
-    );
+    const { user } = renderComponent({ onSlideChange, withProgressIndicator: false });
 
     expect(onSlideChange).not.toHaveBeenCalled();
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
@@ -617,7 +617,7 @@ describe("Portfolio (Wallet V4 Tour)", () => {
   });
 
   it("shows Wallet V4 Tour dialog when tour enabled and not seen", async () => {
-    render(<PortfolioPage />, {
+    const { user } = render(<PortfolioPage />, {
       initialState: {
         settings: {
           ...AFTER_ONBOARDING_STATE,
@@ -633,6 +633,18 @@ describe("Portfolio (Wallet V4 Tour)", () => {
     expect(track).toHaveBeenCalledWith("product_tour_card", {
       page: "Product Tour WV4",
       card: 1,
+    });
+
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+    expect(track).toHaveBeenCalledWith("product_tour_card", {
+      page: "Product Tour WV4",
+      card: 2,
+    });
+
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+    expect(track).toHaveBeenCalledWith("product_tour_card", {
+      page: "Product Tour WV4",
+      card: 3,
     });
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/ProductTour/Drawer/__integrations__/ProductTourDialog.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ProductTour/Drawer/__integrations__/ProductTourDialog.integration.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, waitFor } from "tests/testSetup";
+import { fireEvent, render, screen, waitFor } from "tests/testSetup";
 import { ProductTourDialog } from "../ProductTourDialogView";
 import { useProductTourDialogViewModel } from "../hooks/useProductTourDialogViewModel";
 
@@ -45,6 +45,22 @@ function getProductTourTestInitialState(overrides?: { productTourCompleted?: boo
   };
 }
 
+function completeSlideOutAnimation(fromIndex: number) {
+  const slideOutAnimationStart = new Event("animationstart", {
+    bubbles: true,
+  });
+  Object.defineProperty(slideOutAnimationStart, "animationName", {
+    value: "slide-out-to-left",
+  });
+
+  fireEvent(screen.getByTestId(`product-tour-slide-${fromIndex}`), slideOutAnimationStart);
+}
+
+async function goToNextSlide(user: ReturnType<typeof render>["user"], fromIndex: number) {
+  await user.click(screen.getByRole("button", { name: CONTINUE_LABEL }));
+  completeSlideOutAnimation(fromIndex);
+}
+
 describe("ProductTourDialog", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -81,10 +97,10 @@ describe("ProductTourDialog", () => {
       />,
     );
 
-    await user.click(screen.getByRole("button", { name: CONTINUE_LABEL }));
-    await user.click(screen.getByRole("button", { name: CONTINUE_LABEL }));
-    await user.click(screen.getByRole("button", { name: CONTINUE_LABEL }));
-    await user.click(screen.getByRole("button", { name: CONTINUE_LABEL }));
+    await goToNextSlide(user, 0);
+    await goToNextSlide(user, 1);
+    await goToNextSlide(user, 2);
+    await goToNextSlide(user, 3);
 
     expect(await screen.findByTestId("product-tour-slide-4")).toBeVisible();
     expect(screen.getByRole("button", { name: PORTFOLIO_LABEL })).toBeVisible();
@@ -161,10 +177,10 @@ describe("ProductTour dialog from debug (view model)", () => {
 
     expect(screen.getByTestId("product-tour-slide-0")).toBeVisible();
 
-    await user.click(screen.getByRole("button", { name: CONTINUE_LABEL }));
-    await user.click(screen.getByRole("button", { name: CONTINUE_LABEL }));
-    await user.click(screen.getByRole("button", { name: CONTINUE_LABEL }));
-    await user.click(screen.getByRole("button", { name: CONTINUE_LABEL }));
+    await goToNextSlide(user, 0);
+    await goToNextSlide(user, 1);
+    await goToNextSlide(user, 2);
+    await goToNextSlide(user, 3);
 
     expect(await screen.findByTestId("product-tour-slide-4")).toBeVisible();
     expect(store.getState().settings.productTourCompleted).toBe(true);

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletV4Tour/Drawer/WalletV4TourDialog.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletV4Tour/Drawer/WalletV4TourDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from "react";
+import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Dialog, DialogContent, DialogHeader } from "@ledgerhq/lumen-ui-react";
 import { Slides } from "LLD/components/Slides";
@@ -20,15 +20,6 @@ export const WalletV4TourDialog = ({
   onSlideChange,
 }: WalletV4TourDialogProps) => {
   const { t } = useTranslation();
-  const prevOpenRef = useRef(false);
-
-  useEffect(() => {
-    const justOpened = isOpen && !prevOpenRef.current;
-    prevOpenRef.current = isOpen;
-    if (justOpened) {
-      onSlideChange?.(0);
-    }
-  }, [isOpen, onSlideChange]);
 
   const slides = useMemo(
     () => [
@@ -57,11 +48,19 @@ export const WalletV4TourDialog = ({
     }
   };
 
+  if (!isOpen) {
+    return null;
+  }
+
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogContent className="flex h-screen min-h-0 flex-col">
         <DialogHeader density="compact" onClose={onClose} />
-        <Slides initialSlideIndex={0} onSlideChange={onSlideChange}>
+        <Slides
+          key={isOpen ? "open" : "closed"}
+          initialSlideIndex={0}
+          onSlideChange={onSlideChange}
+        >
           <Slides.Content>
             {slides.map((slide, index) => (
               <Slides.Content.Item key={slide.id}>

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletV4Tour/Drawer/hooks/useWalletV4TourDrawerViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletV4Tour/Drawer/hooks/useWalletV4TourDrawerViewModel.ts
@@ -64,6 +64,7 @@ export const useWalletV4TourDrawerViewModel = (
 
   const openDrawerWithTracking = useCallback((source: "portfolio" | "debug") => {
     isClosingRef.current = false;
+    currentIndexRef.current = 0;
     setIsDialogOpen(true);
     trackPage(
       PAGE_TRACKING_WALLET_V4_TOUR,
@@ -72,6 +73,10 @@ export const useWalletV4TourDrawerViewModel = (
       true,
       false,
     );
+    track("product_tour_card", {
+      page: PAGE_TRACKING_WALLET_V4_TOUR,
+      card: 1,
+    });
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Wallet V4 tour drawer slide navigation and reset behavior
  - Shared desktop Slides animation timing
  - Slides unit coverage around initial index and animation-driven navigation

### 📝 Description

This PR fixes the Wallet V4 tour drawer slide behavior so the drawer resets cleanly when reopened and slide transitions no longer rely on a fixed timeout to swap displayed content.

The shared desktop `Slides` component now switches slides when the CSS slide-out animation starts, keeping the visual transition aligned with the rendered content. The Wallet V4 tour dialog also unmounts when closed so reopening starts from the initial slide state.

https://github.com/user-attachments/assets/39e6d181-6ec9-4d5e-bb30-8887875a45c5




### ❓ Context

- **JIRA or GitHub link**: [LIVE-29800](https://ledgerhq.atlassian.net/browse/LIVE-29800)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29800]: https://ledgerhq.atlassian.net/browse/LIVE-29800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ