### PR TITLE
feat(wallet-cli): emit standalone greppable hash line on broadcast

### DIFF
--- a/.changeset/wallet-cli-send-hash-line.md
+++ b/.changeset/wallet-cli-send-hash-line.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-cli": patch
+---
+
+Emit a plain greppable `hash: <txHash>` line to stdout on broadcast (human output) so scripts can capture the transaction hash without parsing ANSI-styled status lines.

--- a/apps/wallet-cli/src/output.test.ts
+++ b/apps/wallet-cli/src/output.test.ts
@@ -99,6 +99,28 @@ describe("HumanCommandOutput", () => {
     expect(createdSpinners).toHaveLength(1);
   });
 
+  it("emits a plain greppable `hash: <txHash>` line to stdout on broadcasted", async () => {
+    const { installOutputCapture } = await import("./shared/ui");
+    const writes: string[] = [];
+    const restore = installOutputCapture({
+      stdout: chunk => {
+        writes.push(chunk);
+      },
+    });
+    try {
+      const out = createCommandOutput("human", {
+        command: "send",
+        network: "ethereum:main",
+        account: "js:2:ethereum:0x123",
+      });
+      out.spin("Broadcasting…");
+      out.sendEvent({ type: "broadcasted", txHash: "0xdeadbeef" });
+    } finally {
+      restore();
+    }
+    expect(writes.join("")).toContain("hash: 0xdeadbeef");
+  });
+
   it("token() writes the formatted token info to stdout", async () => {
     const { installOutputCapture } = await import("./shared/ui");
     const { USDT_TOKEN_INFO } = await import("./test/helpers/cal-fixtures");

--- a/apps/wallet-cli/src/output.ts
+++ b/apps/wallet-cli/src/output.ts
@@ -325,6 +325,7 @@ class HumanCommandOutput implements CommandOutput {
         break;
       case "broadcasted":
         s?.success(`Broadcasted  ${colors.dim(event.txHash)}`);
+        writeStdout(`hash: ${event.txHash}`);
         break;
     }
   }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [ ] **Impact of the changes:**
  - Adds one extra stdout line (hash: <txHash>) in human output after a successful broadcast. JSON output unchanged.

### 📝 Description

In human mode, the existing Broadcasted spinner-success line styles the hash with ANSI dim and prefixes it with "Broadcasted", which makes it brittle to scrape from scripts. This PR emits an additional plain hash: <txHash> line via writeStdout immediately after the spinner success, so consumers can grep the hash reliably.

JSON mode already exposes tx_hash on the sendComplete envelope — no change there.

### ❓ Context

- **JIRA or GitHub link**: [NTTVS-294](https://ledgerhq.atlassian.net/browse/NTTVS-294)
- **ADR link (if any)**: n/a

[NTTVS-294]: https://ledgerhq.atlassian.net/browse/NTTVS-294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ