### PR TITLE
[LWD] build(zcash): include zcash-utils [LIVE-31167]

### DIFF
--- a/.changeset/mighty-zebras-stare.md
+++ b/.changeset/mighty-zebras-stare.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix build to include zcash-utils

--- a/apps/ledger-live-desktop/electron-builder-nightly.yml
+++ b/apps/ledger-live-desktop/electron-builder-nightly.yml
@@ -63,6 +63,7 @@ nsis:
 files:
   # Include files
   - .webpack/**/*
+  - "node_modules/@ledgerhq/zcash-utils/**/*"
   - from: "dist/node_modules"
     to: "node_modules"
     filter:
@@ -103,3 +104,6 @@ npmRebuild: false
 publish:
   - provider: generic
     url: https://download.live.ledger.com
+
+asarUnpack:
+  - "node_modules/@ledgerhq/zcash-utils/**/*"

--- a/apps/ledger-live-desktop/electron-builder-nosign.yml
+++ b/apps/ledger-live-desktop/electron-builder-nosign.yml
@@ -47,6 +47,7 @@ nsis:
 files:
   # Include files
   - .webpack/**/*
+  - "node_modules/@ledgerhq/zcash-utils/**/*"
   - from: "dist/node_modules"
     to: "node_modules"
     filter:
@@ -83,3 +84,6 @@ files:
 # Disable native module rebuilding since we removed all native dependencies (node-hid, usb)
 buildDependenciesFromSource: false
 npmRebuild: false
+
+asarUnpack:
+  - "node_modules/@ledgerhq/zcash-utils/**/*"

--- a/apps/ledger-live-desktop/electron-builder-pre.yml
+++ b/apps/ledger-live-desktop/electron-builder-pre.yml
@@ -63,6 +63,7 @@ files:
   # Include files
   - .webpack/**/*
   - "!.webpack/**/*.js.map"
+  - "node_modules/@ledgerhq/zcash-utils/**/*"
   - from: "dist/node_modules"
     to: "node_modules"
     filter:
@@ -103,3 +104,6 @@ npmRebuild: false
 publish:
   - provider: generic
     url: https://download.live.ledger.com
+
+asarUnpack:
+  - "node_modules/@ledgerhq/zcash-utils/**/*"

--- a/apps/ledger-live-desktop/electron-builder.yml
+++ b/apps/ledger-live-desktop/electron-builder.yml
@@ -59,6 +59,7 @@ files:
   # Include files
   - .webpack/**/*
   - "!.webpack/**/*.js.map"
+  - "node_modules/@ledgerhq/zcash-utils/**/*"
   - from: "dist/node_modules"
     to: "node_modules"
     filter:
@@ -100,3 +101,6 @@ npmRebuild: false
 publish:
   - provider: generic
     url: https://download.live.ledger.com
+
+asarUnpack:
+  - "node_modules/@ledgerhq/zcash-utils/**/*"


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ledger-live-desktop

### 📝 Description

#### Why the packaged app can't find it
electron-builder.yml ships only .webpack/**/* plus whatever is under dist/node_modules:


electron-builder.yml
Lines 58-94
```
files:
  # Include files
  - .webpack/**/*
  - "!.webpack/**/*.js.map"
  - from: "dist/node_modules"
    to: "node_modules"
    filter:
      - "**/*"
      ...
  # Exclude files
  - "!node_modules"
 ```

Two important things follow from that config:

1. The LLD node_modules/ (where pnpm has symlinked @ledgerhq/zcash-utils to node_modules/.pnpm/@ledgerhq+zcash-utils@0.2.0/...) is explicitly excluded by "!node_modules".
2. Anything that ships must come from apps/ledger-live-desktop/dist/node_modules/. But nothing in the build pipeline (tools/dist/index.js, scripts/post-install.js, scripts/afterPack.js, electron-builder install-app-deps) actually creates or populates that folder. dist/ is just electron-builder's output directory.

You can confirm this on the build you have on disk. The produced app.asar contains only .webpack/, no node_modules/, and there is no sibling app.asar.unpacked/ either:

```
$ npx @electron/asar list "Ledger Wallet.app/Contents/Resources/app.asar" | head
/.webpack
/.webpack/108.renderer.bundle.js
... (387 entries, all under /.webpack)
$ ls "Ledger Wallet.app/Contents/Resources"
app.asar     icon.icns    *.lproj/   app-update.yml      # no app.asar.unpacked
$ grep -E "zcash|node_modules" /tmp/asar-list.txt
/.webpack/zcash-utility.bundle.js
/.webpack/zcash-utility.bundle.js.map
```

So the UtilityProcess starts, the engine runs import("@ledgerhq/zcash-utils"), Node's resolver can't find a node_modules/@ledgerhq/zcash-utils anywhere from inside app.asar, and you get Cannot find module '@ledgerhq/zcash-utils'. That rejection propagates back through the ipcMain.handle promise in main-host.ts and shows up to the renderer as Error invoking remote method 'zcash:findBlockHeight': Error: Cannot find module '@ledgerhq/zcash-utils'.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-31167


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
