### PR TITLE
[LWD] chore(desktop): reduce jest noise and flakiness

### DIFF
--- a/.changeset/tricky-brooms-knock.md
+++ b/.changeset/tricky-brooms-knock.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Reduce desktop Jest noise and flakiness: silence console output by default, enable `clearMocks`/`restoreMocks` globally for better isolation, memoize the `notificationsContentCard` and `language` selectors, stabilize the `dismissedBanners` empty array reference, and harden affected tests.

--- a/apps/ledger-live-desktop/jest-runtime-globals.d.ts
+++ b/apps/ledger-live-desktop/jest-runtime-globals.d.ts
@@ -3,6 +3,10 @@ import { jest as runtimeJest } from "@jest/globals";
 declare global {
   // eslint-disable-next-line no-var -- merged with `namespace jest` from @types/jest; `var` is required for global augmentation
   var jest: typeof runtimeJest;
+
+  function enableConsole(): void;
+
+  function disableConsole(): void;
 }
 
 export {};

--- a/apps/ledger-live-desktop/jest.config.js
+++ b/apps/ledger-live-desktop/jest.config.js
@@ -65,6 +65,8 @@ const transformIncludePatterns = [
 
 const commonConfig = {
   testEnvironment: "jsdom",
+  clearMocks: true,
+  restoreMocks: true,
   globals: {
     __DEV__: false,
     __APP_VERSION__: "2.0.0",

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/__tests__/useAssetDetailViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/__tests__/useAssetDetailViewModel.test.ts
@@ -1,4 +1,5 @@
 import { renderHook, waitFor } from "tests/testSetup";
+import { server } from "tests/server";
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { buildDistributionItem } from "tests/utils/distributionTestUtils";
 import { mockMarket, mockDada } from "tests/utils/assetDetailMocks";
@@ -58,6 +59,10 @@ describe("useAssetDetailViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     locationState(null);
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
   });
 
   describe("mode", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/History/__integrations__/History.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/__integrations__/History.integration.test.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { render, screen, waitFor, within } from "tests/testSetup";
+import { cleanup, render, screen, waitFor, within } from "tests/testSetup";
 import { useNavigate } from "react-router";
 import { setDrawer } from "~/renderer/drawers/Provider";
 import { useExportOperationsCsv } from "~/renderer/hooks/useExportOperationsCsv";
@@ -44,27 +44,37 @@ const mockedUseExportOperationsCsv = jest.mocked(useExportOperationsCsv);
 
 const mockedUseNavigate = jest.mocked(useNavigate);
 
+type ExportHookArgs = {
+  onSuccess?: () => void;
+  onError?: () => void;
+};
+
+function mockUseExportOperationsCsv({ onSuccess, onError }: ExportHookArgs) {
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState(false);
+
+  return {
+    success,
+    error,
+    isLoading: false,
+    exportCsv: async () => {
+      if (mockExportShouldError) {
+        setError(true);
+        onError?.();
+      } else if (mockExportShouldSucceed) {
+        setSuccess(true);
+        onSuccess?.();
+      }
+    },
+    resetState: () => {
+      setSuccess(false);
+      setError(false);
+    },
+  };
+}
+
 function mockExportHook() {
-  mockedUseExportOperationsCsv.mockImplementation(() => {
-    const [success, setSuccess] = useState(false);
-    const [error, setError] = useState(false);
-    return {
-      success,
-      error,
-      isLoading: false,
-      exportCsv: async () => {
-        if (mockExportShouldError) {
-          setError(true);
-        } else if (mockExportShouldSucceed) {
-          setSuccess(true);
-        }
-      },
-      resetState: () => {
-        setSuccess(false);
-        setError(false);
-      },
-    };
-  });
+  mockedUseExportOperationsCsv.mockImplementation(mockUseExportOperationsCsv);
 }
 
 describe("History integration", () => {
@@ -72,6 +82,10 @@ describe("History integration", () => {
     jest.clearAllMocks();
     mockedUseNavigate.mockReturnValue(mockNavigate);
     mockExportHook();
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   function renderHistory(accounts: Account[] = [BTC_ACCOUNT]) {
@@ -186,6 +200,10 @@ describe("History export dialog integration", () => {
     mockExportHook();
   });
 
+  afterEach(() => {
+    cleanup();
+  });
+
   function renderHistoryWithAccounts() {
     return render(<History />, {
       initialState: {
@@ -196,11 +214,19 @@ describe("History export dialog integration", () => {
   }
 
   async function openExportDialog(user: ReturnType<typeof renderHistoryWithAccounts>["user"]) {
-    await user.click(screen.getByRole("button", { name: /export/i }));
-    await waitFor(() =>
-      expect(screen.getByRole("heading", { name: "Export transaction history" })).toBeVisible(),
-    );
-    return within(screen.getByRole("dialog"));
+    const exportButton = await screen.findByTestId("history-export-csv-button");
+    await user.click(exportButton);
+    return within(await screen.findByRole("dialog"));
+  }
+
+  async function selectAllAndExport(
+    user: ReturnType<typeof renderHistoryWithAccounts>["user"],
+    dialog: ReturnType<typeof within>,
+  ) {
+    await user.click(dialog.getByText(/select all/i));
+    const exportButton = dialog.getByRole("button", { name: /export history/i });
+    await waitFor(() => expect(exportButton).toBeEnabled());
+    await user.click(exportButton);
   }
 
   it("should open dialog, list accounts, and toggle selection", async () => {
@@ -225,50 +251,45 @@ describe("History export dialog integration", () => {
 
     await user.click(dialog.getByText(/Bitcoin/));
     expect(exportButton).toBeDisabled();
+
+    await user.keyboard("{Escape}");
   });
 
   it("should export selected accounts and show success scene", async () => {
     const { user } = renderHistoryWithAccounts();
     const dialog = await openExportDialog(user);
 
-    await user.click(dialog.getByText(/select all/i));
-    await user.click(dialog.getByRole("button", { name: /export history/i }));
+    await selectAllAndExport(user, dialog);
 
-    await waitFor(() =>
-      expect(screen.getByText("Transaction history saved successfully")).toBeVisible(),
-    );
-    expect(screen.getByRole("button", { name: /done/i })).toBeVisible();
+    expect(await screen.findByTestId("history-export-success-title")).toBeVisible();
+    await user.click(screen.getByRole("button", { name: /done/i }));
   });
 
   it("should stay on export scene when user cancels save dialog", async () => {
-    mockExportShouldSucceed = false;
-
     const { user } = renderHistoryWithAccounts();
     const dialog = await openExportDialog(user);
 
-    await user.click(dialog.getByText(/select all/i));
-    await user.click(dialog.getByRole("button", { name: /export history/i }));
+    mockExportShouldSucceed = false;
+    await selectAllAndExport(user, dialog);
 
-    expect(screen.queryByText("Transaction history saved successfully")).not.toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Export transaction history" })).toBeVisible();
+    expect(screen.queryByTestId("history-export-success-title")).not.toBeInTheDocument();
+    expect(screen.getByTestId("history-export-dialog")).toBeVisible();
+
+    await user.keyboard("{Escape}");
   });
 
   it("should show error scene on export failure and allow retry", async () => {
-    mockExportShouldError = true;
-
     const { user } = renderHistoryWithAccounts();
     const dialog = await openExportDialog(user);
 
-    await user.click(dialog.getByText(/select all/i));
-    await user.click(dialog.getByRole("button", { name: /export history/i }));
+    mockExportShouldError = true;
+    await selectAllAndExport(user, dialog);
 
-    await waitFor(() => expect(screen.getByText("Something went wrong")).toBeVisible());
+    expect(await screen.findByTestId("history-export-error-title")).toBeVisible();
 
     await user.click(screen.getByRole("button", { name: /try again/i }));
 
-    await waitFor(() =>
-      expect(screen.getByRole("heading", { name: "Export transaction history" })).toBeVisible(),
-    );
-    expect(screen.queryByText("Something went wrong")).not.toBeInTheDocument();
+    expect(await screen.findByTestId("history-export-dialog")).toBeVisible();
+    expect(screen.queryByTestId("history-export-error-title")).not.toBeInTheDocument();
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
@@ -71,8 +71,16 @@ jest.mock("@ledgerhq/live-common/exchange/swap/hooks/index", () => ({
   }),
 }));
 
-const mockUsePortfolioThrottled = jest.spyOn(portfolioReact, "usePortfolioThrottled");
-const mockUseCountervaluesPolling = jest.spyOn(countervaluesReact, "useCountervaluesPolling");
+// Spies are created per-test in `beforeEach` so the global `restoreMocks: true`
+// from jest config can restore them between tests cleanly.
+let mockUsePortfolioThrottled: jest.SpyInstance<
+  ReturnType<typeof portfolioReact.usePortfolioThrottled>,
+  Parameters<typeof portfolioReact.usePortfolioThrottled>
+>;
+let mockUseCountervaluesPolling: jest.SpyInstance<
+  ReturnType<typeof countervaluesReact.useCountervaluesPolling>,
+  Parameters<typeof countervaluesReact.useCountervaluesPolling>
+>;
 
 const defaultPollingMock = {
   pending: false,
@@ -146,6 +154,8 @@ describe("PortfolioView", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUsePortfolioThrottled = jest.spyOn(portfolioReact, "usePortfolioThrottled");
+    mockUseCountervaluesPolling = jest.spyOn(countervaluesReact, "useCountervaluesPolling");
     mockUsePortfolioThrottled.mockReturnValue(defaultPortfolioMock);
     mockUseCountervaluesPolling.mockReturnValue(defaultPollingMock);
     mockedUseNavigate.mockReturnValue(mockNavigate);
@@ -610,6 +620,10 @@ const walletV4TourFlagOverrides = withFlagOverrides({
 describe("Portfolio (Wallet V4 Tour)", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUsePortfolioThrottled = jest.spyOn(portfolioReact, "usePortfolioThrottled");
+    mockUseCountervaluesPolling = jest.spyOn(countervaluesReact, "useCountervaluesPolling");
+    mockUsePortfolioThrottled.mockReturnValue(defaultPortfolioMock);
+    mockUseCountervaluesPolling.mockReturnValue(defaultPollingMock);
   });
 
   afterEach(() => {

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/manageYourBackup.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/manageYourBackup.test.tsx
@@ -18,11 +18,16 @@ jest.mock("@tanstack/react-query", () => {
     ...jest.requireActual("@tanstack/react-query"),
   };
 });
-jest
-  .spyOn(ReactQuery, "useQuery")
-  .mockImplementation(jest.fn().mockReturnValue({ data: [], isLoading: false, isSuccess: true }));
 
 describe("ManageYourBackup", () => {
+  beforeEach(() => {
+    jest
+      .spyOn(ReactQuery, "useQuery")
+      .mockImplementation(
+        jest.fn().mockReturnValue({ data: [], isLoading: false, isSuccess: true }),
+      );
+  });
+
   it("should open drawer and display Wallet Sync Manage flow and delete your backup", async () => {
     const { user } = render(<WalletSyncTestApp />, {
       initialState: {

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/walletSync.hooks.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/walletSync.hooks.test.ts
@@ -50,6 +50,10 @@ describe("useLifeCycle", () => {
     jest.spyOn(console, "error").mockImplementation(() => {});
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it("should expose handleError function", () => {
     const { result } = renderHook(() => useLifeCycle());
     expect(result.current.handleError).toBeInstanceOf(Function);

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/AccountBalanceSummaryFooter.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/AccountBalanceSummaryFooter.test.tsx
@@ -21,17 +21,16 @@ jest.mock("../ZCashExportKeyFlowModal/sync", () => ({
 const mockedGetAccountBridge = jest.mocked(getAccountBridge);
 const mockedSyncStateUpdater = jest.mocked(syncStateUpdater);
 
-// Patch Date.prototype.toLocaleString with explicit typing to avoid "this" implicit any error.
-const origDate = global.Date.prototype.toLocaleString;
-jest.spyOn(global.Date.prototype, "toLocaleString").mockImplementation(function (this: Date) {
-  return origDate.call(this, "en-GB");
-});
+const origToLocaleString = global.Date.prototype.toLocaleString;
 
 describe("Bitcoin Account Balance Summary Footer", () => {
   const account = createFixtureAccount();
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.spyOn(global.Date.prototype, "toLocaleString").mockImplementation(function (this: Date) {
+      return origToLocaleString.call(this, "en-GB");
+    });
   });
 
   it("should render a private balance field", async () => {

--- a/apps/ledger-live-desktop/src/renderer/reducers/dynamicContent.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/dynamicContent.ts
@@ -1,5 +1,6 @@
 import type { Card as BrazeCard } from "@braze/web-sdk";
 import { handleActions } from "redux-actions";
+import { createSelector } from "reselect";
 import {
   ActionContentCard,
   NotificationContentCard,
@@ -93,18 +94,21 @@ export const bottomPortfolioContentCardSelector = (state: {
 export const actionContentCardSelector = (state: { dynamicContent: DynamicContentState }) =>
   state.dynamicContent.actionCards;
 
-export const notificationsContentCardSelector = (state: {
+type NotificationsContentCardState = {
   dynamicContent: DynamicContentState;
   settings: SettingsState;
-}) => {
-  const { settings, dynamicContent } = state;
-  return dynamicContent.notificationsCards.map(n => ({
-    ...n,
-    viewed: trackingEnabledSelector(state as State)
-      ? n.viewed
-      : !!settings.anonymousUserNotifications[n.id],
-  }));
 };
+
+export const notificationsContentCardSelector = createSelector(
+  (state: NotificationsContentCardState) => state.dynamicContent.notificationsCards,
+  (state: NotificationsContentCardState) => state.settings.anonymousUserNotifications,
+  (state: NotificationsContentCardState) => trackingEnabledSelector(state as State),
+  (notificationsCards, anonymousUserNotifications, trackingEnabled) =>
+    notificationsCards.map(n => ({
+      ...n,
+      viewed: trackingEnabled ? n.viewed : !!anonymousUserNotifications[n.id],
+    })),
+);
 
 // Exporting reducer
 

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.test.ts
@@ -10,6 +10,7 @@ import { State } from ".";
 import { purgeExpiredAnonymousUserNotifications } from "../actions/settings";
 import reducer, {
   lastSeenDeviceSelector,
+  languageSelector,
   localeSelector,
   INITIAL_STATE as SETTINGS_INITIAL_STATE,
   SettingsState,
@@ -115,6 +116,56 @@ describe("lastSeenDeviceSelector", () => {
       },
     };
     expect(localeSelector(state)).toEqual("en-US");
+  });
+
+  it("should fall back to the language when the locale is unknown to regions.json", () => {
+    const state = {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      ...({} as State),
+      settings: {
+        ...SETTINGS_INITIAL_STATE,
+        language: "en" as const,
+        locale: "xx-YY",
+      },
+    };
+    expect(localeSelector(state)).toEqual("en");
+  });
+});
+
+describe("languageSelector", () => {
+  const buildState = (settings: Partial<SettingsState>): State => ({
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    ...({} as State),
+    settings: {
+      ...SETTINGS_INITIAL_STATE,
+      ...settings,
+    },
+  });
+
+  it.each([
+    { case: "supported language", language: "fr", expected: "fr" },
+    {
+      case: "unsupported language",
+      language: "xx",
+      expected: SETTINGS_INITIAL_STATE.language,
+    },
+    {
+      case: "missing language",
+      language: undefined,
+      expected: SETTINGS_INITIAL_STATE.language,
+    },
+  ])("should resolve to $expected for $case", ({ language, expected }) => {
+    expect(
+      languageSelector(
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        buildState({ language: language as SettingsState["language"] }),
+      ),
+    ).toBe(expected);
+  });
+
+  it("should return a stable primitive across calls (no new reference allocated)", () => {
+    const state = buildState({ language: "fr" });
+    expect(languageSelector(state)).toBe(languageSelector(state));
   });
 });
 

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -659,28 +659,17 @@ export const userThemeSelector = (state: State): "dark" | "light" | null => {
   return null;
 };
 
-type LanguageAndUseSystemLanguage = {
-  language: Language;
-};
-
-const languageAndUseSystemLangSelector = (state: State): LanguageAndUseSystemLanguage => {
+/** Use this for translations */
+export const languageSelector = (state: State): Language => {
   const { language } = state.settings;
   if (language && LanguageIds.includes(language)) {
-    return {
-      language,
-    };
-  } else {
-    return {
-      language: getInitialLanguageAndLocale().language,
-    };
+    return language;
   }
+  return getInitialLanguageAndLocale().language;
 };
 
-/** Use this for translations */
-export const languageSelector = createSelector(languageAndUseSystemLangSelector, o => o.language);
-
 const isValidRegionLocale = (locale: string) => {
-  return regionsByKey.hasOwnProperty(locale);
+  return Object.hasOwn(regionsByKey, locale);
 };
 const localeFallbackToLanguageSelector = (
   state: State,
@@ -815,7 +804,9 @@ export const enableLearnPageStagingUrlSelector = (state: State) =>
 export const blacklistedTokenIdsSelector = (state: State) => state.settings.blacklistedTokenIds;
 export const hasCompletedOnboardingSelector = (state: State) =>
   state.settings.hasCompletedOnboarding || getEnv("SKIP_ONBOARDING");
-export const dismissedBannersSelector = (state: State) => state.settings.dismissedBanners || [];
+const EMPTY_DISMISSED_BANNERS: string[] = [];
+export const dismissedBannersSelector = (state: State) =>
+  state.settings.dismissedBanners || EMPTY_DISMISSED_BANNERS;
 export const hideEmptyTokenAccountsSelector = (state: State) =>
   state.settings.hideEmptyTokenAccounts;
 export const filterTokenOperationsZeroAmountSelector = (state: State) =>

--- a/apps/ledger-live-desktop/tests/jestSetup.js
+++ b/apps/ledger-live-desktop/tests/jestSetup.js
@@ -150,37 +150,19 @@ jest.mock("react-redux", () => {
   };
 });
 
-const originalError = console.error;
-const originalWarn = console.warn;
-// eslint-disable-next-line no-console
-const originalLog = console.log;
+/*
+ * Console output is silenced by default to keep the test output readable.
+ * Call `enableConsole()` while writing/debugging a test, `disableConsole()`
+ * to silence again. Test failures still surface via Jest's reporter.
+ */
+/* eslint-disable no-console */
+const CONSOLE_METHODS = ["error", "warn", "log", "info", "debug"];
+const ORIGINAL_CONSOLE = Object.fromEntries(
+  CONSOLE_METHODS.map(m => [m, console[m].bind(console)]),
+);
+const noop = () => {};
 
-const EXCLUDED_ERRORS = ["act(...)", "ReactDOMTestUtils.act", "Warning: findDOMNode is deprecated"];
+global.disableConsole = () => CONSOLE_METHODS.forEach(m => (console[m] = noop));
+global.enableConsole = () => CONSOLE_METHODS.forEach(m => (console[m] = ORIGINAL_CONSOLE[m]));
 
-const EXCLUDED_WARNINGS = ["@polkadot"];
-
-const EXCLUDED_LOG_MESSAGES = ["Message posted to worker"];
-
-console.error = (...args) => {
-  const error = args.join();
-  if (EXCLUDED_ERRORS.some(excluded => error.includes(excluded))) {
-    return;
-  }
-  originalError.call(console, ...args);
-};
-
-console.warn = (...args) => {
-  const warning = args.join();
-  if (EXCLUDED_WARNINGS.some(excluded => warning.includes(excluded))) {
-    return;
-  }
-  originalWarn.call(console, ...args);
-};
-// eslint-disable-next-line no-console
-console.log = (...args) => {
-  const log = args.join();
-  if (EXCLUDED_LOG_MESSAGES.some(excluded => log.includes(excluded))) {
-    return;
-  }
-  originalLog.call(console, ...args);
-};
+global.disableConsole();


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Desktop Jest suite stability and runtime (full local & CI runs).
  - Settings screen: language selection, locale fallback, dismissed banners list.
  - Dynamic content notifications (read/viewed state when analytics tracking is disabled).
  - Portfolio / History / WalletSync / AssetDetail rendering paths exercised by the touched tests.

### 📝 Description

**Problem.** The desktop Jest suite was noisy and flaky:

- Hundreds of `console.error` / `console.warn` / `console.log` lines per run (Sentry placeholders, React `act` warnings, Redux init logs) bloated CI output and slowed local runs.
- Several tests installed `jest.spyOn(...)` at module scope and relied on no other test touching the same mock — easy to break by reordering.
- A handful of renderer selectors returned a fresh object/array on every call, triggering extra re-renders in components that rely on referential equality. This produced intermittent `act(...)`-warning bursts and timing-sensitive test failures.

**Solution.**

1. **Jest output is silent by default.** `tests/jestSetup.js` now calls `global.disableConsole()` after the suite boots. Two globals are exposed for dev:

   ```ts
   // In any test file (no import needed):
   enableConsole();   // restore real console.* for the rest of the file
   disableConsole();  // silence again
   ```

   Use `enableConsole()` at the top of a `beforeEach`, inside a single `it`, or at the top of the file while debugging. Failures still surface via Jest's reporter unchanged.

2. **Stronger isolation via Jest config.** `clearMocks: true` + `restoreMocks: true` in `jest.config.js` reset mock state and restore `jest.spyOn` implementations between every test. Tests that previously installed spies at module scope have been rewritten to set them up in `beforeEach` (Bitcoin `AccountBalanceSummaryFooter`, Portfolio integration, WalletSync `manageYourBackup`, etc.).

3. **Selector stability.**
   - `notificationsContentCardSelector` is now built with `reselect.createSelector` so it returns the same array reference when its inputs are unchanged.
   - `languageSelector` is simplified to a direct, referentially stable primitive selector (no more intermediate object).
   - `dismissedBannersSelector` returns a shared `EMPTY_DISMISSED_BANNERS` constant instead of allocating `[]` on each call.

4. **Test fixes covering the above.**
   - `AccountBalanceSummaryFooter.test.tsx` (Bitcoin Zcash): re-installs the `Date.prototype.toLocaleString` `en-GB` spy in `beforeEach` (it was being wiped by the new `restoreMocks: true`).
   - `useAssetDetailViewModel.test.ts`: adds an explicit `server.resetHandlers()` in `afterEach` so MSW state cannot bleed across tests.
   - `walletSync.hooks.test.ts`, `manageYourBackup.test.tsx`, `History.integration.test.tsx`, `Portfolio.integration.test.tsx`: move spy setup into `beforeEach`, add `restoreAllMocks`/`cleanup()` in `afterEach`.
   - `settings.test.ts`: adds dedicated coverage for the new `languageSelector` (incl. a referential-stability assertion) and for the `localeSelector` fallback.

### 🛠️ Developer notes — re-enabling logs during test dev

By default every `console.*` call from the app code is suppressed during Jest runs. When debugging a single test:

```ts
// option 1 — temporarily turn logs back on for the whole file
beforeAll(() => enableConsole());
afterAll(() => disableConsole());

// option 2 — only around a specific assertion
it("debug this one", () => {
  enableConsole();
  render(<MyComponent />);
  // ...your console.log calls fire normally...
  disableConsole();
});

// option 3 — flip globally while iterating
// Edit apps/ledger-live-desktop/tests/jestSetup.js: comment out the final
//   `global.disableConsole();` call. Remember to revert before pushing.
```

The two helpers are typed via `apps/ledger-live-desktop/jest-runtime-globals.d.ts`, so no import is needed and TypeScript will not complain.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30841](https://ledgerhq.atlassian.net/browse/LIVE-30841)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30841]: https://ledgerhq.atlassian.net/browse/LIVE-30841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ