### PR TITLE
[LWDM] refactor(desktop): migrate to AccountBridgeExtensions API

### DIFF
--- a/.changeset/quiet-bridges-extend.md
+++ b/.changeset/quiet-bridges-extend.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"@ledgerhq/live-common": patch
+---
+
+Migrate desktop call sites of deprecated top-level helpers (isAccountEmpty, clearAccount, isEditableOperation, isStuckOperation, getStuckAccountAndOperation) to AccountBridgeExtensions via useAccountBridge / useAccountBridgeMany / getAccountBridge; solana/banner.ts now accepts the resolved bridge as a parameter.

--- a/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/__tests__/addAccountFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/__tests__/addAccountFlow.test.tsx
@@ -40,6 +40,8 @@ const mockAccountBridge = {
   assignToAccountRaw: () => {},
   assignToTokenAccountRaw: () => {},
   toOperationExtraRaw: (extra: unknown) => extra,
+  isAccountEmpty: (a: { operationsCount: number; balance: { isZero: () => boolean } }) =>
+    a.operationsCount === 0 && a.balance.isZero(),
 };
 
 jest.mock("~/renderer/bridge/cache", () => ({

--- a/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/ScanAccounts/useScanAccounts.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/ScanAccounts/useScanAccounts.ts
@@ -1,5 +1,5 @@
-import { isAccountEmpty } from "@ledgerhq/live-common/account/index";
 import { getCurrencyBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridgeMany } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { addAccountsAction } from "@ledgerhq/live-wallet/addAccounts";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { Account } from "@ledgerhq/types-live";
@@ -21,7 +21,6 @@ import {
 import useAddAccountAnalytics from "../../analytics/useAddAccountAnalytics";
 import { WARNING_REASON, WarningReason } from "../../domain";
 import {
-  determineSelectedIds,
   getGroupedAccounts,
   getUnimportedAccounts,
 } from "./utils/processAccounts";
@@ -121,21 +120,33 @@ export function useScanAccounts({
     };
   }, [blacklistedTokenIds, currency, deviceId, stopSubscription]);
 
+  const unimportedAccounts = useMemo(
+    () => getUnimportedAccounts(scannedAccounts, existingAccounts),
+    [scannedAccounts, existingAccounts],
+  );
+  const unimportedBridges = useAccountBridgeMany(unimportedAccounts);
+
   useEffect(() => {
-    const unimportedAccounts = getUnimportedAccounts(scannedAccounts, existingAccounts);
-    const onlyNewAccounts = unimportedAccounts.every(isAccountEmpty);
+    const emptyChecks = unimportedAccounts.map((a, i) => unimportedBridges[i].isAccountEmpty(a));
+    const onlyNewAccounts = emptyChecks.every(Boolean);
 
     const processedAccountIds = new Set<string>();
     const freshAccounts = unimportedAccounts.filter(acc => {
-      if (processedAccountIds.has(acc.id)) {
-        return false;
-      }
+      if (processedAccountIds.has(acc.id)) return false;
       processedAccountIds.add(acc.id);
       return true;
     });
 
-    setSelectedIds(current => determineSelectedIds(freshAccounts, onlyNewAccounts, current));
-  }, [existingAccounts, scannedAccounts]);
+    setSelectedIds(current => {
+      if (onlyNewAccounts) return freshAccounts.map(x => x.id);
+      const latest = freshAccounts.at(-1);
+      if (!latest) return current;
+      const idx = unimportedAccounts.findIndex(a => a.id === latest.id);
+      const latestEmpty = idx >= 0 ? emptyChecks[idx] : true;
+      return latestEmpty ? current : [...current, latest.id];
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [unimportedAccounts]);
 
   const {
     importableAccounts,

--- a/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/ScanAccounts/utils/processAccounts.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/ScanAccounts/utils/processAccounts.test.ts
@@ -1,6 +1,5 @@
 import { Account } from "@ledgerhq/types-live";
-import { determineSelectedIds, getUnimportedAccounts } from "./processAccounts";
-import BigNumber from "bignumber.js";
+import { getUnimportedAccounts } from "./processAccounts";
 
 describe("getUnimportedAccounts", () => {
   it("should return accounts that are not in the existing accounts", () => {
@@ -24,41 +23,6 @@ describe("getUnimportedAccounts", () => {
 
     const result = getUnimportedAccounts(scannedAccounts, []);
     expect(result).toEqual([{ id: "1" }, { id: "2" }]);
-  });
-});
-
-describe("determineSelectedIds", () => {
-  it("should return all accounts if onlyNewAccounts is true", () => {
-    const accounts = [{ id: "1" }, { id: "2" }] as Account[];
-    const result = determineSelectedIds(accounts, true, []);
-    expect(result).toEqual(["1", "2"]);
-  });
-
-  it("should return current selected ids plus the latest account if not empty", () => {
-    const accounts = [
-      { id: "1" },
-      { id: "2", balance: BigNumber("100"), operationsCount: 1 },
-    ] as Account[];
-    const result = determineSelectedIds(accounts, false, ["1"]);
-    expect(result).toEqual(["1", "2"]);
-  });
-
-  it("should return current selected ids if latest account is empty", () => {
-    const accounts = [
-      { id: "1" },
-      { id: "2", balance: BigNumber("0"), operationsCount: 0 },
-    ] as Account[];
-    const result = determineSelectedIds(accounts, false, ["1"]);
-    expect(result).toEqual(["1"]);
-  });
-
-  it("should exclude empty accounts from the selection", () => {
-    const accounts = [
-      { id: "1", balance: BigNumber("0"), operationsCount: 0 },
-      { id: "2", balance: BigNumber("100"), operationsCount: 1 },
-    ] as Account[];
-    const result = determineSelectedIds(accounts, false, []);
-    expect(result).toEqual(["2"]);
   });
 });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/ScanAccounts/utils/processAccounts.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/ScanAccounts/utils/processAccounts.ts
@@ -1,4 +1,3 @@
-import { isAccountEmpty } from "@ledgerhq/live-common/account/index";
 import { groupAddAccounts } from "@ledgerhq/live-wallet/addAccounts";
 import { Account, DerivationMode } from "@ledgerhq/types-live";
 
@@ -13,21 +12,6 @@ export const getUnimportedAccounts = (scanned: Account[], existing: Account[]): 
     seen.add(acc.id);
     return true;
   });
-};
-
-export const determineSelectedIds = (
-  accounts: Account[],
-  onlyNewAccounts: boolean,
-  currentSelectedIds: string[],
-) => {
-  if (onlyNewAccounts) {
-    return accounts.map(x => x.id);
-  }
-
-  const latestAccount = accounts.at(-1);
-  return latestAccount && !isAccountEmpty(latestAccount)
-    ? [...currentSelectedIds, latestAccount.id]
-    : currentSelectedIds;
 };
 
 export const getGroupedAccounts = (

--- a/apps/ledger-live-desktop/src/mvvm/hooks/useAccountStatus.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/useAccountStatus.ts
@@ -1,5 +1,8 @@
 import { useSelector } from "./redux";
-import { areAccountsEmptySelector, hasAccountsSelector } from "~/renderer/reducers/accounts";
+import {
+  hasAccountsSelector,
+  useAreAccountsEmpty,
+} from "~/renderer/reducers/accounts";
 
 /**
  * Hook to determine the status of user accounts and funds.
@@ -7,7 +10,7 @@ import { areAccountsEmptySelector, hasAccountsSelector } from "~/renderer/reduce
  */
 export const useAccountStatus = () => {
   const hasAccount = useSelector(hasAccountsSelector);
-  const areAccountsEmpty = useSelector(areAccountsEmptySelector);
+  const areAccountsEmpty = useAreAccountsEmpty();
   const hasFunds = !areAccountsEmpty && hasAccount;
 
   return {

--- a/apps/ledger-live-desktop/src/renderer/actions/accounts.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/accounts.ts
@@ -1,8 +1,10 @@
 import { Account, AccountUserData } from "@ledgerhq/types-live";
 import { AccountComparator } from "@ledgerhq/live-wallet/ordering";
+import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { getKey } from "~/renderer/storage";
 import { PasswordIncorrectError } from "@ledgerhq/errors";
 import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
+import { accountsSelector } from "~/renderer/reducers/accounts";
 import { ThunkResult } from "./types";
 
 export const removeAccount = (payload: Account) => ({
@@ -68,4 +70,15 @@ export const updateAccount: UpdateAccount = payload => ({
   },
 });
 
-export const cleanAccountsCache = () => ({ type: "CLEAN_ACCOUNTS_CACHE" });
+export const cleanAccountsCache =
+  (): ThunkResult<Promise<void>> =>
+  async (dispatch, getState) => {
+    const accounts = accountsSelector(getState());
+    const cleared = await Promise.all(
+      accounts.map(async account => {
+        const bridge = await getAccountBridge(account);
+        return bridge.clearAccount(account);
+      }),
+    );
+    dispatch(replaceAccounts(cleared));
+  };

--- a/apps/ledger-live-desktop/src/renderer/components/OperationsList/DateCell.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OperationsList/DateCell.tsx
@@ -1,4 +1,3 @@
-import { isStuckOperation } from "@ledgerhq/live-common/operation";
 import { InfiniteLoader, IconsLegacy } from "@ledgerhq/react-ui";
 import { Operation } from "@ledgerhq/types-live";
 import { TFunction } from "i18next";
@@ -19,11 +18,11 @@ const Cell = styled(Box).attrs(() => ({
 
 type Props = {
   t: TFunction;
-  family: string;
   operation: Operation;
   text?: string;
   compact?: boolean;
   editable?: boolean;
+  isStuck?: boolean;
 };
 
 const PendingLoadingIcon = ({ displayWarning }: { displayWarning: boolean }): React.JSX.Element => {
@@ -38,7 +37,7 @@ const PendingLoadingIcon = ({ displayWarning }: { displayWarning: boolean }): Re
   return <InfiniteLoader size={12} style={{ verticalAlign: "middle" }} />;
 };
 
-const DateCell = ({ t, family, operation, compact, text, editable }: Props): React.JSX.Element => {
+const DateCell = ({ t, operation, compact, text, editable, isStuck }: Props): React.JSX.Element => {
   const ellipsis = {
     display: "block",
     textOverflow: "ellipsis",
@@ -61,7 +60,7 @@ const DateCell = ({ t, family, operation, compact, text, editable }: Props): Rea
       {editable ? (
         <Box fontSize={3} color="neutral.c80">
           <Box ff="Inter|SemiBold" fontSize={3} color="neutral.c80" style={ellipsis}>
-            <PendingLoadingIcon displayWarning={isStuckOperation({ family, operation })} />
+            <PendingLoadingIcon displayWarning={!!isStuck} />
             <Box
               style={{
                 marginLeft: "4px",

--- a/apps/ledger-live-desktop/src/renderer/components/OperationsList/EditOperationPanel.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OperationsList/EditOperationPanel.tsx
@@ -1,4 +1,5 @@
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { Account, AccountLike, Operation } from "@ledgerhq/types-live";
 import React, { memo, useCallback, useMemo } from "react";
@@ -22,6 +23,7 @@ const EditOperationPanel = (props: Props) => {
   const { enabled: isEditBitcoinTxEnabled, params: bitcoinParams } =
     useFeature("editBitcoinTx") ?? {};
   const mainAccount = getMainAccount(account, parentAccount);
+  const bridge = useAccountBridge(mainAccount);
 
   // Determine if transaction editing is supported and which modal to use
   const editConfig = useMemo(() => {
@@ -31,6 +33,7 @@ const EditOperationPanel = (props: Props) => {
       parentAccount,
       mainAccount,
       operation,
+      bridge,
       featureFlags: {
         evm: {
           enabled: isEditEvmTxEnabled ?? false,
@@ -55,6 +58,7 @@ const EditOperationPanel = (props: Props) => {
     parentAccount,
     operation,
     mainAccount,
+    bridge,
     isEditEvmTxEnabled,
     params,
     isEditBitcoinTxEnabled,

--- a/apps/ledger-live-desktop/src/renderer/components/OperationsList/Operation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OperationsList/Operation.tsx
@@ -6,6 +6,7 @@ import Box from "~/renderer/components/Box";
 import { TFunction } from "i18next";
 import { AccountLike, Account, Operation } from "@ledgerhq/types-live";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import ConfirmationCell from "./ConfirmationCell";
 import DateCell from "./DateCell";
 import AccountCell from "./AccountCell";
@@ -40,7 +41,6 @@ type OwnProps = {
   withAccount?: boolean;
   withAddress?: boolean;
   text?: string;
-  editable?: boolean;
 };
 type Props = OwnProps;
 
@@ -51,11 +51,11 @@ function OperationComponent({
   onOperationClick,
   t,
   text,
-  editable,
   withAddress = true,
   withAccount = false,
 }: Props) {
   const mainAccount = getMainAccount(account, parentAccount);
+  const bridge = useAccountBridge(mainAccount);
   const confirmationsNb = useSelector((state: State) =>
     confirmationsNbForCurrencySelector(state, mainAccount),
   );
@@ -73,6 +73,7 @@ function OperationComponent({
   const isConfirmed = isConfirmedOperation(operation, mainAccount, confirmationsNb);
   const specific = getLLDCoinFamily(cryptoCurrency.family);
   const CustomMetadataCell = specific ? specific.operationDetails?.customMetadataCell : null;
+  const editable = mainAccount.type === "Account" && bridge.isEditableOperation(mainAccount, operation);
 
   return (
     <OperationRow
@@ -88,10 +89,10 @@ function OperationComponent({
         isConfirmed={isConfirmed}
       />
       <DateCell
-        family={mainAccount.currency.family}
         text={text}
         operation={operation}
         editable={editable}
+        isStuck={bridge.isStuckOperation(operation)}
         t={t}
       />
       {withAccount && <AccountCell accountName={accountName} currency={currency} />}

--- a/apps/ledger-live-desktop/src/renderer/components/OperationsList/OperationsListV1/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OperationsList/OperationsListV1/index.tsx
@@ -10,7 +10,6 @@ import {
   groupAccountOperationsByDay,
   groupAccountsOperationsByDay,
   flattenAccounts,
-  getMainAccount,
 } from "@ledgerhq/live-common/account/index";
 import logger from "~/renderer/logger";
 import { openModal } from "~/renderer/actions/modals";
@@ -25,7 +24,6 @@ import OperationC from "../Operation";
 import TableContainer, { TableHeader } from "../../TableContainer";
 import { OperationDetails } from "~/renderer/drawers/OperationDetails";
 import { setDrawer } from "~/renderer/drawers/Provider";
-import { isEditableOperation } from "@ledgerhq/live-common/operation";
 
 const ShowMore = styled(Box).attrs(() => ({
   horizontal: true,
@@ -153,7 +151,6 @@ export class OperationsList extends PureComponent<Props, State> {
                     return null;
                   }
                 }
-                const mainAccount = getMainAccount(account, parentAccount);
                 return (
                   <OperationC
                     operation={operation}
@@ -163,7 +160,6 @@ export class OperationsList extends PureComponent<Props, State> {
                     onOperationClick={this.handleClickOperation}
                     t={t}
                     withAccount={withAccount}
-                    editable={account && isEditableOperation({ account: mainAccount, operation })}
                   />
                 );
               })}

--- a/apps/ledger-live-desktop/src/renderer/components/OperationsList/tests/EditOperationPanel.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OperationsList/tests/EditOperationPanel.test.tsx
@@ -12,6 +12,10 @@ jest.mock("@ledgerhq/live-common/account/index", () => ({
   getMainAccount: jest.fn(),
 }));
 
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  useAccountBridge: () => ({}),
+}));
+
 jest.mock("~/renderer/actions/modals", () => ({
   ...jest.requireActual("~/renderer/actions/modals"),
   closeModal: jest.fn(),

--- a/apps/ledger-live-desktop/src/renderer/drawers/OperationDetails/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/OperationDetails/index.tsx
@@ -15,9 +15,8 @@ import {
   getOperationAmountNumber,
   getOperationConfirmationDisplayableNumber,
   isConfirmedOperation,
-  isEditableOperation,
-  isStuckOperation,
 } from "@ledgerhq/live-common/operation";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { getEnv } from "@ledgerhq/live-env";
 import { CryptoCurrency, CryptoCurrencyId } from "@ledgerhq/types-cryptoassets";
 import { Account, AccountLike, Operation, OperationType } from "@ledgerhq/types-live";
@@ -143,6 +142,7 @@ const OperationD = (props: Props) => {
   const navigate = useNavigate();
   const location = useLocation();
   const mainAccount = getMainAccount(account, parentAccount);
+  const bridge = useAccountBridge(mainAccount);
   const { hash, date, senders, type, fee, recipients: _recipients } = operation;
 
   const dateFormatted = useDateFormatted(date, dayAndHourFormat);
@@ -260,7 +260,7 @@ const OperationD = (props: Props) => {
     // Check for Bitcoin RBF support
     if (currencyFamily === "bitcoin") {
       // RBF only works for unconfirmed (pending) transactions
-      const isEditable = isEditableOperation({ account: mainAccount, operation });
+      const isEditable = bridge.isEditableOperation(mainAccount, operation);
       if (
         !isEditable ||
         !bitcoinParams?.supportedCurrencyIds?.includes(mainAccount.currency.id as CryptoCurrencyId)
@@ -290,7 +290,7 @@ const OperationD = (props: Props) => {
       const isCurrencySupported =
         params?.supportedCurrencyIds?.includes(mainAccount.currency.id as CryptoCurrencyId) ||
         false;
-      const isEditable = isEditableOperation({ account: mainAccount, operation });
+      const isEditable = bridge.isEditableOperation(mainAccount, operation);
 
       if (isEditEvmTxEnabled && isCurrencySupported && isEditable) {
         return {
@@ -308,6 +308,7 @@ const OperationD = (props: Props) => {
     params,
     mainAccount,
     operation,
+    bridge,
     bitcoinParams?.supportedCurrencyIds,
     isEditBitcoinTxEnabled,
   ]);
@@ -374,7 +375,7 @@ const OperationD = (props: Props) => {
     operation.hash,
   ]);
 
-  const isStuck = isStuckOperation({ family: mainAccount.currency.family, operation });
+  const isStuck = bridge.isStuckOperation(operation);
   const feesCurrency = useMemo(() => getFeesCurrency(mainAccount), [mainAccount]);
   const feesUnit = useMemo(() => getFeesUnit(feesCurrency), [feesCurrency]);
 

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/AccountHeaderManageActions.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/AccountHeaderManageActions.tsx
@@ -1,6 +1,6 @@
 import { useDispatch } from "LLD/hooks/redux";
 import { useTranslation } from "react-i18next";
-import { isAccountEmpty } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { openModal } from "~/renderer/actions/modals";
 import IconTransfer from "~/renderer/icons/Transfer";
 import type { AleoFamily } from "./types";
@@ -9,12 +9,13 @@ import { AleoCustomModal } from "./constants";
 const AccountHeaderActions: AleoFamily["accountHeaderManageActions"] = ({ account }) => {
   const dispatch = useDispatch();
   const { t } = useTranslation();
+  const bridge = useAccountBridge(account);
 
   if (account.type !== "Account") {
     return [];
   }
 
-  const isSelfTransferDisabled = isAccountEmpty(account);
+  const isSelfTransferDisabled = bridge.isAccountEmpty(account);
 
   const onClick = () => {
     dispatch(openModal(AleoCustomModal.SELF_TRANSFER, { account }));

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/__tests__/AccountHeaderManageActions.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/__tests__/AccountHeaderManageActions.test.tsx
@@ -6,6 +6,10 @@ import AccountHeaderActions from "../AccountHeaderManageActions";
 import { AleoCustomModal } from "../constants";
 import { ALEO_ACCOUNT_1, NEW_ALEO_ACCOUNT } from "../__mocks__/account.mock";
 
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  useAccountBridge: () => ({ isAccountEmpty: (a: { balance: { isZero: () => boolean } }) => a.balance.isZero() }),
+}));
+
 describe("AccountHeaderManageActions", () => {
   const hook = AccountHeaderActions;
   invariant(hook, "aleo: type guard AccountHeaderActions");

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/__tests__/addAccountFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/__tests__/addAccountFlow.test.tsx
@@ -34,6 +34,8 @@ const mockAccountBridge = {
   assignToAccountRaw: () => {},
   assignToTokenAccountRaw: () => {},
   toOperationExtraRaw: (extra: unknown) => extra,
+  isAccountEmpty: (a: { operationsCount: number; balance: { isZero: () => boolean } }) =>
+    a.operationsCount === 0 && a.balance.isZero(),
 };
 
 const mockNavigate = jest.fn();

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/EditStuckTransactionPanelBodyHeader.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/EditStuckTransactionPanelBodyHeader.tsx
@@ -1,6 +1,6 @@
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
-import { getStuckAccountAndOperation } from "@ledgerhq/coin-bitcoin/operation";
 import { CryptoCurrencyId } from "@ledgerhq/types-cryptoassets";
 import { Account, AccountLike } from "@ledgerhq/types-live";
 import invariant from "invariant";
@@ -16,6 +16,7 @@ type Props = {
 const EditStuckTransactionPanelBodyHeader = ({ account, parentAccount }: Props) => {
   invariant(account, "account required");
 
+  const bridge = useAccountBridge(account, parentAccount);
   const mainAccount = getMainAccount(account, parentAccount);
   const { enabled: isEditBitcoinTxEnabled, params: bitcoinParams } =
     useFeature("editBitcoinTx") ?? {};
@@ -27,7 +28,7 @@ const EditStuckTransactionPanelBodyHeader = ({ account, parentAccount }: Props) 
     return null;
   }
   // check if there is a stuck transaction. If so, display a warning panel with "speed up or cancel" button
-  const stuckAccountAndOperation = getStuckAccountAndOperation(account, parentAccount);
+  const stuckAccountAndOperation = bridge.getStuckAccountAndOperation(account, parentAccount);
 
   if (!stuckAccountAndOperation) {
     return null;

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/__tests__/EditTransactionComponents.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/__tests__/EditTransactionComponents.test.tsx
@@ -2,7 +2,7 @@ import BigNumber from "bignumber.js";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getFormattedFeeFields } from "@ledgerhq/coin-bitcoin/editTransaction/index";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getStuckAccountAndOperation } from "@ledgerhq/coin-bitcoin/operation";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import React from "react";
 import { render, screen, withFlagOverrides } from "tests/testSetup";
 import EditStuckTransactionPanelBodyHeader from "../EditStuckTransactionPanelBodyHeader";
@@ -20,10 +20,14 @@ jest.mock("@ledgerhq/live-common/account/index", () => ({
   getMainAccount: jest.fn(),
 }));
 
-jest.mock("@ledgerhq/coin-bitcoin/operation", () => ({
-  ...jest.requireActual("@ledgerhq/coin-bitcoin/operation"),
-  getStuckAccountAndOperation: jest.fn(),
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  useAccountBridge: jest.fn(),
 }));
+
+const mockGetStuckAccountAndOperation = jest.fn();
+(useAccountBridge as jest.Mock).mockReturnValue({
+  getStuckAccountAndOperation: mockGetStuckAccountAndOperation,
+});
 
 jest.mock("~/renderer/modals/Send/SendAmountFields", () => ({
   __esModule: true,
@@ -126,7 +130,7 @@ describe("Bitcoin EditTransaction components", () => {
   });
 
   it("EditStuckTransactionPanelBodyHeader renders panel when enabled and stuck tx exists", () => {
-    (getStuckAccountAndOperation as jest.Mock).mockReturnValue({
+    mockGetStuckAccountAndOperation.mockReturnValue({
       operation: {},
       account,
       parentAccount: undefined,

--- a/apps/ledger-live-desktop/src/renderer/families/celo/AccountHeaderManageActions/AccountHeaderManageActions.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/AccountHeaderManageActions/AccountHeaderManageActions.tsx
@@ -1,4 +1,4 @@
-import { isAccountEmpty } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { isAccountRegistrationPending } from "@ledgerhq/live-common/families/celo/logic";
 import { CeloAccount } from "@ledgerhq/live-common/families/celo/types";
 import React, { useCallback } from "react";
@@ -17,10 +17,11 @@ const AccountHeaderManageActions: CeloFamily["accountHeaderManageActions"] = ({
 }) => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
+  const bridge = useAccountBridge(account, parentAccount);
   const label = useGetStakeLabelLocaleBased();
   const isRegistrationPending = isAccountRegistrationPending(account as CeloAccount);
   const onClick = useCallback(() => {
-    if (isAccountEmpty(account)) {
+    if (bridge.isAccountEmpty(account)) {
       dispatch(
         openModal("MODAL_NO_FUNDS_STAKE", {
           account,
@@ -37,7 +38,7 @@ const AccountHeaderManageActions: CeloFamily["accountHeaderManageActions"] = ({
         );
       }
     }
-  }, [account, dispatch, parentAccount, source]);
+  }, [account, bridge, dispatch, parentAccount, source]);
   const disabledLabel = isRegistrationPending
     ? `${t("celo.manage.titleWhenPendingRegistration")}`
     : "";

--- a/apps/ledger-live-desktop/src/renderer/families/evm/AccountHeaderManageActions.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/AccountHeaderManageActions.ts
@@ -1,7 +1,7 @@
 import { Account, AccountLike } from "@ledgerhq/types-live";
 import { useCallback } from "react";
 import { openModal } from "~/renderer/actions/modals";
-import { isAccountEmpty } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useGetStakeLabelLocaleBased } from "~/renderer/hooks/useGetStakeLabelLocaleBased";
 import { useNavigate } from "react-router";
 import { useStake } from "LLD/hooks/useStake";
@@ -18,6 +18,7 @@ type Props = {
 const AccountHeaderActions = ({ account, parentAccount }: Props) => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
+  const bridge = useAccountBridge(account, parentAccount);
   const label = useGetStakeLabelLocaleBased();
   const walletState = useSelector(walletSelector);
   const { getRouteToPlatformApp } = useStake();
@@ -45,7 +46,7 @@ const AccountHeaderActions = ({ account, parentAccount }: Props) => {
   );
 
   const onClickStakeModal = useCallback(() => {
-    if (isAccountEmpty(account)) {
+    if (bridge.isAccountEmpty(account)) {
       dispatch(
         openModal("MODAL_NO_FUNDS_STAKE", {
           account,
@@ -69,7 +70,7 @@ const AccountHeaderActions = ({ account, parentAccount }: Props) => {
         }),
       );
     }
-  }, [account, dispatch, parentAccount, getRouteToPlatformApp, walletState, navigate]);
+  }, [account, bridge, dispatch, parentAccount, getRouteToPlatformApp, walletState, navigate]);
 
   const getStakeAction = useCallback(() => {
     if (isEthereumAccount) {

--- a/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/EditStuckTransactionPanelBodyHeader.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/EditStuckTransactionPanelBodyHeader.tsx
@@ -1,6 +1,6 @@
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
-import { getStuckAccountAndOperation } from "@ledgerhq/live-common/operation";
 import { CryptoCurrencyId } from "@ledgerhq/types-cryptoassets";
 import { Account, AccountLike } from "@ledgerhq/types-live";
 import invariant from "invariant";
@@ -15,6 +15,7 @@ type Props = {
 const EditStuckTransactionPanelBodyHeader = ({ account, parentAccount }: Props) => {
   invariant(account, "account required");
 
+  const bridge = useAccountBridge(account, parentAccount);
   const mainAccount = getMainAccount(account, parentAccount);
   const { enabled: isEditEvmTxEnabled, params } = useFeature("editEvmTx") ?? {};
   const isCurrencySupported =
@@ -24,7 +25,7 @@ const EditStuckTransactionPanelBodyHeader = ({ account, parentAccount }: Props) 
     return null;
   }
   // check if there is a stuck transaction. If so, display a warning panel with "speed up or cancel" button
-  const stuckAccountAndOperation = getStuckAccountAndOperation(account, parentAccount);
+  const stuckAccountAndOperation = bridge.getStuckAccountAndOperation(account, parentAccount);
 
   return (
     <SharedEditStuckTransactionPanelBodyHeader

--- a/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/__tests__/EditTransactionComponents.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/__tests__/EditTransactionComponents.test.tsx
@@ -2,7 +2,7 @@ import BigNumber from "bignumber.js";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getFormattedFeeFields } from "@ledgerhq/coin-evm/editTransaction/index";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getStuckAccountAndOperation } from "@ledgerhq/live-common/operation";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import React from "react";
 import { render, screen, withFlagOverrides } from "tests/testSetup";
 import EditStuckTransactionPanelBodyHeader from "../EditStuckTransactionPanelBodyHeader";
@@ -20,10 +20,14 @@ jest.mock("@ledgerhq/live-common/account/index", () => ({
   getMainAccount: jest.fn(),
 }));
 
-jest.mock("@ledgerhq/live-common/operation", () => ({
-  ...jest.requireActual("@ledgerhq/live-common/operation"),
-  getStuckAccountAndOperation: jest.fn(),
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  useAccountBridge: jest.fn(),
 }));
+
+const mockGetStuckAccountAndOperation = jest.fn();
+(useAccountBridge as jest.Mock).mockReturnValue({
+  getStuckAccountAndOperation: mockGetStuckAccountAndOperation,
+});
 
 jest.mock("~/renderer/components/SpeedUpCancel/SharedStepFees", () => ({
   SharedStepFees: ({
@@ -188,7 +192,7 @@ describe("EVM EditTransaction components", () => {
   });
 
   it("EditStuckTransactionPanelBodyHeader forwards feature/status to shared header", () => {
-    (getStuckAccountAndOperation as jest.Mock).mockReturnValue({
+    mockGetStuckAccountAndOperation.mockReturnValue({
       operation: {},
       account,
       parentAccount: undefined,

--- a/apps/ledger-live-desktop/src/renderer/families/evm/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/index.ts
@@ -1,5 +1,4 @@
 import { getMessageProperties } from "@ledgerhq/coin-evm/logic";
-import { isEditableOperation } from "@ledgerhq/live-common/operation";
 import AccountBalanceSummaryFooter from "./AccountBalanceSummaryFooter";
 import AccountBodyHeader from "./AccountBodyHeader";
 import AccountFooter from "./AccountFooter";
@@ -23,14 +22,14 @@ const family: EvmFamily = {
   message: {
     getMessageProperties,
   },
-  handlesEditTransaction: ({ account, parentAccount, mainAccount, operation, featureFlags }) => {
+  handlesEditTransaction: ({ account, parentAccount, mainAccount, operation, bridge, featureFlags }) => {
     if (!operation.transactionRaw) {
       return null;
     }
 
     const isCurrencySupported =
       featureFlags.evm.supportedCurrencyIds?.includes(mainAccount.currency.id) || false;
-    const isEditable = isEditableOperation({ account: mainAccount, operation });
+    const isEditable = bridge.isEditableOperation(mainAccount, operation);
 
     if (!featureFlags.evm.enabled || !isCurrencySupported || !isEditable) {
       return null;

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/AccountHeaderManageActions.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/AccountHeaderManageActions.tsx
@@ -1,6 +1,6 @@
 import { useDispatch } from "LLD/hooks/redux";
 import { useTranslation } from "react-i18next";
-import { isAccountEmpty } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { openModal } from "~/renderer/actions/modals";
 import { useGetStakeLabelLocaleBased } from "~/renderer/hooks/useGetStakeLabelLocaleBased";
 import IconCoins from "~/renderer/icons/Coins";
@@ -12,6 +12,7 @@ const AccountHeaderActions: HederaFamily["accountHeaderManageActions"] = ({ acco
   const dispatch = useDispatch();
   const { t } = useTranslation();
   const { getCanStakeCurrency } = useStake();
+  const bridge = useAccountBridge(account);
 
   if (account.type !== "Account") {
     return [];
@@ -25,7 +26,7 @@ const AccountHeaderActions: HederaFamily["accountHeaderManageActions"] = ({ acco
   }
 
   const onClick = () => {
-    const modalKey = isAccountEmpty(account) ? "MODAL_NO_FUNDS_STAKE" : "MODAL_HEDERA_DELEGATION";
+    const modalKey = bridge.isAccountEmpty(account) ? "MODAL_NO_FUNDS_STAKE" : "MODAL_HEDERA_DELEGATION";
     dispatch(openModal(modalKey, { account }));
   };
 

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/AccountHeaderManageActions.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/AccountHeaderManageActions.ts
@@ -5,7 +5,8 @@ import {
   hasExternalStash,
   hasPendingOperationType,
 } from "@ledgerhq/live-common/families/polkadot/logic";
-import { getMainAccount, isAccountEmpty } from "@ledgerhq/live-common/account/index";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import IconCoins from "~/renderer/icons/Coins";
 import { PolkadotAccount } from "@ledgerhq/live-common/families/polkadot/types";
 import { useGetStakeLabelLocaleBased } from "~/renderer/hooks/useGetStakeLabelLocaleBased";
@@ -23,6 +24,7 @@ const AccountHeaderManageActions = ({ account, parentAccount, source = "Account 
   const { t } = useTranslation();
   const label = useGetStakeLabelLocaleBased();
   const dispatch = useDispatch();
+  const bridge = useAccountBridge(account, parentAccount);
   const mainAccount = getMainAccount(account, parentAccount);
   const { polkadotResources } = mainAccount;
   const hasBondedBalance = polkadotResources.lockedBalance && polkadotResources.lockedBalance.gt(0);
@@ -42,27 +44,25 @@ const AccountHeaderManageActions = ({ account, parentAccount, source = "Account 
               : `/account/${account.id}`,
         },
       });
+    } else if (bridge.isAccountEmpty(mainAccount)) {
+      dispatch(
+        openModal("MODAL_NO_FUNDS_STAKE", {
+          account: mainAccount,
+        }),
+      );
+    } else if (hasBondedBalance || hasPendingBondOperation) {
+      dispatch(
+        openModal("MODAL_POLKADOT_MANAGE", {
+          account: mainAccount,
+          source,
+        }),
+      );
     } else {
-      if (isAccountEmpty(mainAccount)) {
-        dispatch(
-          openModal("MODAL_NO_FUNDS_STAKE", {
-            account: mainAccount,
-          }),
-        );
-      } else if (hasBondedBalance || hasPendingBondOperation) {
-        dispatch(
-          openModal("MODAL_POLKADOT_MANAGE", {
-            account: mainAccount,
-            source,
-          }),
-        );
-      } else {
-        dispatch(
-          openModal("MODAL_POLKADOT_REWARDS_INFO", {
-            account: mainAccount,
-          }),
-        );
-      }
+      dispatch(
+        openModal("MODAL_POLKADOT_REWARDS_INFO", {
+          account: mainAccount,
+        }),
+      );
     }
   };
 

--- a/apps/ledger-live-desktop/src/renderer/families/solana/AccountHeaderManageActions.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/AccountHeaderManageActions.ts
@@ -1,4 +1,5 @@
-import { getMainAccount, isAccountEmpty } from "@ledgerhq/live-common/account/index";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useCallback } from "react";
 import { useDispatch } from "LLD/hooks/redux";
 import { openModal } from "~/renderer/actions/modals";
@@ -12,12 +13,13 @@ const AccountHeaderActions: SolanaFamily["accountHeaderManageActions"] = ({
   source,
 }) => {
   const dispatch = useDispatch();
+  const bridge = useAccountBridge(account, parentAccount);
   const label = useGetStakeLabelLocaleBased();
   const mainAccount = getMainAccount(account, parentAccount);
   const { solanaResources } = mainAccount;
 
   const onClick = useCallback(() => {
-    if (isAccountEmpty(account)) {
+    if (bridge.isAccountEmpty(account)) {
       dispatch(
         openModal("MODAL_NO_FUNDS_STAKE", {
           account,
@@ -36,7 +38,7 @@ const AccountHeaderActions: SolanaFamily["accountHeaderManageActions"] = ({
         ),
       );
     }
-  }, [account, dispatch, source, solanaResources, mainAccount]);
+  }, [account, bridge, dispatch, source, solanaResources, mainAccount]);
 
   if (account.type === "TokenAccount") {
     return null;

--- a/apps/ledger-live-desktop/src/renderer/families/solana/StakeBanner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/StakeBanner.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import { StakeAccountBannerParams } from "~/renderer/screens/account/types";
 import { useSolanaStakesWithMeta } from "@ledgerhq/live-common/families/solana/react";
 import { getAccountBannerState as getSolanaBannerState } from "@ledgerhq/live-common/families/solana/banner";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { openModal } from "~/renderer/actions/modals";
 import { useDispatch } from "LLD/hooks/redux";
 import { SolanaAccount } from "@ledgerhq/live-common/families/solana/types";
@@ -21,7 +22,8 @@ const StakeBanner: React.FC<{ account: SolanaAccount }> = ({ account }) => {
   );
   const stakeAccountBannerParams: StakeAccountBannerParams | null =
     stakeAccountBanner?.params ?? null;
-  const state = getSolanaBannerState(account);
+  const bridge = useAccountBridge(account);
+  const state = getSolanaBannerState(account, bridge);
   const { redelegate, display, ledgerValidator, stakeAccAddr } = state;
 
   if (redelegate && !stakeAccountBannerParams?.solana?.redelegate) return null;

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/AccountHeaderManageActions.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/AccountHeaderManageActions.ts
@@ -1,4 +1,4 @@
-import { isAccountEmpty } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useTezosStakingInfo } from "@ledgerhq/live-common/families/tezos/react";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { useCallback } from "react";
@@ -15,13 +15,14 @@ const AccountHeaderManageActions: TezosFamily["accountHeaderManageActions"] = ({
   source,
 }) => {
   const dispatch = useDispatch();
+  const bridge = useAccountBridge(account, parentAccount);
   const label = useGetStakeLabelLocaleBased();
   const lldTezosStaking = useFeature("lldTezosStaking");
 
   const { delegation, isDelegated, isStaked } = useTezosStakingInfo(account);
 
   const onClick = useCallback(() => {
-    if (isAccountEmpty(account)) {
+    if (bridge.isAccountEmpty(account)) {
       dispatch(
         openModal("MODAL_NO_FUNDS_STAKE", {
           account,
@@ -56,6 +57,7 @@ const AccountHeaderManageActions: TezosFamily["accountHeaderManageActions"] = ({
     dispatch(openModal("MODAL_DELEGATE", options));
   }, [
     account,
+    bridge,
     delegation,
     isDelegated,
     isStaked,

--- a/apps/ledger-live-desktop/src/renderer/families/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/types.ts
@@ -16,6 +16,7 @@ import {
   FeeStrategy,
   Operation,
   OperationType,
+  ResolvedAccountBridge,
   TokenAccount,
   TransactionCommon,
   TransactionCommonRaw,
@@ -478,6 +479,8 @@ export type LLDCoinFamily<
     parentAccount: A | undefined;
     mainAccount: A;
     operation: O;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    bridge: ResolvedAccountBridge<any>;
     featureFlags: EditTransactionFeatureFlags;
   }) => EditTransactionModalConfig | null;
 

--- a/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/steps/StepImport.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/steps/StepImport.tsx
@@ -3,14 +3,14 @@ import { useDispatch } from "LLD/hooks/redux";
 import styled from "styled-components";
 import { Trans } from "react-i18next";
 import { concat, from, Subscription } from "rxjs";
-import { ignoreElements, filter, map, retry } from "rxjs/operators";
+import { ignoreElements, filter, map, retry, concatMap } from "rxjs/operators";
 import { Account } from "@ledgerhq/types-live";
-import { isAccountEmpty } from "@ledgerhq/live-common/account/index";
 import { isCantonAccount } from "@ledgerhq/coin-canton/bridge/serialization";
 import { isConcordiumAccount } from "@ledgerhq/coin-concordium/bridge/serialization";
 import { openModal } from "~/renderer/actions/modals";
 import { DeviceShouldStayInApp, UnresponsiveDeviceError } from "@ledgerhq/errors";
-import { getCurrencyBridge } from "@ledgerhq/live-common/bridge/index";
+import { getAccountBridge, getCurrencyBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridgeMany } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import uniq from "lodash/uniq";
 import { urls } from "~/config/urls";
 import logger from "~/renderer/logger";
@@ -148,13 +148,17 @@ class StepImport extends PureComponent<
           filter(e => e.type === "discovered"),
           map(e => e.account),
           retry(2), //needs to retry to output proper error message
+          concatMap(account =>
+            from(Promise.resolve(getAccountBridge(account))).pipe(
+              map(accountBridge => ({ account, isNewAccount: accountBridge.isAccountEmpty(account) })),
+            ),
+          ),
         )
         .subscribe({
-          next: account => {
+          next: ({ account, isNewAccount }) => {
             const { scannedAccounts, checkedAccountsIds, existingAccounts } = this.props;
             const hasAlreadyBeenScanned = !!scannedAccounts.find(a => account.id === a.id);
             const hasAlreadyBeenImported = !!existingAccounts.find(a => account.id === a.id);
-            const isNewAccount = isAccountEmpty(account);
             if (!isNewAccount && !hasAlreadyBeenImported) {
               onlyNewAccounts = false;
             }
@@ -387,14 +391,12 @@ export const StepImportFooter = ({
   editedNames,
 }: StepProps) => {
   const dispatch = useDispatch();
-  const willCreateAccount = checkedAccountsIds.some(id => {
-    const account = scannedAccounts.find(a => a.id === id);
-    return account && isAccountEmpty(account);
-  });
-  const willAddAccounts = checkedAccountsIds.some(id => {
-    const account = scannedAccounts.find(a => a.id === id);
-    return account && !isAccountEmpty(account);
-  });
+  const checkedAccounts = checkedAccountsIds
+    .map(id => scannedAccounts.find(a => a.id === id))
+    .filter((a): a is Account => !!a);
+  const checkedBridges = useAccountBridgeMany(checkedAccounts);
+  const willCreateAccount = checkedAccounts.some((a, i) => checkedBridges[i].isAccountEmpty(a));
+  const willAddAccounts = checkedAccounts.some((a, i) => !checkedBridges[i].isAccountEmpty(a));
   const count = checkedAccountsIds.length;
   const willClose = !willCreateAccount && !willAddAccounts;
 

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepRecipient.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepRecipient.test.tsx
@@ -8,6 +8,9 @@ import { getLLDCoinFamily } from "~/renderer/families";
 import StepRecipient from "./StepRecipient";
 
 jest.mock("~/renderer/families");
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  useAccountBridgeOrNull: () => ({ getStuckAccountAndOperation: () => undefined }),
+}));
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 const mockTFunction: jest.Mock<TFunction> = jest.fn(key => key) as unknown as jest.Mock<TFunction>;

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepRecipient.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepRecipient.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react";
-import { getStuckAccountAndOperation } from "@ledgerhq/live-common/operation";
+import { useAccountBridgeOrNull } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Trans } from "react-i18next";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import TrackPage from "~/renderer/analytics/TrackPage";
@@ -59,6 +59,7 @@ export const DefaultStepRecipient = ({
   const forceAutoFocusOnMemoField = useSelector(forceAutoFocusOnMemoFieldSelector);
   const lldMemoTag = useFeature("lldMemoTag");
   const { isEnabledForFamily } = useNewSendFlowFeature();
+  const bridge = useAccountBridgeOrNull(account ?? null, parentAccount);
 
   const accountFilter = useMemo(
     () => (acc: Account) => {
@@ -74,7 +75,7 @@ export const DefaultStepRecipient = ({
   const extensions = getTokenExtensions(account);
 
   // check if there is a stuck transaction. If so, display a warning panel with "speed up or cancel" button
-  const stuckAccountAndOperation = getStuckAccountAndOperation(account, parentAccount);
+  const stuckAccountAndOperation = bridge?.getStuckAccountAndOperation(account, parentAccount);
 
   return (
     <Box flow={4}>

--- a/apps/ledger-live-desktop/src/renderer/reducers/accounts.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/accounts.ts
@@ -3,11 +3,11 @@ import { handleActions } from "redux-actions";
 import { Account, AccountUserData, AccountLike } from "@ledgerhq/types-live";
 import {
   flattenAccounts,
-  clearAccount,
   getAccountCurrency,
   isUpToDateAccount,
-  isAccountEmpty,
 } from "@ledgerhq/live-common/account/index";
+import { useAccountBridgeMany } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { useSelector } from "LLD/hooks/redux";
 
 import isEqual from "lodash/isEqual";
 import { State } from ".";
@@ -33,7 +33,6 @@ type HandlersPayloads = {
   ADD_ACCOUNTS: AddAccountsAction["payload"];
   UPDATE_ACCOUNT: { accountId: string; updater: (a: Account) => Account };
   REMOVE_ACCOUNT: Account;
-  CLEAN_ACCOUNTS_CACHE: never;
   REPLACE_ACCOUNTS: Account[];
 };
 
@@ -51,7 +50,6 @@ const handlers: AccountsHandlers = {
       return updater(existingAccount);
     }),
   REMOVE_ACCOUNT: (state, { payload: account }) => state.filter(acc => acc.id !== account.id),
-  CLEAN_ACCOUNTS_CACHE: state => state.map(clearAccount),
   REPLACE_ACCOUNTS: (state, { payload }) => payload,
 };
 
@@ -128,7 +126,8 @@ export const isUpToDateAccountSelector = createSelector(accountSelector, isUpToD
 
 export const flattenAccountsSelector = createSelector(accountsSelector, flattenAccounts);
 
-export const areAccountsEmptySelector = createSelector(
-  accountsSelector,
-  accounts => accounts.length > 0 && accounts.every(isAccountEmpty),
-);
+export function useAreAccountsEmpty(): boolean {
+  const accounts = useSelector(accountsSelector);
+  const bridges = useAccountBridgeMany(accounts);
+  return accounts.length > 0 && accounts.every((a, i) => bridges[i].isAccountEmpty(a));
+}

--- a/apps/ledger-live-desktop/src/renderer/screens/account/AccountHeaderActions.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/AccountHeaderActions.tsx
@@ -1,9 +1,5 @@
-import {
-  canSend,
-  getAccountCurrency,
-  getMainAccount,
-  isAccountEmpty,
-} from "@ledgerhq/live-common/account/index";
+import { canSend, getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useRampCatalog } from "@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog";
 
 import { Account, AccountLike } from "@ledgerhq/types-live";
@@ -191,6 +187,7 @@ const pageName = "Page Account";
 
 const AccountHeaderActions = ({ account, parentAccount, openModal }: Props) => {
   const { data: currenciesAll } = useFetchCurrencyAll();
+  const bridge = useAccountBridge(account, parentAccount);
   const mainAccount = getMainAccount(account, parentAccount);
   const contrastText = useTheme().colors.neutral.c70;
   const swapDefaultTrack = useGetSwapTrackingProperties();
@@ -403,7 +400,7 @@ const AccountHeaderActions = ({ account, parentAccount, openModal }: Props) => {
 
   return (
     <Box horizontal alignItems="center" justifyContent="flex-end" flow={2} mt={15}>
-      {!isAccountEmpty(account) ? NonEmptyAccountHeader : null}
+      {bridge.isAccountEmpty(account) ? null : NonEmptyAccountHeader}
     </Box>
   );
 };

--- a/apps/ledger-live-desktop/src/renderer/screens/account/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/index.tsx
@@ -8,11 +8,8 @@ import { SyncOneAccountOnMount } from "@ledgerhq/live-common/bridge/react/index"
 import { isAddressPoisoningOperation } from "@ledgerhq/live-common/operation";
 import { getCurrencyColor } from "~/renderer/getCurrencyColor";
 import { accountsSelector } from "~/renderer/reducers/accounts";
-import {
-  findSubAccountById,
-  getMainAccount,
-  isAccountEmpty,
-} from "@ledgerhq/live-common/account/index";
+import { findSubAccountById, getMainAccount } from "@ledgerhq/live-common/account/index";
+import { useAccountBridgeOrNull } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { findAccountById, findSubAccountByIdWithFallback } from "~/renderer/utils";
 import {
   setCountervalueFirst,
@@ -90,6 +87,7 @@ const AccountPage = ({
   const { shouldDisplayAssetSection } = useWalletFeaturesConfig("desktop");
   const fallbackPath = getAccountsSidebarPath(shouldDisplayAssetSection);
   const mainAccount = account ? getMainAccount(account, parentAccount) : null;
+  const bridge = useAccountBridgeOrNull(account ?? null, parentAccount);
   const specific = mainAccount ? getLLDCoinFamily(mainAccount.currency.family) : null;
   const AccountBodyHeader = specific?.AccountBodyHeader;
   const AccountSubHeader = specific?.AccountSubHeader;
@@ -117,7 +115,7 @@ const AccountPage = ({
 
   const currency = mainAccount?.currency;
 
-  if (!account || !mainAccount || !currency) {
+  if (!account || !mainAccount || !currency || !bridge) {
     return <Navigate to={fallbackPath} replace />;
   }
 
@@ -160,7 +158,9 @@ const AccountPage = ({
       {AccountSubHeader ? (
         <AccountSubHeader account={account} parentAccount={parentAccount} />
       ) : null}
-      {!isAccountEmpty(account) ? (
+      {bridge.isAccountEmpty(account) ? (
+        <EmptyStateAccount account={account} parentAccount={parentAccount} />
+      ) : (
         <>
           <Box mb={7}>
             <BalanceSummary
@@ -192,8 +192,6 @@ const AccountPage = ({
             filterOperation={filterOperations}
           />
         </>
-      ) : (
-        <EmptyStateAccount account={account} parentAccount={parentAccount} />
       )}
     </Box>
   );

--- a/apps/ledger-live-desktop/tests/jestSetup.js
+++ b/apps/ledger-live-desktop/tests/jestSetup.js
@@ -1,8 +1,7 @@
-import { registerAllCoins } from "@ledgerhq/live-common/coin-modules/load-all-coins";
+import "src/live-common-set-supported-currencies";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { liveConfig } from "@ledgerhq/live-common/config/sharedConfig";
 import { setCoinConfig } from "@ledgerhq/coin-evm/config";
-registerAllCoins();
 LiveConfig.setConfig(liveConfig);
 setCoinConfig(() => ({ info: {} }));
 import "@jest/globals";

--- a/libs/ledger-live-common/src/families/solana/banner.test.ts
+++ b/libs/ledger-live-common/src/families/solana/banner.test.ts
@@ -2,13 +2,12 @@ import * as preloadedData from "@ledgerhq/coin-solana/preload-data";
 import type { SolanaAccount, SolanaPreloadDataV1, SolanaStake } from "@ledgerhq/coin-solana/types";
 import type { ValidatorsAppValidator } from "@ledgerhq/coin-solana/network/validator-app/index";
 import { getAccountBannerState } from "./banner";
-import * as helpers from "../../account/helpers";
 
 jest.mock("@ledgerhq/coin-solana/preload-data");
-jest.mock("../../account/helpers", () => ({
-  ...jest.requireActual("../../account/helpers"),
-  isAccountEmpty: jest.fn(),
-}));
+
+const mockIsAccountEmpty = jest.fn();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockBridge = { isAccountEmpty: mockIsAccountEmpty } as any;
 
 import { BigNumber } from "bignumber.js";
 
@@ -116,7 +115,7 @@ const validatorsMap = {
   splTokens: null,
 } as SolanaPreloadDataV1;
 
-const mockedIsAccountEmpty = jest.mocked(helpers.isAccountEmpty);
+const mockedIsAccountEmpty = mockIsAccountEmpty;
 
 describe("solana/banner", () => {
   beforeEach(() => {
@@ -130,7 +129,7 @@ describe("solana/banner", () => {
   it("should not display the banner is account is", async () => {
     jest.spyOn(preloadedData, "getCurrentSolanaPreloadData").mockReturnValue(validatorsMap);
     mockedIsAccountEmpty.mockReturnValue(true);
-    const result = getAccountBannerState(account);
+    const result = getAccountBannerState(account, mockBridge);
     expect(result).toStrictEqual({
       display: false,
       redelegate: false,
@@ -141,7 +140,7 @@ describe("solana/banner", () => {
   it("should return display delegate mode is account is not empty", async () => {
     jest.spyOn(preloadedData, "getCurrentSolanaPreloadData").mockReturnValue(validatorsMap);
     mockedIsAccountEmpty.mockReturnValue(false);
-    const result = getAccountBannerState(account);
+    const result = getAccountBannerState(account, mockBridge);
     expect(result).toStrictEqual({
       display: true,
       redelegate: false,
@@ -166,7 +165,7 @@ describe("solana/banner", () => {
     jest.spyOn(preloadedData, "getCurrentSolanaPreloadData").mockReturnValue(validatorsMap);
     mockedIsAccountEmpty.mockReturnValue(false);
     account.solanaResources?.stakes.push(badValidator);
-    const result = getAccountBannerState(account);
+    const result = getAccountBannerState(account, mockBridge);
     expect(result).toStrictEqual({
       display: true,
       redelegate: true,

--- a/libs/ledger-live-common/src/families/solana/banner.ts
+++ b/libs/ledger-live-common/src/families/solana/banner.ts
@@ -3,7 +3,7 @@ import { stakeActions } from "@ledgerhq/coin-solana/logic";
 import { LEDGER_VALIDATORS_VOTE_ACCOUNTS } from "@ledgerhq/coin-solana/utils";
 import type { SolanaAccount } from "@ledgerhq/coin-solana/types";
 import type { ValidatorsAppValidator } from "@ledgerhq/coin-solana/network/validator-app/index";
-import { isAccountEmpty } from "../../account";
+import type { ResolvedAccountBridge } from "@ledgerhq/types-live";
 
 export interface AccountBannerState {
   display: boolean;
@@ -12,7 +12,11 @@ export interface AccountBannerState {
   ledgerValidator: ValidatorsAppValidator | undefined;
 }
 
-export function getAccountBannerState(account: SolanaAccount): AccountBannerState {
+export function getAccountBannerState(
+  account: SolanaAccount,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  bridge: ResolvedAccountBridge<any>,
+): AccountBannerState {
   // Group current validator
   const solanaResources = account.solanaResources ? account.solanaResources : { stakes: [] };
   const delegations = solanaResources?.stakes.map(delegation => {
@@ -60,7 +64,7 @@ export function getAccountBannerState(account: SolanaAccount): AccountBannerStat
   }
   if (worstValidator) {
     if (LEDGER_VALIDATORS_VOTE_ACCOUNTS.includes(worstValidator?.voteAccount)) {
-      if (!isAccountEmpty(account)) {
+      if (!bridge.isAccountEmpty(account)) {
         display = true;
       }
     } else {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [ ] **Impact of the changes:**
  - Desktop only. 31 call sites of deprecated top-level helpers (isAccountEmpty, clearAccount, isEditableOperation, isStuckOperation, getStuckAccountAndOperation) now resolve the bridge per account via useAccountBridge / useAccountBridgeMany (React) or getAccountBridge (non-React). QA focus: operations list (date cell, edit-stuck-tx panels for BTC + EVM), add-account flow (legacy modal + new drawer), account header actions across aleo / celo / evm / hedera / polkadot / solana / tezos, solana stake banner, and cache-clean reducer flow.

### 📝 Description

Extracted from #17338 (`explo/bridge-extensions-mandatory`) to ship the desktop migration independently. The prerequisite — `AccountBridgeExtensions` API added and the top-level helpers deprecated — already landed via #17374.

Replaces sync top-level helper calls with bridge-resolved calls. Cache-clean reducer logic moves to thunks that resolve the bridge per account before dispatching `REPLACE_ACCOUNTS`. `solana/banner.ts` now takes the resolved bridge as a parameter, driven by its consumer `StakeBanner.tsx`.

Mobile migration and the breaking removal of the deprecated helpers remain on #17338 and will land after this PR.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30457](https://ledgerhq.atlassian.net/browse/LIVE-30457) — split out of #17338
- **ADR link (if any)**: —

[LIVE-30457]: https://ledgerhq.atlassian.net/browse/LIVE-30457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ