### PR TITLE
[LWM] feat(LIVE-29443): add mobile swap status drawer

### DIFF
--- a/.changeset/mobile-swap-status-drawer.md
+++ b/.changeset/mobile-swap-status-drawer.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add the mobile swap transaction status drawer with provider details, status tracking, and explorer links.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -241,6 +241,7 @@ apps/ledger-live-desktop/src/mvvm/features/PtxInfoDialog/                       
 apps/ledger-live-desktop/src/mvvm/features/ActionConfirmationDialog/                     @ledgerhq/ptx
 apps/ledger-live-desktop/src/mvvm/features/LiveAppModal/                                 @ledgerhq/ptx
 apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/                  @ledgerhq/ptx
+apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/                         @ledgerhq/ptx
 apps/ledger-live-mobile/src/mvvm/features/LiveAppModal/                                  @ledgerhq/ptx
 apps/ledger-live-mobile/src/mvvm/features/Borrow/                                       @ledgerhq/ptx
 apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBorrowSection   @ledgerhq/ptx

--- a/apps/ledger-live-mobile/src/GlobalDrawers/__tests__/registry.test.ts
+++ b/apps/ledger-live-mobile/src/GlobalDrawers/__tests__/registry.test.ts
@@ -2,6 +2,7 @@ import { DRAWER_REGISTRY, DRAWER_ENTRIES } from "../registry";
 import { ModularDrawerWrapper } from "LLM/features/ModularDrawer";
 import ReceiveDrawerWrapper from "LLM/features/Receive/drawers/ReceiveFundsOptionsDrawer";
 import { NotificationsPromptWrapper } from "LLM/features/NotificationsPrompt";
+import { SwapTransactionStatusDrawerWrapper } from "LLM/features/SwapTransactionStatus";
 
 describe("GlobalDrawers Registry", () => {
   it("should contain all expected drawer entries with correct components", () => {
@@ -13,6 +14,11 @@ describe("GlobalDrawers Registry", () => {
 
     expect(DRAWER_REGISTRY.notificationsPrompt).toBeDefined();
     expect(DRAWER_REGISTRY.notificationsPrompt.component).toBe(NotificationsPromptWrapper);
+
+    expect(DRAWER_REGISTRY.swapTransactionStatus).toBeDefined();
+    expect(DRAWER_REGISTRY.swapTransactionStatus.component).toBe(
+      SwapTransactionStatusDrawerWrapper,
+    );
   });
 
   it("should have all entries with valid structure", () => {

--- a/apps/ledger-live-mobile/src/GlobalDrawers/registry.ts
+++ b/apps/ledger-live-mobile/src/GlobalDrawers/registry.ts
@@ -4,6 +4,7 @@ import ReceiveDrawerWrapper from "LLM/features/Receive/drawers/ReceiveFundsOptio
 import RebornBuyDeviceDrawer from "LLM/features/Reborn/drawers/RebornBuyDeviceDrawer";
 import { DeeplinkInstallAppDrawer } from "LLM/features/DeeplinkInstallApp";
 import { NotificationsPromptWrapper } from "LLM/features/NotificationsPrompt";
+import { SwapTransactionStatusDrawerWrapper } from "LLM/features/SwapTransactionStatus";
 
 /**
  * Registry of all global drawers in the application.
@@ -32,6 +33,9 @@ export const DRAWER_REGISTRY = {
   },
   notificationsPrompt: {
     component: NotificationsPromptWrapper,
+  },
+  swapTransactionStatus: {
+    component: SwapTransactionStatusDrawerWrapper,
   },
 } as const satisfies Record<string, DrawerRegistryEntry>;
 

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -4182,6 +4182,42 @@
       "history": {
         "title": "Swap history"
       },
+      "modals": {
+        "transactionStatus": {
+          "title": "Swap {{sendTicker}} → {{receiveTicker}}",
+          "sections": {
+            "status": {
+              "heading": "Status",
+              "sendPending": "Sending {{ticker}}",
+              "sendCompleted": "Sent {{ticker}}",
+              "receivePending": "Receiving {{ticker}}",
+              "receiveCompleted": "Received {{ticker}}"
+            },
+            "details": {
+              "networkFees": "Network fees",
+              "receiveAccount": "Receive account",
+              "provider": "Provider",
+              "swapId": "Swap ID"
+            }
+          },
+          "statusLabels": {
+            "pending": "Ongoing",
+            "onhold": "On hold",
+            "expired": "Expired",
+            "finished": "Completed",
+            "refunded": "Refunded",
+            "cancelled": "Cancelled",
+            "unknown": "Unknown"
+          },
+          "actions": {
+            "viewInExplorer": "View in explorer",
+            "copied": "Copied"
+          },
+          "accessibility": {
+            "copySwapId": "Copy swap ID"
+          }
+        }
+      },
       "wrongDevice": {
         "title": "Ledger Nano S™ is not compatible with {{provider}}",
         "description": "Ledger Nano S™ is not compatible with {{provider}}. You can use Ledger Nano S Plus™, Ledger Nano X™, Ledger Stax™, or Ledger Flex™ to experience cross-chain swaps on {{provider}} via Ledger Wallet",

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptSwapFlow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptSwapFlow.test.tsx
@@ -4,6 +4,7 @@ import BigNumber from "bignumber.js";
 import { AuthorizationStatus } from "@react-native-firebase/messaging";
 import { CommonActions, NavigationProp, useNavigation } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { getTransactionStatus } from "@ledgerhq/live-common/wallet-api/Exchange/transactionStatus/index";
 import {
   act,
   renderWithReactQuery as render,
@@ -18,6 +19,7 @@ import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/typ
 import { NavigatorName, ScreenName } from "~/const";
 import GlobalDrawers from "~/GlobalDrawers";
 import { track } from "~/analytics";
+import { closeSwapTransactionStatusDrawer } from "~/reducers/swapTransactionStatusDrawer";
 import { MockedAccounts } from "LLM/features/Accounts/__integrations__/mockedAccounts";
 import { createNotificationsPromptFeatureFlags } from "../testUtils";
 
@@ -37,8 +39,23 @@ jest.mock("~/analytics", () => {
 jest.mock("~/screens/Swap/LiveApp/SwapLiveAppWallet40", () => ({
   SwapLiveAppWallet40: () => null,
 }));
+jest.mock("@ledgerhq/live-common/wallet-api/Exchange/transactionStatus/index", () => ({
+  getTransactionStatus: jest.fn(),
+}));
+
+// This test verifies the notification opt-in drawer, not the swap transaction status
+// drawer. The two share a single QueuedDrawer queue, and the real status drawer can't
+// complete its close lifecycle in tests — the @gorhom/bottom-sheet mock never fires
+// onDismiss — so it would hold the queue slot and the opt-in drawer could never mount.
+// Stub it so it never occupies the queue; its open/closed state is driven directly via
+// redux below, and its own behaviour is covered by the SwapTransactionStatus tests.
+jest.mock("LLM/features/SwapTransactionStatus", () => {
+  const actual = jest.requireActual("LLM/features/SwapTransactionStatus");
+  return { ...actual, SwapTransactionStatusDrawerWrapper: () => null };
+});
 
 const featureFlagsForSwapPrompt = createNotificationsPromptFeatureFlags();
+const mockedGetTransactionStatus = jest.mocked(getTransactionStatus);
 
 describe("NotificationsPrompt swap flow", () => {
   beforeAll(() => {
@@ -47,6 +64,15 @@ describe("NotificationsPrompt swap flow", () => {
 
   beforeEach(async () => {
     jest.setSystemTime(new Date("2025-01-01T00:00:00.000Z"));
+    mockedGetTransactionStatus.mockResolvedValue({
+      provider: "changelly",
+      swapId: swapOperation.swapId,
+      status: "finished",
+      fromAccountId: MockedAccounts.active[0].id,
+      toAccountId: MockedAccounts.active[0].id,
+      sentAmount: swapOperation.fromAmount.toString(),
+      receivedAmount: swapOperation.toAmount.toString(),
+    });
     await storage.deleteAll();
   });
 
@@ -55,6 +81,7 @@ describe("NotificationsPrompt swap flow", () => {
   });
 
   afterEach(() => {
+    jest.clearAllTimers();
     jest.clearAllMocks();
   });
 
@@ -133,7 +160,12 @@ describe("NotificationsPrompt swap flow", () => {
         <SwapFlowTestWrapper>
           <HomeScreen swapParams={swapParams} />
         </SwapFlowTestWrapper>,
-        { overrideInitialState: overrideSwapPromptInitialState },
+        {
+          overrideInitialState: overrideSwapPromptInitialState,
+          userEventOptions: {
+            advanceTimers: delay => jest.advanceTimersByTime(delay),
+          },
+        },
       );
     }
 
@@ -148,8 +180,8 @@ describe("NotificationsPrompt swap flow", () => {
       );
 
       await user.press(screen.getAllByTestId("NavigationHeaderCloseButton")[0]);
-      await act(async () => {
-        await jest.runOnlyPendingTimersAsync();
+      act(() => {
+        jest.runOnlyPendingTimers();
       });
 
       expect(track).toHaveBeenCalledWith(
@@ -178,8 +210,8 @@ describe("NotificationsPrompt swap flow", () => {
       });
     });
 
-    it("should prompt only after closing history when swap success opens history", async () => {
-      const { user } = renderWalletV4SwapFlow(swapSuccessParams);
+    it("should prompt notifications drawer after closing transaction status and leaving history", async () => {
+      const { user, store } = renderWalletV4SwapFlow(swapSuccessParams);
 
       await waitFor(() => expect(screen.getByTestId("swap-success-title")).toBeVisible());
       expect(track).not.toHaveBeenCalledWith(
@@ -193,10 +225,20 @@ describe("NotificationsPrompt swap flow", () => {
       expect(track).not.toHaveBeenCalledWith(
         "attempt_to_trigger_push_notification_drawer_after_action",
       );
+      expect(store.getState().swapTransactionStatusDrawer.isOpen).toBe(true);
+      expect(screen.queryByText(/allow notifications/i)).toBeNull();
+
+      // Dismiss the status drawer via state — this test doesn't exercise its UI. Closing it
+      // before leaving history mirrors the real flow (the prompt surfaces only afterwards).
+      act(() => {
+        store.dispatch(closeSwapTransactionStatusDrawer());
+      });
+      expect(store.getState().swapTransactionStatusDrawer.isOpen).toBe(false);
+      expect(screen.queryByText(/allow notifications/i)).toBeNull();
 
       await user.press(screen.getAllByTestId("navigation-header-back-button")[0]);
-      await act(async () => {
-        await jest.runOnlyPendingTimersAsync();
+      act(() => {
+        jest.runOnlyPendingTimers();
       });
 
       expect(track).toHaveBeenCalledWith(
@@ -210,6 +252,11 @@ describe("NotificationsPrompt swap flow", () => {
           drawerPromptTarget: "globalPushNotifications",
         },
       );
+
+      expect(store.getState().notifications.isPushNotificationsModalOpen).toBe(true);
+      await waitFor(() => {
+        expect(screen.getByText(/allow notifications/i)).toBeVisible();
+      });
 
       await user.press(screen.getByText(/allow notifications/i));
       expect(track).toHaveBeenCalledWith("button_clicked", {

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/__integrations__/SwapTransactionStatusDrawer.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/__integrations__/SwapTransactionStatusDrawer.integration.test.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { render, screen, waitFor } from "@tests/test-renderer";
+import type { State } from "~/reducers/types";
+import { useSwapTransactionStatusViewModel } from "../hooks/useSwapTransactionStatusViewModel";
+import { SwapTransactionStatusDrawerWrapper } from "../components/SwapTransactionStatusDrawerWrapper";
+
+jest.mock("../hooks/useSwapTransactionStatusViewModel", () => ({
+  useSwapTransactionStatusViewModel: jest.fn(),
+}));
+
+const bitcoin = getCryptoCurrencyById("bitcoin");
+const ethereum = getCryptoCurrencyById("ethereum");
+const mockedUseSwapTransactionStatusViewModel = jest.mocked(useSwapTransactionStatusViewModel);
+
+function withSwapTransactionStatusDrawerOpen(state: State): State {
+  return {
+    ...state,
+    swapTransactionStatusDrawer: {
+      isOpen: true,
+      params: {
+        provider: "lifi",
+        swapId: "swap-1",
+      },
+    },
+  };
+}
+
+describe("SwapTransactionStatusDrawer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseSwapTransactionStatusViewModel.mockReturnValue({
+      sendCurrency: bitcoin,
+      receiveCurrency: ethereum,
+      receiveAccountCurrency: ethereum,
+      createdAt: new Date("2024-01-02T15:04:00.000Z").getTime(),
+      locale: "en-US",
+      sendStatus: "finished",
+      receiveStatus: "finished",
+      sentAmount: "0.1 BTC",
+      receivedAmount: "2 ETH",
+      feesAmount: "0.0001 BTC",
+      receiveAccountName: "Ethereum 1",
+      provider: "lifi",
+      providerData: undefined,
+      swapId: "swap-1",
+      explorerUrl: "https://scan.li.fi/tx/hash-1",
+      isStatusSectionLoading: false,
+      isFooterLoading: false,
+    });
+  });
+
+  it("should not mount drawer body while closed", () => {
+    render(<SwapTransactionStatusDrawerWrapper />);
+
+    expect(screen.queryByText("Swap BTC → ETH")).toBeNull();
+    expect(mockedUseSwapTransactionStatusViewModel).not.toHaveBeenCalled();
+  });
+
+  it("should render and close the drawer from the header close action", async () => {
+    const { store, user } = render(<SwapTransactionStatusDrawerWrapper />, {
+      overrideInitialState: withSwapTransactionStatusDrawerOpen,
+    });
+
+    expect(await screen.findByText("Swap BTC → ETH")).toBeOnTheScreen();
+    expect(mockedUseSwapTransactionStatusViewModel).toHaveBeenCalledWith({
+      params: { provider: "lifi", swapId: "swap-1" },
+      onClose: expect.any(Function),
+    });
+
+    await user.press(screen.getByLabelText("Close"));
+
+    await waitFor(() => {
+      expect(store.getState().swapTransactionStatusDrawer).toEqual({
+        isOpen: false,
+        params: null,
+      });
+    });
+    expect(screen.queryByText("Swap BTC → ETH")).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/__tests__/DetailsSection.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/__tests__/DetailsSection.test.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { Linking } from "react-native";
+import { log } from "@ledgerhq/logs";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getProviderIconUrl } from "@ledgerhq/live-common/icons/providers/providers";
+import type { AdditionalProviderConfig } from "@ledgerhq/live-common/exchange/providers/swap";
+import { render, screen, waitFor } from "@tests/test-renderer";
+import { DetailsSection } from "../components/Details/DetailsSection";
+
+jest.mock("@ledgerhq/live-common/icons/providers/providers", () => ({
+  getProviderIconUrl: jest.fn(
+    () => 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" />',
+  ),
+}));
+jest.mock("@ledgerhq/logs", () => ({
+  ...jest.requireActual("@ledgerhq/logs"),
+  log: jest.fn(),
+}));
+
+const mockedGetProviderIconUrl = jest.mocked(getProviderIconUrl);
+const ethereum = getCryptoCurrencyById("ethereum");
+
+const changellyProviderData: AdditionalProviderConfig = {
+  type: "CEX",
+  needsKYC: false,
+  termsOfUseUrl: "https://changelly.com/terms",
+  supportUrl: "https://changelly.com/support",
+  mainUrl: "https://changelly.com",
+  useInExchangeApp: true,
+  displayName: "Changelly",
+};
+
+describe("DetailsSection", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
+  });
+
+  it("should render filled transaction details and open the provider website", async () => {
+    const { user } = render(
+      <DetailsSection
+        feesAmount="0.001 ETH"
+        receiveAccountName="Ethereum 1"
+        receiveAccountCurrency={ethereum}
+        provider="changelly"
+        providerData={changellyProviderData}
+        swapId="1234567890abcdef"
+      />,
+    );
+
+    expect(screen.getByText("Network fees")).toBeVisible();
+    expect(screen.getByText("0.001 ETH")).toBeVisible();
+    expect(screen.getByText("Receive account")).toBeVisible();
+    expect(screen.getByText("Ethereum 1")).toBeVisible();
+    expect(screen.getByText("Swap ID")).toBeVisible();
+    expect(screen.getByText("12345678…abcdef")).toBeVisible();
+
+    await user.press(screen.getByText("Changelly"));
+
+    expect(Linking.openURL).toHaveBeenCalledWith("https://changelly.com");
+    expect(mockedGetProviderIconUrl).toHaveBeenCalledWith({
+      name: "changelly",
+      boxed: true,
+    });
+  });
+
+  it("should render provider details without a link when provider metadata has no URL", async () => {
+    const { user } = render(
+      <DetailsSection
+        provider="changelly"
+        providerData={{ ...changellyProviderData, mainUrl: "" }}
+        swapId="swap-1"
+      />,
+    );
+
+    expect(screen.getByText("Changelly")).toBeVisible();
+    await user.press(screen.getByText("Changelly"));
+    expect(Linking.openURL).not.toHaveBeenCalled();
+  });
+
+  it("should log provider website opening errors", async () => {
+    const error = new Error("cannot open URL");
+    jest.spyOn(Linking, "openURL").mockRejectedValue(error);
+
+    const { user } = render(
+      <DetailsSection provider="changelly" providerData={changellyProviderData} swapId="swap-1" />,
+    );
+
+    await user.press(screen.getByText("Changelly"));
+
+    expect(Linking.openURL).toHaveBeenCalledWith("https://changelly.com");
+    await waitFor(() => {
+      expect(log).toHaveBeenCalledWith("swap-transaction-status", "Failed to open provider URL", {
+        error,
+        url: "https://changelly.com",
+      });
+    });
+  });
+
+  it("should keep the provider row hidden until provider data is available", () => {
+    render(<DetailsSection swapId="swap-1" />);
+
+    expect(screen.queryByText("Provider")).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/__tests__/FooterSection.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/__tests__/FooterSection.test.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { log } from "@ledgerhq/logs";
+import { Linking } from "react-native";
+import { render, screen, waitFor } from "@tests/test-renderer";
+import { FooterSection } from "../components/Footer/FooterSection";
+
+jest.mock("@ledgerhq/logs", () => ({
+  ...jest.requireActual("@ledgerhq/logs"),
+  log: jest.fn(),
+}));
+
+describe("FooterSection", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
+  });
+
+  it("should open the explorer URL when the explorer action is pressed", async () => {
+    const { user } = render(
+      <FooterSection explorerUrl="https://explorer.test/tx/1" isLoading={false} />,
+    );
+
+    await user.press(screen.getByText("View in explorer"));
+
+    expect(Linking.openURL).toHaveBeenCalledWith("https://explorer.test/tx/1");
+  });
+
+  it("should log when opening the explorer URL fails", async () => {
+    const error = new Error("Cannot open URL");
+    jest.spyOn(Linking, "openURL").mockRejectedValue(error);
+
+    const { user } = render(
+      <FooterSection explorerUrl="https://explorer.test/tx/1" isLoading={false} />,
+    );
+
+    await user.press(screen.getByText("View in explorer"));
+
+    await waitFor(() => {
+      expect(log).toHaveBeenCalledWith("swap-transaction-status", "Failed to open explorer URL", {
+        error,
+        url: "https://explorer.test/tx/1",
+      });
+    });
+  });
+
+  it("should hide the explorer action while loading", () => {
+    render(<FooterSection explorerUrl="https://explorer.test/tx/1" isLoading />);
+
+    expect(screen.queryByText("View in explorer")).toBeNull();
+  });
+
+  it("should hide the explorer action when no explorer URL is available", () => {
+    render(<FooterSection isLoading={false} />);
+
+    expect(screen.queryByText("View in explorer")).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/__tests__/StatusSection.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/__tests__/StatusSection.test.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import type { TransactionStatusValue } from "@ledgerhq/live-common/wallet-api/Exchange/transactionStatus/index";
+import { render, screen } from "@tests/test-renderer";
+import { StatusSection } from "../components/Status/StatusSection";
+
+const bitcoin = getCryptoCurrencyById("bitcoin");
+const ethereum = getCryptoCurrencyById("ethereum");
+
+function renderStatusSection({
+  sendStatus = "pending",
+  receiveStatus = "pending",
+}: {
+  sendStatus?: TransactionStatusValue;
+  receiveStatus?: TransactionStatusValue;
+} = {}) {
+  return render(
+    <StatusSection
+      sendCurrency={bitcoin}
+      receiveCurrency={ethereum}
+      sendStatus={sendStatus}
+      receiveStatus={receiveStatus}
+      sentAmount="0.1 BTC"
+      receivedAmount="2 ETH"
+      isLoading={false}
+    />,
+  );
+}
+
+describe("StatusSection", () => {
+  it("should render ongoing and unknown status labels", () => {
+    renderStatusSection({ sendStatus: "pending", receiveStatus: "unknown" });
+
+    expect(screen.getByText("Sending BTC")).toBeVisible();
+    expect(screen.getByText("Receiving ETH")).toBeVisible();
+    expect(screen.getByText("Ongoing")).toBeVisible();
+    expect(screen.getByText("Unknown")).toBeVisible();
+  });
+
+  it("should render refunded and cancelled receive status labels for refunded swaps", () => {
+    renderStatusSection({ sendStatus: "refunded", receiveStatus: "refunded" });
+
+    expect(screen.getByText("Sending BTC")).toBeVisible();
+    expect(screen.getByText("Receiving ETH")).toBeVisible();
+    expect(screen.getByText("Refunded")).toBeVisible();
+    expect(screen.getByText("Cancelled")).toBeVisible();
+  });
+
+  it("should hide title and status labels while loading", () => {
+    render(
+      <StatusSection
+        sendCurrency={bitcoin}
+        receiveCurrency={ethereum}
+        sendStatus="pending"
+        receiveStatus="pending"
+        sentAmount={undefined}
+        receivedAmount={undefined}
+        isLoading
+      />,
+    );
+
+    expect(screen.queryByText("Sending BTC")).toBeNull();
+    expect(screen.queryByText("Ongoing")).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/__tests__/TransactionHeader.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/__tests__/TransactionHeader.test.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { formatSwapTransactionStatusCreatedAt } from "@ledgerhq/live-common/exchange/swapTransactionStatus/index";
+import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { render, screen } from "@tests/test-renderer";
+import { TransactionHeader } from "../components/TransactionHeader";
+
+const bitcoin = getCryptoCurrencyById("bitcoin");
+const ethereum = getCryptoCurrencyById("ethereum");
+const usdtEthereum = {
+  type: "TokenCurrency",
+  id: "ethereum/erc20/usd_tether__erc20_",
+  parentCurrencyId: ethereum.id,
+  tokenType: "erc20",
+  contractAddress: "0xdac17f958d2ee523a2206206994597c13d831ec7",
+  ticker: "USDT",
+  name: "Tether USD",
+  units: [
+    {
+      name: "Tether USD",
+      code: "USDT",
+      magnitude: 6,
+    },
+  ],
+} as unknown as TokenCurrency;
+
+describe("TransactionHeader", () => {
+  it("should render the swap title and creation date when currencies are available", () => {
+    const createdAt = new Date(2024, 0, 2, 15, 4).getTime();
+
+    render(
+      <TransactionHeader
+        sendCurrency={bitcoin}
+        receiveCurrency={ethereum}
+        createdAt={createdAt}
+        locale="en-US"
+      />,
+    );
+
+    expect(screen.getByText("Swap BTC → ETH")).toBeVisible();
+    expect(
+      screen.getByText(formatSwapTransactionStatusCreatedAt(createdAt, "en-US")),
+    ).toBeVisible();
+  });
+
+  it("should render token icons without a parent network badge", () => {
+    render(
+      <TransactionHeader
+        sendCurrency={bitcoin}
+        receiveCurrency={usdtEthereum}
+        createdAt={new Date(2024, 0, 2, 15, 4).getTime()}
+        locale="en-US"
+      />,
+    );
+
+    expect(screen.getByText("Swap BTC → USDT")).toBeVisible();
+  });
+
+  it("should hide the swap title and date while header data is loading", () => {
+    render(<TransactionHeader locale="en-US" />);
+
+    expect(screen.queryByText("Swap BTC → ETH")).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/__tests__/useSwapTransactionStatus.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/__tests__/useSwapTransactionStatus.test.ts
@@ -1,0 +1,173 @@
+import { Linking } from "react-native";
+import { log } from "@ledgerhq/logs";
+import { act, renderHook, waitFor } from "@tests/test-renderer";
+import { getTransactionStatus } from "@ledgerhq/live-common/wallet-api/Exchange/transactionStatus/index";
+import type { GetTransactionStatusResponse } from "@ledgerhq/live-common/wallet-api/Exchange/transactionStatus/index";
+import { useSwapTransactionStatus } from "../hooks/useSwapTransactionStatus";
+
+const mockBridgeSync = jest.fn();
+
+jest.mock("@ledgerhq/live-common/bridge/react/index", () => ({
+  useBridgeSync: () => mockBridgeSync,
+}));
+jest.mock("@ledgerhq/live-common/wallet-api/Exchange/transactionStatus/index", () => ({
+  getTransactionStatus: jest.fn(),
+}));
+jest.mock("@ledgerhq/logs", () => ({
+  ...jest.requireActual("@ledgerhq/logs"),
+  log: jest.fn(),
+}));
+
+const mockedGetTransactionStatus = jest.mocked(getTransactionStatus);
+const mockedLog = jest.mocked(log);
+const STATUS_POLL_INTERVAL_MS = 60_000;
+let setTimeoutSpy: jest.SpiedFunction<typeof global.setTimeout> | undefined;
+
+function makeTransactionStatusResponse(
+  overrides: Partial<GetTransactionStatusResponse> = {},
+): GetTransactionStatusResponse {
+  return {
+    provider: "lifi",
+    swapId: "swap-1",
+    status: "pending",
+    ...overrides,
+  } as GetTransactionStatusResponse;
+}
+
+function captureStatusPollTimeout() {
+  const originalSetTimeout = global.setTimeout;
+  let runStatusPoll: (() => Promise<void>) | undefined;
+
+  setTimeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation(((
+    callback: () => unknown,
+    delay?: number,
+  ) => {
+    if (delay === STATUS_POLL_INTERVAL_MS) {
+      runStatusPoll = async () => {
+        await callback();
+      };
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    }
+
+    return originalSetTimeout(callback, delay);
+  }) as typeof setTimeout);
+
+  return () => runStatusPoll;
+}
+
+describe("useSwapTransactionStatus", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    setTimeoutSpy?.mockRestore();
+    setTimeoutSpy = undefined;
+  });
+
+  it("should retry polling after a transient status lookup failure", async () => {
+    const getRunStatusPoll = captureStatusPollTimeout();
+    mockedGetTransactionStatus
+      .mockRejectedValueOnce(new Error("swap history still loading"))
+      .mockResolvedValueOnce(makeTransactionStatusResponse());
+
+    const { unmount } = renderHook(() =>
+      useSwapTransactionStatus({
+        params: { swapId: "swap-1", provider: "lifi" },
+        onClose: jest.fn(),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockedGetTransactionStatus).toHaveBeenCalledTimes(1);
+      expect(getRunStatusPoll()).toEqual(expect.any(Function));
+    });
+
+    await act(async () => {
+      await getRunStatusPoll()?.();
+    });
+
+    expect(mockedGetTransactionStatus).toHaveBeenCalledTimes(2);
+    unmount();
+  });
+
+  it("should stop polling after a terminal status is received", async () => {
+    const getRunStatusPoll = captureStatusPollTimeout();
+    mockedGetTransactionStatus.mockResolvedValueOnce(
+      makeTransactionStatusResponse({ status: "finished" }),
+    );
+
+    const { result, unmount } = renderHook(() =>
+      useSwapTransactionStatus({
+        params: { swapId: "swap-1", provider: "lifi" },
+        onClose: jest.fn(),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.latestStatus?.status).toBe("finished");
+    });
+
+    expect(getRunStatusPoll()).toBeUndefined();
+    expect(mockedGetTransactionStatus).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it("should auto-redirect and close the drawer when a terminal status arrives while hidden", async () => {
+    const onClose = jest.fn();
+    mockedGetTransactionStatus.mockResolvedValueOnce(
+      makeTransactionStatusResponse({ status: "finished" }),
+    );
+
+    const { unmount } = renderHook(() =>
+      useSwapTransactionStatus({
+        params: {
+          swapId: "swap-1",
+          provider: "lifi",
+          redirectUrl: "ledgerlive://swap/done",
+        },
+        onClose,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(Linking.openURL).toHaveBeenCalledWith("ledgerlive://swap/done");
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+    unmount();
+  });
+
+  it("should log when auto-redirect fails to open", async () => {
+    const onClose = jest.fn();
+    const error = new Error("Cannot open URL");
+    jest.spyOn(Linking, "openURL").mockRejectedValue(error);
+    mockedGetTransactionStatus.mockResolvedValueOnce(
+      makeTransactionStatusResponse({ status: "finished" }),
+    );
+
+    const { unmount } = renderHook(() =>
+      useSwapTransactionStatus({
+        params: {
+          swapId: "swap-1",
+          provider: "lifi",
+          redirectUrl: "ledgerlive://swap/done",
+        },
+        onClose,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockedLog).toHaveBeenCalledWith(
+        "swap-transaction-status",
+        "Failed to open auto-redirect URL",
+        {
+          error,
+          url: "ledgerlive://swap/done",
+        },
+      );
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+    unmount();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/__tests__/useSwapTransactionStatusViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/__tests__/useSwapTransactionStatusViewModel.test.ts
@@ -1,0 +1,272 @@
+import { renderHook, waitFor } from "@tests/test-renderer";
+import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import type { Account } from "@ledgerhq/types-live";
+import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { getSwapProvider } from "@ledgerhq/live-common/exchange/providers/swap";
+import { useMaybeAccountName } from "~/reducers/wallet";
+import type { State } from "~/reducers/types";
+import { useSwapTransactionStatus } from "../hooks/useSwapTransactionStatus";
+import { useSwapTransactionStatusViewModel } from "../hooks/useSwapTransactionStatusViewModel";
+
+jest.mock("~/reducers/wallet", () => ({
+  ...jest.requireActual("~/reducers/wallet"),
+  useMaybeAccountName: jest.fn(),
+}));
+jest.mock("@ledgerhq/live-common/exchange/providers/swap", () => ({
+  getSwapProvider: jest.fn(),
+}));
+jest.mock("~/generated/operationDetails", () => ({}));
+jest.mock("../hooks/useSwapTransactionStatus", () => ({
+  useSwapTransactionStatus: jest.fn(),
+}));
+
+const bitcoin = getCryptoCurrencyById("bitcoin");
+const ethereum = getCryptoCurrencyById("ethereum");
+const usdtEthereum: TokenCurrency = {
+  type: "TokenCurrency",
+  id: "ethereum/erc20/usd_tether__erc20_",
+  parentCurrencyId: ethereum.id,
+  tokenType: "erc20",
+  contractAddress: "0xdac17f958d2ee523a2206206994597c13d831ec7",
+  ticker: "USDT",
+  name: "Tether USD",
+  units: [
+    {
+      name: "Tether USD",
+      code: "USDT",
+      magnitude: 6,
+    },
+  ],
+};
+const sendAccount = genAccount("bitcoin-account", { currency: bitcoin });
+const receiveAccount = genAccount("ethereum-account", { currency: ethereum });
+const mockedUseMaybeAccountName = jest.mocked(useMaybeAccountName);
+const mockedUseSwapTransactionStatus = jest.mocked(useSwapTransactionStatus);
+const mockedGetSwapProvider = jest.mocked(getSwapProvider);
+
+function normalizeSpaces(value: string | undefined): string | undefined {
+  return value?.replace(/ /g, " ");
+}
+
+const withTestAccounts =
+  (accounts: Account[]) =>
+  (state: State): State => ({
+    ...state,
+    accounts: { ...state.accounts, active: accounts },
+    settings: { ...state.settings, locale: "en-US" },
+  });
+
+describe("useSwapTransactionStatusViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseMaybeAccountName.mockReturnValue("Ethereum 1");
+    mockedGetSwapProvider.mockResolvedValue({
+      type: "CEX",
+      name: "provider",
+      publicKey: {
+        curve: "secp256k1",
+        data: Buffer.from("test-public-key"),
+      },
+      signature: Buffer.from("test-signature"),
+      needsKYC: false,
+      termsOfUseUrl: "https://provider.test/terms",
+      supportUrl: "https://provider.test/support",
+      mainUrl: "https://provider.test",
+      useInExchangeApp: true,
+      displayName: "Provider",
+    });
+  });
+
+  it("should map transaction details to the drawer view model", async () => {
+    mockedUseSwapTransactionStatus.mockReturnValue({
+      phase: "settled_visible",
+      latestStatus: {
+        provider: "lifi",
+        swapId: "swap-1",
+        status: "finished",
+        finalAmount: "2000000000000000000",
+      },
+      details: {
+        provider: "lifi",
+        swapId: "swap-1",
+        status: "finished",
+        sendStatus: "finished",
+        receiveStatus: "finished",
+        fromAccountId: sendAccount.id,
+        toAccountId: receiveAccount.id,
+        sentAmount: "123456789",
+        receivedAmount: "2000000000000000000",
+        finalAmount: "2100000000000000000",
+        feesAmount: "10000",
+        operationHash: "hash-1",
+        createdAt: 1_704_210_240_000,
+      },
+      isInitialLoading: false,
+      isSettled: true,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useSwapTransactionStatusViewModel({
+          params: { swapId: "swap-1", provider: "lifi" },
+          onClose: jest.fn(),
+        }),
+      { overrideInitialState: withTestAccounts([sendAccount, receiveAccount]) },
+    );
+
+    expect(result.current.sendCurrency).toBe(bitcoin);
+    expect(result.current.receiveCurrency).toBe(ethereum);
+    expect(result.current.receiveAccountCurrency).toBe(ethereum);
+    expect(normalizeSpaces(result.current.sentAmount)).toBe("1.23456789 BTC");
+    expect(normalizeSpaces(result.current.receivedAmount)).toBe("2.1 ETH");
+    expect(normalizeSpaces(result.current.feesAmount)).toBe("0.0001 BTC");
+    expect(result.current.receiveAccountName).toBe("Ethereum 1");
+    expect(result.current.sendStatus).toBe("finished");
+    expect(result.current.receiveStatus).toBe("finished");
+    expect(result.current.explorerUrl).toBe("https://scan.li.fi/tx/hash-1");
+    expect(result.current.isStatusSectionLoading).toBe(false);
+    expect(result.current.isFooterLoading).toBe(false);
+
+    await waitFor(() => {
+      expect(result.current.providerData?.mainUrl).toBe("https://provider.test");
+    });
+  });
+
+  it("should fall back to pending loading state when details are unavailable", () => {
+    mockedUseSwapTransactionStatus.mockReturnValue({
+      phase: "polling_hidden",
+      latestStatus: undefined,
+      details: undefined,
+      isInitialLoading: true,
+      isSettled: false,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useSwapTransactionStatusViewModel({
+          params: { swapId: "swap-1", provider: "lifi" },
+          onClose: jest.fn(),
+        }),
+      { overrideInitialState: withTestAccounts([sendAccount, receiveAccount]) },
+    );
+
+    expect(result.current.provider).toBe("lifi");
+    expect(result.current.sendStatus).toBe("pending");
+    expect(result.current.receiveStatus).toBe("pending");
+    expect(result.current.isStatusSectionLoading).toBe(true);
+    expect(result.current.isFooterLoading).toBe(true);
+    expect(result.current.explorerUrl).toBeUndefined();
+  });
+
+  it("should clear provider metadata when provider lookup fails", async () => {
+    mockedGetSwapProvider.mockRejectedValue(new Error("provider unavailable"));
+    mockedUseSwapTransactionStatus.mockReturnValue({
+      phase: "settled_visible",
+      latestStatus: {
+        provider: "unknown-provider",
+        swapId: "swap-1",
+        status: "finished",
+      },
+      details: {
+        provider: "unknown-provider",
+        swapId: "swap-1",
+        status: "finished",
+        fromAccountId: sendAccount.id,
+        toAccountId: receiveAccount.id,
+      },
+      isInitialLoading: false,
+      isSettled: true,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useSwapTransactionStatusViewModel({
+          params: { swapId: "swap-1", provider: "unknown-provider" },
+          onClose: jest.fn(),
+        }),
+      { overrideInitialState: withTestAccounts([sendAccount, receiveAccount]) },
+    );
+
+    await waitFor(() => {
+      expect(mockedGetSwapProvider).toHaveBeenCalledWith("unknown-provider");
+    });
+    expect(result.current.providerData).toBeUndefined();
+  });
+
+  it("should display a completed receive status when the local send transaction is finished", () => {
+    mockedUseSwapTransactionStatus.mockReturnValue({
+      phase: "settled_visible",
+      latestStatus: {
+        provider: "thorswap",
+        swapId: "swap-1",
+        status: "unknown",
+      },
+      details: {
+        provider: "thorswap",
+        swapId: "swap-1",
+        status: "unknown",
+        sendStatus: "finished",
+        receiveStatus: "unknown",
+        fromAccountId: sendAccount.id,
+        toAccountId: receiveAccount.id,
+      },
+      isInitialLoading: false,
+      isSettled: true,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useSwapTransactionStatusViewModel({
+          params: { swapId: "swap-1", provider: "thorswap" },
+          onClose: jest.fn(),
+        }),
+      { overrideInitialState: withTestAccounts([sendAccount, receiveAccount]) },
+    );
+
+    expect(result.current.sendStatus).toBe("finished");
+    expect(result.current.receiveStatus).toBe("finished");
+  });
+
+  it("should use the parent account name and icon currency for token receive accounts", () => {
+    const receiveParentAccount = genAccount("ethereum-token-parent-account", {
+      currency: ethereum,
+    });
+    const receiveTokenAccount = genTokenAccount(0, receiveParentAccount, usdtEthereum);
+    receiveParentAccount.subAccounts = [receiveTokenAccount];
+    mockedUseMaybeAccountName.mockReturnValue("Ethereum 2");
+    mockedUseSwapTransactionStatus.mockReturnValue({
+      phase: "settled_visible",
+      latestStatus: {
+        provider: "lifi",
+        swapId: "swap-1",
+        status: "finished",
+      },
+      details: {
+        provider: "lifi",
+        swapId: "swap-1",
+        status: "finished",
+        fromAccountId: sendAccount.id,
+        toAccountId: receiveTokenAccount.id,
+        receivedAmount: "2500000",
+      },
+      isInitialLoading: false,
+      isSettled: true,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useSwapTransactionStatusViewModel({
+          params: { swapId: "swap-1", provider: "lifi" },
+          onClose: jest.fn(),
+        }),
+      { overrideInitialState: withTestAccounts([sendAccount, receiveParentAccount]) },
+    );
+
+    expect(mockedUseMaybeAccountName).toHaveBeenCalledWith(receiveParentAccount);
+    expect(result.current.receiveAccountName).toBe("Ethereum 2");
+    expect(result.current.receiveAccountCurrency).toBe(ethereum);
+    expect(result.current.receiveCurrency).toBe(usdtEthereum);
+    expect(normalizeSpaces(result.current.receivedAmount)).toBe("2.5 USDT");
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Details/CopyIconButton.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Details/CopyIconButton.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { Modal } from "react-native";
+import { Box, Pressable, Text } from "@ledgerhq/lumen-ui-rnative";
+import { Copy } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { useCopyToClipboard } from "LLM/hooks/useCopyToClipboard";
+import { useCopyIconButtonViewModel } from "../../hooks/useCopyIconButtonViewModel";
+
+type CopyIconButtonProps = Readonly<{
+  text: string;
+}>;
+
+export function CopyIconButton({ text }: CopyIconButtonProps) {
+  const { copyLabel, copiedText } = useCopyIconButtonViewModel();
+  const { copyToClipboard, isCopied, resetCopied } = useCopyToClipboard();
+
+  return (
+    <>
+      <Pressable
+        onPress={() => copyToClipboard(text)}
+        accessibilityRole="button"
+        accessibilityLabel={copyLabel}
+      >
+        <Copy size={16} color="base" />
+      </Pressable>
+      <Modal transparent visible={isCopied} animationType="fade" onRequestClose={resetCopied}>
+        <Box lx={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
+          <Box
+            lx={{
+              backgroundColor: "surface",
+              borderRadius: "sm",
+              paddingHorizontal: "s16",
+              paddingVertical: "s8",
+            }}
+          >
+            <Text typography="body2SemiBold" lx={{ color: "base" }}>
+              {copiedText}
+            </Text>
+          </Box>
+        </Box>
+      </Modal>
+    </>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Details/DetailRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Details/DetailRow.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
+
+type DetailRowProps = Readonly<{
+  label: string;
+  value: React.ReactNode;
+}>;
+
+export function DetailRow({ label, value }: DetailRowProps) {
+  return (
+    <Box
+      lx={{
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: "s16",
+      }}
+    >
+      <Text typography="body3" lx={{ color: "muted" }}>
+        {label}
+      </Text>
+      {typeof value === "string" ? (
+        <Text typography="body3" lx={{ color: "base", textAlign: "right", flexShrink: 1 }}>
+          {value}
+        </Text>
+      ) : (
+        value
+      )}
+    </Box>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Details/DetailsSection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Details/DetailsSection.tsx
@@ -1,0 +1,177 @@
+import React from "react";
+import { log } from "@ledgerhq/logs";
+import { Linking } from "react-native";
+import type { AdditionalProviderConfig } from "@ledgerhq/live-common/exchange/providers/swap";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { Box, Pressable, Skeleton, Text } from "@ledgerhq/lumen-ui-rnative";
+import CurrencyIcon from "~/components/CurrencyIcon";
+import { useDetailsSectionViewModel } from "../../hooks/useDetailsSectionViewModel";
+import { CopyIconButton } from "./CopyIconButton";
+import { DetailRow } from "./DetailRow";
+import { ProviderIcon } from "./ProviderIcon";
+
+type DetailsSectionProps = Readonly<{
+  feesAmount?: string;
+  receiveAccountName?: string;
+  receiveAccountCurrency?: CryptoCurrency;
+  provider?: string;
+  providerData?: AdditionalProviderConfig;
+  swapId: string;
+}>;
+
+export function DetailsSection({
+  feesAmount,
+  receiveAccountName,
+  receiveAccountCurrency,
+  provider,
+  providerData,
+  swapId,
+}: DetailsSectionProps) {
+  const {
+    networkFeesLabel,
+    receiveAccountLabel,
+    providerLabel,
+    swapIdLabel,
+    providerName,
+    providerMainUrl,
+    truncatedSwapId,
+  } = useDetailsSectionViewModel({ provider, providerData, swapId });
+  const receiveAccountValue = renderReceiveAccountValue({
+    receiveAccountName,
+    receiveAccountCurrency,
+  });
+  const providerRow = renderProviderRow({
+    label: providerLabel,
+    provider,
+    providerName,
+    providerMainUrl,
+  });
+
+  return (
+    <Box lx={{ gap: "s12" }}>
+      <DetailRow
+        label={networkFeesLabel}
+        value={feesAmount ?? <Skeleton lx={{ height: "s16", width: "s96" }} />}
+      />
+      <DetailRow label={receiveAccountLabel} value={receiveAccountValue} />
+      {providerRow}
+      <DetailRow
+        label={swapIdLabel}
+        value={
+          <Box lx={{ flexDirection: "row", alignItems: "center", gap: "s6" }}>
+            <Text typography="body3SemiBold" lx={{ color: "base" }}>
+              {truncatedSwapId}
+            </Text>
+            <CopyIconButton text={swapId} />
+          </Box>
+        }
+      />
+    </Box>
+  );
+}
+
+type ReceiveAccountValueProps = Readonly<{
+  receiveAccountName?: string;
+  receiveAccountCurrency?: CryptoCurrency;
+}>;
+
+function renderReceiveAccountValue({
+  receiveAccountName,
+  receiveAccountCurrency,
+}: ReceiveAccountValueProps) {
+  if (!receiveAccountName) {
+    return <Skeleton lx={{ height: "s16", width: "s112" }} />;
+  }
+
+  return (
+    <Box
+      lx={{
+        flexDirection: "row",
+        alignItems: "center",
+        gap: "s6",
+        flexShrink: 1,
+      }}
+    >
+      <Text typography="body3" lx={{ color: "base", textAlign: "right", flexShrink: 1 }}>
+        {receiveAccountName}
+      </Text>
+      {receiveAccountCurrency ? (
+        <CurrencyIcon currency={receiveAccountCurrency} size={16} squared />
+      ) : null}
+    </Box>
+  );
+}
+
+type ProviderRowProps = Readonly<{
+  label: string;
+  provider?: string;
+  providerName?: string;
+  providerMainUrl?: string;
+}>;
+
+function renderProviderRow({ label, provider, providerName, providerMainUrl }: ProviderRowProps) {
+  if (!provider || !providerName) {
+    return null;
+  }
+
+  return (
+    <DetailRow
+      label={label}
+      value={renderProviderValue({
+        provider,
+        providerName,
+        providerMainUrl,
+      })}
+    />
+  );
+}
+
+type ProviderValueRendererProps = Readonly<{
+  provider: string;
+  providerName: string;
+  providerMainUrl?: string;
+}>;
+
+function renderProviderValue({
+  provider,
+  providerName,
+  providerMainUrl,
+}: ProviderValueRendererProps) {
+  const providerValue = <ProviderValue provider={provider} providerName={providerName} />;
+
+  if (!providerMainUrl) {
+    return providerValue;
+  }
+
+  return (
+    <Pressable
+      onPress={() =>
+        Linking.openURL(providerMainUrl).catch(error => {
+          log("swap-transaction-status", "Failed to open provider URL", {
+            error,
+            url: providerMainUrl,
+          });
+        })
+      }
+      accessibilityRole="link"
+    >
+      {providerValue}
+    </Pressable>
+  );
+}
+
+type ProviderValueProps = Readonly<{
+  provider: string;
+  providerName: string;
+}>;
+
+function ProviderValue({ provider, providerName }: ProviderValueProps) {
+  return (
+    <Box lx={{ flexDirection: "row", alignItems: "center", gap: "s6" }}>
+      <Text typography="body3SemiBold" lx={{ color: "base", textAlign: "right" }}>
+        {providerName}
+      </Text>
+      <ProviderIcon name={provider} />
+    </Box>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Details/ProviderIcon.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Details/ProviderIcon.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { SvgUri } from "react-native-svg";
+import { getProviderIconUrl } from "@ledgerhq/live-common/icons/providers/providers";
+
+type ProviderIconProps = Readonly<{
+  name: string;
+  size?: number;
+}>;
+
+export function ProviderIcon({ name, size = 16 }: ProviderIconProps) {
+  return <SvgUri width={size} height={size} uri={getProviderIconUrl({ name, boxed: true })} />;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Footer/FooterSection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Footer/FooterSection.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { log } from "@ledgerhq/logs";
+import { Linking } from "react-native";
+import { Box, Button, Skeleton } from "@ledgerhq/lumen-ui-rnative";
+import { ExternalLink } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { useFooterSectionViewModel } from "../../hooks/useFooterSectionViewModel";
+
+type FooterSectionProps = Readonly<{
+  explorerUrl?: string;
+  isLoading: boolean;
+}>;
+
+export function FooterSection({ explorerUrl, isLoading }: FooterSectionProps) {
+  const { viewInExplorerLabel } = useFooterSectionViewModel();
+
+  if (isLoading) {
+    return <Skeleton lx={{ height: "s40", width: "full" }} />;
+  }
+
+  if (!explorerUrl) {
+    return <Box lx={{ height: "s40" }} />;
+  }
+
+  return (
+    <Button
+      appearance="transparent"
+      size="md"
+      icon={ExternalLink}
+      lx={{ width: "full" }}
+      onPress={() =>
+        Linking.openURL(explorerUrl).catch(error => {
+          log("swap-transaction-status", "Failed to open explorer URL", {
+            error,
+            url: explorerUrl,
+          });
+        })
+      }
+    >
+      {viewInExplorerLabel}
+    </Button>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Status/StatusLine.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Status/StatusLine.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import {
+  getSwapTransactionStatusVisualTokens,
+  type SwapTransactionStatusDisplayStatus,
+  type SwapTransactionStatusVisualTone,
+} from "@ledgerhq/live-common/exchange/swapTransactionStatus/index";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
+
+type StatusLineProps = Readonly<{
+  status: SwapTransactionStatusDisplayStatus;
+}>;
+
+export function StatusLine({ status }: StatusLineProps) {
+  return (
+    <Box
+      lx={{
+        backgroundColor: getStatusLineBackgroundColor(status),
+        borderRadius: "full",
+        height: "s32",
+        width: "s4",
+        marginTop: "s4",
+      }}
+    />
+  );
+}
+
+function getStatusLineBackgroundColor(status: SwapTransactionStatusDisplayStatus) {
+  return getStatusLineBackgroundColorFromTone(getSwapTransactionStatusVisualTokens(status).tone);
+}
+
+function getStatusLineBackgroundColorFromTone(tone: SwapTransactionStatusVisualTone) {
+  if (tone === "success") {
+    return "successStrong";
+  }
+  if (tone === "error") {
+    return "errorStrong";
+  }
+  return "mutedStrong";
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Status/StatusRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Status/StatusRow.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import {
+  getSwapTransactionStatusVisualTokens,
+  type SwapTransactionStatusDisplayStatus,
+  type SwapTransactionStatusVisualIcon,
+  type SwapTransactionStatusVisualTone,
+} from "@ledgerhq/live-common/exchange/swapTransactionStatus/index";
+import { Box, Skeleton, Text } from "@ledgerhq/lumen-ui-rnative";
+import { CheckmarkCircleFill, Clock, Warning } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { StatusLine } from "./StatusLine";
+
+type StatusRowProps = Readonly<{
+  status: SwapTransactionStatusDisplayStatus;
+  title: string;
+  subtitle: string;
+  value: React.ReactNode;
+  isLoading: boolean;
+  lineStatus?: SwapTransactionStatusDisplayStatus;
+  isLast?: boolean;
+}>;
+
+export function StatusRow({
+  status,
+  title,
+  subtitle,
+  value,
+  isLoading,
+  lineStatus,
+  isLast,
+}: StatusRowProps) {
+  const visualTokens = getSwapTransactionStatusVisualTokens(status);
+
+  return (
+    <Box lx={{ flexDirection: "row", gap: "s12" }}>
+      <Box lx={{ alignItems: "center", width: "s20", paddingTop: "s1" }}>
+        {renderStatusIcon(visualTokens.icon)}
+        {isLast ? null : <StatusLine status={lineStatus ?? status} />}
+      </Box>
+      <Box lx={{ flex: 1, gap: "s2" }}>
+        <Box lx={{ flexDirection: "row", justifyContent: "space-between", gap: "s12" }}>
+          {isLoading ? (
+            <Skeleton lx={{ height: "s16", width: "s112" }} />
+          ) : (
+            <Text typography="body2SemiBold" lx={{ color: "base", flexShrink: 1 }}>
+              {title}
+            </Text>
+          )}
+          {typeof value === "string" ? (
+            <Text typography="body2SemiBold" lx={{ color: "base", textAlign: "right" }}>
+              {value}
+            </Text>
+          ) : (
+            value
+          )}
+        </Box>
+        {isLoading ? (
+          <Skeleton lx={{ height: "s14", width: "s72" }} />
+        ) : (
+          <Text
+            typography="body3"
+            lx={{
+              color: getStatusSubtitleColor(visualTokens.tone),
+            }}
+          >
+            {subtitle}
+          </Text>
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+function renderStatusIcon(icon: SwapTransactionStatusVisualIcon) {
+  if (icon === "success") {
+    return <CheckmarkCircleFill size={20} color="success" />;
+  }
+  if (icon === "error") {
+    return <Warning size={20} color="error" />;
+  }
+  return <Clock size={20} color="muted" />;
+}
+
+function getStatusSubtitleColor(tone: SwapTransactionStatusVisualTone) {
+  if (tone === "success") {
+    return "success";
+  }
+  if (tone === "error") {
+    return "error";
+  }
+  return "muted";
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Status/StatusSection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Status/StatusSection.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import type { TransactionStatusValue } from "@ledgerhq/live-common/wallet-api/Exchange/transactionStatus/index";
+import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { Box, Skeleton, Text } from "@ledgerhq/lumen-ui-rnative";
+import { useStatusSectionViewModel } from "../../hooks/useStatusSectionViewModel";
+import { StatusRow } from "./StatusRow";
+
+type StatusSectionProps = Readonly<{
+  sendCurrency?: CryptoOrTokenCurrency;
+  receiveCurrency?: CryptoOrTokenCurrency;
+  sendStatus: TransactionStatusValue;
+  receiveStatus: TransactionStatusValue;
+  sentAmount?: string;
+  receivedAmount?: string;
+  isLoading: boolean;
+}>;
+
+export function StatusSection({
+  sendCurrency,
+  receiveCurrency,
+  sendStatus,
+  receiveStatus,
+  sentAmount,
+  receivedAmount,
+  isLoading,
+}: StatusSectionProps) {
+  const { heading, sendRow, receiveRow } = useStatusSectionViewModel({
+    sendCurrency,
+    receiveCurrency,
+    sendStatus,
+    receiveStatus,
+  });
+
+  return (
+    <Box lx={{ gap: "s12" }}>
+      <Text typography="heading5SemiBold" lx={{ color: "base" }}>
+        {heading}
+      </Text>
+      <Box lx={{ gap: "s4", borderRadius: "md", backgroundColor: "surface", padding: "s12" }}>
+        <StatusRow
+          status={sendRow.status}
+          title={sendRow.title}
+          subtitle={sendRow.subtitle}
+          value={sentAmount ?? <Skeleton lx={{ height: "s16", width: "s96" }} />}
+          isLoading={isLoading}
+          lineStatus={sendRow.lineStatus}
+        />
+        <StatusRow
+          status={receiveRow.status}
+          title={receiveRow.title}
+          subtitle={receiveRow.subtitle}
+          value={receivedAmount ?? <Skeleton lx={{ height: "s16", width: "s96" }} />}
+          isLoading={isLoading}
+          isLast
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/SwapTransactionStatusDrawerBody.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/SwapTransactionStatusDrawerBody.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import type { SwapTransactionStatusParams } from "@ledgerhq/live-common/exchange/swapTransactionStatus/index";
+import { useSwapTransactionStatusViewModel } from "../hooks/useSwapTransactionStatusViewModel";
+import { SwapTransactionStatusView } from "./SwapTransactionStatusView";
+
+type SwapTransactionStatusDrawerBodyProps = Readonly<{
+  params: SwapTransactionStatusParams;
+  onClose: () => void;
+}>;
+
+export function SwapTransactionStatusDrawerBody({
+  params,
+  onClose,
+}: SwapTransactionStatusDrawerBodyProps) {
+  const viewModel = useSwapTransactionStatusViewModel({ params, onClose });
+
+  return <SwapTransactionStatusView {...viewModel} />;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/SwapTransactionStatusDrawerWrapper.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/SwapTransactionStatusDrawerWrapper.tsx
@@ -1,0 +1,41 @@
+import React, { useCallback } from "react";
+import { BottomSheetHeader, BottomSheetView } from "@ledgerhq/lumen-ui-rnative";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
+import { useDispatch, useSelector } from "~/context/hooks";
+import {
+  closeSwapTransactionStatusDrawer,
+  selectIsSwapTransactionStatusDrawerOpen,
+  selectSwapTransactionStatusDrawerParams,
+} from "~/reducers/swapTransactionStatusDrawer";
+import { SwapTransactionStatusDrawerBody } from "./SwapTransactionStatusDrawerBody";
+import { useCloseDrawerOnAndroidBack } from "../hooks/useCloseDrawerOnAndroidBack";
+
+export function SwapTransactionStatusDrawerWrapper() {
+  const dispatch = useDispatch();
+  const { bottom: bottomInset } = useSafeAreaInsets();
+  const isOpen = useSelector(selectIsSwapTransactionStatusDrawerOpen);
+  const params = useSelector(selectSwapTransactionStatusDrawerParams);
+  const closeDrawer = useCallback(() => {
+    dispatch(closeSwapTransactionStatusDrawer());
+  }, [dispatch]);
+
+  // Android: close this drawer on hardware back instead of navigating the screens behind it.
+  useCloseDrawerOnAndroidBack(isOpen, closeDrawer);
+
+  return (
+    <QueuedDrawerBottomSheet
+      isRequestingToBeOpened={isOpen}
+      onClose={closeDrawer}
+      snapPoints="full"
+      testID="swap-transaction-status-drawer"
+    >
+      <BottomSheetView style={{ paddingHorizontal: 0, paddingBottom: bottomInset + 12 }}>
+        <BottomSheetHeader style={{ paddingHorizontal: 16 }} />
+        {isOpen && params ? (
+          <SwapTransactionStatusDrawerBody params={params} onClose={closeDrawer} />
+        ) : null}
+      </BottomSheetView>
+    </QueuedDrawerBottomSheet>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/SwapTransactionStatusView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/SwapTransactionStatusView.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { BottomSheetScrollView, Box } from "@ledgerhq/lumen-ui-rnative";
+import type { SwapTransactionStatusViewModel } from "../hooks/useSwapTransactionStatusViewModel";
+import { DetailsSection } from "./Details/DetailsSection";
+import { FooterSection } from "./Footer/FooterSection";
+import { StatusSection } from "./Status/StatusSection";
+import { TransactionHeader } from "./TransactionHeader";
+
+export function SwapTransactionStatusView({
+  sendCurrency,
+  receiveCurrency,
+  createdAt,
+  locale,
+  sendStatus,
+  receiveStatus,
+  sentAmount,
+  receivedAmount,
+  feesAmount,
+  receiveAccountName,
+  receiveAccountCurrency,
+  provider,
+  providerData,
+  swapId,
+  explorerUrl,
+  isStatusSectionLoading,
+  isFooterLoading,
+}: Readonly<SwapTransactionStatusViewModel>) {
+  return (
+    <BottomSheetScrollView showsVerticalScrollIndicator={false}>
+      <Box lx={{ gap: "s24", paddingBottom: "s24" }}>
+        <TransactionHeader
+          sendCurrency={sendCurrency}
+          receiveCurrency={receiveCurrency}
+          createdAt={createdAt}
+          locale={locale}
+        />
+
+        <StatusSection
+          sendCurrency={sendCurrency}
+          receiveCurrency={receiveCurrency}
+          sendStatus={sendStatus}
+          receiveStatus={receiveStatus}
+          sentAmount={sentAmount}
+          receivedAmount={receivedAmount}
+          isLoading={isStatusSectionLoading}
+        />
+
+        <DetailsSection
+          feesAmount={feesAmount}
+          receiveAccountName={receiveAccountName}
+          receiveAccountCurrency={receiveAccountCurrency}
+          provider={provider}
+          providerData={providerData}
+          swapId={swapId}
+        />
+
+        <FooterSection explorerUrl={explorerUrl} isLoading={isFooterLoading} />
+      </Box>
+    </BottomSheetScrollView>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/TransactionHeader.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/TransactionHeader.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { Box, Skeleton, Text } from "@ledgerhq/lumen-ui-rnative";
+import CurrencyIcon from "~/components/CurrencyIcon";
+import { useTransactionHeaderViewModel } from "../hooks/useTransactionHeaderViewModel";
+
+type TransactionHeaderProps = Readonly<{
+  sendCurrency?: CryptoOrTokenCurrency;
+  receiveCurrency?: CryptoOrTokenCurrency;
+  createdAt?: number;
+  locale: string;
+}>;
+
+export function TransactionHeader({
+  sendCurrency,
+  receiveCurrency,
+  createdAt,
+  locale,
+}: TransactionHeaderProps) {
+  const { title, formattedDate } = useTransactionHeaderViewModel({
+    sendCurrency,
+    receiveCurrency,
+    createdAt,
+    locale,
+  });
+
+  return (
+    <Box lx={{ alignItems: "center", gap: "s4" }}>
+      <Box lx={{ width: "s80", height: "s72" }}>
+        {sendCurrency ? (
+          <Box lx={{ position: "absolute", left: "s0", top: "s0" }}>
+            <CurrencyIcon currency={sendCurrency} size={48} hideNetwork />
+          </Box>
+        ) : null}
+        {receiveCurrency ? (
+          <Box lx={{ position: "absolute", right: "s0", top: "s16" }}>
+            <CurrencyIcon currency={receiveCurrency} size={48} hideNetwork />
+          </Box>
+        ) : null}
+        {sendCurrency && receiveCurrency ? null : (
+          <Skeleton lx={{ height: "s48", width: "s48", borderRadius: "full" }} />
+        )}
+      </Box>
+      {title ? (
+        <Text typography="heading5SemiBold" lx={{ color: "base", textAlign: "center" }}>
+          {title}
+        </Text>
+      ) : (
+        <Skeleton lx={{ height: "s24", width: "s176" }} />
+      )}
+      {formattedDate ? (
+        <Text typography="body3" lx={{ color: "muted", textAlign: "center" }}>
+          {formattedDate}
+        </Text>
+      ) : (
+        <Skeleton lx={{ height: "s16", width: "s144" }} />
+      )}
+    </Box>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/hooks/__tests__/useCloseDrawerOnAndroidBack.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/hooks/__tests__/useCloseDrawerOnAndroidBack.test.ts
@@ -1,0 +1,66 @@
+import { BackHandler } from "react-native";
+import { renderHook } from "@tests/test-renderer";
+import { useCloseDrawerOnAndroidBack } from "../useCloseDrawerOnAndroidBack";
+
+describe("useCloseDrawerOnAndroidBack", () => {
+  let backPressHandlers: Array<() => boolean | null | undefined>;
+
+  // Mirrors RN's BackHandler: invokes registered handlers most-recent-first until one
+  // returns true. Other handlers in the render tree (e.g. navigation) register too.
+  const simulateHardwareBackPress = () => {
+    for (let i = backPressHandlers.length - 1; i >= 0; i--) {
+      if (backPressHandlers[i]()) return true;
+    }
+    return false;
+  };
+
+  beforeEach(() => {
+    backPressHandlers = [];
+    jest.spyOn(BackHandler, "addEventListener").mockImplementation((event, handler) => {
+      if (event === "hardwareBackPress") {
+        backPressHandlers.push(handler);
+      }
+      return {
+        remove: () => {
+          const index = backPressHandlers.indexOf(handler);
+          if (index >= 0) backPressHandlers.splice(index, 1);
+        },
+      } as ReturnType<typeof BackHandler.addEventListener>;
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("closes the drawer and consumes the back press when open", () => {
+    const onClose = jest.fn();
+    renderHook(() => useCloseDrawerOnAndroidBack(true, onClose));
+
+    const handled = simulateHardwareBackPress();
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(handled).toBe(true);
+  });
+
+  it("does nothing when the drawer is closed", () => {
+    const onClose = jest.fn();
+    renderHook(() => useCloseDrawerOnAndroidBack(false, onClose));
+
+    simulateHardwareBackPress();
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("stops handling back once the drawer closes", () => {
+    const onClose = jest.fn();
+    let isOpen = true;
+    const { rerender } = renderHook(() => useCloseDrawerOnAndroidBack(isOpen, onClose));
+
+    isOpen = false;
+    rerender(undefined);
+    simulateHardwareBackPress();
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/hooks/useCloseDrawerOnAndroidBack.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/hooks/useCloseDrawerOnAndroidBack.ts
@@ -1,0 +1,25 @@
+import { useEffect } from "react";
+import { BackHandler } from "react-native";
+
+/**
+ * While the swap transaction status drawer (a gorhom bottom sheet) is open, the Android
+ * hardware back button should close it first instead of navigating the screens behind it.
+ * gorhom bottom sheets don't capture the hardware back (unlike the RN Modal-based native
+ * QueuedDrawer, whose onRequestClose intercepts it), so we wire it up explicitly.
+ *
+ * Kept local to this feature for now. If we decide every bottom-sheet drawer should behave
+ * this way, this belongs in the shared QueuedDrawerBottomSheet (pending team alignment).
+ */
+export function useCloseDrawerOnAndroidBack(isOpen: boolean, onClose: () => void) {
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const subscription = BackHandler.addEventListener("hardwareBackPress", () => {
+      onClose();
+      // Consume the event so it never reaches the navigator behind the drawer.
+      return true;
+    });
+
+    return () => subscription.remove();
+  }, [isOpen, onClose]);
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/hooks/useCopyIconButtonViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/hooks/useCopyIconButtonViewModel.ts
@@ -1,0 +1,9 @@
+import { useTranslation } from "~/context/Locale";
+
+export function useCopyIconButtonViewModel() {
+  const { t } = useTranslation();
+  return {
+    copyLabel: t("transfer.swap2.modals.transactionStatus.accessibility.copySwapId"),
+    copiedText: t("transfer.swap2.modals.transactionStatus.actions.copied"),
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/hooks/useDetailsSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/hooks/useDetailsSectionViewModel.ts
@@ -1,0 +1,31 @@
+import { getSwapTransactionStatusDetailsViewModel } from "@ledgerhq/live-common/exchange/swapTransactionStatus/index";
+import type { AdditionalProviderConfig } from "@ledgerhq/live-common/exchange/providers/swap";
+import { useTranslation } from "~/context/Locale";
+
+type UseDetailsSectionViewModelProps = Readonly<{
+  provider?: string;
+  providerData?: AdditionalProviderConfig;
+  swapId: string;
+}>;
+
+export function useDetailsSectionViewModel({
+  provider,
+  providerData,
+  swapId,
+}: UseDetailsSectionViewModelProps) {
+  const { t } = useTranslation();
+  const { providerName, providerMainUrl, truncatedSwapId } =
+    getSwapTransactionStatusDetailsViewModel({ provider, providerData, swapId });
+
+  return {
+    networkFeesLabel: t("transfer.swap2.modals.transactionStatus.sections.details.networkFees"),
+    receiveAccountLabel: t(
+      "transfer.swap2.modals.transactionStatus.sections.details.receiveAccount",
+    ),
+    providerLabel: t("transfer.swap2.modals.transactionStatus.sections.details.provider"),
+    swapIdLabel: t("transfer.swap2.modals.transactionStatus.sections.details.swapId"),
+    providerName,
+    providerMainUrl,
+    truncatedSwapId,
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/hooks/useFooterSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/hooks/useFooterSectionViewModel.ts
@@ -1,0 +1,8 @@
+import { useTranslation } from "~/context/Locale";
+
+export function useFooterSectionViewModel() {
+  const { t } = useTranslation();
+  return {
+    viewInExplorerLabel: t("transfer.swap2.modals.transactionStatus.actions.viewInExplorer"),
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/hooks/useStatusSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/hooks/useStatusSectionViewModel.ts
@@ -1,0 +1,44 @@
+import { getSwapTransactionStatusSectionItems } from "@ledgerhq/live-common/exchange/swapTransactionStatus/index";
+import type { TransactionStatusValue } from "@ledgerhq/live-common/wallet-api/Exchange/transactionStatus/index";
+import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { useTranslation } from "~/context/Locale";
+
+const TRANSLATION_PREFIX = "transfer.swap2.modals.transactionStatus";
+
+type UseStatusSectionViewModelProps = Readonly<{
+  sendCurrency?: CryptoOrTokenCurrency;
+  receiveCurrency?: CryptoOrTokenCurrency;
+  sendStatus: TransactionStatusValue;
+  receiveStatus: TransactionStatusValue;
+}>;
+
+export function useStatusSectionViewModel({
+  sendCurrency,
+  receiveCurrency,
+  sendStatus,
+  receiveStatus,
+}: UseStatusSectionViewModelProps) {
+  const { t } = useTranslation();
+  const statusItems = getSwapTransactionStatusSectionItems({
+    sendStatus,
+    receiveStatus,
+    sendTicker: sendCurrency?.ticker,
+    receiveTicker: receiveCurrency?.ticker,
+    translationPrefix: TRANSLATION_PREFIX,
+  });
+
+  return {
+    heading: t(`${TRANSLATION_PREFIX}.sections.status.heading`),
+    sendRow: {
+      status: statusItems.send.displayStatus,
+      title: t(statusItems.send.titleKey, statusItems.send.titleValues),
+      subtitle: t(statusItems.send.labelKey),
+      lineStatus: statusItems.receive.displayStatus,
+    },
+    receiveRow: {
+      status: statusItems.receive.displayStatus,
+      title: t(statusItems.receive.titleKey, statusItems.receive.titleValues),
+      subtitle: t(statusItems.receive.labelKey),
+    },
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/hooks/useSwapTransactionStatus.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/hooks/useSwapTransactionStatus.ts
@@ -1,0 +1,34 @@
+import { useCallback } from "react";
+import { log } from "@ledgerhq/logs";
+import { Linking } from "react-native";
+import {
+  type SwapTransactionStatusParams,
+  useSwapTransactionStatusController,
+  type SwapTransactionStatusControllerViewModel,
+} from "@ledgerhq/live-common/exchange/swapTransactionStatus/index";
+import { useSelector } from "~/context/hooks";
+import { accountsSelector } from "~/reducers/accounts";
+
+export function useSwapTransactionStatus({
+  params,
+  onClose,
+}: {
+  params: SwapTransactionStatusParams;
+  onClose: () => void;
+}): SwapTransactionStatusControllerViewModel {
+  const accounts = useSelector(accountsSelector);
+  const onAutoRedirect = useCallback(
+    (redirectUrl: string) => {
+      Linking.openURL(redirectUrl).catch(error => {
+        log("swap-transaction-status", "Failed to open auto-redirect URL", {
+          error,
+          url: redirectUrl,
+        });
+      });
+      onClose();
+    },
+    [onClose],
+  );
+
+  return useSwapTransactionStatusController({ params, accounts, onAutoRedirect });
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/hooks/useSwapTransactionStatusViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/hooks/useSwapTransactionStatusViewModel.ts
@@ -1,0 +1,50 @@
+import { useMemo } from "react";
+import {
+  type SwapTransactionStatusParams,
+  useSwapTransactionStatusDisplayViewModel,
+  type SwapTransactionStatusTransactionExplorerBuilder,
+} from "@ledgerhq/live-common/exchange/swapTransactionStatus/index";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { useSelector } from "~/context/hooks";
+import byFamiliesOperationDetails from "~/generated/operationDetails";
+import { flattenAccountsSelector } from "~/reducers/accounts";
+import { localeSelector } from "~/reducers/settings";
+import { useMaybeAccountName } from "~/reducers/wallet";
+import { useSwapTransactionStatus } from "./useSwapTransactionStatus";
+
+export function useSwapTransactionStatusViewModel({
+  params,
+  onClose,
+}: {
+  params: SwapTransactionStatusParams;
+  onClose: () => void;
+}) {
+  const transactionStatus = useSwapTransactionStatus({ params, onClose });
+  const accounts = useSelector(flattenAccountsSelector);
+  const locale = useSelector(localeSelector);
+
+  return useSwapTransactionStatusDisplayViewModel({
+    params,
+    transactionStatus,
+    accounts,
+    locale,
+    useReceiveAccountName: useMaybeAccountName,
+    useTransactionExplorerBuilder: useMobileTransactionExplorerBuilder,
+  });
+}
+
+export type SwapTransactionStatusViewModel = ReturnType<typeof useSwapTransactionStatusViewModel>;
+
+function useMobileTransactionExplorerBuilder(
+  currency: CryptoCurrency | undefined,
+): SwapTransactionStatusTransactionExplorerBuilder | undefined {
+  return useMemo(() => {
+    if (!currency) return undefined;
+    const familyDetails =
+      byFamiliesOperationDetails[currency.family as keyof typeof byFamiliesOperationDetails];
+
+    return familyDetails && "getTransactionExplorer" in familyDetails
+      ? (familyDetails.getTransactionExplorer as SwapTransactionStatusTransactionExplorerBuilder)
+      : undefined;
+  }, [currency]);
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/hooks/useTransactionHeaderViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/hooks/useTransactionHeaderViewModel.ts
@@ -1,0 +1,31 @@
+import { formatSwapTransactionStatusCreatedAt } from "@ledgerhq/live-common/exchange/swapTransactionStatus/index";
+import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { useTranslation } from "~/context/Locale";
+
+type UseTransactionHeaderViewModelProps = Readonly<{
+  sendCurrency?: CryptoOrTokenCurrency;
+  receiveCurrency?: CryptoOrTokenCurrency;
+  createdAt?: number;
+  locale: string;
+}>;
+
+export function useTransactionHeaderViewModel({
+  sendCurrency,
+  receiveCurrency,
+  createdAt,
+  locale,
+}: UseTransactionHeaderViewModelProps) {
+  const { t } = useTranslation();
+  const title =
+    sendCurrency && receiveCurrency
+      ? t("transfer.swap2.modals.transactionStatus.title", {
+          sendTicker: sendCurrency.ticker,
+          receiveTicker: receiveCurrency.ticker,
+        })
+      : undefined;
+  const formattedDate = createdAt
+    ? formatSwapTransactionStatusCreatedAt(createdAt, locale)
+    : undefined;
+
+  return { title, formattedDate };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/index.tsx
@@ -1,0 +1,1 @@
+export { SwapTransactionStatusDrawerWrapper } from "./components/SwapTransactionStatusDrawerWrapper";

--- a/apps/ledger-live-mobile/src/mvvm/hooks/useCopyToClipboard.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/useCopyToClipboard.ts
@@ -1,0 +1,31 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Platform } from "react-native";
+import Clipboard from "@react-native-clipboard/clipboard";
+
+export function useCopyToClipboard() {
+  const [isCopied, setIsCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const shouldShowCopiedFeedback = Platform.OS !== "android" || Platform.Version < 33;
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  const copyToClipboard = useCallback(
+    (text: string) => {
+      Clipboard.setString(text);
+      if (!shouldShowCopiedFeedback) return;
+
+      setIsCopied(true);
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => setIsCopied(false), 1_000);
+    },
+    [shouldShowCopiedFeedback],
+  );
+
+  const resetCopied = useCallback(() => setIsCopied(false), []);
+
+  return { copyToClipboard, isCopied, resetCopied };
+}

--- a/apps/ledger-live-mobile/src/screens/Swap/History/OperationRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/History/OperationRow.tsx
@@ -1,15 +1,15 @@
 import React, { useCallback } from "react";
 import { TouchableOpacity, StyleSheet, View } from "react-native";
-import { useNavigation, useTheme } from "@react-navigation/native";
+import { useTheme } from "@react-navigation/native";
 import { Icon } from "@ledgerhq/native-ui";
 import type { MappedSwapOperation } from "@ledgerhq/live-common/exchange/swap/types";
+import { fromSwapOperation } from "@ledgerhq/live-common/exchange/swapTransactionStatus/index";
 import LText from "~/components/LText";
 import SafeAreaView from "~/components/SafeAreaView";
 import CurrencyUnitValue from "~/components/CurrencyUnitValue";
 import { SwapStatusIndicator } from "../SwapStatusIndicator";
-import { ScreenName } from "~/const";
-import type { SwapNavigatorParamList } from "~/components/RootNavigator/types/SwapNavigator";
-import type { StackNavigatorNavigation } from "~/components/RootNavigator/types/helpers";
+import { useDispatch } from "~/context/hooks";
+import { openSwapTransactionStatusDrawer } from "~/reducers/swapTransactionStatusDrawer";
 import { useAccountName } from "~/reducers/wallet";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
 
@@ -18,17 +18,11 @@ const OperationRow = ({ item }: { item: MappedSwapOperation }) => {
   const { fromAccount, toAccount, ...routeParams } = item;
   const { swapId, fromAmount, toAmount, finalAmount, status } = routeParams;
   const displayToAmount = finalAmount?.isGreaterThan(0) ? finalAmount : toAmount;
-  const navigation = useNavigation<StackNavigatorNavigation<SwapNavigatorParamList>>();
+  const dispatch = useDispatch();
 
   const onOpenOperationDetails = useCallback(() => {
-    navigation.navigate(ScreenName.SwapOperationDetails, {
-      swapOperation: {
-        fromAccountId: fromAccount.id,
-        toAccountId: toAccount.id,
-        ...routeParams,
-      },
-    });
-  }, [navigation, routeParams, fromAccount, toAccount]);
+    dispatch(openSwapTransactionStatusDrawer(fromSwapOperation(item)));
+  }, [dispatch, item]);
 
   const fromAccountName = useAccountName(fromAccount);
   const toAccountName = useAccountName(toAccount);

--- a/apps/ledger-live-mobile/src/screens/Swap/SubScreens/PendingOperation.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/SubScreens/PendingOperation.tsx
@@ -8,9 +8,11 @@ import { track, TrackScreen } from "~/analytics";
 import Button from "~/components/Button";
 import LText from "~/components/LText";
 import { ScreenName } from "~/const";
+import { useDispatch } from "~/context/hooks";
 import IconCheck from "~/icons/Check";
 import IconClock from "~/icons/Clock";
 import { rgba } from "../../../colors";
+import { openSwapTransactionStatusDrawer } from "~/reducers/swapTransactionStatusDrawer";
 import { useSyncAllAccounts } from "../LiveApp/hooks/useSyncAllAccounts";
 import { PendingOperationParamList } from "../types";
 import { SWAP_VERSION } from "../utils";
@@ -19,6 +21,7 @@ import { hasSwapTabRoute, navigateBackToSwapTab } from "../navigation/navigateBa
 
 export function PendingOperation({ route, navigation }: PendingOperationParamList) {
   const { colors } = useTheme();
+  const dispatch = useDispatch();
   const { swapId, provider, toCurrency, fromCurrency } = route.params.swapOperation;
   const { isEmbeddedSwap, sponsored } = route.params;
   const syncAccounts = useSyncAllAccounts();
@@ -48,7 +51,14 @@ export function PendingOperation({ route, navigation }: PendingOperationParamLis
   }, []);
 
   const onComplete = useCallback(() => {
-    if (!supportsSwapTabRoute) {
+    if (supportsSwapTabRoute) {
+      navigation.dispatch(
+        CommonActions.reset({
+          index: 1,
+          routes: [{ name: ScreenName.SwapTab }, { name: ScreenName.SwapHistory }],
+        }),
+      );
+    } else {
       // In SwapSubScreensNavigator, keep navigation local to avoid resetting with unknown routes.
       navigation.dispatch(
         CommonActions.reset({
@@ -56,16 +66,10 @@ export function PendingOperation({ route, navigation }: PendingOperationParamLis
           routes: [{ name: ScreenName.SwapHistory }],
         }),
       );
-      return;
     }
 
-    navigation.dispatch(
-      CommonActions.reset({
-        index: 1,
-        routes: [{ name: ScreenName.SwapTab }, { name: ScreenName.SwapHistory }],
-      }),
-    );
-  }, [navigation, supportsSwapTabRoute]);
+    dispatch(openSwapTransactionStatusDrawer({ swapId, provider }));
+  }, [dispatch, navigation, provider, supportsSwapTabRoute, swapId]);
 
   return (
     <SafeAreaView style={[styles.root, { backgroundColor: colors.background }]}>

--- a/apps/ledger-live-mobile/src/screens/Swap/SubScreens/__tests__/PendingOperation.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/SubScreens/__tests__/PendingOperation.test.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { CommonActions } from "@react-navigation/native";
+import { render, screen, waitFor } from "@tests/test-renderer";
+import { ScreenName } from "~/const";
+import type { State } from "~/reducers/types";
+import { PendingOperation } from "../PendingOperation";
+
+function buildNavigation(routeNames: string[]) {
+  return {
+    dispatch: jest.fn(),
+    getState: () => ({ routeNames }),
+    setOptions: jest.fn(),
+  };
+}
+
+const route = {
+  params: {
+    swapOperation: {
+      swapId: "swap-1",
+      provider: "lifi",
+      status: "pending",
+      receiverAccountId: "ethereum-account",
+      operationId: "operation-1",
+      fromAmount: new BigNumber(1),
+      toAmount: new BigNumber(2),
+    },
+  },
+};
+
+describe("PendingOperation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should navigate to swap history and open transaction status details", async () => {
+    const navigation = buildNavigation([ScreenName.SwapTab, ScreenName.SwapHistory]);
+    const { store, user } = render(
+      <PendingOperation route={route as never} navigation={navigation as never} />,
+    );
+
+    await user.press(screen.getByText(/go to history/i));
+
+    expect(navigation.dispatch).toHaveBeenCalledWith(
+      CommonActions.reset({
+        index: 1,
+        routes: [{ name: ScreenName.SwapTab }, { name: ScreenName.SwapHistory }],
+      }),
+    );
+    await waitFor(() => {
+      expect(store.getState().swapTransactionStatusDrawer).toEqual<
+        State["swapTransactionStatusDrawer"]
+      >({
+        isOpen: true,
+        params: {
+          swapId: "swap-1",
+          provider: "lifi",
+        },
+      });
+    });
+  });
+
+  it("should navigate locally to swap history and open transaction status details when SwapTab is unavailable", async () => {
+    const navigation = buildNavigation([ScreenName.SwapHistory]);
+    const { store, user } = render(
+      <PendingOperation route={route as never} navigation={navigation as never} />,
+    );
+
+    await user.press(screen.getByText(/go to history/i));
+
+    expect(navigation.dispatch).toHaveBeenCalledWith(
+      CommonActions.reset({
+        index: 0,
+        routes: [{ name: ScreenName.SwapHistory }],
+      }),
+    );
+    await waitFor(() => {
+      expect(store.getState().swapTransactionStatusDrawer).toEqual<
+        State["swapTransactionStatusDrawer"]
+      >({
+        isOpen: true,
+        params: {
+          swapId: "swap-1",
+          provider: "lifi",
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
**Jira:** https://ledgerhq.atlassian.net/browse/LIVE-29443

## Summary
- Add the Mobile swap transaction status drawer UI, hooks, translations, and tests.
- Wire swap history and post-swap pending operation flows to open the new drawer.
- Bundle the NotificationsPrompt swap-flow test update as a test-only adjustment for the new drawer queue behavior.

## Review Scope
- Primary: `@ledgerhq/ptx` for the swap transaction status feature and swap screen entry points.
- Additional: `@ledgerhq/wallet-xp` for Mobile drawer integration and shared Mobile app wiring.
- Note: `NotificationsPromptSwapFlow.test.tsx` is Engagement-owned but included here as a mechanical test update tied to the new drawer behavior.

## Validation
- Mobile swap transaction status unit and integration tests passed.
- `PendingOperation` focused test passed.
- `NotificationsPromptSwapFlow` integration test passed.

<img width="350" alt="Screenshot_20260622_155807_LL  DEV" src="https://github.com/user-attachments/assets/9be38ed3-edb6-43ed-9f6c-768d84ad4b61" />
<img width="350" alt="Screenshot_20260622_143410_LL  DEV" src="https://github.com/user-attachments/assets/c1c7f977-0f59-4155-96b7-b7b240696b9e" />

<!-- stac-man:stack-start -->
**Stack** _(managed by [stac-man](https://github.com/bluegardenproject/stac-man))_

- **#17458 feat/LIVE-29447-mobile-swap-transaction-status ← this PR**
- #19156 bugfix/LIVE-29447-swap-status-final-amount
<!-- stac-man:stack-end -->