### PR TITLE
[LWD] feat(lld): add Earn button in EVM account header for native staking

### DIFF
--- a/.changeset/happy-camels-agree.md
+++ b/.changeset/happy-camels-agree.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Add Earn button in account header for EVM native staking accounts (Sei EVM)

--- a/apps/ledger-live-desktop/src/renderer/families/evm/AccountHeaderManageActions.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/AccountHeaderManageActions.ts
@@ -2,6 +2,9 @@ import { Account, AccountLike } from "@ledgerhq/types-live";
 import { useCallback } from "react";
 import { openModal } from "~/renderer/actions/modals";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { canDelegate } from "@ledgerhq/live-common/families/evm/staking/logic";
+import { isStakingAccount } from "@ledgerhq/live-common/families/evm/staking/types";
 import { useGetStakeLabelLocaleBased } from "~/renderer/hooks/useGetStakeLabelLocaleBased";
 import { useNavigate } from "react-router";
 import { useStake } from "LLD/hooks/useStake";
@@ -22,6 +25,8 @@ const AccountHeaderActions = ({ account, parentAccount }: Props) => {
   const label = useGetStakeLabelLocaleBased();
   const walletState = useSelector(walletSelector);
   const { getRouteToPlatformApp } = useStake();
+  const { enabled: isEvmNativeStakingEnabled, params: evmNativeStakingParams } =
+    useFeature("evmNativeStaking") ?? {};
 
   const isEthereumAccount = account.type === "Account" && account.currency.id === "ethereum";
   const isBscAccount = account.type === "Account" && account.currency.id === "bsc";
@@ -29,6 +34,11 @@ const AccountHeaderActions = ({ account, parentAccount }: Props) => {
     account.type === "TokenAccount" &&
     account.token.id === "ethereum/erc20/polygon_ecosystem_token";
   const isAvaxAccount = account.type === "Account" && account.currency.id === "avalanche_c_chain";
+  const canShowEvmNativeStake =
+    account.type === "Account" &&
+    isStakingAccount(account) &&
+    (isEvmNativeStakingEnabled ?? false) &&
+    (evmNativeStakingParams?.supportedCurrencyIds?.includes(account.currency.id) ?? false);
 
   const onClickStakekit = useCallback(
     (yieldId: string) => {
@@ -72,6 +82,14 @@ const AccountHeaderActions = ({ account, parentAccount }: Props) => {
     }
   }, [account, bridge, dispatch, parentAccount, getRouteToPlatformApp, walletState, navigate]);
 
+  const onClickEvmNativeStake = useCallback(() => {
+    if (account.type === "Account" && isStakingAccount(account) && canDelegate(account)) {
+      dispatch(openModal("MODAL_EVM_DELEGATE", { account }));
+    } else {
+      dispatch(openModal("MODAL_NO_FUNDS_STAKE", { account, parentAccount }));
+    }
+  }, [account, dispatch, parentAccount]);
+
   const getStakeAction = useCallback(() => {
     if (isEthereumAccount) {
       onClickStakeModal();
@@ -81,6 +99,8 @@ const AccountHeaderActions = ({ account, parentAccount }: Props) => {
       onClickStakekit("ethereum-matic-native-staking");
     } else if (isAvaxAccount) {
       onClickStakekit("avalanche-avax-liquid-staking");
+    } else if (canShowEvmNativeStake) {
+      onClickEvmNativeStake();
     }
   }, [
     isEthereumAccount,
@@ -89,9 +109,11 @@ const AccountHeaderActions = ({ account, parentAccount }: Props) => {
     onClickStakeModal,
     onClickStakekit,
     isPOLAccount,
+    canShowEvmNativeStake,
+    onClickEvmNativeStake,
   ]);
 
-  if (isEthereumAccount || isBscAccount || isPOLAccount || isAvaxAccount) {
+  if (isEthereumAccount || isBscAccount || isPOLAccount || isAvaxAccount || canShowEvmNativeStake) {
     return [
       {
         key: "Stake",

--- a/apps/ledger-live-desktop/src/renderer/families/evm/__tests__/AccountHeaderManageActions.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/__tests__/AccountHeaderManageActions.test.tsx
@@ -1,0 +1,140 @@
+import { act } from "react";
+import BigNumber from "bignumber.js";
+import invariant from "invariant";
+import {
+  getCryptoCurrencyById,
+  setSupportedCurrencies,
+} from "@ledgerhq/live-common/currencies/index";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { Account } from "@ledgerhq/types-live";
+import { renderHook, withFlagOverrides } from "tests/testSetup";
+import AccountHeaderActions from "../AccountHeaderManageActions";
+
+setSupportedCurrencies(["sei_evm"]);
+const seiEvmCurrency = getCryptoCurrencyById("sei_evm");
+
+const emptyStakingResources = {
+  delegatedBalance: new BigNumber(0),
+  pendingRewardsBalance: new BigNumber(0),
+  unbondingBalance: new BigNumber(0),
+  delegations: [],
+  redelegations: [],
+  unbondings: [],
+  validators: [],
+};
+
+const makeSeiAccount = ({
+  withStakingResources = true,
+  spendableBalance = new BigNumber(1_000),
+  operations,
+}: {
+  withStakingResources?: boolean;
+  spendableBalance?: BigNumber;
+  operations?: Account["operations"];
+} = {}): Account => {
+  const base = genAccount("sei_evm-test", { currency: seiEvmCurrency });
+  return {
+    ...base,
+    balance: spendableBalance,
+    spendableBalance,
+    ...(operations !== undefined && { operations, operationsCount: operations.length }),
+    ...(withStakingResources && { stakingResources: emptyStakingResources }),
+  } as Account;
+};
+
+const seiEvmEnabledFlags = withFlagOverrides({
+  evmNativeStaking: { enabled: true, params: { supportedCurrencyIds: ["sei_evm"] } },
+});
+
+describe("EVM AccountHeaderManageActions", () => {
+  const hook = AccountHeaderActions;
+  invariant(hook, "evm: type guard AccountHeaderActions");
+
+  describe("when sei_evm staking is gated out", () => {
+    it("returns an empty array when account has no stakingResources", () => {
+      const account = makeSeiAccount({ withStakingResources: false });
+      const { result } = renderHook(() => hook({ account, parentAccount: null }), {
+        initialState: seiEvmEnabledFlags,
+      });
+
+      expect(result.current).toEqual([]);
+    });
+
+    it("returns an empty array when feature flag is disabled", () => {
+      const account = makeSeiAccount();
+      const { result } = renderHook(() => hook({ account, parentAccount: null }));
+
+      expect(result.current).toEqual([]);
+    });
+
+    it("returns an empty array when currency is not in supportedCurrencyIds", () => {
+      const account = makeSeiAccount();
+      const { result } = renderHook(() => hook({ account, parentAccount: null }), {
+        initialState: withFlagOverrides({
+          evmNativeStaking: { enabled: true, params: { supportedCurrencyIds: [] } },
+        }),
+      });
+
+      expect(result.current).toEqual([]);
+    });
+
+  });
+
+  describe("when sei_evm account has zero spendable balance", () => {
+    it("still returns a Stake action", () => {
+      const account = makeSeiAccount({ spendableBalance: new BigNumber(0) });
+      const { result } = renderHook(() => hook({ account, parentAccount: null }), {
+        initialState: seiEvmEnabledFlags,
+      });
+
+      expect(result.current).toEqual([
+        expect.objectContaining({ key: "Stake", accountActionsTestId: "stake-button" }),
+      ]);
+    });
+
+    it("opens MODAL_NO_FUNDS_STAKE on click", () => {
+      const account = makeSeiAccount({ spendableBalance: new BigNumber(0) });
+      const { result, store } = renderHook(() => hook({ account, parentAccount: null }), {
+        initialState: seiEvmEnabledFlags,
+      });
+
+      act(() => {
+        result.current?.[0].onClick();
+      });
+
+      expect(store.getState().modals.MODAL_NO_FUNDS_STAKE?.isOpened).toBe(true);
+      expect(store.getState().modals.MODAL_EVM_DELEGATE?.isOpened).toBe(undefined);
+    });
+  });
+
+  describe("when sei_evm staking is fully enabled", () => {
+    it("returns a single Stake action", () => {
+      const account = makeSeiAccount();
+      const { result } = renderHook(() => hook({ account, parentAccount: null }), {
+        initialState: seiEvmEnabledFlags,
+      });
+
+      expect(result.current).toHaveLength(1);
+      expect(result.current?.[0]).toEqual(
+        expect.objectContaining({
+          key: "Stake",
+          accountActionsTestId: "stake-button",
+        }),
+      );
+    });
+
+    it("opens MODAL_EVM_DELEGATE when clicking the action on a funded account", () => {
+      const account = makeSeiAccount();
+      const { result, store } = renderHook(() => hook({ account, parentAccount: null }), {
+        initialState: seiEvmEnabledFlags,
+      });
+
+      act(() => {
+        result.current?.[0].onClick();
+      });
+
+      expect(store.getState().modals.MODAL_EVM_DELEGATE?.isOpened).toBe(true);
+      expect(store.getState().modals.MODAL_NO_FUNDS_STAKE?.isOpened).toBe(undefined);
+    });
+  });
+});


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Manual smoke test only — no existing unit tests for `AccountHeaderManageActions` in other EVM families and the change is a trivial branching addition. Visibility is fully driven by remote feature flags._
- [x] **Impact of the changes:**
      - Earn button appears in the account header for Sei EVM (`sei_evm`) when the `evmNativeStaking` and `stakePrograms` feature flags are configured for it.
      - Clicking the button opens the existing delegation flow: `MODAL_NO_FUNDS_STAKE` if the account is empty, `MODAL_EVM_DELEGATE` if the user already has delegations, otherwise `MODAL_EVM_REWARDS_INFO`.
      - No regression on Ethereum / BSC / Polygon / Avalanche stake button — only a deprecated `isAccountEmpty` import was migrated to `useAccountBridge().isAccountEmpty(account)`.

### 📝 Description

Today the EVM account header only shows the Stake button for Ethereum / BSC / POL / Avalanche. The full native-staking infrastructure already exists in `coin-evm` for Sei EVM (staking precompile, `MODAL_EVM_DELEGATE`, `MODAL_EVM_REWARDS_INFO`, `Delegation/index.tsx`) but there is no entry point in the header to launch the flow — users had to scroll down to the Delegation section.

This PR adds an Earn button gated on a generic EVM-native-staking signal (no hardcoded `sei_evm`):
- `isStakingAccount(account)` — the bridge populated `stakingResources` (only currencies with a staking config in `coin-evm` qualify).
- `evmNativeStaking.enabled` + `params.supportedCurrencyIds.includes(account.currency.id)` — same gate as the Delegation section, ensuring header and section stay in sync.

Click behavior matches the cosmos/solana pattern (empty → no-funds modal; has delegations → delegate modal; otherwise → rewards info modal).

Mobile parity will follow in a separate PR.

| Before | After |
| ------ | ----- |
|<img width="618" height="145" alt="Screenshot 2026-05-13 at 17 14 12" src="https://github.com/user-attachments/assets/b65aa603-c3ce-4deb-bd0d-d9cc126f940c" />|<img width="603" height="154" alt="Screenshot 2026-05-13 at 17 14 57" src="https://github.com/user-attachments/assets/8aa02b5e-0089-495e-ba0b-f7b3ca9b7bdb" />|

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30592](https://ledgerhq.atlassian.net/browse/LIVE-30592)

- **E2E**:
  - Desktop: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/64c3ad2f-a7bd-4284-8701-57a773e5d1f0/
---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-30592]: https://ledgerhq.atlassian.net/browse/LIVE-30592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ