### PR TITLE
[LWD] fix(desktop): close perps missing app dialog on redirect to My Ledger

### DIFF
--- a/.changeset/warm-modals-close.md
+++ b/.changeset/warm-modals-close.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix perps "Missing required app" dialog not closing when clicking "Open My Ledger"

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsSign/PerpsSignView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsSign/PerpsSignView.tsx
@@ -11,6 +11,7 @@ export function PerpsSignView({
   request,
   handleDeviceResult,
   handleDeviceError,
+  handleOpenManager,
 }: Readonly<PerpsSignViewModel>) {
   if (phase === "sign" && device) {
     return (
@@ -30,6 +31,7 @@ export function PerpsSignView({
           request={request}
           onResult={handleDeviceResult}
           onError={handleDeviceError}
+          onOpenManager={handleOpenManager}
         />
       </DialogBody>
     </>

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsSign/__tests__/usePerpsSignViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsSign/__tests__/usePerpsSignViewModel.test.ts
@@ -142,6 +142,35 @@ describe("usePerpsSignViewModel", () => {
     expect(data.onCancel).not.toHaveBeenCalled();
   });
 
+  it("should call onClose without onError when handleOpenManager is invoked", () => {
+    const data = createMockData();
+    const onClose = jest.fn();
+    const { result } = renderHook(() => usePerpsSignViewModel(data, onClose));
+
+    act(() => {
+      result.current.handleOpenManager();
+    });
+
+    expect(onClose).toHaveBeenCalled();
+    expect(data.onError).not.toHaveBeenCalled();
+    expect(result.current.closing).toBe(true);
+  });
+
+  it("should call onCancel after handleOpenManager + unmount", () => {
+    const data = createMockData();
+    const onClose = jest.fn();
+    const { result, unmount } = renderHook(() => usePerpsSignViewModel(data, onClose));
+
+    act(() => {
+      result.current.handleOpenManager();
+    });
+
+    unmount();
+
+    expect(data.onCancel).toHaveBeenCalledTimes(1);
+    expect(data.onError).not.toHaveBeenCalled();
+  });
+
   it("should build request from data app options", () => {
     const data = createMockData({
       appName: "TestApp",

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsSign/usePerpsSignViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsSign/usePerpsSignViewModel.ts
@@ -32,6 +32,7 @@ export type PerpsSignViewModel = {
   closing: boolean;
   handleDeviceResult: (result: AppResult) => void;
   handleDeviceError: (error: Error) => void;
+  handleOpenManager: () => void;
 };
 
 export function usePerpsSignViewModel(
@@ -101,6 +102,13 @@ export function usePerpsSignViewModel(
     [data, onClose],
   );
 
+  // User navigated to My Ledger to install/update the required app.
+  // Dismiss the dialog; the unmount cleanup will fire data.onCancel().
+  const handleOpenManager = useCallback(() => {
+    setClosing(true);
+    onClose();
+  }, [onClose]);
+
   return {
     phase: device ? "sign" : "connect",
     closing,
@@ -109,5 +117,6 @@ export function usePerpsSignViewModel(
     request,
     handleDeviceResult,
     handleDeviceError,
+    handleOpenManager,
   };
 }

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/deviceAction.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/deviceAction.test.tsx
@@ -228,6 +228,38 @@ describe("DeviceAction - Deprecation", () => {
     expect(mockOnContinue).toHaveBeenCalled();
   });
 
+  it("should call onOpenManager (not onError) when clicking 'Open My Ledger' on the missing app screen", () => {
+    const mockAction = {
+      useHook: jest.fn(() => ({
+        deviceDeprecationRules: null,
+        requiresAppInstallation: {
+          appName: "Hyperliquid",
+          appNames: ["Hyperliquid"],
+        },
+      })),
+      mapResult: jest.fn(),
+    };
+
+    const onOpenManager = jest.fn();
+    const onError = jest.fn();
+
+    render(
+      <DeviceAction
+        action={mockAction}
+        request={{ account: ETH_ACCOUNT }}
+        location={HOOKS_TRACKING_LOCATIONS.sendModal}
+        onOpenManager={onOpenManager}
+        onError={onError}
+      />,
+    );
+
+    const openManagerButton = screen.getByText("Open My Ledger");
+    fireEvent.click(openManagerButton);
+
+    expect(onOpenManager).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   it("should display Error Screen", () => {
     const device: Device = {
       modelId: DeviceModelId.nanoS,

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
@@ -173,6 +173,7 @@ type InnerProps<P> = {
   Result?: React.ComponentType<P>;
   onResult?: (_: NonNullable<P>) => void;
   onError?: (_: Error) => Promise<void> | void;
+  onOpenManager?: () => void;
   renderOnResult?: (_: P) => React.JSX.Element | null;
   renderDeviceSignatureRequested?: (args: { device: Device; request: unknown }) => React.ReactNode;
   renderLockedDevice?: (args: {
@@ -212,6 +213,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
   Result,
   onResult,
   onError,
+  onOpenManager,
   renderDeviceSignatureRequested,
   renderLockedDevice,
   overridesPreferredDeviceModel,
@@ -493,7 +495,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
     const { appName, appNames: maybeAppNames } = requiresAppInstallation;
     const appNames = maybeAppNames?.length ? maybeAppNames : [appName];
 
-    return renderRequiresAppInstallation({ appNames });
+    return renderRequiresAppInstallation({ appNames, onOpenManager });
   }
 
   if (allowRenamingRequested) {

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -347,6 +347,7 @@ const OpenManagerBtn = ({
   appName,
   updateApp,
   firmwareUpdate,
+  onOpenManager,
   mt = 2,
   ml = 0,
 }: {
@@ -355,6 +356,7 @@ const OpenManagerBtn = ({
   appName?: string;
   updateApp?: boolean;
   firmwareUpdate?: boolean;
+  onOpenManager?: () => void;
   mt?: number;
   ml?: number;
 }) => {
@@ -373,6 +375,7 @@ const OpenManagerBtn = ({
     closeAllModal();
     closePlatformAppDrawer();
     setDrawer(undefined);
+    onOpenManager?.();
   }, [
     updateApp,
     firmwareUpdate,
@@ -381,6 +384,7 @@ const OpenManagerBtn = ({
     closeAllModal,
     closePlatformAppDrawer,
     setDrawer,
+    onOpenManager,
   ]);
 
   return (
@@ -414,7 +418,13 @@ const OpenManagerButton = connect(null, {
   closePlatformAppDrawer,
 })(OpenManagerBtn);
 
-export const renderRequiresAppInstallation = ({ appNames }: { appNames: string[] }) => {
+export const renderRequiresAppInstallation = ({
+  appNames,
+  onOpenManager,
+}: {
+  appNames: string[];
+  onOpenManager?: () => void;
+}) => {
   const appNamesCSV = appNames.join(", ");
   return (
     <Wrapper>
@@ -432,7 +442,7 @@ export const renderRequiresAppInstallation = ({ appNames }: { appNames: string[]
         />
       </ErrorDescription>
       <Box mt={24}>
-        <OpenManagerButton appName={appNamesCSV} />
+        <OpenManagerButton appName={appNamesCSV} onOpenManager={onOpenManager} />
       </Box>
     </Wrapper>
   );


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Added unit tests for `usePerpsSignViewModel.handleOpenManager` (calls `onClose`, leaves `onError` untouched, lets `onCancel` fire on unmount) and a `DeviceAction` test verifying that clicking **Open My Ledger** on the missing‑app screen invokes the new `onOpenManager` prop and not `onError`.
- [x] **Impact of the changes:**
      - Perps sign flow when the Hyperliquid app is not installed on the device
      - "Open My Ledger" button behavior in the `DeviceAction` `renderRequiresAppInstallation` screen
      - Adds a new optional `onOpenManager` prop on `DeviceAction` (opt‑in, no behavior change for existing consumers)

### 📝 Description

**Problem**: During the perps flow (open/close position), when the Hyperliquid app is not installed on the device, a "Missing required app" modal appears. Clicking "Open My Ledger" correctly navigates to the manager page, but the modal does not close — it stays open on top of the manager.

This happens because the `PerpsSignDialog` is a standalone Lumen UI `Dialog` managed by its own `useState`, not by the Redux modal system. The existing `closeAllModal()` / `closePlatformAppDrawer()` / `setDrawer(undefined)` calls in `OpenManagerBtn` don't affect it.

**Solution**: Add a dedicated `onOpenManager?: () => void` prop on `DeviceAction`, threaded down to `renderRequiresAppInstallation` and `OpenManagerBtn`. The button fires it right after performing its existing navigation + modal cleanup, so consumers can dismiss their own non‑Redux UI without overloading `onError` with a synthetic error.

In the perps view model, a new `handleOpenManager` callback:
- sets `closing = true` and calls `onClose()` to dismiss the Lumen `Dialog`,
- does **not** call `data.onError` (the user did not encounter an error — they voluntarily navigated to install the app),
- relies on the existing unmount cleanup to fire `data.onCancel()`, which is the correct semantic for the wallet‑API contract.

`PerpsSignView` wires `onOpenManager={handleOpenManager}` on its `DeviceAction`.

**Why a dedicated callback rather than reusing `onError`**: every other `DeviceAction` consumer (Send `SignatureScreen.finishWithError`, `EditDeviceName`, `ChangeDeviceLanguageAction`, `useTrackDmkErrorsEvents`/Datadog, the various tracking hooks keyed on `error`, …) would otherwise receive a synthetic `Error("App not installed: …")` when the user just clicked a navigation button. A dedicated callback keeps `onError` strictly for actual device errors and makes the intent explicit at every call site.

**Renamed for consistency**: the prop on `OpenManagerBtn` is now `onOpenManager` (was `onManagerOpened` in the previous revision) so both layers use the same name.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29935](https://ledgerhq.atlassian.net/browse/LIVE-29935)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-29935]: https://ledgerhq.atlassian.net/browse/LIVE-29935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ