### PR TITLE
[LWM] feat(mobile): add hidden asset banner on Asset Detail screen

### DIFF
--- a/.changeset/hidden-asset-banner-mobile.md
+++ b/.changeset/hidden-asset-banner-mobile.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add hidden asset banner on the Asset Detail screen with a quick action to unhide the asset

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8960,6 +8960,10 @@
     "fallbackBanner": {
       "title": "Swap and Buy are not supported for this asset."
     },
+    "hiddenAssetBanner": {
+      "title": "This asset is hidden from your portfolio.",
+      "showAsset": "Show asset"
+    },
     "balanceDetails": {
       "totalBalance": "Total balance",
       "transfer": "Transfer",

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
@@ -70,6 +70,15 @@ function withBtcAccounts(count: number, operationsSize = 0) {
   );
 }
 
+function withBlacklistedTokens(tokenIds: string[]) {
+  return {
+    overrideInitialState: (state: State): State => ({
+      ...state,
+      settings: { ...state.settings, blacklistedTokenIds: tokenIds },
+    }),
+  };
+}
+
 describe("AssetDetail screen layout", () => {
   beforeEach(() => {
     mockIsCurrencyAvailable.mockReturnValue(false);
@@ -267,6 +276,40 @@ describe("AssetDetail screen layout", () => {
       expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.swapButton)).toBeVisible();
       expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.receiveButton)).toBeVisible();
       expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.footerReceiveButton)).toBeNull();
+    });
+  });
+
+  describe("hidden asset banner", () => {
+    it("does not render the banner when the asset is not hidden", () => {
+      render(<AssetDetailTestNavigator />);
+
+      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.hiddenAssetBanner)).toBeNull();
+    });
+
+    it("renders the banner when the asset is blacklisted", () => {
+      render(<AssetDetailTestNavigator />, withBlacklistedTokens(["bitcoin"]));
+
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.hiddenAssetBanner)).toBeVisible();
+      expect(screen.getByText("This asset is hidden from your portfolio.")).toBeVisible();
+      expect(screen.getByText("Show asset")).toBeVisible();
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.hiddenAssetBannerShowAsset)).toBeVisible();
+    });
+
+    it("hides the banner and unhides the asset when Show asset is pressed", async () => {
+      const { user, store } = render(
+        <AssetDetailTestNavigator />,
+        withBlacklistedTokens(["bitcoin"]),
+      );
+
+      const showAssetButton = await screen.findByTestId(
+        ASSET_DETAIL_TEST_IDS.hiddenAssetBannerShowAsset,
+      );
+      await user.press(showAssetButton);
+
+      await waitFor(() =>
+        expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.hiddenAssetBanner)).toBeNull(),
+      );
+      expect(store.getState().settings.blacklistedTokenIds).not.toContain("bitcoin");
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
@@ -14,6 +14,7 @@ import { Addresses } from "./components/Addresses";
 import { Transactions } from "./components/Transactions";
 import { Footer } from "./components/Footer";
 import { FallbackBanner } from "./components/FallbackBanner";
+import { HiddenAssetBanner } from "./components/HiddenAssetBanner";
 import { MarketData } from "./components/MarketData";
 import { CTAS_HEIGHT } from "./utils/constants";
 import { AssetCoinOptionsSheetView } from "./components/CoinOptions/AssetCoinOptionsSheetView";
@@ -59,6 +60,7 @@ export function AssetDetailView({
         refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={onRefresh} />}
       >
         <Box lx={contentStyle}>
+          <HiddenAssetBanner show={coinOptions.isHidden} onShowAsset={coinOptions.onShowAsset} />
           <BalanceGraph currency={currency} hideReceive={hideReceiveInBalanceGraph} />
           <BalanceDetails
             currency={currency}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/CoinOptions/useAssetCoinOptionsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/CoinOptions/useAssetCoinOptionsViewModel.ts
@@ -69,6 +69,11 @@ export function useAssetCoinOptionsViewModel({ currency, currencyId, marketId }:
     closeCoinOptions,
   ]);
 
+  const onShowAsset = useCallback(() => {
+    if (!currency) return;
+    dispatch(showToken(currency.id));
+  }, [currency, dispatch]);
+
   const onToggleHideFromPortfolio = useCallback(() => {
     if (!currency) return;
 
@@ -86,10 +91,10 @@ export function useAssetCoinOptionsViewModel({ currency, currencyId, marketId }:
         dispatch(blacklistToken(currency.id));
       }
     } else {
-      dispatch(showToken(currency.id));
+      onShowAsset();
     }
     closeCoinOptions();
-  }, [currency, isHidden, blacklistedTokenIdsSet, dispatch, closeCoinOptions]);
+  }, [currency, isHidden, blacklistedTokenIdsSet, dispatch, closeCoinOptions, onShowAsset]);
 
   return {
     isCoinOptionsSheetOpen,
@@ -100,6 +105,7 @@ export function useAssetCoinOptionsViewModel({ currency, currencyId, marketId }:
     isStarred,
     onToggleFavourite,
     onToggleHideFromPortfolio,
+    onShowAsset,
   };
 }
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/HiddenAssetBanner/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/HiddenAssetBanner/index.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { Banner, Button } from "@ledgerhq/lumen-ui-rnative";
+import { useTranslation } from "~/context/Locale";
+import { ASSET_DETAIL_TEST_IDS } from "../../../../testIds";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+
+type Props = Readonly<{
+  show: boolean;
+  onShowAsset: () => void;
+}>;
+
+export function HiddenAssetBanner({ show, onShowAsset }: Props) {
+  const { t } = useTranslation();
+
+  if (!show) return null;
+
+  return (
+    <Banner
+      testID={ASSET_DETAIL_TEST_IDS.hiddenAssetBanner}
+      lx={bannerStyle}
+      appearance="info"
+      title={t("assetDetail.hiddenAssetBanner.title")}
+      accessibilityLabel={t("assetDetail.hiddenAssetBanner.title")}
+      primaryAction={
+        <Button
+          appearance="gray"
+          size="sm"
+          onPress={onShowAsset}
+          testID={ASSET_DETAIL_TEST_IDS.hiddenAssetBannerShowAsset}
+        >
+          {t("assetDetail.hiddenAssetBanner.showAsset")}
+        </Button>
+      }
+    />
+  );
+}
+
+const bannerStyle: LumenViewStyle = {
+  marginBottom: "-s16",
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/testIds.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/testIds.ts
@@ -21,6 +21,8 @@ export const ASSET_DETAIL_TEST_IDS = {
   swapButton: "asset-detail-swap-button",
   footerReceiveButton: "asset-detail-footer-receive-button",
   fallbackBanner: "asset-detail-fallback-banner",
+  hiddenAssetBanner: "asset-detail-hidden-asset-banner",
+  hiddenAssetBannerShowAsset: "asset-detail-hidden-asset-banner-show-asset",
   coinOptionsTrailing: "asset-detail-coin-options-trailing",
   coinOptionsSheet: "asset-detail-coin-options-sheet",
   coinOptionsFavouriteRow: "asset-detail-coin-options-favourite-row",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Asset Detail screen rendering when an asset is hidden vs visible
  - "Show asset" action on the banner correctly unhides the asset and dismisses the banner
  - No regression on existing CoinOptions sheet behavior (hide/show toggle)

### 📝 Description

When an asset is hidden from the portfolio, the Asset Detail screen now displays a banner at the top informing the user, with a primary action to unhide the asset.

**Problem**: Users could navigate to a hidden asset's detail screen without any visible indication that the asset was hidden, and had to open the coin options sheet to unhide it.

**Solution**:
- New `HiddenAssetBanner` component rendered at the top of the Asset Detail scroll content, gated on `coinOptions.isHidden`.
- Added a dedicated `onShowAsset` callback on `useAssetCoinOptionsViewModel` so the banner unhides the asset without going through the sheet-toggle code path (reused inside `onToggleHideFromPortfolio` for consistency).
- Added translation keys `assetDetail.hiddenAssetBanner.title` and `.showAsset`.

https://github.com/user-attachments/assets/925e076a-8301-4871-af97-6a64212879c7


### ❓ Context

- **JIRA or GitHub link**: [LIVE-30943](https://ledgerhq.atlassian.net/browse/LIVE-30943)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30943]: https://ledgerhq.atlassian.net/browse/LIVE-30943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ