### PR TITLE
[LWD] refactor(desktop): migrate per-family Stake button to AccountBridgeExtensions

### DIFF
--- a/.changeset/bridge-extensions-stake-button.md
+++ b/.changeset/bridge-extensions-stake-button.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Migrate per-family AccountHeaderManageActions (Stake button) for aleo, celo, evm, hedera, polkadot, solana, and tezos from the deprecated isAccountEmpty top-level helper to bridge.isAccountEmpty via useAccountBridge.

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/AccountHeaderManageActions.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/AccountHeaderManageActions.tsx
@@ -6,10 +6,13 @@ import IconTransfer from "~/renderer/icons/Transfer";
 import type { AleoFamily } from "./types";
 import { AleoCustomModal } from "./constants";
 
-const AccountHeaderActions: AleoFamily["accountHeaderManageActions"] = ({ account }) => {
+const AccountHeaderActions: AleoFamily["accountHeaderManageActions"] = ({
+  account,
+  parentAccount,
+}) => {
   const dispatch = useDispatch();
   const { t } = useTranslation();
-  const bridge = useAccountBridge(account);
+  const bridge = useAccountBridge(account, parentAccount);
 
   if (account.type !== "Account") {
     return [];

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/AccountHeaderManageActions.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/AccountHeaderManageActions.tsx
@@ -1,6 +1,6 @@
 import { useDispatch } from "LLD/hooks/redux";
 import { useTranslation } from "react-i18next";
-import { isAccountEmpty } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { openModal } from "~/renderer/actions/modals";
 import IconTransfer from "~/renderer/icons/Transfer";
 import type { AleoFamily } from "./types";
@@ -9,12 +9,13 @@ import { AleoCustomModal } from "./constants";
 const AccountHeaderActions: AleoFamily["accountHeaderManageActions"] = ({ account }) => {
   const dispatch = useDispatch();
   const { t } = useTranslation();
+  const bridge = useAccountBridge(account);
 
   if (account.type !== "Account") {
     return [];
   }
 
-  const isSelfTransferDisabled = isAccountEmpty(account);
+  const isSelfTransferDisabled = bridge.isAccountEmpty(account);
 
   const onClick = () => {
     dispatch(openModal(AleoCustomModal.SELF_TRANSFER, { account }));

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/__tests__/AccountHeaderManageActions.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/__tests__/AccountHeaderManageActions.test.tsx
@@ -6,6 +6,10 @@ import AccountHeaderActions from "../AccountHeaderManageActions";
 import { AleoCustomModal } from "../constants";
 import { ALEO_ACCOUNT_1, NEW_ALEO_ACCOUNT } from "../__mocks__/account.mock";
 
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  useAccountBridge: () => ({ isAccountEmpty: (a: { balance: { isZero: () => boolean } }) => a.balance.isZero() }),
+}));
+
 describe("AccountHeaderManageActions", () => {
   const hook = AccountHeaderActions;
   invariant(hook, "aleo: type guard AccountHeaderActions");

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/__tests__/addAccountFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/__tests__/addAccountFlow.test.tsx
@@ -34,6 +34,8 @@ const mockAccountBridge = {
   assignToAccountRaw: () => {},
   assignToTokenAccountRaw: () => {},
   toOperationExtraRaw: (extra: unknown) => extra,
+  isAccountEmpty: (a: { operationsCount: number; balance: { isZero: () => boolean } }) =>
+    a.operationsCount === 0 && a.balance.isZero(),
 };
 
 const mockNavigate = jest.fn();

--- a/apps/ledger-live-desktop/src/renderer/families/celo/AccountHeaderManageActions/AccountHeaderManageActions.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/AccountHeaderManageActions/AccountHeaderManageActions.tsx
@@ -1,4 +1,4 @@
-import { isAccountEmpty } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { isAccountRegistrationPending } from "@ledgerhq/live-common/families/celo/logic";
 import { CeloAccount } from "@ledgerhq/live-common/families/celo/types";
 import React, { useCallback } from "react";
@@ -17,10 +17,11 @@ const AccountHeaderManageActions: CeloFamily["accountHeaderManageActions"] = ({
 }) => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
+  const bridge = useAccountBridge(account, parentAccount);
   const label = useGetStakeLabelLocaleBased();
   const isRegistrationPending = isAccountRegistrationPending(account as CeloAccount);
   const onClick = useCallback(() => {
-    if (isAccountEmpty(account)) {
+    if (bridge.isAccountEmpty(account)) {
       dispatch(
         openModal("MODAL_NO_FUNDS_STAKE", {
           account,
@@ -37,7 +38,7 @@ const AccountHeaderManageActions: CeloFamily["accountHeaderManageActions"] = ({
         );
       }
     }
-  }, [account, dispatch, parentAccount, source]);
+  }, [account, bridge, dispatch, parentAccount, source]);
   const disabledLabel = isRegistrationPending
     ? `${t("celo.manage.titleWhenPendingRegistration")}`
     : "";

--- a/apps/ledger-live-desktop/src/renderer/families/evm/AccountHeaderManageActions.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/AccountHeaderManageActions.ts
@@ -1,7 +1,7 @@
 import { Account, AccountLike } from "@ledgerhq/types-live";
 import { useCallback } from "react";
 import { openModal } from "~/renderer/actions/modals";
-import { isAccountEmpty } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useGetStakeLabelLocaleBased } from "~/renderer/hooks/useGetStakeLabelLocaleBased";
 import { useNavigate } from "react-router";
 import { useStake } from "LLD/hooks/useStake";
@@ -18,6 +18,7 @@ type Props = {
 const AccountHeaderActions = ({ account, parentAccount }: Props) => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
+  const bridge = useAccountBridge(account, parentAccount);
   const label = useGetStakeLabelLocaleBased();
   const walletState = useSelector(walletSelector);
   const { getRouteToPlatformApp } = useStake();
@@ -45,7 +46,7 @@ const AccountHeaderActions = ({ account, parentAccount }: Props) => {
   );
 
   const onClickStakeModal = useCallback(() => {
-    if (isAccountEmpty(account)) {
+    if (bridge.isAccountEmpty(account)) {
       dispatch(
         openModal("MODAL_NO_FUNDS_STAKE", {
           account,
@@ -69,7 +70,7 @@ const AccountHeaderActions = ({ account, parentAccount }: Props) => {
         }),
       );
     }
-  }, [account, dispatch, parentAccount, getRouteToPlatformApp, walletState, navigate]);
+  }, [account, bridge, dispatch, parentAccount, getRouteToPlatformApp, walletState, navigate]);
 
   const getStakeAction = useCallback(() => {
     if (isEthereumAccount) {

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/AccountHeaderManageActions.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/AccountHeaderManageActions.tsx
@@ -7,12 +7,15 @@ import IconCoins from "~/renderer/icons/Coins";
 import type { HederaFamily } from "~/renderer/families/hedera/types";
 import { useStake } from "LLD/hooks/useStake";
 
-const AccountHeaderActions: HederaFamily["accountHeaderManageActions"] = ({ account }) => {
+const AccountHeaderActions: HederaFamily["accountHeaderManageActions"] = ({
+  account,
+  parentAccount,
+}) => {
   const label = useGetStakeLabelLocaleBased();
   const dispatch = useDispatch();
   const { t } = useTranslation();
   const { getCanStakeCurrency } = useStake();
-  const bridge = useAccountBridge(account);
+  const bridge = useAccountBridge(account, parentAccount);
 
   if (account.type !== "Account") {
     return [];

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/AccountHeaderManageActions.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/AccountHeaderManageActions.tsx
@@ -1,6 +1,6 @@
 import { useDispatch } from "LLD/hooks/redux";
 import { useTranslation } from "react-i18next";
-import { isAccountEmpty } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { openModal } from "~/renderer/actions/modals";
 import { useGetStakeLabelLocaleBased } from "~/renderer/hooks/useGetStakeLabelLocaleBased";
 import IconCoins from "~/renderer/icons/Coins";
@@ -12,6 +12,7 @@ const AccountHeaderActions: HederaFamily["accountHeaderManageActions"] = ({ acco
   const dispatch = useDispatch();
   const { t } = useTranslation();
   const { getCanStakeCurrency } = useStake();
+  const bridge = useAccountBridge(account);
 
   if (account.type !== "Account") {
     return [];
@@ -25,7 +26,7 @@ const AccountHeaderActions: HederaFamily["accountHeaderManageActions"] = ({ acco
   }
 
   const onClick = () => {
-    const modalKey = isAccountEmpty(account) ? "MODAL_NO_FUNDS_STAKE" : "MODAL_HEDERA_DELEGATION";
+    const modalKey = bridge.isAccountEmpty(account) ? "MODAL_NO_FUNDS_STAKE" : "MODAL_HEDERA_DELEGATION";
     dispatch(openModal(modalKey, { account }));
   };
 

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/AccountHeaderManageActions.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/AccountHeaderManageActions.ts
@@ -5,7 +5,8 @@ import {
   hasExternalStash,
   hasPendingOperationType,
 } from "@ledgerhq/live-common/families/polkadot/logic";
-import { getMainAccount, isAccountEmpty } from "@ledgerhq/live-common/account/index";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import IconCoins from "~/renderer/icons/Coins";
 import { PolkadotAccount } from "@ledgerhq/live-common/families/polkadot/types";
 import { useGetStakeLabelLocaleBased } from "~/renderer/hooks/useGetStakeLabelLocaleBased";
@@ -23,6 +24,7 @@ const AccountHeaderManageActions = ({ account, parentAccount, source = "Account 
   const { t } = useTranslation();
   const label = useGetStakeLabelLocaleBased();
   const dispatch = useDispatch();
+  const bridge = useAccountBridge(account, parentAccount);
   const mainAccount = getMainAccount(account, parentAccount);
   const { polkadotResources } = mainAccount;
   const hasBondedBalance = polkadotResources.lockedBalance && polkadotResources.lockedBalance.gt(0);
@@ -42,27 +44,25 @@ const AccountHeaderManageActions = ({ account, parentAccount, source = "Account 
               : `/account/${account.id}`,
         },
       });
+    } else if (bridge.isAccountEmpty(mainAccount)) {
+      dispatch(
+        openModal("MODAL_NO_FUNDS_STAKE", {
+          account: mainAccount,
+        }),
+      );
+    } else if (hasBondedBalance || hasPendingBondOperation) {
+      dispatch(
+        openModal("MODAL_POLKADOT_MANAGE", {
+          account: mainAccount,
+          source,
+        }),
+      );
     } else {
-      if (isAccountEmpty(mainAccount)) {
-        dispatch(
-          openModal("MODAL_NO_FUNDS_STAKE", {
-            account: mainAccount,
-          }),
-        );
-      } else if (hasBondedBalance || hasPendingBondOperation) {
-        dispatch(
-          openModal("MODAL_POLKADOT_MANAGE", {
-            account: mainAccount,
-            source,
-          }),
-        );
-      } else {
-        dispatch(
-          openModal("MODAL_POLKADOT_REWARDS_INFO", {
-            account: mainAccount,
-          }),
-        );
-      }
+      dispatch(
+        openModal("MODAL_POLKADOT_REWARDS_INFO", {
+          account: mainAccount,
+        }),
+      );
     }
   };
 

--- a/apps/ledger-live-desktop/src/renderer/families/solana/AccountHeaderManageActions.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/AccountHeaderManageActions.ts
@@ -1,4 +1,5 @@
-import { getMainAccount, isAccountEmpty } from "@ledgerhq/live-common/account/index";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useCallback } from "react";
 import { useDispatch } from "LLD/hooks/redux";
 import { openModal } from "~/renderer/actions/modals";
@@ -12,12 +13,13 @@ const AccountHeaderActions: SolanaFamily["accountHeaderManageActions"] = ({
   source,
 }) => {
   const dispatch = useDispatch();
+  const bridge = useAccountBridge(account, parentAccount);
   const label = useGetStakeLabelLocaleBased();
   const mainAccount = getMainAccount(account, parentAccount);
   const { solanaResources } = mainAccount;
 
   const onClick = useCallback(() => {
-    if (isAccountEmpty(account)) {
+    if (bridge.isAccountEmpty(account)) {
       dispatch(
         openModal("MODAL_NO_FUNDS_STAKE", {
           account,
@@ -36,7 +38,7 @@ const AccountHeaderActions: SolanaFamily["accountHeaderManageActions"] = ({
         ),
       );
     }
-  }, [account, dispatch, source, solanaResources, mainAccount]);
+  }, [account, bridge, dispatch, source, solanaResources, mainAccount]);
 
   if (account.type === "TokenAccount") {
     return null;

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/AccountHeaderManageActions.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/AccountHeaderManageActions.ts
@@ -1,4 +1,4 @@
-import { isAccountEmpty } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useTezosStakingInfo } from "@ledgerhq/live-common/families/tezos/react";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { useCallback } from "react";
@@ -15,13 +15,14 @@ const AccountHeaderManageActions: TezosFamily["accountHeaderManageActions"] = ({
   source,
 }) => {
   const dispatch = useDispatch();
+  const bridge = useAccountBridge(account, parentAccount);
   const label = useGetStakeLabelLocaleBased();
   const lldTezosStaking = useFeature("lldTezosStaking");
 
   const { delegation, isDelegated, isStaked } = useTezosStakingInfo(account);
 
   const onClick = useCallback(() => {
-    if (isAccountEmpty(account)) {
+    if (bridge.isAccountEmpty(account)) {
       dispatch(
         openModal("MODAL_NO_FUNDS_STAKE", {
           account,
@@ -56,6 +57,7 @@ const AccountHeaderManageActions: TezosFamily["accountHeaderManageActions"] = ({
     dispatch(openModal("MODAL_DELEGATE", options));
   }, [
     account,
+    bridge,
     delegation,
     isDelegated,
     isStaked,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [ ] **Impact of the changes:**
  - Per-family Stake button only. Replaces `isAccountEmpty` with `bridge.isAccountEmpty` (resolved via `useAccountBridge`) in `accountHeaderManageActions` for aleo, celo, evm, hedera, polkadot, solana, and tezos. QA focus: Stake button on each of those coins — `MODAL_NO_FUNDS_STAKE` must still open on empty accounts, regular stake/delegate flows must still trigger on funded ones.

### 📝 Description

Third slice of the desktop `AccountBridgeExtensions` migration (split from #17400 / #17338). Independent of the already-landed solana banner slice (#17477) and of the operations slice (#17484); the `accountHeaderManageActions` hook signature is unchanged, so each family is a self-contained transform.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30457](https://ledgerhq.atlassian.net/browse/LIVE-30457) — split out of #17400 / #17338
- **ADR link (if any)**: —

[LIVE-30457]: https://ledgerhq.atlassian.net/browse/LIVE-30457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ