### PR TITLE
fix(coin-evm): trigger Sei app for SEI EVM send & receive

### DIFF
--- a/.changeset/swift-pandas-build.md
+++ b/.changeset/swift-pandas-build.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/cryptoassets": minor
+"@domain/entity-currency-crypto": minor
+---
+
+Trigger Sei app instead of Ethereum app for SEI EVM send & receive

--- a/domain/entity/currency-crypto/src/currencies/sei_evm.ts
+++ b/domain/entity/currency-crypto/src/currencies/sei_evm.ts
@@ -5,7 +5,7 @@ export const sei_evm = currency({
   id: "sei_evm",
   coinType: 60,
   name: "SEI Network (EVM)",
-  managerAppName: "Ethereum",
+  managerAppName: "Sei",
   ticker: "SEI",
   scheme: "sei",
   color: "#89395b",

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
@@ -4361,7 +4361,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     id: "sei_evm",
     coinType: CoinType.ETH,
     name: "SEI Network (EVM)",
-    managerAppName: "Ethereum",
+    managerAppName: "Sei",
     ticker: "SEI",
     scheme: "sei",
     color: "#89395b",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Currency configuration change — validated manually via send/receive on a real device._
- [x] **Impact of the changes:**
  - SEI EVM send flow now prompts for the **Sei** app instead of the **Ethereum** app
  - SEI EVM receive flow now prompts for the **Sei** app instead of the **Ethereum** app
  - No impact on other EVM currencies

### 📝 Description

**Problem**: SEI EVM accounts were triggering the Ethereum app for send & receive operations instead of the dedicated Sei app.

**Solution**: Updated `managerAppName` from `"Ethereum"` to `"Sei"` for the `sei_evm` currency in both declarations:
- `libs/ledgerjs/packages/cryptoassets/src/currencies.ts`
- `domain/entity/currency-crypto/src/currencies/sei_evm.ts`

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30917](https://ledgerhq.atlassian.net/browse/LIVE-30917)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-30917]: https://ledgerhq.atlassian.net/browse/LIVE-30917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ