### PR TITLE
[LWM] fix(lwm): stop add-account rows from disappearing on Android

### DIFF
--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/components/AccountsListView/components/AnimatedAccountItem/useItemAnimation.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/components/AccountsListView/components/AnimatedAccountItem/useItemAnimation.ts
@@ -9,10 +9,8 @@ import {
 } from "react-native-reanimated";
 
 const ANIMATION_CONFIG = {
-  size: {
+  opacity: {
     duration: 500,
-    from: 0,
-    to: 100,
   },
   position: {
     duration: 350,
@@ -34,7 +32,6 @@ const DEFAULT_TIMING_CONFIG: WithTimingConfig = {
 };
 
 export default function useItemAnimation(index: number = 0) {
-  const height = useSharedValue(ANIMATION_CONFIG.size.from);
   const opacity = useSharedValue(0);
   const y = useSharedValue(ANIMATION_CONFIG.position.from);
   const centerY = useSharedValue(ANIMATION_CONFIG.position.from);
@@ -49,19 +46,19 @@ export default function useItemAnimation(index: number = 0) {
 
   const baseDelay = index * ANIMATION_CONFIG.itemDelay;
 
+  // height intentionally omitted: a percent-based height inside a FlatList row
+  // whose parent has no explicit height collapses on Android and breaks
+  // virtualization (LIVE-30528).
   const animatedStyle = useAnimatedStyle(
     () => ({
-      height: `${height.value}%`,
       opacity: opacity.value,
       transform: [{ translateY: y.value }, { translateY: centerY.value }, { scale: scale.value }],
-      flex: 1,
     }),
-    [height, opacity, y, centerY, scale],
+    [opacity, y, centerY, scale],
   );
 
   const startAnimation = useCallback(() => {
-    animate(height, ANIMATION_CONFIG.size.to, ANIMATION_CONFIG.size.duration, baseDelay);
-    animate(opacity, 1, ANIMATION_CONFIG.size.duration, baseDelay);
+    animate(opacity, 1, ANIMATION_CONFIG.opacity.duration, baseDelay);
     animate(
       y,
       ANIMATION_CONFIG.position.to,
@@ -80,7 +77,7 @@ export default function useItemAnimation(index: number = 0) {
       ANIMATION_CONFIG.scale.duration,
       baseDelay + ANIMATION_CONFIG.scale.delay,
     );
-  }, [animate, height, baseDelay, opacity, y, centerY, scale]);
+  }, [animate, baseDelay, opacity, y, centerY, scale]);
 
   return { animatedStyle, startAnimation };
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Bug is layout/animation-specific on Android; visual regression coverage is not in place for the Add Account list. Verified manually with the repro from LIVE-30528.
- [x] **Impact of the changes:**
  - LWM Add Account flow on Android — "Select the accounts you want to add" screen.
  - Row entry animation visuals (slightly softer entry, no height grow-in).
  - The same animation hook is used by the regular Accounts list (`AnimatedAccountItem`); behaviour preserved there.

### 📝 Description

**Bug:** On Android, after the scan finishes on the "Select the accounts you want to add" screen, the account rows disappear within a few seconds while the section header still reads "We found N accounts". Only a fragment of the UI remains, making the flow unusable.

**Cause:** The per-row entry animation (`useItemAnimation`) animated `height` from `0%` to `100%` on each row's `Animated.View`. That row sits inside a `FlatList` (`SelectableAccountsList`) which is itself nested inside `NavigationScrollView` (`ScanDeviceAccounts/index.tsx`). The FlatList has no constrained parent height, so on Android a percent-based row height collapses to `0`. Once a few accounts arrive and re-renders fire, the FlatList's virtualization measures rows as zero-height and unmounts them — the header keeps showing the count because it reads from `data.length`, not from what's painted.

**Fix:** Drop the `height` tween from the animated style and remove the now-unused `height` shared value. Opacity, translateY and scale animations are kept, so the entry still feels animated — rows just always render at natural height.

| Before | After |
| ------ | ----- |
| rows vanish ~few seconds after scan | rows stay visible until the user moves on |

### ❓ Context

- **JIRA**: [LIVE-30528](https://ledgerhq.atlassian.net/browse/LIVE-30528)
- **ADR link (if any)**: n/a

[LIVE-30528]: https://ledgerhq.atlassian.net/browse/LIVE-30528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ