### PR TITLE
[LWDM] fix(analytics): send consent confirmations as mandatory events

### DIFF
--- a/.changeset/fair-consents-track.md
+++ b/.changeset/fair-consents-track.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Fix analytics consent confirmations to always send mandatory tracking events

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/__integrations__/AnalyticsConsentDialog.portfolio.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/__integrations__/AnalyticsConsentDialog.portfolio.integration.test.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { Route, Routes } from "react-router";
-import { render, screen, waitFor, within } from "tests/testSetup";
+import { render, screen, waitFor } from "tests/testSetup";
 import { FEATURE_FLAGS_INITIAL_STATE } from "@shared/feature-flags";
 import { INITIAL_STATE } from "~/renderer/reducers/settings";
-import { trackPage } from "~/renderer/analytics/segment";
+import { track, trackPage, updateIdentify } from "~/renderer/analytics/segment";
 import { AnalyticsConsentDialog } from "../index";
 
 const featureFlagsWithAnalyticsOptIn = {
@@ -49,296 +49,649 @@ function TestRouter() {
   );
 }
 
+const ANALYTICS_CONSENT_DIALOG_PAGE = "Analytics consent dialog";
+const FRESH_CONSENT_TITLE = "Help us improve Ledger";
+const RECONFIRM_TITLE = "Continue improving Ledger?";
+const PRIVACY_UPDATE_TITLE = "We're updating our privacy policy";
+
 describe("AnalyticsConsentDialog on portfolio route", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it("shows fresh consent when renewal is needed and share analytics is off", async () => {
-    render(<TestRouter />, {
-      initialRoute: "/",
-      initialState: {
-        featureFlags: featureFlagsWithAnalyticsOptIn,
-        settings: baseSettings({
-          shareAnalytics: false,
-          sharePersonalizedRecommandations: false,
-        }),
-      },
+  describe("needs fresh consent", () => {
+    describe("when analytics and recommendations are disabled", () => {
+      it("should opt in when the user accepts", async () => {
+        const { user, store } = render(<TestRouter />, {
+          initialRoute: "/",
+          initialState: {
+            featureFlags: featureFlagsWithAnalyticsOptIn,
+            settings: baseSettings({
+              shareAnalytics: false,
+              sharePersonalizedRecommandations: false,
+            }),
+          },
+        });
+
+        const title = await screen.findByRole("heading", { name: FRESH_CONSENT_TITLE });
+        expect(title).toBeVisible();
+        expect(screen.queryByRole("button", { name: /close/i })).not.toBeInTheDocument();
+        expect(trackPage).toHaveBeenCalledWith(
+          "AnalyticsConsentDialog",
+          "Analytics consent",
+          expect.objectContaining({
+            phase: "consentFresh",
+            type: "modal",
+          }),
+          true,
+          false,
+          true,
+        );
+
+        await user.click(screen.getByRole("button", { name: "Accept all" }));
+        expect(track).toHaveBeenCalledWith(
+          "button_clicked",
+          {
+            button: "analytics_consent_opt_in",
+            page: ANALYTICS_CONSENT_DIALOG_PAGE,
+            privacyPolicyVersion: 1,
+          },
+          true,
+        );
+
+        await waitFor(() => {
+          expect(title).not.toBeInTheDocument();
+        });
+        expect(store.getState().settings.shareAnalytics).toBe(true);
+        expect(store.getState().settings.sharePersonalizedRecommandations).toBe(true);
+        expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
+        expect(updateIdentify).toHaveBeenCalledWith({ force: true });
+      });
+
+      it("should opt out when the user refuses", async () => {
+        const { user, store } = render(<TestRouter />, {
+          initialRoute: "/",
+          initialState: {
+            featureFlags: featureFlagsWithAnalyticsOptIn,
+            settings: baseSettings({
+              shareAnalytics: false,
+              sharePersonalizedRecommandations: false,
+            }),
+          },
+        });
+
+        const title = await screen.findByRole("heading", { name: FRESH_CONSENT_TITLE });
+        expect(title).toBeVisible();
+        expect(trackPage).toHaveBeenCalledWith(
+          "AnalyticsConsentDialog",
+          "Analytics consent",
+          expect.objectContaining({
+            phase: "consentFresh",
+            type: "modal",
+          }),
+          true,
+          false,
+          true,
+        );
+
+        await user.click(screen.getByRole("button", { name: "Refuse all" }));
+        expect(track).toHaveBeenCalledWith(
+          "button_clicked",
+          {
+            button: "analytics_consent_opt_out",
+            page: ANALYTICS_CONSENT_DIALOG_PAGE,
+            privacyPolicyVersion: 1,
+          },
+          true,
+        );
+
+        await waitFor(() => {
+          expect(title).not.toBeInTheDocument();
+        });
+        expect(store.getState().settings.shareAnalytics).toBe(false);
+        expect(store.getState().settings.sharePersonalizedRecommandations).toBe(false);
+        expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
+        expect(updateIdentify).toHaveBeenCalledWith({ force: true });
+      });
+
+      it("should open preferences when the user chooses Set preferences", async () => {
+        const { user } = render(<TestRouter />, {
+          initialRoute: "/",
+          initialState: {
+            featureFlags: featureFlagsWithAnalyticsOptIn,
+            settings: baseSettings({
+              shareAnalytics: false,
+              sharePersonalizedRecommandations: false,
+            }),
+          },
+        });
+
+        const title = await screen.findByRole("heading", { name: FRESH_CONSENT_TITLE });
+        expect(title).toBeVisible();
+        expect(trackPage).toHaveBeenCalledWith(
+          "AnalyticsConsentDialog",
+          "Analytics consent",
+          expect.objectContaining({
+            phase: "consentFresh",
+            type: "modal",
+          }),
+          true,
+          false,
+          true,
+        );
+        const setPreferencesLink = screen.getByRole("link", { name: "Set preferences" });
+        expect(setPreferencesLink).toHaveAttribute("href", "#");
+
+        await user.click(setPreferencesLink);
+        expect(track).toHaveBeenCalledWith("button_clicked", {
+          button: "analytics_consent_set_preferences",
+          page: ANALYTICS_CONSENT_DIALOG_PAGE,
+        });
+
+        await waitFor(() => {
+          expect(screen.getByRole("heading", { name: "Set preferences" })).toBeVisible();
+        });
+        expect(trackPage).toHaveBeenCalledWith(
+          "AnalyticsConsentDialog",
+          "Analytics consent",
+          expect.objectContaining({
+            phase: "preferences",
+            type: "modal",
+          }),
+          true,
+          false,
+          true,
+        );
+        expect(screen.getByRole("button", { name: "Confirm" })).toBeVisible();
+      });
     });
 
-    expect(
-      await screen.findByRole("heading", { name: "Help us improve Ledger" }),
-    ).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /close/i })).not.toBeInTheDocument();
-    expect(trackPage).toHaveBeenCalledWith(
-      "AnalyticsConsentDialog",
-      "Analytics consent",
-      {
-        type: "modal",
-        phase: "consentFresh",
-      },
-      true,
-      false,
-      true,
-    );
+    describe("when analytics is disabled and recommendations are enabled", () => {
+      it("should opt in when the user accepts", async () => {
+        const { user, store } = render(<TestRouter />, {
+          initialRoute: "/",
+          initialState: {
+            featureFlags: featureFlagsWithAnalyticsOptIn,
+            settings: baseSettings({
+              shareAnalytics: false,
+              sharePersonalizedRecommandations: true,
+            }),
+          },
+        });
+
+        const title = await screen.findByRole("heading", { name: FRESH_CONSENT_TITLE });
+        expect(title).toBeVisible();
+        expect(trackPage).toHaveBeenCalledWith(
+          "AnalyticsConsentDialog",
+          "Analytics consent",
+          expect.objectContaining({
+            phase: "consentFresh",
+            type: "modal",
+          }),
+          true,
+          false,
+          true,
+        );
+
+        await user.click(screen.getByRole("button", { name: "Accept all" }));
+        expect(track).toHaveBeenCalledWith(
+          "button_clicked",
+          {
+            button: "analytics_consent_opt_in",
+            page: ANALYTICS_CONSENT_DIALOG_PAGE,
+            privacyPolicyVersion: 1,
+          },
+          true,
+        );
+
+        await waitFor(() => {
+          expect(title).not.toBeInTheDocument();
+        });
+        expect(store.getState().settings.shareAnalytics).toBe(true);
+        expect(store.getState().settings.sharePersonalizedRecommandations).toBe(true);
+        expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
+        expect(updateIdentify).toHaveBeenCalledWith({ force: true });
+      });
+
+      it("should opt out when the user refuses", async () => {
+        const { user, store } = render(<TestRouter />, {
+          initialRoute: "/",
+          initialState: {
+            featureFlags: featureFlagsWithAnalyticsOptIn,
+            settings: baseSettings({
+              shareAnalytics: false,
+              sharePersonalizedRecommandations: true,
+            }),
+          },
+        });
+
+        const title = await screen.findByRole("heading", { name: FRESH_CONSENT_TITLE });
+        expect(title).toBeVisible();
+        expect(trackPage).toHaveBeenCalledWith(
+          "AnalyticsConsentDialog",
+          "Analytics consent",
+          expect.objectContaining({
+            phase: "consentFresh",
+            type: "modal",
+          }),
+          true,
+          false,
+          true,
+        );
+
+        await user.click(screen.getByRole("button", { name: "Refuse all" }));
+        expect(track).toHaveBeenCalledWith(
+          "button_clicked",
+          {
+            button: "analytics_consent_opt_out",
+            page: ANALYTICS_CONSENT_DIALOG_PAGE,
+            privacyPolicyVersion: 1,
+          },
+          true,
+        );
+
+        await waitFor(() => {
+          expect(title).not.toBeInTheDocument();
+        });
+        expect(store.getState().settings.shareAnalytics).toBe(false);
+        expect(store.getState().settings.sharePersonalizedRecommandations).toBe(false);
+        expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
+        expect(updateIdentify).toHaveBeenCalledWith({ force: true });
+      });
+
+      it("should open preferences when the user chooses Set preferences", async () => {
+        const { user } = render(<TestRouter />, {
+          initialRoute: "/",
+          initialState: {
+            featureFlags: featureFlagsWithAnalyticsOptIn,
+            settings: baseSettings({
+              shareAnalytics: false,
+              sharePersonalizedRecommandations: true,
+            }),
+          },
+        });
+
+        const title = await screen.findByRole("heading", { name: FRESH_CONSENT_TITLE });
+        expect(title).toBeVisible();
+        expect(trackPage).toHaveBeenCalledWith(
+          "AnalyticsConsentDialog",
+          "Analytics consent",
+          expect.objectContaining({
+            phase: "consentFresh",
+            type: "modal",
+          }),
+          true,
+          false,
+          true,
+        );
+        const setPreferencesLink = screen.getByRole("link", { name: "Set preferences" });
+        expect(setPreferencesLink).toHaveAttribute("href", "#");
+
+        await user.click(setPreferencesLink);
+        expect(track).toHaveBeenCalledWith("button_clicked", {
+          button: "analytics_consent_set_preferences",
+          page: ANALYTICS_CONSENT_DIALOG_PAGE,
+        });
+
+        await waitFor(() => {
+          expect(screen.getByRole("heading", { name: "Set preferences" })).toBeVisible();
+        });
+        expect(trackPage).toHaveBeenCalledWith(
+          "AnalyticsConsentDialog",
+          "Analytics consent",
+          expect.objectContaining({
+            phase: "preferences",
+            type: "modal",
+          }),
+          true,
+          false,
+          true,
+        );
+        expect(screen.getByRole("button", { name: "Confirm" })).toBeVisible();
+      });
+    });
   });
 
-  it.each([
-    { shareAnalytics: false, sharePersonalizedRecommandations: false },
-    { shareAnalytics: true, sharePersonalizedRecommandations: false },
-    { shareAnalytics: false, sharePersonalizedRecommandations: true },
-    { shareAnalytics: true, sharePersonalizedRecommandations: true },
-  ])(
-    "tracks the consent dialog page as mandatory telemetry when consent is $shareAnalytics/$sharePersonalizedRecommandations",
-    async ({ shareAnalytics, sharePersonalizedRecommandations }) => {
-      render(<TestRouter />, {
+  describe("needs reconfirmation", () => {
+    describe("when analytics is enabled and recommendations are disabled", () => {
+      it("should keep analytics enabled when the user accepts", async () => {
+        const { user, store } = render(<TestRouter />, {
+          initialRoute: "/",
+          initialState: {
+            featureFlags: featureFlagsWithAnalyticsOptIn,
+            settings: baseSettings({
+              shareAnalytics: true,
+              sharePersonalizedRecommandations: false,
+            }),
+          },
+        });
+
+        const title = await screen.findByRole("heading", { name: RECONFIRM_TITLE });
+        expect(title).toBeVisible();
+        expect(trackPage).toHaveBeenCalledWith(
+          "AnalyticsConsentDialog",
+          "Analytics consent",
+          expect.objectContaining({
+            phase: "consentReconfirm",
+            type: "modal",
+          }),
+          true,
+          false,
+          true,
+        );
+
+        await user.click(screen.getByRole("button", { name: "Yes, continue" }));
+        expect(track).toHaveBeenCalledWith(
+          "button_clicked",
+          {
+            button: "analytics_consent_opt_in",
+            page: ANALYTICS_CONSENT_DIALOG_PAGE,
+            privacyPolicyVersion: 1,
+          },
+          true,
+        );
+
+        await waitFor(() => {
+          expect(title).not.toBeInTheDocument();
+        });
+        expect(store.getState().settings.shareAnalytics).toBe(true);
+        expect(store.getState().settings.sharePersonalizedRecommandations).toBe(true);
+        expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
+        expect(updateIdentify).toHaveBeenCalledWith({ force: true });
+      });
+
+      it("should opt out when the user refuses", async () => {
+        const { user, store } = render(<TestRouter />, {
+          initialRoute: "/",
+          initialState: {
+            featureFlags: featureFlagsWithAnalyticsOptIn,
+            settings: baseSettings({
+              shareAnalytics: true,
+              sharePersonalizedRecommandations: false,
+            }),
+          },
+        });
+
+        const title = await screen.findByRole("heading", { name: RECONFIRM_TITLE });
+        expect(title).toBeVisible();
+        expect(trackPage).toHaveBeenCalledWith(
+          "AnalyticsConsentDialog",
+          "Analytics consent",
+          expect.objectContaining({
+            phase: "consentReconfirm",
+            type: "modal",
+          }),
+          true,
+          false,
+          true,
+        );
+
+        await user.click(screen.getByRole("button", { name: "No, stop" }));
+        expect(track).toHaveBeenCalledWith(
+          "button_clicked",
+          {
+            button: "analytics_consent_opt_out",
+            page: ANALYTICS_CONSENT_DIALOG_PAGE,
+            privacyPolicyVersion: 1,
+          },
+          true,
+        );
+
+        await waitFor(() => {
+          expect(title).not.toBeInTheDocument();
+        });
+        expect(store.getState().settings.shareAnalytics).toBe(false);
+        expect(store.getState().settings.sharePersonalizedRecommandations).toBe(false);
+        expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
+        expect(updateIdentify).toHaveBeenCalledWith({ force: true });
+      });
+
+      it("should open preferences when the user chooses Set preferences", async () => {
+        const { user } = render(<TestRouter />, {
+          initialRoute: "/",
+          initialState: {
+            featureFlags: featureFlagsWithAnalyticsOptIn,
+            settings: baseSettings({
+              shareAnalytics: true,
+              sharePersonalizedRecommandations: false,
+            }),
+          },
+        });
+
+        const title = await screen.findByRole("heading", { name: RECONFIRM_TITLE });
+        expect(title).toBeVisible();
+        expect(trackPage).toHaveBeenCalledWith(
+          "AnalyticsConsentDialog",
+          "Analytics consent",
+          expect.objectContaining({
+            phase: "consentReconfirm",
+            type: "modal",
+          }),
+          true,
+          false,
+          true,
+        );
+        const setPreferencesLink = screen.getByRole("link", { name: "Set preferences" });
+        expect(setPreferencesLink).toHaveAttribute("href", "#");
+
+        await user.click(setPreferencesLink);
+        expect(track).toHaveBeenCalledWith("button_clicked", {
+          button: "analytics_consent_set_preferences",
+          page: ANALYTICS_CONSENT_DIALOG_PAGE,
+        });
+
+        await waitFor(() => {
+          expect(screen.getByRole("heading", { name: "Set preferences" })).toBeVisible();
+        });
+        expect(trackPage).toHaveBeenCalledWith(
+          "AnalyticsConsentDialog",
+          "Analytics consent",
+          expect.objectContaining({
+            phase: "preferences",
+            type: "modal",
+          }),
+          true,
+          false,
+          true,
+        );
+        expect(screen.getByRole("button", { name: "Confirm" })).toBeVisible();
+      });
+    });
+
+    describe("when analytics and recommendations are enabled", () => {
+      it("should keep analytics enabled when the user accepts", async () => {
+        const { user, store } = render(<TestRouter />, {
+          initialRoute: "/",
+          initialState: {
+            featureFlags: featureFlagsWithAnalyticsOptIn,
+            settings: baseSettings({
+              shareAnalytics: true,
+              sharePersonalizedRecommandations: true,
+            }),
+          },
+        });
+
+        const title = await screen.findByRole("heading", { name: RECONFIRM_TITLE });
+        expect(title).toBeVisible();
+        expect(trackPage).toHaveBeenCalledWith(
+          "AnalyticsConsentDialog",
+          "Analytics consent",
+          expect.objectContaining({
+            phase: "consentReconfirm",
+            type: "modal",
+          }),
+          true,
+          false,
+          true,
+        );
+
+        await user.click(screen.getByRole("button", { name: "Yes, continue" }));
+        expect(track).toHaveBeenCalledWith(
+          "button_clicked",
+          {
+            button: "analytics_consent_opt_in",
+            page: ANALYTICS_CONSENT_DIALOG_PAGE,
+            privacyPolicyVersion: 1,
+          },
+          true,
+        );
+
+        await waitFor(() => {
+          expect(title).not.toBeInTheDocument();
+        });
+        expect(store.getState().settings.shareAnalytics).toBe(true);
+        expect(store.getState().settings.sharePersonalizedRecommandations).toBe(true);
+        expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
+        expect(updateIdentify).toHaveBeenCalledWith({ force: true });
+      });
+
+      it("should opt out when the user refuses", async () => {
+        const { user, store } = render(<TestRouter />, {
+          initialRoute: "/",
+          initialState: {
+            featureFlags: featureFlagsWithAnalyticsOptIn,
+            settings: baseSettings({
+              shareAnalytics: true,
+              sharePersonalizedRecommandations: true,
+            }),
+          },
+        });
+
+        const title = await screen.findByRole("heading", { name: RECONFIRM_TITLE });
+        expect(title).toBeVisible();
+        expect(trackPage).toHaveBeenCalledWith(
+          "AnalyticsConsentDialog",
+          "Analytics consent",
+          expect.objectContaining({
+            phase: "consentReconfirm",
+            type: "modal",
+          }),
+          true,
+          false,
+          true,
+        );
+
+        await user.click(screen.getByRole("button", { name: "No, stop" }));
+        expect(track).toHaveBeenCalledWith(
+          "button_clicked",
+          {
+            button: "analytics_consent_opt_out",
+            page: ANALYTICS_CONSENT_DIALOG_PAGE,
+            privacyPolicyVersion: 1,
+          },
+          true,
+        );
+
+        await waitFor(() => {
+          expect(title).not.toBeInTheDocument();
+        });
+        expect(store.getState().settings.shareAnalytics).toBe(false);
+        expect(store.getState().settings.sharePersonalizedRecommandations).toBe(false);
+        expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
+        expect(updateIdentify).toHaveBeenCalledWith({ force: true });
+      });
+
+      it("should open preferences when the user chooses Set preferences", async () => {
+        const { user } = render(<TestRouter />, {
+          initialRoute: "/",
+          initialState: {
+            featureFlags: featureFlagsWithAnalyticsOptIn,
+            settings: baseSettings({
+              shareAnalytics: true,
+              sharePersonalizedRecommandations: true,
+            }),
+          },
+        });
+
+        const title = await screen.findByRole("heading", { name: RECONFIRM_TITLE });
+        expect(title).toBeVisible();
+        expect(trackPage).toHaveBeenCalledWith(
+          "AnalyticsConsentDialog",
+          "Analytics consent",
+          expect.objectContaining({
+            phase: "consentReconfirm",
+            type: "modal",
+          }),
+          true,
+          false,
+          true,
+        );
+        const setPreferencesLink = screen.getByRole("link", { name: "Set preferences" });
+        expect(setPreferencesLink).toHaveAttribute("href", "#");
+
+        await user.click(setPreferencesLink);
+        expect(track).toHaveBeenCalledWith("button_clicked", {
+          button: "analytics_consent_set_preferences",
+          page: ANALYTICS_CONSENT_DIALOG_PAGE,
+        });
+
+        await waitFor(() => {
+          expect(screen.getByRole("heading", { name: "Set preferences" })).toBeVisible();
+        });
+        expect(trackPage).toHaveBeenCalledWith(
+          "AnalyticsConsentDialog",
+          "Analytics consent",
+          expect.objectContaining({
+            phase: "preferences",
+            type: "modal",
+          }),
+          true,
+          false,
+          true,
+        );
+        expect(screen.getByRole("button", { name: "Confirm" })).toBeVisible();
+      });
+    });
+  });
+
+  describe("needs privacy policy version update", () => {
+    it("should show the privacy update sheet, persist the policy version, and close after Got it", async () => {
+      const { user, store } = render(<TestRouter />, {
         initialRoute: "/",
         initialState: {
           featureFlags: featureFlagsWithAnalyticsOptIn,
           settings: baseSettings({
-            shareAnalytics,
-            sharePersonalizedRecommandations,
+            shareAnalytics: true,
+            sharePersonalizedRecommandations: true,
+            analyticsConsentInfo: {
+              consentDate: new Date().toISOString(),
+              privacyPolicyVersion: 0,
+            },
           }),
         },
       });
 
-      await screen.findByTestId("analytics-consent-dialog");
-
+      const title = await screen.findByRole("heading", { name: PRIVACY_UPDATE_TITLE });
+      expect(title).toBeVisible();
       expect(trackPage).toHaveBeenCalledWith(
         "AnalyticsConsentDialog",
         "Analytics consent",
         expect.objectContaining({
+          phase: "privacy",
           type: "modal",
         }),
         true,
         false,
         true,
       );
-    },
-  );
 
-  it("shows reconfirm copy when renewal is needed and share analytics is on", async () => {
-    render(<TestRouter />, {
-      initialRoute: "/",
-      initialState: {
-        featureFlags: featureFlagsWithAnalyticsOptIn,
-        settings: baseSettings({
-          shareAnalytics: true,
-          sharePersonalizedRecommandations: true,
-        }),
-      },
-    });
-
-    expect(
-      await screen.findByRole("heading", { name: "Continue improving Ledger?" }),
-    ).toBeInTheDocument();
-  });
-
-  it("opts in and closes when Accept all is used (fresh phase)", async () => {
-    const { user, store } = render(<TestRouter />, {
-      initialRoute: "/",
-      initialState: {
-        featureFlags: featureFlagsWithAnalyticsOptIn,
-        settings: baseSettings({
-          shareAnalytics: false,
-          sharePersonalizedRecommandations: false,
-        }),
-      },
-    });
-
-    const freshTitle = await screen.findByRole("heading", { name: "Help us improve Ledger" });
-    await user.click(screen.getByRole("button", { name: /accept all/i }));
-
-    await waitFor(() => {
-      expect(freshTitle).not.toBeInTheDocument();
-    });
-    expect(store.getState().settings.shareAnalytics).toBe(true);
-    expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
-  });
-
-  it("opts out and closes when Refuse all is used (fresh phase)", async () => {
-    const { user, store } = render(<TestRouter />, {
-      initialRoute: "/",
-      initialState: {
-        featureFlags: featureFlagsWithAnalyticsOptIn,
-        settings: baseSettings({
-          shareAnalytics: false,
-          sharePersonalizedRecommandations: false,
-        }),
-      },
-    });
-
-    const freshTitle = await screen.findByRole("heading", { name: "Help us improve Ledger" });
-    await user.click(screen.getByRole("button", { name: /refuse all/i }));
-
-    await waitFor(() => {
-      expect(freshTitle).not.toBeInTheDocument();
-    });
-    expect(store.getState().settings.shareAnalytics).toBe(false);
-    expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
-  });
-
-  it("keeps analytics on when Yes, continue is used (reconfirm)", async () => {
-    const { user, store } = render(<TestRouter />, {
-      initialRoute: "/",
-      initialState: {
-        featureFlags: featureFlagsWithAnalyticsOptIn,
-        settings: baseSettings({
-          shareAnalytics: true,
-          sharePersonalizedRecommandations: true,
-        }),
-      },
-    });
-
-    const reconfirmTitle = await screen.findByRole("heading", {
-      name: "Continue improving Ledger?",
-    });
-    await user.click(screen.getByRole("button", { name: /yes, continue/i }));
-
-    await waitFor(() => {
-      expect(reconfirmTitle).not.toBeInTheDocument();
-    });
-    expect(store.getState().settings.shareAnalytics).toBe(true);
-    expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
-  });
-
-  it("opts out when No, stop is used (reconfirm)", async () => {
-    const { user, store } = render(<TestRouter />, {
-      initialRoute: "/",
-      initialState: {
-        featureFlags: featureFlagsWithAnalyticsOptIn,
-        settings: baseSettings({
-          shareAnalytics: true,
-          sharePersonalizedRecommandations: true,
-        }),
-      },
-    });
-
-    const reconfirmTitle = await screen.findByRole("heading", {
-      name: "Continue improving Ledger?",
-    });
-    await user.click(screen.getByRole("button", { name: /no, stop/i }));
-
-    await waitFor(() => {
-      expect(reconfirmTitle).not.toBeInTheDocument();
-    });
-    expect(store.getState().settings.shareAnalytics).toBe(false);
-    expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
-  });
-
-  it("shows privacy update and closes after Got it", async () => {
-    const { user, store } = render(<TestRouter />, {
-      initialRoute: "/",
-      initialState: {
-        featureFlags: featureFlagsWithAnalyticsOptIn,
-        settings: baseSettings({
-          shareAnalytics: true,
-          sharePersonalizedRecommandations: true,
-          analyticsConsentInfo: {
-            consentDate: new Date().toISOString(),
-            privacyPolicyVersion: 0,
-          },
-        }),
-      },
-    });
-
-    const privacyTitle = await screen.findByRole("heading", {
-      name: "We're updating our privacy policy",
-    });
-    await user.click(screen.getByRole("button", { name: /got it/i }));
-
-    await waitFor(() => expect(privacyTitle).not.toBeInTheDocument());
-    expect(store.getState().settings.analyticsConsentInfo.privacyPolicyVersion).toBe(1);
-    expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
-  });
-
-  it("shows preferences step when Set preferences is clicked", async () => {
-    const { user } = render(<TestRouter />, {
-      initialRoute: "/",
-      initialState: {
-        featureFlags: featureFlagsWithAnalyticsOptIn,
-        settings: baseSettings({
-          shareAnalytics: false,
-          sharePersonalizedRecommandations: false,
-        }),
-      },
-    });
-
-    await screen.findByRole("heading", { name: "Help us improve Ledger" });
-    const setPreferencesLink = screen.getByRole("link", { name: /set preferences/i });
-
-    // make sure the link is a11y compliant and does not navigate to a new page
-    expect(setPreferencesLink).toHaveAttribute("href", "#");
-
-    await user.click(setPreferencesLink);
-
-    await waitFor(() => {
-      expect(screen.getByRole("heading", { name: "Set preferences" })).toBeInTheDocument();
-    });
-    expect(screen.getByRole("button", { name: "Confirm" })).toBeInTheDocument();
-  });
-
-  it.each([
-    {
-      label: "both toggles on",
-      expectShareAnalytics: true,
-      expectSharePersonalized: true,
-    },
-    {
-      label: "only App performance on",
-      expectShareAnalytics: true,
-      expectSharePersonalized: false,
-    },
-    {
-      label: "only Personalized experience on",
-      expectShareAnalytics: false,
-      expectSharePersonalized: true,
-    },
-    {
-      label: "all toggles off",
-      expectShareAnalytics: false,
-      expectSharePersonalized: false,
-    },
-  ])(
-    "Set preferences: Confirm closes the modal and sets shareAnalytics and sharePersonalizedRecommandations ($label)",
-    async ({ expectShareAnalytics, expectSharePersonalized }) => {
-      const { user, store } = render(<TestRouter />, {
-        initialRoute: "/",
-        initialState: {
-          featureFlags: featureFlagsWithAnalyticsOptIn,
-          settings: baseSettings({
-            shareAnalytics: false,
-            sharePersonalizedRecommandations: false,
-          }),
+      await user.click(screen.getByRole("button", { name: "Got it" }));
+      expect(track).toHaveBeenCalledWith(
+        "button_clicked",
+        {
+          button: "analytics_consent_privacy_got_it",
+          page: ANALYTICS_CONSENT_DIALOG_PAGE,
+          privacyPolicyVersion: 1,
         },
-      });
-
-      await screen.findByRole("heading", { name: "Help us improve Ledger" });
-      await user.click(screen.getByRole("link", { name: /set preferences/i }));
-      const modal = await screen.findByTestId("analytics-consent-dialog");
-      await screen.findByRole("heading", { name: "Set preferences" });
-
-      // Set preferences opens with both switches OFF (`onSetPreferences` seeds drafts to false).
-      const switches = within(modal).getAllByRole("switch");
-      expect(switches).toHaveLength(2);
-      const [appPerformanceSwitch, personalizedSwitch] = switches;
-      if (expectShareAnalytics) {
-        await user.click(appPerformanceSwitch);
-      }
-      if (expectSharePersonalized) {
-        await user.click(personalizedSwitch);
-      }
-
-      await user.click(screen.getByRole("button", { name: "Confirm" }));
+        true,
+      );
 
       await waitFor(() => {
-        expect(modal).not.toBeInTheDocument();
+        expect(title).not.toBeInTheDocument();
       });
-      const { settings: s } = store.getState();
-      expect(s.shareAnalytics).toBe(expectShareAnalytics);
-      expect(s.sharePersonalizedRecommandations).toBe(expectSharePersonalized);
-      expect(s.hasSeenAnalyticsOptInPrompt).toBe(true);
-      expect(s.analyticsConsentInfo.consentDate).not.toBeNull();
-    },
-  );
+      expect(store.getState().settings.analyticsConsentInfo.privacyPolicyVersion).toBe(1);
+      expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
+      expect(updateIdentify).toHaveBeenCalledWith({ force: true });
+    });
+  });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/__tests__/useAnalyticsConsentDialogViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/__tests__/useAnalyticsConsentDialogViewModel.test.ts
@@ -88,6 +88,12 @@ const expectConsentReconfirm = (viewModel: ViewModel) => {
 
 const renderReconfirmViewModel = () => renderViewModel();
 
+const createStaleConsentDate = () => {
+  const staleConsentDate = new Date(FIXED_NOW);
+  staleConsentDate.setUTCDate(staleConsentDate.getUTCDate() - 366);
+  return staleConsentDate.toISOString();
+};
+
 describe("useAnalyticsConsentDialogViewModel", () => {
   beforeEach(() => {
     jest.useFakeTimers({ doNotFake: ["queueMicrotask"] });
@@ -146,6 +152,85 @@ describe("useAnalyticsConsentDialogViewModel", () => {
     expect(settings.analyticsConsentInfo.consentDate).not.toBeNull();
     expect(settings.analyticsConsentInfo.privacyPolicyVersion).toBe(1);
     expectClosed(result.current);
+  });
+
+  it("tracks opt-out as mandatory when user was already fully opted out", async () => {
+    const { result } = renderViewModel({
+      shareAnalytics: false,
+      sharePersonalizedRecommandations: false,
+      analyticsConsentInfo: {
+        consentDate: createStaleConsentDate(),
+        privacyPolicyVersion: 1,
+      },
+    });
+
+    await flushEffects();
+    expect(result.current.phase).toBe("consentFresh");
+
+    await act(async () => {
+      await result.current.applyOptOut();
+    });
+
+    expect(jest.mocked(track)).toHaveBeenCalledWith(
+      "button_clicked",
+      {
+        button: "analytics_consent_opt_out",
+        page: ANALYTICS_CONSENT_DIALOG_PAGE,
+        privacyPolicyVersion: 1,
+      },
+      true,
+    );
+  });
+
+  it("tracks privacy acknowledgement as mandatory", async () => {
+    const { result } = renderViewModel({
+      analyticsConsentInfo: {
+        consentDate: FIXED_NOW.toISOString(),
+        privacyPolicyVersion: 0,
+      },
+    });
+
+    await flushEffects();
+    expect(result.current.phase).toBe("privacy");
+
+    await act(async () => {
+      await result.current.onPrivacyGotIt();
+    });
+
+    expect(jest.mocked(track)).toHaveBeenCalledWith(
+      "button_clicked",
+      {
+        button: "analytics_consent_privacy_got_it",
+        page: ANALYTICS_CONSENT_DIALOG_PAGE,
+        privacyPolicyVersion: 1,
+      },
+      true,
+    );
+  });
+
+  it("tracks preferences confirmation as mandatory", async () => {
+    const { result } = renderReconfirmViewModel();
+
+    await flushEffects();
+    expectConsentReconfirm(result.current);
+
+    act(() => {
+      result.current.onSetPreferences();
+    });
+
+    await act(async () => {
+      await result.current.applyPreferences();
+    });
+
+    expect(jest.mocked(track)).toHaveBeenCalledWith(
+      "button_clicked",
+      {
+        button: "analytics_consent_preferences_confirm",
+        page: ANALYTICS_CONSENT_DIALOG_PAGE,
+        privacyPolicyVersion: 1,
+      },
+      true,
+    );
   });
 
   it("tracks drawer_closed when leaving portfolio while modal is open", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/hooks/useAnalyticsConsentDialogViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/hooks/useAnalyticsConsentDialogViewModel.ts
@@ -7,7 +7,6 @@ import {
   analyticsConsentInfoSelector,
   hasCompletedOnboardingSelector,
   shareAnalyticsSelector,
-  sharePersonalizedRecommendationsSelector,
 } from "~/renderer/reducers/settings";
 import {
   setAnalyticsConsentInfo,
@@ -49,7 +48,6 @@ export function useAnalyticsConsentDialogViewModel() {
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
   const consentInfo = useSelector(analyticsConsentInfoSelector);
   const shareAnalytics = useSelector(shareAnalyticsSelector);
-  const sharePersonalizedRecommendations = useSelector(sharePersonalizedRecommendationsSelector);
 
   const needsUpdatePrivacy = needsPrivacyPolicyAck(consentInfo.privacyPolicyVersion, policyVersion);
   const needsRenewal = needsConsentRenewal(consentInfo.consentDate, consentValidityDays);
@@ -137,8 +135,6 @@ export function useAnalyticsConsentDialogViewModel() {
   };
 
   const applyOptOut = async () => {
-    const isPreviouslyOptedOutCompletely = !shareAnalytics && !sharePersonalizedRecommendations;
-    const trackMandatory = !isPreviouslyOptedOutCompletely;
     track(
       "button_clicked",
       {
@@ -146,7 +142,7 @@ export function useAnalyticsConsentDialogViewModel() {
         page: ANALYTICS_CONSENT_DIALOG_PAGE,
         privacyPolicyVersion: policyVersion,
       },
-      trackMandatory,
+      true,
     );
     dispatch(setShareAnalytics(false));
     dispatch(setSharePersonalizedRecommendations(false));
@@ -155,11 +151,15 @@ export function useAnalyticsConsentDialogViewModel() {
   };
 
   const onPrivacyGotIt = async () => {
-    track("button_clicked", {
-      button: "analytics_consent_privacy_got_it",
-      page: ANALYTICS_CONSENT_DIALOG_PAGE,
-      privacyPolicyVersion: policyVersion,
-    });
+    track(
+      "button_clicked",
+      {
+        button: "analytics_consent_privacy_got_it",
+        page: ANALYTICS_CONSENT_DIALOG_PAGE,
+        privacyPolicyVersion: policyVersion,
+      },
+      true,
+    );
     await persistAnalyticsConsentAck();
     handleCloseDialog();
   };
@@ -183,7 +183,6 @@ export function useAnalyticsConsentDialogViewModel() {
   const onBackFromPreferences = () => setPhase(consentPhaseBeforePreferences);
 
   const applyPreferences = async () => {
-    const trackMandatory = draftShareAnalytics || draftSharePersonalized;
     track(
       "button_clicked",
       {
@@ -191,7 +190,7 @@ export function useAnalyticsConsentDialogViewModel() {
         page: ANALYTICS_CONSENT_DIALOG_PAGE,
         privacyPolicyVersion: policyVersion,
       },
-      trackMandatory,
+      true,
     );
     dispatch(setShareAnalytics(draftShareAnalytics));
     dispatch(setSharePersonalizedRecommendations(draftSharePersonalized));

--- a/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/__integrations__/AnalyticsConsentDrawer.portfolio.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/__integrations__/AnalyticsConsentDrawer.portfolio.integration.test.tsx
@@ -9,27 +9,18 @@ import { AnalyticsConsentDrawer } from "../index";
 import { withConsentDrawerState } from "../__tests__/helpers";
 import { ScreenName } from "~/const";
 import type { State } from "~/reducers/types";
-import subDays from "date-fns/subDays";
 import AnalyticsPreferencesSettings from "~/screens/Settings/AnalyticsPreferencesSettings";
-
-const consentIsoOlderThanValidityWindow = () => subDays(new Date(), 366).toISOString();
 
 const Stack = createNativeStackNavigator();
 const SettingsStack = createNativeStackNavigator();
 
-function GeneralSettingsStub() {
-  return <View testID="GeneralSettingsStub" />;
-}
-
 function SettingsNavigator() {
+  function GeneralSettingsStub() {
+    return <View />;
+  }
   return (
-    <SafeAreaProvider
-      initialMetrics={{
-        frame: { x: 0, y: 0, width: 375, height: 812 },
-        insets: { top: 0, left: 0, right: 0, bottom: 0 },
-      }}
-    >
-      <SettingsStack.Navigator screenOptions={{ headerShown: false }}>
+    <SafeAreaProvider>
+      <SettingsStack.Navigator>
         <SettingsStack.Screen name={ScreenName.GeneralSettings} component={GeneralSettingsStub} />
         <SettingsStack.Screen
           name={ScreenName.AnalyticsPreferencesSettings}
@@ -40,23 +31,25 @@ function SettingsNavigator() {
   );
 }
 
-/**
- * Minimal Portfolio-shaped screen: same mount order as Portfolio (list stub + consent drawer)
- * without pulling Swap / QuickActions, to avoid async teardown noise while still using a focused route.
- */
-function PortfolioScreenWithConsentDrawer() {
-  return (
-    <View style={{ flex: 1 }}>
-      <View testID="PortfolioEmptyList" />
-      <AnalyticsConsentDrawer />
-    </View>
-  );
-}
-
 function IntegrationNavigator() {
+  /**
+   * Minimal Portfolio-shaped screen: same mount order as Portfolio (list stub + consent drawer)
+   * without pulling Swap / QuickActions, to avoid async teardown noise while still using a focused route.
+   */
+  function PortfolioScreenWithConsentDrawer() {
+    return (
+      <View>
+        <View />
+        <AnalyticsConsentDrawer />
+      </View>
+    );
+  }
+
+  const PortfolioName = "Portfolio";
+
   return (
-    <Stack.Navigator screenOptions={{ headerShown: false }} initialRouteName="Portfolio">
-      <Stack.Screen name="Portfolio" component={PortfolioScreenWithConsentDrawer} />
+    <Stack.Navigator initialRouteName={PortfolioName}>
+      <Stack.Screen name={PortfolioName} component={PortfolioScreenWithConsentDrawer} />
       <Stack.Screen name="Settings" component={SettingsNavigator} />
     </Stack.Navigator>
   );
@@ -66,35 +59,10 @@ const composePortfolioOverrides =
   (extra: Parameters<typeof withConsentDrawerState>[0]) => (state: State) =>
     withConsentDrawerState(extra)(overrideInitialStateWithFeatureFlag(state));
 
-/** Fresh: renewal first, analytics off → consentFresh. */
-const overridePortfolioWithAnalyticsConsentDrawer = composePortfolioOverrides({
-  hasCompletedOnboarding: true,
-  analyticsOptInEnabled: true,
-  analyticsEnabled: false,
-  personalizedRecommendationsEnabled: false,
-  consentDate: null,
-  privacyPolicyVersion: 1,
-});
-
-/** Reconfirm: renewal first, analytics on → consentReconfirm. */
-const overridePortfolioWithAnalyticsConsentReconfirm = composePortfolioOverrides({
-  hasCompletedOnboarding: true,
-  analyticsOptInEnabled: true,
-  analyticsEnabled: true,
-  personalizedRecommendationsEnabled: true,
-  consentDate: null,
-  privacyPolicyVersion: 1,
-});
-
-/** Privacy policy ack only (stale policy version, valid consent). */
-const overridePortfolioWithPrivacySheet = composePortfolioOverrides({
-  hasCompletedOnboarding: true,
-  analyticsOptInEnabled: true,
-  analyticsEnabled: true,
-  personalizedRecommendationsEnabled: true,
-  consentDate: new Date().toISOString(),
-  privacyPolicyVersion: 0,
-});
+const ANALYTICS_CONSENT_DRAWER_PAGE = "Analytics consent drawer";
+const FRESH_CONSENT_TITLE = "Help us improve Ledger";
+const RECONFIRM_TITLE = "Continue improving Ledger?";
+const PRIVACY_UPDATE_TITLE = "We're updating our privacy policy";
 
 describe("AnalyticsConsentDrawer on Portfolio", () => {
   beforeEach(() => {
@@ -106,225 +74,594 @@ describe("AnalyticsConsentDrawer on Portfolio", () => {
   });
 
   describe("needs fresh consent", () => {
-    it("should opt in and close the drawer when the user taps Accept all on the fresh consent sheet", async () => {
-      const { user, store } = renderWithReactQuery(<IntegrationNavigator />, {
-        overrideInitialState: overridePortfolioWithAnalyticsConsentDrawer,
-      });
-
-      await screen.findByTestId("PortfolioEmptyList");
-      expect(await screen.findByText("Help us improve Ledger")).toBeVisible();
-
-      await user.press(screen.getByText("Accept all"));
-
-      await waitFor(() => {
-        expect(screen.queryByText("Help us improve Ledger")).toBeNull();
-      });
-      expect(store.getState().settings.analyticsEnabled).toBe(true);
-      expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
-    });
-
-    it.each([
-      {
-        analyticsEnabled: false,
-        personalizedRecommendationsEnabled: false,
-      },
-      {
-        analyticsEnabled: true,
-        personalizedRecommendationsEnabled: false,
-      },
-      {
-        analyticsEnabled: false,
-        personalizedRecommendationsEnabled: true,
-      },
-      {
-        analyticsEnabled: true,
-        personalizedRecommendationsEnabled: true,
-      },
-    ])(
-      "should track the consent drawer page as mandatory telemetry when consent is $analyticsEnabled/$personalizedRecommendationsEnabled",
-      async ({ analyticsEnabled, personalizedRecommendationsEnabled }) => {
-        renderWithReactQuery(<IntegrationNavigator />, {
+    describe("when analytics and recommendations are disabled", () => {
+      it("should opt in when the user accepts", async () => {
+        const { user, store } = renderWithReactQuery(<IntegrationNavigator />, {
           overrideInitialState: composePortfolioOverrides({
             hasCompletedOnboarding: true,
             analyticsOptInEnabled: true,
-            analyticsEnabled,
-            personalizedRecommendationsEnabled,
+            analyticsEnabled: false,
+            personalizedRecommendationsEnabled: false,
             consentDate: null,
             privacyPolicyVersion: 1,
           }),
         });
 
+        const drawerTitle = await screen.findByText(FRESH_CONSENT_TITLE);
+        expect(drawerTitle).toBeVisible();
+        expect(analytics.screen).toHaveBeenCalledWith(
+          "AnalyticsConsentDrawer",
+          "Analytics consent",
+          expect.objectContaining({
+            phase: "consentFresh",
+            type: "drawer",
+          }),
+          true,
+          false,
+          false,
+          true,
+        );
+
+        await user.press(screen.getByRole("button", { name: "Accept all" }));
+        expect(analytics.track).toHaveBeenCalledWith(
+          "button_clicked",
+          {
+            button: "analytics_consent_opt_in",
+            page: ANALYTICS_CONSENT_DRAWER_PAGE,
+            privacyPolicyVersion: 1,
+          },
+          true,
+        );
+
         await waitFor(() => {
-          expect(analytics.screen).toHaveBeenCalledWith(
-            "AnalyticsConsentDrawer",
-            "Analytics consent",
-            expect.objectContaining({
-              type: "drawer",
-            }),
-            true,
-            false,
-            false,
-            true,
-          );
+          expect(drawerTitle).not.toBeOnTheScreen();
         });
-      },
-    );
-
-    it("should opt out and close the drawer when the user taps Refuse all on the fresh consent sheet", async () => {
-      const { user, store } = renderWithReactQuery(<IntegrationNavigator />, {
-        overrideInitialState: overridePortfolioWithAnalyticsConsentDrawer,
+        expect(store.getState().settings.analyticsEnabled).toBe(true);
+        expect(store.getState().settings.personalizedRecommendationsEnabled).toBe(true);
+        expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
+        expect(analytics.updateIdentify).toHaveBeenCalledTimes(1);
       });
 
-      await screen.findByTestId("PortfolioEmptyList");
-      await screen.findByText("Help us improve Ledger");
+      it("should opt out when the user refuses", async () => {
+        const { user, store } = renderWithReactQuery(<IntegrationNavigator />, {
+          overrideInitialState: composePortfolioOverrides({
+            hasCompletedOnboarding: true,
+            analyticsOptInEnabled: true,
+            analyticsEnabled: false,
+            personalizedRecommendationsEnabled: false,
+            consentDate: null,
+            privacyPolicyVersion: 1,
+          }),
+        });
 
-      await user.press(screen.getByText("Refuse all"));
+        const drawerTitle = await screen.findByText(FRESH_CONSENT_TITLE);
+        expect(drawerTitle).toBeVisible();
+        expect(analytics.screen).toHaveBeenCalledWith(
+          "AnalyticsConsentDrawer",
+          "Analytics consent",
+          expect.objectContaining({
+            phase: "consentFresh",
+            type: "drawer",
+          }),
+          true,
+          false,
+          false,
+          true,
+        );
 
-      await waitFor(() => {
-        expect(screen.queryByText("Help us improve Ledger")).toBeNull();
+        await user.press(screen.getByRole("button", { name: "Refuse all" }));
+        expect(analytics.track).toHaveBeenCalledWith(
+          "button_clicked",
+          {
+            button: "analytics_consent_opt_out",
+            page: ANALYTICS_CONSENT_DRAWER_PAGE,
+            privacyPolicyVersion: 1,
+          },
+          true,
+        );
+
+        await waitFor(() => {
+          expect(drawerTitle).not.toBeOnTheScreen();
+        });
+        expect(store.getState().settings.analyticsEnabled).toBe(false);
+        expect(store.getState().settings.personalizedRecommendationsEnabled).toBe(false);
+        expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
+        expect(analytics.updateIdentify).toHaveBeenCalledTimes(1);
       });
-      expect(store.getState().settings.analyticsEnabled).toBe(false);
-      expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
+
+      it("should open preferences when the user chooses Set preferences", async () => {
+        const { user } = renderWithReactQuery(<IntegrationNavigator />, {
+          overrideInitialState: composePortfolioOverrides({
+            hasCompletedOnboarding: true,
+            analyticsOptInEnabled: true,
+            analyticsEnabled: false,
+            personalizedRecommendationsEnabled: false,
+            consentDate: null,
+            privacyPolicyVersion: 1,
+          }),
+        });
+
+        const drawerTitle = await screen.findByText(FRESH_CONSENT_TITLE);
+        expect(drawerTitle).toBeVisible();
+        expect(analytics.screen).toHaveBeenCalledWith(
+          "AnalyticsConsentDrawer",
+          "Analytics consent",
+          expect.objectContaining({
+            phase: "consentFresh",
+            type: "drawer",
+          }),
+          true,
+          false,
+          false,
+          true,
+        );
+
+        await user.press(screen.getByRole("link", { name: "Set preferences" }));
+        expect(analytics.track).toHaveBeenCalledWith("button_clicked", {
+          button: "analytics_consent_set_preferences",
+          page: ANALYTICS_CONSENT_DRAWER_PAGE,
+        });
+
+        await waitFor(() => {
+          expect(drawerTitle).not.toBeOnTheScreen();
+        });
+        expect(await screen.findByTestId("analytics-preferences-screen-title")).toBeVisible();
+      });
     });
 
-    it("should close the drawer and open analytics preferences when the user taps Set preferences", async () => {
-      const { user } = renderWithReactQuery(<IntegrationNavigator />, {
-        overrideInitialState: overridePortfolioWithAnalyticsConsentDrawer,
+    describe("when analytics is disabled and recommendations are enabled", () => {
+      it("should opt in when the user accepts", async () => {
+        const { user, store } = renderWithReactQuery(<IntegrationNavigator />, {
+          overrideInitialState: composePortfolioOverrides({
+            hasCompletedOnboarding: true,
+            analyticsOptInEnabled: true,
+            analyticsEnabled: false,
+            personalizedRecommendationsEnabled: true,
+            consentDate: null,
+            privacyPolicyVersion: 1,
+          }),
+        });
+
+        const drawerTitle = await screen.findByText(FRESH_CONSENT_TITLE);
+        expect(drawerTitle).toBeVisible();
+        expect(analytics.screen).toHaveBeenCalledWith(
+          "AnalyticsConsentDrawer",
+          "Analytics consent",
+          expect.objectContaining({
+            phase: "consentFresh",
+            type: "drawer",
+          }),
+          true,
+          false,
+          false,
+          true,
+        );
+
+        await user.press(screen.getByRole("button", { name: "Accept all" }));
+        expect(analytics.track).toHaveBeenCalledWith(
+          "button_clicked",
+          {
+            button: "analytics_consent_opt_in",
+            page: ANALYTICS_CONSENT_DRAWER_PAGE,
+            privacyPolicyVersion: 1,
+          },
+          true,
+        );
+
+        await waitFor(() => {
+          expect(drawerTitle).not.toBeOnTheScreen();
+        });
+        expect(store.getState().settings.analyticsEnabled).toBe(true);
+        expect(store.getState().settings.personalizedRecommendationsEnabled).toBe(true);
+        expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
+        expect(analytics.updateIdentify).toHaveBeenCalledTimes(1);
       });
 
-      await screen.findByTestId("PortfolioEmptyList");
-      await screen.findByText("Help us improve Ledger");
+      it("should opt out when the user refuses", async () => {
+        const { user, store } = renderWithReactQuery(<IntegrationNavigator />, {
+          overrideInitialState: composePortfolioOverrides({
+            hasCompletedOnboarding: true,
+            analyticsOptInEnabled: true,
+            analyticsEnabled: false,
+            personalizedRecommendationsEnabled: true,
+            consentDate: null,
+            privacyPolicyVersion: 1,
+          }),
+        });
 
-      await user.press(screen.getByText("Set preferences"));
+        const drawerTitle = await screen.findByText(FRESH_CONSENT_TITLE);
+        expect(drawerTitle).toBeVisible();
+        expect(analytics.screen).toHaveBeenCalledWith(
+          "AnalyticsConsentDrawer",
+          "Analytics consent",
+          expect.objectContaining({
+            phase: "consentFresh",
+            type: "drawer",
+          }),
+          true,
+          false,
+          false,
+          true,
+        );
 
-      await waitFor(() => {
-        expect(screen.queryByText("Help us improve Ledger")).toBeNull();
+        await user.press(screen.getByRole("button", { name: "Refuse all" }));
+        expect(analytics.track).toHaveBeenCalledWith(
+          "button_clicked",
+          {
+            button: "analytics_consent_opt_out",
+            page: ANALYTICS_CONSENT_DRAWER_PAGE,
+            privacyPolicyVersion: 1,
+          },
+          true,
+        );
+
+        await waitFor(() => {
+          expect(drawerTitle).not.toBeOnTheScreen();
+        });
+        expect(store.getState().settings.analyticsEnabled).toBe(false);
+        expect(store.getState().settings.personalizedRecommendationsEnabled).toBe(false);
+        expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
+        expect(analytics.updateIdentify).toHaveBeenCalledTimes(1);
       });
-      expect(await screen.findByTestId("analytics-preferences-screen-title")).toBeVisible();
-      expect(analytics.screen).toHaveBeenCalledWith(
-        "Analytics preferences settings",
-        "Set preferences",
-        {},
-        true,
-        true,
-        false,
-        true,
-      );
-    });
 
-    it("should return to Portfolio after Set preferences and Confirm with toggles left off", async () => {
-      jest.spyOn(analytics, "updateIdentify").mockResolvedValue(undefined);
+      it("should open preferences when the user chooses Set preferences", async () => {
+        const { user } = renderWithReactQuery(<IntegrationNavigator />, {
+          overrideInitialState: composePortfolioOverrides({
+            hasCompletedOnboarding: true,
+            analyticsOptInEnabled: true,
+            analyticsEnabled: false,
+            personalizedRecommendationsEnabled: true,
+            consentDate: null,
+            privacyPolicyVersion: 1,
+          }),
+        });
 
-      const { user, store } = renderWithReactQuery(<IntegrationNavigator />, {
-        overrideInitialState: overridePortfolioWithAnalyticsConsentDrawer,
+        const drawerTitle = await screen.findByText(FRESH_CONSENT_TITLE);
+        expect(drawerTitle).toBeVisible();
+        expect(analytics.screen).toHaveBeenCalledWith(
+          "AnalyticsConsentDrawer",
+          "Analytics consent",
+          expect.objectContaining({
+            phase: "consentFresh",
+            type: "drawer",
+          }),
+          true,
+          false,
+          false,
+          true,
+        );
+
+        await user.press(screen.getByRole("link", { name: "Set preferences" }));
+        expect(analytics.track).toHaveBeenCalledWith("button_clicked", {
+          button: "analytics_consent_set_preferences",
+          page: ANALYTICS_CONSENT_DRAWER_PAGE,
+        });
+
+        await waitFor(() => {
+          expect(drawerTitle).not.toBeOnTheScreen();
+        });
+        expect(await screen.findByTestId("analytics-preferences-screen-title")).toBeVisible();
       });
-
-      await screen.findByTestId("PortfolioEmptyList");
-      await screen.findByText("Help us improve Ledger");
-
-      await user.press(screen.getByText("Set preferences"));
-
-      expect(await screen.findByTestId("analytics-preferences-screen-title")).toBeVisible();
-
-      await user.press(screen.getByRole("button", { name: "Confirm" }));
-
-      await waitFor(() => {
-        expect(screen.queryByTestId("analytics-preferences-screen-title")).toBeNull();
-      });
-      expect(await screen.findByTestId("PortfolioEmptyList")).toBeVisible();
-
-      expect(store.getState().settings.analyticsEnabled).toBe(false);
-      expect(store.getState().settings.personalizedRecommendationsEnabled).toBe(false);
-      expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
     });
   });
 
   describe("needs reconfirmation", () => {
-    it("should keep analytics on when the user taps Yes, continue on reconfirm", async () => {
-      const { user, store } = renderWithReactQuery(<IntegrationNavigator />, {
-        overrideInitialState: overridePortfolioWithAnalyticsConsentReconfirm,
+    describe("when analytics is enabled and recommendations are disabled", () => {
+      it("should keep analytics enabled when the user accepts", async () => {
+        const { user, store } = renderWithReactQuery(<IntegrationNavigator />, {
+          overrideInitialState: composePortfolioOverrides({
+            hasCompletedOnboarding: true,
+            analyticsOptInEnabled: true,
+            analyticsEnabled: true,
+            personalizedRecommendationsEnabled: false,
+            consentDate: null,
+            privacyPolicyVersion: 1,
+          }),
+        });
+
+        const drawerTitle = await screen.findByText(RECONFIRM_TITLE);
+        expect(drawerTitle).toBeVisible();
+        expect(analytics.screen).toHaveBeenCalledWith(
+          "AnalyticsConsentDrawer",
+          "Analytics consent",
+          expect.objectContaining({
+            phase: "consentReconfirm",
+            type: "drawer",
+          }),
+          true,
+          false,
+          false,
+          true,
+        );
+
+        await user.press(screen.getByRole("button", { name: "Yes, continue" }));
+        expect(analytics.track).toHaveBeenCalledWith(
+          "button_clicked",
+          {
+            button: "analytics_consent_opt_in",
+            page: ANALYTICS_CONSENT_DRAWER_PAGE,
+            privacyPolicyVersion: 1,
+          },
+          true,
+        );
+
+        await waitFor(() => {
+          expect(drawerTitle).not.toBeOnTheScreen();
+        });
+        expect(store.getState().settings.analyticsEnabled).toBe(true);
+        expect(store.getState().settings.personalizedRecommendationsEnabled).toBe(true);
+        expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
+        expect(analytics.updateIdentify).toHaveBeenCalledTimes(1);
       });
 
-      await screen.findByTestId("PortfolioEmptyList");
-      expect(await screen.findByText("Continue improving Ledger?")).toBeVisible();
+      it("should opt out when the user refuses", async () => {
+        const { user, store } = renderWithReactQuery(<IntegrationNavigator />, {
+          overrideInitialState: composePortfolioOverrides({
+            hasCompletedOnboarding: true,
+            analyticsOptInEnabled: true,
+            analyticsEnabled: true,
+            personalizedRecommendationsEnabled: false,
+            consentDate: null,
+            privacyPolicyVersion: 1,
+          }),
+        });
 
-      await user.press(screen.getByText("Yes, continue"));
+        const drawerTitle = await screen.findByText(RECONFIRM_TITLE);
+        expect(drawerTitle).toBeVisible();
+        expect(analytics.screen).toHaveBeenCalledWith(
+          "AnalyticsConsentDrawer",
+          "Analytics consent",
+          expect.objectContaining({
+            phase: "consentReconfirm",
+            type: "drawer",
+          }),
+          true,
+          false,
+          false,
+          true,
+        );
 
-      await waitFor(() => {
-        expect(screen.queryByText("Continue improving Ledger?")).toBeNull();
+        await user.press(screen.getByRole("button", { name: "No, stop" }));
+        expect(analytics.track).toHaveBeenCalledWith(
+          "button_clicked",
+          {
+            button: "analytics_consent_opt_out",
+            page: ANALYTICS_CONSENT_DRAWER_PAGE,
+            privacyPolicyVersion: 1,
+          },
+          true,
+        );
+
+        await waitFor(() => {
+          expect(drawerTitle).not.toBeOnTheScreen();
+        });
+        expect(store.getState().settings.analyticsEnabled).toBe(false);
+        expect(store.getState().settings.personalizedRecommendationsEnabled).toBe(false);
+        expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
+        expect(analytics.updateIdentify).toHaveBeenCalledTimes(1);
       });
-      expect(store.getState().settings.analyticsEnabled).toBe(true);
-      expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
+
+      it("should open preferences when the user chooses Set preferences", async () => {
+        const { user } = renderWithReactQuery(<IntegrationNavigator />, {
+          overrideInitialState: composePortfolioOverrides({
+            hasCompletedOnboarding: true,
+            analyticsOptInEnabled: true,
+            analyticsEnabled: true,
+            personalizedRecommendationsEnabled: false,
+            consentDate: null,
+            privacyPolicyVersion: 1,
+          }),
+        });
+
+        const drawerTitle = await screen.findByText(RECONFIRM_TITLE);
+        expect(drawerTitle).toBeVisible();
+        expect(analytics.screen).toHaveBeenCalledWith(
+          "AnalyticsConsentDrawer",
+          "Analytics consent",
+          expect.objectContaining({
+            phase: "consentReconfirm",
+            type: "drawer",
+          }),
+          true,
+          false,
+          false,
+          true,
+        );
+
+        await user.press(screen.getByRole("link", { name: "Set preferences" }));
+        expect(analytics.track).toHaveBeenCalledWith("button_clicked", {
+          button: "analytics_consent_set_preferences",
+          page: ANALYTICS_CONSENT_DRAWER_PAGE,
+        });
+
+        await waitFor(() => {
+          expect(drawerTitle).not.toBeOnTheScreen();
+        });
+        expect(await screen.findByTestId("analytics-preferences-screen-title")).toBeVisible();
+      });
     });
 
-    it("should opt out when the user taps No, stop on reconfirm", async () => {
-      const { user, store } = renderWithReactQuery(<IntegrationNavigator />, {
-        overrideInitialState: overridePortfolioWithAnalyticsConsentReconfirm,
+    describe("when analytics and recommendations are enabled", () => {
+      it("should keep analytics enabled when the user accepts", async () => {
+        const { user, store } = renderWithReactQuery(<IntegrationNavigator />, {
+          overrideInitialState: composePortfolioOverrides({
+            hasCompletedOnboarding: true,
+            analyticsOptInEnabled: true,
+            analyticsEnabled: true,
+            personalizedRecommendationsEnabled: true,
+            consentDate: null,
+            privacyPolicyVersion: 1,
+          }),
+        });
+
+        const drawerTitle = await screen.findByText(RECONFIRM_TITLE);
+        expect(drawerTitle).toBeVisible();
+        expect(analytics.screen).toHaveBeenCalledWith(
+          "AnalyticsConsentDrawer",
+          "Analytics consent",
+          expect.objectContaining({
+            phase: "consentReconfirm",
+            type: "drawer",
+          }),
+          true,
+          false,
+          false,
+          true,
+        );
+
+        await user.press(screen.getByRole("button", { name: "Yes, continue" }));
+        expect(analytics.track).toHaveBeenCalledWith(
+          "button_clicked",
+          {
+            button: "analytics_consent_opt_in",
+            page: ANALYTICS_CONSENT_DRAWER_PAGE,
+            privacyPolicyVersion: 1,
+          },
+          true,
+        );
+
+        await waitFor(() => {
+          expect(drawerTitle).not.toBeOnTheScreen();
+        });
+        expect(store.getState().settings.analyticsEnabled).toBe(true);
+        expect(store.getState().settings.personalizedRecommendationsEnabled).toBe(true);
+        expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
+        expect(analytics.updateIdentify).toHaveBeenCalledTimes(1);
       });
 
-      await screen.findByTestId("PortfolioEmptyList");
-      await screen.findByText("Continue improving Ledger?");
+      it("should opt out when the user refuses", async () => {
+        const { user, store } = renderWithReactQuery(<IntegrationNavigator />, {
+          overrideInitialState: composePortfolioOverrides({
+            hasCompletedOnboarding: true,
+            analyticsOptInEnabled: true,
+            analyticsEnabled: true,
+            personalizedRecommendationsEnabled: true,
+            consentDate: null,
+            privacyPolicyVersion: 1,
+          }),
+        });
 
-      await user.press(screen.getByText("No, stop"));
+        const drawerTitle = await screen.findByText(RECONFIRM_TITLE);
+        expect(drawerTitle).toBeVisible();
+        expect(analytics.screen).toHaveBeenCalledWith(
+          "AnalyticsConsentDrawer",
+          "Analytics consent",
+          expect.objectContaining({
+            phase: "consentReconfirm",
+            type: "drawer",
+          }),
+          true,
+          false,
+          false,
+          true,
+        );
 
-      await waitFor(() => {
-        expect(screen.queryByText("Continue improving Ledger?")).toBeNull();
+        await user.press(screen.getByRole("button", { name: "No, stop" }));
+        expect(analytics.track).toHaveBeenCalledWith(
+          "button_clicked",
+          {
+            button: "analytics_consent_opt_out",
+            page: ANALYTICS_CONSENT_DRAWER_PAGE,
+            privacyPolicyVersion: 1,
+          },
+          true,
+        );
+
+        await waitFor(() => {
+          expect(drawerTitle).not.toBeOnTheScreen();
+        });
+        expect(store.getState().settings.analyticsEnabled).toBe(false);
+        expect(store.getState().settings.personalizedRecommendationsEnabled).toBe(false);
+        expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
+        expect(analytics.updateIdentify).toHaveBeenCalledTimes(1);
       });
-      expect(store.getState().settings.analyticsEnabled).toBe(false);
-      expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
+
+      it("should open preferences when the user chooses Set preferences", async () => {
+        const { user } = renderWithReactQuery(<IntegrationNavigator />, {
+          overrideInitialState: composePortfolioOverrides({
+            hasCompletedOnboarding: true,
+            analyticsOptInEnabled: true,
+            analyticsEnabled: true,
+            personalizedRecommendationsEnabled: true,
+            consentDate: null,
+            privacyPolicyVersion: 1,
+          }),
+        });
+
+        const drawerTitle = await screen.findByText(RECONFIRM_TITLE);
+        expect(drawerTitle).toBeVisible();
+        expect(analytics.screen).toHaveBeenCalledWith(
+          "AnalyticsConsentDrawer",
+          "Analytics consent",
+          expect.objectContaining({
+            phase: "consentReconfirm",
+            type: "drawer",
+          }),
+          true,
+          false,
+          false,
+          true,
+        );
+
+        await user.press(screen.getByRole("link", { name: "Set preferences" }));
+        expect(analytics.track).toHaveBeenCalledWith("button_clicked", {
+          button: "analytics_consent_set_preferences",
+          page: ANALYTICS_CONSENT_DRAWER_PAGE,
+        });
+
+        await waitFor(() => {
+          expect(drawerTitle).not.toBeOnTheScreen();
+        });
+        expect(await screen.findByTestId("analytics-preferences-screen-title")).toBeVisible();
+      });
     });
   });
 
   describe("needs privacy policy version update", () => {
     it("should show the privacy update sheet, persist the policy version, and close after Got it", async () => {
       const { user, store } = renderWithReactQuery(<IntegrationNavigator />, {
-        overrideInitialState: overridePortfolioWithPrivacySheet,
-      });
-
-      await screen.findByTestId("PortfolioEmptyList");
-      await screen.findByText("We're updating our privacy policy");
-
-      await user.press(screen.getByText("Got it"));
-
-      await waitFor(() => {
-        expect(screen.queryByText("We're updating our privacy policy")).toBeNull();
-      });
-      expect(store.getState().settings.analyticsConsentInfo.privacyPolicyVersion).toBe(1);
-      expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
-    });
-  });
-
-  describe("when time-based renewal applies", () => {
-    it("should show reconfirm when consent is older than one year and analytics are on", async () => {
-      renderWithReactQuery(<IntegrationNavigator />, {
         overrideInitialState: composePortfolioOverrides({
           hasCompletedOnboarding: true,
           analyticsOptInEnabled: true,
           analyticsEnabled: true,
           personalizedRecommendationsEnabled: true,
-          consentDate: consentIsoOlderThanValidityWindow(),
-          privacyPolicyVersion: 1,
+          consentDate: new Date().toISOString(),
+          privacyPolicyVersion: 0,
         }),
       });
 
-      await screen.findByTestId("PortfolioEmptyList");
-      expect(await screen.findByText("Continue improving Ledger?")).toBeVisible();
-    });
-
-    it("should show fresh consent when consent is older than one year and analytics are off", async () => {
-      renderWithReactQuery(<IntegrationNavigator />, {
-        overrideInitialState: composePortfolioOverrides({
-          hasCompletedOnboarding: true,
-          analyticsOptInEnabled: true,
-          analyticsEnabled: false,
-          personalizedRecommendationsEnabled: false,
-          consentDate: consentIsoOlderThanValidityWindow(),
-          privacyPolicyVersion: 1,
+      const privacySheetTitle = await screen.findByText(PRIVACY_UPDATE_TITLE);
+      expect(privacySheetTitle).toBeVisible();
+      expect(analytics.screen).toHaveBeenCalledWith(
+        "AnalyticsConsentDrawer",
+        "Analytics consent",
+        expect.objectContaining({
+          phase: "privacy",
+          type: "drawer",
         }),
-      });
+        true,
+        false,
+        false,
+        true,
+      );
 
-      await screen.findByTestId("PortfolioEmptyList");
-      expect(await screen.findByText("Help us improve Ledger")).toBeVisible();
+      await user.press(screen.getByRole("button", { name: "Got it" }));
+      expect(analytics.track).toHaveBeenCalledWith(
+        "button_clicked",
+        {
+          button: "analytics_consent_privacy_got_it",
+          page: ANALYTICS_CONSENT_DRAWER_PAGE,
+          privacyPolicyVersion: 1,
+        },
+        true,
+      );
+
+      await waitFor(() => {
+        expect(privacySheetTitle).not.toBeOnTheScreen();
+      });
+      expect(store.getState().settings.analyticsConsentInfo.privacyPolicyVersion).toBe(1);
+      expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
+      expect(analytics.updateIdentify).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/__tests__/useAnalyticsConsentDrawerViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/__tests__/useAnalyticsConsentDrawerViewModel.test.ts
@@ -155,7 +155,7 @@ describe("useAnalyticsConsentDrawerViewModel", () => {
           page: ANALYTICS_CONSENT_DRAWER_ANALYTICS_PAGE,
           privacyPolicyVersion: 1,
         },
-        false,
+        true,
       );
       expect(track).toHaveBeenCalledWith("drawer_closed", drawerEventPayload);
     });
@@ -322,11 +322,15 @@ describe("useAnalyticsConsentDrawerViewModel", () => {
       expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
       expect(store.getState().settings.analyticsConsentInfo.privacyPolicyVersion).toBe(1);
       expect(updateIdentify).toHaveBeenCalled();
-      expect(track).toHaveBeenCalledWith("button_clicked", {
-        button: "analytics_consent_privacy_got_it",
-        page: ANALYTICS_CONSENT_DRAWER_ANALYTICS_PAGE,
-        privacyPolicyVersion: 1,
-      });
+      expect(track).toHaveBeenCalledWith(
+        "button_clicked",
+        {
+          button: "analytics_consent_privacy_got_it",
+          page: ANALYTICS_CONSENT_DRAWER_ANALYTICS_PAGE,
+          privacyPolicyVersion: 1,
+        },
+        true,
+      );
       expect(track).toHaveBeenCalledWith("drawer_closed", drawerEventPayload);
     });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/hooks/useAnalyticsConsentDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/hooks/useAnalyticsConsentDrawerViewModel.ts
@@ -7,7 +7,6 @@ import {
   analyticsConsentInfoSelector,
   analyticsEnabledSelector,
   hasCompletedOnboardingSelector,
-  personalizedRecommendationsEnabledSelector,
 } from "~/reducers/settings";
 import {
   setAnalytics,
@@ -44,9 +43,6 @@ export function useAnalyticsConsentDrawerViewModel() {
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
   const consentInfo = useSelector(analyticsConsentInfoSelector);
   const analyticsEnabled = useSelector(analyticsEnabledSelector);
-  const personalizedRecommendationsEnabled = useSelector(
-    personalizedRecommendationsEnabledSelector,
-  );
 
   const needsUpdatePrivacy = needsPrivacyPolicyAck(consentInfo.privacyPolicyVersion, policyVersion);
   const needsRenewal = needsConsentRenewal(consentInfo.consentDate, consentValidityDays);
@@ -113,8 +109,6 @@ export function useAnalyticsConsentDrawerViewModel() {
   }, [dispatch, persistConsentCompletion, handleCloseDrawer, policyVersion]);
 
   const applyOptOut = useCallback(async () => {
-    const isPreviouslyOptedOutCompletely = !analyticsEnabled && !personalizedRecommendationsEnabled;
-    const trackMandatory = !isPreviouslyOptedOutCompletely;
     track(
       "button_clicked",
       {
@@ -122,27 +116,24 @@ export function useAnalyticsConsentDrawerViewModel() {
         page: ANALYTICS_CONSENT_DRAWER_ANALYTICS_PAGE,
         privacyPolicyVersion: policyVersion,
       },
-      trackMandatory,
+      true,
     );
     dispatch(setAnalytics(false));
     dispatch(setPersonalizedRecommendations(false));
     await persistConsentCompletion();
     handleCloseDrawer();
-  }, [
-    analyticsEnabled,
-    dispatch,
-    handleCloseDrawer,
-    personalizedRecommendationsEnabled,
-    persistConsentCompletion,
-    policyVersion,
-  ]);
+  }, [dispatch, handleCloseDrawer, persistConsentCompletion, policyVersion]);
 
   const onPrivacyGotIt = useCallback(async () => {
-    track("button_clicked", {
-      button: "analytics_consent_privacy_got_it",
-      page: ANALYTICS_CONSENT_DRAWER_ANALYTICS_PAGE,
-      privacyPolicyVersion: policyVersion,
-    });
+    track(
+      "button_clicked",
+      {
+        button: "analytics_consent_privacy_got_it",
+        page: ANALYTICS_CONSENT_DRAWER_ANALYTICS_PAGE,
+        privacyPolicyVersion: policyVersion,
+      },
+      true,
+    );
     dispatch(
       setAnalyticsConsentInfo({
         consentDate: new Date().toISOString(),

--- a/apps/ledger-live-mobile/src/screens/Settings/AnalyticsPreferencesSettings/__tests__/AnalyticsPreferencesSettings.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/AnalyticsPreferencesSettings/__tests__/AnalyticsPreferencesSettings.test.tsx
@@ -42,7 +42,10 @@ function SettingsTestStack() {
     >
       <Stack.Navigator screenOptions={{ headerShown: false }}>
         <Stack.Screen name={ScreenName.GeneralSettings} component={GeneralSettingsStub} />
-        <Stack.Screen name={ScreenName.AnalyticsPreferencesSettings} component={AnalyticsPreferencesSettings} />
+        <Stack.Screen
+          name={ScreenName.AnalyticsPreferencesSettings}
+          component={AnalyticsPreferencesSettings}
+        />
       </Stack.Navigator>
     </SafeAreaProvider>
   );
@@ -85,7 +88,9 @@ describe("AnalyticsPreferencesSettings", () => {
     it("shows title and confirm CTA", () => {
       renderAnalyticsPreferencesSettings();
 
-      expect(screen.getByTestId("analytics-preferences-screen-title")).toHaveTextContent("Set preferences");
+      expect(screen.getByTestId("analytics-preferences-screen-title")).toHaveTextContent(
+        "Set preferences",
+      );
       expect(screen.getByRole("button", { name: "Confirm" })).toBeTruthy();
     });
 
@@ -135,7 +140,7 @@ describe("AnalyticsPreferencesSettings", () => {
 
   describe("footer", () => {
     it("opens the privacy policy URL when the footer link is pressed", async () => {
-      const openSpy = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined as never);
+      const openSpy = jest.spyOn(Linking, "openURL").mockImplementation(async () => undefined);
       try {
         const { user } = renderAnalyticsPreferencesSettings();
 
@@ -227,6 +232,32 @@ describe("AnalyticsPreferencesSettings", () => {
       await waitFor(() => {
         expect(screen.queryByTestId("analytics-preferences-screen-title")).toBeNull();
       });
+    });
+
+    it("should track confirm as mandatory when preferences were already fully disabled", async () => {
+      const { user } = renderAnalyticsPreferencesSettings({
+        overrideInitialState: state => ({
+          ...state,
+          settings: {
+            ...state.settings,
+            analyticsEnabled: false,
+            personalizedRecommendationsEnabled: false,
+          },
+        }),
+      });
+
+      await user.press(screen.getByRole("button", { name: "Confirm" }));
+
+      expect(analytics.track).toHaveBeenCalledWith(
+        "button_clicked",
+        expect.objectContaining({
+          button: "analytics_preferences_confirm",
+          appPerformance: false,
+          personalizedExperience: false,
+        }),
+        true,
+      );
+      expect(analytics.updateIdentify).toHaveBeenCalledWith(undefined, true);
     });
   });
 });

--- a/apps/ledger-live-mobile/src/screens/Settings/AnalyticsPreferencesSettings/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/AnalyticsPreferencesSettings/index.tsx
@@ -50,12 +50,6 @@ export default function AnalyticsPreferencesSettings({ navigation, route }: Prop
   );
 
   const onConfirm = useCallback(async () => {
-    const wasFullyOptedOut = !analyticsFromStore && !personalizedFromStore;
-    const willBeFullyOptedOut = !appPerformanceEnabled && !personalizedEnabled;
-    // Same idea as analytics consent `applyOptOut`: do not force tracking when the user was already
-    // fully opted out in the store and confirms without enabling either toggle.
-    const mandatory = !(wasFullyOptedOut && willBeFullyOptedOut);
-
     await track(
       "button_clicked",
       {
@@ -64,7 +58,7 @@ export default function AnalyticsPreferencesSettings({ navigation, route }: Prop
         appPerformance: appPerformanceEnabled,
         personalizedExperience: personalizedEnabled,
       },
-      mandatory,
+      true,
     );
     dispatch(setAnalytics(appPerformanceEnabled));
     dispatch(setPersonalizedRecommendations(personalizedEnabled));
@@ -75,17 +69,9 @@ export default function AnalyticsPreferencesSettings({ navigation, route }: Prop
       }),
     );
     dispatch(setHasSeenAnalyticsOptInPrompt(true));
-    await updateIdentify(undefined, mandatory);
+    await updateIdentify(undefined, true);
     navigation.goBack();
-  }, [
-    analyticsFromStore,
-    appPerformanceEnabled,
-    dispatch,
-    navigation,
-    personalizedEnabled,
-    personalizedFromStore,
-    policyVersion,
-  ]);
+  }, [appPerformanceEnabled, dispatch, navigation, personalizedEnabled, policyVersion]);
 
   return (
     <Box lx={{ flex: 1, backgroundColor: "canvas" }}>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Partial: desktop and mobile typechecks pass; no dedicated analytics event unit coverage was added._
- [x] **Impact of the changes:**
  - Desktop Analytics Consent dialog opt-out, privacy acknowledgement, and preference confirmation tracking
  - Mobile Analytics Consent drawer opt-out and privacy acknowledgement tracking
  - Mobile Analytics Preferences confirmation tracking and identify update behavior

### 📝 Description

This PR fixes analytics consent confirmation events that could be skipped when users were already fully opted out or when they confirmed disabled analytics preferences.

The affected desktop and mobile consent flows now send these confirmation events as mandatory tracking events so privacy acknowledgement, opt-out, and preference confirmation actions are recorded consistently.


https://github.com/user-attachments/assets/2c636f8c-e2ae-49eb-b0a7-d06d4b1d3692


### ❓ Context

- **JIRA or GitHub link**: [LIVE-30461](https://ledgerhq.atlassian.net/browse/LIVE-30461)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-30461]: https://ledgerhq.atlassian.net/browse/LIVE-30461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ