### PR TITLE
[LWM] refactor(mobile): migrate per-family accountActions to AccountBridgeExtensions

### DIFF
--- a/.changeset/mobile-bridge-account-actions.md
+++ b/.changeset/mobile-bridge-account-actions.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Per-family mobile accountActions (bitcoin, celo, evm, tron) now receive the resolved AccountBridge as a parameter and use bridge.isAccountEmpty instead of the deprecated top-level helper; useAccountActions resolves the bridge via useAccountBridge and passes it through.

--- a/apps/ledger-live-mobile/src/components/Stake/useStakingDrawer.test.tsx
+++ b/apps/ledger-live-mobile/src/components/Stake/useStakingDrawer.test.tsx
@@ -1,0 +1,93 @@
+import { renderHook } from "@testing-library/react-native";
+import BigNumber from "bignumber.js";
+import type { NavigationProp, ParamListBase, RouteProp } from "@react-navigation/native";
+import { NavigatorName } from "~/const";
+import { useStakingDrawer } from "./useStakingDrawer";
+
+const mockGetMainActions = jest.fn();
+const mockBridge = { isAccountEmpty: jest.fn().mockReturnValue(false) };
+
+jest.mock("~/context/hooks", () => ({
+  useSelector: jest.fn(() => ({})),
+}));
+
+jest.mock("LLM/hooks/useStake/useStake", () => ({
+  useStake: () => ({
+    getRouteParamsForPlatformApp: jest.fn().mockReturnValue(null),
+  }),
+}));
+
+jest.mock("../../generated/accountActions", () => ({
+  __esModule: true,
+  default: {
+    bitcoin: { getMainActions: (...args: unknown[]) => mockGetMainActions(...args) },
+  },
+}));
+
+jest.mock("@ledgerhq/live-common/bridge/index", () => ({
+  getAccountBridge: jest.fn(() => mockBridge),
+}));
+
+jest.mock("@ledgerhq/ledger-wallet-framework/account/helpers", () => ({
+  ...jest.requireActual("@ledgerhq/ledger-wallet-framework/account/helpers"),
+  getAccountSpendableBalance: jest.fn().mockReturnValue(new BigNumber(1_000_000)),
+}));
+
+const bitcoinAccount = {
+  type: "Account" as const,
+  id: "btc-1",
+  currency: { family: "bitcoin", id: "bitcoin" },
+};
+
+const navigation = { navigate: jest.fn() } as unknown as NavigationProp<ParamListBase>;
+const parentRoute = {
+  key: "parent",
+  name: "Parent",
+} as unknown as RouteProp<ParamListBase>;
+
+describe("useStakingDrawer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("passes resolved bridge to family getMainActions", () => {
+    mockGetMainActions.mockReturnValue([
+      { id: "stake", navigationParams: ["Stake", { screen: "StakeScreen", params: {} }] },
+    ]);
+
+    const { result } = renderHook(() =>
+      useStakingDrawer({ navigation, parentRoute, alwaysShowNoFunds: false }),
+    );
+
+    result.current(bitcoinAccount as never);
+
+    expect(mockGetMainActions).toHaveBeenCalledTimes(1);
+    expect(mockGetMainActions).toHaveBeenCalledWith(
+      expect.objectContaining({ bridge: mockBridge, account: bitcoinAccount }),
+    );
+  });
+
+  it("navigates to the family stake flow returned by getMainActions", () => {
+    mockGetMainActions.mockReturnValue([
+      {
+        id: "stake",
+        navigationParams: ["StakeNavigator", { screen: "StakeStep", params: { foo: 1 } }],
+      },
+    ]);
+
+    const { result } = renderHook(() =>
+      useStakingDrawer({ navigation, parentRoute, alwaysShowNoFunds: false }),
+    );
+
+    result.current(bitcoinAccount as never);
+
+    expect(navigation.navigate).toHaveBeenCalledWith(NavigatorName.Base, {
+      screen: "StakeNavigator",
+      drawer: undefined,
+      params: {
+        screen: "StakeStep",
+        params: { foo: 1, account: bitcoinAccount, parentAccount: undefined },
+      },
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/components/Stake/useStakingDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/Stake/useStakingDrawer.tsx
@@ -7,6 +7,7 @@ import { useSelector } from "~/context/hooks";
 import { walletSelector } from "~/reducers/wallet";
 import { useStake } from "LLM/hooks/useStake/useStake";
 import { getAccountSpendableBalance } from "@ledgerhq/ledger-wallet-framework/account/helpers";
+import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 
 /** Open the family main actions stake flow for a given account from any navigator. Returns to parent route on completion. */
 export function useStakingDrawer({
@@ -61,6 +62,8 @@ export function useStakingDrawer({
 
       // get the stake flow for the specific currency
 
+      const bridge = getAccountBridge(account, parentAccount);
+
       const familySpecificMainActions =
         (decorators &&
           decorators.getMainActions &&
@@ -70,6 +73,7 @@ export function useStakingDrawer({
             parentAccount,
             colors: {},
             parentRoute,
+            bridge,
           })) ||
         [];
       const familyStakeFlow = familySpecificMainActions.find(

--- a/apps/ledger-live-mobile/src/families/bitcoin/accountActions.tsx
+++ b/apps/ledger-live-mobile/src/families/bitcoin/accountActions.tsx
@@ -2,23 +2,25 @@ import React from "react";
 import { Trans } from "~/context/Locale";
 import { NavigatorName, ScreenName } from "~/const";
 import { ActionButtonEvent, NavigationParamsType } from "~/components/FabActions";
-import { getMainAccount, isAccountEmpty } from "@ledgerhq/live-common/account/index";
-import { TokenAccount } from "@ledgerhq/types-live";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import type { ResolvedAccountBridge, TokenAccount, TransactionCommon } from "@ledgerhq/types-live";
 import { BitcoinAccount } from "@ledgerhq/live-common/families/bitcoin/types";
 import { IconsLegacy } from "@ledgerhq/native-ui";
 import { getStakeLabelLocaleBased } from "~/helpers/getStakeLabelLocaleBased";
 
-const getMainActions = ({
+const getMainActions = <T extends TransactionCommon>({
   account,
   parentAccount,
+  bridge,
 }: {
   account: BitcoinAccount | TokenAccount;
   parentAccount: BitcoinAccount | null | undefined;
+  bridge: ResolvedAccountBridge<T>;
 }): ActionButtonEvent[] => {
   const mainAccount = getMainAccount(account, parentAccount);
   const label = getStakeLabelLocaleBased();
 
-  const navigationParams: NavigationParamsType = isAccountEmpty(mainAccount)
+  const navigationParams: NavigationParamsType = bridge.isAccountEmpty(mainAccount)
     ? [
         NavigatorName.NoFundsFlow,
         {

--- a/apps/ledger-live-mobile/src/families/celo/accountActions.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/accountActions.tsx
@@ -1,23 +1,24 @@
 import React from "react";
 import { Trans } from "~/context/Locale";
 import { CeloAccount } from "@ledgerhq/live-common/families/celo/types";
-import type { Account } from "@ledgerhq/types-live";
-import { isAccountEmpty } from "@ledgerhq/live-common/account/index";
+import type { Account, ResolvedAccountBridge, TransactionCommon } from "@ledgerhq/types-live";
 import CeloIcon from "./components/CeloIcon";
 import { ActionButtonEvent, NavigationParamsType } from "~/components/FabActions";
 import { NavigatorName, ScreenName } from "~/const";
 import { getStakeLabelLocaleBased } from "~/helpers/getStakeLabelLocaleBased";
 
-const getMainActions = ({
+const getMainActions = <T extends TransactionCommon>({
   account,
   parentAccount,
+  bridge,
 }: {
   account: CeloAccount;
   parentAccount: Account;
+  bridge: ResolvedAccountBridge<T>;
 }): ActionButtonEvent[] => {
   const label = getStakeLabelLocaleBased();
 
-  const navigationParams: NavigationParamsType = isAccountEmpty(account)
+  const navigationParams: NavigationParamsType = bridge.isAccountEmpty(account)
     ? [
         NavigatorName.NoFundsFlow,
         {

--- a/apps/ledger-live-mobile/src/families/evm/accountActions.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/accountActions.tsx
@@ -1,8 +1,13 @@
 import React from "react";
-import type { Account, AccountLike } from "@ledgerhq/types-live";
+import type {
+  Account,
+  AccountLike,
+  ResolvedAccountBridge,
+  TransactionCommon,
+} from "@ledgerhq/types-live";
 import { IconsLegacy } from "@ledgerhq/native-ui";
 import { Trans } from "~/context/Locale";
-import { isAccountEmpty, isTokenAccount } from "@ledgerhq/live-common/account/index";
+import { isTokenAccount } from "@ledgerhq/live-common/account/index";
 import { ParamListBase, RouteProp } from "@react-navigation/native";
 import { ActionButtonEvent, NavigationParamsType } from "~/components/FabActions";
 import { NavigatorName, ScreenName } from "~/const";
@@ -27,12 +32,13 @@ type EvmNativeStakingFeature = {
   };
 };
 
-type Props = {
+type Props<T extends TransactionCommon> = {
   account: AccountLike;
   parentAccount: Account;
   parentRoute: RouteProp<ParamListBase, ScreenName>;
   walletState: WalletState;
   evmNativeStakingFeature?: EvmNativeStakingFeature | null;
+  bridge: ResolvedAccountBridge<T>;
 };
 
 type AccountTypeGetterProps = {
@@ -56,17 +62,18 @@ const getAccountType = (account: AccountLike): AccountTypeGetterProps => {
   return { isEthAccount, isPOLAccount, isBscAccount, isAvaxAccount, isStakekit };
 };
 
-function getNavigatorParams({
+function getNavigatorParams<T extends TransactionCommon>({
   parentRoute,
   account,
   parentAccount,
   walletState,
   evmNativeStakingFeature,
-}: Props): NavigationParamsType {
+  bridge,
+}: Props<T>): NavigationParamsType {
   const { isPOLAccount, isBscAccount, isAvaxAccount, isStakekit } = getAccountType(account);
   const isSeiEvmNativeStaking = getIsSeiEvmNativeStakingEnabled(account, evmNativeStakingFeature);
 
-  if (isAccountEmpty(account)) {
+  if (bridge.isAccountEmpty(account)) {
     return [
       NavigatorName.NoFundsFlow,
       {
@@ -153,13 +160,14 @@ function getNavigatorParams({
   }
 }
 
-const getMainActions = ({
+const getMainActions = <T extends TransactionCommon>({
   account,
   parentAccount,
   parentRoute,
   walletState,
   evmNativeStakingFeature,
-}: Props): ActionButtonEvent[] => {
+  bridge,
+}: Props<T>): ActionButtonEvent[] => {
   const { isPOLAccount, isBscAccount, isAvaxAccount, isStakekit, isEthAccount } =
     getAccountType(account);
   const isSeiEvmNativeStaking = getIsSeiEvmNativeStakingEnabled(account, evmNativeStakingFeature);
@@ -181,6 +189,7 @@ const getMainActions = ({
       parentRoute,
       walletState,
       evmNativeStakingFeature,
+      bridge,
     });
 
     const getCurrentCurrency = () => {

--- a/apps/ledger-live-mobile/src/families/tron/accountActions.tsx
+++ b/apps/ledger-live-mobile/src/families/tron/accountActions.tsx
@@ -3,20 +3,22 @@ import { Trans } from "~/context/Locale";
 import type { TronAccount } from "@ledgerhq/live-common/families/tron/types";
 import { NavigatorName, ScreenName } from "~/const";
 import { ActionButtonEvent, NavigationParamsType } from "~/components/FabActions";
-import { getMainAccount, isAccountEmpty } from "@ledgerhq/live-common/account/index";
-import { TokenAccount } from "@ledgerhq/types-live";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import type { ResolvedAccountBridge, TokenAccount, TransactionCommon } from "@ledgerhq/types-live";
 import { IconsLegacy } from "@ledgerhq/native-ui";
 import { getStakeLabelLocaleBased } from "~/helpers/getStakeLabelLocaleBased";
-const getMainActions = ({
+const getMainActions = <T extends TransactionCommon>({
   account,
   parentAccount,
+  bridge,
 }: {
   account: TronAccount | TokenAccount;
   parentAccount: TronAccount | null | undefined;
+  bridge: ResolvedAccountBridge<T>;
 }): ActionButtonEvent[] => {
   const mainAccount = getMainAccount(account, parentAccount);
   const label = getStakeLabelLocaleBased();
-  const navigationParams: NavigationParamsType = isAccountEmpty(mainAccount)
+  const navigationParams: NavigationParamsType = bridge.isAccountEmpty(mainAccount)
     ? [
         NavigatorName.NoFundsFlow,
         {

--- a/apps/ledger-live-mobile/src/screens/Account/hooks/useAccountActions.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/hooks/useAccountActions.tsx
@@ -5,6 +5,7 @@ import {
   getMainAccount,
   getAccountSpendableBalance,
 } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useSelector } from "~/context/hooks";
 import { useTranslation } from "~/context/Locale";
 import { useRoute } from "@react-navigation/native";
@@ -76,6 +77,7 @@ export default function useAccountActions({ account, parentAccount, colors }: Pr
   const balance = getAccountSpendableBalance(account);
   const isZeroBalance = !balance.gt(0);
   const mainAccount = getMainAccount(account, parentAccount);
+  const bridge = useAccountBridge(mainAccount);
   // @ts-expect-error issue in typing
   const decorators = perFamilyAccountActions[mainAccount?.currency?.family];
 
@@ -269,8 +271,9 @@ export default function useAccountActions({ account, parentAccount, colors }: Pr
         colors,
         parentRoute: route,
         evmNativeStakingFeature,
+        bridge,
       }) ?? [],
-    [walletState, account, parentAccount, colors, route, decorators, evmNativeStakingFeature],
+    [walletState, account, parentAccount, colors, route, decorators, evmNativeStakingFeature, bridge],
   );
 
   const mainActions = useMemo(


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [ ] **Impact of the changes:**
  - Account header action buttons for bitcoin, celo, evm, tron. Per-family `getMainActions` now takes the resolved `AccountBridge` as a parameter and uses `bridge.isAccountEmpty` instead of the deprecated top-level helper. `useAccountActions` resolves the bridge via `useAccountBridge(mainAccount)` and passes it through to the family decorators. QA focus: Stake / Receive / Send buttons on the account header for BTC, Celo, EVM and Tron — empty-account variants must still route to the no-funds flow; funded accounts must still trigger the normal flow.

### 📝 Description

Third slice of the mobile `AccountBridgeExtensions` migration (split from #17401 / #17338). Independent of the cache-clean slice (#17491) and the operations slice (#17492).

The per-family files and `useAccountActions.tsx` ship together on purpose: mobile's `getMainActions` signature gains a required `bridge` parameter, so the consumer must provide it in the same change set — splitting them would crash empty-account detection at runtime.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30457](https://ledgerhq.atlassian.net/browse/LIVE-30457) — split out of #17401 / #17338
- **ADR link (if any)**: —

[LIVE-30457]: https://ledgerhq.atlassian.net/browse/LIVE-30457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ