### PR TITLE
[LWDM] fix(common): fix topping up account failing due to payload data excee…

### DIFF
--- a/.changeset/shiny-comics-sleep.md
+++ b/.changeset/shiny-comics-sleep.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-common": minor
+"live-mobile": minor
+---
+
+Fix: Topping up account fails - data length exceed 256 bytes limit

--- a/libs/ledger-live-common/src/exchange/platform/transfer/completeExchange.ts
+++ b/libs/ledger-live-common/src/exchange/platform/transfer/completeExchange.ts
@@ -238,8 +238,10 @@ function convertSignature(signature: string, exchangeType: ExchangeTypes): Buffe
 }
 
 /**
- * FUND: firmware expects the raw base64url string bytes and will
- * base64-decode them internally before running pb_decode (see process_transaction.c).
+ * All legacy paths (Sell and Fund) receive `binaryPayload` as a hex-encoded string.
+ * For Fund: hex-decoding yields the raw base64url string bytes that the firmware
+ * then base64-decodes internally before running pb_decode (see process_transaction.c).
+ * For Sell: hex-decoding yields the raw protobuf bytes directly.
  * @param transactionType
  * @param binaryPayload
  * @returns
@@ -249,23 +251,10 @@ function buildProcessTransactionPayload(
   binaryPayload: string,
 ): { payload: Buffer; format: PayloadSignatureComputedFormat } {
   if (isExchangeTypeNg(transactionType)) {
-    return {
-      payload: Buffer.from("." + binaryPayload),
-      format: "jws",
-    };
+    return { payload: Buffer.from("." + binaryPayload), format: "jws" };
   }
 
-  if (transactionType === ExchangeTypes.Fund) {
-    return {
-      payload: Buffer.from(binaryPayload),
-      format: "raw",
-    };
-  }
-
-  return {
-    payload: Buffer.from(binaryPayload, "hex"),
-    format: "raw",
-  };
+  return { payload: Buffer.from(binaryPayload, "hex"), format: "raw" };
 }
 
 export default completeExchange;


### PR DESCRIPTION
…ding 256 bytes

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Fixes a regression where Fund (top-up) transactions were failing when the transaction payload exceeded 256 bytes
The root cause was that the Fund path in buildProcessTransactionPayload was passing the raw binaryPayload string directly as bytes (Buffer.from(binaryPayload)), instead of hex-decoding it first like the Sell path did
Both legacy paths (Fund and Sell) now correctly hex-decode the binaryPayload before forwarding it to the firmware

<img width="1547" height="893" alt="Screenshot 2026-05-19 at 14 56 05" src="https://github.com/user-attachments/assets/dfef7959-6ae3-46a6-9ec0-8e8087bb0d59" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-30790](https://ledgerhq.atlassian.net/browse/LIVE-30790)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-30790]: https://ledgerhq.atlassian.net/browse/LIVE-30790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ