### PR TITLE
[LWDM] fix(coin-bitcoin): Zcash transparent send crash

### DIFF
--- a/.changeset/sour-buttons-remember.md
+++ b/.changeset/sour-buttons-remember.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-bitcoin": patch
+"@ledgerhq/live-common": patch
+---
+
+fix ZCash send transaction broken after DMK support

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/types.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/types.ts
@@ -4,7 +4,7 @@ import type { AccountShapeInfo } from "@ledgerhq/ledger-wallet-framework/bridge/
 import type { GetAddressOptions } from "@ledgerhq/ledger-wallet-framework/derivation";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Account, AccountRaw, SignOperationEvent, SyncConfig } from "@ledgerhq/types-live";
-import type { BitcoinAddress, BitcoinXPub, SignerContext } from "../signer";
+import type { BitcoinAddress, BitcoinSigner, BitcoinXPub, SignerContext } from "../signer";
 import type { BitcoinAccount, Transaction, TransactionStatus } from "../types";
 
 /**
@@ -112,7 +112,13 @@ export interface ChainAdapter {
 
   /**
    * Override signer instantiation for chains requiring non-BTC signer implementations.
-   * Return `undefined` to fall through to the standard hw-app-btc signer.
+   * `defaultSigner` is the standard hw-app-btc signer — chain adapters can augment it
+   * with chain-specific methods (e.g. overlay DmkSignerZcash.getAddress).
+   * Return `undefined` to use `defaultSigner` as-is.
    */
-  createSigner?(transport: unknown, currency: CryptoCurrency): unknown | undefined;
+  createSigner?(
+    transport: unknown,
+    currency: CryptoCurrency,
+    defaultSigner: BitcoinSigner,
+  ): BitcoinSigner | undefined;
 }

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/index.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/index.test.ts
@@ -2,7 +2,7 @@ import BigNumber from "bignumber.js";
 import type { Account, AccountRaw } from "@ledgerhq/types-live";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import type { BitcoinAccountRaw } from "../../../types";
-import type { SignerContext } from "../../../signer";
+import type { BitcoinSigner, SignerContext } from "../../../signer";
 import type { ZcashAccount, ZcashAccountRaw, ZcashPrivateInfo } from "../types";
 import { getChainAdapter } from "../../registry";
 
@@ -13,7 +13,12 @@ const dmkSignerCtor = jest.fn();
 jest.mock("@ledgerhq/live-signer-zcash", () => ({
   DmkSignerZcash: jest.fn().mockImplementation((...args) => {
     dmkSignerCtor(...args);
-    return { __mockedDmkSignerZcash: true, args };
+    return {
+      __mockedDmkSignerZcash: true,
+      args,
+      getAddress: jest.fn(),
+      getFullViewingKey: jest.fn(),
+    };
   }),
 }));
 
@@ -32,8 +37,7 @@ const currency = getCryptoCurrencyById("zcash");
  */
 const MASTER_PUBKEY_HEX = "0339a36013301597daef41fbe593a02cc513d0b55527ec2df1050e2e8ff49c85c2";
 const ACCOUNT_PUBKEY_HEX = "035a784662a4a20a65bf6aab9ae98a6c068a81c52e4b032c0fb5400c706cfccc56";
-const ACCOUNT_CHAIN_CODE_HEX =
-  "47fdacbd0f1097043b78c63c20c34ef4ed9a111d980047ad16282c7ae6236141";
+const ACCOUNT_CHAIN_CODE_HEX = "47fdacbd0f1097043b78c63c20c34ef4ed9a111d980047ad16282c7ae6236141";
 const EXPECTED_M_0H_XPUB =
   "xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw";
 const XPUB_MAINNET_VERSION = 0x0488b21e;
@@ -324,28 +328,29 @@ describe("zcash chain adapter — getFullViewingKey", () => {
 // ─── createSigner ─────────────────────────────────────────────────────
 
 describe("zcash chain adapter — createSigner", () => {
-  it("instantiates DmkSignerZcash from a DMK transport", () => {
+  it("augments the default signer with DmkSignerZcash methods for DMK transport", () => {
     const dmk = { dmkSentinel: true };
     const sessionId = "session-42";
+    const defaultSigner = { splitTransaction: jest.fn() } as unknown as BitcoinSigner;
 
-    const signer = adapter.createSigner!({ dmk, sessionId }, currency);
+    const signer = adapter.createSigner!({ dmk, sessionId }, currency, defaultSigner);
 
     expect(dmkSignerCtor).toHaveBeenCalledWith(dmk, sessionId);
-    expect(signer).toEqual({
-      __mockedDmkSignerZcash: true,
-      args: [dmk, sessionId],
-    });
+    // Default signer is augmented in-place with DMK methods
+    expect(signer).toBe(defaultSigner);
+    expect(signer).toHaveProperty("getAddress");
+    expect(signer).toHaveProperty("getFullViewingKey");
+    expect(signer).toHaveProperty("splitTransaction");
   });
 
-  it("rejects non-DMK transports (e.g. legacy hw-transport)", () => {
-    expect(() => adapter.createSigner!({}, currency)).toThrow(/Zcash requires DMK transport/);
-    expect(() => adapter.createSigner!({ dmk: {} }, currency)).toThrow(
-      /Zcash requires DMK transport/,
-    );
+  it("returns undefined for non-DMK transports (falls through to standard Btc)", () => {
+    const defaultSigner = {} as BitcoinSigner;
+    expect(adapter.createSigner!({}, currency, defaultSigner)).toBeUndefined();
+    expect(adapter.createSigner!({ dmk: {} }, currency, defaultSigner)).toBeUndefined();
     // sessionId must be a string
-    expect(() => adapter.createSigner!({ dmk: {}, sessionId: 123 }, currency)).toThrow(
-      /Zcash requires DMK transport/,
-    );
+    expect(
+      adapter.createSigner!({ dmk: {}, sessionId: 123 }, currency, defaultSigner),
+    ).toBeUndefined();
   });
 });
 

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/index.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/index.ts
@@ -152,11 +152,17 @@ const zcashChainAdapter: ChainAdapter = {
     });
   },
 
-  createSigner(transport, _currency) {
-    if (!isDmkTransport(transport)) {
-      throw new Error("Zcash requires DMK transport");
-    }
-    return new DmkSignerZcash(transport.dmk, transport.sessionId);
+  createSigner(transport, _currency, defaultSigner) {
+    if (!isDmkTransport(transport)) return undefined;
+
+    // Augment the default BitcoinSigner with DmkSignerZcash methods.
+    // This gives chain adapter overrides (getAddress, getWalletXpub, getFullViewingKey)
+    // access to the DMK signer, while signOperation keeps using BitcoinSigner methods from Btc.
+    const dmk = new DmkSignerZcash(transport.dmk, transport.sessionId);
+    return Object.assign(defaultSigner, {
+      getAddress: dmk.getAddress.bind(dmk),
+      getFullViewingKey: dmk.getFullViewingKey.bind(dmk),
+    });
   },
 };
 

--- a/libs/ledger-live-common/src/families/bitcoin/setup.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/setup.ts
@@ -6,7 +6,7 @@ import { Bridge } from "@ledgerhq/types-live";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import Btc from "@ledgerhq/hw-app-btc";
 import { createBridges } from "@ledgerhq/coin-bitcoin/bridge/js";
-import type { SignerContext } from "@ledgerhq/coin-bitcoin/signer";
+import type { BitcoinSigner, SignerContext } from "@ledgerhq/coin-bitcoin/signer";
 import makeCliTools from "@ledgerhq/coin-bitcoin/cli-transaction";
 import bitcoinResolver from "@ledgerhq/coin-bitcoin/hw-getAddress";
 import { signMessage } from "@ledgerhq/coin-bitcoin/hw-signMessage";
@@ -19,17 +19,16 @@ import { getCurrencyConfiguration } from "../../config";
 import { BitcoinConfigInfo } from "@ledgerhq/coin-bitcoin/config";
 import { SignMessage } from "../../hw/signMessage/types";
 
-const createSigner = (transport: Transport, currency: CryptoCurrency): Btc => {
+const createSigner = (transport: Transport, currency: CryptoCurrency): BitcoinSigner => {
+  const btc = new Btc({ transport, currency: currency.id });
   const adapter = getChainAdapter(currency.id);
-  const custom = adapter.createSigner?.(transport, currency);
-  if (custom) return custom as unknown as Btc;
-  return new Btc({ transport, currency: currency.id });
+  return adapter.createSigner?.(transport, currency, btc) ?? btc;
 };
 
 const signerContext: SignerContext = <T>(
   deviceId: string,
   crypto: CryptoCurrency,
-  fn: (signer: Btc) => Promise<T>,
+  fn: (signer: BitcoinSigner) => Promise<T>,
 ): Promise<T> =>
   firstValueFrom(
     withDevice(deviceId)((transport: Transport) => from(fn(createSigner(transport, crypto)))),


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- Updated unit tests for createSigner composition pattern -->
- [x] **Impact of the changes:**
  - Zcash transparent send flow (was crashing, now works)
  - Zcash shielded sync / UFVK export (unchanged, still uses DMK overlay)
  - Other Bitcoin-family coins (no impact, chain adapter falls through to default)

### 📝 Description

**Bug:** Sending a transparent ZCash transaction crashes with `btc.splitTransaction is not a function`.

**Root cause:** The Zcash chain adapter's `createSigner` returned a raw `DmkSignerZcash` instance which does not implement the `BitcoinSigner` interface (`splitTransaction`, `createPaymentTransaction`). When the `signOperation` falls back to the standard Bitcoin legacy path (PCZT not yet implemented), it calls `signer.splitTransaction()` on the DMK signer and crashes.

**Fix:** `createSigner` now receives the default hw-app-btc signer as a `defaultSigner` parameter and augments it with DMK-specific methods (`getAddress`, `getFullViewingKey`) via `Object.assign`. This preserves all `BitcoinSigner` methods needed by the legacy signing path while exposing DMK capabilities for address resolution, xpub derivation, and viewing key export.

Additionally, `setup.ts` now uses `BitcoinSigner` throughout instead of casting to `Btc`, and the `ChainAdapter.createSigner` interface is properly typed.

### ❓ Context

- **JIRA or GitHub link**: LIVE-30736