### PR TITLE
[LWM] feat(mobile): add dev-menu entries for logs verbosity, navigation, and theme

### DIFF
--- a/.changeset/dev-menu-entries-mobile.md
+++ b/.changeset/dev-menu-entries-mobile.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add dev-menu entries to toggle `@ledgerhq/logs` console verbosity, navigate to Settings / Debug Settings, and toggle the app theme (dev builds only)

--- a/apps/ledger-live-mobile/src/devTools/useDevTools.ts
+++ b/apps/ledger-live-mobile/src/devTools/useDevTools.ts
@@ -3,6 +3,7 @@ import { useReactNavigationDevTools } from "@rozenite/react-navigation-plugin";
 import { useMMKVDevTools } from "@rozenite/mmkv-plugin";
 import { mmkv } from "LLM/storage/mmkvStorageWrapper";
 import { navigationRef } from "~/rootnavigation";
+import { useDevMenu } from "~/hooks/useDevMenu";
 
 const config = {
   inspectors: {
@@ -21,6 +22,7 @@ const HookDevTools = () => {
   useMMKVDevTools({
     storages: [mmkv],
   });
+  useDevMenu();
 
   return null;
 };

--- a/apps/ledger-live-mobile/src/hooks/useDevMenu.ts
+++ b/apps/ledger-live-mobile/src/hooks/useDevMenu.ts
@@ -1,0 +1,45 @@
+import { useEffect } from "react";
+import { DevSettings } from "react-native";
+import { useDispatch } from "~/context/hooks";
+import { store } from "~/state-manager/configureStore";
+import { setTheme } from "~/actions/settings";
+import { resolvedThemeSelector } from "~/reducers/settings";
+import { NavigatorName, ScreenName } from "~/const";
+import { navigate } from "~/rootnavigation";
+import { ConsoleLogger } from "~/logger";
+
+// Module-level guard: prevents duplicate registrations when `HookDevTools`
+// remounts (e.g. when `RebootProvider`'s key changes).
+let registered = false;
+
+/**
+ * Registers custom entries in the React Native developer menu (shake / Cmd-D / Cmd-M).
+ *
+ * Dev-only: nothing is registered in release builds (`__DEV__` is `false`).
+ */
+export const useDevMenu = () => {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (!__DEV__) return;
+    if (registered) return;
+    registered = true;
+
+    DevSettings.addMenuItem("@ledgerhq/logs verbosity: all", () => {
+      ConsoleLogger.getLogger().setVerbosity("all");
+    });
+    DevSettings.addMenuItem("@ledgerhq/logs verbosity: env", () => {
+      ConsoleLogger.getLogger().setVerbosity("env");
+    });
+    DevSettings.addMenuItem("Go to Settings", () => {
+      navigate(NavigatorName.Settings, { screen: ScreenName.SettingsScreen });
+    });
+    DevSettings.addMenuItem("Go to Debug Settings", () => {
+      navigate(NavigatorName.Settings, { screen: ScreenName.DebugSettings });
+    });
+    DevSettings.addMenuItem("Toggle app theme (light/dark)", () => {
+      const resolved = resolvedThemeSelector(store.getState());
+      dispatch(setTheme(resolved === "dark" ? "light" : "dark"));
+    });
+  }, [dispatch]);
+};

--- a/apps/ledger-live-mobile/src/logger.ts
+++ b/apps/ledger-live-mobile/src/logger.ts
@@ -11,6 +11,13 @@ export default {
 };
 
 /**
+ * Verbosity mode for the `ConsoleLogger`:
+ * - "env": filter logs based on the `VERBOSE` env variable (default behavior)
+ * - "all": print every log, regardless of `VERBOSE`
+ */
+export type Verbosity = "all" | "env";
+
+/**
  * Simple logger displaying on the console/stdout logs
  *
  * The filtering is set from the `VERBOSE` env variable.
@@ -23,6 +30,7 @@ export class ConsoleLogger {
   private static instance: ConsoleLogger | undefined;
   private everyLogs: boolean = false;
   private filters: Array<string> = [];
+  private verbosity: Verbosity = "env";
 
   /**
    * Sets up debug console printing of logs
@@ -47,17 +55,24 @@ export class ConsoleLogger {
   }
 
   /**
-   * Refreshes the logger config from the `VERBOSE` env variable
+   * Refreshes the logger config based on the current verbosity mode:
+   * - "all": prints every log
+   * - "env": filters from the `VERBOSE` env variable
    */
   refreshSetup() {
+    if (this.verbosity === "all") {
+      this.everyLogs = true;
+      this.filters = [];
+      console.log("Logs console display setup (verbosity: all)");
+      return;
+    }
+
     const logVerbose = getEnv("VERBOSE");
 
     if (logVerbose) {
       this.everyLogs =
         logVerbose.length === 1 && (logVerbose[0] === "true" || logVerbose[0] === "1");
       this.filters = this.everyLogs ? [] : logVerbose;
-
-      // eslint-disable-next-line no-console
     } else {
       this.everyLogs = false;
       this.filters = [];
@@ -69,6 +84,18 @@ export class ConsoleLogger {
         filters: this.filters,
       })}`,
     );
+  }
+
+  /**
+   * Switches the verbosity mode and immediately applies it.
+   */
+  setVerbosity(mode: Verbosity) {
+    this.verbosity = mode;
+    this.refreshSetup();
+  }
+
+  getVerbosity(): Verbosity {
+    return this.verbosity;
   }
 
   /**


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Dev-menu wiring (`__DEV__`-only, native `DevSettings` API). Manual smoke test only; no unit-test value._
- [x] **Impact of the changes:**
  - Dev-only: nothing ships in release builds (`__DEV__` is `false`)
  - React Native developer menu (shake / Cmd-D / Cmd-M) on Ledger Live Mobile dev builds
  - `ConsoleLogger` gains a `verbosity` mode; default behavior unchanged (still reads `VERBOSE` env)
  - No new dependencies

### 📝 Description

Adds five entries to the React Native developer menu on Ledger Live Mobile (dev builds only) to speed up day-to-day debugging:

- `@ledgerhq/logs verbosity: all` — force `ConsoleLogger` to print every log
- `@ledgerhq/logs verbosity: env` — restore default behavior (filter from `VERBOSE` env)
- `Go to Settings` — jump to the Settings screen from anywhere
- `Go to Debug Settings` — jump straight to the Debug Settings screen
- `Toggle app theme (light/dark)` — flip between light and dark without going through Settings

**Implementation**

- New hook `apps/ledger-live-mobile/src/hooks/useDevMenu.ts` registers the entries inside a `useEffect` guarded by `__DEV__` and an idempotency flag on `global` (to avoid duplicates on Fast Refresh).
- `useDevMenu()` is called from the existing dev-tools wrapper at `apps/ledger-live-mobile/src/devTools/useDevTools.ts`, which is already mounted inside `LedgerStoreProvider` (so Redux is available for the theme toggle).
- Navigation uses the global `navigationRef` from `apps/ledger-live-mobile/src/rootnavigation.ts`, so it works from any screen in `BaseNavigator`. The helper no-ops if navigation isn't ready yet.
- `ConsoleLogger` (in `apps/ledger-live-mobile/src/logger.ts`) gains a `Verbosity` type (`"all" | "env"`), `setVerbosity(mode)` / `getVerbosity()` accessors, and an `"all"` short-circuit in `refreshSetup()`. Default mode is `"env"` so existing behavior is preserved.
- Theme toggle reads `resolvedThemeSelector` and dispatches `setTheme`, so when the current setting is `"system"` it flips visibly (e.g. system=dark → user="light").

**Edge cases**

- During onboarding the `Settings` navigator isn't in the active stack — the navigate entries will silently do nothing. In dev, `SKIP_ONBOARDING` is typically set so this is rarely hit.
- When `AuthPass` is locked, the navigation dispatches successfully under the lock overlay; the destination is visible after unlock.

**Demo**

https://github.com/user-attachments/assets/e2101a6b-1ad3-4ef1-9737-ca8de856e92c


### ❓ Context

- **JIRA or GitHub link**: N/A — internal DX improvement
- **ADR link (if any)**: N/A