### PR TITLE
[LWD] chore(lld): wire Datadog to `useBroadcast`

### DIFF
--- a/.changeset/quick-snakes-broadcast.md
+++ b/.changeset/quick-snakes-broadcast.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Wire Datadog logs in `useBroadcast` for legacy Send, Platform Exchange and the new MVVM Send flow

--- a/apps/ledger-live-desktop/src/datadog/logs.test.ts
+++ b/apps/ledger-live-desktop/src/datadog/logs.test.ts
@@ -1,4 +1,9 @@
-import { __resetDatadogLogsForTesting, initDatadogLogs, isDatadogLogsAvailable } from "./logs";
+import {
+  __resetDatadogLogsForTesting,
+  broadcastLogger,
+  initDatadogLogs,
+  isDatadogLogsAvailable,
+} from "./logs";
 
 jest.mock("./config", () => ({
   getDatadogBuildConfig: jest.fn(),
@@ -13,6 +18,10 @@ jest.mock("@datadog/browser-logs", () => ({
   datadogLogs: {
     init: jest.fn(),
     setGlobalContext: jest.fn(),
+    logger: {
+      info: jest.fn(),
+      error: jest.fn(),
+    },
   },
 }));
 
@@ -153,6 +162,64 @@ describe("datadog logs", () => {
       datadogLogs.init.mockClear();
       expect(initDatadogLogs(() => true)).toBe(true);
       expect(datadogLogs.init).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("broadcastLogger", () => {
+    beforeEach(() => {
+      getDatadogBuildConfig.mockReturnValue({
+        applicationId: null,
+        clientToken: "token",
+        site: "datadoghq.eu",
+        env: "production",
+      });
+      initDatadogLogs(() => true);
+    });
+
+    it("calls datadogLogs.logger.info with correct parameters on success event", () => {
+      broadcastLogger({
+        status: "success",
+        appVersion: "1.0.0",
+        currencyId: "bitcoin",
+        family: "bitcoin",
+      });
+
+      expect(datadogLogs.logger.info).toHaveBeenCalledWith("broadcast_success", {
+        event: {
+          status: "success",
+          appVersion: "1.0.0",
+          currencyId: "bitcoin",
+          family: "bitcoin",
+        },
+      });
+    });
+
+    it("calls datadogLogs.logger.error with correct parameters on failure event", () => {
+      const error = new Error("tx broadcast failed");
+      error.stack = "Error: tx broadcast failed\n  at test:1:1";
+
+      broadcastLogger({
+        status: "failure",
+        error,
+        txPayload: "payload",
+        appVersion: "1.0.0",
+        currencyId: "ethereum",
+        family: "evm",
+      });
+
+      expect(datadogLogs.logger.error).toHaveBeenCalledWith(
+        "broadcast_failure",
+        {
+          event: {
+            status: "failure",
+            txPayload: "payload",
+            appVersion: "1.0.0",
+            currencyId: "ethereum",
+            family: "evm",
+          },
+        },
+        error,
+      );
     });
   });
 });

--- a/apps/ledger-live-desktop/src/datadog/logs.ts
+++ b/apps/ledger-live-desktop/src/datadog/logs.ts
@@ -1,4 +1,5 @@
 import { datadogLogs } from "@datadog/browser-logs";
+import type { LogEvent } from "@ledgerhq/live-common/hooks/useBroadcast";
 import { getOperatingSystemSupportStatus } from "~/support/os";
 import { buildBeforeSend, getDatadogBuildConfig, type ShouldSendCallback } from "./config";
 
@@ -50,5 +51,16 @@ export function initDatadogLogs(shouldSend: ShouldSendCallback): boolean {
   } catch (e) {
     console.error("Datadog Logs init failed", e);
     return false;
+  }
+}
+
+export function broadcastLogger(event: LogEvent): void {
+  if (!initialized) return;
+
+  if (event.status === "success") {
+    datadogLogs.logger.info("broadcast_success", { event });
+  } else {
+    const { error, ...rest } = event;
+    datadogLogs.logger.error("broadcast_failure", { event: rest }, error);
   }
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Signature/hooks/__tests__/useSignatureViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Signature/hooks/__tests__/useSignatureViewModel.test.tsx
@@ -34,7 +34,7 @@ type AccountLike = { id: string; type: "Account" | "TokenAccount"; token?: Token
 type MockState = {
   account: {
     account: AccountLike;
-    parentAccount: { id: string } | null;
+    parentAccount: { id: string; currency: { family: string } } | null;
     currency: { id: string } | null;
   };
   transaction: {
@@ -127,7 +127,7 @@ describe("useSignatureViewModel", () => {
 
   test("exposes action and builds request with tokenCurrency for TokenAccount", () => {
     mockState.account.account = { id: "tokAcc", type: "TokenAccount", token: { id: "token-1" } };
-    mockState.account.parentAccount = { id: "parent-acc" };
+    mockState.account.parentAccount = { id: "parent-acc", currency: { family: "family" } };
 
     const ref = React.createRef<HookApi>();
     render(<Harness ref={ref} />);
@@ -135,7 +135,7 @@ describe("useSignatureViewModel", () => {
     expect(ref.current?.action).toBe(actionMock);
     expect(ref.current?.request).toEqual({
       tokenCurrency: { id: "token-1" },
-      parentAccount: { id: "parent-acc" },
+      parentAccount: { id: "parent-acc", currency: { family: "family" } },
       account: { id: "tokAcc", type: "TokenAccount", token: { id: "token-1" } },
       transaction: { id: "tx" },
       status: { ok: true },

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Signature/hooks/useSignatureViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Signature/hooks/useSignatureViewModel.ts
@@ -13,7 +13,8 @@ import { useTransactionAction } from "~/renderer/hooks/useConnectAppAction";
 import { useFlowWizard } from "../../../../FlowWizard/FlowWizardContext";
 import { useSendFlowActions, useSendFlowData } from "../../../context/SendFlowContext";
 import { selectIsBuyDeviceOpen } from "LLD/features/BuyDevice/buyDeviceDialog";
-import { hasOnboardedDeviceSelector } from "~/renderer/reducers/settings";
+import { hasOnboardedDeviceSelector, mevProtectionSelector } from "~/renderer/reducers/settings";
+import { broadcastLogger } from "~/datadog/logs";
 
 export function useSignatureViewModel() {
   const { navigation } = useFlowWizard();
@@ -61,7 +62,16 @@ export function useSignatureViewModel() {
   }
 
   const action = useTransactionAction();
-  const broadcast = useBroadcast({ account, parentAccount });
+  const mevProtected = useSelector(mevProtectionSelector);
+  const broadcast = useBroadcast({
+    account,
+    parentAccount,
+    broadcastConfig: {
+      mevProtected,
+      source: { type: "coin-module", name: "ledger-live-desktop", flags: { newSendFlow: true } },
+    },
+    logger: broadcastLogger,
+  });
 
   const request = useMemo(() => {
     const tokenCurrency =

--- a/apps/ledger-live-desktop/src/renderer/components/ConnectEnvsToDatadog.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ConnectEnvsToDatadog.test.tsx
@@ -8,8 +8,13 @@ jest.mock("~/datadog/renderer", () => ({
   isDatadogAvailable: jest.fn().mockReturnValue(true),
 }));
 
+jest.mock("~/datadog/logs", () => ({
+  initDatadogLogs: jest.fn().mockReturnValue(true),
+}));
+
 const initDatadog = jest.mocked(jest.requireMock("~/datadog/renderer").initDatadog);
 const isDatadogAvailable = jest.mocked(jest.requireMock("~/datadog/renderer").isDatadogAvailable);
+const initDatadogLogs = jest.mocked(jest.requireMock("~/datadog/logs").initDatadogLogs);
 
 describe("ConnectEnvsToDatadog", () => {
   beforeEach(() => {
@@ -52,6 +57,19 @@ describe("ConnectEnvsToDatadog", () => {
       expect.objectContaining({}),
       expect.anything(),
     );
+  });
+
+  it("should call initDatadogLogs with a shouldSend callback under the same gating", async () => {
+    render(<ConnectEnvsToDatadog />, {
+      initialState: {
+        ...withFlagOverrides({ lldDatadog: { enabled: true, params: {} } }),
+        settings: {
+          sentryLogs: true,
+        },
+      },
+    });
+    await new Promise(r => setImmediate(r));
+    expect(initDatadogLogs).toHaveBeenCalledWith(expect.any(Function));
   });
 
   it("should pass shouldSend that reads current store so opt-out is respected after init", async () => {

--- a/apps/ledger-live-desktop/src/renderer/components/ConnectEnvsToDatadog.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ConnectEnvsToDatadog.tsx
@@ -6,6 +6,7 @@ import { Feature, FeatureId, Features } from "@ledgerhq/types-live";
 import { enabledExperimentalFeatures } from "~/renderer/experimental";
 import { sentryLogsSelector } from "~/renderer/reducers/settings";
 import { initDatadog, setTags, isDatadogAvailable } from "~/datadog/renderer";
+import { initDatadogLogs } from "~/datadog/logs";
 
 const MAX_KEYLEN = 32;
 
@@ -50,6 +51,7 @@ export const ConnectEnvsToDatadog = () => {
     initInFlightRef.current = true;
 
     const shouldSend = () => sentryLogsSelector(store.getState());
+    initDatadogLogs(shouldSend);
     initDatadog(
       shouldSend,
       {

--- a/apps/ledger-live-desktop/src/renderer/modals/Platform/Exchange/CompleteExchange/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Platform/Exchange/CompleteExchange/Body.tsx
@@ -15,6 +15,7 @@ import styled from "styled-components";
 import { mevProtectionSelector } from "~/renderer/reducers/settings";
 import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
 import { useRedirectToSwapHistory } from "~/renderer/screens/exchange/Swap2/utils";
+import { broadcastLogger } from "~/datadog/logs";
 import { BodyContent } from "./BodyContent";
 
 export enum ExchangeModeEnum {
@@ -161,7 +162,12 @@ const Body = ({ data, onClose }: { data: Data; onClose?: () => void | undefined 
     [mevProtected, sponsored, provider],
   );
 
-  const broadcast = useBroadcast({ account, parentAccount, broadcastConfig });
+  const broadcast = useBroadcast({
+    account,
+    parentAccount,
+    broadcastConfig,
+    logger: broadcastLogger,
+  });
   const [transaction, setTransaction] = useState<Transaction>();
   const [signedOperation, setSignedOperation] = useState<SignedOperation>();
   const [error, setError] = useState<Error>();

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/GenericStepConnectDevice.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/GenericStepConnectDevice.tsx
@@ -6,6 +6,7 @@ import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import DeviceAction from "~/renderer/components/DeviceAction";
 import StepProgress from "~/renderer/components/StepProgress";
 import { useBroadcast } from "@ledgerhq/live-common/hooks/useBroadcast";
+import { broadcastLogger } from "~/datadog/logs";
 import { Account, AccountLike, Operation, SignedOperation } from "@ledgerhq/types-live";
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
 import { DeviceBlocker } from "~/renderer/components/DeviceAction/DeviceBlocker";
@@ -14,7 +15,6 @@ import { mevProtectionSelector } from "~/renderer/reducers/settings";
 import { HOOKS_TRACKING_LOCATIONS } from "~/renderer/analytics/hooks/variables";
 import { useTransactionAction } from "~/renderer/hooks/useConnectAppAction";
 import type { ModalData } from "~/renderer/modals/types";
-import { useNewSendFlowFeature } from "LLD/features/Send/hooks/useNewSendFlowFeature";
 
 const Result = (
   props:
@@ -61,30 +61,22 @@ export default function StepConnectDevice({
 }) {
   const mevProtected = useSelector(mevProtectionSelector);
   const dispatch = useDispatch();
-  const newSendFlowFeature = useNewSendFlowFeature();
-  const newSendFlowFamily = newSendFlowFeature.getFamilyFromAccount(
-    account ?? undefined,
-    parentAccount ?? null,
-  );
-  const newSendFlowCurrencyId = newSendFlowFeature.getCurrencyIdFromAccount(
-    account ?? undefined,
-    parentAccount ?? null,
-  );
-  const newSendFlow = newSendFlowFeature.isEnabledForFamily(
-    newSendFlowFamily,
-    newSendFlowCurrencyId,
-  );
   const broadcastConfig = useMemo(
     () => ({
       mevProtected,
-      source: { type: "coin-module" as const, name: "ledger-live-desktop", flags: { newSendFlow } },
+      source: {
+        type: "coin-module" as const,
+        name: "ledger-live-desktop",
+        flags: { newSendFlow: false },
+      },
     }),
-    [mevProtected, newSendFlow],
+    [mevProtected],
   );
   const broadcast = useBroadcast({
     account,
     parentAccount,
     broadcastConfig,
+    logger: broadcastLogger,
   });
   const tokenCurrency = (account && account.type === "TokenAccount" && account.token) || undefined;
   const request = useMemo(


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LWD broadcast

### 📝 Description

Wires Datadog observability into the `useBroadcast` hook for Ledger Live Desktop.

- Adds a `broadcastLogger` function that logs broadcast outcomes to Datadog.
- Passes `broadcastLogger` to `useBroadcast`.
- Adds unit tests covering success and failure events.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
