### PR TITLE
[LWM] feat(mobile): show stuck-loader hint after 10s on device action

### DIFF
--- a/.changeset/live-29175-stuck-device-action-hint.md
+++ b/.changeset/live-29175-stuck-device-action-hint.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Show a stuck-loader hint after 10s on mobile device-action loading screens to invite users to check their device

--- a/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
@@ -66,6 +66,7 @@ import {
   NanoSNotSupportedComponent,
   UnsupportedFeatureComponent,
 } from "./rendering";
+import { useStuckDeviceActionHint } from "../StuckDeviceActionHint/useStuckDeviceActionHint";
 import { ThorSwapIncompatibility } from "./ThorSwapIncompatibility";
 import { WalletState } from "@ledgerhq/live-wallet/store";
 import { DeviceId } from "@ledgerhq/client-ids/ids";
@@ -309,6 +310,11 @@ export function DeviceActionDefaultRendering<R, H extends Status, P>({
 
   useTrackDmkErrorsEvents({ error });
 
+  // Stuck device-action hint: surfaced after 10s of being in a loading
+  // state without an error. The timer naturally resets whenever this
+  // component unmounts or `error` flips truthy.
+  const showStuckHint = useStuckDeviceActionHint(!error);
+
   // Add deviceId to identities store when detected
   useEffect(() => {
     if (deviceId) {
@@ -502,6 +508,7 @@ export function DeviceActionDefaultRendering<R, H extends Status, P>({
       device: selectedDevice,
       colors,
       theme,
+      showStuckHint,
     });
   }
 
@@ -558,6 +565,7 @@ export function DeviceActionDefaultRendering<R, H extends Status, P>({
       description: t("DeviceAction.listApps"),
       colors,
       theme,
+      showStuckHint,
     });
   }
 
@@ -710,6 +718,7 @@ export function DeviceActionDefaultRendering<R, H extends Status, P>({
       t,
       colors,
       theme,
+      showStuckHint,
     });
   }
 

--- a/apps/ledger-live-mobile/src/components/DeviceAction/renderLoading.test.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/renderLoading.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import { useTranslation } from "~/context/Locale";
+import { renderLoading } from "./rendering";
+
+const STUCK_LOADER_HINT_TEXT = "Ensure your device is unlocked and no operation is pending";
+
+function Harness({ showStuckHint }: { showStuckHint: boolean }) {
+  const { t } = useTranslation();
+  return <>{renderLoading({ t, showStuckHint })}</>;
+}
+
+describe("DeviceAction renderLoading - stuck loader hint", () => {
+  it("does not show the hint when showStuckHint is false", () => {
+    render(<Harness showStuckHint={false} />);
+    expect(screen.queryByText(STUCK_LOADER_HINT_TEXT)).toBeNull();
+    expect(screen.queryByTestId("device-action-stuck-loader-hint")).toBeNull();
+  });
+
+  it("shows the hint when showStuckHint is true", () => {
+    render(<Harness showStuckHint={true} />);
+    expect(screen.getByTestId("device-action-stuck-loader-hint")).toBeOnTheScreen();
+    expect(screen.getByText(STUCK_LOADER_HINT_TEXT)).toBeOnTheScreen();
+  });
+
+  it("defaults to no hint when prop is omitted", () => {
+    function Bare() {
+      const { t } = useTranslation();
+      return <>{renderLoading({ t })}</>;
+    }
+    render(<Bare />);
+    expect(screen.queryByTestId("device-action-stuck-loader-hint")).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -28,6 +28,7 @@ import firmwareUpdateRepair from "@ledgerhq/live-common/hw/firmwareUpdate-repair
 import { isInvalidGetFirmwareMetadataResponseError } from "@ledgerhq/live-dmk-mobile";
 import { WalletState } from "@ledgerhq/live-wallet/store";
 import { BoxedIcon, Flex, Icons, IconsLegacy, Link, Log, Tag, Text } from "@ledgerhq/native-ui";
+import { StuckDeviceActionHint } from "../StuckDeviceActionHint";
 import InfiniteLoader from "~/components/InfiniteLoader";
 import { DownloadMedium } from "@ledgerhq/native-ui/assets/icons";
 import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
@@ -281,9 +282,11 @@ export function renderAllowManager({
   device,
   theme,
   requestType = "manager",
+  showStuckHint = false,
 }: RawProps & {
   device: Device;
   requestType?: "manager" | "rename";
+  showStuckHint?: boolean;
 }) {
   // TODO: disable gesture, modal close, hide header buttons
   return (
@@ -306,6 +309,7 @@ export function renderAllowManager({
           style={getDeviceAnimationStyles(device.modelId)}
         />
       </AnimationContainer>
+      {showStuckHint ? <StuckDeviceActionHint /> : null}
     </Wrapper>
   );
 }
@@ -1015,9 +1019,11 @@ export function renderLoading({
   t,
   description,
   lockModal = false,
+  showStuckHint = false,
 }: RawProps & {
   description?: string;
   lockModal?: boolean;
+  showStuckHint?: boolean;
 }) {
   return (
     <Wrapper>
@@ -1025,6 +1031,7 @@ export function renderLoading({
         <InfiniteLoader testID="device-action-loading" />
       </SpinnerContainer>
       <CenteredText>{description ?? t("DeviceAction.loading")}</CenteredText>
+      {showStuckHint ? <StuckDeviceActionHint /> : null}
       {lockModal ? <ModalLock /> : null}
     </Wrapper>
   );

--- a/apps/ledger-live-mobile/src/components/SelectDevice2/DeviceLockedCheckDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice2/DeviceLockedCheckDrawer.tsx
@@ -5,6 +5,8 @@ import { TrackScreen } from "~/analytics";
 import { useTrackDmkErrorsEvents } from "~/analytics/hooks/useTrackDmkErrorsEvents";
 import GenericErrorView from "~/components/GenericErrorView";
 import { ConnectYourDevice } from "../DeviceAction/rendering";
+import { StuckDeviceActionHint } from "../StuckDeviceActionHint";
+import { useStuckDeviceActionHint } from "../StuckDeviceActionHint/useStuckDeviceActionHint";
 import QueuedDrawer from "../QueuedDrawer";
 import { useIsDeviceLockedPolling } from "~/hooks/useIsDeviceLockedPolling/useIsDeviceLockedPolling";
 import { IsDeviceLockedResultType } from "~/hooks/useIsDeviceLockedPolling/types";
@@ -34,6 +36,10 @@ export const DeviceLockedCheckDrawer = ({ isOpen, device, onDeviceUnlocked, onCl
   const isLockedStateCannotBeDetermined =
     isLockedResult.type === IsDeviceLockedResultType.lockedStateCannotBeDetermined;
 
+  // Stuck-loader hint: show after 10s of undetermined polling so the user
+  // gets feedback when the device is silently busy (no AlreadySendingApduError).
+  const showStuckHint = useStuckDeviceActionHint(isOpen && isUndetermined);
+
   useEffect(() => {
     if (isUnlocked || isLockedStateCannotBeDetermined) {
       onDeviceUnlocked();
@@ -56,7 +62,12 @@ export const DeviceLockedCheckDrawer = ({ isOpen, device, onDeviceUnlocked, onCl
 
   return (
     <QueuedDrawer isRequestingToBeOpened={isOpen} onClose={onClose}>
-      {isUndetermined && <InfiniteLoader />}
+      {isUndetermined && (
+        <>
+          <InfiniteLoader />
+          {showStuckHint ? <StuckDeviceActionHint /> : null}
+        </>
+      )}
       {isPeerRemovedPairingError && (
         <BleForgetDeviceIllustration
           productName={getDeviceModel(device.modelId).productName}

--- a/apps/ledger-live-mobile/src/components/StuckDeviceActionHint/index.tsx
+++ b/apps/ledger-live-mobile/src/components/StuckDeviceActionHint/index.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { Alert as BaseAlert, Flex } from "@ledgerhq/native-ui";
+import { useTranslation } from "~/context/Locale";
+
+export function StuckDeviceActionHint() {
+  const { t } = useTranslation();
+  return (
+    <Flex testID="device-action-stuck-loader-hint" width="100%" mt={6}>
+      <BaseAlert type="secondary" title={t("DeviceAction.stuckLoaderHint")} />
+    </Flex>
+  );
+}

--- a/apps/ledger-live-mobile/src/components/StuckDeviceActionHint/useStuckDeviceActionHint.ts
+++ b/apps/ledger-live-mobile/src/components/StuckDeviceActionHint/useStuckDeviceActionHint.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+
+export const STUCK_DEVICE_ACTION_HINT_DELAY_MS = 10_000;
+
+/**
+ * Returns true once `enabled` has been continuously true for
+ * STUCK_DEVICE_ACTION_HINT_DELAY_MS, false otherwise. Resets whenever
+ * `enabled` flips false or the component unmounts.
+ */
+export function useStuckDeviceActionHint(enabled: boolean): boolean {
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    if (!enabled) {
+      setShow(false);
+      return;
+    }
+    const id = setTimeout(() => setShow(true), STUCK_DEVICE_ACTION_HINT_DELAY_MS);
+    return () => clearTimeout(id);
+  }, [enabled]);
+
+  return show;
+}

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -4996,6 +4996,7 @@
   },
   "DeviceAction": {
     "stayInTheAppPlz": "Stay in the Ledger Wallet app and keep your Ledger nearby.",
+    "stuckLoaderHint": "Ensure your device is unlocked and no operation is pending",
     "allowAppPermission": "Open the {{wording}} app on your device",
     "allowAppPermissionSubtitleToken": "to manage your {{token}} tokens",
     "allowManagerPermission": "Allow a secure connection with Ledger",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Mobile device-action loading flows (`renderLoading`, `renderAllowManager`): a hint surfaces after ~10s of being stuck loading without an error.
  - `DeviceLockedCheckDrawer`: a hint surfaces after ~10s of undetermined locked-state polling.
  - Verify the timer resets correctly when the action errors, resolves, the component unmounts, or the drawer closes.
  - Verify no regression on the regular spinner / connect-your-device animations when the action completes within 10s.
  - Verify the new English string renders correctly. Only `en/common.json` was updated — other locales will be covered via Crowdin.

### 📝 Description

When a mobile device action stalls (locked device, busy app, BLE flake), users currently see an infinite spinner with no actionable feedback, and several silent failure modes keep polling indefinitely.

This PR surfaces a discreet alert ("Ensure your device is unlocked and no operation is pending") after the screen has been in a non-error loading state for 10 seconds. The behavior is shared across three loading surfaces:

- `renderLoading` (generic device-action loader)
- `renderAllowManager` (manager-permission flow)
- `DeviceLockedCheckDrawer` (locked-state polling)

The logic is encapsulated in a new reusable hook `useStuckDeviceActionHint(enabled: boolean)` (`STUCK_DEVICE_ACTION_HINT_DELAY_MS = 10_000`), which returns `true` once `enabled` has been continuously truthy for the delay and resets when it flips false or the component unmounts. The `<StuckDeviceActionHint>` component renders a `secondary` `Alert` with the localized hint.

```ts
const showStuckHint = useStuckDeviceActionHint(!error);
```

Unit tests cover the `renderLoading` rendering, including the default-off prop, and the hint appearance / absence based on the prop.

### 📸 Screenshots

https://github.com/user-attachments/assets/b211182f-cb58-40d0-bed0-c066e3c331e6


| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29175](https://ledgerhq.atlassian.net/browse/LIVE-29175)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-29175]: https://ledgerhq.atlassian.net/browse/LIVE-29175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ