### PR TITLE
[LWDM] fix(asset-aggregation): aggregate Stellar and MultiversX tokens under their cross-network meta-currency

### DIFF
--- a/.changeset/metal-terms-smoke.md
+++ b/.changeset/metal-terms-smoke.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/asset-aggregation": minor
+---
+
+Fix Stellar USDC (and MultiversX tokens) not aggregating under their cross-network meta-currency in the portfolio asset distribution. Apply legacyIdToApiId when resolving DADA-keyed lookups so LL-format ids (mixed-case Stellar, multiversx prefix) match the API-format ids returned by DADA.

--- a/libs/asset-aggregation/src/assetDistribution/__tests__/buildAssetDistribution.test.ts
+++ b/libs/asset-aggregation/src/assetDistribution/__tests__/buildAssetDistribution.test.ts
@@ -9,6 +9,11 @@ const mockFindCryptoCurrencyById = jest.fn();
 
 jest.mock("@ledgerhq/cryptoassets", () => ({
   findCryptoCurrencyById: (...args: unknown[]) => mockFindCryptoCurrencyById(...args),
+  legacyIdToApiId: (id: string) => {
+    if (id.startsWith("stellar/asset/")) return id.toLowerCase();
+    if (id.startsWith("multiversx/esdt/")) return id.replace("multiversx/esdt/", "elrond/esdt/");
+    return id;
+  },
 }));
 
 jest.mock("@ledgerhq/live-countervalues/logic", () => ({
@@ -219,5 +224,69 @@ describe("buildAssetDistribution", () => {
     );
 
     expect(result.list).toHaveLength(2);
+  });
+
+  describe("DADA id format normalization (LIVE-22557 / LIVE-22558)", () => {
+    const ethereumUsdc = makeCurrency("ethereum/erc20/usd__coin", "USD Coin");
+    const stellarUsdcMixedCase = makeCurrency(
+      "stellar/asset/USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+      "USDC",
+    );
+    const multiversxUsdc = makeCurrency("multiversx/esdt/USDC-c76f1f", "USD Coin");
+
+    const usdCoinAssetsData: AssetsDataLike = {
+      cryptoAssets: {
+        "urn:crypto:meta-currency:usd_coin": {
+          id: "urn:crypto:meta-currency:usd_coin",
+          assetsIds: {
+            ethereum: "ethereum/erc20/usd__coin",
+            stellar: "stellar/asset/usdc:ga5zsejyb37jrc5avcia5mop4rhtm335x2kgx3ihojapp5re34k4kzvn",
+            elrond: "elrond/esdt/USDC-c76f1f",
+          },
+        },
+      },
+      markets: {},
+    };
+
+    it("should aggregate mixed-case Stellar USDC under usd_coin meta-currency", () => {
+      const result = distribute(
+        [
+          makeAccount("eth-usdc-1", ethereumUsdc, 1000),
+          makeAccount("xlm-usdc-1", stellarUsdcMixedCase, 200),
+        ],
+        undefined,
+        usdCoinAssetsData,
+      );
+
+      expect(result.list).toHaveLength(1);
+      expect(result.list[0].metaCurrencyId).toBe("urn:crypto:meta-currency:usd_coin");
+      expect(result.list[0].networks).toHaveLength(2);
+      const networkIds = result.list[0].networks!.map(n => n.currency.id).sort();
+      expect(networkIds).toEqual(
+        [
+          "ethereum/erc20/usd__coin",
+          "stellar/asset/USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+        ].sort(),
+      );
+    });
+
+    it("should aggregate MultiversX USDC under usd_coin meta-currency (multiversx -> elrond)", () => {
+      const result = distribute(
+        [
+          makeAccount("eth-usdc-1", ethereumUsdc, 1000),
+          makeAccount("egld-usdc-1", multiversxUsdc, 500),
+        ],
+        undefined,
+        usdCoinAssetsData,
+      );
+
+      expect(result.list).toHaveLength(1);
+      expect(result.list[0].metaCurrencyId).toBe("urn:crypto:meta-currency:usd_coin");
+      expect(result.list[0].networks).toHaveLength(2);
+      const networkIds = result.list[0].networks!.map(n => n.currency.id).sort();
+      expect(networkIds).toEqual(
+        ["ethereum/erc20/usd__coin", "multiversx/esdt/USDC-c76f1f"].sort(),
+      );
+    });
   });
 });

--- a/libs/asset-aggregation/src/assetDistribution/buildAssetDistribution.ts
+++ b/libs/asset-aggregation/src/assetDistribution/buildAssetDistribution.ts
@@ -1,4 +1,4 @@
-import { findCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { findCryptoCurrencyById, legacyIdToApiId } from "@ledgerhq/cryptoassets";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 import type { CryptoCurrency, Currency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
@@ -84,11 +84,12 @@ export function buildAssetDistribution(
 
   for (const account of allAccounts) {
     const currency = getAccountCurrency(account);
-    currencyById.set(currency.id, currency);
+    const apiId = legacyIdToApiId(currency.id);
+    currencyById.set(apiId, currency);
 
     if (shouldSkipAccount(account, showEmptyAccounts, hideEmptyTokenAccount)) continue;
 
-    const metaCurrencyId = currencyToMetaId[currency.id] ?? currency.id;
+    const metaCurrencyId = currencyToMetaId[apiId] ?? currency.id;
     const balance = account.balance.toNumber();
 
     let group = groups.get(metaCurrencyId);
@@ -106,7 +107,7 @@ export function buildAssetDistribution(
 
     group.accounts.push(account);
     group.amount += balance;
-    group.marketId ??= assetsData.markets[currency.id]?.id;
+    group.marketId ??= assetsData.markets[apiId]?.id;
 
     let network = group.networks.get(currency.id);
     if (!network) {


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Portfolio "Stablecoins" section: USDC totals across networks (Ethereum, Solana, Polygon, Stellar, …) should be merged into a single "USD Coin" row.
      - Stellar accounts holding USDC: verify the balance contributes to the USD Coin row instead of appearing as a separate "USDC" row with a generic icon.
      - MultiversX (ex-Elrond) ESDT tokens with a cross-network meta-currency (e.g. USDC, USDT): verify they aggregate under the corresponding meta-currency row.
      - Asset detail navigation from the Stablecoins / Assets list: tapping the USD Coin row should still resolve to the right asset detail and expose all networks (including Stellar / MultiversX) in the per-network breakdown.
      - Regression check on already-working aggregation (ETH across mainnet/Arbitrum/Base/Optimism, BTC, etc.) — should be unchanged.
      - Pie chart distribution percentages for Stellar / MultiversX-only holdings: now contribute to the parent meta-currency rather than a standalone slice.

### Description

In the Portfolio's **Stablecoins** section (and the broader Assets list), Stellar's USDC token was rendered as its own row instead of being aggregated under the cross-network "USD Coin" row alongside Ethereum USDC, Solana USDC, etc. The same misbehavior affected every MultiversX (ex-Elrond) ESDT token that has a corresponding cross-network meta-currency.

**Root cause** — `buildAssetDistribution` (in `libs/asset-aggregation`) groups accounts by DADA `metaCurrencyId`, looked up via `currencyToMetaId[currency.id]`. The DADA-side keys differ from Ledger Live's local `currency.id` for two networks:

| Network | LL `currency.id` (in-app) | DADA id (in `assetsIds`) |
|---|---|---|
| Stellar | `stellar/asset/USDC:GA5ZSEJY...` (UPPERCASE) | `stellar/asset/usdc:ga5zsejy...` (lowercase) |
| MultiversX | `multiversx/esdt/USDC-c76f1f` | `elrond/esdt/USDC-c76f1f` |

The lookup missed, the code fell back to `currency.id` as the group key, and the token ended up in its own group instead of merging into `urn:crypto:meta-currency:usd_coin`.

**Fix** — apply the existing `legacyIdToApiId` helper from `@ledgerhq/cryptoassets` (already used on the outbound DADA query path in `dada-client/state-manager/api.ts`) on the inbound aggregation path, before every lookup against DADA-keyed maps:

```ts
const apiId = legacyIdToApiId(currency.id);
currencyById.set(apiId, currency);
const metaCurrencyId = currencyToMetaId[apiId] ?? currency.id;
group.marketId ??= assetsData.markets[apiId]?.id;
```

The fallback `?? currency.id` is preserved, so currencies without a DADA mapping behave exactly as before (existing test "should fallback to currency.id when no DADA mapping exists" still passes).

Two regression tests were added in `buildAssetDistribution.test.ts` under `DADA id format normalization (LIVE-22557 / LIVE-22558)`:
- mixed-case Stellar USDC merging into `urn:crypto:meta-currency:usd_coin`
- MultiversX USDC merging into the same meta-currency via the `multiversx -> elrond` translation


<img width="231" height="500" alt="Screenshot 2026-05-18 at 17 36 22" src="https://github.com/user-attachments/assets/34acaf97-5209-4d53-967a-20494aabe937" />
<img width="225" height="506" alt="Screenshot 2026-05-18 at 17 33 56" src="https://github.com/user-attachments/assets/227620e6-d8d6-420a-af98-b58aa36d46cd" />


### Context

- **JIRA or GitHub link**: [LIVE-30714](https://ledgerhq.atlassian.net/browse/LIVE-30714)

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30714]: https://ledgerhq.atlassian.net/browse/LIVE-30714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ