### PR TITLE
[LWDM] feat(LIVE-29443): add swap status wallet api

### DIFF
--- a/.changeset/wise-swaps-report.md
+++ b/.changeset/wise-swaps-report.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/wallet-api-exchange-module": minor
+"@ledgerhq/live-common": minor
+---
+
+Add swap transaction status Wallet API support.

--- a/libs/exchange-module/src/index.ts
+++ b/libs/exchange-module/src/index.ts
@@ -12,6 +12,8 @@ import {
   SwapLiveError,
   type GetQuotesResponse,
   type GetQuotesWireArgs,
+  type GetTransactionStatusResponse,
+  type GetTransactionStatusWireArgs,
 } from "./types";
 
 export * from "./types";
@@ -185,6 +187,18 @@ export class ExchangeModule extends CustomModule {
    */
   async getQuotes(params: GetQuotesWireArgs): Promise<GetQuotesResponse> {
     return this.request<GetQuotesWireArgs, GetQuotesResponse>("custom.exchange.getQuotes", params);
+  }
+
+  /**
+   * Fetch swap transaction status from the Wallet API host.
+   */
+  async getTransactionStatus(
+    params: GetTransactionStatusWireArgs,
+  ): Promise<GetTransactionStatusResponse> {
+    return this.request<GetTransactionStatusWireArgs, GetTransactionStatusResponse>(
+      "custom.exchange.getTransactionStatus",
+      params,
+    );
   }
 
   /**

--- a/libs/exchange-module/src/types.ts
+++ b/libs/exchange-module/src/types.ts
@@ -137,6 +137,47 @@ export type GetQuotesArgs = {
 
 export type GetQuotesWireArgs = Omit<GetQuotesArgs, "signal">;
 
+// Swap transaction status (`custom.exchange.getTransactionStatus`).
+
+export type TransactionStatusInput = {
+  swapId: string;
+  provider?: string;
+};
+
+export const TransactionStatus = {
+  Pending: "pending",
+  OnHold: "onhold",
+  Expired: "expired",
+  Finished: "finished",
+  Refunded: "refunded",
+  Unknown: "unknown",
+} as const;
+
+export type TransactionStatusValue = (typeof TransactionStatus)[keyof typeof TransactionStatus];
+
+export type GetTransactionStatusArgs = TransactionStatusInput & {
+  signal?: AbortSignal;
+};
+
+export type GetTransactionStatusWireArgs = Omit<GetTransactionStatusArgs, "signal">;
+
+export type GetTransactionStatusResponse = {
+  swapId: string;
+  provider?: string;
+  status?: TransactionStatusValue;
+  sendStatus?: TransactionStatusValue;
+  receiveStatus?: TransactionStatusValue;
+  finalAmount?: string;
+  fromAccountId?: string;
+  toAccountId?: string;
+  sentAmount?: string;
+  receivedAmount?: string;
+  feesAmount?: string;
+  operationHash?: string;
+  createdAt?: number;
+  providerRequired?: boolean;
+};
+
 export type TradeMethod = "fixed" | "float";
 
 export type ProviderTypes = "DEX" | "CEX";

--- a/libs/ledger-live-common/src/exchange/swap/addToSwapHistory.ts
+++ b/libs/ledger-live-common/src/exchange/swap/addToSwapHistory.ts
@@ -2,6 +2,7 @@ import type { Transaction } from "../../coin-modules/transaction-types";
 import type { ExchangeSwap, ExchangeRate } from "./types";
 import { getAccountCurrency, getMainAccount } from "../../account";
 import type { Account, Operation, TokenAccount, SwapOperation } from "@ledgerhq/types-live";
+import { TransactionStatus } from "@ledgerhq/wallet-api-exchange-module";
 
 export default ({
   account,
@@ -35,7 +36,7 @@ export default ({
   const toAmount = transaction.amount.times(exchangeRate.magnitudeAwareRate);
 
   const swapOperation: SwapOperation = {
-    status: "pending",
+    status: TransactionStatus.Pending,
     provider: exchangeRate.provider,
     operationId,
     swapId,

--- a/libs/ledger-live-common/src/exchange/swap/index.ts
+++ b/libs/ledger-live-common/src/exchange/swap/index.ts
@@ -1,4 +1,5 @@
 import { getEnv } from "@ledgerhq/live-env";
+import { TransactionStatus } from "@ledgerhq/wallet-api-exchange-module";
 import {
   AccessDeniedError,
   CurrencyDisabledAsInputError,
@@ -21,9 +22,9 @@ import { getIncompatibleCurrencyKeys } from "./getIncompatibleCurrencyKeys";
 
 export { getAvailableProviders } from "../providers";
 
-export const operationStatusList = {
-  finishedOK: ["finished"],
-  finishedKO: ["refunded"],
+export const operationStatusList: Record<"finishedOK" | "finishedKO", readonly string[]> = {
+  finishedOK: [TransactionStatus.Finished],
+  finishedKO: [TransactionStatus.Refunded],
 };
 
 // A swap operation is considered pending if it is not in a finishedOK or finishedKO state

--- a/libs/ledger-live-common/src/exchange/swap/mock.ts
+++ b/libs/ledger-live-common/src/exchange/swap/mock.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from "bignumber.js";
+import { TransactionStatus } from "@ledgerhq/wallet-api-exchange-module";
 import { getAccountCurrency } from "../../account";
 import { formatCurrencyUnit } from "../../currencies";
 import { SwapExchangeRateAmountTooHigh, SwapExchangeRateAmountTooLow } from "../../errors";
@@ -188,7 +189,7 @@ export const mockGetProviders: GetProviders = async () => {
 export const mockGetStatus: GetMultipleStatus = async statusList => {
   //Fake delay to show loading UI
   await new Promise(r => setTimeout(r, 800));
-  return statusList.map(s => ({ ...s, status: "finished", finalAmount: undefined }));
+  return statusList.map(s => ({ ...s, status: TransactionStatus.Finished, finalAmount: undefined }));
 };
 
 export const mockPostSwapAccepted: PostSwapAccepted = async ({

--- a/libs/ledger-live-common/src/exchange/swap/providersRequiringOperationId.ts
+++ b/libs/ledger-live-common/src/exchange/swap/providersRequiringOperationId.ts
@@ -1,0 +1,11 @@
+const PROVIDERS_REQUIRING_OPERATION_ID: ReadonlySet<string> = new Set([
+  "thorswap",
+  "lifi",
+  "nearintents",
+  "swapsxyz",
+  "moonpay_trade",
+]);
+
+export function swapProviderRequiresOperationId(provider: string): boolean {
+  return PROVIDERS_REQUIRING_OPERATION_ID.has(provider);
+}

--- a/libs/ledger-live-common/src/exchange/swap/types.ts
+++ b/libs/ledger-live-common/src/exchange/swap/types.ts
@@ -4,6 +4,7 @@ import { Account, AccountLike, AccountRaw, AccountRawLike, Operation } from "@le
 import { BigNumber } from "bignumber.js";
 import { Result as UseBridgeTransactionResult } from "../../bridge/useBridgeTransaction";
 import { Transaction } from "../../coin-modules/transaction-types";
+import type { TransactionStatusValue } from "@ledgerhq/wallet-api-exchange-module";
 
 export type { SwapLiveError } from "@ledgerhq/wallet-api-exchange-module";
 
@@ -165,7 +166,7 @@ export type GetExchangeRates = (
   exchangeObject: ExchangeObject,
 ) => Promise<(ExchangeRate & { expirationDate?: Date })[]>;
 
-type ValidSwapStatus = "pending" | "onhold" | "expired" | "finished" | "refunded";
+type ValidSwapStatus = TransactionStatusValue;
 
 export type SwapStatusRequest = {
   provider: string;

--- a/libs/ledger-live-common/src/exchange/swap/updateAccountSwapStatus.ts
+++ b/libs/ledger-live-common/src/exchange/swap/updateAccountSwapStatus.ts
@@ -4,14 +4,8 @@ import { getMultipleStatus } from "./getStatus";
 import type { TokenAccount, Account, SwapOperation, Operation } from "@ledgerhq/types-live";
 import type { SwapStatus, SwapStatusRequest, UpdateAccountSwapStatus } from "./types";
 import { log } from "@ledgerhq/logs";
-
-const PROVIDERS_REQUIRING_OPERATION_ID = [
-  "thorswap",
-  "lifi",
-  "nearintents",
-  "swapsxyz",
-  "moonpay_trade",
-];
+import { swapProviderRequiresOperationId } from "./providersRequiringOperationId";
+import { TransactionStatus } from "@ledgerhq/wallet-api-exchange-module";
 
 const maybeGetUpdatedSwapHistory = async (
   swapHistory: SwapOperation[] | null | undefined,
@@ -34,10 +28,12 @@ const maybeGetUpdatedSwapHistory = async (
           const operation = operations?.find(o => o.id.includes(operationId));
           if (operation) {
             let newStatus;
-            if (operation.blockHeight) {
-              newStatus = operation.hasFailed ? "refunded" : "finished";
+            if (operation.blockHeight != null) {
+              newStatus = operation.hasFailed
+                ? TransactionStatus.Refunded
+                : TransactionStatus.Finished;
             } else {
-              newStatus = "pending";
+              newStatus = TransactionStatus.Pending;
             }
             if (newStatus !== swap.status) {
               accountNeedsUpdating = true;
@@ -47,7 +43,7 @@ const maybeGetUpdatedSwapHistory = async (
           }
         } else {
           // Collect all others swaps that need status update via getMultipleStatus
-          const requiresOperationId = PROVIDERS_REQUIRING_OPERATION_ID.includes(provider);
+          const requiresOperationId = swapProviderRequiresOperationId(provider);
           const relatedTransactionId = requiresOperationId
             ? operations?.find(op => op.id.includes(operationId))?.hash
             : undefined;

--- a/libs/ledger-live-common/src/exchange/transactionStatus/fetchSwapStatus.test.ts
+++ b/libs/ledger-live-common/src/exchange/transactionStatus/fetchSwapStatus.test.ts
@@ -1,0 +1,58 @@
+import { getMultipleStatus } from "../swap/getStatus";
+import { fetchTransactionSwapStatus } from "./fetchSwapStatus";
+
+jest.mock("../swap/getStatus", () => ({
+  getMultipleStatus: jest.fn(),
+}));
+
+const mockGetMultipleStatus = getMultipleStatus as jest.MockedFunction<typeof getMultipleStatus>;
+
+describe("fetchTransactionSwapStatus", () => {
+  beforeEach(() => {
+    mockGetMultipleStatus.mockReset();
+  });
+
+  it("calls the batch status endpoint for a single swap id", async () => {
+    mockGetMultipleStatus.mockResolvedValueOnce([
+      { provider: "lifi", swapId: "swap-1", status: "finished" },
+    ]);
+
+    await expect(
+      fetchTransactionSwapStatus({ provider: "lifi", swapId: "swap-1" }),
+    ).resolves.toEqual({ provider: "lifi", swapId: "swap-1", status: "finished" });
+
+    expect(mockGetMultipleStatus).toHaveBeenCalledWith([
+      { provider: "lifi", swapId: "swap-1" },
+    ]);
+  });
+
+  it("forwards optional transaction and operation ids", async () => {
+    mockGetMultipleStatus.mockResolvedValueOnce([
+      { provider: "lifi", swapId: "swap-1", status: "pending" },
+    ]);
+
+    await fetchTransactionSwapStatus({
+      provider: "lifi",
+      swapId: "swap-1",
+      transactionId: "0xhash",
+      operationId: "operation-id",
+    });
+
+    expect(mockGetMultipleStatus).toHaveBeenCalledWith([
+      {
+        provider: "lifi",
+        swapId: "swap-1",
+        transactionId: "0xhash",
+        operationId: "operation-id",
+      },
+    ]);
+  });
+
+  it("returns undefined when the backend returns no row", async () => {
+    mockGetMultipleStatus.mockResolvedValueOnce([]);
+
+    await expect(
+      fetchTransactionSwapStatus({ provider: "lifi", swapId: "swap-1" }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/libs/ledger-live-common/src/exchange/transactionStatus/fetchSwapStatus.ts
+++ b/libs/ledger-live-common/src/exchange/transactionStatus/fetchSwapStatus.ts
@@ -1,0 +1,9 @@
+import { getMultipleStatus } from "../swap/getStatus";
+import type { SwapStatus, SwapStatusRequest } from "../swap/types";
+
+export async function fetchTransactionSwapStatus(
+  request: SwapStatusRequest,
+): Promise<SwapStatus | undefined> {
+  const [status] = await getMultipleStatus([request]);
+  return status;
+}

--- a/libs/ledger-live-common/src/exchange/transactionStatus/fromSwapOperation.test.ts
+++ b/libs/ledger-live-common/src/exchange/transactionStatus/fromSwapOperation.test.ts
@@ -1,0 +1,36 @@
+import BigNumber from "bignumber.js";
+import type { Account, Operation } from "@ledgerhq/types-live";
+import type { MappedSwapOperation } from "../swap/types";
+import { fromSwapOperation } from "./fromSwapOperation";
+
+function makeAccount(id: string): Account {
+  return { type: "Account", id } as unknown as Account;
+}
+
+describe("fromSwapOperation", () => {
+  it("maps a swap-history operation to the reduced transaction status request", () => {
+    const operation = {
+      hash: "0xhash",
+      fee: new BigNumber("21000"),
+      date: new Date("2026-01-02T03:04:05.000Z"),
+    } as unknown as Operation;
+
+    const mapped: MappedSwapOperation = {
+      provider: "lifi",
+      swapId: "swap-1",
+      status: "finished",
+      fromAccount: makeAccount("from"),
+      toAccount: makeAccount("to"),
+      toExists: true,
+      operation,
+      fromAmount: new BigNumber("-100000"),
+      toAmount: new BigNumber("200000"),
+      finalAmount: new BigNumber("250000"),
+    };
+
+    expect(fromSwapOperation(mapped)).toEqual({
+      swapId: "swap-1",
+      provider: "lifi",
+    });
+  });
+});

--- a/libs/ledger-live-common/src/exchange/transactionStatus/fromSwapOperation.ts
+++ b/libs/ledger-live-common/src/exchange/transactionStatus/fromSwapOperation.ts
@@ -1,0 +1,13 @@
+import type { MappedSwapOperation } from "../swap/types";
+import type { SwapTransactionStatusParams } from "./types";
+
+export function fromSwapOperation(
+  mappedSwapOperation: MappedSwapOperation,
+): SwapTransactionStatusParams {
+  const { provider, swapId } = mappedSwapOperation;
+
+  return {
+    swapId,
+    provider,
+  };
+}

--- a/libs/ledger-live-common/src/exchange/transactionStatus/index.ts
+++ b/libs/ledger-live-common/src/exchange/transactionStatus/index.ts
@@ -1,0 +1,6 @@
+export * from "./fetchSwapStatus";
+export * from "./fromSwapOperation";
+export * from "./parseParams";
+export * from "./statusController";
+export * from "./statusValues";
+export * from "./types";

--- a/libs/ledger-live-common/src/exchange/transactionStatus/parseParams.test.ts
+++ b/libs/ledger-live-common/src/exchange/transactionStatus/parseParams.test.ts
@@ -1,0 +1,56 @@
+import { parseSwapTransactionStatusParams, sanitizeRedirectUrl } from "./parseParams";
+
+describe("sanitizeRedirectUrl", () => {
+  it("keeps https and internal deeplink urls", () => {
+    expect(sanitizeRedirectUrl("https://ledger.com/swap")).toBe("https://ledger.com/swap");
+    expect(sanitizeRedirectUrl("ledgerlive://swap/history")).toBe("ledgerlive://swap/history");
+    expect(sanitizeRedirectUrl("ledgerwallet://open")).toBe("ledgerwallet://open");
+  });
+
+  it("drops unsafe or malformed urls", () => {
+    expect(sanitizeRedirectUrl("javascript:alert(1)")).toBeUndefined();
+    expect(sanitizeRedirectUrl("/relative")).toBeUndefined();
+    expect(sanitizeRedirectUrl("not a url")).toBeUndefined();
+  });
+});
+
+describe("parseSwapTransactionStatusParams", () => {
+  it("parses the minimal swap deeplink payload", () => {
+    expect(
+      parseSwapTransactionStatusParams({
+        swapId: "swap-1",
+        provider: "changelly_v2",
+      }),
+    ).toEqual({
+      ok: true,
+      params: {
+        swapId: "swap-1",
+        provider: "changelly_v2",
+        redirectUrl: undefined,
+      },
+    });
+  });
+
+  it("allows provider to be omitted and trims optional public fields", () => {
+    expect(
+      parseSwapTransactionStatusParams({
+        swapId: " swap-1 ",
+        redirectUrl: " https://example.com/continue ",
+      }),
+    ).toEqual({
+      ok: true,
+      params: {
+        swapId: "swap-1",
+        provider: undefined,
+        redirectUrl: "https://example.com/continue",
+      },
+    });
+  });
+
+  it("rejects missing required fields", () => {
+    expect(parseSwapTransactionStatusParams({ provider: "lifi" })).toMatchObject({
+      ok: false,
+      error: { code: "missing_swap_id" },
+    });
+  });
+});

--- a/libs/ledger-live-common/src/exchange/transactionStatus/parseParams.ts
+++ b/libs/ledger-live-common/src/exchange/transactionStatus/parseParams.ts
@@ -1,0 +1,62 @@
+import type { SwapStatus } from "../swap/types";
+import type {
+  SwapTransactionStatusParseResult,
+  SwapTransactionStatusParamsError,
+  SwapTransactionStatusRawParams,
+} from "./types";
+import { isTransactionStatusValue } from "./statusValues";
+
+const ALLOWED_REDIRECT_PROTOCOLS = new Set(["https:", "ledgerlive:", "ledgerwallet:"]);
+
+function error(
+  code: SwapTransactionStatusParamsError["code"],
+  message: string,
+  value?: string,
+): SwapTransactionStatusParseResult {
+  return { ok: false, error: { code, message, value } };
+}
+
+export function sanitizeRedirectUrl(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return undefined;
+  }
+
+  if (!ALLOWED_REDIRECT_PROTOCOLS.has(parsed.protocol)) {
+    return undefined;
+  }
+  return trimmed;
+}
+
+export function isValidSwapStatus(status: string): status is SwapStatus["status"] {
+  return isTransactionStatusValue(status);
+}
+
+export function parseSwapTransactionStatusParams(
+  raw: SwapTransactionStatusRawParams,
+): SwapTransactionStatusParseResult {
+  const swapId = raw.swapId?.trim();
+  if (!swapId) {
+    return error("missing_swap_id", "Missing swapId", raw.swapId);
+  }
+
+  return {
+    ok: true,
+    params: {
+      swapId,
+      provider: optionalTrim(raw.provider),
+      redirectUrl: sanitizeRedirectUrl(raw.redirectUrl),
+    },
+  };
+}
+
+function optionalTrim(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}

--- a/libs/ledger-live-common/src/exchange/transactionStatus/statusController.test.ts
+++ b/libs/ledger-live-common/src/exchange/transactionStatus/statusController.test.ts
@@ -1,0 +1,236 @@
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import type { SwapStatus } from "../swap/types";
+import {
+  createInitialSwapTransactionStatusState,
+  getSendSwapStatus,
+  getSwapTransactionLegStatuses,
+  getSwapTransactionLegStatusesFromAccounts,
+  isTerminalSwapStatus,
+  shouldPollSwapTransactionStatus,
+  swapTransactionStatusReducer,
+} from "./statusController";
+
+const pending: SwapStatus = { provider: "lifi", swapId: "swap-1", status: "pending" };
+const finished: SwapStatus = { provider: "lifi", swapId: "swap-1", status: "finished" };
+const refunded: SwapStatus = { provider: "lifi", swapId: "swap-1", status: "refunded" };
+const unknown: SwapStatus = { provider: "uniswap", swapId: "swap-1", status: "unknown" };
+
+describe("isTerminalSwapStatus", () => {
+  it("classifies terminal swap statuses", () => {
+    expect(isTerminalSwapStatus("finished")).toBe(true);
+    expect(isTerminalSwapStatus("refunded")).toBe(true);
+    expect(isTerminalSwapStatus("expired")).toBe(true);
+    expect(isTerminalSwapStatus("pending")).toBe(false);
+    expect(isTerminalSwapStatus("onhold")).toBe(false);
+    expect(isTerminalSwapStatus("unknown")).toBe(false);
+  });
+});
+
+describe("shouldPollSwapTransactionStatus", () => {
+  it("polls only for pending status", () => {
+    expect(shouldPollSwapTransactionStatus(undefined)).toBe(false);
+    expect(shouldPollSwapTransactionStatus("pending")).toBe(true);
+    expect(shouldPollSwapTransactionStatus("onhold")).toBe(false);
+    expect(shouldPollSwapTransactionStatus("unknown")).toBe(false);
+    expect(shouldPollSwapTransactionStatus("finished")).toBe(false);
+    expect(shouldPollSwapTransactionStatus("refunded")).toBe(false);
+    expect(shouldPollSwapTransactionStatus("expired")).toBe(false);
+  });
+});
+
+describe("getSendSwapStatus", () => {
+  const makeAccounts = ({
+    blockHeight,
+    hasFailed,
+  }: {
+    blockHeight?: number | null;
+    hasFailed?: boolean;
+  }) => {
+    const account = genAccount("swap-status-account", { operationsSize: 1 });
+    account.operations[0] = {
+      ...account.operations[0],
+      hash: "0xabc",
+      blockHeight,
+      hasFailed,
+    };
+    return [account];
+  };
+
+  it("returns finished for a confirmed successful operation", () => {
+    expect(getSendSwapStatus(makeAccounts({ blockHeight: 123, hasFailed: false }), "0xabc")).toBe(
+      "finished",
+    );
+  });
+
+  it("returns refunded for a confirmed failed operation", () => {
+    expect(getSendSwapStatus(makeAccounts({ blockHeight: 123, hasFailed: true }), "0xabc")).toBe(
+      "refunded",
+    );
+  });
+
+  it("returns pending while the operation is unconfirmed", () => {
+    expect(getSendSwapStatus(makeAccounts({ blockHeight: null, hasFailed: true }), "0xabc")).toBe(
+      "pending",
+    );
+  });
+
+  it("does not return a status without a matching operation hash", () => {
+    expect(getSendSwapStatus(makeAccounts({ blockHeight: 123 }), "0xdef")).toBe(undefined);
+    expect(getSendSwapStatus(makeAccounts({ blockHeight: 123 }), undefined)).toBe(undefined);
+  });
+
+  it("derives leg statuses from local send status and provider status", () => {
+    expect(
+      getSwapTransactionLegStatuses({ sendStatus: "finished", providerStatus: "unknown" }),
+    ).toEqual({
+      sendStatus: "finished",
+      receiveStatus: "unknown",
+    });
+
+    expect(
+      getSwapTransactionLegStatuses({ sendStatus: "refunded", providerStatus: "unknown" }),
+    ).toEqual({
+      sendStatus: "refunded",
+      receiveStatus: "refunded",
+    });
+
+    expect(
+      getSwapTransactionLegStatuses({ sendStatus: undefined, providerStatus: "pending" }),
+    ).toEqual({
+      sendStatus: "pending",
+      receiveStatus: "pending",
+    });
+  });
+
+  it("derives leg statuses from accounts", () => {
+    expect(
+      getSwapTransactionLegStatusesFromAccounts({
+        accounts: makeAccounts({ blockHeight: 123, hasFailed: false }),
+        operationHash: "0xabc",
+        providerStatus: "unknown",
+      }),
+    ).toEqual({
+      sendStatus: "finished",
+      receiveStatus: "unknown",
+    });
+  });
+});
+
+describe("createInitialSwapTransactionStatusState", () => {
+  it("starts hidden for cold deeplinks without known status", () => {
+    expect(createInitialSwapTransactionStatusState()).toEqual({
+      phase: "polling_hidden",
+      shouldAutoRedirect: false,
+    });
+  });
+
+  it("starts visible for known pending history entries", () => {
+    expect(createInitialSwapTransactionStatusState(pending)).toEqual({
+      phase: "polling_visible",
+      latestStatus: pending,
+      shouldAutoRedirect: false,
+    });
+  });
+
+  it("starts settled for known terminal history entries", () => {
+    expect(createInitialSwapTransactionStatusState(refunded)).toEqual({
+      phase: "settled_visible",
+      latestStatus: refunded,
+      shouldAutoRedirect: false,
+    });
+  });
+});
+
+describe("swapTransactionStatusReducer", () => {
+  it("auto-redirects when terminal status arrives while hidden", () => {
+    const state = swapTransactionStatusReducer(createInitialSwapTransactionStatusState(), {
+      type: "POLL_SUCCEEDED",
+      status: finished,
+    });
+
+    expect(state).toEqual({
+      phase: "polling_hidden",
+      latestStatus: finished,
+      shouldAutoRedirect: true,
+    });
+  });
+
+  it("reveals pending UI after the soft deadline", () => {
+    expect(
+      swapTransactionStatusReducer(createInitialSwapTransactionStatusState(), {
+        type: "SOFT_DEADLINE_REACHED",
+      }),
+    ).toEqual({
+      phase: "polling_visible",
+      shouldAutoRedirect: false,
+    });
+  });
+
+  it("reveals settled UI after the soft deadline if a terminal status already arrived", () => {
+    const hiddenTerminal = swapTransactionStatusReducer(createInitialSwapTransactionStatusState(), {
+      type: "POLL_SUCCEEDED",
+      status: finished,
+    });
+
+    expect(
+      swapTransactionStatusReducer(hiddenTerminal, {
+        type: "SOFT_DEADLINE_REACHED",
+      }),
+    ).toEqual({
+      phase: "settled_visible",
+      latestStatus: finished,
+      shouldAutoRedirect: false,
+    });
+  });
+
+  it("settles visible pending UI when a terminal poll arrives", () => {
+    const visible = swapTransactionStatusReducer(createInitialSwapTransactionStatusState(), {
+      type: "SOFT_DEADLINE_REACHED",
+    });
+
+    expect(
+      swapTransactionStatusReducer(visible, {
+        type: "POLL_SUCCEEDED",
+        status: finished,
+      }),
+    ).toEqual({
+      phase: "settled_visible",
+      latestStatus: finished,
+      shouldAutoRedirect: false,
+    });
+  });
+
+  it("keeps visible UI pending for non-terminal polls", () => {
+    const visible = swapTransactionStatusReducer(createInitialSwapTransactionStatusState(), {
+      type: "SOFT_DEADLINE_REACHED",
+    });
+
+    expect(
+      swapTransactionStatusReducer(visible, {
+        type: "POLL_SUCCEEDED",
+        status: pending,
+      }),
+    ).toEqual({
+      phase: "polling_visible",
+      latestStatus: pending,
+      shouldAutoRedirect: false,
+    });
+  });
+
+  it("keeps visible UI pending for unknown status", () => {
+    const visible = swapTransactionStatusReducer(createInitialSwapTransactionStatusState(), {
+      type: "SOFT_DEADLINE_REACHED",
+    });
+
+    expect(
+      swapTransactionStatusReducer(visible, {
+        type: "POLL_SUCCEEDED",
+        status: unknown,
+      }),
+    ).toEqual({
+      phase: "polling_visible",
+      latestStatus: unknown,
+      shouldAutoRedirect: false,
+    });
+  });
+});

--- a/libs/ledger-live-common/src/exchange/transactionStatus/statusController.ts
+++ b/libs/ledger-live-common/src/exchange/transactionStatus/statusController.ts
@@ -1,0 +1,168 @@
+import type { AccountLike } from "@ledgerhq/types-live";
+import { TransactionStatus } from "@ledgerhq/wallet-api-exchange-module";
+import type { SwapStatus } from "../swap/types";
+
+export type SwapTransactionStatusPhase = "polling_hidden" | "polling_visible" | "settled_visible";
+
+const TERMINAL_SWAP_STATUSES: ReadonlySet<SwapStatus["status"]> = new Set([
+  TransactionStatus.Finished,
+  TransactionStatus.Refunded,
+  TransactionStatus.Expired,
+]);
+
+export function isTerminalSwapStatus(status: SwapStatus["status"]): boolean {
+  return TERMINAL_SWAP_STATUSES.has(status);
+}
+
+export function shouldPollSwapTransactionStatus(status: SwapStatus["status"] | undefined): boolean {
+  return status === TransactionStatus.Pending;
+}
+
+type SendSwapStatusValue =
+  | typeof TransactionStatus.Pending
+  | typeof TransactionStatus.Finished
+  | typeof TransactionStatus.Refunded;
+
+export type SendSwapStatus = Extract<SwapStatus["status"], SendSwapStatusValue>;
+
+export type SwapTransactionLegStatuses = {
+  sendStatus?: SwapStatus["status"];
+  receiveStatus?: SwapStatus["status"];
+};
+
+export function getSendSwapStatus(
+  accounts: AccountLike[],
+  operationHash: string | undefined,
+): SendSwapStatus | undefined {
+  if (!operationHash) return undefined;
+
+  for (const account of accounts) {
+    const operation = [...(account.operations ?? []), ...(account.pendingOperations ?? [])].find(
+      operation => operation.hash === operationHash,
+    );
+    if (operation) {
+      if (operation.blockHeight != null) {
+        return operation.hasFailed ? TransactionStatus.Refunded : TransactionStatus.Finished;
+      }
+      return TransactionStatus.Pending;
+    }
+  }
+
+  return undefined;
+}
+
+export function getSwapTransactionLegStatuses({
+  providerStatus,
+  sendStatus,
+}: {
+  providerStatus: SwapStatus["status"] | undefined;
+  sendStatus: SendSwapStatus | undefined;
+}): SwapTransactionLegStatuses {
+  if (sendStatus === TransactionStatus.Refunded) {
+    return {
+      sendStatus,
+      receiveStatus: TransactionStatus.Refunded,
+    };
+  }
+
+  return {
+    sendStatus: sendStatus ?? providerStatus,
+    receiveStatus: providerStatus,
+  };
+}
+
+export function getSwapTransactionLegStatusesFromAccounts({
+  accounts,
+  operationHash,
+  providerStatus,
+}: {
+  accounts: AccountLike[];
+  operationHash: string | undefined;
+  providerStatus: SwapStatus["status"] | undefined;
+}): SwapTransactionLegStatuses {
+  return getSwapTransactionLegStatuses({
+    providerStatus,
+    sendStatus: getSendSwapStatus(accounts, operationHash),
+  });
+}
+
+export type SwapTransactionStatusControllerState = {
+  phase: SwapTransactionStatusPhase;
+  latestStatus?: SwapStatus;
+  shouldAutoRedirect: boolean;
+};
+
+export type SwapTransactionStatusControllerEvent =
+  | { type: "POLL_SUCCEEDED"; status: SwapStatus }
+  | { type: "SOFT_DEADLINE_REACHED" };
+
+export function createInitialSwapTransactionStatusState(
+  initialStatus?: SwapStatus,
+): SwapTransactionStatusControllerState {
+  if (!initialStatus) {
+    return {
+      phase: "polling_hidden",
+      shouldAutoRedirect: false,
+    };
+  }
+
+  return {
+    phase: isTerminalSwapStatus(initialStatus.status) ? "settled_visible" : "polling_visible",
+    latestStatus: initialStatus,
+    shouldAutoRedirect: false,
+  };
+}
+
+export const INITIAL_SWAP_TRANSACTION_STATUS_STATE = createInitialSwapTransactionStatusState();
+
+export function swapTransactionStatusReducer(
+  state: SwapTransactionStatusControllerState,
+  event: SwapTransactionStatusControllerEvent,
+): SwapTransactionStatusControllerState {
+  switch (event.type) {
+    case "POLL_SUCCEEDED": {
+      const isTerminal = isTerminalSwapStatus(event.status.status);
+
+      if (state.phase === "polling_hidden") {
+        if (isTerminal) {
+          return {
+            ...state,
+            latestStatus: event.status,
+            shouldAutoRedirect: true,
+          };
+        }
+        return { ...state, latestStatus: event.status };
+      }
+
+      if (state.phase === "polling_visible" && isTerminal) {
+        return {
+          phase: "settled_visible",
+          latestStatus: event.status,
+          shouldAutoRedirect: false,
+        };
+      }
+
+      return { ...state, latestStatus: event.status };
+    }
+
+    case "SOFT_DEADLINE_REACHED": {
+      if (state.phase !== "polling_hidden") return state;
+      if (state.latestStatus && isTerminalSwapStatus(state.latestStatus.status)) {
+        return {
+          ...state,
+          phase: "settled_visible",
+          shouldAutoRedirect: false,
+        };
+      }
+      return { ...state, phase: "polling_visible", shouldAutoRedirect: false };
+    }
+
+    default: {
+      return assertNever(event);
+    }
+  }
+}
+
+function assertNever(event: never): never {
+  throw new Error(`Unsupported swap transaction status event: ${JSON.stringify(event)}`);
+}

--- a/libs/ledger-live-common/src/exchange/transactionStatus/statusValues.ts
+++ b/libs/ledger-live-common/src/exchange/transactionStatus/statusValues.ts
@@ -1,0 +1,9 @@
+import { TransactionStatus } from "@ledgerhq/wallet-api-exchange-module";
+import type { TransactionStatusValue } from "@ledgerhq/wallet-api-exchange-module";
+
+// Built from `Object.values` so it stays in sync if a new TransactionStatus member is added.
+const TRANSACTION_STATUS_VALUES: ReadonlySet<string> = new Set(Object.values(TransactionStatus));
+
+export function isTransactionStatusValue(status: string): status is TransactionStatusValue {
+  return TRANSACTION_STATUS_VALUES.has(status);
+}

--- a/libs/ledger-live-common/src/exchange/transactionStatus/types.ts
+++ b/libs/ledger-live-common/src/exchange/transactionStatus/types.ts
@@ -1,0 +1,23 @@
+export type SwapTransactionStatusRawParams = {
+  swapId?: string;
+  provider?: string;
+  redirectUrl?: string;
+};
+
+export type SwapTransactionStatusParams = {
+  swapId: string;
+  provider?: string;
+  redirectUrl?: string;
+};
+
+export type SwapTransactionStatusParamsErrorCode = "missing_swap_id";
+
+export type SwapTransactionStatusParamsError = {
+  code: SwapTransactionStatusParamsErrorCode;
+  value?: string;
+  message: string;
+};
+
+export type SwapTransactionStatusParseResult =
+  | { ok: true; params: SwapTransactionStatusParams }
+  | { ok: false; error: SwapTransactionStatusParamsError };

--- a/libs/ledger-live-common/src/wallet-api/Exchange/index.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/index.ts
@@ -26,3 +26,7 @@ export {
 // Swap quotes (Wallet API getQuotes; HTTP-only fetch stays internal to `quotes/getQuotes`)
 export { getQuotes } from "./quotes";
 export type * from "./quotes";
+
+// Swap transaction status (Wallet API getTransactionStatus)
+export { getTransactionStatus } from "./transactionStatus";
+export type * from "./transactionStatus";

--- a/libs/ledger-live-common/src/wallet-api/Exchange/server.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/server.test.ts
@@ -125,6 +125,14 @@ jest.mock("../../exchange/swap/api/v5/actions", () => ({
   }),
 }));
 
+jest.mock("./transactionStatus", () => ({
+  getTransactionStatus: jest.fn().mockResolvedValue({
+    swapId: "swap-1",
+    provider: "lifi",
+    status: "pending",
+  }),
+}));
+
 jest.mock("../../exchange/swap/transactionStrategies", () => ({
   transactionStrategy: {
     bitcoin: jest.fn().mockResolvedValue({
@@ -345,6 +353,46 @@ describe("handlers", () => {
       );
       expect(networkCall).toBeDefined();
       expect((networkCall![0] as { url: string }).url).toContain("/swap/accepted");
+    });
+  });
+
+  describe("custom.exchange.getTransactionStatus", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("delegates to getTransactionStatus with wallet accounts context", async () => {
+      const accounts = [genAccount("accountId1")];
+      const handler = handlers({
+        accounts,
+        tracking: mockTracking,
+        manifest: testAppManifest,
+        locale: "en-US",
+        counterValueCurrency: "USD",
+        uiHooks: mockUiHooks,
+      });
+      const request = {
+        jsonrpc: "2.0",
+        method: "custom.exchange.getTransactionStatus",
+        params: { swapId: "swap-1", provider: "lifi" },
+        id: "test",
+      } as RpcRequest<string, { swapId: string; provider?: string }>;
+      const context = {
+        config: { userId: "u", tracking: false, wallet: { name: "w", version: "2" }, appId: "a" },
+      };
+
+      const result = await handler["custom.exchange.getTransactionStatus"](request, context, {});
+
+      const { getTransactionStatus } = jest.requireMock("./transactionStatus");
+      expect(result).toEqual({
+        swapId: "swap-1",
+        provider: "lifi",
+        status: "pending",
+      });
+      expect(getTransactionStatus).toHaveBeenCalledWith(
+        { swapId: "swap-1", provider: "lifi" },
+        { accounts },
+      );
     });
   });
 

--- a/libs/ledger-live-common/src/wallet-api/Exchange/server.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/server.ts
@@ -64,6 +64,11 @@ import { SwapError } from "./SwapError";
 import { getQuotes } from "./quotes";
 import { resolveQuotesInput } from "./quotes/resolveQuotesInput";
 import { fetchSpotPrices } from "./quotes/service/fetchSpotPrices";
+import {
+  getTransactionStatus,
+  type GetTransactionStatusResponse,
+  type GetTransactionStatusWireArgs,
+} from "./transactionStatus";
 
 export { ExchangeType };
 
@@ -77,6 +82,10 @@ type Handlers = {
   "custom.isReady": RPCHandler<void, void>;
   "custom.exchange.swap": RPCHandler<SwapResult, ExchangeSwapParams>;
   "custom.exchange.getQuotes": RPCHandler<GetQuotesResponse, GetQuotesWireArgs>;
+  "custom.exchange.getTransactionStatus": RPCHandler<
+    GetTransactionStatusResponse,
+    GetTransactionStatusWireArgs
+  >;
 };
 
 export type CompleteExchangeUiRequest = {
@@ -790,6 +799,16 @@ export const handlers = ({
         });
       },
     ),
+
+    "custom.exchange.getTransactionStatus": customWrapper<
+      GetTransactionStatusWireArgs,
+      GetTransactionStatusResponse
+    >(async params => {
+      if (!params) {
+        throw new ServerError(createUnknownError({ message: "params is undefined" }));
+      }
+      return getTransactionStatus(params, { accounts });
+    }),
   }) as const satisfies Handlers;
 
 async function extractSwapStartParam(

--- a/libs/ledger-live-common/src/wallet-api/Exchange/transactionStatus/getTransactionStatus.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/transactionStatus/getTransactionStatus.test.ts
@@ -1,0 +1,275 @@
+import BigNumber from "bignumber.js";
+import type { Account, Operation } from "@ledgerhq/types-live";
+import type { MappedSwapOperation } from "../../../exchange/swap/types";
+import getCompleteSwapHistory from "../../../exchange/swap/getCompleteSwapHistory";
+import { fetchTransactionSwapStatus } from "../../../exchange/transactionStatus/fetchSwapStatus";
+import { getTransactionStatus } from "./getTransactionStatus";
+
+jest.mock("../../../exchange/swap/getCompleteSwapHistory", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock("../../../exchange/transactionStatus/fetchSwapStatus", () => ({
+  fetchTransactionSwapStatus: jest.fn(),
+}));
+
+const mockedGetCompleteSwapHistory = jest.mocked(getCompleteSwapHistory);
+const mockedFetchTransactionSwapStatus = jest.mocked(fetchTransactionSwapStatus);
+
+function makeAccount(id: string): Account {
+  return {
+    type: "Account",
+    id,
+    subAccounts: [],
+    operations: [],
+    pendingOperations: [],
+    currency: {
+      type: "CryptoCurrency",
+      id: `${id}-currency`,
+      units: [{ code: "TEST", magnitude: 8, name: "TEST" }],
+    },
+  } as unknown as Account;
+}
+
+function makeAccountWithOperation(operation: Operation): Account {
+  return {
+    ...makeAccount("from"),
+    operations: [operation],
+  };
+}
+
+function makeOperation(overrides: Partial<Operation> = {}): Operation {
+  return {
+    id: "operation-id",
+    hash: "0xhash",
+    fee: new BigNumber("21000"),
+    date: new Date("2026-01-02T03:04:05.000Z"),
+    ...overrides,
+  } as unknown as Operation;
+}
+
+function makeSwapOperation(overrides: Partial<MappedSwapOperation> = {}): MappedSwapOperation {
+  const operation = makeOperation();
+
+  return {
+    provider: "lifi",
+    swapId: "swap-1",
+    status: "pending",
+    fromAccount: makeAccount("from"),
+    toAccount: makeAccount("to"),
+    toExists: true,
+    operation,
+    fromAmount: new BigNumber("-100000"),
+    toAmount: new BigNumber("200000"),
+    finalAmount: new BigNumber("250000"),
+    ...overrides,
+  };
+}
+
+describe("getTransactionStatus", () => {
+  beforeEach(() => {
+    mockedGetCompleteSwapHistory.mockReset();
+    mockedFetchTransactionSwapStatus.mockReset();
+  });
+
+  it("resolves provider and display details from wallet swap history, normalizing remote final amount", async () => {
+    mockedGetCompleteSwapHistory.mockResolvedValueOnce([
+      { day: new Date("2026-01-02"), data: [makeSwapOperation()] },
+    ]);
+    mockedFetchTransactionSwapStatus.mockResolvedValueOnce({
+      provider: "lifi",
+      swapId: "swap-1",
+      status: "finished",
+      finalAmount: "0.003",
+    });
+
+    await expect(
+      getTransactionStatus({ swapId: "swap-1" }, { accounts: [makeAccount("from")] }),
+    ).resolves.toEqual({
+      swapId: "swap-1",
+      provider: "lifi",
+      status: "finished",
+      sendStatus: "finished",
+      receiveStatus: "finished",
+      finalAmount: "300000",
+      fromAccountId: "from",
+      toAccountId: "to",
+      sentAmount: "100000",
+      receivedAmount: "250000",
+      feesAmount: "21000",
+      operationHash: "0xhash",
+      createdAt: new Date("2026-01-02T03:04:05.000Z").getTime(),
+    });
+    expect(mockedFetchTransactionSwapStatus).toHaveBeenCalledWith({
+      provider: "lifi",
+      swapId: "swap-1",
+      transactionId: "0xhash",
+      operationId: "operation-id",
+    });
+  });
+
+  it("uses provider fallback when swap history cannot resolve the swap", async () => {
+    mockedGetCompleteSwapHistory.mockResolvedValueOnce([]);
+    mockedFetchTransactionSwapStatus.mockResolvedValueOnce({
+      provider: "changelly_v2",
+      swapId: "swap-1",
+      status: "pending",
+    });
+
+    await expect(
+      getTransactionStatus(
+        { swapId: "swap-1", provider: "changelly_v2" },
+        { accounts: [makeAccount("from")] },
+      ),
+    ).resolves.toEqual({
+      swapId: "swap-1",
+      provider: "changelly_v2",
+      status: "pending",
+      sendStatus: "pending",
+      receiveStatus: "pending",
+      finalAmount: undefined,
+    });
+    expect(mockedFetchTransactionSwapStatus).toHaveBeenCalledWith({
+      provider: "changelly_v2",
+      swapId: "swap-1",
+      transactionId: undefined,
+    });
+  });
+
+  it("sends operation identifiers for MoonPay trade status requests", async () => {
+    mockedGetCompleteSwapHistory.mockResolvedValueOnce([
+      {
+        day: new Date("2026-01-02"),
+        data: [makeSwapOperation({ provider: "moonpay_trade" })],
+      },
+    ]);
+    mockedFetchTransactionSwapStatus.mockResolvedValueOnce({
+      provider: "moonpay_trade",
+      swapId: "swap-1",
+      status: "pending",
+    });
+
+    await getTransactionStatus({ swapId: "swap-1" }, { accounts: [makeAccount("from")] });
+
+    expect(mockedFetchTransactionSwapStatus).toHaveBeenCalledWith({
+      provider: "moonpay_trade",
+      swapId: "swap-1",
+      transactionId: "0xhash",
+      operationId: "operation-id",
+    });
+  });
+
+  it("keeps unknown remote status as a first-class status", async () => {
+    mockedGetCompleteSwapHistory.mockResolvedValueOnce([
+      { day: new Date("2026-01-02"), data: [makeSwapOperation({ provider: "uniswap" })] },
+    ]);
+    mockedFetchTransactionSwapStatus.mockResolvedValueOnce({
+      provider: "uniswap",
+      swapId: "swap-1",
+      status: "unknown",
+    });
+
+    await expect(
+      getTransactionStatus({ swapId: "swap-1" }, { accounts: [makeAccount("from")] }),
+    ).resolves.toMatchObject({
+      swapId: "swap-1",
+      provider: "uniswap",
+      status: "unknown",
+    });
+  });
+
+  it("returns providerRequired when neither args nor history provide a provider", async () => {
+    mockedGetCompleteSwapHistory.mockResolvedValueOnce([]);
+
+    await expect(
+      getTransactionStatus({ swapId: "swap-1" }, { accounts: [makeAccount("from")] }),
+    ).resolves.toEqual({
+      swapId: "swap-1",
+      providerRequired: true,
+    });
+    expect(mockedFetchTransactionSwapStatus).not.toHaveBeenCalled();
+  });
+
+  it("keeps local history details when the remote status request fails", async () => {
+    mockedGetCompleteSwapHistory.mockResolvedValueOnce([
+      { day: new Date("2026-01-02"), data: [makeSwapOperation()] },
+    ]);
+    mockedFetchTransactionSwapStatus.mockRejectedValueOnce(new Error("HTTP 429"));
+
+    await expect(
+      getTransactionStatus({ swapId: "swap-1" }, { accounts: [makeAccount("from")] }),
+    ).resolves.toEqual({
+      swapId: "swap-1",
+      provider: "lifi",
+      status: "pending",
+      sendStatus: "pending",
+      receiveStatus: "pending",
+      finalAmount: "250000",
+      fromAccountId: "from",
+      toAccountId: "to",
+      sentAmount: "100000",
+      receivedAmount: "250000",
+      feesAmount: "21000",
+      operationHash: "0xhash",
+      createdAt: new Date("2026-01-02T03:04:05.000Z").getTime(),
+    });
+  });
+
+  it("ignores zero remote final amount so history receive amount remains visible", async () => {
+    mockedGetCompleteSwapHistory.mockResolvedValueOnce([
+      {
+        day: new Date("2026-01-02"),
+        data: [
+          makeSwapOperation({ finalAmount: new BigNumber(0), toAmount: new BigNumber("200000") }),
+        ],
+      },
+    ]);
+    mockedFetchTransactionSwapStatus.mockResolvedValueOnce({
+      provider: "lifi",
+      swapId: "swap-1",
+      status: "finished",
+      finalAmount: "0",
+    });
+
+    await expect(
+      getTransactionStatus({ swapId: "swap-1" }, { accounts: [makeAccount("from")] }),
+    ).resolves.toMatchObject({
+      status: "finished",
+      finalAmount: undefined,
+      receivedAmount: "200000",
+    });
+  });
+
+  it("keeps backend status but exposes failed local send status for row rendering", async () => {
+    const failedOperation = makeOperation({ blockHeight: 123, hasFailed: true });
+    mockedGetCompleteSwapHistory.mockResolvedValueOnce([
+      {
+        day: new Date("2026-01-02"),
+        data: [
+          makeSwapOperation({
+            provider: "uniswap",
+            operation: failedOperation,
+          }),
+        ],
+      },
+    ]);
+    mockedFetchTransactionSwapStatus.mockResolvedValueOnce({
+      provider: "uniswap",
+      swapId: "swap-1",
+      status: "unknown",
+    });
+
+    await expect(
+      getTransactionStatus(
+        { swapId: "swap-1" },
+        { accounts: [makeAccountWithOperation(failedOperation)] },
+      ),
+    ).resolves.toMatchObject({
+      provider: "uniswap",
+      status: "unknown",
+      sendStatus: "refunded",
+      receiveStatus: "refunded",
+    });
+  });
+});

--- a/libs/ledger-live-common/src/wallet-api/Exchange/transactionStatus/getTransactionStatus.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/transactionStatus/getTransactionStatus.ts
@@ -1,0 +1,155 @@
+import BigNumber from "bignumber.js";
+import type { AccountLike } from "@ledgerhq/types-live";
+import { flattenAccounts, getAccountCurrency } from "../../../account";
+import getCompleteSwapHistory from "../../../exchange/swap/getCompleteSwapHistory";
+import { swapProviderRequiresOperationId } from "../../../exchange/swap/providersRequiringOperationId";
+import {
+  getSwapTransactionLegStatusesFromAccounts,
+  isTransactionStatusValue,
+} from "../../../exchange/transactionStatus";
+import { fetchTransactionSwapStatus } from "../../../exchange/transactionStatus/fetchSwapStatus";
+import type {
+  MappedSwapOperation,
+  SwapStatus,
+  SwapStatusRequest,
+} from "../../../exchange/swap/types";
+import type {
+  GetTransactionStatusArgs,
+  GetTransactionStatusResponse,
+  TransactionStatusValue,
+} from "./types";
+
+export type GetTransactionStatusContext = {
+  accounts: AccountLike[];
+};
+
+export async function getTransactionStatus(
+  args: GetTransactionStatusArgs,
+  context: GetTransactionStatusContext,
+): Promise<GetTransactionStatusResponse> {
+  const accounts = flattenAccounts(context.accounts);
+  const swapOperation = await findSwapOperation(accounts, args.swapId);
+  const provider = swapOperation?.provider ?? args.provider;
+
+  if (!provider) {
+    return {
+      swapId: args.swapId,
+      providerRequired: true,
+    };
+  }
+
+  const remoteStatus = await fetchTransactionStatusSafely(
+    buildSwapStatusRequest({
+      provider,
+      swapId: args.swapId,
+      swapOperation,
+    }),
+  );
+  const status = remoteStatus?.status ?? getTransactionStatusValue(swapOperation?.status);
+  const legStatuses = getSwapTransactionLegStatusesFromAccounts({
+    accounts,
+    operationHash: swapOperation?.operation.hash,
+    providerStatus: status,
+  });
+
+  return {
+    swapId: args.swapId,
+    provider,
+    status,
+    ...legStatuses,
+    finalAmount:
+      getMagnitudeAwareRemoteFinalAmount(remoteStatus?.finalAmount, swapOperation) ??
+      getFinalAmount(swapOperation),
+    ...mapSwapOperation(swapOperation),
+  };
+}
+
+function getFinalAmount(swapOperation: MappedSwapOperation | undefined): string | undefined {
+  return swapOperation?.finalAmount?.isGreaterThan(0)
+    ? swapOperation.finalAmount.toFixed()
+    : undefined;
+}
+
+function isAmountGreaterThanZero(amount: string): boolean {
+  return new BigNumber(amount).isGreaterThan(0);
+}
+
+function getMagnitudeAwareRemoteFinalAmount(
+  finalAmount: string | undefined,
+  swapOperation: MappedSwapOperation | undefined,
+): string | undefined {
+  if (!finalAmount || !isAmountGreaterThanZero(finalAmount) || !swapOperation) return undefined;
+
+  const toCurrency = getAccountCurrency(swapOperation.toAccount);
+  const toMagnitude = toCurrency.units[0].magnitude;
+  return new BigNumber(finalAmount).times(new BigNumber(10).pow(toMagnitude)).toFixed();
+}
+
+function getTransactionStatusValue(status: string | undefined): TransactionStatusValue | undefined {
+  if (!status || !isTransactionStatusValue(status)) return undefined;
+  return status;
+}
+
+async function findSwapOperation(
+  accounts: AccountLike[],
+  swapId: string,
+): Promise<MappedSwapOperation | undefined> {
+  const sections = await getCompleteSwapHistory(accounts);
+  return sections.flatMap(section => section.data).find(operation => operation.swapId === swapId);
+}
+
+function buildSwapStatusRequest({
+  provider,
+  swapId,
+  swapOperation,
+}: {
+  provider: string;
+  swapId: string;
+  swapOperation: MappedSwapOperation | undefined;
+}): SwapStatusRequest {
+  const requiresOperationId = swapProviderRequiresOperationId(provider);
+  return {
+    provider,
+    swapId,
+    transactionId: requiresOperationId ? swapOperation?.operation.hash : undefined,
+    ...(requiresOperationId && swapOperation ? { operationId: swapOperation.operation.id } : {}),
+  };
+}
+
+async function fetchTransactionStatusSafely(
+  request: SwapStatusRequest,
+): Promise<SwapStatus | undefined> {
+  try {
+    return await fetchTransactionSwapStatus(request);
+  } catch {
+    return undefined;
+  }
+}
+
+function mapSwapOperation(
+  swapOperation: MappedSwapOperation | undefined,
+): Partial<GetTransactionStatusResponse> {
+  if (!swapOperation) return {};
+  const receivedAmount = swapOperation.finalAmount?.isGreaterThan(0)
+    ? swapOperation.finalAmount
+    : swapOperation.toAmount;
+  const createdAt = getOperationCreatedAt(swapOperation.operation.date);
+
+  return {
+    fromAccountId: swapOperation.fromAccount.id,
+    toAccountId: swapOperation.toAccount.id,
+    sentAmount: swapOperation.fromAmount.absoluteValue().toFixed(),
+    receivedAmount: receivedAmount.toFixed(),
+    feesAmount: swapOperation.operation.fee?.toFixed(),
+    operationHash: swapOperation.operation.hash,
+    createdAt,
+  };
+}
+
+function getOperationCreatedAt(
+  operationDate: MappedSwapOperation["operation"]["date"],
+): number | undefined {
+  if (operationDate instanceof Date) return operationDate.getTime();
+  if (typeof operationDate === "number") return operationDate;
+  return undefined;
+}

--- a/libs/ledger-live-common/src/wallet-api/Exchange/transactionStatus/index.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/transactionStatus/index.ts
@@ -1,0 +1,4 @@
+export { TransactionStatus } from "./types";
+export type * from "./types";
+export { getTransactionStatus } from "./getTransactionStatus";
+export type { GetTransactionStatusContext } from "./getTransactionStatus";

--- a/libs/ledger-live-common/src/wallet-api/Exchange/transactionStatus/types.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/transactionStatus/types.ts
@@ -1,0 +1,9 @@
+export { TransactionStatus } from "@ledgerhq/wallet-api-exchange-module";
+
+export type {
+  TransactionStatusInput,
+  TransactionStatusValue,
+  GetTransactionStatusArgs,
+  GetTransactionStatusWireArgs,
+  GetTransactionStatusResponse,
+} from "@ledgerhq/wallet-api-exchange-module";


### PR DESCRIPTION
**Jira:** https://ledgerhq.atlassian.net/browse/LIVE-29443

### Description:
Add Wallet API endpoint for Swap Transaction Status. This is groundwork for new Transaction Status screen/overlay for Swap.

<!-- stac-man:stack-start -->
**Stack** _(managed by [stac-man](https://github.com/bluegardenproject/stac-man))_

- **#17456 feat/LIVE-29443-swap-transaction-status-api ← this PR**
- #17457 feat/LIVE-29447-desktop-swap-transaction-status
- #17458 feat/LIVE-29447-mobile-swap-transaction-status
- #17552 feat/LIVE-29447-wallet-quote-sorting
- #17553 feat/LIVE-29447-best-wallet-quote
- #17696 bugfix/LIVE-24415-wallet-quote-network-fees
<!-- stac-man:stack-end -->