### PR TITLE
[LWDM] Undelegate doesn't work

### DIFF
--- a/.changeset/moody-trainers-itch.md
+++ b/.changeset/moody-trainers-itch.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-sui": patch
+---
+
+fix(coin-sui): forward stakedSuiId and useAllAmount in getFeesForTransaction to fix undelegate modal crash (TypeError reading 'Object')

--- a/libs/coin-modules/coin-sui/src/bridge/getFeesForTransaction.test.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/getFeesForTransaction.test.ts
@@ -1,3 +1,4 @@
+import { BigNumber } from "bignumber.js";
 import { createFixtureAccount, createFixtureTransaction } from "../types/bridge.fixture";
 import getEstimatedFees from "./getFeesForTransaction";
 
@@ -32,5 +33,44 @@ describe("getEstimatedFees", () => {
     expect(estimateFees).toHaveBeenCalledTimes(1);
     expect(estimateFees.mock.lastCall).not.toBeNull();
     expect(result.toString()).toEqual(gasBudget.toString());
+  });
+
+  it("forwards stakedSuiId and useAllAmount when mode is undelegate", async () => {
+    // GIVEN
+    const account = createFixtureAccount();
+    const stakedSuiId = "0xa5581752d1f6c436bb902641ee080450f2fa42bd2ef3f3cae262824cb3703fa6";
+    const undelegateTransaction = createFixtureTransaction({
+      mode: "undelegate" as const,
+      stakedSuiId,
+      useAllAmount: true,
+      amount: BigNumber(1000000000),
+    });
+    estimateFees.mockResolvedValue(BigInt("3976000"));
+
+    // WHEN
+    await getEstimatedFees({ account, transaction: undelegateTransaction });
+
+    // THEN
+    expect(estimateFees).toHaveBeenCalledTimes(1);
+    expect(estimateFees.mock.lastCall[0]).toMatchObject({
+      type: "undelegate",
+      intentType: "staking",
+      stakedSuiId,
+      useAllAmount: true,
+    });
+  });
+
+  it("omits stakedSuiId from the call when undefined (does not coerce to empty string)", async () => {
+    // GIVEN
+    const account = createFixtureAccount();
+    const sendTransaction = createFixtureTransaction(); // mode: "send", no stakedSuiId
+    estimateFees.mockResolvedValue(BigInt("3976000"));
+
+    // WHEN
+    await getEstimatedFees({ account, transaction: sendTransaction });
+
+    // THEN
+    const args = estimateFees.mock.lastCall[0];
+    expect("stakedSuiId" in args).toBe(false);
   });
 });

--- a/libs/coin-modules/coin-sui/src/bridge/getFeesForTransaction.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/getFeesForTransaction.ts
@@ -61,6 +61,8 @@ export default async function getEstimatedFees({
     type: transactionType,
     asset,
     currencyId: account.currency.id,
+    ...(transaction.useAllAmount !== undefined && { useAllAmount: transaction.useAllAmount }),
+    ...(transaction.stakedSuiId !== undefined && { stakedSuiId: transaction.stakedSuiId }),
   });
   return new BigNumber(fees.toString());
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
   - SUI Undelegate flow (primary): opening "Unstake assets" modal no longer throws TypeError: Cannot read properties of undefined (reading 'Object'); fees populate and the flow proceeds to the device step.
  - SUI Delegate / Send / Token Send (regression risk): fee estimation unchanged for these modes — added fields are spread conditionally and ignored downstream when mode ≠ undelegate.
  - Sign / broadcast path: unaffected — buildTransaction already forwarded these fields.

### 📝 Description

The SUI "Unstake assets" modal crashed on open with TypeError: Cannot read properties of undefined (reading 'Object').

  Cause: getFeesForTransaction forwarded only a subset of fields to estimateFees, dropping stakedSuiId and useAllAmount. The downstream createTransactionForUndelegate then ran tx.object(undefined), and Mysten's getIdFromCallArg dereferenced arg.Object on undefined.

  Fix: forward both fields from the transaction to estimateFees using a conditional spread, so missing values stay absent rather than being coerced to "" / false (which would mask programmer error by passing tx.object("") → resolves to 0x000…000 and surfaces as an opaque RPC error from the SUI node).

  Added two test cases in getFeesForTransaction.test.ts: one asserting stakedSuiId and useAllAmount are forwarded for mode: "undelegate", one asserting stakedSuiId is omitted (not coerced) when undefined.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30895](https://ledgerhq.atlassian.net/browse/LIVE-30895?atlOrigin=eyJpIjoiZWE0MzU1ZmVkN2FkNDI3YWFiZTlmNjNlYjU5MTIyZjgiLCJwIjoiaiJ9)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-30895]: https://ledgerhq.atlassian.net/browse/LIVE-30895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ