### PR TITLE
[LWDM] chore(live-common): prep async getAccountBridge in send amount review

### DIFF
--- a/.changeset/prep-async-send-amount-review.md
+++ b/.changeset/prep-async-send-amount-review.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Prep useSendFlowAmountReviewCore for async getAccountBridge.

--- a/libs/ledger-live-common/src/flows/send/coinControl/hooks/__tests__/useCoinControlScreenViewModelCore.test.ts
+++ b/libs/ledger-live-common/src/flows/send/coinControl/hooks/__tests__/useCoinControlScreenViewModelCore.test.ts
@@ -343,7 +343,7 @@ describe("useCoinControlScreenViewModelCore", () => {
       },
     };
 
-    it("calls buildToggleRowExclusionPatch with transaction, rowKey, and displayData then updateTransaction when custom strategy and config exist", () => {
+    it("calls buildToggleRowExclusionPatch with transaction, rowKey, and displayData then updateTransaction when custom strategy and config exist", async () => {
       const transaction = customTransaction(new BigNumber(1000));
       const displayData = displayDataForCustomRows([row("tx1", 0, false)]);
       const buildToggleRowExclusionPatch = jest.fn().mockReturnValue(togglePatch);
@@ -363,6 +363,7 @@ describe("useCoinControlScreenViewModelCore", () => {
         rowKey,
         displayData,
       });
+      await Promise.resolve();
       expect(updateTransaction).toHaveBeenCalledTimes(1);
     });
 

--- a/libs/ledger-live-common/src/flows/send/hooks/__tests__/useSendFlowAmountReviewCore.test.ts
+++ b/libs/ledger-live-common/src/flows/send/hooks/__tests__/useSendFlowAmountReviewCore.test.ts
@@ -88,7 +88,7 @@ describe("useSendFlowAmountReviewCore", () => {
     expect(result.current.accountCurrency).toBeDefined();
   });
 
-  it("calls updateTransaction when updateTransactionWithPatch is invoked", () => {
+  it("calls updateTransaction when updateTransactionWithPatch is invoked", async () => {
     const account = createAccount();
     const transaction = createTransaction();
     const updateTransaction = jest.fn((fn: (tx: Transaction) => Transaction) => fn(transaction));
@@ -104,7 +104,7 @@ describe("useSendFlowAmountReviewCore", () => {
       }),
     );
 
-    result.current.updateTransactionWithPatch({ amount: new BigNumber(200) });
+    await result.current.updateTransactionWithPatch({ amount: new BigNumber(200) });
     expect(updateTransaction).toHaveBeenCalledTimes(1);
     const updater = updateTransaction.mock.calls[0][0];
     const nextTx = updater(transaction);

--- a/libs/ledger-live-common/src/flows/send/hooks/useSendFlowAmountReviewCore.ts
+++ b/libs/ledger-live-common/src/flows/send/hooks/useSendFlowAmountReviewCore.ts
@@ -57,11 +57,9 @@ export function useSendFlowAmountReviewCore({
   const accountCurrency = useMemo(() => getAccountCurrency(mainAccount), [mainAccount]);
 
   const updateTransactionWithPatch = useCallback(
-    (patch: Partial<Transaction>) => {
-      transactionActions.updateTransaction(currentTx => {
-        const bridge = getAccountBridge(account, parentAccount ?? undefined);
-        return bridge.updateTransaction(currentTx, patch);
-      });
+    async (patch: Partial<Transaction>) => {
+      const bridge = await getAccountBridge(account, parentAccount ?? undefined);
+      transactionActions.updateTransaction(currentTx => bridge.updateTransaction(currentTx, patch));
     },
     [account, parentAccount, transactionActions],
   );


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [ ] **Impact of the changes:**
  - Send flow on Desktop & Mobile — amount review and coin-control screens. No behavior change; `updateTransactionWithPatch` becomes microtask-deferred.

### 📝 Description

Migrate `useSendFlowAmountReviewCore.updateTransactionWithPatch` to `await getAccountBridge`, so it stays correct once `getAccountBridge` becomes async. Public signature unchanged.

### ❓ Context

- **JIRA or GitHub link**: follow-up / partial reboot of #17155 (see last comment on that PR)
- **ADR link (if any)**: n/a