### PR TITLE
[LWDM] fix(coin-tezos): include tokenId in FA2 assetReference (LIVE-30344)

### DIFF
--- a/.changeset/fa2-assetreference-tokenid.md
+++ b/.changeset/fa2-assetreference-tokenid.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tezos": patch
+---
+
+fix(coin-tezos): include tokenId in FA2 assetReference format (LIVE-30344)

--- a/libs/coin-modules/coin-tezos/src/logic/getBalance.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBalance.test.ts
@@ -111,7 +111,7 @@ describe("getBalance", () => {
         value: BigInt("2000"),
         asset: {
           type: "fa2",
-          assetReference: "KT1T87QbpXEVgkwsNPzz8iRoah3SS3D1MDmh",
+          assetReference: "KT1T87QbpXEVgkwsNPzz8iRoah3SS3D1MDmh:0",
           assetOwner: "tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8",
           name: "BTCtz",
           unit: { magnitude: 8, name: "BTCtez", code: "BTCtz" },
@@ -141,7 +141,7 @@ describe("getBalance", () => {
         value: 2000n,
         asset: {
           type: "fa2",
-          assetReference: "KT1T87QbpXEVgkwsNPzz8iRoah3SS3D1MDmh",
+          assetReference: "KT1T87QbpXEVgkwsNPzz8iRoah3SS3D1MDmh:0",
           assetOwner: "tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oMMM",
           name: "BTCtz",
           unit: {

--- a/libs/coin-modules/coin-tezos/src/logic/getBalance.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBalance.ts
@@ -56,7 +56,7 @@ export async function getBalance(address: string): Promise<Balance[]> {
       value: BigInt(balance),
       asset: {
         type: token.standard,
-        assetReference: token.contract.address,
+        assetReference: `${token.contract.address}:${token.tokenId ?? "0"}`,
         assetOwner: address,
         name: token.contract.alias,
         ...(unit && { unit }),

--- a/libs/coin-modules/coin-tezos/src/logic/listOperations.integ.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/listOperations.integ.test.ts
@@ -11,7 +11,9 @@ import { listOperations } from "./listOperations";
 const ADDRESS = "tz1UD2zz5eFTW2Jy26kBnC3ZkdeazUgeFWST";
 /** FA2 USDt contract for this account on mainnet (TzKT). */
 const USDT_FA2_CONTRACT = "KT1XnTn74bUtxHfDtBmm2bGZAQfhPbvKWR8o";
-const KT1_PATTERN = /^KT1[1-9A-HJ-NP-Za-km-z]+$/;
+/** Expected assetReference after the LIVE-30344 fix: contract:tokenId. USDt tokenId is 0. */
+const USDT_FA2_ASSET_REF = `${USDT_FA2_CONTRACT}:0`;
+const KT1_ASSET_REF_PATTERN = /^KT1[1-9A-HJ-NP-Za-km-z]+:\d+$/;
 
 const mainnetConfig = (): TezosCoinConfig =>
   ({
@@ -53,7 +55,7 @@ describe("listOperations — mainnet FA2 / convertTokenOperation", () => {
     const [operations] = await listOperations(ADDRESS, { ...baseOpts, limit: 200 });
     const fa2 = operations.find(op => {
       if (op.asset.type !== "fa2") return false;
-      return op.asset.assetReference === USDT_FA2_CONTRACT;
+      return op.asset.assetReference === USDT_FA2_ASSET_REF;
     });
 
     const tokenOp = fa2!;
@@ -67,8 +69,8 @@ describe("listOperations — mainnet FA2 / convertTokenOperation", () => {
       type: "fa2",
       assetOwner: ADDRESS,
     });
-    expect(asset.assetReference).toMatch(KT1_PATTERN);
-    expect(asset.assetReference).toBe(USDT_FA2_CONTRACT);
+    expect(asset.assetReference).toMatch(KT1_ASSET_REF_PATTERN);
+    expect(asset.assetReference).toBe(USDT_FA2_ASSET_REF);
     const unit = asset.unit!;
     expect(typeof unit.magnitude).toBe("number");
     expect(unit.magnitude).toBeGreaterThanOrEqual(0);

--- a/libs/coin-modules/coin-tezos/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/listOperations.test.ts
@@ -428,7 +428,7 @@ describe("listOperations", () => {
       value: 1_000_000n,
       asset: {
         type: "fa2",
-        assetReference: "KT1TokenContract",
+        assetReference: "KT1TokenContract:0",
         assetOwner: someDestinationAddress,
         unit: { magnitude: 6, name: "Tok", code: "TOK" },
       },
@@ -480,7 +480,6 @@ describe("listOperations", () => {
     const [results] = await listOperations(someDestinationAddress, options);
     const tokenOp = results.find(o => o.asset.type === "fa2");
 
-    expect(tokenOp).toBeDefined();
     expect(tokenOp!.tx.block.hash).toBe("BLK_FROM_TRANSFER");
   });
 
@@ -509,7 +508,6 @@ describe("listOperations", () => {
     const [results] = await listOperations(someSenderAddress, options);
     expect(results).toHaveLength(1);
     const out = results[0];
-    expect(out).toBeDefined();
     expect(out!.tx.failed).toBe(true);
     expect(out!.type).toBe("OUT");
   });
@@ -526,7 +524,6 @@ describe("listOperations", () => {
     const [results] = await listOperations(someDestinationAddress, options);
     expect(results).toHaveLength(1);
     const row = results[0];
-    expect(row).toBeDefined();
     expect(row!.type).toBe("IN");
     expect(row!.details?.ledgerOpType).toBeUndefined();
   });
@@ -544,7 +541,6 @@ describe("listOperations", () => {
     const [results] = await listOperations(someSenderAddress, options);
     expect(results).toHaveLength(1);
     const selfRow = results[0];
-    expect(selfRow).toBeDefined();
     expect(selfRow!.type).toBe("FEES");
     expect(selfRow!.details?.ledgerOpType).toBe("FEES");
   });
@@ -562,7 +558,6 @@ describe("listOperations", () => {
     const [results] = await listOperations(someSenderAddress, options);
     expect(results).toHaveLength(1);
     const zeroRow = results[0];
-    expect(zeroRow).toBeDefined();
     expect(zeroRow!.type).toBe("FEES");
     expect(zeroRow!.details?.ledgerOpType).toBe("FEES");
   });
@@ -598,7 +593,6 @@ describe("listOperations", () => {
     mockGetAccountTokenTransfers.mockResolvedValue([fa2Out]);
     const [results] = await listOperations(someSenderAddress, options);
     const tokenOut = results.find(o => o.asset.type === "fa2");
-    expect(tokenOut).toBeDefined();
     expect(tokenOut!.type).toBe("OUT");
     expect(tokenOut!.details?.ledgerOpType).toBe("OUT");
   });
@@ -623,7 +617,6 @@ describe("listOperations", () => {
     mockGetAccountTokenTransfers.mockResolvedValue([fa2Self]);
     const [results] = await listOperations(someSenderAddress, options);
     const tokenSelf = results.find(o => o.asset.type === "fa2");
-    expect(tokenSelf).toBeDefined();
     expect(tokenSelf!.type).toBe("FEES");
     expect(tokenSelf!.details?.ledgerOpType).toBe("FEES");
   });
@@ -649,7 +642,6 @@ describe("listOperations", () => {
     mockGetAccountTokenTransfers.mockResolvedValue([fa2Orphan]);
     const [results] = await listOperations(someDestinationAddress, options);
     const orphan = results.find(o => o.asset.type === "fa2");
-    expect(orphan).toBeDefined();
     expect(orphan!.tx.fees).toBe(0n);
     expect(orphan!.tx.feesPayer).toBeUndefined();
     expect(orphan!.tx.block.hash).toBe("BLK_ORPHAN");
@@ -676,7 +668,6 @@ describe("listOperations", () => {
     mockGetAccountTokenTransfers.mockResolvedValue([fa2NoBlock]);
     const [results] = await listOperations(someDestinationAddress, options);
     const noBlock = results.find(o => o.asset.type === "fa2");
-    expect(noBlock).toBeDefined();
     expect(noBlock!.tx.block.hash).toBe("");
   });
 
@@ -982,6 +973,59 @@ describe("listOperations", () => {
     });
 
     expect(cursor).not.toBe("");
+  });
+
+  describe("FA2 assetReference must include tokenId", () => {
+    const makeFA2Transfer = (
+      tokenId: string,
+      contractAddress: string,
+      id: number,
+    ): APITokenTransfer & { hash: string } => ({
+      id,
+      level: 200,
+      timestamp: "2024-01-01T00:00:00Z",
+      token: {
+        id: 1,
+        contract: { address: contractAddress },
+        tokenId,
+        standard: "fa2",
+      },
+      from: { address: someSenderAddress },
+      to: { address: someDestinationAddress },
+      amount: "100",
+      hash: "ooLive30344Hash",
+    });
+
+    it("includes tokenId in assetReference for a non-zero tokenId", async () => {
+      mockGetAccountOperations.mockResolvedValue([]);
+      mockGetAccountTokenTransfers.mockResolvedValue([
+        makeFA2Transfer("42", "KT1MultiToken", 10_001),
+      ]);
+      const [results] = await listOperations(someDestinationAddress, options);
+      const op = results.find(o => o.asset.type === "fa2");
+      expect(op!.asset).toMatchObject({ assetReference: "KT1MultiToken:42" });
+    });
+
+    it("includes :0 suffix in assetReference when tokenId is 0", async () => {
+      mockGetAccountOperations.mockResolvedValue([]);
+      mockGetAccountTokenTransfers.mockResolvedValue([makeFA2Transfer("0", "KT1Standard", 10_002)]);
+      const [results] = await listOperations(someDestinationAddress, options);
+      const op = results.find(o => o.asset.type === "fa2");
+      expect(op!.asset).toMatchObject({ assetReference: "KT1Standard:0" });
+    });
+
+    it("defaults to :0 suffix when tokenId is undefined", async () => {
+      const fa2NoTokenId: APITokenTransfer & { hash: string } = {
+        ...makeFA2Transfer("0", "KT1NoId", 10_003),
+        // @ts-expect-error testing missing tokenId
+        token: { id: 1, contract: { address: "KT1NoId" }, standard: "fa2" },
+      };
+      mockGetAccountOperations.mockResolvedValue([]);
+      mockGetAccountTokenTransfers.mockResolvedValue([fa2NoTokenId]);
+      const [results] = await listOperations(someDestinationAddress, options);
+      const op = results.find(o => o.asset.type === "fa2");
+      expect(op!.asset).toMatchObject({ assetReference: "KT1NoId:0" });
+    });
   });
 
   describe("staking operations (Paris adaptive issuance)", () => {

--- a/libs/coin-modules/coin-tezos/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/listOperations.ts
@@ -548,7 +548,8 @@ function convertTokenOperation(
     : 0n;
   const feesPayer = parent?.initiator?.address ?? parent?.sender?.address;
 
-  const assetReference = transfer.token.contract.address;
+  const tokenId = transfer.token.tokenId ?? "0";
+  const assetReference = `${transfer.token.contract.address}:${tokenId}`;
 
   return {
     id: `${transfer.hash}-token-${transfer.id}`,


### PR DESCRIPTION
  ### ✅ Checklist                                                                                                                                                                                                         
                                                                                                                                                                                                                           
  - [X] `npx changeset` was attached.                                                                                                                                                                                      
  - [X] **Covered by automatic tests.**                                                                                                                                                                                    
  - [X] **Impact of the changes:**                          
    - `@ledgerhq/coin-tezos` — `listOperations` and `getBalance` return a corrected `assetReference` for FA2 tokens                                                                                                        
    - Any consumer joining a balance to an operation using `assetReference` equality will now correctly match (previously the two formats were inconsistent)                                                               
    - Any consumer distinguishing two FA2 tokens from the same contract with different `tokenId`s will now work correctly                                                                                                  
                                                                                                                                                                                                                           
  ### 📝 Description                                                                                                                                                                                                       
                                                                                                                                                                                                                           
  Fixes FA2 `assetReference` format inconsistency between `listOperations`, `getBalance`, and `getBlock`.                                                                                                                  
  
  **LIVE-30344 — Missing `tokenId` in FA2 `assetReference`**                                                                                                                                                               
                                                            
  `convertTokenOperation` (in `listOperations`) and `getBalance` both produced an `assetReference` equal to the bare contract address (e.g. `"KT1XnTn..."`) instead of the `contract:tokenId` format already used by       
  `getBlock` (e.g. `"KT1XnTn...:0"`). This made it impossible to reliably distinguish two FA2 tokens from the same contract with different `tokenId`s, and broke any consumer joining a balance to an operation by
  `assetReference` equality.                                                                                                                                                                                               
                                                            
  Fix: align all three producers to `"${contract.address}:${token.tokenId ?? "0"}"`.                                                                                                                                       
  
  ### ❓ Context                                                                                                                                                                                                           
                                                            
  - **JIRA**: [LIVE-30344](https://ledgerhq.atlassian.net/browse/LIVE-30344) 

[LIVE-30344]: https://ledgerhq.atlassian.net/browse/LIVE-30344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ