### PR TITLE
feat(wallet-cli): add assets token resolver commands

### DIFF
--- a/.agents/skills/ledger-wallet-cli/SKILL.md
+++ b/.agents/skills/ledger-wallet-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ledger-wallet-cli
-description: Official Ledger wallet-cli — USB-based CLI for Ledger hardware wallet flows (account discover, receive, balances, operations, send, swap quote/execute/status) built on the Device Management Kit (DMK)
+description: Official Ledger wallet-cli — USB-based CLI for Ledger hardware wallet flows (account discover, receive, balances, operations, send, swap quote/execute/status, assets token / token-by-id) built on the Device Management Kit (DMK)
 ---
 
 # wallet-cli
@@ -32,6 +32,8 @@ Run from repo root: `pnpm --silent wallet-cli start <command> [flags]`
 | `swap quote`       | No     | No           |
 | `swap execute`     | Yes    | **Required** |
 | `swap status`      | No     | No           |
+| `assets token`     | No     | No           |
+| `assets token-by-id` | No   | No           |
 
 *`send --dry-run` needs no device and no sandbox bypass.
 
@@ -134,6 +136,20 @@ pnpm --silent wallet-cli start swap status --swap-id <swapId> --provider changel
 pnpm --silent wallet-cli start swap status --swap-id <swapId> --provider changelly --output json
 ```
 Required flags: `--swap-id`, `--provider`
+
+### assets token / token-by-id
+Resolve token metadata from the cryptoassets store. No device, no session.
+
+```bash
+pnpm --silent wallet-cli start assets token ethereum 0xdac17f958d2ee523a2206206994597c13d831ec7
+pnpm --silent wallet-cli start assets token-by-id ethereum/erc20/usd_tether__erc20_
+```
+
+Use `token` when you have the contract address; use `token-by-id` when you have the id. Exits non-zero if not found.
+
+For non-EVM chains pass `--identifier`.
+
+The `id` printed here is the same id accepted by `swap quote --from` / `--to` and `swap execute --from` / `--to`.
 
 ---
 

--- a/apps/wallet-cli/src/cli.ts
+++ b/apps/wallet-cli/src/cli.ts
@@ -12,6 +12,7 @@ import bunliConfig from "../bunli.config";
 import { getCliProcessExitCode } from "./cli-process-exit-error";
 import { disposeWalletCliDmkTransportFully } from "./device/register-dmk-transport";
 import AccountGroup from "./commands/account/index";
+import AssetsGroup from "./commands/assets/index";
 import SessionGroup from "./commands/session/index";
 import BalancesCommand from "./commands/balances";
 import OperationsCommand from "./commands/operations";
@@ -32,6 +33,7 @@ emitTestingBuildBannerIfNeeded();
 export async function runMain(argv: string[] = process.argv.slice(2)): Promise<number> {
   const cli = await createCLI(bunliConfig as unknown as Parameters<typeof createCLI>[0]);
   cli.command(AccountGroup);
+  cli.command(AssetsGroup);
   cli.command(SessionGroup);
   cli.command(BalancesCommand);
   cli.command(OperationsCommand);

--- a/apps/wallet-cli/src/commands/assets/index.ts
+++ b/apps/wallet-cli/src/commands/assets/index.ts
@@ -1,0 +1,9 @@
+import { defineGroup } from "@bunli/core";
+import TokenCommand from "./token";
+import TokenByIdCommand from "./token-by-id";
+
+export default defineGroup({
+  name: "assets",
+  description: "Crypto-assets store queries (resolve tokens by address or id)",
+  commands: [TokenCommand, TokenByIdCommand],
+});

--- a/apps/wallet-cli/src/commands/assets/token-by-id.ts
+++ b/apps/wallet-cli/src/commands/assets/token-by-id.ts
@@ -1,0 +1,38 @@
+import { defineCommand } from "@bunli/core";
+import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
+import { createCommandOutput } from "../../output";
+import { walletCliDebug } from "../../shared/log";
+import { toTokenInfo } from "../../wallet/models";
+import { outputOption, resolveOutputFormat } from "../inputs";
+
+export default defineCommand({
+  name: "token-by-id",
+  description:
+    "Resolve a token by id (e.g. ethereum/erc20/usd_tether__erc20_). Prints the full token details.",
+  options: {
+    output: outputOption,
+  },
+  handler: async ({ flags, positional }) => {
+    const output = resolveOutputFormat(flags.output);
+    const id = positional[0];
+
+    const ctx = { command: "assets token-by-id", network: "" };
+    const out = createCommandOutput(output, ctx);
+
+    await out.run(async () => {
+      if (!id) {
+        throw new Error(
+          "Missing token id. Usage: assets token-by-id <id> — e.g. `assets token-by-id ethereum/erc20/usd_tether__erc20_`.",
+        );
+      }
+
+      walletCliDebug(`assets token-by-id: id=${id}`);
+      const token = await getCryptoAssetsStore().findTokenById(id);
+      if (!token) {
+        throw new Error(`Token not found: id=${id}.`);
+      }
+      ctx.network = token.parentCurrency.id;
+      out.token(toTokenInfo(token));
+    });
+  },
+});

--- a/apps/wallet-cli/src/commands/assets/token.ts
+++ b/apps/wallet-cli/src/commands/assets/token.ts
@@ -1,0 +1,61 @@
+import { defineCommand, option } from "@bunli/core";
+import { z } from "zod";
+import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
+import { findCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { createCommandOutput } from "../../output";
+import { walletCliDebug } from "../../shared/log";
+import { toTokenInfo } from "../../wallet/models";
+import { outputOption, resolveOutputFormat } from "../inputs";
+
+export default defineCommand({
+  name: "token",
+  description:
+    "Resolve a token by contract address on a given network (e.g. ethereum 0xdac17f95...). Prints the token id.",
+  options: {
+    output: outputOption,
+    identifier: option(z.string().min(1).optional(), {
+      description:
+        "Optional token identifier for non-EVM chains (MultiversX ESDT, Cardano, Algorand, Stellar).",
+      short: "i",
+    }),
+  },
+  handler: async ({ flags, positional }) => {
+    const output = resolveOutputFormat(flags.output);
+    const network = positional[0];
+    const address = positional[1];
+
+    const ctx = { command: "assets token", network: network ?? "" };
+    const out = createCommandOutput(output, ctx);
+
+    await out.run(async () => {
+      if (!network) {
+        throw new Error(
+          "Missing network. Usage: assets token <network> <address> — e.g. `assets token ethereum 0xdac17f95...`.",
+        );
+      }
+      if (!address) {
+        throw new Error(
+          "Missing address. Usage: assets token <network> <address> — e.g. `assets token ethereum 0xdac17f95...`.",
+        );
+      }
+      if (!findCryptoCurrencyById(network)) {
+        throw new Error(
+          `Unknown network "${network}". Pass a Ledger currency id like ethereum, polygon, bsc.`,
+        );
+      }
+
+      walletCliDebug(`assets token: network=${network}, address=${address}`);
+      const token = await getCryptoAssetsStore().findTokenByAddressInCurrency(
+        address,
+        network,
+        flags.identifier,
+      );
+      if (!token) {
+        throw new Error(
+          `Token not found: network=${network}, address=${address}${flags.identifier ? `, identifier=${flags.identifier}` : ""}.`,
+        );
+      }
+      out.token(toTokenInfo(token));
+    });
+  },
+});

--- a/apps/wallet-cli/src/output-json.test.ts
+++ b/apps/wallet-cli/src/output-json.test.ts
@@ -2,6 +2,7 @@ import "./live-common-setup";
 import { beforeEach, describe, expect, it } from "bun:test";
 import { installOutputCapture } from "./shared/ui";
 import { CliProcessExitError } from "./cli-process-exit-error";
+import { USDT_TOKEN_INFO } from "./test/helpers/cal-fixtures";
 
 const { createCommandOutput } = await import("./output");
 
@@ -209,6 +210,31 @@ describe("JsonCommandOutput", () => {
       provider_errors: [providerError],
     });
     expect(lines[0].quotes[0]).toMatchObject({ quoteId: "quote-1", provider: "paraswap" });
+  });
+
+  it("emits a token() envelope containing the resolved TokenInfo", () => {
+    try {
+      const out = createCommandOutput("json", {
+        command: "assets token",
+        network: "ethereum",
+      });
+      out.token(USDT_TOKEN_INFO);
+    } finally {
+      restore();
+    }
+
+    const lines = writes
+      .join("")
+      .trim()
+      .split("\n")
+      .map(line => JSON.parse(line));
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatchObject({
+      status: "success",
+      command: "assets token",
+      network: "ethereum",
+      token: USDT_TOKEN_INFO,
+    });
   });
 
   it("emits swap quote unavailability as an NDJSON error envelope", () => {

--- a/apps/wallet-cli/src/output.test.ts
+++ b/apps/wallet-cli/src/output.test.ts
@@ -98,4 +98,28 @@ describe("HumanCommandOutput", () => {
     expect(spin.text).toBe("[⧖] Review on device. Approve or reject.");
     expect(createdSpinners).toHaveLength(1);
   });
+
+  it("token() writes the formatted token info to stdout", async () => {
+    const { installOutputCapture } = await import("./shared/ui");
+    const { USDT_TOKEN_INFO } = await import("./test/helpers/cal-fixtures");
+    const writes: string[] = [];
+    const restore = installOutputCapture({
+      stdout: chunk => {
+        writes.push(chunk);
+      },
+    });
+    try {
+      const out = createCommandOutput("human", {
+        command: "assets token",
+        network: "ethereum",
+      });
+      out.token(USDT_TOKEN_INFO);
+    } finally {
+      restore();
+    }
+    const joined = writes.join("");
+    expect(joined).toContain(USDT_TOKEN_INFO.id);
+    expect(joined).toContain(USDT_TOKEN_INFO.ticker);
+    expect(joined).toContain(USDT_TOKEN_INFO.contractAddress);
+  });
 });

--- a/apps/wallet-cli/src/output.ts
+++ b/apps/wallet-cli/src/output.ts
@@ -23,7 +23,7 @@ import {
   type SwapQuoteProviderError,
 } from "./commands/swap/quote-shared";
 import { formatSwapStatusHuman, type SwapStatusLine } from "./commands/swap/status-shared";
-import type { Balance, Operation, DiscoveredAccount, SendEvent } from "./wallet/models";
+import type { Balance, Operation, DiscoveredAccount, SendEvent, TokenInfo } from "./wallet/models";
 import type { SessionEntry } from "./session/session-store";
 import type { SwapPayloadResponse } from "@ledgerhq/live-common/exchange/swap/types";
 
@@ -68,6 +68,7 @@ export interface CommandOutput {
 
   balances(items: Balance[]): Promise<void>;
   operations(items: Operation[], currencyId: string, nextCursor?: string): Promise<void>;
+  token(t: TokenInfo): void;
   /** Output a receive / fresh address. `verified` indicates whether the device attested it. */
   address(addr: string, verified: boolean): void;
   /**
@@ -233,6 +234,10 @@ class HumanCommandOutput implements CommandOutput {
       writeStderr("Warning: address was NOT verified on device\n");
     }
     writeStdout(addr);
+  }
+
+  token(t: TokenInfo): void {
+    writeStdout(this._fmt.formatTokenInfo(t));
   }
 
   preVerifyAddress(addr: string): void {
@@ -556,6 +561,10 @@ class JsonCommandOutput implements CommandOutput {
         source: verified ? "device" : "software-derivation",
       }),
     );
+  }
+
+  token(t: TokenInfo): void {
+    this._writeNdjson(this._envelope({ token: this._jsonFmt.token(t) }));
   }
 
   preVerifyAddress(addr: string): void {

--- a/apps/wallet-cli/src/test/commands/assets-token-by-id.test.ts
+++ b/apps/wallet-cli/src/test/commands/assets-token-by-id.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { MockServer } from "../helpers/mock-server";
+import { runCli } from "../helpers/cli-runner";
+import { USDT_CONTRACT, USDT_API_RESPONSE } from "../helpers/cal-fixtures";
+
+describe("assets token-by-id command", () => {
+  const server = new MockServer([
+    {
+      method: "GET",
+      match: /\/v1\/tokens.*id=/i,
+      response: USDT_API_RESPONSE,
+    },
+  ]);
+
+  beforeAll(() => server.start());
+  afterAll(() => server.stop());
+
+  it("human output: prints token details for a valid id", async () => {
+    const { stdout, exitCode, stderr } = await runCli(
+      ["assets", "token-by-id", "ethereum/erc20/usd_tether__erc20_"],
+      { WALLET_CLI_MOCK_PORT: String(server.port) },
+    );
+    expect(exitCode, `stderr: ${stderr}`).toBe(0);
+    expect(stdout).toContain("ethereum/erc20/usd_tether__erc20_");
+    expect(stdout).toContain("USDT");
+    expect(stdout).toContain(USDT_CONTRACT);
+  });
+
+  it("json output: returns a valid envelope", async () => {
+    const { stdout, exitCode, stderr } = await runCli(
+      ["assets", "token-by-id", "ethereum/erc20/usd_tether__erc20_", "--output", "json"],
+      { WALLET_CLI_MOCK_PORT: String(server.port) },
+    );
+    expect(exitCode, `stderr: ${stderr}`).toBe(0);
+    const data = JSON.parse(stdout);
+    expect(data.status).toBe("success");
+    expect(data.command).toBe("assets token-by-id");
+    expect(data.network).toBe("ethereum");
+    expect(data.token).toMatchObject({
+      id: "ethereum/erc20/usd_tether__erc20_",
+      ticker: "USDT",
+      decimals: 6,
+    });
+  });
+
+  it("exits non-zero when the id arg is missing", async () => {
+    const { stdout, exitCode } = await runCli(["assets", "token-by-id", "--output", "json"], {
+      WALLET_CLI_MOCK_PORT: String(server.port),
+    });
+    expect(exitCode).toBe(1);
+    const err = JSON.parse(stdout);
+    expect(err.ok).toBe(false);
+    expect(err.error.message).toMatch(/Missing token id/i);
+  });
+});
+
+describe("assets token-by-id command — not found", () => {
+  const emptyServer = new MockServer([
+    {
+      method: "GET",
+      match: /\/v1\/tokens.*id=/i,
+      response: [],
+    },
+  ]);
+
+  beforeAll(() => emptyServer.start());
+  afterAll(() => emptyServer.stop());
+
+  it("exits non-zero when the store returns no token", async () => {
+    const { stdout, exitCode } = await runCli(
+      ["assets", "token-by-id", "ethereum/erc20/nope", "--output", "json"],
+      { WALLET_CLI_MOCK_PORT: String(emptyServer.port) },
+    );
+    expect(exitCode).toBe(1);
+    const err = JSON.parse(stdout);
+    expect(err.ok).toBe(false);
+    expect(err.error.message).toMatch(/not found/i);
+  });
+});

--- a/apps/wallet-cli/src/test/commands/assets-token.test.ts
+++ b/apps/wallet-cli/src/test/commands/assets-token.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { MockServer } from "../helpers/mock-server";
+import { runCli } from "../helpers/cli-runner";
+import { USDT_CONTRACT, USDT_API_RESPONSE } from "../helpers/cal-fixtures";
+
+describe("assets token command", () => {
+  const server = new MockServer([
+    {
+      method: "GET",
+      match: /\/v1\/tokens.*contract_address=/i,
+      response: USDT_API_RESPONSE,
+    },
+  ]);
+
+  beforeAll(() => server.start());
+  afterAll(() => server.stop());
+
+  it("human output: prints the resolved Ledger token currency id", async () => {
+    const { stdout, exitCode, stderr } = await runCli(
+      ["assets", "token", "ethereum", USDT_CONTRACT],
+      { WALLET_CLI_MOCK_PORT: String(server.port) },
+    );
+    expect(exitCode, `stderr: ${stderr}`).toBe(0);
+    expect(stdout).toContain("ethereum/erc20/usd_tether__erc20_");
+    expect(stdout).toContain("USDT");
+    expect(stdout).toContain(USDT_CONTRACT);
+  });
+
+  it("json output: returns a valid envelope with the token payload", async () => {
+    const { stdout, exitCode, stderr } = await runCli(
+      ["assets", "token", "ethereum", USDT_CONTRACT, "--output", "json"],
+      { WALLET_CLI_MOCK_PORT: String(server.port) },
+    );
+    expect(exitCode, `stderr: ${stderr}`).toBe(0);
+    const data = JSON.parse(stdout);
+    expect(data.status).toBe("success");
+    expect(data.command).toBe("assets token");
+    expect(data.network).toBe("ethereum");
+    expect(data.token).toMatchObject({
+      id: "ethereum/erc20/usd_tether__erc20_",
+      ticker: "USDT",
+      contractAddress: USDT_CONTRACT,
+      parentCurrencyId: "ethereum",
+      tokenType: "erc20",
+      decimals: 6,
+    });
+  });
+
+  it("exits non-zero with a clear error when the network is unknown", async () => {
+    const { stdout, exitCode } = await runCli(
+      ["assets", "token", "notanetwork", USDT_CONTRACT, "--output", "json"],
+      { WALLET_CLI_MOCK_PORT: String(server.port) },
+    );
+    expect(exitCode).toBe(1);
+    const err = JSON.parse(stdout);
+    expect(err.ok).toBe(false);
+    expect(err.error.command).toBe("assets token");
+    expect(err.error.message).toMatch(/Unknown network/i);
+  });
+
+  it("exits non-zero when the address arg is missing", async () => {
+    const { stdout, exitCode } = await runCli(
+      ["assets", "token", "ethereum", "--output", "json"],
+      { WALLET_CLI_MOCK_PORT: String(server.port) },
+    );
+    expect(exitCode).toBe(1);
+    const err = JSON.parse(stdout);
+    expect(err.ok).toBe(false);
+    expect(err.error.message).toMatch(/Missing address/i);
+  });
+});
+
+describe("assets token command — not found", () => {
+  const emptyServer = new MockServer([
+    {
+      method: "GET",
+      match: /\/v1\/tokens.*contract_address=/i,
+      response: [],
+    },
+  ]);
+
+  beforeAll(() => emptyServer.start());
+  afterAll(() => emptyServer.stop());
+
+  it("exits non-zero with a 'not found' error when the store returns no token", async () => {
+    const { stdout, exitCode } = await runCli(
+      [
+        "assets",
+        "token",
+        "ethereum",
+        "0x0000000000000000000000000000000000000000",
+        "--output",
+        "json",
+      ],
+      { WALLET_CLI_MOCK_PORT: String(emptyServer.port) },
+    );
+    expect(exitCode).toBe(1);
+    const err = JSON.parse(stdout);
+    expect(err.ok).toBe(false);
+    expect(err.error.command).toBe("assets token");
+    expect(err.error.message).toMatch(/not found/i);
+  });
+});

--- a/apps/wallet-cli/src/test/helpers/cal-fixtures.ts
+++ b/apps/wallet-cli/src/test/helpers/cal-fixtures.ts
@@ -1,0 +1,29 @@
+import type { TokenInfo } from "../../wallet/models";
+
+export const USDT_CONTRACT = "0xdac17f958d2ee523a2206206994597c13d831ec7";
+
+export const USDT_API_RESPONSE = [
+  {
+    id: "ethereum/erc20/usd_tether__erc20_",
+    contract_address: USDT_CONTRACT,
+    standard: "erc20",
+    decimals: 6,
+    delisted: false,
+    name: "Tether USD",
+    ticker: "USDT",
+    units: [
+      { code: "USDT", name: "USDT", magnitude: 6 },
+      { code: "uUSDT", name: "micro USDT", magnitude: 0 },
+    ],
+  },
+];
+
+export const USDT_TOKEN_INFO: TokenInfo = {
+  id: "ethereum/erc20/usd_tether__erc20_",
+  ticker: "USDT",
+  name: "Tether USD",
+  contractAddress: USDT_CONTRACT,
+  parentCurrencyId: "ethereum",
+  tokenType: "erc20",
+  decimals: 6,
+};

--- a/apps/wallet-cli/src/wallet/formatter/human.test.ts
+++ b/apps/wallet-cli/src/wallet/formatter/human.test.ts
@@ -5,6 +5,7 @@ import { JsonFormatter } from "./json";
 import type { DiscoveredAccount, AccountDescriptor } from "../models";
 import { BalanceSchema, OperationSchema } from "../models";
 import { XPUB, ETH_ADDR } from "../../shared/accountDescriptor/test-fixtures";
+import { USDT_TOKEN_INFO } from "../../test/helpers/cal-fixtures";
 
 const stubStore = {} as CryptoAssetsStore;
 
@@ -40,6 +41,47 @@ const btcDescriptor: AccountDescriptor = {
   derivationMode: "native_segwit",
   index: 2,
 };
+
+describe("HumanFormatter.formatTokenInfo", () => {
+  const formatter = new HumanFormatter(stubStore);
+
+  it("includes the token id, ticker, name, contract, parent, type, decimals", () => {
+    const out = formatter.formatTokenInfo(USDT_TOKEN_INFO);
+    expect(out).toContain("ethereum/erc20/usd_tether__erc20_");
+    expect(out).toContain("USDT");
+    expect(out).toContain("Tether USD");
+    expect(out).toContain("0xdac17f958d2ee523a2206206994597c13d831ec7");
+    expect(out).toContain("ethereum");
+    expect(out).toContain("erc20");
+    expect(out).toContain("6");
+  });
+
+  it("does not render a delisted warning by default", () => {
+    expect(formatter.formatTokenInfo(USDT_TOKEN_INFO)).not.toMatch(/delisted/i);
+  });
+
+  it("renders a delisted warning when the flag is set", () => {
+    const out = formatter.formatTokenInfo({ ...USDT_TOKEN_INFO, delisted: true });
+    expect(out).toMatch(/delisted/i);
+  });
+});
+
+describe("JsonFormatter.token", () => {
+  const json = new JsonFormatter({} as unknown as HumanFormatter);
+
+  it("returns the TokenInfo payload as-is", () => {
+    expect(json.token(USDT_TOKEN_INFO)).toEqual(USDT_TOKEN_INFO);
+  });
+
+  it("omits delisted when absent on input", () => {
+    expect("delisted" in json.token(USDT_TOKEN_INFO)).toBe(false);
+  });
+
+  it("preserves delisted=true when set", () => {
+    const out = json.token({ ...USDT_TOKEN_INFO, delisted: true });
+    expect(out.delisted).toBe(true);
+  });
+});
 
 describe("HumanFormatter.formatError", () => {
   it("returns message for Error instances", () => {

--- a/apps/wallet-cli/src/wallet/formatter/human.ts
+++ b/apps/wallet-cli/src/wallet/formatter/human.ts
@@ -4,7 +4,13 @@ import type { Unit } from "@ledgerhq/types-cryptoassets";
 import type { CryptoAssetsStore, OperationType } from "@ledgerhq/types-live";
 import { colors } from "../../shared/ui";
 import { serializeV1 } from "../../shared/accountDescriptor";
-import type { AccountDescriptor, Balance, Operation, DiscoveredAccount } from "../models";
+import type {
+  AccountDescriptor,
+  Balance,
+  Operation,
+  DiscoveredAccount,
+  TokenInfo,
+} from "../models";
 
 const TYPE_COLORS: Partial<Record<OperationType, (s: string) => string>> = {
   IN: colors.green,
@@ -57,6 +63,22 @@ export class HumanFormatter {
   async formatBalance(b: Balance): Promise<string> {
     const amount = await this.formatAmount(b.balance, b.assetId);
     return b.balance === "0" ? colors.dim(amount) : colors.green(amount);
+  }
+
+  formatTokenInfo(t: TokenInfo): string {
+    const lines = [
+      `ID:        ${colors.bold(t.id)}`,
+      `Ticker:    ${t.ticker}`,
+      `Name:      ${t.name}`,
+      `Contract:  ${t.contractAddress}`,
+      `Parent:    ${t.parentCurrencyId}`,
+      `Type:      ${t.tokenType}`,
+      `Decimals:  ${t.decimals}`,
+    ];
+    if (t.delisted) {
+      lines.push(colors.yellow("Warning: this token is delisted"));
+    }
+    return lines.join("\n");
   }
 
   static formatError(e: unknown): string {

--- a/apps/wallet-cli/src/wallet/formatter/json.ts
+++ b/apps/wallet-cli/src/wallet/formatter/json.ts
@@ -1,5 +1,5 @@
 import { serializeV1 } from "../../shared/accountDescriptor";
-import type { Balance, Operation, DiscoveredAccount } from "../models";
+import type { Balance, Operation, DiscoveredAccount, TokenInfo } from "../models";
 import type { HumanFormatter } from "./human";
 
 export type JsonBalance = { asset: string; amount: string };
@@ -54,5 +54,9 @@ export class JsonFormatter {
 
   static discoveredAccounts(accounts: DiscoveredAccount[]): string[] {
     return accounts.map(a => serializeV1(a.descriptor));
+  }
+
+  token(t: TokenInfo): TokenInfo {
+    return t;
   }
 }

--- a/apps/wallet-cli/src/wallet/models.test.ts
+++ b/apps/wallet-cli/src/wallet/models.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { parseShortAccountDescriptor, parseAccountDescriptor } from "./models";
+import type { TokenCurrency, CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { parseShortAccountDescriptor, parseAccountDescriptor, toTokenInfo } from "./models";
 import { XPUB } from "../shared/accountDescriptor/test-fixtures";
 
 const SHORT = `js:2:bitcoin:${XPUB}:native_segwit:0`;
@@ -51,5 +52,51 @@ describe("parseAccountDescriptor", () => {
 
   it("propagates errors from parseV1 for invalid V1 input", () => {
     expect(() => parseAccountDescriptor("account:1:bad")).toThrow();
+  });
+});
+
+describe("toTokenInfo", () => {
+  const usdtFixture: TokenCurrency = {
+    type: "TokenCurrency",
+    id: "ethereum/erc20/usd_tether__erc20_",
+    name: "Tether USD",
+    ticker: "USDT",
+    contractAddress: "0xdac17f958d2ee523a2206206994597c13d831ec7",
+    tokenType: "erc20",
+    units: [
+      { name: "USDT", code: "USDT", magnitude: 6 },
+      { name: "micro USDT", code: "uUSDT", magnitude: 0 },
+    ],
+    parentCurrency: { id: "ethereum" } as CryptoCurrency,
+  };
+
+  it("maps id, ticker, name, contract, tokenType verbatim", () => {
+    const info = toTokenInfo(usdtFixture);
+    expect(info.id).toBe("ethereum/erc20/usd_tether__erc20_");
+    expect(info.ticker).toBe("USDT");
+    expect(info.name).toBe("Tether USD");
+    expect(info.contractAddress).toBe("0xdac17f958d2ee523a2206206994597c13d831ec7");
+    expect(info.tokenType).toBe("erc20");
+  });
+
+  it("pulls decimals from units[0].magnitude", () => {
+    expect(toTokenInfo(usdtFixture).decimals).toBe(6);
+  });
+
+  it("derives parentCurrencyId from parentCurrency.id", () => {
+    expect(toTokenInfo(usdtFixture).parentCurrencyId).toBe("ethereum");
+  });
+
+  it("omits delisted when not set on the source", () => {
+    const info = toTokenInfo(usdtFixture);
+    expect("delisted" in info).toBe(false);
+  });
+
+  it("preserves delisted=true when flagged on the source", () => {
+    expect(toTokenInfo({ ...usdtFixture, delisted: true }).delisted).toBe(true);
+  });
+
+  it("throws when the token has no units", () => {
+    expect(() => toTokenInfo({ ...usdtFixture, units: [] })).toThrow(/no units/);
   });
 });

--- a/apps/wallet-cli/src/wallet/models.ts
+++ b/apps/wallet-cli/src/wallet/models.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { decodeAccountId } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { BigNumberStrSchema, DateTimeIsoSchema } from "@shared/schema-primitives";
 import type { OperationType } from "@ledgerhq/types-live";
+import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { parseV1, toV0 } from "../shared/accountDescriptor";
 import type { AccountDescriptorV1 } from "../shared/accountDescriptor";
 
@@ -82,6 +83,35 @@ export type SendEvent =
   | { type: "device-signature-granted" }
   | { type: "dry-run" }
   | { type: "broadcasted"; txHash: string };
+
+export const TokenInfoSchema = z.object({
+  id: z.string(),
+  ticker: z.string(),
+  name: z.string(),
+  contractAddress: z.string(),
+  parentCurrencyId: z.string(),
+  tokenType: z.string(),
+  decimals: z.number().int().nonnegative(),
+  delisted: z.boolean().optional(),
+});
+export type TokenInfo = z.infer<typeof TokenInfoSchema>;
+
+export function toTokenInfo(t: TokenCurrency): TokenInfo {
+  const magnitude = t.units[0]?.magnitude;
+  if (magnitude == null) {
+    throw new Error(`Token ${t.id} has no units; cannot determine decimals`);
+  }
+  return {
+    id: t.id,
+    ticker: t.ticker,
+    name: t.name,
+    contractAddress: t.contractAddress,
+    parentCurrencyId: t.parentCurrency.id,
+    tokenType: t.tokenType,
+    decimals: magnitude,
+    ...(t.delisted === undefined ? {} : { delisted: t.delisted }),
+  };
+}
 
 export const OperationSchema = z.object({
   id: z.string(),


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. <!-- N/A — wallet-cli is private -->
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Adds two read-only commands under a new `assets` group in wallet-cli. No behavior change to existing commands.

### 📝 Description

Adds `wallet-cli assets token <network> <address>` and `wallet-cli assets token-by-id <id>` — thin wrappers over `CryptoAssetsStore.findTokenByAddressInCurrency` and `findTokenById`. Lets agents and scripts resolve the canonical Ledger token id (e.g. for `swap quote --from` / `--to`) from a contract address instead of from a ticker.

Consumer side:

```bash
wallet-cli assets token ethereum 0xdac17f958d2ee523a2206206994597c13d831ec7
wallet-cli assets token-by-id ethereum/erc20/usd_tether__erc20_
```

<img width="817" height="505" alt="Screenshot 2026-05-18 at 14 32 03" src="https://github.com/user-attachments/assets/fd6795be-d44b-43f2-a482-797681bee4d5" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-30697](https://ledgerhq.atlassian.net/browse/LIVE-30697)
- **ADR link (if any)**: —

[LIVE-30697]: https://ledgerhq.atlassian.net/browse/LIVE-30697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ