### PR TITLE
fix(ci): sync wallet-cli skill to agent-skills layout

### DIFF
--- a/.agents/skills/ledger-wallet-cli/SKILL.md
+++ b/.agents/skills/ledger-wallet-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ledger-wallet-cli
-description: Official Ledger wallet-cli — USB-based CLI for Ledger hardware wallet flows (account discover, receive, balances, operations, send, swap quote/execute/status, assets token / token-by-id) built on the Device Management Kit (DMK)
+description: Official Ledger wallet-cli - USB-based CLI for Ledger hardware wallet flows (account discover, receive, balances, operations, send, swap quote/execute/status, genuine-check, assets token / token-by-id). Use for any wallet-cli command execution and for mapping informal requests to the right command.
 ---
 
 # wallet-cli
@@ -9,39 +9,52 @@ USB-based CLI for Ledger wallet flows. Networks: **bitcoin**, **ethereum**, **ba
 
 Run from repo root: `pnpm --silent wallet-cli start <command> [flags]`
 
+> **Concepts & rationale:** for _why_ a command behaves the way it does, or to surface a safety rule that this skill states tersely (genuine check, receive-address verification, sessions, sandbox, device contention), read [`references/business-logic.md`](references/business-logic.md).
+
 > **Session first:** When invoked without a specific task, **immediately run `session view`** — do not ask the user what to do first. Show the result, then ask what to do next. If labels exist, skip `account discover`.
 
-> **Sandbox:** `account discover`, `receive`, `send`, `genuine-check` **must** use `dangerouslyDisableSandbox: true` — sandbox blocks USB (causes `Timeout has occurred`). Other commands are fine in sandbox.
+> **Sandbox:** `account discover`, `receive`, `send`, `genuine-check`, `swap execute` **must** use `dangerouslyDisableSandbox: true` — sandbox blocks USB (causes a USB timeout error). Other commands are fine in sandbox.
 
 > **Device contention:** Never run two device commands in parallel — they fail with `[object Object]` or garbled APDU. Run sequentially.
 
+> **Device readiness:** Before running a device command, briefly describe what you're about to do. The CLI prompts for device interaction itself — **don't time out or kill the command**. _Exception: `genuine-check` exits immediately (`[✖] Wrong app. Open Ledger dashboard.`, exit code 4) if any currency app is open — unlike the other device commands, it targets the dashboard and has no auto-launch path. Ensure the device is on the dashboard before running; if it exits, ask the user to back out to the dashboard and re-run._
+
+> **Ambiguous requests — ask, don't guess.** If a required parameter is missing or unclear (no recipient for `send`, no network for `account discover`, an amount with no ticker), stop and ask. A wrong guess on a hardware wallet flow can mean irreversible fund loss.
+
 ---
 
-## Commands
+## Intent map
 
-| Command            | Device | Sandbox      |
-| ------------------ | ------ | ------------ |
-| `session view`     | No     | No           |
-| `session reset`    | No     | No           |
-| `account discover` | Yes    | **Required** |
-| `receive`          | Yes    | **Required** |
-| `send`             | Yes*   | **Required** |
-| `genuine-check`    | Yes    | **Required** |
-| `balances`         | No     | No           |
-| `operations`       | No     | No           |
-| `swap quote`       | No     | No           |
-| `swap execute`     | Yes    | **Required** |
-| `swap status`      | No     | No           |
-| `assets token`     | No     | No           |
-| `assets token-by-id` | No   | No           |
+Map informal phrasings to commands. Account references use a session label (e.g. `ethereum-1`).
 
-*`send --dry-run` needs no device and no sandbox bypass.
+| User says                                                                           | Command                                                      |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| "show me my wallet", "what do I have", "let's get started", no specific task        | `session view` (run _immediately_, before asking anything)   |
+| "find my accounts", "scan my wallet", "import my wallet", "set up Ethereum/Bitcoin" | `account discover <network>`                                 |
+| "where do I send funds to", "give me my address", "deposit address"                 | `receive <account>`                                          |
+| "how much do I have", "balance", "what's my ETH balance"                            | `balances <account>`                                         |
+| "what did I send", "transaction history", "recent activity"                         | `operations <account>`                                       |
+| "send X to Y", "transfer", "pay", "withdraw to an exchange"                         | `send <account> --to <address> --amount '<amount> <ticker>'` |
+| "swap A to B", "convert", "trade ETH for BTC", "exchange"                           | `swap quote` -> `swap execute` -> `swap status`              |
+| "is this Ledger real", "verify authenticity", "I bought this off eBay"              | `genuine-check`                                              |
+| "start over", "clear my session", "I switched devices"                              | `session reset`                                              |
+
+---
+
+## Out of scope — say no, don't improvise
+
+If the user asks for any of the following, surface that wallet-cli does not support it yet rather than constructing a command:
+
+- NFTs (mint, transfer, view).
+- Encryption / OpenPGP / key-share operations.
+- `send`, `receive`, `operations`, or `swap execute` on testnets.
+- Custom chains not listed in the Networks line above.
 
 ---
 
 ## Session & labels
 
-`account discover` persists accounts. Each gets a label: `<network>[-derivation][-env]-<n>` (e.g. `ethereum-1`, `bitcoin-native-1`, `ethereum-goerli-2`).
+`account discover` persists accounts. Each gets a label: `<network>[-derivation][-env]-<n>` (e.g. `ethereum-1`, `bitcoin-native-1`, `ethereum-sepolia-1`).
 
 All `--account` flags accept a session label (e.g. `ethereum-1`). Run `account discover` first to populate the session.
 
@@ -49,47 +62,77 @@ All `--account` flags accept a session label (e.g. `ethereum-1`). Run `account d
 
 ## Commands
 
+| Command              | Device | Sandbox      |
+| -------------------- | ------ | ------------ |
+| `session view`       | No     | No           |
+| `session reset`      | No     | No           |
+| `account discover`   | Yes    | **Required** |
+| `receive`            | Yes    | **Required** |
+| `send`               | Yes\*  | **Required** |
+| `genuine-check`      | Yes    | **Required** |
+| `balances`           | No     | No           |
+| `operations`         | No     | No           |
+| `swap quote`         | No     | No           |
+| `swap execute`       | Yes    | **Required** |
+| `swap status`        | No     | No           |
+| `assets token`       | No     | No           |
+| `assets token-by-id` | No     | No           |
+
+\*`send --dry-run` needs no device and no sandbox bypass.
+
 ### session view / reset
+
 ```bash
 pnpm --silent wallet-cli start session view
 pnpm --silent wallet-cli start session reset
 ```
 
 ### account discover
+
 ```bash
 pnpm --silent wallet-cli start account discover ethereum
 pnpm --silent wallet-cli start account discover bitcoin
 pnpm --silent wallet-cli start account discover ethereum:sepolia
 ```
+
 Networks: `bitcoin` (mainnet), `base`, `ethereum:sepolia`, `bitcoin:testnet`, `solana:devnet`.
 
 ### receive
+
 ```bash
 pnpm --silent wallet-cli start receive ethereum-1
 pnpm --silent wallet-cli start receive ethereum-1 --no-verify  # skip device confirmation
 ```
 
+**If the on-screen address differs from the terminal address:** do not share or use the address. Have the user disconnect the device and run `genuine-check` before retrying. See [`references/business-logic.md`](references/business-logic.md) § Receive-address verification for context.
+
 ### genuine-check
+
 ```bash
 pnpm --silent wallet-cli start genuine-check
-pnpm --silent wallet-cli start genuine-check --output json
+pnpm --silent wallet-cli start genuine-check --output json  # only if a downstream caller needs to parse the result
 ```
-Device must be unlocked and on the dashboard.
+
+**Preconditions:** device unlocked and on the dashboard (exit any open app); host has internet access (the secure channel reaches Ledger's backend — offline runs fail).
 
 ### balances
+
 ```bash
 pnpm --silent wallet-cli start balances ethereum-1
 pnpm --silent wallet-cli start balances ethereum-1 --output json
 ```
 
 ### operations
+
 ```bash
 pnpm --silent wallet-cli start operations ethereum-1
 pnpm --silent wallet-cli start operations ethereum-1 --limit 20 --cursor <cursor>
 ```
+
 Pagination: next cursor on stderr (human) or `nextCursor` in JSON.
 
 ### send
+
 ```bash
 pnpm --silent wallet-cli start send ethereum-1 --to 0xDEF... --amount '0.5 ETH'
 pnpm --silent wallet-cli start send ethereum-1 --to 0xDEF... --amount '100 USDT'  # ERC-20
@@ -104,6 +147,7 @@ Ticker is **mandatory** in `--amount`. No `--token` flag — ticker drives asset
 **Solana flags:** `--mode send|stake.createAccount|stake.delegate|stake.undelegate|stake.withdraw`, `--validator <addr>`, `--stake-account <addr>`, `--memo <text>`
 
 ### swap quote
+
 Fetches quotes in parallel from the built-in provider list (no device when addresses are supplied via flags below).
 
 **Currencies:** `--from` / `-f` and `--to` / `-t` are Ledger **currency IDs** — native assets (e.g. `ethereum`, `bitcoin`, `solana`) **or token IDs** when the token’s parent chain is a supported native swap currency (same IDs the CLI allows for swap). They are **not** session account labels — use `--from-account` / `--to-account` (or fresh addresses) for accounts.
@@ -118,26 +162,36 @@ pnpm --silent wallet-cli start swap quote -f ethereum -t bitcoin --amount 0.1 --
 pnpm --silent wallet-cli start swap quote --from ethereum --to bitcoin --amount 0.1 --from-account ethereum-1 --to-account bitcoin-native-1
 pnpm --silent wallet-cli start swap quote --from ethereum --to bitcoin --amount 0.1 --from-account ethereum-1 --to-account bitcoin-native-1 --output json
 ```
+
 Required: `--from`, `--to`, `--amount`, and both sides covered by the address flags above.
 
 ### swap execute
+
 **Currencies:** `--from` / `-f` and `--to` / `-t` are Ledger **currency IDs** (same as `swap quote`): native assets or **tokens** on an allowed parent chain. They must match the asset of the source `--account` and of `--to-account` respectively.
+
+**Providers:** Valid `--provider` values are `changelly`, `changelly_v2`, `cic`, `cic_v2`, `exodus`, `nearintents`, `swapsxyz`. Use the provider id shown on the quote line you pick from `swap quote`.
+
+**Fee strategy:** `--fee-strategy` accepts `slow`, `medium` (default), or `fast`.
 
 ```bash
 pnpm --silent wallet-cli start swap execute --from ethereum --to bitcoin --account ethereum-1 --to-account bitcoin-native-1 --provider changelly --amount 0.1
 pnpm --silent wallet-cli start swap execute -f ethereum -t bitcoin --account ethereum-1 --to-account bitcoin-native-1 --provider changelly --amount 0.1 --fee-strategy fast
 pnpm --silent wallet-cli start swap execute --from ethereum --to bitcoin --account ethereum-1 --to-account bitcoin-native-1 --provider changelly --amount 0.1 --output json
 ```
+
 Required flags: `--from`, `--to`, `--account`, `--to-account`, `--provider`, `--amount`. Use a `--provider` value that matches the provider id on the quote line you pick from `swap quote`.
 
 ### swap status
+
 ```bash
 pnpm --silent wallet-cli start swap status --swap-id <swapId> --provider changelly
 pnpm --silent wallet-cli start swap status --swap-id <swapId> --provider changelly --output json
 ```
+
 Required flags: `--swap-id`, `--provider`
 
 ### assets token / token-by-id
+
 Resolve token metadata from the cryptoassets store. No device, no session.
 
 ```bash
@@ -155,10 +209,14 @@ The `id` printed here is the same id accepted by `swap quote --from` / `--to` an
 
 ## Common errors
 
-| Error | Cause |
-| ----- | ----- |
-| `Amount must include a ticker` | `--amount` missing ticker |
-| `Ticker UNKN not found in account` | ticker not in account balances |
-| `UnknownDeviceExchangeError` | device not connected or wrong app |
-| `Transaction Cancelled: Rejected on device` | user rejected on device |
-| `Timeout has occurred` | sandbox blocking USB — use `dangerouslyDisableSandbox: true` |
+| Error                                                                                                 | Cause                                                                                                                                                  | Fix                                                                                                                                                                                                                                                                                                                                                                                   |
+| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Amount must include a ticker`                                                                        | `--amount` missing ticker                                                                                                                              | **Ask the user which asset they mean** — do not guess. Then pass the ticker inline, e.g. `--amount '0.5 ETH'`.                                                                                                                                                                                                                                                                        |
+| `Ticker UNKN not found in account`                                                                    | ticker not in account balances                                                                                                                         | Run `balances <account>` and show the user the tickers held by this account. **Ask the user which ticker to use, or whether they meant a different account — do not silently substitute another ticker.**                                                                                                                                                                             |
+| `[✖] Wrong app. Open Ledger dashboard.` (exit code 4)                                                | `genuine-check` invoked while a currency app is open. Unlike other device commands, `genuine-check` targets the dashboard and has no auto-launch path. | Ask the user to exit the foreground app on the device (short-press both buttons on the app's main screen until `Quit` shows, then confirm), then re-run `genuine-check`. Other device commands (`account discover`, `receive`, `send`, `swap execute`) don't hit this — they auto-prompt the correct app launch.                                                                      |
+| `[✖] Rejected on device. No action taken.`                                                           | user rejected a sign request on device                                                                                                                 | The rejection was deliberate. **Ask the user whether to retry or abort** — do not auto-retry. If they retry, have them review amount, recipient, and fees on the device screen before approving.                                                                                                                                                                                      |
+| `[✖] Rejected on device. App was not opened.`                                                        | user rejected the app-open prompt on device                                                                                                            | Ask the user to confirm the app-open prompt on the device and re-run the command.                                                                                                                                                                                                                                                                                                     |
+| `[✖] Timed out talking to the Ledger over USB. The device may be busy or locked. Retry the command.` | sandbox blocking USB, or device busy/locked                                                                                                            | Surface to the user that the command needs `dangerouslyDisableSandbox: true` and **ask for confirmation before re-running with the bypass**. The bypass is expected for device commands (`account discover`, `receive`, `send`, `genuine-check`, `swap execute`); if this error fires on any other command, investigate before bypassing rather than disabling the sandbox by reflex. |
+| `[object Object]` or garbled APDU output                                                              | two device commands running in parallel (contention)                                                                                                   | Run device-touching commands sequentially — never in parallel tool calls.                                                                                                                                                                                                                                                                                                             |
+| `[✖] Ledger not detected. Plug in, unlock, retry.` (exit code 3)                                     | device powered off or unplugged                                                                                                                        | Ask the user to power on the device, unlock it, and connect via USB, then re-run the command.                                                                                                                                                                                                                                                                                         |
+| `device-state … awaiting_approval … reason: unlock` (JSON stream)                                     | device locked                                                                                                                                          | Keep the command running — the CLI resumes automatically once unlocked. Ask the user to unlock the device with their PIN.                                                                                                                                                                                                                                                             |

--- a/.agents/skills/ledger-wallet-cli/references/business-logic.md
+++ b/.agents/skills/ledger-wallet-cli/references/business-logic.md
@@ -1,0 +1,51 @@
+# wallet-cli - business logic
+
+Concepts and product rules behind the wallet-cli commands. Load when the user asks _why_ something works the way it does, or when surfacing context for a safety rule that the main skill states tersely.
+
+For the command surface, errors, sandbox/device rules, and informal-request mapping, see the main `SKILL.md` in this skill folder.
+
+---
+
+## Genuine check
+
+**What it is.** A cryptographic verification that the connected device is a genuine Ledger. Genuine Ledger devices hold a private key embedded during manufacturing - only a device with that key can produce the proof required by the check. The device signs a challenge; Ledger verifies the result.
+
+**When to run it.**
+
+- First time a user connects a device through wallet-cli.
+- Before any high-value flow (large `send`, swap, key-share export).
+- After a device has been out of the user's possession.
+
+**What it does _not_ prove.**
+
+- That the device has not been physically tampered with (anti-tamper is a separate concern).
+- That the seed phrase backup is intact.
+- That the firmware running on the device is the latest version.
+
+---
+
+## Receive-address verification on the trusted display
+
+The host machine cannot be trusted: malware can swap a clipboard, intercept the CLI output, or render a different address than the one the device actually derived. The Ledger screen is the only display the user can trust - that's why the CLI always asks the user to compare, and why a mismatch must be treated as a possible compromise rather than a glitch.
+
+---
+
+## Sessions
+
+**What a session is.** A persisted record of which accounts the CLI has discovered on the connected device. `account discover` populates the session; `session view` shows it; `session reset` clears it.
+
+**What a session is _not_.** It is not authorization. It is not signing material. It is not synced across machines. Re-running `account discover` on a different machine produces the same accounts (deterministic from the seed), but the session itself is local.
+
+**A passphrase changes the seed.** After a user adds a BIP-39 passphrase, the derived accounts change and the existing session is no longer valid. Reset and re-discover.
+
+---
+
+## Sandbox bypass
+
+The Claude Code sandbox blocks USB syscalls by default, so any wallet-cli command that needs the device hardware can't reach it from inside the sandbox - that's why device-touching commands require `dangerouslyDisableSandbox: true`. Commands that only hit Ledger's backend don't need USB and don't need the bypass.
+
+---
+
+## Device contention
+
+The USB HID channel to a Ledger device does not multiplex. Two concurrent wallet-cli processes will both try to drive the secure channel and corrupt each other's APDU exchange. This applies even to seemingly read-only flows like `genuine-check`, which opens the secure channel just like signing flows do.

--- a/.github/workflows/sync-wallet-cli-skill.yml
+++ b/.github/workflows/sync-wallet-cli-skill.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - develop
     paths:
-      - ".agents/skills/ledger-wallet-cli/SKILL.md"
+      - ".agents/skills/ledger-wallet-cli/**"
   workflow_dispatch:
     inputs:
       source_ref:
@@ -33,12 +33,11 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     env:
-      SOURCE_SKILL: .agents/skills/ledger-wallet-cli/SKILL.md
+      SOURCE_SKILL_DIR: .agents/skills/ledger-wallet-cli
       TARGET_REPOSITORY: LedgerHQ/agent-skills
       TARGET_BASE: ${{ inputs.target_base || 'main' }}
       SYNC_BRANCH: ${{ inputs.sync_branch || 'sync/wallet-cli-skill' }}
-      TARGET_SKILL_DIR: skills/wallet-cli/ledger-wallet-cli
-      TARGET_SKILL_SET_DIR: skills/wallet-cli
+      TARGET_SKILL_DIR: skills/wallet-cli/wallet-cli-usage
     steps:
       - name: Generate token
         id: generate-token
@@ -69,54 +68,37 @@ jobs:
         run: |
           set -euo pipefail
 
-          source_path="$GITHUB_WORKSPACE/ledger-live/$SOURCE_SKILL"
+          source_skill_dir="$GITHUB_WORKSPACE/ledger-live/$SOURCE_SKILL_DIR"
           target_skill_dir="$GITHUB_WORKSPACE/agent-skills/$TARGET_SKILL_DIR"
-          target_skill_set_dir="$GITHUB_WORKSPACE/agent-skills/$TARGET_SKILL_SET_DIR"
 
+          rm -rf "$target_skill_dir"
           mkdir -p "$target_skill_dir"
 
-          sed -E 's#pnpm --silent wallet-cli start ?#wallet-cli #g' "$source_path" > "$target_skill_dir/SKILL.md"
+          cp -R "$source_skill_dir/references" "$target_skill_dir/references"
 
-          cat > "$target_skill_set_dir/README.md" <<'EOF'
-          # wallet-cli Skill Set
-
-          Skills for using Ledger wallet-cli, the USB-based command-line tool for Ledger Wallet flows built on the Device Management Kit (DMK).
-
-          ## Structure
-
-          ```text
-          skills/wallet-cli/
-          |-- README.md
-          |-- manifest.json
-          `-- ledger-wallet-cli/
-              `-- SKILL.md
-          ```
-
-          ## How to load
-
-          Load `skills/wallet-cli/ledger-wallet-cli/SKILL.md` when the user asks to interact with Ledger wallet-cli, discover accounts, get receive addresses, inspect balances or operations, send funds, run genuine checks, or execute swap flows.
-          EOF
-
-          cat > "$target_skill_set_dir/manifest.json" <<'EOF'
-          {
-            "name": "wallet-cli",
-            "displayName": "Ledger wallet-cli",
-            "description": "Skill for using Ledger wallet-cli, the USB-based command-line tool for Ledger Wallet flows.",
-            "version": "1.0.0",
-            "skills": [
-              {
-                "name": "ledger-wallet-cli",
-                "description": "Official Ledger wallet-cli commands for account discovery, receive, balances, operations, send, genuine check, and swap flows."
-              }
-            ],
-            "concatenationOrder": [
-              "ledger-wallet-cli/SKILL.md"
-            ]
-          }
-          EOF
+          sed -E \
+            -e 's|^name: ledger-wallet-cli$|name: wallet-cli-usage|' \
+            -e 's|Run from repo root: `pnpm --silent wallet-cli start <command> \[flags\]`|Install globally with a user-preferred package manager — `npm i -g @ledgerhq/wallet-cli`, `pnpm add -g @ledgerhq/wallet-cli`, `yarn global add @ledgerhq/wallet-cli`, or `bun add -g @ledgerhq/wallet-cli`. Run: `wallet-cli [flags]`.|' \
+            -e 's|pnpm --silent wallet-cli start ?|wallet-cli |g' \
+            "$source_skill_dir/SKILL.md" > "$target_skill_dir/SKILL.md"
 
           if grep -Fq "pnpm --silent wallet-cli start" "$target_skill_dir/SKILL.md"; then
             echo "Exported skill still contains monorepo-only wallet-cli commands."
+            exit 1
+          fi
+
+          if grep -Fq "Run from repo root" "$target_skill_dir/SKILL.md"; then
+            echo "Exported skill still contains monorepo-only run instructions."
+            exit 1
+          fi
+
+          if ! grep -Fq "name: wallet-cli-usage" "$target_skill_dir/SKILL.md"; then
+            echo "Exported skill frontmatter does not match the agent-skills skill name."
+            exit 1
+          fi
+
+          if [ ! -f "$target_skill_dir/references/business-logic.md" ]; then
+            echo "Exported skill is missing references/business-logic.md."
             exit 1
           fi
 
@@ -129,7 +111,7 @@ jobs:
           # NOTE: $SYNC_BRANCH is fully managed by this workflow and force-pushed on every run.
           # Do not commit to it directly — manual commits will be lost.
           git checkout -B "$SYNC_BRANCH"
-          git add "$TARGET_SKILL_SET_DIR"
+          git add "$TARGET_SKILL_DIR"
 
           if git diff --cached --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - wallet-cli sync skill flow

### 📝 Description

Export the wallet-cli skill to the existing wallet-cli-usage folder and keep the curated agent-skills README untouched.

Preserve manually added agent guidance by moving it into the monorepo source, including safety rules, intent mapping, and business-logic references.

### ❓ Context

- **JIRA or GitHub link**:
- **ADR link (if any)**: 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
