### PR TITLE
feat(wallet-pnl): add average cost basis PnL library

### DIFF
--- a/.changeset/four-mugs-notice.md
+++ b/.changeset/four-mugs-notice.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-pnl": minor
+---
+
+Add `@ledgerhq/wallet-pnl`: average cost basis PnL (per-asset and portfolio), operation classification, countervalue-backed cost basis cache.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -57,6 +57,7 @@ libs/live-currency-format/                               @ledgerhq/wallet-xp
 libs/live-hooks/                                         @ledgerhq/wallet-xp
 libs/ui/                                                 @ledgerhq/wallet-xp
 libs/asset-aggregation/                                  @ledgerhq/wallet-xp
+libs/wallet-pnl/                                         @ledgerhq/wallet-xp
 libs/live-wallet/                                        @ledgerhq/wallet-xp
 libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/ @ledgerhq/wallet-xp
 libs/ledger-live-common/src/modularDrawer/               @ledgerhq/wallet-xp

--- a/libs/wallet-pnl/.eslintrc.js
+++ b/libs/wallet-pnl/.eslintrc.js
@@ -1,0 +1,28 @@
+module.exports = {
+  env: {
+    browser: true,
+    es6: true,
+  },
+  globals: {
+    Atomics: "readonly",
+    SharedArrayBuffer: "readonly",
+  },
+  extends: ["plugin:import/typescript"],
+  plugins: ["import"],
+  rules: {
+    "no-console": ["error", { allow: ["warn", "error"] }],
+    "linebreak-style": ["error", "unix"],
+    "@typescript-eslint/no-empty-function": "off",
+    "@typescript-eslint/no-namespace": ["error", { allowDeclarations: true }],
+    "@typescript-eslint/no-explicit-any": "warn",
+  },
+  overrides: [
+    {
+      files: ["src/**/*.test.{ts,tsx}"],
+      env: {
+        "jest/globals": true,
+      },
+      plugins: ["jest"],
+    },
+  ],
+};

--- a/libs/wallet-pnl/CHANGELOG.md
+++ b/libs/wallet-pnl/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @ledgerhq/wallet-pnl

--- a/libs/wallet-pnl/jest.config.js
+++ b/libs/wallet-pnl/jest.config.js
@@ -1,0 +1,25 @@
+module.exports = {
+  transform: {
+    "^.+\\.(ts|tsx)?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "esnext",
+          transform: {
+            react: {
+              runtime: "automatic",
+            },
+          },
+        },
+      },
+    ],
+  },
+  testEnvironment: "jsdom",
+  testPathIgnorePatterns: ["lib/", "lib-es/", "fixtures/", "helpers/"],
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../" }], "text"],
+  reporters: [
+    "default",
+    ...(process.env.CI ? ["github-actions"] : []),
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/libs/wallet-pnl/jest.config.js
+++ b/libs/wallet-pnl/jest.config.js
@@ -15,7 +15,7 @@ module.exports = {
     ],
   },
   testEnvironment: "jsdom",
-  testPathIgnorePatterns: ["lib/", "lib-es/", "fixtures/", "helpers/"],
+  testPathIgnorePatterns: ["lib/", "lib-es/", "helpers/"],
   coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../" }], "text"],
   reporters: [
     "default",

--- a/libs/wallet-pnl/package.json
+++ b/libs/wallet-pnl/package.json
@@ -1,0 +1,106 @@
+{
+  "name": "@ledgerhq/wallet-pnl",
+  "version": "0.1.0",
+  "description": "Ledger Live wallet-pnl module – per-asset and portfolio Profit & Loss using Average Cost Basis (ACB)",
+  "keywords": [
+    "Ledger"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LedgerHQ/ledger-live.git"
+  },
+  "bugs": {
+    "url": "https://github.com/LedgerHQ/ledger-live/issues"
+  },
+  "homepage": "https://github.com/LedgerHQ/ledger-live/tree/develop/libs/wallet-pnl",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "lib/index.js",
+  "module": "lib-es/index.js",
+  "types": "lib/index.d.ts",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@ledgerhq/cryptoassets": "workspace:*",
+    "@ledgerhq/ledger-wallet-framework": "workspace:*",
+    "@ledgerhq/types-live": "workspace:*",
+    "@ledgerhq/types-cryptoassets": "workspace:*",
+    "@ledgerhq/live-countervalues": "workspace:*",
+    "bignumber.js": "^9.1.2"
+  },
+  "peerDependencies": {
+    "react": ">=19"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/react": "catalog:",
+    "jest": "catalog:",
+    "jest-environment-jsdom": "catalog:",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
+    "@swc/jest": "catalog:",
+    "@swc/core": "catalog:",
+    "@testing-library/dom": "catalog:",
+    "@testing-library/react": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "scripts": {
+    "clean": "rimraf lib lib-es",
+    "build": "tsc --project tsconfig.build.json && tsc --project tsconfig.build.json -m esnext --moduleResolution bundler --outDir lib-es",
+    "prewatch": "pnpm build",
+    "watch": "tsc --watch --project tsconfig.build.json",
+    "watch:es": "tsc --watch --project tsconfig.build.json -m esnext --moduleResolution bundler --outDir lib-es",
+    "lint": "oxlint -c ../oxc-live-libs/.oxlintrc.json ./src",
+    "lint:fix": "pnpm exec oxfmt -c ../../.oxfmtrc.json ./src && oxlint -c ../oxc-live-libs/.oxlintrc.json ./src --fix --quiet",
+    "format": "pnpm exec oxfmt -c ../../.oxfmtrc.json ./src",
+    "format:check": "pnpm exec oxfmt -c ../../.oxfmtrc.json ./src --check",
+    "typecheck": "tsc --noEmit --customConditions node",
+    "test": "jest",
+    "coverage": "jest --coverage"
+  },
+  "typesVersions": {
+    "*": {
+      "*.json": [
+        "*.json"
+      ],
+      "*": [
+        "lib/*"
+      ],
+      "lib/*": [
+        "lib/*"
+      ],
+      "lib-es/*": [
+        "lib-es/*"
+      ]
+    }
+  },
+  "exports": {
+    "./lib/*": "./lib/*.js",
+    "./lib/*.js": "./lib/*.js",
+    "./lib-es/*": "./lib-es/*.js",
+    "./lib-es/*.js": "./lib-es/*.js",
+    "./hooks": {
+      "@ledgerhq/source": "./src/hooks/index.ts",
+      "require": "./lib/hooks/index.js",
+      "default": "./lib-es/hooks/index.js"
+    },
+    "./*": {
+      "@ledgerhq/source": "./src/*.ts",
+      "require": "./lib/*.js",
+      "default": "./lib-es/*.js"
+    },
+    "./*.js": {
+      "@ledgerhq/source": "./src/*.ts",
+      "require": "./lib/*.js",
+      "default": "./lib-es/*.js"
+    },
+    "./package.json": "./package.json"
+  }
+}

--- a/libs/wallet-pnl/package.json
+++ b/libs/wallet-pnl/package.json
@@ -82,6 +82,12 @@
     }
   },
   "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "@ledgerhq/source": "./src/index.ts",
+      "require": "./lib/index.js",
+      "default": "./lib-es/index.js"
+    },
     "./lib/*": "./lib/*.js",
     "./lib/*.js": "./lib/*.js",
     "./lib-es/*": "./lib-es/*.js",
@@ -90,6 +96,11 @@
       "@ledgerhq/source": "./src/hooks/index.ts",
       "require": "./lib/hooks/index.js",
       "default": "./lib-es/hooks/index.js"
+    },
+    "./scenarios": {
+      "@ledgerhq/source": "./src/scenarios/index.ts",
+      "require": "./lib/scenarios/index.js",
+      "default": "./lib-es/scenarios/index.js"
     },
     "./*": {
       "@ledgerhq/source": "./src/*.ts",

--- a/libs/wallet-pnl/src/__tests__/classifyOperation.test.ts
+++ b/libs/wallet-pnl/src/__tests__/classifyOperation.test.ts
@@ -1,0 +1,100 @@
+import type { OperationType } from "@ledgerhq/types-live";
+import {
+  OPERATION_TYPE_IN_FAMILY,
+  OPERATION_TYPE_OUT_FAMILY,
+  OPERATION_TYPE_STAKE_FAMILY,
+} from "@ledgerhq/ledger-wallet-framework/operation";
+import type { OperationFlow } from "../types";
+import { INFLOWS, OUTFLOWS, STAKE_FAMILY, classifyOperation } from "../classifyOperation";
+import { makeOp, OpOverrides } from "../scenarios/operations";
+
+const opOfType = (
+  type: OperationType | string,
+  extras: OpOverrides = {},
+): ReturnType<typeof makeOp> => makeOp({ type, ...extras });
+
+describe("classifyOperation", () => {
+  describe("taxonomy alignment with @ledgerhq/ledger-wallet-framework", () => {
+    it.each(OPERATION_TYPE_IN_FAMILY)("INFLOWS includes IN_FAMILY '%s'", type => {
+      expect(INFLOWS.has(type)).toBe(true);
+    });
+
+    it.each(OPERATION_TYPE_OUT_FAMILY)("OUTFLOWS includes OUT_FAMILY '%s'", type => {
+      expect(OUTFLOWS.has(type)).toBe(true);
+    });
+
+    it.each(OPERATION_TYPE_STAKE_FAMILY)(
+      "STAKE_FAMILY '%s' is excluded from INFLOWS and OUTFLOWS",
+      type => {
+        expect(INFLOWS.has(type)).toBe(false);
+        expect(OUTFLOWS.has(type)).toBe(false);
+      },
+    );
+  });
+
+  describe("every INFLOWS member → 'inflow'", () => {
+    it.each([...INFLOWS])("'%s'", type => {
+      expect(classifyOperation(opOfType(type))).toBe("inflow");
+    });
+  });
+
+  describe("every OUTFLOWS member → 'outflow'", () => {
+    it.each([...OUTFLOWS])("'%s'", type => {
+      expect(classifyOperation(opOfType(type))).toBe("outflow");
+    });
+  });
+
+  describe("every STAKE_FAMILY member → 'ignored' (no principal transfer)", () => {
+    it.each([...STAKE_FAMILY])("'%s'", type => {
+      expect(classifyOperation(opOfType(type))).toBe("ignored");
+    });
+  });
+  describe("classification anchors", () => {
+    it.each<[string, OperationFlow]>([
+      ["FEES", "outflow"],
+      ["REWARD", "inflow"],
+      ["REWARD_PAYOUT", "inflow"],
+      ["BOND", "ignored"],
+      ["STAKE", "ignored"],
+      ["APPROVE", "ignored"],
+      ["WITHDRAW", "inflow"],
+      ["WITHDRAW_UNBONDED", "ignored"],
+    ])("'%s' → '%s'", (type, expected) => {
+      expect(classifyOperation(opOfType(type))).toBe(expected);
+    });
+  });
+
+  describe("non-family no-op types → 'ignored'", () => {
+    it.each(["NONE", "UNKNOWN"])("'%s'", type => {
+      expect(classifyOperation(opOfType(type))).toBe("ignored");
+    });
+  });
+
+  describe("open-set design: arbitrary strings resolve via INFLOWS / OUTFLOWS membership", () => {
+    it.each<[string, OperationFlow]>([
+      ["SUPPLY", "inflow"],
+      ["REDEEM", "outflow"],
+      ["SELL", "outflow"],
+    ])("'%s' → '%s'", (type, expected) => {
+      expect(classifyOperation(opOfType(type))).toBe(expected);
+    });
+  });
+
+  describe("hasFailed=true short-circuits to 'ignored' regardless of type", () => {
+    it.each(["IN", "OUT", "REWARD", "NFT_OUT", "SELL"])("failed '%s'", type => {
+      expect(classifyOperation(opOfType(type, { hasFailed: true }))).toBe("ignored");
+    });
+  });
+
+  describe("hasFailed: undefined and false are equivalent (strict boolean check)", () => {
+    it("missing hasFailed property → IN classifies as 'inflow'", () => {
+      const op = opOfType("IN");
+      Reflect.deleteProperty(op, "hasFailed");
+      expect(classifyOperation(op)).toBe("inflow");
+    });
+
+    it("hasFailed=false → IN classifies as 'inflow'", () => {
+      expect(classifyOperation(opOfType("IN", { hasFailed: false }))).toBe("inflow");
+    });
+  });
+});

--- a/libs/wallet-pnl/src/__tests__/costBasisCache.test.ts
+++ b/libs/wallet-pnl/src/__tests__/costBasisCache.test.ts
@@ -1,0 +1,97 @@
+import { getCostBasis, invalidatePnLCache } from "../costBasisCache";
+import { EUR, USD } from "../scenarios/currencies";
+import { resetOperationIdCounter } from "../scenarios/operations";
+import { buildHodlerScenario } from "../scenarios/hodler";
+import { buildMultiAssetScenario } from "../scenarios/multiAsset";
+import { buildSingleTradeScenario } from "../scenarios/singleTrade";
+import { buildTraderScenario } from "../scenarios/trader";
+import { expectAssetPnL } from "./helpers/pnl";
+
+beforeEach(() => {
+  invalidatePnLCache();
+  resetOperationIdCounter();
+});
+
+describe("costBasisCache — memoisation policy (key = accountId | fiat | lastOpId | historyKey)", () => {
+  it("identical inputs return the same CostBasisState reference (cache hit)", () => {
+    const scenario = buildHodlerScenario();
+    const a = getCostBasis(scenario.account, USD, scenario.countervalues);
+    const b = getCostBasis(scenario.account, USD, scenario.countervalues);
+    expect(a).toBe(b);
+  });
+
+  describe("invalidatePnLCache", () => {
+    it("scoped to an accountId: drops only that account's entries", () => {
+      const scenario = buildMultiAssetScenario();
+      const btcBefore = getCostBasis(scenario.btcAccount, USD, scenario.countervalues);
+      const ethBefore = getCostBasis(scenario.ethAccount, USD, scenario.countervalues);
+
+      invalidatePnLCache(scenario.btcAccount.id);
+
+      const btcAfter = getCostBasis(scenario.btcAccount, USD, scenario.countervalues);
+      const ethAfter = getCostBasis(scenario.ethAccount, USD, scenario.countervalues);
+
+      expect(btcAfter).not.toBe(btcBefore);
+      expect(ethAfter).toBe(ethBefore);
+    });
+
+    it("no argument: full reset (every entry dropped)", () => {
+      const scenario = buildMultiAssetScenario();
+      const before = getCostBasis(scenario.btcAccount, USD, scenario.countervalues);
+      invalidatePnLCache();
+      const after = getCostBasis(scenario.btcAccount, USD, scenario.countervalues);
+      expect(after).not.toBe(before);
+    });
+  });
+
+  describe("fiat is part of the cache key (USD and EUR do not collide)", () => {
+    it("USD and EUR yield distinct CostBasisState references for the same account", () => {
+      const scenario = buildSingleTradeScenario();
+      const inEur = getCostBasis(scenario.heldAccount, EUR, scenario.countervalues);
+
+      const usdHistoryOnly = (() => {
+        const { data, status, cache } = scenario.countervalues;
+        return {
+          data: { ...data, "BTC USD": data["BTC EUR"] },
+          status: { ...status, "BTC USD": status["BTC EUR"] },
+          cache: { ...cache, "BTC USD": cache["BTC EUR"] },
+        };
+      })();
+      const inUsd = getCostBasis(scenario.heldAccount, USD, usdHistoryOnly);
+
+      expect(inUsd).not.toBe(inEur);
+    });
+  });
+
+  describe("isSpamOperation bypasses the cache", () => {
+    it("filtered call returns a different costBasis from the cached unfiltered baseline (no stale read)", () => {
+      const scenario = buildTraderScenario();
+
+      // Cache test: we want to observe the raw reducer output bypassing the
+      // cache. Reconciliation is balance-driven (uncached) and would mask the
+      // difference here, so disable it for both calls.
+      const baseline = expectAssetPnL(scenario.account, scenario.countervalues, USD, {
+        reconcileWithBalance: false,
+      });
+      const filtered = expectAssetPnL(scenario.account, scenario.countervalues, USD, {
+        isSpamOperation: scenario.dustPredicate,
+        reconcileWithBalance: false,
+      });
+
+      expect(filtered.costBasis.eq(baseline.costBasis)).toBe(false);
+      expect(filtered.costBasis.lt(baseline.costBasis)).toBe(true);
+    });
+
+    it("filtered call leaves the cache untouched: subsequent unfiltered call still hits", () => {
+      const scenario = buildHodlerScenario();
+
+      const before = getCostBasis(scenario.account, USD, scenario.countervalues);
+      getCostBasis(scenario.account, USD, scenario.countervalues, {
+        isSpamOperation: () => true,
+      });
+      const after = getCostBasis(scenario.account, USD, scenario.countervalues);
+
+      expect(after).toBe(before);
+    });
+  });
+});

--- a/libs/wallet-pnl/src/__tests__/costBasisReconciliationUnit.test.ts
+++ b/libs/wallet-pnl/src/__tests__/costBasisReconciliationUnit.test.ts
@@ -1,0 +1,180 @@
+import BigNumber from "bignumber.js";
+import { applyBalanceReconciliation, detectBalanceGap } from "../costBasisReconciliation";
+import { initialCostBasisState } from "../costBasis";
+import { ETH, USD, WEI } from "../scenarios/currencies";
+import { buildCV, dailyHistory } from "../scenarios/countervalues";
+import type { CostBasisState } from "../types";
+import { expectBN } from "./helpers/bn";
+
+const BUY_DATE = new Date(Date.UTC(2025, 0, 15));
+const LATEST_DATE = new Date(Date.UTC(2025, 6, 1));
+const BUY_PRICE = 2000;
+const LATEST_PRICE = 2400;
+
+function stateAt({
+  amountWei,
+  costMinor,
+  aepMinorPerAtom,
+  lastDate = BUY_DATE,
+}: {
+  amountWei: BigNumber;
+  costMinor: BigNumber;
+  aepMinorPerAtom: BigNumber;
+  lastDate?: Date | null;
+}): CostBasisState {
+  return {
+    ...initialCostBasisState,
+    totalAmount: amountWei,
+    totalCostInCounterValue: costMinor,
+    lifetimeCostInCounterValue: costMinor,
+    averageEntryPrice: aepMinorPerAtom,
+    lastOperationDate: lastDate,
+    lastOperationId: lastDate === null ? null : "op-1",
+  };
+}
+
+const tenEthState = (lastDate: Date | null = BUY_DATE) =>
+  stateAt({
+    amountWei: WEI.times(10),
+    // 10 ETH × $2000 = $20,000 ⇒ 2,000,000 cents (USD minor) ⇒ × 1 (fiat magnitude wraps elsewhere).
+    // For these tests we don't need the exact magnitude; we just need consistent units between
+    // costMinor and AEP × amountWei. We model "minor units per atomic crypto unit", with
+    // AEP = costMinor / amountWei = 2_000_000 / 1e19 = 2e-13 — a tiny BigNumber that's fine.
+    costMinor: new BigNumber(2_000_000),
+    aepMinorPerAtom: new BigNumber(2_000_000).div(WEI.times(10)),
+    lastDate,
+  });
+
+describe("detectBalanceGap (pure)", () => {
+  it("reports isClean=true and delta=0 when balance equals recordedAmount", () => {
+    const state = tenEthState();
+    const gap = detectBalanceGap(state, WEI.times(10));
+
+    expect(gap.isClean).toBe(true);
+    expect(gap.applied).toBe(false);
+    expectBN(gap.delta).toEqualBN(0);
+    expectBN(gap.recordedAmount).toEqualBN(WEI.times(10));
+    expectBN(gap.onChainBalance).toEqualBN(WEI.times(10));
+  });
+
+  it("reports a negative delta when on-chain balance < recordedAmount", () => {
+    const state = tenEthState();
+    const gap = detectBalanceGap(state, WEI.times(1));
+
+    expect(gap.isClean).toBe(false);
+    expect(gap.applied).toBe(false);
+    expectBN(gap.delta).toEqualBN(WEI.times(-9));
+  });
+
+  it("reports a positive delta when on-chain balance > recordedAmount", () => {
+    const state = tenEthState();
+    const gap = detectBalanceGap(state, WEI.times(12));
+
+    expect(gap.isClean).toBe(false);
+    expect(gap.applied).toBe(false);
+    expectBN(gap.delta).toEqualBN(WEI.times(2));
+  });
+
+  it("handles a fresh state with no recorded amount: any positive balance ⇒ positive delta", () => {
+    const gap = detectBalanceGap(initialCostBasisState, WEI.times(5));
+
+    expect(gap.isClean).toBe(false);
+    expectBN(gap.delta).toEqualBN(WEI.times(5));
+    expectBN(gap.recordedAmount).toEqualBN(0);
+  });
+});
+
+describe("applyBalanceReconciliation (CV-aware repair)", () => {
+  const cleanCV = buildCV({
+    pair: { from: ETH, to: USD },
+    history: dailyHistory([
+      [BUY_DATE, BUY_PRICE],
+      [LATEST_DATE, LATEST_PRICE],
+    ]),
+    latest: LATEST_PRICE,
+  });
+
+  it("is a no-op when the gap is clean", () => {
+    const state = tenEthState();
+    const gap = detectBalanceGap(state, WEI.times(10));
+    const result = applyBalanceReconciliation(state, gap, ETH, USD, cleanCV);
+
+    expect(result.applied).toBe(false);
+    expect(result.state).toBe(state);
+  });
+
+  it("returns applied=false (and unchanged state) when the CV lookup fails", () => {
+    const state = tenEthState();
+    const gap = detectBalanceGap(state, WEI.times(1));
+    const emptyCV = { data: {}, status: {}, cache: {} };
+    const result = applyBalanceReconciliation(state, gap, ETH, USD, emptyCV);
+
+    expect(result.applied).toBe(false);
+    expect(result.state).toBe(state);
+  });
+
+  it("positive delta: folds a synthetic inflow valued at the latest rate", () => {
+    const state = tenEthState();
+    const gap = detectBalanceGap(state, WEI.times(12));
+    const result = applyBalanceReconciliation(state, gap, ETH, USD, cleanCV);
+
+    expect(result.applied).toBe(true);
+    expectBN(result.state.totalAmount).toEqualBN(WEI.times(12));
+    // Original cost ($20,000 = 2_000_000 minor) + synthetic 2 ETH × $2400 = $4,800 = 480_000 minor
+    expectBN(result.state.totalCostInCounterValue).toBeCloseToBN(new BigNumber("2480000"), 0);
+    // lifetimeCost stays at original — synthetic accruals don't count as cash invested.
+    expectBN(result.state.lifetimeCostInCounterValue).toEqualBN(new BigNumber(2_000_000));
+  });
+
+  it("negative delta: synthetic outflow uses lastOperationDate price and accrues realised PnL", () => {
+    // Use a CV where the buy and the disposal happened at the same $2000 — synthetic
+    // disposal should net zero realised PnL.
+    const flatCV = buildCV({
+      pair: { from: ETH, to: USD },
+      history: dailyHistory([[BUY_DATE, BUY_PRICE]]),
+      latest: BUY_PRICE,
+    });
+    const state = tenEthState();
+    const gap = detectBalanceGap(state, WEI.times(1));
+    const result = applyBalanceReconciliation(state, gap, ETH, USD, flatCV);
+
+    expect(result.applied).toBe(true);
+    expectBN(result.state.totalAmount).toEqualBN(WEI.times(1));
+    // 1 ETH × $2000 entry price = $2000 minor = 200_000 cents.
+    expectBN(result.state.totalCostInCounterValue).toBeCloseToBN(new BigNumber("200000"), 0);
+    // Synthetic 9 ETH disposal valued at $2000 (same as AEP) ⇒ realised ≈ 0.
+    expectBN(result.state.realisedPnL).toBeCloseToBN(new BigNumber("0"), 0);
+    // lifetimeCost is never decremented by outflows (synthetic or not).
+    expectBN(result.state.lifetimeCostInCounterValue).toEqualBN(new BigNumber(2_000_000));
+  });
+
+  it("negative delta on an empty position is a no-op (guarded by totalAmount<=0)", () => {
+    const emptyState: CostBasisState = {
+      ...initialCostBasisState,
+      lastOperationDate: BUY_DATE,
+      lastOperationId: "op-1",
+    };
+    const gap = detectBalanceGap(emptyState, WEI.times(-3));
+
+    expect(gap.isClean).toBe(false);
+    expectBN(gap.delta).toEqualBN(WEI.times(-3));
+
+    const result = applyBalanceReconciliation(emptyState, gap, ETH, USD, cleanCV);
+
+    expect(result.applied).toBe(false);
+    expect(result.state).toBe(emptyState);
+  });
+
+  it("positive delta on an initial state still produces a valid synthetic inflow", () => {
+    // No prior ops at all — balance appeared out of thin air (rebase-only token).
+    const gap = detectBalanceGap(initialCostBasisState, WEI.times(2));
+    const result = applyBalanceReconciliation(initialCostBasisState, gap, ETH, USD, cleanCV);
+
+    expect(result.applied).toBe(true);
+    expectBN(result.state.totalAmount).toEqualBN(WEI.times(2));
+    // 2 ETH × $2400 latest = $4,800 = 480_000 minor.
+    expectBN(result.state.totalCostInCounterValue).toBeCloseToBN(new BigNumber("480000"), 0);
+    // lifetimeCost stays at zero — synthetic inflow doesn't count as cash invested.
+    expectBN(result.state.lifetimeCostInCounterValue).toEqualBN(0);
+  });
+});

--- a/libs/wallet-pnl/src/__tests__/helpers/bn.ts
+++ b/libs/wallet-pnl/src/__tests__/helpers/bn.ts
@@ -1,0 +1,42 @@
+import BigNumber from "bignumber.js";
+
+export type BNLike = BigNumber | number | string;
+
+export function toBN(v: BNLike): BigNumber {
+  return BigNumber.isBigNumber(v) ? v : new BigNumber(v);
+}
+
+/**
+ * Lightweight BigNumber-aware assertions. Avoids `.toString()` boilerplate
+ * everywhere and surfaces a readable diff on failure.
+ */
+export function expectBN(actual: BNLike): {
+  toEqualBN: (expected: BNLike) => void;
+  toBeCloseToBN: (expected: BNLike, decimals?: number) => void;
+  toBePositive: () => void;
+} {
+  const a = toBN(actual);
+  return {
+    toEqualBN(expected: BNLike): void {
+      const e = toBN(expected);
+      if (!a.isEqualTo(e)) {
+        throw new Error(`Expected BigNumber ${a.toString()} to equal ${e.toString()}`);
+      }
+    },
+    toBeCloseToBN(expected: BNLike, decimals = 2): void {
+      const e = toBN(expected);
+      const tolerance = new BigNumber(10).pow(-decimals);
+      const diff = a.minus(e).absoluteValue();
+      if (diff.gt(tolerance)) {
+        throw new Error(
+          `Expected BigNumber ${a.toString()} to be within ${tolerance.toString()} of ${e.toString()} (diff ${diff.toString()})`,
+        );
+      }
+    },
+    toBePositive(): void {
+      if (!a.isPositive() || a.isZero()) {
+        throw new Error(`Expected BigNumber ${a.toString()} to be strictly positive`);
+      }
+    },
+  };
+}

--- a/libs/wallet-pnl/src/__tests__/helpers/pnl.ts
+++ b/libs/wallet-pnl/src/__tests__/helpers/pnl.ts
@@ -1,0 +1,20 @@
+import type { AccountLike } from "@ledgerhq/types-live";
+import type { Currency } from "@ledgerhq/types-cryptoassets";
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
+import { computeAssetPnL } from "../../assetPnL";
+import type { AssetPnL, ComputePnLOptions } from "../../types";
+
+export function expectAssetPnL(
+  account: AccountLike,
+  countervalues: CounterValuesState,
+  fiat: Currency,
+  options?: ComputePnLOptions,
+): AssetPnL {
+  const pnl = computeAssetPnL(account, countervalues, fiat, options);
+  if (pnl === null) {
+    throw new Error(
+      `expectAssetPnL: computeAssetPnL returned null for account "${account.id}" — the fixture has neither operations nor a balance`,
+    );
+  }
+  return pnl;
+}

--- a/libs/wallet-pnl/src/__tests__/helpers/testing.ts
+++ b/libs/wallet-pnl/src/__tests__/helpers/testing.ts
@@ -1,0 +1,8 @@
+import { renderHook, type RenderHookResult } from "@testing-library/react";
+
+export function render<TProps, TResult>(
+  callback: (props: TProps) => TResult,
+  initialProps: TProps,
+): RenderHookResult<TResult, TProps> {
+  return renderHook(callback, { initialProps });
+}

--- a/libs/wallet-pnl/src/__tests__/hooks.test.ts
+++ b/libs/wallet-pnl/src/__tests__/hooks.test.ts
@@ -1,0 +1,206 @@
+import BigNumber from "bignumber.js";
+import type { AccountLike } from "@ledgerhq/types-live";
+import type { Currency } from "@ledgerhq/types-cryptoassets";
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
+import { useAssetPnL, usePortfolioPnL } from "../hooks";
+import { computeAssetPnL } from "../assetPnL";
+import { computePortfolioPnL } from "../portfolioPnL";
+import { invalidatePnLCache } from "../costBasisCache";
+import type { AssetPnL, ComputePnLOptions, PortfolioPnL } from "../types";
+import { BTC, EUR, USD } from "../scenarios/currencies";
+import { makeAccount } from "../scenarios/accounts";
+import { resetOperationIdCounter } from "../scenarios/operations";
+import { buildSingleTradeScenario } from "../scenarios/singleTrade";
+import { buildMultiAssetScenario } from "../scenarios/multiAsset";
+import { buildTraderScenario } from "../scenarios/trader";
+import { render } from "./helpers/testing";
+
+type AssetProps = {
+  account: AccountLike;
+  countervalues: CounterValuesState;
+  fiat: Currency;
+  options?: ComputePnLOptions;
+};
+
+type PortfolioProps = {
+  accounts: AccountLike[];
+  countervalues: CounterValuesState;
+  fiat: Currency;
+  options?: ComputePnLOptions;
+};
+
+function renderAssetHook(initial: AssetProps) {
+  return render(
+    ({ account, countervalues, fiat, options }: AssetProps) =>
+      useAssetPnL(account, countervalues, fiat, options),
+    initial,
+  );
+}
+
+function renderPortfolioHook(initial: PortfolioProps) {
+  return render(
+    ({ accounts, countervalues, fiat, options }: PortfolioProps) =>
+      usePortfolioPnL(accounts, countervalues, fiat, options),
+    initial,
+  );
+}
+
+/** Field-by-field BigNumber equality on the full AssetPnL shape. */
+function expectSameAssetPnL(actual: AssetPnL, expected: AssetPnL): void {
+  expect(actual.costBasis.isEqualTo(expected.costBasis)).toBe(true);
+  expect(actual.lifetimeCost.isEqualTo(expected.lifetimeCost)).toBe(true);
+  expect(actual.realisedPnL.isEqualTo(expected.realisedPnL)).toBe(true);
+  expect(actual.unrealisedPnL.isEqualTo(expected.unrealisedPnL)).toBe(true);
+  expect(actual.totalPnL.isEqualTo(expected.totalPnL)).toBe(true);
+  expect(actual.averageEntryPrice.isEqualTo(expected.averageEntryPrice)).toBe(true);
+  expect(
+    actual.reconciliation.recordedAmount.isEqualTo(expected.reconciliation.recordedAmount),
+  ).toBe(true);
+  expect(
+    actual.reconciliation.onChainBalance.isEqualTo(expected.reconciliation.onChainBalance),
+  ).toBe(true);
+  expect(actual.reconciliation.delta.isEqualTo(expected.reconciliation.delta)).toBe(true);
+  expect(actual.reconciliation.isClean).toBe(expected.reconciliation.isClean);
+  expect(actual.reconciliation.applied).toBe(expected.reconciliation.applied);
+}
+
+/** Field-by-field BigNumber equality on the (no averageEntryPrice) PortfolioPnL shape. */
+function expectSamePortfolioPnL(actual: PortfolioPnL, expected: PortfolioPnL): void {
+  expect(actual.costBasis.isEqualTo(expected.costBasis)).toBe(true);
+  expect(actual.lifetimeCost.isEqualTo(expected.lifetimeCost)).toBe(true);
+  expect(actual.realisedPnL.isEqualTo(expected.realisedPnL)).toBe(true);
+  expect(actual.unrealisedPnL.isEqualTo(expected.unrealisedPnL)).toBe(true);
+  expect(actual.totalPnL.isEqualTo(expected.totalPnL)).toBe(true);
+}
+
+beforeEach(() => {
+  invalidatePnLCache();
+  resetOperationIdCounter();
+});
+
+describe("useAssetPnL — single-trade scenario (BTC held, priced in EUR)", () => {
+  let scenario: ReturnType<typeof buildSingleTradeScenario>;
+  let baseProps: AssetProps;
+
+  beforeEach(() => {
+    scenario = buildSingleTradeScenario();
+    baseProps = {
+      account: scenario.heldAccount,
+      countervalues: scenario.countervalues,
+      fiat: EUR,
+    };
+  });
+
+  it("delegates to computeAssetPnL — every field passes through unchanged", () => {
+    const direct = computeAssetPnL(scenario.heldAccount, scenario.countervalues, EUR);
+    invalidatePnLCache();
+    const { result } = renderAssetHook(baseProps);
+
+    expect(direct).not.toBeNull();
+    expectSameAssetPnL(result.current!, direct!);
+  });
+
+  it("propagates the null contract — no operations and zero balance returns null", () => {
+    const empty = makeAccount(BTC, { operations: [], balance: new BigNumber(0) });
+    const { result } = renderAssetHook({ ...baseProps, account: empty });
+    expect(result.current).toBeNull();
+  });
+
+  it("returns the same reference across renders when inputs are unchanged (stable identity)", () => {
+    const { result, rerender } = renderAssetHook(baseProps);
+    const first = result.current;
+    rerender(baseProps);
+    expect(result.current).toBe(first);
+  });
+
+  it("recomputes when the account changes — closed variant yields costBasis = 0", () => {
+    const { result, rerender } = renderAssetHook(baseProps);
+    const first = result.current;
+    rerender({ ...baseProps, account: scenario.closedAccount });
+
+    expect(result.current).not.toBe(first);
+    expect(result.current!.costBasis.isEqualTo(0)).toBe(true);
+  });
+
+  it("recomputes when the fiat changes — EUR → USD returns a fresh AssetPnL", () => {
+    const { result, rerender } = renderAssetHook(baseProps);
+    const first = result.current;
+    rerender({ ...baseProps, fiat: USD });
+    expect(result.current).not.toBe(first);
+  });
+});
+
+describe("useAssetPnL — trader scenario (ETH/USD, isSpamOperation toggle)", () => {
+  it("recomputes when options change — switching on isSpamOperation shrinks costBasis", () => {
+    const trader = buildTraderScenario();
+    // Reducer-mechanics check: the trader fixture's `balance` deliberately
+    // disagrees with its op stream (dust IN ops don't appear on-chain), and
+    // the always-on reconciliation layer would mask the filtering effect.
+    // Disable it to keep this test focused on the cost-basis reducer.
+    const initial: AssetProps = {
+      account: trader.account,
+      countervalues: trader.countervalues,
+      fiat: USD,
+      options: { reconcileWithBalance: false },
+    };
+    const { result, rerender } = renderAssetHook(initial);
+    const unfiltered = result.current!;
+
+    rerender({
+      ...initial,
+      options: { isSpamOperation: trader.dustPredicate, reconcileWithBalance: false },
+    });
+    const filtered = result.current!;
+
+    expect(filtered).not.toBe(unfiltered);
+    expect(filtered.costBasis.lt(unfiltered.costBasis)).toBe(true);
+  });
+});
+
+describe("usePortfolioPnL — multi-asset scenario (BTC + ETH + USDC in USD)", () => {
+  let scenario: ReturnType<typeof buildMultiAssetScenario>;
+  let baseProps: PortfolioProps;
+
+  beforeEach(() => {
+    scenario = buildMultiAssetScenario();
+    baseProps = {
+      accounts: [scenario.btcAccount, scenario.ethAccount, scenario.usdcAccount],
+      countervalues: scenario.countervalues,
+      fiat: USD,
+    };
+  });
+
+  it("delegates to computePortfolioPnL — aggregated totals pass through unchanged", () => {
+    const direct = computePortfolioPnL(baseProps.accounts, scenario.countervalues, USD);
+    invalidatePnLCache();
+    const { result } = renderPortfolioHook(baseProps);
+    expectSamePortfolioPnL(result.current, direct);
+  });
+
+  it("returns the same reference across renders when inputs are unchanged (stable identity)", () => {
+    const { result, rerender } = renderPortfolioHook(baseProps);
+    const first = result.current;
+    rerender(baseProps);
+    expect(result.current).toBe(first);
+  });
+
+  it("recomputes when the accounts array changes — new array (same content) yields a fresh PortfolioPnL with equal totals", () => {
+    const { result, rerender } = renderPortfolioHook(baseProps);
+    const first = result.current;
+    rerender({ ...baseProps, accounts: [...baseProps.accounts] });
+    const second = result.current;
+
+    expect(second).not.toBe(first);
+    expectSamePortfolioPnL(second, first);
+  });
+
+  it("returns zeroed totals on an empty accounts list", () => {
+    const { result } = renderPortfolioHook({ ...baseProps, accounts: [] });
+    const pnl = result.current;
+    expect(pnl.costBasis.isEqualTo(0)).toBe(true);
+    expect(pnl.lifetimeCost.isEqualTo(0)).toBe(true);
+    expect(pnl.realisedPnL.isEqualTo(0)).toBe(true);
+    expect(pnl.unrealisedPnL.isEqualTo(0)).toBe(true);
+    expect(pnl.totalPnL.isEqualTo(0)).toBe(true);
+  });
+});

--- a/libs/wallet-pnl/src/__tests__/percentage.test.ts
+++ b/libs/wallet-pnl/src/__tests__/percentage.test.ts
@@ -1,0 +1,38 @@
+import BigNumber from "bignumber.js";
+import { pnlPercentage } from "../percentage";
+import { expectBN } from "./helpers/bn";
+
+const bn = (n: number | string) => new BigNumber(n);
+
+describe("pnlPercentage", () => {
+  describe("returns (pnl / basis) × 100; sign mirrors PnL", () => {
+    it.each<[number, number, number]>([
+      [10, 100, 10],
+      [25, 100, 25],
+      [50, 200, 25],
+      [200, 100, 200],
+      [-300, 1000, -30],
+      [0, 1000, 0],
+    ])("pnl=%s, basis=%s → %s%%", (pnl, basis, expected) => {
+      expectBN(pnlPercentage(bn(pnl), bn(basis))!).toEqualBN(expected);
+    });
+
+    it("brokerage-style trade view: PnL €5,571.98 / basis €15,050 → 37.02%", () => {
+      expectBN(pnlPercentage(bn("5571.98"), bn("15050"))!).toBeCloseToBN("37.02", 2);
+    });
+  });
+
+  describe("zero-basis guard: returns null (avoids NaN / Infinity)", () => {
+    it.each<[number]>([[100], [-100], [0]])("pnl=%s, basis=0 → null", pnl => {
+      expect(pnlPercentage(bn(pnl), bn(0))).toBeNull();
+    });
+  });
+
+  describe("unit-agnostic: ratio is invariant under fiat-unit scaling", () => {
+    it("(€5,646.984 / €15,000) ≡ (564,698.4¢ / 1,500,000¢)", () => {
+      const inMajor = pnlPercentage(bn("5646.984"), bn("15000"))!;
+      const inMinor = pnlPercentage(bn("564698.4"), bn("1500000"))!;
+      expectBN(inMinor).toEqualBN(inMajor);
+    });
+  });
+});

--- a/libs/wallet-pnl/src/__tests__/reconciliation.test.ts
+++ b/libs/wallet-pnl/src/__tests__/reconciliation.test.ts
@@ -1,0 +1,173 @@
+import BigNumber from "bignumber.js";
+import { computeAssetPnL } from "../assetPnL";
+import { invalidatePnLCache } from "../costBasisCache";
+import { ETH, USD, WEI } from "../scenarios/currencies";
+import { makeAccount } from "../scenarios/accounts";
+import { buy, resetOperationIdCounter } from "../scenarios/operations";
+import { buildCV, dailyHistory } from "../scenarios/countervalues";
+import { expectBN } from "./helpers/bn";
+
+beforeEach(() => {
+  invalidatePnLCache();
+  resetOperationIdCounter();
+});
+
+const BUY_DATE = new Date(Date.UTC(2025, 0, 15));
+const LATEST_DATE = new Date(Date.UTC(2025, 6, 1));
+const BUY_PRICE = 2000;
+const LATEST_PRICE = 2400;
+
+function buildScenario({ balanceWei }: { balanceWei: BigNumber }) {
+  const account = makeAccount(ETH, {
+    operations: [buy(WEI.times(10), BUY_DATE)],
+    balance: balanceWei,
+  });
+  const countervalues = buildCV({
+    pair: { from: ETH, to: USD },
+    history: dailyHistory([[BUY_DATE, BUY_PRICE]]),
+    latest: LATEST_PRICE,
+  });
+  return { account, countervalues };
+}
+
+describe("computeAssetPnL — balance reconciliation (Fix 1)", () => {
+  describe("clean account (balance equals net of operations)", () => {
+    it("reports isClean=true and applied=false; PnL is unchanged from the raw reducer", () => {
+      const { account, countervalues } = buildScenario({ balanceWei: WEI.times(10) });
+      const pnl = computeAssetPnL(account, countervalues, USD)!;
+
+      expect(pnl.reconciliation.isClean).toBe(true);
+      expect(pnl.reconciliation.applied).toBe(false);
+      expectBN(pnl.reconciliation.delta).toEqualBN(0);
+      expectBN(pnl.reconciliation.recordedAmount).toEqualBN(WEI.times(10));
+      expectBN(pnl.reconciliation.onChainBalance).toEqualBN(WEI.times(10));
+    });
+  });
+
+  describe("missing outflow (chain balance < cumulative-from-ops)", () => {
+    // Models the WETH-after-`approve` case: 10 ETH bought, but on-chain we
+    // only see 1 ETH because 9 ETH were pulled by a router (no OUT op).
+    const balanceWei = WEI.times(1);
+
+    it("recordedAmount and onChainBalance reflect the divergence (delta = -9 ETH)", () => {
+      const { account, countervalues } = buildScenario({ balanceWei });
+      const pnl = computeAssetPnL(account, countervalues, USD)!;
+
+      expectBN(pnl.reconciliation.recordedAmount).toEqualBN(WEI.times(10));
+      expectBN(pnl.reconciliation.onChainBalance).toEqualBN(balanceWei);
+      expectBN(pnl.reconciliation.delta).toEqualBN(WEI.times(-9));
+      expect(pnl.reconciliation.isClean).toBe(false);
+      expect(pnl.reconciliation.applied).toBe(true);
+    });
+
+    it("costBasis is dégonflé to averageEntryPrice × balance (≈ $2,000 instead of $20,000)", () => {
+      const { account, countervalues } = buildScenario({ balanceWei });
+      const pnl = computeAssetPnL(account, countervalues, USD)!;
+
+      // 1 ETH × $2000 entry price = $2000 (in fiat-minor units = cents)
+      expectBN(pnl.costBasis).toBeCloseToBN(new BigNumber("200000"), 0);
+    });
+
+    it("realisedPnL absorbs the disposed value at the last-known op date proxy", () => {
+      const { account, countervalues } = buildScenario({ balanceWei });
+      const pnl = computeAssetPnL(account, countervalues, USD)!;
+
+      // 9 ETH disposed at BUY_DATE proxy ($2000) − 9 × $2000 cost = $0.
+      // (No price action between buy and the missing outflow date in this fixture.)
+      expectBN(pnl.realisedPnL).toEqualBN(0);
+    });
+
+    it("unrealisedPnL is sane: 1 ETH × ($2400 − $2000) = +$400 (not the catastrophic −$22,000)", () => {
+      const { account, countervalues } = buildScenario({ balanceWei });
+      const pnl = computeAssetPnL(account, countervalues, USD)!;
+
+      expectBN(pnl.unrealisedPnL).toBeCloseToBN(new BigNumber("40000"), 0);
+    });
+
+    it("opt-out: passing reconcileWithBalance=false restores the raw catastrophic numbers", () => {
+      const { account, countervalues } = buildScenario({ balanceWei });
+      const raw = computeAssetPnL(account, countervalues, USD, {
+        reconcileWithBalance: false,
+      })!;
+
+      // Raw cost basis = full 10 × $2000 = $20,000, never dégonflé.
+      expectBN(raw.costBasis).toBeCloseToBN(new BigNumber("2000000"), 0);
+      // Raw unrealised = 1 ETH × $2400 − $20,000 = −$17,600.
+      expectBN(raw.unrealisedPnL).toBeCloseToBN(new BigNumber("-1760000"), 0);
+      // Diagnostic still shows the gap, but applied=false.
+      expect(raw.reconciliation.isClean).toBe(false);
+      expect(raw.reconciliation.applied).toBe(false);
+    });
+
+    it("totalPnL = realisedPnL + unrealisedPnL after reconciliation", () => {
+      const { account, countervalues } = buildScenario({ balanceWei });
+      const pnl = computeAssetPnL(account, countervalues, USD)!;
+      expectBN(pnl.totalPnL).toEqualBN(pnl.realisedPnL.plus(pnl.unrealisedPnL));
+    });
+
+    it("lifetimeCost reflects the original 10 ETH × $2000 = $20,000 — synthetic outflow does NOT decrement it", () => {
+      const { account, countervalues } = buildScenario({ balanceWei });
+      const pnl = computeAssetPnL(account, countervalues, USD)!;
+      expectBN(pnl.lifetimeCost).toBeCloseToBN(new BigNumber("2000000"), 0);
+    });
+  });
+
+  describe("missing inflow / silent accrual (chain balance > cumulative-from-ops)", () => {
+    // Models a rebase-token-like situation: ops register 10 ETH bought, but
+    // the balance grew to 12 ETH on its own (rebase, missed IN).
+    const balanceWei = WEI.times(12);
+
+    it("delta = +2 ETH; reconciliation applied", () => {
+      const { account, countervalues } = buildScenario({ balanceWei });
+      const pnl = computeAssetPnL(account, countervalues, USD)!;
+
+      expectBN(pnl.reconciliation.delta).toEqualBN(WEI.times(2));
+      expect(pnl.reconciliation.applied).toBe(true);
+    });
+
+    it("costBasis grows by (delta × latest price) — the synthetic inflow is valued at latest", () => {
+      const { account, countervalues } = buildScenario({ balanceWei });
+      const pnl = computeAssetPnL(account, countervalues, USD)!;
+
+      // Original 10 × $2000 = $20,000  +  synthetic 2 × $2400 = $4,800  →  $24,800.
+      expectBN(pnl.costBasis).toBeCloseToBN(new BigNumber("2480000"), 0);
+    });
+
+    it("averageEntryPrice is pulled toward latest by the synthetic accrual (above the historical $2000)", () => {
+      const { account, countervalues } = buildScenario({ balanceWei });
+      const pnlReconciled = computeAssetPnL(account, countervalues, USD)!;
+      const pnlRaw = computeAssetPnL(account, countervalues, USD, {
+        reconcileWithBalance: false,
+      })!;
+
+      // Reconciliation re-anchors AEP toward the latest price ($2400 > $2000).
+      // Comparing the two same-units values sidesteps cents-per-wei vs $/ETH.
+      expect(pnlReconciled.averageEntryPrice.gt(pnlRaw.averageEntryPrice)).toBe(true);
+    });
+
+    it("unrealisedPnL = original 10 ETH × ($2400−$2000) + synthetic 2 ETH × ($2400−$2400) = +$4,000", () => {
+      const { account, countervalues } = buildScenario({ balanceWei });
+      const pnl = computeAssetPnL(account, countervalues, USD)!;
+
+      expectBN(pnl.unrealisedPnL).toBeCloseToBN(new BigNumber("400000"), 0);
+    });
+
+    it("lifetimeCost = $20,000 — synthetic inflow (rebase yield, not real cash) is NOT counted", () => {
+      const { account, countervalues } = buildScenario({ balanceWei });
+      const pnl = computeAssetPnL(account, countervalues, USD)!;
+      expectBN(pnl.lifetimeCost).toBeCloseToBN(new BigNumber("2000000"), 0);
+    });
+  });
+
+  describe("countervalue lookup fails for the delta", () => {
+    it("returns null when there is no CV at all (no historical buys can be valued)", () => {
+      const account = makeAccount(ETH, {
+        operations: [buy(WEI.times(10), BUY_DATE)],
+        balance: WEI.times(1),
+      });
+      const emptyCV = { data: {}, status: {}, cache: {} };
+      const pnl = computeAssetPnL(account, emptyCV, USD);
+      expect(pnl).toBeNull();
+    });
+  });
+});

--- a/libs/wallet-pnl/src/__tests__/scenarios.test.ts
+++ b/libs/wallet-pnl/src/__tests__/scenarios.test.ts
@@ -1,0 +1,337 @@
+import BigNumber from "bignumber.js";
+import { computePortfolioPnL } from "../portfolioPnL";
+import { invalidatePnLCache } from "../costBasisCache";
+import { pnlPercentage } from "../percentage";
+import { EUR, USD } from "../scenarios/currencies";
+import { resetOperationIdCounter } from "../scenarios/operations";
+import { buildHodlerScenario } from "../scenarios/hodler";
+import { buildStakerScenario } from "../scenarios/staker";
+import { buildTraderScenario } from "../scenarios/trader";
+import { buildMultiAssetScenario, buildNestedSubAccountScenario } from "../scenarios/multiAsset";
+import { buildSingleTradeScenario } from "../scenarios/singleTrade";
+import { expectBN } from "./helpers/bn";
+import { expectAssetPnL } from "./helpers/pnl";
+
+const FIAT_MAJOR_TO_MINOR = new BigNumber(100);
+
+beforeEach(() => {
+  invalidatePnLCache();
+  resetOperationIdCounter();
+});
+
+describe("computeAssetPnL", () => {
+  describe("Hodler — 24 DCA buys + mid-stream partial sell, BTC/USD", () => {
+    let scenario: ReturnType<typeof buildHodlerScenario>;
+    let pnl: ReturnType<typeof expectAssetPnL>;
+
+    beforeEach(() => {
+      scenario = buildHodlerScenario();
+      pnl = expectAssetPnL(scenario.account, scenario.countervalues, USD);
+    });
+
+    it("final costBasis = running ACB resumed after the mid-stream sell", () => {
+      expectBN(pnl.costBasis).toBeCloseToBN(
+        scenario.expected.finalCostBasisUsd.times(FIAT_MAJOR_TO_MINOR),
+        0,
+      );
+    });
+
+    it("realisedPnL uses the average entry price at sell date (not the final average)", () => {
+      expectBN(pnl.realisedPnL).toBeCloseToBN(
+        scenario.expected.realisedPnLUsd.times(FIAT_MAJOR_TO_MINOR),
+        0,
+      );
+      expectBN(pnl.realisedPnL).toBePositive();
+    });
+
+    it("unrealisedPnL > 0 when latest price > final ACB", () => {
+      expectBN(pnl.unrealisedPnL).toBePositive();
+    });
+
+    it("averageEntryPrice > 0", () => {
+      expectBN(pnl.averageEntryPrice).toBePositive();
+    });
+
+    it("totalPnL = realisedPnL + unrealisedPnL", () => {
+      expectBN(pnl.totalPnL).toEqualBN(pnl.realisedPnL.plus(pnl.unrealisedPnL));
+    });
+  });
+
+  describe("Staker — 1 buy + 12 monthly REWARD inflows, ETH/USD", () => {
+    let scenario: ReturnType<typeof buildStakerScenario>;
+    let pnl: ReturnType<typeof expectAssetPnL>;
+
+    beforeEach(() => {
+      scenario = buildStakerScenario();
+      pnl = expectAssetPnL(scenario.account, scenario.countervalues, USD);
+    });
+
+    it("each REWARD adds to costBasis at its market price on the reward date", () => {
+      expectBN(pnl.costBasis).toBeCloseToBN(
+        scenario.expected.totalCostUsd.times(FIAT_MAJOR_TO_MINOR),
+        0,
+      );
+    });
+
+    it("realisedPnL = 0 when no outflow operation exists", () => {
+      expectBN(pnl.realisedPnL).toEqualBN(0);
+    });
+
+    it("totalPnL = unrealisedPnL when realisedPnL = 0", () => {
+      expectBN(pnl.totalPnL).toEqualBN(pnl.unrealisedPnL);
+    });
+
+    it("unrealisedPnL > 0 when latest price > average entry price", () => {
+      expectBN(pnl.unrealisedPnL).toBePositive();
+    });
+  });
+
+  describe("Trader — 80 alternating ops with failures and dust", () => {
+    let scenario: ReturnType<typeof buildTraderScenario>;
+
+    beforeEach(() => {
+      scenario = buildTraderScenario();
+    });
+
+    it("fixture loads 80 ops with the documented failed and dust counts", () => {
+      expect(scenario.account.operations).toHaveLength(80);
+      expect(scenario.account.operations.filter(op => op.hasFailed === true)).toHaveLength(
+        scenario.expected.failedCount,
+      );
+      expect(scenario.account.operations.filter(scenario.dustPredicate)).toHaveLength(
+        scenario.expected.dustCount,
+      );
+    });
+
+    it("unfiltered run yields costBasis > 0", () => {
+      const pnl = expectAssetPnL(scenario.account, scenario.countervalues, USD);
+      expectBN(pnl.costBasis).toBePositive();
+    });
+
+    // The next two assertions probe the cost-basis reducer in isolation
+    // (filtering ops should change the cost basis). The trader fixture
+    // deliberately makes `balance` disagree with the ops (dust IN ops not
+    // reflected on-chain), so the always-on reconciliation layer would
+    // otherwise mask the difference. Opt out for these reducer-focused checks.
+    it("isSpamOperation excludes matching ops → filtered costBasis < unfiltered baseline", () => {
+      const baseline = expectAssetPnL(scenario.account, scenario.countervalues, USD, {
+        reconcileWithBalance: false,
+      });
+
+      invalidatePnLCache();
+      const filtered = expectAssetPnL(scenario.account, scenario.countervalues, USD, {
+        isSpamOperation: scenario.dustPredicate,
+        reconcileWithBalance: false,
+      });
+
+      expect(filtered.costBasis.lt(baseline.costBasis)).toBe(true);
+    });
+
+    it("failed ops are excluded from costBasis (flipping hasFailed=false changes the basis)", () => {
+      const baseline = expectAssetPnL(scenario.account, scenario.countervalues, USD, {
+        reconcileWithBalance: false,
+      });
+
+      const accountWithoutFailures = {
+        ...scenario.account,
+        operations: scenario.account.operations.map(op => ({ ...op, hasFailed: false })),
+      };
+      invalidatePnLCache();
+      const noFailures = expectAssetPnL(accountWithoutFailures, scenario.countervalues, USD, {
+        reconcileWithBalance: false,
+      });
+
+      expect(noFailures.costBasis.eq(baseline.costBasis)).toBe(false);
+    });
+  });
+
+  describe("SingleTrade — one buy ± one full sell, BTC/EUR", () => {
+    let scenario: ReturnType<typeof buildSingleTradeScenario>;
+
+    beforeEach(() => {
+      scenario = buildSingleTradeScenario();
+    });
+
+    describe("held variant — buy + hold (latest price = sell price)", () => {
+      let pnl: ReturnType<typeof expectAssetPnL>;
+
+      beforeEach(() => {
+        pnl = expectAssetPnL(scenario.heldAccount, scenario.countervalues, EUR);
+      });
+
+      it("costBasis = qty × buy price", () => {
+        expectBN(pnl.costBasis).toBeCloseToBN(
+          scenario.expected.investedEur.times(FIAT_MAJOR_TO_MINOR),
+          0,
+        );
+      });
+
+      it("unrealisedPnL = qty × (latest price − buy price)", () => {
+        expectBN(pnl.unrealisedPnL).toBeCloseToBN(
+          scenario.expected.grossUnrealisedAtSellPriceEur.times(FIAT_MAJOR_TO_MINOR),
+          0,
+        );
+      });
+
+      it("gross PnL %-vs-costBasis matches the hand-derived scenario figure", () => {
+        const pct = pnlPercentage(pnl.totalPnL, pnl.costBasis)!;
+        expectBN(pct).toBeCloseToBN(scenario.expected.grossPctOnCostBasis, 2);
+      });
+
+      it("fee-adjusted view → €5,571.98 / 37.02% (caller subtracts entry+exit fees, inflates basis by entry fee)", () => {
+        const grossPnLEur = pnl.totalPnL.div(FIAT_MAJOR_TO_MINOR);
+        const totalFeesEur = scenario.fees.entryEur.plus(scenario.fees.exitEur);
+        const netPnLEur = grossPnLEur.minus(totalFeesEur);
+        const feeBasisEur = scenario.expected.investedEur.plus(scenario.fees.entryEur);
+        const netPctEur = pnlPercentage(netPnLEur, feeBasisEur)!;
+
+        expectBN(netPnLEur).toBeCloseToBN(scenario.expected.feeAdjustedPnLEur, 2);
+        expectBN(netPctEur).toBeCloseToBN(scenario.expected.feeAdjustedPctOnInvestmentPlusFee, 2);
+      });
+    });
+
+    describe("closed variant — buy + full sell", () => {
+      let pnl: ReturnType<typeof expectAssetPnL>;
+
+      beforeEach(() => {
+        pnl = expectAssetPnL(scenario.closedAccount, scenario.countervalues, EUR);
+      });
+
+      it("realisedPnL = qty × (sell price − buy price) on a clean round trip", () => {
+        expectBN(pnl.realisedPnL).toBeCloseToBN(
+          scenario.expected.grossRealisedPnLEur.times(FIAT_MAJOR_TO_MINOR),
+          0,
+        );
+      });
+
+      it("costBasis = 0 after a full sell (no remaining cost-bearing position)", () => {
+        expectBN(pnl.costBasis).toEqualBN(0);
+      });
+
+      it("unrealisedPnL = 0 after a full sell (no balance left to revalue)", () => {
+        expectBN(pnl.unrealisedPnL).toEqualBN(0);
+      });
+
+      it("pnlPercentage(totalPnL, costBasis) = null on a fully closed position (caller must use an invested-amount basis)", () => {
+        expect(pnlPercentage(pnl.totalPnL, pnl.costBasis)).toBeNull();
+      });
+
+      it("lifetimeCost = invested amount even after a full sell (never decremented)", () => {
+        expectBN(pnl.lifetimeCost).toBeCloseToBN(
+          scenario.expected.investedEur.times(FIAT_MAJOR_TO_MINOR),
+          0,
+        );
+      });
+
+      it("pnlPercentage(totalPnL, lifetimeCost) recovers the gross %-vs-invested KPI on a closed position", () => {
+        const pct = pnlPercentage(pnl.totalPnL, pnl.lifetimeCost)!;
+        expectBN(pct).toBeCloseToBN(scenario.expected.grossPctOnCostBasis, 2);
+      });
+    });
+
+    describe("held variant — lifetimeCost equals running costBasis when no sells happened", () => {
+      it("lifetimeCost === costBasis on the held account (every inflow still represented)", () => {
+        const pnl = expectAssetPnL(scenario.heldAccount, scenario.countervalues, EUR);
+        expectBN(pnl.lifetimeCost).toEqualBN(pnl.costBasis);
+      });
+    });
+  });
+});
+
+describe("computePortfolioPnL", () => {
+  describe("MultiAsset — BTC + ETH + USDC, in USD", () => {
+    let scenario: ReturnType<typeof buildMultiAssetScenario>;
+
+    beforeEach(() => {
+      scenario = buildMultiAssetScenario();
+    });
+
+    it("portfolio totals = sum of per-account computeAssetPnL (realisedPnL, unrealisedPnL, costBasis, lifetimeCost)", () => {
+      const accounts = [scenario.btcAccount, scenario.ethAccount, scenario.usdcAccount];
+      const portfolio = computePortfolioPnL(accounts, scenario.countervalues, USD);
+
+      let realised = new BigNumber(0);
+      let unrealised = new BigNumber(0);
+      let costBasis = new BigNumber(0);
+      let lifetimeCost = new BigNumber(0);
+      for (const account of accounts) {
+        const single = expectAssetPnL(account, scenario.countervalues, USD);
+        realised = realised.plus(single.realisedPnL);
+        unrealised = unrealised.plus(single.unrealisedPnL);
+        costBasis = costBasis.plus(single.costBasis);
+        lifetimeCost = lifetimeCost.plus(single.lifetimeCost);
+      }
+
+      expectBN(portfolio.realisedPnL).toEqualBN(realised);
+      expectBN(portfolio.unrealisedPnL).toEqualBN(unrealised);
+      expectBN(portfolio.costBasis).toEqualBN(costBasis);
+      expectBN(portfolio.lifetimeCost).toEqualBN(lifetimeCost);
+      expectBN(portfolio.totalPnL).toEqualBN(realised.plus(unrealised));
+    });
+
+    it("portfolio lifetimeCost ≥ costBasis (sells decrement running basis but not lifetime)", () => {
+      const accounts = [scenario.btcAccount, scenario.ethAccount, scenario.usdcAccount];
+      const portfolio = computePortfolioPnL(accounts, scenario.countervalues, USD);
+      expect(portfolio.lifetimeCost.gte(portfolio.costBasis)).toBe(true);
+    });
+
+    it("BTC partial sell: per-asset lifetimeCost > running costBasis", () => {
+      const btc = expectAssetPnL(scenario.btcAccount, scenario.countervalues, USD);
+      expect(btc.lifetimeCost.gt(btc.costBasis)).toBe(true);
+    });
+
+    it("every account with inflows has costBasis > 0", () => {
+      for (const account of [scenario.btcAccount, scenario.ethAccount, scenario.usdcAccount]) {
+        const pnl = expectAssetPnL(account, scenario.countervalues, USD);
+        expectBN(pnl.costBasis).toBePositive();
+      }
+    });
+
+    it("stable-priced asset (USDC pinned at $1): realisedPnL = 0 and unrealisedPnL ≈ 0", () => {
+      const usdcPnL = expectAssetPnL(scenario.usdcAccount, scenario.countervalues, USD);
+      expectBN(usdcPnL.realisedPnL).toEqualBN(0);
+      expectBN(usdcPnL.unrealisedPnL).toBeCloseToBN(0, 0);
+    });
+  });
+
+  describe("sub-account flattening (mirrors getPortfolio)", () => {
+    let scenario: ReturnType<typeof buildNestedSubAccountScenario>;
+
+    beforeEach(() => {
+      scenario = buildNestedSubAccountScenario();
+    });
+
+    it("aggregates parent + token sub-account when only the parent is passed", () => {
+      const portfolio = computePortfolioPnL([scenario.ethWithUsdc], scenario.countervalues, USD);
+      const ethOnly = expectAssetPnL(scenario.ethWithUsdc, scenario.countervalues, USD);
+      const usdcOnly = expectAssetPnL(scenario.usdcSub, scenario.countervalues, USD);
+
+      expectBN(portfolio.costBasis).toEqualBN(ethOnly.costBasis.plus(usdcOnly.costBasis));
+      expectBN(portfolio.realisedPnL).toEqualBN(ethOnly.realisedPnL.plus(usdcOnly.realisedPnL));
+      expectBN(portfolio.unrealisedPnL).toEqualBN(
+        ethOnly.unrealisedPnL.plus(usdcOnly.unrealisedPnL),
+      );
+      expectBN(portfolio.totalPnL).toEqualBN(ethOnly.totalPnL.plus(usdcOnly.totalPnL));
+    });
+
+    it("portfolio costBasis > parent-only costBasis (sub-account is included, never dropped)", () => {
+      const portfolio = computePortfolioPnL([scenario.ethWithUsdc], scenario.countervalues, USD);
+      const ethOnly = expectAssetPnL(scenario.ethWithUsdc, scenario.countervalues, USD);
+
+      expect(portfolio.costBasis.gt(ethOnly.costBasis)).toBe(true);
+    });
+
+    it("caller contract: passing [parent, sub] together double-counts the sub (matches getPortfolio.flattenAccounts)", () => {
+      const fromTopLevel = computePortfolioPnL([scenario.ethWithUsdc], scenario.countervalues, USD);
+      invalidatePnLCache();
+      const fromMixed = computePortfolioPnL(
+        [scenario.ethWithUsdc, scenario.usdcSub],
+        scenario.countervalues,
+        USD,
+      );
+      const usdcOnly = expectAssetPnL(scenario.usdcSub, scenario.countervalues, USD);
+
+      expectBN(fromMixed.costBasis).toEqualBN(fromTopLevel.costBasis.plus(usdcOnly.costBasis));
+    });
+  });
+});

--- a/libs/wallet-pnl/src/assetPnL.ts
+++ b/libs/wallet-pnl/src/assetPnL.ts
@@ -1,0 +1,74 @@
+import BigNumber from "bignumber.js";
+import type { AccountLike } from "@ledgerhq/types-live";
+import type { Currency } from "@ledgerhq/types-cryptoassets";
+import { calculate } from "@ledgerhq/live-countervalues/logic";
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
+import { getAccountCurrency } from "@ledgerhq/ledger-wallet-framework/account";
+import { getCostBasis } from "./costBasisCache";
+import { applyBalanceReconciliation, detectBalanceGap } from "./costBasisReconciliation";
+import type { AssetPnL, ComputePnLOptions, Reconciliation } from "./types";
+
+const ZERO = new BigNumber(0);
+
+export function computeAssetPnL(
+  account: AccountLike,
+  countervalues: CounterValuesState,
+  fiat: Currency,
+  options?: ComputePnLOptions,
+): AssetPnL | null {
+  const asset = getAccountCurrency(account);
+  const rawState = getCostBasis(account, fiat, countervalues, options);
+
+  const hasOps = account.operations.length > 0;
+  const hasBalance = account.balance.gt(0);
+
+  if (!hasOps && !hasBalance) return null;
+
+  // Reconciliation defaults to ON: if the chain says the wallet holds X and
+  // the cost-basis reducer thinks Y, we close the gap so consumers don't see
+  // a wildly negative `unrealisedPnL` on tokens whose disposals weren't
+  // captured (typical ERC-20 `transferFrom`-after-`APPROVE` flows). Callers
+  // that need raw, op-only values can pass `reconcileWithBalance: false`.
+  //
+  // Detection (`detectBalanceGap`) is pure and always cheap; only the actual
+  // repair (`applyBalanceReconciliation`) is gated on the opt-in flag. This
+  // keeps the diagnostic available for downstream UIs even when the repair
+  // is suppressed.
+  const apply = options?.reconcileWithBalance !== false;
+  const gap = detectBalanceGap(rawState, account.balance);
+  let state = rawState;
+  let applied = false;
+  if (apply && !gap.isClean) {
+    const result = applyBalanceReconciliation(rawState, gap, asset, fiat, countervalues);
+    state = result.state;
+    applied = result.applied;
+  }
+  const reconciliation: Reconciliation = { ...gap, applied };
+
+  const hasHistory = !state.totalAmount.isZero() || !state.realisedPnL.isZero();
+
+  let unrealisedPnL = ZERO;
+  if (hasBalance) {
+    const latestCV = calculate(countervalues, {
+      value: account.balance.toNumber(),
+      from: asset,
+      to: fiat,
+      disableRounding: true,
+    });
+    if (typeof latestCV === "number") {
+      unrealisedPnL = new BigNumber(latestCV).minus(state.totalCostInCounterValue);
+    } else if (!hasHistory) {
+      return null;
+    }
+  }
+
+  return {
+    unrealisedPnL,
+    realisedPnL: state.realisedPnL,
+    totalPnL: state.realisedPnL.plus(unrealisedPnL),
+    costBasis: state.totalCostInCounterValue,
+    lifetimeCost: state.lifetimeCostInCounterValue,
+    averageEntryPrice: state.averageEntryPrice,
+    reconciliation,
+  };
+}

--- a/libs/wallet-pnl/src/classifyOperation.ts
+++ b/libs/wallet-pnl/src/classifyOperation.ts
@@ -1,0 +1,53 @@
+import type { Operation, OperationType } from "@ledgerhq/types-live";
+import {
+  OPERATION_TYPE_IN_FAMILY,
+  OPERATION_TYPE_OUT_FAMILY,
+  OPERATION_TYPE_STAKE_FAMILY,
+} from "@ledgerhq/ledger-wallet-framework/operation";
+import type { OperationFlow } from "./types";
+
+/**
+ * Operation types that move asset INTO the account from a cost-basis
+ * perspective. Derived from the canonical
+ * {@link OPERATION_TYPE_IN_FAMILY} taxonomy of `@ledgerhq/ledger-wallet-framework`,
+ * extended with DeFi types not modelled at the framework level
+ * (`SUPPLY`, `NFT_IN`).
+ */
+export const INFLOWS: ReadonlySet<OperationType | string> = new Set<OperationType | string>([
+  ...OPERATION_TYPE_IN_FAMILY,
+  "NFT_IN",
+  "SUPPLY",
+]);
+
+/**
+ * Operation types that move asset OUT of the account from a cost-basis
+ * perspective. Derived from the canonical
+ * {@link OPERATION_TYPE_OUT_FAMILY} taxonomy of `@ledgerhq/ledger-wallet-framework`,
+ * extended with DeFi types not modelled at the framework level
+ * (`REDEEM`, `SELL`, `NFT_OUT`).
+ *
+ * Note: `OPERATION_TYPE_STAKE_FAMILY` ops (`BOND`, `STAKE`, `APPROVE`,
+ * `WITHDRAW_UNBONDED`, ...) are intentionally NOT included — they only move
+ * fees, not principal, so they're treated as `"ignored"` by `classifyOperation`.
+ */
+export const OUTFLOWS: ReadonlySet<OperationType | string> = new Set<OperationType | string>([
+  ...OPERATION_TYPE_OUT_FAMILY,
+  "NFT_OUT",
+  "REDEEM",
+  "SELL",
+]);
+
+/**
+ * Stake-family ops are exposed for callers (and tests) that need to assert
+ * they're treated as no-ops by the cost-basis reducer.
+ */
+export const STAKE_FAMILY: ReadonlySet<OperationType | string> = new Set<OperationType | string>(
+  OPERATION_TYPE_STAKE_FAMILY,
+);
+
+export function classifyOperation(op: Operation): OperationFlow {
+  if (op.hasFailed) return "ignored";
+  if (INFLOWS.has(op.type)) return "inflow";
+  if (OUTFLOWS.has(op.type)) return "outflow";
+  return "ignored";
+}

--- a/libs/wallet-pnl/src/costBasis.ts
+++ b/libs/wallet-pnl/src/costBasis.ts
@@ -1,0 +1,156 @@
+import BigNumber from "bignumber.js";
+import type { AccountLike, Operation } from "@ledgerhq/types-live";
+import type { Currency } from "@ledgerhq/types-cryptoassets";
+import { calculate } from "@ledgerhq/live-countervalues/logic";
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
+import { getAccountCurrency } from "@ledgerhq/ledger-wallet-framework/account";
+import { classifyOperation } from "./classifyOperation";
+import type { ComputePnLOptions, CostBasisAcc, CostBasisState, OperationFlow } from "./types";
+
+const ZERO = new BigNumber(0);
+
+export const initialCostBasisState: CostBasisState = {
+  totalAmount: ZERO,
+  totalCostInCounterValue: ZERO,
+  lifetimeCostInCounterValue: ZERO,
+  realisedPnL: ZERO,
+  averageEntryPrice: ZERO,
+  lastOperationId: null,
+  lastOperationDate: null,
+};
+
+function compareOps(a: Operation, b: Operation): number {
+  const da = a.date.getTime();
+  const db = b.date.getTime();
+  if (da !== db) return da - db;
+  if (a.id < b.id) return -1;
+  if (a.id > b.id) return 1;
+  return 0;
+}
+
+function isAfterBookmark(op: Operation, prev: CostBasisState): boolean {
+  if (prev.lastOperationDate === null) return true;
+  const opTime = op.date.getTime();
+  const bookTime = prev.lastOperationDate.getTime();
+  if (opTime > bookTime) return true;
+  if (opTime < bookTime) return false;
+  return prev.lastOperationId !== null && op.id > prev.lastOperationId;
+}
+
+function applyInflow(acc: CostBasisAcc, value: BigNumber, cvBN: BigNumber): CostBasisAcc {
+  const totalCost = acc.totalCost.plus(cvBN);
+  const totalAmount = acc.totalAmount.plus(value);
+  return {
+    totalAmount,
+    totalCost,
+    lifetimeCost: acc.lifetimeCost.plus(cvBN),
+    realised: acc.realised,
+    averageEntryPrice: totalAmount.gt(0) ? totalCost.div(totalAmount) : acc.averageEntryPrice,
+  };
+}
+
+function applyOutflow(acc: CostBasisAcc, value: BigNumber, cvBN: BigNumber): CostBasisAcc {
+  if (acc.totalAmount.lte(0)) return acc;
+
+  const sold = BigNumber.minimum(value, acc.totalAmount);
+  const costOfSale = sold.times(acc.averageEntryPrice);
+  // Scale exit CV proportionally when we clamped a sell that exceeded held amount.
+  const exitCV = sold.eq(value) ? cvBN : cvBN.times(sold).div(value);
+
+  return {
+    totalAmount: acc.totalAmount.minus(sold),
+    totalCost: acc.totalCost.minus(costOfSale),
+    // `lifetimeCost` is intentionally untouched on sells — it represents
+    // "money put in over the lifetime of the position", not the running
+    // basis of remaining coins.
+    lifetimeCost: acc.lifetimeCost,
+    realised: acc.realised.plus(exitCV.minus(costOfSale)),
+    averageEntryPrice: acc.averageEntryPrice,
+  };
+}
+
+function applyOperation(
+  acc: CostBasisAcc,
+  op: Operation,
+  flow: Exclude<OperationFlow, "ignored">,
+  asset: Currency,
+  fiat: Currency,
+  countervalues: CounterValuesState,
+): CostBasisAcc {
+  if (op.value.isZero() || op.value.isNegative()) return acc;
+
+  const cvAtDate = calculate(countervalues, {
+    value: op.value.toNumber(),
+    from: asset,
+    to: fiat,
+    date: op.date,
+    disableRounding: true,
+  });
+  if (typeof cvAtDate !== "number") return acc;
+
+  const cvBN = new BigNumber(cvAtDate);
+  return flow === "inflow" ? applyInflow(acc, op.value, cvBN) : applyOutflow(acc, op.value, cvBN);
+}
+
+/**
+ * Append-only ACB reducer. Folds `newOps` into `prev` and returns a new
+ * `CostBasisState`. Reads ONLY historical countervalues at op dates — never
+ * `latest` — so the result is stable under price ticks.
+ *
+ * Returns `prev` (same reference) when nothing new applies.
+ */
+export function reduceCostBasis(
+  prev: CostBasisState,
+  newOps: Operation[],
+  account: AccountLike,
+  countervalues: CounterValuesState,
+  fiat: Currency,
+  options?: ComputePnLOptions,
+): CostBasisState {
+  if (newOps.length === 0) return prev;
+
+  const pending: Operation[] = [];
+  for (const op of newOps) {
+    if (isAfterBookmark(op, prev)) pending.push(op);
+  }
+  if (pending.length === 0) return prev;
+
+  pending.sort(compareOps);
+
+  const asset = getAccountCurrency(account);
+  const isSpam = options?.isSpamOperation;
+
+  let acc: CostBasisAcc = {
+    totalAmount: prev.totalAmount,
+    totalCost: prev.totalCostInCounterValue,
+    lifetimeCost: prev.lifetimeCostInCounterValue,
+    realised: prev.realisedPnL,
+    averageEntryPrice: prev.averageEntryPrice,
+  };
+  let lastOperationId = prev.lastOperationId;
+  let lastOperationDate = prev.lastOperationDate;
+
+  for (const op of pending) {
+    // Advance the bookmark for every seen op (even ignored ones) so that
+    // re-passing the same ops is a true no-op.
+    lastOperationId = op.id;
+    lastOperationDate = op.date;
+
+    if (isSpam?.(op, account)) continue;
+
+    const flow = classifyOperation(op);
+    if (flow === "ignored") continue;
+
+    acc = applyOperation(acc, op, flow, asset, fiat, countervalues);
+  }
+
+  return {
+    totalAmount: acc.totalAmount,
+    totalCostInCounterValue: acc.totalCost,
+    lifetimeCostInCounterValue: acc.lifetimeCost,
+    realisedPnL: acc.realised,
+    averageEntryPrice: acc.averageEntryPrice,
+    lastOperationId,
+    lastOperationDate,
+  };
+}

--- a/libs/wallet-pnl/src/costBasisCache.ts
+++ b/libs/wallet-pnl/src/costBasisCache.ts
@@ -1,0 +1,89 @@
+import type { AccountLike } from "@ledgerhq/types-live";
+import type { Currency } from "@ledgerhq/types-cryptoassets";
+import { lenseRateMap } from "@ledgerhq/live-countervalues/logic";
+import { formatCounterValueDay, inferCurrencyAPIID } from "@ledgerhq/live-countervalues/helpers";
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
+import { getAccountCurrency } from "@ledgerhq/ledger-wallet-framework/account";
+import { initialCostBasisState, reduceCostBasis } from "./costBasis";
+import type { ComputePnLOptions, CostBasisState } from "./types";
+
+const cache = new Map<string, CostBasisState>();
+
+function getHistoryKey(
+  state: CounterValuesState,
+  from: Currency,
+  to: Currency,
+  lastOpDate: Date | null,
+): string {
+  if (inferCurrencyAPIID(from) === inferCurrencyAPIID(to)) return "identity";
+  const pairCache = lenseRateMap(state, { from, to });
+  if (!pairCache) return "noCV";
+  const { oldest, earliest, earliestStableDate } = pairCache.stats;
+  const bucket = lastOpDate ? formatCounterValueDay(lastOpDate) : "0";
+  const earliestRelevant = earliest && earliest <= bucket ? earliest : "";
+  return `${oldest ?? "_"}|${earliestStableDate ?? "_"}|${earliestRelevant}`;
+}
+
+function getLastOpBookmark(account: AccountLike): { id: string; date: Date | null } {
+  const ops = account.operations;
+  if (ops.length === 0) return { id: "_", date: null };
+
+  let best = ops[0];
+  for (let i = 1; i < ops.length; i++) {
+    const op = ops[i];
+    const opTime = op.date.getTime();
+    const bestTime = best.date.getTime();
+    if (opTime > bestTime || (opTime === bestTime && op.id > best.id)) best = op;
+  }
+  return { id: best.id, date: best.date };
+}
+
+export function getCostBasis(
+  account: AccountLike,
+  fiat: Currency,
+  countervalues: CounterValuesState,
+  options?: ComputePnLOptions,
+): CostBasisState {
+  const asset = getAccountCurrency(account);
+
+  if (options?.isSpamOperation) {
+    return reduceCostBasis(
+      initialCostBasisState,
+      account.operations,
+      account,
+      countervalues,
+      fiat,
+      options,
+    );
+  }
+
+  const { id: lastOpId, date: lastOpDate } = getLastOpBookmark(account);
+  const historyKey = getHistoryKey(countervalues, asset, fiat, lastOpDate);
+  const fiatKey = inferCurrencyAPIID(fiat);
+  const key = `${account.id}|${fiatKey}|${lastOpId}|${historyKey}`;
+
+  const hit = cache.get(key);
+  if (hit) return hit;
+
+  const fresh = reduceCostBasis(
+    initialCostBasisState,
+    account.operations,
+    account,
+    countervalues,
+    fiat,
+    options,
+  );
+  cache.set(key, fresh);
+  return fresh;
+}
+
+export function invalidatePnLCache(accountId?: string): void {
+  if (!accountId) {
+    cache.clear();
+    return;
+  }
+  const prefix = `${accountId}|`;
+  for (const key of cache.keys()) {
+    if (key.startsWith(prefix)) cache.delete(key);
+  }
+}

--- a/libs/wallet-pnl/src/costBasisReconciliation.ts
+++ b/libs/wallet-pnl/src/costBasisReconciliation.ts
@@ -1,0 +1,154 @@
+import BigNumber from "bignumber.js";
+import type { Currency } from "@ledgerhq/types-cryptoassets";
+import { calculate } from "@ledgerhq/live-countervalues/logic";
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
+import type { CostBasisState, Reconciliation } from "./types";
+
+const ZERO = new BigNumber(0);
+
+/**
+ * Pure detection: compares the operations-derived `state.totalAmount` to the
+ * on-chain `balance` and returns the diagnostic. **Never** does any I/O on
+ * countervalues, **never** mutates state, **always** returns `applied: false`.
+ *
+ * The repair step is a separate concern — see {@link applyBalanceReconciliation}.
+ * This split lets callers detect anomalies (UI badges, audit logs) without
+ * paying the cost of the heuristic repair, and keeps the reducer pipeline
+ * trivially testable.
+ */
+export function detectBalanceGap(state: CostBasisState, balance: BigNumber): Reconciliation {
+  const delta = balance.minus(state.totalAmount);
+  return {
+    recordedAmount: state.totalAmount,
+    onChainBalance: balance,
+    delta,
+    isClean: delta.isZero(),
+    applied: false,
+  };
+}
+
+/**
+ * Opinionated repair: when the `gap` shows a non-zero `delta`, folds a
+ * synthetic operation into the cost-basis state to close it.
+ *
+ * - `delta > 0` → synthetic INFLOW valued at the latest counter-value
+ *                 (rebase tokens, missing IN op…). Pushes the average
+ *                 entry price toward the latest market.
+ * - `delta < 0` → synthetic OUTFLOW priced at `state.lastOperationDate`
+ *                 (best-effort proxy for the unknown disposal date).
+ *                 The realised gain/loss equals `delta_value − sold × AEP`.
+ *
+ * `lifetimeCostInCounterValue` is intentionally NEVER touched here, even on
+ * a positive delta: rebase yield / silent accruals are not real cash
+ * investments, so they would distort a "% vs invested" KPI.
+ *
+ * Returns `applied: false` (and an unchanged state) when:
+ * - the gap is clean,
+ * - the counter-value lookup for the delta fails,
+ * - or a negative delta hits an empty position.
+ *
+ * Callers that want the combined detect+repair flow with the legacy signature
+ * should use {@link reconcileCostBasisWithBalance}.
+ */
+export function applyBalanceReconciliation(
+  state: CostBasisState,
+  gap: Reconciliation,
+  asset: Currency,
+  fiat: Currency,
+  countervalues: CounterValuesState,
+): { state: CostBasisState; applied: boolean } {
+  if (gap.isClean) return { state, applied: false };
+
+  const delta = gap.delta;
+  // Negative delta → synthetic disposal of the missing tokens. We don't know
+  // when they actually left, so we proxy with the last known operation date
+  // (better than `latest` for tax-ish use cases, neutral otherwise).
+  // Positive delta → synthetic acquisition; price it at the latest rate
+  // because rebase / missed-IN gains accrue continuously up to "now".
+  const valuationDate = delta.isPositive() ? null : state.lastOperationDate ?? null;
+
+  const cvAtDelta = calculate(countervalues, {
+    value: delta.absoluteValue().toNumber(),
+    from: asset,
+    to: fiat,
+    date: valuationDate,
+    disableRounding: true,
+  });
+  if (typeof cvAtDelta !== "number") {
+    return { state, applied: false };
+  }
+
+  const cvBN = new BigNumber(cvAtDelta);
+
+  if (delta.isPositive()) {
+    const totalAmount = state.totalAmount.plus(delta);
+    const totalCostInCounterValue = state.totalCostInCounterValue.plus(cvBN);
+    return {
+      state: {
+        ...state,
+        totalAmount,
+        totalCostInCounterValue,
+        averageEntryPrice: totalAmount.gt(0)
+          ? totalCostInCounterValue.div(totalAmount)
+          : state.averageEntryPrice,
+      },
+      applied: true,
+    };
+  }
+
+  // delta < 0 — apply outflow semantics symmetric to `applyOutflow` in costBasis.ts.
+  if (state.totalAmount.lte(0)) {
+    return { state, applied: false };
+  }
+  const sold = BigNumber.minimum(delta.absoluteValue(), state.totalAmount);
+  const costOfSale = sold.times(state.averageEntryPrice);
+  const exitCV = sold.eq(delta.absoluteValue())
+    ? cvBN
+    : cvBN.times(sold).div(delta.absoluteValue());
+
+  return {
+    state: {
+      ...state,
+      totalAmount: state.totalAmount.minus(sold),
+      totalCostInCounterValue: BigNumber.maximum(
+        state.totalCostInCounterValue.minus(costOfSale),
+        ZERO,
+      ),
+      realisedPnL: state.realisedPnL.plus(exitCV.minus(costOfSale)),
+    },
+    applied: true,
+  };
+}
+
+/**
+ * Legacy combined detect+repair entry point, preserved for API stability.
+ * New code should prefer composing {@link detectBalanceGap} and
+ * {@link applyBalanceReconciliation} explicitly so the conditional mutation
+ * is obvious to the reader.
+ *
+ * Always returns the {@link Reconciliation} diagnostic so callers can flag
+ * the result in the UI (e.g. show a warning badge on the asset row).
+ *
+ * If `apply` is `false`, the gap is detected but no repair is attempted —
+ * `applied` will be `false` regardless of the delta.
+ */
+export function reconcileCostBasisWithBalance(
+  state: CostBasisState,
+  balance: BigNumber,
+  asset: Currency,
+  fiat: Currency,
+  countervalues: CounterValuesState,
+  apply: boolean,
+): { state: CostBasisState; reconciliation: Reconciliation } {
+  const gap = detectBalanceGap(state, balance);
+
+  if (gap.isClean || !apply) {
+    return { state, reconciliation: gap };
+  }
+
+  const result = applyBalanceReconciliation(state, gap, asset, fiat, countervalues);
+  return {
+    state: result.state,
+    reconciliation: { ...gap, applied: result.applied },
+  };
+}

--- a/libs/wallet-pnl/src/hooks/index.ts
+++ b/libs/wallet-pnl/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export { useAssetPnL } from "./useAssetPnL";
+export { usePortfolioPnL } from "./usePortfolioPnL";

--- a/libs/wallet-pnl/src/hooks/useAssetPnL.ts
+++ b/libs/wallet-pnl/src/hooks/useAssetPnL.ts
@@ -1,0 +1,18 @@
+import { useMemo } from "react";
+import type { AccountLike } from "@ledgerhq/types-live";
+import type { Currency } from "@ledgerhq/types-cryptoassets";
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
+import { computeAssetPnL } from "../assetPnL";
+import type { AssetPnL, ComputePnLOptions } from "../types";
+
+export function useAssetPnL(
+  account: AccountLike,
+  countervalues: CounterValuesState,
+  fiat: Currency,
+  options?: ComputePnLOptions,
+): AssetPnL | null {
+  return useMemo(
+    () => computeAssetPnL(account, countervalues, fiat, options),
+    [account, countervalues, fiat, options],
+  );
+}

--- a/libs/wallet-pnl/src/hooks/usePortfolioPnL.ts
+++ b/libs/wallet-pnl/src/hooks/usePortfolioPnL.ts
@@ -1,0 +1,18 @@
+import { useMemo } from "react";
+import type { AccountLike } from "@ledgerhq/types-live";
+import type { Currency } from "@ledgerhq/types-cryptoassets";
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
+import { computePortfolioPnL } from "../portfolioPnL";
+import type { ComputePnLOptions, PortfolioPnL } from "../types";
+
+export function usePortfolioPnL(
+  accounts: AccountLike[],
+  countervalues: CounterValuesState,
+  fiat: Currency,
+  options?: ComputePnLOptions,
+): PortfolioPnL {
+  return useMemo(
+    () => computePortfolioPnL(accounts, countervalues, fiat, options),
+    [accounts, countervalues, fiat, options],
+  );
+}

--- a/libs/wallet-pnl/src/index.ts
+++ b/libs/wallet-pnl/src/index.ts
@@ -1,0 +1,19 @@
+export type {
+  AssetPnL,
+  PortfolioPnL,
+  CostBasisState,
+  OperationFlow,
+  ComputePnLOptions,
+  Reconciliation,
+} from "./types";
+export { INFLOWS, OUTFLOWS, STAKE_FAMILY, classifyOperation } from "./classifyOperation";
+export { initialCostBasisState, reduceCostBasis } from "./costBasis";
+export { getCostBasis, invalidatePnLCache } from "./costBasisCache";
+export {
+  applyBalanceReconciliation,
+  detectBalanceGap,
+  reconcileCostBasisWithBalance,
+} from "./costBasisReconciliation";
+export { computeAssetPnL } from "./assetPnL";
+export { computePortfolioPnL } from "./portfolioPnL";
+export { pnlPercentage } from "./percentage";

--- a/libs/wallet-pnl/src/percentage.ts
+++ b/libs/wallet-pnl/src/percentage.ts
@@ -1,0 +1,6 @@
+import type BigNumber from "bignumber.js";
+
+export function pnlPercentage(pnl: BigNumber, basis: BigNumber): BigNumber | null {
+  if (basis.isZero()) return null;
+  return pnl.div(basis).times(100);
+}

--- a/libs/wallet-pnl/src/portfolioPnL.ts
+++ b/libs/wallet-pnl/src/portfolioPnL.ts
@@ -1,0 +1,34 @@
+import BigNumber from "bignumber.js";
+import type { AccountLike } from "@ledgerhq/types-live";
+import type { Currency } from "@ledgerhq/types-cryptoassets";
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
+import { flattenAccounts } from "@ledgerhq/ledger-wallet-framework/account";
+import { computeAssetPnL } from "./assetPnL";
+import type { ComputePnLOptions, PortfolioPnL } from "./types";
+
+const ZERO = new BigNumber(0);
+
+export function computePortfolioPnL(
+  accounts: AccountLike[],
+  countervalues: CounterValuesState,
+  fiat: Currency,
+  options?: ComputePnLOptions,
+): PortfolioPnL {
+  let unrealisedPnL = ZERO;
+  let realisedPnL = ZERO;
+  let totalPnL = ZERO;
+  let costBasis = ZERO;
+  let lifetimeCost = ZERO;
+
+  for (const account of flattenAccounts(accounts)) {
+    const assetPnL = computeAssetPnL(account, countervalues, fiat, options);
+    if (!assetPnL) continue;
+    unrealisedPnL = unrealisedPnL.plus(assetPnL.unrealisedPnL);
+    realisedPnL = realisedPnL.plus(assetPnL.realisedPnL);
+    totalPnL = totalPnL.plus(assetPnL.totalPnL);
+    costBasis = costBasis.plus(assetPnL.costBasis);
+    lifetimeCost = lifetimeCost.plus(assetPnL.lifetimeCost);
+  }
+
+  return { unrealisedPnL, realisedPnL, totalPnL, costBasis, lifetimeCost };
+}

--- a/libs/wallet-pnl/src/scenarios/accounts.ts
+++ b/libs/wallet-pnl/src/scenarios/accounts.ts
@@ -1,0 +1,86 @@
+import BigNumber from "bignumber.js";
+import type { Account, Operation, TokenAccount } from "@ledgerhq/types-live";
+import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+
+const emptyBalanceHistoryCache = {
+  HOUR: { balances: [], latestDate: undefined },
+  DAY: { balances: [], latestDate: undefined },
+  WEEK: { balances: [], latestDate: undefined },
+};
+
+export type CommonOverrides = Partial<
+  Pick<Account, "id" | "balance" | "spendableBalance" | "operations" | "operationsCount">
+>;
+
+export type TokenAccountOverrides = CommonOverrides & { parentId?: string };
+
+type CommonDefaults = {
+  balance: BigNumber;
+  spendableBalance: BigNumber;
+  operations: Operation[];
+  operationsCount: number;
+};
+
+function applyCommonDefaults(id: string, overrides: CommonOverrides): CommonDefaults {
+  const operations = (overrides.operations ?? []).map(op => ({ ...op, accountId: id }));
+  const balance = overrides.balance ?? new BigNumber(0);
+  return {
+    balance,
+    spendableBalance: overrides.spendableBalance ?? balance,
+    operations,
+    operationsCount: overrides.operationsCount ?? operations.length,
+  };
+}
+
+export function makeAccount(currency: CryptoCurrency, overrides: CommonOverrides = {}): Account {
+  const id = overrides.id ?? `js:2:${currency.id}:0xtest:`;
+  const common = applyCommonDefaults(id, overrides);
+  return {
+    type: "Account",
+    id,
+    seedIdentifier: "0xtest",
+    derivationMode: "" as Account["derivationMode"],
+    index: 0,
+    freshAddress: "0xtest",
+    freshAddressPath: "44'/60'/0'/0/0",
+    used: common.operations.length > 0,
+    creationDate: new Date("2024-01-01T00:00:00Z"),
+    blockHeight: 0,
+    currency,
+    pendingOperations: [],
+    lastSyncDate: new Date("2026-01-01T00:00:00Z"),
+    subAccounts: [],
+    balanceHistoryCache: emptyBalanceHistoryCache,
+    swapHistory: [],
+    ...common,
+  };
+}
+
+export function makeTokenAccount(
+  token: TokenCurrency,
+  overrides: TokenAccountOverrides = {},
+): TokenAccount {
+  const parentId = overrides.parentId ?? `js:2:${token.parentCurrency.id}:0xtest:`;
+  const id = overrides.id ?? `${parentId}+${token.id}`;
+  const common = applyCommonDefaults(id, overrides);
+  return {
+    type: "TokenAccount",
+    id,
+    parentId,
+    token,
+    creationDate: new Date("2024-01-01T00:00:00Z"),
+    pendingOperations: [],
+    balanceHistoryCache: emptyBalanceHistoryCache,
+    swapHistory: [],
+    ...common,
+  };
+}
+
+export function makeAccountWithTokens(
+  currency: CryptoCurrency,
+  tokens: TokenAccount[],
+  overrides: CommonOverrides = {},
+): Account {
+  const account = makeAccount(currency, overrides);
+  return { ...account, subAccounts: tokens };
+}

--- a/libs/wallet-pnl/src/scenarios/countervalues.ts
+++ b/libs/wallet-pnl/src/scenarios/countervalues.ts
@@ -1,0 +1,98 @@
+import type { Currency } from "@ledgerhq/types-cryptoassets";
+import { pairId } from "@ledgerhq/live-countervalues/helpers";
+import type {
+  CounterValuesState,
+  PairRateMapCache,
+  RateMap,
+  RateMapStats,
+} from "@ledgerhq/live-countervalues/types";
+
+export type Pair = { from: Currency; to: Currency };
+
+export type BuildCVInput = {
+  pair: Pair;
+  /** Map of "YYYY-MM-DD" → rate. Order does not matter. */
+  history?: Record<string, number>;
+  latest?: number;
+  /** Dates (YYYY-MM-DD) that should be treated as holes (i.e. earliestStableDate < them). */
+  holes?: string[];
+};
+
+function parseDay(s: string): Date {
+  return new Date(`${s}T00:00:00.000Z`);
+}
+
+function buildPairCache(input: BuildCVInput): PairRateMapCache {
+  const history = input.history ?? {};
+  const map: RateMap = new Map();
+  for (const [day, rate] of Object.entries(history)) {
+    map.set(day, rate);
+  }
+  if (input.latest !== undefined) {
+    map.set("latest", input.latest);
+  }
+
+  const sentinelDay = "2099-01-01";
+  if (!(sentinelDay in history)) {
+    map.set(sentinelDay, input.latest ?? 0);
+  }
+
+  const sortedDays = Array.from(map.keys())
+    .filter(k => k !== "latest")
+    .sort((a, b) => a.localeCompare(b));
+  const oldest = sortedDays[0];
+  const earliest = sortedDays.at(-1);
+
+  let earliestStableDate: Date | null | undefined =
+    earliest === undefined ? null : parseDay(earliest);
+  if (input.holes && input.holes.length > 0) {
+    const earliestHole = [...input.holes].sort((a, b) => a.localeCompare(b))[0];
+    earliestStableDate = parseDay(earliestHole);
+  }
+
+  const stats: RateMapStats = {
+    oldest,
+    earliest,
+    oldestDate: oldest === undefined ? null : parseDay(oldest),
+    earliestDate: earliest === undefined ? null : parseDay(earliest),
+    earliestStableDate,
+  };
+
+  return {
+    fallback: undefined,
+    map,
+    stats,
+  };
+}
+
+/** `CounterValuesState` for multiple (from, to) pairs at once. */
+export function buildMultiCV(inputs: BuildCVInput[]): CounterValuesState {
+  const data: CounterValuesState["data"] = {};
+  const status: CounterValuesState["status"] = {};
+  const cache: CounterValuesState["cache"] = {};
+  for (const input of inputs) {
+    const id = pairId(input.pair);
+    const pairCache = buildPairCache(input);
+    data[id] = pairCache.map;
+    status[id] = { timestamp: Date.now() };
+    cache[id] = pairCache;
+  }
+  return { data, status, cache };
+}
+
+/** Minimal `CounterValuesState` for a single (from, to) pair. */
+export function buildCV(input: BuildCVInput): CounterValuesState {
+  return buildMultiCV([input]);
+}
+
+/**
+ * Zip an array of (date, rate) tuples into the `{ "YYYY-MM-DD": rate }` shape
+ * expected by `BuildCVInput.history`. Convenience helper for scenario builders.
+ */
+export function dailyHistory(entries: Array<[Date, number]>): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const [d, r] of entries) {
+    out[d.toISOString().slice(0, 10)] = r;
+  }
+  return out;
+}

--- a/libs/wallet-pnl/src/scenarios/currencies.ts
+++ b/libs/wallet-pnl/src/scenarios/currencies.ts
@@ -1,0 +1,32 @@
+import BigNumber from "bignumber.js";
+import { cryptocurrenciesById, getFiatCurrencyByTicker } from "@ledgerhq/cryptoassets";
+import type { CryptoCurrency, FiatCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+
+export const BTC: CryptoCurrency = cryptocurrenciesById["bitcoin"];
+export const ETH: CryptoCurrency = cryptocurrenciesById["ethereum"];
+
+export const USD: FiatCurrency = getFiatCurrencyByTicker("USD");
+export const EUR: FiatCurrency = getFiatCurrencyByTicker("EUR");
+
+export const USDC: TokenCurrency = {
+  type: "TokenCurrency",
+  id: "ethereum/erc20/usd_coin",
+  contractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+  parentCurrency: ETH,
+  tokenType: "erc20",
+  ticker: "USDC",
+  name: "USD Coin",
+  units: [
+    {
+      name: "USDC",
+      code: "USDC",
+      magnitude: 6,
+    },
+  ],
+};
+
+// Atomic-unit magnitudes (1 unit = 10^magnitude atoms). Centralised here so
+// scenarios don't redeclare them.
+export const SAT = new BigNumber(10).pow(BTC.units[0].magnitude); // 1e8
+export const WEI = new BigNumber(10).pow(ETH.units[0].magnitude); // 1e18
+export const USDC_UNIT = new BigNumber(10).pow(USDC.units[0].magnitude); // 1e6

--- a/libs/wallet-pnl/src/scenarios/hodler.ts
+++ b/libs/wallet-pnl/src/scenarios/hodler.ts
@@ -1,0 +1,114 @@
+import BigNumber from "bignumber.js";
+import type { Account } from "@ledgerhq/types-live";
+import { BTC, SAT, USD } from "./currencies";
+import { makeAccount } from "./accounts";
+import { buy, sell } from "./operations";
+import { buildCV, dailyHistory } from "./countervalues";
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
+
+// Monthly close prices for 2024 + 2025 (USD).
+const MONTHLY_PRICES = [
+  30000, 32000, 35000, 38000, 41000, 44000, 47000, 50000, 53000, 56000, 60000, 64000, 68000, 70000,
+  72000, 74000, 76000, 78000, 80000, 78000, 75000, 72000, 70000, 68000,
+];
+
+const MONTHLY_DATES = MONTHLY_PRICES.map((_, i) => {
+  const month = i % 12;
+  const year = 2024 + Math.floor(i / 12);
+  return new Date(Date.UTC(year, month, 15));
+});
+
+const BUY_AMOUNT_SAT = SAT.times("0.05");
+const SELL_DATE = new Date(Date.UTC(2025, 5, 20));
+const SELL_PRICE = 70000;
+const SELL_AMOUNT_SAT = SAT.times("0.3");
+
+export type HodlerScenario = {
+  account: Account;
+  countervalues: CounterValuesState;
+  expected: {
+    boughtTotalSat: BigNumber;
+    soldSat: BigNumber;
+    finalAmountSat: BigNumber;
+    finalCostBasisUsd: BigNumber;
+    averageEntryPriceUsdPerBtc: BigNumber;
+    realisedPnLUsd: BigNumber;
+  };
+};
+
+/**
+ * "Hodler" — DCA into BTC across 24 months, with a single partial sell injected mid-stream.
+ *
+ * Operations (chronological):
+ *  - 24 monthly buys of 0.05 BTC, on the 15th of each month from 2024-01-15
+ *    to 2025-12-15. Prices ramp $30k → $80k then back down to $68k.
+ *  - 1 sell of 0.3 BTC on 2025-06-20 at $70k (lands between buys #17 and #18).
+ *
+ * Counter-values: one historical rate per op date + `latest = $75k`.
+ *
+ * Stresses the **running-ACB path-dependence**: the average entry price at
+ * the sell time (over the first 18 buys) differs from the final average
+ * (recomputed at each subsequent buy). `realisedPnL` must use the former,
+ * `costBasis` reflects the holding after the sell has reduced totalCost.
+ *
+ * `expected` exposes both atomic-unit totals (`*Sat`) and the running-ACB
+ * outputs in USD (`finalCostBasisUsd`, `realisedPnLUsd`,
+ * `averageEntryPriceUsdPerBtc`). All prices are stored in atomic units
+ * (1 BTC = 1e8 sat) so the math matches the implementation exactly.
+ */
+export function buildHodlerScenario(): HodlerScenario {
+  const operations = [
+    ...MONTHLY_PRICES.map((_, i) => buy(BUY_AMOUNT_SAT, MONTHLY_DATES[i])),
+    sell(SELL_AMOUNT_SAT, SELL_DATE),
+  ];
+
+  const finalAmountSat = BUY_AMOUNT_SAT.times(MONTHLY_PRICES.length).minus(SELL_AMOUNT_SAT);
+  const account = makeAccount(BTC, {
+    operations,
+    balance: finalAmountSat,
+  });
+
+  const history = dailyHistory([
+    ...MONTHLY_DATES.map((d, i): [Date, number] => [d, MONTHLY_PRICES[i]]),
+    [SELL_DATE, SELL_PRICE],
+  ]);
+
+  const countervalues = buildCV({
+    pair: { from: BTC, to: USD },
+    history,
+    latest: 75000,
+  });
+
+  // Running ACB: split buys by side of the sell, compute the avg AT SELL TIME.
+  const preSellPrices = MONTHLY_PRICES.filter((_, i) => MONTHLY_DATES[i] < SELL_DATE);
+  const postSellPrices = MONTHLY_PRICES.filter((_, i) => MONTHLY_DATES[i] >= SELL_DATE);
+
+  const sumUsd = (prices: number[]) =>
+    prices.reduce((acc, p) => acc.plus(new BigNumber(p).times("0.05")), new BigNumber(0));
+
+  const costPreSellUsd = sumUsd(preSellPrices);
+  const btcPreSell = new BigNumber("0.05").times(preSellPrices.length);
+  const avgAtSell = costPreSellUsd.div(btcPreSell);
+  const soldBtc = new BigNumber("0.3");
+  const realisedPnLUsd = soldBtc.times(new BigNumber(SELL_PRICE).minus(avgAtSell));
+  const costOfSaleUsd = soldBtc.times(avgAtSell);
+
+  const finalCostBasisUsd = costPreSellUsd.minus(costOfSaleUsd).plus(sumUsd(postSellPrices));
+  const finalAmountBtc = btcPreSell
+    .minus(soldBtc)
+    .plus(new BigNumber("0.05").times(postSellPrices.length));
+  const averageEntryPriceUsdPerBtc = finalCostBasisUsd.div(finalAmountBtc);
+
+  return {
+    account,
+    countervalues,
+    expected: {
+      boughtTotalSat: BUY_AMOUNT_SAT.times(MONTHLY_PRICES.length),
+      soldSat: SELL_AMOUNT_SAT,
+      finalAmountSat,
+      finalCostBasisUsd,
+      averageEntryPriceUsdPerBtc,
+      realisedPnLUsd,
+    },
+  };
+}

--- a/libs/wallet-pnl/src/scenarios/index.ts
+++ b/libs/wallet-pnl/src/scenarios/index.ts
@@ -1,0 +1,25 @@
+export { BTC, ETH, USD, EUR, USDC, SAT, WEI, USDC_UNIT } from "./currencies";
+
+export type { CommonOverrides, TokenAccountOverrides } from "./accounts";
+export { makeAccount, makeTokenAccount, makeAccountWithTokens } from "./accounts";
+
+export type { BNLike, OpOverrides } from "./operations";
+export { makeOp, buy, sell, reward, fail, resetOperationIdCounter } from "./operations";
+
+export type { Pair, BuildCVInput } from "./countervalues";
+export { buildCV, buildMultiCV, dailyHistory } from "./countervalues";
+
+export type { HodlerScenario } from "./hodler";
+export { buildHodlerScenario } from "./hodler";
+
+export type { StakerScenario } from "./staker";
+export { buildStakerScenario } from "./staker";
+
+export type { TraderScenario } from "./trader";
+export { buildTraderScenario } from "./trader";
+
+export type { SingleTradeScenario } from "./singleTrade";
+export { buildSingleTradeScenario } from "./singleTrade";
+
+export type { MultiAssetScenario, NestedSubAccountScenario } from "./multiAsset";
+export { buildMultiAssetScenario, buildNestedSubAccountScenario } from "./multiAsset";

--- a/libs/wallet-pnl/src/scenarios/multiAsset.ts
+++ b/libs/wallet-pnl/src/scenarios/multiAsset.ts
@@ -1,0 +1,150 @@
+import type { Account, TokenAccount } from "@ledgerhq/types-live";
+import { BTC, ETH, USDC, USD, SAT, WEI, USDC_UNIT } from "./currencies";
+import { makeAccount, makeAccountWithTokens, makeTokenAccount } from "./accounts";
+import { buy, sell } from "./operations";
+import { buildMultiCV } from "./countervalues";
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
+
+export type MultiAssetScenario = {
+  btcAccount: Account;
+  ethAccount: Account;
+  usdcAccount: TokenAccount;
+  countervalues: CounterValuesState;
+};
+
+export type NestedSubAccountScenario = {
+  ethWithUsdc: Account;
+  usdcSub: TokenAccount;
+  countervalues: CounterValuesState;
+};
+
+/**
+ * Multi-asset portfolio — three positions across two account kinds (Account + TokenAccount).
+ *
+ * BTC (`btcAccount`): 4 monthly buys of 0.1 BTC (Jan–Apr 2025, $40k → $55k)
+ *   + 1 sell of 0.1 BTC on 2025-06-01 at $65k. Final balance 0.3 BTC.
+ *
+ * ETH (`ethAccount`): 2 buys of 5 ETH ($2000 then $2500) + 1 sell of 2 ETH
+ *   at $3000. Final balance 8 ETH.
+ *
+ * USDC (`usdcAccount`, token under `ethAccount`): 1 buy of 1000 USDC at $1,
+ *   no sells. Final balance 1000 USDC; PnL should be ~0 since latest = entry.
+ *
+ * Counter-values: historical rates per pair + per-pair `latest` (BTC $70k,
+ * ETH $3200, USDC $1).
+ *
+ * Stresses `computePortfolioPnL`: the returned totals MUST equal the
+ * elementwise sum of `computeAssetPnL` across the 3 accounts, across both
+ * crypto and token account types.
+ *
+ * Intentionally exposes no pre-computed `expected.*` — tests assert
+ * portfolio = Σ asset on the fly to avoid duplicating the impl's math.
+ */
+export function buildMultiAssetScenario(): MultiAssetScenario {
+  const btcOps = [
+    buy(SAT.times("0.1"), new Date(Date.UTC(2025, 0, 15))),
+    buy(SAT.times("0.1"), new Date(Date.UTC(2025, 1, 15))),
+    buy(SAT.times("0.1"), new Date(Date.UTC(2025, 2, 15))),
+    buy(SAT.times("0.1"), new Date(Date.UTC(2025, 3, 15))),
+    sell(SAT.times("0.1"), new Date(Date.UTC(2025, 5, 1))),
+  ];
+  const btcAccount = makeAccount(BTC, {
+    id: "js:2:bitcoin:btc-account:",
+    operations: btcOps,
+    balance: SAT.times("0.3"),
+  });
+
+  const ethOps = [
+    buy(WEI.times(5), new Date(Date.UTC(2025, 0, 10))),
+    buy(WEI.times(5), new Date(Date.UTC(2025, 2, 10))),
+    sell(WEI.times(2), new Date(Date.UTC(2025, 5, 10))),
+  ];
+  const ethAccount = makeAccount(ETH, {
+    id: "js:2:ethereum:eth-account:",
+    operations: ethOps,
+    balance: WEI.times(8),
+  });
+
+  const usdcOps = [buy(USDC_UNIT.times(1000), new Date(Date.UTC(2025, 1, 1)))];
+  const usdcAccount = makeTokenAccount(USDC, {
+    id: "js:2:ethereum:eth-account:+ethereum/erc20/usd_coin",
+    parentId: "js:2:ethereum:eth-account:",
+    operations: usdcOps,
+    balance: USDC_UNIT.times(1000),
+  });
+
+  const countervalues = buildMultiCV([
+    {
+      pair: { from: BTC, to: USD },
+      history: {
+        "2025-01-15": 40000,
+        "2025-02-15": 45000,
+        "2025-03-15": 50000,
+        "2025-04-15": 55000,
+        "2025-06-01": 65000,
+      },
+      latest: 70000,
+    },
+    {
+      pair: { from: ETH, to: USD },
+      history: {
+        "2025-01-10": 2000,
+        "2025-03-10": 2500,
+        "2025-06-10": 3000,
+      },
+      latest: 3200,
+    },
+    {
+      pair: { from: USDC, to: USD },
+      history: {
+        "2025-02-01": 1,
+      },
+      latest: 1,
+    },
+  ]);
+
+  return { btcAccount, ethAccount, usdcAccount, countervalues };
+}
+
+/**
+ * Nested-sub-account variant — a single top-level `Account` (ETH) carrying
+ * one `TokenAccount` (USDC) under its `subAccounts`. Both positions have
+ * non-zero ops and balances.
+ *
+ * Used to assert that `computePortfolioPnL` flattens sub-accounts the same
+ * way `getPortfolio` from `@ledgerhq/live-countervalues` does — i.e. an ETH
+ * account passed alone must contribute BOTH its own PnL AND its USDC
+ * sub-account's PnL to the totals.
+ */
+export function buildNestedSubAccountScenario(): NestedSubAccountScenario {
+  const ethBuyDate = new Date(Date.UTC(2025, 0, 10));
+  const usdcBuyDate = new Date(Date.UTC(2025, 1, 1));
+
+  const usdcSub = makeTokenAccount(USDC, {
+    id: "js:2:ethereum:eth-nested-account:+ethereum/erc20/usd_coin",
+    parentId: "js:2:ethereum:eth-nested-account:",
+    operations: [buy(USDC_UNIT.times(500), usdcBuyDate)],
+    balance: USDC_UNIT.times(500),
+  });
+
+  const ethWithUsdc = makeAccountWithTokens(ETH, [usdcSub], {
+    id: "js:2:ethereum:eth-nested-account:",
+    operations: [buy(WEI.times(2), ethBuyDate)],
+    balance: WEI.times(2),
+  });
+
+  const countervalues = buildMultiCV([
+    {
+      pair: { from: ETH, to: USD },
+      history: { "2025-01-10": 2000 },
+      latest: 3000,
+    },
+    {
+      pair: { from: USDC, to: USD },
+      history: { "2025-02-01": 1 },
+      latest: 1,
+    },
+  ]);
+
+  return { ethWithUsdc, usdcSub, countervalues };
+}

--- a/libs/wallet-pnl/src/scenarios/operations.ts
+++ b/libs/wallet-pnl/src/scenarios/operations.ts
@@ -1,0 +1,82 @@
+import BigNumber from "bignumber.js";
+import type { Operation, OperationType } from "@ledgerhq/types-live";
+
+export type BNLike = BigNumber | number | string;
+
+function toBN(v: BNLike): BigNumber {
+  return BigNumber.isBigNumber(v) ? v : new BigNumber(v);
+}
+
+export type OpOverrides = {
+  id?: string;
+  hash?: string;
+  /**
+   * Accepts any string, not just `OperationType`. This mirrors the open-set
+   * design of `classifyOperation` (INFLOWS / OUTFLOWS hold strings beyond the
+   * canonical union, e.g. "SUPPLY" / "REDEEM" / "SELL"). The single boundary
+   * cast lives in `makeOp` below.
+   */
+  type?: OperationType | string;
+  value?: number | BigNumber;
+  fee?: number | BigNumber;
+  date?: Date | string;
+  hasFailed?: boolean;
+  senders?: string[];
+  recipients?: string[];
+  accountId?: string;
+};
+
+let _counter = 0;
+function nextId(): string {
+  _counter += 1;
+  return `op-${String(_counter).padStart(6, "0")}`;
+}
+
+export function resetOperationIdCounter(): void {
+  _counter = 0;
+}
+
+function toDate(d: Date | string | undefined): Date {
+  if (d === undefined) return new Date(0);
+  return d instanceof Date ? d : new Date(d);
+}
+
+export function makeOp(overrides: OpOverrides = {}): Operation {
+  const id = overrides.id ?? nextId();
+  return {
+    id,
+    hash: overrides.hash ?? id,
+    // Cast at the scenario boundary: the `Operation.type` field is the
+    // canonical `OperationType` union, but the classifier treats it as an
+    // open string set. Scenarios need to pass strings outside the union.
+    type: (overrides.type ?? "IN") as OperationType,
+    value: toBN(overrides.value ?? 0),
+    fee: toBN(overrides.fee ?? 0),
+    senders: overrides.senders ?? [],
+    recipients: overrides.recipients ?? [],
+    blockHeight: 1,
+    blockHash: "0xblock",
+    accountId: overrides.accountId ?? "acc",
+    date: toDate(overrides.date),
+    hasFailed: overrides.hasFailed ?? false,
+    extra: {},
+  };
+}
+
+// `value` in sugar helpers is in the asset's atomic unit (sat for BTC, wei for ETH).
+
+const defineOp =
+  (type: OperationType) =>
+  (value: number | BigNumber, date: Date | string, extra: OpOverrides = {}): Operation =>
+    makeOp({ type, value, date, ...extra });
+
+export const buy = defineOp("IN");
+export const sell = defineOp("OUT");
+export const reward = defineOp("REWARD");
+
+export const fail = (
+  type: OperationType,
+  value: number | BigNumber,
+  date: Date | string,
+  extra: OpOverrides = {},
+): Operation => makeOp({ type, value, date, hasFailed: true, ...extra });

--- a/libs/wallet-pnl/src/scenarios/singleTrade.ts
+++ b/libs/wallet-pnl/src/scenarios/singleTrade.ts
@@ -1,0 +1,108 @@
+import BigNumber from "bignumber.js";
+import type { Account } from "@ledgerhq/types-live";
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
+import { BTC, EUR, SAT } from "./currencies";
+import { makeAccount } from "./accounts";
+import { buy, sell } from "./operations";
+import { buildCV, dailyHistory } from "./countervalues";
+
+const QTY_BTC = new BigNumber("0.3");
+const QTY_SAT = SAT.times(QTY_BTC);
+
+const BUY_PRICE_EUR = 50000;
+const SELL_PRICE_EUR = 68823.28;
+
+const BUY_DATE = new Date(Date.UTC(2025, 0, 15));
+const SELL_DATE = new Date(Date.UTC(2025, 5, 15));
+
+const ENTRY_FEE_EUR = new BigNumber(50);
+const EXIT_FEE_EUR = new BigNumber(25);
+
+export type SingleTradeScenario = {
+  heldAccount: Account;
+
+  closedAccount: Account;
+  countervalues: CounterValuesState;
+
+  fees: { entryEur: BigNumber; exitEur: BigNumber };
+  expected: {
+    qtyBtc: BigNumber;
+    investedEur: BigNumber;
+    sellProceedsEur: BigNumber;
+    grossRealisedPnLEur: BigNumber;
+    grossUnrealisedAtSellPriceEur: BigNumber;
+    grossPctOnCostBasis: BigNumber;
+    feeAdjustedPnLEur: BigNumber;
+    feeAdjustedPctOnInvestmentPlusFee: BigNumber;
+  };
+};
+
+/**
+ * "SingleTrade" — the smallest non-trivial PnL scenario: one buy, optionally
+ * followed by one full sell at a higher price, on a single asset (BTC) priced
+ * in a single fiat (EUR).
+ *
+ *   Buy:  0.3 BTC at €50,000 on 2025-01-15  (notional €15,000, entry fee €50)
+ *   Sell: 0.3 BTC at €68,823.28 on 2025-06-15 (notional €20,646.98, exit fee €25)
+ *
+ * The same buy is shared by two account variants:
+ *   - `heldAccount`   → buy only, balance = 0.3 BTC. Exercises `unrealisedPnL`
+ *                       and the percentage helper against a non-zero `costBasis`.
+ *   - `closedAccount` → buy + full sell, balance = 0. Exercises `realisedPnL`
+ *                       on a fully disposed position, where `costBasis` returns
+ *                       to 0 and `pnlPercentage` rightly returns `null`.
+ *
+ * Validates three things at once:
+ *  1. Realised PnL on a clean round trip equals `qty × (sellPrice − buyPrice)`
+ *     to the cent — no rounding artefacts from the running-ACB reducer.
+ *  2. Our gross output (€5,646.98 / 37.65 %) sits exactly €75 above the
+ *     fee-adjusted view (€5,571.98 / 37.02 %), and the wedge is entirely
+ *     explained by `entryFee + exitFee`. No silent disagreement.
+ *  3. After a full sell, `costBasis` is 0 → `pnlPercentage(totalPnL, costBasis)`
+ *     returns `null` (documented behaviour, not a bug).
+ */
+export function buildSingleTradeScenario(): SingleTradeScenario {
+  const buyOp = buy(QTY_SAT, BUY_DATE);
+  const sellOp = sell(QTY_SAT, SELL_DATE);
+
+  const heldAccount = makeAccount(BTC, {
+    operations: [buyOp],
+    balance: QTY_SAT,
+  });
+
+  const closedAccount = makeAccount(BTC, {
+    operations: [buyOp, sellOp],
+    balance: new BigNumber(0),
+  });
+
+  const countervalues = buildCV({
+    pair: { from: BTC, to: EUR },
+    history: dailyHistory([
+      [BUY_DATE, BUY_PRICE_EUR],
+      [SELL_DATE, SELL_PRICE_EUR],
+    ]),
+    latest: SELL_PRICE_EUR,
+  });
+
+  const investedEur = QTY_BTC.times(BUY_PRICE_EUR);
+  const sellProceedsEur = QTY_BTC.times(SELL_PRICE_EUR);
+  const grossRealisedPnLEur = sellProceedsEur.minus(investedEur);
+  const grossPctOnCostBasis = grossRealisedPnLEur.div(investedEur).times(100);
+
+  return {
+    heldAccount,
+    closedAccount,
+    countervalues,
+    fees: { entryEur: ENTRY_FEE_EUR, exitEur: EXIT_FEE_EUR },
+    expected: {
+      qtyBtc: QTY_BTC,
+      investedEur,
+      sellProceedsEur,
+      grossRealisedPnLEur,
+      grossUnrealisedAtSellPriceEur: grossRealisedPnLEur,
+      grossPctOnCostBasis,
+      feeAdjustedPnLEur: new BigNumber("5571.98"),
+      feeAdjustedPctOnInvestmentPlusFee: new BigNumber("37.02"),
+    },
+  };
+}

--- a/libs/wallet-pnl/src/scenarios/staker.ts
+++ b/libs/wallet-pnl/src/scenarios/staker.ts
@@ -1,0 +1,88 @@
+import BigNumber from "bignumber.js";
+import type { Account } from "@ledgerhq/types-live";
+import { ETH, USD, WEI } from "./currencies";
+import { makeAccount } from "./accounts";
+import { buy, reward } from "./operations";
+import { buildCV, dailyHistory } from "./countervalues";
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
+
+const INITIAL_BUY_DATE = new Date(Date.UTC(2025, 0, 10));
+const INITIAL_BUY_AMOUNT = WEI.times(10);
+const INITIAL_BUY_PRICE = 1500;
+
+const REWARD_AMOUNT = WEI.times("0.05");
+const REWARD_PRICES = [1600, 1700, 1800, 1900, 2000, 2100, 2200, 2300, 2400, 2500, 2600, 2700];
+const REWARD_DATES = REWARD_PRICES.map((_, i) => new Date(Date.UTC(2025, 1 + i, 1)));
+
+export type StakerScenario = {
+  account: Account;
+  countervalues: CounterValuesState;
+  expected: {
+    finalAmountEth: BigNumber;
+    totalCostUsd: BigNumber;
+    averageEntryPriceUsdPerEth: BigNumber;
+  };
+};
+
+/**
+ * "Staker" — one initial buy, then 12 monthly REWARD inflows. No sells.
+ *
+ * Operations (chronological):
+ *  - 1 buy of 10 ETH on 2025-01-10 at $1500.
+ *  - 12 REWARD inflows of 0.05 ETH on the 1st of each month from 2025-02-01
+ *    to 2026-01-01, at rising prices $1600 → $2700.
+ *
+ * Counter-values: one historical rate per op date + `latest = $2800`.
+ *
+ * Stresses that REWARD ops count as inflows (per `classifyOperation` spec)
+ * and add to cost basis at the reward date's market price. Since there are
+ * no sells, the running ACB and the naive `Σ cost / Σ amount` formula
+ * agree → `expected.totalCostUsd` and `expected.averageEntryPriceUsdPerEth`
+ * can be hand-computed without splitting by sell date.
+ *
+ * `realisedPnL` should always be 0; `unrealisedPnL` positive since the
+ * latest price ($2800) is above the weighted average entry.
+ */
+export function buildStakerScenario(): StakerScenario {
+  const operations = [
+    buy(INITIAL_BUY_AMOUNT, INITIAL_BUY_DATE),
+    ...REWARD_PRICES.map((_, i) => reward(REWARD_AMOUNT, REWARD_DATES[i])),
+  ];
+
+  const totalRewardEth = new BigNumber("0.05").times(REWARD_PRICES.length);
+  const finalAmountEth = new BigNumber(10).plus(totalRewardEth);
+  const finalAmountWei = WEI.times(finalAmountEth);
+
+  const account = makeAccount(ETH, {
+    operations,
+    balance: finalAmountWei,
+  });
+
+  const history = dailyHistory([
+    [INITIAL_BUY_DATE, INITIAL_BUY_PRICE],
+    ...REWARD_DATES.map((d, i): [Date, number] => [d, REWARD_PRICES[i]]),
+  ]);
+
+  const countervalues = buildCV({
+    pair: { from: ETH, to: USD },
+    history,
+    latest: 2800,
+  });
+
+  const rewardsCostUsd = REWARD_PRICES.reduce(
+    (acc, p) => acc.plus(new BigNumber(p).times("0.05")),
+    new BigNumber(0),
+  );
+  const totalCostUsd = new BigNumber(15000).plus(rewardsCostUsd);
+  const averageEntryPriceUsdPerEth = totalCostUsd.div(finalAmountEth);
+
+  return {
+    account,
+    countervalues,
+    expected: {
+      finalAmountEth,
+      totalCostUsd,
+      averageEntryPriceUsdPerEth,
+    },
+  };
+}

--- a/libs/wallet-pnl/src/scenarios/trader.ts
+++ b/libs/wallet-pnl/src/scenarios/trader.ts
@@ -1,0 +1,124 @@
+import BigNumber from "bignumber.js";
+import type { Account, Operation } from "@ledgerhq/types-live";
+import { ETH, USD, WEI } from "./currencies";
+import { makeAccount } from "./accounts";
+import { buy, sell, fail, makeOp } from "./operations";
+import { buildCV, dailyHistory } from "./countervalues";
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
+
+const DUST_THRESHOLD = WEI.times("0.001");
+
+function priceAt(step: number): number {
+  let p = 2000;
+  for (let i = 0; i < step; i++) {
+    const dir = i % 7 < 4 ? 1 : -1;
+    const mag = 30 + ((i * 17) % 50);
+    p += dir * mag;
+  }
+  return Math.max(p, 1000);
+}
+
+function dateAt(step: number): Date {
+  return new Date(Date.UTC(2025, 0, 1 + step * 2));
+}
+
+const TOTAL = 80;
+const FAILED_INDICES = new Set([7, 23, 51]);
+const DUST_INDICES = new Set([3, 14, 27, 40, 65]);
+
+export type TraderScenario = {
+  account: Account;
+  countervalues: CounterValuesState;
+  dustPredicate: (op: Operation) => boolean;
+  expected: {
+    appliedCount: number;
+    failedCount: number;
+    dustCount: number;
+  };
+};
+
+/**
+ * "Day-trader" — high-frequency alternating buys/sells with failed + dust ops mixed in.
+ *
+ * Operations (chronological, 80 total, one every 2 days from 2025-01-01):
+ *  - Indices 7, 23, 51: failed ops (`hasFailed=true`, 0.5 ETH) — must be
+ *    ignored by `classifyOperation` regardless of nominal type.
+ *  - Indices 3, 14, 27, 40, 65: dust ops (value < 0.001 ETH, IN). The
+ *    returned `dustPredicate` is meant to be passed as
+ *    `options.isSpamOperation` to filter them out of the cost basis.
+ *  - All other indices: alternating buy (even) / sell (odd) of 0.1–0.3 ETH
+ *    at a deterministic random-walk price ($1000–$2.5k).
+ *
+ * Counter-values: a historical rate at every op date + `latest = $2500`.
+ *
+ * Stresses two filter paths in `reduceCostBasis`:
+ *  - failed ops are stripped via `classifyOperation` returning "ignored",
+ *  - the `isSpamOperation` predicate is honoured and shrinks the cost basis
+ *    when filtering small inflows.
+ *
+ * `expected` exposes counts only (`appliedCount`/`failedCount`/`dustCount`);
+ * exact PnL numbers are not pre-computed since the price walk is
+ * deterministic but not human-readable.
+ */
+export function buildTraderScenario(): TraderScenario {
+  const operations: Operation[] = [];
+  let appliedCount = 0;
+
+  for (let i = 0; i < TOTAL; i++) {
+    const date = dateAt(i);
+
+    if (FAILED_INDICES.has(i)) {
+      operations.push(fail(i % 2 === 0 ? "IN" : "OUT", WEI.times("0.5"), date));
+      continue;
+    }
+    if (DUST_INDICES.has(i)) {
+      operations.push(makeOp({ type: "IN", value: DUST_THRESHOLD.div(2), date }));
+      continue;
+    }
+    const amount = WEI.times(0.1 + (i % 5) * 0.05);
+    operations.push(i % 2 === 0 ? buy(amount, date) : sell(amount, date));
+    appliedCount++;
+  }
+
+  const history = dailyHistory(
+    Array.from({ length: TOTAL }, (_, i): [Date, number] => [dateAt(i), priceAt(i)]),
+  );
+
+  const finalBalanceWei = (() => {
+    let bal = new BigNumber(0);
+    for (let i = 0; i < TOTAL; i++) {
+      if (FAILED_INDICES.has(i) || DUST_INDICES.has(i)) continue;
+      const amount = WEI.times(0.1 + (i % 5) * 0.05);
+      if (i % 2 === 0) {
+        bal = bal.plus(amount);
+      } else {
+        bal = BigNumber.maximum(bal.minus(amount), new BigNumber(0));
+      }
+    }
+    return bal;
+  })();
+
+  const account = makeAccount(ETH, {
+    operations,
+    balance: finalBalanceWei,
+  });
+
+  const countervalues = buildCV({
+    pair: { from: ETH, to: USD },
+    history,
+    latest: 2500,
+  });
+
+  const dustPredicate = (op: Operation): boolean => op.value.lt(DUST_THRESHOLD);
+
+  return {
+    account,
+    countervalues,
+    dustPredicate,
+    expected: {
+      appliedCount,
+      failedCount: FAILED_INDICES.size,
+      dustCount: DUST_INDICES.size,
+    },
+  };
+}

--- a/libs/wallet-pnl/src/types.ts
+++ b/libs/wallet-pnl/src/types.ts
@@ -1,0 +1,117 @@
+import type { BigNumber } from "bignumber.js";
+import type { AccountLike, Operation } from "@ledgerhq/types-live";
+
+/**
+ * Shared fiat-denominated PnL totals (chosen counter-currency, e.g. USD).
+ * Portfolio-level uses this shape only: no single `averageEntryPrice` across
+ * mixed assets (BTC@$40k and ETH@$2k are not meaningfully averaged).
+ *
+ * Two cost figures coexist on purpose:
+ * - `costBasis` is the **running** ACB cost of coins still held. It is
+ *   decremented on every sell (proportional to `averageEntryPrice`), so it
+ *   collapses toward 0 as a position is closed. That makes it the right
+ *   denominator for `unrealisedPnL` (mark-to-market on what's left).
+ * - `lifetimeCost` is the **cumulative** fiat amount paid for inflows over
+ *   the position's lifetime, **never** decremented by sells. It is the
+ *   right denominator for a "% vs invested" KPI, which stays meaningful
+ *   for partially / fully closed positions where `costBasis → 0`.
+ */
+export type PortfolioPnL = {
+  unrealisedPnL: BigNumber;
+  realisedPnL: BigNumber;
+  totalPnL: BigNumber;
+  costBasis: BigNumber;
+  lifetimeCost: BigNumber;
+};
+
+/**
+ * Per-asset metrics: same totals as {@link PortfolioPnL} plus
+ * `averageEntryPrice` in counter-currency per unit of the asset (e.g. USD per BTC),
+ * and a {@link Reconciliation} block describing how the operations-derived
+ * holding was rebalanced against the on-chain `account.balance`.
+ */
+export type AssetPnL = PortfolioPnL & {
+  averageEntryPrice: BigNumber;
+  reconciliation: Reconciliation;
+};
+
+/**
+ * Diagnostic for the gap between what the operations stream cumulatively
+ * implies (`recordedAmount`) and what the chain reports (`onChainBalance`).
+ *
+ * A non-`isClean` reconciliation happens when some operation that moved the
+ * asset never made it into `account.operations` (typical example: ERC-20
+ * `transferFrom` triggered by a router after an `APPROVE`, where only the
+ * `APPROVE` is attributed to the user's wallet) or when the asset itself
+ * accrues silently (rebase tokens, stETH-like).
+ *
+ * Unless `ComputePnLOptions.reconcileWithBalance` is `false`, the cost-basis
+ * state is adjusted to make `recordedAmount === onChainBalance` and the
+ * delta is folded into either `realisedPnL` (negative delta → synthetic
+ * outflow at the average entry price, gain/loss valued at the date proxy)
+ * or `costBasis` / `averageEntryPrice` (positive delta → synthetic inflow
+ * at the latest known rate).
+ */
+export type Reconciliation = {
+  /** Final `totalAmount` from the cost-basis reducer, before any rebalance. */
+  recordedAmount: BigNumber;
+  /** `account.balance` at the time of the computation. */
+  onChainBalance: BigNumber;
+  /** `onChainBalance − recordedAmount` (signed). Zero ⇒ nothing to do. */
+  delta: BigNumber;
+  /** True if `delta` is exactly zero (no synthetic op was applied). */
+  isClean: boolean;
+  /** True when a synthetic operation was folded into the cost-basis state. */
+  applied: boolean;
+};
+
+/**
+ * Cumulative cost-basis state for a single asset. Produced by the
+ * `reduceCostBasis` reducer and cached by `getCostBasis`.
+ *
+ * - Stable under `latest` countervalue ticks (only `historical` rates feed into it).
+ * - Append-only: passing a previous state + new operations resumes from where it left off.
+ */
+export type CostBasisState = {
+  totalAmount: BigNumber;
+  totalCostInCounterValue: BigNumber;
+  /**
+   * Cumulative fiat cost of every inflow seen, **never** decremented by
+   * sells. Tracks "lifetime invested" so `% vs cost` stays meaningful on
+   * partially / fully closed positions where `totalCostInCounterValue → 0`.
+   * Synthetic inflows added by {@link Reconciliation} are NOT counted here
+   * (rebase / silent accruals are not real cash investments).
+   */
+  lifetimeCostInCounterValue: BigNumber;
+  realisedPnL: BigNumber;
+  averageEntryPrice: BigNumber;
+  lastOperationId: string | null;
+  lastOperationDate: Date | null;
+};
+
+export type CostBasisAcc = {
+  totalAmount: BigNumber;
+  totalCost: BigNumber;
+  /** See {@link CostBasisState.lifetimeCostInCounterValue}. */
+  lifetimeCost: BigNumber;
+  realised: BigNumber;
+  averageEntryPrice: BigNumber;
+};
+
+export type OperationFlow = "inflow" | "outflow" | "ignored";
+
+export type ComputePnLOptions = {
+  isSpamOperation?: (op: Operation, account: AccountLike) => boolean;
+  /**
+   * When `true` (default), if the chain balance disagrees with the cumulative
+   * inflow-minus-outflow from operations, a synthetic operation is folded
+   * into the cost-basis state to close the gap. This is what most consumers
+   * want — it stops the UI from showing wildly negative `unrealisedPnL` for
+   * tokens whose outflows weren't captured (ERC-20 `transferFrom` etc.).
+   *
+   * Set to `false` to expose the raw, unreconciled values (useful for tax
+   * exports where every cost-basis change must trace back to a real op).
+   * The {@link Reconciliation} diagnostic is always produced regardless.
+   */
+  reconcileWithBalance?: boolean;
+};

--- a/libs/wallet-pnl/tsconfig.build.json
+++ b/libs/wallet-pnl/tsconfig.build.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "customConditions": [],
+    "types": []
+  },
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/__tests__/**/*",
+    "**/tests/**/*",
+    "**/__mocks__/**/*",
+    "**/*.test.js",
+    "**/*.test.jsx",
+    "**/*.spec.js",
+    "**/*.spec.jsx"
+  ]
+}

--- a/libs/wallet-pnl/tsconfig.json
+++ b/libs/wallet-pnl/tsconfig.json
@@ -6,7 +6,7 @@
     "noImplicitAny": true,
     "noImplicitThis": true,
     "jsx": "react",
-    "lib": ["es2020", "dom"],
+    "lib": ["es2022", "dom"],
     "outDir": "lib",
     "rootDir": "src",
     "types": ["node", "jest"]

--- a/libs/wallet-pnl/tsconfig.json
+++ b/libs/wallet-pnl/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "jsx": "react",
+    "lib": ["es2020", "dom"],
+    "outDir": "lib",
+    "rootDir": "src",
+    "types": ["node", "jest"]
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12249,6 +12249,67 @@ importers:
         specifier: 'catalog:'
         version: 1.51.0
 
+  libs/wallet-pnl:
+    dependencies:
+      '@ledgerhq/cryptoassets':
+        specifier: workspace:*
+        version: link:../ledgerjs/packages/cryptoassets
+      '@ledgerhq/ledger-wallet-framework':
+        specifier: workspace:*
+        version: link:../ledger-wallet-framework
+      '@ledgerhq/live-countervalues':
+        specifier: workspace:*
+        version: link:../live-countervalues
+      '@ledgerhq/types-cryptoassets':
+        specifier: workspace:*
+        version: link:../ledgerjs/packages/types-cryptoassets
+      '@ledgerhq/types-live':
+        specifier: workspace:*
+        version: link:../ledgerjs/packages/types-live
+      bignumber.js:
+        specifier: 9.1.2
+        version: 9.1.2
+    devDependencies:
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@testing-library/dom':
+        specifier: 'catalog:'
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.0.14
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0(@types/node@24.12.0)
+      jest-environment-jsdom:
+        specifier: 'catalog:'
+        version: 30.2.0
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.36.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.51.0
+      react:
+        specifier: 19.0.0
+        version: 19.0.0
+      react-dom:
+        specifier: 19.0.0
+        version: 19.0.0(react@19.0.0)
+
   shared/feature-flags:
     dependencies:
       '@reduxjs/toolkit':


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - New `@ledgerhq/wallet-pnl` library: ACB-based asset and portfolio PnL, cost-basis cache, operation classification, optional React hooks
  - Jest tests (classification, compute scenarios, hooks); no app or UI changes in this PR

### 📝 Description

**Problem:** Ledger Live needs a shared, testable module to compute profit and loss from on-chain operations using average cost basis, with stable behaviour under countervalue updates.

**Solution:** Introduces `@ledgerhq/wallet-pnl` with `reduceCostBasis` / `getCostBasis`, `computeAssetPnL` and `computePortfolioPnL`, spam-operation filtering, and `useAssetPnL` / `usePortfolioPnL` hooks. Tests cover hodler, staker, trader, multi-asset, and single-trade scenarios plus cache invalidation.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30294](https://ledgerhq.atlassian.net/browse/LIVE-30294)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30294]: https://ledgerhq.atlassian.net/browse/LIVE-30294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ