### PR TITLE
[LWM] fix(mobile): exit cleanly when back is pressed at navigation root on android

### DIFF
--- a/.changeset/clean-back-exit.md
+++ b/.changeset/clean-back-exit.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix android crash when spamming hardware back button after opening from google play store

--- a/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
+++ b/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
@@ -16,6 +16,7 @@ import Braze from "@braze/react-native-sdk";
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import { hasCompletedOnboardingSelector } from "~/reducers/settings";
 import { navigationRef, isReadyRef } from "../rootnavigation";
+import { useAndroidBackExit } from "./useAndroidBackExit";
 import { ScreenName, NavigatorName } from "~/const";
 import { setWallectConnectUri } from "~/actions/walletconnect";
 import { useGeneralTermsAccepted } from "~/logic/terms";
@@ -951,6 +952,8 @@ export const DeeplinksProvider = ({
     },
     [],
   );
+
+  useAndroidBackExit(isNavigationContainerReady);
 
   return (
     <View style={styles.appBackground}>

--- a/apps/ledger-live-mobile/src/navigation/useAndroidBackExit.ts
+++ b/apps/ledger-live-mobile/src/navigation/useAndroidBackExit.ts
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+import { BackHandler, Platform } from "react-native";
+import { navigationRef } from "../rootnavigation";
+
+/**
+ * If the user reaches the root screen
+ * (nothing left in the RN stack) and spams the hardware back button, React Navigation
+ * returns `false`, Android takes over, and the rapid activity lifecycle transitions
+ * are reported as a crash. This hook intercepts that case and exits cleanly instead.
+ */
+export function useAndroidBackExit(isNavigationReady: boolean) {
+  useEffect(() => {
+    if (!isNavigationReady || Platform.OS !== "android") return;
+    const sub = BackHandler.addEventListener("hardwareBackPress", () => {
+      if (!navigationRef.current?.canGoBack()) {
+        BackHandler.exitApp();
+        return true;
+      }
+      return false;
+    });
+    return () => sub.remove();
+  }, [isNavigationReady]);
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _This is a native Android back stack edge case only reproducible by opening from the Play Store and spamming back — not easily unit-testable at the JS layer._
- [x] **Impact of the changes:**
  - Android hardware back button behaviour when at the navigation root (wallet screen)
  - Only affects users on 3-button navigation who open the app from the Google Play Store
  - No change to normal in-app back navigation

### 📝 Description

When the app is launched from the Google Play Store, an extra activity sits behind `MainActivity` on the native Android back stack. If the user reaches the wallet screen (nothing left in the React Navigation stack) and spams the hardware back button, React Navigation's internal handler returns `false`, Android takes over, and the rapid activity lifecycle transitions are reported as a crash.

The fix adds a `useAndroidBackExit` hook that intercepts the `hardwareBackPress` event at the navigation root level. When `canGoBack()` is false it calls `BackHandler.exitApp()` and returns `true`, so the app always exits cleanly instead of deferring to the OS activity stack. Normal in-app back navigation is unaffected (`return false` passes the event to React Navigation's own handler).

The hook is registered after `NavigationContainer` is ready and before any screen-level `BackHandler` listeners, so LIFO ordering ensures screen-specific handlers (webviews, modals, onboarding) always take priority.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27243](https://ledgerhq.atlassian.net/browse/LIVE-27243)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27243]: https://ledgerhq.atlassian.net/browse/LIVE-27243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ