### PR TITLE
[LWD] feat(desktop): add PnlDetail component with MVVM pattern

### DIFF
--- a/.changeset/green-cheetahs-breathe.md
+++ b/.changeset/green-cheetahs-breathe.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+add PnlDetail component with MVVM pattern, local dialog state and discreet mode via Redux selector

--- a/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnlDetail/PnLinfoDetail.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnlDetail/PnLinfoDetail.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import {
+  ListItem,
+  ListItemLeading,
+  ListItemTitle,
+  ListItemDescription,
+  ListItemContent,
+  ListItemTrailing,
+} from "@ledgerhq/lumen-ui-react";
+
+type PnLinfoDetailProps = {
+  title: string;
+  description: string;
+  value: string;
+  discreet?: boolean;
+};
+
+export const PnLinfoDetail = ({ title, description, value, discreet }: PnLinfoDetailProps) => {
+  const displayedValue = discreet ? "***" : value;
+  return (
+    <ListItem className="px-0">
+      <ListItemLeading>
+        <ListItemContent>
+          <ListItemTitle>{title}</ListItemTitle>
+          <ListItemDescription className="whitespace-normal break-words">
+            {description}
+          </ListItemDescription>
+        </ListItemContent>
+      </ListItemLeading>
+      <ListItemTrailing>
+        <ListItemTitle>{displayedValue}</ListItemTitle>
+      </ListItemTrailing>
+    </ListItem>
+  );
+};

--- a/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnlDetail/PnlDetailView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnlDetail/PnlDetailView.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogTrigger,
+  DialogHeader,
+  DialogBody,
+  Button,
+} from "@ledgerhq/lumen-ui-react";
+import type { PnlDetailItem } from "./usePnlDetailViewModel";
+import { PnLinfoDetail } from "./PnLinfoDetail";
+
+type PnlDetailViewProps = {
+  title: string;
+  description: string;
+  items: PnlDetailItem[];
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  discreet: boolean;
+};
+
+export const PnlDetailView = ({
+  title,
+  description,
+  items,
+  isOpen,
+  onOpenChange,
+  discreet,
+}: PnlDetailViewProps) => (
+  <Dialog open={isOpen} onOpenChange={onOpenChange}>
+    <DialogTrigger asChild>
+      <Button>Open Dialog</Button>
+    </DialogTrigger>
+    <DialogContent>
+      <DialogHeader
+        density="expanded"
+        title={title}
+        description={description}
+        onClose={() => onOpenChange(false)}
+      />
+      <DialogBody>
+        {items.map(item => (
+          <PnLinfoDetail key={item.title} {...item} discreet={discreet} />
+        ))}
+      </DialogBody>
+    </DialogContent>
+  </Dialog>
+);

--- a/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnlDetail/__tests__/PnLinfoDetail.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnlDetail/__tests__/PnLinfoDetail.test.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import { PnLinfoDetail } from "../PnLinfoDetail";
+
+type PnLinfoDetailProps = React.ComponentProps<typeof PnLinfoDetail>;
+
+const TITLE = "Realised return";
+const DESCRIPTION = "Estimated gain or loss on your current holdings.";
+const VALUE = "$243.32";
+const DISCREET_PLACEHOLDER = "***";
+
+const makeProps = (overrides: Partial<PnLinfoDetailProps> = {}): PnLinfoDetailProps => ({
+  title: TITLE,
+  description: DESCRIPTION,
+  value: VALUE,
+  ...overrides,
+});
+
+describe("PnLinfoDetail", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should render the title, the description and the value", () => {
+    render(<PnLinfoDetail {...makeProps()} />);
+
+    expect(screen.getByText(TITLE)).toBeVisible();
+    expect(screen.getByText(DESCRIPTION)).toBeVisible();
+    expect(screen.getByText(VALUE)).toBeVisible();
+  });
+
+  it("should hide the value behind '***' when discreet is enabled", () => {
+    render(<PnLinfoDetail {...makeProps({ discreet: true })} />);
+
+    expect(screen.getByText(DISCREET_PLACEHOLDER)).toBeVisible();
+    expect(screen.queryByText(VALUE)).not.toBeInTheDocument();
+  });
+
+  it("should still render the title and the description when the value is hidden", () => {
+    render(<PnLinfoDetail {...makeProps({ discreet: true })} />);
+
+    expect(screen.getByText(TITLE)).toBeVisible();
+    expect(screen.getByText(DESCRIPTION)).toBeVisible();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnlDetail/__tests__/index.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnlDetail/__tests__/index.test.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { render, screen, waitFor } from "tests/testSetup";
+import { PnlDetail } from "../index";
+
+const TITLE = "Profit and loss";
+const DESCRIPTION = "Your portfolio performance broken down into realised and unrealised returns.";
+const ITEMS = [
+  { title: "Realised return", description: "Profits taken from sold positions.", value: "$120.00" },
+  {
+    title: "Unrealised return",
+    description: "Estimated gain or loss on your current holdings.",
+    value: "$243.32",
+  },
+] as const;
+
+const DEFAULT_PROPS = { title: TITLE, description: DESCRIPTION, items: [...ITEMS] };
+
+async function openDialog(user: ReturnType<typeof render>["user"]) {
+  await user.click(screen.getByRole("button", { name: /open dialog/i }));
+  await waitFor(() => expect(screen.getByRole("dialog")).toBeVisible());
+}
+
+describe("PnlDetail", () => {
+  it("does not render the dialog before the trigger is clicked", () => {
+    render(<PnlDetail {...DEFAULT_PROPS} />);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders the trigger button", () => {
+    render(<PnlDetail {...DEFAULT_PROPS} />);
+
+    expect(screen.getByRole("button", { name: /open dialog/i })).toBeVisible();
+  });
+
+  it("opens the dialog with title and description when the trigger is clicked", async () => {
+    const { user } = render(<PnlDetail {...DEFAULT_PROPS} />);
+    await openDialog(user);
+
+    // Radix also renders a sr-only h2/p for a11y — scope to div to target the visible elements
+    expect(screen.getByText(TITLE, { selector: "div" })).toBeVisible();
+    expect(screen.getByText(DESCRIPTION, { selector: "div" })).toBeVisible();
+  });
+
+  it("renders every item when the dialog is open", async () => {
+    const { user } = render(<PnlDetail {...DEFAULT_PROPS} />);
+    await openDialog(user);
+
+    for (const { title, description, value } of ITEMS) {
+      expect(screen.getByText(title)).toBeVisible();
+      expect(screen.getByText(description)).toBeVisible();
+      expect(screen.getByText(value)).toBeVisible();
+    }
+  });
+
+  it("masks all item values behind '***' when the store has discreet mode enabled", async () => {
+    const { user } = render(<PnlDetail {...DEFAULT_PROPS} />, {
+      initialState: { settings: { discreetMode: true } },
+    });
+    await openDialog(user);
+
+    expect(screen.getAllByText("***")).toHaveLength(ITEMS.length);
+    for (const { value } of ITEMS) {
+      expect(screen.queryByText(value)).not.toBeInTheDocument();
+    }
+  });
+
+  it("closes the dialog when the close button is clicked", async () => {
+    const { user } = render(<PnlDetail {...DEFAULT_PROPS} />);
+    await openDialog(user);
+
+    await user.click(screen.getByRole("button", { name: /close/i }));
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnlDetail/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnlDetail/index.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import type { PnlDetailItem } from "./usePnlDetailViewModel";
+import { usePnlDetailViewModel } from "./usePnlDetailViewModel";
+import { PnlDetailView } from "./PnlDetailView";
+
+type PnlDetailProps = {
+  title: string;
+  description: string;
+  items: PnlDetailItem[];
+};
+
+export const PnlDetail = ({ title, description, items }: PnlDetailProps) => {
+  const viewModel = usePnlDetailViewModel({ title, description, items });
+  return <PnlDetailView {...viewModel} />;
+};

--- a/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnlDetail/usePnlDetailViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnlDetail/usePnlDetailViewModel.ts
@@ -1,0 +1,29 @@
+import { useState } from "react";
+import { useSelector } from "LLD/hooks/redux";
+import { discreetModeSelector } from "~/renderer/reducers/settings";
+
+export type PnlDetailItem = {
+  title: string;
+  description: string;
+  value: string;
+};
+
+type PnlDetailViewModelInput = {
+  title: string;
+  description: string;
+  items: PnlDetailItem[];
+};
+
+export function usePnlDetailViewModel({ title, description, items }: PnlDetailViewModelInput) {
+  const [isOpen, setIsOpen] = useState(false);
+  const discreet = useSelector(discreetModeSelector);
+
+  return {
+    title,
+    description,
+    items,
+    isOpen,
+    onOpenChange: setIsOpen,
+    discreet,
+  };
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - PnlDetail dialog open/close state
  - Discreet mode masking via Redux selector
  - MVVM compliance in the PnL feature

### 📝 Description

The \`PnlDetail\` component mixed local dialog state and discreet mode logic directly inside the view, violating the MVVM contract.

Refactored into three layers:
- \`usePnlDetailViewModel\` — manages \`useState\` for dialog open/close and reads \`discreetModeSelector\` from the Redux store
- \`PnlDetailView\` — pure view receiving all data and handlers via props, no external hook calls
- \`index.tsx\` — container that wires ViewModel → View

Discreet mode is now driven globally by the Redux store instead of a per-item prop.


https://github.com/user-attachments/assets/5a77d23c-42a4-4b46-a954-9131bfddbb6a




### ❓ Context

- **JIRA or GitHub link**: [LIVE-30296](https://ledgerhq.atlassian.net/browse/LIVE-30296)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-30296]: https://ledgerhq.atlassian.net/browse/LIVE-30296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ