### PR TITLE
[LWDM] feat(live-common): prepare formatters async

### DIFF
--- a/.changeset/async-formatters.md
+++ b/.changeset/async-formatters.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": patch
+"@ledgerhq/live-cli": patch
+"live-mobile": patch
+---
+
+Make formatAccount and formatOperation async to forward-compatibly await getAccountBridge

--- a/apps/cli/src/commands/blockchain/botTransfer.ts
+++ b/apps/cli/src/commands/blockchain/botTransfer.ts
@@ -274,7 +274,7 @@ export default {
                     signedOperation,
                   });
 
-              console.log(formatOperation(account)(optimisticOperation));
+              console.log((await formatOperation(account))(optimisticOperation));
             } catch (e) {
               console.error("Something went wrong on trying to send from " + account.id, tx, e);
             }

--- a/apps/cli/src/commands/blockchain/confirmOp.ts
+++ b/apps/cli/src/commands/blockchain/confirmOp.ts
@@ -31,7 +31,7 @@ export default {
       switchMap(async account => {
         const op = findOperationInAccount(account, id);
         if (!op) throw new Error("operation was not found in account " + account.id);
-        return format === "text" ? formatOperation(account)(op) : await toOperationRaw(op);
+        return format === "text" ? (await formatOperation(account))(op) : await toOperationRaw(op);
       }),
     );
   },

--- a/apps/cli/src/commands/blockchain/send.ts
+++ b/apps/cli/src/commands/blockchain/send.ts
@@ -66,7 +66,7 @@ export default {
         : (_l: any) => {};
     return scan(opts).pipe(
       tap(account => {
-        l(`→ FROM ${formatAccount(account, "basic")}`);
+        formatAccount(account, "basic").then(str => l(`→ FROM ${str}`));
       }),
       switchMap(account =>
         from(inferTransactions(account, opts)).pipe(
@@ -106,8 +106,8 @@ export default {
                                           })
                                           .then(async op => {
                                             l(
-                                              `✔️ broadcasted! optimistic operation: ${formatOperation(
-                                                account,
+                                              `✔️ broadcasted! optimistic operation: ${(
+                                                await formatOperation(account)
                                               )(
                                                 // @ts-expect-error we are supposed to give an OperationRaw and yet it's an Operation
                                                 await fromOperationRaw(op, account.id),

--- a/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
+++ b/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
@@ -105,7 +105,7 @@ export const useSignWithDevice = ({
       gestureEnabled: false,
     });
     setSigning(true);
-    log("transaction-summary", `→ FROM ${formatAccount(mainAccount, "basic")}`);
+    formatAccount(mainAccount, "basic").then(str => log("transaction-summary", `→ FROM ${str}`));
     log(
       "transaction-summary",
       `✔️ transaction ${formatTransaction(transaction, mainAccount)}`,
@@ -157,11 +157,11 @@ export const useSignWithDevice = ({
               break;
 
             case "broadcasted":
-              log(
-                "transaction-summary",
-                `✔️ broadcasted! optimistic operation: ${formatOperation(mainAccount)(
-                  e.operation,
-                )}`,
+              formatOperation(mainAccount).then(fmt =>
+                log(
+                  "transaction-summary",
+                  `✔️ broadcasted! optimistic operation: ${fmt(e.operation)}`,
+                ),
               );
               (navigation as NativeStackNavigationProp<{ [key: string]: object }>).replace(
                 context + "ValidationSuccess",
@@ -247,10 +247,10 @@ export const broadcastSignedTx = async (
         signedOperation,
         broadcastConfig,
       })
-      .then(op => {
+      .then(async op => {
         log(
           "transaction-summary",
-          `✔️ broadcasted! optimistic operation: ${formatOperation(mainAccount)(op)}`,
+          `✔️ broadcasted! optimistic operation: ${(await formatOperation(mainAccount))(op)}`,
         );
         return op;
       }),
@@ -308,7 +308,7 @@ export function useSignedTxHandler({
 
         log(
           "transaction-summary",
-          `✔️ broadcasted! optimistic operation: ${formatOperation(mainAccount)(operation)}`,
+          `✔️ broadcasted! optimistic operation: ${(await formatOperation(mainAccount))(operation)}`,
         );
         (navigation as NativeStackNavigationProp<{ [key: string]: object }>).replace(
           route.name.replace("ConnectDevice", "ValidationSuccess"),

--- a/libs/ledger-live-common/src/account/formatters.ts
+++ b/libs/ledger-live-common/src/account/formatters.ts
@@ -67,7 +67,7 @@ function maybeDisplaySumOfOpsIssue(ops, balance, unit) {
   );
 }
 
-const cliFormat = (account, level?: string) => {
+const cliFormat = async (account, level?: string): Promise<string> => {
   const { id, name, freshAddress, freshAddressPath, derivationMode, index, operations } = account;
   const tag = getTagDerivationMode(account.currency, derivationMode);
   const balance = formatCurrencyUnit(getAccountCurrency(account).units[0], account.balance, {
@@ -86,9 +86,9 @@ const cliFormat = (account, level?: string) => {
     getAccountCurrency(account).units[0],
   );
 
-  const formatAccountSpecifics = getAccountBridge(account).formatAccountSpecifics;
-  if (formatAccountSpecifics) {
-    str += formatAccountSpecifics(account);
+  const bridge = await getAccountBridge(account);
+  if (bridge.formatAccountSpecifics) {
+    str += bridge.formatAccountSpecifics(account);
     str += "\n";
   }
 
@@ -123,9 +123,7 @@ const cliFormat = (account, level?: string) => {
           if (ta) return getAccountCurrency(ta).units[0];
           console.error("unexpected missing token account " + id);
         },
-        (operation, unit) => {
-          return getAccountBridge(account).formatOperationSpecifics?.(operation, unit) ?? "";
-        },
+        (operation, unit) => bridge.formatOperationSpecifics?.(operation, unit) ?? "",
       ),
     )
     .join("");
@@ -198,12 +196,14 @@ export const accountFormatters: { [_: string]: (Account) => any } = {
       .map(ta => getAccountCurrency(ta).ticker)
       .join("\n"),
 };
-export function formatAccount(account: Account, format = "full"): string {
+export async function formatAccount(account: Account, format = "full"): Promise<string> {
   const f = accountFormatters[format];
   invariant(f, "missing account formatter=" + format);
   return f(account);
 }
-export function formatOperation(account: Account | null | undefined): (arg0: Operation) => string {
+export async function formatOperation(
+  account: Account | null | undefined,
+): Promise<(arg0: Operation) => string> {
   const unitByAccountId = (id: string) => {
     if (!account) return;
     if (account.id === id) return getAccountCurrency(account).units[0];
@@ -211,11 +211,9 @@ export function formatOperation(account: Account | null | undefined): (arg0: Ope
     if (ta) return getAccountCurrency(ta).units[0];
   };
 
-  const familyExtra = (operation, unit) => {
-    if (!account) return "";
-
-    return getAccountBridge(account).formatOperationSpecifics?.(operation, unit) ?? "";
-  };
+  const bridge = account ? await getAccountBridge(account) : null;
+  const familyExtra = (operation, unit) =>
+    bridge?.formatOperationSpecifics?.(operation, unit) ?? "";
 
   return formatOp(unitByAccountId, familyExtra);
 }

--- a/libs/ledger-live-common/src/bot/engine.ts
+++ b/libs/ledger-live-common/src/bot/engine.ts
@@ -179,12 +179,15 @@ export async function runWithAppSpec<T extends TransactionCommon>(
       invariant(accounts.length > 0, "unexpected empty accounts for " + currency.name);
     }
     const preloadStats = preloadDuration > 10 ? ` (preload: ${formatTime(preloadDuration)})` : "";
+    const formattedAccountHeads = (
+      await Promise.all(accounts.map(a => formatAccount(a, "head")))
+    ).join("\n");
     reportLog(
       `Spec ${spec.name} found ${accounts.length} ${
         currency.name
       } accounts${preloadStats}. Will use ${formatAppCandidate(
         appCandidate as AppCandidate,
-      )}\n${accounts.map(a => formatAccount(a, "head")).join("\n")}\n`,
+      )}\n${formattedAccountHeads}\n`,
     );
 
     const emptyChecks = await Promise.all(

--- a/libs/ledger-live-common/src/bot/formatters.ts
+++ b/libs/ledger-live-common/src/bot/formatters.ts
@@ -63,7 +63,7 @@ export async function formatReportForConsole<T extends Transaction>({
   str += `▬ ${formatAppCandidate(appCandidate)}\n`;
 
   if (account) {
-    str += `→ FROM ${formatAccount(account, "basic")}\n`;
+    str += `→ FROM ${await formatAccount(account, "basic")}\n`;
   }
 
   if (account && maxSpendable) {
@@ -96,7 +96,7 @@ export async function formatReportForConsole<T extends Transaction>({
   }
 
   if (destination) {
-    str += `→ TO ${formatAccount(destination, "head")}\n`;
+    str += `→ TO ${await formatAccount(destination, "head")}\n`;
   }
 
   if (transaction && account) {
@@ -137,17 +137,17 @@ export async function formatReportForConsole<T extends Transaction>({
     str += `✔️ broadcasted! (${formatDt(
       signedTime,
       broadcastedTime,
-    )}) optimistic operation: ${formatOperation(account)(optimisticOperation)}\n`;
+    )}) optimistic operation: ${(await formatOperation(account))(optimisticOperation)}\n`;
   }
 
   if (operation) {
-    str += `✔️ operation confirmed (${formatDt(broadcastedTime, confirmedTime)}): ${formatOperation(
-      finalAccount || account,
+    str += `✔️ operation confirmed (${formatDt(broadcastedTime, confirmedTime)}): ${(
+      await formatOperation(finalAccount || account)
     )(operation)}\n`;
   }
 
   if (finalAccount) {
-    str += `✔️ ${formatAccount(finalAccount, "basic")}`;
+    str += `✔️ ${await formatAccount(finalAccount, "basic")}`;
   }
 
   if (testDuration) {
@@ -155,7 +155,7 @@ export async function formatReportForConsole<T extends Transaction>({
   }
 
   if (finalDestination && finalDestinationOperation) {
-    str += `✔️ destination operation ${formatOperation(finalDestination)(
+    str += `✔️ destination operation ${(await formatOperation(finalDestination))(
       finalDestinationOperation,
     )}\n`;
   }

--- a/libs/ledger-live-common/src/bot/index.ts
+++ b/libs/ledger-live-common/src/bot/index.ts
@@ -616,7 +616,7 @@ export async function bot({ disabled, filter }: Arg = {}): Promise<void> {
   });
 
   appendBody("\n```\n");
-  appendBody(allAccountsAfter.map(a => formatAccount(a, "head")).join("\n"));
+  appendBody((await Promise.all(allAccountsAfter.map(a => formatAccount(a, "head")))).join("\n"));
   appendBody("\n```\n");
 
   appendBody("\n</details>\n\n");

--- a/libs/ledger-live-common/src/hooks/useBroadcast.ts
+++ b/libs/ledger-live-common/src/hooks/useBroadcast.ts
@@ -77,7 +77,7 @@ export const useBroadcast = ({
           });
           log(
             "transaction-summary",
-            `✔️ broadcasted! optimistic operation: ${formatOperation(mainAccount)(operation)}`,
+            `✔️ broadcasted! optimistic operation: ${(await formatOperation(mainAccount))(operation)}`,
           );
           if (logger) {
             logger({


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - `formatAccount` and `formatOperation` (in `libs/ledger-live-common/src/account/formatters.ts`) now return a `Promise`. All in-tree call sites are updated. Behavior is unchanged today; the `await` on `getAccountBridge` is a no-op until that helper becomes async.
  - QA: bot reports, CLI `send` / `confirmOp` / `botTransfer` output, mobile transaction-summary logs.

### Description

Extracted from #17155 to ship the formatter signature change independently and shrink that PR's diff.

`formatAccount` / `formatOperation` are made `async` so they can `await getAccountBridge(account)`. This is forward-compatible: today `getAccountBridge` is sync (the `await` resolves immediately), and once #17155 lands it will be async without further call-site churn.

Call sites updated:
- `apps/cli/src/commands/blockchain/{botTransfer,confirmOp,send}.ts`
- `apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts`
- `libs/ledger-live-common/src/bot/{engine,formatters,index}.ts`
- `libs/ledger-live-common/src/hooks/useBroadcast.ts`

Consumer impact:

```diff
-const str = formatAccount(account, "basic");
+const str = await formatAccount(account, "basic");

-const fmt = formatOperation(account);
+const fmt = await formatOperation(account);
```

### Context

- **JIRA or GitHub link**: depends on / extracted from #17155
- **ADR link (if any)**: none