### PR TITLE
[LWD] test(desktop): validate market page title

### DIFF
--- a/.changeset/market-title-e2e.md
+++ b/.changeset/market-title-e2e.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Add a desktop page header title test id for market E2E validation.

--- a/apps/ledger-live-desktop/src/mvvm/components/PageHeader/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/PageHeader/index.tsx
@@ -11,7 +11,9 @@ export default function PageHeader({ title, onBack, trailing }: Props) {
   return (
     <NavBar data-testid="page-header">
       {onBack ? <NavBarBackButton onClick={onBack} /> : null}
-      <NavBarTitle>{title}</NavBarTitle>
+      <NavBarTitle>
+        <span data-testid="page-header-title">{title}</span>
+      </NavBarTitle>
       {trailing ? <NavBarTrailing>{trailing}</NavBarTrailing> : null}
     </NavBar>
   );

--- a/e2e/desktop/tests/page/market.page.ts
+++ b/e2e/desktop/tests/page/market.page.ts
@@ -4,6 +4,7 @@ import { expect } from "@playwright/test";
 import { isWallet40Enabled } from "tests/utils/featureFlagUtils";
 
 export class MarketPage extends AppPage {
+  private navbarTitle = this.page.getByTestId("page-header-title");
   private searchInput = this.page.getByTestId("market-search-input");
   private loadingPlaceholder = this.page.getByTestId("loading-placeholder");
   private coinRow = (ticker: string) => this.page.getByTestId(`market-${ticker}-row`).first();
@@ -37,8 +38,9 @@ export class MarketPage extends AppPage {
 
   @step("Validate Market List")
   async validateMarketList() {
-    await this.coinRow("btc").waitFor({ state: "visible" });
-    await this.coinRow("eth").waitFor({ state: "visible" });
+    await expect(this.navbarTitle).toHaveText("Market");
+    await expect(this.coinRow("btc")).toBeVisible();
+    await expect(this.coinRow("eth")).toBeVisible();
   }
 
   @step("Open coin page for $0")

--- a/e2e/desktop/tests/page/market.page.ts
+++ b/e2e/desktop/tests/page/market.page.ts
@@ -7,7 +7,8 @@ export class MarketPage extends AppPage {
   private readonly navbarTitle = this.page.getByTestId("page-header-title");
   private searchInput = this.page.getByTestId("market-search-input");
   private loadingPlaceholder = this.page.getByTestId("loading-placeholder");
-  private coinRow = (ticker: string) => this.page.getByTestId(`market-${ticker}-row`).first();
+  private readonly coinRow = (ticker: string) =>
+    this.page.getByTestId(`market-${ticker}-row`).first();
   private coinPageContainer = this.page.getByTestId("market-coin-page-container");
   private swapButtonOnAsset = this.page.getByTestId("market-coin-swap-button");
 
@@ -18,7 +19,7 @@ export class MarketPage extends AppPage {
   private stakeButtonLegacy = (ticker: string) =>
     this.page.locator(`[data-testid="market-${ticker}-stake-button"]:visible`).first();
 
-  private buyButton = (ticker: string) =>
+  private readonly buyButton = (ticker: string) =>
     this.coinRow(ticker).getByTestId(`market-${ticker}-buy-button-icon`);
   private swapButton = (ticker: string) =>
     this.coinRow(ticker).getByTestId(`market-${ticker}-swap-button-icon`);

--- a/e2e/desktop/tests/page/market.page.ts
+++ b/e2e/desktop/tests/page/market.page.ts
@@ -4,7 +4,7 @@ import { expect } from "@playwright/test";
 import { isWallet40Enabled } from "tests/utils/featureFlagUtils";
 
 export class MarketPage extends AppPage {
-  private navbarTitle = this.page.getByTestId("page-header-title");
+  private readonly navbarTitle = this.page.getByTestId("page-header-title");
   private searchInput = this.page.getByTestId("market-search-input");
   private loadingPlaceholder = this.page.getByTestId("loading-placeholder");
   private coinRow = (ticker: string) => this.page.getByTestId(`market-${ticker}-row`).first();

--- a/e2e/desktop/tests/specs/market.spec.ts
+++ b/e2e/desktop/tests/specs/market.spec.ts
@@ -8,27 +8,9 @@ import { LWD_WALLET_40_FF_ENABLED } from "tests/utils/featureFlagUtils";
 test.describe("Market", () => {
   test.use({
     teamOwner: Team.WALLET_XP,
-    //TODO: remove feature flag when market banner is enabled for all users
     userdata: "speculos-tests-app",
     featureFlags: LWD_WALLET_40_FF_ENABLED,
   });
-
-  test(
-    "Market list content",
-    {
-      tag: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"],
-      annotation: {
-        type: "TMS",
-        description: "B2CQA-4316",
-      },
-    },
-    async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
-      await app.marketBanner.clickExploreMarketHeader();
-      await app.market.validateMarketList();
-    },
-  );
 
   test(
     "Filters behavior",
@@ -36,14 +18,13 @@ test.describe("Market", () => {
       tag: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"],
       annotation: {
         type: "TMS",
-        description: "B2CQA-4315, B2CQA-1879",
+        description: "B2CQA-4315, B2CQA-4316, B2CQA-1879",
       },
     },
     async ({ app }) => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
       await app.marketBanner.clickExploreMarketHeader();
-
       await app.market.validateMarketList();
 
       await app.market.starCoin(Account.BTC_NATIVE_SEGWIT_1.currency.ticker);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Desktop and desktop E2E typechecks passed locally. Full Desktop E2E workflow is running with broadcast disabled.
- [x] **Impact of the changes:**
  - Desktop PageHeader test selectors
  - Market desktop E2E title/list validation
  - Market filters E2E coverage consolidation

### 📝 Description

This PR updates the Market desktop E2E coverage for QAA-1108 by validating that navigation from the market banner lands on the Market page before checking that the BTC and ETH rows are visible.

The PageHeader component now exposes a stable `page-header-title` test id on the rendered title content, allowing the Market page object to keep the same direct `getByTestId(...)` locator style used by the rest of the desktop E2E suite. The standalone market list content test is folded into the existing filters behavior scenario to avoid duplicated navigation and row checks.

### 🧪 CI Execution

- **Desktop E2E full run, broadcast OFF**: [Workflow run #25796287509](https://github.com/LedgerHQ/ledger-live/actions/runs/25796287509)

### ❓ Context

- **JIRA or GitHub link**: [QAA-1108](https://ledgerhq.atlassian.net/browse/QAA-1108)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-1108]: https://ledgerhq.atlassian.net/browse/QAA-1108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ