### PR TITLE
[LWM] fix(mobile): asset detail transfer bottom sheet

### DIFF
--- a/.changeset/fix-asset-detail-transfer-drawer.md
+++ b/.changeset/fix-asset-detail-transfer-drawer.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix transfer bottom sheet opening on Portfolio instead of Asset Detail screen

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import { render, screen, waitFor } from "@tests/test-renderer";
+import { render, screen, waitFor, within } from "@tests/test-renderer";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { NavigatorName, ScreenName } from "~/const";
 import type { State } from "~/reducers/types";
 import AssetDetailNavigator from "../Navigator";
 import { ASSET_DETAIL_TEST_IDS } from "../testIds";
+import { QUICK_ACTIONS_TEST_IDS } from "LLM/features/QuickActions/testIds";
 
 const mockIsCurrencyAvailable = jest.fn().mockReturnValue(false);
 const mockIsAcceptedCurrency = jest.fn().mockReturnValue(false);
@@ -96,9 +97,21 @@ describe("AssetDetail screen layout", () => {
       expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.balanceDetails)).toBeVisible(),
     );
     expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.totalBalance)).toBeVisible();
-    expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.transferButton)).toBeVisible();
+    const transferButton = screen.getByTestId(ASSET_DETAIL_TEST_IDS.transferButton);
+    expect(transferButton).toBeVisible();
     expect(screen.getByText("Total balance")).toBeVisible();
-    expect(screen.getByText("Transfer")).toBeVisible();
+    expect(within(transferButton).getByText("Transfer")).toBeVisible();
+  });
+
+  it("opens the transfer drawer on the asset detail screen when the transfer button is pressed", async () => {
+    const { user } = render(<AssetDetailTestNavigator />, withBtcAccounts(2));
+
+    const transferButton = await screen.findByTestId(ASSET_DETAIL_TEST_IDS.transferButton);
+    await user.press(transferButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId(QUICK_ACTIONS_TEST_IDS.transferDrawer.container)).toBeVisible();
+    });
   });
 
   it("renders the market price section with title and chart placeholder", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
@@ -6,6 +6,7 @@ import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import type { DistributionItem } from "@ledgerhq/types-live";
 import { TrackScreen } from "~/analytics";
 import type { AssetDetailCurrencyProps } from "LLM/features/AssetDetail/types";
+import { TransferDrawer } from "LLM/features/QuickActions";
 import { ASSET_DETAIL_TEST_IDS } from "../../testIds";
 import { BalanceGraph } from "./components/BalanceGraph";
 import { BalanceDetails } from "./components/BalanceDetails";
@@ -65,6 +66,7 @@ export function AssetDetailView({
         </Box>
       </ScrollView>
       <Footer currency={currency} />
+      <TransferDrawer />
       <AssetCoinOptionsSheetView
         isOpen={coinOptions.isCoinOptionsSheetOpen}
         onClose={coinOptions.closeCoinOptions}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/TotalBalanceView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/TotalBalanceView.tsx
@@ -37,7 +37,7 @@ export function TotalBalanceView({
         </Text>
       </Box>
       <Button
-        appearance="base"
+        appearance="gray"
         size="md"
         icon={TransferVertical}
         onPress={onTransferPress}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Tap **Transfer** on the asset detail screen and verify the bottom sheet opens on the same screen (not after navigating back to Portfolio).
  - Open Transfer from Portfolio still works as before.
  - Visual check: the Transfer button on the asset detail screen uses the new gray appearance matching the Figma spec.

### 📝 Description

**Problem**: Tapping the **Transfer** button on the asset detail screen dispatched `openTransferDrawer` to the redux `transferDrawer` slice, but the `<TransferDrawer />` UI was only mounted inside the Portfolio screen. The bottom sheet therefore opened on Portfolio and was only visible to the user after navigating back — instead of appearing on the asset detail screen itself.

**Solution**: Mount `<TransferDrawer />` inside `AssetDetailView` so the bottom sheet renders on the asset detail screen when its open state is toggled from there. Also updated the Transfer button `appearance` from `base` to `gray` in `TotalBalanceView` to match the Figma spec.

**Tests**: Added an integration test that presses the Transfer button on the asset detail screen and asserts the `transfer-drawer` container becomes visible. Scoped a pre-existing assertion that searched for the text "Transfer" globally, since the mounted drawer's title also contains that word.

https://github.com/user-attachments/assets/53d25cc8-e087-46e9-8eae-39258dbc13ba

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30709](https://ledgerhq.atlassian.net/browse/LIVE-30709)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30709]: https://ledgerhq.atlassian.net/browse/LIVE-30709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ