### PR TITLE
chore: generic awareness modal update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -326,6 +326,7 @@ apps/ledger-live-desktop/src/renderer/actions/dynamicContent.ts                 
 apps/ledger-live-desktop/src/types/dynamicContent.ts                                           @ledgerhq/engagement
 apps/ledger-live-desktop/src/braze-setup.ts                                                    @ledgerhq/engagement
 apps/ledger-live-desktop/src/mvvm/features/DynamicContent/                                     @ledgerhq/engagement
+apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/                              @ledgerhq/engagement
 apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/                                          @ledgerhq/engagement
 apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/                               @ledgerhq/engagement
 apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/                             @ledgerhq/engagement
@@ -361,6 +362,7 @@ apps/ledger-live-mobile/src/mvvm/features/WelcomePage/                          
 apps/ledger-live-mobile/src/mvvm/features/Onboarding/                                          @ledgerhq/engagement
 apps/ledger-live-mobile/src/mvvm/features/PostOnboardingHubDrawer/                             @ledgerhq/engagement
 apps/ledger-live-mobile/src/mvvm/features/DynamicContent/                                      @ledgerhq/engagement
+apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/                              @ledgerhq/engagement
 apps/ledger-live-mobile/src/mvvm/features/LandingPages/                                        @ledgerhq/engagement
 apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/                                 @ledgerhq/engagement
 apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/                              @ledgerhq/engagement
@@ -387,6 +389,7 @@ apps/ledger-live-mobile/src/screens/Settings/AnalyticsPreferencesSettings/      
 libs/ledger-live-common/src/braze/                                                             @ledgerhq/engagement
 libs/ledger-live-common/src/analyticsConsent/                                                  @ledgerhq/engagement
 libs/ledger-live-common/src/analytics/                                                         @ledgerhq/engagement
+libs/ledger-live-common/src/genericAwarenessModal/                                             @ledgerhq/engagement
 libs/ledger-live-common/src/onboarding/                                                        @ledgerhq/engagement
 libs/ledger-live-common/src/postOnboarding/                                                    @ledgerhq/engagement
 libs/ledger-live-common/src/transactionsAlerts/                                                @ledgerhq/engagement


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _Not needed: CODEOWNERS-only change._
- [ ] **Covered by automatic tests.** _Not applicable: ownership metadata only._
- [x] **Impact of the changes:**
  - Review routing for GenericAwarenessModal ownership across Desktop, Mobile, and live-common paths.

### 📝 Description

This PR updates `CODEOWNERS` so GenericAwarenessModal-related paths are owned by the Engagement team.

It covers:
- `apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/`
- `apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/`
- `libs/ledger-live-common/src/genericAwarenessModal/`

No runtime code, UI behavior, dependencies, or tests are changed.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28769](https://ledgerhq.atlassian.net/browse/LIVE-28769)
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-28769]: https://ledgerhq.atlassian.net/browse/LIVE-28769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ