### PR TITLE
[LWM] fix(mobile): display currency ticker in asset details header capsule

### DIFF
--- a/.changeset/silent-otters-whisper.md
+++ b/.changeset/silent-otters-whisper.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Display currency ticker instead of name in asset details coin capsule

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/index.tsx
@@ -37,7 +37,7 @@ export default function AssetDetail() {
     const opts: Partial<LumenNativeStackNavigationOptions> = {
       lumenNavBar: {
         coinCapsule: {
-          ticker: currency.name,
+          ticker: currency.ticker,
           icon: <CurrencyIcon currency={currency} hideNetwork size={24} />,
         },
         renderTrailing,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Asset details screen header on mobile
  - Currency capsule label (should display ticker, not full name)

### 📝 Description

The coin capsule at the top of the Asset Details screen on mobile was displaying the full currency name (e.g. "Bitcoin") instead of the ticker (e.g. "BTC").

This PR updates the `coinCapsule` navigation option to use `currency.ticker` instead of `currency.name`, aligning the header with the expected design.

### ❓ Context

- **JIRA or GitHub link**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)