### PR TITLE
chore(wallet-cli): clarify --help text and remove internal jargon

### DIFF
--- a/.agents/skills/ledger-wallet-cli/SKILL.md
+++ b/.agents/skills/ledger-wallet-cli/SKILL.md
@@ -41,7 +41,7 @@ Run from repo root: `pnpm --silent wallet-cli start <command> [flags]`
 
 `account discover` persists accounts. Each gets a label: `<network>[-derivation][-env]-<n>` (e.g. `ethereum-1`, `bitcoin-native-1`, `ethereum-goerli-2`).
 
-All `--account` flags accept a label or a full descriptor.
+All `--account` flags accept a session label (e.g. `ethereum-1`). Run `account discover` first to populate the session.
 
 ---
 
@@ -108,7 +108,7 @@ Fetches quotes in parallel from the built-in provider list (no device when addre
 
 **Default providers queried by `swap quote` and usable by `swap execute`:** `changelly`, `cic`, `exodus`, `nearintents`, `swapsxyz`.
 
-**Addresses (pick one per side):** `--from-fresh-address` or `--from-account`; `--to-fresh-address` or `--to-account`. Account flags accept a session label or descriptor; the CLI resolves a fresh receive address like `receive`.
+**Addresses (pick one per side):** `--from-fresh-address` or `--from-account`; `--to-fresh-address` or `--to-account`. Account flags accept a session label only; the CLI resolves a fresh receive address like `receive`.
 
 ```bash
 pnpm --silent wallet-cli start swap quote --from ethereum --to bitcoin --amount 0.1 --from-fresh-address 0xABC... --to-fresh-address bc1q...

--- a/apps/wallet-cli/README.md
+++ b/apps/wallet-cli/README.md
@@ -14,14 +14,15 @@ wallet-cli is **not production-ready**. Behavior and flags may change without no
 
 | Command | Role |
 | -------- | ---- |
-| `account discover` | Discover accounts for a currency on the **connected Ledger** (USB). Outputs short **account descriptors** (human table or `--output json`). |
-| `balances` | Given an account descriptor from discovery, fetch **native and token balances**. **No device** required. |
-| `operations` | Given an account descriptor, **list operations**. **No device** required. For Alpaca-backed families, optional pagination via `--limit` and `--cursor`. |
+| `account discover` | Discover accounts for a currency on the **connected Ledger** (USB). Each discovered account is saved to the session under a **label** (e.g. `ethereum-1`). |
+| `session view` / `session reset` | List or wipe accounts stored in the session. |
+| `balances` | Fetch **native and token balances** for an account (by session label). **No device** required. |
+| `operations` | **List operations** for an account (by session label). **No device** required. Optional pagination via `--limit` and `--cursor`. |
 | `send` | Sign and broadcast a transaction. Requires `--amount` with ticker (e.g. `0.001 BTC`, `0.01 ETH`). Use `--dry-run` to validate without signing. |
 | `receive` | Get the receive address for an account (optionally verify on device). |
 | `swap execute` | Execute the full swap flow with `--provider` and `--amount`: prepare the swap, interact with the connected device as needed, complete the exchange, then sign and broadcast the transaction. |
 
-Typical flow: run `account discover` with a currency id (e.g. `bitcoin`, `ethereum`), then pass the printed descriptor to `balances`, `operations`, or `send`.
+Typical flow: run `account discover` with a currency id (e.g. `bitcoin`, `ethereum`), then pass the assigned **session label** (e.g. `--account ethereum-1`) to `balances`, `operations`, `send`, or `receive`. Use `session view` to see what's saved.
 
 For exact flags and defaults (from repo root):
 

--- a/apps/wallet-cli/src/commands/account/discover.ts
+++ b/apps/wallet-cli/src/commands/account/discover.ts
@@ -54,7 +54,8 @@ async function discoverAccounts({
 
 export default defineCommand({
   name: "discover",
-  description: "Discover accounts for a network on the connected device",
+  description:
+    "Discover accounts for a network on the connected device (saves each to the session as --account <label>, e.g. ethereum-1).",
   options: {
     network: option(z.string().min(1).optional(), {
       description:

--- a/apps/wallet-cli/src/commands/balances.ts
+++ b/apps/wallet-cli/src/commands/balances.ts
@@ -13,7 +13,7 @@ import {
 
 export default defineCommand({
   name: "balances",
-  description: "Fetch native and token balances for an account descriptor (no device required)",
+  description: "Fetch native and token balances for an account (no device required)",
   options: {
     account: accountOption,
     output: outputOption,

--- a/apps/wallet-cli/src/commands/operations.ts
+++ b/apps/wallet-cli/src/commands/operations.ts
@@ -14,16 +14,15 @@ import {
 
 export default defineCommand({
   name: "operations",
-  description: "List operations for an account descriptor (no device required)",
+  description: "List operations for an account (no device required)",
   options: {
     account: accountOption,
     limit: option(z.coerce.number().int().min(1).optional(), {
-      description: "Max number of operations to return (coin-framework families only)",
+      description: "Max number of operations to return",
       short: "l",
     }),
     cursor: option(z.string().min(1).optional(), {
-      description:
-        "Pagination cursor from a previous call's nextCursor (coin-framework families only)",
+      description: "Pagination cursor from a previous call's nextCursor",
     }),
     output: outputOption,
   },

--- a/apps/wallet-cli/src/commands/send.ts
+++ b/apps/wallet-cli/src/commands/send.ts
@@ -145,7 +145,7 @@ async function runLiveSend({
 
 export default defineCommand({
   name: "send",
-  description: "Sign and broadcast a transaction (bridge only, no coin-framework)",
+  description: "Sign and broadcast a transaction",
   options: {
     account: accountOption,
     to: option(z.string().min(1, "Recipient address is required (--to <address>)"), {

--- a/apps/wallet-cli/src/commands/swap/execute.ts
+++ b/apps/wallet-cli/src/commands/swap/execute.ts
@@ -128,7 +128,7 @@ export async function executeSwapCommand({
 
     const toAccountArg = flags["to-account"];
     if (typeof toAccountArg !== "string" || toAccountArg.trim().length === 0) {
-      throw new Error("Swap execute requires --to-account <descriptor-or-label>.");
+      throw new Error("Swap execute requires --to-account <session-label>.");
     }
     const toDescriptor = await resolveDescriptor(toAccountArg);
 
@@ -199,7 +199,7 @@ export default defineCommand({
       description: "Swap source amount in human units",
     }),
     "to-account": option(swapExecuteFlagsSchema.shape["to-account"], {
-      description: "Destination account descriptor or session label (required for full pipeline)",
+      description: "Destination account session label (required for full pipeline)",
     }),
     account: accountOption,
     "fee-strategy": option(swapExecuteFlagsSchema.shape["fee-strategy"], {

--- a/apps/wallet-cli/src/commands/swap/quote.ts
+++ b/apps/wallet-cli/src/commands/swap/quote.ts
@@ -73,17 +73,17 @@ export default defineCommand({
       short: "t",
     }),
     "from-fresh-address": option(z.string().min(1).optional(), {
-      description: "Source account fresh receive address is required",
+      description: "Source account fresh receive address (alternative to --from-account)",
     }),
     "to-fresh-address": option(z.string().min(1).optional(), {
-      description: "Destination account fresh receive address is required",
+      description: "Destination account fresh receive address (alternative to --to-account)",
     }),
     "from-account": option(z.string().min(1).optional(), {
-      description: "Source account descriptor or session label (used to resolve fresh address)",
+      description: "Source account session label (used to resolve fresh address)",
     }),
     "to-account": option(z.string().min(1).optional(), {
       description:
-        "Destination account descriptor or session label (used to resolve fresh address)",
+        "Destination account session label (used to resolve fresh address)",
     }),
     amount: option(z.string().min(1, "Amount is required"), {
       description: "Amount to swap in source currency",


### PR DESCRIPTION
### ✅ Checklist

- [x] **Covered by automatic tests.** Help-text/docs only; no behavior change.
- [x] **Impact of the changes:** wallet-cli `--help` output, README, and skill docs. No CLI surface change.

### 📝 Description

Drop internal jargon (account descriptor, Alpaca, bridge only) from user-facing `--help`, README, and the wallet-cli skill. Document that `account discover` saves accounts to the session under a label usable as `--account <label>`.

### ❓ Context

- **JIRA or GitHub link**: n/a
- **ADR link (if any)**: n/a