### PR TITLE
[LWM] fix(live-mobile): duplicated known devices Redux slice

### DIFF
--- a/.changeset/cyan-dryers-develop.md
+++ b/.changeset/cyan-dryers-develop.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix duplicated known devices Redux slice

--- a/apps/ledger-live-mobile/src/reducers/__tests__/knownDevices.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/__tests__/knownDevices.test.ts
@@ -45,6 +45,13 @@ describe("knownDevices reducer", () => {
     transport: rnHidTransportIdentifier,
   };
 
+  const nanoSPlus = {
+    id: "1002",
+    name: "Nano S Plus",
+    deviceModelId: DeviceModelId.nanoSP,
+    transport: rnHidTransportIdentifier,
+  };
+
   const discoveredNanoX: DiscoveredDevice = {
     id: "discovered-ble-id",
     name: "Discovered Nano X",
@@ -137,6 +144,22 @@ describe("knownDevices reducer", () => {
 
       // THEN
       expect(nextState.knownDevices).toEqual([flex, nanoX]);
+    });
+
+    it("GIVEN an existing HID known device WHEN updating the same model with a new id THEN it updates the existing entry", () => {
+      // GIVEN
+      const state = { knownDevices: [flex, nanoSPlus] };
+      const updatedDevice = {
+        ...nanoSPlus,
+        id: "usb_1002",
+        name: "Ledger Nano S Plus",
+      };
+
+      // WHEN
+      const nextState = reducer(state, updateKnownDevice(updatedDevice));
+
+      // THEN
+      expect(nextState.knownDevices).toEqual([flex, updatedDevice]);
     });
   });
 

--- a/apps/ledger-live-mobile/src/reducers/knownDevices.ts
+++ b/apps/ledger-live-mobile/src/reducers/knownDevices.ts
@@ -123,6 +123,14 @@ function findMatchingKnownDevice(
   const oldDevicesForTransport = knownDevices.filter(
     device => device.transport === newDevice.transport,
   );
+
+  if (newDevice.transport === rnHidTransportIdentifier) {
+    return (
+      oldDevicesForTransport.find(device => device.deviceModelId === newDevice.deviceModelId) ??
+      null
+    );
+  }
+
   const matchingOldDevice = findMatchingOldDevice(
     mapKnownDeviceToDeviceBaseInfo(newDevice),
     oldDevicesForTransport.map(mapKnownDeviceToDeviceBaseInfo),


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Non-regression tests cover HID updates when DMK reports a new id for the same device model, and when multiple HID known devices share the same model but only one exact id should be updated.
- [x] **Impact of the changes:**
  - Mobile known devices deduplication now handles HID devices by first matching the exact id, then falling back to model-based matching only when no id match exists.
  - This avoids updating the wrong known HID device when multiple devices of the same model are stored.
  - QA should focus on the device selection flow on mobile, especially USB/HID discovery and reconnection for Nano S Plus / Flex-style devices.
  - BLE known device matching remains unchanged and continues to use the existing `findMatchingOldDevice` logic.

### 📝 Description

This PR fixes duplicated or incorrectly updated known devices in Ledger Live Mobile for HID devices.

Previously, HID matching relied only on the device model. That handled cases where DMK reports a different runtime id for the same USB device, but it could update the wrong entry when multiple known HID devices of the same model were stored.

The reducer now matches HID known devices by transport and exact id first. If no exact id match exists, it falls back to model-based matching to preserve the id-format migration behavior. If neither match exists, the device is inserted as a new known device.

The PR also adds reducer non-regression tests for both HID update paths and includes a patch changeset for `live-mobile`.

### ❓ Context

- **JIRA**: [LIVE-30665](https://ledgerhq.atlassian.net/browse/LIVE-30665)
---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-30665]: https://ledgerhq.atlassian.net/browse/LIVE-30665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ