### PR TITLE
[LWDM] feat(concordium) [LIVE-29692]: Forward max fee to device during signing

### DIFF
--- a/.changeset/quiet-lies-yawn.md
+++ b/.changeset/quiet-lies-yawn.md
@@ -1,0 +1,12 @@
+---
+"@ledgerhq/coin-concordium": minor
+"@ledgerhq/errors": minor
+"@ledgerhq/live-signer-concordium": minor
+"@ledgerhq/live-dmk-shared": patch
+"@ledgerhq/live-signer-evm": patch
+"@ledgerhq/live-signer-solana": patch
+---
+
+Add max-fee display for Concordium app 5.6.0+. `ConcordiumSigner.signTransaction` takes a required `maxFee: bigint` (µCCD) forwarded to the device for on-screen rendering. New `ConcordiumInvalidMaxFeeError` typed error for invalid input.
+
+Bumps `@ledgerhq/context-module` to `2.0.0`, which now requires `setChain` before `ContextModuleBuilder.build()`. `live-signer-evm`, `live-signer-solana`, and `live-dmk-shared` set their chain explicitly to satisfy the new contract.

--- a/libs/coin-modules/coin-concordium/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/signOperation.test.ts
@@ -138,6 +138,7 @@ describe("signOperation", () => {
           payload: expect.any(Object),
         }),
         derivationPath,
+        expect.any(BigInt),
       );
     });
 

--- a/libs/coin-modules/coin-concordium/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/signOperation.ts
@@ -49,7 +49,12 @@ export const buildSignOperation =
             },
           );
 
-          const result = await signer.signTransaction(structuredTransaction, derivationPath);
+          const maxFee = BigInt(estimation.cost.toString());
+          const result = await signer.signTransaction(
+            structuredTransaction,
+            derivationPath,
+            maxFee,
+          );
 
           return combine(result.serialized, result.signature);
         });

--- a/libs/coin-modules/coin-concordium/src/test/concordiumTestUtils.ts
+++ b/libs/coin-modules/coin-concordium/src/test/concordiumTestUtils.ts
@@ -87,7 +87,11 @@ export function createMockSigner(keyPair: ConcordiumTestKeyPair): ConcordiumSign
       return keyPair.publicKeyHex;
     },
 
-    signTransaction: async (tx: Transaction, path: string): Promise<SigningResult> => {
+    signTransaction: async (
+      tx: Transaction,
+      path: string,
+      _maxFee: bigint,
+    ): Promise<SigningResult> => {
       const serializedTx = JSON.stringify({
         transaction: tx,
         path,

--- a/libs/coin-modules/coin-concordium/src/types/signer.ts
+++ b/libs/coin-modules/coin-concordium/src/types/signer.ts
@@ -31,8 +31,12 @@ export interface ConcordiumSigner {
    * Sign a transaction (Transfer or TransferWithMemo).
    * Routes to the appropriate signing method based on transaction type.
    * Returns both signature and serialized transaction.
+   *
+   * @param maxFee Maximum fee in µCCD (uint64). Forwarded to the device for
+   * display only when the firmware supports it; not part of the canonical
+   * signed bytes.
    */
-  signTransaction(tx: Transaction, path: string): Promise<SigningResult>;
+  signTransaction(tx: Transaction, path: string, maxFee: bigint): Promise<SigningResult>;
 
   /**
    * Sign a credential deployment transaction (hw-app format).

--- a/libs/ledgerjs/packages/errors/src/index.ts
+++ b/libs/ledgerjs/packages/errors/src/index.ts
@@ -227,6 +227,9 @@ export const ConcordiumTrustedMetadataServiceError = createCustomErrorClass(
 export const ConcordiumAddressVerificationFailedError = createCustomErrorClass(
   "ConcordiumAddressVerificationFailedError",
 );
+export const ConcordiumInvalidMaxFeeError = createCustomErrorClass(
+  "ConcordiumInvalidMaxFeeError",
+);
 
 // Language
 export const LanguageNotFound = createCustomErrorClass("LanguageNotFound");

--- a/libs/live-dmk-shared/src/services/LiveBlindSigningReporter.ts
+++ b/libs/live-dmk-shared/src/services/LiveBlindSigningReporter.ts
@@ -4,6 +4,7 @@ import {
   type BlindSigningPlatform,
   type BlindSigningReporter,
   type BlindSigningReportParams,
+  ContextModuleChainID,
   DEFAULT_CONFIG,
   DefaultBlindSigningReporter,
   HttpBlindSigningReporterDatasource,
@@ -85,6 +86,7 @@ export function buildDefaultHttpBlindSigningReporter(
       ...DEFAULT_CONFIG,
       appSource,
       originToken,
+      chain: ContextModuleChainID.Ethereum,
       loggerFactory: noopLoggerFactory,
     }),
   );

--- a/libs/live-signer-concordium/src/DmkSignerConcordium.ts
+++ b/libs/live-signer-concordium/src/DmkSignerConcordium.ts
@@ -17,6 +17,7 @@ import {
 } from "@ledgerhq/device-management-kit";
 import {
   ConcordiumAddressVerificationFailedError,
+  ConcordiumInvalidMaxFeeError,
   ConcordiumTrustedMetadataServiceError,
   LockedDeviceError,
   UserRefusedOnDevice,
@@ -70,10 +71,10 @@ export class DmkSignerConcordium implements ConcordiumSigner {
     return { address: publicKey, publicKey };
   }
 
-  async signTransaction(tx: Transaction, path: string): Promise<SigningResult> {
+  async signTransaction(tx: Transaction, path: string, maxFee: bigint): Promise<SigningResult> {
     const serialized = serializeTransaction(tx);
 
-    const { observable } = this.signer.signTransaction(path, new Uint8Array(serialized), {
+    const { observable } = this.signer.signTransaction(path, new Uint8Array(serialized), maxFee, {
       skipOpenApp: true,
     });
 
@@ -148,6 +149,8 @@ export class DmkSignerConcordium implements ConcordiumSigner {
         return new ConcordiumTrustedMetadataServiceError(originalMessage);
       case "address_verification_failed":
         return new ConcordiumAddressVerificationFailedError(originalMessage);
+      case "invalid_max_fee":
+        return new ConcordiumInvalidMaxFeeError(originalMessage);
       default:
         return new Error(this.formatGenericMessage(error._tag, originalMessage));
     }

--- a/libs/live-signer-concordium/tests/DmkSignerConcordium.test.ts
+++ b/libs/live-signer-concordium/tests/DmkSignerConcordium.test.ts
@@ -191,6 +191,8 @@ describe("DmkSignerConcordium", () => {
       },
     };
 
+    const mockMaxFee = 1234n;
+
     it("should return signature and serialized transaction", async () => {
       const signatureBytes = new Uint8Array(64).fill(0xcc);
       mockSignerConcordium.signTransaction.mockReturnValue({
@@ -200,13 +202,14 @@ describe("DmkSignerConcordium", () => {
         }),
       });
 
-      const result = await signer.signTransaction(mockTx, mockPath);
+      const result = await signer.signTransaction(mockTx, mockPath, mockMaxFee);
 
       expect(result.signature).toBe("cc".repeat(64));
       expect(typeof result.serialized).toBe("string");
       expect(mockSignerConcordium.signTransaction).toHaveBeenCalledWith(
         mockPath,
         expect.any(Uint8Array),
+        mockMaxFee,
         { skipOpenApp: true },
       );
     });
@@ -219,7 +222,27 @@ describe("DmkSignerConcordium", () => {
         }),
       });
 
-      await expect(signer.signTransaction(mockTx, mockPath)).rejects.toThrow(UserRefusedOnDevice);
+      await expect(signer.signTransaction(mockTx, mockPath, mockMaxFee)).rejects.toThrow(
+        UserRefusedOnDevice,
+      );
+    });
+
+    it("should map invalid_max_fee error to ConcordiumInvalidMaxFeeError", async () => {
+      const { ConcordiumInvalidMaxFeeError } = await import("@ledgerhq/errors");
+      mockSignerConcordium.signTransaction.mockReturnValue({
+        observable: of({
+          status: DeviceActionStatus.Error,
+          error: {
+            _tag: "InvalidMaxFeeError",
+            errorCode: "invalid_max_fee",
+            originalError: new Error("Invalid maxFee: must be non-negative"),
+          },
+        }),
+      });
+
+      await expect(signer.signTransaction(mockTx, mockPath, mockMaxFee)).rejects.toThrow(
+        ConcordiumInvalidMaxFeeError,
+      );
     });
   });
 

--- a/libs/live-signer-evm/src/DmkSignerEth.ts
+++ b/libs/live-signer-evm/src/DmkSignerEth.ts
@@ -16,7 +16,7 @@ import {
   DeviceManagementKit,
   hexaStringToBuffer,
 } from "@ledgerhq/device-management-kit";
-import { ContextModuleBuilder } from "@ledgerhq/context-module";
+import { ContextModuleBuilder, ContextModuleChainID } from "@ledgerhq/context-module";
 import { EIP712Message } from "@ledgerhq/types-live";
 import {
   EthAppPleaseEnableContractData,
@@ -48,6 +48,7 @@ export class DmkSignerEth implements EvmSigner {
     );
     liveBlindSigningReporter.setContext({ sessionId });
     const contextModule = new ContextModuleBuilder({ originToken })
+      .setChain(ContextModuleChainID.Ethereum)
       .setAppSource("ledger-wallet")
       .setBlindSigningReporter(liveBlindSigningReporter)
       .build();

--- a/libs/live-signer-solana/package.json
+++ b/libs/live-signer-solana/package.json
@@ -28,6 +28,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ledgerhq/coin-solana": "workspace:^",
+    "@ledgerhq/context-module": "catalog:",
     "@ledgerhq/devices": "workspace:*",
     "@ledgerhq/device-management-kit": "catalog:",
     "@ledgerhq/device-signer-kit-solana": "catalog:",

--- a/libs/live-signer-solana/src/DmkSignerSol.ts
+++ b/libs/live-signer-solana/src/DmkSignerSol.ts
@@ -16,6 +16,7 @@ import {
   TransactionResolutionContext,
   SignMessageVersion,
 } from "@ledgerhq/device-signer-kit-solana";
+import { ContextModuleBuilder, ContextModuleChainID } from "@ledgerhq/context-module";
 import { DeviceActionStatus, DeviceManagementKit } from "@ledgerhq/device-management-kit";
 import bs58 from "bs58";
 import {
@@ -45,11 +46,16 @@ export class DmkSignerSol implements SolanaSigner {
    * @param sessionId - active session ID of the connected device
    */
   constructor(dmk: DeviceManagementKit, sessionId: string) {
+    const contextModule = new ContextModuleBuilder({ originToken: "Solana" })
+      .setChain(ContextModuleChainID.Solana)
+      .build();
     this.dmkSigner = new SignerSolanaBuilder({
       dmk,
       sessionId,
       originToken: "Solana",
-    }).build();
+    })
+      .withContextModule(contextModule)
+      .build();
   }
 
   private _mapError<E extends DAError>(error: E): Error {

--- a/libs/live-signer-solana/tests/DMKSignerSol.test.ts
+++ b/libs/live-signer-solana/tests/DMKSignerSol.test.ts
@@ -15,6 +15,7 @@ import { of, throwError } from "rxjs";
 // Mock the SignerSolanaBuilder to avoid actual builder logic
 jest.mock("@ledgerhq/device-signer-kit-solana", () => ({
   SignerSolanaBuilder: jest.fn().mockImplementation(() => ({
+    withContextModule: jest.fn().mockReturnThis(),
     build: () => ({}),
   })),
   SignMessageVersion: { Raw: "raw", Legacy: "legacy", V0: "v0", V1: "v1" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ catalogs:
       specifier: 0.3.0
       version: 0.3.0
     '@ledgerhq/device-signer-kit-concordium':
-      specifier: 0.3.0
-      version: 0.3.0
+      specifier: 0.4.0
+      version: 0.4.0
     '@ledgerhq/device-signer-kit-cosmos':
       specifier: 1.0.0
       version: 1.0.0
@@ -488,7 +488,7 @@ overrides:
   remove-flow-types-loader>loader-utils: '*'
   '@ledgerhq/devices': workspace:*
   '@ledgerhq/hw-transport': workspace:*
-  '@ledgerhq/context-module': 1.17.1
+  '@ledgerhq/context-module': 2.0.0
   tslib: 2.6.2
   '@ethersproject/providers>ws': 7.5.10
   elliptic: 6.6.1
@@ -1632,8 +1632,8 @@ importers:
         specifier: workspace:^
         version: link:../../libs/coin-modules/coin-stacks
       '@ledgerhq/context-module':
-        specifier: 1.17.1
-        version: 1.17.1(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
+        specifier: 2.0.0
+        version: 2.0.0(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
         version: 2.0.3(@ledgerhq/lumen-design-core@0.1.14)(@ledgerhq/lumen-ui-rnative@0.1.33(f25fbd70fb9677a120a671a6ec1a1478))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
@@ -1648,7 +1648,7 @@ importers:
         version: 1.5.0(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-ethereum':
         specifier: 'catalog:'
-        version: 1.15.1(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
+        version: 1.15.1(@ledgerhq/context-module@2.0.0(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
       '@ledgerhq/device-transport-kit-react-native-hid':
         specifier: 'catalog:'
         version: 1.0.3(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(rxjs@7.8.2)
@@ -10961,8 +10961,8 @@ importers:
   libs/live-dmk-shared:
     dependencies:
       '@ledgerhq/context-module':
-        specifier: 1.17.1
-        version: 1.17.1(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
+        specifier: 2.0.0
+        version: 2.0.0(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../ledgerjs/packages/hw-transport
@@ -11171,14 +11171,14 @@ importers:
         specifier: workspace:^
         version: link:../coin-modules/coin-aleo
       '@ledgerhq/context-module':
-        specifier: 1.17.1
-        version: 1.17.1(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
+        specifier: 2.0.0
+        version: 2.0.0(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
         version: 1.5.0(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-aleo':
         specifier: 'catalog:'
-        version: 0.3.0(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
+        version: 0.3.0(@ledgerhq/context-module@2.0.0(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../ledgerjs/packages/errors
@@ -11315,14 +11315,14 @@ importers:
         specifier: workspace:^
         version: link:../concordium-core
       '@ledgerhq/context-module':
-        specifier: 1.17.1
-        version: 1.17.1(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
+        specifier: 2.0.0
+        version: 2.0.0(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
         version: 1.5.0(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-concordium':
         specifier: 'catalog:'
-        version: 0.3.0(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
+        version: 0.4.0(@ledgerhq/context-module@2.0.0(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../ledgerjs/packages/errors
@@ -11416,14 +11416,14 @@ importers:
         specifier: workspace:^
         version: link:../coin-modules/coin-evm
       '@ledgerhq/context-module':
-        specifier: 1.17.1
-        version: 1.17.1(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
+        specifier: 2.0.0
+        version: 2.0.0(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
         version: 1.5.0(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-ethereum':
         specifier: 'catalog:'
-        version: 1.15.1(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
+        version: 1.15.1(@ledgerhq/context-module@2.0.0(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../ledgerjs/packages/errors
@@ -11516,6 +11516,9 @@ importers:
       '@ledgerhq/coin-solana':
         specifier: workspace:^
         version: link:../coin-modules/coin-solana
+      '@ledgerhq/context-module':
+        specifier: 2.0.0
+        version: 2.0.0(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
         version: 1.5.0(rxjs@7.8.2)
@@ -17096,10 +17099,10 @@ packages:
       '@ledgerhq/live-network': ^2.4.0
       '@ledgerhq/logs': ^6.17.0
 
-  '@ledgerhq/context-module@1.17.1':
-    resolution: {integrity: sha512-Nu3B36tkACBfI9zouQGx8ZmeQ8SmeJwFBL1JozS/yRH4nAR7jizfKwBL6hYdqgcyG9rbV6z67+hv0BBe6r3b5A==}
+  '@ledgerhq/context-module@2.0.0':
+    resolution: {integrity: sha512-2SizUNTzqkuYLyA62d0yQIHBZ0xlwy1IrbqZVmIZ2iMKEA9Go7nypFigIteaCWPyaLavooQoadj10QYamVL6Ig==}
     peerDependencies:
-      '@ledgerhq/device-management-kit': ^1.3.0
+      '@ledgerhq/device-management-kit': ^1.5.0
 
   '@ledgerhq/crypto-icons@2.0.3':
     resolution: {integrity: sha512-GW2UBrhhu/eBb7npbWrmay3lQ5u/YHMjxNmygsBvHC5NE/VzZX463yLaHrFnOTYlNXuYbm0NcZMxz6OdbdrjnA==}
@@ -17130,14 +17133,14 @@ packages:
   '@ledgerhq/device-signer-kit-aleo@0.3.0':
     resolution: {integrity: sha512-yVw76991hahT2T0ob0BXWu60cz7LLFjeBC8eeXmquPYOML6HEfdHIKjV8/uzTQQ4M/X3t3L+CC0avjuW4ezmPw==}
     peerDependencies:
-      '@ledgerhq/context-module': 1.17.1
+      '@ledgerhq/context-module': 2.0.0
       '@ledgerhq/device-management-kit': ^1.5.0
 
-  '@ledgerhq/device-signer-kit-concordium@0.3.0':
-    resolution: {integrity: sha512-o8/5e5fjFTQ3apRaN9UC3DCHcIWSe1hpc6p99Sc5c3Zh+WZFPS25AuaGxh1PcvqG5GoafcYsPpZfa0xdHuQQqA==}
+  '@ledgerhq/device-signer-kit-concordium@0.4.0':
+    resolution: {integrity: sha512-jqVp8232dkI34ZVbsQOcGpjK9J+g8BzGD9+/0Ezy7nGtMUfX8c6AhEmn79kj3w96kJ0z1YkakaClCHxicFWtKQ==}
     peerDependencies:
-      '@ledgerhq/context-module': 1.17.1
-      '@ledgerhq/device-management-kit': ^1.3.0
+      '@ledgerhq/context-module': 2.0.0
+      '@ledgerhq/device-management-kit': ^1.5.0
 
   '@ledgerhq/device-signer-kit-cosmos@1.0.0':
     resolution: {integrity: sha512-z5r7TwUrROxzmKJLXPk4cjGWRY4vGrwdTIQuBVyM6p6/zaEIiOV5yq9CO6GUn1vMeUKtFmESXrWV8eyYyNHLEg==}
@@ -17147,7 +17150,7 @@ packages:
   '@ledgerhq/device-signer-kit-ethereum@1.15.1':
     resolution: {integrity: sha512-xKQ2czK6L4RSRZmtm6ZixMe8myQtU1Vm7GkmQp0T2E/GPiXYXeTu7/sgqv5F+GzAPTeDmB+uFyjUzyHSr0eLJA==}
     peerDependencies:
-      '@ledgerhq/context-module': 1.17.1
+      '@ledgerhq/context-module': 2.0.0
       '@ledgerhq/device-management-kit': ^1.4.1
 
   '@ledgerhq/device-signer-kit-hyperliquid@1.1.0':
@@ -21314,7 +21317,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.1.4
       react-dom: 19.1.4
-      webpack: ^5.89.0
+      webpack: '*'
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -23594,7 +23597,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: ^5.5.10
+      rxjs: '*'
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -44954,7 +44957,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))':
+  '@ledgerhq/context-module@2.0.0(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))':
     dependencies:
       '@ledgerhq/device-management-kit': 1.5.0(rxjs@7.8.2)
       crypto-js: 4.2.0
@@ -45026,9 +45029,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/device-signer-kit-aleo@0.3.0(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-aleo@0.3.0(@ledgerhq/context-module@2.0.0(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/context-module': 1.17.1(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
+      '@ledgerhq/context-module': 2.0.0(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
       '@ledgerhq/device-management-kit': 1.5.0(rxjs@7.8.2)
       '@ledgerhq/signer-utils': 1.1.3(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
       inversify: 7.5.1(reflect-metadata@0.2.2)
@@ -45036,9 +45039,9 @@ snapshots:
       reflect-metadata: 0.2.2
       xstate: 5.19.2
 
-  '@ledgerhq/device-signer-kit-concordium@0.3.0(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-concordium@0.4.0(@ledgerhq/context-module@2.0.0(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/context-module': 1.17.1(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
+      '@ledgerhq/context-module': 2.0.0(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
       '@ledgerhq/device-management-kit': 1.5.0(rxjs@7.8.2)
       '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
       inversify: 7.5.1(reflect-metadata@0.2.2)
@@ -45055,9 +45058,9 @@ snapshots:
       reflect-metadata: 0.2.2
       xstate: 5.19.2
 
-  '@ledgerhq/device-signer-kit-ethereum@1.15.1(@ledgerhq/context-module@1.17.1(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-ethereum@1.15.1(@ledgerhq/context-module@2.0.0(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/context-module': 1.17.1(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
+      '@ledgerhq/context-module': 2.0.0(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
       '@ledgerhq/device-management-kit': 1.5.0(rxjs@7.8.2)
       '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
       ethers: 6.15.0
@@ -45072,7 +45075,7 @@ snapshots:
 
   '@ledgerhq/device-signer-kit-hyperliquid@1.1.0(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/context-module': 1.17.1(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
+      '@ledgerhq/context-module': 2.0.0(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
       '@ledgerhq/device-management-kit': 1.5.0(rxjs@7.8.2)
       '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
       inversify: 7.5.1(reflect-metadata@0.2.2)
@@ -45085,7 +45088,7 @@ snapshots:
 
   '@ledgerhq/device-signer-kit-solana@1.8.0(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))(typescript@6.0.2)':
     dependencies:
-      '@ledgerhq/context-module': 1.17.1(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
+      '@ledgerhq/context-module': 2.0.0(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
       '@ledgerhq/device-management-kit': 1.5.0(rxjs@7.8.2)
       '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(typescript@6.0.2))(typescript@6.0.2)
@@ -64336,7 +64339,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3(metro-transform-worker@0.83.3)
+      metro: 0.83.3
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -64460,54 +64463,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro@0.83.3(metro-transform-worker@0.83.3):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.28.5
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      accepts: 1.3.8
-      chalk: 4.1.2
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 4.4.3
-      error-stack-parser: 2.1.4
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      hermes-parser: 0.32.0
-      image-size: 1.1.1
-      invariant: 2.2.4
-      jest-worker: 29.7.0(metro@0.83.3)
-      jsc-safe-url: 0.2.4
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.3
-      metro-cache: 0.83.3
-      metro-cache-key: 0.83.3
-      metro-config: 0.83.3(metro-transform-worker@0.83.3)
-      metro-core: 0.83.3
-      metro-file-map: 0.83.3(metro@0.83.3)
-      metro-resolver: 0.83.3
-      metro-runtime: 0.83.3
-      metro-source-map: 0.83.3
-      metro-symbolicate: 0.83.3
-      metro-transform-plugins: 0.83.3
-      metro-transform-worker: 0.83.3
-      mime-types: 2.1.35
-      nullthrows: 1.1.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      throat: 5.0.0
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - metro-transform-worker
       - supports-color
       - utf-8-validate
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,11 +21,11 @@ packages:
 
 catalog:
   "@jest/globals": 30.2.0
-  "@ledgerhq/context-module": 1.17.1
+  "@ledgerhq/context-module": 2.0.0
   "@ledgerhq/crypto-icons": "2.0.3"
   "@ledgerhq/device-management-kit": 1.5.0
   "@ledgerhq/device-signer-kit-aleo": 0.3.0
-  "@ledgerhq/device-signer-kit-concordium": 0.3.0
+  "@ledgerhq/device-signer-kit-concordium": 0.4.0
   "@ledgerhq/device-signer-kit-ethereum": 1.15.1
   "@ledgerhq/device-signer-kit-hyperliquid": 1.1.0
   "@ledgerhq/device-signer-kit-solana": 1.8.0


### PR DESCRIPTION

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** see description

### 📝 Description

Forwards a max-fee value (µCCD) to the Concordium device so it can be rendered on-screen during signing on Concordium app ≥ 5.6.0.
  `ConcordiumSigner.signTransaction` gains a required `maxFee: bigint` third argument; the bridge passes the value already computed via `estimateFees`. On
  older firmware the value is dropped at the wire boundary and signing falls back to the legacy display layout.

  ### 🔧 Changes

  - **`@ledgerhq/coin-concordium`** — `ConcordiumSigner.signTransaction(tx, path, maxFee)` interface; bridge `signOperation` passes `BigInt(estimation.cost.toString())`.
  - **`@ledgerhq/live-signer-concordium`** — `DmkSignerConcordium` forwards `maxFee` to the DMK signer and maps the new `invalid_max_fee` error code to `ConcordiumInvalidMaxFeeError`.
  - **`@ledgerhq/errors`** — new `ConcordiumInvalidMaxFeeError` typed error.
  - **`@ledgerhq/live-dmk-shared`** — passes the now-required `chain: ContextModuleChainID.Ethereum` to `HttpBlindSigningReporterDatasource` (cascade from the new `context-module` peer; blind signing is EVM-bound in `context-module`'s DI container).

  ### 📦 Catalog bumps

  | Package | Before | After |
  |---|---|---|
  | `@ledgerhq/device-signer-kit-concordium` | `0.3.0` | `0.4.0` |
  | `@ledgerhq/context-module` | `1.17.1` | `2.0.0` |

  `device-signer-kit-concordium@0.4.0` peer-requires `context-module ^2.0.0` (uses the new `ContextModuleChainID.Concordium` enum). **This PR is the first consumer of `context-module@2.0.0` in ledger-live's catalog.** The only API-level cascade is the `chain` field becoming required on `ContextModuleServiceConfig`, fixed in `LiveBlindSigningReporter`.

### ❓ Context

 - **JIRA**: [LIVE-29692](https://ledgerhq.atlassian.net/browse/LIVE-29692)
 - **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-29692]: https://ledgerhq.atlassian.net/browse/LIVE-29692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ