### PR TITLE
[LWD] fix(LIVE-30571): align RecoverWidget visibility gating with mobile

### DIFF
--- a/.changeset/three-flies-sing.md
+++ b/.changeset/three-flies-sing.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix: update recover widget display logic

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/RecoverWidgetView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/RecoverWidgetView.tsx
@@ -12,7 +12,7 @@ import { ShieldCheck } from "@ledgerhq/lumen-ui-react/symbols";
 import useTheme from "~/renderer/hooks/useTheme";
 
 const RecoverWidgetView = memo(function RecoverWidgetView({
-  isVisible,
+  shouldDisplay,
   titleKey,
   descriptionKey,
   onOpenRecover,
@@ -27,7 +27,7 @@ const RecoverWidgetView = memo(function RecoverWidgetView({
     [colors],
   );
 
-  if (!isVisible) {
+  if (!shouldDisplay) {
     return null;
   }
 

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__integrations__/RecoverWidget.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__integrations__/RecoverWidget.integration.test.tsx
@@ -28,14 +28,23 @@ const RECOVER_UPSELL_LEDGER_LIVE_URI = "ledgerlive://protect/upsell";
 
 const protectDesktopDefaultParams = DEFAULT_FEATURES.protectServicesDesktop.params!;
 
-const protectServicesForStax = (onboardingUpsellUri: string) =>
+type ProtectFeatureOverrides = {
+  onboardingUpsellUri?: string;
+  bannerSubscriptionNotification?: boolean;
+};
+
+const protectServicesFeature = ({
+  onboardingUpsellUri = RECOVER_UPSELL_LEDGER_LIVE_URI,
+  bannerSubscriptionNotification = true,
+}: ProtectFeatureOverrides = {}) =>
   withFlagOverrides({
     protectServicesDesktop: {
       enabled: true,
       params: {
         ...protectDesktopDefaultParams,
         protectId: "protect-prod",
-        compatibleDevices: [{ name: DeviceModelId.stax, available: true, comingSoon: false }],
+        bannerSubscriptionNotification,
+        compatibleDevices: [],
         onboardingCompleted: {
           ...protectDesktopDefaultParams.onboardingCompleted,
           upsellURI: onboardingUpsellUri,
@@ -60,7 +69,10 @@ function postOnboardingActive(
   };
 }
 
-function renderWithProvider(postOnboarding: PostOnboardingState, featureFlagSlice: ReturnType<typeof withFlagOverrides>) {
+function renderWithProvider(
+  postOnboarding: PostOnboardingState,
+  featureFlagSlice: ReturnType<typeof withFlagOverrides>,
+) {
   const store = createStore({
     state: {
       postOnboarding,
@@ -94,10 +106,7 @@ describe("RecoverWidget integration", () => {
   });
 
   it("renders the recover CTA and navigates to the upsell when clicked", async () => {
-    const { user } = renderWithProvider(
-      postOnboardingActive(),
-      protectServicesForStax(RECOVER_UPSELL_LEDGER_LIVE_URI),
-    );
+    const { user } = renderWithProvider(postOnboardingActive(), protectServicesFeature());
 
     const button = await screen.findByRole("button", {
       name: /Finish securing your backup/i,
@@ -112,8 +121,12 @@ describe("RecoverWidget integration", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("renders nothing for the recover widget when the upsell is unavailable", async () => {
-    renderWithProvider(postOnboardingActive(), protectServicesForStax(""));
+  it("renders nothing when the upsellURI configuration is not available (prevents broken click)", async () => {
+    renderWithProvider(
+      postOnboardingActive(),
+      protectServicesFeature({ onboardingUpsellUri: "" }),
+    );
+
     await waitFor(() => {
       expect(screen.queryByTestId("recover-finish-onboarding-widget")).not.toBeInTheDocument();
     });
@@ -121,9 +134,16 @@ describe("RecoverWidget integration", () => {
 
   it("renders nothing when recover was never started (NO_SUBSCRIPTION)", async () => {
     mockGetStoreValue.mockReturnValue(LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION);
+    renderWithProvider(postOnboardingActive(), protectServicesFeature());
+    await waitFor(() => {
+      expect(screen.queryByTestId("recover-finish-onboarding-widget")).not.toBeInTheDocument();
+    });
+  });
+
+  it("renders nothing when bannerSubscriptionNotification feature param is false", async () => {
     renderWithProvider(
       postOnboardingActive(),
-      protectServicesForStax(RECOVER_UPSELL_LEDGER_LIVE_URI),
+      protectServicesFeature({ bannerSubscriptionNotification: false }),
     );
     await waitFor(() => {
       expect(screen.queryByTestId("recover-finish-onboarding-widget")).not.toBeInTheDocument();

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__tests__/useRecoverWidgetViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__tests__/useRecoverWidgetViewModel.test.ts
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router";
 import { track } from "~/renderer/analytics/segment";
 import { getStoreValue } from "~/renderer/store";
 import { usePostOnboardingHubState } from "@ledgerhq/live-common/postOnboarding/hooks/index";
-import { isRecoverDisplayed, useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { useUpsellPath } from "@ledgerhq/live-common/hooks/recoverFeatureFlag";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { useRecoverWidgetViewModel } from "LLD/features/FinishOnboarding/RecoverWidget/useRecoverWidgetViewModel";
@@ -29,17 +29,19 @@ const mockNavigate = jest.fn();
 const mockUseNavigate = jest.mocked(useNavigate);
 const mockUsePostOnboardingHubState = jest.mocked(usePostOnboardingHubState);
 const mockUseFeature = jest.mocked(useFeature);
-const mockIsRecoverDisplayed = jest.mocked(isRecoverDisplayed);
 const mockUseUpsellPath = jest.mocked(useUpsellPath);
 const mockGetStoreValue = jest.mocked(getStoreValue);
 const PROTECT_ID = "protect-prod";
-const recoverFeature = {
-  enabled: true,
-  params: {
-    protectId: PROTECT_ID,
-    compatibleDevices: [{ name: DeviceModelId.stax, available: true }],
-  },
-};
+
+function recoverFeatureWith(overrides: { bannerSubscriptionNotification?: boolean } = {}) {
+  return {
+    enabled: true,
+    params: {
+      protectId: PROTECT_ID,
+      bannerSubscriptionNotification: overrides.bannerSubscriptionNotification ?? true,
+    },
+  };
+}
 
 function setHub(overrides: {
   postOnboardingInProgress?: boolean;
@@ -78,42 +80,48 @@ describe("useRecoverWidgetViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseNavigate.mockReturnValue(mockNavigate);
-    mockUseFeature.mockReturnValue(recoverFeature);
+    mockUseFeature.mockReturnValue(recoverFeatureWith());
     mockUseUpsellPath.mockReturnValue("/protect/upsell");
-    mockIsRecoverDisplayed.mockReturnValue(true);
     mockGetStoreValue.mockReturnValue(undefined);
     setHub({});
   });
 
-  it("returns isVisible true when recover flow is in progress and the offer is available", async () => {
+  it("returns shouldDisplay true when banner notification is on, subscription is in progress, and banner is not dismissed", async () => {
     const { result } = renderRecoverWidgetViewModel();
 
     await waitFor(() => {
-      expect(result.current.isVisible).toBe(true);
+      expect(result.current.shouldDisplay).toBe(true);
     });
-    expect(result.current.shouldDisplayRecoverInPortfolioBannerRow).toBe(true);
   });
 
-  it("returns isVisible false when subscription is NO_SUBSCRIPTION (never started recover)", async () => {
+  it("returns shouldDisplay false when bannerSubscriptionNotification feature param is false", async () => {
+    mockUseFeature.mockReturnValue(recoverFeatureWith({ bannerSubscriptionNotification: false }));
+    const { result } = renderRecoverWidgetViewModel();
+
+    await waitFor(() => {
+      expect(result.current.shouldDisplay).toBe(false);
+    });
+  });
+
+  it("returns shouldDisplay false when subscription is NO_SUBSCRIPTION (never started recover)", async () => {
     const { result } = renderRecoverWidgetViewModel(
       LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION,
     );
 
     await waitFor(() => {
-      expect(result.current.isVisible).toBe(false);
+      expect(result.current.shouldDisplay).toBe(false);
     });
-    expect(result.current.shouldDisplayRecoverInPortfolioBannerRow).toBe(false);
   });
 
-  it("returns isVisible false when subscription state is not hydrated", async () => {
+  it("returns shouldDisplay false when subscription state is not hydrated", async () => {
     const { result } = renderHook(() => useRecoverWidgetViewModel());
 
     await waitFor(() => {
-      expect(result.current.isVisible).toBe(false);
+      expect(result.current.shouldDisplay).toBe(false);
     });
   });
 
-  it("returns isVisible true after rehydrating subscription state from storage", async () => {
+  it("returns shouldDisplay true after rehydrating subscription state from storage", async () => {
     mockGetStoreValue.mockImplementation((key: string) => {
       if (key === "SUBSCRIPTION_STATE") {
         return LedgerRecoverSubscriptionStateEnum.STARGATE_SUBSCRIBE;
@@ -124,65 +132,51 @@ describe("useRecoverWidgetViewModel", () => {
     const { result } = renderHook(() => useRecoverWidgetViewModel());
 
     await waitFor(() => {
-      expect(result.current.isVisible).toBe(true);
+      expect(result.current.shouldDisplay).toBe(true);
     });
     expect(mockGetStoreValue).toHaveBeenCalledWith("SUBSCRIPTION_STATE", PROTECT_ID);
   });
 
-  it("returns isVisible true when post-onboarding hub is not in progress but recover criteria are met", async () => {
+  it("returns shouldDisplay true when post-onboarding hub is not in progress but recover criteria are met", async () => {
     setHub({ postOnboardingInProgress: false });
     const { result } = renderRecoverWidgetViewModel();
 
     await waitFor(() => {
-      expect(result.current.isVisible).toBe(true);
+      expect(result.current.shouldDisplay).toBe(true);
     });
   });
 
-  it("returns isVisible false when recover is not offered for this device", async () => {
-    mockIsRecoverDisplayed.mockReturnValue(false);
-    const { result } = renderRecoverWidgetViewModel();
-
-    await waitFor(() => {
-      expect(result.current.isVisible).toBe(false);
-    });
-  });
-
-  it("returns isVisible false when backup is already done", async () => {
+  it("returns shouldDisplay false when backup is already done", async () => {
     const { result } = renderRecoverWidgetViewModel(LedgerRecoverSubscriptionStateEnum.BACKUP_DONE);
 
     await waitFor(() => {
-      expect(result.current.isVisible).toBe(false);
+      expect(result.current.shouldDisplay).toBe(false);
     });
   });
 
-  it("returns isVisible false when there is no upsell path", async () => {
+  it("returns shouldDisplay false when the user has dismissed the banner", async () => {
+    const { result } = renderHook(() => useRecoverWidgetViewModel(), {
+      initialState: withRecoverState(LedgerRecoverSubscriptionStateEnum.STARGATE_SUBSCRIBE, false),
+    });
+
+    await waitFor(() => {
+      expect(result.current.shouldDisplay).toBe(false);
+    });
+  });
+
+  it("returns shouldDisplay false when upsellPath is undefined", async () => {
     mockUseUpsellPath.mockReturnValue(undefined);
     const { result } = renderRecoverWidgetViewModel();
 
     await waitFor(() => {
-      expect(result.current.isVisible).toBe(false);
+      expect(result.current.shouldDisplay).toBe(false);
     });
-    expect(result.current.shouldDisplayRecoverInPortfolioBannerRow).toBe(false);
-  });
-
-  it("returns shouldDisplayRecoverInPortfolioBannerRow false when displayBanner is dismissed but subscription is in progress", async () => {
-    const { result } = renderHook(() => useRecoverWidgetViewModel(), {
-      initialState: withRecoverState(
-        LedgerRecoverSubscriptionStateEnum.STARGATE_SUBSCRIBE,
-        false,
-      ),
-    });
-
-    await waitFor(() => {
-      expect(result.current.isVisible).toBe(true);
-    });
-    expect(result.current.shouldDisplayRecoverInPortfolioBannerRow).toBe(false);
   });
 
   it("navigates to the upsell path and tracks when the CTA is used", async () => {
     const { result } = renderRecoverWidgetViewModel();
     await waitFor(() => {
-      expect(result.current.isVisible).toBe(true);
+      expect(result.current.shouldDisplay).toBe(true);
     });
 
     act(() => {

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/index.tsx
@@ -3,10 +3,10 @@ import RecoverWidgetView from "./RecoverWidgetView";
 import { useRecoverWidgetViewModel } from "./useRecoverWidgetViewModel";
 
 const RecoverWidget = () => {
-  const { isVisible, titleKey, descriptionKey, onOpenRecover } = useRecoverWidgetViewModel();
+  const { shouldDisplay, titleKey, descriptionKey, onOpenRecover } = useRecoverWidgetViewModel();
   return (
     <RecoverWidgetView
-      isVisible={isVisible}
+      shouldDisplay={shouldDisplay}
       titleKey={titleKey}
       descriptionKey={descriptionKey}
       onOpenRecover={onOpenRecover}

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/useRecoverWidgetViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/useRecoverWidgetViewModel.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from "react";
 import { useNavigate } from "react-router";
-import { isRecoverDisplayed, useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { useUpsellPath } from "@ledgerhq/live-common/hooks/recoverFeatureFlag";
 import { usePostOnboardingHubState } from "@ledgerhq/live-common/postOnboarding/hooks/index";
 import { useRecoverBannerState } from "~/renderer/hooks/useRecoverBannerState";
@@ -13,23 +13,17 @@ const TRACK = {
 } as const;
 
 export type RecoverWidgetViewProps = {
-  readonly isVisible: boolean;
+  readonly shouldDisplay: boolean;
   readonly titleKey: string;
   readonly descriptionKey: string;
   readonly onOpenRecover: () => void;
-};
-
-/** View-model output; includes portfolio-only gating so parents read `useRecoverBannerState` once (here). */
-export type RecoverWidgetViewModelResult = RecoverWidgetViewProps & {
-  /** Same as rendering `RecoverWidget` in the Wallet40 portfolio row: offer visible and banner not dismissed. */
-  readonly shouldDisplayRecoverInPortfolioBannerRow: boolean;
 };
 
 export const RECOVER_WIDGET_TITLE_I18N_KEY = "postOnboarding.dialog.actions.recover.title";
 export const RECOVER_WIDGET_DESCRIPTION_I18N_KEY =
   "postOnboarding.dialog.actions.recover.description";
 
-export function useRecoverWidgetViewModel(): RecoverWidgetViewModelResult {
+export function useRecoverWidgetViewModel(): RecoverWidgetViewProps {
   const navigate = useNavigate();
   const recoverServices = useFeature("protectServicesDesktop");
   const upsellPath = useUpsellPath(recoverServices);
@@ -40,24 +34,16 @@ export function useRecoverWidgetViewModel(): RecoverWidgetViewModelResult {
     data: { subscriptionState, displayBanner },
   } = useRecoverBannerState(protectId);
 
-  const isRecoverOfferAvailable = isRecoverDisplayed(recoverServices, deviceModelId ?? undefined);
+  const bannerNotificationEnabled =
+    recoverServices?.params?.bannerSubscriptionNotification ?? false;
 
-  const isVisible = useMemo(() => {
-    if (!isRecoverOfferAvailable) {
-      return false;
-    }
-    if (!shouldShowRecoverPortfolioWidget(subscriptionState)) {
-      return false;
-    }
-    if (!upsellPath) {
-      return false;
-    }
-    return true;
-  }, [isRecoverOfferAvailable, subscriptionState, upsellPath]);
-
-  const shouldDisplayRecoverInPortfolioBannerRow = useMemo(
-    () => isVisible && displayBanner,
-    [displayBanner, isVisible],
+  const shouldDisplay = useMemo(
+    () =>
+      bannerNotificationEnabled &&
+      shouldShowRecoverPortfolioWidget(subscriptionState) &&
+      !!upsellPath &&
+      displayBanner,
+    [bannerNotificationEnabled, subscriptionState, displayBanner, upsellPath],
   );
 
   const onOpenRecover = useCallback(() => {
@@ -73,12 +59,11 @@ export function useRecoverWidgetViewModel(): RecoverWidgetViewModelResult {
 
   return useMemo(
     () => ({
-      isVisible,
-      shouldDisplayRecoverInPortfolioBannerRow,
+      shouldDisplay,
       titleKey: RECOVER_WIDGET_TITLE_I18N_KEY,
       descriptionKey: RECOVER_WIDGET_DESCRIPTION_I18N_KEY,
       onOpenRecover,
     }),
-    [isVisible, onOpenRecover, shouldDisplayRecoverInPortfolioBannerRow],
+    [shouldDisplay, onOpenRecover],
   );
 }

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/components/Banners/PortfolioBannerContent/__tests__/PortfolioBannerContent.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/components/Banners/PortfolioBannerContent/__tests__/PortfolioBannerContent.test.tsx
@@ -55,8 +55,7 @@ const mockUseRecoverWidgetViewModel = jest.mocked(useRecoverWidgetViewModel);
 
 function defaultRecoverWidgetViewModelReturn() {
   return {
-    isVisible: true,
-    shouldDisplayRecoverInPortfolioBannerRow: true,
+    shouldDisplay: true,
     titleKey: "postOnboarding.dialog.actions.recover.title",
     descriptionKey: "postOnboarding.dialog.actions.recover.description",
     onOpenRecover: jest.fn(),
@@ -66,7 +65,7 @@ function defaultRecoverWidgetViewModelReturn() {
 function setWallet40RecoverInRow(show: boolean) {
   mockUseRecoverWidgetViewModel.mockReturnValue({
     ...defaultRecoverWidgetViewModelReturn(),
-    shouldDisplayRecoverInPortfolioBannerRow: show,
+    shouldDisplay: show,
   });
 }
 
@@ -211,8 +210,7 @@ describe("PortfolioBannerContent", () => {
     it("falls back to portfolio content cards when banner allows recover but RecoverWidget visibility gates are off", () => {
       mockUseRecoverWidgetViewModel.mockReturnValue({
         ...defaultRecoverWidgetViewModelReturn(),
-        isVisible: false,
-        shouldDisplayRecoverInPortfolioBannerRow: false,
+        shouldDisplay: false,
       });
       setVisibility({
         shouldDisplayFinishOnboardingWidget: true,

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/components/Banners/PortfolioBannerContent/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/components/Banners/PortfolioBannerContent/index.tsx
@@ -19,19 +19,23 @@ const PortfolioBannerWallet40 = memo(function PortfolioBannerWallet40({
 }: {
   isFinishOnboardingWidgetVisible: boolean;
 }) {
-  const recoverVm = useRecoverWidgetViewModel();
-  const { shouldDisplayRecoverInPortfolioBannerRow } = recoverVm;
+  const {
+    shouldDisplay: shouldDisplayRecoverWidget,
+    titleKey,
+    descriptionKey,
+    onOpenRecover,
+  } = useRecoverWidgetViewModel();
 
-  if (isFinishOnboardingWidgetVisible || shouldDisplayRecoverInPortfolioBannerRow) {
+  if (isFinishOnboardingWidgetVisible || shouldDisplayRecoverWidget) {
     return (
       <div className="flex w-full gap-12">
         {isFinishOnboardingWidgetVisible && <FinishOnboardingWidget />}
-        {shouldDisplayRecoverInPortfolioBannerRow && (
+        {shouldDisplayRecoverWidget && (
           <RecoverWidgetView
-            isVisible={recoverVm.isVisible}
-            titleKey={recoverVm.titleKey}
-            descriptionKey={recoverVm.descriptionKey}
-            onOpenRecover={recoverVm.onOpenRecover}
+            shouldDisplay
+            titleKey={titleKey}
+            descriptionKey={descriptionKey}
+            onOpenRecover={onOpenRecover}
           />
         )}
       </div>
@@ -55,8 +59,8 @@ const PortfolioBannerWallet40 = memo(function PortfolioBannerWallet40({
  *
  * When Wallet40 applies and LNS upsell is visible, LNS is rendered here without mounting the Recover
  * subtree. Otherwise the finish/recover row uses one `useRecoverWidgetViewModel` (→ `useRecoverBannerState`,
- * LIVE-30279) and `shouldDisplayRecoverInPortfolioBannerRow`; the same view-model props are passed to
- * `RecoverWidgetView` so hooks are not duplicated when the Recover tile is shown.
+ * LIVE-30279); its `shouldDisplay` boolean gates the Recover tile and the same view-model output is
+ * passed to `RecoverWidgetView` so hooks are not duplicated when the Recover tile is shown.
  *
  * Used in PortfolioView (above MarketBanner) and in BannerSection (legacy dashboard).
  */


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Updated unit test (`useRecoverWidgetViewModel.test.ts`), integration test (`RecoverWidget.integration.test.tsx`), and consumer test (`PortfolioBannerContent.test.tsx`) to reflect the new gating.
- [x] **Impact of the changes:** the desktop RecoverWidget displayed alongside the FinishOnboarding widget (Wallet40 portfolio row) and rendered via `RecoverWidget/index.tsx` now follows the same visibility rules as the mobile `RecoverBanner`.
  - QA: verify the widget appears for users with an in-progress Ledger Recover subscription regardless of device model, provided `protectServicesDesktop.params.bannerSubscriptionNotification` is on and the banner has not been dismissed.
  - QA: verify the widget no longer appears when `bannerSubscriptionNotification` is off in the GrowthBook config.
  - QA: verify the click still navigates to the upsell when configured; if the upsell URI is missing the widget is hidden entirely.

### 📝 Description

The desktop `useRecoverWidgetViewModel` previously gated the widget on `isRecoverDisplayed` (which requires both the feature toggle `enabled` and a device-model entry in `compatibleDevices`). Mobile's equivalent `useRecoverBannerViewModel` gates only on the `bannerSubscriptionNotification` feature-flag param, the subscription state being in progress, and the dismissal flag — it does not check device compatibility. Per PM direction, desktop should behave the same way.

**Changes:**

- `useRecoverWidgetViewModel.ts`: drop `isRecoverDisplayed` import and call; gate on `recoverServices?.params?.bannerSubscriptionNotification` instead. Collapse `isVisible` + `shouldDisplayRecoverInPortfolioBannerRow` into a single `shouldDisplay` boolean. `onOpenRecover` keeps its `!upsellPath` early-return guard.
- `RecoverWidget/index.tsx` and `PortfolioBannerContent/index.tsx`: consume the new `shouldDisplay` field.
- `RecoverWidgetView.tsx`: rename the `isVisible` prop to `shouldDisplay` for naming consistency with the view-model output.
- Unit + integration + consumer tests updated to drop `isRecoverDisplayed` mocks, add `bannerSubscriptionNotification` fixtures, and cover the new param-off / mobile-parity cases.

**Spec:** `apps/ledger-live-desktop/docs/specs/recover-widget-mobile-parity.md` (local; not part of this PR).

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30571](https://ledgerhq.atlassian.net/browse/LIVE-30571)
- **ADR link (if any)**: —

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30571]: https://ledgerhq.atlassian.net/browse/LIVE-30571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ