### PR TITLE
[LWDM] feat(evm-staking): claim rewards flow on mobile

### DIFF
--- a/.changeset/wire-evm-claim-rewards-flow.md
+++ b/.changeset/wire-evm-claim-rewards-flow.md
@@ -1,0 +1,7 @@
+---
+"live-mobile": minor
+"@ledgerhq/coin-evm": minor
+"@ledgerhq/live-common": patch
+---
+
+Wire EVM claim rewards flow on mobile, emit fees-exceed-rewards bridge warning, and map `claimReward` staking operations to the `REWARD` type (optimistic and confirmed) so claimed rewards show as incoming in the operation history. Bump `@ledgerhq/coin-module-framework` to 3.2.0 so `'claimReward'` is part of the framework's `StakingOperation` union.

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
@@ -38,6 +38,7 @@ import type { CosmosUndelegationFlowParamList } from "../../../families/cosmos/U
 import type { EditTransactionParamList } from "../../../families/evm/EditTransactionFlow/EditTransactionParamList";
 import type { EvmDelegationFlowParamList } from "../../../families/evm/DelegationFlow/types";
 import type { EvmUndelegationFlowParamList } from "../../../families/evm/UndelegationFlow/types";
+import type { EvmClaimRewardsFlowParamList } from "../../../families/evm/ClaimRewardsFlow/types";
 import type { BitcoinEditTransactionParamList } from "../../../families/bitcoin/EditTransactionFlow/EditTransactionParamList";
 import type { PolkadotBondFlowParamList } from "../../../families/polkadot/BondFlow/types";
 import type { PolkadotNominateFlowParamList } from "../../../families/polkadot/NominateFlow/types";
@@ -291,6 +292,7 @@ export type BaseNavigatorStackParamList = {
   // EVM
   [NavigatorName.EvmDelegationFlow]: NavigatorScreenParams<EvmDelegationFlowParamList>;
   [NavigatorName.EvmUndelegationFlow]: NavigatorScreenParams<EvmUndelegationFlowParamList>;
+  [NavigatorName.EvmClaimRewardsFlow]: NavigatorScreenParams<EvmClaimRewardsFlowParamList>;
   [NavigatorName.EvmEditTransaction]: NavigatorScreenParams<EditTransactionParamList>;
 
   // Bitcoin edit transaction (RBF)

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -254,6 +254,12 @@ export enum ScreenName {
   EvmRedelegationConnectDevice = "EvmRedelegationConnectDevice",
   EvmRedelegationValidationError = "EvmRedelegationValidationError",
   EvmRedelegationValidationSuccess = "EvmRedelegationValidationSuccess",
+  EvmClaimRewardsValidator = "EvmClaimRewardsValidator",
+  EvmClaimRewardsClaim = "EvmClaimRewardsClaim",
+  EvmClaimRewardsSelectDevice = "EvmClaimRewardsSelectDevice",
+  EvmClaimRewardsConnectDevice = "EvmClaimRewardsConnectDevice",
+  EvmClaimRewardsValidationError = "EvmClaimRewardsValidationError",
+  EvmClaimRewardsValidationSuccess = "EvmClaimRewardsValidationSuccess",
 
   // cosmos
   CosmosFamilyEditMemo = "CosmosFamilyEditMemo",
@@ -631,6 +637,7 @@ export enum NavigatorName {
   BuyDevice = "BuyDevice",
   EvmDelegationFlow = "EvmDelegationFlow",
   EvmUndelegationFlow = "EvmUndelegationFlow",
+  EvmClaimRewardsFlow = "EvmClaimRewardsFlow",
   CosmosClaimRewardsFlow = "CosmosClaimRewardsFlow",
   CosmosDelegationFlow = "CosmosDelegationFlow",
   CosmosRedelegationFlow = "CosmosRedelegationFlow",

--- a/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/01-SelectValidator.test.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/01-SelectValidator.test.tsx
@@ -1,0 +1,88 @@
+import BigNumber from "bignumber.js";
+import React from "react";
+import { fireEvent, screen } from "@testing-library/react-native";
+import { render } from "@tests/test-renderer";
+import type { Account } from "@ledgerhq/types-live";
+import type { StakingMappedDelegation } from "@ledgerhq/live-common/families/evm/staking/types";
+import ClaimRewardsSelectValidator from "./01-SelectValidator";
+
+const account = {
+  id: "evm-sei_evm-1",
+  type: "Account",
+  currency: {
+    family: "evm",
+    id: "sei_evm",
+    ticker: "SEI",
+    units: [{ code: "SEI", magnitude: 18 }],
+  },
+  freshAddress: "0x0000000000000000000000000000000000000001",
+  stakingResources: { delegations: [], unbondings: [], redelegations: [] },
+} as unknown as Account;
+
+const makeDelegation = (name: string, pendingRewards: BigNumber): StakingMappedDelegation =>
+  ({
+    validatorAddress: `seivaloper1${name.toLowerCase()}`,
+    pendingRewards,
+    amount: new BigNumber("1e18"),
+    formattedAmount: "1 SEI",
+    formattedPendingRewards: pendingRewards.toString(),
+    rank: 0,
+    validator: {
+      validatorAddress: `seivaloper1${name.toLowerCase()}`,
+      name,
+      votingPower: 0,
+      commission: 0.05,
+      estimatedYearlyRewardsRate: 0.1,
+      tokens: "0",
+    },
+  }) as unknown as StakingMappedDelegation;
+
+const mockNavigate = jest.fn();
+const mockDelegations: StakingMappedDelegation[] = [];
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+  useRoute: () => ({ params: { accountId: account.id } }),
+}));
+jest.mock("LLM/hooks/useAccountScreen", () => ({
+  useAccountScreen: () => ({ account, parentAccount: undefined }),
+}));
+jest.mock("LLM/hooks/useAccountUnit", () => ({
+  useAccountUnit: () => ({ code: "SEI", magnitude: 18 }),
+}));
+jest.mock("@ledgerhq/live-common/families/evm/staking/types", () => ({
+  isStakingAccount: () => true,
+}));
+jest.mock("@ledgerhq/live-common/families/evm/staking/react", () => ({
+  useEvmFamilyMappedDelegations: () => mockDelegations,
+}));
+
+describe("EVM ClaimRewardsSelectValidator screen", () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockDelegations.length = 0;
+  });
+
+  it("lists only delegations with pendingRewards > 0", () => {
+    mockDelegations.push(
+      makeDelegation("Alpha", new BigNumber("0.5e18")),
+      makeDelegation("Beta", new BigNumber(0)),
+      makeDelegation("Gamma", new BigNumber("0.3e18")),
+    );
+    render(<ClaimRewardsSelectValidator />);
+    expect(screen.getByText("Alpha")).toBeOnTheScreen();
+    expect(screen.getByText("Gamma")).toBeOnTheScreen();
+    expect(screen.queryByText("Beta")).toBeNull();
+  });
+
+  it("navigates to Claim with validator + value when a row is tapped", () => {
+    mockDelegations.push(makeDelegation("Alpha", new BigNumber("0.5e18")));
+    render(<ClaimRewardsSelectValidator />);
+    fireEvent.press(screen.getByText("Alpha"));
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.stringMatching(/Claim$/),
+      expect.objectContaining({ validator: expect.objectContaining({ name: "Alpha" }) }),
+    );
+  });
+});

--- a/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/01-SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/01-SelectValidator.tsx
@@ -1,0 +1,119 @@
+import invariant from "invariant";
+import React, { useCallback, useMemo } from "react";
+import { FlatList, ListRenderItem, StyleSheet, TouchableOpacity, View } from "react-native";
+import BigNumber from "bignumber.js";
+import { useNavigation, useRoute, useTheme } from "@react-navigation/native";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { useEvmFamilyMappedDelegations } from "@ledgerhq/live-common/families/evm/staking/react";
+import {
+  isStakingAccount,
+  StakingAccount,
+  StakingMappedDelegation,
+  StakingValidatorItem,
+} from "@ledgerhq/live-common/families/evm/staking/types";
+import { ScreenName } from "~/const";
+import LText from "~/components/LText";
+import CurrencyUnitValue from "~/components/CurrencyUnitValue";
+import ArrowRight from "~/icons/ArrowRight";
+import ValidatorImage from "~/families/evm/shared/ValidatorImage";
+import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import { useAccountUnit } from "LLM/hooks/useAccountUnit";
+import { useAccountScreen } from "LLM/hooks/useAccountScreen";
+import type { EvmClaimRewardsFlowParamList } from "./types";
+
+type Navigation = StackNavigatorProps<
+  EvmClaimRewardsFlowParamList,
+  ScreenName.EvmClaimRewardsValidator
+>;
+
+function ClaimRewardsSelectValidator() {
+  const navigation = useNavigation<Navigation["navigation"]>();
+  const route = useRoute<Navigation["route"]>();
+  const { colors } = useTheme();
+  const { account } = useAccountScreen(route);
+  invariant(account, "account required");
+  invariant(account.type === "Account", "account must be of type Account");
+  invariant(isStakingAccount(account), "evm staking account required");
+
+  const mainAccount = getMainAccount(account, undefined) as StakingAccount;
+  const unit = useAccountUnit(mainAccount);
+
+  const allDelegations = useEvmFamilyMappedDelegations(mainAccount);
+  const claimable = useMemo(
+    () => allDelegations.filter(d => d.pendingRewards?.gt(0)),
+    [allDelegations],
+  );
+
+  const onSelect = useCallback(
+    (validator: StakingValidatorItem, value: BigNumber) => {
+      navigation.navigate(ScreenName.EvmClaimRewardsClaim, {
+        ...route.params,
+        validator,
+        value,
+      });
+    },
+    [navigation, route.params],
+  );
+
+  const renderItem: ListRenderItem<StakingMappedDelegation> = useCallback(
+    ({ item }) => {
+      const validator = item.validator;
+      if (!validator) return null;
+      const pending = item.pendingRewards ?? new BigNumber(0);
+      return (
+        <TouchableOpacity style={styles.row} onPress={() => onSelect(validator, pending)}>
+          <ValidatorImage isLedger={false} name={validator.name} size={32} />
+          <View style={styles.rowText}>
+            <LText semiBold numberOfLines={1} style={styles.validatorName}>
+              {validator.name}
+            </LText>
+            <LText color="grey" style={styles.rewardValue}>
+              <CurrencyUnitValue unit={unit} value={pending} showCode />
+            </LText>
+          </View>
+          <ArrowRight size={16} color={colors.grey} />
+        </TouchableOpacity>
+      );
+    },
+    [colors.grey, unit, onSelect],
+  );
+
+  return (
+    <View style={[styles.root, { backgroundColor: colors.background }]}>
+      <FlatList
+        style={styles.list}
+        keyExtractor={d => d.validatorAddress}
+        data={claimable}
+        renderItem={renderItem}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  list: {
+    width: "100%",
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  rowText: {
+    flex: 1,
+    marginLeft: 12,
+  },
+  validatorName: {
+    fontSize: 14,
+  },
+  rewardValue: {
+    fontSize: 13,
+    marginTop: 2,
+  },
+});
+
+export default ClaimRewardsSelectValidator;

--- a/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/02-Claim.test.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/02-Claim.test.tsx
@@ -1,0 +1,126 @@
+import BigNumber from "bignumber.js";
+import React from "react";
+import { fireEvent, screen } from "@testing-library/react-native";
+import { render } from "@tests/test-renderer";
+import { ClaimRewardsFeesWarning } from "@ledgerhq/errors";
+import type { Account } from "@ledgerhq/types-live";
+import type { StakingValidatorItem } from "@ledgerhq/live-common/families/evm/staking/types";
+import ClaimRewardsClaim from "./02-Claim";
+
+const account = {
+  id: "evm-sei_evm-1",
+  type: "Account",
+  currency: {
+    family: "evm",
+    id: "sei_evm",
+    ticker: "SEI",
+    units: [{ code: "SEI", magnitude: 18 }],
+  },
+  freshAddress: "0x0000000000000000000000000000000000000001",
+} as unknown as Account;
+
+const validator: StakingValidatorItem = {
+  validatorAddress: "seivaloper1xyz",
+  name: "Test Validator",
+  votingPower: 0,
+  commission: 0.05,
+  estimatedYearlyRewardsRate: 0.1,
+  tokens: "0",
+};
+
+const mockNavigate = jest.fn();
+const mockStatus: { errors: object; warnings: object; estimatedFees: BigNumber } = {
+  errors: {},
+  warnings: {},
+  estimatedFees: new BigNumber(0),
+};
+const fakeTx = {};
+
+jest.mock("LLM/hooks/useAccountScreen", () => ({
+  useAccountScreen: () => ({ account, parentAccount: undefined }),
+}));
+jest.mock("LLM/hooks/useAccountUnit", () => ({
+  useAccountUnit: () => ({ code: "SEI", magnitude: 18 }),
+}));
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  useAccountBridge: () => ({
+    createTransaction: () => ({}),
+    updateTransaction: (t: object) => t,
+  }),
+}));
+jest.mock("@ledgerhq/live-common/bridge/useBridgeTransaction", () => ({
+  __esModule: true,
+  default: () => ({
+    transaction: fakeTx,
+    status: mockStatus,
+    bridgePending: false,
+    bridgeError: null,
+  }),
+}));
+
+describe("EVM ClaimRewardsClaim screen", () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockStatus.errors = {};
+    mockStatus.warnings = {};
+  });
+
+  it("renders the rewards amount and validator name", () => {
+    render(
+      <ClaimRewardsClaim
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        route={
+          { params: { accountId: account.id, validator, value: new BigNumber("0.5e18") } } as any
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        navigation={{ navigate: mockNavigate } as any}
+      />,
+    );
+    expect(screen.getByText(validator.name)).toBeOnTheScreen();
+    expect(screen.getByText(/0\.5\sSEI/)).toBeOnTheScreen();
+  });
+
+  it("shows the fees-exceed-rewards warning when bridge returns it", () => {
+    mockStatus.warnings = { claimRewardsFee: new ClaimRewardsFeesWarning() };
+    render(
+      <ClaimRewardsClaim
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        route={{ params: { accountId: account.id, validator, value: new BigNumber(100) } } as any}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        navigation={{ navigate: mockNavigate } as any}
+      />,
+    );
+    expect(
+      screen.getByText("The rewards are smaller than the estimated fees to claim them."),
+    ).toBeOnTheScreen();
+  });
+
+  it("disables Continue when the bridge returns errors", () => {
+    mockStatus.errors = { fees: new Error("NotEnoughBalance") };
+    render(
+      <ClaimRewardsClaim
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        route={{ params: { accountId: account.id, validator, value: new BigNumber(100) } } as any}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        navigation={{ navigate: mockNavigate } as any}
+      />,
+    );
+    expect(screen.getByText("Continue")).toBeDisabled();
+  });
+
+  it("navigates to SelectDevice on Continue", () => {
+    render(
+      <ClaimRewardsClaim
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        route={{ params: { accountId: account.id, validator, value: new BigNumber(100) } } as any}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        navigation={{ navigate: mockNavigate } as any}
+      />,
+    );
+    fireEvent.press(screen.getByText("Continue"));
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.stringMatching(/SelectDevice/),
+      expect.objectContaining({ validator, value: expect.any(BigNumber) }),
+    );
+  });
+});

--- a/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/02-Claim.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/02-Claim.tsx
@@ -1,0 +1,147 @@
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+import invariant from "invariant";
+import React, { useCallback } from "react";
+import { StyleSheet, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Flex, Text } from "@ledgerhq/native-ui";
+import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-coin-framework/types";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import type { TransactionStatus } from "@ledgerhq/coin-evm/types/index";
+import { Trans } from "~/context/Locale";
+import { TrackScreen } from "~/analytics";
+import Button from "~/components/Button";
+import CounterValue from "~/components/CounterValue";
+import CurrencyUnitValue from "~/components/CurrencyUnitValue";
+import TranslatedError from "~/components/TranslatedError";
+import ValidatorImage from "~/families/evm/shared/ValidatorImage";
+import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import { ScreenName } from "~/const";
+import { useAccountUnit } from "LLM/hooks/useAccountUnit";
+import { useAccountScreen } from "LLM/hooks/useAccountScreen";
+import type { EvmClaimRewardsFlowParamList } from "./types";
+
+type Props = StackNavigatorProps<EvmClaimRewardsFlowParamList, ScreenName.EvmClaimRewardsClaim>;
+
+function ClaimRewardsClaim({ navigation, route }: Props) {
+  const { account } = useAccountScreen(route);
+  invariant(account, "account required");
+  invariant(account.type === "Account", "account must be of type Account");
+
+  const { validator, value } = route.params;
+  const unit = useAccountUnit(account);
+  const bridge = useAccountBridge<GenericTransaction>(account);
+
+  const { transaction, status, bridgePending, bridgeError } = useBridgeTransaction(bridge, () => {
+    const base = bridge.updateTransaction(bridge.createTransaction(account), {
+      recipient: account.freshAddress,
+    });
+    const claimTx = bridge.updateTransaction(base, {
+      mode: "claimReward",
+      valAddress: validator.validatorAddress,
+      amount: value,
+    });
+    return { account, parentAccount: undefined, transaction: claimTx as unknown as Transaction };
+  });
+
+  invariant(transaction, "transaction required");
+
+  const onContinue = useCallback(() => {
+    navigation.navigate(ScreenName.EvmClaimRewardsSelectDevice, {
+      ...route.params,
+      transaction: transaction as unknown as Transaction,
+      status: status as TransactionStatus,
+    });
+  }, [navigation, route.params, transaction, status]);
+
+  const hasErrors = Object.keys(status.errors).length > 0;
+  const error = Object.values(status.errors)[0] ?? status.warnings.claimRewardsFee;
+
+  return (
+    <SafeAreaView style={styles.root}>
+      <TrackScreen
+        category="EvmClaimRewards"
+        name="Claim"
+        flow="stake"
+        action="claim_rewards"
+        currency={account.currency.ticker}
+      />
+      <View style={styles.body}>
+        <Flex mb={32}>
+          <Text fontWeight="semiBold" textAlign="center" color="smoke" mb={3}>
+            <Trans i18nKey="evm.claimRewards.flow.steps.claim.youEarned" />
+          </Text>
+          <Text
+            fontWeight="semiBold"
+            numberOfLines={1}
+            fontSize={24}
+            textAlign="center"
+            mb={3}
+            adjustsFontSizeToFit
+          >
+            <CurrencyUnitValue showCode unit={unit} value={value} />
+          </Text>
+          <Text textAlign="center" color="smoke">
+            <CounterValue
+              currency={account.currency}
+              value={value}
+              alwaysShowSign={false}
+              withPlaceholder
+              showCode
+            />
+          </Text>
+        </Flex>
+        <Text fontWeight="semiBold" textAlign="center" color="smoke" mb={2}>
+          <Trans i18nKey="evm.claimRewards.flow.steps.claim.byDelegationAssetsTo" />
+        </Text>
+        <Flex flexDirection="row" alignItems="center" justifyContent="center" columnGap={2} mb={8}>
+          <ValidatorImage isLedger={false} name={validator.name} size={32} />
+          <Text numberOfLines={1} fontWeight="semiBold" fontSize={14}>
+            {validator.name}
+          </Text>
+        </Flex>
+        <Text fontWeight="semiBold" textAlign="center">
+          <Trans i18nKey="evm.claimRewards.flow.steps.claim.description" />
+        </Text>
+      </View>
+      <View style={styles.footer}>
+        {error ? (
+          <Text color="alert" fontWeight="semiBold" textAlign="center" mb={6}>
+            <TranslatedError error={error} />
+          </Text>
+        ) : null}
+        <Button
+          event="EvmClaimRewardsClaimContinue"
+          type="primary"
+          title={<Trans i18nKey="evm.claimRewards.flow.steps.claim.cta" />}
+          containerStyle={styles.continueButton}
+          onPress={onContinue}
+          disabled={bridgePending || !!bridgeError || hasErrors}
+          pending={bridgePending}
+        />
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  body: {
+    flex: 1,
+    paddingHorizontal: 16,
+    justifyContent: "center",
+  },
+  footer: {
+    paddingHorizontal: 16,
+    paddingTop: 16,
+    paddingBottom: 16,
+  },
+  continueButton: {
+    alignSelf: "stretch",
+  },
+});
+
+export default ClaimRewardsClaim;

--- a/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/04-ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/04-ValidationError.tsx
@@ -1,0 +1,51 @@
+import React, { useCallback } from "react";
+import { StyleSheet } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { useTheme } from "@react-navigation/native";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
+import { TrackScreen } from "~/analytics";
+import ValidateError from "~/components/ValidateError";
+import type {
+  BaseComposite,
+  StackNavigatorNavigation,
+  StackNavigatorProps,
+} from "~/components/RootNavigator/types/helpers";
+import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import type { EvmClaimRewardsFlowParamList } from "./types";
+import { ScreenName } from "~/const";
+import { useAccountScreen } from "LLM/hooks/useAccountScreen";
+
+type Props = BaseComposite<
+  StackNavigatorProps<EvmClaimRewardsFlowParamList, ScreenName.EvmClaimRewardsValidationError>
+>;
+
+export default function ValidationError({ navigation, route }: Props) {
+  const { colors } = useTheme();
+  const { account } = useAccountScreen(route);
+  const { ticker } = getAccountCurrency(account);
+  const onClose = useCallback(() => {
+    navigation.getParent<StackNavigatorNavigation<BaseNavigatorStackParamList>>().pop();
+  }, [navigation]);
+  const retry = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
+  const error = route.params.error;
+  return (
+    <SafeAreaView style={[styles.root, { backgroundColor: colors.background }]}>
+      <TrackScreen
+        category="EvmClaimRewards"
+        name="ValidationError"
+        flow="stake"
+        action="claim_rewards"
+        currency={ticker}
+      />
+      <ValidateError error={error} onRetry={retry} onClose={onClose} />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+});

--- a/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/04-ValidationSuccess.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/04-ValidationSuccess.tsx
@@ -1,0 +1,63 @@
+import React, { useCallback } from "react";
+import { View, StyleSheet } from "react-native";
+import { Trans } from "~/context/Locale";
+import { useTheme } from "@react-navigation/native";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
+import { TrackScreen } from "~/analytics";
+import { ScreenName } from "~/const";
+import PreventNativeBack from "~/components/PreventNativeBack";
+import ValidateSuccess from "~/components/ValidateSuccess";
+import type {
+  BaseComposite,
+  StackNavigatorNavigation,
+  StackNavigatorProps,
+} from "~/components/RootNavigator/types/helpers";
+import type { EvmClaimRewardsFlowParamList } from "./types";
+import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import { useAccountScreen } from "LLM/hooks/useAccountScreen";
+
+type Props = BaseComposite<
+  StackNavigatorProps<EvmClaimRewardsFlowParamList, ScreenName.EvmClaimRewardsValidationSuccess>
+>;
+
+export default function ValidationSuccess({ navigation, route }: Props) {
+  const { colors } = useTheme();
+  const { account } = useAccountScreen(route);
+  const { ticker } = getAccountCurrency(account);
+  const onClose = useCallback(() => {
+    navigation.getParent<StackNavigatorNavigation<BaseNavigatorStackParamList>>().pop();
+  }, [navigation]);
+  const goToOperationDetails = useCallback(() => {
+    if (!account) return;
+    const result = route.params?.result;
+    if (!result) return;
+    navigation.navigate(ScreenName.OperationDetails, {
+      accountId: account.id,
+      operation: result,
+    });
+  }, [account, route.params, navigation]);
+  return (
+    <View style={[styles.root, { backgroundColor: colors.background }]}>
+      <TrackScreen
+        category="EvmClaimRewards"
+        name="ValidationSuccess"
+        flow="stake"
+        action="claim_rewards"
+        currency={ticker}
+      />
+      <PreventNativeBack />
+      <ValidateSuccess
+        onClose={onClose}
+        onViewDetails={goToOperationDetails}
+        title={<Trans i18nKey="evm.claimRewards.flow.steps.verification.success.title" />}
+        description={<Trans i18nKey="evm.claimRewards.flow.steps.verification.success.text" />}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+});

--- a/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/index.tsx
@@ -1,0 +1,132 @@
+import React, { useMemo } from "react";
+import { Platform } from "react-native";
+import { useTranslation } from "~/context/Locale";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { useTheme } from "@react-navigation/native";
+import {
+  bridgeSuspenseScreenLayout,
+  defaultNavigationOptions,
+  getStackNavigatorConfig,
+} from "~/navigation/navigatorConfig";
+import StepHeader from "~/components/StepHeader";
+import { ScreenName } from "~/const";
+import ClaimRewardsSelectValidator from "./01-SelectValidator";
+import ClaimRewardsClaim from "./02-Claim";
+import ClaimRewardsSelectDevice from "~/screens/SelectDevice";
+import ClaimRewardsConnectDevice from "~/screens/ConnectDevice";
+import ClaimRewardsValidationError from "./04-ValidationError";
+import ClaimRewardsValidationSuccess from "./04-ValidationSuccess";
+import type { EvmClaimRewardsFlowParamList } from "./types";
+import { Flex } from "@ledgerhq/native-ui";
+import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+
+const totalSteps = "4";
+
+function StepTitle({ titleKey, currentStep }: { titleKey: string; currentStep: string }) {
+  const { t } = useTranslation();
+  return (
+    <StepHeader
+      title={t(titleKey)}
+      subtitle={t("evm.claimRewards.stepperHeader.stepRange", { currentStep, totalSteps })}
+    />
+  );
+}
+
+function ValidatorHeader() {
+  const { t } = useTranslation();
+  return (
+    <Flex flex={1} width="90%" alignSelf="center">
+      <StepHeader
+        title={t("evm.claimRewards.stepperHeader.validator")}
+        subtitle={t("evm.claimRewards.stepperHeader.stepRange", { currentStep: "1", totalSteps })}
+        adjustFontSize
+      />
+    </Flex>
+  );
+}
+
+function ClaimHeader() {
+  return <StepTitle titleKey="evm.claimRewards.stepperHeader.claim" currentStep="2" />;
+}
+
+function SelectDeviceHeader() {
+  return <StepTitle titleKey="evm.claimRewards.stepperHeader.selectDevice" currentStep="3" />;
+}
+
+function ConnectDeviceHeader() {
+  return <StepTitle titleKey="evm.claimRewards.stepperHeader.connectDevice" currentStep="4" />;
+}
+
+function ClaimRewardsFlow() {
+  const { colors } = useTheme();
+  const { notifyFlowCompleted } = useNotificationsContext();
+  const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
+  return (
+    <Stack.Navigator
+      screenOptions={{
+        ...stackNavigationConfig,
+        gestureEnabled: Platform.OS === "ios",
+      }}
+      screenLayout={bridgeSuspenseScreenLayout}
+    >
+      <Stack.Screen
+        name={ScreenName.EvmClaimRewardsValidator}
+        component={ClaimRewardsSelectValidator}
+        options={{
+          headerTitle: ValidatorHeader,
+          headerLeft: () => null,
+          headerStyle: defaultNavigationOptions.headerStyle,
+          gestureEnabled: false,
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.EvmClaimRewardsClaim}
+        component={ClaimRewardsClaim}
+        options={{ headerTitle: ClaimHeader }}
+      />
+      <Stack.Screen
+        name={ScreenName.EvmClaimRewardsSelectDevice}
+        component={ClaimRewardsSelectDevice}
+        options={{ headerTitle: SelectDeviceHeader }}
+      />
+      <Stack.Screen
+        name={ScreenName.EvmClaimRewardsConnectDevice}
+        component={ClaimRewardsConnectDevice}
+        options={{
+          headerLeft: undefined,
+          gestureEnabled: false,
+          headerTitle: ConnectDeviceHeader,
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.EvmClaimRewardsValidationError}
+        component={ClaimRewardsValidationError}
+        options={{
+          headerShown: false,
+          gestureEnabled: false,
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.EvmClaimRewardsValidationSuccess}
+        component={ClaimRewardsValidationSuccess}
+        options={{
+          headerLeft: undefined,
+          headerRight: undefined,
+          headerTitle: "",
+          gestureEnabled: false,
+        }}
+        listeners={{
+          beforeRemove: () => {
+            notifyFlowCompleted("stake");
+          },
+        }}
+      />
+    </Stack.Navigator>
+  );
+}
+
+const options = {
+  headerShown: false,
+};
+export { ClaimRewardsFlow as component, options };
+const Stack = createNativeStackNavigator<EvmClaimRewardsFlowParamList>();

--- a/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/types.ts
+++ b/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/types.ts
@@ -1,0 +1,52 @@
+import type { StakingValidatorItem } from "@ledgerhq/live-common/families/evm/staking/types";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import type { TransactionStatus } from "@ledgerhq/coin-evm/types/index";
+import type { Operation } from "@ledgerhq/types-live";
+import type { Device } from "@ledgerhq/live-common/hw/actions/types";
+import BigNumber from "bignumber.js";
+import { ScreenName } from "~/const";
+
+export type EvmClaimRewardsFlowParamList = {
+  [ScreenName.EvmClaimRewardsValidator]: {
+    accountId: string;
+  };
+  [ScreenName.EvmClaimRewardsClaim]: {
+    accountId: string;
+    parentId?: string | null;
+    validator: StakingValidatorItem;
+    value: BigNumber;
+  };
+  [ScreenName.EvmClaimRewardsSelectDevice]: {
+    accountId: string;
+    parentId?: string | null;
+    transaction: Transaction;
+    status: TransactionStatus;
+    validator?: StakingValidatorItem;
+    value?: BigNumber;
+  };
+  [ScreenName.EvmClaimRewardsConnectDevice]: {
+    device: Device;
+    accountId: string;
+    parentId?: string | null;
+    transaction: Transaction;
+    status: TransactionStatus;
+    appName?: string;
+    selectDeviceLink?: boolean;
+    onSuccess?: (payload: unknown) => void;
+    onError?: (error: Error) => void;
+    analyticsPropertyFlow?: string;
+    forceSelectDevice?: boolean;
+  };
+  [ScreenName.EvmClaimRewardsValidationError]: {
+    accountId: string;
+    deviceId: string;
+    transaction: Transaction;
+    error: Error;
+  };
+  [ScreenName.EvmClaimRewardsValidationSuccess]: {
+    accountId: string;
+    deviceId: string;
+    transaction: Transaction;
+    result: Operation;
+  };
+};

--- a/apps/ledger-live-mobile/src/families/evm/Delegations/index.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/Delegations/index.tsx
@@ -20,17 +20,23 @@ import {
   StakingMappedUnbonding,
 } from "@ledgerhq/live-common/families/evm/staking/types";
 import { useFeature } from "@features/platform-feature-flags";
+import { Text } from "@ledgerhq/native-ui";
 import type { AccountLike } from "@ledgerhq/types-live";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import AccountDelegationInfo from "~/components/AccountDelegationInfo";
 import AccountSectionLabel from "~/components/AccountSectionLabel";
+import Button from "~/components/Button";
 import Circle from "~/components/Circle";
+import CounterValue from "~/components/CounterValue";
+import CurrencyUnitValue from "~/components/CurrencyUnitValue";
 import DateFromNow from "~/components/DateFromNow";
 import DelegationDrawer, { IconProps } from "~/components/DelegationDrawer";
 import LText from "~/components/LText";
 import Touchable from "~/components/Touchable";
 import { NavigatorName, ScreenName } from "~/const";
 import { useTranslation } from "~/context/Locale";
+import { rgba } from "../../../colors";
+import ClaimRewardIcon from "~/icons/ClaimReward";
 import IlluRewards from "~/icons/images/Rewards";
 import RedelegateIcon from "~/icons/Redelegate";
 import UndelegateIcon from "~/icons/Undelegate";
@@ -67,6 +73,14 @@ function Delegations({ account }: { account: StakingAccount }) {
     () => mapUnbondings(account.stakingResources.unbondings, validators, unit),
     [account.stakingResources.unbondings, unit, validators],
   );
+  const totalRewardsAvailable = useMemo(
+    () =>
+      delegations.reduce(
+        (sum, d) => sum.plus(d.pendingRewards ?? new BigNumber(0)),
+        new BigNumber(0),
+      ),
+    [delegations],
+  );
 
   const onNavigate = useCallback(
     ({
@@ -99,6 +113,24 @@ function Delegations({ account }: { account: StakingAccount }) {
       },
     });
   }, [onNavigate, route]);
+
+  const onCollectRewards = useCallback(() => {
+    if (delegation?.validator && delegation.pendingRewards?.gt(0)) {
+      onNavigate({
+        navigator: NavigatorName.EvmClaimRewardsFlow,
+        screen: ScreenName.EvmClaimRewardsClaim,
+        params: {
+          validator: delegation.validator,
+          value: delegation.pendingRewards,
+        },
+      });
+    } else {
+      onNavigate({
+        navigator: NavigatorName.EvmClaimRewardsFlow,
+        screen: ScreenName.EvmClaimRewardsValidator,
+      });
+    }
+  }, [onNavigate, delegation]);
 
   const onRedelegate = useCallback(() => {
     if (!delegation) return;
@@ -279,8 +311,30 @@ function Delegations({ account }: { account: StakingAccount }) {
       });
     }
 
+    if (delegation.pendingRewards?.gt(0)) {
+      result.push({
+        label: t("delegation.actions.collectRewards"),
+        Icon: (props: IconProps) => (
+          <Circle {...props} bg={rgba(colors.yellow, 0.2)}>
+            <ClaimRewardIcon />
+          </Circle>
+        ),
+        onPress: onCollectRewards,
+        event: "DelegationActionCollectRewards",
+      });
+    }
+
     return result;
-  }, [account, colors.fog, delegation, onRedelegate, onUndelegate, t]);
+  }, [
+    account,
+    colors.fog,
+    colors.yellow,
+    delegation,
+    onCollectRewards,
+    onRedelegate,
+    onUndelegate,
+    t,
+  ]);
 
   const delegationDisabled = delegations.length <= 0 || !canDelegate(account);
   const selected = delegation || undelegation;
@@ -304,6 +358,27 @@ function Delegations({ account }: { account: StakingAccount }) {
         data={data}
         actions={actions}
       />
+      {totalRewardsAvailable.gt(0) && (
+        <>
+          <AccountSectionLabel name={t("account.claimReward.sectionLabel")} />
+          <View style={[styles.rewardsWrapper]}>
+            <View style={styles.column}>
+              <Text fontWeight={"semiBold"} variant={"h4"}>
+                <CurrencyUnitValue value={totalRewardsAvailable} unit={unit} />
+              </Text>
+              <LText semiBold style={styles.subLabel} color="grey">
+                <CounterValue currency={currency} value={totalRewardsAvailable} withPlaceholder />
+              </LText>
+            </View>
+            <Button
+              event="Evm AccountClaimRewardsBtn Click"
+              onPress={onCollectRewards}
+              type="primary"
+              title={t("account.claimReward.cta")}
+            />
+          </View>
+        </>
+      )}
       {delegations.length === 0 ? (
         <AccountDelegationInfo
           title={t("account.delegation.info.title")}
@@ -382,6 +457,21 @@ const styles = StyleSheet.create({
   wrapper: {},
   delegationsWrapper: {
     borderRadius: 4,
+  },
+  rewardsWrapper: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignContent: "center",
+    paddingVertical: 16,
+    marginBottom: 16,
+    borderRadius: 4,
+  },
+  column: {
+    flexDirection: "column",
+  },
+  subLabel: {
+    fontSize: 14,
+    flex: 1,
   },
   row: {
     flexDirection: "row",

--- a/apps/ledger-live-mobile/src/families/evm/index.ts
+++ b/apps/ledger-live-mobile/src/families/evm/index.ts
@@ -1,6 +1,5 @@
-import * as EvmEditGasLimit from "./ScreenEditGasLimit";
-import * as EvmCustomFees from "./EvmCustomFees";
-import * as EvmDelegationFlow from "./DelegationFlow";
-import * as EvmUndelegationFlow from "./UndelegationFlow";
-
-export { EvmEditGasLimit, EvmCustomFees, EvmDelegationFlow, EvmUndelegationFlow };
+export * as EvmEditGasLimit from "./ScreenEditGasLimit";
+export * as EvmCustomFees from "./EvmCustomFees";
+export * as EvmDelegationFlow from "./DelegationFlow";
+export * as EvmUndelegationFlow from "./UndelegationFlow";
+export * as EvmClaimRewardsFlow from "./ClaimRewardsFlow";

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -6787,30 +6787,22 @@
     "claimRewards": {
       "stepperHeader": {
         "validator": "Select reward to collect",
-        "method": "Claim rewards",
-        "summary": "Summary",
+        "claim": "Claim rewards",
         "selectDevice": "Select device",
         "connectDevice": "Connect device",
         "stepRange": "Step {{currentStep}} of {{totalSteps}}"
       },
       "flow": {
         "steps": {
-          "method": {
+          "claim": {
             "youEarned": "You earned",
             "byDelegationAssetsTo": "by delegating assets to",
-            "claimReward": "Cash in",
-            "claimRewardCompound": "Compound",
-            "claimRewardInfo": "They will be claimed now and added to your available balance.",
-            "claimRewardCompoundInfo": "They will be claimed now and automatically delegated to the same validator.",
-            "compoundOrCashIn": "Compound or Cash in?",
-            "claimRewardTooltip": "Rewards will be added to the available balance",
-            "claimRewardCompoundTooltip": "Rewards will be added to the delegated amount",
+            "description": "Rewards will be claimed now and added to your available balance.",
             "cta": "Continue"
           },
           "verification": {
             "success": {
               "title": "You have successfully claimed your rewards. They were added to your available balance.",
-              "titleCompound": "Your rewards were delegated to the same validator.",
               "text": "Your account balance will be updated when the network confirms the transaction.",
               "cta": "View details"
             },

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/NotificationsPromptStakeFlow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/NotificationsPromptStakeFlow.test.tsx
@@ -337,6 +337,17 @@ const stakePromptCases: StakePromptCase[] = [
     transaction: { family: "evm", mode: "undelegate" },
   },
   {
+    label: "EVM claim rewards",
+    bucket: "revoke/claim/lifecycle",
+    flowName: NavigatorName.EvmClaimRewardsFlow,
+    familyExportKey: "EvmClaimRewardsFlow",
+    successScreenName: ScreenName.EvmClaimRewardsValidationSuccess,
+    errorScreenName: ScreenName.EvmClaimRewardsValidationError,
+    accountKey: "ethereum",
+    operationType: "REWARD",
+    transaction: { family: "evm", mode: "claimReward" },
+  },
+  {
     label: "Hedera claim rewards",
     bucket: "revoke/claim/lifecycle",
     flowName: NavigatorName.HederaClaimRewardsFlow,

--- a/apps/ledger-live-mobile/src/screens/ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/ConnectDevice.tsx
@@ -58,6 +58,7 @@ import { SuiStakingFlowParamList } from "~/families/sui/StakingFlow/types";
 import { SuiUnstakingFlowParamList } from "~/families/sui/UnstakingFlow/types";
 import type { EvmDelegationFlowParamList } from "~/families/evm/DelegationFlow/types";
 import type { EvmUndelegationFlowParamList } from "~/families/evm/UndelegationFlow/types";
+import type { EvmClaimRewardsFlowParamList } from "~/families/evm/ClaimRewardsFlow/types";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 
 type Props =
@@ -126,7 +127,8 @@ type Props =
   | StackNavigatorProps<HederaClaimRewardsFlowParamList, ScreenName.HederaClaimRewardsConnectDevice>
   | StackNavigatorProps<EvmDelegationFlowParamList, ScreenName.EvmDelegationConnectDevice>
   | StackNavigatorProps<EvmUndelegationFlowParamList, ScreenName.EvmUndelegationConnectDevice>
-  | StackNavigatorProps<EvmDelegationFlowParamList, ScreenName.EvmRedelegationConnectDevice>;
+  | StackNavigatorProps<EvmDelegationFlowParamList, ScreenName.EvmRedelegationConnectDevice>
+  | StackNavigatorProps<EvmClaimRewardsFlowParamList, ScreenName.EvmClaimRewardsConnectDevice>;
 
 export const navigateToSelectDevice = (navigation: Props["navigation"], route: Props["route"]) =>
   // Assumes that it will always navigate to a "SelectDevice"

--- a/libs/coin-modules/coin-evm/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/listOperations.test.ts
@@ -1059,6 +1059,43 @@ describe("listOperations", () => {
     expect(items[0].recipients[0]).toBe(stakingContract);
   });
 
+  it("preserves REWARD type for outbound claim-reward tx (not downgraded to OUT/FEES)", async () => {
+    const address = "0xdelegator";
+    const distributionPrecompile = "0x0000000000000000000000000000000000001007";
+    setCoinConfig(() => ({ info: { explorer: { type: "ledger" } } }) as unknown as EvmCoinConfig);
+    jest.spyOn(ledgerExplorer, "getOperations").mockResolvedValue({
+      lastCoinOperations: [
+        {
+          id: "reward-op",
+          accountId: "",
+          type: "REWARD",
+          senders: [address],
+          recipients: [distributionPrecompile],
+          value: new BigNumber(0),
+          hash: "0xreward-tx",
+          blockHeight: 100,
+          blockHash: "0xblock",
+          fee: new BigNumber(1),
+          date: new Date("2025-02-20"),
+          transactionSequenceNumber: new BigNumber(1),
+          hasFailed: false,
+          extra: {},
+        },
+      ],
+      lastTokenOperations: [],
+      lastNftOperations: [],
+      lastInternalOperations: [],
+      nextPagingToken: "",
+    });
+
+    const { items } = await listOperations({} as CryptoCurrency, address, {
+      minHeight: 0,
+      order: "asc",
+    });
+    expect(items).toHaveLength(1);
+    expect(items[0].type).toBe("REWARD");
+  });
+
   it("copies smart contract fields from explorer extra into operation details", async () => {
     setCoinConfig(() => ({ info: { explorer: { type: "ledger" } } }) as unknown as EvmCoinConfig);
     const contractAddr = "0x1111111111111111111111111111111111111111";

--- a/libs/coin-modules/coin-evm/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-evm/src/logic/listOperations.ts
@@ -60,6 +60,7 @@ const SEMANTIC_OP_TYPES: Set<OperationType> = new Set([
   "DELEGATE",
   "UNDELEGATE",
   "REDELEGATE",
+  "REWARD",
   "NFT_IN",
   "NFT_OUT",
 ]);
@@ -309,6 +310,7 @@ export async function listOperations(
       "DELEGATE",
       "UNDELEGATE",
       "REDELEGATE",
+      "REWARD",
       "NFT_IN",
       "NFT_OUT",
     ].includes(operation.type);

--- a/libs/coin-modules/coin-evm/src/logic/validateIntent.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/validateIntent.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@ledgerhq/coin-module-framework/api/types";
 import {
   AmountRequired,
+  ClaimRewardsFeesWarning,
   ETHAddressNonEIP,
   FeeNotLoaded,
   FeeTooHigh,
@@ -672,6 +673,49 @@ describe("validateIntent", () => {
         expect(res.amount).toBe(900_000_000_000_000_000n);
         expect(res.errors.amount).toBeUndefined();
       });
+    });
+
+    const tokenAsset = {
+      type: "token" as const,
+      assetReference: "0x0000000000000000000000000000000000000001",
+    };
+    const claimRewardIntent = (overrides: { amount: bigint; native: boolean }) =>
+      stakingIntent({
+        mode: "claimReward",
+        amount: overrides.amount,
+        valAddress: "seivaloper1y82m5y3wevjneamzg0pmx87dzanyxzht0kepvn",
+        ...(overrides.native ? {} : { asset: tokenAsset }),
+      });
+    const claimRewardBalances = (native: boolean) => [
+      { value: 10_000_000n, asset: { type: "native" as const } },
+      ...(native ? [] : [{ value: 1_000n, asset: tokenAsset }]),
+    ];
+    const claimRewardFees = { value: 150n, parameters: { gasLimit: 21000n, gasPrice: 1n } };
+
+    it.each([
+      { name: "fires when network fees exceed claim reward amount", amount: 100n, native: true },
+    ])("$name", async ({ amount, native }) => {
+      const res = await validateIntent(
+        stakingCurrency,
+        claimRewardIntent({ amount, native }),
+        claimRewardBalances(native),
+        claimRewardFees,
+      );
+      expect(res.warnings.claimRewardsFee).toBeInstanceOf(ClaimRewardsFeesWarning);
+    });
+
+    it.each([
+      { name: "does not fire when claim rewards exceed fees", amount: 1_000_000n, native: true },
+      { name: "does not fire when claim reward amount is zero", amount: 0n, native: true },
+      { name: "does not fire when claim reward asset is not native", amount: 100n, native: false },
+    ])("$name", async ({ amount, native }) => {
+      const res = await validateIntent(
+        stakingCurrency,
+        claimRewardIntent({ amount, native }),
+        claimRewardBalances(native),
+        claimRewardFees,
+      );
+      expect(res.warnings.claimRewardsFee).toBeUndefined();
     });
   });
 

--- a/libs/coin-modules/coin-evm/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-evm/src/logic/validateIntent.ts
@@ -10,6 +10,7 @@ import type {
 import { formatCurrencyUnit } from "@ledgerhq/coin-module-framework/currencies/formatCurrencyUnit";
 import {
   AmountRequired,
+  ClaimRewardsFeesWarning,
   ETHAddressNonEIP,
   FeeNotLoaded,
   FeeTooHigh,
@@ -301,6 +302,15 @@ function validateStaking(
   }
   if (intent.mode === "delegate" && intent.amount + totalFees > spendable) {
     errors.amount = new NotEnoughBalance();
+  }
+  // Only compare fees vs rewards when both are in the same native unit.
+  if (
+    intent.mode === "claimReward" &&
+    isNative(intent.asset) &&
+    intent.amount > 0n &&
+    totalFees > intent.amount
+  ) {
+    warnings.claimRewardsFee = new ClaimRewardsFeesWarning();
   }
   return { errors, warnings };
 }

--- a/libs/coin-modules/coin-evm/src/staking/detectOperationType.test.ts
+++ b/libs/coin-modules/coin-evm/src/staking/detectOperationType.test.ts
@@ -53,6 +53,21 @@ describe("detectEvmStakingOperationType", () => {
     expect(result).toBe("REDELEGATE");
   });
 
+  it("should return REWARD for claimReward on the distribution precompile", () => {
+    const distributionAddress = "0x0000000000000000000000000000000000001007";
+    const fn = "withdrawDelegationRewards(string)";
+    const methodId = ethers.id(fn).slice(0, 10).toLowerCase();
+    const result = detectEvmStakingOperationType("sei_evm", distributionAddress, methodId);
+    expect(result).toBe("REWARD");
+  });
+
+  it("should return undefined for claimReward selector sent to the staking contract", () => {
+    const fn = "withdrawDelegationRewards(string)";
+    const methodId = ethers.id(fn).slice(0, 10).toLowerCase();
+    const result = detectEvmStakingOperationType("sei_evm", contractAddress, methodId);
+    expect(result).toBeUndefined();
+  });
+
   it("should return undefined for invalid methodId", () => {
     const result = detectEvmStakingOperationType("sei_evm", contractAddress, "0xdeadbeef");
     expect(result).toBeUndefined();

--- a/libs/coin-modules/coin-evm/src/staking/detectOperationType.ts
+++ b/libs/coin-modules/coin-evm/src/staking/detectOperationType.ts
@@ -8,6 +8,7 @@ const OP_MAP: Partial<Record<StakingOperation, OperationType>> = {
   delegate: "DELEGATE",
   undelegate: "UNDELEGATE",
   redelegate: "REDELEGATE",
+  claimReward: "REWARD",
 };
 
 /**
@@ -26,21 +27,29 @@ export function isStakingOperation(value: string): value is StakingOperation {
 }
 
 /**
- * Builds a map of 4-byte selectors to OperationType for a staking currency.
+ * Builds a map of `(to, 4-byte selector)` pairs to OperationType for a staking currency.
+ * Some chains (e.g. SEI) route specific operations to dedicated precompiles
+ * (`specificContractAddressByOperation`) instead of the main staking contract.
+ * Cached per `currencyId` since inputs are static (config + ABI files).
  */
-const getStakingMethodSelectors = (
-  currencyId: string,
-): Record<string, OperationType> | undefined => {
+const selectorsCache = new Map<string, Map<string, OperationType>>();
+const getStakingMethodSelectors = (currencyId: string): Map<string, OperationType> | undefined => {
+  const cached = selectorsCache.get(currencyId);
+  if (cached) return cached;
+
   const config = STAKING_CONTRACTS[currencyId];
   const abi = getStakingABI(currencyId);
-  if (!config || !abi) return undefined;
+  if (!config?.contractAddress || !abi) return undefined;
 
-  const selectors: Record<string, OperationType> = {};
+  const selectors = new Map<string, OperationType>();
+  selectorsCache.set(currencyId, selectors);
+  const key = (to: string, selector: string): string =>
+    `${to.toLowerCase()}|${selector.toLowerCase()}`;
 
   for (const [op, fn] of Object.entries(config.functions)) {
     const operation = op as StakingOperation;
     const mapped = OP_MAP[operation];
-    if (!mapped || !fn) continue; // only map delegate/undelegate/redelegate
+    if (!mapped || !fn) continue;
 
     try {
       // Find the appropriate function in the ABI by the name
@@ -52,8 +61,10 @@ const getStakingMethodSelectors = (
       const paramTypes = inputs.map(input => input.type).join(",");
       const signature = `${fn}(${paramTypes})`;
       // calculate selector (first 4 bytes of the keccak256 hash)
-      const selector = ethers.id(signature).slice(0, 10).toLowerCase();
-      selectors[selector] = mapped;
+      const selector = ethers.id(signature).slice(0, 10);
+      const opContractAddress =
+        config.specificContractAddressByOperation?.[operation] ?? config.contractAddress;
+      selectors.set(key(opContractAddress, selector), mapped);
     } catch {
       // ignore if function not in ABI or malformed
       continue;
@@ -70,13 +81,8 @@ export const detectEvmStakingOperationType = (
 ): OperationType | undefined => {
   if (!to || !methodId) return undefined;
 
-  const config = STAKING_CONTRACTS[currencyId];
-  if (!config?.contractAddress) return undefined;
-
-  if (config.contractAddress.toLowerCase() !== to.toLowerCase()) return undefined;
-
   const selectors = getStakingMethodSelectors(currencyId);
   if (!selectors) return undefined;
 
-  return selectors[methodId.toLowerCase()];
+  return selectors.get(`${to.toLowerCase()}|${methodId.toLowerCase()}`);
 };

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
@@ -516,6 +516,9 @@ export const buildOptimisticOperation = (
     case "finalize_unstake":
       type = "FINALIZE_UNSTAKE";
       break;
+    case "claimReward":
+      type = "REWARD";
+      break;
     default:
       type = "OUT";
       break;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ catalogs:
       specifier: 30.2.0
       version: 30.2.0
     '@ledgerhq/coin-module-framework':
-      specifier: 3.1.0
-      version: 3.1.0
+      specifier: 3.2.0
+      version: 3.2.0
     '@ledgerhq/coin-xrp':
       specifier: 7.21.7
       version: 7.21.7
@@ -701,7 +701,7 @@ importers:
         version: link:../../libs/coin-modules/coin-bitcoin
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/cryptoassets
@@ -971,7 +971,7 @@ importers:
         version: link:../../libs/coin-modules/coin-filecoin
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
         version: 2.0.3(@ledgerhq/lumen-design-core@0.1.15)(@ledgerhq/lumen-ui-react@0.1.35(e90fd83ca17bf10e850de74ae9e31ccb))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1627,7 +1627,7 @@ importers:
         version: link:../../libs/coin-modules/coin-filecoin
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/coin-multiversx':
         specifier: workspace:^
         version: link:../../libs/coin-modules/coin-multiversx
@@ -2357,7 +2357,7 @@ importers:
         version: link:../../libs/coin-modules/coin-evm
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/coin-solana':
         specifier: workspace:^
         version: link:../../libs/coin-modules/coin-solana
@@ -2507,7 +2507,7 @@ importers:
         version: link:../../features/platform/feature-flags
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
         version: 2.0.3(@ledgerhq/lumen-design-core@0.1.15)(@ledgerhq/lumen-ui-react@0.1.35(e90fd83ca17bf10e850de74ae9e31ccb))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -3748,7 +3748,7 @@ importers:
     devDependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0
+        version: 3.2.0
       '@ledgerhq/disable-network-setup':
         specifier: workspace:^
         version: link:../disable-network-setup
@@ -3790,7 +3790,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/cryptoassets
@@ -3872,7 +3872,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/cryptoassets
@@ -3963,7 +3963,7 @@ importers:
         version: 3.1.3(got@11.8.5)
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/cryptoassets
@@ -4060,7 +4060,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/cryptoassets
@@ -4232,7 +4232,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/cryptoassets
@@ -4317,7 +4317,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/cryptoassets
@@ -4405,7 +4405,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/cryptoassets
@@ -4496,7 +4496,7 @@ importers:
         version: link:../coin-evm
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/cryptoassets
@@ -4596,7 +4596,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/concordium-core':
         specifier: workspace:^
         version: link:../../concordium-core
@@ -4696,7 +4696,7 @@ importers:
         version: 0.12.306
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/cryptoassets
@@ -4799,7 +4799,7 @@ importers:
         version: 5.7.0
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/cryptoassets
@@ -4923,7 +4923,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/cryptoassets
@@ -5017,7 +5017,7 @@ importers:
         version: 2.78.0
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/cryptoassets
@@ -5105,7 +5105,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/cryptoassets
@@ -5193,7 +5193,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/cryptoassets
@@ -5284,7 +5284,7 @@ importers:
         version: 1.2.0
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/cryptoassets
@@ -5390,7 +5390,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/cryptoassets
@@ -5478,7 +5478,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/cryptoassets
@@ -5554,7 +5554,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/cryptoassets
@@ -5648,7 +5648,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/cryptoassets
@@ -5730,7 +5730,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/cryptoassets
@@ -5848,7 +5848,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/cryptoassets
@@ -5960,7 +5960,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/cryptoassets
@@ -6069,7 +6069,7 @@ importers:
         version: 1.0.0-alpha.1(patch_hash=7deb6c5bd39ee007fca03da7609b2e0dee99dbb9962c3c8715edfd026da0a732)
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/errors
@@ -6130,7 +6130,7 @@ importers:
         version: 1.0.11(graphql@16.13.2)
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/cryptoassets
@@ -6224,7 +6224,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/cryptoassets
@@ -6324,7 +6324,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/cryptoassets
@@ -6415,7 +6415,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/cryptoassets
@@ -6509,7 +6509,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/cryptoassets
@@ -6804,7 +6804,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0
+        version: 3.2.0
       '@ledgerhq/coin-polkadot':
         specifier: workspace:^
         version: link:../../coin-modules/coin-polkadot
@@ -7796,7 +7796,7 @@ importers:
         version: link:../coin-modules/coin-mina
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/coin-multiversx':
         specifier: workspace:^
         version: link:../coin-modules/coin-multiversx
@@ -8409,7 +8409,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../ledgerjs/packages/cryptoassets
@@ -17276,8 +17276,8 @@ packages:
   '@kwsites/promise-deferred@1.1.1':
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
 
-  '@ledgerhq/coin-module-framework@3.1.0':
-    resolution: {integrity: sha512-7COZ4fGsABwug/5deApVF+c/BnNYEROFCPHmRho2XLH+8Gh5ZdahvgcpN+J1G7HvE9xxF0UJ7If5Ojsrg7tDOA==}
+  '@ledgerhq/coin-module-framework@3.2.0':
+    resolution: {integrity: sha512-SNSjvLqF7GUU0F+Wa2haqhV/7YQWH/Sj4r32SWlP/DLHU9ei7CjsqOWdziUvAaqgy7pmD5hvD5jepepgPEKmRw==}
     peerDependencies:
       '@ledgerhq/errors': ^6.33.0
 
@@ -45321,18 +45321,18 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@ledgerhq/coin-module-framework@3.1.0':
+  '@ledgerhq/coin-module-framework@3.2.0':
     dependencies:
       bignumber.js: 9.1.2
 
-  '@ledgerhq/coin-module-framework@3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)':
+  '@ledgerhq/coin-module-framework@3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)':
     dependencies:
       '@ledgerhq/errors': link:libs/ledgerjs/packages/errors
       bignumber.js: 9.1.2
 
   '@ledgerhq/coin-xrp@7.21.7(@ledgerhq/errors@libs+ledgerjs+packages+errors)(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)':
     dependencies:
-      '@ledgerhq/coin-module-framework': 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+      '@ledgerhq/coin-module-framework': 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/errors': link:libs/ledgerjs/packages/errors
       '@ledgerhq/live-network': link:libs/live-network
       '@ledgerhq/logs': link:libs/ledgerjs/packages/logs

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -197,7 +197,7 @@ catalog:
   oxlint: 1.51.0
   oxfmt: 0.36.0
   # Modules published by coin-modules
-  "@ledgerhq/coin-module-framework": 3.1.0
+  "@ledgerhq/coin-module-framework": 3.2.0
   "@ledgerhq/coin-xrp": 7.21.7
   detox: 20.51.1
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Bridge unit tests + 2 UI component tests + coverage guard. No E2E._
- [x] **Impact of the changes:**
      - EVM Delegations: wire the existing "Claim rewards" header CTA and per-row drawer "Collect rewards" action.
      - New `EvmClaimRewardsFlow`: SelectValidator → Claim (recap + fees-vs-rewards warning) → SelectDevice → ConnectDevice → Validation.
      - Bridge: `validateStaking` emits `claimRewardsFee` warning when network fees exceed the claimable amount (native asset only).
      - Fix `claimReward` staking ops mistakenly tagged as `OUT` (instead of `REWARD`) in both `buildOptimisticOperation` (generic-coin-framework) and `detectEvmStakingOperationType` (coin-evm).

### 📝 Description

EVM staking accounts on mobile had the "Claim rewards" UI in place on the Delegations screen but the callbacks were empty placeholders. This PR wires them and aligns the EVM claim experience with the cross-chain pattern used by Cosmos, Algorand, Hedera and MultiversX:

- **Bridge** emits `warnings.claimRewardsFee` when the estimated fees exceed the claimable amount — same pattern as Cosmos (`coin-cosmos/getTransactionStatus.ts`), Algorand (`coin-algorand/getTransactionStatus.ts`) and Hedera (`coin-hedera/bridge/getTransactionStatus.ts`).
- **UI** introduces a Hedera-like Claim recap screen between the validator pick and the device step, displaying the rewards, the validator, and surfacing the bridge warning via `TranslatedError`. Both entry points (header CTA + per-row drawer) converge on it, so the warning is shown regardless of how the claim is initiated.
- **Op type mapping** maps `claimReward` to `REWARD` in `buildOptimisticOperation` and `detectEvmStakingOperationType`, so claimed rewards display as incoming (`+value`) in the operation history instead of outgoing (`-value`).

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26604](https://ledgerhq.atlassian.net/browse/LIVE-26604)

- **E2E**:
  - Mobile: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/1062e3cf-70f4-47ba-9239-1058401ced10/
  - Desktop: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/b2d4ccba-108d-4796-8dcf-94b0db4d87d9/
  
- **Demo** : https://drive.google.com/file/d/1kL4mGI05V3KWWstJzKh8vyBiRJRf7Gj3/view?usp=sharing
  
| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26604]: https://ledgerhq.atlassian.net/browse/LIVE-26604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
