### PR TITLE
[LWM] docs(device-intent): document Device Intent Executor and add LWM input helper

### DIFF
--- a/.agents/skills/device-intent-executor/SKILL.md
+++ b/.agents/skills/device-intent-executor/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: device-intent-executor
+description: Device Intent Executor (DIE) and Device Intents reference. Read when working with libs/device-intent/, DeviceIntentExecutor / DeviceIntentExecutorLWM, Intent definitions (IntentDefinition, IntentPlatformDefinition, Job, createIntent), deviceInitializationInput / buildDeviceInitializationInput, DmkCompatTransport, or migrating a Ledger Wallet device flow off connectApp / DeviceAction / withDevice.
+---
+
+# Device Intent Executor (DIE)
+
+For tasks involving the `@ledgerhq/device-intent` package, the
+`DeviceIntentExecutor` / `DeviceIntentExecutorLWM` component, Device Intents
+(`IntentDefinition`, `IntentPlatformDefinition`, `Job`, `createIntent`),
+`deviceInitializationInput` / `buildDeviceInitializationInput`, the
+`DmkCompatTransport` bridge, or migrating a Ledger Wallet device flow off
+`connectApp` / `DeviceAction` / `withDevice`:
+
+Read `libs/device-intent/README.md`. It is the canonical reference and
+already contains a `## Summary`, a `## Table of contents`, and a
+`### What's covered` map — use those to jump directly to the relevant
+section instead of paraphrasing the contents in chat.

--- a/.changeset/brave-insects-begin.md
+++ b/.changeset/brave-insects-begin.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Add `buildDeviceInitializationInput` helper exported from the LWM `DeviceIntentExecutor` module to translate an `AppRequest` into the executor's `deviceInitializationInput`.

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/utils/buildDeviceInitializationInput.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/utils/buildDeviceInitializationInput.ts
@@ -1,0 +1,24 @@
+import {
+  buildEnsureAppReadyInput,
+  type BuildEnsureAppReadyInputParams,
+} from "@ledgerhq/live-common/device/use-cases/ensureAppReady/buildEnsureAppReadyInput";
+import type { InitializationInput } from "../../types";
+
+export type BuildDeviceInitializationInputParams = BuildEnsureAppReadyInputParams;
+
+/**
+ * Build the `deviceInitializationInput` consumed by the LWM
+ * `DeviceIntentExecutor` from an `AppRequest`.
+ *
+ * Canonical translation from the rich `AppRequest` shape (account, currency,
+ * dependencies, …) that flows already build for the legacy `connectApp`
+ * device-action into the structured input the executor needs to drive
+ * Phase 2 (device context initialisation).
+ *
+ * @see buildEnsureAppReadyInput - underlying implementation.
+ */
+export function buildDeviceInitializationInput(
+  params: BuildDeviceInitializationInputParams,
+): Promise<InitializationInput> {
+  return buildEnsureAppReadyInput(params);
+}

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/index.tsx
@@ -16,6 +16,12 @@ import DeviceContextInitializerComponentLWM, {
 } from "./DeviceContextInitializerComponentLWM";
 import type { InitializationInput } from "./types";
 
+export {
+  buildDeviceInitializationInput,
+  type BuildDeviceInitializationInputParams,
+} from "./DeviceContextInitializerComponentLWM/utils/buildDeviceInitializationInput";
+export type { InitializationInput } from "./types";
+
 type Props<JobState, Input, ExtraProps> = DeviceIntentExecutorProps<
   JobState,
   Input,

--- a/libs/device-intent/README.md
+++ b/libs/device-intent/README.md
@@ -4,6 +4,103 @@ Shared types, helpers and the **Device Intent Executor** component for Ledger Wa
 
 See the [ADR: Device Intent Executor component](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/6852083917) for the full design rationale.
 
+## Summary
+
+### Who should read this
+
+- **Wallet flow developers** integrating device interactions (sign, fetch address, broadcast, etc.) in LWM or LWD.
+- **Engineers migrating** an existing flow from the legacy `connectApp` / `DeviceAction` patterns to DIE.
+- **Coin module maintainers** wiring up new intents for additional coins or flows.
+- **Maintainers of the executor itself** looking for the internal lifecycle, state machine, and orchestration contracts.
+
+### What's covered
+
+- **Concepts** — what a Device Intent is, what the Device Intent Executor (DIE) is, and how they fit together.
+- **Usage guide** — mounting the executor, building the `deviceInitializationInput`, defining and structuring intents, orchestrating multi-step (and context-switching) flows.
+- **Runtime contracts and observability** — completion, intent/context co-changes, cancellation, callbacks, interactive jobs, idle state.
+- **Pitfalls and common mistakes** when integrating.
+- **Internals** — three-layer architecture, XState lifecycle, hook orchestration, disconnection handling.
+- **Installation**.
+
+## Table of contents
+
+- [Compatibility](#compatibility)
+  - [LWM (Ledger Wallet Mobile)](#lwm-ledger-wallet-mobile)
+  - [LWD (Ledger Wallet Desktop)](#lwd-ledger-wallet-desktop)
+  - [CLI](#cli)
+- [What is a Device Intent?](#what-is-a-device-intent)
+  - [Anatomy of an Intent](#anatomy-of-an-intent)
+- [What is the Device Intent Executor?](#what-is-the-device-intent-executor)
+  - [High-level flow](#high-level-flow)
+- [Exports](#exports)
+  - [Core types](#core-types-srccorets)
+  - [Executor types](#executor-types-srcexecutorts)
+- [Usage Guide](#usage-guide)
+  - [Mounting the executor](#mounting-the-executor)
+  - [Building the `deviceInitializationInput`](#building-the-deviceinitializationinput)
+  - [Defining intents](#defining-intents)
+  - [Structuring intents (single vs. multiple)](#structuring-intents-single-vs-multiple)
+  - [Orchestrating a multi-intent flow](#orchestrating-a-multi-intent-flow)
+  - [Job completion contract](#job-completion-contract)
+  - [Changing `deviceInitializationInput` and `intent` together](#changing-deviceinitializationinput-and-intent-together)
+  - [Observability: callbacks](#observability-callbacks)
+  - [Cancelling an intent](#cancelling-an-intent)
+  - [Enabling / disabling](#enabling--disabling)
+  - [Idle state and `lastIntentSnapshot`](#idle-state-and-lastintentsnapshot)
+  - [Advanced: interactive jobs with callbacks in `JobState`](#advanced-interactive-jobs-with-callbacks-in-jobstate)
+  - [Working with ledgerjs `Transport`-based code](#working-with-ledgerjs-transport-based-code)
+  - [Pitfalls and common mistakes](#pitfalls-and-common-mistakes)
+- [How It Works](#how-it-works)
+  - [Three-layer architecture](#three-layer-architecture)
+  - [State machine lifecycle](#state-machine-lifecycle)
+  - [XState v5 and auto-cancellation](#xstate-v5-and-auto-cancellation)
+  - [Hook orchestration of simultaneous prop changes](#hook-orchestration-of-simultaneous-prop-changes)
+  - [Callback refs for freshness](#callback-refs-for-freshness)
+  - [Device disconnection monitoring](#device-disconnection-monitoring)
+- [Installation](#installation)
+
+## Compatibility
+
+### LWM (Ledger Wallet Mobile)
+
+Fully supported via the `DeviceIntentExecutorLWM` wrapper at
+`apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/`. Mount it
+as shown in [Mounting the executor](#mounting-the-executor) — the connection,
+context-initialisation, and intent-error screens are all wired with
+platform-specific components.
+
+### LWD (Ledger Wallet Desktop)
+
+Not yet integrated — coming soon. The wrapper will mirror the LWM one
+(planned as `DeviceIntentExecutorLWD`) and inject desktop-specific platform
+components for the connection, initialisation, and error screens. The
+shared core (`DeviceIntentExecutor`, state machine, intent definitions, initialization logic via ensureAppStateReadyUseCase) is
+already platform-agnostic, so the wiring is the only missing piece.
+
+### CLI
+
+Not supported out of the box. DIE is designed for React apps and assumes a
+React component renderer for each phase. That said, several pieces are
+individually reusable from a CLI host:
+
+- **[`ensureAppReadyUseCase`][ensure-app-ready-uc]** can drive Phase 2 (open
+  app, derivation, dependencies, deprecation handling, …) directly from a CLI
+  with no React involved.
+- **The DIE state machine** ([`DeviceIntentExecutorStateMachine.ts`][die-sm])
+  is built on XState and could be wrapped by a non-React host that subscribes
+  to its emitted states and drives it through events.
+- **Intents** can be defined with placeholder components (`() => null`) if a
+  CLI still wants to go through the executor — though the React layer adds
+  little value in that context.
+
+In practice the biggest win on the CLI is the **`Job` abstraction itself**:
+keeping a flow's business logic inside a reusable `Job` (or composition of
+reusable jobs) means the same logic can drive the LWM and LWD UI through DIE
+*and* power CLI commands directly, without duplicating device-interaction
+code per platform.
+
+[die-sm]: ./src/DeviceIntentExecutorStateMachine.ts
+
 ## What is a Device Intent?
 
 Many Ledger Wallet flows require one or more interactions with a connected
@@ -21,6 +118,35 @@ Each intent is defined in three layers:
 3. **`Intent`** -- a runtime instance created from a platform definition and
    concrete input via `createIntent()`. This is what is actually passed to the
    executor.
+
+### Anatomy of an Intent
+
+At runtime, an Intent is essentially two things glued together: a **Job** that
+runs against the connected device and a **Component** that renders the job's
+state to the user.
+
+```mermaid
+---
+title: Anatomy of a Device Intent
+---
+flowchart LR
+    subgraph Intent["Device Intent"]
+        direction LR
+        Job["<b>Job</b><br/>job(dmk, sessionId)<br/>→ Observable&lt;JobState&gt;"]
+        Comp["<b>Component</b><br/>(jobState) → React UI"]
+        Job -.->|JobState stream| Comp
+    end
+
+    style Intent fill:#37474f,color:#fff
+    style Job fill:#1976d2,color:#fff
+    style Comp fill:#2e7d32,color:#fff
+```
+
+- **Job** — given the DMK and an active session, returns an
+  `Observable<JobState>` describing the progress and outcome of the device
+  interaction.
+- **Component** — a React component that subscribes (via the executor) to the
+  emitted `JobState` and renders it on the current platform.
 
 ## What is the Device Intent Executor?
 
@@ -42,6 +168,57 @@ The caller retains ownership of the business flow: it decides which intent is
 current, when the device initialization input changes, and when the flow is done. The
 executor standardises the difficult runtime concerns that are common to every
 device-centric flow.
+
+### High-level flow
+
+```mermaid
+sequenceDiagram
+    actor Caller as Caller screen<br/>(e.g. Swap)
+    participant DIE as Device Intent Executor<br/>(react component)
+    participant UI as Device Intent Executor UI
+    participant Dev as Device
+
+    Caller->>DIE: mount with<br/>deviceInitializationInput + intent
+
+    rect rgba(33, 150, 243, 0.2)
+        Note over DIE,Dev: Phase 1 — Device selection & connection
+        DIE->>UI: show Connection screen
+        UI->>Dev: connect (DMK)
+        Dev-->>UI: connected
+        UI-->>DIE: device connected (DMK session)
+    end
+
+    rect rgba(76, 175, 80, 0.2)
+        Note over DIE,Dev: Phase 2 — Device context initialisation
+        DIE->>UI: show Initializer screen<br/>(using deviceInitializationInput)
+        UI->>Dev: open app / derivation / dependencies
+        Dev-->>UI: ready
+        UI-->>DIE: device context ready
+    end
+
+    rect rgba(255, 152, 0, 0.2)
+        Note over DIE,Dev: Phase 3 — Intent execution
+        DIE->>DIE: intent.job(dmk, sessionId)
+        DIE->>DIE: subscribe to returned Observable
+        loop while job is running
+            DIE->>Dev: APDU exchanges
+            Dev-->>DIE: APDU responses
+            DIE->>UI: show Intent screen with JobState
+            DIE-->>Caller: onIntentJobStateChanged
+        end
+        DIE-->>Caller: onIntentJobComplete
+    end
+
+    Note over Caller,Dev: After intent completion,<br/>the caller has two options:
+
+    alt Pass a new intent only
+        Caller->>DIE: new intent
+        Note over DIE,Dev: Re-run Phase 3 only<br/>(Phase 1 + Phase 2 preserved)
+    else Pass a new intent AND deviceInitializationInput
+        Caller->>DIE: new intent + deviceInitializationInput
+        Note over DIE,Dev: Re-run Phase 2 → Phase 3<br/>(Phase 1 connection preserved)
+    end
+```
 
 ## Exports
 
@@ -76,8 +253,8 @@ device-centric flow.
 ### Mounting the executor
 
 The executor is typically placed inside a bottom sheet (LWM) or modal (LWD).
-Each platform provides a thin wrapper (`LwmDeviceIntentExecutor` /
-`LwdDeviceIntentExecutor`) that injects the platform-specific UI components
+Each platform provides a thin wrapper (`DeviceIntentExecutorLWM` /
+`DeviceIntentExecutorLWD`) that injects the platform-specific UI components
 (device connection, context initialiser, error screens). The caller screen
 mounts that wrapper and passes all the required props:
 
@@ -121,6 +298,135 @@ function MyFlowScreen({ enabled, onDone }: Props) {
   );
 }
 ```
+
+### Building the `deviceInitializationInput`
+
+In the LWM and LWD wrappers, `deviceInitializationInput` is the input consumed
+by [`ensureAppReadyUseCase`][ensure-app-ready-uc]: that's what the
+platform-injected `DeviceContextInitializerComponent` calls during **Phase 2**
+(opening / installing the requested app, performing derivation, validating the
+expected account, surfacing deprecation, etc.).
+
+You almost never want to build the `deviceInitializationInput` by hand. Most
+Ledger Wallet flows already construct an **`AppRequest`** — the same domain
+object historically passed to the legacy `connectApp` device-action (`account`,
+`currency`, `tokenCurrency`, `appName`, `dependencies`, `requireLatestFirmware`,
+`allowPartialDependencies`). Each platform LWM/LWD wrapper re-exports a scoped
+helper that does the canonical translation from that shape into the structured
+input the executor expects — for LWM that's
+[`buildDeviceInitializationInput`][build-input-lwm]. It derives `appName`,
+`dependencies`, `requiresDerivation`, `expectedAccount` and `deprecation` from
+the `AppRequest`, so callers don't recompute any of them.
+
+Under the hood, `buildDeviceInitializationInput` simply forwards to
+[`buildEnsureAppReadyInput`][build-input], the shared cross-platform helper —
+LWM consumers should prefer the scoped name.
+
+[ensure-app-ready-uc]: ../../libs/ledger-live-common/src/device/use-cases/ensureAppReady/ensureAppReadyUseCase.ts
+[build-input]: ../../libs/ledger-live-common/src/device/use-cases/ensureAppReady/buildEnsureAppReadyInput.ts
+[build-input-lwm]: ../../apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/buildDeviceInitializationInput.ts
+
+#### Example: Sign Transaction flow
+
+A "send / sign transaction" screen already has everything it needs to build an
+`AppRequest`. Migrating it to DIE only adds a single call to
+`buildDeviceInitializationInput` and feeds its result as
+`deviceInitializationInput`:
+
+```tsx
+import { useEffect, useMemo, useState } from "react";
+import { createIntent } from "@ledgerhq/device-intent";
+import {
+  buildDeviceInitializationInput,
+  type InitializationInput,
+} from "LLM/components/DeviceIntentExecutor";
+import type { AppRequest } from "@ledgerhq/live-common/hw/actions/app";
+
+function SignTransactionStep({
+  enabled,
+  account,
+  parentAccount,
+  transaction,
+  dependencies,
+  requireLatestFirmware,
+  onSigned,
+  onError,
+  onClose,
+}: Props) {
+  // 1) Build the AppRequest from the flow's domain inputs (same shape the flow
+  //    already builds today for the legacy connectApp action).
+  const appRequest = useMemo<AppRequest>(
+    () => ({
+      account,
+      tokenCurrency: account.type === "TokenAccount" ? account.token : undefined,
+      dependencies,
+      requireLatestFirmware,
+    }),
+    [account, dependencies, requireLatestFirmware],
+  );
+
+  // 2) Translate the AppRequest into the executor's deviceInitializationInput.
+  const [deviceInitializationInput, setDeviceInitializationInput] =
+    useState<InitializationInput | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    buildDeviceInitializationInput({ appRequest, flow: "send" }).then(input => {
+      if (!cancelled) setDeviceInitializationInput(input);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [appRequest]);
+
+  // 3) Build the intent and mount the executor once the input is ready.
+  const [intent] = useState(() =>
+    createIntent(signTransactionIntentPlatformDefinition, {
+      account,
+      parentAccount,
+      transaction,
+    }),
+  );
+
+  if (!deviceInitializationInput) return null;
+
+  return (
+    <LwmDeviceIntentExecutor
+      enabled={enabled}
+      deviceConnectionParams={{ acceptedDeviceModelIds: [] }}
+      deviceInitializationInput={deviceInitializationInput}
+      intent={intent}
+      intentComponentExtraProps={{}}
+      onExecutorStateChanged={state => {
+        /* track lifecycle if needed */
+      }}
+      onIntentJobStateChanged={state => {
+        /* react to progress */
+      }}
+      onIntentJobComplete={() => onSigned()}
+      onIntentJobError={onError}
+      onUserCancel={onClose}
+      cancellableUI={true}
+      cancelIntentRequestId={undefined}
+    />
+  );
+}
+```
+
+Things to keep in mind:
+
+- `buildDeviceInitializationInput` is **async** — it resolves currency /
+  account / token requirements internally. Resolve it before mounting the
+  executor with `enabled={true}`, since the executor needs a valid
+  `deviceInitializationInput` to start Phase 2.
+- The same `AppRequest` shape works for any flow that already has one (sign
+  message, swap, exchange, account discovery, manage app install, …). Just
+  pass the relevant `flow` name so deprecation screens are wired correctly.
+- If your flow does not have an `AppRequest`, you can build an
+  `InitializationInput` literal directly (see the [Mounting the
+  executor](#mounting-the-executor) example), but
+  `buildDeviceInitializationInput` remains the recommended path whenever an
+  `AppRequest` is available.
 
 ### Defining intents
 
@@ -318,7 +624,70 @@ inside a single platform package or app first, then move `types.ts`, `job.ts`,
 and `intentDefinition.ts` into a shared lib later without changing the platform
 file naming.
 
+### Structuring intents (single vs. multiple)
+
+> Preliminary guidance — based on early integrations. Expect it to evolve as
+> more real flows land.
+
+For a given user flow, you have two ways to slice work between the caller and
+the executor:
+
+1. **One big intent** whose `Job` Observable internally orchestrates several
+   steps (RxJS `concat` / `switchMap` / `mergeMap`, conditional branches,
+   retries, etc.).
+2. **Multiple intents** that the caller chains by swapping `intent` (and
+   possibly `deviceInitializationInput`) on the executor (see
+   [Orchestrating a multi-intent flow](#orchestrating-a-multi-intent-flow)).
+
+#### Default: prefer a single intent
+
+If the whole flow runs against the same device context (same app, same
+account/derivation, same expected dependencies), build **one** intent and let
+its job orchestrate sub-steps internally.
+
+Reasons to prefer this:
+
+- **Orchestration stays in plain RxJS, not in React.** Sub-step wiring is a
+  pipeline (`concat(of(initial), signStep$, postProcessStep$, …)`), not a
+  reducer reacting to `onIntentJobComplete`. Easier to read, easier to unit
+  test (no rendering needed), no coupling to the executor's lifecycle.
+- **Sub-steps remain modular.** A single big job is just a composition of
+  smaller pure functions / Observables — those building blocks stay reusable
+  across intents and apps.
+- **No flash between phases.** With multiple intents the executor briefly
+  returns to idle between them; with one intent the user sees a single
+  continuous Phase 3 driven by `JobState` transitions in your discriminated
+  union.
+- **No need to thread step results through React.** Intermediate results
+  (e.g. a `signedTxHex`) stay inside the Observable pipeline instead of
+  having to be lifted to React state to feed the next intent's input.
+
+The `JobState` example in [Defining intents](#defining-intents) — a job that
+emits `waiting-for-confirmation` → `signed` → `error` — is already this
+pattern: one intent, several internal steps in the discriminated union.
+
+#### When to split into multiple intents
+
+Split only when two consecutive steps need a **different device context**.
+In practice that means:
+
+- A different app (e.g. Exchange app for the swap quote acceptance, then the
+  coin-specific app for the actual transaction sign).
+- Different installation requirements (different dependencies, different
+  `requireLatestFirmware`, etc.).
+
+In those cases you must swap both `intent` and `deviceInitializationInput`
+together to re-run Phase 2 (see [Changing
+`deviceInitializationInput` and `intent` together](#changing-deviceinitializationinput-and-intent-together)),
+which is exactly the contract the multi-intent orchestration pattern is
+designed for.
+
+If the steps share a context, keep them inside one job.
+
 ### Orchestrating a multi-intent flow
+
+> This pattern is for **context-switching** flows. If every step runs against
+> the same device context, prefer a single intent — see [Structuring intents](#structuring-intents-single-vs-multiple).
 
 The caller owns the business flow. The recommended pattern is an
 **orchestration hook** that:
@@ -329,26 +698,51 @@ The caller owns the business flow. The recommended pattern is an
 3. Returns the current `intent`, `deviceInitializationInput`,
    `intentComponentExtraProps`, and the callback props for the executor.
 
-A simplified example for a two-step flow (sign then broadcast):
+The canonical case is **Swap**: step 1 runs in the Exchange app to accept the
+quote on the device, step 2 runs in the coin-specific app (e.g. Ethereum) to
+sign the prepared transaction. Each step needs a different app, so
+`deviceInitializationInput` changes alongside `intent` between steps.
 
 ```tsx
 type FlowPhase =
-  | { step: "signing"; intent: Intent<SignJobState, SignInput, ExtraProps> }
-  | { step: "broadcasting"; intent: Intent<BroadcastJobState, BroadcastInput, ExtraProps> };
+  | {
+      step: "exchange-init";
+      intent: Intent<ExchangeInitJobState, ExchangeInitInput, ExtraProps>;
+    }
+  | { step: "signing"; intent: Intent<SignJobState, SignInput, ExtraProps> };
 
 type FlowState =
   | { type: "running"; phase: FlowPhase }
-  | { type: "done"; txHash: string }
+  | { type: "done"; signedTxHash: string }
   | { type: "error"; error: Error };
 
-function useMyFlowOrchestration({ enabled, quote, platformDefs, deps }) {
+const EXCHANGE_INITIALIZATION_INPUT: InitializationInput = {
+  appName: "Exchange",
+  dependencies: [],
+  requireLatestFirmware: false,
+  allowPartialDependencies: false,
+};
+
+function useSwapFlowOrchestration({ enabled, quote, platformDefs, deps }) {
   const [state, setState] = useState<FlowState>(() => ({
     type: "running",
     phase: {
-      step: "signing",
-      intent: createIntent(platformDefs.sign, { rawTxHex: deps.buildTx(quote) }),
+      step: "exchange-init",
+      intent: createIntent(platformDefs.exchangeInit, { quote }),
     },
   }));
+
+  // Each step needs a different app, so deviceInitializationInput is derived
+  // from the current phase and changes alongside intent.
+  const deviceInitializationInput = useMemo<InitializationInput>(() => {
+    if (state.type !== "running") return EXCHANGE_INITIALIZATION_INPUT;
+    switch (state.phase.step) {
+      case "exchange-init":
+        return EXCHANGE_INITIALIZATION_INPUT;
+      case "signing":
+        return deps.buildSigningInitializationInput(quote); // app: e.g. "Ethereum"
+    }
+  }, [state, quote, deps]);
 
   // Store results from the running job -- do NOT transition from here.
   const lastJobStateRef = useRef<unknown>(null);
@@ -361,30 +755,32 @@ function useMyFlowOrchestration({ enabled, quote, platformDefs, deps }) {
     if (state.type !== "running") return;
     const jobState = lastJobStateRef.current;
     switch (state.phase.step) {
-      case "signing": {
-        if (jobState?.step === "signed") {
+      case "exchange-init": {
+        if (jobState?.step === "exchange-accepted") {
+          // Phase 2 will re-run in the coin app because both intent and
+          // deviceInitializationInput change in the same render.
           setState({
             type: "running",
             phase: {
-              step: "broadcasting",
-              intent: createIntent(platformDefs.broadcast, {
-                signedTxHex: jobState.signedTxHex,
+              step: "signing",
+              intent: createIntent(platformDefs.sign, {
+                preparedTxHex: jobState.preparedTxHex,
               }),
             },
           });
         }
         break;
       }
-      case "broadcasting": {
-        if (jobState?.step === "confirmed") {
-          setState({ type: "done", txHash: jobState.txHash });
+      case "signing": {
+        if (jobState?.step === "signed") {
+          setState({ type: "done", signedTxHash: jobState.signedTxHash });
         }
         break;
       }
     }
   }, [state, platformDefs, deps]);
 
-  // ... return executor props derived from state
+  // ... return executor props derived from state, with deviceInitializationInput
 }
 ```
 
@@ -392,10 +788,10 @@ The screen renders the executor when the flow is running, and terminal
 success/error UI otherwise:
 
 ```tsx
-function MyFlowScreen({ enabled, quote, onClose }) {
-  const { state, executorProps } = useMyFlowOrchestration({ enabled, quote, ... });
+function SwapFlowScreen({ enabled, quote, onClose }) {
+  const { state, executorProps } = useSwapFlowOrchestration({ enabled, quote, ... });
 
-  if (state.type === "done") return <SuccessScreen txHash={state.txHash} />;
+  if (state.type === "done") return <SuccessScreen txHash={state.signedTxHash} />;
   if (state.type === "error") return <ErrorScreen error={state.error} />;
 
   return <LwmDeviceIntentExecutor {...executorProps} />;
@@ -640,6 +1036,82 @@ const myJob: Job<MyJobState, { signedTxHex: string }> = ({ input }) =>
 The intent component renders a confirmation button that calls
 `jobState.onConfirm()`, creating a two-way communication channel between the
 job and the UI without any external state.
+
+### Working with ledgerjs `Transport`-based code
+
+DIE gives jobs **native access to the DMK**: the `Job` function receives the
+live `DeviceManagementKit` instance and the current `sessionId` directly via
+`deviceConnectionResult`. Whenever possible, prefer calling DMK use cases and
+device actions directly — that's the long-term target shape of every flow.
+
+However, plenty of ledgerjs code (e.g. coin-specific signers like
+`@ledgerhq/hw-app-eth`) still expects a `@ledgerhq/hw-transport` `Transport`
+instance. For those cases DIE provides a thin adapter so a job can keep using
+them on top of the active DMK session.
+
+#### `DmkCompatTransport`
+
+Wrap the active DMK session in a `DmkCompatTransport` and pass it to whatever
+expects a `Transport`:
+
+```ts
+import { DmkCompatTransport } from "@ledgerhq/live-dmk-shared";
+import Eth from "@ledgerhq/hw-app-eth";
+import { defer, map, catchError, of } from "rxjs";
+import type { Job } from "@ledgerhq/device-intent";
+
+const myJob: Job<MyJobState, { txHex: string }> = ({
+  deviceConnectionResult,
+  input,
+}) =>
+  defer(async () => {
+    const transport = new DmkCompatTransport(
+      deviceConnectionResult.dmk,
+      deviceConnectionResult.sessionId,
+    );
+    const eth = new Eth(transport);
+    return await eth.signTransaction("44'/60'/0'/0/0", input.txHex);
+  }).pipe(
+    map((signature): MyJobState => ({ step: "signed", signature })),
+    catchError(err =>
+      of<MyJobState>({
+        step: "error",
+        error: err instanceof Error ? err : new Error(String(err)),
+      }),
+    ),
+  );
+```
+
+`DmkCompatTransport` is a minimal `hw-transport` adapter — it only bridges
+APDU exchanges since the DMK already owns the session lifecycle. Do **not**
+call `transport.close()` from a job: the executor manages the session and
+will tear it down on its own.
+
+#### Avoid legacy `DeviceAction`s and `withDevice` from a job
+
+DIE is **designed to replace** the legacy `DeviceAction` / `withDevice`
+plumbing. When migrating a flow, prefer **rewriting** its device-side logic
+as a job rather than wrapping a legacy `DeviceAction` inside one. The `Job`
+is the new unit of reusable, observable device interaction; smuggling a
+`DeviceAction` across the boundary defeats the purpose of the migration and
+keeps the flow locked on the old machinery.
+
+`withDevice` in particular is **redundant** inside DIE. Its only role was
+"connect to a device by id, then hand a `Transport` to the callback" — but
+in a job the device is already connected and the executor owns the live
+session. There is nothing to connect, and `DmkCompatTransport` is all you
+need when a `Transport` instance is genuinely required.
+
+Recommended migration path when a flow currently relies on a legacy
+`DeviceAction`:
+
+1. Identify the device-side logic the `DeviceAction` actually performs (e.g.
+   "open app, then call the signer, then read app config").
+2. Re-implement it as a `Job` returning `Observable<JobState>`, calling DMK
+   use cases directly — or ledgerjs signers via `DmkCompatTransport` when a
+   `Transport` is still required.
+3. Drop the `DeviceAction` and its `withDevice` host once the new job has
+   parity.
 
 ### Pitfalls and common mistakes
 

--- a/libs/device-intent/README.md
+++ b/libs/device-intent/README.md
@@ -74,7 +74,7 @@ platform-specific components.
 Not yet integrated — coming soon. The wrapper will mirror the LWM one
 (planned as `DeviceIntentExecutorLWD`) and inject desktop-specific platform
 components for the connection, initialisation, and error screens. The
-shared core (`DeviceIntentExecutor`, state machine, intent definitions, initialization logic via ensureAppStateReadyUseCase) is
+shared core (`DeviceIntentExecutor`, state machine, intent definitions, initialization logic via `ensureAppReadyUseCase`) is
 already platform-agnostic, so the wiring is the only missing piece.
 
 ### CLI
@@ -269,7 +269,7 @@ function MyFlowScreen({ enabled, onDone }: Props) {
   );
 
   return (
-    <LwmDeviceIntentExecutor
+    <DeviceIntentExecutorLWM
       enabled={enabled}
       deviceConnectionParams={{ acceptedDeviceModelIds: [] }}
       deviceInitializationInput={{
@@ -324,7 +324,7 @@ LWM consumers should prefer the scoped name.
 
 [ensure-app-ready-uc]: ../../libs/ledger-live-common/src/device/use-cases/ensureAppReady/ensureAppReadyUseCase.ts
 [build-input]: ../../libs/ledger-live-common/src/device/use-cases/ensureAppReady/buildEnsureAppReadyInput.ts
-[build-input-lwm]: ../../apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/buildDeviceInitializationInput.ts
+[build-input-lwm]: ../../apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/utils/buildDeviceInitializationInput.ts
 
 #### Example: Sign Transaction flow
 
@@ -341,6 +341,7 @@ import {
   type InitializationInput,
 } from "LLM/components/DeviceIntentExecutor";
 import type { AppRequest } from "@ledgerhq/live-common/hw/actions/app";
+import { FlowName } from "@ledgerhq/live-common/device-action/utils";
 
 function SignTransactionStep({
   enabled,
@@ -371,7 +372,7 @@ function SignTransactionStep({
 
   useEffect(() => {
     let cancelled = false;
-    buildDeviceInitializationInput({ appRequest, flow: "send" }).then(input => {
+    buildDeviceInitializationInput({ appRequest, flow: FlowName.send }).then(input => {
       if (!cancelled) setDeviceInitializationInput(input);
     });
     return () => {
@@ -391,7 +392,7 @@ function SignTransactionStep({
   if (!deviceInitializationInput) return null;
 
   return (
-    <LwmDeviceIntentExecutor
+    <DeviceIntentExecutorLWM
       enabled={enabled}
       deviceConnectionParams={{ acceptedDeviceModelIds: [] }}
       deviceInitializationInput={deviceInitializationInput}
@@ -794,7 +795,7 @@ function SwapFlowScreen({ enabled, quote, onClose }) {
   if (state.type === "done") return <SuccessScreen txHash={state.signedTxHash} />;
   if (state.type === "error") return <ErrorScreen error={state.error} />;
 
-  return <LwmDeviceIntentExecutor {...executorProps} />;
+  return <DeviceIntentExecutorLWM {...executorProps} />;
 }
 ```
 

--- a/libs/device-intent/README.md
+++ b/libs/device-intent/README.md
@@ -16,7 +16,7 @@ See the [ADR: Device Intent Executor component](https://ledgerhq.atlassian.net/w
 ### What's covered
 
 - **Concepts** — what a Device Intent is, what the Device Intent Executor (DIE) is, and how they fit together.
-- **Usage guide** — mounting the executor, building the `deviceInitializationInput`, defining and structuring intents, orchestrating multi-step (and context-switching) flows.
+- **Usage guide** — implementation checklist, mounting the executor, building the `deviceInitializationInput`, defining and structuring intents, orchestrating multi-step (and context-switching) flows.
 - **Runtime contracts and observability** — completion, intent/context co-changes, cancellation, callbacks, interactive jobs, idle state.
 - **Pitfalls and common mistakes** when integrating.
 - **Internals** — three-layer architecture, XState lifecycle, hook orchestration, disconnection handling.
@@ -36,6 +36,7 @@ See the [ADR: Device Intent Executor component](https://ledgerhq.atlassian.net/w
   - [Core types](#core-types-srccorets)
   - [Executor types](#executor-types-srcexecutorts)
 - [Usage Guide](#usage-guide)
+  - [Intent implementation checklist](#intent-implementation-checklist)
   - [Mounting the executor](#mounting-the-executor)
   - [Building the `deviceInitializationInput`](#building-the-deviceinitializationinput)
   - [Defining intents](#defining-intents)
@@ -47,7 +48,7 @@ See the [ADR: Device Intent Executor component](https://ledgerhq.atlassian.net/w
   - [Cancelling an intent](#cancelling-an-intent)
   - [Enabling / disabling](#enabling--disabling)
   - [Idle state and `lastIntentSnapshot`](#idle-state-and-lastintentsnapshot)
-  - [Advanced: interactive jobs with callbacks in `JobState`](#advanced-interactive-jobs-with-callbacks-in-jobstate)
+  - [Interactive jobs with callbacks in `JobState`](#interactive-jobs-with-callbacks-in-jobstate)
   - [Working with ledgerjs `Transport`-based code](#working-with-ledgerjs-transport-based-code)
   - [Pitfalls and common mistakes](#pitfalls-and-common-mistakes)
 - [How It Works](#how-it-works)
@@ -250,6 +251,88 @@ sequenceDiagram
 
 ## Usage Guide
 
+### Intent implementation checklist
+
+Once you are familiar with the concepts below, use this checklist as a compact
+implementation guide for adding a new intent.
+
+1. **Choose the intent granularity for the flow.**
+   If every device interaction happens in the same device app, prefer one
+   intent and keep orchestration inside its job. If the flow crosses device
+   apps or app requirements, use one intent per device context, each with its
+   own `deviceInitializationInput`, and orchestrate the phases from a shared
+   hook.
+   Read more:
+   [Structuring intents](#structuring-intents-single-vs-multiple),
+   [When to split into multiple intents](#when-to-split-into-multiple-intents),
+   [Orchestrating a multi-intent flow](#orchestrating-a-multi-intent-flow).
+
+2. **Decide where the intent lives.**
+   Keep reusable contracts and execution logic in a shared package, then bind
+   them to platform-specific renderers in LWM and LWD. This keeps orchestration
+   hooks testable because they can depend on typed contracts and injected
+   platform definitions rather than concrete app implementations.
+   Read more:
+   [Recommended file organization](#recommended-file-organization),
+   [`IntentDefinition`](#1-intentdefinition----shared-cross-platform-logic),
+   [`IntentPlatformDefinition`](#2-intentplatformdefinition----platform-specific-ui).
+
+3. **Define the intent input.**
+   Include the raw business input the job needs, such as a swap quote,
+   transaction payload, or user address. Also include injected dependencies
+   that are not available when the intent definition is declared but are needed
+   at execution time, such as feature flags, analytics helpers, or flow-specific
+   logic. This keeps the intent reusable while preserving dependency inversion.
+   Read more:
+   [Defining intents](#defining-intents),
+   [Runtime `Intent` via `createIntent()`](#3-runtime-intent-via-createintent).
+
+4. **Define the `JobState` union.**
+   Model every state the UI needs to display as a discriminated union so the
+   platform component can render with an exhaustive switch. If a state needs
+   user interaction, such as displaying a warning before resuming execution,
+   carry callbacks in `JobState` and let the React component call them from UI
+   handlers.
+   Read more:
+   [`IntentDefinition`](#1-intentdefinition----shared-cross-platform-logic),
+   [`IntentPlatformDefinition`](#2-intentplatformdefinition----platform-specific-ui),
+   [interactive jobs with callbacks in `JobState`](#interactive-jobs-with-callbacks-in-jobstate).
+
+5. **Implement the job.**
+   Choose the implementation style that best fits the flow: an RxJS pipeline,
+   an imperative `new Observable(observer => { ... })`, or another internal
+   abstraction. Consider XState when orchestration is complex, especially when
+   it includes user interactivity, retries, guards, or many explicit
+   transitions. The job should emit `JobState` values, model recoverable errors
+   as `JobState`, and complete when the intent is finished.
+   Read more:
+   [`IntentDefinition`](#1-intentdefinition----shared-cross-platform-logic),
+   [Job completion contract](#job-completion-contract),
+   [Working with ledgerjs `Transport`-based code](#working-with-ledgerjs-transport-based-code),
+   [Pitfalls and common mistakes](#pitfalls-and-common-mistakes).
+
+6. **Implement the platform components.**
+   Add the intent component for each supported platform, such as LWM and LWD.
+   Render from `JobState` with an exhaustive switch, and use an `assertNever`
+   helper so newly added `JobState` variants cannot be missed silently.
+   Read more:
+   [`IntentPlatformDefinition`](#2-intentplatformdefinition----platform-specific-ui),
+   [Recommended file organization](#recommended-file-organization).
+
+7. **Integrate the executor in the flow.**
+   Import the platform-specific DeviceIntentExecutor component, build the
+   `deviceInitializationInput` with the appropriate helper, then either use the
+   flow orchestration hook or create the intent at runtime and pass it with the
+   initialization input to the DIE component. Add job state listeners when the
+   caller needs to capture intermediate results, and wire cancellation or
+   lifecycle callbacks when the flow needs them.
+   Read more:
+   [Mounting the executor](#mounting-the-executor),
+   [Building the `deviceInitializationInput`](#building-the-deviceinitializationinput),
+   [Observability: callbacks](#observability-callbacks),
+   [Cancelling an intent](#cancelling-an-intent),
+   [Changing `deviceInitializationInput` and `intent` together](#changing-deviceinitializationinput-and-intent-together).
+
 ### Mounting the executor
 
 The executor is typically placed inside a bottom sheet (LWM) or modal (LWD).
@@ -257,6 +340,9 @@ Each platform provides a thin wrapper (`DeviceIntentExecutorLWM` /
 `DeviceIntentExecutorLWD`) that injects the platform-specific UI components
 (device connection, context initialiser, error screens). The caller screen
 mounts that wrapper and passes all the required props:
+
+Do not import the raw `DeviceIntentExecutor` from `@ledgerhq/device-intent`;
+always use the existing platform wrapper.
 
 ```tsx
 import { createIntent } from "@ledgerhq/device-intent";
@@ -833,7 +919,7 @@ In practice this means:
   component call them from UI handlers. The callback can resume the job, emit a
   terminal state such as `cancelled`, then complete the observable. This keeps
   interactivity inside the job/component contract. See
-  [Advanced: interactive jobs with callbacks in `JobState`](#advanced-interactive-jobs-with-callbacks-in-jobstate).
+  [Interactive jobs with callbacks in `JobState`](#interactive-jobs-with-callbacks-in-jobstate).
 
 ### Changing `deviceInitializationInput` and `intent` together
 
@@ -985,7 +1071,7 @@ a new intent, closing the flow, or showing terminal UI).
 If no intent has ever executed, `lastIntentSnapshot` is `null` and the
 executor renders nothing during idle.
 
-### Advanced: interactive jobs with callbacks in `JobState`
+### Interactive jobs with callbacks in `JobState`
 
 `JobState` does not have to be serializable -- it can contain functions.
 Because `JobState` is just a TypeScript type flowing from the observable to the
@@ -1165,7 +1251,7 @@ Common causes:
   completes, the orchestrator is forced to bypass the completion contract. Emit
   callbacks in `JobState` so the component can resume or cancel the job, then
   complete the observable (see
-  [Advanced: interactive jobs with callbacks in `JobState`](#advanced-interactive-jobs-with-callbacks-in-jobstate)).
+  [Interactive jobs with callbacks in `JobState`](#interactive-jobs-with-callbacks-in-jobstate)).
 - Calling a navigation callback (e.g. `goTo()`) from a UI button without
   first completing the job.
 

--- a/libs/device-intent/README.md
+++ b/libs/device-intent/README.md
@@ -96,7 +96,7 @@ individually reusable from a CLI host:
 In practice the biggest win on the CLI is the **`Job` abstraction itself**:
 keeping a flow's business logic inside a reusable `Job` (or composition of
 reusable jobs) means the same logic can drive the LWM and LWD UI through DIE
-*and* power CLI commands directly, without duplicating device-interaction
+_and_ power CLI commands directly, without duplicating device-interaction
 code per platform.
 
 [die-sm]: ./src/DeviceIntentExecutorStateMachine.ts
@@ -439,6 +439,21 @@ An `IntentDefinition` contains the `Job` function and execution metadata. The
 job receives the device connection, extracted context and typed input, and
 returns an `Observable<JobState>`.
 
+The executor does not prescribe how a job is implemented internally. A job can
+be written as an RxJS operator pipeline, as an imperative
+`new Observable(observer => { ... })`, or by adapting another workflow tool.
+Choose the style that makes the flow easiest to understand, test and maintain.
+The boundary contract is what matters: emit meaningful `JobState` values,
+complete when the job is done, and keep internal orchestration details out of
+React.
+
+For complex flows with many explicit states, transitions, guards, retries or
+user-driven branches, consider using a state machine such as XState internally.
+It can be more verbose than a hand-written observable, but the explicit state
+chart is often easier to read and maintain. The machine should remain an
+implementation detail of the job; expose only `JobState` values through the
+returned observable.
+
 **Important: model errors as `JobState` values, not observable errors.** A job
 observable should **not** error (i.e. should not call `observer.error()`).
 Instead, include an error variant in your `JobState` discriminated union (e.g.
@@ -446,8 +461,9 @@ Instead, include an error variant in your `JobState` discriminated union (e.g.
 This gives you full control over the error UI through the intent's `component`,
 whereas an observable error triggers a generic `executingIntentError` phase
 handled by the platform-injected `IntentErrorComponent`, which cannot be
-customised per intent. Use `catchError` to convert thrown errors into emitted
-error states.
+customised per intent. Convert thrown errors into emitted error states in
+whichever style the job uses (for example, `catchError` in an RxJS pipeline or
+`try` / `catch` in an imperative observable).
 
 **Be aware of `jobState: undefined` before the first emission.** When the
 executor starts running a job, the `jobState` passed to the intent's UI
@@ -457,17 +473,18 @@ request), the component will render with `jobState: undefined` for a while.
 
 You can handle this in two ways:
 
-- **Emit an initial state synchronously** using `concat(of(initialState), ...)`
-  or `startWith(initialState)` so the component immediately receives a
-  meaningful state.
+- **Emit an initial state synchronously** from the job implementation (for
+  example, `startWith(initialState)` in an RxJS pipeline or
+  `observer.next(initialState)` in an imperative observable) so the component
+  immediately receives a meaningful state.
 - **Handle `undefined` in the component** by rendering a generic loading
   indicator when `jobState` is `undefined`.
 
-Example of a synchronous initial emission:
+Example of a synchronous initial emission in an RxJS pipeline:
 
 ```typescript
-import { concat, of, from } from "rxjs";
-import { map, catchError } from "rxjs/operators";
+import { of } from "rxjs";
+import { map, catchError, startWith } from "rxjs/operators";
 import type { Job } from "@ledgerhq/device-intent";
 
 type MyJobState =
@@ -476,19 +493,17 @@ type MyJobState =
   | { step: "error"; error: Error };
 
 const myJob: Job<MyJobState, { rawTxHex: string }> = ({ deviceConnectionResult, input }) =>
-  concat(
-    // Synchronous initial emission -- the UI immediately knows what to render
-    of<MyJobState>({ step: "waiting-for-confirmation" }),
+  signOnDevice(deviceConnectionResult.sessionId, input.rawTxHex).pipe(
     // Async device work follows
-    signOnDevice(deviceConnectionResult.sessionId, input.rawTxHex).pipe(
-      map((hex): MyJobState => ({ step: "signed", signedTxHex: hex })),
-      catchError(err =>
-        of<MyJobState>({
-          step: "error",
-          error: err instanceof Error ? err : new Error(String(err)),
-        }),
-      ),
+    map((hex): MyJobState => ({ step: "signed", signedTxHex: hex })),
+    catchError(err =>
+      of<MyJobState>({
+        step: "error",
+        error: err instanceof Error ? err : new Error(String(err)),
+      }),
     ),
+    // Synchronous initial emission -- the UI immediately knows what to render
+    startWith<MyJobState>({ step: "waiting-for-confirmation" }),
   );
 
 const MyIntentDefinition: IntentDefinition<MyJobState, { rawTxHex: string }> = {
@@ -633,9 +648,9 @@ file naming.
 For a given user flow, you have two ways to slice work between the caller and
 the executor:
 
-1. **One big intent** whose `Job` Observable internally orchestrates several
-   steps (RxJS `concat` / `switchMap` / `mergeMap`, conditional branches,
-   retries, etc.).
+1. **One big intent** whose `Job` observable internally orchestrates several
+   steps. That orchestration can be an RxJS pipeline, an imperative observable,
+   a state machine, or another internal abstraction.
 2. **Multiple intents** that the caller chains by swapping `intent` (and
    possibly `deviceInitializationInput`) on the executor (see
    [Orchestrating a multi-intent flow](#orchestrating-a-multi-intent-flow)).
@@ -648,20 +663,17 @@ its job orchestrate sub-steps internally.
 
 Reasons to prefer this:
 
-- **Orchestration stays in plain RxJS, not in React.** Sub-step wiring is a
-  pipeline (`concat(of(initial), signStep$, postProcessStep$, …)`), not a
-  reducer reacting to `onIntentJobComplete`. Easier to read, easier to unit
-  test (no rendering needed), no coupling to the executor's lifecycle.
+- **Orchestration stays inside the job, not in React.** Sub-step wiring can be
+  expressed with RxJS operators, an imperative observable, XState, or another
+  internal abstraction. The important part is that React receives a clear
+  stream of `JobState` values instead of coordinating sub-steps from
+  `onIntentJobComplete`.
 - **Sub-steps remain modular.** A single big job is just a composition of
-  smaller pure functions / Observables — those building blocks stay reusable
-  across intents and apps.
-- **No flash between phases.** With multiple intents the executor briefly
-  returns to idle between them; with one intent the user sees a single
-  continuous Phase 3 driven by `JobState` transitions in your discriminated
-  union.
+  smaller building blocks -- functions, observables, state-machine actions or
+  services -- that stay reusable across intents and apps.
 - **No need to thread step results through React.** Intermediate results
-  (e.g. a `signedTxHex`) stay inside the Observable pipeline instead of
-  having to be lifted to React state to feed the next intent's input.
+  (e.g. a `signedTxHex`) stay inside the job implementation instead of having
+  to be lifted to React state to feed the next intent's input.
 
 The `JobState` example in [Defining intents](#defining-intents) — a job that
 emits `waiting-for-confirmation` → `signed` → `error` — is already this
@@ -817,36 +829,11 @@ In practice this means:
   signed transaction hex), but do **not** set a new intent or context from it
   -- the job is still running at that point.
 - **Interactive jobs must complete before the orchestrator advances.** If a
-  job waits for user action (e.g. a "Continue" button), give it a completion
-  signal -- a `Subject<never>` passed as input. The button handler calls
-  `subject.complete()`, which completes the job observable, which triggers
-  `onIntentJobComplete`, which drives the orchestrator forward. Do **not** use
-  `NEVER` as a job tail; it prevents the observable from ever completing,
-  forcing the orchestrator to bypass the completion contract.
-
-A correct interactive job pattern:
-
-```typescript
-import { type Subject, type Observable, concat, of } from "rxjs";
-
-type ConfirmJobState = { type: "waiting" };
-type ConfirmInput = { done$: Subject<never> };
-
-const confirmJob: Job<ConfirmJobState, ConfirmInput> = ({ input }) =>
-  concat(of<ConfirmJobState>({ type: "waiting" }), input.done$);
-```
-
-The orchestrator creates the Subject and wires the button:
-
-```typescript
-const done$ = new Subject<never>();
-const intent = createIntent(confirmDef, { done$ });
-// In extraProps or jobState callback:
-const onContinue = () => done$.complete();
-```
-
-When the user presses Continue, `done$.complete()` completes the observable,
-the executor fires `onIntentJobComplete`, and the orchestrator advances.
+  job waits for user action, emit callbacks in `JobState` and let the intent
+  component call them from UI handlers. The callback can resume the job, emit a
+  terminal state such as `cancelled`, then complete the observable. This keeps
+  interactivity inside the job/component contract. See
+  [Advanced: interactive jobs with callbacks in `JobState`](#advanced-interactive-jobs-with-callbacks-in-jobstate).
 
 ### Changing `deviceInitializationInput` and `intent` together
 
@@ -1003,40 +990,63 @@ executor renders nothing during idle.
 `JobState` does not have to be serializable -- it can contain functions.
 Because `JobState` is just a TypeScript type flowing from the observable to the
 component via React state, it can carry callbacks. This enables interactive
-patterns where the job pauses and emits a callback for the UI to resume it.
+patterns where the job pauses and emits callbacks for the UI to resume or
+cancel it. This is a natural fit for React: those callbacks end up as props
+passed to the intent component.
 
-For example, a job that waits for user confirmation before broadcasting:
+For example, a job can display transaction warnings before broadcasting. The
+user can ignore the warning, which resumes execution, or cancel, which emits a
+final `cancelled` state and completes the job:
 
 ```typescript
+import { Observable } from "rxjs";
+import type { Job } from "@ledgerhq/device-intent";
+
+type TransactionWarning = { message: string };
+
 type MyJobState =
-  | { step: "waiting-for-confirmation"; onConfirm: () => void }
-  | { step: "broadcasting" }
-  | { step: "done"; txHash: string };
+  | {
+      type: "transactionChecksWarning";
+      warnings: TransactionWarning[];
+      onIgnoreWarning: () => void;
+      onCancel: () => void;
+    }
+  | { type: "broadcasting" }
+  | { type: "done"; txHash: string }
+  | { type: "cancelled" };
 
 const myJob: Job<MyJobState, { signedTxHex: string }> = ({ input }) =>
   new Observable<MyJobState>(async subscriber => {
-    let resolveConfirm: () => void;
-    const confirmed = new Promise<void>(r => {
-      resolveConfirm = r;
+    let resolveWarning!: (action: "ignore" | "cancel") => void;
+    const warningAction = new Promise<"ignore" | "cancel">(resolve => {
+      resolveWarning = resolve;
     });
 
     subscriber.next({
-      step: "waiting-for-confirmation",
-      onConfirm: () => resolveConfirm(),
+      type: "transactionChecksWarning",
+      warnings: await getTransactionWarnings(input.signedTxHex),
+      onIgnoreWarning: () => resolveWarning("ignore"),
+      onCancel: () => resolveWarning("cancel"),
     });
 
-    await confirmed;
-    subscriber.next({ step: "broadcasting" });
+    const action = await warningAction;
+    if (action === "cancel") {
+      subscriber.next({ type: "cancelled" });
+      subscriber.complete();
+      return;
+    }
+
+    subscriber.next({ type: "broadcasting" });
 
     const txHash = await broadcast(input.signedTxHex);
-    subscriber.next({ step: "done", txHash });
+    subscriber.next({ type: "done", txHash });
     subscriber.complete();
   });
 ```
 
-The intent component renders a confirmation button that calls
-`jobState.onConfirm()`, creating a two-way communication channel between the
-job and the UI without any external state.
+The intent component renders warning actions that call
+`jobState.onIgnoreWarning()` or `jobState.onCancel()`, creating a two-way
+communication channel between the job and the UI without external state.
 
 ### Working with ledgerjs `Transport`-based code
 
@@ -1061,10 +1071,7 @@ import Eth from "@ledgerhq/hw-app-eth";
 import { defer, map, catchError, of } from "rxjs";
 import type { Job } from "@ledgerhq/device-intent";
 
-const myJob: Job<MyJobState, { txHex: string }> = ({
-  deviceConnectionResult,
-  input,
-}) =>
+const myJob: Job<MyJobState, { txHex: string }> = ({ deviceConnectionResult, input }) =>
   defer(async () => {
     const transport = new DmkCompatTransport(
       deviceConnectionResult.dmk,
@@ -1126,9 +1133,9 @@ Either emit an initial state synchronously in the job:
 
 ```typescript
 const job: Job<MyState, MyInput> = ({ input }) =>
-  concat(
-    of<MyState>({ step: "loading" }),  // synchronous, immediate
-    fetchData(input).pipe(map(...)),   // async work follows
+  fetchData(input).pipe(
+    map(...),                                // async work follows
+    startWith<MyState>({ step: "loading" }), // synchronous, immediate
   );
 ```
 
@@ -1154,17 +1161,18 @@ Common causes:
 - Advancing the flow from `onIntentJobStateChanged` instead of
   `onIntentJobComplete`. The job may still be emitting when the state callback
   fires.
-- Using `NEVER` as a job tail for interactive intents. The observable never
-  completes, so the orchestrator is forced to bypass the completion contract.
-  Use a `Subject<never>` completion signal instead (see
-  [Job completion contract](#job-completion-contract)).
+- Leaving an interactive job waiting forever. If the observable never
+  completes, the orchestrator is forced to bypass the completion contract. Emit
+  callbacks in `JobState` so the component can resume or cancel the job, then
+  complete the observable (see
+  [Advanced: interactive jobs with callbacks in `JobState`](#advanced-interactive-jobs-with-callbacks-in-jobstate)).
 - Calling a navigation callback (e.g. `goTo()`) from a UI button without
   first completing the job.
 
 **Fix:** always ensure the job observable completes before transitioning. For
-interactive jobs, complete a `Subject<never>` from the button handler. For
-async jobs, let the observable complete naturally and react in
-`onIntentJobComplete`.
+interactive jobs, callbacks emitted in `JobState` should resume or cancel the
+job and let it complete. For async jobs, let the observable complete naturally
+and react in `onIntentJobComplete`.
 
 #### Changing `deviceInitializationInput` and `intent` in separate renders
 
@@ -1207,17 +1215,15 @@ inside the observable:
 
 ```typescript
 const job: Job<MyState, MyInput> = ({ input }) =>
-  concat(
-    of<MyState>({ step: "loading" }),
-    doWork(input).pipe(
-      map((result): MyState => ({ step: "done", result })),
-      catchError(err =>
-        of<MyState>({
-          step: "error",
-          error: err instanceof Error ? err : new Error(String(err)),
-        }),
-      ),
+  doWork(input).pipe(
+    map((result): MyState => ({ step: "done", result })),
+    catchError(err =>
+      of<MyState>({
+        step: "error",
+        error: err instanceof Error ? err : new Error(String(err)),
+      }),
     ),
+    startWith<MyState>({ step: "loading" }),
   );
 ```
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Docs-only README + thin re-export of an already-tested `live-common` helper._
- [x] **Impact of the changes:**
  - No runtime behavior change — the new `buildDeviceInitializationInput` is not yet consumed anywhere.
  - README and agent skill are documentation / dev tooling only.

### 📝 Description

Turn `libs/device-intent/README.md` into a usage guide for the **Device Intent Executor (DIE)** and add a small LWM-scoped helper for adoption from existing flows.

- **`docs(device-intent)`** — rewritten README (lifecycle, anatomy of an intent, defining and structuring intents, multi-intent orchestration, `DmkCompatTransport` interop, pitfalls).
- **New agent skill** `.agents/skills/device-intent-executor/SKILL.md` — narrowly-scoped skill that auto-points agents to the README when they touch DIE-related topics (`DeviceIntentExecutor`, intents, `deviceInitializationInput`, `DmkCompatTransport`, migrations off `connectApp` / `DeviceAction` / `withDevice`). Stays out of the context window otherwise.
- **`feat(mobile)`** — `buildDeviceInitializationInput` exported from `LLM/mvvm/components/DeviceIntentExecutor`, a thin re-export of `buildEnsureAppReadyInput` so flows can translate their existing `AppRequest` into the executor's `deviceInitializationInput`.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30702](https://ledgerhq.atlassian.net/browse/LIVE-30702)

[LIVE-30702]: https://ledgerhq.atlassian.net/browse/LIVE-30702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ