### PR TITLE
[LWDM] chore(live-wallet): await getAccountBridge in syncNewAccountsToImport

### DIFF
--- a/.changeset/ten-pigs-shave.md
+++ b/.changeset/ten-pigs-shave.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-wallet": patch
+---
+
+Await getAccountBridge in syncNewAccountsToImport to forward-compatibly support async bridge resolution

--- a/libs/live-wallet/src/liveqr/importAccounts.ts
+++ b/libs/live-wallet/src/liveqr/importAccounts.ts
@@ -50,7 +50,7 @@ export const syncNewAccountsToImport = async (
   const failed: Record<string, Error> = {};
   await promiseAllBatched(getEnv("SYNC_MAX_CONCURRENT"), selectedItems, async ({ account }) => {
     try {
-      const bridge = getAccountBridge(account);
+      const bridge = await getAccountBridge(account);
       await bridgeCache.prepareCurrency(account.currency);
       const syncConfig = {
         paginationConfig: {},


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Pre-existing behavior; awaiting a sync value is a no-op.
- [ ] **Impact of the changes:**
  - Forward-compat only: makes `syncNewAccountsToImport` ready for the upcoming async `getAccountBridge`. No runtime change today.

### 📝 Description

Small step toward #17155 (make `getAccountBridge` async via `import()`-based loaders).

`syncNewAccountsToImport` now awaits `getAccountBridge(account)`. Today the callback is synchronous, so `await` resolves immediately and behavior is unchanged. Once `getAccountBridge` becomes async, this call site is already compatible — no follow-up needed here.

```diff
-      const bridge = getAccountBridge(account);
+      const bridge = await getAccountBridge(account);
```

### ❓ Context

- **JIRA or GitHub link**: #17155 (LIVE-26176)
- **ADR link (if any)**: [ADR-033](https://ledgerhq.atlassian.net/wiki/spaces/CF/pages/7041482926/Coin+modules+-+ADR-033+-+Reverse+CoinModule+Wallet+dependency)