### PR TITLE
[LWDM] fix(coin-tester-tezos): await async coin-framework bridge builders

### DIFF
--- a/libs/coin-tester-modules/coin-tester-tezos/src/helpers.ts
+++ b/libs/coin-tester-modules/coin-tester-tezos/src/helpers.ts
@@ -11,17 +11,17 @@ import type { TezosTestSigner } from "./signer";
 
 registerCoinModules(coinModuleLoaders);
 
-export function getBridges(signer: TezosTestSigner): {
+export async function getBridges(signer: TezosTestSigner): Promise<{
   currencyBridge: CurrencyBridge;
   accountBridge: AccountBridge<GenericTransaction>;
   getAddress: GetAddressFn;
-} {
+}> {
   const context: SignerContext<TezosTestSigner> = (_, fn) => fn(signer);
   const getAddress = tezosGetAddress(context);
 
   return {
-    currencyBridge: getCoinFrameworkCurrencyBridge("tezos", "local", { context, getAddress }),
-    accountBridge: getCoinFrameworkAccountBridge("tezos", "local", { context, getAddress }),
+    currencyBridge: await getCoinFrameworkCurrencyBridge("tezos", "local", { context, getAddress }),
+    accountBridge: await getCoinFrameworkAccountBridge("tezos", "local", { context, getAddress }),
     getAddress,
   };
 }

--- a/libs/coin-tester-modules/coin-tester-tezos/src/scenarii/tezos.ts
+++ b/libs/coin-tester-modules/coin-tester-tezos/src/scenarii/tezos.ts
@@ -121,7 +121,7 @@ export const scenarioTezosTz1: Scenario<GenericTransaction, Account> = {
     await spawnFlextesa();
 
     const signer = await buildTz1Signer();
-    const { currencyBridge, accountBridge, getAddress } = getBridges(signer);
+    const { currencyBridge, accountBridge, getAddress } = await getBridges(signer);
 
     const { address } = await getAddress("", {
       path: "44'/1729'/0'/0'",
@@ -210,7 +210,7 @@ export const scenarioTezosTz2: Scenario<GenericTransaction, Account> = {
 
     await spawnFlextesa();
     const signer = await buildTz2Signer();
-    const { currencyBridge, accountBridge, getAddress } = getBridges(signer);
+    const { currencyBridge, accountBridge, getAddress } = await getBridges(signer);
     const { address } = await getAddress("", {
       path: "44'/1729'/0'",
       currency: TEZOS,


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. <!-- internal-only coin-tester change -->
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:** coin-tester-tezos only. Mirrors the EVM/Solana tester pattern: `getBridges` becomes async and the two scenario call sites `await getBridges(...)`. Shippable on develop: `await` on a sync return is a no-op today; correctness is preserved once `getCoinFrameworkCurrencyBridge`/`getCoinFrameworkAccountBridge` actually return Promises (parent draft #17155).

### 📝 Description

`getBridges` in `coin-tester-tezos` synchronously called the generic coin-framework bridge builders. Once those builders go async (parent draft #17155), the call sites would silently end up with `Promise<Bridge>` instead of `Bridge`.

Mirror the EVM/Solana tester:
- `getBridges` becomes `async` and returns `Promise<{ ... }>`
- `getCoinFrameworkCurrencyBridge` / `getCoinFrameworkAccountBridge` are awaited
- Both scenario call sites (`tz1` / `tz2` setup) `await getBridges(signer)`

```diff
- export function getBridges(signer: TezosTestSigner): { ... } {
+ export async function getBridges(signer: TezosTestSigner): Promise<{ ... }> {
   ...
   return {
-    currencyBridge: getCoinFrameworkCurrencyBridge("tezos", "local", ctx),
-    accountBridge: getCoinFrameworkAccountBridge("tezos", "local", ctx),
+    currencyBridge: await getCoinFrameworkCurrencyBridge("tezos", "local", ctx),
+    accountBridge: await getCoinFrameworkAccountBridge("tezos", "local", ctx),
     ...
   };
 }
```

### ❓ Context

- **JIRA or GitHub link**: parent draft #17155 — async coin-loader migration
- **ADR link (if any)**: n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)