### PR TITLE
[LWDM] chore(tests): force mock specs to stay on legacy Wallet 4.0 FF

### DIFF
--- a/apps/ledger-live-desktop/tests/fixtures/common.ts
+++ b/apps/ledger-live-desktop/tests/fixtures/common.ts
@@ -98,7 +98,11 @@ export const test = base.extend<TestFixtures>({
         PLAYWRIGHT_RUN: true,
         CRASH_ON_INTERNAL_CRASH: true,
         LEDGER_MIN_HEIGHT: 768,
-        FEATURE_FLAGS: JSON.stringify(featureFlags),
+        // NOTE: KEEP WALLET 4.0 disabled for legacy mocks
+        FEATURE_FLAGS: JSON.stringify({
+          lwdWallet40: { enabled: false },
+          ...featureFlags,
+        }),
       },
       env,
     );

--- a/apps/ledger-live-mobile/e2e/page/index.ts
+++ b/apps/ledger-live-mobile/e2e/page/index.ts
@@ -92,9 +92,11 @@ export class Application {
       await loadAccounts(this.testAccounts);
     }
 
-    if (featureFlags) {
-      await setFeatureFlags(featureFlags);
-    }
+    // NOTE: KEEP WALLET 4.0 disabled for legacy mocks
+    await setFeatureFlags({
+      lwmWallet40: { enabled: false },
+      ...featureFlags,
+    });
   }
 
   public get assetAccountsPage() {


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _N/A — change is to E2E test fixture infrastructure only; no app/library behavior change._
- [x] **Covered by automatic tests.** _N/A — this change IS the test infrastructure; it is exercised implicitly by the entire mock E2E suite._
- [x] **Impact of the changes:**
  - Desktop Playwright mock suite (`apps/ledger-live-desktop/tests/specs/`) — confirm specs still pass and screenshots match the legacy (pre-Wallet 4.0) UI
  - Mobile Detox mock suite (`apps/ledger-live-mobile/e2e/specs/`) — confirm specs still pass against the legacy UI
  - No production app code is touched; no impact outside the mock E2E test environments

### 📝 Description

**Problem.** Wallet 4.0 (`lwdWallet40` on desktop, `lwmWallet40` on mobile) is moving toward becoming the default rollout. The mock E2E suites in `apps/ledger-live-desktop/tests/specs/` and `apps/ledger-live-mobile/e2e/specs/` have not been migrated to Wallet 4.0 — their screenshots and selectors target the legacy UI. Once the FF flips to default-on, those specs break.

**Solution.** Inject a baseline `{ enabled: false }` override at the single shared fixture point on each side, so all mock specs continue running against the legacy UI by default. Per-spec overrides still win (the spread order `baseline → ...featureFlags` makes any future migration spec able to opt back in via `lwdWallet40: { enabled: true }` / `lwmWallet40: { enabled: true }` in its own `test.use({ ... })` / `app.init({ ... })` call).

**Files touched:**
- `apps/ledger-live-desktop/tests/fixtures/common.ts` — desktop Playwright fixture (`electronApp` → `FEATURE_FLAGS` env var)
- `apps/ledger-live-mobile/e2e/page/index.ts` — mobile Detox `Application.init`

**Notes:**
- 9 desktop mock specs already set `lwdWallet40: { enabled: false }` per-spec; they become redundant but are left in place (separate cleanup).
- Mobile `Application.init` now always calls `setFeatureFlags` (the previous `if (featureFlags)` guard was removed) so the baseline applies even when a spec passes no overrides.

### ❓ Context

- **JIRA or GitHub link**: [QAA-1216](https://ledgerhq.atlassian.net/browse/QAA-1216)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[QAA-1216]: https://ledgerhq.atlassian.net/browse/QAA-1216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ