### PR TITLE
docs: prep related to migrating Cursor rules to shared agent skills

### DIFF
--- a/.cursor/rules/coin-families-contract.mdc
+++ b/.cursor/rules/coin-families-contract.mdc
@@ -18,27 +18,27 @@ alwaysApply: false
 
 ## Do (correct pattern)
 
-1. **Define a slot on the contract**  
+- **Define a slot on the contract**
    - **Desktop:** Add an optional property to `LLDCoinFamily` in `apps/ledger-live-desktop/src/renderer/families/types.ts` (e.g. `NoAssociatedAccounts?: React.ComponentType<...>`).
    - **Mobile:** Use the same idea: a typed contract (or generated map like `noAssociatedAccountsByFamily`) that families can optionally fill.
 
-2. **Implement only in the family**  
+- **Implement only in the family**
    - Put the component or logic in `families/<family>/` (e.g. `families/hedera/NoAssociatedAccounts.tsx`) and export it from the family index (Desktop: in the object passed to `generated`; Mobile: in the generated aggregation if applicable).
 
-3. **Use the contract in generic code**  
+- **Use the contract in generic code**
    - Generic code looks up by family and uses the slot if present, with **no** `if (family === "hedera")`:
    - **Desktop:** `getLLDCoinFamily(currency.family).NoAssociatedAccounts` → use it when defined.
    - **Mobile:** e.g. `getCustomNoAssociatedAccounts(currency)` returning a component from a family map, then pass it to the screen (e.g. as `CustomNoAssociatedAccounts` in route params).
 
 ## Reference example: Scan Device “no associated accounts”
 
-- **Contract (Desktop):**  
+- **Contract (Desktop):**
   `apps/ledger-live-desktop/src/renderer/families/types.ts` — `NoAssociatedAccounts?: React.ComponentType<AddAccountsStepProps>` on `LLDCoinFamily`.
-- **Family implementation:**  
+- **Family implementation:**
   `apps/ledger-live-desktop/src/renderer/families/hedera/NoAssociatedAccounts.tsx` and `hedera/index.ts` exporting it in the family object.
-- **Generic usage (Desktop):**  
+- **Generic usage (Desktop):**
   `StepImport.tsx` / `useScanAccounts.ts`: `getLLDCoinFamily(mainCurrency.family).NoAssociatedAccounts` — no Hedera-specific branch.
-- **Generic usage (Mobile):**  
+- **Generic usage (Mobile):**
   `useScanDeviceAccountsViewModel.ts`: `getCustomNoAssociatedAccounts(currency)` from `~/generated/NoAssociatedAccounts`; result passed as `CustomNoAssociatedAccounts` to the NoAssociatedAccounts screen. No `if (family === "hedera")` in the VM.
 
 When you need **new** coin-specific behavior in a generic flow (e.g. post-add-account navigation, custom empty state): **extend the contract** (add a new optional slot and document it), implement it in the relevant family folder, and have the generic code only read from the contract. Do not add new `if (family === "…")` branches in shared UI.

--- a/.cursor/rules/common-commands.mdc
+++ b/.cursor/rules/common-commands.mdc
@@ -1,5 +1,5 @@
 ---
-description: Use pnpm commands for build, dev, linting and testing.
+description: Use pnpm commands for build, dev, linting and testing
 alwaysApply: true
 ---
 

--- a/.cursor/rules/git-workflow.mdc
+++ b/.cursor/rules/git-workflow.mdc
@@ -3,6 +3,8 @@ description: Git workflow and commit conventions for Ledger Wallet
 alwaysApply: true
 ---
 
+<!-- cursor-doctor: conflicts with testing.mdc — review manually -->
+
 # Git Workflow & Commit Conventions
 
 ## Branch Naming

--- a/.cursor/rules/testing.mdc
+++ b/.cursor/rules/testing.mdc
@@ -3,6 +3,7 @@ description: General, Desktop, and Mobile testing patterns for Ledger Wallet
 globs: ["*.test.*", "*.spec.*", "**/tests/**", "**/__tests__/**"]
 alwaysApply: false
 ---
+<!-- cursor-doctor: conflicts with git-workflow.mdc — review manually -->
 
 # Testing Rules
 

--- a/.cursor/rules/trial/README.md
+++ b/.cursor/rules/trial/README.md
@@ -1,5 +1,0 @@
-# Trial rules
-
-Place rules in this directory that will be ignored by git but picked up by Cursor. 
-
-This is especially useful for trialing `alwaysApply` rules before pushing them to everyone.

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ libs/ui/packages/react/rsbuild.config.js.map
 
 .claude/settings.local.json
 .claude/worktrees/
-.cursor/rules/trial/*
 
 .nx/cache
 .nx/workspace-data


### PR DESCRIPTION
### 📝 Description

- I'm migrating the Cursor rules into shared agent files, see [LIVE-29412](https://ledgerhq.atlassian.net/browse/LIVE-29412)
- I'll do it via a series of PRs that relate to each rule individually
- These changes are a little bit of prep that doesn't relate to any one rule

#### What changed:

- **Removed the `.cursor/rules/trial` directory** – this was a fail experiment (because Cursor follows .gitignore unless your override it). Now we plan to migrate all the rules to `.agents/skills` and `AGENTS.md` so we might as well delete it
- **Let `cursor-doctor fix` auto fix a few things** – this is mostly linting and some notes about conflicts. The notes might be useful for the migration anyway and the linting I just want to commit so it doesn't come up everytime I use cursor-doctor

### ❓ Context

- **JIRA**: https://ledgerhq.atlassian.net/browse/LIVE-29412


[LIVE-29412]: https://ledgerhq.atlassian.net/browse/LIVE-29412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ