### PR TITLE
[LWDM] fix: strip curve-prefix byte from 33-byte ED25519 device payload for tezos

### DIFF
--- a/.changeset/silly-tigers-dream.md
+++ b/.changeset/silly-tigers-dream.md
@@ -1,0 +1,14 @@
+---
+"@ledgerhq/coin-tezos": patch
+---
+
+Fix "Unable to normalize sender public key" on tz1 first-tx delegation/send
+
+normalizePublicKeyForAddress did not strip the leading curve-prefix byte from
+the 33-byte ED25519 payload returned by the Ledger Tezos app, producing a b58
+string without the `edpk` prefix that craftTransaction rejected before any APDU
+was sent. The function is now curve-aware and explicitly handles the 33-byte
+ED25519 format (introduced when `@taquito/ledger-signer` was removed in favor
+of `hw-app-tezos`), the 32-byte raw ED25519 form, and SEC1 33/65-byte shapes
+for tz2/tz3. Malformed tz1 inputs now return undefined rather than emitting
+a bogus key. Regression tests cover the production payload captured from CI.

--- a/libs/coin-modules/coin-tezos/src/utils.test.ts
+++ b/libs/coin-modules/coin-tezos/src/utils.test.ts
@@ -1,3 +1,4 @@
+import { validatePublicKey, ValidationResult } from "@taquito/utils";
 import {
   normalizePublicKeyForAddress,
   parseTezosTokenAsset,
@@ -96,5 +97,45 @@ describe("normalizePublicKeyForAddress", () => {
 
     // Then: should return the correct base58 encoded public key
     expect(result).toBe(expectedPublicKey);
+  });
+
+  it("should normalize a 33-byte Ledger ED25519 payload (prefix byte + raw key) to a valid edpk", () => {
+    const tz1Address = "tz1SVgE7L6xzEY2UpQ4UvtPkRDDMwSmcqVqr";
+    const ledgerEd25519Hex = "02b053b74eab7e21c5a8fc1d945ee9fa6dbe2fedb6d47a43299ff33b7f28ea179b";
+
+    const result = normalizePublicKeyForAddress(ledgerEd25519Hex, tz1Address);
+
+    expect(result).toBeDefined();
+    expect(result!.startsWith("edpk")).toBe(true);
+    expect(validatePublicKey(result!)).toBe(ValidationResult.VALID);
+  });
+
+  it("should normalize a 32-byte raw ED25519 key to a valid edpk", () => {
+    const tz1Address = "tz1SVgE7L6xzEY2UpQ4UvtPkRDDMwSmcqVqr";
+    const rawEd25519Hex = "b053b74eab7e21c5a8fc1d945ee9fa6dbe2fedb6d47a43299ff33b7f28ea179b";
+
+    const result = normalizePublicKeyForAddress(rawEd25519Hex, tz1Address);
+
+    expect(result).toBeDefined();
+    expect(result!.startsWith("edpk")).toBe(true);
+    expect(validatePublicKey(result!)).toBe(ValidationResult.VALID);
+  });
+
+  it("should refuse to encode a malformed tz1 input (e.g. a non-hex b58 string parsed to 0 bytes)", () => {
+    const tz1Address = "tz1SVgE7L6xzEY2UpQ4UvtPkRDDMwSmcqVqr";
+    const garbage = "3s7xnj2xf2q7au3rrpg7j9k5zf3djfqgbtrswxf8d69vh94hfdtsbpni";
+
+    const result = normalizePublicKeyForAddress(garbage, tz1Address);
+
+    expect(result).toBeUndefined();
+  });
+
+  it("should refuse to encode a 65-byte SEC1 input for a tz1 (ED25519) address", () => {
+    const tz1Address = "tz1SVgE7L6xzEY2UpQ4UvtPkRDDMwSmcqVqr";
+    const sec1Hex = "04" + "ab".repeat(64); // 65 bytes
+
+    const result = normalizePublicKeyForAddress(sec1Hex, tz1Address);
+
+    expect(result).toBeUndefined();
   });
 });

--- a/libs/coin-modules/coin-tezos/src/utils.ts
+++ b/libs/coin-modules/coin-tezos/src/utils.ts
@@ -114,13 +114,23 @@ export function normalizePublicKeyForAddress(
       prefix = PrefixV2.P256PublicKey;
     }
 
-    // uncompressed public key is 65 bytes, compressed is 33 bytes
-    const compressedPubKeyLength = 33;
-    if (keyBuf.length > compressedPubKeyLength) {
-      return b58Encode(compressPublicKey(keyBuf, derivationType), prefix);
-    } else {
+    const RAW_ED25519_KEY_LENGTH = 32;
+    const COMPRESSED_SEC1_LENGTH = 33;
+    const UNCOMPRESSED_SEC1_LENGTH = 65;
+    const isEd25519 = derivationType === DerivationType.ED25519;
+    if (isEd25519) {
+      if (keyBuf.length === COMPRESSED_SEC1_LENGTH) {
+        return b58Encode(keyBuf.slice(1), prefix);
+      }
+      if (keyBuf.length !== RAW_ED25519_KEY_LENGTH) {
+        return undefined;
+      }
       return b58Encode(keyBuf, prefix);
     }
+    if (keyBuf.length === UNCOMPRESSED_SEC1_LENGTH) {
+      return b58Encode(compressPublicKey(keyBuf, derivationType), prefix);
+    }
+    return b58Encode(keyBuf, prefix);
   } catch {
     return undefined;
   }


### PR DESCRIPTION
The Ledger Tezos app returns ED25519 public keys as **33 bytes**: 1 curve-prefix byte + the 32-byte raw key (SECP256K1/P256 come back as 65 bytes SEC1 uncompressed). After `@taquito/ledger-signer` was 
  removed (#17213, `df45280fc0`), the new `normalizePublicKeyForAddress` in `libs/coin-modules/coin-tezos/src/utils.ts` only stripped the prefix when `keyBuf.length > 33`:
                                                                                                                                                                                                           
  ```ts           
  const compressedPubKeyLength = 33;
  if (keyBuf.length > compressedPubKeyLength) {
    return b58Encode(compressPublicKey(keyBuf, derivationType), prefix);                                                                                                                                   
  } else {                                                                                                                                                                                                 
    return b58Encode(keyBuf, prefix);                                                                                                                                                                      
  } 
```                                                                                                                                                                                                       
                  
  For the 33-byte ED25519 payload `length > 33` is false, so the leading byte was never stripped. `b58Encode` produced a 56-char string without the edpk prefix (e.g. `3s7Xnj2XF2Q7au3rrpg7J9k5Zf3DJfQgBTrswXF8d69vH94hfdTSBPNi`). `craftTransaction` in `coin-tezos/src/api/index.ts` rejected it and threw "Unable to normalize sender public key" before any APDU reached the device — Speculos sat on the idle Tezos Wallet home screen and the E2E test timed out waiting for "Review". The bug shipped because the existing unit test only covered the tz2 (SECP256K1) path, where 33 bytes is already SEC1-compressed and the passthrough branch is correct.

  Fix

  `normalizePublicKeyForAddress` is now curve-aware:

   ```
┌──────────────────────────────┬────────────────┬────────────────────────────────────────────────────────────┐                                                                                           
  │            Curve             │ Payload length │                         Treatment                          │
  ├──────────────────────────────┼────────────────┼────────────────────────────────────────────────────────────┤                                                                                           
  │ ED25519 (tz1)                │ 33 bytes       │ strip leading prefix byte → b58 encode the 32-byte raw key │
  ├──────────────────────────────┼────────────────┼────────────────────────────────────────────────────────────┤
  │ ED25519 (tz1)                │ 32 bytes       │ b58 encode directly                                        │                                                                                           
  ├──────────────────────────────┼────────────────┼────────────────────────────────────────────────────────────┤
  │ ED25519 (tz1)                │ other          │ return undefined                                           │                                                                                           
  ├──────────────────────────────┼────────────────┼────────────────────────────────────────────────────────────┤
  │ SECP256K1 (tz2) / P256 (tz3) │ 65 bytes       │ compressPublicKey → b58 encode                             │
  ├──────────────────────────────┼────────────────┼────────────────────────────────────────────────────────────┤                                                                                           
  │ SECP256K1 (tz2) / P256 (tz3) │ 33 bytes       │ b58 encode directly                                        │
  └──────────────────────────────┴────────────────┴────────────────────────────────────────────────────────────┘                                                                                            
 ```                 
  Regression tests in `coin-tezos/src/utils.test.ts` use the exact 33-byte hex captured from the failing CI run; they fail under the old code and pass under the fix.  

https://ledgerhq.atlassian.net/browse/LIVE-30546