### PR TITLE
[LWDM] fix(common): use n-2 speculos firmware for touch devices

### DIFF
--- a/.changeset/quiet-frogs-check.md
+++ b/.changeset/quiet-frogs-check.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Use n-2 firmware for touch device Speculos app catalogs

--- a/libs/ledger-live-common/src/e2e/speculosAppVersion.ts
+++ b/libs/ledger-live-common/src/e2e/speculosAppVersion.ts
@@ -98,13 +98,13 @@ export async function getDeviceFirmwareVersion(device: DeviceModelId): Promise<s
     );
   }
 
-  // Nano S, Nano SP, Nano X use latest firmware; other devices use n-1.
+  // Nano S, Nano SP, Nano X use latest firmware; other devices use n-2.
   const sortedByIdDesc = [...providerFirmwares].sort((a, b) => b.id - a.id);
   const firmwareIndex = [DeviceModelId.nanoS, DeviceModelId.nanoSP, DeviceModelId.nanoX].includes(
     device,
   )
     ? 0
-    : 1;
+    : 2;
   const firmware = sortedByIdDesc[firmwareIndex] ?? sortedByIdDesc[0]!;
 
   firmwareVersionCache.set(device, firmware.version);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No focused Jest test exists for `speculosAppVersion.ts`; validated with `pnpm --filter @ledgerhq/live-common typecheck`._
- [x] **Impact of the changes:**
  - Speculos app catalog generation for touch devices
  - Firmware version selected for Stax, Flex, and Nano Gen 5 E2E runs
  - Nano S, Nano S Plus, and Nano X firmware selection should remain unchanged

### 📝 Description

This PR updates the Speculos firmware selection used when generating app catalogs for Ledger Live E2E helpers. Touch devices need to use the n-2 firmware version instead of n-1 so the generated catalog matches the expected compatible firmware baseline.

Before this change, non-Nano S/SP/X devices selected index `1` from the newest-first firmware list. The helper now selects index `2` for those devices while preserving the fallback to the latest firmware if fewer versions are available.

```ts
const firmwareIndex = [DeviceModelId.nanoS, DeviceModelId.nanoSP, DeviceModelId.nanoX].includes(device)
  ? 0
  : 2;
```

### ❓ Context

- **JIRA or GitHub link**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)