### PR TITLE
[LWM] fix(mobile): hide balances in asset detail when discreet mode is enabled

### DIFF
--- a/.changeset/fix-asset-detail-discreet-mode.md
+++ b/.changeset/fix-asset-detail-discreet-mode.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix discreet mode not hiding balances on Asset Detail screen

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/components/AddressAccountItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/components/AddressAccountItem.tsx
@@ -10,7 +10,7 @@ import {
   CardTrailing,
 } from "@ledgerhq/lumen-ui-rnative";
 import CurrencyIcon from "~/components/CurrencyIcon";
-import { useFormattedAccountBalance } from "LLM/features/Send/screens/Recipient/hooks/useFormattedAccountBalance";
+import { useFormattedAccountBalance } from "LLM/hooks/useFormattedAccountBalance";
 import type { AddressAccountData } from "../useAddressesViewModel";
 
 type Props = Readonly<{

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/BalanceDetailsView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/BalanceDetailsView.tsx
@@ -12,6 +12,7 @@ type EarnState = BalanceDetailsViewModelResult["earnState"];
 
 type Props = Readonly<{
   hasAccounts: boolean;
+  discreet: boolean;
   counterValue: number | undefined;
   counterValueFormatter: (value: number) => FormattedValue;
   formattedTotalBalance: string;
@@ -23,6 +24,7 @@ type Props = Readonly<{
 
 export function BalanceDetailsView({
   hasAccounts,
+  discreet,
   counterValue,
   counterValueFormatter,
   formattedTotalBalance,
@@ -36,6 +38,7 @@ export function BalanceDetailsView({
   return (
     <Box testID={ASSET_DETAIL_TEST_IDS.balanceDetails} lx={containerStyle}>
       <TotalBalanceView
+        discreet={discreet}
         counterValue={counterValue}
         counterValueFormatter={counterValueFormatter}
         formattedTotalBalance={formattedTotalBalance}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/TotalBalanceView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/TotalBalanceView.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from "~/context/Locale";
 import { ASSET_DETAIL_TEST_IDS } from "LLM/features/AssetDetail/testIds";
 
 type Props = Readonly<{
+  discreet: boolean;
   counterValue: number | undefined;
   counterValueFormatter: (value: number) => FormattedValue;
   formattedTotalBalance: string;
@@ -14,6 +15,7 @@ type Props = Readonly<{
 }>;
 
 export function TotalBalanceView({
+  discreet,
   counterValue,
   counterValueFormatter,
   formattedTotalBalance,
@@ -28,7 +30,7 @@ export function TotalBalanceView({
           {t("assetDetail.balanceDetails.totalBalance")}
         </Text>
         {counterValue != null && (
-          <AmountDisplay value={counterValue} formatter={counterValueFormatter} />
+          <AmountDisplay value={counterValue} formatter={counterValueFormatter} hidden={discreet} />
         )}
         <Text typography="body3" lx={{ color: "muted" }}>
           {formattedTotalBalance}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/useBalanceDetailsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/useBalanceDetailsViewModel.ts
@@ -12,7 +12,7 @@ import { useInterestRatesByCurrencies } from "@ledgerhq/live-common/dada-client/
 import { useNavigation } from "@react-navigation/native";
 import { useSelector } from "~/context/hooks";
 import { accountsByCryptoCurrencyScreenSelector } from "~/reducers/accounts";
-import { counterValueCurrencySelector } from "~/reducers/settings";
+import { counterValueCurrencySelector, discreetModeSelector } from "~/reducers/settings";
 import { NavigatorName, ScreenName } from "~/const";
 import { track } from "~/analytics";
 import { useLocale, useTranslation } from "~/context/Locale";
@@ -27,6 +27,7 @@ type EarnState =
 
 export function useBalanceDetailsViewModel(currency: AssetDetailCurrencyProps) {
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const discreet = useSelector(discreetModeSelector);
   const { locale } = useLocale();
   const { t } = useTranslation();
 
@@ -58,8 +59,8 @@ export function useBalanceDetailsViewModel(currency: AssetDetailCurrencyProps) {
 
   const formattedTotalBalance = useMemo(() => {
     if (!unit) return "";
-    return formatCurrencyUnit(unit, totalBalance, { showCode: true });
-  }, [unit, totalBalance]);
+    return formatCurrencyUnit(unit, totalBalance, { showCode: true, discreet });
+  }, [unit, totalBalance, discreet]);
 
   const counterValueUnit = counterValueCurrency.units[0];
 
@@ -95,8 +96,11 @@ export function useBalanceDetailsViewModel(currency: AssetDetailCurrencyProps) {
     if (isStakeable && hasStake && unit) {
       return {
         type: "staked",
-        formattedAvailable: formatCurrencyUnit(unit, availableBalance, { showCode: true }),
-        formattedDeposit: formatCurrencyUnit(unit, earnDeposit, { showCode: true }),
+        formattedAvailable: formatCurrencyUnit(unit, availableBalance, {
+          showCode: true,
+          discreet,
+        }),
+        formattedDeposit: formatCurrencyUnit(unit, earnDeposit, { showCode: true, discreet }),
       };
     }
 
@@ -111,7 +115,17 @@ export function useBalanceDetailsViewModel(currency: AssetDetailCurrencyProps) {
     }
 
     return { type: "hidden" };
-  }, [hasAccounts, hasStake, isStakeable, unit, availableBalance, earnDeposit, interestRate, t]);
+  }, [
+    hasAccounts,
+    hasStake,
+    isStakeable,
+    unit,
+    availableBalance,
+    earnDeposit,
+    interestRate,
+    t,
+    discreet,
+  ]);
 
   const { openDrawer } = useTransferDrawerController();
   const navigation = useNavigation<BaseNavigation>();
@@ -158,6 +172,7 @@ export function useBalanceDetailsViewModel(currency: AssetDetailCurrencyProps) {
 
   return {
     hasAccounts,
+    discreet,
     counterValue,
     counterValueFormatter,
     formattedTotalBalance,

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/AccountRowWithBalance.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/AccountRowWithBalance.tsx
@@ -3,7 +3,7 @@ import type { Account } from "@ledgerhq/types-live";
 import { formatAddress } from "@ledgerhq/live-common/utils/addressUtils";
 import { useTranslation } from "~/context/Locale";
 import { AddressListItem } from "./AddressListItem";
-import { useFormattedAccountBalance } from "../hooks/useFormattedAccountBalance";
+import { useFormattedAccountBalance } from "LLM/hooks/useFormattedAccountBalance";
 import { useMaybeAccountName } from "~/reducers/wallet";
 
 type AccountRowWithBalanceProps = Readonly<{

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/MyAddressItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/MyAddressItem.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { AddressListItem } from "./AddressListItem";
-import { useFormattedAccountBalance } from "../hooks/useFormattedAccountBalance";
+import { useFormattedAccountBalance } from "LLM/hooks/useFormattedAccountBalance";
 import { Account } from "@ledgerhq/types-live";
 import { useMaybeAccountName } from "~/reducers/wallet";
 import { formatAddress } from "@ledgerhq/live-common/utils/addressUtils";

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useAddressValidation.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useAddressValidation.test.ts
@@ -10,7 +10,7 @@ import {
   getAccountCurrency,
 } from "@ledgerhq/live-common/account/index";
 import { useBridgeRecipientValidation } from "@ledgerhq/live-common/flows/send/recipient/hooks/useBridgeRecipientValidation";
-import { useFormattedAccountBalance } from "../useFormattedAccountBalance";
+import { useFormattedAccountBalance } from "LLM/hooks/useFormattedAccountBalance";
 import { useMaybeAccountName, useBatchMaybeAccountName } from "~/reducers/wallet";
 import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
 import { createMockAccount, createMockCurrency } from "./accounts";
@@ -21,7 +21,7 @@ jest.mock("@ledgerhq/domain-service/hooks/index");
 jest.mock("@ledgerhq/ledger-wallet-framework/sanction/index");
 jest.mock("@ledgerhq/live-common/account/index");
 jest.mock("@ledgerhq/live-common/flows/send/recipient/hooks/useBridgeRecipientValidation");
-jest.mock("../useFormattedAccountBalance");
+jest.mock("LLM/hooks/useFormattedAccountBalance");
 jest.mock("@ledgerhq/live-common/bridge/descriptor/send/features");
 
 const mockedUseSelector = jest.mocked(useSelector);

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
@@ -26,7 +26,7 @@ import type {
   RecentAddress,
 } from "@ledgerhq/live-common/flows/send/recipient/types";
 import { normalizeLastUsedTimestamp } from "../utils/dateFormatter";
-import { useFormattedAccountBalance } from "./useFormattedAccountBalance";
+import { useFormattedAccountBalance } from "LLM/hooks/useFormattedAccountBalance";
 
 function isDomainLoading(domain: DomainServiceStatus): boolean {
   return domain.status === "loading" || domain.status === "queued";

--- a/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useFormattedAccountBalance.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useFormattedAccountBalance.test.ts
@@ -1,25 +1,46 @@
 import { renderHook } from "@testing-library/react-native";
 import { useFormattedAccountBalance } from "../useFormattedAccountBalance";
 import { useSelector } from "~/context/hooks";
-import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { useCalculate } from "@ledgerhq/live-countervalues-react";
 import { useMaybeAccountUnit } from "LLM/hooks/useAccountUnit";
-import { createMockAccount } from "./accounts";
+import { discreetModeSelector } from "~/reducers/settings";
 import type { Account } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { getCryptoCurrencyById, formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 
 jest.mock("~/context/hooks");
 jest.mock("@ledgerhq/live-common/currencies/index");
 jest.mock("@ledgerhq/live-common/account/index");
 jest.mock("@ledgerhq/live-countervalues-react");
 jest.mock("LLM/hooks/useAccountUnit");
+jest.mock("~/reducers/settings", () => ({
+  counterValueCurrencySelector: jest.fn(),
+  discreetModeSelector: jest.fn(),
+}));
 
 const mockedUseSelector = jest.mocked(useSelector);
 const mockedUseMaybeAccountUnit = jest.mocked(useMaybeAccountUnit);
 const mockedGetAccountCurrency = jest.mocked(getAccountCurrency);
 const mockedFormatCurrencyUnit = jest.mocked(formatCurrencyUnit);
 const mockedUseCalculate = jest.mocked(useCalculate);
+
+const createMockCurrency = (overrides?: Partial<CryptoCurrency>): CryptoCurrency => ({
+  ...getCryptoCurrencyById("bitcoin"),
+  ...overrides,
+});
+
+const createMockAccount = (overrides?: Partial<Account>): Account => ({
+  ...genAccount("mock_account"),
+  id: "mock_account_id",
+  freshAddress: "source_address",
+  balance: new BigNumber(100000000),
+  spendableBalance: new BigNumber(100000000),
+  currency: createMockCurrency(),
+  ...overrides,
+});
 
 const mockAccount = createMockAccount();
 
@@ -32,7 +53,10 @@ const mockUnit = { code: "BTC", name: "Bitcoin", magnitude: 8 };
 describe("useFormattedAccountBalance", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedUseSelector.mockReturnValue(mockCounterValueCurrency);
+    mockedUseSelector.mockImplementation((selector: unknown) => {
+      if (selector === discreetModeSelector) return false;
+      return mockCounterValueCurrency;
+    });
     mockedUseMaybeAccountUnit.mockReturnValue(mockUnit);
     mockedGetAccountCurrency.mockReturnValue(mockAccount.currency);
     mockedFormatCurrencyUnit.mockImplementation((unit, _value, _options) => {
@@ -74,17 +98,38 @@ describe("useFormattedAccountBalance", () => {
     expect(result.current.formattedCounterValue).toBeUndefined();
   });
 
-  it("calls formatCurrencyUnit with correct parameters", () => {
+  it("calls formatCurrencyUnit with discreet option", () => {
     renderHook(() => useFormattedAccountBalance(mockAccount));
 
     expect(mockedFormatCurrencyUnit).toHaveBeenCalledWith(mockUnit, mockAccount.balance, {
       showCode: true,
+      discreet: false,
     });
 
     expect(mockedFormatCurrencyUnit).toHaveBeenCalledWith(
       mockCounterValueCurrency.units[0],
       expect.anything(),
-      { showCode: true },
+      { showCode: true, discreet: false },
+    );
+  });
+
+  it("passes discreet true when discreet mode is enabled", () => {
+    mockedUseSelector.mockImplementation((selector: unknown) => {
+      if (selector === discreetModeSelector) return true;
+      return mockCounterValueCurrency;
+    });
+
+    renderHook(() => useFormattedAccountBalance(mockAccount));
+
+    expect(mockedFormatCurrencyUnit).toHaveBeenCalledWith(mockUnit, mockAccount.balance, {
+      showCode: true,
+      discreet: true,
+    });
+
+    expect(mockedFormatCurrencyUnit).toHaveBeenCalledWith(
+      mockCounterValueCurrency.units[0],
+      expect.anything(),
+      { showCode: true, discreet: true },
     );
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/hooks/useFormattedAccountBalance.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/useFormattedAccountBalance.ts
@@ -6,19 +6,16 @@ import { BigNumber } from "bignumber.js";
 import { useMaybeAccountUnit } from "LLM/hooks/useAccountUnit";
 import { useMemo } from "react";
 import { useSelector } from "~/context/hooks";
-import { counterValueCurrencySelector } from "~/reducers/settings";
+import { counterValueCurrencySelector, discreetModeSelector } from "~/reducers/settings";
 
 type FormattedAccountBalance = {
   formattedBalance: string | undefined;
   formattedCounterValue: string | undefined;
 };
 
-/**
- * Hook to format account balance and counter value
- * Handles both defined and undefined accounts
- */
 export function useFormattedAccountBalance(account: Account | undefined): FormattedAccountBalance {
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const discreet = useSelector(discreetModeSelector);
   const unit = useMaybeAccountUnit(account);
   const accountCurrency = account ? getAccountCurrency(account) : undefined;
 
@@ -40,15 +37,17 @@ export function useFormattedAccountBalance(account: Account | undefined): Format
     }
     return formatCurrencyUnit(counterValueCurrency.units[0], new BigNumber(counterValue), {
       showCode: true,
+      discreet,
     });
-  }, [counterValue, counterValueCurrency, account, unit]);
+  }, [counterValue, counterValueCurrency, account, unit, discreet]);
 
   const formattedBalance = useMemo(() => {
     if (!account || !unit) return undefined;
     return formatCurrencyUnit(unit, account.balance, {
       showCode: true,
+      discreet,
     });
-  }, [account, unit]);
+  }, [account, unit, discreet]);
 
   return { formattedBalance, formattedCounterValue };
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Asset Detail screen balance display when discreet mode is toggled
      - Total balance (AmountDisplay + formatted text), earn cards (available/deposit), and address account items
      - Verify discreet mode toggle hides/reveals all balance values on the Asset Detail screen

### 📝 Description

**Problem**: When discreet mode is enabled, none of the balances on the Asset Detail screen are hidden. The total balance, available/earn deposit balances, and address account balances all remain visible, breaking the expected privacy behavior.

**Solution**: 
- Added `discreetModeSelector` to `useBalanceDetailsViewModel` and passed `hidden={discreet}` to the `AmountDisplay` in `TotalBalanceView`
- Passed `discreet` option to `formatCurrencyUnit` calls for text-based balances (total balance, available balance, earn deposit)
- Updated `useFormattedAccountBalance` to read discreet mode and mask counter values and crypto balances in address account items
- Updated existing tests to account for the new discreet mode parameter

<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-05-15 at 11 02 25" src="https://github.com/user-attachments/assets/4310a8f9-84bc-49da-8bf2-15bc193ee4b2" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-30447](https://ledgerhq.atlassian.net/browse/LIVE-30447)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30447]: https://ledgerhq.atlassian.net/browse/LIVE-30447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ