### PR TITLE
[LWDM] chore(live-common): prepare transaction async

### DIFF
--- a/.changeset/spicy-ligers-think.md
+++ b/.changeset/spicy-ligers-think.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Await loadTransactionForFamily in transaction helpers to forward-compatibly support async coin-module loaders

--- a/libs/ledger-live-common/src/transaction/index.ts
+++ b/libs/ledger-live-common/src/transaction/index.ts
@@ -11,12 +11,12 @@ import { loadTransactionForFamily } from "../coin-modules/registry";
 import type { Account } from "@ledgerhq/types-live";
 
 export const fromTransactionRaw = async (tr: TransactionRaw): Promise<Transaction> => {
-  const TM = loadTransactionForFamily(tr.family);
+  const TM = await loadTransactionForFamily(tr.family);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return TM.fromTransactionRaw(tr as any) as unknown as Transaction;
 };
 export const toTransactionRaw = async (t: Transaction): Promise<TransactionRaw> => {
-  const TM = loadTransactionForFamily(t.family);
+  const TM = await loadTransactionForFamily(t.family);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return TM.toTransactionRaw(t as any) as unknown as TransactionRaw;
 };
@@ -25,7 +25,7 @@ export const fromTransactionStatusRaw = async (
   tr: TransactionStatusRaw,
   family: string,
 ): Promise<TransactionStatus> => {
-  const TM = loadTransactionForFamily(family);
+  const TM = await loadTransactionForFamily(family);
   if (!TM.fromTransactionStatusRaw)
     throw new Error(`fromTransactionStatusRaw not implemented for family "${family}"`);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -35,7 +35,7 @@ export const toTransactionStatusRaw = async (
   t: TransactionStatus,
   family: string,
 ): Promise<TransactionStatusRaw> => {
-  const TM = loadTransactionForFamily(family);
+  const TM = await loadTransactionForFamily(family);
   if (!TM.toTransactionStatusRaw)
     throw new Error(`toTransactionStatusRaw not implemented for family "${family}"`);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -43,7 +43,7 @@ export const toTransactionStatusRaw = async (
 };
 
 export const formatTransaction = async (t: Transaction, a: Account): Promise<string> => {
-  const TM = loadTransactionForFamily(t.family);
+  const TM = await loadTransactionForFamily(t.family);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return TM.formatTransaction ? await TM.formatTransaction(t as any, a as any) : "";
 };
@@ -53,7 +53,7 @@ export const formatTransactionStatus = async (
   ts: TransactionStatus,
   mainAccount: Account,
 ): Promise<string> => {
-  const TM = loadTransactionForFamily(t.family);
+  const TM = await loadTransactionForFamily(t.family);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return TM.formatTransactionStatus ? TM.formatTransactionStatus(t as any, ts as any, mainAccount as any) : "";
 };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Pre-existing behavior; awaiting a sync value is a no-op.
- [ ] **Impact of the changes:**
  - Forward-compat only: makes the transaction (raw/status/format) helpers ready for the upcoming async `loadTransactionForFamily`. No runtime change today.

### 📝 Description

Small step toward #17155 (move coin-module loaders to `import()` so `loadTransactionForFamily` returns a `Promise`).

The four transaction helpers (`fromTransactionRaw`, `toTransactionRaw`, `fromTransactionStatusRaw`, `toTransactionStatusRaw`, `formatTransaction`, `formatTransactionStatus`) now `await loadTransactionForFamily(...)`. Today the loader is synchronous, so `await` resolves immediately and behavior is unchanged. Once the loader becomes async, these call sites are already compatible — no follow-up needed here.

```diff
-  const TM = loadTransactionForFamily(t.family);
+  const TM = await loadTransactionForFamily(t.family);
```

### ❓ Context

- **JIRA or GitHub link**: #17155 (LIVE-26176)
- **ADR link (if any)**: [ADR-033](https://ledgerhq.atlassian.net/wiki/spaces/CF/pages/7041482926/Coin+modules+-+ADR-033+-+Reverse+CoinModule+Wallet+dependency)