### PR TITLE
[LWDM] refactor(desktop,mobile): add Suspense boundaries for bridge hooks

### DIFF
--- a/.changeset/bridge-suspense-boundaries.md
+++ b/.changeset/bridge-suspense-boundaries.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Add Suspense boundaries around call sites of useAccountBridge/useCurrencyBridge

--- a/apps/ledger-live-desktop/src/mvvm/features/GlobalDialogs/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GlobalDialogs/index.tsx
@@ -6,7 +6,9 @@ import ActionConfirmationDialog from "LLD/features/ActionConfirmationDialog";
 
 const ReleaseNotes = lazy(() => import("LLD/features/ReleaseNotes"));
 const BuyDevice = lazy(() => import("LLD/features/BuyDevice"));
-const FinishOnboardingDialog = lazy(() => import("LLD/features/FinishOnboarding/FinishOnboardingDialog"));
+const FinishOnboardingDialog = lazy(
+  () => import("LLD/features/FinishOnboarding/FinishOnboardingDialog"),
+);
 const PtxInfoDialog = lazy(() => import("LLD/features/PtxInfoDialog"));
 const LiveAppModal = lazy(() => import("LLD/features/LiveAppModal"));
 const GenericAwarenessModal = lazy(() => import("LLD/features/GenericAwarenessModal"));
@@ -15,7 +17,9 @@ const GenericAwarenessModal = lazy(() => import("LLD/features/GenericAwarenessMo
 const GlobalDialogs = () => (
   <>
     <ModularDialogRoot />
-    <SendFlowRoot />
+    <Suspense fallback={null}>
+      <SendFlowRoot />
+    </Suspense>
     <PerpsSignRoot />
     <ActionConfirmationDialog />
     <Suspense fallback={null}>

--- a/apps/ledger-live-desktop/src/renderer/ModalsLayer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/ModalsLayer.tsx
@@ -60,7 +60,7 @@ const ModalsLayer = ({ modalsState }: { modalsState: ModalsState }) => {
     >
       {state => (
         <BackDrop ref={nodeRef} state={state}>
-          {first || null}
+          <React.Suspense fallback={null}>{first || null}</React.Suspense>
         </BackDrop>
       )}
     </Transition>

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/steps/StepValidator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/steps/StepValidator.tsx
@@ -94,8 +94,9 @@ const StepValidator = ({
   const onBakerClick = useCallback(
     (baker: Baker) => {
       if (!transaction) return;
+      const tx = transaction;
       onChangeTransaction(
-        bridge.updateTransaction(transaction, {
+        bridge.updateTransaction(tx, {
           recipient: baker.address,
         }),
       );

--- a/apps/ledger-live-mobile/src/components/RootNavigator/FreezeNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/FreezeNavigator.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "~/context/Locale";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTheme } from "styled-components/native";
 import { ScreenName } from "~/const";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import Info from "~/screens/FreezeFunds/01-Info";
 import Amount from "~/screens/FreezeFunds/02-Amount";
 import SelectDevice from "~/screens/SelectDevice";
@@ -21,7 +21,7 @@ export default function FreezeNavigator() {
   const { t } = useTranslation();
   const stackNavConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
-    <Stack.Navigator screenOptions={stackNavConfig}>
+    <Stack.Navigator screenOptions={stackNavConfig} screenLayout={bridgeSuspenseScreenLayout}>
       <Stack.Screen
         name={ScreenName.FreezeInfo}
         component={Info}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SendFundsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SendFundsNavigator.tsx
@@ -13,7 +13,7 @@ import SendConnectDevice from "~/screens/ConnectDevice";
 import SendValidationSuccess from "~/screens/SendFunds/07-ValidationSuccess";
 import SendBroadcastError from "~/screens/SendFunds/07-SendBroadcastError";
 import SendValidationError from "~/screens/SendFunds/07-ValidationError";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import StepHeader from "../StepHeader";
 import type { SendFundsNavigatorStackParamList } from "./types/SendFundsNavigator";
 import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
@@ -30,7 +30,10 @@ export default function SendFundsNavigator() {
 
   return (
     <DomainServiceProvider>
-      <Stack.Navigator screenOptions={stackNavigationConfig}>
+      <Stack.Navigator
+        screenOptions={stackNavigationConfig}
+        screenLayout={bridgeSuspenseScreenLayout}
+      >
         <Stack.Screen
           name={ScreenName.SendCoin}
           component={SendCoin}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SignTransactionNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SignTransactionNavigator.tsx
@@ -8,7 +8,7 @@ import SignTransactionSummary from "~/screens/SendFunds/04-Summary";
 import SelectDevice from "~/screens/SelectDevice";
 import SignTransactionConnectDevice from "~/screens/SignTransaction/02-ConnectDevice";
 import SignTransactionValidationError from "~/screens/SignTransaction/03-ValidationError";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import StepHeader from "../StepHeader";
 import { SignTransactionNavigatorParamList } from "./types/SignTransactionNavigator";
 
@@ -22,7 +22,10 @@ export default function SignTransactionNavigator() {
 
   return (
     <DomainServiceProvider>
-      <Stack.Navigator screenOptions={stackNavigationConfig}>
+      <Stack.Navigator
+        screenOptions={stackNavigationConfig}
+        screenLayout={bridgeSuspenseScreenLayout}
+      >
         <Stack.Screen
           name={ScreenName.SignTransactionSummary}
           component={SignTransactionSummary}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/UnfreezeNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/UnfreezeNavigator.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "~/context/Locale";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTheme } from "styled-components/native";
 import { ScreenName } from "~/const";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import Amount from "~/screens/UnfreezeFunds/01-Amount";
 import SelectDevice from "~/screens/SelectDevice";
 import ConnectDevice from "~/screens/ConnectDevice";
@@ -18,7 +18,10 @@ export default function UnfreezeNavigator() {
   const { colors } = useTheme();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
-    <Stack.Navigator screenOptions={stackNavigationConfig}>
+    <Stack.Navigator
+      screenOptions={stackNavigationConfig}
+      screenLayout={bridgeSuspenseScreenLayout}
+    >
       <Stack.Screen
         name={ScreenName.UnfreezeAmount}
         component={Amount}

--- a/apps/ledger-live-mobile/src/families/algorand/Rewards/ClaimRewardsFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/algorand/Rewards/ClaimRewardsFlow/index.tsx
@@ -6,6 +6,7 @@ import { useTheme } from "@react-navigation/native";
 import {
   getStackNavigatorConfig,
   defaultNavigationOptions,
+  bridgeSuspenseScreenLayout,
 } from "../../../../navigation/navigatorConfig";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
@@ -30,6 +31,7 @@ function ClaimRewardsFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.AlgorandClaimRewardsStarted}

--- a/apps/ledger-live-mobile/src/families/celo/RegistrationFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/RegistrationFlow/index.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "~/context/Locale";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTheme } from "@react-navigation/native";
 import { ScreenName } from "~/const";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import StepHeader from "~/components/StepHeader";
 
 import RegisterAccountStarted from "./01-Started";
@@ -24,7 +24,7 @@ function RegisterAccountFlow() {
   const stackNavigatorConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
 
   return (
-    <Stack.Navigator screenOptions={stackNavigatorConfig}>
+    <Stack.Navigator screenOptions={stackNavigatorConfig} screenLayout={bridgeSuspenseScreenLayout}>
       <Stack.Screen
         name={ScreenName.CeloRegistrationStarted}
         component={RegisterAccountStarted}

--- a/apps/ledger-live-mobile/src/families/celo/RevokeFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/RevokeFlow/index.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "~/context/Locale";
 import { Platform } from "react-native";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import ConnectDevice from "~/screens/ConnectDevice";
 import SelectDevice from "~/screens/SelectDevice";
 import VoteAmount from "./VoteAmount";
@@ -29,6 +29,7 @@ function RevokeFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.CeloRevokeSummary}

--- a/apps/ledger-live-mobile/src/families/celo/UnlockFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/UnlockFlow/index.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "~/context/Locale";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTheme } from "@react-navigation/native";
 import { ScreenName } from "~/const";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import StepHeader from "~/components/StepHeader";
 
 import UnlockAmount from "./01-Amount";
@@ -24,7 +24,7 @@ function UnlockFlow() {
   const stackNavigatorConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
 
   return (
-    <Stack.Navigator screenOptions={stackNavigatorConfig}>
+    <Stack.Navigator screenOptions={stackNavigatorConfig} screenLayout={bridgeSuspenseScreenLayout}>
       <Stack.Screen
         name={ScreenName.CeloUnlockAmount}
         component={UnlockAmount}

--- a/apps/ledger-live-mobile/src/families/celo/VoteFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/VoteFlow/index.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "~/context/Locale";
 import { Platform } from "react-native";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import ConnectDevice from "~/screens/ConnectDevice";
 import SelectDevice from "~/screens/SelectDevice";
 import VoteAmount from "./VoteAmount";
@@ -30,6 +30,7 @@ function VoteFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.CeloVoteStarted}

--- a/apps/ledger-live-mobile/src/families/celo/WithdrawFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/WithdrawFlow/index.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "~/context/Locale";
 import { Platform } from "react-native";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import ConnectDevice from "~/screens/ConnectDevice";
 import SelectDevice from "~/screens/SelectDevice";
 import WithdrawAmount from "./WithdrawAmount";
@@ -27,6 +27,7 @@ function WithdrawFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.CeloWithdrawAmount}

--- a/apps/ledger-live-mobile/src/families/cosmos/ClaimRewardsFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/ClaimRewardsFlow/index.tsx
@@ -3,7 +3,11 @@ import { Platform } from "react-native";
 import { useTranslation } from "~/context/Locale";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTheme } from "@react-navigation/native";
-import { getStackNavigatorConfig, defaultNavigationOptions } from "~/navigation/navigatorConfig";
+import {
+  getStackNavigatorConfig,
+  defaultNavigationOptions,
+  bridgeSuspenseScreenLayout,
+} from "~/navigation/navigatorConfig";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
 import ClaimRewardsSelectValidator from "./01-SelectValidator";
@@ -29,6 +33,7 @@ function ClaimRewardsFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.CosmosClaimRewardsValidator}

--- a/apps/ledger-live-mobile/src/families/cosmos/DelegationFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/DelegationFlow/index.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "~/context/Locale";
 import { Platform } from "react-native";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import ConnectDevice from "~/screens/ConnectDevice";
 import SelectDevice from "~/screens/SelectDevice";
 import DelegationAmount from "../shared/02-SelectAmount";
@@ -30,6 +30,7 @@ function DelegationFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.CosmosDelegationStarted}

--- a/apps/ledger-live-mobile/src/families/cosmos/RedelegationFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/RedelegationFlow/index.tsx
@@ -3,7 +3,11 @@ import { Platform } from "react-native";
 import { useTranslation } from "~/context/Locale";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTheme } from "@react-navigation/native";
-import { getStackNavigatorConfig, defaultNavigationOptions } from "~/navigation/navigatorConfig";
+import {
+  getStackNavigatorConfig,
+  defaultNavigationOptions,
+  bridgeSuspenseScreenLayout,
+} from "~/navigation/navigatorConfig";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
 import RedelegationSelectValidator from "./01-SelectValidator";
@@ -29,6 +33,7 @@ function RedelegationFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.CosmosRedelegationValidator}

--- a/apps/ledger-live-mobile/src/families/cosmos/UndelegationFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/UndelegationFlow/index.tsx
@@ -3,7 +3,7 @@ import { Platform } from "react-native";
 import { useTranslation } from "~/context/Locale";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTheme } from "@react-navigation/native";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
 import UndelegationAmount from "./01-Amount";
@@ -28,6 +28,7 @@ function UndelegationFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.CosmosUndelegationAmount}

--- a/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/index.tsx
@@ -12,7 +12,7 @@ import type { HederaAssociateTokenFlowParamList } from "./types";
 import { NavigationHeaderBackButton } from "~/components/NavigationHeaderBackButton";
 import { NavigationHeaderCloseButtonAdvanced } from "~/components/NavigationHeaderCloseButton";
 import { ScreenName } from "~/const";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import SelectDevice from "~/screens/SelectDevice";
 import ConnectDevice from "~/screens/ConnectDevice";
 
@@ -27,6 +27,7 @@ function AssociateTokenFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.HederaAssociateTokenSelectToken}

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Claim/Claim.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Claim/Claim.tsx
@@ -7,7 +7,7 @@ import { useTheme } from "@react-navigation/native";
 import StepHeader from "~/components/StepHeader";
 import ClaimRewardsSelectDevice from "~/screens/SelectDevice";
 import ClaimRewardsConnectDevice from "~/screens/ConnectDevice";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import styles from "~/navigation/styles";
 import { ScreenName } from "~/const";
 
@@ -46,6 +46,7 @@ const Claim = () => {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.MultiversXClaimRewardsValidator}

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Delegate/Delegate.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Delegate/Delegate.tsx
@@ -5,7 +5,7 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTheme } from "@react-navigation/native";
 
 import StepHeader from "~/components/StepHeader";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import { ScreenName } from "~/const";
 
 import EarnRewards from "./components/EarnRewards";
@@ -49,6 +49,7 @@ const Delegate = () => {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.MultiversXDelegationStarted}

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Undelegate/Undelegate.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Undelegate/Undelegate.tsx
@@ -5,7 +5,7 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTheme } from "@react-navigation/native";
 
 import StepHeader from "~/components/StepHeader";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import { ScreenName } from "~/const";
 
 import PickAmount from "./components/PickAmount";
@@ -45,6 +45,7 @@ const Undelegate = () => {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.MultiversXUndelegationAmount}

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Withdraw/Withdraw.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Withdraw/Withdraw.tsx
@@ -8,7 +8,7 @@ import StepHeader from "~/components/StepHeader";
 import WithdrawSelectDevice from "~/screens/SelectDevice";
 import WithdrawConnectDevice from "~/screens/ConnectDevice";
 
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import { ScreenName } from "~/const";
 
 import WithdrawFunds from "./components/WithdrawFunds";
@@ -45,6 +45,7 @@ const Withdraw = () => {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.MultiversXWithdrawFunds}

--- a/apps/ledger-live-mobile/src/families/near/StakingFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/near/StakingFlow/index.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "~/context/Locale";
 import { Platform } from "react-native";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import ConnectDevice from "~/screens/ConnectDevice";
 import SelectDevice from "~/screens/SelectDevice";
 import StakingAmount from "../shared/02-SelectAmount";
@@ -31,6 +31,7 @@ function StakingFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.NearStakingStarted}

--- a/apps/ledger-live-mobile/src/families/near/UnstakingFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/near/UnstakingFlow/index.tsx
@@ -3,7 +3,7 @@ import { Platform } from "react-native";
 import { useTranslation } from "~/context/Locale";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTheme } from "@react-navigation/native";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
 import UnstakingAmount from "./01-Amount";
@@ -27,6 +27,7 @@ function UnstakingFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.NearUnstakingAmount}

--- a/apps/ledger-live-mobile/src/families/near/WithdrawingFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/near/WithdrawingFlow/index.tsx
@@ -3,7 +3,7 @@ import { Platform } from "react-native";
 import { useTranslation } from "~/context/Locale";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTheme } from "@react-navigation/native";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
 import WithdrawingAmount from "./01-Amount";
@@ -27,6 +27,7 @@ function WithdrawingFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.NearWithdrawingAmount}

--- a/apps/ledger-live-mobile/src/families/solana/DelegationFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/DelegationFlow/index.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "~/context/Locale";
 import { Platform } from "react-native";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import DelegationConnectDevice from "~/screens/ConnectDevice";
 import DelegationSelectDevice from "~/screens/SelectDevice";
 import DelegationSelectValidator from "./SelectValidator";
@@ -30,6 +30,7 @@ function DelegationFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.SolanaDelegationStarted}

--- a/apps/ledger-live-mobile/src/families/stellar/AddAssetFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/stellar/AddAssetFlow/index.tsx
@@ -3,7 +3,7 @@ import { Platform } from "react-native";
 import { useTranslation } from "~/context/Locale";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTheme } from "@react-navigation/native";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import styles from "~/navigation/styles";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
@@ -25,6 +25,7 @@ function AddAssetFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.StellarAddAssetSelectAsset}

--- a/apps/ledger-live-mobile/src/families/sui/UnstakingFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/sui/UnstakingFlow/index.tsx
@@ -3,7 +3,7 @@ import { Platform } from "react-native";
 import { useTranslation } from "~/context/Locale";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTheme } from "@react-navigation/native";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
 import UnstakingAmount from "./01-Amount";
@@ -27,6 +27,7 @@ function UnstakingFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.SuiUnstakingAmount}

--- a/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/index.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "~/context/Locale";
 import { useTheme } from "@react-navigation/native";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import DelegationStarted from "./Started";
 import DelegationSummary from "./Summary";
 import DelegationSelectValidator from "./SelectValidator";
@@ -29,6 +29,7 @@ function DelegationFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.DelegationStarted}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/index.tsx
@@ -80,12 +80,14 @@ export default function SendWorkflow() {
 
   return (
     <DomainServiceProvider>
-      <SendFlowOrchestrator
-        initParams={initParams}
-        onClose={handleClose}
-        stepRegistry={stepRegistry}
-        flowConfig={SEND_FLOW_CONFIG}
-      />
+      <React.Suspense fallback={null}>
+        <SendFlowOrchestrator
+          initParams={initParams}
+          onClose={handleClose}
+          stepRegistry={stepRegistry}
+          flowConfig={SEND_FLOW_CONFIG}
+        />
+      </React.Suspense>
     </DomainServiceProvider>
   );
 }

--- a/apps/ledger-live-mobile/src/navigation/navigatorConfig.tsx
+++ b/apps/ledger-live-mobile/src/navigation/navigatorConfig.tsx
@@ -22,6 +22,12 @@ export const defaultNavigationOptions: Partial<NativeStackNavigationOptions> = {
 type ColorV2 = Theme["colors"];
 type ColorV3 = DefaultTheme["colors"];
 
+export const bridgeSuspenseScreenLayout = ({
+  children,
+}: {
+  children: React.ReactElement;
+}): React.ReactElement => <React.Suspense fallback={null}>{children}</React.Suspense>;
+
 export const getStackNavigatorConfig = (
   c: ColorV2 | ColorV3,
   closable = false,

--- a/apps/ledger-live-mobile/src/screens/Account/ListHeaderComponent.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/ListHeaderComponent.tsx
@@ -235,7 +235,11 @@ export function useListHeaderComponents({
           ]
         : []),
       ...(!empty && AccountBodyHeaderRendered
-        ? [<SectionContainer key="AccountBody">{AccountBodyHeaderRendered}</SectionContainer>]
+        ? [
+            <SectionContainer key="AccountBody">
+              <React.Suspense fallback={null}>{AccountBodyHeaderRendered}</React.Suspense>
+            </SectionContainer>,
+          ]
         : []),
       ...(!empty && account.type === "Account" && account.subAccounts
         ? [


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Wraps bridge-driven flows (Send / Sign / Freeze / Unfreeze and family stake/claim/delegate flows, desktop modals, account header) with <Suspense fallback={null}> so the tree is ready when useAccountBridge / useCurrencyBridge start suspending. No visible UX change.

### 📝 Description

Adds <Suspense fallback={null}> around every call site of useAccountBridge / useCurrencyBridge so that once getAccountBridge / getCurrencyBridge become async (and the hooks suspend via React use()), the ancestor tree is ready.

- Desktop: ModalsLayer, SendFlowRoot (GlobalDialogs), tezos delegate validator step.
- Mobile: bridge-driven flow navigators via bridgeSuspenseScreenLayout (Send / Sign / Freeze / Unfreeze and family stake/claim/delegate flows), MVVM Send entry, account header.

fallback={null} — bridge load is fast enough, no visible UX change.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31267](https://ledgerhq.atlassian.net/browse/LIVE-31267)
- **ADR link (if any)**: N/A

[LIVE-31267]: https://ledgerhq.atlassian.net/browse/LIVE-31267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ