### PR TITLE
[LWDM] track(desktop,mobile): add finish onboarding tracking

### DIFF
--- a/.changeset/chilled-parents-scream.md
+++ b/.changeset/chilled-parents-scream.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+track: add finish onboarding tracking

--- a/libs/ledger-live-common/src/analytics/featureFlagHelpers/wallet40.ts
+++ b/libs/ledger-live-common/src/analytics/featureFlagHelpers/wallet40.ts
@@ -32,5 +32,9 @@ export const getWallet40Attributes = (
     myWallet: wallet40FeatureFlag?.params?.myWallet ?? false,
     aggregatedAssets: wallet40FeatureFlag?.params?.aggregatedAssets ?? false,
     pnl: wallet40FeatureFlag?.params?.pnl ?? false,
+    finishOnboardingWidget:
+      wallet40FeatureFlag?.params?.finishOnboardingWidget ??
+      wallet40FeatureFlag?.params?.onboardingWidget ??
+      false,
   };
 };

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -879,6 +879,7 @@ type Feature_Wallet40_Params = {
   brazePlacement?: boolean;
   newReceiveDialog?: boolean;
   finishOnboardingWidget?: boolean;
+  onboardingWidget?: boolean;
 };
 
 export type Feature_LwmWallet40 = Feature<Feature_Wallet40_Params & { onboardingWidget: boolean }>;


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Impact of the changes:**
  - Tracking added for the finish onboarding widget.

### 📝 Description

* Adds `finishOnboardingWidget` as a tracked attribute.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-30934
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
