### PR TITLE
[LWM] fix(mobile): batch wipeCountervalues with reboot to avoid Fabric crash

### DIFF
--- a/.changeset/fix-lwm-clear-cache-fabric-crash.md
+++ b/.changeset/fix-lwm-clear-cache-fabric-crash.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix Android crash on clear cache flow. Dispatching `wipeCountervalues` inside `useCleanCache` caused every mounted `CounterValue` consumer to re-render against the wiped state in a separate React commit from the subsequent `reboot()`; under Fabric this produced an `IllegalStateException: The specified child already has a parent`. Wipe is now dispatched from the reboot middleware in the same synchronous tick as the reboot action so React batches both updates and the `RebootProvider` key change unmounts the subtree before any countervalue consumer re-renders.

--- a/apps/ledger-live-mobile/src/actions/general.ts
+++ b/apps/ledger-live-mobile/src/actions/general.ts
@@ -8,7 +8,6 @@ import type { FlattenAccountsOptions } from "@ledgerhq/live-common/account/index
 import type { TrackingPair } from "@ledgerhq/live-countervalues/types";
 import {
   useCalculateCountervalueCallback as useCalculateCountervalueCallbackCommon,
-  useCountervaluesPolling,
   useTrackingPairForAccounts,
 } from "@ledgerhq/live-countervalues-react";
 import { useDistribution as useLegacyDistribution } from "@ledgerhq/live-countervalues-react/portfolio";
@@ -114,7 +113,6 @@ export function useRefreshAccountsOrderingEffect({
 export function useCleanCache() {
   const dispatch = useDispatch();
   const accounts = useSelector(accountsSelector);
-  const { wipe } = useCountervaluesPolling();
   return useCallback(async () => {
     const cleared = await Promise.all(
       accounts.map(async account => {
@@ -125,9 +123,8 @@ export function useCleanCache() {
     dispatch(replaceAccounts(cleared));
 
     await clearBridgeCache();
-    wipe();
     flushAll();
-  }, [dispatch, accounts, wipe]);
+  }, [dispatch, accounts]);
 }
 
 export function useUserSettings() {

--- a/apps/ledger-live-mobile/src/middleware/__tests__/rebootMiddleware.test.ts
+++ b/apps/ledger-live-mobile/src/middleware/__tests__/rebootMiddleware.test.ts
@@ -1,0 +1,47 @@
+import { configureStore, Middleware } from "@reduxjs/toolkit";
+import { rebootMiddleware } from "../rebootMiddleware";
+import { reboot } from "~/actions/appstate";
+import { setCountervaluesState } from "~/actions/countervalues";
+import { AppStateActionTypes, CountervaluesActionTypes } from "~/actions/types";
+
+jest.mock("react-native-splash-screen", () => ({ show: jest.fn() }));
+
+function buildStore() {
+  const dispatched: string[] = [];
+  const recorder: Middleware = () => next => action => {
+    if (action && typeof action === "object" && "type" in action) {
+      dispatched.push((action as { type: string }).type);
+    }
+    return next(action);
+  };
+  const store = configureStore({
+    reducer: (state = {}) => state,
+    middleware: getDefault =>
+      getDefault({ serializableCheck: false, immutableCheck: false }).concat(
+        recorder,
+        rebootMiddleware as Middleware,
+      ),
+  });
+  return { store, dispatched };
+}
+
+describe("rebootMiddleware", () => {
+  it("dispatches wipeCountervalues immediately after the reboot action", () => {
+    const { store, dispatched } = buildStore();
+
+    store.dispatch(reboot());
+
+    expect(dispatched).toEqual([
+      AppStateActionTypes.INCREMENT_REBOOT_ID,
+      CountervaluesActionTypes.COUNTERVALUES_WIPE,
+    ]);
+  });
+
+  it("does not dispatch wipeCountervalues for unrelated actions", () => {
+    const { store, dispatched } = buildStore();
+
+    store.dispatch(setCountervaluesState({} as never));
+
+    expect(dispatched).not.toContain(CountervaluesActionTypes.COUNTERVALUES_WIPE);
+  });
+});

--- a/apps/ledger-live-mobile/src/middleware/rebootMiddleware.ts
+++ b/apps/ledger-live-mobile/src/middleware/rebootMiddleware.ts
@@ -1,5 +1,6 @@
 import { Middleware } from "@reduxjs/toolkit";
 import { AppStateActionTypes } from "../actions/types";
+import { wipeCountervalues } from "../actions/countervalues";
 import SplashScreen from "react-native-splash-screen";
 import { State } from "~/reducers/types";
 
@@ -11,12 +12,16 @@ const isRebootAction = (action: unknown): boolean => {
   return false;
 };
 
-export const rebootMiddleware: Middleware<object, State> = _store => next => async action => {
+export const rebootMiddleware: Middleware<object, State> = store => next => async action => {
   const result = next(action);
 
-  // Display splash screen whenever reboot ID is incremented
   if (isRebootAction(action)) {
     SplashScreen.show(); // on iOS it seems to not be exposed
+    // Dispatched in the same synchronous tick as the reboot so React batches both
+    // into one commit: the RebootProvider key change unmounts the subtree before
+    // any CounterValue consumer re-renders against the wiped state, which would
+    // otherwise trigger a Fabric "child already has a parent" crash.
+    store.dispatch(wipeCountervalues());
   }
 
   return result;


### PR DESCRIPTION
> 🍒 Cherry-pick of #17632 (release → develop). The conflict on `useCleanCache` was resolved to keep develop's `replaceAccounts` thunk shape; only the `wipe()` call and the `useCountervaluesPolling` import were dropped. Everything else (middleware, unit test, changeset) is identical to the release PR.

### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _New unit test on `rebootMiddleware` verifies `wipeCountervalues` is dispatched in the same tick as the reboot action and not for unrelated actions. The Fabric race itself can only be observed end-to-end (Detox)._
- [x] **Impact of the changes:**
  - Clear cache flow on Android (Settings > Help and MyWallet > Help)
  - Clear cache flow on iOS
  - Reboot via other entry points
  - Countervalue refresh after reboot

### 📝 Description

**Problem.** Tapping Clear in Settings > Help (or MyWallet > Help) crashes the Android app in staging/prod builds with:

```
java.lang.IllegalStateException: The specified child already has a parent.
You must call removeView() on the child's parent first.
  at com.facebook.react.views.view.ReactClippingViewManager.addView
  at com.facebook.react.fabric.mounting.SurfaceMountingManager.addViewAt
  at com.facebook.react.fabric.mounting.mountitems.IntBufferBatchMountItem.execute
```

`useCleanCache` dispatched `wipeCountervalues()` and `reboot()` in separate React commits. The first reset `countervalues.state` to `initialState` while the tree was still mounted — every `useCalculate` / `<CounterValue/>` consumer across portfolio, asset detail, account rows, send flow, etc. re-rendered simultaneously, many flipping between `<CurrencyUnitValue>` and `null` / `<NoCountervaluePlaceholder>`. The resulting `IntBufferBatchMountItem` carried a large set of view-remove/add operations and tripped the Fabric "child already has a parent" invariant. Reproducible 100% of the time in the Detox e2e for clear-cache (`SettingsHelpPage.clickOnClearCacheButton`).

**Fix.** `useCleanCache` no longer dispatches `wipeCountervalues`. The reboot middleware dispatches it immediately after `next(action)` when the action is `INCREMENT_REBOOT_ID`. Both updates land in the same synchronous tick — React 19 batches them into one commit and the `RebootProvider` `key` change unmounts the subtree before any countervalue consumer re-renders against the wiped state. The fresh tree mounts on already-wiped state.

```ts
// rebootMiddleware.ts
if (isRebootAction(action)) {
  SplashScreen.show();
  store.dispatch(wipeCountervalues());
}
```

```ts
// useCleanCache: wipe() removed; flushAll + reboot dispatched by callers as before
```

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30713](https://ledgerhq.atlassian.net/browse/LIVE-30713)
- **Cherry-picked from**: #17632 (base `release`)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-30713]: https://ledgerhq.atlassian.net/browse/LIVE-30713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ