### PR TITLE
[LWM] defer pending operation update until after navigation

### DIFF
--- a/.changeset/nasty-suns-applaud.md
+++ b/.changeset/nasty-suns-applaud.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": patch
+"ledger-live-mobile-e2e-tests": patch
+---
+
+Defer pending operation account updates until after broadcast success navigation transitions complete

--- a/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
+++ b/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
@@ -48,6 +48,7 @@ import type { AlgorandClaimRewardsFlowParamList } from "~/families/algorand/Rewa
 import type { StellarAddAssetFlowParamList } from "~/families/stellar/AddAssetFlow/types";
 import { mevProtectionSelector } from "~/reducers/settings";
 import { useNewSendFlowFeature } from "LLM/features/Send/hooks/useNewSendFlowFeature";
+import type { AppDispatch } from "~/state-manager/configureStore";
 
 type Navigation =
   | StackNavigatorNavigation<SendFundsNavigatorStackParamList, ScreenName.SendSummary>
@@ -65,6 +66,60 @@ type Route =
   | StackNavigatorRoute<SignTransactionNavigatorParamList, ScreenName.SignTransactionSummary>
   | StackNavigatorRoute<AlgorandClaimRewardsFlowParamList, ScreenName.AlgorandClaimRewardsSummary>
   | StackNavigatorRoute<StellarAddAssetFlowParamList, ScreenName.StellarAddAssetValidation>;
+
+const completeSignBroadcast = ({
+  navigation,
+  context,
+  routeParams,
+  mainAccount,
+  operation,
+  updateAccountWithUpdater,
+}: {
+  navigation: NativeStackNavigationProp<{ [key: string]: object }>;
+  context: string;
+  routeParams: Route["params"];
+  mainAccount: Account;
+  operation: Operation;
+  updateAccountWithUpdater: (accountId: string, updater: (account: Account) => Account) => void;
+}): void => {
+  formatOperation(mainAccount).then(fmt =>
+    log("transaction-summary", `✔️ broadcasted! optimistic operation: ${fmt(operation)}`),
+  );
+  navigation.replace(context + "ValidationSuccess", {
+    ...routeParams,
+    result: operation,
+  });
+  InteractionManager.runAfterInteractions(() => {
+    updateAccountWithUpdater(mainAccount.id, account => addPendingOperation(account, operation));
+  });
+};
+
+const completeSignedTxBroadcast = ({
+  navigation,
+  route,
+  mainAccount,
+  operation,
+  dispatch,
+}: {
+  navigation: NativeStackNavigationProp<{ [key: string]: object }>;
+  route: { name: string; params?: object };
+  mainAccount: Account;
+  operation: Operation;
+  dispatch: AppDispatch;
+}): void => {
+  navigation.replace(route.name.replace("ConnectDevice", "ValidationSuccess"), {
+    ...route.params,
+    result: operation,
+  });
+  InteractionManager.runAfterInteractions(() => {
+    dispatch(
+      updateAccountWithUpdater({
+        accountId: mainAccount.id,
+        updater: account => addPendingOperation(account, operation),
+      }),
+    );
+  });
+};
 
 export const useTransactionChangeFromNavigation = (setTransaction: (_: Transaction) => void) => {
   const route = useRoute<Route>();
@@ -157,24 +212,14 @@ export const useSignWithDevice = ({
               break;
 
             case "broadcasted":
-              formatOperation(mainAccount).then(fmt =>
-                log(
-                  "transaction-summary",
-                  `✔️ broadcasted! optimistic operation: ${fmt(e.operation)}`,
-                ),
-              );
-              (navigation as NativeStackNavigationProp<{ [key: string]: object }>).replace(
-                context + "ValidationSuccess",
-                {
-                  ...route.params,
-                  result: e.operation,
-                },
-              );
-              InteractionManager.runAfterInteractions(() =>
-                updateAccountWithUpdater(mainAccount.id, account =>
-                  addPendingOperation(account, e.operation),
-                ),
-              );
+              completeSignBroadcast({
+                navigation: navigation as NativeStackNavigationProp<{ [key: string]: object }>,
+                context,
+                routeParams: route.params,
+                mainAccount,
+                operation: e.operation,
+                updateAccountWithUpdater,
+              });
               break;
 
             default:
@@ -312,18 +357,13 @@ export function useSignedTxHandler({
           "transaction-summary",
           `✔️ broadcasted! optimistic operation: ${(await formatOperation(mainAccount))(operation)}`,
         );
-        (navigation as NativeStackNavigationProp<{ [key: string]: object }>).replace(
-          route.name.replace("ConnectDevice", "ValidationSuccess"),
-          { ...route.params, result: operation },
-        );
-        InteractionManager.runAfterInteractions(() =>
-          dispatch(
-            updateAccountWithUpdater({
-              accountId: mainAccount.id,
-              updater: account => addPendingOperation(account, operation),
-            }),
-          ),
-        );
+        completeSignedTxBroadcast({
+          navigation: navigation as NativeStackNavigationProp<{ [key: string]: object }>,
+          route,
+          mainAccount,
+          operation,
+          dispatch,
+        });
       } catch (error) {
         if (
           !(error instanceof UserRefusedOnDevice || error instanceof TransactionRefusedOnDevice)

--- a/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
+++ b/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
@@ -2,7 +2,7 @@ import invariant from "invariant";
 import { concat, of, from, Subscription } from "rxjs";
 import { concatMap, filter } from "rxjs/operators";
 import { useState, useCallback, useEffect, useRef } from "react";
-import { Platform } from "react-native";
+import { InteractionManager, Platform } from "react-native";
 import { log } from "@ledgerhq/logs";
 import { useRoute, useNavigation } from "@react-navigation/native";
 import type {
@@ -170,8 +170,10 @@ export const useSignWithDevice = ({
                   result: e.operation,
                 },
               );
-              updateAccountWithUpdater(mainAccount.id, account =>
-                addPendingOperation(account, e.operation),
+              InteractionManager.runAfterInteractions(() =>
+                updateAccountWithUpdater(mainAccount.id, account =>
+                  addPendingOperation(account, e.operation),
+                ),
               );
               break;
 
@@ -314,11 +316,13 @@ export function useSignedTxHandler({
           route.name.replace("ConnectDevice", "ValidationSuccess"),
           { ...route.params, result: operation },
         );
-        dispatch(
-          updateAccountWithUpdater({
-            accountId: mainAccount.id,
-            updater: account => addPendingOperation(account, operation),
-          }),
+        InteractionManager.runAfterInteractions(() =>
+          dispatch(
+            updateAccountWithUpdater({
+              accountId: mainAccount.id,
+              updater: account => addPendingOperation(account, operation),
+            }),
+          ),
         );
       } catch (error) {
         if (

--- a/e2e/mobile/page/common.page.ts
+++ b/e2e/mobile/page/common.page.ts
@@ -68,7 +68,7 @@ export default class CommonPage {
 
   @Step("Tap on view details")
   async successViewDetails() {
-    await waitForElementById(this.validateSuccessScreenId);
+    await waitForElementById(this.validateSuccessScreenId, 10000);
     await waitForElementById(this.successViewDetailsButtonId);
     await tapById(this.successViewDetailsButtonId);
   }

--- a/e2e/mobile/page/common.page.ts
+++ b/e2e/mobile/page/common.page.ts
@@ -1,7 +1,7 @@
 import { Step } from "jest-allure2-reporter/api";
 import { removeSpeculosAndDeregisterKnownSpeculos } from "../utils/speculosUtils";
 import { Account, getParentAccountName } from "@ledgerhq/live-common/e2e/enum/Account";
-import { delay, isIos } from "../helpers/commonHelpers";
+import { isIos } from "../helpers/commonHelpers";
 import { device } from "detox";
 import ErrorPage from "./error.page";
 
@@ -70,7 +70,6 @@ export default class CommonPage {
   async successViewDetails() {
     await waitForElementById(this.validateSuccessScreenId);
     await waitForElementById(this.successViewDetailsButtonId);
-    await delay(1000);
     await tapById(this.successViewDetailsButtonId);
   }
 

--- a/e2e/mobile/page/trade/operationDetails.page.ts
+++ b/e2e/mobile/page/trade/operationDetails.page.ts
@@ -32,7 +32,7 @@ export default class OperationDetailsPage {
 
   @Step("Wait for operation details")
   async waitForOperationDetails() {
-    await waitForElementById(this.titleId);
+    await waitForElementById(this.titleId, 10000);
   }
 
   @Step("Check account details")

--- a/e2e/mobile/specs/delegate/delegate.ts
+++ b/e2e/mobile/specs/delegate/delegate.ts
@@ -1,7 +1,6 @@
 import { setEnv } from "@ledgerhq/live-env";
 import { DelegateType } from "@ledgerhq/live-common/e2e/models/Delegate";
 import { verifyAppValidationStakeInfo, verifyStakeOperationDetailsInfo } from "../../models/stake";
-import { device } from "detox";
 import { getCurrencyManagerApp } from "../../models/currencies";
 
 const beforeAllFunction = async (delegation: DelegateType) => {
@@ -56,7 +55,6 @@ export function runDelegateTest(delegation: DelegateType, tmsLinks: string[], ta
       await app.stake.summaryContinue(currencyId);
 
       await verifyAppValidationStakeInfo(delegation, amountWithCode, fees);
-      await device.disableSynchronization();
       await app.speculos.signDelegationTransaction(delegation);
       await app.common.successViewDetails();
 
@@ -118,7 +116,6 @@ export async function runLockCelo(
       await app.stake.validateAmount(currencyId);
 
       await verifyAppValidationStakeInfo(delegation, amountWithCode);
-      await device.disableSynchronization();
       await app.speculos.signDelegationTransaction(delegation);
 
       await app.common.successViewDetails();
@@ -154,7 +151,6 @@ export async function runVoteCelo(
       await app.stake.setCeloVoteAmount(delegation.amount);
 
       await app.stake.validateCeloVoteAmount();
-      await device.disableSynchronization();
       await app.stake.celoVoteSummaryContinue();
 
       await verifyAppValidationStakeInfo(delegation, amountWithCode);
@@ -205,7 +201,6 @@ export async function runDelegateTezos(
       await app.stake.summaryContinue(currencyId);
 
       await verifyAppValidationStakeInfo(delegation, amountWithCode);
-      await device.disableSynchronization();
       await app.speculos.signDelegationTransaction(delegation);
 
       await app.common.successViewDetails();

--- a/e2e/mobile/specs/send/send.ts
+++ b/e2e/mobile/specs/send/send.ts
@@ -1,7 +1,6 @@
 import { setEnv } from "@ledgerhq/live-env";
 import { verifyAppValidationSendInfo } from "../../models/send";
 
-import { device } from "detox";
 import invariant from "invariant";
 import { TransactionType } from "@ledgerhq/live-common/e2e/models/Transaction";
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
@@ -85,7 +84,6 @@ export async function verifySendAndOperationDetails(
 
   await verifyAppValidationSendInfo(transaction, amountWithCode);
 
-  await device.disableSynchronization();
   await app.speculos.signSendTransaction(transaction);
   await app.common.successViewDetails();
 
@@ -297,7 +295,6 @@ export function runSendENSTest(transaction: TransactionType, tmsLinks: string[],
 
       await verifyAppValidationSendInfo(transaction, amountWithCode);
 
-      await device.disableSynchronization();
       await app.speculos.signSendTransaction(transaction);
       await app.common.successViewDetails();
 

--- a/e2e/mobile/specs/subAccount/subAccount.ts
+++ b/e2e/mobile/specs/subAccount/subAccount.ts
@@ -1,5 +1,4 @@
 import { verifyAppValidationSendInfo } from "../../models/send";
-import { device } from "detox";
 import { TransactionType } from "@ledgerhq/live-common/e2e/models/Transaction";
 import { AccountType } from "@ledgerhq/live-common/e2e/enum/Account";
 import { Addresses } from "@ledgerhq/live-common/e2e/enum/Addresses";
@@ -60,8 +59,6 @@ export function runSendSPL(transaction: TransactionType, tmsLinks: string[], tag
       await verifyAppValidationSendInfo(transaction, amountWithCode);
 
       await app.speculos.signSendTransaction(transaction);
-
-      await device.disableSynchronization();
       await app.common.successViewDetails();
 
       await app.operationDetails.checkOperationInfos(transaction, true, "OUT");


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - send and device-sign broadcast flows

### 📝 Description

Defer addPendingOperation Redux updates in send and device-sign broadcast flows until InteractionManager finishes the navigation transition. Success screens still use route.params.result, so behavior is unchanged; this only avoids doing account state work during the animation and should make the success transition smoother.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- CI [run](https://github.com/LedgerHQ/ledger-live/actions/runs/26434812683)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
