### PR TITLE
[LWD] feat(desktop): add text truncation with tooltips to assets table

### DIFF
--- a/.changeset/breezy-coats-teach.md
+++ b/.changeset/breezy-coats-teach.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add text truncation with tooltips to Assets table Name and Balance columns, and hide Price column below xl breakpoint for responsive layout

--- a/apps/ledger-live-desktop/src/mvvm/components/Cells/BalanceCell/BalanceCellView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/Cells/BalanceCell/BalanceCellView.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { TableCellContent } from "@ledgerhq/lumen-ui-react";
+import { TruncatedText } from "LLD/components/TruncatedText";
 
 type BalanceCellViewProps = {
   readonly formattedBalance: string;
@@ -9,6 +10,6 @@ type BalanceCellViewProps = {
 export const BalanceCellView = ({ formattedBalance, className }: BalanceCellViewProps) => (
   <TableCellContent
     align="end"
-    title={className ? <span className={className}>{formattedBalance}</span> : formattedBalance}
+    title={<TruncatedText text={formattedBalance} className={className} />}
   />
 );

--- a/apps/ledger-live-desktop/src/mvvm/components/TruncatedText/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TruncatedText/index.tsx
@@ -1,0 +1,35 @@
+import React, { useCallback, useRef, useState } from "react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@ledgerhq/lumen-ui-react";
+import { cn } from "LLD/utils/cn";
+
+type TruncatedTextProps = Readonly<{
+  text: string;
+  className?: string;
+}>;
+
+export function TruncatedText({ text, className }: TruncatedTextProps) {
+  const textRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    if (!nextOpen) {
+      setOpen(false);
+      return;
+    }
+    const element = textRef.current;
+    if (element && element.scrollWidth > element.clientWidth) {
+      setOpen(true);
+    }
+  }, []);
+
+  return (
+    <Tooltip open={open} onOpenChange={handleOpenChange}>
+      <TooltipTrigger asChild>
+        <div ref={textRef} className={cn("min-w-0 max-w-full truncate", className)}>
+          {text}
+        </div>
+      </TooltipTrigger>
+      <TooltipContent>{text}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useTable.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useTable.tsx
@@ -21,6 +21,7 @@ import { PriceCell } from "../components/Cells/PriceCell";
 import { BalanceCell } from "LLD/components/Cells/BalanceCell";
 import { CounterValueCell } from "LLD/components/Cells/CounterValueCell";
 import { TrendCell } from "../components/Cells/TrendCell";
+import { TruncatedText } from "LLD/components/TruncatedText";
 import { sanitizeAssetNameForTestId } from "../utils/assetTableHelpers";
 import type { AssetTableItem } from "../types";
 
@@ -51,23 +52,22 @@ export const useTable = (assets: AssetTableItem[], options?: UseAssetTableOption
             `${row.original.currency.name}-${row.original.currency.id}`,
           );
           return (
-            <div data-testid={`w40-asset-row-${assetTestId}`}>
-              <TableCellContent
-                leadingContent={
-                  row.original.isPlaceholder || shouldDisplayAggregatedAssets ? (
-                    <CryptoIcon
-                      ledgerId={row.original.currency.id}
-                      ticker={row.original.currency.ticker}
-                      size={getValidCryptoIconSize(32)}
-                    />
-                  ) : (
-                    <CryptoCurrencyIcon currency={row.original.currency} size={32} />
-                  )
-                }
-                title={row.original.currency.name}
-                description={row.original.currency.ticker}
-              />
-            </div>
+            <TableCellContent
+              data-testid={`w40-asset-row-${assetTestId}`}
+              leadingContent={
+                row.original.isPlaceholder || shouldDisplayAggregatedAssets ? (
+                  <CryptoIcon
+                    ledgerId={row.original.currency.id}
+                    ticker={row.original.currency.ticker}
+                    size={getValidCryptoIconSize(32)}
+                  />
+                ) : (
+                  <CryptoCurrencyIcon currency={row.original.currency} size={32} />
+                )
+              }
+              title={<TruncatedText text={row.original.currency.name} />}
+              description={row.original.currency.ticker}
+            />
           );
         },
       },
@@ -81,7 +81,7 @@ export const useTable = (assets: AssetTableItem[], options?: UseAssetTableOption
             placeholderPrice={row.original.placeholderPrice}
           />
         ),
-        meta: { align: "end" },
+        meta: { align: "end", hideBelow: "xl" },
       },
       {
         accessorKey: "balance",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Assets table rendering and responsiveness
  - Name and Balance column display with truncation
  - Tooltip visibility on hover for truncated text
  - Price column visibility at different screen sizes

### 📝 Description

This PR improves the Assets table layout by adding text truncation with tooltips and responsive column hiding:

**Problem**: When the Assets table is rendered in constrained layouts (e.g., narrower panels), long asset names and balance values were either truncating without indication or causing layout issues.

**Solution**: 
- Created a new `TruncatedText` component that detects when text overflows and conditionally wraps it in a Lumen `Tooltip`
- Applied text truncation to the Name column (asset name) with hover tooltip to show full text
- Applied text truncation to the Balance column with hover tooltip to show full balance
- Hid the Price column below xl breakpoint (1280px) to improve responsiveness in tight layouts

**Technical Details**:
- `TruncatedText` uses `useLayoutEffect` with `ResizeObserver` to detect overflow
- Tooltip only displays when the user hovers and text is actually truncated
- Uses `min-w-0 max-w-full truncate` for proper flex shrinking and truncation
- Lumen `Tooltip` with controlled open state via `onOpenChange` callback

Before

https://github.com/user-attachments/assets/b0aadc7d-aad1-4d10-9d91-3c3190d0d764

After

https://github.com/user-attachments/assets/dbf94162-526d-4bfd-a8fe-a2561184305a



E2E run=> https://github.com/LedgerHQ/ledger-live/actions/runs/26154276803



### ❓ Context

- **JIRA or GitHub link**: [LIVE-30910](https://ledgerhq.atlassian.net/browse/LIVE-30910)

[LIVE-30910]: https://ledgerhq.atlassian.net/browse/LIVE-30910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ