### PR TITLE
[LWD] refactor(desktop): migrate operations layer to AccountBridgeExtensions

### DIFF
--- a/.changeset/bridge-extensions-operations-layer.md
+++ b/.changeset/bridge-extensions-operations-layer.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Migrate desktop operations layer (operations list, operation details drawer, edit-stuck-transaction panels for BTC and EVM, send recipient stuck-tx detection, account header actions) from deprecated isEditableOperation / isStuckOperation / getStuckAccountAndOperation top-level helpers to AccountBridgeExtensions via useAccountBridge / getAccountBridge.

--- a/apps/ledger-live-desktop/src/renderer/components/OperationsList/DateCell.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OperationsList/DateCell.tsx
@@ -1,4 +1,3 @@
-import { isStuckOperation } from "@ledgerhq/live-common/operation";
 import { InfiniteLoader, IconsLegacy } from "@ledgerhq/react-ui";
 import { Operation } from "@ledgerhq/types-live";
 import { TFunction } from "i18next";
@@ -19,11 +18,11 @@ const Cell = styled(Box).attrs(() => ({
 
 type Props = {
   t: TFunction;
-  family: string;
   operation: Operation;
   text?: string;
   compact?: boolean;
   editable?: boolean;
+  isStuck?: boolean;
 };
 
 const PendingLoadingIcon = ({ displayWarning }: { displayWarning: boolean }): React.JSX.Element => {
@@ -38,7 +37,7 @@ const PendingLoadingIcon = ({ displayWarning }: { displayWarning: boolean }): Re
   return <InfiniteLoader size={12} style={{ verticalAlign: "middle" }} />;
 };
 
-const DateCell = ({ t, family, operation, compact, text, editable }: Props): React.JSX.Element => {
+const DateCell = ({ t, operation, compact, text, editable, isStuck }: Props): React.JSX.Element => {
   const ellipsis = {
     display: "block",
     textOverflow: "ellipsis",
@@ -61,7 +60,7 @@ const DateCell = ({ t, family, operation, compact, text, editable }: Props): Rea
       {editable ? (
         <Box fontSize={3} color="neutral.c80">
           <Box ff="Inter|SemiBold" fontSize={3} color="neutral.c80" style={ellipsis}>
-            <PendingLoadingIcon displayWarning={isStuckOperation({ family, operation })} />
+            <PendingLoadingIcon displayWarning={!!isStuck} />
             <Box
               style={{
                 marginLeft: "4px",

--- a/apps/ledger-live-desktop/src/renderer/components/OperationsList/EditOperationPanel.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OperationsList/EditOperationPanel.tsx
@@ -1,4 +1,5 @@
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { Account, AccountLike, Operation } from "@ledgerhq/types-live";
 import React, { memo, useCallback, useMemo } from "react";
@@ -22,6 +23,7 @@ const EditOperationPanel = (props: Props) => {
   const { enabled: isEditBitcoinTxEnabled, params: bitcoinParams } =
     useFeature("editBitcoinTx") ?? {};
   const mainAccount = getMainAccount(account, parentAccount);
+  const bridge = useAccountBridge(mainAccount);
 
   // Determine if transaction editing is supported and which modal to use
   const editConfig = useMemo(() => {
@@ -31,6 +33,7 @@ const EditOperationPanel = (props: Props) => {
       parentAccount,
       mainAccount,
       operation,
+      bridge,
       featureFlags: {
         evm: {
           enabled: isEditEvmTxEnabled ?? false,
@@ -55,6 +58,7 @@ const EditOperationPanel = (props: Props) => {
     parentAccount,
     operation,
     mainAccount,
+    bridge,
     isEditEvmTxEnabled,
     params,
     isEditBitcoinTxEnabled,

--- a/apps/ledger-live-desktop/src/renderer/components/OperationsList/Operation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OperationsList/Operation.tsx
@@ -6,6 +6,7 @@ import Box from "~/renderer/components/Box";
 import { TFunction } from "i18next";
 import { AccountLike, Account, Operation } from "@ledgerhq/types-live";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import ConfirmationCell from "./ConfirmationCell";
 import DateCell from "./DateCell";
 import AccountCell from "./AccountCell";
@@ -40,7 +41,6 @@ type OwnProps = {
   withAccount?: boolean;
   withAddress?: boolean;
   text?: string;
-  editable?: boolean;
 };
 type Props = OwnProps;
 
@@ -51,11 +51,11 @@ function OperationComponent({
   onOperationClick,
   t,
   text,
-  editable,
   withAddress = true,
   withAccount = false,
 }: Props) {
   const mainAccount = getMainAccount(account, parentAccount);
+  const bridge = useAccountBridge(mainAccount);
   const confirmationsNb = useSelector((state: State) =>
     confirmationsNbForCurrencySelector(state, mainAccount),
   );
@@ -73,6 +73,7 @@ function OperationComponent({
   const isConfirmed = isConfirmedOperation(operation, mainAccount, confirmationsNb);
   const specific = getLLDCoinFamily(cryptoCurrency.family);
   const CustomMetadataCell = specific ? specific.operationDetails?.customMetadataCell : null;
+  const editable = mainAccount.type === "Account" && bridge.isEditableOperation(mainAccount, operation);
 
   return (
     <OperationRow
@@ -88,10 +89,10 @@ function OperationComponent({
         isConfirmed={isConfirmed}
       />
       <DateCell
-        family={mainAccount.currency.family}
         text={text}
         operation={operation}
         editable={editable}
+        isStuck={bridge.isStuckOperation(operation)}
         t={t}
       />
       {withAccount && <AccountCell accountName={accountName} currency={currency} />}

--- a/apps/ledger-live-desktop/src/renderer/components/OperationsList/OperationsListV1/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OperationsList/OperationsListV1/index.tsx
@@ -10,7 +10,6 @@ import {
   groupAccountOperationsByDay,
   groupAccountsOperationsByDay,
   flattenAccounts,
-  getMainAccount,
 } from "@ledgerhq/live-common/account/index";
 import logger from "~/renderer/logger";
 import { openModal } from "~/renderer/actions/modals";
@@ -25,7 +24,6 @@ import OperationC from "../Operation";
 import TableContainer, { TableHeader } from "../../TableContainer";
 import { OperationDetails } from "~/renderer/drawers/OperationDetails";
 import { setDrawer } from "~/renderer/drawers/Provider";
-import { isEditableOperation } from "@ledgerhq/live-common/operation";
 
 const ShowMore = styled(Box).attrs(() => ({
   horizontal: true,
@@ -153,7 +151,6 @@ export class OperationsList extends PureComponent<Props, State> {
                     return null;
                   }
                 }
-                const mainAccount = getMainAccount(account, parentAccount);
                 return (
                   <OperationC
                     operation={operation}
@@ -163,7 +160,6 @@ export class OperationsList extends PureComponent<Props, State> {
                     onOperationClick={this.handleClickOperation}
                     t={t}
                     withAccount={withAccount}
-                    editable={account && isEditableOperation({ account: mainAccount, operation })}
                   />
                 );
               })}

--- a/apps/ledger-live-desktop/src/renderer/components/OperationsList/tests/EditOperationPanel.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OperationsList/tests/EditOperationPanel.test.tsx
@@ -12,6 +12,10 @@ jest.mock("@ledgerhq/live-common/account/index", () => ({
   getMainAccount: jest.fn(),
 }));
 
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  useAccountBridge: () => ({}),
+}));
+
 jest.mock("~/renderer/actions/modals", () => ({
   ...jest.requireActual("~/renderer/actions/modals"),
   closeModal: jest.fn(),

--- a/apps/ledger-live-desktop/src/renderer/drawers/OperationDetails/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/OperationDetails/index.tsx
@@ -15,9 +15,8 @@ import {
   getOperationAmountNumber,
   getOperationConfirmationDisplayableNumber,
   isConfirmedOperation,
-  isEditableOperation,
-  isStuckOperation,
 } from "@ledgerhq/live-common/operation";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { getEnv } from "@ledgerhq/live-env";
 import { CryptoCurrency, CryptoCurrencyId } from "@ledgerhq/types-cryptoassets";
 import { Account, AccountLike, Operation, OperationType } from "@ledgerhq/types-live";
@@ -143,6 +142,7 @@ const OperationD = (props: Props) => {
   const navigate = useNavigate();
   const location = useLocation();
   const mainAccount = getMainAccount(account, parentAccount);
+  const bridge = useAccountBridge(mainAccount);
   const { hash, date, senders, type, fee, recipients: _recipients } = operation;
 
   const dateFormatted = useDateFormatted(date, dayAndHourFormat);
@@ -260,7 +260,7 @@ const OperationD = (props: Props) => {
     // Check for Bitcoin RBF support
     if (currencyFamily === "bitcoin") {
       // RBF only works for unconfirmed (pending) transactions
-      const isEditable = isEditableOperation({ account: mainAccount, operation });
+      const isEditable = bridge.isEditableOperation(mainAccount, operation);
       if (
         !isEditable ||
         !bitcoinParams?.supportedCurrencyIds?.includes(mainAccount.currency.id as CryptoCurrencyId)
@@ -290,7 +290,7 @@ const OperationD = (props: Props) => {
       const isCurrencySupported =
         params?.supportedCurrencyIds?.includes(mainAccount.currency.id as CryptoCurrencyId) ||
         false;
-      const isEditable = isEditableOperation({ account: mainAccount, operation });
+      const isEditable = bridge.isEditableOperation(mainAccount, operation);
 
       if (isEditEvmTxEnabled && isCurrencySupported && isEditable) {
         return {
@@ -308,6 +308,7 @@ const OperationD = (props: Props) => {
     params,
     mainAccount,
     operation,
+    bridge,
     bitcoinParams?.supportedCurrencyIds,
     isEditBitcoinTxEnabled,
   ]);
@@ -374,7 +375,7 @@ const OperationD = (props: Props) => {
     operation.hash,
   ]);
 
-  const isStuck = isStuckOperation({ family: mainAccount.currency.family, operation });
+  const isStuck = bridge.isStuckOperation(operation);
   const feesCurrency = useMemo(() => getFeesCurrency(mainAccount), [mainAccount]);
   const feesUnit = useMemo(() => getFeesUnit(feesCurrency), [feesCurrency]);
 

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/EditStuckTransactionPanelBodyHeader.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/EditStuckTransactionPanelBodyHeader.tsx
@@ -1,6 +1,6 @@
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
-import { getStuckAccountAndOperation } from "@ledgerhq/coin-bitcoin/operation";
 import { CryptoCurrencyId } from "@ledgerhq/types-cryptoassets";
 import { Account, AccountLike } from "@ledgerhq/types-live";
 import invariant from "invariant";
@@ -16,6 +16,7 @@ type Props = {
 const EditStuckTransactionPanelBodyHeader = ({ account, parentAccount }: Props) => {
   invariant(account, "account required");
 
+  const bridge = useAccountBridge(account, parentAccount);
   const mainAccount = getMainAccount(account, parentAccount);
   const { enabled: isEditBitcoinTxEnabled, params: bitcoinParams } =
     useFeature("editBitcoinTx") ?? {};
@@ -27,7 +28,7 @@ const EditStuckTransactionPanelBodyHeader = ({ account, parentAccount }: Props) 
     return null;
   }
   // check if there is a stuck transaction. If so, display a warning panel with "speed up or cancel" button
-  const stuckAccountAndOperation = getStuckAccountAndOperation(account, parentAccount);
+  const stuckAccountAndOperation = bridge.getStuckAccountAndOperation(account, parentAccount);
 
   if (!stuckAccountAndOperation) {
     return null;

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/__tests__/EditTransactionComponents.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/__tests__/EditTransactionComponents.test.tsx
@@ -2,7 +2,7 @@ import BigNumber from "bignumber.js";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getFormattedFeeFields } from "@ledgerhq/coin-bitcoin/editTransaction/index";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getStuckAccountAndOperation } from "@ledgerhq/coin-bitcoin/operation";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import React from "react";
 import { render, screen, withFlagOverrides } from "tests/testSetup";
 import EditStuckTransactionPanelBodyHeader from "../EditStuckTransactionPanelBodyHeader";
@@ -20,10 +20,14 @@ jest.mock("@ledgerhq/live-common/account/index", () => ({
   getMainAccount: jest.fn(),
 }));
 
-jest.mock("@ledgerhq/coin-bitcoin/operation", () => ({
-  ...jest.requireActual("@ledgerhq/coin-bitcoin/operation"),
-  getStuckAccountAndOperation: jest.fn(),
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  useAccountBridge: jest.fn(),
 }));
+
+const mockGetStuckAccountAndOperation = jest.fn();
+(useAccountBridge as jest.Mock).mockReturnValue({
+  getStuckAccountAndOperation: mockGetStuckAccountAndOperation,
+});
 
 jest.mock("~/renderer/modals/Send/SendAmountFields", () => ({
   __esModule: true,
@@ -126,7 +130,7 @@ describe("Bitcoin EditTransaction components", () => {
   });
 
   it("EditStuckTransactionPanelBodyHeader renders panel when enabled and stuck tx exists", () => {
-    (getStuckAccountAndOperation as jest.Mock).mockReturnValue({
+    mockGetStuckAccountAndOperation.mockReturnValue({
       operation: {},
       account,
       parentAccount: undefined,

--- a/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/EditStuckTransactionPanelBodyHeader.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/EditStuckTransactionPanelBodyHeader.tsx
@@ -1,6 +1,6 @@
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
-import { getStuckAccountAndOperation } from "@ledgerhq/live-common/operation";
 import { CryptoCurrencyId } from "@ledgerhq/types-cryptoassets";
 import { Account, AccountLike } from "@ledgerhq/types-live";
 import invariant from "invariant";
@@ -15,6 +15,7 @@ type Props = {
 const EditStuckTransactionPanelBodyHeader = ({ account, parentAccount }: Props) => {
   invariant(account, "account required");
 
+  const bridge = useAccountBridge(account, parentAccount);
   const mainAccount = getMainAccount(account, parentAccount);
   const { enabled: isEditEvmTxEnabled, params } = useFeature("editEvmTx") ?? {};
   const isCurrencySupported =
@@ -24,7 +25,7 @@ const EditStuckTransactionPanelBodyHeader = ({ account, parentAccount }: Props) 
     return null;
   }
   // check if there is a stuck transaction. If so, display a warning panel with "speed up or cancel" button
-  const stuckAccountAndOperation = getStuckAccountAndOperation(account, parentAccount);
+  const stuckAccountAndOperation = bridge.getStuckAccountAndOperation(account, parentAccount);
 
   return (
     <SharedEditStuckTransactionPanelBodyHeader

--- a/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/__tests__/EditTransactionComponents.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/__tests__/EditTransactionComponents.test.tsx
@@ -9,6 +9,7 @@ import EditStuckTransactionPanelBodyHeader from "../EditStuckTransactionPanelBod
 import StepFees, { StepFeesFooter } from "../steps/StepFees";
 import { StepSummaryFooter } from "../steps/StepSummaryFooter";
 import type { StepProps } from "../types";
+import evmFamily from "../../index";
 
 jest.mock("@ledgerhq/coin-evm/editTransaction/index", () => ({
   ...jest.requireActual("@ledgerhq/coin-evm/editTransaction/index"),
@@ -203,5 +204,23 @@ describe("EVM EditTransaction components", () => {
     });
 
     expect(screen.getByTestId("shared-stuck-header")).toHaveTextContent("true-true-true");
+  });
+
+  describe("family.handlesEditTransaction", () => {
+    const mainAccount = { ...account, currency: { ...account.currency, family: "evm", id: "ethereum" } };
+    const operation = { transactionRaw: { type: 2 } } as never;
+    const featureFlags = { evm: { enabled: true, supportedCurrencyIds: ["ethereum"] } };
+
+    it("returns null when the bridge marks the operation as non-editable", () => {
+      const bridge = { isEditableOperation: jest.fn().mockReturnValue(false) } as never;
+      const result = evmFamily.handlesEditTransaction!({ account, parentAccount: undefined, mainAccount, operation, bridge, featureFlags });
+      expect(result).toBeNull();
+    });
+
+    it("returns modal config when the bridge marks the operation as editable", () => {
+      const bridge = { isEditableOperation: jest.fn().mockReturnValue(true) } as never;
+      const result = evmFamily.handlesEditTransaction!({ account, parentAccount: undefined, mainAccount, operation, bridge, featureFlags });
+      expect(result).toEqual(expect.objectContaining({ modalName: "MODAL_EVM_EDIT_TRANSACTION" }));
+    });
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/__tests__/EditTransactionComponents.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/__tests__/EditTransactionComponents.test.tsx
@@ -2,7 +2,7 @@ import BigNumber from "bignumber.js";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getFormattedFeeFields } from "@ledgerhq/coin-evm/editTransaction/index";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getStuckAccountAndOperation } from "@ledgerhq/live-common/operation";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import React from "react";
 import { render, screen, withFlagOverrides } from "tests/testSetup";
 import EditStuckTransactionPanelBodyHeader from "../EditStuckTransactionPanelBodyHeader";
@@ -20,10 +20,14 @@ jest.mock("@ledgerhq/live-common/account/index", () => ({
   getMainAccount: jest.fn(),
 }));
 
-jest.mock("@ledgerhq/live-common/operation", () => ({
-  ...jest.requireActual("@ledgerhq/live-common/operation"),
-  getStuckAccountAndOperation: jest.fn(),
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  useAccountBridge: jest.fn(),
 }));
+
+const mockGetStuckAccountAndOperation = jest.fn();
+(useAccountBridge as jest.Mock).mockReturnValue({
+  getStuckAccountAndOperation: mockGetStuckAccountAndOperation,
+});
 
 jest.mock("~/renderer/components/SpeedUpCancel/SharedStepFees", () => ({
   SharedStepFees: ({
@@ -188,7 +192,7 @@ describe("EVM EditTransaction components", () => {
   });
 
   it("EditStuckTransactionPanelBodyHeader forwards feature/status to shared header", () => {
-    (getStuckAccountAndOperation as jest.Mock).mockReturnValue({
+    mockGetStuckAccountAndOperation.mockReturnValue({
       operation: {},
       account,
       parentAccount: undefined,

--- a/apps/ledger-live-desktop/src/renderer/families/evm/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/index.ts
@@ -1,5 +1,4 @@
 import { getMessageProperties } from "@ledgerhq/coin-evm/logic";
-import { isEditableOperation } from "@ledgerhq/live-common/operation";
 import AccountBalanceSummaryFooter from "./AccountBalanceSummaryFooter";
 import AccountBodyHeader from "./AccountBodyHeader";
 import AccountFooter from "./AccountFooter";
@@ -23,14 +22,14 @@ const family: EvmFamily = {
   message: {
     getMessageProperties,
   },
-  handlesEditTransaction: ({ account, parentAccount, mainAccount, operation, featureFlags }) => {
+  handlesEditTransaction: ({ account, parentAccount, mainAccount, operation, bridge, featureFlags }) => {
     if (!operation.transactionRaw) {
       return null;
     }
 
     const isCurrencySupported =
       featureFlags.evm.supportedCurrencyIds?.includes(mainAccount.currency.id) || false;
-    const isEditable = isEditableOperation({ account: mainAccount, operation });
+    const isEditable = bridge.isEditableOperation(mainAccount, operation);
 
     if (!featureFlags.evm.enabled || !isCurrencySupported || !isEditable) {
       return null;

--- a/apps/ledger-live-desktop/src/renderer/families/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/types.ts
@@ -16,6 +16,7 @@ import {
   FeeStrategy,
   Operation,
   OperationType,
+  ResolvedAccountBridge,
   TokenAccount,
   TransactionCommon,
   TransactionCommonRaw,
@@ -478,6 +479,7 @@ export type LLDCoinFamily<
     parentAccount: A | undefined;
     mainAccount: A;
     operation: O;
+    bridge: ResolvedAccountBridge<T>;
     featureFlags: EditTransactionFeatureFlags;
   }) => EditTransactionModalConfig | null;
 

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepRecipient.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepRecipient.test.tsx
@@ -8,8 +8,9 @@ import { getLLDCoinFamily } from "~/renderer/families";
 import StepRecipient from "./StepRecipient";
 
 jest.mock("~/renderer/families");
+const mockUseAccountBridgeOrNull = jest.fn(() => ({ getStuckAccountAndOperation: () => undefined }));
 jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
-  useAccountBridgeOrNull: () => ({ getStuckAccountAndOperation: () => undefined }),
+  useAccountBridgeOrNull: () => mockUseAccountBridgeOrNull(),
 }));
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -125,5 +126,14 @@ describe("StepRecipient", () => {
     render(<StepRecipient {...baseParams} />);
 
     expect(screen.queryByTestId("family-send-step")).toBeInTheDocument();
+  });
+
+  it("renders without crashing when account bridge is not yet resolved", () => {
+    mockUseAccountBridgeOrNull.mockReturnValueOnce(null as never);
+    mockGetLLDCoinFamily.mockReturnValue({});
+
+    render(<StepRecipient {...baseParams} />);
+
+    expect(screen.queryByText("send.steps.details.selectAccountDebit")).toBeInTheDocument();
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepRecipient.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepRecipient.test.tsx
@@ -128,7 +128,7 @@ describe("StepRecipient", () => {
     expect(screen.queryByTestId("family-send-step")).toBeInTheDocument();
   });
 
-  it("renders without crashing when account bridge is not yet resolved", () => {
+  it("renders without crashing when useAccountBridgeOrNull returns null", () => {
     mockUseAccountBridgeOrNull.mockReturnValueOnce(null as never);
     mockGetLLDCoinFamily.mockReturnValue({});
 

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepRecipient.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepRecipient.test.tsx
@@ -8,6 +8,9 @@ import { getLLDCoinFamily } from "~/renderer/families";
 import StepRecipient from "./StepRecipient";
 
 jest.mock("~/renderer/families");
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  useAccountBridgeOrNull: () => ({ getStuckAccountAndOperation: () => undefined }),
+}));
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 const mockTFunction: jest.Mock<TFunction> = jest.fn(key => key) as unknown as jest.Mock<TFunction>;

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepRecipient.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepRecipient.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react";
-import { getStuckAccountAndOperation } from "@ledgerhq/live-common/operation";
+import { useAccountBridgeOrNull } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Trans } from "react-i18next";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import TrackPage from "~/renderer/analytics/TrackPage";
@@ -59,6 +59,7 @@ export const DefaultStepRecipient = ({
   const forceAutoFocusOnMemoField = useSelector(forceAutoFocusOnMemoFieldSelector);
   const lldMemoTag = useFeature("lldMemoTag");
   const { isEnabledForFamily } = useNewSendFlowFeature();
+  const bridge = useAccountBridgeOrNull(account ?? null, parentAccount);
 
   const accountFilter = useMemo(
     () => (acc: Account) => {
@@ -74,7 +75,7 @@ export const DefaultStepRecipient = ({
   const extensions = getTokenExtensions(account);
 
   // check if there is a stuck transaction. If so, display a warning panel with "speed up or cancel" button
-  const stuckAccountAndOperation = getStuckAccountAndOperation(account, parentAccount);
+  const stuckAccountAndOperation = bridge?.getStuckAccountAndOperation(account, parentAccount);
 
   return (
     <Box flow={4}>

--- a/apps/ledger-live-desktop/src/renderer/screens/account/AccountHeaderActions.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/AccountHeaderActions.tsx
@@ -1,9 +1,5 @@
-import {
-  canSend,
-  getAccountCurrency,
-  getMainAccount,
-  isAccountEmpty,
-} from "@ledgerhq/live-common/account/index";
+import { canSend, getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useRampCatalog } from "@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog";
 
 import { Account, AccountLike } from "@ledgerhq/types-live";
@@ -191,6 +187,7 @@ const pageName = "Page Account";
 
 const AccountHeaderActions = ({ account, parentAccount, openModal }: Props) => {
   const { data: currenciesAll } = useFetchCurrencyAll();
+  const bridge = useAccountBridge(account, parentAccount);
   const mainAccount = getMainAccount(account, parentAccount);
   const contrastText = useTheme().colors.neutral.c70;
   const swapDefaultTrack = useGetSwapTrackingProperties();
@@ -403,7 +400,7 @@ const AccountHeaderActions = ({ account, parentAccount, openModal }: Props) => {
 
   return (
     <Box horizontal alignItems="center" justifyContent="flex-end" flow={2} mt={15}>
-      {!isAccountEmpty(account) ? NonEmptyAccountHeader : null}
+      {bridge.isAccountEmpty(account) ? null : NonEmptyAccountHeader}
     </Box>
   );
 };

--- a/apps/ledger-live-desktop/tests/jestSetup.js
+++ b/apps/ledger-live-desktop/tests/jestSetup.js
@@ -1,8 +1,7 @@
-import { registerAllCoins } from "@ledgerhq/live-common/coin-modules/load-all-coins";
+import "../src/live-common-set-supported-currencies";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { liveConfig } from "@ledgerhq/live-common/config/sharedConfig";
 import { setCoinConfig } from "@ledgerhq/coin-evm/config";
-registerAllCoins();
 LiveConfig.setConfig(liveConfig);
 setCoinConfig(() => ({ info: {} }));
 import "@jest/globals";


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [ ] **Impact of the changes:**
  - Operations layer only. Replaces deprecated `isEditableOperation`, `isStuckOperation`, `getStuckAccountAndOperation` top-level helpers with bridge equivalents across operations list (DateCell, Operation, EditOperationPanel, OperationsListV1), operation details drawer, edit-stuck-tx panels (BTC + EVM), send recipient stuck-tx detection, and account header actions. `EditTransactionModalConfig` now carries `bridge`, so family `handlesEditTransaction` hooks receive the resolved bridge directly. QA focus: operations list (stuck operation visual badge), operation details drawer (edit/cancel actions on stuck txs), edit-stuck-tx panels for BTC & EVM, sending to a recipient with an existing stuck transaction, account header stuck-tx warnings.

### 📝 Description

Second slice of the desktop `AccountBridgeExtensions` migration (split from #17400 / #17338). Migrates the operations + edit-transaction surface to bridge-resolved calls. Independent of the Solana banner slice (#17477) and of the still-pending per-family Stake button and add-account/cache-clean slices.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30457](https://ledgerhq.atlassian.net/browse/LIVE-30457) — split out of #17400 / #17338
- **ADR link (if any)**: —

[LIVE-30457]: https://ledgerhq.atlassian.net/browse/LIVE-30457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ