### PR TITLE
[LWM] fix(mobile): use interactive Card type for Asset Detail Earn cards

### DIFF
--- a/.changeset/asset-detail-earn-card-interactive.md
+++ b/.changeset/asset-detail-earn-card-interactive.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Use interactive Card type for Asset Detail Earn banner and deposit card

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/EarnBannerView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/EarnBannerView.tsx
@@ -1,17 +1,17 @@
 import React from "react";
 import {
+  Box,
   Card,
   CardContent,
   CardContentDescription,
   CardContentTitle,
   CardHeader,
   CardLeading,
-  IconButton,
-  Pressable,
 } from "@ledgerhq/lumen-ui-rnative";
 import { Plus } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { useTranslation } from "~/context/Locale";
 import { ASSET_DETAIL_TEST_IDS } from "LLM/features/AssetDetail/testIds";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 
 type Props = Readonly<{
   label: string;
@@ -22,26 +22,32 @@ export function EarnBannerView({ label, onPress }: Props) {
   const { t } = useTranslation();
 
   return (
-    <Pressable onPress={onPress} testID={ASSET_DETAIL_TEST_IDS.earnBanner}>
-      <Card type="info">
-        <CardHeader>
-          <CardLeading>
-            <CardContent>
-              <CardContentTitle>{label}</CardContentTitle>
-              <CardContentDescription>
-                {t("assetDetail.balanceDetails.earnBannerSubtitle")}
-              </CardContentDescription>
-            </CardContent>
-          </CardLeading>
-          <IconButton
-            appearance="transparent"
-            size="sm"
-            icon={Plus}
-            accessibilityLabel={t("assetDetail.balanceDetails.earnBannerAction")}
-            onPress={onPress}
-          />
-        </CardHeader>
-      </Card>
-    </Pressable>
+    <Card
+      onPress={onPress}
+      testID={ASSET_DETAIL_TEST_IDS.earnBanner}
+      accessibilityLabel={t("assetDetail.balanceDetails.earnBannerAction")}
+    >
+      <CardHeader>
+        <CardLeading>
+          <CardContent>
+            <CardContentTitle>{label}</CardContentTitle>
+            <CardContentDescription>
+              {t("assetDetail.balanceDetails.earnBannerSubtitle")}
+            </CardContentDescription>
+          </CardContent>
+        </CardLeading>
+        <Box lx={IconWrapper}>
+          <Plus size={20} color="base" />
+        </Box>
+      </CardHeader>
+    </Card>
   );
 }
+
+const IconWrapper: LumenViewStyle = {
+  borderRadius: "full",
+  backgroundColor: "mutedTransparent",
+  justifyContent: "center",
+  alignItems: "center",
+  padding: "s10",
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/EarnCardsView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/EarnCardsView.tsx
@@ -7,7 +7,6 @@ import {
   CardContentTitle,
   CardHeader,
   CardLeading,
-  Pressable,
   Text,
   Tooltip,
   TooltipTrigger,
@@ -62,22 +61,20 @@ export function EarnCardsView({ formattedAvailable, formattedDeposit, onEarnDepo
           </CardHeader>
         </Card>
       </Box>
-      <Box lx={cardWrapperStyle} testID={ASSET_DETAIL_TEST_IDS.earnDeposit}>
-        <Pressable onPress={onEarnDepositPress}>
-          <Card type="info">
-            <CardHeader>
-              <CardLeading>
-                <CardContent>
-                  <CardContentDescription>
-                    {t("assetDetail.balanceDetails.earnDeposit")}
-                  </CardContentDescription>
-                  <CardContentTitle>{formattedDeposit}</CardContentTitle>
-                </CardContent>
-              </CardLeading>
-              <ChevronRight size={16} color="muted" />
-            </CardHeader>
-          </Card>
-        </Pressable>
+      <Box lx={cardWrapperStyle}>
+        <Card onPress={onEarnDepositPress} testID={ASSET_DETAIL_TEST_IDS.earnDeposit}>
+          <CardHeader>
+            <CardLeading>
+              <CardContent>
+                <CardContentDescription>
+                  {t("assetDetail.balanceDetails.earnDeposit")}
+                </CardContentDescription>
+                <CardContentTitle>{formattedDeposit}</CardContentTitle>
+              </CardContent>
+            </CardLeading>
+            <ChevronRight size={16} color="muted" />
+          </CardHeader>
+        </Card>
       </Box>
     </Box>
   );


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Small UI/structural change — Pressable removed and Card given built-in interactive press behavior; verified manually._
- [x] **Impact of the changes:**
      - Tap behavior on the Earn banner on the Asset Detail screen (still navigates to the Earn flow).
      - Tap behavior on the Earn deposit card in the staked balance row.
      - Pressed-state visual feedback on both cards (Card surface darkens on press in `interactive` mode).
      - Test IDs `asset-detail-earn-banner` and `asset-detail-earn-deposit` are now on the `Card` itself (E2E selectors still resolve to the same node).

### 📝 Description

The Earn banner and Earn deposit card on the Asset Detail screen were wrapped in a `Pressable` while the underlying `Card` was set to `type="info"` (no built-in press handling). This duplicated press behavior and missed the proper pressed-state styling defined by the Lumen Card.

This PR removes the `Pressable` wrappers and lets the `Card` handle the press itself (defaults to `type="interactive"`). The `onPress` handler and the `testID` move directly onto the `Card`, matching the design system's intended usage.

### 🖼️ Screenshots

https://github.com/user-attachments/assets/9b779f5c-5a1c-4bc1-9a5d-456f7d388bfa

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30931](https://ledgerhq.atlassian.net/browse/LIVE-30931)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30931]: https://ledgerhq.atlassian.net/browse/LIVE-30931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ