### PR TITLE
[LWDM] feat(apps): filter unsupported-currency accounts at load

### DIFF
--- a/.changeset/filter-unsupported-accounts-at-load.md
+++ b/.changeset/filter-unsupported-accounts-at-load.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Filter accounts at load time: accounts whose currency (or derivation mode) is not supported by the current build are dropped before they reach the Redux store. This makes the invariant "if an account is in state, getAccountBridge resolves" hold, preventing crashes in the Send/Receive/Swap/Sync paths when the supported-currencies list shrinks or a coin module is missing.

--- a/apps/ledger-live-desktop/src/renderer/actions/accounts.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/accounts.test.ts
@@ -1,0 +1,64 @@
+import type { Account, AccountUserData } from "@ledgerhq/types-live";
+import { checkAccountSupported } from "@ledgerhq/live-common/account/index";
+import { initAccounts } from "./accounts";
+
+jest.mock("@ledgerhq/live-common/account/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/account/index"),
+  checkAccountSupported: jest.fn(),
+}));
+
+const mockCheckAccountSupported = checkAccountSupported as jest.Mock;
+
+function fakeTuple(id: string, currencyId: string): [Account, AccountUserData] {
+  const account = {
+    id,
+    type: "Account",
+    currency: { id: currencyId },
+    name: `name-${id}`,
+  } as unknown as Account;
+  const userData = { id, name: `custom-${id}` } as unknown as AccountUserData;
+  return [account, userData];
+}
+
+describe("initAccounts", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("drops accounts whose currency is not supported by this build", () => {
+    mockCheckAccountSupported.mockImplementation((a: { currency: { id: string } }) =>
+      a.currency.id === "bitcoin" ? null : new Error("currency not supported"),
+    );
+
+    const action = initAccounts([
+      fakeTuple("btc-1", "bitcoin"),
+      fakeTuple("eth-1", "ethereum"),
+      fakeTuple("btc-2", "bitcoin"),
+    ]);
+
+    expect(action.type).toBe("INIT_ACCOUNTS");
+    expect(action.payload.accounts.map(a => a.id)).toEqual(["btc-1", "btc-2"]);
+    expect(action.payload.accountsUserData.map(u => u.id)).toEqual(["btc-1", "btc-2"]);
+  });
+
+  it("keeps all accounts when every currency is supported", () => {
+    mockCheckAccountSupported.mockReturnValue(null);
+
+    const action = initAccounts([fakeTuple("btc-1", "bitcoin"), fakeTuple("eth-1", "ethereum")]);
+
+    expect(action.payload.accounts.map(a => a.id)).toEqual(["btc-1", "eth-1"]);
+  });
+
+  it("drops accounts on any non-currency error (e.g. unsupported derivation mode)", () => {
+    mockCheckAccountSupported.mockImplementation((a: { id: string }) =>
+      a.id === "btc-segwit" ? null : new Error("derivation mode not supported"),
+    );
+
+    const action = initAccounts([
+      fakeTuple("btc-segwit", "bitcoin"),
+      fakeTuple("btc-legacy", "bitcoin"),
+    ]);
+
+    expect(action.payload.accounts.map(a => a.id)).toEqual(["btc-segwit"]);
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/actions/accounts.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/accounts.ts
@@ -4,7 +4,9 @@ import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { getKey } from "~/renderer/storage";
 import { PasswordIncorrectError } from "@ledgerhq/errors";
 import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
+import { checkAccountSupported } from "@ledgerhq/live-common/account/index";
 import { accountsSelector } from "~/renderer/reducers/accounts";
+import logger from "~/renderer/logger";
 import { ThunkResult } from "./types";
 
 export const removeAccount = (payload: Account) => ({
@@ -13,8 +15,14 @@ export const removeAccount = (payload: Account) => ({
 });
 
 export const initAccounts = (data: [Account, AccountUserData][]) => {
-  const accounts = data.map(([account]) => account);
-  const accountsUserData = data
+  const supported = data.filter(([account]) => {
+    const error = checkAccountSupported(account);
+    if (!error) return true;
+    logger.warn(`dropping account ${account.id}: ${error.message}`);
+    return false;
+  });
+  const accounts = supported.map(([account]) => account);
+  const accountsUserData = supported
     .filter(([account, userData]) => userData.name !== getDefaultAccountName(account))
     .map(([, userData]) => userData);
   return {

--- a/apps/ledger-live-mobile/src/actions/accounts.test.ts
+++ b/apps/ledger-live-mobile/src/actions/accounts.test.ts
@@ -1,0 +1,90 @@
+import type { Account, AccountRaw, AccountUserData } from "@ledgerhq/types-live";
+import { checkAccountSupported } from "@ledgerhq/live-common/account/index";
+import accountModel from "../logic/accountModel";
+import { importStore } from "./accounts";
+
+jest.mock("@ledgerhq/live-common/account/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/account/index"),
+  checkAccountSupported: jest.fn(),
+}));
+
+jest.mock("../logic/accountModel", () => ({
+  __esModule: true,
+  default: { decode: jest.fn() },
+}));
+
+const mockCheckAccountSupported = checkAccountSupported as jest.Mock;
+const mockDecode = accountModel.decode as jest.Mock;
+
+function fakeTuple(id: string, currencyId: string): [Account, AccountUserData] {
+  const account = {
+    id,
+    type: "Account",
+    currency: { id: currencyId },
+    name: `name-${id}`,
+  } as unknown as Account;
+  const userData = { id, name: `custom-${id}` } as unknown as AccountUserData;
+  return [account, userData];
+}
+
+describe("importStore", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("drops accounts whose currency is not supported by this build", async () => {
+    mockCheckAccountSupported.mockImplementation((a: { currency: { id: string } }) =>
+      a.currency.id === "bitcoin" ? null : new Error("currency not supported"),
+    );
+    mockDecode
+      .mockResolvedValueOnce(fakeTuple("btc-1", "bitcoin"))
+      .mockResolvedValueOnce(fakeTuple("eth-1", "ethereum"))
+      .mockResolvedValueOnce(fakeTuple("btc-2", "bitcoin"));
+
+    const action = await importStore({
+      active: [
+        { data: { id: "btc-1" } as AccountRaw },
+        { data: { id: "eth-1" } as AccountRaw },
+        { data: { id: "btc-2" } as AccountRaw },
+      ],
+    });
+
+    expect(action.type).toBe("INIT_ACCOUNTS");
+    expect(action.payload.accounts.map((a: Account) => a.id)).toEqual(["btc-1", "btc-2"]);
+    expect(action.payload.accountsUserData.map((u: AccountUserData) => u.id)).toEqual([
+      "btc-1",
+      "btc-2",
+    ]);
+  });
+
+  it("keeps all accounts when every currency is supported", async () => {
+    mockCheckAccountSupported.mockReturnValue(null);
+    mockDecode
+      .mockResolvedValueOnce(fakeTuple("btc-1", "bitcoin"))
+      .mockResolvedValueOnce(fakeTuple("eth-1", "ethereum"));
+
+    const action = await importStore({
+      active: [{ data: { id: "btc-1" } as AccountRaw }, { data: { id: "eth-1" } as AccountRaw }],
+    });
+
+    expect(action.payload.accounts.map((a: Account) => a.id)).toEqual(["btc-1", "eth-1"]);
+  });
+
+  it("drops accounts on any non-currency error (e.g. unsupported derivation mode)", async () => {
+    mockCheckAccountSupported.mockImplementation((a: { id: string }) =>
+      a.id === "btc-segwit" ? null : new Error("derivation mode not supported"),
+    );
+    mockDecode
+      .mockResolvedValueOnce(fakeTuple("btc-segwit", "bitcoin"))
+      .mockResolvedValueOnce(fakeTuple("btc-legacy", "bitcoin"));
+
+    const action = await importStore({
+      active: [
+        { data: { id: "btc-segwit" } as AccountRaw },
+        { data: { id: "btc-legacy" } as AccountRaw },
+      ],
+    });
+
+    expect(action.payload.accounts.map((a: Account) => a.id)).toEqual(["btc-segwit"]);
+  });
+});

--- a/apps/ledger-live-mobile/src/actions/accounts.ts
+++ b/apps/ledger-live-mobile/src/actions/accounts.ts
@@ -11,6 +11,7 @@ import { AccountsActionTypes } from "./types";
 import logger from "../logger";
 import { initAccounts } from "@ledgerhq/live-wallet/store";
 import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
+import { checkAccountSupported } from "@ledgerhq/live-common/account/index";
 
 const version = 0; // FIXME this needs to come from user data
 
@@ -35,8 +36,15 @@ export const importStore = async (rawAccounts: { active: { data: AccountRaw }[] 
     (tuple): tuple is [Account, AccountUserData] => tuple !== null,
   );
 
-  const accounts = tuples.map(([account]) => account);
-  const accountsUserData = tuples
+  const supported = tuples.filter(([account]) => {
+    const error = checkAccountSupported(account);
+    if (!error) return true;
+    console.warn(`dropping account ${account.id}: ${error.message}`);
+    return false;
+  });
+
+  const accounts = supported.map(([account]) => account);
+  const accountsUserData = supported
     .filter(([account, userData]) => userData.name !== getDefaultAccountName(account))
     .map(([, userData]) => userData);
   return initAccounts(accounts, accountsUserData);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Persisted accounts of unsupported currencies are now dropped at load (desktop + mobile) before reaching the Redux store. On the next save tick the on-disk blob is rewritten without them — wallet-sync still holds the account descriptor (currency, derivation, address), so when support comes back the bridge can rediscover the account; operation history is not recovered (accepted tradeoff).
  - QA focus: cold-boot account list integrity, send/receive/swap flows on currencies that may transit through unsupported states (feature-flag-gated, killswitched, or being removed), and wallet-sync round-trips.

### 📝 Description

`getAccountBridge` throws `CurrencyNotSupported` whenever an account's currency is missing from `listSupportedCurrencies()`. Today, persisted accounts are loaded into Redux without any support check, so any feature that resolves the bridge (Send/Receive/Swap/Sync, `useAccountBridge`) can crash on accounts the current build no longer supports. As the codebase moves toward `useAccountBridge` as the single resolution path, this becomes more brittle, especially with feature-flag-gated currencies and the dynamic registry direction.

This PR filters at load using `checkAccountSupported` (the exact same check `getAccountBridge` performs at `libs/ledger-live-common/src/bridge/impl.ts:93`), establishing the invariant: **if an account is in Redux state, the bridge resolves**. Filtering is destructive: the next save persists the filtered list. Wallet-sync keeps a compressed descriptor (currency, derivation, address) so a future build that re-adds support can rediscover the account via bridge sync — ops history is not recoverable.

Two short call sites:

```ts
// apps/ledger-live-desktop/src/renderer/actions/accounts.ts (initAccounts)
const supported = data.filter(([account]) => {
  const error = checkAccountSupported(account);
  if (!error) return true;
  logger.warn(`dropping account ${account.id}: ${error.message}`);
  return false;
});
```

```ts
// apps/ledger-live-mobile/src/actions/accounts.ts (importStore)
const supported = tuples.filter(([account]) => {
  const error = checkAccountSupported(account);
  if (!error) return true;
  console.warn(`dropping account ${account.id}: ${error.message}`);
  return false;
});
```

### ❓ Context

- **JIRA or GitHub link**: _none_
- **ADR link (if any)**: https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/7141392397/Account+Support+Architecture+Layers+Lifecycle+and+Future+Portfolio+API