### PR TITLE
[LWD] fix(desktop): keep Web3 webviews context isolated

### DIFF
--- a/.changeset/calm-dapps-isolate.md
+++ b/.changeset/calm-dapps-isolate.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Re-enable context isolation on dapp webviews and inject the EIP-1193 provider via `contextBridge`.

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/prop-types */
-
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { useToasts } from "@ledgerhq/live-common/notifications/ToastProvider/index";
 import {
@@ -220,8 +218,8 @@ function useUiHook(manifest: AppManifest, tracking: TrackingAPI): UiHook {
       },
       "transaction.broadcast": (account, parentAccount, mainAccount, optimisticOperation) => {
         dispatch(
-          updateAccountWithUpdater(mainAccount.id, account =>
-            addPendingOperation(account, optimisticOperation),
+          updateAccountWithUpdater(mainAccount.id, a =>
+            addPendingOperation(a, optimisticOperation),
           ),
         );
 
@@ -554,7 +552,6 @@ export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
            * seem to be set
            */
           style={webviewStyle}
-          // eslint-disable-next-line react/no-unknown-property
           preload={`file://${window.api.appDirname}/${preloader}.bundle.js`}
           /**
            * There seems to be an issue between Electron webview and react
@@ -563,10 +560,8 @@ export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
            * cf. https://github.com/electron/electron/issues/6046
            */
           // @ts-expect-error: see above comment
-          // eslint-disable-next-line react/no-unknown-property
           allowpopups="true"
-          // eslint-disable-next-line react/no-unknown-property
-          webpreferences={`nativeWindowOpen=no${isDapp ? ", contextIsolation=no" : ""}`}
+          webpreferences="nativeWindowOpen=no"
           {...webviewProps}
           {...webviewPartition}
         />

--- a/apps/ledger-live-desktop/src/webviewPreloader/dappPreloader.ts
+++ b/apps/ledger-live-desktop/src/webviewPreloader/dappPreloader.ts
@@ -1,8 +1,44 @@
-import { ipcRenderer } from "electron";
-import { onPageLoad } from "@ledgerhq/ethereum-provider";
+import { contextBridge, ipcRenderer } from "electron";
+import ethereumProvider from "@ledgerhq/ethereum-provider/lib/ethereum-provider.umd.json";
 
-window.ElectronWebview = {
+contextBridge.exposeInMainWorld("ElectronWebview", {
   postMessage: (message: unknown) => ipcRenderer.sendToHost("dappToParent", message),
+});
+
+// `${ethereumProvider.code}` is interpolated once here at preload eval time,
+// producing a plain string that we then assign to `script.textContent`. Any
+// backticks or `${...}` sequences that exist inside the bundled UMD source
+// are therefore inert at this point — they only get re-tokenized as JS when
+// the browser parses the injected <script>, where they're valid template
+// literals again. Do not refactor this into a concatenation that would let
+// `${...}` be re-evaluated by the outer template.
+const ethereumProviderInjection = `
+${ethereumProvider.code}
+
+if (document.readyState === "complete") {
+  LedgerLiveEthereumProvider.onPageLoad();
+} else {
+  window.addEventListener("load", LedgerLiveEthereumProvider.onPageLoad, { once: true });
+}
+`;
+
+const injectEthereumProvider = () => {
+  const parent = document.head || document.documentElement;
+
+  if (!parent) {
+    document.addEventListener("DOMContentLoaded", injectEthereumProvider, { once: true });
+    return;
+  }
+
+  const script = document.createElement("script");
+  script.textContent = ethereumProviderInjection;
+
+  // Inline <script> execution is synchronous on insertion into a parented
+  // document, so by the time `appendChild` returns the provider has already
+  // attached itself to the page's `window` and registered its load listener.
+  // We can safely detach the node to keep the DOM clean.
+  parent.appendChild(script);
+  script.remove();
 };
 
-window.addEventListener("load", onPageLoad);
+injectEthereumProvider();


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - desktop dApps

### 📝 Description

Remove the dapp-specific `contextIsolation=no` webview preference.

### ❓ Context

- **JIRA or GitHub link**:
- **ADR link (if any)**:

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
