### PR TITLE
[LWDM] fix(LIVE-31245): correct app memory prediction

### DIFF
--- a/.changeset/warm-chairs-design.md
+++ b/.changeset/warm-chairs-design.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-common": patch
+"@ledgerhq/devices": patch
+---
+
+correct app memory prediction

--- a/libs/ledger-live-common/src/apps/logic.test.ts
+++ b/libs/ledger-live-common/src/apps/logic.test.ts
@@ -1,8 +1,9 @@
 import {
+  distribute,
   initState,
+  isOutOfMemoryState,
   reducer,
   /*
-  distribute,
   getActionPlan,
   predictOptimisticState,
   */
@@ -10,14 +11,30 @@ import {
   getNextAppOp,
 } from "./logic";
 import { /*runAll,*/ runOneAppOp } from "./runner";
-import { deviceInfo155, mockListAppsResult, mockExecWithInstalledContext } from "./mock";
+import { deviceInfo155, deviceInfo222, mockListAppsResult, mockExecWithInstalledContext } from "./mock";
 // import { prettyActionPlan, prettyInstalled } from "./formatting";
 import { setEnv } from "@ledgerhq/live-env";
 import { Action } from "./types";
 import { firstValueFrom } from "rxjs";
+import { DeviceModelId } from "@ledgerhq/devices";
+import type { Language, LanguagePackage } from "@ledgerhq/types-live";
 
 setEnv("MANAGER_INSTALL_DELAY", 0);
 // TODO reactivate this test after bitcoin 2.1.0 nano app
+
+const makeLanguagePack = (language: Language, bytes: number): LanguagePackage => ({
+  language,
+  languagePackageVersionId: 1,
+  version: "1.0.0",
+  language_package_id: 1,
+  apdu_install_url: "",
+  apdu_uninstall_url: "",
+  device_versions: [],
+  se_firmware_final_versions: [],
+  bytes,
+  date_creation: "",
+  date_last_modified: "",
+});
 
 /*
 const scenarios = [
@@ -446,4 +463,39 @@ test("global progress", async () => {
 
   expect(i).toBe(total);
   expect(updateAllProgress(state)).toBe(1);
+});
+
+describe("memory distribution", () => {
+  const createState = () =>
+    initState(mockListAppsResult("", "", deviceInfo222, DeviceModelId.stax));
+
+  test("does not count the embedded English language pack as installed storage", () => {
+    const state = createState();
+
+    state.installedLanguagePack = makeLanguagePack("english", 10 * 512);
+    expect(distribute(state).languagePackBlocks).toBe(0);
+
+    state.installedLanguagePack = makeLanguagePack("french", 10 * 512);
+    expect(distribute(state).languagePackBlocks).toBe(10);
+  });
+
+  test("predicts out of memory before the final storage block is used", () => {
+    const state = createState();
+    const { appsSpaceBlocks } = distribute(state);
+
+    state.installed = [
+      {
+        name: "Test app",
+        updated: true,
+        hash: "",
+        blocks: appsSpaceBlocks - 2,
+        version: "",
+        availableVersion: "",
+      },
+    ];
+    expect(isOutOfMemoryState(state)).toBe(false);
+
+    state.installed = [{ ...state.installed[0], blocks: appsSpaceBlocks - 1 }];
+    expect(isOutOfMemoryState(state)).toBe(true);
+  });
 });

--- a/libs/ledger-live-common/src/apps/logic.ts
+++ b/libs/ledger-live-common/src/apps/logic.ts
@@ -10,6 +10,8 @@ import { App } from "@ledgerhq/types-live";
 import { getEnv } from "@ledgerhq/live-env";
 import { LatestFirmwareVersionRequired } from "@ledgerhq/errors";
 
+const RESERVED_BLOCKS = 1;
+
 export const initState = (
   { deviceModelId, appsListNames, installed, appByName, ...listAppsResult }: ListAppsResult,
   appsToRestore?: string[],
@@ -389,6 +391,10 @@ const defaultConfig = {
   warnMemoryRatio: 0.1,
   sortApps: false,
 };
+
+const getLanguagePackBytes = (state: State): number =>
+  state.installedLanguagePack?.language === "english" ? 0 : state.installedLanguagePack?.bytes || 0;
+
 // calculate all size information useful for display
 export const distribute = (
   state: State,
@@ -401,7 +407,7 @@ export const distribute = (
   const totalBlocks = Math.floor(totalBytes / blockSize);
   const osBytes = (state.firmware && state.firmware.bytes) || 0;
   const osBlocks = Math.ceil(osBytes / blockSize);
-  const languagePackBytes = state.installedLanguagePack?.bytes || 0;
+  const languagePackBytes = getLanguagePackBytes(state);
   const languagePackBlocks = Math.ceil(languagePackBytes / blockSize);
   const appsSpaceBlocks = totalBlocks - osBlocks - customImageBlocks - languagePackBlocks;
   const appsSpaceBytes = appsSpaceBlocks * blockSize;
@@ -456,7 +462,7 @@ export const isIncompleteState = (state: State): boolean => state.installed.some
 // calculate if a given state (typically a predicted one) is out of memory (meaning impossible to reach with a device)
 export const isOutOfMemoryState = (state: State): boolean => {
   const { totalAppsBlocks, appsSpaceBlocks } = distribute(state);
-  return totalAppsBlocks > appsSpaceBlocks;
+  return totalAppsBlocks >= appsSpaceBlocks - RESERVED_BLOCKS;
 };
 export const isLiveSupportedApp = (app: App): boolean => {
   const currency = app?.currencyId ? findCryptoCurrencyById(app.currencyId) : null;

--- a/libs/ledgerjs/packages/devices/src/index.ts
+++ b/libs/ledgerjs/packages/devices/src/index.ts
@@ -86,7 +86,7 @@ const devices: { [key in DeviceModelId]: DeviceModel } = {
     usbOnly: true,
     memorySize: 1533 * 1024,
     masks: [0x33100000],
-    getBlockSize: (_firmwareVersion: string): number => 32,
+    getBlockSize: (_firmwareVersion: string): number => 512,
   },
   [DeviceModelId.apex]: {
     id: DeviceModelId.apex,
@@ -96,7 +96,7 @@ const devices: { [key in DeviceModelId]: DeviceModel } = {
     usbOnly: false,
     memorySize: 1533 * 1024,
     masks: [0x33400000],
-    getBlockSize: (_firmwareVersion: string): number => 32,
+    getBlockSize: (_firmwareVersion: string): number => 512,
     bluetoothSpec: [
       {
         serviceUuid: "13d63400-2c97-8004-0000-4c6564676572",
@@ -114,7 +114,7 @@ const devices: { [key in DeviceModelId]: DeviceModel } = {
     usbOnly: false,
     memorySize: 1533 * 1024,
     masks: [0x33200000],
-    getBlockSize: (_firmwareVersion: string): number => 32,
+    getBlockSize: (_firmwareVersion: string): number => 512,
     bluetoothSpec: [
       {
         serviceUuid: "13d63400-2c97-6004-0000-4c6564676572",
@@ -132,7 +132,7 @@ const devices: { [key in DeviceModelId]: DeviceModel } = {
     usbOnly: false,
     memorySize: 1533 * 1024,
     masks: [0x33300000],
-    getBlockSize: (_firmwareVersion: string): number => 32,
+    getBlockSize: (_firmwareVersion: string): number => 512,
     bluetoothSpec: [
       {
         serviceUuid: "13d63400-2c97-3004-0000-4c6564676572",


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Invalid out-of-memory prediction for apps installation.
Details in ticket: https://ledgerhq.atlassian.net/browse/LIVE-31245

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
