### PR TITLE
[LWM] feat(mobile): cap AssetDetail addresses and add filtered See all

### DIFF
--- a/.changeset/cap-asset-detail-addresses.md
+++ b/.changeset/cap-asset-detail-addresses.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Cap the Asset Detail addresses section to 5 items and add a "See all" button that opens the CryptoAddresses screen filtered by the current asset (with the "Add account" footer hidden). The portfolio-wide entry to CryptoAddresses is unchanged.

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/AccountsNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/AccountsNavigator.ts
@@ -34,6 +34,8 @@ export type AccountsNavigatorParamList = {
   };
   [ScreenName.CryptoAddresses]: {
     sourceScreenName: ScreenName;
+    accountIds?: string[];
+    hideAddAccount?: boolean;
   };
   [ScreenName.Crypto]: {
     sourceScreenName: ScreenName;

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8690,6 +8690,7 @@
     "addresses": {
       "title": "Addresses",
       "addAccount": "Add",
+      "seeAll": "See all",
       "empty": "No addresses yet. Tap Add to get started."
     },
     "marketStats": {

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
@@ -123,6 +123,23 @@ describe("AssetDetail screen layout", () => {
     expect(screen.getByText("Add")).toBeVisible();
   });
 
+  it("hides the See all addresses button when 5 or fewer accounts exist", async () => {
+    render(<AssetDetailTestNavigator />, withBtcAccounts(5));
+
+    await waitFor(() => expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.addresses)).toBeVisible());
+    expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.seeAllAddresses)).toBeNull();
+  });
+
+  it("caps the addresses preview at 5 items and shows See all when 6+ accounts exist", async () => {
+    render(<AssetDetailTestNavigator />, withBtcAccounts(6));
+
+    await waitFor(() =>
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.seeAllAddresses)).toBeVisible(),
+    );
+    expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.addresses)).toBeVisible();
+    expect(screen.getByText("See all")).toBeVisible();
+  });
+
   it("hides the transactions section when there are no operations", () => {
     render(<AssetDetailTestNavigator />, withBtcAccounts(2, 0));
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/AddressesView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/AddressesView.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import {
   Box,
+  Button,
   Pressable,
   Subheader,
   SubheaderRow,
@@ -14,14 +15,16 @@ import { AddressAccountItem } from "./components/AddressAccountItem";
 import type { AddressAccountData } from "./useAddressesViewModel";
 
 type Props = Readonly<{
-  accounts: readonly AddressAccountData[];
+  displayedAccounts: readonly AddressAccountData[];
+  hasMore: boolean;
   onAddAccount: () => void;
+  onSeeAll: () => void;
 }>;
 
-export function AddressesView({ accounts, onAddAccount }: Props) {
+export function AddressesView({ displayedAccounts, hasMore, onAddAccount, onSeeAll }: Props) {
   const { t } = useTranslation();
 
-  if (accounts.length === 0) return null;
+  if (displayedAccounts.length === 0) return null;
 
   return (
     <Box testID={ASSET_DETAIL_TEST_IDS.addresses}>
@@ -42,10 +45,22 @@ export function AddressesView({ accounts, onAddAccount }: Props) {
         </SubheaderRow>
       </Subheader>
       <Box lx={{ gap: "s8" }}>
-        {accounts.map(data => (
+        {displayedAccounts.map(data => (
           <AddressAccountItem key={data.id} data={data} />
         ))}
       </Box>
+      {hasMore && (
+        <Button
+          appearance="gray"
+          size="lg"
+          isFull
+          onPress={onSeeAll}
+          testID={ASSET_DETAIL_TEST_IDS.seeAllAddresses}
+          lx={{ marginTop: "s12" }}
+        >
+          {t("assetDetail.addresses.seeAll")}
+        </Button>
+      )}
     </Box>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/__tests__/useAddressesViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/__tests__/useAddressesViewModel.test.ts
@@ -71,15 +71,15 @@ describe("useAddressesViewModel", () => {
     jest.clearAllMocks();
   });
 
-  describe("accounts", () => {
+  describe("displayedAccounts", () => {
     it("returns an empty array when currency or distributionItem is undefined", () => {
       const { result } = renderHook(() => useAddressesViewModel(undefined, undefined));
-      expect(result.current.accounts).toEqual([]);
+      expect(result.current.displayedAccounts).toEqual([]);
 
       const { result: noDistribution } = renderHook(() =>
         useAddressesViewModel(mockBtcCryptoCurrency, undefined),
       );
-      expect(noDistribution.current.accounts).toEqual([]);
+      expect(noDistribution.current.displayedAccounts).toEqual([]);
     });
 
     it("returns one tuple per top-level account in the distribution item", () => {
@@ -97,8 +97,8 @@ describe("useAddressesViewModel", () => {
         withRawAccounts(btcAccounts),
       );
 
-      expect(result.current.accounts).toHaveLength(2);
-      result.current.accounts.forEach(acc => {
+      expect(result.current.displayedAccounts).toHaveLength(2);
+      result.current.displayedAccounts.forEach(acc => {
         expect(acc.name).toBeDefined();
         expect(acc.truncatedAddress).toBeDefined();
         expect(acc.balanceAccount).toBe(acc.account);
@@ -131,10 +131,140 @@ describe("useAddressesViewModel", () => {
         withRawAccounts([ethAccount, algoAccount]),
       );
 
-      const parentIds = result.current.accounts.map(a => a.account.id).sort();
+      const parentIds = result.current.displayedAccounts.map(a => a.account.id).sort();
       expect(parentIds).toEqual([ethAccount.id, algoAccount.id].sort());
-      result.current.accounts.forEach(entry => {
+      result.current.displayedAccounts.forEach(entry => {
         expect(entry.balanceAccount.type).toBe("TokenAccount");
+      });
+    });
+  });
+
+  describe("preview cap and See all", () => {
+    const buildBtcSetup = (count: number) => {
+      const btcAccounts = Array.from({ length: count }, (_, i) =>
+        genAccount(`bitcoin-${i}`, { currency: mockBtcCryptoCurrency, operationsSize: 0 }),
+      );
+      return {
+        btcAccounts,
+        distributionItem: buildDistributionItem(mockBtcCryptoCurrency, btcAccounts),
+      };
+    };
+
+    describe("displayedAccounts", () => {
+      it("caps displayedAccounts to 5 when more accounts exist", () => {
+        const { btcAccounts, distributionItem } = buildBtcSetup(7);
+        const { result } = renderHook(
+          () => useAddressesViewModel(mockBtcCryptoCurrency, distributionItem),
+          withRawAccounts(btcAccounts),
+        );
+
+        expect(result.current.displayedAccounts).toHaveLength(5);
+      });
+    });
+
+    describe("hasMore", () => {
+      it("is false when there are fewer than 5 accounts", () => {
+        const { btcAccounts, distributionItem } = buildBtcSetup(4);
+        const { result } = renderHook(
+          () => useAddressesViewModel(mockBtcCryptoCurrency, distributionItem),
+          withRawAccounts(btcAccounts),
+        );
+
+        expect(result.current.hasMore).toBe(false);
+      });
+
+      it("is false when there are exactly 5 accounts (all fit in the preview)", () => {
+        const { btcAccounts, distributionItem } = buildBtcSetup(5);
+        const { result } = renderHook(
+          () => useAddressesViewModel(mockBtcCryptoCurrency, distributionItem),
+          withRawAccounts(btcAccounts),
+        );
+
+        expect(result.current.hasMore).toBe(false);
+      });
+
+      it("is true when there are more than 5 accounts", () => {
+        const { btcAccounts, distributionItem } = buildBtcSetup(8);
+        const { result } = renderHook(
+          () => useAddressesViewModel(mockBtcCryptoCurrency, distributionItem),
+          withRawAccounts(btcAccounts),
+        );
+
+        expect(result.current.hasMore).toBe(true);
+      });
+    });
+
+    describe("onSeeAll", () => {
+      it("navigates to the CryptoAddresses screen with the parent accountIds and fires analytics", () => {
+        const { btcAccounts, distributionItem } = buildBtcSetup(6);
+
+        const { result } = renderHook(
+          () => useAddressesViewModel(mockBtcCryptoCurrency, distributionItem),
+          withRawAccounts(btcAccounts),
+        );
+
+        act(() => result.current.onSeeAll());
+
+        const expectedIds = btcAccounts.map(a => a.id);
+        expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Accounts, {
+          screen: ScreenName.CryptoAddresses,
+          params: {
+            sourceScreenName: ScreenName.AssetDetail,
+            accountIds: expect.arrayContaining(expectedIds),
+            hideAddAccount: true,
+          },
+        });
+        const navParams = mockNavigate.mock.calls[0][1].params;
+        expect(navParams.accountIds).toHaveLength(expectedIds.length);
+        expect(track).toHaveBeenCalledWith("button_clicked", {
+          button: "see_all_addresses",
+          currency: "bitcoin",
+          page: "Asset Detail",
+        });
+      });
+
+      it("passes deduplicated parent ids for multi-network tokens", () => {
+        const ethAccount = genAccount("usdt-eth", {
+          currency: mockEthCryptoCurrency,
+          operationsSize: 0,
+        });
+        const ethSub = genTokenAccount(0, ethAccount, usdtEthToken);
+        ethSub.balance = new BigNumber(120_000_000);
+        ethAccount.subAccounts = [ethSub];
+
+        const algoAccount = genAccount("usdt-algo", {
+          currency: algorandCurrency,
+          operationsSize: 0,
+        });
+        const algoSub = genTokenAccount(0, algoAccount, usdtAlgoToken);
+        algoSub.balance = new BigNumber(80_000_000);
+        algoAccount.subAccounts = [algoSub];
+
+        const { result } = renderHook(
+          () =>
+            useAddressesViewModel(
+              usdtEthToken,
+              buildDistributionItem(usdtEthToken, [ethSub, algoSub]),
+            ),
+          withRawAccounts([ethAccount, algoAccount]),
+        );
+
+        act(() => result.current.onSeeAll());
+
+        const navParams = mockNavigate.mock.calls[0][1].params;
+        expect(navParams.accountIds).toEqual(
+          expect.arrayContaining([ethAccount.id, algoAccount.id]),
+        );
+        expect(navParams.accountIds).toHaveLength(2);
+      });
+
+      it("does nothing when currency is undefined", () => {
+        const { result } = renderHook(() => useAddressesViewModel(undefined, undefined));
+
+        act(() => result.current.onSeeAll());
+
+        expect(mockNavigate).not.toHaveBeenCalled();
+        expect(track).not.toHaveBeenCalled();
       });
     });
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/useAddressesViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/useAddressesViewModel.ts
@@ -13,6 +13,8 @@ import { track } from "~/analytics";
 import { AddAccountContexts } from "LLM/features/Accounts/screens/AddAccount/enums";
 import { buildMainAccountByIdMap } from "@ledgerhq/asset-aggregation/assetDistribution/index";
 
+export const MAX_PREVIEW_ADDRESSES = 5;
+
 export type AddressAccountData = Readonly<{
   id: string;
   account: Account;
@@ -58,6 +60,15 @@ export function useAddressesViewModel(
     });
   }, [currency, distributionItem, sortedAccounts, mainAccountById, walletState]);
 
+  const displayedAccounts = useMemo(() => accounts.slice(0, MAX_PREVIEW_ADDRESSES), [accounts]);
+
+  const hasMore = accounts.length > MAX_PREVIEW_ADDRESSES;
+
+  const allAccountIds = useMemo(
+    () => Array.from(new Set(accounts.map(a => a.account.id))),
+    [accounts],
+  );
+
   const onAddAccount = useCallback(() => {
     if (!currency) return;
     track("button_clicked", {
@@ -75,8 +86,27 @@ export function useAddressesViewModel(
     });
   }, [navigation, currency]);
 
+  const onSeeAll = useCallback(() => {
+    if (!currency) return;
+    track("button_clicked", {
+      button: "see_all_addresses",
+      currency: currency.id,
+      page: "Asset Detail",
+    });
+    navigation.navigate(NavigatorName.Accounts, {
+      screen: ScreenName.CryptoAddresses,
+      params: {
+        sourceScreenName: ScreenName.AssetDetail,
+        accountIds: allAccountIds,
+        hideAddAccount: true,
+      },
+    });
+  }, [navigation, currency, allAccountIds]);
+
   return {
-    accounts,
+    displayedAccounts,
+    hasMore,
     onAddAccount,
+    onSeeAll,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/testIds.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/testIds.ts
@@ -12,6 +12,7 @@ export const ASSET_DETAIL_TEST_IDS = {
   earnDeposit: "asset-detail-earn-deposit",
   addresses: "asset-detail-addresses",
   addAccount: "asset-detail-add-account",
+  seeAllAddresses: "asset-detail-see-all-addresses",
   marketStats: "asset-detail-market-stats",
   pricePerformance: "asset-detail-price-performance",
   transactions: "asset-detail-transactions",

--- a/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/__integrations__/CryptoAddressesScreen.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/__integrations__/CryptoAddressesScreen.integration.test.tsx
@@ -51,6 +51,7 @@ const baseViewModel: ReturnType<typeof useCryptoAddressesViewModel> = {
   emptyStateLabel: "No accounts yet",
   trackingPage: ScreenName.Accounts,
   sourceScreenName: undefined,
+  hideAddAccount: false,
 };
 
 function renderScreen(vmOverrides: Partial<ReturnType<typeof useCryptoAddressesViewModel>> = {}) {
@@ -80,6 +81,12 @@ describe("CryptoAddressesScreen", () => {
     it("should render the add account label", () => {
       renderScreen();
       expect(screen.getByText("Add account")).toBeVisible();
+    });
+
+    it("should hide the add account footer when hideAddAccount is true", () => {
+      renderScreen({ hideAddAccount: true });
+      expect(screen.queryByTestId("crypto-addresses-add-button")).toBeNull();
+      expect(screen.queryByText("Add account")).toBeNull();
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/__tests__/useCryptoAddressesViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/__tests__/useCryptoAddressesViewModel.test.ts
@@ -22,9 +22,11 @@ jest.mock("@ledgerhq/live-common/bridge/react/useGlobalSyncState", () => ({
 
 const bitcoin = getCryptoCurrencyById("bitcoin");
 const ethereum = getCryptoCurrencyById("ethereum");
+const polygon = getCryptoCurrencyById("polygon");
 
 const btcAccount = genAccount("btc1", { currency: bitcoin });
 const ethAccount = genAccount("eth1", { currency: ethereum });
+const polygonAccount = genAccount("polygon1", { currency: polygon });
 const tokenAccount = genTokenAccount(0, ethAccount, usdcToken);
 
 const withAccounts =
@@ -88,6 +90,74 @@ describe("useCryptoAddressesViewModel", () => {
     const entry = result.current.aggregatedAccountsData.get(parentWithToken.id);
     expect(entry).toBeDefined();
     expect(entry?.subAccountsCount).toBe(1);
+  });
+
+  describe("accountIds filtering", () => {
+    it("should return all store accounts when no accountIds are provided", () => {
+      const { result } = renderHook(() => useCryptoAddressesViewModel(), {
+        overrideInitialState: withAccounts([btcAccount, ethAccount, polygonAccount]),
+      });
+
+      expect(result.current.accounts).toHaveLength(3);
+      expect(result.current.accounts.map(a => a.id).sort()).toEqual(
+        [btcAccount.id, ethAccount.id, polygonAccount.id].sort(),
+      );
+    });
+
+    it("should return only the requested accounts when accountIds are provided", () => {
+      const { result } = renderHook(
+        () => useCryptoAddressesViewModel(undefined, [btcAccount.id, polygonAccount.id]),
+        {
+          overrideInitialState: withAccounts([btcAccount, ethAccount, polygonAccount]),
+        },
+      );
+
+      expect(result.current.accounts).toHaveLength(2);
+      expect(result.current.accounts.map(a => a.id).sort()).toEqual(
+        [btcAccount.id, polygonAccount.id].sort(),
+      );
+      expect(result.current.accounts.some(a => a.id === ethAccount.id)).toBe(false);
+    });
+
+    it("should aggregate countervalue data on the filtered subset only", () => {
+      const parentWithToken = { ...ethAccount, subAccounts: [tokenAccount] };
+
+      const { result } = renderHook(
+        () => useCryptoAddressesViewModel(undefined, [parentWithToken.id]),
+        {
+          overrideInitialState: withAccounts([btcAccount, parentWithToken, polygonAccount]),
+        },
+      );
+
+      expect(result.current.accounts).toHaveLength(1);
+      expect(result.current.accounts[0]?.id).toBe(parentWithToken.id);
+      expect(result.current.aggregatedAccountsData.get(parentWithToken.id)?.subAccountsCount).toBe(
+        1,
+      );
+      expect(result.current.aggregatedAccountsData.get(btcAccount.id)).toBeUndefined();
+      expect(result.current.aggregatedAccountsData.get(polygonAccount.id)).toBeUndefined();
+    });
+
+    it("should return an empty list when accountIds is an empty array", () => {
+      const { result } = renderHook(() => useCryptoAddressesViewModel(undefined, []), {
+        overrideInitialState: withAccounts([btcAccount, ethAccount]),
+      });
+
+      expect(result.current.accounts).toHaveLength(0);
+      expect(result.current.hasNoAccount).toBe(true);
+    });
+
+    it("should ignore unknown accountIds and only return matching ones", () => {
+      const { result } = renderHook(
+        () => useCryptoAddressesViewModel(undefined, [btcAccount.id, "non-existent-id"]),
+        {
+          overrideInitialState: withAccounts([btcAccount, ethAccount]),
+        },
+      );
+
+      expect(result.current.accounts).toHaveLength(1);
+      expect(result.current.accounts[0]?.id).toBe(btcAccount.id);
+    });
   });
 
   describe("loading and error states", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/index.tsx
@@ -39,6 +39,7 @@ function CryptoAddressesView({
   emptyStateLabel,
   trackingPage,
   sourceScreenName,
+  hideAddAccount,
 }: Readonly<ReturnType<typeof useCryptoAddressesViewModel>>) {
   const { bottom } = useSafeAreaInsets();
   const renderItem = useCallback(
@@ -61,6 +62,8 @@ function CryptoAddressesView({
     return <CryptoAddressesEmptyState label={emptyStateLabel} />;
   }, [isLoading, emptyStateLabel]);
 
+  const listPaddingBottom = hideAddAccount ? bottom : FOOTER_HEIGHT + bottom;
+
   return (
     <Box style={{ flex: 1 }}>
       <TrackScreen name={trackingPage} source={sourceScreenName} />
@@ -74,23 +77,35 @@ function CryptoAddressesView({
             data={accounts}
             showsVerticalScrollIndicator={false}
             showsHorizontalScrollIndicator={false}
-            contentContainerStyle={{ paddingBottom: FOOTER_HEIGHT + bottom }}
+            contentContainerStyle={{ paddingBottom: listPaddingBottom }}
             ListEmptyComponent={ListEmpty}
           />
         )}
-        <CryptoAddressesFooter label={addAccountLabel} onPress={onAddAccountPress} />
+        {!hideAddAccount && (
+          <CryptoAddressesFooter label={addAccountLabel} onPress={onAddAccountPress} />
+        )}
       </Box>
-      <AddAccountDrawer
-        isOpened={isAddAccountOpen}
-        onClose={onCloseAddAccount}
-        doesNotHaveAccount={hasNoAccount}
-      />
+      {!hideAddAccount && (
+        <AddAccountDrawer
+          isOpened={isAddAccountOpen}
+          onClose={onCloseAddAccount}
+          doesNotHaveAccount={hasNoAccount}
+        />
+      )}
     </Box>
   );
 }
 
 export default withDiscreetMode(function CryptoAddressesScreen({ route }: Props) {
-  return <CryptoAddressesView {...useCryptoAddressesViewModel(route.params?.sourceScreenName)} />;
+  return (
+    <CryptoAddressesView
+      {...useCryptoAddressesViewModel(
+        route.params?.sourceScreenName,
+        route.params?.accountIds,
+        route.params?.hideAddAccount,
+      )}
+    />
+  );
 });
 
 const containerStyle: LumenViewStyle = {

--- a/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/types.ts
@@ -3,5 +3,7 @@ import { ScreenName } from "~/const";
 export type CryptoAddressesNavigator = {
   [ScreenName.CryptoAddresses]: {
     sourceScreenName: ScreenName;
+    accountIds?: string[];
+    hideAddAccount?: boolean;
   };
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/useCryptoAddressesViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/useCryptoAddressesViewModel.ts
@@ -27,12 +27,22 @@ type NavigationProp = BaseNavigationComposite<
   StackNavigatorNavigation<AccountsNavigatorParamList, ScreenName.CryptoAddresses>
 >;
 
-export default function useCryptoAddressesViewModel(sourceScreenName?: ScreenName) {
+export default function useCryptoAddressesViewModel(
+  sourceScreenName?: ScreenName,
+  accountIds?: string[],
+  hideAddAccount?: boolean,
+) {
   const { t } = useTranslation();
   const navigation = useNavigation<NavigationProp>();
   const countervalueState = useCountervaluesState();
   const toCurrency = useSelector(counterValueCurrencySelector);
   const allAccounts = useSelector(accountsSelector, isEqual);
+
+  const filteredAccounts = useMemo(() => {
+    if (!accountIds) return allAccounts;
+    const idSet = new Set(accountIds);
+    return allAccounts.filter(a => idSet.has(a.id));
+  }, [allAccounts, accountIds]);
 
   const aggregatedAccountsData = useMemo(() => {
     const calculateCv: CalculateCountervalue = (from, value) => {
@@ -44,16 +54,16 @@ export default function useCryptoAddressesViewModel(sourceScreenName?: ScreenNam
       });
       return raw == null ? undefined : new BigNumber(raw);
     };
-    return computeAggregatedAccountsData(allAccounts, calculateCv);
-  }, [allAccounts, countervalueState, toCurrency]);
+    return computeAggregatedAccountsData(filteredAccounts, calculateCv);
+  }, [filteredAccounts, countervalueState, toCurrency]);
 
   const accounts = useMemo((): Account[] => {
-    return [...allAccounts].sort((a, b) => {
+    return [...filteredAccounts].sort((a, b) => {
       const aCV = aggregatedAccountsData.get(a.id)?.countervalue ?? new BigNumber(0);
       const bCV = aggregatedAccountsData.get(b.id)?.countervalue ?? new BigNumber(0);
       return bCV.comparedTo(aCV);
     });
-  }, [allAccounts, aggregatedAccountsData]);
+  }, [filteredAccounts, aggregatedAccountsData]);
 
   const hasNoAccount = accounts.length === 0;
 
@@ -101,5 +111,6 @@ export default function useCryptoAddressesViewModel(sourceScreenName?: ScreenNam
     emptyStateLabel: t("cryptoAddresses.emptyState"),
     trackingPage: ScreenName.Accounts,
     sourceScreenName,
+    hideAddAccount: hideAddAccount ?? false,
   };
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - AssetDetail: Addresses section truncated to 5 + "See all" button when 6+ accounts exist
  - CryptoAddresses: now accepts an optional `accountIds` filter (portfolio-wide entry unchanged)

### 📝 Description

The AssetDetail screen's "Addresses" section previously rendered every account associated with the asset, which becomes unwieldy when users have many accounts on the same network.

This PR caps the preview to a maximum of 5 items. When more accounts exist, a "See all" button appears and navigates to the `CryptoAddresses` screen, **filtered to the exact account set computed by AssetDetail** (works for native crypto and multi-network tokens). The "Add account" footer is hidden on this filtered view to match the Figma; the portfolio-wide entry to `CryptoAddresses` is unchanged.

#### Why filter by `accountIds` (not by `currencyId`)

The first iteration filtered the CryptoAddresses screen by `currencyId`, but that broke for tokens:

- Multi-network tokens (e.g. USDT on Ethereum + Algorand) would only show one network.
- The downstream selector mapped to parent accounts, so the list lost the token-level metadata and could include parents that don't hold the token.
- It also triggered a redundant `useFindTokenByIdQuery({ id: "" })` on every portfolio-wide mount.

Switching to `accountIds: string[]` (the parent account ids already computed by the AssetDetail VM, deduplicated) makes the filtered list **identical to what the preview shows** — including for multi-network tokens — with zero extra API calls and no unsafe type casts.

#### Touched surfaces

- `useAddressesViewModel`: exposes `displayedAccounts` (capped at 5), `hasMore` (strict `>` boundary), and a new `onSeeAll` that navigates with `accountIds` + `hideAddAccount: true`.
- `useCryptoAddressesViewModel`: accepts an optional `accountIds?: string[]` and filters `allAccounts` via a `Set` lookup. Countervalue aggregation is now scoped to the filtered subset.
- `AccountsNavigator` / `CryptoAddressesNavigator` types: `accountIds?: string[]` and `hideAddAccount?: boolean` added to the route params.
- Analytics: `see_all_addresses` button event fires from the AssetDetail "See all".
- Tests:
  - Unit tests for the new AssetDetail VM behaviors (cap, `hasMore` boundary, `onSeeAll` payload, multi-network parent-id dedup).
  - Unit tests for the new CryptoAddresses VM `accountIds` path (no filter / subset / empty array / unknown ids / aggregation scoped to subset).
  - Integration tests for the AssetDetail layout (cap + button visibility) and the filtered `CryptoAddresses` footer hiding.

FAKE DATAS 
<img width="350" height="750" alt="Simulator Screenshot - iOS Simulator - 2026-05-18 at 11 15 59" src="https://github.com/user-attachments/assets/9195d6e3-06ef-4e4e-962e-117393c88cc8" />
<img width="350" height="750" alt="Simulator Screenshot - iOS Simulator - 2026-05-18 at 13 52 48" src="https://github.com/user-attachments/assets/b184ab85-bc8c-481c-a398-e6db5408a6ab" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30338](https://ledgerhq.atlassian.net/browse/LIVE-30338)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30338]: https://ledgerhq.atlassian.net/browse/LIVE-30338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ