### PR TITLE
[LWDM] ci/qaa: deprecation of old speculos mechanism to Speculinho operator

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -125,6 +125,10 @@ on:
         required: false
         type: boolean
         default: false
+    secrets:
+      SPECULINHO_URL:
+        description: Base URL for the Speculinho operator (remote Speculos on iOS E2E). Repository secret; pass via secrets inherit when reusing this workflow.
+        required: false
 
 permissions:
   id-token: write
@@ -137,7 +141,8 @@ env:
   ANDROID_TESTBINARY_PATH: apps/ledger-live-mobile/android/app/build/outputs/apk/androidTest/detox${{ inputs.production_firebase == true && 'PreRelease' || '' }}/app-detox${{ inputs.production_firebase == true && 'PreRelease' || '' }}-androidTest.apk
   IOS_JSBUNDLE_PATH: apps/ledger-live-mobile/ios/build/Build/Products/Release-iphonesimulator/ledgerlivemobile.app/main.jsbundle
   IOS_NATIVE_PATH: apps/ledger-live-mobile/ios/build/Build/Products/Release-iphonesimulator
-  SPECULOS_IMAGE_TAG: ghcr.io/ledgerhq/speculos:${{ inputs.speculos_device == 'nanoS' && '1be65b91a8e0691866f880fd437ac05fce78af9d' || 'latest' }}
+  SPECULOS_IMAGE_TAG_ANDROID: ghcr.io/ledgerhq/speculos:${{ inputs.speculos_device == 'nanoS' && '1be65b91a8e0691866f880fd437ac05fce78af9d' || 'latest' }}
+  SPECULOS_IMAGE_TAG_IOS: ghcr.io/ledgerhq/speculos:${{ inputs.speculos_device == 'nanoS' && 'speculos-38ccc68068db-coinapps-83978f0' || 'latest' }}
   COINAPPS: ${{ github.workspace }}/coin-apps
   SPECULOS_DEVICE: ${{ inputs.speculos_device || 'nanoX' }}
   E2E_ENABLE_WALLET40: ${{ inputs.enable_wallet40 == 'false' && '0' || '1' }}
@@ -593,7 +598,7 @@ jobs:
         timeout-minutes: ${{ fromJSON(needs.determine-builds.outputs.ios_timeout) }}
         env:
           SEED: ${{ secrets.SEED_QAA_B2C }}
-          GITHUB_TOKEN: ${{ secrets.LL_SPECULOS_CI }}
+          SPECULINHO_URL: ${{ secrets.SPECULINHO_URL }}
           INPUT_E2E: "true"
           REMOTE_SPECULOS: "true"
           PRODUCTION: ${{ inputs.production_firebase }}
@@ -602,6 +607,7 @@ jobs:
           SHARD_INDEX: ${{ matrix.shard }}
           DEVICE_INFO: ${{ env.DEVICE_INFO }}
           NX_SKIP_NX_CACHE: true
+          SPECULOS_IMAGE_TAG: ${{ env.SPECULOS_IMAGE_TAG_IOS }}
         run: pnpm run mobile e2e:ci -p ios -t --e2e $([[ "$PRODUCTION" == "true" ]] && printf %s '--production') $SHARD_TEST_FILES --outputFile=artifacts/${{ env.E2E_TEST_RESULTS_PREFIX_IOS }}-${{ matrix.shard }}.json
 
       - name: Upload iOS artifacts
@@ -815,6 +821,7 @@ jobs:
           SHARD_INDEX: ${{ matrix.shard }}
           ADB: /usr/local/lib/android/sdk/platform-tools/adb # Needed for scrcpy
           DEVICE_INFO: ${{ env.DEVICE_INFO }}
+          SPECULOS_IMAGE_TAG: ${{ env.SPECULOS_IMAGE_TAG_ANDROID }}
         run: pnpm run mobile e2e:ci -p android -t --e2e $([[ "$PRODUCTION" == "true" ]] && printf %s '--production') $SHARD_TEST_FILES --outputFile=artifacts/${{ env.E2E_TEST_RESULTS_PREFIX_ANDROID }}-${{ matrix.shard }}.json
 
       - name: Upload Android artifacts

--- a/e2e/mobile/bridge/server.ts
+++ b/e2e/mobile/bridge/server.ts
@@ -176,6 +176,7 @@ async function fetchData(message: MessageData, timeout = RESPONSE_TIMEOUT): Prom
     postMessage(message);
     const timeoutId = setTimeout(() => {
       global.pendingCallbacks?.delete(message.type);
+      delete webSocket.messages[message.id];
       console.warn(`Timeout while waiting for ${message.type}`);
       resolve("");
     }, timeout);

--- a/e2e/mobile/helpers/commonHelpers.ts
+++ b/e2e/mobile/helpers/commonHelpers.ts
@@ -67,6 +67,7 @@ function createDetoxURLBlacklistRegex(): string {
     ".*127.0.0.1.*",
     ".*speculos.*ldg-tech.com.*",
     ".*optimism.*",
+    ".*speculos.ledgerlabs.net.*",
   ];
 
   return `\\("${patterns.join('","')}"\\)`;

--- a/e2e/mobile/helpers/commonHelpers.ts
+++ b/e2e/mobile/helpers/commonHelpers.ts
@@ -108,24 +108,28 @@ export function setupEnvironment() {
   setEnv("DISABLE_TRANSACTION_BROADCAST", !shouldBroadcast);
 }
 
-export const logMemoryUsage = async (): Promise<void> => {
+export const logMemoryUsage = (): Promise<void> => {
   const pid = process.pid;
   const isLinux = process.platform !== "darwin";
   const topArgs = isLinux ? `-b -n 1 -p ${pid}` : `-l 1 -pid ${pid}`;
-  exec(
-    `top ${topArgs} | grep "${pid}" | awk '{print ${isLinux ? "$6" : "$8"}}'`,
-    async (error: Error | null, stdout: string, stderr: string): Promise<void> => {
-      if (error || stderr) {
-        log.error(
-          `Error getting memory usage:\n Error: ${sanitizeError(error)}\n Stderr: ${stderr}`,
-        );
-        return;
-      }
-      const logMessage = `📦 Detox Memory Usage: ${stdout.trim()}`;
-      await allure.attachment("Memory Usage Details", logMessage, "text/plain");
-      log.warn(logMessage);
-    },
-  );
+  return new Promise<void>(resolve => {
+    exec(
+      `top ${topArgs} | grep "${pid}" | awk '{print ${isLinux ? "$6" : "$8"}}'`,
+      async (error: Error | null, stdout: string, stderr: string): Promise<void> => {
+        if (error || stderr) {
+          log.error(
+            `Error getting memory usage:\n Error: ${sanitizeError(error)}\n Stderr: ${stderr}`,
+          );
+          resolve();
+          return;
+        }
+        const logMessage = `📦 Detox Memory Usage: ${stdout.trim()}`;
+        await allure.attachment("Memory Usage Details", logMessage, "text/plain");
+        log.warn(logMessage);
+        resolve();
+      },
+    );
+  });
 };
 
 export async function takeAppScreenshot(screenshotName: string) {

--- a/e2e/mobile/jest.environment.ts
+++ b/e2e/mobile/jest.environment.ts
@@ -58,13 +58,15 @@ async function captureFailureDiagnostics(): Promise<void> {
   );
   // getLogs has its own 10s RESPONSE_TIMEOUT inside the bridge; this outer bound
   // is just defense-in-depth in case the inner timer is starved on a wedged worker.
-  const logs = await withTimeout(getLogs(), 12_000, "getLogs");
+  let logs = await withTimeout(getLogs(), 12_000, "getLogs");
   if (logs)
     await withTimeout(
       attachFailureLogsToAllure(logs),
       SLOW_DIAGNOSTIC_TIMEOUT_MS,
       "attachFailureLogsToAllure",
     );
+  logs = "";
+
   await withTimeout(
     captureNativeViewHierarchy(),
     SLOW_DIAGNOSTIC_TIMEOUT_MS,

--- a/e2e/mobile/utils/loggingUtils.ts
+++ b/e2e/mobile/utils/loggingUtils.ts
@@ -145,12 +145,15 @@ export async function attachFailureLogsToAllure(logsPayload: string): Promise<vo
     JSON.stringify(parsed.appLogs ?? logsPayload),
     "application/json",
   );
+  parsed.appLogs = undefined;
+
   if (parsed.webviewNetworkLogs?.length) {
     await allure.attachment(
       "Webview Network Logs",
       JSON.stringify(parsed.webviewNetworkLogs, null, 2),
       "application/json",
     );
+    parsed.webviewNetworkLogs = undefined;
   }
   if (parsed.webviewConsoleLogs?.length) {
     await allure.attachment(
@@ -158,6 +161,7 @@ export async function attachFailureLogsToAllure(logsPayload: string): Promise<vo
       formatWebviewConsoleLogs(parsed.webviewConsoleLogs),
       "text/plain",
     );
+    parsed.webviewConsoleLogs = undefined;
   }
 
   if (parsed.webviewLoadErrors?.length) {
@@ -166,5 +170,6 @@ export async function attachFailureLogsToAllure(logsPayload: string): Promise<vo
       JSON.stringify(parsed.webviewLoadErrors, null, 2),
       "application/json",
     );
+    parsed.webviewLoadErrors = undefined;
   }
 }

--- a/e2e/mobile/utils/speculosUtils.ts
+++ b/e2e/mobile/utils/speculosUtils.ts
@@ -112,7 +112,7 @@ export async function launchSpeculos(appName: string) {
 
   if (!device) {
     const note =
-      "[E2E Setup] Speculos not started: no device returned. Check SEED, COINAPPS, and Docker (local) or CI workflow (remote).";
+      "[E2E Setup] Speculos not started: no device returned. Check SEED, COINAPPS, Docker (local), or SPECULINHO_URL + Speculinho /acquire (remote).";
     globalThis.speculosStartupErrorMessage = note;
     globalThis.speculosFailureStderr = getCapturedStderr();
     log.error("E2E Setup", "[E2E Setup] Speculos not started");
@@ -120,7 +120,7 @@ export async function launchSpeculos(appName: string) {
   }
   if (!device.port) {
     const remoteHint = isSpeculosRemote()
-      ? " Remote Speculos workflow may have failed (port 0). Check CI/GitHub Actions."
+      ? " Remote Speculos (Speculinho) did not return an API port — check logs above for POST /acquire errors, SPECULINHO_URL, and SEED."
       : "";
     const message = [
       "[E2E Setup] Speculos port not set.",

--- a/libs/ledger-live-common/src/e2e/deviceInteraction/DeviceController.ts
+++ b/libs/ledger-live-common/src/e2e/deviceInteraction/DeviceController.ts
@@ -5,6 +5,7 @@ import {
   type DeviceControllerClient,
   type ButtonKey,
 } from "@ledgerhq/speculos-device-controller";
+import { retryAxiosRequest } from "./retryAxiosRequest";
 
 // temp type until DeviceControllerClient exposes buttonFactory type
 type ButtonsController = {
@@ -42,7 +43,17 @@ export const getButtonsWithMemo = (getController: () => DeviceControllerClient) 
   return () => {
     const ctrl = getController();
     if (!cache || cache.ctrl !== ctrl) {
-      cache = { ctrl, buttons: ctrl.buttonFactory() };
+      const inner = ctrl.buttonFactory();
+      cache = {
+        ctrl,
+        buttons: {
+          left: () => retryAxiosRequest(() => inner.left()),
+          right: () => retryAxiosRequest(() => inner.right()),
+          both: () => retryAxiosRequest(() => inner.both()),
+          pressSequence: (keys, delayMs) =>
+            retryAxiosRequest(() => inner.pressSequence(keys, delayMs)),
+        },
+      };
     }
     return cache.buttons;
   };

--- a/libs/ledger-live-common/src/e2e/deviceInteraction/TouchDeviceSimulator.ts
+++ b/libs/ledger-live-common/src/e2e/deviceInteraction/TouchDeviceSimulator.ts
@@ -1,6 +1,7 @@
-import { retryAxiosRequest, getSpeculosAddress, getDeviceLabelCoordinates } from "../speculos";
+import { getSpeculosAddress, getDeviceLabelCoordinates } from "../speculos";
 import axios from "axios";
 import { getEnv } from "@ledgerhq/live-env";
+import { retryAxiosRequest } from "./retryAxiosRequest";
 
 function getSpeculosInfo(): {
   speculosApiPort: number;

--- a/libs/ledger-live-common/src/e2e/deviceInteraction/retryAxiosRequest.ts
+++ b/libs/ledger-live-common/src/e2e/deviceInteraction/retryAxiosRequest.ts
@@ -1,0 +1,63 @@
+import axios, { AxiosError } from "axios";
+
+const RETRYABLE_NODE_CODES = new Set([
+  "ECONNABORTED",
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ENOTFOUND",
+  "ECONNREFUSED",
+  "EPIPE",
+]);
+
+/**
+ * Retries any Axios-based async call on transient failures: retryable HTTP statuses,
+ * no-response network errors, common Node socket codes, or "socket hang up"
+ * (speculos-device-controller / remote Speculos).
+ */
+export async function retryAxiosRequest<T>(
+  requestFn: () => Promise<T>,
+  maxRetries: number = 5,
+  baseDelay: number = 1000,
+  retryableStatusCodes: number[] = [500, 502, 503, 504],
+): Promise<T> {
+  let lastError: AxiosError | Error;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await requestFn();
+    } catch (error) {
+      lastError = error as AxiosError | Error;
+
+      const ax = axios.isAxiosError(error) ? error : null;
+
+      const isRetryableStatus = !!ax?.response && retryableStatusCodes.includes(ax.response.status);
+
+      const isNetworkError = !!ax && !ax.response;
+
+      const socketHangUp =
+        !!ax && typeof ax.message === "string" && ax.message.includes("socket hang up");
+
+      const isRetryableCode = !!ax?.code && RETRYABLE_NODE_CODES.has(ax.code);
+
+      if (
+        (isRetryableStatus || isNetworkError || socketHangUp || isRetryableCode) &&
+        attempt < maxRetries
+      ) {
+        const delay = baseDelay * (attempt + 1);
+        console.warn(
+          `Axios request failed (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${delay}ms...`,
+          {
+            status: ax?.response?.status ?? "network error",
+            message: ax?.message ?? (error as Error).message,
+          },
+        );
+        await new Promise(resolve => setTimeout(resolve, delay));
+        continue;
+      }
+
+      throw lastError;
+    }
+  }
+
+  throw lastError!;
+}

--- a/libs/ledger-live-common/src/e2e/runCli.ts
+++ b/libs/ledger-live-common/src/e2e/runCli.ts
@@ -102,9 +102,7 @@ function parseGetAddressCliOutput(output: string): GetAddressResult {
 
   const { address, path, publicKey } = parsed as Record<string, unknown>;
   if (typeof address !== "string" || typeof path !== "string" || typeof publicKey !== "string") {
-    throw new Error(
-      `CLI getAddress output missing address/path/publicKey. Raw output:\n${output}`,
-    );
+    throw new Error(`CLI getAddress output missing address/path/publicKey. Raw output:\n${output}`);
   }
 
   return parsed as GetAddressResult;
@@ -172,7 +170,7 @@ export function runCliCommand(command: string): Promise<string> {
           errorOutput ? `🧾 CLI Error : ${errorOutput.trim()}` : "",
         ].join("\n");
 
-        reject(new Error(errorDetails));
+        reject(sanitizeError(errorDetails));
       }
     });
 

--- a/libs/ledger-live-common/src/e2e/speculos.ts
+++ b/libs/ledger-live-common/src/e2e/speculos.ts
@@ -11,7 +11,7 @@ import { createSpeculosDeviceCI, releaseSpeculosDeviceCI } from "./speculosCI";
 import type { AppCandidate } from "@ledgerhq/ledger-wallet-framework/bot/types";
 import { DeviceModelId } from "@ledgerhq/devices";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
-import axios, { AxiosError, AxiosResponse } from "axios";
+import axios from "axios";
 import { getEnv } from "@ledgerhq/live-env";
 import { getCryptoCurrencyById } from "../currencies";
 import { DeviceLabels } from "./enum/DeviceLabels";
@@ -50,6 +50,7 @@ import {
   swipeRight,
 } from "./deviceInteraction/TouchDeviceSimulator";
 import { withDeviceController } from "./deviceInteraction/DeviceController";
+import { retryAxiosRequest } from "./deviceInteraction/retryAxiosRequest";
 import { sanitizeError } from ".";
 import { sendVechain } from "./families/vechain";
 import { getDeviceCoordinates } from "./deviceCoordinates";
@@ -532,47 +533,6 @@ export function drainSpeculosScreenshots(port: number): Buffer[] {
   const screenshots = _capturedSpeculosScreenshots.get(port) ?? [];
   _capturedSpeculosScreenshots.delete(port);
   return screenshots;
-}
-
-export async function retryAxiosRequest<T>(
-  requestFn: () => Promise<AxiosResponse<T>>,
-  maxRetries: number = 5,
-  baseDelay: number = 1000,
-  retryableStatusCodes: number[] = [500, 502, 503, 504],
-): Promise<AxiosResponse<T>> {
-  let lastError: AxiosError | Error;
-
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    try {
-      return await requestFn();
-    } catch (error) {
-      lastError = error as AxiosError | Error;
-
-      const isRetryable =
-        axios.isAxiosError(error) &&
-        error.response &&
-        retryableStatusCodes.includes(error.response.status);
-
-      const isNetworkError = axios.isAxiosError(error) && !error.response;
-
-      if ((isRetryable || isNetworkError) && attempt < maxRetries) {
-        const delay = baseDelay * (attempt + 1);
-        console.warn(
-          `Axios request failed (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${delay}ms...`,
-          {
-            status: axios.isAxiosError(error) ? error.response?.status : "network error",
-            message: error.message,
-          },
-        );
-        await new Promise(resolve => setTimeout(resolve, delay));
-        continue;
-      }
-
-      throw lastError;
-    }
-  }
-
-  throw lastError!;
 }
 
 export async function waitFor(text: string, maxAttempts = 60): Promise<string> {

--- a/libs/ledger-live-common/src/e2e/speculosCI.ts
+++ b/libs/ledger-live-common/src/e2e/speculosCI.ts
@@ -5,16 +5,15 @@ import {
   reverseModelMap,
 } from "@ledgerhq/speculos-transport";
 import { SpeculosDevice } from "./speculos";
-import https from "https";
 import { sanitizeError } from "./index";
 import { v4 as uuid } from "uuid";
 
-const { GITHUB_TOKEN, SPECULOS_IMAGE_TAG } = process.env;
-const GIT_API_URL = "https://api.github.com/repos/LedgerHQ/actions/actions/";
-const START_WORKFLOW_ID = "workflows/161487603/dispatches";
-const STOP_WORKFLOW_ID = "workflows/161487604/dispatches";
-const GITHUB_REF = "main";
-const getSpeculosAddress = (runId: string) => `https://${runId}.speculos.aws.stg.ldg-tech.com`;
+/** Speculinho operator base URL (no trailing slash). In CI, set via the `SPECULINHO_URL` secret / env var. */
+function getSpeculinhoBaseUrl(): string | undefined {
+  const raw = process.env.SPECULINHO_URL?.trim();
+  return raw ? raw.replace(/\/+$/, "") : undefined;
+}
+
 const speculosPort = 443;
 
 function uniqueId(): string {
@@ -30,168 +29,189 @@ function slugify(name: string): string {
 }
 
 /**
- * Helper function to make API requests with error handling
+ * DNS-1123 run_id for Speculinho (max 63 chars): lowercase, hyphens, alphanumeric.
  */
-async function githubApiRequest<T = unknown>({
-  method = "POST",
-  urlSuffix,
-  data,
-  params,
-}: {
-  method?: "GET" | "POST";
-  urlSuffix: string;
-  data?: Record<string, unknown>;
-  params?: Record<string, unknown>;
-}): Promise<T> {
-  const url = `${GIT_API_URL}${urlSuffix}`;
-  try {
-    const response = await axios({
-      method,
-      url,
-      headers: {
-        Authorization: `Bearer ${GITHUB_TOKEN}`,
-        Accept: "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-      },
-      data,
-      params,
-    });
-    return response.data;
-  } catch (error) {
-    console.warn(`API Request failed: ${method} ${url}`, sanitizeError(error));
-    throw sanitizeError(error);
-  }
+function makeRunId(deviceParams: DeviceParams): string {
+  const slug = slugify(deviceParams.appName) || "app";
+  const suffix = uniqueId().replace(/-/g, "").slice(0, 12);
+  const combined = `${slug.slice(0, 20)}-${suffix}`;
+  return combined.slice(0, 63);
 }
 
-export function waitForSpeculosReady(
-  deviceId: string,
-  { interval = 2_000, timeout = 150_000 } = {},
-) {
-  return new Promise((resolve, reject) => {
-    const startTime = Date.now();
-    let currentRequest: ReturnType<typeof https.get> | null = null;
-    const url = getSpeculosAddress(deviceId);
+type SpeculinhoAcquireResponse = {
+  run_id?: string;
+  status?: string;
+};
 
-    function cleanup() {
-      if (currentRequest) {
-        currentRequest.destroy();
-        currentRequest = null;
-      }
-    }
+type SpeculinhoStatusResponse = {
+  run_id?: string;
+  status?: "pending" | "ready" | "failed";
+  speculos_url?: string;
+  error_details?: string;
+};
 
-    function check() {
-      cleanup();
-
-      currentRequest = https.get(url, { timeout: 10000 }, res => {
-        if (res.statusCode && res.statusCode >= 200 && res.statusCode < 400) {
-          process.env.SPECULOS_ADDRESS = url;
-          cleanup();
-          console.warn(`Speculos is ready at ${url}`);
-          resolve(true);
-        } else {
-          console.warn(`Speculos not ready yet, status: ${res.statusCode}`);
-          retry();
-        }
-      });
-
-      currentRequest.on("error", error => {
-        console.error(`Request error: ${error.message}`);
-        retry();
-      });
-
-      currentRequest.on("timeout", () => {
-        console.error("Request timeout");
-        retry();
-      });
-    }
-
-    function retry() {
-      if (Date.now() - startTime >= timeout) {
-        cleanup();
-        reject(new Error(`Timeout: ${url} did not become available within ${timeout}ms`));
-      } else {
-        setTimeout(check, interval);
-      }
-    }
-
-    check();
-  });
-}
-
-function createStartPayload(deviceParams: DeviceParams, runId: string) {
+function buildAcquirePayload(deviceParams: DeviceParams, runId: string, seed: string) {
   const { model, firmware, appName, appVersion, dependencies } = deviceParams;
-
-  let additional_args = "-p";
-
-  if (dependencies?.length) {
-    additional_args = [
-      additional_args,
-      ...new Set(
-        dependencies.map(
-          dep =>
-            `-l ${dep.name}:/apps/${conventionalAppSubpath(
-              model,
-              firmware,
-              dep.name,
-              dep.appVersion ?? appVersion,
-            )}`,
-        ),
-      ),
-    ].join(" ");
+  const device = reverseModelMap[model];
+  if (!device) {
+    throw new Error(`[speculosCI] Unsupported device model for Speculinho: ${String(model)}`);
   }
+
+  const rawTag = process.env.SPECULOS_IMAGE_TAG?.trim();
+  const tag =
+    rawTag && rawTag.includes(":") ? rawTag.slice(rawTag.lastIndexOf(":") + 1) : rawTag || "latest";
+
+  const libraries =
+    dependencies?.map(dep => ({
+      name: dep.name,
+      path: `/apps/${conventionalAppSubpath(
+        model,
+        firmware,
+        dep.name,
+        dep.appVersion ?? appVersion,
+      )}`,
+    })) ?? undefined;
 
   return {
-    ref: GITHUB_REF,
-    inputs: {
-      speculos_version: SPECULOS_IMAGE_TAG?.split(":")[1] || "master",
-      coin_app: appName,
-      coin_app_version: appVersion,
-      device: reverseModelMap[model],
-      device_os_version: firmware,
-      run_id: runId,
-      additional_args,
-    },
+    coin_app: appName,
+    coin_app_version: appVersion,
+    device,
+    device_os_version: firmware,
+    seed,
+    run_id: runId,
+    speculos_version: tag,
+    ...(libraries?.length ? { libraries } : {}),
+    /** Matches legacy workflow `additional_args` / local Docker Detox (`-p`). */
+    extra_args: ["-p"],
   };
+}
+
+export async function waitForSpeculosReady(
+  deviceId: string,
+  { interval = 2_000, timeout = 150_000 } = {},
+): Promise<void> {
+  const speculinhoUrl = getSpeculinhoBaseUrl();
+  if (!speculinhoUrl) {
+    throw new Error(
+      "SPECULINHO_URL is not set — required for remote Speculos (Speculinho operator).",
+    );
+  }
+
+  const statusUrl = `${speculinhoUrl}/status/${encodeURIComponent(deviceId)}`;
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < timeout) {
+    try {
+      const res = await axios.get<SpeculinhoStatusResponse>(statusUrl, {
+        timeout: 10_000,
+        validateStatus: s => s >= 200 && s < 500,
+      });
+
+      if (res.status === 200 && res.data) {
+        const { status, speculos_url, error_details } = res.data;
+
+        if (status === "ready" && speculos_url) {
+          process.env.SPECULOS_ADDRESS = speculos_url.replace(/\/+$/, "");
+          console.warn(`Speculos is ready at ${process.env.SPECULOS_ADDRESS}`);
+          return;
+        }
+
+        if (status === "failed") {
+          throw new Error(
+            `[speculosCI] Speculinho instance failed for ${deviceId}: ${error_details ?? JSON.stringify(res.data)}`,
+          );
+        }
+      }
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (msg.includes("Speculinho instance failed")) {
+        throw e;
+      }
+      console.warn(`Speculos status poll error (${deviceId}): ${sanitizeError(e)}`);
+    }
+
+    await new Promise(resolve => setTimeout(resolve, interval));
+  }
+
+  throw new Error(`Timeout: ${statusUrl} did not become ready within ${timeout}ms`);
+}
+
+function formatAcquireFailure(status: number, data: unknown): string {
+  const body = typeof data === "string" ? data : JSON.stringify(data);
+  return `Speculinho POST /acquire failed with HTTP ${status}${body ? `: ${body}` : ""}`;
 }
 
 export async function createSpeculosDeviceCI(
   deviceParams: DeviceParams,
 ): Promise<SpeculosDevice | undefined> {
-  const runId = `${slugify(deviceParams.appName)}-${uniqueId()}`;
-  try {
-    const data = createStartPayload(deviceParams, runId);
-    await githubApiRequest({ urlSuffix: START_WORKFLOW_ID, data });
-    return {
-      id: runId,
-      port: speculosPort,
-      appName: deviceParams.appName,
-      appVersion: deviceParams.appVersion,
-      dependencies: deviceParams.dependencies,
-    };
-  } catch (error) {
-    console.warn(
-      `Failed to create remote Speculos ${deviceParams.appName}:${deviceParams.appVersion}:`,
-      sanitizeError(error),
+  const speculinhoUrl = getSpeculinhoBaseUrl();
+  if (!speculinhoUrl) {
+    throw new Error(
+      "[speculosCI] SPECULINHO_URL is not set. Set the env var (e.g. GitHub Actions secret SPECULINHO_URL on the iOS E2E job) to your Speculinho operator base URL.",
     );
-    return {
-      id: runId,
-      port: 0,
-      appName: deviceParams.appName,
-      appVersion: deviceParams.appVersion,
-      dependencies: deviceParams.dependencies,
-    };
   }
+
+  const seed = process.env.SEED?.trim();
+  if (!seed) {
+    throw new Error("[speculosCI] SEED is not set — required for Speculinho /acquire.");
+  }
+
+  let runId = makeRunId(deviceParams);
+
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const payload = buildAcquirePayload(deviceParams, runId, seed);
+    let res;
+    try {
+      res = await axios.post<SpeculinhoAcquireResponse>(`${speculinhoUrl}/acquire`, payload, {
+        headers: { "Content-Type": "application/json" },
+        validateStatus: () => true,
+      });
+    } catch (error: unknown) {
+      throw new Error(
+        `[speculosCI] Speculinho /acquire transport error (${speculinhoUrl}): ${sanitizeError(error)}`,
+      );
+    }
+
+    if (res.status === 202) {
+      const finalRunId = res.data?.run_id ?? runId;
+      return {
+        id: finalRunId,
+        port: speculosPort,
+        appName: deviceParams.appName,
+        appVersion: deviceParams.appVersion,
+        dependencies: deviceParams.dependencies,
+      };
+    }
+
+    if (res.status === 409) {
+      runId = makeRunId(deviceParams);
+      continue;
+    }
+
+    throw new Error(formatAcquireFailure(res.status, res.data));
+  }
+
+  throw new Error(
+    `[speculosCI] Speculinho /acquire failed after retries (run_id collisions). Last run_id: ${runId}`,
+  );
 }
 
 export async function releaseSpeculosDeviceCI(runId: string) {
-  const data = {
-    ref: GITHUB_REF,
-    inputs: {
-      run_id: runId.toString(),
-    },
-  };
+  const speculinhoUrl = getSpeculinhoBaseUrl();
+  if (!speculinhoUrl) {
+    console.warn("[speculosCI] SPECULINHO_URL is not set; skipping Speculinho release.");
+    return;
+  }
+
   try {
-    await githubApiRequest({ urlSuffix: STOP_WORKFLOW_ID, data });
+    await axios.post(
+      `${speculinhoUrl}/release`,
+      { run_id: runId.toString() },
+      {
+        headers: { "Content-Type": "application/json" },
+        validateStatus: s => s >= 200 && s < 300,
+      },
+    );
   } catch (error) {
     console.warn(`Failed to release remote Speculos ${runId}:`, sanitizeError(error));
   }

--- a/libs/live-dmk-speculos/src/transport/DeviceManagementKitTransportSpeculos.ts
+++ b/libs/live-dmk-speculos/src/transport/DeviceManagementKitTransportSpeculos.ts
@@ -10,6 +10,7 @@ import {
 import { speculosTransportFactory } from "@ledgerhq/device-transport-kit-speculos";
 import { getEnv } from "@ledgerhq/live-env";
 import { ButtonKey, deviceControllerClientFactory } from "@ledgerhq/speculos-device-controller";
+import { withTransientHttpRetries } from "./speculosTransientHttpRetry";
 
 export type SpeculosHttpTransportOpts = {
   apiPort?: string;
@@ -131,10 +132,12 @@ export default class SpeculosHttpTransport extends Transport {
         ),
       );
 
-      deviceManagementEntry.sessionId = await deviceManagementEntry.dmk.connect({
-        device: discoveredDevices[0],
-        sessionRefresherOptions: { isRefresherDisabled: true },
-      });
+      deviceManagementEntry.sessionId = await withTransientHttpRetries("speculos-dmk-connect", () =>
+        deviceManagementEntry.dmk.connect({
+          device: discoveredDevices[0],
+          sessionRefresherOptions: { isRefresherDisabled: true },
+        }),
+      );
     })();
 
     try {
@@ -187,17 +190,23 @@ export default class SpeculosHttpTransport extends Transport {
         : buttonInput;
 
     log("speculos-button", "press-and-release", resolved);
-    return await this.getButtonClient().press(resolved);
+    return await withTransientHttpRetries("speculos-button-press", () =>
+      this.getButtonClient().press(resolved),
+    );
   }
 
   async exchange(apduCommand: Buffer): Promise<Buffer> {
-    try {
-      const { data, statusCode } = await this.dmk.sendApdu({
+    const apdu = new Uint8Array(apduCommand.buffer, apduCommand.byteOffset, apduCommand.byteLength);
+
+    const sendOnce = () =>
+      this.dmk.sendApdu({
         sessionId: this.sessionId,
-        apdu: new Uint8Array(apduCommand.buffer, apduCommand.byteOffset, apduCommand.byteLength),
+        apdu,
       });
-      const responseBuffer = Buffer.from([...data, ...statusCode]);
-      return responseBuffer;
+
+    try {
+      const { data, statusCode } = await withTransientHttpRetries("speculos-send-apdu", sendOnce);
+      return Buffer.from([...data, ...statusCode]);
     } catch {
       const deviceManagementEntry = SpeculosHttpTransport.ensureEntry(
         this.baseUrl,
@@ -210,12 +219,11 @@ export default class SpeculosHttpTransport extends Transport {
       }
       this.sessionId = deviceManagementEntry.sessionId;
 
-      const { data, statusCode } = await this.dmk.sendApdu({
-        sessionId: this.sessionId,
-        apdu: new Uint8Array(apduCommand.buffer, apduCommand.byteOffset, apduCommand.byteLength),
-      });
-      const responseBuffer = Buffer.from([...data, ...statusCode]);
-      return responseBuffer;
+      const { data, statusCode } = await withTransientHttpRetries(
+        "speculos-send-apdu-after-reconnect",
+        sendOnce,
+      );
+      return Buffer.from([...data, ...statusCode]);
     }
   }
 

--- a/libs/live-dmk-speculos/src/transport/speculosTransientHttpRetry.ts
+++ b/libs/live-dmk-speculos/src/transport/speculosTransientHttpRetry.ts
@@ -1,0 +1,86 @@
+import { log } from "@ledgerhq/logs";
+
+const RETRYABLE_HTTP_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+const RETRYABLE_AXIOS_NETWORK_CODES = new Set([
+  "ECONNABORTED",
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ENOTFOUND",
+  "ECONNREFUSED",
+  "EPIPE",
+  "ERR_BAD_RESPONSE",
+]);
+
+export type TransientHttpRetryOptions = {
+  maxAttempts?: number;
+  baseDelayMs?: number;
+};
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/** Walks error.cause and common wrapper fields to detect Axios / transient HTTP failures from DMK. */
+export function isRetryableSpeculosHttpError(error: unknown): boolean {
+  const visit = (e: unknown, depth: number): boolean => {
+    if (depth > 10 || e == null) return false;
+
+    if (typeof e !== "object") return false;
+
+    const obj = e as Record<string, unknown>;
+
+    if (obj.isAxiosError === true) {
+      const status = (obj.response as { status?: number } | undefined)?.status;
+      if (status != null && RETRYABLE_HTTP_STATUSES.has(status)) return true;
+
+      const code = obj.code;
+      if (typeof code === "string" && RETRYABLE_AXIOS_NETWORK_CODES.has(code)) return true;
+
+      // Node often uses ECONNRESET; some stacks only surface this on the Axios message.
+      const msg = String((obj as { message?: string }).message ?? "");
+      if (msg.includes("socket hang up")) return true;
+    }
+
+    const errLike = e as Error & { cause?: unknown };
+    if (errLike.cause != null && visit(errLike.cause, depth + 1)) return true;
+
+    for (const key of ["originalError", "error"] as const) {
+      if (key in obj && visit(obj[key], depth + 1)) return true;
+    }
+
+    return false;
+  };
+
+  return visit(error, 0);
+}
+
+export async function withTransientHttpRetries<T>(
+  label: string,
+  fn: () => Promise<T>,
+  opts?: TransientHttpRetryOptions,
+): Promise<T> {
+  const maxAttempts = opts?.maxAttempts ?? 4;
+  const baseDelayMs = opts?.baseDelayMs ?? 400;
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (e) {
+      lastError = e;
+      const retryable = isRetryableSpeculosHttpError(e);
+      if (!retryable || attempt === maxAttempts) {
+        throw e;
+      }
+      const delayMs = Math.round(baseDelayMs * 2 ** (attempt - 1));
+      log(
+        "speculos-transport",
+        `${label}: transient HTTP failure (attempt ${attempt}/${maxAttempts}), retrying in ${delayMs}ms`,
+      );
+      await sleep(delayMs);
+    }
+  }
+
+  throw lastError;
+}

--- a/patches/detox-allure2-adapter@1.0.0-alpha.42.patch
+++ b/patches/detox-allure2-adapter@1.0.0-alpha.42.patch
@@ -1,6 +1,29 @@
 --- a/dist/listener.js
 +++ b/dist/listener.js
-@@ -75,8 +75,20 @@
+@@ -25,10 +25,18 @@
+     const onError = (0, utils_1.createErrorHandler)(onErrorOption ?? 'warn');
+     const recycleBin = file_handlers_1.RecycleBin.instance(onError);
+     const flushArtifacts = (0, utils_1.once)(async () => {
+-        await Promise.all([
+-            logs?.close(),
+-            videoManager?.stopAndAttach($hook, failing),
+-            recycleBin.clear(),
++        // PATCH: timeout prevents indefinite hang if logkitten close() stalls (e.g. simctl log stream)
++        let _timeoutId;
++        let _timedOut = false;
++        const _flushTimeout = new Promise(resolve => { _timeoutId = setTimeout(() => { _timedOut = true; resolve(); }, 60000); _timeoutId.unref(); });
++        await Promise.race([
++            Promise.all([
++                logs?.close(),
++                videoManager?.stopAndAttach($hook, failing),
++                recycleBin.clear(),
++            ]).then(r => { clearTimeout(_timeoutId); return r; }),
++            _flushTimeout,
+         ]);
+         workerWrapper = logs = screenshots = viewHierarchy = videoManager = undefined;
++        if (_timedOut) process.exit(0);
+     });
+@@ -75,8 +83,20 @@
                  onError,
              });
          }
@@ -23,7 +46,7 @@
              videoManager = new video_1.VideoManager({ device, options: baseOptions, onError });
          }
          if (deviceViewHierarchy && viewHierarchyFactory) {
-@@ -152,7 +164,7 @@
+@@ -152,7 +172,7 @@
      })
          .on('test_fn_failure', async () => {
          failing = true;
@@ -32,3 +55,26 @@
      })
          .on('test_fn_success', async () => {
          await Promise.all([logs?.attachAfterSuccess(api_1.allure), screenshots?.attachSuccess(api_1.allure)]);
+--- a/dist/logs/log-buffer.js
++++ b/dist/logs/log-buffer.js
+@@ -76,15 +76,15 @@
+     }
+     _attachLogs = (allure, failed, after) => {
+         const saveAll = this._options.saveAll ?? false;
+-        if (!saveAll && !failed) {
+-            return;
+-        }
+-        const appContent = this._appEntries.flushAsString();
++        const appContent = this._appEntries.flushAsString();
++        const detoxContent = this._detoxEntries.flushAsString();
++        if (!saveAll && !failed) {
++            return;
++        }
+         if (appContent) {
+             const name = after ? 'app.log' : 'app-before.log';
+             allure.attachment(name, appContent, 'text/plain');
+         }
+-        const detoxContent = this._detoxEntries.flushAsString();
+         if (detoxContent) {
+             const name = after ? 'detox.log' : 'detox-before.log';
+             allure.attachment(name, detoxContent, 'text/plain');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -536,7 +536,7 @@ patchedDependencies:
     hash: 42321bf7b7c77317e644bb216138271640fb39808e74312037dac216f4b9bc5d
     path: patches/buffer@6.0.3.patch
   detox-allure2-adapter@1.0.0-alpha.42:
-    hash: de02364484341fdd00f4e5601cb028842443dcf23b7ce9932c1ff36d073b2e81
+    hash: c0c5e6419e53a25ed902cac4ce3608f467d0332b34c90b669fed2089e2bf97ba
     path: patches/detox-allure2-adapter@1.0.0-alpha.42.patch
   detox@20.51.1:
     hash: 6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61
@@ -2234,7 +2234,7 @@ importers:
         version: 20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2)))
       detox-allure2-adapter:
         specifier: 1.0.0-alpha.42
-        version: 1.0.0-alpha.42(patch_hash=de02364484341fdd00f4e5601cb028842443dcf23b7ce9932c1ff36d073b2e81)(detox@20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2))))(jest-allure2-reporter@2.2.8(@jest/reporters@30.2.0)(jest-docblock@30.2.0)(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2))))
+        version: 1.0.0-alpha.42(patch_hash=c0c5e6419e53a25ed902cac4ce3608f467d0332b34c90b669fed2089e2bf97ba)(detox@20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2))))(jest-allure2-reporter@2.2.8(@jest/reporters@30.2.0)(jest-docblock@30.2.0)(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2))))
       eslint:
         specifier: 8.57.0
         version: 8.57.0
@@ -3276,7 +3276,7 @@ importers:
         version: 20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(@jest/types@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(typescript@6.0.2)))
       detox-allure2-adapter:
         specifier: 1.0.0-alpha.42
-        version: 1.0.0-alpha.42(patch_hash=de02364484341fdd00f4e5601cb028842443dcf23b7ce9932c1ff36d073b2e81)(detox@20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(@jest/types@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(typescript@6.0.2))))(jest-allure2-reporter@2.2.8(@jest/reporters@30.2.0)(@jest/types@30.2.0)(jest-docblock@30.2.0)(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(typescript@6.0.2))))
+        version: 1.0.0-alpha.42(patch_hash=c0c5e6419e53a25ed902cac4ce3608f467d0332b34c90b669fed2089e2bf97ba)(detox@20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(@jest/types@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(typescript@6.0.2))))(jest-allure2-reporter@2.2.8(@jest/reporters@30.2.0)(@jest/types@30.2.0)(jest-docblock@30.2.0)(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(typescript@6.0.2))))
       expect:
         specifier: 'catalog:'
         version: 30.2.0
@@ -58130,7 +58130,7 @@ snapshots:
 
   detect-node@2.1.0: {}
 
-  detox-allure2-adapter@1.0.0-alpha.42(patch_hash=de02364484341fdd00f4e5601cb028842443dcf23b7ce9932c1ff36d073b2e81)(detox@20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(@jest/types@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(typescript@6.0.2))))(jest-allure2-reporter@2.2.8(@jest/reporters@30.2.0)(@jest/types@30.2.0)(jest-docblock@30.2.0)(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(typescript@6.0.2)))):
+  detox-allure2-adapter@1.0.0-alpha.42(patch_hash=c0c5e6419e53a25ed902cac4ce3608f467d0332b34c90b669fed2089e2bf97ba)(detox@20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(@jest/types@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(typescript@6.0.2))))(jest-allure2-reporter@2.2.8(@jest/reporters@30.2.0)(@jest/types@30.2.0)(jest-docblock@30.2.0)(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(typescript@6.0.2)))):
     dependencies:
       archiver: 6.0.2
       detox: 20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(@jest/types@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(typescript@6.0.2)))
@@ -58140,7 +58140,7 @@ snapshots:
       tslib: 2.6.2
       videokitten: 1.0.1
 
-  detox-allure2-adapter@1.0.0-alpha.42(patch_hash=de02364484341fdd00f4e5601cb028842443dcf23b7ce9932c1ff36d073b2e81)(detox@20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2))))(jest-allure2-reporter@2.2.8(@jest/reporters@30.2.0)(jest-docblock@30.2.0)(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2)))):
+  detox-allure2-adapter@1.0.0-alpha.42(patch_hash=c0c5e6419e53a25ed902cac4ce3608f467d0332b34c90b669fed2089e2bf97ba)(detox@20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2))))(jest-allure2-reporter@2.2.8(@jest/reporters@30.2.0)(jest-docblock@30.2.0)(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2)))):
     dependencies:
       archiver: 6.0.2
       detox: 20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2)))


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

-  iOS Speculos migrates from a GitHub Actions-dispatch workflow to a direct REST API against a new Speculinho operator service, configured by a SPECULINHO_URL secret. https://github.com/LedgerHQ/infra-tools/tree/main/docker-linux/speculinho
- Improves E2E test reliability by fixing memory leaks in the mobile test environment and adding a retry mechanism for transient Speculos/axios errors.

CI run : 
- [LNS](https://github.com/LedgerHQ/ledger-live/actions/runs/26051886336)
- [NanoGen5](https://github.com/LedgerHQ/ledger-live/actions/runs/26052018538)
---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
