### PR TITLE
[LWDM] fix(ff-middleware): wire fetchRemoteFlags + bridge legacy providers (LWD + LWM)

### DIFF
--- a/.changeset/wire-ff-middleware-fetch-remote.md
+++ b/.changeset/wire-ff-middleware-fetch-remote.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Wire fetchRemoteFlags into createFeatureFlagsMiddleware for LWD and LWM. Centralize Firebase fetch behind a shared module so the Redux slice and the legacy Context provider stay synchronized.

--- a/apps/ledger-live-desktop/src/firebase/remoteConfig.test.ts
+++ b/apps/ledger-live-desktop/src/firebase/remoteConfig.test.ts
@@ -1,0 +1,186 @@
+const mockInitializeApp = jest.fn(() => ({ name: "test-app" }));
+const mockGetRemoteConfig = jest.fn(() => ({
+  settings: { minimumFetchIntervalMillis: -1 },
+  defaultConfig: {} as Record<string, string>,
+}));
+const mockFetchAndActivate = jest.fn();
+const mockGetAll = jest.fn();
+
+jest.mock("firebase/app", () => ({
+  initializeApp: (...args: unknown[]) => mockInitializeApp(...(args as [])),
+}));
+jest.mock("firebase/remote-config", () => ({
+  getRemoteConfig: (...args: unknown[]) => mockGetRemoteConfig(...(args as [])),
+  fetchAndActivate: (...args: unknown[]) => mockFetchAndActivate(...(args as [])),
+  getAll: (...args: unknown[]) => mockGetAll(...(args as [])),
+}));
+jest.mock("~/firebase-setup", () => ({
+  getFirebaseConfig: () => ({ projectId: "test" }),
+}));
+jest.mock("@ledgerhq/live-common/featureFlags/index", () => ({
+  DEFAULT_FEATURES: { mockFeature: { enabled: false } },
+  formatDefaultFeatures: () => ({ feature_mock_feature: JSON.stringify({ enabled: false }) }),
+}));
+
+const value = (raw: string) => ({ asString: () => raw });
+
+async function loadModule() {
+  return await import("./remoteConfig");
+}
+
+beforeEach(() => {
+  jest.resetModules();
+  mockInitializeApp.mockReset().mockReturnValue({ name: "test-app" } as never);
+  mockGetRemoteConfig
+    .mockReset()
+    .mockReturnValue({ settings: { minimumFetchIntervalMillis: -1 }, defaultConfig: {} } as never);
+  mockFetchAndActivate.mockReset().mockResolvedValue(true);
+  mockGetAll.mockReset().mockReturnValue({});
+});
+
+describe("fetchRemoteFlags", () => {
+  it("filters out non-feature keys, strips feature_ prefix, and camelCases", async () => {
+    mockGetAll.mockReturnValue({
+      feature_mock_feature: value(JSON.stringify({ enabled: true })),
+      feature_some_other_flag: value(JSON.stringify({ enabled: false, params: { x: 1 } })),
+      config_unrelated: value("\"ignored\""),
+      stranger_key: value("\"ignored\""),
+    });
+
+    const { fetchRemoteFlags } = await loadModule();
+    const result = await fetchRemoteFlags();
+
+    expect(result).toEqual({
+      mockFeature: { enabled: true },
+      someOtherFlag: { enabled: false, params: { x: 1 } },
+    });
+  });
+
+  it("silently drops keys whose value is not valid JSON", async () => {
+    mockGetAll.mockReturnValue({
+      feature_good: value(JSON.stringify({ enabled: true })),
+      feature_bad: value("not json"),
+    });
+
+    const { fetchRemoteFlags } = await loadModule();
+    const result = await fetchRemoteFlags();
+
+    expect(result).toEqual({ good: { enabled: true } });
+  });
+
+  it("propagates the fetchAndActivate failure (middleware swallows it)", async () => {
+    mockFetchAndActivate.mockRejectedValue(new Error("network down"));
+    const { fetchRemoteFlags } = await loadModule();
+    await expect(fetchRemoteFlags()).rejects.toThrow("network down");
+  });
+
+  it("initializes the Firebase app and configures remote config exactly once", async () => {
+    mockGetAll.mockReturnValue({});
+    const { fetchRemoteFlags } = await loadModule();
+    await fetchRemoteFlags();
+    await fetchRemoteFlags();
+    await fetchRemoteFlags();
+    expect(mockInitializeApp).toHaveBeenCalledTimes(1);
+    expect(mockGetRemoteConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("sets minimumFetchIntervalMillis=0 and defaultConfig on first access", async () => {
+    const rcInstance = { settings: { minimumFetchIntervalMillis: -1 }, defaultConfig: {} };
+    mockGetRemoteConfig.mockReturnValue(rcInstance as never);
+    mockGetAll.mockReturnValue({});
+
+    const { fetchRemoteFlags } = await loadModule();
+    await fetchRemoteFlags();
+
+    expect(rcInstance.settings.minimumFetchIntervalMillis).toBe(0);
+    expect(rcInstance.defaultConfig).toEqual({
+      feature_mock_feature: JSON.stringify({ enabled: false }),
+    });
+  });
+});
+
+describe("subscribeToRemoteFlags", () => {
+  it("notifies every subscriber after a successful fetch", async () => {
+    mockGetAll.mockReturnValue({ feature_mock_feature: value(JSON.stringify({ enabled: true })) });
+    const { fetchRemoteFlags, subscribeToRemoteFlags } = await loadModule();
+
+    const a = jest.fn();
+    const b = jest.fn();
+    subscribeToRemoteFlags(a);
+    subscribeToRemoteFlags(b);
+
+    await fetchRemoteFlags();
+
+    expect(a).toHaveBeenCalledWith({ fetchedAt: expect.any(Number) });
+    expect(b).toHaveBeenCalledWith({ fetchedAt: expect.any(Number) });
+  });
+
+  it("does not notify subscribers on fetch failure", async () => {
+    mockFetchAndActivate.mockRejectedValue(new Error("network down"));
+    const { fetchRemoteFlags, subscribeToRemoteFlags } = await loadModule();
+    const cb = jest.fn();
+    subscribeToRemoteFlags(cb);
+
+    await expect(fetchRemoteFlags()).rejects.toThrow("network down");
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("replays the last successful fetch to a late subscriber", async () => {
+    mockGetAll.mockReturnValue({});
+    const { fetchRemoteFlags, subscribeToRemoteFlags } = await loadModule();
+
+    await fetchRemoteFlags();
+
+    const late = jest.fn();
+    subscribeToRemoteFlags(late);
+    expect(late).toHaveBeenCalledTimes(1);
+    expect(late).toHaveBeenCalledWith({ fetchedAt: expect.any(Number) });
+  });
+
+  it("removes a subscriber when its unsubscribe is invoked", async () => {
+    mockGetAll.mockReturnValue({});
+    const { fetchRemoteFlags, subscribeToRemoteFlags } = await loadModule();
+    const cb = jest.fn();
+    const unsubscribe = subscribeToRemoteFlags(cb);
+
+    await fetchRemoteFlags();
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    await fetchRemoteFlags();
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("whenReady", () => {
+  it("resolves after the first successful fetch", async () => {
+    mockGetAll.mockReturnValue({});
+    const { fetchRemoteFlags, whenReady } = await loadModule();
+
+    let resolved = false;
+    void whenReady().then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    await fetchRemoteFlags();
+    await Promise.resolve();
+    expect(resolved).toBe(true);
+  });
+
+  it("resolves even when the first fetch fails (so boot is not blocked)", async () => {
+    mockFetchAndActivate.mockRejectedValue(new Error("network down"));
+    const { fetchRemoteFlags, whenReady } = await loadModule();
+
+    let resolved = false;
+    void whenReady().then(() => {
+      resolved = true;
+    });
+
+    await fetchRemoteFlags().catch(() => null);
+    await Promise.resolve();
+    expect(resolved).toBe(true);
+  });
+});

--- a/apps/ledger-live-desktop/src/firebase/remoteConfig.ts
+++ b/apps/ledger-live-desktop/src/firebase/remoteConfig.ts
@@ -1,0 +1,115 @@
+import { initializeApp, FirebaseApp } from "firebase/app";
+import {
+  getRemoteConfig,
+  fetchAndActivate,
+  getAll,
+  RemoteConfig,
+} from "firebase/remote-config";
+import camelCase from "lodash/camelCase";
+import { DEFAULT_FEATURES, formatDefaultFeatures } from "@ledgerhq/live-common/featureFlags/index";
+import type { PartialFeatures } from "@shared/feature-flags";
+import { getFirebaseConfig } from "~/firebase-setup";
+
+type Subscriber = (event: { fetchedAt: number }) => void;
+
+let app: FirebaseApp | null = null;
+let remoteConfig: RemoteConfig | null = null;
+let setupDone = false;
+let lastFetchedAt: number | null = null;
+const subscribers = new Set<Subscriber>();
+
+let resolveReady: (() => void) | null = null;
+const readyPromise: Promise<void> = new Promise(resolve => {
+  resolveReady = resolve;
+});
+
+function getApp(): FirebaseApp {
+  if (!app) app = initializeApp(getFirebaseConfig());
+  return app;
+}
+
+/**
+ * Lazy singleton accessor for the Firebase RemoteConfig instance. On first call,
+ * applies the same settings as the legacy provider: zero fetch-interval cache
+ * window and default values seeded from {@link DEFAULT_FEATURES}.
+ */
+export function getRemoteConfigSingleton(): RemoteConfig {
+  if (!remoteConfig) {
+    remoteConfig = getRemoteConfig(getApp());
+  }
+  if (!setupDone) {
+    remoteConfig.settings.minimumFetchIntervalMillis = 0;
+    remoteConfig.defaultConfig = { ...formatDefaultFeatures(DEFAULT_FEATURES) };
+    setupDone = true;
+  }
+  return remoteConfig;
+}
+
+/**
+ * Subscribe to successful remote-flag fetches. The callback fires after each
+ * successful {@link fetchRemoteFlags} call with the wall-clock timestamp. Used
+ * by the legacy `FirebaseRemoteConfigProvider` to bump `lastFetchTime` so
+ * Context consumers re-render in lockstep with the Redux slice.
+ *
+ * If a fetch has already succeeded by the time of subscription, the callback
+ * fires synchronously with the last known timestamp so late subscribers don't
+ * miss the boot-time fetch dispatched by the middleware.
+ *
+ * @returns An unsubscribe function.
+ */
+export function subscribeToRemoteFlags(callback: Subscriber): () => void {
+  subscribers.add(callback);
+  if (lastFetchedAt !== null) {
+    callback({ fetchedAt: lastFetchedAt });
+  }
+  return () => {
+    subscribers.delete(callback);
+  };
+}
+
+/**
+ * Resolves on the first {@link fetchRemoteFlags} completion (success or failure)
+ * so callers can gate app boot on Firebase having had a chance to respond.
+ * Mirrors the legacy provider's `loaded` flag, which flipped true in a `finally`
+ * block regardless of fetch outcome.
+ */
+export function whenReady(): Promise<void> {
+  return readyPromise;
+}
+
+/**
+ * Single source of truth for fetching Firebase remote feature flags. Wired into
+ * `createFeatureFlagsMiddleware` so the Redux slice's `state.featureFlags.remote`
+ * stays in sync, and exposed via {@link subscribeToRemoteFlags} so the legacy
+ * Context provider hydrates from the same payload at the same tick.
+ *
+ * Filters out `config_*` keys (owned by `LiveConfig`), strips the `feature_`
+ * prefix, camelCases the remainder, and JSON-parses each value. Malformed JSON
+ * values are dropped silently — at worst the slice falls back to defaults for
+ * that key. Unknown feature IDs are dropped at runtime inside `resolveAll`, so
+ * the closing cast to {@link PartialFeatures} is safe.
+ */
+export async function fetchRemoteFlags(): Promise<PartialFeatures> {
+  try {
+    const rc = getRemoteConfigSingleton();
+    await fetchAndActivate(rc);
+    const all = getAll(rc);
+    const flags: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(all)) {
+      if (!key.startsWith("feature_")) continue;
+      const featureId = camelCase(key.slice("feature_".length));
+      try {
+        flags[featureId] = JSON.parse(value.asString());
+      } catch {
+        // Malformed JSON in remote config — drop this key, fall back to default.
+      }
+    }
+    const fetchedAt = Date.now();
+    lastFetchedAt = fetchedAt;
+    subscribers.forEach(callback => callback({ fetchedAt }));
+    return flags as PartialFeatures;
+  } finally {
+    resolveReady?.();
+    resolveReady = null;
+  }
+}

--- a/apps/ledger-live-desktop/src/renderer/components/FirebaseRemoteConfig.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/FirebaseRemoteConfig.test.tsx
@@ -1,8 +1,29 @@
 import React from "react";
 
-const fetchAndActivate = jest.fn().mockResolvedValue(true);
-const getValueMock = jest.fn().mockReturnValue("");
-const getAllMock = jest.fn().mockReturnValue({});
+let resolveReady: (() => void) | null = null;
+let readyPromise: Promise<void>;
+const subscribeMock = jest.fn();
+const unsubscribeMock = jest.fn();
+const getRemoteConfigSingletonMock = jest.fn(() => ({
+  settings: { minimumFetchIntervalMillis: 0 },
+  defaultConfig: {} as Record<string, string>,
+}));
+
+const resetReady = () => {
+  readyPromise = new Promise<void>(resolve => {
+    resolveReady = resolve;
+  });
+};
+resetReady();
+
+jest.mock("~/firebase/remoteConfig", () => ({
+  getRemoteConfigSingleton: () => getRemoteConfigSingletonMock(),
+  subscribeToRemoteFlags: (cb: (e: { fetchedAt: number }) => void) => {
+    subscribeMock(cb);
+    return () => unsubscribeMock();
+  },
+  whenReady: () => readyPromise,
+}));
 
 jest.mock("firebase/app", () => ({
   initializeApp: jest.fn(),
@@ -11,18 +32,19 @@ jest.mock("firebase/app", () => ({
 
 jest.mock("firebase/remote-config", () => ({
   getRemoteConfig: jest.fn(() => ({ settings: {}, defaultConfig: {} })),
-  fetchAndActivate: (...args: unknown[]) => fetchAndActivate(...args),
-  getValue: (...args: unknown[]) => getValueMock(...args),
-  getAll: () => getAllMock(),
+  fetchAndActivate: jest.fn().mockResolvedValue(true),
+  getValue: jest.fn().mockReturnValue(""),
+  getAll: jest.fn().mockReturnValue({}),
 }));
 
 jest.mock("~/firebase-setup", () => ({
   getFirebaseConfig: () => ({}),
 }));
 
+const setProviderMock = jest.fn();
 jest.mock("@ledgerhq/live-config/LiveConfig", () => ({
   LiveConfig: {
-    setProvider: jest.fn(),
+    setProvider: (...args: unknown[]) => setProviderMock(...args),
     instance: { config: {} },
     getDefaultValueByKey: jest.fn(),
   },
@@ -32,29 +54,38 @@ jest.mock("@ledgerhq/live-config/providers/index", () => ({
   FirebaseRemoteConfigProvider: jest.fn().mockImplementation(() => ({})),
 }));
 
-jest.mock("@ledgerhq/live-common/featureFlags/index", () => ({
-  DEFAULT_FEATURES: {},
-  formatDefaultFeatures: () => ({}),
-}));
-
 import { act, render } from "@testing-library/react";
 import { FirebaseRemoteConfigProvider } from "./FirebaseRemoteConfig";
 
-const FIVE_MINUTES = 5 * 60 * 1000;
 const flushMicrotasks = () => act(async () => {});
 
 describe("FirebaseRemoteConfigProvider", () => {
   beforeEach(() => {
-    fetchAndActivate.mockClear();
-    fetchAndActivate.mockResolvedValue(true);
-    jest.useFakeTimers();
+    subscribeMock.mockClear();
+    unsubscribeMock.mockClear();
+    setProviderMock.mockClear();
+    getRemoteConfigSingletonMock.mockClear();
+    resetReady();
   });
 
-  afterEach(() => {
-    jest.useRealTimers();
+  it("returns null until whenReady resolves", async () => {
+    const { container } = render(
+      <FirebaseRemoteConfigProvider>
+        <div data-testid="child" />
+      </FirebaseRemoteConfigProvider>,
+    );
+
+    expect(container.querySelector('[data-testid="child"]')).toBeNull();
+
+    await act(async () => {
+      resolveReady?.();
+      await readyPromise;
+    });
+
+    expect(container.querySelector('[data-testid="child"]')).not.toBeNull();
   });
 
-  it("calls fetchAndActivate once on mount and again on each 5-minute interval tick", async () => {
+  it("installs the LiveConfig provider on mount", async () => {
     render(
       <FirebaseRemoteConfigProvider>
         <div />
@@ -62,37 +93,39 @@ describe("FirebaseRemoteConfigProvider", () => {
     );
 
     await flushMicrotasks();
-    expect(fetchAndActivate).toHaveBeenCalledTimes(1);
-
-    await act(async () => {
-      jest.advanceTimersByTime(FIVE_MINUTES);
-    });
-    expect(fetchAndActivate).toHaveBeenCalledTimes(2);
-
-    await act(async () => {
-      jest.advanceTimersByTime(FIVE_MINUTES);
-    });
-    expect(fetchAndActivate).toHaveBeenCalledTimes(3);
+    expect(setProviderMock).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps polling even when a fetch rejects", async () => {
-    fetchAndActivate.mockRejectedValueOnce(new Error("network error"));
-    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
-
-    render(
+  it("subscribes to remote-flag updates on mount and unsubscribes on unmount", async () => {
+    const { unmount } = render(
       <FirebaseRemoteConfigProvider>
         <div />
       </FirebaseRemoteConfigProvider>,
     );
 
     await flushMicrotasks();
-    expect(fetchAndActivate).toHaveBeenCalledTimes(1);
+    expect(subscribeMock).toHaveBeenCalledTimes(1);
 
+    unmount();
+    expect(unsubscribeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders children even when whenReady resolves after a failed first fetch", async () => {
+    const { container } = render(
+      <FirebaseRemoteConfigProvider>
+        <div data-testid="child" />
+      </FirebaseRemoteConfigProvider>,
+    );
+
+    expect(container.querySelector('[data-testid="child"]')).toBeNull();
+
+    // Mirrors the production case where fetchRemoteFlags throws but whenReady
+    // still resolves so the app boots without remote values.
     await act(async () => {
-      jest.advanceTimersByTime(FIVE_MINUTES);
+      resolveReady?.();
+      await readyPromise;
     });
-    expect(fetchAndActivate).toHaveBeenCalledTimes(2);
 
-    consoleErrorSpy.mockRestore();
+    expect(container.querySelector('[data-testid="child"]')).not.toBeNull();
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/components/FirebaseRemoteConfig.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/FirebaseRemoteConfig.tsx
@@ -9,8 +9,12 @@ import {
 } from "firebase/remote-config";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { FirebaseRemoteConfigProvider as FirebaseProvider } from "@ledgerhq/live-config/providers/index";
-import { DEFAULT_FEATURES, formatDefaultFeatures } from "@ledgerhq/live-common/featureFlags/index";
 import { getFirebaseConfig } from "~/firebase-setup";
+import {
+  getRemoteConfigSingleton,
+  subscribeToRemoteFlags,
+  whenReady,
+} from "~/firebase/remoteConfig";
 import isMatch from "lodash/isMatch";
 import * as fs from "fs";
 
@@ -34,6 +38,66 @@ const parseEnvFile = (fileContent: string) => {
   return envVariables;
 };
 
+// Spins up a parallel Firebase app per env, fetches its remote config, and
+// warns when remote `config_*` values diverge from the local defaults declared
+// via LiveConfig. Dev-only — runs alongside the main provider but does not
+// interact with the singleton owned by `~/firebase/remoteConfig`.
+const warnOnConfigMismatch = async () => {
+  if (!__DEV__) {
+    return;
+  }
+  const envs = ["production", "staging", "testing", "development"];
+  envs.forEach(async (env: string) => {
+    const envFilePath = `./.env.${env}`;
+    let apiKey, authDomain, projectId, storageBucket, messagingSenderId, appId, envVars;
+    try {
+      const fileContent = fs.readFileSync(envFilePath, "utf8");
+      envVars = parseEnvFile(fileContent);
+      apiKey = envVars["FIREBASE_API_KEY"];
+      authDomain = envVars["FIREBASE_AUTH_DOMAIN"];
+      projectId = envVars["FIREBASE_PROJECT_ID"];
+      storageBucket = envVars["FIREBASE_STORAGE_BUCKET"];
+      messagingSenderId = envVars["FIREBASE_MESSAGING_SENDER_ID"];
+      appId = envVars["FIREBASE_APP_ID"];
+    } catch {
+      apiKey = undefined;
+    }
+
+    const firebaseOptions = apiKey
+      ? { apiKey, authDomain, projectId, storageBucket, messagingSenderId, appId }
+      : getFirebaseConfig();
+    const firebaseApp = initializeApp(firebaseOptions, env);
+    const remoteConfig = getRemoteConfig(firebaseApp);
+    remoteConfig.settings.minimumFetchIntervalMillis = 0;
+    await fetchAndActivate(remoteConfig);
+    const allConfigs = getAll(remoteConfig);
+    for (const key in allConfigs) {
+      if (key.startsWith("config_")) {
+        const value = allConfigs[key].asString();
+        const configType = LiveConfig.instance.config[key]?.type;
+        if (configType === "object" || configType === "array") {
+          if (!isMatch(LiveConfig.getDefaultValueByKey(key) as object, JSON.parse(value))) {
+            console.warn(
+              `Config mismatch for ${key} in ${env}, Remote: ${value}, Local: ${JSON.stringify(
+                LiveConfig.getDefaultValueByKey(key),
+              )}`,
+            );
+          }
+        } else {
+          if (LiveConfig.getDefaultValueByKey(key)?.toString() !== value) {
+            console.warn(
+              `Config mismatch for ${key} in ${env}, Remote: ${value}, Local: ${LiveConfig.getDefaultValueByKey(
+                key,
+              )?.toString()}`,
+            );
+          }
+        }
+      }
+    }
+    await deleteApp(firebaseApp);
+  });
+};
+
 export const FirebaseRemoteConfigProvider = ({
   children,
 }: {
@@ -44,18 +108,14 @@ export const FirebaseRemoteConfigProvider = ({
   const [lastFetchTime, setLastFetchTime] = useState<number>(0);
 
   useEffect(() => {
+    let remoteConfig: RemoteConfig;
     try {
-      const firebaseConfig = getFirebaseConfig();
-      initializeApp(firebaseConfig);
+      remoteConfig = getRemoteConfigSingleton();
     } catch (error) {
       console.error(`Failed to initialize Firebase SDK with error: ${error}`);
       setLoaded(true);
+      return;
     }
-    const remoteConfig = getRemoteConfig();
-    remoteConfig.settings.minimumFetchIntervalMillis = 0;
-    remoteConfig.defaultConfig = {
-      ...formatDefaultFeatures(DEFAULT_FEATURES),
-    };
     setConfig(remoteConfig);
 
     LiveConfig.setProvider(
@@ -66,83 +126,30 @@ export const FirebaseRemoteConfigProvider = ({
       }),
     );
 
-    // check whether local default settings and firebase remote settings are consistent
-    const warnOnConfigMismatch = async () => {
-      if (!__DEV__) {
-        return;
-      }
-      const envs = ["production", "staging", "testing", "development"];
-      envs.forEach(async (env: string) => {
-        const envFilePath = `./.env.${env}`;
-        let apiKey, authDomain, projectId, storageBucket, messagingSenderId, appId, envVars;
-        try {
-          const fileContent = fs.readFileSync(envFilePath, "utf8");
-          envVars = parseEnvFile(fileContent);
-          apiKey = envVars["FIREBASE_API_KEY"];
-          authDomain = envVars["FIREBASE_AUTH_DOMAIN"];
-          projectId = envVars["FIREBASE_PROJECT_ID"];
-          storageBucket = envVars["FIREBASE_STORAGE_BUCKET"];
-          messagingSenderId = envVars["FIREBASE_MESSAGING_SENDER_ID"];
-          appId = envVars["FIREBASE_APP_ID"];
-        } catch {
-          apiKey = undefined;
-        }
+    // Bump lastFetchTime on every successful middleware-driven fetch so Context
+    // consumers re-render in lockstep with the Redux slice. Replay semantics in
+    // subscribeToRemoteFlags ensure we receive the boot-time fetch even when
+    // the middleware completes it before this effect runs.
+    const unsubscribe = subscribeToRemoteFlags(({ fetchedAt }) => {
+      setLastFetchTime(fetchedAt);
+    });
 
-        const firebaseOptions = apiKey
-          ? { apiKey, authDomain, projectId, storageBucket, messagingSenderId, appId }
-          : getFirebaseConfig();
-        const firebaseApp = initializeApp(firebaseOptions, env);
-        const remoteConfig = getRemoteConfig(firebaseApp);
-        remoteConfig.settings.minimumFetchIntervalMillis = 0;
-        await fetchAndActivate(remoteConfig);
-        const allConfigs = getAll(remoteConfig);
-        for (const key in allConfigs) {
-          if (key.startsWith("config_")) {
-            const value = allConfigs[key].asString();
-            const configType = LiveConfig.instance.config[key]?.type;
-            if (configType === "object" || configType === "array") {
-              if (!isMatch(LiveConfig.getDefaultValueByKey(key) as object, JSON.parse(value))) {
-                console.warn(
-                  `Config mismatch for ${key} in ${env}, Remote: ${value}, Local: ${JSON.stringify(
-                    LiveConfig.getDefaultValueByKey(key),
-                  )}`,
-                );
-              }
-            } else {
-              if (LiveConfig.getDefaultValueByKey(key)?.toString() !== value) {
-                console.warn(
-                  `Config mismatch for ${key} in ${env}, Remote: ${value}, Local: ${LiveConfig.getDefaultValueByKey(
-                    key,
-                  )?.toString()}`,
-                );
-              }
-            }
-          }
-        }
-        await deleteApp(firebaseApp);
-      });
-    };
+    // Release the boot gate as soon as the first fetch resolves (success or
+    // failure), matching the legacy provider's `finally`-based behavior.
+    let cancelled = false;
+    whenReady().then(() => {
+      if (!cancelled) setLoaded(true);
+    });
 
-    const fetchAndActivateConfig = async () => {
-      try {
-        await warnOnConfigMismatch();
-      } catch {
-        // ignore the config check if any error occurs because it's not critical
-      }
-      try {
-        await fetchAndActivate(remoteConfig);
-        setLastFetchTime(Date.now());
-      } catch (error) {
-        console.error(`Failed to fetch Firebase remote config with error: ${error}`);
-      } finally {
-        setLoaded(true);
-      }
+    warnOnConfigMismatch().catch(() => {
+      // The dev-only config check is best-effort.
+    });
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
     };
-    fetchAndActivateConfig();
-    // 5 minutes fetch interval. TODO: make this configurable
-    const intervalId = window.setInterval(fetchAndActivateConfig, 5 * 60 * 1000);
-    return () => clearInterval(intervalId);
-  }, [setConfig]);
+  }, []);
 
   if (!loaded) {
     return null;

--- a/apps/ledger-live-desktop/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-desktop/src/state-manager/configureStore.ts
@@ -6,6 +6,7 @@ import { applyLldRTKApiMiddlewares } from "~/renderer/reducers/rtkQueryApi";
 import { createIdentitiesSyncMiddleware } from "@ledgerhq/client-ids/store";
 import { trackingEnabledSelector } from "~/renderer/reducers/settings";
 import { createFeatureFlagsMiddleware } from "@shared/feature-flags";
+import { fetchRemoteFlags } from "~/firebase/remoteConfig";
 type Props = {
   state?: State;
   dbMiddleware?: Middleware;
@@ -32,6 +33,7 @@ const customCreateStore = ({ state, dbMiddleware, analyticsMiddleware }: Props) 
         .concat(
           createFeatureFlagsMiddleware({
             resolutionConfig: { platform: "desktop", appVersion: __APP_VERSION__ },
+            fetchRemoteFlags,
           }),
         ),
     devTools: __DEV__,

--- a/apps/ledger-live-mobile/__tests__/jest-setup.js
+++ b/apps/ledger-live-mobile/__tests__/jest-setup.js
@@ -266,9 +266,22 @@ jest.mock("@react-native-firebase/remote-config", () => {
     setConfigSettings: jest.fn().mockResolvedValue(null),
     setDefaults: jest.fn().mockResolvedValue(null),
     fetchAndActivate: jest.fn().mockResolvedValue(null),
+    getAll: jest.fn().mockReturnValue({}),
   };
   return { getRemoteConfig: jest.fn().mockReturnValue(rc) };
 });
+
+// Default mock for the new remote-config bridge module. Tests that need finer
+// control (e.g. delayed whenReady to assert boot-gate behavior) override this
+// per-file via their own `jest.mock("~/firebase/remoteConfig", ...)`. By default
+// whenReady resolves immediately so any test exercising the existing
+// `useFirebaseRemoteConfig` / `WaitForAppReady` boot path sees firebaseIsReady=true
+// without the feature-flags middleware being wired in.
+jest.mock("~/firebase/remoteConfig", () => ({
+  fetchRemoteFlags: jest.fn().mockResolvedValue({}),
+  subscribeToRemoteFlags: jest.fn(() => () => {}),
+  whenReady: jest.fn().mockResolvedValue(undefined),
+}));
 
 jest.mock("@braze/react-native-sdk", () => ({}));
 

--- a/apps/ledger-live-mobile/src/firebase/remoteConfig.test.ts
+++ b/apps/ledger-live-mobile/src/firebase/remoteConfig.test.ts
@@ -1,0 +1,188 @@
+const mockSetConfigSettings = jest.fn();
+const mockSetDefaults = jest.fn();
+const mockFetchAndActivate = jest.fn();
+const mockGetAll = jest.fn();
+const mockGetRemoteConfig = jest.fn(() => ({
+  setConfigSettings: (...args: unknown[]) => mockSetConfigSettings(...(args as [])),
+  setDefaults: (...args: unknown[]) => mockSetDefaults(...(args as [])),
+  fetchAndActivate: (...args: unknown[]) => mockFetchAndActivate(...(args as [])),
+  getAll: (...args: unknown[]) => mockGetAll(...(args as [])),
+}));
+
+jest.mock("@react-native-firebase/remote-config", () => ({
+  getRemoteConfig: () => mockGetRemoteConfig(),
+}));
+jest.mock("@ledgerhq/live-common/featureFlags/index", () => ({
+  DEFAULT_FEATURES: { mockFeature: { enabled: false } },
+  formatDefaultFeatures: () => ({ feature_mock_feature: JSON.stringify({ enabled: false }) }),
+}));
+
+const value = (raw: string) => ({ asString: () => raw });
+
+async function loadModule() {
+  return await import("./remoteConfig");
+}
+
+beforeEach(() => {
+  jest.resetModules();
+  mockSetConfigSettings.mockReset().mockResolvedValue(undefined);
+  mockSetDefaults.mockReset().mockResolvedValue(undefined);
+  mockFetchAndActivate.mockReset().mockResolvedValue(true);
+  mockGetAll.mockReset().mockReturnValue({});
+  mockGetRemoteConfig.mockClear();
+});
+
+describe("fetchRemoteFlags", () => {
+  it("filters out non-feature keys, strips feature_ prefix, and camelCases", async () => {
+    mockGetAll.mockReturnValue({
+      feature_mock_feature: value(JSON.stringify({ enabled: true })),
+      feature_some_other_flag: value(JSON.stringify({ enabled: false, params: { x: 1 } })),
+      config_unrelated: value("\"ignored\""),
+      stranger_key: value("\"ignored\""),
+    });
+
+    const { fetchRemoteFlags } = await loadModule();
+    const result = await fetchRemoteFlags();
+
+    expect(result).toEqual({
+      mockFeature: { enabled: true },
+      someOtherFlag: { enabled: false, params: { x: 1 } },
+    });
+  });
+
+  it("silently drops keys whose value is not valid JSON", async () => {
+    mockGetAll.mockReturnValue({
+      feature_good: value(JSON.stringify({ enabled: true })),
+      feature_bad: value("not json"),
+    });
+
+    const { fetchRemoteFlags } = await loadModule();
+    const result = await fetchRemoteFlags();
+
+    expect(result).toEqual({ good: { enabled: true } });
+  });
+
+  it("propagates the fetchAndActivate failure (middleware swallows it)", async () => {
+    mockFetchAndActivate.mockRejectedValue(new Error("network down"));
+    const { fetchRemoteFlags } = await loadModule();
+    await expect(fetchRemoteFlags()).rejects.toThrow("network down");
+  });
+
+  it("runs setup (setConfigSettings + setDefaults) exactly once across multiple fetches", async () => {
+    const { fetchRemoteFlags } = await loadModule();
+
+    await fetchRemoteFlags();
+    await fetchRemoteFlags();
+    await fetchRemoteFlags();
+
+    expect(mockSetConfigSettings).toHaveBeenCalledTimes(1);
+    expect(mockSetConfigSettings).toHaveBeenCalledWith({ minimumFetchIntervalMillis: 0 });
+    expect(mockSetDefaults).toHaveBeenCalledTimes(1);
+    expect(mockSetDefaults).toHaveBeenCalledWith({
+      feature_mock_feature: JSON.stringify({ enabled: false }),
+    });
+  });
+
+  it("awaits setup before calling fetchAndActivate", async () => {
+    const calls: string[] = [];
+    mockSetConfigSettings.mockImplementation(async () => {
+      calls.push("setConfigSettings");
+    });
+    mockSetDefaults.mockImplementation(async () => {
+      calls.push("setDefaults");
+    });
+    mockFetchAndActivate.mockImplementation(async () => {
+      calls.push("fetchAndActivate");
+      return true;
+    });
+
+    const { fetchRemoteFlags } = await loadModule();
+    await fetchRemoteFlags();
+
+    expect(calls.indexOf("fetchAndActivate")).toBeGreaterThan(calls.indexOf("setConfigSettings"));
+    expect(calls.indexOf("fetchAndActivate")).toBeGreaterThan(calls.indexOf("setDefaults"));
+  });
+});
+
+describe("subscribeToRemoteFlags", () => {
+  it("notifies every subscriber after a successful fetch", async () => {
+    mockGetAll.mockReturnValue({ feature_mock_feature: value(JSON.stringify({ enabled: true })) });
+    const { fetchRemoteFlags, subscribeToRemoteFlags } = await loadModule();
+
+    const a = jest.fn();
+    const b = jest.fn();
+    subscribeToRemoteFlags(a);
+    subscribeToRemoteFlags(b);
+
+    await fetchRemoteFlags();
+
+    expect(a).toHaveBeenCalledWith({ fetchedAt: expect.any(Number) });
+    expect(b).toHaveBeenCalledWith({ fetchedAt: expect.any(Number) });
+  });
+
+  it("does not notify subscribers on fetch failure", async () => {
+    mockFetchAndActivate.mockRejectedValue(new Error("network down"));
+    const { fetchRemoteFlags, subscribeToRemoteFlags } = await loadModule();
+    const cb = jest.fn();
+    subscribeToRemoteFlags(cb);
+
+    await expect(fetchRemoteFlags()).rejects.toThrow("network down");
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("replays the last successful fetch to a late subscriber", async () => {
+    const { fetchRemoteFlags, subscribeToRemoteFlags } = await loadModule();
+
+    await fetchRemoteFlags();
+
+    const late = jest.fn();
+    subscribeToRemoteFlags(late);
+    expect(late).toHaveBeenCalledTimes(1);
+    expect(late).toHaveBeenCalledWith({ fetchedAt: expect.any(Number) });
+  });
+
+  it("removes a subscriber when its unsubscribe is invoked", async () => {
+    const { fetchRemoteFlags, subscribeToRemoteFlags } = await loadModule();
+    const cb = jest.fn();
+    const unsubscribe = subscribeToRemoteFlags(cb);
+
+    await fetchRemoteFlags();
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    await fetchRemoteFlags();
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("whenReady", () => {
+  it("resolves after the first successful fetch", async () => {
+    const { fetchRemoteFlags, whenReady } = await loadModule();
+
+    let resolved = false;
+    void whenReady().then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    await fetchRemoteFlags();
+    await Promise.resolve();
+    expect(resolved).toBe(true);
+  });
+
+  it("resolves even when the first fetch fails (so boot is not blocked)", async () => {
+    mockFetchAndActivate.mockRejectedValue(new Error("network down"));
+    const { fetchRemoteFlags, whenReady } = await loadModule();
+
+    let resolved = false;
+    void whenReady().then(() => {
+      resolved = true;
+    });
+
+    await fetchRemoteFlags().catch(() => null);
+    await Promise.resolve();
+    expect(resolved).toBe(true);
+  });
+});

--- a/apps/ledger-live-mobile/src/firebase/remoteConfig.test.ts
+++ b/apps/ledger-live-mobile/src/firebase/remoteConfig.test.ts
@@ -1,3 +1,7 @@
+// Use the real module under test, overriding the default mock that other tests
+// in this app rely on via `__tests__/jest-setup.js`.
+jest.unmock("~/firebase/remoteConfig");
+
 const mockSetConfigSettings = jest.fn();
 const mockSetDefaults = jest.fn();
 const mockFetchAndActivate = jest.fn();

--- a/apps/ledger-live-mobile/src/firebase/remoteConfig.ts
+++ b/apps/ledger-live-mobile/src/firebase/remoteConfig.ts
@@ -1,0 +1,100 @@
+import { getRemoteConfig } from "@react-native-firebase/remote-config";
+import camelCase from "lodash/camelCase";
+import { DEFAULT_FEATURES, formatDefaultFeatures } from "@ledgerhq/live-common/featureFlags/index";
+import type { PartialFeatures } from "@shared/feature-flags";
+
+type Subscriber = (event: { fetchedAt: number }) => void;
+
+const rc = getRemoteConfig();
+
+let setupPromise: Promise<void> | null = null;
+let lastFetchedAt: number | null = null;
+const subscribers = new Set<Subscriber>();
+
+let resolveReady: (() => void) | null = null;
+const readyPromise: Promise<void> = new Promise(resolve => {
+  resolveReady = resolve;
+});
+
+/**
+ * One-shot setup: applies `minimumFetchIntervalMillis: 0` and seeds defaults
+ * from {@link DEFAULT_FEATURES}. Awaited at the start of every
+ * {@link fetchRemoteFlags} so the first fetch always honors defaults even when
+ * the middleware fires immediately at store creation.
+ */
+function setup(): Promise<void> {
+  if (!setupPromise) {
+    setupPromise = Promise.all([
+      rc.setConfigSettings({ minimumFetchIntervalMillis: 0 }),
+      rc.setDefaults(formatDefaultFeatures(DEFAULT_FEATURES)),
+    ]).then(() => undefined);
+  }
+  return setupPromise;
+}
+
+/**
+ * Subscribe to successful remote-flag fetches. The callback fires after each
+ * successful {@link fetchRemoteFlags} call with the wall-clock timestamp. Used
+ * by callers that already gate boot on the legacy RTK Query (`firebaseRemoteConfigApi`)
+ * so Context/Redux consumers stay in lockstep.
+ *
+ * If a fetch has already succeeded by the time of subscription, the callback
+ * fires synchronously with the last known timestamp so late subscribers don't
+ * miss the boot-time fetch dispatched by the middleware.
+ *
+ * @returns An unsubscribe function.
+ */
+export function subscribeToRemoteFlags(callback: Subscriber): () => void {
+  subscribers.add(callback);
+  if (lastFetchedAt !== null) {
+    callback({ fetchedAt: lastFetchedAt });
+  }
+  return () => {
+    subscribers.delete(callback);
+  };
+}
+
+/**
+ * Resolves on the first {@link fetchRemoteFlags} completion (success or failure)
+ * so callers can gate app boot on Firebase having had a chance to respond.
+ */
+export function whenReady(): Promise<void> {
+  return readyPromise;
+}
+
+/**
+ * Single source of truth for fetching Firebase remote feature flags. Wired into
+ * `createFeatureFlagsMiddleware` so the Redux slice's `state.featureFlags.remote`
+ * stays in sync, and exposed via {@link subscribeToRemoteFlags} so legacy
+ * consumers hydrate from the same payload at the same tick.
+ *
+ * Filters out `config_*` keys (owned by `LiveConfig`), strips the `feature_`
+ * prefix, camelCases the remainder, and JSON-parses each value. Malformed JSON
+ * values are dropped silently — at worst the slice falls back to defaults for
+ * that key. Unknown feature IDs are dropped at runtime inside `resolveAll`, so
+ * the closing cast to {@link PartialFeatures} is safe.
+ */
+export async function fetchRemoteFlags(): Promise<PartialFeatures> {
+  try {
+    await setup();
+    await rc.fetchAndActivate();
+    const all = rc.getAll();
+    const flags: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(all)) {
+      if (!key.startsWith("feature_")) continue;
+      const featureId = camelCase(key.slice("feature_".length));
+      try {
+        flags[featureId] = JSON.parse(value.asString());
+      } catch {
+        // Malformed JSON in remote config — drop this key, fall back to default.
+      }
+    }
+    const fetchedAt = Date.now();
+    lastFetchedAt = fetchedAt;
+    subscribers.forEach(callback => callback({ fetchedAt }));
+    return flags as PartialFeatures;
+  } finally {
+    resolveReady?.();
+    resolveReady = null;
+  }
+}

--- a/apps/ledger-live-mobile/src/mvvm/api/firebaseRemoteConfigApi.ts
+++ b/apps/ledger-live-mobile/src/mvvm/api/firebaseRemoteConfigApi.ts
@@ -1,29 +1,21 @@
-import type { FirebaseRemoteConfigTypes } from "@react-native-firebase/remote-config";
 import { createApi } from "@reduxjs/toolkit/query/react";
-import { DEFAULT_FEATURES, formatDefaultFeatures } from "@ledgerhq/live-common/featureFlags/index";
+import { whenReady } from "~/firebase/remoteConfig";
 
+/**
+ * Boot-gate proxy for Firebase remote config. The actual `setConfigSettings`,
+ * `setDefaults`, and `fetchAndActivate` calls now live in
+ * `~/firebase/remoteConfig` and are driven by the feature-flags middleware.
+ * This mutation simply awaits the module's first-fetch signal so the existing
+ * `useFirebaseRemoteConfig` / `WaitForAppReady` surface keeps working as the
+ * `firebaseIsReady` boolean source.
+ */
 export const firebaseRemoteConfigApi = createApi({
   reducerPath: "firebaseRemoteConfigApi",
   baseQuery: () => ({ data: null }),
 
   endpoints: build => ({
-    init: build.mutation<null, FirebaseRemoteConfigTypes.Module>({
-      queryFn: rc =>
-        Promise.all([
-          rc.setConfigSettings({ minimumFetchIntervalMillis: 0 }),
-          rc.setDefaults(formatDefaultFeatures(DEFAULT_FEATURES)),
-        ]).then(
-          () => ({ data: null }),
-          error => ({ error }),
-        ),
-    }),
-
-    fetchAndActivate: build.query<boolean, FirebaseRemoteConfigTypes.Module>({
-      queryFn: rc =>
-        rc.fetchAndActivate().then(
-          result => ({ data: result }),
-          error => ({ error }),
-        ),
+    init: build.mutation<null, void>({
+      queryFn: () => whenReady().then(() => ({ data: null })),
     }),
   }),
 });

--- a/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useFirebaseRemoteConfig.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useFirebaseRemoteConfig.test.tsx
@@ -1,43 +1,59 @@
-import { getRemoteConfig } from "@react-native-firebase/remote-config";
+let resolveReady: (() => void) | null = null;
+let rejectReady: ((error: Error) => void) | null = null;
+let readyPromise: Promise<void>;
+
+const resetReady = () => {
+  readyPromise = new Promise<void>((resolve, reject) => {
+    resolveReady = resolve;
+    rejectReady = reject;
+  });
+};
+resetReady();
+
+jest.mock("~/firebase/remoteConfig", () => ({
+  whenReady: () => readyPromise,
+}));
+
+const setProviderMock = jest.fn();
+jest.mock("@ledgerhq/live-config/LiveConfig", () => ({
+  LiveConfig: {
+    setProvider: (...args: unknown[]) => setProviderMock(...args),
+  },
+}));
+
+jest.mock("@ledgerhq/live-config/providers/index", () => ({
+  FirebaseRemoteConfigProvider: jest.fn().mockImplementation(args => args),
+}));
+
 import { renderHook, waitFor } from "@tests/test-renderer";
 import { useFirebaseRemoteConfig } from "../useFirebaseRemoteConfig";
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-const { setDefaults, setConfigSettings, fetchAndActivate } = getRemoteConfig() as jest.Mocked<
-  ReturnType<typeof getRemoteConfig>
->;
-
 describe("useFirebaseRemoteConfig", () => {
   beforeEach(() => {
-    jest.clearAllMocks();
-    setConfigSettings.mockResolvedValue();
-    setDefaults.mockResolvedValue(null);
-    fetchAndActivate.mockResolvedValue(true);
+    setProviderMock.mockClear();
+    resetReady();
   });
 
-  it("returns true once setConfigSettings, setDefaults, and fetchAndActivate are resolved", async () => {
-    const { result } = renderHook(() => useFirebaseRemoteConfig());
-    await waitFor(() => expect(result.current).toBe(true));
-    expect(setConfigSettings).toHaveBeenCalledWith({ minimumFetchIntervalMillis: 0 });
-    expect(setDefaults).toHaveBeenCalled();
-    expect(fetchAndActivate).toHaveBeenCalled();
+  it("installs the LiveConfig provider on mount", async () => {
+    renderHook(() => useFirebaseRemoteConfig());
+    expect(setProviderMock).toHaveBeenCalledTimes(1);
   });
 
-  it("still returns true if one of the firebase initialization calls fail", async () => {
-    setConfigSettings.mockRejectedValue(new Error("Request failed"));
+  it("returns true once whenReady resolves", async () => {
     const { result } = renderHook(() => useFirebaseRemoteConfig());
+    expect(result.current).toBe(false);
+
+    resolveReady?.();
+
     await waitFor(() => expect(result.current).toBe(true));
-    expect(setConfigSettings).toHaveBeenCalledWith({ minimumFetchIntervalMillis: 0 });
-    expect(setDefaults).toHaveBeenCalled();
-    expect(fetchAndActivate).not.toHaveBeenCalled();
   });
 
-  it("still returns true if fetchAndActivate fails", async () => {
-    fetchAndActivate.mockRejectedValue(new Error("Request failed"));
+  it("returns true even when whenReady rejects so the app boot is not blocked", async () => {
     const { result } = renderHook(() => useFirebaseRemoteConfig());
+    expect(result.current).toBe(false);
+
+    rejectReady?.(new Error("whenReady failed"));
+
     await waitFor(() => expect(result.current).toBe(true));
-    expect(setConfigSettings).toHaveBeenCalledWith({ minimumFetchIntervalMillis: 0 });
-    expect(setDefaults).toHaveBeenCalled();
-    expect(fetchAndActivate).toHaveBeenCalled();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/hooks/useFirebaseRemoteConfig.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/useFirebaseRemoteConfig.ts
@@ -4,16 +4,16 @@ import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { FirebaseRemoteConfigProvider } from "@ledgerhq/live-config/providers/index";
 import { firebaseRemoteConfigApi } from "../api/firebaseRemoteConfigApi";
 
-const FETCH_INTERVAL = 5 * 60 * 1000; // 5 minutes
-
+/**
+ * Returns `firebaseIsReady` for the initial-queries boot gate. Setup and
+ * polling now happen in `~/firebase/remoteConfig`, driven by the feature-flags
+ * middleware; this hook only installs the LiveConfig provider bridge and waits
+ * for the module's first-fetch signal via the RTK Query mutation.
+ */
 export function useFirebaseRemoteConfig() {
   const rcRef = useRef(getRemoteConfig());
 
   const [init, initResult] = firebaseRemoteConfigApi.useInitMutation();
-  const fetchQuery = firebaseRemoteConfigApi.useFetchAndActivateQuery(rcRef.current, {
-    pollingInterval: FETCH_INTERVAL,
-    skip: !initResult.isSuccess,
-  });
 
   useEffect(() => {
     LiveConfig.setProvider(
@@ -21,15 +21,14 @@ export function useFirebaseRemoteConfig() {
         getValue: (key: string) => rcRef.current.getValue(key),
       }),
     );
-    init(rcRef.current);
+    init();
   }, [init]);
 
-  const error = initResult.error || fetchQuery.error;
   useEffect(() => {
-    if (error) {
-      console.error(`Failed to fetch Firebase remote config with error:`, error);
+    if (initResult.error) {
+      console.error("Failed to fetch Firebase remote config with error:", initResult.error);
     }
-  }, [error]);
+  }, [initResult.error]);
 
-  return !initResult.isLoading && (initResult.isError || !fetchQuery.isLoading);
+  return initResult.isSuccess || initResult.isError;
 }

--- a/apps/ledger-live-mobile/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-mobile/src/state-manager/configureStore.ts
@@ -14,6 +14,7 @@ import { createIdentitiesSyncMiddleware } from "@ledgerhq/client-ids/store";
 import { State } from "~/reducers/types";
 import { trackingEnabledSelector } from "~/reducers/settings";
 import { createFeatureFlagsMiddleware } from "@shared/feature-flags";
+import { fetchRemoteFlags } from "~/firebase/remoteConfig";
 
 export const store = configureStore({
   reducer: reducers,
@@ -35,6 +36,7 @@ export const store = configureStore({
             platform: Platform.OS === "ios" ? "ios" : "android",
             appVersion: VersionNumber.appVersion ?? undefined,
           },
+          fetchRemoteFlags,
         }),
       ),
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - LWD renderer: the legacy `<FirebaseRemoteConfigProvider>` no longer initializes Firebase or polls; it subscribes to the new `firebase/remoteConfig` module. Boot gate still flips on the first fetch outcome (success or failure) so app boot timing is unchanged.
  - LWM: `firebaseRemoteConfigApi.init` mutation now awaits `whenReady()` instead of calling `setConfigSettings`/`setDefaults`/`fetchAndActivate` directly. The `fetchAndActivate` query endpoint was removed (only the hook used it). `useFirebaseRemoteConfig` still installs `LiveConfig.setProvider`; RTK Query surface unchanged.
  - QA focus: Firebase-controlled feature flags (anything not at its default value) should still be respected on both apps. Watch boot-time behavior under flaky network (the original failure handling is preserved — the boot gate still releases on a failed first fetch).

### 📝 Description

Wire `fetchRemoteFlags` into `createFeatureFlagsMiddleware` in both LWD and LWM, and centralize Firebase remote-config fetching behind a per-app `firebase/remoteConfig.ts` module so the Redux slice and the legacy Context/RTK Query providers hydrate from the same payload at the same tick.

**Why**: `state.featureFlags.resolved` was being filled only by `defaults + local overrides` — remote Firebase values never reached the slice because both apps mounted the middleware without a `fetchRemoteFlags` callback. Today this is hidden because ~99% of call sites read via live-common's Context-based `useFeature`, but any direct slice consumer (e.g. `analyticsOptIn` at `apps/ledger-live-mobile/src/reducers/settings.ts:765`) silently gets the default. Becomes a real regression once call-site migrations land (LIVE-30412 / LIVE-30964).

**What**: single source of truth per app — `firebase/remoteConfig.ts` exporting `fetchRemoteFlags`, `subscribeToRemoteFlags`, `whenReady` (+ `getRemoteConfigSingleton` on LWD). The middleware drives the only polling loop; legacy providers subscribe to the module rather than running their own fetch.

> ⚠️ **The pub/sub bridge (`subscribeToRemoteFlags` + `whenReady` + the singleton accessor) is temporary.** It only exists so the legacy `<FirebaseRemoteConfigProvider>` (LWD) and `firebaseRemoteConfigApi` / `useFirebaseRemoteConfig` (LWM) can keep working while we still depend on them. The bridge — along with the legacy providers themselves — gets deleted by LIVE-31228 (LWD) and LIVE-30413 (LWM). After that, only `fetchRemoteFlags` remains, consumed solely by the middleware.

**LWD changes**
- NEW `apps/ledger-live-desktop/src/firebase/remoteConfig.ts`
- `state-manager/configureStore.ts` wires `fetchRemoteFlags`
- `renderer/components/FirebaseRemoteConfig.tsx` rewritten — removed in-effect `initializeApp`/`getRemoteConfig`/settings/`fetchAndActivate`/`setInterval`. Subscribes via `subscribeToRemoteFlags`, gates `loaded` on `whenReady`. `LiveConfig.setProvider` and dev-only `warnOnConfigMismatch` preserved (owned by LIVE-31228).

**LWM changes**
- NEW `apps/ledger-live-mobile/src/firebase/remoteConfig.ts` (cached `setupPromise` for `setConfigSettings` + `setDefaults`)
- `state-manager/configureStore.ts` wires `fetchRemoteFlags`
- `mvvm/api/firebaseRemoteConfigApi.ts` — `init` mutation body becomes `await whenReady()`; removed local setup + `fetchAndActivate` query
- `mvvm/hooks/useFirebaseRemoteConfig.ts` — dropped `useFetchAndActivateQuery`; still installs `LiveConfig.setProvider`. RTK Query surface intact, so `InitialQueriesContext` / `WaitForAppReady` keep working unchanged.

**Out of scope** (deferred to dependent tickets)
- `remoteFlagsReady` Redux signal — LIVE-30413 Phase A
- Drop `<FirebaseFeatureFlagsProvider>` / `<FirebaseRemoteConfigProvider>` entirely (and remove the pub/sub bridge in this PR) — LIVE-31228 (LWD), LIVE-30413 (LWM)
- `LiveConfig.setProvider` decision — LIVE-31228
- Remove `firebaseRemoteConfigApi` + `useFirebaseRemoteConfig` — LIVE-30413 Phase B
- Call-site migration to slice-based hook — LIVE-30412 (LWD), LIVE-30964 (LWM)
- `DEFAULT_FEATURES` → `FEATURE_FLAGS_DEFAULTS` rename — LIVE-30412 Phase 6

**Smoke test**: both apps confirmed end-to-end — 320 `feature_*` flags fetched, parsed, and dispatched within ~1s of boot (LWM measured at ~440ms).

### ❓ Context

- **JIRA**: [LIVE-31275](https://ledgerhq.atlassian.net/browse/LIVE-31275)
- Blocks: LIVE-31228, LIVE-30413, LIVE-30412, LIVE-30964
- Epic: LIVE-30799 (Monorepo Architecture)

[LIVE-31275]: https://ledgerhq.atlassian.net/browse/LIVE-31275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ