### PR TITLE
[LWDM] chore(deps): bump lumen ui to 0.1.31 / 0.1.32 and 0.1.13

### DIFF
--- a/.changeset/lumen-ui-0-1-31-bump.md
+++ b/.changeset/lumen-ui-0-1-31-bump.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Bump lumen UI to 0.1.31 (React) / 0.1.32 (React Native), lumen-design-core to 0.1.13 and lumen-ui-react-visualization to 0.1.10. Migrate Input call sites from removed `errorMessage` prop to `helperText` + `status="error"`.

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CoinControl/components/AmountInput.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CoinControl/components/AmountInput.tsx
@@ -29,7 +29,8 @@ export const AmountInput = ({
         onChange={onAmountChange}
         value={amount ?? ""}
         type="text"
-        errorMessage={errorMessage ?? undefined}
+        helperText={errorMessage ?? undefined}
+        status={errorMessage ? "error" : undefined}
       />
     </div>
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CustomFees/components/CustomFeesScreenView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CustomFees/components/CustomFeesScreenView.tsx
@@ -56,8 +56,8 @@ export function CustomFeesScreenView({
               value={input.value}
               onChange={e => onInputChange(input.key, e.target.value)}
               onClear={() => onInputClear(input.key)}
-              aria-invalid={input.error !== null}
-              errorMessage={input.error ?? undefined}
+              helperText={input.error ?? undefined}
+              status={input.error ? "error" : undefined}
               inputMode="decimal"
               autoComplete="off"
             />

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/Memo/MemoValueInput.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/Memo/MemoValueInput.tsx
@@ -78,7 +78,8 @@ function MemoValueInputComponent({
       className="w-full"
       value={value}
       maxLength={isTagType ? undefined : maxLength}
-      errorMessage={errorMessage}
+      helperText={errorMessage}
+      status={errorMessage ? "error" : undefined}
     />
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CoinControl/components/AmountInput.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CoinControl/components/AmountInput.tsx
@@ -33,7 +33,8 @@ export const AmountInput = ({
         label={amountInputLabel}
         aria-label={amountInputLabel}
         value={amount ?? ""}
-        errorMessage={errorMessage ?? undefined}
+        helperText={errorMessage ?? undefined}
+        status={errorMessage ? "error" : undefined}
         onChangeText={onAmountChange}
       />
     </Box>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,17 +55,17 @@ catalogs:
       specifier: 1.2.3
       version: 1.2.3
     '@ledgerhq/lumen-design-core':
-      specifier: 0.1.12
-      version: 0.1.12
+      specifier: 0.1.13
+      version: 0.1.13
     '@ledgerhq/lumen-ui-react':
-      specifier: 0.1.30
-      version: 0.1.30
+      specifier: 0.1.31
+      version: 0.1.31
     '@ledgerhq/lumen-ui-react-visualization':
-      specifier: 0.1.8
-      version: 0.1.8
+      specifier: 0.1.10
+      version: 0.1.10
     '@ledgerhq/lumen-ui-rnative':
-      specifier: 0.1.29
-      version: 0.1.29
+      specifier: 0.1.32
+      version: 0.1.32
     '@ledgerhq/speculos-device-controller':
       specifier: 0.2.3
       version: 0.2.3
@@ -593,7 +593,7 @@ importers:
         version: link:tools/create-release-hash
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.12
+        version: 0.1.13
       '@ledgerhq/pnpm-utils':
         specifier: workspace:*
         version: link:tools/pnpm-utils
@@ -968,7 +968,7 @@ importers:
         version: 2.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.12)(@ledgerhq/lumen-ui-react@0.1.30(dcbfab10dcd5417d898239a9a392543b))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.13)(@ledgerhq/lumen-ui-react@0.1.31(a8cccf4730528caceafebf2c6f0140b7))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/cryptoassets
@@ -1037,13 +1037,13 @@ importers:
         version: link:../../libs/ledgerjs/packages/logs
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.12
+        version: 0.1.13
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.30(dcbfab10dcd5417d898239a9a392543b)
+        version: 0.1.31(a8cccf4730528caceafebf2c6f0140b7)
       '@ledgerhq/lumen-ui-react-visualization':
         specifier: 'catalog:'
-        version: 0.1.8(@ledgerhq/lumen-design-core@0.1.12)(@ledgerhq/lumen-ui-react@0.1.30(dcbfab10dcd5417d898239a9a392543b))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
+        version: 0.1.10(@ledgerhq/lumen-design-core@0.1.13)(@ledgerhq/lumen-ui-react@0.1.31(a8cccf4730528caceafebf2c6f0140b7))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
       '@ledgerhq/react-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/react
@@ -1624,7 +1624,7 @@ importers:
         version: 1.17.1(@ledgerhq/device-management-kit@1.4.1(rxjs@7.8.2))
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.12)(@ledgerhq/lumen-ui-rnative@0.1.29(aaef53925dd57879e30bd9df42ba0adb))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.13)(@ledgerhq/lumen-ui-rnative@0.1.32(21f4227632be30b0f49d01a2b350e488))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/cryptoassets
@@ -1705,10 +1705,10 @@ importers:
         version: link:../../libs/ledgerjs/packages/logs
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.12
+        version: 0.1.13
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.29(aaef53925dd57879e30bd9df42ba0adb)
+        version: 0.1.32(21f4227632be30b0f49d01a2b350e488)
       '@ledgerhq/native-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/native
@@ -2454,7 +2454,7 @@ importers:
         version: 2.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.12)(@ledgerhq/lumen-ui-react@0.1.30(dcbfab10dcd5417d898239a9a392543b))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.13)(@ledgerhq/lumen-ui-react@0.1.31(a8cccf4730528caceafebf2c6f0140b7))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/cryptoassets
@@ -2508,10 +2508,10 @@ importers:
         version: link:../../libs/ledgerjs/packages/logs
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.12
+        version: 0.1.13
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.30(dcbfab10dcd5417d898239a9a392543b)
+        version: 0.1.31(a8cccf4730528caceafebf2c6f0140b7)
       '@ledgerhq/react-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/react
@@ -2771,13 +2771,13 @@ importers:
         version: 30.2.0
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.12
+        version: 0.1.13
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.30(6d5eafba7705ee38ebc0331edc563a6c)
+        version: 0.1.31(5b0f8dec7ec57ebf0f0d9266dd237bb4)
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.29(064b1549be5bc617017e6a807f28758f)
+        version: 0.1.32(654277828b73b9745437809ac2c01a5b)
       '@radix-ui/react-checkbox':
         specifier: 'catalog:'
         version: 1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -3312,13 +3312,13 @@ importers:
         version: 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.1.6(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.12
+        version: 0.1.13
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.30(@ledgerhq/lumen-design-core@0.1.12)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
+        version: 0.1.31(@ledgerhq/lumen-design-core@0.1.13)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.29(b0cfe5fc3887fb74414e017e41293ebc)
+        version: 0.1.32(433783fcd4bd89f0582da0bf84f2994e)
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -11644,7 +11644,7 @@ importers:
     dependencies:
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.12)(@ledgerhq/lumen-ui-rnative@0.1.29(55b33773819c0a4362e83129f56cd9b4))(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
+        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.13)(@ledgerhq/lumen-ui-rnative@0.1.32(30635d6a6413ea2272c5df4eb0a98cea))(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
       '@ledgerhq/icons-ui':
         specifier: workspace:^
         version: link:../icons
@@ -11708,10 +11708,10 @@ importers:
         version: 0.19.12
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.12
+        version: 0.1.13
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.29(55b33773819c0a4362e83129f56cd9b4)
+        version: 0.1.32(30635d6a6413ea2272c5df4eb0a98cea)
       '@react-native-async-storage/async-storage':
         specifier: 2.1.2
         version: 2.1.2(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))
@@ -11972,7 +11972,7 @@ importers:
     dependencies:
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.12)(@ledgerhq/lumen-ui-react@0.1.30(dcbfab10dcd5417d898239a9a392543b))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.13)(@ledgerhq/lumen-ui-react@0.1.31(a8cccf4730528caceafebf2c6f0140b7))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@ledgerhq/icons-ui':
         specifier: workspace:^
         version: file:libs/ui/packages/icons(@types/react@19.0.14)(react@19.0.0)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@19.0.0(react@19.0.0))(react-is@17.0.2)(react@19.0.0))(styled-system@5.1.5)
@@ -12033,10 +12033,10 @@ importers:
         version: 7.28.5(@babel/core@7.28.5)
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.12
+        version: 0.1.13
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.30(dcbfab10dcd5417d898239a9a392543b)
+        version: 0.1.31(a8cccf4730528caceafebf2c6f0140b7)
       '@radix-ui/react-checkbox':
         specifier: 'catalog:'
         version: 1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -17139,22 +17139,22 @@ packages:
   '@ledgerhq/logs@6.16.0':
     resolution: {integrity: sha512-v/PLfb1dq1En35kkpbfRWp8jLYgbPUXxGhmd4pmvPSIe0nRGkNTomsZASmWQAv6pRonVGqHIBVlte7j1MBbOww==}
 
-  '@ledgerhq/lumen-design-core@0.1.12':
-    resolution: {integrity: sha512-McBfYo5jZwhkBirtSQwmVAdc/YJuO/w7pw4h2zyxU5KHQiQfEUmJdg2/0h3oTSpKdtuHCl59+QHWLHQZf3SlcA==}
+  '@ledgerhq/lumen-design-core@0.1.13':
+    resolution: {integrity: sha512-E7rJM+zDxQHDoVreAhTaOyF1n4LkutbRW7Yl2ORFGO0DGcnQiQqYm1PZ5p0IsWruJzanLDGL1S5rhsZFnOaZPQ==}
 
-  '@ledgerhq/lumen-ui-react-visualization@0.1.8':
-    resolution: {integrity: sha512-q+Y7jcJGFHxcRsmxc4QMqdpVYtqGPRw5d8/7+c/llZ+XAUlTxjCwY4ms8VC9oM+iy8sGck/syevahX6/Ax6dnQ==}
+  '@ledgerhq/lumen-ui-react-visualization@0.1.10':
+    resolution: {integrity: sha512-Py4Wuzg/wHADl/cqCOyyLqfH+X0RCBMOFuZ9rJdOW8sOZB8yEO8RE/+TAeljK5U2wmyUyditEiFn39PKGHNceQ==}
     peerDependencies:
-      '@ledgerhq/lumen-design-core': 0.1.12
-      '@ledgerhq/lumen-ui-react': 0.1.29
+      '@ledgerhq/lumen-design-core': 0.1.13
+      '@ledgerhq/lumen-ui-react': 0.1.31
       class-variance-authority: ^0.7.1
       clsx: ^2.1.1
       react: 19.0.0
       react-dom: 19.0.0
       tailwind-merge: ^2.6.0
 
-  '@ledgerhq/lumen-ui-react@0.1.30':
-    resolution: {integrity: sha512-QHkU+4u5eR6yMTBMYc4dRRyVkr6Xp2gombDtOu1KlgnhvCTdmkhr8QdVLhjhpj7rVsndYIqCmS8YNCyc9u34Rg==}
+  '@ledgerhq/lumen-ui-react@0.1.31':
+    resolution: {integrity: sha512-JcqDN9hAoOvdPVVXRdSTflLKnG+Ms2tO0rG6b7HjqRDLW+DLT3W7yW97DbCtaudyprdz/eLrSwVGG1ryOsa72Q==}
     peerDependencies:
       '@base-ui/react': ^1.3.0
       '@ledgerhq/lumen-design-core': 0.1.13
@@ -17171,11 +17171,11 @@ packages:
       react-dom: 19.0.0
       tailwind-merge: ^2.6.0
 
-  '@ledgerhq/lumen-ui-rnative@0.1.29':
-    resolution: {integrity: sha512-4tm2L1w/piK59pDLmS4i6WpgCdqvP6CE2H3mqzhPZYC7VC9znaYGFkvwuBMDhQLKKctr2qGymvg9DRMr6W9IYg==}
+  '@ledgerhq/lumen-ui-rnative@0.1.32':
+    resolution: {integrity: sha512-bMukJ/8cptCKDzEg1OWiwMaqSeG3ZFR9+H8j8KJjN9ubSR5zT+93rvyjz9PCJqVkeBE1GUA00KE2Obxrivbz/A==}
     peerDependencies:
       '@gorhom/bottom-sheet': ^5.0.0
-      '@ledgerhq/lumen-design-core': 0.1.12
+      '@ledgerhq/lumen-design-core': 0.1.13
       '@sbaiahmed1/react-native-blur': ^4.5.5
       '@types/react': ^19.0.0
       expo: '>=53.0.0'
@@ -45247,30 +45247,30 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/crypto-icons@2.0.1(@ledgerhq/lumen-design-core@0.1.12)(@ledgerhq/lumen-ui-react@0.1.30(dcbfab10dcd5417d898239a9a392543b))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@ledgerhq/crypto-icons@2.0.1(@ledgerhq/lumen-design-core@0.1.13)(@ledgerhq/lumen-ui-react@0.1.31(a8cccf4730528caceafebf2c6f0140b7))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       react: 19.0.0
     optionalDependencies:
-      '@ledgerhq/lumen-design-core': 0.1.12
-      '@ledgerhq/lumen-ui-react': 0.1.30(dcbfab10dcd5417d898239a9a392543b)
+      '@ledgerhq/lumen-design-core': 0.1.13
+      '@ledgerhq/lumen-ui-react': 0.1.31(a8cccf4730528caceafebf2c6f0140b7)
       react-dom: 19.0.0(react@19.0.0)
 
-  '@ledgerhq/crypto-icons@2.0.1(@ledgerhq/lumen-design-core@0.1.12)(@ledgerhq/lumen-ui-rnative@0.1.29(55b33773819c0a4362e83129f56cd9b4))(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)':
+  '@ledgerhq/crypto-icons@2.0.1(@ledgerhq/lumen-design-core@0.1.13)(@ledgerhq/lumen-ui-rnative@0.1.32(21f4227632be30b0f49d01a2b350e488))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
     dependencies:
       react: 19.0.0
     optionalDependencies:
-      '@ledgerhq/lumen-design-core': 0.1.12
-      '@ledgerhq/lumen-ui-rnative': 0.1.29(55b33773819c0a4362e83129f56cd9b4)
+      '@ledgerhq/lumen-design-core': 0.1.13
+      '@ledgerhq/lumen-ui-rnative': 0.1.32(21f4227632be30b0f49d01a2b350e488)
+      react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
+
+  '@ledgerhq/crypto-icons@2.0.1(@ledgerhq/lumen-design-core@0.1.13)(@ledgerhq/lumen-ui-rnative@0.1.32(30635d6a6413ea2272c5df4eb0a98cea))(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@ledgerhq/lumen-design-core': 0.1.13
+      '@ledgerhq/lumen-ui-rnative': 0.1.32(30635d6a6413ea2272c5df4eb0a98cea)
       react-dom: 19.0.0(react@19.0.0)
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0)
-
-  '@ledgerhq/crypto-icons@2.0.1(@ledgerhq/lumen-design-core@0.1.12)(@ledgerhq/lumen-ui-rnative@0.1.29(aaef53925dd57879e30bd9df42ba0adb))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
-    dependencies:
-      react: 19.0.0
-    optionalDependencies:
-      '@ledgerhq/lumen-design-core': 0.1.12
-      '@ledgerhq/lumen-ui-rnative': 0.1.29(aaef53925dd57879e30bd9df42ba0adb)
-      react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
 
   '@ledgerhq/device-management-kit@1.4.1':
     dependencies:
@@ -45489,15 +45489,15 @@ snapshots:
 
   '@ledgerhq/logs@6.16.0': {}
 
-  '@ledgerhq/lumen-design-core@0.1.12':
+  '@ledgerhq/lumen-design-core@0.1.13':
     dependencies:
       tailwindcss: 4.1.18
       tslib: 2.6.2
 
-  '@ledgerhq/lumen-ui-react-visualization@0.1.8(@ledgerhq/lumen-design-core@0.1.12)(@ledgerhq/lumen-ui-react@0.1.30(dcbfab10dcd5417d898239a9a392543b))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)':
+  '@ledgerhq/lumen-ui-react-visualization@0.1.10(@ledgerhq/lumen-design-core@0.1.13)(@ledgerhq/lumen-ui-react@0.1.31(a8cccf4730528caceafebf2c6f0140b7))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)':
     dependencies:
-      '@ledgerhq/lumen-design-core': 0.1.12
-      '@ledgerhq/lumen-ui-react': 0.1.30(dcbfab10dcd5417d898239a9a392543b)
+      '@ledgerhq/lumen-design-core': 0.1.13
+      '@ledgerhq/lumen-ui-react': 0.1.31(a8cccf4730528caceafebf2c6f0140b7)
       '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
       class-variance-authority: 0.7.1
       clsx: 2.1.1
@@ -45508,9 +45508,9 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
       tailwind-merge: 3.4.0
 
-  '@ledgerhq/lumen-ui-react@0.1.30(6d5eafba7705ee38ebc0331edc563a6c)':
+  '@ledgerhq/lumen-ui-react@0.1.31(5b0f8dec7ec57ebf0f0d9266dd237bb4)':
     dependencies:
-      '@ledgerhq/lumen-design-core': 0.1.12
+      '@ledgerhq/lumen-design-core': 0.1.13
       '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
       '@radix-ui/react-checkbox': 1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -45529,9 +45529,9 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-react@0.1.30(@ledgerhq/lumen-design-core@0.1.12)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)':
+  '@ledgerhq/lumen-ui-react@0.1.31(@ledgerhq/lumen-design-core@0.1.13)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)':
     dependencies:
-      '@ledgerhq/lumen-design-core': 0.1.12
+      '@ledgerhq/lumen-design-core': 0.1.13
       '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
       clsx: 2.1.1
       i18next: 23.10.1
@@ -45542,9 +45542,9 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-react@0.1.30(dcbfab10dcd5417d898239a9a392543b)':
+  '@ledgerhq/lumen-ui-react@0.1.31(a8cccf4730528caceafebf2c6f0140b7)':
     dependencies:
-      '@ledgerhq/lumen-design-core': 0.1.12
+      '@ledgerhq/lumen-design-core': 0.1.13
       '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
       '@radix-ui/react-checkbox': 1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -45563,43 +45563,10 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-rnative@0.1.29(064b1549be5bc617017e6a807f28758f)':
-    dependencies:
-      '@gorhom/bottom-sheet': 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.1.6(react-native-worklets@0.7.2(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-      '@ledgerhq/lumen-design-core': 0.1.12
-      '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
-      '@types/react': 19.0.14
-      expo-haptics: 14.1.4(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-      i18next: 23.10.1
-      react: 19.0.0
-      react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-      react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
-      react-native-reanimated: 4.1.6(react-native-worklets@0.7.2(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-      react-native-safe-area-context: 5.6.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-      react-native-svg: 15.15.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-    transitivePeerDependencies:
-      - react-dom
-
-  '@ledgerhq/lumen-ui-rnative@0.1.29(55b33773819c0a4362e83129f56cd9b4)':
-    dependencies:
-      '@ledgerhq/lumen-design-core': 0.1.12
-      '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
-      '@types/react': 19.0.14
-      expo: 53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
-      i18next: 23.10.1
-      react: 19.0.0
-      react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
-      react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0)
-      react-native-reanimated: 4.1.6(@babel/core@7.28.5)(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
-      react-native-safe-area-context: 5.6.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
-      react-native-svg: 15.15.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
-    transitivePeerDependencies:
-      - react-dom
-
-  '@ledgerhq/lumen-ui-rnative@0.1.29(aaef53925dd57879e30bd9df42ba0adb)':
+  '@ledgerhq/lumen-ui-rnative@0.1.32(21f4227632be30b0f49d01a2b350e488)':
     dependencies:
       '@gorhom/bottom-sheet': 5.2.6(beb07f7799bea5989bf46dbe8fcef3d9)
-      '@ledgerhq/lumen-design-core': 0.1.12
+      '@ledgerhq/lumen-design-core': 0.1.13
       '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
       '@sbaiahmed1/react-native-blur': 4.5.5(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@types/react': 19.0.14
@@ -45615,10 +45582,26 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  '@ledgerhq/lumen-ui-rnative@0.1.29(b0cfe5fc3887fb74414e017e41293ebc)':
+  '@ledgerhq/lumen-ui-rnative@0.1.32(30635d6a6413ea2272c5df4eb0a98cea)':
+    dependencies:
+      '@ledgerhq/lumen-design-core': 0.1.13
+      '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
+      '@types/react': 19.0.14
+      expo: 53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
+      i18next: 23.10.1
+      react: 19.0.0
+      react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
+      react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0)
+      react-native-reanimated: 4.1.6(@babel/core@7.28.5)(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
+      react-native-safe-area-context: 5.6.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
+      react-native-svg: 15.15.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
+    transitivePeerDependencies:
+      - react-dom
+
+  '@ledgerhq/lumen-ui-rnative@0.1.32(433783fcd4bd89f0582da0bf84f2994e)':
     dependencies:
       '@gorhom/bottom-sheet': 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.1.6(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-      '@ledgerhq/lumen-design-core': 0.1.12
+      '@ledgerhq/lumen-design-core': 0.1.13
       '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
       '@types/react': 19.0.14
       i18next: 23.10.1
@@ -45626,6 +45609,23 @@ snapshots:
       react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
       react-native-reanimated: 4.1.6(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      react-native-safe-area-context: 5.6.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      react-native-svg: 15.15.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+    transitivePeerDependencies:
+      - react-dom
+
+  '@ledgerhq/lumen-ui-rnative@0.1.32(654277828b73b9745437809ac2c01a5b)':
+    dependencies:
+      '@gorhom/bottom-sheet': 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.1.6(react-native-worklets@0.7.2(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      '@ledgerhq/lumen-design-core': 0.1.13
+      '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
+      '@types/react': 19.0.14
+      expo-haptics: 14.1.4(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      i18next: 23.10.1
+      react: 19.0.0
+      react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
+      react-native-reanimated: 4.1.6(react-native-worklets@0.7.2(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react-native-safe-area-context: 5.6.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react-native-svg: 15.15.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,10 +33,10 @@ catalog:
   "@ledgerhq/signer-utils": 1.2.0
   "@ledgerhq/device-transport-kit-web-hid": 1.2.3
   "@ledgerhq/speculos-device-controller": 0.2.3
-  "@ledgerhq/lumen-design-core": 0.1.12
-  "@ledgerhq/lumen-ui-react": 0.1.30
-  "@ledgerhq/lumen-ui-rnative": 0.1.29
-  "@ledgerhq/lumen-ui-react-visualization": 0.1.8
+  "@ledgerhq/lumen-design-core": 0.1.13
+  "@ledgerhq/lumen-ui-react": 0.1.31
+  "@ledgerhq/lumen-ui-rnative": 0.1.32
+  "@ledgerhq/lumen-ui-react-visualization": 0.1.10
   "@ledgerhq/zcash-utils": 0.2.0
   # React Native
   react-native: 0.79.7


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Pure dependency bump verified via TypeScript compilation (`pnpm typecheck` passes on both desktop and mobile). The 4 migrated TextInput call sites need manual visual QA._
- [x] **Impact of the changes:**
  - Visual rendering of error state on `TextInput` in Send → Recipient → Memo input (XRP/Casper/etc. tag flows)
  - Visual rendering of error state on `TextInput` in Send → CustomFees (custom gas/fee inputs)
  - Visual rendering of error state on `TextInput` in Send → CoinControl amount input (desktop and mobile)
  - Confirm `aria-invalid` is still set automatically on errored inputs (now driven by `status="error"`)
  - General Lumen-driven UI smoke test (gradient utilities now reference `*-transparent-0` CSS variables — covered by `lumen-design-core@0.1.13`)

### 📝 Description

Bumps the Lumen design-system packages to their latest versions announced on Slack:

- `@ledgerhq/lumen-design-core` `0.1.12` → `0.1.13` (required peer of ui-react `0.1.31`)
- `@ledgerhq/lumen-ui-react` `0.1.30` → `0.1.31`
- `@ledgerhq/lumen-ui-rnative` `0.1.29` → `0.1.32`
- `@ledgerhq/lumen-ui-react-visualization` `0.1.8` → `0.1.10`

**Breaking change applied** — `Input.errorMessage` was removed in both React and React Native; the replacement is `helperText` + `status="error"`. Migrated 4 lumen `TextInput` call sites:

- `apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/Memo/MemoValueInput.tsx`
- `apps/ledger-live-desktop/src/mvvm/features/Send/screens/CustomFees/components/CustomFeesScreenView.tsx` (also dropped the now-redundant explicit `aria-invalid` — `status="error"` sets it automatically)
- `apps/ledger-live-desktop/src/mvvm/features/Send/screens/CoinControl/components/AmountInput.tsx`
- `apps/ledger-live-mobile/src/mvvm/features/Send/screens/CoinControl/components/AmountInput.tsx`

```diff
- <TextInput errorMessage={msg ?? undefined} />
+ <TextInput
+   helperText={msg ?? undefined}
+   status={msg ? "error" : undefined}
+ />
```

The other Lumen changes (`bg-gradient-*` Tailwind utilities, `SegmentedControl` trailing content, `DataTable/Table` stickyHeader, `LineChart` scrubber) are additive — no migration required for the bump.

Peer-dep ranges in `libs/ui/packages/{react,native}` already satisfied (`>=0.1.11` / `>=0.1.24` / `>=0.1.25`), so no library peer-dep updates needed.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30589](https://ledgerhq.atlassian.net/browse/LIVE-30589)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30589]: https://ledgerhq.atlassian.net/browse/LIVE-30589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ