### PR TITLE
[LWM] fix(mobile): hide bank transfer in transfer drawer for non-stablecoin assets

### DIFF
--- a/.changeset/asset-detail-hide-bank-transfer.md
+++ b/.changeset/asset-detail-hide-bank-transfer.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix Bank transfer option showing in TransferDrawer for all assets on Asset Detail screen

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
@@ -82,7 +82,7 @@ export function AssetDetailView({
         </Box>
       </ScrollView>
       <Footer currency={currency} />
-      <TransferDrawer />
+      <TransferDrawer currency={currency} />
       <AssetCoinOptionsSheetView
         isOpen={coinOptions.isCoinOptionsSheetOpen}
         onClose={coinOptions.closeCoinOptions}

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/__integrations__/TransferDrawerBankTransferVisibility.integration.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/__integrations__/TransferDrawerBankTransferVisibility.integration.test.ts
@@ -1,0 +1,75 @@
+import { renderHook } from "@tests/test-renderer";
+import { useTransferDrawerViewModel } from "../useTransferDrawerViewModel";
+import { overrideStateWithFunds } from "LLM/features/QuickActions/__integrations__/shared";
+import { State } from "~/reducers/types";
+import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+
+const USDC_CURRENCY_ID = "ethereum/erc20/usd__coin";
+
+const mockBitcoin = getCryptoCurrencyById("bitcoin");
+
+const mockUsdc = {
+  type: "TokenCurrency",
+  id: USDC_CURRENCY_ID,
+  parentCurrency: { family: "evm" },
+} as unknown as TokenCurrency;
+
+const withOpenDrawer =
+  (noahEnabled: boolean, activeCurrencyIds: string[] = []) =>
+  (state: State): State => {
+    const base = overrideStateWithFunds(state);
+    return {
+      ...base,
+      featureFlags: {
+        ...base.featureFlags,
+        overrides: {
+          ...base.featureFlags.overrides,
+          noah: {
+            enabled: noahEnabled,
+            params: { activeCurrencyIds },
+          },
+        },
+      },
+      transferDrawer: {
+        isOpen: true,
+        sourceScreenName: "Asset Detail",
+      },
+    };
+  };
+
+describe("TransferDrawer bank_transfer visibility", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("should hide bank_transfer for a non-stablecoin asset when Noah is enabled", () => {
+    const { result } = renderHook(() => useTransferDrawerViewModel({ currency: mockBitcoin }), {
+      overrideInitialState: withOpenDrawer(true, [USDC_CURRENCY_ID]),
+    });
+
+    expect(result.current.actions.find(a => a.id === "bank_transfer")).toBeUndefined();
+  });
+
+  it("should show bank_transfer for a stablecoin when Noah is enabled and currency is in activeCurrencyIds", () => {
+    const { result } = renderHook(() => useTransferDrawerViewModel({ currency: mockUsdc }), {
+      overrideInitialState: withOpenDrawer(true, [USDC_CURRENCY_ID]),
+    });
+
+    expect(result.current.actions.find(a => a.id === "bank_transfer")).toBeDefined();
+  });
+
+  it("should hide bank_transfer when Noah flag is disabled regardless of currency", () => {
+    const { result } = renderHook(() => useTransferDrawerViewModel({ currency: mockUsdc }), {
+      overrideInitialState: withOpenDrawer(false),
+    });
+
+    expect(result.current.actions.find(a => a.id === "bank_transfer")).toBeUndefined();
+  });
+
+  it("should show bank_transfer when no currency is provided (Portfolio context) and Noah is enabled", () => {
+    const { result } = renderHook(() => useTransferDrawerViewModel(), {
+      overrideInitialState: withOpenDrawer(true, [USDC_CURRENCY_ID]),
+    });
+
+    expect(result.current.actions.find(a => a.id === "bank_transfer")).toBeDefined();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/index.tsx
@@ -1,10 +1,15 @@
 import React from "react";
+import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
 import QueuedDrawerGorhom from "LLM/components/QueuedDrawer/temp/QueuedDrawerGorhom";
 import { TransferDrawerView } from "./TransferDrawerView";
 import { TransferDrawerViewLegacy } from "./TransferDrawerViewLegacy";
 import { useTransferDrawerViewModel } from "./useTransferDrawerViewModel";
+
+type Props = Readonly<{
+  currency?: CryptoOrTokenCurrency;
+}>;
 
 /**
  * TransferDrawer - Bottom sheet with transfer action options
@@ -14,8 +19,10 @@ import { useTransferDrawerViewModel } from "./useTransferDrawerViewModel";
  * - Send crypto: Navigates to send flow
  * - Bank transfer: Navigates to buy flow for stablecoin purchases
  */
-export const TransferDrawer = () => {
-  const { isOpen, title, actions, handleClose, bottomInset } = useTransferDrawerViewModel();
+export const TransferDrawer = ({ currency }: Props = {}) => {
+  const { isOpen, title, actions, handleClose, bottomInset } = useTransferDrawerViewModel({
+    currency,
+  });
   const { isEnabled } = useWalletFeaturesConfig("mobile");
 
   if (isEnabled) {

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/useTransferDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/useTransferDrawerViewModel.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { useSelector } from "~/context/hooks";
 import { QrCode, ArrowUp, Bank } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { NavigatorName, ScreenName } from "~/const";
@@ -30,7 +31,13 @@ interface TransferDrawerViewModel {
   bottomInset: number;
 }
 
-export const useTransferDrawerViewModel = (): TransferDrawerViewModel => {
+interface UseTransferDrawerViewModelParams {
+  currency?: CryptoOrTokenCurrency;
+}
+
+export const useTransferDrawerViewModel = ({
+  currency,
+}: UseTransferDrawerViewModelParams = {}): TransferDrawerViewModel => {
   const { t } = useTranslation();
   const { bottom: bottomInset } = useSafeAreaInsets();
   const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
@@ -46,7 +53,7 @@ export const useTransferDrawerViewModel = (): TransferDrawerViewModel => {
     fromMenu: true,
   });
 
-  const { showNoahMenu: showNoahOption } = useReceiveNoahEntry();
+  const { showNoahMenu: showNoahOption } = useReceiveNoahEntry({ currency });
 
   const transferCopyFlag = useFeature("llmTransferButtonCopyVariant");
   const language = useSelector(languageSelector);


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.** 
- [x] **Impact of the changes:**
  - TransferDrawer on the Asset Detail screen: "Bank transfer" row visibility
  - Only affects users with the `noah` Firebase feature flag enabled
  - No change to Portfolio-level TransferDrawer behaviour (no currency context → no filtering)

### 📝 Description

**Problem**: On the Asset Detail screen, the "Bank transfer" option was always visible in the TransferDrawer (opened via the Transfer or Receive CTA) regardless of the currently viewed asset. It should only appear for USDC and USDT.

**Root cause**: `useTransferDrawerViewModel` called `useReceiveNoahEntry()` without a currency argument. Inside `shouldShowNoahMenu`, when no currency is provided `hasValidCurrency` defaults to `true`, so the Noah option was shown for every asset whenever the `noah` flag was enabled.

**Fix**: Pass the current asset's currency down the chain `AssetDetailView → TransferDrawer → useTransferDrawerViewModel → useReceiveNoahEntry`. The existing `shouldShowNoahMenu` logic then correctly checks the currency against the `activeCurrencyIds` list managed by the **`noah` Firebase feature flag** — Bank transfer is now shown only when the viewed asset is in that list (USDC, USDT).



https://github.com/user-attachments/assets/ec5c1c3b-4bc7-4bbe-8cf8-ee8d690ba865



### ❓ Context

- **JIRA or GitHub link**: [LIVE-31224](https://ledgerhq.atlassian.net/browse/LIVE-31224)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31224]: https://ledgerhq.atlassian.net/browse/LIVE-31224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ