### PR TITLE
fix(ci): install shared and domain packages when running features tests

### DIFF
--- a/.github/workflows/test-features-reusable.yml
+++ b/.github/workflows/test-features-reusable.yml
@@ -52,7 +52,7 @@ jobs:
           turbo-server-token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
 
       - name: Install dependencies
-        run: pnpm i --filter="./features/**"
+        run: pnpm i --filter="./features/**" --filter="./shared/**" --filter="./domain/**"
 
       - name: Run coverage on feature packages
         env:


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** CI-only change — verified by the features test job on PR #17239.
- [ ] **Impact of the changes:**
  - Features packages that depend on `@shared/*` or `@domain/*` will now have those transitive deps available during the test run.
  - No behavioral change — only affects the install scope during CI.
  - QA focus: none.

### 📝 Description

`test-features-reusable.yml` only ran `pnpm i --filter="./features/**"`, which symlinks workspace deps but does not install their transitive dependencies. When a feature package depends on `domain` or `shared` it can have issues. For example if the feature require `@shared/feature-flags`, the tests fail with `Cannot find module 'zod'` because `zod` is a dep of `@shared/feature-flags`, not of the feature package itself.

Mirrors the existing pattern in `test-domain-reusable.yml`:
```diff
- run: pnpm i --filter="./features/**"
+ run: pnpm i --filter="./features/**" --filter="./shared/**" --filter="./domain/**"
```

Features can depend on `@shared/*` and `@domain/*` per the module-boundary constraints, so both scopes need to be installed.

### ❓ Context

- Discovered while working on [LIVE-30360](https://ledgerhq.atlassian.net/browse/LIVE-30360) (`@features/platform-feature-flags`), the first features package to depend on `@shared/*`.

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30360]: https://ledgerhq.atlassian.net/browse/LIVE-30360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ