### PR TITLE
chore: add debug-rn-native-crash skill

### DIFF
--- a/.agents/skills/debug-rn-native-crash/SKILL.md
+++ b/.agents/skills/debug-rn-native-crash/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: debug-rn-native-crash
+description: Investigate native React Native crashes (Fabric/Hermes/iOS) in ledger-live-mobile when JS error logs are missing or unhelpful. Use when the app dies silently, throws an NSException on iOS, or shows only a native stack trace.
+---
+
+# Debug RN native crash
+
+## Trigger
+
+The mobile app crashes with one of:
+- A native iOS exception (`NSInternalInconsistencyException`, `RCTFatal`, Fabric assertion)
+- Only a native stack trace (`RCTViewComponentView`, `RCTPerformMountInstructions`, …) with no JS source
+- "Failed to symbolicate" in Metro and no actionable JS error
+- Reproducible crash but unclear which RN component is at fault
+
+If the JS console already gives a clear stack, **don't use this skill** — read the JS error.
+
+## Workflow
+
+### 1. Capture the native exception from the simulator
+
+```bash
+xcrun simctl list devices booted   # get the booted sim UDID
+xcrun simctl spawn <UDID> log show --last 5m --style compact \
+  --predicate 'processImagePath CONTAINS "ledgerlivemobile" AND (eventMessage CONTAINS "Assertion failure" OR eventMessage CONTAINS "Attempt to unmount" OR eventMessage CONTAINS "Terminating app")'
+```
+
+Extract the exception message, native stack, and any view descriptors (`frame`, `tag`, `backgroundColor`, `alpha`). These already tell you a lot — see reference.md "Anatomy of a Fabric assertion message".
+
+### 2. Reproduce under Xcode debugger
+
+```bash
+open apps/ledger-live-mobile/ios/ledgerlivemobile.xcworkspace
+```
+
+- Stop the running app first (otherwise Xcode can't attach cleanly).
+- In Xcode: **Cmd+8 → +** → Exception Breakpoint → Objective-C → All.
+- **Cmd+R** to build + run + attach.
+- Reproduce the crash. Xcode pauses at `objc_exception_throw`.
+
+### 3. Identify the offending React component
+
+In the **lldb console** at the bottom of Xcode:
+
+1. Pick the frame that has the offending C++/ObjC code:
+   ```
+   bt              # full backtrace, find the frame in RN code
+   frame select N  # N = the RN frame (often RCTPerformMountInstructions)
+   ```
+2. Inspect the views referenced by the failed instruction. Variable names depend on the frame — read the source displayed in Xcode. Common ones:
+   ```
+   po parentViewDescriptor.view
+   po oldChildViewDescriptor.view
+   p  mutation.parentTag
+   p  mutation.index
+   p  oldChildShadowView.componentName
+   ```
+3. Find **where the orphan child is actually attached** vs where Fabric thinks:
+   ```
+   po [oldChildViewDescriptor.view superview]
+   po [oldChildViewDescriptor.view accessibilityIdentifier]   # = RN testID
+   po [parentViewDescriptor.view superview]
+   po [[parentViewDescriptor.view superview] accessibilityIdentifier]
+   po [parentViewDescriptor.view subviews]
+   ```
+4. Climb the superview chain until you hit a `accessibilityIdentifier` (= RN `testID`) you recognise in source. Grep for it:
+   ```bash
+   grep -rn 'testID="<identifier>"' apps/ledger-live-mobile/src libs/ui
+   ```
+   That's the RN component family. From there, read the JSX and find the conditional render / animation / library that produced the mismatch.
+
+### 4. Map the native cause to a code pattern
+
+The vast majority of Fabric assertions come from a small set of patterns. See reference.md "Common Fabric crash patterns".
+
+### 5. Fix and verify Metro actually serves the fix
+
+A common trap: Metro's file watcher dies on `EMFILE: too many open files`. Edits silently never reach the bundle. Always confirm Metro logged a fresh `Compiled ios in Xs` line after each edit (in the terminal running `pnpm mobile start:ios`, or wherever Metro's stdout is streaming).
+
+If the watcher is broken, restart Metro with `--reset-cache`. Reload the app (Cmd+R in sim or shake → Reload).
+
+## Guardrails
+
+- Don't guess at causes from the JS code alone — the native debugger is the source of truth.
+- Don't trust "the bug only happens when flag X is on" until the user has tested both states. Correlation in mobile apps is often coincidental (cold start vs hot reload, cache state, etc.).
+- Don't apply five fixes at once. Apply one, verify Metro served it, retest. Each silent failed iteration is wasted hours.
+
+## Output
+
+- The exact React component identified as the orphan (from `accessibilityIdentifier` / `testID`)
+- The pattern name (e.g. "Reanimated `withRepeat` on unmount", "unstable `keyExtractor`")
+- The minimal fix applied
+- Confirmation Metro served the fix and the crash no longer reproduces
+
+## Reference
+
+See `reference.md` in this folder for:
+- Anatomy of a Fabric assertion message
+- lldb cheatsheet for Fabric mount errors
+- Catalogue of common Fabric crash patterns with code-side fixes

--- a/.agents/skills/debug-rn-native-crash/reference.md
+++ b/.agents/skills/debug-rn-native-crash/reference.md
@@ -1,0 +1,165 @@
+# Reference — RN native crash debugging
+
+## Anatomy of a Fabric assertion message
+
+Example:
+
+```
+*** Terminating app due to uncaught exception 'NSInternalInconsistencyException',
+reason: 'Attempt to unmount a view which is mounted inside different view.
+(parent: <RCTViewComponentView: 0x305b61e60; frame = (16 16; 0 0); alpha = 0.84; tag = 5854>,
+ child:  <RCTViewComponentView: 0x178cf90e0; frame = (0 0; 0 0); tag = 5852;
+         backgroundColor = UIExtendedSRGBColorSpace 0 0 0 0.05>, index: 0)'
+```
+
+What each field tells you:
+
+| Field | Meaning |
+|---|---|
+| `tag` | Fabric/React tag of the view. Lower tag = created earlier. **Child tag < parent tag is a strong signal of reparenting** (the child existed before its supposed parent was created). |
+| `frame = (x y; w h)` | Layout in superview coordinates. `(16 16; 0 0)` = origin (16,16), size 0×0. A 0×0 view usually means the view hasn't been laid out yet — fresh mount. |
+| `alpha = 0.84` | Mid-animation opacity (between 1.0 and `TouchableOpacity.activeOpacity` default 0.2). Tells you a press animation or a fade animation is in flight at crash time. |
+| `backgroundColor = 0 0 0 0.05` | sRGB premultiplied. `rgba(0,0,0,0.05)` often maps to `neutral.c30` / `opacityDefault.c05` in the Ledger theme — useful to grep for. |
+| `index: N` | Which child position in the parent. |
+
+Cross-reference the bg color and frame against styled components in suspect screens. The match is often unique.
+
+## lldb cheatsheet (paused on `objc_exception_throw`)
+
+Common variable names in `RCTPerformMountInstructions` (`RCTMountingManager.mm`):
+
+```
+po parentViewDescriptor.view
+po oldChildViewDescriptor.view
+p  mutation.parentTag
+p  mutation.index
+p  oldChildShadowView.componentName     # "View", "Image", "TextInput", "ScrollView", ...
+p  oldChildShadowView.tag
+```
+
+UIView traversal to identify the React component:
+
+```
+po [oldChildViewDescriptor.view superview]
+po [oldChildViewDescriptor.view accessibilityIdentifier]   # = RN testID
+po [oldChildViewDescriptor.view subviews]
+
+po [parentViewDescriptor.view superview]
+po [[parentViewDescriptor.view superview] accessibilityIdentifier]
+po [parentViewDescriptor.view subviews]
+po [[parentViewDescriptor.view superview] superview]
+```
+
+Print a whole view tree from a node:
+
+```
+po [(UIView*)0x178cf90e0 recursiveDescription]
+```
+
+If `accessibilityIdentifier` is nil, climb superviews until you find one that's set. Then `grep -rn 'testID="<id>"' apps/ledger-live-mobile/src libs/ui`.
+
+Hermes JS state from native (rough, last resort):
+
+```
+po (id)[[RCTBridge currentBridge] valueForKey:@"_jsThread"]
+```
+
+Usually not useful — Fabric crashes happen on the UI thread mid-mount, JS is paused already.
+
+## Common Fabric crash patterns
+
+Most "Attempt to unmount a view which is mounted inside different view" crashes match one of these.
+
+### 1. Unstable `keyExtractor` / list keys
+
+Pattern:
+
+```tsx
+keyExtractor={(item, index) => item.id + index}  // wrong: index changes on filter
+data.map((x, i) => <Row key={i} ... />)          // wrong: index as key in array
+<Flex key={index}>                                // useless on single child
+```
+
+Symptom: list re-renders after data update (search filter, sort, refresh) and crashes within 1s of the data arriving.
+
+Fix: use a stable identity from the data (`item.id`). Never include `index` in keys for lists that filter/sort/reorder.
+
+### 2. Reanimated animation running through unmount
+
+Pattern (lib code, e.g. `@ledgerhq/lumen-ui-rnative` Pulse, Skeleton wrappers):
+
+```tsx
+useEffect(() => {
+  sv.value = withRepeat(withTiming(...), -1);
+  return () => cancelAnimation(sv);
+}, [...]);
+```
+
+When the parent toggles `loading ? <Skeleton/> : <Image/>`, the Skeleton (and its inner `Animated.View` driven by Reanimated) unmounts mid-animation. The cleanup `cancelAnimation` runs, but Fabric's mount instruction for unmount races the animation thread. Tag mismatch → crash.
+
+Symptom: orphan child has `testID="skeleton"` (or other animated wrapper), parent frame is the wrapper's measured 0×0 placeholder.
+
+Fixes (in order of preference):
+- Avoid the conditional swap: render the final content with `opacity: loading ? skeletonOpacity : 1` instead of `loading ? <Skeleton/> : <Content/>`.
+- Patch the lib to use Reanimated's `Layout.exiting` so unmount is animation-aware.
+- As a workaround at the call-site, set `loading={false}` to skip the skeleton for list contexts.
+- Upgrade Reanimated and/or React Native — these races are progressively fixed upstream.
+
+### 3. Inline JSX recreated every render in FlatList sticky header
+
+Pattern:
+
+```tsx
+const listHeaderComponent = (<View>...</View>);          // new element each render
+return <FlatList stickyHeaderIndices={[0]} ListHeaderComponent={listHeaderComponent} ... />;
+```
+
+Each render produces a new ListHeaderComponent identity. Fabric + sticky headers + Animated.FlatList compounds into reparenting glitches.
+
+Fix: wrap header/footer/empty/refreshControl in `useMemo`, extract `renderItem` to `useCallback`, extract style/array constants outside the component:
+
+```tsx
+const stickyHeaderIndices = [0];
+const contentContainerStyle = { paddingHorizontal: 16 };
+
+function View(...) {
+  const listHeaderComponent = useMemo(() => <View>...</View>, [deps]);
+  const renderItem = useCallback(({item}) => <Row item={item}/>, [deps]);
+  ...
+}
+```
+
+### 4. Third-party lib not Fabric-ready
+
+Symptom: native stack includes a third-party module name (gesture handler, bottom-sheet, lottie, …). The lib renders into UIViews it manages directly, behind RN's back.
+
+Fix: check the lib's release notes for Fabric/new-arch support. Pin to the first version with proper Fabric implementation, or wrap the lib in `<View collapsable={false}>` to give Fabric a stable anchor.
+
+### 5. Conditional rendering switching component types under the same parent
+
+Pattern:
+
+```tsx
+{loading && <Skeleton/>}
+{!loading && shouldFallback && <Text>...</Text>}
+{!loading && !shouldFallback && <Image .../>}
+```
+
+Three siblings that mount/unmount in coordinated transitions. Combined with any inflight animation on one of them, this is the reparenting recipe.
+
+Fix: render all three branches always, hide with `opacity: 0` or `display: 'none'`, OR render a single component that internally swaps content via state without changing the JSX shape.
+
+## When to escalate
+
+If the crash matches none of the above and the lldb traversal still doesn't point to a recognisable component:
+
+1. Toggle `RCT_NEW_ARCH_ENABLED = '0'` in `apps/ledger-live-mobile/ios/Podfile`, `pod install`, rebuild. If the crash disappears on Paper, the bug is Fabric-specific (most are). Revert the Podfile + lockfile before committing.
+2. Bisect on `git log --oneline` for the screen / library that introduced the crash.
+3. Capture a sysdiagnose / sample of the app at crash time for the platform team.
+
+## Metro / dev-loop gotchas
+
+- `Watchpack Error: EMFILE: too many open files, watch` → the watcher silently stops. Edits never reach the bundle. The fix in source is invisible at runtime. Restart Metro with `--reset-cache`.
+- `react-native run-ios` fails to spawn a Metro window in sandboxed/non-interactive shells (`open …launchPackager.command` errors). Start Metro separately (`pnpm mobile start:ios`) and run the build with `--no-packager`.
+- `react-native run-ios --target <scheme>` picks the first physical device if one is connected. Force the simulator with `--simulator="<device-name>"` (pick an installed one via `xcrun simctl list devices`).
+- Don't trust silently failing fast refresh. Confirm a fresh `Compiled ios in Xs` line in Metro after each edit.


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _(N/A — docs-only, no package changes)_
- [ ] **Covered by automatic tests.** _(N/A — Claude Code skill, no runtime code)_
- [ ] **Impact of the changes:**
  - Adds a new Claude Code skill under `.agents/skills/debug-rn-native-crash/`. No app/lib code touched.

### 📝 Description

Adds a skill that captures the methodology for investigating native React Native crashes on iOS — the kind where Metro / JS gives no actionable stack and the only signal is an `NSException` from Fabric.

Two files:
- `SKILL.md` — trigger + 5-step workflow (capture exception from sim → reproduce under Xcode breakpoint → identify React component via lldb + accessibilityIdentifier → map to a code pattern → verify Metro served the fix).
- `reference.md` — anatomy of a Fabric assertion message, lldb cheatsheet, catalogue of 5 common Fabric crash patterns with fixes, Metro / dev-loop gotchas.

Distilled from a live debugging session where a NSInternalInconsistencyException ("Attempt to unmount a view which is mounted inside different view") in MarketList search was eventually traced to lumen-ui-rnative's Pulse + Skeleton racing Fabric on unmount. The skill makes that traversal (sim log → Xcode exception breakpoint → po [view accessibilityIdentifier] → grep testID in source) the default playbook.

### ❓ Context

- **JIRA or GitHub link**: _(none — internal tooling)_
- **ADR link (if any)**: _(none)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)