### PR TITLE
[LWD] fix: stable row id for CryptoAddresses table to prevent reorder races

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/hooks/useCryptoDataTable.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/hooks/useCryptoDataTable.tsx
@@ -171,6 +171,7 @@ export function useCryptoDataTable({
     enableSortingRemoval: false,
     state: { sorting },
     onSortingChange: handleSortingChange,
+    getRowId: row => row.id,
   });
 
   const handleRowClick = useCallback(


### PR DESCRIPTION
`useCryptoDataTable` created the table without `getRowId`, so TanStack Table fell back to indexing rows by position. `PlainCryptoTableBody` keys rows with `key={row.id}` - meaning React's reconciliation followed index, not account.                                                                                                                                                                                                                                                                                                       
 
When sync emits UPDATE_ACCOUNT actions, the comparator re-runs and the rows array re-sorts. React then keeps the same DOM nodes but rewrites their props (data-testid, onClick), so a click in flight on what used to be Tron 1 lands on whatever account just took that slot.                                                                                                                                                                                                                                                               

Fix by deriving the table row id from the AccountLike id, so React reconciles by account identity. Resolves flake in "[Tron] Add subAccount when parent exists (USDT)" and similar Cryptos-page tests where a sync re-sort can race the click. 