### PR TITLE
chore(deps): bump DMK and signer-eth

### DIFF
--- a/.changeset/bump-dmk-signer-eth.md
+++ b/.changeset/bump-dmk-signer-eth.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": patch
+"ledger-live-desktop": patch
+---
+
+Bump @ledgerhq/device-management-kit to 1.4.1 and @ledgerhq/device-signer-kit-ethereum to 1.15.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ catalogs:
       specifier: 2.0.1
       version: 2.0.1
     '@ledgerhq/device-management-kit':
-      specifier: 1.4.0
-      version: 1.4.0
+      specifier: 1.4.1
+      version: 1.4.1
     '@ledgerhq/device-signer-kit-concordium':
       specifier: 0.3.0
       version: 0.3.0
@@ -34,8 +34,8 @@ catalogs:
       specifier: 1.0.0
       version: 1.0.0
     '@ledgerhq/device-signer-kit-ethereum':
-      specifier: 1.15.0
-      version: 1.15.0
+      specifier: 1.15.1
+      version: 1.15.1
     '@ledgerhq/device-signer-kit-hyperliquid':
       specifier: 1.0.2
       version: 1.0.2
@@ -1621,7 +1621,7 @@ importers:
         version: link:../../libs/coin-modules/coin-stacks
       '@ledgerhq/context-module':
         specifier: 1.17.1
-        version: 1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
+        version: 1.17.1(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
         version: 2.0.1(@ledgerhq/lumen-design-core@0.1.12)(@ledgerhq/lumen-ui-rnative@0.1.29(aaef53925dd57879e30bd9df42ba0adb))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
@@ -1633,13 +1633,13 @@ importers:
         version: link:../../libs/device-intent
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.4.0(rxjs@7.8.2)
+        version: 1.4.1(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-ethereum':
         specifier: 'catalog:'
-        version: 1.15.0(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
+        version: 1.15.1(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))
       '@ledgerhq/device-transport-kit-react-native-hid':
         specifier: 'catalog:'
-        version: 1.0.3(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(rxjs@7.8.2)
+        version: 1.0.3(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(rxjs@7.8.2)
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../libs/ledgerjs/packages/devices
@@ -2333,7 +2333,7 @@ importers:
         version: link:../../libs/ledgerjs/packages/cryptoassets
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.4.0(rxjs@7.8.2)
+        version: 1.4.1(rxjs@7.8.2)
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/errors
@@ -6913,7 +6913,7 @@ importers:
         version: link:../client-ids
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.4.0(rxjs@7.8.2)
+        version: 1.4.1(rxjs@7.8.2)
       '@ledgerhq/types-devices':
         specifier: workspace:^
         version: link:../ledgerjs/packages/types-devices
@@ -7501,7 +7501,7 @@ importers:
         version: link:../device-intent
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.4.0(rxjs@7.8.2)
+        version: 1.4.1(rxjs@7.8.2)
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../ledgerjs/packages/devices
@@ -7639,7 +7639,7 @@ importers:
         version: link:../ledgerjs/packages/logs
       '@ledgerhq/speculos-device-controller':
         specifier: 'catalog:'
-        version: 0.2.3(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
+        version: 0.2.3(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))
       '@ledgerhq/speculos-transport':
         specifier: workspace:^
         version: link:../speculos-transport
@@ -8810,7 +8810,7 @@ importers:
     dependencies:
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.4.0
+        version: 1.4.1
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../errors
@@ -10606,10 +10606,10 @@ importers:
     dependencies:
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.4.0(rxjs@7.8.2)
+        version: 1.4.1(rxjs@7.8.2)
       '@ledgerhq/device-transport-kit-web-hid':
         specifier: 'catalog:'
-        version: 1.2.3(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))(rxjs@7.8.2)
+        version: 1.2.3(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))(rxjs@7.8.2)
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../ledgerjs/packages/hw-transport
@@ -10673,10 +10673,10 @@ importers:
     dependencies:
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.4.0(rxjs@7.8.2)
+        version: 1.4.1(rxjs@7.8.2)
       '@ledgerhq/device-transport-kit-react-native-ble':
         specifier: 'catalog:'
-        version: 1.3.2(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))(react-native-ble-plx@3.4.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(react@19.0.0))(rxjs@7.8.2)
+        version: 1.3.2(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))(react-native-ble-plx@3.4.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(react@19.0.0))(rxjs@7.8.2)
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../ledgerjs/packages/devices
@@ -10704,7 +10704,7 @@ importers:
     devDependencies:
       '@ledgerhq/device-transport-kit-react-native-hid':
         specifier: 'catalog:'
-        version: 1.0.3(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(react@19.0.0))(rxjs@7.8.2)
+        version: 1.0.3(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(react@19.0.0))(rxjs@7.8.2)
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -10755,7 +10755,7 @@ importers:
     dependencies:
       '@ledgerhq/context-module':
         specifier: 1.17.1
-        version: 1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
+        version: 1.17.1(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../ledgerjs/packages/hw-transport
@@ -10783,7 +10783,7 @@ importers:
     devDependencies:
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.4.0(rxjs@7.8.2)
+        version: 1.4.1(rxjs@7.8.2)
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -10828,10 +10828,10 @@ importers:
     dependencies:
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.4.0(rxjs@7.8.2)
+        version: 1.4.1(rxjs@7.8.2)
       '@ledgerhq/device-transport-kit-speculos':
         specifier: 'catalog:'
-        version: 1.2.0(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))(rxjs@7.8.2)
+        version: 1.2.0(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))(rxjs@7.8.2)
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../ledgerjs/packages/hw-transport
@@ -10843,7 +10843,7 @@ importers:
         version: link:../ledgerjs/packages/logs
       '@ledgerhq/speculos-device-controller':
         specifier: 'catalog:'
-        version: 0.2.3(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
+        version: 0.2.3(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))
     devDependencies:
       '@swc/core':
         specifier: 'catalog:'
@@ -10965,13 +10965,13 @@ importers:
         version: link:../coin-modules/coin-aleo
       '@ledgerhq/context-module':
         specifier: 1.17.1
-        version: 1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
+        version: 1.17.1(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.4.0(rxjs@7.8.2)
+        version: 1.4.1(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-aleo':
         specifier: 0.2.0
-        version: 0.2.0(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
+        version: 0.2.0(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../ledgerjs/packages/errors
@@ -11109,13 +11109,13 @@ importers:
         version: link:../concordium-core
       '@ledgerhq/context-module':
         specifier: 1.17.1
-        version: 1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
+        version: 1.17.1(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.4.0(rxjs@7.8.2)
+        version: 1.4.1(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-concordium':
         specifier: 'catalog:'
-        version: 0.3.0(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
+        version: 0.3.0(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../ledgerjs/packages/errors
@@ -11152,10 +11152,10 @@ importers:
         version: link:../coin-modules/coin-cosmos
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.4.0(rxjs@7.8.2)
+        version: 1.4.1(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-cosmos':
         specifier: 'catalog:'
-        version: 1.0.0(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
+        version: 1.0.0(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../ledgerjs/packages/errors
@@ -11210,13 +11210,13 @@ importers:
         version: link:../coin-modules/coin-evm
       '@ledgerhq/context-module':
         specifier: 1.17.1
-        version: 1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
+        version: 1.17.1(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.4.0(rxjs@7.8.2)
+        version: 1.4.1(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-ethereum':
         specifier: 'catalog:'
-        version: 1.15.0(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
+        version: 1.15.1(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../ledgerjs/packages/errors
@@ -11262,10 +11262,10 @@ importers:
     dependencies:
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.4.0(rxjs@7.8.2)
+        version: 1.4.1(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-hyperliquid':
         specifier: 'catalog:'
-        version: 1.0.2(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
+        version: 1.0.2(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../ledgerjs/packages/devices
@@ -11311,10 +11311,10 @@ importers:
         version: link:../coin-modules/coin-solana
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.4.0(rxjs@7.8.2)
+        version: 1.4.1(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-solana':
         specifier: 'catalog:'
-        version: 1.8.0(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))(typescript@6.0.2)
+        version: 1.8.0(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))(typescript@6.0.2)
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../ledgerjs/packages/devices
@@ -16976,8 +16976,8 @@ packages:
       react-native:
         optional: true
 
-  '@ledgerhq/device-management-kit@1.4.0':
-    resolution: {integrity: sha512-CISA5PY79H5lEEbQ21kuDV8RC28xeVWH6UcKA1w41E/baOZEsFuvsQKTThAEwGsyg9/B9jitkaWYYuyi3cKsrQ==}
+  '@ledgerhq/device-management-kit@1.4.1':
+    resolution: {integrity: sha512-TEfO0fOSQ6iphOT7lMVYCjW1q7B3xSLhf9DaXgbiYT6tDgVHlYznbgpPWDFBeczbDapt0m+YlXQH7VqVIwOqzQ==}
     peerDependencies:
       rxjs: 7.8.2
 
@@ -16998,11 +16998,11 @@ packages:
     peerDependencies:
       '@ledgerhq/device-management-kit': ^1.2.0
 
-  '@ledgerhq/device-signer-kit-ethereum@1.15.0':
-    resolution: {integrity: sha512-wVGir4EZw135QxaYrG/NlO86AyuiKILDIJX+EobTxw09U5O+UtF7xI9zFC0Ws0B6wrPj+c90D8gpe5h9FxYsow==}
+  '@ledgerhq/device-signer-kit-ethereum@1.15.1':
+    resolution: {integrity: sha512-xKQ2czK6L4RSRZmtm6ZixMe8myQtU1Vm7GkmQp0T2E/GPiXYXeTu7/sgqv5F+GzAPTeDmB+uFyjUzyHSr0eLJA==}
     peerDependencies:
       '@ledgerhq/context-module': 1.17.1
-      '@ledgerhq/device-management-kit': ^1.3.0
+      '@ledgerhq/device-management-kit': ^1.4.1
 
   '@ledgerhq/device-signer-kit-hyperliquid@1.0.2':
     resolution: {integrity: sha512-vOHQRrMsUj4XMI4LC+WcerH0yyIiWw2kPHK0yN847FccKaB5x9+wiz2zWgcqk7fKHqYFr1S5GqXjmaiRWiAcwA==}
@@ -45188,9 +45188,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))':
+  '@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
+      '@ledgerhq/device-management-kit': 1.4.1(rxjs@7.8.2)
       crypto-js: 4.2.0
       ethers: 6.15.0
       inversify: 7.5.1(reflect-metadata@0.2.2)
@@ -45225,7 +45225,7 @@ snapshots:
       '@ledgerhq/lumen-ui-rnative': 0.1.29(aaef53925dd57879e30bd9df42ba0adb)
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
 
-  '@ledgerhq/device-management-kit@1.4.0':
+  '@ledgerhq/device-management-kit@1.4.1':
     dependencies:
       '@noble/hashes': 1.8.0
       '@sentry/minimal': 6.19.7
@@ -45242,7 +45242,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2)':
+  '@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2)':
     dependencies:
       '@noble/hashes': 1.8.0
       '@sentry/minimal': 6.19.7
@@ -45260,40 +45260,40 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/device-signer-kit-aleo@0.2.0(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-aleo@0.2.0(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/context-module': 1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
-      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
-      '@ledgerhq/signer-utils': 1.1.3(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
+      '@ledgerhq/context-module': 1.17.1(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))
+      '@ledgerhq/device-management-kit': 1.4.1(rxjs@7.8.2)
+      '@ledgerhq/signer-utils': 1.1.3(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))
       inversify: 7.5.1(reflect-metadata@0.2.2)
       purify-ts: 2.1.0
       reflect-metadata: 0.2.2
       xstate: 5.19.2
 
-  '@ledgerhq/device-signer-kit-concordium@0.3.0(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-concordium@0.3.0(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/context-module': 1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
-      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
-      '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
+      '@ledgerhq/context-module': 1.17.1(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))
+      '@ledgerhq/device-management-kit': 1.4.1(rxjs@7.8.2)
+      '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))
       inversify: 7.5.1(reflect-metadata@0.2.2)
       purify-ts: 2.1.0
       reflect-metadata: 0.2.2
       xstate: 5.19.2
 
-  '@ledgerhq/device-signer-kit-cosmos@1.0.0(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-cosmos@1.0.0(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
-      '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
+      '@ledgerhq/device-management-kit': 1.4.1(rxjs@7.8.2)
+      '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))
       inversify: 7.5.1(reflect-metadata@0.2.2)
       purify-ts: 2.1.0
       reflect-metadata: 0.2.2
       xstate: 5.19.2
 
-  '@ledgerhq/device-signer-kit-ethereum@1.15.0(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-ethereum@1.15.1(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/context-module': 1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
-      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
-      '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
+      '@ledgerhq/context-module': 1.17.1(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))
+      '@ledgerhq/device-management-kit': 1.4.1(rxjs@7.8.2)
+      '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))
       ethers: 6.15.0
       inversify: 7.5.1(reflect-metadata@0.2.2)
       purify-ts: 2.1.0
@@ -45304,11 +45304,11 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/device-signer-kit-hyperliquid@1.0.2(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-hyperliquid@1.0.2(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/context-module': 1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
-      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
-      '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
+      '@ledgerhq/context-module': 1.17.1(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))
+      '@ledgerhq/device-management-kit': 1.4.1(rxjs@7.8.2)
+      '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))
       inversify: 7.5.1(reflect-metadata@0.2.2)
       purify-ts: 2.1.0
       reflect-metadata: 0.2.2
@@ -45317,11 +45317,11 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/device-signer-kit-solana@1.8.0(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))(typescript@6.0.2)':
+  '@ledgerhq/device-signer-kit-solana@1.8.0(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))(typescript@6.0.2)':
     dependencies:
-      '@ledgerhq/context-module': 1.17.1(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
-      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
-      '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))
+      '@ledgerhq/context-module': 1.17.1(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))
+      '@ledgerhq/device-management-kit': 1.4.1(rxjs@7.8.2)
+      '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(typescript@6.0.2))(typescript@6.0.2)
       '@solana/web3.js': 1.98.4(typescript@6.0.2)
       bs58: 6.0.0
@@ -45338,9 +45338,9 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@ledgerhq/device-transport-kit-react-native-ble@1.3.2(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))(react-native-ble-plx@3.4.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(react@19.0.0))(rxjs@7.8.2)':
+  '@ledgerhq/device-transport-kit-react-native-ble@1.3.2(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))(react-native-ble-plx@3.4.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(react@19.0.0))(rxjs@7.8.2)':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
+      '@ledgerhq/device-management-kit': 1.4.1(rxjs@7.8.2)
       '@sentry/minimal': 6.19.7
       js-base64: 3.7.8
       purify-ts: 2.1.0
@@ -45349,35 +45349,35 @@ snapshots:
       rxjs: 7.8.2
       uuid: 11.0.3
 
-  '@ledgerhq/device-transport-kit-react-native-hid@1.0.3(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(rxjs@7.8.2)':
+  '@ledgerhq/device-transport-kit-react-native-hid@1.0.3(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(rxjs@7.8.2)':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
+      '@ledgerhq/device-management-kit': 1.4.1(rxjs@7.8.2)
       '@sentry/minimal': 6.19.7
       purify-ts: 2.1.0
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
       rxjs: 7.8.2
       uuid: 11.0.3
 
-  '@ledgerhq/device-transport-kit-react-native-hid@1.0.3(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(react@19.0.0))(rxjs@7.8.2)':
+  '@ledgerhq/device-transport-kit-react-native-hid@1.0.3(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(react@19.0.0))(rxjs@7.8.2)':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
+      '@ledgerhq/device-management-kit': 1.4.1(rxjs@7.8.2)
       '@sentry/minimal': 6.19.7
       purify-ts: 2.1.0
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(react@19.0.0)
       rxjs: 7.8.2
       uuid: 11.0.3
 
-  '@ledgerhq/device-transport-kit-speculos@1.2.0(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))(rxjs@7.8.2)':
+  '@ledgerhq/device-transport-kit-speculos@1.2.0(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))(rxjs@7.8.2)':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
+      '@ledgerhq/device-management-kit': 1.4.1(rxjs@7.8.2)
       '@sentry/minimal': 6.19.7
       axios: 1.13.5
       purify-ts: 2.1.0
       rxjs: 7.8.2
 
-  '@ledgerhq/device-transport-kit-web-hid@1.2.3(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))(rxjs@7.8.2)':
+  '@ledgerhq/device-transport-kit-web-hid@1.2.3(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))(rxjs@7.8.2)':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
+      '@ledgerhq/device-management-kit': 1.4.1(rxjs@7.8.2)
       '@sentry/minimal': 6.19.7
       purify-ts: 2.1.0
       rxjs: 7.8.2
@@ -45590,19 +45590,19 @@ snapshots:
       react: 19.0.0
       tailwind-merge: 2.6.0
 
-  '@ledgerhq/signer-utils@1.1.3(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))':
+  '@ledgerhq/signer-utils@1.1.3(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
+      '@ledgerhq/device-management-kit': 1.4.1(rxjs@7.8.2)
       semver: 7.7.2
 
-  '@ledgerhq/signer-utils@1.2.0(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))':
+  '@ledgerhq/signer-utils@1.2.0(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
+      '@ledgerhq/device-management-kit': 1.4.1(rxjs@7.8.2)
       semver: 7.7.2
 
-  '@ledgerhq/speculos-device-controller@0.2.3(@ledgerhq/device-management-kit@1.4.0(rxjs@7.8.2))':
+  '@ledgerhq/speculos-device-controller@0.2.3(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.4.0(rxjs@7.8.2)
+      '@ledgerhq/device-management-kit': 1.4.1(rxjs@7.8.2)
       '@sentry/minimal': 6.19.7
       axios: 1.13.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,9 +21,9 @@ catalog:
   "@jest/globals": 30.2.0
   "@ledgerhq/context-module": 1.17.1
   "@ledgerhq/crypto-icons": "2.0.1"
-  "@ledgerhq/device-management-kit": 1.4.0
+  "@ledgerhq/device-management-kit": 1.4.1
   "@ledgerhq/device-signer-kit-concordium": 0.3.0
-  "@ledgerhq/device-signer-kit-ethereum": 1.15.0
+  "@ledgerhq/device-signer-kit-ethereum": 1.15.1
   "@ledgerhq/device-signer-kit-hyperliquid": 1.0.2
   "@ledgerhq/device-signer-kit-solana": 1.8.0
   "@ledgerhq/device-signer-kit-cosmos": 1.0.0


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Dependency bump only — covered by existing test suites; no new tests needed._
- [x] **Impact of the changes:**
      - Device connection flows (BLE/USB) on mobile and desktop
      - Ethereum signing flows: send, swap, sign message, sign typed data
      - General DMK transport behavior

### 📝 Description

Bumps the following workspace catalog dependencies to their latest patch releases:

- `@ledgerhq/device-management-kit`: `1.4.0` → `1.4.1`
- `@ledgerhq/device-signer-kit-ethereum`: `1.15.0` → `1.15.1`

No code changes required — patch-level updates picked up via the pnpm catalog. Lockfile updated accordingly.

### ❓ Context

- **JIRA or GitHub link**: n/a — maintenance bump

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)