### PR TITLE
[LWD] fix(desktop): show finish-onboarding dialog after closing Recover

### DIFF
--- a/.changeset/live-30572-sync-completion-finish-dialog.md
+++ b/.changeset/live-30572-sync-completion-finish-dialog.md
@@ -2,4 +2,4 @@
 "ledger-live-desktop": patch
 ---
 
-Fix post-onboarding flow to open finish-onboarding dialog instead of legacy hub after closing Recover
+Fix Wallet40 post-onboarding to show Recover landing behind the finish-onboarding dialog and route to the portfolio dialog instead of the legacy hub after closing Recover (LIVE-30572)

--- a/.changeset/live-30572-sync-completion-finish-dialog.md
+++ b/.changeset/live-30572-sync-completion-finish-dialog.md
@@ -1,5 +1,6 @@
 ---
 "ledger-live-desktop": patch
+"@ledgerhq/live-common": patch
 ---
 
-Open finish-onboarding dialog from sync onboarding completion when Wallet40 finish widget is enabled
+Fix post-onboarding flow to open finish-onboarding dialog instead of legacy hub after closing Recover

--- a/.changeset/live-30572-sync-completion-finish-dialog.md
+++ b/.changeset/live-30572-sync-completion-finish-dialog.md
@@ -1,6 +1,5 @@
 ---
 "ledger-live-desktop": patch
-"@ledgerhq/live-common": patch
 ---
 
 Fix post-onboarding flow to open finish-onboarding dialog instead of legacy hub after closing Recover

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/hooks/__tests__/useFinishOnboardingDialogViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/hooks/__tests__/useFinishOnboardingDialogViewModel.test.ts
@@ -36,6 +36,17 @@ describe("useFinishOnboardingDialogViewModel", () => {
     expect(result.current.isOpen).toBe(true);
   });
 
+  it("should mark hasBeenRedirectedToPostOnboarding when the dialog is open", () => {
+    const { store } = renderHook(() => useFinishOnboardingDialogViewModel(), {
+      initialState: {
+        dialogs: { FINISH_POST_ONBOARDING: true },
+        settings: { hasBeenRedirectedToPostOnboarding: false },
+      },
+    });
+
+    expect(store.getState().settings.hasBeenRedirectedToPostOnboarding).toBe(true);
+  });
+
   it("should exclude buyCrypto from actions", () => {
     const actionsState = [
       { id: PostOnboardingActionId.deviceOnboarded, completed: true },

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/hooks/useFinishOnboardingDialogViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/hooks/useFinishOnboardingDialogViewModel.ts
@@ -10,6 +10,7 @@ import { trustchainSelector } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { type StartActionArgs } from "@ledgerhq/types-live";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { accountsSelector } from "~/renderer/reducers/accounts";
+import { setHasRedirectedToPostOnboarding } from "~/renderer/actions/settings";
 import { track } from "~/renderer/analytics/segment";
 import {
   closeFinishPostOnboarding,
@@ -78,6 +79,12 @@ export default function useFinishOnboardingDialogViewModel(): FinishOnboardingDi
     dispatch(hidePostOnboardingWalletEntryPoint());
     dispatch(postOnboardingSetFinished());
   }, [allActionsCompleted, hasActions, deviceModelId, dispatch]);
+
+  useEffect(() => {
+    if (isDialogOpen) {
+      dispatch(setHasRedirectedToPostOnboarding(true));
+    }
+  }, [dispatch, isDialogOpen]);
 
   const onGotIt = useCallback(() => {
     track("button_clicked2", {

--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompletion/__tests__/useCompletionScreenViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompletion/__tests__/useCompletionScreenViewModel.test.tsx
@@ -8,10 +8,7 @@ import { Device, DeviceModelId } from "@ledgerhq/types-devices";
 import { useCompletionScreenViewModel } from "../useCompletionScreenViewModel";
 import { SettingsState } from "~/renderer/reducers/settings";
 
-const mockNavigate = jest.fn();
-const mockOpenFinishOnboardingDialog = jest.fn();
 const mockRedirectToPostOnboarding = jest.fn();
-const mockStartPostOnboarding = jest.fn();
 
 jest.mock("~/renderer/hooks/useAutoRedirectToPostOnboarding", () => ({
   useRedirectToPostOnboardingCallback: jest.fn(),
@@ -20,22 +17,6 @@ jest.mock("~/renderer/hooks/useAutoRedirectToPostOnboarding", () => ({
 jest.mock("react-router", () => ({
   ...jest.requireActual("react-router"),
   useLocation: jest.fn().mockReturnValue({ state: { seedConfiguration: "new_seed" } }),
-  useNavigate: () => mockNavigate,
-}));
-
-jest.mock(
-  "LLD/features/FinishOnboarding/FinishOnboardingDialog/hooks/useFinishOnboardingDialog",
-  () => ({
-    __esModule: true,
-    default: () => ({
-      handleOpen: mockOpenFinishOnboardingDialog,
-    }),
-  }),
-);
-
-jest.mock("@ledgerhq/live-common/postOnboarding/hooks/index", () => ({
-  ...jest.requireActual("@ledgerhq/live-common/postOnboarding/hooks/index"),
-  useStartPostOnboardingCallback: () => mockStartPostOnboarding,
 }));
 
 const getInitialState = (modelId: DeviceModelId = DeviceModelId.stax): Partial<State> => ({
@@ -49,9 +30,6 @@ describe("useCompletionScreenViewModel", () => {
   beforeEach(() => {
     jest.useFakeTimers();
     mockRedirectToPostOnboarding.mockClear();
-    mockNavigate.mockClear();
-    mockOpenFinishOnboardingDialog.mockClear();
-    mockStartPostOnboarding.mockClear();
     jest
       .mocked(useRedirectToPostOnboardingCallback)
       .mockReturnValue(mockRedirectToPostOnboarding);
@@ -74,9 +52,6 @@ describe("useCompletionScreenViewModel", () => {
       });
 
       expect(mockRedirectToPostOnboarding).toHaveBeenCalledTimes(1);
-      expect(mockStartPostOnboarding).not.toHaveBeenCalled();
-      expect(mockNavigate).not.toHaveBeenCalled();
-      expect(mockOpenFinishOnboardingDialog).not.toHaveBeenCalled();
 
       const { settings } = store.getState() as { settings: SettingsState };
       expect(settings.hasCompletedOnboarding).toBe(true);
@@ -86,7 +61,7 @@ describe("useCompletionScreenViewModel", () => {
     }),
   );
 
-  it("should init post-onboarding, navigate home, and open finish-onboarding dialog when Wallet40 finish widget is enabled", () => {
+  it("should redirect via useRedirectToPostOnboardingCallback when Wallet40 finish widget is enabled", () => {
     const deviceId = DeviceModelId.stax;
     const initialState = {
       ...getInitialState(deviceId),
@@ -104,20 +79,6 @@ describe("useCompletionScreenViewModel", () => {
       jest.advanceTimersByTime(6000);
     });
 
-    expect(mockRedirectToPostOnboarding).not.toHaveBeenCalled();
-    expect(mockStartPostOnboarding).toHaveBeenCalledWith({
-      deviceModelId: deviceId,
-      skipNavigateToHub: true,
-    });
-    expect(mockNavigate).toHaveBeenCalledWith("/");
-    expect(mockOpenFinishOnboardingDialog).toHaveBeenCalledTimes(1);
-
-    const [startOrder, navigateOrder, openDialogOrder] = [
-      mockStartPostOnboarding.mock.invocationCallOrder[0],
-      mockNavigate.mock.invocationCallOrder[0],
-      mockOpenFinishOnboardingDialog.mock.invocationCallOrder[0],
-    ];
-    expect(startOrder).toBeLessThan(navigateOrder);
-    expect(navigateOrder).toBeLessThan(openDialogOrder);
+    expect(mockRedirectToPostOnboarding).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompletion/__tests__/useCompletionScreenViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompletion/__tests__/useCompletionScreenViewModel.test.tsx
@@ -11,6 +11,7 @@ import { SettingsState } from "~/renderer/reducers/settings";
 const mockNavigate = jest.fn();
 const mockOpenFinishOnboardingDialog = jest.fn();
 const mockRedirectToPostOnboarding = jest.fn();
+const mockStartPostOnboarding = jest.fn();
 
 jest.mock("~/renderer/hooks/useAutoRedirectToPostOnboarding", () => ({
   useRedirectToPostOnboardingCallback: jest.fn(),
@@ -32,6 +33,11 @@ jest.mock(
   }),
 );
 
+jest.mock("@ledgerhq/live-common/postOnboarding/hooks/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/postOnboarding/hooks/index"),
+  useStartPostOnboardingCallback: () => mockStartPostOnboarding,
+}));
+
 const getInitialState = (modelId: DeviceModelId = DeviceModelId.stax): Partial<State> => ({
   devices: {
     devices: [],
@@ -45,6 +51,7 @@ describe("useCompletionScreenViewModel", () => {
     mockRedirectToPostOnboarding.mockClear();
     mockNavigate.mockClear();
     mockOpenFinishOnboardingDialog.mockClear();
+    mockStartPostOnboarding.mockClear();
     jest
       .mocked(useRedirectToPostOnboardingCallback)
       .mockReturnValue(mockRedirectToPostOnboarding);
@@ -67,6 +74,7 @@ describe("useCompletionScreenViewModel", () => {
       });
 
       expect(mockRedirectToPostOnboarding).toHaveBeenCalledTimes(1);
+      expect(mockStartPostOnboarding).not.toHaveBeenCalled();
       expect(mockNavigate).not.toHaveBeenCalled();
       expect(mockOpenFinishOnboardingDialog).not.toHaveBeenCalled();
 
@@ -78,7 +86,7 @@ describe("useCompletionScreenViewModel", () => {
     }),
   );
 
-  it("should navigate home and open finish-onboarding dialog when Wallet40 finish widget is enabled", () => {
+  it("should init post-onboarding, navigate home, and open finish-onboarding dialog when Wallet40 finish widget is enabled", () => {
     const deviceId = DeviceModelId.stax;
     const initialState = {
       ...getInitialState(deviceId),
@@ -97,7 +105,19 @@ describe("useCompletionScreenViewModel", () => {
     });
 
     expect(mockRedirectToPostOnboarding).not.toHaveBeenCalled();
+    expect(mockStartPostOnboarding).toHaveBeenCalledWith({
+      deviceModelId: deviceId,
+      skipNavigateToHub: true,
+    });
     expect(mockNavigate).toHaveBeenCalledWith("/");
     expect(mockOpenFinishOnboardingDialog).toHaveBeenCalledTimes(1);
+
+    const [startOrder, navigateOrder, openDialogOrder] = [
+      mockStartPostOnboarding.mock.invocationCallOrder[0],
+      mockNavigate.mock.invocationCallOrder[0],
+      mockOpenFinishOnboardingDialog.mock.invocationCallOrder[0],
+    ];
+    expect(startOrder).toBeLessThan(navigateOrder);
+    expect(navigateOrder).toBeLessThan(openDialogOrder);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompletion/useCompletionScreenViewModel.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompletion/useCompletionScreenViewModel.tsx
@@ -11,6 +11,7 @@ import {
 } from "~/renderer/actions/settings";
 import { lastSeenDeviceSelector } from "~/renderer/reducers/settings";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
+import { useStartPostOnboardingCallback } from "@ledgerhq/live-common/postOnboarding/hooks/index";
 import { useRedirectToPostOnboardingCallback } from "~/renderer/hooks/useAutoRedirectToPostOnboarding";
 import useFinishOnboardingDialog from "LLD/features/FinishOnboarding/FinishOnboardingDialog/hooks/useFinishOnboardingDialog";
 
@@ -35,6 +36,7 @@ export function useCompletionScreenViewModel(): ViewProps {
   }, [currentDevice, lastSeenDevice]);
 
   const { shouldDisplayFinishOnboardingWidget = false } = useWalletFeaturesConfig("desktop");
+  const startPostOnboarding = useStartPostOnboardingCallback();
   const redirectToPostOnboarding = useRedirectToPostOnboardingCallback();
   const { handleOpen: openFinishOnboardingDialog } = useFinishOnboardingDialog();
 
@@ -45,6 +47,7 @@ export function useCompletionScreenViewModel(): ViewProps {
     dispatch(setLastOnboardedDevice(currentDevice));
     const timeout = setTimeout(() => {
       if (shouldDisplayFinishOnboardingWidget) {
+        startPostOnboarding({ deviceModelId, skipNavigateToHub: true });
         navigate("/");
         openFinishOnboardingDialog();
       } else {
@@ -56,11 +59,13 @@ export function useCompletionScreenViewModel(): ViewProps {
     };
   }, [
     currentDevice,
+    deviceModelId,
     dispatch,
     navigate,
     openFinishOnboardingDialog,
     redirectToPostOnboarding,
     shouldDisplayFinishOnboardingWidget,
+    startPostOnboarding,
   ]);
 
   return {

--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompletion/useCompletionScreenViewModel.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompletion/useCompletionScreenViewModel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { useLocation } from "react-router";
 import { DeviceModelId } from "@ledgerhq/types-devices";
@@ -32,11 +32,15 @@ export function useCompletionScreenViewModel(): ViewProps {
   }, [currentDevice, lastSeenDevice]);
 
   const redirectToPostOnboarding = useRedirectToPostOnboardingCallback();
+  const hasPreparedPostOnboardingRedirect = useRef(false);
 
   useEffect(() => {
     dispatch(saveSettings({ hasCompletedOnboarding: true }));
-    dispatch(setHasRedirectedToPostOnboarding(false));
-    dispatch(setHasBeenUpsoldRecover(false));
+    if (!hasPreparedPostOnboardingRedirect.current) {
+      hasPreparedPostOnboardingRedirect.current = true;
+      dispatch(setHasRedirectedToPostOnboarding(false));
+      dispatch(setHasBeenUpsoldRecover(false));
+    }
     dispatch(setLastOnboardedDevice(currentDevice));
     const timeout = setTimeout(() => {
       redirectToPostOnboarding();

--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompletion/useCompletionScreenViewModel.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompletion/useCompletionScreenViewModel.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo } from "react";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
-import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
-import { useLocation, useNavigate } from "react-router";
+import { useLocation } from "react-router";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import {
   saveSettings,
@@ -11,9 +10,7 @@ import {
 } from "~/renderer/actions/settings";
 import { lastSeenDeviceSelector } from "~/renderer/reducers/settings";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
-import { useStartPostOnboardingCallback } from "@ledgerhq/live-common/postOnboarding/hooks/index";
 import { useRedirectToPostOnboardingCallback } from "~/renderer/hooks/useAutoRedirectToPostOnboarding";
-import useFinishOnboardingDialog from "LLD/features/FinishOnboarding/FinishOnboardingDialog/hooks/useFinishOnboardingDialog";
 
 const COMPLETION_SCREEN_TIMEOUT = 6000;
 
@@ -25,7 +22,6 @@ export interface ViewProps {
 export function useCompletionScreenViewModel(): ViewProps {
   const dispatch = useDispatch();
   const location = useLocation();
-  const navigate = useNavigate();
   const state = location.state as { seedConfiguration?: string } | null;
   const currentDevice = useSelector(getCurrentDevice);
   const lastSeenDevice = useSelector(lastSeenDeviceSelector);
@@ -35,10 +31,7 @@ export function useCompletionScreenViewModel(): ViewProps {
     return device?.modelId || DeviceModelId.stax;
   }, [currentDevice, lastSeenDevice]);
 
-  const { shouldDisplayFinishOnboardingWidget = false } = useWalletFeaturesConfig("desktop");
-  const startPostOnboarding = useStartPostOnboardingCallback();
   const redirectToPostOnboarding = useRedirectToPostOnboardingCallback();
-  const { handleOpen: openFinishOnboardingDialog } = useFinishOnboardingDialog();
 
   useEffect(() => {
     dispatch(saveSettings({ hasCompletedOnboarding: true }));
@@ -46,27 +39,12 @@ export function useCompletionScreenViewModel(): ViewProps {
     dispatch(setHasBeenUpsoldRecover(false));
     dispatch(setLastOnboardedDevice(currentDevice));
     const timeout = setTimeout(() => {
-      if (shouldDisplayFinishOnboardingWidget) {
-        startPostOnboarding({ deviceModelId, skipNavigateToHub: true });
-        navigate("/");
-        openFinishOnboardingDialog();
-      } else {
-        redirectToPostOnboarding();
-      }
+      redirectToPostOnboarding();
     }, COMPLETION_SCREEN_TIMEOUT);
     return () => {
       clearTimeout(timeout);
     };
-  }, [
-    currentDevice,
-    deviceModelId,
-    dispatch,
-    navigate,
-    openFinishOnboardingDialog,
-    redirectToPostOnboarding,
-    shouldDisplayFinishOnboardingWidget,
-    startPostOnboarding,
-  ]);
+  }, [currentDevice, dispatch, redirectToPostOnboarding]);
 
   return {
     seedConfiguration: state?.seedConfiguration,

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/__tests__/useNavigateToPostOnboardingHubCallback.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/__tests__/useNavigateToPostOnboardingHubCallback.test.ts
@@ -7,9 +7,7 @@ import { DEFAULT_FEATURES } from "@ledgerhq/live-common/featureFlags/defaultFeat
 import { act, renderHook, withFlagOverrides } from "tests/testSetup";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { PostOnboardingActionId } from "@ledgerhq/types-live";
-import { getStoreValue } from "~/renderer/store";
 import { useNavigateToPostOnboardingHubCallback } from "../useNavigateToPostOnboardingHubCallback";
-import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
 
 const mockNavigate = jest.fn();
 
@@ -18,19 +16,11 @@ jest.mock("react-router", () => ({
   useNavigate: () => mockNavigate,
 }));
 
-jest.mock("~/renderer/store", () => ({
-  getStoreValue: jest.fn(),
-  setStoreValue: jest.fn(),
-  resetStore: jest.fn(),
-}));
-
 const PROTECT_ID = "protect-prod";
 const RECOVER_UPSELL_URI = "ledgerlive://recover/protect-prod?redirectTo=upsell&source=lld-onboarding-24";
 const RECOVER_LANDING_PATH = `/recover/${PROTECT_ID}?redirectTo=upsell&source=lld-post-onboarding-banner`;
 
 const protectDesktopDefaultParams = DEFAULT_FEATURES.protectServicesDesktop.params!;
-
-const mockGetStoreValue = jest.mocked(getStoreValue);
 
 function featureFlagsWithRecover() {
   return withFlagOverrides({
@@ -51,6 +41,16 @@ function featureFlagsWithRecover() {
         },
       },
     },
+  });
+}
+
+function featureFlagsWithWallet40WithoutRecover() {
+  return withFlagOverrides({
+    lwdWallet40: {
+      enabled: true,
+      params: { finishOnboardingWidget: true },
+    },
+    protectServicesDesktop: { enabled: false },
   });
 }
 
@@ -92,7 +92,6 @@ function renderNavigateHook(initialState: NavigateHookInitialState = {}) {
 describe("useNavigateToPostOnboardingHubCallback", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetStoreValue.mockReturnValue(LedgerRecoverSubscriptionStateEnum.STARGATE_SUBSCRIBE);
   });
 
   it("should navigate to recover landing and open finish dialog when Wallet40 and recover apply", () => {
@@ -112,30 +111,9 @@ describe("useNavigateToPostOnboardingHubCallback", () => {
     expect(mockNavigate).not.toHaveBeenCalledWith("/post-onboarding");
   });
 
-  it("reads subscription state when navigation runs, not at hook render time", () => {
-    mockGetStoreValue.mockReturnValue(LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION);
-
-    const { result } = renderNavigateHook({
-      ...featureFlagsWithRecover(),
-      postOnboarding: postOnboardingState(),
-      settings: { hasBeenRedirectedToPostOnboarding: false },
-    });
-
-    mockGetStoreValue.mockReturnValue(LedgerRecoverSubscriptionStateEnum.STARGATE_SUBSCRIBE);
-
-    act(() => {
-      result.current();
-    });
-
-    expect(mockNavigate).toHaveBeenCalledWith(RECOVER_LANDING_PATH, { replace: true });
-    expect(mockGetStoreValue).toHaveBeenCalledWith("SUBSCRIPTION_STATE", PROTECT_ID);
-  });
-
   it("should navigate to portfolio and open finish dialog when Wallet40 is enabled without recover", () => {
-    mockGetStoreValue.mockReturnValue(LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION);
-
     const { result, store } = renderNavigateHook({
-      ...featureFlagsWithRecover(),
+      ...featureFlagsWithWallet40WithoutRecover(),
       postOnboarding: postOnboardingState(),
       settings: { hasBeenRedirectedToPostOnboarding: false },
     });

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/__tests__/useNavigateToPostOnboardingHubCallback.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/__tests__/useNavigateToPostOnboardingHubCallback.test.ts
@@ -29,12 +29,15 @@ describe("useNavigateToPostOnboardingHubCallback", () => {
 
   it("should navigate to portfolio and open finish dialog when Wallet40 finish widget is enabled", () => {
     const { result } = renderHook(() => useNavigateToPostOnboardingHubCallback(), {
-      initialState: withFlagOverrides({
-        lwdWallet40: {
-          enabled: true,
-          params: { finishOnboardingWidget: true },
-        },
-      }),
+      initialState: {
+        ...withFlagOverrides({
+          lwdWallet40: {
+            enabled: true,
+            params: { finishOnboardingWidget: true },
+          },
+        }),
+        settings: { hasBeenRedirectedToPostOnboarding: false },
+      },
     });
 
     act(() => {
@@ -44,6 +47,27 @@ describe("useNavigateToPostOnboardingHubCallback", () => {
     expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true });
     expect(mockOpenFinishOnboardingDialog).toHaveBeenCalledTimes(1);
     expect(mockNavigate).not.toHaveBeenCalledWith("/post-onboarding");
+  });
+
+  it("should not reopen finish dialog when already redirected with Wallet40 enabled", () => {
+    const { result } = renderHook(() => useNavigateToPostOnboardingHubCallback(), {
+      initialState: {
+        ...withFlagOverrides({
+          lwdWallet40: {
+            enabled: true,
+            params: { finishOnboardingWidget: true },
+          },
+        }),
+        settings: { hasBeenRedirectedToPostOnboarding: true },
+      },
+    });
+
+    act(() => {
+      result.current();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true });
+    expect(mockOpenFinishOnboardingDialog).not.toHaveBeenCalled();
   });
 
   it("should navigate to post-onboarding hub when finish widget is disabled", () => {

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/__tests__/useNavigateToPostOnboardingHubCallback.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/__tests__/useNavigateToPostOnboardingHubCallback.test.ts
@@ -77,7 +77,18 @@ describe("useNavigateToPostOnboardingHubCallback", () => {
       result.current();
     });
 
-    expect(mockNavigate).toHaveBeenCalledWith("/post-onboarding");
+    expect(mockNavigate).toHaveBeenCalledWith("/post-onboarding", { replace: false });
+    expect(mockOpenFinishOnboardingDialog).not.toHaveBeenCalled();
+  });
+
+  it("should replace history when navigating to post-onboarding hub with resetNavigationStack", () => {
+    const { result } = renderHook(() => useNavigateToPostOnboardingHubCallback());
+
+    act(() => {
+      result.current(true);
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith("/post-onboarding", { replace: true });
     expect(mockOpenFinishOnboardingDialog).not.toHaveBeenCalled();
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/__tests__/useNavigateToPostOnboardingHubCallback.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/__tests__/useNavigateToPostOnboardingHubCallback.test.ts
@@ -44,7 +44,7 @@ function featureFlagsWithRecover() {
         ...protectDesktopDefaultParams,
         protectId: PROTECT_ID,
         availableOnDesktop: true,
-        compatibleDevices: [{ name: DeviceModelId.nanoX, available: true }],
+        compatibleDevices: [{ name: DeviceModelId.nanoX, available: true, comingSoon: false }],
         onboardingCompleted: {
           ...protectDesktopDefaultParams.onboardingCompleted,
           upsellURI: RECOVER_UPSELL_URI,
@@ -67,9 +67,11 @@ function postOnboardingState(deviceModelId = DeviceModelId.nanoX) {
   };
 }
 
-function renderNavigateHook(
-  initialState: Parameters<typeof renderHook>[1]["initialState"] = {},
-) {
+type NavigateHookInitialState = NonNullable<
+  Parameters<typeof renderHook>[1]
+>["initialState"];
+
+function renderNavigateHook(initialState: NavigateHookInitialState = {}) {
   const Wrapper = ({ children }: { children: React.ReactNode }) =>
     React.createElement(
       PostOnboardingProvider,
@@ -108,6 +110,25 @@ describe("useNavigateToPostOnboardingHubCallback", () => {
     expect(store.getState().dialogs.FINISH_POST_ONBOARDING).toBe(true);
     expect(mockNavigate).not.toHaveBeenCalledWith("/");
     expect(mockNavigate).not.toHaveBeenCalledWith("/post-onboarding");
+  });
+
+  it("reads subscription state when navigation runs, not at hook render time", () => {
+    mockGetStoreValue.mockReturnValue(LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION);
+
+    const { result } = renderNavigateHook({
+      ...featureFlagsWithRecover(),
+      postOnboarding: postOnboardingState(),
+      settings: { hasBeenRedirectedToPostOnboarding: false },
+    });
+
+    mockGetStoreValue.mockReturnValue(LedgerRecoverSubscriptionStateEnum.STARGATE_SUBSCRIBE);
+
+    act(() => {
+      result.current();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(RECOVER_LANDING_PATH, { replace: true });
+    expect(mockGetStoreValue).toHaveBeenCalledWith("SUBSCRIPTION_STATE", PROTECT_ID);
   });
 
   it("should navigate to portfolio and open finish dialog when Wallet40 is enabled without recover", () => {

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/__tests__/useNavigateToPostOnboardingHubCallback.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/__tests__/useNavigateToPostOnboardingHubCallback.test.ts
@@ -1,65 +1,122 @@
 /**
  * @jest-environment jsdom
  */
+import React from "react";
+import { PostOnboardingProvider } from "@ledgerhq/live-common/postOnboarding/PostOnboardingProvider";
+import { DEFAULT_FEATURES } from "@ledgerhq/live-common/featureFlags/defaultFeatures";
 import { act, renderHook, withFlagOverrides } from "tests/testSetup";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { PostOnboardingActionId } from "@ledgerhq/types-live";
+import { getStoreValue } from "~/renderer/store";
 import { useNavigateToPostOnboardingHubCallback } from "../useNavigateToPostOnboardingHubCallback";
+import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
 
 const mockNavigate = jest.fn();
-const mockOpenFinishOnboardingDialog = jest.fn();
 
 jest.mock("react-router", () => ({
   ...jest.requireActual("react-router"),
   useNavigate: () => mockNavigate,
 }));
 
-jest.mock(
-  "LLD/features/FinishOnboarding/FinishOnboardingDialog/hooks/useFinishOnboardingDialog",
-  () => ({
-    __esModule: true,
-    default: () => ({
-      handleOpen: mockOpenFinishOnboardingDialog,
-    }),
-  }),
-);
+jest.mock("~/renderer/store", () => ({
+  getStoreValue: jest.fn(),
+  setStoreValue: jest.fn(),
+  resetStore: jest.fn(),
+}));
+
+const PROTECT_ID = "protect-prod";
+const RECOVER_UPSELL_URI = "ledgerlive://recover/protect-prod?redirectTo=upsell&source=lld-onboarding-24";
+const RECOVER_LANDING_PATH = `/recover/${PROTECT_ID}?redirectTo=upsell&source=lld-post-onboarding-banner`;
+
+const protectDesktopDefaultParams = DEFAULT_FEATURES.protectServicesDesktop.params!;
+
+const mockGetStoreValue = jest.mocked(getStoreValue);
+
+function featureFlagsWithRecover() {
+  return withFlagOverrides({
+    lwdWallet40: {
+      enabled: true,
+      params: { finishOnboardingWidget: true },
+    },
+    protectServicesDesktop: {
+      enabled: true,
+      params: {
+        ...protectDesktopDefaultParams,
+        protectId: PROTECT_ID,
+        availableOnDesktop: true,
+        compatibleDevices: [{ name: DeviceModelId.nanoX, available: true }],
+        onboardingCompleted: {
+          ...protectDesktopDefaultParams.onboardingCompleted,
+          upsellURI: RECOVER_UPSELL_URI,
+        },
+      },
+    },
+  });
+}
+
+function postOnboardingState(deviceModelId = DeviceModelId.nanoX) {
+  return {
+    deviceModelId,
+    walletEntryPointDismissed: false,
+    entryPointFirstDisplayedDate: null,
+    walletEntryPointEligibleForPortfolio: null,
+    actionsToComplete: [PostOnboardingActionId.syncAccounts],
+    actionsCompleted: { [PostOnboardingActionId.syncAccounts]: false },
+    lastActionCompleted: null,
+    postOnboardingInProgress: true,
+  };
+}
+
+function renderNavigateHook(
+  initialState: Parameters<typeof renderHook>[1]["initialState"] = {},
+) {
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      PostOnboardingProvider,
+      {
+        navigateToPostOnboardingHub: jest.fn(),
+        getPostOnboardingActionsForDevice: () => [],
+        getPostOnboardingAction: () => undefined,
+      },
+      children,
+    );
+
+  return renderHook(() => useNavigateToPostOnboardingHubCallback(), {
+    wrapper: Wrapper,
+    initialState,
+  });
+}
 
 describe("useNavigateToPostOnboardingHubCallback", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetStoreValue.mockReturnValue(LedgerRecoverSubscriptionStateEnum.STARGATE_SUBSCRIBE);
   });
 
-  it("should navigate to portfolio and open finish dialog when Wallet40 finish widget is enabled", () => {
-    const { result } = renderHook(() => useNavigateToPostOnboardingHubCallback(), {
-      initialState: {
-        ...withFlagOverrides({
-          lwdWallet40: {
-            enabled: true,
-            params: { finishOnboardingWidget: true },
-          },
-        }),
-        settings: { hasBeenRedirectedToPostOnboarding: false },
-      },
+  it("should navigate to recover landing and open finish dialog when Wallet40 and recover apply", () => {
+    const { result, store } = renderNavigateHook({
+      ...featureFlagsWithRecover(),
+      postOnboarding: postOnboardingState(),
+      settings: { hasBeenRedirectedToPostOnboarding: false },
     });
 
     act(() => {
       result.current();
     });
 
-    expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true });
-    expect(mockOpenFinishOnboardingDialog).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(RECOVER_LANDING_PATH, { replace: true });
+    expect(store.getState().dialogs.FINISH_POST_ONBOARDING).toBe(true);
+    expect(mockNavigate).not.toHaveBeenCalledWith("/");
     expect(mockNavigate).not.toHaveBeenCalledWith("/post-onboarding");
   });
 
-  it("should not reopen finish dialog when already redirected with Wallet40 enabled", () => {
-    const { result } = renderHook(() => useNavigateToPostOnboardingHubCallback(), {
-      initialState: {
-        ...withFlagOverrides({
-          lwdWallet40: {
-            enabled: true,
-            params: { finishOnboardingWidget: true },
-          },
-        }),
-        settings: { hasBeenRedirectedToPostOnboarding: true },
-      },
+  it("should navigate to portfolio and open finish dialog when Wallet40 is enabled without recover", () => {
+    mockGetStoreValue.mockReturnValue(LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION);
+
+    const { result, store } = renderNavigateHook({
+      ...featureFlagsWithRecover(),
+      postOnboarding: postOnboardingState(),
+      settings: { hasBeenRedirectedToPostOnboarding: false },
     });
 
     act(() => {
@@ -67,28 +124,68 @@ describe("useNavigateToPostOnboardingHubCallback", () => {
     });
 
     expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true });
-    expect(mockOpenFinishOnboardingDialog).not.toHaveBeenCalled();
+    expect(store.getState().dialogs.FINISH_POST_ONBOARDING).toBe(true);
+    expect(mockNavigate).not.toHaveBeenCalledWith(RECOVER_LANDING_PATH);
+  });
+
+  it("should not reopen finish dialog when already redirected with Wallet40 enabled", () => {
+    const { result, store } = renderNavigateHook({
+      ...featureFlagsWithRecover(),
+      postOnboarding: postOnboardingState(),
+      settings: { hasBeenRedirectedToPostOnboarding: true },
+      dialogs: { FINISH_POST_ONBOARDING: false },
+    });
+
+    act(() => {
+      result.current();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(RECOVER_LANDING_PATH, { replace: true });
+    expect(store.getState().dialogs.FINISH_POST_ONBOARDING).toBe(false);
+  });
+
+  it("should use resetNavigationStack for recover landing navigation", () => {
+    const { result } = renderNavigateHook({
+      ...featureFlagsWithRecover(),
+      postOnboarding: postOnboardingState(),
+      settings: { hasBeenRedirectedToPostOnboarding: false },
+    });
+
+    act(() => {
+      result.current(false);
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(RECOVER_LANDING_PATH, { replace: false });
   });
 
   it("should navigate to post-onboarding hub when finish widget is disabled", () => {
-    const { result } = renderHook(() => useNavigateToPostOnboardingHubCallback());
+    const { result, store } = renderNavigateHook({
+      ...withFlagOverrides({
+        lwdWallet40: { enabled: false },
+        protectServicesDesktop: { enabled: true },
+      }),
+      postOnboarding: postOnboardingState(),
+    });
 
     act(() => {
       result.current();
     });
 
     expect(mockNavigate).toHaveBeenCalledWith("/post-onboarding", { replace: false });
-    expect(mockOpenFinishOnboardingDialog).not.toHaveBeenCalled();
+    expect(store.getState().dialogs.FINISH_POST_ONBOARDING).not.toBe(true);
   });
 
   it("should replace history when navigating to post-onboarding hub with resetNavigationStack", () => {
-    const { result } = renderHook(() => useNavigateToPostOnboardingHubCallback());
+    const { result } = renderNavigateHook({
+      ...withFlagOverrides({ lwdWallet40: { enabled: false } }),
+      postOnboarding: postOnboardingState(),
+    });
 
     act(() => {
       result.current(true);
     });
 
     expect(mockNavigate).toHaveBeenCalledWith("/post-onboarding", { replace: true });
-    expect(mockOpenFinishOnboardingDialog).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalledWith("/");
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/__tests__/useNavigateToPostOnboardingHubCallback.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/__tests__/useNavigateToPostOnboardingHubCallback.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, renderHook, withFlagOverrides } from "tests/testSetup";
+import { useNavigateToPostOnboardingHubCallback } from "../useNavigateToPostOnboardingHubCallback";
+
+const mockNavigate = jest.fn();
+const mockOpenFinishOnboardingDialog = jest.fn();
+
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock(
+  "LLD/features/FinishOnboarding/FinishOnboardingDialog/hooks/useFinishOnboardingDialog",
+  () => ({
+    __esModule: true,
+    default: () => ({
+      handleOpen: mockOpenFinishOnboardingDialog,
+    }),
+  }),
+);
+
+describe("useNavigateToPostOnboardingHubCallback", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should navigate to portfolio and open finish dialog when Wallet40 finish widget is enabled", () => {
+    const { result } = renderHook(() => useNavigateToPostOnboardingHubCallback(), {
+      initialState: withFlagOverrides({
+        lwdWallet40: {
+          enabled: true,
+          params: { finishOnboardingWidget: true },
+        },
+      }),
+    });
+
+    act(() => {
+      result.current();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true });
+    expect(mockOpenFinishOnboardingDialog).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalledWith("/post-onboarding");
+  });
+
+  it("should navigate to post-onboarding hub when finish widget is disabled", () => {
+    const { result } = renderHook(() => useNavigateToPostOnboardingHubCallback());
+
+    act(() => {
+      result.current();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith("/post-onboarding");
+    expect(mockOpenFinishOnboardingDialog).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/useNavigateToPostOnboardingHubCallback.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/useNavigateToPostOnboardingHubCallback.ts
@@ -4,21 +4,8 @@ import { useNavigate } from "react-router";
 import { isRecoverDisplayed, useFeature, useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import { useUpsellPath } from "@ledgerhq/live-common/hooks/recoverFeatureFlag";
 import { usePostOnboardingHubState } from "@ledgerhq/live-common/postOnboarding/hooks/index";
-import { hasStartedLedgerRecoverFlowForPostOnboarding } from "LLD/features/FinishOnboarding/RecoverWidget/recoverPortfolioWidgetVisibility";
 import { hasBeenRedirectedToPostOnboardingSelector } from "~/renderer/reducers/settings";
 import useFinishOnboardingDialog from "LLD/features/FinishOnboarding/FinishOnboardingDialog/hooks/useFinishOnboardingDialog";
-import { getStoreValue } from "~/renderer/store";
-import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
-
-function readRecoverSubscriptionState(
-  protectId: string,
-): LedgerRecoverSubscriptionStateEnum | undefined {
-  try {
-    return getStoreValue<LedgerRecoverSubscriptionStateEnum>("SUBSCRIPTION_STATE", protectId);
-  } catch {
-    return undefined;
-  }
-}
 
 export function useNavigateToPostOnboardingHubCallback() {
   const navigate = useNavigate();
@@ -34,8 +21,7 @@ export function useNavigateToPostOnboardingHubCallback() {
     (resetNavigationStack?: boolean) => {
       const shouldNavigateToRecoverLanding =
         isRecoverDisplayed(recoverServices, deviceModelId ?? undefined) &&
-        !!upsellPath &&
-        hasStartedLedgerRecoverFlowForPostOnboarding(readRecoverSubscriptionState(protectId));
+        !!upsellPath;
 
       if (shouldDisplayFinishOnboardingWidget) {
         const replace = resetNavigationStack ?? true;

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/useNavigateToPostOnboardingHubCallback.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/useNavigateToPostOnboardingHubCallback.ts
@@ -1,10 +1,23 @@
 import { useCallback } from "react";
 import { useNavigate } from "react-router";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import useFinishOnboardingDialog from "LLD/features/FinishOnboarding/FinishOnboardingDialog/hooks/useFinishOnboardingDialog";
 
 export function useNavigateToPostOnboardingHubCallback() {
   const navigate = useNavigate();
+  const { shouldDisplayFinishOnboardingWidget = false } = useWalletFeaturesConfig("desktop");
+  const { handleOpen: openFinishOnboardingDialog } = useFinishOnboardingDialog();
 
-  return useCallback(() => {
-    navigate("/post-onboarding");
-  }, [navigate]);
+  return useCallback(
+    (_resetNavigationStack?: boolean) => {
+      if (shouldDisplayFinishOnboardingWidget) {
+        navigate("/", { replace: true });
+        openFinishOnboardingDialog();
+        return;
+      } else {
+        navigate("/post-onboarding");
+      }
+    },
+    [navigate, openFinishOnboardingDialog, shouldDisplayFinishOnboardingWidget],
+  );
 }

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/useNavigateToPostOnboardingHubCallback.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/useNavigateToPostOnboardingHubCallback.ts
@@ -12,7 +12,7 @@ export function useNavigateToPostOnboardingHubCallback() {
   const { handleOpen: openFinishOnboardingDialog } = useFinishOnboardingDialog();
 
   return useCallback(
-    (_resetNavigationStack?: boolean) => {
+    (resetNavigationStack?: boolean) => {
       if (shouldDisplayFinishOnboardingWidget) {
         navigate("/", { replace: true });
         if (!hasBeenRedirectedToPostOnboarding) {
@@ -20,7 +20,7 @@ export function useNavigateToPostOnboardingHubCallback() {
         }
         return;
       }
-      navigate("/post-onboarding");
+      navigate("/post-onboarding", { replace: !!resetNavigationStack });
     },
     [
       hasBeenRedirectedToPostOnboarding,

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/useNavigateToPostOnboardingHubCallback.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/useNavigateToPostOnboardingHubCallback.ts
@@ -1,20 +1,52 @@
 import { useCallback } from "react";
 import { useSelector } from "LLD/hooks/redux";
 import { useNavigate } from "react-router";
-import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { isRecoverDisplayed, useFeature, useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { useUpsellPath } from "@ledgerhq/live-common/hooks/recoverFeatureFlag";
+import { usePostOnboardingHubState } from "@ledgerhq/live-common/postOnboarding/hooks/index";
+import { hasStartedLedgerRecoverFlowForPostOnboarding } from "LLD/features/FinishOnboarding/RecoverWidget/recoverPortfolioWidgetVisibility";
 import { hasBeenRedirectedToPostOnboardingSelector } from "~/renderer/reducers/settings";
 import useFinishOnboardingDialog from "LLD/features/FinishOnboarding/FinishOnboardingDialog/hooks/useFinishOnboardingDialog";
+import { getStoreValue } from "~/renderer/store";
+import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
 
 export function useNavigateToPostOnboardingHubCallback() {
   const navigate = useNavigate();
   const hasBeenRedirectedToPostOnboarding = useSelector(hasBeenRedirectedToPostOnboardingSelector);
   const { shouldDisplayFinishOnboardingWidget = false } = useWalletFeaturesConfig("desktop");
   const { handleOpen: openFinishOnboardingDialog } = useFinishOnboardingDialog();
+  const { deviceModelId } = usePostOnboardingHubState();
+  const recoverServices = useFeature("protectServicesDesktop");
+  const upsellPath = useUpsellPath(recoverServices);
+  const protectId = recoverServices?.params?.protectId ?? "protect-prod";
+
+  let subscriptionState: LedgerRecoverSubscriptionStateEnum | undefined;
+  try {
+    subscriptionState = getStoreValue<LedgerRecoverSubscriptionStateEnum>(
+      "SUBSCRIPTION_STATE",
+      protectId,
+    );
+  } catch {
+    subscriptionState = undefined;
+  }
+
+  const shouldNavigateToRecoverLanding =
+    isRecoverDisplayed(recoverServices, deviceModelId ?? undefined) &&
+    !!upsellPath &&
+    hasStartedLedgerRecoverFlowForPostOnboarding(subscriptionState);
 
   return useCallback(
     (resetNavigationStack?: boolean) => {
       if (shouldDisplayFinishOnboardingWidget) {
-        navigate("/", { replace: true });
+        const replace = resetNavigationStack ?? true;
+        if (shouldNavigateToRecoverLanding) {
+          navigate(
+            `/recover/${protectId}?redirectTo=upsell&source=lld-post-onboarding-banner`,
+            { replace },
+          );
+        } else {
+          navigate("/", { replace: true });
+        }
         if (!hasBeenRedirectedToPostOnboarding) {
           openFinishOnboardingDialog();
         }
@@ -26,7 +58,9 @@ export function useNavigateToPostOnboardingHubCallback() {
       hasBeenRedirectedToPostOnboarding,
       navigate,
       openFinishOnboardingDialog,
+      protectId,
       shouldDisplayFinishOnboardingWidget,
+      shouldNavigateToRecoverLanding,
     ],
   );
 }

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/useNavigateToPostOnboardingHubCallback.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/useNavigateToPostOnboardingHubCallback.ts
@@ -1,10 +1,13 @@
 import { useCallback } from "react";
+import { useSelector } from "LLD/hooks/redux";
 import { useNavigate } from "react-router";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { hasBeenRedirectedToPostOnboardingSelector } from "~/renderer/reducers/settings";
 import useFinishOnboardingDialog from "LLD/features/FinishOnboarding/FinishOnboardingDialog/hooks/useFinishOnboardingDialog";
 
 export function useNavigateToPostOnboardingHubCallback() {
   const navigate = useNavigate();
+  const hasBeenRedirectedToPostOnboarding = useSelector(hasBeenRedirectedToPostOnboardingSelector);
   const { shouldDisplayFinishOnboardingWidget = false } = useWalletFeaturesConfig("desktop");
   const { handleOpen: openFinishOnboardingDialog } = useFinishOnboardingDialog();
 
@@ -12,12 +15,18 @@ export function useNavigateToPostOnboardingHubCallback() {
     (_resetNavigationStack?: boolean) => {
       if (shouldDisplayFinishOnboardingWidget) {
         navigate("/", { replace: true });
-        openFinishOnboardingDialog();
+        if (!hasBeenRedirectedToPostOnboarding) {
+          openFinishOnboardingDialog();
+        }
         return;
-      } else {
-        navigate("/post-onboarding");
       }
+      navigate("/post-onboarding");
     },
-    [navigate, openFinishOnboardingDialog, shouldDisplayFinishOnboardingWidget],
+    [
+      hasBeenRedirectedToPostOnboarding,
+      navigate,
+      openFinishOnboardingDialog,
+      shouldDisplayFinishOnboardingWidget,
+    ],
   );
 }

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/useNavigateToPostOnboardingHubCallback.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/useNavigateToPostOnboardingHubCallback.ts
@@ -10,6 +10,16 @@ import useFinishOnboardingDialog from "LLD/features/FinishOnboarding/FinishOnboa
 import { getStoreValue } from "~/renderer/store";
 import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
 
+function readRecoverSubscriptionState(
+  protectId: string,
+): LedgerRecoverSubscriptionStateEnum | undefined {
+  try {
+    return getStoreValue<LedgerRecoverSubscriptionStateEnum>("SUBSCRIPTION_STATE", protectId);
+  } catch {
+    return undefined;
+  }
+}
+
 export function useNavigateToPostOnboardingHubCallback() {
   const navigate = useNavigate();
   const hasBeenRedirectedToPostOnboarding = useSelector(hasBeenRedirectedToPostOnboardingSelector);
@@ -20,23 +30,13 @@ export function useNavigateToPostOnboardingHubCallback() {
   const upsellPath = useUpsellPath(recoverServices);
   const protectId = recoverServices?.params?.protectId ?? "protect-prod";
 
-  let subscriptionState: LedgerRecoverSubscriptionStateEnum | undefined;
-  try {
-    subscriptionState = getStoreValue<LedgerRecoverSubscriptionStateEnum>(
-      "SUBSCRIPTION_STATE",
-      protectId,
-    );
-  } catch {
-    subscriptionState = undefined;
-  }
-
-  const shouldNavigateToRecoverLanding =
-    isRecoverDisplayed(recoverServices, deviceModelId ?? undefined) &&
-    !!upsellPath &&
-    hasStartedLedgerRecoverFlowForPostOnboarding(subscriptionState);
-
   return useCallback(
     (resetNavigationStack?: boolean) => {
+      const shouldNavigateToRecoverLanding =
+        isRecoverDisplayed(recoverServices, deviceModelId ?? undefined) &&
+        !!upsellPath &&
+        hasStartedLedgerRecoverFlowForPostOnboarding(readRecoverSubscriptionState(protectId));
+
       if (shouldDisplayFinishOnboardingWidget) {
         const replace = resetNavigationStack ?? true;
         if (shouldNavigateToRecoverLanding) {
@@ -55,12 +55,14 @@ export function useNavigateToPostOnboardingHubCallback() {
       navigate("/post-onboarding", { replace: !!resetNavigationStack });
     },
     [
+      deviceModelId,
       hasBeenRedirectedToPostOnboarding,
       navigate,
       openFinishOnboardingDialog,
       protectId,
+      recoverServices,
       shouldDisplayFinishOnboardingWidget,
-      shouldNavigateToRecoverLanding,
+      upsellPath,
     ],
   );
 }

--- a/libs/ledger-live-common/src/postOnboarding/hooks/useStartPostOnboardingCallback.ts
+++ b/libs/ledger-live-common/src/postOnboarding/hooks/useStartPostOnboardingCallback.ts
@@ -12,8 +12,6 @@ type StartPostOnboardingOptions = {
   fallbackIfNoAction?: () => void;
   resetNavigationStack?: boolean;
   canShowRecover?: boolean;
-  /** When true, only initializes Redux state without navigating to the post-onboarding hub. */
-  skipNavigateToHub?: boolean;
 };
 
 /**
@@ -34,13 +32,7 @@ export function useStartPostOnboardingCallback(): (options: StartPostOnboardingO
 
   return useCallback(
     (options: StartPostOnboardingOptions) => {
-      const {
-        deviceModelId,
-        mock = false,
-        fallbackIfNoAction,
-        resetNavigationStack,
-        skipNavigateToHub = false,
-      } = options;
+      const { deviceModelId, mock = false, fallbackIfNoAction, resetNavigationStack } = options;
       const actions = getPostOnboardingActionsForDevice(deviceModelId, mock).filter(
         actionWithState =>
           (!actionWithState.featureFlagId || getFeature(actionWithState.featureFlagId)?.enabled) &&
@@ -58,9 +50,7 @@ export function useStartPostOnboardingCallback(): (options: StartPostOnboardingO
         if (fallbackIfNoAction) fallbackIfNoAction();
         return;
       }
-      if (!skipNavigateToHub) {
-        navigateToPostOnboardingHub(resetNavigationStack);
-      }
+      navigateToPostOnboardingHub(resetNavigationStack);
     },
     [dispatch, getFeature, getPostOnboardingActionsForDevice, navigateToPostOnboardingHub],
   );

--- a/libs/ledger-live-common/src/postOnboarding/hooks/useStartPostOnboardingCallback.ts
+++ b/libs/ledger-live-common/src/postOnboarding/hooks/useStartPostOnboardingCallback.ts
@@ -12,6 +12,8 @@ type StartPostOnboardingOptions = {
   fallbackIfNoAction?: () => void;
   resetNavigationStack?: boolean;
   canShowRecover?: boolean;
+  /** When true, only initializes Redux state without navigating to the post-onboarding hub. */
+  skipNavigateToHub?: boolean;
 };
 
 /**
@@ -32,7 +34,13 @@ export function useStartPostOnboardingCallback(): (options: StartPostOnboardingO
 
   return useCallback(
     (options: StartPostOnboardingOptions) => {
-      const { deviceModelId, mock = false, fallbackIfNoAction, resetNavigationStack } = options;
+      const {
+        deviceModelId,
+        mock = false,
+        fallbackIfNoAction,
+        resetNavigationStack,
+        skipNavigateToHub = false,
+      } = options;
       const actions = getPostOnboardingActionsForDevice(deviceModelId, mock).filter(
         actionWithState =>
           (!actionWithState.featureFlagId || getFeature(actionWithState.featureFlagId)?.enabled) &&
@@ -50,7 +58,9 @@ export function useStartPostOnboardingCallback(): (options: StartPostOnboardingO
         if (fallbackIfNoAction) fallbackIfNoAction();
         return;
       }
-      navigateToPostOnboardingHub(resetNavigationStack);
+      if (!skipNavigateToHub) {
+        navigateToPostOnboardingHub(resetNavigationStack);
+      }
     },
     [dispatch, getFeature, getPostOnboardingActionsForDevice, navigateToPostOnboardingHub],
   );


### PR DESCRIPTION
## Summary

- Centralize Wallet40 post-onboarding navigation in `useNavigateToPostOnboardingHubCallback`: Recover landing when `protectServicesDesktop` + compatible device + upsell path, otherwise portfolio + finish-onboarding dialog (once).
- Legacy `/post-onboarding` hub unchanged when the finish widget is off.
- Sync onboarding completion delegates to `useRedirectToPostOnboardingCallback`; finish dialog sets `hasBeenRedirectedToPostOnboarding` when opened.

## Test plan

- [x] Wallet40 + Recover FF on → Recover landing URL + finish dialog
- [x] Close Recover → portfolio + dialog (no `/post-onboarding`)
- [x] Wallet40 without Recover FF → portfolio + dialog only
- [x] Wallet40 off → legacy `/post-onboarding` hub
- [x] Unit: `useNavigateToPostOnboardingHubCallback.test.ts`, `useCompletionScreenViewModel.test.tsx`, `useFinishOnboardingDialogViewModel.test.ts`
- [ ] Desktop E2E on branch `fix/postonboarding-dialog` (nanoSP or stax)

## Context

- JIRA: [LIVE-30572](https://ledgerhq.atlassian.net/browse/LIVE-30572)
- JIRA: [LIVE-30729](https://ledgerhq.atlassian.net/browse/LIVE-30729)

[LIVE-30572]: https://ledgerhq.atlassian.net/browse/LIVE-30572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-30729]: https://ledgerhq.atlassian.net/browse/LIVE-30729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ