### PR TITLE
[LWD] fix(desktop): scope ProductTour dark theme to dialog subtree

### DIFF
--- a/.changeset/light-lobsters-push.md
+++ b/.changeset/light-lobsters-push.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix half-light / half-dark rendering on the Wallet 4.0 Portfolio when toggling theme via the floating ThemeConsole. The ProductTour dialog's hardcoded `<ThemeProvider colorScheme="dark">` wrapper was applying the `dark` class on `<html>` globally and racing with the root ThemeProvider. The dialog is now scoped via a local `dark` class on `DialogContent` so it stays dark without polluting the global theme.

--- a/apps/ledger-live-desktop/src/mvvm/features/ProductTour/Drawer/ProductTourDialogView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ProductTour/Drawer/ProductTourDialogView.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react";
-import { Dialog, DialogContent, DialogHeader, ThemeProvider } from "@ledgerhq/lumen-ui-react";
+import { Dialog, DialogContent, DialogHeader } from "@ledgerhq/lumen-ui-react";
 import { Slides } from "LLD/components/Slides";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import { ProductTourFooter } from "./components/ProductTourFooter";
@@ -39,32 +39,30 @@ export const ProductTourDialog = ({
   );
 
   return (
-    <ThemeProvider colorScheme="dark">
-      <Dialog open={isOpen} onOpenChange={() => {}}>
-        <DialogContent
-          className="flex h-screen min-h-0 flex-col"
-          onPointerDownOutside={onDismiss}
-          onEscapeKeyDown={onDismiss}
+    <Dialog open={isOpen} onOpenChange={() => {}}>
+      <DialogContent
+        className="dark flex h-screen min-h-0 flex-col"
+        onPointerDownOutside={onDismiss}
+        onEscapeKeyDown={onDismiss}
+      >
+        {isOpen && <TrackPage category={PAGE_TRACKING_PRODUCT_TOUR} />}
+        <DialogHeader density="compact" onClose={onClose} />
+        <Slides
+          key={isOpen ? "reset" : "closed"}
+          initialSlideIndex={0}
+          onSlideChange={onSlideChange}
         >
-          {isOpen && <TrackPage category={PAGE_TRACKING_PRODUCT_TOUR} />}
-          <DialogHeader density="compact" onClose={onClose} />
-          <Slides
-            key={isOpen ? "reset" : "closed"}
-            initialSlideIndex={0}
-            onSlideChange={onSlideChange}
-          >
-            <Slides.Content>{slideItems}</Slides.Content>
+          <Slides.Content>{slideItems}</Slides.Content>
 
-            <Slides.ProgressIndicator>
-              <ProductTourProgressIndicator />
-            </Slides.ProgressIndicator>
+          <Slides.ProgressIndicator>
+            <ProductTourProgressIndicator />
+          </Slides.ProgressIndicator>
 
-            <Slides.Footer>
-              <ProductTourFooter onPrimaryAction={onPrimaryAction} onComplete={onComplete} />
-            </Slides.Footer>
-          </Slides>
-        </DialogContent>
-      </Dialog>
-    </ThemeProvider>
+          <Slides.Footer>
+            <ProductTourFooter onPrimaryAction={onPrimaryAction} onComplete={onComplete} />
+          </Slides.Footer>
+        </Slides>
+      </DialogContent>
+    </Dialog>
   );
 };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Existing ProductTourDialog integration test still passes. No new assertion added because the regression is a global side-effect (Lumen `ThemeProvider` writing to `<html>`) that is awkward to assert in a Jest environment without DOM-level mocking; manual QA on the V4 Portfolio + floating ThemeConsole reproduces and confirms the fix._
- [x] **Impact of the changes:**
  - Wallet 4.0 (`lwdWallet40`) Portfolio rendering when toggling theme via the floating ThemeConsole
  - ProductTour dialog visual appearance (must remain dark as before)
  - Global theme behaviour across the rest of the app (must follow user selection — no leakage)

### 📝 Description

**Problem**: On the Wallet 4.0 Portfolio, toggling the theme via the floating ThemeConsole (Dev menu) produced a half-light / half-dark rendering — Lumen / Tailwind components stayed dark while styled-components legacy components followed the user selection.

**Root cause**: The ProductTour dialog (`ProductTourDialogView.tsx`) was wrapped in `<ThemeProvider colorScheme="dark">`. Lumen's `ThemeProvider` internally calls `useRootColorModeSideEffect`, which writes the `dark` / `light` class onto `<html>` globally. Because the ProductTour lives in the Portfolio tree and is mounted even when `open={false}`, this nested provider was permanently re-applying `dark` on `<html>`, racing with the root `ThemeProvider` (`App.tsx:70`) and overwriting the user's choice. Styled-components read the Redux state and rendered Light correctly; Lumen / Tailwind components read `<html>.dark` and rendered Dark — hence the mismatched halves.

**Solution**: Remove the hardcoded `<ThemeProvider colorScheme="dark">` wrapper and apply a local `dark` class on `DialogContent`. Tailwind's `darkMode: 'class'` strategy scopes the dark tokens to the dialog's DOM subtree only — the dialog stays visually dark as intended, and the global `<html>` class is no longer touched.

```tsx
// Before
<ThemeProvider colorScheme="dark">
  <Dialog open={isOpen} ...>
    <DialogContent className="flex h-screen min-h-0 flex-col" ...>
      ...
    </DialogContent>
  </Dialog>
</ThemeProvider>

// After
<Dialog open={isOpen} ...>
  <DialogContent className="dark flex h-screen min-h-0 flex-col" ...>
    ...
  </DialogContent>
</Dialog>
```

**Reproduction (before this fix)**:
1. Enable `lwdWallet40` feature flag
2. Open the Portfolio page
3. Open the floating ThemeConsole (Dev menu) and toggle Dark → Light **without navigating away**
4. → half-light / half-dark rendering

**Note for future**: never nest a Lumen `<ThemeProvider>` with a hardcoded `colorScheme` inside the app tree — it will always fight the root theme via global `<html>` mutation. Any "always dark" UI surface should be styled locally with utility classes.


https://github.com/user-attachments/assets/e3b1c8ea-5892-4237-abbb-67bed27db1c6


https://github.com/user-attachments/assets/c66e355b-809e-40ce-904a-ce59841946f1



### ❓ Context

- **JIRA or GitHub link**: [LIVE-30958](https://ledgerhq.atlassian.net/browse/LIVE-30958)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.


[LIVE-30958]: https://ledgerhq.atlassian.net/browse/LIVE-30958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ