### PR TITLE
[LWM] feat(mobile): show address count and clickable "See all" on Asset Detail

### DIFF
--- a/.changeset/afraid-walls-rest.md
+++ b/.changeset/afraid-walls-rest.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Display the addresses count next to the section title on Asset Detail and add a "See all" action when an asset has more than 5 accounts.

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
@@ -145,6 +145,13 @@ describe("AssetDetail screen layout", () => {
     expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.seeAllAddresses)).toBeNull();
   });
 
+  it("does not render the addresses count when 5 or fewer accounts exist", async () => {
+    render(<AssetDetailTestNavigator />, withBtcAccounts(5));
+
+    await waitFor(() => expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.addresses)).toBeVisible());
+    expect(screen.queryByText("(5)")).toBeNull();
+  });
+
   it("caps the addresses preview at 5 items and shows See all when 6+ accounts exist", async () => {
     render(<AssetDetailTestNavigator />, withBtcAccounts(6));
 
@@ -153,6 +160,14 @@ describe("AssetDetail screen layout", () => {
     );
     expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.addresses)).toBeVisible();
     expect(screen.getByText("See all")).toBeVisible();
+  });
+
+  it("renders the total addresses count next to the title when 6+ accounts exist", async () => {
+    render(<AssetDetailTestNavigator />, withBtcAccounts(8));
+
+    await waitFor(() => expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.addresses)).toBeVisible());
+    const header = screen.getByTestId(ASSET_DETAIL_TEST_IDS.addressesHeader);
+    expect(within(header).getByText("(8)")).toBeVisible();
   });
 
   it("hides the transactions section when there are no operations", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/AddressesView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/AddressesView.tsx
@@ -4,7 +4,9 @@ import {
   Button,
   Pressable,
   Subheader,
+  SubheaderCount,
   SubheaderRow,
+  SubheaderShowMore,
   SubheaderTitle,
   Text,
 } from "@ledgerhq/lumen-ui-rnative";
@@ -17,6 +19,7 @@ import { SectionSkeleton } from "../SectionSkeleton";
 
 type Props = Readonly<{
   displayedAccounts: readonly AddressAccountData[];
+  addressesCount: number;
   hasMore: boolean;
   hasData: boolean;
   onAddAccount: () => void;
@@ -27,6 +30,7 @@ type Props = Readonly<{
 
 export function AddressesView({
   displayedAccounts,
+  addressesCount,
   hasMore,
   hasData,
   onAddAccount,
@@ -46,7 +50,23 @@ export function AddressesView({
     <Box testID={ASSET_DETAIL_TEST_IDS.addresses}>
       <Subheader>
         <SubheaderRow lx={{ marginBottom: "s12" }}>
-          <SubheaderTitle>{t("assetDetail.addresses.title")}</SubheaderTitle>
+          <Pressable
+            lx={{ flexDirection: "row", alignItems: "center", flexShrink: 1 }}
+            onPress={onSeeAll}
+            disabled={!hasMore}
+            accessibilityRole={hasMore ? "button" : undefined}
+            testID={ASSET_DETAIL_TEST_IDS.addressesHeader}
+          >
+            <SubheaderTitle lx={hasMore ? { marginRight: "s4" } : undefined}>
+              {t("assetDetail.addresses.title")}
+            </SubheaderTitle>
+            {hasMore && (
+              <>
+                <SubheaderCount value={addressesCount} />
+                <SubheaderShowMore />
+              </>
+            )}
+          </Pressable>
           <Box lx={{ flex: 1 }} />
           <Pressable
             lx={{ flexDirection: "row", alignItems: "center", gap: "s8" }}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/__tests__/useAddressesViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/__tests__/useAddressesViewModel.test.ts
@@ -162,6 +162,26 @@ describe("useAddressesViewModel", () => {
       });
     });
 
+    describe("addressesCount", () => {
+      it("returns the total number of accounts (not capped by the preview)", () => {
+        const { btcAccounts, distributionItem } = buildBtcSetup(8);
+        const { result } = renderHook(
+          () => useAddressesViewModel(mockBtcCryptoCurrency, distributionItem),
+          withRawAccounts(btcAccounts),
+        );
+
+        expect(result.current.addressesCount).toBe(8);
+        expect(result.current.displayedAccounts).toHaveLength(5);
+      });
+
+      it("is 0 when distributionItem is undefined", () => {
+        const { result } = renderHook(() =>
+          useAddressesViewModel(mockBtcCryptoCurrency, undefined),
+        );
+        expect(result.current.addressesCount).toBe(0);
+      });
+    });
+
     describe("hasMore", () => {
       it("is false when there are fewer than 5 accounts", () => {
         const { btcAccounts, distributionItem } = buildBtcSetup(4);

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/useAddressesViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/useAddressesViewModel.ts
@@ -131,6 +131,7 @@ export function useAddressesViewModel(
 
   return {
     displayedAccounts,
+    addressesCount: accounts.length,
     hasMore,
     hasData: displayedAccounts.length > 0,
     onAddAccount,

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/testIds.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/testIds.ts
@@ -11,6 +11,7 @@ export const ASSET_DETAIL_TEST_IDS = {
   availableBalance: "asset-detail-available-balance",
   earnDeposit: "asset-detail-earn-deposit",
   addresses: "asset-detail-addresses",
+  addressesHeader: "asset-detail-addresses-header",
   addAccount: "asset-detail-add-account",
   seeAllAddresses: "asset-detail-see-all-addresses",
   marketStats: "asset-detail-market-stats",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Addresses section on the Asset Detail screen when an asset has more than 5 accounts (count badge `(N)` + chevron + "See all" button).
  - Cases with ≤5 accounts (no badge, no "See all" action).
  - "See all" navigation to the `CryptoAddresses` screen.
  - Analytics tracking for the `see_all_addresses` button.

### 📝 Description

Update the Addresses section title on the Asset Detail screen to display the number of accounts next to it, matching the Figma design.

When the asset has more than 5 accounts, the section header shows the total count and becomes clickable (chevron + dedicated "See all" CTA at the bottom of the section) so the user can navigate to the full list. Below or equal to 5 accounts, the header keeps the previous behavior with no count and no "See all" action.

<img width="350" height="750" alt="Simulator Screenshot - iOS Simulator - 2026-05-20 at 16 57 44" src="https://github.com/user-attachments/assets/34c76a3c-ee75-4caa-9478-efca62cd4e3a" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30951](https://ledgerhq.atlassian.net/browse/LIVE-30951)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30951]: https://ledgerhq.atlassian.net/browse/LIVE-30951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ