### PR TITLE
chore(desktop): remove wallet 4.0 legacy toggle from e2e tests

### DIFF
--- a/.changeset/qaa-1116-wallet-40-cleanup.md
+++ b/.changeset/qaa-1116-wallet-40-cleanup.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop-e2e-tests": patch
+---
+
+Remove Wallet 4.0 legacy toggle and conditional branches from desktop E2E tests

--- a/e2e/desktop/README.md
+++ b/e2e/desktop/README.md
@@ -82,20 +82,7 @@ pnpm e2e:desktop test:playwright <testFileName>
 For detailed setup, debugging, and contribution guidelines, see:
 [Ledger Wallet Desktop E2E Wiki](https://github.com/LedgerHQ/ledger-live/wiki/LLD:E2ETesting)
 
-### 6. Wallet 4.0
-
-The Wallet 4.0 feature is ON by default (regardless of Firebase).
-You can force Wallet 4.0 OFF (legacy) by setting the E2E environment variable:
-
-```bash
-export E2E_ENABLE_WALLET40=0
-```
-
-Individual tests can still switch Wallet 4.0 OFF by explicitly passing the `LWD_WALLET_40_FF_DISABLED` FF.
-
-To switch Wallet 4.0 OFF on CI please untick the checkbox on the Github Workflow.
-
-### 7. Custom feature flags with E2E_FEATURE_FLAGS_JSON
+### 6. Custom feature flags with E2E_FEATURE_FLAGS_JSON
 
 You can inject extra feature flags globally for Desktop E2E by setting `E2E_FEATURE_FLAGS_JSON`.
 

--- a/e2e/desktop/tests/fixtures/common.ts
+++ b/e2e/desktop/tests/fixtures/common.ts
@@ -18,7 +18,6 @@ import { lastValueFrom, Observable } from "rxjs";
 import { launchSpeculos, cleanSpeculos } from "tests/utils/speculosUtils";
 import { getSpeculosAddress, SpeculosDevice } from "@ledgerhq/live-common/e2e/speculos";
 import { attachNetworkLogging } from "../utils/networkLogging";
-import { LWD_WALLET_40_FF_DISABLED, LWD_WALLET_40_FF_ENABLED } from "tests/utils/featureFlagUtils";
 import type { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import { unregisterAllTransportModules } from "@ledgerhq/live-common/hw/index";
 import { parseExtraFeatureFlags } from "../utils/featureFlagsJsonUtils";
@@ -83,9 +82,6 @@ const DEFAULT_FEATURE_FLAGS: OptionalFeatureMap = {
       live_apps_blocklist: [],
     },
   },
-  ...(process.env.E2E_ENABLE_WALLET40 === "0"
-    ? LWD_WALLET_40_FF_DISABLED
-    : LWD_WALLET_40_FF_ENABLED),
 };
 
 async function executeCliCommand(cmd: CliCommand, userdataDestinationPath?: string) {

--- a/e2e/desktop/tests/page/market.page.ts
+++ b/e2e/desktop/tests/page/market.page.ts
@@ -1,7 +1,6 @@
 import { AppPage } from "./abstractClasses";
 import { step } from "../misc/reporters/step";
 import { expect } from "@playwright/test";
-import { isWallet40Enabled } from "tests/utils/featureFlagUtils";
 
 export class MarketPage extends AppPage {
   private readonly navbarTitle = this.page.getByTestId("page-header-title");
@@ -11,13 +10,6 @@ export class MarketPage extends AppPage {
     this.page.getByTestId(`market-${ticker}-row`).first();
   private coinPageContainer = this.page.getByTestId("market-coin-page-container");
   private swapButtonOnAsset = this.page.getByTestId("market-coin-swap-button");
-
-  private buyButtonLegacy = (ticker: string) =>
-    this.page.locator(`[data-testid="market-${ticker}-buy-button"]:visible`).first();
-  private swapButtonLegacy = (ticker: string) =>
-    this.page.locator(`[data-testid="market-${ticker}-swap-button"]:visible`).first();
-  private stakeButtonLegacy = (ticker: string) =>
-    this.page.locator(`[data-testid="market-${ticker}-stake-button"]:visible`).first();
 
   private readonly buyButton = (ticker: string) =>
     this.coinRow(ticker).getByTestId(`market-${ticker}-buy-button-icon`);
@@ -53,19 +45,13 @@ export class MarketPage extends AppPage {
 
   @step("Open buy page for $0")
   async openBuyPage(ticker: string) {
-    const button = (await isWallet40Enabled(this.page))
-      ? this.buyButton(ticker.toLowerCase())
-      : this.buyButtonLegacy(ticker.toLowerCase());
-
+    const button = this.buyButton(ticker.toLowerCase());
     await button.click();
   }
 
   @step("Click on swap button for $0")
   async startSwapForSelectedTicker(ticker: string) {
-    const button = (await isWallet40Enabled(this.page))
-      ? this.swapButton(ticker.toLowerCase())
-      : this.swapButtonLegacy(ticker.toLowerCase());
-
+    const button = this.swapButton(ticker.toLowerCase());
     await button.click();
   }
 
@@ -76,10 +62,7 @@ export class MarketPage extends AppPage {
 
   @step("Click on stake button for $0")
   async stakeButtonClick(ticker: string) {
-    const button = (await isWallet40Enabled(this.page))
-      ? this.stakeButton(ticker.toLowerCase())
-      : this.stakeButtonLegacy(ticker.toLowerCase());
-
+    const button = this.stakeButton(ticker.toLowerCase());
     await button.click();
   }
 

--- a/e2e/desktop/tests/specs/assets.addresses.spec.ts
+++ b/e2e/desktop/tests/specs/assets.addresses.spec.ts
@@ -5,7 +5,6 @@ import { Currency } from "@ledgerhq/live-common/e2e/enum/Currency";
 import { addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
 import { getModularSelector } from "tests/utils/modularSelectorUtils";
-import { LWD_WALLET_40_FF_ENABLED } from "tests/utils/featureFlagUtils";
 
 /**
  * Suite: Wallet 4.0 - Portfolio-Asset/Address
@@ -29,7 +28,6 @@ test.describe("Wallet 4.0 - Portfolio-Asset/Address", () => {
       teamOwner: Team.WALLET_XP,
       userdata: "skip-onboarding-with-last-seen-device",
       speculosApp: Currency.BTC.speculosApp,
-      featureFlags: LWD_WALLET_40_FF_ENABLED,
     });
 
     test(
@@ -105,7 +103,6 @@ test.describe("Wallet 4.0 - Portfolio-Asset/Address", () => {
     test.use({
       teamOwner: Team.WALLET_XP,
       userdata: "1AccountBTC1AccountETH",
-      featureFlags: LWD_WALLET_40_FF_ENABLED,
     });
 
     test(
@@ -145,7 +142,6 @@ test.describe("Wallet 4.0 - Portfolio-Asset/Address", () => {
     test.use({
       teamOwner: Team.WALLET_XP,
       userdata: "portfolioWithManyStablecoins",
-      featureFlags: LWD_WALLET_40_FF_ENABLED,
     });
 
     test(

--- a/e2e/desktop/tests/specs/buySell.spec.ts
+++ b/e2e/desktop/tests/specs/buySell.spec.ts
@@ -12,7 +12,6 @@ import { BuySell } from "@ledgerhq/live-common/e2e/models/BuySell";
 import { BuySellProvider } from "@ledgerhq/live-common/e2e/enum/Provider";
 import { OperationType } from "@ledgerhq/live-common/e2e/enum/OperationType";
 import { getFamilyByCurrencyId } from "@ledgerhq/live-common/currencies/helpers";
-import { isWallet40Enabled } from "tests/utils/featureFlagUtils";
 import { liveDataCommand } from "@ledgerhq/live-common/e2e/cliCommandsUtils";
 
 const assets: Array<{ buySell: BuySell; xrayTicket: string; provider: BuySellProvider }> = [
@@ -88,13 +87,6 @@ for (const asset of assets) {
         await app.mainNavigation.openTargetFromMainNavigation("home");
         await app.portfolio.clickOnSelectedAssetRow(crypto.currency.name);
         await app.assetPage.startBuyFlow();
-
-        if ((await isWallet40Enabled(app.getPage())) === false) {
-          // TODO: Remove this when wallet 4.0 is permanent
-          // Buy / Sell is only in the side navigation for legacy app
-          await app.layout.verifyBuySellSideBarIsSelected();
-        }
-
         await app.buyAndSell.verifyBuySellLandingAndCryptoAssetSelector(crypto, operation);
         await app.buyAndSell.verifyFiatAssetSelector(fiat.currencyTicker);
       },
@@ -111,22 +103,9 @@ for (const asset of assets) {
       },
       async ({ app }) => {
         await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
-        if (await isWallet40Enabled(app.getPage())) {
-          await app.marketBanner.clickExploreMarketHeader();
-        } else {
-          await app.layout.goToMarket();
-        }
-
+        await app.layout.goToMarket();
         await app.market.search(crypto.currency.ticker);
         await app.market.openBuyPage(crypto.currency.ticker);
-
-        if ((await isWallet40Enabled(app.getPage())) === false) {
-          // TODO: Remove this when wallet 4.0 is permanent
-          // Buy / Sell is only in the side navigation for legacy app
-          await app.layout.verifyBuySellSideBarIsSelected();
-        }
-
         await app.buyAndSell.verifyBuySellLandingAndCryptoAssetSelector(crypto, operation);
         await app.buyAndSell.verifyFiatAssetSelector(fiat.currencyTicker);
       },
@@ -164,12 +143,6 @@ for (const asset of assets) {
         );
         await app.account.clickBuy();
 
-        if ((await isWallet40Enabled(app.getPage())) === false) {
-          // TODO: Remove this when wallet 4.0 is permanent
-          // Buy / Sell is only in the side navigation for legacy app
-          await app.layout.verifyBuySellSideBarIsSelected();
-        }
-
         await app.buyAndSell.verifyBuySellLandingAndCryptoAssetSelector(
           asset.buySell.crypto,
           operation,
@@ -198,23 +171,16 @@ for (const asset of assets) {
       },
       async ({ app, userdataDestinationPath }) => {
         await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-        if (await isWallet40Enabled(app.getPage())) {
-          await app.portfolio.clickBuyButton();
-        } else {
-          await app.portfolio.clickBuySellButton();
-          await app.layout.verifyBuySellSideBarIsSelected();
-        }
-
+        await app.portfolio.clickBuySellButton();
+        await app.layout.verifyBuySellSideBarIsSelected();
         await app.buyAndSell.chooseAssetIfNotSelected(crypto);
         await app.buyAndSell.verifyBuySellLandingAndCryptoAssetSelector(crypto, operation);
         await app.buyAndSell.verifyFiatAssetSelector(fiat.currencyTicker);
         await app.buyAndSell.verifyBuyInfoBox();
         await app.buyAndSell.verifyProviderInfoIsNotVisible();
-
         await app.buyAndSell.setAmountToPay(amount, operation);
         await app.buyAndSell.selectProviderQuote(operation, asset.provider.uiName);
         await app.buyAndSell.selectQuote();
-
         await app.buyAndSell.verifyProviderUrl(
           asset.provider.uiName,
           asset.buySell,
@@ -270,21 +236,13 @@ test.describe("Sell flow - ", () => {
     },
     async ({ app, userdataDestinationPath }) => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-      if (await isWallet40Enabled(app.getPage())) {
-        await app.portfolio.clickSellButton();
-        await app.buyAndSell.verifyBuySellLandingAndCryptoAssetSelector(crypto, OperationType.Sell);
-        await app.buyAndSell.verifyFiatAssetSelector("USD");
-        await app.buyAndSell.verifySellInfoBox();
-        await app.buyAndSell.verifyProviderInfoIsNotVisible();
-      } else {
-        await app.layout.goToBuySellCrypto();
-        await app.layout.verifyBuySellSideBarIsSelected();
-        await app.buyAndSell.verifyBuySellLandingAndCryptoAssetSelector(crypto, OperationType.Buy);
-        await app.buyAndSell.verifyFiatAssetSelector("USD");
-        await app.buyAndSell.verifyBuyInfoBox();
-        await app.buyAndSell.verifyProviderInfoIsNotVisible();
-        await app.buyAndSell.selectTab(operation);
-      }
+      await app.layout.goToBuySellCrypto();
+      await app.layout.verifyBuySellSideBarIsSelected();
+      await app.buyAndSell.verifyBuySellLandingAndCryptoAssetSelector(crypto, OperationType.Buy);
+      await app.buyAndSell.verifyFiatAssetSelector("USD");
+      await app.buyAndSell.verifyBuyInfoBox();
+      await app.buyAndSell.verifyProviderInfoIsNotVisible();
+      await app.buyAndSell.selectTab(operation);
       await app.buyAndSell.changeRegionAndCurrency(fiat);
       await app.buyAndSell.verifyFiatAssetSelector(fiat.currencyTicker);
 

--- a/e2e/desktop/tests/specs/delegate.spec.ts
+++ b/e2e/desktop/tests/specs/delegate.spec.ts
@@ -430,59 +430,6 @@ for (const validator of validators) {
   });
 }
 
-test.describe("Staking flow from different entry point - legacy", () => {
-  const delegateAccount = new Delegate(Account.ATOM_1, "0.001", "Ledger by Chorus One");
-  test.use({
-    teamOwner: Team.EARN,
-    userdata: "skip-onboarding-with-last-seen-device",
-    speculosApp: delegateAccount.account.currency.speculosApp,
-    cliCommands: [liveDataCommand(delegateAccount.account)],
-  });
-
-  const family = getFamilyByCurrencyId(delegateAccount.account.currency.id);
-
-  test(
-    "Staking flow from portfolio entry point",
-    {
-      tag: [
-        "@NanoSP",
-        "@LNS",
-        "@NanoX",
-        "@Stax",
-        "@Flex",
-        "@NanoGen5",
-        `@${delegateAccount.account.currency.id}`,
-        ...(family ? [`@family-${family}`] : []),
-      ],
-      annotation: {
-        type: "TMS",
-        description: "B2CQA-2769, B2CQA-3281, B2CQA-3289",
-      },
-    },
-    async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
-      await app.layout.goToPortfolio();
-      await app.portfolio.startStakeFlow();
-
-      const selector = await getModularSelector(app, "ASSET");
-      if (selector) {
-        await selector.validateItems();
-        await selector.selectAsset(delegateAccount.account.currency);
-        await selector.selectNetwork(delegateAccount.account.currency);
-        await selector.selectAccountByName(delegateAccount.account);
-      } else {
-        await app.portfolio.expectChooseAssetToBeVisible();
-        await app.assetDrawer.selectAsset(delegateAccount.account.currency);
-        await app.assetDrawer.selectAccountByIndex(delegateAccount.account);
-      }
-
-      await app.delegate.verifyFirstProviderName(delegateAccount.provider);
-      await app.delegate.continue();
-    },
-  );
-});
-
 test.describe("Staking flow from different entry point", () => {
   const delegateAccount = new Delegate(Account.ATOM_1, "0.001", "Ledger by Chorus One");
   test.use({

--- a/e2e/desktop/tests/specs/delegate.spec.ts
+++ b/e2e/desktop/tests/specs/delegate.spec.ts
@@ -8,7 +8,6 @@ import { addBugLink, addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
 import { getFamilyByCurrencyId } from "@ledgerhq/live-common/currencies/helpers";
 import { getModularSelector } from "tests/utils/modularSelectorUtils";
-import { isWallet40Enabled, LWD_WALLET_40_FF_DISABLED } from "tests/utils/featureFlagUtils";
 import { liveDataCommand } from "@ledgerhq/live-common/e2e/cliCommandsUtils";
 
 function setupEnv(disableBroadcast?: boolean) {
@@ -437,7 +436,6 @@ test.describe("Staking flow from different entry point - legacy", () => {
     teamOwner: Team.EARN,
     userdata: "skip-onboarding-with-last-seen-device",
     speculosApp: delegateAccount.account.currency.speculosApp,
-    featureFlags: LWD_WALLET_40_FF_DISABLED,
     cliCommands: [liveDataCommand(delegateAccount.account)],
   });
 
@@ -516,13 +514,7 @@ test.describe("Staking flow from different entry point", () => {
     },
     async ({ app }) => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
-      if (await isWallet40Enabled(app.getPage())) {
-        await app.marketBanner.clickExploreMarketHeader();
-      } else {
-        await app.layout.goToMarket();
-      }
-
+      await app.layout.goToMarket();
       await app.market.search(delegateAccount.account.currency.ticker);
       await app.market.stakeButtonClick(delegateAccount.account.currency.ticker);
 

--- a/e2e/desktop/tests/specs/entrypoint.swap.spec.ts
+++ b/e2e/desktop/tests/specs/entrypoint.swap.spec.ts
@@ -17,7 +17,6 @@ import { overrideNetworkPayload } from "tests/utils/networkUtils";
 import { getModularSelector } from "tests/utils/modularSelectorUtils";
 import { liveDataWithAddressCommand } from "@ledgerhq/live-common/e2e/cliCommandsUtils";
 import { Addresses } from "@ledgerhq/live-common/e2e/enum/Addresses";
-import { isWallet40Enabled } from "tests/utils/featureFlagUtils";
 
 const app: AppInfos = AppInfos.EXCHANGE;
 
@@ -102,13 +101,7 @@ test.describe("Swap flow from different entry point", () => {
     },
     async ({ app }) => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
-      if (await isWallet40Enabled(app.getPage())) {
-        await app.marketBanner.clickExploreMarketHeader();
-      } else {
-        await app.layout.goToMarket();
-      }
-
+      await app.layout.goToMarket();
       await app.swap.goAndWaitForSwapToBeReady(() =>
         app.market.startSwapForSelectedTicker(swapEntryPoint.swap.accountToDebit.currency.ticker),
       );
@@ -139,13 +132,7 @@ test.describe("Swap flow from different entry point", () => {
     },
     async ({ app }) => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
-      if (await isWallet40Enabled(app.getPage())) {
-        await app.marketBanner.clickExploreMarketHeader();
-      } else {
-        await app.layout.goToMarket();
-      }
-
+      await app.layout.goToMarket();
       await app.market.openCoinPage(swapEntryPoint.swap.accountToDebit.currency.ticker);
       await app.swap.goAndWaitForSwapToBeReady(() => app.market.clickOnSwapButtonOnAsset());
       await app.swap.checkAssetToContains(swapEntryPoint.swap.accountToDebit.currency.name);

--- a/e2e/desktop/tests/specs/main.navigation.spec.ts
+++ b/e2e/desktop/tests/specs/main.navigation.spec.ts
@@ -2,7 +2,6 @@ import { test } from "tests/fixtures/common";
 import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
-import { LWD_WALLET_40_FF_ENABLED } from "tests/utils/featureFlagUtils";
 
 const DEVICE_TAGS = ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"] as const;
 
@@ -11,7 +10,6 @@ test.describe("Main navigation", () => {
     teamOwner: Team.WALLET_XP,
     userdata: "1AccountBTC1AccountETH",
     featureFlags: {
-      ...LWD_WALLET_40_FF_ENABLED,
       referralProgramDesktopSidebar: {
         enabled: true,
         params: {

--- a/e2e/desktop/tests/specs/market.spec.ts
+++ b/e2e/desktop/tests/specs/market.spec.ts
@@ -3,13 +3,11 @@ import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
-import { LWD_WALLET_40_FF_ENABLED } from "tests/utils/featureFlagUtils";
 
 test.describe("Market", () => {
   test.use({
     teamOwner: Team.WALLET_XP,
     userdata: "speculos-tests-app",
-    featureFlags: LWD_WALLET_40_FF_ENABLED,
   });
 
   test(

--- a/e2e/desktop/tests/specs/marketBanner.spec.ts
+++ b/e2e/desktop/tests/specs/marketBanner.spec.ts
@@ -3,13 +3,11 @@ import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { expect } from "@playwright/test";
 import { addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
-import { LWD_WALLET_40_FF_ENABLED } from "tests/utils/featureFlagUtils";
 
 test.describe("Market Banner", () => {
   test.use({
     teamOwner: Team.WALLET_XP,
     userdata: "speculos-tests-app",
-    featureFlags: LWD_WALLET_40_FF_ENABLED,
   });
 
   test(

--- a/e2e/desktop/tests/specs/portfolio.spec.ts
+++ b/e2e/desktop/tests/specs/portfolio.spec.ts
@@ -2,16 +2,13 @@ import { test } from "tests/fixtures/common";
 import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
-import { LWD_WALLET_40_FF_DISABLED, LWD_WALLET_40_FF_ENABLED } from "tests/utils/featureFlagUtils";
 import { Currency } from "@ledgerhq/live-common/e2e/enum/Currency";
 import { getModularSelector } from "tests/utils/modularSelectorUtils";
 
-// Skipping this suite as legacy is not visible on prod anymore
 test.describe.skip("Portfolio - legacy", () => {
   test.use({
     teamOwner: Team.WALLET_XP,
     userdata: "speculos-subAccount",
-    featureFlags: LWD_WALLET_40_FF_DISABLED,
   });
   test(
     "Charts are displayed when user added his accounts",
@@ -40,7 +37,6 @@ test.describe("Portfolio Wallet 4.0 - Zero balance state", () => {
   test.use({
     teamOwner: Team.WALLET_XP,
     userdata: "skip-onboarding-with-last-seen-device",
-    featureFlags: LWD_WALLET_40_FF_ENABLED,
   });
 
   test(
@@ -74,7 +70,6 @@ test.describe("Portfolio Wallet 4.0 - With Account", () => {
   test.use({
     teamOwner: Team.WALLET_XP,
     userdata: "1AccountSOL0Balance",
-    featureFlags: LWD_WALLET_40_FF_ENABLED,
   });
 
   test(
@@ -108,7 +103,6 @@ test.describe("Portfolio Wallet 4.0 - With Funds", () => {
   test.use({
     teamOwner: Team.WALLET_XP,
     userdata: "1AccountBTC1AccountETH",
-    featureFlags: LWD_WALLET_40_FF_ENABLED,
   });
 
   test(
@@ -135,7 +129,6 @@ test.describe("Portfolio Wallet 4.0 - No seen device (Reborn mode)", () => {
   test.use({
     teamOwner: Team.WALLET_XP,
     userdata: "skip-onboarding",
-    featureFlags: LWD_WALLET_40_FF_ENABLED,
   });
 
   test(
@@ -160,7 +153,6 @@ test.describe("Portfolio Wallet 4.0 - add funded account", () => {
   test.use({
     teamOwner: Team.WALLET_XP,
     userdata: "1AccountSOL0Balance",
-    featureFlags: LWD_WALLET_40_FF_ENABLED,
     speculosApp: currency.speculosApp,
   });
 

--- a/e2e/desktop/tests/specs/portfolio.spec.ts
+++ b/e2e/desktop/tests/specs/portfolio.spec.ts
@@ -5,34 +5,6 @@ import { getDescription } from "tests/utils/customJsonReporter";
 import { Currency } from "@ledgerhq/live-common/e2e/enum/Currency";
 import { getModularSelector } from "tests/utils/modularSelectorUtils";
 
-test.describe.skip("Portfolio - legacy", () => {
-  test.use({
-    teamOwner: Team.WALLET_XP,
-    userdata: "speculos-subAccount",
-  });
-  test(
-    "Charts are displayed when user added his accounts",
-    {
-      tag: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"],
-      annotation: {
-        type: "TMS",
-        description: "B2CQA-927, B2CQA-928, B2CQA-3038",
-      },
-    },
-    async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
-      await app.mainNavigation.openTargetFromMainNavigation("home");
-      await app.portfolio.checkBuySellButtonVisibility();
-      await app.portfolio.checkStakeButtonVisibility();
-      await app.portfolio.checkEmbeddedSwapContainerVisibility();
-      await app.swap.expectSelectedAssetDisplayed(/ETH|BTC/);
-      await app.portfolio.checkChartVisibility();
-      await app.portfolio.checkAssetAllocationSection();
-    },
-  );
-});
-
 test.describe("Portfolio Wallet 4.0 - Zero balance state", () => {
   test.use({
     teamOwner: Team.WALLET_XP,

--- a/e2e/desktop/tests/utils/featureFlagUtils.ts
+++ b/e2e/desktop/tests/utils/featureFlagUtils.ts
@@ -8,11 +8,6 @@ export const getFeatureFlags = async (page: Page): Promise<OptionalFeatureMap> =
   return featureFlags;
 };
 
-export const isWallet40Enabled = async (page: Page): Promise<boolean> => {
-  const featureFlags = await getFeatureFlags(page);
-  return featureFlags.lwdWallet40?.enabled === true;
-};
-
 const lwdWallet40BaseParams = {
   marketBanner: true,
   graphRework: true,
@@ -20,14 +15,6 @@ const lwdWallet40BaseParams = {
   mainNavigation: true,
   assetSection: true,
 } as const;
-
-// TODO: remove when wallet 4.0 is default
-export const LWD_WALLET_40_FF_ENABLED: OptionalFeatureMap = {
-  lwdWallet40: {
-    enabled: true,
-    params: { ...lwdWallet40BaseParams },
-  },
-};
 
 // TODO: remove when wallet 4.0 Q2 is default
 export const LWD_WALLET_40_Q2_FF_ENABLED: OptionalFeatureMap = {
@@ -40,16 +27,10 @@ export const LWD_WALLET_40_Q2_FF_ENABLED: OptionalFeatureMap = {
   },
 };
 
-// TODO: remove when wallet 4.0 is default
-export const LWD_WALLET_40_FF_DISABLED: OptionalFeatureMap = {
-  lwdWallet40: { enabled: false },
-};
-
 export const useLocalEarnManifest = process.env.USE_LOCAL_EARN_MANIFEST === "1";
 
 export const EARN_V1_DESKTOP_FLAGS: OptionalFeatureMap = {
   ptxEarnUi: { enabled: false, params: { value: "v1" } },
-  ...LWD_WALLET_40_FF_DISABLED,
 };
 
 export const EARN_V2_DESKTOP_FLAGS: OptionalFeatureMap = {
@@ -57,5 +38,4 @@ export const EARN_V2_DESKTOP_FLAGS: OptionalFeatureMap = {
     ptxEarnLiveApp: { enabled: true, params: { manifest_id: "earn-local-manifest" } },
   }),
   ptxEarnUi: { enabled: true, params: { value: "v2" } },
-  ...LWD_WALLET_40_FF_ENABLED,
 };

--- a/e2e/desktop/tests/utils/global.setup.ts
+++ b/e2e/desktop/tests/utils/global.setup.ts
@@ -36,7 +36,6 @@ export default async function globalSetup(_config: FullConfig) {
     [
       `SPECULOS_DEVICE=${SPECULOS_DEVICE}`,
       `SPECULOS_FIRMWARE_VERSION=${SPECULOS_FIRMWARE_VERSION}`,
-      `WALLET=${process.env.E2E_ENABLE_WALLET40 === "0" ? "Legacy" : "Wallet 4.0"}`,
       "",
     ].join("\n"),
     { encoding: "utf8", flag: "w" },


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Desktop E2E test suite (Playwright): buy/sell, swap, delegate, portfolio, market, navigation, addresses
  - Removal of the `E2E_ENABLE_WALLET40` env var and `isWallet40Enabled()` helper from E2E utilities
  - Default feature flags wiring in `fixtures/common.ts` (no more legacy/4.0 conditional spread)
  - Global setup log line in `global.setup.ts` (no more `WALLET=Legacy/Wallet 4.0` output)
  - README: removed the Wallet 4.0 section (#6) and renumbered subsequent sections

### ⚠️ Merge Prerequisites — DO NOT MERGE UNTIL

This PR removes the legacy/4.0 toggle in E2E and assumes Wallet 4.0 is the default everywhere. It can **only** be merged once **both** of the following are in place:

- [x] **Mock-side feature flags forced to Wallet 4.0** in:
  - `apps/ledger-live-desktop/tests/specs`
  - `apps/ledger-live-mobile/e2e/specs`
- [x] **Wallet 4.0 feature flag activated on Firebase** for test builds.

Merging before these conditions are met will break test runs that rely on the (now removed) legacy/4.0 conditional path.

### Description

Wallet 4.0 is now the default and permanent UI on desktop. The desktop E2E test suite still carried the dual-mode legacy/4.0 plumbing: the `E2E_ENABLE_WALLET40` env var, the `isWallet40Enabled()` helper, the `LWD_WALLET_40_FF_ENABLED` / `LWD_WALLET_40_FF_DISABLED` flag bundles, plus `if/else` branches inside specs to handle both UIs. This added noise, duplicated assertions, and made specs harder to read.

This PR removes all Wallet 4.0 legacy toggles and conditional branches from the desktop E2E test suite, keeping only the 4.0 path. The `LWD_WALLET_40_Q2_FF_ENABLED` bundle is preserved since the Q2 rollout is still in progress. Touched files: `fixtures/common.ts`, `utils/featureFlagUtils.ts`, `utils/global.setup.ts`, specs (`buySell`, `delegate`, `entrypoint.swap`, `main.navigation`, `market`, `marketBanner`, `portfolio`, `assets.addresses`), `page/market.page.ts`, and the desktop E2E `README.md`.

### Context

- **JIRA or GitHub link**: [QAA-1116](https://ledgerhq.atlassian.net/browse/QAA-1116)
- Desktop Manual CI: https://github.com/LedgerHQ/ledger-live/actions/runs/26511287466
---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-1116]: https://ledgerhq.atlassian.net/browse/QAA-1116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ