### PR TITLE
[LWM] feat(live-mobile): add PnlDetailDrawer shared component (LIVE-30303)

### DIFF
--- a/.changeset/pnl-detail-drawer-shared-component.md
+++ b/.changeset/pnl-detail-drawer-shared-component.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add PnlDetailDrawer shared component under `src/mvvm/features/Pnl`, a Lumen bottom sheet that displays per-asset or portfolio PnL detail rows (title, value, optional definition) and respects discreet mode. Items prop is optional, so the drawer can also be used as a header-only info drawer.

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/__integrations__/pnlDetailDrawer.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/__integrations__/pnlDetailDrawer.integration.test.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import { State } from "~/reducers/types";
+import { PnlDetailDrawer } from "../components/PnlDetailDrawer";
+import { PnlDetailItem } from "../components/PnlDetailDrawer/types";
+
+const TITLE = "Profit & Loss";
+const DESCRIPTION = "Lifetime metrics for your portfolio.";
+
+const ITEMS: PnlDetailItem[] = [
+  {
+    title: "Total return",
+    value: "$1,200.00 USD",
+    definition: "Realised + unrealised gains since first inflow.",
+  },
+  {
+    title: "Unrealised return",
+    value: "$900.00 USD",
+    definition: "Mark-to-market on coins you still hold.",
+  },
+  {
+    title: "Realised return",
+    value: "$300.00 USD",
+    definition: "Gains booked through past sells.",
+  },
+];
+
+const withDiscreet =
+  (discreetMode: boolean) =>
+  (state: State): State => ({
+    ...state,
+    settings: { ...state.settings, discreetMode },
+  });
+
+describe("PnlDetailDrawer integration", () => {
+  it("renders the header and every detail row when open", () => {
+    render(
+      <PnlDetailDrawer
+        isOpen
+        onClose={jest.fn()}
+        title={TITLE}
+        description={DESCRIPTION}
+        items={ITEMS}
+      />,
+    );
+
+    expect(screen.getByText(TITLE)).toBeOnTheScreen();
+    expect(screen.getByText(DESCRIPTION)).toBeOnTheScreen();
+    for (const item of ITEMS) {
+      expect(screen.getByText(item.title)).toBeOnTheScreen();
+      expect(screen.getByText(item.value)).toBeOnTheScreen();
+      if (item.definition) {
+        expect(screen.getByText(item.definition)).toBeOnTheScreen();
+      }
+    }
+  });
+
+  it("masks every value when discreet mode is on", () => {
+    render(<PnlDetailDrawer isOpen onClose={jest.fn()} title={TITLE} items={ITEMS} />, {
+      overrideInitialState: withDiscreet(true),
+    });
+
+    expect(screen.getAllByText("***")).toHaveLength(ITEMS.length);
+    for (const item of ITEMS) {
+      expect(screen.queryByText(item.value)).toBeNull();
+    }
+  });
+
+  it("shows real values when discreet mode is off", () => {
+    render(<PnlDetailDrawer isOpen onClose={jest.fn()} title={TITLE} items={ITEMS} />, {
+      overrideInitialState: withDiscreet(false),
+    });
+
+    for (const item of ITEMS) {
+      expect(screen.getByText(item.value)).toBeOnTheScreen();
+    }
+    expect(screen.queryByText("***")).toBeNull();
+  });
+
+  it("renders bodyText below the header for header-only drawers", () => {
+    const BODY = "The total amount you paid to acquire your current holdings, including fees.";
+    render(<PnlDetailDrawer isOpen onClose={jest.fn()} title="Cost basis" bodyText={BODY} />);
+
+    expect(screen.getByText("Cost basis")).toBeOnTheScreen();
+    expect(screen.getByText(BODY)).toBeOnTheScreen();
+  });
+
+  it("renders rows without a definition", () => {
+    const ITEMS_WITHOUT_DEFINITION: PnlDetailItem[] = [
+      { title: "Bare row", value: "$50.00 USD" },
+    ];
+    render(
+      <PnlDetailDrawer
+        isOpen
+        onClose={jest.fn()}
+        title={TITLE}
+        items={ITEMS_WITHOUT_DEFINITION}
+      />,
+    );
+
+    expect(screen.getByText("Bare row")).toBeOnTheScreen();
+    expect(screen.getByText("$50.00 USD")).toBeOnTheScreen();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlDetailDrawer/PnlDetailRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlDetailDrawer/PnlDetailRow.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
+import { PnlDetailItem } from "./types";
+
+type Props = Readonly<{ item: PnlDetailItem }>;
+
+export function PnlDetailRow({ item }: Props) {
+  return (
+    <Box
+      lx={{ flexDirection: "row", alignItems: "flex-start", gap: "s16" }}
+      testID={`pnl-detail-row-${item.title}`}
+    >
+      <Box lx={{ flex: 1, gap: "s4" }}>
+        <Text typography="body2SemiBold" lx={{ color: "base" }}>
+          {item.title}
+        </Text>
+        {item.definition ? (
+          <Text typography="body3" lx={{ color: "muted" }}>
+            {item.definition}
+          </Text>
+        ) : null}
+      </Box>
+      <Text typography="body2SemiBold" lx={{ color: "base" }}>
+        {item.value}
+      </Text>
+    </Box>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlDetailDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlDetailDrawer/index.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Box, BottomSheetHeader, BottomSheetView, Text } from "@ledgerhq/lumen-ui-rnative";
+import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
+import { PnlDetailDrawerProps } from "./types";
+import { usePnlDetailDrawerViewModel } from "./usePnlDetailDrawerViewModel";
+import { PnlDetailRow } from "./PnlDetailRow";
+
+export function PnlDetailDrawer(props: Readonly<PnlDetailDrawerProps>) {
+  const { isOpen, onClose, title, description, bodyText, items, testID } =
+    usePnlDetailDrawerViewModel(props);
+  const { bottom: bottomInset } = useSafeAreaInsets();
+
+  return (
+    <QueuedDrawerBottomSheet
+      testID={testID}
+      isRequestingToBeOpened={isOpen}
+      enableDynamicSizing
+      onClose={onClose}
+    >
+      <BottomSheetView style={{ paddingBottom: bottomInset + 24 }}>
+        <BottomSheetHeader density="expanded" title={title} description={description} />
+        {bodyText ? (
+          <Text typography="body1" lx={{ color: "base", marginBottom: "s16" }}>
+            {bodyText}
+          </Text>
+        ) : null}
+        <Box lx={{ gap: "s16" }}>
+          {items.map(item => (
+            <PnlDetailRow key={item.title} item={item} />
+          ))}
+        </Box>
+      </BottomSheetView>
+    </QueuedDrawerBottomSheet>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlDetailDrawer/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlDetailDrawer/types.ts
@@ -1,0 +1,17 @@
+export type PnlDetailItem = {
+  title: string;
+  value: string;
+  definition?: string;
+};
+
+export type PnlDetailDrawerProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  /** Short subtitle rendered inside the BottomSheetHeader (body2, muted). */
+  description?: string;
+  /** Longer body text rendered inside the BottomSheetView (body1, base color). */
+  bodyText?: string;
+  items?: PnlDetailItem[];
+  testID?: string;
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlDetailDrawer/usePnlDetailDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlDetailDrawer/usePnlDetailDrawerViewModel.ts
@@ -1,0 +1,37 @@
+import { useSelector } from "~/context/hooks";
+import { discreetModeSelector } from "~/reducers/settings";
+import { PnlDetailDrawerProps, PnlDetailItem } from "./types";
+
+const DISCREET_PLACEHOLDER = "***";
+
+export type PnlDetailDrawerViewModel = Omit<PnlDetailDrawerProps, "items"> & {
+  discreet: boolean;
+  items: PnlDetailItem[];
+};
+
+export function usePnlDetailDrawerViewModel({
+  isOpen,
+  onClose,
+  title,
+  description,
+  bodyText,
+  items = [],
+  testID,
+}: PnlDetailDrawerProps): PnlDetailDrawerViewModel {
+  const discreet = useSelector(discreetModeSelector);
+
+  const displayedItems: PnlDetailItem[] = discreet
+    ? items.map(item => ({ ...item, value: DISCREET_PLACEHOLDER }))
+    : items;
+
+  return {
+    isOpen,
+    onClose,
+    title,
+    description,
+    bodyText,
+    items: displayedItems,
+    discreet,
+    testID,
+  };
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Adds a brand-new shared component under `apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlDetailDrawer/`. Not opened from anywhere yet, so no visible impact for users on this PR alone — QA can wait until LIVE-30305 wires it into the Analytics screen.
  - The bottom sheet uses `QueuedDrawerBottomSheet`, which already participates in the global drawer queue, so it interacts correctly with any other drawer flow.

### 📝 Description

Adds the reusable `PnlDetailDrawer` shared component for the Wallet 4.0 Analytics screen. The drawer is built on `QueuedDrawerBottomSheet` + Lumen RN's `BottomSheetView` / `BottomSheetHeader`, follows the MVVM split (View + ViewModel) and is reused for both the per-asset and portfolio-level PnL summaries.

- Renders a list of items (title, value, optional definition). \`items\` is **optional**, so the same drawer can serve as a header-only info drawer (used by the Cost basis card on LIVE-30305).
- Bottom padding follows the convention used by the other QueuedDrawerBottomSheets in the codebase (`paddingBottom: bottomInset + 24` via `useSafeAreaInsets()`).
- Values are masked with `***` when discreet mode is on.

<img  height="600" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-05-18 at 13 25 27" src="https://github.com/user-attachments/assets/d6243ec9-8f54-4fe8-a64b-f280f5a548d6" />

<img height="600" alt="image" src="https://github.com/user-attachments/assets/e18c974f-d7da-495f-a4f5-0c3d7552210c" />


An integration test under \`__integrations__/pnlDetailDrawer.integration.test.tsx\` covers header + rows rendering, discreet-mode masking on every row and pass-through when discreet mode is off.



### ❓ Context

- **JIRA or GitHub link**: [LIVE-30303](https://ledgerhq.atlassian.net/browse/LIVE-30303)
- **ADR link (if any)**: _N/A_

> Stacked on top of #17530 — please merge that one first. Followed by #17532.

[LIVE-30303]: https://ledgerhq.atlassian.net/browse/LIVE-30303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ