### PR TITLE
[LWDM] feat(mobile,live-dmk-shared): improve console log readability

### DIFF
--- a/.changeset/loud-logs-collapse.md
+++ b/.changeset/loud-logs-collapse.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@ledgerhq/live-dmk-shared": minor
+---
+
+Improve console log readability when debugging via Chrome / React Native DevTools: mobile's `ConsoleLogger` now uses `console.groupCollapsed` with raw objects instead of stringifying everything to JSON, and the DMK logger emits a clearer `DMK[tag]` log type (with backward-compatible filtering in the logs viewer) instead of the generic `live-dmk-logger`.

--- a/apps/ledger-live-mobile/src/logger.ts
+++ b/apps/ledger-live-mobile/src/logger.ts
@@ -56,50 +56,42 @@ export class ConsoleLogger {
       this.everyLogs =
         logVerbose.length === 1 && (logVerbose[0] === "true" || logVerbose[0] === "1");
       this.filters = this.everyLogs ? [] : logVerbose;
-
-      // eslint-disable-next-line no-console
     } else {
       this.everyLogs = false;
       this.filters = [];
     }
 
-    console.log(
-      `Logs console display setup: ${JSON.stringify({
-        everyLogs: this.everyLogs,
-        filters: this.filters,
-      })}`,
-    );
+    console.log("Logs console display setup:", {
+      everyLogs: this.everyLogs,
+      filters: this.filters,
+    });
   }
 
   /**
    * Displays a log in the console, if not filtered out.
+   *
+   * Objects (context, data, ...) are passed as-is to `console.log` so that
+   * DevTools can render them as interactive, inspectable trees.
    */
-  log({ type, message, context, ...rest }: Log) {
+  log({ type, message, context, data, ...rest }: Log) {
     if (!this.everyLogs && !this.filters.includes(type)) {
       return;
     }
 
-    try {
-      if (context) {
-        // Displays the tracing context before the message for better readability in the console
-        // eslint-disable-next-line no-console
-        console.log(
-          `------------------------------\n${type}: ${JSON.stringify(context, null, 2)}\n${
-            message || ""
-          }\n${JSON.stringify(rest, null, 2)}`,
-        );
-      } else {
-        // eslint-disable-next-line no-console
-        console.log(
-          `------------------------------\n${type}: ${message || ""}${JSON.stringify(
-            rest,
-            null,
-            2,
-          )}`,
-        );
-      }
-    } catch {
-      console.error("Badly formatted log");
+    const label = `[${type}]${message ? ` ${message}` : ""}`;
+    const hasContext = !!context && Object.keys(context).length > 0;
+    const hasData = data !== undefined;
+    const hasRest = Object.keys(rest).length > 0;
+
+    if (!hasContext && !hasData && !hasRest) {
+      console.log(label);
+      return;
     }
+
+    console.groupCollapsed(label);
+    if (hasContext) console.log("context:", context);
+    if (hasData) console.log("data:", data);
+    if (hasRest) console.log("extra:", rest);
+    console.groupEnd();
   }
 }

--- a/apps/web-tools/src/pages/logsviewer.tsx
+++ b/apps/web-tools/src/pages/logsviewer.tsx
@@ -104,6 +104,12 @@ const HeaderRow = styled.div`
   }
 `;
 
+const dmkLoggerTags = ["live-dmk-logger", "DMK"]; // "live-dmk-logger" is kept for backward compatibility
+
+function isDmkLog(log: Log): boolean {
+  return dmkLoggerTags.some(tag => log.type.startsWith(tag));
+}
+
 const Header = ({
   logs,
   logsMeta,
@@ -185,14 +191,10 @@ const Header = ({
       logs
         .slice(0)
         .reverse()
-        .filter(
-          l =>
-            l.type === "apdu" ||
-            (l.type === "live-dmk-logger" && l.message.startsWith("[exchange]")),
-        )
+        .filter(l => l.type === "apdu" || (isDmkLog(l) && l.message.startsWith("[exchange]")))
         // filter out live-dmk-tracer logs that are not APDUs
         .map(l => {
-          if (l.type === "live-dmk-logger") {
+          if (isDmkLog(l)) {
             l.message = l.message.replace(/^\[exchange\] /, ""); // remove `[exchange] ` prefix
           }
           return l;

--- a/libs/live-dmk-shared/src/services/LedgerLiveLogger.test.ts
+++ b/libs/live-dmk-shared/src/services/LedgerLiveLogger.test.ts
@@ -7,7 +7,9 @@ jest.mock("@ledgerhq/logs", () => ({
 }));
 
 describe("LedgerLiveLogger", () => {
-  const options = { tag: "test", timestamp: Date.now(), data: { key: "value" } };
+  // DMK's `DefaultLogTagFormatter` always wraps tags as "[name]" before
+  // handing them to subscribers, so the fixture mirrors that shape.
+  const options = { tag: "[test]", timestamp: Date.now(), data: { key: "value" } };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -21,7 +23,7 @@ describe("LedgerLiveLogger", () => {
     logger.log(LogLevel.Debug, "debug message", options);
 
     //then
-    expect(log).toHaveBeenCalledWith("live-dmk-logger", "debug message", {
+    expect(log).toHaveBeenCalledWith("DMK[test]", "debug message", {
       level: LogLevel.Debug,
       ...options,
     });
@@ -46,7 +48,7 @@ describe("LedgerLiveLogger", () => {
     logger.log(null, "null level message", options);
 
     //then
-    expect(log).toHaveBeenCalledWith("live-dmk-logger", "null level message", {
+    expect(log).toHaveBeenCalledWith("DMK[test]", "null level message", {
       level: null,
       ...options,
     });

--- a/libs/live-dmk-shared/src/services/LedgerLiveLogger.ts
+++ b/libs/live-dmk-shared/src/services/LedgerLiveLogger.ts
@@ -16,6 +16,7 @@ export class LedgerLiveLogger implements LoggerSubscriberService {
     if (level !== null && level > this.maxLevel) {
       return;
     }
-    log("live-dmk-logger", message, { level, ...options });
+    // ${options.tag} looks like "[myTag]", so no need for an additional separator
+    log(`DMK${options.tag}`, message, { level, ...options });
   }
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _DX-only change to logger formatting and log tag string; verified manually by running the mobile app and the logs viewer._
- [x] **Impact of the changes:**
  - Mobile in-app console output (when debugging via Chrome / React Native DevTools)
  - The `type` value of logs emitted through `LedgerLiveLogger` (was `live-dmk-logger`, now `DMK[<tag>]`)
  - The Logs Viewer (`apps/web-tools`) APDU/exchange filtering — kept backward-compatible with the old `live-dmk-logger` tag

### 📝 Description

**Problem.** The mobile `ConsoleLogger` was built back when Metro's terminal was the only practical way to read RN logs, so it serialized every log payload through `JSON.stringify(..., null, 2)` and concatenated everything (context, message, data, id, date…) into a single multi-line string. The day-to-day effect in DevTools was that each log entry took ten or more lines — every low-level field expanded inline — so the console scrolled away constantly, it was easy to skip a log entirely or lose track of where you were, and finding a specific entry meant a lot of scrolling.

On top of the noise problem, the `JSON.stringify` pipeline also degraded log fidelity: `BigNumber`, `Error`, `Buffer`, `Map`/`Set` and circular refs all serialized poorly (or tripped the `"Badly formatted log"` fallback), every entry pointed back to the same `logger.ts` source line, and DevTools' object inspector / log grouping were bypassed entirely.

Separately, all DMK logs were emitted under the generic `live-dmk-logger` type, which ignored the tag of the DMK log.

**Solution.**

1. `apps/ledger-live-mobile/src/logger.ts` — rewrite `ConsoleLogger.log` to pass `context`, `data` and the rest of the payload as real objects to `console.log`, wrapped in a `console.groupCollapsed`. Each entry now renders as a single compact `[type] message` line that you can expand on demand; low-level details (context, data, extra fields, and the `id`/`date` metadata) stay folded by default, so the console is dense and scannable instead of a wall of pretty-printed JSON. Dropped the `------` separator and the now-unnecessary `try/catch + "Badly formatted log"` fallback (native `console.log` doesn't serialize, so it can't throw on circular refs). The `VERBOSE` env filtering behavior is unchanged.

2. `libs/live-dmk-shared/src/services/LedgerLiveLogger.ts` — emit logs under `DMK${options.tag}` instead of the generic `live-dmk-logger`, so DMK area tags propagate through the log `type` and become directly filterable (e.g. `VERBOSE="DMK[exchange],apdu"`).

3. `apps/web-tools/src/pages/logsviewer.tsx` — update APDU/exchange filtering to recognize both the new `DMK*` prefix and the legacy `live-dmk-logger` tag, so previously exported log files keep parsing correctly.

<table>
<tr>
<th width="50%">Before</th>
<th width="50%">After</th>
</tr>
<tr>
<td>

Each log from `@ledgerhq/logs` takes several lines, few logs are visible (especially in the 2nd example).

</td>
<td>

Each log from `@ledgerhq/logs` is compact, with lower level details collapsed. As a result, more logs are visible simultaneously.

</td>
</tr>
<tr>
<td>

bitcoin logs

<img width="1155" height="1001" alt="Screenshot 2026-05-19 at 16 17 14" src="https://github.com/user-attachments/assets/21d8fa6d-d1db-4644-8c4c-9cad8b558fe1" />

</td>
<td>

https://github.com/user-attachments/assets/9902bd47-c370-45b8-bb32-b07f4acbdc8a

</td>
</tr>
<tr>
<td>

DMK logs
<img width="1154" height="1002" alt="Screenshot 2026-05-19 at 16 50 41" src="https://github.com/user-attachments/assets/54e3c39d-ba89-407d-bcd2-9fbd9286f95d" />

</td>
<td>

<img width="1154" height="1002" alt="Screenshot 2026-05-19 at 16 53 42" src="https://github.com/user-attachments/assets/978900fb-900f-44ec-83f7-8261494c2260" />

</td>
</tr>
</table>



### ❓ Context

- **JIRA or GitHub link**: _N/A — internal DX improvement_

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)