### PR TITLE
[LWM] feat(live-mobile): add PnlCard shared component (LIVE-30302)

### DIFF
--- a/.changeset/pnl-card-shared-component.md
+++ b/.changeset/pnl-card-shared-component.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add PnlCard shared component under `src/mvvm/features/Pnl` with interactive (trend + chevron) and info (ⓘ icon) variants, gated by `shouldDisplayPnl` and respecting discreet mode.

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/__integrations__/pnlCard.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/__integrations__/pnlCard.integration.test.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { render, screen, withFlagOverrides } from "@tests/test-renderer";
+import { State } from "~/reducers/types";
+import { PnlCard } from "../components/PnlCard";
+
+const TITLE = "Unrealised return";
+const VALUE = "$243.32";
+
+const withPnl = (enabled: boolean) =>
+  withFlagOverrides({ lwmWallet40: { enabled: true, params: { pnl: enabled } } });
+
+const withDiscreet =
+  (discreetMode: boolean) =>
+  (state: State): State => ({
+    ...state,
+    settings: { ...state.settings, discreetMode },
+  });
+
+const compose =
+  (...transforms: Array<(state: State) => State>) =>
+  (state: State): State =>
+    transforms.reduce((acc, t) => t(acc), state);
+
+describe("PnlCard integration", () => {
+  describe("feature flag gating", () => {
+    it("renders the interactive card when shouldDisplayPnl is true", () => {
+      render(
+        <PnlCard type="interactive" title={TITLE} value={VALUE} trend="up" onPress={jest.fn()} />,
+        { overrideInitialState: withPnl(true) },
+      );
+
+      expect(screen.getByText(TITLE)).toBeOnTheScreen();
+      expect(screen.getByText(VALUE)).toBeOnTheScreen();
+    });
+
+    it("renders nothing when shouldDisplayPnl is false", () => {
+      render(
+        <PnlCard type="interactive" title={TITLE} value={VALUE} trend="up" onPress={jest.fn()} />,
+        { overrideInitialState: withPnl(false) },
+      );
+
+      expect(screen.queryByText(TITLE)).toBeNull();
+      expect(screen.queryByText(VALUE)).toBeNull();
+    });
+  });
+
+  describe("interactive variant", () => {
+    it("calls onPress when the card is pressed", async () => {
+      const onPress = jest.fn();
+      const { user } = render(
+        <PnlCard
+          type="interactive"
+          title={TITLE}
+          value={VALUE}
+          trend="up"
+          onPress={onPress}
+          testID="pnl-card"
+        />,
+        { overrideInitialState: withPnl(true) },
+      );
+
+      await user.press(screen.getByTestId("pnl-card"));
+
+      expect(onPress).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("info variant", () => {
+    it("renders without onPress and with the info icon", () => {
+      render(<PnlCard type="info" title="Cost basis" value="$2.21" />, {
+        overrideInitialState: withPnl(true),
+      });
+
+      expect(screen.getByText("Cost basis")).toBeOnTheScreen();
+      expect(screen.getByText("$2.21")).toBeOnTheScreen();
+    });
+  });
+
+  describe("discreet mode", () => {
+    it("hides the value when discreet mode is on", () => {
+      render(
+        <PnlCard type="interactive" title={TITLE} value={VALUE} trend="up" onPress={jest.fn()} />,
+        { overrideInitialState: compose(withPnl(true), withDiscreet(true)) },
+      );
+
+      expect(screen.getByText("***")).toBeOnTheScreen();
+      expect(screen.queryByText(VALUE)).toBeNull();
+    });
+
+    it("shows the value when discreet mode is off", () => {
+      render(
+        <PnlCard type="interactive" title={TITLE} value={VALUE} trend="up" onPress={jest.fn()} />,
+        { overrideInitialState: compose(withPnl(true), withDiscreet(false)) },
+      );
+
+      expect(screen.getByText(VALUE)).toBeOnTheScreen();
+      expect(screen.queryByText("***")).toBeNull();
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlCard/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlCard/index.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import {
+  Box,
+  Card,
+  CardContent,
+  CardHeader,
+  CardLeading,
+  CardTrailing,
+  Text,
+} from "@ledgerhq/lumen-ui-rnative";
+import { ChevronRight, Information } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { PnlCardProps } from "./types";
+import { usePnlCardViewModel } from "./usePnlCardViewModel";
+
+export function PnlCard(props: Readonly<PnlCardProps>) {
+  const {
+    shouldRender,
+    title,
+    displayedValue,
+    cardType,
+    showInfoIcon,
+    showChevron,
+    TrendIcon,
+    trendColor,
+    onPress,
+    testID,
+  } = usePnlCardViewModel(props);
+
+  if (!shouldRender) return null;
+
+  return (
+    <Card type={cardType} onPress={onPress} testID={testID}>
+      <CardHeader>
+        <CardLeading>
+          <CardContent>
+            <Box lx={{ flexDirection: "row", alignItems: "center", gap: "s4" }}>
+              <Text typography="body3" lx={{ color: "muted" }}>
+                {title}
+              </Text>
+              {showInfoIcon ? <Information size={16} color="muted" /> : null}
+            </Box>
+            <Box lx={{ flexDirection: "row", alignItems: "center", gap: "s4" }}>
+              {TrendIcon ? <TrendIcon size={16} color={trendColor} /> : null}
+              <Text typography="body2SemiBold" lx={{ color: "base" }}>
+                {displayedValue}
+              </Text>
+            </Box>
+          </CardContent>
+        </CardLeading>
+        {showChevron ? (
+          <CardTrailing>
+            <ChevronRight size={20} color="muted" />
+          </CardTrailing>
+        ) : null}
+      </CardHeader>
+    </Card>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlCard/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlCard/types.ts
@@ -1,0 +1,16 @@
+type InteractivePnlCardProps = {
+  type: "interactive";
+  trend: "up" | "down" | "neutral";
+  onPress: () => void;
+};
+
+type InfoPnlCardProps = {
+  type: "info";
+  onPress?: () => void;
+};
+
+export type PnlCardProps = {
+  title: string;
+  value: string;
+  testID?: string;
+} & (InteractivePnlCardProps | InfoPnlCardProps);

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlCard/usePnlCardViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlCard/usePnlCardViewModel.ts
@@ -1,0 +1,57 @@
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { TriangleDown, TriangleUp } from "@ledgerhq/lumen-ui-rnative/symbols";
+import type { LumenTextStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import type { CardType } from "@ledgerhq/lumen-ui-rnative";
+import { useSelector } from "~/context/hooks";
+import { discreetModeSelector } from "~/reducers/settings";
+import { PnlCardProps } from "./types";
+
+const DISCREET_PLACEHOLDER = "***";
+
+const TREND_ICON = {
+  up: TriangleUp,
+  down: TriangleDown,
+  neutral: undefined,
+} as const;
+
+const TREND_COLOR: Record<"up" | "down" | "neutral", LumenTextStyle["color"]> = {
+  up: "success",
+  down: "error",
+  neutral: "muted",
+};
+
+export type PnlCardViewModel = {
+  shouldRender: boolean;
+  title: string;
+  displayedValue: string;
+  cardType: CardType;
+  showInfoIcon: boolean;
+  showChevron: boolean;
+  TrendIcon?: typeof TriangleUp;
+  trendColor?: LumenTextStyle["color"];
+  onPress?: () => void;
+  testID?: string;
+};
+
+export function usePnlCardViewModel(props: PnlCardProps): PnlCardViewModel {
+  const { shouldDisplayPnl } = useWalletFeaturesConfig("mobile");
+  const discreet = useSelector(discreetModeSelector);
+  const displayedValue = discreet ? DISCREET_PLACEHOLDER : props.value;
+
+  const isInteractive = props.type === "interactive";
+  const onPress = props.onPress;
+  const cardType: CardType = onPress ? "interactive" : "info";
+
+  return {
+    shouldRender: shouldDisplayPnl,
+    title: props.title,
+    displayedValue,
+    cardType,
+    showInfoIcon: props.type === "info",
+    showChevron: isInteractive,
+    TrendIcon: isInteractive ? TREND_ICON[props.trend] : undefined,
+    trendColor: isInteractive ? TREND_COLOR[props.trend] : undefined,
+    onPress,
+    testID: props.testID,
+  };
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Adds a brand-new shared component under `apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlCard/`. Not rendered anywhere yet, so no visible impact for users on this PR. QA should focus on this component once it lands in a screen (LIVE-30305).
  - Visibility gated by `shouldDisplayPnl` from `useWalletFeaturesConfig("mobile")` — when the `pnl` param of `lwmWallet40` is off, the component returns `null`.

### 📝 Description

Adds the reusable `PnlCard` shared component for the Wallet 4.0 Analytics screen. The card is built on Lumen RN's `Card`, follows the MVVM split (View + ViewModel) used across `src/mvvm/`, and supports two discriminated variants:

- `type="interactive"` — trend triangle prefix (up/down/neutral), required `onPress`, chevron-right in trailing.
- `type="info"` — `ⓘ` icon next to the title, optional `onPress`, no chevron.

The ViewModel resolves the card type, trend icon/color, info-icon visibility and chevron visibility, so the View only destructures. The displayed value is masked with `***` when discreet mode is on (Redux `discreetModeSelector`).

An integration test under `__integrations__/pnlCard.integration.test.tsx` covers feature-flag gating, interactive vs info rendering, the `onPress` callback and the discreet-mode masking.

Demo (nothing displayed yet):

<img height="600" alt="image" src="https://github.com/user-attachments/assets/045f581a-c0af-4aca-b87c-d128c5345351" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-30302](https://ledgerhq.atlassian.net/browse/LIVE-30302)
- **ADR link (if any)**: _N/A_

> This is the bottom of a 3-PR stack: this PR → #17531 → #17532.

[LIVE-30302]: https://ledgerhq.atlassian.net/browse/LIVE-30302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ