### PR TITLE
[LWM] refactor(mobile): migrate operations layer to AccountBridgeExtensions

### DIFF
--- a/.changeset/mobile-bridge-operations.md
+++ b/.changeset/mobile-bridge-operations.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Migrate the mobile operations layer (OperationRow, OperationDetails, SendFunds recipient stuck-tx detection, account screen header) from deprecated isEditableOperation / isStuckOperation / getStuckAccountAndOperation top-level helpers to AccountBridgeExtensions via useAccountBridge / useAccountBridgeOrNull.

--- a/apps/ledger-live-mobile/src/components/OperationRow/index.tsx
+++ b/apps/ledger-live-mobile/src/components/OperationRow/index.tsx
@@ -6,10 +6,9 @@ import { useNavigation } from "@react-navigation/native";
 import {
   getOperationAmountNumber,
   isConfirmedOperation,
-  isEditableOperation,
-  isStuckOperation,
 } from "@ledgerhq/live-common/operation";
 import { getMainAccount, getAccountCurrency } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Account, Operation, AccountLike } from "@ledgerhq/types-live";
 import { Box, Flex, InfiniteLoader, Text } from "@ledgerhq/native-ui";
 import { WarningMedium } from "@ledgerhq/native-ui/assets/icons";
@@ -143,6 +142,7 @@ function OperationRow({
   const amount = getOperationAmountNumber(operation);
   const currency = getAccountCurrency(account);
   const mainAccount = getMainAccount(account, parentAccount);
+  const bridge = useAccountBridge(mainAccount);
   const accountName = useAccountName(account);
   const currencySettings = useCurrencySettingsForAccount(mainAccount);
   const isConfirmed = isConfirmedOperation(
@@ -159,8 +159,7 @@ function OperationRow({
   const text = <Trans i18nKey={`operations.types.${operation.type}`} />;
   const isOptimistic = operation.blockHeight === null;
   const isOperationStuck =
-    isEditableOperation({ account: mainAccount, operation }) &&
-    isStuckOperation({ family: mainAccount.currency.family, operation });
+    bridge.isEditableOperation(mainAccount, operation) && bridge.isStuckOperation(operation);
 
   const spinner = isOperationStuck ? (
     <WarningMedium />

--- a/apps/ledger-live-mobile/src/screens/Account/ListHeaderComponent.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/ListHeaderComponent.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode, useMemo } from "react";
 import { LayoutChangeEvent } from "react-native";
-import { isAccountEmpty, getMainAccount } from "@ledgerhq/live-common/account/index";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { useAccountBridgeOrNull } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import {
   AccountLike,
   Account,
@@ -18,7 +19,6 @@ import { PolkadotAccount } from "@ledgerhq/live-common/families/polkadot/types";
 import { MultiversXAccount } from "@ledgerhq/live-common/families/multiversx/types";
 import { NearAccount } from "@ledgerhq/live-common/families/near/types";
 import { HederaAccount } from "@ledgerhq/live-common/families/hedera/types";
-import { isEditableOperation, isStuckOperation } from "@ledgerhq/live-common/operation";
 import AccountGraphCard from "~/components/AccountGraphCard";
 import SubAccountsList from "./SubAccountsList";
 import perFamilyAccountHeader from "../../generated/AccountHeader";
@@ -98,11 +98,12 @@ export function useListHeaderComponents({
     () => (account ? getMainAccount(account, parentAccount) : undefined),
     [account, parentAccount],
   );
+  const bridge = useAccountBridgeOrNull(account ?? null, parentAccount);
   const oldestEditableOperation = useMemo(() => {
-    if (!account || !mainAccount) return undefined;
+    if (!account || !mainAccount || !bridge) return undefined;
 
     const editablePendingOperations = account.pendingOperations.filter(pendingOperation =>
-      isEditableOperation({ account: mainAccount, operation: pendingOperation }),
+      bridge.isEditableOperation(mainAccount, pendingOperation),
     );
 
     return mainAccount.currency.family === "bitcoin"
@@ -121,13 +122,14 @@ export function useListHeaderComponents({
           }
           return 0;
         })[0];
-  }, [account, mainAccount]);
+  }, [account, mainAccount, bridge]);
 
-  if (!account || !mainAccount) return { listHeaderComponents: [], stickyHeaderIndices: undefined };
+  if (!account || !mainAccount || !bridge)
+    return { listHeaderComponents: [], stickyHeaderIndices: undefined };
 
   const family: string = mainAccount.currency.family;
 
-  const empty = isAccountEmpty(account);
+  const empty = bridge.isAccountEmpty(account);
   const shouldUseCounterValue = countervalueAvailable && useCounterValue;
 
   const AccountHeader = (perFamilyAccountHeader as Record<string, MaybeComponent>)[family];
@@ -163,8 +165,7 @@ export function useListHeaderComponents({
   const stickyHeaderIndices = empty ? [] : [0];
 
   const isOperationStuck = Boolean(
-    oldestEditableOperation &&
-    isStuckOperation({ family: mainAccount.currency.family, operation: oldestEditableOperation }),
+    oldestEditableOperation && bridge.isStuckOperation(oldestEditableOperation),
   );
 
   const disableDelegation =

--- a/apps/ledger-live-mobile/src/screens/Account/__tests__/ListHeaderComponent.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/__tests__/ListHeaderComponent.test.tsx
@@ -9,15 +9,23 @@ import type { Account, TokenAccount, Operation } from "@ledgerhq/types-live";
 import { ActionButtonEvent } from "~/components/FabActions";
 import * as featureFlagsIndex from "@ledgerhq/live-common/featureFlags/index";
 import * as accountIndex from "@ledgerhq/live-common/account/index";
+import { useAccountBridgeOrNull } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { TFunction } from "i18next";
 import { render } from "@testing-library/react-native";
 import React from "react";
 
-/**
- * isAccountEmpty can not be spied because it is declared in multiple files
- * and overriden in ledger-live-common/src/account/helpers.ts
- */
-const mockIsAccountEmpty = jest.requireMock("@ledgerhq/live-common/account/index").isAccountEmpty;
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  useAccountBridgeOrNull: jest.fn(),
+}));
+
+const mockIsAccountEmpty = jest.fn();
+const mockIsEditableOperation = jest.fn();
+const mockIsStuckOperation = jest.fn();
+(useAccountBridgeOrNull as jest.Mock).mockReturnValue({
+  isAccountEmpty: mockIsAccountEmpty,
+  isEditableOperation: mockIsEditableOperation,
+  isStuckOperation: mockIsStuckOperation,
+});
 
 describe("Testing ListHeaderComponent Component", () => {
   describe("Testing disable delegation flag", () => {

--- a/apps/ledger-live-mobile/src/screens/OperationDetails/Content.tsx
+++ b/apps/ledger-live-mobile/src/screens/OperationDetails/Content.tsx
@@ -9,9 +9,8 @@ import {
   getOperationAmountNumber,
   isConfirmedOperation,
   getOperationConfirmationDisplayableNumber,
-  isEditableOperation,
-  isStuckOperation,
 } from "@ledgerhq/live-common/operation";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { NavigatorName, ScreenName } from "~/const";
 import LText from "~/components/LText";
@@ -100,6 +99,7 @@ export default function Content({
   }, []);
 
   const currencySettings = useCurrencySettingsForAccount(mainAccount);
+  const bridge = useAccountBridge(mainAccount);
 
   const isToken = currency.type === "TokenCurrency";
   const accountName = useAccountName(account);
@@ -122,8 +122,8 @@ export default function Content({
     currencySettings.confirmationsNb,
   );
 
-  const isEditable = isEditableOperation({ account: mainAccount, operation });
-  const isOperationStuck = isStuckOperation({ family: mainAccount.currency.family, operation });
+  const isEditable = bridge.isEditableOperation(mainAccount, operation);
+  const isOperationStuck = bridge.isStuckOperation(operation);
 
   const specificOperationDetails =
     byFamiliesOperationDetails[

--- a/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.test.tsx
@@ -17,7 +17,10 @@ jest.mock("@react-navigation/native", () => ({
   useScrollToTop: jest.fn(),
 }));
 jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
-  useAccountBridge: jest.fn().mockReturnValue({ updateTransaction: jest.fn() }),
+  useAccountBridge: jest.fn().mockReturnValue({
+    updateTransaction: jest.fn(),
+    getStuckAccountAndOperation: jest.fn(() => undefined),
+  }),
 }));
 
 describe("SendSelectRecipient", () => {

--- a/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
@@ -11,7 +11,6 @@ import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransact
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
-import { getStuckAccountAndOperation } from "@ledgerhq/live-common/operation";
 import { Operation } from "@ledgerhq/types-live";
 import QrCode from "@ledgerhq/icons-ui/native/QrCode";
 import { useNavigation, useTheme } from "@react-navigation/native";
@@ -254,7 +253,7 @@ export default function SendSelectRecipient({ route }: Props) {
     !!status.errors.transaction ||
     !!status.errors.sender;
 
-  const stuckAccountAndOperation = getStuckAccountAndOperation(account, mainAccount);
+  const stuckAccountAndOperation = bridge.getStuckAccountAndOperation(account, mainAccount);
   const extensions = getTokenExtensions(account);
 
   return (


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [ ] **Impact of the changes:**
  - Mobile operations layer. Replaces deprecated `isEditableOperation`, `isStuckOperation`, and `getStuckAccountAndOperation` top-level helpers with bridge equivalents (`useAccountBridge` / `useAccountBridgeOrNull`) across `OperationRow`, `OperationDetails`, send-funds recipient stuck-tx detection, and the account screen header `ListHeaderComponent` (the latter also moves its co-located `isAccountEmpty` check to `bridge.isAccountEmpty`, since it sits inside the same component body). QA focus: operation row stuck/editable visual states, operation details edit/cancel actions on stuck pending tx, send recipient → stuck-tx warning, account screen header (stuck-tx banner + empty-state behavior).

### 📝 Description

Second slice of the mobile `AccountBridgeExtensions` migration (split from #17401 / #17338). Independent of the cache-clean slice (#17491). Mirrors desktop's operations slice (#17484).

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30457](https://ledgerhq.atlassian.net/browse/LIVE-30457) — split out of #17401 / #17338
- **ADR link (if any)**: —

[LIVE-30457]: https://ledgerhq.atlassian.net/browse/LIVE-30457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ