### PR TITLE
[LWD] refactor(desktop): switch EVM RedelegationFlow to useAccountBridge hook

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/families/evm/RedelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/RedelegationFlowModal/Body.tsx
@@ -9,8 +9,9 @@ import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { Transaction as EvmTransaction } from "@ledgerhq/coin-evm/types/index";
 import { StepId, StepProps, St } from "./types";
 import { Account, Operation } from "@ledgerhq/types-live";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -103,7 +104,7 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
   const dispatch = useDispatch();
   const { account, validatorAddress, source = "Account Page" } = params;
 
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge<EvmTransaction>(account, undefined);
   const {
     transaction,
     setTransaction,
@@ -121,9 +122,9 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
     const transaction = bridge.updateTransaction(baseTransaction, {
       mode: "redelegate",
       valAddress: validatorAddress ?? "",
-      amount: sourceDelegation?.amount,
       recipient: account.freshAddress,
-    });
+      ...(sourceDelegation && { amount: sourceDelegation.amount }),
+    } as unknown as Partial<EvmTransaction>);
     return {
       account,
       parentAccount: undefined,

--- a/apps/ledger-live-desktop/src/renderer/families/evm/RedelegationFlowModal/steps/StepDestinationValidators.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/RedelegationFlowModal/steps/StepDestinationValidators.tsx
@@ -1,7 +1,6 @@
 import invariant from "invariant";
 import React, { useCallback } from "react";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
-import type { AccountBridge } from "@ledgerhq/types-live";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-coin-framework/types";
 import ValidatorField from "../fields/ValidatorField";
 import { StepProps } from "../types";
@@ -12,10 +11,10 @@ export default function StepDestinationValidators({
   onUpdateTransaction,
   transaction,
   transitionTo,
-}: StepProps) {
+}: Readonly<StepProps>) {
   invariant(transaction, "transaction required");
 
-  const bridge = getAccountBridge(account, parentAccount) as AccountBridge<GenericTransaction>;
+  const bridge = useAccountBridge<GenericTransaction>(account, parentAccount);
 
   const updateDestinationValidator = useCallback(
     (address: string) => {

--- a/apps/ledger-live-desktop/src/renderer/families/evm/RedelegationFlowModal/steps/StepValidators.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/RedelegationFlowModal/steps/StepValidators.tsx
@@ -3,8 +3,7 @@ import React, { useCallback, useMemo } from "react";
 import styled from "styled-components";
 import { Trans } from "react-i18next";
 import { BigNumber } from "bignumber.js";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
-import type { AccountBridge } from "@ledgerhq/types-live";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-coin-framework/types";
 import type { StakingMappedDelegation } from "@ledgerhq/live-common/families/evm/staking/types";
 import TrackPage from "~/renderer/analytics/TrackPage";
@@ -62,10 +61,10 @@ export default function StepValidators({
   error,
   t,
   transitionTo,
-}: StepProps) {
+}: Readonly<StepProps>) {
   invariant(transaction, "transaction required");
 
-  const bridge = getAccountBridge(account, parentAccount) as AccountBridge<GenericTransaction>;
+  const bridge = useAccountBridge<GenericTransaction>(account, parentAccount);
   const updateRedelegation = useCallback(
     (patch: Partial<GenericTransaction>) => {
       onUpdateTransaction(tx => bridge.updateTransaction(tx, patch));
@@ -195,7 +194,7 @@ export function StepValidatorsFooter({
   onClose,
   status,
   bridgePending,
-}: StepProps) {
+}: Readonly<StepProps>) {
   invariant(account, "account required");
   const { errors } = status;
   const hasErrors = Object.keys(errors).length;


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. <!-- desktop-only refactor, no public API change -->
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:** Desktop EVM RedelegationFlow only. Replaces direct `getAccountBridge` calls with the suspend-ready `useAccountBridge` hook in `Body`, `StepValidators` and `StepDestinationValidators`. Shippable on develop: `useAccountBridge` already exists and wraps the (currently sync) bridge in a fulfilled Promise, so React's `use()` resolves synchronously — same behaviour today, correct tomorrow once `getAccountBridge` becomes async (parent draft #17155).

### 📝 Description

The EVM `RedelegationFlowModal` currently uses the imperative `getAccountBridge(...)` helper inside React components. Once `getAccountBridge` returns a Promise (parent draft #17155), those sync call sites break. Migrate to the dedicated `useAccountBridge` hook (already on develop, suspend-ready via `use()` on a fulfilled-Promise wrap) — same behaviour today, ready for tomorrow.

```diff
- import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+ import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
  ...
- const bridge = getAccountBridge(account, parentAccount);
+ const bridge = useAccountBridge<EvmTransaction>(account, parentAccount);
```

Touches `Body.tsx`, `steps/StepValidators.tsx`, `steps/StepDestinationValidators.tsx`.

### ❓ Context

- **JIRA or GitHub link**: parent draft #17155 — async coin-loader migration
- **ADR link (if any)**: n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)