### PR TITLE
[LWDM] refactor(bridge): turn BridgeApi.getChainSpecificRules into a plain field

### DIFF
--- a/.changeset/modern-dragons-tell.md
+++ b/.changeset/modern-dragons-tell.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/ledger-wallet-framework": patch
+"@ledgerhq/live-common": patch
+---
+
+Change BridgeApi.getChainSpecificRules from a function returning ChainSpecificRules to a plain ChainSpecificRules field, and update Stellar accordingly (LIVE-28622)

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/families/stellar/bridge.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/families/stellar/bridge.ts
@@ -5,19 +5,17 @@ import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
 import { StellarBurnAddressError } from "@ledgerhq/coin-stellar/types";
 import { STELLAR_BURN_ADDRESS } from "@ledgerhq/coin-stellar/logic";
 
-export function getChainSpecificRules(): ChainSpecificRules {
-  return {
-    getAccountShape: (address: string) => {
-      // NOTE: https://github.com/LedgerHQ/ledger-live/pull/2058
-      if (address === STELLAR_BURN_ADDRESS) {
-        throw new StellarBurnAddressError();
-      }
-    },
-    getTransactionStatus: {
-      throwIfPendingOperation: true,
-    },
-  };
-}
+export const getChainSpecificRules: ChainSpecificRules = {
+  getAccountShape: (address: string) => {
+    // NOTE: https://github.com/LedgerHQ/ledger-live/pull/2058
+    if (address === STELLAR_BURN_ADDRESS) {
+      throw new StellarBurnAddressError();
+    }
+  },
+  getTransactionStatus: {
+    throwIfPendingOperation: true,
+  },
+};
 
 export async function getTokenFromAsset(asset: AssetInfo): Promise<TokenCurrency | undefined> {
   const assetId =

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
@@ -327,7 +327,7 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
     const alpacaApi = await getAlpacaApi(currency.id, kind);
     const bridgeApi = getBridgeApi(currency, network);
 
-    const chainSpecificValidation = bridgeApi.getChainSpecificRules?.();
+    const chainSpecificValidation = bridgeApi.getChainSpecificRules;
     if (chainSpecificValidation) {
       chainSpecificValidation.getAccountShape(address);
     }

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/getTransactionStatus.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/getTransactionStatus.ts
@@ -39,7 +39,7 @@ export function genericGetTransactionStatus(
       dstValAddress: transaction.dstValAddress,
     };
 
-    const chainSpecificValidation = bridgeApi.getChainSpecificRules?.();
+    const chainSpecificValidation = bridgeApi.getChainSpecificRules;
     if (chainSpecificValidation) {
       if (chainSpecificValidation.getTransactionStatus.throwIfPendingOperation) {
         if (account.pendingOperations.length > 0) {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getAccountShape.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getAccountShape.test.ts
@@ -33,9 +33,9 @@ jest.mock("../bridge", () => ({
 }));
 const defaultBridgeApi = () => ({
   getTokenFromAsset: getTokenFromAssetMock,
-  getChainSpecificRules: () => ({
+  getChainSpecificRules: {
     getAccountShape: (...a: any[]) => chainSpecificGetAccountShapeMock(...a),
-  }),
+  },
 });
 getBridgeApiMock.mockImplementation(defaultBridgeApi);
 

--- a/libs/ledger-wallet-framework/src/api/types.ts
+++ b/libs/ledger-wallet-framework/src/api/types.ts
@@ -10,7 +10,7 @@ export type ChainSpecificRules = {
 };
 
 export type BridgeApi = {
-  getChainSpecificRules?: () => ChainSpecificRules;
+  getChainSpecificRules?: ChainSpecificRules;
   getTokenFromAsset?: (asset: AssetInfo) => Promise<TokenCurrency | undefined>;
   getAssetFromToken?: (token: TokenCurrency, owner: string) => AssetInfo;
   computeIntentType?: (transaction: Record<string, unknown>) => string;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Stellar account synchronization (burn address rejection in `getAccountShape`)
  - Stellar transaction status (pending operations check)

### 📝 Description

`BridgeApi.getChainSpecificRules` was typed as a function returning `ChainSpecificRules`, but it is implemented only by Stellar and returns a static object with no dynamic behavior. The function indirection is unnecessary.

This PR changes the field to a plain `ChainSpecificRules` object on `BridgeApi`, updates the Stellar implementation accordingly, and adapts the two call sites in the generic coin framework (`getAccountShape`, `getTransactionStatus`).

```ts
// Before
export type BridgeApi = {
  getChainSpecificRules?: () => ChainSpecificRules;
  // ...
};

// After
export type BridgeApi = {
  getChainSpecificRules?: ChainSpecificRules;
  // ...
};
```

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28622](https://ledgerhq.atlassian.net/browse/LIVE-28622)

- **E2E**:
  - Mobile: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/99d23224-cc3b-4e14-ba40-828dc385df61/
  - Desktop: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/8befca9b-923e-4f26-bed0-549e1867c792/
---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-28622]: https://ledgerhq.atlassian.net/browse/LIVE-28622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ