### PR TITLE
[LWDM] test(zcash): update activate private balance [LIVE-30955]

### DIFF
--- a/.changeset/wise-dolls-chew.md
+++ b/.changeset/wise-dolls-chew.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Update E2E test for activating private balance on Zcash

--- a/libs/ledger-live-common/src/e2e/speculos.ts
+++ b/libs/ledger-live-common/src/e2e/speculos.ts
@@ -1079,16 +1079,12 @@ export const exportUfvk = withDeviceController(
   ({ getButtonsController }) =>
     async (account: Account) => {
       const buttons = getButtonsController();
-      const { receiveVerifyLabel, receiveConfirmLabel } = getDeviceLabels(
-        account.currency.speculosApp,
-      );
-      await waitFor(receiveVerifyLabel);
 
       if (isTouchDevice()) {
-        await pressUntilTextFound(receiveConfirmLabel);
+        await pressUntilTextFound(DeviceLabels.CONFIRM);
         await pressAndRelease(DeviceLabels.CONFIRM);
       } else {
-        await pressUntilTextFound(receiveConfirmLabel);
+        await pressUntilTextFound(DeviceLabels.CONFIRM);
         await buttons.both();
       }
     },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - @ledgerhq/live-common, ledger-live-desktop-e2e-tests

### 📝 Description

Update E2E test for activating private balance for Zcash.

_**NOTE**_:
This requires app Zcash version 3.3.0.
By default, when running the test, the catalog (`e2e/desktop/tests/artifacts/appVersion/nano-app-catalog.json`) will be set to use version 3.0.0, most likely because version 3.3.0 is not available in P1 (only P4). In order to test this I had to make changes to `e2e/desktop/tests/utils/global.setup.ts` to force version 3.3.0.
I tested with `nanoSP` and `europa`.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-30955


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
