### PR TITLE
ci: flatten desktop unit tests to remove composite

### DIFF
--- a/.github/workflows/test-desktop-reusable.yml
+++ b/.github/workflows/test-desktop-reusable.yml
@@ -72,13 +72,15 @@ jobs:
 
       - name: lint
         run: pnpm desktop lint:ci
+
       - name: lint (guardrails)
         run: pnpm desktop lint:guardrails
+
       - name: typecheck
         run: pnpm desktop typecheck
+
       - name: check for dead code
         run: pnpm desktop knip-check
-        shell: bash
 
   unit-tests:
     name: "Desktop Unit Tests"
@@ -110,13 +112,15 @@ jobs:
           region: ${{ secrets.AWS_CACHE_REGION }}
           turbo-server-token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
 
-      - uses: LedgerHQ/ledger-live/tools/actions/composites/setup-test-desktop@develop
-        id: setup-test-desktop
-        with:
-          skip_builds: true
-          turborepo-server-port: ${{ steps.setup-caches.outputs.port }}
+      - name: Install dependencies
+        run: pnpm i --filter="ledger-live-desktop..." --filter="ledger-live"
+
+      - name: Build dependencies
+        run: pnpm exec nx run ledger-live-desktop:build-lib-deps
+
       - name: Run unit tests
         run: pnpm desktop test:jest:coverage
+
       - name: Upload unit test coverage
         id: generate_coverage
         if: ${{ !cancelled() }}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

- Improve workflow readability by deprecating the setup desktop on coverage checks
- Improve timing by removing unused builds & dep installs

Test run: https://github.com/LedgerHQ/ledger-live/actions/runs/25800325956/job/75788499264?pr=17438

### ❓ Context

Ticket: https://ledgerhq.atlassian.net/browse/LIVE-27758


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
