### PR TITLE
[LWM] fix(mobile): post-onboarding push opt-in on Android (LIVE-30796)

### DIFF
--- a/.changeset/fresh-prompts-refresh.md
+++ b/.changeset/fresh-prompts-refresh.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Make sure push notifications data is initialized even if the user is not onboarded

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/new/NotificationsPromptBootstrap.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/new/NotificationsPromptBootstrap.tsx
@@ -2,8 +2,6 @@ import { useCallback, useEffect } from "react";
 import { AppState } from "react-native";
 import { getNotificationPermissionStatus } from "~/logic/getNotificationPermissionStatus";
 import { useNotificationsPermission } from "LLM/hooks/useNotificationsPermission";
-import { useSelector } from "~/context/hooks";
-import { hasCompletedOnboardingSelector } from "~/reducers/settings";
 import {
   getPushNotificationsDataOfUserFromStorage,
   type InitPushNotificationsDataResult,
@@ -12,8 +10,7 @@ import {
 } from "LLM/features/NotificationsPrompt";
 
 export function NotificationsPromptBootstrap() {
-  const { onInitialDataLoaded } = useNotificationsContext();
-  const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
+  const { tryTriggerPushNotificationDrawerAfterInactivity } = useNotificationsContext();
   const { setPermissionStatus } = useNotificationsPermission();
   const {
     notifications,
@@ -92,21 +89,7 @@ export function NotificationsPromptBootstrap() {
     ]);
 
   useEffect(() => {
-    if (!hasCompletedOnboarding) {
-      return;
-    }
-
-    let isCurrentEffect = true;
-    initPushNotificationsData().then(data => {
-      if (isCurrentEffect) {
-        onInitialDataLoaded(data);
-      }
-    });
-
-    return () => {
-      isCurrentEffect = false;
-    };
-
+    initPushNotificationsData().then(tryTriggerPushNotificationDrawerAfterInactivity);
     // Run this effect only once
     // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/new/NotificationsPromptProvider.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/new/NotificationsPromptProvider.tsx
@@ -11,7 +11,7 @@ type NotificationsPromptProviderProps = {
 
 export type NotificationsPromptContextValue = {
   notifyFlowCompleted: (source: NotificationsPromptAfterActionSource) => void;
-  onInitialDataLoaded: (data: InitPushNotificationsDataResult) => void;
+  tryTriggerPushNotificationDrawerAfterInactivity: (data: InitPushNotificationsDataResult) => void;
 };
 
 export const NotificationsPromptContext = createContext<NotificationsPromptContextValue | null>(
@@ -35,7 +35,7 @@ export function NotificationsPromptProvider({ children }: NotificationsPromptPro
   const value = useMemo(
     () => ({
       notifyFlowCompleted,
-      onInitialDataLoaded: tryTriggerPushNotificationDrawerAfterInactivity,
+      tryTriggerPushNotificationDrawerAfterInactivity,
     }),
     [notifyFlowCompleted, tryTriggerPushNotificationDrawerAfterInactivity],
   );


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No automated tests were added for this small bootstrap wiring change; validate through the notification prompt flows below._
- [x] **Impact of the changes:**
  - Mobile notification prompt bootstrap on app startup.
  - Push notification data initialization for users who have not completed onboarding yet.
  - Post-inactivity push notification drawer trigger after initial notification data is loaded.

### 📝 Description

The notification prompt bootstrap was previously gated by `hasCompletedOnboarding`. Because of that, users who had not completed onboarding skipped the initial push notification data and OS permission status initialization entirely.

This PR removes that onboarding guard so push notification data is initialized on startup regardless of onboarding state. The bootstrap still passes the loaded data to the post-inactivity notification prompt trigger once initialization completes, and the context value now exposes that trigger under its real name.


https://github.com/user-attachments/assets/46aece2d-0456-4adb-8939-bf880b1aa89a


https://github.com/user-attachments/assets/35faa481-d706-42f7-a272-c545655b2827



### ❓ Context

- **JIRA or GitHub link**: [LIVE-30796](https://ledgerhq.atlassian.net/browse/LIVE-30796)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

---

### 🧪 Test plan

- [ ] Fresh install / reset app state, start onboarding, and verify push notification data initialization runs before onboarding is completed.
- [ ] Complete onboarding and verify the push notification prompt can still be triggered normally.
- [ ] Background and foreground the app, then verify notification permission state remains synced.

[LIVE-30796]: https://ledgerhq.atlassian.net/browse/LIVE-30796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ