### PR TITLE
[LWD] fix(desktop): stabilize concordium OnboardModal happy-path test

### DIFF
--- a/.changeset/quiet-pandas-flake.md
+++ b/.changeset/quiet-pandas-flake.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Stabilize Concordium OnboardModal happy-path test by moving the transient QR-code assertion to a dedicated PREPARE-only test that can't race the SUCCESS debounce

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/OnboardModal.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/OnboardModal.test.tsx
@@ -63,6 +63,19 @@ function createMockPairObservable() {
   };
 }
 
+// PREPARE-only: emits the QR-code state and stays open, so the intermediate
+// step can be asserted without racing the SUCCESS debounce.
+function createMockPairPrepareOnlyObservable() {
+  return {
+    subscribe: jest.fn(({ next }: SubscribeArgs) => {
+      const t1 = setTimeout(() => {
+        next({ status: "PREPARE", walletConnectUri: "wc:mock-uri-for-testing" });
+      }, 10);
+      return { unsubscribe: jest.fn(() => clearTimeout(t1)) };
+    }),
+  };
+}
+
 function createMockOnboardObservable(completedAccount: Account) {
   return {
     subscribe: jest.fn(({ next, complete }: SubscribeArgs) => {
@@ -151,10 +164,10 @@ describe("OnboardModal", () => {
     await user.click(agreeButton);
     expect(mockPairWalletConnect).toHaveBeenCalledWith(currency.id, mockDevice.deviceId);
 
-    await waitFor(() => {
-      expect(screen.getByText(/scan the qr code/i)).toBeVisible();
-    }, WAIT_OPTS);
-
+    // The PREPARE → SUCCESS gap (T+200 vs T-debounce) is intentionally tight so
+    // the test stays fast; setStateWithTimeout may legitimately debounce the
+    // intermediate QR-code state away on a slow CI runner. Coverage for the QR
+    // step lives in the "should render QR code during pairing" test below.
     await waitFor(() => {
       expect(screen.getByText(/successfully connected to concordium id app/i)).toBeVisible();
     }, WAIT_OPTS);
@@ -189,6 +202,20 @@ describe("OnboardModal", () => {
 
     await user.click(doneButton);
   }, 20_000);
+
+  it("should render QR code during pairing", async () => {
+    // PREPARE-only observable — SUCCESS never arrives to debounce the
+    // intermediate state away.
+    mockPairWalletConnect.mockReturnValue(createMockPairPrepareOnlyObservable());
+
+    const { user } = render(<OnboardModal {...defaultProps} />, { initialState });
+
+    await user.click(await screen.findByRole("button", { name: /agree/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/scan the qr code/i)).toBeVisible();
+    }, WAIT_OPTS);
+  }, 10_000);
 
   it("should show error and Try again when pairing fails", async () => {
     mockPairWalletConnect.mockReturnValue(


### PR DESCRIPTION
## Summary

- The `OnboardModal › should complete the full onboarding happy path` test has been [intermittently failing in CI](https://github.com/LedgerHQ/ledger-live/actions/runs/26166538150/job/76972126524).
- Root cause is in `OnboardModal.setStateWithTimeout` (`apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/index.tsx:205-216`): each progress event clears the previous pending 1500 ms transition timeout and schedules a new one. The mock observable emits SUCCESS only 200 ms after PREPARE, so on a slow CI runner the PREPARE (QR-code) state update can be discarded before it lands — the QR step never renders and the intermediate assertion fails.
- This is debounce behaviour that production may legitimately exhibit too (back-to-back observable events coalesce), so asserting on the transient QR step inside the happy-path test is brittle.
- Fix: remove the intermediate `expect(getByText(/scan the qr code/i))` from the happy-path test, and add a dedicated `should render QR code during pairing` test that uses a PREPARE-only observable (no SUCCESS ever arrives), guaranteeing the intermediate state is observable.

## Example Failure 
https://github.com/LedgerHQ/ledger-live/actions/runs/26223680423/job/77164966284
https://github.com/LedgerHQ/ledger-live/actions/runs/26166538150/job/76972126524

## Tradeoff

- The happy-path test no longer single-asserts every intermediate UI step — but the QR step is now covered by a focused test that cannot race.
- No production change. Test runtime is essentially unchanged.

## Test plan

- [x] All 10 tests in `OnboardModal.test.tsx` pass locally
- [x] CI passes on this PR
- [x] Spot-check by re-running Desktop Unit Tests a few times

🤖 Generated with [Claude Code](https://claude.com/claude-code)