### PR TITLE
ci: switch e2e & push job pools

### DIFF
--- a/.github/workflows/build-and-test-push.yml
+++ b/.github/workflows/build-and-test-push.yml
@@ -34,9 +34,9 @@ jobs:
     uses: LedgerHQ/ledger-live/.github/workflows/test-mobile-mock-reusable.yml@develop
     secrets: inherit
     with:
-      macos-specificity-runner-label: "performance-pool"
+      macos-specificity-runner-label: "general-pool"
       skip-bundle-size-reporting: true
-      max-shards: 1
+      max-shards: 2
       skip-pod-checks: "true"
 
   # Tests

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -459,7 +459,7 @@ jobs:
     name: iOS E2E Tests (${{ matrix.shard }}, ${{ matrix.total }})
     needs: [build-ios, determine-builds]
     if: ${{ inputs.tests_type != 'Android Only' && needs.determine-builds.outputs.test_files_for_sharding != '' }}
-    runs-on: ["qaa", macOS, ARM64]
+    runs-on: ["qaa", macOS, ARM64, "performance-pool"]
     env:
       NODE_OPTIONS: "--max-old-space-size=8192"
       LANG: en_US.UTF-8


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Study: Move e2e tests to the performance pool and push testing to the general-pool, while increasing shard count

Aim: Reduce flakes & increase speed caused by e2e tests being scheduled according to run times, without a stable base for comparison. Reduce overall macOS usage


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
