### PR TITLE
[LWM] feat(mobile): add generic awareness modal QA tools

### DIFF
--- a/.changeset/gentle-modals-appear.md
+++ b/.changeset/gentle-modals-appear.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add mobile debug tools for QAing generic awareness modals

--- a/apps/ledger-live-mobile/src/dynamicContent/buildLocalGenericAwarenessModalCards.test.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/buildLocalGenericAwarenessModalCards.test.ts
@@ -1,0 +1,138 @@
+import { GenericAwarenessModalLayout } from "@ledgerhq/live-common/genericAwarenessModal";
+import {
+  buildDefaultGenericAwarenessModalFormValues,
+  buildLocalGenericAwarenessModalBrazeCards,
+  buildLocalGenericAwarenessModalContentCards,
+  getDefaultGenericAwarenessModalCampaignId,
+} from "./buildLocalGenericAwarenessModalCards";
+
+describe("buildLocalGenericAwarenessModalCards", () => {
+  it("should build carousel content cards from raw Braze-like cards", () => {
+    const values = {
+      ...buildDefaultGenericAwarenessModalFormValues(),
+      campaignId: "debug-carousel",
+      items: [
+        {
+          title: "Second",
+          subtitle: "Second slide",
+          imageUrl: "https://example.com/second.png",
+          primaryButtonLabel: "Next",
+          primaryButtonLink: "ledgerlive://portfolio",
+        },
+        {
+          title: "First",
+          subtitle: "First slide",
+          imageUrl: "https://example.com/first.png",
+          primaryButtonLabel: "Start",
+          primaryButtonLink: "ledgerlive://portfolio",
+        },
+      ],
+    };
+
+    const rawCards = buildLocalGenericAwarenessModalBrazeCards(values);
+    const contentCards = buildLocalGenericAwarenessModalContentCards(values);
+
+    expect(rawCards).toHaveLength(2);
+    expect(rawCards[0].extras).toMatchObject({
+      campaignId: "debug-carousel",
+      layout: GenericAwarenessModalLayout.Carousel,
+      location: "generic_awareness_modal",
+      index: "0",
+    });
+    expect(contentCards).toEqual([
+      {
+        id: "debug-carousel",
+        isLocal: true,
+        layout: GenericAwarenessModalLayout.Carousel,
+        data: [
+          {
+            title: "Second",
+            subtitle: "Second slide",
+            imageUrl: "https://example.com/second.png",
+            primaryButtonLabel: "Next",
+            primaryButtonLink: "ledgerlive://portfolio",
+          },
+          {
+            title: "First",
+            subtitle: "First slide",
+            imageUrl: "https://example.com/first.png",
+            primaryButtonLabel: "Start",
+            primaryButtonLink: "ledgerlive://portfolio",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("should build feature intro content cards from main and item Braze-like cards", () => {
+    const values = {
+      ...buildDefaultGenericAwarenessModalFormValues(),
+      layout: GenericAwarenessModalLayout.FeatureIntro,
+      campaignId: "debug-feature-intro",
+      title: "Feature intro",
+      subtitle: "Feature intro subtitle",
+      imageUrl: "https://example.com/main.png",
+      primaryButtonLabel: "Start",
+      primaryButtonLink: "ledgerlive://buy",
+      secondaryButtonLabel: "Later",
+      secondaryButtonLink: "ledgerlive://portfolio",
+      items: [
+        {
+          icon: "Shield",
+          title: "Secure",
+          subtitle: "Keep keys safe.",
+        },
+      ],
+    };
+
+    const rawCards = buildLocalGenericAwarenessModalBrazeCards(values);
+    const contentCards = buildLocalGenericAwarenessModalContentCards(values);
+
+    expect(rawCards).toHaveLength(2);
+    expect(rawCards[0].extras).toMatchObject({
+      campaignId: "debug-feature-intro",
+      layout: GenericAwarenessModalLayout.FeatureIntro,
+      role: "main",
+      location: "generic_awareness_modal",
+    });
+    expect(rawCards[1].extras).toMatchObject({
+      role: "item",
+      index: "0",
+    });
+    expect(contentCards).toEqual([
+      {
+        id: "debug-feature-intro",
+        isLocal: true,
+        layout: GenericAwarenessModalLayout.FeatureIntro,
+        title: "Feature intro",
+        subtitle: "Feature intro subtitle",
+        imageUrl: "https://example.com/main.png",
+        primaryButtonLabel: "Start",
+        primaryButtonLink: "ledgerlive://buy",
+        secondaryButtonLabel: "Later",
+        secondaryButtonLink: "ledgerlive://portfolio",
+        items: [
+          {
+            icon: "Shield",
+            title: "Secure",
+            subtitle: "Keep keys safe.",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("should provide app-start and deeplink campaign defaults", () => {
+    const appStartCampaignId = getDefaultGenericAwarenessModalCampaignId(
+      GenericAwarenessModalLayout.Carousel,
+      "appStart",
+    );
+    const deeplinkCampaignId = getDefaultGenericAwarenessModalCampaignId(
+      GenericAwarenessModalLayout.Carousel,
+      "deeplink",
+    );
+
+    expect(appStartCampaignId).toBe("app_start_debug_generic_awareness_carousel");
+    expect(deeplinkCampaignId).toBe("debug_generic_awareness_carousel");
+  });
+});

--- a/apps/ledger-live-mobile/src/dynamicContent/buildLocalGenericAwarenessModalCards.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/buildLocalGenericAwarenessModalCards.ts
@@ -1,0 +1,184 @@
+import {
+  GenericAwarenessModalLayout,
+  processGenericAwarenessModalBrazeCards,
+} from "@ledgerhq/live-common/genericAwarenessModal";
+import type { GenericAwarenessModalMobileContentCard } from "~/reducers/genericAwarenessModal";
+
+export type GenericAwarenessModalDebugLayout =
+  | GenericAwarenessModalLayout.Carousel
+  | GenericAwarenessModalLayout.FeatureIntro;
+
+export type GenericAwarenessModalDebugTrigger = "appStart" | "deeplink";
+
+export type GenericAwarenessModalDebugItem = {
+  title: string;
+  subtitle: string;
+  imageUrl?: string;
+  primaryButtonLabel?: string;
+  primaryButtonLink?: string;
+  icon?: string;
+};
+
+export type GenericAwarenessModalDebugFormValues = {
+  layout: GenericAwarenessModalDebugLayout;
+  trigger: GenericAwarenessModalDebugTrigger;
+  campaignId: string;
+  title: string;
+  subtitle: string;
+  imageUrl: string;
+  primaryButtonLabel: string;
+  primaryButtonLink: string;
+  secondaryButtonLabel: string;
+  secondaryButtonLink: string;
+  items: GenericAwarenessModalDebugItem[];
+};
+
+type GenericAwarenessModalDebugBrazeCard = Parameters<
+  typeof processGenericAwarenessModalBrazeCards
+>[0][number];
+
+const GENERIC_AWARENESS_LOCATION = "generic_awareness_modal";
+
+const DEFAULT_IMAGE_URL =
+  "https://images.unsplash.com/photo-1640161704729-cbe966a08476?auto=format&fit=crop&w=1200&q=80";
+
+const DEFAULT_APP_START_CAMPAIGN_IDS: Record<GenericAwarenessModalDebugLayout, string> = {
+  [GenericAwarenessModalLayout.Carousel]: "app_start_debug_generic_awareness_carousel",
+  [GenericAwarenessModalLayout.FeatureIntro]: "app_start_debug_generic_awareness_feature_intro",
+};
+
+const DEFAULT_DEEPLINK_CAMPAIGN_IDS: Record<GenericAwarenessModalDebugLayout, string> = {
+  [GenericAwarenessModalLayout.Carousel]: "debug_generic_awareness_carousel",
+  [GenericAwarenessModalLayout.FeatureIntro]: "debug_generic_awareness_feature_intro",
+};
+
+export function getDefaultGenericAwarenessModalCampaignId(
+  layout: GenericAwarenessModalDebugLayout,
+  trigger: GenericAwarenessModalDebugTrigger,
+): string {
+  return trigger === "appStart"
+    ? DEFAULT_APP_START_CAMPAIGN_IDS[layout]
+    : DEFAULT_DEEPLINK_CAMPAIGN_IDS[layout];
+}
+
+export function buildDefaultGenericAwarenessModalFormValues(): GenericAwarenessModalDebugFormValues {
+  const layout = GenericAwarenessModalLayout.Carousel;
+  const trigger: GenericAwarenessModalDebugTrigger = "appStart";
+
+  return {
+    layout,
+    trigger,
+    campaignId: getDefaultGenericAwarenessModalCampaignId(layout, trigger),
+    title: "Secure your crypto journey",
+    subtitle: "Discover how Ledger Wallet helps you stay in control.",
+    imageUrl: DEFAULT_IMAGE_URL,
+    primaryButtonLabel: "Continue",
+    primaryButtonLink: "ledgerlive://buy/bitcoin",
+    secondaryButtonLabel: "Maybe later",
+    secondaryButtonLink: "ledgerlive://myledger",
+    items: [
+      {
+        title: "Own your keys",
+        subtitle: "Your private keys stay protected by your Ledger device.",
+        imageUrl: DEFAULT_IMAGE_URL,
+        primaryButtonLabel: "Open My Ledger",
+        primaryButtonLink: "ledgerlive://myledger",
+        icon: "Shield",
+      },
+      {
+        title: "Explore safely",
+        subtitle: "Review every transaction before you sign.",
+        imageUrl: DEFAULT_IMAGE_URL,
+        primaryButtonLabel: "Receive Bitcoin",
+        primaryButtonLink: "ledgerlive://receive?currency=bitcoin",
+        icon: "Eye",
+      },
+      {
+        title: "Stay informed",
+        subtitle: "Get timely product and security updates.",
+        imageUrl: DEFAULT_IMAGE_URL,
+        primaryButtonLabel: "Open Discover",
+        primaryButtonLink: "ledgerlive://discover",
+        icon: "Bell",
+      },
+    ],
+  };
+}
+
+function buildCarouselBrazeCards({
+  campaignId,
+  items,
+}: GenericAwarenessModalDebugFormValues): GenericAwarenessModalDebugBrazeCard[] {
+  return items.map((item, index) => ({
+    id: `${campaignId}-${index}`,
+    extras: {
+      campaignId,
+      layout: GenericAwarenessModalLayout.Carousel,
+      location: GENERIC_AWARENESS_LOCATION,
+      index: String(index),
+      title: item.title,
+      subtitle: item.subtitle,
+      imageUrl: item.imageUrl,
+      primaryButtonLabel: item.primaryButtonLabel,
+      primaryButtonLink: item.primaryButtonLink,
+    },
+  }));
+}
+
+function buildFeatureIntroBrazeCards(
+  values: GenericAwarenessModalDebugFormValues,
+): GenericAwarenessModalDebugBrazeCard[] {
+  const mainCard: GenericAwarenessModalDebugBrazeCard = {
+    id: `${values.campaignId}-main`,
+    extras: {
+      campaignId: values.campaignId,
+      layout: GenericAwarenessModalLayout.FeatureIntro,
+      role: "main",
+      location: GENERIC_AWARENESS_LOCATION,
+      title: values.title,
+      subtitle: values.subtitle,
+      imageUrl: values.imageUrl,
+      primaryButtonLabel: values.primaryButtonLabel,
+      primaryButtonLink: values.primaryButtonLink,
+      secondaryButtonLabel: values.secondaryButtonLabel,
+      secondaryButtonLink: values.secondaryButtonLink,
+    },
+  };
+
+  const itemCards = values.items.map((item, index) => ({
+    id: `${values.campaignId}-item-${index}`,
+    extras: {
+      campaignId: values.campaignId,
+      layout: GenericAwarenessModalLayout.FeatureIntro,
+      role: "item",
+      location: GENERIC_AWARENESS_LOCATION,
+      index: String(index),
+      icon: item.icon,
+      title: item.title,
+      subtitle: item.subtitle,
+    },
+  }));
+
+  return [mainCard, ...itemCards];
+}
+
+export function buildLocalGenericAwarenessModalBrazeCards(
+  values: GenericAwarenessModalDebugFormValues,
+): GenericAwarenessModalDebugBrazeCard[] {
+  if (values.layout === GenericAwarenessModalLayout.Carousel) {
+    return buildCarouselBrazeCards(values);
+  }
+
+  return buildFeatureIntroBrazeCards(values);
+}
+
+export function buildLocalGenericAwarenessModalContentCards(
+  values: GenericAwarenessModalDebugFormValues,
+): GenericAwarenessModalMobileContentCard[] {
+  return processGenericAwarenessModalBrazeCards(
+    buildLocalGenericAwarenessModalBrazeCards(values),
+  ).map(card => ({
+    ...card,
+    isLocal: true,
+  }));
+}

--- a/apps/ledger-live-mobile/src/dynamicContent/useDynamicContentLogic.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/useDynamicContentLogic.ts
@@ -27,7 +27,7 @@ import { ContentCardLocation, ContentCardsType, BrazeContentCard } from "./types
 import { dismissedContentCardsSelector } from "~/reducers/settings";
 import { getOldCampaignIds } from "@ledgerhq/live-common/braze/anonymousUsers";
 import { clearDismissedContentCards } from "~/actions/settings";
-import { setGenericAwarenessModalContentCards } from "~/reducers/genericAwarenessModal";
+import { appendGenericAwarenessModalContentCards } from "~/reducers/genericAwarenessModal";
 
 export const useDynamicContentLogic = () => {
   const dispatch = useDispatch();
@@ -88,7 +88,7 @@ export const useDynamicContentLogic = () => {
     dispatch(setDynamicContentAssetsCards(assetCards));
     dispatch(setDynamicContentNotificationCards(notificationCards));
     dispatch(setDynamicContentLandingPageStickyCtaCards(landingPageStickyCtaCards));
-    dispatch(setGenericAwarenessModalContentCards(genericAwarenessModalContentCards));
+    dispatch(appendGenericAwarenessModalContentCards(genericAwarenessModalContentCards));
     dispatch(setIsDynamicContentLoading(false));
   }, [dismissedContentCardsIds, dispatch]);
 

--- a/apps/ledger-live-mobile/src/dynamicContent/utils.test.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/utils.test.tsx
@@ -1,5 +1,5 @@
 import type { ContentCard } from "@braze/react-native-sdk";
-import { mapAsCategoryContentCard } from "./utils";
+import { filterCardsThatHaveBeenDismissed, mapAsCategoryContentCard } from "./utils";
 
 const createCategoryCard = (extras: ContentCard["extras"]): ContentCard => ({
   id: "card-id",
@@ -42,5 +42,49 @@ describe("mapAsCategoryContentCard", () => {
 
     expect(category.location).toBe("my_ledger");
     expect(category.link).toBe("ledgerlive://discover/app?deeplinkLocation=my_ledger");
+  });
+});
+
+describe("filterCardsThatHaveBeenDismissed", () => {
+  it("should filter regular content cards by card id", () => {
+    const dismissedCard = createCategoryCard({
+      id: "regular-dismissed",
+      location: "wallet",
+    });
+    const visibleCard = {
+      ...createCategoryCard({
+        id: "regular-visible",
+        location: "wallet",
+      }),
+      id: "visible-card-id",
+    };
+
+    expect(filterCardsThatHaveBeenDismissed([dismissedCard, visibleCard], ["card-id"])).toEqual([
+      visibleCard,
+    ]);
+  });
+
+  it("should filter generic awareness modal raw cards by campaign id", () => {
+    const dismissedCampaignSlide = {
+      ...createCategoryCard({
+        campaignId: "dismissed-campaign",
+        location: "generic_awareness_modal",
+      }),
+      id: "dismissed-campaign-slide-1",
+    };
+    const visibleCampaignSlide = {
+      ...createCategoryCard({
+        campaignId: "visible-campaign",
+        location: "generic_awareness_modal",
+      }),
+      id: "visible-campaign-slide-1",
+    };
+
+    expect(
+      filterCardsThatHaveBeenDismissed(
+        [dismissedCampaignSlide, visibleCampaignSlide],
+        ["dismissed-campaign"],
+      ),
+    ).toEqual([visibleCampaignSlide]);
   });
 });

--- a/apps/ledger-live-mobile/src/dynamicContent/utils.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/utils.tsx
@@ -52,7 +52,14 @@ export const filterCardsThatHaveBeenDismissed = (
   cards: BrazeContentCard[],
   dismissedContentCardsIds: string[],
 ) => {
-  const filteredCards = cards.filter(card => !dismissedContentCardsIds.includes(card.id));
+  const filteredCards = cards.filter(card => {
+    const dismissedId =
+      card.extras.location === ContentCardLocation.GenericAwarenessModal
+        ? card.extras.campaignId
+        : card.id;
+
+    return !dismissedId || !dismissedContentCardsIds.includes(dismissedId);
+  });
 
   return filteredCards;
 };

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -3663,7 +3663,47 @@
         "addSampleWalletCarouselTag": "Add bottom wallet carousel (tag)",
         "addSampleWalletCarouselTagDesc": "One mock card with tag, title, image, link. No Braze.",
         "dismissAll": "Dismiss all local cards",
-        "dismissAllDesc": "Remove all locally generated content cards."
+        "dismissAllDesc": "Remove all locally generated content cards.",
+        "genericAwareness": {
+          "title": "Generic awareness modal",
+          "description": "Create raw Braze-like cards, process them through the generic awareness modal parser, then return to Portfolio to view the drawer.",
+          "carousel": "Carousel",
+          "featureIntro": "Feature intro",
+          "appStart": "App start",
+          "deeplink": "Deeplink",
+          "campaignId": "Campaign ID",
+          "titleField": "Title",
+          "subtitle": "Subtitle",
+          "imageUrl": "Image URL",
+          "primaryButtonLabel": "Primary button label",
+          "primaryButtonLink": "Primary button link",
+          "secondaryButtonLabel": "Secondary button label",
+          "secondaryButtonLink": "Secondary button link",
+          "icon": "Icon",
+          "slide": "Slide",
+          "item": "Item",
+          "addItem": "Add {{item}}",
+          "removeItem": "Remove",
+          "create": "Create generic awareness modal",
+          "createDesc": "Parse the form as raw Braze-like cards and add it to the existing modal list.",
+          "createCarousel": "Create Carousel Generic Awareness Modal",
+          "createCarouselDesc": "Open a form to create a carousel generic awareness modal.",
+          "createFeatureIntro": "Create Feature Intro Generic Awareness Modal",
+          "createFeatureIntroDesc": "Open a form to create a feature intro generic awareness modal.",
+          "openCurrent": "Open current campaign",
+          "openCurrentDesc": "Set the drawer state for this campaign. Return to Portfolio to view it.",
+          "clear": "Clear generic awareness modals",
+          "clearDesc": "Remove every generic awareness modal currently stored in app state.",
+          "existingTitle": "Existing generic awareness modals",
+          "existingDescription": "Tap a campaign to set it as the drawer to open, then return to Portfolio.",
+          "noExisting": "No generic awareness modal is currently stored in app state.",
+          "existingDesc": "{{layout}} • {{count}} entries",
+          "layoutLabel": "Layout",
+          "idLabel": "ID",
+          "triggerLabel": "Trigger",
+          "entriesLabel": "Entries ({{count}})",
+          "untitledEntry": "Untitled entry"
+        }
       }
     }
   },
@@ -4921,7 +4961,7 @@
               "title": "Pairing was refused",
               "cta": {
                 "retry": "Retry pairing"
-              } 
+              }
             },
             "blePairingPeerRemovedPairing": {
               "title": "Go to your phone’s Bluetooth settings to unpair {{productName}}",

--- a/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/components/CarouselSlideItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/components/CarouselSlideItem.tsx
@@ -27,7 +27,12 @@ export function CarouselSlideItem({
   onSubtitleTextLayout,
 }: CarouselSlideItemProps) {
   const titleMinHeight = titleLineCount > 1 ? "s80" : "s40";
-  const subtitleMinHeight = subtitleLineCount > 2 ? "s64" : subtitleLineCount > 1 ? "s40" : "s20";
+  let subtitleMinHeight: "s20" | "s40" | "s64" = "s20";
+  if (subtitleLineCount > 2) {
+    subtitleMinHeight = "s64";
+  } else if (subtitleLineCount > 1) {
+    subtitleMinHeight = "s40";
+  }
 
   return (
     <Box

--- a/apps/ledger-live-mobile/src/reducers/genericAwarenessModal.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/genericAwarenessModal.test.ts
@@ -1,0 +1,66 @@
+import { GenericAwarenessModalLayout } from "@ledgerhq/live-common/genericAwarenessModal";
+import type { GenericAwarenessModalContentCard } from "@ledgerhq/live-common/genericAwarenessModal";
+import reducer, {
+  appendGenericAwarenessModalContentCards,
+  clearLocalGenericAwarenessModalContentCards,
+  setGenericAwarenessModalContentCards,
+  type GenericAwarenessModalMobileContentCard,
+} from "./genericAwarenessModal";
+
+const buildCarouselCard = (id: string): GenericAwarenessModalContentCard => ({
+  id,
+  layout: GenericAwarenessModalLayout.Carousel,
+  data: [],
+});
+
+const buildLocalCarouselCard = (id: string): GenericAwarenessModalMobileContentCard => ({
+  ...buildCarouselCard(id),
+  isLocal: true,
+});
+
+describe("genericAwarenessModal reducer", () => {
+  it("should keep existing cards when Braze cards are refreshed", () => {
+    const initialState = reducer(
+      undefined,
+      setGenericAwarenessModalContentCards([buildCarouselCard("existing-card")]),
+    );
+
+    const nextState = reducer(
+      initialState,
+      appendGenericAwarenessModalContentCards([buildCarouselCard("new-braze-card")]),
+    );
+
+    expect(nextState.contentCards).toEqual([
+      buildCarouselCard("existing-card"),
+      buildCarouselCard("new-braze-card"),
+    ]);
+  });
+
+  it("should let refreshed Braze cards replace existing cards with the same id", () => {
+    const initialState = reducer(
+      undefined,
+      setGenericAwarenessModalContentCards([buildCarouselCard("same-id")]),
+    );
+
+    const nextState = reducer(
+      initialState,
+      appendGenericAwarenessModalContentCards([buildCarouselCard("same-id")]),
+    );
+
+    expect(nextState.contentCards).toEqual([buildCarouselCard("same-id")]);
+  });
+
+  it("should clear local content cards only", () => {
+    const initialState = reducer(
+      undefined,
+      setGenericAwarenessModalContentCards([
+        buildCarouselCard("braze-card"),
+        buildLocalCarouselCard("local-card"),
+      ]),
+    );
+
+    const nextState = reducer(initialState, clearLocalGenericAwarenessModalContentCards());
+
+    expect(nextState.contentCards).toEqual([buildCarouselCard("braze-card")]);
+  });
+});

--- a/apps/ledger-live-mobile/src/reducers/genericAwarenessModal.ts
+++ b/apps/ledger-live-mobile/src/reducers/genericAwarenessModal.ts
@@ -1,10 +1,14 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { type GenericAwarenessModalContentCard } from "@ledgerhq/live-common/genericAwarenessModal";
 
+export type GenericAwarenessModalMobileContentCard = GenericAwarenessModalContentCard & {
+  isLocal?: boolean;
+};
+
 export type GenericAwarenessModalState = {
   isOpen: boolean;
   campaignId: string | undefined;
-  contentCards: GenericAwarenessModalContentCard[];
+  contentCards: GenericAwarenessModalMobileContentCard[];
 };
 
 type OpenGenericAwarenessModalDrawerPayload = {
@@ -41,9 +45,21 @@ const genericAwarenessModalSlice = createSlice({
     },
     setGenericAwarenessModalContentCards: (
       state,
-      action: PayloadAction<GenericAwarenessModalContentCard[]>,
+      action: PayloadAction<GenericAwarenessModalMobileContentCard[]>,
     ) => {
       state.contentCards = action.payload;
+    },
+    clearLocalGenericAwarenessModalContentCards: state => {
+      state.contentCards = state.contentCards.filter(card => !card.isLocal);
+    },
+    appendGenericAwarenessModalContentCards: (
+      state,
+      action: PayloadAction<GenericAwarenessModalContentCard[]>,
+    ) => {
+      const brazeCardIds = new Set(action.payload.map(card => card.id));
+      const existingCards = state.contentCards.filter(card => !brazeCardIds.has(card.id));
+
+      state.contentCards = [...existingCards, ...action.payload];
     },
     markGenericAwarenessModalContentCardAsRead: (
       state,
@@ -66,6 +82,8 @@ export const {
   closeGenericAwarenessModalDrawer,
   setGenericAwarenessModalCampaignId,
   setGenericAwarenessModalContentCards,
+  clearLocalGenericAwarenessModalContentCards,
+  appendGenericAwarenessModalContentCards,
   markGenericAwarenessModalContentCardAsRead,
 } = genericAwarenessModalSlice.actions;
 

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/GenericAwarenessItemsList.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/GenericAwarenessItemsList.tsx
@@ -1,0 +1,226 @@
+import React, { useCallback, useRef } from "react";
+import { FlatList } from "react-native";
+import { Box, Button as LumenButton, IconButton, Text } from "@ledgerhq/lumen-ui-rnative";
+import { Close } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { useTranslation } from "~/context/Locale";
+import type { GenericAwarenessModalDebugItem } from "~/dynamicContent/buildLocalGenericAwarenessModalCards";
+import { GenericAwarenessModalField } from "./GenericAwarenessModalField";
+
+type GenericAwarenessItemsListProps = Readonly<{
+  items: GenericAwarenessModalDebugItem[];
+  itemLabel: string;
+  itemWidth: number;
+  isCarousel: boolean;
+  maxItems?: number;
+  onAddItem: () => void;
+  onRemoveItem: (index: number) => void;
+  onChangeItem: (index: number, values: Partial<GenericAwarenessModalDebugItem>) => void;
+}>;
+
+export function GenericAwarenessItemsList({
+  items,
+  itemLabel,
+  itemWidth,
+  isCarousel,
+  maxItems,
+  onAddItem,
+  onRemoveItem,
+  onChangeItem,
+}: GenericAwarenessItemsListProps) {
+  const listRef = useRef<FlatList<GenericAwarenessModalDebugItem | null>>(null);
+  const canAddItem = maxItems == null || items.length < maxItems;
+  const data = canAddItem ? [...items, null] : items;
+
+  const handleAddItem = useCallback(() => {
+    if (canAddItem) {
+      const nextIndex = items.length;
+      onAddItem();
+      requestAnimationFrame(() => {
+        listRef.current?.scrollToIndex({
+          index: nextIndex,
+          animated: true,
+        });
+      });
+    }
+  }, [canAddItem, items.length, onAddItem]);
+
+  return (
+    <FlatList
+      ref={listRef}
+      data={data}
+      horizontal
+      keyExtractor={(item, index) => (item ? `${itemLabel}-${index}` : `${itemLabel}-add`)}
+      keyboardShouldPersistTaps="handled"
+      showsHorizontalScrollIndicator={false}
+      snapToInterval={itemWidth + 16}
+      decelerationRate="fast"
+      getItemLayout={(_, index) => ({
+        length: itemWidth + 16,
+        offset: (itemWidth + 16) * index,
+        index,
+      })}
+      onScrollToIndexFailed={() => {
+        listRef.current?.scrollToEnd({ animated: true });
+      }}
+      renderItem={({ item, index }) =>
+        item ? (
+          <GenericAwarenessItemCard
+            item={item}
+            index={index}
+            itemLabel={itemLabel}
+            width={itemWidth}
+            isCarousel={isCarousel}
+            canRemove={items.length > 1}
+            onChange={onChangeItem}
+            onRemove={onRemoveItem}
+          />
+        ) : (
+          <GenericAwarenessAddItemCard
+            itemLabel={itemLabel}
+            width={itemWidth}
+            onPress={handleAddItem}
+          />
+        )
+      }
+    />
+  );
+}
+
+type GenericAwarenessAddItemCardProps = Readonly<{
+  itemLabel: string;
+  width: number;
+  onPress: () => void;
+}>;
+
+function GenericAwarenessAddItemCard({
+  itemLabel,
+  width,
+  onPress,
+}: GenericAwarenessAddItemCardProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Box
+      lx={{
+        borderWidth: "s1",
+        borderColor: "muted",
+        borderRadius: "sm",
+        padding: "s16",
+        marginRight: "s16",
+        marginBottom: "s16",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+      style={{ width }}
+    >
+      <LumenButton
+        appearance="base"
+        size="md"
+        onPress={onPress}
+        testID="debug-generic-awareness-add-item"
+      >
+        {t("settings.debug.contentCards.genericAwareness.addItem", {
+          item: itemLabel,
+        })}
+      </LumenButton>
+    </Box>
+  );
+}
+
+type GenericAwarenessItemCardProps = Readonly<{
+  item: GenericAwarenessModalDebugItem;
+  index: number;
+  itemLabel: string;
+  width: number;
+  isCarousel: boolean;
+  canRemove: boolean;
+  onChange: (index: number, values: Partial<GenericAwarenessModalDebugItem>) => void;
+  onRemove: (index: number) => void;
+}>;
+
+function GenericAwarenessItemCard({
+  item,
+  index,
+  itemLabel,
+  width,
+  isCarousel,
+  canRemove,
+  onChange,
+  onRemove,
+}: GenericAwarenessItemCardProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Box
+      lx={{
+        borderWidth: "s1",
+        borderColor: "muted",
+        borderRadius: "sm",
+        padding: "s16",
+        marginRight: "s16",
+        marginBottom: "s16",
+      }}
+      style={{ width }}
+    >
+      <Box
+        lx={{
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginBottom: "s12",
+        }}
+      >
+        <Text typography="body1SemiBold" lx={{ color: "base" }}>
+          {itemLabel} {index + 1}
+        </Text>
+        {canRemove ? (
+          <IconButton
+            appearance="no-background"
+            size="sm"
+            icon={Close}
+            onPress={() => onRemove(index)}
+            testID={`debug-generic-awareness-remove-item-${index}`}
+            accessibilityLabel="Remove item"
+          />
+        ) : null}
+      </Box>
+      <GenericAwarenessModalField
+        label={t("settings.debug.contentCards.genericAwareness.titleField")}
+        value={item.title}
+        onChangeText={value => onChange(index, { title: value })}
+      />
+      <GenericAwarenessModalField
+        label={t("settings.debug.contentCards.genericAwareness.subtitle")}
+        value={item.subtitle}
+        onChangeText={value => onChange(index, { subtitle: value })}
+        multiline
+      />
+      {isCarousel ? (
+        <>
+          <GenericAwarenessModalField
+            label={t("settings.debug.contentCards.genericAwareness.imageUrl")}
+            value={item.imageUrl ?? ""}
+            onChangeText={value => onChange(index, { imageUrl: value })}
+          />
+          <GenericAwarenessModalField
+            label={t("settings.debug.contentCards.genericAwareness.primaryButtonLabel")}
+            value={item.primaryButtonLabel ?? ""}
+            onChangeText={value => onChange(index, { primaryButtonLabel: value })}
+          />
+          <GenericAwarenessModalField
+            label={t("settings.debug.contentCards.genericAwareness.primaryButtonLink")}
+            value={item.primaryButtonLink ?? ""}
+            onChangeText={value => onChange(index, { primaryButtonLink: value })}
+          />
+        </>
+      ) : (
+        <GenericAwarenessModalField
+          label={t("settings.debug.contentCards.genericAwareness.icon")}
+          value={item.icon ?? ""}
+          onChangeText={value => onChange(index, { icon: value })}
+        />
+      )}
+    </Box>
+  );
+}
+

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/GenericAwarenessModalField.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/GenericAwarenessModalField.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { StyleSheet, TextInput } from "react-native";
+import { useTheme } from "@react-navigation/native";
+import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
+
+type GenericAwarenessModalFieldProps = Readonly<{
+  label: string;
+  value: string;
+  onChangeText: (value: string) => void;
+  multiline?: boolean;
+}>;
+
+export function GenericAwarenessModalField({
+  label,
+  value,
+  onChangeText,
+  multiline,
+}: GenericAwarenessModalFieldProps) {
+  const { colors } = useTheme();
+
+  return (
+    <Box lx={{ marginBottom: "s12" }}>
+      <Text typography="body2SemiBold" lx={{ color: "base", marginBottom: "s8" }}>
+        {label}
+      </Text>
+      <TextInput
+        value={value}
+        onChangeText={onChangeText}
+        autoCapitalize="none"
+        autoCorrect={false}
+        multiline={multiline}
+        style={[
+          styles.input,
+          multiline && styles.multilineInput,
+          {
+            backgroundColor: colors.card,
+            borderColor: colors.border,
+            color: colors.text,
+          },
+        ]}
+      />
+    </Box>
+  );
+}
+
+const styles = StyleSheet.create({
+  input: {
+    borderRadius: 8,
+    borderWidth: 1,
+    fontSize: 14,
+    minHeight: 44,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  multilineInput: {
+    minHeight: 76,
+    textAlignVertical: "top",
+  },
+});

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/GenericAwarenessModalFormSheet.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/GenericAwarenessModalFormSheet.tsx
@@ -1,0 +1,154 @@
+import React from "react";
+import { StyleSheet, useWindowDimensions } from "react-native";
+import { GenericAwarenessModalLayout } from "@ledgerhq/live-common/genericAwarenessModal";
+import {
+  BottomSheetHeader,
+  BottomSheetScrollView,
+  Box,
+  Button as LumenButton,
+} from "@ledgerhq/lumen-ui-rnative";
+import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
+import { useTranslation } from "~/context/Locale";
+import type {
+  GenericAwarenessModalDebugFormValues,
+  GenericAwarenessModalDebugItem,
+  GenericAwarenessModalDebugTrigger,
+} from "~/dynamicContent/buildLocalGenericAwarenessModalCards";
+import { GenericAwarenessItemsList } from "./GenericAwarenessItemsList";
+import { GenericAwarenessModalField } from "./GenericAwarenessModalField";
+import { GenericAwarenessTriggerSelector } from "./GenericAwarenessTriggerSelector";
+
+type GenericAwarenessModalFormSheetProps = Readonly<{
+  form: GenericAwarenessModalDebugFormValues;
+  isOpen: boolean;
+  maxFeatureIntroItems: number;
+  onClose: () => void;
+  onCreate: () => void;
+  onChangeField: <Key extends keyof GenericAwarenessModalDebugFormValues>(
+    key: Key,
+    value: GenericAwarenessModalDebugFormValues[Key],
+  ) => void;
+  onChangeTrigger: (trigger: GenericAwarenessModalDebugTrigger) => void;
+  onAddItem: () => void;
+  onRemoveItem: (index: number) => void;
+  onChangeItem: (index: number, values: Partial<GenericAwarenessModalDebugItem>) => void;
+}>;
+
+export function GenericAwarenessModalFormSheet({
+  form,
+  isOpen,
+  maxFeatureIntroItems,
+  onClose,
+  onCreate,
+  onChangeField,
+  onChangeTrigger,
+  onAddItem,
+  onRemoveItem,
+  onChangeItem,
+}: GenericAwarenessModalFormSheetProps) {
+  const { t } = useTranslation();
+  const { width } = useWindowDimensions();
+  const isCarousel = form.layout === GenericAwarenessModalLayout.Carousel;
+  const isFeatureIntro = form.layout === GenericAwarenessModalLayout.FeatureIntro;
+  const itemLabel = isCarousel
+    ? t("settings.debug.contentCards.genericAwareness.slide")
+    : t("settings.debug.contentCards.genericAwareness.item");
+  const itemWidth = Math.max(width - 72, 280);
+
+  return (
+    <QueuedDrawerBottomSheet
+      isRequestingToBeOpened={isOpen}
+      onClose={onClose}
+      snapPoints={["92%"]}
+      enablePanDownToClose
+    >
+      <BottomSheetHeader
+        title={
+          isCarousel
+            ? t("settings.debug.contentCards.genericAwareness.createCarousel")
+            : t("settings.debug.contentCards.genericAwareness.createFeatureIntro")
+        }
+        spacing
+        density="expanded"
+      />
+      <BottomSheetScrollView
+        contentContainerStyle={styles.drawerContent}
+        keyboardShouldPersistTaps="handled"
+      >
+        <GenericAwarenessTriggerSelector value={form.trigger} onChange={onChangeTrigger} />
+        <GenericAwarenessModalField
+          label={t("settings.debug.contentCards.genericAwareness.campaignId")}
+          value={form.campaignId}
+          onChangeText={value => onChangeField("campaignId", value)}
+        />
+        {isFeatureIntro ? (
+          <>
+            <GenericAwarenessModalField
+              label={t("settings.debug.contentCards.genericAwareness.titleField")}
+              value={form.title}
+              onChangeText={value => onChangeField("title", value)}
+            />
+            <GenericAwarenessModalField
+              label={t("settings.debug.contentCards.genericAwareness.subtitle")}
+              value={form.subtitle}
+              onChangeText={value => onChangeField("subtitle", value)}
+              multiline
+            />
+            <GenericAwarenessModalField
+              label={t("settings.debug.contentCards.genericAwareness.imageUrl")}
+              value={form.imageUrl}
+              onChangeText={value => onChangeField("imageUrl", value)}
+            />
+            <GenericAwarenessModalField
+              label={t("settings.debug.contentCards.genericAwareness.primaryButtonLabel")}
+              value={form.primaryButtonLabel}
+              onChangeText={value => onChangeField("primaryButtonLabel", value)}
+            />
+            <GenericAwarenessModalField
+              label={t("settings.debug.contentCards.genericAwareness.primaryButtonLink")}
+              value={form.primaryButtonLink}
+              onChangeText={value => onChangeField("primaryButtonLink", value)}
+            />
+            <GenericAwarenessModalField
+              label={t("settings.debug.contentCards.genericAwareness.secondaryButtonLabel")}
+              value={form.secondaryButtonLabel}
+              onChangeText={value => onChangeField("secondaryButtonLabel", value)}
+            />
+            <GenericAwarenessModalField
+              label={t("settings.debug.contentCards.genericAwareness.secondaryButtonLink")}
+              value={form.secondaryButtonLink}
+              onChangeText={value => onChangeField("secondaryButtonLink", value)}
+            />
+          </>
+        ) : null}
+        <GenericAwarenessItemsList
+          items={form.items}
+          itemLabel={itemLabel}
+          itemWidth={itemWidth}
+          isCarousel={isCarousel}
+          maxItems={isCarousel ? undefined : maxFeatureIntroItems}
+          onAddItem={onAddItem}
+          onRemoveItem={onRemoveItem}
+          onChangeItem={onChangeItem}
+        />
+        <Box lx={{ marginTop: "s16", marginBottom: "s24" }}>
+          <LumenButton
+            appearance="accent"
+            size="md"
+            onPress={onCreate}
+            testID="debug-generic-awareness-create"
+            isFull
+          >
+            {t("settings.debug.contentCards.genericAwareness.create")}
+          </LumenButton>
+        </Box>
+      </BottomSheetScrollView>
+    </QueuedDrawerBottomSheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  drawerContent: {
+    paddingBottom: 24,
+  },
+});

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/GenericAwarenessModalsSection.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/GenericAwarenessModalsSection.tsx
@@ -1,0 +1,148 @@
+import React, { useCallback } from "react";
+import Clipboard from "@react-native-clipboard/clipboard";
+import { GenericAwarenessModalLayout } from "@ledgerhq/live-common/genericAwarenessModal";
+import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
+import { Information, Screens, Trash } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { useToastsActions } from "~/actions/toast";
+import SettingsRow from "~/components/SettingsRow";
+import { useTranslation } from "~/context/Locale";
+import type { GenericAwarenessModalMobileContentCard } from "~/reducers/genericAwarenessModal";
+
+type GenericAwarenessModalsSectionProps = Readonly<{
+  cards: GenericAwarenessModalMobileContentCard[];
+  onOpenModal: (campaignId: string) => void;
+  onClearLocalCards: () => void;
+  onCreateCarousel: () => void;
+  onCreateFeatureIntro: () => void;
+}>;
+
+const getItemCount = (card: GenericAwarenessModalMobileContentCard) =>
+  card.layout === GenericAwarenessModalLayout.Carousel ? card.data.length : card.items.length;
+
+const getEntryTitles = (card: GenericAwarenessModalMobileContentCard) =>
+  card.layout === GenericAwarenessModalLayout.Carousel
+    ? card.data.map(slide => slide.title)
+    : [card.title, ...card.items.map(item => item.title)];
+
+const getTrigger = (card: GenericAwarenessModalMobileContentCard) =>
+  card.id.toLowerCase().startsWith("app_start") ? "appStart" : "deeplink";
+
+const getTriggerValue = (card: GenericAwarenessModalMobileContentCard) =>
+  getTrigger(card) === "appStart"
+    ? "appStart"
+    : `ledgerlive://generic-awareness-modal?id=${encodeURIComponent(card.id)}`;
+
+export function GenericAwarenessModalsSection({
+  cards,
+  onOpenModal,
+  onClearLocalCards,
+  onCreateCarousel,
+  onCreateFeatureIntro,
+}: GenericAwarenessModalsSectionProps) {
+  const { t } = useTranslation();
+  const { pushToast } = useToastsActions();
+
+  const copyTriggerLink = useCallback(
+    (card: GenericAwarenessModalMobileContentCard) => {
+      const triggerValue = getTriggerValue(card);
+
+      Clipboard.setString(triggerValue);
+      pushToast({
+        id: `generic-awareness-modal-trigger-${card.id}`,
+        type: "success",
+        icon: "success",
+        title: "Element copied",
+      });
+    },
+    [pushToast],
+  );
+
+  return (
+    <>
+      <Box lx={{ paddingHorizontal: "s24", paddingTop: "s24", paddingBottom: "s8" }}>
+        <Text typography="heading4SemiBold" lx={{ color: "base", marginBottom: "s8" }}>
+          {t("settings.debug.contentCards.genericAwareness.existingTitle")}
+        </Text>
+        <Text typography="body2" lx={{ color: "muted" }}>
+          {cards.length === 0
+            ? t("settings.debug.contentCards.genericAwareness.noExisting")
+            : t("settings.debug.contentCards.genericAwareness.existingDescription")}
+        </Text>
+      </Box>
+      {cards.map(card => (
+        <SettingsRow
+          key={card.id}
+          title={card.id}
+          desc={
+            <Box lx={{ marginTop: "s4" }}>
+              <Text typography="body2SemiBold" lx={{ color: "muted" }}>
+                {t("settings.debug.contentCards.genericAwareness.layoutLabel")}: {card.layout}
+              </Text>
+              <Text typography="body2SemiBold" lx={{ color: "muted" }}>
+                {t("settings.debug.contentCards.genericAwareness.idLabel")}: {card.id}
+              </Text>
+              <Text typography="body2SemiBold" lx={{ color: "muted" }}>
+                {t("settings.debug.contentCards.genericAwareness.triggerLabel")}:{" "}
+                {getTrigger(card) === "appStart"
+                  ? t("settings.debug.contentCards.genericAwareness.appStart")
+                  : null}
+              </Text>
+              {getTrigger(card) === "deeplink" ? (
+                <Text
+                  typography="body2SemiBold"
+                  lx={{ color: "base" }}
+                  onPress={() => copyTriggerLink(card)}
+                >
+                  {getTriggerValue(card)}
+                </Text>
+              ) : null}
+              <Text typography="body2SemiBold" lx={{ color: "base", marginTop: "s8" }}>
+                {t("settings.debug.contentCards.genericAwareness.entriesLabel", {
+                  count: getItemCount(card),
+                })}
+              </Text>
+              {getEntryTitles(card).map((title, index) => (
+                <Text
+                  key={`${card.id}-${index}-${title}`}
+                  typography="body2SemiBold"
+                  lx={{ color: "muted" }}
+                >
+                  {index + 1}.{" "}
+                  {title || t("settings.debug.contentCards.genericAwareness.untitledEntry")}
+                </Text>
+              ))}
+            </Box>
+          }
+          noTextDesc
+          iconLeft={<Information size={24} color="base" />}
+          onPress={() => onOpenModal(card.id)}
+          testID={`debug-generic-awareness-existing-${card.id}`}
+        />
+      ))}
+      {cards.length > 0 ? (
+        <SettingsRow
+          title={t("settings.debug.contentCards.genericAwareness.clear")}
+          desc={t("settings.debug.contentCards.genericAwareness.clearDesc")}
+          iconLeft={<Trash size={24} color="base" />}
+          onPress={onClearLocalCards}
+          testID="debug-generic-awareness-clear"
+        />
+      ) : null}
+      <SettingsRow
+        hasBorderTop
+        title={t("settings.debug.contentCards.genericAwareness.createCarousel")}
+        desc={t("settings.debug.contentCards.genericAwareness.createCarouselDesc")}
+        iconLeft={<Screens size={24} color="base" />}
+        onPress={onCreateCarousel}
+        testID="debug-generic-awareness-create-carousel"
+      />
+      <SettingsRow
+        title={t("settings.debug.contentCards.genericAwareness.createFeatureIntro")}
+        desc={t("settings.debug.contentCards.genericAwareness.createFeatureIntroDesc")}
+        iconLeft={<Information size={24} color="base" />}
+        onPress={onCreateFeatureIntro}
+        testID="debug-generic-awareness-create-feature-intro"
+      />
+    </>
+  );
+}

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/GenericAwarenessTriggerSelector.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/GenericAwarenessTriggerSelector.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { Box, Button as LumenButton } from "@ledgerhq/lumen-ui-rnative";
+import { useTranslation } from "~/context/Locale";
+import type { GenericAwarenessModalDebugTrigger } from "~/dynamicContent/buildLocalGenericAwarenessModalCards";
+
+type GenericAwarenessTriggerSelectorProps = Readonly<{
+  value: GenericAwarenessModalDebugTrigger;
+  onChange: (trigger: GenericAwarenessModalDebugTrigger) => void;
+}>;
+
+export function GenericAwarenessTriggerSelector({
+  value,
+  onChange,
+}: GenericAwarenessTriggerSelectorProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Box lx={{ flexDirection: "row", marginBottom: "s16" }}>
+      <Box lx={{ flex: 1, marginRight: "s8" }}>
+        <LumenButton
+          appearance={value === "appStart" ? "accent" : "base"}
+          size="md"
+          onPress={() => onChange("appStart")}
+          testID="debug-generic-awareness-trigger-app-start"
+          isFull
+        >
+          {t("settings.debug.contentCards.genericAwareness.appStart")}
+        </LumenButton>
+      </Box>
+      <Box lx={{ flex: 1, marginLeft: "s8" }}>
+        <LumenButton
+          appearance={value === "deeplink" ? "accent" : "base"}
+          size="md"
+          onPress={() => onChange("deeplink")}
+          testID="debug-generic-awareness-trigger-deeplink"
+          isFull
+        >
+          {t("settings.debug.contentCards.genericAwareness.deeplink")}
+        </LumenButton>
+      </Box>
+    </Box>
+  );
+}

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/index.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/index.test.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { GenericAwarenessModalLayout } from "@ledgerhq/live-common/genericAwarenessModal";
+import { render, screen } from "@tests/test-renderer";
+import { SafeAreaProvider } from "react-native-safe-area-context";
+import type { State } from "~/reducers/types";
+import DebugContentCards from ".";
+
+const Stack = createNativeStackNavigator();
+
+function DebugContentCardsTestScreen() {
+  return (
+    <SafeAreaProvider
+      initialMetrics={{
+        frame: { x: 0, y: 0, width: 375, height: 812 },
+        insets: { top: 0, left: 0, right: 0, bottom: 0 },
+      }}
+    >
+      <Stack.Navigator screenOptions={{ headerShown: false }}>
+        <Stack.Screen name="DebugContentCards" component={DebugContentCards} />
+      </Stack.Navigator>
+    </SafeAreaProvider>
+  );
+}
+
+const withExistingBrazeCard = (state: State): State => ({
+  ...state,
+  genericAwarenessModal: {
+    ...state.genericAwarenessModal,
+    contentCards: [
+      {
+        id: "braze-card",
+        layout: GenericAwarenessModalLayout.Carousel,
+        data: [],
+      },
+    ],
+  },
+});
+
+describe("DebugContentCards", () => {
+  it("should create, list, and open generic awareness modal cards", async () => {
+    const { store, user } = render(<DebugContentCardsTestScreen />, {
+      overrideInitialState: withExistingBrazeCard,
+    });
+
+    expect(screen.getByText("Existing generic awareness modals")).toBeOnTheScreen();
+    expect(screen.getByText("braze-card")).toBeOnTheScreen();
+
+    await user.press(screen.getAllByText("Create Carousel Generic Awareness Modal")[0]);
+    await user.press(screen.getByText("Create generic awareness modal"));
+
+    const stateAfterCreate = store.getState();
+    expect(stateAfterCreate.genericAwarenessModal.contentCards).toHaveLength(2);
+    expect(stateAfterCreate.genericAwarenessModal.contentCards[0].id).toBe("braze-card");
+    const campaignId = stateAfterCreate.genericAwarenessModal.contentCards[1].id;
+    expect(campaignId).toBe("app_start_debug_generic_awareness_carousel");
+
+    expect(screen.getByText(campaignId)).toBeOnTheScreen();
+    await user.press(screen.getByText(campaignId));
+
+    expect(store.getState().genericAwarenessModal).toMatchObject({
+      isOpen: true,
+      campaignId,
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/index.tsx
@@ -1,6 +1,8 @@
-import React, { useCallback, useRef } from "react";
+import React, { useCallback, useRef, useState } from "react";
 import { useTranslation } from "~/context/Locale";
-import { Alert, Flex, IconsLegacy } from "@ledgerhq/native-ui";
+import { Banner, Box } from "@ledgerhq/lumen-ui-rnative";
+import { Information, Screens, Trash, Wallet } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { GenericAwarenessModalLayout } from "@ledgerhq/live-common/genericAwarenessModal";
 import { useDispatch, useSelector } from "~/context/hooks";
 import SettingsNavigationScrollView from "../../SettingsNavigationScrollView";
 import SettingsRow from "~/components/SettingsRow";
@@ -18,17 +20,51 @@ import {
   buildSampleWalletCarouselTag,
   type SampleActionBannerVariant,
 } from "~/dynamicContent/buildLocalContentCards";
+import {
+  buildDefaultGenericAwarenessModalFormValues,
+  buildLocalGenericAwarenessModalContentCards,
+  getDefaultGenericAwarenessModalCampaignId,
+  type GenericAwarenessModalDebugFormValues,
+  type GenericAwarenessModalDebugItem,
+  type GenericAwarenessModalDebugLayout,
+  type GenericAwarenessModalDebugTrigger,
+} from "~/dynamicContent/buildLocalGenericAwarenessModalCards";
 import { localCategoriesCardsSelector } from "~/reducers/dynamicContent";
+import {
+  appendGenericAwarenessModalContentCards,
+  clearLocalGenericAwarenessModalContentCards,
+  closeGenericAwarenessModalDrawer,
+  openGenericAwarenessModalDrawer,
+  selectGenericAwarenessModalContentCards,
+} from "~/reducers/genericAwarenessModal";
+import { GenericAwarenessModalFormSheet } from "./GenericAwarenessModalFormSheet";
+import { GenericAwarenessModalsSection } from "./GenericAwarenessModalsSection";
 
 type ActionCarouselSession = {
   categoryId: string;
   nextIndex: number;
 };
 
+const FEATURE_INTRO_MAX_ITEMS = 3;
+
+const buildDefaultItem = (index: number): GenericAwarenessModalDebugItem => ({
+  title: `Step ${index + 1}`,
+  subtitle: "Describe this step for QA.",
+  imageUrl:
+    "https://images.unsplash.com/photo-1640161704729-cbe966a08476?auto=format&fit=crop&w=1200&q=80",
+  primaryButtonLabel: "Continue",
+  primaryButtonLink: "ledgerlive://earn",
+  icon: "Info",
+});
+
 export default function DebugContentCards() {
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const localCategories = useSelector(localCategoriesCardsSelector);
+  const genericAwarenessModalContentCards = useSelector(selectGenericAwarenessModalContentCards);
+  const [genericAwarenessForm, setGenericAwarenessForm] =
+    useState<GenericAwarenessModalDebugFormValues>(buildDefaultGenericAwarenessModalFormValues);
+  const [isGenericAwarenessFormOpen, setIsGenericAwarenessFormOpen] = useState(false);
 
   /** Single shared top_wallet action carousel: icon + image_background taps append to the same row. */
   const actionCarouselSessionRef = useRef<ActionCarouselSession | null>(null);
@@ -43,8 +79,7 @@ export default function DebugContentCards() {
       let session = actionCarouselSessionRef.current;
       const sessionCategoryId = session?.categoryId;
       const categoryStillExists =
-        sessionCategoryId != null &&
-        localCategories.some(c => c.categoryId === sessionCategoryId);
+        sessionCategoryId != null && localCategories.some(c => c.categoryId === sessionCategoryId);
 
       if (!categoryStillExists) {
         actionCarouselSessionRef.current = null;
@@ -94,48 +129,162 @@ export default function DebugContentCards() {
     dispatch(clearLocalContentCards());
   }, [dispatch]);
 
+  const updateGenericAwarenessForm = useCallback(
+    <Key extends keyof GenericAwarenessModalDebugFormValues>(
+      key: Key,
+      value: GenericAwarenessModalDebugFormValues[Key],
+    ) => {
+      setGenericAwarenessForm(current => ({
+        ...current,
+        [key]: value,
+      }));
+    },
+    [],
+  );
+
+  const updateGenericAwarenessTrigger = useCallback(
+    (trigger: GenericAwarenessModalDebugTrigger) => {
+      setGenericAwarenessForm(current => ({
+        ...current,
+        trigger,
+        campaignId: getDefaultGenericAwarenessModalCampaignId(current.layout, trigger),
+      }));
+    },
+    [],
+  );
+
+  const updateGenericAwarenessItem = useCallback(
+    (index: number, values: Partial<GenericAwarenessModalDebugItem>) => {
+      setGenericAwarenessForm(current => ({
+        ...current,
+        items: current.items.map((item, itemIndex) =>
+          itemIndex === index ? { ...item, ...values } : item,
+        ),
+      }));
+    },
+    [],
+  );
+
+  const addGenericAwarenessItem = useCallback(() => {
+    setGenericAwarenessForm(current => ({
+      ...current,
+      items: [...current.items, buildDefaultItem(current.items.length)],
+    }));
+  }, []);
+
+  const removeGenericAwarenessItem = useCallback((index: number) => {
+    setGenericAwarenessForm(current => {
+      if (current.items.length <= 1) {
+        return current;
+      }
+
+      return {
+        ...current,
+        items: current.items.filter((_, itemIndex) => itemIndex !== index),
+      };
+    });
+  }, []);
+
+  const openGenericAwarenessModal = useCallback(
+    (campaignId: string) => {
+      dispatch(openGenericAwarenessModalDrawer({ campaignId }));
+    },
+    [dispatch],
+  );
+
+  const onCreateGenericAwarenessModal = useCallback(() => {
+    const nextCards = buildLocalGenericAwarenessModalContentCards(genericAwarenessForm);
+    dispatch(appendGenericAwarenessModalContentCards(nextCards));
+    setIsGenericAwarenessFormOpen(false);
+  }, [dispatch, genericAwarenessForm]);
+
+  const onClearGenericAwarenessModals = useCallback(() => {
+    dispatch(clearLocalGenericAwarenessModalContentCards());
+    dispatch(closeGenericAwarenessModalDrawer());
+  }, [dispatch]);
+
+  const openGenericAwarenessForm = useCallback((layout: GenericAwarenessModalDebugLayout) => {
+    setGenericAwarenessForm(current => ({
+      ...current,
+      layout,
+      campaignId: getDefaultGenericAwarenessModalCampaignId(layout, current.trigger),
+      items:
+        layout === GenericAwarenessModalLayout.FeatureIntro
+          ? current.items.slice(0, FEATURE_INTRO_MAX_ITEMS)
+          : current.items,
+    }));
+    setIsGenericAwarenessFormOpen(true);
+  }, []);
+
+  const closeGenericAwarenessForm = useCallback(() => {
+    setIsGenericAwarenessFormOpen(false);
+  }, []);
+
   return (
-    <SettingsNavigationScrollView>
-      <Flex p={6} pt={0}>
-        <Alert type="info" title={t("settings.debug.contentCards.description")} />
-      </Flex>
-      <SettingsRow
-        hasBorderTop
-        title={t("settings.debug.contentCards.addSampleBanner")}
-        desc={t("settings.debug.contentCards.addSampleBannerDesc")}
-        iconLeft={<IconsLegacy.GraphGrowMedium size={24} color="black" />}
-        onPress={onAddSampleBanner}
+    <>
+      <SettingsNavigationScrollView>
+        <Box lx={{ paddingHorizontal: "s24", paddingBottom: "s24" }}>
+          <Banner title={t("settings.debug.contentCards.description")} />
+        </Box>
+        <SettingsRow
+          hasBorderTop
+          title={t("settings.debug.contentCards.addSampleBanner")}
+          desc={t("settings.debug.contentCards.addSampleBannerDesc")}
+          iconLeft={<Information size={24} color="base" />}
+          onPress={onAddSampleBanner}
+        />
+        <SettingsRow
+          title={t("settings.debug.contentCards.addSampleActionCarouselIcon")}
+          desc={t("settings.debug.contentCards.addSampleActionCarouselIconDesc")}
+          iconLeft={<Screens size={24} color="base" />}
+          onPress={onAddSampleActionCarouselIcon}
+        />
+        <SettingsRow
+          title={t("settings.debug.contentCards.addSampleActionCarouselImageBackground")}
+          desc={t("settings.debug.contentCards.addSampleActionCarouselImageBackgroundDesc")}
+          iconLeft={<Screens size={24} color="base" />}
+          onPress={onAddSampleActionCarouselImageBackground}
+        />
+        <SettingsRow
+          title={t("settings.debug.contentCards.addSampleWalletCarouselPicto")}
+          desc={t("settings.debug.contentCards.addSampleWalletCarouselPictoDesc")}
+          iconLeft={<Wallet size={24} color="base" />}
+          onPress={onAddSampleWalletCarouselPicto}
+        />
+        <SettingsRow
+          title={t("settings.debug.contentCards.addSampleWalletCarouselTag")}
+          desc={t("settings.debug.contentCards.addSampleWalletCarouselTagDesc")}
+          iconLeft={<Wallet size={24} color="base" />}
+          onPress={onAddSampleWalletCarouselTag}
+        />
+        <SettingsRow
+          title={t("settings.debug.contentCards.dismissAll")}
+          desc={t("settings.debug.contentCards.dismissAllDesc")}
+          iconLeft={<Trash size={24} color="base" />}
+          onPress={onDismissAll}
+        />
+        <GenericAwarenessModalsSection
+          cards={genericAwarenessModalContentCards}
+          onOpenModal={openGenericAwarenessModal}
+          onClearLocalCards={onClearGenericAwarenessModals}
+          onCreateCarousel={() => openGenericAwarenessForm(GenericAwarenessModalLayout.Carousel)}
+          onCreateFeatureIntro={() =>
+            openGenericAwarenessForm(GenericAwarenessModalLayout.FeatureIntro)
+          }
+        />
+      </SettingsNavigationScrollView>
+      <GenericAwarenessModalFormSheet
+        form={genericAwarenessForm}
+        isOpen={isGenericAwarenessFormOpen}
+        maxFeatureIntroItems={FEATURE_INTRO_MAX_ITEMS}
+        onClose={closeGenericAwarenessForm}
+        onCreate={onCreateGenericAwarenessModal}
+        onChangeField={updateGenericAwarenessForm}
+        onChangeTrigger={updateGenericAwarenessTrigger}
+        onAddItem={addGenericAwarenessItem}
+        onRemoveItem={removeGenericAwarenessItem}
+        onChangeItem={updateGenericAwarenessItem}
       />
-      <SettingsRow
-        title={t("settings.debug.contentCards.addSampleActionCarouselIcon")}
-        desc={t("settings.debug.contentCards.addSampleActionCarouselIconDesc")}
-        iconLeft={<IconsLegacy.BoxMedium size={24} color="black" />}
-        onPress={onAddSampleActionCarouselIcon}
-      />
-      <SettingsRow
-        title={t("settings.debug.contentCards.addSampleActionCarouselImageBackground")}
-        desc={t("settings.debug.contentCards.addSampleActionCarouselImageBackgroundDesc")}
-        iconLeft={<IconsLegacy.LayersMedium size={24} color="black" />}
-        onPress={onAddSampleActionCarouselImageBackground}
-      />
-      <SettingsRow
-        title={t("settings.debug.contentCards.addSampleWalletCarouselPicto")}
-        desc={t("settings.debug.contentCards.addSampleWalletCarouselPictoDesc")}
-        iconLeft={<IconsLegacy.WalletMedium size={24} color="black" />}
-        onPress={onAddSampleWalletCarouselPicto}
-      />
-      <SettingsRow
-        title={t("settings.debug.contentCards.addSampleWalletCarouselTag")}
-        desc={t("settings.debug.contentCards.addSampleWalletCarouselTagDesc")}
-        iconLeft={<IconsLegacy.WalletMedium size={24} color="black" />}
-        onPress={onAddSampleWalletCarouselTag}
-      />
-      <SettingsRow
-        title={t("settings.debug.contentCards.dismissAll")}
-        desc={t("settings.debug.contentCards.dismissAllDesc")}
-        iconLeft={<IconsLegacy.TrashMedium size={24} color="black" />}
-        onPress={onDismissAll}
-      />
-    </SettingsNavigationScrollView>
+    </>
   );
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Mobile Settings > Debug > Content Cards generic awareness modal QA panel
  - Generic awareness modal app-start and deeplink campaign handling
  - Braze refresh merging with locally generated QA cards
  - Feature intro and carousel modal rendering from raw Braze-like cards

### 📝 Description

This PR adds mobile debug tooling so PMs and QA can create and validate generic awareness modal content cards directly from the Content Cards debug screen.

The implementation builds raw Braze-like cards, parses them through the same generic awareness modal parser used by dynamic content, and lets QA generate carousel or feature-intro layouts with editable fields. Locally generated cards are kept alongside fetched Braze cards, can be cleared independently, and generated trigger links can be copied from the existing modal list.

| Carousel | Feature Intro |
| ------ | ----- |
|<video src="https://github.com/user-attachments/assets/f0db6be5-76f2-4e80-8743-db755a410585"/> | <video src="https://github.com/user-attachments/assets/ad6ddfb9-d902-4eb0-a35d-9570d8740928"/> |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29420](https://ledgerhq.atlassian.net/browse/LIVE-29420)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-29420]: https://ledgerhq.atlassian.net/browse/LIVE-29420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ