### PR TITLE
[LWDM] chore(live-common): async-prep useBridgeTransaction for getAccountBridge

### DIFF
--- a/.changeset/async-prep-use-bridge-transaction.md
+++ b/.changeset/async-prep-use-bridge-transaction.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+async prep useBridgeTransaction — wrap the pre-tx sync path with `from(Promise.resolve(getAccountBridge(...)))` so the hook stays compatible when `getAccountBridge` becomes async

--- a/libs/ledger-live-common/src/bridge/useBridgeTransaction.ts
+++ b/libs/ledger-live-common/src/bridge/useBridgeTransaction.ts
@@ -1,5 +1,6 @@
 import { BigNumber } from "bignumber.js";
 import { useEffect, useReducer, useCallback, useRef } from "react";
+import { from, switchMap } from "rxjs";
 import { log } from "@ledgerhq/logs";
 import { getAccountBridge } from ".";
 import { getMainAccount } from "../account";
@@ -300,16 +301,13 @@ const useBridgeTransaction = <T extends Transaction = Transaction>(
     if (!shouldSync) return; // skip sync if not required by currency config
 
     dispatch({ type: "onStartSync" });
-    const bridge = getAccountBridge(mainAccount, null);
-    const sub = bridge.sync(mainAccount, { paginationConfig: {} }).subscribe({
-      error: (_: Error) => {
+    const sub = from(Promise.resolve(getAccountBridge(mainAccount, null)))
+      .pipe(switchMap(bridge => bridge.sync(mainAccount, { paginationConfig: {} })))
+      .subscribe({
         // we do not block the user in case of error for now but it should be the case
-        dispatch({ type: "onSync" });
-      },
-      complete: () => {
-        dispatch({ type: "onSync" });
-      },
-    });
+        error: (_: Error) => dispatch({ type: "onSync" }),
+        complete: () => dispatch({ type: "onSync" }),
+      });
 
     return () => {
       sub.unsubscribe();


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Existing `useBridgeTransaction.test.ts` already `await`s `getAccountBridge`, exercising the future-async path.
- [ ] **Impact of the changes:**
  - Send flow pre-tx sync (currencies with `syncBeforeTx`, e.g. Bitcoin) — verify sync still runs and unblocks the bridge.

### Description

Prepare `useBridgeTransaction` for the upcoming async `getAccountBridge` (shipped in #17760). The pre-tx sync was the only call site still relying on synchronous bridge resolution; wrap it with the documented RxJS pattern from `libs/ledger-live-common/src/bridge/impl.ts`:

```diff
-const bridge = getAccountBridge(mainAccount, null);
-const sub = bridge.sync(mainAccount, { paginationConfig: {} }).subscribe({...});
+const sub = from(Promise.resolve(getAccountBridge(mainAccount, null)))
+  .pipe(switchMap(bridge => bridge.sync(mainAccount, { paginationConfig: {} })))
+  .subscribe({...});
```

The other two call sites (`setAccount` via `await`, second `useEffect` via a `.then()` chain) are already async-compatible.

### Context

- **JIRA or GitHub link**: companion to #17760
- **ADR link (if any)**: n/a