### PR TITLE
[LWDM] fix(live-dmk-shared): clear sticky user interaction in EnsureAppReady

### DIFF
--- a/.changeset/ensure-app-ready-sticky-interaction.md
+++ b/.changeset/ensure-app-ready-sticky-interaction.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-dmk-shared": patch
+---
+
+Fix sticky user interaction state in EnsureAppReady pending mapping: when ConnectApp reports `UserInteractionRequired.None` without an install plan, emit a generic loading state instead of returning null so the UI no longer remains stuck on the previous interaction prompt.

--- a/libs/live-dmk-shared/src/device-action/EnsureAppReady/EnsureAppReadyDeviceAction.test.ts
+++ b/libs/live-dmk-shared/src/device-action/EnsureAppReady/EnsureAppReadyDeviceAction.test.ts
@@ -17,7 +17,12 @@ import type {
   ConnectAppDAState,
 } from "../ConnectApp/types";
 import { Subject } from "rxjs";
-import { AppInteractionRequiredStateType, FinalStateType, type EnsureAppReadyState } from "./state";
+import {
+  AppInteractionRequiredStateType,
+  FinalStateType,
+  LoadingStateType,
+  type EnsureAppReadyState,
+} from "./state";
 import type { ConnectAppDASnapshotHandler, DeprecationPresentationInput } from "./types";
 import {
   EnsureAppReadyDeviceAction,
@@ -64,6 +69,10 @@ const deviceMetadata = {
 const currentApp: GetAppAndVersionResponse = {
   name: "Ethereum",
   version: "2.0.0",
+};
+
+const loadingState: EnsureAppReadyState = {
+  type: LoadingStateType.Loading,
 };
 
 const successState: EnsureAppReadyState = {
@@ -343,7 +352,7 @@ describe("EnsureAppReadyDeviceAction", () => {
       expect(harness.snapshotHandler.handleSnapshot).toHaveBeenCalledWith(
         expect.objectContaining({ status: DeviceActionStatus.Completed }),
       );
-      expect(harness.emittedStates).toEqual([successState]);
+      expect(harness.emittedStates).toEqual([loadingState, successState]);
       expect(harness.actionStates[harness.actionStates.length - 1]).toEqual({
         status: DeviceActionStatus.Completed,
         output: undefined,

--- a/libs/live-dmk-shared/src/device-action/EnsureAppReady/stateMapping.test.ts
+++ b/libs/live-dmk-shared/src/device-action/EnsureAppReady/stateMapping.test.ts
@@ -197,7 +197,7 @@ describe("mapConnectAppDAPendingStatus", () => {
   });
 
   describe("GIVEN no user interaction is required", () => {
-    it("WHEN there is no install plan THEN it returns null", () => {
+    it("WHEN there is no install plan THEN it emits the loading state", () => {
       // GIVEN
       const state = makePending(UserInteractionRequired.None);
 
@@ -208,7 +208,7 @@ describe("mapConnectAppDAPendingStatus", () => {
       });
 
       // THEN
-      expect(result).toBeNull();
+      expect(result).toEqual({ type: LoadingStateType.Loading });
     });
 
     it("WHEN there is an install plan THEN it emits the installing app state", () => {

--- a/libs/live-dmk-shared/src/device-action/EnsureAppReady/stateMapping.ts
+++ b/libs/live-dmk-shared/src/device-action/EnsureAppReady/stateMapping.ts
@@ -74,8 +74,8 @@ export function mapConnectAppDAPendingStatus(params: {
       };
 
     case UserInteractionRequired.None:
-      if (!intermediateValue.installPlan) return null;
-      return { type: LoadingStateType.InstallingApp };
+      if (intermediateValue.installPlan) return { type: LoadingStateType.InstallingApp };
+      return { type: LoadingStateType.Loading };
 
     case UserInteractionRequiredLL.DeviceDeprecation:
       return mapDeprecationState({


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - only `DeviceIntentExecutor`, nothing user facing for now

### 📝 Description

**Problem**: In `mapConnectAppDAPendingStatus`, when the ConnectApp device action emitted `UserInteractionRequired.None` _without_ an install plan, the mapper returned `null`. Because `EnsureAppReadyStateEmitter` skips `null` results, the previously emitted interaction state remained "sticky" in the UI — for example, after the user unlocked their device, the screen would stay on the "Unlock device" prompt instead of resetting to a neutral loading state until the next intermediate value arrived.

**Solution**: Emit a generic `LoadingStateType.Loading` state for `UserInteractionRequired.None` without an install plan so the UI can correctly reflect that no interaction is currently required. The pre-existing `InstallingApp` branch (when an install plan is present) is unchanged.

### ❓ Context

- **JIRA or GitHub link**: _N/A_
- **ADR link (if any)**: _N/A_

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)