### PR TITLE
[LWM] fix(mobile): adjust asset detail page UI

### DIFF
--- a/.changeset/swift-pandas-dance.md
+++ b/.changeset/swift-pandas-dance.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Adjust asset detail page UI: show Earn entry point on non-owned stakeable assets, replace plus with chevron icon in the Earn banner, and resize the Transfer CTA.

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/BalanceDetailsView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/BalanceDetailsView.tsx
@@ -40,7 +40,14 @@ export function BalanceDetailsView({
     return <SectionSkeleton rows={1} rowHeight="s56" />;
   }
 
-  if (!hasAccounts) return null;
+  if (!hasAccounts) {
+    if (earnState.type !== "banner") return null;
+    return (
+      <Box testID={ASSET_DETAIL_TEST_IDS.balanceDetails} lx={containerStyle}>
+        <EarnBannerView label={earnState.label} onPress={onEarnBannerPress} />
+      </Box>
+    );
+  }
 
   return (
     <Box testID={ASSET_DETAIL_TEST_IDS.balanceDetails} lx={containerStyle}>

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/EarnBannerView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/EarnBannerView.tsx
@@ -1,17 +1,16 @@
 import React from "react";
 import {
-  Box,
   Card,
   CardContent,
   CardContentDescription,
   CardContentTitle,
   CardHeader,
   CardLeading,
+  IconButton,
 } from "@ledgerhq/lumen-ui-rnative";
-import { Plus } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { ChevronRight } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { useTranslation } from "~/context/Locale";
 import { ASSET_DETAIL_TEST_IDS } from "LLM/features/AssetDetail/testIds";
-import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 
 type Props = Readonly<{
   label: string;
@@ -23,6 +22,7 @@ export function EarnBannerView({ label, onPress }: Props) {
 
   return (
     <Card
+      type="info"
       onPress={onPress}
       testID={ASSET_DETAIL_TEST_IDS.earnBanner}
       accessibilityLabel={t("assetDetail.balanceDetails.earnBannerAction")}
@@ -36,18 +36,14 @@ export function EarnBannerView({ label, onPress }: Props) {
             </CardContentDescription>
           </CardContent>
         </CardLeading>
-        <Box lx={IconWrapper}>
-          <Plus size={20} color="base" />
-        </Box>
+        <IconButton
+          appearance="transparent"
+          size="sm"
+          icon={ChevronRight}
+          accessibilityLabel={t("assetDetail.balanceDetails.earnBannerAction")}
+          onPress={onPress}
+        />
       </CardHeader>
     </Card>
   );
 }
-
-const IconWrapper: LumenViewStyle = {
-  borderRadius: "full",
-  backgroundColor: "mutedTransparent",
-  justifyContent: "center",
-  alignItems: "center",
-  padding: "s10",
-};

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/TotalBalanceView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/TotalBalanceView.tsx
@@ -38,7 +38,7 @@ export function TotalBalanceView({
       </Box>
       <Button
         appearance="gray"
-        size="md"
+        size="sm"
         icon={TransferVertical}
         onPress={onTransferPress}
         testID={ASSET_DETAIL_TEST_IDS.transferButton}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/__tests__/useBalanceDetailsViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/__tests__/useBalanceDetailsViewModel.test.ts
@@ -185,6 +185,28 @@ describe("useBalanceDetailsViewModel", () => {
       expect(result.current.earnState.type).toBe("hidden");
     });
 
+    it("shows banner when stakeable and no accounts", () => {
+      mockGetCanStakeCurrency.mockReturnValue(true);
+
+      const { result } = renderHook(() =>
+        useBalanceDetailsViewModel(mockBtcCryptoCurrency, undefined),
+      );
+
+      expect(result.current.hasAccounts).toBe(false);
+      expect(result.current.earnState.type).toBe("banner");
+    });
+
+    it("remains hidden when not stakeable and no accounts", () => {
+      mockGetCanStakeCurrency.mockReturnValue(false);
+
+      const { result } = renderHook(() =>
+        useBalanceDetailsViewModel(mockBtcCryptoCurrency, undefined),
+      );
+
+      expect(result.current.hasAccounts).toBe(false);
+      expect(result.current.earnState.type).toBe("hidden");
+    });
+
     it("shows banner when stakeable but no stake", () => {
       mockGetCanStakeCurrency.mockReturnValue(true);
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/useBalanceDetailsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/useBalanceDetailsViewModel.ts
@@ -93,8 +93,6 @@ export function useBalanceDetailsViewModel(
   );
 
   const earnState: EarnState = useMemo(() => {
-    if (!hasAccounts) return { type: "hidden" };
-
     if (isStakeable && hasStake && unit) {
       return {
         type: "staked",
@@ -121,7 +119,6 @@ export function useBalanceDetailsViewModel(
 
     return { type: "hidden" };
   }, [
-    hasAccounts,
     hasStake,
     isStakeable,
     unit,

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/BalanceGraphView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/BalanceGraphView.tsx
@@ -117,7 +117,7 @@ export function BalanceGraphView({
       {showReceive && (
         <Box lx={receiveContainerStyle}>
           <Button
-            appearance="base"
+            appearance="gray"
             size="lg"
             isFull
             icon={ArrowDown}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Only the Earn banner visibility logic (`!hasAccounts` + stakeable) is covered by unit tests on `useBalanceDetailsViewModel`. Pure visual changes (icon swap, button size/appearance) are not tested._
- [x] **Impact of the changes:**
  - Asset detail page on Ledger Live Mobile
  - Earn banner: now displayed on non-owned stakeable assets, icon swapped from plus to chevron
  - Total balance section: Transfer CTA resized from `md` to `sm`
  - Balance graph: Receive button appearance switched from `base` to `gray`

### 📝 Description

The Figma for the Asset detail page was updated with a few graphic adjustments that were not reflected in the app yet.

**Changes:**
- Show an Earn entry point on stakeable assets the user does not own yet (case that was not originally covered by the designs).
- Replace the `Plus` icon with `ChevronRight` in the Earn banner.
- Reduce the Transfer CTA from `md` to `sm` to match the smaller Total balance typography.
- Align the Receive button on the Balance graph with the new gray appearance.

> Note: the Total balance typography size reduction mentioned in the ticket is still pending the corresponding Lumen variant and is not part of this PR.

| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30914](https://ledgerhq.atlassian.net/browse/LIVE-30914)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30914]: https://ledgerhq.atlassian.net/browse/LIVE-30914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ