### PR TITLE
[LWM] fix(mobile): add safe area bottom padding to asset detail tooltips

### DIFF
--- a/.changeset/fix-tooltip-bottom-padding.md
+++ b/.changeset/fix-tooltip-bottom-padding.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add safe area bottom padding to AssetDetail tooltip content

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/EarnCardsView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/EarnCardsView.tsx
@@ -15,6 +15,7 @@ import {
 } from "@ledgerhq/lumen-ui-rnative";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { ChevronRight, Information } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "~/context/Locale";
 import { ASSET_DETAIL_TEST_IDS } from "LLM/features/AssetDetail/testIds";
 
@@ -26,6 +27,7 @@ type Props = Readonly<{
 
 export function EarnCardsView({ formattedAvailable, formattedDeposit, onEarnDepositPress }: Props) {
   const { t } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
 
   return (
     <Box lx={rowStyle}>
@@ -45,9 +47,11 @@ export function EarnCardsView({ formattedAvailable, formattedDeposit, onEarnDepo
                     <TooltipContent
                       title={t("assetDetail.balanceDetails.availableBalance")}
                       content={
-                        <Text typography="body2" lx={{ color: "muted" }}>
-                          {t("assetDetail.balanceDetails.availableBalanceTooltip")}
-                        </Text>
+                        <Box style={{ paddingBottom: bottom + 24 }}>
+                          <Text typography="body1" lx={{ color: "base" }}>
+                            {t("assetDetail.balanceDetails.availableBalanceTooltip")}
+                          </Text>
+                        </Box>
                       }
                     />
                   </Tooltip>

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/MarketStatsView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/MarketStatsView.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Box, Text, Tooltip, TooltipTrigger, TooltipContent } from "@ledgerhq/lumen-ui-rnative";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { Information } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "~/context/Locale";
 import { ASSET_DETAIL_TEST_IDS } from "LLM/features/AssetDetail/testIds";
 import { SectionContentState } from "../SectionContentState";
@@ -24,6 +25,7 @@ type Props = Readonly<{
 
 export function MarketStatsView({ stats, isLoading, isError, hasData, onTooltipOpen }: Props) {
   const { t } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
 
   return (
     <Box testID={ASSET_DETAIL_TEST_IDS.marketStats} lx={containerStyle}>
@@ -54,9 +56,11 @@ export function MarketStatsView({ stats, isLoading, isError, hasData, onTooltipO
                     <TooltipContent
                       title={stat.tooltip.title}
                       content={
-                        <Text typography="body2" lx={{ color: "muted" }}>
-                          {stat.tooltip.content}
-                        </Text>
+                        <Box style={{ paddingBottom: bottom + 24 }}>
+                          <Text typography="body1" lx={{ color: "base" }}>
+                            {stat.tooltip.content}
+                          </Text>
+                        </Box>
                       }
                     />
                   </Tooltip>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Tooltip padding is a visual change best verified on device._
- [x] **Impact of the changes:**
      - Tooltip bottom sheets in the AssetDetail screen (MarketStats + EarnCards)
      - Safe area inset handling on devices with home indicator

### 📝 Description

Tooltip content in the AssetDetail feature was missing safe area bottom padding, causing text to be cut off or too close to the bottom edge on devices with a home indicator.

Wrapped the tooltip content in a `Box` with `paddingBottom: bottom + 24` using `useSafeAreaInsets` to ensure proper spacing. Applied to all 3 tooltips across `MarketStatsView` (circulating supply, max supply) and `EarnCardsView` (available balance).

https://github.com/user-attachments/assets/c39105b6-61ae-4621-97d0-ec43d40d5f69


### ❓ Context

- **JIRA or GitHub link**: [LIVE-30596](https://ledgerhq.atlassian.net/browse/LIVE-30596)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30596]: https://ledgerhq.atlassian.net/browse/LIVE-30596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ