### PR TITLE
chore: check export rules step continue-on-error false in test libs w…

### DIFF
--- a/.github/workflows/test-libs-reusable.yml
+++ b/.github/workflows/test-libs-reusable.yml
@@ -170,7 +170,6 @@ jobs:
         run: pnpm exec nx run-many -t lint --exclude=ledger-live-desktop,live-mobile,@ledgerhq/live-cli,@ledgerhq/web-tools,ledger-live-desktop-e2e-tests,ledger-live-mobile-e2e-tests --parallel=3 --nxBail=false -- --quiet
       - name: Check export rules
         run: pnpm exec nx run @ledgerhq/client-ids:check-export-rules
-        continue-on-error: true
       - name: Typecheck affected libraries
         id: typecheck-libs
         run: pnpm exec nx run-many -t typecheck --exclude=ledger-live-desktop,live-mobile,@ledgerhq/live-cli,@ledgerhq/web-tools,ledger-live-desktop-e2e-tests,ledger-live-mobile-e2e-tests --parallel=3 --nxBail=false


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- The change is itself a CI enforcement; the workflow step it controls now fails the job on violation. -->
- [x] **Impact of the changes:**
  - The `Check export rules` step in `test-libs-reusable.yml` (running `@ledgerhq/client-ids:check-export-rules`) will now fail the job on violation instead of silently passing. QA should monitor CI on subsequent PRs to confirm the step still passes on `develop` and properly blocks regressions in the `client-ids` export rules.

### 📝 Description

Flips `continue-on-error` from `true` to `false` on the `Check export rules` step in `.github/workflows/test-libs-reusable.yml`.

This step was introduced with `continue-on-error: true` so it would not block the in-flight release branch while `@ledgerhq/client-ids` export rules were being stabilised. Now that the release has shipped, the safety net can be removed so the check is enforced for all future PRs and releases.

No code or runtime behaviour changes — CI enforcement only.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29937](https://ledgerhq.atlassian.net/browse/LIVE-29937)
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29937]: https://ledgerhq.atlassian.net/browse/LIVE-29937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ