### PR TITLE
[LWM] style(live-mobile): add lumen UI for DIE discovery and connection errors

### DIFF
--- a/.changeset/chilly-plants-sell.md
+++ b/.changeset/chilly-plants-sell.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Add Lumen UI for DIE discovery and connection errors

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -4893,11 +4893,9 @@
     },
     "connectDevice": {
       "common": {
-        "available": "Available",
-        "close": "Close",
         "ledgerDevice": "Ledger device",
-        "notConnected": "Not connected",
-        "tryAgain": "Try again"
+        "available": "Available",
+        "notConnected": "Not connected"
       },
       "states": {
         "connecting": {
@@ -4907,15 +4905,26 @@
           "errors": {
             "blePairingRefused": {
               "title": "Pairing was refused",
-              "description": "Pairing was refused"
+              "cta": {
+                "retry": "Retry pairing"
+              } 
             },
             "blePairingPeerRemovedPairing": {
-              "title": "Pairing was removed",
-              "description": "Pairing was removed"
+              "title": "Go to your phone’s Bluetooth settings to unpair {{productName}}",
+              "description": "To fix the pairing issue, remove {{productName}} from your phone’s Bluetooth list, then return to this app and try again.",
+              "cta": {
+                "retry": "I unpaired, try again",
+                "help": "Learn how to fix"
+              }
             },
             "unknown": {
-              "title": "Unable to connect",
-              "description": "Unknown error"
+              "title": "Pairing unsuccessful",
+              "description": "Please try again or read our Bluetooth troubleshooting article below.",
+              "tip": "Make sure your device is unlocked.",
+              "cta": {
+                "retry": "Try again",
+                "help": "Get help"
+              }
             }
           }
         },
@@ -4923,59 +4932,126 @@
           "title": "Select a device"
         },
         "discoveryError": {
-          "continueWithUsb": "I want to continue with USB",
           "errors": {
             "bluetoothPermissionDeniedPromptable": {
-              "title": "Bluetooth permission needed",
-              "description": "Please enable Bluetooth permission to use Bluetooth"
+              "title": "Allow Bluetooth access",
+              "description": "Allow Bluetooth to scan for nearby Ledger devices.",
+              "cta": {
+                "retry": "Allow",
+                "ignore": "Continue with USB"
+              }
             },
             "bluetoothPermissionDeniedManualSettings": {
-              "title": "Bluetooth permission needed",
-              "description": "Please enable Bluetooth permission in your phone settings to use Bluetooth"
+              "title": "Allow Bluetooth access",
+              "description": "Bluetooth permission is required. Go to Settings → Apps → Ledger Wallet → Permissions → Nearby devices, then come back.",
+              "cta": {
+                "retry": "I enabled it, try again",
+                "ignore": "Continue with USB"
+              }
             },
             "bluetoothPermissionUnauthorizedManualSettings": {
-              "title": "Bluetooth permission needed",
-              "description": "Please enable Bluetooth permission in your phone settings to use Bluetooth"
+              "title": "Allow Bluetooth access",
+              "description": "Ledger Wallet needs Bluetooth permission to find your device. Enable it in Settings.",
+              "cta": {
+                "platform": {
+                  "ios": {
+                    "retry": "I enabled it, try again"
+                  },
+                  "android": {
+                    "retry": "I enabled it, try again",
+                    "ignore": "Continue with USB"
+                  }
+                }
+              }
             },
             "bluetoothDisabledPromptable": {
-              "title": "Bluetooth settings disabled",
-              "description": "Please enable Bluetooth settings to use Bluetooth"
+              "title": "Turn on Bluetooth",
+              "description": "Bluetooth is off. Turn it on to find your Ledger device.",
+              "cta": {
+                "retry": "Turn on Bluetooth",
+                "ignore": "Continue with USB"
+              }
             },
             "bluetoothDisabledManualAction": {
-              "title": "Bluetooth settings disabled",
-              "description": "Please enable Bluetooth settings in your phone settings to use Bluetooth"
+              "title": "Turn on Bluetooth",
+              "description": "Bluetooth is off. Turn it on in your Settings → Bluetooth, then come back.",
+              "cta": {
+                "platform": {
+                  "ios": {
+                    "retry": "I enabled Bluetooth, try again"
+                  },
+                  "android": {
+                    "retry": "I enabled Bluetooth, try again",
+                    "ignore": "Continue with USB"
+                  }
+                }
+              }
             },
             "bluetoothStateUnknownCheckOnly": {
-              "title": "Bluetooth is not ready",
-              "description": "Please check your Bluetooth settings to use Bluetooth"
+              "title": "Checking Bluetooth..."
             },
             "bluetoothUnsupported": {
-              "title": "Bluetooth is not supported",
-              "description": "Bluetooth is not supported. Please check your Bluetooth settings."
+              "title": "Bluetooth not supported",
+              "description": {
+                "platform": {
+                  "android": "This phone doesn’t support Bluetooth. You can connect your Ledger device via USB instead.",
+                  "ios": "This phone doesn’t support Bluetooth. Please use Ledger Wallet desktop or contact Ledger support."
+                }
+              },
+              "cta": {
+                "platform": {
+                  "android": {
+                    "ignore": "Continue with USB"
+                  }
+                }
+              }
             },
             "locationPermissionDeniedPromptable": {
-              "title": "Location permission needed",
-              "description": "Please enable Location permission to use Bluetooth"
+              "title": "Allow location access",
+              "description": "Android needs Location permission to scan for Bluetooth devices.",
+              "cta": {
+                "retry": "Allow",
+                "ignore": "Continue with USB"
+              }
             },
             "locationPermissionDeniedManualSettings": {
-              "title": "Location permission needed",
-              "description": "Please enable Location permission in your phone settings to use Bluetooth"
+              "title": "Allow location access",
+              "description": "Location permission is required to scan for Bluetooth devices. Go to Settings → Apps → Ledger Wallet → Permissions → Location, then come back.",
+              "cta": {
+                "retry": "I enabled it, try again",
+                "ignore": "Continue with USB"
+              }
             },
             "locationDisabledPromptable": {
-              "title": "Location settings disabled",
-              "description": "Please enable Location settings to use Bluetooth"
+              "title": "Turn on Location",
+              "description": "Location services are off. Turn them on to scan for Bluetooth devices.",
+              "cta": {
+                "retry": "Turn on Location",
+                "ignore": "Continue with USB"
+              }
             },
             "locationDisabledManualAction": {
-              "title": "Location settings disabled",
-              "description": "Please enable Location settings in your phone settings to use Bluetooth"
+              "title": "Turn on Location",
+              "description": "Location services are off. Turn them on from Settings → Location, then come back.",
+              "cta": {
+                "retry": "I enabled Location, try again",
+                "ignore": "Continue with USB"
+              }
             },
             "locationServicePermissionMissing": {
-              "title": "Location permission needed",
-              "description": "Please enable Location permission to use Bluetooth"
+              "title": "Allow location access",
+              "description": "Location permission seems missing. Tap below to try again.",
+              "cta": {
+                "retry": "Try again",
+                "ignore": "Continue with USB"
+              }
             },
             "unknown": {
-              "title": "Unable to discover devices",
-              "description": "Unable to discover devices."
+              "title": "Something went wrong",
+              "description": "We couldn’t start the Bluetooth scan. Please try again or contact Ledger support.",
+              "cta": {
+                "retry": "Try again"
+              }
             }
           }
         },

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/DeviceConnectionComponentLWMView.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/DeviceConnectionComponentLWMView.test.tsx
@@ -36,6 +36,7 @@ function renderView(
   return render(
     <DeviceConnectionComponentLWMView
       state={state}
+      platform={callbacks.platform ?? "android"}
       onConnectLedgerDevice={callbacks.onConnectLedgerDevice ?? jest.fn()}
       onBuyLedgerDevice={callbacks.onBuyLedgerDevice ?? jest.fn()}
     />,
@@ -102,7 +103,7 @@ describe("DeviceConnectionComponentLWMView", () => {
       ignore: jest.fn(),
     });
 
-    expect(screen.getByText("Unable to discover devices")).toBeVisible();
+    expect(screen.getByText("Something went wrong")).toBeVisible();
   });
 
   it("should render the connecting state", () => {
@@ -119,7 +120,7 @@ describe("DeviceConnectionComponentLWMView", () => {
       ignore: jest.fn(),
     });
 
-    expect(screen.getByText("Unable to connect")).toBeVisible();
+    expect(screen.getByText("Pairing unsuccessful")).toBeVisible();
   });
 
   it("should render nothing when connected", () => {

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/DeviceConnectionComponentLWMView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/DeviceConnectionComponentLWMView.tsx
@@ -6,8 +6,8 @@ import { DiscoveringState } from "./components/DiscoveringState";
 import { WaitingForSelectedDeviceState } from "./components/WaitingForSelectedDeviceState";
 import { DiscoveryErrorState } from "./components/DiscoveryErrorState";
 import { ConnectingState } from "./components/ConnectingState";
-import { ConnectionErrorState } from "./components/ConnectionErrorState";
 import { ConnectedState } from "./components/ConnectedState";
+import { ConnectionErrorState } from "./components/ConnectionErrorState";
 import type { DeviceConnectionComponentLWMViewModel } from "./useDeviceConnectionComponentLWMViewModel";
 
 function assertNever(value: never): never {
@@ -16,6 +16,7 @@ function assertNever(value: never): never {
 
 export function DeviceConnectionComponentLWMView({
   state,
+  platform,
   onConnectLedgerDevice,
   onBuyLedgerDevice,
 }: Readonly<DeviceConnectionComponentLWMViewModel>) {
@@ -38,7 +39,7 @@ export function DeviceConnectionComponentLWMView({
       return <WaitingForSelectedDeviceState state={state} />;
 
     case ConnectDeviceUIStateTypes.DiscoveryError:
-      return <DiscoveryErrorState state={state} />;
+      return <DiscoveryErrorState state={state} platform={platform} />;
 
     case ConnectDeviceUIStateTypes.Connecting:
       return <ConnectingState />;

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectionErrorState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectionErrorState.test.tsx
@@ -1,10 +1,12 @@
 import React from "react";
+import { Linking } from "react-native";
 import { render, screen } from "@tests/test-renderer";
 import {
   ConnectionErrorTypes,
   ConnectDeviceUIStateTypes,
   type ConnectDeviceUIState,
 } from "@ledgerhq/live-dmk-mobile";
+import { urls } from "~/utils/urls";
 import { ConnectionErrorState } from "./ConnectionErrorState";
 
 type ConnectionErrorUIState = Extract<
@@ -16,17 +18,21 @@ const errorCases = [
   {
     type: ConnectionErrorTypes.BlePairingRefused,
     title: "Pairing was refused",
-    description: "Pairing was refused",
+    description: undefined,
+    cta: "Retry pairing",
   },
   {
     type: ConnectionErrorTypes.BlePairingPeerRemovedPairing,
-    title: "Pairing was removed",
-    description: "Pairing was removed",
+    title: "Go to your phone’s Bluetooth settings to unpair Ledger device",
+    description:
+      "To fix the pairing issue, remove Ledger device from your phone’s Bluetooth list, then return to this app and try again.",
+    cta: "Learn how to fix",
   },
   {
     type: ConnectionErrorTypes.Unknown,
-    title: "Unable to connect",
-    description: "Unknown error",
+    title: "Pairing unsuccessful",
+    description: "Please try again or read our Bluetooth troubleshooting article below.",
+    cta: "Try again",
   },
 ] as const;
 
@@ -46,27 +52,43 @@ function renderState(errorType: ConnectionErrorTypes) {
 }
 
 describe("ConnectionErrorState", () => {
+  beforeEach(() => {
+    jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
+  });
+
   it.each(errorCases)(
-    "should render the $type error title and description",
-    ({ type, title, description }) => {
+    "should render the $type error content",
+    ({ type, title, description, cta }) => {
       renderState(type);
 
-      if (title === description) {
-        expect(screen.getAllByText(title)).toHaveLength(2);
-      } else {
-        expect(screen.getByText(title)).toBeVisible();
+      expect(screen.getByText(title)).toBeVisible();
+      expect(screen.getByText(cta)).toBeVisible();
+
+      if (description) {
         expect(screen.getByText(description)).toBeVisible();
       }
     },
   );
 
-  it("should call retry and ignore when action buttons are pressed", async () => {
-    const { user, retry, ignore } = renderState(ConnectionErrorTypes.Unknown);
+  it("should render the unknown error tip", () => {
+    renderState(ConnectionErrorTypes.Unknown);
+
+    expect(screen.getByText("Make sure your device is unlocked.")).toBeVisible();
+  });
+
+  it("should call retry when the retry button is pressed", async () => {
+    const { user, retry } = renderState(ConnectionErrorTypes.Unknown);
 
     await user.press(screen.getByText("Try again"));
-    await user.press(screen.getByText("Close"));
 
     expect(retry).toHaveBeenCalledTimes(1);
-    expect(ignore).toHaveBeenCalledTimes(1);
+  });
+
+  it("should open the generic pairing help article", async () => {
+    const { user } = renderState(ConnectionErrorTypes.Unknown);
+
+    await user.press(screen.getByText("Get help"));
+
+    expect(Linking.openURL).toHaveBeenCalledWith(urls.pairingIssues);
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectionErrorState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectionErrorState.tsx
@@ -1,51 +1,118 @@
 import React from "react";
+import { Linking } from "react-native";
 import {
   ConnectionErrorTypes,
   ConnectDeviceUIStateTypes,
   type ConnectDeviceUIState,
 } from "@ledgerhq/live-dmk-mobile";
 import { InfoState } from "LLM/components/InfoState";
+import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
 import { useTranslation } from "~/context/Locale";
+import { urls } from "~/utils/urls";
+import { PeerRemovedPairingState } from "./PeerRemovedPairingState";
 
 type ConnectionErrorStateProps = {
   state: Extract<ConnectDeviceUIState, { type: ConnectDeviceUIStateTypes.ConnectionError }>;
 };
 
-const connectionErrorTitleKeys: Record<ConnectionErrorTypes, string> = {
-  [ConnectionErrorTypes.BlePairingRefused]:
-    "deviceIntentExecutor.connectDevice.states.connectionError.errors.blePairingRefused.title",
-  [ConnectionErrorTypes.BlePairingPeerRemovedPairing]:
-    "deviceIntentExecutor.connectDevice.states.connectionError.errors.blePairingPeerRemovedPairing.title",
-  [ConnectionErrorTypes.Unknown]:
-    "deviceIntentExecutor.connectDevice.states.connectionError.errors.unknown.title",
+type InfoStateProps = React.ComponentProps<typeof InfoState>;
+type InfoStateCta = InfoStateProps["primaryCta"];
+
+type ConnectionErrorViewState = {
+  preset: "info" | "error";
+  title: string;
+  description?: string;
+  banner?: {
+    title: string;
+  };
+  primaryCta?: InfoStateCta;
+  secondaryCta?: InfoStateCta;
 };
 
-const connectionErrorDescriptionKeys: Record<ConnectionErrorTypes, string> = {
-  [ConnectionErrorTypes.BlePairingRefused]:
-    "deviceIntentExecutor.connectDevice.states.connectionError.errors.blePairingRefused.description",
-  [ConnectionErrorTypes.BlePairingPeerRemovedPairing]:
-    "deviceIntentExecutor.connectDevice.states.connectionError.errors.blePairingPeerRemovedPairing.description",
-  [ConnectionErrorTypes.Unknown]:
-    "deviceIntentExecutor.connectDevice.states.connectionError.errors.unknown.description",
+type BlePairingPeerRemovedPairingViewState = {
+  title: string;
+  description: string;
+  helpLabel: string;
+  retryLabel: string;
 };
+
+type ConnectionErrorViewStates = {
+  [ConnectionErrorTypes.BlePairingPeerRemovedPairing]: BlePairingPeerRemovedPairingViewState
+} & Record<Exclude<ConnectionErrorTypes, ConnectionErrorTypes.BlePairingPeerRemovedPairing>, ConnectionErrorViewState>;
+
+const connectionErrorTranslationBaseKey =
+  "deviceIntentExecutor.connectDevice.states.connectionError.errors";
 
 export function ConnectionErrorState({ state }: Readonly<ConnectionErrorStateProps>): React.ReactNode {
   const { t } = useTranslation();
+  const bleForgetDeviceUrl = useLocalizedUrl(urls.errors.BleForgetDevice);
+  const pairingIssuesUrl = useLocalizedUrl(urls.pairingIssues);
+  const productName = t("deviceIntentExecutor.connectDevice.common.ledgerDevice");
+
+  const retryCta = (labelKey: string): InfoStateCta => ({
+    label: t(labelKey),
+    onPress: state.retry,
+  });
+
+  const helpCta = (labelKey: string, url: string): InfoStateCta => ({
+    label: t(labelKey),
+    onPress: () => {
+      Linking.openURL(url).catch(() => undefined);
+    },
+  });
+
+  const connectionErrorViewStates: ConnectionErrorViewStates = {
+    [ConnectionErrorTypes.BlePairingRefused]: {
+      preset: "info",
+      title: `${connectionErrorTranslationBaseKey}.blePairingRefused.title`,
+      primaryCta: retryCta(`${connectionErrorTranslationBaseKey}.blePairingRefused.cta.retry`),
+    },
+    [ConnectionErrorTypes.Unknown]: {
+      preset: "error",
+      title: `${connectionErrorTranslationBaseKey}.unknown.title`,
+      description: `${connectionErrorTranslationBaseKey}.unknown.description`,
+      banner: {
+        title: `${connectionErrorTranslationBaseKey}.unknown.tip`,
+      },
+      primaryCta: retryCta(`${connectionErrorTranslationBaseKey}.unknown.cta.retry`),
+      secondaryCta: helpCta(`${connectionErrorTranslationBaseKey}.unknown.cta.help`, pairingIssuesUrl),
+    },
+    [ConnectionErrorTypes.BlePairingPeerRemovedPairing]: {
+      title: `${connectionErrorTranslationBaseKey}.blePairingPeerRemovedPairing.title`,
+      description: `${connectionErrorTranslationBaseKey}.blePairingPeerRemovedPairing.description`,
+      helpLabel: `${connectionErrorTranslationBaseKey}.blePairingPeerRemovedPairing.cta.help`,
+      retryLabel: `${connectionErrorTranslationBaseKey}.blePairingPeerRemovedPairing.cta.retry`,
+    },
+  };
+
+  if (state.error.type === ConnectionErrorTypes.BlePairingPeerRemovedPairing) {
+    const errorState = connectionErrorViewStates[state.error.type];
+
+    return (
+      <PeerRemovedPairingState
+        title={t(errorState.title, { productName })}
+        description={t(errorState.description, { productName })}
+        helpLabel={t(errorState.helpLabel)}
+        retryLabel={t(errorState.retryLabel)}
+        onHelp={() => {
+          Linking.openURL(bleForgetDeviceUrl).catch(() => undefined);
+        }}
+        onRetry={state.retry}
+      />
+    );
+  }
+
+  const errorState = connectionErrorViewStates[state.error.type];
 
   return (
     <InfoState
-      preset="error"
+      preset={errorState.preset}
       size="hug"
-      title={t(connectionErrorTitleKeys[state.error.type])}
-      description={t(connectionErrorDescriptionKeys[state.error.type])}
-      primaryCta={{
-        label: t("deviceIntentExecutor.connectDevice.common.tryAgain"),
-        onPress: state.retry,
-      }}
-      secondaryCta={{
-        label: t("deviceIntentExecutor.connectDevice.common.close"),
-        onPress: state.ignore,
-      }}
+      title={t(errorState.title)}
+      description={errorState.description ? t(errorState.description) : undefined}
+      banner={errorState.banner ? { title: t(errorState.banner.title) } : undefined}
+      primaryCta={errorState.primaryCta}
+      secondaryCta={errorState.secondaryCta}
     />
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveryErrorState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveryErrorState.test.tsx
@@ -7,6 +7,7 @@ import {
   type ConnectDeviceUIState,
   type DiscoveryError,
 } from "@ledgerhq/live-dmk-mobile";
+import type { AppPlatform } from "@ledgerhq/live-common/platform/types";
 import { DiscoveryErrorState } from "./DiscoveryErrorState";
 
 type DiscoveryErrorUIState = Extract<
@@ -17,68 +18,71 @@ type DiscoveryErrorUIState = Extract<
 const errorCases = [
   {
     type: DiscoveryErrorTypes.BluetoothPermissionDeniedPromptable,
-    title: "Bluetooth permission needed",
-    description: "Please enable Bluetooth permission to use Bluetooth",
+    title: "Allow Bluetooth access",
+    description: "Allow Bluetooth to scan for nearby Ledger devices.",
   },
   {
     type: DiscoveryErrorTypes.BluetoothPermissionDeniedManualSettings,
-    title: "Bluetooth permission needed",
-    description: "Please enable Bluetooth permission in your phone settings to use Bluetooth",
+    title: "Allow Bluetooth access",
+    description:
+      "Bluetooth permission is required. Go to Settings → Apps → Ledger Wallet → Permissions → Nearby devices, then come back.",
   },
   {
     type: DiscoveryErrorTypes.BluetoothPermissionUnauthorizedManualSettings,
-    title: "Bluetooth permission needed",
-    description: "Please enable Bluetooth permission in your phone settings to use Bluetooth",
+    title: "Allow Bluetooth access",
+    description: "Ledger Wallet needs Bluetooth permission to find your device. Enable it in Settings.",
   },
   {
     type: DiscoveryErrorTypes.BluetoothDisabledPromptable,
-    title: "Bluetooth settings disabled",
-    description: "Please enable Bluetooth settings to use Bluetooth",
+    title: "Turn on Bluetooth",
+    description: "Bluetooth is off. Turn it on to find your Ledger device.",
   },
   {
     type: DiscoveryErrorTypes.BluetoothDisabledManualAction,
-    title: "Bluetooth settings disabled",
-    description: "Please enable Bluetooth settings in your phone settings to use Bluetooth",
+    title: "Turn on Bluetooth",
+    description: "Bluetooth is off. Turn it on in your Settings → Bluetooth, then come back.",
   },
   {
     type: DiscoveryErrorTypes.BluetoothStateUnknownCheckOnly,
-    title: "Bluetooth is not ready",
-    description: "Please check your Bluetooth settings to use Bluetooth",
+    title: "Checking Bluetooth...",
+    description: undefined,
   },
   {
     type: DiscoveryErrorTypes.BluetoothUnsupported,
-    title: "Bluetooth is not supported",
-    description: "Bluetooth is not supported. Please check your Bluetooth settings.",
+    title: "Bluetooth not supported",
+    description:
+      "This phone doesn’t support Bluetooth. You can connect your Ledger device via USB instead.",
   },
   {
     type: DiscoveryErrorTypes.LocationPermissionDeniedPromptable,
-    title: "Location permission needed",
-    description: "Please enable Location permission to use Bluetooth",
+    title: "Allow location access",
+    description: "Android needs Location permission to scan for Bluetooth devices.",
   },
   {
     type: DiscoveryErrorTypes.LocationPermissionDeniedManualSettings,
-    title: "Location permission needed",
-    description: "Please enable Location permission in your phone settings to use Bluetooth",
+    title: "Allow location access",
+    description:
+      "Location permission is required to scan for Bluetooth devices. Go to Settings → Apps → Ledger Wallet → Permissions → Location, then come back.",
   },
   {
     type: DiscoveryErrorTypes.LocationDisabledPromptable,
-    title: "Location settings disabled",
-    description: "Please enable Location settings to use Bluetooth",
+    title: "Turn on Location",
+    description: "Location services are off. Turn them on to scan for Bluetooth devices.",
   },
   {
     type: DiscoveryErrorTypes.LocationDisabledManualAction,
-    title: "Location settings disabled",
-    description: "Please enable Location settings in your phone settings to use Bluetooth",
+    title: "Turn on Location",
+    description: "Location services are off. Turn them on from Settings → Location, then come back.",
   },
   {
     type: DiscoveryErrorTypes.LocationServicePermissionMissing,
-    title: "Location permission needed",
-    description: "Please enable Location permission to use Bluetooth",
+    title: "Allow location access",
+    description: "Location permission seems missing. Tap below to try again.",
   },
   {
     type: DiscoveryErrorTypes.Unknown,
-    title: "Unable to discover devices",
-    description: "Unable to discover devices.",
+    title: "Something went wrong",
+    description: "We couldn’t start the Bluetooth scan. Please try again or contact Ledger support.",
   },
 ] as const;
 
@@ -97,9 +101,11 @@ function makeDiscoveryError(type: DiscoveryErrorTypes): DiscoveryError {
 function renderState({
   type,
   retry,
+  platform = "android",
 }: {
   type: DiscoveryErrorTypes;
   retry?: DiscoveryErrorUIState["retry"];
+  platform?: Exclude<AppPlatform, "desktop">;
 }) {
   const ignore = jest.fn();
   const state: DiscoveryErrorUIState = {
@@ -109,7 +115,7 @@ function renderState({
     ignore,
   };
 
-  const view = render(<DiscoveryErrorState state={state} />);
+  const view = render(<DiscoveryErrorState state={state} platform={platform} />);
 
   return { ...view, ignore };
 }
@@ -121,18 +127,20 @@ describe("DiscoveryErrorState", () => {
       renderState({ type });
 
       expect(screen.getByText(title)).toBeVisible();
-      expect(screen.getByText(description)).toBeVisible();
+      if (description) {
+        expect(screen.getByText(description)).toBeVisible();
+      }
     },
   );
 
-  it("should render retry when a retry callback is available", async () => {
+  it("should render the translated retry cta when a retry callback is available", async () => {
     const retry = jest.fn();
     const { user } = renderState({
       type: DiscoveryErrorTypes.BluetoothPermissionDeniedPromptable,
       retry,
     });
 
-    await user.press(screen.getByText("Try again"));
+    await user.press(screen.getByText("Allow"));
 
     expect(retry).toHaveBeenCalledTimes(1);
   });
@@ -140,24 +148,39 @@ describe("DiscoveryErrorState", () => {
   it("should not render retry when no retry callback is available", () => {
     renderState({ type: DiscoveryErrorTypes.BluetoothUnsupported });
 
-    expect(screen.queryByText("Try again")).toBeNull();
+    expect(screen.queryByText("Allow")).toBeNull();
   });
 
-  it("should render continue with USB for known discovery errors", async () => {
+  it("should render the translated continue with USB cta on Android when available", async () => {
     const { user, ignore } = renderState({
       type: DiscoveryErrorTypes.LocationDisabledManualAction,
     });
 
-    await user.press(screen.getByText("I want to continue with USB"));
+    await user.press(screen.getByText("Continue with USB"));
 
     expect(ignore).toHaveBeenCalledTimes(1);
   });
 
-  it("should render close for unknown discovery errors", async () => {
-    const { user, ignore } = renderState({ type: DiscoveryErrorTypes.Unknown });
+  it("should hide Android USB fallback on iOS-only discovery errors", () => {
+    renderState({
+      type: DiscoveryErrorTypes.BluetoothDisabledManualAction,
+      platform: "ios",
+    });
 
-    await user.press(screen.getByText("Close"));
+    expect(screen.queryByText("Continue with USB")).toBeNull();
+  });
 
-    expect(ignore).toHaveBeenCalledTimes(1);
+  it("should render the iOS Bluetooth unsupported copy without a CTA", () => {
+    renderState({
+      type: DiscoveryErrorTypes.BluetoothUnsupported,
+      platform: "ios",
+    });
+
+    expect(
+      screen.getByText(
+        "This phone doesn’t support Bluetooth. Please use Ledger Wallet desktop or contact Ledger support.",
+      ),
+    ).toBeVisible();
+    expect(screen.queryByText("Continue with USB")).toBeNull();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveryErrorState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveryErrorState.tsx
@@ -4,86 +4,180 @@ import {
   DiscoveryErrorTypes,
   type ConnectDeviceUIState,
 } from "@ledgerhq/live-dmk-mobile";
+import type { AppPlatform } from "@ledgerhq/live-common/platform/types";
 import { InfoState } from "LLM/components/InfoState";
 import { useTranslation } from "~/context/Locale";
+import { Box, Spinner, Text } from "@ledgerhq/lumen-ui-rnative";
 
 type DiscoveryErrorStateProps = {
   state: Extract<ConnectDeviceUIState, { type: ConnectDeviceUIStateTypes.DiscoveryError }>;
+  platform: Exclude<AppPlatform, "desktop">;
 };
 
 type InfoStateCta = React.ComponentProps<typeof InfoState>["primaryCta"];
 
-const discoveryErrorTranslationBaseKeys: Record<DiscoveryErrorTypes, string> = {
-  [DiscoveryErrorTypes.BluetoothPermissionDeniedPromptable]:
-    "deviceIntentExecutor.connectDevice.states.discoveryError.errors.bluetoothPermissionDeniedPromptable",
-  [DiscoveryErrorTypes.BluetoothPermissionDeniedManualSettings]:
-    "deviceIntentExecutor.connectDevice.states.discoveryError.errors.bluetoothPermissionDeniedManualSettings",
-  [DiscoveryErrorTypes.BluetoothPermissionUnauthorizedManualSettings]:
-    "deviceIntentExecutor.connectDevice.states.discoveryError.errors.bluetoothPermissionUnauthorizedManualSettings",
-  [DiscoveryErrorTypes.BluetoothDisabledPromptable]:
-    "deviceIntentExecutor.connectDevice.states.discoveryError.errors.bluetoothDisabledPromptable",
-  [DiscoveryErrorTypes.BluetoothDisabledManualAction]:
-    "deviceIntentExecutor.connectDevice.states.discoveryError.errors.bluetoothDisabledManualAction",
-  [DiscoveryErrorTypes.BluetoothStateUnknownCheckOnly]:
-    "deviceIntentExecutor.connectDevice.states.discoveryError.errors.bluetoothStateUnknownCheckOnly",
-  [DiscoveryErrorTypes.BluetoothUnsupported]:
-    "deviceIntentExecutor.connectDevice.states.discoveryError.errors.bluetoothUnsupported",
-  [DiscoveryErrorTypes.LocationPermissionDeniedPromptable]:
-    "deviceIntentExecutor.connectDevice.states.discoveryError.errors.locationPermissionDeniedPromptable",
-  [DiscoveryErrorTypes.LocationPermissionDeniedManualSettings]:
-    "deviceIntentExecutor.connectDevice.states.discoveryError.errors.locationPermissionDeniedManualSettings",
-  [DiscoveryErrorTypes.LocationDisabledPromptable]:
-    "deviceIntentExecutor.connectDevice.states.discoveryError.errors.locationDisabledPromptable",
-  [DiscoveryErrorTypes.LocationDisabledManualAction]:
-    "deviceIntentExecutor.connectDevice.states.discoveryError.errors.locationDisabledManualAction",
-  [DiscoveryErrorTypes.LocationServicePermissionMissing]:
-    "deviceIntentExecutor.connectDevice.states.discoveryError.errors.locationServicePermissionMissing",
-  [DiscoveryErrorTypes.Unknown]:
-    "deviceIntentExecutor.connectDevice.states.discoveryError.errors.unknown",
+type DiscoveryErrorViewState = {
+  preset: "info" | "error";
+  title: string;
+  description?: string;
+  primaryCta?: InfoStateCta;
+  secondaryCta?: InfoStateCta;
 };
 
-const getDiscoveryErrorTranslationKey = (
-  errorType: DiscoveryErrorTypes,
-  key: "title" | "description",
-) => `${discoveryErrorTranslationBaseKeys[errorType]}.${key}`;
+type DiscoveryErrorViewStates = {
+  [DiscoveryErrorTypes.BluetoothStateUnknownCheckOnly]: { title: string };
+} & Record<
+  Exclude<DiscoveryErrorTypes, DiscoveryErrorTypes.BluetoothStateUnknownCheckOnly>,
+  DiscoveryErrorViewState
+>;
 
-export function DiscoveryErrorState({ state }: Readonly<DiscoveryErrorStateProps>): React.ReactNode {
+const discoveryErrorTranslationBaseKey =
+  "deviceIntentExecutor.connectDevice.states.discoveryError.errors";
+
+export function DiscoveryErrorState({
+  state,
+  platform,
+}: Readonly<DiscoveryErrorStateProps>): React.ReactNode {
   const { t } = useTranslation();
-  const isUnknownError = state.error.type === DiscoveryErrorTypes.Unknown;
 
-  const closeCta: InfoStateCta = {
-    label: t("deviceIntentExecutor.connectDevice.common.close"),
+  const retryCta = (labelKey: string): InfoStateCta | undefined =>
+    state.retry
+      ? {
+          label: t(labelKey),
+          onPress: state.retry,
+        }
+      : undefined;
+
+  const ignoreCta = (labelKey: string): InfoStateCta => ({
+    label: t(labelKey),
     onPress: state.ignore,
+  });
+
+  const discoveryErrorViewStates: DiscoveryErrorViewStates = {
+    [DiscoveryErrorTypes.BluetoothPermissionDeniedPromptable]: {
+      preset: "info",
+      title: `${discoveryErrorTranslationBaseKey}.bluetoothPermissionDeniedPromptable.title`,
+      description: `${discoveryErrorTranslationBaseKey}.bluetoothPermissionDeniedPromptable.description`,
+      primaryCta: retryCta(
+        `${discoveryErrorTranslationBaseKey}.bluetoothPermissionDeniedPromptable.cta.retry`,
+      ),
+      secondaryCta: ignoreCta(
+        `${discoveryErrorTranslationBaseKey}.bluetoothPermissionDeniedPromptable.cta.ignore`,
+      ),
+    },
+    [DiscoveryErrorTypes.BluetoothPermissionDeniedManualSettings]: {
+      preset: "info",
+      title: `${discoveryErrorTranslationBaseKey}.bluetoothPermissionDeniedManualSettings.title`,
+      description: `${discoveryErrorTranslationBaseKey}.bluetoothPermissionDeniedManualSettings.description`,
+      primaryCta: retryCta(
+        `${discoveryErrorTranslationBaseKey}.bluetoothPermissionDeniedManualSettings.cta.retry`,
+      ),
+      secondaryCta: ignoreCta(
+        `${discoveryErrorTranslationBaseKey}.bluetoothPermissionDeniedManualSettings.cta.ignore`,
+      ),
+    },
+    [DiscoveryErrorTypes.BluetoothPermissionUnauthorizedManualSettings]: {
+      preset: "info",
+      title: `${discoveryErrorTranslationBaseKey}.bluetoothPermissionUnauthorizedManualSettings.title`,
+      description: `${discoveryErrorTranslationBaseKey}.bluetoothPermissionUnauthorizedManualSettings.description`,
+      primaryCta: retryCta(`${discoveryErrorTranslationBaseKey}.bluetoothPermissionUnauthorizedManualSettings.cta.platform.${platform}.retry`),
+      secondaryCta:
+        platform === "android" ? ignoreCta(`${discoveryErrorTranslationBaseKey}.bluetoothPermissionUnauthorizedManualSettings.cta.platform.android.ignore`) : undefined,
+    },
+    [DiscoveryErrorTypes.BluetoothDisabledPromptable]: {
+      preset: "info",
+      title: `${discoveryErrorTranslationBaseKey}.bluetoothDisabledPromptable.title`,
+      description: `${discoveryErrorTranslationBaseKey}.bluetoothDisabledPromptable.description`,
+      primaryCta: retryCta(`${discoveryErrorTranslationBaseKey}.bluetoothDisabledPromptable.cta.retry`),
+      secondaryCta: ignoreCta(`${discoveryErrorTranslationBaseKey}.bluetoothDisabledPromptable.cta.ignore`),
+    },
+    [DiscoveryErrorTypes.BluetoothDisabledManualAction]: {
+      preset: "info",
+      title: `${discoveryErrorTranslationBaseKey}.bluetoothDisabledManualAction.title`,
+      description: `${discoveryErrorTranslationBaseKey}.bluetoothDisabledManualAction.description`,
+      primaryCta: retryCta(`${discoveryErrorTranslationBaseKey}.bluetoothDisabledManualAction.cta.platform.${platform}.retry`),
+      secondaryCta:
+        platform === "android" ? ignoreCta(`${discoveryErrorTranslationBaseKey}.bluetoothDisabledManualAction.cta.platform.android.ignore`) : undefined,
+    },
+    [DiscoveryErrorTypes.BluetoothUnsupported]: {
+      preset: "error",
+      title: `${discoveryErrorTranslationBaseKey}.bluetoothUnsupported.title`,
+      description: `${discoveryErrorTranslationBaseKey}.bluetoothUnsupported.description.platform.${platform}`,
+      primaryCta:
+        platform === "android" ? ignoreCta(`${discoveryErrorTranslationBaseKey}.bluetoothUnsupported.cta.platform.android.ignore`) : undefined,
+    },
+    [DiscoveryErrorTypes.LocationPermissionDeniedPromptable]: {
+      preset: "info",
+      title: `${discoveryErrorTranslationBaseKey}.locationPermissionDeniedPromptable.title`,
+      description: `${discoveryErrorTranslationBaseKey}.locationPermissionDeniedPromptable.description`,
+      primaryCta: retryCta(`${discoveryErrorTranslationBaseKey}.locationPermissionDeniedPromptable.cta.retry`),
+      secondaryCta: ignoreCta(`${discoveryErrorTranslationBaseKey}.locationPermissionDeniedPromptable.cta.ignore`),
+    },
+    [DiscoveryErrorTypes.LocationPermissionDeniedManualSettings]: {
+      preset: "info",
+      title: `${discoveryErrorTranslationBaseKey}.locationPermissionDeniedManualSettings.title`,
+      description: `${discoveryErrorTranslationBaseKey}.locationPermissionDeniedManualSettings.description`,
+      primaryCta: retryCta(`${discoveryErrorTranslationBaseKey}.locationPermissionDeniedManualSettings.cta.retry`),
+      secondaryCta: ignoreCta(`${discoveryErrorTranslationBaseKey}.locationPermissionDeniedManualSettings.cta.ignore`),
+    },
+    [DiscoveryErrorTypes.LocationDisabledPromptable]: { 
+      preset: "info",
+      title: `${discoveryErrorTranslationBaseKey}.locationDisabledPromptable.title`,
+      description: `${discoveryErrorTranslationBaseKey}.locationDisabledPromptable.description`,
+      primaryCta: retryCta(`${discoveryErrorTranslationBaseKey}.locationDisabledPromptable.cta.retry`),
+      secondaryCta: ignoreCta(`${discoveryErrorTranslationBaseKey}.locationDisabledPromptable.cta.ignore`),
+    },
+    [DiscoveryErrorTypes.LocationDisabledManualAction]: {
+      preset: "info",
+      title: `${discoveryErrorTranslationBaseKey}.locationDisabledManualAction.title`,
+      description: `${discoveryErrorTranslationBaseKey}.locationDisabledManualAction.description`,
+      primaryCta: retryCta(`${discoveryErrorTranslationBaseKey}.locationDisabledManualAction.cta.retry`),
+      secondaryCta: ignoreCta(`${discoveryErrorTranslationBaseKey}.locationDisabledManualAction.cta.ignore`),
+    },
+    [DiscoveryErrorTypes.LocationServicePermissionMissing]: {
+      preset: "info",
+      title: `${discoveryErrorTranslationBaseKey}.locationServicePermissionMissing.title`,
+      description: `${discoveryErrorTranslationBaseKey}.locationServicePermissionMissing.description`,
+      primaryCta: retryCta(`${discoveryErrorTranslationBaseKey}.locationServicePermissionMissing.cta.retry`),
+      secondaryCta: ignoreCta(`${discoveryErrorTranslationBaseKey}.locationServicePermissionMissing.cta.ignore`),
+    },
+    [DiscoveryErrorTypes.Unknown]: {
+      preset: "error",
+      title: `${discoveryErrorTranslationBaseKey}.unknown.title`,
+      description: `${discoveryErrorTranslationBaseKey}.unknown.description`,
+      primaryCta: retryCta(`${discoveryErrorTranslationBaseKey}.unknown.cta.retry`),
+    },
+    [DiscoveryErrorTypes.BluetoothStateUnknownCheckOnly]: {
+      title: `${discoveryErrorTranslationBaseKey}.bluetoothStateUnknownCheckOnly.title`,
+    },
   };
 
-  const retryCta: InfoStateCta = state.retry
-    ? {
-        label: t("deviceIntentExecutor.connectDevice.common.tryAgain"),
-        onPress: state.retry,
-      }
-    : undefined;
+  if (state.error.type === DiscoveryErrorTypes.BluetoothStateUnknownCheckOnly) {
+    const errorState = discoveryErrorViewStates[state.error.type];
 
-  const continueWithUsbCta: InfoStateCta = {
-    label: t("deviceIntentExecutor.connectDevice.states.discoveryError.continueWithUsb"),
-    onPress: state.ignore,
-  };
-
-  let primaryCta: InfoStateCta = retryCta;
-  let secondaryCta: InfoStateCta = continueWithUsbCta;
-
-  if (isUnknownError) {
-    primaryCta = retryCta ?? closeCta;
-    secondaryCta = retryCta ? closeCta : undefined;
+    return (
+      <Box lx={{ width: "full", alignItems: "center", paddingTop: "s16" }}>
+        <Spinner size={32} color="base" />
+        <Text
+          typography="heading4SemiBold"
+          lx={{ color: "base", textAlign: "center", paddingTop: "s16", paddingBottom: "s32" }}
+        >
+          {t(errorState.title)}
+        </Text>
+      </Box>
+    );
   }
+
+  const errorState = discoveryErrorViewStates[state.error.type];
 
   return (
     <InfoState
-      preset="info"
+      preset={errorState.preset}
       size="hug"
-      title={t(getDiscoveryErrorTranslationKey(state.error.type, "title"))}
-      description={t(getDiscoveryErrorTranslationKey(state.error.type, "description"))}
-      primaryCta={primaryCta}
-      secondaryCta={secondaryCta}
+      title={t(errorState.title)}
+      description={errorState.description ? t(errorState.description) : undefined}
+      primaryCta={errorState.primaryCta}
+      secondaryCta={errorState.secondaryCta}
     />
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/PeerRemovedPairingState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/PeerRemovedPairingState.test.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import { PeerRemovedPairingState } from "./PeerRemovedPairingState";
+
+function renderState() {
+  const onHelp = jest.fn();
+  const onRetry = jest.fn();
+
+  const view = render(
+    <PeerRemovedPairingState
+      title="Go to your phone's Bluetooth settings to unpair Ledger device"
+      description="Remove Ledger device from your phone's Bluetooth list, then return to this app and try again."
+      helpLabel="Learn how to fix"
+      retryLabel="I unpaired, try again"
+      onHelp={onHelp}
+      onRetry={onRetry}
+    />,
+  );
+
+  return { ...view, onHelp, onRetry };
+}
+
+describe("PeerRemovedPairingState", () => {
+  it("should render the peer removed pairing content", () => {
+    renderState();
+
+    expect(
+      screen.getByText("Go to your phone's Bluetooth settings to unpair Ledger device"),
+    ).toBeVisible();
+    expect(
+      screen.getByText(
+        "Remove Ledger device from your phone's Bluetooth list, then return to this app and try again.",
+      ),
+    ).toBeVisible();
+    expect(screen.getByText("Learn how to fix")).toBeVisible();
+    expect(screen.getByText("I unpaired, try again")).toBeVisible();
+    expect(screen.getByTestId("peer-removed-help-external-link-icon")).toBeVisible();
+  });
+
+  it("should call the help action when the help button is pressed", async () => {
+    const { user, onHelp } = renderState();
+
+    await user.press(screen.getByText("Learn how to fix"));
+
+    expect(onHelp).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call the retry action when the retry link is pressed", async () => {
+    const { user, onRetry } = renderState();
+
+    await user.press(screen.getByText("I unpaired, try again"));
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/PeerRemovedPairingState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/PeerRemovedPairingState.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { Image, StyleSheet } from "react-native";
+import { Box, Link, Pressable, Text } from "@ledgerhq/lumen-ui-rnative";
+import { ExternalLink } from "@ledgerhq/lumen-ui-rnative/symbols";
+import forgetDeviceIllustration from "~/components/BleDevicePairingFlow/assets/forget-device.webp";
+
+type PeerRemovedPairingStateProps = {
+  title: string;
+  description: string;
+  helpLabel: string;
+  retryLabel: string;
+  onHelp: () => void;
+  onRetry: () => void;
+};
+
+export function PeerRemovedPairingState({
+  title,
+  description,
+  helpLabel,
+  retryLabel,
+  onHelp,
+  onRetry,
+}: Readonly<PeerRemovedPairingStateProps>): React.ReactNode {
+  return (
+    <Box lx={{ width: "full" }}>
+      <Box lx={{ gap: "s32", paddingVertical: "s24", width: "full" }}>
+        <Box lx={{ alignItems: "center", gap: "s24", justifyContent: "center", width: "full" }}>
+          <Box
+            lx={{
+              alignItems: "center",
+              borderRadius: "sm",
+              height: "s208",
+              justifyContent: "center",
+              overflow: "hidden",
+              width: "s208",
+            }}
+          >
+            <Image
+              source={forgetDeviceIllustration}
+              resizeMode="contain"
+              style={styles.forgetDeviceIllustration}
+            />
+          </Box>
+          <Box lx={{ alignItems: "center", gap: "s8", width: "full" }}>
+            <Text typography="heading4SemiBold" lx={{ color: "base", textAlign: "center" }}>
+              {title}
+            </Text>
+            <Text typography="body2" lx={{ color: "muted", textAlign: "center" }}>
+              {description}
+            </Text>
+          </Box>
+        </Box>
+
+        <Box lx={{ gap: "s16", width: "full" }}>
+          <Pressable
+            accessibilityRole="button"
+            onPress={onHelp}
+            lx={{
+              alignItems: "center",
+              backgroundColor: "interactive",
+              borderRadius: "full",
+              flexDirection: "row",
+              gap: "s8",
+              justifyContent: "center",
+              paddingHorizontal: "s16",
+              paddingVertical: "s16",
+              width: "full",
+            }}
+            style={({ pressed }) => (pressed ? styles.pressedButton : undefined)}
+          >
+            <Text typography="body1SemiBold" lx={{ color: "onInteractive", textAlign: "center" }}>
+              {helpLabel}
+            </Text>
+            <ExternalLink
+              size={20}
+              color="onInteractive"
+              testID="peer-removed-help-external-link-icon"
+            />
+          </Pressable>
+          <Box lx={{ alignItems: "center" }}>
+            <Link appearance="base" size="md" underline={false} onPress={onRetry}>
+              {retryLabel}
+            </Link>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+}
+
+const styles = StyleSheet.create({
+  forgetDeviceIllustration: {
+    height: 172,
+    width: 198,
+  },
+  pressedButton: {
+    opacity: 0.8,
+  },
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/useDeviceConnectionComponentLWMViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/useDeviceConnectionComponentLWMViewModel.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { Linking } from "react-native";
+import { Linking, Platform } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { DeviceConnectionResult } from "@ledgerhq/device-intent";
@@ -19,6 +19,7 @@ import { NavigatorName, ScreenName } from "~/const";
 import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { urls } from "~/utils/urls";
 import { dmkToLedgerDeviceIdMap } from "@ledgerhq/live-dmk-shared";
+import type { AppPlatform } from "@ledgerhq/live-common/platform/types";
 
 type UseDeviceConnectionComponentLWMViewModelParams = {
   onConnected: (connectionResult: DeviceConnectionResult) => void;
@@ -27,6 +28,7 @@ type UseDeviceConnectionComponentLWMViewModelParams = {
 
 export type DeviceConnectionComponentLWMViewModel = {
   state: ConnectDeviceUIState;
+  platform: Exclude<AppPlatform, "desktop">;
   onConnectLedgerDevice: () => void;
   onBuyLedgerDevice: () => void;
 };
@@ -35,6 +37,7 @@ export function useDeviceConnectionComponentLWMViewModel({
   onConnected,
   onError,
 }: UseDeviceConnectionComponentLWMViewModelParams): DeviceConnectionComponentLWMViewModel {
+  const platform = Platform.OS === "ios" ? "ios" : "android";
   const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
   const dispatch = useDispatch();
   const dmk = useDeviceManagementKit();
@@ -131,6 +134,7 @@ export function useDeviceConnectionComponentLWMViewModel({
 
   return {
     state,
+    platform,
     onConnectLedgerDevice,
     onBuyLedgerDevice,
   };


### PR DESCRIPTION
### ✅ Checklist
- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Updates Ledger Live Mobile DIE connection error UI for the peer-removed BLE pairing case.
  - QA should focus on the Bluetooth pairing error flow where the device was removed from the phone pairing list.
  - Verify the help CTA opens the forget-device support article and the retry CTA restarts pairing.
### 📝 Description
This PR improves the Ledger Live Mobile Device Intent Executor discovery and connection errors screens using Lumen. 
Some updates have also been made on translation keys and and CTAs.

### ❓ Context
- **JIRA or GitHub link**: [LIVE-30699](https://ledgerhq.atlassian.net/browse/LIVE-30699?atlOrigin=eyJpIjoiMjJhZTNmMjNhZTEyNGYwYWEwYTFkYWFiOTU5MzNjYjYiLCJwIjoiaiJ9)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-30699]: https://ledgerhq.atlassian.net/browse/LIVE-30699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ