### PR TITLE
[LWM] feat(deeplinks): implement new routing for asset and market deeplinks

### DIFF
--- a/.changeset/quick-deeplinks-route.md
+++ b/.changeset/quick-deeplinks-route.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Route `asset/:currencyId` and `market/:currencyId` deeplinks to the new Asset Detail screen when the Wallet 4.0 `aggregatedAssets` feature flag is enabled, with tracking source `"deeplink_asset"` / `"deeplink_market"`.

--- a/apps/ledger-live-mobile/docs/deeplinks.md
+++ b/apps/ledger-live-mobile/docs/deeplinks.md
@@ -29,6 +29,22 @@ When working on deeplinks, please update the **Wiki** accordingly.
   `?currency` param can be name or ticker of the currency targeted
   `?address` param requires currency to work, address of the account to select
 
+- **_asset/:currencyId_** 🠒 Asset Page
+
+  `ledgerlive://asset/bitcoin` opens the asset page for the given currency.
+
+  - When the aggregated Asset Detail flow (Wallet 4.0 `aggregatedAssets` param) is **enabled**, this opens the new Asset Detail screen (LIVE-29734). The screen view event is tracked with `source = "deeplink_asset"`.
+  - Otherwise it opens the legacy WalletCentricAsset screen.
+  - If `:currencyId` is missing or invalid, the deeplink falls back to the portfolio.
+
+- **_market/:currencyId_** 🠒 Market / Asset Detail
+
+  `ledgerlive://market/bitcoin` opens market data for the given currency.
+
+  - When the aggregated Asset Detail flow (Wallet 4.0 `aggregatedAssets` param) is **enabled**, this opens the new Asset Detail screen (LIVE-29734). The screen view event is tracked with `source = "deeplink_market"`.
+  - Otherwise it opens the Market Detail screen (charts / stats).
+  - If `:currencyId` is missing or invalid, the deeplink falls back to the market list.
+
 - **_send?currency_** 🠒 Send Flow
 
   `ledgerlive://send` will redirect to send page

--- a/apps/ledger-live-mobile/ledger-live-mobile-deeplinks.html
+++ b/apps/ledger-live-mobile/ledger-live-mobile-deeplinks.html
@@ -408,11 +408,13 @@
                     section: "Asset",
                     title: "Asset Page",
                     url: "ledgerlive://asset/:currencyId",
-                    description: "Opens the asset page for a specific currency.",
+                    description: "Opens the asset page for a specific currency. When the Wallet 4.0 `aggregatedAssets` param is enabled, opens the Asset Detail screen with source = \"deeplink_asset\"; otherwise opens the legacy WalletCentricAsset screen. Invalid or missing currencyId falls back to portfolio.",
                     parameters: [
                         { name: "currencyId", required: true, description: "The currency ID (e.g., bitcoin, ethereum)" }
                     ],
                     examples: [
+                        "ledgerwallet://asset/bitcoin",
+                        "ledgerwallet://asset/ethereum",
                         "ledgerlive://asset/bitcoin",
                         "ledgerlive://asset/ethereum"
                     ]
@@ -489,11 +491,13 @@
                     section: "Market",
                     title: "Market Detail Page",
                     url: "ledgerlive://market/:currencyId",
-                    description: "Opens the market detail page for a specific cryptocurrency.",
+                    description: "Opens the market detail page for a specific cryptocurrency. When the Wallet 4.0 `aggregatedAssets` param is enabled, opens the Asset Detail screen with source = \"deeplink_market\"; otherwise opens the Market Detail screen (charts / stats). Invalid or missing currencyId falls back to the market list.",
                     parameters: [
                         { name: "currencyId", required: true, description: "The ID of the cryptocurrency (e.g., bitcoin, ethereum)" }
                     ],
                     examples: [
+                        "ledgerwallet://market/bitcoin",
+                        "ledgerwallet://market/ethereum",
                         "ledgerlive://market/bitcoin",
                         "ledgerlive://market/ethereum",
                         "ledgerlive://market/solana"

--- a/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
+++ b/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
@@ -48,6 +48,7 @@ import {
 } from "./deeplinks/validation";
 import { handleWallet40Deeplink } from "./deeplinks/handleWallet40Deeplink";
 import { handleMarketBannerDeeplink } from "./deeplinks/handleMarketBannerDeeplink";
+import { handleAssetDetailDeeplink } from "./deeplinks/handleAssetDetailDeeplink";
 import { useProductTourEligibility } from "LLM/features/ProductTour";
 import { SplashScreenHandle } from "LLM/features/LaunchScreen/SplashScreenHandle";
 import { useDeeplinkDrawerCleanup } from "./deeplinks/useDeeplinkDrawerCleanup";
@@ -348,8 +349,12 @@ export const DeeplinksProvider = ({
   const userAcceptedTerms = useGeneralTermsAccepted();
   const buySellUiFlag = useFeature("buySellUi");
   const llmAccountListUI = useFeature("llmAccountListUI");
-  const { shouldDisplayMarketBanner, shouldDisplayWallet40MainNav, shouldDisplayAssetSection } =
-    useWalletFeaturesConfig("mobile");
+  const {
+    shouldDisplayMarketBanner,
+    shouldDisplayWallet40MainNav,
+    shouldDisplayAssetSection,
+    shouldDisplayAggregatedAssets,
+  } = useWalletFeaturesConfig("mobile");
   const web3hubFlag = useFeature("web3hub");
   const { isProductTourEligible } = useProductTourEligibility();
 
@@ -703,6 +708,13 @@ export const DeeplinksProvider = ({
                 return getStateFromPath("market", config);
               }
 
+              if (shouldDisplayAggregatedAssets) {
+                return handleAssetDetailDeeplink({
+                  currencyId: validatedCurrencyId,
+                  source: "deeplink_market",
+                });
+              }
+
               url.pathname = `/${validatedCurrencyId}`;
               return getStateFromPath(url.href?.split("://")[1], config);
             }
@@ -722,8 +734,18 @@ export const DeeplinksProvider = ({
                 return getStateFromPath("portfolio", config);
               }
 
+              if (shouldDisplayAggregatedAssets) {
+                return handleAssetDetailDeeplink({
+                  currencyId: validatedCurrencyId,
+                  source: "deeplink_asset",
+                });
+              }
+
               url.pathname = `/${validatedCurrencyId}`;
               return getStateFromPath(url.href?.split("://")[1], config);
+            }
+            if (shouldDisplayAggregatedAssets) {
+              return getStateFromPath("portfolio", config);
             }
           }
 
@@ -893,6 +915,7 @@ export const DeeplinksProvider = ({
     shouldDisplayMarketBanner,
     shouldDisplayWallet40MainNav,
     shouldDisplayAssetSection,
+    shouldDisplayAggregatedAssets,
     liveAppProviderInitialized,
     manifests,
     web3hubFlag?.enabled,

--- a/apps/ledger-live-mobile/src/navigation/deeplinks/__tests__/handleAssetDetailDeeplink.test.ts
+++ b/apps/ledger-live-mobile/src/navigation/deeplinks/__tests__/handleAssetDetailDeeplink.test.ts
@@ -1,0 +1,83 @@
+import { NavigatorName, ScreenName } from "~/const";
+import { handleAssetDetailDeeplink } from "../handleAssetDetailDeeplink";
+
+describe("handleAssetDetailDeeplink", () => {
+  describe("navigation shape", () => {
+    it("returns navigation state targeting AssetDetail nested under BaseNavigator", () => {
+      const result = handleAssetDetailDeeplink({
+        currencyId: "bitcoin",
+        source: "deeplink_asset",
+      });
+
+      expect(result).toEqual({
+        routes: [
+          {
+            name: NavigatorName.Base,
+            state: {
+              index: 1,
+              routes: [
+                { name: NavigatorName.Main },
+                {
+                  name: NavigatorName.AssetDetail,
+                  state: {
+                    routes: [
+                      {
+                        name: ScreenName.AssetDetail,
+                        params: { currencyId: "bitcoin", source: "deeplink_asset" },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      });
+    });
+
+    it("places Main at index 0 so back press returns to Main instead of exiting the app", () => {
+      const result = handleAssetDetailDeeplink({
+        currencyId: "ethereum",
+        source: "deeplink_market",
+      });
+
+      const baseState = result?.routes[0].state;
+      expect(baseState?.index).toBe(1);
+      expect(baseState?.routes[0]).toEqual({ name: NavigatorName.Main });
+    });
+  });
+
+  describe("params propagation", () => {
+    it("forwards currencyId to the AssetDetail screen params", () => {
+      const result = handleAssetDetailDeeplink({
+        currencyId: "solana",
+        source: "deeplink_asset",
+      });
+
+      const assetDetailRoute = result?.routes[0].state?.routes[1];
+      const screenRoute = assetDetailRoute?.state?.routes[0];
+      expect(screenRoute?.name).toBe(ScreenName.AssetDetail);
+      expect(screenRoute?.params).toMatchObject({ currencyId: "solana" });
+    });
+
+    it("forwards source='deeplink_asset' to params for the asset hostname flow", () => {
+      const result = handleAssetDetailDeeplink({
+        currencyId: "bitcoin",
+        source: "deeplink_asset",
+      });
+
+      const screenRoute = result?.routes[0].state?.routes[1]?.state?.routes[0];
+      expect(screenRoute?.params).toMatchObject({ source: "deeplink_asset" });
+    });
+
+    it("forwards source='deeplink_market' to params for the market hostname flow", () => {
+      const result = handleAssetDetailDeeplink({
+        currencyId: "bitcoin",
+        source: "deeplink_market",
+      });
+
+      const screenRoute = result?.routes[0].state?.routes[1]?.state?.routes[0];
+      expect(screenRoute?.params).toMatchObject({ source: "deeplink_market" });
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/navigation/deeplinks/handleAssetDetailDeeplink.ts
+++ b/apps/ledger-live-mobile/src/navigation/deeplinks/handleAssetDetailDeeplink.ts
@@ -1,0 +1,50 @@
+import { NavigatorName, ScreenName } from "~/const";
+
+export type AssetDetailDeeplinkSource = "deeplink_asset" | "deeplink_market";
+
+/**
+ * Handles `asset` / `market` deeplinks when the aggregated Asset Detail (Wallet 4.0) flow is ON.
+ *
+ * Builds a navigation state that pushes the new `AssetDetail` screen on top of `Main`, so that
+ * back navigation returns to the portfolio instead of exiting the app — matching
+ * `handleMarketBannerDeeplink` and `handleWallet40Deeplink`.
+ *
+ * The `source` route param flows into `useAssetDetailViewModel` and is forwarded by
+ * `AssetDetailView`'s `TrackScreen` to the screen-view event properties.
+ *
+ * @param currencyId - Validated Ledger crypto asset id (e.g. "bitcoin").
+ * @param source - Origin of the deeplink ("deeplink_asset" or "deeplink_market"), used for tracking.
+ * @returns Navigation state targeting `Base > AssetDetail > AssetDetail` with `Main` at index 0.
+ */
+export function handleAssetDetailDeeplink({
+  currencyId,
+  source,
+}: {
+  currencyId: string;
+  source: AssetDetailDeeplinkSource;
+}): ReturnType<typeof import("@react-navigation/native").getStateFromPath> {
+  return {
+    routes: [
+      {
+        name: NavigatorName.Base,
+        state: {
+          index: 1,
+          routes: [
+            { name: NavigatorName.Main },
+            {
+              name: NavigatorName.AssetDetail,
+              state: {
+                routes: [
+                  {
+                    name: ScreenName.AssetDetail,
+                    params: { currencyId, source },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Deeplink routing for `asset/:currencyId` and `market/:currencyId` (both `ledgerwallet://` and `ledgerlive://` schemes)
  - Legacy fallback paths (`WalletCentricAsset`, `MarketDetail`) when the feature flag is OFF
  - Graceful handling of missing / invalid `currencyId`
  - Screen-view tracking on the new Asset Detail screen (`source` property)
  - Back navigation from a deeplinked Asset Detail screen

### 📝 Description

The new aggregated **Asset Detail** screen (added in LIVE-29722) was not reachable via deeplinks. This PR wires both `asset/:currencyId` and `market/:currencyId` deeplinks to that screen, gated by the Wallet 4.0 `aggregatedAssets` feature flag so that legacy behavior is preserved when the flag is OFF.

A new helper `handleAssetDetailDeeplink` (sibling to `handleMarketBannerDeeplink` and `handleWallet40Deeplink`) builds a navigation state targeting `Base > AssetDetail > AssetDetail` with `Main` at index 0 — guaranteeing that back navigation returns to the portfolio instead of exiting the app. The helper enforces a literal-union `source` type (`"deeplink_asset"` / `"deeplink_market"`) at the producer side, while the screen continues to accept any `source?: string`. The existing `TrackScreen` in `AssetDetailView` forwards the value to the screen-view event properties, and the generic `deeplink_clicked` event keeps firing from `getStateFromPath`.

**Routing table:**

| Deeplink | Flag `aggregatedAssets` ON | Flag OFF |
| --- | --- | --- |
| `asset/:currencyId` | New `AssetDetail` (source = `deeplink_asset`) | Legacy `WalletCentricAsset` |
| `asset/invalid-id` | Fallback → portfolio | Fallback → portfolio (unchanged) |
| `asset` (no segment) | Fallback → portfolio | No-op (unchanged) |
| `market/:currencyId` | New `AssetDetail` (source = `deeplink_market`) | Legacy `MarketDetail` |
| `market/invalid-id` | Fallback → market list (unchanged) | Fallback → market list (unchanged) |

### 🧪 Test cases

**Automated (Jest)** — 5 new tests in `handleAssetDetailDeeplink.test.ts`, all passing:

- Navigation shape
  - Returns navigation state targeting `AssetDetail` nested under `BaseNavigator`
  - Places `Main` at index 0 so back press returns to Main instead of exiting the app
- Params propagation
  - Forwards `currencyId` to the `AssetDetail` screen params
  - Forwards `source = "deeplink_asset"` to params for the asset hostname flow
  - Forwards `source = "deeplink_market"` to params for the market hostname flow

**Regression check** — `pnpm mobile test:jest \"navigation/deeplinks|features/AssetDetail\"` → **143/143 tests pass across 16 suites** (full deeplink suite + Asset Detail integration tests).

**Manual QA cases** (toggle the flag via Settings → Debug → Wallet 4.0 Features → `aggregatedAssets`):

| # | Command | Flag | Expected |
| --- | --- | --- | --- |
| 1 | `xcrun simctl openurl booted \"ledgerwallet://asset/bitcoin\"` | ON | Opens new AssetDetail; capsule shows BTC ticker + icon; screen-view event `Page Asset` fires with `source: \"deeplink_asset\"` |
| 2 | `xcrun simctl openurl booted \"ledgerlive://asset/bitcoin\"` | ON | Same as #1 (verifies the `ledgerlive://` prefix still resolves) |
| 3 | `xcrun simctl openurl booted \"ledgerwallet://asset/bitcoin\"` | OFF | Opens legacy `WalletCentricAsset` (no regression) |
| 4 | `xcrun simctl openurl booted \"ledgerwallet://asset/invalid-xyz\"` | ON | Graceful fallback → portfolio (no crash) |
| 5 | `xcrun simctl openurl booted \"ledgerwallet://asset\"` | ON | Graceful fallback → portfolio (no crash) |
| 6 | Open `ledgerwallet://asset/<currencyId>` for an asset with **no accounts** | ON | Opens AssetDetail in zero-accounts state (sections hidden per child VMs) |
| 7 | `xcrun simctl openurl booted \"ledgerwallet://market/bitcoin\"` | ON | Opens new AssetDetail with `source: \"deeplink_market\"` |
| 8 | `xcrun simctl openurl booted \"ledgerwallet://market/bitcoin\"` | OFF | Opens legacy `MarketDetail` (no regression) |
| 9 | `xcrun simctl openurl booted \"ledgerwallet://market/invalid-xyz\"` | ON | Graceful fallback → market list |
| 10 | Back press from AssetDetail (after #1 or #7) | ON | Returns to Portfolio (does not exit the app) |
| 11 | `adb shell am start -W -a android.intent.action.VIEW -d \"ledgerwallet://asset/bitcoin\" com.ledger.live.debug` | ON | Same as #1 on Android |
| 12 | Tracking inspector | ON | Generic `deeplink_clicked` fires from `getStateFromPath`; screen-view `Page Asset` carries `source` + `currency` |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29734](https://ledgerhq.atlassian.net/browse/LIVE-29734)
- **Depends on**: [LIVE-29722](https://ledgerhq.atlassian.net/browse/LIVE-29722) (route + params for the new Asset Detail screen) — already merged.
- **Related**: [LIVE-29733](https://ledgerhq.atlassian.net/browse/LIVE-29733) wires the in-app entry points from Market / Asset flows, using the same \`source\` route-param plumbing.

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29734]: https://ledgerhq.atlassian.net/browse/LIVE-29734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ