### PR TITLE
[LWM] fix(mobile): improve swiper card transitions

### DIFF
--- a/.changeset/gentle-swipers-glide.md
+++ b/.changeset/gentle-swipers-glide.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix mobile swiper gesture resistance and single-card swipe handling

--- a/apps/ledger-live-mobile/src/mvvm/components/Swiper/components/SwipeableCard.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/Swiper/components/SwipeableCard.tsx
@@ -1,14 +1,18 @@
 import React from "react";
 import { Dimensions, StyleSheet } from "react-native";
 import Animated, {
+  Extrapolation,
   interpolate,
   SharedValue,
   useAnimatedStyle,
   withSpring,
+  WithSpringConfig,
 } from "react-native-reanimated";
 
 const { width } = Dimensions.get("window");
-const SPRING_CONFIG = {
+const FOLLOW_DISTANCE = width * 0.45;
+
+const SPRING_CONFIG: WithSpringConfig = {
   damping: 30,
   stiffness: 400,
   overshootClamping: true,
@@ -37,11 +41,31 @@ function useSwipeStyle(swipeX: SharedValue<number>, swipeY: SharedValue<number>,
       translateY = swipeY.value;
       rotateDeg = interpolate(swipeX.value, [-width / 2, 0, width / 2], [-16, 0, 15]);
     } else if (isNext) {
-      scale = interpolate(Math.abs(swipeX.value), [0, width], [0.95, 1]);
-      translateY = interpolate(Math.abs(swipeX.value), [0, width], [-28, 0]);
+      scale = interpolate(
+        Math.abs(swipeX.value),
+        [0, FOLLOW_DISTANCE],
+        [0.95, 1],
+        Extrapolation.CLAMP,
+      );
+      translateY = interpolate(
+        Math.abs(swipeX.value),
+        [0, FOLLOW_DISTANCE],
+        [-28, 0],
+        Extrapolation.CLAMP,
+      );
     } else if (isAfterNext) {
-      scale = interpolate(index, [2, 5], [0.9, 0.8]);
-      translateY = interpolate(index, [2, 5], [-56, -96]);
+      scale = interpolate(
+        Math.abs(swipeX.value),
+        [0, FOLLOW_DISTANCE],
+        [0.9, 0.95],
+        Extrapolation.CLAMP,
+      );
+      translateY = interpolate(
+        Math.abs(swipeX.value),
+        [0, FOLLOW_DISTANCE],
+        [-56, -28],
+        Extrapolation.CLAMP,
+      );
     }
 
     return {

--- a/apps/ledger-live-mobile/src/mvvm/components/Swiper/hooks/useSwiper.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/Swiper/hooks/useSwiper.ts
@@ -14,6 +14,7 @@ export function useSwiper<T>(
   const swipeY = useSharedValue(0);
 
   const cards = useCardRotation(cardIndex, initialCards);
+  const canSwipeAway = initialCards.length > 1;
 
   const handleSwipeComplete = useCallback(() => {
     const nextIndex = (cardIndex + 1) % initialCards.length;
@@ -30,7 +31,7 @@ export function useSwiper<T>(
     swipeY.value = 0;
   }, [cardIndex, swipeX, swipeY]);
 
-  const gesture = createGesture(swipeX, swipeY, handleSwipeComplete);
+  const gesture = createGesture(swipeX, swipeY, handleSwipeComplete, canSwipeAway);
 
   return { cards, gesture, swipeX, swipeY };
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/Swiper/utils/gesture.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/Swiper/utils/gesture.ts
@@ -13,21 +13,18 @@ const SWIPE_CONFIG = {
   MULTIPLIER_Y: 1.5,
   VELOCITY_THRESHOLD: 400,
   VELOCITY_Y_MULTIPLIER: 0.3,
+  VERTICAL_RESISTANCE_DISTANCE: height * 0.25,
   THRESHOLD_X: width * 0.3,
   THRESHOLD_Y: height * 0.3,
   TIMEOUT: 250,
 };
 
-function resetGesture({ swipeX, swipeY, velocityX, velocityY }: GestureParams) {
+function resetGesture({ swipeX, swipeY }: GestureParams) {
   "worklet";
   swipeX.value = withSpring(0, {
-    velocity: velocityX,
-    damping: SWIPE_CONFIG.DAMPING,
     overshootClamping: true,
   });
   swipeY.value = withSpring(0, {
-    velocity: velocityY,
-    damping: SWIPE_CONFIG.DAMPING,
     overshootClamping: true,
   });
 }
@@ -77,7 +74,12 @@ function isHorizontalAngle(angle: number): boolean {
   return (angle > -40 && angle < 40) || angle > 140 || angle < -140;
 }
 
-function createGesture(swipeX: SwipeValues, swipeY: SwipeValues, handleSwipeComplete: () => void) {
+function createGesture(
+  swipeX: SwipeValues,
+  swipeY: SwipeValues,
+  handleSwipeComplete: () => void,
+  canSwipeAway: boolean,
+) {
   // Wrapper that delays the completion callback to let the swipe animation finish
   const delayedComplete = () => {
     setTimeout(handleSwipeComplete, SWIPE_CONFIG.TIMEOUT);
@@ -86,11 +88,11 @@ function createGesture(swipeX: SwipeValues, swipeY: SwipeValues, handleSwipeComp
   return Gesture.Pan()
     .withTestId("pan")
     .onUpdate(event => {
-      const angle = Math.atan2(event.translationY, event.translationX) * (180 / Math.PI);
-      if (isHorizontalAngle(angle)) {
-        swipeX.value = event.translationX;
-        swipeY.value = event.translationY;
-      }
+      const resistance =
+        SWIPE_CONFIG.VERTICAL_RESISTANCE_DISTANCE /
+        (SWIPE_CONFIG.VERTICAL_RESISTANCE_DISTANCE + Math.abs(event.translationY));
+      swipeX.value = event.translationX;
+      swipeY.value = event.translationY * resistance;
     })
     .onEnd(event => {
       const angle = Math.atan2(event.translationY, event.translationX) * (180 / Math.PI);
@@ -103,6 +105,7 @@ function createGesture(swipeX: SwipeValues, swipeY: SwipeValues, handleSwipeComp
       };
 
       if (
+        canSwipeAway &&
         isHorizontalAngle(angle) &&
         canSwipeHorizontal(params.swipeX.value, params.velocityX, SWIPE_CONFIG.THRESHOLD_X)
       ) {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No test files were updated in this pass per request; validated with mobile typecheck._
- [x] **Impact of the changes:**
  - Large Movers landing page swiper transitions
  - Card stack animation while swiping between landing pages
  - Horizontal swipe gesture handling with resisted vertical movement
  - Single-card swiper behavior, which now resets instead of swiping away

### 📝 Description

This PR fixes swiper interaction issues on the Large Movers landing page, including unstable card transitions and swipe behavior when the card stack contains only one item.

The swiper now applies Y-axis resistance during pan updates, prevents swipe-away completion when only one card is available, and smooths inactive card stack transitions with clamped interpolation. A changeset was added for `live-mobile`.

https://github.com/user-attachments/assets/b86a3031-7ea0-4ff6-8c70-bccb5e8584db


https://github.com/user-attachments/assets/99f17741-cbd1-4e7a-9bc5-bd3b726827d2



before 

https://github.com/user-attachments/assets/2b6083a5-a3d8-4b4c-afe5-6cd0dd496d5f

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28067](https://ledgerhq.atlassian.net/browse/LIVE-28067)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-28067]: https://ledgerhq.atlassian.net/browse/LIVE-28067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ