### PR TITLE
feat(LWMD): bump crypto-icons

### DIFF
--- a/.changeset/rare-rivers-crash.md
+++ b/.changeset/rare-rivers-crash.md
@@ -1,0 +1,9 @@
+---
+"live-mobile": patch
+"ledger-live-desktop": patch
+"@ledgerhq/web-tools": patch
+"@ledgerhq/native-ui": patch
+"@ledgerhq/react-ui": patch
+---
+
+Bump crypto-icons with latest lumen bump

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ catalogs:
       specifier: 7.21.4
       version: 7.21.4
     '@ledgerhq/crypto-icons':
-      specifier: 2.0.1
-      version: 2.0.1
+      specifier: 2.0.3
+      version: 2.0.3
     '@ledgerhq/device-management-kit':
       specifier: 1.4.1
       version: 1.4.1
@@ -968,7 +968,7 @@ importers:
         version: 2.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.13)(@ledgerhq/lumen-ui-react@0.1.31(a8cccf4730528caceafebf2c6f0140b7))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 2.0.3(@ledgerhq/lumen-design-core@0.1.13)(@ledgerhq/lumen-ui-react@0.1.31(a8cccf4730528caceafebf2c6f0140b7))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/cryptoassets
@@ -1624,7 +1624,7 @@ importers:
         version: 1.17.1(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.13)(@ledgerhq/lumen-ui-rnative@0.1.32(21f4227632be30b0f49d01a2b350e488))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+        version: 2.0.3(@ledgerhq/lumen-design-core@0.1.13)(@ledgerhq/lumen-ui-rnative@0.1.32(21f4227632be30b0f49d01a2b350e488))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/cryptoassets
@@ -2454,7 +2454,7 @@ importers:
         version: 2.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.13)(@ledgerhq/lumen-ui-react@0.1.31(a8cccf4730528caceafebf2c6f0140b7))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 2.0.3(@ledgerhq/lumen-design-core@0.1.13)(@ledgerhq/lumen-ui-react@0.1.31(a8cccf4730528caceafebf2c6f0140b7))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/cryptoassets
@@ -11638,7 +11638,7 @@ importers:
     dependencies:
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.13)(@ledgerhq/lumen-ui-rnative@0.1.32(30635d6a6413ea2272c5df4eb0a98cea))(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
+        version: 2.0.3(@ledgerhq/lumen-design-core@0.1.13)(@ledgerhq/lumen-ui-rnative@0.1.32(30635d6a6413ea2272c5df4eb0a98cea))(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
       '@ledgerhq/icons-ui':
         specifier: workspace:^
         version: link:../icons
@@ -11966,7 +11966,7 @@ importers:
     dependencies:
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.13)(@ledgerhq/lumen-ui-react@0.1.31(a8cccf4730528caceafebf2c6f0140b7))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 2.0.3(@ledgerhq/lumen-design-core@0.1.13)(@ledgerhq/lumen-ui-react@0.1.31(a8cccf4730528caceafebf2c6f0140b7))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@ledgerhq/icons-ui':
         specifier: workspace:^
         version: file:libs/ui/packages/icons(@types/react@19.0.14)(react@19.0.0)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@19.0.0(react@19.0.0))(react-is@17.0.2)(react@19.0.0))(styled-system@5.1.5)
@@ -16995,12 +16995,12 @@ packages:
     peerDependencies:
       '@ledgerhq/device-management-kit': ^1.3.0
 
-  '@ledgerhq/crypto-icons@2.0.1':
-    resolution: {integrity: sha512-nGw1ENrkpLDiKUMjxzHeO3w5FZLD9dJLu+Gvbl7EfrLg7wQU0cOCokbvxEUXeWI8B3iAbUyBWW51JeqnbYO8JA==}
+  '@ledgerhq/crypto-icons@2.0.3':
+    resolution: {integrity: sha512-GW2UBrhhu/eBb7npbWrmay3lQ5u/YHMjxNmygsBvHC5NE/VzZX463yLaHrFnOTYlNXuYbm0NcZMxz6OdbdrjnA==}
     peerDependencies:
-      '@ledgerhq/lumen-design-core': '>=0.1.11'
-      '@ledgerhq/lumen-ui-react': '>=0.1.24'
-      '@ledgerhq/lumen-ui-rnative': '>=0.1.25'
+      '@ledgerhq/lumen-design-core': '>=0.1.13'
+      '@ledgerhq/lumen-ui-react': '>=0.1.31'
+      '@ledgerhq/lumen-ui-rnative': '>=0.1.32'
       react: 19.0.0
       react-dom: 19.0.0
       react-native: '>=0.70'
@@ -21379,7 +21379,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.0.0
       react-dom: 19.0.0
-      webpack: '*'
+      webpack: ^5.89.0
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -23662,7 +23662,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: '*'
+      rxjs: ^5.5.10
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -45241,7 +45241,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/crypto-icons@2.0.1(@ledgerhq/lumen-design-core@0.1.13)(@ledgerhq/lumen-ui-react@0.1.31(a8cccf4730528caceafebf2c6f0140b7))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@ledgerhq/crypto-icons@2.0.3(@ledgerhq/lumen-design-core@0.1.13)(@ledgerhq/lumen-ui-react@0.1.31(a8cccf4730528caceafebf2c6f0140b7))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       react: 19.0.0
     optionalDependencies:
@@ -45249,7 +45249,7 @@ snapshots:
       '@ledgerhq/lumen-ui-react': 0.1.31(a8cccf4730528caceafebf2c6f0140b7)
       react-dom: 19.0.0(react@19.0.0)
 
-  '@ledgerhq/crypto-icons@2.0.1(@ledgerhq/lumen-design-core@0.1.13)(@ledgerhq/lumen-ui-rnative@0.1.32(21f4227632be30b0f49d01a2b350e488))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
+  '@ledgerhq/crypto-icons@2.0.3(@ledgerhq/lumen-design-core@0.1.13)(@ledgerhq/lumen-ui-rnative@0.1.32(21f4227632be30b0f49d01a2b350e488))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
     dependencies:
       react: 19.0.0
     optionalDependencies:
@@ -45257,7 +45257,7 @@ snapshots:
       '@ledgerhq/lumen-ui-rnative': 0.1.32(21f4227632be30b0f49d01a2b350e488)
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
 
-  '@ledgerhq/crypto-icons@2.0.1(@ledgerhq/lumen-design-core@0.1.13)(@ledgerhq/lumen-ui-rnative@0.1.32(30635d6a6413ea2272c5df4eb0a98cea))(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)':
+  '@ledgerhq/crypto-icons@2.0.3(@ledgerhq/lumen-design-core@0.1.13)(@ledgerhq/lumen-ui-rnative@0.1.32(30635d6a6413ea2272c5df4eb0a98cea))(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)':
     dependencies:
       react: 19.0.0
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,7 +20,7 @@ packages:
 catalog:
   "@jest/globals": 30.2.0
   "@ledgerhq/context-module": 1.17.1
-  "@ledgerhq/crypto-icons": "2.0.1"
+  "@ledgerhq/crypto-icons": "2.0.3"
   "@ledgerhq/device-management-kit": 1.4.1
   "@ledgerhq/device-signer-kit-concordium": 0.3.0
   "@ledgerhq/device-signer-kit-ethereum": 1.15.1


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _Dependency bump — covered by the consumer apps' existing icon usage and the crypto-icons package's own test suite._
- [x] **Impact of the changes:**
  - Crypto icon rendering across Desktop and Mobile (Asset Detail, Market, Manager, Send/Receive, Swap)
  - `@ledgerhq/native-ui`, `@ledgerhq/react-ui`, `@ledgerhq/web-tools` consumers that re-export `CryptoIcon`
  - No public API change — `import { CryptoIcon } from '@ledgerhq/crypto-icons'` and `'@ledgerhq/crypto-icons/native'` remain stable

### 📝 Description

Bumps `@ledgerhq/crypto-icons` from `2.0.1` → `2.0.3` in the workspace catalog.

This release rolls up two upstream PRs:

- **[crypto-icons#110](https://github.com/LedgerHQ/crypto-icons/pull/110) — `:package: bump lumen`**
  Keeps the icon set in sync with the latest lumen bump landed in ledger-live.

- **[crypto-icons#113](https://github.com/LedgerHQ/crypto-icons/pull/113) — migrate build from rollup to tsdown (rolldown)**
  Fixes a build regression introduced by the lumen bump where `picomatch@2.3.2` broke the extglob filter in `rollup-plugin-typescript2`, silently letting `.ts` files through untransformed. Switches the package to `tsdown` (Rolldown + oxc):
  - Single `tsdown.config.mjs` replaces the dual rollup configs
  - `.d.ts` bundled per entry; dual ESM+CJS output
  - `module` field changed from `dist/index.esm.js` → `dist/index.mjs` (standard convention)
  - Root `native.js` / `native.d.ts` shims removed — `./native` export now points directly at `dist/index.native.*`
  - Build time: ~40s → ~2s
  - `Build` step added to `verify.yml` so future PRs catch broken builds before merge

Public API is unchanged — Metro still auto-resolves the React Native entry via the `react-native` field, and type exports (`CryptoIcon`, `CryptoIconProps`) are preserved on both subpaths.


On desktop

https://github.com/user-attachments/assets/d71c94ab-38aa-456d-83dc-36ded424375b

On mobile

https://github.com/user-attachments/assets/b2c12216-2f2a-44ce-b397-ca2c0fca3310


### ❓ Context

- **JIRA or GitHub link**: [LIVE-30443](https://ledgerhq.atlassian.net/browse/LIVE-30443) && [LIVE-29991](https://ledgerhq.atlassian.net/browse/LIVE-29991)
- Upstream PRs: [crypto-icons#110](https://github.com/LedgerHQ/crypto-icons/pull/110), [crypto-icons#113](https://github.com/LedgerHQ/crypto-icons/pull/113)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-30443]: https://ledgerhq.atlassian.net/browse/LIVE-30443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ