### PR TITLE
chore: remove unnecessary knip ignore entries

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -48,18 +48,13 @@
         ".storybook/electronStub.js",
         ".storybook/fsStub.js",
         ".storybook/settingsMock.ts",
-        "src/renderer/mockServiceWorker.js",
-        "src/mvvm/utils/cn.ts"
+        "src/renderer/mockServiceWorker.js"
       ],
       "ignoreDependencies": [
         "prop-types",
         "allure-commandline",
-        "msw",
-        "buffer",
         "ws",
         "@electron/fuses",
-        "@reduxjs/toolkit",
-        "class-variance-authority",
         "embla-carousel-autoplay",
         "embla-carousel-react",
         "events",
@@ -75,11 +70,9 @@
         "src/devTools/perfUtils.ts"
       ],
       "ignoreDependencies": [
-        "@react-native-masked-view/masked-view",
         "@react-native/assets-registry",
         "@react-native/community-cli-plugin",
         "@react-native/gradle-plugin",
-        "asyncstorage-down",
         "buffer",
         "expo-crypto",
         "expo-file-system",
@@ -89,10 +82,8 @@
         "prop-types",
         "react-is",
         "react-native-fast-pbkdf2",
-        "react-native-level-fs",
         "react-native-navigation-bar-color",
         "react-native-randombytes",
-        "react-native-tcp-socket",
         "react-native-udp",
         "stylis"
       ]
@@ -159,8 +150,7 @@
         "src/reactLegacy/index.ts",
         "src/nativeLegacy/index.ts"
       ],
-      "ignoreDependencies": ["stylis"],
-      "ignore": ["scripts/**", "index.js"]
+      "ignore": ["index.js"]
     },
     "./libs/ledgerjs/packages/react-native-hid": {
       "entry": ["src/index.ts"]


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _No code changes — config-only cleanup validated by running knip per-workspace._
- [x] **Impact of the changes:**
      - No behavior change. Knip lint results remain identical before and after.
      - Only `knip.json` configuration was cleaned up.

### 📝 Description

The `knip.json` config had accumulated `ignoreDependencies` and `ignore` entries that are no longer necessary — knip no longer flags them even without the suppression.

**Removed entries:**

- **Desktop `ignoreDependencies`**: `msw`, `buffer`, `@reduxjs/toolkit`, `class-variance-authority` (knip sees them as used)
- **Desktop `ignore`**: `src/mvvm/utils/cn.ts` (not flagged as unused file)
- **Mobile `ignoreDependencies`**: `@react-native-masked-view/masked-view`, `asyncstorage-down`, `react-native-level-fs`, `react-native-tcp-socket` (not flagged)
- **Icons `ignoreDependencies`**: `stylis` (not flagged)
- **Icons `ignore`**: `scripts/**` (redundant with global `**/scripts/**` pattern)

Each removal was validated by running `pnpm knip -W <workspace>` without the entry and confirming no new errors appeared.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30631](https://ledgerhq.atlassian.net/browse/LIVE-30631)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30631]: https://ledgerhq.atlassian.net/browse/LIVE-30631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ