### PR TITLE
[LWDM][Tezos] Stake flow

### DIFF
--- a/.changeset/fifty-clocks-poke.md
+++ b/.changeset/fifty-clocks-poke.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add Tezos stake flow modal (LIVE-29536). Wires the Stake CTA from the Earning Choice modal to a 5-step flow (validator → confirm delegation → amount → confirm staking → confirmation) for non-delegated accounts, or a 3-step flow (amount → confirm staking → confirmation) when entered with `skipDelegation: true` from an already-delegated account.

--- a/.changeset/silver-baboons-trade.md
+++ b/.changeset/silver-baboons-trade.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Drop the staking amount clamp in transactionToIntent so coin modules can receive the user-typed transaction amount for stake/unstake/finalize_unstake intents.
+Previously the framework forced amount=0n and useAllAmount=true for any staking intent, which prevented partial-amount staking for tezos. EVM/XRP/Stellar never produce these intent types, so they are unaffected.
+
+Also log rejections from `loadAccountDelegation` in `useDelegation` instead of silently swallowing them, so failed delegation fetches are observable.

--- a/.changeset/slimy-chicken-scream.md
+++ b/.changeset/slimy-chicken-scream.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-tezos": patch
+---
+
+Fall back to requestedAmount (or 0) when parsing failed staking operations from TzKT. Failed stake ops return only requestedAmount and no amount field;
+BigInt(undefined) was throwing and stalling account sync on any account that has a failed staking operation in its history.

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/EarningChoiceModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/EarningChoiceModal/Body.tsx
@@ -145,13 +145,7 @@ const Body = ({ onClose, params }: Props) => {
                 <Bullet i18nKey="tezos.earnChoice.stake.bullet.3" />
               </OptionCard>
               <Box alignItems="center">
-                {/* Pending LIVE-29536: enable once the Stake flow ships (https://ledgerhq.atlassian.net/browse/LIVE-29536). */}
-                <Button
-                  primary
-                  disabled
-                  data-testid="tezos-earn-choice-stake-button"
-                  onClick={onStake}
-                >
+                <Button primary data-testid="tezos-earn-choice-stake-button" onClick={onStake}>
                   <Trans i18nKey="tezos.earnChoice.stake.cta" />
                 </Button>
               </Box>

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/EarningChoiceModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/EarningChoiceModal/Body.tsx
@@ -86,6 +86,7 @@ const Body = ({ onClose, params }: Props) => {
   }, [dispatch, account, parentAccount, source]);
 
   const onStake = useCallback(() => {
+    if (account.type !== "Account") return;
     dispatch(closeModal(MODAL_NAME));
     dispatch(openModal("MODAL_TEZOS_STAKE", { account, parentAccount, source }));
   }, [dispatch, account, parentAccount, source]);

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/EarningChoiceModal/__tests__/Body.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/EarningChoiceModal/__tests__/Body.test.tsx
@@ -34,8 +34,15 @@ describe("EarningChoiceModal/Body", () => {
     expect(modals.MODAL_DELEGATE?.isOpened).toBe(true);
   });
 
-  it("Stake button is disabled until LIVE-29536 ships", () => {
-    render(<Body onClose={jest.fn()} params={{ account }} />);
-    expect(screen.getByTestId("tezos-earn-choice-stake-button")).toBeDisabled();
+  it("clicking Stake closes the choice modal and opens MODAL_TEZOS_STAKE", async () => {
+    const { user, store } = render(<Body onClose={jest.fn()} params={{ account }} />);
+
+    await act(async () => {
+      await user.click(screen.getByTestId("tezos-earn-choice-stake-button"));
+    });
+
+    const modals = store.getState().modals;
+    expect(modals.MODAL_TEZOS_EARNING_CHOICE?.isOpened).toBe(false);
+    expect(modals.MODAL_TEZOS_STAKE?.isOpened).toBe(true);
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/Body.tsx
@@ -1,0 +1,229 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { bindActionCreators } from "redux";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
+import { Trans, useTranslation } from "react-i18next";
+import invariant from "invariant";
+import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { Operation, TokenAccount } from "@ledgerhq/types-live";
+import { addPendingOperation, getMainAccount } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
+import { useBakers } from "@ledgerhq/live-common/families/tezos/react";
+import { whitelist } from "@ledgerhq/live-common/families/tezos/staking";
+import { TezosAccount, Transaction } from "@ledgerhq/live-common/families/tezos/types";
+import logger from "~/renderer/logger";
+import Track from "~/renderer/analytics/Track";
+import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
+import { openModal } from "~/renderer/actions/modals";
+import { getCurrentDevice } from "~/renderer/reducers/devices";
+import Stepper from "~/renderer/components/Stepper";
+import StepValidator from "./steps/StepValidator";
+import StepDeviceDelegation from "./steps/StepDeviceDelegation";
+import StepAmount, { StepAmountFooter } from "./steps/StepAmount";
+import StepDeviceStaking from "./steps/StepDeviceStaking";
+import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmation";
+import { St, StepId, StepProps } from "./types";
+
+export type Data = {
+  account: TezosAccount | TokenAccount;
+  parentAccount?: TezosAccount | null;
+  source?: string;
+  skipDelegation?: boolean;
+};
+
+type Props = {
+  stepId: StepId;
+  onClose: () => void;
+  onChangeStepId: (a: StepId) => void;
+  params: Data;
+};
+
+const fullSteps: Array<St> = [
+  {
+    id: "validator",
+    label: <Trans i18nKey="tezos.stake.flow.steps.validator.title" />,
+    component: StepValidator,
+    noScroll: true,
+  },
+  {
+    id: "device-delegation",
+    label: <Trans i18nKey="tezos.stake.flow.steps.deviceDelegation.title" />,
+    component: StepDeviceDelegation,
+    onBack: ({ transitionTo }: StepProps) => transitionTo("validator"),
+  },
+  {
+    id: "amount",
+    label: <Trans i18nKey="tezos.stake.flow.steps.amount.title" />,
+    component: StepAmount,
+    footer: StepAmountFooter,
+    noScroll: true,
+  },
+  {
+    id: "device-staking",
+    label: <Trans i18nKey="tezos.stake.flow.steps.deviceStaking.title" />,
+    component: StepDeviceStaking,
+    onBack: ({ transitionTo }: StepProps) => transitionTo("amount"),
+  },
+  {
+    id: "confirmation",
+    label: <Trans i18nKey="tezos.stake.flow.steps.confirmation.title" />,
+    component: StepConfirmation,
+    footer: StepConfirmationFooter,
+  },
+];
+
+const stakeOnlySteps: Array<St> = fullSteps.filter(
+  s => s.id !== "validator" && s.id !== "device-delegation",
+);
+
+const Body = ({ stepId, params, onClose, onChangeStepId }: Props) => {
+  invariant(
+    params.account?.type === "Account",
+    "MODAL_TEZOS_STAKE: a Tezos main account is required (TokenAccount not supported).",
+  );
+
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const device = useSelector(getCurrentDevice);
+  const [defaultBaker] = useBakers(whitelist);
+  const skipDelegation = !!params.skipDelegation;
+
+  const bridge = useAccountBridge<Transaction>(params.account, params.parentAccount);
+
+  const {
+    transaction,
+    setTransaction,
+    updateTransaction,
+    account,
+    parentAccount,
+    status,
+    bridgeError,
+    bridgePending,
+  } = useBridgeTransaction<Transaction>(bridge, () => {
+    invariant(params.account, "tezos: account required");
+    const initial = bridge.createTransaction(params.account);
+    const initialTx = bridge.updateTransaction(initial, {
+      mode: skipDelegation ? "stake" : "delegate",
+    });
+    return {
+      account: params.account,
+      parentAccount: params.parentAccount ?? undefined,
+      transaction: initialTx,
+    };
+  });
+
+  const [optimisticOperation, setOptimisticOperation] = useState<Operation | null>(null);
+  const [transactionError, setTransactionError] = useState<Error | null>(null);
+  const [signed, setSigned] = useState(false);
+  const [failedStep, setFailedStep] = useState<StepId | null>(null);
+
+  const steps = skipDelegation ? stakeOnlySteps : fullSteps;
+  // Parent seeds stepId to "validator"; skipDelegation excludes it — fall back to the first available step.
+  const effectiveStepId = steps.some(s => s.id === stepId) ? stepId : steps[0].id;
+  useEffect(() => {
+    if (stepId !== effectiveStepId) onChangeStepId(effectiveStepId);
+  }, [effectiveStepId, onChangeStepId, stepId]);
+
+  useEffect(() => {
+    if (skipDelegation || !transaction) return;
+    if (transaction.mode !== "delegate" || transaction.recipient || !defaultBaker?.address) return;
+    setTransaction(bridge.updateTransaction(transaction, { recipient: defaultBaker.address }));
+  }, [bridge, defaultBaker, setTransaction, skipDelegation, transaction]);
+
+  const handleOpenModal = useMemo(() => bindActionCreators(openModal, dispatch), [dispatch]);
+
+  const handleRetry = useCallback(() => {
+    setTransactionError(null);
+    setOptimisticOperation(null);
+    setSigned(false);
+  }, []);
+
+  const handleTransactionError = useCallback(
+    (error: Error) => {
+      if (!(error instanceof UserRefusedOnDevice)) {
+        logger.critical(error);
+      }
+      setTransactionError(error);
+      setFailedStep(effectiveStepId);
+    },
+    [effectiveStepId],
+  );
+
+  const handleOperationBroadcasted = useCallback(
+    (op: Operation) => {
+      if (!account) return;
+      const mainAccount = getMainAccount(account, parentAccount);
+      dispatch(updateAccountWithUpdater(mainAccount.id, a => addPendingOperation(a, op)));
+
+      if (effectiveStepId === "device-delegation") {
+        // StepDeviceDelegation intercepts the post-broadcast transitionTo("confirmation") and lands on "amount".
+        const fresh = bridge.updateTransaction(bridge.createTransaction(account), {
+          mode: "stake",
+        });
+        setTransaction(fresh);
+        setOptimisticOperation(null);
+        setSigned(false);
+        setTransactionError(null);
+        setFailedStep(null);
+        return;
+      }
+
+      setOptimisticOperation(op);
+      setTransactionError(null);
+    },
+    [account, bridge, dispatch, effectiveStepId, parentAccount, setTransaction],
+  );
+
+  const handleStepChange = useCallback((e: St) => onChangeStepId(e.id), [onChangeStepId]);
+
+  const errorSteps: number[] = [];
+  if (transactionError && failedStep) {
+    const idx = steps.findIndex(s => s.id === failedStep);
+    if (idx >= 0) errorSteps.push(idx);
+  } else if (bridgeError) {
+    errorSteps.push(0);
+  }
+
+  const error = transactionError || bridgeError;
+
+  const stepperProps = {
+    title: t("tezos.stake.flow.title"),
+    stepId: effectiveStepId,
+    steps,
+    errorSteps,
+    disabledSteps: [],
+    hideBreadcrumb: !!error && effectiveStepId === "validator",
+    device,
+    account,
+    parentAccount,
+    transaction,
+    signed,
+    error,
+    status,
+    bridgePending,
+    optimisticOperation,
+    openModal: handleOpenModal,
+    failedStep,
+    source: params.source ?? "Account Page",
+    onClose,
+    onChangeTransaction: setTransaction,
+    onUpdateTransaction: updateTransaction,
+    onOperationBroadcasted: handleOperationBroadcasted,
+    onTransactionError: handleTransactionError,
+    onRetry: handleRetry,
+    onStepChange: handleStepChange,
+    setSigned,
+  };
+
+  if (!status) return null;
+
+  return (
+    <Stepper {...stepperProps}>
+      <SyncSkipUnderPriority priority={100} />
+      <Track onUnmount event="CloseModalTezosStake" />
+    </Stepper>
+  );
+};
+
+export default Body;

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/Body.tsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { Trans, useTranslation } from "react-i18next";
 import invariant from "invariant";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { Operation, TokenAccount } from "@ledgerhq/types-live";
+import { Operation } from "@ledgerhq/types-live";
 import { addPendingOperation, getMainAccount } from "@ledgerhq/live-common/account/index";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -23,10 +23,10 @@ import StepDeviceDelegation from "./steps/StepDeviceDelegation";
 import StepAmount, { StepAmountFooter } from "./steps/StepAmount";
 import StepDeviceStaking from "./steps/StepDeviceStaking";
 import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmation";
-import { St, StepId, StepProps } from "./types";
+import { Step, StepId, StepProps } from "./types";
 
 export type Data = {
-  account: TezosAccount | TokenAccount;
+  account: TezosAccount;
   parentAccount?: TezosAccount | null;
   source?: string;
   skipDelegation?: boolean;
@@ -39,7 +39,7 @@ type Props = {
   params: Data;
 };
 
-const fullSteps: Array<St> = [
+const fullSteps: Array<Step> = [
   {
     id: "validator",
     label: <Trans i18nKey="tezos.stake.flow.steps.validator.title" />,
@@ -73,7 +73,7 @@ const fullSteps: Array<St> = [
   },
 ];
 
-const stakeOnlySteps: Array<St> = fullSteps.filter(
+const stakeOnlySteps: Array<Step> = fullSteps.filter(
   s => s.id !== "validator" && s.id !== "device-delegation",
 );
 
@@ -175,7 +175,7 @@ const Body = ({ stepId, params, onClose, onChangeStepId }: Props) => {
     [account, bridge, dispatch, effectiveStepId, parentAccount, setTransaction],
   );
 
-  const handleStepChange = useCallback((e: St) => onChangeStepId(e.id), [onChangeStepId]);
+  const handleStepChange = useCallback((e: Step) => onChangeStepId(e.id), [onChangeStepId]);
 
   const errorSteps: number[] = [];
   if (transactionError && failedStep) {

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/Body.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/Body.test.tsx
@@ -1,0 +1,225 @@
+import React, { useState } from "react";
+import BigNumber from "bignumber.js";
+import { act, render, screen } from "tests/testSetup";
+import {
+  getCryptoCurrencyById,
+  setSupportedCurrencies,
+} from "@ledgerhq/live-common/currencies/index";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import type { TezosAccount } from "@ledgerhq/live-common/families/tezos/types";
+import type { StepId } from "../types";
+
+type StakingInfo = ReturnType<
+  typeof import("@ledgerhq/live-common/families/tezos/react").useTezosStakingInfo
+>;
+
+const stakingInfoMock = jest.fn<StakingInfo, []>();
+const bakersMock = jest.fn<unknown[], []>(() => [
+  {
+    address: "tz1baker",
+    name: "Baker A",
+    logoURL: "",
+    nominalYield: "5 %",
+    capacityStatus: "normal",
+  },
+]);
+
+jest.mock("@ledgerhq/live-common/families/tezos/react", () => ({
+  __esModule: true,
+  useBakers: () => bakersMock(),
+  useTezosStakingInfo: () => stakingInfoMock(),
+  useDelegation: () => null,
+  useBaker: () => undefined,
+}));
+
+jest.mock("../steps/StepValidator", () => ({
+  __esModule: true,
+  default: () => <div data-testid="step-validator">validator</div>,
+}));
+
+const makeOp = (accountId: string | undefined) => ({
+  id: "op-1",
+  hash: "h",
+  accountId: accountId ?? "",
+  type: "OUT" as const,
+  value: new BigNumber(0),
+  fee: new BigNumber(0),
+  senders: [],
+  recipients: [],
+  blockHeight: null,
+  blockHash: null,
+  transactionSequenceNumber: 0,
+  date: new Date(),
+  extra: {},
+});
+
+jest.mock("../steps/StepDeviceDelegation", () => ({
+  __esModule: true,
+  default: (props: any) => (
+    <div data-testid="step-device-delegation">
+      <button
+        data-testid="device-delegation-broadcast"
+        onClick={() => {
+          props.onOperationBroadcasted(makeOp(props.account?.id));
+          props.transitionTo("amount");
+        }}
+      >
+        broadcast
+      </button>
+      <button
+        data-testid="device-delegation-error"
+        onClick={() => {
+          props.onTransactionError(new Error("dev-error"));
+          props.transitionTo("confirmation");
+        }}
+      >
+        error
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock("../steps/StepAmount", () => ({
+  __esModule: true,
+  default: () => <div data-testid="step-amount">amount</div>,
+  StepAmountFooter: () => null,
+}));
+
+jest.mock("../steps/StepDeviceStaking", () => ({
+  __esModule: true,
+  default: (props: any) => (
+    <div data-testid="step-device-staking">
+      <button
+        data-testid="device-staking-error"
+        onClick={() => {
+          props.onTransactionError(new Error("dev-error"));
+          props.transitionTo("confirmation");
+        }}
+      >
+        error
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock("../steps/StepConfirmation", () => ({
+  __esModule: true,
+  default: (props: any) => (
+    <div data-testid="step-confirmation">
+      <span data-testid="failed-step">{props.failedStep ?? ""}</span>
+    </div>
+  ),
+  StepConfirmationFooter: () => null,
+}));
+
+import Body from "../Body";
+
+setSupportedCurrencies(["tezos"]);
+
+const currency = getCryptoCurrencyById("tezos");
+
+const makeAccount = (): TezosAccount =>
+  ({
+    ...genAccount("tezos-stake-test", { currency }),
+  }) as unknown as TezosAccount;
+
+const defaultStakingInfo: StakingInfo = {
+  isDelegated: false,
+  isStaked: false,
+  hasUnstaking: false,
+  delegation: null,
+  stakedBalance: new BigNumber(0),
+  unstakedBalance: new BigNumber(0),
+  unstakedFinalizable: new BigNumber(0),
+  availableBalance: new BigNumber(1_000_000),
+  delegateAddress: undefined,
+};
+
+beforeEach(() => {
+  stakingInfoMock.mockReturnValue(defaultStakingInfo);
+});
+
+const ControlledBody = ({
+  initialStep,
+  skipDelegation,
+}: {
+  initialStep: StepId;
+  skipDelegation: boolean;
+}) => {
+  const [stepId, setStepId] = useState<StepId>(initialStep);
+  const account = makeAccount();
+  return (
+    <Body
+      stepId={stepId}
+      onClose={jest.fn()}
+      onChangeStepId={setStepId}
+      params={{ account, skipDelegation }}
+    />
+  );
+};
+
+describe("StakeFlowModal/Body", () => {
+  it("renders the validator step first when skipDelegation is false", async () => {
+    const account = makeAccount();
+    await act(async () => {
+      render(
+        <Body
+          stepId="validator"
+          onClose={jest.fn()}
+          onChangeStepId={jest.fn()}
+          params={{ account, skipDelegation: false }}
+        />,
+      );
+    });
+    expect(screen.getByTestId("step-validator")).toBeInTheDocument();
+  });
+
+  it("starts on the amount step when skipDelegation is true", async () => {
+    const account = makeAccount();
+    const onChangeStepId = jest.fn();
+    await act(async () => {
+      render(
+        <Body
+          stepId="validator"
+          onClose={jest.fn()}
+          onChangeStepId={onChangeStepId}
+          params={{ account, skipDelegation: true }}
+        />,
+      );
+    });
+    expect(onChangeStepId).toHaveBeenCalledWith("amount");
+  });
+
+  it("broadcasting from device-delegation navigates to the amount step", async () => {
+    const { user } = render(
+      <ControlledBody initialStep="device-delegation" skipDelegation={false} />,
+    );
+    expect(screen.getByTestId("step-device-delegation")).toBeInTheDocument();
+    await act(async () => {
+      await user.click(screen.getByTestId("device-delegation-broadcast"));
+    });
+    expect(screen.getByTestId("step-amount")).toBeInTheDocument();
+  });
+
+  it("error at device-staking surfaces failedStep on the confirmation step", async () => {
+    const { user } = render(<ControlledBody initialStep="device-staking" skipDelegation={true} />);
+    expect(screen.getByTestId("step-device-staking")).toBeInTheDocument();
+    await act(async () => {
+      await user.click(screen.getByTestId("device-staking-error"));
+    });
+    expect(screen.getByTestId("step-confirmation")).toBeInTheDocument();
+    expect(screen.getByTestId("failed-step")).toHaveTextContent("device-staking");
+  });
+
+  it("error at device-delegation surfaces failedStep on the confirmation step", async () => {
+    const { user } = render(
+      <ControlledBody initialStep="device-delegation" skipDelegation={false} />,
+    );
+    expect(screen.getByTestId("step-device-delegation")).toBeInTheDocument();
+    await act(async () => {
+      await user.click(screen.getByTestId("device-delegation-error"));
+    });
+    expect(screen.getByTestId("step-confirmation")).toBeInTheDocument();
+    expect(screen.getByTestId("failed-step")).toHaveTextContent("device-delegation");
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/StepAmount.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/StepAmount.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import BigNumber from "bignumber.js";
-import { act, render } from "tests/testSetup";
+import { act, fireEvent, render, screen } from "tests/testSetup";
 import {
   getCryptoCurrencyById,
   setSupportedCurrencies,
@@ -11,21 +11,23 @@ import type { StepProps } from "../types";
 
 const syncDispatchMock = jest.fn();
 const useDelegationMock = jest.fn().mockReturnValue(null);
+const stakingInfoMock = jest.fn(() => ({
+  isDelegated: false,
+  isStaked: false,
+  hasUnstaking: false,
+  delegation: null,
+  stakedBalance: new BigNumber(0),
+  unstakedBalance: new BigNumber(0),
+  unstakedFinalizable: new BigNumber(0),
+  availableBalance: new BigNumber(1_000_000),
+  delegateAddress: undefined,
+}));
+const updateTransactionMock = jest.fn((tx, patch) => ({ ...tx, ...patch }));
 
 jest.mock("@ledgerhq/live-common/families/tezos/react", () => ({
   __esModule: true,
   useDelegation: () => useDelegationMock(),
-  useTezosStakingInfo: () => ({
-    isDelegated: false,
-    isStaked: false,
-    hasUnstaking: false,
-    delegation: null,
-    stakedBalance: new BigNumber(0),
-    unstakedBalance: new BigNumber(0),
-    unstakedFinalizable: new BigNumber(0),
-    availableBalance: new BigNumber(1_000_000),
-    delegateAddress: undefined,
-  }),
+  useTezosStakingInfo: () => stakingInfoMock(),
 }));
 
 jest.mock("@ledgerhq/live-common/bridge/react/index", () => ({
@@ -37,7 +39,7 @@ jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
   __esModule: true,
   useAccountBridge: () => ({
     createTransaction: jest.fn(),
-    updateTransaction: jest.fn((tx, patch) => ({ ...tx, ...patch })),
+    updateTransaction: updateTransactionMock,
     getTransactionStatus: jest.fn(),
   }),
 }));
@@ -57,7 +59,11 @@ jest.mock("~/renderer/components/SpendableBanner", () => ({
 }));
 jest.mock("~/renderer/components/RequestAmount", () => ({
   __esModule: true,
-  default: () => null,
+  default: ({ onChange }: { onChange: (amount: BigNumber) => void }) => (
+    <button data-testid="request-amount-fire" onClick={() => onChange(new BigNumber(123_456))}>
+      onChange
+    </button>
+  ),
 }));
 jest.mock("~/renderer/modals/Send/AccountFooter", () => ({
   __esModule: true,
@@ -193,5 +199,65 @@ describe("StakeFlowModal/StepAmount await-delegation", () => {
       jest.advanceTimersByTime(5000 * 3);
     });
     expect(syncDispatchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("StakeFlowModal/StepAmount delegated state", () => {
+  beforeEach(() => {
+    syncDispatchMock.mockClear();
+    updateTransactionMock.mockClear();
+    useDelegationMock.mockReturnValue({ address: "tz1baker", isPending: false });
+  });
+
+  it("onMax sets amount = availableBalance - reserve", () => {
+    const props = makeProps();
+    act(() => {
+      render(<StepAmount {...props} />);
+    });
+    act(() => {
+      fireEvent.click(screen.getByTestId("tezos-stake-amount-max-button"));
+    });
+    expect(updateTransactionMock).toHaveBeenCalledTimes(1);
+    const [, patch] = updateTransactionMock.mock.calls[0];
+    // availableBalance (1_000_000) - reserve (0.5 XTZ × 1e6 = 500_000) = 500_000
+    expect((patch.amount as BigNumber).toString()).toBe("500000");
+    expect(props.onChangeTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("onMax clamps to 0 when the reserve exceeds availableBalance", () => {
+    stakingInfoMock.mockReturnValueOnce({
+      isDelegated: true,
+      isStaked: false,
+      hasUnstaking: false,
+      delegation: null,
+      stakedBalance: new BigNumber(0),
+      unstakedBalance: new BigNumber(0),
+      unstakedFinalizable: new BigNumber(0),
+      availableBalance: new BigNumber(100),
+      delegateAddress: undefined,
+    });
+    const props = makeProps();
+    act(() => {
+      render(<StepAmount {...props} />);
+    });
+    act(() => {
+      fireEvent.click(screen.getByTestId("tezos-stake-amount-max-button"));
+    });
+    const [, patch] = updateTransactionMock.mock.calls[0];
+    expect((patch.amount as BigNumber).toString()).toBe("0");
+  });
+
+  it("onChange from RequestAmount propagates via bridge.updateTransaction", () => {
+    const props = makeProps();
+    act(() => {
+      render(<StepAmount {...props} />);
+    });
+    act(() => {
+      fireEvent.click(screen.getByTestId("request-amount-fire"));
+    });
+    expect(updateTransactionMock).toHaveBeenCalledTimes(1);
+    const [, patch] = updateTransactionMock.mock.calls[0];
+    expect((patch.amount as BigNumber).toString()).toBe("123456");
+    expect(props.onChangeTransaction).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/StepAmount.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/StepAmount.test.tsx
@@ -1,0 +1,197 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { act, render } from "tests/testSetup";
+import {
+  getCryptoCurrencyById,
+  setSupportedCurrencies,
+} from "@ledgerhq/live-common/currencies/index";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import type { TezosAccount, Transaction } from "@ledgerhq/live-common/families/tezos/types";
+import type { StepProps } from "../types";
+
+const syncDispatchMock = jest.fn();
+const useDelegationMock = jest.fn().mockReturnValue(null);
+
+jest.mock("@ledgerhq/live-common/families/tezos/react", () => ({
+  __esModule: true,
+  useDelegation: () => useDelegationMock(),
+  useTezosStakingInfo: () => ({
+    isDelegated: false,
+    isStaked: false,
+    hasUnstaking: false,
+    delegation: null,
+    stakedBalance: new BigNumber(0),
+    unstakedBalance: new BigNumber(0),
+    unstakedFinalizable: new BigNumber(0),
+    availableBalance: new BigNumber(1_000_000),
+    delegateAddress: undefined,
+  }),
+}));
+
+jest.mock("@ledgerhq/live-common/bridge/react/index", () => ({
+  __esModule: true,
+  useBridgeSync: () => syncDispatchMock,
+}));
+
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  __esModule: true,
+  useAccountBridge: () => ({
+    createTransaction: jest.fn(),
+    updateTransaction: jest.fn((tx, patch) => ({ ...tx, ...patch })),
+    getTransactionStatus: jest.fn(),
+  }),
+}));
+
+jest.mock("~/renderer/analytics/TrackPage", () => ({ __esModule: true, default: () => null }));
+jest.mock("~/renderer/components/CurrencyDownStatusAlert", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock("~/renderer/components/ErrorBanner", () => ({
+  __esModule: true,
+  default: () => <div data-testid="error-banner" />,
+}));
+jest.mock("~/renderer/components/SpendableBanner", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock("~/renderer/components/RequestAmount", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock("~/renderer/modals/Send/AccountFooter", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+import StepAmount from "../steps/StepAmount";
+
+setSupportedCurrencies(["tezos"]);
+const currency = getCryptoCurrencyById("tezos");
+
+const makeAccount = (): TezosAccount =>
+  ({
+    ...genAccount("tezos-stepamount-test", { currency }),
+  }) as unknown as TezosAccount;
+
+const makeProps = (overrides: Partial<StepProps> = {}): StepProps => {
+  const account = makeAccount();
+  const transaction = {
+    family: "tezos",
+    mode: "stake",
+    amount: new BigNumber(0),
+    fees: new BigNumber(0),
+    recipient: "",
+    useAllAmount: false,
+  } as unknown as Transaction;
+  return {
+    t: (key: string) => key,
+    transitionTo: jest.fn(),
+    device: null,
+    account,
+    parentAccount: null,
+    transaction,
+    status: {
+      errors: {},
+      warnings: {},
+      estimatedFees: new BigNumber(0),
+      amount: new BigNumber(0),
+      totalSpent: new BigNumber(0),
+    },
+    bridgePending: false,
+    error: null,
+    optimisticOperation: null,
+    signed: false,
+    failedStep: null,
+    onClose: jest.fn(),
+    openModal: jest.fn(),
+    onChangeTransaction: jest.fn(),
+    onUpdateTransaction: jest.fn(),
+    onTransactionError: jest.fn(),
+    onOperationBroadcasted: jest.fn(),
+    onRetry: jest.fn(),
+    setSigned: jest.fn(),
+    ...overrides,
+  } as unknown as StepProps;
+};
+
+describe("StakeFlowModal/StepAmount await-delegation", () => {
+  beforeEach(() => {
+    syncDispatchMock.mockClear();
+    useDelegationMock.mockReturnValue(null);
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("dispatches a priority-200 sync on mount when awaiting delegation in stake mode", () => {
+    const props = makeProps();
+    act(() => {
+      render(<StepAmount {...props} />);
+    });
+    expect(syncDispatchMock).toHaveBeenCalledTimes(1);
+    expect(syncDispatchMock).toHaveBeenCalledWith({
+      type: "SYNC_ONE_ACCOUNT",
+      priority: 200,
+      accountId: props.account?.id,
+      reason: "tezos-stake-await-delegation",
+    });
+  });
+
+  it("re-dispatches the sync on every interval tick until the cap", () => {
+    const props = makeProps();
+    act(() => {
+      render(<StepAmount {...props} />);
+    });
+    expect(syncDispatchMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+    expect(syncDispatchMock).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      jest.advanceTimersByTime(5000 * 11);
+    });
+    expect(syncDispatchMock).toHaveBeenCalledTimes(12);
+
+    act(() => {
+      jest.advanceTimersByTime(5000 * 5);
+    });
+    expect(syncDispatchMock).toHaveBeenCalledTimes(12);
+  });
+
+  it("does not dispatch the sync in delegate mode", () => {
+    const props = makeProps({
+      transaction: {
+        family: "tezos",
+        mode: "delegate",
+        amount: new BigNumber(0),
+        fees: new BigNumber(0),
+        recipient: "",
+        useAllAmount: false,
+      } as unknown as Transaction,
+    });
+    act(() => {
+      render(<StepAmount {...props} />);
+    });
+    expect(syncDispatchMock).not.toHaveBeenCalled();
+  });
+
+  it("clears the interval on unmount", () => {
+    const props = makeProps();
+    let unmount: () => void = () => {};
+    act(() => {
+      ({ unmount } = render(<StepAmount {...props} />));
+    });
+    expect(syncDispatchMock).toHaveBeenCalledTimes(1);
+    act(() => {
+      unmount();
+    });
+    act(() => {
+      jest.advanceTimersByTime(5000 * 3);
+    });
+    expect(syncDispatchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/StepConfirmation.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/StepConfirmation.test.tsx
@@ -1,0 +1,187 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { act, fireEvent, render, screen } from "tests/testSetup";
+import {
+  getCryptoCurrencyById,
+  setSupportedCurrencies,
+} from "@ledgerhq/live-common/currencies/index";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import type { TezosAccount, Transaction } from "@ledgerhq/live-common/families/tezos/types";
+import type { Operation } from "@ledgerhq/types-live";
+import type { StepProps } from "../types";
+
+jest.mock("~/renderer/analytics/TrackPage", () => ({
+  __esModule: true,
+  default: () => null,
+  setTrackingSource: jest.fn(),
+}));
+jest.mock("~/renderer/analytics/segment", () => ({
+  ...jest.requireActual("~/renderer/analytics/segment"),
+  track: jest.fn(),
+  setTrackingSource: jest.fn(),
+}));
+jest.mock("~/renderer/hooks/useLocalizedUrls", () => ({
+  __esModule: true,
+  useLocalizedUrl: () => "https://stake.example",
+}));
+jest.mock("~/renderer/linking", () => ({ __esModule: true, openURL: jest.fn() }));
+jest.mock("@ledgerhq/live-common/bridge/react/index", () => ({
+  __esModule: true,
+  SyncOneAccountOnMount: () => null,
+}));
+jest.mock("~/renderer/components/SuccessDisplay", () => ({
+  __esModule: true,
+  default: ({ title }: { title: React.ReactNode }) => (
+    <div data-testid="success-display">{title}</div>
+  ),
+}));
+jest.mock("~/renderer/components/ErrorDisplay", () => ({
+  __esModule: true,
+  default: ({ error }: { error: Error }) => <div data-testid="error-display">{error.message}</div>,
+}));
+jest.mock("~/renderer/components/BroadcastErrorDisclaimer", () => ({
+  __esModule: true,
+  default: () => <div data-testid="broadcast-error-disclaimer" />,
+}));
+jest.mock("~/renderer/components/RetryButton", () => ({
+  __esModule: true,
+  default: ({ onClick }: { onClick: () => void }) => (
+    <button data-testid="retry-button" onClick={onClick}>
+      retry
+    </button>
+  ),
+}));
+
+import StepConfirmation, { StepConfirmationFooter } from "../steps/StepConfirmation";
+
+setSupportedCurrencies(["tezos"]);
+const currency = getCryptoCurrencyById("tezos");
+
+const makeAccount = (): TezosAccount =>
+  ({
+    ...genAccount("tezos-stepconfirmation-test", { currency }),
+  }) as unknown as TezosAccount;
+
+const makeProps = (overrides: Partial<StepProps> = {}): StepProps => {
+  const account = makeAccount();
+  const transaction = {
+    family: "tezos",
+    mode: "stake",
+    amount: new BigNumber(1_000_000),
+    fees: new BigNumber(0),
+    recipient: "",
+    useAllAmount: false,
+  } as unknown as Transaction;
+  return {
+    t: (key: string, opts?: { amount?: string }) => (opts?.amount ? `${key}:${opts.amount}` : key),
+    transitionTo: jest.fn(),
+    device: null,
+    account,
+    parentAccount: null,
+    transaction,
+    status: {
+      errors: {},
+      warnings: {},
+      estimatedFees: new BigNumber(0),
+      amount: new BigNumber(0),
+      totalSpent: new BigNumber(0),
+    },
+    bridgePending: false,
+    error: null,
+    optimisticOperation: null,
+    signed: false,
+    failedStep: null,
+    onClose: jest.fn(),
+    openModal: jest.fn(),
+    onChangeTransaction: jest.fn(),
+    onUpdateTransaction: jest.fn(),
+    onTransactionError: jest.fn(),
+    onOperationBroadcasted: jest.fn(),
+    onRetry: jest.fn(),
+    setSigned: jest.fn(),
+    ...overrides,
+  } as unknown as StepProps;
+};
+
+const makeOp = (): Operation =>
+  ({
+    id: "op-1",
+    hash: "h",
+    accountId: "tezos-stepconfirmation-test",
+    type: "OUT",
+    value: new BigNumber(0),
+    fee: new BigNumber(0),
+    senders: [],
+    recipients: [],
+    blockHeight: null,
+    blockHash: null,
+    transactionSequenceNumber: 0,
+    date: new Date(),
+    extra: {},
+  }) as unknown as Operation;
+
+describe("StakeFlowModal/StepConfirmation", () => {
+  it("renders success when the operation has been broadcasted", () => {
+    const props = makeProps({ optimisticOperation: makeOp() });
+    act(() => {
+      render(<StepConfirmation {...props} />);
+    });
+    expect(screen.queryByTestId("success-display")).toBeInTheDocument();
+    expect(screen.queryByTestId("error-display")).not.toBeInTheDocument();
+  });
+
+  it("renders error display when an error is present", () => {
+    const err = new Error("boom");
+    const props = makeProps({ error: err });
+    act(() => {
+      render(<StepConfirmation {...props} />);
+    });
+    expect(screen.queryByTestId("error-display")).toBeInTheDocument();
+    expect(screen.queryByTestId("success-display")).not.toBeInTheDocument();
+  });
+
+  it("shows BroadcastErrorDisclaimer when error occurs post-signing", () => {
+    const props = makeProps({ error: new Error("boom"), signed: true });
+    act(() => {
+      render(<StepConfirmation {...props} />);
+    });
+    expect(screen.queryByTestId("broadcast-error-disclaimer")).toBeInTheDocument();
+  });
+
+  it("footer retry calls onRetry and transitions to failedStep", () => {
+    const props = makeProps({ error: new Error("boom"), failedStep: "device-staking" });
+    act(() => {
+      render(<StepConfirmationFooter {...props} />);
+    });
+    act(() => {
+      fireEvent.click(screen.getByTestId("retry-button"));
+    });
+    expect(props.onRetry).toHaveBeenCalledTimes(1);
+    expect(props.transitionTo).toHaveBeenCalledWith("device-staking");
+  });
+
+  it("footer retry falls back to 'amount' when no failedStep is set", () => {
+    const props = makeProps({ error: new Error("boom"), failedStep: null });
+    act(() => {
+      render(<StepConfirmationFooter {...props} />);
+    });
+    act(() => {
+      fireEvent.click(screen.getByTestId("retry-button"));
+    });
+    expect(props.transitionTo).toHaveBeenCalledWith("amount");
+  });
+
+  it("footer success CTA closes the modal", () => {
+    const props = makeProps({ optimisticOperation: makeOp() });
+    let result: ReturnType<typeof render>;
+    act(() => {
+      result = render(<StepConfirmationFooter {...props} />);
+    });
+    const cta = result!.container.querySelector("#tezos-stake-confirmation-visit-earn-button");
+    expect(cta).toBeInTheDocument();
+    act(() => {
+      fireEvent.click(cta!);
+    });
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/StepValidator.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/StepValidator.test.tsx
@@ -1,0 +1,148 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { act, fireEvent, render, screen } from "tests/testSetup";
+import {
+  getCryptoCurrencyById,
+  setSupportedCurrencies,
+} from "@ledgerhq/live-common/currencies/index";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import type { TezosAccount, Transaction } from "@ledgerhq/live-common/families/tezos/types";
+import type { StepProps } from "../types";
+
+const updateTransactionMock = jest.fn((tx, patch) => ({ ...tx, ...patch }));
+
+const bakersMock = jest.fn(() => [
+  {
+    address: "tz1baker-a",
+    name: "Baker A",
+    logoURL: "",
+    nominalYield: "5 %",
+    capacityStatus: "normal",
+  },
+  {
+    address: "tz1baker-b",
+    name: "Baker B",
+    logoURL: "",
+    nominalYield: "4 %",
+    capacityStatus: "full",
+  },
+]);
+
+jest.mock("@ledgerhq/live-common/families/tezos/react", () => ({
+  __esModule: true,
+  useBakers: () => bakersMock(),
+}));
+
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  __esModule: true,
+  useAccountBridge: () => ({
+    createTransaction: jest.fn(),
+    updateTransaction: updateTransactionMock,
+    getTransactionStatus: jest.fn(),
+  }),
+}));
+
+jest.mock("~/renderer/analytics/TrackPage", () => ({ __esModule: true, default: () => null }));
+jest.mock("~/renderer/components/Modal/ModalContent", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+jest.mock("../../BakerImage", () => ({ __esModule: true, default: () => null }));
+
+import StepValidator from "../steps/StepValidator";
+
+setSupportedCurrencies(["tezos"]);
+const currency = getCryptoCurrencyById("tezos");
+
+const makeAccount = (): TezosAccount =>
+  ({
+    ...genAccount("tezos-stepvalidator-test", { currency }),
+  }) as unknown as TezosAccount;
+
+const makeProps = (overrides: Partial<StepProps> = {}): StepProps => {
+  const account = makeAccount();
+  const transaction = {
+    family: "tezos",
+    mode: "delegate",
+    amount: new BigNumber(0),
+    fees: new BigNumber(0),
+    recipient: "",
+    useAllAmount: false,
+  } as unknown as Transaction;
+  return {
+    t: (key: string) => key,
+    transitionTo: jest.fn(),
+    device: null,
+    account,
+    parentAccount: null,
+    transaction,
+    status: {
+      errors: {},
+      warnings: {},
+      estimatedFees: new BigNumber(0),
+      amount: new BigNumber(0),
+      totalSpent: new BigNumber(0),
+    },
+    bridgePending: false,
+    error: null,
+    optimisticOperation: null,
+    signed: false,
+    failedStep: null,
+    onClose: jest.fn(),
+    openModal: jest.fn(),
+    onChangeTransaction: jest.fn(),
+    onUpdateTransaction: jest.fn(),
+    onTransactionError: jest.fn(),
+    onOperationBroadcasted: jest.fn(),
+    onRetry: jest.fn(),
+    setSigned: jest.fn(),
+    ...overrides,
+  } as unknown as StepProps;
+};
+
+describe("StakeFlowModal/StepValidator", () => {
+  beforeEach(() => {
+    updateTransactionMock.mockClear();
+  });
+
+  it("renders one row per baker", () => {
+    const props = makeProps();
+    act(() => {
+      render(<StepValidator {...props} />);
+    });
+    expect(screen.getByText("Baker A")).toBeInTheDocument();
+    expect(screen.getByText("Baker B")).toBeInTheDocument();
+  });
+
+  it("clicking a baker sets the recipient and transitions to device-delegation", () => {
+    const props = makeProps();
+    act(() => {
+      render(<StepValidator {...props} />);
+    });
+
+    act(() => {
+      fireEvent.click(screen.getByText("Baker A"));
+    });
+
+    expect(updateTransactionMock).toHaveBeenCalledWith(props.transaction, {
+      recipient: "tz1baker-a",
+    });
+    expect(props.onChangeTransaction).toHaveBeenCalledTimes(1);
+    expect(props.transitionTo).toHaveBeenCalledWith("device-delegation");
+  });
+
+  it("does nothing when transaction is missing", () => {
+    const props = makeProps({ transaction: null });
+    act(() => {
+      render(<StepValidator {...props} />);
+    });
+
+    act(() => {
+      fireEvent.click(screen.getByText("Baker A"));
+    });
+
+    expect(updateTransactionMock).not.toHaveBeenCalled();
+    expect(props.onChangeTransaction).not.toHaveBeenCalled();
+    expect(props.transitionTo).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/constants.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/constants.ts
@@ -1,0 +1,9 @@
+import BigNumber from "bignumber.js";
+
+// Reserve for reveal + future unstake/finalize fees; padded well above the ~1500 mutez stake-op fee.
+export const STAKE_GAS_RESERVE_XTZ = new BigNumber(0.5);
+
+// Must exceed Body's SyncSkipUnderPriority(100); otherwise the await-delegation poll is dropped.
+export const AWAIT_DELEGATION_SYNC_PRIORITY = 200;
+export const AWAIT_DELEGATION_POLL_INTERVAL_MS = 5000;
+export const MAX_AWAIT_DELEGATION_POLLS = 12;

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/index.tsx
@@ -1,0 +1,42 @@
+import React, { PureComponent } from "react";
+import Modal from "~/renderer/components/Modal";
+import Body, { Data } from "./Body";
+import { StepId } from "./types";
+
+type State = {
+  stepId: StepId;
+};
+
+const INITIAL_STATE: State = { stepId: "validator" };
+
+class StakeFlowModal extends PureComponent<Data, State> {
+  state: State = INITIAL_STATE;
+
+  handleReset = () => this.setState(INITIAL_STATE);
+
+  handleStepChange = (stepId: StepId) => this.setState({ stepId });
+
+  render() {
+    const { stepId } = this.state;
+    const isLocked = ["device-delegation", "device-staking", "confirmation"].includes(stepId);
+    return (
+      <Modal
+        name="MODAL_TEZOS_STAKE"
+        centered
+        width={500}
+        onHide={this.handleReset}
+        preventBackdropClick={isLocked}
+        render={({ onClose, data }) => (
+          <Body
+            stepId={stepId}
+            onClose={onClose}
+            onChangeStepId={this.handleStepChange}
+            params={(data ?? {}) as Data}
+          />
+        )}
+      />
+    );
+  }
+}
+
+export default StakeFlowModal;

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/steps/StepAmount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/steps/StepAmount.tsx
@@ -1,0 +1,210 @@
+import React, { Fragment, PureComponent, useCallback, useEffect, useState } from "react";
+import BigNumber from "bignumber.js";
+import invariant from "invariant";
+import { Trans } from "react-i18next";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { useBridgeSync } from "@ledgerhq/live-common/bridge/react/index";
+import { useDelegation, useTezosStakingInfo } from "@ledgerhq/live-common/families/tezos/react";
+import { Transaction } from "@ledgerhq/live-common/families/tezos/types";
+import { useSelector } from "LLD/hooks/redux";
+import { accountSelector } from "~/renderer/reducers/accounts";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import Alert from "~/renderer/components/Alert";
+import Box from "~/renderer/components/Box";
+import Button from "~/renderer/components/Button";
+import CurrencyDownStatusAlert from "~/renderer/components/CurrencyDownStatusAlert";
+import ErrorBanner from "~/renderer/components/ErrorBanner";
+import Label from "~/renderer/components/Label";
+import RequestAmount from "~/renderer/components/RequestAmount";
+import Spinner from "~/renderer/components/Spinner";
+import SpendableBanner from "~/renderer/components/SpendableBanner";
+import Text from "~/renderer/components/Text";
+import AccountFooter from "~/renderer/modals/Send/AccountFooter";
+import {
+  AWAIT_DELEGATION_POLL_INTERVAL_MS,
+  AWAIT_DELEGATION_SYNC_PRIORITY,
+  MAX_AWAIT_DELEGATION_POLLS,
+  STAKE_GAS_RESERVE_XTZ,
+} from "../constants";
+import { StepProps } from "../types";
+
+const StepAmount = ({
+  t,
+  account,
+  parentAccount,
+  transaction,
+  onChangeTransaction,
+  error,
+  status,
+  bridgePending,
+}: StepProps) => {
+  invariant(account, "account required");
+  invariant(transaction && transaction.family === "tezos", "tezos transaction required");
+
+  const mainAccount = getMainAccount(account, parentAccount);
+  // useBridgeTransaction snapshots the account; use the live one to see post-broadcast delegation state.
+  const liveAccount = useSelector(state => accountSelector(state, { accountId: mainAccount.id }));
+  const accountForHooks = liveAccount ?? mainAccount;
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
+  const { availableBalance } = useTezosStakingInfo(accountForHooks);
+  const delegation = useDelegation(accountForHooks);
+  // validateIntent throws MustDelegateBeforeStaking until the chain confirms the delegation.
+  const isAwaitingDelegation =
+    transaction.mode === "stake" && (!delegation || delegation.isPending);
+  const [awaitDelegationTimedOut, setAwaitDelegationTimedOut] = useState(false);
+  const syncDispatch = useBridgeSync();
+
+  // Body mounts <SyncSkipUnderPriority priority={100} />; the await-sync must exceed
+  // that threshold or it's silently dropped.
+  useEffect(() => {
+    if (!isAwaitingDelegation) {
+      setAwaitDelegationTimedOut(false);
+      return;
+    }
+    let attempts = 0;
+    const dispatchSync = () => {
+      syncDispatch({
+        type: "SYNC_ONE_ACCOUNT",
+        priority: AWAIT_DELEGATION_SYNC_PRIORITY,
+        accountId: mainAccount.id,
+        reason: "tezos-stake-await-delegation",
+      });
+      attempts += 1;
+    };
+    dispatchSync();
+    const id = setInterval(() => {
+      if (attempts >= MAX_AWAIT_DELEGATION_POLLS) {
+        clearInterval(id);
+        setAwaitDelegationTimedOut(true);
+        return;
+      }
+      dispatchSync();
+    }, AWAIT_DELEGATION_POLL_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [isAwaitingDelegation, mainAccount.id, syncDispatch]);
+
+  const reserveMutez = STAKE_GAS_RESERVE_XTZ.shiftedBy(mainAccount.currency.units[0].magnitude);
+
+  const onChange = useCallback(
+    (amount: BigNumber) => {
+      onChangeTransaction(bridge.updateTransaction(transaction, { amount }));
+    },
+    [bridge, onChangeTransaction, transaction],
+  );
+
+  const onMax = useCallback(() => {
+    const max = BigNumber.max(availableBalance.minus(reserveMutez), 0);
+    onChangeTransaction(bridge.updateTransaction(transaction, { amount: max }));
+  }, [availableBalance, bridge, onChangeTransaction, reserveMutez, transaction]);
+
+  if (!status) return null;
+  const { amount, errors, warnings } = status;
+  const amountError = amount.eq(0) && bridgePending ? undefined : errors.amount;
+  const amountWarning = amount.eq(0) && bridgePending ? undefined : warnings.amount;
+
+  if (isAwaitingDelegation && !awaitDelegationTimedOut) {
+    return (
+      <Box flow={4}>
+        {error ? <ErrorBanner error={error} /> : null}
+        <Box flow={4} alignItems="center" justifyContent="center" py={50}>
+          <TrackPage
+            category="Stake Flow"
+            name="Step Amount Pending Delegation"
+            flow="stake"
+            action="stake"
+            currency="xtz"
+          />
+          <Spinner size={36} />
+          <Text ff="Inter|Medium" fontSize={4} color="neutral.c80" mt={4} textAlign="center">
+            <Trans i18nKey="tezos.stake.flow.amount.awaitingDelegation" />
+          </Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flow={4}>
+      <TrackPage
+        category="Stake Flow"
+        name="Step Amount"
+        flow="stake"
+        action="stake"
+        currency="xtz"
+      />
+      <CurrencyDownStatusAlert currencies={[mainAccount.currency]} />
+      {error ? <ErrorBanner error={error} /> : null}
+      <Fragment key={account.id}>
+        <SpendableBanner
+          account={account}
+          parentAccount={parentAccount}
+          transaction={transaction}
+        />
+        <Box flow={1}>
+          <Box
+            horizontal
+            alignItems="center"
+            justifyContent="space-between"
+            style={{ width: "50%", paddingRight: 28 }}
+          >
+            <Label>{t("send.steps.details.amount")}</Label>
+            <Text
+              color="primary.c80"
+              ff="Inter|Medium"
+              fontSize={10}
+              onClick={onMax}
+              style={{ cursor: "pointer" }}
+              data-testid="tezos-stake-amount-max-button"
+            >
+              <Trans i18nKey="send.steps.details.useMax" />
+            </Text>
+          </Box>
+          <RequestAmount
+            account={account}
+            value={transaction.amount}
+            validTransactionError={amountError}
+            validTransactionWarning={amountWarning}
+            onChange={onChange}
+            autoFocus
+          />
+        </Box>
+        <Alert type="primary" small>
+          <Trans i18nKey="tezos.stake.flow.amount.disclaimer" />
+        </Alert>
+      </Fragment>
+    </Box>
+  );
+};
+
+export class StepAmountFooter extends PureComponent<StepProps> {
+  onNext = async () => {
+    this.props.transitionTo("device-staking");
+  };
+
+  render() {
+    const { account, parentAccount, status, bridgePending, transaction } = this.props;
+    if (!account || !transaction) return null;
+    const mainAccount = getMainAccount(account, parentAccount);
+    const isTerminated = mainAccount.currency.terminated;
+    const hasErrors = Object.keys(status.errors).length > 0;
+    const isZero = !transaction.amount || transaction.amount.eq(0);
+    const canNext = !bridgePending && !hasErrors && !isTerminated && !isZero;
+    return (
+      <>
+        <AccountFooter parentAccount={parentAccount} account={account} status={status} />
+        <Button
+          id="tezos-stake-amount-continue-button"
+          isLoading={bridgePending}
+          primary
+          disabled={!canNext}
+          onClick={this.onNext}
+        >
+          <Trans i18nKey="common.continue" />
+        </Button>
+      </>
+    );
+  }
+}
+
+export default StepAmount;

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/steps/StepAmount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/steps/StepAmount.tsx
@@ -40,7 +40,7 @@ const StepAmount = ({
   bridgePending,
 }: StepProps) => {
   invariant(account, "account required");
-  invariant(transaction && transaction.family === "tezos", "tezos transaction required");
+  invariant(transaction?.family === "tezos", "tezos transaction required");
 
   const mainAccount = getMainAccount(account, parentAccount);
   // useBridgeTransaction snapshots the account; use the live one to see post-broadcast delegation state.

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/steps/StepConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/steps/StepConfirmation.tsx
@@ -40,7 +40,7 @@ const StepConfirmation = ({
   transaction,
   source,
 }: StepProps) => {
-  invariant(transaction && transaction.family === "tezos", "tezos transaction required");
+  invariant(transaction?.family === "tezos", "tezos transaction required");
 
   useEffect(() => {
     if (optimisticOperation) {
@@ -128,6 +128,22 @@ export const StepConfirmationFooter = ({
     transitionTo(failedStep ?? "amount");
   }, [failedStep, onRetry, transitionTo]);
 
+  let action: React.ReactNode = null;
+  if (optimisticOperation) {
+    action = (
+      <Button
+        ml={2}
+        id="tezos-stake-confirmation-visit-earn-button"
+        primary
+        onClick={onVisitEarnDashboard}
+      >
+        <Trans i18nKey="tezos.stake.flow.steps.confirmation.success.cta" />
+      </Button>
+    );
+  } else if (error) {
+    action = <RetryButton ml={2} primary onClick={onRetryClick} />;
+  }
+
   return (
     <>
       <Box mr={2} ff="Inter|SemiBold" fontSize={4}>
@@ -136,18 +152,7 @@ export const StepConfirmationFooter = ({
           onClick={() => openURL(stakingUrl)}
         />
       </Box>
-      {optimisticOperation ? (
-        <Button
-          ml={2}
-          id="tezos-stake-confirmation-visit-earn-button"
-          primary
-          onClick={onVisitEarnDashboard}
-        >
-          <Trans i18nKey="tezos.stake.flow.steps.confirmation.success.cta" />
-        </Button>
-      ) : error ? (
-        <RetryButton ml={2} primary onClick={onRetryClick} />
-      ) : null}
+      {action}
     </>
   );
 };

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/steps/StepConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/steps/StepConfirmation.tsx
@@ -1,0 +1,155 @@
+import invariant from "invariant";
+import React, { useCallback, useEffect } from "react";
+import { Trans } from "react-i18next";
+import { useNavigate } from "react-router";
+import styled from "styled-components";
+import { SyncOneAccountOnMount } from "@ledgerhq/live-common/bridge/react/index";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { formatCurrencyUnit } from "@ledgerhq/coin-module-framework/currencies/index";
+import TrackPage, { setTrackingSource } from "~/renderer/analytics/TrackPage";
+import { track } from "~/renderer/analytics/segment";
+import Box from "~/renderer/components/Box";
+import BroadcastErrorDisclaimer from "~/renderer/components/BroadcastErrorDisclaimer";
+import Button from "~/renderer/components/Button";
+import ErrorDisplay from "~/renderer/components/ErrorDisplay";
+import LinkWithExternalIcon from "~/renderer/components/LinkWithExternalIcon";
+import RetryButton from "~/renderer/components/RetryButton";
+import SuccessDisplay from "~/renderer/components/SuccessDisplay";
+import { useLocalizedUrl } from "~/renderer/hooks/useLocalizedUrls";
+import { openURL } from "~/renderer/linking";
+import { multiline } from "~/renderer/styles/helpers";
+import { urls } from "~/config/urls";
+import { StepProps } from "../types";
+
+const Container = styled(Box).attrs(() => ({
+  alignItems: "center",
+  grow: true,
+  color: "neutral.c100",
+}))<{ shouldSpace?: boolean }>`
+  justify-content: ${p => (p.shouldSpace ? "space-between" : "center")};
+  min-height: 220px;
+`;
+
+const StepConfirmation = ({
+  t,
+  account,
+  parentAccount,
+  optimisticOperation,
+  error,
+  signed,
+  transaction,
+  source,
+}: StepProps) => {
+  invariant(transaction && transaction.family === "tezos", "tezos transaction required");
+
+  useEffect(() => {
+    if (optimisticOperation) {
+      track("staking_completed", {
+        currency: "XTZ",
+        source,
+        delegation: transaction.mode,
+        flow: "stake",
+      });
+    }
+  }, [optimisticOperation, source, transaction.mode]);
+
+  if (optimisticOperation) {
+    const mainAccount = account ? getMainAccount(account, parentAccount) : null;
+    const unit = mainAccount?.currency.units[0];
+    const amountText = unit
+      ? formatCurrencyUnit(unit, transaction.amount, { showCode: true, disableRounding: true })
+      : "";
+
+    return (
+      <Container>
+        <TrackPage
+          category="Stake Flow"
+          name="Step Confirmed"
+          flow="stake"
+          action="stake"
+          currency="xtz"
+        />
+        <SyncOneAccountOnMount
+          reason="transaction-flow-confirmation"
+          priority={10}
+          accountId={optimisticOperation.accountId}
+        />
+        <SuccessDisplay
+          title={<Trans i18nKey="tezos.stake.flow.steps.confirmation.success.title" />}
+          description={multiline(
+            t("tezos.stake.flow.steps.confirmation.success.text", { amount: amountText }),
+          )}
+        />
+      </Container>
+    );
+  }
+
+  if (error) {
+    return (
+      <Container shouldSpace={signed}>
+        <TrackPage
+          category="Stake Flow"
+          name="Step Confirmation Error"
+          flow="stake"
+          action="stake"
+          currency="xtz"
+        />
+        {signed ? (
+          <BroadcastErrorDisclaimer
+            title={<Trans i18nKey="tezos.stake.flow.steps.confirmation.broadcastError" />}
+          />
+        ) : null}
+        <ErrorDisplay error={error} withExportLogs />
+      </Container>
+    );
+  }
+  return null;
+};
+
+export const StepConfirmationFooter = ({
+  transitionTo,
+  onRetry,
+  optimisticOperation,
+  error,
+  failedStep,
+  onClose,
+}: StepProps) => {
+  const navigate = useNavigate();
+  const stakingUrl = useLocalizedUrl(urls.stakingTezos);
+
+  const onVisitEarnDashboard = useCallback(() => {
+    onClose();
+    setTrackingSource("stake flow");
+    navigate("/earn");
+  }, [navigate, onClose]);
+
+  const onRetryClick = useCallback(() => {
+    onRetry();
+    transitionTo(failedStep ?? "amount");
+  }, [failedStep, onRetry, transitionTo]);
+
+  return (
+    <>
+      <Box mr={2} ff="Inter|SemiBold" fontSize={4}>
+        <LinkWithExternalIcon
+          label={<Trans i18nKey="tezos.stake.flow.steps.confirmation.howItWorks" />}
+          onClick={() => openURL(stakingUrl)}
+        />
+      </Box>
+      {optimisticOperation ? (
+        <Button
+          ml={2}
+          id="tezos-stake-confirmation-visit-earn-button"
+          primary
+          onClick={onVisitEarnDashboard}
+        >
+          <Trans i18nKey="tezos.stake.flow.steps.confirmation.success.cta" />
+        </Button>
+      ) : error ? (
+        <RetryButton ml={2} primary onClick={onRetryClick} />
+      ) : null}
+    </>
+  );
+};
+
+export default StepConfirmation;

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/steps/StepDeviceDelegation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/steps/StepDeviceDelegation.tsx
@@ -1,0 +1,63 @@
+import React, { useCallback, useRef } from "react";
+import { Operation } from "@ledgerhq/types-live";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import GenericStepConnectDevice from "~/renderer/modals/Send/steps/GenericStepConnectDevice";
+import { StepProps } from "../types";
+
+export default function StepDeviceDelegation({
+  account,
+  parentAccount,
+  transaction,
+  status,
+  transitionTo,
+  onOperationBroadcasted,
+  onTransactionError,
+  setSigned,
+}: StepProps) {
+  // GenericStepConnectDevice always calls transitionTo("confirmation") after broadcast
+  // (success or failure). We want success to land on "amount" so the user signs the
+  // staking op next, while errors must still go to "confirmation".
+  const broadcastedRef = useRef(false);
+
+  const handleBroadcasted = useCallback(
+    (op: Operation) => {
+      broadcastedRef.current = true;
+      onOperationBroadcasted(op);
+    },
+    [onOperationBroadcasted],
+  );
+
+  const handleTransition = useCallback(
+    (next: string) => {
+      if (next === "confirmation" && broadcastedRef.current) {
+        broadcastedRef.current = false;
+        transitionTo("amount");
+        return;
+      }
+      transitionTo(next);
+    },
+    [transitionTo],
+  );
+
+  return (
+    <>
+      <TrackPage
+        category="Stake Flow"
+        name="Step ConnectDevice Delegation"
+        flow="stake"
+        action="stake"
+        currency="xtz"
+      />
+      <GenericStepConnectDevice
+        account={account}
+        parentAccount={parentAccount}
+        transaction={transaction}
+        status={status}
+        transitionTo={handleTransition}
+        onOperationBroadcasted={handleBroadcasted}
+        onTransactionError={onTransactionError}
+        setSigned={setSigned}
+      />
+    </>
+  );
+}

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/steps/StepDeviceDelegation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/steps/StepDeviceDelegation.tsx
@@ -13,7 +13,7 @@ export default function StepDeviceDelegation({
   onOperationBroadcasted,
   onTransactionError,
   setSigned,
-}: StepProps) {
+}: Readonly<StepProps>) {
   // GenericStepConnectDevice always calls transitionTo("confirmation") after broadcast
   // (success or failure). We want success to land on "amount" so the user signs the
   // staking op next, while errors must still go to "confirmation".

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/steps/StepDeviceStaking.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/steps/StepDeviceStaking.tsx
@@ -12,7 +12,7 @@ export default function StepDeviceStaking({
   onOperationBroadcasted,
   onTransactionError,
   setSigned,
-}: StepProps) {
+}: Readonly<StepProps>) {
   return (
     <>
       <TrackPage

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/steps/StepDeviceStaking.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/steps/StepDeviceStaking.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import GenericStepConnectDevice from "~/renderer/modals/Send/steps/GenericStepConnectDevice";
+import { StepProps } from "../types";
+
+export default function StepDeviceStaking({
+  account,
+  parentAccount,
+  transaction,
+  status,
+  transitionTo,
+  onOperationBroadcasted,
+  onTransactionError,
+  setSigned,
+}: StepProps) {
+  return (
+    <>
+      <TrackPage
+        category="Stake Flow"
+        name="Step ConnectDevice Staking"
+        flow="stake"
+        action="stake"
+        currency="xtz"
+      />
+      <GenericStepConnectDevice
+        account={account}
+        parentAccount={parentAccount}
+        transaction={transaction}
+        status={status}
+        transitionTo={transitionTo}
+        onOperationBroadcasted={onOperationBroadcasted}
+        onTransactionError={onTransactionError}
+        setSigned={setSigned}
+      />
+    </>
+  );
+}

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/steps/StepValidator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/steps/StepValidator.tsx
@@ -113,7 +113,7 @@ const StepValidator = ({
         <Box style={{ maxHeight: 255, margin: -20, marginTop: 0 }}>
           <ModalContent ref={contentRef}>
             {bakers.map(baker => (
-              <BakerRow baker={baker} key={baker.name} onClick={onBakerClick} />
+              <BakerRow baker={baker} key={baker.address} onClick={onBakerClick} />
             ))}
           </ModalContent>
         </Box>

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/steps/StepValidator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/steps/StepValidator.tsx
@@ -1,0 +1,143 @@
+import React, { useCallback, useRef } from "react";
+import invariant from "invariant";
+import styled from "styled-components";
+import { Trans } from "react-i18next";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { useBakers } from "@ledgerhq/live-common/families/tezos/react";
+import { Baker, Transaction } from "@ledgerhq/live-common/families/tezos/types";
+import { whitelist as bakersWhitelistDefault } from "@ledgerhq/live-common/families/tezos/staking";
+import { openURL } from "~/renderer/linking";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import Box from "~/renderer/components/Box";
+import Text from "~/renderer/components/Text";
+import ModalContent from "~/renderer/components/Modal/ModalContent";
+import BakerImage from "../../BakerImage";
+import { StepProps } from "../types";
+
+const Row = styled(Box).attrs(() => ({
+  horizontal: true,
+}))`
+  cursor: pointer;
+  padding: 8px;
+  margin-bottom: 8px;
+  border-radius: 4px;
+  border: 1px solid ${p => p.theme.colors.neutral.c40};
+  justify-content: space-between;
+  align-items: center;
+  transition: box-shadow 250ms ease-out;
+
+  &:hover,
+  &:active {
+    background-color: ${p => p.theme.colors.opacityDefault.c10};
+  }
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+`;
+
+const BakerRow = ({ baker, onClick }: { baker: Baker; onClick: (a: Baker) => void }) => (
+  <Row onClick={() => onClick(baker)}>
+    <Box horizontal alignItems="center">
+      <BakerImage baker={baker} size={24} />
+      <Text ff="Inter|SemiBold" fontSize={3} color="neutral.c100" style={{ marginLeft: 8 }}>
+        {baker.name}
+      </Text>
+      {baker.capacityStatus === "full" ? (
+        <Text ff="Inter|SemiBold" fontSize={3} color="legacyWarning" style={{ marginLeft: 8 }}>
+          <Trans i18nKey="delegation.overdelegated" />
+        </Text>
+      ) : null}
+    </Box>
+    <Text
+      style={{ opacity: baker.capacityStatus === "full" ? 0.5 : 1 }}
+      ff="Inter|SemiBold"
+      fontSize={3}
+      color="neutral.c100"
+    >
+      {baker.nominalYield}
+    </Text>
+  </Row>
+);
+
+const StepValidator = ({
+  account,
+  parentAccount,
+  transaction,
+  transitionTo,
+  onChangeTransaction,
+}: StepProps) => {
+  invariant(account, "account is required");
+  const contentRef = useRef(null);
+  const bakers = useBakers(bakersWhitelistDefault);
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
+
+  const onBakerClick = useCallback(
+    (baker: Baker) => {
+      if (!transaction) return;
+      onChangeTransaction(
+        bridge.updateTransaction(transaction, { recipient: baker.address }),
+      );
+      transitionTo("device-delegation");
+    },
+    [bridge, onChangeTransaction, transaction, transitionTo],
+  );
+
+  const openPartner = useCallback(() => {
+    openURL("https://baking-bad.org/");
+  }, []);
+
+  return (
+    <Box flow={4} mx={20}>
+      <TrackPage
+        category="Stake Flow"
+        name="Step Validator"
+        flow="stake"
+        action="stake"
+        currency="xtz"
+      />
+      <Box>
+        <Text ff="Inter|Regular" color="neutral.c80" fontSize={4} textAlign="center">
+          <Trans i18nKey="tezos.stake.flow.steps.validator.description" />
+        </Text>
+      </Box>
+      <Box my={24}>
+        <Box mb={3} horizontal justifyContent="space-between">
+          <Text ff="Inter|Medium" fontSize={3} color="neutral.c70">
+            <Trans i18nKey="delegation.validator" />
+          </Text>
+          <Text ff="Inter|Medium" fontSize={3} color="neutral.c70">
+            <Trans i18nKey="delegation.yield" />
+          </Text>
+        </Box>
+        <Box style={{ maxHeight: 255, margin: -20, marginTop: 0 }}>
+          <ModalContent ref={contentRef}>
+            {bakers.map(baker => (
+              <BakerRow baker={baker} key={baker.name} onClick={onBakerClick} />
+            ))}
+          </ModalContent>
+        </Box>
+      </Box>
+      <Box alignItems="center">
+        <Box mt={5}>
+          <Text ff="Inter|Medium" fontSize={2} color="neutral.c60">
+            <Trans
+              i18nKey="delegation.flow.steps.validator.providedBy"
+              values={{ name: "Baking Bad" }}
+            >
+              {"Yield rates provided by"}
+              <Text
+                onClick={openPartner}
+                style={{ cursor: "pointer", textDecoration: "underline" }}
+              >
+                {"Baking Bad"}
+              </Text>
+            </Trans>
+          </Text>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default StepValidator;

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/types.ts
@@ -1,12 +1,12 @@
 import { TFunction } from "i18next";
-import { Account, Operation, TokenAccount } from "@ledgerhq/types-live";
+import { Account, Operation } from "@ledgerhq/types-live";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import {
   TezosAccount,
   Transaction,
   TransactionStatus,
 } from "@ledgerhq/live-common/families/tezos/types";
-import { Step } from "~/renderer/components/Stepper";
+import { Step as StepperProps } from "~/renderer/components/Stepper";
 import { OpenModal } from "~/renderer/actions/modals";
 
 export type StepId =
@@ -20,7 +20,7 @@ export type StepProps = {
   t: TFunction;
   transitionTo: (a: string) => void;
   device: Device | undefined | null;
-  account: TezosAccount | TokenAccount | undefined | null;
+  account: TezosAccount | undefined | null;
   parentAccount: Account | undefined | null;
   transaction: Transaction | undefined | null;
   status: TransactionStatus;
@@ -40,4 +40,4 @@ export type StepProps = {
   setSigned: (a: boolean) => void;
 };
 
-export type St = Step<StepId, StepProps>;
+export type Step = StepperProps<StepId, StepProps>;

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/types.ts
@@ -1,0 +1,43 @@
+import { TFunction } from "i18next";
+import { Account, Operation, TokenAccount } from "@ledgerhq/types-live";
+import { Device } from "@ledgerhq/live-common/hw/actions/types";
+import {
+  TezosAccount,
+  Transaction,
+  TransactionStatus,
+} from "@ledgerhq/live-common/families/tezos/types";
+import { Step } from "~/renderer/components/Stepper";
+import { OpenModal } from "~/renderer/actions/modals";
+
+export type StepId =
+  | "validator"
+  | "device-delegation"
+  | "amount"
+  | "device-staking"
+  | "confirmation";
+
+export type StepProps = {
+  t: TFunction;
+  transitionTo: (a: string) => void;
+  device: Device | undefined | null;
+  account: TezosAccount | TokenAccount | undefined | null;
+  parentAccount: Account | undefined | null;
+  transaction: Transaction | undefined | null;
+  status: TransactionStatus;
+  bridgePending: boolean;
+  error: Error | undefined | null;
+  optimisticOperation: Operation | undefined | null;
+  signed: boolean;
+  failedStep: StepId | null;
+  source?: string;
+  onClose: () => void;
+  openModal: OpenModal;
+  onChangeTransaction: (a: Transaction) => void;
+  onUpdateTransaction: (a: (a: Transaction) => Transaction) => void;
+  onTransactionError: (a: Error) => void;
+  onOperationBroadcasted: (a: Operation) => void;
+  onRetry: () => void;
+  setSigned: (a: boolean) => void;
+};
+
+export type St = Step<StepId, StepProps>;

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/modals.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/modals.ts
@@ -1,20 +1,10 @@
-import React from "react";
-import { TokenAccount } from "@ledgerhq/types-live";
-import { TezosAccount } from "@ledgerhq/live-common/families/tezos/types";
 import MODAL_DELEGATE from "./DelegateFlowModal";
 import { Data as DelegateProps } from "./DelegateFlowModal/Body";
 import MODAL_TEZOS_EARNING_CHOICE from "./EarningChoiceModal";
 import { Data as EarningChoiceProps } from "./EarningChoiceModal/Body";
+import MODAL_TEZOS_STAKE from "./StakeFlowModal";
+import { Data as TezosStakeProps } from "./StakeFlowModal/Body";
 import { MakeModalsType } from "../../modals/types";
-
-// Pending LIVE-29536: replace this stub with the real Stake flow modal.
-type TezosStakeProps = {
-  account: TezosAccount | TokenAccount;
-  parentAccount?: TezosAccount | null;
-  source?: string;
-  skipDelegation?: boolean;
-};
-const MODAL_TEZOS_STAKE: React.ComponentType<TezosStakeProps> = () => null;
 
 export type ModalsData = {
   MODAL_DELEGATE: DelegateProps;

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -4620,6 +4620,40 @@
         },
         "cta": "Stake"
       }
+    },
+    "stake": {
+      "flow": {
+        "title": "Stake",
+        "amount": {
+          "disclaimer": "Unstaking will take 4 days.",
+          "awaitingDelegation": "Confirming your delegation. This usually takes less than a minute…"
+        },
+        "steps": {
+          "validator": {
+            "title": "Validator",
+            "description": "Choose a baker to delegate to. You will be able to stake your XTZ after the delegation is confirmed."
+          },
+          "deviceDelegation": {
+            "title": "Confirm Delegation"
+          },
+          "amount": {
+            "title": "Amount"
+          },
+          "deviceStaking": {
+            "title": "Confirm Staking"
+          },
+          "confirmation": {
+            "title": "Confirmation",
+            "success": {
+              "title": "You have successfully staked your assets",
+              "text": "You staked {{amount}}. Your account balance will be updated when the blockchain confirms the transaction.",
+              "cta": "Visit Earn Dashboard"
+            },
+            "broadcastError": "Your transaction may have failed. Please wait a moment then check the transaction history before trying again.",
+            "howItWorks": "How staking works"
+          }
+        }
+      }
     }
   },
   "delegation": {

--- a/libs/coin-modules/coin-tezos/src/logic/getBlock.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBlock.ts
@@ -188,7 +188,7 @@ function buildStakingOperations(op: APIStakingType): BlockOperation[] {
       amount: 0n,
       details: {
         operationType,
-        stakedAmount: BigInt(op.amount),
+        stakedAmount: BigInt(op.amount ?? 0),
         ...(bakerAddr && { delegate: bakerAddr }),
         counter: op.counter,
         gasLimit: op.gasLimit,

--- a/libs/coin-modules/coin-tezos/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/listOperations.test.ts
@@ -1097,6 +1097,36 @@ describe("listOperations", () => {
       expect(results[0].tx.feesPayer).toBe(stakerAddress);
     });
 
+    it("falls back to requestedAmount when amount is missing on a failed staking op", async () => {
+      const op = {
+        ...makeStaking("stake", 0),
+        status: "failed",
+        amount: undefined,
+        requestedAmount: 500_000_000,
+      } as unknown as APIStakingType;
+      mockGetAccountOperations.mockResolvedValue([op]);
+
+      const [results] = await listOperations(stakerAddress, options);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].value).toBe(500_000_000n);
+    });
+
+    it("returns 0 when both amount and requestedAmount are missing on a staking op", async () => {
+      const op = {
+        ...makeStaking("stake", 0),
+        status: "failed",
+        amount: undefined,
+        requestedAmount: undefined,
+      } as unknown as APIStakingType;
+      mockGetAccountOperations.mockResolvedValue([op]);
+
+      const [results] = await listOperations(stakerAddress, options);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].value).toBe(0n);
+    });
+
     it("includes staking ops alongside transfers in pagination", async () => {
       const stake = makeStaking("stake", 100);
       mockGetAccountOperations.mockResolvedValue([stake]);

--- a/libs/coin-modules/coin-tezos/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/listOperations.ts
@@ -419,6 +419,16 @@ function resolveStakingAddresses(op: APIStakingType): {
   return { senders: stakerArr, recipients: bakerArr };
 }
 
+// Failed stake/unstake ops carry `requestedAmount` and no `amount` field;
+// `BigInt(undefined)` throws and breaks sync. Fall back per-shape.
+function resolveAmount(operation: ConvertibleOperation): bigint {
+  if (isAPIRevealType(operation) || isAPIDelegationType(operation)) return 0n;
+  if (isAPIStakingType(operation)) {
+    return BigInt(operation.amount ?? operation.requestedAmount ?? 0);
+  }
+  return BigInt(operation.amount ?? 0);
+}
+
 function resolveNormalizedType(
   operation: ConvertibleOperation,
   address: string,
@@ -484,14 +494,7 @@ function convertOperation(
         recipients: targetAddress ? [targetAddress] : [],
       };
 
-  const amount =
-    isAPIRevealType(operation) || isAPIDelegationType(operation)
-      ? 0n
-      : // Failed stake/unstake ops carry `requestedAmount` and no `amount` field;
-        // `BigInt(undefined)` throws and breaks sync. Fall back per-shape.
-        isAPIStakingType(operation)
-        ? BigInt(operation.amount ?? operation.requestedAmount ?? 0)
-        : BigInt(operation.amount ?? 0);
+  const amount = resolveAmount(operation);
 
   const fee =
     BigInt(operation.storageFee ?? 0) +

--- a/libs/coin-modules/coin-tezos/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/listOperations.ts
@@ -485,7 +485,13 @@ function convertOperation(
       };
 
   const amount =
-    isAPIRevealType(operation) || isAPIDelegationType(operation) ? 0n : BigInt(operation.amount);
+    isAPIRevealType(operation) || isAPIDelegationType(operation)
+      ? 0n
+      : // Failed stake/unstake ops carry `requestedAmount` and no `amount` field;
+        // `BigInt(undefined)` throws and breaks sync. Fall back per-shape.
+        isAPIStakingType(operation)
+        ? BigInt(operation.amount ?? operation.requestedAmount ?? 0)
+        : BigInt(operation.amount ?? 0);
 
   const fee =
     BigInt(operation.storageFee ?? 0) +

--- a/libs/coin-modules/coin-tezos/src/network/types.ts
+++ b/libs/coin-modules/coin-tezos/src/network/types.ts
@@ -79,7 +79,8 @@ export function isAPIRevealType(op: APIOperation): op is APIRevealType {
 export type APIStakingType = Omit<CommonOperationType, "block"> & {
   type: "staking";
   action: "stake" | "unstake" | "finalize";
-  amount: number;
+  /** Present on succeeded ops; failed ops omit `amount` and only carry `requestedAmount`. */
+  amount?: number;
   requestedAmount?: number;
   counter: number;
   sender: { address: string } | undefined | null;

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
@@ -424,18 +424,21 @@ describe("Alpaca utils", () => {
         ).toThrow("Unsupported transaction mode: any");
       });
 
-      it("treats finalize_unstake as a staking intent with forced amount=0 and useAllAmount=true", () => {
-        const intent = transactionToIntent(
-          { currency: { name: "tezos", units: [{}] } } as Account,
-          { mode: "finalize_unstake", amount: new BigNumber(100) } as GenericTransaction,
-        );
-        expect(intent).toMatchObject({
-          intentType: "staking",
-          type: "finalize_unstake",
-          amount: 0n,
-          useAllAmount: true,
-        });
-      });
+      it.each(["stake", "unstake", "finalize_unstake"] as const)(
+        "preserves user-typed amount and useAllAmount for %s staking intent",
+        mode => {
+          const intent = transactionToIntent(
+            { currency: { name: "tezos", units: [{}] } } as Account,
+            { mode, amount: new BigNumber(100) } as GenericTransaction,
+          );
+          expect(intent).toMatchObject({
+            intentType: "staking",
+            type: mode,
+            amount: 100n,
+            useAllAmount: false,
+          });
+        },
+      );
 
       it("supersedes the logic with a custom function", () => {
         const computeIntentType = (transaction: GenericTransaction) =>

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
@@ -424,18 +424,25 @@ describe("Alpaca utils", () => {
         ).toThrow("Unsupported transaction mode: any");
       });
 
-      it.each(["stake", "unstake", "finalize_unstake"] as const)(
-        "preserves user-typed amount and useAllAmount for %s staking intent",
-        mode => {
+      it.each([
+        { mode: "stake", useAllAmount: false },
+        { mode: "stake", useAllAmount: true },
+        { mode: "unstake", useAllAmount: false },
+        { mode: "unstake", useAllAmount: true },
+        { mode: "finalize_unstake", useAllAmount: false },
+        { mode: "finalize_unstake", useAllAmount: true },
+      ] as const)(
+        "preserves user-typed amount and useAllAmount=$useAllAmount for $mode staking intent",
+        ({ mode, useAllAmount }) => {
           const intent = transactionToIntent(
             { currency: { name: "tezos", units: [{}] } } as Account,
-            { mode, amount: new BigNumber(100) } as GenericTransaction,
+            { mode, amount: new BigNumber(100), useAllAmount } as GenericTransaction,
           );
           expect(intent).toMatchObject({
             intentType: "staking",
             type: mode,
             amount: 100n,
-            useAllAmount: false,
+            useAllAmount,
           });
         },
       );

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
@@ -308,8 +308,8 @@ export function transactionToIntent(
   const isStaking = ["stake", "unstake", "finalize_unstake"].includes(intentType);
   const delegationMode = isDelegationMode(transaction.mode) ? transaction.mode : undefined;
   const isDelegation = delegationMode !== undefined;
-  const amount = isStaking ? 0n : fromBigNumberToBigInt(transaction.amount, 0n);
-  const useAllAmount = isStaking || !!transaction.useAllAmount;
+  const amount = fromBigNumberToBigInt(transaction.amount, 0n);
+  const useAllAmount = !!transaction.useAllAmount;
   const res: GenericAlpacaTransactionIntent = {
     intentType: isStaking || isDelegation ? "staking" : "transaction",
     type: intentType,

--- a/libs/ledger-live-common/src/families/tezos/react.ts
+++ b/libs/ledger-live-common/src/families/tezos/react.ts
@@ -1,6 +1,7 @@
 import type { AccountLike } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { useEffect, useMemo, useState } from "react";
+import { log } from "@ledgerhq/logs";
 import {
   Baker,
   Delegation,
@@ -24,10 +25,16 @@ export function useDelegation(account: AccountLike): Delegation | null | undefin
   const [delegation, setDelegation] = useState(() => bakers.getAccountDelegationSync(account));
   useEffect(() => {
     let cancelled = false;
-    bakers.loadAccountDelegation(account).then(delegation => {
-      if (cancelled) return;
-      setDelegation(delegation);
-    });
+    bakers
+      .loadAccountDelegation(account)
+      .then(delegation => {
+        if (cancelled) return;
+        setDelegation(delegation);
+      })
+      .catch(err => {
+        if (cancelled) return;
+        log("coin:tezos", `useDelegation: loadAccountDelegation failed: ${String(err)}`);
+      });
     return () => {
       cancelled = true;
     };

--- a/libs/ledger-live-common/src/families/tezos/react.ts
+++ b/libs/ledger-live-common/src/families/tezos/react.ts
@@ -33,7 +33,7 @@ export function useDelegation(account: AccountLike): Delegation | null | undefin
       })
       .catch(err => {
         if (cancelled) return;
-        log("coin:tezos", `useDelegation: loadAccountDelegation failed: ${String(err)}`);
+        log("coin:tezos", "useDelegation: loadAccountDelegation failed", { error: err });
       });
     return () => {
       cancelled = true;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Tezos staking happy path: full 5-step flow on a fresh XTZ account; verify the delegation pending op shows up after the first signing and the staking pending op after the second.
  - Tezos staking (3-step path): trigger via devtools openModal("MODAL_TEZOS_STAKE", { account, skipDelegation: true }) until LIVE-29544 wires the real entry. Breadcrumb should be 1/3 .. 3/3.
  - Error recovery: UserRefusedOnDevice at each device step → retry returns to the failing step (not to the validator). Network error during amount validation keeps the user on the amount step with an error banner.
  - Slow-network / await-delegation: between the two signings, the amount step shows a spinner while the chain confirms the delegation (poll cap ~60 s, then form falls through with MustDelegateBeforeStaking if not confirmed).
  - Tezos sync: any XTZ account whose history contains a failed staking op (mainnet or shadownet) should now sync to completion without retries.
  - Generic-framework coins: sanity-check send/swap/delegate on EVM, XRP, Stellar — no behavioural change expected, but the framework hunk is shared.

### 📝 Description

 Adds the Tezos LWD Stake flow modal (LIVE-29536). Wires the Stake CTA in the Earning Choice modal into a 5-step flow (validator → confirm delegation → amount → confirm staking → confirmation) for non-delegated accounts, or a 3-step flow (amount → confirm staking → confirmation) when entered with skipDelegation: true from an already-delegated account.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
