### PR TITLE
[LWD] Add FeatureIntro and Carousel templates for Generic Awareness Modal

### DIFF
--- a/.changeset/lucky-socks-drum.md
+++ b/.changeset/lucky-socks-drum.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add templates for Generic Awareness Modal

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/GenericAwarenessModalView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/GenericAwarenessModalView.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { Dialog, DialogBody, DialogContent, DialogHeader } from "@ledgerhq/lumen-ui-react";
+import type { GenericAwarenessModalViewProps } from "./useGenericAwarenessModalViewModel";
+import useGenericAwarenessModalFeatureIntroViewModel from "./useGenericAwarenessModalFeatureIntroViewModel";
+import useGenericAwarenessModalCarouselViewModel from "./useGenericAwarenessModalCarouselViewModel";
+import CarouselContent from "./components/CarouselContent";
+import FeatureIntroContent from "./components/FeatureIntroContent";
+
+const GenericAwarenessModalView = ({
+  isOpen,
+  onClose,
+  campaignId,
+  contentVariant,
+}: GenericAwarenessModalViewProps) => {
+  const featureIntroViewModel = useGenericAwarenessModalFeatureIntroViewModel();
+  const carouselViewModel = useGenericAwarenessModalCarouselViewModel();
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) onClose();
+  };
+
+  const isCarousel = contentVariant === "carousel";
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent
+        className="max-h-[90vh] rounded-xl"
+        aria-describedby={undefined}
+        data-testid="generic-awareness-modal"
+        data-campaign-id={campaignId ?? undefined}
+      >
+        <DialogHeader density="expanded" onClose={onClose} />
+        <DialogBody className="flex min-h-0 flex-1 flex-col gap-24 overflow-hidden">
+          {isCarousel ? (
+            <CarouselContent {...carouselViewModel} />
+          ) : (
+            <FeatureIntroContent {...featureIntroViewModel} />
+          )}
+        </DialogBody>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default GenericAwarenessModalView;

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/__integrations__/GenericAwarenessModal.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/__integrations__/GenericAwarenessModal.integration.test.tsx
@@ -1,0 +1,143 @@
+import React from "react";
+import { render, screen, waitFor, act } from "tests/testSetup";
+import type { AppDispatch } from "~/state-manager/configureStore";
+import GenericAwarenessModal from "..";
+import { closeGenericAwarenessModal, openGenericAwarenessModal } from "../genericAwarenessModal";
+
+describe("GenericAwarenessModal Integration", () => {
+  const dispatchThunk = (
+    store: { dispatch: unknown },
+    thunk:
+      | ReturnType<typeof openGenericAwarenessModal>
+      | ReturnType<typeof closeGenericAwarenessModal>,
+  ) => {
+    (store.dispatch as AppDispatch)(thunk);
+  };
+
+  it("should not render a dialog while the modal is closed", () => {
+    render(<GenericAwarenessModal />);
+    expect(screen.queryByTestId("generic-awareness-modal")).not.toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  describe("feature intro variant", () => {
+    it("should render feature intro when opened without campaign id and close on Got it", async () => {
+      const { store, user } = render(<GenericAwarenessModal />);
+
+      act(() => {
+        dispatchThunk(store, openGenericAwarenessModal());
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Connect a Ledger device")).toBeVisible();
+      });
+      expect(screen.getByText("Swap and bridge")).toBeVisible();
+      expect(
+        screen.queryByTestId("generic-awareness-modal-continue-button"),
+      ).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "Got it" }));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("generic-awareness-modal")).not.toBeInTheDocument();
+      });
+      expect(store.getState().dialogs.GENERIC_AWARENESS_MODAL).toBe(false);
+      expect(store.getState().genericAwarenessModal.campaignId).toBeUndefined();
+    });
+
+    it("should render feature intro when opened with odd campaign id", async () => {
+      const { store } = render(<GenericAwarenessModal />);
+
+      act(() => {
+        dispatchThunk(store, openGenericAwarenessModal({ campaignId: "1" }));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Connect a Ledger device")).toBeVisible();
+      });
+      expect(screen.getByTestId("generic-awareness-modal").getAttribute("data-campaign-id")).toBe(
+        "1",
+      );
+    });
+  });
+
+  describe("carousel variant", () => {
+    it("should render carousel when opened with even campaign id", async () => {
+      const { store } = render(<GenericAwarenessModal />);
+
+      act(() => {
+        dispatchThunk(store, openGenericAwarenessModal({ campaignId: "2" }));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Your portfolio at a glance")).toBeVisible();
+      });
+      expect(screen.getByText("See balances and accounts in one secure dashboard.")).toBeVisible();
+      expect(screen.getByTestId("generic-awareness-modal-continue-button")).toBeVisible();
+      expect(screen.getByRole("button", { name: "Learn more" })).toBeVisible();
+      expect(screen.queryByText("Connect a Ledger device")).not.toBeInTheDocument();
+    });
+
+    it("should close carousel without flashing feature intro content", async () => {
+      const { store } = render(<GenericAwarenessModal />);
+
+      act(() => {
+        dispatchThunk(store, openGenericAwarenessModal({ campaignId: "2" }));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Your portfolio at a glance")).toBeVisible();
+      });
+
+      act(() => {
+        dispatchThunk(store, closeGenericAwarenessModal());
+      });
+
+      expect(screen.queryByText("Connect a Ledger device")).not.toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("generic-awareness-modal")).not.toBeInTheDocument();
+      });
+      expect(store.getState().genericAwarenessModal.campaignId).toBeUndefined();
+    });
+
+    it("should close when the carousel primary button is clicked", async () => {
+      const { store, user } = render(<GenericAwarenessModal />);
+
+      act(() => {
+        dispatchThunk(store, openGenericAwarenessModal({ campaignId: "0" }));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Learn more" })).toBeVisible();
+      });
+
+      await user.click(screen.getByTestId("generic-awareness-modal-primary-button"));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("generic-awareness-modal")).not.toBeInTheDocument();
+      });
+      expect(store.getState().dialogs.GENERIC_AWARENESS_MODAL).toBe(false);
+    });
+  });
+
+  it("should close when closeGenericAwarenessModal is dispatched", async () => {
+    const { store } = render(<GenericAwarenessModal />);
+
+    act(() => {
+      dispatchThunk(store, openGenericAwarenessModal());
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeVisible();
+    });
+
+    act(() => {
+      dispatchThunk(store, closeGenericAwarenessModal());
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/components/CarouselContent.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/components/CarouselContent.tsx
@@ -1,0 +1,131 @@
+import React, { useCallback } from "react";
+import { Slides, useSlidesContext } from "LLD/components/Slides";
+import { Button, PageIndicator } from "@ledgerhq/lumen-ui-react";
+
+export type AwarenessCarouselSlide = {
+  id: string;
+  title: string;
+  subtitle: string;
+  imageUrl: string;
+  primaryButtonLabel: string;
+  primaryButtonLink: string;
+};
+
+type CarouselContentSlideProps = Pick<AwarenessCarouselSlide, "title" | "subtitle" | "imageUrl">;
+
+function CarouselContentSlide({ title, subtitle, imageUrl }: Readonly<CarouselContentSlideProps>) {
+  const showImage = imageUrl != null && imageUrl.length > 0;
+
+  return (
+    <div className="flex size-full flex-col">
+      <div className="py-24 overflow-hidden w-full">
+        {showImage ? (
+          <img
+            src={imageUrl}
+            alt=""
+            className="pointer-events-none h-[200px] w-full select-none rounded-xl object-cover"
+            draggable={false}
+            decoding="async"
+          />
+        ) : null}
+      </div>
+      <div className="flex flex-1 flex-col items-center px-20 gap-30">
+        <div
+          className="flex animate-fade-in flex-col items-center text-center"
+          style={{ pointerEvents: "none" }}
+        >
+          <div>
+            <h3 className="m-0 mb-8 heading-4-semi-bold text-base">{title}</h3>
+            <p className="m-0 body-2 text-muted">{subtitle}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export type CarouselContentProps = {
+  slides: AwarenessCarouselSlide[];
+  onSlidePrimaryClick: (slide: AwarenessCarouselSlide) => void;
+};
+
+function CarouselContentProgress() {
+  const { currentIndex, totalSlides } = useSlidesContext();
+  return (
+    <div className="flex justify-center py-24">
+      <PageIndicator currentPage={currentIndex + 1} totalPages={totalSlides} />
+    </div>
+  );
+}
+
+function CarouselContentFooter({
+  slides,
+  onSlidePrimaryClick,
+}: Readonly<{
+  slides: AwarenessCarouselSlide[];
+  onSlidePrimaryClick: (slide: AwarenessCarouselSlide) => void;
+}>) {
+  const { currentIndex, totalSlides, goToNext, goToSlide } = useSlidesContext();
+  const isLastSlide = currentIndex === totalSlides - 1;
+  const currentSlide = slides[currentIndex];
+
+  const handleContinue = useCallback(() => {
+    if (isLastSlide) {
+      goToSlide(0);
+    } else {
+      goToNext();
+    }
+  }, [isLastSlide, goToNext, goToSlide]);
+
+  const handlePrimary = useCallback(() => {
+    if (currentSlide) {
+      onSlidePrimaryClick(currentSlide);
+    }
+  }, [currentSlide, onSlidePrimaryClick]);
+
+  return (
+    <div className="flex flex-col gap-16">
+      <Button
+        appearance="base"
+        size="lg"
+        isFull
+        onClick={handlePrimary}
+        data-testid="generic-awareness-modal-primary-button"
+      >
+        {currentSlide?.primaryButtonLabel}
+      </Button>
+      <Button
+        appearance="gray"
+        size="lg"
+        isFull
+        onClick={handleContinue}
+        data-testid="generic-awareness-modal-continue-button"
+      >
+        {isLastSlide ? "Go to first slide" : "Continue"}
+      </Button>
+    </div>
+  );
+}
+
+export default function CarouselContent({
+  slides,
+  onSlidePrimaryClick,
+}: Readonly<CarouselContentProps>) {
+  return (
+    <Slides initialSlideIndex={0}>
+      <Slides.Content>
+        {slides.map(slide => (
+          <Slides.Content.Item key={slide.id}>
+            <CarouselContentSlide {...slide} />
+          </Slides.Content.Item>
+        ))}
+      </Slides.Content>
+      <Slides.ProgressIndicator>
+        <CarouselContentProgress />
+      </Slides.ProgressIndicator>
+      <Slides.Footer>
+        <CarouselContentFooter slides={slides} onSlidePrimaryClick={onSlidePrimaryClick} />
+      </Slides.Footer>
+    </Slides>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/components/FeatureIntroContent.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/components/FeatureIntroContent.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import {
+  Button,
+  ListItem,
+  ListItemContent,
+  ListItemDescription,
+  ListItemLeading,
+  ListItemTitle,
+} from "@ledgerhq/lumen-ui-react";
+import * as Icons from "@ledgerhq/lumen-ui-react/symbols";
+
+export type LumenSymbolName = keyof typeof Icons;
+
+export type FeatureIntroContentItem = {
+  id: string;
+  title: string;
+  description: string;
+  iconName: LumenSymbolName;
+};
+
+export type FeatureIntroContentProps = {
+  title: string;
+  subtitle: string;
+  items: FeatureIntroContentItem[];
+  primaryButtonLabel: string;
+  secondaryButtonLabel: string;
+  onPrimaryClick: () => void;
+  onSecondaryClick: () => void;
+  imageUrl?: string;
+};
+
+export default function FeatureIntroContent({
+  title,
+  subtitle,
+  imageUrl,
+  items,
+  primaryButtonLabel,
+  secondaryButtonLabel,
+  onPrimaryClick,
+  onSecondaryClick,
+}: Readonly<FeatureIntroContentProps>) {
+  const showImage = imageUrl != null && imageUrl.length > 0;
+
+  return (
+    <div className="flex min-h-0 w-full flex-1 flex-col">
+      <div className="flex min-h-0 flex-1 flex-col gap-24 overflow-y-auto">
+        {showImage ? (
+          <img
+            src={imageUrl}
+            alt=""
+            className="pointer-events-none h-[200px] w-full select-none rounded-xl object-cover"
+            draggable={false}
+            decoding="async"
+          />
+        ) : (
+          <div className="h-[200px] shrink-0 rounded-xl bg-muted" aria-hidden />
+        )}
+        <div className="relative right-auto flex flex-col gap-[unset]">
+          <span className="heading-2-semi-bold text-base">{title}</span>
+          <span className="mb-12 body-2 text-muted">{subtitle}</span>
+          {items.map(item => {
+            const ItemIcon = Icons[item.iconName];
+            return (
+              <ListItem key={item.id} className="pointer-events-none px-0">
+                <ListItemLeading className="p-0">
+                  <ItemIcon size={24} />
+                  <ListItemContent>
+                    <ListItemTitle>{item.title}</ListItemTitle>
+                    <ListItemDescription>{item.description}</ListItemDescription>
+                  </ListItemContent>
+                </ListItemLeading>
+              </ListItem>
+            );
+          })}
+        </div>
+      </div>
+      <div className="flex w-full shrink-0 flex-col items-center gap-16 pt-24">
+        <Button
+          appearance="base"
+          size="lg"
+          onClick={onPrimaryClick}
+          className="w-full"
+          data-testid="generic-awareness-modal-primary-button"
+        >
+          {primaryButtonLabel}
+        </Button>
+        <Button
+          appearance="gray"
+          size="lg"
+          onClick={onSecondaryClick}
+          className="w-full"
+          data-testid="generic-awareness-modal-secondary-button"
+        >
+          {secondaryButtonLabel}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/components/__tests__/CarouselContent.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/components/__tests__/CarouselContent.test.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { fireEvent, render, screen } from "tests/testSetup";
+import CarouselContent from "../CarouselContent";
+
+const slides = [
+  {
+    id: "slide-a",
+    title: "First slide title",
+    subtitle: "First slide subtitle",
+    imageUrl: "https://example.com/a.png",
+    primaryButtonLabel: "Primary A",
+    primaryButtonLink: "https://www.ledger.com",
+  },
+  {
+    id: "slide-b",
+    title: "Second slide title",
+    subtitle: "Second slide subtitle",
+    imageUrl: "https://example.com/b.png",
+    primaryButtonLabel: "Primary B",
+    primaryButtonLink: "https://www.ledger.com",
+  },
+] as const;
+
+describe("CarouselContent", () => {
+  it("should render the first slide copy and primary label", () => {
+    const onSlidePrimaryClick = jest.fn();
+    render(<CarouselContent slides={[...slides]} onSlidePrimaryClick={onSlidePrimaryClick} />);
+
+    expect(screen.getByText("First slide title")).toBeVisible();
+    expect(screen.getByText("First slide subtitle")).toBeVisible();
+    expect(screen.getByTestId("generic-awareness-modal-primary-button")).toHaveTextContent(
+      "Primary A",
+    );
+  });
+
+  it("should advance visible slide after Continue and slide-out animation start", async () => {
+    const onSlidePrimaryClick = jest.fn();
+    const { user } = render(
+      <CarouselContent slides={[...slides]} onSlidePrimaryClick={onSlidePrimaryClick} />,
+    );
+
+    await user.click(screen.getByTestId("generic-awareness-modal-continue-button"));
+
+    const slideOutAnimationStart = new Event("animationstart", { bubbles: true });
+    Object.defineProperty(slideOutAnimationStart, "animationName", {
+      value: "slide-out-to-left",
+    });
+    fireEvent(screen.getByText("First slide title"), slideOutAnimationStart);
+
+    expect(screen.getByText("Second slide title")).toBeVisible();
+    expect(screen.getByText("Second slide subtitle")).toBeVisible();
+    expect(screen.getByTestId("generic-awareness-modal-primary-button")).toHaveTextContent(
+      "Primary B",
+    );
+  });
+
+  it("should invoke onSlidePrimaryClick with the current slide", async () => {
+    const onSlidePrimaryClick = jest.fn();
+    const { user } = render(
+      <CarouselContent slides={[...slides]} onSlidePrimaryClick={onSlidePrimaryClick} />,
+    );
+
+    await user.click(screen.getByTestId("generic-awareness-modal-primary-button"));
+
+    expect(onSlidePrimaryClick).toHaveBeenCalledTimes(1);
+    expect(onSlidePrimaryClick).toHaveBeenCalledWith(expect.objectContaining({ id: "slide-a" }));
+  });
+
+  it("should return to the first slide when Go to first slide is clicked on the last slide", async () => {
+    const onSlidePrimaryClick = jest.fn();
+    const { user } = render(
+      <CarouselContent slides={[...slides]} onSlidePrimaryClick={onSlidePrimaryClick} />,
+    );
+
+    await user.click(screen.getByTestId("generic-awareness-modal-continue-button"));
+
+    const slideOutAnimationStart = new Event("animationstart", { bubbles: true });
+    Object.defineProperty(slideOutAnimationStart, "animationName", {
+      value: "slide-out-to-left",
+    });
+    fireEvent(screen.getByText("First slide title"), slideOutAnimationStart);
+
+    expect(screen.getByText("Second slide title")).toBeVisible();
+
+    await user.click(screen.getByRole("button", { name: "Go to first slide" }));
+
+    const slideOutRight = new Event("animationstart", { bubbles: true });
+    Object.defineProperty(slideOutRight, "animationName", {
+      value: "slide-out-to-right",
+    });
+    fireEvent(screen.getByText("Second slide title"), slideOutRight);
+
+    expect(screen.getByText("First slide title")).toBeVisible();
+    expect(screen.getByTestId("generic-awareness-modal-primary-button")).toHaveTextContent(
+      "Primary A",
+    );
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/components/__tests__/FeatureIntroContent.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/components/__tests__/FeatureIntroContent.test.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import FeatureIntroContent from "../FeatureIntroContent";
+
+const baseProps = {
+  title: "Test title",
+  subtitle: "Test subtitle",
+  items: [
+    {
+      id: "item-1",
+      title: "Item title",
+      description: "Item description",
+      iconName: "HandCoins" as const,
+    },
+  ],
+  primaryButtonLabel: "Primary",
+  secondaryButtonLabel: "Secondary",
+  onPrimaryClick: jest.fn(),
+  onSecondaryClick: jest.fn(),
+};
+
+describe("FeatureIntroContent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should render title, subtitle, and list item copy", () => {
+    render(<FeatureIntroContent {...baseProps} />);
+
+    expect(screen.getByText("Test title")).toBeVisible();
+    expect(screen.getByText("Test subtitle")).toBeVisible();
+    expect(screen.getByText("Item title")).toBeVisible();
+    expect(screen.getByText("Item description")).toBeVisible();
+  });
+
+  it("should call onPrimaryClick when the primary button is pressed", async () => {
+    const { user } = render(<FeatureIntroContent {...baseProps} />);
+
+    await user.click(screen.getByTestId("generic-awareness-modal-primary-button"));
+
+    expect(baseProps.onPrimaryClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call onSecondaryClick when the secondary button is pressed", async () => {
+    const { user } = render(<FeatureIntroContent {...baseProps} />);
+
+    await user.click(screen.getByTestId("generic-awareness-modal-secondary-button"));
+
+    expect(baseProps.onSecondaryClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("should render an image when imageUrl is provided", () => {
+    const { container } = render(
+      <FeatureIntroContent {...baseProps} imageUrl="https://example.com/hero.png" />,
+    );
+
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img).toHaveAttribute("src", "https://example.com/hero.png");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/genericAwarenessModal.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/genericAwarenessModal.test.ts
@@ -1,0 +1,88 @@
+import { closeDialog, openDialog } from "~/renderer/reducers/dialogs";
+import { setGenericAwarenessModalCampaignId } from "~/renderer/reducers/genericAwarenessModalSlice";
+import type { State } from "~/renderer/reducers";
+import type { AppDispatch } from "~/state-manager/configureStore";
+import {
+  closeGenericAwarenessModal,
+  openGenericAwarenessModal,
+  resolveGenericAwarenessModalContentVariant,
+  selectGenericAwarenessModalCampaignId,
+  selectIsGenericAwarenessModalOpen,
+} from "./genericAwarenessModal";
+
+function collectThunkDispatches(thunkFn: (dispatch: AppDispatch) => void) {
+  const dispatched: unknown[] = [];
+  const fakeDispatch = ((action: unknown) => {
+    dispatched.push(action);
+  }) as AppDispatch;
+  thunkFn(fakeDispatch);
+  return dispatched;
+}
+
+describe("resolveGenericAwarenessModalContentVariant", () => {
+  it("should return carousel for even numeric campaign ids", () => {
+    expect(resolveGenericAwarenessModalContentVariant("0")).toBe("carousel");
+    expect(resolveGenericAwarenessModalContentVariant("2")).toBe("carousel");
+  });
+
+  it("should return feature intro for odd numeric campaign ids", () => {
+    expect(resolveGenericAwarenessModalContentVariant("1")).toBe("featureIntro");
+    expect(resolveGenericAwarenessModalContentVariant("3")).toBe("featureIntro");
+  });
+
+  it("should return feature intro when campaign id is missing or not numeric", () => {
+    expect(resolveGenericAwarenessModalContentVariant(undefined)).toBe("featureIntro");
+    expect(resolveGenericAwarenessModalContentVariant("welcome")).toBe("featureIntro");
+  });
+});
+
+describe("genericAwarenessModal", () => {
+  it("open thunk stores campaign id and opens dialog", () => {
+    const actions = collectThunkDispatches(openGenericAwarenessModal({ campaignId: "campaign-a" }));
+
+    expect(actions[0]).toEqual(setGenericAwarenessModalCampaignId("campaign-a"));
+    expect(actions[1]).toEqual(openDialog("GENERIC_AWARENESS_MODAL"));
+  });
+
+  it("open thunk without campaign id clears stored campaign id", () => {
+    const actions = collectThunkDispatches(openGenericAwarenessModal());
+
+    expect(actions[0]).toEqual(setGenericAwarenessModalCampaignId(undefined));
+    expect(actions[1]).toEqual(openDialog("GENERIC_AWARENESS_MODAL"));
+  });
+
+  it("close thunk closes dialog and clears campaign id", () => {
+    const actions = collectThunkDispatches(closeGenericAwarenessModal());
+
+    expect(actions[0]).toEqual(closeDialog("GENERIC_AWARENESS_MODAL"));
+    expect(actions[1]).toEqual(setGenericAwarenessModalCampaignId(undefined));
+  });
+
+  it("should return false from selector when dialog is absent", () => {
+    expect(selectIsGenericAwarenessModalOpen({ dialogs: {} })).toBe(false);
+  });
+
+  it("should return true from selector when GENERIC_AWARENESS_MODAL is open", () => {
+    expect(
+      selectIsGenericAwarenessModalOpen({
+        dialogs: { GENERIC_AWARENESS_MODAL: true },
+      }),
+    ).toBe(true);
+  });
+
+  it("should return false from selector when GENERIC_AWARENESS_MODAL is explicitly closed", () => {
+    expect(
+      selectIsGenericAwarenessModalOpen({
+        dialogs: { GENERIC_AWARENESS_MODAL: false },
+      }),
+    ).toBe(false);
+  });
+
+  it("selectGenericAwarenessModalCampaignId reads slice state", () => {
+    const state = {
+      genericAwarenessModal: { campaignId: "welcome-v2" },
+    } as State;
+
+    expect(selectGenericAwarenessModalCampaignId(state)).toBe("welcome-v2");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/genericAwarenessModal.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/genericAwarenessModal.ts
@@ -1,0 +1,42 @@
+import {
+  closeDialog,
+  openDialog,
+  selectIsDialogOpen,
+  type DialogId,
+} from "~/renderer/reducers/dialogs";
+import {
+  selectGenericAwarenessModalCampaignId,
+  setGenericAwarenessModalCampaignId,
+} from "~/renderer/reducers/genericAwarenessModalSlice";
+import type { State } from "~/renderer/reducers";
+import type { AppDispatch } from "~/state-manager/configureStore";
+
+const DIALOG_ID: DialogId = "GENERIC_AWARENESS_MODAL";
+
+export type GenericAwarenessModalContentVariant = "carousel" | "featureIntro";
+
+export function resolveGenericAwarenessModalContentVariant(
+  campaignId: string | undefined,
+): GenericAwarenessModalContentVariant {
+  const numericId = Number(campaignId);
+  if (!Number.isFinite(numericId)) {
+    return "featureIntro";
+  }
+  return numericId % 2 === 0 ? "carousel" : "featureIntro";
+}
+
+export const openGenericAwarenessModal =
+  (options?: { campaignId?: string }) => (dispatch: AppDispatch) => {
+    dispatch(setGenericAwarenessModalCampaignId(options?.campaignId));
+    dispatch(openDialog(DIALOG_ID));
+  };
+
+export const closeGenericAwarenessModal = () => (dispatch: AppDispatch) => {
+  dispatch(closeDialog(DIALOG_ID));
+  dispatch(setGenericAwarenessModalCampaignId(undefined));
+};
+
+export const selectIsGenericAwarenessModalOpen = (state: Pick<State, "dialogs">) =>
+  selectIsDialogOpen(state, DIALOG_ID);
+
+export { selectGenericAwarenessModalCampaignId };

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/index.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import GenericAwarenessModalView from "./GenericAwarenessModalView";
+import useGenericAwarenessModalViewModel from "./useGenericAwarenessModalViewModel";
+
+const GenericAwarenessModal = () => (
+  <GenericAwarenessModalView {...useGenericAwarenessModalViewModel()} />
+);
+
+export default GenericAwarenessModal;

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/useGenericAwarenessModalCarouselViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/useGenericAwarenessModalCarouselViewModel.ts
@@ -1,0 +1,59 @@
+import { useCallback, useMemo } from "react";
+import { useDispatch } from "LLD/hooks/redux";
+import { closeGenericAwarenessModal } from "./genericAwarenessModal";
+import type { AwarenessCarouselSlide } from "./components/CarouselContent";
+import { openURL } from "~/renderer/linking";
+
+const CAROUSEL_SLIDES: AwarenessCarouselSlide[] = [
+  {
+    id: "overview",
+    title: "Your portfolio at a glance",
+    subtitle: "See balances and accounts in one secure dashboard.",
+    imageUrl: "https://placehold.co/600x400/orange/white",
+    primaryButtonLabel: "Learn more",
+    primaryButtonLink: "https://www.ledger.com",
+  },
+  {
+    id: "security",
+    title: "Keys never leave your device",
+    subtitle: "Transactions are verified on your Ledger hardware.",
+    imageUrl: "https://placehold.co/600x400/lightgreen/white",
+    primaryButtonLabel: "Why Ledger",
+    primaryButtonLink: "https://www.ledger.com/academy",
+  },
+  {
+    id: "next-steps",
+    title: "Connect when you are ready",
+    subtitle: "Plug in your Ledger to send, swap, and receive with confidence.",
+    imageUrl: "https://placehold.co/600x400/png",
+    primaryButtonLabel: "Get support",
+    primaryButtonLink: "https://support.ledger.com",
+  },
+];
+
+export interface GenericAwarenessModalCarouselViewModel {
+  slides: AwarenessCarouselSlide[];
+  onSlidePrimaryClick: (slide: AwarenessCarouselSlide) => void;
+}
+
+const useGenericAwarenessModalCarouselViewModel = (): GenericAwarenessModalCarouselViewModel => {
+  const dispatch = useDispatch();
+
+  const onSlidePrimaryClick = useCallback(
+    (slide: AwarenessCarouselSlide) => {
+      openURL(slide.primaryButtonLink);
+      dispatch(closeGenericAwarenessModal());
+    },
+    [dispatch],
+  );
+
+  return useMemo(
+    () => ({
+      slides: CAROUSEL_SLIDES,
+      onSlidePrimaryClick,
+    }),
+    [onSlidePrimaryClick],
+  );
+};
+
+export default useGenericAwarenessModalCarouselViewModel;

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/useGenericAwarenessModalFeatureIntroViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/useGenericAwarenessModalFeatureIntroViewModel.ts
@@ -1,0 +1,67 @@
+import { useCallback, useMemo } from "react";
+import { useDispatch } from "LLD/hooks/redux";
+import { closeGenericAwarenessModal } from "./genericAwarenessModal";
+import type { FeatureIntroContentItem } from "./components/FeatureIntroContent";
+import { openURL } from "~/renderer/linking";
+
+const FEATURE_INTRO_ITEMS: FeatureIntroContentItem[] = [
+  {
+    id: "swap",
+    title: "Swap and bridge",
+    description: "Move assets across networks from one place.",
+    iconName: "HandCoins",
+  },
+  {
+    id: "send",
+    title: "Send and receive",
+    description: "Share addresses and confirm transfers on your device.",
+    iconName: "Gift",
+  },
+  {
+    id: "control",
+    title: "Stay in control",
+    description: "Review every sensitive action on your Ledger screen.",
+    iconName: "Github",
+  },
+];
+
+export interface GenericAwarenessModalFeatureIntroViewModel {
+  title: string;
+  subtitle: string;
+  items: FeatureIntroContentItem[];
+  primaryButtonLabel: string;
+  secondaryButtonLabel: string;
+  onPrimaryClick: () => void;
+  onSecondaryClick: () => void;
+  imageUrl?: string;
+}
+
+const useGenericAwarenessModalFeatureIntroViewModel =
+  (): GenericAwarenessModalFeatureIntroViewModel => {
+    const dispatch = useDispatch();
+
+    const onPrimaryClick = useCallback(() => {
+      openURL("https://www.ledger.com");
+      dispatch(closeGenericAwarenessModal());
+    }, [dispatch]);
+
+    const onSecondaryClick = useCallback(() => {
+      openURL("https://www.ledger.com/remind-me-later");
+      dispatch(closeGenericAwarenessModal());
+    }, [dispatch]);
+
+    return useMemo(
+      () => ({
+        title: "Connect a Ledger device",
+        subtitle: "To unlock the full potential of your Ledger Wallet, connect a Ledger device.",
+        items: FEATURE_INTRO_ITEMS,
+        primaryButtonLabel: "Got it",
+        secondaryButtonLabel: "Remind me later",
+        onPrimaryClick,
+        onSecondaryClick,
+      }),
+      [onPrimaryClick, onSecondaryClick],
+    );
+  };
+
+export default useGenericAwarenessModalFeatureIntroViewModel;

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/useGenericAwarenessModalViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/useGenericAwarenessModalViewModel.test.ts
@@ -1,0 +1,67 @@
+import { act, renderHook } from "tests/testSetup";
+import type { AppDispatch } from "~/state-manager/configureStore";
+import { closeGenericAwarenessModal, openGenericAwarenessModal } from "./genericAwarenessModal";
+import useGenericAwarenessModalViewModel from "./useGenericAwarenessModalViewModel";
+
+const dispatchThunk = (
+  store: { dispatch: unknown },
+  thunk:
+    | ReturnType<typeof openGenericAwarenessModal>
+    | ReturnType<typeof closeGenericAwarenessModal>,
+) => {
+  (store.dispatch as AppDispatch)(thunk);
+};
+
+describe("useGenericAwarenessModalViewModel", () => {
+  it("should expose feature intro variant when opened without campaign id", () => {
+    const { result, store } = renderHook(() => useGenericAwarenessModalViewModel());
+
+    act(() => {
+      dispatchThunk(store, openGenericAwarenessModal());
+    });
+
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.campaignId).toBeUndefined();
+    expect(result.current.contentVariant).toBe("featureIntro");
+  });
+
+  it("should expose carousel variant when opened with even numeric campaign id", () => {
+    const { result, store } = renderHook(() => useGenericAwarenessModalViewModel());
+
+    act(() => {
+      dispatchThunk(store, openGenericAwarenessModal({ campaignId: "2" }));
+    });
+
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.campaignId).toBe("2");
+    expect(result.current.contentVariant).toBe("carousel");
+  });
+
+  it("should expose feature intro variant when opened with odd numeric campaign id", () => {
+    const { result, store } = renderHook(() => useGenericAwarenessModalViewModel());
+
+    act(() => {
+      dispatchThunk(store, openGenericAwarenessModal({ campaignId: "3" }));
+    });
+
+    expect(result.current.contentVariant).toBe("featureIntro");
+  });
+
+  it("should keep carousel variant after close when campaign id is cleared", () => {
+    const { result, store } = renderHook(() => useGenericAwarenessModalViewModel());
+
+    act(() => {
+      dispatchThunk(store, openGenericAwarenessModal({ campaignId: "2" }));
+    });
+
+    expect(result.current.contentVariant).toBe("carousel");
+
+    act(() => {
+      dispatchThunk(store, closeGenericAwarenessModal());
+    });
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.campaignId).toBeUndefined();
+    expect(result.current.contentVariant).toBe("carousel");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/useGenericAwarenessModalViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/useGenericAwarenessModalViewModel.ts
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useRef } from "react";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
+import {
+  closeGenericAwarenessModal,
+  resolveGenericAwarenessModalContentVariant,
+  selectGenericAwarenessModalCampaignId,
+  selectIsGenericAwarenessModalOpen,
+  type GenericAwarenessModalContentVariant,
+} from "./genericAwarenessModal";
+
+export interface GenericAwarenessModalViewProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Parsed from `ledgerwallet://generic-awareness-modal?id=…` when opened via deeplink */
+  campaignId: string | undefined;
+  /** Locked while the dialog closes so clearing campaignId does not swap body content */
+  contentVariant: GenericAwarenessModalContentVariant;
+}
+
+const useGenericAwarenessModalViewModel = (): GenericAwarenessModalViewProps => {
+  const dispatch = useDispatch();
+  const isOpen = useSelector(selectIsGenericAwarenessModalOpen);
+  const campaignId = useSelector(selectGenericAwarenessModalCampaignId);
+  const lockedContentVariantRef = useRef<GenericAwarenessModalContentVariant>("featureIntro");
+
+  useEffect(() => {
+    if (isOpen) {
+      lockedContentVariantRef.current = resolveGenericAwarenessModalContentVariant(campaignId);
+    }
+  }, [isOpen, campaignId]);
+
+  const contentVariant = isOpen
+    ? resolveGenericAwarenessModalContentVariant(campaignId)
+    : lockedContentVariantRef.current;
+
+  const onClose = useCallback(() => {
+    dispatch(closeGenericAwarenessModal());
+  }, [dispatch]);
+
+  return {
+    isOpen,
+    onClose,
+    campaignId,
+    contentVariant,
+  };
+};
+
+export default useGenericAwarenessModalViewModel;

--- a/apps/ledger-live-desktop/src/mvvm/features/GlobalDialogs/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GlobalDialogs/index.tsx
@@ -9,6 +9,7 @@ const BuyDevice = lazy(() => import("LLD/features/BuyDevice"));
 const FinishOnboardingDialog = lazy(() => import("LLD/features/FinishOnboarding/FinishOnboardingDialog"));
 const PtxInfoDialog = lazy(() => import("LLD/features/PtxInfoDialog"));
 const LiveAppModal = lazy(() => import("LLD/features/LiveAppModal"));
+const GenericAwarenessModal = lazy(() => import("LLD/features/GenericAwarenessModal"));
 
 /** Mounts all root-level dialogs and flows. Add new global dialogs here. */
 const GlobalDialogs = () => (
@@ -31,6 +32,9 @@ const GlobalDialogs = () => (
     </Suspense>
     <Suspense fallback={null}>
       <LiveAppModal />
+    </Suspense>
+    <Suspense fallback={null}>
+      <GenericAwarenessModal />
     </Suspense>
   </>
 );

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/__tests__/parseDeepLink.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/__tests__/parseDeepLink.test.ts
@@ -339,6 +339,25 @@ describe("parseDeepLink", () => {
       });
     });
 
+    it("creates generic awareness modal route", () => {
+      const parsed = parseDeepLink("ledgerwallet://generic-awareness-modal");
+      const route = createRoute(parsed);
+
+      expect(route).toEqual({
+        type: "generic-awareness-modal",
+      });
+    });
+
+    it("creates generic awareness modal route with id from query", () => {
+      const parsed = parseDeepLink("ledgerwallet://generic-awareness-modal?id=welcome-v2");
+      const route = createRoute(parsed);
+
+      expect(route).toEqual({
+        type: "generic-awareness-modal",
+        id: "welcome-v2",
+      });
+    });
+
     it("creates default route for unknown URLs", () => {
       const parsed = parseDeepLink("ledgerwallet://unknown-route");
       const route = createRoute(parsed);

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/__tests__/useDeepLinkHandler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/__tests__/useDeepLinkHandler.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 
-import { renderHook, waitFor } from "tests/testSetup";
+import { renderHook, waitFor, withFlagOverrides } from "tests/testSetup";
 import { Account, TokenAccount } from "@ledgerhq/types-live";
 import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
@@ -322,6 +322,57 @@ describe("useDeepLinkHandler", () => {
           expect(mockOpenAddAccountFlow).not.toHaveBeenCalled();
           expect(mockOpenAssetFlow).not.toHaveBeenCalled();
         });
+      });
+    });
+  });
+
+  describe("generic-awareness-modal deeplink", () => {
+    it("sets GENERIC_AWARENESS_MODAL when flag is enabled and onboarding is complete", async () => {
+      const { result, store } = renderHook(() => useDeepLinkHandler(), {
+        initialState: {
+          ...withFlagOverrides({ lwdGenericAwarenessModal: { enabled: true } }),
+          settings: { hasCompletedOnboarding: true },
+        },
+      });
+
+      result.current.handler("ledgerwallet://generic-awareness-modal", false);
+
+      await waitFor(() => {
+        expect(store.getState().dialogs.GENERIC_AWARENESS_MODAL).toBe(true);
+      });
+
+      expect(store.getState().genericAwarenessModal.campaignId).toBeUndefined();
+    });
+
+    it("stores campaign id from query when modal opens", async () => {
+      const { result, store } = renderHook(() => useDeepLinkHandler(), {
+        initialState: {
+          ...withFlagOverrides({ lwdGenericAwarenessModal: { enabled: true } }),
+          settings: { hasCompletedOnboarding: true },
+        },
+      });
+
+      result.current.handler("ledgerwallet://generic-awareness-modal?id=welcome-v2", false);
+
+      await waitFor(() => {
+        expect(store.getState().dialogs.GENERIC_AWARENESS_MODAL).toBe(true);
+      });
+
+      expect(store.getState().genericAwarenessModal.campaignId).toBe("welcome-v2");
+    });
+
+    it("does not set GENERIC_AWARENESS_MODAL when lwdGenericAwarenessModal is disabled", async () => {
+      const { result, store } = renderHook(() => useDeepLinkHandler(), {
+        initialState: {
+          ...withFlagOverrides({ lwdGenericAwarenessModal: { enabled: false } }),
+          settings: { hasCompletedOnboarding: true },
+        },
+      });
+
+      result.current.handler("ledgerwallet://generic-awareness-modal", false);
+
+      await waitFor(() => {
+        expect(store.getState().dialogs.GENERIC_AWARENESS_MODAL).toBeFalsy();
       });
     });
   });

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/genericAwarenessModal.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/genericAwarenessModal.handler.test.ts
@@ -1,0 +1,71 @@
+import { openDialog } from "~/renderer/reducers/dialogs";
+import { setGenericAwarenessModalCampaignId } from "~/renderer/reducers/genericAwarenessModalSlice";
+import { genericAwarenessModalHandler } from "../genericAwarenessModal.handler";
+import { createMockContext } from "./test-utils";
+import type { AppDispatch } from "~/state-manager/configureStore";
+
+describe("genericAwarenessModalHandler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function runDispatchedThunk(context: ReturnType<typeof createMockContext>) {
+    const dispatchMock = context.dispatch as jest.Mock;
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    const thunk = dispatchMock.mock.calls[0][0] as (d: AppDispatch) => void;
+    const inner = jest.fn();
+    thunk(inner as AppDispatch);
+    return inner;
+  }
+
+  it("opens Generic Awareness modal when onboarding is complete and feature flag is enabled", () => {
+    const context = createMockContext({
+      hasCompletedOnboarding: true,
+      isGenericAwarenessModalEnabled: true,
+    });
+
+    genericAwarenessModalHandler({ type: "generic-awareness-modal" }, context);
+
+    const inner = runDispatchedThunk(context);
+    expect(inner.mock.calls[0][0]).toEqual(setGenericAwarenessModalCampaignId(undefined));
+    expect(inner.mock.calls[1][0]).toEqual(openDialog("GENERIC_AWARENESS_MODAL"));
+  });
+
+  it("passes route id through open thunk", () => {
+    const context = createMockContext({
+      hasCompletedOnboarding: true,
+      isGenericAwarenessModalEnabled: true,
+    });
+
+    genericAwarenessModalHandler(
+      { type: "generic-awareness-modal", id: "braze-intro" },
+      context,
+    );
+
+    const inner = runDispatchedThunk(context);
+    expect(inner.mock.calls[0][0]).toEqual(setGenericAwarenessModalCampaignId("braze-intro"));
+    expect(inner.mock.calls[1][0]).toEqual(openDialog("GENERIC_AWARENESS_MODAL"));
+  });
+
+  it("does not open the modal when onboarding is incomplete", () => {
+    const context = createMockContext({
+      hasCompletedOnboarding: false,
+      isGenericAwarenessModalEnabled: true,
+    });
+
+    genericAwarenessModalHandler({ type: "generic-awareness-modal" }, context);
+
+    expect(context.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("does not open the modal when lwdGenericAwarenessModal feature flag is disabled", () => {
+    const context = createMockContext({
+      hasCompletedOnboarding: true,
+      isGenericAwarenessModalEnabled: false,
+    });
+
+    genericAwarenessModalHandler({ type: "generic-awareness-modal" }, context);
+
+    expect(context.dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/test-utils.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/test-utils.ts
@@ -17,5 +17,6 @@ export const createMockContext = (
   currentLocationState: undefined,
   accountsPath: "/accounts",
   isProductTourEnabled: true,
+  isGenericAwarenessModalEnabled: true,
   ...overrides,
 });

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/genericAwarenessModal.handler.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/genericAwarenessModal.handler.ts
@@ -1,0 +1,13 @@
+import { openGenericAwarenessModal } from "LLD/features/GenericAwarenessModal/genericAwarenessModal";
+import { DeeplinkHandler } from "../types";
+
+export const genericAwarenessModalHandler: DeeplinkHandler<"generic-awareness-modal"> = (
+  route,
+  { dispatch, hasCompletedOnboarding, isGenericAwarenessModalEnabled },
+) => {
+  if (!hasCompletedOnboarding || !isGenericAwarenessModalEnabled) {
+    return;
+  }
+
+  dispatch(openGenericAwarenessModal({ campaignId: route.id }));
+};

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/parseDeepLink.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/parseDeepLink.ts
@@ -26,6 +26,7 @@ import {
   PostOnboardingRoute,
   LedgerSyncRoute,
   ProductTourRoute,
+  GenericAwarenessModalRoute,
   DefaultRoute,
 } from "./types";
 
@@ -305,6 +306,14 @@ export function createRoute(parsed: ParsedDeeplink): DeeplinkRoute {
     case "product-tour": {
       const route: ProductTourRoute = {
         type: "product-tour",
+      };
+      return route;
+    }
+
+    case "generic-awareness-modal": {
+      const route: GenericAwarenessModalRoute = {
+        type: "generic-awareness-modal",
+        id: query.id,
       };
       return route;
     }

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/registry.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/registry.ts
@@ -17,6 +17,7 @@ import { perpsHandler } from "./handlers/perps.handler";
 import { postOnboardingHandler } from "./handlers/postOnboarding.handler";
 import { ledgerSyncHandler } from "./handlers/ledgerSync.handler";
 import { productTourHandler } from "./handlers/productTour.handler";
+import { genericAwarenessModalHandler } from "./handlers/genericAwarenessModal.handler";
 import { defaultHandler } from "./handlers/default.handler";
 
 export const deeplinkRegistry: DeeplinkHandlerRegistry = {
@@ -44,6 +45,7 @@ export const deeplinkRegistry: DeeplinkHandlerRegistry = {
   "post-onboarding": postOnboardingHandler,
   ledgersync: ledgerSyncHandler,
   "product-tour": productTourHandler,
+  "generic-awareness-modal": genericAwarenessModalHandler,
   default: defaultHandler,
 };
 

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/types.ts
@@ -48,6 +48,8 @@ export interface DeeplinkHandlerContext {
   recoverAppId?: string;
   /** `lwdProductTour` — Product Tour dialog is only mounted on Portfolio when enabled; avoid opening dialog Redux state when false. */
   isProductTourEnabled: boolean;
+  /** `lwdGenericAwarenessModal` — deeplink opens the modal only when this flag is enabled. */
+  isGenericAwarenessModalEnabled: boolean;
 }
 
 export interface ParsedDeeplink {
@@ -215,6 +217,11 @@ export interface ProductTourRoute {
   type: "product-tour";
 }
 
+export interface GenericAwarenessModalRoute {
+  type: "generic-awareness-modal";
+  id?: string;
+}
+
 export interface DefaultRoute {
   type: "default";
 }
@@ -244,6 +251,7 @@ export type DeeplinkRoute =
   | PostOnboardingRoute
   | LedgerSyncRoute
   | ProductTourRoute
+  | GenericAwarenessModalRoute
   | DefaultRoute;
 
 export type RouteByType<T extends DeeplinkRoute["type"]> = Extract<DeeplinkRoute, { type: T }>;

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/useDeepLinkHandler.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/useDeepLinkHandler.ts
@@ -43,6 +43,8 @@ export function useDeepLinkHandler() {
   const recoverAppId = recoverFF?.params?.protectId;
   const lwdProductTour = useFeature("lwdProductTour");
   const isProductTourEnabled = lwdProductTour?.enabled === true;
+  const lwdGenericAwarenessModal = useFeature("lwdGenericAwarenessModal");
+  const isGenericAwarenessModalEnabled = lwdGenericAwarenessModal?.enabled === true;
   const { shouldDisplayAssetSection } = useWalletFeaturesConfig("desktop");
   const accountsPath = getAccountsSidebarPath(shouldDisplayAssetSection);
 
@@ -81,6 +83,7 @@ export function useDeepLinkHandler() {
       accountsPath,
       recoverAppId,
       isProductTourEnabled,
+      isGenericAwarenessModalEnabled,
     }),
     [
       dispatch,
@@ -98,6 +101,7 @@ export function useDeepLinkHandler() {
       accountsPath,
       recoverAppId,
       isProductTourEnabled,
+      isGenericAwarenessModalEnabled,
     ],
   );
 

--- a/apps/ledger-live-desktop/src/renderer/reducers/dialogs.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/dialogs.ts
@@ -27,6 +27,7 @@ export const DIALOG_IDS = [
   "BUY_DEVICE",
   "FINISH_POST_ONBOARDING",
   "PRODUCT_TOUR",
+  "GENERIC_AWARENESS_MODAL",
 ] as const;
 export type DialogId = (typeof DIALOG_IDS)[number];
 

--- a/apps/ledger-live-desktop/src/renderer/reducers/genericAwarenessModalSlice.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/genericAwarenessModalSlice.ts
@@ -1,0 +1,27 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+
+export type GenericAwarenessModalSliceState = {
+  /** Optional campaign id from `ledgerwallet://generic-awareness-modal?id=…` */
+  campaignId: string | undefined;
+};
+
+const initialState: GenericAwarenessModalSliceState = {
+  campaignId: undefined,
+};
+
+const genericAwarenessModalSlice = createSlice({
+  name: "genericAwarenessModal",
+  initialState,
+  reducers: {
+    setGenericAwarenessModalCampaignId: (state, action: PayloadAction<string | undefined>) => {
+      state.campaignId = action.payload;
+    },
+  },
+});
+
+export const selectGenericAwarenessModalCampaignId = (state: {
+  genericAwarenessModal: GenericAwarenessModalSliceState;
+}) => state.genericAwarenessModal.campaignId;
+
+export const { setGenericAwarenessModalCampaignId } = genericAwarenessModalSlice.actions;
+export default genericAwarenessModalSlice.reducer;

--- a/apps/ledger-live-desktop/src/renderer/reducers/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/index.ts
@@ -36,6 +36,9 @@ import countervaluesExtraTracking, {
   CountervaluesExtraTrackingState,
 } from "./countervaluesExtraTracking";
 import { recoverStateReducer, RecoverStateSliceState } from "./recoverState";
+import genericAwarenessModal, {
+  GenericAwarenessModalSliceState,
+} from "./genericAwarenessModalSlice";
 
 export type State = LLDRTKApiState & {
   accounts: AccountsState;
@@ -65,6 +68,7 @@ export type State = LLDRTKApiState & {
   shieldedSyncSubscriptions: ShieldedSyncSubscriptionsState;
   countervaluesExtraTracking: CountervaluesExtraTrackingState;
   recoverState: RecoverStateSliceState;
+  genericAwarenessModal: GenericAwarenessModalSliceState;
 };
 
 const appReducer = combineReducers({
@@ -95,6 +99,7 @@ const appReducer = combineReducers({
   shieldedSyncSubscriptions,
   countervaluesExtraTracking,
   recoverState: recoverStateReducer,
+  genericAwarenessModal,
   ...lldRTKApiReducers,
   ...(getEnv("PLAYWRIGHT_RUN") && { lastAction: (_: unknown, action: PayloadAction) => action }),
 });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Add templates for generic awareness modal

### 📝 Description
This pull request introduces a new, reusable Generic Awareness Modal to the Ledger Live Desktop application, including both "feature intro" and "carousel" content variants. It adds the core modal view, supporting components for each variant, and comprehensive unit and integration tests to ensure correct behavior and user interactions. The changes also include logic for determining which variant to show based on campaign ID, and updates the changelog accordingly.

https://github.com/user-attachments/assets/d1547a6a-b419-4e4a-babf-e118e3123346


The most important changes are:

**Feature Implementation**
* Added the main `GenericAwarenessModalView` React component, which displays either a feature intro or carousel based on the `contentVariant` prop, and manages modal state and campaign ID.
* Implemented `CarouselContent` and `FeatureIntroContent` components, each with their own props, rendering logic, and UI for their respective modal variants. [[1]](diffhunk://#diff-81f39e68920d217cdd247ede61eeacddfb29531c0fa68139b7c5d95d9dbe46d7R1-R131) [[2]](diffhunk://#diff-26c67ee8bdd4a70b0dc3e498b496992e778972dc2a2ecff6988f7a0b2c727f1aR1-R99)

**Testing**
* Added comprehensive integration tests for the modal, covering open/close logic, variant selection, campaign ID handling, and user interactions.
* Added unit tests for `CarouselContent` and `FeatureIntroContent` components to verify rendering and button callbacks. [[1]](diffhunk://#diff-3cacb9b54c2ff5d244ee949c2164f996494cdcacfba847c0b8a0b44f59ddbf07R1-R98) [[2]](diffhunk://#diff-df5b54015050a793afed22c910b9430b72da302577d651618bfea619d7abe470R1-R61)
* Added unit tests for modal logic, including thunk actions and selectors, ensuring correct state management and variant resolution.

**Documentation**
* Updated the changeset to record the addition of the Generic Awareness Modal templates as a minor change.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28770]
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-28770]: https://ledgerhq.atlassian.net/browse/LIVE-28770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ