### PR TITLE
[LWDM] fix(live-dmk-shared): handle node 22 interop for hw-transport default…

### DIFF
--- a/.changeset/unlucky-gifts-drum.md
+++ b/.changeset/unlucky-gifts-drum.md
@@ -1,0 +1,10 @@
+---
+"@ledgerhq/live-dmk-shared": minor
+---
+
+fix(live-dmk-shared): handle Node.js 22 ESM/CJS interop for hw-transport default import
+
+When loaded via require() in Node.js 22, @ledgerhq/hw-transport resolves to its
+CJS build where the class is exposed as `module.exports.default`. Unwrap the
+default export with a fallback so DmkCompatTransport can correctly extend Transport
+in both ESM and CJS environments.

--- a/libs/live-dmk-shared/src/transport/DmkCompatTransport.ts
+++ b/libs/live-dmk-shared/src/transport/DmkCompatTransport.ts
@@ -1,5 +1,12 @@
 import type { DeviceManagementKit } from "@ledgerhq/device-management-kit";
-import Transport from "@ledgerhq/hw-transport";
+import _Transport from "@ledgerhq/hw-transport";
+
+// Node.js 22 ESM/CJS interop: when this ESM module is loaded via require()
+// (importSyncForRequire), hw-transport resolves to its CJS build where
+// module.exports = { default: Transport, … }.  The ESM default import then
+// receives the whole exports object rather than the class.  Unwrap it here.
+const Transport = ((_Transport as { default?: typeof _Transport }).default ??
+  _Transport) as typeof _Transport;
 
 /**
  * Minimal hw-transport adapter over an existing DMK session.


### PR DESCRIPTION
… import

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

When loaded via require() in Node.js 22, @ledgerhq/hw-transport resolves to its
CJS build where the class is exposed as `module.exports.default`. Unwrap the
default export with a fallback so DmkCompatTransport can correctly extend Transport
in both ESM and CJS environments.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
