### PR TITLE
[LWD] fix(desktop): stabilize concordium OnboardModal happy-path test

### DIFF
--- a/.changeset/concordium-onboard-test-stable-pair-timing.md
+++ b/.changeset/concordium-onboard-test-stable-pair-timing.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Stabilize Concordium OnboardModal happy-path test by widening the gap between PREPARE/SIGN and SUCCESS in the mock observables so the intermediate state-update timeout has time to land on slow CI runners

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/OnboardModal.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/OnboardModal.test.tsx
@@ -48,10 +48,13 @@ function createMockPairObservable() {
       const t1 = setTimeout(() => {
         next({ status: "PREPARE", walletConnectUri: "wc:mock-uri-for-testing" });
       }, 10);
+      // SUCCESS must fire well after the PREPARE state-update setTimeout (T) has
+      // landed; otherwise setStateWithTimeout clears the pending PREPARE update
+      // and the QR step is skipped — flaky on busy CI runners.
       const t2 = setTimeout(() => {
         next({ status: "SUCCESS", sessionTopic: SESSION_TOPIC });
         complete();
-      }, T + 200);
+      }, T + 800);
 
       return {
         unsubscribe: jest.fn(() => {
@@ -72,7 +75,7 @@ function createMockOnboardObservable(completedAccount: Account) {
       const t2 = setTimeout(() => {
         next({ account: completedAccount });
         complete();
-      }, T + 200);
+      }, T + 800);
 
       return {
         unsubscribe: jest.fn(() => {


### PR DESCRIPTION
## Summary

- The `OnboardModal › should complete the full onboarding happy path` test in `apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/OnboardModal.test.tsx` has been [intermittently failing in CI](https://github.com/LedgerHQ/ledger-live/actions/runs/26166538150/job/76972126524) with `Unable to find an element with the text: /scan the qr code/i`.
- Root cause is a race in `OnboardModal.setStateWithTimeout` (`apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/index.tsx:205-216`): every progress event calls `clearStepTransitionTimeout()` *first* and then re-schedules a new 1500 ms state-update timeout. The mock observables fired their terminal `SUCCESS` event only 200 ms after the intermediate `PREPARE`/`SIGN` event — so the PREPARE state-update timeout (scheduled at `T + 10` ≈ 1510 ms) had only a ~190 ms window to actually land before the next `setStateWithTimeout` cleared it. On a busy CI runner the PREPARE update was discarded and the QR-code intermediate UI never rendered.
- Fix: widen the gap in both `createMockPairObservable` and `createMockOnboardObservable` from `T + 200` to `T + 800`, giving ~800 ms of headroom for the intermediate state to apply before the terminal event arrives.

## Tradeoff

The happy-path test now runs ≈1.2 s longer (≈4.3 s → ≈5.5 s). That's not ideal, but improving stability of the merge pipeline is the right call for now — the alternative (refactoring `setStateWithTimeout` or switching the test to fake timers) is a bigger change we can revisit separately. `WAIT_OPTS` (3500 ms) and per-test timeouts (10–25 s) are unaffected.

## Test plan

- [ ] CI passes on this PR
- [ ] Re-run the Desktop Unit Tests job a few times to confirm the test is stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)