### PR TITLE
[LWM] fix(mobile): prevent memo tag drawer flash on device selection step

### DIFF
--- a/.changeset/large-chefs-judge.md
+++ b/.changeset/large-chefs-judge.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix memo tag drawer briefly flashing on the device selection step when ignoring the memo prompt

--- a/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
@@ -446,7 +446,10 @@ export default function SendSelectRecipient({ route }: Props) {
         onModalHide={
           () => requestAnimationFrame(() => setFocusMemoInput(true)) // Focus memo input after drawer finishes animating
         }
-        onNext={onPressContinue}
+        onNext={() => {
+          setMemoTagDrawerState(MemoTagDrawerState.SHOWN);
+          onPressContinue();
+        }}
       />
 
       <GenericErrorBottomModal


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Visual regression (modal animation race) — not covered by existing unit/integration tests; verified manually._
- [x] **Impact of the changes:**
  - Send flow for assets with a memo/tag disclaimer (Solana, XRP, etc.)
  - Memo tag drawer "Ignore" button behavior
  - Transition from Recipient → Amount / Summary → Device selection

### 📝 Description

**Problem**: On LLM, when initiating a send on an asset supporting a memo tag (e.g., Solana, XRP), choosing not to add a memo and tapping Continue triggered the memo tag drawer. After tapping "Ignore", the drawer briefly flashed again on the device selection step before the transaction was sent to the device.

**Root cause**: In `02-SelectRecipient.tsx`, the `onNext` callback passed to `MemoTagDrawer` (the "Ignore" button) only forwarded to `onPressContinue` without resetting the drawer state. The state stayed in `SHOWING`, so the `QueuedDrawer` remained marked as requesting to be opened during the navigation to the device selection step, producing a brief flash before the close animation finished.

**Solution**: Reset `memoTagDrawerState` to `SHOWN` in the `onNext` handler before calling `onPressContinue`. `onPressContinue` continues to gate the drawer opening on `state === INITIAL`, so navigation still proceeds.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30652](https://ledgerhq.atlassian.net/browse/LIVE-30652)

- **E2E**:
  - Mobile: https://github.com/LedgerHQ/ledger-live/actions/runs/26092626504
  https://ledger-live.allure.green.ledgerlabs.net/allure/reports/1c4fcd2e-417b-475f-a5fc-9e78f6ff33b8/
---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-30652]: https://ledgerhq.atlassian.net/browse/LIVE-30652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ