### PR TITLE
test(desktop): add portfolio funded account coverage

### DIFF
--- a/e2e/desktop/tests/page/accounts.page.ts
+++ b/e2e/desktop/tests/page/accounts.page.ts
@@ -5,6 +5,7 @@ import { Currency } from "@ledgerhq/live-common/e2e/enum/Currency";
 
 export class AccountsPage extends AppPage {
   private accountsTitle = this.page.getByRole("heading", { name: "Accounts" });
+  private cryptoAddAddressButton = this.page.getByTestId("crypto-add-address-button");
   private readonly visibleAccountsList = this.page
     .locator(`[data-testid^="crypto-account-row-"]`)
     .filter({ visible: true });
@@ -21,6 +22,11 @@ export class AccountsPage extends AppPage {
 
   private syncAccountButton = (accountName: string) =>
     this.cryptoAccountRow(accountName).getByTestId("sync-button").locator("div").first();
+
+  @step("Click add account button from accounts page")
+  async clickAddAccountButtonFromAccountsPage() {
+    await this.cryptoAddAddressButton.click();
+  }
 
   @step("Wait for Accounts title to be visible")
   async expectAccountsTitleVisibility() {

--- a/e2e/desktop/tests/specs/portfolio.spec.ts
+++ b/e2e/desktop/tests/specs/portfolio.spec.ts
@@ -3,6 +3,8 @@ import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
 import { LWD_WALLET_40_FF_DISABLED, LWD_WALLET_40_FF_ENABLED } from "tests/utils/featureFlagUtils";
+import { Currency } from "@ledgerhq/live-common/e2e/enum/Currency";
+import { getModularSelector } from "tests/utils/modularSelectorUtils";
 
 // Skipping this suite as legacy is not visible on prod anymore
 test.describe.skip("Portfolio - legacy", () => {
@@ -149,6 +151,57 @@ test.describe("Portfolio Wallet 4.0 - No seen device (Reborn mode)", () => {
       await app.portfolio.checkNoDeviceTitleVisibility();
       await app.portfolio.checkConnectButtonVisibility();
       await app.portfolio.checkBuyALedgerButtonVisibility();
+    },
+  );
+});
+
+test.describe("Portfolio Wallet 4.0 - add funded account", () => {
+  const currency = Currency.BTC;
+  test.use({
+    teamOwner: Team.WALLET_XP,
+    userdata: "1AccountSOL0Balance",
+    featureFlags: LWD_WALLET_40_FF_ENABLED,
+    speculosApp: currency.speculosApp,
+  });
+
+  test(
+    "Portfolio: with zero-balance account, then add funded account and verify balance and quick actions",
+    {
+      tag: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"],
+      annotation: {
+        type: "TMS",
+        description: "B2CQA-4351",
+      },
+    },
+    async ({ app }) => {
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+
+      await app.portfolio.checkReceiveButtonVisibility();
+      await app.portfolio.checkBuyButtonVisibility();
+      await app.portfolio.checkSellButtonDisabled();
+      await app.portfolio.checkSendButtonDisabled();
+
+      await app.mainNavigation.openTargetFromMainNavigation("accounts");
+      await app.accounts.clickAddAccountButtonFromAccountsPage();
+      const selector = await getModularSelector(app, "ASSET");
+      if (selector) {
+        await selector.validateItems();
+        await selector.selectAssetByTicker(currency);
+        await selector.selectNetwork(currency);
+        await app.scanAccountsDrawer.selectFirstAccount();
+        await app.scanAccountsDrawer.clickCloseButton();
+      } else {
+        await app.addAccount.expectModalVisibility();
+        await app.addAccount.selectCurrency(currency);
+        await app.addAccount.addAccounts();
+        await app.addAccount.done();
+      }
+
+      await app.mainNavigation.openTargetFromMainNavigation("home");
+      await app.portfolio.checkSellButtonEnabled();
+      await app.portfolio.checkSendButtonEnabled();
+      await app.portfolio.expectBalanceVisibility();
+      await app.portfolio.checkOneDayPerformanceIndicatorVisibility();
     },
   );
 });


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _Not applicable: private E2E-only test package._
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Wallet 4.0 Portfolio quick actions with a zero-balance account
  - Add-account entry point from the Crypto Addresses / Accounts page
  - Portfolio state after adding a funded Bitcoin account

### 📝 Description

This PR adds desktop E2E coverage for the Wallet 4.0 Portfolio state transition where the user starts with a zero-balance account, adds a funded BTC account, then returns to Portfolio.

The scenario verifies that sell/send actions are disabled before adding the funded account and become enabled afterward, with balance and one-day performance indicators visible.

### 🧪 CI Execution

- [Desktop E2E workflow execution](https://github.com/LedgerHQ/ledger-live/actions/runs/25737159544)
- Filter: `Portfolio: with zero-balance account, then add funded account and verify balance and quick actions`
- Device: `nanoSP`

### ❓ Context

- **JIRA or GitHub link**:

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-1173]: https://ledgerhq.atlassian.net/browse/QAA-1173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ