### PR TITLE
[LWDM] refactor(llc): uniform set memo during getTransactionStatus

### DIFF
--- a/.changeset/loud-kiwis-retire.md
+++ b/.changeset/loud-kiwis-retire.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Unify memo mapping inside `transactionToIntent` in the generic coin framework; remove the now-redundant `applyMemoToIntent` post-step from `getTransactionStatus` and `signOperation`.

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/getTransactionStatus.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/getTransactionStatus.ts
@@ -3,12 +3,7 @@ import { AccountAwaitingSendPendingOperations } from "@ledgerhq/errors";
 import BigNumber from "bignumber.js";
 import { getCoinModuleApi } from "./api";
 import { getBridgeApi } from "./bridge";
-import {
-  bigNumberToBigIntDeep,
-  extractBalances,
-  applyMemoToIntent,
-  transactionToIntent,
-} from "./utils";
+import { bigNumberToBigIntDeep, extractBalances, transactionToIntent } from "./utils";
 import type { GenericTransaction } from "./types";
 
 // => coin-framework validateIntent
@@ -30,6 +25,7 @@ export function genericGetTransactionStatus(
       subAccountId: transaction.subAccountId || "",
       memoType: transaction.memoType || "",
       memoValue: transaction.memoValue || "",
+      tag: transaction.tag,
       family: transaction.family,
       feesStrategy: transaction.feesStrategy,
       data: transaction.data,
@@ -48,13 +44,12 @@ export function genericGetTransactionStatus(
       }
     }
 
-    let intent = transactionToIntent(
+    const intent = transactionToIntent(
       account,
       draftTransaction,
       bridgeApi.computeIntentType,
       coinModuleApi.craftTransactionData,
     );
-    intent = applyMemoToIntent(intent, transaction);
 
     const customFees = bigNumberToBigIntDeep({
       value: transaction.fees ?? new BigNumber(0),

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/signOperation.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/signOperation.ts
@@ -4,7 +4,6 @@ import type { Account, DeviceId, SignOperationEvent, AccountBridge } from "@ledg
 import { getCoinModuleApi } from "./api";
 import { getBridgeApi } from "./bridge";
 import {
-  applyMemoToIntent,
   bigNumberToBigIntDeep,
   buildOptimisticOperation,
   extractBalances,
@@ -12,27 +11,10 @@ import {
 } from "./utils";
 import { FeeNotLoaded } from "@ledgerhq/errors";
 import { Result } from "@ledgerhq/ledger-wallet-framework/derivation";
-import type { TransactionIntent } from "@ledgerhq/coin-module-framework/api/types";
 import { log } from "@ledgerhq/logs";
 import BigNumber from "bignumber.js";
 import { GenericTransaction } from "./types";
 
-/**
- * Enriches transaction intent with memo and asset information
- */
-function enrichTransactionIntent(
-  transactionIntent: TransactionIntent,
-  transaction: GenericTransaction,
-  publicKey: string,
-): TransactionIntent {
-  // Set sender public key
-  transactionIntent.senderPublicKey = publicKey;
-
-  // Apply memo information
-  transactionIntent = applyMemoToIntent(transactionIntent, transaction);
-
-  return transactionIntent;
-}
 /**
  * Sign Transaction with Ledger hardware
  */
@@ -72,6 +54,9 @@ export const genericSignOperation =
             assetReference: transaction?.assetReference || "",
             assetOwner: transaction?.assetOwner || "",
             subAccountId: transaction.subAccountId || "",
+            memoType: transaction.memoType || "",
+            memoValue: transaction.memoValue || "",
+            tag: transaction.tag,
             family: transaction.family,
             feesStrategy: transaction.feesStrategy,
             data: transaction.data,
@@ -96,16 +81,13 @@ export const genericSignOperation =
             derivationMode: account.derivationMode,
           })) as Result;
 
-          let transactionIntent = transactionToIntent(
+          const transactionIntent = transactionToIntent(
             account,
             { ...transaction },
             bridgeApi.computeIntentType,
             coinModuleApi.craftTransactionData,
           );
           transactionIntent.senderPublicKey = publicKey;
-
-          // Enrich with memo and asset information
-          transactionIntent = enrichTransactionIntent(transactionIntent, transaction, publicKey);
 
           if (typeof transactionIntent.sequence !== "bigint" || transactionIntent.sequence < 0n) {
             // TODO: should compute it and pass it down to craftTransaction (duplicate call right now)

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getTransactionStatus.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getTransactionStatus.test.ts
@@ -9,19 +9,16 @@ jest.mock("../api", () => ({
 
 jest.mock("../utils", () => ({
   ...jest.requireActual("../utils"),
-  transactionToIntent: jest.fn(),
-  applyMemoToIntent: jest.fn(),
   extractBalances: jest.fn(),
 }));
 
-const mockTransactionToIntent = utils.transactionToIntent as jest.Mock;
-const mockApplyMemoToIntent = utils.applyMemoToIntent as jest.Mock;
 const mockExtractBalances = utils.extractBalances as jest.Mock;
 
 describe("genericGetTransactionStatus", () => {
   const account = {
     id: "test-account",
-    currency: { id: "ethereum" },
+    freshAddress: "0xSender",
+    currency: { id: "ethereum", name: "ethereum", units: [{ name: "ether", code: "ETH" }] },
     pendingOperations: [],
   } as any;
 
@@ -35,14 +32,13 @@ describe("genericGetTransactionStatus", () => {
     totalFees: 50n,
   };
 
+  const validateIntent = jest.fn();
+
   beforeEach(() => {
     jest.clearAllMocks();
-    mockTransactionToIntent.mockReturnValue({ intent: true });
-    mockApplyMemoToIntent.mockImplementation((intent: unknown) => intent);
+    validateIntent.mockResolvedValue(validateIntentResult);
     mockExtractBalances.mockReturnValue({});
-    (getCoinModuleApi as jest.Mock).mockReturnValue({
-      validateIntent: jest.fn().mockResolvedValue(validateIntentResult),
-    });
+    (getCoinModuleApi as jest.Mock).mockReturnValue({ validateIntent });
   });
 
   it.each([
@@ -68,4 +64,29 @@ describe("genericGetTransactionStatus", () => {
       expect(result.amount).toEqual(expected);
     },
   );
+
+  it("forwards a destination tag through transactionToIntent to validateIntent", async () => {
+    const xrpAccount = {
+      ...account,
+      freshAddress: "rSender",
+      currency: { id: "ripple", name: "ripple", units: [{ name: "ripple", code: "XRP" }] },
+    };
+
+    const getStatus = genericGetTransactionStatus("mainnet", "xrp");
+    await getStatus(xrpAccount, {
+      amount: new BigNumber(100),
+      useAllAmount: false,
+      recipient: "rRecipient",
+      family: "xrp",
+      tag: 1234,
+    } as any);
+
+    expect(validateIntent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        memo: { type: "map", memos: new Map([["destinationTag", "1234"]]) },
+      }),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
 });

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/signOperation.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/signOperation.test.ts
@@ -1,9 +1,10 @@
+import BigNumber from "bignumber.js";
 import { lastValueFrom } from "rxjs";
 import { toArray } from "rxjs/operators";
 import { genericSignOperation } from "../signOperation";
 import { FeeNotLoaded } from "@ledgerhq/errors";
 import { getCoinModuleApi } from "../api";
-import { buildOptimisticOperation, transactionToIntent } from "../utils";
+import { buildOptimisticOperation } from "../utils";
 
 jest.mock("../api", () => ({
   getCoinModuleApi: jest.fn(),
@@ -12,7 +13,6 @@ jest.mock("../api", () => ({
 jest.mock("../utils", () => ({
   ...jest.requireActual("../utils"),
   buildOptimisticOperation: jest.fn(),
-  transactionToIntent: jest.fn(),
 }));
 
 describe("genericSignOperation", () => {
@@ -23,33 +23,30 @@ describe("genericSignOperation", () => {
   };
 
   const transaction = {
-    amount: 100_000n,
-    fees: 500n,
+    amount: new BigNumber(100_000),
+    fees: new BigNumber(500),
     tag: 1234,
+    recipient: "rRecipient",
+    family: "xrp",
     recipientDomain: {
       domain: "recipient.gen",
       address: "recipient-address",
     },
   } as any;
 
-  const txIntent = {
-    memo: {
-      type: "map",
-      memos: new Map(),
-    },
-  };
+  const craftTransaction = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
 
+    craftTransaction.mockResolvedValue({ transaction: "unsignedTx" });
     (getCoinModuleApi as jest.Mock).mockReturnValue({
-      craftTransaction: jest.fn().mockResolvedValue({ transaction: "unsignedTx" }),
+      craftTransaction,
       getAccountInfo: jest.fn().mockResolvedValue("pubKey"),
       combine: jest.fn().mockResolvedValue("signedTx"),
       getNextSequence: jest.fn().mockResolvedValue(1n),
     });
 
-    (transactionToIntent as jest.Mock).mockReturnValue(txIntent);
     (buildOptimisticOperation as jest.Mock).mockReturnValue({ id: "mock-op" });
 
     mockSigner.getAddress.mockResolvedValue({ publicKey: "pubKey" });
@@ -61,11 +58,11 @@ describe("genericSignOperation", () => {
     freshAddressPath: "44'/144'/0'/0/0",
     freshAddress: "rTestAddress",
     address: "rTestAddress",
-    currency: { id: "testnet" },
+    currency: { id: "ripple", name: "ripple", units: [{ name: "ripple", code: "XRP" }] },
   } as any;
 
-  it("emits full sign operation flow", async () => {
-    const signOperation = genericSignOperation("testnet", "local")(mockSignerContext);
+  it("emits full sign operation flow and forwards destination tag to craftTransaction", async () => {
+    const signOperation = genericSignOperation("mainnet", "xrp")(mockSignerContext);
     const observable = signOperation({ account, transaction, deviceId: "" });
 
     const events = await lastValueFrom(observable.pipe(toArray()));
@@ -80,20 +77,24 @@ describe("genericSignOperation", () => {
       },
     });
 
-    expect(transactionToIntent).toHaveBeenCalledWith(account, transaction, undefined, undefined);
     expect(mockSigner.signTransaction).toHaveBeenCalledWith("44'/144'/0'/0/0", "unsignedTx", {
       domain: "recipient.gen",
       address: "recipient-address",
       derivationMode: undefined,
     });
-    expect(txIntent.memo.memos.get("destinationTag")).toBe("1234");
+    expect(craftTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        memo: { type: "map", memos: new Map([["destinationTag", "1234"]]) },
+      }),
+      expect.anything(),
+    );
   });
 
   it("throws FeeNotLoaded if fees are missing", async () => {
     const txWithoutFees = { ...transaction };
     delete txWithoutFees.fees;
 
-    const signOperation = genericSignOperation("testnet", "local")(mockSignerContext);
+    const signOperation = genericSignOperation("mainnet", "xrp")(mockSignerContext);
     const observable = signOperation({ account, transaction: txWithoutFees, deviceId: "" });
 
     await expect(lastValueFrom(observable)).rejects.toThrow(FeeNotLoaded);

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 import {
   adaptCoreOperationToLiveOperation,
-  applyMemoToIntent,
   bigNumberToBigIntDeep,
   buildOptimisticOperation,
   cleanedOperation,
@@ -11,10 +10,7 @@ import {
   transactionToIntent,
 } from "./utils";
 import BigNumber from "bignumber.js";
-import {
-  Operation as CoreOperation,
-  TransactionIntent,
-} from "@ledgerhq/coin-module-framework/api/types";
+import type { Operation as CoreOperation } from "@ledgerhq/coin-module-framework/api/types";
 import { Account } from "@ledgerhq/types-live";
 import { GenericTransaction, GenericTransactionMode, OperationCommon } from "./types";
 import * as craftTransactionDataModule from "@ledgerhq/coin-module-framework/logic/craftTransactionData";
@@ -32,42 +28,6 @@ jest.mock("@ledgerhq/coin-module-framework/logic/craftTransactionData", () => {
 describe("coin-framework utils", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-  });
-
-  describe("applyMemoToIntent", () => {
-    it("does not apply any memo", () => {
-      const intent = applyMemoToIntent(
-        {} as unknown as TransactionIntent,
-        {} as GenericTransaction,
-      );
-
-      expect(intent).toEqual({});
-    });
-
-    it.each([
-      [0, "0"],
-      [1, "1"],
-    ])("applies '%s' as the destination tag", (tag, expectedTag) => {
-      const intent = applyMemoToIntent(
-        {} as unknown as TransactionIntent,
-        { tag } as GenericTransaction,
-      );
-
-      expect(intent).toEqual({
-        memo: { type: "map", memos: new Map([["destinationTag", expectedTag]]) },
-      });
-    });
-
-    it("applies a custom memo type", () => {
-      const intent = applyMemoToIntent(
-        {} as unknown as TransactionIntent,
-        { memoType: "memo-type", memoValue: "memo-value" } as GenericTransaction,
-      );
-
-      expect(intent).toEqual({
-        memo: { type: "memo-type", value: "memo-value" },
-      });
-    });
   });
 
   describe("bigNumberToBigIntDeep", () => {
@@ -543,6 +503,46 @@ describe("coin-framework utils", () => {
 
         expect(craftTransactionDataMock).not.toHaveBeenCalled();
         expect(defaultCraftTransactionDataSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("memo", () => {
+      const account = { currency: { name: "ethereum", units: [{}] } } as Account;
+
+      it("defaults to NO_MEMO when no memo or tag is provided", () => {
+        const intent = transactionToIntent(account, {} as GenericTransaction);
+        expect(intent.memo).toEqual({ type: "NO_MEMO" });
+      });
+
+      it.each([
+        [0, "0"],
+        [1, "1"],
+      ])("maps tag '%s' to a destination tag memo", (tag, expectedTag) => {
+        const intent = transactionToIntent(account, { tag } as GenericTransaction);
+        expect(intent.memo).toEqual({
+          type: "map",
+          memos: new Map([["destinationTag", expectedTag]]),
+        });
+      });
+
+      it("maps memoType/memoValue to a typed memo", () => {
+        const intent = transactionToIntent(account, {
+          memoType: "memo-type",
+          memoValue: "memo-value",
+        } as GenericTransaction);
+        expect(intent.memo).toEqual({ type: "memo-type", value: "memo-value" });
+      });
+
+      it("prefers tag over memoType/memoValue when both are set", () => {
+        const intent = transactionToIntent(account, {
+          tag: 42,
+          memoType: "memo-type",
+          memoValue: "memo-value",
+        } as GenericTransaction);
+        expect(intent.memo).toEqual({
+          type: "map",
+          memos: new Map([["destinationTag", "42"]]),
+        });
       });
     });
 

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
@@ -6,7 +6,6 @@ import type {
   AssetInfo,
   Balance,
   Operation as CoreOperation,
-  MapMemo,
   StakingOperation,
   TransactionIntent,
   TxData,
@@ -22,7 +21,6 @@ import type {
   GenericTransactionRaw,
   OperationCommon,
 } from "./types";
-import type { StellarMemo } from "@ledgerhq/coin-stellar/types/model";
 import { craftTransactionData as defaultCraftTransactionData } from "@ledgerhq/coin-module-framework/logic/craftTransactionData";
 
 type BigNumberToBigIntDeep<T> = T extends BigNumber
@@ -106,7 +104,9 @@ function isDelegationMode(mode: GenericTransaction["mode"]): mode is StakingOper
   );
 }
 
-type GenericCoinFrameworkMemo = { type: string; value?: string };
+type GenericCoinFrameworkMemo =
+  | { type: string; value?: string }
+  | { type: "map"; memos: Map<string, string> };
 type GenericCoinFrameworkTxData = { type: string; value?: unknown };
 type GenericCoinFrameworkTransactionIntent = TransactionIntent & {
   memo?: GenericCoinFrameworkMemo;
@@ -268,7 +268,15 @@ function defaultComputeIntentType(transaction: GenericTransaction): string {
   const mode = modeRemap[transaction.mode] ?? transaction.mode;
 
   if (
-    ["changeTrust", "send", "send-legacy", "send-eip1559", "stake", "unstake", "finalize_unstake"].includes(mode)
+    [
+      "changeTrust",
+      "send",
+      "send-legacy",
+      "send-eip1559",
+      "stake",
+      "unstake",
+      "finalize_unstake",
+    ].includes(mode)
   )
     return mode;
 
@@ -341,7 +349,12 @@ export function transactionToIntent(
     };
   }
 
-  if (transaction.memoType && transaction.memoValue) {
+  if (typeof transaction.tag === "number") {
+    res.memo = {
+      type: "map",
+      memos: new Map([["destinationTag", String(transaction.tag)]]),
+    };
+  } else if (transaction.memoType && transaction.memoValue) {
     res.memo = {
       type: transaction.memoType,
       value: transaction.memoValue,
@@ -560,42 +573,3 @@ export const buildOptimisticOperation = (
   }
   return operation;
 };
-
-/**
- * Applies memo information to transaction intent
- * Handles both destination tags (XRP-like) and Stellar-style memos
- */
-export function applyMemoToIntent(
-  transactionIntent: TransactionIntent<any>,
-  transaction: GenericTransaction,
-): TransactionIntent<any> {
-  // Handle destination tag memo (for XRP-like chains)
-  if (typeof transaction.tag === "number") {
-    const txWithMemoTag = transactionIntent as TransactionIntent<MapMemo<string, string>>;
-    const txMemo = String(transaction.tag);
-
-    txWithMemoTag.memo = {
-      type: "map",
-      memos: new Map(),
-    };
-    txWithMemoTag.memo.memos.set("destinationTag", txMemo);
-
-    return txWithMemoTag;
-  }
-
-  // Handle Stellar-style memo
-  if (transaction.memoType && transaction.memoValue) {
-    const txWithMemo = transactionIntent as TransactionIntent<StellarMemo>;
-    const txMemoType = String(transaction.memoType);
-    const txMemoValue = String(transaction.memoValue);
-
-    txWithMemo.memo = {
-      type: txMemoType as "NO_MEMO" | "MEMO_TEXT" | "MEMO_ID" | "MEMO_HASH" | "MEMO_RETURN",
-      value: txMemoValue,
-    };
-
-    return txWithMemo;
-  }
-
-  return transactionIntent;
-}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - XRP send (destination tag must still validate and reach the signed transaction)
  - Stellar send (MEMO_TEXT / MEMO_ID / MEMO_HASH / MEMO_RETURN must still validate and sign correctly)
  - Any generic-coin-framework coin without memo (must keep producing `NO_MEMO` intents)

### 📝 Description

**Problem**: memo handling on the generic-coin-framework bridge was done in two places. `transactionToIntent` already mapped Stellar-style `memoType` / `memoValue`, but a separate `applyMemoToIntent` post-step was also called right after — both in `getTransactionStatus` and in `signOperation` — to map the XRP destination `tag` (and to re-map Stellar memos, duplicating logic). The split existed because `draftTransaction` in `getTransactionStatus.ts` silently dropped `transaction.tag`, so the post-step received the full transaction and patched the intent afterwards. Every new call site had to remember to call `applyMemoToIntent`, which is error-prone.

**Solution**: memo mapping is now done in a single place inside `transactionToIntent` (XRP destination tag, Stellar-style memo, `NO_MEMO` default). `applyMemoToIntent` is removed and its call sites in `getTransactionStatus.ts` / `signOperation.ts` are dropped. The hand-rolled `draftTransaction` objects in both files now also forward `tag` (and the memo fields in the `useAllAmount` branch of `signOperation`) so the unified path receives everything it needs. Tag is given precedence over `memoType`/`memoValue`, matching the previous behavior of `applyMemoToIntent`.

```ts
// before
let intent = transactionToIntent(account, draftTransaction, …);
intent = applyMemoToIntent(intent, transaction);

// after
const intent = transactionToIntent(account, draftTransaction, …);
```

Test coverage:

- `utils.test.ts` — unit tests for the new `transactionToIntent` memo branches (NO_MEMO, destination tag, Stellar-style, tag-over-memoType precedence).
- `signOperation.test.ts` — un-mocks `transactionToIntent` and asserts the destination tag is forwarded all the way down to `craftTransaction`.
- `getTransactionStatus.test.ts` — same approach, asserts the destination tag is forwarded to `validateIntent` (guards against `draftTransaction` losing `tag` again).

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29118](https://ledgerhq.atlassian.net/browse/LIVE-29118)

- **E2E**:
  - Mobile: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/f7b5e8ce-5f0a-4705-81e6-e92e430987f8/
  - Desktop: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/f4de41e8-0c0a-483d-99dc-5e0fdd4a8e8f/

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29118]: https://ledgerhq.atlassian.net/browse/LIVE-29118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ