### PR TITLE
[LWM] fix(mobile): await async getAccountBridge in useStakingDrawer callback

### DIFF
--- a/apps/ledger-live-mobile/src/components/Stake/useStakingDrawer.test.tsx
+++ b/apps/ledger-live-mobile/src/components/Stake/useStakingDrawer.test.tsx
@@ -25,7 +25,7 @@ jest.mock("../../generated/accountActions", () => ({
 }));
 
 jest.mock("@ledgerhq/live-common/bridge/index", () => ({
-  getAccountBridge: jest.fn(() => mockBridge),
+  getAccountBridge: jest.fn(() => Promise.resolve(mockBridge)),
 }));
 
 jest.mock("@ledgerhq/ledger-wallet-framework/account/helpers", () => ({
@@ -50,7 +50,7 @@ describe("useStakingDrawer", () => {
     jest.clearAllMocks();
   });
 
-  it("passes resolved bridge to family getMainActions", () => {
+  it("passes resolved bridge to family getMainActions", async () => {
     mockGetMainActions.mockReturnValue([
       { id: "stake", navigationParams: ["Stake", { screen: "StakeScreen", params: {} }] },
     ]);
@@ -59,7 +59,7 @@ describe("useStakingDrawer", () => {
       useStakingDrawer({ navigation, parentRoute, alwaysShowNoFunds: false }),
     );
 
-    result.current(bitcoinAccount as never);
+    await result.current(bitcoinAccount as never);
 
     expect(mockGetMainActions).toHaveBeenCalledTimes(1);
     expect(mockGetMainActions).toHaveBeenCalledWith(
@@ -67,7 +67,7 @@ describe("useStakingDrawer", () => {
     );
   });
 
-  it("navigates to the family stake flow returned by getMainActions", () => {
+  it("navigates to the family stake flow returned by getMainActions", async () => {
     mockGetMainActions.mockReturnValue([
       {
         id: "stake",
@@ -79,7 +79,7 @@ describe("useStakingDrawer", () => {
       useStakingDrawer({ navigation, parentRoute, alwaysShowNoFunds: false }),
     );
 
-    result.current(bitcoinAccount as never);
+    await result.current(bitcoinAccount as never);
 
     expect(navigation.navigate).toHaveBeenCalledWith(NavigatorName.Base, {
       screen: "StakeNavigator",

--- a/apps/ledger-live-mobile/src/components/Stake/useStakingDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/Stake/useStakingDrawer.tsx
@@ -26,7 +26,7 @@ export function useStakingDrawer({
   const { getRouteParamsForPlatformApp } = useStake();
 
   return useCallback(
-    (account: AccountLike, parentAccount?: Account) => {
+    async (account: AccountLike, parentAccount?: Account) => {
       if (alwaysShowNoFunds || getAccountSpendableBalance(account).isZero()) {
         // get funds to stake with
         navigation.navigate(NavigatorName.Base, {
@@ -62,7 +62,7 @@ export function useStakingDrawer({
 
       // get the stake flow for the specific currency
 
-      const bridge = getAccountBridge(account, parentAccount);
+      const bridge = await getAccountBridge(account, parentAccount);
 
       const familySpecificMainActions =
         (decorators &&


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. <!-- internal-only mobile callback fix -->
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:** Mobile only. The staking-drawer callback (used by Stake screen, WebPTX, EarnLiveApp, modular drawer's onAccountSelected) now awaits `getAccountBridge` before forwarding the resolved bridge to family decorators. Shippable on develop: `await` on a sync return is a no-op today; the fix becomes load-bearing once `getAccountBridge` actually returns a Promise (parent draft #17155).

### 📝 Description

`useStakingDrawer` synchronously called `getAccountBridge(account, parentAccount)` and forwarded the result to family `getMainActions` decorators (celo/cosmos/sui/tezos/...). Those decorators in turn call `bridge.isAccountEmpty(account)` directly. Once `getAccountBridge` returns a Promise (per the async migration in draft #17155) this breaks at runtime: `Promise.isAccountEmpty` is not a function.

Make the callback async and `await getAccountBridge` so the bridge is resolved before being forwarded. All call sites are fire-and-forget (`useLayoutEffect`, WebPTX handler, navigator deeplink, modular-drawer `onAccountSelected`) — returning a Promise instead of void is harmless.

The test mock is updated to return `Promise.resolve(mockBridge)` and tests `await result.current(...)` so assertions run after the bridge resolves.

```diff
- (account: AccountLike, parentAccount?: Account) => {
+ async (account: AccountLike, parentAccount?: Account) => {
   ...
-   const bridge = getAccountBridge(account, parentAccount);
+   const bridge = await getAccountBridge(account, parentAccount);
   ...
```

### ❓ Context

- **JIRA or GitHub link**: parent draft #17155 — async coin-loader migration
- **ADR link (if any)**: n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)