### PR TITLE
[LWDM] feat(coin-cardano) add listOperations CoinModuleAPI method

### DIFF
--- a/.changeset/silly-mugs-relax.md
+++ b/.changeset/silly-mugs-relax.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-cardano": minor
+"@ledgerhq/live-common": patch
+---
+
+Add listOperations method to Coin Cardano CoinModule API

--- a/libs/coin-modules/coin-cardano/.unimportedrc.json
+++ b/libs/coin-modules/coin-cardano/.unimportedrc.json
@@ -9,6 +9,7 @@
     "src/datasets/scanAccounts.ts",
     "src/deviceTransactionConfig.ts",
     "src/errors.ts",
+    "src/pools.ts",
     "src/specs.ts",
     "src/speculos-deviceActions.ts",
     "src/transaction.ts",

--- a/libs/coin-modules/coin-cardano/src/api/index.ts
+++ b/libs/coin-modules/coin-cardano/src/api/index.ts
@@ -24,10 +24,10 @@ import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import coinConfig, { type CardanoConfig } from "../config";
 import { broadcast } from "../logic/broadcast";
 import { lastBlock } from "../logic/lastBlock";
+import { listOperations } from "../logic/listOperations";
 
 export function createApi(config: CardanoConfig, currencyId: string): CoinModuleApi<StringMemo> {
   coinConfig.setCoinConfig(() => ({ ...config, status: { type: "active" } }));
-
   const currency = getCryptoCurrencyById(currencyId);
 
   return {
@@ -44,12 +44,8 @@ export function createApi(config: CardanoConfig, currencyId: string): CoinModule
     getBalance: (_address: string, _options?: BalanceOptions): Promise<Balance[]> => {
       throw new Error("getBalance is not supported");
     },
-    listOperations: (
-      _address: string,
-      _options: ListOperationsOptions,
-    ): Promise<Page<Operation>> => {
-      throw new Error("listOperations is not supported");
-    },
+    listOperations: (address: string, options: ListOperationsOptions): Promise<Page<Operation>> =>
+      listOperations(currency, address, options),
     getStakes: (_address: string, _cursor?: Cursor): Promise<Page<Stake>> => {
       throw new Error("getStakes is not supported");
     },

--- a/libs/coin-modules/coin-cardano/src/api/listOperations.test.ts
+++ b/libs/coin-modules/coin-cardano/src/api/listOperations.test.ts
@@ -1,15 +1,74 @@
+import type {
+  ListOperationsOptions,
+  MemoNotSupported,
+  Operation,
+  Page,
+} from "@ledgerhq/coin-module-framework/api/types";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import type { CardanoConfig } from "../config";
+import { listOperations } from "../logic/listOperations";
 import { createApi } from ".";
-import { type CardanoConfig } from "../config";
-import type { ListOperationsOptions } from "@ledgerhq/coin-module-framework/api/index";
+
+jest.mock("../logic/listOperations", () => ({
+  listOperations: jest.fn(),
+}));
+
+const mockListOperations = jest.mocked(listOperations);
 
 const config: CardanoConfig = { maxFeesWarning: 0, maxFeesError: 0 };
+const currency = getCryptoCurrencyById("cardano");
 
-describe("listOperations", () => {
-  it("throws an unsupported error", () => {
+const options: ListOperationsOptions = { minHeight: 10, order: "desc" };
+
+const operation: Operation<MemoNotSupported> = {
+  id: "cardano-tx-hash",
+  type: "IN",
+  senders: ["addr1_sender"],
+  recipients: ["addr1_me"],
+  value: 5000000n,
+  asset: { type: "native" },
+  tx: {
+    hash: "tx-hash",
+    block: { height: 100, hash: "", time: new Date(0) },
+    fees: 200000n,
+    date: new Date(0),
+    failed: false,
+  },
+  details: {},
+};
+
+describe("api.listOperations", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("delegates to the logic listOperations with the resolved currency, address and options", async () => {
+    const page: Page<Operation<MemoNotSupported>> = { items: [], next: undefined };
+    mockListOperations.mockResolvedValue(page);
+
+    const api = createApi(config, "cardano");
+    const result = await api.listOperations("addr1_me", options);
+
+    expect(mockListOperations).toHaveBeenCalledTimes(1);
+    expect(mockListOperations).toHaveBeenCalledWith(currency, "addr1_me", options);
+    expect(result).toBe(page);
+  });
+
+  it("returns the page (items and next cursor) produced by the logic layer unchanged", async () => {
+    const page: Page<Operation<MemoNotSupported>> = { items: [operation], next: "2" };
+    mockListOperations.mockResolvedValue(page);
+
+    const api = createApi(config, "cardano");
+    const result = await api.listOperations("addr1_me", options);
+
+    expect(result).toEqual({ items: [operation], next: "2" });
+  });
+
+  it("propagates errors thrown by the logic layer", async () => {
+    mockListOperations.mockRejectedValue(new Error("network down"));
+
     const api = createApi(config, "cardano");
 
-    expect(() => api.listOperations("address", {} as ListOperationsOptions)).toThrow(
-      "listOperations is not supported",
-    );
+    await expect(api.listOperations("addr1_me", options)).rejects.toThrow("network down");
   });
 });

--- a/libs/coin-modules/coin-cardano/src/logic.ts
+++ b/libs/coin-modules/coin-cardano/src/logic.ts
@@ -11,7 +11,7 @@ import ShelleyTypeAddress from "@stricahq/typhonjs/dist/address/ShelleyTypeAddre
 import bech32 from "bech32";
 import BigNumber from "bignumber.js";
 import groupBy from "lodash/groupBy";
-import { APITransaction } from "./api/api-types";
+import { APITransaction, HashType } from "./api/api-types";
 import {
   CARDANO_COIN_TYPE,
   CARDANO_PURPOSE,
@@ -349,4 +349,83 @@ export function isProtocolParamsValid(pp: ProtocolParams): boolean {
     pp.utxoCostPerByte,
   ];
   return paramsRequiredCheck.every(isValidNumString);
+}
+
+export function getRewardAddress(stakeKey: string, networkId: number): TyphonAddress.RewardAddress {
+  return new TyphonAddress.RewardAddress(networkId, {
+    // Use Typhon's own HashType when constructing a Typhon address (don't rely on
+    // the api-types enum sharing the same numeric values).
+    type: TyphonTypes.HashType.ADDRESS,
+    hash: Buffer.from(stakeKey, "hex"),
+  });
+}
+
+export function findStakeRegistration(
+  tx: APITransaction,
+  stakeKey: string,
+  networkId: number,
+  stakeKeyDeposit: string,
+): string | undefined {
+  // Pre-Conway stake registrations use the protocol-level deposit; the amount is
+  // not carried on the certificate, so it's sourced from network protocol params.
+  if (tx.certificate.stakeRegistrations?.length) {
+    const match = tx.certificate.stakeRegistrations.find(
+      c => c.stakeCredential.type === HashType.ADDRESS && c.stakeCredential.key === stakeKey,
+    );
+    if (match) {
+      return stakeKeyDeposit;
+    }
+  }
+
+  // Conway era stake registrations
+  if (tx.certificate.stakeRegsConway?.length) {
+    const stakeAddress = getRewardAddress(stakeKey, networkId);
+    const match = tx.certificate.stakeRegsConway.find(w => stakeAddress.getHex() === w.stakeHex);
+    if (match) {
+      return match.deposit;
+    }
+  }
+
+  return undefined;
+}
+
+export function findStakeDeRegistration(
+  tx: APITransaction,
+  stakeKey: string,
+  networkId: number,
+  stakeKeyDeposit: string,
+): string | undefined {
+  // Pre-Conway de-registrations refund the protocol-level deposit (equal to the
+  // original registration deposit), sourced from network protocol params.
+  if (tx.certificate.stakeDeRegistrations?.length) {
+    const match = tx.certificate.stakeDeRegistrations.find(
+      c => c.stakeCredential.type === HashType.ADDRESS && c.stakeCredential.key === stakeKey,
+    );
+    if (match) {
+      return stakeKeyDeposit;
+    }
+  }
+
+  // Conway era stake de-registrations
+  if (tx.certificate.stakeDeRegsConway?.length) {
+    const stakeAddress = getRewardAddress(stakeKey, networkId);
+    const match = tx.certificate.stakeDeRegsConway.find(w => stakeAddress.getHex() === w.stakeHex);
+    if (match) {
+      return match.deposit;
+    }
+  }
+
+  return undefined;
+}
+
+export function findWithdrawal(tx: APITransaction, stakeKey: string): string | undefined {
+  if (!tx.withdrawals?.length) {
+    return undefined;
+  }
+
+  const match = tx.withdrawals.find(
+    w => w.stakeCredential.type === HashType.ADDRESS && w.stakeCredential.key === stakeKey,
+  );
+
+  return match?.amount;
 }

--- a/libs/coin-modules/coin-cardano/src/logic/listOperations.integ.test.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/listOperations.integ.test.ts
@@ -1,0 +1,863 @@
+import { Operation } from "@ledgerhq/coin-module-framework/api/types";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import {
+  address as TyphonAddress,
+  types as TyphonTypes,
+  utils as TyphonUtils,
+} from "@stricahq/typhonjs";
+import { listOperations } from "./listOperations";
+
+/**
+ * Integration tests for listOperations against Cardano mainnet API.
+ * Tests are resilient to empty data and validate logic with real blockchain transactions.
+ *
+ * NOTE: these are `.integ.test.ts` and are excluded from the default `pnpm test`
+ * run, so they do not gate correctness in CI. The mapping/pagination logic should
+ * also be covered by deterministic unit tests that mock `@ledgerhq/live-network/network`
+ * (tracked as a follow-up) — those are what catch a mapping regression on every PR.
+ */
+describe("listOperations", () => {
+  let currency: CryptoCurrency;
+  let TESTING_ADDRESS: string;
+  let PRISTINE_ADDRESS: string;
+  // `listOperations` ignores `options.limit` (the backend dictates page size), so
+  // every first-page `minHeight: 0, order: "desc"` query returns the same page.
+  // Fetch it once and share it across the tests that only inspect that page,
+  // instead of hitting mainnet ~24 times.
+  let descFirstPage: Awaited<ReturnType<typeof listOperations>>;
+
+  beforeAll(async () => {
+    currency = getCryptoCurrencyById("cardano");
+
+    const testAddressFromCodebase =
+      "addr1q8mgw8geggkl2hs0m6rq3pgt69uxttpqcgu6euxje5tt6plxjtjrnskhhtt03g6l3sr98p9t8mtlajr26vmwjzep77pqxn8cms";
+    const decodedAddress = TyphonUtils.getAddressFromString(testAddressFromCodebase);
+
+    if (!(decodedAddress instanceof TyphonAddress.BaseAddress)) {
+      throw new Error("Test address must be a BaseAddress");
+    }
+
+    const realPaymentCredHash = decodedAddress.paymentCredential.hash;
+    const realStakeCredHash = decodedAddress.stakeCredential.hash;
+
+    const testAddress = new TyphonAddress.BaseAddress(
+      TyphonTypes.NetworkId.MAINNET,
+      {
+        type: TyphonTypes.HashType.ADDRESS,
+        hash: realPaymentCredHash,
+      },
+      {
+        type: TyphonTypes.HashType.ADDRESS,
+        hash: realStakeCredHash,
+      },
+    );
+    TESTING_ADDRESS = testAddress.getBech32();
+
+    const pristinePaymentHash = Buffer.from("00".repeat(28), "hex");
+    const pristineStakeHash = Buffer.from("00".repeat(28), "hex");
+
+    const pristineAddress = new TyphonAddress.BaseAddress(
+      TyphonTypes.NetworkId.MAINNET,
+      {
+        type: TyphonTypes.HashType.ADDRESS,
+        hash: pristinePaymentHash,
+      },
+      {
+        type: TyphonTypes.HashType.ADDRESS,
+        hash: pristineStakeHash,
+      },
+    );
+    PRISTINE_ADDRESS = pristineAddress.getBech32();
+
+    descFirstPage = await listOperations(currency, TESTING_ADDRESS, {
+      minHeight: 0,
+      order: "desc",
+      limit: 200,
+    });
+  }, 30000);
+
+  describe("Basic operations", () => {
+    it("rejects ascending order (unsupported on a newest-first backend)", async () => {
+      await expect(
+        listOperations(currency, TESTING_ADDRESS, { minHeight: 0, order: "asc", limit: 20 }),
+      ).rejects.toThrow("ascending order is not supported");
+    });
+
+    it("should fetch operations in descending order", () => {
+      const result = descFirstPage;
+
+      expect(result.items).toBeInstanceOf(Array);
+
+      if (result.items.length > 1) {
+        for (let i = 1; i < result.items.length; i++) {
+          const prevTimestamp = result.items[i - 1].tx.date.getTime();
+          const currTimestamp = result.items[i].tx.date.getTime();
+          expect(currTimestamp).toBeLessThanOrEqual(prevTimestamp);
+        }
+      }
+    }, 30000);
+
+    it("should filter by minHeight", async () => {
+      const minHeight = 8000000;
+      const result = await listOperations(currency, TESTING_ADDRESS, {
+        minHeight,
+        order: "desc",
+        limit: 20,
+      });
+
+      for (const op of result.items) {
+        expect(op.tx.block.height).toBeGreaterThanOrEqual(minHeight);
+      }
+    }, 30000);
+  });
+
+  describe("Operation structure validation", () => {
+    it("should return properly structured operations", () => {
+      const result = descFirstPage;
+
+      expect(result.items).toBeInstanceOf(Array);
+
+      if (result.items.length === 0) {
+        return;
+      }
+
+      result.items.forEach(op => {
+        expect(op).toHaveProperty("id");
+        expect(op).toHaveProperty("type");
+        expect(op).toHaveProperty("senders");
+        expect(op).toHaveProperty("recipients");
+        expect(op).toHaveProperty("value");
+        expect(op).toHaveProperty("asset");
+        expect(op).toHaveProperty("tx");
+
+        expect(["NONE", "FEES", "IN", "OUT", "DELEGATE", "UNDELEGATE"]).toContain(op.type);
+
+        expect(Array.isArray(op.senders)).toBe(true);
+        expect(Array.isArray(op.recipients)).toBe(true);
+
+        expect(typeof op.value).toBe("bigint");
+        expect(op.value).toBeGreaterThanOrEqual(0n);
+
+        expect(op.asset).toHaveProperty("type");
+        expect(["native", "token"].includes(op.asset.type)).toBe(true);
+
+        expect(op.tx).toHaveProperty("hash");
+        expect(op.tx).toHaveProperty("block");
+        expect(op.tx).toHaveProperty("fees");
+        expect(op.tx).toHaveProperty("date");
+        expect(op.tx).toHaveProperty("failed");
+
+        expect(op.tx.hash).toMatch(/^[a-f0-9]{64}$/);
+
+        expect(op.tx.block.height).toBeGreaterThan(0);
+        expect(op.tx.block.time).toBeInstanceOf(Date);
+
+        expect(typeof op.tx.fees).toBe("bigint");
+        expect(op.tx.fees).toBeGreaterThanOrEqual(0n);
+
+        expect(op.tx.date).toBeInstanceOf(Date);
+
+        expect(typeof op.tx.failed).toBe("boolean");
+
+        // API returns addresses in hex format while we query with bech32. Address filtering
+        // happens at the API level by payment key, so all returned operations are relevant.
+      });
+    }, 30000);
+  });
+
+  describe("Pagination", () => {
+    it("should paginate through operations without duplicates", async () => {
+      const allOperations: Operation[] = [];
+      const seenTxIds = new Set<string>();
+      let cursor: string | undefined;
+      let pageCount = 0;
+      const maxPages = 3;
+      const limit = 10;
+
+      while (pageCount < maxPages) {
+        const result = await listOperations(currency, TESTING_ADDRESS, {
+          minHeight: 0,
+          order: "desc",
+          limit,
+          ...(cursor ? { cursor } : {}),
+        });
+        pageCount++;
+
+        for (const op of result.items) {
+          if (seenTxIds.has(op.id)) {
+            throw new Error(`Duplicate operation found: ${op.id}`);
+          }
+          seenTxIds.add(op.id);
+          allOperations.push(op);
+        }
+
+        if (!result.next) break;
+        cursor = result.next;
+      }
+
+      expect(seenTxIds.size).toBe(allOperations.length);
+
+      for (let i = 1; i < allOperations.length; i++) {
+        const prevTimestamp = allOperations[i - 1].tx.date.getTime();
+        const currTimestamp = allOperations[i].tx.date.getTime();
+        expect(currTimestamp).toBeLessThanOrEqual(prevTimestamp);
+      }
+    }, 60000);
+
+    it("should return consistent results when re-fetching with same cursor", async () => {
+      const firstPage = await listOperations(currency, TESTING_ADDRESS, {
+        minHeight: 0,
+        order: "desc",
+        limit: 10,
+      });
+
+      if (!firstPage.next) {
+        return;
+      }
+
+      const secondPageA = await listOperations(currency, TESTING_ADDRESS, {
+        minHeight: 0,
+        order: "desc",
+        limit: 10,
+        cursor: firstPage.next,
+      });
+      const secondPageB = await listOperations(currency, TESTING_ADDRESS, {
+        minHeight: 0,
+        order: "desc",
+        limit: 10,
+        cursor: firstPage.next,
+      });
+
+      expect(secondPageA.items.length).toBe(secondPageB.items.length);
+      for (let i = 0; i < secondPageA.items.length; i++) {
+        expect(secondPageA.items[i].id).toBe(secondPageB.items[i].id);
+      }
+    }, 30000);
+
+    it("should return undefined cursor on last page", async () => {
+      let cursor: string | undefined;
+      let lastResult;
+      let pageCount = 0;
+      const maxPages = 10;
+
+      while (pageCount < maxPages) {
+        lastResult = await listOperations(currency, TESTING_ADDRESS, {
+          minHeight: 0,
+          order: "desc",
+          limit: 10,
+          ...(cursor ? { cursor } : {}),
+        });
+        pageCount++;
+
+        if (!lastResult.next) {
+          expect(lastResult.next).toBeUndefined();
+          return;
+        }
+
+        cursor = lastResult.next;
+      }
+    }, 60000);
+  });
+
+  describe("Transaction types", () => {
+    it("should return native ADA operations", () => {
+      const result = descFirstPage;
+
+      const nativeOps = result.items.filter(op => op.asset.type === "native");
+
+      if (nativeOps.length === 0) {
+        return;
+      }
+
+      nativeOps.forEach(op => {
+        expect(op.asset).toEqual({ type: "native" });
+        expect(op.value).toBeGreaterThanOrEqual(0n);
+      });
+    }, 30000);
+
+    it("should return token operations if present", () => {
+      const result = descFirstPage;
+
+      const tokenOps = result.items.filter(op => op.asset.type === "token");
+
+      if (tokenOps.length > 0) {
+        tokenOps.forEach(op => {
+          expect(op.asset.type).toBe("token");
+          expect(op.asset).toHaveProperty("assetReference");
+
+          if ("assetOwner" in op.asset && op.asset.assetOwner) {
+            expect(op.asset.assetOwner).toBe(TESTING_ADDRESS);
+          }
+
+          if (op.details) {
+            expect(op.details).toHaveProperty("policyId");
+            expect(op.details).toHaveProperty("assetName");
+          }
+        });
+      }
+    });
+  });
+
+  describe("Operation types", () => {
+    it("should correctly identify IN operations", () => {
+      const result = descFirstPage;
+
+      const inOps = result.items.filter(op => op.type === "IN");
+
+      inOps.forEach(op => {
+        expect(op.type).toBe("IN");
+        expect(op.recipients.length).toBeGreaterThan(0);
+        expect(op.value).toBeGreaterThan(0n);
+      });
+    }, 30000);
+
+    it("should correctly identify OUT operations", () => {
+      const result = descFirstPage;
+
+      const outOps = result.items.filter(op => op.type === "OUT");
+
+      outOps.forEach(op => {
+        expect(op.type).toBe("OUT");
+        expect(op.senders.length).toBeGreaterThan(0);
+      });
+    }, 30000);
+
+    it("should correctly identify FEES operations", () => {
+      const result = descFirstPage;
+
+      const feesOps = result.items.filter(op => op.type === "FEES");
+
+      if (feesOps.length > 0) {
+        feesOps.forEach(op => {
+          expect(op.type).toBe("FEES");
+          // value excludes the fee (the generic-coin-framework adapter re-adds tx.fees).
+          expect(op.value).toBe(0n);
+          expect(op.senders.length).toBeGreaterThan(0);
+        });
+      }
+    }, 30000);
+
+    it("should correctly identify DELEGATE operations", () => {
+      const result = descFirstPage;
+
+      const delegateOps = result.items.filter(op => op.type === "DELEGATE");
+
+      if (delegateOps.length > 0) {
+        delegateOps.forEach(op => {
+          expect(op.type).toBe("DELEGATE");
+          if (op.details && typeof op.details === "object") {
+            expect(op.details).toHaveProperty("poolId");
+          }
+        });
+      }
+    }, 30000);
+
+    it("should correctly identify UNDELEGATE operations", () => {
+      const result = descFirstPage;
+
+      const undelegateOps = result.items.filter(op => op.type === "UNDELEGATE");
+
+      if (undelegateOps.length > 0) {
+        undelegateOps.forEach(op => {
+          expect(op.type).toBe("UNDELEGATE");
+          expect(op.senders.length).toBeGreaterThan(0);
+          expect(op.recipients.length).toBeGreaterThan(0);
+        });
+      }
+    }, 30000);
+  });
+
+  describe("Cardano-specific features", () => {
+    it("should include deposit details for stake registrations", () => {
+      const result = descFirstPage;
+
+      const opsWithDeposit = result.items.filter(
+        op => op.details && typeof op.details === "object" && "deposit" in op.details,
+      );
+
+      if (opsWithDeposit.length > 0) {
+        opsWithDeposit.forEach(op => {
+          expect(op.details).toHaveProperty("deposit");
+          const deposit = (op.details as any).deposit;
+          expect(typeof deposit).toBe("string");
+          const depositAmount = BigInt(deposit);
+          expect(depositAmount).toBeGreaterThan(0n);
+        });
+      }
+    }, 30000);
+
+    it("should include refund details for stake de-registrations", () => {
+      const result = descFirstPage;
+
+      const opsWithRefund = result.items.filter(
+        op =>
+          op.type === "UNDELEGATE" &&
+          op.details &&
+          typeof op.details === "object" &&
+          "refund" in op.details,
+      );
+
+      if (opsWithRefund.length > 0) {
+        opsWithRefund.forEach(op => {
+          expect(op.type).toBe("UNDELEGATE");
+          expect(op.details).toHaveProperty("refund");
+          const refund = (op.details as any).refund;
+          expect(typeof refund).toBe("string");
+          const refundAmount = BigInt(refund);
+          expect(refundAmount).toBeGreaterThan(0n);
+        });
+      }
+    }, 30000);
+
+    it("should include rewards for withdrawal operations", () => {
+      const result = descFirstPage;
+
+      const opsWithWithdrawals = result.items.filter(
+        op => op.details && typeof op.details === "object" && "rewards" in op.details,
+      );
+
+      if (opsWithWithdrawals.length > 0) {
+        opsWithWithdrawals.forEach(op => {
+          expect(op.details).toHaveProperty("rewards");
+          const rewards = (op.details as any).rewards;
+          expect(typeof rewards).toBe("string");
+          const rewardsAmount = BigInt(rewards);
+          expect(rewardsAmount).toBeGreaterThan(0n);
+          expect(op.value).toBeGreaterThanOrEqual(0n);
+        });
+      }
+    }, 30000);
+
+    it("should format pool IDs in bech32 format for delegations", () => {
+      const result = descFirstPage;
+
+      const delegateOpsWithPool = result.items.filter(
+        op =>
+          op.type === "DELEGATE" &&
+          op.details &&
+          typeof op.details === "object" &&
+          "poolId" in op.details,
+      );
+
+      if (delegateOpsWithPool.length > 0) {
+        delegateOpsWithPool.forEach(op => {
+          expect(op.type).toBe("DELEGATE");
+          expect(op.details).toHaveProperty("poolId");
+          const poolId = (op.details as any).poolId;
+          expect(typeof poolId).toBe("string");
+
+          const isBech32 = poolId.startsWith("pool1") || poolId.startsWith("pool_test1");
+          const isHex = /^[a-f0-9]{56}$/.test(poolId);
+
+          expect(isBech32).toBe(true);
+          expect(isHex).toBe(false);
+        });
+      }
+    }, 30000);
+
+    it("should include memo when present in transaction metadata", () => {
+      const result = descFirstPage;
+
+      const opsWithMemo = result.items.filter(
+        op => op.details && typeof op.details === "object" && "memo" in op.details,
+      );
+
+      if (opsWithMemo.length > 0) {
+        opsWithMemo.forEach(op => {
+          expect(op.details).toHaveProperty("memo");
+          const memo = (op.details as any).memo;
+          expect(typeof memo).toBe("string");
+          expect(memo.length).toBeGreaterThan(0);
+        });
+      }
+    }, 30000);
+
+    it("should include metadata hash when present", () => {
+      const result = descFirstPage;
+
+      const opsWithMetadata = result.items.filter(
+        op => op.details && typeof op.details === "object" && "metadataHash" in op.details,
+      );
+
+      if (opsWithMetadata.length > 0) {
+        opsWithMetadata.forEach(op => {
+          expect(op.details).toHaveProperty("metadataHash");
+          const metadataHash = (op.details as any).metadataHash;
+          expect(typeof metadataHash).toBe("string");
+          expect(metadataHash.length).toBeGreaterThan(0);
+        });
+      }
+    }, 30000);
+
+    it("should handle Conway era stake registrations", async () => {
+      const result = await listOperations(currency, TESTING_ADDRESS, {
+        minHeight: 8000000, // Post-Conway hardfork
+        order: "desc",
+        limit: 200,
+      });
+
+      const conwayRegistrations = result.items.filter(
+        op =>
+          op.type === "DELEGATE" &&
+          op.details &&
+          typeof op.details === "object" &&
+          "deposit" in op.details,
+      );
+
+      if (conwayRegistrations.length > 0) {
+        conwayRegistrations.forEach(op => {
+          expect(op.type).toBe("DELEGATE");
+          expect(op.details).toHaveProperty("deposit");
+          const deposit = (op.details as any).deposit;
+          expect(typeof deposit).toBe("string");
+          expect(BigInt(deposit)).toBeGreaterThan(0n);
+        });
+      }
+    }, 30000);
+  });
+
+  describe("Token operations", () => {
+    it("should return token operations with proper structure", () => {
+      const result = descFirstPage;
+
+      const tokenOps = result.items.filter(op => op.asset.type === "token");
+
+      if (tokenOps.length > 0) {
+        tokenOps.forEach(op => {
+          expect(op.asset.type).toBe("token");
+          expect(op.asset).toHaveProperty("assetReference");
+
+          if ("assetOwner" in op.asset && op.asset.assetOwner) {
+            expect(op.asset.assetOwner).toBe(TESTING_ADDRESS);
+          }
+
+          if (op.details) {
+            expect(op.details).toHaveProperty("policyId");
+            expect(op.details).toHaveProperty("assetName");
+          }
+        });
+      }
+    }, 30000);
+
+    it("should decode token asset names when ASCII-decodable", () => {
+      const result = descFirstPage;
+
+      const tokenOps = result.items.filter(op => op.asset.type === "token");
+
+      if (tokenOps.length > 0) {
+        tokenOps.forEach(op => {
+          expect(op.details).toHaveProperty("assetName");
+          const assetName = (op.details as any).assetName;
+          expect(typeof assetName).toBe("string");
+
+          if (op.details && "assetNameDecoded" in op.details) {
+            const decoded = (op.details as any).assetNameDecoded;
+            expect(typeof decoded).toBe("string");
+            expect(decoded).not.toBe(assetName);
+            expect(decoded).toMatch(/^[\x20-\x7E]+$/);
+          }
+        });
+      }
+    }, 30000);
+
+    it("should handle transactions with multiple tokens", () => {
+      const result = descFirstPage;
+
+      const tokenOps = result.items.filter(op => op.asset.type === "token");
+
+      if (tokenOps.length > 1) {
+        const opsByTx = new Map<string, typeof tokenOps>();
+        tokenOps.forEach(op => {
+          const txHash = op.tx.hash;
+          if (!opsByTx.has(txHash)) {
+            opsByTx.set(txHash, []);
+          }
+          opsByTx.get(txHash)!.push(op);
+        });
+
+        for (const [txHash, ops] of opsByTx) {
+          if (ops.length > 1) {
+            const assetRefs = new Set(ops.map(op => (op.asset as any).assetReference));
+            expect(assetRefs.size).toBe(ops.length);
+
+            ops.forEach(op => {
+              expect(op.tx.hash).toBe(txHash);
+            });
+          }
+        }
+      }
+    }, 30000);
+  });
+
+  describe("Address handling", () => {
+    it("should convert hex addresses to bech32 format", () => {
+      const result = descFirstPage;
+
+      if (result.items.length > 0) {
+        result.items.forEach(op => {
+          op.senders.forEach(sender => {
+            const isShelleyBech32 =
+              sender.startsWith("addr1") ||
+              sender.startsWith("addr_test1") ||
+              sender.startsWith("stake") ||
+              sender.startsWith("stake_test");
+
+            const isByron =
+              sender.startsWith("Ae2") ||
+              sender.startsWith("Dd") ||
+              /^[A-Za-z0-9]{58,}$/.test(sender);
+
+            const isHex = /^[a-f0-9]+$/.test(sender) && sender.length > 50;
+
+            expect(isShelleyBech32 || isByron).toBe(true);
+            expect(isHex).toBe(false);
+          });
+
+          op.recipients.forEach(recipient => {
+            const isShelleyBech32 =
+              recipient.startsWith("addr1") ||
+              recipient.startsWith("addr_test1") ||
+              recipient.startsWith("stake") ||
+              recipient.startsWith("stake_test");
+
+            const isByron =
+              recipient.startsWith("Ae2") ||
+              recipient.startsWith("Dd") ||
+              /^[A-Za-z0-9]{58,}$/.test(recipient);
+
+            const isHex = /^[a-f0-9]+$/.test(recipient) && recipient.length > 50;
+
+            expect(isShelleyBech32 || isByron).toBe(true);
+            expect(isHex).toBe(false);
+          });
+        });
+      }
+    }, 30000);
+
+    it("should handle Byron addresses gracefully", async () => {
+      const byronAddress = "Ae2tdPwUPEZCanmBz5g2GEwFqKTKpNJcGYPKfDxoNeKZ8bRHr8366kseiK2";
+
+      const result = await listOperations(currency, byronAddress, {
+        minHeight: 0,
+        order: "desc",
+        limit: 10,
+      });
+
+      expect(result.items).toHaveLength(0);
+      expect(result.next).toBeUndefined();
+    }, 30000);
+  });
+
+  describe("Edge cases and error handling", () => {
+    it("should handle pristine address query correctly", async () => {
+      const result = await listOperations(currency, PRISTINE_ADDRESS, {
+        minHeight: 0,
+        order: "desc",
+        limit: 10,
+      });
+
+      expect(result.items).toBeInstanceOf(Array);
+      expect(result).toHaveProperty("next");
+    }, 30000);
+
+    it("should handle invalid address gracefully", async () => {
+      const invalidAddress = "invalid_cardano_address";
+
+      const result = await listOperations(currency, invalidAddress, {
+        minHeight: 0,
+        order: "desc",
+        limit: 10,
+      });
+
+      expect(result.items).toHaveLength(0);
+      expect(result.next).toBeUndefined();
+    }, 30000);
+
+    it("should handle malformed/empty address strings", async () => {
+      const testCases = [
+        "",
+        "   ",
+        "0x123",
+        "not_a_cardano_address",
+        null as any,
+        undefined as any,
+      ];
+
+      for (const invalidAddr of testCases) {
+        const result = await listOperations(currency, invalidAddr, {
+          minHeight: 0,
+          order: "desc",
+          limit: 10,
+        });
+
+        expect(result.items).toHaveLength(0);
+        expect(result.next).toBeUndefined();
+      }
+    }, 30000);
+
+    it("should ignore options.limit (API uses fixed page size)", async () => {
+      const result1 = await listOperations(currency, TESTING_ADDRESS, {
+        minHeight: 0,
+        order: "desc",
+        limit: 50,
+      });
+
+      const result2 = await listOperations(currency, TESTING_ADDRESS, {
+        minHeight: 0,
+        order: "desc",
+        limit: 5,
+      });
+
+      if (result1.items.length > 0 && result2.items.length > 0) {
+        expect(result1.items.length).toBe(result2.items.length);
+      }
+    }, 30000);
+
+    it("should return undefined cursor when all transactions are filtered by minHeight", async () => {
+      const result = await listOperations(currency, TESTING_ADDRESS, {
+        minHeight: 999999999,
+        order: "desc",
+        limit: 10,
+      });
+
+      expect(result.items).toHaveLength(0);
+      expect(result.next).toBeUndefined();
+    }, 30000);
+
+    it("should verify multi-token operations have unique asset references", () => {
+      const result = descFirstPage;
+
+      const tokenOps = result.items.filter(op => op.asset.type === "token");
+
+      if (tokenOps.length > 1) {
+        const opsByTx = new Map<string, typeof tokenOps>();
+        tokenOps.forEach(op => {
+          const txHash = op.tx.hash;
+          if (!opsByTx.has(txHash)) {
+            opsByTx.set(txHash, []);
+          }
+          opsByTx.get(txHash)!.push(op);
+        });
+
+        for (const [txHash, ops] of opsByTx) {
+          if (ops.length > 1) {
+            const assetRefs = new Set(ops.map(op => (op.asset as any).assetReference));
+            expect(assetRefs.size).toBe(ops.length);
+
+            ops.forEach(op => {
+              expect(op.tx.hash).toBe(txHash);
+            });
+          }
+        }
+      }
+    }, 30000);
+
+    it("should handle very old transactions (edge case block heights)", async () => {
+      const result = await listOperations(currency, TESTING_ADDRESS, {
+        minHeight: 1,
+        order: "desc",
+        limit: 10,
+      });
+
+      expect(result.items).toBeInstanceOf(Array);
+      result.items.forEach(op => {
+        expect(op.tx.block.height).toBeGreaterThanOrEqual(1);
+      });
+    }, 30000);
+
+    it("should maintain operation order across pagination", async () => {
+      const allOps: Operation[] = [];
+      let cursor: string | undefined;
+      const maxPages = 5;
+      let pageCount = 0;
+
+      while (pageCount < maxPages) {
+        const result = await listOperations(currency, TESTING_ADDRESS, {
+          minHeight: 0,
+          order: "desc",
+          limit: 10,
+          ...(cursor ? { cursor } : {}),
+        });
+
+        allOps.push(...result.items);
+        pageCount++;
+
+        if (!result.next) break;
+        cursor = result.next;
+      }
+
+      for (let i = 1; i < allOps.length; i++) {
+        const prevDate = allOps[i - 1].tx.date.getTime();
+        const currDate = allOps[i].tx.date.getTime();
+        expect(currDate).toBeLessThanOrEqual(prevDate);
+      }
+    }, 90000);
+
+    it("should handle cursor edge cases", async () => {
+      const invalidCursors = ["abc", "-1", "0", "999999999999", "", "  ", "NaN"];
+
+      for (const invalidCursor of invalidCursors) {
+        const result = await listOperations(currency, TESTING_ADDRESS, {
+          minHeight: 0,
+          order: "desc",
+          limit: 10,
+          cursor: invalidCursor,
+        });
+
+        expect(result.items).toBeInstanceOf(Array);
+        expect(result).toHaveProperty("next");
+      }
+    }, 30000);
+
+    it("should verify all operations have unique IDs", () => {
+      const result = descFirstPage;
+
+      if (result.items.length > 0) {
+        const ids = new Set(result.items.map(op => op.id));
+        expect(ids.size).toBe(result.items.length);
+      }
+    }, 30000);
+
+    it("should handle zero-value operations correctly", () => {
+      const result = descFirstPage;
+
+      result.items.forEach(op => {
+        expect(op.value).toBeGreaterThanOrEqual(0n);
+      });
+    }, 30000);
+
+    it("should validate operation dates are chronologically valid", () => {
+      const result = descFirstPage;
+
+      result.items.forEach(op => {
+        const date = op.tx.date;
+        const blockTime = op.tx.block.time;
+
+        expect(date).toBeInstanceOf(Date);
+        expect(blockTime).toBeInstanceOf(Date);
+        expect(isNaN(date.getTime())).toBe(false);
+        expect(isNaN(blockTime.getTime())).toBe(false);
+
+        // 1 hour tolerance for clock drift
+        const now = Date.now() + 3600000;
+        expect(date.getTime()).toBeLessThan(now);
+        expect(blockTime.getTime()).toBeLessThan(now);
+      });
+    }, 30000);
+
+    it("should handle UNDELEGATE operations", () => {
+      const result = descFirstPage;
+
+      const undelegateOps = result.items.filter(op => op.type === "UNDELEGATE");
+
+      if (undelegateOps.length > 0) {
+        undelegateOps.forEach(op => {
+          expect(op.type).toBe("UNDELEGATE");
+          expect(op.senders.length).toBeGreaterThan(0);
+          expect(op.recipients.length).toBeGreaterThan(0);
+        });
+      }
+    }, 30000);
+  });
+});

--- a/libs/coin-modules/coin-cardano/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/listOperations.test.ts
@@ -1,0 +1,831 @@
+import type { ListOperationsOptions } from "@ledgerhq/coin-module-framework/api/types";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { address as TyphonAddress, types as TyphonTypes } from "@stricahq/typhonjs";
+import network from "@ledgerhq/live-network/network";
+import { APITransaction, HashType, TransactionCertificates } from "../api/api-types";
+import { listOperations } from "./listOperations";
+
+jest.mock("@ledgerhq/live-network/network");
+
+const mockNetwork = network as jest.Mock;
+
+const currency = getCryptoCurrencyById("cardano");
+
+const PAYMENT_HASH = "11".repeat(28);
+const STAKE_HASH = "22".repeat(28);
+const OTHER_PAYMENT_HASH = "33".repeat(28);
+const POOL_KEY_HASH = "a314a18528d00c5fbd067ecb4a212cf2f307c83d2c08f44a11ebebf6";
+
+function bech32BaseAddress(paymentHashHex: string, stakeHashHex: string): string {
+  return new TyphonAddress.BaseAddress(
+    TyphonTypes.NetworkId.MAINNET,
+    { type: TyphonTypes.HashType.ADDRESS, hash: Buffer.from(paymentHashHex, "hex") },
+    { type: TyphonTypes.HashType.ADDRESS, hash: Buffer.from(stakeHashHex, "hex") },
+  ).getBech32();
+}
+
+const ADDRESS = bech32BaseAddress(PAYMENT_HASH, STAKE_HASH);
+const COUNTERPARTY_ADDRESS = bech32BaseAddress(OTHER_PAYMENT_HASH, "44".repeat(28));
+
+const emptyCertificate: TransactionCertificates = {
+  stakeRegistrations: [],
+  stakeDeRegistrations: [],
+  stakeDelegations: [],
+};
+
+function makeTx(overrides: Partial<APITransaction> = {}): APITransaction {
+  return {
+    fees: "200000",
+    hash: "tx-hash-1",
+    timestamp: "2023-06-01T00:00:00.000Z",
+    blockHeight: 1000,
+    inputs: [],
+    outputs: [],
+    certificate: { ...emptyCertificate },
+    ...overrides,
+  };
+}
+
+function mockResponse(
+  transactions: APITransaction[],
+  {
+    pageNo = 1,
+    limit = 50,
+    blockHeight = 0,
+    stakeKeyDeposit = "2000000",
+  }: Partial<{ pageNo: number; limit: number; blockHeight: number; stakeKeyDeposit: string }> = {},
+) {
+  mockNetwork.mockImplementation((req: { url?: string }) => {
+    if (typeof req?.url === "string" && req.url.includes("/network/info")) {
+      return Promise.resolve({ data: { protocolParams: { stakeKeyDeposit } } });
+    }
+    return Promise.resolve({ data: { transactions, pageNo, limit, blockHeight } });
+  });
+}
+
+const options: ListOperationsOptions = { limit: 100 } as ListOperationsOptions;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("listOperations", () => {
+  describe("early returns without hitting the network", () => {
+    it("returns an empty page for an empty address", async () => {
+      const page = await listOperations(currency, "", options);
+
+      expect(page).toEqual({ items: [], next: undefined });
+      expect(mockNetwork).not.toHaveBeenCalled();
+    });
+
+    it("returns an empty page for an unsupported/unparseable address", async () => {
+      const page = await listOperations(currency, "not-a-cardano-address", options);
+
+      expect(page).toEqual({ items: [], next: undefined });
+      expect(mockNetwork).not.toHaveBeenCalled();
+    });
+  });
+
+  it("queries the API with the payment key derived from the address", async () => {
+    mockResponse([]);
+
+    await listOperations(currency, ADDRESS, options);
+
+    expect(mockNetwork).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "POST",
+        data: expect.objectContaining({ paymentKeys: [PAYMENT_HASH], pageNo: 1, blockHeight: 0 }),
+      }),
+    );
+  });
+
+  it("maps an incoming transfer to a native IN operation", async () => {
+    mockResponse([
+      makeTx({
+        inputs: [
+          {
+            txId: "in-0",
+            index: 0,
+            address: COUNTERPARTY_ADDRESS,
+            value: "10000000",
+            paymentKey: OTHER_PAYMENT_HASH,
+            tokens: [],
+          },
+        ],
+        outputs: [{ address: ADDRESS, value: "5000000", paymentKey: PAYMENT_HASH, tokens: [] }],
+      }),
+    ]);
+
+    const { items } = await listOperations(currency, ADDRESS, options);
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      id: "cardano-tx-hash-1",
+      type: "IN",
+      value: 5000000n,
+      senders: [COUNTERPARTY_ADDRESS],
+      recipients: [ADDRESS],
+      asset: { type: "native" },
+    });
+    expect(items[0].tx).toMatchObject({
+      hash: "tx-hash-1",
+      fees: 200000n,
+      feesPayer: COUNTERPARTY_ADDRESS,
+      failed: false,
+    });
+  });
+
+  it("maps an outgoing transfer to a native OUT operation with the spent value", async () => {
+    mockResponse([
+      makeTx({
+        fees: "200000",
+        inputs: [
+          {
+            txId: "in-0",
+            index: 0,
+            address: ADDRESS,
+            value: "10000000",
+            paymentKey: PAYMENT_HASH,
+            tokens: [],
+          },
+        ],
+        outputs: [
+          {
+            address: COUNTERPARTY_ADDRESS,
+            value: "7000000",
+            paymentKey: OTHER_PAYMENT_HASH,
+            tokens: [],
+          },
+          { address: ADDRESS, value: "2800000", paymentKey: PAYMENT_HASH, tokens: [] },
+        ],
+      }),
+    ]);
+
+    const { items } = await listOperations(currency, ADDRESS, options);
+
+    // value EXCLUDES the fee (amount sent = 7_000_000); the generic-coin-framework
+    // adapter re-adds tx.fees, so including it here would double-count.
+    expect(items[0]).toMatchObject({ type: "OUT", value: 7000000n });
+  });
+
+  it("classifies a self-transfer where the only net change is fees as FEES", async () => {
+    mockResponse([
+      makeTx({
+        fees: "200000",
+        inputs: [
+          {
+            txId: "in-0",
+            index: 0,
+            address: ADDRESS,
+            value: "3000000",
+            paymentKey: PAYMENT_HASH,
+            tokens: [],
+          },
+        ],
+        outputs: [{ address: ADDRESS, value: "2800000", paymentKey: PAYMENT_HASH, tokens: [] }],
+      }),
+    ]);
+
+    const { items } = await listOperations(currency, ADDRESS, options);
+
+    // A pure-fee self-transfer carries value 0; the adapter surfaces tx.fees.
+    expect(items[0]).toMatchObject({ type: "FEES", value: 0n });
+  });
+
+  it("clamps value to 0 (never negative) when an address's net outflow is below the tx fee", async () => {
+    // Per-address edge: this address spends less than the whole-tx fee (the rest of
+    // the fee is covered by other inputs). value must stay >= 0 — a negative
+    // CoinModule value would corrupt the bridge's balance math (it's consumed by the
+    // fee-adding adapter with no clamp). The adapter re-adds tx.fees on top.
+    mockResponse([
+      makeTx({
+        fees: "200000",
+        inputs: [
+          {
+            txId: "in-0",
+            index: 0,
+            address: ADDRESS,
+            value: "100000",
+            paymentKey: PAYMENT_HASH,
+            tokens: [],
+          },
+        ],
+        outputs: [
+          {
+            address: COUNTERPARTY_ADDRESS,
+            value: "100000",
+            paymentKey: OTHER_PAYMENT_HASH,
+            tokens: [],
+          },
+        ],
+      }),
+    ]);
+
+    const { items } = await listOperations(currency, ADDRESS, options);
+
+    expect(items[0].type).toBe("OUT");
+    expect(items[0].value).toBe(0n);
+  });
+
+  it("emits a token operation alongside the native one and decodes a printable asset name", async () => {
+    const assetNameHex = Buffer.from("MYTOKEN").toString("hex");
+    mockResponse([
+      makeTx({
+        inputs: [
+          {
+            txId: "in-0",
+            index: 0,
+            address: COUNTERPARTY_ADDRESS,
+            value: "10000000",
+            paymentKey: OTHER_PAYMENT_HASH,
+            tokens: [],
+          },
+        ],
+        outputs: [
+          {
+            address: ADDRESS,
+            value: "5000000",
+            paymentKey: PAYMENT_HASH,
+            tokens: [{ policyId: "pol1", assetName: assetNameHex, value: "100" }],
+          },
+        ],
+      }),
+    ]);
+
+    const { items } = await listOperations(currency, ADDRESS, options);
+
+    const tokenOp = items.find(op => op.asset.type === "token");
+    expect(tokenOp).toMatchObject({
+      id: `cardano-tx-hash-1-pol1.${assetNameHex}`,
+      type: "IN",
+      value: 100n,
+      asset: { type: "token", assetReference: `pol1.${assetNameHex}`, assetOwner: ADDRESS },
+    });
+    expect(tokenOp?.details).toMatchObject({ assetNameDecoded: "MYTOKEN" });
+  });
+
+  it("skips tokens whose net balance is zero", async () => {
+    mockResponse([
+      makeTx({
+        inputs: [
+          {
+            txId: "in-0",
+            index: 0,
+            address: ADDRESS,
+            value: "3000000",
+            paymentKey: PAYMENT_HASH,
+            tokens: [{ policyId: "pol1", assetName: "abcd", value: "50" }],
+          },
+        ],
+        outputs: [
+          {
+            address: ADDRESS,
+            value: "2800000",
+            paymentKey: PAYMENT_HASH,
+            tokens: [{ policyId: "pol1", assetName: "abcd", value: "50" }],
+          },
+        ],
+      }),
+    ]);
+
+    const { items } = await listOperations(currency, ADDRESS, options);
+
+    expect(items.every(op => op.asset.type === "native")).toBe(true);
+  });
+
+  it("emits a token OUT operation when tokens are spent", async () => {
+    mockResponse([
+      makeTx({
+        inputs: [
+          {
+            txId: "in-0",
+            index: 0,
+            address: ADDRESS,
+            value: "3000000",
+            paymentKey: PAYMENT_HASH,
+            tokens: [{ policyId: "pol1", assetName: "abcd", value: "50" }],
+          },
+        ],
+        outputs: [{ address: ADDRESS, value: "2800000", paymentKey: PAYMENT_HASH, tokens: [] }],
+      }),
+    ]);
+
+    const { items } = await listOperations(currency, ADDRESS, options);
+
+    const tokenOp = items.find(op => op.asset.type === "token");
+    expect(tokenOp).toMatchObject({ type: "OUT", value: 50n });
+  });
+
+  it("emits one operation per distinct asset moved in a transaction", async () => {
+    mockResponse([
+      makeTx({
+        inputs: [
+          {
+            txId: "in-0",
+            index: 0,
+            address: COUNTERPARTY_ADDRESS,
+            value: "10000000",
+            paymentKey: OTHER_PAYMENT_HASH,
+            tokens: [],
+          },
+        ],
+        outputs: [
+          {
+            address: ADDRESS,
+            value: "5000000",
+            paymentKey: PAYMENT_HASH,
+            tokens: [
+              { policyId: "pol1", assetName: "a1", value: "10" },
+              { policyId: "pol2", assetName: "a2", value: "20" },
+            ],
+          },
+        ],
+      }),
+    ]);
+
+    const { items } = await listOperations(currency, ADDRESS, options);
+
+    const tokenOps = items.filter(op => op.asset.type === "token");
+    expect(tokenOps).toHaveLength(2);
+    expect(tokenOps.map(op => op.value).sort()).toEqual([10n, 20n]);
+    expect(items.filter(op => op.asset.type === "native")).toHaveLength(1);
+  });
+
+  it("nets the same asset across multiple inputs and outputs into one token operation", async () => {
+    mockResponse([
+      makeTx({
+        inputs: [
+          {
+            txId: "in-0",
+            index: 0,
+            address: ADDRESS,
+            value: "1000000",
+            paymentKey: PAYMENT_HASH,
+            tokens: [{ policyId: "pol1", assetName: "abcd", value: "20" }],
+          },
+        ],
+        outputs: [
+          {
+            address: ADDRESS,
+            value: "500000",
+            paymentKey: PAYMENT_HASH,
+            tokens: [{ policyId: "pol1", assetName: "abcd", value: "40" }],
+          },
+          {
+            address: ADDRESS,
+            value: "500000",
+            paymentKey: PAYMENT_HASH,
+            tokens: [{ policyId: "pol1", assetName: "abcd", value: "10" }],
+          },
+        ],
+      }),
+    ]);
+
+    const { items } = await listOperations(currency, ADDRESS, options);
+
+    const tokenOps = items.filter(op => op.asset.type === "token");
+    // net = (40 + 10 received) - (20 spent) = +30
+    expect(tokenOps).toHaveLength(1);
+    expect(tokenOps[0]).toMatchObject({ type: "IN", value: 30n });
+  });
+
+  it("classifies a delegation certificate as DELEGATE and resolves the pool id", async () => {
+    mockResponse([
+      makeTx({
+        certificate: {
+          ...emptyCertificate,
+          stakeDelegations: [
+            {
+              index: 0,
+              poolKeyHash: POOL_KEY_HASH,
+              stakeCredential: { type: HashType.ADDRESS, key: STAKE_HASH },
+            },
+          ],
+        },
+        inputs: [
+          {
+            txId: "in-0",
+            index: 0,
+            address: ADDRESS,
+            value: "3000000",
+            paymentKey: PAYMENT_HASH,
+            tokens: [],
+          },
+        ],
+        outputs: [{ address: ADDRESS, value: "2800000", paymentKey: PAYMENT_HASH, tokens: [] }],
+      }),
+    ]);
+
+    const { items } = await listOperations(currency, ADDRESS, options);
+
+    expect(items[0].type).toBe("DELEGATE");
+    expect(items[0].details).toMatchObject({ poolId: expect.stringMatching(/^pool1/) });
+    // Outflow whose only cost is the fee → value 0 (adapter re-adds tx.fees).
+    expect(items[0].value).toBe(0n);
+  });
+
+  it("does not attribute another account's delegation certificate to this operation", async () => {
+    const FOREIGN_STAKE_HASH = "99".repeat(28);
+    mockResponse([
+      makeTx({
+        certificate: {
+          ...emptyCertificate,
+          stakeDelegations: [
+            {
+              index: 0,
+              poolKeyHash: POOL_KEY_HASH,
+              stakeCredential: { type: HashType.ADDRESS, key: FOREIGN_STAKE_HASH },
+            },
+          ],
+        },
+        inputs: [
+          {
+            txId: "in-0",
+            index: 0,
+            address: COUNTERPARTY_ADDRESS,
+            value: "10000000",
+            paymentKey: OTHER_PAYMENT_HASH,
+            tokens: [],
+          },
+        ],
+        outputs: [{ address: ADDRESS, value: "5000000", paymentKey: PAYMENT_HASH, tokens: [] }],
+      }),
+    ]);
+
+    const { items } = await listOperations(currency, ADDRESS, options);
+
+    expect(items[0].type).toBe("IN");
+    expect(items[0].details).not.toHaveProperty("poolId");
+  });
+
+  it("classifies a de-registration as UNDELEGATE and records the refund", async () => {
+    mockResponse([
+      makeTx({
+        certificate: {
+          ...emptyCertificate,
+          stakeDeRegistrations: [
+            { index: 0, stakeCredential: { type: HashType.ADDRESS, key: STAKE_HASH } },
+          ],
+        },
+        inputs: [
+          {
+            txId: "in-0",
+            index: 0,
+            address: ADDRESS,
+            value: "3000000",
+            paymentKey: PAYMENT_HASH,
+            tokens: [],
+          },
+        ],
+        outputs: [{ address: ADDRESS, value: "4600000", paymentKey: PAYMENT_HASH, tokens: [] }],
+      }),
+    ]);
+
+    const { items } = await listOperations(currency, ADDRESS, options);
+
+    expect(items[0].type).toBe("UNDELEGATE");
+    expect(items[0].details).toMatchObject({ refund: "2000000" });
+    // magnitude (400_000) minus fee (200_000); adapter re-adds tx.fees.
+    expect(items[0].value).toBe(200000n);
+  });
+
+  it("does not attribute another account's de-registration to this operation", async () => {
+    const FOREIGN_STAKE_HASH = "99".repeat(28);
+    mockResponse([
+      makeTx({
+        certificate: {
+          ...emptyCertificate,
+          stakeDeRegistrations: [
+            { index: 0, stakeCredential: { type: HashType.ADDRESS, key: FOREIGN_STAKE_HASH } },
+          ],
+        },
+        inputs: [
+          {
+            txId: "in-0",
+            index: 0,
+            address: COUNTERPARTY_ADDRESS,
+            value: "10000000",
+            paymentKey: OTHER_PAYMENT_HASH,
+            tokens: [],
+          },
+        ],
+        outputs: [{ address: ADDRESS, value: "5000000", paymentKey: PAYMENT_HASH, tokens: [] }],
+      }),
+    ]);
+
+    const { items } = await listOperations(currency, ADDRESS, options);
+
+    expect(items[0].type).toBe("IN");
+    expect(items[0].details).not.toHaveProperty("refund");
+  });
+
+  it("records a stake registration deposit", async () => {
+    mockResponse([
+      makeTx({
+        certificate: {
+          ...emptyCertificate,
+          stakeRegistrations: [
+            { index: 0, stakeCredential: { type: HashType.ADDRESS, key: STAKE_HASH } },
+          ],
+        },
+        inputs: [
+          {
+            txId: "in-0",
+            index: 0,
+            address: ADDRESS,
+            value: "5000000",
+            paymentKey: PAYMENT_HASH,
+            tokens: [],
+          },
+        ],
+        outputs: [{ address: ADDRESS, value: "2800000", paymentKey: PAYMENT_HASH, tokens: [] }],
+      }),
+    ]);
+
+    const { items } = await listOperations(currency, ADDRESS, options);
+
+    expect(items[0].details).toMatchObject({ deposit: "2000000" });
+    // A bare registration (no delegation) is not a staking type: it stays value-based.
+    expect(items[0].type).toBe("OUT");
+  });
+
+  it("sources the pre-Conway stake deposit from network protocol params, not a hard-coded value", async () => {
+    mockResponse(
+      [
+        makeTx({
+          certificate: {
+            ...emptyCertificate,
+            stakeRegistrations: [
+              { index: 0, stakeCredential: { type: HashType.ADDRESS, key: STAKE_HASH } },
+            ],
+          },
+          inputs: [
+            {
+              txId: "in-0",
+              index: 0,
+              address: ADDRESS,
+              value: "9000000",
+              paymentKey: PAYMENT_HASH,
+              tokens: [],
+            },
+          ],
+          outputs: [{ address: ADDRESS, value: "2800000", paymentKey: PAYMENT_HASH, tokens: [] }],
+        }),
+      ],
+      { stakeKeyDeposit: "500000" },
+    );
+
+    const { items } = await listOperations(currency, ADDRESS, options);
+
+    expect(items[0].details).toMatchObject({ deposit: "500000" });
+  });
+
+  it("does not fetch network protocol params for pages without pre-Conway stake certs", async () => {
+    mockResponse([
+      makeTx({
+        inputs: [
+          {
+            txId: "in-0",
+            index: 0,
+            address: COUNTERPARTY_ADDRESS,
+            value: "10000000",
+            paymentKey: OTHER_PAYMENT_HASH,
+            tokens: [],
+          },
+        ],
+        outputs: [{ address: ADDRESS, value: "5000000", paymentKey: PAYMENT_HASH, tokens: [] }],
+      }),
+    ]);
+
+    await listOperations(currency, ADDRESS, options);
+
+    const fetchedNetworkInfo = mockNetwork.mock.calls.some(
+      ([req]: [{ url?: string }]) =>
+        typeof req?.url === "string" && req.url.includes("/network/info"),
+    );
+    expect(fetchedNetworkInfo).toBe(false);
+  });
+
+  it("records reward withdrawals", async () => {
+    mockResponse([
+      makeTx({
+        withdrawals: [
+          {
+            stakeCredential: { type: HashType.ADDRESS, key: STAKE_HASH },
+            stakeHex: "deadbeef",
+            amount: "1500000",
+          },
+        ],
+        inputs: [
+          {
+            txId: "in-0",
+            index: 0,
+            address: ADDRESS,
+            value: "3000000",
+            paymentKey: PAYMENT_HASH,
+            tokens: [],
+          },
+        ],
+        outputs: [{ address: ADDRESS, value: "2800000", paymentKey: PAYMENT_HASH, tokens: [] }],
+      }),
+    ]);
+
+    const { items } = await listOperations(currency, ADDRESS, options);
+
+    expect(items[0].details).toMatchObject({ rewards: "1500000" });
+  });
+
+  it("extracts a transaction memo from metadata", async () => {
+    mockResponse([
+      makeTx({
+        metadata: {
+          hash: "metadata-hash",
+          data: [{ label: "674", value: JSON.stringify({ msg: ["hello", "world"] }) }],
+        },
+        inputs: [
+          {
+            txId: "in-0",
+            index: 0,
+            address: COUNTERPARTY_ADDRESS,
+            value: "10000000",
+            paymentKey: OTHER_PAYMENT_HASH,
+            tokens: [],
+          },
+        ],
+        outputs: [{ address: ADDRESS, value: "5000000", paymentKey: PAYMENT_HASH, tokens: [] }],
+      }),
+    ]);
+
+    const { items } = await listOperations(currency, ADDRESS, options);
+
+    expect(items[0].details).toMatchObject({ memo: "hello, world", metadataHash: "metadata-hash" });
+  });
+
+  describe("pagination", () => {
+    it("returns the next cursor when the page is full", async () => {
+      mockResponse(
+        [
+          makeTx({
+            inputs: [
+              {
+                txId: "in-0",
+                index: 0,
+                address: COUNTERPARTY_ADDRESS,
+                value: "10000000",
+                paymentKey: OTHER_PAYMENT_HASH,
+                tokens: [],
+              },
+            ],
+            outputs: [{ address: ADDRESS, value: "5000000", paymentKey: PAYMENT_HASH, tokens: [] }],
+          }),
+        ],
+        { limit: 1 },
+      );
+
+      const { next } = await listOperations(currency, ADDRESS, options);
+
+      expect(next).toBe("2");
+    });
+
+    it("derives the next cursor from the server-returned page, not the requested one", async () => {
+      // Backend clamps the requested page (cursor "999") to page 5; next must
+      // follow the page actually served (-> "6"), not the requested one.
+      mockResponse(
+        [
+          makeTx({
+            inputs: [
+              {
+                txId: "in-0",
+                index: 0,
+                address: COUNTERPARTY_ADDRESS,
+                value: "10000000",
+                paymentKey: OTHER_PAYMENT_HASH,
+                tokens: [],
+              },
+            ],
+            outputs: [{ address: ADDRESS, value: "5000000", paymentKey: PAYMENT_HASH, tokens: [] }],
+          }),
+        ],
+        { limit: 1, pageNo: 5 },
+      );
+
+      const { next } = await listOperations(currency, ADDRESS, { ...options, cursor: "999" });
+
+      expect(next).toBe("6");
+    });
+
+    it("has no next cursor when the page is not full", async () => {
+      mockResponse(
+        [
+          makeTx({
+            inputs: [
+              {
+                txId: "in-0",
+                index: 0,
+                address: COUNTERPARTY_ADDRESS,
+                value: "10000000",
+                paymentKey: OTHER_PAYMENT_HASH,
+                tokens: [],
+              },
+            ],
+            outputs: [{ address: ADDRESS, value: "5000000", paymentKey: PAYMENT_HASH, tokens: [] }],
+          }),
+        ],
+        { limit: 50 },
+      );
+
+      const { next } = await listOperations(currency, ADDRESS, options);
+
+      expect(next).toBeUndefined();
+    });
+
+    it("requests the page indicated by the cursor", async () => {
+      mockResponse([], { limit: 50 });
+
+      await listOperations(currency, ADDRESS, { ...options, cursor: "3" });
+
+      expect(mockNetwork).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ pageNo: 3 }) }),
+      );
+    });
+
+    it("falls back to page 1 for an invalid cursor", async () => {
+      mockResponse([], { limit: 50 });
+
+      await listOperations(currency, ADDRESS, { ...options, cursor: "not-a-number" });
+
+      expect(mockNetwork).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ pageNo: 1 }) }),
+      );
+    });
+
+    it("keeps paginating when a full page is entirely filtered out by minHeight", async () => {
+      // Full raw page (transactions.length === limit) but every tx is below
+      // minHeight, so no operations are produced. Pagination must still advance
+      // — hasMore keys off the raw transaction count, not the operation count.
+      mockResponse([makeTx({ blockHeight: 1000 })], { limit: 1 });
+
+      const { items, next } = await listOperations(currency, ADDRESS, {
+        ...options,
+        minHeight: 2000,
+      });
+
+      expect(items).toEqual([]);
+      expect(next).toBe("2");
+    });
+  });
+
+  it("filters out transactions below minHeight", async () => {
+    mockResponse([makeTx({ blockHeight: 1000 })]);
+
+    const { items } = await listOperations(currency, ADDRESS, { ...options, minHeight: 2000 });
+
+    expect(items).toEqual([]);
+  });
+
+  it("orders operations descending (newest first)", async () => {
+    mockResponse([
+      makeTx({
+        hash: "older",
+        timestamp: "2023-01-01T00:00:00.000Z",
+        inputs: [
+          {
+            txId: "in-0",
+            index: 0,
+            address: COUNTERPARTY_ADDRESS,
+            value: "10000000",
+            paymentKey: OTHER_PAYMENT_HASH,
+            tokens: [],
+          },
+        ],
+        outputs: [{ address: ADDRESS, value: "5000000", paymentKey: PAYMENT_HASH, tokens: [] }],
+      }),
+      makeTx({
+        hash: "newer",
+        timestamp: "2023-12-31T00:00:00.000Z",
+        inputs: [
+          {
+            txId: "in-1",
+            index: 0,
+            address: COUNTERPARTY_ADDRESS,
+            value: "10000000",
+            paymentKey: OTHER_PAYMENT_HASH,
+            tokens: [],
+          },
+        ],
+        outputs: [{ address: ADDRESS, value: "5000000", paymentKey: PAYMENT_HASH, tokens: [] }],
+      }),
+    ]);
+
+    const { items } = await listOperations(currency, ADDRESS, { ...options, order: "desc" });
+
+    expect(items[0].id).toBe("cardano-newer");
+    expect(items[1].id).toBe("cardano-older");
+  });
+
+  it("rejects ascending order (cannot be honored across pages on a newest-first backend)", async () => {
+    await expect(listOperations(currency, ADDRESS, { ...options, order: "asc" })).rejects.toThrow(
+      "ascending order is not supported",
+    );
+  });
+});

--- a/libs/coin-modules/coin-cardano/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/listOperations.ts
@@ -1,0 +1,509 @@
+import {
+  AssetInfo,
+  Page,
+  MemoNotSupported,
+  Operation,
+  ListOperationsOptions,
+} from "@ledgerhq/coin-module-framework/api/types";
+import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { OperationType } from "@ledgerhq/types-live";
+import { log } from "@ledgerhq/logs";
+import network from "@ledgerhq/live-network/network";
+import { BigNumber } from "bignumber.js";
+import { APITransaction, HashType, StakeDelegationCertificate } from "../api/api-types";
+import { fetchNetworkInfo } from "../api/getNetworkInfo";
+import { CARDANO_API_ENDPOINT, CARDANO_TESTNET_API_ENDPOINT } from "../constants";
+import {
+  isTestnet,
+  getMemoFromTx,
+  isHexString,
+  decodeTokenName,
+  getBech32PoolId,
+  findStakeRegistration,
+  findStakeDeRegistration,
+  findWithdrawal,
+  getOperationType,
+} from "../logic";
+import { getNetworkParameters } from "../networks";
+import {
+  safeBigInt,
+  safeDate,
+  normalizeAddress,
+  extractPaymentKeyFromAddress,
+  extractStakeKeyFromAddress,
+  EMPTY_CREDENTIAL_KEY,
+} from "../utils";
+
+// Logs a warning when a page yields an unusually large number of operations. One
+// transaction can produce several operations (native + one per token moved), so
+// the threshold is measured in derived operations, not transactions.
+const LARGE_OPERATION_SET_THRESHOLD = 200;
+
+type TransactionParties = {
+  senders: string[];
+  recipients: string[];
+};
+
+type TokenBalance = {
+  policyId: string;
+  assetName: string;
+  balance: bigint;
+};
+
+function buildTransactionInfo(
+  tx: APITransaction,
+  senders: string[],
+): Operation<MemoNotSupported>["tx"] {
+  return {
+    hash: tx.hash,
+    block: {
+      height: tx.blockHeight,
+      hash: "", // Cardano API doesn't provide block hash in transaction list
+      time: safeDate(tx.timestamp),
+    },
+    fees: safeBigInt(tx.fees),
+    feesPayer: senders.length === 1 ? senders[0] : undefined,
+    date: safeDate(tx.timestamp),
+    failed: false, // Cardano API only returns successful transactions
+  };
+}
+
+function extractParties(tx: APITransaction): TransactionParties {
+  const senderSet = new Set<string>();
+
+  if (Array.isArray(tx.inputs)) {
+    for (const input of tx.inputs) {
+      const address = normalizeAddress(input.address, isHexString);
+      senderSet.add(address);
+    }
+  }
+
+  const recipientSet = new Set<string>();
+
+  if (Array.isArray(tx.outputs)) {
+    for (const output of tx.outputs) {
+      const address = normalizeAddress(output.address, isHexString);
+      recipientSet.add(address);
+    }
+  }
+
+  const senders = Array.from(senderSet);
+  const recipients = Array.from(recipientSet);
+
+  return {
+    senders,
+    recipients,
+  };
+}
+
+// Returns SIGNED value (positive = received, negative = spent)
+function computeValue(tx: APITransaction, paymentKey: string): bigint {
+  let totalReceived = 0n;
+  let totalSpent = 0n;
+
+  if (Array.isArray(tx.outputs)) {
+    for (const output of tx.outputs) {
+      if (output.paymentKey === paymentKey) {
+        totalReceived += safeBigInt(output.value);
+      }
+    }
+  }
+
+  if (Array.isArray(tx.inputs)) {
+    for (const input of tx.inputs) {
+      if (input.paymentKey === paymentKey) {
+        totalSpent += safeBigInt(input.value);
+      }
+    }
+  }
+
+  return totalReceived - totalSpent;
+}
+
+// Finds a delegation certificate belonging to THIS account's stake key.
+// A transaction may carry certificates for several accounts, so matching on the
+// stake key is required before attributing the delegation (and its pool) to us.
+function findOwnedStakeDelegation(
+  tx: APITransaction,
+  stakeKey: string,
+): StakeDelegationCertificate | undefined {
+  return tx.certificate.stakeDelegations?.find(
+    cert => cert.stakeCredential.type === HashType.ADDRESS && cert.stakeCredential.key === stakeKey,
+  );
+}
+
+// Staking types (DELEGATE/UNDELEGATE) are only assigned when the certificate
+// belongs to this account's stake key. Certificates for other accounts present
+// in the same transaction must not reclassify our operation.
+function determineOperationType(
+  tx: APITransaction,
+  stakeKey: string | undefined,
+  networkId: number,
+  stakeKeyDeposit: string,
+  operationValue: bigint,
+  fees: bigint,
+): OperationType {
+  if (stakeKey) {
+    if (findOwnedStakeDelegation(tx, stakeKey)) {
+      return "DELEGATE";
+    }
+
+    if (findStakeDeRegistration(tx, stakeKey, networkId, stakeKeyDeposit) !== undefined) {
+      return "UNDELEGATE";
+    }
+  }
+
+  return getOperationType({
+    valueChange: new BigNumber(operationValue.toString()),
+    fees: new BigNumber(fees.toString()),
+  });
+}
+
+function toNativeOperation(
+  currency: CryptoCurrency,
+  paymentKey: string,
+  tx: APITransaction,
+  parties: TransactionParties,
+  stakeKey: string | undefined,
+  stakeKeyDeposit: string,
+): Operation<MemoNotSupported> {
+  const { senders, recipients } = parties;
+  const networkParams = getNetworkParameters(currency.id);
+
+  const details: Record<string, unknown> = {};
+
+  const memo = getMemoFromTx(tx);
+  if (memo) {
+    details.memo = memo;
+  }
+
+  let operationValue = computeValue(tx, paymentKey);
+
+  if (stakeKey) {
+    const registration = findStakeRegistration(
+      tx,
+      stakeKey,
+      networkParams.networkId,
+      stakeKeyDeposit,
+    );
+    if (registration) {
+      details.deposit = registration;
+    }
+
+    const deRegistration = findStakeDeRegistration(
+      tx,
+      stakeKey,
+      networkParams.networkId,
+      stakeKeyDeposit,
+    );
+    if (deRegistration) {
+      const refundAmount = safeBigInt(deRegistration);
+      operationValue = operationValue - refundAmount;
+      details.refund = deRegistration;
+    }
+
+    const withdrawal = findWithdrawal(tx, stakeKey);
+    if (withdrawal) {
+      const withdrawalAmount = safeBigInt(withdrawal);
+      operationValue = operationValue - withdrawalAmount;
+      details.rewards = withdrawal;
+    }
+  }
+
+  const ownedDelegation = stakeKey ? findOwnedStakeDelegation(tx, stakeKey) : undefined;
+  if (ownedDelegation) {
+    details.poolId = getBech32PoolId(ownedDelegation.poolKeyHash, currency.id);
+  }
+
+  if (tx.metadata?.hash) {
+    details.metadataHash = tx.metadata.hash;
+  }
+
+  const fees = safeBigInt(tx.fees);
+  const type = determineOperationType(
+    tx,
+    stakeKey,
+    networkParams.networkId,
+    stakeKeyDeposit,
+    operationValue,
+    fees,
+  );
+
+  // The generic-coin-framework adapter re-adds tx.fees to native OUT/FEES/DELEGATE/
+  // UNDELEGATE operations (libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts),
+  // so Operation.value must EXCLUDE the fee for those types to avoid double-counting.
+  // IN/NONE are passed through as-is by the adapter. A pure-fee self-transfer (FEES)
+  // therefore carries value 0 — the adapter surfaces the fee.
+  const magnitude = operationValue >= 0n ? operationValue : -operationValue;
+  const adapterReaddsFee =
+    type === "OUT" || type === "FEES" || type === "DELEGATE" || type === "UNDELEGATE";
+  const value = adapterReaddsFee ? (magnitude > fees ? magnitude - fees : 0n) : magnitude;
+
+  const assetInfo: AssetInfo = { type: "native" };
+
+  return {
+    id: `${currency.id}-${tx.hash}`,
+    type,
+    senders,
+    recipients,
+    value,
+    asset: assetInfo,
+    tx: buildTransactionInfo(tx, senders),
+    details,
+  };
+}
+
+// Process token items with balance multiplier (-1n for inputs, +1n for outputs)
+function processTokenItems(
+  items: Array<{
+    paymentKey: string;
+    tokens: Array<{ policyId: string; assetName: string; value: string }>;
+  }>,
+  paymentKey: string,
+  balanceMultiplier: bigint,
+  tokenBalances: Map<string, TokenBalance>,
+): void {
+  for (const item of items) {
+    if (item.paymentKey !== paymentKey) {
+      continue;
+    }
+
+    for (const token of item.tokens) {
+      const key = `${token.policyId}.${token.assetName}`;
+      const current = tokenBalances.get(key) || {
+        policyId: token.policyId,
+        assetName: token.assetName,
+        balance: 0n,
+      };
+      current.balance += safeBigInt(token.value) * balanceMultiplier;
+      tokenBalances.set(key, current);
+    }
+  }
+}
+
+function extractTokenOperations(
+  currency: CryptoCurrency,
+  address: string,
+  paymentKey: string,
+  tx: APITransaction,
+  parties: TransactionParties,
+): Operation<MemoNotSupported>[] {
+  const tokenOperations: Operation<MemoNotSupported>[] = [];
+  const { senders, recipients } = parties;
+
+  const tokenBalances = new Map<string, TokenBalance>();
+
+  if (Array.isArray(tx.inputs)) {
+    processTokenItems(tx.inputs, paymentKey, -1n, tokenBalances);
+  }
+
+  if (Array.isArray(tx.outputs)) {
+    processTokenItems(tx.outputs, paymentKey, 1n, tokenBalances);
+  }
+
+  for (const [, tokenData] of tokenBalances) {
+    // Zero net balance is normal (self-transfers / consolidations) — skip silently
+    // rather than logging on every such token, which would be noisy in production.
+    if (tokenData.balance === 0n) {
+      continue;
+    }
+
+    const isReceiving = tokenData.balance > 0n;
+    const tokenType = isReceiving ? "IN" : "OUT";
+    const tokenValue = tokenData.balance >= 0n ? tokenData.balance : -tokenData.balance;
+
+    const assetReference = `${tokenData.policyId}.${tokenData.assetName}`;
+
+    const assetInfo: AssetInfo = {
+      type: "token",
+      assetReference,
+      assetOwner: address,
+    };
+
+    const decodedName = decodeTokenName(tokenData.assetName);
+    const details: Record<string, unknown> = {
+      policyId: tokenData.policyId,
+      assetName: tokenData.assetName,
+    };
+
+    if (decodedName !== tokenData.assetName) {
+      details.assetNameDecoded = decodedName;
+    }
+
+    tokenOperations.push({
+      id: `${currency.id}-${tx.hash}-${assetReference}`,
+      type: tokenType,
+      senders,
+      recipients,
+      value: tokenValue,
+      asset: assetInfo,
+      tx: buildTransactionInfo(tx, senders),
+      details,
+    });
+  }
+
+  return tokenOperations;
+}
+
+// We don't send a limit to this endpoint; the server dictates the page size and
+// returns it as `limit`, which the caller uses only to detect a full page.
+async function fetchTransactionsByPaymentKey(
+  paymentKey: string,
+  currency: CryptoCurrency,
+  blockHeight: number = 0,
+  pageNo: number = 1,
+): Promise<{
+  transactions: APITransaction[];
+  pageNo: number;
+  limit: number;
+  blockHeight: number;
+}> {
+  const endpoint = isTestnet(currency) ? CARDANO_TESTNET_API_ENDPOINT : CARDANO_API_ENDPOINT;
+
+  const res = await network({
+    method: "POST",
+    url: `${endpoint}/v1/transaction`,
+    data: {
+      paymentKeys: [paymentKey],
+      pageNo,
+      blockHeight,
+    },
+  });
+
+  const {
+    transactions = [],
+    pageNo: resPageNo = pageNo,
+    limit = 0,
+    blockHeight: resBlockHeight = blockHeight,
+  } = res.data;
+
+  return {
+    transactions,
+    pageNo: resPageNo,
+    limit,
+    blockHeight: resBlockHeight,
+  };
+}
+
+/**
+ * List operations for a Cardano address with pagination support.
+ *
+ * Pagination is page-based. This implementation never sends a `limit` to the
+ * `/v1/transaction` endpoint, so `options.limit` has no effect — the page size
+ * is whatever the server returns (used only to detect a full page). The
+ * `options.minHeight` and `options.order` options are applied.
+ *
+ * @param currency - The Cardano currency object
+ * @param address - Cardano address string (bech32 format)
+ * @param options - Pagination and filtering options (note: `limit` is not sent and has no effect)
+ * @returns Paginated list of operations (native ADA + tokens)
+ */
+export async function listOperations(
+  currency: CryptoCurrency,
+  address: string,
+  options: ListOperationsOptions,
+): Promise<Page<Operation<MemoNotSupported>>> {
+  // The backend pages newest -> oldest and the cursor only moves forward, so
+  // ascending order can't be honored consistently across pages. Reject it rather
+  // than return a misleading within-page-only sort (same stance as coin-solana).
+  if (options.order === "asc") {
+    throw new Error("ascending order is not supported");
+  }
+
+  if (!address || typeof address !== "string") {
+    return {
+      items: [],
+      next: undefined,
+    };
+  }
+
+  const paymentKey = extractPaymentKeyFromAddress(address);
+
+  if (paymentKey === EMPTY_CREDENTIAL_KEY) {
+    return {
+      items: [],
+      next: undefined,
+    };
+  }
+
+  const stakeKey = extractStakeKeyFromAddress(address);
+
+  let pageNo = 1;
+  if (options.cursor) {
+    const parsed = Number.parseInt(options.cursor, 10);
+    if (Number.isNaN(parsed) || parsed < 1) {
+      log("cardano/listOperations", "Invalid cursor, falling back to page 1", {
+        cursor: options.cursor,
+        parsed,
+        address,
+      });
+    } else {
+      pageNo = parsed;
+    }
+  }
+  const blockHeight = options.minHeight || 0;
+
+  // Use the page number the backend actually served (it may clamp/normalize the
+  // requested one) so the `next` cursor stays consistent with the server.
+  const {
+    transactions,
+    limit,
+    pageNo: servedPageNo,
+  } = await fetchTransactionsByPaymentKey(paymentKey, currency, blockHeight, pageNo);
+
+  // Pre-Conway registration/de-registration amounts aren't carried on the
+  // certificate — they come from the protocol params (as the rest of the Cardano
+  // stack does). Fetch once, and only when the page actually contains such a
+  // certificate, to avoid an extra request for plain transfer history.
+  const hasPreConwayStakeCerts = transactions.some(
+    tx => tx.certificate.stakeRegistrations?.length || tx.certificate.stakeDeRegistrations?.length,
+  );
+  const stakeKeyDeposit = hasPreConwayStakeCerts
+    ? (await fetchNetworkInfo(currency)).protocolParams.stakeKeyDeposit
+    : "";
+
+  const allOperations: Operation<MemoNotSupported>[] = [];
+
+  for (const tx of transactions) {
+    if (options.minHeight && tx.blockHeight < options.minHeight) {
+      continue;
+    }
+
+    const parties = extractParties(tx);
+
+    const nativeOp = toNativeOperation(
+      currency,
+      paymentKey,
+      tx,
+      parties,
+      stakeKey,
+      stakeKeyDeposit,
+    );
+    allOperations.push(nativeOp);
+
+    const tokenOps = extractTokenOperations(currency, address, paymentKey, tx, parties);
+    allOperations.push(...tokenOps);
+  }
+
+  if (allOperations.length > LARGE_OPERATION_SET_THRESHOLD) {
+    log("cardano/listOperations", "Large operation set returned", {
+      operationCount: allOperations.length,
+      transactionCount: transactions.length,
+      pageNo: servedPageNo,
+      addressTruncated: `${address.substring(0, 20)}...`,
+    });
+  }
+
+  // Descending (newest first) — ascending is rejected above.
+  allOperations.sort((a, b) => b.tx.date.getTime() - a.tx.date.getTime());
+
+  // Page fullness is decided on the raw transaction count, not the derived
+  // operation count: a full page filtered out by minHeight still has more pages.
+  const hasMore = limit > 0 && transactions.length >= limit;
+  const nextCursor = hasMore ? String(servedPageNo + 1) : undefined;
+
+  return {
+    items: allOperations,
+    next: nextCursor,
+  };
+}

--- a/libs/coin-modules/coin-cardano/src/pools.ts
+++ b/libs/coin-modules/coin-cardano/src/pools.ts
@@ -1,0 +1,14 @@
+// Ledger stake pool IDs shown in LLD/LLM. Kept in a dependency-free module so
+// consumers that only need these constants (e.g. ledger-live-common's staking
+// re-export) don't pull in the address-parsing helpers' Typhon dependency.
+
+// Ledger by Figment 4 — the default selected pool.
+export const DEFAULT_SELECTED_POOL_ID: string =
+  "1f550e7b0c9ec67887859b182af4b8e8e08c1728c47344f2deb9424c";
+
+export const LEDGER_POOL_IDS: Array<string> = [
+  "a314a18528d00c5fbd067ecb4a212cf2f307c83d2c08f44a11ebebf6", // Ledger by Figment 1
+  "4a9c9902c9538da900b10b716d5d1b214487455fdb06028b32ffa180", // Ledger by Figment 2
+  "c726c9da5615d5f9f6858c25bb13f81c4741eccd08ce32f3414f323f", // Ledger by Figment 3
+  DEFAULT_SELECTED_POOL_ID, // Ledger by Figment 4
+];

--- a/libs/coin-modules/coin-cardano/src/synchronisation.ts
+++ b/libs/coin-modules/coin-cardano/src/synchronisation.ts
@@ -9,16 +9,19 @@ import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import { inferSubOperations } from "@ledgerhq/ledger-wallet-framework/serialization/index";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import type { Operation, OperationType, TokenAccount } from "@ledgerhq/types-live";
-import { utils as TyphonUtils, address as TyphonAddress } from "@stricahq/typhonjs";
+import { utils as TyphonUtils } from "@stricahq/typhonjs";
 import BigNumber from "bignumber.js";
 import uniqBy from "lodash/uniqBy";
-import { APITransaction, HashType } from "./api/api-types";
+import { APITransaction } from "./api/api-types";
 import { getDelegationInfo } from "./api/getDelegationInfo";
 import { fetchNetworkInfo } from "./api/getNetworkInfo";
 import { getTransactions } from "./api/getTransactions";
 import { buildSubAccounts } from "./buildSubAccounts";
 import { CARDANO_MAX_SUPPLY } from "./constants";
 import {
+  findStakeDeRegistration,
+  findStakeRegistration,
+  findWithdrawal,
   getAccountChange,
   getAccountStakeCredential,
   getBaseAddress,
@@ -212,10 +215,6 @@ export function mapTxToAccountOperation(
 ): CardanoOperation {
   const accountChange = getAccountChange(tx, accountCredentialsMap);
   const networkParams = getNetworkParameters(accountShapeInfo.currency.id);
-  const stakeAddress = new TyphonAddress.RewardAddress(networkParams.networkId, {
-    type: HashType.ADDRESS,
-    hash: Buffer.from(stakeCredential.key, "hex"),
-  });
 
   const subOperations = inferSubOperations(tx.hash, subAccounts);
   const memo = getMemoFromTx(tx);
@@ -226,97 +225,46 @@ export function mapTxToAccountOperation(
 
   let operationValue = accountChange.ada;
 
-  // pre-conway era stake registrations
-  if (tx.certificate.stakeRegistrations.length) {
-    const walletRegistration = tx.certificate.stakeRegistrations.find(
-      c =>
-        c.stakeCredential.type === HashType.ADDRESS &&
-        c.stakeCredential.key === stakeCredential.key,
-    );
-    if (walletRegistration) {
-      extra.deposit = formatCurrencyUnit(
-        accountShapeInfo.currency.units[0],
-        new BigNumber(protocolParams.stakeKeyDeposit),
-        {
-          showCode: true,
-          disableRounding: true,
-        },
-      );
-    }
+  // Stake registration deposit, de-registration refund, and reward withdrawal are
+  // detected via the shared logic.ts helpers (same source of truth as the
+  // CoinModule listOperations path), which cover both pre-Conway and Conway
+  // certificates and return the raw lovelace amount. The bridge formats it for
+  // display and adjusts the operation value (deposit is informational; refund and
+  // rewards reduce the spendable change).
+  const deposit = findStakeRegistration(
+    tx,
+    stakeCredential.key,
+    networkParams.networkId,
+    protocolParams.stakeKeyDeposit,
+  );
+  if (deposit) {
+    extra.deposit = formatCurrencyUnit(accountShapeInfo.currency.units[0], new BigNumber(deposit), {
+      showCode: true,
+      disableRounding: true,
+    });
   }
 
-  // conway era stake registrations
-  if (tx.certificate.stakeRegsConway?.length) {
-    const walletRegistration = tx.certificate.stakeRegsConway.find(
-      w => stakeAddress.getHex() === w.stakeHex,
-    );
-    if (walletRegistration) {
-      extra.deposit = formatCurrencyUnit(
-        accountShapeInfo.currency.units[0],
-        new BigNumber(walletRegistration.deposit),
-        {
-          showCode: true,
-          disableRounding: true,
-        },
-      );
-    }
+  const refund = findStakeDeRegistration(
+    tx,
+    stakeCredential.key,
+    networkParams.networkId,
+    protocolParams.stakeKeyDeposit,
+  );
+  if (refund) {
+    operationValue = operationValue.minus(refund);
+    extra.refund = formatCurrencyUnit(accountShapeInfo.currency.units[0], new BigNumber(refund), {
+      showCode: true,
+      disableRounding: true,
+    });
   }
 
-  // pre-conway era stake de-registrations
-  if (tx.certificate.stakeDeRegistrations.length) {
-    const walletDeRegistration = tx.certificate.stakeDeRegistrations.find(
-      c =>
-        c.stakeCredential.type === HashType.ADDRESS &&
-        c.stakeCredential.key === stakeCredential.key,
-    );
-    if (walletDeRegistration) {
-      operationValue = operationValue.minus(protocolParams.stakeKeyDeposit);
-      extra.refund = formatCurrencyUnit(
-        accountShapeInfo.currency.units[0],
-        new BigNumber(protocolParams.stakeKeyDeposit),
-        {
-          showCode: true,
-          disableRounding: true,
-        },
-      );
-    }
-  }
-
-  // conway era stake de-registrations
-  if (tx.certificate.stakeDeRegsConway?.length) {
-    const walletDeRegistration = tx.certificate.stakeDeRegsConway.find(
-      w => stakeAddress.getHex() === w.stakeHex,
-    );
-    if (walletDeRegistration) {
-      operationValue = operationValue.minus(walletDeRegistration.deposit);
-      extra.refund = formatCurrencyUnit(
-        accountShapeInfo.currency.units[0],
-        new BigNumber(walletDeRegistration.deposit),
-        {
-          showCode: true,
-          disableRounding: true,
-        },
-      );
-    }
-  }
-
-  if (tx.withdrawals && tx.withdrawals.length) {
-    const walletWithdraw = tx.withdrawals.find(
-      w =>
-        w.stakeCredential.type === HashType.ADDRESS &&
-        w.stakeCredential.key === stakeCredential.key,
-    );
-    if (walletWithdraw) {
-      operationValue = operationValue.minus(walletWithdraw.amount);
-      extra.rewards = formatCurrencyUnit(
-        accountShapeInfo.currency.units[0],
-        new BigNumber(walletWithdraw.amount),
-        {
-          showCode: true,
-          disableRounding: true,
-        },
-      );
-    }
+  const rewards = findWithdrawal(tx, stakeCredential.key);
+  if (rewards) {
+    operationValue = operationValue.minus(rewards);
+    extra.rewards = formatCurrencyUnit(accountShapeInfo.currency.units[0], new BigNumber(rewards), {
+      showCode: true,
+      disableRounding: true,
+    });
   }
 
   let mainOperationType: OperationType;

--- a/libs/coin-modules/coin-cardano/src/utils.test.ts
+++ b/libs/coin-modules/coin-cardano/src/utils.test.ts
@@ -1,0 +1,131 @@
+import {
+  address as TyphonAddress,
+  types as TyphonTypes,
+  utils as TyphonUtils,
+} from "@stricahq/typhonjs";
+import { isHexString } from "./logic";
+import {
+  EMPTY_CREDENTIAL_KEY,
+  extractPaymentKeyFromAddress,
+  extractStakeKeyFromAddress,
+  normalizeAddress,
+  safeBigInt,
+  safeDate,
+} from "./utils";
+
+const PAYMENT_HASH = "11".repeat(28);
+const STAKE_HASH = "22".repeat(28);
+
+const baseAddress = new TyphonAddress.BaseAddress(
+  TyphonTypes.NetworkId.MAINNET,
+  { type: TyphonTypes.HashType.ADDRESS, hash: Buffer.from(PAYMENT_HASH, "hex") },
+  { type: TyphonTypes.HashType.ADDRESS, hash: Buffer.from(STAKE_HASH, "hex") },
+);
+const enterpriseAddress = new TyphonAddress.EnterpriseAddress(TyphonTypes.NetworkId.MAINNET, {
+  type: TyphonTypes.HashType.ADDRESS,
+  hash: Buffer.from(PAYMENT_HASH, "hex"),
+});
+const rewardAddress = new TyphonAddress.RewardAddress(TyphonTypes.NetworkId.MAINNET, {
+  type: TyphonTypes.HashType.ADDRESS,
+  hash: Buffer.from(STAKE_HASH, "hex"),
+});
+
+describe("safeBigInt", () => {
+  it("converts numeric-like values", () => {
+    expect(safeBigInt("123")).toBe(123n);
+    expect(safeBigInt(456)).toBe(456n);
+  });
+
+  it("returns 0n for nullish or empty input", () => {
+    expect(safeBigInt(null)).toBe(0n);
+    expect(safeBigInt(undefined)).toBe(0n);
+    expect(safeBigInt("")).toBe(0n);
+  });
+
+  it("returns 0n for unparseable input", () => {
+    expect(safeBigInt("not-a-number")).toBe(0n);
+    expect(safeBigInt(1.5)).toBe(0n);
+  });
+});
+
+describe("safeDate", () => {
+  it("parses numeric and string timestamps", () => {
+    expect(safeDate(0).toISOString()).toBe("1970-01-01T00:00:00.000Z");
+    expect(safeDate("2023-06-01T00:00:00.000Z").toISOString()).toBe("2023-06-01T00:00:00.000Z");
+  });
+
+  it("falls back to epoch for invalid input", () => {
+    expect(safeDate("definitely-not-a-date").getTime()).toBe(0);
+    expect(safeDate({}).getTime()).toBe(0);
+    expect(safeDate(undefined).getTime()).toBe(0);
+  });
+});
+
+describe("normalizeAddress", () => {
+  it("returns bech32 addresses unchanged", () => {
+    const bech32 = baseAddress.getBech32();
+    expect(normalizeAddress(bech32, isHexString)).toBe(bech32);
+  });
+
+  it("converts a hex-encoded address to bech32", () => {
+    const bech32 = baseAddress.getBech32();
+    const hex = TyphonUtils.getAddressFromString(bech32).getHex();
+    expect(normalizeAddress(hex, isHexString)).toBe(bech32);
+  });
+
+  it("returns odd-length hex unchanged instead of silently truncating it", () => {
+    // "abc" is all hex chars but odd-length: Buffer.from would drop the last nibble.
+    const oddLengthHex = "abc";
+    expect(normalizeAddress(oddLengthHex, isHexString)).toBe(oddLengthHex);
+  });
+
+  it("returns the original string when hex decoding fails instead of throwing", () => {
+    const spy = jest.spyOn(TyphonUtils, "getAddressFromHex").mockImplementation(() => {
+      throw new Error("bad hex address");
+    });
+    const hexInput = "abcdef";
+
+    try {
+      expect(() => normalizeAddress(hexInput, isHexString)).not.toThrow();
+      expect(normalizeAddress(hexInput, isHexString)).toBe(hexInput);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe("extractPaymentKeyFromAddress", () => {
+  it("returns the payment credential hash for a base address", () => {
+    expect(extractPaymentKeyFromAddress(baseAddress.getBech32())).toBe(PAYMENT_HASH);
+  });
+
+  it("returns the payment credential hash for an enterprise address", () => {
+    expect(extractPaymentKeyFromAddress(enterpriseAddress.getBech32())).toBe(PAYMENT_HASH);
+  });
+
+  it("returns the empty credential key for a reward address (no payment credential)", () => {
+    expect(extractPaymentKeyFromAddress(rewardAddress.getBech32())).toBe(EMPTY_CREDENTIAL_KEY);
+  });
+
+  it("returns the empty credential key for an unparseable address", () => {
+    expect(extractPaymentKeyFromAddress("not-an-address")).toBe(EMPTY_CREDENTIAL_KEY);
+  });
+});
+
+describe("extractStakeKeyFromAddress", () => {
+  it("returns the stake credential hash for a base address", () => {
+    expect(extractStakeKeyFromAddress(baseAddress.getBech32())).toBe(STAKE_HASH);
+  });
+
+  it("returns the stake credential hash for a reward address", () => {
+    expect(extractStakeKeyFromAddress(rewardAddress.getBech32())).toBe(STAKE_HASH);
+  });
+
+  it("returns undefined for an enterprise address (no stake credential)", () => {
+    expect(extractStakeKeyFromAddress(enterpriseAddress.getBech32())).toBeUndefined();
+  });
+
+  it("returns undefined for an unparseable address", () => {
+    expect(extractStakeKeyFromAddress("not-an-address")).toBeUndefined();
+  });
+});

--- a/libs/coin-modules/coin-cardano/src/utils.ts
+++ b/libs/coin-modules/coin-cardano/src/utils.ts
@@ -1,11 +1,115 @@
-// the IDs of ledger stake pools to shows
-// Ledger by Figment 4
-export const DEFAULT_SELECTED_POOL_ID: string =
-  "1f550e7b0c9ec67887859b182af4b8e8e08c1728c47344f2deb9424c";
-// the IDs of ledger stake pools to shows in lld and llm
-export const LEDGER_POOL_IDS: Array<string> = [
-  "a314a18528d00c5fbd067ecb4a212cf2f307c83d2c08f44a11ebebf6", // Ledger by Figment 1
-  "4a9c9902c9538da900b10b716d5d1b214487455fdb06028b32ffa180", // Ledger by Figment 2
-  "c726c9da5615d5f9f6858c25bb13f81c4741eccd08ce32f3414f323f", // Ledger by Figment 3
-  DEFAULT_SELECTED_POOL_ID, // Ledger by Figment 4
-];
+import { log } from "@ledgerhq/logs";
+import { utils as TyphonUtils, address as TyphonAddress } from "@stricahq/typhonjs";
+
+/**
+ * Safely converts a value to BigInt, returning 0n if conversion fails.
+ * Prevents crashes from malformed API data (NaN, undefined, empty strings, null).
+ */
+export function safeBigInt(value: unknown): bigint {
+  if (typeof value !== "string" && typeof value !== "number" && typeof value !== "bigint") {
+    return 0n;
+  }
+  try {
+    return BigInt(value);
+  } catch {
+    return 0n;
+  }
+}
+
+/**
+ * Safely converts a timestamp to Date, returning epoch (1970-01-01) if invalid.
+ * Prevents Invalid Date objects from malformed API data.
+ */
+export function safeDate(timestamp: unknown): Date {
+  const date = new Date(
+    typeof timestamp === "number" || typeof timestamp === "string" ? timestamp : 0,
+  );
+  return Number.isNaN(date.getTime()) ? new Date(0) : date;
+}
+
+// Empty credential key used for unsupported address types (Byron, unknown)
+export const EMPTY_CREDENTIAL_KEY =
+  "0000000000000000000000000000000000000000000000000000000000000000";
+
+/**
+ * Normalizes a Cardano address from hex to bech32 format if needed.
+ * Returns the address as-is if it's already bech32 (or can't be decoded as hex).
+ */
+export function normalizeAddress(address: string, isHexString: (s: string) => boolean): string {
+  // An odd-length hex string would be silently truncated by Buffer.from(..., "hex"),
+  // yielding a wrong address instead of failing — require an even length before decoding.
+  if (isHexString(address) && address.length % 2 === 0) {
+    try {
+      return TyphonUtils.getAddressFromHex(Buffer.from(address, "hex")).getBech32();
+    } catch (error) {
+      log("cardano/utils", "Failed to normalize hex address", {
+        address,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return address;
+    }
+  }
+  return address;
+}
+
+/**
+ * Extract payment credential key hash from a Cardano address.
+ * Supports Base, Enterprise, and Pointer addresses (Shelley era).
+ * Reward (stake) addresses have no payment credential, and Byron / invalid
+ * addresses cannot be parsed — all return the empty credential key, which the
+ * caller treats as "no operations".
+ */
+export function extractPaymentKeyFromAddress(address: string): string {
+  try {
+    const cardanoAddress = TyphonUtils.getAddressFromString(address);
+
+    if (
+      cardanoAddress instanceof TyphonAddress.BaseAddress ||
+      cardanoAddress instanceof TyphonAddress.EnterpriseAddress ||
+      cardanoAddress instanceof TyphonAddress.PointerAddress
+    ) {
+      return cardanoAddress.paymentCredential.hash.toString("hex");
+    }
+
+    log("cardano/utils", "Unsupported address type", {
+      address,
+      addressType: cardanoAddress.constructor.name,
+      isByron: cardanoAddress instanceof TyphonAddress.ByronAddress,
+    });
+
+    return EMPTY_CREDENTIAL_KEY;
+  } catch (error) {
+    log("cardano/utils", "Failed to parse Cardano address", {
+      address,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return EMPTY_CREDENTIAL_KEY;
+  }
+}
+
+/**
+ * Extract stake credential key hash from a Cardano address.
+ * Only Base and Reward addresses have stake credentials.
+ * Returns undefined for Enterprise, Pointer, Byron, or invalid addresses.
+ */
+export function extractStakeKeyFromAddress(address: string): string | undefined {
+  try {
+    const cardanoAddress = TyphonUtils.getAddressFromString(address);
+
+    if (cardanoAddress instanceof TyphonAddress.BaseAddress) {
+      return cardanoAddress.stakeCredential.hash.toString("hex");
+    }
+
+    if (cardanoAddress instanceof TyphonAddress.RewardAddress) {
+      return cardanoAddress.stakeCredential.hash.toString("hex");
+    }
+
+    return undefined;
+  } catch (error) {
+    log("cardano/utils", "Failed to extract stake key from address", {
+      address,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  }
+}

--- a/libs/ledger-live-common/src/families/cardano/staking.ts
+++ b/libs/ledger-live-common/src/families/cardano/staking.ts
@@ -1,3 +1,3 @@
 export type { APIGetPoolsDetail, StakePool } from "@ledgerhq/coin-cardano/api/api-types";
 export { fetchPoolDetails } from "@ledgerhq/coin-cardano/api/getPools";
-export { DEFAULT_SELECTED_POOL_ID, LEDGER_POOL_IDS } from "@ledgerhq/coin-cardano/utils";
+export { DEFAULT_SELECTED_POOL_ID, LEDGER_POOL_IDS } from "@ledgerhq/coin-cardano/pools";


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Adds a new read-only CoinModule API method (`listOperations`) — no change to the wallet send/sign flows.
  - The Cardano **account synchronisation** path was refactored to reuse shared stake-certificate helpers (see below). This is a behavior-preserving change but touches the bridge used by LLD/LLM, so QA should sanity-check Cardano account history: **DELEGATE / UNDELEGATE classification**, and the **deposit / refund / rewards** amounts shown in operation details for staking transactions.

### 📝 Description

Implements the `listOperations` method of the Cardano CoinModule API and converges the
account-bridge stake-certificate handling onto the same shared logic.

**`listOperations` (CoinModule API)**

- Lists operations for a single Cardano address with page-based pagination, mapping backend
  transactions into framework `Operation`s — native ADA **and** per-token operations.
- Address-centric (single payment credential), consistent with the other CoinModule methods
  (`getBalance`, `craftTransaction`, `estimateFees`). Staking detail (deposit / refund /
  rewards / pool id / memo / metadata) is attached per operation.
- `Operation.value` **excludes** the fee for OUT/FEES/DELEGATE/UNDELEGATE, since the generic
  coin-framework adapter re-adds `tx.fees` for those types (avoids double-counting).
- Pre-Conway registration/de-registration deposit amounts (not carried on the certificate)
  are sourced from `protocolParams.stakeKeyDeposit` via `fetchNetworkInfo`, fetched only when
  the page actually contains such a certificate.
- Ascending order is rejected (the backend pages newest→oldest and the cursor only moves
  forward, so ascending can't be honored consistently across pages).

**Bridge convergence (review follow-up)**

- `synchronisation.ts` (`mapTxToAccountOperation`) previously duplicated the stake
  registration / de-registration / withdrawal extraction inline. It now reuses the shared
  `findStakeRegistration` / `findStakeDeRegistration` / `findWithdrawal` helpers in `logic.ts`
  — the same source of truth the new `listOperations` path uses — so the two consumption
  surfaces (account bridge + CoinModule API) can't drift.
- Behavior-preserving: the helpers cover both pre-Conway and Conway certificates and return
  the raw lovelace amount; the bridge still formats it via `formatCurrencyUnit` and applies
  the same operation-value adjustments. Confirmed by the existing `synchronisation.unit.test.ts`.

### 🧪 Review feedback addressed

- Extracted a named `TokenBalance` type to remove the repeated inline token-balance shape.
- Reworked the integration tests to fetch the shared first page **once** in `beforeAll` and
  reuse it across the ~24 first-page assertions (these tests ignore `limit`, so every
  first-page `desc` query returns the same backend page), cutting ~24 live mainnet calls to 1.
  Tests with a distinct query (different `minHeight`, cursor/pagination, address) still make
  their own calls.

### ❓ Context

- **JIRA or GitHub link**: [JIRA-18629](https://ledgerhq.atlassian.net/browse/LIVE-18629)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
