### PR TITLE
[LWDM] feat(LIVE-29447): sort wallet quotes by net countervalue

### DIFF
--- a/.changeset/bright-falcons-stack.md
+++ b/.changeset/bright-falcons-stack.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/wallet-api-exchange-module": minor
+"@ledgerhq/live-common": minor
+---
+
+sort wallet-api swap quotes by net countervalue

--- a/libs/exchange-module/src/types.ts
+++ b/libs/exchange-module/src/types.ts
@@ -114,6 +114,7 @@ export type SwapLiveError = {
 
 export type UniswapOrderType = "classic" | "uniswapxv2" | "all";
 export type QuotesAppPlatform = "lld" | "llm-ios" | "llm-android" | "unknown";
+export type QuoteSortBy = "netCounterValue";
 
 export type QuotesInput = {
   amount: string;
@@ -131,6 +132,7 @@ export type QuotesInput = {
 export type GetQuotesArgs = {
   providers: string[];
   data: QuotesInput;
+  sortBy?: QuoteSortBy;
   headers?: Array<[string, string]>;
   signal?: AbortSignal;
 };

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/getQuotes.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/getQuotes.test.ts
@@ -288,6 +288,61 @@ describe("getQuotes", () => {
     expect(fetchQuotesMock).toHaveBeenCalledTimes(1);
   });
 
+  it("returns plain Quote objects sorted by netCounterValue", async () => {
+    const feeContext = {
+      maxFeePerGas: undefined,
+      gasPrice: undefined,
+      defaultGasLimit: "21000",
+      estimatedFeesAtomic: new BigNumber(0),
+      balanceAtomic: new BigNumber("5000000000000000000"),
+      feeCurrencyId: "ethereum",
+      feeCurrencyMagnitude: 18,
+      mainAccountCurrencyId: "ethereum",
+    };
+    fetchNetworkFeeContextMock.mockResolvedValue(feeContext);
+    computeFeeEstimateMock.mockImplementation(raw => {
+      if (raw.key === "higher-receive-with-fees") {
+        return {
+          estimatedNetworkFee: { amount: "100000000000000000", currencyId: "ethereum" },
+          approvalNetworkFee: { amount: "100000000000000000", currencyId: "ethereum" },
+          notEnoughBalance: false,
+        };
+      }
+      return {
+        estimatedNetworkFee: undefined,
+        approvalNetworkFee: undefined,
+        notEnoughBalance: false,
+      };
+    });
+    fetchQuotesMock.mockResolvedValue({
+      rawQuotes: [
+        makeRawQuote({
+          key: "higher-receive-with-fees",
+          amountTo: 1,
+          networkFees: { currency: "ethereum" },
+        }),
+        makeRawQuote({
+          key: "lower-receive-no-fees",
+          amountTo: 0.99,
+          networkFees: { currency: "ethereum" },
+        }),
+      ],
+      providerErrors: [],
+    });
+
+    const response = await getQuotes(makeArgs("ethereum", "bitcoin"), {
+      ...emptyContext,
+      spotPrices: { bitcoin: 30_000, ethereum: 2_000 },
+    });
+
+    expect(response.quotes.map(q => q.key)).toEqual([
+      "lower-receive-no-fees",
+      "higher-receive-with-fees",
+    ]);
+    expect(response.quotes[0]).not.toHaveProperty("netCounterValue");
+    expect(response.quotes[0]).not.toHaveProperty("quote");
+  });
+
   describe("digested global errors (computeQuotesErrors integration)", () => {
     it("emits `amountTooLow` alongside `noQuotes` when every provider rejected on a min bound that brackets the input", async () => {
       // amount = "1", min bounds reported = "10" and "12" -> lowest is "10".

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/getQuotes.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/getQuotes.ts
@@ -12,6 +12,7 @@ import { fetchQuotes } from "./service/fetchQuotes";
 import { computeFeeEstimate } from "./normalizer/networkFeeEstimate";
 import { buildFormatContext } from "./normalizer/buildFormatContext";
 import { normalizeQuote } from "./normalizer";
+import { sortQuotes } from "./sorting/sortQuotes";
 import {
   QuotesErrorCodes,
   type GetQuotesArgs,
@@ -190,13 +191,19 @@ export async function getQuotes(
     const feeEstimate = feeContext ? computeFeeEstimate(raw, feeContext) : undefined;
     return normalizeQuote(raw, providerData, normalizationContext, feeEstimate, formatContext);
   });
+  const sortedQuotes = sortQuotes(quotes, {
+    sortBy: args.sortBy,
+    receiveCurrencyId: quotesInput.receiveCurrencyId,
+    spotPrices: context.spotPrices,
+    feeCurrencyMagnitude: feeContext?.feeCurrencyMagnitude,
+  });
 
   return {
-    quotes,
+    quotes: sortedQuotes,
     providerErrors,
     warnings,
     errors: computeQuotesErrors({
-      successfulQuotesCount: quotes.length,
+      successfulQuotesCount: sortedQuotes.length,
       providerErrors,
       amountFrom: args.data.amount,
     }),

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/sorting/buildNetCounterValue.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/sorting/buildNetCounterValue.ts
@@ -1,0 +1,45 @@
+import BigNumber from "bignumber.js";
+
+import type { Quote, QuoteEstimatedNetworkFee } from "../types";
+
+export type NetCounterValueContext = {
+  receiveCurrencyId: string;
+  spotPrices: Record<string, number>;
+  feeCurrencyMagnitude?: number;
+};
+
+function feeAmountAsDisplayValue(
+  fee: QuoteEstimatedNetworkFee | undefined,
+  feeCurrencyMagnitude: number | undefined,
+): BigNumber {
+  if (!fee || feeCurrencyMagnitude === undefined) {
+    return new BigNumber(0);
+  }
+  return new BigNumber(fee.amount).shiftedBy(-feeCurrencyMagnitude);
+}
+
+export function buildNetCounterValue(quote: Quote, context: NetCounterValueContext): BigNumber {
+  // `??` not `||`: a 0 spot price means "price unknown" and must stay 0, not
+  // collapse to 1 and sort on the raw receiveAmount.
+  const receiveSpotPrice = context.spotPrices[context.receiveCurrencyId] ?? 1;
+  const receiveCounterValue = new BigNumber(quote.quoteDetails.receiveAmount).times(
+    receiveSpotPrice,
+  );
+
+  const estimatedFee = feeAmountAsDisplayValue(
+    quote.quoteDetails.estimatedNetworkFee,
+    context.feeCurrencyMagnitude,
+  );
+  const approvalFee = feeAmountAsDisplayValue(
+    quote.quoteDetails.approvalNetworkFee,
+    context.feeCurrencyMagnitude,
+  );
+  const feeCurrencyId =
+    quote.quoteDetails.estimatedNetworkFee?.currencyId ??
+    quote.quoteDetails.approvalNetworkFee?.currencyId ??
+    quote.quoteDetails.networkFees.currencyId;
+  const feeSpotPrice = context.spotPrices[feeCurrencyId] || 0;
+  const networkFeeCounterValue = estimatedFee.plus(approvalFee).times(feeSpotPrice);
+
+  return receiveCounterValue.minus(networkFeeCounterValue);
+}

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/sorting/sortQuotes.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/sorting/sortQuotes.test.ts
@@ -1,0 +1,130 @@
+import type { Quote } from "../types";
+import { sortQuotes } from "./sortQuotes";
+
+function makeQuote(key: string, overrides: Partial<Quote["quoteDetails"]> = {}): Quote {
+  return {
+    key,
+    provider: "lifi",
+    providerDetails: {
+      name: "LiFi",
+      type: "DEX",
+      isUniswapX: false,
+      requiresKYC: false,
+      continuesInProviderLiveApp: false,
+    },
+    quoteDetails: {
+      type: "float",
+      sendAmount: 1,
+      receiveAmount: 1,
+      gasLess: false,
+      networkFees: { currencyId: "ethereum" },
+      slippage: 1,
+      exchangeRate: 1,
+      ...overrides,
+    },
+    warnings: [],
+    errors: [],
+  };
+}
+
+describe("sortQuotes", () => {
+  it("orders quotes by net countervalue descending", () => {
+    const quotes = [
+      makeQuote("low", { receiveAmount: 1 }),
+      makeQuote("high", { receiveAmount: 3 }),
+      makeQuote("middle", { receiveAmount: 2 }),
+    ];
+
+    const sorted = sortQuotes(quotes, {
+      receiveCurrencyId: "bitcoin",
+      spotPrices: { bitcoin: 30_000 },
+      feeCurrencyMagnitude: 18,
+    });
+
+    expect(sorted.map(q => q.key)).toEqual(["high", "middle", "low"]);
+  });
+
+  it("subtracts estimated and approval network fee countervalues", () => {
+    const higherReceiveWithFees = makeQuote("higher-receive-with-fees", {
+      receiveAmount: 1,
+      estimatedNetworkFee: { amount: "100000000000000000", currencyId: "ethereum" },
+      approvalNetworkFee: { amount: "100000000000000000", currencyId: "ethereum" },
+    });
+    const lowerReceiveNoFees = makeQuote("lower-receive-no-fees", {
+      receiveAmount: 0.99,
+    });
+
+    const sorted = sortQuotes([higherReceiveWithFees, lowerReceiveNoFees], {
+      receiveCurrencyId: "bitcoin",
+      spotPrices: { bitcoin: 30_000, ethereum: 2_000 },
+      feeCurrencyMagnitude: 18,
+    });
+
+    expect(sorted.map(q => q.key)).toEqual(["lower-receive-no-fees", "higher-receive-with-fees"]);
+  });
+
+  it("preserves input order for equal net countervalues", () => {
+    const quotes = [
+      makeQuote("first", { receiveAmount: 1 }),
+      makeQuote("second", { receiveAmount: 1 }),
+      makeQuote("third", { receiveAmount: 1 }),
+    ];
+
+    const sorted = sortQuotes(quotes, {
+      receiveCurrencyId: "bitcoin",
+      spotPrices: { bitcoin: 30_000 },
+      feeCurrencyMagnitude: 18,
+    });
+
+    expect(sorted.map(q => q.key)).toEqual(["first", "second", "third"]);
+  });
+
+  it("does not sort on raw receiveAmount when the receive spot price is explicitly 0 (unknown)", () => {
+    // Both net countervalues are 0 (price unknown), so input order is preserved
+    // rather than ordered by raw receiveAmount (["high", "low"]).
+    const quotes = [
+      makeQuote("low", { receiveAmount: 1 }),
+      makeQuote("high", { receiveAmount: 3 }),
+    ];
+
+    const sorted = sortQuotes(quotes, {
+      receiveCurrencyId: "bitcoin",
+      spotPrices: { bitcoin: 0 },
+      feeCurrencyMagnitude: 18,
+    });
+
+    expect(sorted.map(q => q.key)).toEqual(["low", "high"]);
+  });
+
+  it("ranks quotes with an uncomputable (NaN) net countervalue last, keeping their input order", () => {
+    const sorted = sortQuotes(
+      [
+        makeQuote("nan-1", { receiveAmount: NaN }),
+        makeQuote("valid", { receiveAmount: 2 }),
+        makeQuote("nan-2", { receiveAmount: NaN }),
+      ],
+      { receiveCurrencyId: "bitcoin", spotPrices: { bitcoin: 30_000 }, feeCurrencyMagnitude: 18 },
+    );
+
+    expect(sorted.map(q => q.key)).toEqual(["valid", "nan-1", "nan-2"]);
+  });
+
+  it("uses current live-app spot price fallbacks", () => {
+    const feePriced = makeQuote("fee-priced", {
+      receiveAmount: 10,
+      estimatedNetworkFee: { amount: "1000000000000000000", currencyId: "ethereum" },
+    });
+    const feeUnpriced = makeQuote("fee-unpriced", {
+      receiveAmount: 9,
+      estimatedNetworkFee: { amount: "1000000000000000000", currencyId: "ethereum" },
+    });
+
+    const sorted = sortQuotes([feePriced, feeUnpriced], {
+      receiveCurrencyId: "bitcoin",
+      spotPrices: {},
+      feeCurrencyMagnitude: 18,
+    });
+
+    expect(sorted.map(q => q.key)).toEqual(["fee-priced", "fee-unpriced"]);
+  });
+});

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/sorting/sortQuotes.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/sorting/sortQuotes.ts
@@ -1,0 +1,47 @@
+import type BigNumber from "bignumber.js";
+
+import type { Quote, QuoteSortBy } from "../types";
+import { buildNetCounterValue, type NetCounterValueContext } from "./buildNetCounterValue";
+
+type RankedQuote = {
+  quote: Quote;
+  netCounterValue: BigNumber;
+  index: number;
+};
+
+export type SortQuotesContext = NetCounterValueContext & {
+  sortBy?: QuoteSortBy;
+};
+
+function rankQuotes(quotes: Quote[], context: NetCounterValueContext): RankedQuote[] {
+  return quotes.map((quote, index) => ({
+    quote,
+    index,
+    netCounterValue: buildNetCounterValue(quote, context),
+  }));
+}
+
+// Total order: highest net countervalue first, NaN (uncomputable) last, ties
+// broken by original index. Being a total order keeps the result deterministic
+// across engines without relying on Array.sort stability.
+function byNetCounterValueDesc(a: RankedQuote, b: RankedQuote): number {
+  const aNaN = a.netCounterValue.isNaN();
+  const bNaN = b.netCounterValue.isNaN();
+  if (aNaN || bNaN) {
+    if (aNaN && bNaN) return a.index - b.index;
+    return aNaN ? 1 : -1;
+  }
+  return b.netCounterValue.comparedTo(a.netCounterValue) || a.index - b.index;
+}
+
+export function sortQuotes(quotes: Quote[], context: SortQuotesContext): Quote[] {
+  const sortBy = context.sortBy ?? "netCounterValue";
+
+  if (sortBy !== "netCounterValue") {
+    return quotes;
+  }
+
+  return rankQuotes(quotes, context)
+    .sort(byNetCounterValueDesc)
+    .map(({ quote }) => quote);
+}

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/types.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/types.ts
@@ -5,6 +5,7 @@
 export type {
   QuotesInput,
   QuotesAppPlatform,
+  QuoteSortBy,
   GetQuotesArgs,
   GetQuotesWireArgs,
   GetQuotesResponse,


### PR DESCRIPTION
Jira: https://ledgerhq.atlassian.net/browse/LIVE-29447

**Description:** sort wallet quotes by net countervalue and provide option for future sorting methods via param

<!-- stac-man:stack-start -->
**Stack** _(managed by [stac-man](https://github.com/bluegardenproject/stac-man))_

- **#17552 feat/LIVE-29447-wallet-quote-sorting ← this PR**
- #17553 feat/LIVE-29447-best-wallet-quote
- #17696 bugfix/LIVE-24415-wallet-quote-network-fees
<!-- stac-man:stack-end -->