### PR TITLE
[LWM] feat(mobile): add asset detail coin options (favourite + hide)

### DIFF
--- a/.changeset/asset-detail-coin-options.md
+++ b/.changeset/asset-detail-coin-options.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add asset detail coin options (NavBar trailing button + bottom sheet) to favourite/unfavourite a coin and hide/show it from the portfolio, with state persisted across sessions

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8731,6 +8731,13 @@
       "earnBannerSubtitle": "Hold and earn with this asset",
       "earnBannerAction": "Go to Earn",
       "availableBalanceTooltip": "Funds available for immediate use, excluding staked or delegated amounts."
+    },
+    "coinOptions": {
+      "openMenuA11yLabel": "Coin options",
+      "addFavourite": "Add to favourites",
+      "removeFavourite": "Remove from favourites",
+      "hideFromPortfolio": "Hide from portfolio",
+      "showInPortfolio": "Show in portfolio"
     }
   },
   "assetSelection": {

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
@@ -81,6 +81,7 @@ describe("AssetDetail screen layout", () => {
     expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.screen)).toBeVisible();
     expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.balanceGraph)).toBeVisible();
     expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.marketStats)).toBeVisible();
+    expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.coinOptionsTrailing)).toBeVisible();
     expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.transactions)).toBeNull();
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
@@ -15,6 +15,8 @@ import { Footer } from "./components/Footer";
 import { FallbackBanner } from "./components/FallbackBanner";
 import { MarketData } from "./components/MarketData";
 import { CTAS_HEIGHT } from "./utils/constants";
+import { AssetCoinOptionsSheetView } from "./components/CoinOptions/AssetCoinOptionsSheetView";
+import type { AssetCoinOptionsViewModel } from "./components/CoinOptions/useAssetCoinOptionsViewModel";
 
 type Props = Readonly<{
   currency: AssetDetailCurrencyProps;
@@ -25,6 +27,7 @@ type Props = Readonly<{
   hasFooter: boolean;
   hideReceiveInBalanceGraph: boolean;
   showFallbackBanner: boolean;
+  coinOptions: AssetCoinOptionsViewModel;
 }>;
 
 export function AssetDetailView({
@@ -36,6 +39,7 @@ export function AssetDetailView({
   hasFooter,
   hideReceiveInBalanceGraph,
   showFallbackBanner,
+  coinOptions,
 }: Props) {
   const { bottom } = useSafeAreaInsets();
   const scrollPaddingBottom = useMemo(
@@ -61,6 +65,14 @@ export function AssetDetailView({
         </Box>
       </ScrollView>
       <Footer currency={currency} />
+      <AssetCoinOptionsSheetView
+        isOpen={coinOptions.isCoinOptionsSheetOpen}
+        onClose={coinOptions.closeCoinOptions}
+        isHidden={coinOptions.isHidden}
+        isStarred={coinOptions.isStarred}
+        onToggleFavourite={coinOptions.onToggleFavourite}
+        onToggleHideFromPortfolio={coinOptions.onToggleHideFromPortfolio}
+      />
     </Box>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/CoinOptions/AssetCoinOptionsSheetView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/CoinOptions/AssetCoinOptionsSheetView.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { useTranslation } from "~/context/Locale";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { BottomSheetHeader, BottomSheetView } from "@ledgerhq/lumen-ui-rnative";
+import { Eye, EyeCross, Star, StarFill } from "@ledgerhq/lumen-ui-rnative/symbols";
+import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
+import { ASSET_DETAIL_TEST_IDS } from "LLM/features/AssetDetail/testIds";
+import { CoinOptionRow } from "./CoinOptionRow";
+
+type Props = Readonly<{
+  isOpen: boolean;
+  onClose: () => void;
+  isHidden: boolean;
+  isStarred: boolean;
+  onToggleFavourite: () => void;
+  onToggleHideFromPortfolio: () => void;
+}>;
+
+export function AssetCoinOptionsSheetView({
+  isOpen,
+  onClose,
+  isHidden,
+  isStarred,
+  onToggleFavourite,
+  onToggleHideFromPortfolio,
+}: Props) {
+  const { t } = useTranslation();
+  const { bottom: bottomInset } = useSafeAreaInsets();
+
+  const favouriteTitle = isStarred
+    ? t("assetDetail.coinOptions.removeFavourite")
+    : t("assetDetail.coinOptions.addFavourite");
+  const hideTitle = isHidden
+    ? t("assetDetail.coinOptions.showInPortfolio")
+    : t("assetDetail.coinOptions.hideFromPortfolio");
+
+  return (
+    <QueuedDrawerBottomSheet
+      testID={ASSET_DETAIL_TEST_IDS.coinOptionsSheet}
+      isRequestingToBeOpened={isOpen}
+      enableDynamicSizing
+      onClose={onClose}
+    >
+      <BottomSheetView style={{ paddingBottom: bottomInset + 24 }}>
+        <BottomSheetHeader />
+        <CoinOptionRow
+          onPress={onToggleFavourite}
+          title={favouriteTitle}
+          Icon={isStarred ? StarFill : Star}
+          testID={ASSET_DETAIL_TEST_IDS.coinOptionsFavouriteRow}
+        />
+        <CoinOptionRow
+          onPress={onToggleHideFromPortfolio}
+          title={hideTitle}
+          Icon={isHidden ? Eye : EyeCross}
+          testID={ASSET_DETAIL_TEST_IDS.coinOptionsHideRow}
+        />
+      </BottomSheetView>
+    </QueuedDrawerBottomSheet>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/CoinOptions/AssetCoinOptionsTrailing.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/CoinOptions/AssetCoinOptionsTrailing.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { IconButton } from "@ledgerhq/lumen-ui-rnative";
+import { MoreVertical } from "@ledgerhq/lumen-ui-rnative/symbols";
+
+type Props = Readonly<{
+  onPress: () => void;
+  accessibilityLabel: string;
+  testID: string;
+}>;
+
+export function AssetCoinOptionsTrailing({ onPress, accessibilityLabel, testID }: Props) {
+  return (
+    <IconButton
+      appearance="no-background"
+      size="md"
+      icon={MoreVertical}
+      accessibilityLabel={accessibilityLabel}
+      onPress={onPress}
+      testID={testID}
+    />
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/CoinOptions/CoinOptionRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/CoinOptions/CoinOptionRow.tsx
@@ -1,0 +1,29 @@
+import React, { ComponentType } from "react";
+import {
+  ListItem,
+  ListItemContent,
+  ListItemLeading,
+  ListItemTitle,
+  Spot,
+  type IconProps,
+} from "@ledgerhq/lumen-ui-rnative";
+
+type Props = Readonly<{
+  onPress: () => void;
+  title: string;
+  Icon: ComponentType<IconProps>;
+  testID?: string;
+}>;
+
+export function CoinOptionRow({ onPress, title, Icon, testID }: Props) {
+  return (
+    <ListItem onPress={onPress} testID={testID}>
+      <ListItemLeading>
+        <Spot appearance="icon" icon={Icon} />
+        <ListItemContent>
+          <ListItemTitle>{title}</ListItemTitle>
+        </ListItemContent>
+      </ListItemLeading>
+    </ListItem>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/CoinOptions/__tests__/useAssetCoinOptionsViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/CoinOptions/__tests__/useAssetCoinOptionsViewModel.test.ts
@@ -1,0 +1,85 @@
+import { act, renderHook } from "@tests/test-renderer";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { track } from "~/analytics";
+import type { State } from "~/reducers/types";
+import { useAssetCoinOptionsViewModel } from "../useAssetCoinOptionsViewModel";
+
+jest.mock("LLM/features/NotificationsPrompt", () => ({
+  useNotifications: () => ({ tryTriggerPushNotificationDrawerAfterAction: jest.fn() }),
+}));
+
+jest.mock("~/analytics", () => ({ track: jest.fn() }));
+
+const bitcoin = getCryptoCurrencyById("bitcoin");
+
+function renderViewModel({
+  blacklistedTokenIds = [],
+  starredMarketCoins = [],
+}: {
+  blacklistedTokenIds?: string[];
+  starredMarketCoins?: string[];
+} = {}) {
+  return renderHook(
+    () => useAssetCoinOptionsViewModel({ currency: bitcoin, currencyId: bitcoin.id }),
+    {
+      overrideInitialState: (state: State): State => ({
+        ...state,
+        settings: { ...state.settings, blacklistedTokenIds, starredMarketCoins },
+      }),
+    },
+  );
+}
+
+describe("useAssetCoinOptionsViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("persists the favourite state and tracks analytics in both directions", () => {
+    const { result, store } = renderViewModel();
+
+    act(() => result.current.onToggleFavourite());
+    expect(store.getState().settings.starredMarketCoins).toContain(bitcoin.id);
+    expect(track).toHaveBeenLastCalledWith(
+      "button_clicked",
+      expect.objectContaining({
+        button: "asset_coin_options_favourite",
+        is_favourite: true,
+      }),
+    );
+
+    act(() => result.current.onToggleFavourite());
+    expect(store.getState().settings.starredMarketCoins).not.toContain(bitcoin.id);
+    expect(track).toHaveBeenLastCalledWith(
+      "button_clicked",
+      expect.objectContaining({
+        button: "asset_coin_options_favourite",
+        is_favourite: false,
+      }),
+    );
+  });
+
+  it("persists the hidden state and tracks analytics in both directions", () => {
+    const { result, store } = renderViewModel();
+
+    act(() => result.current.onToggleHideFromPortfolio());
+    expect(store.getState().settings.blacklistedTokenIds).toContain(bitcoin.id);
+    expect(track).toHaveBeenLastCalledWith(
+      "button_clicked",
+      expect.objectContaining({
+        button: "asset_coin_options_hide_portfolio",
+        is_hidden: true,
+      }),
+    );
+
+    act(() => result.current.onToggleHideFromPortfolio());
+    expect(store.getState().settings.blacklistedTokenIds).not.toContain(bitcoin.id);
+    expect(track).toHaveBeenLastCalledWith(
+      "button_clicked",
+      expect.objectContaining({
+        button: "asset_coin_options_hide_portfolio",
+        is_hidden: false,
+      }),
+    );
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/CoinOptions/useAssetCoinOptionsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/CoinOptions/useAssetCoinOptionsViewModel.ts
@@ -1,0 +1,104 @@
+import { useCallback, useMemo, useState } from "react";
+import { useDispatch, useSelector } from "~/context/hooks";
+import {
+  addStarredMarketCoins,
+  blacklistToken,
+  removeStarredMarketCoins,
+  showToken,
+} from "~/actions/settings";
+import { blacklistedTokenIdsSelector, starredMarketCoinsSelector } from "~/reducers/settings";
+import { track } from "~/analytics";
+import { useNotifications } from "LLM/features/NotificationsPrompt";
+import type { AssetDetailCurrencyProps } from "LLM/features/AssetDetail/types";
+import { useTranslation } from "~/context/Locale";
+
+type Params = Readonly<{
+  currency: AssetDetailCurrencyProps;
+  currencyId: string;
+}>;
+
+export function useAssetCoinOptionsViewModel({ currency, currencyId }: Params) {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const { tryTriggerPushNotificationDrawerAfterAction } = useNotifications();
+
+  const blacklistedTokenIds = useSelector(blacklistedTokenIdsSelector);
+  const starredMarketCoins = useSelector(starredMarketCoinsSelector);
+
+  const [isCoinOptionsSheetOpen, setCoinOptionsSheetOpen] = useState(false);
+
+  const isHidden = !!currency && blacklistedTokenIds.includes(currency.id);
+  const isStarred = starredMarketCoins.includes(currencyId);
+
+  const blacklistedTokenIdsSet = useMemo(() => new Set(blacklistedTokenIds), [blacklistedTokenIds]);
+
+  const openCoinOptions = useCallback(() => setCoinOptionsSheetOpen(true), []);
+  const closeCoinOptions = useCallback(() => setCoinOptionsSheetOpen(false), []);
+
+  const trailingAccessibilityLabel = t("assetDetail.coinOptions.openMenuA11yLabel");
+
+  const onToggleFavourite = useCallback(() => {
+    if (!currency) return;
+    const nextStarred = !isStarred;
+
+    track("button_clicked", {
+      button: "asset_coin_options_favourite",
+      currency: currency.id,
+      page: "Asset Detail",
+      is_favourite: nextStarred,
+    });
+
+    if (nextStarred) {
+      if (!starredMarketCoins.includes(currencyId)) {
+        dispatch(addStarredMarketCoins(currencyId));
+      }
+      tryTriggerPushNotificationDrawerAfterAction("add_favorite_coin");
+    } else if (starredMarketCoins.includes(currencyId)) {
+      dispatch(removeStarredMarketCoins(currencyId));
+    }
+    closeCoinOptions();
+  }, [
+    currency,
+    isStarred,
+    currencyId,
+    dispatch,
+    starredMarketCoins,
+    tryTriggerPushNotificationDrawerAfterAction,
+    closeCoinOptions,
+  ]);
+
+  const onToggleHideFromPortfolio = useCallback(() => {
+    if (!currency) return;
+
+    const nextHidden = !isHidden;
+
+    track("button_clicked", {
+      button: "asset_coin_options_hide_portfolio",
+      currency: currency.id,
+      page: "Asset Detail",
+      is_hidden: nextHidden,
+    });
+
+    if (nextHidden) {
+      if (!blacklistedTokenIdsSet.has(currency.id)) {
+        dispatch(blacklistToken(currency.id));
+      }
+    } else {
+      dispatch(showToken(currency.id));
+    }
+    closeCoinOptions();
+  }, [currency, isHidden, blacklistedTokenIdsSet, dispatch, closeCoinOptions]);
+
+  return {
+    isCoinOptionsSheetOpen,
+    openCoinOptions,
+    closeCoinOptions,
+    trailingAccessibilityLabel,
+    isHidden,
+    isStarred,
+    onToggleFavourite,
+    onToggleHideFromPortfolio,
+  };
+}
+
+export type AssetCoinOptionsViewModel = ReturnType<typeof useAssetCoinOptionsViewModel>;

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/index.tsx
@@ -1,12 +1,15 @@
 import React, { useLayoutEffect } from "react";
+import type { NativeStackHeaderRightProps } from "@react-navigation/native-stack";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import CurrencyIcon from "~/components/CurrencyIcon";
 import type { LumenNativeStackNavigationOptions } from "LLM/components/Navigation";
 import type { AssetDetailNavigatorParamsList } from "LLM/features/AssetDetail/types";
 import { ScreenName } from "~/const";
+import { ASSET_DETAIL_TEST_IDS } from "../../testIds";
 import { useAssetDetailViewModel } from "./useAssetDetailViewModel";
 import { AssetDetailView } from "./AssetDetailView";
+import { AssetCoinOptionsTrailing } from "./components/CoinOptions/AssetCoinOptionsTrailing";
 
 type NavigationProps = NativeStackNavigationProp<
   AssetDetailNavigatorParamsList,
@@ -15,21 +18,36 @@ type NavigationProps = NativeStackNavigationProp<
 
 export default function AssetDetail() {
   const viewModel = useAssetDetailViewModel();
-  const { currency } = viewModel;
+  const { currency, coinOptions } = viewModel;
   const navigation = useNavigation<NavigationProps>();
 
   useLayoutEffect(() => {
     if (!currency) return;
+
+    function renderTrailing(_props: NativeStackHeaderRightProps) {
+      return (
+        <AssetCoinOptionsTrailing
+          onPress={coinOptions.openCoinOptions}
+          accessibilityLabel={coinOptions.trailingAccessibilityLabel}
+          testID={ASSET_DETAIL_TEST_IDS.coinOptionsTrailing}
+        />
+      );
+    }
+
     const opts: Partial<LumenNativeStackNavigationOptions> = {
       lumenNavBar: {
         coinCapsule: {
-          ticker: currency.ticker,
+          ticker: currency.name,
           icon: <CurrencyIcon currency={currency} hideNetwork size={24} />,
+        },
+        renderTrailing,
+        navBarTrailingProps: {
+          style: { marginRight: 16 },
         },
       },
     };
     navigation.setOptions(opts);
-  }, [navigation, currency]);
+  }, [navigation, currency, coinOptions.openCoinOptions, coinOptions.trailingAccessibilityLabel]);
 
   return <AssetDetailView {...viewModel} />;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
@@ -9,6 +9,7 @@ import { useDistribution } from "~/actions/general";
 import { resolveDistributionItem } from "@ledgerhq/asset-aggregation/assetDistribution/index";
 import type { AssetDetailNavigatorParamsList } from "../../types";
 import { useIsBuyAvailable, useSecondaryButtonType } from "./components/Footer/useFooterViewModel";
+import { useAssetCoinOptionsViewModel } from "./components/CoinOptions/useAssetCoinOptionsViewModel";
 
 type Route = StackNavigatorProps<AssetDetailNavigatorParamsList, ScreenName.AssetDetail>["route"];
 
@@ -37,6 +38,7 @@ export function useAssetDetailViewModel() {
   const accounts = useSelector(shallowAccountsSelector);
   const walletHasFunds = useMemo(() => accounts.some(a => a.balance.gt(0)), [accounts]);
   const showFallbackBanner = !hasFooter && walletHasFunds && !!currency;
+  const coinOptions = useAssetCoinOptionsViewModel({ currency, currencyId });
 
   return {
     currency,
@@ -47,5 +49,6 @@ export function useAssetDetailViewModel() {
     hasFooter,
     hideReceiveInBalanceGraph,
     showFallbackBanner,
+    coinOptions,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/testIds.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/testIds.ts
@@ -20,4 +20,8 @@ export const ASSET_DETAIL_TEST_IDS = {
   swapButton: "asset-detail-swap-button",
   footerReceiveButton: "asset-detail-footer-receive-button",
   fallbackBanner: "asset-detail-fallback-banner",
+  coinOptionsTrailing: "asset-detail-coin-options-trailing",
+  coinOptionsSheet: "asset-detail-coin-options-sheet",
+  coinOptionsFavouriteRow: "asset-detail-coin-options-favourite-row",
+  coinOptionsHideRow: "asset-detail-coin-options-hide-row",
 } as const;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Asset Detail screen (NavBar trailing button + bottom sheet)
  - Add/remove favourite persistence (`settings.starredMarketCoins`)
  - Hide/show from portfolio persistence (`settings.blacklistedTokenIds`)
  - Analytics events: `asset_coin_options_favourite`, `asset_coin_options_hide_portfolio`

### 📝 Description

The Asset Detail screen was missing a contextual menu to act on the displayed coin. Users had no way to favourite a coin or hide it from their portfolio directly from this screen.

This PR adds a `MoreVertical` trailing button to the Asset Detail NavBar that opens a Lumen bottom sheet with two options: Add/Remove favourite and Hide/Show from portfolio. Both actions persist in the existing `settings` Redux slice (`starredMarketCoins`, `blacklistedTokenIds`) so the state is restored across sessions. The whole flow follows the MVVM layout (`useAssetCoinOptionsViewModel`, `AssetCoinOptionsSheetView`, `AssetCoinOptionsTrailing`).

<img width="636" height="118" alt="image" src="https://github.com/user-attachments/assets/93e2775c-f6d0-4a6d-a064-3bdc36eccd02" />
<img width="642" height="464" alt="image" src="https://github.com/user-attachments/assets/6f8715e8-d16f-434a-8368-ea53283c4c99" />
<img width="668" height="414" alt="image" src="https://github.com/user-attachments/assets/fedd50e9-6cb3-4ac4-9f2e-16b7cb66cecc" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29732](https://ledgerhq.atlassian.net/browse/LIVE-29732)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29732]: https://ledgerhq.atlassian.net/browse/LIVE-29732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ