### PR TITLE
[LWM] refactor(mobile): migrate to AccountBridgeExtensions API

### DIFF
--- a/.changeset/mobile-bridge-extensions.md
+++ b/.changeset/mobile-bridge-extensions.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Migrate mobile call sites of `isAccountEmpty`, `clearAccount`, `isEditableOperation`, `isStuckOperation`, `getStuckAccountAndOperation`, and `getVotesCount` to the `AccountBridgeExtensions` API (`useAccountBridge` / `useAccountBridgeMany` in React, `getAccountBridge` elsewhere).

--- a/apps/ledger-live-mobile/src/actions/accounts.ts
+++ b/apps/ledger-live-mobile/src/actions/accounts.ts
@@ -64,4 +64,3 @@ export const replaceAccounts = createAction<AccountsReplacePayload>(
   AccountsActionTypes.SET_ACCOUNTS,
 );
 
-export const cleanCache = createAction(AccountsActionTypes.CLEAN_CACHE);

--- a/apps/ledger-live-mobile/src/actions/general.ts
+++ b/apps/ledger-live-mobile/src/actions/general.ts
@@ -19,7 +19,8 @@ import {
 } from "@ledgerhq/live-common/portfolio/useAssetDistribution";
 import VersionNumber from "react-native-version-number";
 import { BehaviorSubject } from "rxjs";
-import { cleanCache, reorderAccounts } from "./accounts";
+import { replaceAccounts, reorderAccounts } from "./accounts";
+import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { accountsSelector } from "../reducers/accounts";
 import { counterValueCurrencySelector, orderAccountsSelector } from "../reducers/settings";
 import { clearBridgeCache } from "../bridge/cache";
@@ -112,14 +113,21 @@ export function useRefreshAccountsOrderingEffect({
 }
 export function useCleanCache() {
   const dispatch = useDispatch();
+  const accounts = useSelector(accountsSelector);
   const { wipe } = useCountervaluesPolling();
   return useCallback(async () => {
-    dispatch(cleanCache());
+    const cleared = await Promise.all(
+      accounts.map(async account => {
+        const bridge = await getAccountBridge(account);
+        return bridge.clearAccount(account);
+      }),
+    );
+    dispatch(replaceAccounts(cleared));
 
     await clearBridgeCache();
     wipe();
     flushAll();
-  }, [dispatch, wipe]);
+  }, [dispatch, accounts, wipe]);
 }
 
 export function useUserSettings() {

--- a/apps/ledger-live-mobile/src/components/OperationRow/index.tsx
+++ b/apps/ledger-live-mobile/src/components/OperationRow/index.tsx
@@ -6,10 +6,9 @@ import { useNavigation } from "@react-navigation/native";
 import {
   getOperationAmountNumber,
   isConfirmedOperation,
-  isEditableOperation,
-  isStuckOperation,
 } from "@ledgerhq/live-common/operation";
 import { getMainAccount, getAccountCurrency } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Account, Operation, AccountLike } from "@ledgerhq/types-live";
 import { Box, Flex, InfiniteLoader, Text } from "@ledgerhq/native-ui";
 import { WarningMedium } from "@ledgerhq/native-ui/assets/icons";
@@ -143,6 +142,7 @@ function OperationRow({
   const amount = getOperationAmountNumber(operation);
   const currency = getAccountCurrency(account);
   const mainAccount = getMainAccount(account, parentAccount);
+  const bridge = useAccountBridge(mainAccount);
   const accountName = useAccountName(account);
   const currencySettings = useCurrencySettingsForAccount(mainAccount);
   const isConfirmed = isConfirmedOperation(
@@ -159,8 +159,7 @@ function OperationRow({
   const text = <Trans i18nKey={`operations.types.${operation.type}`} />;
   const isOptimistic = operation.blockHeight === null;
   const isOperationStuck =
-    isEditableOperation({ account: mainAccount, operation }) &&
-    isStuckOperation({ family: mainAccount.currency.family, operation });
+    bridge.isEditableOperation(mainAccount, operation) && bridge.isStuckOperation(operation);
 
   const spinner = isOperationStuck ? (
     <WarningMedium />

--- a/apps/ledger-live-mobile/src/families/bitcoin/accountActions.tsx
+++ b/apps/ledger-live-mobile/src/families/bitcoin/accountActions.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { Trans } from "~/context/Locale";
 import { NavigatorName, ScreenName } from "~/const";
 import { ActionButtonEvent, NavigationParamsType } from "~/components/FabActions";
-import { getMainAccount, isAccountEmpty } from "@ledgerhq/live-common/account/index";
-import { TokenAccount } from "@ledgerhq/types-live";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import type { ResolvedAccountBridge, TokenAccount } from "@ledgerhq/types-live";
 import { BitcoinAccount } from "@ledgerhq/live-common/families/bitcoin/types";
 import { IconsLegacy } from "@ledgerhq/native-ui";
 import { getStakeLabelLocaleBased } from "~/helpers/getStakeLabelLocaleBased";
@@ -11,14 +11,17 @@ import { getStakeLabelLocaleBased } from "~/helpers/getStakeLabelLocaleBased";
 const getMainActions = ({
   account,
   parentAccount,
+  bridge,
 }: {
   account: BitcoinAccount | TokenAccount;
   parentAccount: BitcoinAccount | null | undefined;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  bridge: ResolvedAccountBridge<any>;
 }): ActionButtonEvent[] => {
   const mainAccount = getMainAccount(account, parentAccount);
   const label = getStakeLabelLocaleBased();
 
-  const navigationParams: NavigationParamsType = isAccountEmpty(mainAccount)
+  const navigationParams: NavigationParamsType = bridge.isAccountEmpty(mainAccount)
     ? [
         NavigatorName.NoFundsFlow,
         {

--- a/apps/ledger-live-mobile/src/families/celo/accountActions.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/accountActions.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { Trans } from "~/context/Locale";
 import { CeloAccount } from "@ledgerhq/live-common/families/celo/types";
-import type { Account } from "@ledgerhq/types-live";
-import { isAccountEmpty } from "@ledgerhq/live-common/account/index";
+import type { Account, ResolvedAccountBridge } from "@ledgerhq/types-live";
 import CeloIcon from "./components/CeloIcon";
 import { ActionButtonEvent, NavigationParamsType } from "~/components/FabActions";
 import { NavigatorName, ScreenName } from "~/const";
@@ -11,13 +10,16 @@ import { getStakeLabelLocaleBased } from "~/helpers/getStakeLabelLocaleBased";
 const getMainActions = ({
   account,
   parentAccount,
+  bridge,
 }: {
   account: CeloAccount;
   parentAccount: Account;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  bridge: ResolvedAccountBridge<any>;
 }): ActionButtonEvent[] => {
   const label = getStakeLabelLocaleBased();
 
-  const navigationParams: NavigationParamsType = isAccountEmpty(account)
+  const navigationParams: NavigationParamsType = bridge.isAccountEmpty(account)
     ? [
         NavigatorName.NoFundsFlow,
         {

--- a/apps/ledger-live-mobile/src/families/evm/accountActions.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/accountActions.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import type { Account, AccountLike } from "@ledgerhq/types-live";
+import type { Account, AccountLike, ResolvedAccountBridge } from "@ledgerhq/types-live";
 import { IconsLegacy } from "@ledgerhq/native-ui";
 import { Trans } from "~/context/Locale";
-import { isAccountEmpty, isTokenAccount } from "@ledgerhq/live-common/account/index";
+import { isTokenAccount } from "@ledgerhq/live-common/account/index";
 import { ParamListBase, RouteProp } from "@react-navigation/native";
 import { ActionButtonEvent, NavigationParamsType } from "~/components/FabActions";
 import { NavigatorName, ScreenName } from "~/const";
@@ -33,6 +33,8 @@ type Props = {
   parentRoute: RouteProp<ParamListBase, ScreenName>;
   walletState: WalletState;
   evmNativeStakingFeature?: EvmNativeStakingFeature | null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  bridge: ResolvedAccountBridge<any>;
 };
 
 type AccountTypeGetterProps = {
@@ -62,11 +64,12 @@ function getNavigatorParams({
   parentAccount,
   walletState,
   evmNativeStakingFeature,
+  bridge,
 }: Props): NavigationParamsType {
   const { isPOLAccount, isBscAccount, isAvaxAccount, isStakekit } = getAccountType(account);
   const isSeiEvmNativeStaking = getIsSeiEvmNativeStakingEnabled(account, evmNativeStakingFeature);
 
-  if (isAccountEmpty(account)) {
+  if (bridge.isAccountEmpty(account)) {
     return [
       NavigatorName.NoFundsFlow,
       {
@@ -159,6 +162,7 @@ const getMainActions = ({
   parentRoute,
   walletState,
   evmNativeStakingFeature,
+  bridge,
 }: Props): ActionButtonEvent[] => {
   const { isPOLAccount, isBscAccount, isAvaxAccount, isStakekit, isEthAccount } =
     getAccountType(account);
@@ -181,6 +185,7 @@ const getMainActions = ({
       parentRoute,
       walletState,
       evmNativeStakingFeature,
+      bridge,
     });
 
     const getCurrentCurrency = () => {

--- a/apps/ledger-live-mobile/src/families/tron/accountActions.tsx
+++ b/apps/ledger-live-mobile/src/families/tron/accountActions.tsx
@@ -3,20 +3,23 @@ import { Trans } from "~/context/Locale";
 import type { TronAccount } from "@ledgerhq/live-common/families/tron/types";
 import { NavigatorName, ScreenName } from "~/const";
 import { ActionButtonEvent, NavigationParamsType } from "~/components/FabActions";
-import { getMainAccount, isAccountEmpty } from "@ledgerhq/live-common/account/index";
-import { TokenAccount } from "@ledgerhq/types-live";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import type { ResolvedAccountBridge, TokenAccount } from "@ledgerhq/types-live";
 import { IconsLegacy } from "@ledgerhq/native-ui";
 import { getStakeLabelLocaleBased } from "~/helpers/getStakeLabelLocaleBased";
 const getMainActions = ({
   account,
   parentAccount,
+  bridge,
 }: {
   account: TronAccount | TokenAccount;
   parentAccount: TronAccount | null | undefined;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  bridge: ResolvedAccountBridge<any>;
 }): ActionButtonEvent[] => {
   const mainAccount = getMainAccount(account, parentAccount);
   const label = getStakeLabelLocaleBased();
-  const navigationParams: NavigationParamsType = isAccountEmpty(mainAccount)
+  const navigationParams: NavigationParamsType = bridge.isAccountEmpty(mainAccount)
     ? [
         NavigatorName.NoFundsFlow,
         {

--- a/apps/ledger-live-mobile/src/hooks/useQuickActions.ts
+++ b/apps/ledger-live-mobile/src/hooks/useQuickActions.ts
@@ -10,7 +10,7 @@ import { AccountLike } from "@ledgerhq/types-live";
 import { NavigatorName, ScreenName } from "~/const";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { EntryOf } from "~/types/helpers";
-import { accountsCountSelector, areAccountsEmptySelector } from "../reducers/accounts";
+import { accountsCountSelector, useAreAccountsEmpty } from "../reducers/accounts";
 import { readOnlyModeEnabledSelector } from "../reducers/settings";
 import { useStake } from "LLM/hooks/useStake/useStake";
 import { useOpenStakeDrawer } from "LLM/features/Stake";
@@ -45,7 +45,7 @@ function useQuickActions({ currency, accounts }: QuickActionProps = {}) {
 
   const readOnlyModeEnabled = useSelector(readOnlyModeEnabledSelector);
   const hasAnyAccounts = useSelector(accountsCountSelector) > 0;
-  const hasFunds = !useSelector(areAccountsEmptySelector) && hasAnyAccounts;
+  const hasFunds = !useAreAccountsEmpty() && hasAnyAccounts;
   const hasCurrency = currency ? !!accounts?.some(({ balance }) => balance.gt(0)) : hasFunds;
 
   const recoverEntryPoint = useFeature("protectServicesMobile");

--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/__tests__/shared.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/__tests__/shared.ts
@@ -57,6 +57,9 @@ jest.mock("@ledgerhq/live-common/bridge/index", () => ({
     preload: jest.fn(() => Promise.resolve(undefined)),
     hydrate: jest.fn(),
   })),
+  getAccountBridge: jest.fn(() => ({
+    isAccountEmpty: jest.fn(() => false),
+  })),
 }));
 
 jest.mock("~/bridge/cache", () => ({

--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
@@ -3,7 +3,7 @@ import { useEffect, useCallback, useState, useRef, useMemo } from "react";
 import { concat, from, Subscription } from "rxjs";
 import { ignoreElements } from "rxjs/operators";
 import { useDispatch } from "~/context/hooks";
-import { isAccountEmpty } from "@ledgerhq/live-common/account/index";
+import { useAccountBridgeOrNull } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import uniq from "lodash/uniq";
 import type { Account } from "@ledgerhq/types-live";
 import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
@@ -341,30 +341,38 @@ export default function useScanDeviceAccountsViewModel({
     return () => stopSubscription(false);
   }, [startSubscription, stopSubscription]);
 
+  const latestScannedAccountBridge = useAccountBridgeOrNull(latestScannedAccount ?? null);
+
   useEffect(() => {
-    if (latestScannedAccount) {
-      const hasAlreadyBeenScanned = scannedAccounts.some(a => latestScannedAccount.id === a.id);
-      const hasAlreadyBeenImported = existingAccounts.some(a => latestScannedAccount.id === a.id);
-      const isNewAccount = isAccountEmpty(latestScannedAccount);
+    if (!latestScannedAccount || !latestScannedAccountBridge) return;
+    const hasAlreadyBeenScanned = scannedAccounts.some(a => latestScannedAccount.id === a.id);
+    const hasAlreadyBeenImported = existingAccounts.some(a => latestScannedAccount.id === a.id);
+    const isNewAccount = latestScannedAccountBridge.isAccountEmpty(latestScannedAccount);
 
-      if (!isNewAccount && !hasAlreadyBeenImported) {
-        setOnlyNewAccounts(false);
-      }
-
-      if (!hasAlreadyBeenScanned) {
-        setScannedAccounts([...scannedAccounts, latestScannedAccount]);
-        setSelectedIds(
-          onlyNewAccounts
-            ? hasAlreadyBeenImported || selectedIds.length > 0
-              ? selectedIds
-              : [latestScannedAccount.id]
-            : !hasAlreadyBeenImported && !isNewAccount
-              ? uniq([...selectedIds, latestScannedAccount.id])
-              : selectedIds,
-        );
-      }
+    if (!isNewAccount && !hasAlreadyBeenImported) {
+      setOnlyNewAccounts(false);
     }
-  }, [existingAccounts, latestScannedAccount, onlyNewAccounts, scannedAccounts, selectedIds]);
+
+    if (!hasAlreadyBeenScanned) {
+      setScannedAccounts([...scannedAccounts, latestScannedAccount]);
+      setSelectedIds(
+        onlyNewAccounts
+          ? hasAlreadyBeenImported || selectedIds.length > 0
+            ? selectedIds
+            : [latestScannedAccount.id]
+          : !hasAlreadyBeenImported && !isNewAccount
+            ? uniq([...selectedIds, latestScannedAccount.id])
+            : selectedIds,
+      );
+    }
+  }, [
+    existingAccounts,
+    latestScannedAccount,
+    latestScannedAccountBridge,
+    onlyNewAccounts,
+    scannedAccounts,
+    selectedIds,
+  ]);
 
   useEffect(() => {
     const hasScannedAccounts = scannedAccounts.length > 0 || !!latestScannedAccount;

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/__integrations__/addAccountFlow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/__integrations__/addAccountFlow.test.tsx
@@ -113,6 +113,7 @@ jest.mock("@ledgerhq/live-common/bridge/index", () => ({
     preload: () => Promise.resolve(true),
     hydrate: () => true,
   }),
+  getAccountBridge: () => ({ isAccountEmpty: () => false }),
 }));
 
 const mockScanAccountsSubscription = async (accounts: Account[]) => {

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/components/QuickActionsCtas/useQuickActionsCtasViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/components/QuickActionsCtas/useQuickActionsCtasViewModel.ts
@@ -17,7 +17,7 @@ import {
   StackNavigatorNavigation,
 } from "~/components/RootNavigator/types/helpers";
 import { languageSelector, readOnlyModeEnabledSelector } from "~/reducers/settings";
-import { accountsCountSelector, areAccountsEmptySelector } from "~/reducers/accounts";
+import { accountsCountSelector, useAreAccountsEmpty } from "~/reducers/accounts";
 import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import { resolveRemoteCopy } from "@ledgerhq/live-common/featureFlags/remoteABTesting/resolveRemoteCopy";
@@ -52,7 +52,7 @@ export const useQuickActionsCtasViewModel = ({
 
   const readOnlyModeEnabled = useSelector(readOnlyModeEnabledSelector);
   const hasAnyAccounts = useSelector(accountsCountSelector) > 0;
-  const hasFunds = !useSelector(areAccountsEmptySelector) && hasAnyAccounts;
+  const hasFunds = !useAreAccountsEmpty() && hasAnyAccounts;
 
   const ptxServiceCtaExchangeDrawer = useFeature("ptxServiceCtaExchangeDrawer");
   const isExchangeEnabled = ptxServiceCtaExchangeDrawer?.enabled ?? true;

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/useTransferDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/useTransferDrawerViewModel.ts
@@ -7,7 +7,7 @@ import { QrCode, ArrowUp, Bank } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { NavigatorName, ScreenName } from "~/const";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { languageSelector, readOnlyModeEnabledSelector } from "~/reducers/settings";
-import { accountsCountSelector, areAccountsEmptySelector } from "~/reducers/accounts";
+import { accountsCountSelector, useAreAccountsEmpty } from "~/reducers/accounts";
 import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 import { resolveRemoteCopy } from "@ledgerhq/live-common/featureFlags/remoteABTesting/resolveRemoteCopy";
 import { track } from "~/analytics";
@@ -39,7 +39,7 @@ export const useTransferDrawerViewModel = (): TransferDrawerViewModel => {
 
   const readOnlyModeEnabled = useSelector(readOnlyModeEnabledSelector);
   const hasAnyAccounts = useSelector(accountsCountSelector) > 0;
-  const hasFunds = !useSelector(areAccountsEmptySelector) && hasAnyAccounts;
+  const hasFunds = !useAreAccountsEmpty() && hasAnyAccounts;
 
   const { handleOpenReceiveDrawer } = useOpenReceiveDrawer({
     sourceScreenName,

--- a/apps/ledger-live-mobile/src/reducers/accounts.ts
+++ b/apps/ledger-live-mobile/src/reducers/accounts.ts
@@ -17,14 +17,14 @@ import type {
 } from "@ledgerhq/types-cryptoassets";
 import isEqual from "lodash/isEqual";
 import {
-  isAccountEmpty,
   flattenAccounts,
   getAccountCurrency,
   isUpToDateAccount,
-  clearAccount,
   makeEmptyTokenAccount,
   isAccountBalanceUnconfirmed,
 } from "@ledgerhq/live-common/account/index";
+import { useAccountBridgeMany } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { useSelector } from "~/context/hooks";
 
 import type { AccountsState, State } from "./types";
 import type {
@@ -109,10 +109,6 @@ const handlers: ReducerMap<AccountsState, Payload> = {
     active: (action as Action<AccountsReplacePayload>).payload,
   }),
 
-  [AccountsActionTypes.CLEAN_CACHE]: (state: AccountsState) => ({
-    active: state.active.map(clearAccount),
-  }),
-
   [AccountsActionTypes.DANGEROUSLY_OVERRIDE_STATE]: (
     state: AccountsState,
     action,
@@ -180,10 +176,12 @@ export const flattenAccountsSelector = createSelector(accountsSelector, flattenA
 export const accountsCountSelector = createSelector(accountsSelector, acc => acc.length);
 /** Returns a boolean that is true if and only if there is no account */
 export const hasNoAccountsSelector = createSelector(accountsSelector, acc => acc.length <= 0);
-/** Returns a boolean that is true if and only if all accounts are empty */
-export const areAccountsEmptySelector = createSelector(accountsSelector, accounts =>
-  accounts.every(isAccountEmpty),
-);
+
+export function useAreAccountsEmpty(): boolean {
+  const accounts = useSelector(accountsSelector);
+  const bridges = useAccountBridgeMany(accounts);
+  return accounts.every((a, i) => bridges[i].isAccountEmpty(a));
+}
 
 export const currenciesSelector = createSelector(accountsSelector, accounts =>
   uniq(flattenAccounts(accounts).map(a => getAccountCurrency(a))).sort((a, b) =>

--- a/apps/ledger-live-mobile/src/screens/Account/ListHeaderComponent.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/ListHeaderComponent.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode, useMemo } from "react";
 import { LayoutChangeEvent } from "react-native";
-import { isAccountEmpty, getMainAccount } from "@ledgerhq/live-common/account/index";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { useAccountBridgeOrNull } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import {
   AccountLike,
   Account,
@@ -18,7 +19,6 @@ import { PolkadotAccount } from "@ledgerhq/live-common/families/polkadot/types";
 import { MultiversXAccount } from "@ledgerhq/live-common/families/multiversx/types";
 import { NearAccount } from "@ledgerhq/live-common/families/near/types";
 import { HederaAccount } from "@ledgerhq/live-common/families/hedera/types";
-import { isEditableOperation, isStuckOperation } from "@ledgerhq/live-common/operation";
 import AccountGraphCard from "~/components/AccountGraphCard";
 import SubAccountsList from "./SubAccountsList";
 import perFamilyAccountHeader from "../../generated/AccountHeader";
@@ -98,11 +98,12 @@ export function useListHeaderComponents({
     () => (account ? getMainAccount(account, parentAccount) : undefined),
     [account, parentAccount],
   );
+  const bridge = useAccountBridgeOrNull(account ?? null, parentAccount);
   const oldestEditableOperation = useMemo(() => {
-    if (!account || !mainAccount) return undefined;
+    if (!account || !mainAccount || !bridge) return undefined;
 
     const editablePendingOperations = account.pendingOperations.filter(pendingOperation =>
-      isEditableOperation({ account: mainAccount, operation: pendingOperation }),
+      bridge.isEditableOperation(mainAccount, pendingOperation),
     );
 
     return mainAccount.currency.family === "bitcoin"
@@ -121,13 +122,14 @@ export function useListHeaderComponents({
           }
           return 0;
         })[0];
-  }, [account, mainAccount]);
+  }, [account, mainAccount, bridge]);
 
-  if (!account || !mainAccount) return { listHeaderComponents: [], stickyHeaderIndices: undefined };
+  if (!account || !mainAccount || !bridge)
+    return { listHeaderComponents: [], stickyHeaderIndices: undefined };
 
   const family: string = mainAccount.currency.family;
 
-  const empty = isAccountEmpty(account);
+  const empty = bridge.isAccountEmpty(account);
   const shouldUseCounterValue = countervalueAvailable && useCounterValue;
 
   const AccountHeader = (perFamilyAccountHeader as Record<string, MaybeComponent>)[family];
@@ -163,8 +165,7 @@ export function useListHeaderComponents({
   const stickyHeaderIndices = empty ? [] : [0];
 
   const isOperationStuck = Boolean(
-    oldestEditableOperation &&
-    isStuckOperation({ family: mainAccount.currency.family, operation: oldestEditableOperation }),
+    oldestEditableOperation && bridge.isStuckOperation(oldestEditableOperation),
   );
 
   const disableDelegation =

--- a/apps/ledger-live-mobile/src/screens/Account/__tests__/ListHeaderComponent.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/__tests__/ListHeaderComponent.test.tsx
@@ -9,15 +9,23 @@ import type { Account, TokenAccount, Operation } from "@ledgerhq/types-live";
 import { ActionButtonEvent } from "~/components/FabActions";
 import * as featureFlagsIndex from "@ledgerhq/live-common/featureFlags/index";
 import * as accountIndex from "@ledgerhq/live-common/account/index";
+import { useAccountBridgeOrNull } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { TFunction } from "i18next";
 import { render } from "@testing-library/react-native";
 import React from "react";
 
-/**
- * isAccountEmpty can not be spied because it is declared in multiple files
- * and overriden in ledger-live-common/src/account/helpers.ts
- */
-const mockIsAccountEmpty = jest.requireMock("@ledgerhq/live-common/account/index").isAccountEmpty;
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  useAccountBridgeOrNull: jest.fn(),
+}));
+
+const mockIsAccountEmpty = jest.fn();
+const mockIsEditableOperation = jest.fn();
+const mockIsStuckOperation = jest.fn();
+(useAccountBridgeOrNull as jest.Mock).mockReturnValue({
+  isAccountEmpty: mockIsAccountEmpty,
+  isEditableOperation: mockIsEditableOperation,
+  isStuckOperation: mockIsStuckOperation,
+});
 
 describe("Testing ListHeaderComponent Component", () => {
   describe("Testing disable delegation flag", () => {

--- a/apps/ledger-live-mobile/src/screens/Account/hooks/useAccountActions.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/hooks/useAccountActions.tsx
@@ -5,6 +5,7 @@ import {
   getMainAccount,
   getAccountSpendableBalance,
 } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useSelector } from "~/context/hooks";
 import { useTranslation } from "~/context/Locale";
 import { useRoute } from "@react-navigation/native";
@@ -76,6 +77,7 @@ export default function useAccountActions({ account, parentAccount, colors }: Pr
   const balance = getAccountSpendableBalance(account);
   const isZeroBalance = !balance.gt(0);
   const mainAccount = getMainAccount(account, parentAccount);
+  const bridge = useAccountBridge(mainAccount);
   // @ts-expect-error issue in typing
   const decorators = perFamilyAccountActions[mainAccount?.currency?.family];
 
@@ -269,8 +271,9 @@ export default function useAccountActions({ account, parentAccount, colors }: Pr
         colors,
         parentRoute: route,
         evmNativeStakingFeature,
+        bridge,
       }) ?? [],
-    [walletState, account, parentAccount, colors, route, decorators, evmNativeStakingFeature],
+    [walletState, account, parentAccount, colors, route, decorators, evmNativeStakingFeature, bridge],
   );
 
   const mainActions = useMemo(

--- a/apps/ledger-live-mobile/src/screens/Account/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/index.tsx
@@ -10,7 +10,8 @@ import SafeAreaView from "~/components/SafeAreaView";
 import { useTranslation } from "~/context/Locale";
 import { getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
 import { useTheme } from "styled-components/native";
-import { getMainAccount, isAccountEmpty } from "@ledgerhq/live-common/account/helpers";
+import { getMainAccount } from "@ledgerhq/live-common/account/helpers";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { switchCountervalueFirst } from "~/actions/settings";
 import { useBalanceHistoryWithCountervalue } from "~/hooks/portfolio";
@@ -91,7 +92,8 @@ const AccountScreenInner = ({
     useBalanceHistoryWithCountervalue({ account, range });
   const useCounterValue = useSelector(countervalueFirstSelector);
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
-  const isEmpty = isAccountEmpty(account);
+  const bridge = useAccountBridge(account, parentAccount);
+  const isEmpty = bridge.isAccountEmpty(account);
 
   const onSwitchAccountCurrency = useCallback(() => {
     dispatch(switchCountervalueFirst());

--- a/apps/ledger-live-mobile/src/screens/Analytics/Operations/OperationsList.tsx
+++ b/apps/ledger-live-mobile/src/screens/Analytics/Operations/OperationsList.tsx
@@ -1,8 +1,9 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { SectionList, SectionListData, SectionListRenderItem } from "react-native";
 import { Flex } from "@ledgerhq/native-ui";
 import { Account, AccountLike, DailyOperationsSection, Operation } from "@ledgerhq/types-live";
-import { flattenAccounts, isAccountEmpty } from "@ledgerhq/live-common/account/helpers";
+import { flattenAccounts } from "@ledgerhq/live-common/account/helpers";
+import { useAccountBridgeMany } from "@ledgerhq/live-common/bridge/useAccountBridge";
 
 import { Trans } from "~/context/Locale";
 
@@ -21,16 +22,47 @@ function keyExtractor(item: Operation) {
   return item.id;
 }
 
-function ListEmptyComponent({ accountsFiltered }: { accountsFiltered: AccountLike[] }) {
-  if (accountsFiltered.length === 0) {
-    return <EmptyStatePortfolio />;
-  }
-
-  if (accountsFiltered.every(isAccountEmpty)) {
-    return <NoOpStatePortfolio />;
-  }
-
+function ListEmptyBody({
+  accountsFiltered,
+  isAllEmpty,
+}: Readonly<{
+  accountsFiltered: AccountLike[];
+  isAllEmpty: boolean;
+}>) {
+  if (accountsFiltered.length === 0) return <EmptyStatePortfolio />;
+  if (isAllEmpty) return <NoOpStatePortfolio />;
   return null;
+}
+
+function renderFooter({
+  completed,
+  onEndReached,
+  isAllEmpty,
+  hasSections,
+  onTransactionButtonPress,
+}: {
+  completed: boolean;
+  onEndReached: boolean;
+  isAllEmpty: boolean;
+  hasSections: boolean;
+  onTransactionButtonPress?: () => void;
+}) {
+  if (!completed) {
+    return onEndReached ? (
+      <LoadingFooter />
+    ) : (
+      <Flex m={8}>
+        <Button
+          event="View Transactions"
+          type="lightPrimary"
+          title={<Trans i18nKey="common.seeAll" />}
+          onPress={onTransactionButtonPress}
+        />
+      </Flex>
+    );
+  }
+  if (isAllEmpty) return null;
+  return hasSections ? <NoMoreOperationFooter /> : <NoOperationFooter />;
 }
 
 export function OperationsList({
@@ -41,6 +73,16 @@ export function OperationsList({
   onEndReached,
   onTransactionButtonPress,
 }: ListProps) {
+  const mainAccounts = accountsFiltered.filter((a): a is Account => a.type === "Account");
+  const bridges = useAccountBridgeMany(mainAccounts);
+  const bridgeById = new Map(mainAccounts.map((a, i) => [a.id, bridges[i]]));
+  const isAllEmpty = accountsFiltered.every(a =>
+    bridgeById.get(a.type === "Account" ? a.id : a.parentId)?.isAccountEmpty(a),
+  );
+  const ListEmptyComponent = useCallback(
+    () => <ListEmptyBody accountsFiltered={accountsFiltered} isAllEmpty={isAllEmpty} />,
+    [accountsFiltered, isAllEmpty],
+  );
   const renderItem: SectionListRenderItem<Operation, DailyOperationsSection> = ({
     item,
     index,
@@ -88,26 +130,13 @@ export function OperationsList({
         onEndReached={onEndReached}
         onEndReachedThreshold={0.5}
         showsVerticalScrollIndicator={false}
-        ListFooterComponent={
-          !completed ? (
-            !onEndReached ? (
-              <Flex m={8}>
-                <Button
-                  event="View Transactions"
-                  type="lightPrimary"
-                  title={<Trans i18nKey="common.seeAll" />}
-                  onPress={onTransactionButtonPress}
-                />
-              </Flex>
-            ) : (
-              <LoadingFooter />
-            )
-          ) : accountsFiltered.every(isAccountEmpty) ? null : sections.length ? (
-            <NoMoreOperationFooter />
-          ) : (
-            <NoOperationFooter />
-          )
-        }
+        ListFooterComponent={renderFooter({
+          completed,
+          onEndReached: !!onEndReached,
+          isAllEmpty,
+          hasSections: sections.length > 0,
+          onTransactionButtonPress,
+        })}
         ListEmptyComponent={ListEmptyComponent}
       />
       <TrackScreen category="Analytics" name="Operations" />

--- a/apps/ledger-live-mobile/src/screens/OperationDetails/Content.tsx
+++ b/apps/ledger-live-mobile/src/screens/OperationDetails/Content.tsx
@@ -9,9 +9,8 @@ import {
   getOperationAmountNumber,
   isConfirmedOperation,
   getOperationConfirmationDisplayableNumber,
-  isEditableOperation,
-  isStuckOperation,
 } from "@ledgerhq/live-common/operation";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { NavigatorName, ScreenName } from "~/const";
 import LText from "~/components/LText";
@@ -100,6 +99,7 @@ export default function Content({
   }, []);
 
   const currencySettings = useCurrencySettingsForAccount(mainAccount);
+  const bridge = useAccountBridge(mainAccount);
 
   const isToken = currency.type === "TokenCurrency";
   const accountName = useAccountName(account);
@@ -122,8 +122,8 @@ export default function Content({
     currencySettings.confirmationsNb,
   );
 
-  const isEditable = isEditableOperation({ account: mainAccount, operation });
-  const isOperationStuck = isStuckOperation({ family: mainAccount.currency.family, operation });
+  const isEditable = bridge.isEditableOperation(mainAccount, operation);
+  const isOperationStuck = bridge.isStuckOperation(operation);
 
   const specificOperationDetails =
     byFamiliesOperationDetails[

--- a/apps/ledger-live-mobile/src/screens/Portfolio/PortfolioGraphCard.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/PortfolioGraphCard.tsx
@@ -5,7 +5,7 @@ import { LayoutChangeEvent } from "react-native";
 import { useSharedValue } from "react-native-reanimated";
 import { useSelector } from "~/context/hooks";
 import { usePortfolioAllAccounts } from "~/hooks/portfolio";
-import { areAccountsEmptySelector } from "~/reducers/accounts";
+import { useAreAccountsEmpty } from "~/reducers/accounts";
 import { counterValueCurrencySelector } from "~/reducers/settings";
 import { PortfolioBalanceSection } from "LLM/features/Portfolio/components";
 import GraphCardContainer from "./GraphCardContainer";
@@ -23,7 +23,7 @@ const PortfolioGraphCard = ({
   hideGraph,
   isReadOnlyMode = false,
 }: Props) => {
-  const areAccountsEmpty = useSelector(areAccountsEmptySelector);
+  const areAccountsEmpty = useAreAccountsEmpty();
   const portfolio = usePortfolioAllAccounts();
   const counterValueCurrency: Currency = useSelector(counterValueCurrencySelector);
 

--- a/apps/ledger-live-mobile/src/screens/SelectAccount.tsx
+++ b/apps/ledger-live-mobile/src/screens/SelectAccount.tsx
@@ -7,10 +7,10 @@ import {
 } from "@ledgerhq/live-common/account/helpers";
 import { Flex } from "@ledgerhq/native-ui";
 import {
-  isAccountEmpty,
   getAccountSpendableBalance,
   getMainAccount,
 } from "@ledgerhq/live-common/account/index";
+import { useAccountBridgeMany } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { NotEnoughBalance } from "@ledgerhq/errors";
 import { ScreenName, NavigatorName } from "~/const";
 import { accountsSelector } from "~/reducers/accounts";
@@ -20,7 +20,7 @@ import GenericErrorBottomModal from "~/components/GenericErrorBottomModal";
 import { SendFundsNavigatorStackParamList } from "~/components/RootNavigator/types/SendFundsNavigator";
 import { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import SafeAreaView from "~/components/SafeAreaView";
-import { AccountLike } from "@ledgerhq/types-live";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
 import { withDiscreetMode } from "~/context/DiscreetModeContext";
 import { useNewSendFlowFeature } from "LLM/features/Send/hooks/useNewSendFlowFeature";
 
@@ -64,8 +64,13 @@ function ReceiveFunds({ navigation, route }: Props) {
     }
     return flattenAccounts(accounts);
   }, [accounts, selectedCurrency]);
+  const mainAccounts = enhancedAccounts.filter((a): a is Account => a.type === "Account");
+  const bridges = useAccountBridgeMany(mainAccounts);
+  const bridgeById = new Map(mainAccounts.map((a, i) => [a.id, bridges[i]]));
   const allAccounts = notEmptyAccounts
-    ? enhancedAccounts.filter(account => !isAccountEmpty(account))
+    ? enhancedAccounts.filter(
+        a => !bridgeById.get(a.type === "Account" ? a.id : a.parentId)?.isAccountEmpty(a),
+      )
     : enhancedAccounts;
 
   const { isEnabledForFamily, getFamilyFromAccount, getCurrencyIdFromAccount } =

--- a/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.test.tsx
@@ -17,7 +17,10 @@ jest.mock("@react-navigation/native", () => ({
   useScrollToTop: jest.fn(),
 }));
 jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
-  useAccountBridge: jest.fn().mockReturnValue({ updateTransaction: jest.fn() }),
+  useAccountBridge: jest.fn().mockReturnValue({
+    updateTransaction: jest.fn(),
+    getStuckAccountAndOperation: jest.fn(() => undefined),
+  }),
 }));
 
 describe("SendSelectRecipient", () => {

--- a/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
@@ -11,7 +11,6 @@ import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransact
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
-import { getStuckAccountAndOperation } from "@ledgerhq/live-common/operation";
 import { Operation } from "@ledgerhq/types-live";
 import QrCode from "@ledgerhq/icons-ui/native/QrCode";
 import { useNavigation, useTheme } from "@react-navigation/native";
@@ -254,7 +253,7 @@ export default function SendSelectRecipient({ route }: Props) {
     !!status.errors.transaction ||
     !!status.errors.sender;
 
-  const stuckAccountAndOperation = getStuckAccountAndOperation(account, mainAccount);
+  const stuckAccountAndOperation = bridge.getStuckAccountAndOperation(account, mainAccount);
   const extensions = getTokenExtensions(account);
 
   return (

--- a/apps/ledger-live-mobile/src/screens/WalletCentricAsset/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/WalletCentricAsset/index.tsx
@@ -8,7 +8,7 @@ import Animated, {
 import { useTranslation } from "~/context/Locale";
 import { Box, Flex } from "@ledgerhq/native-ui";
 import { getCurrencyColor, isCryptoCurrency } from "@ledgerhq/live-common/currencies/index";
-import { isAccountEmpty } from "@ledgerhq/live-common/account/helpers";
+import { useAccountBridgeMany } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useTheme } from "styled-components/native";
 import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssetsData";
 import VersionNumber from "react-native-version-number";
@@ -19,7 +19,10 @@ import BigNumber from "bignumber.js";
 import accountSyncRefreshControl from "~/components/accountSyncRefreshControl";
 import { withDiscreetMode } from "~/context/DiscreetModeContext";
 import SafeAreaView from "~/components/SafeAreaView";
-import { useFlattenAccountsByCryptoCurrency } from "LLM/hooks/useAccountsByCryptoCurrency";
+import {
+  useAccountsByCryptoCurrency,
+  useFlattenAccountsByCryptoCurrency,
+} from "LLM/hooks/useAccountsByCryptoCurrency";
 import SectionContainer from "../WalletCentricSections/SectionContainer";
 import SectionTitle from "../WalletCentricSections/SectionTitle";
 import OperationsHistorySection from "../WalletCentricSections/OperationsHistory";
@@ -70,12 +73,17 @@ const AssetScreen = ({ route }: NavigationProps) => {
   }, [preloadedCurrency, currencyId, assetData]);
 
   const cryptoAccounts = useFlattenAccountsByCryptoCurrency(currency);
-
+  // useFlattenAccountsByCryptoCurrency returns only TokenAccounts for a TokenCurrency,
+  // so we pull parent Accounts from the tuples selector to resolve bridges by parentId.
+  const cryptoAccountTuples = useAccountsByCryptoCurrency(currency);
   const defaultAccount = cryptoAccounts?.length === 1 ? cryptoAccounts[0] : undefined;
-
-  const cryptoAccountsEmpty = useMemo(
-    () => cryptoAccounts.every(account => isAccountEmpty(account)),
-    [cryptoAccounts],
+  const mainCryptoAccounts = cryptoAccountTuples
+    .map(t => t.account)
+    .filter((a): a is Account => a.type === "Account");
+  const bridges = useAccountBridgeMany(mainCryptoAccounts);
+  const bridgeByParentId = new Map(mainCryptoAccounts.map((a, i) => [a.id, bridges[i]]));
+  const cryptoAccountsEmpty = cryptoAccounts.every(a =>
+    Boolean(bridgeByParentId.get(a.type === "Account" ? a.id : a.parentId)?.isAccountEmpty(a)),
   );
 
   const [graphCardEndPosition, setGraphCardEndPosition] = useState(60);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [ ] **Impact of the changes:**
  - Account screen header (empty state, balance graph)
  - Operation rows + details (editable/stuck ops, ETH speed-up/cancel)
  - Quick actions, transfer drawer, send-funds recipient
  - Scan-device-accounts cache-clean path
  - Per-family account actions: BTC, Celo, EVM, Tron
  - Voting count on Cosmos/Tezos/Tron stake screens

### 📝 Description

Extracted from #17338 so the mobile half can land independently.

Switches mobile call sites of the deprecated top-level helpers — `isAccountEmpty`, `clearAccount`, `isEditableOperation`, `isStuckOperation`, `getStuckAccountAndOperation`, `getVotesCount` — to the bridge-resolved equivalents:

- `useAccountBridge` / `useAccountBridgeMany` in React components
- `getAccountBridge` in non-React contexts (actions, thunks)

Cache-clean reducer path is reshaped: inline `clearAccount` calls are replaced by thunks that resolve the bridge per account before dispatching `REPLACE_ACCOUNTS`.

Mobile-only. No `libs/**` changes — depends on the API already on `develop` from #17374.

For consumers updating sites in mobile code:

```diff
-import { isAccountEmpty } from "@ledgerhq/live-common/account/helpers";
-const isEmpty = isAccountEmpty(account);
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+const bridge = useAccountBridge(account, parentAccount);
+const isEmpty = bridge.isAccountEmpty(account);
```

### ❓ Context

- **JIRA**: [LIVE-30457](https://ledgerhq.atlassian.net/browse/LIVE-30457)
- **Related PRs**: #17338 (parent, stays open), #17374 (merged infra)
- **ADR link (if any)**: N/A

[LIVE-30457]: https://ledgerhq.atlassian.net/browse/LIVE-30457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ