### PR TITLE
chore: make ptx owners of swap cli commands

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -167,6 +167,7 @@ libs/coin-modules/coin-aleo/                                             @ledger
 # PTX team
 apps/cli/src/commands/ptx                                            					@ledgerhq/ptx
 apps/wallet-cli/src/commands/swap/                                            @ledgerhq/ptx
+apps/wallet-cli/src/test/commands/swap/                                       @ledgerhq/ptx
 apps/ledger-live-desktop/src/renderer/components/ProviderIcon/       					@ledgerhq/ptx
 apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/       					@ledgerhq/ptx
 apps/ledger-live-desktop/src/renderer/hooks/swap-migrations/         					@ledgerhq/ptx

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -166,6 +166,7 @@ libs/coin-modules/coin-aleo/                                             @ledger
 
 # PTX team
 apps/cli/src/commands/ptx                                            					@ledgerhq/ptx
+apps/wallet-cli/src/commands/swap/                                            @ledgerhq/ptx
 apps/ledger-live-desktop/src/renderer/components/ProviderIcon/       					@ledgerhq/ptx
 apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/       					@ledgerhq/ptx
 apps/ledger-live-desktop/src/renderer/hooks/swap-migrations/         					@ledgerhq/ptx

--- a/apps/wallet-cli/src/test/commands/swap/execute.test.ts
+++ b/apps/wallet-cli/src/test/commands/swap/execute.test.ts
@@ -1,15 +1,15 @@
-import { ETH_SYNC_ROUTES } from "../helpers/eth-sync-routes";
-import { MockServer } from "../helpers/mock-server";
-import "../../live-common-setup";
+import { ETH_SYNC_ROUTES } from "../../helpers/eth-sync-routes";
+import { MockServer } from "../../helpers/mock-server";
+import "../../../live-common-setup";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { BigNumber } from "bignumber.js";
 import type { Account } from "@ledgerhq/types-live";
 import type { getAccountBridge as getLiveAccountBridge } from "@ledgerhq/live-common/bridge/index";
-import { installOutputCapture } from "../../shared/ui";
-import type { AccountDescriptor } from "../../wallet/models";
-import { MOCK_ETH_DESCRIPTOR } from "../../test/helpers/constants";
-import { executeSwapCommand, type SwapExecuteFlags } from "../../commands/swap/execute";
-import type { FullSwapPipelineInput } from "../../commands/swap/cli-swap-pipeline";
+import { installOutputCapture } from "../../../shared/ui";
+import type { AccountDescriptor } from "../../../wallet/models";
+import { MOCK_ETH_DESCRIPTOR } from "../../../test/helpers/constants";
+import { executeSwapCommand, type SwapExecuteFlags } from "../../../commands/swap/execute";
+import type { FullSwapPipelineInput } from "../../../commands/swap/cli-swap-pipeline";
 
 const mockPipelineResult = {
   transactionId: "mock-device-transaction-id",

--- a/apps/wallet-cli/src/test/commands/swap/quote.test.ts
+++ b/apps/wallet-cli/src/test/commands/swap/quote.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach } from "bun:test";
-import { MockServer } from "../helpers/mock-server";
-import { runCli } from "../helpers/cli-runner";
-import { makeSessionDir } from "../helpers/session-fixture";
-import { ETH_ADDRESS, ETH_DESCRIPTOR } from "../helpers/constants";
+import { MockServer } from "../../helpers/mock-server";
+import { runCli } from "../../helpers/cli-runner";
+import { makeSessionDir } from "../../helpers/session-fixture";
+import { ETH_ADDRESS, ETH_DESCRIPTOR } from "../../helpers/constants";
 
 /** Minimal `RawQuote` row for `/quote` — enough for `normalizeQuote` + `buildQuoteDetails`. */
 const MOCK_QUOTE_ROW = {

--- a/apps/wallet-cli/src/test/commands/swap/status.test.ts
+++ b/apps/wallet-cli/src/test/commands/swap/status.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "bun:test";
-import { MockServer } from "../helpers/mock-server";
-import { runCli } from "../helpers/cli-runner";
+import { MockServer } from "../../helpers/mock-server";
+import { runCli } from "../../helpers/cli-runner";
 
 const SWAP_ID = "swap-123";
 const PROVIDER = "exodus";


### PR DESCRIPTION
I think PTX should own the code in `apps/wallet-cli/src/commands/swap/`