### PR TITLE
[LWM] fix(mobile): fix asset detail footer gradient transparency

### DIFF
--- a/.changeset/smooth-feet-glow.md
+++ b/.changeset/smooth-feet-glow.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix asset detail footer gradient transparency rendering

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/FooterView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/FooterView.tsx
@@ -29,8 +29,8 @@ export function FooterView({
   return (
     <LinearGradient
       stops={[
-        { color: "transparent", opacity: 0 },
-        { offset: 0.2, color: "base", opacity: 1 },
+        { color: "base", opacity: 0 },
+        { offset: 0.1, color: "base", opacity: 1 },
         { offset: 1, color: "base", opacity: 1 },
       ]}
       direction="to-bottom"


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _UI-only gradient tweak — requires visual verification._
- [x] **Impact of the changes:**
      - Asset detail footer gradient rendering on mobile
      - Gradient transition smoothness from top to opaque background

### 📝 Description

The gradient overlay at the bottom of the asset detail screen was using `"transparent"` as the starting color, which could cause visual artifacts on certain backgrounds due to color interpolation between transparent black and the base color.

Replaced `"transparent"` with `"base"` at `opacity: 0` for consistent color interpolation, and adjusted the second stop offset from `0.2` to `0.1` for a tighter, smoother gradient transition.


https://github.com/user-attachments/assets/2657dc5e-d04e-4492-8349-0822035b750c

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30624](https://ledgerhq.atlassian.net/browse/LIVE-30624)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30624]: https://ledgerhq.atlassian.net/browse/LIVE-30624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ