### PR TITLE
[LWDM] chore(concordium): move Concordium ID App store links to feature flag

### DIFF
--- a/.changeset/rotten-tips-yawn.md
+++ b/.changeset/rotten-tips-yawn.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/types-live": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+"@shared/feature-flags": minor
+---
+
+Move Concordium ID App store links (App Store / Google Play) to a new `concordiumIdAppLinks` feature flag with runtime override support via Firebase

--- a/apps/ledger-live-desktop/src/config/urls.ts
+++ b/apps/ledger-live-desktop/src/config/urls.ts
@@ -233,8 +233,6 @@ export const urls = {
   },
   concordium: {
     learnMore: "https://support.ledger.com/article/Concordium-CCD",
-    appStore: "https://apps.apple.com/app/concordium-id/id6746754485",
-    playStore: "https://play.google.com/store/apps/details?id=com.idwallet.app",
   },
   deviceDeprecation: {
     shop: "https://shop.ledger.com/pages/ledger-nano-s-upgrade-program",

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/components/StepOnboard/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/components/StepOnboard/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
 import { AccountOnboardStatus } from "@ledgerhq/coin-concordium/types";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { urls } from "~/config/urls";
 import Text from "~/renderer/components/Text";
 import Alert from "~/renderer/components/Alert";
@@ -30,8 +31,9 @@ export default function StepOnboard({
   sessionTopic,
 }: StepProps) {
   const learnMoreUrl = useLocalizedUrl(urls.concordium.learnMore);
-  const appStoreUrl = useLocalizedUrl(urls.concordium.appStore);
-  const playStoreUrl = useLocalizedUrl(urls.concordium.playStore);
+  const idAppLinks = useFeature("concordiumIdAppLinks");
+  const appStoreUrl = idAppLinks?.params?.appStore;
+  const playStoreUrl = idAppLinks?.params?.playStore;
 
   if (onboardingStatus === AccountOnboardStatus.INIT && !isPairing) {
     return (
@@ -91,24 +93,28 @@ export default function StepOnboard({
                     <Trans i18nKey="families.concordium.addAccount.identity.downloadApp" />
                   </Text>
                   <AppStoreLinks horizontal justifyContent="center">
-                    <AppStoreLink
-                      href={playStoreUrl}
-                      onClick={e => {
-                        e.preventDefault();
-                        openURL(playStoreUrl);
-                      }}
-                    >
-                      <AppStoreImage src={GetItOnGooglePlayImage} alt="Get it on Google Play" />
-                    </AppStoreLink>
-                    <AppStoreLink
-                      href={appStoreUrl}
-                      onClick={e => {
-                        e.preventDefault();
-                        openURL(appStoreUrl);
-                      }}
-                    >
-                      <AppStoreImage src={GetItOnAppleStoreImage} alt="Get it on Apple Store" />
-                    </AppStoreLink>
+                    {playStoreUrl && (
+                      <AppStoreLink
+                        href={playStoreUrl}
+                        onClick={e => {
+                          e.preventDefault();
+                          openURL(playStoreUrl);
+                        }}
+                      >
+                        <AppStoreImage src={GetItOnGooglePlayImage} alt="Get it on Google Play" />
+                      </AppStoreLink>
+                    )}
+                    {appStoreUrl && (
+                      <AppStoreLink
+                        href={appStoreUrl}
+                        onClick={e => {
+                          e.preventDefault();
+                          openURL(appStoreUrl);
+                        }}
+                      >
+                        <AppStoreImage src={GetItOnAppleStoreImage} alt="Get it on Apple Store" />
+                      </AppStoreLink>
+                    )}
                   </AppStoreLinks>
                 </AppStoreSection>
               </Box>

--- a/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/components/StepPair.tsx
+++ b/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/components/StepPair.tsx
@@ -72,24 +72,26 @@ export default function StepPair({
                   <Text variant="body" color="neutral.c70" mt={4} textAlign="center" px={4}>
                     <Trans i18nKey="concordium.onboard.pair.scanQRCodeOrDownload" />
                   </Text>
-                  <Flex mt={8}>
-                    <TouchableOpacity
-                      activeOpacity={0.7}
-                      onPress={() => Linking.openURL(storeUrl)}
-                      accessibilityRole="link"
-                      accessibilityLabel={
-                        Platform.OS === "ios"
-                          ? "Download on the App Store"
-                          : "Get it on Google Play"
-                      }
-                    >
-                      <Image
-                        source={storeBadge}
-                        style={{ height: 40, width: 135 }}
-                        resizeMode="contain"
-                      />
-                    </TouchableOpacity>
-                  </Flex>
+                  {storeUrl && (
+                    <Flex mt={8}>
+                      <TouchableOpacity
+                        activeOpacity={0.7}
+                        onPress={() => Linking.openURL(storeUrl)}
+                        accessibilityRole="link"
+                        accessibilityLabel={
+                          Platform.OS === "ios"
+                            ? "Download on the App Store"
+                            : "Get it on Google Play"
+                        }
+                      >
+                        <Image
+                          source={storeBadge}
+                          style={{ height: 40, width: 135 }}
+                          resizeMode="contain"
+                        />
+                      </TouchableOpacity>
+                    </Flex>
+                  )}
                 </Flex>
               )}
             </Flex>

--- a/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/hooks/useIdAppDetection.ts
+++ b/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/hooks/useIdAppDetection.ts
@@ -1,12 +1,13 @@
 import { useCallback, useEffect, useState } from "react";
 import { Linking, Platform } from "react-native";
 import { log } from "@ledgerhq/logs";
-import { urls } from "~/utils/urls";
+import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 
 const ID_APP_SCHEME = "concordiumidapp://";
 
 export function useIdAppDetection() {
   const [isInstalled, setIsInstalled] = useState<boolean | null>(null);
+  const idAppLinks = useFeature("concordiumIdAppLinks");
 
   useEffect(() => {
     Linking.canOpenURL(ID_APP_SCHEME)
@@ -15,7 +16,7 @@ export function useIdAppDetection() {
   }, []);
 
   const storeUrl =
-    Platform.OS === "ios" ? urls.concordium.idApp.appStore : urls.concordium.idApp.playStore;
+    Platform.OS === "ios" ? idAppLinks?.params?.appStore : idAppLinks?.params?.playStore;
 
   const openIdApp = useCallback(
     (uri: string) => {
@@ -23,6 +24,7 @@ export function useIdAppDetection() {
         log("concordium-onboarding", "Failed to open Concordium ID App, redirecting to store", {
           error,
         });
+        if (!storeUrl) return;
         Linking.openURL(storeUrl).catch(storeError => {
           log("concordium-onboarding", "Failed to open store URL", { error: storeError });
         });

--- a/apps/ledger-live-mobile/src/utils/urls.tsx
+++ b/apps/ledger-live-mobile/src/utils/urls.tsx
@@ -268,10 +268,6 @@ export const urls = {
   },
   concordium: {
     learnMore: "https://support.ledger.com/article/Concordium-CCD",
-    idApp: {
-      appStore: "https://apps.apple.com/app/concordium-id/id6746754485",
-      playStore: "https://play.google.com/store/apps/details?id=com.idwallet.app",
-    },
   },
   fwUpdateReleaseNotes: {
     nanoS: "https://support.ledger.com/article/360010446000-zd",

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -131,6 +131,13 @@ export const CURRENCY_DEFAULT_FEATURES = {
  */
 export const DEFAULT_FEATURES: Features = {
   ...CURRENCY_DEFAULT_FEATURES,
+  concordiumIdAppLinks: initFeature({
+    enabled: true,
+    params: {
+      appStore: "https://apps.apple.com/app/concordium-id/id6746754485",
+      playStore: "https://play.google.com/store/apps/details?id=com.idwallet.app",
+    },
+  }),
   nanoOnboardingFundWallet: DEFAULT_FEATURE,
   portfolioExchangeBanner: DEFAULT_FEATURE,
   counterValue: DEFAULT_FEATURE,

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -325,6 +325,7 @@ export type Features = CurrencyFeatures & {
   lwmWallet40: Feature_LwmWallet40;
   lwdWallet40: Feature_LwdWallet40;
   addressPoisoningOperationsFilter: Feature_AddressPoisoningOperationsFilter;
+  concordiumIdAppLinks: Feature_ConcordiumIdAppLinks;
   concordiumVerifyAddress: DefaultFeature;
   lldHideSmallValueTokenOperations: Feature_LldHideSmallValueTokenOperations;
   llmTransferButtonCopyVariant: Feature_LlmTransferButtonCopyVariant;
@@ -570,6 +571,11 @@ export type Feature_DeviceInitialApps = Feature<{
 export type Feature_BuyDeviceFromLive = Feature<{
   debug: boolean;
   url: string | null;
+}>;
+
+export type Feature_ConcordiumIdAppLinks = Feature<{
+  appStore: string;
+  playStore: string;
 }>;
 
 export type Feature_Discover = Feature<{

--- a/shared/feature-flags/src/flags/team-coin-integration/concordiumIdAppLinks.ts
+++ b/shared/feature-flags/src/flags/team-coin-integration/concordiumIdAppLinks.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+import { flagWith } from "../../define";
+
+export const concordiumIdAppLinks = flagWith(
+  {
+    appStore: z.string().url(),
+    playStore: z.string().url(),
+  },
+  {
+    enabled: true,
+    params: {
+      appStore: "https://apps.apple.com/app/concordium-id/id6746754485",
+      playStore: "https://play.google.com/store/apps/details?id=com.idwallet.app",
+    },
+  },
+);

--- a/shared/feature-flags/src/flags/team-coin-integration/index.ts
+++ b/shared/feature-flags/src/flags/team-coin-integration/index.ts
@@ -1,4 +1,5 @@
 export * from "./addressPoisoningOperationsFilter";
+export * from "./concordiumIdAppLinks";
 export * from "./concordiumVerifyAddress";
 export * from "./currencyAdi";
 export * from "./currencyAleo";


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

The Concordium ID App store links (App Store / Google Play) were hardcoded in both mobile and desktop. This moves them into a new `concordiumIdAppLinks` feature flag so they can be overridden remotely via Firebase Remote Config without an app release.

- **New flag:** `concordiumIdAppLinks` with zod-validated `appStore` / `playStore` URL params. Defaults match the previously hardcoded values, so behavior is unchanged out of the box.
- **Partial Firebase overrides supported:** lodash deep-merge means ops can change `appStore` alone (or `playStore` alone) without touching the other; unset keys fall back to the bundled defaults.
- **Consumers updated:** mobile `useIdAppDetection` and desktop `StepOnboard` now read from `useFeature("concordiumIdAppLinks")`. The orphaned `concordium.idApp` / `concordium.appStore` / `concordium.playStore` entries are removed from the per-app `urls` configs.

### Design notes

- **Why a dedicated flag instead of extending `currencyConcordium`?** `currencyConcordium` and `currencyConcordiumTestnet` are pure on/off currency gates with no other params today; adding URL params would (a) break the established `currency*` convention, (b) duplicate the same URLs across mainnet and testnet (the ID App is network-agnostic), and (c) conflate currency-availability with companion-app distribution.
- **Why ignore `enabled`?** This flag delivers config, not toggles a feature. If Firebase ever pushes `enabled: false`, the bundled defaults still flow through `params` via lodash merge — i.e. the failure mode is "use the safe bundled URLs", which preserves onboarding. Hiding the badges entirely would break the flow.
### ❓ Context

- **JIRA or GitHub link**: [LIVE-27574](https://ledgerhq.atlassian.net/browse/LIVE-27574)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-27574]: https://ledgerhq.atlassian.net/browse/LIVE-27574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ