### PR TITLE
fix: empty solana drawer after send

### DIFF
--- a/.changeset/cute-cobras-bake.md
+++ b/.changeset/cute-cobras-bake.md
@@ -1,0 +1,12 @@
+---
+"@ledgerhq/ledger-wallet-framework": patch
+---
+
+Fix shouldRetainPendingOperation dropping optimistic operations across digit boundaries
+
+The previous implementation compared `transactionSequenceNumber` values with `<=`, which
+coerces BigNumber operands to strings via `valueOf()` and compares them lexicographically.
+Whenever the optimistic op's sequence crossed a digit boundary (e.g. 99 → 100), the
+string compare (`"100" < "99"`) erroneously dropped the fresh pending op, leaving the
+OperationDetails drawer empty after a successful send (seen on Solana E2E).
+Switched to `BigNumber.prototype.lte(...)` so the comparison is numeric.

--- a/libs/ledger-wallet-framework/src/account/pending.test.ts
+++ b/libs/ledger-wallet-framework/src/account/pending.test.ts
@@ -107,6 +107,33 @@ describe("shouldRetainPendingOperation", () => {
     expect(shouldRetainPending).toBe(false);
   });
 
+  it.each([
+    [9, 10],
+    [99, 100],
+    [999, 1000],
+    [9999, 10000],
+  ])(
+    "should retain when op's transactionSequenceNumber numerically exceeds last's across digit boundary (last=%i, op=%i)",
+    (lastSeq, opSeq) => {
+      const account = createAccount("12");
+      const date = new Date();
+      account.operations = [createOperation("12", [account.freshAddress], BigInt(lastSeq), date)];
+      const op = createOperation("12", [account.freshAddress], BigInt(opSeq), date);
+
+      const result = addPendingOperation(account, op);
+      expect(shouldRetainPendingOperation(result, op)).toBe(true);
+    },
+  );
+
+  it("should not retain when op's transactionSequenceNumber equals last's", () => {
+    const account = createAccount("12");
+    const date = new Date();
+    account.operations = [createOperation("12", [account.freshAddress], BigInt(100), date)];
+    const op = createOperation("12", [account.freshAddress], BigInt(100), date);
+
+    expect(shouldRetainPendingOperation(account, op)).toBe(false);
+  });
+
   it("should not retain the operation if last operation has no matching sender", () => {
     // Given
     const account = createAccount("12");

--- a/libs/ledger-wallet-framework/src/account/pending.ts
+++ b/libs/ledger-wallet-framework/src/account/pending.ts
@@ -14,7 +14,7 @@ export function shouldRetainPendingOperation(account: Account, op: Operation): b
     last &&
     last.transactionSequenceNumber &&
     op.transactionSequenceNumber &&
-    op.transactionSequenceNumber <= last.transactionSequenceNumber
+    op.transactionSequenceNumber.lte(last.transactionSequenceNumber)
   ) {
     return false;
   }


### PR DESCRIPTION
Fix shouldRetainPendingOperation dropping optimistic operations across digit boundaries

The previous implementation compared `transactionSequenceNumber` values with `<=`, which
coerces BigNumber operands to strings via `valueOf()` and compares them lexicographically.
Whenever the optimistic op's sequence crossed a digit boundary (e.g. 99 → 100), the
string compare (`"100" < "99"`) erroneously dropped the fresh pending op, leaving the
OperationDetails drawer empty after a successful send (seen on Solana E2E).
Switched to `BigNumber.prototype.lte(...)` so the comparison is numeric.

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->https://ledgerhq.atlassian.net/browse/LIVE-30549
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
