### PR TITLE
ci(mobile): select platform-specific speculos devices for nightly runs

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -162,6 +162,8 @@ jobs:
     name: "Determine Builds & Generate Shards"
     runs-on: ubuntu-24.04
     outputs:
+      ios_device: ${{ steps.devices.outputs.ios_device }}
+      android_device: ${{ steps.devices.outputs.android_device }}
       matrix_ios: ${{ steps.generate-shards.outputs.matrix_ios }}
       matrix_android: ${{ steps.generate-shards.outputs.matrix_android }}
       test_files_for_sharding: ${{ steps.generate-shards.outputs.test_files_for_sharding }}
@@ -221,10 +223,30 @@ jobs:
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
 
+      - name: Resolve per-platform Speculos device
+        id: devices
+        shell: bash
+        run: |
+          # Per-platform mapping for scheduled nightly runs (QAA-1193)
+          declare -A PLATFORM_DEVICE=(
+            [ios]=stax        # iOS     - Stax
+            [android]=nanoX   # Android - LNX
+          )
+
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "ios_device=${PLATFORM_DEVICE[ios]}"           >> $GITHUB_OUTPUT
+            echo "android_device=${PLATFORM_DEVICE[android]}"  >> $GITHUB_OUTPUT
+          else
+            INPUT_DEVICE="${{ inputs.speculos_device || 'nanoX' }}"
+            echo "ios_device=$INPUT_DEVICE"     >> $GITHUB_OUTPUT
+            echo "android_device=$INPUT_DEVICE" >> $GITHUB_OUTPUT
+          fi
+
       - name: Write summary
         run: |
           FILTER_PATTERN="${{ inputs.test_filter || '' }}"
-          DEVICE="${{ inputs.speculos_device || 'nanoX' }}"
+          IOS_DEVICE="${{ steps.devices.outputs.ios_device }}"
+          ANDROID_DEVICE="${{ steps.devices.outputs.android_device }}"
           BUILD_TYPE="${{ inputs.production_firebase && 'production' || 'testing' }}"
           BROADCAST_ENABLED="${{ inputs.enable_broadcast }}"
           SMOKE_TESTS="${{ inputs.smoke_tests }}"
@@ -240,7 +262,8 @@ jobs:
           echo "- **Workflow source branch:** ${{ github.ref_name }}"
           echo "- **Triggered branch:** ${{ inputs.ref || github.ref_name }}"
           echo "- **Commit SHA:** ${{ github.sha }}"
-          echo "- **Device selected:** $DEVICE"
+          echo "- **iOS device:** $IOS_DEVICE"
+          echo "- **Android device:** $ANDROID_DEVICE"
           echo "- **Filtered pattern:** $FILTER_PATTERN"
           echo "- **Smoke tests:** $SMOKE_TESTS"
           echo "- **Test Execution ticket ID (Android):** $TEST_EXECUTION_ANDROID"
@@ -434,6 +457,7 @@ jobs:
       LANG: en_US.UTF-8
       LANGUAGE: en_US.UTF-8
       LC_ALL: en_US.UTF-8
+      SPECULOS_DEVICE: ${{ needs.determine-builds.outputs.ios_device }}
     outputs:
       status: ${{ steps.run-ios.outcome }}
       artifact: ${{ steps.test-artifacts.outputs.artifact-id }}
@@ -633,6 +657,7 @@ jobs:
       LANG: en_US.UTF-8
       LANGUAGE: en_US.UTF-8
       LC_ALL: en_US.UTF-8
+      SPECULOS_DEVICE: ${{ needs.determine-builds.outputs.android_device }}
     outputs:
       status: ${{ steps.run-android.outcome }}
       artifact: ${{ steps.test-artifacts.outputs.artifact-id }}
@@ -1050,7 +1075,7 @@ jobs:
   report-on-slack:
     name: "Test Mobile E2E > Slack Report"
     runs-on: ubuntu-22.04
-    needs: [allure-report-android, allure-report-ios]
+    needs: [determine-builds, allure-report-android, allure-report-ios]
     if: ${{ !cancelled() && (needs.allure-report-ios.outputs.finalStatus || needs.allure-report-android.outputs.finalStatus) }}
     env:
       IOS_STATUS: ${{ needs.allure-report-ios.outputs.finalStatus }}
@@ -1073,7 +1098,7 @@ jobs:
                 "type": "header",
                 "text": {
                   "type": "plain_text",
-                  "text": ":ledger-logo: Ledger Live Mobile E2E tests results on ${{ inputs.ref || github.ref_name }} - ${{ inputs.speculos_device || 'nanoX' }}${{ inputs.smoke_tests && ' (Smoke Tests)' || '' }}",
+                  "text": ":ledger-logo: Ledger Live Mobile E2E tests results on ${{ inputs.ref || github.ref_name }} - iOS:${{ needs.determine-builds.outputs.ios_device }} / Android:${{ needs.determine-builds.outputs.android_device }}${{ inputs.smoke_tests && ' (Smoke Tests)' || '' }}",
                   "emoji": true
                 }
               },
@@ -1087,7 +1112,7 @@ jobs:
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": `- 🍏 iOS - ${{ inputs.speculos_device }}: ${process.env.IOS_STATUS !== 'success' ? '❌' : '✅'} ${{ needs.allure-report-ios.outputs.result || 'No test results' }}`
+                  "text": `- 🍏 iOS - ${{ needs.determine-builds.outputs.ios_device }}: ${process.env.IOS_STATUS !== 'success' ? '❌' : '✅'} ${{ needs.allure-report-ios.outputs.result || 'No test results' }}`
                 }
               }
             ];
@@ -1097,7 +1122,7 @@ jobs:
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": `- 🤖 Android - ${{ inputs.speculos_device }}: ${process.env.ANDROID_STATUS !== 'success' ? '❌' : '✅'} ${{ needs.allure-report-android.outputs.result || 'No test results' }}`
+                  "text": `- 🤖 Android - ${{ needs.determine-builds.outputs.android_device }}: ${process.env.ANDROID_STATUS !== 'success' ? '❌' : '✅'} ${{ needs.allure-report-android.outputs.result || 'No test results' }}`
                 }
               }
             ];


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _Not applicable — change is CI-only (`.github/workflows/`), no published package affected. Matches recent precedent (e.g. `ci(devtools): point reusable workflows to develop`)._
- [ ] **Covered by automatic tests.** _Verified locally with a bash harness simulating `schedule` and `workflow_dispatch` events — both produce the expected `ios_device` / `android_device` step outputs. `act` was not used because `determine-builds` depends on the `setup-caches` composite (resolved by full monorepo clone) and several secrets — out of reach for local emulation. No dedicated test infra exists in the repo for inline workflow scripts._
- [x] **Impact of the changes:**
  - LWM nightly E2E runs (`.github/workflows/test-mobile-e2e-reusable.yml`) now pick the Speculos device per platform: iOS → `stax`, Android → `nanoX`.
  - Manual `workflow_dispatch` and `workflow_call` paths are unchanged — they still honour the explicit `speculos_device` input on both platforms.
  - Slack notifier and the job summary now read the resolved device from `determine-builds.outputs.{ios,android}_device` instead of the (empty-on-schedule) input.

### 📝 Description

LWM nightly coverage previously ran on `nanoX` for both platforms because the scheduled trigger doesn't pass `inputs.speculos_device`, so the workflow-level fallback always applied. This PR fixes one device per mobile platform, satisfying QAA-1193: iOS exercises Stax-flow paths every night and Android exercises the LNX-flow paths.

**Mapping (platform → device):**

| Platform | Device   | Ticket label |
|----------|----------|--------------|
| Android  | `nanoX`  | LNX          |
| iOS      | `stax`   | Stax         |

**Implementation:**

- In the existing `determine-builds` job (the upstream setup job both platform-test jobs already depend on), a new `Resolve per-platform Speculos device` step computes `ios_device` and `android_device` outputs. On schedule events, the mapping above applies. On manual/workflow_call, both outputs equal the input device (preserving today's single-device manual UX).
- `detox-tests-ios` and `detox-tests-android` each override `SPECULOS_DEVICE` at job level with the matching output. Workflow-level `SPECULOS_DEVICE` (line 142) stays as the default for other jobs that read it.
- `Write summary` and the Slack notifier (header + per-platform lines) now read the per-platform outputs. `report-on-slack.needs` gains `determine-builds`.
- `SPECULOS_IMAGE_TAG` is intentionally **not** overridden per job — the workflow-level expression already resolves correctly for the current mapping (both `stax` and `nanoX` use `:latest`; only `nanoS` needs the pinned commit). A comment in the new step flags this for future-mapping-changers.

### ❓ Context

- **JIRA or GitHub link**: [QAA-1193](https://ledgerhq.atlassian.net/browse/QAA-1193)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA issue.
- **The PR description clearly documents the changes** made and the deliberate trade-off on `SPECULOS_IMAGE_TAG` scope.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** locally (bash harness for the new step); the manual single-device path is unchanged.
- **Any new dependencies** — none.
- **Performance** — no impact (one extra shell step in `determine-builds`).

[QAA-1193]: https://ledgerhq.atlassian.net/browse/QAA-1193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ