### PR TITLE
[LWM] fix(mobile): handle long balance overflow on asset detail

### DIFF
--- a/.changeset/asset-detail-balance-overflow-fix.md
+++ b/.changeset/asset-detail-balance-overflow-fix.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix asset detail Total balance hiding behind the Transfer button when the counter value exceeds 9 integer digits — the formatter now truncates with an ellipsis and the balance row clips overflow as a safety net

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/TotalBalanceView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/TotalBalanceView.tsx
@@ -53,9 +53,12 @@ const headerRowStyle: LumenViewStyle = {
   flexDirection: "row",
   justifyContent: "space-between",
   alignItems: "center",
+  gap: "s12",
 };
 
 const balanceContainerStyle: LumenViewStyle = {
   gap: "s4",
   flex: 1,
+  flexShrink: 1,
+  overflow: "hidden",
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/__tests__/capFormattedValue.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/__tests__/capFormattedValue.test.ts
@@ -1,0 +1,42 @@
+import type { FormattedValue } from "@ledgerhq/lumen-ui-rnative";
+import { capFormattedValue, MAX_INTEGER_CHARS } from "../capFormattedValue";
+
+const base: FormattedValue = {
+  integerPart: "",
+  decimalPart: "00",
+  decimalSeparator: ".",
+  currencyText: "$",
+  currencyPosition: "start",
+};
+
+describe("capFormattedValue", () => {
+  it("returns the value unchanged when integerPart fits within MAX_INTEGER_CHARS", () => {
+    const value = { ...base, integerPart: "1,234,567" };
+    expect(capFormattedValue(value)).toBe(value);
+  });
+
+  it("returns the value unchanged at exactly MAX_INTEGER_CHARS", () => {
+    const value = { ...base, integerPart: "x".repeat(MAX_INTEGER_CHARS) };
+    expect(capFormattedValue(value)).toBe(value);
+  });
+
+  it("truncates the integerPart with an ellipsis when exceeding the limit", () => {
+    const value = { ...base, integerPart: "60,494,256" };
+    const capped = capFormattedValue(value);
+    expect(capped.integerPart).toBe("60,494,25…");
+    expect(capped.decimalPart).toBe("");
+  });
+
+  it("preserves currency metadata when capping", () => {
+    const value = {
+      ...base,
+      integerPart: "1234567890",
+      currencyText: "€",
+      currencyPosition: "end" as const,
+    };
+    const capped = capFormattedValue(value);
+    expect(capped.currencyText).toBe("€");
+    expect(capped.currencyPosition).toBe("end");
+    expect(capped.decimalSeparator).toBe(".");
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/capFormattedValue.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/capFormattedValue.ts
@@ -1,0 +1,13 @@
+import type { FormattedValue } from "@ledgerhq/lumen-ui-rnative";
+
+export const MAX_INTEGER_CHARS = 9;
+const ELLIPSIS = "…";
+
+export function capFormattedValue(value: FormattedValue): FormattedValue {
+  if (value.integerPart.length <= MAX_INTEGER_CHARS) return value;
+  return {
+    ...value,
+    integerPart: value.integerPart.slice(0, MAX_INTEGER_CHARS) + ELLIPSIS,
+    decimalPart: "",
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/useBalanceDetailsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/useBalanceDetailsViewModel.ts
@@ -17,6 +17,7 @@ import { useLocale, useTranslation } from "~/context/Locale";
 import type { BaseNavigation } from "~/components/RootNavigator/types/helpers";
 import { useStake } from "LLM/hooks/useStake/useStake";
 import { useTransferDrawerController } from "LLM/features/QuickActions/hooks/useTransferDrawerController";
+import { capFormattedValue } from "./capFormattedValue";
 
 type EarnState =
   | { type: "hidden" }
@@ -71,11 +72,13 @@ export function useBalanceDetailsViewModel(
   const counterValue = hasAccounts ? distributionItem?.countervalue ?? 0 : undefined;
 
   const counterValueFormatter = useCallback(
-    (value: number): FormattedValue =>
-      formatCurrencyUnitFragment(counterValueUnit, new BigNumber(value), {
+    (value: number): FormattedValue => {
+      const formatted = formatCurrencyUnitFragment(counterValueUnit, new BigNumber(value), {
         locale,
         showCode: true,
-      }),
+      });
+      return capFormattedValue(formatted);
+    },
     [counterValueUnit, locale],
   );
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Asset Detail screen — Total balance row layout when the counter value has many digits
  - `AmountDisplay` rendering of the counter value (animated digit strips)
  - No impact on Portfolio balance, market price block or any other screen

### 📝 Description

**Problem**: On the Asset Detail screen, when the counter value has 9+ integer digits (e.g. `$60,494,256.10`), the balance text overflows its `flex: 1` container and paints over the Transfer button — `AmountDisplay` uses fixed-width animated digit strips internally, so it does not shrink to honor the parent's flex constraint.

**Solution**: Cap the formatted integer part at 9 characters (including thousand separators) and append `…`. Non-digit characters in `integerPart` are rendered as plain text by `AmountDisplay` (via `useSplitText`'s separator path), so the animation keeps working for normal-sized values. Added `flexShrink: 1` + `overflow: "hidden"` on the balance container and `gap: "s12"` on the row as a layout safety net.

- New helper `capFormattedValue.ts` truncates `integerPart` and blanks `decimalPart` past the threshold
- `useBalanceDetailsViewModel` wraps the `counterValueFormatter` with this helper
- Unit tests cover under / at / over threshold + currency metadata preservation

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30686](https://ledgerhq.atlassian.net/browse/LIVE-30686)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30686]: https://ledgerhq.atlassian.net/browse/LIVE-30686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ