### PR TITLE
[LWDM] fix(common): round fiat price before formatting market trend display

### DIFF
--- a/.changeset/purple-snails-dance.md
+++ b/.changeset/purple-snails-dance.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+fix rounding regarding new rates when changing countervalues for dada

--- a/libs/ledger-live-common/src/modularDrawer/hooks/modules/useRightMarketTrendModule.tsx
+++ b/libs/ledger-live-common/src/modularDrawer/hooks/modules/useRightMarketTrendModule.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from "react";
 import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { roundFiatPrice } from "@ledgerhq/live-currency-format";
 import { useMarketByCurrencies } from "../../../dada-client/hooks/useMarketByCurrencies";
 import counterValueFormatter from "../../../market/utils/countervalueFormatter";
 import { useUsdToFiatRate } from "../../../counterValues/hooks/useUsdToFiatRate";
@@ -41,7 +42,7 @@ export const useRightMarketTrendModule = (
       }
 
       const priceFormatted = counterValueFormatter({
-        value: currencyMarket.price * rate,
+        value: roundFiatPrice(currencyMarket.price * rate),
         currency: counterValueCurrency.ticker,
         locale,
       });


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Existing `createAssetConfiguration` integration tests cover the market trend wiring, but no test asserts `roundFiatPrice` behavior on converted prices._
- [x] **Impact of the changes:**
  - Modular drawer asset selection when `rightElement` is `marketTrend`
  - Market price display after changing counter value currency
  - Fiat price formatting consistency with the rest of the app

### 📝 Description

**Problem**: In the modular drawer market trend module, converted market prices were passed directly to `counterValueFormatter` without applying `roundFiatPrice`. When the USD market price was multiplied by the user's counter value rate, floating-point noise could produce inconsistent or overly precise displayed values.

**Solution**: Apply `roundFiatPrice` before formatting the converted price in `useRightMarketTrendModule`:

```tsx
const priceFormatted = counterValueFormatter({
  value: roundFiatPrice(currencyMarket.price * rate),
  currency: counterValueCurrency.ticker,
  locale,
});
```

This aligns market trend price display with the rounding rules used elsewhere in the app.


https://github.com/user-attachments/assets/1d9a5d58-85dc-4b8a-b3ec-e0233b528761



### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-31195

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)