### PR TITLE
chore(wallet-cli): show session label in account discover output

### DIFF
--- a/.changeset/wallet-cli-discover-label-output.md
+++ b/.changeset/wallet-cli-discover-label-output.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-cli": minor
+---
+
+wallet-cli: `account discover` no longer exposes the raw V1 descriptor. Human output shows the session label in bold as the primary identifier; JSON output replaces the descriptor strings with `{ label, freshAddress }` objects.

--- a/apps/wallet-cli/src/commands/account/discover.ts
+++ b/apps/wallet-cli/src/commands/account/discover.ts
@@ -10,7 +10,6 @@ import {
 import { walletCliDebug } from "../../shared/log";
 import { colors } from "../../shared/ui";
 import { parseNetworkArg, currencyIdFromNetwork } from "../../shared/accountDescriptor";
-import type { AccountDescriptorV1 } from "../../shared/accountDescriptor";
 import { createCommandOutput } from "../../output";
 import { Session } from "../../session/session-store";
 import { runObservable } from "../run-observable";
@@ -20,6 +19,7 @@ type DiscoverAccountsParams = {
   wallet: WalletAdapter;
   network: ReturnType<typeof parseNetworkArg>;
   managerAppName: string;
+  session: Session;
   out: ReturnType<typeof createCommandOutput>;
 };
 
@@ -27,17 +27,19 @@ async function discoverAccounts({
   wallet,
   network,
   managerAppName,
+  session,
   out,
-}: DiscoverAccountsParams): Promise<AccountDescriptorV1[]> {
+}: DiscoverAccountsParams): Promise<number> {
   const scanSpin = out.spin(`Scanning for ${colors.bold(network.name)} accounts…`);
   let count = 0;
-  const discoveredDescriptors: AccountDescriptorV1[] = [];
+  let added = 0;
 
   await runObservable({
     source$: wallet.discoverAccounts(network, WALLET_CLI_DMK_DEVICE_ID),
-    onNext: discoveredAccount => {
-      out.discoveredAccount(discoveredAccount);
-      discoveredDescriptors.push(discoveredAccount.descriptor);
+    onNext: raw => {
+      const { label, added: wasAdded } = session.addDescriptor(raw.descriptor);
+      if (wasAdded) added++;
+      out.discoveredAccount({ ...raw, label });
       count++;
       if (scanSpin) scanSpin.text = `Scanning… (${count} found so far)`;
     },
@@ -49,7 +51,7 @@ async function discoverAccounts({
 
   scanSpin?.success(`Found ${count} account${count === 1 ? "" : "s"}`);
   out.flushDiscovery();
-  return discoveredDescriptors;
+  return added;
 }
 
 export default defineCommand({
@@ -91,23 +93,26 @@ export default defineCommand({
         currencyId,
         async () => {
           const wallet = new WalletAdapter();
-          const discoveredDescriptors = await discoverAccounts({
+          // Surface read failures (e.g. corrupted session.yaml) before discovery so we never
+          // overwrite a recoverable file with a fresh one. Session.read() returns an empty
+          // session on ENOENT, so this only throws on parse/IO errors that need user action.
+          const session = await Session.read();
+          const added = await discoverAccounts({
             wallet,
             network,
             managerAppName,
+            session,
             out,
           });
 
-          let added = 0;
-          try {
-            const session = await Session.read();
-            added = session.addDescriptors(discoveredDescriptors);
-            if (added > 0) session.write();
-          } catch {
-            // Session persistence failure is non-fatal; discovery output is already flushed.
+          if (added > 0) {
+            try {
+              session.write();
+              out.sessionSaved(added);
+            } catch {
+              // Session persistence failure is non-fatal; discovery output is already flushed.
+            }
           }
-
-          if (added > 0) out.sessionSaved(added);
         },
         {
           deviceTimeoutMs: flags["device-timeout"],

--- a/apps/wallet-cli/src/session/session-store.ts
+++ b/apps/wallet-cli/src/session/session-store.ts
@@ -111,19 +111,25 @@ export class Session {
     return count;
   }
 
+  /**
+   * Add (or look up) a single descriptor. Returns the assigned label and whether a new entry
+   * was appended. Used to attach labels at discovery time before the session is persisted.
+   */
+  addDescriptor(descriptor: AccountDescriptorV1): { label: string; added: boolean } {
+    const serialized = serializeV1(descriptor);
+    const existing = this.entries.find(e => e.descriptor === serialized);
+    if (existing) return { label: existing.label, added: false };
+    const knownLabels = new Set(this.entries.map(e => e.label));
+    const label = generateLabel(descriptor, knownLabels);
+    this.entries.push({ label, descriptor: serialized });
+    return { label, added: true };
+  }
+
   /** Merge new descriptors in-place. Returns count of newly added entries. */
   addDescriptors(descriptors: AccountDescriptorV1[]): number {
-    const knownDescriptors = new Set(this.entries.map(e => e.descriptor));
-    const knownLabels = new Set(this.entries.map(e => e.label));
     let added = 0;
     for (const d of descriptors) {
-      const serialized = serializeV1(d);
-      if (knownDescriptors.has(serialized)) continue;
-      const label = generateLabel(d, knownLabels);
-      knownLabels.add(label);
-      knownDescriptors.add(serialized);
-      this.entries.push({ label, descriptor: serialized });
-      added++;
+      if (this.addDescriptor(d).added) added++;
     }
     return added;
   }

--- a/apps/wallet-cli/src/test/commands/account/discover.test.ts
+++ b/apps/wallet-cli/src/test/commands/account/discover.test.ts
@@ -32,6 +32,13 @@ describe("account discover command (mock DMK)", () => {
     expect(data.command).toBe("account discover");
     expect(data.network).toBe("ethereum:main");
     expect(Array.isArray(data.accounts)).toBe(true);
+    expect(data.accounts.length).toBeGreaterThan(0);
+    for (const account of data.accounts) {
+      expect(typeof account.label).toBe("string");
+      expect(account.label.length).toBeGreaterThan(0);
+      expect(typeof account.freshAddress).toBe("string");
+      expect("descriptor" in account).toBe(false);
+    }
   });
 });
 

--- a/apps/wallet-cli/src/wallet/formatter/human.test.ts
+++ b/apps/wallet-cli/src/wallet/formatter/human.test.ts
@@ -19,6 +19,7 @@ const btcDiscovered: DiscoveredAccount = {
     path: "m/84h/0h/0h",
   },
   freshAddress: "bc1qexample",
+  label: "bitcoin-native-1",
 };
 
 const ethDiscovered: DiscoveredAccount = {
@@ -31,6 +32,7 @@ const ethDiscovered: DiscoveredAccount = {
     path: "m/44h/60h/0h/0/0",
   },
   freshAddress: ETH_ADDR,
+  label: "ethereum-1",
 };
 
 const btcDescriptor: AccountDescriptor = {
@@ -101,26 +103,22 @@ describe("HumanFormatter.formatError", () => {
 describe("HumanFormatter.formatDiscoveredAccount", () => {
   const formatter = new HumanFormatter(stubStore);
 
-  it("contains the network name", () => {
-    expect(formatter.formatDiscoveredAccount(btcDiscovered)).toContain("bitcoin");
+  it("contains the session label", () => {
+    expect(formatter.formatDiscoveredAccount(btcDiscovered)).toContain("bitcoin-native-1");
   });
 
   it("contains the fresh address", () => {
     expect(formatter.formatDiscoveredAccount(btcDiscovered)).toContain("bc1qexample");
   });
 
-  it("contains the serialized V1 descriptor", () => {
+  it("does not leak the serialized V1 descriptor", () => {
     const out = formatter.formatDiscoveredAccount(btcDiscovered);
-    expect(out).toContain(`account:1:utxo:bitcoin:main:${XPUB}:m/84h/0h/0h`);
-  });
-
-  it("extracts account index from path (index 0)", () => {
-    expect(formatter.formatDiscoveredAccount(btcDiscovered)).toContain("#0");
+    expect(out).not.toContain(`account:1:utxo:bitcoin:main:${XPUB}:m/84h/0h/0h`);
   });
 
   it("works for address-type (ethereum)", () => {
     const out = formatter.formatDiscoveredAccount(ethDiscovered);
-    expect(out).toContain("ethereum");
+    expect(out).toContain("ethereum-1");
     expect(out).toContain(ETH_ADDR);
   });
 });
@@ -142,11 +140,11 @@ describe("HumanFormatter.formatAccountDescriptor", () => {
 });
 
 describe("JsonFormatter.discoveredAccounts", () => {
-  it("returns serialized V1 strings", () => {
+  it("returns label + freshAddress objects (no descriptor)", () => {
     const result = JsonFormatter.discoveredAccounts([btcDiscovered, ethDiscovered]);
     expect(result).toEqual([
-      `account:1:utxo:bitcoin:main:${XPUB}:m/84h/0h/0h`,
-      `account:1:address:ethereum:main:${ETH_ADDR}:m/44h/60h/0h/0/0`,
+      { label: "bitcoin-native-1", freshAddress: "bc1qexample" },
+      { label: "ethereum-1", freshAddress: ETH_ADDR },
     ]);
   });
 

--- a/apps/wallet-cli/src/wallet/formatter/human.ts
+++ b/apps/wallet-cli/src/wallet/formatter/human.ts
@@ -3,7 +3,6 @@ import { findCryptoCurrencyById, formatCurrencyUnit } from "@ledgerhq/live-commo
 import type { Unit } from "@ledgerhq/types-cryptoassets";
 import type { CryptoAssetsStore, OperationType } from "@ledgerhq/types-live";
 import { colors } from "../../shared/ui";
-import { serializeV1 } from "../../shared/accountDescriptor";
 import type {
   AccountDescriptor,
   Balance,
@@ -50,14 +49,7 @@ export class HumanFormatter {
   }
 
   formatDiscoveredAccount(d: DiscoveredAccount): string {
-    const { descriptor, freshAddress } = d;
-    const v1str = serializeV1(descriptor);
-    const networkStr = `${descriptor.network.name}:${descriptor.network.env}`;
-    const rawIndex = descriptor.path.split("/")[3]?.replaceAll(/[h']/g, "") ?? "?";
-    const typeLabel = colors.dim(`(${descriptor.type})`);
-    const accountNum = `#${rawIndex}`;
-    const label = `${colors.bold(colors.cyan(networkStr))} account ${colors.bold(accountNum)} ${typeLabel}  ${freshAddress}`;
-    return `${label}\n  ${colors.dim(v1str)}`;
+    return `${colors.bold(d.label)}  ${d.freshAddress}`;
   }
 
   async formatBalance(b: Balance): Promise<string> {

--- a/apps/wallet-cli/src/wallet/formatter/json.ts
+++ b/apps/wallet-cli/src/wallet/formatter/json.ts
@@ -1,8 +1,9 @@
-import { serializeV1 } from "../../shared/accountDescriptor";
 import type { Balance, Operation, DiscoveredAccount, TokenInfo } from "../models";
 import type { HumanFormatter } from "./human";
 
 export type JsonBalance = { asset: string; amount: string };
+
+export type JsonDiscoveredAccount = { label: string; freshAddress: string };
 
 export type JsonOperation = {
   accountId: string;
@@ -52,8 +53,8 @@ export class JsonFormatter {
     );
   }
 
-  static discoveredAccounts(accounts: DiscoveredAccount[]): string[] {
-    return accounts.map(a => serializeV1(a.descriptor));
+  static discoveredAccounts(accounts: DiscoveredAccount[]): JsonDiscoveredAccount[] {
+    return accounts.map(a => ({ label: a.label, freshAddress: a.freshAddress }));
   }
 
   token(t: TokenInfo): TokenInfo {

--- a/apps/wallet-cli/src/wallet/index.ts
+++ b/apps/wallet-cli/src/wallet/index.ts
@@ -6,7 +6,7 @@ import { Observable, from } from "rxjs";
 import { map, switchMap } from "rxjs/operators";
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import type { DeviceModelId } from "@ledgerhq/types-devices";
-import type { AccountDescriptor, Balance, SendEvent, DiscoveredAccount } from "./models";
+import type { AccountDescriptor, Balance, SendEvent, DiscoveredAccountRaw } from "./models";
 // BridgeAdapter and CoinFrameworkAdapter are loaded lazily via dynamic import() inside getters
 // to avoid pulling in live-common/bridge/index (~328ms) and coinframework/local/evm (~105ms)
 // at module load time for every subprocess regardless of which command is invoked.
@@ -43,7 +43,7 @@ export class WalletAdapter {
    * Returns V1 descriptors plus the fresh receive address for each account.
    * deviceId is the live-common device id (or "" for the first detected device).
    */
-  discoverAccounts(network: Network, deviceId: string): Observable<DiscoveredAccount> {
+  discoverAccounts(network: Network, deviceId: string): Observable<DiscoveredAccountRaw> {
     const currencyId = currencyIdFromNetwork(network);
     return from(this.getBridge()).pipe(
       switchMap(bridge =>

--- a/apps/wallet-cli/src/wallet/models.ts
+++ b/apps/wallet-cli/src/wallet/models.ts
@@ -23,12 +23,17 @@ export const accountDescriptorSchema = z.object({
 export type AccountDescriptor = z.infer<typeof accountDescriptorSchema>;
 
 /**
- * Bundled result of account discovery: the V1 descriptor and the fresh receive address.
- * V1 does not store freshAddress (it is dynamic); it is carried separately here.
+ * Raw discovery result from the bridge: V1 descriptor and fresh receive address.
+ * The session label is assigned downstream (see DiscoveredAccount).
  */
-export type DiscoveredAccount = {
+export type DiscoveredAccountRaw = {
   descriptor: AccountDescriptorV1;
   freshAddress: string;
+};
+
+/** Labeled discovered account — what commands surface to the user. */
+export type DiscoveredAccount = DiscoveredAccountRaw & {
+  label: string;
 };
 
 // Short form: "{id}:{index}" — e.g. "js:2:bitcoin:xpub...:native_segwit:0"


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [ ] **Impact of the changes:**
  - `account discover` output shape changes in both human and JSON formats. Any agent / script consuming the JSON `accounts` array must be updated (see snippet below).

### 📝 Description

`account discover` no longer exposes the raw V1 descriptor. The descriptor isn't a valid CLI argument anymore (labels are), so surfacing it was misleading.

- **Human output**: each discovered account is rendered as `bold(label)  freshAddress`. The dim descriptor line under the network header is gone; the label is the primary info.
- **JSON output**: the `accounts` array changes from descriptor strings to `{ label, freshAddress }` objects.
- Labels are now assigned at discovery time via the new `Session.addDescriptor()` so the value displayed is the one persisted to the session in the same run.

Consumer-side diff for JSON readers:

```diff
- accounts: ["account:1:address:ethereum:main:0x...:m/44h/60h/0h/0/0"]
+ accounts: [{ label: "ethereum-1", freshAddress: "0x..." }]
```

| Before | After |
| --- | --- |
| `bitcoin:main account #0 (utxo)  bc1q...` <br>`  account:1:utxo:bitcoin:main:<xpub>:m/84h/0h/0h` (dim) | `bitcoin-native-1  bc1q...` (label bold) |

### ❓ Context

- **JIRA or GitHub link**: n/a — follow-up to the descriptor → label rework
- **ADR link (if any)**: n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)