### PR TITLE
fix(wallet-cli): improve USB interruption and DMK teardown

### DIFF
--- a/.changeset/calm-usbs-exit.md
+++ b/.changeset/calm-usbs-exit.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-cli": minor
+---
+
+Fix wallet CLI USB interruption and DMK teardown handling

--- a/apps/wallet-cli/src/cli-process-exit-error.ts
+++ b/apps/wallet-cli/src/cli-process-exit-error.ts
@@ -13,3 +13,8 @@ export class CliProcessExitError extends Error {
     super(`CLI exit ${code}`);
   }
 }
+
+/** Returns the exit code if `e` is a CliProcessExitError, otherwise `null`. */
+export function getCliProcessExitCode(e: unknown): number | null {
+  return e instanceof CliProcessExitError ? e.code : null;
+}

--- a/apps/wallet-cli/src/cli.ts
+++ b/apps/wallet-cli/src/cli.ts
@@ -9,7 +9,7 @@ import { emitTestingBuildBannerIfNeeded } from "./shared/testing-build-banner";
 // This side-effect import registers commands in the standalone binary.
 import "../.bunli/commands.gen";
 import bunliConfig from "../bunli.config";
-import { CliProcessExitError } from "./cli-process-exit-error";
+import { getCliProcessExitCode } from "./cli-process-exit-error";
 import { disposeWalletCliDmkTransportFully } from "./device/register-dmk-transport";
 import AccountGroup from "./commands/account/index";
 import SessionGroup from "./commands/session/index";
@@ -53,13 +53,11 @@ if (import.meta.main) {
   try {
     exitCode = await runMain();
   } catch (e) {
-    if (e instanceof CliProcessExitError && e.isCliProcessExitError) {
-      exitCode = e.code;
-    } else {
-      throw e;
-    }
+    const code = getCliProcessExitCode(e);
+    if (code === null) throw e;
+    exitCode = code;
   } finally {
     await disposeWalletCliDmkTransportFully();
   }
-  process.exit(exitCode);
+  process.exitCode = exitCode;
 }

--- a/apps/wallet-cli/src/commands/receive.ts
+++ b/apps/wallet-cli/src/commands/receive.ts
@@ -1,7 +1,12 @@
 import { defineCommand, option } from "@bunli/core";
 import { z } from "zod";
 import { WalletAdapter } from "../wallet";
-import { serializeNetwork, serializeV1, toV0, currencyIdFromNetwork } from "../shared/accountDescriptor";
+import {
+  serializeNetwork,
+  serializeV1,
+  toV0,
+  currencyIdFromNetwork,
+} from "../shared/accountDescriptor";
 import { WALLET_CLI_DMK_DEVICE_ID } from "../device/register-dmk-transport";
 import { WalletCliDeviceError } from "../device/wallet-cli-device-error";
 import {
@@ -40,9 +45,7 @@ export default defineCommand({
     const out = createCommandOutput(output, ctx);
 
     await out.run(async () => {
-      const v1 = await resolveAccountDescriptorV1(
-        resolveAccountArg(flags.account, positional),
-      );
+      const v1 = await resolveAccountDescriptorV1(resolveAccountArg(flags.account, positional));
       ctx.network = serializeNetwork(v1.network);
       ctx.account = serializeV1(v1);
       const currencyId = currencyIdFromNetwork(v1.network);

--- a/apps/wallet-cli/src/device/connect-ledger-app.ts
+++ b/apps/wallet-cli/src/device/connect-ledger-app.ts
@@ -144,30 +144,23 @@ async function connectLedgerAppOnce(
   }, silenceTimeoutMs);
 
   let lastRequiredInteraction: ConnectAppDARequiredInteraction | undefined;
-  try {
-    finalState = await lastValueFrom(
-      observable.pipe(
-        tap((state: ConnectAppState) => {
-          if (state.status !== DeviceActionStatus.Pending) return;
-          const r = state.intermediateValue?.requiredUserInteraction;
-          if (r == null || r === UserInteractionRequired.None || r === lastRequiredInteraction) {
-            return;
-          }
-          lastRequiredInteraction = r;
-          walletCliDebug(
-            "ConnectApp pending: requiredUserInteraction=%s app=%s",
-            r,
-            managerAppName,
-          );
+  const onIntermediateState = (state: ConnectAppState) => {
+    if (state.status !== DeviceActionStatus.Pending) return;
+    const r = state.intermediateValue?.requiredUserInteraction;
+    if (r == null || r === UserInteractionRequired.None || r === lastRequiredInteraction) {
+      return;
+    }
+    lastRequiredInteraction = r;
+    walletCliDebug("ConnectApp pending: requiredUserInteraction=%s app=%s", r, managerAppName);
 
-          if (r === UserInteractionRequired.UnlockDevice) {
-            onStateChange?.({ code: "awaiting_approval", reason: "unlock" });
-          } else if (r === UserInteractionRequired.ConfirmOpenApp) {
-            onStateChange?.({ code: "awaiting_approval", reason: "open_app" });
-          }
-        }),
-      ),
-    );
+    if (r === UserInteractionRequired.UnlockDevice) {
+      onStateChange?.({ code: "awaiting_approval", reason: "unlock" });
+    } else if (r === UserInteractionRequired.ConfirmOpenApp) {
+      onStateChange?.({ code: "awaiting_approval", reason: "open_app" });
+    }
+  };
+  try {
+    finalState = await lastValueFrom(observable.pipe(tap(onIntermediateState)));
   } catch (e) {
     if (e instanceof EmptyError) {
       throw new WalletCliDeviceError({ code: "disconnected" }, { cause: e });

--- a/apps/wallet-cli/src/device/dmk.ts
+++ b/apps/wallet-cli/src/device/dmk.ts
@@ -2,19 +2,46 @@ import {
   DeviceManagementKit,
   DeviceManagementKitBuilder,
   LogLevel,
+  type TransportFactory,
 } from "@ledgerhq/device-management-kit";
-import { nodeWebUsbTransportFactory } from "./node-webusb";
+import { nodeWebUsbTransportFactory, type NodeWebUsbTransport } from "./node-webusb";
 import { LedgerLiveLogger } from "@ledgerhq/live-dmk-shared/services/LedgerLiveLogger";
 import { UserHashService } from "@ledgerhq/live-dmk-shared/services/UserHashService";
 import { getEnv } from "@ledgerhq/live-env";
 
-export function createDeviceManagementKit(): DeviceManagementKit {
+export type WalletCliDmk = {
+  dmk: DeviceManagementKit;
+  /**
+   * Tear down the underlying node-webusb transport this kit was built with.
+   * Bound to *this* kit's transport — building another kit returns its own
+   * `destroyTransport` rather than overwriting a shared module-level ref.
+   */
+  destroyTransport: () => Promise<void>;
+};
+
+export function createDeviceManagementKit(): WalletCliDmk {
   const userId = getEnv("USER_ID") || "wallet-cli";
   const firmwareDistributionSalt = UserHashService.compute(userId).firmwareSalt;
 
-  return new DeviceManagementKitBuilder()
-    .addTransport(nodeWebUsbTransportFactory)
+  let nodeWebUsbTransport: NodeWebUsbTransport | null = null;
+  const captureTransportFactory: TransportFactory = args => {
+    const transport = nodeWebUsbTransportFactory(args) as NodeWebUsbTransport;
+    nodeWebUsbTransport = transport;
+    return transport;
+  };
+
+  const dmk = new DeviceManagementKitBuilder()
+    .addTransport(captureTransportFactory)
     .addLogger(new LedgerLiveLogger(LogLevel.Warning))
     .addConfig({ firmwareDistributionSalt })
     .build();
+
+  return {
+    dmk,
+    destroyTransport: async () => {
+      const transport = nodeWebUsbTransport;
+      nodeWebUsbTransport = null;
+      await transport?.destroy();
+    },
+  };
 }

--- a/apps/wallet-cli/src/device/interrupt-scope.ts
+++ b/apps/wallet-cli/src/device/interrupt-scope.ts
@@ -1,0 +1,15 @@
+/** Tracks DMK/native USB work where SIGINT should skip graceful USB teardown. */
+let activeScopes = 0;
+
+export function hasWalletCliDeviceInterruptScope(): boolean {
+  return activeScopes > 0;
+}
+
+export async function withWalletCliDeviceInterruptScope<T>(fn: () => Promise<T>): Promise<T> {
+  activeScopes++;
+  try {
+    return await fn();
+  } finally {
+    activeScopes--;
+  }
+}

--- a/apps/wallet-cli/src/device/node-webusb/NodeWebUsbApduSender.test.ts
+++ b/apps/wallet-cli/src/device/node-webusb/NodeWebUsbApduSender.test.ts
@@ -79,4 +79,52 @@ describe("NodeWebUsbApduSender", () => {
     const sendResult = await sendPromise;
     expect(sendResult.isLeft()).toBe(true);
   });
+
+  it("does not wait forever when the active read loop is stuck", async () => {
+    let transferInStarted: (() => void) | undefined;
+    const transferInStartedPromise = new Promise<void>(resolve => {
+      transferInStarted = resolve;
+    });
+
+    const device = {
+      opened: true,
+      transferOut: async () => ({ status: "ok" }),
+      transferIn: async () => {
+        transferInStarted?.();
+        return new Promise<{ status: "ok"; data: DataView }>(() => {});
+      },
+      releaseInterface: async () => {},
+      close: async () => {},
+    };
+
+    const apduSenderFactory = (() => ({
+      getFrames: () => [
+        {
+          getRawData: () => new Uint8Array([0xe0, 0x01, 0x00, 0x00]),
+        },
+      ],
+    })) as unknown as ApduSenderServiceFactory;
+
+    const apduReceiverFactory = (() => ({
+      handleFrame: () => {
+        throw new Error("read loop should not resolve in this test");
+      },
+    })) as unknown as ApduReceiverServiceFactory;
+
+    const sender = new NodeWebUsbApduSender({
+      dependencies: { device: device as never, interfaceNumber: 1 },
+      apduSenderFactory,
+      apduReceiverFactory,
+      loggerFactory: () => createLogger(),
+      closeReadLoopTimeoutMs: 5,
+    });
+
+    const sendPromise = sender.sendApdu(new Uint8Array([0xe0, 0x01, 0x00, 0x00]));
+    await transferInStartedPromise;
+
+    await sender.closeConnection();
+
+    const sendResult = await sendPromise;
+    expect(sendResult.isLeft()).toBe(true);
+  });
 });

--- a/apps/wallet-cli/src/device/node-webusb/NodeWebUsbApduSender.test.ts
+++ b/apps/wallet-cli/src/device/node-webusb/NodeWebUsbApduSender.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "bun:test";
+import type {
+  ApduReceiverServiceFactory,
+  ApduSenderServiceFactory,
+  LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
+import { NodeWebUsbApduSender } from "./NodeWebUsbApduSender";
+
+function flushTasks(): Promise<void> {
+  return new Promise(resolve => queueMicrotask(resolve));
+}
+
+function createLogger(): LoggerPublisherService {
+  return {
+    subscribers: [],
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  } as unknown as LoggerPublisherService;
+}
+
+describe("NodeWebUsbApduSender", () => {
+  it("waits for the active read loop before closing", async () => {
+    let resolveTransferIn: ((result: { status: "ok"; data: DataView }) => void) | undefined;
+    let transferInStarted: (() => void) | undefined;
+    const transferInStartedPromise = new Promise<void>(resolve => {
+      transferInStarted = resolve;
+    });
+
+    const device = {
+      opened: true,
+      transferOut: async () => ({ status: "ok" }),
+      transferIn: async () => {
+        transferInStarted?.();
+        return new Promise<{ status: "ok"; data: DataView }>(resolve => {
+          resolveTransferIn = resolve;
+        });
+      },
+      releaseInterface: async () => {},
+      close: async () => {},
+    };
+
+    const apduSenderFactory = (() => ({
+      getFrames: () => [
+        {
+          getRawData: () => new Uint8Array([0xe0, 0x01, 0x00, 0x00]),
+        },
+      ],
+    })) as unknown as ApduSenderServiceFactory;
+
+    const apduReceiverFactory = (() => ({
+      handleFrame: () => {
+        throw new Error("read loop should stop before handling frames");
+      },
+    })) as unknown as ApduReceiverServiceFactory;
+
+    const sender = new NodeWebUsbApduSender({
+      dependencies: { device: device as never, interfaceNumber: 1 },
+      apduSenderFactory,
+      apduReceiverFactory,
+      loggerFactory: () => createLogger(),
+    });
+
+    const sendPromise = sender.sendApdu(new Uint8Array([0xe0, 0x01, 0x00, 0x00]));
+    await transferInStartedPromise;
+
+    let closeSettled = false;
+    const closePromise = sender.closeConnection().then(() => {
+      closeSettled = true;
+    });
+
+    await flushTasks();
+    expect(closeSettled).toBe(false);
+
+    resolveTransferIn?.({ status: "ok", data: new DataView(new ArrayBuffer(0)) });
+    await closePromise;
+
+    const sendResult = await sendPromise;
+    expect(sendResult.isLeft()).toBe(true);
+  });
+});

--- a/apps/wallet-cli/src/device/node-webusb/NodeWebUsbApduSender.ts
+++ b/apps/wallet-cli/src/device/node-webusb/NodeWebUsbApduSender.ts
@@ -57,6 +57,8 @@ export class NodeWebUsbApduSender implements DeviceApduSender<NodeWebUsbApduSend
   private sendApduPromiseResolver: Maybe<(result: SendApduResult) => void> = Nothing;
   private abortTimeout: Maybe<ReturnType<typeof setTimeout>> = Nothing;
   private readLoopGeneration = 0;
+  private readLoopPromise: Promise<void> | null = null;
+  private closeConnectionPromise: Promise<void> | null = null;
 
   constructor({
     dependencies,
@@ -97,6 +99,10 @@ export class NodeWebUsbApduSender implements DeviceApduSender<NodeWebUsbApduSend
   }
 
   async setupConnection(): Promise<void> {
+    if (this.closeConnectionPromise) {
+      await this.closeConnectionPromise;
+    }
+
     const { device, interfaceNumber } = this.dependencies;
 
     if (device.opened) {
@@ -131,16 +137,28 @@ export class NodeWebUsbApduSender implements DeviceApduSender<NodeWebUsbApduSend
     this.logger.info("Connected to device (WebUSB)");
   }
 
-  async closeConnection(): Promise<void> {
+  closeConnection(): Promise<void> {
+    if (this.closeConnectionPromise) {
+      return this.closeConnectionPromise;
+    }
+
+    const closePromise = this.closeConnectionInternal().finally(() => {
+      if (this.closeConnectionPromise === closePromise) {
+        this.closeConnectionPromise = null;
+      }
+    });
+    this.closeConnectionPromise = closePromise;
+    return closePromise;
+  }
+
+  private async closeConnectionInternal(): Promise<void> {
     const { device, interfaceNumber } = this.dependencies;
     this.readLoopGeneration++;
-    this.sendApduPromiseResolver = Nothing;
-    this.abortTimeout.map(t => {
-      this.abortTimeout = Nothing;
-      clearTimeout(t);
-    });
+    const readLoopPromise = this.readLoopPromise;
+    this.resolvePendingApdu(Left(new OpeningConnectionError("WebUSB connection closed")));
 
     if (!device.opened) {
+      await readLoopPromise;
       return;
     }
 
@@ -150,11 +168,11 @@ export class NodeWebUsbApduSender implements DeviceApduSender<NodeWebUsbApduSend
       // ignore
     }
     try {
-      await gracefullyResetDevice(device);
       await device.close();
     } catch (e) {
       this.logger.error("Error while closing WebUSB device", { data: { error: e } });
     }
+    await readLoopPromise;
     this.logger.info("Disconnect (WebUSB)");
   }
 
@@ -204,7 +222,12 @@ export class NodeWebUsbApduSender implements DeviceApduSender<NodeWebUsbApduSend
     }
 
     const generation = ++this.readLoopGeneration;
-    void this.receiveResponseFrames(device, generation);
+    const readLoopPromise = this.receiveResponseFrames(device, generation).finally(() => {
+      if (this.readLoopPromise === readLoopPromise) {
+        this.readLoopPromise = null;
+      }
+    });
+    this.readLoopPromise = readLoopPromise;
 
     return completion;
   }

--- a/apps/wallet-cli/src/device/node-webusb/NodeWebUsbApduSender.ts
+++ b/apps/wallet-cli/src/device/node-webusb/NodeWebUsbApduSender.ts
@@ -19,6 +19,8 @@ import {
   LEDGER_WEBUSB_ENDPOINT_NUMBER,
 } from "./node-webusb-constants";
 
+const CLOSE_READ_LOOP_TIMEOUT_MS = 1_000;
+
 export type NodeWebUsbApduSenderDependencies = {
   device: WebUSBDevice;
   interfaceNumber: number;
@@ -29,6 +31,7 @@ export type NodeWebUsbApduSenderConstructorArgs = {
   apduSenderFactory: ApduSenderServiceFactory;
   apduReceiverFactory: ApduReceiverServiceFactory;
   loggerFactory: (tag: string) => LoggerPublisherService;
+  closeReadLoopTimeoutMs?: number;
 };
 
 async function gracefullyResetDevice(device: WebUSBDevice): Promise<void> {
@@ -46,6 +49,27 @@ function bufferFromInTransfer(data: DataView): Uint8Array {
   return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
 }
 
+async function awaitReadLoopClose(
+  readLoopPromise: Promise<void> | null,
+  timeoutMs: number,
+): Promise<void> {
+  if (!readLoopPromise) {
+    return;
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<void>(resolve => {
+    timer = setTimeout(resolve, timeoutMs);
+    timer.unref?.();
+  });
+
+  try {
+    await Promise.race([readLoopPromise.catch(() => undefined), timeoutPromise]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 /** DMK device APDU sender over Ledger WebUSB bulk endpoints (node-usb WebUSB API, same framing as hw-transport-webusb). */
 export class NodeWebUsbApduSender implements DeviceApduSender<NodeWebUsbApduSenderDependencies> {
   private dependencies: NodeWebUsbApduSenderDependencies;
@@ -59,12 +83,14 @@ export class NodeWebUsbApduSender implements DeviceApduSender<NodeWebUsbApduSend
   private readLoopGeneration = 0;
   private readLoopPromise: Promise<void> | null = null;
   private closeConnectionPromise: Promise<void> | null = null;
+  private readonly closeReadLoopTimeoutMs: number;
 
   constructor({
     dependencies,
     apduSenderFactory,
     apduReceiverFactory,
     loggerFactory,
+    closeReadLoopTimeoutMs = CLOSE_READ_LOOP_TIMEOUT_MS,
   }: NodeWebUsbApduSenderConstructorArgs) {
     const channel = Maybe.of(crypto.getRandomValues(new Uint8Array(2)));
     this.dependencies = dependencies;
@@ -77,6 +103,7 @@ export class NodeWebUsbApduSender implements DeviceApduSender<NodeWebUsbApduSend
     this.apduReceiverFactory = apduReceiverFactory;
     this.apduReceiver = this.apduReceiverFactory({ channel });
     this.logger = loggerFactory("NodeWebUsbApduSender");
+    this.closeReadLoopTimeoutMs = closeReadLoopTimeoutMs;
   }
 
   getDependencies(): NodeWebUsbApduSenderDependencies {
@@ -158,7 +185,7 @@ export class NodeWebUsbApduSender implements DeviceApduSender<NodeWebUsbApduSend
     this.resolvePendingApdu(Left(new OpeningConnectionError("WebUSB connection closed")));
 
     if (!device.opened) {
-      await readLoopPromise;
+      await awaitReadLoopClose(readLoopPromise, this.closeReadLoopTimeoutMs);
       return;
     }
 
@@ -172,7 +199,7 @@ export class NodeWebUsbApduSender implements DeviceApduSender<NodeWebUsbApduSend
     } catch (e) {
       this.logger.error("Error while closing WebUSB device", { data: { error: e } });
     }
-    await readLoopPromise;
+    await awaitReadLoopClose(readLoopPromise, this.closeReadLoopTimeoutMs);
     this.logger.info("Disconnect (WebUSB)");
   }
 

--- a/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.test.ts
+++ b/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.test.ts
@@ -55,70 +55,172 @@ function createStubApduSender() {
   };
 }
 
-describe("NodeWebUsbTransport", () => {
-  let subscriptions: Subscription[] = [];
+let subscriptions: Subscription[] = [];
 
+type NativeLedgerDevice = {
+  deviceDescriptor: {
+    idVendor: number;
+    idProduct: number;
+  };
+};
+
+type WebUsbLedgerDevice = {
+  vendorId: number;
+  productId: number;
+  serialNumber: string;
+  configurations: Array<{
+    interfaces: Array<{
+      interfaceNumber: number;
+      alternates: Array<{ interfaceClass: number }>;
+    }>;
+  }>;
+};
+
+type TestPlatformBindings = NonNullable<ConstructorParameters<typeof NodeWebUsbTransport>[6]>;
+
+function createNativeLedgerDevice(): NativeLedgerDevice {
+  return {
+    deviceDescriptor: {
+      idVendor: 0x2c97,
+      idProduct: 0x5011,
+    },
+  };
+}
+
+function createWebUsbLedgerDevice(serialNumber = "ledger-1"): WebUsbLedgerDevice {
+  return {
+    vendorId: 0x2c97,
+    productId: 0x5011,
+    serialNumber,
+    configurations: [
+      {
+        interfaces: [
+          {
+            interfaceNumber: 1,
+            alternates: [{ interfaceClass: 255 }],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function createLedgerModelDataSource(): DeviceModelDataSource {
+  return {
+    getAllDeviceModels: () => [
+      {
+        id: "nanoSP",
+        productName: "Ledger Nano S Plus",
+        usbProductId: 0x50,
+        bootloaderUsbProductId: 0x5011,
+      },
+    ],
+  } as DeviceModelDataSource;
+}
+
+function createUnusedApduSenderFactory(): ApduSenderServiceFactory {
+  return (() => {
+    throw new Error("unused apdu sender factory");
+  }) as ApduSenderServiceFactory;
+}
+
+function createUnusedApduReceiverFactory(): ApduReceiverServiceFactory {
+  return (() => {
+    throw new Error("unused apdu receiver factory");
+  }) as ApduReceiverServiceFactory;
+}
+
+function createPlatformBindings(
+  overrides: Pick<TestPlatformBindings, "getDeviceList" | "createWebUsbDevice"> &
+    Partial<TestPlatformBindings>,
+): TestPlatformBindings {
+  return {
+    platform: "win32",
+    usbBindings: {
+      on: () => {},
+      removeListener: () => {},
+      unrefHotplugEvents: () => {},
+    },
+    setInterval: callback => {
+      queueMicrotask(callback);
+      return 0 as unknown as ReturnType<typeof globalThis.setInterval>;
+    },
+    clearInterval: () => {},
+    ...overrides,
+  };
+}
+
+function createTestTransport(
+  deviceConnectionStateMachineFactory?: ConstructorParameters<typeof NodeWebUsbTransport>[4],
+  deviceApduSenderFactory?: ConstructorParameters<typeof NodeWebUsbTransport>[5],
+  platformBindings?: TestPlatformBindings,
+): NodeWebUsbTransport {
+  return new NodeWebUsbTransport(
+    createLedgerModelDataSource(),
+    () => createLogger(),
+    createUnusedApduSenderFactory(),
+    createUnusedApduReceiverFactory(),
+    deviceConnectionStateMachineFactory,
+    deviceApduSenderFactory,
+    platformBindings,
+  );
+}
+
+function collectDeviceEmissions(
+  transport: NodeWebUsbTransport,
+): Array<Array<{ id: string; transport: string }>> {
+  const emissions: Array<Array<{ id: string; transport: string }>> = [];
+  subscriptions.push(
+    transport.listenToAvailableDevices().subscribe(devices => {
+      emissions.push(devices.map(device => ({ id: device.id, transport: device.transport })));
+    }),
+  );
+  return emissions;
+}
+
+async function waitForFirstDeviceId(
+  emissions: Array<Array<{ id: string; transport: string }>>,
+): Promise<DeviceId> {
+  let connectedDeviceId: DeviceId | undefined;
+  await waitFor(() => {
+    connectedDeviceId = emissions.at(-1)?.[0]?.id;
+    expect(connectedDeviceId).toBeDefined();
+  });
+  return connectedDeviceId!;
+}
+
+function unwrapConnectedDevice(
+  connectResult: Awaited<ReturnType<NodeWebUsbTransport["connect"]>>,
+): TransportConnectedDevice {
+  let connectedDevice: TransportConnectedDevice | undefined;
+  connectResult.ifRight(device => {
+    connectedDevice = device;
+  });
+  expect(connectedDevice).toBeDefined();
+  return connectedDevice!;
+}
+
+describe("NodeWebUsbTransport", () => {
   afterEach(() => {
     subscriptions.forEach(subscription => subscription.unsubscribe());
     subscriptions = [];
   });
 
   it("refreshes discovered devices from the Windows polling fallback when hotplug attach is missed", async () => {
-    const nativeDevice = {
-      deviceDescriptor: {
-        idVendor: 0x2c97,
-        idProduct: 0x5011,
-      },
-    };
-    const webUsbDevice = {
-      vendorId: 0x2c97,
-      productId: 0x5011,
-      serialNumber: "ledger-1",
-      configurations: [
-        {
-          interfaces: [
-            {
-              interfaceNumber: 1,
-              alternates: [{ interfaceClass: 255 }],
-            },
-          ],
-        },
-      ],
-    };
+    const nativeDevice = createNativeLedgerDevice();
+    const webUsbDevice = createWebUsbLedgerDevice();
 
     let currentDeviceList: (typeof nativeDevice)[] = [];
     let pollCallback: (() => void) | undefined;
     let clearedInterval: ReturnType<typeof globalThis.setInterval> | null = null;
 
-    const transport = new NodeWebUsbTransport(
-      {
-        getAllDeviceModels: () => [
-          {
-            id: "nanoSP",
-            productName: "Ledger Nano S Plus",
-            usbProductId: 0x50,
-            bootloaderUsbProductId: 0x5011,
-          },
-        ],
-      } as DeviceModelDataSource,
-      () => createLogger(),
-      (() => {
-        throw new Error("unused apdu sender factory");
-      }) as ApduSenderServiceFactory,
-      (() => {
-        throw new Error("unused apdu receiver factory");
-      }) as ApduReceiverServiceFactory,
+    const transport = createTestTransport(
       undefined,
       undefined,
-      {
+      createPlatformBindings({
         platform: "win32",
         getDeviceList: () => currentDeviceList as never[],
         createWebUsbDevice: async () => webUsbDevice as never,
-        usbBindings: {
-          on: () => {},
-          removeListener: () => {},
-          unrefHotplugEvents: () => {},
-        },
         setInterval: callback => {
           pollCallback = callback;
           return 0 as unknown as ReturnType<typeof globalThis.setInterval>;
@@ -126,7 +228,7 @@ describe("NodeWebUsbTransport", () => {
         clearInterval: handle => {
           clearedInterval = handle;
         },
-      },
+      }),
     );
 
     const emissions: Array<{ id: string; transport: string }> = [];
@@ -148,32 +250,13 @@ describe("NodeWebUsbTransport", () => {
     expect(emissions[0]?.transport).toBe("NODE-WEBUSB");
     expect(typeof emissions[0]?.id).toBe("string");
 
-    transport.destroy();
+    await transport.destroy();
     expect(clearedInterval).not.toBeNull();
   });
 
   it("restarts Windows discovery polling when the connection state machine asks to reconnect", async () => {
-    const nativeDevice = {
-      deviceDescriptor: {
-        idVendor: 0x2c97,
-        idProduct: 0x5011,
-      },
-    };
-    const webUsbDevice = {
-      vendorId: 0x2c97,
-      productId: 0x5011,
-      serialNumber: "ledger-1",
-      configurations: [
-        {
-          interfaces: [
-            {
-              interfaceNumber: 1,
-              alternates: [{ interfaceClass: 255 }],
-            },
-          ],
-        },
-      ],
-    };
+    const nativeDevice = createNativeLedgerDevice();
+    const webUsbDevice = createWebUsbLedgerDevice();
 
     let currentDeviceList: (typeof nativeDevice)[] = [nativeDevice];
     let nextHandle = 0;
@@ -185,24 +268,7 @@ describe("NodeWebUsbTransport", () => {
       | undefined;
     let connectedDeviceId: DeviceId | undefined;
 
-    const transport = new NodeWebUsbTransport(
-      {
-        getAllDeviceModels: () => [
-          {
-            id: "nanoSP",
-            productName: "Ledger Nano S Plus",
-            usbProductId: 0x50,
-            bootloaderUsbProductId: 0x5011,
-          },
-        ],
-      } as DeviceModelDataSource,
-      () => createLogger(),
-      (() => {
-        throw new Error("unused apdu sender factory");
-      }) as ApduSenderServiceFactory,
-      (() => {
-        throw new Error("unused apdu receiver factory");
-      }) as ApduReceiverServiceFactory,
+    const transport = createTestTransport(
       params => {
         tryToReconnect = params.tryToReconnect;
 
@@ -221,15 +287,10 @@ describe("NodeWebUsbTransport", () => {
         } as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>;
       },
       () => createStubApduSender() as never,
-      {
+      createPlatformBindings({
         platform: "win32",
         getDeviceList: () => currentDeviceList as never[],
         createWebUsbDevice: async () => webUsbDevice as never,
-        usbBindings: {
-          on: () => {},
-          removeListener: () => {},
-          unrefHotplugEvents: () => {},
-        },
         setInterval: callback => {
           nextHandle += 1;
           intervalHandles.push(nextHandle);
@@ -239,20 +300,12 @@ describe("NodeWebUsbTransport", () => {
         clearInterval: handle => {
           clearedHandles.push(handle as unknown as number);
         },
-      },
-    );
-
-    const emissions: Array<Array<{ id: string; transport: string }>> = [];
-    subscriptions.push(
-      transport.listenToAvailableDevices().subscribe(devices => {
-        emissions.push(devices.map(device => ({ id: device.id, transport: device.transport })));
       }),
     );
 
-    await waitFor(() => {
-      connectedDeviceId = emissions.at(-1)?.[0]?.id;
-      expect(connectedDeviceId).toBeDefined();
-    });
+    const emissions = collectDeviceEmissions(transport);
+
+    connectedDeviceId = await waitForFirstDeviceId(emissions);
     expect(tryToReconnect).toBeUndefined();
     expect(intervalHandles).toEqual([1]);
     expect(clearedHandles).toEqual([1]);
@@ -276,32 +329,13 @@ describe("NodeWebUsbTransport", () => {
       expect(emissions.at(-1)).toEqual([]);
     });
 
-    transport.destroy();
+    await transport.destroy();
     expect(clearedHandles).toContain(2);
   });
 
   it("reconnects a pending machine from a rescan even if attach arrived before pending mode", async () => {
-    const nativeDevice = {
-      deviceDescriptor: {
-        idVendor: 0x2c97,
-        idProduct: 0x5011,
-      },
-    };
-    const webUsbDevice = {
-      vendorId: 0x2c97,
-      productId: 0x5011,
-      serialNumber: "ledger-1",
-      configurations: [
-        {
-          interfaces: [
-            {
-              interfaceNumber: 1,
-              alternates: [{ interfaceClass: 255 }],
-            },
-          ],
-        },
-      ],
-    };
+    const nativeDevice = createNativeLedgerDevice();
+    const webUsbDevice = createWebUsbLedgerDevice();
 
     let currentDeviceList: (typeof nativeDevice)[] = [nativeDevice];
     let tryToReconnect:
@@ -311,24 +345,7 @@ describe("NodeWebUsbTransport", () => {
     let setupConnectionCalls = 0;
     let eventDeviceConnectedCalls = 0;
 
-    const transport = new NodeWebUsbTransport(
-      {
-        getAllDeviceModels: () => [
-          {
-            id: "nanoSP",
-            productName: "Ledger Nano S Plus",
-            usbProductId: 0x50,
-            bootloaderUsbProductId: 0x5011,
-          },
-        ],
-      } as DeviceModelDataSource,
-      () => createLogger(),
-      (() => {
-        throw new Error("unused apdu sender factory");
-      }) as ApduSenderServiceFactory,
-      (() => {
-        throw new Error("unused apdu receiver factory");
-      }) as ApduReceiverServiceFactory,
+    const transport = createTestTransport(
       params => {
         tryToReconnect = params.tryToReconnect;
 
@@ -351,34 +368,16 @@ describe("NodeWebUsbTransport", () => {
         } as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>;
       },
       () => createStubApduSender() as never,
-      {
+      createPlatformBindings({
         platform: "win32",
         getDeviceList: () => currentDeviceList as never[],
         createWebUsbDevice: async () => webUsbDevice as never,
-        usbBindings: {
-          on: () => {},
-          removeListener: () => {},
-          unrefHotplugEvents: () => {},
-        },
-        setInterval: callback => {
-          queueMicrotask(callback);
-          return 0 as unknown as ReturnType<typeof globalThis.setInterval>;
-        },
-        clearInterval: () => {},
-      },
-    );
-
-    const emissions: Array<Array<{ id: string; transport: string }>> = [];
-    subscriptions.push(
-      transport.listenToAvailableDevices().subscribe(devices => {
-        emissions.push(devices.map(device => ({ id: device.id, transport: device.transport })));
       }),
     );
 
-    await waitFor(() => {
-      connectedDeviceId = emissions.at(-1)?.[0]?.id;
-      expect(connectedDeviceId).toBeDefined();
-    });
+    const emissions = collectDeviceEmissions(transport);
+
+    connectedDeviceId = await waitForFirstDeviceId(emissions);
 
     await transport.connect({
       deviceId: connectedDeviceId!,
@@ -394,31 +393,12 @@ describe("NodeWebUsbTransport", () => {
       expect(eventDeviceConnectedCalls).toBe(1);
     });
 
-    transport.destroy();
+    await transport.destroy();
   });
 
   it("keeps a machine pending when an early reconnect attempt fails before a later scan succeeds", async () => {
-    const nativeDevice = {
-      deviceDescriptor: {
-        idVendor: 0x2c97,
-        idProduct: 0x5011,
-      },
-    };
-    const webUsbDevice = {
-      vendorId: 0x2c97,
-      productId: 0x5011,
-      serialNumber: "ledger-1",
-      configurations: [
-        {
-          interfaces: [
-            {
-              interfaceNumber: 1,
-              alternates: [{ interfaceClass: 255 }],
-            },
-          ],
-        },
-      ],
-    };
+    const nativeDevice = createNativeLedgerDevice();
+    const webUsbDevice = createWebUsbLedgerDevice();
 
     let currentDeviceList: (typeof nativeDevice)[] = [nativeDevice];
     let tryToReconnect:
@@ -429,24 +409,7 @@ describe("NodeWebUsbTransport", () => {
     let eventDeviceConnectedCalls = 0;
     let closeConnectionCalls = 0;
 
-    const transport = new NodeWebUsbTransport(
-      {
-        getAllDeviceModels: () => [
-          {
-            id: "nanoSP",
-            productName: "Ledger Nano S Plus",
-            usbProductId: 0x50,
-            bootloaderUsbProductId: 0x5011,
-          },
-        ],
-      } as DeviceModelDataSource,
-      () => createLogger(),
-      (() => {
-        throw new Error("unused apdu sender factory");
-      }) as ApduSenderServiceFactory,
-      (() => {
-        throw new Error("unused apdu receiver factory");
-      }) as ApduReceiverServiceFactory,
+    const transport = createTestTransport(
       params => {
         tryToReconnect = params.tryToReconnect;
 
@@ -474,34 +437,16 @@ describe("NodeWebUsbTransport", () => {
         } as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>;
       },
       () => createStubApduSender() as never,
-      {
+      createPlatformBindings({
         platform: "win32",
         getDeviceList: () => currentDeviceList as never[],
         createWebUsbDevice: async () => webUsbDevice as never,
-        usbBindings: {
-          on: () => {},
-          removeListener: () => {},
-          unrefHotplugEvents: () => {},
-        },
-        setInterval: callback => {
-          queueMicrotask(callback);
-          return 0 as unknown as ReturnType<typeof globalThis.setInterval>;
-        },
-        clearInterval: () => {},
-      },
-    );
-
-    const emissions: Array<Array<{ id: string; transport: string }>> = [];
-    subscriptions.push(
-      transport.listenToAvailableDevices().subscribe(devices => {
-        emissions.push(devices.map(device => ({ id: device.id, transport: device.transport })));
       }),
     );
 
-    await waitFor(() => {
-      connectedDeviceId = emissions.at(-1)?.[0]?.id;
-      expect(connectedDeviceId).toBeDefined();
-    });
+    const emissions = collectDeviceEmissions(transport);
+
+    connectedDeviceId = await waitForFirstDeviceId(emissions);
 
     await transport.connect({
       deviceId: connectedDeviceId!,
@@ -528,31 +473,12 @@ describe("NodeWebUsbTransport", () => {
 
     expect(closeConnectionCalls).toBe(0);
 
-    transport.destroy();
+    await transport.destroy();
   });
 
   it("keeps a machine pending and not active when eventDeviceConnected throws during reconnection", async () => {
-    const nativeDevice = {
-      deviceDescriptor: {
-        idVendor: 0x2c97,
-        idProduct: 0x5011,
-      },
-    };
-    const webUsbDevice = {
-      vendorId: 0x2c97,
-      productId: 0x5011,
-      serialNumber: "ledger-1",
-      configurations: [
-        {
-          interfaces: [
-            {
-              interfaceNumber: 1,
-              alternates: [{ interfaceClass: 255 }],
-            },
-          ],
-        },
-      ],
-    };
+    const nativeDevice = createNativeLedgerDevice();
+    const webUsbDevice = createWebUsbLedgerDevice();
 
     const currentDeviceList: (typeof nativeDevice)[] = [nativeDevice];
     let tryToReconnect:
@@ -564,24 +490,7 @@ describe("NodeWebUsbTransport", () => {
     let eventDeviceDisconnectedCalls = 0;
     let closeConnectionCalls = 0;
 
-    const transport = new NodeWebUsbTransport(
-      {
-        getAllDeviceModels: () => [
-          {
-            id: "nanoSP",
-            productName: "Ledger Nano S Plus",
-            usbProductId: 0x50,
-            bootloaderUsbProductId: 0x5011,
-          },
-        ],
-      } as DeviceModelDataSource,
-      () => createLogger(),
-      (() => {
-        throw new Error("unused apdu sender factory");
-      }) as ApduSenderServiceFactory,
-      (() => {
-        throw new Error("unused apdu receiver factory");
-      }) as ApduReceiverServiceFactory,
+    const transport = createTestTransport(
       params => {
         tryToReconnect = params.tryToReconnect;
 
@@ -612,34 +521,16 @@ describe("NodeWebUsbTransport", () => {
         } as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>;
       },
       () => createStubApduSender() as never,
-      {
+      createPlatformBindings({
         platform: "win32",
         getDeviceList: () => currentDeviceList as never[],
         createWebUsbDevice: async () => webUsbDevice as never,
-        usbBindings: {
-          on: () => {},
-          removeListener: () => {},
-          unrefHotplugEvents: () => {},
-        },
-        setInterval: callback => {
-          queueMicrotask(callback);
-          return 0 as unknown as ReturnType<typeof globalThis.setInterval>;
-        },
-        clearInterval: () => {},
-      },
-    );
-
-    const emissions: Array<Array<{ id: string; transport: string }>> = [];
-    subscriptions.push(
-      transport.listenToAvailableDevices().subscribe(devices => {
-        emissions.push(devices.map(device => ({ id: device.id, transport: device.transport })));
       }),
     );
 
-    await waitFor(() => {
-      connectedDeviceId = emissions.at(-1)?.[0]?.id;
-      expect(connectedDeviceId).toBeDefined();
-    });
+    const emissions = collectDeviceEmissions(transport);
+
+    connectedDeviceId = await waitForFirstDeviceId(emissions);
 
     const connected = await transport.connect({
       deviceId: connectedDeviceId!,
@@ -673,54 +564,18 @@ describe("NodeWebUsbTransport", () => {
     // recoverable rather than tearing it down on a transient failure.
     expect(closeConnectionCalls).toBe(0);
 
-    transport.destroy();
+    await transport.destroy();
   });
 
   it("serializes APDU calls sent through the same connected device", async () => {
-    const nativeDevice = {
-      deviceDescriptor: {
-        idVendor: 0x2c97,
-        idProduct: 0x5011,
-      },
-    };
-    const webUsbDevice = {
-      vendorId: 0x2c97,
-      productId: 0x5011,
-      serialNumber: "ledger-1",
-      configurations: [
-        {
-          interfaces: [
-            {
-              interfaceNumber: 1,
-              alternates: [{ interfaceClass: 255 }],
-            },
-          ],
-        },
-      ],
-    };
+    const nativeDevice = createNativeLedgerDevice();
+    const webUsbDevice = createWebUsbLedgerDevice();
 
     let connectedDeviceId: DeviceId | undefined;
     let sendApduCalls = 0;
     let resolveFirstApdu: (() => void) | undefined;
 
-    const transport = new NodeWebUsbTransport(
-      {
-        getAllDeviceModels: () => [
-          {
-            id: "nanoSP",
-            productName: "Ledger Nano S Plus",
-            usbProductId: 0x50,
-            bootloaderUsbProductId: 0x5011,
-          },
-        ],
-      } as DeviceModelDataSource,
-      () => createLogger(),
-      (() => {
-        throw new Error("unused apdu sender factory");
-      }) as ApduSenderServiceFactory,
-      (() => {
-        throw new Error("unused apdu receiver factory");
-      }) as ApduReceiverServiceFactory,
+    const transport = createTestTransport(
       params =>
         ({
           setupConnection: async () => {},
@@ -747,47 +602,25 @@ describe("NodeWebUsbTransport", () => {
           closeConnection: () => {},
         }) as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>,
       () => createStubApduSender() as never,
-      {
+      createPlatformBindings({
         platform: "win32",
         getDeviceList: () => [nativeDevice] as never[],
         createWebUsbDevice: async () => webUsbDevice as never,
-        usbBindings: {
-          on: () => {},
-          removeListener: () => {},
-          unrefHotplugEvents: () => {},
-        },
-        setInterval: callback => {
-          queueMicrotask(callback);
-          return 0 as unknown as ReturnType<typeof globalThis.setInterval>;
-        },
-        clearInterval: () => {},
-      },
-    );
-
-    const emissions: Array<Array<{ id: string; transport: string }>> = [];
-    subscriptions.push(
-      transport.listenToAvailableDevices().subscribe(devices => {
-        emissions.push(devices.map(device => ({ id: device.id, transport: device.transport })));
       }),
     );
 
-    await waitFor(() => {
-      connectedDeviceId = emissions.at(-1)?.[0]?.id;
-      expect(connectedDeviceId).toBeDefined();
-    });
+    const emissions = collectDeviceEmissions(transport);
+
+    connectedDeviceId = await waitForFirstDeviceId(emissions);
 
     const connectResult = await transport.connect({
       deviceId: connectedDeviceId!,
       onDisconnect: () => {},
     });
-    let connectedDevice: TransportConnectedDevice | undefined;
-    connectResult.ifRight(device => {
-      connectedDevice = device;
-    });
-    expect(connectedDevice).toBeDefined();
+    const connectedDevice = unwrapConnectedDevice(connectResult);
 
-    const firstApdu = connectedDevice!.sendApdu(new Uint8Array([0xb0, 0x01]));
-    const secondApdu = connectedDevice!.sendApdu(new Uint8Array([0xb0, 0x01]));
+    const firstApdu = connectedDevice.sendApdu(new Uint8Array([0xb0, 0x01]));
+    const secondApdu = connectedDevice.sendApdu(new Uint8Array([0xb0, 0x01]));
 
     await waitFor(() => {
       expect(sendApduCalls).toBe(1);
@@ -801,54 +634,25 @@ describe("NodeWebUsbTransport", () => {
 
     expect(sendApduCalls).toBe(2);
 
-    transport.destroy();
+    await transport.destroy();
   });
 
   it("creates a fresh connection state machine after disconnecting a session", async () => {
-    const nativeDevice = {
-      deviceDescriptor: {
-        idVendor: 0x2c97,
-        idProduct: 0x5011,
-      },
-    };
-    const webUsbDevice = {
-      vendorId: 0x2c97,
-      productId: 0x5011,
-      serialNumber: "ledger-1",
-      configurations: [
-        {
-          interfaces: [
-            {
-              interfaceNumber: 1,
-              alternates: [{ interfaceClass: 255 }],
-            },
-          ],
-        },
-      ],
-    };
+    const nativeDevice = createNativeLedgerDevice();
+    const webUsbDevice = createWebUsbLedgerDevice();
 
     let connectedDeviceId: DeviceId | undefined;
     let setupConnectionCalls = 0;
-    let closeConnectionCalls = 0;
+    let machineCloseConnectionCalls = 0;
+    let usbCloseConnectionCalls = 0;
+    let usbCloseCompleted = false;
+    let releaseUsbClose: (() => void) | undefined;
+    const usbCloseGate = new Promise<void>(resolve => {
+      releaseUsbClose = resolve;
+    });
+    let usbClosePromise: Promise<void> | null = null;
 
-    const transport = new NodeWebUsbTransport(
-      {
-        getAllDeviceModels: () => [
-          {
-            id: "nanoSP",
-            productName: "Ledger Nano S Plus",
-            usbProductId: 0x50,
-            bootloaderUsbProductId: 0x5011,
-          },
-        ],
-      } as DeviceModelDataSource,
-      () => createLogger(),
-      (() => {
-        throw new Error("unused apdu sender factory");
-      }) as ApduSenderServiceFactory,
-      (() => {
-        throw new Error("unused apdu receiver factory");
-      }) as ApduReceiverServiceFactory,
+    const transport = createTestTransport(
       params =>
         ({
           setupConnection: async () => {
@@ -864,39 +668,32 @@ describe("NodeWebUsbTransport", () => {
           eventDeviceDisconnected: () => {},
           eventDeviceConnected: () => {},
           closeConnection: () => {
-            closeConnectionCalls += 1;
+            machineCloseConnectionCalls += 1;
             params.onTerminated();
           },
         }) as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>,
-      () => createStubApduSender() as never,
-      {
+      () =>
+        ({
+          ...createStubApduSender(),
+          closeConnection: () => {
+            usbClosePromise ??= (async () => {
+              usbCloseConnectionCalls += 1;
+              await usbCloseGate;
+              usbCloseCompleted = true;
+            })();
+            return usbClosePromise;
+          },
+        }) as never,
+      createPlatformBindings({
         platform: "win32",
         getDeviceList: () => [nativeDevice] as never[],
         createWebUsbDevice: async () => webUsbDevice as never,
-        usbBindings: {
-          on: () => {},
-          removeListener: () => {},
-          unrefHotplugEvents: () => {},
-        },
-        setInterval: callback => {
-          queueMicrotask(callback);
-          return 0 as unknown as ReturnType<typeof globalThis.setInterval>;
-        },
-        clearInterval: () => {},
-      },
-    );
-
-    const emissions: Array<Array<{ id: string; transport: string }>> = [];
-    subscriptions.push(
-      transport.listenToAvailableDevices().subscribe(devices => {
-        emissions.push(devices.map(device => ({ id: device.id, transport: device.transport })));
       }),
     );
 
-    await waitFor(() => {
-      connectedDeviceId = emissions.at(-1)?.[0]?.id;
-      expect(connectedDeviceId).toBeDefined();
-    });
+    const emissions = collectDeviceEmissions(transport);
+
+    connectedDeviceId = await waitForFirstDeviceId(emissions);
 
     const onDisconnectCalls: DeviceId[] = [];
     const firstConnect = await transport.connect({
@@ -905,16 +702,24 @@ describe("NodeWebUsbTransport", () => {
         onDisconnectCalls.push(id);
       },
     });
-    let connectedDevice: TransportConnectedDevice | undefined;
-    firstConnect.ifRight(device => {
-      connectedDevice = device;
-    });
-    expect(connectedDevice).toBeDefined();
+    const connectedDevice = unwrapConnectedDevice(firstConnect);
     expect(setupConnectionCalls).toBe(1);
 
-    await transport.disconnect({ connectedDevice: connectedDevice! });
-    expect(closeConnectionCalls).toBe(1);
+    const disconnectPromise = transport.disconnect({ connectedDevice });
+    await flushTasks();
+    expect(machineCloseConnectionCalls).toBe(1);
+    expect(usbCloseConnectionCalls).toBe(1);
     expect(onDisconnectCalls).toEqual([connectedDeviceId!]);
+    expect(usbCloseCompleted).toBe(false);
+
+    releaseUsbClose?.();
+    await disconnectPromise;
+    expect(usbCloseCompleted).toBe(true);
+
+    await waitFor(() => {
+      connectedDeviceId = emissions.at(-1)?.[0]?.id;
+      expect(connectedDeviceId).toBeDefined();
+    });
 
     await transport.connect({
       deviceId: connectedDeviceId!,
@@ -922,53 +727,17 @@ describe("NodeWebUsbTransport", () => {
     });
     expect(setupConnectionCalls).toBe(2);
 
-    transport.destroy();
+    await transport.destroy();
   });
 
   it("rejects sendApdu with DeviceDisconnectedBeforeSendingApdu after the machine is unrouted", async () => {
-    const nativeDevice = {
-      deviceDescriptor: {
-        idVendor: 0x2c97,
-        idProduct: 0x5011,
-      },
-    };
-    const webUsbDevice = {
-      vendorId: 0x2c97,
-      productId: 0x5011,
-      serialNumber: "ledger-1",
-      configurations: [
-        {
-          interfaces: [
-            {
-              interfaceNumber: 1,
-              alternates: [{ interfaceClass: 255 }],
-            },
-          ],
-        },
-      ],
-    };
+    const nativeDevice = createNativeLedgerDevice();
+    const webUsbDevice = createWebUsbLedgerDevice();
 
     let connectedDeviceId: DeviceId | undefined;
     let machineSendApduCalls = 0;
 
-    const transport = new NodeWebUsbTransport(
-      {
-        getAllDeviceModels: () => [
-          {
-            id: "nanoSP",
-            productName: "Ledger Nano S Plus",
-            usbProductId: 0x50,
-            bootloaderUsbProductId: 0x5011,
-          },
-        ],
-      } as DeviceModelDataSource,
-      () => createLogger(),
-      (() => {
-        throw new Error("unused apdu sender factory");
-      }) as ApduSenderServiceFactory,
-      (() => {
-        throw new Error("unused apdu receiver factory");
-      }) as ApduReceiverServiceFactory,
+    const transport = createTestTransport(
       params =>
         ({
           setupConnection: async () => {},
@@ -992,49 +761,27 @@ describe("NodeWebUsbTransport", () => {
           },
         }) as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>,
       () => createStubApduSender() as never,
-      {
+      createPlatformBindings({
         platform: "win32",
         getDeviceList: () => [nativeDevice] as never[],
         createWebUsbDevice: async () => webUsbDevice as never,
-        usbBindings: {
-          on: () => {},
-          removeListener: () => {},
-          unrefHotplugEvents: () => {},
-        },
-        setInterval: callback => {
-          queueMicrotask(callback);
-          return 0 as unknown as ReturnType<typeof globalThis.setInterval>;
-        },
-        clearInterval: () => {},
-      },
-    );
-
-    const emissions: Array<Array<{ id: string; transport: string }>> = [];
-    subscriptions.push(
-      transport.listenToAvailableDevices().subscribe(devices => {
-        emissions.push(devices.map(device => ({ id: device.id, transport: device.transport })));
       }),
     );
 
-    await waitFor(() => {
-      connectedDeviceId = emissions.at(-1)?.[0]?.id;
-      expect(connectedDeviceId).toBeDefined();
-    });
+    const emissions = collectDeviceEmissions(transport);
+
+    connectedDeviceId = await waitForFirstDeviceId(emissions);
 
     const connectResult = await transport.connect({
       deviceId: connectedDeviceId!,
       onDisconnect: () => {},
     });
-    let connectedDevice: TransportConnectedDevice | undefined;
-    connectResult.ifRight(device => {
-      connectedDevice = device;
-    });
-    expect(connectedDevice).toBeDefined();
+    const connectedDevice = unwrapConnectedDevice(connectResult);
 
-    await transport.disconnect({ connectedDevice: connectedDevice! });
+    await transport.disconnect({ connectedDevice });
 
     const callsBefore = machineSendApduCalls;
-    const result = await connectedDevice!.sendApdu(new Uint8Array([0xb0, 0x01]));
+    const result = await connectedDevice.sendApdu(new Uint8Array([0xb0, 0x01]));
 
     expect(machineSendApduCalls).toBe(callsBefore);
     let leftError: unknown;
@@ -1043,52 +790,14 @@ describe("NodeWebUsbTransport", () => {
     });
     expect(leftError).toBeInstanceOf(DeviceDisconnectedBeforeSendingApdu);
 
-    transport.destroy();
+    await transport.destroy();
   });
 
   it("isolates onDisconnect callbacks and APDU routing per connected device", async () => {
-    const nativeDeviceA = {
-      deviceDescriptor: {
-        idVendor: 0x2c97,
-        idProduct: 0x5011,
-      },
-    };
-    const nativeDeviceB = {
-      deviceDescriptor: {
-        idVendor: 0x2c97,
-        idProduct: 0x5011,
-      },
-    };
-    const webUsbDeviceA = {
-      vendorId: 0x2c97,
-      productId: 0x5011,
-      serialNumber: "ledger-A",
-      configurations: [
-        {
-          interfaces: [
-            {
-              interfaceNumber: 1,
-              alternates: [{ interfaceClass: 255 }],
-            },
-          ],
-        },
-      ],
-    };
-    const webUsbDeviceB = {
-      vendorId: 0x2c97,
-      productId: 0x5011,
-      serialNumber: "ledger-B",
-      configurations: [
-        {
-          interfaces: [
-            {
-              interfaceNumber: 1,
-              alternates: [{ interfaceClass: 255 }],
-            },
-          ],
-        },
-      ],
-    };
+    const nativeDeviceA = createNativeLedgerDevice();
+    const nativeDeviceB = createNativeLedgerDevice();
+    const webUsbDeviceA = createWebUsbLedgerDevice("ledger-A");
+    const webUsbDeviceB = createWebUsbLedgerDevice("ledger-B");
 
     const nativeToWeb = new Map<unknown, unknown>([
       [nativeDeviceA, webUsbDeviceA],
@@ -1097,24 +806,7 @@ describe("NodeWebUsbTransport", () => {
 
     const machineSendApduCounts = new Map<DeviceId, number>();
 
-    const transport = new NodeWebUsbTransport(
-      {
-        getAllDeviceModels: () => [
-          {
-            id: "nanoSP",
-            productName: "Ledger Nano S Plus",
-            usbProductId: 0x50,
-            bootloaderUsbProductId: 0x5011,
-          },
-        ],
-      } as DeviceModelDataSource,
-      () => createLogger(),
-      (() => {
-        throw new Error("unused apdu sender factory");
-      }) as ApduSenderServiceFactory,
-      (() => {
-        throw new Error("unused apdu receiver factory");
-      }) as ApduReceiverServiceFactory,
+    const transport = createTestTransport(
       params => {
         let dependencies: NodeWebUsbApduSenderDependencies = {
           device: webUsbDeviceA as never,
@@ -1145,29 +837,14 @@ describe("NodeWebUsbTransport", () => {
         } as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>;
       },
       () => createStubApduSender() as never,
-      {
+      createPlatformBindings({
         platform: "linux",
         getDeviceList: () => [nativeDeviceA, nativeDeviceB] as never[],
         createWebUsbDevice: async native => nativeToWeb.get(native) as never,
-        usbBindings: {
-          on: () => {},
-          removeListener: () => {},
-          unrefHotplugEvents: () => {},
-        },
-        setInterval: callback => {
-          queueMicrotask(callback);
-          return 0 as unknown as ReturnType<typeof globalThis.setInterval>;
-        },
-        clearInterval: () => {},
-      },
-    );
-
-    const emissions: Array<Array<{ id: string; transport: string }>> = [];
-    subscriptions.push(
-      transport.listenToAvailableDevices().subscribe(devices => {
-        emissions.push(devices.map(device => ({ id: device.id, transport: device.transport })));
       }),
     );
+
+    const emissions = collectDeviceEmissions(transport);
 
     let deviceIdA: DeviceId | undefined;
     let deviceIdB: DeviceId | undefined;
@@ -1184,34 +861,25 @@ describe("NodeWebUsbTransport", () => {
       deviceId: deviceIdA!,
       onDisconnect: id => onDisconnectA.push(id),
     });
-    let connectedA: TransportConnectedDevice | undefined;
-    connectA.ifRight(d => {
-      connectedA = d;
-    });
+    const connectedA = unwrapConnectedDevice(connectA);
 
     const connectB = await transport.connect({
       deviceId: deviceIdB!,
       onDisconnect: id => onDisconnectB.push(id),
     });
-    let connectedB: TransportConnectedDevice | undefined;
-    connectB.ifRight(d => {
-      connectedB = d;
-    });
+    const connectedB = unwrapConnectedDevice(connectB);
 
-    expect(connectedA).toBeDefined();
-    expect(connectedB).toBeDefined();
-
-    await transport.disconnect({ connectedDevice: connectedA! });
+    await transport.disconnect({ connectedDevice: connectedA });
 
     expect(onDisconnectA).toEqual([deviceIdA!]);
     expect(onDisconnectB).toEqual([]);
 
-    const apduOnB = await connectedB!.sendApdu(new Uint8Array([0xb0, 0x01]));
+    const apduOnB = await connectedB.sendApdu(new Uint8Array([0xb0, 0x01]));
     expect(apduOnB.isRight()).toBe(true);
     expect(machineSendApduCounts.get(deviceIdB!)).toBe(1);
     expect(machineSendApduCounts.get(deviceIdA!) ?? 0).toBe(0);
 
-    transport.destroy();
+    await transport.destroy();
   });
 
   it("does not return an empty list to a concurrent caller while a refresh is in-flight", async () => {
@@ -1219,27 +887,8 @@ describe("NodeWebUsbTransport", () => {
     // when a refresh was already running, which caused promptDeviceAccess() to
     // throw NoAccessibleDeviceError when a Windows polling tick (or attach
     // handler) overlapped with startDiscovering().
-    const nativeDevice = {
-      deviceDescriptor: {
-        idVendor: 0x2c97,
-        idProduct: 0x5011,
-      },
-    };
-    const webUsbDevice = {
-      vendorId: 0x2c97,
-      productId: 0x5011,
-      serialNumber: "ledger-1",
-      configurations: [
-        {
-          interfaces: [
-            {
-              interfaceNumber: 1,
-              alternates: [{ interfaceClass: 255 }],
-            },
-          ],
-        },
-      ],
-    };
+    const nativeDevice = createNativeLedgerDevice();
+    const webUsbDevice = createWebUsbLedgerDevice();
 
     let releaseFirstScan: (() => void) | undefined;
     const firstScanGate = new Promise<void>(resolve => {
@@ -1248,27 +897,10 @@ describe("NodeWebUsbTransport", () => {
     let createWebUsbDeviceCalls = 0;
     let deviceListCalls = 0;
 
-    const transport = new NodeWebUsbTransport(
-      {
-        getAllDeviceModels: () => [
-          {
-            id: "nanoSP",
-            productName: "Ledger Nano S Plus",
-            usbProductId: 0x50,
-            bootloaderUsbProductId: 0x5011,
-          },
-        ],
-      } as DeviceModelDataSource,
-      () => createLogger(),
-      (() => {
-        throw new Error("unused apdu sender factory");
-      }) as ApduSenderServiceFactory,
-      (() => {
-        throw new Error("unused apdu receiver factory");
-      }) as ApduReceiverServiceFactory,
+    const transport = createTestTransport(
       undefined,
       undefined,
-      {
+      createPlatformBindings({
         platform: "linux",
         getDeviceList: () => {
           deviceListCalls += 1;
@@ -1281,14 +913,8 @@ describe("NodeWebUsbTransport", () => {
           }
           return webUsbDevice as never;
         },
-        usbBindings: {
-          on: () => {},
-          removeListener: () => {},
-          unrefHotplugEvents: () => {},
-        },
         setInterval: () => 0 as unknown as ReturnType<typeof globalThis.setInterval>,
-        clearInterval: () => {},
-      },
+      }),
     );
 
     const first = transport.updateTransportDiscoveredDevices();
@@ -1310,6 +936,6 @@ describe("NodeWebUsbTransport", () => {
     // than triggering one rescan per caller.
     expect(deviceListCalls).toBe(2);
 
-    transport.destroy();
+    await transport.destroy();
   });
 });

--- a/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.ts
+++ b/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.ts
@@ -152,6 +152,10 @@ export class NodeWebUsbTransport implements Transport {
     DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>,
     Promise<unknown>
   >();
+  private readonly _deviceApduSendersByConnectionMachine = new WeakMap<
+    DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>,
+    NodeWebUsbApduSender
+  >();
 
   private readonly _logger: LoggerPublisherService;
   private readonly connectionType = "USB" as const;
@@ -159,6 +163,7 @@ export class NodeWebUsbTransport implements Transport {
   private _usbAttachHandler: ((d: NativeUsbDevice) => void) | null = null;
   private _usbDetachHandler: ((d: NativeUsbDevice) => void) | null = null;
   private _discoveryPollInterval: NodeWebUsbIntervalHandle | null = null;
+  private _explicitConnectionClosesInFlight = 0;
   // In-flight discovery refresh promise. While a scan is running, additional
   // callers (e.g. a Windows polling tick overlapping with startDiscovering()
   // or with the attach handler) get a queued follow-up scan instead of an
@@ -235,6 +240,37 @@ export class NodeWebUsbTransport implements Transport {
     if (!stillReferenced) {
       this._activeConnectionMachines.delete(machine);
     }
+  }
+
+  private deleteActiveConnectionsForMachine(
+    machine: DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>,
+  ): void {
+    for (const [dev, sm] of this._deviceConnectionsByWebUsbDevice) {
+      if (sm === machine) this.deleteActiveConnection(dev);
+    }
+    this._deviceConnectionsPendingReconnection.delete(machine);
+    // Safety: drop activeMachines flag in case the device map had no entry for this machine.
+    this._activeConnectionMachines.delete(machine);
+    this._deviceApduSendersByConnectionMachine.delete(machine);
+  }
+
+  private async closeMachineConnection(
+    machine: DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>,
+  ): Promise<void> {
+    const apduSender = this._deviceApduSendersByConnectionMachine.get(machine);
+    this._explicitConnectionClosesInFlight++;
+    try {
+      machine.closeConnection();
+      await apduSender?.closeConnection();
+    } finally {
+      this.deleteActiveConnectionsForMachine(machine);
+      this._explicitConnectionClosesInFlight--;
+    }
+  }
+
+  private async refreshDiscoveredDevicesAfterExplicitClose(): Promise<void> {
+    this._transportDiscoveredDevices.next([]);
+    await this.updateTransportDiscoveredDevices();
   }
 
   private makeTransportConnectedDevice({
@@ -496,6 +532,9 @@ export class NodeWebUsbTransport implements Transport {
   }
 
   private startListeningToConnectionEvents(): void {
+    if (this._usbAttachHandler || this._usbDetachHandler) {
+      return;
+    }
     this._logger.debug("startListeningToConnectionEvents (WebUSB)");
     this._usbAttachHandler = (d: NativeUsbDevice) => {
       void this.handleDeviceConnection(d);
@@ -506,11 +545,6 @@ export class NodeWebUsbTransport implements Transport {
     this._platformBindings.usbBindings.on("attach", this._usbAttachHandler);
     this._platformBindings.usbBindings.on("detach", this._usbDetachHandler);
     this.startWindowsDiscoveryPolling();
-
-    process.on("exit", () => {
-      this.stopListeningToConnectionEvents();
-      this._platformBindings.usbBindings.unrefHotplugEvents();
-    });
   }
 
   private stopListeningToConnectionEvents(): void {
@@ -566,6 +600,8 @@ export class NodeWebUsbTransport implements Transport {
         this.resumeDiscoveryAfterDisconnect();
       },
       onTerminated: () => {
+        // _deviceApduSendersByConnectionMachine is a WeakMap keyed by `machine`, so its entries
+        // are reclaimed automatically once the machine becomes unreachable below.
         this._deviceConnectionsPendingReconnection.forEach(sm => {
           if (sm.getDeviceId() === deviceId) {
             this._deviceConnectionsPendingReconnection.delete(sm);
@@ -581,10 +617,12 @@ export class NodeWebUsbTransport implements Transport {
         this.resumeDiscoveryAfterDisconnect();
       },
     });
+    this._deviceApduSendersByConnectionMachine.set(machine, apduSender);
 
     try {
       await machine.setupConnection();
     } catch (e) {
+      this._deviceApduSendersByConnectionMachine.delete(machine);
       this._logger.error("Error while setting up device connection", { data: { error: e } });
       return Left(new OpeningConnectionError(e));
     }
@@ -605,13 +643,25 @@ export class NodeWebUsbTransport implements Transport {
       });
       return Left(new UnknownDeviceError(`Unknown device ${params.connectedDevice.id}`));
     }
-    sm.closeConnection();
+    this.stopListeningToConnectionEvents();
+    try {
+      await this.closeMachineConnection(sm);
+      await this.refreshDiscoveredDevicesAfterExplicitClose();
+    } finally {
+      this.startListeningToConnectionEvents();
+    }
     return Right(undefined);
   }
 
   async handleDeviceDisconnection(native: NativeUsbDevice): Promise<void> {
     const { idVendor, idProduct } = native.deviceDescriptor;
     if (idVendor !== LEDGER_VENDOR_ID) {
+      return;
+    }
+    if (this._explicitConnectionClosesInFlight > 0) {
+      this._logger.debug("[handleDeviceDisconnection] Ignoring detach during explicit close", {
+        data: { vendorId: idVendor, productId: idProduct },
+      });
       return;
     }
     this._logger.info("[handleDeviceDisconnection] Device disconnected (WebUSB)", {
@@ -668,6 +718,12 @@ export class NodeWebUsbTransport implements Transport {
     if (idVendor !== LEDGER_VENDOR_ID) {
       return;
     }
+    if (this._explicitConnectionClosesInFlight > 0) {
+      this._logger.debug("[handleDeviceConnection] Ignoring attach during explicit close", {
+        data: { vendorId: idVendor, productId: idProduct },
+      });
+      return;
+    }
     this._logger.info("[handleDeviceConnection] New device connected (WebUSB)", {
       data: { vendorId: idVendor, productId: idProduct },
     });
@@ -689,11 +745,18 @@ export class NodeWebUsbTransport implements Transport {
     }
   }
 
-  destroy(): void {
+  async destroy(): Promise<void> {
     this.stopListeningToConnectionEvents();
-    this._deviceConnectionsByWebUsbDevice.forEach(sm => sm.closeConnection());
+    await Promise.all(
+      [...this._deviceConnectionsByWebUsbDevice.values()].map(sm =>
+        this.closeMachineConnection(sm),
+      ),
+    );
     this._deviceConnectionsPendingReconnection.clear();
     this._activeConnectionMachines.clear();
+    // Unref last, after in-flight close transfers have settled, so we don't
+    // release hotplug refs while native USB ops are still running.
+    this._platformBindings.usbBindings.unrefHotplugEvents();
   }
 }
 

--- a/apps/wallet-cli/src/device/register-dmk-transport.test.ts
+++ b/apps/wallet-cli/src/device/register-dmk-transport.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  DeviceModelId as DmkDeviceModelId,
+  DeviceStatus,
+  type DeviceManagementKit,
+} from "@ledgerhq/device-management-kit";
+import { disconnect as disconnectTransport, open as openTransport } from "@ledgerhq/live-common/hw/index";
+import { DeviceModelId as LedgerDeviceModelId } from "@ledgerhq/types-devices";
+import { of } from "rxjs";
+
+let createDeviceManagementKitImpl: () => Promise<{
+  dmk: DeviceManagementKit;
+  destroyTransport: () => Promise<void>;
+}>;
+
+mock.module("./dmk", () => ({
+  createDeviceManagementKit: () => createDeviceManagementKitImpl(),
+}));
+
+const {
+  WALLET_CLI_DMK_DEVICE_ID,
+  _setTestDmkTransport,
+  disposeWalletCliDmkTransportFully,
+  ensureWalletCliDmkTransport,
+  getWalletCliDeviceModelId,
+  registerWalletCliDmkTransport,
+  resetWalletCliDmkSession,
+} = await import("./register-dmk-transport");
+
+function makeDmk({
+  getSessionState = () => ({}),
+}: {
+  getSessionState?: () => unknown;
+} = {}) {
+  let nextSessionIndex = 0;
+  const dmk = {
+    listenToAvailableDevices: () => of([{ id: "ledger-usb-1" }]),
+    connect: async () => {
+      nextSessionIndex += 1;
+      return `session-${nextSessionIndex}`;
+    },
+    getDeviceSessionState: () => of(getSessionState()),
+    disconnect: async () => {},
+    close: () => {},
+  } as unknown as DeviceManagementKit;
+
+  return {
+    dmk,
+    kit: {
+      dmk,
+      destroyTransport: async () => {},
+    },
+  };
+}
+
+function makeTestTransport(sessionState?: unknown) {
+  const dmk = {
+    getDeviceSessionState: () => of(sessionState ?? {}),
+    disconnect: async () => {},
+  } as unknown as DeviceManagementKit;
+
+  return {
+    transport: {
+      dmk,
+      sessionId: "test-session-1",
+      close: async () => {},
+    },
+  };
+}
+
+beforeEach(async () => {
+  _setTestDmkTransport(null);
+  await disposeWalletCliDmkTransportFully();
+});
+
+afterEach(async () => {
+  await disposeWalletCliDmkTransportFully();
+  _setTestDmkTransport(null);
+});
+
+describe("ensureWalletCliDmkTransport", () => {
+  it("reuses the same transport until the caller resets the session", async () => {
+    const fake = makeDmk();
+    createDeviceManagementKitImpl = async () => fake.kit;
+
+    const first = await ensureWalletCliDmkTransport();
+    const second = await ensureWalletCliDmkTransport();
+    await resetWalletCliDmkSession();
+    const afterReset = await ensureWalletCliDmkTransport();
+
+    expect(first).toBe(second);
+    expect(first.sessionId).toBe("session-1");
+    expect(afterReset).not.toBe(first);
+    expect(afterReset.sessionId).toBe("session-2");
+  });
+
+  it("asks the user to retry when the initial session is busy", async () => {
+    let sessionState: unknown = { deviceStatus: DeviceStatus.BUSY };
+    const fake = makeDmk({ getSessionState: () => sessionState });
+    createDeviceManagementKitImpl = async () => fake.kit;
+
+    await expect(ensureWalletCliDmkTransport()).rejects.toThrow(
+      "The Ledger device did not respond to the initial ping",
+    );
+
+    sessionState = {};
+    await expect(ensureWalletCliDmkTransport()).resolves.toMatchObject({
+      sessionId: "session-2",
+    });
+  });
+});
+
+describe("getWalletCliDeviceModelId", () => {
+  it("returns undefined when no DMK session is active", async () => {
+    await expect(getWalletCliDeviceModelId()).resolves.toBeUndefined();
+  });
+
+  it("maps the active DMK model id to the live-common device model id", async () => {
+    const { transport } = makeTestTransport({ deviceModelId: DmkDeviceModelId.NANO_X });
+    _setTestDmkTransport(transport as never);
+
+    await ensureWalletCliDmkTransport();
+
+    await expect(getWalletCliDeviceModelId()).resolves.toBe(LedgerDeviceModelId.nanoX);
+  });
+});
+
+describe("registerWalletCliDmkTransport", () => {
+  it("allows live-common callers to open and disconnect the wallet CLI device id", async () => {
+    const { transport } = makeTestTransport({ deviceModelId: DmkDeviceModelId.NANO_X });
+    _setTestDmkTransport(transport as never);
+
+    registerWalletCliDmkTransport();
+    registerWalletCliDmkTransport();
+
+    await expect(openTransport("other-device")).rejects.toThrow(
+      "Cannot find registered transport to open other-device",
+    );
+    const opened = await openTransport(WALLET_CLI_DMK_DEVICE_ID);
+    expect(opened as unknown).toBe(transport);
+    await expect(getWalletCliDeviceModelId()).resolves.toBe(LedgerDeviceModelId.nanoX);
+
+    await expect(disconnectTransport("other-device")).rejects.toThrow(
+      "Can't find handler to disconnect other-device",
+    );
+    await expect(disconnectTransport(WALLET_CLI_DMK_DEVICE_ID)).resolves.toBeUndefined();
+    await expect(getWalletCliDeviceModelId()).resolves.toBeUndefined();
+  });
+});

--- a/apps/wallet-cli/src/device/register-dmk-transport.ts
+++ b/apps/wallet-cli/src/device/register-dmk-transport.ts
@@ -5,22 +5,36 @@ import { dmkToLedgerDeviceIdMap } from "@ledgerhq/live-dmk-shared";
 import { firstValueFrom } from "rxjs";
 import { filter, timeout } from "rxjs/operators";
 import { WalletCliDmkTransport } from "./wallet-cli-dmk-transport";
+import type { WalletCliDmk } from "./dmk";
+import {
+  hasWalletCliDeviceInterruptScope,
+  withWalletCliDeviceInterruptScope,
+} from "./interrupt-scope";
+import { restoreTerminalCursor } from "../shared/ui";
 
 /** Device id passed to live-common `withDevice` / bridge methods for the first USB Ledger (DMK node WebUSB). */
 export const WALLET_CLI_DMK_DEVICE_ID = "wallet-cli-dmk";
 
 const CONNECT_TIMEOUT_MS = 60_000;
 
+/**
+ * Bound on the dispose-time `dmk.disconnect`: under SIGINT / process exit the
+ * native USB transport may be parked in an unreturnable transferIn, so we cap
+ * the wait rather than skipping the call entirely.
+ */
+const DISPOSE_DISCONNECT_TIMEOUT_MS = 1_000;
+
 const MODULE_ID = "wallet-cli-dmk-webusb";
 
 type Singleton = {
   dmk: DeviceManagementKit;
   transport: WalletCliDmkTransport;
+  destroyTransport: () => Promise<void>;
 };
 
 let singleton: Singleton | null = null;
 /** One DMK per CLI process: each `createDeviceManagementKit()` adds node-usb hotplug listeners; closing + recreating stacks listeners and breaks the 3rd+ in-process connect (same pattern as the former node-hid kit). */
-let persistentDmk: Promise<DeviceManagementKit> | null = null;
+let persistentDmk: Promise<WalletCliDmk> | null = null;
 let exitHooksRegistered = false;
 
 let _testTransport: WalletCliDmkTransport | null = null;
@@ -39,13 +53,94 @@ function closeDmkQuietly(dmk: DeviceManagementKit): void {
   }
 }
 
-function getOrCreatePersistentDmk(): Promise<DeviceManagementKit> {
+function terminateWalletCliFromSignal(code: number): void {
+  // yocto-spinner hides the cursor while spinning; force-killing the process below
+  // skips its normal cleanup, so explicitly restore the cursor first.
+  restoreTerminalCursor();
+  process.exitCode = code;
+  if ("bun" in process.versions) {
+    process.kill(process.pid, "SIGKILL");
+    return;
+  }
+  process.exit(code);
+}
+
+function getOrCreatePersistentDmk(): Promise<WalletCliDmk> {
   return (persistentDmk ??= import("./dmk")
     .then(({ createDeviceManagementKit }) => createDeviceManagementKit())
     .catch(error => {
       persistentDmk = null;
       throw error;
     }));
+}
+
+/**
+ * Race the supplied promise against a timeout, swallowing both the resolution
+ * and the error. Used to bound the dispose-time `dmk.disconnect`: at process
+ * exit, a wedged USB transferIn must not be allowed to keep us alive.
+ */
+async function awaitWithTimeout(work: Promise<unknown>, timeoutMs: number): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<void>(resolve => {
+    timer = setTimeout(resolve, timeoutMs);
+  });
+  try {
+    await Promise.race([work.then(() => undefined).catch(() => undefined), timeoutPromise]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function disconnectHeldDmk(
+  held: Singleton | null,
+  mode: "reset" | "dispose",
+): Promise<void> {
+  if (!held) return;
+
+  const disconnect = held.dmk.disconnect({ sessionId: held.transport.sessionId });
+  if (mode === "reset" || _testTransport) {
+    await disconnect.catch(() => {});
+    return;
+  }
+
+  await awaitWithTimeout(disconnect, DISPOSE_DISCONNECT_TIMEOUT_MS);
+}
+
+async function destroyHeldDmk(held: Singleton | null): Promise<void> {
+  if (!held) return;
+
+  await held.destroyTransport();
+  closeDmkQuietly(held.dmk);
+}
+
+async function destroyPersistentDmkOnReset(
+  kit: WalletCliDmk | null,
+  mode: "reset" | "dispose",
+): Promise<void> {
+  if (mode !== "reset" || !kit) return;
+
+  await kit.destroyTransport();
+  closeDmkQuietly(kit.dmk);
+}
+
+async function teardownPersistentDmk(
+  held: Singleton | null,
+  mode: "reset" | "dispose",
+): Promise<void> {
+  if (!persistentDmk) return;
+
+  const kit = await persistentDmk.catch(() => null);
+  if (held) {
+    // The persistent kit was the one held; closeDmkQuietly above already closed it.
+    // Drop the ref so the next ensure() rebuilds.
+    if (kit?.dmk === held.dmk) persistentDmk = null;
+    return;
+  }
+
+  // No singleton owned the persistent kit. Reset closes it now; dispose lets the
+  // OS reclaim it as the process is exiting.
+  await destroyPersistentDmkOnReset(kit, mode);
+  persistentDmk = null;
 }
 
 async function connectFirstUsbDevice(dmk: DeviceManagementKit): Promise<string> {
@@ -59,7 +154,10 @@ async function connectFirstUsbDevice(dmk: DeviceManagementKit): Promise<string> 
   if (!device) {
     throw new Error("No Ledger device found. Unlock the device and try again.");
   }
-  const sessionId = await dmk.connect({ device });
+  const sessionId = await dmk.connect({
+    device,
+    sessionRefresherOptions: { isRefresherDisabled: true },
+  });
 
   const sessionState = await firstValueFrom(dmk.getDeviceSessionState({ sessionId })).catch(
     () => null,
@@ -83,39 +181,52 @@ async function connectFirstUsbDevice(dmk: DeviceManagementKit): Promise<string> 
 /**
  * Ensures a DMK USB session exists and returns the shared transport (same instance across `open()` calls until reset).
  *
- * The session refresher is left enabled (default) so the DMK periodically pings the device and
- * keeps session state (CONNECTED / LOCKED / BUSY) up to date — matching the DMK sample app behaviour.
- * If the initial session state is BUSY we disconnect and ask the user to retry.
+ * The session refresher is disabled in wallet-cli: short-lived command sessions otherwise race
+ * refresher APDUs against explicit disconnect/reopen cycles. If the initial session state is BUSY
+ * we disconnect and ask the user to retry.
  */
-export async function ensureWalletCliDmkTransport(): Promise<WalletCliDmkTransport> {
-  if (_testTransport) {
-    singleton ??= { dmk: _testTransport.dmk, transport: _testTransport };
-    return singleton.transport;
-  }
+export function ensureWalletCliDmkTransport(): Promise<WalletCliDmkTransport> {
+  return withWalletCliDeviceInterruptScope(async () => {
+    if (_testTransport) {
+      singleton ??= {
+        dmk: _testTransport.dmk,
+        transport: _testTransport,
+        destroyTransport: async () => {},
+      };
+      return singleton.transport;
+    }
 
-  if (singleton) {
-    return singleton.transport;
-  }
+    if (singleton) {
+      return singleton.transport;
+    }
 
-  const dmk = await getOrCreatePersistentDmk();
-  const sessionId = await connectFirstUsbDevice(dmk);
-  const transport = new WalletCliDmkTransport(dmk, sessionId);
-  singleton = { dmk, transport };
-  return transport;
+    const kit = await getOrCreatePersistentDmk();
+    const sessionId = await connectFirstUsbDevice(kit.dmk);
+    const transport = new WalletCliDmkTransport(kit.dmk, sessionId);
+    singleton = { dmk: kit.dmk, transport, destroyTransport: kit.destroyTransport };
+    return transport;
+  });
 }
 
 /**
- * Drops the active USB session so the device can be used again, without tearing down the process-wide DMK
- * (see `persistentDmk`). Call {@link disposeWalletCliDmkTransportFully} on process exit.
+ * Reset: drops the active USB session and tears down DMK/native USB state before the next open.
+ * Dispose: same teardown — used at process exit. The DMK disconnect is bounded by
+ * {@link DISPOSE_DISCONNECT_TIMEOUT_MS} because the native USB transport may be wedged
+ * (e.g. a parked transferIn after SIGINT) and would otherwise keep the process alive.
  */
-export async function resetWalletCliDmkSession(): Promise<void> {
+async function teardownDmk(mode: "reset" | "dispose"): Promise<void> {
   const held = singleton;
-  if (!held) {
-    return;
-  }
   singleton = null;
-  await held.dmk.disconnect({ sessionId: held.transport.sessionId }).catch(() => {});
+
+  await disconnectHeldDmk(held, mode);
+
+  if (_testTransport) return;
+
+  await destroyHeldDmk(held);
+  await teardownPersistentDmk(held, mode);
 }
+
+export const resetWalletCliDmkSession = (): Promise<void> => teardownDmk("reset");
 
 /**
  * Returns the live-common DeviceModelId for the active DMK session, or undefined if unavailable.
@@ -131,14 +242,13 @@ export async function getWalletCliDeviceModelId(): Promise<DeviceModelId | undef
   return dmkToLedgerDeviceIdMap[state.deviceModelId];
 }
 
-/** Disconnect any live session and `dmk.close()` the persistent kit (USB hotplug listeners). */
-export async function disposeWalletCliDmkTransportFully(): Promise<void> {
-  await resetWalletCliDmkSession();
-  if (persistentDmk) {
-    closeDmkQuietly(await persistentDmk);
-    persistentDmk = null;
-  }
-}
+/**
+ * Process-exit teardown: best-effort `dmk.disconnect` (capped by
+ * {@link DISPOSE_DISCONNECT_TIMEOUT_MS}), destroy the node-webusb transport,
+ * then `dmk.close()` the persistent kit so the node-usb hotplug listeners
+ * stop holding the event loop open.
+ */
+export const disposeWalletCliDmkTransportFully = (): Promise<void> => teardownDmk("dispose");
 
 function registerWalletCliDmkProcessExitHooks(): void {
   if (exitHooksRegistered) {
@@ -146,17 +256,28 @@ function registerWalletCliDmkProcessExitHooks(): void {
   }
   exitHooksRegistered = true;
 
-  const exitAfterTeardown = (code: number) => {
-    void disposeWalletCliDmkTransportFully().finally(() => {
-      process.exit(code);
+  // process.once: a second Ctrl+C during teardown removes our listener and
+  // falls back to Node's default SIGINT behaviour (force-exit), so we don't
+  // need a re-entrancy guard here.
+  const exitAfterTeardown = (_signal: NodeJS.Signals, code: number) => {
+    // Avoid graceful USB teardown while a native transfer may be parked.
+    if (hasWalletCliDeviceInterruptScope()) {
+      terminateWalletCliFromSignal(code);
+      return;
+    }
+    void (async () => {
+      await disposeWalletCliDmkTransportFully();
+      terminateWalletCliFromSignal(code);
+    })().catch(() => {
+      terminateWalletCliFromSignal(code);
     });
   };
 
   process.once("SIGINT", () => {
-    exitAfterTeardown(130);
+    exitAfterTeardown("SIGINT", 130);
   });
   process.once("SIGTERM", () => {
-    exitAfterTeardown(143);
+    exitAfterTeardown("SIGTERM", 143);
   });
 }
 

--- a/apps/wallet-cli/src/device/register-dmk-transport.ts
+++ b/apps/wallet-cli/src/device/register-dmk-transport.ts
@@ -23,6 +23,7 @@ const CONNECT_TIMEOUT_MS = 60_000;
  * the wait rather than skipping the call entirely.
  */
 const DISPOSE_DISCONNECT_TIMEOUT_MS = 1_000;
+const DISPOSE_DESTROY_TIMEOUT_MS = 1_000;
 
 const MODULE_ID = "wallet-cli-dmk-webusb";
 
@@ -76,8 +77,8 @@ function getOrCreatePersistentDmk(): Promise<WalletCliDmk> {
 
 /**
  * Race the supplied promise against a timeout, swallowing both the resolution
- * and the error. Used to bound the dispose-time `dmk.disconnect`: at process
- * exit, a wedged USB transferIn must not be allowed to keep us alive.
+ * and the error. At process exit, a wedged USB transferIn must not be allowed
+ * to keep us alive.
  */
 async function awaitWithTimeout(work: Promise<unknown>, timeoutMs: number): Promise<void> {
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -91,10 +92,7 @@ async function awaitWithTimeout(work: Promise<unknown>, timeoutMs: number): Prom
   }
 }
 
-async function disconnectHeldDmk(
-  held: Singleton | null,
-  mode: "reset" | "dispose",
-): Promise<void> {
+async function disconnectHeldDmk(held: Singleton | null, mode: "reset" | "dispose"): Promise<void> {
   if (!held) return;
 
   const disconnect = held.dmk.disconnect({ sessionId: held.transport.sessionId });
@@ -109,17 +107,21 @@ async function disconnectHeldDmk(
 async function destroyHeldDmk(held: Singleton | null): Promise<void> {
   if (!held) return;
 
-  await held.destroyTransport();
+  await awaitWithTimeout(held.destroyTransport(), DISPOSE_DESTROY_TIMEOUT_MS);
   closeDmkQuietly(held.dmk);
 }
 
-async function destroyPersistentDmkOnReset(
+async function destroyPersistentDmk(
   kit: WalletCliDmk | null,
   mode: "reset" | "dispose",
 ): Promise<void> {
-  if (mode !== "reset" || !kit) return;
+  if (!kit) return;
 
-  await kit.destroyTransport();
+  if (mode === "reset") {
+    await kit.destroyTransport().catch(() => {});
+  } else {
+    await awaitWithTimeout(kit.destroyTransport(), DISPOSE_DESTROY_TIMEOUT_MS);
+  }
   closeDmkQuietly(kit.dmk);
 }
 
@@ -137,9 +139,9 @@ async function teardownPersistentDmk(
     return;
   }
 
-  // No singleton owned the persistent kit. Reset closes it now; dispose lets the
-  // OS reclaim it as the process is exiting.
-  await destroyPersistentDmkOnReset(kit, mode);
+  // No singleton owned the persistent kit. Close it in both reset and dispose
+  // so hotplug listeners cannot keep the process alive after a failed connect.
+  await destroyPersistentDmk(kit, mode);
   persistentDmk = null;
 }
 

--- a/apps/wallet-cli/src/device/wallet-cli-dmk-transport.ts
+++ b/apps/wallet-cli/src/device/wallet-cli-dmk-transport.ts
@@ -1,5 +1,6 @@
 import type { DeviceManagementKit } from "@ledgerhq/device-management-kit";
 import HwTransport from "@ledgerhq/hw-transport";
+import { withWalletCliDeviceInterruptScope } from "./interrupt-scope";
 
 const TransportClass =
   HwTransport as unknown as abstract new () => import("@ledgerhq/hw-transport").default;
@@ -24,12 +25,14 @@ export class WalletCliDmkTransport extends TransportClass {
     apdu: Buffer,
     { abortTimeoutMs }: { abortTimeoutMs?: number } = {},
   ): Promise<Buffer> {
-    const { data, statusCode } = await this.dmk.sendApdu({
-      sessionId: this.sessionId,
-      apdu: new Uint8Array(apdu.buffer, apdu.byteOffset, apdu.byteLength),
-      abortTimeout: abortTimeoutMs ?? WALLET_CLI_DEFAULT_APDU_ABORT_MS,
+    return withWalletCliDeviceInterruptScope(async () => {
+      const { data, statusCode } = await this.dmk.sendApdu({
+        sessionId: this.sessionId,
+        apdu: new Uint8Array(apdu.buffer, apdu.byteOffset, apdu.byteLength),
+        abortTimeout: abortTimeoutMs ?? WALLET_CLI_DEFAULT_APDU_ABORT_MS,
+      });
+      return Buffer.from([...data, ...statusCode]);
     });
-    return Buffer.from([...data, ...statusCode]);
   }
 
   close(): Promise<void> {

--- a/apps/wallet-cli/src/output.ts
+++ b/apps/wallet-cli/src/output.ts
@@ -209,7 +209,7 @@ class HumanCommandOutput implements CommandOutput {
       writeStderr(displayText + "\n");
     }
     this._activeSpin = null;
-    process.exit(err.exitCode);
+    throw new CliProcessExitError(err.exitCode);
   }
 
   async balances(items: Balance[]): Promise<void> {

--- a/apps/wallet-cli/src/session/bridge-device-session.test.ts
+++ b/apps/wallet-cli/src/session/bridge-device-session.test.ts
@@ -1,9 +1,8 @@
-import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { DeviceActionStatus } from "@ledgerhq/device-management-kit";
 import { Observable } from "rxjs";
 
 const calls = {
-  ensure: 0,
   execute: [] as Array<{
     sessionId: string;
     deviceAction: unknown;
@@ -44,61 +43,48 @@ const testTransport = {
       calls.execute.push({ sessionId, deviceAction });
       return executeImpl();
     },
+    disconnect: async () => {
+      calls.reset += 1;
+    },
   },
   sessionId: "test-session-id",
 };
 
-let ensureImpl: () => Promise<typeof testTransport>;
 let executeImpl: () => { observable: Observable<unknown>; cancel: () => void };
-let resetImpl: () => Promise<void>;
 
-mock.module("../device/register-dmk-transport", () => {
-  let _leakedTestTransport: unknown = null;
-  return {
-    WALLET_CLI_DMK_DEVICE_ID: "wallet-cli-dmk",
-    // Allow cli-runner (running in a worker that received the leaked mock) to
-    // install a test transport so DMK-dependent commands still work.
-    _setTestDmkTransport: (t: unknown) => {
-      _leakedTestTransport = t;
-    },
-    ensureWalletCliDmkTransport: async () => {
-      if (_leakedTestTransport) return _leakedTestTransport;
-      calls.ensure += 1;
-      return ensureImpl();
-    },
-    resetWalletCliDmkSession: async () => {
-      calls.reset += 1;
-      return resetImpl();
-    },
-    disposeWalletCliDmkTransportFully: async () => {},
-    registerWalletCliDmkTransport: () => {},
-  };
-});
-
+const { _setTestDmkTransport, disposeWalletCliDmkTransportFully } =
+  await import("../device/register-dmk-transport");
 const { WalletCliDeviceError } = await import("../device/wallet-cli-device-error");
 const { getManagerAppNameForCurrencyId, withCurrencyDeviceSession } =
   await import("./bridge-device-session");
 
 describe("withCurrencyDeviceSession", () => {
-  beforeEach(() => {
-    calls.ensure = 0;
+  beforeEach(async () => {
+    _setTestDmkTransport(null);
+    await disposeWalletCliDmkTransportFully();
     calls.execute = [];
     calls.reset = 0;
-    ensureImpl = async () => testTransport;
     executeImpl = () => completedAction();
-    resetImpl = async () => {};
+    _setTestDmkTransport(testTransport as never);
+  });
+
+  afterEach(async () => {
+    await disposeWalletCliDmkTransportFully();
+    _setTestDmkTransport(null);
   });
 
   it("wraps setup failures as WalletCliDeviceError", async () => {
     const usbError = new Error("USB down");
-    ensureImpl = async () => {
-      throw usbError;
-    };
+    _setTestDmkTransport({
+      get dmk() {
+        throw usbError;
+      },
+      sessionId: "broken-session-id",
+    } as never);
 
     await expect(withCurrencyDeviceSession("ethereum", async () => "ok")).rejects.toBeInstanceOf(
       WalletCliDeviceError,
     );
-    expect(calls.ensure).toBe(1);
     expect(calls.execute).toHaveLength(0);
     expect(calls.reset).toBe(0);
   });
@@ -109,7 +95,6 @@ describe("withCurrencyDeviceSession", () => {
     await expect(withCurrencyDeviceSession("ethereum", async () => "ok")).rejects.toBeInstanceOf(
       WalletCliDeviceError,
     );
-    expect(calls.ensure).toBe(1);
     expect(calls.execute).toHaveLength(1);
     expect(calls.reset).toBe(0);
   });

--- a/apps/wallet-cli/src/session/bridge-device-session.ts
+++ b/apps/wallet-cli/src/session/bridge-device-session.ts
@@ -6,6 +6,7 @@ import {
   ensureWalletCliDmkTransport,
   resetWalletCliDmkSession,
 } from "../device/register-dmk-transport";
+import { withWalletCliDeviceInterruptScope } from "../device/interrupt-scope";
 import { walletCliDebug } from "../shared/log";
 
 export type CurrencyDeviceSessionOptions = {
@@ -19,49 +20,53 @@ export function getManagerAppNameForCurrencyId(currencyId: string): string {
   return getCryptoCurrencyById(currencyId).managerAppName;
 }
 
-export async function withCurrencyDeviceSession<T>(
+export function withCurrencyDeviceSession<T>(
   currencyId: string,
   fn: () => Promise<T>,
   options: CurrencyDeviceSessionOptions = {},
 ): Promise<T> {
-  const managerAppName = getManagerAppNameForCurrencyId(currencyId);
-  walletCliDebug("Ensuring DMK transport…");
-  try {
-    const transport = await ensureWalletCliDmkTransport();
-    walletCliDebug(`Connecting Ledger app (${managerAppName})…`);
-    await connectLedgerApp(transport.dmk, transport.sessionId, managerAppName, {
-      onStateChange: options.onStateChange,
-      deviceTimeoutMs: options.deviceTimeoutMs,
-    });
-  } catch (e) {
-    throw WalletCliDeviceError.fromUnknown(e, { expectedApp: managerAppName });
-  }
-  walletCliDebug("Device session ready.");
-  try {
-    return await fn();
-  } finally {
-    walletCliDebug("Resetting device session…");
-    await resetWalletCliDmkSession();
-  }
+  return withWalletCliDeviceInterruptScope(async () => {
+    const managerAppName = getManagerAppNameForCurrencyId(currencyId);
+    walletCliDebug("Ensuring DMK transport…");
+    try {
+      const transport = await ensureWalletCliDmkTransport();
+      walletCliDebug(`Connecting Ledger app (${managerAppName})…`);
+      await connectLedgerApp(transport.dmk, transport.sessionId, managerAppName, {
+        onStateChange: options.onStateChange,
+        deviceTimeoutMs: options.deviceTimeoutMs,
+      });
+    } catch (e) {
+      throw WalletCliDeviceError.fromUnknown(e, { expectedApp: managerAppName });
+    }
+    walletCliDebug("Device session ready.");
+    try {
+      return await fn();
+    } finally {
+      walletCliDebug("Resetting device session…");
+      await resetWalletCliDmkSession();
+    }
+  });
 }
 
 /**
  * Runs a callback with a DMK transport available, without opening or switching Ledger apps.
  */
-export async function withDmkDeviceSession<T>(fn: () => Promise<T>): Promise<T> {
-  walletCliDebug("Ensuring DMK transport…");
-  try {
-    await ensureWalletCliDmkTransport();
-  } catch (e) {
-    throw WalletCliDeviceError.fromUnknown(e, { expectedApp: "Ledger dashboard" });
-  }
-  walletCliDebug("DMK device session ready.");
-  try {
-    return await fn();
-  } finally {
-    walletCliDebug("Resetting device session…");
-    await resetWalletCliDmkSession();
-  }
+export function withDmkDeviceSession<T>(fn: () => Promise<T>): Promise<T> {
+  return withWalletCliDeviceInterruptScope(async () => {
+    walletCliDebug("Ensuring DMK transport…");
+    try {
+      await ensureWalletCliDmkTransport();
+    } catch (e) {
+      throw WalletCliDeviceError.fromUnknown(e, { expectedApp: "Ledger dashboard" });
+    }
+    walletCliDebug("DMK device session ready.");
+    try {
+      return await fn();
+    } finally {
+      walletCliDebug("Resetting device session…");
+      await resetWalletCliDmkSession();
+    }
+  });
 }
 
 /**
@@ -74,7 +79,7 @@ const FAMILY_CURRENCY_ID: Record<string, string> = {
   solana: "solana",
 };
 
-export async function withBridgeDeviceSession<T>(
+export function withBridgeDeviceSession<T>(
   family: string,
   fn: () => Promise<T>,
   options: CurrencyDeviceSessionOptions = {},

--- a/apps/wallet-cli/src/session/exchange-device-session.ts
+++ b/apps/wallet-cli/src/session/exchange-device-session.ts
@@ -4,32 +4,35 @@ import {
   ensureWalletCliDmkTransport,
   resetWalletCliDmkSession,
 } from "../device/register-dmk-transport";
+import { withWalletCliDeviceInterruptScope } from "../device/interrupt-scope";
 import { walletCliDebug } from "../shared/log";
 
-export async function withLedgerManagerAppSession<T>(
+export function withLedgerManagerAppSession<T>(
   managerAppName: string,
   fn: () => Promise<T>,
 ): Promise<T> {
-  walletCliDebug("Ensuring DMK transport…");
-  try {
-    const transport = await ensureWalletCliDmkTransport();
-    walletCliDebug(`Connecting Ledger app (${managerAppName})…`);
-    await connectLedgerApp(transport.dmk, transport.sessionId, managerAppName);
-  } catch (e) {
-    throw toWalletCliDeviceError(e, { expectedApp: managerAppName, rejectedContext: "open_app" });
-  }
-  walletCliDebug("Device session ready.");
-  try {
-    return await fn();
-  } catch (e) {
-    throw (
-      WalletCliDeviceError.fromKnownDeviceError(e, {
-        expectedApp: managerAppName,
-        rejectedContext: "sign",
-      }) ?? e
-    );
-  } finally {
-    walletCliDebug("Resetting device session…");
-    await resetWalletCliDmkSession();
-  }
+  return withWalletCliDeviceInterruptScope(async () => {
+    walletCliDebug("Ensuring DMK transport…");
+    try {
+      const transport = await ensureWalletCliDmkTransport();
+      walletCliDebug(`Connecting Ledger app (${managerAppName})…`);
+      await connectLedgerApp(transport.dmk, transport.sessionId, managerAppName);
+    } catch (e) {
+      throw toWalletCliDeviceError(e, { expectedApp: managerAppName, rejectedContext: "open_app" });
+    }
+    walletCliDebug("Device session ready.");
+    try {
+      return await fn();
+    } catch (e) {
+      throw (
+        WalletCliDeviceError.fromKnownDeviceError(e, {
+          expectedApp: managerAppName,
+          rejectedContext: "sign",
+        }) ?? e
+      );
+    } finally {
+      walletCliDebug("Resetting device session…");
+      await resetWalletCliDmkSession();
+    }
+  });
 }

--- a/apps/wallet-cli/src/shared/ui.ts
+++ b/apps/wallet-cli/src/shared/ui.ts
@@ -91,6 +91,24 @@ export function spinner(text: string): Spinner {
   return activeSpinner;
 }
 
+/**
+ * Best-effort terminal cursor restore.
+ *
+ * yocto-spinner hides the cursor (`\x1b[?25l`) while spinning and only restores it on
+ * stop/success/error. When the CLI is force-killed via SIGINT/SIGTERM mid-spin, the
+ * show-cursor escape is never written and the user's terminal is left without a visible
+ * cursor. We write `\x1b[?25h` directly to stderr (where the spinner stream lives) as a
+ * safety net before termination.
+ */
+export function restoreTerminalCursor(): void {
+  if (!process.stderr.isTTY) return;
+  try {
+    writeStderr("\x1b[?25h");
+  } catch {
+    // stderr may already be closed during teardown; ignore.
+  }
+}
+
 export async function withSpinner<T>(
   text: string,
   successText: string,

--- a/apps/wallet-cli/src/test/helpers/cli-runner.ts
+++ b/apps/wallet-cli/src/test/helpers/cli-runner.ts
@@ -17,7 +17,7 @@
  */
 
 import path from "node:path";
-import { CliProcessExitError } from "../../cli-process-exit-error";
+import { getCliProcessExitCode } from "../../cli-process-exit-error";
 import { installOutputCapture } from "../../shared/ui";
 
 // ---------------------------------------------------------------------------
@@ -161,9 +161,9 @@ async function installInterceptors(): Promise<void> {
     return {
       hostname: "localhost",
       port: currentMockPort,
-      path: (o.path as string) ?? "/",
-      method: (o.method as string) ?? "GET",
-      headers: (o.headers as Record<string, unknown>) ?? {},
+      path: o.path ?? "/",
+      method: o.method ?? "GET",
+      headers: o.headers ?? {},
     };
   }
 
@@ -314,11 +314,9 @@ export async function runCli(args: string[], env: Record<string, string> = {}): 
   try {
     exitCode = await runMain(args);
   } catch (e) {
-    if (e instanceof CliProcessExitError && e.isCliProcessExitError) {
-      exitCode = e.code;
-    } else {
-      throw e;
-    }
+    const code = getCliProcessExitCode(e);
+    if (code === null) throw e;
+    exitCode = code;
   } finally {
     restoreOutputCapture();
 

--- a/apps/wallet-cli/src/test/helpers/human-device-error-exit.ts
+++ b/apps/wallet-cli/src/test/helpers/human-device-error-exit.ts
@@ -1,5 +1,6 @@
 import "../../live-common-setup";
 import { createCommandOutput } from "../../output";
+import { getCliProcessExitCode } from "../../cli-process-exit-error";
 import { WalletCliDeviceError } from "../../device/wallet-cli-device-error";
 
 const out = createCommandOutput("human", {
@@ -7,6 +8,12 @@ const out = createCommandOutput("human", {
   network: "ethereum:main",
 });
 
-await out.run(async () => {
-  throw new WalletCliDeviceError({ code: "timeout" });
-});
+try {
+  await out.run(async () => {
+    throw new WalletCliDeviceError({ code: "timeout" });
+  });
+} catch (e) {
+  const code = getCliProcessExitCode(e);
+  if (code === null) throw e;
+  process.exitCode = code;
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - wallet-cli usb connectivity

### 📝 Description

Bound DMK disconnect teardown on exit to avoid hanging on wedged USB transfers.
Restore terminal state before forced interrupt termination.
Improve Node WebUSB session cleanup and recovery tests.

### ❓ Context

- **JIRA or GitHub link**: 
- **ADR link (if any)**: 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
