### PR TITLE
[LWM] feat(mobile): open addresses in a drawer from asset detail

### DIFF
--- a/.changeset/asset-detail-addresses-drawer.md
+++ b/.changeset/asset-detail-addresses-drawer.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Open the "See all" addresses entry from the Asset Detail screen in a bottom-sheet drawer instead of navigating to the CryptoAddresses screen. The portfolio-wide entry to the CryptoAddresses screen is unchanged.

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
@@ -142,7 +142,8 @@ describe("AssetDetail screen layout", () => {
     render(<AssetDetailTestNavigator />, withBtcAccounts(2));
 
     await waitFor(() => expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.addresses)).toBeVisible());
-    expect(screen.getByText("Addresses")).toBeVisible();
+    const section = screen.getByTestId(ASSET_DETAIL_TEST_IDS.addresses);
+    expect(within(section).getByText("Addresses")).toBeVisible();
     expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.addAccount)).toBeVisible();
     expect(screen.getByText("Add")).toBeVisible();
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/AddressesView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/AddressesView.tsx
@@ -14,6 +14,7 @@ import { PlusCircleFill } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { useTranslation } from "~/context/Locale";
 import { ASSET_DETAIL_TEST_IDS } from "LLM/features/AssetDetail/testIds";
 import { AddressAccountItem } from "./components/AddressAccountItem";
+import { AllAddressesDrawer } from "./components/AllAddressesDrawer";
 import type { AddressAccountData } from "./useAddressesViewModel";
 import { SectionSkeleton } from "../SectionSkeleton";
 
@@ -26,6 +27,9 @@ type Props = Readonly<{
   onSeeAll: () => void;
   onAccountPress: (data: AddressAccountData) => void;
   isLoading: boolean;
+  allAccountIds: string[];
+  isAllAddressesDrawerOpen: boolean;
+  closeAllAddressesDrawer: () => void;
 }>;
 
 export function AddressesView({
@@ -37,6 +41,9 @@ export function AddressesView({
   onSeeAll,
   onAccountPress,
   isLoading,
+  allAccountIds,
+  isAllAddressesDrawerOpen,
+  closeAllAddressesDrawer,
 }: Props) {
   const { t } = useTranslation();
 
@@ -47,56 +54,65 @@ export function AddressesView({
   if (!hasData) return null;
 
   return (
-    <Box testID={ASSET_DETAIL_TEST_IDS.addresses}>
-      <Subheader>
-        <SubheaderRow lx={{ marginBottom: "s12" }}>
-          <Pressable
-            lx={{ flexDirection: "row", alignItems: "center", flexShrink: 1 }}
+    <>
+      <Box testID={ASSET_DETAIL_TEST_IDS.addresses}>
+        <Subheader>
+          <SubheaderRow lx={{ marginBottom: "s12" }}>
+            <Pressable
+              lx={{ flexDirection: "row", alignItems: "center", flexShrink: 1 }}
+              onPress={onSeeAll}
+              disabled={!hasMore}
+              accessibilityRole={hasMore ? "button" : undefined}
+              testID={ASSET_DETAIL_TEST_IDS.addressesHeader}
+            >
+              <SubheaderTitle lx={hasMore ? { marginRight: "s4" } : undefined}>
+                {t("assetDetail.addresses.title")}
+              </SubheaderTitle>
+              {hasMore && (
+                <>
+                  <SubheaderCount value={addressesCount} />
+                  <SubheaderShowMore />
+                </>
+              )}
+            </Pressable>
+            <Box lx={{ flex: 1 }} />
+            <Pressable
+              lx={{ flexDirection: "row", alignItems: "center", gap: "s8" }}
+              onPress={onAddAccount}
+              testID={ASSET_DETAIL_TEST_IDS.addAccount}
+            >
+              <PlusCircleFill size={20} color="interactive" />
+              <Text typography="body2SemiBold" lx={{ color: "active" }}>
+                {t("assetDetail.addresses.addAccount")}
+              </Text>
+            </Pressable>
+          </SubheaderRow>
+        </Subheader>
+        <Box lx={{ gap: "s8" }}>
+          {displayedAccounts.map(data => (
+            <AddressAccountItem key={data.id} data={data} onPress={onAccountPress} />
+          ))}
+        </Box>
+        {hasMore && (
+          <Button
+            appearance="gray"
+            size="lg"
+            isFull
             onPress={onSeeAll}
-            disabled={!hasMore}
-            accessibilityRole={hasMore ? "button" : undefined}
-            testID={ASSET_DETAIL_TEST_IDS.addressesHeader}
+            testID={ASSET_DETAIL_TEST_IDS.seeAllAddresses}
+            lx={{ marginTop: "s12" }}
           >
-            <SubheaderTitle lx={hasMore ? { marginRight: "s4" } : undefined}>
-              {t("assetDetail.addresses.title")}
-            </SubheaderTitle>
-            {hasMore && (
-              <>
-                <SubheaderCount value={addressesCount} />
-                <SubheaderShowMore />
-              </>
-            )}
-          </Pressable>
-          <Box lx={{ flex: 1 }} />
-          <Pressable
-            lx={{ flexDirection: "row", alignItems: "center", gap: "s8" }}
-            onPress={onAddAccount}
-            testID={ASSET_DETAIL_TEST_IDS.addAccount}
-          >
-            <PlusCircleFill size={20} color="interactive" />
-            <Text typography="body2SemiBold" lx={{ color: "active" }}>
-              {t("assetDetail.addresses.addAccount")}
-            </Text>
-          </Pressable>
-        </SubheaderRow>
-      </Subheader>
-      <Box lx={{ gap: "s8" }}>
-        {displayedAccounts.map(data => (
-          <AddressAccountItem key={data.id} data={data} onPress={onAccountPress} />
-        ))}
+            {t("assetDetail.addresses.seeAll")}
+          </Button>
+        )}
       </Box>
       {hasMore && (
-        <Button
-          appearance="gray"
-          size="lg"
-          isFull
-          onPress={onSeeAll}
-          testID={ASSET_DETAIL_TEST_IDS.seeAllAddresses}
-          lx={{ marginTop: "s12" }}
-        >
-          {t("assetDetail.addresses.seeAll")}
-        </Button>
+        <AllAddressesDrawer
+          isOpen={isAllAddressesDrawerOpen}
+          onClose={closeAllAddressesDrawer}
+          accountIds={allAccountIds}
+        />
       )}
-    </Box>
+    </>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/__tests__/useAddressesViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/__tests__/useAddressesViewModel.test.ts
@@ -215,7 +215,7 @@ describe("useAddressesViewModel", () => {
     });
 
     describe("onSeeAll", () => {
-      it("navigates to the CryptoAddresses screen with the parent accountIds and fires analytics", () => {
+      it("opens the all addresses drawer and fires analytics", () => {
         const { btcAccounts, distributionItem } = buildBtcSetup(6);
 
         const { result } = renderHook(
@@ -223,19 +223,12 @@ describe("useAddressesViewModel", () => {
           withRawAccounts(btcAccounts),
         );
 
+        expect(result.current.isAllAddressesDrawerOpen).toBe(false);
+
         act(() => result.current.onSeeAll());
 
-        const expectedIds = btcAccounts.map(a => a.id);
-        expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Accounts, {
-          screen: ScreenName.CryptoAddresses,
-          params: {
-            sourceScreenName: ScreenName.AssetDetail,
-            accountIds: expect.arrayContaining(expectedIds),
-            hideAddAccount: true,
-          },
-        });
-        const navParams = mockNavigate.mock.calls[0][1].params;
-        expect(navParams.accountIds).toHaveLength(expectedIds.length);
+        expect(result.current.isAllAddressesDrawerOpen).toBe(true);
+        expect(mockNavigate).not.toHaveBeenCalled();
         expect(track).toHaveBeenCalledWith("button_clicked", {
           button: "see_all_addresses",
           currency: "bitcoin",
@@ -243,7 +236,20 @@ describe("useAddressesViewModel", () => {
         });
       });
 
-      it("passes deduplicated parent ids for multi-network tokens", () => {
+      it("exposes the parent accountIds for the drawer", () => {
+        const { btcAccounts, distributionItem } = buildBtcSetup(6);
+
+        const { result } = renderHook(
+          () => useAddressesViewModel(mockBtcCryptoCurrency, distributionItem),
+          withRawAccounts(btcAccounts),
+        );
+
+        const expectedIds = btcAccounts.map(a => a.id);
+        expect(result.current.allAccountIds).toEqual(expect.arrayContaining(expectedIds));
+        expect(result.current.allAccountIds).toHaveLength(expectedIds.length);
+      });
+
+      it("exposes deduplicated parent accountIds for multi-network tokens", () => {
         const ethAccount = genAccount("usdt-eth", {
           currency: mockEthCryptoCurrency,
           operationsSize: 0,
@@ -269,13 +275,10 @@ describe("useAddressesViewModel", () => {
           withRawAccounts([ethAccount, algoAccount]),
         );
 
-        act(() => result.current.onSeeAll());
-
-        const navParams = mockNavigate.mock.calls[0][1].params;
-        expect(navParams.accountIds).toEqual(
+        expect(result.current.allAccountIds).toEqual(
           expect.arrayContaining([ethAccount.id, algoAccount.id]),
         );
-        expect(navParams.accountIds).toHaveLength(2);
+        expect(result.current.allAccountIds).toHaveLength(2);
       });
 
       it("does nothing when currency is undefined", () => {
@@ -283,8 +286,26 @@ describe("useAddressesViewModel", () => {
 
         act(() => result.current.onSeeAll());
 
+        expect(result.current.isAllAddressesDrawerOpen).toBe(false);
         expect(mockNavigate).not.toHaveBeenCalled();
         expect(track).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("closeAllAddressesDrawer", () => {
+      it("closes the all addresses drawer", () => {
+        const { btcAccounts, distributionItem } = buildBtcSetup(6);
+
+        const { result } = renderHook(
+          () => useAddressesViewModel(mockBtcCryptoCurrency, distributionItem),
+          withRawAccounts(btcAccounts),
+        );
+
+        act(() => result.current.onSeeAll());
+        expect(result.current.isAllAddressesDrawerOpen).toBe(true);
+
+        act(() => result.current.closeAllAddressesDrawer());
+        expect(result.current.isAllAddressesDrawerOpen).toBe(false);
       });
     });
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/components/AllAddressesDrawer.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/components/AllAddressesDrawer.tsx
@@ -1,0 +1,78 @@
+import React, { useCallback, useMemo } from "react";
+import { ListRenderItemInfo } from "react-native";
+import BigNumber from "bignumber.js";
+import { Account } from "@ledgerhq/types-live";
+import { BottomSheetFlatList, BottomSheetHeader } from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
+import CryptoAddressesListItem from "LLM/features/CryptoAddresses/screens/CryptoAddressesScreen/components/CryptoAddressesListItem";
+import useCryptoAddressesViewModel from "LLM/features/CryptoAddresses/screens/CryptoAddressesScreen/useCryptoAddressesViewModel";
+import { ScreenName } from "~/const";
+import { useTranslation } from "~/context/Locale";
+import { ASSET_DETAIL_TEST_IDS } from "LLM/features/AssetDetail/testIds";
+
+type Props = Readonly<{
+  isOpen: boolean;
+  onClose: () => void;
+  accountIds: string[];
+}>;
+
+export function AllAddressesDrawer({ isOpen, onClose, accountIds }: Props) {
+  const { t } = useTranslation();
+  const { accounts, aggregatedAccountsData, onAccountPress } = useCryptoAddressesViewModel(
+    ScreenName.AssetDetail,
+    accountIds,
+    true,
+  );
+
+  const handleAccountPress = useCallback(
+    (account: Account) => {
+      onClose();
+      onAccountPress(account);
+    },
+    [onClose, onAccountPress],
+  );
+
+  const renderItem = useCallback(
+    ({ item }: ListRenderItemInfo<Account>) => {
+      const data = aggregatedAccountsData.get(item.id);
+      return (
+        <CryptoAddressesListItem
+          account={item}
+          aggregatedCountervalue={data?.countervalue ?? new BigNumber(0)}
+          subAccountsCount={data?.subAccountsCount ?? 0}
+          onPress={handleAccountPress}
+          lx={LIST_ITEM_NEGATIVE_OFFSET}
+        />
+      );
+    },
+    [aggregatedAccountsData, handleAccountPress],
+  );
+
+  const keyExtractor = useCallback((item: Account) => item.id, []);
+
+  const headerTitle = useMemo(() => t("assetDetail.addresses.title"), [t]);
+
+  return (
+    <QueuedDrawerBottomSheet
+      testID={ASSET_DETAIL_TEST_IDS.allAddressesDrawer}
+      isRequestingToBeOpened={isOpen}
+      onClose={onClose}
+    >
+      <BottomSheetHeader spacing density="expanded" title={headerTitle} />
+      <BottomSheetFlatList
+        data={accounts}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        showsVerticalScrollIndicator={false}
+      />
+    </QueuedDrawerBottomSheet>
+  );
+}
+
+/**
+ * Cancels half of the `BottomSheetFlatList` default `paddingHorizontal: s16`
+ * so list items end up indented by `s8` from the drawer edge, matching the
+ * CryptoAddresses page rendered in the Portfolio context.
+ */
+const LIST_ITEM_NEGATIVE_OFFSET: LumenViewStyle = { marginHorizontal: "-s8" };

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/useAddressesViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/useAddressesViewModel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useNavigation } from "@react-navigation/native";
 import type { AssetDetailCurrencyProps } from "LLM/features/AssetDetail/types";
 import type { Account, AccountLike, DistributionItem } from "@ledgerhq/types-live";
@@ -69,6 +69,10 @@ export function useAddressesViewModel(
     [accounts],
   );
 
+  const [isAllAddressesDrawerOpen, setIsAllAddressesDrawerOpen] = useState(false);
+
+  const closeAllAddressesDrawer = useCallback(() => setIsAllAddressesDrawerOpen(false), []);
+
   const onAddAccount = useCallback(() => {
     if (!currency) return;
     track("button_clicked", {
@@ -93,15 +97,8 @@ export function useAddressesViewModel(
       currency: currency.id,
       page: "Asset Detail",
     });
-    navigation.navigate(NavigatorName.Accounts, {
-      screen: ScreenName.CryptoAddresses,
-      params: {
-        sourceScreenName: ScreenName.AssetDetail,
-        accountIds: allAccountIds,
-        hideAddAccount: true,
-      },
-    });
-  }, [navigation, currency, allAccountIds]);
+    setIsAllAddressesDrawerOpen(true);
+  }, [currency]);
 
   const onAccountPress = useCallback(
     (data: AddressAccountData) => {
@@ -137,5 +134,8 @@ export function useAddressesViewModel(
     onAddAccount,
     onSeeAll,
     onAccountPress,
+    allAccountIds,
+    isAllAddressesDrawerOpen,
+    closeAllAddressesDrawer,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/testIds.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/testIds.ts
@@ -14,6 +14,7 @@ export const ASSET_DETAIL_TEST_IDS = {
   addressesHeader: "asset-detail-addresses-header",
   addAccount: "asset-detail-add-account",
   seeAllAddresses: "asset-detail-see-all-addresses",
+  allAddressesDrawer: "asset-detail-all-addresses-drawer",
   marketStats: "asset-detail-market-stats",
   pricePerformance: "asset-detail-price-performance",
   transactions: "asset-detail-transactions",

--- a/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/components/CryptoAddressesListItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/components/CryptoAddressesListItem.tsx
@@ -7,6 +7,7 @@ import {
   ListItemTitle,
   ListItemDescription,
 } from "@ledgerhq/lumen-ui-rnative";
+import { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import BigNumber from "bignumber.js";
 import { useSelector } from "~/context/hooks";
@@ -23,6 +24,7 @@ type Props = Readonly<{
   aggregatedCountervalue: BigNumber;
   subAccountsCount: number;
   onPress: (account: Account) => void;
+  lx?: LumenViewStyle;
 }>;
 
 export default function CryptoAddressesListItem({
@@ -30,6 +32,7 @@ export default function CryptoAddressesListItem({
   aggregatedCountervalue,
   subAccountsCount,
   onPress,
+  lx,
 }: Props) {
   const { t } = useTranslation();
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
@@ -47,7 +50,7 @@ export default function CryptoAddressesListItem({
   const displayedAssetsCount = subAccountsCount + 1;
 
   return (
-    <ListItem onPress={handlePress}>
+    <ListItem onPress={handlePress} lx={lx}>
       <AccountItem
         account={account}
         balance={account.balance}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Asset Detail screen: clicking the "See all" button or the "Addresses (N)" title now opens a bottom-sheet drawer instead of navigating to the CryptoAddresses page.
  - Drawer content: lists all parent accounts for the current asset with their aggregated countervalue (same rows as the CryptoAddresses page).
  - Tapping an address inside the drawer closes it and navigates to the Account screen (unchanged destination).
  - The portfolio-wide entry to the CryptoAddresses page (from the Portfolio assets section) is **unchanged**.

### 📝 Description

When users are on the Asset Detail screen and have 5+ accounts for a given asset, clicking "See all" (or the "Addresses (N)" title) used to push a full CryptoAddresses screen. The desired UX is to keep the user in context by opening a modal instead.

This PR introduces a new `AllAddressesDrawer` component built on top of `QueuedDrawerBottomSheet` + `BottomSheetFlatList`. It reuses the existing `useCryptoAddressesViewModel` and `CryptoAddressesListItem` so the row UI, balances and account-press navigation stay strictly consistent with the dedicated page. Only the entry point from Asset Detail is rerouted; all other entry points (Portfolio assets section, deeplinks, etc.) continue to navigate to the page.

`CryptoAddressesListItem` now accepts an optional `lx` prop (forwarded to the underlying lumen `ListItem`) so the drawer can pass `marginHorizontal: "-s8"` to offset the `BottomSheetFlatList` default padding and match the portfolio alignment.

<img width="420" height="919" alt="exemple list" src="https://github.com/user-attachments/assets/805894c3-3eb2-452e-897e-8571cc9516c4" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31037](https://ledgerhq.atlassian.net/browse/LIVE-31037)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31037]: https://ledgerhq.atlassian.net/browse/LIVE-31037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ