### PR TITLE
chore(hw-app-concordium): deprecate in favor of device-signer-kit-concordium

### DIFF
--- a/.changeset/dim-clouds-fade.md
+++ b/.changeset/dim-clouds-fade.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/hw-app-concordium": minor
+---
+
+Deprecate `@ledgerhq/hw-app-concordium` in favor of `@ledgerhq/device-signer-kit-concordium`. Ledger Live has migrated to the DMK signer; this package will be removed in a future release.

--- a/libs/ledgerjs/packages/hw-app-concordium/README.md
+++ b/libs/ledgerjs/packages/hw-app-concordium/README.md
@@ -6,6 +6,12 @@
 
 ## @ledgerhq/hw-app-concordium
 
+> ⚠️ **DEPRECATED — this package is deprecated and will be removed in a future release.**
+>
+> Ledger Live has migrated to the Device Management Kit (DMK). New integrations should use `@ledgerhq/device-signer-kit-concordium` instead. The DMK signer provides the same Concordium device operations through the unified DMK transport layer.
+>
+> No further features or fixes will be shipped here. Pin a version if you still depend on it.
+
 Ledger Hardware Wallet Concordium JavaScript bindings.
 
 **Low-level device communication library. Depends on `@ledgerhq/hw-transport` and `@ledgerhq/concordium-core` (shared Concordium protocol types and serialization).**


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** no functional changes made
- [x] **Impact of the changes:** no functional changes made, added deprecation notice to comments and README
  - ...

### 📝 Description

Deprecate `@ledgerhq/hw-app-concordium`. Ledger Live has migrated to the DMK signer (`@ledgerhq/device-signer-kit-concordium`), and this package is no longer used anywhere in the monorepo. Planned for removal in ~1 month.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29694](https://ledgerhq.atlassian.net/browse/LIVE-29694)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-29694]: https://ledgerhq.atlassian.net/browse/LIVE-29694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ