### PR TITLE
chore(wallet-cli): ship Apache-2.0 LICENSE in tarballs

### DIFF
--- a/.changeset/wallet-cli-license-file.md
+++ b/.changeset/wallet-cli-license-file.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-cli": patch
+---
+
+chore(wallet-cli): ship Apache-2.0 LICENSE file in wrapper and platform tarballs

--- a/apps/wallet-cli/LICENSE
+++ b/apps/wallet-cli/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/apps/wallet-cli/package.json
+++ b/apps/wallet-cli/package.json
@@ -9,6 +9,7 @@
   },
   "files": [
     "bin/",
+    "LICENSE",
     "README.md",
     "CHANGELOG.md",
     "package.json"

--- a/apps/wallet-cli/scripts/pack-check.mjs
+++ b/apps/wallet-cli/scripts/pack-check.mjs
@@ -14,6 +14,7 @@ const packages = [
     required: [
       "package/bin/wallet-cli",
       "package/CHANGELOG.md",
+      "package/LICENSE",
       "package/README.md",
       "package/package.json",
     ],
@@ -22,22 +23,22 @@ const packages = [
   {
     name: "@ledgerhq/wallet-cli-darwin-arm64",
     cwd: path.join(root, "npm/darwin-arm64/.npm-package"),
-    required: ["package/bin/wallet-cli", "package/package.json"],
+    required: ["package/bin/wallet-cli", "package/LICENSE", "package/package.json"],
   },
   {
     name: "@ledgerhq/wallet-cli-linux-arm64",
     cwd: path.join(root, "npm/linux-arm64/.npm-package"),
-    required: ["package/bin/wallet-cli", "package/package.json"],
+    required: ["package/bin/wallet-cli", "package/LICENSE", "package/package.json"],
   },
   {
     name: "@ledgerhq/wallet-cli-linux-x64",
     cwd: path.join(root, "npm/linux-x64/.npm-package"),
-    required: ["package/bin/wallet-cli", "package/package.json"],
+    required: ["package/bin/wallet-cli", "package/LICENSE", "package/package.json"],
   },
   {
     name: "@ledgerhq/wallet-cli-windows-x64",
     cwd: path.join(root, "npm/windows-x64/.npm-package"),
-    required: ["package/bin/wallet-cli.exe", "package/package.json"],
+    required: ["package/bin/wallet-cli.exe", "package/LICENSE", "package/package.json"],
   },
 ];
 

--- a/apps/wallet-cli/scripts/prepare-npm.mjs
+++ b/apps/wallet-cli/scripts/prepare-npm.mjs
@@ -90,7 +90,7 @@ async function prepareMainPackage() {
     description: mainPackage.description,
     license: mainPackage.license,
     bin: mainPackage.bin,
-    files: ["bin/", "README.md", "CHANGELOG.md"],
+    files: ["bin/", "LICENSE", "README.md", "CHANGELOG.md"],
     optionalDependencies: Object.fromEntries(
       platforms.map(platform => [platform.packageName, mainPackage.version]),
     ),
@@ -102,6 +102,7 @@ async function prepareMainPackage() {
   await rm(packageDirectory, { recursive: true, force: true });
   await mkdir(packageDirectory, { recursive: true });
   await writeFile(path.join(packageDirectory, "package.json"), `${JSON.stringify(publishPackage, null, 2)}\n`);
+  await copyFile(path.join(root, "LICENSE"), path.join(packageDirectory, "LICENSE"));
   await copyFile(path.join(root, "README.md"), path.join(packageDirectory, "README.md"));
   await copyFile(path.join(root, "CHANGELOG.md"), path.join(packageDirectory, "CHANGELOG.md"));
 }
@@ -119,7 +120,7 @@ async function preparePlatformBinaries() {
       bin: platform.bin,
       os: [platform.os],
       cpu: [platform.cpu],
-      files: ["bin/"],
+      files: ["bin/", "LICENSE"],
       publishConfig: {
         access: "public",
       },
@@ -131,6 +132,7 @@ async function preparePlatformBinaries() {
     await mkdir(path.join(packageDirectory, "bin"), { recursive: true });
     await writeFile(path.join(packageDirectory, "package.json"), `${JSON.stringify(publishPackage, null, 2)}\n`);
     await copyFile(source, path.join(packageDirectory, platform.bin["wallet-cli"]));
+    await copyFile(path.join(root, "LICENSE"), path.join(packageDirectory, "LICENSE"));
 
     if (platform.executable) {
       await chmod(target, 0o755);


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** `scripts/pack-check.mjs` now requires `package/LICENSE` in every wallet-cli tarball; CI runs `prepare:npm` → `pack:check` → `smoke:npm` on every build.
- [x] **Impact of the changes:**
  - Adds `apps/wallet-cli/LICENSE` (Apache-2.0) and ships it inside the wrapper package `@ledgerhq/wallet-cli` and the 4 platform packages (`@ledgerhq/wallet-cli-{darwin-arm64,linux-arm64,linux-x64,windows-x64}`).
  - No runtime/behavioral change.

### Description

The `license: "Apache-2.0"` field in `package.json` alone does not satisfy the redistribution clauses of upstream MIT/BSD/Apache dependencies that wallet-cli bundles into its compiled binary (Apache-2.0 §4(a) requires recipients to receive a copy of the License; MIT/BSD require the copyright/permission notice to ship with redistributions).

This PR adds the canonical Apache-2.0 v2.0 text as a `LICENSE` file at the root of every wallet-cli tarball:

- `apps/wallet-cli/LICENSE` — new, copied from `apps/ledger-live-mobile/LICENSE` (same canonical Apache-2.0 text already used by `libs/ledger-live-common`).
- `apps/wallet-cli/scripts/prepare-npm.mjs` — copies the LICENSE into `.npm-package/LICENSE` (wrapper) and each `npm/<platform>/.npm-package/LICENSE`; adds `LICENSE` to the generated `files` arrays.
- `apps/wallet-cli/scripts/pack-check.mjs` — adds `package/LICENSE` to the `required` entries for the 5 tarballs so the validation step fails loudly if it is ever missing.
- `apps/wallet-cli/package.json` — adds `LICENSE` to the source `files` array for consistency.

Verified locally: `pnpm prepare:npm` produces a LICENSE in all 5 `.npm-package/` directories, `pnpm pack:check` passes for all 5 packages, and `tar -tzf` on the wrapper and one platform tarball confirms `package/LICENSE` at the root.

### Context

- **JIRA or GitHub link**: N/A
- **ADR link (if any)**: N/A