### PR TITLE
fix(coin-evm): rewrite ops on zkSync L1→L2 priority txs

### DIFF
--- a/.changeset/rude-mugs-smash.md
+++ b/.changeset/rude-mugs-smash.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": patch
+---
+
+Fix zkSync L1→L2 priority deposits (receipt type 0xff) producing a null net balance on the user's L2 account. We now parse `Mint(account, amount)` events into Transfer-equivalent ops with `peer = 0x0` (generic ERC20 mint convention). On zkSync L1→L2 priority txs, this surfaces the deposit credit, the bootloader fee, and the gas refund. On the native side, the cancelling self pair from `tx.value` is replaced with a single credit op (`peer = 0x0`). Mint-source ops on `0x0` are filtered out as accounting noise.

--- a/libs/coin-modules/coin-evm/src/logic/getBlock.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/getBlock.test.ts
@@ -1005,6 +1005,328 @@ describe("getBlock", () => {
     const result = await getBlock({} as CryptoCurrency, 12345);
     expect(result.transactions[0].fees).toEqual(21000n * 1000000000n);
   });
+
+  describe("zkSync L1→L2 priority transactions (receipt type 0xff)", () => {
+    const USER = "0xbEB30f27e61eFFF46Aa27dcE18E23ee8D5A7c6a4";
+    const L2_BASE_TOKEN = "0x000000000000000000000000000000000000800A";
+    const MINT_PEER = "0x0000000000000000000000000000000000000000";
+    const ZKSYNC = { id: "zksync" } as CryptoCurrency;
+
+    function buildZksyncMocks(
+      txOverrides: Partial<PrefetchedBlockTransaction>,
+      receiptOverrides: Partial<BlockReceiptInfo>,
+    ): void {
+      setCoinConfig(
+        () => ({ info: { node: { type: "external", retries: 0 } } }) as unknown as EvmCoinConfig,
+      );
+      const mockGetNodeApi = jest.mocked(getNodeApi);
+      mockGetNodeApi.mockReturnValue({
+        getBlockByHeight: jest
+          .fn()
+          .mockResolvedValue(
+            makeNodeBlock({ transactions: [makeNodeBlockTx({ hash: "0xtx", ...txOverrides })] }),
+          ),
+        getBlockReceipts: jest
+          .fn()
+          .mockResolvedValue([makeNodeBlockReceipt({ hash: "0xtx", ...receiptOverrides })]),
+        getTransaction: jest.fn(),
+      } as any);
+    }
+
+    it("does not modify ops when receipt type is undefined (regular L2 tx)", async () => {
+      buildZksyncMocks(
+        { from: USER, to: USER, value: "270000000000000000" },
+        {
+          erc20Transfers: [
+            {
+              asset: { type: "erc20", assetReference: L2_BASE_TOKEN },
+              from: USER,
+              to: USER,
+              value: "270000000000000000",
+            },
+          ],
+        },
+      );
+      const result = await getBlock(ZKSYNC, 12345);
+      expect(result.transactions[0].operations).toEqual([
+        {
+          type: "transfer",
+          address: USER,
+          peer: USER,
+          asset: { type: "native" },
+          amount: -270000000000000000n,
+        },
+        {
+          type: "transfer",
+          address: USER,
+          peer: USER,
+          asset: { type: "native" },
+          amount: 270000000000000000n,
+        },
+        {
+          type: "transfer",
+          address: USER,
+          peer: USER,
+          asset: { type: "erc20", assetReference: L2_BASE_TOKEN },
+          amount: -270000000000000000n,
+        },
+        {
+          type: "transfer",
+          address: USER,
+          peer: USER,
+          asset: { type: "erc20", assetReference: L2_BASE_TOKEN },
+          amount: 270000000000000000n,
+        },
+      ]);
+    });
+
+    it("does not modify ops for receipt type 2 (EIP-1559)", async () => {
+      buildZksyncMocks(
+        { from: USER, to: USER, value: "270000000000000000" },
+        { type: 2, erc20Transfers: [] },
+      );
+      const result = await getBlock(ZKSYNC, 12345);
+      expect(result.transactions[0].operations).toEqual([
+        {
+          type: "transfer",
+          address: USER,
+          peer: USER,
+          asset: { type: "native" },
+          amount: -270000000000000000n,
+        },
+        {
+          type: "transfer",
+          address: USER,
+          peer: USER,
+          asset: { type: "native" },
+          amount: 270000000000000000n,
+        },
+      ]);
+    });
+
+    it("drops native self pair and prepends a synthesized native credit (peer=0x0)", async () => {
+      buildZksyncMocks(
+        { from: USER, to: USER, value: "270000000000000000" },
+        {
+          type: 0xff,
+          erc20Transfers: [
+            // Transfer log (user → user, the on-chain self transfer)
+            {
+              asset: { type: "erc20", assetReference: L2_BASE_TOKEN },
+              from: USER,
+              to: USER,
+              value: "270000000000000000",
+            },
+            // Mint event surfaced as Transfer(0x0 → user) by parseERC20TransfersFromLogs
+            {
+              asset: { type: "erc20", assetReference: L2_BASE_TOKEN },
+              from: MINT_PEER,
+              to: USER,
+              value: "270000000000000000",
+            },
+          ],
+        },
+      );
+      const result = await getBlock(ZKSYNC, 12345);
+      expect(result.transactions[0].operations).toEqual([
+        // native credit (synthesized, replaces the native self pair)
+        {
+          type: "transfer",
+          address: USER,
+          peer: MINT_PEER,
+          asset: { type: "native" },
+          amount: 270000000000000000n,
+        },
+        // 800A self pair (from Transfer log)
+        {
+          type: "transfer",
+          address: USER,
+          peer: USER,
+          asset: { type: "erc20", assetReference: L2_BASE_TOKEN },
+          amount: -270000000000000000n,
+        },
+        {
+          type: "transfer",
+          address: USER,
+          peer: USER,
+          asset: { type: "erc20", assetReference: L2_BASE_TOKEN },
+          amount: 270000000000000000n,
+        },
+        // 800A credit (from Mint event, mint-source side on 0x0 is filtered out)
+        {
+          type: "transfer",
+          address: USER,
+          peer: MINT_PEER,
+          asset: { type: "erc20", assetReference: L2_BASE_TOKEN },
+          amount: 270000000000000000n,
+        },
+      ]);
+    });
+
+    it("prepends only a native credit when no L2BaseToken events are present (type 0xff)", async () => {
+      buildZksyncMocks(
+        { from: USER, to: USER, value: "270000000000000000" },
+        { type: 0xff, erc20Transfers: [] },
+      );
+      const result = await getBlock(ZKSYNC, 12345);
+      expect(result.transactions[0].operations).toEqual([
+        {
+          type: "transfer",
+          address: USER,
+          peer: MINT_PEER,
+          asset: { type: "native" },
+          amount: 270000000000000000n,
+        },
+      ]);
+    });
+
+    it("filters mint-source ops on 0x0 even when no native self pair is found (type 0xff)", async () => {
+      buildZksyncMocks(
+        { from: USER, to: USER, value: "0" },
+        {
+          type: 0xff,
+          erc20Transfers: [
+            // Mint-derived entry: would produce {0x0, peer: user, -V} + {user, peer: 0x0, +V}
+            {
+              asset: { type: "erc20", assetReference: L2_BASE_TOKEN },
+              from: MINT_PEER,
+              to: USER,
+              value: "1000",
+            },
+          ],
+        },
+      );
+      const result = await getBlock(ZKSYNC, 12345);
+      // Only the to-side (on user) remains; the from-side (on 0x0) is filtered out.
+      expect(result.transactions[0].operations).toEqual([
+        {
+          type: "transfer",
+          address: USER,
+          peer: MINT_PEER,
+          asset: { type: "erc20", assetReference: L2_BASE_TOKEN },
+          amount: 1000n,
+        },
+      ]);
+    });
+
+    it("leaves user ERC20 (non-800A) self transfers unchanged under type 0xff", async () => {
+      const usdc = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+      buildZksyncMocks(
+        { from: USER, to: USER, value: "0" },
+        {
+          type: 0xff,
+          erc20Transfers: [
+            {
+              asset: { type: "erc20", assetReference: usdc },
+              from: USER,
+              to: USER,
+              value: "1000000",
+            },
+          ],
+        },
+      );
+      const result = await getBlock(ZKSYNC, 12345);
+      expect(result.transactions[0].operations).toEqual([
+        {
+          type: "transfer",
+          address: USER,
+          peer: USER,
+          asset: { type: "erc20", assetReference: usdc },
+          amount: -1000000n,
+        },
+        {
+          type: "transfer",
+          address: USER,
+          peer: USER,
+          asset: { type: "erc20", assetReference: usdc },
+          amount: 1000000n,
+        },
+      ]);
+    });
+
+    it("leaves 800A non-self transfers unchanged under type 0xff", async () => {
+      const other = "0x6cBCD73CD8e8a42844662f0A0e76D7F79Afd933d";
+      buildZksyncMocks(
+        { from: USER, to: USER, value: "0" },
+        {
+          type: 0xff,
+          erc20Transfers: [
+            {
+              asset: { type: "erc20", assetReference: L2_BASE_TOKEN },
+              from: USER,
+              to: other,
+              value: "1000",
+            },
+          ],
+        },
+      );
+      const result = await getBlock(ZKSYNC, 12345);
+      expect(result.transactions[0].operations).toEqual([
+        {
+          type: "transfer",
+          address: USER,
+          peer: other,
+          asset: { type: "erc20", assetReference: L2_BASE_TOKEN },
+          amount: -1000n,
+        },
+        {
+          type: "transfer",
+          address: other,
+          peer: USER,
+          asset: { type: "erc20", assetReference: L2_BASE_TOKEN },
+          amount: 1000n,
+        },
+      ]);
+    });
+
+    it("does not apply zkSync corrections to other currencies (e.g. ethereum) even when receipt type is 0xff", async () => {
+      buildZksyncMocks(
+        { from: USER, to: USER, value: "270000000000000000" },
+        {
+          type: 0xff,
+          erc20Transfers: [
+            {
+              asset: { type: "erc20", assetReference: L2_BASE_TOKEN },
+              from: USER,
+              to: USER,
+              value: "270000000000000000",
+            },
+          ],
+        },
+      );
+      const result = await getBlock({ id: "ethereum" } as CryptoCurrency, 12345);
+      expect(result.transactions[0].operations).toEqual([
+        {
+          type: "transfer",
+          address: USER,
+          peer: USER,
+          asset: { type: "native" },
+          amount: -270000000000000000n,
+        },
+        {
+          type: "transfer",
+          address: USER,
+          peer: USER,
+          asset: { type: "native" },
+          amount: 270000000000000000n,
+        },
+        {
+          type: "transfer",
+          address: USER,
+          peer: USER,
+          asset: { type: "erc20", assetReference: L2_BASE_TOKEN },
+          amount: -270000000000000000n,
+        },
+        {
+          type: "transfer",
+          address: USER,
+          peer: USER,
+          asset: { type: "erc20", assetReference: L2_BASE_TOKEN },
+          amount: 270000000000000000n,
+        },
+      ]);
+    });
+  });
 });
 
 describe("dropRootTraceDuplicates", () => {

--- a/libs/coin-modules/coin-evm/src/logic/getBlock.ts
+++ b/libs/coin-modules/coin-evm/src/logic/getBlock.ts
@@ -3,6 +3,7 @@ import type {
   BlockInfo,
   BlockOperation,
   BlockTransaction,
+  TransferBlockOperation,
 } from "@ledgerhq/coin-module-framework/api/index";
 import { promiseAllBatched } from "@ledgerhq/live-promise";
 import { log } from "@ledgerhq/logs";
@@ -19,7 +20,7 @@ import { isEtherscanLikeExplorerConfig } from "../network/explorer/types";
 import { getNodeApi } from "../network/node";
 import { BlockReceiptInfo, NodeApi, PrefetchedBlockTransaction } from "../network/node/types";
 import { dropRootTraceDuplicates } from "./rootTraceDedup";
-import { buildSmartContractDetails } from "../utils";
+import { buildSmartContractDetails, safeEncodeEIP55 } from "../utils";
 
 function internalTransactionsFetcher(
   nodeApi: NodeApi,
@@ -182,7 +183,11 @@ async function getTransactionsFromPrefetchedData(
     for (const tx of prefetchedTransactions) {
       const receipt = receiptsByHash.get(tx.hash);
       if (!receipt) return null;
-      transactions.push(prefetchedTransactionToBlockTransaction(tx, receipt));
+      const blockTx = prefetchedTransactionToBlockTransaction(tx, receipt);
+      transactions.push({
+        ...blockTx,
+        operations: applyChainSpecificCorrections(currency, blockTx.operations, receipt.type),
+      });
     }
 
     return transactions;
@@ -239,7 +244,8 @@ async function getTransactionFromHash(
   const failed = txInfo.status === 0;
   const fees = BigInt(txInfo.gasUsed) * BigInt(txInfo.gasPrice);
 
-  const operations = rpcTransactionToBlockOperations(txInfo);
+  const rawOperations = rpcTransactionToBlockOperations(txInfo);
+  const operations = applyChainSpecificCorrections(currency, rawOperations, txInfo.type);
 
   const details = buildSmartContractDetails(txInfo.to, txInfo.input, txInfo.contractAddress);
 
@@ -251,4 +257,54 @@ async function getTransactionFromHash(
     feesPayer: txInfo.from,
     ...(details ? { details } : {}),
   };
+}
+
+const ZKSYNC_MINT_PEER = safeEncodeEIP55("0x0000000000000000000000000000000000000000");
+
+function applyChainSpecificCorrections(
+  currency: CryptoCurrency,
+  operations: BlockOperation[],
+  receiptType: number | undefined,
+): BlockOperation[] {
+  switch (currency.id) {
+    case "zksync":
+      return rewriteZkSyncL1ToL2DepositOps(operations, receiptType);
+    default:
+      return operations;
+  }
+}
+
+/**
+ * On zkSync L1→L2 priority txs (receipt.type === 0xff): replace the cancelling native self
+ * pair (from `tx.value`) with a single credit op (`peer = 0x0`), and drop mint-source ops
+ * on `0x0` (noise).
+ */
+function rewriteZkSyncL1ToL2DepositOps(
+  operations: BlockOperation[],
+  receiptType: number | undefined,
+): BlockOperation[] {
+  if (receiptType !== 0xff) return operations;
+  const withoutMintSource = operations.filter(
+    op => op.type !== "transfer" || op.address.toLowerCase() !== ZKSYNC_MINT_PEER.toLowerCase(),
+  );
+  const nativeSelf = withoutMintSource.find(
+    (op): op is TransferBlockOperation =>
+      op.type === "transfer" &&
+      op.asset.type === "native" &&
+      op.amount > 0n &&
+      op.peer !== undefined &&
+      op.address.toLowerCase() === op.peer.toLowerCase(),
+  );
+  if (!nativeSelf) return withoutMintSource;
+  const nativeCredit: TransferBlockOperation = {
+    type: "transfer",
+    address: nativeSelf.address,
+    peer: ZKSYNC_MINT_PEER,
+    asset: { type: "native" },
+    amount: nativeSelf.amount,
+  };
+  return [
+    nativeCredit,
+    ...withoutMintSource.filter(op => op.type !== "transfer" || op.asset.type !== "native"),
+  ];
 }

--- a/libs/coin-modules/coin-evm/src/network/node/rpc.common.ts
+++ b/libs/coin-modules/coin-evm/src/network/node/rpc.common.ts
@@ -50,6 +50,10 @@ export const WETH_DEPOSIT_TOPIC =
 export const WETH_WITHDRAWAL_TOPIC =
   "0x7fcf532c15f0a6db0bd6d0e038bea71d30d808c7d98cb3bf7268a95bf5081b65";
 
+/** keccak256("Mint(address,uint256)") — generic ERC20 mint event signature. */
+export const ERC20_MINT_TOPIC =
+  "0x0f6798a560793a54c3bcfe86a93cde1e73087d944c0ea20544137d4121396885";
+
 const ZERO_ADDRESS_HEX = safeEncodeEIP55("0x0000000000000000000000000000000000000000");
 
 function topicToAddress(topic: string | undefined): string {
@@ -67,6 +71,10 @@ function isWethDeposit(log: LogWithAddress): boolean {
 
 function isWethWithdrawal(log: LogWithAddress): boolean {
   return log.topics[0] === WETH_WITHDRAWAL_TOPIC && log.topics.length === 2 && log.data.length > 2;
+}
+
+function isMint(log: LogWithAddress): boolean {
+  return log.topics[0] === ERC20_MINT_TOPIC && log.topics.length === 2 && log.data.length > 2;
 }
 
 function makeErc20Transfer(log: LogWithAddress, from: string, to: string): ERC20Transfer {
@@ -102,6 +110,12 @@ function makeErc20Transfer(log: LogWithAddress, from: string, to: string): ERC20
  * - data: wad (uint256, 32 bytes)
  * - log.address: token contract address
  *
+ * ERC20 `Mint(address,uint256)` (supply increase, ≡ Transfer from 0x0):
+ * - topic[0]: event signature hash (0x0f6798a5…)
+ * - topic[1]: account address (indexed, padded to 32 bytes)
+ * - data: amount (uint256, 32 bytes)
+ * - log.address: token contract address
+ *
  *  Other standards (not supported yet):
  * - ERC721:  4 topics (sig, from, to, tokenId) - filtered out by topics.length === 3
  * - ERC1155: different event signature - filtered out by topic[0] check
@@ -119,6 +133,9 @@ export function parseERC20TransfersFromLogs(logs: ReadonlyArray<LogWithAddress>)
     }
     if (isWethWithdrawal(log)) {
       return [makeErc20Transfer(log, topicToAddress(log.topics[1]), ZERO_ADDRESS_HEX)];
+    }
+    if (isMint(log)) {
+      return [makeErc20Transfer(log, ZERO_ADDRESS_HEX, topicToAddress(log.topics[1]))];
     }
     return [];
   });
@@ -218,6 +235,7 @@ async function getTransaction(
     value: tx.value.toString(),
     from: tx.from,
     to: tx.to ?? undefined,
+    type: receipt.type ?? tx.type ?? undefined,
     ...(tx.data !== null && tx.data !== undefined && isSmartContractInput(tx.data)
       ? { input: tx.data }
       : {}),
@@ -633,6 +651,7 @@ async function getBlockReceipts(
       status: receipt.status === null ? null : Number(receipt.status),
       erc20Transfers: parseERC20TransfersFromLogs(receipt.logs),
       ...(contractAddress ? { contractAddress } : {}),
+      ...(receipt.type !== undefined ? { type: Number(receipt.type) } : {}),
     };
   });
 }

--- a/libs/coin-modules/coin-evm/src/network/node/rpc.test.ts
+++ b/libs/coin-modules/coin-evm/src/network/node/rpc.test.ts
@@ -290,6 +290,7 @@ describe("EVM Family", () => {
           from: "0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d",
           to: "0xC2907EFccE4011C491BbedA8A0fA63BA7aab596C",
           erc20Transfers: [],
+          type: 0,
         });
       });
     });
@@ -514,6 +515,29 @@ describe("EVM Family", () => {
             from: "0xbeBcf96eEEd98D495F45407CE7017179738E3552",
             to: "0x0000000000000000000000000000000000000000",
             value: "200000000000000",
+          },
+        ]);
+      });
+
+      it("parses Mint as Transfer from 0x0", () => {
+        const MINT_TOPIC = "0x0f6798a560793a54c3bcfe86a93cde1e73087d944c0ea20544137d4121396885";
+        const L2_BASE_TOKEN = "0x000000000000000000000000000000000000800A";
+        const result = parseERC20TransfersFromLogs([
+          {
+            address: L2_BASE_TOKEN,
+            topics: [
+              MINT_TOPIC,
+              "0x000000000000000000000000beb30f27e61efff46aa27dce18e23ee8d5a7c6a4",
+            ],
+            data: "0x0000000000000000000000000000000000000000000000000000000000000064",
+          },
+        ]);
+        expect(result).toEqual([
+          {
+            asset: { type: "erc20", assetReference: L2_BASE_TOKEN },
+            from: "0x0000000000000000000000000000000000000000",
+            to: "0xbEB30f27e61eFFF46Aa27dcE18E23ee8D5A7c6a4",
+            value: "100",
           },
         ]);
       });

--- a/libs/coin-modules/coin-evm/src/network/node/types.ts
+++ b/libs/coin-modules/coin-evm/src/network/node/types.ts
@@ -118,6 +118,8 @@ export type TransactionReceipt = {
   gasPrice?: string;
   status: string | number | null;
   logs: LogWithAddress[];
+  /** Tx envelope type per EIP-2718, hex-prefixed (e.g. "0x2" EIP-1559). */
+  type?: string;
 };
 
 /**
@@ -140,6 +142,8 @@ export type TransactionInfo = {
   contractAddress?: string;
   /** ERC20 Transfer events extracted from receipt logs */
   erc20Transfers: ERC20Transfer[];
+  /** Tx envelope type per EIP-2718 (decimal), e.g. 2 for EIP-1559. */
+  type?: number;
 };
 
 export type PrefetchedBlockTransaction = Pick<
@@ -149,7 +153,7 @@ export type PrefetchedBlockTransaction = Pick<
 
 export type BlockReceiptInfo = Pick<
   TransactionInfo,
-  "hash" | "gasUsed" | "gasPrice" | "status" | "erc20Transfers" | "contractAddress"
+  "hash" | "gasUsed" | "gasPrice" | "status" | "erc20Transfers" | "contractAddress" | "type"
 >;
 
 export type BlockByHeightResult = {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - `getBlock` output for zkSync L1→L2 priority txs (receipt type `0xff`) — verify deposits show the correct net balance on the user's L2 account
  - Regular L2 zkSync txs (ETH transfer, ERC20, swap) must be unchanged
  - `parseERC20TransfersFromLogs` now also parses `Mint` events on all EVM chains — verify no regression on tx histories that involve mint-emitting tokens (e.g. stETH, LP tokens). Mint events become standard ops with `peer = 0x0`.

### 📝 Description

On zkSync Era, an L1→L2 priority deposit (receipt `type = 0xff`) to the user's own L2 address produced a null net balance: the generic RPC adapter emits cancelling self-transfer pairs on both native (`tx.value`) and L2BaseToken (`0x...800A`), and the actual L1→L2 credit only surfaces as a `Mint` event which wasn't parsed.

Fix:
- Parse `Mint(account, amount)` events as `Transfer(0x0 → account)` (generic ERC20 mint convention). On zkSync L1→L2 priority txs this surfaces the deposit credit, the bootloader fee, and the gas refund.
- On the native side, replace the cancelling self pair (from `tx.value`) with a single credit op (`peer = 0x0`).
- Filter out mint-source ops on `address = 0x0` (accounting noise).

**Before** (block `4415784`, tx `0xe63e66c…`): 4 cancelling ops, net = 0.
**After**: 4 ops on the user (native credit, L2BaseToken credit, L2BaseToken self pair, gas refund) + 1 fee op on the bootloader, net = +0.27 ETH.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29713](https://ledgerhq.atlassian.net/browse/LIVE-29713)
- **E2E**:
  - Mobile: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/f759501a-4658-437f-b5ff-59cf130a53e0/
  - Desktop: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/a37540cc-7c10-4b8b-8421-5f186e4bd052/

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29713]: https://ledgerhq.atlassian.net/browse/LIVE-29713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ