### PR TITLE
[LWDM] refactor(solana-banner): accept resolved AccountBridge as parameter

### DIFF
--- a/.changeset/solana-banner-bridge.md
+++ b/.changeset/solana-banner-bridge.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-common": patch
+"ledger-live-desktop": patch
+---
+
+getAccountBannerState for solana now accepts the resolved AccountBridge as a parameter; desktop StakeBanner resolves it via useAccountBridge.

--- a/apps/ledger-live-desktop/src/renderer/families/solana/StakeBanner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/StakeBanner.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import { StakeAccountBannerParams } from "~/renderer/screens/account/types";
 import { useSolanaStakesWithMeta } from "@ledgerhq/live-common/families/solana/react";
 import { getAccountBannerState as getSolanaBannerState } from "@ledgerhq/live-common/families/solana/banner";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { openModal } from "~/renderer/actions/modals";
 import { useDispatch } from "LLD/hooks/redux";
 import { SolanaAccount } from "@ledgerhq/live-common/families/solana/types";
@@ -21,7 +22,8 @@ const StakeBanner: React.FC<{ account: SolanaAccount }> = ({ account }) => {
   );
   const stakeAccountBannerParams: StakeAccountBannerParams | null =
     stakeAccountBanner?.params ?? null;
-  const state = getSolanaBannerState(account);
+  const bridge = useAccountBridge(account);
+  const state = getSolanaBannerState(account, bridge);
   const { redelegate, display, ledgerValidator, stakeAccAddr } = state;
 
   if (redelegate && !stakeAccountBannerParams?.solana?.redelegate) return null;

--- a/libs/ledger-live-common/src/families/solana/banner.test.ts
+++ b/libs/ledger-live-common/src/families/solana/banner.test.ts
@@ -2,13 +2,12 @@ import * as preloadedData from "@ledgerhq/coin-solana/preload-data";
 import type { SolanaAccount, SolanaPreloadDataV1, SolanaStake } from "@ledgerhq/coin-solana/types";
 import type { ValidatorsAppValidator } from "@ledgerhq/coin-solana/network/validator-app/index";
 import { getAccountBannerState } from "./banner";
-import * as helpers from "../../account/helpers";
 
 jest.mock("@ledgerhq/coin-solana/preload-data");
-jest.mock("../../account/helpers", () => ({
-  ...jest.requireActual("../../account/helpers"),
-  isAccountEmpty: jest.fn(),
-}));
+
+const mockIsAccountEmpty = jest.fn();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockBridge = { isAccountEmpty: mockIsAccountEmpty } as any;
 
 import { BigNumber } from "bignumber.js";
 
@@ -116,7 +115,7 @@ const validatorsMap = {
   splTokens: null,
 } as SolanaPreloadDataV1;
 
-const mockedIsAccountEmpty = jest.mocked(helpers.isAccountEmpty);
+const mockedIsAccountEmpty = mockIsAccountEmpty;
 
 describe("solana/banner", () => {
   beforeEach(() => {
@@ -130,7 +129,7 @@ describe("solana/banner", () => {
   it("should not display the banner is account is", async () => {
     jest.spyOn(preloadedData, "getCurrentSolanaPreloadData").mockReturnValue(validatorsMap);
     mockedIsAccountEmpty.mockReturnValue(true);
-    const result = getAccountBannerState(account);
+    const result = getAccountBannerState(account, mockBridge);
     expect(result).toStrictEqual({
       display: false,
       redelegate: false,
@@ -141,7 +140,7 @@ describe("solana/banner", () => {
   it("should return display delegate mode is account is not empty", async () => {
     jest.spyOn(preloadedData, "getCurrentSolanaPreloadData").mockReturnValue(validatorsMap);
     mockedIsAccountEmpty.mockReturnValue(false);
-    const result = getAccountBannerState(account);
+    const result = getAccountBannerState(account, mockBridge);
     expect(result).toStrictEqual({
       display: true,
       redelegate: false,
@@ -166,7 +165,7 @@ describe("solana/banner", () => {
     jest.spyOn(preloadedData, "getCurrentSolanaPreloadData").mockReturnValue(validatorsMap);
     mockedIsAccountEmpty.mockReturnValue(false);
     account.solanaResources?.stakes.push(badValidator);
-    const result = getAccountBannerState(account);
+    const result = getAccountBannerState(account, mockBridge);
     expect(result).toStrictEqual({
       display: true,
       redelegate: true,

--- a/libs/ledger-live-common/src/families/solana/banner.ts
+++ b/libs/ledger-live-common/src/families/solana/banner.ts
@@ -3,7 +3,7 @@ import { stakeActions } from "@ledgerhq/coin-solana/logic";
 import { LEDGER_VALIDATORS_VOTE_ACCOUNTS } from "@ledgerhq/coin-solana/utils";
 import type { SolanaAccount } from "@ledgerhq/coin-solana/types";
 import type { ValidatorsAppValidator } from "@ledgerhq/coin-solana/network/validator-app/index";
-import { isAccountEmpty } from "../../account";
+import type { ResolvedAccountBridge } from "@ledgerhq/types-live";
 
 export interface AccountBannerState {
   display: boolean;
@@ -12,7 +12,11 @@ export interface AccountBannerState {
   ledgerValidator: ValidatorsAppValidator | undefined;
 }
 
-export function getAccountBannerState(account: SolanaAccount): AccountBannerState {
+export function getAccountBannerState(
+  account: SolanaAccount,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  bridge: ResolvedAccountBridge<any>,
+): AccountBannerState {
   // Group current validator
   const solanaResources = account.solanaResources ? account.solanaResources : { stakes: [] };
   const delegations = solanaResources?.stakes.map(delegation => {
@@ -60,7 +64,7 @@ export function getAccountBannerState(account: SolanaAccount): AccountBannerStat
   }
   if (worstValidator) {
     if (LEDGER_VALIDATORS_VOTE_ACCOUNTS.includes(worstValidator?.voteAccount)) {
-      if (!isAccountEmpty(account)) {
+      if (!bridge.isAccountEmpty(account)) {
         display = true;
       }
     } else {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [ ] **Impact of the changes:**
  - Solana stake banner only. `getAccountBannerState` in live-common now takes the resolved `AccountBridge` and uses `bridge.isAccountEmpty` instead of the deprecated top-level helper. Desktop `StakeBanner` resolves the bridge via `useAccountBridge`. QA focus: Solana stake banner visibility/state on accounts with and without delegation, on empty accounts (should stay hidden), and on accounts delegating to a non-Ledger validator (should show redelegate variant).

### 📝 Description

First slice of the desktop `AccountBridgeExtensions` migration (split from #17400). Smallest and most isolated: a single live-common signature change plus its one desktop consumer.

```diff
- function getAccountBannerState(account: SolanaAccount): AccountBannerState
+ function getAccountBannerState(account: SolanaAccount, bridge: ResolvedAccountBridge<any>): AccountBannerState
```

Consumers must now resolve the bridge before calling — desktop does so via `useAccountBridge(account)`.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30457](https://ledgerhq.atlassian.net/browse/LIVE-30457) — split out of #17400 / #17338
- **ADR link (if any)**: —

[LIVE-30457]: https://ledgerhq.atlassian.net/browse/LIVE-30457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ