### PR TITLE
[LWD] feat(desktop): open finish onboarding after sync completion when wall…

### DIFF
--- a/.changeset/live-30572-sync-completion-finish-dialog.md
+++ b/.changeset/live-30572-sync-completion-finish-dialog.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Open finish-onboarding dialog from sync onboarding completion when Wallet40 finish widget is enabled

--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompletion/__tests__/useCompletionScreenViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompletion/__tests__/useCompletionScreenViewModel.test.tsx
@@ -1,12 +1,16 @@
 /**
  * @jest-environment jsdom
  */
-import { renderHook, waitFor } from "tests/testSetup";
+import { renderHook, act, withFlagOverrides } from "tests/testSetup";
 import { useRedirectToPostOnboardingCallback } from "~/renderer/hooks/useAutoRedirectToPostOnboarding";
 import { State } from "~/renderer/reducers";
 import { Device, DeviceModelId } from "@ledgerhq/types-devices";
 import { useCompletionScreenViewModel } from "../useCompletionScreenViewModel";
 import { SettingsState } from "~/renderer/reducers/settings";
+
+const mockNavigate = jest.fn();
+const mockOpenFinishOnboardingDialog = jest.fn();
+const mockRedirectToPostOnboarding = jest.fn();
 
 jest.mock("~/renderer/hooks/useAutoRedirectToPostOnboarding", () => ({
   ...jest.requireActual("~/renderer/hooks/useAutoRedirectToPostOnboarding"),
@@ -16,7 +20,18 @@ jest.mock("~/renderer/hooks/useAutoRedirectToPostOnboarding", () => ({
 jest.mock("react-router", () => ({
   ...jest.requireActual("react-router"),
   useLocation: jest.fn().mockReturnValue({ state: { seedConfiguration: "new_seed" } }),
+  useNavigate: () => mockNavigate,
 }));
+
+jest.mock(
+  "LLD/features/FinishOnboarding/FinishOnboardingDialog/hooks/useFinishOnboardingDialog",
+  () => ({
+    __esModule: true,
+    default: () => ({
+      handleOpen: mockOpenFinishOnboardingDialog,
+    }),
+  }),
+);
 
 const getInitialState = (modelId: DeviceModelId = DeviceModelId.stax): Partial<State> => ({
   devices: {
@@ -27,25 +42,34 @@ const getInitialState = (modelId: DeviceModelId = DeviceModelId.stax): Partial<S
 
 describe("useCompletionScreenViewModel", () => {
   beforeEach(() => {
-    jest.mocked(useRedirectToPostOnboardingCallback).mockReset();
+    jest.useFakeTimers();
+    mockRedirectToPostOnboarding.mockClear();
+    mockNavigate.mockClear();
+    mockOpenFinishOnboardingDialog.mockClear();
+    jest
+      .mocked(useRedirectToPostOnboardingCallback)
+      .mockReturnValue(mockRedirectToPostOnboarding);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   [DeviceModelId.stax, DeviceModelId.apex, DeviceModelId.europa].forEach(deviceId =>
-    it(`should return ${deviceId} device ID and redirect to post onboarding`, async () => {
+    it(`should return ${deviceId} device ID and redirect to post onboarding`, () => {
       const initialState = getInitialState(deviceId);
       const { result, store } = renderHook(() => useCompletionScreenViewModel(), { initialState });
 
       expect(result.current.deviceModelId).toBe(deviceId);
       expect(result.current.seedConfiguration).toBe("new_seed");
 
-      await waitFor(
-        () => {
-          expect(useRedirectToPostOnboardingCallback).toHaveBeenCalled();
-        },
-        {
-          timeout: 7000,
-        },
-      );
+      act(() => {
+        jest.advanceTimersByTime(6000);
+      });
+
+      expect(mockRedirectToPostOnboarding).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(mockOpenFinishOnboardingDialog).not.toHaveBeenCalled();
 
       const { settings } = store.getState() as { settings: SettingsState };
       expect(settings.hasCompletedOnboarding).toBe(true);
@@ -54,4 +78,27 @@ describe("useCompletionScreenViewModel", () => {
       expect(settings.lastOnboardedDevice).toHaveProperty("modelId", deviceId);
     }),
   );
+
+  it("should navigate home and open finish-onboarding dialog when Wallet40 finish widget is enabled", () => {
+    const deviceId = DeviceModelId.stax;
+    const initialState = {
+      ...getInitialState(deviceId),
+      ...withFlagOverrides({
+        lwdWallet40: {
+          enabled: true,
+          params: { finishOnboardingWidget: true },
+        },
+      }),
+    };
+
+    renderHook(() => useCompletionScreenViewModel(), { initialState });
+
+    act(() => {
+      jest.advanceTimersByTime(6000);
+    });
+
+    expect(mockRedirectToPostOnboarding).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith("/");
+    expect(mockOpenFinishOnboardingDialog).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompletion/useCompletionScreenViewModel.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompletion/useCompletionScreenViewModel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from "react";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
-import { useLocation } from "react-router";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { useLocation, useNavigate } from "react-router";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import {
   saveSettings,
@@ -11,6 +12,7 @@ import {
 import { lastSeenDeviceSelector } from "~/renderer/reducers/settings";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import { useRedirectToPostOnboardingCallback } from "~/renderer/hooks/useAutoRedirectToPostOnboarding";
+import useFinishOnboardingDialog from "LLD/features/FinishOnboarding/FinishOnboardingDialog/hooks/useFinishOnboardingDialog";
 
 const COMPLETION_SCREEN_TIMEOUT = 6000;
 
@@ -22,6 +24,7 @@ export interface ViewProps {
 export function useCompletionScreenViewModel(): ViewProps {
   const dispatch = useDispatch();
   const location = useLocation();
+  const navigate = useNavigate();
   const state = location.state as { seedConfiguration?: string } | null;
   const currentDevice = useSelector(getCurrentDevice);
   const lastSeenDevice = useSelector(lastSeenDeviceSelector);
@@ -31,18 +34,34 @@ export function useCompletionScreenViewModel(): ViewProps {
     return device?.modelId || DeviceModelId.stax;
   }, [currentDevice, lastSeenDevice]);
 
+  const { shouldDisplayFinishOnboardingWidget = false } = useWalletFeaturesConfig("desktop");
   const redirectToPostOnboarding = useRedirectToPostOnboardingCallback();
+  const { handleOpen: openFinishOnboardingDialog } = useFinishOnboardingDialog();
 
   useEffect(() => {
     dispatch(saveSettings({ hasCompletedOnboarding: true }));
     dispatch(setHasRedirectedToPostOnboarding(false));
     dispatch(setHasBeenUpsoldRecover(false));
     dispatch(setLastOnboardedDevice(currentDevice));
-    const timeout = setTimeout(redirectToPostOnboarding, COMPLETION_SCREEN_TIMEOUT);
+    const timeout = setTimeout(() => {
+      if (shouldDisplayFinishOnboardingWidget) {
+        navigate("/");
+        openFinishOnboardingDialog();
+      } else {
+        redirectToPostOnboarding();
+      }
+    }, COMPLETION_SCREEN_TIMEOUT);
     return () => {
       clearTimeout(timeout);
     };
-  }, [currentDevice, dispatch, redirectToPostOnboarding]);
+  }, [
+    currentDevice,
+    dispatch,
+    navigate,
+    openFinishOnboardingDialog,
+    redirectToPostOnboarding,
+    shouldDisplayFinishOnboardingWidget,
+  ]);
 
   return {
     seedConfiguration: state?.seedConfiguration,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Unit tests for `useCompletionScreenViewModel` (fake timers + Wallet40 flag); no E2E sync onboarding._
- [x] **Impact of the changes:**
  - Sync onboarding **completion** screen: delay unchanged (6s), then either legacy redirect to post-onboarding **or** `navigate("/")` + open **finish post-onboarding** dialog when `lwdWallet40` has `finishOnboardingWidget` enabled.
  - Feature flag: use **`finishOnboardingWidget`** in `lwdWallet40` params (not `shouldDisplayFinishOnboardingWidget` in JSON) so `useWalletFeaturesConfig` is true.
  - QA: confirm dialog content / post-onboarding state if hub init is still required for your product case.

### 📝 Description

**Context ([LIVE-30572](https://ledgerhq.atlassian.net/browse/LIVE-30572)):** Align Ledger Sync onboarding completion with the Wallet 40 “finish onboarding” entry (modal) instead of always sending users to the legacy full-screen post-onboarding hub when the finish widget flag is on.

**Change:** After the completion timeout, if `shouldDisplayFinishOnboardingWidget` is true, the app navigates to the portfolio and opens the global finish-onboarding dialog; otherwise it keeps calling `redirectToPostOnboarding()` (Recover + hub flow unchanged there).

**Tests:** `useCompletionScreenViewModel` tests use `jest.useFakeTimers`, `withFlagOverrides` for `lwdWallet40` / `finishOnboardingWidget`, and mocks for `useNavigate` + finish dialog `handleOpen` where needed.

| Before | After |
| ------ | ----- |
| _Sync completion always redirected to post-onboarding hub (after delay)._ | _With Wallet40 finish widget: home + finish dialog; without flag: same redirect as before._ |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30572](https://ledgerhq.atlassian.net/browse/LIVE-30572)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30572]: https://ledgerhq.atlassian.net/browse/LIVE-30572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-30572]: https://ledgerhq.atlassian.net/browse/LIVE-30572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ