### PR TITLE
[LWD] feat(desktop): add reusable PnLCard component

### DIFF
--- a/.changeset/stale-queens-sort.md
+++ b/.changeset/stale-queens-sort.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add a reusable PnLCard component for the PnL feature with interactive/info variants and discreet mode support.

--- a/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnLCard/__tests__/index.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnLCard/__tests__/index.test.tsx
@@ -1,0 +1,138 @@
+import React from "react";
+import { render, screen, waitFor } from "tests/testSetup";
+import { PnLCard } from "../index";
+
+type PnLCardProps = React.ComponentProps<typeof PnLCard>;
+type InteractiveProps = Extract<PnLCardProps, { type: "interactive" }>;
+type InfoProps = Extract<PnLCardProps, { type: "info" }>;
+
+const TITLE = "Unrealised return";
+const VALUE = "243.32";
+const TOOLTIP = "This is a tooltip";
+const DISCREET_PLACEHOLDER = "***";
+
+const makeInteractiveProps = (
+  overrides: Partial<Omit<InteractiveProps, "type">> = {},
+): InteractiveProps => ({
+  type: "interactive",
+  title: TITLE,
+  value: VALUE,
+  trend: "up",
+  onClick: jest.fn(),
+  ...overrides,
+});
+
+const makeInfoProps = (overrides: Partial<Omit<InfoProps, "type">> = {}): InfoProps => ({
+  type: "info",
+  title: TITLE,
+  value: VALUE,
+  tooltipContent: TOOLTIP,
+  ...overrides,
+});
+
+describe("PnLCard", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("when type is 'interactive'", () => {
+    it("should render the title and the value", () => {
+      render(<PnLCard {...makeInteractiveProps()} />);
+
+      expect(screen.getByText(TITLE)).toBeVisible();
+      expect(screen.getByText(VALUE)).toBeVisible();
+    });
+
+    it("should render the card as a clickable button", () => {
+      render(<PnLCard {...makeInteractiveProps()} />);
+
+      expect(screen.getByRole("button")).toBeVisible();
+    });
+
+    it("should call onClick when the card is clicked", async () => {
+      const onClick = jest.fn();
+      const { user } = render(<PnLCard {...makeInteractiveProps({ onClick })} />);
+
+      await user.click(screen.getByRole("button"));
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it("should render an up arrow when trend is 'up'", () => {
+      const { container } = render(<PnLCard {...makeInteractiveProps({ trend: "up" })} />);
+
+      expect(container.querySelector(".text-success")).toBeInTheDocument();
+      expect(container.querySelector(".text-error")).not.toBeInTheDocument();
+    });
+
+    it("should render a down arrow when trend is 'down'", () => {
+      const { container } = render(<PnLCard {...makeInteractiveProps({ trend: "down" })} />);
+
+      expect(container.querySelector(".text-error")).toBeInTheDocument();
+      expect(container.querySelector(".text-success")).not.toBeInTheDocument();
+    });
+
+    it("should not render any tooltip", () => {
+      render(<PnLCard {...makeInteractiveProps()} />);
+
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when type is 'info'", () => {
+    it("should render the title and the value", () => {
+      render(<PnLCard {...makeInfoProps()} />);
+
+      expect(screen.getByText(TITLE)).toBeVisible();
+      expect(screen.getByText(VALUE)).toBeVisible();
+    });
+
+    it("should not render the card as a clickable button", () => {
+      render(<PnLCard {...makeInfoProps()} />);
+
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    });
+
+    it("should not render any trend arrow", () => {
+      const { container } = render(<PnLCard {...makeInfoProps()} />);
+
+      expect(container.querySelector(".text-success")).not.toBeInTheDocument();
+      expect(container.querySelector(".text-error")).not.toBeInTheDocument();
+    });
+
+    it("should reveal the tooltip content when the trigger is hovered", async () => {
+      const { container, user } = render(<PnLCard {...makeInfoProps()} />);
+
+      const trigger = container.querySelector("[data-slot='tooltip-trigger']");
+      if (!trigger) throw new Error("Tooltip trigger not found");
+      await user.hover(trigger);
+
+      await waitFor(() => {
+        const tooltips = screen.getAllByText(TOOLTIP);
+        expect(tooltips.some(el => el.closest("[role='tooltip']"))).toBe(true);
+      });
+    });
+  });
+
+  describe("when discreet is enabled", () => {
+    it("should hide the value behind '***' in the interactive variant", () => {
+      render(<PnLCard {...makeInteractiveProps({ discreet: true })} />);
+
+      expect(screen.getByText(DISCREET_PLACEHOLDER)).toBeVisible();
+      expect(screen.queryByText(VALUE)).not.toBeInTheDocument();
+    });
+
+    it("should hide the value behind '***' in the info variant", () => {
+      render(<PnLCard {...makeInfoProps({ discreet: true })} />);
+
+      expect(screen.getByText(DISCREET_PLACEHOLDER)).toBeVisible();
+      expect(screen.queryByText(VALUE)).not.toBeInTheDocument();
+    });
+
+    it("should still render the title when the value is hidden", () => {
+      render(<PnLCard {...makeInteractiveProps({ discreet: true })} />);
+
+      expect(screen.getByText(TITLE)).toBeVisible();
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnLCard/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnLCard/index.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import {
+  Card,
+  CardHeader,
+  CardLeading,
+  CardContent,
+  CardContentDescription,
+  CardContentTitle,
+  CardTrailing,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@ledgerhq/lumen-ui-react";
+import {
+  ChevronRight,
+  Information,
+  TriangleUp,
+  TriangleDown,
+} from "@ledgerhq/lumen-ui-react/symbols";
+import type { PnLCardProps } from "./types";
+
+export const PnLCard = (props: PnLCardProps) => {
+  const { title, value, type, discreet } = props;
+  const displayedValue = discreet ? "***" : value;
+
+  return (
+    <Card type={type} onClick={type === "interactive" ? props.onClick : undefined}>
+      <CardHeader>
+        <CardLeading>
+          <CardContent>
+            <div className="flex min-w-0 items-center gap-4 text-muted">
+              <CardContentTitle>
+                <span className="body-3">{title}</span>
+              </CardContentTitle>
+              {type === "info" && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="inline-flex cursor-help">
+                      <Information size={16} />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>{props.tooltipContent}</TooltipContent>
+                </Tooltip>
+              )}
+            </div>
+            <CardContentDescription>
+              <div className="flex items-center align-center gap-4">
+                {type === "interactive" && (
+                  <span className="text-muted body-3">
+                    {props.trend === "up" ? (
+                      <TriangleUp size={16} className="text-success" />
+                    ) : (
+                      <TriangleDown size={16} className="text-error" />
+                    )}
+                  </span>
+                )}
+                <span className="text-base body-2-semi-bold">{displayedValue}</span>
+              </div>
+            </CardContentDescription>
+          </CardContent>
+        </CardLeading>
+        {type === "interactive" && (
+          <CardTrailing>
+            <ChevronRight size={20} className="text-muted" />
+          </CardTrailing>
+        )}
+      </CardHeader>
+    </Card>
+  );
+};

--- a/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnLCard/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnLCard/types.ts
@@ -1,0 +1,18 @@
+type InteractiveCard = {
+  type: "interactive";
+  trend: "up" | "down";
+  onClick: () => void;
+};
+
+type InfoCard = {
+  type: "info";
+  tooltipContent: string;
+};
+
+type PnLCardProps = {
+  title: string;
+  value: string;
+  discreet?: boolean;
+} & (InteractiveCard | InfoCard);
+
+export type { InteractiveCard, InfoCard, PnLCardProps };


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - PnLCard rendering in both `interactive` (clickable, with trend arrow) and `info` (with tooltip) variants
      - Discreet mode replacing the value with `***` across both variants
      - Click and keyboard accessibility on the interactive card
      - Tooltip visibility on hover for the info variant

### Description

Initial setup for the LWD W4.0 PnL feature. This PR introduces a shared, reusable `PnLCard` component under `apps/ledger-live-desktop/src/mvvm/features/PnL/`, intended to be reused across the analytics page, the asset detail page, and the portfolio table.

**Problem**: PnL metric cards are duplicated across multiple screens. We need a single source of truth for the metric tile (value + trend + optional definition tooltip), with built-in discreet-mode support.

**Solution**: A discriminated-union `PnLCard` with two typed variants:
- `interactive`: clickable card with `trend` arrow (`up`/`down`) and a trailing chevron, requires `onClick`
- `info`: read-only card with a `tooltipContent` definition tooltip next to the title

Both variants accept an optional `discreet` prop that replaces the value with `***`. TypeScript enforces variant-specific props at compile time (no `tooltipContent` on `interactive`, no `trend`/`onClick` on `info`).

The view model (`usePnlCardViewModel`), `shouldDisplayPnl` feature flag wiring, and `discreetModeSelector` integration will land in follow-up PRs.


https://github.com/user-attachments/assets/808ba271-aecb-4ec3-a1b1-b10f67411549


### Context

- **JIRA or GitHub link**: [LIVE-30295](https://ledgerhq.atlassian.net/browse/LIVE-30295)

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30295]: https://ledgerhq.atlassian.net/browse/LIVE-30295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ