### PR TITLE
[LWDM] feat(dmk): add shared session registry

### DIFF
--- a/.changeset/neat-sessions-register.md
+++ b/.changeset/neat-sessions-register.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-dmk-shared": minor
+"@ledgerhq/live-dmk-mobile": minor
+"@ledgerhq/live-dmk-desktop": minor
+---
+
+Add a shared DMK session registry for active device sessions

--- a/libs/live-dmk-desktop/src/hooks/useDeviceManagementKit.tsx
+++ b/libs/live-dmk-desktop/src/hooks/useDeviceManagementKit.tsx
@@ -1,11 +1,15 @@
-import React, { createContext, useContext, useMemo } from "react";
+import React, { createContext, useContext, useEffect, useMemo } from "react";
 import {
   DeviceManagementKitBuilder,
   DeviceManagementKit,
   LogLevel,
 } from "@ledgerhq/device-management-kit";
 import { webHidTransportFactory } from "@ledgerhq/device-transport-kit-web-hid";
-import { LedgerLiveLogger, UserHashService } from "@ledgerhq/live-dmk-shared";
+import {
+  activeDeviceSessionRegistry,
+  LedgerLiveLogger,
+  UserHashService,
+} from "@ledgerhq/live-dmk-shared";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { getEnv } from "@ledgerhq/live-env";
 import { LocalTracer } from "@ledgerhq/logs";
@@ -47,6 +51,10 @@ export const DeviceManagementKitProvider: React.FC<Props> = ({ children, disable
     if (!ldmkTransportFlag) return null;
     return getDeviceManagementKit();
   }, [ldmkTransportFlag]);
+
+  useEffect(() => {
+    return () => activeDeviceSessionRegistry.dispose();
+  }, []);
 
   if (!ldmkTransportFlag || deviceManagementKit === null) {
     return <>{children}</>;

--- a/libs/live-dmk-desktop/src/transport/DeviceManagementKitTransport.test.ts
+++ b/libs/live-dmk-desktop/src/transport/DeviceManagementKitTransport.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@ledgerhq/device-management-kit";
 import { DeviceManagementKitTransport } from "./DeviceManagementKitTransport";
 import { getDeviceManagementKit } from "../hooks/useDeviceManagementKit";
+import { activeDeviceSessionRegistry } from "@ledgerhq/live-dmk-shared";
 
 let obs: Subject<DeviceSessionState> = new Subject<DeviceSessionState>();
 let transport: DeviceManagementKitTransport;
@@ -63,6 +64,7 @@ describe("DeviceManagementKitTransport", () => {
   });
 
   afterEach(() => {
+    activeDeviceSessionRegistry.dispose();
     obs.complete();
     obs = new Subject<DeviceSessionState>();
     jest.clearAllMocks();

--- a/libs/live-dmk-desktop/src/transport/DeviceManagementKitTransport.ts
+++ b/libs/live-dmk-desktop/src/transport/DeviceManagementKitTransport.ts
@@ -2,11 +2,10 @@ import {
   type DeviceId,
   DeviceManagementKit,
   DeviceStatus,
-  type DeviceSessionState,
   DiscoveredDevice,
 } from "@ledgerhq/device-management-kit";
 import Transport from "@ledgerhq/hw-transport";
-import { dmkToLedgerDeviceIdMap, activeDeviceSessionSubject } from "@ledgerhq/live-dmk-shared";
+import { activeDeviceSessionRegistry, dmkToLedgerDeviceIdMap } from "@ledgerhq/live-dmk-shared";
 import { LocalTracer } from "@ledgerhq/logs";
 import { DescriptorEvent } from "@ledgerhq/types-devices";
 import { firstValueFrom, Observer, startWith, pairwise, map, Subscription } from "rxjs";
@@ -17,56 +16,22 @@ const tracer = new LocalTracer("live-dmk-tracer", { function: "DeviceManagementK
 export class DeviceManagementKitTransport extends Transport {
   sessionId: string;
   readonly dmk: DeviceManagementKit;
+  private registrySubscription: Subscription;
+  private wasRegistered = false;
 
   constructor(dmk: DeviceManagementKit, sessionId: string) {
     super();
     this.sessionId = sessionId;
     this.dmk = dmk;
-    this.listenToDisconnect();
+    this.registrySubscription = this.listenToRegistryRemoval();
   }
 
-  listenToDisconnect = () => {
-    const subscription = this.dmk.getDeviceSessionState({ sessionId: this.sessionId }).subscribe({
-      next: (state: { deviceStatus: DeviceStatus }) => {
-        if (state.deviceStatus === DeviceStatus.NOT_CONNECTED) {
-          tracer.trace("[listenToDisconnect] Device disconnected, closing transport");
-          activeDeviceSessionSubject.next(null);
-          this.emit("disconnect");
-        }
-      },
-      error: (error: unknown) => {
-        console.error("[listenToDisconnect] error", error);
-        this.emit("disconnect");
-        subscription.unsubscribe();
-      },
-      complete: () => {
-        tracer.trace("[listenToDisconnect] Complete");
-        this.emit("disconnect");
-        subscription.unsubscribe();
-      },
-    });
-    return subscription;
-  };
-
   static async open(): Promise<DeviceManagementKitTransport> {
-    const activeSessionId = activeDeviceSessionSubject.value?.sessionId;
+    const reusableSession = activeDeviceSessionRegistry.findSession(() => true);
 
-    if (activeSessionId) {
-      tracer.trace(`[open] checking existing session ${activeSessionId}`);
-      const deviceSessionState: DeviceSessionState | null = await firstValueFrom(
-        getDeviceManagementKit().getDeviceSessionState({ sessionId: activeSessionId }),
-      ).catch(e => {
-        tracer.trace("[SDKTransport][open] error getting device session state", e);
-        return null;
-      });
-
-      if (
-        deviceSessionState?.deviceStatus !== DeviceStatus.NOT_CONNECTED &&
-        activeDeviceSessionSubject.value?.transport
-      ) {
-        tracer.trace("[open] reusing existing session and instantiating a new SdkTransport");
-        return activeDeviceSessionSubject.value.transport;
-      }
+    if (reusableSession) {
+      tracer.trace("[open] reusing existing session and instantiating a new SdkTransport");
+      return new DeviceManagementKitTransport(reusableSession.dmk, reusableSession.sessionId);
     }
 
     tracer.trace("[open] No active session found, starting discovery");
@@ -79,11 +44,9 @@ export class DeviceManagementKitTransport extends Transport {
     });
 
     tracer.trace("[open] Connected");
-    const transport = new DeviceManagementKitTransport(
-      getDeviceManagementKit(),
-      connectedSessionId,
-    );
-    activeDeviceSessionSubject.next({ sessionId: connectedSessionId, transport });
+    const dmk = getDeviceManagementKit();
+    activeDeviceSessionRegistry.addSession({ sessionId: connectedSessionId, dmk });
+    const transport = new DeviceManagementKitTransport(dmk, connectedSessionId);
 
     return transport;
   }
@@ -252,7 +215,10 @@ export class DeviceManagementKitTransport extends Transport {
     };
   };
 
-  close: () => Promise<void> = () => Promise.resolve();
+  close: () => Promise<void> = () => {
+    this.registrySubscription.unsubscribe();
+    return Promise.resolve();
+  };
 
   disconnect = () => {
     this.dmk.disconnect({ sessionId: this.sessionId });
@@ -271,6 +237,10 @@ export class DeviceManagementKitTransport extends Transport {
         sessionRefresherOptions: { isRefresherDisabled: true },
       });
       this.sessionId = connectedSessionId;
+      activeDeviceSessionRegistry.addSession({
+        sessionId: connectedSessionId,
+        dmk: getDeviceManagementKit(),
+      });
     }
 
     return await this.dmk
@@ -285,5 +255,21 @@ export class DeviceManagementKitTransport extends Transport {
       .catch(e => {
         throw e;
       });
+  }
+
+  private listenToRegistryRemoval(): Subscription {
+    return activeDeviceSessionRegistry.subscribe(sessions => {
+      const isRegistered = sessions.some(session => session.sessionId === this.sessionId);
+
+      if (isRegistered) {
+        this.wasRegistered = true;
+        return;
+      }
+
+      if (this.wasRegistered) {
+        this.wasRegistered = false;
+        this.emit("disconnect");
+      }
+    });
   }
 }

--- a/libs/live-dmk-mobile/src/hooks/useBleDevicePairing.test.tsx
+++ b/libs/live-dmk-mobile/src/hooks/useBleDevicePairing.test.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import { Device } from "@ledgerhq/types-devices";
 import { act, render } from "@testing-library/react";
 import { Observable } from "rxjs";
+import { activeDeviceSessionRegistry } from "@ledgerhq/live-dmk-shared";
 
 const TestComponent: React.FC<{ device: Device }> = ({ device }) => {
   const { isPaired, pairingError } = useBleDevicePairing({ device });
@@ -35,10 +36,15 @@ describe("useBleDevicePairing", () => {
     dmk.close.mockResolvedValue(undefined);
     dmk.getDeviceSessionState.mockReturnValue(new Observable());
   });
+  afterEach(() => {
+    activeDeviceSessionRegistry.dispose();
+    jest.clearAllMocks();
+  });
   it("should pair a device", async () => {
     // given
     let result: ReturnType<typeof render> | undefined;
     dmk.connect.mockResolvedValue("session");
+    const addSessionSpy = jest.spyOn(activeDeviceSessionRegistry, "addSession");
     const device = { deviceId: "id", deviceName: "name", modelId: "model" };
 
     // when
@@ -55,6 +61,7 @@ describe("useBleDevicePairing", () => {
     // then
     expect(isPaired).toHaveTextContent("true");
     expect(pairingError).toHaveTextContent("null");
+    expect(addSessionSpy).toHaveBeenCalledWith({ sessionId: "session", dmk });
   });
   it("should set an error", async () => {
     // given

--- a/libs/live-dmk-mobile/src/hooks/useBleDevicePairing.ts
+++ b/libs/live-dmk-mobile/src/hooks/useBleDevicePairing.ts
@@ -5,9 +5,8 @@ import {
   rnBleTransportIdentifier,
   PeerRemovedPairingError,
 } from "@ledgerhq/device-transport-kit-react-native-ble";
-import { activeDeviceSessionSubject } from "@ledgerhq/live-dmk-shared";
+import { activeDeviceSessionRegistry } from "@ledgerhq/live-dmk-shared";
 import { Device } from "@ledgerhq/types-devices";
-import { DeviceManagementKitBLETransport } from "../transport/DeviceManagementKitBLETransport";
 import { useDeviceManagementKit } from "./useDeviceManagementKit";
 import { getDeviceModel } from "@ledgerhq/devices";
 
@@ -44,8 +43,7 @@ export const useBleDevicePairing = ({
         },
         sessionRefresherOptions: { isRefresherDisabled: true },
       });
-      const transport = new DeviceManagementKitBLETransport(dmk, sessionId);
-      activeDeviceSessionSubject.next({ sessionId, transport });
+      activeDeviceSessionRegistry.addSession({ sessionId, dmk });
       setIsPaired(true);
     } catch (error) {
       if (error instanceof PeerRemovedPairingError) {

--- a/libs/live-dmk-mobile/src/hooks/useDeviceManagementKit.tsx
+++ b/libs/live-dmk-mobile/src/hooks/useDeviceManagementKit.tsx
@@ -1,11 +1,15 @@
-import React, { createContext, useContext, useMemo } from "react";
+import React, { createContext, useContext, useEffect, useMemo } from "react";
 import {
   DeviceManagementKitBuilder,
   DeviceManagementKit,
   LogLevel,
 } from "@ledgerhq/device-management-kit";
 import { RNBleTransportFactory } from "@ledgerhq/device-transport-kit-react-native-ble";
-import { LedgerLiveLogger, UserHashService } from "@ledgerhq/live-dmk-shared";
+import {
+  activeDeviceSessionRegistry,
+  LedgerLiveLogger,
+  UserHashService,
+} from "@ledgerhq/live-dmk-shared";
 import { RNHidTransportFactory } from "@ledgerhq/device-transport-kit-react-native-hid";
 import { getEnv } from "@ledgerhq/live-env";
 import { LocalTracer } from "@ledgerhq/logs";
@@ -44,6 +48,10 @@ export const DeviceManagementKitProvider: React.FC<Props> = ({ children }) => {
 
   const deviceManagementKit = useMemo(() => {
     return getDeviceManagementKit();
+  }, []);
+
+  useEffect(() => {
+    return () => activeDeviceSessionRegistry.dispose();
   }, []);
 
   if (deviceManagementKit === null) {

--- a/libs/live-dmk-mobile/src/transport/DeviceManagementKitBLETransport.test.ts
+++ b/libs/live-dmk-mobile/src/transport/DeviceManagementKitBLETransport.test.ts
@@ -1,6 +1,6 @@
 import { BlePlxManager } from "./BlePlxManager";
 import { DeviceManagementKitBLETransport, tracer } from "./DeviceManagementKitBLETransport";
-import { Observable, Subject, Subscription } from "rxjs";
+import { Observable, Subject } from "rxjs";
 import { State } from "react-native-ble-plx";
 import { getDeviceManagementKit } from "../hooks";
 import {
@@ -9,11 +9,12 @@ import {
   DeviceStatus,
   DiscoveredDevice,
 } from "@ledgerhq/device-management-kit";
-import { activeDeviceSessionSubject } from "@ledgerhq/live-dmk-shared";
+import { activeDeviceSessionRegistry } from "@ledgerhq/live-dmk-shared";
 import type { Subscription as TransportSubscription } from "@ledgerhq/hw-transport";
 
 describe("DeviceManagementKitBLETransport", () => {
   afterEach(() => {
+    activeDeviceSessionRegistry.dispose();
     jest.clearAllMocks();
   });
 
@@ -165,10 +166,10 @@ describe("DeviceManagementKitBLETransport", () => {
 
   describe("open", () => {
     afterEach(() => {
+      activeDeviceSessionRegistry.dispose();
       jest.clearAllMocks();
-      jest.spyOn(activeDeviceSessionSubject, "getValue").mockReturnValue(null);
     });
-    it("should return the active transport", async () => {
+    it("should return a BLE transport for a reusable registry session", async () => {
       // given
       const staticTransport = DeviceManagementKitBLETransport;
       const dmk = getDeviceManagementKit();
@@ -177,11 +178,7 @@ describe("DeviceManagementKitBLETransport", () => {
           subscriber.next({ deviceStatus: DeviceStatus.CONNECTED } as DeviceSessionState);
         }),
       );
-      const activeTransport = new DeviceManagementKitBLETransport(dmk, "sessionId");
-      jest.spyOn(activeDeviceSessionSubject, "getValue").mockReturnValue({
-        sessionId: "sessionId",
-        transport: activeTransport,
-      });
+      activeDeviceSessionRegistry.addSession({ sessionId: "sessionId", dmk });
       jest.spyOn(dmk, "getConnectedDevice").mockReturnValue({
         id: "deviceId",
         type: "BLE",
@@ -191,9 +188,10 @@ describe("DeviceManagementKitBLETransport", () => {
       const transport = await staticTransport.open("deviceId");
 
       // then
-      expect(transport).toEqual(activeTransport);
+      expect(transport).toBeInstanceOf(DeviceManagementKitBLETransport);
+      expect(transport.sessionId).toEqual("sessionId");
     });
-    it("should scan and connect if get dmk device session state throws", async () => {
+    it("should scan and connect if the registry session is stale", async () => {
       // given
       const staticTransport = DeviceManagementKitBLETransport;
       const dmk = getDeviceManagementKit();
@@ -202,33 +200,24 @@ describe("DeviceManagementKitBLETransport", () => {
           subscriber.next({ deviceStatus: DeviceStatus.CONNECTED } as DeviceSessionState);
         }),
       );
-      const activeTransport = new DeviceManagementKitBLETransport(dmk, "sessionId");
-      jest.spyOn(dmk, "getDeviceSessionState").mockReturnValue(
-        new Observable(subscriber => {
-          subscriber.error(new Error("get device session state error"));
-        }),
-      );
+      activeDeviceSessionRegistry.addSession({ sessionId: "staleSessionId", dmk });
       jest.spyOn(dmk, "connect").mockResolvedValue("sessionId");
-      jest.spyOn(dmk, "getConnectedDevice").mockReturnValue({} as ConnectedDevice);
+      jest.spyOn(dmk, "getConnectedDevice").mockImplementation(() => {
+        throw new Error("stale session");
+      });
       jest
         .spyOn(dmk, "listenToAvailableDevices")
         .mockReturnValue(
           new Observable(subscriber => subscriber.next([{ id: "deviceId" }] as DiscoveredDevice[])),
         );
-      jest.spyOn(activeDeviceSessionSubject, "getValue").mockReturnValue({
-        sessionId: "sessionId",
-        transport: activeTransport,
-      });
-      jest.spyOn(activeDeviceSessionSubject, "next");
 
       // when
       const transport = await staticTransport.open("deviceId");
 
       // then
-      expect(activeDeviceSessionSubject.next).toHaveBeenCalledWith({
-        sessionId: "sessionId",
-        transport: transport,
-      });
+      expect(transport.sessionId).toEqual("sessionId");
+      expect(activeDeviceSessionRegistry.getSession("staleSessionId")).toBeNull();
+      expect(activeDeviceSessionRegistry.getSession("sessionId")).toEqual({ sessionId: "sessionId", dmk });
     });
     it("should return a new transport after dmk scanning and connect", async () => {
       // given
@@ -244,7 +233,6 @@ describe("DeviceManagementKitBLETransport", () => {
           subscriber.next([{ id: "deviceId" } as DiscoveredDevice]);
         }),
       );
-      jest.spyOn(activeDeviceSessionSubject, "getValue").mockReturnValue(null);
       jest.spyOn(dmk, "connect").mockResolvedValue("sessionId");
 
       // when
@@ -348,89 +336,17 @@ describe("DeviceManagementKitBLETransport", () => {
     });
   });
 
-  // FixMe listenToDisconnect subscription should be cleared at some point
-  describe("listenToDisconnect", () => {
-    let subscription: Subscription | undefined = undefined;
-
-    afterEach(() => {
-      jest.clearAllMocks();
-      if (subscription) {
-        subscription.unsubscribe();
-        subscription = undefined;
-      }
-    });
-    it("should emit disconnect and reset active session if device session not connected", () => {
+  describe("registry disconnect bridge", () => {
+    it("should emit disconnect when its registry session is removed", () => {
       // given
       const dmk = getDeviceManagementKit();
-      jest.spyOn(dmk, "getDeviceSessionState").mockReturnValue(
-        new Observable(subscriber =>
-          subscriber.next({
-            deviceStatus: DeviceStatus.NOT_CONNECTED,
-          } as DeviceSessionState),
-        ),
-      );
-      const transport = new DeviceManagementKitBLETransport(dmk, "session");
-      jest.spyOn(activeDeviceSessionSubject, "next");
-      jest.spyOn(transport, "emit");
-
-      // when
-      subscription = transport.listenToDisconnect();
-
-      // then
-      //expect(activeDeviceSessionSubject.next).toHaveBeenCalledWith(null);
-      expect(transport.emit).toHaveBeenCalledWith("disconnect");
-    });
-    it("should not emit disconnect and reset active session if device session connected", () => {
-      // given
-      const dmk = getDeviceManagementKit();
-      jest.spyOn(dmk, "getDeviceSessionState").mockReturnValue(
-        new Observable(subscriber =>
-          subscriber.next({
-            deviceStatus: DeviceStatus.CONNECTED,
-          } as DeviceSessionState),
-        ),
-      );
-      const transport = new DeviceManagementKitBLETransport(dmk, "session");
-      jest.spyOn(activeDeviceSessionSubject, "next");
-      jest.spyOn(transport, "emit");
-
-      // when
-      subscription = transport.listenToDisconnect();
-
-      // then
-      expect(activeDeviceSessionSubject.next).toHaveBeenCalledTimes(0);
-      expect(transport.emit).toHaveBeenCalledTimes(0);
-    });
-    it("should emit disconnect on dmk listen error", () => {
-      // given
-      const dmk = getDeviceManagementKit();
-      jest.spyOn(dmk, "getDeviceSessionState").mockReturnValue(
-        new Observable(subscriber => {
-          subscriber.error(new Error("error"));
-        }),
-      );
+      jest.spyOn(dmk, "getDeviceSessionState").mockReturnValue(new Observable());
+      activeDeviceSessionRegistry.addSession({ sessionId: "session", dmk });
       const transport = new DeviceManagementKitBLETransport(dmk, "session");
       jest.spyOn(transport, "emit");
 
       // when
-      subscription = transport.listenToDisconnect();
-
-      // then
-      expect(transport.emit).toHaveBeenCalledWith("disconnect");
-    });
-    it("should emit disconnect on dmk listen complete", () => {
-      // given
-      const dmk = getDeviceManagementKit();
-      jest.spyOn(dmk, "getDeviceSessionState").mockReturnValue(
-        new Observable(subscriber => {
-          subscriber.complete();
-        }),
-      );
-      const transport = new DeviceManagementKitBLETransport(dmk, "session");
-      jest.spyOn(transport, "emit");
-
-      // when
-      subscription = transport.listenToDisconnect();
+      activeDeviceSessionRegistry.removeSession("session");
 
       // then
       expect(transport.emit).toHaveBeenCalledWith("disconnect");
@@ -457,19 +373,25 @@ describe("DeviceManagementKitBLETransport", () => {
     beforeEach(() => {
       jest.clearAllMocks();
     });
-    it("should throw an error if no active session", async () => {
+    it("should use its own session even when the registry has no active session", async () => {
       // given
       const dmk = getDeviceManagementKit();
       jest.spyOn(dmk, "getDeviceSessionState").mockReturnValue(new Observable());
-      jest.spyOn(activeDeviceSessionSubject, "getValue").mockReturnValue(null);
       const transport = new DeviceManagementKitBLETransport(dmk, "session");
-      try {
-        // when
-        await transport.exchange(Buffer.from([]));
-      } catch (e) {
-        // then
-        expect(e).toEqual(new Error("No active session found"));
-      }
+      jest.spyOn(dmk, "sendApdu").mockResolvedValue({
+        data: Uint8Array.from([]),
+        statusCode: Uint8Array.from([0x90, 0x00]),
+      });
+
+      // when
+      await transport.exchange(Buffer.from([]));
+
+      // then
+      expect(dmk.sendApdu).toHaveBeenCalledWith({
+        sessionId: "session",
+        apdu: Uint8Array.from([]),
+        abortTimeout: undefined,
+      });
     });
 
     it("should call dmk sendApdu and return response", async () => {
@@ -477,10 +399,6 @@ describe("DeviceManagementKitBLETransport", () => {
       const dmk = getDeviceManagementKit();
       jest.spyOn(dmk, "getDeviceSessionState").mockReturnValue(new Observable());
       const transport = new DeviceManagementKitBLETransport(dmk, "session");
-      jest.spyOn(activeDeviceSessionSubject, "getValue").mockReturnValue({
-        sessionId: "session",
-        transport: transport,
-      });
       jest.spyOn(dmk, "sendApdu").mockResolvedValue({
         data: Uint8Array.from([0x42, 0x21, 0x34, 0x44, 0x54, 0x67, 0x89]),
         statusCode: Uint8Array.from([0x90, 0x00]),
@@ -506,10 +424,6 @@ describe("DeviceManagementKitBLETransport", () => {
       const dmk = getDeviceManagementKit();
       jest.spyOn(dmk, "getDeviceSessionState").mockReturnValue(new Observable());
       const transport = new DeviceManagementKitBLETransport(dmk, "session");
-      jest.spyOn(activeDeviceSessionSubject, "getValue").mockReturnValue({
-        sessionId: "session",
-        transport: transport,
-      });
       jest.spyOn(dmk, "sendApdu").mockRejectedValue(new Error("SendApdu error"));
 
       try {

--- a/libs/live-dmk-mobile/src/transport/DeviceManagementKitBLETransport.ts
+++ b/libs/live-dmk-mobile/src/transport/DeviceManagementKitBLETransport.ts
@@ -11,7 +11,7 @@ import {
   PairingRefusedError,
   rnBleTransportIdentifier,
 } from "@ledgerhq/device-transport-kit-react-native-ble";
-import { activeDeviceSessionSubject, dmkToLedgerDeviceIdMap } from "@ledgerhq/live-dmk-shared";
+import { activeDeviceSessionRegistry, dmkToLedgerDeviceIdMap } from "@ledgerhq/live-dmk-shared";
 import { LocalTracer, TraceContext } from "@ledgerhq/logs";
 import {
   catchError,
@@ -43,13 +43,15 @@ export const tracer = new LocalTracer("live-dmk-tracer", {
 export class DeviceManagementKitBLETransport extends Transport {
   sessionId: string;
   dmk: DeviceManagementKit;
+  private registrySubscription: Subscription;
+  private wasRegistered = false;
 
   constructor(dmk: DeviceManagementKit, sessionId: string) {
     super();
     this.sessionId = sessionId;
     this.dmk = dmk;
-    this.listenToDisconnect();
     this.tracer = tracer;
+    this.registrySubscription = this.listenToRegistryRemoval();
   }
 
   static setLogLevel(_level: string): void {
@@ -122,28 +124,11 @@ export class DeviceManagementKitBLETransport extends Transport {
     _context?: TraceContext,
     options?: { matchDeviceByName?: string },
   ): Promise<DeviceManagementKitBLETransport> {
-    const activeSessionId = activeDeviceSessionSubject.value?.sessionId;
-
-    tracer.trace(
-      "[DMKTransport] [open] activeSessionId: " + activeSessionId + " and deviceId: " + deviceOrId,
-      { options },
-    );
-
-    if (activeSessionId) {
-      tracer.trace(`[DMKTransport] [open] checking existing session ${activeSessionId}`);
-
-      const deviceSessionState: DeviceSessionState | null = await firstValueFrom(
-        getDeviceManagementKit().getDeviceSessionState({ sessionId: activeSessionId }),
-      ).catch(e => {
-        tracer.trace("[open] error getting device session state", { error: e });
-        return null;
-      });
-
-      const connectedDevice = getDeviceManagementKit().getConnectedDevice({
-        sessionId: activeSessionId,
-      });
-
-      const isSameDeviceId = connectedDevice.id === deviceOrId;
+    const reusableSession = activeDeviceSessionRegistry.findSession((_, connectedDevice) => {
+      const isSameDeviceId =
+        typeof deviceOrId === "string"
+          ? connectedDevice.id === deviceOrId
+          : connectedDevice.id === deviceOrId.id;
       const isSameDeviceNameButDifferentId =
         !isSameDeviceId &&
         matchDeviceByName({
@@ -151,38 +136,28 @@ export class DeviceManagementKitBLETransport extends Transport {
           newDevice: { deviceName: connectedDevice.name },
         });
 
-      if (
-        deviceSessionState?.deviceStatus !== DeviceStatus.NOT_CONNECTED &&
-        connectedDevice.type === "BLE" &&
-        activeDeviceSessionSubject.value?.transport &&
-        (isSameDeviceId || isSameDeviceNameButDifferentId)
-      ) {
-        tracer.trace(
-          "[DMKTransport] [open] reusing existing session and instantiating a new DmkTransport",
-          {
-            data: {
-              isSameDeviceId,
-              isSameDeviceNameButDifferentId,
-              status: deviceSessionState?.deviceStatus,
-              transport: activeDeviceSessionSubject.value?.transport,
-              oldDevice: { deviceName: options?.matchDeviceByName },
-              newDevice: { deviceName: connectedDevice.name },
-            },
-          },
-        );
-        return activeDeviceSessionSubject.value.transport;
-      } else {
-        tracer.trace("[DMKTransport] [open] not reusing existing session", {
+      return connectedDevice.type === "BLE" && (isSameDeviceId || isSameDeviceNameButDifferentId);
+    });
+
+    tracer.trace(
+      "[DMKTransport] [open] activeSessionId: " +
+        reusableSession?.sessionId +
+        " and deviceId: " +
+        deviceOrId,
+      { options },
+    );
+
+    if (reusableSession) {
+      tracer.trace(
+        "[DMKTransport] [open] reusing existing session and instantiating a new DmkTransport",
+        {
           data: {
-            isSameDeviceId,
-            isSameDeviceNameButDifferentId,
-            status: deviceSessionState?.deviceStatus,
-            transport: activeDeviceSessionSubject.value?.transport,
+            sessionId: reusableSession.sessionId,
             oldDevice: { deviceName: options?.matchDeviceByName },
-            newDevice: { deviceName: connectedDevice.name },
           },
-        });
-      }
+        },
+      );
+      return new DeviceManagementKitBLETransport(reusableSession.dmk, reusableSession.sessionId);
     }
 
     if (typeof deviceOrId === "string") {
@@ -215,12 +190,9 @@ export class DeviceManagementKitBLETransport extends Transport {
               }
               throw error;
             });
-          const transport = new DeviceManagementKitBLETransport(
-            getDeviceManagementKit(),
-            sessionId,
-          );
-
-          activeDeviceSessionSubject.next({ sessionId, transport });
+          const dmk = getDeviceManagementKit();
+          activeDeviceSessionRegistry.addSession({ sessionId, dmk });
+          const transport = new DeviceManagementKitBLETransport(dmk, sessionId);
           getDeviceManagementKit().stopDiscovering();
 
           return transport;
@@ -265,8 +237,9 @@ export class DeviceManagementKitBLETransport extends Transport {
         device: deviceOrId,
         sessionRefresherOptions: { isRefresherDisabled: true },
       });
-      const transport = new DeviceManagementKitBLETransport(getDeviceManagementKit(), sessionId);
-      activeDeviceSessionSubject.next({ sessionId, transport });
+      const dmk = getDeviceManagementKit();
+      activeDeviceSessionRegistry.addSession({ sessionId, dmk });
+      const transport = new DeviceManagementKitBLETransport(dmk, sessionId);
 
       return transport;
     }
@@ -315,40 +288,8 @@ export class DeviceManagementKitBLETransport extends Transport {
     };
   }
 
-  listenToDisconnect = () => {
-    let subscription: Subscription | undefined = undefined;
-    subscription = this.dmk.getDeviceSessionState({ sessionId: this.sessionId }).subscribe({
-      next: (state: { deviceStatus: DeviceStatus }) => {
-        if (state.deviceStatus === DeviceStatus.NOT_CONNECTED) {
-          tracer.trace(
-            "[DMKTransport] [listenToDisconnect] Device disconnected, closing transport",
-          );
-
-          if (activeDeviceSessionSubject.value?.sessionId === this.sessionId) {
-            activeDeviceSessionSubject.next(null);
-          }
-          this.emit("disconnect");
-        }
-      },
-      error: (error: unknown) => {
-        tracer.trace("[DMKTransport] [listenToDisconnect] error", { error });
-        this.emit("disconnect");
-        if (subscription) {
-          subscription.unsubscribe();
-        }
-      },
-      complete: () => {
-        tracer.trace("[DMKTransport] [listenToDisconnect] Complete");
-        this.emit("disconnect");
-        if (subscription) {
-          subscription.unsubscribe();
-        }
-      },
-    });
-    return subscription;
-  };
-
   close() {
+    this.registrySubscription.unsubscribe();
     return Promise.resolve();
   }
 
@@ -362,14 +303,9 @@ export class DeviceManagementKitBLETransport extends Transport {
     apdu: Buffer,
     { abortTimeoutMs }: { abortTimeoutMs?: number } = {},
   ): Promise<Buffer> {
-    const activeSessionId = activeDeviceSessionSubject.value?.sessionId;
-    if (!activeSessionId) {
-      throw new Error("No active session found");
-    }
-
     return await this.dmk
       .sendApdu({
-        sessionId: activeSessionId,
+        sessionId: this.sessionId,
         apdu: new Uint8Array(apdu),
         abortTimeout: abortTimeoutMs,
       })
@@ -380,5 +316,21 @@ export class DeviceManagementKitBLETransport extends Transport {
       .catch(error => {
         throw error;
       });
+  }
+
+  private listenToRegistryRemoval(): Subscription {
+    return activeDeviceSessionRegistry.subscribe(sessions => {
+      const isRegistered = sessions.some(session => session.sessionId === this.sessionId);
+
+      if (isRegistered) {
+        this.wasRegistered = true;
+        return;
+      }
+
+      if (this.wasRegistered) {
+        this.wasRegistered = false;
+        this.emit("disconnect");
+      }
+    });
   }
 }

--- a/libs/live-dmk-mobile/src/transport/DeviceManagementKitHIDTransport.test.ts
+++ b/libs/live-dmk-mobile/src/transport/DeviceManagementKitHIDTransport.test.ts
@@ -13,10 +13,10 @@ import {
 } from "@ledgerhq/device-management-kit";
 import {
   DeviceManagementKitHIDTransport,
-  activeDeviceSessionSubject,
 } from "./DeviceManagementKitHIDTransport";
 import { rnHidTransportIdentifier } from "@ledgerhq/device-transport-kit-react-native-hid";
 import { DisconnectedDevice } from "@ledgerhq/errors";
+import { activeDeviceSessionRegistry } from "@ledgerhq/live-dmk-shared";
 
 function createMockDMK(): DeviceManagementKit {
   const mock = {
@@ -55,7 +55,12 @@ const createMockDiscoveredDevice = (
 
 describe("DeviceManagementKitHIDTransport", () => {
   beforeEach(() => {
+    activeDeviceSessionRegistry.dispose();
     jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    activeDeviceSessionRegistry.dispose();
   });
 
   describe("open", () => {
@@ -68,10 +73,7 @@ describe("DeviceManagementKitHIDTransport", () => {
           subscriber.next(deviceSessionState);
         }),
       );
-      const activeTransport = new DeviceManagementKitHIDTransport(mockDMK, "sessionId");
-      jest.spyOn(activeDeviceSessionSubject, "getValue").mockReturnValue({
-        transport: activeTransport,
-      });
+      activeDeviceSessionRegistry.addSession({ sessionId: "sessionId", dmk: mockDMK });
       const connectedDevice: ConnectedDevice = {
         id: "deviceId",
         type: "USB",
@@ -91,7 +93,8 @@ describe("DeviceManagementKitHIDTransport", () => {
       );
 
       // then
-      expect(transport).toEqual(activeTransport);
+      expect(transport).toBeInstanceOf(DeviceManagementKitHIDTransport);
+      expect(transport.sessionId).toEqual("sessionId");
     });
 
     describe("given there is an an active session", () => {
@@ -105,10 +108,7 @@ describe("DeviceManagementKitHIDTransport", () => {
             deviceStatus: DeviceStatus.CONNECTED,
           }).asObservable(),
         );
-        const activeTransport = new DeviceManagementKitHIDTransport(mockDMK, "sessionId");
-        jest.spyOn(activeDeviceSessionSubject, "getValue").mockReturnValue({
-          transport: activeTransport,
-        });
+        activeDeviceSessionRegistry.addSession({ sessionId: "sessionId", dmk: mockDMK });
 
         jest.mocked(mockDMK.getConnectedDevice).mockReturnValue({
           id: "deviceId",
@@ -128,7 +128,8 @@ describe("DeviceManagementKitHIDTransport", () => {
         );
 
         // then
-        expect(transport).toEqual(activeTransport);
+        expect(transport).toBeInstanceOf(DeviceManagementKitHIDTransport);
+        expect(transport.sessionId).toEqual("sessionId");
       });
 
       it("when it is in a NOT_CONNECTED state, it should wait for a new device to be available and return a new transport", async () => {
@@ -140,10 +141,7 @@ describe("DeviceManagementKitHIDTransport", () => {
             deviceStatus: DeviceStatus.NOT_CONNECTED,
           }).asObservable(),
         );
-        const activeTransport = new DeviceManagementKitHIDTransport(mockDMK, "sessionIdA");
-        jest.spyOn(activeDeviceSessionSubject, "getValue").mockReturnValue({
-          transport: activeTransport,
-        });
+        activeDeviceSessionRegistry.addSession({ sessionId: "sessionIdA", dmk: mockDMK });
 
         jest.mocked(mockDMK.getConnectedDevice).mockReturnValue({
           id: "deviceId",
@@ -173,7 +171,6 @@ describe("DeviceManagementKitHIDTransport", () => {
         );
 
         // then
-        expect(transport).not.toEqual(activeTransport);
         expect(transport.sessionId).toEqual("sessionIdB");
         expect(mockedListenToAvailableDevices).toHaveBeenCalledWith({
           transport: rnHidTransportIdentifier,
@@ -194,8 +191,6 @@ describe("DeviceManagementKitHIDTransport", () => {
           deviceStatus: DeviceStatus.NOT_CONNECTED,
         }).asObservable(),
       );
-      jest.spyOn(activeDeviceSessionSubject, "getValue").mockReturnValue(null);
-
       const mockedDiscoveredDevice = createMockDiscoveredDevice();
       const mockedListenToAvailableDevices = jest.mocked(mockDMK.listenToAvailableDevices);
       mockedListenToAvailableDevices.mockReturnValue(
@@ -237,22 +232,25 @@ describe("DeviceManagementKitHIDTransport", () => {
   });
 
   describe("exchange", () => {
-    it("should throw an error if no active session", async () => {
+    it("should call dmk sendApdu with its own session without an active registry session", async () => {
       // given
       const mockDMK = createMockDMK();
       jest.mocked(mockDMK.getDeviceSessionState).mockReturnValue(new Observable());
-      jest.spyOn(activeDeviceSessionSubject, "getValue").mockReturnValue(null);
       const transport = new DeviceManagementKitHIDTransport(mockDMK, "session");
+      jest.mocked(mockDMK.sendApdu).mockResolvedValue({
+        data: Uint8Array.from([]),
+        statusCode: Uint8Array.from([0x90, 0x00]),
+      });
 
       // when
-      const result = transport.exchange(Buffer.from([]));
+      await transport.exchange(Buffer.from([]));
 
       // then
-      let caughtError;
-      await result.catch(e => {
-        caughtError = e;
+      expect(mockDMK.sendApdu).toHaveBeenCalledWith({
+        sessionId: "session",
+        apdu: Uint8Array.from([]),
+        abortTimeout: undefined,
       });
-      expect(caughtError).toEqual(new DisconnectedDevice());
     });
 
     it("should call dmk sendApdu and return response", async () => {
@@ -262,9 +260,6 @@ describe("DeviceManagementKitHIDTransport", () => {
 
       const mockSendApdu = jest.mocked(mockDMK.sendApdu);
       const transport = new DeviceManagementKitHIDTransport(mockDMK, "session");
-      jest.spyOn(activeDeviceSessionSubject, "getValue").mockReturnValue({
-        transport,
-      });
       jest.mocked(mockDMK.sendApdu).mockResolvedValue({
         data: Uint8Array.from([0x42, 0x21, 0x34, 0x44, 0x54, 0x67, 0x89]),
         statusCode: Uint8Array.from([0x90, 0x00]),
@@ -291,9 +286,6 @@ describe("DeviceManagementKitHIDTransport", () => {
       jest.mocked(mockDMK.getDeviceSessionState).mockReturnValue(new Observable());
       const mockSendApdu = jest.mocked(mockDMK.sendApdu);
       const transport = new DeviceManagementKitHIDTransport(mockDMK, "session");
-      jest.spyOn(activeDeviceSessionSubject, "getValue").mockReturnValue({
-        transport,
-      });
       mockSendApdu.mockRejectedValue(new Error("SendApdu error"));
 
       // when
@@ -318,9 +310,6 @@ describe("DeviceManagementKitHIDTransport", () => {
         jest.mocked(mockDMK.getDeviceSessionState).mockReturnValue(new Observable());
         const mockSendApdu = jest.mocked(mockDMK.sendApdu);
         const transport = new DeviceManagementKitHIDTransport(mockDMK, "session");
-        jest.spyOn(activeDeviceSessionSubject, "getValue").mockReturnValue({
-          transport,
-        });
         mockSendApdu.mockRejectedValue(error);
 
         // when
@@ -336,94 +325,20 @@ describe("DeviceManagementKitHIDTransport", () => {
     });
   });
 
-  describe("listenToDisconnect", () => {
-    it("should be called on new transport", () => {
-      // given
-      const mockDMK = createMockDMK();
-      jest.mocked(mockDMK.getDeviceSessionState).mockReturnValue(new Observable());
-      jest.spyOn(DeviceManagementKitHIDTransport.prototype, "listenToDisconnect");
-
-      // when
-      const transport = new DeviceManagementKitHIDTransport(mockDMK, "session");
-
-      // then
-      expect(transport.listenToDisconnect).toHaveBeenCalled();
-    });
-
-    it("when the device gets disconnected, it should reset activeDeviceSession and emit disconnect", async () => {
+  describe("registry disconnect bridge", () => {
+    it("when the registry session is removed, it should emit disconnect", async () => {
       // given
       const mockDMK = createMockDMK();
       const deviceSessionStateSubject = new Subject<DeviceSessionState>();
       jest
         .mocked(mockDMK.getDeviceSessionState)
         .mockReturnValue(deviceSessionStateSubject.asObservable());
-      jest.spyOn(activeDeviceSessionSubject, "next");
+      activeDeviceSessionRegistry.addSession({ sessionId: "session", dmk: mockDMK });
       const transport = new DeviceManagementKitHIDTransport(mockDMK, "session");
       jest.spyOn(transport, "emit");
 
       // when
-      deviceSessionStateSubject.next({
-        ...aMockedDeviceSessionState,
-        deviceStatus: DeviceStatus.NOT_CONNECTED,
-      });
-
-      // then
-      expect(activeDeviceSessionSubject.next).toHaveBeenCalledWith(null);
-      expect(transport.emit).toHaveBeenCalledWith("disconnect");
-    });
-
-    it("when the device state changes to another state than NOT_CONNECTED, it should not reset activeDeviceSession and not emit disconnect", async () => {
-      // given
-      const mockDMK = createMockDMK();
-      const deviceSessionStateSubject = new Subject<DeviceSessionState>();
-      jest
-        .mocked(mockDMK.getDeviceSessionState)
-        .mockReturnValue(deviceSessionStateSubject.asObservable());
-      jest.spyOn(activeDeviceSessionSubject, "next");
-
-      const transport = new DeviceManagementKitHIDTransport(mockDMK, "session");
-      jest.spyOn(transport, "emit");
-
-      // when
-      deviceSessionStateSubject.next({
-        ...aMockedDeviceSessionState,
-        deviceStatus: DeviceStatus.BUSY,
-      });
-
-      // then
-      expect(activeDeviceSessionSubject.next).not.toHaveBeenCalled();
-      expect(transport.emit).not.toHaveBeenCalled();
-    });
-
-    it("should emit disconnect on complete", async () => {
-      // given
-      const mockDMK = createMockDMK();
-      const deviceSessionStateSubject = new Subject<DeviceSessionState>();
-      jest
-        .mocked(mockDMK.getDeviceSessionState)
-        .mockReturnValue(deviceSessionStateSubject.asObservable());
-      const transport = new DeviceManagementKitHIDTransport(mockDMK, "sessionId");
-      jest.spyOn(transport, "emit");
-
-      // when
-      deviceSessionStateSubject.complete();
-
-      // then
-      expect(transport.emit).toHaveBeenCalledWith("disconnect");
-    });
-
-    it("should emit disconnect on error", async () => {
-      // given
-      const mockDMK = createMockDMK();
-      const deviceSessionStateSubject = new Subject<DeviceSessionState>();
-      jest
-        .mocked(mockDMK.getDeviceSessionState)
-        .mockReturnValue(deviceSessionStateSubject.asObservable());
-      const transport = new DeviceManagementKitHIDTransport(mockDMK, "sessionId");
-      jest.spyOn(transport, "emit");
-
-      // when
-      deviceSessionStateSubject.error(new Error("error"));
+      activeDeviceSessionRegistry.removeSession("session");
 
       // then
       expect(transport.emit).toHaveBeenCalledWith("disconnect");

--- a/libs/live-dmk-mobile/src/transport/DeviceManagementKitHIDTransport.ts
+++ b/libs/live-dmk-mobile/src/transport/DeviceManagementKitHIDTransport.ts
@@ -2,35 +2,31 @@ import {
   DeviceDisconnectedBeforeSendingApdu,
   DeviceDisconnectedWhileSendingError,
   DeviceManagementKit,
-  DeviceStatus,
   SendApduEmptyResponseError,
 } from "@ledgerhq/device-management-kit";
 import { rnHidTransportIdentifier } from "@ledgerhq/device-transport-kit-react-native-hid";
 import { DisconnectedDevice } from "@ledgerhq/errors";
 import Transport from "@ledgerhq/hw-transport";
+import { activeDeviceSessionRegistry } from "@ledgerhq/live-dmk-shared";
 import { LocalTracer, TraceContext } from "@ledgerhq/logs";
-import { BehaviorSubject, Subscription, firstValueFrom } from "rxjs";
+import { Subscription, firstValueFrom } from "rxjs";
 import { first, tap, timeout } from "rxjs/operators";
 import { getDeviceManagementKit } from "../hooks/useDeviceManagementKit";
-
-export const activeDeviceSessionSubject = new BehaviorSubject<{
-  transport: DeviceManagementKitHIDTransport;
-} | null>(null);
-
-activeDeviceSessionSubject.subscribe();
 
 export const tracer = new LocalTracer("live-dmk", { function: "DeviceManagementKitHIDTransport" });
 
 export class DeviceManagementKitHIDTransport extends Transport {
   sessionId: string;
   dmk: DeviceManagementKit;
+  private registrySubscription: Subscription;
+  private wasRegistered = false;
 
   constructor(dmk: DeviceManagementKit, sessionId: string) {
     super();
     this.sessionId = sessionId;
     this.dmk = dmk;
     this.tracer = tracer;
-    this.listenToDisconnect();
+    this.registrySubscription = this.listenToRegistryRemoval();
   }
 
   static async open(
@@ -39,34 +35,18 @@ export class DeviceManagementKitHIDTransport extends Transport {
     _context?: TraceContext,
     dmk: DeviceManagementKit = getDeviceManagementKit(),
   ) {
-    const activeDeviceSession = activeDeviceSessionSubject.value;
+    const reusableSession = activeDeviceSessionRegistry.findSession(
+      (_, connectedDevice) => connectedDevice.type === "USB",
+    );
 
     tracer.trace(`[open] called with deviceId: ${deviceId} and timeoutMs: ${timeoutMs}`);
 
     try {
-      if (activeDeviceSession) {
+      if (reusableSession) {
         tracer.trace("[open] checking existing session", {
-          sessionId: activeDeviceSession.transport.sessionId,
+          sessionId: reusableSession.sessionId,
         });
-        const deviceSessionState = await firstValueFrom(
-          dmk.getDeviceSessionState({
-            sessionId: activeDeviceSession.transport.sessionId,
-          }),
-        );
-
-        const connectedDevice = dmk.getConnectedDevice({
-          sessionId: activeDeviceSession.transport.sessionId,
-        });
-        if (
-          connectedDevice.type === "USB" &&
-          deviceSessionState.deviceStatus !== DeviceStatus.NOT_CONNECTED
-        ) {
-          tracer.trace("[open] reusing existing session", {
-            sessionId: activeDeviceSession.transport.sessionId,
-          });
-          return activeDeviceSession.transport;
-        }
-        tracer.trace("[open] session not reusable");
+        return new DeviceManagementKitHIDTransport(reusableSession.dmk, reusableSession.sessionId);
       }
       tracer.trace(
         `[open] listening to available devices and connecting to first available device with timeoutMs: ${timeoutMs}`,
@@ -85,10 +65,8 @@ export class DeviceManagementKitHIDTransport extends Transport {
       tracer.trace("[DMKTransportHID] [open] new device connected", {
         sessionId,
       });
+      activeDeviceSessionRegistry.addSession({ sessionId, dmk });
       const transport = new DeviceManagementKitHIDTransport(dmk, sessionId);
-      activeDeviceSessionSubject.next({
-        transport,
-      });
       return transport;
     } catch (err) {
       tracer.trace("[open] open error", { err });
@@ -97,14 +75,9 @@ export class DeviceManagementKitHIDTransport extends Transport {
   }
 
   async exchange(apdu: Buffer, { abortTimeoutMs }: { abortTimeoutMs?: number } = {}) {
-    const activeSessionId = activeDeviceSessionSubject.value?.transport.sessionId;
-    if (!activeSessionId) {
-      throw new DisconnectedDevice();
-    }
-
     return await this.dmk
       .sendApdu({
-        sessionId: activeSessionId,
+        sessionId: this.sessionId,
         apdu: new Uint8Array(apdu),
         abortTimeout: abortTimeoutMs,
       })
@@ -125,37 +98,23 @@ export class DeviceManagementKitHIDTransport extends Transport {
   }
 
   close() {
+    this.registrySubscription.unsubscribe();
     return Promise.resolve();
   }
 
-  listenToDisconnect() {
-    let subscription: Subscription | undefined = undefined;
+  private listenToRegistryRemoval(): Subscription {
+    return activeDeviceSessionRegistry.subscribe(sessions => {
+      const isRegistered = sessions.some(session => session.sessionId === this.sessionId);
 
-    subscription = this.dmk.getDeviceSessionState({ sessionId: this.sessionId }).subscribe({
-      next: (state: { deviceStatus: DeviceStatus }) => {
-        if (state.deviceStatus === DeviceStatus.NOT_CONNECTED) {
-          this.tracer.trace(
-            "[DMKTransport] [listenToDisconnect] Device disconnected, closing transport",
-          );
-          activeDeviceSessionSubject.next(null);
-          this.emit("disconnect");
-        }
-      },
-      error: (error: unknown) => {
-        this.tracer.trace("[DMKTransport] [listenToDisconnect] error", { error });
+      if (isRegistered) {
+        this.wasRegistered = true;
+        return;
+      }
+
+      if (this.wasRegistered) {
+        this.wasRegistered = false;
         this.emit("disconnect");
-        if (subscription) {
-          subscription.unsubscribe();
-        }
-      },
-      complete: () => {
-        this.tracer.trace("[DMKTransport] [listenToDisconnect] Complete");
-        this.emit("disconnect");
-        if (subscription) {
-          subscription.unsubscribe();
-        }
-      },
+      }
     });
-    return subscription;
   }
 }

--- a/libs/live-dmk-shared/src/config/activeDeviceSession.test.ts
+++ b/libs/live-dmk-shared/src/config/activeDeviceSession.test.ts
@@ -1,0 +1,114 @@
+import {
+  type ConnectedDevice,
+  type DeviceManagementKit,
+  type DeviceSessionState,
+  DeviceStatus,
+} from "@ledgerhq/device-management-kit";
+import { Subject } from "rxjs";
+
+import { ActiveDeviceSessionRegistry } from "./activeDeviceSession";
+
+const makeDmk = () => {
+  const sessionState = new Subject<DeviceSessionState>();
+  const dmk = {
+    getDeviceSessionState: jest.fn(() => sessionState.asObservable()),
+    getConnectedDevice: jest.fn(),
+  } as unknown as jest.Mocked<DeviceManagementKit>;
+
+  return { dmk, sessionState };
+};
+
+describe("ActiveDeviceSessionRegistry", () => {
+  let registry: ActiveDeviceSessionRegistry;
+
+  beforeEach(() => {
+    registry = new ActiveDeviceSessionRegistry();
+  });
+
+  afterEach(() => {
+    registry.dispose();
+    jest.clearAllMocks();
+  });
+
+  it("adds a session and subscribes to its session state", () => {
+    const { dmk } = makeDmk();
+
+    registry.addSession({ sessionId: "session-1", dmk });
+
+    expect(registry.getSession("session-1")).toEqual({ sessionId: "session-1", dmk });
+    expect(dmk.getDeviceSessionState).toHaveBeenCalledWith({ sessionId: "session-1" });
+  });
+
+  it("removes a session when it becomes disconnected", () => {
+    const { dmk, sessionState } = makeDmk();
+    registry.addSession({ sessionId: "session-1", dmk });
+
+    sessionState.next({ deviceStatus: DeviceStatus.NOT_CONNECTED } as DeviceSessionState);
+
+    expect(registry.getSession("session-1")).toBeNull();
+  });
+
+  it("unsubscribes when removing a session", () => {
+    const { dmk, sessionState } = makeDmk();
+    registry.addSession({ sessionId: "session-1", dmk });
+
+    registry.removeSession("session-1");
+
+    expect(registry.getSession("session-1")).toBeNull();
+    expect(sessionState.observed).toBe(false);
+  });
+
+  it("disposes all sessions", () => {
+    const first = makeDmk();
+    const second = makeDmk();
+    registry.addSession({ sessionId: "session-1", dmk: first.dmk });
+    registry.addSession({ sessionId: "session-2", dmk: second.dmk });
+
+    registry.dispose();
+
+    expect(registry.getSessions()).toEqual([]);
+    expect(first.sessionState.observed).toBe(false);
+    expect(second.sessionState.observed).toBe(false);
+  });
+
+  it("supports multiple simultaneous sessions", () => {
+    const first = makeDmk();
+    const second = makeDmk();
+
+    registry.addSession({ sessionId: "session-1", dmk: first.dmk });
+    registry.addSession({ sessionId: "session-2", dmk: second.dmk });
+
+    expect(registry.getSessions()).toEqual([
+      { sessionId: "session-1", dmk: first.dmk },
+      { sessionId: "session-2", dmk: second.dmk },
+    ]);
+  });
+
+  it("finds a matching session from connected device metadata", () => {
+    const { dmk } = makeDmk();
+    jest.mocked(dmk.getConnectedDevice).mockReturnValue({
+      id: "device-1",
+      type: "BLE",
+    } as ConnectedDevice);
+    registry.addSession({ sessionId: "session-1", dmk });
+
+    const session = registry.findSession(
+      (_, connectedDevice) => connectedDevice.type === "BLE" && connectedDevice.id === "device-1",
+    );
+
+    expect(session).toEqual({ sessionId: "session-1", dmk });
+  });
+
+  it("cleans invalid sessions during lookup", () => {
+    const { dmk } = makeDmk();
+    jest.mocked(dmk.getConnectedDevice).mockImplementation(() => {
+      throw new Error("stale session");
+    });
+    registry.addSession({ sessionId: "session-1", dmk });
+
+    const session = registry.findSession(() => true);
+
+    expect(session).toBeNull();
+    expect(registry.getSession("session-1")).toBeNull();
+  });
+});

--- a/libs/live-dmk-shared/src/config/activeDeviceSession.ts
+++ b/libs/live-dmk-shared/src/config/activeDeviceSession.ts
@@ -1,15 +1,134 @@
-import { BehaviorSubject, Subscription } from "rxjs";
-import Transport from "@ledgerhq/hw-transport";
-import { DeviceManagementKit } from "@ledgerhq/device-management-kit";
+import {
+  type ConnectedDevice,
+  type DeviceManagementKit,
+  DeviceStatus,
+} from "@ledgerhq/device-management-kit";
+import { BehaviorSubject, type Subscription } from "rxjs";
 
-export type DMKTransport = Transport & {
+export type ActiveDeviceSession = {
   sessionId: string;
   dmk: DeviceManagementKit;
-  listenToDisconnect: () => Subscription;
-  disconnect: (id?: string) => Promise<void> | void;
 };
 
-export const activeDeviceSessionSubject = new BehaviorSubject<{
-  sessionId: string;
-  transport: DMKTransport;
-} | null>(null);
+type StoredActiveDeviceSession = ActiveDeviceSession & {
+  subscription: Subscription;
+};
+
+type ActiveDeviceSessionPredicate = (
+  session: ActiveDeviceSession,
+  connectedDevice: ConnectedDevice,
+) => boolean;
+
+export class ActiveDeviceSessionRegistry {
+  private readonly sessions = new Map<string, StoredActiveDeviceSession>();
+
+  private readonly sessionsSubject = new BehaviorSubject<ActiveDeviceSession[]>([]);
+
+  addSession(session: ActiveDeviceSession): void {
+    this.removeSession(session.sessionId);
+
+    let shouldKeepSession = true;
+    const subscription = session.dmk
+      .getDeviceSessionState({ sessionId: session.sessionId })
+      .subscribe({
+        next: state => {
+          if (state.deviceStatus === DeviceStatus.NOT_CONNECTED) {
+            shouldKeepSession = false;
+            this.removeSession(session.sessionId);
+          }
+        },
+        error: () => {
+          shouldKeepSession = false;
+          this.removeSession(session.sessionId);
+        },
+        complete: () => {
+          shouldKeepSession = false;
+          this.removeSession(session.sessionId);
+        },
+      });
+
+    if (!shouldKeepSession) {
+      subscription.unsubscribe();
+      return;
+    }
+
+    this.sessions.set(session.sessionId, { ...session, subscription });
+    this.emitSessions();
+  }
+
+  removeSession(sessionId: string): void {
+    const session = this.sessions.get(sessionId);
+
+    if (!session) {
+      return;
+    }
+
+    session.subscription.unsubscribe();
+    this.sessions.delete(sessionId);
+    this.emitSessions();
+  }
+
+  getSession(sessionId: string): ActiveDeviceSession | null {
+    const session = this.sessions.get(sessionId);
+
+    return session ? this.toPublicSession(session) : null;
+  }
+
+  getSessions(): ActiveDeviceSession[] {
+    return Array.from(this.sessions.values(), session => this.toPublicSession(session));
+  }
+
+  getConnectedDevice(sessionId: string): ConnectedDevice | null {
+    const session = this.sessions.get(sessionId);
+
+    if (!session) {
+      return null;
+    }
+
+    try {
+      return session.dmk.getConnectedDevice({ sessionId });
+    } catch {
+      this.removeSession(sessionId);
+      return null;
+    }
+  }
+
+  findSession(predicate: ActiveDeviceSessionPredicate): ActiveDeviceSession | null {
+    for (const session of this.getSessions()) {
+      const connectedDevice = this.getConnectedDevice(session.sessionId);
+
+      if (connectedDevice && predicate(session, connectedDevice)) {
+        return session;
+      }
+    }
+
+    return null;
+  }
+
+  subscribe(listener: (sessions: ActiveDeviceSession[]) => void): Subscription {
+    return this.sessionsSubject.subscribe(listener);
+  }
+
+  dispose(): void {
+    for (const sessionId of Array.from(this.sessions.keys())) {
+      this.removeSession(sessionId);
+    }
+  }
+
+  clear(): void {
+    this.dispose();
+  }
+
+  private emitSessions(): void {
+    this.sessionsSubject.next(this.getSessions());
+  }
+
+  private toPublicSession(session: StoredActiveDeviceSession): ActiveDeviceSession {
+    return {
+      sessionId: session.sessionId,
+      dmk: session.dmk,
+    };
+  }
+}
+
+export const activeDeviceSessionRegistry = new ActiveDeviceSessionRegistry();

--- a/libs/live-dmk-shared/src/hooks/useDeviceSessionState.test.tsx
+++ b/libs/live-dmk-shared/src/hooks/useDeviceSessionState.test.tsx
@@ -1,13 +1,13 @@
-import { act, render } from "@testing-library/react";
+import { act, cleanup, render } from "@testing-library/react";
 import React from "react";
-import { of } from "rxjs";
+import { Subject } from "rxjs";
 import {
   DeviceManagementKit,
   DeviceSessionState,
   DeviceStatus,
 } from "@ledgerhq/device-management-kit";
 import { useDeviceSessionState } from "./useDeviceSessionState";
-import { activeDeviceSessionSubject } from "../config/activeDeviceSession";
+import { activeDeviceSessionRegistry } from "../config/activeDeviceSession";
 
 const TestComponent: React.FC<{ dmk: DeviceManagementKit }> = ({ dmk }) => {
   const sessionState = useDeviceSessionState(dmk);
@@ -16,30 +16,26 @@ const TestComponent: React.FC<{ dmk: DeviceManagementKit }> = ({ dmk }) => {
 
 describe("useDeviceSessionState", () => {
   let deviceManagementKitMock: DeviceManagementKit;
+  let sessionStateSubject: Subject<DeviceSessionState>;
 
   beforeEach(() => {
+    sessionStateSubject = new Subject<DeviceSessionState>();
     deviceManagementKitMock = {
       getDeviceSessionState: jest.fn(),
     } as unknown as DeviceManagementKit;
 
     jest
       .spyOn(deviceManagementKitMock, "getDeviceSessionState")
-      .mockImplementation(({ sessionId }) =>
-        of({
-          deviceStatus:
-            sessionId === "valid-session" ? DeviceStatus.CONNECTED : DeviceStatus.NOT_CONNECTED,
-        } as DeviceSessionState),
-      );
+      .mockReturnValue(sessionStateSubject.asObservable());
   });
 
   afterEach(() => {
+    cleanup();
+    activeDeviceSessionRegistry.dispose();
     jest.clearAllMocks();
   });
 
   it("provides a default state when there is no active session", async () => {
-    // given
-    activeDeviceSessionSubject.next(null);
-
     // when
     const result = await act(async () =>
       render(<TestComponent dmk={deviceManagementKitMock as unknown as DeviceManagementKit} />),
@@ -53,31 +49,45 @@ describe("useDeviceSessionState", () => {
 
   it("should display the device status when an active session is found", async () => {
     // given
-    activeDeviceSessionSubject.next({ sessionId: "valid-session", transport: {} as any });
+    activeDeviceSessionRegistry.addSession({
+      sessionId: "valid-session",
+      dmk: deviceManagementKitMock,
+    });
     // when
     const result = await act(async () =>
       render(<TestComponent dmk={deviceManagementKitMock as unknown as DeviceManagementKit} />),
     );
     const { getByTestId } = result;
     const statusElement = getByTestId("device-status");
+    await act(async () => {
+      sessionStateSubject.next({ deviceStatus: DeviceStatus.CONNECTED } as DeviceSessionState);
+    });
     // then
     expect(statusElement).toHaveTextContent("CONNECTED");
   });
 
   it("should update the state when the device disconnects", async () => {
     // given
-    activeDeviceSessionSubject.next({ sessionId: "valid-session", transport: {} as any });
+    activeDeviceSessionRegistry.addSession({
+      sessionId: "valid-session",
+      dmk: deviceManagementKitMock,
+    });
     // when
     const result = await act(async () =>
       render(<TestComponent dmk={deviceManagementKitMock as unknown as DeviceManagementKit} />),
     );
     const { getByTestId } = result;
     const statusElement = getByTestId("device-status");
+    await act(async () => {
+      sessionStateSubject.next({ deviceStatus: DeviceStatus.CONNECTED } as DeviceSessionState);
+    });
     // then
     expect(statusElement).toHaveTextContent("CONNECTED");
     // and when
     await act(async () => {
-      activeDeviceSessionSubject.next(null);
+      sessionStateSubject.next({
+        deviceStatus: DeviceStatus.NOT_CONNECTED,
+      } as DeviceSessionState);
     });
     // then
     expect(statusElement).toHaveTextContent("null");

--- a/libs/live-dmk-shared/src/hooks/useDeviceSessionState.tsx
+++ b/libs/live-dmk-shared/src/hooks/useDeviceSessionState.tsx
@@ -4,7 +4,7 @@ import {
   DeviceStatus,
 } from "@ledgerhq/device-management-kit";
 import { useState, useEffect } from "react";
-import { activeDeviceSessionSubject } from "../config/activeDeviceSession";
+import { activeDeviceSessionRegistry } from "../config/activeDeviceSession";
 
 export const useDeviceSessionState = (
   dmk: DeviceManagementKit | null,
@@ -13,27 +13,34 @@ export const useDeviceSessionState = (
 
   useEffect(() => {
     if (!dmk) return;
-    const subscription = activeDeviceSessionSubject.subscribe({
-      next: session => {
-        if (!session) {
+    let stateSubscription: { unsubscribe: () => void } | null = null;
+    const subscription = activeDeviceSessionRegistry.subscribe(sessions => {
+      stateSubscription?.unsubscribe();
+      stateSubscription = null;
+
+      const session = sessions.find(session => session.dmk === dmk) ?? sessions[0];
+
+      if (!session) {
+        setSessionState(undefined);
+        return;
+      }
+
+      stateSubscription = session.dmk.getDeviceSessionState({ sessionId: session.sessionId }).subscribe({
+        next: (state: DeviceSessionState) => {
+          if (state.deviceStatus !== DeviceStatus.NOT_CONNECTED) {
+            setSessionState(state);
+          } else {
           setSessionState(undefined);
-        } else {
-          const { sessionId } = session;
-          const stateSubscription = dmk.getDeviceSessionState({ sessionId }).subscribe({
-            next: (state: DeviceSessionState) => {
-              state.deviceStatus !== DeviceStatus.NOT_CONNECTED
-                ? setSessionState(state)
-                : setSessionState(undefined);
-            },
-            error: (error: Error) => console.error("[useDeviceSessionState] error", error),
-          });
-          return () => stateSubscription.unsubscribe();
-        }
-      },
-      error: error => console.error("[useDeviceSessionState] subscription error", error),
+          }
+        },
+        error: (error: Error) => console.error("[useDeviceSessionState] error", error),
+      });
     });
 
-    return () => subscription.unsubscribe();
+    return () => {
+      stateSubscription?.unsubscribe();
+      subscription.unsubscribe();
+    };
   }, [dmk]);
 
   return sessionState;

--- a/libs/live-dmk-shared/src/index.ts
+++ b/libs/live-dmk-shared/src/index.ts
@@ -1,6 +1,10 @@
 export * from "./hooks";
 export type { KnownDevice } from "./connectDevice/types";
-export { activeDeviceSessionSubject } from "./config/activeDeviceSession";
+export {
+  ActiveDeviceSessionRegistry,
+  activeDeviceSessionRegistry,
+  type ActiveDeviceSession,
+} from "./config/activeDeviceSession";
 export { dmkToLedgerDeviceIdMap, ledgerToDmkDeviceIdMap } from "./config/dmkToLedgerDeviceIdMap";
 export { LedgerLiveLogger } from "./services/LedgerLiveLogger";
 export { UserHashService } from "./services/UserHashService";


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - DMK session reuse in legacy BLE, HID, and desktop transport adapters
  - Cleanup of disconnected DMK sessions
  - `useDeviceSessionState` consumers
  - BLE pairing session registration

### 📝 Description

This PR introduces a shared DMK session registry used by the DMK transport packages to track active device sessions. The registry stores only the minimal session ownership data, `{ sessionId, dmk }`, and is responsible for subscribing to each session state. When DMK reports `DeviceStatus.NOT_CONNECTED`, or when the session state stream ends, the registry removes the session and releases its subscription.

Previously, active session state was split across incompatible implementations. BLE and desktop transports relied on `@ledgerhq/live-dmk-shared`'s `activeDeviceSessionSubject`, while the mobile HID transport had its own local subject with the same name. Those subjects stored transport instances, which made session reuse depend on a specific adapter object instead of the DMK session itself. That made it easy for different flows to miss each other's sessions, and it also mixed two responsibilities: tracking an active DMK session and returning a legacy transport implementation.

The new registry separates those concerns. It centralizes session lifecycle tracking, but it does not store transport instances. Legacy adapters now query the registry for a reusable DMK session and then create their own transport instance around the matching `sessionId`, preserving each adapter's own `exchange` implementation. This keeps BLE, HID, and desktop behavior compatible while making the session source of truth shared and extensible for multiple simultaneous sessions.

Concretely, this PR:

- Replaces the shared active-session subject with `ActiveDeviceSessionRegistry`.
- Removes the duplicate HID-local active-session subject.
- Moves active session cleanup to the registry through `dmk.getDeviceSessionState` subscriptions.
- Adds `dispose()`/`clear()` to release all registry subscriptions when the DMK provider unmounts.
- Updates BLE, HID, and desktop legacy transports to reuse registry sessions without reusing stored transport objects.
- Updates `useBleDevicePairing` to register sessions without creating a BLE transport only for subject compatibility.
- Updates shared hook and transport tests, and adds direct registry unit coverage.

### ❓ Context

- **JIRA or GitHub link**: N/A
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)