### PR TITLE
[LWM] feat(mobile): add info state component

### DIFF
--- a/.changeset/live-30551-info-state.md
+++ b/.changeset/live-30551-info-state.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add reusable mobile info state component

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
@@ -42,6 +42,7 @@ import DebugSwap from "~/screens/Settings/Debug/Features/Swap";
 import DebugVideos from "~/screens/Settings/Debug/Features/Videos";
 import TooltipDemo from "~/screens/Settings/Debug/Features/TooltipDemo";
 import DebugDeviceActionContentScreen from "~/screens/Settings/Debug/Features/DeviceIntentExecutor/DeviceActionContentScreen";
+import DebugInfoStateScreen from "~/screens/Settings/Debug/Features/DeviceIntentExecutor/InfoStateScreen";
 import DebugDeviceIntentExecutorInitialization from "~/screens/Settings/Debug/Features/DeviceIntentExecutor/InitializationScreen";
 import DebugDeviceIntentExecutorOrchestration from "~/screens/Settings/Debug/Features/DeviceIntentExecutor/OrchestrationScreen";
 import Settings from "~/screens/Settings";
@@ -315,6 +316,13 @@ export default function SettingsNavigator() {
         component={DebugDeviceActionContentScreen}
         options={{
           title: "DIE Device Action Content",
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.DebugDeviceIntentExecutorInfoState}
+        component={DebugInfoStateScreen}
+        options={{
+          title: "DIE Info State",
         }}
       />
       <Stack.Screen

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/SettingsNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/SettingsNavigator.ts
@@ -36,6 +36,7 @@ export type SettingsNavigatorStackParamList = {
   [ScreenName.DebugDebugging]: undefined;
   [ScreenName.DebugDeviceIntentExecutor]: undefined;
   [ScreenName.DebugDeviceIntentExecutorContent]: undefined;
+  [ScreenName.DebugDeviceIntentExecutorInfoState]: undefined;
   [ScreenName.DebugDeviceIntentExecutorInitialization]: undefined;
   [ScreenName.DebugDeviceIntentExecutorOrchestration]: undefined;
   [ScreenName.DebugConfiguration]: undefined;

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -41,6 +41,7 @@ export enum ScreenName {
   DebugDebugging = "DebugDebugging",
   DebugDeviceIntentExecutor = "DebugDeviceIntentExecutor",
   DebugDeviceIntentExecutorContent = "DebugDeviceIntentExecutorContent",
+  DebugDeviceIntentExecutorInfoState = "DebugDeviceIntentExecutorInfoState",
   DebugDeviceIntentExecutorInitialization = "DebugDeviceIntentExecutorInitialization",
   DebugDeviceIntentExecutorOrchestration = "DebugDeviceIntentExecutorOrchestration",
   DebugQueuedDrawers = "DebugQueuedDrawers",

--- a/apps/ledger-live-mobile/src/mvvm/components/InfoState/InfoState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/InfoState/InfoState.test.tsx
@@ -2,7 +2,9 @@ import React from "react";
 import { fireEvent, render, screen } from "@tests/test-renderer";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { Search } from "@ledgerhq/lumen-ui-rnative/symbols";
-import { InfoState } from ".";
+import { InfoState, type InfoStatePreset } from ".";
+
+type VisualInfoStatePreset = Exclude<InfoStatePreset, "text">;
 
 describe("InfoState", () => {
   it("renders title, description, banner, and actions", () => {
@@ -76,7 +78,7 @@ describe("InfoState", () => {
 });
 
 function getPresetProps(
-  preset: "success" | "error" | "info" | "spot" | "illustration",
+  preset: VisualInfoStatePreset,
 ): React.ComponentProps<typeof InfoState> {
   switch (preset) {
     case "illustration":
@@ -93,5 +95,11 @@ function getPresetProps(
     case "error":
     case "info":
       return { preset };
+    default:
+      return assertNever(preset);
   }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled info state preset: ${value}`);
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/InfoState/InfoState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/InfoState/InfoState.test.tsx
@@ -1,17 +1,18 @@
 import React from "react";
-import { fireEvent, render, screen } from "@tests/test-renderer";
+import { render, screen } from "@tests/test-renderer";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { Search } from "@ledgerhq/lumen-ui-rnative/symbols";
-import { InfoState, type InfoStatePreset } from ".";
+import { InfoState } from ".";
+import type { InfoStatePreset } from "./types";
 
 type VisualInfoStatePreset = Exclude<InfoStatePreset, "text">;
 
 describe("InfoState", () => {
-  it("renders title, description, banner, and actions", () => {
+  it("renders title, description, banner, and actions", async () => {
     const onPrimaryPress = jest.fn();
     const onSecondaryPress = jest.fn();
 
-    render(
+    const { user } = render(
       <InfoState
         preset="success"
         title="State title"
@@ -35,8 +36,8 @@ describe("InfoState", () => {
     expect(screen.getByText("Banner title")).toBeVisible();
     expect(screen.getByText("Banner description")).toBeVisible();
 
-    fireEvent.press(screen.getByTestId("info-state-primary"));
-    fireEvent.press(screen.getByTestId("info-state-secondary"));
+    await user.press(screen.getByTestId("info-state-primary"));
+    await user.press(screen.getByTestId("info-state-secondary"));
 
     expect(onPrimaryPress).toHaveBeenCalledTimes(1);
     expect(onSecondaryPress).toHaveBeenCalledTimes(1);
@@ -77,9 +78,7 @@ describe("InfoState", () => {
   });
 });
 
-function getPresetProps(
-  preset: VisualInfoStatePreset,
-): React.ComponentProps<typeof InfoState> {
+function getPresetProps(preset: VisualInfoStatePreset): React.ComponentProps<typeof InfoState> {
   switch (preset) {
     case "illustration":
       return {
@@ -101,5 +100,5 @@ function getPresetProps(
 }
 
 function assertNever(value: never): never {
-  throw new Error(`Unhandled info state preset: ${value}`);
+  throw new Error(`Unhandled info state preset: ${JSON.stringify(value)}`);
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/InfoState/InfoState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/InfoState/InfoState.test.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { fireEvent, render, screen } from "@tests/test-renderer";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
+import { Search } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { InfoState } from ".";
+
+describe("InfoState", () => {
+  it("renders title, description, banner, and actions", () => {
+    const onPrimaryPress = jest.fn();
+    const onSecondaryPress = jest.fn();
+
+    render(
+      <InfoState
+        preset="success"
+        title="State title"
+        description="State description"
+        banner={{ title: "Banner title", description: "Banner description" }}
+        primaryCta={{
+          label: "Primary action",
+          onPress: onPrimaryPress,
+          testID: "info-state-primary",
+        }}
+        secondaryCta={{
+          label: "Secondary action",
+          onPress: onSecondaryPress,
+          testID: "info-state-secondary",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("State title")).toBeVisible();
+    expect(screen.getByText("State description")).toBeVisible();
+    expect(screen.getByText("Banner title")).toBeVisible();
+    expect(screen.getByText("Banner description")).toBeVisible();
+
+    fireEvent.press(screen.getByTestId("info-state-primary"));
+    fireEvent.press(screen.getByTestId("info-state-secondary"));
+
+    expect(onPrimaryPress).toHaveBeenCalledTimes(1);
+    expect(onSecondaryPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides optional title, description, banner, and actions when props are omitted", () => {
+    render(<InfoState preset="info" testID="info-state" />);
+
+    expect(screen.getByTestId("info-state")).toBeVisible();
+    expect(screen.queryByText("State title")).toBeNull();
+    expect(screen.queryByText("State description")).toBeNull();
+    expect(screen.queryByText("Banner title")).toBeNull();
+    expect(screen.queryByText("Primary action")).toBeNull();
+    expect(screen.queryByText("Secondary action")).toBeNull();
+  });
+
+  it.each(["success", "error", "info", "spot", "illustration"] as const)(
+    "renders the %s preset visual",
+    preset => {
+      render(
+        <InfoState
+          {...getPresetProps(preset)}
+          title={`${preset} title`}
+          testID={`info-state-${preset}`}
+        />,
+      );
+
+      expect(screen.getByTestId(`info-state-${preset}`)).toBeVisible();
+      expect(screen.getByText(`${preset} title`)).toBeVisible();
+    },
+  );
+
+  it("renders text preset without a preset visual gap", () => {
+    render(<InfoState preset="text" title="Text-only title" testID="info-state-text" />);
+
+    expect(screen.getByText("Text-only title")).toBeVisible();
+    expect(screen.getByTestId("info-state-text")).toBeVisible();
+  });
+});
+
+function getPresetProps(
+  preset: "success" | "error" | "info" | "spot" | "illustration",
+): React.ComponentProps<typeof InfoState> {
+  switch (preset) {
+    case "illustration":
+      return {
+        preset,
+        illustration: <Box testID="info-state-illustration-visual" />,
+      };
+    case "spot":
+      return {
+        preset,
+        spotProps: { icon: Search },
+      };
+    case "success":
+    case "error":
+    case "info":
+      return { preset };
+  }
+}

--- a/apps/ledger-live-mobile/src/mvvm/components/InfoState/components/InfoStateButton.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/InfoState/components/InfoStateButton.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { Button } from "@ledgerhq/lumen-ui-rnative";
+import type { InfoStateCta } from "../types";
+
+export function InfoStateButton({
+  cta,
+  appearance,
+}: Readonly<{
+  cta: InfoStateCta;
+  appearance: "base" | "gray";
+}>) {
+  return (
+    <Button
+      appearance={appearance}
+      size="lg"
+      lx={{ width: "full" }}
+      onPress={cta.onPress}
+      disabled={cta.disabled}
+      testID={cta.testID}
+    >
+      {cta.label}
+    </Button>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/components/InfoState/components/PresetVisual.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/InfoState/components/PresetVisual.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { Box, Spot } from "@ledgerhq/lumen-ui-rnative";
+import type { InfoStateProps } from "../types";
+import { illustrationSlotStyle } from "../styles";
+
+const SPOT_SIZE = 72;
+
+export function PresetVisual(props: InfoStateProps) {
+  switch (props.preset) {
+    case "illustration":
+      return <Box lx={illustrationSlotStyle}>{props.illustration}</Box>;
+    case "spot":
+      return <Spot appearance="icon" size={SPOT_SIZE} icon={props.spotProps.icon} />;
+    case "success":
+      return <Spot appearance="check" size={SPOT_SIZE} />;
+    case "error":
+      return <Spot appearance="error" size={SPOT_SIZE} />;
+    case "info":
+      return <Spot appearance="info" size={SPOT_SIZE} />;
+    case "text":
+      return null;
+    default:
+      return assertNever(props);
+  }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled info state preset: ${JSON.stringify(value)}`);
+}

--- a/apps/ledger-live-mobile/src/mvvm/components/InfoState/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/InfoState/index.tsx
@@ -62,7 +62,9 @@ export function InfoState(props: InfoStateProps) {
 }
 
 function renderPresetVisual(presetProps: InfoStateProps): React.ReactNode {
-  switch (presetProps.preset) {
+  const preset = presetProps.preset;
+
+  switch (preset) {
     case "illustration":
       return (
         <Box lx={illustrationSlotStyle} style={styles.illustrationSlot}>
@@ -79,7 +81,13 @@ function renderPresetVisual(presetProps: InfoStateProps): React.ReactNode {
       return <Spot appearance="info" size={72} />;
     case "text":
       return null;
+    default:
+      return assertNever(preset);
   }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled info state preset: ${value}`);
 }
 
 function InfoStateButton({

--- a/apps/ledger-live-mobile/src/mvvm/components/InfoState/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/InfoState/index.tsx
@@ -1,7 +1,16 @@
 import React from "react";
-import { StyleSheet } from "react-native";
-import { Banner, Box, Button, Spot, Text } from "@ledgerhq/lumen-ui-rnative";
-import type { InfoStateCta, InfoStateProps } from "./types";
+import { Banner, Box, Text } from "@ledgerhq/lumen-ui-rnative";
+import type { InfoStateProps } from "./types";
+import { InfoStateButton } from "./components/InfoStateButton";
+import { PresetVisual } from "./components/PresetVisual";
+import {
+  actionsStyle,
+  contentStyle,
+  fullWidthStyle,
+  infoStateStyle,
+  rootStyle,
+  titleDescriptionStyle,
+} from "./styles";
 
 /**
  * Shared mobile state layout for informational, success, and error screens.
@@ -20,10 +29,10 @@ export function InfoState(props: InfoStateProps) {
   const isFullHeight = size === "full-height";
 
   return (
-    <Box lx={rootStyle} testID={testID}>
-      <Box lx={infoStateStyle} style={isFullHeight ? styles.fullHeight : undefined}>
+    <Box lx={rootStyle(isFullHeight)} testID={testID}>
+      <Box lx={infoStateStyle(isFullHeight)}>
         <Box lx={contentStyle(isFullHeight, isTextPreset)}>
-          {renderPresetVisual(props)}
+          <PresetVisual {...props} />
           {title || description ? (
             <Box lx={titleDescriptionStyle}>
               {title ? (
@@ -60,112 +69,3 @@ export function InfoState(props: InfoStateProps) {
     </Box>
   );
 }
-
-function renderPresetVisual(presetProps: InfoStateProps): React.ReactNode {
-  const preset = presetProps.preset;
-
-  switch (preset) {
-    case "illustration":
-      return (
-        <Box lx={illustrationSlotStyle} style={styles.illustrationSlot}>
-          {presetProps.illustration}
-        </Box>
-      );
-    case "spot":
-      return <Spot appearance="icon" size={72} icon={presetProps.spotProps.icon} />;
-    case "success":
-      return <Spot appearance="check" size={72} />;
-    case "error":
-      return <Spot appearance="error" size={72} />;
-    case "info":
-      return <Spot appearance="info" size={72} />;
-    case "text":
-      return null;
-    default:
-      return assertNever(preset);
-  }
-}
-
-function assertNever(value: never): never {
-  throw new Error(`Unhandled info state preset: ${value}`);
-}
-
-function InfoStateButton({
-  cta,
-  appearance,
-}: Readonly<{
-  cta: InfoStateCta;
-  appearance: "base" | "gray";
-}>) {
-  return (
-    <Button
-      appearance={appearance}
-      size="lg"
-      lx={{ width: "full" }}
-      onPress={cta.onPress}
-      disabled={cta.disabled}
-      testID={cta.testID}
-    >
-      {cta.label}
-    </Button>
-  );
-}
-
-const rootStyle = {
-  width: "full",
-} as const;
-
-const infoStateStyle = {
-  gap: "s32",
-  paddingVertical: "s24",
-  width: "full",
-} as const;
-
-const contentStyle = (isFullHeight: boolean, isTextPreset: boolean) =>
-  ({
-    alignItems: "center",
-    flex: isFullHeight ? 1 : undefined,
-    gap: isTextPreset ? "s0" : "s24",
-    justifyContent: "center",
-    width: "full",
-  }) as const;
-
-const titleDescriptionStyle = {
-  alignItems: "center",
-  gap: "s8",
-  width: "full",
-} as const;
-
-const fullWidthStyle = {
-  width: "full",
-} as const;
-
-const actionsStyle = {
-  gap: "s16",
-  width: "full",
-} as const;
-
-const illustrationSlotStyle = {
-  alignItems: "center",
-  borderRadius: "sm",
-  justifyContent: "center",
-  overflow: "hidden",
-} as const;
-
-const styles = StyleSheet.create({
-  fullHeight: {
-    minHeight: 440,
-  },
-  illustrationSlot: {
-    height: 208,
-    width: 208,
-  },
-});
-
-export type {
-  InfoStateBanner,
-  InfoStateCta,
-  InfoStatePreset,
-  InfoStateProps,
-  InfoStateSpotProps,
-} from "./types";

--- a/apps/ledger-live-mobile/src/mvvm/components/InfoState/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/InfoState/index.tsx
@@ -1,0 +1,163 @@
+import React from "react";
+import { StyleSheet } from "react-native";
+import { Banner, Box, Button, Spot, Text } from "@ledgerhq/lumen-ui-rnative";
+import type { InfoStateCta, InfoStateProps } from "./types";
+
+/**
+ * Shared mobile state layout for informational, success, and error screens.
+ */
+export function InfoState(props: InfoStateProps) {
+  const {
+    title,
+    description,
+    primaryCta,
+    secondaryCta,
+    banner,
+    size = "full-height",
+    testID,
+  } = props;
+  const isTextPreset = props.preset === "text";
+  const isFullHeight = size === "full-height";
+
+  return (
+    <Box lx={rootStyle} testID={testID}>
+      <Box lx={infoStateStyle} style={isFullHeight ? styles.fullHeight : undefined}>
+        <Box lx={contentStyle(isFullHeight, isTextPreset)}>
+          {renderPresetVisual(props)}
+          {title || description ? (
+            <Box lx={titleDescriptionStyle}>
+              {title ? (
+                <Text typography="heading4SemiBold" lx={{ color: "base", textAlign: "center" }}>
+                  {title}
+                </Text>
+              ) : null}
+              {description ? (
+                <Text typography="body2" lx={{ color: "muted", textAlign: "center" }}>
+                  {description}
+                </Text>
+              ) : null}
+            </Box>
+          ) : null}
+        </Box>
+
+        {banner ? (
+          <Box lx={fullWidthStyle}>
+            <Banner
+              appearance={banner.appearance ?? "info"}
+              title={banner.title}
+              description={banner.description}
+            />
+          </Box>
+        ) : null}
+
+        {primaryCta || secondaryCta ? (
+          <Box lx={actionsStyle}>
+            {primaryCta ? <InfoStateButton cta={primaryCta} appearance="base" /> : null}
+            {secondaryCta ? <InfoStateButton cta={secondaryCta} appearance="gray" /> : null}
+          </Box>
+        ) : null}
+      </Box>
+    </Box>
+  );
+}
+
+function renderPresetVisual(presetProps: InfoStateProps): React.ReactNode {
+  switch (presetProps.preset) {
+    case "illustration":
+      return (
+        <Box lx={illustrationSlotStyle} style={styles.illustrationSlot}>
+          {presetProps.illustration}
+        </Box>
+      );
+    case "spot":
+      return <Spot appearance="icon" size={72} icon={presetProps.spotProps.icon} />;
+    case "success":
+      return <Spot appearance="check" size={72} />;
+    case "error":
+      return <Spot appearance="error" size={72} />;
+    case "info":
+      return <Spot appearance="info" size={72} />;
+    case "text":
+      return null;
+  }
+}
+
+function InfoStateButton({
+  cta,
+  appearance,
+}: Readonly<{
+  cta: InfoStateCta;
+  appearance: "base" | "gray";
+}>) {
+  return (
+    <Button
+      appearance={appearance}
+      size="lg"
+      lx={{ width: "full" }}
+      onPress={cta.onPress}
+      disabled={cta.disabled}
+      testID={cta.testID}
+    >
+      {cta.label}
+    </Button>
+  );
+}
+
+const rootStyle = {
+  width: "full",
+} as const;
+
+const infoStateStyle = {
+  gap: "s32",
+  paddingVertical: "s24",
+  width: "full",
+} as const;
+
+const contentStyle = (isFullHeight: boolean, isTextPreset: boolean) =>
+  ({
+    alignItems: "center",
+    flex: isFullHeight ? 1 : undefined,
+    gap: isTextPreset ? "s0" : "s24",
+    justifyContent: "center",
+    width: "full",
+  }) as const;
+
+const titleDescriptionStyle = {
+  alignItems: "center",
+  gap: "s8",
+  width: "full",
+} as const;
+
+const fullWidthStyle = {
+  width: "full",
+} as const;
+
+const actionsStyle = {
+  gap: "s16",
+  width: "full",
+} as const;
+
+const illustrationSlotStyle = {
+  alignItems: "center",
+  borderRadius: "sm",
+  justifyContent: "center",
+  overflow: "hidden",
+} as const;
+
+const styles = StyleSheet.create({
+  fullHeight: {
+    minHeight: 440,
+  },
+  illustrationSlot: {
+    height: 208,
+    width: 208,
+  },
+});
+
+export type {
+  InfoStateBanner,
+  InfoStateCta,
+  InfoStatePreset,
+  InfoStateProps,
+  InfoStateSpotProps,
+} from "./types";

--- a/apps/ledger-live-mobile/src/mvvm/components/InfoState/styles.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/InfoState/styles.ts
@@ -1,0 +1,60 @@
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+
+const baseRootStyle: LumenViewStyle = {
+  width: "full",
+};
+
+export const rootStyle = (isFullHeight: boolean): LumenViewStyle =>
+  isFullHeight
+    ? {
+        ...baseRootStyle,
+        flex: 1,
+      }
+    : baseRootStyle;
+
+const baseInfoStateStyle: LumenViewStyle = {
+  gap: "s32",
+  paddingVertical: "s24",
+  width: "full",
+};
+
+export const infoStateStyle = (isFullHeight: boolean): LumenViewStyle =>
+  isFullHeight
+    ? {
+        ...baseInfoStateStyle,
+        flex: 1,
+        minHeight: "s480",
+      }
+    : baseInfoStateStyle;
+
+export const contentStyle = (isFullHeight: boolean, isTextPreset: boolean): LumenViewStyle => ({
+  alignItems: "center",
+  flex: isFullHeight ? 1 : undefined,
+  gap: isTextPreset ? "s0" : "s24",
+  justifyContent: "center",
+  width: "full",
+});
+
+export const titleDescriptionStyle: LumenViewStyle = {
+  alignItems: "center",
+  gap: "s8",
+  width: "full",
+};
+
+export const fullWidthStyle: LumenViewStyle = {
+  width: "full",
+};
+
+export const actionsStyle: LumenViewStyle = {
+  gap: "s16",
+  width: "full",
+};
+
+export const illustrationSlotStyle: LumenViewStyle = {
+  alignItems: "center",
+  borderRadius: "sm",
+  height: "s208",
+  justifyContent: "center",
+  overflow: "hidden",
+  width: "s208",
+};

--- a/apps/ledger-live-mobile/src/mvvm/components/InfoState/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/InfoState/types.ts
@@ -1,0 +1,89 @@
+import type { ReactNode } from "react";
+import type { SpotProps } from "@ledgerhq/lumen-ui-rnative";
+
+type LumenIconSpotProps = Extract<SpotProps, { appearance: "icon" }>;
+
+/** Preset that controls the visual rendered above the title and description. */
+export type InfoStatePreset = "illustration" | "spot" | "success" | "error" | "info" | "text";
+
+/** CTA displayed in the action stack below the content and optional banner. */
+export type InfoStateCta = Readonly<{
+  /** Button label. */
+  label: ReactNode;
+
+  /** Called when the button is pressed. */
+  onPress: () => void;
+
+  /** Optional test identifier forwarded to the button. */
+  testID?: string;
+
+  /** Whether the button is disabled. */
+  disabled?: boolean;
+}>;
+
+/** Lumen banner displayed between content and actions. */
+export type InfoStateBanner = Readonly<{
+  /** Banner title. */
+  title: string;
+
+  /** Optional banner body copy. */
+  description?: ReactNode;
+
+  /** Visual treatment for the banner. Defaults to info. */
+  appearance?: "info" | "warning" | "error" | "success";
+}>;
+
+/** Props forwarded to the Lumen Spot for the custom spot preset. */
+export type InfoStateSpotProps = Pick<LumenIconSpotProps, "icon">;
+
+type InfoStateBaseProps = Readonly<{
+  /** Optional centered heading. */
+  title?: ReactNode;
+
+  /** Optional centered explanatory copy below the title. */
+  description?: ReactNode;
+
+  /** Primary action rendered first in the action stack. */
+  primaryCta?: InfoStateCta;
+
+  /** Secondary action rendered below the primary action. */
+  secondaryCta?: InfoStateCta;
+
+  /** Optional banner rendered before the action stack. */
+  banner?: InfoStateBanner;
+
+  /** Layout sizing mode. Full-height expands the content area. Defaults to full-height. */
+  size?: "hug" | "full-height";
+
+  /** Optional test identifier applied to the root container. */
+  testID?: string;
+}>;
+
+/** Props for the shared mobile InfoState layout. */
+export type InfoStateProps =
+  | (InfoStateBaseProps & {
+      /** Renders a caller-provided illustration in a 208px visual slot. */
+      preset: "illustration";
+      illustration: ReactNode;
+    })
+  | (InfoStateBaseProps & {
+      /** Renders a Lumen Spot with caller-provided icon props. */
+      preset: "spot";
+      spotProps: InfoStateSpotProps;
+    })
+  | (InfoStateBaseProps & {
+      /** Renders a success status Spot. */
+      preset: "success";
+    })
+  | (InfoStateBaseProps & {
+      /** Renders an error status Spot. */
+      preset: "error";
+    })
+  | (InfoStateBaseProps & {
+      /** Renders an info status Spot. */
+      preset: "info";
+    })
+  | (InfoStateBaseProps & {
+      /** Renders only title, description, banner, and actions without visual spacing. */
+      preset: "text";
+    });

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/InfoStateScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/InfoStateScreen.tsx
@@ -4,11 +4,8 @@ import { BottomSheetHeader, BottomSheetView, Box, Button, Text } from "@ledgerhq
 import { Search } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
-import {
-  InfoState,
-  type InfoStatePreset,
-  type InfoStateProps,
-} from "LLM/components/InfoState";
+import { InfoState } from "LLM/components/InfoState";
+import type { InfoStatePreset, InfoStateProps } from "LLM/components/InfoState/types";
 
 const presetOptions: InfoStatePreset[] = ["illustration", "spot", "success", "error", "info", "text"];
 const sizeOptions: Array<NonNullable<InfoStateProps["size"]>> = ["full-height", "hug"];

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/InfoStateScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/InfoStateScreen.tsx
@@ -198,7 +198,13 @@ function renderInfoStatePreview({
       return <InfoState {...commonProps} preset="info" testID="info-state-preview" />;
     case "text":
       return <InfoState {...commonProps} preset="text" testID="info-state-preview" />;
+    default:
+      return assertNever(preset);
   }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled info state preset: ${value}`);
 }
 
 function SettingSection({

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/InfoStateScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/InfoStateScreen.tsx
@@ -1,0 +1,294 @@
+import React, { useState } from "react";
+import { ScrollView, StyleSheet } from "react-native";
+import { BottomSheetHeader, BottomSheetView, Box, Button, Text } from "@ledgerhq/lumen-ui-rnative";
+import { Search } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
+import {
+  InfoState,
+  type InfoStatePreset,
+  type InfoStateProps,
+} from "LLM/components/InfoState";
+
+const presetOptions: InfoStatePreset[] = ["illustration", "spot", "success", "error", "info", "text"];
+const sizeOptions: Array<NonNullable<InfoStateProps["size"]>> = ["full-height", "hug"];
+
+export default function DebugInfoStateScreen() {
+  const { bottom: bottomInset } = useSafeAreaInsets();
+  const [preset, setPreset] = useState<InfoStatePreset>("success");
+  const [size, setSize] = useState<NonNullable<InfoStateProps["size"]>>("full-height");
+  const [showTitle, setShowTitle] = useState(true);
+  const [showDescription, setShowDescription] = useState(true);
+  const [showBanner, setShowBanner] = useState(false);
+  const [showPrimaryCta, setShowPrimaryCta] = useState(true);
+  const [showSecondaryCta, setShowSecondaryCta] = useState(true);
+  const [useLongTitle, setUseLongTitle] = useState(false);
+  const [useLongDescription, setUseLongDescription] = useState(false);
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+
+  const title = useLongTitle ? longTitle : `${formatPresetLabel(preset)} state title`;
+  const description = useLongDescription
+    ? longDescription
+    : "Use this component for focused feedback and next-step guidance.";
+
+  return (
+    <>
+      <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+        <Box lx={{ gap: "s8", marginBottom: "s24" }}>
+          <Text typography="body2" lx={{ color: "muted" }}>
+            Local playground for the reusable mobile info-state component.
+          </Text>
+        </Box>
+
+        <Box lx={cardStyle}>
+          <Text typography="body2SemiBold" lx={{ color: "base" }}>
+            Playground controls
+          </Text>
+
+          <SettingSection title="Preset">
+            {presetOptions.map(presetOption => (
+              <ChoiceButton
+                key={presetOption}
+                label={formatPresetLabel(presetOption)}
+                selected={presetOption === preset}
+                onPress={() => setPreset(presetOption)}
+              />
+            ))}
+          </SettingSection>
+
+          <SettingSection title="Size">
+            {sizeOptions.map(sizeOption => (
+              <ChoiceButton
+                key={sizeOption}
+                label={sizeOption}
+                selected={sizeOption === size}
+                onPress={() => setSize(sizeOption)}
+              />
+            ))}
+          </SettingSection>
+
+          <SettingSection title="Visibility">
+            <ToggleButton
+              label="Title"
+              enabled={showTitle}
+              onPress={() => setShowTitle(value => !value)}
+            />
+            <ToggleButton
+              label="Description"
+              enabled={showDescription}
+              onPress={() => setShowDescription(value => !value)}
+            />
+            <ToggleButton
+              label="Banner"
+              enabled={showBanner}
+              onPress={() => setShowBanner(value => !value)}
+            />
+            <ToggleButton
+              label="Primary CTA"
+              enabled={showPrimaryCta}
+              onPress={() => setShowPrimaryCta(value => !value)}
+            />
+            <ToggleButton
+              label="Secondary CTA"
+              enabled={showSecondaryCta}
+              onPress={() => setShowSecondaryCta(value => !value)}
+            />
+          </SettingSection>
+
+          <SettingSection title="Copy stress">
+            <ToggleButton
+              label="Long title"
+              enabled={useLongTitle}
+              onPress={() => setUseLongTitle(value => !value)}
+            />
+            <ToggleButton
+              label="Long description"
+              enabled={useLongDescription}
+              onPress={() => setUseLongDescription(value => !value)}
+            />
+          </SettingSection>
+
+          <Button
+            appearance="base"
+            size="lg"
+            onPress={() => setIsPreviewOpen(true)}
+            testID="info-state-open-preview"
+          >
+            Open preview
+          </Button>
+        </Box>
+      </ScrollView>
+
+      <QueuedDrawerBottomSheet
+        isRequestingToBeOpened={isPreviewOpen}
+        onClose={() => setIsPreviewOpen(false)}
+        enableDynamicSizing
+        testID="info-state-preview-sheet"
+      >
+        <BottomSheetView style={[styles.sheetContent, { paddingBottom: bottomInset + 24 }]}>
+          <BottomSheetHeader />
+          {renderInfoStatePreview({
+            preset,
+            size,
+            title: showTitle ? title : undefined,
+            description: showDescription ? description : undefined,
+            banner: showBanner
+              ? {
+                  title: "Important information",
+                  description: "This optional banner sits before the action stack.",
+                  appearance: "info",
+                }
+              : undefined,
+            primaryCta: showPrimaryCta
+              ? {
+                  label: "Primary action",
+                  onPress: () => undefined,
+                  testID: "info-state-primary-cta",
+                }
+              : undefined,
+            secondaryCta: showSecondaryCta
+              ? {
+                  label: "Secondary action",
+                  onPress: () => undefined,
+                  testID: "info-state-secondary-cta",
+                }
+              : undefined,
+          })}
+        </BottomSheetView>
+      </QueuedDrawerBottomSheet>
+    </>
+  );
+}
+
+function renderInfoStatePreview({
+  preset,
+  ...commonProps
+}: Readonly<
+  Pick<
+    InfoStateProps,
+    "banner" | "description" | "primaryCta" | "secondaryCta" | "size" | "title"
+  > & {
+    preset: InfoStatePreset;
+  }
+>) {
+  switch (preset) {
+    case "illustration":
+      return (
+        <InfoState
+          {...commonProps}
+          preset="illustration"
+          illustration={<Box lx={illustrationPlaceholderStyle} />}
+          testID="info-state-preview"
+        />
+      );
+    case "spot":
+      return (
+        <InfoState
+          {...commonProps}
+          preset="spot"
+          spotProps={{ icon: Search }}
+          testID="info-state-preview"
+        />
+      );
+    case "success":
+      return <InfoState {...commonProps} preset="success" testID="info-state-preview" />;
+    case "error":
+      return <InfoState {...commonProps} preset="error" testID="info-state-preview" />;
+    case "info":
+      return <InfoState {...commonProps} preset="info" testID="info-state-preview" />;
+    case "text":
+      return <InfoState {...commonProps} preset="text" testID="info-state-preview" />;
+  }
+}
+
+function SettingSection({
+  title,
+  children,
+}: Readonly<{
+  title: string;
+  children: React.ReactNode;
+}>) {
+  return (
+    <Box lx={{ gap: "s8" }}>
+      <Text typography="body2" lx={{ color: "muted" }}>
+        {title}
+      </Text>
+      <Box lx={controlsRowStyle}>{children}</Box>
+    </Box>
+  );
+}
+
+function ChoiceButton({
+  label,
+  selected,
+  onPress,
+}: Readonly<{
+  label: string;
+  selected: boolean;
+  onPress: () => void;
+}>) {
+  return (
+    <Button appearance={selected ? "base" : "gray"} size="sm" onPress={onPress}>
+      {label}
+    </Button>
+  );
+}
+
+function ToggleButton({
+  label,
+  enabled,
+  onPress,
+}: Readonly<{
+  label: string;
+  enabled: boolean;
+  onPress: () => void;
+}>) {
+  return (
+    <Button appearance={enabled ? "base" : "gray"} size="sm" onPress={onPress}>
+      {label}: {enabled ? "On" : "Off"}
+    </Button>
+  );
+}
+
+function formatPresetLabel(preset: InfoStatePreset): string {
+  return preset.charAt(0).toUpperCase() + preset.slice(1);
+}
+
+const cardStyle = {
+  backgroundColor: "surface",
+  borderRadius: "md",
+  gap: "s16",
+  padding: "s16",
+  width: "full",
+} as const;
+
+const controlsRowStyle = {
+  flexDirection: "row",
+  flexWrap: "wrap",
+  gap: "s8",
+} as const;
+
+const illustrationPlaceholderStyle = {
+  backgroundColor: "muted",
+  borderRadius: "sm",
+  height: "full",
+  width: "full",
+} as const;
+
+const longTitle =
+  "A longer title that validates the centered heading behavior when the info state is used in compact mobile surfaces";
+
+const longDescription =
+  "This longer description intentionally spans several lines on narrow mobile screens. It helps validate the body copy line height, centered alignment, vertical rhythm, and the transition into banners and actions.";
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 16,
+  },
+  sheetContent: {
+    paddingHorizontal: 16,
+  },
+});

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/index.tsx
@@ -26,6 +26,11 @@ export default function DebugDeviceIntentExecutor() {
         onPress={() => navigation.navigate(ScreenName.DebugDeviceIntentExecutorContent)}
       />
       <DebugEntry
+        title="Info State"
+        description="Preview the reusable mobile state component for presets, copy, banners, and actions."
+        onPress={() => navigation.navigate(ScreenName.DebugDeviceIntentExecutorInfoState)}
+      />
+      <DebugEntry
         title="Orchestration"
         description="Run the existing chained intent playground to test DIE core orchestration."
         onPress={() => navigation.navigate(ScreenName.DebugDeviceIntentExecutorOrchestration)}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Mobile Device Intent Executor debug tools
  - New reusable mobile `InfoState` component
  - Info state preset rendering, banners, and actions

### 📝 Description

This PR introduces a reusable Ledger Live Mobile `InfoState` component for Connect App and Device Intent Executor flows. It provides a shared layout for preset visuals, title, description, optional banner, and primary/secondary actions as requested by LIVE-30551.

[Figma](https://www.figma.com/design/JxaLVMTWirCpU0rsbZ30k7/2.-Components-Library?node-id=1425-2784&m=dev)

The implementation uses Lumen React Native primitives, supports the mobile Figma presets (`illustration`, `spot`, `success`, `error`, `info`, and `text`), adds a Device Intent Executor debug playground in a dynamic bottom sheet, and covers rendering, presets, banners, and actions with Jest tests.

Note: there is no gradient yet as it's not yet functional in Lumen.

https://github.com/user-attachments/assets/64a3acfe-20a6-4893-bdca-7b20e3acc909



### ❓ Context

- **JIRA or GitHub link**: [LIVE-30551](https://ledgerhq.atlassian.net/browse/LIVE-30551)
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30551]: https://ledgerhq.atlassian.net/browse/LIVE-30551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ