### PR TITLE
[LWM] fix(mobile): show main account icons in crypto addresses button

### DIFF
--- a/.changeset/bright-clouds-dance.md
+++ b/.changeset/bright-clouds-dance.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Show main account currencies instead of categorized assets in crypto addresses button icons

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/CryptoAddressesButton/__tests__/useCryptoAddressesButtonViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/CryptoAddressesButton/__tests__/useCryptoAddressesButtonViewModel.test.ts
@@ -2,7 +2,6 @@ import { act } from "@testing-library/react-native";
 import { renderHook } from "@tests/test-renderer";
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { genAccount } from "@ledgerhq/live-common/mock/account";
-import { CategorizedAssets } from "@ledgerhq/asset-aggregation/assetCategorization/types";
 import { NavigatorName, ScreenName } from "~/const";
 import { State } from "~/reducers/types";
 import { track } from "~/analytics";
@@ -15,12 +14,6 @@ jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
   useNavigation: () => ({ navigate: mockNavigate }),
   useRoute: () => ({ name: "Portfolio" }),
-}));
-
-const mockCategorizedAssets = jest.fn();
-
-jest.mock("LLM/hooks/useCategorizedAssetsFromPortfolio", () => ({
-  useCategorizedAssetsFromPortfolio: () => mockCategorizedAssets(),
 }));
 
 const bitcoin = getCryptoCurrencyById("bitcoin");
@@ -38,32 +31,9 @@ const withAccounts =
     accounts: { active: accounts as State["accounts"]["active"] },
   });
 
-const mockPortfolio = (
-  cryptos: CategorizedAssets["cryptos"] = [],
-  stablecoins: CategorizedAssets["stablecoins"] = [],
-): void => {
-  mockCategorizedAssets.mockReturnValue({
-    categorizedAssets: { cryptos, stablecoins },
-    stablecoinTickers: new Set<string>(),
-    isLoadingStablecoinTickers: false,
-  });
-};
-
-const makeCategorizedItem = (
-  currency: ReturnType<typeof getCryptoCurrencyById>,
-  value: number,
-) => ({
-  currency,
-  balance: value,
-  value,
-  distribution: 0,
-  accounts: [],
-});
-
 describe("useCryptoAddressesButtonViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockPortfolio();
   });
 
   describe("accountsCount", () => {
@@ -85,52 +55,45 @@ describe("useCryptoAddressesButtonViewModel", () => {
   });
 
   describe("firstThreeCurrencies", () => {
-    it("should return currencies sorted by countervalue descending", () => {
-      mockPortfolio([
-        makeCategorizedItem(bitcoin, 500),
-        makeCategorizedItem(ethereum, 1000),
-        makeCategorizedItem(solana, 200),
-      ]);
+    it("should return unique currencies from accounts", () => {
+      const solAccount = genAccount("sol1", { currency: solana });
 
       const { result } = renderHook(() => useCryptoAddressesButtonViewModel(), {
-        overrideInitialState: withAccounts([btcAccount, ethAccount]),
+        overrideInitialState: withAccounts([btcAccount, ethAccount, solAccount]),
       });
 
       expect(result.current.firstThreeCurrencies).toHaveLength(3);
-      expect(result.current.firstThreeCurrencies[0]).toBe(ethereum);
-      expect(result.current.firstThreeCurrencies[1]).toBe(bitcoin);
-      expect(result.current.firstThreeCurrencies[2]).toBe(solana);
+      expect(result.current.firstThreeCurrencies).toEqual(
+        expect.arrayContaining([bitcoin, ethereum, solana]),
+      );
     });
 
     it("should cap at 3 currencies", () => {
-      mockPortfolio([
-        makeCategorizedItem(bitcoin, 1000),
-        makeCategorizedItem(ethereum, 800),
-        makeCategorizedItem(solana, 600),
-        makeCategorizedItem(ripple, 400),
-      ]);
+      const accounts = [bitcoin, ethereum, solana, ripple].map((c, i) =>
+        genAccount(`acc${i}`, { currency: c }),
+      );
 
       const { result } = renderHook(() => useCryptoAddressesButtonViewModel(), {
-        overrideInitialState: withAccounts([btcAccount]),
+        overrideInitialState: withAccounts(accounts),
       });
 
       expect(result.current.firstThreeCurrencies).toHaveLength(3);
     });
 
-    it("should include stablecoins sorted by countervalue alongside cryptos", () => {
-      mockPortfolio([makeCategorizedItem(bitcoin, 300)], [makeCategorizedItem(ethereum, 900)]);
+    it("should deduplicate accounts with the same currency", () => {
+      const btcAccount2 = genAccount("btc2", { currency: bitcoin });
 
       const { result } = renderHook(() => useCryptoAddressesButtonViewModel(), {
-        overrideInitialState: withAccounts([btcAccount, ethAccount]),
+        overrideInitialState: withAccounts([btcAccount, btcAccount2, ethAccount]),
       });
 
-      expect(result.current.firstThreeCurrencies[0]).toBe(ethereum);
-      expect(result.current.firstThreeCurrencies[1]).toBe(bitcoin);
+      expect(result.current.firstThreeCurrencies).toHaveLength(2);
+      expect(result.current.firstThreeCurrencies).toEqual(
+        expect.arrayContaining([bitcoin, ethereum]),
+      );
     });
 
-    it("should return empty array when portfolio has no assets", () => {
-      mockPortfolio([], []);
-
+    it("should return empty array when there are no accounts", () => {
       const { result } = renderHook(() => useCryptoAddressesButtonViewModel(), {
         overrideInitialState: withAccounts([]),
       });
@@ -225,7 +188,6 @@ describe("useCryptoAddressesButtonViewModel", () => {
 
   describe("moreAccountsCount", () => {
     it("should be total accounts minus displayed icon slots when above three accounts", () => {
-      mockPortfolio([makeCategorizedItem(bitcoin, 100)]);
       const fiveAccounts = [
         genAccount("a1", { currency: bitcoin }),
         genAccount("a2", { currency: bitcoin }),
@@ -241,7 +203,6 @@ describe("useCryptoAddressesButtonViewModel", () => {
     });
 
     it("should be non-positive when at most three accounts", () => {
-      mockPortfolio([makeCategorizedItem(bitcoin, 100)]);
       const { result } = renderHook(() => useCryptoAddressesButtonViewModel(), {
         overrideInitialState: withAccounts([btcAccount, ethAccount]),
       });
@@ -250,7 +211,6 @@ describe("useCryptoAddressesButtonViewModel", () => {
     });
 
     it("should not exceed 99", () => {
-      mockPortfolio([makeCategorizedItem(bitcoin, 100)]);
       const manyAccounts = Array.from({ length: 105 }, (_, i) =>
         genAccount(`many${i}`, { currency: bitcoin }),
       );

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/CryptoAddressesButton/useCryptoAddressesButtonViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/CryptoAddressesButton/useCryptoAddressesButtonViewModel.ts
@@ -1,5 +1,6 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { useNavigation, useRoute } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
@@ -7,7 +8,6 @@ import { NavigatorName, ScreenName } from "~/const";
 import { useSelector } from "~/context/hooks";
 import { shallowAccountsSelector } from "~/reducers/accounts";
 import { track } from "~/analytics";
-import { useCategorizedAssetsFromPortfolio } from "LLM/hooks/useCategorizedAssetsFromPortfolio";
 
 interface CryptoAddressesButtonViewModelResult {
   accountsCount: number;
@@ -26,20 +26,15 @@ export function useCryptoAddressesButtonViewModel(): CryptoAddressesButtonViewMo
   const accounts = useSelector(shallowAccountsSelector);
   const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
   const route = useRoute();
-  const { categorizedAssets } = useCategorizedAssetsFromPortfolio();
   const [isAddAccountOpen, setIsAddAccountOpen] = useState(false);
 
   const accountsCount = accounts.length;
   const hasAccounts = accountsCount > 0;
   const shouldShowAddAccount = isAddAccountOpen && !hasAccounts;
 
-  const firstThreeCurrencies = useMemo(
-    () =>
-      [...categorizedAssets.cryptos, ...categorizedAssets.stablecoins]
-        .sort((a, b) => b.value - a.value)
-        .slice(0, MAX_ACCOUNTS_TO_DISPLAY)
-        .map(asset => asset.currency),
-    [categorizedAssets],
+  const firstThreeCurrencies = [...new Set(accounts.map(a => getAccountCurrency(a)))].slice(
+    0,
+    MAX_ACCOUNTS_TO_DISPLAY,
   );
 
   const onPress = useCallback(() => {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Existing tests should be updated to reflect the new data source. Manual QA validated on simulator._
- [x] **Impact of the changes:**
      - Crypto addresses button icons on the Portfolio screen
      - Verify the 3 displayed icons match the top main account currencies (e.g. Ethereum, Bitcoin, Base) and not tokens/stablecoins

### 📝 Description

The crypto addresses button on the Portfolio screen was displaying icons from categorized assets (including tokens and stablecoins) instead of showing the main account currencies (parent chains like Ethereum, Base, Bitcoin).

Aligned the mobile implementation with desktop (`useCryptoAddressesBannerViewModel`): derive the top 3 unique currencies directly from `shallowAccountsSelector` using `getAccountCurrency`, removing the dependency on `useCategorizedAssetsFromPortfolio`.


<img height="700" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-05-11 at 18 37 09" src="https://github.com/user-attachments/assets/d0cab2d1-ad08-46da-83b6-ba3aae952f17" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-30449](https://ledgerhq.atlassian.net/browse/LIVE-30449)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30449]: https://ledgerhq.atlassian.net/browse/LIVE-30449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ