### PR TITLE
[LWDM] fix: total spent formatting after fee currency account support in sen…

### DIFF
--- a/.changeset/hungry-rice-dance.md
+++ b/.changeset/hungry-rice-dance.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@ledgerhq/coin-evm": minor
+---
+
+Fix: Send Summary “total spent” display with fee-currency accounts; restore EVM tx token fields (assetReference/assetOwner) during raw deserialization for edit flow.

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepSummary.tsx
@@ -349,7 +349,7 @@ const StepSummary = (props: StepProps) => {
           />
         )}
 
-        {!totalSpent.eq(amount) ? (
+        {feesCurrency.id === currency.id && !totalSpent.eq(amount) ? (
           <>
             <Separator />
             <Box horizontal justifyContent="space-between">

--- a/libs/coin-modules/coin-evm/src/transaction.test.ts
+++ b/libs/coin-modules/coin-evm/src/transaction.test.ts
@@ -110,6 +110,57 @@ describe("EVM Family", () => {
           });
         });
       });
+
+      describe("with token fields (assetReference / assetOwner)", () => {
+        const CONTRACT = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+        const OWNER = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+
+        it("should deserialize both assetReference and assetOwner when present", () => {
+          expect(
+            fromTransactionRaw({ ...rawEip1559Tx, assetReference: CONTRACT, assetOwner: OWNER }),
+          ).toEqual({ ...eip1559Tx, assetReference: CONTRACT, assetOwner: OWNER });
+        });
+
+        it("should deserialize only assetReference when assetOwner is absent", () => {
+          expect(fromTransactionRaw({ ...rawEip1559Tx, assetReference: CONTRACT })).toEqual({
+            ...eip1559Tx,
+            assetReference: CONTRACT,
+          });
+        });
+
+        it("should deserialize only assetOwner when assetReference is absent", () => {
+          expect(fromTransactionRaw({ ...rawEip1559Tx, assetOwner: OWNER })).toEqual({
+            ...eip1559Tx,
+            assetOwner: OWNER,
+          });
+        });
+
+        it("should not set assetReference when absent from raw", () => {
+          expect(fromTransactionRaw(rawEip1559Tx)).not.toHaveProperty("assetReference");
+        });
+
+        it("should not set assetOwner when absent from raw", () => {
+          expect(fromTransactionRaw(rawEip1559Tx)).not.toHaveProperty("assetOwner");
+        });
+
+        it("should not set assetReference when raw value is an empty string", () => {
+          expect(
+            fromTransactionRaw({ ...rawEip1559Tx, assetReference: "" } as any),
+          ).not.toHaveProperty("assetReference");
+        });
+
+        it("should not set assetOwner when raw value is an empty string", () => {
+          expect(fromTransactionRaw({ ...rawEip1559Tx, assetOwner: "" } as any)).not.toHaveProperty(
+            "assetOwner",
+          );
+        });
+
+        it("should deserialize both fields on a legacy transaction", () => {
+          expect(
+            fromTransactionRaw({ ...rawLegacyTx, assetReference: CONTRACT, assetOwner: OWNER }),
+          ).toEqual({ ...legacyTx, assetReference: CONTRACT, assetOwner: OWNER });
+        });
+      });
     });
 
     describe("toTransaction", () => {

--- a/libs/coin-modules/coin-evm/src/transaction.ts
+++ b/libs/coin-modules/coin-evm/src/transaction.ts
@@ -94,6 +94,17 @@ export const fromTransactionRaw = (rawTx: EvmTransactionRaw): EvmTransaction => 
     type: rawTx.type ?? 0, // if rawTx.type is undefined, transaction will be considered legacy and therefore type 0
   };
 
+  // Restore assetReference and assetOwner when present in the raw.
+  // These fields can be present in the transactionRaw produced by `toGenericTransactionRaw`
+  // (used in buildOptimisticOperation), so we map them back to the transaction here to
+  // support the edit-transaction flow on previously-broadcast token operations.
+  if (rawTx.assetReference) {
+    (tx as Record<string, unknown>).assetReference = rawTx.assetReference;
+  }
+  if (rawTx.assetOwner) {
+    (tx as Record<string, unknown>).assetOwner = rawTx.assetOwner;
+  }
+
   if (rawTx.data) {
     tx.data = Buffer.from(rawTx.data, "hex");
   }

--- a/libs/coin-modules/coin-evm/src/types/transaction.ts
+++ b/libs/coin-modules/coin-evm/src/types/transaction.ts
@@ -81,6 +81,8 @@ type EvmTransactionBaseRaw = TransactionCommonRaw & {
   nonce: number;
   gasLimit: string;
   customGasLimit?: string | undefined;
+  assetReference?: string | null | undefined;
+  assetOwner?: string | null | undefined;
   chainId: number;
   data?: string | null | undefined;
   type?: number | undefined;


### PR DESCRIPTION
…d summary

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

The Send summary shows a Total spent row when totalSpent !== amount (typically native sends where the total includes amount + fees).

After fee currency support, feesUnit comes from feeCurrencyAccount ?? mainAccount, which can differ from the sending account's unit. The FormattedVal for total spent picks between those units based on whether estimatedFees equals totalSpent:

Before: feesUnit when equal, unit when not
After: unit when equal, feesUnit when not


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:  [LIVE-31273](https://ledgerhq.atlassian.net/browse/LIVE-31273)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31273]: https://ledgerhq.atlassian.net/browse/LIVE-31273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ