### PR TITLE
[LWM] ci: adjust JS builds to minify existing built bundle

### DIFF
--- a/.github/workflows/test-mobile-build-android-reusable.yml
+++ b/.github/workflows/test-mobile-build-android-reusable.yml
@@ -207,16 +207,10 @@ jobs:
           command: pnpm i --filter="live-mobile..." --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --unsafe-perm
           new_command_on_retry: rm -rf ~/.cocoapods/ && pnpm clean && pnpm i --filter="live-mobile..." --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --unsafe-perm
 
-      - name: Build JS Bundle app for Detox test run
+      - name: Build JS bundle and minify for size analysis
         uses: LedgerHQ/ledger-live/tools/actions/composites/nx-step@develop
         with:
-          command: pnpm exec nx run live-mobile:e2e:ci -- -p android --bundle
-          disable_cache: ${{ inputs.disable-turbo-cache || false }}
-
-      - name: Build minified JS Bundle for size analysis
-        uses: LedgerHQ/ledger-live/tools/actions/composites/nx-step@develop
-        with:
-          command: pnpm exec nx run live-mobile:e2e:ci -- -p android --bundle-size
+          command: pnpm exec nx run live-mobile:e2e:ci -- -p android --bundle --bundle-size
           disable_cache: ${{ inputs.disable-turbo-cache || false }}
 
       - name: Output bundle size for analysis

--- a/.github/workflows/test-mobile-build-ios-reusable.yml
+++ b/.github/workflows/test-mobile-build-ios-reusable.yml
@@ -231,16 +231,10 @@ jobs:
           command: pnpm i --filter="live-mobile..." --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --unsafe-perm
           new_command_on_retry: rm -rf ~/.cocoapods/ && pnpm clean && pnpm i --filter="live-mobile..." --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --unsafe-perm
 
-      - name: Build JS Bundle app for Detox test run
+      - name: Build JS bundle and minify for size analysis
         uses: LedgerHQ/ledger-live/tools/actions/composites/nx-step@develop
         with:
-          command: pnpm exec nx run live-mobile:e2e:ci -- -p ios --bundle
-          disable_cache: ${{ inputs.disable-turbo-cache || false }}
-
-      - name: Build minified JS Bundle for size analysis
-        uses: LedgerHQ/ledger-live/tools/actions/composites/nx-step@develop
-        with:
-          command: pnpm exec nx run live-mobile:e2e:ci -- -p ios --bundle-size
+          command: pnpm exec nx run live-mobile:e2e:ci -- -p ios --bundle --bundle-size
           disable_cache: ${{ inputs.disable-turbo-cache || false }}
 
       - name: Output bundle size for analysis

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -17,6 +17,7 @@
     "bundle:ios:prod": "NODE_OPTIONS=--max-old-space-size=8192 react-native bundle --platform ios --entry-file index.js --dev false --bundle-output main.ios.jsbundle",
     "bundle:android": "NODE_OPTIONS=--max-old-space-size=8192 react-native bundle --platform android --entry-file index.js --bundle-output main.jsbundle",
     "bundle:android:prod": "NODE_OPTIONS=--max-old-space-size=8192 react-native bundle --platform android --entry-file index.js --dev false --bundle-output main.android.jsbundle",
+    "minify:bundle": "zx ./scripts/minify-jsbundle.mjs",
     "ios": "react-native run-ios --target ledgerlivemobile",
     "android": "react-native run-android --appIdSuffix=debug --active-arch-only",
     "android:gradleClean": "cd android && ./gradlew clean",

--- a/apps/ledger-live-mobile/scripts/e2e-ci.mjs
+++ b/apps/ledger-live-mobile/scripts/e2e-ci.mjs
@@ -43,12 +43,8 @@ const bundle_android = async () => {
 };
 
 // Minified bundle for size reporting (not used for E2E tests)
-const bundle_ios_minified = async () => {
-  await $`pnpm mobile bundle:ios --dev false --minify true --bundle-output main.jsbundle.minified`;
-};
-
-const bundle_android_minified = async () => {
-  await $`pnpm mobile bundle:android --dev false --minify true --bundle-output main.jsbundle.minified`;
+const minify_existing_bundle = async () => {
+  await $`pnpm mobile minify:bundle`;
 };
 
 const bundle_ios_with_cache = async () => {
@@ -102,13 +98,13 @@ const getTasksFrom = {
   ios: {
     build: build_ios,
     bundle: async () => (cache ? await bundle_ios_with_cache() : await bundle_ios()),
-    bundleSize: bundle_ios_minified,
+    bundleSize: minify_existing_bundle,
     test: test_ios,
   },
   android: {
     build: build_android,
     bundle: async () => await bundle_android(),
-    bundleSize: bundle_android_minified,
+    bundleSize: minify_existing_bundle,
     test: test_android,
   },
 };

--- a/apps/ledger-live-mobile/scripts/minify-jsbundle.mjs
+++ b/apps/ledger-live-mobile/scripts/minify-jsbundle.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env zx
+import { existsSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { minify } from "@swc/core";
+
+const appRoot = resolve(import.meta.dirname, "..");
+const positionalArgs = process.argv.slice(2).filter(arg => !arg.endsWith(".mjs"));
+const inputPath = resolve(appRoot, positionalArgs[0] ?? "main.jsbundle");
+const outputPath = resolve(appRoot, positionalArgs[1] ?? "main.jsbundle.minified");
+
+if (!existsSync(inputPath)) {
+  console.error(`Input bundle not found: ${inputPath}`);
+  console.error("Run bundle first (e.g. e2e-ci --bundle) before minifying.");
+  process.exit(1);
+}
+
+const code = await readFile(inputPath, "utf8");
+const result = await minify(code, {
+  compress: true,
+  mangle: true,
+  sourceMap: false,
+  module: false,
+});
+
+if (!result.code) {
+  console.error("Minification produced empty output");
+  process.exit(1);
+}
+
+await writeFile(outputPath, result.code, "utf8");
+console.log(`Minified ${inputPath} -> ${outputPath} (${result.code.length} bytes)`);


### PR DESCRIPTION
### 📝 Description

Currently the JS bundle for mobile is built twice - once unminified, once minified. This adds around 2-3 minutes to the critical path.

This was going to be deprecated by RSDoctor however, this is ongoing. Bring in a temporary step to minify the existing build

Note: This may shift baseline slightly, so while re-configuring some PRs may get a false positive/negative

### ❓ Context

Test Run: https://github.com/LedgerHQ/ledger-live/actions/runs/26094790456/job/76729728736
Ticket: https://ledgerhq.atlassian.net/browse/LIVE-30819


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
