### PR TITLE
ci(desktop): rotate speculos device per weekday for LWD nightly

### DIFF
--- a/.github/workflows/test-ui-e2e-only-desktop.yml
+++ b/.github/workflows/test-ui-e2e-only-desktop.yml
@@ -138,7 +138,21 @@ jobs:
       - name: Parse speculos device input
         id: parse
         run: |
-          if [ "${{ inputs.speculos_device }}" = "nanoSP and stax" ]; then
+          declare -A WEEKDAY_DEVICE=(
+            [1]=nanoSP    # Monday     - LNSP
+            [2]=stax      # Tuesday    - Stax
+            [3]=nanoX     # Wednesday  - LNX
+            [4]=flex      # Thursday   - Flex
+            [5]=nanoGen5  # Friday     - NG5
+          )
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            DOW=$(date -u +%u)
+            DEVICE="${WEEKDAY_DEVICE[$DOW]:-nanoSP}"
+            echo "device_1=$DEVICE" >> $GITHUB_OUTPUT
+            echo "device_2=skipped" >> $GITHUB_OUTPUT
+            echo "is_dual=false"   >> $GITHUB_OUTPUT
+            printf 'e2e_matrix={"include":[{"device":"%s","is_primary":true,"artifact_suffix":""}]}\n' "$DEVICE" >> $GITHUB_OUTPUT
+          elif [ "${{ inputs.speculos_device }}" = "nanoSP and stax" ]; then
             echo "device_1=nanoSP" >> $GITHUB_OUTPUT
             echo "device_2=stax" >> $GITHUB_OUTPUT
             echo "is_dual=true" >> $GITHUB_OUTPUT
@@ -530,7 +544,7 @@ jobs:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": `:ledger-logo: Ledger Live Desktop E2E tests results on ${{ inputs.ref || github.ref_name }} - ${{ inputs.speculos_device || 'nanoSP' }}${{ inputs.smoke_tests && ' (Smoke Tests)' || '' }}`,
+                    "text": `:ledger-logo: Ledger Live Desktop E2E tests results on ${{ inputs.ref || github.ref_name }} - ${device1}${{ inputs.smoke_tests && ' (Smoke Tests)' || '' }}`,
                     "emoji": true
                   }
                 },


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _Not applicable — change is CI-only (`.github/workflows/`), no published package affected. Matches recent precedent (e.g. `ci(devtools): point reusable workflows to develop`)._
- [ ] **Covered by automatic tests.** _Verified locally with a bash harness simulating each weekday, and via `act schedule -W .github/workflows/test-ui-e2e-only-desktop.yml -j prepare-devices` which executed the actual workflow YAML with `github.event_name=schedule` and produced the expected job outputs (`device_1=nanoSP`, `is_dual=false`, well-formed `e2e_matrix`). No dedicated test infra for inline workflow scripts exists in the repo._
- [x] **Impact of the changes:**
  - The LWD nightly E2E run (`.github/workflows/test-ui-e2e-only-desktop.yml`) now picks the Speculos device from the current UTC weekday.
  - Manual `workflow_dispatch` and `workflow_call` paths are unchanged — they still honour the explicit `speculos_device` input, including the dual `"nanoSP and stax"` matrix.
  - The Slack notifier's single-device header now reads the resolved device from `prepare-devices` outputs instead of the (empty-on-schedule) input.

### 📝 Description

LWD nightly coverage previously ran on `nanoSP` every weekday because the scheduled trigger doesn't pass `inputs.speculos_device`, so the parse step always fell through to the default. This PR rotates the device across the work week so all supported profiles get exercised by the cron without manual CI edits.

**Rotation (UTC weekday):**

| Day       | Device              |
|-----------|---------------------|
| Monday    | `nanoSP`   (LNSP)   |
| Tuesday   | `stax`     (Stax)   |
| Wednesday | `nanoX`    (LNX)    |
| Thursday  | `flex`     (Flex)   |
| Friday    | `nanoGen5` (NG5)    |

**Implementation:**

- In the `prepare-devices` job, branch on `github.event_name == 'schedule'`. If scheduled, compute the device from `date -u +%u` using a single editable bash associative array. Otherwise keep the existing input-driven behaviour (single device or dual `nanoSP+stax`).
- A `:-nanoSP` fallback covers any weekday outside the Mon–Fri cron window in case the schedule is widened later.
- The mapping lives in one place (the `WEEKDAY_DEVICE` array) — future device swaps are a one-line edit.
- Fixed the Slack notifier header (line 545) to read the resolved device from `prepare-devices.outputs.device_1` instead of `inputs.speculos_device`, which is empty on scheduled runs.

**Follow-up (separate ticket to be filed):** the Allure platform tag for scheduled runs (`linux-speculos-nightly`) is a single bucket across all 5 devices, so trend history will mix devices. Worth deciding whether to split per device, but out of scope for QAA-1192.

### ❓ Context

- **JIRA or GitHub link**: [QAA-1192](https://ledgerhq.atlassian.net/browse/QAA-1192)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA issue.
- **The PR description clearly documents the changes** made and explains the trade-off on Allure platform bucketing.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** locally (bash harness + `act schedule`); the manual and dual paths are unchanged.
- **Any new dependencies** — none.
- **Performance** — no impact (one extra `date` call per scheduled run).

[QAA-1192]: https://ledgerhq.atlassian.net/browse/QAA-1192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ