### PR TITLE
[LWM] fix(mobile): update asset detail v4 loading skeletons to match Figma

### DIFF
--- a/.changeset/asset-detail-loading-skeletons.md
+++ b/.changeset/asset-detail-loading-skeletons.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Update Asset Detail v4 loading state to render animated `Skeleton` placeholders (from `@ledgerhq/lumen-ui-rnative`) for the BalanceGraph header (Market price), BalanceDetails, Addresses, Transactions, MarketStats and PricePerformance sections. Section titles are also skeletoned during loading for visual consistency.

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
@@ -114,10 +114,11 @@ describe("AssetDetail screen layout", () => {
     });
   });
 
-  it("renders the market price section with title and chart placeholder", () => {
+  it("renders the BalanceGraph with chart placeholder", () => {
     render(<AssetDetailTestNavigator />);
 
-    expect(screen.getByText("Market price")).toBeVisible();
+    // While market data is loading, the header is rendered as a skeleton (no
+    // "Market price" text). The chart placeholder is still mounted.
     expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.chartPlaceholder)).toBeVisible();
     expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.receiveButton)).toBeNull();
   });
@@ -160,10 +161,12 @@ describe("AssetDetail screen layout", () => {
     expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.transactions)).toBeNull();
   });
 
-  it("renders the transactions section when operations exist", () => {
+  it("renders the transactions section when operations exist", async () => {
     render(<AssetDetailTestNavigator />, withBtcAccounts(1, 5));
 
-    expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.transactions)).toBeVisible();
+    await waitFor(() =>
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.transactions)).toBeVisible(),
+    );
     expect(screen.getByText("Transactions")).toBeVisible();
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
@@ -29,6 +29,7 @@ type Props = Readonly<{
   hideReceiveInBalanceGraph: boolean;
   showFallbackBanner: boolean;
   coinOptions: AssetCoinOptionsViewModel;
+  isLoading: boolean;
 }>;
 
 export function AssetDetailView({
@@ -41,6 +42,7 @@ export function AssetDetailView({
   hideReceiveInBalanceGraph,
   showFallbackBanner,
   coinOptions,
+  isLoading,
 }: Props) {
   const { bottom } = useSafeAreaInsets();
   const scrollPaddingBottom = useMemo(
@@ -58,10 +60,18 @@ export function AssetDetailView({
       >
         <Box lx={contentStyle}>
           <BalanceGraph currency={currency} hideReceive={hideReceiveInBalanceGraph} />
-          <BalanceDetails currency={currency} distributionItem={distributionItem} />
-          <Addresses currency={currency} distributionItem={distributionItem} />
+          <BalanceDetails
+            currency={currency}
+            distributionItem={distributionItem}
+            isLoading={isLoading}
+          />
+          <Addresses
+            currency={currency}
+            distributionItem={distributionItem}
+            isLoading={isLoading}
+          />
           <MarketData currency={currency} />
-          <Transactions currency={currency} />
+          <Transactions currency={currency} isLoading={isLoading} />
           <FallbackBanner show={showFallbackBanner} />
         </Box>
       </ScrollView>
@@ -85,5 +95,5 @@ const screenStyle: LumenViewStyle = {
 
 const contentStyle: LumenViewStyle = {
   padding: "s16",
-  gap: "s24",
+  gap: "s32",
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/AddressesView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/AddressesView.tsx
@@ -13,18 +13,32 @@ import { useTranslation } from "~/context/Locale";
 import { ASSET_DETAIL_TEST_IDS } from "LLM/features/AssetDetail/testIds";
 import { AddressAccountItem } from "./components/AddressAccountItem";
 import type { AddressAccountData } from "./useAddressesViewModel";
+import { SectionSkeleton } from "../SectionSkeleton";
 
 type Props = Readonly<{
   displayedAccounts: readonly AddressAccountData[];
   hasMore: boolean;
+  hasData: boolean;
   onAddAccount: () => void;
   onSeeAll: () => void;
+  isLoading: boolean;
 }>;
 
-export function AddressesView({ displayedAccounts, hasMore, onAddAccount, onSeeAll }: Props) {
+export function AddressesView({
+  displayedAccounts,
+  hasMore,
+  hasData,
+  onAddAccount,
+  onSeeAll,
+  isLoading,
+}: Props) {
   const { t } = useTranslation();
 
-  if (displayedAccounts.length === 0) return null;
+  if (isLoading && !hasData) {
+    return <SectionSkeleton rows={1} rowHeight="s56" />;
+  }
+
+  if (!hasData) return null;
 
   return (
     <Box testID={ASSET_DETAIL_TEST_IDS.addresses}>

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/index.tsx
@@ -7,9 +7,10 @@ import { AddressesView } from "./AddressesView";
 type Props = Readonly<{
   currency: AssetDetailCurrencyProps;
   distributionItem: DistributionItem | undefined;
+  isLoading: boolean;
 }>;
 
-export function Addresses({ currency, distributionItem }: Props) {
+export function Addresses({ currency, distributionItem, isLoading }: Props) {
   const viewModel = useAddressesViewModel(currency, distributionItem);
-  return <AddressesView {...viewModel} />;
+  return <AddressesView {...viewModel} isLoading={isLoading} />;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/useAddressesViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/useAddressesViewModel.ts
@@ -106,6 +106,7 @@ export function useAddressesViewModel(
   return {
     displayedAccounts,
     hasMore,
+    hasData: displayedAccounts.length > 0,
     onAddAccount,
     onSeeAll,
   };

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/BalanceDetailsView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/BalanceDetailsView.tsx
@@ -7,6 +7,7 @@ import type { BalanceDetailsViewModelResult } from "./useBalanceDetailsViewModel
 import { TotalBalanceView } from "./TotalBalanceView";
 import { EarnBannerView } from "./EarnBannerView";
 import { EarnCardsView } from "./EarnCardsView";
+import { SectionSkeleton } from "../SectionSkeleton";
 
 type EarnState = BalanceDetailsViewModelResult["earnState"];
 
@@ -20,6 +21,7 @@ type Props = Readonly<{
   onTransferPress: () => void;
   onEarnBannerPress: () => void;
   onEarnDepositPress: () => void;
+  isLoading: boolean;
 }>;
 
 export function BalanceDetailsView({
@@ -32,7 +34,12 @@ export function BalanceDetailsView({
   onTransferPress,
   onEarnBannerPress,
   onEarnDepositPress,
+  isLoading,
 }: Props) {
+  if (isLoading && !hasAccounts) {
+    return <SectionSkeleton rows={1} rowHeight="s56" />;
+  }
+
   if (!hasAccounts) return null;
 
   return (

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/index.tsx
@@ -7,9 +7,10 @@ import { BalanceDetailsView } from "./BalanceDetailsView";
 type Props = Readonly<{
   currency: AssetDetailCurrencyProps;
   distributionItem: DistributionItem | undefined;
+  isLoading: boolean;
 }>;
 
-export function BalanceDetails({ currency, distributionItem }: Props) {
+export function BalanceDetails({ currency, distributionItem, isLoading }: Props) {
   const viewModel = useBalanceDetailsViewModel(currency, distributionItem);
-  return <BalanceDetailsView {...viewModel} />;
+  return <BalanceDetailsView {...viewModel} isLoading={isLoading} />;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/BalanceGraphView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/BalanceGraphView.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   SegmentedControl,
   SegmentedControlButton,
+  Skeleton,
   Text,
 } from "@ledgerhq/lumen-ui-rnative";
 import type { FormattedValue } from "@ledgerhq/lumen-ui-rnative";
@@ -30,6 +31,7 @@ type Props = Readonly<{
   onRangeChange: (value: string) => void;
   showReceive: boolean;
   onReceivePress: () => void;
+  isLoading: boolean;
 }>;
 
 export function BalanceGraphView({
@@ -44,33 +46,38 @@ export function BalanceGraphView({
   onRangeChange,
   showReceive,
   onReceivePress,
+  isLoading,
 }: Props) {
   const { t } = useTranslation();
 
   return (
     <Box testID={ASSET_DETAIL_TEST_IDS.balanceGraph} lx={containerStyle}>
       {/* Box 1 — Header: label + price + trend */}
-      <Box lx={headerStyle}>
-        <Text typography="body3" lx={{ color: "muted" }}>
-          {t("assetDetail.balanceGraph.marketPrice")}
-        </Text>
+      {isLoading && !hasMarketData ? (
+        <Skeleton lx={{ height: "s56", width: "s256", borderRadius: "md" }} />
+      ) : (
+        <Box lx={headerStyle}>
+          <Text typography="body3" lx={{ color: "muted" }}>
+            {t("assetDetail.balanceGraph.marketPrice")}
+          </Text>
 
-        {hasMarketData && (
-          <>
-            <AmountDisplay
-              value={price}
-              formatter={priceFormatter}
-              testID={ASSET_DETAIL_TEST_IDS.marketPrice}
-            />
+          {hasMarketData && (
+            <>
+              <AmountDisplay
+                value={price}
+                formatter={priceFormatter}
+                testID={ASSET_DETAIL_TEST_IDS.marketPrice}
+              />
 
-            <Trend
-              percentage={priceChangePercentage}
-              formattedChange={formattedPriceChange}
-              timeLabel={rangeTimeLabel}
-            />
-          </>
-        )}
-      </Box>
+              <Trend
+                percentage={priceChangePercentage}
+                formattedChange={formattedPriceChange}
+                timeLabel={rangeTimeLabel}
+              />
+            </>
+          )}
+        </Box>
+      )}
 
       {/* Box 2 — Chart placeholder */}
       <Box

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/MarketStatsView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/MarketStatsView.tsx
@@ -6,7 +6,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "~/context/Locale";
 import { ASSET_DETAIL_TEST_IDS } from "LLM/features/AssetDetail/testIds";
 import { SectionContentState } from "../SectionContentState";
-import { STAT_KEYS } from "./useMarketStatsViewModel";
+import { SectionSkeleton } from "../SectionSkeleton";
 
 type StatRow = {
   key: string;
@@ -27,19 +27,23 @@ export function MarketStatsView({ stats, isLoading, isError, hasData, onTooltipO
   const { t } = useTranslation();
   const { bottom } = useSafeAreaInsets();
 
+  if (isLoading && !hasData) {
+    return (
+      <Box testID={ASSET_DETAIL_TEST_IDS.marketStats}>
+        <SectionSkeleton rows={1} rowHeight="s56" />
+      </Box>
+    );
+  }
+
   return (
     <Box testID={ASSET_DETAIL_TEST_IDS.marketStats} lx={containerStyle}>
       <Text typography="heading5SemiBold" lx={{ color: "base" }}>
         {t("assetDetail.marketStats.title")}
       </Text>
       <SectionContentState
-        isLoading={isLoading}
         isError={isError}
         hasData={hasData}
         errorMessage={t("assetDetail.marketStats.error")}
-        skeletonKeys={STAT_KEYS}
-        listStyle={listStyle}
-        skeletonStyle={skeletonRowStyle}
       >
         <Box lx={listStyle}>
           {stats.map(stat => (
@@ -95,10 +99,4 @@ const labelContainerStyle: LumenViewStyle = {
   flexDirection: "row",
   alignItems: "center",
   gap: "s4",
-};
-
-const skeletonRowStyle: LumenViewStyle = {
-  height: "s24",
-  backgroundColor: "surface",
-  borderRadius: "sm",
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/useMarketStatsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/useMarketStatsViewModel.ts
@@ -5,14 +5,6 @@ import { track } from "~/analytics";
 import { counterValueFormatter } from "LLM/features/Market/utils";
 import { useAssetMarketData } from "../../hooks/useAssetMarketData";
 
-export const STAT_KEYS = [
-  "market_cap",
-  "market_rank",
-  "circulating_supply",
-  "max_supply",
-  "trading_volume",
-] as const;
-
 type StatRow = {
   key: string;
   label: string;

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/PricePerformanceView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/PricePerformanceView.tsx
@@ -4,7 +4,7 @@ import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { useTranslation } from "~/context/Locale";
 import { ASSET_DETAIL_TEST_IDS } from "LLM/features/AssetDetail/testIds";
 import { SectionContentState } from "../SectionContentState";
-import { RECORD_KEYS } from "./usePricePerformanceViewModel";
+import { SectionSkeleton } from "../SectionSkeleton";
 
 type PriceRecord = {
   id: string;
@@ -25,19 +25,23 @@ type Props = Readonly<{
 export function PricePerformanceView({ records, isLoading, isError, hasData }: Props) {
   const { t } = useTranslation();
 
+  if (isLoading && !hasData) {
+    return (
+      <Box testID={ASSET_DETAIL_TEST_IDS.pricePerformance}>
+        <SectionSkeleton rows={1} rowHeight="s56" />
+      </Box>
+    );
+  }
+
   return (
     <Box testID={ASSET_DETAIL_TEST_IDS.pricePerformance} lx={containerStyle}>
       <Text typography="heading5SemiBold" lx={{ color: "base" }}>
         {t("assetDetail.pricePerformance.title")}
       </Text>
       <SectionContentState
-        isLoading={isLoading}
         isError={isError}
-        hasData={hasData && records.length > 0}
+        hasData={hasData}
         errorMessage={t("assetDetail.pricePerformance.error")}
-        skeletonKeys={RECORD_KEYS}
-        listStyle={listStyle}
-        skeletonStyle={skeletonRowStyle}
       >
         <Box lx={listStyle}>
           {records.map(record => (
@@ -87,10 +91,4 @@ const recordLeftStyle: LumenViewStyle = {
 const recordRightStyle: LumenViewStyle = {
   alignItems: "flex-end",
   gap: "s2",
-};
-
-const skeletonRowStyle: LumenViewStyle = {
-  height: "s40",
-  backgroundColor: "surface",
-  borderRadius: "sm",
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/usePricePerformanceViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/usePricePerformanceViewModel.ts
@@ -4,8 +4,6 @@ import { useTranslation, useLocale } from "~/context/Locale";
 import { counterValueFormatter } from "LLM/features/Market/utils";
 import { useAssetMarketData } from "../../hooks/useAssetMarketData";
 
-export const RECORD_KEYS = ["ath", "atl"] as const;
-
 type PriceRecord = {
   id: string;
   label: string;
@@ -108,7 +106,7 @@ export function usePricePerformanceViewModel(currency: AssetDetailCurrencyProps)
     records,
     isLoading,
     isError,
-    hasData: !!marketCurrency,
+    hasData: !!marketCurrency && records.length > 0,
   };
 }
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/SectionContentState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/SectionContentState.tsx
@@ -4,36 +4,13 @@ import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { Warning } from "@ledgerhq/lumen-ui-rnative/symbols";
 
 type Props = Readonly<{
-  isLoading: boolean;
   isError: boolean;
   hasData: boolean;
   errorMessage: string;
-  skeletonKeys: readonly string[];
-  listStyle: LumenViewStyle;
-  skeletonStyle: LumenViewStyle;
   children: React.ReactNode;
 }>;
 
-export function SectionContentState({
-  isLoading,
-  isError,
-  hasData,
-  errorMessage,
-  skeletonKeys,
-  listStyle,
-  skeletonStyle,
-  children,
-}: Props) {
-  if (isLoading && !hasData) {
-    return (
-      <Box lx={listStyle}>
-        {skeletonKeys.map(key => (
-          <Box key={key} lx={skeletonStyle} />
-        ))}
-      </Box>
-    );
-  }
-
+export function SectionContentState({ isError, hasData, errorMessage, children }: Props) {
   if (isError && !hasData) {
     return (
       <Box lx={errorContainerStyle}>

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/SectionSkeleton.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/SectionSkeleton.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { Box, Skeleton } from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+
+type SkeletonSize = NonNullable<LumenViewStyle["height"]>;
+
+type Props = Readonly<{
+  rows: number;
+  rowHeight: SkeletonSize;
+  titleWidth?: SkeletonSize;
+  testID?: string;
+}>;
+
+export const SECTION_SKELETON_TEST_ID = "asset-detail-section-skeleton";
+
+export function SectionSkeleton({
+  rows,
+  rowHeight,
+  titleWidth = "s256",
+  testID = SECTION_SKELETON_TEST_ID,
+}: Props) {
+  return (
+    <Box lx={containerStyle} testID={testID}>
+      <Skeleton lx={{ height: "s12", width: titleWidth, borderRadius: "full" }} />
+      <Box lx={rowsContainerStyle}>
+        {getSkeletonRowKeys(rows).map(key => (
+          <Skeleton key={key} lx={{ height: rowHeight, width: "full", borderRadius: "md" }} />
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
+function getSkeletonRowKeys(rows: number): string[] {
+  return Array.from({ length: rows }, (_, i) => `skeleton-row-${i}`);
+}
+
+const containerStyle: LumenViewStyle = {
+  gap: "s16",
+};
+
+const rowsContainerStyle: LumenViewStyle = {
+  gap: "s8",
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Transactions/TransactionsView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Transactions/TransactionsView.tsx
@@ -10,6 +10,7 @@ import { Account, AccountLike, Operation } from "@ledgerhq/types-live";
 import { useTranslation } from "~/context/Locale";
 import OperationsListItem from "LLM/features/OperationsHistory/screens/OperationsList/components/OperationsListItem";
 import { ASSET_DETAIL_TEST_IDS } from "LLM/features/AssetDetail/testIds";
+import { SectionSkeleton } from "../SectionSkeleton";
 
 type Props = Readonly<{
   operations: readonly Operation[];
@@ -19,6 +20,8 @@ type Props = Readonly<{
     accountId: string,
   ) => { account: AccountLike; parentAccount: Account | undefined } | null;
   onHeaderPress: () => void;
+  hasData: boolean;
+  isLoading: boolean;
 }>;
 
 export function TransactionsView({
@@ -27,10 +30,16 @@ export function TransactionsView({
   lastSeenTs,
   findAccount,
   onHeaderPress,
+  hasData,
+  isLoading,
 }: Props) {
   const { t } = useTranslation();
 
-  if (operations.length === 0) return null;
+  if (isLoading && !hasData) {
+    return <SectionSkeleton rows={1} rowHeight="s56" />;
+  }
+
+  if (!hasData) return null;
 
   return (
     <Box testID={ASSET_DETAIL_TEST_IDS.transactions}>

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Transactions/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Transactions/index.tsx
@@ -5,9 +5,10 @@ import { TransactionsView } from "./TransactionsView";
 
 type Props = Readonly<{
   currency: CryptoOrTokenCurrency | undefined;
+  isLoading: boolean;
 }>;
 
-export function Transactions({ currency }: Props) {
+export function Transactions({ currency, isLoading }: Props) {
   const viewModel = useTransactionsViewModel(currency);
-  return <TransactionsView {...viewModel} />;
+  return <TransactionsView {...viewModel} isLoading={isLoading} />;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Transactions/useTransactionsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Transactions/useTransactionsViewModel.ts
@@ -78,5 +78,6 @@ export function useTransactionsViewModel(currency: CryptoOrTokenCurrency | undef
     lastSeenTs,
     findAccount,
     onHeaderPress,
+    hasData: operations.length > 0,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
@@ -24,6 +24,7 @@ export function useAssetDetailViewModel() {
     () => resolveDistributionItem({ routeAssetId: currencyId, distribution }),
     [currencyId, distribution],
   );
+  const isLoading = distribution.isLoading;
 
   const [isRefreshing, setIsRefreshing] = useState(false);
   const onRefresh = useCallback(() => {
@@ -50,5 +51,6 @@ export function useAssetDetailViewModel() {
     hideReceiveInBalanceGraph,
     showFallbackBanner,
     coinOptions,
+    isLoading,
   };
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Visual polish on the Asset Detail v4 loading state; existing view-model unit tests still cover the underlying logic but no new view-level snapshots were added._
- [x] **Impact of the changes:**
  - Asset Detail v4 screen (mobile) — loading state of every section below the chart (BalanceGraph header, BalanceDetails, Addresses, Transactions, MarketStats, PricePerformance)
  - Verify pulsing skeletons render while `distribution.isLoading` (or each section's own `isLoading`) is true
  - Verify normal rendering once data resolves and no regression on the empty / error states
  - Spacing between sections is now `s32` (was `s24`)

### 📝 Description

The loading skeletons on the Asset Detail v4 screen did not match the latest Figma reference: titles stayed rendered as plain text and the placeholders were flat, unanimated boxes.

This PR routes every section below the chart through a new shared `SectionSkeleton` component built on top of `@ledgerhq/lumen-ui-rnative`'s animated `Skeleton`. Both the section title and content now render as pulsing skeletons while loading:

- `useAssetDetailViewModel` now exposes `isLoading` (from `distribution.isLoading`) and threads it to `BalanceDetails`, `Addresses` and `Transactions`.
- `BalanceGraph` shows a left-capped `s256 × s56` skeleton in place of the Market price header while market data loads.
- `MarketStats` and `PricePerformance` keep their existing loading source (`useAssetMarketData`) but render the same single-row skeleton (title + content).
- `SectionContentState` is simplified — its loading branch is dropped since each section now owns its skeleton.
- `PricePerformance` viewmodel exposes `hasData` already factoring `records.length > 0`.

<img width="350" height="750" alt="Simulator Screenshot - iOS Simulator - 2026-05-19 at 12 06 24" src="https://github.com/user-attachments/assets/08eba2c2-08f2-4599-88fd-7dc2d311d2f9" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30751](https://ledgerhq.atlassian.net/browse/LIVE-30751)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30751]: https://ledgerhq.atlassian.net/browse/LIVE-30751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ