### PR TITLE
[LWDM] fix(live-30586): zcash shielded transaction timestamps

### DIFF
--- a/.changeset/quick-rules-rescue.md
+++ b/.changeset/quick-rules-rescue.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-bitcoin": patch
+---
+
+Fix zcash shielded txs timestamp

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/operations.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/operations.test.ts
@@ -244,7 +244,7 @@ describe("convertShieldedTransactionsToOperations", () => {
       blockHash: "blockhash1",
       blockHeight: 100,
       type: "SHIELDED_TX_ORCHARD_IN",
-      date: new Date(1700000000),
+      date: new Date(1700000000 * 1000), // timestamp is in Unix seconds
       fee: new BigNumber(500),
       value: new BigNumber(1000),
     });

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/operations.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/operations.ts
@@ -96,7 +96,7 @@ export function convertShieldedTransactionsToOperations(
       type: txType,
       senders: [],
       recipients: [],
-      date: new Date(tx.timestamp),
+      date: new Date(tx.timestamp * 1000), // zcash shielded transaction timestamps are Unix seconds.
       value,
       fee: new BigNumber(tx.fee),
       extra: {},


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [X] `npx changeset` was attached.
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [X] **Impact of the changes:** Display shielded transactions in history

### 📝 Description

Shielded tx timestamp are return in seconds

### ❓ Context

- **JIRA or GitHub link**: LIVE-30586

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
