### PR TITLE
[LWDM] test(e2e): skip POL and BASE send tests on touch devices

### DIFF
--- a/libs/ledger-live-common/src/e2e/families/evm.ts
+++ b/libs/ledger-live-common/src/e2e/families/evm.ts
@@ -14,6 +14,7 @@ import {
 } from "../deviceInteraction/TouchDeviceSimulator";
 import { DeviceLabels } from "../enum/DeviceLabels";
 import { Device } from "../enum/Device";
+import { Currency } from "../enum/Currency";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { withDeviceController } from "../deviceInteraction/DeviceController";
 import { getEnv } from "@ledgerhq/live-env";
@@ -25,6 +26,17 @@ function formatEventsForError(events: string[], maxLength = 1000): string {
     return formatted;
   }
   return `${formatted.slice(0, maxLength)}...\n  (truncated, ${events.length} total events)`;
+}
+
+// TODO: remove once LIVE-28070 is fixed
+function shouldSkipTouchValidation(tx: Transaction): boolean {
+  const isPolOrBase =
+    tx.accountToCredit.currency.id === Currency.POL.id ||
+    tx.accountToCredit.currency.id === Currency.BASE.id;
+  const isStaxOrFlex =
+    process.env.SPECULOS_DEVICE === Device.STAX.name ||
+    process.env.SPECULOS_DEVICE === Device.FLEX.name;
+  return isStaxOrFlex && isPolOrBase;
 }
 
 function validateTransactionData(tx: Transaction, events: string[]) {
@@ -59,13 +71,16 @@ function validateTransactionData(tx: Transaction, events: string[]) {
 async function sendEvmTouchDevices(tx: Transaction) {
   await waitForReviewTransaction();
 
+  const skipValidation = shouldSkipTouchValidation(tx);
   const events: string[] = [];
   if (tx.accountToCredit.ensName) {
     const ensEvents = await getEnsScreenTexts(tx.accountToCredit.ensName);
     events.push(...ensEvents);
   }
   events.push(...(await pressUntilTextFound(DeviceLabels.HOLD_TO_SIGN)));
-  validateTransactionData(tx, events);
+  if (!skipValidation) {
+    validateTransactionData(tx, events);
+  }
   await longPressAndRelease(DeviceLabels.HOLD_TO_SIGN, 3);
 }
 


### PR DESCRIPTION

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- Disable validateTransactionData on Stax/Flex for Polygon and Base sends
    while LIVE-28070 is not fixed.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->
[@Mobile E2E • Manual • iOS & Android • support/skip-touch-send-pol-base-live-28070 • cunhabruno](https://github.com/LedgerHQ/ledger-live/actions/runs/26230418640)
[@Desktop E2E • triggered on support/skip-touch-send-pol-base-live-28070 by cunhabruno](https://github.com/LedgerHQ/ledger-live/actions/runs/26230532854)
---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
