### PR TITLE
[LWDM] feat(wallet): surface dropped unsupported accounts as non-imported

### DIFF
--- a/.changeset/surface-unsupported-as-non-imported.md
+++ b/.changeset/surface-unsupported-as-non-imported.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+"@ledgerhq/live-wallet": patch
+---
+
+When accounts are dropped at load because their currency is unsupported by the current build, surface them as non-imported entries in the wallet store. If the user has wallet-sync active, the next sync cycle naturally cleans up any entry whose descriptor is no longer in the cloud; otherwise entries stay parked invisibly. A new `addNonImportedAccounts` action merges new entries without overwriting existing ones. No UI change in this PR — surfacing comes next.

--- a/apps/ledger-live-desktop/src/renderer/actions/accounts.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/accounts.test.ts
@@ -1,9 +1,9 @@
 import type { Account, AccountUserData } from "@ledgerhq/types-live";
-import { checkAccountSupported } from "@ledgerhq/live-common/account/index";
+import { checkAccountSupported } from "@ledgerhq/ledger-wallet-framework/account/support";
 import { initAccounts } from "./accounts";
 
-jest.mock("@ledgerhq/live-common/account/index", () => ({
-  ...jest.requireActual("@ledgerhq/live-common/account/index"),
+jest.mock("@ledgerhq/ledger-wallet-framework/account/support", () => ({
+  ...jest.requireActual("@ledgerhq/ledger-wallet-framework/account/support"),
   checkAccountSupported: jest.fn(),
 }));
 
@@ -20,6 +20,20 @@ function fakeTuple(id: string, currencyId: string): [Account, AccountUserData] {
   return [account, userData];
 }
 
+function runThunk(thunk: ReturnType<typeof initAccounts>) {
+  const dispatched: { type: string; payload?: unknown }[] = [];
+  const dispatch = jest.fn((action: { type: string; payload?: unknown }) => {
+    dispatched.push(action);
+  });
+  // ThunkAction signature: (dispatch, getState, extra) => R
+  (thunk as unknown as (d: typeof dispatch, g: unknown, e: unknown) => void)(
+    dispatch,
+    jest.fn(),
+    undefined,
+  );
+  return dispatched;
+}
+
 describe("initAccounts", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -30,23 +44,70 @@ describe("initAccounts", () => {
       a.currency.id === "bitcoin" ? null : new Error("currency not supported"),
     );
 
-    const action = initAccounts([
-      fakeTuple("btc-1", "bitcoin"),
-      fakeTuple("eth-1", "ethereum"),
-      fakeTuple("btc-2", "bitcoin"),
-    ]);
+    const dispatched = runThunk(
+      initAccounts([
+        fakeTuple("btc-1", "bitcoin"),
+        fakeTuple("eth-1", "ethereum"),
+        fakeTuple("btc-2", "bitcoin"),
+      ]),
+    );
 
-    expect(action.type).toBe("INIT_ACCOUNTS");
-    expect(action.payload.accounts.map(a => a.id)).toEqual(["btc-1", "btc-2"]);
-    expect(action.payload.accountsUserData.map(u => u.id)).toEqual(["btc-1", "btc-2"]);
+    const init = dispatched.find(a => a.type === "INIT_ACCOUNTS") as
+      | { type: string; payload: { accounts: Account[]; accountsUserData: AccountUserData[] } }
+      | undefined;
+    expect(init).toBeDefined();
+    expect(init!.payload.accounts.map(a => a.id)).toEqual(["btc-1", "btc-2"]);
+    expect(init!.payload.accountsUserData.map(u => u.id)).toEqual(["btc-1", "btc-2"]);
   });
 
   it("keeps all accounts when every currency is supported", () => {
     mockCheckAccountSupported.mockReturnValue(null);
 
-    const action = initAccounts([fakeTuple("btc-1", "bitcoin"), fakeTuple("eth-1", "ethereum")]);
+    const dispatched = runThunk(
+      initAccounts([fakeTuple("btc-1", "bitcoin"), fakeTuple("eth-1", "ethereum")]),
+    );
 
-    expect(action.payload.accounts.map(a => a.id)).toEqual(["btc-1", "eth-1"]);
+    const init = dispatched.find(a => a.type === "INIT_ACCOUNTS") as
+      | { type: string; payload: { accounts: Account[] } }
+      | undefined;
+    expect(init!.payload.accounts.map(a => a.id)).toEqual(["btc-1", "eth-1"]);
+  });
+
+  it("emits ADD_NON_IMPORTED_ACCOUNTS with dropped descriptors and their error", () => {
+    mockCheckAccountSupported.mockImplementation((a: { currency: { id: string } }) => {
+      if (a.currency.id === "bitcoin") return null;
+      const error = new Error(`currency ${a.currency.id} not supported`);
+      error.name = "CurrencyNotSupported";
+      return error;
+    });
+
+    const dispatched = runThunk(
+      initAccounts([
+        fakeTuple("btc-1", "bitcoin"),
+        fakeTuple("eth-1", "ethereum"),
+        fakeTuple("sol-1", "solana"),
+      ]),
+    );
+
+    const added = dispatched.find(a => a.type === "ADD_NON_IMPORTED_ACCOUNTS") as
+      | { type: string; payload: { id: string; error: { name: string; message: string } }[] }
+      | undefined;
+    expect(added).toBeDefined();
+    expect(added!.payload.map(p => p.id)).toEqual(["eth-1", "sol-1"]);
+    expect(added!.payload[0].error).toEqual({
+      name: "CurrencyNotSupported",
+      message: "currency ethereum not supported",
+    });
+    expect(added!.payload[1].error).toEqual({
+      name: "CurrencyNotSupported",
+      message: "currency solana not supported",
+    });
+  });
+
+  it("does not emit ADD_NON_IMPORTED_ACCOUNTS when nothing is dropped", () => {
+    mockCheckAccountSupported.mockReturnValue(null);
+    const dispatched = runThunk(initAccounts([fakeTuple("btc-1", "bitcoin")]));
+    expect(dispatched.some(a => a.type === "ADD_NON_IMPORTED_ACCOUNTS")).toBe(false);
   });
 
   it("drops accounts on any non-currency error (e.g. unsupported derivation mode)", () => {
@@ -54,11 +115,13 @@ describe("initAccounts", () => {
       a.id === "btc-segwit" ? null : new Error("derivation mode not supported"),
     );
 
-    const action = initAccounts([
-      fakeTuple("btc-segwit", "bitcoin"),
-      fakeTuple("btc-legacy", "bitcoin"),
-    ]);
+    const dispatched = runThunk(
+      initAccounts([fakeTuple("btc-segwit", "bitcoin"), fakeTuple("btc-legacy", "bitcoin")]),
+    );
 
-    expect(action.payload.accounts.map(a => a.id)).toEqual(["btc-segwit"]);
+    const init = dispatched.find(a => a.type === "INIT_ACCOUNTS") as
+      | { type: string; payload: { accounts: Account[] } }
+      | undefined;
+    expect(init!.payload.accounts.map(a => a.id)).toEqual(["btc-segwit"]);
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/actions/accounts.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/accounts.ts
@@ -4,7 +4,7 @@ import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { getKey } from "~/renderer/storage";
 import { PasswordIncorrectError } from "@ledgerhq/errors";
 import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
-import { checkAccountSupported } from "@ledgerhq/live-common/account/index";
+import { addNonImportedAccounts, splitSupportedAccounts } from "@ledgerhq/live-wallet/store";
 import { accountsSelector } from "~/renderer/reducers/accounts";
 import logger from "~/renderer/logger";
 import { ThunkResult } from "./types";
@@ -14,25 +14,24 @@ export const removeAccount = (payload: Account) => ({
   payload,
 });
 
-export const initAccounts = (data: [Account, AccountUserData][]) => {
-  const supported = data.filter(([account]) => {
-    const error = checkAccountSupported(account);
-    if (!error) return true;
-    logger.warn(`dropping account ${account.id}: ${error.message}`);
-    return false;
-  });
-  const accounts = supported.map(([account]) => account);
-  const accountsUserData = supported
-    .filter(([account, userData]) => userData.name !== getDefaultAccountName(account))
-    .map(([, userData]) => userData);
-  return {
-    type: "INIT_ACCOUNTS",
-    payload: {
-      accounts,
-      accountsUserData,
-    },
+export const initAccounts =
+  (data: [Account, AccountUserData][]): ThunkResult =>
+  (dispatch, _getState, _extra) => {
+    const { supported, dropped } = splitSupportedAccounts(data, (id, message) =>
+      logger.warn(`dropping account ${id}: ${message}`),
+    );
+    const accounts = supported.map(([account]) => account);
+    const accountsUserData = supported
+      .filter(([account, userData]) => userData.name !== getDefaultAccountName(account))
+      .map(([, userData]) => userData);
+    dispatch({
+      type: "INIT_ACCOUNTS",
+      payload: { accounts, accountsUserData },
+    });
+    if (dropped.length > 0) {
+      dispatch(addNonImportedAccounts(dropped));
+    }
   };
-};
 
 export const replaceAccounts = (accounts: Account[]) => ({
   type: "REPLACE_ACCOUNTS",

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -208,8 +208,7 @@ async function init() {
   );
   const accountData = await getKey("app", "accounts", []);
   if (accountData) {
-    const e = initAccounts(accountData);
-    store.dispatch(e);
+    dispatch(initAccounts(accountData));
   } else {
     // if accountData is falsy, it's a lock case, we need to globally decrypted the app data, we use app.accounts as general safe guard for possible other app.* encrypted fields
     store.dispatch(lock());

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/utils.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/utils.ts
@@ -9,6 +9,7 @@ import {
   accountUserDataExportSelector,
 } from "@ledgerhq/live-wallet/store";
 import { getKey } from "~/renderer/storage";
+import type { AppDispatch } from "~/state-manager/configureStore";
 import { Account, AccountUserData } from "@ledgerhq/types-live";
 import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { v4 as uuidv4 } from "uuid";
@@ -53,8 +54,7 @@ export const injectMockAccounts = async (
   const store = window.ledger.store;
 
   const newAccountData = accountData?.concat(accounts);
-  const e = initAccounts(newAccountData || []);
-  store.dispatch(e);
+  (store.dispatch as AppDispatch)(initAccounts(newAccountData || []));
 };
 
 export const generateRandomAccounts = (count: number): [Account, AccountUserData][] => {

--- a/apps/ledger-live-mobile/e2e/bridge/client.ts
+++ b/apps/ledger-live-mobile/e2e/bridge/client.ts
@@ -99,7 +99,9 @@ async function onMessage(event: WebSocketMessageEvent) {
         acceptGeneralTerms(store);
         break;
       case "importAccounts": {
-        store.dispatch(await importAccountsRaw({ active: msg.payload }));
+        for (const action of await importAccountsRaw({ active: msg.payload })) {
+          store.dispatch(action);
+        }
         break;
       }
       case "mockDeviceEvent": {

--- a/apps/ledger-live-mobile/src/actions/accounts.test.ts
+++ b/apps/ledger-live-mobile/src/actions/accounts.test.ts
@@ -1,10 +1,10 @@
 import type { Account, AccountRaw, AccountUserData } from "@ledgerhq/types-live";
-import { checkAccountSupported } from "@ledgerhq/live-common/account/index";
+import { checkAccountSupported } from "@ledgerhq/ledger-wallet-framework/account/support";
 import accountModel from "../logic/accountModel";
 import { importStore } from "./accounts";
 
-jest.mock("@ledgerhq/live-common/account/index", () => ({
-  ...jest.requireActual("@ledgerhq/live-common/account/index"),
+jest.mock("@ledgerhq/ledger-wallet-framework/account/support", () => ({
+  ...jest.requireActual("@ledgerhq/ledger-wallet-framework/account/support"),
   checkAccountSupported: jest.fn(),
 }));
 
@@ -27,6 +27,10 @@ function fakeTuple(id: string, currencyId: string): [Account, AccountUserData] {
   return [account, userData];
 }
 
+async function dispatchedFrom(rawAccounts: { active: { data: AccountRaw }[] }) {
+  return (await importStore(rawAccounts)) as { type: string; payload?: unknown }[];
+}
+
 describe("importStore", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -41,7 +45,7 @@ describe("importStore", () => {
       .mockResolvedValueOnce(fakeTuple("eth-1", "ethereum"))
       .mockResolvedValueOnce(fakeTuple("btc-2", "bitcoin"));
 
-    const action = await importStore({
+    const dispatched = await dispatchedFrom({
       active: [
         { data: { id: "btc-1" } as AccountRaw },
         { data: { id: "eth-1" } as AccountRaw },
@@ -49,9 +53,12 @@ describe("importStore", () => {
       ],
     });
 
-    expect(action.type).toBe("INIT_ACCOUNTS");
-    expect(action.payload.accounts.map((a: Account) => a.id)).toEqual(["btc-1", "btc-2"]);
-    expect(action.payload.accountsUserData.map((u: AccountUserData) => u.id)).toEqual([
+    const init = dispatched.find(a => a.type === "INIT_ACCOUNTS") as
+      | { type: string; payload: { accounts: Account[]; accountsUserData: AccountUserData[] } }
+      | undefined;
+    expect(init).toBeDefined();
+    expect(init!.payload.accounts.map((a: Account) => a.id)).toEqual(["btc-1", "btc-2"]);
+    expect(init!.payload.accountsUserData.map((u: AccountUserData) => u.id)).toEqual([
       "btc-1",
       "btc-2",
     ]);
@@ -63,11 +70,60 @@ describe("importStore", () => {
       .mockResolvedValueOnce(fakeTuple("btc-1", "bitcoin"))
       .mockResolvedValueOnce(fakeTuple("eth-1", "ethereum"));
 
-    const action = await importStore({
+    const dispatched = await dispatchedFrom({
       active: [{ data: { id: "btc-1" } as AccountRaw }, { data: { id: "eth-1" } as AccountRaw }],
     });
 
-    expect(action.payload.accounts.map((a: Account) => a.id)).toEqual(["btc-1", "eth-1"]);
+    const init = dispatched.find(a => a.type === "INIT_ACCOUNTS") as
+      | { type: string; payload: { accounts: Account[] } }
+      | undefined;
+    expect(init!.payload.accounts.map((a: Account) => a.id)).toEqual(["btc-1", "eth-1"]);
+  });
+
+  it("emits ADD_NON_IMPORTED_ACCOUNTS with dropped descriptors and their error", async () => {
+    mockCheckAccountSupported.mockImplementation((a: { currency: { id: string } }) => {
+      if (a.currency.id === "bitcoin") return null;
+      const error = new Error(`currency ${a.currency.id} not supported`);
+      error.name = "CurrencyNotSupported";
+      return error;
+    });
+    mockDecode
+      .mockResolvedValueOnce(fakeTuple("btc-1", "bitcoin"))
+      .mockResolvedValueOnce(fakeTuple("eth-1", "ethereum"))
+      .mockResolvedValueOnce(fakeTuple("sol-1", "solana"));
+
+    const dispatched = await dispatchedFrom({
+      active: [
+        { data: { id: "btc-1" } as AccountRaw },
+        { data: { id: "eth-1" } as AccountRaw },
+        { data: { id: "sol-1" } as AccountRaw },
+      ],
+    });
+
+    const added = dispatched.find(a => a.type === "ADD_NON_IMPORTED_ACCOUNTS") as
+      | { type: string; payload: { id: string; error: { name: string; message: string } }[] }
+      | undefined;
+    expect(added).toBeDefined();
+    expect(added!.payload.map(p => p.id)).toEqual(["eth-1", "sol-1"]);
+    expect(added!.payload[0].error).toEqual({
+      name: "CurrencyNotSupported",
+      message: "currency ethereum not supported",
+    });
+    expect(added!.payload[1].error).toEqual({
+      name: "CurrencyNotSupported",
+      message: "currency solana not supported",
+    });
+  });
+
+  it("does not emit ADD_NON_IMPORTED_ACCOUNTS when nothing is dropped", async () => {
+    mockCheckAccountSupported.mockReturnValue(null);
+    mockDecode.mockResolvedValueOnce(fakeTuple("btc-1", "bitcoin"));
+
+    const dispatched = await dispatchedFrom({
+      active: [{ data: { id: "btc-1" } as AccountRaw }],
+    });
+
+    expect(dispatched.some(a => a.type === "ADD_NON_IMPORTED_ACCOUNTS")).toBe(false);
   });
 
   it("drops accounts on any non-currency error (e.g. unsupported derivation mode)", async () => {
@@ -78,13 +134,16 @@ describe("importStore", () => {
       .mockResolvedValueOnce(fakeTuple("btc-segwit", "bitcoin"))
       .mockResolvedValueOnce(fakeTuple("btc-legacy", "bitcoin"));
 
-    const action = await importStore({
+    const dispatched = await dispatchedFrom({
       active: [
         { data: { id: "btc-segwit" } as AccountRaw },
         { data: { id: "btc-legacy" } as AccountRaw },
       ],
     });
 
-    expect(action.payload.accounts.map((a: Account) => a.id)).toEqual(["btc-segwit"]);
+    const init = dispatched.find(a => a.type === "INIT_ACCOUNTS") as
+      | { type: string; payload: { accounts: Account[] } }
+      | undefined;
+    expect(init!.payload.accounts.map((a: Account) => a.id)).toEqual(["btc-segwit"]);
   });
 });

--- a/apps/ledger-live-mobile/src/actions/accounts.ts
+++ b/apps/ledger-live-mobile/src/actions/accounts.ts
@@ -1,5 +1,6 @@
 import type { Account, AccountRaw, AccountUserData } from "@ledgerhq/types-live";
 import { createAction } from "redux-actions";
+import { UnknownAction } from "redux";
 import accountModel from "../logic/accountModel";
 import type {
   AccountsDeleteAccountPayload,
@@ -9,13 +10,18 @@ import type {
 } from "./types";
 import { AccountsActionTypes } from "./types";
 import logger from "../logger";
-import { initAccounts } from "@ledgerhq/live-wallet/store";
+import {
+  addNonImportedAccounts,
+  initAccounts,
+  splitSupportedAccounts,
+} from "@ledgerhq/live-wallet/store";
 import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
-import { checkAccountSupported } from "@ledgerhq/live-common/account/index";
 
 const version = 0; // FIXME this needs to come from user data
 
-export const importStore = async (rawAccounts: { active: { data: AccountRaw }[] }) => {
+export const importStore = async (
+  rawAccounts: { active: { data: AccountRaw }[] },
+): Promise<UnknownAction[]> => {
   const decodePromises: Array<Promise<[Account, AccountUserData] | null>> = [];
 
   if (rawAccounts && Array.isArray(rawAccounts.active)) {
@@ -36,18 +42,20 @@ export const importStore = async (rawAccounts: { active: { data: AccountRaw }[] 
     (tuple): tuple is [Account, AccountUserData] => tuple !== null,
   );
 
-  const supported = tuples.filter(([account]) => {
-    const error = checkAccountSupported(account);
-    if (!error) return true;
-    console.warn(`dropping account ${account.id}: ${error.message}`);
-    return false;
-  });
+  const { supported, dropped } = splitSupportedAccounts(tuples, (id, message) =>
+    console.warn(`dropping account ${id}: ${message}`),
+  );
 
   const accounts = supported.map(([account]) => account);
   const accountsUserData = supported
     .filter(([account, userData]) => userData.name !== getDefaultAccountName(account))
     .map(([, userData]) => userData);
-  return initAccounts(accounts, accountsUserData);
+
+  const actions: UnknownAction[] = [initAccounts(accounts, accountsUserData) as UnknownAction];
+  if (dropped.length > 0) {
+    actions.push(addNonImportedAccounts(dropped) as UnknownAction);
+  }
+  return actions;
 };
 export const reorderAccounts = createAction<AccountsReorderPayload>(
   AccountsActionTypes.REORDER_ACCOUNTS,

--- a/apps/ledger-live-mobile/src/context/LedgerStore.tsx
+++ b/apps/ledger-live-mobile/src/context/LedgerStore.tsx
@@ -154,7 +154,9 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
 
       // Handle account import with error recovery for async issues
       try {
-        store.dispatch(await importAccountsRaw(accountsData));
+        for (const action of await importAccountsRaw(accountsData)) {
+          store.dispatch(action);
+        }
       } catch (error) {
         // eslint-disable-next-line no-console
         console.error("Failed to import accounts during initialization:", error);

--- a/libs/live-wallet/src/store.test.ts
+++ b/libs/live-wallet/src/store.test.ts
@@ -4,6 +4,7 @@ import {
   accountNameWithDefaultSelector,
   accountRawToAccountUserData,
   accountUserDataExportSelector,
+  addNonImportedAccounts,
   exportWalletState,
   handlers,
   importWalletState,
@@ -445,5 +446,53 @@ describe("Wallet store", () => {
     expect(walletStateExportShouldDiffer(initialState, result)).toBe(true);
     expect(walletStateExportShouldDiffer(initialState, initialState)).toBe(false);
     expect(walletStateExportShouldDiffer(result, result)).toBe(false);
+  });
+
+  describe("ADD_NON_IMPORTED_ACCOUNTS", () => {
+    const makeInfo = (id: string, errorName = "CurrencyNotSupported") => ({
+      id,
+      attempts: 0,
+      attemptsLastTimestamp: 0,
+      error: { name: errorName, message: `error for ${id}` },
+    });
+
+    it("appends entries to an empty list", () => {
+      const a = makeInfo("a");
+      const b = makeInfo("b");
+      const result = handlers.ADD_NON_IMPORTED_ACCOUNTS(initialState, addNonImportedAccounts([a, b]));
+      expect(result.nonImportedAccountInfos).toEqual([a, b]);
+    });
+
+    it("merges with existing entries", () => {
+      const existing = makeInfo("a");
+      const fresh = makeInfo("b");
+      const state = { ...initialState, nonImportedAccountInfos: [existing] };
+      const result = handlers.ADD_NON_IMPORTED_ACCOUNTS(state, addNonImportedAccounts([fresh]));
+      expect(result.nonImportedAccountInfos).toEqual([existing, fresh]);
+    });
+
+    it("dedups by id and preserves the existing entry (does not overwrite)", () => {
+      const existing = { ...makeInfo("a"), attempts: 3, attemptsLastTimestamp: 12345 };
+      const incoming = makeInfo("a");
+      const state = { ...initialState, nonImportedAccountInfos: [existing] };
+      const result = handlers.ADD_NON_IMPORTED_ACCOUNTS(state, addNonImportedAccounts([incoming]));
+      expect(result.nonImportedAccountInfos).toEqual([existing]);
+    });
+
+    it("returns the same state when payload is empty", () => {
+      const state = { ...initialState, nonImportedAccountInfos: [makeInfo("a")] };
+      const result = handlers.ADD_NON_IMPORTED_ACCOUNTS(state, addNonImportedAccounts([]));
+      expect(result).toBe(state);
+    });
+
+    it("returns the same state when all payload ids already exist", () => {
+      const existing = makeInfo("a");
+      const state = { ...initialState, nonImportedAccountInfos: [existing] };
+      const result = handlers.ADD_NON_IMPORTED_ACCOUNTS(
+        state,
+        addNonImportedAccounts([makeInfo("a")]),
+      );
+      expect(result).toBe(state);
+    });
   });
 });

--- a/libs/live-wallet/src/store.ts
+++ b/libs/live-wallet/src/store.ts
@@ -13,8 +13,31 @@ import {
 import { getDefaultAccountName, getDefaultAccountNameForCurrencyIndex } from "./accountName";
 import { AddAccountsAction } from "./addAccounts";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { checkAccountSupported } from "@ledgerhq/ledger-wallet-framework/account/support";
 import { DistantState } from "./walletsync";
 import { NonImportedAccountInfo } from "./walletsync/modules/accounts";
+
+export type { NonImportedAccountInfo };
+
+export function splitSupportedAccounts(
+  tuples: [Account, AccountUserData][],
+  onDrop?: (id: string, message: string) => void,
+): { supported: [Account, AccountUserData][]; dropped: NonImportedAccountInfo[] } {
+  const dropped: NonImportedAccountInfo[] = [];
+  const supported = tuples.filter(([account]) => {
+    const error = checkAccountSupported(account);
+    if (!error) return true;
+    onDrop?.(account.id, error.message);
+    dropped.push({
+      id: account.id,
+      attempts: 0,
+      attemptsLastTimestamp: 0,
+      error: { name: error.name, message: error.message },
+    });
+    return false;
+  });
+  return { supported, dropped };
+}
 
 export type WSState = {
   data: DistantState | null;
@@ -62,6 +85,7 @@ export enum WalletHandlerType {
   WALLET_SYNC_UPDATE = "WALLET_SYNC_UPDATE",
   IMPORT_WALLET_SYNC = "IMPORT_WALLET_SYNC",
   SET_NON_IMPORTED_ACCOUNTS = "SET_NON_IMPORTED_ACCOUNTS",
+  ADD_NON_IMPORTED_ACCOUNTS = "ADD_NON_IMPORTED_ACCOUNTS",
   UPDATE_RECENT_ADDRESSES = "UPDATE_RECENT_ADDRESSES",
 }
 
@@ -77,6 +101,7 @@ export type HandlersPayloads = {
   };
   IMPORT_WALLET_SYNC: Partial<ExportedWalletState>;
   SET_NON_IMPORTED_ACCOUNTS: NonImportedAccountInfo[];
+  ADD_NON_IMPORTED_ACCOUNTS: NonImportedAccountInfo[];
   UPDATE_RECENT_ADDRESSES: RecentAddressesState;
 };
 
@@ -155,6 +180,19 @@ export const handlers: WalletHandlers = {
   SET_NON_IMPORTED_ACCOUNTS: (state, { payload }) => {
     return { ...state, nonImportedAccountInfos: payload };
   },
+  ADD_NON_IMPORTED_ACCOUNTS: (state, { payload }) => {
+    if (payload.length === 0) return state;
+    if (state.nonImportedAccountInfos.length === 0) {
+      return { ...state, nonImportedAccountInfos: payload };
+    }
+    const existingIds = new Set(state.nonImportedAccountInfos.map(n => n.id));
+    const toAdd = payload.filter(n => !existingIds.has(n.id));
+    if (toAdd.length === 0) return state;
+    return {
+      ...state,
+      nonImportedAccountInfos: [...state.nonImportedAccountInfos, ...toAdd],
+    };
+  },
   UPDATE_RECENT_ADDRESSES: (state, { payload }) => {
     return { ...state, recentAddresses: { ...payload } };
   },
@@ -205,6 +243,11 @@ export const walletSyncUpdate = (data: DistantState | null, version: number) => 
 
 export const setNonImportedAccounts = (payload: NonImportedAccountInfo[]) => ({
   type: "SET_NON_IMPORTED_ACCOUNTS",
+  payload,
+});
+
+export const addNonImportedAccounts = (payload: NonImportedAccountInfo[]) => ({
+  type: "ADD_NON_IMPORTED_ACCOUNTS",
   payload,
 });
 


### PR DESCRIPTION
> [!WARNING]
> This approach is problematic because we change the semantic of "non imported accounts"

### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Accounts filtered out at load because their currency is unsupported are now also pushed to `wallet.nonImportedAccountInfos`, so wallet-sync reconcile can later remove them (if the cloud no longer has the descriptor) or surface them for re-import.
  - QA focus: same as #17576 plus wallet-sync round-trips with reduced currency support.

### 📝 Description

Follow-up to #17576 to make dropped accounts visible to wallet-sync reconciliation:

- New `addNonImportedAccounts` action in `@ledgerhq/live-wallet` merges entries by id (preserves existing, dedups). The existing `setNonImportedAccounts` replaces, which would clobber wallet-sync's own retry state.
- New `splitSupportedAccounts(tuples, onDrop?)` helper owns the filter + descriptor-build so both apps' load paths share one implementation.
- Desktop `initAccounts` becomes a thunk: dispatches `INIT_ACCOUNTS` then `ADD_NON_IMPORTED_ACCOUNTS` if anything was dropped.
- Mobile `importStore` returns `UnknownAction[]`; the caller iterates and dispatches.

Cleanup happens naturally: on the next wallet-sync poll, `resolveIncrementalUpdate` removes any `nonImportedAccountInfos` entry whose descriptor is not in the distant cloud. For users without wallet-sync, entries persist invisibly until a UI surfaces them.

```ts
// consumer side
import { splitSupportedAccounts, addNonImportedAccounts } from "@ledgerhq/live-wallet/store";
const { supported, dropped } = splitSupportedAccounts(tuples, (id, msg) => logger.warn(id, msg));
if (dropped.length) dispatch(addNonImportedAccounts(dropped));
```

### ❓ Context

- **JIRA or GitHub link**: depends on #17576
- **ADR link (if any)**: https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/7141392397/Account+Support+Architecture+Layers+Lifecycle+and+Future+Portfolio+API
