### PR TITLE
fix(mobile): bound e2e failure-capture to prevent multi-minute CI hangs

### DIFF
--- a/e2e/mobile/jest.environment.ts
+++ b/e2e/mobile/jest.environment.ts
@@ -34,6 +34,44 @@ import { ServerData } from "../../apps/ledger-live-mobile/e2e/bridge/types";
 
 // @ts-expect-error detox doesn't provide type declarations for this module
 import DetoxEnvironment from "detox/runners/jest/testEnvironment";
+import { withTimeout } from "./utils/withTimeout";
+
+const FAST_DIAGNOSTIC_TIMEOUT_MS = 5_000;
+const SLOW_DIAGNOSTIC_TIMEOUT_MS = 15_000;
+
+async function captureFailureDiagnostics(): Promise<void> {
+  await withTimeout(takeSpeculosScreenshot(), FAST_DIAGNOSTIC_TIMEOUT_MS, "takeSpeculosScreenshot");
+  await withTimeout(
+    takeAppScreenshot("Test Failure"),
+    FAST_DIAGNOSTIC_TIMEOUT_MS,
+    "takeAppScreenshot",
+  );
+  await withTimeout(
+    attachTestExecutionConsoleToAllure(),
+    FAST_DIAGNOSTIC_TIMEOUT_MS,
+    "attachTestExecutionConsoleToAllure",
+  );
+  await withTimeout(
+    attachSpeculosStartupErrorToAllure(),
+    FAST_DIAGNOSTIC_TIMEOUT_MS,
+    "attachSpeculosStartupErrorToAllure",
+  );
+  // getLogs has its own 10s RESPONSE_TIMEOUT inside the bridge; this outer bound
+  // is just defense-in-depth in case the inner timer is starved on a wedged worker.
+  const logs = await withTimeout(getLogs(), 12_000, "getLogs");
+  if (logs)
+    await withTimeout(
+      attachFailureLogsToAllure(logs),
+      SLOW_DIAGNOSTIC_TIMEOUT_MS,
+      "attachFailureLogsToAllure",
+    );
+  await withTimeout(
+    captureNativeViewHierarchy(),
+    SLOW_DIAGNOSTIC_TIMEOUT_MS,
+    "captureNativeViewHierarchy",
+  );
+  console.info("Failure diagnostics capture completed");
+}
 
 export default class TestEnvironment extends DetoxEnvironment {
   declare global: typeof globalThis;
@@ -181,8 +219,9 @@ export default class TestEnvironment extends DetoxEnvironment {
       }
 
       try {
-        const { DeviceManagementKitTransportSpeculos } =
-          await import("@ledgerhq/live-dmk-speculos");
+        const { DeviceManagementKitTransportSpeculos } = await import(
+          "@ledgerhq/live-dmk-speculos"
+        );
         await DeviceManagementKitTransportSpeculos.disconnectAll();
       } catch {
         // Ignore cleanup errors
@@ -201,18 +240,7 @@ export default class TestEnvironment extends DetoxEnvironment {
 
     if (["hook_failure", "test_fn_failure"].includes(event.name)) {
       this.global.IS_FAILED = true;
-      await takeSpeculosScreenshot();
-      await takeAppScreenshot("Test Failure");
-      try {
-        await attachTestExecutionConsoleToAllure();
-        await attachSpeculosStartupErrorToAllure();
-        const logsPayload = await getLogs();
-        await attachFailureLogsToAllure(logsPayload);
-        await captureNativeViewHierarchy();
-        console.info("Failure logs attached to Allure report");
-      } catch (err) {
-        console.warn("Failed to attach failure logs to Allure:", err);
-      }
+      await captureFailureDiagnostics();
     }
 
     if (event.name === "run_start") {

--- a/e2e/mobile/jest.globalTeardown.ts
+++ b/e2e/mobile/jest.globalTeardown.ts
@@ -20,6 +20,7 @@ import { log } from "detox";
 import { Subject } from "rxjs";
 import { NativeElementHelpers } from "./helpers/elementHelpers";
 import { sanitizeError } from "@ledgerhq/live-common/e2e/index";
+import { withTimeout } from "./utils/withTimeout";
 
 const ARTIFACT_ENV_PATH = path.resolve("artifacts/environment.properties");
 const USERDATA_DIR = path.resolve(__dirname, "userdata");
@@ -34,30 +35,6 @@ globalThis.webSocket = {
   e2eBridgeServer: new Subject(),
 };
 globalThis.pendingCallbacks = new Map<string, { callback: (data: string) => void }>();
-
-// Helper to wrap operations with a timeout to prevent CI hangs
-async function withTimeout<T>(
-  promise: Promise<T>,
-  timeoutMs: number,
-  operationName: string,
-): Promise<T | undefined> {
-  let timeoutId: ReturnType<typeof setTimeout>;
-  const timeoutPromise = new Promise<undefined>(resolve => {
-    timeoutId = setTimeout(() => {
-      log.warn(`${operationName} timed out after ${timeoutMs}ms, continuing...`);
-      resolve(undefined);
-    }, timeoutMs);
-  });
-
-  try {
-    const result = await Promise.race([promise, timeoutPromise]);
-    clearTimeout(timeoutId!);
-    return result;
-  } catch (err) {
-    clearTimeout(timeoutId!);
-    throw err;
-  }
-}
 
 export default async () => {
   if (process.env.CI && process.env.SHARD_INDEX === "1") {
@@ -88,8 +65,9 @@ export default async () => {
     }
   }
 
-  // default Detox teardown with timeout protection to prevent CI hangs from proper-lockfile issues
-  await withTimeout(globalTeardown(), 60_000, "globalTeardown");
+  // default Detox teardown with timeout protection to prevent CI hangs from proper-lockfile issues.
+  // Surface real failures (orphaned simulators, broken cleanup) instead of swallowing them.
+  await withTimeout(globalTeardown(), 60_000, "globalTeardown", { rethrow: true });
 
   // parallel file cleanups and force close any lingering connections
   await Promise.all([cleanupUserdata(), forceGarbageCollection()]);

--- a/e2e/mobile/utils/withTimeout.ts
+++ b/e2e/mobile/utils/withTimeout.ts
@@ -1,0 +1,53 @@
+import { log } from "detox";
+import { sanitizeError } from "@ledgerhq/live-common/e2e/index";
+
+/**
+ * Race a promise against a timeout. Timeouts always warn-and-resolve-`undefined`;
+ * rejection swallowing is opt-out via `rethrow: true` for teardown ops that
+ * should fail loud.
+ *
+ * `Promise.race` cannot cancel: if the underlying operation settles after the
+ * timeout, a "late side effects possible" warning is logged. Any late rejection
+ * is silenced so it doesn't surface as an `unhandledRejection`.
+ *
+ * @param promise   The operation to bound.
+ * @param timeoutMs Timeout budget in milliseconds.
+ * @param label     Identifier used in warning logs.
+ * @param options.rethrow When `true`, rejections propagate to the caller
+ *                  instead of being swallowed. Timeouts are always swallowed.
+ * @returns The resolved value, or `undefined` on timeout / swallowed rejection.
+ */
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  label: string,
+  options: { rethrow?: boolean } = {},
+): Promise<T | undefined> {
+  let timedOut = false;
+  promise.then(
+    () => {
+      if (timedOut) log.warn(`${label} completed after timeout — late side effects possible`);
+    },
+    err => {
+      if (timedOut) log.warn(`${label} rejected after timeout: ${sanitizeError(err)}`);
+    },
+  );
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<undefined>(resolve => {
+    timer = setTimeout(() => {
+      timedOut = true;
+      log.warn(`${label} timed out after ${timeoutMs}ms; skipping`);
+      resolve(undefined);
+    }, timeoutMs);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } catch (err) {
+    if (options.rethrow) throw err;
+    log.warn(`${label} failed: ${sanitizeError(err)}`);
+    return undefined;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- Bound each step of mobile e2e failure-diagnostic capture with `withTimeout` so a hung Detox bridge call (`takeScreenshot`, `generateViewHierarchyXml`) can no longer eat the full [72-minute iOS Detox](https://github.com/LedgerHQ/ledger-live/actions/runs/25841507505/job/75927743687#step:16:620) step budget
- Per-step budgets: **5s** for fast device/local ops (screenshots, console + speculos-startup-error attachments), **15s** for bridge / native / large-payload ops (`getLogs`, `attachFailureLogsToAllure`, `captureNativeViewHierarchy`) — worst case 65s, real wedge case ~30s
- Each timeout logs the step label (e.g. `takeAppScreenshot timed out after 5000ms; skipping`) so triage knows exactly which call hung
- Extract `withTimeout` from `jest.globalTeardown.ts` into shared `e2e/mobile/utils/withTimeout.ts`; standardize semantics to warn-and-resolve-`undefined` on both timeout and rejection (callers no longer need a surrounding try/catch)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:  [QAA-1220](https://ledgerhq.atlassian.net/browse/QAA-1220)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-1220]: https://ledgerhq.atlassian.net/browse/QAA-1220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ