### PR TITLE
[LWM] refactor(mobile): migrate empty-account checks to AccountBridgeExtensions

### DIFF
--- a/.changeset/mobile-bridge-empty-checks.md
+++ b/.changeset/mobile-bridge-empty-checks.md
@@ -1,0 +1,7 @@
+---
+"live-mobile": patch
+---
+
+Migrate mobile empty-account checks (account/portfolio screens, asset screen, select-account, quick-actions, transfer drawer, analytics operations list, device-scan add-account flow) from the deprecated isAccountEmpty top-level helper to bridge-resolved equivalents. Replace areAccountsEmptySelector with the new useAreAccountsEmpty hook.
+
+Also fix the Operations list empty/no-op state when filtered on token accounts whose parent is not in the filtered slice, and stabilize useAreAccountsEmpty by selecting through the existing memoized shallow accounts selector to avoid re-rendering consumers on irrelevant account updates.

--- a/apps/ledger-live-mobile/src/hooks/useQuickActions.ts
+++ b/apps/ledger-live-mobile/src/hooks/useQuickActions.ts
@@ -10,7 +10,7 @@ import { AccountLike } from "@ledgerhq/types-live";
 import { NavigatorName, ScreenName } from "~/const";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { EntryOf } from "~/types/helpers";
-import { accountsCountSelector, areAccountsEmptySelector } from "../reducers/accounts";
+import { accountsCountSelector, useAreAccountsEmpty } from "../reducers/accounts";
 import { readOnlyModeEnabledSelector } from "../reducers/settings";
 import { useStake } from "LLM/hooks/useStake/useStake";
 import { useOpenStakeDrawer } from "LLM/features/Stake";
@@ -45,7 +45,7 @@ function useQuickActions({ currency, accounts }: QuickActionProps = {}) {
 
   const readOnlyModeEnabled = useSelector(readOnlyModeEnabledSelector);
   const hasAnyAccounts = useSelector(accountsCountSelector) > 0;
-  const hasFunds = !useSelector(areAccountsEmptySelector) && hasAnyAccounts;
+  const hasFunds = !useAreAccountsEmpty() && hasAnyAccounts;
   const hasCurrency = currency ? !!accounts?.some(({ balance }) => balance.gt(0)) : hasFunds;
 
   const recoverEntryPoint = useFeature("protectServicesMobile");

--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/__tests__/shared.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/__tests__/shared.ts
@@ -57,6 +57,9 @@ jest.mock("@ledgerhq/live-common/bridge/index", () => ({
     preload: jest.fn(() => Promise.resolve(undefined)),
     hydrate: jest.fn(),
   })),
+  getAccountBridge: jest.fn(() => ({
+    isAccountEmpty: jest.fn(() => false),
+  })),
 }));
 
 jest.mock("~/bridge/cache", () => ({

--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
@@ -3,7 +3,7 @@ import { useEffect, useCallback, useState, useRef, useMemo } from "react";
 import { concat, from, Subscription } from "rxjs";
 import { ignoreElements } from "rxjs/operators";
 import { useDispatch } from "~/context/hooks";
-import { isAccountEmpty } from "@ledgerhq/live-common/account/index";
+import { useAccountBridgeOrNull } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import uniq from "lodash/uniq";
 import type { Account } from "@ledgerhq/types-live";
 import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
@@ -341,30 +341,38 @@ export default function useScanDeviceAccountsViewModel({
     return () => stopSubscription(false);
   }, [startSubscription, stopSubscription]);
 
+  const latestScannedAccountBridge = useAccountBridgeOrNull(latestScannedAccount ?? null);
+
   useEffect(() => {
-    if (latestScannedAccount) {
-      const hasAlreadyBeenScanned = scannedAccounts.some(a => latestScannedAccount.id === a.id);
-      const hasAlreadyBeenImported = existingAccounts.some(a => latestScannedAccount.id === a.id);
-      const isNewAccount = isAccountEmpty(latestScannedAccount);
+    if (!latestScannedAccount || !latestScannedAccountBridge) return;
+    const hasAlreadyBeenScanned = scannedAccounts.some(a => latestScannedAccount.id === a.id);
+    const hasAlreadyBeenImported = existingAccounts.some(a => latestScannedAccount.id === a.id);
+    const isNewAccount = latestScannedAccountBridge.isAccountEmpty(latestScannedAccount);
 
-      if (!isNewAccount && !hasAlreadyBeenImported) {
-        setOnlyNewAccounts(false);
-      }
-
-      if (!hasAlreadyBeenScanned) {
-        setScannedAccounts([...scannedAccounts, latestScannedAccount]);
-        setSelectedIds(
-          onlyNewAccounts
-            ? hasAlreadyBeenImported || selectedIds.length > 0
-              ? selectedIds
-              : [latestScannedAccount.id]
-            : !hasAlreadyBeenImported && !isNewAccount
-              ? uniq([...selectedIds, latestScannedAccount.id])
-              : selectedIds,
-        );
-      }
+    if (!isNewAccount && !hasAlreadyBeenImported) {
+      setOnlyNewAccounts(false);
     }
-  }, [existingAccounts, latestScannedAccount, onlyNewAccounts, scannedAccounts, selectedIds]);
+
+    if (!hasAlreadyBeenScanned) {
+      setScannedAccounts([...scannedAccounts, latestScannedAccount]);
+      setSelectedIds(
+        onlyNewAccounts
+          ? hasAlreadyBeenImported || selectedIds.length > 0
+            ? selectedIds
+            : [latestScannedAccount.id]
+          : !hasAlreadyBeenImported && !isNewAccount
+            ? uniq([...selectedIds, latestScannedAccount.id])
+            : selectedIds,
+      );
+    }
+  }, [
+    existingAccounts,
+    latestScannedAccount,
+    latestScannedAccountBridge,
+    onlyNewAccounts,
+    scannedAccounts,
+    selectedIds,
+  ]);
 
   useEffect(() => {
     const hasScannedAccounts = scannedAccounts.length > 0 || !!latestScannedAccount;

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/__integrations__/addAccountFlow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/__integrations__/addAccountFlow.test.tsx
@@ -113,6 +113,7 @@ jest.mock("@ledgerhq/live-common/bridge/index", () => ({
     preload: () => Promise.resolve(true),
     hydrate: () => true,
   }),
+  getAccountBridge: () => ({ isAccountEmpty: () => false }),
 }));
 
 const mockScanAccountsSubscription = async (accounts: Account[]) => {

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/components/QuickActionsCtas/__tests__/useQuickActionsCtasViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/components/QuickActionsCtas/__tests__/useQuickActionsCtasViewModel.test.ts
@@ -1,0 +1,118 @@
+import { renderHook } from "@tests/test-renderer";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { setSupportedCurrencies } from "@ledgerhq/live-common/currencies/index";
+import type { State } from "~/reducers/types";
+import { useQuickActionsCtasViewModel } from "../useQuickActionsCtasViewModel";
+import { QUICK_ACTIONS_TEST_IDS } from "../../../testIds";
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: jest.fn() }),
+  useRoute: () => ({ name: "Portfolio", key: "portfolio-key", params: {} }),
+}));
+
+jest.mock("../../../hooks/useTransferDrawerController", () => ({
+  useTransferDrawerController: () => ({
+    openDrawer: jest.fn(),
+    closeDrawer: jest.fn(),
+    isOpen: false,
+    sourceScreenName: "Portfolio",
+  }),
+}));
+
+jest.mock("LLM/features/Reborn/hooks/useBuyDeviceAction", () => ({
+  __esModule: true,
+  default: () => jest.fn(),
+}));
+
+jest.mock("LLM/features/Swap", () => ({
+  useOpenSwap: () => ({ handleOpenSwap: jest.fn() }),
+}));
+
+jest.mock("LLM/features/Receive", () => ({
+  useOpenReceiveDrawer: () => ({ handleOpenReceiveDrawer: jest.fn() }),
+}));
+
+setSupportedCurrencies(["bitcoin"]);
+
+const bitcoin = getCryptoCurrencyById("bitcoin");
+const BTC_FUNDED = genAccount("qa-ctas-btc-funded", {
+  currency: bitcoin,
+  operationsSize: 3,
+});
+const BTC_EMPTY = genAccount("qa-ctas-btc-empty", {
+  currency: bitcoin,
+  operationsSize: 0,
+});
+
+const withReadOnly = (state: State): State => ({
+  ...state,
+  settings: { ...state.settings, readOnlyModeEnabled: true },
+});
+
+const withFundedAccount = (state: State): State => ({
+  ...state,
+  accounts: { active: [BTC_FUNDED] },
+  settings: { ...state.settings, readOnlyModeEnabled: false },
+});
+
+const withEmptyAccount = (state: State): State => ({
+  ...state,
+  accounts: { active: [BTC_EMPTY] },
+  settings: { ...state.settings, readOnlyModeEnabled: false },
+});
+
+describe("useQuickActionsCtasViewModel", () => {
+  it("returns the no_signer CTAs (connect + buy_ledger) when readOnlyModeEnabled", () => {
+    const { result } = renderHook(() => useQuickActionsCtasViewModel(), {
+      overrideInitialState: withReadOnly,
+    });
+
+    const ids = result.current.quickActions.map(a => a.id);
+    expect(ids).toEqual(["connect", "buy_ledger"]);
+    expect(result.current.isVariant).toBe(false);
+  });
+
+  it("returns the standard CTAs (transfer + swap + buy) when accounts have funds", () => {
+    const { result } = renderHook(() => useQuickActionsCtasViewModel(), {
+      overrideInitialState: withFundedAccount,
+    });
+
+    const ids = result.current.quickActions.map(a => a.id);
+    expect(ids).toEqual(["transfer", "swap", "buy"]);
+  });
+
+  it("returns the standard CTAs even when accounts are empty (userState=no_funds)", () => {
+    const { result } = renderHook(() => useQuickActionsCtasViewModel(), {
+      overrideInitialState: withEmptyAccount,
+    });
+
+    const ids = result.current.quickActions.map(a => a.id);
+    expect(ids).toEqual(["transfer", "swap", "buy"]);
+  });
+
+  it("exposes testIDs that match QUICK_ACTIONS_TEST_IDS for the standard CTAs", () => {
+    const { result } = renderHook(() => useQuickActionsCtasViewModel(), {
+      overrideInitialState: withFundedAccount,
+    });
+
+    const testIds = result.current.quickActions.map(a => a.testID);
+    expect(testIds).toEqual([
+      QUICK_ACTIONS_TEST_IDS.ctas.transfer,
+      QUICK_ACTIONS_TEST_IDS.ctas.swap,
+      QUICK_ACTIONS_TEST_IDS.ctas.buy,
+    ]);
+  });
+
+  it("forwards sourceScreenName override to the page tracking name", () => {
+    const { result } = renderHook(
+      () => useQuickActionsCtasViewModel({ sourceScreenName: "AssetDetail" }),
+      {
+        overrideInitialState: withFundedAccount,
+      },
+    );
+
+    expect(result.current.quickActions.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/components/QuickActionsCtas/useQuickActionsCtasViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/components/QuickActionsCtas/useQuickActionsCtasViewModel.ts
@@ -17,7 +17,7 @@ import {
   StackNavigatorNavigation,
 } from "~/components/RootNavigator/types/helpers";
 import { languageSelector, readOnlyModeEnabledSelector } from "~/reducers/settings";
-import { accountsCountSelector, areAccountsEmptySelector } from "~/reducers/accounts";
+import { accountsCountSelector, useAreAccountsEmpty } from "~/reducers/accounts";
 import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import { resolveRemoteCopy } from "@ledgerhq/live-common/featureFlags/remoteABTesting/resolveRemoteCopy";
@@ -52,7 +52,7 @@ export const useQuickActionsCtasViewModel = ({
 
   const readOnlyModeEnabled = useSelector(readOnlyModeEnabledSelector);
   const hasAnyAccounts = useSelector(accountsCountSelector) > 0;
-  const hasFunds = !useSelector(areAccountsEmptySelector) && hasAnyAccounts;
+  const hasFunds = !useAreAccountsEmpty() && hasAnyAccounts;
 
   const ptxServiceCtaExchangeDrawer = useFeature("ptxServiceCtaExchangeDrawer");
   const isExchangeEnabled = ptxServiceCtaExchangeDrawer?.enabled ?? true;

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/useTransferDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/useTransferDrawerViewModel.ts
@@ -7,7 +7,7 @@ import { QrCode, ArrowUp, Bank } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { NavigatorName, ScreenName } from "~/const";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { languageSelector, readOnlyModeEnabledSelector } from "~/reducers/settings";
-import { accountsCountSelector, areAccountsEmptySelector } from "~/reducers/accounts";
+import { accountsCountSelector, useAreAccountsEmpty } from "~/reducers/accounts";
 import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 import { resolveRemoteCopy } from "@ledgerhq/live-common/featureFlags/remoteABTesting/resolveRemoteCopy";
 import { track } from "~/analytics";
@@ -39,7 +39,7 @@ export const useTransferDrawerViewModel = (): TransferDrawerViewModel => {
 
   const readOnlyModeEnabled = useSelector(readOnlyModeEnabledSelector);
   const hasAnyAccounts = useSelector(accountsCountSelector) > 0;
-  const hasFunds = !useSelector(areAccountsEmptySelector) && hasAnyAccounts;
+  const hasFunds = !useAreAccountsEmpty() && hasAnyAccounts;
 
   const { handleOpenReceiveDrawer } = useOpenReceiveDrawer({
     sourceScreenName,

--- a/apps/ledger-live-mobile/src/reducers/__tests__/accounts.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/__tests__/accounts.test.ts
@@ -1,0 +1,94 @@
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { setSupportedCurrencies } from "@ledgerhq/live-common/currencies/index";
+import type { Account } from "@ledgerhq/types-live";
+import { renderHook, act } from "@tests/test-renderer";
+import {
+  accountsSelector,
+  accountsCountSelector,
+  hasNoAccountsSelector,
+  useAreAccountsEmpty,
+} from "../accounts";
+import type { State } from "../types";
+
+setSupportedCurrencies(["bitcoin", "ethereum"]);
+
+const bitcoin = getCryptoCurrencyById("bitcoin");
+const ethereum = getCryptoCurrencyById("ethereum");
+
+const BTC_FUNDED = genAccount("accounts-test-btc", { currency: bitcoin, operationsSize: 3 });
+const ETH_EMPTY = genAccount("accounts-test-eth-empty", {
+  currency: ethereum,
+  operationsSize: 0,
+});
+
+function withAccounts(active: Account[]) {
+  return (state: State): State => ({ ...state, accounts: { active } });
+}
+
+describe("accountsSelector / accountsCountSelector / hasNoAccountsSelector", () => {
+  it("returns the active accounts and derived counts", () => {
+    const state = {
+      accounts: { active: [BTC_FUNDED, ETH_EMPTY] },
+    } as unknown as State;
+
+    expect(accountsSelector(state)).toEqual([BTC_FUNDED, ETH_EMPTY]);
+    expect(accountsCountSelector(state)).toBe(2);
+    expect(hasNoAccountsSelector(state)).toBe(false);
+  });
+
+  it("hasNoAccountsSelector returns true when there are no accounts", () => {
+    const state = { accounts: { active: [] } } as unknown as State;
+    expect(hasNoAccountsSelector(state)).toBe(true);
+  });
+});
+
+describe("useAreAccountsEmpty", () => {
+  it("returns true when every account is empty", () => {
+    const { result } = renderHook(() => useAreAccountsEmpty(), {
+      overrideInitialState: withAccounts([ETH_EMPTY]),
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("returns false when at least one account has operations", () => {
+    const { result } = renderHook(() => useAreAccountsEmpty(), {
+      overrideInitialState: withAccounts([BTC_FUNDED, ETH_EMPTY]),
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("returns true when there are no accounts", () => {
+    const { result } = renderHook(() => useAreAccountsEmpty(), {
+      overrideInitialState: withAccounts([]),
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("does not re-render the consumer when an unrelated state slice updates", () => {
+    let renderCount = 0;
+    const { store } = renderHook(
+      () => {
+        renderCount += 1;
+        return useAreAccountsEmpty();
+      },
+      {
+        overrideInitialState: withAccounts([ETH_EMPTY]),
+      },
+    );
+
+    const initial = renderCount;
+
+    act(() => {
+      store.dispatch({
+        type: "SETTINGS_SET_THEME",
+        payload: "light",
+      });
+    });
+
+    expect(renderCount).toBe(initial);
+  });
+});

--- a/apps/ledger-live-mobile/src/reducers/accounts.ts
+++ b/apps/ledger-live-mobile/src/reducers/accounts.ts
@@ -17,13 +17,14 @@ import type {
 } from "@ledgerhq/types-cryptoassets";
 import isEqual from "lodash/isEqual";
 import {
-  isAccountEmpty,
   flattenAccounts,
   getAccountCurrency,
   isUpToDateAccount,
   makeEmptyTokenAccount,
   isAccountBalanceUnconfirmed,
 } from "@ledgerhq/live-common/account/index";
+import { useAccountBridgeMany } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { useSelector } from "~/context/hooks";
 
 import type { AccountsState, State } from "./types";
 import type {
@@ -175,10 +176,12 @@ export const flattenAccountsSelector = createSelector(accountsSelector, flattenA
 export const accountsCountSelector = createSelector(accountsSelector, acc => acc.length);
 /** Returns a boolean that is true if and only if there is no account */
 export const hasNoAccountsSelector = createSelector(accountsSelector, acc => acc.length <= 0);
-/** Returns a boolean that is true if and only if all accounts are empty */
-export const areAccountsEmptySelector = createSelector(accountsSelector, accounts =>
-  accounts.every(isAccountEmpty),
-);
+
+export function useAreAccountsEmpty(): boolean {
+  const accounts = useSelector(shallowAccountsSelector);
+  const bridges = useAccountBridgeMany(accounts);
+  return accounts.every((a, i) => bridges[i].isAccountEmpty(a));
+}
 
 export const currenciesSelector = createSelector(accountsSelector, accounts =>
   uniq(flattenAccounts(accounts).map(a => getAccountCurrency(a))).sort((a, b) =>

--- a/apps/ledger-live-mobile/src/screens/Account/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/index.tsx
@@ -10,7 +10,8 @@ import SafeAreaView from "~/components/SafeAreaView";
 import { useTranslation } from "~/context/Locale";
 import { getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
 import { useTheme } from "styled-components/native";
-import { getMainAccount, isAccountEmpty } from "@ledgerhq/live-common/account/helpers";
+import { getMainAccount } from "@ledgerhq/live-common/account/helpers";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { switchCountervalueFirst } from "~/actions/settings";
 import { useBalanceHistoryWithCountervalue } from "~/hooks/portfolio";
@@ -91,7 +92,8 @@ const AccountScreenInner = ({
     useBalanceHistoryWithCountervalue({ account, range });
   const useCounterValue = useSelector(countervalueFirstSelector);
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
-  const isEmpty = isAccountEmpty(account);
+  const bridge = useAccountBridge(account, parentAccount);
+  const isEmpty = bridge.isAccountEmpty(account);
 
   const onSwitchAccountCurrency = useCallback(() => {
     dispatch(switchCountervalueFirst());

--- a/apps/ledger-live-mobile/src/screens/Analytics/Operations/OperationsList.tsx
+++ b/apps/ledger-live-mobile/src/screens/Analytics/Operations/OperationsList.tsx
@@ -1,8 +1,10 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { SectionList, SectionListData, SectionListRenderItem } from "react-native";
+import uniqBy from "lodash/uniqBy";
 import { Flex } from "@ledgerhq/native-ui";
 import { Account, AccountLike, DailyOperationsSection, Operation } from "@ledgerhq/types-live";
-import { flattenAccounts, isAccountEmpty } from "@ledgerhq/live-common/account/helpers";
+import { flattenAccounts } from "@ledgerhq/live-common/account/helpers";
+import { useAccountBridgeMany } from "@ledgerhq/live-common/bridge/useAccountBridge";
 
 import { Trans } from "~/context/Locale";
 
@@ -21,16 +23,47 @@ function keyExtractor(item: Operation) {
   return item.id;
 }
 
-function ListEmptyComponent({ accountsFiltered }: { accountsFiltered: AccountLike[] }) {
-  if (accountsFiltered.length === 0) {
-    return <EmptyStatePortfolio />;
-  }
-
-  if (accountsFiltered.every(isAccountEmpty)) {
-    return <NoOpStatePortfolio />;
-  }
-
+function ListEmptyBody({
+  accountsFiltered,
+  isAllEmpty,
+}: Readonly<{
+  accountsFiltered: AccountLike[];
+  isAllEmpty: boolean;
+}>) {
+  if (accountsFiltered.length === 0) return <EmptyStatePortfolio />;
+  if (isAllEmpty) return <NoOpStatePortfolio />;
   return null;
+}
+
+function renderFooter({
+  completed,
+  hasOnEndReached,
+  isAllEmpty,
+  hasSections,
+  onTransactionButtonPress,
+}: {
+  completed: boolean;
+  hasOnEndReached: boolean;
+  isAllEmpty: boolean;
+  hasSections: boolean;
+  onTransactionButtonPress?: () => void;
+}) {
+  if (!completed) {
+    return hasOnEndReached ? (
+      <LoadingFooter />
+    ) : (
+      <Flex m={8}>
+        <Button
+          event="View Transactions"
+          type="lightPrimary"
+          title={<Trans i18nKey="common.seeAll" />}
+          onPress={onTransactionButtonPress}
+        />
+      </Flex>
+    );
+  }
+  if (isAllEmpty) return null;
+  return hasSections ? <NoMoreOperationFooter /> : <NoOperationFooter />;
 }
 
 export function OperationsList({
@@ -41,6 +74,24 @@ export function OperationsList({
   onEndReached,
   onTransactionButtonPress,
 }: ListProps) {
+  const allAccountsById = new Map(allAccounts.map(a => [a.id, a]));
+  const parentAccountsNeeded = uniqBy(
+    accountsFiltered
+      .map(a => (a.type === "Account" ? a : allAccountsById.get(a.parentId)))
+      .filter((a): a is Account => Boolean(a)),
+    a => a.id,
+  );
+  const bridges = useAccountBridgeMany(parentAccountsNeeded);
+  const bridgeById = new Map(parentAccountsNeeded.map((a, i) => [a.id, bridges[i]]));
+  const isAllEmpty =
+    accountsFiltered.length > 0 &&
+    accountsFiltered.every(a =>
+      Boolean(bridgeById.get(a.type === "Account" ? a.id : a.parentId)?.isAccountEmpty(a)),
+    );
+  const ListEmptyComponent = useCallback(
+    () => <ListEmptyBody accountsFiltered={accountsFiltered} isAllEmpty={isAllEmpty} />,
+    [accountsFiltered, isAllEmpty],
+  );
   const renderItem: SectionListRenderItem<Operation, DailyOperationsSection> = ({
     item,
     index,
@@ -88,26 +139,13 @@ export function OperationsList({
         onEndReached={onEndReached}
         onEndReachedThreshold={0.5}
         showsVerticalScrollIndicator={false}
-        ListFooterComponent={
-          !completed ? (
-            !onEndReached ? (
-              <Flex m={8}>
-                <Button
-                  event="View Transactions"
-                  type="lightPrimary"
-                  title={<Trans i18nKey="common.seeAll" />}
-                  onPress={onTransactionButtonPress}
-                />
-              </Flex>
-            ) : (
-              <LoadingFooter />
-            )
-          ) : accountsFiltered.every(isAccountEmpty) ? null : sections.length ? (
-            <NoMoreOperationFooter />
-          ) : (
-            <NoOperationFooter />
-          )
-        }
+        ListFooterComponent={renderFooter({
+          completed,
+          hasOnEndReached: !!onEndReached,
+          isAllEmpty,
+          hasSections: sections.length > 0,
+          onTransactionButtonPress,
+        })}
         ListEmptyComponent={ListEmptyComponent}
       />
       <TrackScreen category="Analytics" name="Operations" />

--- a/apps/ledger-live-mobile/src/screens/Analytics/Operations/__tests__/OperationsList.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/Analytics/Operations/__tests__/OperationsList.test.tsx
@@ -1,0 +1,120 @@
+import React from "react";
+import {
+  genAccount,
+  genTokenAccount,
+} from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { setSupportedCurrencies } from "@ledgerhq/live-common/currencies/index";
+import BigNumber from "bignumber.js";
+import type { AccountLike, TokenAccount } from "@ledgerhq/types-live";
+import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { render, screen } from "@tests/test-renderer";
+import LoadingFooter from "~/components/LoadingFooter";
+import { OperationsList } from "../OperationsList";
+
+jest.mock("~/screens/Portfolio/EmptyStatePortfolio", () => {
+  const { View } = jest.requireActual("react-native");
+  return function MockEmptyStatePortfolio() {
+    return <View testID="empty-state-portfolio" />;
+  };
+});
+
+jest.mock("~/screens/Portfolio/NoOpStatePortfolio", () => {
+  const { View } = jest.requireActual("react-native");
+  return function MockNoOpStatePortfolio() {
+    return <View testID="no-op-state-portfolio" />;
+  };
+});
+
+setSupportedCurrencies(["ethereum"]);
+
+const ethereum = getCryptoCurrencyById("ethereum");
+const usdc = { parentCurrency: { family: "evm" } } as TokenCurrency;
+
+const EMPTY_PARENT = genAccount("opslist-parent-empty", {
+  currency: ethereum,
+  operationsSize: 0,
+  subAccountsCount: 0,
+});
+const FUNDED_PARENT = genAccount("opslist-parent-funded", {
+  currency: ethereum,
+  operationsSize: 5,
+  subAccountsCount: 0,
+});
+const emptyTokenOf = (parent: typeof EMPTY_PARENT): TokenAccount => ({
+  ...genTokenAccount(0, parent, usdc),
+  balance: new BigNumber(0),
+  spendableBalance: new BigNumber(0),
+  operations: [],
+  operationsCount: 0,
+});
+
+const EMPTY_PARENT_TOKEN = emptyTokenOf(EMPTY_PARENT);
+const FUNDED_PARENT_TOKEN: TokenAccount = genTokenAccount(0, FUNDED_PARENT, usdc);
+
+function renderList(props: {
+  accountsFiltered: AccountLike[];
+  allAccounts: typeof EMPTY_PARENT[];
+}) {
+  return render(
+    <OperationsList
+      accountsFiltered={props.accountsFiltered}
+      allAccounts={props.allAccounts}
+      sections={[]}
+      completed={true}
+    />,
+  );
+}
+
+describe("OperationsList — empty / no-op state", () => {
+  it("renders EmptyStatePortfolio when accountsFiltered is empty", () => {
+    renderList({ accountsFiltered: [], allAccounts: [] });
+
+    expect(screen.queryByTestId("empty-state-portfolio")).not.toBeNull();
+    expect(screen.queryByTestId("no-op-state-portfolio")).toBeNull();
+  });
+
+  it("renders NoOpStatePortfolio when filtered TokenAccounts' parent bridge reports empty (regression for token-only filter)", () => {
+    renderList({ accountsFiltered: [EMPTY_PARENT_TOKEN], allAccounts: [EMPTY_PARENT] });
+
+    expect(screen.queryByTestId("no-op-state-portfolio")).not.toBeNull();
+    expect(screen.queryByTestId("empty-state-portfolio")).toBeNull();
+  });
+
+  it("does not render NoOpStatePortfolio when at least one bridge reports non-empty", () => {
+    renderList({
+      accountsFiltered: [FUNDED_PARENT, FUNDED_PARENT_TOKEN],
+      allAccounts: [FUNDED_PARENT],
+    });
+
+    expect(screen.queryByTestId("no-op-state-portfolio")).toBeNull();
+    expect(screen.queryByTestId("empty-state-portfolio")).toBeNull();
+  });
+
+  it("falls back to non-empty (no NoOpState) when parent Account is missing from allAccounts", () => {
+    renderList({ accountsFiltered: [EMPTY_PARENT_TOKEN], allAccounts: [] });
+
+    expect(screen.queryByTestId("no-op-state-portfolio")).toBeNull();
+    expect(screen.queryByTestId("empty-state-portfolio")).toBeNull();
+  });
+
+  it("renders NoOpStatePortfolio for a plain Account in accountsFiltered when its bridge reports empty", () => {
+    renderList({ accountsFiltered: [EMPTY_PARENT], allAccounts: [EMPTY_PARENT] });
+
+    expect(screen.queryByTestId("no-op-state-portfolio")).not.toBeNull();
+  });
+
+  it("renders the loading footer when not yet completed and onEndReached is set", () => {
+    render(
+      <OperationsList
+        accountsFiltered={[FUNDED_PARENT]}
+        allAccounts={[FUNDED_PARENT]}
+        sections={[]}
+        completed={false}
+        onEndReached={() => {}}
+      />,
+    );
+
+    expect(screen.UNSAFE_queryByType(LoadingFooter)).not.toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/Portfolio/PortfolioGraphCard.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/PortfolioGraphCard.tsx
@@ -5,7 +5,7 @@ import { LayoutChangeEvent } from "react-native";
 import { useSharedValue } from "react-native-reanimated";
 import { useSelector } from "~/context/hooks";
 import { usePortfolioAllAccounts } from "~/hooks/portfolio";
-import { areAccountsEmptySelector } from "~/reducers/accounts";
+import { useAreAccountsEmpty } from "~/reducers/accounts";
 import { counterValueCurrencySelector } from "~/reducers/settings";
 import { PortfolioBalanceSection } from "LLM/features/Portfolio/components";
 import GraphCardContainer from "./GraphCardContainer";
@@ -23,7 +23,7 @@ const PortfolioGraphCard = ({
   hideGraph,
   isReadOnlyMode = false,
 }: Props) => {
-  const areAccountsEmpty = useSelector(areAccountsEmptySelector);
+  const areAccountsEmpty = useAreAccountsEmpty();
   const portfolio = usePortfolioAllAccounts();
   const counterValueCurrency: Currency = useSelector(counterValueCurrencySelector);
 

--- a/apps/ledger-live-mobile/src/screens/SelectAccount.tsx
+++ b/apps/ledger-live-mobile/src/screens/SelectAccount.tsx
@@ -7,10 +7,10 @@ import {
 } from "@ledgerhq/live-common/account/helpers";
 import { Flex } from "@ledgerhq/native-ui";
 import {
-  isAccountEmpty,
   getAccountSpendableBalance,
   getMainAccount,
 } from "@ledgerhq/live-common/account/index";
+import { useAccountBridgeMany } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { NotEnoughBalance } from "@ledgerhq/errors";
 import { ScreenName, NavigatorName } from "~/const";
 import { accountsSelector } from "~/reducers/accounts";
@@ -20,7 +20,7 @@ import GenericErrorBottomModal from "~/components/GenericErrorBottomModal";
 import { SendFundsNavigatorStackParamList } from "~/components/RootNavigator/types/SendFundsNavigator";
 import { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import SafeAreaView from "~/components/SafeAreaView";
-import { AccountLike } from "@ledgerhq/types-live";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
 import { withDiscreetMode } from "~/context/DiscreetModeContext";
 import { useNewSendFlowFeature } from "LLM/features/Send/hooks/useNewSendFlowFeature";
 
@@ -64,8 +64,13 @@ function ReceiveFunds({ navigation, route }: Props) {
     }
     return flattenAccounts(accounts);
   }, [accounts, selectedCurrency]);
+  const mainAccounts = enhancedAccounts.filter((a): a is Account => a.type === "Account");
+  const bridges = useAccountBridgeMany(mainAccounts);
+  const bridgeById = new Map(mainAccounts.map((a, i) => [a.id, bridges[i]]));
   const allAccounts = notEmptyAccounts
-    ? enhancedAccounts.filter(account => !isAccountEmpty(account))
+    ? enhancedAccounts.filter(
+        a => !bridgeById.get(a.type === "Account" ? a.id : a.parentId)?.isAccountEmpty(a),
+      )
     : enhancedAccounts;
 
   const { isEnabledForFamily, getFamilyFromAccount, getCurrencyIdFromAccount } =

--- a/apps/ledger-live-mobile/src/screens/WalletCentricAsset/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/WalletCentricAsset/index.tsx
@@ -8,7 +8,7 @@ import Animated, {
 import { useTranslation } from "~/context/Locale";
 import { Box, Flex } from "@ledgerhq/native-ui";
 import { getCurrencyColor, isCryptoCurrency } from "@ledgerhq/live-common/currencies/index";
-import { isAccountEmpty } from "@ledgerhq/live-common/account/helpers";
+import { useAccountBridgeMany } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useTheme } from "styled-components/native";
 import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssetsData";
 import VersionNumber from "react-native-version-number";
@@ -19,7 +19,10 @@ import BigNumber from "bignumber.js";
 import accountSyncRefreshControl from "~/components/accountSyncRefreshControl";
 import { withDiscreetMode } from "~/context/DiscreetModeContext";
 import SafeAreaView from "~/components/SafeAreaView";
-import { useFlattenAccountsByCryptoCurrency } from "LLM/hooks/useAccountsByCryptoCurrency";
+import {
+  useAccountsByCryptoCurrency,
+  useFlattenAccountsByCryptoCurrency,
+} from "LLM/hooks/useAccountsByCryptoCurrency";
 import SectionContainer from "../WalletCentricSections/SectionContainer";
 import SectionTitle from "../WalletCentricSections/SectionTitle";
 import OperationsHistorySection from "../WalletCentricSections/OperationsHistory";
@@ -70,12 +73,17 @@ const AssetScreen = ({ route }: NavigationProps) => {
   }, [preloadedCurrency, currencyId, assetData]);
 
   const cryptoAccounts = useFlattenAccountsByCryptoCurrency(currency);
-
+  // useFlattenAccountsByCryptoCurrency returns only TokenAccounts for a TokenCurrency,
+  // so we pull parent Accounts from the tuples selector to resolve bridges by parentId.
+  const cryptoAccountTuples = useAccountsByCryptoCurrency(currency);
   const defaultAccount = cryptoAccounts?.length === 1 ? cryptoAccounts[0] : undefined;
-
-  const cryptoAccountsEmpty = useMemo(
-    () => cryptoAccounts.every(account => isAccountEmpty(account)),
-    [cryptoAccounts],
+  const mainCryptoAccounts = cryptoAccountTuples
+    .map(t => t.account)
+    .filter((a): a is Account => a.type === "Account");
+  const bridges = useAccountBridgeMany(mainCryptoAccounts);
+  const bridgeByParentId = new Map(mainCryptoAccounts.map((a, i) => [a.id, bridges[i]]));
+  const cryptoAccountsEmpty = cryptoAccounts.every(a =>
+    Boolean(bridgeByParentId.get(a.type === "Account" ? a.id : a.parentId)?.isAccountEmpty(a)),
   );
 
   const [graphCardEndPosition, setGraphCardEndPosition] = useState(60);

--- a/apps/ledger-live-mobile/src/screens/__tests__/SelectAccount.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/__tests__/SelectAccount.test.tsx
@@ -1,0 +1,126 @@
+import React from "react";
+import {
+  genAccount,
+  genTokenAccount,
+} from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { setSupportedCurrencies } from "@ledgerhq/live-common/currencies/index";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
+import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { render, screen } from "@tests/test-renderer";
+import SelectAccount from "../SelectAccount";
+import type { State } from "~/reducers/types";
+
+jest.mock("~/components/AccountSelector", () => {
+  const { View, Text } = jest.requireActual("react-native");
+  return function MockAccountSelector({ list }: { list: AccountLike[] }) {
+    return (
+      <View testID="account-selector">
+        {list.map(a => (
+          <Text key={a.id} testID={`account-${a.id}`}>
+            {a.id}
+          </Text>
+        ))}
+      </View>
+    );
+  };
+});
+
+jest.mock("LLM/features/Send/hooks/useNewSendFlowFeature", () => ({
+  useNewSendFlowFeature: () => ({
+    isEnabledForFamily: () => false,
+    getFamilyFromAccount: () => "ethereum",
+    getCurrencyIdFromAccount: () => "ethereum",
+  }),
+}));
+
+setSupportedCurrencies(["ethereum"]);
+
+const ethereum = getCryptoCurrencyById("ethereum");
+const usdc = { parentCurrency: ethereum } as unknown as TokenCurrency;
+
+const EMPTY_ETH = genAccount("sa-empty-eth", {
+  currency: ethereum,
+  operationsSize: 0,
+  subAccountsCount: 0,
+});
+const FUNDED_ETH = genAccount("sa-funded-eth", {
+  currency: ethereum,
+  operationsSize: 5,
+  subAccountsCount: 0,
+});
+const FUNDED_TOKEN = genTokenAccount(0, FUNDED_ETH, usdc);
+
+function makeRoute(params: Record<string, unknown> = {}) {
+  return {
+    key: "SendCoin-key",
+    name: "SendCoin" as const,
+    params: { category: "test", ...params },
+  };
+}
+
+function makeNavigation() {
+  return {
+    navigate: jest.fn(),
+    addListener: jest.fn(() => jest.fn()),
+    setOptions: jest.fn(),
+    getParent: jest.fn(),
+    goBack: jest.fn(),
+    setParams: jest.fn(),
+    dispatch: jest.fn(),
+  };
+}
+
+const withAccounts =
+  (accounts: Account[]) =>
+  (state: State): State => ({
+    ...state,
+    accounts: { active: accounts },
+  });
+
+describe("SelectAccount — notEmptyAccounts filter via bridge", () => {
+  it("filters out accounts whose bridge reports empty when notEmptyAccounts is true", () => {
+    render(
+      <SelectAccount
+        // oxlint-disable-next-line typescript/no-explicit-any
+        navigation={makeNavigation() as any}
+        // oxlint-disable-next-line typescript/no-explicit-any
+        route={makeRoute({ notEmptyAccounts: true }) as any}
+      />,
+      { overrideInitialState: withAccounts([EMPTY_ETH, FUNDED_ETH]) },
+    );
+
+    expect(screen.queryByTestId(`account-${EMPTY_ETH.id}`)).toBeNull();
+    expect(screen.queryByTestId(`account-${FUNDED_ETH.id}`)).not.toBeNull();
+  });
+
+  it("keeps all accounts when notEmptyAccounts is not set", () => {
+    render(
+      <SelectAccount
+        // oxlint-disable-next-line typescript/no-explicit-any
+        navigation={makeNavigation() as any}
+        // oxlint-disable-next-line typescript/no-explicit-any
+        route={makeRoute() as any}
+      />,
+      { overrideInitialState: withAccounts([EMPTY_ETH, FUNDED_ETH]) },
+    );
+
+    expect(screen.queryByTestId(`account-${EMPTY_ETH.id}`)).not.toBeNull();
+    expect(screen.queryByTestId(`account-${FUNDED_ETH.id}`)).not.toBeNull();
+  });
+
+  it("resolves a TokenAccount's bridge via its parent Account when filtering", () => {
+    render(
+      <SelectAccount
+        // oxlint-disable-next-line typescript/no-explicit-any
+        navigation={makeNavigation() as any}
+        // oxlint-disable-next-line typescript/no-explicit-any
+        route={makeRoute({ notEmptyAccounts: true }) as any}
+      />,
+      { overrideInitialState: withAccounts([{ ...FUNDED_ETH, subAccounts: [FUNDED_TOKEN] }]) },
+    );
+
+    expect(screen.queryByTestId(`account-${FUNDED_ETH.id}`)).not.toBeNull();
+    expect(screen.queryByTestId(`account-${FUNDED_TOKEN.id}`)).not.toBeNull();
+  });
+});


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
  - [ ] https://github.com/LedgerHQ/ledger-live/actions/runs/26090278851
  - [x] i've also tested manually on the app
- [ ] **Impact of the changes:**
  - Mobile empty-account checks across 12 files: account screen entry, portfolio graph card, asset screen, select-account, quick-actions cluster (hook + CTAs view model + transfer-drawer view model), analytics operations list (empty-state vs no-op-state rendering), and the device-scan add-account flow (view model + test fixture + integration test). `areAccountsEmptySelector` is replaced by a new `useAreAccountsEmpty` hook that resolves bridges via `useAccountBridgeMany`. QA focus: portfolio empty-state vs no-op-state rendering, quick-actions / transfer-drawer when all accounts are empty, account list selection, asset screen for an empty wallet, add-account device scan filtering newly-discovered empty accounts.

### 📝 Description

Final slice of the mobile `AccountBridgeExtensions` migration (split from #17401 / #17338). Independent of the cache-clean slice (#17491), operations slice (#17492), and per-family accountActions slice (#17493). Once this merges, every deprecated top-level helper has zero mobile call sites, unblocking the breaking removal in #17338 (mobile half).

`reducers/accounts.ts` is touched by both this PR and the cache-clean slice (#17491), but on disjoint regions — the selector → hook swap here, the `CLEAN_CACHE` handler removal there. They merge in any order without textual conflict.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30457](https://ledgerhq.atlassian.net/browse/LIVE-30457) — split out of #17401 / #17338
- **ADR link (if any)**: —

[LIVE-30457]: https://ledgerhq.atlassian.net/browse/LIVE-30457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ