### PR TITLE
[LWM] fix(mobile): align Transactions currency prop to CryptoOrTokenCurrency

### DIFF
--- a/.changeset/silent-tokens-shrink.md
+++ b/.changeset/silent-tokens-shrink.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix TypeScript type error in Transactions component by aligning currency prop to CryptoOrTokenCurrency

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Transactions/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Transactions/index.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { useTransactionsViewModel } from "./useTransactionsViewModel";
 import { TransactionsView } from "./TransactionsView";
 
 type Props = Readonly<{
-  currency: CryptoCurrency | undefined;
+  currency: CryptoOrTokenCurrency | undefined;
 }>;
 
 export function Transactions({ currency }: Props) {

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Transactions/useTransactionsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Transactions/useTransactionsViewModel.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from "react";
 import { useNavigation } from "@react-navigation/native";
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { Account, AccountLike, Operation } from "@ledgerhq/types-live";
 import { flattenAccounts } from "@ledgerhq/ledger-wallet-framework/account/helpers";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
@@ -15,7 +15,7 @@ import type { BaseNavigation } from "~/components/RootNavigator/types/helpers";
 
 export const MAX_PREVIEW_OPERATIONS = 3;
 
-export function useTransactionsViewModel(currency: CryptoCurrency | undefined) {
+export function useTransactionsViewModel(currency: CryptoOrTokenCurrency | undefined) {
   const navigation = useNavigation<BaseNavigation>();
 
   const accountTuples = useAccountsByCryptoCurrency(currency);


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - `Transactions` component in AssetDetail — prop type now accepts token currencies
  - `useTransactionsViewModel` hook — parameter type aligned

### 📝 Description

The `Transactions` component and its viewmodel `useTransactionsViewModel` were typed with `CryptoCurrency | undefined`, but `AssetDetailCurrencyProps` is `CryptoOrTokenCurrency | undefined` (i.e. it includes `TokenCurrency`). This caused a `TS2322` type error in CI.

Since `useAccountsByCryptoCurrency` already accepts `CryptoOrTokenCurrency`, the fix is a pure type alignment — no runtime behavior change.

### ❓ Context

- **JIRA or GitHub link**: CI failure on `AssetDetailView.tsx:46`

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)