### PR TITLE
[LWM] feat(mobile): make Asset Detail addresses pressable

### DIFF
--- a/.changeset/press-address-asset-detail.md
+++ b/.changeset/press-address-asset-detail.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add address row press handler on Asset Detail to navigate to the corresponding account

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/AddressesView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/AddressesView.tsx
@@ -21,6 +21,7 @@ type Props = Readonly<{
   hasData: boolean;
   onAddAccount: () => void;
   onSeeAll: () => void;
+  onAccountPress: (data: AddressAccountData) => void;
   isLoading: boolean;
 }>;
 
@@ -30,6 +31,7 @@ export function AddressesView({
   hasData,
   onAddAccount,
   onSeeAll,
+  onAccountPress,
   isLoading,
 }: Props) {
   const { t } = useTranslation();
@@ -60,7 +62,7 @@ export function AddressesView({
       </Subheader>
       <Box lx={{ gap: "s8" }}>
         {displayedAccounts.map(data => (
-          <AddressAccountItem key={data.id} data={data} />
+          <AddressAccountItem key={data.id} data={data} onPress={onAccountPress} />
         ))}
       </Box>
       {hasMore && (

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/__tests__/useAddressesViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/__tests__/useAddressesViewModel.test.ts
@@ -269,6 +269,92 @@ describe("useAddressesViewModel", () => {
     });
   });
 
+  describe("onAccountPress", () => {
+    it("navigates to the Account screen for a main account and fires analytics", () => {
+      const btcAccounts = [
+        genAccount("bitcoin-0", { currency: mockBtcCryptoCurrency, operationsSize: 0 }),
+      ];
+
+      const { result } = renderHook(
+        () =>
+          useAddressesViewModel(
+            mockBtcCryptoCurrency,
+            buildDistributionItem(mockBtcCryptoCurrency, btcAccounts),
+          ),
+        withRawAccounts(btcAccounts),
+      );
+
+      const [data] = result.current.displayedAccounts;
+      act(() => result.current.onAccountPress(data));
+
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Accounts, {
+        screen: ScreenName.Account,
+        params: { accountId: btcAccounts[0].id },
+      });
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "address",
+        currency: "bitcoin",
+        chain: "bitcoin",
+        page: "Asset Detail",
+      });
+    });
+
+    it("navigates to the parent account for a token account and tracks the chain", () => {
+      const ethAccount = genAccount("usdt-eth", {
+        currency: mockEthCryptoCurrency,
+        operationsSize: 0,
+      });
+      const ethSub = genTokenAccount(0, ethAccount, usdtEthToken);
+      ethSub.balance = new BigNumber(120_000_000);
+      ethAccount.subAccounts = [ethSub];
+
+      const { result } = renderHook(
+        () => useAddressesViewModel(usdtEthToken, buildDistributionItem(usdtEthToken, [ethSub])),
+        withRawAccounts([ethAccount]),
+      );
+
+      const [data] = result.current.displayedAccounts;
+      act(() => result.current.onAccountPress(data));
+
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Accounts, {
+        screen: ScreenName.Account,
+        params: {
+          currencyId: mockEthCryptoCurrency.id,
+          parentId: ethAccount.id,
+          accountId: ethSub.id,
+        },
+      });
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "address",
+        currency: usdtEthToken.id,
+        chain: mockEthCryptoCurrency.id,
+        page: "Asset Detail",
+      });
+    });
+
+    it("does nothing when currency is undefined", () => {
+      const btcAccount = genAccount("bitcoin-0", {
+        currency: mockBtcCryptoCurrency,
+        operationsSize: 0,
+      });
+
+      const { result } = renderHook(() => useAddressesViewModel(undefined, undefined));
+
+      act(() =>
+        result.current.onAccountPress({
+          id: btcAccount.id,
+          account: btcAccount,
+          balanceAccount: btcAccount,
+          name: "name",
+          truncatedAddress: "addr",
+        }),
+      );
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(track).not.toHaveBeenCalled();
+    });
+  });
+
   describe("onAddAccount", () => {
     it("navigates to device selection and fires analytics", () => {
       const btcAccounts = [

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/components/AddressAccountItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/components/AddressAccountItem.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from "react";
+import React, { memo, useCallback } from "react";
 import {
   Box,
   Card,
@@ -15,14 +15,21 @@ import type { AddressAccountData } from "../useAddressesViewModel";
 
 type Props = Readonly<{
   data: AddressAccountData;
+  onPress: (data: AddressAccountData) => void;
 }>;
 
-export const AddressAccountItem = memo(function AddressAccountItem({ data }: Props) {
+export const AddressAccountItem = memo(function AddressAccountItem({ data, onPress }: Props) {
   const { account, balanceAccount, name, truncatedAddress } = data;
   const { formattedBalance, formattedCounterValue } = useFormattedAccountBalance(balanceAccount);
 
+  const handlePress = useCallback(() => onPress(data), [onPress, data]);
+
   return (
-    <Card type="info" testID={`asset-detail-address-item-${account.id}`}>
+    <Card
+      type="interactive"
+      onPress={handlePress}
+      testID={`asset-detail-address-item-${account.id}`}
+    >
       <CardHeader>
         <CardLeading>
           <CardContent>

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/useAddressesViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/useAddressesViewModel.ts
@@ -103,11 +103,41 @@ export function useAddressesViewModel(
     });
   }, [navigation, currency, allAccountIds]);
 
+  const onAccountPress = useCallback(
+    (data: AddressAccountData) => {
+      if (!currency) return;
+      const { account, balanceAccount } = data;
+      track("button_clicked", {
+        button: "address",
+        currency: currency.id,
+        chain: account.currency.id,
+        page: "Asset Detail",
+      });
+      if (balanceAccount.type === "TokenAccount") {
+        navigation.navigate(NavigatorName.Accounts, {
+          screen: ScreenName.Account,
+          params: {
+            currencyId: account.currency.id,
+            parentId: account.id,
+            accountId: balanceAccount.id,
+          },
+        });
+        return;
+      }
+      navigation.navigate(NavigatorName.Accounts, {
+        screen: ScreenName.Account,
+        params: { accountId: account.id },
+      });
+    },
+    [navigation, currency],
+  );
+
   return {
     displayedAccounts,
     hasMore,
     hasData: displayedAccounts.length > 0,
     onAddAccount,
     onSeeAll,
+    onAccountPress,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/useAddressesViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/useAddressesViewModel.ts
@@ -113,20 +113,17 @@ export function useAddressesViewModel(
         chain: account.currency.id,
         page: "Asset Detail",
       });
-      if (balanceAccount.type === "TokenAccount") {
-        navigation.navigate(NavigatorName.Accounts, {
-          screen: ScreenName.Account,
-          params: {
-            currencyId: account.currency.id,
-            parentId: account.id,
-            accountId: balanceAccount.id,
-          },
-        });
-        return;
-      }
+      const params =
+        balanceAccount.type === "TokenAccount"
+          ? {
+              currencyId: account.currency.id,
+              parentId: account.id,
+              accountId: balanceAccount.id,
+            }
+          : { accountId: account.id };
       navigation.navigate(NavigatorName.Accounts, {
         screen: ScreenName.Account,
-        params: { accountId: account.id },
+        params,
       });
     },
     [navigation, currency],


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Pressing an address row on the Asset Detail screen navigates to the correct account screen (main account for coins, token account for tokens).
  - Verify the `button_clicked` analytics event fires with `{ page: "Asset Detail", button: "address", currency, chain }` on press.
  - Regression-check the rest of the Addresses section (Add account, See all, list rendering, skeleton/empty state).

### 📝 Description

Previously, the address rows shown in the Asset Detail screen's Addresses section were not interactive — there was no way to jump from an asset summary into a specific account.

This PR makes each address row pressable. Tapping a row now navigates to `ScreenName.Account` (through `NavigatorName.Accounts`) and fires a `button_clicked` analytics event including the account's chain so multi-network tokens can be analyzed. For token accounts, navigation passes `currencyId`, `parentId`, and `accountId` so the right token account is opened.


https://github.com/user-attachments/assets/65909d60-96e8-4047-8c8f-98a308080f25






### ❓ Context

- **JIRA or GitHub link**: [LIVE-30921](https://ledgerhq.atlassian.net/browse/LIVE-30921)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30921]: https://ledgerhq.atlassian.net/browse/LIVE-30921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ