### PR TITLE
test(e2e-desktop): review receive.address.spec (QAA-1110)

### DIFF
--- a/e2e/desktop/tests/specs/receive.address.spec.ts
+++ b/e2e/desktop/tests/specs/receive.address.spec.ts
@@ -1,12 +1,17 @@
 import { test } from "tests/fixtures/common";
 import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
-import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import {
+  Account,
+  TokenAccount,
+  getParentAccountName,
+} from "@ledgerhq/live-common/e2e/enum/Account";
 import { addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
 import { getFamilyByCurrencyId } from "@ledgerhq/live-common/currencies/helpers";
 import { liveDataCommand } from "@ledgerhq/live-common/e2e/cliCommandsUtils";
+import type { Application } from "tests/page";
 
-const accounts = [
+const nativeAccounts = [
   { account: Account.BTC_NATIVE_SEGWIT_1, xrayTicket: "B2CQA-2559, B2CQA-2687" },
   { account: Account.ETH_1, xrayTicket: "B2CQA-2561, B2CQA-2688, B2CQA-2697" },
   { account: Account.SOL_1, xrayTicket: "B2CQA-2563, B2CQA-2689" },
@@ -20,19 +25,37 @@ const accounts = [
   //{ account: Account.BSC_1, xrayTicket: "B2CQA-2686, B2CQA-2696, B2CQA-2698" },
 ];
 
-for (const account of accounts) {
-  test.describe("Receive", () => {
+const tokenAccounts = [{ account: TokenAccount.ETH_USDT_1, xrayTicket: "B2CQA-XXX" }];
+
+async function verifySendCurrencyTokensWarning(app: Application, account: Account) {
+  switch (account) {
+    case Account.TRX_1:
+      await app.receive.verifySendCurrencyTokensWarningMessage(account, "TRC10/TRC20");
+      break;
+    case Account.ETH_1:
+      await app.receive.expectRecieveMenu();
+      await app.receive.clickReceive();
+      await app.receive.verifySendCurrencyTokensWarningMessage(account, "Ethereum");
+      break;
+    case Account.BSC_1:
+      await app.receive.verifySendCurrencyTokensWarningMessage(account, "BEP20");
+      break;
+  }
+}
+
+for (const receive of nativeAccounts) {
+  test.describe("Receive native coin", () => {
     test.use({
       teamOwner: Team.WALLET_XP,
       userdata: "skip-onboarding-with-last-seen-device",
-      speculosApp: account.account.currency.speculosApp,
-      cliCommands: [liveDataCommand(account.account)],
+      speculosApp: receive.account.currency.speculosApp,
+      cliCommands: [liveDataCommand(receive.account)],
     });
 
-    const family = getFamilyByCurrencyId(account.account.currency.id);
+    const family = getFamilyByCurrencyId(receive.account.currency.id);
 
     test(
-      `[${account.account.currency.name}] Receive`,
+      `[${receive.account.currency.name}] Receive`,
       {
         tag: [
           "@NanoSP",
@@ -41,49 +64,33 @@ for (const account of accounts) {
           "@Stax",
           "@Flex",
           "@NanoGen5",
-          `@${account.account.currency.id}`,
+          `@${receive.account.currency.id}`,
           ...(family ? [`@family-${family}`] : []),
-          ...(account.account === Account.SOL_1 ? ["@smoke"] : []),
+          ...(receive.account === Account.SOL_1 ? ["@smoke"] : []),
         ],
         annotation: {
           type: "TMS",
-          description: account.xrayTicket,
+          description: receive.xrayTicket,
         },
       },
       async ({ app }) => {
         await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
         await app.mainNavigation.openTargetFromMainNavigation("accounts");
-        await app.accounts.navigateToAccountByName(account.account.accountName);
-        await app.account.expectAccountVisibility(account.account.accountName);
+        await app.accounts.navigateToAccountByName(receive.account.accountName);
+        await app.account.expectAccountVisibility(receive.account.accountName);
         await app.account.clickReceive();
-        switch (account.account) {
-          case Account.TRX_1:
-            await app.receive.verifySendCurrencyTokensWarningMessage(
-              account.account,
-              "TRC10/TRC20",
-            );
-            break;
-          case Account.ETH_1:
-            await app.receive.expectRecieveMenu();
-            await app.receive.clickReceive();
-            await app.receive.verifySendCurrencyTokensWarningMessage(account.account, "Ethereum");
-            break;
-          case Account.BSC_1:
-            await app.receive.verifySendCurrencyTokensWarningMessage(account.account, "BEP20");
-            break;
-        }
+        await verifySendCurrencyTokensWarning(app, receive.account);
         await app.receive.continue();
         const displayedAddress = await app.receive.getAddressDisplayed();
         await app.receive.expectValidReceiveAddress(displayedAddress);
-        await app.speculos.expectValidAddressDevice(account.account, displayedAddress);
+        await app.speculos.expectValidAddressDevice(receive.account, displayedAddress);
         await app.receive.expectApproveLabel();
       },
     );
   });
 }
 
-test.describe("Receive", () => {
+test.describe("Receive TRX empty balance", () => {
   const account = Account.TRX_3;
   test.use({
     teamOwner: Team.WALLET_XP,
@@ -124,3 +131,50 @@ test.describe("Receive", () => {
     },
   );
 });
+
+for (const receive of tokenAccounts) {
+  test.describe("Receive token", () => {
+    test.use({
+      teamOwner: Team.WALLET_XP,
+      userdata: "speculos-subAccount",
+      speculosApp: receive.account.currency.speculosApp,
+    });
+
+    const family = getFamilyByCurrencyId(receive.account.currency.id);
+
+    test(
+      `[${receive.account.currency.name}] Receive`,
+      {
+        tag: [
+          "@NanoSP",
+          "@LNS",
+          "@NanoX",
+          "@Stax",
+          "@Flex",
+          "@NanoGen5",
+          `@${receive.account.currency.id}`,
+          ...(family ? [`@family-${family}`] : []),
+        ],
+        annotation: {
+          type: "TMS",
+          description: receive.xrayTicket,
+        },
+      },
+      async ({ app }) => {
+        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+
+        await app.mainNavigation.openTargetFromMainNavigation("accounts");
+        await app.accounts.navigateToAccountByName(getParentAccountName(receive.account));
+        await app.account.navigateToTokenInAccount(receive.account);
+        await app.account.expectTokenAccount(receive.account);
+        await app.account.clickReceive();
+        await app.receive.continue();
+
+        const displayedAddress = await app.receive.getAddressDisplayed();
+        await app.receive.expectValidReceiveAddress(displayedAddress);
+        await app.speculos.expectValidAddressDevice(receive.account, displayedAddress);
+        await app.receive.expectApproveLabel();
+      },
+    );
+  });
+}

--- a/e2e/desktop/tests/specs/receive.address.spec.ts
+++ b/e2e/desktop/tests/specs/receive.address.spec.ts
@@ -25,7 +25,7 @@ const nativeAccounts = [
   //{ account: Account.BSC_1, xrayTicket: "B2CQA-2686, B2CQA-2696, B2CQA-2698" },
 ];
 
-const tokenAccounts = [{ account: TokenAccount.ETH_USDT_1, xrayTicket: "B2CQA-5694" }];
+const tokenAccount = { account: TokenAccount.ETH_USDT_1, xrayTicket: "B2CQA-5694" };
 
 async function verifySendCurrencyTokensWarning(app: Application, account: Account) {
   switch (account) {
@@ -132,50 +132,48 @@ test.describe("Receive TRX empty balance", () => {
   );
 });
 
-for (const receive of tokenAccounts) {
-  test.describe("Receive token", () => {
-    test.use({
-      teamOwner: Team.WALLET_XP,
-      userdata: "speculos-subAccount",
-      speculosApp: receive.account.currency.speculosApp,
-    });
-
-    const family = getFamilyByCurrencyId(receive.account.currency.id);
-
-    test(
-      `[${receive.account.currency.name}] Receive`,
-      {
-        tag: [
-          "@NanoSP",
-          "@LNS",
-          "@NanoX",
-          "@Stax",
-          "@Flex",
-          "@NanoGen5",
-          `@${receive.account.currency.id}`,
-          ...(family ? [`@family-${family}`] : []),
-        ],
-        annotation: {
-          type: "TMS",
-          description: receive.xrayTicket,
-        },
-      },
-      async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
-        await app.mainNavigation.openTargetFromMainNavigation("accounts");
-        await app.accounts.navigateToAccountByName(getParentAccountName(receive.account));
-        await app.account.expectAccountVisibility(getParentAccountName(receive.account));
-        await app.account.navigateToTokenInAccount(receive.account);
-        await app.account.expectTokenAccount(receive.account);
-        await app.account.clickReceive();
-        await app.receive.continue();
-
-        const displayedAddress = await app.receive.getAddressDisplayed();
-        await app.receive.expectValidReceiveAddress(displayedAddress);
-        await app.speculos.expectValidAddressDevice(receive.account, displayedAddress);
-        await app.receive.expectApproveLabel();
-      },
-    );
+test.describe("Receive token", () => {
+  test.use({
+    teamOwner: Team.WALLET_XP,
+    userdata: "speculos-subAccount",
+    speculosApp: tokenAccount.account.currency.speculosApp,
   });
-}
+
+  const family = getFamilyByCurrencyId(tokenAccount.account.currency.id);
+
+  test(
+    `[${tokenAccount.account.currency.name}] Receive`,
+    {
+      tag: [
+        "@NanoSP",
+        "@LNS",
+        "@NanoX",
+        "@Stax",
+        "@Flex",
+        "@NanoGen5",
+        `@${tokenAccount.account.currency.id}`,
+        ...(family ? [`@family-${family}`] : []),
+      ],
+      annotation: {
+        type: "TMS",
+        description: tokenAccount.xrayTicket,
+      },
+    },
+    async ({ app }) => {
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+
+      await app.mainNavigation.openTargetFromMainNavigation("accounts");
+      await app.accounts.navigateToAccountByName(getParentAccountName(tokenAccount.account));
+      await app.account.expectAccountVisibility(getParentAccountName(tokenAccount.account));
+      await app.account.navigateToTokenInAccount(tokenAccount.account);
+      await app.account.expectTokenAccount(tokenAccount.account);
+      await app.account.clickReceive();
+      await app.receive.continue();
+
+      const displayedAddress = await app.receive.getAddressDisplayed();
+      await app.receive.expectValidReceiveAddress(displayedAddress);
+      await app.speculos.expectValidAddressDevice(tokenAccount.account, displayedAddress);
+      await app.receive.expectApproveLabel();
+    },
+  );
+});

--- a/e2e/desktop/tests/specs/receive.address.spec.ts
+++ b/e2e/desktop/tests/specs/receive.address.spec.ts
@@ -165,6 +165,7 @@ for (const receive of tokenAccounts) {
 
         await app.mainNavigation.openTargetFromMainNavigation("accounts");
         await app.accounts.navigateToAccountByName(getParentAccountName(receive.account));
+        await app.account.expectAccountVisibility(getParentAccountName(receive.account));
         await app.account.navigateToTokenInAccount(receive.account);
         await app.account.expectTokenAccount(receive.account);
         await app.account.clickReceive();

--- a/e2e/desktop/tests/specs/receive.address.spec.ts
+++ b/e2e/desktop/tests/specs/receive.address.spec.ts
@@ -25,7 +25,7 @@ const nativeAccounts = [
   //{ account: Account.BSC_1, xrayTicket: "B2CQA-2686, B2CQA-2696, B2CQA-2698" },
 ];
 
-const tokenAccounts = [{ account: TokenAccount.ETH_USDT_1, xrayTicket: "B2CQA-XXX" }];
+const tokenAccounts = [{ account: TokenAccount.ETH_USDT_1, xrayTicket: "B2CQA-5694" }];
 
 async function verifySendCurrencyTokensWarning(app: Application, account: Account) {
   switch (account) {


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _Not required: changes are scoped to `e2e/desktop/tests/**` and no shipped package is affected (precedent: commit `3a13174554c`)._
- [x] **Covered by automatic tests.** _Changes ARE the automated tests; verified via the @Desktop E2E job linked below._
- [x] **Impact of the changes:**
  - Desktop `Receive` flow for native coins (BTC, ETH, SOL, ADA, TRX, XRP, DOT, BCH, ALGO, LTC) — address shown in-app must match Speculos device.
  - Desktop `Receive` flow for ERC-20 tokens (ETH USDT) — newly covered, including parent-account navigation and token-row click-through.
  - "Send currency tokens" warning copy for ETH (Ethereum), TRX (TRC10/TRC20), and BSC (BEP20 — currently skipped).
  - TRX empty-balance address-activation warning.

### 📝 Description

Cleanup pass on `receive.address.spec.ts` per QAA-1110.

**Problem:** the spec covered only native-coin receive flows, the per-currency token-warning logic was an inline `switch` inside the test body, and the two `Receive` `describe` blocks shared the same name which made reports ambiguous.

**Solution:**

- Split the `accounts` array into `nativeAccounts` and a new `tokenAccounts` array; added the first ERC-20 token receive case (`TokenAccount.ETH_USDT_1`, `B2CQA-5694`) with its own parameterised loop and dedicated `Receive token` `describe`.
- Extracted the currency-specific warning `switch/case` into a `verifySendCurrencyTokensWarning(app, account)` helper to keep the test body flat.
- Renamed the two `Receive` `describe` blocks to `Receive native coin` and `Receive TRX empty balance` so Allure/Playwright reports are unambiguous.
- BSC_1 stays commented out until `LIVE-25852` is fixed (carry-over from QAA-1110).

### 🔗 CI execution

- [@Desktop E2E run on `support/qaa-1110`](https://github.com/LedgerHQ/ledger-live/actions/runs/26019158830/job/76476917775)

### ❓ Context

- **JIRA**: [QAA-1110](https://ledgerhq.atlassian.net/browse/QAA-1110)
- **Parent epic**: [QAA-1101 — LWD E2E Desktop Test Suite Cleanup & Improvements](https://ledgerhq.atlassian.net/browse/QAA-1101)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-1110]: https://ledgerhq.atlassian.net/browse/QAA-1110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ