### PR TITLE
[LWDM] feat(mobile): wire AssetDetail entry points and fix market id resolution

### DIFF
--- a/.changeset/wire-asset-detail-entry-points.md
+++ b/.changeset/wire-asset-detail-entry-points.md
@@ -1,0 +1,7 @@
+---
+"live-mobile": minor
+"ledger-live-desktop": patch
+"@ledgerhq/asset-aggregation": minor
+---
+
+Wire mobile asset entry points (Market list, Market banner, Portfolio asset rows, Crypto/Stablecoin lists, Analytics distribution cards) to the new MVVM AssetDetail screen when shouldDisplayAggregatedAssets is true; fall back to the legacy MarketDetail / Accounts > Asset routes otherwise. Add a shared `resolveAssetMarketInputs` helper in `@ledgerhq/asset-aggregation` to derive `marketApiId` / `knownLedgerIds` / `knownMarketId` consistently across desktop and mobile, fixing the BNB-style ledger-id ≠ market-id mismatch that caused empty market data on the asset detail screen.

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/useAssetDetailViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/useAssetDetailViewModel.ts
@@ -9,7 +9,10 @@ import { useSelector } from "LLD/hooks/redux";
 import { useDistribution } from "~/renderer/actions/general";
 import { counterValueCurrencySelector } from "~/renderer/reducers/settings";
 import { decodeRouteParam } from "../utils/decodeRouteParam";
-import { resolveDistributionItem } from "@ledgerhq/asset-aggregation/assetDistribution/index";
+import {
+  resolveAssetMarketInputs,
+  resolveDistributionItem,
+} from "@ledgerhq/asset-aggregation/assetDistribution/index";
 import { type AssetDetailViewModel } from "../types";
 
 export function useAssetDetailViewModel(): AssetDetailViewModel {
@@ -26,15 +29,15 @@ export function useAssetDetailViewModel(): AssetDetailViewModel {
     [routeAssetId, decodedAssetId, marketState, distribution],
   );
 
-  const marketApiId =
-    distributionItem?.marketId ??
-    distributionItem?.slug ??
-    distributionItem?.currency.id ??
-    decodedAssetId;
-  const knownLedgerIds = useMemo<readonly string[] | undefined>(() => {
-    if (distributionItem) return [distributionItem.currency.id];
-    return marketState?.ledgerIds;
-  }, [distributionItem, marketState]);
+  const { marketApiId, knownLedgerIds } = useMemo(
+    () =>
+      resolveAssetMarketInputs({
+        distributionItem,
+        marketState,
+        fallbackId: decodedAssetId,
+      }),
+    [distributionItem, marketState, decodedAssetId],
+  );
 
   const { marketCurrencyData, marketId, ledgerCurrencyFromDada, isLoading } = useAssetMarketData({
     marketApiId,

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/DetailedAllocation/components/DistributionCard.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/DetailedAllocation/components/DistributionCard.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useMemo } from "react";
 import { TouchableOpacity } from "react-native";
-import { useNavigation } from "@react-navigation/native";
 import styled, { useTheme } from "styled-components/native";
 import { getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
 import { Flex, Text } from "@ledgerhq/native-ui";
@@ -9,12 +8,11 @@ import CounterValue from "~/components/CounterValue";
 import CurrencyIcon from "~/components/CurrencyIcon";
 import CurrencyUnitValue from "~/components/CurrencyUnitValue";
 import ProgressBar from "~/components/ProgressBar";
-import { NavigatorName, ScreenName } from "~/const";
 import { withDiscreetMode } from "~/context/DiscreetModeContext";
 import { track } from "~/analytics";
 import { DETAILED_ALLOCATION_PAGE } from "../../../const";
 import type { DistributionItem } from "../../../types/distribution";
-import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { useAssetDetailNavigation } from "LLM/features/AssetDetail/hooks/useAssetDetailNavigation";
 
 type Props = Readonly<{
   item: DistributionItem;
@@ -59,8 +57,7 @@ const DistributionRow = styled(Flex).attrs({
 
 function DistributionCard({ item: { currency, amount, distribution } }: Props) {
   const { colors } = useTheme();
-  const navigation = useNavigation();
-  const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("mobile");
+  const { openFromAsset, hideNetwork } = useAssetDetailNavigation();
 
   const color = useMemo(
     () => ensureContrast(getCurrencyColor(currency), colors.background.main),
@@ -74,19 +71,14 @@ function DistributionCard({ item: { currency, amount, distribution } }: Props) {
       page: DETAILED_ALLOCATION_PAGE,
     });
 
-    navigation.navigate(NavigatorName.Accounts, {
-      screen: ScreenName.Asset,
-      params: {
-        currency,
-      },
-    });
-  }, [currency, navigation]);
+    openFromAsset({ currency, source: "detailed_allocation" });
+  }, [currency, openFromAsset]);
 
   return (
     <Container onPress={navigateToAccounts}>
       <Flex flexDirection="row">
         <IconContainer>
-          <CurrencyIcon currency={currency} size={35} hideNetwork={shouldDisplayAggregatedAssets} />
+          <CurrencyIcon currency={currency} size={35} hideNetwork={hideNetwork} />
         </IconContainer>
         <CoinInfoContainer>
           <CurrencyRow>

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
@@ -33,7 +33,17 @@ jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
 
 const Stack = createNativeStackNavigator();
 
-function AssetDetailTestNavigator() {
+type NavigatorParams = {
+  currencyId: string;
+  source?: string;
+  marketState?: { id: string; ledgerIds?: string[] };
+};
+
+function AssetDetailTestNavigator({
+  params = { currencyId: "bitcoin" },
+}: {
+  params?: NavigatorParams;
+} = {}) {
   return (
     <Stack.Navigator>
       <Stack.Screen
@@ -41,7 +51,7 @@ function AssetDetailTestNavigator() {
         component={AssetDetailNavigator}
         initialParams={{
           screen: ScreenName.AssetDetail,
-          params: { currencyId: "bitcoin" },
+          params,
         }}
         options={{ headerShown: false }}
       />
@@ -337,6 +347,25 @@ describe("AssetDetail screen layout", () => {
         expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.hiddenAssetBanner)).toBeNull(),
       );
       expect(store.getState().settings.blacklistedTokenIds).not.toContain("bitcoin");
+    });
+  });
+
+  describe("market-origin navigation (marketState)", () => {
+    it("renders the screen when navigated from Market with a marketState hint", async () => {
+      render(
+        <AssetDetailTestNavigator
+          params={{
+            currencyId: "binancecoin",
+            source: "market_banner",
+            marketState: { id: "binancecoin", ledgerIds: ["bsc"] },
+          }}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.screen)).toBeVisible();
+      });
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.balanceGraph)).toBeVisible();
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/hooks/__tests__/useAssetDetailNavigation.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/hooks/__tests__/useAssetDetailNavigation.test.ts
@@ -1,0 +1,190 @@
+import { renderHook, withFlagOverrides, act } from "@tests/test-renderer";
+import {
+  mockBtcCryptoCurrency,
+  mockEthCryptoCurrency,
+} from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
+import { NavigatorName, ScreenName } from "~/const";
+import { useAssetDetailNavigation } from "../useAssetDetailNavigation";
+
+const mockNavigate = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+const withAggregatedAssets = (enabled: boolean) =>
+  withFlagOverrides({
+    lwmWallet40: { enabled: true, params: { aggregatedAssets: enabled } },
+  });
+
+describe("useAssetDetailNavigation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("openFromAsset", () => {
+    it("routes to AssetDetail when aggregatedAssets is enabled", () => {
+      const { result } = renderHook(() => useAssetDetailNavigation(), {
+        overrideInitialState: withAggregatedAssets(true),
+      });
+
+      act(() => {
+        result.current.openFromAsset({
+          currency: mockBtcCryptoCurrency,
+          source: "wallet",
+        });
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.AssetDetail, {
+        screen: ScreenName.AssetDetail,
+        params: { currencyId: mockBtcCryptoCurrency.id, source: "wallet" },
+      });
+    });
+
+    it("forwards marketId via marketState when aggregatedAssets is enabled (e.g. BNB placeholder)", () => {
+      const { result } = renderHook(() => useAssetDetailNavigation(), {
+        overrideInitialState: withAggregatedAssets(true),
+      });
+
+      act(() => {
+        result.current.openFromAsset({
+          currency: mockBtcCryptoCurrency,
+          source: "wallet",
+          isPlaceholder: true,
+          marketId: "binancecoin",
+        });
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.AssetDetail, {
+        screen: ScreenName.AssetDetail,
+        params: {
+          currencyId: mockBtcCryptoCurrency.id,
+          source: "wallet",
+          marketState: { id: "binancecoin", ledgerIds: [mockBtcCryptoCurrency.id] },
+        },
+      });
+    });
+
+    it("routes to MarketDetail for placeholder assets when aggregatedAssets is disabled", () => {
+      const { result } = renderHook(() => useAssetDetailNavigation(), {
+        overrideInitialState: withAggregatedAssets(false),
+      });
+
+      act(() => {
+        result.current.openFromAsset({
+          currency: mockEthCryptoCurrency,
+          source: "wallet",
+          isPlaceholder: true,
+          marketId: "ethereum",
+        });
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(ScreenName.MarketDetail, {
+        currencyId: "ethereum",
+      });
+    });
+
+    it("prefers the placeholder marketId over currency.id for the legacy MarketDetail route", () => {
+      const { result } = renderHook(() => useAssetDetailNavigation(), {
+        overrideInitialState: withAggregatedAssets(false),
+      });
+
+      act(() => {
+        result.current.openFromAsset({
+          currency: mockBtcCryptoCurrency,
+          source: "wallet",
+          isPlaceholder: true,
+          marketId: "binancecoin",
+        });
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(ScreenName.MarketDetail, {
+        currencyId: "binancecoin",
+      });
+    });
+
+    it("routes to legacy Asset for non-placeholder assets when aggregatedAssets is disabled", () => {
+      const { result } = renderHook(() => useAssetDetailNavigation(), {
+        overrideInitialState: withAggregatedAssets(false),
+      });
+
+      act(() => {
+        result.current.openFromAsset({
+          currency: mockBtcCryptoCurrency,
+          source: "wallet",
+        });
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Accounts, {
+        screen: ScreenName.Asset,
+        params: { currency: mockBtcCryptoCurrency },
+      });
+    });
+  });
+
+  describe("openFromMarket", () => {
+    it("routes to AssetDetail with the market id and marketState when aggregatedAssets is enabled", () => {
+      const { result } = renderHook(() => useAssetDetailNavigation(), {
+        overrideInitialState: withAggregatedAssets(true),
+      });
+
+      act(() => {
+        result.current.openFromMarket({
+          marketCurrencyId: "binancecoin",
+          ledgerCurrencyIds: ["bsc"],
+          source: "market",
+        });
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.AssetDetail, {
+        screen: ScreenName.AssetDetail,
+        params: {
+          currencyId: "binancecoin",
+          source: "market",
+          marketState: { id: "binancecoin", ledgerIds: ["bsc"] },
+        },
+      });
+    });
+
+    it("still passes the market id when no ledger ids are available", () => {
+      const { result } = renderHook(() => useAssetDetailNavigation(), {
+        overrideInitialState: withAggregatedAssets(true),
+      });
+
+      act(() => {
+        result.current.openFromMarket({
+          marketCurrencyId: "unsupported-asset",
+          source: "market",
+        });
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.AssetDetail, {
+        screen: ScreenName.AssetDetail,
+        params: {
+          currencyId: "unsupported-asset",
+          source: "market",
+          marketState: { id: "unsupported-asset", ledgerIds: undefined },
+        },
+      });
+    });
+
+    it("routes to MarketDetail when aggregatedAssets is disabled", () => {
+      const { result } = renderHook(() => useAssetDetailNavigation(), {
+        overrideInitialState: withAggregatedAssets(false),
+      });
+
+      act(() => {
+        result.current.openFromMarket({
+          marketCurrencyId: "bitcoin",
+          ledgerCurrencyIds: [mockBtcCryptoCurrency.id],
+          source: "market",
+        });
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(ScreenName.MarketDetail, {
+        currencyId: "bitcoin",
+      });
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/hooks/useAssetDetailNavigation.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/hooks/useAssetDetailNavigation.ts
@@ -1,0 +1,106 @@
+import { useCallback } from "react";
+import { useNavigation } from "@react-navigation/native";
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { dadaIdToMarketId } from "@ledgerhq/live-common/market/utils/index";
+import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import { NavigatorName, ScreenName } from "~/const";
+
+type Navigation = NativeStackNavigationProp<BaseNavigatorStackParamList>;
+
+type OpenFromAssetParams = Readonly<{
+  currency: CryptoOrTokenCurrency;
+  source: string;
+  isPlaceholder?: boolean;
+  marketId?: string;
+}>;
+
+type OpenFromMarketParams = Readonly<{
+  marketCurrencyId: string;
+  ledgerCurrencyIds?: string[];
+  source: string;
+}>;
+
+/**
+ * Centralised navigation helper for the AssetDetail flow.
+ *
+ * `aggregatedAssets` (from `lwmWallet40`) decides the destination:
+ *   - **enabled**  → the new MVVM `AssetDetail` screen.
+ *   - **disabled** → the legacy `MarketDetail` (for placeholder / market entries)
+ *                    or `Accounts > Asset` (for in-wallet assets).
+ *
+ * Two entry-point modes:
+ *   - `openFromAsset`  — tap on a portfolio / asset list row. Carries the
+ *                        ledger currency, source, and optional placeholder info
+ *                        so the legacy fallback can still resolve a market id.
+ *   - `openFromMarket` — tap on a market row / tile. Carries the market id and
+ *                        any known ledger ids. When the flag is on we also
+ *                        forward a `marketState` hint so the AssetDetail screen
+ *                        can resolve the distribution item via `bySlug` and the
+ *                        market API via the correct id (fixes BNB-style
+ *                        ledger-id ≠ market-id mismatches).
+ *
+ * Also exposes `hideNetwork = shouldDisplayAggregatedAssets` so call sites
+ * don't have to re-read `useWalletFeaturesConfig` for the icon-related rule.
+ */
+export function useAssetDetailNavigation() {
+  const navigation = useNavigation<Navigation>();
+  const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("mobile");
+
+  const openFromAsset = useCallback(
+    ({ currency, source, isPlaceholder, marketId }: OpenFromAssetParams) => {
+      if (shouldDisplayAggregatedAssets) {
+        navigation.navigate(NavigatorName.AssetDetail, {
+          screen: ScreenName.AssetDetail,
+          params: {
+            currencyId: currency.id,
+            source,
+            // Thread `marketId` via `marketState` so `resolveAssetMarketInputs`
+            // resolves the market API id correctly for assets whose ledger id
+            // differs from the market id (e.g. BNB: "bsc" vs "binancecoin").
+            ...(marketId && { marketState: { id: marketId, ledgerIds: [currency.id] } }),
+          },
+        });
+        return;
+      }
+      if (isPlaceholder) {
+        navigation.navigate(ScreenName.MarketDetail, {
+          currencyId: dadaIdToMarketId(marketId ?? currency.id),
+        });
+        return;
+      }
+      navigation.navigate(NavigatorName.Accounts, {
+        screen: ScreenName.Asset,
+        params: { currency },
+      });
+    },
+    [navigation, shouldDisplayAggregatedAssets],
+  );
+
+  const openFromMarket = useCallback(
+    ({ marketCurrencyId, ledgerCurrencyIds, source }: OpenFromMarketParams) => {
+      if (shouldDisplayAggregatedAssets) {
+        navigation.navigate(NavigatorName.AssetDetail, {
+          screen: ScreenName.AssetDetail,
+          params: {
+            currencyId: marketCurrencyId,
+            source,
+            marketState: { id: marketCurrencyId, ledgerIds: ledgerCurrencyIds },
+          },
+        });
+        return;
+      }
+      navigation.navigate(ScreenName.MarketDetail, {
+        currencyId: marketCurrencyId,
+      });
+    },
+    [navigation, shouldDisplayAggregatedAssets],
+  );
+
+  return {
+    openFromAsset,
+    openFromMarket,
+    hideNetwork: shouldDisplayAggregatedAssets,
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
@@ -23,6 +23,9 @@ import type { AssetCoinOptionsViewModel } from "./components/CoinOptions/useAsse
 type Props = Readonly<{
   currency: AssetDetailCurrencyProps;
   distributionItem: DistributionItem | undefined;
+  marketApiId?: string;
+  knownLedgerIds?: readonly string[];
+  knownMarketId?: string;
   source?: string;
   isRefreshing: boolean;
   onRefresh: () => void;
@@ -36,6 +39,9 @@ type Props = Readonly<{
 export function AssetDetailView({
   currency,
   distributionItem,
+  marketApiId,
+  knownLedgerIds,
+  knownMarketId,
   source,
   isRefreshing,
   onRefresh,
@@ -61,7 +67,13 @@ export function AssetDetailView({
       >
         <Box lx={contentStyle}>
           <HiddenAssetBanner show={coinOptions.isHidden} onShowAsset={coinOptions.onShowAsset} />
-          <BalanceGraph currency={currency} hideReceive={hideReceiveInBalanceGraph} />
+          <BalanceGraph
+            currency={currency}
+            marketApiId={marketApiId}
+            knownLedgerIds={knownLedgerIds}
+            knownMarketId={knownMarketId}
+            hideReceive={hideReceiveInBalanceGraph}
+          />
           <BalanceDetails
             currency={currency}
             distributionItem={distributionItem}
@@ -72,7 +84,12 @@ export function AssetDetailView({
             distributionItem={distributionItem}
             isLoading={isLoading}
           />
-          <MarketData currency={currency} />
+          <MarketData
+            currency={currency}
+            marketApiId={marketApiId}
+            knownLedgerIds={knownLedgerIds}
+            knownMarketId={knownMarketId}
+          />
           <Transactions
             currency={currency}
             distributionItem={distributionItem}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/useBalanceGraphViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/useBalanceGraphViewModel.test.ts
@@ -99,7 +99,9 @@ describe("useBalanceGraphViewModel", () => {
 
   describe("price & trend", () => {
     it("exposes price and the 24h change percentage by default", () => {
-      const { result } = renderHook(() => useBalanceGraphViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useBalanceGraphViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       expect(result.current.price).toBe(50000);
       expect(result.current.priceChangePercentage).toBe(2.35);
@@ -111,7 +113,9 @@ describe("useBalanceGraphViewModel", () => {
         isFetching: false,
       } as unknown as ReturnType<typeof useGetCurrencyDataQuery>);
 
-      const { result } = renderHook(() => useBalanceGraphViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useBalanceGraphViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       expect(result.current.price).toBe(0);
       expect(result.current.hasMarketData).toBe(false);
@@ -119,7 +123,9 @@ describe("useBalanceGraphViewModel", () => {
     });
 
     it("uses the correct priceChangePercentage key after range change", () => {
-      const { result } = renderHook(() => useBalanceGraphViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useBalanceGraphViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       act(() => result.current.onRangeChange("7d"));
       expect(result.current.priceChangePercentage).toBe(-5.12);
@@ -131,7 +137,9 @@ describe("useBalanceGraphViewModel", () => {
 
   describe("priceFormatter", () => {
     it("splits a USD-formatted value into FormattedValue parts", () => {
-      const { result } = renderHook(() => useBalanceGraphViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useBalanceGraphViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       const formatted = result.current.priceFormatter(1234.56);
 
@@ -142,7 +150,9 @@ describe("useBalanceGraphViewModel", () => {
     });
 
     it("preserves 6 decimals for a sub-cent BONK-like price", () => {
-      const { result } = renderHook(() => useBalanceGraphViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useBalanceGraphViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       const formatted = result.current.priceFormatter(0.000006);
 
@@ -154,13 +164,17 @@ describe("useBalanceGraphViewModel", () => {
 
   describe("formattedPriceChange", () => {
     it("returns a signed currency string for a positive change", () => {
-      const { result } = renderHook(() => useBalanceGraphViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useBalanceGraphViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       expect(result.current.formattedPriceChange).toMatch(/^\+/);
     });
 
     it("returns a minus-prefixed string for a negative change", () => {
-      const { result } = renderHook(() => useBalanceGraphViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useBalanceGraphViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       act(() => result.current.onRangeChange("7d"));
 
@@ -173,7 +187,9 @@ describe("useBalanceGraphViewModel", () => {
         isFetching: false,
       } as unknown as ReturnType<typeof useGetCurrencyDataQuery>);
 
-      const { result } = renderHook(() => useBalanceGraphViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useBalanceGraphViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       expect(result.current.formattedPriceChange).toBeUndefined();
     });
@@ -184,7 +200,9 @@ describe("useBalanceGraphViewModel", () => {
         isFetching: false,
       } as unknown as ReturnType<typeof useGetCurrencyDataQuery>);
 
-      const { result } = renderHook(() => useBalanceGraphViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useBalanceGraphViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       expect(result.current.formattedPriceChange).toBe("+<$0.000001");
     });
@@ -192,7 +210,9 @@ describe("useBalanceGraphViewModel", () => {
 
   describe("onRangeChange", () => {
     it("updates selectedRange and fires analytics", () => {
-      const { result } = renderHook(() => useBalanceGraphViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useBalanceGraphViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       expect(result.current.selectedRange).toBe("24h");
 
@@ -208,7 +228,9 @@ describe("useBalanceGraphViewModel", () => {
     });
 
     it("does not fire analytics when selecting the same range", () => {
-      const { result } = renderHook(() => useBalanceGraphViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useBalanceGraphViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       act(() => result.current.onRangeChange("24h"));
 
@@ -218,14 +240,14 @@ describe("useBalanceGraphViewModel", () => {
 
   describe("showReceive", () => {
     it("is false when currency is undefined", () => {
-      const { result } = renderHook(() => useBalanceGraphViewModel(undefined));
+      const { result } = renderHook(() => useBalanceGraphViewModel({ currency: undefined }));
 
       expect(result.current.showReceive).toBe(false);
     });
 
     it("is true when the asset has no funds but another asset does", () => {
       const { result } = renderHook(
-        () => useBalanceGraphViewModel(mockBtcCryptoCurrency),
+        () => useBalanceGraphViewModel({ currency: mockBtcCryptoCurrency }),
         withAccounts([
           { currencyId: "bitcoin", balance: 0 },
           { currencyId: "ethereum", balance: 1000 },
@@ -237,7 +259,7 @@ describe("useBalanceGraphViewModel", () => {
 
     it("is false when the asset already has funds", () => {
       const { result } = renderHook(
-        () => useBalanceGraphViewModel(mockBtcCryptoCurrency),
+        () => useBalanceGraphViewModel({ currency: mockBtcCryptoCurrency }),
         withAccounts([
           { currencyId: "bitcoin", balance: 500 },
           { currencyId: "ethereum", balance: 1000 },
@@ -249,7 +271,7 @@ describe("useBalanceGraphViewModel", () => {
 
     it("is false when the wallet has no funds at all", () => {
       const { result } = renderHook(
-        () => useBalanceGraphViewModel(mockBtcCryptoCurrency),
+        () => useBalanceGraphViewModel({ currency: mockBtcCryptoCurrency }),
         withAccounts([
           { currencyId: "bitcoin", balance: 0 },
           { currencyId: "ethereum", balance: 0 },
@@ -261,7 +283,7 @@ describe("useBalanceGraphViewModel", () => {
 
     it("is false when hideReceive is true even if conditions are met", () => {
       const { result } = renderHook(
-        () => useBalanceGraphViewModel(mockBtcCryptoCurrency, true),
+        () => useBalanceGraphViewModel({ currency: mockBtcCryptoCurrency, hideReceive: true }),
         withAccounts([
           { currencyId: "bitcoin", balance: 0 },
           { currencyId: "ethereum", balance: 1000 },
@@ -273,7 +295,7 @@ describe("useBalanceGraphViewModel", () => {
 
     it("is false for a token the user already holds (regression: ERC-20 detected via flattenAccounts)", () => {
       const { result } = renderHook(
-        () => useBalanceGraphViewModel(eursToken),
+        () => useBalanceGraphViewModel({ currency: eursToken }),
         withEthAndEursToken({ ethBalance: 0, eursBalance: 36_300_500 }),
       );
 
@@ -283,7 +305,9 @@ describe("useBalanceGraphViewModel", () => {
 
   describe("onReceivePress", () => {
     it("tracks analytics and opens the receive drawer", () => {
-      const { result } = renderHook(() => useBalanceGraphViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useBalanceGraphViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       act(() => result.current.onReceivePress());
 
@@ -298,7 +322,9 @@ describe("useBalanceGraphViewModel", () => {
 
   describe("ranges", () => {
     it("exposes translated range options in chronological order (24h first, 1y last)", () => {
-      const { result } = renderHook(() => useBalanceGraphViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useBalanceGraphViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       const values = result.current.ranges.map(r => r.value);
       expect(values).toEqual(["24h", "7d", "30d", "1y"]);
@@ -312,7 +338,13 @@ describe("useBalanceGraphViewModel", () => {
         isFetching: true,
       } as unknown as ReturnType<typeof useGetCurrencyDataQuery>);
 
-      const { result } = renderHook(() => useBalanceGraphViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useBalanceGraphViewModel({
+          currency: mockBtcCryptoCurrency,
+          marketApiId: mockBtcCryptoCurrency.id,
+          knownLedgerIds: [mockBtcCryptoCurrency.id],
+        }),
+      );
 
       expect(result.current.isLoading).toBe(true);
     });

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/index.tsx
@@ -5,10 +5,25 @@ import { BalanceGraphView } from "./BalanceGraphView";
 
 type Props = Readonly<{
   currency?: AssetDetailCurrencyProps;
+  marketApiId?: string;
+  knownLedgerIds?: readonly string[];
+  knownMarketId?: string;
   hideReceive?: boolean;
 }>;
 
-export function BalanceGraph({ currency, hideReceive }: Props) {
-  const viewModel = useBalanceGraphViewModel(currency, hideReceive);
+export function BalanceGraph({
+  currency,
+  marketApiId,
+  knownLedgerIds,
+  knownMarketId,
+  hideReceive,
+}: Props) {
+  const viewModel = useBalanceGraphViewModel({
+    currency,
+    marketApiId,
+    knownLedgerIds,
+    knownMarketId,
+    hideReceive,
+  });
   return <BalanceGraphView {...viewModel} />;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
@@ -14,15 +14,30 @@ import { useOpenReceiveDrawer } from "LLM/features/Receive";
 import { RANGE_TO_PRICE_CHANGE_KEY, type RangeKey } from "../../utils/rangeMapping";
 import { useAssetMarketData } from "../../hooks/useAssetMarketData";
 
-export function useBalanceGraphViewModel(
-  currency?: AssetDetailCurrencyProps,
-  hideReceive?: boolean,
-) {
+type Params = {
+  currency?: AssetDetailCurrencyProps;
+  marketApiId?: string;
+  knownLedgerIds?: readonly string[];
+  knownMarketId?: string;
+  hideReceive?: boolean;
+};
+
+export function useBalanceGraphViewModel({
+  currency,
+  marketApiId,
+  knownLedgerIds,
+  knownMarketId,
+  hideReceive,
+}: Params) {
   const { t } = useTranslation();
   const { locale } = useLocale();
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
   const counterValueUnit = counterValueCurrency.units[0];
-  const { marketCurrency, isLoading } = useAssetMarketData(currency);
+  const { marketCurrency, isLoading } = useAssetMarketData({
+    marketApiId,
+    knownLedgerIds,
+    knownMarketId,
+  });
 
   const [range, setRange] = useState<RangeKey>("24h");
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketData/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketData/index.tsx
@@ -5,11 +5,28 @@ import type { AssetDetailCurrencyProps } from "LLM/features/AssetDetail/types";
 import { MarketStats } from "../MarketStats";
 import { PricePerformance } from "../PricePerformance";
 
-export function MarketData({ currency }: Readonly<{ currency: AssetDetailCurrencyProps }>) {
+type Props = Readonly<{
+  currency: AssetDetailCurrencyProps;
+  marketApiId?: string;
+  knownLedgerIds?: readonly string[];
+  knownMarketId?: string;
+}>;
+
+export function MarketData({ currency, marketApiId, knownLedgerIds, knownMarketId }: Props) {
   return (
     <Box lx={containerStyle}>
-      <MarketStats currency={currency} />
-      <PricePerformance currency={currency} />
+      <MarketStats
+        currency={currency}
+        marketApiId={marketApiId}
+        knownLedgerIds={knownLedgerIds}
+        knownMarketId={knownMarketId}
+      />
+      <PricePerformance
+        currency={currency}
+        marketApiId={marketApiId}
+        knownLedgerIds={knownLedgerIds}
+        knownMarketId={knownMarketId}
+      />
     </Box>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/__tests__/useMarketStatsViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/__tests__/useMarketStatsViewModel.test.ts
@@ -28,7 +28,9 @@ describe("useMarketStatsViewModel", () => {
 
   describe("stats", () => {
     it("returns 5 stat rows with correct labels", () => {
-      const { result } = renderHook(() => useMarketStatsViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useMarketStatsViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       expect(result.current.stats).toHaveLength(5);
       expect(result.current.stats[0].label).toMatch(/market cap/i);
@@ -39,14 +41,18 @@ describe("useMarketStatsViewModel", () => {
     });
 
     it("formats market rank with # prefix", () => {
-      const { result } = renderHook(() => useMarketStatsViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useMarketStatsViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       const rankStat = result.current.stats.find(s => s.key === "market_rank");
       expect(rankStat?.value).toBe("#1");
     });
 
     it("provides tooltip for every stat row except market rank", () => {
-      const { result } = renderHook(() => useMarketStatsViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useMarketStatsViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       const withTooltip = result.current.stats.filter(s => s.tooltip);
       expect(withTooltip.map(s => s.key)).toEqual([
@@ -61,7 +67,9 @@ describe("useMarketStatsViewModel", () => {
     it("returns an empty array when no market data", () => {
       mockMarketData({ marketCurrency: undefined });
 
-      const { result } = renderHook(() => useMarketStatsViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useMarketStatsViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       expect(result.current.stats).toEqual([]);
     });
@@ -71,14 +79,18 @@ describe("useMarketStatsViewModel", () => {
         marketCurrency: { ...marketCurrencyData, marketcap: undefined, maxSupply: 0 } as any,
       });
 
-      const { result } = renderHook(() => useMarketStatsViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useMarketStatsViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       expect(result.current.stats.find(s => s.key === "market_cap")?.value).toBe("-");
       expect(result.current.stats.find(s => s.key === "max_supply")?.value).toBe("-");
     });
 
     it("formats supply rows with the ticker suffix from market data", () => {
-      const { result } = renderHook(() => useMarketStatsViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useMarketStatsViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       const circulating = result.current.stats.find(s => s.key === "circulating_supply")?.value;
       const maxSupply = result.current.stats.find(s => s.key === "max_supply")?.value;
@@ -93,7 +105,9 @@ describe("useMarketStatsViewModel", () => {
         marketCurrency: { ...marketCurrencyData, ticker: "" } as any,
       });
 
-      const { result } = renderHook(() => useMarketStatsViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useMarketStatsViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       const circulating = result.current.stats.find(s => s.key === "circulating_supply")?.value;
       expect(circulating).toMatch(/BTC$/);
@@ -104,7 +118,9 @@ describe("useMarketStatsViewModel", () => {
         marketCurrency: { ...marketCurrencyData, circulatingSupply: 124329543825 } as any,
       });
 
-      const { result } = renderHook(() => useMarketStatsViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useMarketStatsViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       const circulating = result.current.stats.find(s => s.key === "circulating_supply")?.value;
       expect(circulating).not.toBe("124329543825");
@@ -116,7 +132,9 @@ describe("useMarketStatsViewModel", () => {
     it("reflects isFetching from the query", () => {
       mockMarketData({ marketCurrency: undefined, isLoading: true });
 
-      const { result } = renderHook(() => useMarketStatsViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useMarketStatsViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       expect(result.current.isLoading).toBe(true);
       expect(result.current.hasData).toBe(false);
@@ -127,7 +145,9 @@ describe("useMarketStatsViewModel", () => {
     it("reflects isError from the query", () => {
       mockMarketData({ marketCurrency: undefined, isError: true });
 
-      const { result } = renderHook(() => useMarketStatsViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useMarketStatsViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       expect(result.current.isError).toBe(true);
     });
@@ -135,7 +155,9 @@ describe("useMarketStatsViewModel", () => {
 
   describe("onTooltipOpen", () => {
     it("tracks info_bubble_pressed when tooltip opens", () => {
-      const { result } = renderHook(() => useMarketStatsViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useMarketStatsViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       result.current.onTooltipOpen("circulating_supply", true);
 
@@ -147,7 +169,9 @@ describe("useMarketStatsViewModel", () => {
     });
 
     it("does not track when tooltip closes", () => {
-      const { result } = renderHook(() => useMarketStatsViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useMarketStatsViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       result.current.onTooltipOpen("circulating_supply", false);
 
@@ -156,10 +180,15 @@ describe("useMarketStatsViewModel", () => {
   });
 
   describe("skip query", () => {
-    it("passes undefined currency to useAssetMarketData", () => {
-      renderHook(() => useMarketStatsViewModel(undefined));
+    it("passes resolved ids through to useAssetMarketData when no overrides are provided", () => {
+      renderHook(() => useMarketStatsViewModel({ currency: undefined }));
 
-      expect(mockUseAssetMarketData).toHaveBeenCalledWith(undefined);
+      expect(mockUseAssetMarketData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          marketApiId: undefined,
+          knownLedgerIds: undefined,
+        }),
+      );
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/index.tsx
@@ -3,7 +3,19 @@ import type { AssetDetailCurrencyProps } from "LLM/features/AssetDetail/types";
 import { useMarketStatsViewModel } from "./useMarketStatsViewModel";
 import { MarketStatsView } from "./MarketStatsView";
 
-export function MarketStats({ currency }: Readonly<{ currency: AssetDetailCurrencyProps }>) {
-  const viewModel = useMarketStatsViewModel(currency);
+type Props = Readonly<{
+  currency: AssetDetailCurrencyProps;
+  marketApiId?: string;
+  knownLedgerIds?: readonly string[];
+  knownMarketId?: string;
+}>;
+
+export function MarketStats({ currency, marketApiId, knownLedgerIds, knownMarketId }: Props) {
+  const viewModel = useMarketStatsViewModel({
+    currency,
+    marketApiId,
+    knownLedgerIds,
+    knownMarketId,
+  });
   return <MarketStatsView {...viewModel} />;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/useMarketStatsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/useMarketStatsViewModel.ts
@@ -12,10 +12,26 @@ type StatRow = {
   tooltip?: { title: string; content: string };
 };
 
-export function useMarketStatsViewModel(currency: AssetDetailCurrencyProps) {
+type Params = {
+  currency: AssetDetailCurrencyProps;
+  marketApiId?: string;
+  knownLedgerIds?: readonly string[];
+  knownMarketId?: string;
+};
+
+export function useMarketStatsViewModel({
+  currency,
+  marketApiId,
+  knownLedgerIds,
+  knownMarketId,
+}: Params) {
   const { t } = useTranslation();
   const { locale } = useLocale();
-  const { marketCurrency, counterCurrency, isLoading, isError } = useAssetMarketData(currency);
+  const { marketCurrency, counterCurrency, isLoading, isError } = useAssetMarketData({
+    marketApiId,
+    knownLedgerIds,
+    knownMarketId,
+  });
 
   const stats: StatRow[] = useMemo(() => {
     if (!marketCurrency) return [];

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/__tests__/usePricePerformanceViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/__tests__/usePricePerformanceViewModel.test.ts
@@ -27,7 +27,9 @@ describe("usePricePerformanceViewModel", () => {
 
   describe("records", () => {
     it("returns ATH and ATL records with correct labels", () => {
-      const { result } = renderHook(() => usePricePerformanceViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        usePricePerformanceViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       expect(result.current.records).toHaveLength(2);
       expect(result.current.records[0].label).toMatch(/all.time high/i);
@@ -35,7 +37,9 @@ describe("usePricePerformanceViewModel", () => {
     });
 
     it("computes negative ATH change and positive ATL change", () => {
-      const { result } = renderHook(() => usePricePerformanceViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        usePricePerformanceViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       expect(result.current.records[0].changePercentage).toMatch(/^-/);
       expect(result.current.records[1].changePercentage).toMatch(/^\+/);
@@ -44,7 +48,9 @@ describe("usePricePerformanceViewModel", () => {
     it("returns an empty array when no market data", () => {
       mockMarketData({ marketCurrency: undefined });
 
-      const { result } = renderHook(() => usePricePerformanceViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        usePricePerformanceViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       expect(result.current.records).toEqual([]);
     });
@@ -54,7 +60,9 @@ describe("usePricePerformanceViewModel", () => {
     it("reflects isFetching from the query", () => {
       mockMarketData({ marketCurrency: undefined, isLoading: true });
 
-      const { result } = renderHook(() => usePricePerformanceViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        usePricePerformanceViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       expect(result.current.isLoading).toBe(true);
       expect(result.current.hasData).toBe(false);
@@ -65,17 +73,24 @@ describe("usePricePerformanceViewModel", () => {
     it("reflects isError from the query", () => {
       mockMarketData({ marketCurrency: undefined, isError: true });
 
-      const { result } = renderHook(() => usePricePerformanceViewModel(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        usePricePerformanceViewModel({ currency: mockBtcCryptoCurrency }),
+      );
 
       expect(result.current.isError).toBe(true);
     });
   });
 
   describe("skip query", () => {
-    it("passes undefined currency to useAssetMarketData", () => {
-      renderHook(() => usePricePerformanceViewModel(undefined));
+    it("passes resolved ids through to useAssetMarketData when no overrides are provided", () => {
+      renderHook(() => usePricePerformanceViewModel({ currency: undefined }));
 
-      expect(mockUseAssetMarketData).toHaveBeenCalledWith(undefined);
+      expect(mockUseAssetMarketData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          marketApiId: undefined,
+          knownLedgerIds: undefined,
+        }),
+      );
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/index.tsx
@@ -3,7 +3,19 @@ import type { AssetDetailCurrencyProps } from "LLM/features/AssetDetail/types";
 import { usePricePerformanceViewModel } from "./usePricePerformanceViewModel";
 import { PricePerformanceView } from "./PricePerformanceView";
 
-export function PricePerformance({ currency }: Readonly<{ currency: AssetDetailCurrencyProps }>) {
-  const viewModel = usePricePerformanceViewModel(currency);
+type Props = Readonly<{
+  currency: AssetDetailCurrencyProps;
+  marketApiId?: string;
+  knownLedgerIds?: readonly string[];
+  knownMarketId?: string;
+}>;
+
+export function PricePerformance({ currency, marketApiId, knownLedgerIds, knownMarketId }: Props) {
+  const viewModel = usePricePerformanceViewModel({
+    currency,
+    marketApiId,
+    knownLedgerIds,
+    knownMarketId,
+  });
   return <PricePerformanceView {...viewModel} />;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/usePricePerformanceViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/usePricePerformanceViewModel.ts
@@ -41,10 +41,26 @@ function formatPercentage(value: number): string {
   return `${sign}${value.toFixed(2)}%`;
 }
 
-export function usePricePerformanceViewModel(currency: AssetDetailCurrencyProps) {
+type Params = {
+  currency: AssetDetailCurrencyProps;
+  marketApiId?: string;
+  knownLedgerIds?: readonly string[];
+  knownMarketId?: string;
+};
+
+export function usePricePerformanceViewModel({
+  currency,
+  marketApiId,
+  knownLedgerIds,
+  knownMarketId,
+}: Params) {
   const { t } = useTranslation();
   const { locale } = useLocale();
-  const { marketCurrency, counterCurrency, isLoading, isError } = useAssetMarketData(currency);
+  const { marketCurrency, counterCurrency, isLoading, isError } = useAssetMarketData({
+    marketApiId,
+    knownLedgerIds,
+    knownMarketId,
+  });
 
   const dateFormatter = useMemo(
     () =>

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/__tests__/useAssetMarketData.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/__tests__/useAssetMarketData.test.ts
@@ -16,7 +16,12 @@ const withCounterValue =
 describe("useAssetMarketData", () => {
   describe("data forwarding", () => {
     it("returns marketCurrency from the market API", async () => {
-      const { result } = renderHook(() => useAssetMarketData(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useAssetMarketData({
+          marketApiId: mockBtcCryptoCurrency.id,
+          knownLedgerIds: [mockBtcCryptoCurrency.id],
+        }),
+      );
 
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
@@ -28,7 +33,12 @@ describe("useAssetMarketData", () => {
     });
 
     it("defaults counterCurrency to the USD settings value", () => {
-      const { result } = renderHook(() => useAssetMarketData(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useAssetMarketData({
+          marketApiId: mockBtcCryptoCurrency.id,
+          knownLedgerIds: [mockBtcCryptoCurrency.id],
+        }),
+      );
 
       expect(result.current.counterCurrency).toBe("usd");
     });
@@ -36,9 +46,14 @@ describe("useAssetMarketData", () => {
 
   describe("settings counter-value reactivity", () => {
     it("derives counterCurrency from the user's settings counter-value (not market screen state)", () => {
-      const { result } = renderHook(() => useAssetMarketData(mockBtcCryptoCurrency), {
-        overrideInitialState: withCounterValue("EUR"),
-      });
+      const { result } = renderHook(
+        () =>
+          useAssetMarketData({
+            marketApiId: mockBtcCryptoCurrency.id,
+            knownLedgerIds: [mockBtcCryptoCurrency.id],
+          }),
+        { overrideInitialState: withCounterValue("EUR") },
+      );
 
       expect(result.current.counterCurrency).toBe("eur");
     });
@@ -53,9 +68,14 @@ describe("useAssetMarketData", () => {
         }),
       );
 
-      renderHook(() => useAssetMarketData(mockBtcCryptoCurrency), {
-        overrideInitialState: withCounterValue("GBP"),
-      });
+      renderHook(
+        () =>
+          useAssetMarketData({
+            marketApiId: mockBtcCryptoCurrency.id,
+            knownLedgerIds: [mockBtcCryptoCurrency.id],
+          }),
+        { overrideInitialState: withCounterValue("GBP") },
+      );
 
       await waitFor(() => {
         expect(requestedToValues).toContain("gbp");
@@ -65,7 +85,12 @@ describe("useAssetMarketData", () => {
 
   describe("loading state", () => {
     it("starts with isLoading true before data resolves", () => {
-      const { result } = renderHook(() => useAssetMarketData(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useAssetMarketData({
+          marketApiId: mockBtcCryptoCurrency.id,
+          knownLedgerIds: [mockBtcCryptoCurrency.id],
+        }),
+      );
 
       expect(result.current.isLoading).toBe(true);
       expect(result.current.marketCurrency).toBeUndefined();
@@ -78,7 +103,12 @@ describe("useAssetMarketData", () => {
         http.get(`${COUNTERVALUES_API}/v3/markets`, () => HttpResponse.json(null, { status: 500 })),
       );
 
-      const { result } = renderHook(() => useAssetMarketData(mockBtcCryptoCurrency));
+      const { result } = renderHook(() =>
+        useAssetMarketData({
+          marketApiId: mockBtcCryptoCurrency.id,
+          knownLedgerIds: [mockBtcCryptoCurrency.id],
+        }),
+      );
 
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
@@ -89,8 +119,8 @@ describe("useAssetMarketData", () => {
   });
 
   describe("skip query", () => {
-    it("does not fetch when currency is undefined", () => {
-      const { result } = renderHook(() => useAssetMarketData(undefined));
+    it("does not fetch when no marketApiId is provided", () => {
+      const { result } = renderHook(() => useAssetMarketData({}));
 
       expect(result.current.marketCurrency).toBeUndefined();
       expect(result.current.isLoading).toBe(false);

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/useAssetMarketData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/useAssetMarketData.ts
@@ -2,19 +2,30 @@ import VersionNumber from "react-native-version-number";
 import { useAssetMarketData as useSharedAssetMarketData } from "@ledgerhq/asset-detail";
 import { useSelector } from "~/context/hooks";
 import { counterValueCurrencySelector } from "~/reducers/settings";
-import type { AssetDetailCurrencyProps } from "LLM/features/AssetDetail/types";
 
-export function useAssetMarketData(currency: AssetDetailCurrencyProps) {
+type Params = {
+  marketApiId?: string;
+  knownLedgerIds?: readonly string[];
+  knownMarketId?: string;
+};
+
+/**
+ * Mobile wrapper around `useAssetMarketData` from `@ledgerhq/asset-detail`.
+ * Inputs must be already resolved — see `resolveAssetMarketInputs` from
+ * `@ledgerhq/asset-aggregation`. No silent fallback to `currency.id` so a
+ * mismatch between ledger id and market id (e.g. BNB → "bsc" vs "binancecoin")
+ * cannot reintroduce the wrong query.
+ */
+export function useAssetMarketData({ marketApiId, knownLedgerIds, knownMarketId }: Params) {
   const counterCurrency = useSelector(counterValueCurrencySelector).ticker.toLowerCase();
 
-  const knownLedgerIds = currency ? [currency.id] : undefined;
-
   const { marketCurrencyData, marketId, isLoading, isError } = useSharedAssetMarketData({
-    marketApiId: currency?.id,
+    marketApiId,
     knownLedgerIds,
     counterCurrency,
     product: "llm",
     version: VersionNumber.appVersion,
+    knownMarketId,
   });
 
   return {

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
@@ -6,7 +6,10 @@ import { ScreenName } from "~/const";
 import { useSelector } from "~/context/hooks";
 import { shallowAccountsSelector } from "~/reducers/accounts";
 import { useDistribution } from "~/actions/general";
-import { resolveDistributionItem } from "@ledgerhq/asset-aggregation/assetDistribution/index";
+import {
+  resolveAssetMarketInputs,
+  resolveDistributionItem,
+} from "@ledgerhq/asset-aggregation/assetDistribution/index";
 import type { AssetDetailNavigatorParamsList } from "../../types";
 import { useIsBuyAvailable, useSecondaryButtonType } from "./components/Footer/useFooterViewModel";
 import { useAssetCoinOptionsViewModel } from "./components/CoinOptions/useAssetCoinOptionsViewModel";
@@ -16,15 +19,29 @@ type Route = StackNavigatorProps<AssetDetailNavigatorParamsList, ScreenName.Asse
 
 export function useAssetDetailViewModel() {
   const route = useRoute<Route>();
-  const { currencyId, source } = route.params;
-
-  const { currency } = useCurrencyById(currencyId);
+  const { currencyId, source, marketState } = route.params;
 
   const distribution = useDistribution({ groupBy: "asset" });
   const distributionItem = useMemo(
-    () => resolveDistributionItem({ routeAssetId: currencyId, distribution }),
-    [currencyId, distribution],
+    () => resolveDistributionItem({ routeAssetId: currencyId, marketState, distribution }),
+    [currencyId, marketState, distribution],
   );
+
+  const ledgerIdFallback = marketState?.ledgerIds?.[0] ?? currencyId;
+  const { currency: ledgerCurrencyById } = useCurrencyById(ledgerIdFallback);
+  const currency = distributionItem?.currency ?? ledgerCurrencyById;
+
+  const { marketApiId, knownLedgerIds, knownMarketId } = useMemo(
+    () =>
+      resolveAssetMarketInputs({
+        distributionItem,
+        marketState,
+        currency,
+        fallbackId: currencyId,
+      }),
+    [distributionItem, marketState, currency, currencyId],
+  );
+
   const isLoading = distribution.isLoading;
 
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -40,12 +57,15 @@ export function useAssetDetailViewModel() {
   const accounts = useSelector(shallowAccountsSelector);
   const walletHasFunds = useMemo(() => accounts.some(a => a.balance.gt(0)), [accounts]);
   const showFallbackBanner = !hasFooter && walletHasFunds && !!currency;
-  const { marketId } = useAssetMarketData(currency);
+  const { marketId } = useAssetMarketData({ marketApiId, knownLedgerIds, knownMarketId });
   const coinOptions = useAssetCoinOptionsViewModel({ currency, currencyId, marketId });
 
   return {
     currency,
     distributionItem,
+    marketApiId,
+    knownLedgerIds,
+    knownMarketId,
     source,
     isRefreshing,
     onRefresh,

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/types.ts
@@ -3,9 +3,15 @@ import { ScreenName } from "~/const";
 
 export type AssetDetailCurrencyProps = CryptoOrTokenCurrency | undefined;
 
+export type AssetDetailMarketState = {
+  id: string;
+  ledgerIds?: string[];
+};
+
 export type AssetDetailNavigatorParamsList = {
   [ScreenName.AssetDetail]: {
     currencyId: string;
     source?: string;
+    marketState?: AssetDetailMarketState;
   };
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/Assets/hooks/useAssetsListViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Assets/hooks/useAssetsListViewModel.ts
@@ -1,21 +1,16 @@
 import { useCallback, useMemo } from "react";
 import useEnv from "@ledgerhq/live-common/hooks/useEnv";
-import { useFocusEffect, useNavigation } from "@react-navigation/native";
+import { useFocusEffect } from "@react-navigation/native";
 import { GestureResponderEvent } from "react-native";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import { useNonBlacklistedDistribution } from "~/hooks/useNonBlacklistedDistribution";
 import { useSelector } from "~/context/hooks";
 import { blacklistedTokenIdsSelector } from "~/reducers/settings";
 import { useRefreshAccountsOrdering } from "~/actions/general";
-import { NavigatorName, ScreenName } from "~/const";
+import { ScreenName } from "~/const";
 import { Asset } from "~/types/asset";
 import { track } from "~/analytics";
-import { AccountsNavigatorParamList } from "~/components/RootNavigator/types/AccountsNavigator";
-import {
-  BaseNavigationComposite,
-  StackNavigatorNavigation,
-} from "~/components/RootNavigator/types/helpers";
-import { PortfolioNavigatorStackParamList } from "~/components/RootNavigator/types/PortfolioNavigator";
+import { useAssetDetailNavigation } from "LLM/features/AssetDetail/hooks/useAssetDetailNavigation";
 
 export interface Props {
   sourceScreenName?: ScreenName;
@@ -24,19 +19,14 @@ export interface Props {
   onContentChange?: (width: number, height: number) => void;
 }
 
-export type NavigationProp = BaseNavigationComposite<
-  | StackNavigatorNavigation<AccountsNavigatorParamList, ScreenName.Assets>
-  | StackNavigatorNavigation<PortfolioNavigatorStackParamList>
->;
-
 const useAssetsListViewModel = ({
   isSyncEnabled = false,
   limitNumberOfAssets,
   onContentChange,
 }: Props) => {
   const hideEmptyTokenAccount = useEnv("HIDE_EMPTY_TOKEN_ACCOUNTS");
-  const navigation = useNavigation<NavigationProp>();
   const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("mobile");
+  const { openFromAsset } = useAssetDetailNavigation();
 
   const filteredDistribution = useNonBlacklistedDistribution({
     showEmptyAccounts: true,
@@ -65,14 +55,14 @@ const useAssetsListViewModel = ({
         page: "Assets",
       });
 
-      navigation.navigate(NavigatorName.Accounts, {
-        screen: ScreenName.Asset,
-        params: {
-          currency: asset.currency,
-        },
+      openFromAsset({
+        currency: asset.currency,
+        source: "assets",
+        isPlaceholder: asset.isPlaceholder,
+        marketId: asset.marketId,
       });
     },
-    [navigation],
+    [openFromAsset],
   );
 
   return {

--- a/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/useCryptoViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/useCryptoViewModel.ts
@@ -1,23 +1,15 @@
 import { useCallback, useMemo } from "react";
-import { useFocusEffect, useNavigation } from "@react-navigation/native";
+import { useFocusEffect } from "@react-navigation/native";
 import { useRefreshAccountsOrdering } from "~/actions/general";
-import { NavigatorName, ScreenName } from "~/const";
+import { ScreenName } from "~/const";
 import { Asset } from "~/types/asset";
 import { track } from "~/analytics";
 import { useTranslation } from "~/context/Locale";
-import {
-  BaseNavigationComposite,
-  StackNavigatorNavigation,
-} from "~/components/RootNavigator/types/helpers";
-import { AccountsNavigatorParamList } from "~/components/RootNavigator/types/AccountsNavigator";
 import { useCategorizedAssetsFromPortfolio } from "LLM/hooks/useCategorizedAssetsFromPortfolio";
+import { useAssetDetailNavigation } from "LLM/features/AssetDetail/hooks/useAssetDetailNavigation";
 import { toAsset } from "LLM/utils/assetUtils";
 import { CryptoScreenViewData, CryptoVariant } from "./types";
 import { selectAssetList } from "./utils";
-
-type NavigationProp = BaseNavigationComposite<
-  StackNavigatorNavigation<AccountsNavigatorParamList, ScreenName.Crypto>
->;
 
 interface UseCryptoViewModelParams {
   sourceScreenName?: ScreenName;
@@ -35,7 +27,7 @@ const useCryptoViewModel = ({
   variant,
 }: UseCryptoViewModelParams): CryptoScreenViewData => {
   const { t } = useTranslation();
-  const navigation = useNavigation<NavigationProp>();
+  const { openFromAsset } = useAssetDetailNavigation();
 
   const { categorizedAssets, isLoadingStablecoinTickers, isStablecoinTickersError } =
     useCategorizedAssetsFromPortfolio();
@@ -57,14 +49,14 @@ const useCryptoViewModel = ({
         page: TRACKING_TYPE_BY_VARIANT[resolvedVariant],
       });
 
-      navigation.navigate(NavigatorName.Accounts, {
-        screen: ScreenName.Asset,
-        params: {
-          currency: asset.currency,
-        },
+      openFromAsset({
+        currency: asset.currency,
+        source: `crypto_${resolvedVariant}_list`,
+        isPlaceholder: asset.isPlaceholder,
+        marketId: asset.marketId,
       });
     },
-    [navigation, resolvedVariant],
+    [openFromAsset, resolvedVariant],
   );
 
   const trackingType = TRACKING_TYPE_BY_VARIANT[resolvedVariant];

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketList/components/ListRow/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketList/components/ListRow/index.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import { TouchableOpacity } from "react-native";
-import { useNavigation } from "@react-navigation/native";
-import { ScreenName } from "~/const";
 import MarketRowItem from "LLM/features/Market/components/MarketRowItem";
 import { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
+import { useAssetDetailNavigation } from "LLM/features/AssetDetail/hooks/useAssetDetailNavigation";
 
 interface ListRowProps {
   item: MarketCurrencyData;
@@ -12,12 +11,14 @@ interface ListRowProps {
   range?: string;
 }
 function ListRow({ item, index, counterCurrency, range }: ListRowProps) {
-  const navigation = useNavigation();
+  const { openFromMarket } = useAssetDetailNavigation();
   return (
     <TouchableOpacity
       onPress={() => {
-        navigation.navigate(ScreenName.MarketDetail, {
-          currencyId: item.id,
+        openFromMarket({
+          marketCurrencyId: item.id,
+          ledgerCurrencyIds: item.ledgerIds,
+          source: "market",
         });
       }}
     >

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/__integrations__/marketBanner.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/__integrations__/marketBanner.integration.test.tsx
@@ -55,7 +55,9 @@ describe("MarketBanner Integration Tests", () => {
       );
 
       renderWithReactQuery(<MarketBannerTest />, {
-        overrideInitialState: withFlagOverrides({ lwmWallet40: { enabled: false, params: { marketBanner: true } } }),
+        overrideInitialState: withFlagOverrides({
+          lwmWallet40: { enabled: false, params: { marketBanner: true } },
+        }),
       });
 
       expect(screen.queryByTestId("market-banner-container")).toBeNull();
@@ -69,7 +71,9 @@ describe("MarketBanner Integration Tests", () => {
       );
 
       renderWithReactQuery(<MarketBannerTest />, {
-        overrideInitialState: withFlagOverrides({ lwmWallet40: { enabled: true, params: { marketBanner: false } } }),
+        overrideInitialState: withFlagOverrides({
+          lwmWallet40: { enabled: true, params: { marketBanner: false } },
+        }),
       });
 
       expect(screen.queryByTestId("market-banner-container")).toBeNull();
@@ -83,7 +87,9 @@ describe("MarketBanner Integration Tests", () => {
       );
 
       renderWithReactQuery(<MarketBannerTest />, {
-        overrideInitialState: withFlagOverrides({ lwmWallet40: { enabled: true, params: { marketBanner: true } } }),
+        overrideInitialState: withFlagOverrides({
+          lwmWallet40: { enabled: true, params: { marketBanner: true } },
+        }),
       });
 
       expect(await screen.findByTestId("market-banner-container")).toBeVisible();
@@ -100,7 +106,9 @@ describe("MarketBanner Integration Tests", () => {
       );
 
       renderWithReactQuery(<MarketBannerTest />, {
-        overrideInitialState: withFlagOverrides({ lwmWallet40: { enabled: true, params: { marketBanner: true } } }),
+        overrideInitialState: withFlagOverrides({
+          lwmWallet40: { enabled: true, params: { marketBanner: true } },
+        }),
       });
 
       expect(await screen.findByTestId("market-banner-skeleton-0")).toBeVisible();
@@ -115,7 +123,9 @@ describe("MarketBanner Integration Tests", () => {
       );
 
       renderWithReactQuery(<MarketBannerTest />, {
-        overrideInitialState: withFlagOverrides({ lwmWallet40: { enabled: true, params: { marketBanner: true } } }),
+        overrideInitialState: withFlagOverrides({
+          lwmWallet40: { enabled: true, params: { marketBanner: true } },
+        }),
       });
 
       expect(await screen.findByText(/Connection failed/i)).toBeVisible();
@@ -127,7 +137,9 @@ describe("MarketBanner Integration Tests", () => {
       );
 
       renderWithReactQuery(<MarketBannerTest />, {
-        overrideInitialState: withFlagOverrides({ lwmWallet40: { enabled: true, params: { marketBanner: true } } }),
+        overrideInitialState: withFlagOverrides({
+          lwmWallet40: { enabled: true, params: { marketBanner: true } },
+        }),
       });
 
       expect(await screen.findByText(/Connection failed/i)).toBeVisible();
@@ -145,7 +157,9 @@ describe("MarketBanner Integration Tests", () => {
       );
 
       renderWithReactQuery(<MarketBannerTest />, {
-        overrideInitialState: withFlagOverrides({ lwmWallet40: { enabled: true, params: { marketBanner: true } } }),
+        overrideInitialState: withFlagOverrides({
+          lwmWallet40: { enabled: true, params: { marketBanner: true } },
+        }),
       });
 
       expect(await screen.findByTestId("market-banner-tile-0")).toBeVisible();
@@ -162,7 +176,9 @@ describe("MarketBanner Integration Tests", () => {
       );
 
       renderWithReactQuery(<MarketBannerTest />, {
-        overrideInitialState: withFlagOverrides({ lwmWallet40: { enabled: true, params: { marketBanner: true } } }),
+        overrideInitialState: withFlagOverrides({
+          lwmWallet40: { enabled: true, params: { marketBanner: true } },
+        }),
       });
 
       expect(await screen.findByTestId("market-banner-view-all")).toBeVisible();
@@ -177,7 +193,9 @@ describe("MarketBanner Integration Tests", () => {
       );
 
       renderWithReactQuery(<MarketBannerTest />, {
-        overrideInitialState: withFlagOverrides({ lwmWallet40: { enabled: true, params: { marketBanner: true } } }),
+        overrideInitialState: withFlagOverrides({
+          lwmWallet40: { enabled: true, params: { marketBanner: true } },
+        }),
       });
 
       expect(await screen.findByText(/Explore the market/i)).toBeVisible();
@@ -193,15 +211,25 @@ describe("MarketBanner Integration Tests", () => {
       );
 
       const { user } = renderWithReactQuery(<MarketBannerTest />, {
-        overrideInitialState: withFlagOverrides({ lwmWallet40: { enabled: true, params: { marketBanner: true } } }),
+        overrideInitialState: withFlagOverrides({
+          lwmWallet40: {
+            enabled: true,
+            params: { marketBanner: true, aggregatedAssets: true },
+          },
+        }),
       });
 
       const tile = await screen.findByTestId("market-banner-tile-0");
       await user.press(tile);
 
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith("MarketDetail", {
-          currencyId: "bitcoin",
+        expect(mockNavigate).toHaveBeenCalledWith("AssetDetail", {
+          screen: "AssetDetail",
+          params: {
+            currencyId: "bitcoin",
+            source: "market_banner",
+            marketState: { id: "bitcoin", ledgerIds: ["bitcoin"] },
+          },
         });
       });
     });
@@ -214,7 +242,9 @@ describe("MarketBanner Integration Tests", () => {
       );
 
       const { user } = renderWithReactQuery(<MarketBannerTest />, {
-        overrideInitialState: withFlagOverrides({ lwmWallet40: { enabled: true, params: { marketBanner: true } } }),
+        overrideInitialState: withFlagOverrides({
+          lwmWallet40: { enabled: true, params: { marketBanner: true } },
+        }),
       });
 
       const viewAllTile = await screen.findByTestId("market-banner-view-all");
@@ -233,7 +263,9 @@ describe("MarketBanner Integration Tests", () => {
       );
 
       const { user } = renderWithReactQuery(<MarketBannerTest />, {
-        overrideInitialState: withFlagOverrides({ lwmWallet40: { enabled: true, params: { marketBanner: true } } }),
+        overrideInitialState: withFlagOverrides({
+          lwmWallet40: { enabled: true, params: { marketBanner: true } },
+        }),
       });
 
       const sectionTitle = await screen.findByText(/Explore the market/i);
@@ -246,7 +278,7 @@ describe("MarketBanner Integration Tests", () => {
   });
 
   describe("Navigation", () => {
-    it("should navigate to market detail when tile is pressed", async () => {
+    it("navigates to AssetDetail when aggregatedAssets is enabled", async () => {
       server.use(
         http.get(`${COUNTERVALUES_API}/v3/markets`, () =>
           HttpResponse.json(MOCK_MARKET_PERFORMERS),
@@ -254,7 +286,43 @@ describe("MarketBanner Integration Tests", () => {
       );
 
       const { user } = renderWithReactQuery(<MarketBannerTest />, {
-        overrideInitialState: withFlagOverrides({ lwmWallet40: { enabled: true, params: { marketBanner: true } } }),
+        overrideInitialState: withFlagOverrides({
+          lwmWallet40: {
+            enabled: true,
+            params: { marketBanner: true, aggregatedAssets: true },
+          },
+        }),
+      });
+
+      const tile = await screen.findByTestId("market-banner-tile-0");
+      await user.press(tile);
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith("AssetDetail", {
+          screen: "AssetDetail",
+          params: {
+            currencyId: "bitcoin",
+            source: "market_banner",
+            marketState: { id: "bitcoin", ledgerIds: ["bitcoin"] },
+          },
+        });
+      });
+    });
+
+    it("falls back to MarketDetail when aggregatedAssets is disabled", async () => {
+      server.use(
+        http.get(`${COUNTERVALUES_API}/v3/markets`, () =>
+          HttpResponse.json(MOCK_MARKET_PERFORMERS),
+        ),
+      );
+
+      const { user } = renderWithReactQuery(<MarketBannerTest />, {
+        overrideInitialState: withFlagOverrides({
+          lwmWallet40: {
+            enabled: true,
+            params: { marketBanner: true, aggregatedAssets: false },
+          },
+        }),
       });
 
       const tile = await screen.findByTestId("market-banner-tile-0");
@@ -275,7 +343,9 @@ describe("MarketBanner Integration Tests", () => {
       );
 
       const { user } = renderWithReactQuery(<MarketBannerTest />, {
-        overrideInitialState: withFlagOverrides({ lwmWallet40: { enabled: true, params: { marketBanner: true } } }),
+        overrideInitialState: withFlagOverrides({
+          lwmWallet40: { enabled: true, params: { marketBanner: true } },
+        }),
       });
 
       const viewAllTile = await screen.findByTestId("market-banner-view-all");
@@ -311,7 +381,9 @@ describe("MarketBanner Integration Tests", () => {
       );
 
       renderWithReactQuery(<MarketBannerTest />, {
-        overrideInitialState: withFlagOverrides({ lwmWallet40: { enabled: true, params: { marketBanner: true } } }),
+        overrideInitialState: withFlagOverrides({
+          lwmWallet40: { enabled: true, params: { marketBanner: true } },
+        }),
       });
 
       expect(await screen.findByText(/neutral/i)).toBeVisible();
@@ -321,7 +393,9 @@ describe("MarketBanner Integration Tests", () => {
       server.use(http.get(API_ENDPOINT, () => HttpResponse.json(null, { status: 500 })));
 
       renderWithReactQuery(<MarketBannerTest />, {
-        overrideInitialState: withFlagOverrides({ lwmWallet40: { enabled: true, params: { marketBanner: true } } }),
+        overrideInitialState: withFlagOverrides({
+          lwmWallet40: { enabled: true, params: { marketBanner: true } },
+        }),
       });
 
       expect(await screen.queryByText(/neutral/i)).toBeNull();

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/hooks/useMarketBannerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/hooks/useMarketBannerViewModel.ts
@@ -13,6 +13,7 @@ import { track } from "~/analytics";
 import { ScreenName } from "~/const";
 import { counterValueCurrencySelector } from "~/reducers/settings";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import { useAssetDetailNavigation } from "LLM/features/AssetDetail/hooks/useAssetDetailNavigation";
 import { MARKET_BANNER_TILE_COUNT, PAGE_NAME, BANNER_NAME } from "../constants";
 import { UseMarketBannerViewModelResult } from "../types";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
@@ -27,6 +28,7 @@ import {
 const useMarketBannerViewModel = (): UseMarketBannerViewModelResult => {
   const baseNavigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
   const { shouldDisplayMarketBanner } = useWalletFeaturesConfig("mobile");
+  const { openFromMarket } = useAssetDetailNavigation();
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
 
   const { isCurrencyAvailable } = useRampCatalog();
@@ -62,13 +64,6 @@ const useMarketBannerViewModel = (): UseMarketBannerViewModelResult => {
     baseNavigation.navigate(ScreenName.MarketList);
   }, [baseNavigation]);
 
-  const navigateToMarketDetail = useCallback(
-    (currencyId: string) => {
-      baseNavigation.navigate(ScreenName.MarketDetail, { currencyId });
-    },
-    [baseNavigation],
-  );
-
   const onTilePress = useCallback(
     (item: MarketItemPerformer) => {
       track("button_clicked", {
@@ -77,9 +72,13 @@ const useMarketBannerViewModel = (): UseMarketBannerViewModelResult => {
         coin: item.name,
         banner: BANNER_NAME,
       });
-      navigateToMarketDetail(item.id);
+      openFromMarket({
+        marketCurrencyId: item.id,
+        ledgerCurrencyIds: item.ledgerIds,
+        source: "market_banner",
+      });
     },
-    [navigateToMarketDetail],
+    [openFromMarket],
   );
 
   const onViewAllPress = useCallback(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/shared/usePortfolioSectionActions.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/shared/usePortfolioSectionActions.ts
@@ -6,7 +6,7 @@ import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/Ba
 import { NavigatorName, ScreenName } from "~/const";
 import { Asset } from "~/types/asset";
 import { useAnalytics } from "~/analytics";
-import { dadaIdToMarketId } from "@ledgerhq/live-common/market/utils/index";
+import { useAssetDetailNavigation } from "LLM/features/AssetDetail/hooks/useAssetDetailNavigation";
 
 interface PortfolioSectionActions {
   onPressShowAll: () => void;
@@ -17,10 +17,10 @@ export function usePortfolioSectionActions(
   isReadOnly: boolean,
   variant: "crypto" | "stablecoin" | "all",
 ): PortfolioSectionActions {
-  const { shouldDisplayAssetSection, shouldDisplayAggregatedAssets } =
-    useWalletFeaturesConfig("mobile");
+  const { shouldDisplayAssetSection } = useWalletFeaturesConfig("mobile");
   const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
   const { track } = useAnalytics();
+  const { openFromAsset } = useAssetDetailNavigation();
 
   const onPressShowAll = useCallback(() => {
     track("button_clicked", {
@@ -49,29 +49,14 @@ export function usePortfolioSectionActions(
         asset: asset.currency.name,
         page: "Wallet",
       });
-      if (shouldDisplayAggregatedAssets) {
-        navigation.navigate(NavigatorName.AssetDetail, {
-          screen: ScreenName.AssetDetail,
-          params: {
-            currencyId: asset.currency.id,
-            source: "portfolio",
-          },
-        });
-      } else if (asset.isPlaceholder) {
-        const currencyId = dadaIdToMarketId(asset.marketId ?? asset.currency.id);
-        navigation.navigate(ScreenName.MarketDetail, {
-          currencyId,
-        });
-      } else {
-        navigation.navigate(NavigatorName.Accounts, {
-          screen: ScreenName.Asset,
-          params: {
-            currency: asset.currency,
-          },
-        });
-      }
+      openFromAsset({
+        currency: asset.currency,
+        source: "portfolio",
+        isPlaceholder: asset.isPlaceholder,
+        marketId: asset.marketId,
+      });
     },
-    [navigation, track, shouldDisplayAggregatedAssets],
+    [openFromAsset, track],
   );
 
   return { onPressShowAll, onItemPress };

--- a/apps/ledger-live-mobile/src/screens/Analytics/DistributionCard.tsx
+++ b/apps/ledger-live-mobile/src/screens/Analytics/DistributionCard.tsx
@@ -4,14 +4,13 @@ import { getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
 import styled, { useTheme } from "styled-components/native";
 import { Text, Flex } from "@ledgerhq/native-ui";
 import { TouchableOpacity } from "react-native";
-import { useNavigation } from "@react-navigation/native";
 import CurrencyUnitValue from "~/components/CurrencyUnitValue";
 import ProgressBar from "~/components/ProgressBar";
 import CounterValue from "~/components/CounterValue";
 import { ensureContrast } from "../../colors";
 import { withDiscreetMode } from "~/context/DiscreetModeContext";
-import { NavigatorName, ScreenName } from "~/const";
 import CurrencyIcon from "~/components/CurrencyIcon";
+import { useAssetDetailNavigation } from "LLM/features/AssetDetail/hooks/useAssetDetailNavigation";
 
 export type DistributionItem = {
   currency: CryptoCurrency | TokenCurrency;
@@ -63,7 +62,7 @@ const DistributionRow = styled(Flex).attrs({
 
 function DistributionCard({ item: { currency, amount, distribution } }: Props) {
   const { colors } = useTheme();
-  const navigation = useNavigation();
+  const { openFromAsset } = useAssetDetailNavigation();
   const color = useMemo(
     () => ensureContrast(getCurrencyColor(currency), colors.background.main),
     [colors, currency],
@@ -71,13 +70,8 @@ function DistributionCard({ item: { currency, amount, distribution } }: Props) {
   const percentage = Math.round(distribution * 1e4) / 1e2;
 
   const navigateToAccounts = useCallback(() => {
-    navigation.navigate(NavigatorName.Accounts, {
-      screen: ScreenName.Asset,
-      params: {
-        currency,
-      },
-    });
-  }, [currency, navigation]);
+    openFromAsset({ currency, source: "analytics_distribution" });
+  }, [currency, openFromAsset]);
 
   return (
     <Container onPress={navigateToAccounts}>

--- a/apps/ledger-live-mobile/src/screens/Assets/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Assets/index.tsx
@@ -1,12 +1,12 @@
 import React, { memo, useCallback, useMemo, useState } from "react";
 import { useSelector } from "~/context/hooks";
-import { useFocusEffect, useNavigation } from "@react-navigation/native";
+import { useFocusEffect } from "@react-navigation/native";
 import { Flex, Text, Button, IconsLegacy } from "@ledgerhq/native-ui";
 import { RefreshMedium } from "@ledgerhq/native-ui/assets/icons";
 import SafeAreaView from "~/components/SafeAreaView";
 import { useTranslation } from "~/context/Locale";
 import { useGlobalSyncState } from "@ledgerhq/live-common/bridge/react/index";
-import { FlatList, FlatListProps } from "react-native";
+import { FlatList, FlatListProps, type ListRenderItem } from "react-native";
 import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 
@@ -14,7 +14,7 @@ import { useDistribution, useRefreshAccountsOrdering } from "~/actions/general";
 import { isUpToDateSelector } from "~/reducers/accounts";
 import TrackScreen from "~/analytics/TrackScreen";
 import { withDiscreetMode } from "~/context/DiscreetModeContext";
-import AssetRow, { NavigationProp } from "../WalletCentricAsset/AssetRow";
+import AssetRow from "../WalletCentricAsset/AssetRow";
 
 import Spinning from "~/components/Spinning";
 import AssetsNavigationHeader from "./AssetsNavigationHeader";
@@ -26,7 +26,6 @@ import AddAccountDrawer from "LLM/features/Accounts/screens/AddAccount";
 const List = globalSyncRefreshControl<FlatListProps<Asset>>(FlatList);
 
 function Assets() {
-  const navigation = useNavigation<NavigationProp>();
   const isUpToDate = useSelector(isUpToDateSelector);
   const globalSyncState = useGlobalSyncState();
   const hideEmptyTokenAccount = useEnv("HIDE_EMPTY_TOKEN_ACCOUNTS");
@@ -67,9 +66,9 @@ function Assets() {
 
   const closeAddModal = useCallback(() => setAddModalOpened(false), [setAddModalOpened]);
 
-  const renderItem = useCallback(
-    ({ item }: { item: Asset }) => <AssetRow asset={item} navigation={navigation} />,
-    [navigation],
+  const renderItem = useCallback<ListRenderItem<Asset>>(
+    ({ item }) => <AssetRow asset={item} />,
+    [],
   );
 
   return (

--- a/apps/ledger-live-mobile/src/screens/Portfolio/Assets.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/Assets.tsx
@@ -1,18 +1,16 @@
 import React, { useCallback } from "react";
-import { FlatList } from "react-native";
-import { useNavigation } from "@react-navigation/native";
+import { FlatList, type ListRenderItem } from "react-native";
 import isEqual from "lodash/isEqual";
-import AssetRow, { NavigationProp } from "../WalletCentricAsset/AssetRow";
+import AssetRow from "../WalletCentricAsset/AssetRow";
 import { withDiscreetMode } from "~/context/DiscreetModeContext";
 import { Asset } from "~/types/asset";
 
 type ListProps = { assets: Asset[] };
 
 const AssetsList = ({ assets }: ListProps) => {
-  const navigation = useNavigation<NavigationProp>();
-  const renderItem = useCallback(
-    ({ item }: { item: Asset }) => <AssetRow asset={item} navigation={navigation} />,
-    [navigation],
+  const renderItem = useCallback<ListRenderItem<Asset>>(
+    ({ item }) => <AssetRow asset={item} />,
+    [],
   );
 
   return (

--- a/apps/ledger-live-mobile/src/screens/Portfolio/ReadOnlyAssets.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/ReadOnlyAssets.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, memo } from "react";
-import { FlatList } from "react-native";
+import { FlatList, type ListRenderItem } from "react-native";
 import { Flex, Text } from "@ledgerhq/native-ui";
 
 import { useTranslation } from "~/context/Locale";
@@ -8,14 +8,14 @@ import { withDiscreetMode } from "~/context/DiscreetModeContext";
 
 import GradientContainer from "~/components/GradientContainer";
 import TabBarSafeAreaView, { TAB_BAR_SAFE_HEIGHT } from "~/components/TabBar/TabBarSafeAreaView";
-import AssetRow, { NavigationProp } from "../WalletCentricAsset/AssetRow";
+import AssetRow from "../WalletCentricAsset/AssetRow";
 import AssetsNavigationHeader from "../Assets/AssetsNavigationHeader";
 import { Asset } from "~/types/asset";
 import { useReadOnlyCoins } from "~/hooks/useReadOnlyCoins";
 
 const maxReadOnlyCryptoCurrencies = 10;
 
-function ReadOnlyAssets({ navigation }: { navigation: NavigationProp }) {
+function ReadOnlyAssets() {
   const { sortedCryptoCurrencies } = useReadOnlyCoins({
     maxDisplayed: maxReadOnlyCryptoCurrencies,
   });
@@ -32,9 +32,9 @@ function ReadOnlyAssets({ navigation }: { navigation: NavigationProp }) {
 
   const { t } = useTranslation();
 
-  const renderItem = useCallback(
-    ({ item }: { item: Asset }) => <AssetRow asset={item} navigation={navigation} />,
-    [navigation],
+  const renderItem = useCallback<ListRenderItem<Asset>>(
+    ({ item }) => <AssetRow asset={item} />,
+    [],
   );
 
   return (

--- a/apps/ledger-live-mobile/src/screens/WalletCentricAsset/AssetRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/WalletCentricAsset/AssetRow.tsx
@@ -4,37 +4,26 @@ import { BigNumber } from "bignumber.js";
 import isEqual from "lodash/isEqual";
 import { GestureResponderEvent } from "react-native";
 
-import { NavigatorName, ScreenName } from "~/const";
 import { usePortfolioForAccounts } from "~/hooks/portfolio";
 import AssetRowLayout from "~/components/AssetRowLayout";
 import { track } from "~/analytics";
-import {
-  BaseNavigationComposite,
-  StackNavigatorNavigation,
-} from "~/components/RootNavigator/types/helpers";
-import { AccountsNavigatorParamList } from "~/components/RootNavigator/types/AccountsNavigator";
-import { PortfolioNavigatorStackParamList } from "~/components/RootNavigator/types/PortfolioNavigator";
 import { Asset } from "~/types/asset";
-
-export type NavigationProp = BaseNavigationComposite<
-  | StackNavigatorNavigation<AccountsNavigatorParamList, ScreenName.Assets>
-  | StackNavigatorNavigation<PortfolioNavigatorStackParamList>
->;
+import { useAssetDetailNavigation } from "LLM/features/AssetDetail/hooks/useAssetDetailNavigation";
 
 type Props = {
   asset: Asset;
-  navigation: NavigationProp;
   hideDelta?: boolean;
   topLink?: boolean;
   bottomLink?: boolean;
 };
 
-const AssetRow = ({ asset, navigation, hideDelta, topLink, bottomLink }: Props) => {
+const AssetRow = ({ asset, hideDelta, topLink, bottomLink }: Props) => {
   // makes it refresh if this changes
   useEnv("HIDE_EMPTY_TOKEN_ACCOUNTS");
   const currency = asset.currency;
   const name = currency.name;
   const unit = currency.units[0];
+  const { openFromAsset } = useAssetDetailNavigation();
 
   // TODO: implement a much lighter hook to get this simple value
   const { countervalueChange } = usePortfolioForAccounts(asset.accounts);
@@ -45,14 +34,14 @@ const AssetRow = ({ asset, navigation, hideDelta, topLink, bottomLink }: Props) 
         asset: currency.name,
       });
 
-      navigation.navigate(NavigatorName.Accounts, {
-        screen: ScreenName.Asset,
-        params: {
-          currency,
-        },
+      openFromAsset({
+        currency,
+        source: "wallet_centric_asset",
+        isPlaceholder: asset.isPlaceholder,
+        marketId: asset.marketId,
       });
     },
-    [currency, navigation],
+    [currency, asset.isPlaceholder, asset.marketId, openFromAsset],
   );
 
   /**

--- a/apps/ledger-live-mobile/src/screens/WalletCentricSections/MarketPrice.tsx
+++ b/apps/ledger-live-mobile/src/screens/WalletCentricSections/MarketPrice.tsx
@@ -1,11 +1,9 @@
 import React, { memo, useCallback } from "react";
 import { Flex, Text, IconsLegacy } from "@ledgerhq/native-ui";
 import { useTranslation } from "~/context/Locale";
-import { useNavigation } from "@react-navigation/native";
 import counterValueFormatter from "@ledgerhq/live-common/market/utils/countervalueFormatter";
 import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { withDiscreetMode } from "~/context/DiscreetModeContext";
-import { ScreenName } from "~/const";
 import DeltaVariation from "LLM/features/Market/components/DeltaVariation";
 import Touchable from "~/components/Touchable";
 import { useSettings } from "~/hooks";
@@ -13,6 +11,7 @@ import { MarketCurrencyData, KeysPriceChange } from "@ledgerhq/live-common/marke
 import { useTimeRange } from "~/actions/settings";
 import { PortfolioRange } from "@ledgerhq/types-live";
 import { resolveMarketId } from "LLM/features/Market/utils/marketIdResolver";
+import { useAssetDetailNavigation } from "LLM/features/AssetDetail/hooks/useAssetDetailNavigation";
 
 type Props = {
   currency: CryptoOrTokenCurrency;
@@ -23,15 +22,17 @@ type Props = {
 const MarketPrice = ({ currency, selectedCoinData, counterCurrency }: Props) => {
   const { t } = useTranslation();
   const { locale } = useSettings();
-  const navigation = useNavigation();
+  const { openFromMarket } = useAssetDetailNavigation();
 
   const [range] = useTimeRange();
 
   const goToMarketPage = useCallback(() => {
-    navigation.navigate(ScreenName.MarketDetail, {
-      currencyId: resolveMarketId(currency.id),
+    openFromMarket({
+      marketCurrencyId: resolveMarketId(currency.id),
+      ledgerCurrencyIds: [currency.id],
+      source: "wallet_centric_market_price",
     });
-  }, [currency, navigation]);
+  }, [currency, openFromMarket]);
 
   const getPrice = (selectedCoinData: MarketCurrencyData, range: PortfolioRange) => {
     const key: KeysPriceChange = range === "all" ? KeysPriceChange.year : KeysPriceChange[range];

--- a/libs/asset-aggregation/src/assetDistribution/__tests__/resolveAssetMarketInputs.test.ts
+++ b/libs/asset-aggregation/src/assetDistribution/__tests__/resolveAssetMarketInputs.test.ts
@@ -1,0 +1,114 @@
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import type { DistributionItem } from "@ledgerhq/types-live";
+import { resolveAssetMarketInputs } from "../resolveAssetMarketInputs";
+
+const cryptoCurrency = (id: string): CryptoCurrency =>
+  ({ id, type: "CryptoCurrency", name: id, ticker: id.toUpperCase() }) as unknown as CryptoCurrency;
+
+const item = (
+  currency: CryptoCurrency,
+  overrides: Partial<DistributionItem> = {},
+): DistributionItem => ({
+  currency,
+  distribution: 0,
+  amount: 0,
+  accounts: [],
+  ...overrides,
+});
+
+describe("resolveAssetMarketInputs", () => {
+  it("returns all undefined when no input is provided", () => {
+    expect(resolveAssetMarketInputs({})).toEqual({
+      marketApiId: undefined,
+      knownLedgerIds: undefined,
+      knownMarketId: undefined,
+    });
+  });
+
+  it("prefers distributionItem.marketId over every other source", () => {
+    const result = resolveAssetMarketInputs({
+      distributionItem: item(cryptoCurrency("bsc"), {
+        marketId: "binancecoin",
+        slug: "binancecoin",
+      }),
+      marketState: { id: "another-id", ledgerIds: ["other"] },
+      currency: cryptoCurrency("bsc"),
+      fallbackId: "fallback",
+    });
+
+    expect(result.marketApiId).toBe("binancecoin");
+  });
+
+  it("falls back to distributionItem.slug when marketId is missing", () => {
+    const result = resolveAssetMarketInputs({
+      distributionItem: item(cryptoCurrency("bsc"), { slug: "binancecoin" }),
+    });
+
+    expect(result.marketApiId).toBe("binancecoin");
+  });
+
+  it("falls back to distributionItem.currency.id when marketId and slug are missing", () => {
+    const result = resolveAssetMarketInputs({
+      distributionItem: item(cryptoCurrency("bsc")),
+      marketState: { id: "ignored" },
+    });
+
+    expect(result.marketApiId).toBe("bsc");
+  });
+
+  it("falls back to marketState.id when no distributionItem is provided", () => {
+    const result = resolveAssetMarketInputs({
+      marketState: { id: "binancecoin", ledgerIds: ["bsc"] },
+      currency: cryptoCurrency("bsc"),
+    });
+
+    expect(result.marketApiId).toBe("binancecoin");
+  });
+
+  it("falls back to currency.id when no distribution and no marketState", () => {
+    const result = resolveAssetMarketInputs({ currency: cryptoCurrency("bitcoin") });
+
+    expect(result.marketApiId).toBe("bitcoin");
+  });
+
+  it("uses fallbackId as the last resort", () => {
+    const result = resolveAssetMarketInputs({ fallbackId: "raw-route-id" });
+
+    expect(result.marketApiId).toBe("raw-route-id");
+  });
+
+  it("prefers distributionItem.currency.id for knownLedgerIds", () => {
+    const result = resolveAssetMarketInputs({
+      distributionItem: item(cryptoCurrency("bsc")),
+      marketState: { id: "binancecoin", ledgerIds: ["other"] },
+      currency: cryptoCurrency("ignored"),
+    });
+
+    expect(result.knownLedgerIds).toEqual(["bsc"]);
+  });
+
+  it("falls back to currency.id for knownLedgerIds when no distributionItem", () => {
+    const result = resolveAssetMarketInputs({
+      marketState: { id: "binancecoin", ledgerIds: ["bsc"] },
+      currency: cryptoCurrency("bsc"),
+    });
+
+    expect(result.knownLedgerIds).toEqual(["bsc"]);
+  });
+
+  it("uses marketState.ledgerIds when no distributionItem and no currency", () => {
+    const result = resolveAssetMarketInputs({
+      marketState: { id: "binancecoin", ledgerIds: ["bsc", "ethereum"] },
+    });
+
+    expect(result.knownLedgerIds).toEqual(["bsc", "ethereum"]);
+  });
+
+  it("returns marketState.id as knownMarketId", () => {
+    const result = resolveAssetMarketInputs({
+      marketState: { id: "binancecoin" },
+    });
+
+    expect(result.knownMarketId).toBe("binancecoin");
+  });
+});

--- a/libs/asset-aggregation/src/assetDistribution/index.ts
+++ b/libs/asset-aggregation/src/assetDistribution/index.ts
@@ -6,6 +6,8 @@ export type {
   MarketStateSlice,
   ResolveDistributionItemParams,
 } from "./resolveDistributionItem";
+export { resolveAssetMarketInputs } from "./resolveAssetMarketInputs";
+export type { AssetMarketInputs, ResolveAssetMarketInputsParams } from "./resolveAssetMarketInputs";
 export { buildMainAccountByIdMap, lookupParentAccountFromMap } from "./parentAccountLookup";
 export type {
   AssetsDataLike,

--- a/libs/asset-aggregation/src/assetDistribution/resolveAssetMarketInputs.ts
+++ b/libs/asset-aggregation/src/assetDistribution/resolveAssetMarketInputs.ts
@@ -1,0 +1,69 @@
+import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type { DistributionItem } from "@ledgerhq/types-live";
+import type { MarketStateSlice } from "./resolveDistributionItem";
+
+export type AssetMarketInputs = {
+  /** Id to use against the market API (CoinGecko-style id, e.g. "binancecoin"). */
+  marketApiId?: string;
+  /** Known Ledger currency ids to hint the DADA endpoint. */
+  knownLedgerIds?: readonly string[];
+  /** Known market id, used when the market query is loading / errors out. */
+  knownMarketId?: string;
+};
+
+export type ResolveAssetMarketInputsParams = {
+  distributionItem?: DistributionItem;
+  marketState?: MarketStateSlice & { id?: string };
+  currency?: CryptoOrTokenCurrency;
+  /** Last-resort fallback (e.g. the raw route param the navigation was opened with). */
+  fallbackId?: string;
+};
+
+/**
+ * Resolves the inputs needed by `useAssetMarketData` from whatever context is
+ * available on the AssetDetail screen — distribution lookup, market navigation
+ * hint, or a raw currency. Centralised so desktop and mobile stay in sync.
+ *
+ * Precedence for `marketApiId`:
+ *  1. `distributionItem.marketId`     — the resolved market id from the wallet
+ *  2. `distributionItem.slug`         — slug derived from the DADA meta-currency
+ *  3. `distributionItem.currency.id`  — the resolved ledger currency id from the wallet
+ *  4. `marketState.id`                — hint passed when navigating from Market
+ *  5. `currency.id`                   — last-resort, only correct for assets whose
+ *                                       ledger id == market id (e.g. BTC)
+ *  6. `fallbackId`                    — raw route param
+ */
+export function resolveAssetMarketInputs({
+  distributionItem,
+  marketState,
+  currency,
+  fallbackId,
+}: ResolveAssetMarketInputsParams): AssetMarketInputs {
+  const marketApiId =
+    distributionItem?.marketId ??
+    distributionItem?.slug ??
+    distributionItem?.currency.id ??
+    marketState?.id ??
+    currency?.id ??
+    fallbackId;
+
+  const knownLedgerIds = resolveKnownLedgerIds({ distributionItem, currency, marketState });
+
+  return {
+    marketApiId,
+    knownLedgerIds,
+    knownMarketId: marketState?.id,
+  };
+}
+
+function resolveKnownLedgerIds({
+  distributionItem,
+  currency,
+  marketState,
+}: Pick<ResolveAssetMarketInputsParams, "distributionItem" | "currency" | "marketState">):
+  | readonly string[]
+  | undefined {
+  if (distributionItem) return [distributionItem.currency.id];
+  if (currency) return [currency.id];
+  return marketState?.ledgerIds;
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Navigation from Market list / Market banner / Portfolio asset rows / Crypto + Stablecoin lists / Analytics distribution cards / WalletCentric MarketPrice
  - Legacy fallback (when `aggregatedAssets` is disabled): still routes to MarketDetail / Accounts > Asset / dadaIdToMarketId placeholder
  - Asset Detail screen data sections (BalanceGraph, Market Stats, Price Performance) for assets where the ledger id differs from the market id — BNB (ledger `bsc` → market `binancecoin`) is the canonical case
  - Deeplinks to AssetDetail (no `marketState` param) — should still render correctly
  - Desktop AssetDetail viewmodel was refactored to consume the shared resolver; behaviour preserved

### 📝 Description

Mobile entry points (Market and Asset/portfolio rows) were not wired to the new MVVM AssetDetail screen — taps still landed on the legacy `MarketDetail` / `Accounts > Asset` routes. Once the feature flag `lwmWallet40.aggregatedAssets` is on, all user-tap entry points must navigate to the new screen with consistent params, while staying on the legacy destinations when the flag is off.

Additionally, the new AssetDetail screen rendered empty Market price / Market stats / Price performance sections for assets whose ledger id differs from their market id (BNB native ledger id is `bsc`, market id is `binancecoin`). The shared `useAssetMarketData` was being called with the ledger id as `marketApiId`, so the market API returned nothing.

**Solution:**

- New `useAssetDetailNavigation` hook exposing `openFromAsset` / `openFromMarket` (and a `hideNetwork` convenience for icon rendering). Centralises the `shouldDisplayAggregatedAssets` branching that was previously duplicated in `usePortfolioSectionActions`.
- Rewired all user-tap entry points: Market list, Market banner, Portfolio (already wired — now delegates to the helper), Assets list, Crypto/Stablecoin screens, both Analytics DistributionCards (MVVM + legacy), WalletCentric AssetRow, WalletCentric MarketPrice.
- Added a `marketState?: { id; ledgerIds? }` param to the AssetDetail navigator so market-origin navigations carry the hint required by `resolveDistributionItem`.
- Extracted a shared `resolveAssetMarketInputs({ distributionItem, marketState, currency, fallbackId })` helper into `@ledgerhq/asset-aggregation` returning `{ marketApiId, knownLedgerIds, knownMarketId }`. Both desktop's and mobile's AssetDetail viewmodels consume it, eliminating the previous platform drift in the resolution chain (desktop ended in `decodedAssetId`, mobile in `currency?.id`).
- Mobile's `useAssetMarketData` wrapper now requires already-resolved ids (no silent fallback to `currency.id`), so a child viewmodel that forgets to pass them can no longer reintroduce the BNB-style bug.

FF ON

https://github.com/user-attachments/assets/b191a807-080e-4348-9020-952aefa72d72

FF OFF

https://github.com/user-attachments/assets/6798db6b-9ff9-4d34-bc50-43294efff707



### ❓ Context

- **JIRA or GitHub link**: [LIVE-29733](https://ledgerhq.atlassian.net/browse/LIVE-29733)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29733]: https://ledgerhq.atlassian.net/browse/LIVE-29733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ