### PR TITLE
[LWDM] feat(common): add altcoin season index endpoint to cmc api client

### DIFF
--- a/.changeset/add-altcoin-season-index-endpoint.md
+++ b/.changeset/add-altcoin-season-index-endpoint.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Add altcoin season index endpoint to CMC API client

--- a/libs/ledger-live-common/src/cmc-client/README.md
+++ b/libs/ledger-live-common/src/cmc-client/README.md
@@ -27,6 +27,13 @@ Fetches the latest CMC Crypto Fear and Greed value.
 **Cache/Update frequency**: Every 15 minutes
 **Plan credit use**: 1 credit per request
 
+### Altcoin Season Index Latest
+
+Fetches the latest Altcoin Season Index with yearly high/low context.
+
+**Cache/Update frequency**: Every 15 minutes
+**Plan credit use**: 1 credit per request
+
 ## Usage
 
 ### Setup
@@ -44,23 +51,38 @@ const store = configureStore({
 });
 ```
 
-### Using the Hook
+### Using the Hooks
 
 ```typescript
-import { useGetFearAndGreedLatestQuery } from "@ledgerhq/live-common/cmc-client";
+import {
+  useGetFearAndGreedLatestQuery,
+  useGetAltcoinSeasonIndexLatestQuery,
+} from "@ledgerhq/live-common/cmc-client";
 
 function FearAndGreedIndicator() {
-  const { data, error, isLoading, isFetching, isError } = useGetFearAndGreedLatestQuery();
+  const { data, isLoading, isError } = useGetFearAndGreedLatestQuery();
 
   if (isLoading) return <div>Loading...</div>;
   if (isError) return <div>Error loading data</div>;
 
   return (
     <div>
-      <h2>Fear & Greed Index</h2>
       <p>Value: {data?.value}</p>
       <p>Classification: {data?.classification}</p>
-      {isFetching && <span>Refreshing...</span>}
+    </div>
+  );
+}
+
+function AltcoinSeasonIndicator() {
+  const { data, isLoading, isError } = useGetAltcoinSeasonIndexLatestQuery();
+
+  if (isLoading) return <div>Loading...</div>;
+  if (isError) return <div>Error loading data</div>;
+
+  return (
+    <div>
+      <p>Index: {data?.value}</p>
+      <p>Market Cap: {data?.altcoinMarketcap}</p>
     </div>
   );
 }
@@ -103,14 +125,25 @@ const { data, refetch } = useGetFearAndGreedLatestQuery(undefined, {
 const handleRefresh = () => refetch();
 ```
 
-## Response Structure
+## Response Structures
 
-The hook returns a simplified, transformed response:
+The hooks return simplified, transformed responses:
+
+### Fear and Greed
 
 ```typescript
 {
-  value: number; // Fear & Greed index value (0-100)
+  value: number;          // 0-100
   classification: string; // "Extreme Fear", "Fear", "Neutral", "Greed", "Extreme Greed"
+}
+```
+
+### Altcoin Season Index
+
+```typescript
+{
+  value: number;           // 0-100
+  altcoinMarketcap: number;
 }
 ```
 

--- a/libs/ledger-live-common/src/cmc-client/state-manager/api.ts
+++ b/libs/ledger-live-common/src/cmc-client/state-manager/api.ts
@@ -14,6 +14,11 @@ export const FIFTEEN_MINUTES_IN_MS = 15 * ONE_MINUTE_IN_MS;
 const ONE_MINUTE_IN_SECONDS = 60;
 const FIFTEEN_MINUTES_IN_SECONDS = 15 * ONE_MINUTE_IN_SECONDS;
 
+const ENDPOINTS = {
+  fearAndGreed: "/fear-and-greed/latest",
+  altcoinSeasonIndex: "/altcoin-season-index/latest",
+};
+
 export const cmcApi = createApi({
   reducerPath: "cmcApi",
   baseQuery: fetchBaseQuery({
@@ -23,7 +28,7 @@ export const cmcApi = createApi({
   endpoints: build => ({
     getFearAndGreedLatest: build.query<FearAndGreedIndex, void>({
       query: () => ({
-        url: "/fear-and-greed/latest",
+        url: ENDPOINTS.fearAndGreed,
       }),
       providesTags: [FearAndGreedTags.Latest],
       transformResponse: transformFearAndGreedResponse,
@@ -31,7 +36,7 @@ export const cmcApi = createApi({
     }),
     getAltcoinSeasonIndexLatest: build.query<AltcoinSeasonIndex, void>({
       query: () => ({
-        url: "/altcoin-season-index/latest",
+        url: ENDPOINTS.altcoinSeasonIndex,
       }),
       providesTags: [AltcoinSeasonIndexTags.Latest],
       transformResponse: transformAltcoinSeasonIndexResponse,

--- a/libs/ledger-live-common/src/cmc-client/state-manager/api.ts
+++ b/libs/ledger-live-common/src/cmc-client/state-manager/api.ts
@@ -1,7 +1,12 @@
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 import { getEnv } from "@ledgerhq/live-env";
-import { FearAndGreedTags, FearAndGreedIndex, FearAndGreedResponseSchema } from "./types";
-import { log } from "@ledgerhq/logs";
+import {
+  FearAndGreedTags,
+  FearAndGreedIndex,
+  AltcoinSeasonIndexTags,
+  AltcoinSeasonIndex,
+} from "./types";
+import { transformFearAndGreedResponse, transformAltcoinSeasonIndexResponse } from "./transforms";
 
 const ONE_MINUTE_IN_MS = 60 * 1000;
 export const FIFTEEN_MINUTES_IN_MS = 15 * ONE_MINUTE_IN_MS;
@@ -9,33 +14,12 @@ export const FIFTEEN_MINUTES_IN_MS = 15 * ONE_MINUTE_IN_MS;
 const ONE_MINUTE_IN_SECONDS = 60;
 const FIFTEEN_MINUTES_IN_SECONDS = 15 * ONE_MINUTE_IN_SECONDS;
 
-function transformFearAndGreedResponse(response: unknown): FearAndGreedIndex {
-  const result = FearAndGreedResponseSchema.safeParse(response);
-
-  if (!result.success) {
-    log("cmc-client", "Invalid response schema:", {
-      errors: result.error.issues,
-      received: response,
-    });
-    throw new Error(
-      `[CMC API] Schema validation failed: ${result.error.issues
-        .map(e => `${e.path.join(".")}: ${e.message}`)
-        .join(", ")}`,
-    );
-  }
-
-  return {
-    value: result.data.data.value,
-    classification: result.data.data.value_classification,
-  };
-}
-
 export const cmcApi = createApi({
   reducerPath: "cmcApi",
   baseQuery: fetchBaseQuery({
     baseUrl: getEnv("CMC_API_URL"),
   }),
-  tagTypes: [FearAndGreedTags.Latest],
+  tagTypes: [FearAndGreedTags.Latest, AltcoinSeasonIndexTags.Latest],
   endpoints: build => ({
     getFearAndGreedLatest: build.query<FearAndGreedIndex, void>({
       query: () => ({
@@ -45,7 +29,15 @@ export const cmcApi = createApi({
       transformResponse: transformFearAndGreedResponse,
       keepUnusedDataFor: FIFTEEN_MINUTES_IN_SECONDS,
     }),
+    getAltcoinSeasonIndexLatest: build.query<AltcoinSeasonIndex, void>({
+      query: () => ({
+        url: "/altcoin-season-index/latest",
+      }),
+      providesTags: [AltcoinSeasonIndexTags.Latest],
+      transformResponse: transformAltcoinSeasonIndexResponse,
+      keepUnusedDataFor: FIFTEEN_MINUTES_IN_SECONDS,
+    }),
   }),
 });
 
-export const { useGetFearAndGreedLatestQuery } = cmcApi;
+export const { useGetFearAndGreedLatestQuery, useGetAltcoinSeasonIndexLatestQuery } = cmcApi;

--- a/libs/ledger-live-common/src/cmc-client/state-manager/transforms.ts
+++ b/libs/ledger-live-common/src/cmc-client/state-manager/transforms.ts
@@ -36,12 +36,7 @@ export function transformFearAndGreedResponse(response: unknown): FearAndGreedIn
 export function transformAltcoinSeasonIndexResponse(response: unknown): AltcoinSeasonIndex {
   const { data } = parseOrThrow(AltcoinSeasonIndexResponseSchema, response);
   return {
-    altcoinIndex: data.altcoin_index,
+    value: data.altcoin_index,
     altcoinMarketcap: data.altcoin_marketcap,
-    snapshotTime: data.snapshot_time,
-    yearlyHigh: data.yearly_high,
-    yearlyHighDate: data.yearly_high_date,
-    yearlyLow: data.yearly_low,
-    yearlyLowDate: data.yearly_low_date,
   };
 }

--- a/libs/ledger-live-common/src/cmc-client/state-manager/transforms.ts
+++ b/libs/ledger-live-common/src/cmc-client/state-manager/transforms.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+import { log } from "@ledgerhq/logs";
+import {
+  FearAndGreedIndex,
+  FearAndGreedResponseSchema,
+  AltcoinSeasonIndex,
+  AltcoinSeasonIndexResponseSchema,
+} from "./types";
+
+function parseOrThrow<T extends z.ZodTypeAny>(schema: T, response: unknown): z.infer<T> {
+  const result = schema.safeParse(response);
+
+  if (!result.success) {
+    log("cmc-client", "Invalid response schema:", {
+      errors: result.error.issues,
+      received: response,
+    });
+    throw new Error(
+      `[CMC API] Schema validation failed: ${result.error.issues
+        .map(e => `${e.path.join(".")}: ${e.message}`)
+        .join(", ")}`,
+    );
+  }
+
+  return result.data;
+}
+
+export function transformFearAndGreedResponse(response: unknown): FearAndGreedIndex {
+  const { data } = parseOrThrow(FearAndGreedResponseSchema, response);
+  return {
+    value: data.value,
+    classification: data.value_classification,
+  };
+}
+
+export function transformAltcoinSeasonIndexResponse(response: unknown): AltcoinSeasonIndex {
+  const { data } = parseOrThrow(AltcoinSeasonIndexResponseSchema, response);
+  return {
+    altcoinIndex: data.altcoin_index,
+    altcoinMarketcap: data.altcoin_marketcap,
+    snapshotTime: data.snapshot_time,
+    yearlyHigh: data.yearly_high,
+    yearlyHighDate: data.yearly_high_date,
+    yearlyLow: data.yearly_low,
+    yearlyLowDate: data.yearly_low_date,
+  };
+}

--- a/libs/ledger-live-common/src/cmc-client/state-manager/types.ts
+++ b/libs/ledger-live-common/src/cmc-client/state-manager/types.ts
@@ -43,11 +43,6 @@ export enum AltcoinSeasonIndexTags {
 const AltcoinSeasonIndexDataSchema = z.object({
   altcoin_index: z.number().min(0).max(100),
   altcoin_marketcap: z.number(),
-  snapshot_time: z.string(),
-  yearly_high: z.number(),
-  yearly_high_date: z.string(),
-  yearly_low: z.number(),
-  yearly_low_date: z.string(),
 });
 
 const AltcoinSeasonIndexStatusSchema = z.object({
@@ -65,13 +60,8 @@ export const AltcoinSeasonIndexResponseSchema = z.object({
 });
 
 export const AltcoinSeasonIndexSchema = z.object({
-  altcoinIndex: z.number().min(0).max(100),
+  value: z.number().min(0).max(100),
   altcoinMarketcap: z.number(),
-  snapshotTime: z.string(),
-  yearlyHigh: z.number(),
-  yearlyHighDate: z.string(),
-  yearlyLow: z.number(),
-  yearlyLowDate: z.string(),
 });
 
 export type AltcoinSeasonIndexResponse = z.infer<typeof AltcoinSeasonIndexResponseSchema>;

--- a/libs/ledger-live-common/src/cmc-client/state-manager/types.ts
+++ b/libs/ledger-live-common/src/cmc-client/state-manager/types.ts
@@ -35,3 +35,44 @@ export type FearAndGreedResponse = z.infer<typeof FearAndGreedResponseSchema>;
 export type FearAndGreedIndex = z.infer<typeof FearAndGreedIndexSchema>;
 
 export type FearAndGreedLevel = "fear" | "cautious" | "neutral" | "optimistic" | "greedy";
+
+export enum AltcoinSeasonIndexTags {
+  Latest = "AltcoinSeasonIndexLatest",
+}
+
+const AltcoinSeasonIndexDataSchema = z.object({
+  altcoin_index: z.number().min(0).max(100),
+  altcoin_marketcap: z.number(),
+  snapshot_time: z.string(),
+  yearly_high: z.number(),
+  yearly_high_date: z.string(),
+  yearly_low: z.number(),
+  yearly_low_date: z.string(),
+});
+
+const AltcoinSeasonIndexStatusSchema = z.object({
+  timestamp: z.string(),
+  error_code: z.union([z.number(), z.string()]),
+  error_message: z.string().nullable(),
+  elapsed: z.number(),
+  credit_count: z.number(),
+  notice: z.string().nullable(),
+});
+
+export const AltcoinSeasonIndexResponseSchema = z.object({
+  data: AltcoinSeasonIndexDataSchema,
+  status: AltcoinSeasonIndexStatusSchema,
+});
+
+export const AltcoinSeasonIndexSchema = z.object({
+  altcoinIndex: z.number().min(0).max(100),
+  altcoinMarketcap: z.number(),
+  snapshotTime: z.string(),
+  yearlyHigh: z.number(),
+  yearlyHighDate: z.string(),
+  yearlyLow: z.number(),
+  yearlyLowDate: z.string(),
+});
+
+export type AltcoinSeasonIndexResponse = z.infer<typeof AltcoinSeasonIndexResponseSchema>;
+export type AltcoinSeasonIndex = z.infer<typeof AltcoinSeasonIndexSchema>;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No tests added — follows existing pattern where the API layer has no unit tests. Transform logic uses Zod schema validation as the safety net._
- [x] **Impact of the changes:**
      - New RTK Query endpoint `getAltcoinSeasonIndexLatest` and its hook `useGetAltcoinSeasonIndexLatestQuery`
      - Existing fear and greed endpoint is unchanged
      - Transform functions extracted to dedicated file (refactor of existing code)

### 📝 Description

**Problem**: The CMC API client only supports the Fear and Greed index. We need access to the new Altcoin Season Index endpoint (`/altcoin-season-index/latest`) to surface altcoin market sentiment in the app.

**Solution**:
- Added `getAltcoinSeasonIndexLatest` RTK Query endpoint with Zod schema validation and 15-minute cache
- Added types and schemas for the altcoin season index response with snake_case → camelCase transform
- Extracted both transform functions into a dedicated `transforms.ts` file with a shared `parseOrThrow` helper to reduce duplication
- Updated the cmc-client README with the new endpoint documentation

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30671](https://ledgerhq.atlassian.net/browse/LIVE-30671)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30671]: https://ledgerhq.atlassian.net/browse/LIVE-30671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ