### PR TITLE
[LWM] fix(mobile): close perps dialog when opening My Ledger

### DIFF
--- a/.changeset/fix-perps-open-manager-mobile.md
+++ b/.changeset/fix-perps-open-manager-mobile.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix perps "Missing required app" screen not dismissing when tapping "Open My Ledger" on mobile

--- a/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
@@ -138,6 +138,7 @@ type Status = PartialNullable<{
 type Props<H extends Status, P> = {
   onResult?: (_: NonNullable<P>) => Promise<void> | void;
   onError?: (_: Error) => Promise<void> | void;
+  onOpenManager?: () => void;
   renderOnResult?: (_: P) => React.JSX.Element | null;
   status: H;
   device: Device;
@@ -181,6 +182,7 @@ export default function DeviceAction<R, H extends Status, P>({
 export function DeviceActionDefaultRendering<R, H extends Status, P>({
   onResult,
   onError,
+  onOpenManager,
   device: selectedDevice,
   renderOnResult,
   onSelectDeviceLink,
@@ -488,6 +490,7 @@ export function DeviceActionDefaultRendering<R, H extends Status, P>({
       t,
       navigation,
       appNames,
+      onOpenManager,
       colors,
       theme,
     });

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -153,9 +153,11 @@ export function renderRequiresAppInstallation({
   t,
   navigation,
   appNames,
+  onOpenManager,
 }: RawProps & {
   navigation: NativeStackNavigationProp<ParamListBase>;
   appNames: string[];
+  onOpenManager?: () => void;
 }) {
   const appNamesCSV = appNames.join(", ");
 
@@ -172,12 +174,16 @@ export function renderRequiresAppInstallation({
           event="DeviceActionRequiresAppInstallationOpenManager"
           type="primary"
           title={t("DeviceAction.button.openManager")}
-          onPress={() =>
-            navigation.navigate(NavigatorName.MyLedger, {
-              screen: ScreenName.MyLedgerChooseDevice,
-              params: { searchQuery: appNamesCSV },
-            })
-          }
+          onPress={() => {
+            if (onOpenManager) {
+              onOpenManager();
+            } else {
+              navigation.navigate(NavigatorName.MyLedger, {
+                screen: ScreenName.MyLedgerChooseDevice,
+                params: { searchQuery: appNamesCSV },
+              });
+            }
+          }}
         />
       </ActionContainer>
     </Wrapper>

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsSign/__tests__/usePerpsSignViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsSign/__tests__/usePerpsSignViewModel.test.ts
@@ -12,6 +12,7 @@ function createNavigationProps(overrides: Record<string, unknown> = {}) {
     navigation: {
       goBack: jest.fn(),
       setOptions: jest.fn(),
+      replace: jest.fn(),
     },
     route: {
       params: {
@@ -173,7 +174,7 @@ describe("usePerpsSignViewModel", () => {
 
   it("should navigate back on handleDrawerHidden when signing completed", async () => {
     const onSuccess = jest.fn();
-    const navigation = { goBack: jest.fn(), setOptions: jest.fn() };
+    const navigation = { goBack: jest.fn(), setOptions: jest.fn(), replace: jest.fn() };
     const props = {
       navigation,
       route: {
@@ -201,5 +202,72 @@ describe("usePerpsSignViewModel", () => {
     });
 
     expect(navigation.goBack).toHaveBeenCalled();
+  });
+
+  it("should silently dismiss without calling onCancel and replace to MyLedger on handleOpenManager", () => {
+    const onCancel = jest.fn();
+    const onError = jest.fn();
+    const navigation = { goBack: jest.fn(), setOptions: jest.fn(), replace: jest.fn() };
+    const props = {
+      navigation,
+      route: {
+        params: {
+          appName: "Hyperliquid",
+          signFactory: jest.fn().mockResolvedValue({ signatures: [] }),
+          onSuccess: jest.fn(),
+          onError,
+          onCancel,
+          onClose: jest.fn(),
+        },
+      },
+    } as never;
+
+    const { result } = renderHook(() => usePerpsSignViewModel(props));
+
+    act(() => {
+      result.current.setSelectedDevice(mockDevice);
+    });
+    expect(result.current.drawerOpen).toBe(true);
+
+    act(() => {
+      result.current.handleOpenManager();
+    });
+
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+    expect(navigation.replace).toHaveBeenCalledWith("MyLedger", {
+      screen: "MyLedgerChooseDevice",
+      params: { searchQuery: "Hyperliquid" },
+    });
+  });
+
+  it("should not call onCancel after handleOpenManager + unmount", () => {
+    const onCancel = jest.fn();
+    const props = createNavigationProps({ onCancel });
+    const { result, unmount } = renderHook(() => usePerpsSignViewModel(props));
+
+    act(() => {
+      result.current.handleOpenManager();
+    });
+
+    unmount();
+
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("should not call onCancel when handleDrawerClose fires after handleOpenManager", () => {
+    const onCancel = jest.fn();
+    const props = createNavigationProps({ onCancel });
+    const { result } = renderHook(() => usePerpsSignViewModel(props));
+
+    act(() => {
+      result.current.handleOpenManager();
+    });
+
+    act(() => {
+      result.current.handleDrawerClose();
+    });
+
+    expect(onCancel).not.toHaveBeenCalled();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsSign/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsSign/index.tsx
@@ -48,12 +48,14 @@ function ConnectDeviceAction({
   device,
   onResult,
   onClose,
+  onOpenManager,
 }: Readonly<{
   action: PerpsSignViewModel["action"];
   request: PerpsSignViewModel["request"];
   device: Device;
   onResult: (result: AppResult) => void;
   onClose: () => void;
+  onOpenManager: () => void;
 }>) {
   return (
     <Box lx={{ alignItems: "center" }} testID="device-action-modal">
@@ -72,6 +74,7 @@ function ConnectDeviceAction({
           onResult={onResult}
           analyticsPropertyFlow="perps sign"
           onClose={onClose}
+          onOpenManager={onOpenManager}
         />
       </Box>
     </Box>
@@ -91,6 +94,7 @@ export function PerpsSignView({
   handleAppResult,
   handleDrawerClose,
   handleDrawerHidden,
+  handleOpenManager,
   requestToSetHeaderOptions,
 }: Readonly<PerpsSignViewModel>) {
   return (
@@ -121,6 +125,7 @@ export function PerpsSignView({
                 device={selectedDevice}
                 onResult={handleAppResult}
                 onClose={handleDrawerClose}
+                onOpenManager={handleOpenManager}
               />
             )
           )}

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsSign/usePerpsSignViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsSign/usePerpsSignViewModel.ts
@@ -8,7 +8,7 @@ import type { SetHeaderOptionsRequest } from "~/components/SelectDevice2";
 import { useAppDeviceAction } from "~/hooks/deviceActions";
 import type { RootComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
-import type { ScreenName } from "~/const";
+import { NavigatorName, ScreenName } from "~/const";
 
 type NavigationProps = RootComposite<
   StackNavigatorProps<BaseNavigatorStackParamList, ScreenName.PerpsSign>
@@ -34,6 +34,7 @@ export type PerpsSignViewModel = {
   handleAppResult: (result: AppResult) => void;
   handleDrawerClose: () => void;
   handleDrawerHidden: () => void;
+  handleOpenManager: () => void;
   requestToSetHeaderOptions: (req: SetHeaderOptionsRequest) => void;
 };
 
@@ -46,6 +47,7 @@ export function usePerpsSignViewModel({ navigation, route }: NavigationProps): P
   const [selectedDevice, setSelectedDevice] = useState<Device | null | undefined>();
   const [connectedDevice, setConnectedDevice] = useState<Device | null>(null);
   const completedRef = useRef(false);
+  const navigatingToManagerRef = useRef(false);
 
   const action = useAppDeviceAction();
   const request = useMemo(
@@ -74,7 +76,7 @@ export function usePerpsSignViewModel({ navigation, route }: NavigationProps): P
   }, [onCancel]);
 
   const handleDrawerHidden = useCallback(() => {
-    if (completedRef.current) {
+    if (completedRef.current && !navigatingToManagerRef.current) {
       navigation.goBack();
     }
   }, [navigation]);
@@ -123,6 +125,15 @@ export function usePerpsSignViewModel({ navigation, route }: NavigationProps): P
     };
   }, [connectedDevice, signFactory, onSuccess, onError]);
 
+  const handleOpenManager = useCallback(() => {
+    completedRef.current = true;
+    navigatingToManagerRef.current = true;
+    navigation.replace(NavigatorName.MyLedger, {
+      screen: ScreenName.MyLedgerChooseDevice,
+      params: { searchQuery: appName },
+    });
+  }, [navigation, appName]);
+
   useEffect(() => {
     return () => {
       if (!completedRef.current) {
@@ -144,6 +155,7 @@ export function usePerpsSignViewModel({ navigation, route }: NavigationProps): P
     handleAppResult,
     handleDrawerClose,
     handleDrawerHidden,
+    handleOpenManager,
     requestToSetHeaderOptions,
   };
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Added 3 unit tests for `usePerpsSignViewModel.handleOpenManager` covering: silent dismiss + navigation.replace; no onCancel/onError after handleOpenManager; no double-onCancel when handleDrawerClose fires after handleOpenManager.
- [x] **Impact of the changes:**
      - Perps sign flow when the Hyperliquid app is not installed on the device (mobile)
      - "Open My Ledger" button behavior in the mobile DeviceAction `renderRequiresAppInstallation` screen
      - Adds a new optional `onOpenManager` prop on mobile `DeviceAction` (opt-in, no behavior change for existing consumers)

### 📝 Description

**Problem**: During the perps flow on mobile (open/close position), when the Hyperliquid app is not installed on the device, the "Missing required app" screen appears. Tapping "Open My Ledger" navigates to MyLedger, but the `PerpsSignScreen` stays mounted underneath. The `QueuedDrawerBottomSheet` auto-closes on focus change, which drops the user back on the `SelectDevice2` device chooser. Tapping the device again re-enters the same connect/sign flow against the still-missing app, creating an infinite loop.

This happens because `renderRequiresAppInstallation` hard-codes `navigation.navigate(MyLedger, …)`, which pushes MyLedger over the perps stack without dismissing `PerpsSignScreen`.

**Solution**: Mirror the desktop fix ([PR #17408](https://github.com/LedgerHQ/ledger-live/pull/17408)). Add a dedicated `onOpenManager?: () => void` prop on the mobile `DeviceAction`, threaded through `renderRequiresAppInstallation`. When provided, the button calls `onOpenManager()` instead of the hard-coded navigation. Existing consumers that don't pass the prop keep the default behavior.

In the perps view model, a new `handleOpenManager` callback:
- Marks `completedRef` so neither `handleDrawerClose` nor the unmount cleanup fires `onCancel()` — this is a **silent dismiss** that leaves the dApp's signing promise pending, avoiding a "User cancelled signing" error dialog in the Live App
- Sets a `navigatingToManagerRef` flag so that `handleDrawerHidden` does not call `navigation.goBack()` when the drawer unmounts during the screen transition (which would immediately pop MyLedger off the stack)
- Calls `navigation.replace(NavigatorName.MyLedger, …)` so the user lands on MyLedger with `PerpsSignScreen` removed from the stack entirely — no stale screen to bounce back to

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29935](https://ledgerhq.atlassian.net/browse/LIVE-29935)
- **Related**: Desktop fix in [PR #17408](https://github.com/LedgerHQ/ledger-live/pull/17408)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-29935]: https://ledgerhq.atlassian.net/browse/LIVE-29935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ