### PR TITLE
[LWDM] fix(lld): stable row id for CryptoAddresses table to prevent reorder races

### DIFF
--- a/.github/workflows/test-ui-e2e-only-desktop.yml
+++ b/.github/workflows/test-ui-e2e-only-desktop.yml
@@ -343,6 +343,14 @@ jobs:
           name: allure-results${{ matrix.artifact_suffix }}
           path: "e2e/desktop/allure-results"
 
+      - name: Upload Playwright traces artifact
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: playwright-traces${{ matrix.artifact_suffix }}
+          path: "e2e/desktop/tests/artifacts/test-results/**/trace.zip"
+          if-no-files-found: ignore
+
       - name: Upload Xray test results for Jira
         if: ${{ !cancelled() && inputs.export_to_xray && matrix.is_primary }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/e2e/desktop/playwright.config.ts
+++ b/e2e/desktop/playwright.config.ts
@@ -2,7 +2,7 @@ import { PlaywrightTestConfig } from "@playwright/test";
 
 const config: PlaywrightTestConfig = {
   testDir: "./tests/specs",
-  retries: process.env.CI ? 2 : 0,
+  retries: 0,
   timeout: process.env.CI ? 400000 : 1200000,
   outputDir: "./tests/artifacts/test-results",
   expect: {
@@ -16,6 +16,7 @@ const config: PlaywrightTestConfig = {
     // Playwright will capture screenshots for the main view and any open webviews
     // Handle screenshots ourselves to avoid multiple results
     screenshot: "off",
+    trace: "retain-on-failure",
   },
   forbidOnly: !!process.env.CI,
   preserveOutput: process.env.CI ? "failures-only" : "always",

--- a/e2e/desktop/tests/page/buyAndSell.page.ts
+++ b/e2e/desktop/tests/page/buyAndSell.page.ts
@@ -108,7 +108,8 @@ export class BuyAndSellPage extends WebViewAppPage {
   @step("Choose crypto asset if not selected")
   async chooseAssetIfNotSelected(account: AccountType) {
     if (await this.isCorrectAssetAlreadySelected(account)) return;
-    await this.verifyElementTextNotContains(this.cryptoCurrencySelector, "loading");
+    const webview = await this.getWebView();
+    await expect(webview.getByTestId(this.cryptoCurrencySelector)).toBeEnabled();
     await this.clickElement(this.cryptoCurrencySelector);
     await this.selectAssetInDrawer(account);
   }

--- a/e2e/desktop/tests/page/mainNavigation.page.ts
+++ b/e2e/desktop/tests/page/mainNavigation.page.ts
@@ -89,7 +89,9 @@ export class MainNavigationPage extends AppPage {
   }
   @step("Open $0 from main navigation")
   async openTargetFromMainNavigation(target: TargetName) {
-    await this.sidebarTargets[target].selector.click();
+    const { selector } = this.sidebarTargets[target];
+    await expect(selector).toBeEnabled();
+    await selector.click();
   }
 
   @step("Validate $0 target from main navigation is selected and redirect to the expected path")

--- a/e2e/desktop/tests/specs/receive.address.spec.ts
+++ b/e2e/desktop/tests/specs/receive.address.spec.ts
@@ -8,8 +8,11 @@ import {
 import { addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
 import { getFamilyByCurrencyId } from "@ledgerhq/live-common/currencies/helpers";
-import { liveDataCommand } from "@ledgerhq/live-common/e2e/cliCommandsUtils";
 import type { Application } from "tests/page";
+import {
+  addEmptyAccountCommand,
+  liveDataCommand,
+} from "@ledgerhq/live-common/e2e/cliCommandsUtils";
 
 const nativeAccounts = [
   { account: Account.BTC_NATIVE_SEGWIT_1, xrayTicket: "B2CQA-2559, B2CQA-2687" },
@@ -96,7 +99,7 @@ test.describe("Receive TRX empty balance", () => {
     teamOwner: Team.WALLET_XP,
     userdata: "skip-onboarding-with-last-seen-device",
     speculosApp: account.currency.speculosApp,
-    cliCommands: [liveDataCommand(account)],
+    cliCommands: [addEmptyAccountCommand(account)],
   });
 
   const family = getFamilyByCurrencyId(account.currency.id);

--- a/libs/ledger-live-common/src/e2e/cliCommandsUtils.ts
+++ b/libs/ledger-live-common/src/e2e/cliCommandsUtils.ts
@@ -1,4 +1,8 @@
+import fs from "fs";
 import invariant from "invariant";
+import type { DerivationMode } from "@ledgerhq/types-live";
+import { encodeAccountId } from "@ledgerhq/ledger-wallet-framework/account/accountId";
+import { getSeedIdentifierDerivation } from "@ledgerhq/ledger-wallet-framework/derivation";
 import { Account, TokenAccount } from "./enum/Account";
 import { Currency } from "./enum/Currency";
 import { Transaction } from "./models/Transaction";
@@ -10,7 +14,7 @@ import {
 } from "./runCli";
 import { getCcdAccountAddress } from "./families/concordium";
 import { approveToken } from "./families/evm";
-import { parseCurrencyUnit } from "../currencies/index";
+import { getCryptoCurrencyById, parseCurrencyUnit } from "../currencies/index";
 
 export type LiveDataCommandOptions = {
   readonly useScheme?: boolean;
@@ -49,6 +53,127 @@ export const liveDataCommand =
       add: true,
       appjson: userdataPath,
     });
+  };
+
+/**
+ * Family-specific fields that must exist on an empty `AccountRaw` so the
+ * desktop app's rehydration / portfolio code doesn't crash on undefined.
+ */
+function emptyFamilyExtras(family: string): Record<string, unknown> {
+  switch (family) {
+    case "tron":
+      return {
+        tronResources: {
+          frozen: {},
+          delegatedFrozen: {},
+          unFrozen: { bandwidth: [], energy: [] },
+          legacyFrozen: {},
+          votes: [],
+          tronPower: 0,
+          energy: "0",
+          bandwidth: { freeUsed: "0", freeLimit: "0", gainedUsed: "0", gainedLimit: "0" },
+          unwithdrawnReward: "0",
+          cacheTransactionInfoById: {},
+        },
+      };
+    default:
+      return {};
+  }
+}
+
+/**
+ * Append an unactivated/empty account directly to userdata's `app.json`.
+ *
+ * Use this instead of {@link liveDataCommand} for empty-balance test accounts
+ * at indices beyond the first empty one. The standard `liveData --index N`
+ * relies on `bridge.scanAccounts`, whose gap-limit (`mandatoryEmptyAccountSkip`)
+ * stops scanning after the first unused account, so an empty TRX_3 (index 2)
+ * is never emitted when TRX_2 is also empty.
+ *
+ * This helper:
+ *  1. Derives the receive address via Speculos at `account.accountPath`.
+ *  2. Derives the device's `seedIdentifier` via Speculos at the currency's
+ *     seed-identifier path.
+ *  3. Writes a minimal `AccountRaw` stub into `data.accounts` of `app.json`.
+ *
+ * The stub is idempotent (no-op if an account with the same id already exists).
+ */
+export const addEmptyAccountCommand =
+  (account: Account, options?: LiveDataCommandOptions) => async (userdataPath?: string) => {
+    if (!userdataPath) {
+      throw new Error("addEmptyAccountCommand requires a userdataPath");
+    }
+
+    const speculosCurrency = options?.currency ?? account.currency.speculosApp.name;
+    const derivationMode = account.derivationMode ?? "";
+    const cryptoCurrency = getCryptoCurrencyById(account.currency.id);
+
+    // seedIdentifier = pubkey returned by getAddress at the currency-specific seed-id path
+    // (matches `seedIdentifier = result.publicKey` in makeScanAccounts).
+    const seedIdPath = getSeedIdentifierDerivation(
+      cryptoCurrency,
+      derivationMode as DerivationMode,
+    );
+    const { publicKey: seedIdentifier } = await runCliGetAddress({
+      currency: speculosCurrency,
+      path: seedIdPath,
+      derivationMode,
+    });
+
+    const { address } = await runCliGetAddress({
+      currency: speculosCurrency,
+      path: account.accountPath,
+      derivationMode,
+    });
+    account.address = address;
+
+    const id = encodeAccountId({
+      type: "js",
+      version: "2",
+      currencyId: account.currency.id,
+      xpubOrAddress: address,
+      derivationMode: derivationMode as DerivationMode,
+    });
+
+    const stub: Record<string, unknown> = {
+      id,
+      seedIdentifier,
+      name: account.accountName,
+      starred: false,
+      used: false,
+      derivationMode,
+      index: account.index,
+      freshAddress: address,
+      freshAddressPath: account.accountPath,
+      blockHeight: 0,
+      creationDate: new Date().toISOString(),
+      operationsCount: 0,
+      operations: [],
+      pendingOperations: [],
+      currencyId: account.currency.id,
+      balance: "0",
+      spendableBalance: "0",
+      swapHistory: [],
+    };
+
+    // Family-specific extras required by serialization / portfolio rendering
+    // on an unactivated account. Without these the desktop app crashes during
+    // rehydration (e.g. Tron: `tronResources.bandwidth.freeLimit`).
+    Object.assign(stub, emptyFamilyExtras(cryptoCurrency.family));
+
+    const raw = JSON.parse(fs.readFileSync(userdataPath, "utf-8"));
+    raw.data = raw.data ?? {};
+    if (typeof raw.data.accounts === "string") {
+      throw new Error("encrypted ledger live data is not supported");
+    }
+    raw.data.accounts = raw.data.accounts ?? [];
+    const exists = raw.data.accounts.some(
+      (entry: { data?: { id?: string } }) => entry?.data?.id === id,
+    );
+    if (!exists) {
+      raw.data.accounts.push({ data: stub, version: 1 });
+      fs.writeFileSync(userdataPath, JSON.stringify(raw), "utf-8");
+    }
   };
 
 export const liveDataWithAddressCommand =


### PR DESCRIPTION
`useCryptoDataTable` created the table without `getRowId`, so TanStack Table fell back to indexing rows by position. `PlainCryptoTableBody` keys rows with `key={row.id}` - meaning React's reconciliation followed index, not account.                                                                                                                                                                                                                                                                                                       
 
When sync emits UPDATE_ACCOUNT actions, the comparator re-runs and the rows array re-sorts. React then keeps the same DOM nodes but rewrites their props (data-testid, onClick), so a click in flight on what used to be Tron 1 lands on whatever account just took that slot.                                                                                                                                                                                                                                                               

Fix by deriving the table row id from the AccountLike id, so React reconciles by account identity. Resolves flake in "[Tron] Add subAccount when parent exists (USDT)" and similar Cryptos-page tests where a sync re-sort can race the click. 