### PR TITLE
[LWM] fix(mobile): force hide on portfolio page

### DIFF
--- a/.changeset/quiet-llamas-vanish.md
+++ b/.changeset/quiet-llamas-vanish.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix "Hide from portfolio" not hiding parent CryptoCurrencies (e.g. Ethereum) in the new portfolio asset lists

--- a/apps/ledger-live-mobile/src/mvvm/features/Assets/__integrations__/assetShortListView.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Assets/__integrations__/assetShortListView.integration.test.tsx
@@ -114,28 +114,26 @@ describe("AssetShortListView", () => {
   });
 
   describe("blacklisted tokens", () => {
-     const mockStateWithBlacklistedToken = (state: State): State => {
-         const mockEthAccountWithUSDC = createMockEthAccountWithUSDC();
-          return {
-            ...state,
-            accounts: { ...state.accounts, active: [mockEthAccountWithUSDC] },
-            settings: { ...state.settings, counterValue: "USD", blacklistedTokenIds: [usdcToken.id] },
-          };
-        }
-        const mockStateWithNonBlacklistedToken = (state: State): State => {
-         const mockEthAccountWithUSDC = createMockEthAccountWithUSDC();
-          return {
-            ...state,
-            accounts: { ...state.accounts, active: [mockEthAccountWithUSDC] },
-            settings: { ...state.settings, counterValue: "USD", blacklistedTokenIds: [] },
-          };
-        }
-    
+    const mockStateWithBlacklistedToken = (state: State): State => {
+      const mockEthAccountWithUSDC = createMockEthAccountWithUSDC();
+      return {
+        ...state,
+        accounts: { ...state.accounts, active: [mockEthAccountWithUSDC] },
+        settings: { ...state.settings, counterValue: "USD", blacklistedTokenIds: [usdcToken.id] },
+      };
+    };
+    const mockStateWithNonBlacklistedToken = (state: State): State => {
+      const mockEthAccountWithUSDC = createMockEthAccountWithUSDC();
+      return {
+        ...state,
+        accounts: { ...state.accounts, active: [mockEthAccountWithUSDC] },
+        settings: { ...state.settings, counterValue: "USD", blacklistedTokenIds: [] },
+      };
+    };
 
     beforeEach(() => {
       jest.clearAllMocks();
     });
-
 
     it("should display a token that is not blacklisted", () => {
       renderComponent({}, mockStateWithNonBlacklistedToken);
@@ -145,6 +143,20 @@ describe("AssetShortListView", () => {
     it("should not display a blacklisted token", () => {
       renderComponent({}, mockStateWithBlacklistedToken);
       expect(screen.queryByText(usdcToken.name)).toBeNull();
+    });
+
+    it("should not display a blacklisted parent CryptoCurrency", () => {
+      const mockStateWithBlacklistedEthereum = (state: State): State => {
+        const mockEthAccountWithUSDC = createMockEthAccountWithUSDC();
+        return {
+          ...state,
+          accounts: { ...state.accounts, active: [mockEthAccountWithUSDC] },
+          settings: { ...state.settings, counterValue: "USD", blacklistedTokenIds: ["ethereum"] },
+        };
+      };
+
+      renderComponent({}, mockStateWithBlacklistedEthereum);
+      expect(screen.queryByTestId("assetItem-Ethereum-name")).toBeNull();
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Assets/hooks/useAssetsListViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Assets/hooks/useAssetsListViewModel.ts
@@ -4,6 +4,8 @@ import { useFocusEffect, useNavigation } from "@react-navigation/native";
 import { GestureResponderEvent } from "react-native";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import { useNonBlacklistedDistribution } from "~/hooks/useNonBlacklistedDistribution";
+import { useSelector } from "~/context/hooks";
+import { blacklistedTokenIdsSelector } from "~/reducers/settings";
 import { useRefreshAccountsOrdering } from "~/actions/general";
 import { NavigatorName, ScreenName } from "~/const";
 import { Asset } from "~/types/asset";
@@ -42,12 +44,18 @@ const useAssetsListViewModel = ({
     groupBy: shouldDisplayAggregatedAssets ? "asset" : undefined,
   });
 
+  const blacklistedTokenIds = useSelector(blacklistedTokenIdsSelector);
+  const blacklistedTokenIdsSet = useMemo(() => new Set(blacklistedTokenIds), [blacklistedTokenIds]);
+
   const refreshAccountsOrdering = useRefreshAccountsOrdering();
   useFocusEffect(refreshAccountsOrdering);
 
   const assetsToDisplay = useMemo(
-    () => filteredDistribution.slice(0, limitNumberOfAssets),
-    [filteredDistribution, limitNumberOfAssets],
+    () =>
+      filteredDistribution
+        .filter(({ currency }) => !blacklistedTokenIdsSet.has(currency.id))
+        .slice(0, limitNumberOfAssets),
+    [filteredDistribution, blacklistedTokenIdsSet, limitNumberOfAssets],
   );
 
   const onItemPress = useCallback(

--- a/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/__tests__/useCryptoViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/__tests__/useCryptoViewModel.test.ts
@@ -1,7 +1,6 @@
 import { act } from "@testing-library/react-native";
 import { renderHook } from "@tests/test-renderer";
 import { NavigatorName, ScreenName } from "~/const";
-import { State } from "~/reducers/types";
 import { Asset } from "~/types/asset";
 import { track } from "~/analytics";
 import useCryptoViewModel from "../useCryptoViewModel";
@@ -24,13 +23,6 @@ jest.mock("~/actions/general", () => ({
   ...jest.requireActual("~/actions/general"),
   useRefreshAccountsOrdering: () => jest.fn(),
 }));
-
-const withBlacklistedTokens =
-  (tokenIds: string[]) =>
-  (state: State): State => ({
-    ...state,
-    settings: { ...state.settings, blacklistedTokenIds: tokenIds },
-  });
 
 const makeCurrency = (name: string, id: string, type = "CryptoCurrency") =>
   ({
@@ -131,42 +123,6 @@ describe("useCryptoViewModel", () => {
 
       expect(result.current.assetsToDisplay).toHaveLength(1);
       expect(result.current.assetsToDisplay[0].currency.name).toBe("Tether");
-    });
-  });
-
-  describe("blacklist filtering", () => {
-    it("should filter out blacklisted token assets", () => {
-      const btcItem = makeCategorizedItem("Bitcoin", "bitcoin");
-      const tokenItem = makeCategorizedItem("USDT", "usdt-token", "TokenCurrency");
-
-      mockCategorizedAssets.mockReturnValue({
-        ...emptyCategorizedAssets(),
-        categorizedAssets: { cryptos: [btcItem], stablecoins: [tokenItem] },
-      });
-
-      const { result } = renderHook(
-        () => useCryptoViewModel({ sourceScreenName: ScreenName.Portfolio }),
-        { overrideInitialState: withBlacklistedTokens(["usdt-token"]) },
-      );
-
-      expect(result.current.assetsToDisplay).toHaveLength(1);
-      expect(result.current.assetsToDisplay[0].currency.name).toBe("Bitcoin");
-    });
-
-    it("should keep non-blacklisted tokens", () => {
-      const tokenItem = makeCategorizedItem("USDC", "usdc-token", "TokenCurrency");
-
-      mockCategorizedAssets.mockReturnValue({
-        ...emptyCategorizedAssets(),
-        categorizedAssets: { cryptos: [], stablecoins: [tokenItem] },
-      });
-
-      const { result } = renderHook(
-        () => useCryptoViewModel({ sourceScreenName: ScreenName.Portfolio }),
-        { overrideInitialState: withBlacklistedTokens(["other-token"]) },
-      );
-
-      expect(result.current.assetsToDisplay).toHaveLength(1);
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/useCryptoViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/useCryptoViewModel.ts
@@ -1,9 +1,7 @@
 import { useCallback, useMemo } from "react";
 import { useFocusEffect, useNavigation } from "@react-navigation/native";
-import { useSelector } from "~/context/hooks";
 import { useRefreshAccountsOrdering } from "~/actions/general";
 import { NavigatorName, ScreenName } from "~/const";
-import { blacklistedTokenIdsSelector } from "~/reducers/settings";
 import { Asset } from "~/types/asset";
 import { track } from "~/analytics";
 import { useTranslation } from "~/context/Locale";
@@ -39,9 +37,6 @@ const useCryptoViewModel = ({
   const { t } = useTranslation();
   const navigation = useNavigation<NavigationProp>();
 
-  const blacklistedTokenIds = useSelector(blacklistedTokenIdsSelector);
-  const blacklistedTokenIdsSet = useMemo(() => new Set(blacklistedTokenIds), [blacklistedTokenIds]);
-
   const { categorizedAssets, isLoadingStablecoinTickers, isStablecoinTickersError } =
     useCategorizedAssetsFromPortfolio();
 
@@ -50,16 +45,10 @@ const useCryptoViewModel = ({
 
   const resolvedVariant: CryptoVariant = variant ?? "all";
 
-  const assetsToDisplay = useMemo((): Asset[] => {
-    const list = selectAssetList(categorizedAssets, resolvedVariant);
-
-    return list
-      .filter(
-        ({ currency }) =>
-          currency.type !== "TokenCurrency" || !blacklistedTokenIdsSet.has(currency.id),
-      )
-      .map(toAsset);
-  }, [categorizedAssets, resolvedVariant, blacklistedTokenIdsSet]);
+  const assetsToDisplay = useMemo(
+    (): Asset[] => selectAssetList(categorizedAssets, resolvedVariant).map(toAsset),
+    [categorizedAssets, resolvedVariant],
+  );
 
   const onItemPress = useCallback(
     (asset: Asset) => {

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/hooks/useWalletAssetsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/hooks/useWalletAssetsViewModel.ts
@@ -1,7 +1,5 @@
 import { useMemo } from "react";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
-import { useSelector } from "~/context/hooks";
-import { blacklistedTokenIdsSelector } from "~/reducers/settings";
 import useDynamicContent from "~/dynamicContent/useDynamicContent";
 import { useCategorizedAssetsFromPortfolio } from "LLM/hooks/useCategorizedAssetsFromPortfolio";
 import {
@@ -21,24 +19,15 @@ export function useWalletAssetsViewModel(): WalletAssetsViewModelResult {
   const { onPressShowAll } = usePortfolioSectionActions(false, "all");
   const { categorizedAssets } = useCategorizedAssetsFromPortfolio();
   const { walletCardsDisplayed } = useDynamicContent();
-  const {
-    shouldDisplayOperationsList,
-    shouldDisplayAssetSection,
-    shouldDisplayGraphRework,
-  } = useWalletFeaturesConfig("mobile");
+  const { shouldDisplayOperationsList, shouldDisplayAssetSection, shouldDisplayGraphRework } =
+    useWalletFeaturesConfig("mobile");
 
-  const blacklistedTokenIds = useSelector(blacklistedTokenIdsSelector);
-  const blacklistedTokenIdsSet = useMemo(() => new Set(blacklistedTokenIds), [blacklistedTokenIds]);
-
-  const hasMore = useMemo(() => {
-    const isVisible = ({ currency }: { currency: { type: string; id: string } }) =>
-      currency.type !== "TokenCurrency" || !blacklistedTokenIdsSet.has(currency.id);
-
-    const cryptosCount = categorizedAssets.cryptos.filter(isVisible).length;
-    const stablecoinsCount = categorizedAssets.stablecoins.filter(isVisible).length;
-
-    return cryptosCount > MAX_ASSETS_TO_DISPLAY || stablecoinsCount > MAX_STABLECOINS_TO_DISPLAY;
-  }, [categorizedAssets, blacklistedTokenIdsSet]);
+  const hasMore = useMemo(
+    () =>
+      categorizedAssets.cryptos.length > MAX_ASSETS_TO_DISPLAY ||
+      categorizedAssets.stablecoins.length > MAX_STABLECOINS_TO_DISPLAY,
+    [categorizedAssets],
+  );
 
   // Tx History in header: extra space under the last block — Accounts when carousel is absent and
   // nothing is rendered below (no allocations row when graph rework is off).
@@ -46,9 +35,7 @@ export function useWalletAssetsViewModel(): WalletAssetsViewModelResult {
     hasMore,
     onPressShowAll,
     shouldAddBottomPadding:
-      shouldDisplayOperationsList &&
-      walletCardsDisplayed.length === 0 &&
-      shouldDisplayGraphRework,
+      shouldDisplayOperationsList && walletCardsDisplayed.length === 0 && shouldDisplayGraphRework,
     shouldDisplayAssetSection,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/CryptosSection/usePortfolioCryptosSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/CryptosSection/usePortfolioCryptosSectionViewModel.ts
@@ -1,6 +1,4 @@
 import { useMemo } from "react";
-import { useSelector } from "~/context/hooks";
-import { blacklistedTokenIdsSelector } from "~/reducers/settings";
 import { Asset } from "~/types/asset";
 import { useDefaultAssetsByCategory } from "LLM/hooks/useDefaultAssetsByCategory";
 import { useReadOnlyCoins } from "~/hooks/useReadOnlyCoins";
@@ -40,20 +38,11 @@ const usePortfolioCryptosSectionViewModel = ({
   const isLimitedView = isEmptyState || (isReadOnly && shouldDisplayAssetSection);
   const isLegacyReadOnly = isReadOnly && !shouldDisplayAssetSection;
 
-  const blacklistedTokenIds = useSelector(blacklistedTokenIdsSelector);
-  const blacklistedTokenIdsSet = useMemo(() => new Set(blacklistedTokenIds), [blacklistedTokenIds]);
-
   const { categorizedAssets, stablecoinTickers } = useCategorizedAssetsFromPortfolio();
 
   const filteredAssets = useMemo(
-    () =>
-      categorizedAssets.cryptos
-        .filter(
-          ({ currency }) =>
-            currency.type !== "TokenCurrency" || !blacklistedTokenIdsSet.has(currency.id),
-        )
-        .map(toAsset),
-    [categorizedAssets.cryptos, blacklistedTokenIdsSet],
+    () => categorizedAssets.cryptos.map(toAsset),
+    [categorizedAssets.cryptos],
   );
 
   const needsDefaultAssets = isLimitedView || filteredAssets.length < EMPTY_STATE_MAX_ASSETS;

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StablecoinsSection/usePortfolioStablecoinsSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StablecoinsSection/usePortfolioStablecoinsSectionViewModel.ts
@@ -1,6 +1,4 @@
 import { useMemo } from "react";
-import { useSelector } from "~/context/hooks";
-import { blacklistedTokenIdsSelector } from "~/reducers/settings";
 import { Asset } from "~/types/asset";
 import { useDefaultAssetsByCategory } from "LLM/hooks/useDefaultAssetsByCategory";
 import { useCategorizedAssetsFromPortfolio } from "LLM/hooks/useCategorizedAssetsFromPortfolio";
@@ -33,20 +31,11 @@ const usePortfolioStablecoinsSectionViewModel = ({
   const isReadOnly = variant === "readOnly";
   const { onPressShowAll, onItemPress } = usePortfolioSectionActions(isReadOnly, "stablecoin");
 
-  const blacklistedTokenIds = useSelector(blacklistedTokenIdsSelector);
-  const blacklistedTokenIdsSet = useMemo(() => new Set(blacklistedTokenIds), [blacklistedTokenIds]);
-
   const { categorizedAssets, stablecoinTickers } = useCategorizedAssetsFromPortfolio();
 
   const filteredStablecoins = useMemo(
-    () =>
-      categorizedAssets.stablecoins
-        .filter(
-          ({ currency }) =>
-            currency.type !== "TokenCurrency" || !blacklistedTokenIdsSet.has(currency.id),
-        )
-        .map(toAsset),
-    [categorizedAssets.stablecoins, blacklistedTokenIdsSet],
+    () => categorizedAssets.stablecoins.map(toAsset),
+    [categorizedAssets.stablecoins],
   );
 
   const needsPadding = isLimitedView || filteredStablecoins.length < EMPTY_STATE_MAX_STABLECOINS;

--- a/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useCategorizedAssetsFromPortfolio.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useCategorizedAssetsFromPortfolio.test.ts
@@ -1,0 +1,109 @@
+import { renderHook } from "@tests/test-renderer";
+import { useCategorizedAssetsFromPortfolio } from "LLM/hooks/useCategorizedAssetsFromPortfolio";
+import { State } from "~/reducers/types";
+
+const mockUseCategorizedAssets = jest.fn();
+const mockUseDistribution = jest.fn();
+const mockUseStablecoinTickers = jest.fn();
+
+jest.mock("@ledgerhq/asset-aggregation/assetCategorization/index", () => ({
+  useCategorizedAssets: (...args: unknown[]) => mockUseCategorizedAssets(...args),
+}));
+
+jest.mock("~/actions/general", () => ({
+  ...jest.requireActual("~/actions/general"),
+  useDistribution: (...args: unknown[]) => mockUseDistribution(...args),
+}));
+
+jest.mock("@ledgerhq/live-common/dada-client/hooks/useStablecoinTickers", () => ({
+  useStablecoinTickers: (...args: unknown[]) => mockUseStablecoinTickers(...args),
+}));
+
+const withBlacklistedTokens =
+  (tokenIds: string[]) =>
+  (state: State): State => ({
+    ...state,
+    settings: { ...state.settings, blacklistedTokenIds: tokenIds },
+  });
+
+const makeItem = (name: string, id: string, type: "CryptoCurrency" | "TokenCurrency") => ({
+  currency: { id, name, type, ticker: id.toUpperCase() },
+  balance: 100,
+  value: 100,
+  distribution: 0.5,
+  accounts: [],
+});
+
+describe("useCategorizedAssetsFromPortfolio", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseDistribution.mockReturnValue({ isAvailable: true, list: [], isLoading: false });
+    mockUseStablecoinTickers.mockReturnValue({
+      tickers: new Set<string>(),
+      isLoading: false,
+      isError: false,
+    });
+    mockUseCategorizedAssets.mockReturnValue({ cryptos: [], stablecoins: [] });
+  });
+
+  describe("blacklist filtering", () => {
+    it("removes blacklisted CryptoCurrency parents from cryptos", () => {
+      const btc = makeItem("Bitcoin", "bitcoin", "CryptoCurrency");
+      const eth = makeItem("Ethereum", "ethereum", "CryptoCurrency");
+      mockUseCategorizedAssets.mockReturnValue({ cryptos: [btc, eth], stablecoins: [] });
+
+      const { result } = renderHook(() => useCategorizedAssetsFromPortfolio(), {
+        overrideInitialState: withBlacklistedTokens(["ethereum"]),
+      });
+
+      expect(result.current.categorizedAssets.cryptos).toHaveLength(1);
+      expect(result.current.categorizedAssets.cryptos[0].currency.id).toBe("bitcoin");
+    });
+
+    it("removes blacklisted TokenCurrency entries from stablecoins", () => {
+      const usdc = makeItem("USDC", "usdc-token", "TokenCurrency");
+      const usdt = makeItem("USDT", "usdt-token", "TokenCurrency");
+      mockUseCategorizedAssets.mockReturnValue({ cryptos: [], stablecoins: [usdc, usdt] });
+
+      const { result } = renderHook(() => useCategorizedAssetsFromPortfolio(), {
+        overrideInitialState: withBlacklistedTokens(["usdc-token"]),
+      });
+
+      expect(result.current.categorizedAssets.stablecoins).toHaveLength(1);
+      expect(result.current.categorizedAssets.stablecoins[0].currency.id).toBe("usdt-token");
+    });
+
+    it("returns the original list unchanged when no token is blacklisted", () => {
+      const btc = makeItem("Bitcoin", "bitcoin", "CryptoCurrency");
+      const usdc = makeItem("USDC", "usdc-token", "TokenCurrency");
+      const source = { cryptos: [btc], stablecoins: [usdc] };
+      mockUseCategorizedAssets.mockReturnValue(source);
+
+      const { result } = renderHook(() => useCategorizedAssetsFromPortfolio());
+
+      expect(result.current.categorizedAssets).toBe(source);
+    });
+  });
+
+  describe("loading state", () => {
+    it("reports loading when distribution is loading", () => {
+      mockUseDistribution.mockReturnValue({ isAvailable: true, list: [], isLoading: true });
+
+      const { result } = renderHook(() => useCategorizedAssetsFromPortfolio());
+
+      expect(result.current.isLoadingStablecoinTickers).toBe(true);
+    });
+
+    it("reports loading when stablecoin tickers are loading", () => {
+      mockUseStablecoinTickers.mockReturnValue({
+        tickers: new Set<string>(),
+        isLoading: true,
+        isError: false,
+      });
+
+      const { result } = renderHook(() => useCategorizedAssetsFromPortfolio());
+
+      expect(result.current.isLoadingStablecoinTickers).toBe(true);
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/hooks/useCategorizedAssetsFromPortfolio.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/useCategorizedAssetsFromPortfolio.ts
@@ -1,9 +1,12 @@
+import { useMemo } from "react";
 import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import { useStablecoinTickers } from "@ledgerhq/live-common/dada-client/hooks/useStablecoinTickers";
 import { useCategorizedAssets } from "@ledgerhq/asset-aggregation/assetCategorization/index";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/walletFeaturesConfig/index";
 import VersionNumber from "react-native-version-number";
 import { useDistribution } from "~/actions/general";
+import { useSelector } from "~/context/hooks";
+import { blacklistedTokenIdsSelector } from "~/reducers/settings";
 
 export function useCategorizedAssetsFromPortfolio() {
   const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("mobile");
@@ -23,8 +26,24 @@ export function useCategorizedAssetsFromPortfolio() {
 
   const categorizedAssets = useCategorizedAssets(distribution, stablecoinTickers);
 
+  const blacklistedTokenIds = useSelector(blacklistedTokenIdsSelector);
+  const blacklistedTokenIdsSet = useMemo(() => new Set(blacklistedTokenIds), [blacklistedTokenIds]);
+
+  // Exclude blacklisted assets so all portfolio-derived views share the same filtering rule.
+  const filteredCategorizedAssets = useMemo(() => {
+    if (blacklistedTokenIdsSet.size === 0) return categorizedAssets;
+    return {
+      cryptos: categorizedAssets.cryptos.filter(
+        ({ currency }) => !blacklistedTokenIdsSet.has(currency.id),
+      ),
+      stablecoins: categorizedAssets.stablecoins.filter(
+        ({ currency }) => !blacklistedTokenIdsSet.has(currency.id),
+      ),
+    };
+  }, [categorizedAssets, blacklistedTokenIdsSet]);
+
   return {
-    categorizedAssets,
+    categorizedAssets: filteredCategorizedAssets,
     isLoadingStablecoinTickers: isLoadingStablecoinTickers || distribution.isLoading,
     isStablecoinTickersError,
     stablecoinTickers,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Verify "Hide from portfolio" on Asset Detail (e.g. Ethereum) now removes the parent crypto from the new portfolio asset list (Crypto and Stablecoins sections, "Show All" screen, and the Assets short list view).
  - Verify "Show in portfolio" restores it.
  - Verify hiding a token (e.g. USDT) still works as before.
  - Verify the legacy (non-MVVM) portfolio path is unchanged: the shared hook `useNonBlacklistedDistribution` and the legacy screens (`screens/Portfolio/PortfolioAssets.tsx`, `screens/Assets/index.tsx`) were intentionally not modified to avoid regressions on the legacy flow that is still controlled by feature flags.

### 📝 Description

When a user tapped "Hide from portfolio" on a parent `CryptoCurrency` (e.g. Ethereum) from the Asset Detail screen, the action correctly dispatched `blacklistToken(currency.id)` and Redux state was updated, but the asset stayed visible on the portfolio. This was not a refresh problem — the filters on the portfolio asset lists only excluded entries of type `TokenCurrency`:

```ts
currency.type !== "TokenCurrency" || !blacklistedTokenIdsSet.has(currency.id)
```

For a `CryptoCurrency`, the `||` short-circuits to `true`, so the parent crypto was never filtered out.

The fix replaces the predicate by a uniform check on the `currency.id` regardless of type, applied locally to the new MVVM portfolio view models only:

- `usePortfolioCryptosSectionViewModel.ts`
- `usePortfolioStablecoinsSectionViewModel.ts`
- `useWalletAssetsViewModel.ts` (drives the "See all" button via `hasMore`)
- `useCryptoViewModel.ts` (full "Show All" list)
- `useAssetsListViewModel.ts` (additional local filter on top of `useNonBlacklistedDistribution`, so the shared hook used by legacy code is not changed)

The legacy (non-MVVM) code paths and the shared `useNonBlacklistedDistribution` hook are intentionally left unchanged so the feature-flagged legacy portfolio is not impacted.

#### Before / After

| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31035](https://ledgerhq.atlassian.net/browse/LIVE-31035)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31035]: https://ledgerhq.atlassian.net/browse/LIVE-31035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ