### PR TITLE
[LWDM] fix(asset-detail): use coingecko market id for asset detail favorites

### DIFF
--- a/.changeset/sweet-monkeys-sort.md
+++ b/.changeset/sweet-monkeys-sort.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/asset-detail": minor
+---
+
+Fix asset detail favorites to use Coingecko market ids so starring tokens matches the Market list

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/AssetDetailView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/AssetDetailView.tsx
@@ -15,40 +15,38 @@ type AssetDetailViewProps = Readonly<{
 }>;
 
 export function AssetDetailView({ viewModel }: AssetDetailViewProps) {
-  const { distributionItem, marketInfo, market, assetName, assetTicker, ledgerId, ledgerCurrency } =
+  const { distributionItem, marketData, displayName, displayTicker, ledgerId, ledgerCurrency } =
     viewModel;
 
   return (
     <div className="flex w-full shrink-0 flex-col gap-24 pb-32">
       <AssetHeader
-        assetLabel={assetName}
+        assetLabel={displayName}
         icon={
           ledgerId && (
             <CryptoIcon
               ledgerId={ledgerId}
-              ticker={assetTicker}
+              ticker={displayTicker}
               size={getValidCryptoIconSize(24)}
             />
           )
         }
         distributionItem={distributionItem}
-        market={market}
-        marketInfo={marketInfo}
+        marketData={marketData}
         ledgerCurrency={ledgerCurrency}
       />
 
       <MarketPriceSection
         distributionItem={distributionItem}
-        marketInfo={marketInfo}
         ledgerId={ledgerId}
-        market={market}
+        marketData={marketData}
       />
 
       <ActionBar
         distributionItem={distributionItem}
         ledgerCurrency={ledgerCurrency}
-        marketCurrencyData={market.marketCurrencyData}
-        tickerHint={assetTicker}
+        marketCurrencyData={marketData.marketCurrencyData}
+        tickerHint={displayTicker}
       />
 
       <div className="flex flex-col gap-32">
@@ -56,7 +54,7 @@ export function AssetDetailView({ viewModel }: AssetDetailViewProps) {
 
         {distributionItem && <PnLSection distributionItem={distributionItem} />}
 
-        {marketInfo && <MarketDataSection market={market} />}
+        {marketData.marketCurrencyData && <MarketDataSection marketData={marketData} />}
 
         {distributionItem && <TransactionsSection distributionItem={distributionItem} />}
       </div>

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/__integrations__/AssetDetail.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/__integrations__/AssetDetail.integration.test.tsx
@@ -257,6 +257,38 @@ describe("AssetDetail integration", () => {
       expect(screen.getByRole("menuitem", { name: /hide from portfolio/i })).toBeVisible();
     });
 
+    it("USDC - enables the favorite action and stores the coingecko id when toggled", async () => {
+      mockMarket.withData(MarketMockedResponse.usdcDetail);
+      const account = genAccount("asset-detail-usdc-star-account", { currency: btc });
+      const item = buildDistributionItem({
+        currency: makeIntegrationTokenCurrency("ethereum/erc20/usd__coin", "USDC", "USD Coin"),
+        accounts: [account],
+        slug: "usd-coin",
+      });
+      setupRoute("ethereum/erc20/usd__coin", { bySlug: {}, list: [item] });
+
+      const { user, store } = renderWithMockedCounterValuesProvider(<AssetDetail />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId(TEST_ID.HEADER_OPTIONS)).toBeVisible();
+      });
+
+      await user.click(screen.getByTestId(TEST_ID.HEADER_OPTIONS));
+
+      const favoriteItem = await screen.findByRole("menuitem", { name: /add to favorites/i });
+      expect(favoriteItem).toBeVisible();
+      expect(favoriteItem).not.toHaveAttribute("aria-disabled", "true");
+
+      await user.click(favoriteItem);
+
+      await waitFor(() => {
+        expect(store.getState().settings.starredMarketCoins).toContain("usd-coin");
+      });
+      expect(store.getState().settings.starredMarketCoins).not.toContain(
+        "ethereum/erc20/usd__coin",
+      );
+    });
+
     it("shows Show in portfolio when the asset is blacklisted", async () => {
       mockMarket.withData(MarketMockedResponse.usdcDetail);
       setupRoute("ethereum/erc20/usd__coin", OWNED_ASSETS[1].buildDistribution());

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ActionBar/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ActionBar/index.tsx
@@ -6,9 +6,9 @@ import { ActionBarView } from "./ActionBar";
 import { useActionBarViewModel } from "./useActionBarViewModel";
 
 type ActionBarProps = Readonly<{
-  distributionItem: DistributionItem | undefined;
-  ledgerCurrency: CryptoOrTokenCurrency | undefined;
-  marketCurrencyData: MarketCurrencyData | undefined;
+  distributionItem?: DistributionItem;
+  ledgerCurrency?: CryptoOrTokenCurrency;
+  marketCurrencyData?: MarketCurrencyData;
   tickerHint: string;
 }>;
 

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ActionBar/useActionBarViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ActionBar/useActionBarViewModel.ts
@@ -27,9 +27,9 @@ import { useBuyNavigation } from "LLD/features/Market/hooks/useBuyNavigation";
 import { useSellNavigation } from "LLD/features/Market/hooks/useSellNavigation";
 
 type UseActionBarViewModelProps = Readonly<{
-  distributionItem: DistributionItem | undefined;
-  ledgerCurrency: CryptoOrTokenCurrency | undefined;
-  marketCurrencyData: MarketCurrencyData | undefined;
+  distributionItem?: DistributionItem;
+  ledgerCurrency?: CryptoOrTokenCurrency;
+  marketCurrencyData?: MarketCurrencyData;
   tickerHint: string;
 }>;
 

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AssetHeader/AssetHeaderView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AssetHeader/AssetHeaderView.tsx
@@ -5,7 +5,7 @@ import {
   NavBarCoinCapsule,
   NavBarTrailing,
 } from "@ledgerhq/lumen-ui-react";
-import type { AssetDetailMarketInfo, AssetMarketData } from "@ledgerhq/asset-detail";
+import type { AssetMarketData } from "@ledgerhq/asset-detail";
 import type { DistributionItem } from "@ledgerhq/types-live";
 import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { OptionsMenu } from "../OptionsMenu";
@@ -15,10 +15,9 @@ export type AssetHeaderViewProps = Readonly<{
   assetLabel: string;
   icon: React.ReactNode;
   viewModel: AssetHeaderViewModel;
-  distributionItem: DistributionItem | undefined;
-  market: AssetMarketData;
-  marketInfo: AssetDetailMarketInfo | undefined;
-  ledgerCurrency: CryptoOrTokenCurrency | undefined;
+  distributionItem?: DistributionItem;
+  marketData: AssetMarketData;
+  ledgerCurrency?: CryptoOrTokenCurrency;
 }>;
 
 export function AssetHeaderView({
@@ -26,8 +25,7 @@ export function AssetHeaderView({
   icon,
   viewModel,
   distributionItem,
-  market,
-  marketInfo,
+  marketData,
   ledgerCurrency,
 }: AssetHeaderViewProps) {
   const { onBack } = viewModel;
@@ -43,8 +41,7 @@ export function AssetHeaderView({
         {ledgerCurrency ? (
           <OptionsMenu
             distributionItem={distributionItem}
-            market={market}
-            marketInfo={marketInfo}
+            marketData={marketData}
             currency={ledgerCurrency}
           />
         ) : null}

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AssetHeader/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AssetHeader/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import type { AssetDetailMarketInfo, AssetMarketData } from "@ledgerhq/asset-detail";
+import type { AssetMarketData } from "@ledgerhq/asset-detail";
 import type { DistributionItem } from "@ledgerhq/types-live";
 import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { AssetHeaderView } from "./AssetHeaderView";
@@ -8,18 +8,16 @@ import { useAssetHeaderViewModel } from "./useAssetHeaderViewModel";
 export type AssetHeaderProps = Readonly<{
   assetLabel: string;
   icon: React.ReactNode;
-  distributionItem: DistributionItem | undefined;
-  market: AssetMarketData;
-  marketInfo: AssetDetailMarketInfo | undefined;
-  ledgerCurrency: CryptoOrTokenCurrency | undefined;
+  distributionItem?: DistributionItem;
+  marketData: AssetMarketData;
+  ledgerCurrency?: CryptoOrTokenCurrency;
 }>;
 
 export function AssetHeader({
   assetLabel,
   icon,
   distributionItem,
-  market,
-  marketInfo,
+  marketData,
   ledgerCurrency,
 }: AssetHeaderProps) {
   const viewModel = useAssetHeaderViewModel();
@@ -30,8 +28,7 @@ export function AssetHeader({
       icon={icon}
       viewModel={viewModel}
       distributionItem={distributionItem}
-      market={market}
-      marketInfo={marketInfo}
+      marketData={marketData}
       ledgerCurrency={ledgerCurrency}
     />
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/__tests__/useMarketDataSectionCurrencyData.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/__tests__/useMarketDataSectionCurrencyData.test.ts
@@ -11,7 +11,12 @@ describe("useMarketDataSectionCurrencyData", () => {
   it("forwards the resolved market data and adds counter value + locale", () => {
     const marketCurrencyData = createMockMarketCurrencyData();
     const { result } = renderHook(
-      () => useMarketDataSectionCurrencyData({ marketCurrencyData, isLoading: false }),
+      () =>
+        useMarketDataSectionCurrencyData({
+          marketCurrencyData,
+          marketId: undefined,
+          isLoading: false,
+        }),
       hookOptions(),
     );
 
@@ -23,7 +28,12 @@ describe("useMarketDataSectionCurrencyData", () => {
 
   it("shows the skeleton while the upstream hook is still loading without data", () => {
     const { result } = renderHook(
-      () => useMarketDataSectionCurrencyData({ marketCurrencyData: undefined, isLoading: true }),
+      () =>
+        useMarketDataSectionCurrencyData({
+          marketCurrencyData: undefined,
+          marketId: undefined,
+          isLoading: true,
+        }),
       hookOptions(),
     );
 
@@ -36,6 +46,7 @@ describe("useMarketDataSectionCurrencyData", () => {
       () =>
         useMarketDataSectionCurrencyData({
           marketCurrencyData: createMockMarketCurrencyData(),
+          marketId: undefined,
           isLoading: true,
         }),
       hookOptions(),
@@ -46,7 +57,12 @@ describe("useMarketDataSectionCurrencyData", () => {
 
   it("does not show the skeleton when neither data nor loading is reported", () => {
     const { result } = renderHook(
-      () => useMarketDataSectionCurrencyData({ marketCurrencyData: undefined, isLoading: false }),
+      () =>
+        useMarketDataSectionCurrencyData({
+          marketCurrencyData: undefined,
+          marketId: undefined,
+          isLoading: false,
+        }),
       hookOptions(),
     );
 

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/hooks/useMarketDataSectionCurrencyData.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/hooks/useMarketDataSectionCurrencyData.ts
@@ -4,21 +4,21 @@ import { counterValueCurrencySelector, localeSelector } from "~/renderer/reducer
 import type { AssetMarketData } from "@ledgerhq/asset-detail";
 
 export type MarketDataSectionCurrencyData = Readonly<{
-  data: MarketCurrencyData | undefined;
+  data?: MarketCurrencyData;
   showSkeleton: boolean;
   counterCurrency: string;
   locale: string;
 }>;
 
 export function useMarketDataSectionCurrencyData(
-  market: AssetMarketData,
+  marketData: AssetMarketData,
 ): MarketDataSectionCurrencyData {
   const counterCurrency = useSelector(counterValueCurrencySelector).ticker.toLowerCase();
   const locale = useSelector(localeSelector);
 
   return {
-    data: market.marketCurrencyData,
-    showSkeleton: !market.marketCurrencyData && market.isLoading,
+    data: marketData.marketCurrencyData,
+    showSkeleton: !marketData.marketCurrencyData && marketData.isLoading,
     counterCurrency,
     locale,
   };

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/index.tsx
@@ -5,11 +5,11 @@ import { PricePerformance } from "./PricePerformance";
 import { useMarketDataSectionCurrencyData } from "./hooks/useMarketDataSectionCurrencyData";
 
 type MarketDataSectionProps = Readonly<{
-  market: AssetMarketData;
+  marketData: AssetMarketData;
 }>;
 
-export function MarketDataSection({ market }: MarketDataSectionProps) {
-  const currencyData = useMarketDataSectionCurrencyData(market);
+export function MarketDataSection({ marketData }: MarketDataSectionProps) {
+  const currencyData = useMarketDataSectionCurrencyData(marketData);
 
   return (
     <div className="grid grid-cols-2 gap-24" data-testid="asset-detail-market-data-section">

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/__tests__/resolveMarketPriceSectionSourceId.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/__tests__/resolveMarketPriceSectionSourceId.test.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
-import type { AssetDetailMarketInfo } from "@ledgerhq/asset-detail";
 import type { DistributionItem } from "@ledgerhq/types-live";
 import { resolveMarketPriceSectionSourceId } from "../utils/resolveMarketPriceSectionSourceId";
 
@@ -7,22 +6,21 @@ describe("resolveMarketPriceSectionSourceId", () => {
   it("returns undefined when no source is available", () => {
     expect(
       resolveMarketPriceSectionSourceId({
-        marketInfo: undefined,
+        marketId: undefined,
         distributionItem: undefined,
         ledgerId: undefined,
       }),
     ).toBeUndefined();
   });
 
-  it("prefers marketInfo.id", () => {
-    const marketInfo = { id: "usd-coin", ledgerIds: [] } as AssetDetailMarketInfo;
+  it("prefers marketId over every other source", () => {
     const distribution = {
       marketId: "ignored",
       currency: { id: "ethereum/erc20/usd__coin" },
     } as unknown as DistributionItem;
     expect(
       resolveMarketPriceSectionSourceId({
-        marketInfo,
+        marketId: "usd-coin",
         distributionItem: distribution,
         ledgerId: "ledger-fallback",
       }),
@@ -36,7 +34,7 @@ describe("resolveMarketPriceSectionSourceId", () => {
     } as unknown as DistributionItem;
     expect(
       resolveMarketPriceSectionSourceId({
-        marketInfo: undefined,
+        marketId: undefined,
         distributionItem: distribution,
         ledgerId: undefined,
       }),
@@ -44,7 +42,7 @@ describe("resolveMarketPriceSectionSourceId", () => {
 
     expect(
       resolveMarketPriceSectionSourceId({
-        marketInfo: undefined,
+        marketId: undefined,
         distributionItem: { currency: { id: "only-currency" } } as unknown as DistributionItem,
         ledgerId: undefined,
       }),
@@ -52,7 +50,7 @@ describe("resolveMarketPriceSectionSourceId", () => {
 
     expect(
       resolveMarketPriceSectionSourceId({
-        marketInfo: undefined,
+        marketId: undefined,
         distributionItem: undefined,
         ledgerId: "bitcoin",
       }),

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/index.tsx
@@ -1,27 +1,24 @@
 import React from "react";
-import type { AssetDetailMarketInfo, AssetMarketData } from "@ledgerhq/asset-detail";
+import type { AssetMarketData } from "@ledgerhq/asset-detail";
 import type { DistributionItem } from "@ledgerhq/types-live";
 import { useMarketPriceSectionViewModel } from "./useMarketPriceSectionViewModel";
 import { MarketPriceSectionView } from "./MarketPriceSectionView";
 
 type MarketPriceSectionProps = Readonly<{
-  distributionItem: DistributionItem | undefined;
-  marketInfo: AssetDetailMarketInfo | undefined;
-  ledgerId: string | undefined;
-  market: AssetMarketData;
+  distributionItem?: DistributionItem;
+  ledgerId?: string;
+  marketData: AssetMarketData;
 }>;
 
 export function MarketPriceSection({
   distributionItem,
-  marketInfo,
   ledgerId,
-  market,
+  marketData,
 }: MarketPriceSectionProps) {
   const viewModel = useMarketPriceSectionViewModel({
     distributionItem,
-    marketInfo,
     ledgerId,
-    market,
+    marketData,
   });
   const { shouldRenderSection, ...viewProps } = viewModel;
   if (!shouldRenderSection) return null;

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/useMarketPriceSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/useMarketPriceSectionViewModel.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from "react";
-import type { AssetDetailMarketInfo, AssetMarketData } from "@ledgerhq/asset-detail";
+import type { AssetMarketData } from "@ledgerhq/asset-detail";
 import type { DistributionItem, ValueChange } from "@ledgerhq/types-live";
 import { KeysPriceChange } from "@ledgerhq/live-common/market/utils/types";
 import { formatCurrencyUnitFragment } from "@ledgerhq/live-common/currencies/index";
@@ -18,10 +18,9 @@ import {
 } from "./utils";
 
 type UseMarketPriceSectionViewModelProps = Readonly<{
-  distributionItem: DistributionItem | undefined;
-  marketInfo: AssetDetailMarketInfo | undefined;
-  ledgerId: string | undefined;
-  market: AssetMarketData;
+  distributionItem?: DistributionItem;
+  ledgerId?: string;
+  marketData: AssetMarketData;
 }>;
 
 type UseMarketPriceSectionViewModelResult = Readonly<{
@@ -40,24 +39,23 @@ type UseMarketPriceSectionViewModelResult = Readonly<{
 
 export function useMarketPriceSectionViewModel({
   distributionItem,
-  marketInfo,
   ledgerId,
-  market,
+  marketData,
 }: UseMarketPriceSectionViewModelProps): UseMarketPriceSectionViewModelResult {
   const { t } = useTranslation();
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
   const locale = useSelector(localeSelector);
   const fiatUnit = counterValueCurrency.units[0];
   const marketAssetId = resolveMarketPriceSectionSourceId({
-    marketInfo,
+    marketId: marketData.marketId,
     distributionItem,
     ledgerId,
   });
   const shouldRenderSection = Boolean(marketAssetId);
-  const data = market.marketCurrencyData;
+  const data = marketData.marketCurrencyData;
 
   const hasPriceData = Number.isFinite(data?.price);
-  const showSkeleton = Boolean(marketAssetId && market.isLoading && !hasPriceData);
+  const showSkeleton = Boolean(marketAssetId && marketData.isLoading && !hasPriceData);
   const dayPercentage = data?.priceChangePercentage?.[KeysPriceChange.day];
   const normalizedDayPercentage = clampDayChangePercentPointsNearZero(dayPercentage);
   const dayVariationFiat = getFiatPriceVariationFromPercentChange(

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/utils/resolveMarketPriceSectionSourceId.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/utils/resolveMarketPriceSectionSourceId.ts
@@ -1,20 +1,15 @@
-import type { AssetDetailMarketInfo } from "@ledgerhq/asset-detail";
 import type { DistributionItem } from "@ledgerhq/types-live";
 
 type ResolveMarketPriceSectionSourceIdParams = Readonly<{
-  marketInfo: AssetDetailMarketInfo | undefined;
-  distributionItem: DistributionItem | undefined;
-  ledgerId: string | undefined;
+  marketId?: string;
+  distributionItem?: DistributionItem;
+  ledgerId?: string;
 }>;
 
-/**
- * First identifier available to drive the market price block (mount + query fallbacks).
- * Order matches asset detail context: API market row, then distribution index, then ledger.
- */
 export function resolveMarketPriceSectionSourceId({
-  marketInfo,
+  marketId,
   distributionItem,
   ledgerId,
 }: ResolveMarketPriceSectionSourceIdParams): string | undefined {
-  return marketInfo?.id ?? distributionItem?.marketId ?? distributionItem?.currency.id ?? ledgerId;
+  return marketId ?? distributionItem?.marketId ?? distributionItem?.currency.id ?? ledgerId;
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/OptionsMenu/__tests__/useOptionsMenuViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/OptionsMenu/__tests__/useOptionsMenuViewModel.test.ts
@@ -4,94 +4,111 @@ import { format } from "@ledgerhq/live-common/market/utils/currencyFormatter";
 import type { MarketItemResponse } from "@ledgerhq/live-common/market/utils/types";
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { usdcToken } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
+import type { DistributionItem } from "@ledgerhq/types-live";
 import { buildDistributionItem } from "tests/utils/distributionTestUtils";
 import { MarketMockedResponse } from "tests/handlers/fixtures/market";
 import { useOptionsMenuViewModel } from "../useOptionsMenuViewModel";
 
 const btc = getCryptoCurrencyById("bitcoin");
-
 const [bitcoinMarketRaw] = MarketMockedResponse.bitcoinDetail as MarketItemResponse[];
 const [usdcMarketRaw] = MarketMockedResponse.usdcDetail as MarketItemResponse[];
 
 const bitcoinMarket: AssetMarketData = {
   marketCurrencyData: format(bitcoinMarketRaw),
+  marketId: "bitcoin",
   isLoading: false,
 };
 
 const usdcMarket: AssetMarketData = {
   marketCurrencyData: format(usdcMarketRaw),
+  marketId: "usd-coin",
   isLoading: false,
 };
 
+const emptyMarket: AssetMarketData = {
+  marketCurrencyData: undefined,
+  marketId: undefined,
+  isLoading: false,
+};
+
+type Settings = {
+  counterValue?: string;
+  starredMarketCoins?: string[];
+  blacklistedTokenIds?: string[];
+};
+
+function renderViewModel({
+  distributionItem = buildDistributionItem({ currency: btc }),
+  marketData = bitcoinMarket,
+  settings = {},
+}: {
+  distributionItem?: DistributionItem;
+  marketData?: AssetMarketData;
+  settings?: Settings;
+} = {}) {
+  return renderHook(
+    () => useOptionsMenuViewModel({ distributionItem, marketData, currency: btc }),
+    {
+      initialState: { settings: { counterValue: "USD", starredMarketCoins: [], ...settings } },
+    },
+  );
+}
+
 describe("useOptionsMenuViewModel", () => {
-  it("prefers distributionItem.marketId for star key so market list stars stay in sync", () => {
-    const item = buildDistributionItem({
-      currency: btc,
-      marketId: "coingecko-btc-id",
+  describe("favourite star id resolution", () => {
+    it("prefers marketData.marketId (Coingecko id) over distributionItem.marketId so favourites stay aligned with the Market list", () => {
+      const { result, store } = renderViewModel({
+        distributionItem: buildDistributionItem({
+          currency: btc,
+          marketId: "distribution-fallback-id",
+        }),
+      });
+
+      expect(result.current.isStarEnabled).toBe(true);
+      expect(result.current.isStarred).toBe(false);
+
+      act(() => result.current.onToggleStar());
+
+      const { starredMarketCoins } = store.getState().settings;
+      expect(starredMarketCoins).toContain("bitcoin");
+      expect(starredMarketCoins).not.toContain("distribution-fallback-id");
     });
 
-    const { result, store } = renderHook(
-      () =>
-        useOptionsMenuViewModel({
-          distributionItem: item,
-          market: bitcoinMarket,
-          marketInfo: undefined,
-          currency: btc,
-        }),
-      { initialState: { settings: { counterValue: "USD", starredMarketCoins: [] } } },
-    );
-
-    expect(result.current.isStarEnabled).toBe(true);
-    expect(result.current.isStarred).toBe(false);
-
-    act(() => {
-      result.current.onToggleStar();
-    });
-
-    expect(store.getState().settings.starredMarketCoins).toContain("coingecko-btc-id");
-  });
-
-  it("treats blacklisted currency as hidden from portfolio in the menu", () => {
-    const item = buildDistributionItem({ currency: btc });
-
-    const { result } = renderHook(
-      () =>
-        useOptionsMenuViewModel({
-          distributionItem: item,
-          market: bitcoinMarket,
-          marketInfo: undefined,
-          currency: btc,
-        }),
-      {
-        initialState: {
-          settings: {
-            counterValue: "USD",
-            starredMarketCoins: [],
-            blacklistedTokenIds: ["bitcoin"],
-          },
+    it("falls back to distributionItem.marketId when marketData.marketId is missing (DADA-only path)", () => {
+      const { result, store } = renderViewModel({
+        distributionItem: buildDistributionItem({ currency: btc, marketId: "coingecko-btc-id" }),
+        marketData: {
+          ...emptyMarket,
+          marketCurrencyData: { id: "dada-internal-id" } as AssetMarketData["marketCurrencyData"],
         },
-      },
-    );
+      });
 
-    expect(result.current.isHiddenFromPortfolio).toBe(true);
+      act(() => result.current.onToggleStar());
+
+      const { starredMarketCoins } = store.getState().settings;
+      expect(starredMarketCoins).toContain("coingecko-btc-id");
+      expect(starredMarketCoins).not.toContain("dada-internal-id");
+    });
+
+    it("falls back to distributionItem.slug when neither marketId source is available (token case)", () => {
+      const { result, store } = renderViewModel({
+        distributionItem: buildDistributionItem({ currency: btc, slug: "usd-coin" }),
+        marketData: emptyMarket,
+      });
+
+      expect(result.current.isStarEnabled).toBe(true);
+
+      act(() => result.current.onToggleStar());
+
+      expect(store.getState().settings.starredMarketCoins).toContain("usd-coin");
+    });
   });
 
   it("reflects starred state from settings using market id", () => {
-    const item = buildDistributionItem({
-      currency: btc,
-      marketId: "bitcoin",
+    const { result } = renderViewModel({
+      distributionItem: buildDistributionItem({ currency: btc, marketId: "bitcoin" }),
+      settings: { starredMarketCoins: ["bitcoin"] },
     });
-
-    const { result } = renderHook(
-      () =>
-        useOptionsMenuViewModel({
-          distributionItem: item,
-          market: bitcoinMarket,
-          marketInfo: undefined,
-          currency: btc,
-        }),
-      { initialState: { settings: { counterValue: "USD", starredMarketCoins: ["bitcoin"] } } },
-    );
 
     expect(result.current.isStarred).toBe(true);
   });
@@ -103,8 +120,7 @@ describe("useOptionsMenuViewModel", () => {
       () =>
         useOptionsMenuViewModel({
           distributionItem: item,
-          market: bitcoinMarket,
-          marketInfo: undefined,
+          marketData: bitcoinMarket,
           currency: btc,
         }),
       { initialState: { settings: { counterValue: "USD" } } },
@@ -120,13 +136,20 @@ describe("useOptionsMenuViewModel", () => {
       () =>
         useOptionsMenuViewModel({
           distributionItem: item,
-          market: usdcMarket,
-          marketInfo: undefined,
+          marketData: usdcMarket,
           currency: usdcToken,
         }),
       { initialState: { settings: { counterValue: "USD" } } },
     );
 
     expect(result.current.isHideFromPortfolioEnabled).toBe(true);
+  });
+
+  it("treats blacklisted currency as hidden from portfolio in the menu", () => {
+    const { result } = renderViewModel({
+      settings: { blacklistedTokenIds: ["bitcoin"] },
+    });
+
+    expect(result.current.isHiddenFromPortfolio).toBe(true);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/OptionsMenu/useOptionsMenuViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/OptionsMenu/useOptionsMenuViewModel.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import type { AssetDetailMarketInfo, AssetMarketData } from "@ledgerhq/asset-detail";
+import type { AssetMarketData } from "@ledgerhq/asset-detail";
 import type { DistributionItem } from "@ledgerhq/types-live";
 import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
@@ -16,9 +16,8 @@ import {
 } from "~/renderer/reducers/settings";
 
 export type UseOptionsMenuViewModelProps = Readonly<{
-  distributionItem: DistributionItem | undefined;
-  market: AssetMarketData;
-  marketInfo: AssetDetailMarketInfo | undefined;
+  distributionItem?: DistributionItem;
+  marketData: AssetMarketData;
   currency: CryptoOrTokenCurrency;
 }>;
 
@@ -40,8 +39,7 @@ export type OptionsMenuViewModel = Readonly<{
 
 export function useOptionsMenuViewModel({
   distributionItem,
-  market,
-  marketInfo,
+  marketData,
   currency,
 }: UseOptionsMenuViewModelProps): OptionsMenuViewModel {
   const { t } = useTranslation();
@@ -49,11 +47,11 @@ export function useOptionsMenuViewModel({
   const starredMarketCoins = useSelector(starredMarketCoinsSelector);
   const blacklistedTokenIds = useSelector(blacklistedTokenIdsSelector) ?? [];
 
-  const { marketCurrencyData } = market;
+  const { marketId } = marketData;
 
   const starMarketId = useMemo(
-    () => distributionItem?.marketId ?? marketCurrencyData?.id ?? marketInfo?.id ?? undefined,
-    [distributionItem?.marketId, marketCurrencyData?.id, marketInfo?.id],
+    () => marketId ?? distributionItem?.marketId ?? distributionItem?.slug,
+    [marketId, distributionItem?.marketId, distributionItem?.slug],
   );
 
   const portfolioCurrencyId = currency.id;

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/__tests__/useAssetDetailViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/__tests__/useAssetDetailViewModel.test.ts
@@ -95,7 +95,7 @@ describe("useAssetDetailViewModel", () => {
     });
   });
 
-  describe("marketInfo source priority", () => {
+  describe("market data source priority", () => {
     beforeEach(() => {
       route("bitcoin", { bySlug: { bitcoin: buildDistributionItem({ currency: btc }) } });
     });
@@ -113,7 +113,7 @@ describe("useAssetDetailViewModel", () => {
       assertReady(result.current);
       await waitFor(() => {
         assertReady(result.current);
-        expect(result.current.marketInfo?.name).toBe("Bitcoin DADA");
+        expect(result.current.marketData.marketCurrencyData?.name).toBe("Bitcoin DADA");
       });
     });
 
@@ -126,16 +126,17 @@ describe("useAssetDetailViewModel", () => {
       const { result } = renderVM();
       await waitFor(() => {
         assertReady(result.current);
-        expect(result.current.marketInfo?.name).toBe("Bitcoin Hook");
+        expect(result.current.marketData.marketCurrencyData?.name).toBe("Bitcoin Hook");
       });
     });
 
     it("falls back to location.state when DADA and marketFromHook are empty", async () => {
       mockMarket.empty();
       mockDada.empty();
+      route("bitcoin");
       locationState({ id: "bitcoin", ledgerIds: ["bitcoin"], name: "Bitcoin Seed", price: 9 });
 
-      expect((await waitForReady()).marketInfo?.name).toBe("Bitcoin Seed");
+      expect((await waitForReady()).displayName).toBe("Bitcoin Seed");
     });
   });
 
@@ -145,13 +146,13 @@ describe("useAssetDetailViewModel", () => {
 
       const vm = await waitForReady();
 
-      expect(vm.assetName).toBe(btc.name);
-      expect(vm.assetTicker).toBe(btc.ticker);
+      expect(vm.displayName).toBe(btc.name);
+      expect(vm.displayTicker).toBe(btc.ticker);
       expect(vm.ledgerCurrency).toBe(btc);
       expect(vm.ledgerId).toBe(btc.id);
     });
 
-    it("falls back to marketInfo for name/ticker in discovery mode", async () => {
+    it("falls back to marketCurrencyData for name/ticker in discovery mode", async () => {
       mockMarket.withData([
         { id: "bitcoin", ledgerIds: ["bitcoin"], name: "Bitcoin", ticker: "BTC", price: 100 },
       ]);
@@ -159,8 +160,8 @@ describe("useAssetDetailViewModel", () => {
 
       const vm = await waitForReady();
 
-      expect(vm.assetName).toBe("Bitcoin");
-      expect(vm.assetTicker).toBe("BTC");
+      expect(vm.displayName).toBe("Bitcoin");
+      expect(vm.displayTicker).toBe("BTC");
     });
 
     it("falls back to empty strings when neither source provides name/ticker", async () => {
@@ -170,8 +171,8 @@ describe("useAssetDetailViewModel", () => {
 
       const vm = await waitForReady();
 
-      expect(vm.assetName).toBe("");
-      expect(vm.assetTicker).toBe("");
+      expect(vm.displayName).toBe("");
+      expect(vm.displayTicker).toBe("");
     });
 
     it("derives ledgerCurrency from DADA assetData in discovery mode", async () => {
@@ -186,7 +187,7 @@ describe("useAssetDetailViewModel", () => {
       });
     });
 
-    it("exposes the resolved market dataset under viewModel.market for MarketDataSection", async () => {
+    it("exposes the resolved market dataset under viewModel.marketData for MarketDataSection", async () => {
       mockMarket.withData([
         { id: "bitcoin", ledgerIds: ["bitcoin"], name: "Bitcoin Hook", ticker: "BTC", price: 1 },
       ]);
@@ -197,8 +198,8 @@ describe("useAssetDetailViewModel", () => {
       await waitFor(() => expect(result.current.mode).toBe("ready"));
       await waitFor(() => {
         assertReady(result.current);
-        expect(result.current.market.marketCurrencyData?.name).toBe("Bitcoin Hook");
-        expect(result.current.market.isLoading).toBe(false);
+        expect(result.current.marketData.marketCurrencyData?.name).toBe("Bitcoin Hook");
+        expect(result.current.marketData.isLoading).toBe(false);
       });
     });
   });

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/useAssetDetailViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/useAssetDetailViewModel.ts
@@ -26,35 +26,38 @@ export function useAssetDetailViewModel(): AssetDetailViewModel {
     [routeAssetId, decodedAssetId, marketState, distribution],
   );
 
-  const marketApiCurrencyId = distributionItem?.currency.id ?? decodedAssetId;
+  const marketApiId =
+    distributionItem?.marketId ??
+    distributionItem?.slug ??
+    distributionItem?.currency.id ??
+    decodedAssetId;
   const knownLedgerIds = useMemo<readonly string[] | undefined>(() => {
     if (distributionItem) return [distributionItem.currency.id];
     return marketState?.ledgerIds;
   }, [distributionItem, marketState]);
 
-  const { marketCurrencyData, ledgerCurrencyFromDada, isLoading } = useAssetMarketData({
-    marketApiCurrencyId,
+  const { marketCurrencyData, marketId, ledgerCurrencyFromDada, isLoading } = useAssetMarketData({
+    marketApiId,
     knownLedgerIds,
     counterCurrency,
     product: "lld",
     version: __APP_VERSION__,
+    knownMarketId: marketState?.id,
   });
 
-  const marketInfo = resolveAssetDetailMarketInfo(marketCurrencyData, marketState);
+  const marketFallback = resolveAssetDetailMarketInfo(marketCurrencyData, marketState);
 
   const ledgerCurrency = distributionItem?.currency ?? ledgerCurrencyFromDada;
 
-  if (distributionItem || marketInfo) {
+  if (distributionItem || marketFallback) {
     return {
       mode: "ready",
       distributionItem,
-      marketInfo,
-      market: { marketCurrencyData, isLoading },
+      marketData: { marketCurrencyData, marketId, isLoading },
       ledgerCurrency,
-      assetName: ledgerCurrency?.name ?? marketInfo?.name ?? "",
-      assetTicker: ledgerCurrency?.ticker ?? marketInfo?.ticker ?? "",
-      ledgerId: ledgerCurrency?.id ?? marketInfo?.ledgerIds?.[0],
-      isLoading,
+      displayName: ledgerCurrency?.name ?? marketFallback?.name ?? "",
+      displayTicker: ledgerCurrency?.ticker ?? marketFallback?.ticker ?? "",
+      ledgerId: ledgerCurrency?.id ?? marketFallback?.ledgerIds?.[0],
     };
   }
 

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/types.ts
@@ -1,17 +1,18 @@
 import type { DistributionItem } from "@ledgerhq/types-live";
 import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
-import type { AssetDetailMarketInfo, AssetMarketData } from "@ledgerhq/asset-detail";
+import type { AssetMarketData } from "@ledgerhq/asset-detail";
 
-export type AssetDetailReady = {
+type AssetDetailLoading = Readonly<{ mode: "loading" }>;
+type AssetDetailNotFound = Readonly<{ mode: "not-found" }>;
+
+export type AssetDetailReady = Readonly<{
   mode: "ready";
-  distributionItem: DistributionItem | undefined;
-  marketInfo: AssetDetailMarketInfo | undefined;
-  market: AssetMarketData;
-  ledgerCurrency: CryptoOrTokenCurrency | undefined;
-  assetName: string;
-  assetTicker: string;
-  ledgerId: string | undefined;
-  isLoading: boolean;
-};
+  distributionItem?: DistributionItem;
+  marketData: AssetMarketData;
+  ledgerCurrency?: CryptoOrTokenCurrency;
+  displayName: string;
+  displayTicker: string;
+  ledgerId?: string;
+}>;
 
-export type AssetDetailViewModel = AssetDetailReady | { mode: "loading" } | { mode: "not-found" };
+export type AssetDetailViewModel = AssetDetailLoading | AssetDetailNotFound | AssetDetailReady;

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/CoinOptions/__tests__/useAssetCoinOptionsViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/CoinOptions/__tests__/useAssetCoinOptionsViewModel.test.ts
@@ -15,12 +15,14 @@ const bitcoin = getCryptoCurrencyById("bitcoin");
 function renderViewModel({
   blacklistedTokenIds = [],
   starredMarketCoins = [],
+  marketId,
 }: {
   blacklistedTokenIds?: string[];
   starredMarketCoins?: string[];
+  marketId?: string;
 } = {}) {
   return renderHook(
-    () => useAssetCoinOptionsViewModel({ currency: bitcoin, currencyId: bitcoin.id }),
+    () => useAssetCoinOptionsViewModel({ currency: bitcoin, currencyId: bitcoin.id, marketId }),
     {
       overrideInitialState: (state: State): State => ({
         ...state,
@@ -57,6 +59,16 @@ describe("useAssetCoinOptionsViewModel", () => {
         is_favourite: false,
       }),
     );
+  });
+
+  it("prefers marketId over currencyId as the star key so favourites stay aligned with the Market list", () => {
+    const { result, store } = renderViewModel({ marketId: "bitcoin-coingecko-id" });
+
+    act(() => result.current.onToggleFavourite());
+
+    const { starredMarketCoins } = store.getState().settings;
+    expect(starredMarketCoins).toContain("bitcoin-coingecko-id");
+    expect(starredMarketCoins).not.toContain(bitcoin.id);
   });
 
   it("persists the hidden state and tracks analytics in both directions", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/CoinOptions/useAssetCoinOptionsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/CoinOptions/useAssetCoinOptionsViewModel.ts
@@ -15,9 +15,10 @@ import { useTranslation } from "~/context/Locale";
 type Params = Readonly<{
   currency: AssetDetailCurrencyProps;
   currencyId: string;
+  marketId?: string;
 }>;
 
-export function useAssetCoinOptionsViewModel({ currency, currencyId }: Params) {
+export function useAssetCoinOptionsViewModel({ currency, currencyId, marketId }: Params) {
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const { tryTriggerPushNotificationDrawerAfterAction } = useNotifications();
@@ -27,8 +28,9 @@ export function useAssetCoinOptionsViewModel({ currency, currencyId }: Params) {
 
   const [isCoinOptionsSheetOpen, setCoinOptionsSheetOpen] = useState(false);
 
+  const starKey = marketId ?? currencyId;
   const isHidden = !!currency && blacklistedTokenIds.includes(currency.id);
-  const isStarred = starredMarketCoins.includes(currencyId);
+  const isStarred = starredMarketCoins.includes(starKey);
 
   const blacklistedTokenIdsSet = useMemo(() => new Set(blacklistedTokenIds), [blacklistedTokenIds]);
 
@@ -49,18 +51,18 @@ export function useAssetCoinOptionsViewModel({ currency, currencyId }: Params) {
     });
 
     if (nextStarred) {
-      if (!starredMarketCoins.includes(currencyId)) {
-        dispatch(addStarredMarketCoins(currencyId));
+      if (!starredMarketCoins.includes(starKey)) {
+        dispatch(addStarredMarketCoins(starKey));
       }
       tryTriggerPushNotificationDrawerAfterAction("add_favorite_coin");
-    } else if (starredMarketCoins.includes(currencyId)) {
-      dispatch(removeStarredMarketCoins(currencyId));
+    } else if (starredMarketCoins.includes(starKey)) {
+      dispatch(removeStarredMarketCoins(starKey));
     }
     closeCoinOptions();
   }, [
     currency,
     isStarred,
-    currencyId,
+    starKey,
     dispatch,
     starredMarketCoins,
     tryTriggerPushNotificationDrawerAfterAction,

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/__tests__/useMarketStatsViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/__tests__/useMarketStatsViewModel.test.ts
@@ -12,6 +12,7 @@ const mockUseAssetMarketData = jest.mocked(useAssetMarketData);
 function mockMarketData(overrides?: Partial<ReturnType<typeof useAssetMarketData>>) {
   mockUseAssetMarketData.mockReturnValue({
     marketCurrency: marketCurrencyData as any,
+    marketId: "bitcoin",
     counterCurrency: "usd",
     isLoading: false,
     isError: false,

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/__tests__/usePricePerformanceViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/__tests__/usePricePerformanceViewModel.test.ts
@@ -11,6 +11,7 @@ const mockUseAssetMarketData = jest.mocked(useAssetMarketData);
 function mockMarketData(overrides?: Partial<ReturnType<typeof useAssetMarketData>>) {
   mockUseAssetMarketData.mockReturnValue({
     marketCurrency: marketCurrencyData as any,
+    marketId: "bitcoin",
     counterCurrency: "usd",
     isLoading: false,
     isError: false,

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/useAssetMarketData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/useAssetMarketData.ts
@@ -10,8 +10,8 @@ export function useAssetMarketData(currency: AssetDetailCurrencyProps) {
 
   const knownLedgerIds = currency ? [currency.id] : undefined;
 
-  const { marketCurrencyData, isLoading, isError } = useSharedAssetMarketData({
-    marketApiCurrencyId: currency?.id,
+  const { marketCurrencyData, marketId, isLoading, isError } = useSharedAssetMarketData({
+    marketApiId: currency?.id,
     knownLedgerIds,
     counterCurrency,
     product: "llm",
@@ -20,6 +20,7 @@ export function useAssetMarketData(currency: AssetDetailCurrencyProps) {
 
   return {
     marketCurrency: marketCurrencyData,
+    marketId,
     counterCurrency,
     isLoading,
     isError,

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
@@ -10,6 +10,7 @@ import { resolveDistributionItem } from "@ledgerhq/asset-aggregation/assetDistri
 import type { AssetDetailNavigatorParamsList } from "../../types";
 import { useIsBuyAvailable, useSecondaryButtonType } from "./components/Footer/useFooterViewModel";
 import { useAssetCoinOptionsViewModel } from "./components/CoinOptions/useAssetCoinOptionsViewModel";
+import { useAssetMarketData } from "./hooks/useAssetMarketData";
 
 type Route = StackNavigatorProps<AssetDetailNavigatorParamsList, ScreenName.AssetDetail>["route"];
 
@@ -38,7 +39,8 @@ export function useAssetDetailViewModel() {
   const accounts = useSelector(shallowAccountsSelector);
   const walletHasFunds = useMemo(() => accounts.some(a => a.balance.gt(0)), [accounts]);
   const showFallbackBanner = !hasFooter && walletHasFunds && !!currency;
-  const coinOptions = useAssetCoinOptionsViewModel({ currency, currencyId });
+  const { marketId } = useAssetMarketData(currency);
+  const coinOptions = useAssetCoinOptionsViewModel({ currency, currencyId, marketId });
 
   return {
     currency,

--- a/libs/asset-detail/src/hooks/useAssetMarketData.ts
+++ b/libs/asset-detail/src/hooks/useAssetMarketData.ts
@@ -11,21 +11,22 @@ import { selectCurrency } from "@ledgerhq/live-common/dada-client/utils/currency
 import type { AssetMarketDataInput, AssetMarketDataResult } from "../types";
 
 export function useAssetMarketData({
-  marketApiCurrencyId,
+  marketApiId,
   knownLedgerIds,
   counterCurrency,
   product,
   version,
   isStaging = false,
+  knownMarketId,
 }: AssetMarketDataInput): AssetMarketDataResult {
   const {
     data: marketFromHook,
     isLoading: isLoadingMarket,
     isError: isErrorMarket,
   } = useGetCurrencyDataQuery(
-    { id: marketApiCurrencyId ?? "", counterCurrency },
+    { id: marketApiId ?? "", counterCurrency },
     {
-      skip: !marketApiCurrencyId,
+      skip: !marketApiId,
       pollingInterval: REFETCH_TIME_ONE_MINUTE * BASIC_REFETCH,
     },
   );
@@ -65,6 +66,7 @@ export function useAssetMarketData({
 
   return {
     marketCurrencyData,
+    marketId: marketFromHook?.id ?? knownMarketId,
     ledgerCurrencyFromDada,
     isLoading: isLoadingMarket || isLoadingDada,
     isError: isErrorMarket || isErrorDada,

--- a/libs/asset-detail/src/types.ts
+++ b/libs/asset-detail/src/types.ts
@@ -10,12 +10,9 @@ export type AssetDetailMarketInfo = Readonly<{
 }>;
 
 export type AssetMarketDataInput = Readonly<{
-  marketApiCurrencyId: string | undefined;
-  /**
-   * Ledger ids known up-front (owned distribution item or location.state seed).
-   * Falls back to the Market hook's `ledgerIds` when undefined.
-   */
-  knownLedgerIds: readonly string[] | undefined;
+  marketApiId?: string;
+  knownLedgerIds?: readonly string[];
+  knownMarketId?: string;
   counterCurrency: string;
   product: "lld" | "llm";
   version: string;
@@ -23,12 +20,13 @@ export type AssetMarketDataInput = Readonly<{
 }>;
 
 export type AssetMarketData = Readonly<{
-  marketCurrencyData: MarketCurrencyData | undefined;
+  marketCurrencyData?: MarketCurrencyData;
+  marketId?: string;
   isLoading: boolean;
 }>;
 
 export type AssetMarketDataResult = AssetMarketData &
   Readonly<{
-    ledgerCurrencyFromDada: CryptoOrTokenCurrency | undefined;
+    ledgerCurrencyFromDada?: CryptoOrTokenCurrency;
     isError: boolean;
   }>;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Asset Detail header options menu (Add/Remove from favorites) on desktop and mobile
  - Tokens fetched from Market or DADA (e.g. USDC, SHIB, BONK) — star state must match the Market list
  - Discovery mode asset detail when market data comes from navigation state vs portfolio distribution

### 📝 Description

**Problem**: When opening Asset Detail from Market or Assets, some tokens (e.g. Shiba Inu, Bonk, USDC) could not be starred or removed from favorites. Favorites were keyed with distribution or internal IDs instead of the Coingecko market id used by the Market list.

**Solution**:
- Expose `marketId` (Coingecko id) from `@ledgerhq/asset-detail` `useAssetMarketData` and thread it through desktop/mobile Asset Detail view models
- Resolve the star/favorite key as `marketId` → `distributionItem.marketId` → `distributionItem.slug` so favorites stay aligned with Market
- Consolidate `market` / `marketInfo` props into a single `marketData` object across Asset Detail components
- Add integration test for USDC favorite toggle on desktop

https://github.com/user-attachments/assets/e68dcf41-7857-4115-99d3-02b9f8720e99

### ❓ Context





- **JIRA or GitHub link**: [LIVE-30795](https://ledgerhq.atlassian.net/browse/LIVE-30795)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30795]: https://ledgerhq.atlassian.net/browse/LIVE-30795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ