### PR TITLE
[LWM] fix(mobile): filter asset detail transactions to the viewed asset

### DIFF
--- a/.changeset/quiet-otters-scope.md
+++ b/.changeset/quiet-otters-scope.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix Asset Detail transactions filtering so token assets (e.g. USDC, USDT) only show their own operations on both the preview and the "See all" history list, instead of bleeding parent-network and sibling-token operations.

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
@@ -71,7 +71,11 @@ export function AssetDetailView({
             isLoading={isLoading}
           />
           <MarketData currency={currency} />
-          <Transactions currency={currency} isLoading={isLoading} />
+          <Transactions
+            currency={currency}
+            distributionItem={distributionItem}
+            isLoading={isLoading}
+          />
           <FallbackBanner show={showFallbackBanner} />
         </Box>
       </ScrollView>

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Transactions/__tests__/useTransactionsViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Transactions/__tests__/useTransactionsViewModel.test.ts
@@ -1,9 +1,13 @@
 import { renderHook, act } from "@tests/test-renderer";
-import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import BigNumber from "bignumber.js";
+import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import {
   mockBtcCryptoCurrency,
   mockEthCryptoCurrency,
+  usdcToken,
+  maticEth,
 } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
+import type { Account, AccountLike, DistributionItem, TokenAccount } from "@ledgerhq/types-live";
 import { track } from "~/analytics";
 import { NavigatorName, ScreenName } from "~/const";
 import type { State } from "~/reducers/types";
@@ -16,19 +20,35 @@ jest.mock("@react-navigation/native", () => ({
   useNavigation: () => ({ navigate: mockNavigate }),
 }));
 
-function withAccounts(currencyId: string, count: number, operationsSize = 0) {
-  const currency = currencyId === "bitcoin" ? mockBtcCryptoCurrency : mockEthCryptoCurrency;
+function buildDistributionItem(
+  currency: DistributionItem["currency"],
+  accounts: AccountLike[],
+): DistributionItem {
+  return {
+    currency,
+    distribution: 1,
+    accounts,
+    amount: accounts.reduce((sum, a) => sum + a.balance.toNumber(), 0),
+    countervalue: 0,
+  };
+}
+
+function withState(activeAccounts: Account[]) {
   return {
     overrideInitialState: (state: State): State => ({
       ...state,
       accounts: {
         ...state.accounts,
-        active: Array.from({ length: count }, (_, i) =>
-          genAccount(`${currencyId}-${i}`, { currency, operationsSize }),
-        ),
+        active: activeAccounts,
       },
     }),
   };
+}
+
+function genBitcoinAccounts(count: number, operationsSize = 0): Account[] {
+  return Array.from({ length: count }, (_, i) =>
+    genAccount(`bitcoin-${i}`, { currency: mockBtcCryptoCurrency, operationsSize }),
+  );
 }
 
 describe("useTransactionsViewModel", () => {
@@ -37,20 +57,53 @@ describe("useTransactionsViewModel", () => {
   });
 
   describe("operations", () => {
-    it.each([
-      { scenario: "currency is undefined", currency: undefined, accounts: undefined },
-      { scenario: "there are no accounts", currency: mockBtcCryptoCurrency, accounts: undefined },
-      { scenario: "accounts have no operations", currency: mockBtcCryptoCurrency, accounts: withAccounts("bitcoin", 2, 0) },
-    ])("returns an empty array when $scenario", ({ currency, accounts }) => {
-      const { result } = renderHook(() => useTransactionsViewModel(currency), accounts);
+    it("returns an empty array when currency and distributionItem are undefined", () => {
+      const { result } = renderHook(() => useTransactionsViewModel(undefined, undefined));
+      expect(result.current.operations).toEqual([]);
+    });
+
+    it("falls back to currency-scoped operations for a native currency when distributionItem is undefined", () => {
+      const accounts = genBitcoinAccounts(1, 5);
+      const { result } = renderHook(
+        () => useTransactionsViewModel(mockBtcCryptoCurrency, undefined),
+        withState(accounts),
+      );
+      expect(result.current.operations.length).toBeGreaterThan(0);
+    });
+
+    it("returns an empty array for a token currency when distributionItem is undefined", () => {
+      const ethRoot = genAccount("eth-no-distribution", {
+        currency: mockEthCryptoCurrency,
+        subAccountsCount: 0,
+        operationsSize: 5,
+      });
+      const usdc = genTokenAccount(0, ethRoot, usdcToken);
+      const ethTree: Account = { ...ethRoot, subAccounts: [usdc] };
+
+      const { result } = renderHook(
+        () => useTransactionsViewModel(usdcToken, undefined),
+        withState([ethTree]),
+      );
 
       expect(result.current.operations).toEqual([]);
     });
 
-    it("returns operations when accounts have them", () => {
+    it("returns an empty array when accounts have no operations", () => {
+      const accounts = genBitcoinAccounts(2, 0);
+      const distributionItem = buildDistributionItem(mockBtcCryptoCurrency, accounts);
       const { result } = renderHook(
-        () => useTransactionsViewModel(mockBtcCryptoCurrency),
-        withAccounts("bitcoin", 1, 10),
+        () => useTransactionsViewModel(mockBtcCryptoCurrency, distributionItem),
+        withState(accounts),
+      );
+      expect(result.current.operations).toEqual([]);
+    });
+
+    it("returns operations when accounts have them", () => {
+      const accounts = genBitcoinAccounts(1, 10);
+      const distributionItem = buildDistributionItem(mockBtcCryptoCurrency, accounts);
+      const { result } = renderHook(
+        () => useTransactionsViewModel(mockBtcCryptoCurrency, distributionItem),
+        withState(accounts),
       );
 
       expect(result.current.operations.length).toBeGreaterThan(0);
@@ -58,54 +111,88 @@ describe("useTransactionsViewModel", () => {
     });
 
     it("limits operations to MAX_PREVIEW_OPERATIONS", () => {
+      const accounts = genBitcoinAccounts(2, 20);
+      const distributionItem = buildDistributionItem(mockBtcCryptoCurrency, accounts);
       const { result } = renderHook(
-        () => useTransactionsViewModel(mockBtcCryptoCurrency),
-        withAccounts("bitcoin", 2, 20),
+        () => useTransactionsViewModel(mockBtcCryptoCurrency, distributionItem),
+        withState(accounts),
       );
 
       expect(result.current.operations.length).toBeLessThanOrEqual(MAX_PREVIEW_OPERATIONS);
     });
 
-    it("returns no operations for a non-matching currency", () => {
+    it("returns no operations when distributionItem has no matching accounts", () => {
+      const ethAccounts = Array.from({ length: 1 }, (_, i) =>
+        genAccount(`ethereum-${i}`, { currency: mockEthCryptoCurrency, operationsSize: 10 }),
+      );
+      const distributionItem = buildDistributionItem(mockBtcCryptoCurrency, []);
       const { result } = renderHook(
-        () => useTransactionsViewModel(mockBtcCryptoCurrency),
-        withAccounts("ethereum", 1, 10),
+        () => useTransactionsViewModel(mockBtcCryptoCurrency, distributionItem),
+        withState(ethAccounts),
       );
 
       expect(result.current.operations).toEqual([]);
     });
   });
 
-  describe("accountByAddress", () => {
-    it("builds a map keyed by currencyId:freshAddress", () => {
+  describe("token scoping", () => {
+    it("returns only the token's operations when viewing a token sub-account (USDC on ETH)", () => {
+      const ethRoot = genAccount("eth-prev-scope", {
+        currency: mockEthCryptoCurrency,
+        subAccountsCount: 0,
+        operationsSize: 5,
+      });
+      const usdc = genTokenAccount(0, ethRoot, usdcToken);
+      const matic = genTokenAccount(1, ethRoot, maticEth);
+      usdc.balance = new BigNumber(100);
+      usdc.spendableBalance = new BigNumber(100);
+      const ethTree: Account = { ...ethRoot, subAccounts: [usdc, matic] };
+
+      const distributionItem = buildDistributionItem(usdcToken, [usdc]);
+
       const { result } = renderHook(
-        () => useTransactionsViewModel(mockBtcCryptoCurrency),
-        withAccounts("bitcoin", 2, 1),
+        () => useTransactionsViewModel(usdcToken, distributionItem),
+        withState([ethTree]),
+      );
+
+      expect(result.current.operations.length).toBeGreaterThan(0);
+      expect(result.current.operations.every(op => op.accountId === usdc.id)).toBe(true);
+    });
+  });
+
+  describe("accountByAddress", () => {
+    it("builds a map keyed by currencyId:freshAddress from root accounts", () => {
+      const accounts = genBitcoinAccounts(2, 1);
+      const distributionItem = buildDistributionItem(mockBtcCryptoCurrency, accounts);
+      const { result } = renderHook(
+        () => useTransactionsViewModel(mockBtcCryptoCurrency, distributionItem),
+        withState(accounts),
       );
 
       expect(result.current.accountByAddress).toBeInstanceOf(Map);
       expect(result.current.accountByAddress.size).toBeGreaterThan(0);
     });
 
-    it("returns an empty map when there are no accounts", () => {
-      const { result } = renderHook(() => useTransactionsViewModel(undefined));
-
+    it("returns an empty map when there are no scoped accounts", () => {
+      const { result } = renderHook(() => useTransactionsViewModel(undefined, undefined));
       expect(result.current.accountByAddress.size).toBe(0);
     });
   });
 
   describe("onHeaderPress", () => {
-    it("navigates to filtered OperationsHistory and fires analytics", () => {
+    it("navigates to OperationsHistory with the scoped accountIds and fires analytics", () => {
+      const accounts = genBitcoinAccounts(1, 5);
+      const distributionItem = buildDistributionItem(mockBtcCryptoCurrency, accounts);
       const { result } = renderHook(
-        () => useTransactionsViewModel(mockBtcCryptoCurrency),
-        withAccounts("bitcoin", 1, 5),
+        () => useTransactionsViewModel(mockBtcCryptoCurrency, distributionItem),
+        withState(accounts),
       );
 
       act(() => result.current.onHeaderPress());
 
       expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.OperationsHistory, {
         screen: ScreenName.OperationsList,
-        params: { currencyId: "bitcoin" },
+        params: { accountIds: accounts.map(a => a.id) },
       });
       expect(track).toHaveBeenCalledWith("button_clicked", {
         button: "transactions_header",
@@ -113,13 +200,38 @@ describe("useTransactionsViewModel", () => {
         page: "Asset Detail",
       });
     });
+
+    it("forwards the token's account ids for a token asset", () => {
+      const ethRoot = genAccount("eth-token-nav", {
+        currency: mockEthCryptoCurrency,
+        subAccountsCount: 0,
+        operationsSize: 0,
+      });
+      const usdc: TokenAccount = genTokenAccount(0, ethRoot, usdcToken);
+      const ethTree: Account = { ...ethRoot, subAccounts: [usdc] };
+      const distributionItem = buildDistributionItem(usdcToken, [usdc]);
+
+      const { result } = renderHook(
+        () => useTransactionsViewModel(usdcToken, distributionItem),
+        withState([ethTree]),
+      );
+
+      act(() => result.current.onHeaderPress());
+
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.OperationsHistory, {
+        screen: ScreenName.OperationsList,
+        params: { accountIds: [usdc.id] },
+      });
+    });
   });
 
   describe("findAccount", () => {
     it("resolves an account by operation accountId", () => {
+      const accounts = genBitcoinAccounts(1, 5);
+      const distributionItem = buildDistributionItem(mockBtcCryptoCurrency, accounts);
       const { result } = renderHook(
-        () => useTransactionsViewModel(mockBtcCryptoCurrency),
-        withAccounts("bitcoin", 1, 5),
+        () => useTransactionsViewModel(mockBtcCryptoCurrency, distributionItem),
+        withState(accounts),
       );
 
       const op = result.current.operations[0];
@@ -131,9 +243,11 @@ describe("useTransactionsViewModel", () => {
     });
 
     it("returns null for an unknown accountId", () => {
+      const accounts = genBitcoinAccounts(1, 5);
+      const distributionItem = buildDistributionItem(mockBtcCryptoCurrency, accounts);
       const { result } = renderHook(
-        () => useTransactionsViewModel(mockBtcCryptoCurrency),
-        withAccounts("bitcoin", 1, 5),
+        () => useTransactionsViewModel(mockBtcCryptoCurrency, distributionItem),
+        withState(accounts),
       );
 
       expect(result.current.findAccount("unknown-id")).toBeNull();

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Transactions/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Transactions/index.tsx
@@ -1,14 +1,16 @@
 import React from "react";
 import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type { DistributionItem } from "@ledgerhq/types-live";
 import { useTransactionsViewModel } from "./useTransactionsViewModel";
 import { TransactionsView } from "./TransactionsView";
 
 type Props = Readonly<{
-  currency: CryptoOrTokenCurrency | undefined;
+  currency?: CryptoOrTokenCurrency;
+  distributionItem?: DistributionItem;
   isLoading: boolean;
 }>;
 
-export function Transactions({ currency, isLoading }: Props) {
-  const viewModel = useTransactionsViewModel(currency);
+export function Transactions({ currency, distributionItem, isLoading }: Props) {
+  const viewModel = useTransactionsViewModel(currency, distributionItem);
   return <TransactionsView {...viewModel} isLoading={isLoading} />;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Transactions/useTransactionsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Transactions/useTransactionsViewModel.ts
@@ -1,13 +1,13 @@
 import { useCallback, useMemo } from "react";
 import { useNavigation } from "@react-navigation/native";
 import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { Account, AccountLike, Operation } from "@ledgerhq/types-live";
+import { Account, AccountLike, DistributionItem, Operation } from "@ledgerhq/types-live";
 import { flattenAccounts } from "@ledgerhq/ledger-wallet-framework/account/helpers";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { useSelector } from "~/context/hooks";
+import { accountsSelector } from "~/reducers/accounts";
 import { lastSeenOperationDateSelector } from "~/reducers/history";
 import { parseLastSeenMs } from "LLM/features/OperationsHistory/utils/unreadOperations";
-import { useAccountsByCryptoCurrency } from "LLM/hooks/useAccountsByCryptoCurrency";
 import { useOperationsV1 } from "~/screens/Analytics/Operations/useOperationsV1";
 import { NavigatorName, ScreenName } from "~/const";
 import { track } from "~/analytics";
@@ -15,19 +15,46 @@ import type { BaseNavigation } from "~/components/RootNavigator/types/helpers";
 
 export const MAX_PREVIEW_OPERATIONS = 3;
 
-export function useTransactionsViewModel(currency: CryptoOrTokenCurrency | undefined) {
+export function useTransactionsViewModel(
+  currency?: CryptoOrTokenCurrency,
+  distributionItem?: DistributionItem,
+) {
   const navigation = useNavigation<BaseNavigation>();
 
-  const accountTuples = useAccountsByCryptoCurrency(currency);
+  const allAccounts = useSelector(accountsSelector);
 
-  const accounts: Account[] = useMemo(
-    () => accountTuples.map(tuple => tuple.account as Account),
-    [accountTuples],
+  // Falls back to a native-currency lookup when the asset distribution is not
+  // yet available (e.g. async load, or native account with zero balance and
+  // past operations). Token currencies still require an explicit
+  // `distributionItem` to avoid leaking sibling-token operations.
+  const allowedIds = useMemo(() => {
+    if (distributionItem) {
+      return new Set(distributionItem.accounts.map(a => a.id));
+    }
+    if (currency?.type === "CryptoCurrency") {
+      return new Set(allAccounts.filter(a => a.currency.id === currency.id).map(a => a.id));
+    }
+    return new Set<string>();
+  }, [distributionItem, currency, allAccounts]);
+
+  const rootAccounts: Account[] = useMemo(() => {
+    if (allowedIds.size === 0) return [];
+    return allAccounts.filter(root => flattenAccounts([root]).some(a => allowedIds.has(a.id)));
+  }, [allAccounts, allowedIds]);
+
+  const flattenedRootAccounts: AccountLike[] = useMemo(
+    () => flattenAccounts(rootAccounts),
+    [rootAccounts],
   );
 
-  const allAccounts: AccountLike[] = useMemo(() => flattenAccounts(accounts), [accounts]);
+  const scopedFilter = useCallback(
+    (_op: Operation, account: AccountLike) => allowedIds.has(account.id),
+    [allowedIds],
+  );
 
-  const { sections } = useOperationsV1(accounts, MAX_PREVIEW_OPERATIONS);
+  const { sections } = useOperationsV1(rootAccounts, MAX_PREVIEW_OPERATIONS, {
+    filterOperation: scopedFilter,
+  });
 
   const operations: Operation[] = useMemo(
     () => sections.flatMap(section => section.data).slice(0, MAX_PREVIEW_OPERATIONS),
@@ -39,7 +66,7 @@ export function useTransactionsViewModel(currency: CryptoOrTokenCurrency | undef
 
   const accountByAddress = useMemo(() => {
     const map = new Map<string, AccountLike>();
-    for (const account of accounts) {
+    for (const account of rootAccounts) {
       const { freshAddress } = account;
       if (freshAddress) {
         const currId = getAccountCurrency(account).id;
@@ -47,17 +74,17 @@ export function useTransactionsViewModel(currency: CryptoOrTokenCurrency | undef
       }
     }
     return map;
-  }, [accounts]);
+  }, [rootAccounts]);
 
   const findAccount = useCallback(
     (accountId: string): { account: AccountLike; parentAccount: Account | undefined } | null => {
-      const account = allAccounts.find(a => a.id === accountId);
+      const account = flattenedRootAccounts.find(a => a.id === accountId);
       if (!account) return null;
       const parentAccount: Account | undefined =
-        account.type === "Account" ? undefined : accounts.find(a => a.id === account.parentId);
+        account.type === "Account" ? undefined : rootAccounts.find(a => a.id === account.parentId);
       return { account, parentAccount };
     },
-    [allAccounts, accounts],
+    [flattenedRootAccounts, rootAccounts],
   );
 
   const onHeaderPress = useCallback(() => {
@@ -68,9 +95,9 @@ export function useTransactionsViewModel(currency: CryptoOrTokenCurrency | undef
     });
     navigation.navigate(NavigatorName.OperationsHistory, {
       screen: ScreenName.OperationsList,
-      params: { currencyId: currency?.id },
+      params: { accountIds: Array.from(allowedIds) },
     });
-  }, [navigation, currency?.id]);
+  }, [navigation, currency?.id, allowedIds]);
 
   return {
     operations,

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
@@ -1,7 +1,9 @@
 import { act } from "@testing-library/react-native";
 import { renderHook } from "@tests/test-renderer";
-import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { usdcToken, maticEth } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
+import type { Account } from "@ledgerhq/types-live";
 import type { State } from "~/reducers/types";
 import { useOperationsListViewModel } from "../useOperationsListViewModel";
 
@@ -65,14 +67,14 @@ describe("useOperationsListViewModel", () => {
     });
   });
 
-  describe("currencyId filtering", () => {
-    it("filters accounts and flattenedAccounts to the given currency", () => {
+  describe("accountIds scoping", () => {
+    it("filters root accounts to those whose tree intersects the given accountIds", () => {
       const ethereum = getCryptoCurrencyById("ethereum");
       const bitcoin = getCryptoCurrencyById("bitcoin");
       const ethAccount = genAccount("eth-filter", { currency: ethereum });
       const btcAccount = genAccount("btc-filter", { currency: bitcoin });
 
-      const { result } = renderHook(() => useOperationsListViewModel("bitcoin"), {
+      const { result } = renderHook(() => useOperationsListViewModel([btcAccount.id]), {
         overrideInitialState: (state: State) => ({
           ...state,
           accounts: { ...state.accounts, active: [ethAccount, btcAccount] },
@@ -80,11 +82,11 @@ describe("useOperationsListViewModel", () => {
       });
 
       expect(result.current.accounts).toHaveLength(1);
-      expect(result.current.accounts[0].currency.id).toBe("bitcoin");
+      expect(result.current.accounts[0].id).toBe(btcAccount.id);
       expect(result.current.flattenedAccounts.every(a => a.id.includes("btc"))).toBe(true);
     });
 
-    it("returns all accounts when currencyId is undefined", () => {
+    it("returns all accounts when accountIds is undefined", () => {
       const ethereum = getCryptoCurrencyById("ethereum");
       const bitcoin = getCryptoCurrencyById("bitcoin");
       const ethAccount = genAccount("eth-nofilter", { currency: ethereum });
@@ -98,6 +100,38 @@ describe("useOperationsListViewModel", () => {
       });
 
       expect(result.current.accounts).toHaveLength(2);
+    });
+
+    it("keeps the parent root when only a token sub-account id is provided", () => {
+      const ethereum = getCryptoCurrencyById("ethereum");
+      const ethRoot = genAccount("eth-token-scope", {
+        currency: ethereum,
+        subAccountsCount: 0,
+      });
+      const usdc = genTokenAccount(0, ethRoot, usdcToken);
+      const matic = genTokenAccount(1, ethRoot, maticEth);
+      const ethTree: Account = { ...ethRoot, subAccounts: [usdc, matic] };
+
+      const { result } = renderHook(() => useOperationsListViewModel([usdc.id]), {
+        overrideInitialState: (state: State) => ({
+          ...state,
+          accounts: { ...state.accounts, active: [ethTree] },
+        }),
+      });
+
+      expect(result.current.accounts).toHaveLength(1);
+      expect(result.current.accounts[0].id).toBe(ethTree.id);
+      expect(result.current.flattenedAccounts.map(a => a.id)).toEqual(
+        expect.arrayContaining([ethTree.id, usdc.id, matic.id]),
+      );
+
+      // The scoping filter is forwarded to useOperationsV1 so only USDC ops survive.
+      const lastCall = mockUseOperationsV1.mock.calls.at(-1);
+      const filter = lastCall?.[2]?.filterOperation;
+      expect(typeof filter).toBe("function");
+      expect(filter({} as never, usdc)).toBe(true);
+      expect(filter({} as never, matic)).toBe(false);
+      expect(filter({} as never, ethTree)).toBe(false);
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/index.tsx
@@ -26,7 +26,7 @@ function keyExtractor(item: Operation) {
 
 export default function OperationsList({ route }: Props) {
   const { bottom } = useSafeAreaInsets();
-  const currencyId = route.params?.currencyId;
+  const accountIds = route.params?.accountIds;
   const {
     accounts,
     flattenedAccounts,
@@ -36,7 +36,7 @@ export default function OperationsList({ route }: Props) {
     completed,
     isEmpty,
     onEndReached,
-  } = useOperationsListViewModel(currencyId);
+  } = useOperationsListViewModel(accountIds);
 
   const listContentStyle = useMemo(
     () => ({

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
@@ -1,12 +1,11 @@
 import { useState, useCallback, useEffect, useMemo } from "react";
-import { findCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { flattenAccounts, getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { useSelector, useDispatch } from "~/context/hooks";
 import { flattenAccountsSelector, shallowAccountsSelector } from "~/reducers/accounts";
 import { lastSeenOperationDateSelector, markOperationsAsSeen } from "~/reducers/history";
 import { parseLastSeenMs } from "LLM/features/OperationsHistory/utils/unreadOperations";
 import { useOperationsV1 } from "~/screens/Analytics/Operations/useOperationsV1";
-import { AccountLike } from "@ledgerhq/types-live";
+import { AccountLike, Operation } from "@ledgerhq/types-live";
 import { useOperationsSections } from "./hooks/useOperationsSections";
 
 export type { OperationsListSection } from "./hooks/useOperationsSections";
@@ -14,25 +13,31 @@ export type { OperationsListSection } from "./hooks/useOperationsSections";
 const INITIAL_OP_COUNT = 50;
 const OP_COUNT_INCREMENT = 50;
 
-export function useOperationsListViewModel(currencyId?: string) {
+export function useOperationsListViewModel(accountIds?: string[]) {
   const dispatch = useDispatch();
   const allAccounts = useSelector(shallowAccountsSelector);
   const allFlattenedAccounts = useSelector(flattenAccountsSelector);
   const [opCount, setOpCount] = useState(INITIAL_OP_COUNT);
 
-  const currency = useMemo(
-    () => (currencyId ? findCryptoCurrencyById(currencyId) : undefined),
-    [currencyId],
+  const allowedIds = useMemo(
+    () => (accountIds && accountIds.length > 0 ? new Set(accountIds) : null),
+    [accountIds],
   );
 
-  const accounts = useMemo(
-    () => (currency ? allAccounts.filter(a => a.currency.id === currency.id) : allAccounts),
-    [allAccounts, currency],
-  );
+  const accounts = useMemo(() => {
+    if (!allowedIds) return allAccounts;
+    return allAccounts.filter(root => flattenAccounts([root]).some(a => allowedIds.has(a.id)));
+  }, [allAccounts, allowedIds]);
 
   const flattenedAccounts = useMemo(
-    () => (currency ? flattenAccounts(accounts) : allFlattenedAccounts),
-    [accounts, allFlattenedAccounts, currency],
+    () => (allowedIds ? flattenAccounts(accounts) : allFlattenedAccounts),
+    [accounts, allFlattenedAccounts, allowedIds],
+  );
+
+  const scopedFilter = useMemo(
+    () =>
+      allowedIds ? (_op: Operation, account: AccountLike) => allowedIds.has(account.id) : undefined,
+    [allowedIds],
   );
 
   const lastSeenDate = useSelector(lastSeenOperationDateSelector);
@@ -44,7 +49,9 @@ export function useOperationsListViewModel(currencyId?: string) {
     };
   }, [dispatch]);
 
-  const { sections: rawSections, completed } = useOperationsV1(accounts, opCount);
+  const { sections: rawSections, completed } = useOperationsV1(accounts, opCount, {
+    filterOperation: scopedFilter,
+  });
 
   const accountByAddress = useMemo(() => {
     const map = new Map<string, AccountLike>();

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/types.ts
@@ -1,5 +1,5 @@
 import { ScreenName } from "~/const";
 
 export type OperationsHistoryNavigatorParamsList = {
-  [ScreenName.OperationsList]: { currencyId?: string } | undefined;
+  [ScreenName.OperationsList]: { accountIds?: string[] } | undefined;
 };

--- a/apps/ledger-live-mobile/src/screens/Analytics/Operations/useOperationsV1.ts
+++ b/apps/ledger-live-mobile/src/screens/Analytics/Operations/useOperationsV1.ts
@@ -6,7 +6,15 @@ import { useSelector } from "~/context/hooks";
 import { filterTokenOperationsZeroAmountEnabledSelector } from "~/reducers/settings";
 import { useAddressPoisoningOperationsFamilies } from "@ledgerhq/live-common/hooks/useAddressPoisoningOperationsFamilies";
 
-export function useOperationsV1(accounts: AccountLike[], opCount: number) {
+export type UseOperationsV1Options = {
+  filterOperation?: (operation: Operation, account: AccountLike) => boolean;
+};
+
+export function useOperationsV1(
+  accounts: AccountLike[],
+  opCount: number,
+  options?: UseOperationsV1Options,
+) {
   const shouldFilterTokenOpsZeroAmount = useSelector(
     filterTokenOperationsZeroAmountEnabledSelector,
   );
@@ -15,8 +23,14 @@ export function useOperationsV1(accounts: AccountLike[], opCount: number) {
     shouldFilter: shouldFilterTokenOpsZeroAmount,
   });
 
+  const externalFilter = options?.filterOperation;
+
   const filterOperation = useCallback(
     (operation: Operation, account: AccountLike) => {
+      if (externalFilter && !externalFilter(operation, account)) {
+        return false;
+      }
+
       const isOperationPoisoned = isAddressPoisoningOperation(
         operation,
         account,
@@ -27,7 +41,7 @@ export function useOperationsV1(accounts: AccountLike[], opCount: number) {
 
       return shouldFilterOperation;
     },
-    [shouldFilterTokenOpsZeroAmount, addressPoisoningFamilies],
+    [shouldFilterTokenOpsZeroAmount, addressPoisoningFamilies, externalFilter],
   );
 
   const { sections, completed } = groupAccountsOperationsByDay(accounts, {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Asset Detail screen — "Transactions" preview section (mobile)
  - Tap "See all" on Asset Detail → OperationsHistory full list
  - Token assets (ERC-20: USDC, USDT, MATIC, etc.) — must show only that token's operations
  - Native assets (ETH, BTC, SOL, …) — must still show their own operations only
  - Global "Operations" entry from TopBar — must still show every operation (no scoping)

### 📝 Description

**Problem**: On the mobile Asset Detail page, the transactions preview was scoped on the **parent account** rather than on the focused asset. As a consequence, opening a token asset (e.g. USDC on Ethereum) was showing parent-native (ETH) operations and sibling-token (USDT, MATIC, …) operations mixed in. The "See all" entry suffered from the same problem because `useOperationsListViewModel` resolved the route param via `findCryptoCurrencyById`, which silently fails for token currency ids.

**Solution**: Port the existing V4 desktop pattern (`useTransactionsSectionViewModel`) verbatim to mobile:

1. Compute `allowedIds = Set(distributionItem.accounts.map(a => a.id))`.
2. Derive `rootAccounts` = top-level accounts whose flattened tree intersects `allowedIds`.
3. Pass an `(op, account) => allowedIds.has(account.id)` predicate to `useOperationsV1`, which composes it with the existing address-poisoning filter inside `groupAccountsOperationsByDay`.
4. Navigate "See all" with `accountIds: string[]` (instead of `currencyId`); `useOperationsListViewModel` applies the same 3-step scoping.

\`useOperationsV1\` is extended in a backward-compatible way: an optional \`{ filterOperation }\` option is composed with the internal poisoning filter — untouched callers (\`PortfolioHistoryV1\`, \`OperationsV1\`, \`OperationsHistoryV1\`) are unaffected.

Added a USDC-only scoping test mirroring desktop's existing case (ETH parent with USDC + MATIC sub-accounts → only USDC ops appear) plus a sibling test for token scoping in \`useOperationsListViewModel\`.

https://github.com/user-attachments/assets/286099e4-9c60-44af-993c-5830d2cf3f4f


### ❓ Context

- **JIRA or GitHub link**: [LIVE-30634](https://ledgerhq.atlassian.net/browse/LIVE-30634)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30634]: https://ledgerhq.atlassian.net/browse/LIVE-30634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ