### PR TITLE
test(e2e-desktop): use min amount from request for B2CQA-3241 swap quote test

### DIFF
--- a/e2e/desktop/tests/specs/validation.swap.spec.ts
+++ b/e2e/desktop/tests/specs/validation.swap.spec.ts
@@ -30,7 +30,7 @@ const tooLowAmountForQuoteSwaps = [
   // Enable test when "Sponsored" program is over
 
   // {
-  //   swap: new Swap(TokenAccount.ETH_USDT_2, Account.BTC_NATIVE_SEGWIT_1, "24"),
+  //   swap: new Swap(TokenAccount.ETH_USDT_2, Account.BTC_NATIVE_SEGWIT_1, "USE_MIN_AMOUNT"),
   //   xrayTicket: "B2CQA-3241",
   //   errorMessage: new RegExp(`\\d+(\\.\\d{1,10})? ETH needed for network fees\\.\\s*$`),
   //   ctaBanner: true,
@@ -113,7 +113,12 @@ for (const swap of tooLowAmountForQuoteSwaps) {
       async ({ app }) => {
         await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
-        await performSwapUntilQuoteSelectionStep(app, swap.swap, swap.swap.amount ?? "0");
+        const swapAmount =
+          swap.swap.amount === "USE_MIN_AMOUNT"
+            ? await app.swap.getMinimumAmount(accountToDebit, accountToCredit)
+            : swap.swap.amount ?? "0";
+
+        await performSwapUntilQuoteSelectionStep(app, swap.swap, swapAmount);
         if (swap.quotesVisible) {
           await app.swap.checkQuotes();
           await app.swap.selectExchange();


### PR DESCRIPTION
### Checklist

- [ ] `npx changeset` was attached. _Not needed — e2e-only change._
- [ ] **Covered by automatic tests.** _The modified case lives inside the commented-out "Sponsored program" block in `validation.swap.spec.ts`. It will only execute once the test is re-enabled; no runtime impact today._
- [x] **Impact of the changes:**
  - Only the commented-out B2CQA-3241 case in `e2e/desktop/tests/specs/validation.swap.spec.ts` is touched — no test runs differently today.
  - QA can verify the other `tooLowAmountForQuoteSwaps` cases (B2CQA-3239, 3240, 3242, 3243) still behave as before.
  - When the Sponsored program ends and the B2CQA-3241 block is uncommented, the test will use the dynamic min amount from the swap quote endpoint instead of the previously hardcoded `24`.

### Description

For some tests, a hardcoded amount of `24` was used to fill the swap "Amount" field. Because the network min amount for quotes is higher than that, the test would fail when re-enabled (see ticket for the failing Allure report).

This PR aligns the B2CQA-3241 case with the pattern already used by the SWAP (accepted) mobile test: instead of a literal value, the amount is fetched from the swap quote endpoint via `app.swap.getMinimumAmount(accountToDebit, accountToCredit)`.

The data entry uses a `"USE_MIN_AMOUNT"` sentinel string; the test loop resolves it at runtime:

```ts
const swapAmount =
  swap.swap.amount === "USE_MIN_AMOUNT"
    ? await app.swap.getMinimumAmount(accountToDebit, accountToCredit)
    : swap.swap.amount ?? "0";
```

The mobile side (`e2e/mobile/specs/swap/swap.ts`) already computes `minAmount` dynamically, so no mobile change is required.

### Context

- **JIRA or GitHub link**: [QAA-722](https://ledgerhq.atlassian.net/browse/QAA-722)
- Desktop Manual CI : https://github.com/LedgerHQ/ledger-live/actions/runs/26107810198

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-722]: https://ledgerhq.atlassian.net/browse/QAA-722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ