### PR TITLE
[LWM] fix(mobile): pending tx not appearing immediately in OperationsList

### DIFF
--- a/.changeset/fix-pending-ops-history-display.md
+++ b/.changeset/fix-pending-ops-history-display.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix pending transaction not appearing immediately in OperationsList screen

--- a/apps/ledger-live-mobile/src/reducers/accounts.ts
+++ b/apps/ledger-live-mobile/src/reducers/accounts.ts
@@ -133,9 +133,7 @@ export async function exportSelector(state: State): Promise<{
         if (!accountUserData) return null;
         return accountModel.encode([account, accountUserData]);
       })
-      .filter(
-        (p): p is Promise<{ data: AccountRaw; version: number }> => p !== null,
-      ),
+      .filter((p): p is Promise<{ data: AccountRaw; version: number }> => p !== null),
   );
   return { active };
 }
@@ -157,7 +155,7 @@ export const accountsSelector = (s: State): Account[] => s.accounts.active;
 // NB some components don't need to refresh every time an account is updated, usually it's only
 // when the balance/name/length/starred/swapHistory of accounts changes.
 const accountHash = (a: AccountLike) =>
-  `${a.id}-${a.balance.toString()}-swapHistory(${a.swapHistory.length})`;
+  `${a.id}-${a.balance.toString()}-swapHistory(${a.swapHistory.length})-pending(${a.pendingOperations.length})`;
 
 // TODO can we share with desktop in common?
 const shallowAccountsSelectorCreator = createSelectorCreator(lruMemoize, (a, b): boolean =>


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [ ] **Covered by automatic tests.** _No automated test added — the selector memoization behavior is difficult to unit test in isolation; manual verification on the OperationsList screen after a broadcast is the recommended test path._
- [x] **Impact of the changes:**
  - OperationsList screen: pending transaction should now appear immediately after broadcast (no delay)
  - All other consumers of \`shallowAccountsSelector\` (AssetDetail, Swap, Buy, Analytics PnL, CryptoAddressesButton, NotEnoughFundFeesAlert) will re-render when \`pendingOperations.length\` changes — this is correct behavior and the extra re-render is bounded to broadcast/confirmation events only

### 📝 Description

After broadcasting a transaction, the new pending operation was not appearing in the OperationsList screen until the next sync cycle (up to 10 seconds).

The root cause was in \`shallowAccountsSelector\`: its \`accountHash\` function hashed accounts by \`id + balance + swapHistory.length\`. Adding a pending operation via \`addPendingOperation\` creates a new account object but changes none of those fields, so \`lruMemoize\` returned the stale cached array. The OperationsList ViewModel never saw the new pending op.

The fix adds \`pendingOperations.length\` to the hash, making the selector invalidate its cache whenever a pending op is added or removed. The dot indicator in the TopBar was already instant because it uses \`accountsSelector\` (raw) via \`hasUnreadOperationsSelector\` — this fix aligns the OperationsList with the same reactivity.

https://github.com/user-attachments/assets/a100bdff-0609-48f0-b4e9-7dd580c79c0e


### ❓ Context

- **JIRA or GitHub link**: [LIVE-31246](https://ledgerhq.atlassian.net/browse/LIVE-31246)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31246]: https://ledgerhq.atlassian.net/browse/LIVE-31246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ