### PR TITLE
[LWM] fix(mobile): display correct APY percentage in Asset Detail Earn banner

### DIFF
--- a/.changeset/fix-asset-detail-earn-apy-percentage.md
+++ b/.changeset/fix-asset-detail-earn-apy-percentage.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix the APY percentage shown in the Asset Detail Earn banner. The interest rate value is a decimal fraction (e.g. `0.04` for 4%) and was rendered as-is, which made every banner display "0.0% APY". The value is now converted to a percentage before formatting, and the parameterized banner is only shown when the rounded display percentage is greater than zero (the generic banner is used otherwise).

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/__tests__/useBalanceDetailsViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/__tests__/useBalanceDetailsViewModel.test.ts
@@ -32,6 +32,13 @@ jest.mock("LLM/features/Stake", () => ({
   useOpenStakeDrawer: (props: unknown) => mockUseOpenStakeDrawer(props),
 }));
 
+const mockUseInterestRatesByCurrencies = jest.fn().mockReturnValue({});
+
+jest.mock("@ledgerhq/live-common/dada-client/hooks/useInterestRatesByCurrencies", () => ({
+  useInterestRatesByCurrencies: (currencies: unknown) =>
+    mockUseInterestRatesByCurrencies(currencies),
+}));
+
 function buildDistributionItem(
   currency: DistributionItem["currency"],
   accounts: AccountLike[],
@@ -50,6 +57,7 @@ describe("useBalanceDetailsViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetCanStakeCurrency.mockReturnValue(false);
+    mockUseInterestRatesByCurrencies.mockReturnValue({});
   });
 
   it("returns defaults when currency is undefined", () => {
@@ -193,6 +201,78 @@ describe("useBalanceDetailsViewModel", () => {
       );
 
       expect(result.current.earnState.type).toBe("banner");
+    });
+
+    it("formats the banner APY by converting the decimal fraction to a percentage", () => {
+      mockGetCanStakeCurrency.mockReturnValue(true);
+      mockUseInterestRatesByCurrencies.mockReturnValue({
+        bitcoin: { value: 0.0345, type: "APY" },
+      });
+
+      const btcAccount = genAccount("bitcoin-0", {
+        currency: mockBtcCryptoCurrency,
+        operationsSize: 0,
+      });
+
+      const { result } = renderHook(() =>
+        useBalanceDetailsViewModel(
+          mockBtcCryptoCurrency,
+          buildDistributionItem(mockBtcCryptoCurrency, [btcAccount]),
+        ),
+      );
+
+      expect(result.current.earnState.type).toBe("banner");
+      if (result.current.earnState.type === "banner") {
+        expect(result.current.earnState.label).toContain("3.45");
+      }
+    });
+
+    it("falls back to the generic banner when the rounded percentage is 0%", () => {
+      mockGetCanStakeCurrency.mockReturnValue(true);
+      mockUseInterestRatesByCurrencies.mockReturnValue({
+        bitcoin: { value: 0.00001, type: "APY" },
+      });
+
+      const btcAccount = genAccount("bitcoin-0", {
+        currency: mockBtcCryptoCurrency,
+        operationsSize: 0,
+      });
+
+      const { result } = renderHook(() =>
+        useBalanceDetailsViewModel(
+          mockBtcCryptoCurrency,
+          buildDistributionItem(mockBtcCryptoCurrency, [btcAccount]),
+        ),
+      );
+
+      expect(result.current.earnState.type).toBe("banner");
+      if (result.current.earnState.type === "banner") {
+        expect(result.current.earnState.label).toBe("Earn with this asset");
+        expect(result.current.earnState.label).not.toContain("Earn up to");
+      }
+    });
+
+    it("falls back to the generic banner when no interest rate is available", () => {
+      mockGetCanStakeCurrency.mockReturnValue(true);
+      mockUseInterestRatesByCurrencies.mockReturnValue({});
+
+      const btcAccount = genAccount("bitcoin-0", {
+        currency: mockBtcCryptoCurrency,
+        operationsSize: 0,
+      });
+
+      const { result } = renderHook(() =>
+        useBalanceDetailsViewModel(
+          mockBtcCryptoCurrency,
+          buildDistributionItem(mockBtcCryptoCurrency, [btcAccount]),
+        ),
+      );
+
+      expect(result.current.earnState.type).toBe("banner");
+      if (result.current.earnState.type === "banner") {
+        expect(result.current.earnState.label).toBe("Earn with this asset");
+        expect(result.current.earnState.label).not.toContain("Earn up to");
+      }
     });
 
     it("shows staked state when balance > spendableBalance", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/useBalanceDetailsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/useBalanceDetailsViewModel.ts
@@ -8,6 +8,7 @@ import {
   formatCurrencyUnitFragment,
 } from "@ledgerhq/live-common/currencies/index";
 import { useInterestRatesByCurrencies } from "@ledgerhq/live-common/dada-client/hooks/useInterestRatesByCurrencies";
+import { getInterestRateForAsset } from "@ledgerhq/live-common/modularDrawer/utils/getInterestRateForAsset";
 import { useSelector } from "~/context/hooks";
 import { counterValueCurrencySelector, discreetModeSelector } from "~/reducers/settings";
 import { track } from "~/analytics";
@@ -83,7 +84,13 @@ export function useBalanceDetailsViewModel(
 
   const currencies = useMemo(() => (currency ? [currency] : []), [currency]);
   const interestRates = useInterestRatesByCurrencies(currencies);
-  const interestRate = currency ? interestRates[currency.id] : undefined;
+  const { interestRate, interestRatePercentageRounded } = useMemo(
+    () =>
+      currency
+        ? getInterestRateForAsset(currency, interestRates)
+        : { interestRate: undefined, interestRatePercentageRounded: 0 },
+    [currency, interestRates],
+  );
 
   const earnState: EarnState = useMemo(() => {
     if (!hasAccounts) return { type: "hidden" };
@@ -100,11 +107,14 @@ export function useBalanceDetailsViewModel(
     }
 
     if (isStakeable) {
-      const apyValue = interestRate?.value;
-      const apyType = interestRate?.type ?? "APY";
+      // Fall back to the generic banner when the rounded rate is 0% to avoid
+      // surfacing a meaningless "Earn up to 0% APY" label.
       const label =
-        apyValue && apyValue > 0
-          ? t("assetDetail.balanceDetails.earnBanner", { apy: apyValue.toFixed(1), type: apyType })
+        interestRate && interestRatePercentageRounded > 0
+          ? t("assetDetail.balanceDetails.earnBanner", {
+              apy: interestRatePercentageRounded,
+              type: interestRate.type,
+            })
           : t("assetDetail.balanceDetails.earnBannerGeneric");
       return { type: "banner", label };
     }
@@ -118,6 +128,7 @@ export function useBalanceDetailsViewModel(
     availableBalance,
     earnDeposit,
     interestRate,
+    interestRatePercentageRounded,
     t,
     discreet,
   ]);


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Verify the Earn banner on the Asset Detail page (mobile V4) displays the correct APY for stakeable assets (ETH, SOL, TRX, ATOM, ...).
      - Verify the generic banner is shown when no interest rate is available, or when the rate is too small to display (< 0.05%).
      - Verify other Earn states are unaffected (hidden when not stakeable, staked card when balance > spendable).

### Description

The Earn banner on the Asset Detail page was always displaying `0.0% APY` because the interest rate value returned by `useInterestRatesByCurrencies` is a decimal fraction (e.g. `0.04` for 4%), and the view model rendered it as-is via `value.toFixed(1)`. For a typical rate of 3%, the formatted output was `"0.0"`.

The value is now multiplied by 100 before formatting, matching the canonical helper used elsewhere in the codebase (`roundPercentage` in `libs/ledger-live-common/src/modularDrawer/utils/getInterestRateForAsset.ts`). The parameterized banner is only shown when the rounded display percentage is greater than zero; otherwise the generic banner is used, which avoids the misleading `0.0%` output for vanishing rates.

Before / after example for ETH with a 3% APY:

```
- "Earn up to 0.0% APY"
+ "Earn up to 3.0% APY"
```

<img width="395" height="189" alt="image" src="https://github.com/user-attachments/assets/8acb8f8c-3953-4401-8cbf-ef43763e0819" />

### Context

- **JIRA or GitHub link**: [LIVE-30734](https://ledgerhq.atlassian.net/browse/LIVE-30734)

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30734]: https://ledgerhq.atlassian.net/browse/LIVE-30734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ