### PR TITLE
[LWDM] refactor(desktop): migrate add-account flow and cache-clean to AccountBridgeExtensions

### DIFF
--- a/.changeset/bridge-extensions-add-account.md
+++ b/.changeset/bridge-extensions-add-account.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Migrate add-account flows (legacy modal + AddAccountDrawer scan), account screen entry, cache-clean reducer, and useAccountStatus from deprecated isAccountEmpty / clearAccount top-level helpers to bridge-resolved equivalents (useAccountBridgeMany, useAreAccountsEmpty, getAccountBridge thunks).

--- a/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/__tests__/addAccountFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/__tests__/addAccountFlow.test.tsx
@@ -40,6 +40,8 @@ const mockAccountBridge = {
   assignToAccountRaw: () => {},
   assignToTokenAccountRaw: () => {},
   toOperationExtraRaw: (extra: unknown) => extra,
+  isAccountEmpty: (a: { operationsCount: number; balance: { isZero: () => boolean } }) =>
+    a.operationsCount === 0 && a.balance.isZero(),
 };
 
 jest.mock("~/renderer/bridge/cache", () => ({

--- a/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/ScanAccounts/useScanAccounts.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/ScanAccounts/useScanAccounts.ts
@@ -1,4 +1,4 @@
-import { getCurrencyBridge } from "@ledgerhq/live-common/bridge/index";
+import { getAccountBridge, getCurrencyBridge } from "@ledgerhq/live-common/bridge/index";
 import { addAccountsAction } from "@ledgerhq/live-wallet/addAccounts";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { Account } from "@ledgerhq/types-live";
@@ -65,6 +65,14 @@ export function useScanAccounts({
   existingAccountsRef.current = existingAccounts;
   const scannedAccountsRef = useRef(scannedAccounts);
   scannedAccountsRef.current = scannedAccounts;
+  // Emptiness is resolved per discovered account in the scan pipeline (getAccountBridge
+  // is not safe to call synchronously); the predicate passed to computeSelectedIdsFromScan
+  // reads from this ref.
+  const emptyByIdRef = useRef<Map<string, boolean>>(new Map());
+  const isAccountEmpty = useCallback(
+    (account: Account) => emptyByIdRef.current.get(account.id) ?? false,
+    [],
+  );
 
   const newAccountSchemes = useMemo(() => {
     const accountSchemes = scannedAccounts
@@ -87,6 +95,7 @@ export function useScanAccounts({
 
   useEffect(() => {
     let cancelled = false;
+    emptyByIdRef.current = new Map();
     (async () => {
       const bridge = await getCurrencyBridge(currency);
       if (cancelled) return;
@@ -103,12 +112,24 @@ export function useScanAccounts({
           },
         }),
       )
-        .pipe(RX.scan((acc: Account[], { account }) => [...acc, account], []))
+        .pipe(
+          RX.concatMap(async ({ account }) => {
+            const accountBridge = await getAccountBridge(account);
+            emptyByIdRef.current.set(account.id, accountBridge.isAccountEmpty(account));
+            return account;
+          }),
+          RX.scan((acc: Account[], account: Account) => [...acc, account], []),
+        )
         .subscribe({
           next: (accounts: Account[]) => {
             setScannedAccounts(accounts);
             setSelectedIds(current =>
-              computeSelectedIdsFromScan(accounts, existingAccountsRef.current, current),
+              computeSelectedIdsFromScan(
+                accounts,
+                existingAccountsRef.current,
+                current,
+                isAccountEmpty,
+              ),
             );
             setScanning(true);
           },
@@ -121,13 +142,14 @@ export function useScanAccounts({
       cancelled = true;
       stopSubscription(false);
     };
-  }, [blacklistedTokenIds, currency, deviceId, stopSubscription]);
+  }, [blacklistedTokenIds, currency, deviceId, isAccountEmpty, stopSubscription]);
 
   useLayoutEffect(() => {
+    const resolved = scannedAccountsRef.current.filter(a => emptyByIdRef.current.has(a.id));
     setSelectedIds(current =>
-      computeSelectedIdsFromScan(scannedAccountsRef.current, existingAccounts, current),
+      computeSelectedIdsFromScan(resolved, existingAccounts, current, isAccountEmpty),
     );
-  }, [existingAccounts]);
+  }, [existingAccounts, isAccountEmpty]);
 
   const {
     importableAccounts,

--- a/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/ScanAccounts/utils/processAccounts.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/ScanAccounts/utils/processAccounts.test.ts
@@ -1,10 +1,11 @@
 import { Account } from "@ledgerhq/types-live";
+import BigNumber from "bignumber.js";
+import { defaultIsAccountEmpty } from "@ledgerhq/live-common/bridge/defaultBridgeExtensions";
 import {
   computeSelectedIdsFromScan,
   determineSelectedIds,
   getUnimportedAccounts,
 } from "./processAccounts";
-import BigNumber from "bignumber.js";
 
 describe("getUnimportedAccounts", () => {
   it("should return accounts that are not in the existing accounts", () => {
@@ -34,7 +35,7 @@ describe("getUnimportedAccounts", () => {
 describe("determineSelectedIds", () => {
   it("should return all accounts if onlyNewAccounts is true", () => {
     const accounts = [{ id: "1" }, { id: "2" }] as Account[];
-    const result = determineSelectedIds(accounts, true, []);
+    const result = determineSelectedIds(accounts, true, [], defaultIsAccountEmpty);
     expect(result).toEqual(["1", "2"]);
   });
 
@@ -43,7 +44,7 @@ describe("determineSelectedIds", () => {
       { id: "1" },
       { id: "2", balance: BigNumber("100"), operationsCount: 1 },
     ] as Account[];
-    const result = determineSelectedIds(accounts, false, ["1"]);
+    const result = determineSelectedIds(accounts, false, ["1"], defaultIsAccountEmpty);
     expect(result).toEqual(["1", "2"]);
   });
 
@@ -52,7 +53,7 @@ describe("determineSelectedIds", () => {
       { id: "1" },
       { id: "2", balance: BigNumber("0"), operationsCount: 0 },
     ] as Account[];
-    const result = determineSelectedIds(accounts, false, ["1"]);
+    const result = determineSelectedIds(accounts, false, ["1"], defaultIsAccountEmpty);
     expect(result).toEqual(["1"]);
   });
 
@@ -61,7 +62,7 @@ describe("determineSelectedIds", () => {
       { id: "1", balance: BigNumber("0"), operationsCount: 0 },
       { id: "2", balance: BigNumber("100"), operationsCount: 1 },
     ] as Account[];
-    const result = determineSelectedIds(accounts, false, []);
+    const result = determineSelectedIds(accounts, false, [], defaultIsAccountEmpty);
     expect(result).toEqual(["2"]);
   });
 });
@@ -74,7 +75,12 @@ describe("computeSelectedIdsFromScan", () => {
     ] as Account[];
     const existingAccounts = [{ id: "existing" }] as Account[];
 
-    const result = computeSelectedIdsFromScan(scannedAccounts, existingAccounts, []);
+    const result = computeSelectedIdsFromScan(
+      scannedAccounts,
+      existingAccounts,
+      [],
+      defaultIsAccountEmpty,
+    );
     expect(result).toEqual(["1", "2"]);
   });
 
@@ -84,7 +90,12 @@ describe("computeSelectedIdsFromScan", () => {
       { id: "2", balance: BigNumber("200"), operationsCount: 1 },
     ] as Account[];
 
-    const result = computeSelectedIdsFromScan(scannedAccounts, [], ["1"]);
+    const result = computeSelectedIdsFromScan(
+      scannedAccounts,
+      [],
+      ["1"],
+      defaultIsAccountEmpty,
+    );
     expect(result).toEqual(["1", "2"]);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/ScanAccounts/utils/processAccounts.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/ScanAccounts/utils/processAccounts.ts
@@ -1,6 +1,7 @@
-import { isAccountEmpty } from "@ledgerhq/live-common/account/index";
 import { groupAddAccounts } from "@ledgerhq/live-wallet/addAccounts";
 import { Account, DerivationMode } from "@ledgerhq/types-live";
+
+type IsAccountEmpty = (account: Account) => boolean;
 
 export const getUnimportedAccounts = (scanned: Account[], existing: Account[]): Account[] => {
   const existingIds = new Set(existing.map(acc => acc.id));
@@ -19,6 +20,7 @@ export const determineSelectedIds = (
   accounts: Account[],
   onlyNewAccounts: boolean,
   currentSelectedIds: string[],
+  isAccountEmpty: IsAccountEmpty,
 ) => {
   if (onlyNewAccounts) {
     return accounts.map(x => x.id);
@@ -34,6 +36,7 @@ export const computeSelectedIdsFromScan = (
   scannedAccounts: Account[],
   existingAccounts: Account[],
   currentSelectedIds: string[],
+  isAccountEmpty: IsAccountEmpty,
 ): string[] => {
   const unimportedAccounts = getUnimportedAccounts(scannedAccounts, existingAccounts);
   const onlyNewAccounts = unimportedAccounts.every(isAccountEmpty);
@@ -47,7 +50,7 @@ export const computeSelectedIdsFromScan = (
     return true;
   });
 
-  return determineSelectedIds(freshAccounts, onlyNewAccounts, currentSelectedIds);
+  return determineSelectedIds(freshAccounts, onlyNewAccounts, currentSelectedIds, isAccountEmpty);
 };
 
 export const getGroupedAccounts = (

--- a/apps/ledger-live-desktop/src/mvvm/hooks/useAccountStatus.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/useAccountStatus.ts
@@ -1,5 +1,6 @@
 import { useSelector } from "./redux";
-import { areAccountsEmptySelector, hasAccountsSelector } from "~/renderer/reducers/accounts";
+import { hasAccountsSelector } from "~/renderer/reducers/accounts";
+import { useAreAccountsEmpty } from "./useAreAccountsEmpty";
 
 /**
  * Hook to determine the status of user accounts and funds.
@@ -7,7 +8,7 @@ import { areAccountsEmptySelector, hasAccountsSelector } from "~/renderer/reduce
  */
 export const useAccountStatus = () => {
   const hasAccount = useSelector(hasAccountsSelector);
-  const areAccountsEmpty = useSelector(areAccountsEmptySelector);
+  const areAccountsEmpty = useAreAccountsEmpty();
   const hasFunds = !areAccountsEmpty && hasAccount;
 
   return {

--- a/apps/ledger-live-desktop/src/mvvm/hooks/useAreAccountsEmpty.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/useAreAccountsEmpty.ts
@@ -1,0 +1,9 @@
+import { useAccountBridgeMany } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { accountsSelector } from "~/renderer/reducers/accounts";
+import { useSelector } from "./redux";
+
+export function useAreAccountsEmpty(): boolean {
+  const accounts = useSelector(accountsSelector);
+  const bridges = useAccountBridgeMany(accounts);
+  return accounts.length > 0 && accounts.every((a, i) => bridges[i].isAccountEmpty(a));
+}

--- a/apps/ledger-live-desktop/src/renderer/actions/__tests__/cleanAccountsCache.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/__tests__/cleanAccountsCache.test.ts
@@ -1,0 +1,60 @@
+import { Account } from "@ledgerhq/types-live";
+import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { cleanAccountsCache, replaceAccounts } from "../accounts";
+import type { State } from "~/renderer/reducers";
+
+jest.mock("@ledgerhq/live-common/bridge/index", () => ({
+  getAccountBridge: jest.fn(),
+}));
+
+const mockedGetAccountBridge = jest.mocked(getAccountBridge);
+
+type ThunkAction = ReturnType<typeof replaceAccounts>;
+
+const makeHarness = (accounts: Account[]) => {
+  const dispatched: ThunkAction[] = [];
+  const dispatch = <T extends ThunkAction>(action: T): T => {
+    dispatched.push(action);
+    return action;
+  };
+  const getState = () => ({ accounts }) as unknown as State;
+  return { dispatched, dispatch, getState };
+};
+
+describe("cleanAccountsCache", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("dispatches replaceAccounts with each account cleared via its own bridge", async () => {
+    const account1 = { id: "1", balance: 100 } as unknown as Account;
+    const account2 = { id: "2", balance: 200 } as unknown as Account;
+    const cleared1 = { id: "1", balance: 0 } as unknown as Account;
+    const cleared2 = { id: "2", balance: 0 } as unknown as Account;
+
+    const clearAccount1 = jest.fn().mockReturnValue(cleared1);
+    const clearAccount2 = jest.fn().mockReturnValue(cleared2);
+
+    mockedGetAccountBridge.mockImplementation(account => {
+      const clearAccount = account.id === "1" ? clearAccount1 : clearAccount2;
+      return { clearAccount } as unknown as ReturnType<typeof getAccountBridge>;
+    });
+
+    const { dispatched, dispatch, getState } = makeHarness([account1, account2]);
+    await cleanAccountsCache()(dispatch, getState, undefined);
+
+    expect(mockedGetAccountBridge).toHaveBeenCalledTimes(2);
+    expect(clearAccount1).toHaveBeenCalledWith(account1);
+    expect(clearAccount2).toHaveBeenCalledWith(account2);
+    expect(dispatched).toEqual([replaceAccounts([cleared1, cleared2])]);
+  });
+
+  it("dispatches replaceAccounts with an empty array when there are no accounts", async () => {
+    const { dispatched, dispatch, getState } = makeHarness([]);
+
+    await cleanAccountsCache()(dispatch, getState, undefined);
+
+    expect(mockedGetAccountBridge).not.toHaveBeenCalled();
+    expect(dispatched).toEqual([replaceAccounts([])]);
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/actions/accounts.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/accounts.ts
@@ -1,8 +1,10 @@
 import { Account, AccountUserData } from "@ledgerhq/types-live";
 import { AccountComparator } from "@ledgerhq/live-wallet/ordering";
+import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { getKey } from "~/renderer/storage";
 import { PasswordIncorrectError } from "@ledgerhq/errors";
 import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
+import { accountsSelector } from "~/renderer/reducers/accounts";
 import { ThunkResult } from "./types";
 
 export const removeAccount = (payload: Account) => ({
@@ -68,4 +70,15 @@ export const updateAccount: UpdateAccount = payload => ({
   },
 });
 
-export const cleanAccountsCache = () => ({ type: "CLEAN_ACCOUNTS_CACHE" });
+export const cleanAccountsCache =
+  (): ThunkResult<Promise<void>> =>
+  async (dispatch, getState) => {
+    const accounts = accountsSelector(getState());
+    const cleared = await Promise.all(
+      accounts.map(async account => {
+        const bridge = await getAccountBridge(account);
+        return bridge.clearAccount(account);
+      }),
+    );
+    dispatch(replaceAccounts(cleared));
+  };

--- a/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/steps/StepImport.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/steps/StepImport.tsx
@@ -3,14 +3,14 @@ import { useDispatch } from "LLD/hooks/redux";
 import styled from "styled-components";
 import { Trans } from "react-i18next";
 import { concat, from, Subscription } from "rxjs";
-import { ignoreElements, filter, map, retry } from "rxjs/operators";
+import { ignoreElements, filter, map, retry, concatMap } from "rxjs/operators";
 import { Account } from "@ledgerhq/types-live";
-import { isAccountEmpty } from "@ledgerhq/live-common/account/index";
 import { isCantonAccount } from "@ledgerhq/coin-canton/bridge/serialization";
 import { isConcordiumAccount } from "@ledgerhq/coin-concordium/bridge/serialization";
 import { openModal } from "~/renderer/actions/modals";
 import { DeviceShouldStayInApp, UnresponsiveDeviceError } from "@ledgerhq/errors";
-import { getCurrencyBridge } from "@ledgerhq/live-common/bridge/index";
+import { getAccountBridge, getCurrencyBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridgeMany } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import uniq from "lodash/uniq";
 import { urls } from "~/config/urls";
 import logger from "~/renderer/logger";
@@ -32,6 +32,7 @@ import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { getLLDCoinFamily } from "~/renderer/families";
 import { groupAddAccounts } from "@ledgerhq/live-wallet/addAccounts";
 import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
+import { classifyChecked } from "./stepImportSelection";
 
 type Props = AccountListProps & {
   defaultSelected: boolean;
@@ -148,13 +149,16 @@ class StepImport extends PureComponent<
           filter(e => e.type === "discovered"),
           map(e => e.account),
           retry(2), //needs to retry to output proper error message
+          concatMap(async account => {
+            const accountBridge = await getAccountBridge(account);
+            return { account, isNewAccount: accountBridge.isAccountEmpty(account) };
+          }),
         )
         .subscribe({
-          next: account => {
+          next: ({ account, isNewAccount }) => {
             const { scannedAccounts, checkedAccountsIds, existingAccounts } = this.props;
             const hasAlreadyBeenScanned = !!scannedAccounts.find(a => account.id === a.id);
             const hasAlreadyBeenImported = !!existingAccounts.find(a => account.id === a.id);
-            const isNewAccount = isAccountEmpty(account);
             if (!isNewAccount && !hasAlreadyBeenImported) {
               onlyNewAccounts = false;
             }
@@ -387,14 +391,11 @@ export const StepImportFooter = ({
   editedNames,
 }: StepProps) => {
   const dispatch = useDispatch();
-  const willCreateAccount = checkedAccountsIds.some(id => {
-    const account = scannedAccounts.find(a => a.id === id);
-    return account && isAccountEmpty(account);
-  });
-  const willAddAccounts = checkedAccountsIds.some(id => {
-    const account = scannedAccounts.find(a => a.id === id);
-    return account && !isAccountEmpty(account);
-  });
+  const checkedAccounts = checkedAccountsIds
+    .map(id => scannedAccounts.find(a => a.id === id))
+    .filter((a): a is Account => !!a);
+  const checkedBridges = useAccountBridgeMany(checkedAccounts);
+  const { willCreateAccount, willAddAccounts } = classifyChecked(checkedAccounts, checkedBridges);
   const count = checkedAccountsIds.length;
   const willClose = !willCreateAccount && !willAddAccounts;
 

--- a/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/steps/stepImportSelection.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/steps/stepImportSelection.test.ts
@@ -1,0 +1,40 @@
+import { Account } from "@ledgerhq/types-live";
+import { classifyChecked } from "./stepImportSelection";
+
+const makeBridge = (empty: boolean) => ({ isAccountEmpty: () => empty });
+
+describe("classifyChecked", () => {
+  it("returns both flags false when nothing is checked", () => {
+    expect(classifyChecked([], [])).toEqual({
+      willCreateAccount: false,
+      willAddAccounts: false,
+    });
+  });
+
+  it("flags both when the selection mixes empty and non-empty accounts", () => {
+    const accounts = [{ id: "1" }, { id: "2" }] as Account[];
+    const bridges = [makeBridge(true), makeBridge(false)];
+    expect(classifyChecked(accounts, bridges)).toEqual({
+      willCreateAccount: true,
+      willAddAccounts: true,
+    });
+  });
+
+  it("flags only willCreateAccount when every checked account is empty", () => {
+    const accounts = [{ id: "1" }, { id: "2" }] as Account[];
+    const bridges = [makeBridge(true), makeBridge(true)];
+    expect(classifyChecked(accounts, bridges)).toEqual({
+      willCreateAccount: true,
+      willAddAccounts: false,
+    });
+  });
+
+  it("flags only willAddAccounts when every checked account is non-empty", () => {
+    const accounts = [{ id: "1" }, { id: "2" }] as Account[];
+    const bridges = [makeBridge(false), makeBridge(false)];
+    expect(classifyChecked(accounts, bridges)).toEqual({
+      willCreateAccount: false,
+      willAddAccounts: true,
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/steps/stepImportSelection.ts
+++ b/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/steps/stepImportSelection.ts
@@ -1,0 +1,17 @@
+import { Account } from "@ledgerhq/types-live";
+
+type EmptyChecker = { isAccountEmpty: (account: Account) => boolean };
+
+export const classifyChecked = (
+  checked: Account[],
+  bridges: EmptyChecker[],
+): { willCreateAccount: boolean; willAddAccounts: boolean } => {
+  let willCreateAccount = false;
+  let willAddAccounts = false;
+  for (let i = 0; i < checked.length; i++) {
+    if (bridges[i].isAccountEmpty(checked[i])) willCreateAccount = true;
+    else willAddAccounts = true;
+    if (willCreateAccount && willAddAccounts) break;
+  }
+  return { willCreateAccount, willAddAccounts };
+};

--- a/apps/ledger-live-desktop/src/renderer/reducers/accounts.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/accounts.ts
@@ -3,10 +3,8 @@ import { handleActions } from "redux-actions";
 import { Account, AccountUserData, AccountLike } from "@ledgerhq/types-live";
 import {
   flattenAccounts,
-  clearAccount,
   getAccountCurrency,
   isUpToDateAccount,
-  isAccountEmpty,
 } from "@ledgerhq/live-common/account/index";
 
 import isEqual from "lodash/isEqual";
@@ -33,7 +31,6 @@ type HandlersPayloads = {
   ADD_ACCOUNTS: AddAccountsAction["payload"];
   UPDATE_ACCOUNT: { accountId: string; updater: (a: Account) => Account };
   REMOVE_ACCOUNT: Account;
-  CLEAN_ACCOUNTS_CACHE: never;
   REPLACE_ACCOUNTS: Account[];
 };
 
@@ -51,7 +48,6 @@ const handlers: AccountsHandlers = {
       return updater(existingAccount);
     }),
   REMOVE_ACCOUNT: (state, { payload: account }) => state.filter(acc => acc.id !== account.id),
-  CLEAN_ACCOUNTS_CACHE: state => state.map(clearAccount),
   REPLACE_ACCOUNTS: (state, { payload }) => payload,
 };
 
@@ -127,8 +123,3 @@ export const starredAccountsSelector = createSelector(
 export const isUpToDateAccountSelector = createSelector(accountSelector, isUpToDateAccount);
 
 export const flattenAccountsSelector = createSelector(accountsSelector, flattenAccounts);
-
-export const areAccountsEmptySelector = createSelector(
-  accountsSelector,
-  accounts => accounts.length > 0 && accounts.every(isAccountEmpty),
-);

--- a/apps/ledger-live-desktop/src/renderer/screens/account/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/index.tsx
@@ -8,11 +8,8 @@ import { SyncOneAccountOnMount } from "@ledgerhq/live-common/bridge/react/index"
 import { isAddressPoisoningOperation } from "@ledgerhq/live-common/operation";
 import { getCurrencyColor } from "~/renderer/getCurrencyColor";
 import { accountsSelector } from "~/renderer/reducers/accounts";
-import {
-  findSubAccountById,
-  getMainAccount,
-  isAccountEmpty,
-} from "@ledgerhq/live-common/account/index";
+import { findSubAccountById, getMainAccount } from "@ledgerhq/live-common/account/index";
+import { useAccountBridgeOrNull } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { findAccountById, findSubAccountByIdWithFallback } from "~/renderer/utils";
 import {
   setCountervalueFirst,
@@ -90,6 +87,7 @@ const AccountPage = ({
   const { shouldDisplayAssetSection } = useWalletFeaturesConfig("desktop");
   const fallbackPath = getAccountsSidebarPath(shouldDisplayAssetSection);
   const mainAccount = account ? getMainAccount(account, parentAccount) : null;
+  const bridge = useAccountBridgeOrNull(account ?? null, parentAccount);
   const specific = mainAccount ? getLLDCoinFamily(mainAccount.currency.family) : null;
   const AccountBodyHeader = specific?.AccountBodyHeader;
   const AccountSubHeader = specific?.AccountSubHeader;
@@ -160,7 +158,9 @@ const AccountPage = ({
       {AccountSubHeader ? (
         <AccountSubHeader account={account} parentAccount={parentAccount} />
       ) : null}
-      {!isAccountEmpty(account) ? (
+      {bridge?.isAccountEmpty(account) ? (
+        <EmptyStateAccount account={account} parentAccount={parentAccount} />
+      ) : (
         <>
           <Box mb={7}>
             <BalanceSummary
@@ -192,8 +192,6 @@ const AccountPage = ({
             filterOperation={filterOperations}
           />
         </>
-      ) : (
-        <EmptyStateAccount account={account} parentAccount={parentAccount} />
       )}
     </Box>
   );

--- a/libs/ledger-live-common/src/bridge/useAccountBridge.ts
+++ b/libs/ledger-live-common/src/bridge/useAccountBridge.ts
@@ -48,5 +48,10 @@ export function useAccountBridgeOrNull<T extends TransactionCommon>(
 // loops and conditional statements like if." — https://react.dev/reference/react/use
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function useAccountBridgeMany(accounts: Account[]): ResolvedAccountBridge<any>[] {
-  return accounts.map(a => getAccountBridge(a));
+  // Memoize on the (id-derived) shape rather than `accounts` reference: callers that
+  // rebuild the array each render (e.g. inline `.map().filter()`) still get a stable
+  // bridge list as long as the account ids haven't changed.
+  const idsKey = accounts.map(a => a.id).join("|");
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  return useMemo(() => accounts.map(a => getAccountBridge(a)), [idsKey]);
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [ ] **Impact of the changes:**
  - Add-account flows + cache-clean reducer + account screen entry. Replaces `isAccountEmpty` / `clearAccount` top-level helpers with bridge-resolved equivalents (`useAccountBridge`, `useAccountBridgeMany`, `useAreAccountsEmpty`, `getAccountBridge` inside thunks). `cleanAccountsCache` is now a thunk that resolves the bridge per account before dispatching `REPLACE_ACCOUNTS`. QA focus: Settings → Clear cache (still empties balances/operations correctly), legacy "Add account" modal import step (empty-account filtering), new AddAccountDrawer scan step (empty-account selection), account list empty-state indicator, account page entry on an empty account.

### 📝 Description

Final slice of the desktop `AccountBridgeExtensions` migration (split from #17400 / #17338). Builds on the already-landed Solana banner slice (#17477) and stacks alongside the operations slice (#17484) and the per-family Stake button slice (#17486) — once this merges, every deprecated top-level helper has zero desktop call sites, unblocking the breaking removal in #17338.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30457](https://ledgerhq.atlassian.net/browse/LIVE-30457) — split out of #17400 / #17338
- **ADR link (if any)**: —

[LIVE-30457]: https://ledgerhq.atlassian.net/browse/LIVE-30457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ