### PR TITLE
[LWM] fix(lwm): speed up Save logs export by skipping base64 round-trip

### DIFF
--- a/apps/ledger-live-mobile/src/components/useExportLogs.tsx
+++ b/apps/ledger-live-mobile/src/components/useExportLogs.tsx
@@ -52,9 +52,7 @@ export default function useExportLogs() {
 
     try {
       const logs = logReport.getLogs();
-      const base64 = Buffer.from(JSON.stringify(logs, getJSONStringifyReplacer(), 2)).toString(
-        "base64",
-      );
+      const serialized = JSON.stringify(logs, getJSONStringifyReplacer(), 2);
 
       const version = getFullAppVersion(undefined, undefined, "-");
       const date = new Date().toISOString().split("T")[0];
@@ -62,7 +60,7 @@ export default function useExportLogs() {
       const humanReadableName = `ledgerwallet-mob-${version}-${date}-logs.txt`;
       const filePath = `${RNFetchBlob.fs.dirs.DocumentDir}/${humanReadableName}`;
 
-      await RNFetchBlob.fs.writeFile(filePath, base64, "base64");
+      await RNFetchBlob.fs.writeFile(filePath, serialized, "utf8");
       const options = {
         failOnCancel: false,
         saveToFiles: true,


### PR DESCRIPTION
### ✅ Checklist

<\!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <\!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <\!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LWM only — Settings → Help → **Save logs** (and every other consumer of `useExportLogs`: Send broadcast error screen, Swap custom error screen, Debug → Logs, MyWallet Help). QA should verify the share sheet still opens and the exported `.txt` is readable on iOS and Android.

### 📝 Description

LWM users reported that tapping **Settings → Save logs** leaves the app unresponsive for several seconds before the share sheet appears.

`useExportLogs` was serializing logs to JSON, then doing a full `Buffer.from(...).toString("base64")` pass over the resulting string, then handing that base64 buffer to `RNFetchBlob.fs.writeFile` with `"base64"` encoding. The base64 round-trip is a synchronous walk over the entire (potentially large) log string on the JS thread and roughly doubles peak memory — for no benefit, since `Share.open` only needs a file URL.

This PR writes the JSON string directly with `"utf8"` encoding and drops the intermediate base64 buffer. The DETOX path is unaffected: `readFile`'s `"base64"` argument describes the *output* encoding and is independent of how the file was written.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30531](https://ledgerhq.atlassian.net/browse/LIVE-30531)

[LIVE-30531]: https://ledgerhq.atlassian.net/browse/LIVE-30531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ