### PR TITLE
[LWM] fix(mobile): display token balance in asset detail addresses

### DIFF
--- a/.changeset/fix-address-token-balance.md
+++ b/.changeset/fix-address-token-balance.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix asset detail addresses showing parent account balance instead of token balance

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/__tests__/useAddressesViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/__tests__/useAddressesViewModel.test.ts
@@ -56,6 +56,7 @@ describe("useAddressesViewModel", () => {
         expect(acc.name).toBeDefined();
         expect(acc.truncatedAddress).toBeDefined();
         expect(acc.account).toBeDefined();
+        expect(acc.balanceAccount).toBe(acc.account);
       });
     });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/components/AddressAccountItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/components/AddressAccountItem.tsx
@@ -18,8 +18,8 @@ type Props = Readonly<{
 }>;
 
 export const AddressAccountItem = memo(function AddressAccountItem({ data }: Props) {
-  const { account, name, truncatedAddress } = data;
-  const { formattedBalance, formattedCounterValue } = useFormattedAccountBalance(account);
+  const { account, balanceAccount, name, truncatedAddress } = data;
+  const { formattedBalance, formattedCounterValue } = useFormattedAccountBalance(balanceAccount);
 
   return (
     <Card type="info" testID={`asset-detail-address-item-${account.id}`}>

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/useAddressesViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/useAddressesViewModel.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from "react";
 import { useNavigation } from "@react-navigation/native";
 import { shallowEqual } from "react-redux";
 import type { AssetDetailCurrencyProps } from "LLM/features/AssetDetail/types";
-import type { Account } from "@ledgerhq/types-live";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
 import { accountNameWithDefaultSelector } from "@ledgerhq/live-wallet/store";
 import { formatAddress } from "@ledgerhq/live-common/utils/addressUtils";
 import { useSelector } from "~/context/hooks";
@@ -15,6 +15,7 @@ import { AddAccountContexts } from "LLM/features/Accounts/screens/AddAccount/enu
 export type AddressAccountData = Readonly<{
   id: string;
   account: Account;
+  balanceAccount: AccountLike;
   name: string;
   truncatedAddress: string;
 }>;
@@ -37,6 +38,7 @@ export function useAddressesViewModel(currency: AssetDetailCurrencyProps) {
       return {
         id: acc.id,
         account: mainAccount,
+        balanceAccount: acc,
         name: tuple.name || accountNameWithDefaultSelector(walletState, mainAccount),
         truncatedAddress: formatAddress(mainAccount.freshAddress, {
           prefixLength: 4,

--- a/apps/ledger-live-mobile/src/mvvm/hooks/useFormattedAccountBalance.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/useFormattedAccountBalance.ts
@@ -1,7 +1,7 @@
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { useCalculate } from "@ledgerhq/live-countervalues-react";
-import type { Account } from "@ledgerhq/types-live";
+import type { AccountLike } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import { useMaybeAccountUnit } from "LLM/hooks/useAccountUnit";
 import { useMemo } from "react";
@@ -13,7 +13,9 @@ type FormattedAccountBalance = {
   formattedCounterValue: string | undefined;
 };
 
-export function useFormattedAccountBalance(account: Account | undefined): FormattedAccountBalance {
+export function useFormattedAccountBalance(
+  account: AccountLike | undefined,
+): FormattedAccountBalance {
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
   const discreet = useSelector(discreetModeSelector);
   const unit = useMaybeAccountUnit(account);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Asset detail Addresses section balance display for token currencies (e.g. USDC, USDT)
      - No impact on native currency asset detail pages (BTC, ETH, etc.)

### 📝 Description

**Problem**: When viewing a token asset detail page (e.g. USDC on Ethereum), the Addresses section incorrectly displayed the parent account balance (ETH) instead of the token balance (USDC). This is because `AddressAccountItem` was passing the main Ethereum `Account` to `useFormattedAccountBalance`, ignoring the token sub-account.

**Solution**:
- Widened `useFormattedAccountBalance` parameter type from `Account` to `AccountLike` so it accepts both `Account` and `TokenAccount`
- Added a `balanceAccount` field to `AddressAccountData` that holds the sub-account for tokens or the main account for native currencies
- `AddressAccountItem` now uses `balanceAccount` for balance formatting while keeping `account` for address display and currency icon

https://github.com/user-attachments/assets/aae82ed8-84af-429e-b198-9cf4a50d76c5



### ❓ Context

- **JIRA or GitHub link**: [LIVE-30632](https://ledgerhq.atlassian.net/browse/LIVE-30632)
- **Stacked on**: `bugfix/fix-asset-detail-discreet-mode`

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30632]: https://ledgerhq.atlassian.net/browse/LIVE-30632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ