### PR TITLE
chore(mobile): disable aggregatedAssets flag in wallet 4.0 e2e tests

### DIFF
--- a/.changeset/plenty-bikes-complain.md
+++ b/.changeset/plenty-bikes-complain.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-mobile-e2e-tests": patch
+---
+
+Disable aggregatedAssets flag in Wallet 4.0 e2e feature flags

--- a/e2e/mobile/utils/constants.ts
+++ b/e2e/mobile/utils/constants.ts
@@ -15,7 +15,7 @@ export const WALLET_40_FEATURE_FLAGS = {
       assetSection: true,
       onboardingWidget: true,
       operationsList: true,
-      aggregatedAssets: true,
+      aggregatedAssets: false,
       myWallet: false,
       pnl: false,
     },


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Wallet 4.0 e2e specs on mobile (`e2e/mobile/specs/wallet40/*`) now run with `aggregatedAssets` disabled
  - No production code is touched — only the shared e2e feature flag constants

### 📝 Description

The shared Wallet 4.0 e2e feature flag `aggregatedAssets` was set to `true`, but the aggregated assets section isn't ready for full e2e coverage yet, which leads to flaky/unreliable runs.

This PR flips `aggregatedAssets` to `false` in `e2e/mobile/utils/constants.ts` so Wallet 4.0 e2e specs run against the legacy assets layout until the new section is stable. The flag stays alongside `myWallet` and `pnl`, which are already disabled for the same reason.


e2e run => https://github.com/LedgerHQ/ledger-live/actions/runs/26035510517
### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-30684

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)