### PR TITLE
[LWD] fix(desktop): render micro-cap fiat prices without truncation

### DIFF
--- a/.changeset/clever-chairs-refuse.md
+++ b/.changeset/clever-chairs-refuse.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix Market Price and Assets list displaying `0.00` for micro-cap tokens (e.g. `$0.00000591`). Introduce a reusable `fiatPriceFormat` helper that auto-picks `subMagnitude` / `disableRounding` so prices below 1 base unit keep up to 8 fractional digits, while standard prices still render with normal grouping.

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/useMarketPriceSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/useMarketPriceSectionViewModel.ts
@@ -2,11 +2,10 @@ import { useCallback, useMemo } from "react";
 import type { AssetDetailMarketInfo, AssetMarketData } from "@ledgerhq/asset-detail";
 import type { DistributionItem, ValueChange } from "@ledgerhq/types-live";
 import { KeysPriceChange } from "@ledgerhq/live-common/market/utils/types";
-import { formatCurrencyUnitFragment } from "@ledgerhq/live-common/currencies/index";
+import { fiatFloatToSmallestUnit, formatFiatPriceFragment } from "LLD/utils/fiatPriceFormat";
 import { useTrendViewModel } from "LLD/features/Portfolio/hooks/useTrendViewModel";
 import { useSelector } from "LLD/hooks/redux";
 import type { FormattedValue } from "@ledgerhq/lumen-ui-react";
-import { BigNumber } from "bignumber.js";
 import { useTranslation } from "react-i18next";
 import { counterValueCurrencySelector, localeSelector } from "~/renderer/reducers/settings";
 import {
@@ -67,11 +66,9 @@ export function useMarketPriceSectionViewModel({
 
   const priceFormatter = useCallback(
     (value: number): FormattedValue =>
-      formatCurrencyUnitFragment(fiatUnit, new BigNumber(value), {
+      formatFiatPriceFragment(fiatUnit, fiatFloatToSmallestUnit(fiatUnit, value), {
         locale,
         showCode: true,
-        disableRounding: true,
-        showAllDigits: true,
       }),
     [fiatUnit, locale],
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/components/Cells/PriceCell/__tests__/usePriceCellViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/components/Cells/PriceCell/__tests__/usePriceCellViewModel.test.ts
@@ -1,21 +1,21 @@
 import { renderHook } from "tests/testSetup";
 import { usePriceCellViewModel } from "../usePriceCellViewModel";
 import {
-  formatCurrencyUnit,
   getCryptoCurrencyById,
   getFiatCurrencyByTicker,
 } from "@ledgerhq/live-common/currencies/index";
+import { formatFiatPrice } from "LLD/utils/fiatPriceFormat";
 import { usePrice } from "~/renderer/hooks/usePrice";
 import { BigNumber } from "bignumber.js";
 
-jest.mock("@ledgerhq/live-common/currencies/index", () => ({
-  ...jest.requireActual("@ledgerhq/live-common/currencies/index"),
-  formatCurrencyUnit: jest.fn(),
+jest.mock("LLD/utils/fiatPriceFormat", () => ({
+  ...jest.requireActual("LLD/utils/fiatPriceFormat"),
+  formatFiatPrice: jest.fn(),
 }));
 
 jest.mock("~/renderer/hooks/usePrice");
 
-const mockedFormatCurrencyUnit = jest.mocked(formatCurrencyUnit);
+const mockedFormatFiatPrice = jest.mocked(formatFiatPrice);
 const mockedUsePrice = jest.mocked(usePrice);
 
 const mockCurrency = getCryptoCurrencyById("bitcoin");
@@ -34,7 +34,7 @@ describe("usePriceCellViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedUsePrice.mockReturnValue(mockUsePriceReturn(new BigNumber(50000)));
-    mockedFormatCurrencyUnit.mockReturnValue("$50,000.00");
+    mockedFormatFiatPrice.mockReturnValue("$50,000.00");
   });
 
   it("should return formatted price when counterValue is valid", () => {
@@ -49,69 +49,81 @@ describe("usePriceCellViewModel", () => {
     const { result } = renderHook(() => usePriceCellViewModel(mockCurrency));
 
     expect(result.current.formattedPrice).toBe("-");
-    expect(mockedFormatCurrencyUnit).not.toHaveBeenCalled();
+    expect(mockedFormatFiatPrice).not.toHaveBeenCalled();
   });
 
-  it("should use subMagnitude 0 and no disableRounding when price >= 1", () => {
+  it("delegates rounding policy to formatFiatPrice (high-value counterValue)", () => {
     renderHook(() => usePriceCellViewModel(mockCurrency));
 
-    expect(mockedFormatCurrencyUnit).toHaveBeenCalledWith(
+    expect(mockedFormatFiatPrice).toHaveBeenCalledWith(
       mockCounterValueCurrency.units[0],
       new BigNumber(50000),
-      { showCode: true, disableRounding: false, subMagnitude: 0 },
+      { showCode: true },
     );
   });
 
-  it("should use subMagnitude 1 and disableRounding when price < 1", () => {
+  it("delegates rounding policy to formatFiatPrice (sub-dollar counterValue)", () => {
     mockedUsePrice.mockReturnValue(mockUsePriceReturn(new BigNumber(0.5)));
 
     renderHook(() => usePriceCellViewModel(mockCurrency));
 
-    expect(mockedFormatCurrencyUnit).toHaveBeenCalledWith(
+    expect(mockedFormatFiatPrice).toHaveBeenCalledWith(
       mockCounterValueCurrency.units[0],
       new BigNumber(0.5),
-      { showCode: true, disableRounding: true, subMagnitude: 1 },
+      { showCode: true },
     );
   });
 
   it("should fall back to placeholderPrice (high value) when counterValue is undefined", () => {
     mockedUsePrice.mockReturnValue(mockUsePriceReturn(undefined));
-    mockedFormatCurrencyUnit.mockReturnValue("USD 43,000.00");
+    mockedFormatFiatPrice.mockReturnValue("USD 43,000.00");
 
     const { result } = renderHook(() => usePriceCellViewModel(mockCurrency, 43000));
 
     expect(result.current.formattedPrice).toBe("USD 43,000.00");
     const expectedValue = new BigNumber(43000).times(10 ** usdMagnitude);
-    expect(mockedFormatCurrencyUnit).toHaveBeenCalledWith(
+    expect(mockedFormatFiatPrice).toHaveBeenCalledWith(
       mockCounterValueCurrency.units[0],
       expectedValue,
-      { showCode: true, disableRounding: false, subMagnitude: 0 },
+      { showCode: true },
     );
   });
 
-  it("should fall back to placeholderPrice with subMagnitude for small values when counterValue is undefined", () => {
+  it("should fall back to placeholderPrice for small values when counterValue is undefined", () => {
     mockedUsePrice.mockReturnValue(mockUsePriceReturn(undefined));
-    mockedFormatCurrencyUnit.mockReturnValue("USD 0.07");
+    mockedFormatFiatPrice.mockReturnValue("USD 0.07");
 
     const { result } = renderHook(() => usePriceCellViewModel(mockCurrency, 0.07));
 
     expect(result.current.formattedPrice).toBe("USD 0.07");
     const expectedValue = new BigNumber(0.07).times(10 ** usdMagnitude);
-    expect(mockedFormatCurrencyUnit).toHaveBeenCalledWith(
+    expect(mockedFormatFiatPrice).toHaveBeenCalledWith(
       mockCounterValueCurrency.units[0],
       expectedValue,
-      { showCode: true, disableRounding: true, subMagnitude: 1 },
+      { showCode: true },
+    );
+  });
+
+  it("forwards micro-cap counterValues to formatFiatPrice (e.g. 0.000591 cents = $0.00000591)", () => {
+    mockedUsePrice.mockReturnValue(mockUsePriceReturn(new BigNumber(0.000591)));
+
+    renderHook(() => usePriceCellViewModel(mockCurrency));
+
+    expect(mockedFormatFiatPrice).toHaveBeenCalledWith(
+      mockCounterValueCurrency.units[0],
+      new BigNumber(0.000591),
+      { showCode: true },
     );
   });
 
   it("should use counterValue over placeholderPrice when both are available", () => {
     mockedUsePrice.mockReturnValue(mockUsePriceReturn(new BigNumber(50000)));
-    mockedFormatCurrencyUnit.mockReturnValue("$50,000.00");
+    mockedFormatFiatPrice.mockReturnValue("$50,000.00");
 
     const { result } = renderHook(() => usePriceCellViewModel(mockCurrency, 43000));
 
     expect(result.current.formattedPrice).toBe("$50,000.00");
-    expect(mockedFormatCurrencyUnit).toHaveBeenCalledWith(
+    expect(mockedFormatFiatPrice).toHaveBeenCalledWith(
       mockCounterValueCurrency.units[0],
       new BigNumber(50000),
       expect.objectContaining({ showCode: true }),

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/components/Cells/PriceCell/usePriceCellViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/components/Cells/PriceCell/usePriceCellViewModel.ts
@@ -1,28 +1,21 @@
-import { Currency, Unit } from "@ledgerhq/types-cryptoassets";
-import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
-import BigNumber from "bignumber.js";
+import { Currency } from "@ledgerhq/types-cryptoassets";
+import { fiatFloatToSmallestUnit, formatFiatPrice } from "LLD/utils/fiatPriceFormat";
 import { usePrice } from "~/renderer/hooks/usePrice";
-
-function formatPrice(unit: Unit, value: BigNumber): string {
-  const subMagnitude = value.lt(10 ** unit.magnitude) ? 1 : 0;
-  return formatCurrencyUnit(unit, value, {
-    showCode: true,
-    disableRounding: !!subMagnitude,
-    subMagnitude,
-  });
-}
 
 export function usePriceCellViewModel(currency: Currency, placeholderPrice?: number) {
   const { counterValue, counterValueCurrency } = usePrice(currency);
   const unit = counterValueCurrency.units[0];
 
   if (counterValue) {
-    return { formattedPrice: formatPrice(unit, counterValue) };
+    return { formattedPrice: formatFiatPrice(unit, counterValue, { showCode: true }) };
   }
 
   if (placeholderPrice != null) {
-    const value = new BigNumber(placeholderPrice).times(10 ** unit.magnitude);
-    return { formattedPrice: formatPrice(unit, value) };
+    return {
+      formattedPrice: formatFiatPrice(unit, fiatFloatToSmallestUnit(unit, placeholderPrice), {
+        showCode: true,
+      }),
+    };
   }
 
   return { formattedPrice: "-" };

--- a/apps/ledger-live-desktop/src/mvvm/utils/fiatPriceFormat.ts
+++ b/apps/ledger-live-desktop/src/mvvm/utils/fiatPriceFormat.ts
@@ -1,0 +1,72 @@
+import { BigNumber } from "bignumber.js";
+import type { Unit } from "@ledgerhq/types-cryptoassets";
+import {
+  formatCurrencyUnit,
+  formatCurrencyUnitFragment,
+  type formatCurrencyUnitOptions,
+  type FormatterValue,
+} from "@ledgerhq/live-common/currencies/index";
+
+// Total fractional digits allowed when rendering a sub-base-unit fiat price.
+// Enough to surface micro-cap prices like $0.00000591 without truncation.
+// `subMagnitude` is derived so that `magnitude + subMagnitude` never exceeds
+// this cap, regardless of the unit's magnitude.
+const SUB_BASE_UNIT_MAX_FRACTION_DIGITS = 8;
+
+type FiatPriceRoundingOptions = Required<
+  Pick<formatCurrencyUnitOptions, "subMagnitude" | "disableRounding">
+>;
+
+/**
+ * Pick `subMagnitude` / `disableRounding` so a fiat price held in its smallest
+ * unit (cents for USD, etc.) keeps its significant digits even when below 1
+ * base unit. Values >= 1 base unit fall back to the formatter's standard
+ * dynamic rounding.
+ */
+export const getFiatPriceFormatOptions = (
+  unit: Unit,
+  valueInSmallestUnit: BigNumber,
+): FiatPriceRoundingOptions => {
+  const isSubBaseUnit = valueInSmallestUnit.abs().lt(new BigNumber(10).pow(unit.magnitude));
+  if (!isSubBaseUnit) return { subMagnitude: 0, disableRounding: false };
+  const subMagnitude = Math.max(0, SUB_BASE_UNIT_MAX_FRACTION_DIGITS - unit.magnitude);
+  return { subMagnitude, disableRounding: true };
+};
+
+/**
+ * Convert a fiat price expressed as a float (e.g. `0.00000591` USD) to its
+ * smallest-unit BigNumber expected by `formatCurrencyUnit` /
+ * `formatCurrencyUnitFragment`.
+ */
+export const fiatFloatToSmallestUnit = (unit: Unit, floatPrice: BigNumber.Value): BigNumber =>
+  new BigNumber(floatPrice).times(new BigNumber(10).pow(unit.magnitude));
+
+type FormatFiatPriceOptions = Omit<formatCurrencyUnitOptions, "subMagnitude" | "disableRounding">;
+
+/**
+ * Format a fiat price (in smallest unit) as a string with sub-unit precision
+ * applied automatically for micro-cap values.
+ */
+export const formatFiatPrice = (
+  unit: Unit,
+  valueInSmallestUnit: BigNumber,
+  options: FormatFiatPriceOptions = {},
+): string =>
+  formatCurrencyUnit(unit, valueInSmallestUnit, {
+    ...options,
+    ...getFiatPriceFormatOptions(unit, valueInSmallestUnit),
+  });
+
+/**
+ * Fragment variant of {@link formatFiatPrice} for consumers that render
+ * fiat prices through `AmountDisplay` / other split-render components.
+ */
+export const formatFiatPriceFragment = (
+  unit: Unit,
+  valueInSmallestUnit: BigNumber,
+  options: FormatFiatPriceOptions = {},
+): FormatterValue =>
+  formatCurrencyUnitFragment(unit, valueInSmallestUnit, {
+    ...options,
+    ...getFiatPriceFormatOptions(unit, valueInSmallestUnit),
+  });

--- a/apps/ledger-live-desktop/src/mvvm/utils/tests/fiatPriceFormat.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/utils/tests/fiatPriceFormat.test.ts
@@ -1,0 +1,131 @@
+import { BigNumber } from "bignumber.js";
+import type { Unit } from "@ledgerhq/types-cryptoassets";
+import {
+  fiatFloatToSmallestUnit,
+  formatFiatPrice,
+  formatFiatPriceFragment,
+  getFiatPriceFormatOptions,
+} from "../fiatPriceFormat";
+
+const usdUnit: Unit = {
+  name: "US Dollar",
+  code: "USD",
+  magnitude: 2,
+  showAllDigits: false,
+  prefixCode: false,
+};
+
+const jpyUnit: Unit = {
+  name: "Japanese Yen",
+  code: "JPY",
+  magnitude: 0,
+  showAllDigits: false,
+  prefixCode: false,
+};
+
+describe("getFiatPriceFormatOptions", () => {
+  it("caps total fractional digits at 8 for sub-base-unit values (USD, magnitude 2)", () => {
+    expect(getFiatPriceFormatOptions(usdUnit, new BigNumber(99.99))).toEqual({
+      subMagnitude: 6,
+      disableRounding: true,
+    });
+    expect(getFiatPriceFormatOptions(usdUnit, new BigNumber(0.000591))).toEqual({
+      subMagnitude: 6,
+      disableRounding: true,
+    });
+  });
+
+  it("returns no extra precision when value >= 10^magnitude", () => {
+    expect(getFiatPriceFormatOptions(usdUnit, new BigNumber(100))).toEqual({
+      subMagnitude: 0,
+      disableRounding: false,
+    });
+    expect(getFiatPriceFormatOptions(usdUnit, new BigNumber(5_000_000))).toEqual({
+      subMagnitude: 0,
+      disableRounding: false,
+    });
+  });
+
+  it("treats negative sub-base-unit values the same as positive ones", () => {
+    expect(getFiatPriceFormatOptions(usdUnit, new BigNumber(-0.000591))).toEqual({
+      subMagnitude: 6,
+      disableRounding: true,
+    });
+    expect(getFiatPriceFormatOptions(usdUnit, new BigNumber(-100))).toEqual({
+      subMagnitude: 0,
+      disableRounding: false,
+    });
+  });
+
+  it("uses the full 8-digit budget for magnitude 0 units (e.g. JPY)", () => {
+    expect(getFiatPriceFormatOptions(jpyUnit, new BigNumber(0.5))).toEqual({
+      subMagnitude: 8,
+      disableRounding: true,
+    });
+    expect(getFiatPriceFormatOptions(jpyUnit, new BigNumber(1))).toEqual({
+      subMagnitude: 0,
+      disableRounding: false,
+    });
+  });
+});
+
+describe("fiatFloatToSmallestUnit", () => {
+  it("scales by 10^magnitude for USD", () => {
+    expect(fiatFloatToSmallestUnit(usdUnit, 0.00000591).toString()).toBe("0.000591");
+    expect(fiatFloatToSmallestUnit(usdUnit, 0.07).toString()).toBe("7");
+    expect(fiatFloatToSmallestUnit(usdUnit, 50000).toString()).toBe("5000000");
+  });
+
+  it("is a no-op for magnitude 0 units", () => {
+    expect(fiatFloatToSmallestUnit(jpyUnit, 12345).toString()).toBe("12345");
+  });
+
+  it("accepts string and BigNumber inputs", () => {
+    expect(fiatFloatToSmallestUnit(usdUnit, "0.5").toString()).toBe("50");
+    expect(fiatFloatToSmallestUnit(usdUnit, new BigNumber("0.5")).toString()).toBe("50");
+  });
+});
+
+describe("formatFiatPrice", () => {
+  it("renders micro-cap prices without truncation", () => {
+    expect(formatFiatPrice(usdUnit, new BigNumber(0.000591), { showCode: true })).toBe(
+      "0.00000591\u00A0USD",
+    );
+  });
+
+  it("strips trailing zeros for sub-cent prices", () => {
+    expect(formatFiatPrice(usdUnit, new BigNumber(7), { showCode: true })).toBe("0.07\u00A0USD");
+  });
+
+  it("renders standard prices with grouping and no extra digits", () => {
+    expect(formatFiatPrice(usdUnit, new BigNumber(5_000_000), { showCode: true })).toBe(
+      "50,000\u00A0USD",
+    );
+  });
+
+  it("forwards locale option", () => {
+    expect(
+      formatFiatPrice(usdUnit, new BigNumber(0.000591), { showCode: true, locale: "fr-FR" }),
+    ).toBe("0,00000591\u00A0USD");
+  });
+});
+
+describe("formatFiatPriceFragment", () => {
+  it("splits micro-cap prices into integer/decimal parts", () => {
+    const result = formatFiatPriceFragment(usdUnit, new BigNumber(0.000591), { showCode: true });
+    expect(result).toEqual({
+      integerPart: "0",
+      decimalPart: "00000591",
+      decimalSeparator: ".",
+      currencyText: "USD",
+      currencyPosition: "end",
+    });
+  });
+
+  it("omits the decimal part for round whole-unit prices", () => {
+    const result = formatFiatPriceFragment(usdUnit, new BigNumber(5_000_000), { showCode: true });
+    expect(result.integerPart).toBe("50,000");
+    expect(result.decimalPart).toBe("");
+    expect(result.currencyText).toBe("USD");
+  });
+});


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Asset Detail page — Market Price section rendering for micro-cap tokens (price < ~$0.01).
  - Assets list (Portfolio) — Price column for the same tokens.
  - Verify large-cap prices (BTC, ETH, …) still render with normal grouping and no extra trailing zeros.
  - Locale-specific formatting (en-US `.` separator, fr-FR `,` separator).
  - Different counter-value currencies (USD/EUR magnitude 2, JPY magnitude 0).

### Description

The Asset Detail Market Price section and the Assets list Price column were rendering `$0.00` for tokens with a price below ~$0.01 (e.g. Bonk, Pepe, Shiba Inu). The root cause was using `formatCurrencyUnit` / `formatCurrencyUnitFragment` with `subMagnitude: 0`, which caps the number of fractional digits at `unit.magnitude` (2 for USD) — anything smaller than a cent gets truncated.

**Fix.** Introduce a reusable helper `LLD/utils/fiatPriceFormat` exposing:

- `getFiatPriceFormatOptions(unit, valueInSmallestUnit)` — auto-picks `subMagnitude` / `disableRounding` so the total fractional digits stay capped at 8 for sub-base-unit values (`subMagnitude = max(0, 8 - magnitude)`), and fall back to the formatter's dynamic rounding for values ≥ 1 base unit.
- `fiatFloatToSmallestUnit(unit, floatPrice)` — convert a float price (e.g. CoinGecko `0.00000591`) to its smallest-unit `BigNumber`.
- `formatFiatPrice` / `formatFiatPriceFragment` — string and `FormattedValue` wrappers that apply the policy above.

Both call sites now delegate the rounding policy:

- `useMarketPriceSectionViewModel` uses `formatFiatPriceFragment` + `fiatFloatToSmallestUnit`.
- `usePriceCellViewModel` collapses to a single `formatFiatPrice` call (with `fiatFloatToSmallestUnit` for the placeholder branch).


https://github.com/user-attachments/assets/c3f7ceb6-b7b3-443b-845f-38071d9048bb


### Context

- **JIRA or GitHub link**: [LIVE-30673](https://ledgerhq.atlassian.net/browse/LIVE-30673)

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-30673]: https://ledgerhq.atlassian.net/browse/LIVE-30673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ