### PR TITLE
fix(wallet-cli): make --no-<flag> negation work

### DIFF
--- a/.changeset/wallet-cli-no-verify.md
+++ b/.changeset/wallet-cli-no-verify.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-cli": patch
+---
+
+Fix `--no-verify` (and other `--no-<flag>` negations) being silently ignored. bunli's parser drops unknown flags, so `--no-verify` was a no-op and the device verification screen still appeared. argv is now pre-processed to rewrite `--no-<flag>` to `--<flag>=false`.

--- a/apps/wallet-cli/src/cli.ts
+++ b/apps/wallet-cli/src/cli.ts
@@ -39,8 +39,13 @@ export async function runMain(argv: string[] = process.argv.slice(2)): Promise<n
   cli.command(SendCommand);
   cli.command(SwapGroup);
   cli.command(GenuineCheckCommand);
-  const code = await cli.run(argv, { noExit: true });
+  const code = await cli.run(normalizeNegatedFlags(argv), { noExit: true });
   return code ?? 0;
+}
+
+// bunli silently drops unknown --no-foo flags; rewrite to --foo=false for GNU-style negation.
+function normalizeNegatedFlags(argv: string[]): string[] {
+  return argv.map(arg => (arg.startsWith("--no-") ? `--${arg.slice(5)}=false` : arg));
 }
 
 if (import.meta.main) {

--- a/apps/wallet-cli/src/commands/receive.ts
+++ b/apps/wallet-cli/src/commands/receive.ts
@@ -26,7 +26,7 @@ export default defineCommand({
     account: accountOption,
     verify: option(z.boolean().default(true), {
       description:
-        "Verify address on device screen (default: true). Use --verify=false to skip device.",
+        "Verify address on device screen (default: true). Use --no-verify to skip device.",
       short: "v",
       argumentKind: "flag",
     }),

--- a/apps/wallet-cli/src/test/commands/receive.test.ts
+++ b/apps/wallet-cli/src/test/commands/receive.test.ts
@@ -86,4 +86,17 @@ describe("receive --verify command (mock DMK)", () => {
     expect(stdout).toBe(MOCK_ETH_ADDRESS);
     expect(stderr).toContain("Warning: address was NOT verified on device");
   });
+
+  it("--no-verify is equivalent to --verify=false", async () => {
+    const fixture = makeSessionDir([{ label: "ethereum-1", descriptor: MOCK_ETH_DESCRIPTOR }]);
+    sessionCleanup = fixture.cleanup;
+    const { stdout, stderr, exitCode } = await runCli(
+      ["receive", "--account", "ethereum-1", "--no-verify", "--output", "json"],
+      { WALLET_CLI_MOCK_PORT: String(server.port), ...fixture.env },
+    );
+    expect(exitCode, `stderr: ${stderr}`).toBe(0);
+    const data = JSON.parse(stdout);
+    expect(data.verified).toBe(false);
+    expect(data.source).toBe("software-derivation");
+  });
 });


### PR DESCRIPTION
### ✅ Checklist

- [x] npx changeset was attached.
- [x] Covered by automatic tests.
- [ ] Impact of the changes:
  - QA should verify wallet-cli start receive <account> --no-verify skips the device verification screen and prints the warning, matching --verify=false.

### 📝 Description

bunli's parser silently drops unknown --<name> flags. --no-verify was therefore a no-op, the verify option kept its default true, and the device verification screen still appeared.

Fix: pre-process argv in runMain to rewrite --no-<flag> into --<flag>=false before passing to cli.run. Applies to every boolean flag declared with argumentKind flag (verify, rbf, dry-run, ...).

Before:

    $ wallet-cli start receive bitcoin-native-1 --no-verify
    ✔ Fresh address resolved
    bc1q...
    Compare the address above with what's shown on your Ledger…   ← verification still requested

After: equivalent to --verify=false, prints the not-verified warning.

### ❓ Context

- JIRA or GitHub link: [LIVE-30524](https://ledgerhq.atlassian.net/browse/LIVE-30524)
- ADR link (if any): n/a

[LIVE-30524]: https://ledgerhq.atlassian.net/browse/LIVE-30524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ