### PR TITLE
[LWD] chore(lwd): add Datadog log client

### DIFF
--- a/.changeset/nervous-cars-agree.md
+++ b/.changeset/nervous-cars-agree.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+chore(lwd): add Datadog log client

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -57,6 +57,7 @@
     "test-deep-links": "ws --spa ledger-live-desktop-deeplinks.html"
   },
   "dependencies": {
+    "@datadog/browser-logs": "6.30.1",
     "@datadog/browser-rum": "6.30.1",
     "@braze/web-sdk": "6.4.0",
     "@electron/fuses": "2.0.0",

--- a/apps/ledger-live-desktop/src/datadog/config.test.ts
+++ b/apps/ledger-live-desktop/src/datadog/config.test.ts
@@ -19,13 +19,14 @@ describe("datadog config", () => {
   });
 
   describe("getDatadogBuildConfig", () => {
-    it("should return config from build globals (null in Jest)", () => {
+    it("should return config from build globals (null in Jest) and default values", () => {
       const result = getDatadogBuildConfig();
       expect(result).toEqual({
         applicationId: null,
         clientToken: null,
-        site: null,
-        env: null,
+        env: "production",
+        service: "ledger-live-desktop",
+        site: "datadoghq.eu",
       });
     });
   });

--- a/apps/ledger-live-desktop/src/datadog/config.ts
+++ b/apps/ledger-live-desktop/src/datadog/config.ts
@@ -13,7 +13,7 @@ function getEventMessage(ev: Record<string, unknown>): string {
 }
 
 /**
- * Builds the beforeSend callback for Datadog RUM.
+ * Builds the beforeSend callback for Datadog RUM / Log.
  * Drops events when opt-in is off or error message matches ignore list;
  * applies anonymization to the payload (parity with Sentry).
  */

--- a/apps/ledger-live-desktop/src/datadog/config.ts
+++ b/apps/ledger-live-desktop/src/datadog/config.ts
@@ -41,13 +41,15 @@ export function buildBeforeSend(shouldSend: ShouldSendCallback) {
 export function getDatadogBuildConfig(): {
   applicationId: string | null | undefined;
   clientToken: string | null | undefined;
-  site: string | null | undefined;
-  env: string | null | undefined;
+  site: string;
+  service: string;
+  env: string;
 } {
   return {
     applicationId: __DATADOG_APPLICATION_ID__,
     clientToken: __DATADOG_CLIENT_TOKEN__,
-    site: __DATADOG_SITE__,
-    env: __DATADOG_ENV__,
+    site: __DATADOG_SITE__ ?? "datadoghq.eu",
+    service: "ledger-live-desktop",
+    env: __DATADOG_ENV__ ?? (__DEV__ ? "development" : "production"),
   };
 }

--- a/apps/ledger-live-desktop/src/datadog/logs.test.ts
+++ b/apps/ledger-live-desktop/src/datadog/logs.test.ts
@@ -34,8 +34,9 @@ describe("datadog logs", () => {
       getDatadogBuildConfig.mockReturnValue({
         applicationId: null,
         clientToken: null,
-        site: null,
-        env: null,
+        site: "datadoghq.eu",
+        service: "ledger-live-desktop",
+        env: "production",
       });
       expect(isDatadogLogsAvailable()).toBe(false);
     });
@@ -44,8 +45,9 @@ describe("datadog logs", () => {
       getDatadogBuildConfig.mockReturnValue({
         applicationId: null,
         clientToken: "token",
-        site: null,
-        env: null,
+        site: "datadoghq.eu",
+        service: "ledger-live-desktop",
+        env: "production",
       });
       getOperatingSystemSupportStatus.mockReturnValue({ supported: false });
       expect(isDatadogLogsAvailable()).toBe(false);
@@ -55,8 +57,9 @@ describe("datadog logs", () => {
       getDatadogBuildConfig.mockReturnValue({
         applicationId: null,
         clientToken: "token",
-        site: null,
-        env: null,
+        site: "datadoghq.eu",
+        service: "ledger-live-desktop",
+        env: "production",
       });
       expect(isDatadogLogsAvailable()).toBe(true);
     });
@@ -68,6 +71,7 @@ describe("datadog logs", () => {
         applicationId: null,
         clientToken: "token",
         site: "datadoghq.eu",
+        service: "ledger-live-desktop",
         env: "production",
       });
       expect(initDatadogLogs(() => false)).toBe(false);
@@ -78,8 +82,9 @@ describe("datadog logs", () => {
       getDatadogBuildConfig.mockReturnValue({
         applicationId: null,
         clientToken: null,
-        site: null,
-        env: null,
+        site: "datadoghq.eu",
+        service: "ledger-live-desktop",
+        env: "production",
       });
       expect(initDatadogLogs(() => true)).toBe(false);
       expect(datadogLogs.init).not.toHaveBeenCalled();
@@ -89,8 +94,9 @@ describe("datadog logs", () => {
       getDatadogBuildConfig.mockReturnValue({
         applicationId: null,
         clientToken: "token",
-        site: null,
-        env: null,
+        site: "datadoghq.eu",
+        service: "ledger-live-desktop",
+        env: "production",
       });
       getOperatingSystemSupportStatus.mockReturnValue({ supported: false });
       expect(initDatadogLogs(() => true)).toBe(false);
@@ -102,6 +108,7 @@ describe("datadog logs", () => {
         applicationId: null,
         clientToken: "token",
         site: "datadoghq.eu",
+        service: "ledger-live-desktop",
         env: "production",
       });
       datadogLogs.init.mockImplementationOnce(() => {
@@ -119,6 +126,7 @@ describe("datadog logs", () => {
         applicationId: null,
         clientToken: "token",
         site: "datadoghq.eu",
+        service: "ledger-live-desktop",
         env: "production",
       });
     });
@@ -137,22 +145,6 @@ describe("datadog logs", () => {
       );
       expect(datadogLogs.setGlobalContext).toHaveBeenCalledWith(
         expect.objectContaining({ git_commit: expect.any(String) }),
-      );
-    });
-
-    it("should fall back to defaults for missing site/env", () => {
-      getDatadogBuildConfig.mockReturnValue({
-        applicationId: null,
-        clientToken: "token",
-        site: null,
-        env: null,
-      });
-      initDatadogLogs(() => true);
-      expect(datadogLogs.init).toHaveBeenCalledWith(
-        expect.objectContaining({
-          site: "datadoghq.eu",
-          env: expect.any(String),
-        }),
       );
     });
 

--- a/apps/ledger-live-desktop/src/datadog/logs.test.ts
+++ b/apps/ledger-live-desktop/src/datadog/logs.test.ts
@@ -1,0 +1,166 @@
+import { __resetDatadogLogsForTesting, initDatadogLogs, isDatadogLogsAvailable } from "./logs";
+
+jest.mock("./config", () => ({
+  getDatadogBuildConfig: jest.fn(),
+  buildBeforeSend: jest.fn(() => () => true),
+}));
+
+jest.mock("~/support/os", () => ({
+  getOperatingSystemSupportStatus: jest.fn(() => ({ supported: true })),
+}));
+
+jest.mock("@datadog/browser-logs", () => ({
+  datadogLogs: {
+    init: jest.fn(),
+    setGlobalContext: jest.fn(),
+  },
+}));
+
+const getDatadogBuildConfig = jest.mocked(jest.requireMock("./config").getDatadogBuildConfig);
+const getOperatingSystemSupportStatus = jest.mocked(
+  jest.requireMock("~/support/os").getOperatingSystemSupportStatus,
+);
+const datadogLogs = jest.requireMock("@datadog/browser-logs").datadogLogs;
+
+describe("datadog logs", () => {
+  beforeEach(() => {
+    __resetDatadogLogsForTesting();
+    jest.clearAllMocks();
+    getOperatingSystemSupportStatus.mockReturnValue({ supported: true });
+  });
+
+  describe("isDatadogLogsAvailable", () => {
+    it("should return false when clientToken is missing", () => {
+      getDatadogBuildConfig.mockReturnValue({
+        applicationId: null,
+        clientToken: null,
+        site: null,
+        env: null,
+      });
+      expect(isDatadogLogsAvailable()).toBe(false);
+    });
+
+    it("should return false when OS is not supported", () => {
+      getDatadogBuildConfig.mockReturnValue({
+        applicationId: null,
+        clientToken: "token",
+        site: null,
+        env: null,
+      });
+      getOperatingSystemSupportStatus.mockReturnValue({ supported: false });
+      expect(isDatadogLogsAvailable()).toBe(false);
+    });
+
+    it("should return true when clientToken is set and OS is supported", () => {
+      getDatadogBuildConfig.mockReturnValue({
+        applicationId: null,
+        clientToken: "token",
+        site: null,
+        env: null,
+      });
+      expect(isDatadogLogsAvailable()).toBe(true);
+    });
+  });
+
+  describe("initDatadogLogs failure paths", () => {
+    it("should return false when shouldSend() is false", () => {
+      getDatadogBuildConfig.mockReturnValue({
+        applicationId: null,
+        clientToken: "token",
+        site: "datadoghq.eu",
+        env: "production",
+      });
+      expect(initDatadogLogs(() => false)).toBe(false);
+      expect(datadogLogs.init).not.toHaveBeenCalled();
+    });
+
+    it("should return false when clientToken is missing", () => {
+      getDatadogBuildConfig.mockReturnValue({
+        applicationId: null,
+        clientToken: null,
+        site: null,
+        env: null,
+      });
+      expect(initDatadogLogs(() => true)).toBe(false);
+      expect(datadogLogs.init).not.toHaveBeenCalled();
+    });
+
+    it("should return false when OS is not supported", () => {
+      getDatadogBuildConfig.mockReturnValue({
+        applicationId: null,
+        clientToken: "token",
+        site: null,
+        env: null,
+      });
+      getOperatingSystemSupportStatus.mockReturnValue({ supported: false });
+      expect(initDatadogLogs(() => true)).toBe(false);
+      expect(datadogLogs.init).not.toHaveBeenCalled();
+    });
+
+    it("should return false when init throws", () => {
+      getDatadogBuildConfig.mockReturnValue({
+        applicationId: null,
+        clientToken: "token",
+        site: "datadoghq.eu",
+        env: "production",
+      });
+      datadogLogs.init.mockImplementationOnce(() => {
+        throw new Error("init failed");
+      });
+      const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+      expect(initDatadogLogs(() => true)).toBe(false);
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("initDatadogLogs success and when initialized", () => {
+    beforeEach(() => {
+      getDatadogBuildConfig.mockReturnValue({
+        applicationId: null,
+        clientToken: "token",
+        site: "datadoghq.eu",
+        env: "production",
+      });
+    });
+
+    it("should init Logs with config values and set global context", () => {
+      const result = initDatadogLogs(() => true);
+      expect(result).toBe(true);
+      expect(datadogLogs.init).toHaveBeenCalledWith(
+        expect.objectContaining({
+          clientToken: "token",
+          site: "datadoghq.eu",
+          service: "ledger-live-desktop",
+          env: "production",
+          forwardErrorsToLogs: false,
+        }),
+      );
+      expect(datadogLogs.setGlobalContext).toHaveBeenCalledWith(
+        expect.objectContaining({ git_commit: expect.any(String) }),
+      );
+    });
+
+    it("should fall back to defaults for missing site/env", () => {
+      getDatadogBuildConfig.mockReturnValue({
+        applicationId: null,
+        clientToken: "token",
+        site: null,
+        env: null,
+      });
+      initDatadogLogs(() => true);
+      expect(datadogLogs.init).toHaveBeenCalledWith(
+        expect.objectContaining({
+          site: "datadoghq.eu",
+          env: expect.any(String),
+        }),
+      );
+    });
+
+    it("should return true and skip re-init when already initialized", () => {
+      initDatadogLogs(() => true);
+      datadogLogs.init.mockClear();
+      expect(initDatadogLogs(() => true)).toBe(true);
+      expect(datadogLogs.init).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/datadog/logs.ts
+++ b/apps/ledger-live-desktop/src/datadog/logs.ts
@@ -21,16 +21,16 @@ export function initDatadogLogs(shouldSend: ShouldSendCallback): boolean {
   if (initialized) return true;
   if (!shouldSend()) return false;
 
-  const { clientToken, site, env } = getDatadogBuildConfig();
+  const { clientToken, site, service, env } = getDatadogBuildConfig();
   if (!clientToken) return false;
   if (!getOperatingSystemSupportStatus().supported) return false;
 
   try {
     datadogLogs.init({
       clientToken,
-      site: site ?? "datadoghq.eu",
-      service: "ledger-live-desktop",
-      env: env ?? (__DEV__ ? "development" : "production"),
+      site,
+      service,
+      env,
       version: __APP_VERSION__,
       sessionSampleRate: 100,
       forwardErrorsToLogs: false,

--- a/apps/ledger-live-desktop/src/datadog/logs.ts
+++ b/apps/ledger-live-desktop/src/datadog/logs.ts
@@ -1,0 +1,54 @@
+import { datadogLogs } from "@datadog/browser-logs";
+import { getOperatingSystemSupportStatus } from "~/support/os";
+import { buildBeforeSend, getDatadogBuildConfig, type ShouldSendCallback } from "./config";
+
+let initialized = false;
+
+/** Reset module state for tests so suites are order-independent. Do not use in production. */
+export function __resetDatadogLogsForTesting(): void {
+  initialized = false;
+}
+
+export function isDatadogLogsAvailable(): boolean {
+  const { clientToken } = getDatadogBuildConfig();
+  return getOperatingSystemSupportStatus().supported && !!clientToken;
+}
+
+/**
+ * Initialize Datadog browser-logs.
+ */
+export function initDatadogLogs(shouldSend: ShouldSendCallback): boolean {
+  if (initialized) return true;
+  if (!shouldSend()) return false;
+
+  const { clientToken, site, env } = getDatadogBuildConfig();
+  if (!clientToken) return false;
+  if (!getOperatingSystemSupportStatus().supported) return false;
+
+  try {
+    datadogLogs.init({
+      clientToken,
+      site: site ?? "datadoghq.eu",
+      service: "ledger-live-desktop",
+      env: env ?? (__DEV__ ? "development" : "production"),
+      version: __APP_VERSION__,
+      sessionSampleRate: 100,
+      forwardErrorsToLogs: false,
+      forwardConsoleLogs: [],
+      forwardReports: [],
+      beforeSend: buildBeforeSend(shouldSend),
+      sessionPersistence: "local-storage",
+    });
+
+    datadogLogs.setGlobalContext({
+      git_commit: __GIT_REVISION__,
+      process: globalThis.window === undefined ? "main" : "renderer",
+    });
+
+    initialized = true;
+    return true;
+  } catch (e) {
+    console.error("Datadog Logs init failed", e);
+    return false;
+  }
+}

--- a/apps/ledger-live-desktop/src/datadog/renderer.test.ts
+++ b/apps/ledger-live-desktop/src/datadog/renderer.test.ts
@@ -68,8 +68,9 @@ describe("datadog renderer", () => {
       getDatadogBuildConfig.mockReturnValue({
         applicationId: null,
         clientToken: "token",
-        site: null,
-        env: null,
+        site: "datadoghq.eu",
+        service: "ledger-live-desktop",
+        env: "production",
       });
       expect(isDatadogAvailable()).toBe(false);
     });
@@ -78,8 +79,9 @@ describe("datadog renderer", () => {
       getDatadogBuildConfig.mockReturnValue({
         applicationId: "app-id",
         clientToken: null,
-        site: null,
-        env: null,
+        site: "datadoghq.eu",
+        service: "ledger-live-desktop",
+        env: "production",
       });
       expect(isDatadogAvailable()).toBe(false);
     });
@@ -88,8 +90,9 @@ describe("datadog renderer", () => {
       getDatadogBuildConfig.mockReturnValue({
         applicationId: "app-id",
         clientToken: "token",
-        site: null,
-        env: null,
+        site: "datadoghq.eu",
+        service: "ledger-live-desktop",
+        env: "production",
       });
       getOperatingSystemSupportStatus.mockReturnValue({ supported: false });
       expect(isDatadogAvailable()).toBe(false);
@@ -99,8 +102,9 @@ describe("datadog renderer", () => {
       getDatadogBuildConfig.mockReturnValue({
         applicationId: "app-id",
         clientToken: "token",
-        site: null,
-        env: null,
+        site: "datadoghq.eu",
+        service: "ledger-live-desktop",
+        env: "production",
       });
       expect(isDatadogAvailable()).toBe(true);
     });
@@ -140,7 +144,8 @@ describe("datadog renderer", () => {
         applicationId: "app-id",
         clientToken: "token",
         site: "datadoghq.eu",
-        env: null,
+        service: "ledger-live-desktop",
+        env: "production",
       });
       const result = await initDatadog(() => false, undefined, createMockStore());
       expect(result).toBe(false);
@@ -151,8 +156,9 @@ describe("datadog renderer", () => {
       getDatadogBuildConfig.mockReturnValue({
         applicationId: null,
         clientToken: "token",
-        site: null,
-        env: null,
+        site: "datadoghq.eu",
+        service: "ledger-live-desktop",
+        env: "production",
       });
       const result = await initDatadog(() => true, undefined, createMockStore());
       expect(result).toBe(false);
@@ -163,8 +169,9 @@ describe("datadog renderer", () => {
       getDatadogBuildConfig.mockReturnValue({
         applicationId: "app-id",
         clientToken: "token",
-        site: null,
-        env: null,
+        site: "datadoghq.eu",
+        service: "ledger-live-desktop",
+        env: "production",
       });
       getOperatingSystemSupportStatus.mockReturnValue({ supported: false });
       const result = await initDatadog(() => true, undefined, createMockStore());
@@ -177,7 +184,8 @@ describe("datadog renderer", () => {
         applicationId: "app-id",
         clientToken: "token",
         site: "datadoghq.eu",
-        env: null,
+        service: "ledger-live-desktop",
+        env: "production",
       });
       datadogRum.init.mockImplementationOnce(() => {
         throw new Error("init failed");
@@ -192,6 +200,7 @@ describe("datadog renderer", () => {
       applicationId: "app-id",
       clientToken: "token",
       site: "datadoghq.eu",
+      service: "ledger-live-desktop",
       env: "production",
     };
 

--- a/apps/ledger-live-desktop/src/datadog/renderer.ts
+++ b/apps/ledger-live-desktop/src/datadog/renderer.ts
@@ -79,7 +79,7 @@ export async function initDatadog(
   if (initialized) return true;
   if (!shouldSend()) return false;
 
-  const { applicationId, clientToken, site, env } = getDatadogBuildConfig();
+  const { applicationId, clientToken, site, service, env } = getDatadogBuildConfig();
   if (!applicationId || !clientToken) return false;
   if (!getOperatingSystemSupportStatus().supported) return false;
 
@@ -93,9 +93,9 @@ export async function initDatadog(
     datadogRum.init({
       applicationId,
       clientToken,
-      site: site ?? "datadoghq.eu",
-      service: "ledger-live-desktop",
-      env: env ?? (__DEV__ ? "development" : "production"),
+      site,
+      service,
+      env,
       version: __APP_VERSION__,
       sessionSampleRate: params?.sessionSampleRate ?? 100,
       sessionReplaySampleRate: params?.sessionReplaySampleRate ?? 0,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -918,9 +918,12 @@ importers:
       '@braze/web-sdk':
         specifier: 6.4.0
         version: 6.4.0
+      '@datadog/browser-logs':
+        specifier: 6.30.1
+        version: 6.30.1(@datadog/browser-rum@6.30.1)
       '@datadog/browser-rum':
         specifier: 6.30.1
-        version: 6.30.1
+        version: 6.30.1(@datadog/browser-logs@6.30.1)
       '@electron/fuses':
         specifier: 2.0.0
         version: 2.0.0
@@ -15048,6 +15051,14 @@ packages:
 
   '@datadog/browser-core@6.30.1':
     resolution: {integrity: sha512-udXaUdjFld/UkdaH69oVWzDYILRqTdSXobVGnmcsqPvC5VBqdhunl0cR+t1k0oJgJndabqCFY/zluJ+joTOdaA==}
+
+  '@datadog/browser-logs@6.30.1':
+    resolution: {integrity: sha512-FhV1xY60U9wyaX+uQm8z7yN1Jn8XeI+1bF+LOL+tn1zuaJkOnLbSYz/tvDWsVk8LsJ1/gOHMht5D9JXHbDxexA==}
+    peerDependencies:
+      '@datadog/browser-rum': 6.30.1
+    peerDependenciesMeta:
+      '@datadog/browser-rum':
+        optional: true
 
   '@datadog/browser-rum-core@6.30.1':
     resolution: {integrity: sha512-U7TxRz5MuvLACfuskP4gGZk3ghSniEzkrhDNJeUXdA9+TZZLyrsZYBT9n6NuZTL1qTM5NNeK89e49kLUVI3Tiw==}
@@ -41950,14 +41961,22 @@ snapshots:
 
   '@datadog/browser-core@6.30.1': {}
 
+  '@datadog/browser-logs@6.30.1(@datadog/browser-rum@6.30.1)':
+    dependencies:
+      '@datadog/browser-core': 6.30.1
+    optionalDependencies:
+      '@datadog/browser-rum': 6.30.1(@datadog/browser-logs@6.30.1)
+
   '@datadog/browser-rum-core@6.30.1':
     dependencies:
       '@datadog/browser-core': 6.30.1
 
-  '@datadog/browser-rum@6.30.1':
+  '@datadog/browser-rum@6.30.1(@datadog/browser-logs@6.30.1)':
     dependencies:
       '@datadog/browser-core': 6.30.1
       '@datadog/browser-rum-core': 6.30.1
+    optionalDependencies:
+      '@datadog/browser-logs': 6.30.1(@datadog/browser-rum@6.30.1)
 
   '@datadog/datadog-api-client-synthetics@0.0.1-beta.1':
     dependencies:


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - No impact on Ledger Wallet, the code is not used at the moment.

### 📝 Description

Add a Datadog client for the log API, similar to what we have for [LWM](https://github.com/LedgerHQ/ledger-live/blob/develop/apps/ledger-live-mobile/src/datadog.ts).
One use case for the client is to send logs at broadcast for analytic purposes, we already do it in LWM.
Also adding unit tests that follow a similar pattern to what we have for the RUM client.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-30467
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
