### PR TITLE
[LWM] fix(mobile): correct MyWallet top bar avatar size to match Figma design

### DIFF
--- a/.changeset/smooth-avatar-fix.md
+++ b/.changeset/smooth-avatar-fix.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix MyWallet top bar avatar size to match Figma design

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/components/MyWalletTopBarAction.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/components/MyWalletTopBarAction.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { UserAvatar } from "LLM/features/MyWallet/components/UserAvatar";
 import { Pressable } from "@ledgerhq/lumen-ui-rnative";
 import { Platform } from "react-native";
-import { useTheme, LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 
 type Props = {
   onPress: () => void;
@@ -10,7 +10,6 @@ type Props = {
 };
 
 export function MyWalletTopBarAction({ onPress, showNotification }: Readonly<Props>) {
-  const { theme } = useTheme();
   const isAndroid = Platform.OS === "android";
   const backgroundColor: LumenViewStyle["backgroundColor"] = isAndroid
     ? "muted"
@@ -21,16 +20,14 @@ export function MyWalletTopBarAction({ onPress, showNotification }: Readonly<Pro
     : "mutedTransparentPressed";
 
   return (
-    <Pressable
-      onPress={onPress}
-      testID="topbar-mywallet"
-      lx={{ borderRadius: "full" }}
-      accessibilityLabel="My Wallet"
-      style={({ pressed }) => ({
-        backgroundColor: pressed ? theme.colors.bg[pressedBackgroundColor] : undefined,
-      })}
-    >
-      <UserAvatar size="lg" lx={{ backgroundColor }} showNotification={showNotification} />
+    <Pressable onPress={onPress} testID="topbar-mywallet" accessibilityLabel="My Wallet">
+      {({ pressed }) => (
+        <UserAvatar
+          size="md"
+          lx={{ backgroundColor: pressed ? pressedBackgroundColor : backgroundColor }}
+          showNotification={showNotification}
+        />
+      )}
     </Pressable>
   );
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _UI-only change affecting avatar size and press interaction styling — visual verification required._
- [x] **Impact of the changes:**
      - MyWallet top bar avatar display size and background
      - Press interaction feedback on the avatar button
      - Visual alignment with Figma design specs

### 📝 Description

The MyWallet top bar avatar was incorrectly sized, not matching the Figma design specifications. The avatar container was using `size="lg"` with a separate Pressable background handling that created a visual disconnect.

**Fix**: Changed Avatar to `size="md"` (48px container with 4px padding, 40px image) which matches the Figma design exactly. Simplified the Pressable by using a render function for children, passing pressed state directly to the Avatar's `backgroundColor` token instead of layering backgrounds. Removed unused `useTheme` hook.


https://github.com/user-attachments/assets/7aa6955f-a977-42ae-ba1e-cc8d07a4cd03


### ❓ Context

- **JIRA or GitHub link**: [LIVE-30672](https://ledgerhq.atlassian.net/browse/LIVE-30672)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30672]: https://ledgerhq.atlassian.net/browse/LIVE-30672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ