### PR TITLE
[LWDM] feat(LIVE-29441): add wallet quote global outcomes

### DIFF
--- a/.changeset/quiet-quotes-respond.md
+++ b/.changeset/quiet-quotes-respond.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/wallet-api-exchange-module": minor
+"@ledgerhq/live-common": minor
+---
+
+Add wallet quote global outcome errors and warnings

--- a/libs/exchange-module/src/types.ts
+++ b/libs/exchange-module/src/types.ts
@@ -113,6 +113,7 @@ export type SwapLiveError = {
 // Swap quotes (`custom.exchange.getQuotes`). Internal HTTP shapes live in ledger-live-common only.
 
 export type UniswapOrderType = "classic" | "uniswapxv2" | "all";
+export type QuotesAppPlatform = "lld" | "llm-ios" | "llm-android" | "unknown";
 
 export type QuotesInput = {
   amount: string;
@@ -334,9 +335,14 @@ export type Quote = {
   formatted?: FormattedQuoteValues;
 };
 
+export enum ProviderErrorCodes {
+  AMOUNT_OFF_LIMITS = "amount_off_limits",
+  FAILED_TO_GET_QUOTE_ERROR = "failed_to_get_quote_error",
+}
+
 /** Error rows returned next to quotes (swap API error objects). */
 export type QuoteProviderError = {
-  code: string;
+  code: ProviderErrorCodes | (string & {});
   type: TradeMethod;
   provider: string;
   message: string;
@@ -351,17 +357,34 @@ export type QuoteProviderError = {
  * Producers live wallet-side; this is the contract consumers read.
  */
 export enum QuotesErrorCodes {
+  AMOUNT_TOO_HIGH = "amountTooHigh",
+  AMOUNT_TOO_LOW = "amountTooLow",
+  LEDGER_LIVE_VERSION_INCOMPATIBILITY = "ledgerLiveVersionIncompatibility",
   NO_QUOTES = "noQuotes",
   QUOTE_INPUT_RESOLUTION_FAILED = "quoteInputResolutionFailed",
-  AMOUNT_TOO_LOW = "amountTooLow",
-  AMOUNT_TOO_HIGH = "amountTooHigh",
 }
 
 export type QuotesError =
   | { code: QuotesErrorCodes.NO_QUOTES }
   | { code: QuotesErrorCodes.QUOTE_INPUT_RESOLUTION_FAILED }
   | { code: QuotesErrorCodes.AMOUNT_TOO_LOW; minAmount: string }
-  | { code: QuotesErrorCodes.AMOUNT_TOO_HIGH; maxAmount: string };
+  | { code: QuotesErrorCodes.AMOUNT_TOO_HIGH; maxAmount: string }
+  | {
+      code: QuotesErrorCodes.LEDGER_LIVE_VERSION_INCOMPATIBILITY;
+      currencyId: string;
+      platform: QuotesAppPlatform;
+      currentVersion: string;
+      requiredVersion: string;
+    };
+
+export enum QuotesWarningCodes {
+  NANO_S_CURRENCY_INCOMPATIBILITY = "nanoSCurrencyIncompatibility",
+}
+
+export type QuotesWarning = {
+  code: QuotesWarningCodes.NANO_S_CURRENCY_INCOMPATIBILITY;
+  currencyId: string;
+};
 
 export type GetQuotesResponse = {
   quotes: Quote[];
@@ -372,6 +395,11 @@ export type GetQuotesResponse = {
    * digest these into globals here, that lives in {@link errors}.
    */
   providerErrors: QuoteProviderError[];
+  /**
+   * Digested global warnings for the whole batch. Empty array when there is
+   * nothing to surface.
+   */
+  warnings: QuotesWarning[];
   /**
    * Digested global state for the whole batch (e.g. `noQuotes` when no
    * successful quotes came back, `amountTooLow` / `amountTooHigh` when

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/computeLedgerLiveVersionCompatibilityError.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/computeLedgerLiveVersionCompatibilityError.ts
@@ -1,0 +1,88 @@
+import semver from "semver";
+
+import { QuotesErrorCodes, type QuotesAppPlatform, type QuotesError } from "./types";
+
+type VersionCompatibilityRule = {
+  id: string;
+  token: "none" | "only" | "all";
+  lld: string | null;
+  llm: string | null;
+};
+
+const VERSION_COMPATIBILITY_RULES: VersionCompatibilityRule[] = [
+  { id: "aptos", token: "none", lld: "2.82.0", llm: null },
+  { id: "sui", token: "all", lld: "2.120.1", llm: "3.86.0" },
+  { id: "ton", token: "only", lld: "2.120.0", llm: "3.84.0" },
+  { id: "solana", token: "only", lld: null, llm: "3.76.0" },
+];
+
+function getRequiredVersion(
+  platform: QuotesAppPlatform,
+  rule: VersionCompatibilityRule,
+): string | null {
+  switch (platform) {
+    case "lld":
+      return rule.lld;
+    case "llm-ios":
+    case "llm-android":
+      return rule.llm;
+    case "unknown":
+      return null;
+  }
+}
+
+function isVersionLowerThanRequired(currentVersion: string, requiredVersion: string): boolean {
+  const current = semver.coerce(currentVersion, { includePrerelease: true });
+  const required = semver.coerce(requiredVersion, { includePrerelease: true });
+  if (!current || !required) {
+    return false;
+  }
+
+  return semver.lt(current, required, { includePrerelease: true });
+}
+
+function matchesRule(currencyId: string, rule: VersionCompatibilityRule): boolean {
+  switch (rule.token) {
+    case "none":
+      return currencyId === rule.id;
+    case "only":
+      return currencyId.startsWith(`${rule.id}/`);
+    case "all":
+      return currencyId === rule.id || currencyId.startsWith(`${rule.id}/`);
+  }
+}
+
+export function computeLedgerLiveVersionCompatibilityError(input: {
+  sendCurrencyId: string;
+  receiveCurrencyId: string;
+  appVersion?: {
+    platform: QuotesAppPlatform;
+    version: string | null;
+  };
+}): QuotesError | undefined {
+  const appVersion = input.appVersion;
+  if (!appVersion?.version) {
+    return undefined;
+  }
+
+  const currencyIds = [input.sendCurrencyId, input.receiveCurrencyId];
+  for (const rule of VERSION_COMPATIBILITY_RULES) {
+    const requiredVersion = getRequiredVersion(appVersion.platform, rule);
+    if (!requiredVersion || !isVersionLowerThanRequired(appVersion.version, requiredVersion)) {
+      continue;
+    }
+
+    const currencyId = currencyIds.find(id => matchesRule(id, rule));
+    if (currencyId) {
+      return {
+        code: QuotesErrorCodes.LEDGER_LIVE_VERSION_INCOMPATIBILITY,
+        currencyId,
+        platform: appVersion.platform,
+        currentVersion: appVersion.version,
+        requiredVersion,
+      };
+    }
+  }
+
+  return undefined;
+}

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/computeQuotesErrors.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/computeQuotesErrors.test.ts
@@ -1,9 +1,10 @@
 import { computeQuotesErrors } from "./computeQuotesErrors";
 import type { RawQuoteError } from "./service/types";
+import { ProviderErrorCodes, QuotesErrorCodes } from "./types";
 
 function makeProviderError(overrides: Partial<RawQuoteError> = {}): RawQuoteError {
   return {
-    code: "amount_off_limits",
+    code: ProviderErrorCodes.AMOUNT_OFF_LIMITS,
     type: "float",
     provider: "lifi",
     message: "amount out of range",
@@ -33,7 +34,7 @@ describe("computeQuotesErrors", () => {
       amountFrom: "5",
     });
 
-    expect(result).toEqual([{ code: "noQuotes" }]);
+    expect(result).toEqual([{ code: QuotesErrorCodes.NO_QUOTES }]);
   });
 
   it("stacks `amountTooLow` on top of `noQuotes` when a min-bound row brackets amountFrom", () => {
@@ -44,8 +45,8 @@ describe("computeQuotesErrors", () => {
     });
 
     expect(result).toEqual([
-      { code: "noQuotes" },
-      { code: "amountTooLow", minAmount: "10" },
+      { code: QuotesErrorCodes.NO_QUOTES },
+      { code: QuotesErrorCodes.AMOUNT_TOO_LOW, minAmount: "10" },
     ]);
   });
 
@@ -57,8 +58,8 @@ describe("computeQuotesErrors", () => {
     });
 
     expect(result).toEqual([
-      { code: "noQuotes" },
-      { code: "amountTooHigh", maxAmount: "100" },
+      { code: QuotesErrorCodes.NO_QUOTES },
+      { code: QuotesErrorCodes.AMOUNT_TOO_HIGH, maxAmount: "100" },
     ]);
   });
 
@@ -73,9 +74,9 @@ describe("computeQuotesErrors", () => {
     });
 
     expect(result).toEqual([
-      { code: "noQuotes" },
-      { code: "amountTooLow", minAmount: "10" },
-      { code: "amountTooHigh", maxAmount: "1" },
+      { code: QuotesErrorCodes.NO_QUOTES },
+      { code: QuotesErrorCodes.AMOUNT_TOO_LOW, minAmount: "10" },
+      { code: QuotesErrorCodes.AMOUNT_TOO_HIGH, maxAmount: "1" },
     ]);
   });
 
@@ -91,8 +92,8 @@ describe("computeQuotesErrors", () => {
     });
 
     expect(result).toEqual([
-      { code: "noQuotes" },
-      { code: "amountTooLow", minAmount: "12" },
+      { code: QuotesErrorCodes.NO_QUOTES },
+      { code: QuotesErrorCodes.AMOUNT_TOO_LOW, minAmount: "12" },
     ]);
   });
 
@@ -108,8 +109,8 @@ describe("computeQuotesErrors", () => {
     });
 
     expect(result).toEqual([
-      { code: "noQuotes" },
-      { code: "amountTooHigh", maxAmount: "150" },
+      { code: QuotesErrorCodes.NO_QUOTES },
+      { code: QuotesErrorCodes.AMOUNT_TOO_HIGH, maxAmount: "150" },
     ]);
   });
 
@@ -125,7 +126,7 @@ describe("computeQuotesErrors", () => {
       amountFrom: "5",
     });
 
-    expect(result).toEqual([{ code: "noQuotes" }]);
+    expect(result).toEqual([{ code: QuotesErrorCodes.NO_QUOTES }]);
   });
 
   it("treats edge case `minAmount === amountFrom` as below the limit (legacy `gte`)", () => {
@@ -137,8 +138,8 @@ describe("computeQuotesErrors", () => {
     });
 
     expect(result).toEqual([
-      { code: "noQuotes" },
-      { code: "amountTooLow", minAmount: "5" },
+      { code: QuotesErrorCodes.NO_QUOTES },
+      { code: QuotesErrorCodes.AMOUNT_TOO_LOW, minAmount: "5" },
     ]);
   });
 
@@ -153,7 +154,7 @@ describe("computeQuotesErrors", () => {
       amountFrom: "5",
     });
 
-    expect(result).toEqual([{ code: "noQuotes" }]);
+    expect(result).toEqual([{ code: QuotesErrorCodes.NO_QUOTES }]);
   });
 
   it("ignores `amount_off_limits` rows missing both bound parameters", () => {
@@ -163,6 +164,19 @@ describe("computeQuotesErrors", () => {
       amountFrom: "5",
     });
 
-    expect(result).toEqual([{ code: "noQuotes" }]);
+    expect(result).toEqual([{ code: QuotesErrorCodes.NO_QUOTES }]);
+  });
+
+  it("ignores `amount_off_limits` rows with non-numeric bounds", () => {
+    const result = computeQuotesErrors({
+      successfulQuotesCount: 0,
+      providerErrors: [
+        makeProviderError({ parameter: { minAmount: "not-a-number" } }),
+        makeProviderError({ parameter: { maxAmount: "not-a-number" }, provider: "okx" }),
+      ],
+      amountFrom: "5",
+    });
+
+    expect(result).toEqual([{ code: QuotesErrorCodes.NO_QUOTES }]);
   });
 });

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/computeQuotesErrors.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/computeQuotesErrors.ts
@@ -1,14 +1,7 @@
 import BigNumber from "bignumber.js";
 
 import type { RawQuoteError } from "./service/types";
-import { QuotesErrorCodes, type QuotesError } from "./types";
-
-/**
- * Aggregator rejection rows carry a free-form `code` string. Only this
- * one is consumed by `computeQuotesErrors`; everything else is left in
- * `providerErrors` for the consumer to inspect directly.
- */
-const AMOUNT_OFF_LIMITS = "amount_off_limits";
+import { ProviderErrorCodes, QuotesErrorCodes, type QuotesError } from "./types";
 
 /**
  * Inputs the producer reads. `amountFrom` is the user-input atomic amount
@@ -51,7 +44,9 @@ export function computeQuotesErrors(args: ComputeQuotesErrorsArgs): QuotesError[
   const errors: QuotesError[] = [{ code: QuotesErrorCodes.NO_QUOTES }];
 
   const amountFromBn = new BigNumber(args.amountFrom);
-  const amountOffLimits = args.providerErrors.filter(row => row.code === AMOUNT_OFF_LIMITS);
+  const amountOffLimits = args.providerErrors.filter(
+    row => row.code === ProviderErrorCodes.AMOUNT_OFF_LIMITS,
+  );
 
   const tooLowCandidates = amountOffLimits
     .map(row => ({ minAmount: row.parameter?.minAmount }))

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/computeQuotesWarnings.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/computeQuotesWarnings.test.ts
@@ -1,0 +1,45 @@
+import { computeQuotesWarnings } from "./computeQuotesWarnings";
+import { QuotesWarningCodes } from "./types";
+
+describe("computeQuotesWarnings", () => {
+  it("returns no warnings for non-Nano S devices", () => {
+    const result = computeQuotesWarnings({
+      deviceModelId: "nanoX",
+      sendCurrencyId: "ton",
+      receiveCurrencyId: "bitcoin",
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("emits Nano S currency incompatibility for incompatible currencies", () => {
+    const result = computeQuotesWarnings({
+      deviceModelId: "nanoS",
+      sendCurrencyId: "ton",
+      receiveCurrencyId: "bitcoin",
+    });
+
+    expect(result).toEqual([
+      {
+        code: QuotesWarningCodes.NANO_S_CURRENCY_INCOMPATIBILITY,
+        currencyId: "ton",
+      },
+    ]);
+  });
+
+  it("emits Nano S currency incompatibility for incompatible token parents", () => {
+    const result = computeQuotesWarnings({
+      deviceModelId: "nanoS",
+      sendCurrencyId: "ethereum/erc20/usd_tether__erc20_",
+      receiveCurrencyId: "bitcoin",
+      sendParentCurrencyId: "solana",
+    });
+
+    expect(result).toEqual([
+      {
+        code: QuotesWarningCodes.NANO_S_CURRENCY_INCOMPATIBILITY,
+        currencyId: "solana",
+      },
+    ]);
+  });
+});

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/computeQuotesWarnings.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/computeQuotesWarnings.ts
@@ -1,0 +1,59 @@
+import { QuotesWarningCodes, type QuotesWarning } from "./types";
+
+export type ComputeQuotesWarningsArgs = {
+  deviceModelId?: string;
+  sendCurrencyId: string;
+  receiveCurrencyId: string;
+  sendParentCurrencyId?: string;
+  receiveParentCurrencyId?: string;
+};
+
+const NANO_S_MODEL_ID = "nanoS";
+
+const NANO_S_INCOMPATIBLE_CURRENCIES = new Set([
+  "ton",
+  "cardano",
+  "cosmos",
+  "near",
+  "aptos",
+  "hedera",
+  "monad",
+  "etherlink",
+  "osmo",
+  "sui",
+  "dydx",
+  "kaspa",
+  "assethub_polkadot",
+  "zcash",
+  "hyperevm",
+]);
+
+const NANO_S_INCOMPATIBLE_TOKEN_PARENT_CURRENCIES = new Set(["solana", "sui"]);
+
+export function computeQuotesWarnings(args: ComputeQuotesWarningsArgs): QuotesWarning[] {
+  if (args.deviceModelId !== NANO_S_MODEL_ID) {
+    return [];
+  }
+
+  const incompatibleCurrencyIds = new Set<string>();
+  for (const currencyId of [args.sendCurrencyId, args.receiveCurrencyId]) {
+    if (NANO_S_INCOMPATIBLE_CURRENCIES.has(currencyId)) {
+      incompatibleCurrencyIds.add(currencyId);
+    }
+  }
+
+  for (const currencyId of [args.sendParentCurrencyId, args.receiveParentCurrencyId]) {
+    if (
+      currencyId &&
+      (NANO_S_INCOMPATIBLE_CURRENCIES.has(currencyId) ||
+        NANO_S_INCOMPATIBLE_TOKEN_PARENT_CURRENCIES.has(currencyId))
+    ) {
+      incompatibleCurrencyIds.add(currencyId);
+    }
+  }
+
+  return Array.from(incompatibleCurrencyIds).map(currencyId => ({
+    code: QuotesWarningCodes.NANO_S_CURRENCY_INCOMPATIBILITY,
+    currencyId,
+  }));
+}

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/getQuotes.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/getQuotes.test.ts
@@ -6,7 +6,13 @@ import { fetchAndMergeProviderData } from "../../../exchange/providers/swap";
 import { fetchNetworkFeeContext } from "./fetchNetworkFeeContext";
 import { computeFeeEstimate } from "./normalizer/networkFeeEstimate";
 import type { RawQuote, RawQuoteError } from "./service/types";
-import { QuoteErrorCodes, type GetQuotesArgs } from "./types";
+import {
+  ProviderErrorCodes,
+  QuoteErrorCodes,
+  QuotesErrorCodes,
+  QuotesWarningCodes,
+  type GetQuotesArgs,
+} from "./types";
 
 jest.mock("./service/fetchQuotes", () => ({
   fetchQuotes: jest.fn(),
@@ -119,11 +125,79 @@ describe("getQuotes", () => {
     expect(response).toEqual({
       quotes: [],
       providerErrors: [],
-      errors: [{ code: "quoteInputResolutionFailed" }],
+      warnings: [],
+      errors: [{ code: QuotesErrorCodes.QUOTE_INPUT_RESOLUTION_FAILED }],
     });
     expect(fetchQuotesMock).not.toHaveBeenCalled();
     expect(fetchAndMergeProviderDataMock).not.toHaveBeenCalled();
     expect(fetchNetworkFeeContextMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a Ledger Live version incompatibility error before fetching quotes", async () => {
+    const response = await getQuotes(makeArgs("aptos", "bitcoin"), {
+      ...emptyContext,
+      appVersion: { platform: "lld", version: "2.81.0" },
+    });
+
+    expect(response).toEqual({
+      quotes: [],
+      providerErrors: [],
+      warnings: [],
+      errors: [
+        {
+          code: QuotesErrorCodes.LEDGER_LIVE_VERSION_INCOMPATIBILITY,
+          currencyId: "aptos",
+          platform: "lld",
+          currentVersion: "2.81.0",
+          requiredVersion: "2.82.0",
+        },
+      ],
+    });
+    expect(fetchQuotesMock).not.toHaveBeenCalled();
+    expect(fetchAndMergeProviderDataMock).not.toHaveBeenCalled();
+    expect(fetchNetworkFeeContextMock).not.toHaveBeenCalled();
+  });
+
+  it("matches Ledger Live version incompatibility against token-only rules", async () => {
+    const response = await getQuotes(makeArgs("ethereum", "solana/spl/usdc"), {
+      ...emptyContext,
+      appVersion: { platform: "llm-ios", version: "3.75.0" },
+    });
+
+    expect(response.errors).toEqual([
+      {
+        code: QuotesErrorCodes.LEDGER_LIVE_VERSION_INCOMPATIBILITY,
+        currencyId: "solana/spl/usdc",
+        platform: "llm-ios",
+        currentVersion: "3.75.0",
+        requiredVersion: "3.76.0",
+      },
+    ]);
+    expect(fetchQuotesMock).not.toHaveBeenCalled();
+  });
+
+  it("skips Ledger Live version compatibility for unknown app platforms", async () => {
+    fetchQuotesMock.mockResolvedValue({ rawQuotes: [], providerErrors: [] });
+
+    const response = await getQuotes(makeArgs("aptos", "bitcoin"), {
+      ...emptyContext,
+      appVersion: { platform: "unknown", version: "2.81.0" },
+    });
+
+    expect(response.errors).toEqual([{ code: QuotesErrorCodes.NO_QUOTES }]);
+    expect(fetchQuotesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips Ledger Live version compatibility when the current version cannot be parsed", async () => {
+    fetchQuotesMock.mockResolvedValue({ rawQuotes: [], providerErrors: [] });
+
+    const response = await getQuotes(makeArgs("aptos", "bitcoin"), {
+      ...emptyContext,
+      appVersion: { platform: "lld", version: "dev-build" },
+    });
+
+    expect(response.errors).toEqual([{ code: QuotesErrorCodes.NO_QUOTES }]);
+    expect(fetchQuotesMock).toHaveBeenCalledTimes(1);
   });
 
   it("drops every successful quote for an unsupported pair while forwarding providerErrors", async () => {
@@ -138,7 +212,7 @@ describe("getQuotes", () => {
     expect(response.providerErrors).toEqual([aggregatorError]);
     // Unsupported pair drops every successful quote -> the digested
     // error list is non-empty (`noQuotes` from the producer).
-    expect(response.errors).toEqual([{ code: "noQuotes" }]);
+    expect(response.errors).toEqual([{ code: QuotesErrorCodes.NO_QUOTES }]);
   });
 
   it("blocks the unsupported pair in the reverse direction as well", async () => {
@@ -151,13 +225,10 @@ describe("getQuotes", () => {
 
     expect(response.quotes).toEqual([]);
     expect(response.providerErrors).toEqual([]);
-    expect(response.errors).toEqual([{ code: "noQuotes" }]);
+    expect(response.errors).toEqual([{ code: QuotesErrorCodes.NO_QUOTES }]);
   });
 
   it("skips the provider-data fetch when the pair is unsupported", async () => {
-    // The CAL + CDN round-trip inside `fetchAndMergeProviderData` is a cold
-    // cache miss on first call; asserting the mock was not touched protects
-    // the short-circuit path from regressions.
     fetchQuotesMock.mockResolvedValue({ rawQuotes: [makeRawQuote()], providerErrors: [] });
 
     await getQuotes(makeArgs("near", "stellar"), emptyContext);
@@ -166,19 +237,13 @@ describe("getQuotes", () => {
   });
 
   it("forwards providerErrors and skips the provider-data + fee-context fetches when no rawQuotes are returned", async () => {
-    // Common error-only response: every provider rejected the request
-    // (amount-too-small, KYC required, slippage too high, etc.). Both
-    // fetchAndMergeProviderData (CAL + CDN) and fetchNetworkFeeContext
-    // (bridge.sync + prepareTransaction + getTransactionStatus) are
-    // pure waste in this case — their results would never be consumed
-    // by normalizeQuote/computeFeeEstimate.
     fetchQuotesMock.mockResolvedValue({ rawQuotes: [], providerErrors: [aggregatorError] });
 
     const response = await getQuotes(makeArgs("ethereum", "bitcoin"), emptyContext);
 
     expect(response.quotes).toEqual([]);
     expect(response.providerErrors).toEqual([aggregatorError]);
-    expect(response.errors).toEqual([{ code: "noQuotes" }]);
+    expect(response.errors).toEqual([{ code: QuotesErrorCodes.NO_QUOTES }]);
     expect(fetchAndMergeProviderDataMock).not.toHaveBeenCalled();
     expect(fetchNetworkFeeContextMock).not.toHaveBeenCalled();
   });
@@ -194,10 +259,33 @@ describe("getQuotes", () => {
     expect(response.quotes).toHaveLength(1);
     expect(response.quotes[0].quoteDetails.exchangeRate).toBe(0.999);
     expect(response.providerErrors).toEqual([aggregatorError]);
+    expect(response.warnings).toEqual([]);
     // Successful quotes were returned -> the producer emits no globals,
     // even when the response carries provider-level rejection rows.
     expect(response.errors).toEqual([]);
     expect(fetchAndMergeProviderDataMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns Nano S currency incompatibility as a global warning while still fetching quotes", async () => {
+    fetchQuotesMock.mockResolvedValue({
+      rawQuotes: [makeRawQuote({ provider: "changelly_v2" })],
+      providerErrors: [],
+    });
+
+    const response = await getQuotes(makeArgs("ton", "bitcoin"), {
+      ...emptyContext,
+      deviceModelId: "nanoS",
+    });
+
+    expect(response.quotes).toHaveLength(1);
+    expect(response.warnings).toEqual([
+      {
+        code: QuotesWarningCodes.NANO_S_CURRENCY_INCOMPATIBILITY,
+        currencyId: "ton",
+      },
+    ]);
+    expect(response.quotes[0].warnings).toEqual([]);
+    expect(fetchQuotesMock).toHaveBeenCalledTimes(1);
   });
 
   describe("digested global errors (computeQuotesErrors integration)", () => {
@@ -207,14 +295,14 @@ describe("getQuotes", () => {
         rawQuotes: [],
         providerErrors: [
           {
-            code: "amount_off_limits",
+            code: ProviderErrorCodes.AMOUNT_OFF_LIMITS,
             type: "float",
             provider: "lifi",
             message: "min",
             parameter: { minAmount: "10" },
           },
           {
-            code: "amount_off_limits",
+            code: ProviderErrorCodes.AMOUNT_OFF_LIMITS,
             type: "float",
             provider: "okx",
             message: "min",
@@ -229,8 +317,8 @@ describe("getQuotes", () => {
       );
 
       expect(response.errors).toEqual([
-        { code: "noQuotes" },
-        { code: "amountTooLow", minAmount: "10" },
+        { code: QuotesErrorCodes.NO_QUOTES },
+        { code: QuotesErrorCodes.AMOUNT_TOO_LOW, minAmount: "10" },
       ]);
     });
 
@@ -239,14 +327,14 @@ describe("getQuotes", () => {
         rawQuotes: [],
         providerErrors: [
           {
-            code: "amount_off_limits",
+            code: ProviderErrorCodes.AMOUNT_OFF_LIMITS,
             type: "float",
             provider: "lifi",
             message: "max",
             parameter: { maxAmount: "100" },
           },
           {
-            code: "amount_off_limits",
+            code: ProviderErrorCodes.AMOUNT_OFF_LIMITS,
             type: "float",
             provider: "okx",
             message: "max",
@@ -261,8 +349,8 @@ describe("getQuotes", () => {
       );
 
       expect(response.errors).toEqual([
-        { code: "noQuotes" },
-        { code: "amountTooHigh", maxAmount: "150" },
+        { code: QuotesErrorCodes.NO_QUOTES },
+        { code: QuotesErrorCodes.AMOUNT_TOO_HIGH, maxAmount: "150" },
       ]);
     });
 
@@ -271,7 +359,7 @@ describe("getQuotes", () => {
         rawQuotes: [makeRawQuote()],
         providerErrors: [
           {
-            code: "amount_off_limits",
+            code: ProviderErrorCodes.AMOUNT_OFF_LIMITS,
             type: "float",
             provider: "okx",
             message: "min",
@@ -293,7 +381,7 @@ describe("getQuotes", () => {
         rawQuotes: [makeRawQuote()],
         providerErrors: [
           {
-            code: "amount_off_limits",
+            code: ProviderErrorCodes.AMOUNT_OFF_LIMITS,
             type: "float",
             provider: "lifi",
             message: "min",
@@ -307,8 +395,8 @@ describe("getQuotes", () => {
       // Unsupported-pair short-circuit forces successful quotes to 0. The
       // providerErrors still flow through, so amount_off_limits can stack too.
       expect(response.errors).toEqual([
-        { code: "noQuotes" },
-        { code: "amountTooLow", minAmount: "10" },
+        { code: QuotesErrorCodes.NO_QUOTES },
+        { code: QuotesErrorCodes.AMOUNT_TOO_LOW, minAmount: "10" },
       ]);
     });
   });

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/getQuotes.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/getQuotes.ts
@@ -3,14 +3,21 @@ import { getParentAccount } from "@ledgerhq/ledger-wallet-framework/account/inde
 import type { AccountLike } from "@ledgerhq/types-live";
 
 import { fetchAndMergeProviderData } from "../../../exchange/providers/swap";
-import { getAccountIdFromWalletAccountId } from "../../converters";
+import { getAccountIdFromWalletAccountId, getWalletApiIdFromAccountId } from "../../converters";
+import { computeLedgerLiveVersionCompatibilityError } from "./computeLedgerLiveVersionCompatibilityError";
 import { computeQuotesErrors } from "./computeQuotesErrors";
+import { computeQuotesWarnings } from "./computeQuotesWarnings";
 import { fetchNetworkFeeContext } from "./fetchNetworkFeeContext";
 import { fetchQuotes } from "./service/fetchQuotes";
 import { computeFeeEstimate } from "./normalizer/networkFeeEstimate";
 import { buildFormatContext } from "./normalizer/buildFormatContext";
 import { normalizeQuote } from "./normalizer";
-import { QuotesErrorCodes, type GetQuotesArgs, type GetQuotesResponse } from "./types";
+import {
+  QuotesErrorCodes,
+  type GetQuotesArgs,
+  type GetQuotesResponse,
+  type QuotesAppPlatform,
+} from "./types";
 import { isUnsupportedPair } from "./unsupportedPairs";
 import { resolveQuotesInput } from "./resolveQuotesInput";
 
@@ -45,6 +52,8 @@ import { resolveQuotesInput } from "./resolveQuotesInput";
  *     wallet's counter-value setting.
  *   - `deviceModelId`: optional last-seen device model id. When present,
  *     quote warnings can include device-specific incompatibility signals.
+ *   - `appVersion`: optional caller platform/version. When present, quote
+ *     errors can include Ledger Live version incompatibility signals.
  *   - `highValueLossThreshold`: optional ratio used to flag quotes whose
  *     receive-side fiat value is below the configured send-side threshold.
  */
@@ -54,32 +63,21 @@ export type GetQuotesContext = {
   locale: string;
   counterValueCurrency: string;
   deviceModelId?: string;
+  appVersion?: {
+    platform: QuotesAppPlatform;
+    version: string | null;
+  };
   highValueLossThreshold?: number;
 };
 
 function getParentCurrencyId(accounts: AccountLike[], walletAccountId: string): string | undefined {
   const accountId = getAccountIdFromWalletAccountId(walletAccountId);
-  const account = accountId ? accounts.find(acc => acc.id === accountId) : undefined;
+  const account =
+    (accountId ? accounts.find(acc => acc.id === accountId) : undefined) ??
+    accounts.find(acc => getWalletApiIdFromAccountId(acc.id) === walletAccountId);
   return account ? getParentAccount(account, accounts)?.currency.id : undefined;
 }
 
-/**
- * Fetch + normalize swap quotes for a single wallet-api `getQuotes`
- * invocation. Fans out to the aggregator, joins provider / fee /
- * formatting context, and returns the wire-shaped response ready for
- * the handler to forward to the caller.
- *
- * @param args - Wire-level `getQuotes` arguments (providers, quotes
- *   input, headers, abort signal).
- * @param context - Handler-side dependencies — see
- *   {@link GetQuotesContext}. `locale` + `counterValueCurrency` come
- *   from the wallet's Redux store and drive both the aggregator call
- *   and the `Quote.formatted` strings on each returned quote.
- * @returns The response emitted back to the caller: normalized quotes
- *   (filtered for unsupported pairs), the raw per-provider rejection rows
- *   on `providerErrors`, and the digested global error list on `errors`
- *   (`noQuotes` / `amountTooLow` / `amountTooHigh`).
- */
 export async function getQuotes(
   args: GetQuotesArgs,
   context: GetQuotesContext,
@@ -89,11 +87,38 @@ export async function getQuotes(
     return {
       quotes: [],
       providerErrors: [],
+      warnings: [],
       errors: [{ code: QuotesErrorCodes.QUOTE_INPUT_RESOLUTION_FAILED }],
     };
   }
 
   const resolvedArgs = { ...args, data: quotesInput };
+  const sendParentCurrencyId = getParentCurrencyId(context.accounts, args.data.sendAccountId);
+  const receiveParentCurrencyId = getParentCurrencyId(context.accounts, args.data.receiveAccountId);
+  const deviceModelId = context.deviceModelId;
+
+  const ledgerLiveVersionCompatibilityError = computeLedgerLiveVersionCompatibilityError({
+    sendCurrencyId: quotesInput.sendCurrencyId,
+    receiveCurrencyId: quotesInput.receiveCurrencyId,
+    appVersion: context.appVersion,
+  });
+  if (ledgerLiveVersionCompatibilityError) {
+    return {
+      quotes: [],
+      providerErrors: [],
+      warnings: [],
+      errors: [ledgerLiveVersionCompatibilityError],
+    };
+  }
+
+  const warnings = computeQuotesWarnings({
+    deviceModelId,
+    sendCurrencyId: quotesInput.sendCurrencyId,
+    receiveCurrencyId: quotesInput.receiveCurrencyId,
+    sendParentCurrencyId,
+    receiveParentCurrencyId,
+  });
+
   const { rawQuotes, providerErrors } = await fetchQuotes(
     resolvedArgs,
     context.counterValueCurrency,
@@ -108,6 +133,7 @@ export async function getQuotes(
     return {
       quotes: [],
       providerErrors,
+      warnings,
       errors: computeQuotesErrors({
         successfulQuotesCount: 0,
         providerErrors,
@@ -116,15 +142,11 @@ export async function getQuotes(
     };
   }
 
-  // Skip the provider-data fetch (CAL + CDN) and the bridge-side fee-context
-  // build (sync + prepareTransaction + getTransactionStatus) when the
-  // aggregator returned only error rows — neither result would be consumed
-  // by `normalizeQuote`/`computeFeeEstimate`. The digested errors still need
-  // to be emitted so consumers can surface `noQuotes` / `amountTooLow` etc.
   if (rawQuotes.length === 0) {
     return {
       quotes: [],
       providerErrors,
+      warnings,
       errors: computeQuotesErrors({
         successfulQuotesCount: 0,
         providerErrors,
@@ -148,15 +170,13 @@ export async function getQuotes(
   const normalizationContext = {
     sendCurrencyId: quotesInput.sendCurrencyId,
     receiveCurrencyId: quotesInput.receiveCurrencyId,
-    sendParentCurrencyId: getParentCurrencyId(context.accounts, args.data.sendAccountId),
-    receiveParentCurrencyId: getParentCurrencyId(context.accounts, args.data.receiveAccountId),
-    deviceModelId: context.deviceModelId,
+    sendParentCurrencyId,
+    receiveParentCurrencyId,
+    deviceModelId,
     highValueLossThreshold: context.highValueLossThreshold,
     spotPrices: context.spotPrices,
   };
 
-  // Resolve once per request: send / receive / fee currency metadata +
-  // counter-value fiat do not vary across quotes in a single response.
   const formatContext = buildFormatContext({
     args: resolvedArgs,
     accounts: context.accounts,
@@ -174,6 +194,7 @@ export async function getQuotes(
   return {
     quotes,
     providerErrors,
+    warnings,
     errors: computeQuotesErrors({
       successfulQuotesCount: quotes.length,
       providerErrors,

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/normalizer/normalizeQuote.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/normalizer/normalizeQuote.test.ts
@@ -568,10 +568,7 @@ describe("normalizeQuote", () => {
         doubledInFiat,
       );
       expect(quote.warnings).toEqual([
-        {
-          code: QuoteWarningCodes.UNREALISTIC_QUOTE,
-          gainPercent: 100,
-        },
+        { code: QuoteWarningCodes.UNREALISTIC_QUOTE, gainPercent: 100 },
       ]);
     });
 
@@ -587,10 +584,7 @@ describe("normalizeQuote", () => {
         },
       );
       expect(quote.warnings).toEqual([
-        {
-          code: QuoteWarningCodes.UNREALISTIC_QUOTE,
-          gainPercent: 1.5,
-        },
+        { code: QuoteWarningCodes.UNREALISTIC_QUOTE, gainPercent: 1.5 },
       ]);
     });
   });
@@ -639,7 +633,7 @@ describe("normalizeQuote", () => {
       expect(quote.warnings).toEqual([]);
     });
 
-    it("populates `warnings[]` when the unrealistic-quote check fires", () => {
+    it("emits `unrealisticQuote` in `warnings[]` when the unrealistic-quote check fires", () => {
       // amountFromFiat = 1 * 1 = 1, amountToFiat = 1 * 2 = 2 -> gain = 100%
       const quote = normalizeQuote(
         makeRawQuote({ amountFrom: 1, amountTo: 1 }),
@@ -655,7 +649,7 @@ describe("normalizeQuote", () => {
       ]);
     });
 
-    it("omits both fields and leaves errors empty when the fee estimate is undefined", () => {
+    it("omits fee fields and leaves errors empty when the fee estimate is undefined", () => {
       const quote = normalizeQuote(makeRawQuote(), emptyProviderData, emptyUnrealisticInput);
       expect(quote.quoteDetails.estimatedNetworkFee).toBeUndefined();
       expect(quote.quoteDetails.approvalNetworkFee).toBeUndefined();

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/normalizer/normalizeQuote.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/normalizer/normalizeQuote.ts
@@ -31,7 +31,7 @@ const EMPTY_CONTEXT: NormalizationContext = {
  * @param feeEstimate - Wallet-side default-strategy fee estimate from
  *   {@link computeFeeEstimate}. When absent, `estimatedNetworkFee` /
  *   `approvalNetworkFee` stay undefined and `notEnoughBalanceForFees` is
- *   not emitted.
+ *   not included in `errors`.
  * @param formatContext - Locale / counter-value fiat / resolved currency
  *   metadata needed to produce `Quote.formatted`. When absent, the
  *   returned quote omits `formatted` and consumers fall back to their

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/service/fetchQuotes.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/service/fetchQuotes.test.ts
@@ -1,0 +1,112 @@
+import axios from "axios";
+
+import { getSwapAPIBaseURL } from "../../../../exchange/swap";
+import { ProviderErrorCodes } from "../types";
+import { fetchQuotes } from "./fetchQuotes";
+
+jest.mock("axios");
+
+jest.mock("../../../../exchange/swap", () => ({
+  getSwapAPIBaseURL: jest.fn(),
+}));
+
+const axiosGetMock = jest.mocked(axios.get);
+const axiosIsAxiosErrorMock = jest.mocked(axios.isAxiosError);
+const axiosIsCancelMock = jest.mocked(axios.isCancel);
+const getSwapAPIBaseURLMock = jest.mocked(getSwapAPIBaseURL);
+
+function makeArgs(): Parameters<typeof fetchQuotes>[0] {
+  return {
+    providers: ["lifi", "okx"],
+    data: {
+      amount: "100000000",
+      sendAccountId: "send-account",
+      receiveAccountId: "receive-account",
+      sendAddress: "0xfrom",
+      receiveAddress: "0xto",
+      sendCurrencyId: "bitcoin",
+      receiveCurrencyId: "ethereum",
+    },
+  };
+}
+
+describe("fetchQuotes", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getSwapAPIBaseURLMock.mockReturnValue("https://swap.test");
+    axiosIsAxiosErrorMock.mockReturnValue(false);
+    axiosIsCancelMock.mockReturnValue(false);
+  });
+
+  it("splits successful quote rows from provider error rows", async () => {
+    const rawQuote = {
+      provider: "lifi",
+      providerType: "DEX",
+      amountFrom: 1,
+      amountTo: 0.99,
+      exchangeRate: 0.99,
+      slippage: 1,
+      type: "float",
+      networkFees: { currency: "ethereum" },
+      tags: { isRegistrationRequired: false, isTokenApprovalRequired: false },
+      key: "lifi-key",
+      liquiditySource: "AMM",
+    };
+    const providerError = {
+      code: ProviderErrorCodes.AMOUNT_OFF_LIMITS,
+      type: "float",
+      provider: "okx",
+      message: "amount out of range",
+      parameter: { minAmount: "200000000" },
+    };
+    axiosGetMock.mockResolvedValue({ data: [rawQuote, providerError] });
+
+    const result = await fetchQuotes(makeArgs(), "usd");
+
+    expect(result).toEqual({
+      rawQuotes: [rawQuote],
+      providerErrors: [providerError],
+    });
+    expect(axiosGetMock).toHaveBeenCalledWith(
+      "https://swap.test/quote",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Accept: "application/json" }),
+        params: expect.any(URLSearchParams),
+      }),
+    );
+    const requestParams = axiosGetMock.mock.calls[0][1]?.params;
+    expect(requestParams).toBeInstanceOf(URLSearchParams);
+    if (!(requestParams instanceof URLSearchParams)) {
+      throw new Error("Expected request params to be URLSearchParams");
+    }
+    expect(requestParams.get("from")).toBe("bitcoin");
+    expect(requestParams.get("to")).toBe("ethereum");
+  });
+
+  it("returns an empty result when the quote HTTP response is not OK", async () => {
+    const httpError = { response: { status: 500 } };
+    axiosGetMock.mockRejectedValue(httpError);
+    axiosIsAxiosErrorMock.mockImplementation(error => error === httpError);
+
+    await expect(fetchQuotes(makeArgs(), "usd")).resolves.toEqual({
+      rawQuotes: [],
+      providerErrors: [],
+    });
+  });
+
+  it("rethrows cancelled requests", async () => {
+    const cancelError = { message: "cancelled" };
+    axiosGetMock.mockRejectedValue(cancelError);
+    axiosIsCancelMock.mockImplementation(error => error === cancelError);
+
+    await expect(fetchQuotes(makeArgs(), "usd")).rejects.toBe(cancelError);
+  });
+
+  it("rethrows network failures without an HTTP response", async () => {
+    const networkError = { request: {} };
+    axiosGetMock.mockRejectedValue(networkError);
+    axiosIsAxiosErrorMock.mockImplementation(error => error === networkError);
+
+    await expect(fetchQuotes(makeArgs(), "usd")).rejects.toBe(networkError);
+  });
+});

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/service/fetchQuotes.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/service/fetchQuotes.ts
@@ -23,7 +23,8 @@ type FetchQuotesArgs = Omit<GetQuotesArgs, "data"> & {
  *   (`rawQuotes`) and per-provider rejection rows (`providerErrors`).
  *   Rejection rows carry an aggregator `code` (e.g. `amount_off_limits`)
  *   plus the provider's reason; consumers digest them into globals via
- *   `computeQuotesErrors`.
+ *   `computeQuotesErrors`. Non-OK HTTP responses become an empty result
+ *   so the caller can return the same `noQuotes` global as the legacy UI.
  */
 export async function fetchQuotes(
   args: FetchQuotesArgs,
@@ -61,18 +62,34 @@ export async function fetchQuotes(
     searchParams.set("slippage", quotesInput.slippage.toString());
   }
 
-  const url = `${baseURL}/quote?${searchParams.toString()}`;
+  const url = `${baseURL}/quote`;
 
   const requestHeaders: Record<string, string> = {
     Accept: "application/json",
     ...(customHeaders ? Object.fromEntries(customHeaders) : {}),
   };
 
-  const response = await axios.get(url, { headers: requestHeaders, signal });
-  const data: Array<RawQuote | RawQuoteError> = response.data ?? [];
+  try {
+    const response = await axios.get(url, {
+      params: searchParams,
+      headers: requestHeaders,
+      signal,
+    });
+    const data: Array<RawQuote | RawQuoteError> = response.data ?? [];
 
-  const rawQuotes = data.filter((q): q is RawQuote => !("code" in q));
-  const providerErrors = data.filter((q): q is RawQuoteError => "code" in q);
+    const rawQuotes = data.filter((q): q is RawQuote => !("code" in q));
+    const providerErrors = data.filter((q): q is RawQuoteError => "code" in q);
 
-  return { rawQuotes, providerErrors };
+    return { rawQuotes, providerErrors };
+  } catch (error) {
+    if (axios.isCancel(error)) {
+      throw error;
+    }
+
+    if (axios.isAxiosError(error) && error.response) {
+      return { rawQuotes: [], providerErrors: [] };
+    }
+
+    throw error;
+  }
 }

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/service/types.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/service/types.ts
@@ -1,3 +1,5 @@
+import type { ProviderErrorCodes } from "../types";
+
 export type TradeMethod = "fixed" | "float";
 
 export type ProviderTypes = "DEX" | "CEX";
@@ -114,7 +116,7 @@ export type RawQuoteErrorParameter = {
 };
 
 export type RawQuoteError = {
-  code: string;
+  code: ProviderErrorCodes | (string & {});
   type: "float" | "fixed";
   provider: string;
   message: string;

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/types.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/types.ts
@@ -4,6 +4,7 @@
  */
 export type {
   QuotesInput,
+  QuotesAppPlatform,
   GetQuotesArgs,
   GetQuotesWireArgs,
   GetQuotesResponse,
@@ -13,6 +14,7 @@ export type {
   QuoteWarning,
   QuoteError,
   QuotesError,
+  QuotesWarning,
   ProviderDetails,
   QuoteProviderError,
   QuoteLiquiditySource,
@@ -26,7 +28,9 @@ export type {
 } from "@ledgerhq/wallet-api-exchange-module";
 
 export {
+  ProviderErrorCodes,
   QuoteErrorCodes,
   QuoteWarningCodes,
   QuotesErrorCodes,
+  QuotesWarningCodes,
 } from "@ledgerhq/wallet-api-exchange-module";


### PR DESCRIPTION
**Jira:** https://ledgerhq.atlassian.net/browse/LIVE-29445

**Description:**
Add Error handling for local and global errors in the Wallet Quotes logic

<!-- stac-man:stack-start -->
**Stack** _(managed by [stac-man](https://github.com/bluegardenproject/stac-man))_

- **#17336 feat/LIVE-29441-wallet-quote-global-outcomes ← this PR**
- #17456 feat/LIVE-29443-swap-transaction-status-api
- #17457 feat/LIVE-29447-desktop-swap-transaction-status
- #17458 feat/LIVE-29447-mobile-swap-transaction-status
- #17552 feat/LIVE-29447-wallet-quote-sorting
- #17553 feat/LIVE-29447-best-wallet-quote
- #17696 bugfix/LIVE-24415-wallet-quote-network-fees
<!-- stac-man:stack-end -->