### PR TITLE
[LWD] fix(desktop): align AssetDetail typography with design

### DIFF
--- a/.changeset/lovely-forks-wait.md
+++ b/.changeset/lovely-forks-wait.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Align AssetDetail market price and total balance typography with design

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/MarketPriceSectionView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/MarketPriceSectionView.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { AmountDisplay, Skeleton } from "@ledgerhq/lumen-ui-react";
-import { cn } from "LLD/utils/cn";
-import { trendPercentageBody3Styles } from "LLD/shared/trendPercentageStyles";
+import { trendPercentageBody2Styles } from "LLD/shared/trendPercentageStyles";
 import type { MarketPriceSectionViewModelResult } from "./useMarketPriceSectionViewModel";
 
 type MarketPriceSectionViewProps = Readonly<MarketPriceSectionViewModelResult>;
@@ -9,7 +8,7 @@ type MarketPriceSectionViewProps = Readonly<MarketPriceSectionViewModelResult>;
 export function MarketPriceSectionView(viewModel: MarketPriceSectionViewProps) {
   return (
     <div className="flex flex-col gap-8" data-testid="asset-detail-market-price-section">
-      <span className="body-2-semi-bold text-muted">{viewModel.title}</span>
+      <span className="body-2 text-muted">{viewModel.title}</span>
       {viewModel.showSkeleton ? (
         <span aria-hidden className="inline-block">
           <Skeleton className="h-40 w-1/2 rounded-8" />
@@ -23,28 +22,24 @@ export function MarketPriceSectionView(viewModel: MarketPriceSectionViewProps) {
               data-testid="asset-detail-market-price"
             />
           ) : (
-            <span className={cn("body-1", "text-muted")} data-testid="asset-detail-market-price">
+            <span className="body-1 text-muted" data-testid="asset-detail-market-price">
               —
             </span>
           )}
           <div className="flex flex-row items-center gap-4">
             <span
               data-testid="asset-detail-market-price-percent"
-              className={trendPercentageBody3Styles({ variant: viewModel.variationVariant })}
+              className={trendPercentageBody2Styles({ variant: viewModel.variationVariant })}
             >
               {viewModel.percentageText}
             </span>
             <span
-              className={cn(
-                "body-3",
-                "tabular-nums",
-                viewModel.hasVariationData ? "text-base" : "text-muted",
-              )}
+              className="body-2 tabular-nums text-muted"
               data-testid="asset-detail-market-price-fiat-variation"
             >
               {viewModel.variationText}
             </span>
-            <span className={cn("body-3", "text-muted")}>
+            <span className="body-2 text-muted">
               <span aria-hidden>&middot;</span> {viewModel.dayLabel}
             </span>
           </div>

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/PortfolioSection/TotalBalance/TotalBalanceView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/PortfolioSection/TotalBalance/TotalBalanceView.tsx
@@ -19,7 +19,7 @@ export function TotalBalanceView({
 }: TotalBalanceViewProps) {
   return (
     <div className="flex flex-col gap-8" data-testid="asset-detail-total-balance">
-      <p className="body-2-semi-bold text-muted">{totalBalanceLabel}</p>
+      <p className="body-3 text-muted">{totalBalanceLabel}</p>
 
       <div className="flex min-w-0 flex-wrap items-baseline gap-4">
         <AmountDisplay


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Asset Detail page — Market Price section font sizes/weights
  - Asset Detail page — Portfolio Total Balance label typography
  - Verify light/dark themes render correctly

### 📝 Description

Align typography in the AssetDetail page with the latest design spec.

**Problem**: The Market Price section and Portfolio Total Balance label used outdated body styles (`body-2-semi-bold`, `body-3`) that diverged from the current design.

**Solution**: Update the affected spans/paragraphs to use the correct `body-2` / `body-3` tokens, switch the percentage variation to `trendPercentageBody2Styles`, and remove the now-unnecessary `cn` helper calls where a single className suffices.

### 🖼️ Screenshots

<img width="768" height="474" alt="Screenshot 2026-05-22 at 11 24 19" src="https://github.com/user-attachments/assets/57ae0923-46fd-4a37-8218-de63eee24354" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-30940](https://ledgerhq.atlassian.net/browse/LIVE-30940) https://ledgerhq.atlassian.net/browse/LIVE-30940

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30940]: https://ledgerhq.atlassian.net/browse/LIVE-30940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ