### PR TITLE
test(e2e): add ERC-20 token re-approval flow for swap (QAA-1210)

### DIFF
--- a/e2e/desktop/tests/specs/token.reapproval.swap.spec.ts
+++ b/e2e/desktop/tests/specs/token.reapproval.swap.spec.ts
@@ -1,0 +1,82 @@
+import test from "tests/fixtures/common";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
+import { Account, TokenAccount } from "@ledgerhq/live-common/e2e/enum/Account";
+import { Swap } from "@ledgerhq/live-common/e2e/models/Swap";
+import { Provider } from "@ledgerhq/live-common/e2e/enum/Provider";
+import {
+  setupEnv,
+  performSwapUntilQuoteSelectionStep,
+  revokeTokenApproval,
+  ensureTokenApproval,
+} from "tests/utils/swapUtils";
+import { liveDataWithAddressCommand } from "@ledgerhq/live-common/e2e/cliCommandsUtils";
+import { addTmsLink } from "tests/utils/allureUtils";
+import { getDescription } from "tests/utils/customJsonReporter";
+import BigNumber from "bignumber.js";
+import { pickRotatingProvider } from "@ledgerhq/live-common/e2e/swap";
+
+const xrayTicket = "B2CQA-4012";
+const fromAccount = TokenAccount.ETH_USDC_1;
+const toAccount = Account.ETH_1;
+const eligibleProviders = [Provider.THORCHAIN, Provider.LIFI, Provider.OKX];
+const provider = pickRotatingProvider(eligibleProviders);
+
+test.describe("Token reapproval - flow", () => {
+  test.skip(
+    process.env.DISABLE_TRANSACTION_BROADCAST !== "0",
+    "Token re-approval (bigger amount) flow requires broadcast to be enabled — runs on Monday nightly only",
+  );
+
+  setupEnv(false);
+
+  test.use({
+    teamOwner: Team.SWAP,
+    userdata: "skip-onboarding-with-last-seen-device",
+    speculosApp: provider.app ?? fromAccount.currency.speculosApp,
+
+    cliCommandsOnApp: [
+      [
+        {
+          app: fromAccount.currency.speculosApp,
+          cmd: liveDataWithAddressCommand(fromAccount),
+        },
+        {
+          app: toAccount.currency.speculosApp,
+          cmd: liveDataWithAddressCommand(toAccount),
+        },
+      ],
+      { scope: "test" },
+    ],
+  });
+
+  test(
+    "Swap - token reapproval flow",
+    {
+      tag: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@ethereum", "@family-evm"],
+      annotation: [
+        {
+          type: "TMS",
+          description: xrayTicket,
+        },
+      ],
+    },
+    async ({ app }) => {
+      await app.swap.getSelectedProvider(provider.uiName);
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+      await revokeTokenApproval(fromAccount, provider);
+      const minAmount = await app.swap.getMinimumAmount(fromAccount, toAccount);
+      const smallAmount = new BigNumber(minAmount).div(4).toFixed();
+      await ensureTokenApproval(fromAccount, provider, smallAmount);
+      const swap = new Swap(fromAccount, toAccount, minAmount, provider);
+      await performSwapUntilQuoteSelectionStep(app, swap, minAmount);
+      await app.swap.selectSpecificProvider(provider);
+      await app.swap.clickExchangeButton(provider.name);
+      await app.swap.expectTwoStepApprovalScreen();
+      await app.swap.clickGiveApprovalButton();
+      await app.swap.clickContinueButton();
+      await app.speculos.signTokenApproval();
+      await app.swap.expectTwoStepSignScreen();
+      await app.swap.expectTransactionSentToasterToBeVisible();
+    },
+  );
+});

--- a/e2e/desktop/tests/specs/token.reapproval.swap.spec.ts
+++ b/e2e/desktop/tests/specs/token.reapproval.swap.spec.ts
@@ -3,6 +3,7 @@ import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { Account, TokenAccount } from "@ledgerhq/live-common/e2e/enum/Account";
 import { Swap } from "@ledgerhq/live-common/e2e/models/Swap";
 import { Provider } from "@ledgerhq/live-common/e2e/enum/Provider";
+import { AppInfos } from "@ledgerhq/live-common/e2e/enum/AppInfos";
 import {
   setupEnv,
   performSwapUntilQuoteSelectionStep,
@@ -18,7 +19,13 @@ import { pickRotatingProvider } from "@ledgerhq/live-common/e2e/swap";
 const xrayTicket = "B2CQA-4012";
 const fromAccount = TokenAccount.ETH_USDC_1;
 const toAccount = Account.ETH_1;
-const eligibleProviders = [Provider.THORCHAIN, Provider.LIFI, Provider.OKX];
+const eligibleProviders = [
+  Provider.THORCHAIN,
+  Provider.LIFI,
+  Provider.OKX,
+  Provider.ONE_INCH,
+  Provider.VELORA,
+];
 const provider = pickRotatingProvider(eligibleProviders);
 
 test.describe("Token reapproval - flow", () => {
@@ -32,7 +39,7 @@ test.describe("Token reapproval - flow", () => {
   test.use({
     teamOwner: Team.SWAP,
     userdata: "skip-onboarding-with-last-seen-device",
-    speculosApp: provider.app ?? fromAccount.currency.speculosApp,
+    speculosApp: AppInfos.ETHEREUM,
 
     cliCommandsOnApp: [
       [

--- a/e2e/desktop/tests/specs/token.reapproval.swap.spec.ts
+++ b/e2e/desktop/tests/specs/token.reapproval.swap.spec.ts
@@ -61,7 +61,7 @@ test.describe("Token reapproval - flow", () => {
       ],
     },
     async ({ app }) => {
-      await app.swap.getSelectedProvider(provider.uiName);
+      await app.swap.logSelectedProvider(provider.uiName);
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await revokeTokenApproval(fromAccount, provider);
       const minAmount = await app.swap.getMinimumAmount(fromAccount, toAccount);

--- a/e2e/desktop/tests/specs/token.reapproval.swap.spec.ts
+++ b/e2e/desktop/tests/specs/token.reapproval.swap.spec.ts
@@ -64,8 +64,9 @@ test.describe("Token reapproval - flow", () => {
       await app.swap.logSelectedProvider(provider.uiName);
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await revokeTokenApproval(fromAccount, provider);
+      await app.swap.ensureRevokeTokenApproval(fromAccount, provider);
       const minAmount = await app.swap.getMinimumAmount(fromAccount, toAccount);
-      const smallAmount = new BigNumber(minAmount).div(4).toFixed();
+      const smallAmount = new BigNumber(minAmount).div(4).toFixed(6, BigNumber.ROUND_DOWN);
       await ensureTokenApproval(fromAccount, provider, smallAmount);
       const swap = new Swap(fromAccount, toAccount, minAmount, provider);
       await performSwapUntilQuoteSelectionStep(app, swap, minAmount);

--- a/e2e/desktop/tests/specs/token.reapproval.swap.spec.ts
+++ b/e2e/desktop/tests/specs/token.reapproval.swap.spec.ts
@@ -38,7 +38,7 @@ test.describe("Token reapproval - flow", () => {
   test.use({
     teamOwner: Team.SWAP,
     userdata: "skip-onboarding-with-last-seen-device",
-    speculosApp: AppInfos.ETHEREUM,
+    speculosApp: fromAccount.currency.speculosApp ?? AppInfos.ETHEREUM,
 
     cliCommandsOnApp: [
       [

--- a/e2e/desktop/tests/specs/token.reapproval.swap.spec.ts
+++ b/e2e/desktop/tests/specs/token.reapproval.swap.spec.ts
@@ -16,7 +16,6 @@ import { getDescription } from "tests/utils/customJsonReporter";
 import BigNumber from "bignumber.js";
 import { pickRotatingProvider } from "@ledgerhq/live-common/e2e/swap";
 
-const xrayTicket = "B2CQA-4012";
 const fromAccount = TokenAccount.ETH_USDC_1;
 const toAccount = Account.ETH_1;
 const eligibleProviders = [
@@ -63,7 +62,7 @@ test.describe("Token reapproval - flow", () => {
       annotation: [
         {
           type: "TMS",
-          description: xrayTicket,
+          description: "B2CQA-4012",
         },
       ],
     },

--- a/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenReapprovalFlow.ts
+++ b/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenReapprovalFlow.ts
@@ -26,7 +26,7 @@ export function runSwapTokenReapprovalFlow(
       await app.speculos.setExchangeDependencies(fromAccount, toAccount);
       await beforeAllFunctionSwap({
         userdata: "skip-onboarding",
-        speculosApp: AppInfos.ETHEREUM,
+        speculosApp: fromAccount.currency.speculosApp ?? AppInfos.ETHEREUM,
 
         cliCommandsOnApp: [
           {

--- a/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenReapprovalFlow.ts
+++ b/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenReapprovalFlow.ts
@@ -1,0 +1,69 @@
+import { Account, TokenAccount } from "@ledgerhq/live-common/e2e/enum/Account";
+import {
+  ensureTokenApproval,
+  performSwapUntilQuoteSelectionStep,
+  revokeTokenApproval,
+} from "../../../utils/swapUtils";
+import { Provider } from "@ledgerhq/live-common/e2e/enum/Provider";
+import { beforeAllFunctionSwap } from "../swap.setup";
+import BigNumber from "bignumber.js";
+
+export function runSwapTokenReapprovalFlow(
+  fromAccount: TokenAccount,
+  toAccount: Account,
+  provider: Provider,
+  tmsLinks: string[],
+  tags: string[],
+) {
+  const isBroadcastEnabled = process.env.DISABLE_TRANSACTION_BROADCAST === "0";
+  if (!isBroadcastEnabled) {
+    console.warn(
+      "[reapproval.swap.spec] Skipping — requires DISABLE_TRANSACTION_BROADCAST=0 (Monday nightly only)",
+    );
+  }
+  (isBroadcastEnabled ? describe : describe.skip)("Token reapproval - flow", () => {
+    beforeAll(async () => {
+      await app.speculos.setExchangeDependencies(fromAccount, toAccount);
+      await beforeAllFunctionSwap({
+        userdata: "skip-onboarding",
+        speculosApp: provider.app ?? fromAccount.currency.speculosApp,
+        cliCommandsOnApp: [
+          {
+            app: fromAccount.currency.speculosApp,
+            cmd: liveDataWithAddressCommand(fromAccount),
+          },
+          {
+            app: toAccount.currency.speculosApp,
+            cmd: liveDataWithAddressCommand(toAccount),
+          },
+        ],
+      });
+    });
+
+    tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
+    tags.forEach(tag => $Tag(tag));
+
+    it("Swap - token reapproval flow", async () => {
+      await app.swap.getSelectedProvider(provider.uiName);
+      await revokeTokenApproval(fromAccount, provider);
+      const minAmount = await app.swapLiveApp.getMinimumAmount(fromAccount, toAccount);
+      const smallAmount = new BigNumber(minAmount).div(4).toFixed();
+      await ensureTokenApproval(fromAccount, provider, smallAmount);
+      const swap = new Swap(fromAccount, toAccount, minAmount, provider);
+      await performSwapUntilQuoteSelectionStep(
+        swap.accountToDebit,
+        swap.accountToCredit,
+        minAmount,
+        true,
+      );
+      await app.swapLiveApp.selectSpecificProvider(provider.uiName);
+      await app.swapLiveApp.tapExecuteSwap(provider.uiName);
+      await app.swapLiveApp.expectTwoStepApprovalScreen();
+      await app.swapLiveApp.tapGiveApprovalButton();
+      await app.send.summaryContinue();
+      await app.speculos.signTokenApproval();
+      await app.swapLiveApp.expectTwoStepSignScreen();
+      await app.swapLiveApp.expectExecuteSwapOnStepApproval();
+    });
+  });
+}

--- a/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenReapprovalFlow.ts
+++ b/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenReapprovalFlow.ts
@@ -44,7 +44,7 @@ export function runSwapTokenReapprovalFlow(
     tags.forEach(tag => $Tag(tag));
 
     it("Swap - token reapproval flow", async () => {
-      await app.swap.getSelectedProvider(provider.uiName);
+      await app.swap.logSelectedProvider(provider.uiName);
       await revokeTokenApproval(fromAccount, provider);
       const minAmount = await app.swapLiveApp.getMinimumAmount(fromAccount, toAccount);
       const smallAmount = new BigNumber(minAmount).div(4).toFixed();

--- a/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenReapprovalFlow.ts
+++ b/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenReapprovalFlow.ts
@@ -62,7 +62,6 @@ export function runSwapTokenReapprovalFlow(
       await app.swapLiveApp.tapGiveApprovalButton();
       await app.send.summaryContinue();
       await app.speculos.signTokenApproval();
-      await app.swapLiveApp.expectTwoStepSignScreen();
       await app.swapLiveApp.expectExecuteSwapOnStepApproval();
     });
   });

--- a/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenReapprovalFlow.ts
+++ b/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenReapprovalFlow.ts
@@ -46,8 +46,9 @@ export function runSwapTokenReapprovalFlow(
     it("Swap - token reapproval flow", async () => {
       await app.swap.logSelectedProvider(provider.uiName);
       await revokeTokenApproval(fromAccount, provider);
+      await app.swap.ensureRevokeTokenApproval(fromAccount, provider);
       const minAmount = await app.swapLiveApp.getMinimumAmount(fromAccount, toAccount);
-      const smallAmount = new BigNumber(minAmount).div(4).toFixed();
+      const smallAmount = new BigNumber(minAmount).div(4).toFixed(6, BigNumber.ROUND_DOWN);
       await ensureTokenApproval(fromAccount, provider, smallAmount);
       const swap = new Swap(fromAccount, toAccount, minAmount, provider);
       await performSwapUntilQuoteSelectionStep(

--- a/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenReapprovalFlow.ts
+++ b/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenReapprovalFlow.ts
@@ -26,7 +26,8 @@ export function runSwapTokenReapprovalFlow(
       await app.speculos.setExchangeDependencies(fromAccount, toAccount);
       await beforeAllFunctionSwap({
         userdata: "skip-onboarding",
-        speculosApp: provider.app ?? fromAccount.currency.speculosApp,
+        speculosApp: AppInfos.ETHEREUM,
+
         cliCommandsOnApp: [
           {
             app: fromAccount.currency.speculosApp,

--- a/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenReapprovalRotatingProvider.spec.ts
+++ b/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenReapprovalRotatingProvider.spec.ts
@@ -1,0 +1,22 @@
+import { Provider } from "@ledgerhq/live-common/e2e/enum/Provider";
+import { runSwapTokenReapprovalFlow } from "./swapTokenReapprovalFlow";
+import { pickRotatingProvider } from "@ledgerhq/live-common/e2e/swap";
+
+const eligibleProviders = [Provider.THORCHAIN, Provider.LIFI, Provider.OKX];
+const provider = pickRotatingProvider(eligibleProviders);
+
+const swapTokenReapprovalFlowTestConfig = {
+  fromAccount: TokenAccount.ETH_USDC_1,
+  toAccount: Account.ETH_1,
+  provider,
+  tmsLinks: ["B2CQA-4012"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@ethereum", "@family-evm"],
+};
+
+runSwapTokenReapprovalFlow(
+  swapTokenReapprovalFlowTestConfig.fromAccount,
+  swapTokenReapprovalFlowTestConfig.toAccount,
+  swapTokenReapprovalFlowTestConfig.provider,
+  swapTokenReapprovalFlowTestConfig.tmsLinks,
+  swapTokenReapprovalFlowTestConfig.tags,
+);

--- a/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenReapprovalRotatingProvider.spec.ts
+++ b/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenReapprovalRotatingProvider.spec.ts
@@ -2,7 +2,13 @@ import { Provider } from "@ledgerhq/live-common/e2e/enum/Provider";
 import { runSwapTokenReapprovalFlow } from "./swapTokenReapprovalFlow";
 import { pickRotatingProvider } from "@ledgerhq/live-common/e2e/swap";
 
-const eligibleProviders = [Provider.THORCHAIN, Provider.LIFI, Provider.OKX];
+const eligibleProviders = [
+  Provider.THORCHAIN,
+  Provider.LIFI,
+  Provider.OKX,
+  Provider.ONE_INCH,
+  Provider.VELORA,
+];
 const provider = pickRotatingProvider(eligibleProviders);
 
 const swapTokenReapprovalFlowTestConfig = {


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _E2E test-only changes — no changeset required._
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Swap flow with ERC-20 re-approval (USDC on Ethereum, ThorChain / LiFi / OKX / 1INCH / Velora providers)

### 📝 Description

Follow-up to QAA-613 — same UI flow, different pre-condition.

This PR covers the case where the user already has a **non-zero but insufficient** ERC-20 allowance for the swap provider's spender contract, forcing Ledger Live to prompt a *re-approval* for a larger amount before the swap can proceed.

**Pre-condition setup (same on both platforms):**

1. Revoke any existing allowance to `0` via CLI (`revokeTokenApproval`).
2. CLI-approve a small amount (e.g. `minAmount / 4`) via `ensureTokenApproval` so the resulting on-chain allowance ends up well below `minAmount`.
3. Start the swap flow with `minAmount`, which forces Ledger Live to display the 2-step approval UI for the re-approval.

**Scope:**

- ERC-20 re-approval (2-step UI), triggered when current allowance is `> 0` but `< swap amount`.
- Token: **USDC on Ethereum** — not USDT (its contract reverts `approve(non-zero)` when the existing allowance is non-zero, which is a different 3-step scenario tracked elsewhere).
- Providers: any DEX that requires token approval *except* Uniswap (Permit2 is a separate 3-step flow). At runtime we weekly pick from **ThorChain / LiFi / OKX / 1Inch / Velora** via the new `pickRotatingProvider` helper, matching the QAA-613 approach.
- Platforms: **Ledger Live Desktop (Playwright)** and **Ledger Live Mobile (Detox)**, mirroring the QAA-613 spec structure.
- Runs on the **Monday nightly only** (requires `DISABLE_TRANSACTION_BROADCAST=0`).

**Acceptance:**

- New spec covers the full flow up to the 2-step sign screen (we do not broadcast the swap itself), tagged with TMS **B2CQA-4012**.
- Reuses existing helpers from QAA-613 (`revokeTokenApproval`, `ensureTokenApproval`, `expectTwoStepApprovalScreen`, `signTokenApproval`, `expectTwoStepSignScreen`).

### ❓ Context

- **JIRA or GitHub link**: [QAA-1210](https://ledgerhq.atlassian.net/browse/QAA-1210)
- Desktop Manual CI : https://github.com/LedgerHQ/ledger-live/actions/runs/26107975301
- Mobile Manual CI: https://github.com/LedgerHQ/ledger-live/actions/runs/26108033704
---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-1210]: https://ledgerhq.atlassian.net/browse/QAA-1210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ