### PR TITLE
[LWDM] feat(cryptoassets): add Bittensor (TAO) currency

### DIFF
--- a/.changeset/add-bittensor-currency.md
+++ b/.changeset/add-bittensor-currency.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/cryptoassets": patch
+"@ledgerhq/types-cryptoassets": patch
+---
+
+Add Bittensor (TAO) currency metadata: CoinType.BITTENSOR = 1005 in types-cryptoassets and bittensor currency entry with TAO/RAO units in cryptoassets

--- a/libs/ledgerjs/packages/cryptoassets/src/abandonseed.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/abandonseed.ts
@@ -47,6 +47,7 @@ const abandonSeedAddresses: Partial<Record<CryptoCurrency["id"], string>> = {
   westend: "111111111111111111111111111111111HC1",
   assethub_westend: "111111111111111111111111111111111HC1",
   assethub_polkadot: "111111111111111111111111111111111HC1",
+  bittensor: "111111111111111111111111111111111HC1",
   qtum: "QPvRe2C17qk24K6v5gTg7CPghZ8b4WMxZP",
   stratis: "Sdo6x9k5AxWtfyJe5B9SZPteYTKgUoMMr1",
   zcash: "t1XVXWCvpMgBvUaed4XDqWtgQgJSu1Ghz7F",

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
@@ -3551,6 +3551,36 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
       },
     ],
   },
+  bittensor: {
+    type: "CryptoCurrency",
+    id: "bittensor",
+    coinType: CoinType.BITTENSOR,
+    name: "Bittensor",
+    managerAppName: "Polkadot",
+    ticker: "TAO",
+    scheme: "bittensor",
+    color: "#252525",
+    family: "polkadot",
+    units: [
+      {
+        name: "TAO",
+        code: "TAO",
+        magnitude: 9,
+      },
+      {
+        name: "RAO",
+        code: "RAO",
+        magnitude: 0,
+      },
+    ],
+    explorerViews: [
+      {
+        address: "https://taostats.io/account/$address",
+        tx: "https://taostats.io/extrinsic/$hash",
+      },
+    ],
+    keywords: ["tao", "bittensor"],
+  },
   bitcoin_testnet: {
     type: "CryptoCurrency",
     id: "bitcoin_testnet",

--- a/libs/ledgerjs/packages/types-cryptoassets/src/slip44.ts
+++ b/libs/ledgerjs/packages/types-cryptoassets/src/slip44.ts
@@ -10,6 +10,7 @@ export enum CoinType {
   ARK = 111,
   ATH = 1620,
   BANANO = 198,
+  BITTENSOR = 1005,
   BTC = 0,
   BTC_CASH = 145,
   BTC_GOLD = 156,

--- a/libs/live-currency-format/src/__snapshots__/formatCurrencyUnit.test.ts.snap
+++ b/libs/live-currency-format/src/__snapshots__/formatCurrencyUnit.test.ts.snap
@@ -64,6 +64,8 @@ exports[`formatCurrencyUnit with custom options with locale de-DE should correct
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Bitlayer unit (BTC) 1`] = `"0,012345678900000000- -BTC"`;
 
+exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Bittensor unit (TAO) 1`] = `"12.345.678,900000000- -TAO"`;
+
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Bittorent Chain unit (BTT) 1`] = `"0,012345678900000000- -BTT"`;
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Blast Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
@@ -471,6 +473,8 @@ exports[`formatCurrencyUnit with custom options with locale en-US should correct
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Bitcoin unit (bitcoin) 1`] = `"123,456,789.00000000- -BTC"`;
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Bitlayer unit (BTC) 1`] = `"0.012345678900000000- -BTC"`;
+
+exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Bittensor unit (TAO) 1`] = `"12,345,678.900000000- -TAO"`;
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Bittorent Chain unit (BTT) 1`] = `"0.012345678900000000- -BTT"`;
 
@@ -880,6 +884,8 @@ exports[`formatCurrencyUnit with custom options with locale es-ES should correct
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Bitlayer unit (BTC) 1`] = `"0,012345678900000000- -BTC"`;
 
+exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Bittensor unit (TAO) 1`] = `"12.345.678,900000000- -TAO"`;
+
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Bittorent Chain unit (BTT) 1`] = `"0,012345678900000000- -BTT"`;
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Blast Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
@@ -1287,6 +1293,8 @@ exports[`formatCurrencyUnit with custom options with locale fr-FR should correct
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Bitcoin unit (bitcoin) 1`] = `"123 456 789,00000000- -BTC"`;
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Bitlayer unit (BTC) 1`] = `"0,012345678900000000- -BTC"`;
+
+exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Bittensor unit (TAO) 1`] = `"12 345 678,900000000- -TAO"`;
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Bittorent Chain unit (BTT) 1`] = `"0,012345678900000000- -BTT"`;
 
@@ -1696,6 +1704,8 @@ exports[`formatCurrencyUnit with custom options with locale ja-JP should correct
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Bitlayer unit (BTC) 1`] = `"0.012345678900000000- -BTC"`;
 
+exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Bittensor unit (TAO) 1`] = `"12,345,678.900000000- -TAO"`;
+
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Bittorent Chain unit (BTT) 1`] = `"0.012345678900000000- -BTT"`;
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Blast Sepolia unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
@@ -2103,6 +2113,8 @@ exports[`formatCurrencyUnit with custom options with locale ko-KR should correct
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Bitcoin unit (bitcoin) 1`] = `"123,456,789.00000000- -BTC"`;
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Bitlayer unit (BTC) 1`] = `"0.012345678900000000- -BTC"`;
+
+exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Bittensor unit (TAO) 1`] = `"12,345,678.900000000- -TAO"`;
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Bittorent Chain unit (BTT) 1`] = `"0.012345678900000000- -BTT"`;
 
@@ -2512,6 +2524,8 @@ exports[`formatCurrencyUnit with custom options with locale pt-BR should correct
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Bitlayer unit (BTC) 1`] = `"0,012345678900000000- -BTC"`;
 
+exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Bittensor unit (TAO) 1`] = `"12.345.678,900000000- -TAO"`;
+
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Bittorent Chain unit (BTT) 1`] = `"0,012345678900000000- -BTT"`;
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Blast Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
@@ -2919,6 +2933,8 @@ exports[`formatCurrencyUnit with custom options with locale ru-RU should correct
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Bitcoin unit (bitcoin) 1`] = `"123 456 789,00000000- -BTC"`;
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Bitlayer unit (BTC) 1`] = `"0,012345678900000000- -BTC"`;
+
+exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Bittensor unit (TAO) 1`] = `"12 345 678,900000000- -TAO"`;
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Bittorent Chain unit (BTT) 1`] = `"0,012345678900000000- -BTT"`;
 
@@ -3328,6 +3344,8 @@ exports[`formatCurrencyUnit with custom options with locale tr-TR should correct
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Bitlayer unit (BTC) 1`] = `"0,012345678900000000- -BTC"`;
 
+exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Bittensor unit (TAO) 1`] = `"12.345.678,900000000- -TAO"`;
+
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Bittorent Chain unit (BTT) 1`] = `"0,012345678900000000- -BTT"`;
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Blast Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
@@ -3736,6 +3754,8 @@ exports[`formatCurrencyUnit with custom options with locale zh-CN should correct
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Bitlayer unit (BTC) 1`] = `"0.012345678900000000- -BTC"`;
 
+exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Bittensor unit (TAO) 1`] = `"12,345,678.900000000- -TAO"`;
+
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Bittorent Chain unit (BTT) 1`] = `"0.012345678900000000- -BTT"`;
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Blast Sepolia unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
@@ -4143,6 +4163,8 @@ exports[`formatCurrencyUnit with default options should correctly format Bitcoin
 exports[`formatCurrencyUnit with default options should correctly format Bitcoin unit (bitcoin) 1`] = `"123,456,789"`;
 
 exports[`formatCurrencyUnit with default options should correctly format Bitlayer unit (BTC) 1`] = `"0.0123456"`;
+
+exports[`formatCurrencyUnit with default options should correctly format Bittensor unit (TAO) 1`] = `"12,345,678"`;
 
 exports[`formatCurrencyUnit with default options should correctly format Bittorent Chain unit (BTT) 1`] = `"0.0123456"`;
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- **Impact of the changes:**
  - Adds Bittensor (TAO) to `cryptoassets.ts`. No changes to existing currencies.

### 📝 Description

Adds Bittensor (TAO) currency metadata to the cryptoassets library.

Key parameters:
- `id`: `bittensor`
- `family`: `polkadot` (reuses coin-polkadot module — no standalone coin-bittensor package)
- `ticker`: `TAO`
- `coinType`: 1005 (SLIP-44)
- `units`: TAO (magnitude 9), RAO (magnitude 0)
- `managerAppName`: `Polkadot`

### ❓ Context

- **JIRA**: [LIVE-30991](https://ledgerhq.atlassian.net/browse/LIVE-30991)

[LIVE-30991]: https://ledgerhq.atlassian.net/browse/LIVE-30991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ