### PR TITLE
test(desktop): skip private balance activation e2e

### DIFF
--- a/e2e/desktop/tests/specs/activate.private.balance.spec.ts
+++ b/e2e/desktop/tests/specs/activate.private.balance.spec.ts
@@ -11,7 +11,8 @@ const accounts = [
 ];
 
 for (const account of accounts) {
-  test.describe("Activate Private Balance", () => {
+  // TODO: Activate when next app is available
+  test.describe.skip("Activate Private Balance", () => {
     test.use({
       teamOwner: Team.BST,
       userdata: "skip-onboarding-with-last-seen-device",


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _Not applicable: desktop E2E test-only change._
- [x] **Covered by automatic tests.** _Validated with `pnpm e2e:desktop typecheck`; `pnpm e2e:desktop lint` completed with existing warnings and 0 errors._
- [x] **Impact of the changes:**
      - Desktop E2E suite scheduling
      - Activate Private Balance flow is temporarily skipped until the next app is available

### 📝 Description

The Activate Private Balance desktop E2E currently depends on the next app being available. Until that app is available, the spec should not run in CI because it cannot complete the intended flow reliably.

This PR temporarily marks the `Activate Private Balance` describe block as skipped and leaves a TODO to reactivate it when the next app is available.

### ❓ Context

- **JIRA or GitHub link**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)