### PR TITLE
[LWDM] chore(client-ids): update /v2/pushdevices

### DIFF
--- a/.changeset/client-ids-analytics-optin-gate.md
+++ b/.changeset/client-ids-analytics-optin-gate.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/client-ids": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Gate the device-ids push middleware behind the `analyticsOptIn` feature flag in addition to the user analytics consent. Device IDs are now only sent to `/v2/pushdevices` when the FF is enabled AND the user has opted in.

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.test.ts
@@ -16,6 +16,7 @@ import reducer, {
   SettingsState,
   filterValidSettings,
   trackingEnabledSelector,
+  canPushDeviceIdsSelector,
 } from "./settings";
 const invalidDeviceModelIds = ["nanoFTS", undefined, "whatever"];
 const validDeviceModelIds: DeviceModelId[] = Object.values(DeviceModelId);
@@ -674,5 +675,43 @@ describe("trackingEnabledSelector", () => {
         },
       }),
     ).toBe(true);
+  });
+});
+
+describe("canPushDeviceIdsSelector", () => {
+  const FIXED_NOW = new Date("2024-06-15T12:00:00.000Z");
+
+  beforeAll(() => jest.useFakeTimers());
+  afterAll(() => jest.useRealTimers());
+  beforeEach(() => jest.setSystemTime(FIXED_NOW));
+
+  const optedInSettings: Partial<SettingsState> = {
+    lastAnalyticsConsentDate: FIXED_NOW.toISOString(),
+    privacyPolicyVersion: 1,
+    shareAnalytics: true,
+    sharePersonalizedRecommandations: true,
+  };
+
+  it("returns false when FF is off (regardless of user opt-in)", () => {
+    expect(
+      canPushDeviceIdsSelector(mockStateWithSettings(optedInSettings, { enabled: false })),
+    ).toBe(false);
+  });
+
+  it("returns false when FF is on but user has not opted in", () => {
+    expect(
+      canPushDeviceIdsSelector(
+        mockStateWithSettings({
+          lastAnalyticsConsentDate: FIXED_NOW.toISOString(),
+          privacyPolicyVersion: 1,
+          shareAnalytics: false,
+          sharePersonalizedRecommandations: false,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns true only when FF is on and user has opted in", () => {
+    expect(canPushDeviceIdsSelector(mockStateWithSettings(optedInSettings))).toBe(true);
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -44,6 +44,7 @@ import {
   needsConsentRenewal,
   resolveAnalyticsOptInParams,
 } from "@ledgerhq/live-common/analyticsConsent/index";
+import { selectFeature } from "@shared/feature-flags";
 
 /* Initial state */
 
@@ -789,6 +790,9 @@ export const trackingEnabledSelector = (state: State) => {
 
   return s.shareAnalytics || s.sharePersonalizedRecommandations;
 };
+export const canPushDeviceIdsSelector = (state: State) =>
+  !!selectFeature(state, "analyticsOptIn")?.enabled && trackingEnabledSelector(state);
+
 export const selectedTimeRangeSelector = (state: State) => state.settings.selectedTimeRange;
 export const hasInstalledAppsSelector = (state: State) => state.settings.hasInstalledApps;
 export const USBTroubleshootingIndexSelector = (state: State) =>

--- a/apps/ledger-live-desktop/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-desktop/src/state-manager/configureStore.ts
@@ -4,7 +4,7 @@ import logger from "~/renderer/middlewares/logger";
 import reducers, { State } from "~/renderer/reducers";
 import { applyLldRTKApiMiddlewares } from "~/renderer/reducers/rtkQueryApi";
 import { createIdentitiesSyncMiddleware } from "@ledgerhq/client-ids/store";
-import { trackingEnabledSelector } from "~/renderer/reducers/settings";
+import { canPushDeviceIdsSelector } from "~/renderer/reducers/settings";
 import { createFeatureFlagsMiddleware } from "@shared/feature-flags";
 type Props = {
   state?: State;
@@ -26,7 +26,7 @@ const customCreateStore = ({ state, dbMiddleware, analyticsMiddleware }: Props) 
         .concat(
           createIdentitiesSyncMiddleware({
             getIdentitiesState: (state: State) => state.identities,
-            getAnalyticsConsent: (state: State) => trackingEnabledSelector(state),
+            getAnalyticsConsent: canPushDeviceIdsSelector,
           }),
         )
         .concat(

--- a/apps/ledger-live-mobile/src/reducers/settings.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.test.ts
@@ -9,6 +9,7 @@ import reducer, {
   resolvedThemeSelector,
   themeSelector,
   trackingEnabledSelector,
+  canPushDeviceIdsSelector,
   INITIAL_STATE as SETTINGS_INITIAL_STATE,
   filterValidSettings,
 } from "./settings";
@@ -43,6 +44,7 @@ const stateWithSettings = (settingsPatch: Partial<SettingsState>): State => ({
 const withAnalyticsOptInResolved = (
   base: State,
   params: Partial<{ policyVersion: number; consentValidityDays: number }> = {},
+  enabled = true,
 ): State =>
   ({
     ...base,
@@ -55,7 +57,7 @@ const withAnalyticsOptInResolved = (
         analyticsOptIn: {
           ...FEATURE_FLAGS_INITIAL_STATE.resolved.analyticsOptIn,
           ...base.featureFlags?.resolved?.analyticsOptIn,
-          enabled: true,
+          enabled,
           params: {
             ...FEATURE_FLAGS_INITIAL_STATE.resolved.analyticsOptIn.params,
             ...base.featureFlags?.resolved?.analyticsOptIn?.params,
@@ -245,6 +247,50 @@ describe("trackingEnabledSelector", () => {
       personalizedRecommendationsEnabled: true,
     });
     expect(trackingEnabledSelector(state)).toBe(true);
+  });
+});
+
+describe("canPushDeviceIdsSelector", () => {
+  const FIXED_NOW = new Date("2026-03-01T12:00:00.000Z");
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(FIXED_NOW);
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const optedInState = (): State =>
+    withAnalyticsOptInResolved(
+      stateWithSettings({
+        analyticsConsentInfo: { consentDate: FIXED_NOW.toISOString(), privacyPolicyVersion: 1 },
+        analyticsEnabled: true,
+        personalizedRecommendationsEnabled: true,
+      }),
+    );
+
+  it("returns false when FF is off (regardless of user opt-in)", () => {
+    const state = withAnalyticsOptInResolved(
+      stateWithSettings({ analyticsEnabled: true }),
+      {},
+      false,
+    );
+    expect(canPushDeviceIdsSelector(state)).toBe(false);
+  });
+
+  it("returns false when FF is on but user has not opted in", () => {
+    const state = withAnalyticsOptInResolved(
+      stateWithSettings({
+        analyticsConsentInfo: { consentDate: FIXED_NOW.toISOString(), privacyPolicyVersion: 1 },
+        analyticsEnabled: false,
+        personalizedRecommendationsEnabled: false,
+      }),
+    );
+    expect(canPushDeviceIdsSelector(state)).toBe(false);
+  });
+
+  it("returns true only when FF is on and user has opted in", () => {
+    expect(canPushDeviceIdsSelector(optedInState())).toBe(true);
   });
 });
 

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -14,6 +14,7 @@ import { DeviceModelId } from "@ledgerhq/types-devices";
 import type { CurrencySettings, SettingsState, State, Theme } from "./types";
 import { currencySettingsDefaults } from "../helpers/CurrencySettingsDefaults";
 import { getDefaultLanguageLocale, getDefaultLocale } from "../languages";
+import { selectFeature } from "@shared/feature-flags";
 import type {
   SettingsBlacklistTokenPayload,
   SettingsDismissBannerPayload,
@@ -778,6 +779,8 @@ export const trackingEnabledSelector = (state: State) => {
   }
   return settings.analyticsEnabled || settings.personalizedRecommendationsEnabled;
 };
+export const canPushDeviceIdsSelector = (state: State) =>
+  !!selectFeature(state, "analyticsOptIn")?.enabled && trackingEnabledSelector(state);
 export const lastSeenCustomImageSelector = createSelector(
   settingsStoreSelector,
   s => s.lastSeenCustomImage,

--- a/apps/ledger-live-mobile/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-mobile/src/state-manager/configureStore.ts
@@ -12,7 +12,7 @@ import { setupCryptoAssetsStore } from "~/config/bridge-setup";
 import { setupRecentAddressesStore } from "LLM/storage/recentAddresses";
 import { createIdentitiesSyncMiddleware } from "@ledgerhq/client-ids/store";
 import { State } from "~/reducers/types";
-import { trackingEnabledSelector } from "~/reducers/settings";
+import { canPushDeviceIdsSelector } from "~/reducers/settings";
 import { createFeatureFlagsMiddleware } from "@shared/feature-flags";
 
 export const store = configureStore({
@@ -26,7 +26,7 @@ export const store = configureStore({
       .concat(
         createIdentitiesSyncMiddleware({
           getIdentitiesState: (state: State) => state.identities,
-          getAnalyticsConsent: (state: State) => trackingEnabledSelector(state),
+          getAnalyticsConsent: canPushDeviceIdsSelector,
         }),
       )
       .concat(

--- a/libs/client-ids/src/api/api.ts
+++ b/libs/client-ids/src/api/api.ts
@@ -39,7 +39,7 @@ export const pushDevicesApi = createApi({
       query: body => {
         const baseUrl = getEnv("PUSH_DEVICES_SERVICE_URL");
         return {
-          url: `${baseUrl}/pushdevices`,
+          url: `${baseUrl}/v2/pushdevices`,
           method: "POST",
           body,
         };

--- a/libs/client-ids/src/store/middleware.ts
+++ b/libs/client-ids/src/store/middleware.ts
@@ -32,7 +32,10 @@ export interface SyncMiddlewareConfig<State = unknown> {
 
   /**
    * Selector to get analytics consent from the global state
-   * This avoids duplicating analytics consent in the identities state
+   * This avoids duplicating analytics consent in the identities state.
+   * The app is responsible for combining all consent gates (e.g. the
+   * `analyticsOptIn` remote feature flag AND the user's stored opt-in)
+   * so the middleware only pushes device IDs when this returns true.
    */
   getAnalyticsConsent: (state: State) => boolean;
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [ ] **Impact of the changes:**
  - No device ID is sent until the `analyticsOptIn` FF is enabled AND the user opts in.
  - Endpoint moved from `/pushdevices` to `/v2/pushdevices`.

### 📝 Description

Two coupled changes shipped together:

- Switch `pushDevicesApi` endpoint from `/pushdevices` to `/v2/pushdevices`.
- Gate `createIdentitiesSyncMiddleware` behind the `analyticsOptIn` remote feature flag in addition to the existing user opt-in. Both apps now compose the selector:

```ts
export const canPushDeviceIdsSelector = (state: State) =>
  !!selectFeature(state, "analyticsOptIn")?.enabled && trackingEnabledSelector(state);
```

### ❓ Context

- **JIRA**: [LIVE-31193](https://ledgerhq.atlassian.net/browse/LIVE-31193) (epic [LIVE-31190](https://ledgerhq.atlassian.net/browse/LIVE-31190))
- **ADR link (if any)**: —

[LIVE-31193]: https://ledgerhq.atlassian.net/browse/LIVE-31193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-31190]: https://ledgerhq.atlassian.net/browse/LIVE-31190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ