### PR TITLE
[LWM] fix(lwm): check account type to avoid error on token account

### DIFF
--- a/.changeset/stupid-points-kneel.md
+++ b/.changeset/stupid-points-kneel.md
@@ -1,0 +1,10 @@
+---
+"live-mobile": minor
+---
+
+fix(mobile): guard EVM AccountBalanceSummaryFooter against TokenAccount
+
+Move the `account.type !== "Account"` early return before `account.currency.id`
+is accessed in AccountBalanceFooter. TokenAccount objects have no `currency`
+property, causing a crash ("Cannot read property 'id' of undefined") when
+navigating to any EVM token account (e.g. USDT).

--- a/apps/ledger-live-mobile/src/families/evm/AccountBalanceSummaryFooter.test.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/AccountBalanceSummaryFooter.test.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { render, withFlagOverrides } from "@tests/test-renderer";
+import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type { TokenAccount } from "@ledgerhq/types-live";
+import AccountBalanceFooter from "./AccountBalanceSummaryFooter";
+
+jest.mock("@ledgerhq/live-common/config/index", () => ({
+  getCurrencyConfiguration: jest.fn().mockReturnValue({}),
+}));
+
+const ethereum = getCryptoCurrencyById("ethereum");
+const usdt = {
+  type: "TokenCurrency",
+  id: "ethereum/erc20/usdt",
+  name: "Tether USD",
+  ticker: "USDT",
+  contractAddress: "0xdac17f958d2ee523a2206206994597c13d831ec7",
+  decimals: 6,
+  units: [
+    {
+      name: "USDT",
+      code: "USDT",
+      magnitude: 6,
+    },
+  ],
+  tokenType: "erc20",
+  parentCurrency: ethereum,
+} as unknown as TokenCurrency;
+
+const ethAccount = genAccount("test-eth", { currency: ethereum, subAccountsCount: 0 });
+const usdtAccount: TokenAccount = genTokenAccount(0, ethAccount, usdt);
+
+const withEvmStakingEnabled = withFlagOverrides({
+  evmNativeStaking: { enabled: true, params: { supportedCurrencyIds: ["ethereum"] } },
+});
+
+describe("AccountBalanceFooter", () => {
+  it("should render null without crashing when given a TokenAccount", () => {
+    // Regression test: previously crashed with "Cannot read property 'id' of undefined"
+    // because account.currency.id was accessed before the account.type !== "Account" guard
+    const { toJSON } = render(<AccountBalanceFooter account={usdtAccount} />, {
+      overrideInitialState: withEvmStakingEnabled,
+    });
+    expect(toJSON()).toBeNull();
+  });
+
+  it("should render null for a non-ethereum Account (unsupported currency)", () => {
+    const bitcoin = getCryptoCurrencyById("bitcoin");
+    const btcAccount = genAccount("test-btc", { currency: bitcoin, subAccountsCount: 0 });
+    const { toJSON } = render(<AccountBalanceFooter account={btcAccount} />, {
+      overrideInitialState: withEvmStakingEnabled,
+    });
+    expect(toJSON()).toBeNull();
+  });
+
+  it("should render null when evmNativeStaking is disabled", () => {
+    const { toJSON } = render(<AccountBalanceFooter account={ethAccount} />, {
+      overrideInitialState: withFlagOverrides({ evmNativeStaking: { enabled: false } }),
+    });
+    expect(toJSON()).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/families/evm/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/AccountBalanceSummaryFooter.tsx
@@ -5,7 +5,7 @@ import {
   type StakingAccount,
 } from "@ledgerhq/live-common/families/evm/staking/types";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
-import { Account } from "@ledgerhq/types-live";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
 import React, { useCallback, useState } from "react";
 import { ScrollView } from "react-native";
@@ -16,7 +16,7 @@ import { useTranslation } from "~/context/Locale";
 import type { ModalInfo } from "~/modals/Info";
 import InfoModal from "~/modals/Info";
 
-type Props = { account: Account };
+type Props = { account: AccountLike };
 type InfoName = "available" | "delegated" | "undelegating";
 
 function AccountBalanceSummaryFooter({ account }: { account: StakingAccount }) {
@@ -77,9 +77,10 @@ function AccountBalanceSummaryFooter({ account }: { account: StakingAccount }) {
 
 export default function AccountBalanceFooter({ account }: Props) {
   const { enabled, params } = useFeature("evmNativeStaking") ?? {};
-  const isSupported = params?.supportedCurrencyIds?.some(id => id === account.currency.id) ?? false;
 
   if (account.type !== "Account") return null;
+
+  const isSupported = params?.supportedCurrencyIds?.some(id => id === account.currency.id) ?? false;
   if (!enabled || !isSupported) return null;
   if (!isStakingAccount(account) || account.balance.lte(0)) return null;
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Move the `account.type !== "Account"` early return before `account.currency.id`
is accessed in AccountBalanceFooter. TokenAccount objects have no `currency`
property, causing a crash ("Cannot read property 'id' of undefined") when
navigating to any EVM token account (e.g. USDT).

BEFORE

https://github.com/user-attachments/assets/272ce9d5-40a3-4052-9b19-7f3697dc2b1c

AFTER

https://github.com/user-attachments/assets/9937ccc4-b3cc-4515-a36b-e9945609a260


### ❓ Context

- **JIRA or GitHub link**: [LIVE-31062](https://ledgerhq.atlassian.net/browse/LIVE-31062)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31062]: https://ledgerhq.atlassian.net/browse/LIVE-31062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ