### PR TITLE
[LWD] feat(desktop): add neutral PnL trend and simplify trend icon resolution

### DIFF
--- a/.changeset/tricky-seahorses-raise.md
+++ b/.changeset/tricky-seahorses-raise.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add a neutral PnL trend display when the unrealised return is exactly zero. The card now shows a disabled (greyed) up arrow instead of a green one for zero balances. Internally, the trend resolution is consolidated into a single `getTrendIcon` helper in the PnL builder layer, and the `PnLCard` View now receives a precomputed `trendIcon` prop, keeping it fully presentational.

--- a/apps/ledger-live-desktop/src/mvvm/features/PnL/builders/__tests__/buildUnrealisedReturnCard.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PnL/builders/__tests__/buildUnrealisedReturnCard.test.ts
@@ -2,6 +2,7 @@ import { BigNumber } from "bignumber.js";
 import type { TFunction } from "i18next";
 import type { PnLCardProps } from "../../components/PnLCard/types";
 import { buildUnrealisedReturnCard } from "../buildUnrealisedReturnCard";
+import { getTrendIcon } from "../trend";
 
 const fakeT = ((key: string) => key) as unknown as TFunction;
 
@@ -47,15 +48,11 @@ describe("buildUnrealisedReturnCard", () => {
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
-  describe("trend", () => {
-    it.each([
-      [new BigNumber(10), "up"],
-      [new BigNumber(-10), "down"],
-      [new BigNumber(0), "up"],
-    ] as const)("is %s for %s", (unrealisedPnL, expected) => {
-      const card = buildUnrealisedReturnCard(makeInput({ unrealisedPnL }));
-      assertInteractive(card);
-      expect(card.trend).toBe(expected);
-    });
+  it("wires trendIcon through getTrendIcon", () => {
+    const unrealisedPnL = new BigNumber(-7);
+    const card = buildUnrealisedReturnCard(makeInput({ unrealisedPnL }));
+
+    assertInteractive(card);
+    expect(card.trendIcon).toEqual(getTrendIcon(unrealisedPnL));
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/PnL/builders/__tests__/trend.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PnL/builders/__tests__/trend.test.ts
@@ -1,0 +1,13 @@
+import { BigNumber } from "bignumber.js";
+import { TriangleUp, TriangleDown } from "@ledgerhq/lumen-ui-react/symbols";
+import { getTrendIcon } from "../trend";
+
+describe("getTrendIcon", () => {
+  it.each([
+    [new BigNumber(10), { Icon: TriangleUp, className: "text-success" }],
+    [new BigNumber(-10), { Icon: TriangleDown, className: "text-error" }],
+    [new BigNumber(0), { Icon: TriangleUp, className: "text-disabled" }],
+  ] as const)("maps %s to the expected icon", (value, expected) => {
+    expect(getTrendIcon(value)).toEqual(expected);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/PnL/builders/buildUnrealisedReturnCard.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PnL/builders/buildUnrealisedReturnCard.ts
@@ -2,6 +2,7 @@ import { BigNumber } from "bignumber.js";
 import type { TFunction } from "i18next";
 import type { PnLCardProps } from "../components/PnLCard/types";
 import type { PnlNamespace } from "../types";
+import { getTrendIcon } from "./trend";
 
 export type BuildUnrealisedReturnCardInput = {
   namespace: PnlNamespace;
@@ -23,7 +24,7 @@ export function buildUnrealisedReturnCard({
     title: t(`${namespace}.return.title`),
     value: formatFiat(unrealisedPnL),
     type: "interactive",
-    trend: unrealisedPnL.isNegative() ? "down" : "up",
+    trendIcon: getTrendIcon(unrealisedPnL),
     onClick,
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/PnL/builders/trend.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PnL/builders/trend.ts
@@ -1,0 +1,13 @@
+import type { BigNumber } from "bignumber.js";
+import { TriangleUp, TriangleDown } from "@ledgerhq/lumen-ui-react/symbols";
+import type { TrendIconConfig } from "../components/PnLCard/types";
+
+const UP: TrendIconConfig = { Icon: TriangleUp, className: "text-success" };
+const DOWN: TrendIconConfig = { Icon: TriangleDown, className: "text-error" };
+const NEUTRAL: TrendIconConfig = { Icon: TriangleUp, className: "text-disabled" };
+
+export function getTrendIcon(value: BigNumber): TrendIconConfig {
+  if (value.isZero()) return NEUTRAL;
+  if (value.isNegative()) return DOWN;
+  return UP;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnLCard/__tests__/index.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnLCard/__tests__/index.test.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { TriangleUp, TriangleDown } from "@ledgerhq/lumen-ui-react/symbols";
 import { render, screen, waitFor } from "tests/testSetup";
 import { PnLCard } from "../index";
 
@@ -11,6 +12,10 @@ const TITLE = "Unrealised return";
 const VALUE = "243.32";
 const TOOLTIP = "This is a tooltip";
 
+const UP_ICON = { Icon: TriangleUp, className: "text-success" } as const;
+const DOWN_ICON = { Icon: TriangleDown, className: "text-error" } as const;
+const NEUTRAL_ICON = { Icon: TriangleUp, className: "text-disabled" } as const;
+
 const makeInteractiveProps = (
   overrides: Partial<Omit<InteractiveProps, "type">> = {},
 ): InteractiveProps => ({
@@ -18,7 +23,7 @@ const makeInteractiveProps = (
   id: ID,
   title: TITLE,
   value: VALUE,
-  trend: "up",
+  trendIcon: UP_ICON,
   onClick: jest.fn(),
   ...overrides,
 });
@@ -60,18 +65,17 @@ describe("PnLCard", () => {
       expect(onClick).toHaveBeenCalledTimes(1);
     });
 
-    it("should render an up arrow when trend is 'up'", () => {
-      const { container } = render(<PnLCard {...makeInteractiveProps({ trend: "up" })} />);
+    it.each([
+      [UP_ICON, ".text-success", [".text-error", ".text-disabled"]],
+      [DOWN_ICON, ".text-error", [".text-success", ".text-disabled"]],
+      [NEUTRAL_ICON, ".text-disabled", [".text-success", ".text-error"]],
+    ] as const)("renders the trend icon with %o", (trendIcon, expectedClass, otherClasses) => {
+      const { container } = render(<PnLCard {...makeInteractiveProps({ trendIcon })} />);
 
-      expect(container.querySelector(".text-success")).toBeInTheDocument();
-      expect(container.querySelector(".text-error")).not.toBeInTheDocument();
-    });
-
-    it("should render a down arrow when trend is 'down'", () => {
-      const { container } = render(<PnLCard {...makeInteractiveProps({ trend: "down" })} />);
-
-      expect(container.querySelector(".text-error")).toBeInTheDocument();
-      expect(container.querySelector(".text-success")).not.toBeInTheDocument();
+      expect(container.querySelector(expectedClass)).toBeInTheDocument();
+      otherClasses.forEach(cls => {
+        expect(container.querySelector(cls)).not.toBeInTheDocument();
+      });
     });
 
     it("should not render any tooltip", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnLCard/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnLCard/index.tsx
@@ -11,12 +11,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@ledgerhq/lumen-ui-react";
-import {
-  ChevronRight,
-  Information,
-  TriangleUp,
-  TriangleDown,
-} from "@ledgerhq/lumen-ui-react/symbols";
+import { ChevronRight, Information } from "@ledgerhq/lumen-ui-react/symbols";
 import type { PnLCardProps } from "./types";
 
 export const PnLCard = (props: PnLCardProps) => {
@@ -46,11 +41,7 @@ export const PnLCard = (props: PnLCardProps) => {
               <div className="flex items-center align-center gap-4">
                 {type === "interactive" && (
                   <span className="text-muted body-3">
-                    {props.trend === "up" ? (
-                      <TriangleUp size={16} className="text-success" />
-                    ) : (
-                      <TriangleDown size={16} className="text-error" />
-                    )}
+                    <props.trendIcon.Icon size={16} className={props.trendIcon.className} />
                   </span>
                 )}
                 <span className="text-base body-2-semi-bold">{value}</span>

--- a/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnLCard/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnLCard/types.ts
@@ -1,6 +1,13 @@
+import type { TriangleUp, TriangleDown } from "@ledgerhq/lumen-ui-react/symbols";
+
+type TrendIconConfig = {
+  Icon: typeof TriangleUp | typeof TriangleDown;
+  className: string;
+};
+
 type InteractiveCard = {
   type: "interactive";
-  trend: "up" | "down";
+  trendIcon: TrendIconConfig;
   onClick: () => void;
 };
 
@@ -15,4 +22,4 @@ type PnLCardProps = {
   value: string;
 } & (InteractiveCard | InfoCard);
 
-export type { InteractiveCard, InfoCard, PnLCardProps };
+export type { InteractiveCard, InfoCard, PnLCardProps, TrendIconConfig };


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - PnLCard rendering on portfolio and asset detail when unrealised return is exactly zero (now shows a disabled-coloured up arrow instead of a green one).
      - Internal refactor of the PnL builder layer: trend resolution consolidated into `getTrendIcon(BigNumber)`; `PnLCard` View becomes fully presentational.

### Description

Previously the PnL card surfaced a green up arrow (`text-success`) even when the unrealised return was exactly zero, because the trend was derived as `isNegative() ? "down" : "up"`. Zero is not negative, so a flat balance was misrepresented as a positive trend.

This PR adds a third "neutral" trend state — `TriangleUp` rendered with `text-disabled` — used when `unrealisedPnL.isZero()`. Along the way, the trend resolution is collapsed into a single `getTrendIcon(BigNumber): TrendIconConfig` helper in the builder layer (upstream view model), and `PnLCard` now receives a precomputed `trendIcon` prop instead of a semantic `trend` string it had to interpret. The View is fully dumb.

<img width="482" height="119" alt="Screenshot 2026-05-19 at 15 19 25" src="https://github.com/user-attachments/assets/825a00ff-28fd-44f5-807a-daa4516f4abb" />


### Context

- **JIRA or GitHub link**: [LIVE-30838](https://ledgerhq.atlassian.net/browse/LIVE-30838)

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30838]: https://ledgerhq.atlassian.net/browse/LIVE-30838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ