### PR TITLE
[LWD] fix(desktop): align analytics balance with portfolio sync

### DIFF
--- a/.changeset/modern-carrots-greet.md
+++ b/.changeset/modern-carrots-greet.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Align Analytics total balance display with Portfolio V4 sync state

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/__integrations__/Analytics.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/__integrations__/Analytics.test.tsx
@@ -4,6 +4,7 @@ import Analytics from "../index";
 import useAnalyticsViewModel from "../useAnalyticsViewModel";
 import { useAllocationData } from "../hooks/useAllocationData";
 import { makeAllocationViewProps } from "../__fixtures__/allocationFixtures";
+import { mockPortfolioBalanceInfo } from "LLD/hooks/__tests__/fixtures";
 
 jest.mock("../useAnalyticsViewModel");
 const mockedUseAnalyticsViewModel = useAnalyticsViewModel as jest.Mock;
@@ -42,6 +43,7 @@ const defaultViewModel = {
   counterValue: { ticker: "USD", name: "US Dollar" },
   selectedTimeRange: "month",
   navigateToDashboard: mockNavigateToDashboard,
+  balanceInfo: mockPortfolioBalanceInfo,
 };
 
 describe("Analytics", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/__tests__/useAnalyticsViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/__tests__/useAnalyticsViewModel.test.ts
@@ -2,6 +2,8 @@ import { act, renderHook, withFlagOverrides } from "tests/testSetup";
 import { useNavigate } from "react-router";
 import { getFiatCurrencyByTicker } from "@ledgerhq/live-common/currencies/index";
 import { INITIAL_STATE } from "~/renderer/reducers/settings";
+import * as usePortfolioBalanceDisplayStateModule from "LLD/hooks/usePortfolioBalanceDisplayState";
+import { mockPortfolioBalanceInfo } from "LLD/hooks/__tests__/fixtures";
 import useAnalyticsViewModel from "../useAnalyticsViewModel";
 
 jest.mock("react-router", () => ({
@@ -9,11 +11,19 @@ jest.mock("react-router", () => ({
   useNavigate: jest.fn(),
 }));
 
+jest.mock("LLD/hooks/usePortfolioBalanceDisplayState");
+
 const mockedUseNavigate = jest.mocked(useNavigate);
+const mockUsePortfolioBalanceDisplayState = jest.mocked(
+  usePortfolioBalanceDisplayStateModule.usePortfolioBalanceDisplayState,
+);
 
 describe("useAnalyticsViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUsePortfolioBalanceDisplayState.mockReturnValue({
+      balanceInfo: mockPortfolioBalanceInfo,
+    } as ReturnType<typeof usePortfolioBalanceDisplayStateModule.usePortfolioBalanceDisplayState>);
   });
 
   it("should return expected values and navigate back to dashboard", () => {
@@ -34,6 +44,8 @@ describe("useAnalyticsViewModel", () => {
     expect(result.current.counterValue).toBe(getFiatCurrencyByTicker("USD"));
     expect(result.current.selectedTimeRange).toBe("day");
     expect(result.current.shouldDisplayGraphRework).toBe(true);
+    expect(result.current.balanceInfo).toEqual(mockPortfolioBalanceInfo);
+    expect(mockUsePortfolioBalanceDisplayState).toHaveBeenCalledWith();
 
     act(() => {
       result.current.navigateToDashboard();

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/index.tsx
@@ -21,6 +21,7 @@ function AnalyticsView({ viewModel }: { readonly viewModel: AnalyticsViewModel }
     navigateToDashboard,
     shouldDisplayGraphRework,
     shouldDisplayAssetSection,
+    balanceInfo,
   } = viewModel;
 
   const { t } = useTranslation();
@@ -37,6 +38,7 @@ function AnalyticsView({ viewModel }: { readonly viewModel: AnalyticsViewModel }
           range={selectedTimeRange}
           isWallet40
           shouldDisplayGraphRework={shouldDisplayGraphRework}
+          balanceInfo={balanceInfo}
         />
       </div>
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/types.ts
@@ -1,5 +1,6 @@
 import { CryptoOrTokenCurrency, Currency } from "@ledgerhq/types-cryptoassets";
 import { PortfolioRange } from "@ledgerhq/types-live";
+import type { PortfolioBalanceInfo } from "LLD/hooks/usePortfolioBalanceDisplayState";
 
 export type AllocationTableItem = {
   currency: CryptoOrTokenCurrency;
@@ -18,6 +19,7 @@ export type AnalyticsViewModel = {
   navigateToDashboard: () => void;
   counterValue: Currency;
   selectedTimeRange: PortfolioRange;
+  balanceInfo: PortfolioBalanceInfo;
   shouldDisplayGraphRework?: boolean;
   shouldDisplayAssetSection?: boolean;
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/useAnalyticsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/useAnalyticsViewModel.ts
@@ -6,6 +6,7 @@ import {
   selectedTimeRangeSelector,
 } from "~/renderer/reducers/settings";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { usePortfolioBalanceDisplayState } from "LLD/hooks/usePortfolioBalanceDisplayState";
 import type { AnalyticsViewModel } from "./types";
 
 export default function useAnalyticsViewModel(): AnalyticsViewModel {
@@ -14,6 +15,7 @@ export default function useAnalyticsViewModel(): AnalyticsViewModel {
   const selectedTimeRange = useSelector(selectedTimeRangeSelector);
   const { shouldDisplayGraphRework, shouldDisplayAssetSection } =
     useWalletFeaturesConfig("desktop");
+  const { balanceInfo } = usePortfolioBalanceDisplayState();
 
   const navigateToDashboard = useCallback(() => {
     navigate("/");
@@ -23,7 +25,7 @@ export default function useAnalyticsViewModel(): AnalyticsViewModel {
     navigateToDashboard,
     counterValue,
     selectedTimeRange,
-
+    balanceInfo,
     shouldDisplayGraphRework,
     shouldDisplayAssetSection,
   };

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useBalanceViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useBalanceViewModel.ts
@@ -7,17 +7,15 @@ import {
 } from "~/renderer/reducers/settings";
 import { themeSelector } from "~/renderer/actions/general";
 import { useAccountStatus } from "LLD/hooks/useAccountStatus";
-import { usePortfolioBalance } from "LLD/hooks/usePortfolioBalance";
+import { usePortfolioBalanceDisplayState } from "LLD/hooks/usePortfolioBalanceDisplayState";
 import { BalanceViewModelResult } from "../components/Balance/types";
 import { formatCurrencyUnitFragment } from "@ledgerhq/live-common/currencies/index";
-import { useBalanceSyncState } from "@ledgerhq/live-common/bridge/react/index";
 import type { FormattedValue } from "@ledgerhq/lumen-ui-react";
 import { useNavigate } from "react-router";
 import BigNumber from "bignumber.js";
 import { track } from "~/renderer/analytics/segment";
 import { PORTFOLIO_TRACKING_PAGE_NAME } from "LLD/utils/constants";
 import { setTrackingSource } from "~/renderer/analytics/TrackPage";
-import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 
 interface UseBalanceViewModelOptions {
   readonly legacyRange?: boolean;
@@ -26,8 +24,6 @@ interface UseBalanceViewModelOptions {
 export const useBalanceViewModel = (
   options: UseBalanceViewModelOptions = {},
 ): BalanceViewModelResult => {
-  const { shouldDisplayBalanceRefreshRework } = useWalletFeaturesConfig("desktop");
-  const { legacyRange = false } = options;
   const navigate = useNavigate();
   const locale = useSelector(localeSelector);
   const discreet = useSelector(discreetModeSelector);
@@ -36,27 +32,16 @@ export const useBalanceViewModel = (
   const { hasAccount } = useAccountStatus();
 
   const {
-    portfolio,
     counterValue,
+    displayedBalance,
+    balanceAvailable,
+    isLoading,
     isColdStart,
-    balanceAvailable: rawBalanceAvailable,
-    syncPhase,
-    isCvPending,
-  } = usePortfolioBalance({ legacyRange });
-
-  const latestBalanceValue =
-    portfolio.balanceHistory[portfolio.balanceHistory.length - 1]?.value ?? 0;
-
-  const { balanceAvailable, displayedBalance, isLoading } = useBalanceSyncState({
-    rawBalanceAvailable,
-    syncPhase,
-    latestBalance: latestBalanceValue,
-    shouldFreezeOnSync: shouldDisplayBalanceRefreshRework,
-    cvPending: shouldDisplayBalanceRefreshRework ? isCvPending : undefined,
-  });
+    valueChange,
+    shouldDisplayBalanceRefreshRework,
+  } = usePortfolioBalanceDisplayState(options);
 
   const unit = counterValue.units[0];
-  const valueChange = portfolio.countervalueChange;
 
   const navigateToAnalytics = useCallback(() => {
     setTrackingSource(PORTFOLIO_TRACKING_PAGE_NAME);

--- a/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/fixtures.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/fixtures.ts
@@ -46,6 +46,12 @@ export const defaultPortfolio: Portfolio = {
   countervalueChange: { percentage: 0, value: 0 },
 };
 
+export const mockPortfolioBalanceInfo = {
+  totalBalance: 9000,
+  isAvailable: true,
+  valueChange: { percentage: 12.34, value: 567 },
+};
+
 // --- usePortfolioBalance mock return ---
 
 export function makePortfolioBalanceReturn(overrides?: Partial<ReturnType<typeof getDefault>>) {

--- a/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/usePortfolioBalanceDisplayState.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/usePortfolioBalanceDisplayState.test.ts
@@ -1,0 +1,65 @@
+import { renderHook, withFlagOverrides } from "tests/testSetup";
+import { usePortfolioBalanceDisplayState } from "../usePortfolioBalanceDisplayState";
+import * as usePortfolioBalanceModule from "LLD/hooks/usePortfolioBalance";
+import {
+  defaultPortfolio,
+  makePortfolioBalanceReturn,
+  mockPortfolioBalanceInfo,
+  mockCounterValue,
+} from "LLD/hooks/__tests__/fixtures";
+import { INITIAL_STATE } from "~/renderer/reducers/settings";
+
+jest.mock("LLD/hooks/usePortfolioBalance");
+
+const mockUsePortfolioBalance = jest.mocked(usePortfolioBalanceModule.usePortfolioBalance);
+
+const initialState = {
+  settings: {
+    ...INITIAL_STATE,
+    counterValue: "USD",
+    counterValueCurrency: mockCounterValue,
+  },
+  ...withFlagOverrides({
+    lwdWallet40: {
+      enabled: true,
+      params: { balanceRefreshRework: true },
+    },
+  }),
+};
+
+describe("usePortfolioBalanceDisplayState", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePortfolioBalance.mockReturnValue(makePortfolioBalanceReturn());
+  });
+
+  it("should request the Portfolio V4 day range by default", () => {
+    renderHook(() => usePortfolioBalanceDisplayState(), { initialState });
+
+    expect(mockUsePortfolioBalance).toHaveBeenCalledWith({ legacyRange: false });
+  });
+
+  it("should expose the display balance and value change as balanceInfo", () => {
+    mockUsePortfolioBalance.mockReturnValue(
+      makePortfolioBalanceReturn({
+        portfolio: {
+          ...defaultPortfolio,
+          balanceHistory: [
+            { date: new Date("2026-05-21"), value: mockPortfolioBalanceInfo.totalBalance },
+          ],
+          countervalueChange: mockPortfolioBalanceInfo.valueChange,
+        },
+      }),
+    );
+
+    const { result } = renderHook(() => usePortfolioBalanceDisplayState(), { initialState });
+
+    expect(result.current.balanceInfo).toEqual(mockPortfolioBalanceInfo);
+  });
+
+  it("should pass legacyRange through when explicitly requested", () => {
+    renderHook(() => usePortfolioBalanceDisplayState({ legacyRange: true }), { initialState });
+
+    expect(mockUsePortfolioBalance).toHaveBeenCalledWith({ legacyRange: true });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/hooks/usePortfolioBalanceDisplayState.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/usePortfolioBalanceDisplayState.ts
@@ -1,0 +1,95 @@
+import { useMemo } from "react";
+import { useBalanceSyncState } from "@ledgerhq/live-common/bridge/react/index";
+import type { SyncPhase } from "@ledgerhq/live-common/bridge/react/useSyncLifecycle";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import type { Currency } from "@ledgerhq/types-cryptoassets";
+import type { Portfolio, ValueChange } from "@ledgerhq/types-live";
+import { usePortfolioBalance } from "LLD/hooks/usePortfolioBalance";
+
+export interface UsePortfolioBalanceDisplayStateOptions {
+  readonly legacyRange?: boolean;
+}
+
+export interface PortfolioBalanceInfo {
+  readonly totalBalance: number;
+  readonly isAvailable: boolean;
+  readonly valueChange: ValueChange;
+}
+
+export interface PortfolioBalanceDisplayState {
+  readonly portfolio: Portfolio;
+  readonly counterValue: Currency;
+  readonly displayedBalance: number;
+  readonly balanceAvailable: boolean;
+  readonly isLoading: boolean;
+  readonly isColdStart: boolean;
+  readonly isCvPending: boolean;
+  readonly syncPhase: SyncPhase;
+  readonly valueChange: ValueChange;
+  readonly balanceInfo: PortfolioBalanceInfo;
+  readonly shouldDisplayBalanceRefreshRework: boolean;
+}
+
+export function usePortfolioBalanceDisplayState(
+  options: UsePortfolioBalanceDisplayStateOptions = {},
+): PortfolioBalanceDisplayState {
+  const { shouldDisplayBalanceRefreshRework } = useWalletFeaturesConfig("desktop");
+  const {
+    portfolio,
+    counterValue,
+    isColdStart,
+    balanceAvailable: rawBalanceAvailable,
+    syncPhase,
+    isCvPending,
+  } = usePortfolioBalance({ legacyRange: options.legacyRange ?? false });
+
+  const latestBalanceValue =
+    portfolio.balanceHistory[portfolio.balanceHistory.length - 1]?.value ?? 0;
+
+  const { balanceAvailable, displayedBalance, isLoading } = useBalanceSyncState({
+    rawBalanceAvailable,
+    syncPhase,
+    latestBalance: latestBalanceValue,
+    shouldFreezeOnSync: shouldDisplayBalanceRefreshRework,
+    cvPending: shouldDisplayBalanceRefreshRework ? isCvPending : undefined,
+  });
+
+  const valueChange = portfolio.countervalueChange;
+  const balanceInfo = useMemo(
+    () => ({
+      totalBalance: displayedBalance,
+      isAvailable: balanceAvailable,
+      valueChange,
+    }),
+    [displayedBalance, balanceAvailable, valueChange],
+  );
+
+  return useMemo(
+    () => ({
+      portfolio,
+      counterValue,
+      displayedBalance,
+      balanceAvailable,
+      isLoading,
+      isColdStart,
+      isCvPending,
+      syncPhase,
+      valueChange,
+      balanceInfo,
+      shouldDisplayBalanceRefreshRework,
+    }),
+    [
+      portfolio,
+      counterValue,
+      displayedBalance,
+      balanceAvailable,
+      isLoading,
+      isColdStart,
+      isCvPending,
+      syncPhase,
+      valueChange,
+      balanceInfo,
+      shouldDisplayBalanceRefreshRework,
+    ],
+  );
+}

--- a/apps/ledger-live-desktop/src/renderer/components/BalanceInfos/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/BalanceInfos/index.tsx
@@ -65,7 +65,11 @@ export function BalanceDiff({
           <FormattedVal
             isPercent
             animateTicker
-            val={Math.round(valueChange.percentage * 100)}
+            val={
+              shouldDisplayGraphRework
+                ? valueChange.percentage * 100
+                : Math.round(valueChange.percentage * 100)
+            }
             inline
             withIcon
             percentageTwoDecimals={shouldDisplayGraphRework}

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/GlobalSummary.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/GlobalSummary.test.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import PortfolioBalanceSummary from "./GlobalSummary";
+import { usePortfolio } from "~/renderer/actions/portfolio";
+import {
+  defaultPortfolio,
+  mockCounterValue,
+  mockPortfolioBalanceInfo,
+} from "LLD/hooks/__tests__/fixtures";
+
+jest.mock("~/renderer/actions/portfolio", () => ({
+  usePortfolio: jest.fn(),
+}));
+
+jest.mock("~/renderer/components/Chart", () => ({
+  __esModule: true,
+  GraphTrackingScreenName: { Portfolio: "Portfolio" },
+  default: jest.fn(({ data, tickXScale }) => (
+    <div
+      data-testid="chart"
+      data-latest-value={data[data.length - 1]?.value}
+      data-range={tickXScale}
+    />
+  )),
+}));
+
+jest.mock("~/renderer/components/BalanceInfos", () => ({
+  __esModule: true,
+  default: jest.fn(({ totalBalance, isAvailable, valueChange }) => (
+    <div
+      data-testid="balance-infos"
+      data-total-balance={totalBalance}
+      data-is-available={String(isAvailable)}
+      data-value-change={valueChange.value}
+      data-percentage={valueChange.percentage}
+    />
+  )),
+}));
+
+const mockUsePortfolio = jest.mocked(usePortfolio);
+
+describe("PortfolioBalanceSummary", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePortfolio.mockReturnValue({
+      ...defaultPortfolio,
+      balanceHistory: [
+        { date: new Date("2026-05-20"), value: 100 },
+        { date: new Date("2026-05-21"), value: 200 },
+      ],
+      countervalueChange: { percentage: 1, value: 2 },
+      range: "month",
+    });
+  });
+
+  it("should keep chart data from the selected Analytics range while displaying injected Portfolio V4 balance info", () => {
+    render(
+      <PortfolioBalanceSummary
+        counterValue={mockCounterValue}
+        chartColor="#000"
+        range="month"
+        isWallet40
+        balanceInfo={mockPortfolioBalanceInfo}
+      />,
+    );
+
+    expect(screen.getByTestId("chart")).toHaveAttribute("data-latest-value", "200");
+    expect(screen.getByTestId("chart")).toHaveAttribute("data-range", "month");
+    expect(screen.getByTestId("balance-infos")).toHaveAttribute(
+      "data-total-balance",
+      String(mockPortfolioBalanceInfo.totalBalance),
+    );
+    expect(screen.getByTestId("balance-infos")).toHaveAttribute(
+      "data-value-change",
+      String(mockPortfolioBalanceInfo.valueChange.value),
+    );
+    expect(screen.getByTestId("balance-infos")).toHaveAttribute(
+      "data-percentage",
+      String(mockPortfolioBalanceInfo.valueChange.percentage),
+    );
+  });
+
+  it("should fall back to the Analytics portfolio when no balance info is injected", () => {
+    render(
+      <PortfolioBalanceSummary
+        counterValue={mockCounterValue}
+        chartColor="#000"
+        range="month"
+        isWallet40
+      />,
+    );
+
+    expect(screen.getByTestId("balance-infos")).toHaveAttribute("data-total-balance", "200");
+    expect(screen.getByTestId("balance-infos")).toHaveAttribute("data-value-change", "2");
+    expect(screen.getByTestId("balance-infos")).toHaveAttribute("data-percentage", "1");
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/GlobalSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/GlobalSummary.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import { useSelector } from "LLD/hooks/redux";
 import { BigNumber } from "bignumber.js";
 import { formatShort } from "@ledgerhq/live-common/currencies/index";
@@ -12,12 +12,15 @@ import { discreetModeSelector } from "~/renderer/reducers/settings";
 import BalanceInfos from "~/renderer/components/BalanceInfos";
 import { usePortfolio } from "~/renderer/actions/portfolio";
 import { hourFormat, dayFormat, useDateFormatter } from "~/renderer/hooks/useDateFormatter";
+import type { PortfolioBalanceInfo } from "LLD/hooks/usePortfolioBalanceDisplayState";
+
 type Props = {
   counterValue: Currency;
   chartColor: string;
   range: PortfolioRange;
   isWallet40?: boolean;
   shouldDisplayGraphRework?: boolean;
+  balanceInfo?: PortfolioBalanceInfo;
 };
 export default function PortfolioBalanceSummary({
   range,
@@ -25,6 +28,7 @@ export default function PortfolioBalanceSummary({
   counterValue,
   isWallet40,
   shouldDisplayGraphRework,
+  balanceInfo,
 }: Props) {
   const portfolio = usePortfolio();
   const discreetMode = useSelector(discreetModeSelector);
@@ -50,15 +54,30 @@ export default function PortfolioBalanceSummary({
     ),
     [counterValue, dayFormatter, hourFormatter],
   );
+  const displayBalanceInfo = useMemo(
+    () =>
+      balanceInfo ?? {
+        totalBalance: portfolio.balanceHistory[portfolio.balanceHistory.length - 1]?.value ?? 0,
+        isAvailable: portfolio.balanceAvailable,
+        valueChange: portfolio.countervalueChange,
+      },
+    [
+      balanceInfo,
+      portfolio.balanceHistory,
+      portfolio.balanceAvailable,
+      portfolio.countervalueChange,
+    ],
+  );
+
   const content = (
     <>
       <Box px={6}>
         <BalanceInfos
           counterValueId={counterValue.type !== "FiatCurrency" ? counterValue.id : undefined}
           unit={counterValue.units[0]}
-          isAvailable={portfolio.balanceAvailable}
-          valueChange={portfolio.countervalueChange}
-          totalBalance={portfolio.balanceHistory[portfolio.balanceHistory.length - 1].value}
+          isAvailable={displayBalanceInfo.isAvailable}
+          valueChange={displayBalanceInfo.valueChange}
+          totalBalance={displayBalanceInfo.totalBalance}
           shouldDisplayGraphRework={shouldDisplayGraphRework}
         />
       </Box>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Verify Portfolio V4 and Analytics show the same total balance during and after manual sync.
  - Verify Analytics graph still follows the selected time range, especially non-day ranges such as week and month.
  - Verify the Analytics percentage display matches Portfolio V4 when Wallet 4.0 graph rework is enabled.

### 📝 Description

Analytics could show a different total balance and percentage than Portfolio V4 when Wallet 4.0 was enabled, especially around sync and countervalue refresh timing.

This PR centralizes the Portfolio V4 display-state logic in a shared Desktop MVVM hook and injects only the display-ready balance info into the Analytics summary. The Analytics chart keeps using its own selected time range data, so aligning the header balance no longer forces the chart onto the Portfolio V4 day range.

Before: Analytics could reuse a portfolio snapshot with the wrong range or compute display state independently from Portfolio V4.

After: Portfolio and Analytics share the same display-ready total balance state, while Analytics graph data remains range-specific.


https://github.com/user-attachments/assets/ea5edb2f-5336-40eb-a859-c9bd0294a07d





### ❓ Context

- **JIRA or GitHub link**: [LIVE-29125](https://ledgerhq.atlassian.net/browse/LIVE-29125)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29125]: https://ledgerhq.atlassian.net/browse/LIVE-29125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ