### PR TITLE
[LWM] refactor(mobile): migrate cache-clean reducer to AccountBridgeExtensions thunk

### DIFF
--- a/.changeset/mobile-bridge-cache-clean.md
+++ b/.changeset/mobile-bridge-cache-clean.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Replace the CLEAN_CACHE reducer handler with a thunk in useCleanCache that resolves the AccountBridge per account and dispatches replaceAccounts.

--- a/apps/ledger-live-mobile/src/actions/accounts.ts
+++ b/apps/ledger-live-mobile/src/actions/accounts.ts
@@ -64,4 +64,3 @@ export const replaceAccounts = createAction<AccountsReplacePayload>(
   AccountsActionTypes.SET_ACCOUNTS,
 );
 
-export const cleanCache = createAction(AccountsActionTypes.CLEAN_CACHE);

--- a/apps/ledger-live-mobile/src/actions/general.ts
+++ b/apps/ledger-live-mobile/src/actions/general.ts
@@ -19,7 +19,8 @@ import {
 } from "@ledgerhq/live-common/portfolio/useAssetDistribution";
 import VersionNumber from "react-native-version-number";
 import { BehaviorSubject } from "rxjs";
-import { cleanCache, reorderAccounts } from "./accounts";
+import { replaceAccounts, reorderAccounts } from "./accounts";
+import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { accountsSelector } from "../reducers/accounts";
 import { counterValueCurrencySelector, orderAccountsSelector } from "../reducers/settings";
 import { clearBridgeCache } from "../bridge/cache";
@@ -112,14 +113,21 @@ export function useRefreshAccountsOrderingEffect({
 }
 export function useCleanCache() {
   const dispatch = useDispatch();
+  const accounts = useSelector(accountsSelector);
   const { wipe } = useCountervaluesPolling();
   return useCallback(async () => {
-    dispatch(cleanCache());
+    const cleared = await Promise.all(
+      accounts.map(async account => {
+        const bridge = await getAccountBridge(account);
+        return bridge.clearAccount(account);
+      }),
+    );
+    dispatch(replaceAccounts(cleared));
 
     await clearBridgeCache();
     wipe();
     flushAll();
-  }, [dispatch, wipe]);
+  }, [dispatch, accounts, wipe]);
 }
 
 export function useUserSettings() {

--- a/apps/ledger-live-mobile/src/reducers/accounts.ts
+++ b/apps/ledger-live-mobile/src/reducers/accounts.ts
@@ -21,7 +21,6 @@ import {
   flattenAccounts,
   getAccountCurrency,
   isUpToDateAccount,
-  clearAccount,
   makeEmptyTokenAccount,
   isAccountBalanceUnconfirmed,
 } from "@ledgerhq/live-common/account/index";
@@ -107,10 +106,6 @@ const handlers: ReducerMap<AccountsState, Payload> = {
 
   [AccountsActionTypes.SET_ACCOUNTS]: (state, action) => ({
     active: (action as Action<AccountsReplacePayload>).payload,
-  }),
-
-  [AccountsActionTypes.CLEAN_CACHE]: (state: AccountsState) => ({
-    active: state.active.map(clearAccount),
   }),
 
   [AccountsActionTypes.DANGEROUSLY_OVERRIDE_STATE]: (


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [ ] **Impact of the changes:**
  - Cache-clean reducer flow only. `useCleanCache` becomes a thunk: it resolves the AccountBridge per account via `getAccountBridge`, calls `bridge.clearAccount(account)` for each, and dispatches `replaceAccounts(cleared)`. The legacy `CLEAN_CACHE` reducer handler and the `cleanCache` action creator are removed. `areAccountsEmptySelector` is left intact (migrated separately). QA focus: Settings → Clear cache (balances & operations must clear correctly, no stale UI state).

### 📝 Description

First slice of the mobile `AccountBridgeExtensions` migration (split from #17401 / #17338). Smallest and most isolated: a single cache-clean refactor across 3 files (`actions/accounts.ts`, `actions/general.ts`, `reducers/accounts.ts`). Independent of every other slice — the `areAccountsEmptySelector` → `useAreAccountsEmpty` hook swap lands in a follow-up.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30457](https://ledgerhq.atlassian.net/browse/LIVE-30457) — split out of #17401 / #17338
- **ADR link (if any)**: —

[LIVE-30457]: https://ledgerhq.atlassian.net/browse/LIVE-30457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ