### PR TITLE
[LWM] fix(mobile): extend asset detail footer gradient to screen bottom

### DIFF
--- a/.changeset/fix-footer-gradient-coverage.md
+++ b/.changeset/fix-footer-gradient-coverage.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix asset detail footer gradient not extending to the bottom of the screen

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/FooterView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/FooterView.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { Box, Button } from "@ledgerhq/lumen-ui-rnative";
+import { Box, Button, LinearGradient } from "@ledgerhq/lumen-ui-rnative";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { useTranslation } from "~/context/Locale";
 import type { SecondaryButtonType } from "./useFooterViewModel";
 import { ASSET_DETAIL_TEST_IDS } from "../../../../testIds";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 type Props = Readonly<{
   isBuyAvailable: boolean;
@@ -27,14 +27,19 @@ export function FooterView({
   if (!isBuyAvailable && !secondaryButton) return null;
 
   return (
-    <Box
+    <LinearGradient
+      stops={[
+        { color: "transparent", opacity: 0 },
+        { offset: 0.2, color: "base", opacity: 1 },
+        { offset: 1, color: "base", opacity: 1 },
+      ]}
+      direction="to-bottom"
       testID={ASSET_DETAIL_TEST_IDS.ctas}
       lx={containerStyle}
-      style={{ paddingBottom: bottom + 16 }}
     >
-      <Box lx={rowStyle}>
+      <Box lx={rowStyle} style={{ paddingBottom: bottom + 16 }}>
         {isBuyAvailable && (
-          <Box style={buttonSlotStyle}>
+          <Box lx={buttonSlotStyle}>
             <Button
               appearance="gray"
               size="lg"
@@ -48,7 +53,7 @@ export function FooterView({
         )}
 
         {secondaryButton === "swap" && (
-          <Box style={buttonSlotStyle}>
+          <Box lx={buttonSlotStyle}>
             <Button
               appearance="base"
               size="lg"
@@ -62,7 +67,7 @@ export function FooterView({
         )}
 
         {secondaryButton === "receive" && (
-          <Box style={buttonSlotStyle}>
+          <Box lx={buttonSlotStyle}>
             <Button
               appearance="base"
               size="lg"
@@ -75,22 +80,24 @@ export function FooterView({
           </Box>
         )}
       </Box>
-    </Box>
+    </LinearGradient>
   );
 }
+
+const rowStyle: LumenViewStyle = {
+  paddingHorizontal: "s16",
+  paddingTop: "s16",
+  flexDirection: "row",
+  gap: "s8",
+};
 
 const containerStyle: LumenViewStyle = {
   position: "absolute",
   bottom: "s0",
   left: "s0",
   right: "s0",
-  paddingHorizontal: "s16",
-  paddingTop: "s16",
 };
 
-const rowStyle: LumenViewStyle = {
-  flexDirection: "row",
-  gap: "s8",
+const buttonSlotStyle: LumenViewStyle = {
+  flex: 1,
 };
-
-const buttonSlotStyle = { flex: 1 } as const;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Visual fix verified manually on Android and iOS._
- [x] **Impact of the changes:**
      - Asset detail footer rendering on devices with varying safe area insets
      - Gradient coverage at the bottom of the screen (Buy/Swap buttons area)

### 📝 Description

The footer gradient on the Asset Detail screen was not extending all the way to the bottom of the screen, leaving content visible below the Buy/Swap buttons.

**Fix**: Replaced the plain `Box` container with a `LinearGradient` using explicit stops (transparent → opaque at 20% → opaque at 100%) and enforced a minimum `paddingBottom` of `bottom+ 16` to guarantee coverage on all devices, even when `useSafeAreaInsets().bottom` returns 0.

Android

https://github.com/user-attachments/assets/a972721d-0bcb-4e77-92c5-5cfba8eacfa7

IOS

https://github.com/user-attachments/assets/4fa489d4-eb6c-4e60-ba45-f0c35da1de1f


### ❓ Context

- **JIRA or GitHub link**: [LIVE-30594](https://ledgerhq.atlassian.net/browse/LIVE-30594)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30594]: https://ledgerhq.atlassian.net/browse/LIVE-30594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ