### PR TITLE
[LWM] fix(mobile): redirect Earn CTAs from Asset Detail to coin-specific page

### DIFF
--- a/.changeset/fix-asset-detail-earn-redirection.md
+++ b/.changeset/fix-asset-detail-earn-redirection.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix Earn redirection from the Asset Detail page. The Earn banner and the Earn deposit card now open the stake drawer filtered on the current asset, leading the user to the coin-specific Earn page instead of the generic Earn entry point.

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/__tests__/useBalanceDetailsViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/__tests__/useBalanceDetailsViewModel.test.ts
@@ -23,6 +23,15 @@ jest.mock("LLM/hooks/useStake/useStake", () => ({
   useStake: () => ({ getCanStakeCurrency: mockGetCanStakeCurrency }),
 }));
 
+const mockHandleOpenStakeDrawer = jest.fn();
+const mockUseOpenStakeDrawer = jest.fn((_props: unknown) => ({
+  handleOpenStakeDrawer: mockHandleOpenStakeDrawer,
+}));
+
+jest.mock("LLM/features/Stake", () => ({
+  useOpenStakeDrawer: (props: unknown) => mockUseOpenStakeDrawer(props),
+}));
+
 function buildDistributionItem(
   currency: DistributionItem["currency"],
   accounts: AccountLike[],
@@ -235,7 +244,7 @@ describe("useBalanceDetailsViewModel", () => {
       });
     });
 
-    it("onEarnBannerPress and onEarnDepositPress fire analytics", () => {
+    it("onEarnBannerPress and onEarnDepositPress fire analytics and open the stake drawer", () => {
       const btcAccount = genAccount("bitcoin-0", {
         currency: mockBtcCryptoCurrency,
         operationsSize: 0,
@@ -254,12 +263,42 @@ describe("useBalanceDetailsViewModel", () => {
         currency: "bitcoin",
         page: "Asset Detail",
       });
+      expect(mockHandleOpenStakeDrawer).toHaveBeenCalledTimes(1);
 
       act(() => result.current.onEarnDepositPress());
       expect(track).toHaveBeenCalledWith("button_clicked", {
         button: "earn_deposit",
         currency: "bitcoin",
         page: "Asset Detail",
+      });
+      expect(mockHandleOpenStakeDrawer).toHaveBeenCalledTimes(2);
+    });
+
+    it("configures useOpenStakeDrawer with the current currency and Asset Detail source", () => {
+      const btcAccount = genAccount("bitcoin-0", {
+        currency: mockBtcCryptoCurrency,
+        operationsSize: 0,
+      });
+
+      renderHook(() =>
+        useBalanceDetailsViewModel(
+          mockBtcCryptoCurrency,
+          buildDistributionItem(mockBtcCryptoCurrency, [btcAccount]),
+        ),
+      );
+
+      expect(mockUseOpenStakeDrawer).toHaveBeenCalledWith({
+        sourceScreenName: "Asset Detail",
+        currencies: [mockBtcCryptoCurrency.id],
+      });
+    });
+
+    it("calls useOpenStakeDrawer with undefined currencies when no currency is provided", () => {
+      renderHook(() => useBalanceDetailsViewModel(undefined, undefined));
+
+      expect(mockUseOpenStakeDrawer).toHaveBeenCalledWith({
+        sourceScreenName: "Asset Detail",
+        currencies: undefined,
       });
     });
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/useBalanceDetailsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/useBalanceDetailsViewModel.ts
@@ -8,14 +8,12 @@ import {
   formatCurrencyUnitFragment,
 } from "@ledgerhq/live-common/currencies/index";
 import { useInterestRatesByCurrencies } from "@ledgerhq/live-common/dada-client/hooks/useInterestRatesByCurrencies";
-import { useNavigation } from "@react-navigation/native";
 import { useSelector } from "~/context/hooks";
 import { counterValueCurrencySelector, discreetModeSelector } from "~/reducers/settings";
-import { NavigatorName, ScreenName } from "~/const";
 import { track } from "~/analytics";
 import { useLocale, useTranslation } from "~/context/Locale";
-import type { BaseNavigation } from "~/components/RootNavigator/types/helpers";
 import { useStake } from "LLM/hooks/useStake/useStake";
+import { useOpenStakeDrawer } from "LLM/features/Stake";
 import { useTransferDrawerController } from "LLM/features/QuickActions/hooks/useTransferDrawerController";
 
 type EarnState =
@@ -125,20 +123,11 @@ export function useBalanceDetailsViewModel(
   ]);
 
   const { openDrawer } = useTransferDrawerController();
-  const navigation = useNavigation<BaseNavigation>();
 
-  const navigateToEarn = useCallback(() => {
-    navigation.navigate(NavigatorName.Base, {
-      screen: NavigatorName.Earn,
-      params: {
-        screen: ScreenName.Earn,
-        params: {
-          intent: "deposit",
-          ...(currency?.id && { currencyId: currency.id }),
-        },
-      },
-    });
-  }, [navigation, currency?.id]);
+  const { handleOpenStakeDrawer } = useOpenStakeDrawer({
+    sourceScreenName: "Asset Detail",
+    currencies: currency?.id ? [currency.id] : undefined,
+  });
 
   const onTransferPress = useCallback(() => {
     track("button_clicked", {
@@ -155,8 +144,8 @@ export function useBalanceDetailsViewModel(
       currency: currency?.id,
       page: "Asset Detail",
     });
-    navigateToEarn();
-  }, [currency?.id, navigateToEarn]);
+    handleOpenStakeDrawer();
+  }, [currency?.id, handleOpenStakeDrawer]);
 
   const onEarnDepositPress = useCallback(() => {
     track("button_clicked", {
@@ -164,8 +153,8 @@ export function useBalanceDetailsViewModel(
       currency: currency?.id,
       page: "Asset Detail",
     });
-    navigateToEarn();
-  }, [currency?.id, navigateToEarn]);
+    handleOpenStakeDrawer();
+  }, [currency?.id, handleOpenStakeDrawer]);
 
   return {
     hasAccounts,


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Tap on the Earn banner and the Earn deposit card on the Asset Detail page (mobile V4) across multiple assets (ETH, SOL, TRX, ATOM, BTC, ...) and verify the Earn live-app opens on the coin-specific page (not the dashboard entry point).
      - NoFunds path: open Asset Detail of a stakeable asset with zero spendable balance and verify the NoFunds flow opens.
      - Multi-account assets: verify the stake drawer opens and lets the user pick an account before navigating.
      - Single-account assets: verify the flow still routes correctly through the drawer.
      - Native-only stake assets (Cosmos, Tezos, Solana, ...) still reach their family stake flow.

### Description

The Earn banner and the Earn deposit card on the Asset Detail (mobile V4) page were navigating to the Earn live-app **entry point / dashboard** instead of the coin-specific Earn page.

**Root cause:** the view model was hand-rolling the navigation with `currencyId` (which is only consumed by the `get-funds` deeplink -> StakeFlow), and was missing the `accountId` / `customDappURL` that the Earn live-app needs to pre-select an asset and account.

**Solution:** align with the established mobile pattern (already used by `useAssetActions`, the Portfolio quick actions and the Earn webview `redirect-provider` handler) by calling `useOpenStakeDrawer({ currencies: [currency.id], sourceScreenName: "Asset Detail" })`. The drawer filters on the current asset, lets the user pick an account, and `useStakingDrawer` then builds the correct route via `getRouteParamsForPlatformApp`, handling Earn live-app, partner PlatformApp, family-specific native stake flow and NoFunds uniformly.

### Context

- **JIRA or GitHub link**: [LIVE-30723](https://ledgerhq.atlassian.net/browse/LIVE-30723)

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30723]: https://ledgerhq.atlassian.net/browse/LIVE-30723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ