### PR TITLE
[LWM][E2E] check no error after DEX swap on E2E

### DIFF
--- a/e2e/mobile/page/liveApps/swapLiveApp.ts
+++ b/e2e/mobile/page/liveApps/swapLiveApp.ts
@@ -149,6 +149,12 @@ export default class SwapLiveAppPage {
     await tapWebElementByElement(button);
   }
 
+  @Step("Expect execute swap button on step approval")
+  async expectExecuteSwapOnStepApproval() {
+    await waitWebElementByTestId(this.executeSwapButtonStepApproval, { timeout: 20000 });
+    await detoxExpect(getWebElementByTestId(this.executeSwapButtonStepApproval)).toExist();
+  }
+
   @Step("Tap execute swap button on step approval")
   async tapExecuteSwapOnStepApproval() {
     await waitWebElementByTestId(this.executeSwapButtonStepApproval);

--- a/e2e/mobile/page/trade/swap.page.ts
+++ b/e2e/mobile/page/trade/swap.page.ts
@@ -36,7 +36,6 @@ export default class SwapPage extends CommonPage {
   exportOperationsButton = "enabled-export-swap-operations-link";
   swapHistoryFeedbackLink = "swap-history-feedback-link";
   swapFormTabId = "swap-form-tab";
-  swapCloseButtonCompletedTestId = "NavigationHeaderCloseButtonCompleted";
 
   operationDetails = {
     fromAccount: "swap-operation-details-fromAccount",
@@ -204,11 +203,6 @@ export default class SwapPage extends CommonPage {
       errorElementId: app.swapLiveApp.deviceActionErrorDescriptionId,
     });
     await tapById(app.common.proceedButtonId);
-  }
-
-  @Step("Wait for swap navigation header title completed")
-  async waitForSwapHeaderCompleted() {
-    await waitForElementById(this.swapCloseButtonCompletedTestId);
   }
 
   @Step("Ensure token approval")

--- a/e2e/mobile/specs/swap/otherTestCases/swapDexNativeFlow.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapDexNativeFlow.ts
@@ -57,7 +57,7 @@ export function runSwapDexNativeFlow(
       await app.send.dismissHighFeeModal();
 
       await app.swap.verifyAmountsAndAcceptSwap(swap, Number(amountToSwap).toFixed(8));
-      await app.swap.waitForSwapHeaderCompleted();
+      await app.swapLiveApp.expectExecuteSwapOnStepApproval();
     });
   });
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [X] `npx changeset` was attached. (no need)
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Mobile Dex test

### 📝 Description

Workaround to check transaction is validated on device don't work anymore. We check that we are back to Step2 so no error message after device validation.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- Mobile swap [run](https://github.com/LedgerHQ/ledger-live/actions/runs/25727250957)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
