### PR TITLE
[LWDM] fix: evm staking delegation when using full balance

### DIFF
--- a/.changeset/beige-pens-yawn.md
+++ b/.changeset/beige-pens-yawn.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-evm": minor
+"@ledgerhq/live-common": minor
+---
+
+Fix: evm staking delegation when using full balance
+

--- a/libs/coin-modules/coin-evm/src/logic/common.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/common.test.ts
@@ -2,7 +2,13 @@
 
 import { MemoNotSupported } from "@ledgerhq/coin-module-framework/api/index";
 import { TransactionIntent, BufferTxData } from "@ledgerhq/coin-module-framework/api/types";
-import { getCallData } from "./common";
+import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { BigNumber } from "bignumber.js";
+import { getNodeApi } from "../network/node";
+import { mockNodeApi } from "../network/node/node.fixtures";
+import { buildStakingTransactionParams } from "../staking";
+import { USEI_TO_EVM_SCALE } from "../utils";
+import { getCallData, prepareUnsignedTxParams } from "./common";
 import * as getErc20DataModule from "./getErc20Data";
 
 jest.mock("./getErc20Data", () => {
@@ -13,6 +19,19 @@ jest.mock("./getErc20Data", () => {
     ),
   };
 });
+
+jest.mock("../network/node", () => ({
+  ...jest.requireActual("../network/node"),
+  getNodeApi: jest.fn(),
+}));
+
+jest.mock("../staking", () => ({
+  ...jest.requireActual("../staking"),
+  buildStakingTransactionParams: jest.fn(),
+}));
+
+const mockGetNodeApi = jest.mocked(getNodeApi);
+const mockBuildStakingTransactionParams = jest.mocked(buildStakingTransactionParams);
 
 const getErc20DataMock = getErc20DataModule.getErc20Data as jest.Mock;
 
@@ -120,6 +139,145 @@ describe("common", () => {
       expect(getErc20DataMock).toHaveBeenCalledTimes(1);
       expect(getErc20DataMock).toHaveBeenCalledWith(recipient, amount);
       expect(result).toEqual(expectedResult);
+    });
+  });
+
+  describe("prepareUnsignedTxParams — staking gas estimation retry", () => {
+    const mockCurrency = {
+      id: "sei_evm",
+      family: "evm",
+      ethereumLikeInfo: { chainId: 1329 },
+    } as CryptoCurrency;
+
+    const stakingContractAddress = "0x0000000000000000000000000000000000001005";
+    const stakingData = Buffer.from("encoded-delegate-calldata");
+    const GAS_ESTIMATION_ERROR = new Error(
+      'execution reverted (action="estimateGas", data="0x", reason="require(false)")',
+    );
+
+    const makeStakingIntent = (amount: bigint) =>
+      ({
+        intentType: "staking",
+        type: "staking-legacy",
+        mode: "delegate",
+        amount,
+        asset: { type: "native" },
+        recipient: stakingContractAddress,
+        sender: "0xSender",
+        valAddress: "seivaloper1y82m5y3wevjneamzg0pmx87dzanyxzht0kepvn",
+        feesStrategy: "medium",
+        data: { type: "buffer", value: Buffer.from([]) },
+      }) as unknown as TransactionIntent<MemoNotSupported, BufferTxData>;
+
+    const nodeApiMock = mockNodeApi();
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockGetNodeApi.mockReturnValue(nodeApiMock);
+    });
+
+    it("retries with the chain calldataAmountScale (USEI_TO_EVM_SCALE for SEI) when initial gas estimation fails for a payable staking call (value > 0)", async () => {
+      const spendableBalance = 1_000_000_000_000_000_000n; // 1 SEI
+
+      mockBuildStakingTransactionParams.mockReturnValue({
+        to: stakingContractAddress,
+        data: stakingData,
+        value: spendableBalance, // payable: amount goes into msg.value
+      });
+
+      // First call (full balance) fails, retry (1 usei) succeeds
+      nodeApiMock.getGasEstimation
+        .mockRejectedValueOnce(GAS_ESTIMATION_ERROR)
+        .mockResolvedValueOnce(new BigNumber(70_000));
+
+      const result = await prepareUnsignedTxParams(
+        mockCurrency,
+        makeStakingIntent(spendableBalance),
+      );
+
+      expect(nodeApiMock.getGasEstimation).toHaveBeenCalledTimes(2);
+      // First call used the full balance
+      expect(nodeApiMock.getGasEstimation).toHaveBeenNthCalledWith(
+        1,
+        { currency: mockCurrency, freshAddress: "0xSender" },
+        {
+          amount: new BigNumber(spendableBalance.toString()),
+          recipient: stakingContractAddress,
+          data: stakingData,
+        },
+      );
+      // Retry used the minimum calldata unit for the chain (calldataAmountScale)
+      expect(nodeApiMock.getGasEstimation).toHaveBeenNthCalledWith(
+        2,
+        { currency: mockCurrency, freshAddress: "0xSender" },
+        {
+          amount: new BigNumber(USEI_TO_EVM_SCALE.toString()),
+          recipient: stakingContractAddress,
+          data: stakingData,
+        },
+      );
+      expect(result.gasLimit).toEqual(new BigNumber(70_000));
+    });
+
+    it("retries with the chain calldataAmountScale (USEI_TO_EVM_SCALE for SEI) when initial gas estimation fails for a staking call with amount=0 (delegation form freshly opened)", async () => {
+      mockBuildStakingTransactionParams.mockReturnValue({
+        to: stakingContractAddress,
+        data: stakingData,
+        value: 0n, // amount=0 → 0 usei → precompile rejects
+      });
+
+      nodeApiMock.getGasEstimation
+        .mockRejectedValueOnce(GAS_ESTIMATION_ERROR)
+        .mockResolvedValueOnce(new BigNumber(70_000));
+
+      const result = await prepareUnsignedTxParams(mockCurrency, makeStakingIntent(0n));
+
+      expect(nodeApiMock.getGasEstimation).toHaveBeenCalledTimes(2);
+      expect(nodeApiMock.getGasEstimation).toHaveBeenNthCalledWith(
+        2,
+        { currency: mockCurrency, freshAddress: "0xSender" },
+        {
+          amount: new BigNumber(USEI_TO_EVM_SCALE.toString()),
+          recipient: stakingContractAddress,
+          data: stakingData,
+        },
+      );
+      expect(result.gasLimit).toEqual(new BigNumber(70_000));
+    });
+
+    it("falls back to gasLimit=0 when both the initial and retry gas estimation fail for a staking call", async () => {
+      mockBuildStakingTransactionParams.mockReturnValue({
+        to: stakingContractAddress,
+        data: stakingData,
+        value: 0n,
+      });
+
+      nodeApiMock.getGasEstimation.mockRejectedValue(GAS_ESTIMATION_ERROR);
+
+      const result = await prepareUnsignedTxParams(mockCurrency, makeStakingIntent(0n));
+
+      expect(nodeApiMock.getGasEstimation).toHaveBeenCalledTimes(2);
+      expect(result.gasLimit).toEqual(new BigNumber(0));
+    });
+
+    it("does not retry for send transactions — falls back to gasLimit=0 on first failure without a second call", async () => {
+      const sendIntent = {
+        intentType: "transaction",
+        type: "send-legacy",
+        amount: 1n,
+        asset: { type: "native" },
+        recipient: "0x7b2C7232f9E38F30E2868f0E5Bf311Cd83554b5A",
+        sender: "0xSender",
+        feesStrategy: "medium",
+        data: { type: "buffer", value: Buffer.from([]) },
+      } as unknown as TransactionIntent<MemoNotSupported, BufferTxData>;
+
+      nodeApiMock.getGasEstimation.mockRejectedValueOnce(GAS_ESTIMATION_ERROR);
+
+      const result = await prepareUnsignedTxParams(mockCurrency, sendIntent);
+
+      expect(nodeApiMock.getGasEstimation).toHaveBeenCalledTimes(1);
+      expect(result.gasLimit).toEqual(new BigNumber(0));
     });
   });
 });

--- a/libs/coin-modules/coin-evm/src/logic/common.ts
+++ b/libs/coin-modules/coin-evm/src/logic/common.ts
@@ -4,12 +4,15 @@ import type {
   MemoNotSupported,
   TransactionIntent,
 } from "@ledgerhq/coin-module-framework/api/index";
-import { isSendTransactionIntent } from "@ledgerhq/coin-module-framework/utils";
+import {
+  isSendTransactionIntent,
+  isStakingTransactionIntent,
+} from "@ledgerhq/coin-module-framework/utils";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import BigNumber from "bignumber.js";
 import { ethers } from "ethers";
 import { getNodeApi } from "../network/node";
-import { buildStakingTransactionParams } from "../staking";
+import { buildStakingTransactionParams, STAKING_CONTRACTS } from "../staking";
 import {
   ApiFeeData,
   ApiGasOptions,
@@ -131,8 +134,23 @@ export async function prepareUnsignedTxParams(
             { currency, freshAddress: sender },
             { amount: BigNumber(value.toString()), recipient: to, data },
           )
-          .catch(() => new BigNumber(0));
-
+          .catch(async () => {
+            if (isStakingTransactionIntent(transactionIntent)) {
+              // Staking precompiles may reject the initial amount (e.g. 0 or rounded value).
+              // Retry with the minimum meaningful calldata unit for this chain so the node
+              // can at least estimate the gas overhead of the contract call itself.
+              const minUnit = STAKING_CONTRACTS[currency.id]?.calldataAmountScale ?? 1n;
+              return node
+                .getGasEstimation(
+                  { currency, freshAddress: sender },
+                  { amount: new BigNumber(minUnit.toString()), recipient: to, data },
+                )
+                .catch(() => {
+                  return new BigNumber(0);
+                });
+            }
+            return new BigNumber(0);
+          });
   return {
     type: transactionType,
     to,

--- a/libs/coin-modules/coin-evm/src/logic/validateIntent.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/validateIntent.test.ts
@@ -601,6 +601,78 @@ describe("validateIntent", () => {
 
       expect(res.errors).toMatchObject({});
     });
+
+    describe("useAllAmount on delegate", () => {
+      // sei_evm has delegationMaxAmountReserve = 10n**17n and calldataAmountScale = 10n**12n.
+      const seiCurrency = {
+        id: "sei_evm",
+        name: "Sei",
+        ticker: "SEI",
+        units: [{ code: "SEI", name: "SEI", magnitude: 18 }],
+      } as CryptoCurrency;
+
+      it("uses totalFees as the effective reserve when no reserve is configured for the chain", async () => {
+        // Unknown chain → configuredReserve = 0n, effectiveReserve = max(0n, totalFees) = totalFees.
+        // validateIntent recalculates fees from gasPrice * gasLimit, so we align parameters
+        // to get totalFees = 100_000n (gasLimit 100_000 × gasPrice 1).
+        const balance = 1_000_000n;
+        const totalFees = 100_000n; // gasLimit(100_000) × gasPrice(1)
+        const res = await validateIntent(
+          { id: "unknown_chain" } as CryptoCurrency,
+          stakingIntent({ mode: "delegate", useAllAmount: true }),
+          [{ value: balance, asset: { type: "native" } }],
+          { value: totalFees, parameters: { gasLimit: 100_000n, gasPrice: 1n } },
+        );
+
+        // effectiveReserve = max(0n, 100_000n) = 100_000n → amount = 1_000_000n - 100_000n
+        expect(res.amount).toBe(balance - totalFees);
+        expect(res.errors.amount).toBeUndefined();
+      });
+
+      it("uses totalFees as the effective reserve when totalFees exceed the configured reserve (sei_evm)", async () => {
+        // sei_evm configuredReserve = 10n**17n; set fees = 2 × 10n**17n so totalFees wins.
+        // Balance = 1 SEI = 10n**18n. Scale = 10n**12n.
+        const balance = 10n ** 18n;
+        const fees = 2n * 10n ** 17n; // > configuredReserve
+        const res = await validateIntent(
+          seiCurrency,
+          stakingIntent({ mode: "delegate", useAllAmount: true }),
+          [{ value: balance, asset: { type: "native" } }],
+          {
+            value: fees,
+            parameters: { gasLimit: 200_000n, gasPrice: 10n ** 12n },
+          },
+        );
+
+        // effectiveReserve = max(10n**17n, 2n*10n**17n) = 2n*10n**17n = 200_000_000_000_000_000n
+        // rawAmount = 10n**18n - 200_000_000_000_000_000n = 800_000_000_000_000_000n
+        // After scale floor: 800_000_000_000_000_000n (already a multiple of 10n**12n)
+        expect(res.amount).toBe(800_000_000_000_000_000n);
+        expect(res.errors.amount).toBeUndefined();
+      });
+
+      it("uses the configured reserve when it exceeds totalFees (sei_evm)", async () => {
+        // sei_evm configuredReserve = 10n**17n; set fees < 10n**17n so configured reserve wins.
+        // Balance = 1 SEI = 10n**18n. Scale = 10n**12n.
+        const balance = 10n ** 18n;
+        const fees = 10n ** 14n; // < configuredReserve
+        const res = await validateIntent(
+          seiCurrency,
+          stakingIntent({ mode: "delegate", useAllAmount: true }),
+          [{ value: balance, asset: { type: "native" } }],
+          {
+            value: fees,
+            parameters: { gasLimit: 21000n, gasPrice: 5n },
+          },
+        );
+
+        // effectiveReserve = max(10n**17n, 10n**14n) = 10n**17n = 100_000_000_000_000_000n
+        // rawAmount = 10n**18n - 10n**17n = 900_000_000_000_000_000n
+        // After scale floor: 900_000_000_000_000_000n (already a multiple of 10n**12n)
+        expect(res.amount).toBe(900_000_000_000_000_000n);
+        expect(res.errors.amount).toBeUndefined();
+      });
+    });
   });
 
   describe("gas", () => {

--- a/libs/coin-modules/coin-evm/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-evm/src/logic/validateIntent.ts
@@ -30,6 +30,7 @@ import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import BigNumber from "bignumber.js";
 import { getGasTracker } from "../network/gasTracker";
 import { isNative, StakingOperation, TransactionTypes } from "../types";
+import { STAKING_CONTRACTS } from "../staking";
 import { DEFAULT_GAS_LIMIT, isEthAddress, isStakingIntent } from "../utils";
 import {
   getTransactionType,
@@ -297,6 +298,7 @@ function validateStaking(
 }
 
 function computeAmount(
+  currency: CryptoCurrency,
   intent: TransactionIntent,
   estimatedFees: FeeEstimation,
   balance: Balance,
@@ -304,8 +306,27 @@ function computeAmount(
   if (!intent.useAllAmount) return intent.amount;
 
   const available = balance.value - (balance.locked ?? 0n);
-
   if (isNative(intent.asset)) {
+    if (isStakingIntent(intent) && intent.mode === "delegate") {
+      const additionalFees =
+        typeof estimatedFees.parameters?.additionalFees === "bigint"
+          ? estimatedFees.parameters.additionalFees
+          : 0n;
+      const totalFees = estimatedFees.value + additionalFees;
+      // Use max(configuredReserve, totalFees) so that:
+      // - chains with a large per-chain reserve keep their existing behaviour,
+      // - unconfigured chains (reserve = 0n) fall back to the current fees,
+      // - high-fee selections never produce an amount the account cannot afford.
+      const configuredReserve = STAKING_CONTRACTS[currency.id]?.delegationMaxAmountReserve ?? 0n;
+      const effectiveReserve = configuredReserve > totalFees ? configuredReserve : totalFees;
+      const rawAmount = available > effectiveReserve ? available - effectiveReserve : 0n;
+      // Floor-round to the nearest minimum calldata unit for this chain's staking precompile.
+      // Chains like SEI require msg.value to be a whole multiple of their unit scale
+      // (e.g. 10^12 wei = 1 usei), otherwise the precompile reverts.
+      // For chains without a scale (calldataAmountScale = 1n), this is a no-op.
+      const scale = STAKING_CONTRACTS[currency.id]?.calldataAmountScale ?? 1n;
+      return (rawAmount / scale) * scale;
+    }
     const additionalFees =
       typeof estimatedFees.parameters?.additionalFees === "bigint"
         ? estimatedFees.parameters.additionalFees
@@ -352,7 +373,7 @@ export async function validateIntent(
     ? { ...customFees, value: refreshEstimationValue(intent, customFees.parameters) }
     : await estimateFees(currency, intent);
   const balance = findBalance(intent.asset, balances);
-  const amount = computeAmount(intent, estimatedFees, balance);
+  const amount = computeAmount(currency, intent, estimatedFees, balance);
   const additionalFees =
     typeof estimatedFees.parameters?.additionalFees === "bigint"
       ? estimatedFees.parameters.additionalFees

--- a/libs/coin-modules/coin-evm/src/staking/contracts.ts
+++ b/libs/coin-modules/coin-evm/src/staking/contracts.ts
@@ -44,6 +44,9 @@ export const STAKING_CONTRACTS: Record<string, StakingContractConfig> = {
     // The redelegate/undelegate precompile encodes amounts in usei (6 decimals).
     // Multiply by this scale to convert back to the EVM-native 18-decimal unit.
     calldataAmountScale: USEI_TO_EVM_SCALE,
+    // Reserve 0.1 SEI (≈ 830k gas at 120 gwei) so that fee spikes between
+    // prepareTransaction and broadcast do not cause the staking precompile to revert.
+    delegationMaxAmountReserve: 10n ** 17n, // 0.1 SEI in wei (10^17)
   },
 
   // Celo staking

--- a/libs/coin-modules/coin-evm/src/types/staking.ts
+++ b/libs/coin-modules/coin-evm/src/types/staking.ts
@@ -81,6 +81,13 @@ export type StakingContractConfig = {
    * Defaults to 1n (no conversion) when omitted.
    */
   calldataAmountScale?: bigint;
+  /**
+   * Fixed reserve (in wei) subtracted from the spendable balance when computing
+   * the maximum delegation amount ("send all").  Decouples the computed amount
+   * from gas-price fluctuations between prepareTransaction and broadcast.
+   * Defaults to 0n when omitted.
+   */
+  delegationMaxAmountReserve?: bigint;
 };
 
 export type StakeCreate = {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/signOperation.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/signOperation.ts
@@ -61,6 +61,9 @@ export const genericSignOperation =
             feesStrategy: transaction.feesStrategy,
             data: transaction.data,
             type: transaction.type,
+            sponsored: transaction.sponsored,
+            valAddress: transaction?.valAddress || "",
+            dstValAddress: transaction?.dstValAddress || "",
           };
           // TODO Remove the call to `validateIntent` https://ledgerhq.atlassian.net/browse/LIVE-22227
           const { amount } = await coinModuleApi.validateIntent(

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/prepareTransaction.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/prepareTransaction.test.ts
@@ -172,6 +172,57 @@ describe("genericPrepareTransaction", () => {
     );
   });
 
+  describe("delegation gas estimation (useAllAmount)", () => {
+    const delegationAccount = {
+      ...account,
+      spendableBalance: new BigNumber(1_000_000_000),
+    };
+
+    it("passes transaction amount to fee estimation for delegation with useAllAmount", async () => {
+      const estimateFees = jest.fn().mockResolvedValue({ value: new BigNumber(100) });
+      (getCoinModuleApi as jest.Mock).mockReturnValue({
+        estimateFees,
+        validateIntent: jest.fn().mockResolvedValue({ amount: 0n }),
+      });
+
+      const prepareTransaction = genericPrepareTransaction("testnet", "local");
+      await prepareTransaction(delegationAccount, {
+        ...baseTransaction,
+        mode: "delegate",
+        useAllAmount: true,
+      } as GenericTransaction);
+
+      expect(transactionToIntent).toHaveBeenCalledWith(
+        delegationAccount,
+        expect.objectContaining({ amount: baseTransaction.amount }),
+        undefined,
+        undefined,
+      );
+    });
+
+    it("passes transaction amount to fee estimation for non-delegation modes with useAllAmount", async () => {
+      const estimateFees = jest.fn().mockResolvedValue({ value: new BigNumber(1_200_000) });
+      (getCoinModuleApi as jest.Mock).mockReturnValue({
+        estimateFees,
+        validateIntent: jest.fn().mockResolvedValue({ amount: 0n }),
+      });
+
+      const prepareTransaction = genericPrepareTransaction("testnet", "local");
+      await prepareTransaction(delegationAccount, {
+        ...baseTransaction,
+        mode: "send",
+        useAllAmount: true,
+      } as GenericTransaction);
+
+      expect(transactionToIntent).toHaveBeenCalledWith(
+        delegationAccount,
+        expect.objectContaining({ amount: baseTransaction.amount }),
+        undefined,
+        undefined,
+      );
+    });
+  });
+
   it("estimates using the token account spendable balance when sending all amount", async () => {
     (decodeTokenAccountId as jest.Mock).mockResolvedValueOnce({
       accountId: "test-sub-account",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

When a user taps "use all amount" for an EVM staking delegation, the computeAmount function in validateIntent now subtracts a per-chain fee reserve before computing the final delegated amount. This prevents the staking precompile from reverting due to gas price spikes between prepareTransaction and broadcast.

`coin-evm/validateIntent` — computeAmount now handles the useAllAmount + delegate path: it reads delegationMaxAmountReserve and calldataAmountScale from STAKING_CONTRACTS and returns a floor-rounded amount that is safe to broadcast.

`coin-evm/staking/contracts` — Added delegationMaxAmountReserve: 10n ** 17n (0.1 SEI) to the Sei EVM config to absorb fee spikes.

`coin-evm/logic/common` — Gas estimation now retries with the minimum calldata unit (calldataAmountScale) when the initial estimation fails for a staking transaction, so the UI doesn't break when the amount is 0 or unrounded.

l`ive-common/signOperation` — The generic signOperation now re-computes the final amount via validateIntent at signing time when useAllAmount is set, ensuring the signed transaction uses the reserve-adjusted value rather than the pre-computed one.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:  [LIVE-31272](https://ledgerhq.atlassian.net/browse/LIVE-31272)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31272]: https://ledgerhq.atlassian.net/browse/LIVE-31272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ