### PR TITLE
chore(cli): prepare apps/cli for async migration

### DIFF
--- a/apps/cli/rslib.config.ts
+++ b/apps/cli/rslib.config.ts
@@ -37,4 +37,15 @@ export default defineConfig({
       },
     },
   ],
+  tools: {
+    rspack: {
+      module: {
+        parser: {
+          javascript: {
+            dynamicImportMode: "eager",
+          },
+        },
+      },
+    },
+  },
 });

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -10,95 +10,7 @@ import {
   loadSetupForFamily,
 } from "@ledgerhq/live-common/coin-modules/registry";
 
-const commands = {
-  ...getRegisteredFamilies()
-    .map(family => loadSetupForFamily(family).cliTools)
-    .map((m: any) => typeof m === "object" && m && m.commands)
-    .reduce((acc: Record<string, unknown>, c) => ({ ...acc, ...c }), {}),
-  ...commandsMain,
-};
-
-const mainOptions = commandLineArgs(
-  [
-    { name: "command", defaultOption: true },
-    { name: "help", alias: "h", type: Boolean },
-  ],
-  {
-    stopAtFirstUnknown: true,
-  },
-);
-
-if (mainOptions.help || !mainOptions.command) {
-  console.log("Ledger Live @ https://github.com/LedgerHQ/ledger-live");
-  console.log("");
-  console.log("Usage: ledger-live <command> ...");
-  console.log("");
-  for (const k in commands) {
-    const cmd = commands[k];
-    console.log(
-      `Usage: ledger-live ${k} `.padEnd(30) + (cmd.description ? `# ${cmd.description}` : ""),
-    );
-    for (const opt of cmd.args) {
-      let str = opt.alias ? ` -${opt.alias}, ` : "     ";
-      str += `--${opt.name}`;
-      if ((opt.type && opt.type !== Boolean) || opt.typeDesc) {
-        str += ` <${opt.typeDesc || opt.type.name}>`;
-      }
-      if (opt.desc) {
-        str = str.padEnd(30) + `: ${opt.desc}`;
-      }
-      console.log(str);
-    }
-    console.log("");
-  }
-  console.log("");
-  console.log("                ````                    ");
-  console.log("           `.--:::::                    ");
-  console.log("        `.-:::::::::       ````         ");
-  console.log("       .://///:-..``     `-/+++/-`      ");
-  console.log("     `://///-`           -++++++o/.     ");
-  console.log("    `/+++/:`            -+++++osss+`    ");
-  console.log("   `:++++:`            ./++++-/osss/`   ");
-  console.log("   .+++++`             `-://- .ooooo.   ");
-  console.log("   -+ooo/`                ``  `/oooo-   ");
-  console.log("   .oooo+` .::-.`             `+++++.   ");
-  console.log("   `+oooo:./+++/.             -++++/`   ");
-  console.log("    -ossso+++++:`            -/+++/.    ");
-  console.log("     -ooo+++++:`           .://///.     ");
-  console.log("      ./+++++/`       ``.-://///:`      ");
-  console.log("        `---.`      -:::::///:-.        ");
-  console.log("                    :::::::-.`          ");
-  console.log("                    ....``              ");
-  console.log("");
-  console.log(
-    "Please be advised this software is experimental and shall not create any obligation for Ledger to continue to develop, offer, support or repair any of its features. The software is provided “as is.” Ledger shall not be liable for any damages whatsoever including loss of profits or data, business interruption arising from using the software.",
-  );
-  process.exit(0);
-}
-
-const cmd = commands[mainOptions.command];
-if (!cmd) {
-  console.error("Command not found: ledger-live " + mainOptions.command);
-  process.exit(1);
-}
-const argv = mainOptions._unknown || [];
-const options = commandLineArgs(cmd.args, { argv, stopAtFirstUnknown: true });
-from(cmd.job(options)).subscribe({
-  next: log => {
-    if (log !== undefined) console.log(log);
-  },
-  error: error => {
-    const e = error instanceof Error ? error : deserializeError(error);
-    if (process.env.VERBOSE || process.env.VERBOSE_FILE) console.error(e);
-    else console.error(String((e && e.message) || e));
-    process.exit(1);
-  },
-  complete: () => {
-    closeAllDevices();
-  },
-});
-
-let sigIntSent;
+let sigIntSent: number | undefined;
 process.on("SIGINT", () => {
   if (!sigIntSent) {
     sigIntSent = Date.now();
@@ -109,4 +21,103 @@ process.on("SIGINT", () => {
       process.exit(1);
     }
   }
+});
+
+(async () => {
+  const familySetups = await Promise.all(
+    getRegisteredFamilies().map(family => loadSetupForFamily(family)),
+  );
+
+  const commands = {
+    ...familySetups
+      .map(setup => setup?.cliTools)
+      .map((m: any) => typeof m === "object" && m && m.commands)
+      .reduce((acc: Record<string, unknown>, c) => ({ ...acc, ...c }), {}),
+    ...commandsMain,
+  };
+
+  const mainOptions = commandLineArgs(
+    [
+      { name: "command", defaultOption: true },
+      { name: "help", alias: "h", type: Boolean },
+    ],
+    {
+      stopAtFirstUnknown: true,
+    },
+  );
+
+  if (mainOptions.help || !mainOptions.command) {
+    console.log("Ledger Live @ https://github.com/LedgerHQ/ledger-live");
+    console.log("");
+    console.log("Usage: ledger-live <command> ...");
+    console.log("");
+    for (const k in commands) {
+      const cmd = commands[k];
+      console.log(
+        `Usage: ledger-live ${k} `.padEnd(30) + (cmd.description ? `# ${cmd.description}` : ""),
+      );
+      const args = await cmd.args;
+      for (const opt of args) {
+        let str = opt.alias ? ` -${opt.alias}, ` : "     ";
+        str += `--${opt.name}`;
+        if ((opt.type && opt.type !== Boolean) || opt.typeDesc) {
+          str += ` <${opt.typeDesc || opt.type.name}>`;
+        }
+        if (opt.desc) {
+          str = str.padEnd(30) + `: ${opt.desc}`;
+        }
+        console.log(str);
+      }
+      console.log("");
+    }
+    console.log("");
+    console.log("                ````                    ");
+    console.log("           `.--:::::                    ");
+    console.log("        `.-:::::::::       ````         ");
+    console.log("       .://///:-..``     `-/+++/-`      ");
+    console.log("     `://///-`           -++++++o/.     ");
+    console.log("    `/+++/:`            -+++++osss+`    ");
+    console.log("   `:++++:`            ./++++-/osss/`   ");
+    console.log("   .+++++`             `-://- .ooooo.   ");
+    console.log("   -+ooo/`                ``  `/oooo-   ");
+    console.log("   .oooo+` .::-.`             `+++++.   ");
+    console.log("   `+oooo:./+++/.             -++++/`   ");
+    console.log("    -ossso+++++:`            -/+++/.    ");
+    console.log("     -ooo+++++:`           .://///.     ");
+    console.log("      ./+++++/`       ``.-://///:`      ");
+    console.log("        `---.`      -:::::///:-.        ");
+    console.log("                    :::::::-.`          ");
+    console.log("                    ....``              ");
+    console.log("");
+    console.log(
+      "Please be advised this software is experimental and shall not create any obligation for Ledger to continue to develop, offer, support or repair any of its features. The software is provided \"as is.\" Ledger shall not be liable for any damages whatsoever including loss of profits or data, business interruption arising from using the software.",
+    );
+    process.exit(0);
+  }
+
+  const cmd = commands[mainOptions.command];
+  if (!cmd) {
+    console.error("Command not found: ledger-live " + mainOptions.command);
+    process.exit(1);
+  }
+  const argv = mainOptions._unknown || [];
+  const args = await cmd.args;
+  const options = commandLineArgs(args, { argv, stopAtFirstUnknown: true });
+  from(cmd.job(options)).subscribe({
+    next: log => {
+      if (log !== undefined) console.log(log);
+    },
+    error: error => {
+      const e = error instanceof Error ? error : deserializeError(error);
+      if (process.env.VERBOSE || process.env.VERBOSE_FILE) console.error(e);
+      else console.error(String((e && e.message) || e));
+      process.exit(1);
+    },
+    complete: () => {
+      closeAllDevices();
+    },
+  });
+})().catch(e => {
+  console.error(e);
+  process.exit(1);
 });

--- a/apps/cli/src/commands/blockchain/generateTestTransaction.ts
+++ b/apps/cli/src/commands/blockchain/generateTestTransaction.ts
@@ -50,7 +50,7 @@ export type GenerateTestTransactionJobOpts = InferTransactionsOpts & ScanCommonO
 
 export default {
   description: "Generate a test for transaction (live-common dataset)",
-  args: [...scanCommonOpts, ...inferTransactionsOpts],
+  args: inferTransactionsOpts.then(opts => [...scanCommonOpts, ...opts]),
   job: (opts: GenerateTestTransactionJobOpts) =>
     scan(opts).pipe(
       switchMap(account =>

--- a/apps/cli/src/commands/blockchain/getTransactionStatus.ts
+++ b/apps/cli/src/commands/blockchain/getTransactionStatus.ts
@@ -46,9 +46,9 @@ export type GetTransactionStatusJobOpts = ScanCommonOpts &
 
 export default {
   description: "Prepare a transaction and returns 'TransactionStatus' meta information",
-  args: [
+  args: inferTransactionsOpts.then(opts => [
     ...scanCommonOpts,
-    ...inferTransactionsOpts,
+    ...opts,
     {
       name: "format",
       alias: "f",
@@ -56,7 +56,7 @@ export default {
       typeDesc: Object.keys(getTransactionStatusFormatters).join(" | "),
       desc: "how to display the data",
     },
-  ],
+  ]),
   job: (
     opts: ScanCommonOpts &
       InferTransactionsOpts & {

--- a/apps/cli/src/commands/blockchain/send.ts
+++ b/apps/cli/src/commands/blockchain/send.ts
@@ -30,9 +30,9 @@ export type SendJobOpts = ScanCommonOpts &
 
 export default {
   description: "Send crypto-assets",
-  args: [
+  args: inferTransactionsOpts.then(opts => [
     ...scanCommonOpts,
-    ...inferTransactionsOpts,
+    ...opts,
     {
       name: "ignore-errors",
       type: Boolean,
@@ -58,7 +58,7 @@ export default {
       type: String,
       desc: "default | json | silent",
     },
-  ],
+  ]),
   job: (opts: SendJobOpts) => {
     const l =
       opts.format !== "json" && opts.format !== "silent"

--- a/apps/cli/src/transaction.ts
+++ b/apps/cli/src/transaction.ts
@@ -50,64 +50,70 @@ export type InferTransactionsOpts = Partial<{
   tokenIds: string;
   quantities: string;
 }>;
-export const inferTransactionsOpts = uniqBy(
-  [
-    {
-      name: "self-transaction",
-      type: Boolean,
-      desc: "Pre-fill the transaction for the account to send to itself",
-    },
-    {
-      name: "use-all-amount",
-      type: Boolean,
-      desc: "Send MAX of the account balance",
-    },
-    {
-      name: "recipient",
-      type: String,
-      desc: "the address to send funds to",
-      multiple: true,
-    },
-    {
-      name: "amount",
-      type: String,
-      desc: "how much to send in the main currency unit",
-    },
-    {
-      name: "shuffle",
-      type: Boolean,
-      desc: "if using multiple token or recipient, order will be randomized",
-    },
-    {
-      name: "collection",
-      type: String,
-      desc: "collection of an NFT (in corelation with --tokenIds)",
-    },
-    {
-      name: "tokenIds",
-      type: String,
-      desc: "tokenId or list of tokenIds of an NFT separated by commas (order is kept in corelation with --quantities)",
-    },
-    {
-      name: "quantities",
-      type: String,
-      desc: "quantity or list of quantity of an ERC1155 NFT separated by commas (order is kept in corelation with --tokenIds)",
-    },
-  ].concat(
-    flatMap(
-      getRegisteredFamilies().map(family => loadSetupForFamily(family).cliTools),
-      (m: unknown) =>
-        (m && typeof m === "object" && "options" in m ? (m as any).options : []) || [],
+export const inferTransactionsOpts = (async () => {
+  const setups = await Promise.all(
+    getRegisteredFamilies().map(family => Promise.resolve(loadSetupForFamily(family))),
+  );
+  return uniqBy(
+    [
+      {
+        name: "self-transaction",
+        type: Boolean,
+        desc: "Pre-fill the transaction for the account to send to itself",
+      },
+      {
+        name: "use-all-amount",
+        type: Boolean,
+        desc: "Send MAX of the account balance",
+      },
+      {
+        name: "recipient",
+        type: String,
+        desc: "the address to send funds to",
+        multiple: true,
+      },
+      {
+        name: "amount",
+        type: String,
+        desc: "how much to send in the main currency unit",
+      },
+      {
+        name: "shuffle",
+        type: Boolean,
+        desc: "if using multiple token or recipient, order will be randomized",
+      },
+      {
+        name: "collection",
+        type: String,
+        desc: "collection of an NFT (in corelation with --tokenIds)",
+      },
+      {
+        name: "tokenIds",
+        type: String,
+        desc: "tokenId or list of tokenIds of an NFT separated by commas (order is kept in corelation with --quantities)",
+      },
+      {
+        name: "quantities",
+        type: String,
+        desc: "quantity or list of quantity of an ERC1155 NFT separated by commas (order is kept in corelation with --tokenIds)",
+      },
+    ].concat(
+      flatMap(
+        setups.map(setup => setup?.cliTools),
+        (m: unknown) =>
+          (m && typeof m === "object" && "options" in m ? (m as any).options : []) || [],
+      ),
     ),
-  ),
-  "name",
-);
+    "name",
+  );
+})();
 export async function inferTransactions(
   mainAccount: Account,
   opts: InferTransactionsOpts,
 ): Promise<[Transaction, TransactionStatusCommon][]> {
   const bridge = await getAccountBridge(mainAccount, null);
-  const specific = loadSetupForFamily(mainAccount.currency.family).cliTools;
+  const setup = await Promise.resolve(loadSetupForFamily(mainAccount.currency.family));
+  const specific = setup?.cliTools;
 
   const inferAccounts: (account: Account, opts: Record<string, unknown>) => AccountLikeArray =
     (specific && "inferAccounts" in specific && (specific.inferAccounts as any)) ||


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _(N/A — `apps/cli` is a private app)_
- [ ] **Covered by automatic tests.** _(refactor; behavior preserved)_
- [ ] **Impact of the changes:**
  - `apps/cli` only — smoke-test `ledger-live --help` and a `send` / `getTransactionStatus` run

### 📝 Description

Prepares `apps/cli` for async coin-module loaders (see #17155):

- CLI entrypoint wrapped in an `async` IIFE.
- `inferTransactionsOpts` is now a `Promise<Option[]>`; loader calls go through `Promise.resolve(loadSetupForFamily(...))` so they stay correct when the loader becomes async.
- Consuming commands resolve their `args` via `.then(...)`; `cli.ts` awaits `cmd.args`.
- rspack: `dynamicImportMode: "eager"` to keep the CLI as a single bundle.

No runtime behavior change.

### ❓ Context

- **JIRA or GitHub link**: related to #17155
- **ADR link (if any)**: —