### PR TITLE
[LWDM] test(e2e): use provider catalog versions for speculos dependencies

### DIFF
--- a/.changeset/fuzzy-sui-apps.md
+++ b/.changeset/fuzzy-sui-apps.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Use provider catalog versions for Speculos dependency apps

--- a/libs/ledger-live-common/src/e2e/speculos.ts
+++ b/libs/ledger-live-common/src/e2e/speculos.ts
@@ -8,7 +8,6 @@ import {
   SpeculosTransport,
 } from "../load/speculos";
 import { createSpeculosDeviceCI, releaseSpeculosDeviceCI } from "./speculosCI";
-import type { AppCandidate } from "@ledgerhq/ledger-wallet-framework/bot/types";
 import { DeviceModelId } from "@ledgerhq/devices";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import axios from "axios";
@@ -43,7 +42,7 @@ import { AppInfos } from "./enum/AppInfos";
 import { DEVICE_LABELS_CONFIG } from "./data/deviceLabelsData";
 import { sendSui } from "./families/sui";
 import { sendConcordium } from "./families/concordium";
-import { getAppVersionFromCatalog, getSpeculosModel, isTouchDevice } from "./speculosAppVersion";
+import { getNanoAppCatalogVersionMap, getSpeculosModel, isTouchDevice } from "./speculosAppVersion";
 import {
   pressAndRelease,
   longPressAndRelease,
@@ -435,11 +434,12 @@ export async function startSpeculos(
   const appCandidates = await listAppCandidates(coinapps);
 
   const nanoAppCatalogPath = getEnv("E2E_NANO_APP_VERSION_PATH");
+  const catalogVersions = await getNanoAppCatalogVersionMap(nanoAppCatalogPath);
 
   const { appQuery, onSpeculosDeviceCreated } = spec;
   try {
     const displayName = spec.currency?.managerAppName || appQuery.appName;
-    const catalogVersion = await getAppVersionFromCatalog(displayName, nanoAppCatalogPath);
+    const catalogVersion = catalogVersions.get(displayName);
     if (catalogVersion) {
       appQuery.appVersion = catalogVersion;
     }
@@ -448,27 +448,6 @@ export async function startSpeculos(
   }
 
   const appCandidate = findLatestAppCandidate(appCandidates, appQuery);
-  const { model } = appQuery;
-  const { dependencies } = spec;
-  const newAppQuery = await Promise.all(
-    dependencies?.map(async dep => {
-      const catalogVersion = await getAppVersionFromCatalog(dep.name, nanoAppCatalogPath);
-      if (catalogVersion) {
-        dep.appVersion = catalogVersion;
-      }
-
-      return findLatestAppCandidate(appCandidates, {
-        model,
-        appName: dep.name,
-        appVersion: dep.appVersion,
-        firmware: appCandidate?.firmware,
-      });
-    }) ?? [],
-  );
-  const appVersionMap = new Map(newAppQuery?.map(app => [app?.appName, app?.appVersion]));
-  dependencies?.forEach(dependency => {
-    dependency.appVersion = appVersionMap.get(dependency.name) || "1.0.0";
-  });
   if (!appCandidate) {
     console.warn("no app found for " + testName);
     console.warn(appQuery);
@@ -479,12 +458,37 @@ export async function startSpeculos(
     testName,
     coinapps,
   );
+
+  const { model } = appQuery;
+  const { dependencies } = spec;
+  dependencies?.forEach(dependency => {
+    const catalogVersion = catalogVersions.get(dependency.name);
+    const dependencyCandidate = findLatestAppCandidate(appCandidates, {
+      model,
+      appName: dependency.name,
+      appVersion: catalogVersion,
+      firmware: appCandidate.firmware,
+    });
+
+    invariant(
+      dependencyCandidate,
+      "%s: no dependency app found for %s %s on %s %s. Are you sure your COINAPPS is up to date?",
+      testName,
+      dependency.name,
+      catalogVersion ?? "latest local version",
+      model,
+      appCandidate.firmware,
+    );
+
+    dependency.appVersion = dependencyCandidate.appVersion;
+  });
+
   log(
     "engine",
     `test ${testName} will use ${appCandidate.appName} ${appCandidate.appVersion} on ${appCandidate.model} ${appCandidate.firmware}`,
   );
   const deviceParams = {
-    ...(appCandidate as AppCandidate),
+    ...appCandidate,
     appName: spec.currency ? spec.currency.managerAppName : spec.appQuery.appName,
     seed,
     dependencies,
@@ -514,9 +518,11 @@ export async function startSpeculos(
 export async function stopSpeculos(deviceId: string | undefined) {
   if (deviceId) {
     log("engine", `test ${deviceId} finished`);
-    isSpeculosRemote
-      ? await releaseSpeculosDeviceCI(deviceId)
-      : await releaseSpeculosDevice(deviceId);
+    if (isSpeculosRemote) {
+      await releaseSpeculosDeviceCI(deviceId);
+    } else {
+      await releaseSpeculosDevice(deviceId);
+    }
   }
 }
 

--- a/libs/ledger-live-common/src/e2e/speculos.ts
+++ b/libs/ledger-live-common/src/e2e/speculos.ts
@@ -450,13 +450,21 @@ export async function startSpeculos(
   const appCandidate = findLatestAppCandidate(appCandidates, appQuery);
   const { model } = appQuery;
   const { dependencies } = spec;
-  const newAppQuery = dependencies?.map(dep => {
-    return findLatestAppCandidate(appCandidates, {
-      model,
-      appName: dep.name,
-      firmware: appCandidate?.firmware,
-    });
-  });
+  const newAppQuery = await Promise.all(
+    dependencies?.map(async dep => {
+      const catalogVersion = await getAppVersionFromCatalog(dep.name, nanoAppCatalogPath);
+      if (catalogVersion) {
+        dep.appVersion = catalogVersion;
+      }
+
+      return findLatestAppCandidate(appCandidates, {
+        model,
+        appName: dep.name,
+        appVersion: dep.appVersion,
+        firmware: appCandidate?.firmware,
+      });
+    }) ?? [],
+  );
   const appVersionMap = new Map(newAppQuery?.map(app => [app?.appName, app?.appVersion]));
   dependencies?.forEach(dependency => {
     dependency.appVersion = appVersionMap.get(dependency.name) || "1.0.0";

--- a/libs/ledger-live-common/src/e2e/speculosAppVersion.ts
+++ b/libs/ledger-live-common/src/e2e/speculosAppVersion.ts
@@ -9,6 +9,8 @@ import * as path from "path";
 const liveCommonVersion = "34.64.0"; // live-common version isn't really necessary here, so we can hardcode it
 const nanoAppProviderId = 1;
 
+type CatalogApp = { versionDisplayName: string; version: string };
+
 export function getSpeculosModel(): DeviceModelId {
   const speculosDevice = process.env.SPECULOS_DEVICE;
   switch (speculosDevice) {
@@ -111,14 +113,9 @@ export async function getDeviceFirmwareVersion(device: DeviceModelId): Promise<s
 
 export async function createNanoAppJsonFile(nanoAppFilePath: string): Promise<void> {
   const jsonFilePath = path.resolve(process.cwd(), nanoAppFilePath);
-  const providerFilePath = `${jsonFilePath}.provider`;
 
   try {
-    if (
-      fs.existsSync(jsonFilePath) &&
-      fs.existsSync(providerFilePath) &&
-      fs.readFileSync(providerFilePath, "utf8") === String(nanoAppProviderId)
-    ) {
+    if (fs.existsSync(jsonFilePath)) {
       return; // File already exists
     }
 
@@ -129,16 +126,12 @@ export async function createNanoAppJsonFile(nanoAppFilePath: string): Promise<vo
     const appCatalog = await getNanoAppCatalog(device, firmware);
 
     const tmpPath = `${jsonFilePath}.${process.pid}.tmp`;
-    const providerTmpPath = `${providerFilePath}.${process.pid}.tmp`;
     fs.writeFileSync(tmpPath, JSON.stringify(appCatalog, null, 2), "utf8");
-    fs.writeFileSync(providerTmpPath, String(nanoAppProviderId), "utf8");
     try {
       fs.renameSync(tmpPath, jsonFilePath);
-      fs.renameSync(providerTmpPath, providerFilePath);
     } catch {
       try {
         fs.unlinkSync(tmpPath);
-        fs.unlinkSync(providerTmpPath);
       } catch {
         // ignore
       }
@@ -148,10 +141,9 @@ export async function createNanoAppJsonFile(nanoAppFilePath: string): Promise<vo
   }
 }
 
-export async function getAppVersionFromCatalog(
-  currency: string,
+export async function getNanoAppCatalogVersionMap(
   nanoAppFilePath: string,
-): Promise<string | undefined> {
+): Promise<Map<string, string>> {
   const jsonFilePath = path.resolve(process.cwd(), nanoAppFilePath);
 
   try {
@@ -159,16 +151,27 @@ export async function getAppVersionFromCatalog(
 
     if (!fs.existsSync(jsonFilePath)) {
       console.error(`Catalog file not found: ${jsonFilePath}`);
-      return;
+      return new Map();
     }
 
-    type CatalogApp = { versionDisplayName: string; version: string };
     const raw = fs.readFileSync(jsonFilePath, "utf8");
     const catalog: CatalogApp[] = JSON.parse(raw);
 
-    const app = catalog.find(entry => entry.versionDisplayName === currency);
+    return new Map(catalog.map(entry => [entry.versionDisplayName, entry.version]));
+  } catch (error) {
+    console.error("Unable to get app versions from catalog:", error);
+  }
 
-    return app?.version ?? "";
+  return new Map();
+}
+
+export async function getAppVersionFromCatalog(
+  currency: string,
+  nanoAppFilePath: string,
+): Promise<string | undefined> {
+  try {
+    const catalogVersions = await getNanoAppCatalogVersionMap(nanoAppFilePath);
+    return catalogVersions.get(currency) ?? "";
   } catch (error) {
     console.error(`Unable to get app version for ${currency} from catalog:`, error);
   }

--- a/libs/ledger-live-common/src/e2e/speculosAppVersion.ts
+++ b/libs/ledger-live-common/src/e2e/speculosAppVersion.ts
@@ -7,6 +7,7 @@ import * as fs from "fs";
 import * as path from "path";
 
 const liveCommonVersion = "34.64.0"; // live-common version isn't really necessary here, so we can hardcode it
+const nanoAppProviderId = 1;
 
 export function getSpeculosModel(): DeviceModelId {
   const speculosDevice = process.env.SPECULOS_DEVICE;
@@ -54,7 +55,7 @@ export async function getNanoAppCatalog(
   const repository = new HttpManagerApiRepository(getEnv("MANAGER_API_BASE"), liveCommonVersion);
   const targetId = getDeviceTargetId(device);
   return await repository.catalogForDevice({
-    provider: 1,
+    provider: nanoAppProviderId,
     targetId: targetId,
     firmwareVersion: deviceFirmware,
   });
@@ -72,12 +73,11 @@ export async function getDeviceFirmwareVersion(device: DeviceModelId): Promise<s
   const cached = firmwareVersionCache.get(device);
   if (cached) return cached;
 
-  const providerId = 1;
   const repository = new HttpManagerApiRepository(getEnv("MANAGER_API_BASE"), liveCommonVersion);
 
   const deviceVersion = await repository.getDeviceVersion({
     targetId: getDeviceTargetId(device),
-    providerId,
+    providerId: nanoAppProviderId,
   });
 
   const firmwareIds = deviceVersion.se_firmware_final_versions;
@@ -89,7 +89,7 @@ export async function getDeviceFirmwareVersion(device: DeviceModelId): Promise<s
 
   // Only firmwares matching providerId
   const providerFirmwares = firmwares.filter(
-    fw => Array.isArray(fw.providers) && fw.providers.includes(providerId),
+    fw => Array.isArray(fw.providers) && fw.providers.includes(nanoAppProviderId),
   );
 
   if (providerFirmwares.length === 0) {
@@ -111,9 +111,14 @@ export async function getDeviceFirmwareVersion(device: DeviceModelId): Promise<s
 
 export async function createNanoAppJsonFile(nanoAppFilePath: string): Promise<void> {
   const jsonFilePath = path.resolve(process.cwd(), nanoAppFilePath);
+  const providerFilePath = `${jsonFilePath}.provider`;
 
   try {
-    if (fs.existsSync(jsonFilePath)) {
+    if (
+      fs.existsSync(jsonFilePath) &&
+      fs.existsSync(providerFilePath) &&
+      fs.readFileSync(providerFilePath, "utf8") === String(nanoAppProviderId)
+    ) {
       return; // File already exists
     }
 
@@ -124,12 +129,16 @@ export async function createNanoAppJsonFile(nanoAppFilePath: string): Promise<vo
     const appCatalog = await getNanoAppCatalog(device, firmware);
 
     const tmpPath = `${jsonFilePath}.${process.pid}.tmp`;
+    const providerTmpPath = `${providerFilePath}.${process.pid}.tmp`;
     fs.writeFileSync(tmpPath, JSON.stringify(appCatalog, null, 2), "utf8");
+    fs.writeFileSync(providerTmpPath, String(nanoAppProviderId), "utf8");
     try {
       fs.renameSync(tmpPath, jsonFilePath);
+      fs.renameSync(providerTmpPath, providerFilePath);
     } catch {
       try {
         fs.unlinkSync(tmpPath);
+        fs.unlinkSync(providerTmpPath);
       } catch {
         // ignore
       }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Typechecks passed locally; focused desktop E2E workflow is running.
- [x] **Impact of the changes:**
      - SUI swap E2E setup on Ledger Wallet Desktop
      - Speculos Exchange dependency app version resolution
      - Provider 1 nano app catalog usage for E2E app selection

### 📝 Description

This PR fixes SUI nano app selection for Ledger Wallet Desktop swap E2E setup. Exchange dependencies such as Sui and Solana were previously resolved from the latest local `coin-apps` ELF, which could select a newer app than the provider 1 catalog expects.

The Speculos app version lookup now uses a single provider 1 source of truth and applies catalog versions to Exchange dependency apps as well as the main app. The generated nano app catalog cache is also provider-aware so stale catalogs from another provider are not reused.

### ❓ Context

- **JIRA or GitHub link**: [QAA-1239](https://ledgerhq.atlassian.net/browse/QAA-1239)
- **Desktop E2E execution**: [workflow run](https://github.com/LedgerHQ/ledger-live/actions/runs/26215911248)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-1239]: https://ledgerhq.atlassian.net/browse/QAA-1239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ