### PR TITLE
[LWM] fix(lwm): opt out of Android predictive back to prevent navigation freeze

### DIFF
--- a/apps/ledger-live-mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/ledger-live-mobile/android/app/src/main/AndroidManifest.xml
@@ -50,6 +50,7 @@
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
       android:allowBackup="false"
+      android:enableOnBackInvokedCallback="false"
       android:theme="@style/AppTheme"
       android:networkSecurityConfig="@xml/network_security_config"
       android:supportsRtl="true">

--- a/apps/ledger-live-mobile/android/app/src/main/java/com/ledger/live/MainActivity.kt
+++ b/apps/ledger-live-mobile/android/app/src/main/java/com/ledger/live/MainActivity.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.view.WindowManager
-import androidx.activity.OnBackPressedCallback
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
@@ -32,14 +31,6 @@ class MainActivity : ReactActivity() {
             )
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
-            override fun handleOnBackPressed() {
-                isEnabled = false
-                this@MainActivity.onBackPressed()
-                isEnabled = true
-            }
-        })
-
         if (android.os.Build.VERSION.SDK_INT >= 31) {
             installSplashScreen()
         }
@@ -50,10 +41,6 @@ class MainActivity : ReactActivity() {
 
         val sharedI18nUtilInstance = I18nUtil.getInstance()
         sharedI18nUtilInstance.allowRTL(applicationContext, true)
-    }
-
-    override fun invokeDefaultOnBackPressed() {
-        moveTaskToBack(false)
     }
 
     override fun onWindowFocusChanged(hasFocus: Boolean) {


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** No unit test — this is a manifest/native-config change for an OS-level behaviour (Android 16 predictive back). Must be validated on a physical Android 16 device.
- [x] **Impact of the changes:**
  - QA focus: Android 16 navigation flow — open the app with one BTC and one ETH account, then navigate between Wallet, Earn, Discover, Manager, Settings, and back. Confirm the app no longer freezes.
  - QA focus: Hardware back button + edge-swipe back gesture on Android 13/14/15/16 — confirm back navigation still works as expected on all SDKs and that `BackHandler` listeners in JS (e.g. modal/drawer dismissals) still fire.
  - No iOS impact.

### 📝 Description

**Bug:** [LIVE-30532](https://ledgerhq.atlassian.net/browse/LIVE-30532) — on Android 16, the app freezes while navigating after the user has added accounts. JS thread keeps running (countervalues, sync queue, BLE traffic all continue in the in-app logs), but the UI stops responding — the signature of a UI/render-thread stall, not a JS crash.

**Root cause:** `targetSdkVersion = 36` plus `newArchEnabled = true` puts the app fully on Android 16's enforced predictive-back path. Back events are routed through `OnBackPressedDispatcher`. The prior native bridge in `MainActivity.kt` registered an `OnBackPressedCallback(enabled = true)` unconditionally and called the deprecated `onBackPressed()` inside it — on SDK 33+ that re-enters the dispatcher and interferes with React Navigation's own back handling, contributing to the UI-thread stall rather than fixing it.

**Fix:** opt out of predictive back at the manifest level — the official Google escape hatch for apps not yet fully migrated. With predictive back disabled, the OS keeps routing back events through the legacy `onBackPressed()` path that RN's `BackHandler` already supports, and no native bridge is needed.

Changes:
- `apps/ledger-live-mobile/android/app/src/main/AndroidManifest.xml` — add `android:enableOnBackInvokedCallback="false"` to `<application>`.
- `apps/ledger-live-mobile/android/app/src/main/java/com/ledger/live/MainActivity.kt` — remove the `OnBackPressedCallback` registration, the `invokeDefaultOnBackPressed()` override, and the unused `androidx.activity.OnBackPressedCallback` import.
- `.changeset/android-predictive-back-optout.md` — `live-mobile` minor changeset.

Net: +1 line in the manifest, −13 lines of native Kotlin, no new dependencies.

### ❓ Context

- **JIRA**: [LIVE-30532](https://ledgerhq.atlassian.net/browse/LIVE-30532)
- **ADR link (if any)**: n/a
- **Android guidance**: [`enableOnBackInvokedCallback` — Migrate to predictive back](https://developer.android.com/guide/navigation/custom-back/predictive-back-gesture#opt-out) (recommended opt-out path while React Native / React Navigation predictive-back support stabilises).

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30532]: https://ledgerhq.atlassian.net/browse/LIVE-30532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-30532]: https://ledgerhq.atlassian.net/browse/LIVE-30532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ