### PR TITLE
test(e2e-desktop): review settings spec (QAA-1115)

### DIFF
--- a/e2e/desktop/tests/page/settings.page.ts
+++ b/e2e/desktop/tests/page/settings.page.ts
@@ -4,9 +4,14 @@ import { expect } from "@playwright/test";
 import axios from "axios";
 import * as path from "path";
 import { FileUtils } from "../utils/fileUtils";
-import { mkdir, rename } from "fs/promises";
 
 export class SettingsPage extends AppPage {
+  private static readonly EXPORT_LOGS_SOURCE_PATH = path.resolve("./ledgerwallet-logs.txt");
+  private static readonly EXPORT_LOGS_ARTIFACT_PATH = path.resolve(
+    __dirname,
+    "../artifacts/ledgerwallet-logs.txt",
+  );
+
   private syncWalletSyncButton = this.page.getByTestId("button-sync-walletSync");
   private manageWalletSyncButton = this.page.getByTestId("button-manage-walletSync");
   private readonly turnOnLedgerSyncButton = this.page.getByTestId("button-turn-on-ledger-sync");
@@ -153,15 +158,23 @@ export class SettingsPage extends AppPage {
   @step("Click on export logs")
   async clickExportLogs() {
     await this.exportLogsButton.click();
+  }
 
-    const originalFilePath = path.resolve("./ledgerwallet-logs.txt");
-    const targetFilePath = path.resolve(__dirname, "../artifacts/ledgerwallet-logs.txt");
-
-    const fileExists = await FileUtils.waitForFileToExist(originalFilePath, 5000);
+  @step("Expect exported logs file to be created")
+  async expectExportLogsFileCreated() {
+    const fileExists = await FileUtils.waitForFileToExist(
+      SettingsPage.EXPORT_LOGS_SOURCE_PATH,
+      5000,
+    );
     expect(fileExists).toBeTruthy();
+  }
 
-    const targetDir = path.dirname(targetFilePath);
-    await mkdir(targetDir, { recursive: true });
-    await rename(originalFilePath, targetFilePath);
+  // Electron writes the logs to process.cwd(); move them under tests/artifacts so Playwright/CI collects them and the repo root stays clean (same pattern as swap.page.ts and history.page.ts).
+  @step("Move exported logs to artifacts folder")
+  async moveExportedLogsToArtifacts() {
+    await FileUtils.waitForFileAndMove(
+      SettingsPage.EXPORT_LOGS_SOURCE_PATH,
+      SettingsPage.EXPORT_LOGS_ARTIFACT_PATH,
+    );
   }
 }

--- a/e2e/desktop/tests/page/settings.page.ts
+++ b/e2e/desktop/tests/page/settings.page.ts
@@ -162,11 +162,15 @@ export class SettingsPage extends AppPage {
 
   @step("Expect exported logs file to be created")
   async expectExportLogsFileCreated() {
+    const timeout = 5000;
     const fileExists = await FileUtils.waitForFileToExist(
       SettingsPage.EXPORT_LOGS_SOURCE_PATH,
-      5000,
+      timeout,
     );
-    expect(fileExists).toBeTruthy();
+    expect(
+      fileExists,
+      `Export file was not created at ${SettingsPage.EXPORT_LOGS_SOURCE_PATH} within ${timeout}ms`,
+    ).toBeTruthy();
   }
 
   // Electron writes the logs to process.cwd(); move them under tests/artifacts so Playwright/CI collects them and the repo root stays clean (same pattern as swap.page.ts and history.page.ts).

--- a/e2e/desktop/tests/specs/settings.spec.ts
+++ b/e2e/desktop/tests/specs/settings.spec.ts
@@ -71,6 +71,7 @@ test.describe("Password", () => {
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       const countAfterLock = await app.accounts.countAccounts();
       await app.accounts.compareAccountsCountFromJson(countBeforeLock, countAfterLock);
+      await app.accounts.expectCryptoAccountRowVisible(account.accountName);
       await app.accounts.navigateToAccountByName(account.accountName);
     },
   );
@@ -179,7 +180,7 @@ test.describe("Reset app", () => {
   );
 });
 
-test.describe("Settings - Help tab", () => {
+test.describe("Settings - Export Log", () => {
   test.use({
     teamOwner: Team.WALLET_XP,
     userdata: "1AccountBTC1AccountETH",
@@ -201,6 +202,8 @@ test.describe("Settings - Help tab", () => {
       await app.settings.goToHelpTab();
       await app.settings.checkViewUserDataButtonIsEnabled();
       await app.settings.clickExportLogs();
+      await app.settings.expectExportLogsFileCreated();
+      await app.settings.moveExportedLogsToArtifacts();
     },
   );
 });


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _Not required: changes are scoped to `e2e/desktop/tests/**` and no shipped package is affected (precedent: commits `2ed86e50149`, `3a13174554c`)._
- [x] **Covered by automatic tests.** _Changes ARE the automated Playwright tests._
- [x] **Impact of the changes:**
  - Desktop Settings: account-list visibility after password lock/unlock.
  - Settings → Help tab → Export logs (describe renamed to "Settings - Export Log"); now reports 3 distinct Allure steps (click / expect file / move).
  - Counter-value selection test: behaviour unchanged; `TODO(QAA-1115)` marker added for the future USD+EUR merge.

### 📝 Description

Review and cleanup of `settings.spec.ts` and `settings.page.ts` per [QAA-1115](https://ledgerhq.atlassian.net/browse/QAA-1115) (sub-task of [QAA-1101 — LWD E2E Desktop Test Suite Cleanup & Improvements](https://ledgerhq.atlassian.net/browse/QAA-1101)).

**Problem:** the export-logs page method bundled three logical actions (click button, assert file appears, move to artifacts) under a single `@step`, hiding intent in reports and making failures hard to attribute. The password-lock test relied on the implicit click-through of `navigateToAccountByName` to confirm the account survived the lock, the help-tab describe was misnamed, and the counter-value describe had an unresolved USD/EUR merge to-do.

**Solution:**

- Split `SettingsPage.clickExportLogs()` into three `@step`-decorated methods: `clickExportLogs`, `expectExportLogsFileCreated`, `moveExportedLogsToArtifacts`. The move step reuses the existing `FileUtils.waitForFileAndMove` helper (same pattern as `swap.page.ts`).
- Added an inline comment on `moveExportedLogsToArtifacts` explaining the rename: Electron writes the export to `process.cwd()`; moving it under `tests/artifacts/` keeps the repo root clean and lets Playwright/CI collect it as an artifact.
- Added an explicit `app.accounts.expectCryptoAccountRowVisible(account.accountName)` assertion in the password test so post-lock visibility is verified independently of the navigation click.
- Renamed `test.describe("Settings - Help tab")` → `test.describe("Settings - Export Log")` and wired it to the three new page methods.
- Left the `counter value selection` describe and `B2CQA-804` annotation untouched (the TMS case is still live in mobile, see `e2e/mobile/specs/settings/userCanSelectCounterValueToDisplayAmountInLedgerLive.spec.ts`) and added a `TODO(QAA-1115)` for the USD+EUR merge, which is blocked on a soft-assertion utility not yet available in `e2e/desktop`.

https://github.com/LedgerHQ/ledger-live/actions/runs/26043392592

### ❓ Context

- **JIRA**: [QAA-1115](https://ledgerhq.atlassian.net/browse/QAA-1115)
- **Parent epic**: [QAA-1101](https://ledgerhq.atlassian.net/browse/QAA-1101)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-1115]: https://ledgerhq.atlassian.net/browse/QAA-1115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QAA-1115]: https://ledgerhq.atlassian.net/browse/QAA-1115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ