### PR TITLE
[LWD] feat: implement per-section loading skeletons on Asset Detail

### DIFF
--- a/.changeset/asset-detail-desktop-loading-skeletons.md
+++ b/.changeset/asset-detail-desktop-loading-skeletons.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add per-section loading skeletons on Asset Detail (market price, portfolio, PnL, staking, market data, transactions) and hide the action bar until data is ready.

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/AssetDetailView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/AssetDetailView.tsx
@@ -11,13 +11,33 @@ import { MetricsRowSection } from "./components/MetricsRowSection";
 import { TotalBalance } from "./components/TotalBalance";
 import { TransactionsSection } from "./components/TransactionsSection";
 import type { AssetDetailReady } from "./types";
+import { resolveAssetDetailSectionLoading } from "./utils/resolveAssetDetailSectionLoading";
 
 type AssetDetailViewProps = Readonly<{
   viewModel: AssetDetailReady;
 }>;
 
 export function AssetDetailView({ viewModel }: AssetDetailViewProps) {
-  const { distributionItem, marketData, displayTicker, ledgerId, ledgerCurrency } = viewModel;
+  const {
+    distributionItem,
+    marketData,
+    displayTicker,
+    ledgerId,
+    ledgerCurrency,
+    isDistributionLoading,
+  } = viewModel;
+
+  const { isLoading: isMarketLoading, marketCurrencyData } = marketData;
+  const hasDistributionItem = distributionItem != null;
+  const hasPortfolioAccounts = (distributionItem?.accounts.length ?? 0) > 0;
+  const portfolioSectionLoading = resolveAssetDetailSectionLoading(
+    isDistributionLoading,
+    isMarketLoading,
+    hasDistributionItem,
+  );
+  const showPortfolioSections = portfolioSectionLoading || hasPortfolioAccounts;
+  const showMarketDataSection =
+    marketCurrencyData != null || isDistributionLoading || isMarketLoading;
 
   return (
     <div className="flex w-full shrink-0 flex-col gap-24 pb-32">
@@ -43,29 +63,47 @@ export function AssetDetailView({ viewModel }: AssetDetailViewProps) {
         distributionItem={distributionItem}
         ledgerId={ledgerId}
         marketData={marketData}
+        isDistributionLoading={isDistributionLoading}
       />
 
       <ActionBar
         distributionItem={distributionItem}
         ledgerCurrency={ledgerCurrency}
-        marketCurrencyData={marketData.marketCurrencyData}
+        marketCurrencyData={marketCurrencyData}
         tickerHint={displayTicker}
+        isDistributionLoading={isDistributionLoading}
+        isMarketLoading={isMarketLoading}
       />
 
       <div className="flex flex-col gap-32">
-        {distributionItem && distributionItem.accounts.length > 0 && (
-          <TotalBalance distributionItem={distributionItem} />
+        {showPortfolioSections && (
+          <TotalBalance distributionItem={distributionItem} isLoading={portfolioSectionLoading} />
         )}
 
-        {distributionItem && <MetricsRowSection distributionItem={distributionItem} />}
+        <MetricsRowSection
+          distributionItem={distributionItem}
+          isDistributionLoading={isDistributionLoading}
+          isMarketLoading={isMarketLoading}
+        />
 
-        {distributionItem && distributionItem.accounts.length > 0 && (
-          <AddressListSection distributionItem={distributionItem} />
+        {showPortfolioSections && (
+          <AddressListSection
+            distributionItem={distributionItem}
+            isLoading={portfolioSectionLoading}
+          />
         )}
 
-        {marketData.marketCurrencyData && <MarketDataSection marketData={marketData} />}
+        {showMarketDataSection && (
+          <MarketDataSection
+            marketData={marketData}
+            isDistributionLoading={isDistributionLoading}
+          />
+        )}
 
-        {distributionItem && <TransactionsSection distributionItem={distributionItem} />}
+        <TransactionsSection
+          distributionItem={distributionItem}
+          isLoading={portfolioSectionLoading}
+        />
       </div>
     </div>
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/__integrations__/AssetDetail.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/__integrations__/AssetDetail.integration.test.tsx
@@ -40,6 +40,7 @@ const TEST_ID = {
   MARKET_PRICE_FIAT_VARIATION: "asset-detail-market-price-fiat-variation",
   MARKET_DATA_SECTION: "asset-detail-market-data-section",
   TRANSACTIONS_SECTION: "asset-detail-transactions-section",
+  ACTION_BAR: "asset-detail-action-bar",
   ACTION_BUY: "asset-detail-action-buy",
   ACTION_RECEIVE: "asset-detail-action-receive",
   ACTION_SELL: "asset-detail-action-sell",
@@ -133,6 +134,8 @@ const expectNoOwnedView = () => {
   expect(screen.queryByTestId(TEST_ID.ADDRESS_LIST)).not.toBeInTheDocument();
 };
 const expectNotFound = () => expect(screen.getByText(LABEL.NOT_FOUND)).toBeVisible();
+const expectActionBarHidden = () =>
+  expect(screen.queryByTestId(TEST_ID.ACTION_BAR)).not.toBeInTheDocument();
 
 type OwnedAsset = {
   label: string;
@@ -629,13 +632,18 @@ describe("AssetDetail integration", () => {
     beforeEach(() => jest.useFakeTimers());
     afterEach(() => jest.useRealTimers());
 
-    it("shows skeleton while waiting for Market response", () => {
+    it("shows per-section skeletons while waiting for Market response", () => {
       mockMarket.hang();
       setupRoute("unknown-asset", { list: [] });
 
       render(<AssetDetail />);
 
-      expect(screen.queryByTestId(TEST_ID.HEADER)).not.toBeInTheDocument();
+      expect(screen.getByTestId(TEST_ID.MARKET_PRICE_SECTION)).toBeVisible();
+      expect(screen.getByTestId(TEST_ID.MARKET_DATA_SECTION)).toBeVisible();
+      expectActionBarHidden();
+      expect(screen.getByTestId("asset-detail-total-balance-skeleton")).toBeVisible();
+      expect(screen.getByTestId("asset-detail-address-list-skeleton")).toBeVisible();
+      expect(screen.getByTestId("asset-detail-transactions-skeleton")).toBeVisible();
       expect(screen.queryByText(LABEL.NOT_FOUND)).not.toBeInTheDocument();
     });
   });
@@ -658,6 +666,8 @@ describe("AssetDetail integration", () => {
 
       render(<AssetDetail />);
 
+      expectActionBarHidden();
+      expect(screen.getByTestId("asset-detail-total-balance-skeleton")).toBeVisible();
       expect(screen.queryByText(LABEL.NOT_FOUND)).not.toBeInTheDocument();
     });
   });

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ActionBar/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ActionBar/index.tsx
@@ -10,6 +10,8 @@ type ActionBarProps = Readonly<{
   ledgerCurrency?: CryptoOrTokenCurrency;
   marketCurrencyData?: MarketCurrencyData;
   tickerHint: string;
+  isDistributionLoading: boolean;
+  isMarketLoading: boolean;
 }>;
 
 export function ActionBar({
@@ -17,13 +19,21 @@ export function ActionBar({
   ledgerCurrency,
   marketCurrencyData,
   tickerHint,
+  isDistributionLoading,
+  isMarketLoading,
 }: ActionBarProps) {
   const viewModel = useActionBarViewModel({
     distributionItem,
     ledgerCurrency,
     marketCurrencyData,
     tickerHint,
+    isDistributionLoading,
+    isMarketLoading,
   });
+
+  if (viewModel.showSkeleton) {
+    return null;
+  }
 
   return <ActionBarView viewModel={viewModel} />;
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ActionBar/useActionBarViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ActionBar/useActionBarViewModel.ts
@@ -20,6 +20,7 @@ import { accountsSelector } from "~/renderer/reducers/accounts";
 import { openModal } from "~/renderer/actions/modals";
 import { useOpenSendFlow } from "LLD/features/Send/hooks/useOpenSendFlow";
 import { ASSET_DETAIL_TRACKING_PAGE_NAME } from "LLD/features/AssetDetail/constants";
+import { isAssetDetailPageLoading } from "LLD/features/AssetDetail/utils/isAssetDetailPageLoading";
 import { useTranslation } from "react-i18next";
 import { track } from "~/renderer/analytics/segment";
 import { setTrackingSource } from "~/renderer/analytics/TrackPage";
@@ -31,9 +32,12 @@ type UseActionBarViewModelProps = Readonly<{
   ledgerCurrency?: CryptoOrTokenCurrency;
   marketCurrencyData?: MarketCurrencyData;
   tickerHint: string;
+  isDistributionLoading: boolean;
+  isMarketLoading: boolean;
 }>;
 
 export type ActionBarViewModel = Readonly<{
+  showSkeleton: boolean;
   receiveLabel: string;
   buyLabel: string;
   sellLabel: string;
@@ -99,6 +103,8 @@ export function useActionBarViewModel({
   ledgerCurrency,
   marketCurrencyData,
   tickerHint,
+  isDistributionLoading,
+  isMarketLoading,
 }: UseActionBarViewModelProps): ActionBarViewModel {
   const { t } = useTranslation();
   const dispatch = useDispatch();
@@ -164,6 +170,12 @@ export function useActionBarViewModel({
     return hasAccounts && (hasBalance || hasPositiveBalanceWithZeroSpendable);
   }, [distributionItem]);
 
+  const isPageLoading = isAssetDetailPageLoading(
+    isDistributionLoading,
+    isMarketLoading,
+    Boolean(marketCurrencyData),
+  );
+
   const { isBuyEnabled, isSellEnabled, isSendEnabled } = useMemo(
     () => ({
       isBuyEnabled: canBuyOnRamp,
@@ -223,6 +235,7 @@ export function useActionBarViewModel({
   }, [dispatch, primaryAccount, primaryParentAccount, ledgerCurrency?.ticker, tickerHint]);
 
   return {
+    showSkeleton: isPageLoading,
     receiveLabel: t("quickActions.receive"),
     buyLabel: t("quickActions.buy"),
     sellLabel: t("quickActions.sell"),

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AddressList/AddressListSection.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AddressList/AddressListSection.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import type { DistributionItem } from "@ledgerhq/types-live";
+import { AssetDetailSection } from "../AssetDetailSection";
+import { AllAddressesDialog } from "./components/AllAddressesDialog";
+import { AddressList } from "./components/AddressList";
+import { useAddressListViewModel } from "./hooks/useAddressListViewModel";
+
+type AddressListSectionProps = Readonly<{
+  distributionItem: DistributionItem;
+}>;
+
+export function AddressListSection({ distributionItem }: AddressListSectionProps) {
+  const viewModel = useAddressListViewModel(distributionItem);
+
+  const seeAllProps = viewModel.shouldShowSeeAll
+    ? {
+        showSeeAll: true as const,
+        itemCount: viewModel.addressCount,
+        onSeeAllClick: viewModel.onSeeAll,
+        seeAllTestId: "asset-detail-addresses-see-all",
+      }
+    : { showSeeAll: false as const };
+
+  return (
+    <>
+      <AssetDetailSection
+        title={viewModel.sectionTitle}
+        actionLabel={viewModel.sectionActionLabel}
+        onActionClick={viewModel.onAddAddress}
+        actionTestId="asset-detail-add-address"
+        {...seeAllProps}
+      >
+        <AddressList
+          sortedAccounts={viewModel.previewAccounts}
+          lookupParentAccount={viewModel.lookupParentAccount}
+          onAccountClick={viewModel.onAccountClick}
+        />
+      </AssetDetailSection>
+
+      <AllAddressesDialog
+        open={viewModel.allAddressesDialog.open}
+        title={viewModel.allAddressesDialog.title}
+        description={viewModel.allAddressesDialog.description}
+        sortedAccounts={viewModel.sortedAccounts}
+        lookupParentAccount={viewModel.lookupParentAccount}
+        onAccountClick={viewModel.onAccountClick}
+        onOpenChange={viewModel.allAddressesDialog.onOpenChange}
+      />
+    </>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AddressList/AddressListSectionSkeleton.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AddressList/AddressListSectionSkeleton.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { Skeleton } from "@ledgerhq/lumen-ui-react";
+
+export function AddressListSectionSkeleton() {
+  return (
+    <div
+      className="flex flex-col gap-12"
+      data-testid="asset-detail-address-list-skeleton"
+      aria-hidden
+    >
+      <div className="flex items-center justify-between gap-8">
+        <Skeleton className="h-12 w-40 rounded-full" />
+        <Skeleton className="h-12 w-24 rounded-full" />
+      </div>
+      <Skeleton className="h-56 w-full rounded-12" />
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AddressList/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AddressList/index.tsx
@@ -1,49 +1,20 @@
 import React from "react";
 import type { DistributionItem } from "@ledgerhq/types-live";
-import { AssetDetailSection } from "../AssetDetailSection";
-import { AllAddressesDialog } from "./components/AllAddressesDialog";
-import { AddressList } from "./components/AddressList";
-import { useAddressListViewModel } from "./hooks/useAddressListViewModel";
+import { AddressListSectionSkeleton } from "./AddressListSectionSkeleton";
+import { AddressListSection as AddressListSectionComponent } from "./AddressListSection";
+import { shouldShowAssetDetailSectionSkeleton } from "../../utils/shouldShowAssetDetailSectionSkeleton";
 
 export type AddressListSectionProps = Readonly<{
-  distributionItem: DistributionItem;
+  distributionItem?: DistributionItem;
+  isLoading: boolean;
 }>;
 
-export function AddressListSection({ distributionItem }: AddressListSectionProps) {
-  const viewModel = useAddressListViewModel(distributionItem);
+export function AddressListSection({ distributionItem, isLoading }: AddressListSectionProps) {
+  if (shouldShowAssetDetailSectionSkeleton(isLoading, distributionItem != null)) {
+    return <AddressListSectionSkeleton />;
+  }
 
-  return (
-    <>
-      <AssetDetailSection
-        title={viewModel.sectionTitle}
-        actionLabel={viewModel.sectionActionLabel}
-        onActionClick={viewModel.onAddAddress}
-        actionTestId="asset-detail-add-address"
-        {...(viewModel.shouldShowSeeAll
-          ? {
-              showSeeAll: true as const,
-              itemCount: viewModel.addressCount,
-              onSeeAllClick: viewModel.onSeeAll,
-              seeAllTestId: "asset-detail-addresses-see-all",
-            }
-          : { showSeeAll: false as const })}
-      >
-        <AddressList
-          sortedAccounts={viewModel.previewAccounts}
-          lookupParentAccount={viewModel.lookupParentAccount}
-          onAccountClick={viewModel.onAccountClick}
-        />
-      </AssetDetailSection>
+  if (!distributionItem) return null;
 
-      <AllAddressesDialog
-        open={viewModel.allAddressesDialog.open}
-        title={viewModel.allAddressesDialog.title}
-        description={viewModel.allAddressesDialog.description}
-        sortedAccounts={viewModel.sortedAccounts}
-        lookupParentAccount={viewModel.lookupParentAccount}
-        onAccountClick={viewModel.onAccountClick}
-        onOpenChange={viewModel.allAddressesDialog.onOpenChange}
-      />
-    </>
-  );
+  return <AddressListSectionComponent distributionItem={distributionItem} />;
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AssetDetailSectionSkeleton.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AssetDetailSectionSkeleton.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { Skeleton } from "@ledgerhq/lumen-ui-react";
+
+type Props = Readonly<{
+  testId?: string;
+  contentClassName?: string;
+}>;
+
+export function AssetDetailSectionSkeleton({
+  testId,
+  contentClassName = "h-56 w-full rounded-12",
+}: Props) {
+  return (
+    <div className="flex flex-col gap-12" data-testid={testId} aria-hidden>
+      <Skeleton className="h-12 w-64 rounded-full" />
+      <Skeleton className={contentClassName} />
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/MarketStats/MarketStatsView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/MarketStats/MarketStatsView.tsx
@@ -10,6 +10,7 @@ import {
 import { Information } from "@ledgerhq/lumen-ui-react/symbols";
 import { StatRow } from "../components/StatRow";
 import { MarketDataStatRowSkeletons } from "../components/MarketDataStatRowSkeletons";
+import { MarketDataSectionTitleSkeleton } from "../components/MarketDataSectionTitleSkeleton";
 import type { MarketStatsViewModelResult } from "./hooks/useMarketStatsViewModel";
 
 type Props = Readonly<MarketStatsViewModelResult>;
@@ -17,21 +18,25 @@ type Props = Readonly<MarketStatsViewModelResult>;
 export function MarketStatsView({ rows, showSkeleton, sectionTitle, sectionTooltip }: Props) {
   return (
     <div className="flex min-w-0 flex-col gap-16">
-      <Subheader>
-        <SubheaderRow className="min-w-0 items-center justify-between gap-4">
-          <div className="flex min-w-0 items-center gap-4">
-            <SubheaderTitle>{sectionTitle}</SubheaderTitle>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="inline-flex cursor-help">
-                  <Information size={16} />
-                </span>
-              </TooltipTrigger>
-              <TooltipContent>{sectionTooltip}</TooltipContent>
-            </Tooltip>
-          </div>
-        </SubheaderRow>
-      </Subheader>
+      {showSkeleton ? (
+        <MarketDataSectionTitleSkeleton />
+      ) : (
+        <Subheader>
+          <SubheaderRow className="min-w-0 items-center justify-between gap-4">
+            <div className="flex min-w-0 items-center gap-4">
+              <SubheaderTitle>{sectionTitle}</SubheaderTitle>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="inline-flex cursor-help">
+                    <Information size={16} />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>{sectionTooltip}</TooltipContent>
+              </Tooltip>
+            </div>
+          </SubheaderRow>
+        </Subheader>
+      )}
       <div className="text-body">
         {showSkeleton ? (
           <MarketDataStatRowSkeletons count={rows.length} />

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/PricePerformance/PricePerformanceView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/PricePerformance/PricePerformanceView.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { SectionHeader } from "../../SectionHeader";
 import { PricePerformanceSectionSkeleton } from "../components/PricePerformanceSectionSkeleton";
+import { MarketDataSectionTitleSkeleton } from "../components/MarketDataSectionTitleSkeleton";
 import { PricePerformanceListRow } from "./components/PricePerformanceListRow";
 import type { PricePerformanceViewModelResult } from "./hooks/usePricePerformanceViewModel";
 
@@ -9,7 +10,7 @@ type Props = Readonly<PricePerformanceViewModelResult>;
 export function PricePerformanceView({ sectionTitle, athBlock, atlBlock, showSkeleton }: Props) {
   return (
     <div className="flex min-w-0 flex-col gap-16">
-      <SectionHeader title={sectionTitle} />
+      {showSkeleton ? <MarketDataSectionTitleSkeleton /> : <SectionHeader title={sectionTitle} />}
       <div className="text-body">
         {showSkeleton ? (
           <PricePerformanceSectionSkeleton />

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/__tests__/useMarketDataSectionCurrencyData.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/__tests__/useMarketDataSectionCurrencyData.test.ts
@@ -12,11 +12,14 @@ describe("useMarketDataSectionCurrencyData", () => {
     const marketCurrencyData = createMockMarketCurrencyData();
     const { result } = renderHook(
       () =>
-        useMarketDataSectionCurrencyData({
-          marketCurrencyData,
-          marketId: undefined,
-          isLoading: false,
-        }),
+        useMarketDataSectionCurrencyData(
+          {
+            marketCurrencyData,
+            marketId: undefined,
+            isLoading: false,
+          },
+          false,
+        ),
       hookOptions(),
     );
 
@@ -29,11 +32,14 @@ describe("useMarketDataSectionCurrencyData", () => {
   it("shows the skeleton while the upstream hook is still loading without data", () => {
     const { result } = renderHook(
       () =>
-        useMarketDataSectionCurrencyData({
-          marketCurrencyData: undefined,
-          marketId: undefined,
-          isLoading: true,
-        }),
+        useMarketDataSectionCurrencyData(
+          {
+            marketCurrencyData: undefined,
+            marketId: undefined,
+            isLoading: true,
+          },
+          false,
+        ),
       hookOptions(),
     );
 
@@ -44,11 +50,31 @@ describe("useMarketDataSectionCurrencyData", () => {
   it("hides the skeleton as soon as data is available even if the upstream is still refreshing", () => {
     const { result } = renderHook(
       () =>
-        useMarketDataSectionCurrencyData({
-          marketCurrencyData: createMockMarketCurrencyData(),
-          marketId: undefined,
-          isLoading: true,
-        }),
+        useMarketDataSectionCurrencyData(
+          {
+            marketCurrencyData: createMockMarketCurrencyData(),
+            marketId: undefined,
+            isLoading: true,
+          },
+          true,
+        ),
+      hookOptions(),
+    );
+
+    expect(result.current.showSkeleton).toBe(false);
+  });
+
+  it("hides the skeleton while distribution is loading when market data is already available", () => {
+    const { result } = renderHook(
+      () =>
+        useMarketDataSectionCurrencyData(
+          {
+            marketCurrencyData: createMockMarketCurrencyData(),
+            marketId: undefined,
+            isLoading: false,
+          },
+          true,
+        ),
       hookOptions(),
     );
 
@@ -58,11 +84,14 @@ describe("useMarketDataSectionCurrencyData", () => {
   it("does not show the skeleton when neither data nor loading is reported", () => {
     const { result } = renderHook(
       () =>
-        useMarketDataSectionCurrencyData({
-          marketCurrencyData: undefined,
-          marketId: undefined,
-          isLoading: false,
-        }),
+        useMarketDataSectionCurrencyData(
+          {
+            marketCurrencyData: undefined,
+            marketId: undefined,
+            isLoading: false,
+          },
+          false,
+        ),
       hookOptions(),
     );
 

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/components/MarketDataSectionTitleSkeleton.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/components/MarketDataSectionTitleSkeleton.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { Skeleton } from "@ledgerhq/lumen-ui-react";
+
+export function MarketDataSectionTitleSkeleton() {
+  return <Skeleton className="h-12 w-48 rounded-full" aria-hidden />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/hooks/useMarketDataSectionCurrencyData.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/hooks/useMarketDataSectionCurrencyData.ts
@@ -2,6 +2,7 @@ import { useSelector } from "LLD/hooks/redux";
 import type { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
 import { counterValueCurrencySelector, localeSelector } from "~/renderer/reducers/settings";
 import type { AssetMarketData } from "@ledgerhq/asset-detail";
+import { resolveAssetDetailSectionLoading } from "../../../utils/resolveAssetDetailSectionLoading";
 
 export type MarketDataSectionCurrencyData = Readonly<{
   data?: MarketCurrencyData;
@@ -12,13 +13,19 @@ export type MarketDataSectionCurrencyData = Readonly<{
 
 export function useMarketDataSectionCurrencyData(
   marketData: AssetMarketData,
+  isDistributionLoading: boolean,
 ): MarketDataSectionCurrencyData {
   const counterCurrency = useSelector(counterValueCurrencySelector).ticker.toLowerCase();
   const locale = useSelector(localeSelector);
+  const hasData = marketData.marketCurrencyData != null;
 
   return {
     data: marketData.marketCurrencyData,
-    showSkeleton: !marketData.marketCurrencyData && marketData.isLoading,
+    showSkeleton: resolveAssetDetailSectionLoading(
+      isDistributionLoading,
+      marketData.isLoading,
+      hasData,
+    ),
     counterCurrency,
     locale,
   };

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/index.tsx
@@ -6,10 +6,11 @@ import { useMarketDataSectionCurrencyData } from "./hooks/useMarketDataSectionCu
 
 type MarketDataSectionProps = Readonly<{
   marketData: AssetMarketData;
+  isDistributionLoading: boolean;
 }>;
 
-export function MarketDataSection({ marketData }: MarketDataSectionProps) {
-  const currencyData = useMarketDataSectionCurrencyData(marketData);
+export function MarketDataSection({ marketData, isDistributionLoading }: MarketDataSectionProps) {
+  const currencyData = useMarketDataSectionCurrencyData(marketData, isDistributionLoading);
 
   return (
     <div className="grid grid-cols-2 gap-24" data-testid="asset-detail-market-data-section">

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/MarketPriceSectionView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/MarketPriceSectionView.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { AmountDisplay, Skeleton } from "@ledgerhq/lumen-ui-react";
 import { trendPercentageBody2Styles } from "LLD/shared/trendPercentageStyles";
+import { MarketDataSectionTitleSkeleton } from "../MarketDataSection/components/MarketDataSectionTitleSkeleton";
 import type { MarketPriceSectionViewModelResult } from "./useMarketPriceSectionViewModel";
 
 type MarketPriceSectionViewProps = Readonly<MarketPriceSectionViewModelResult>;
@@ -8,42 +9,45 @@ type MarketPriceSectionViewProps = Readonly<MarketPriceSectionViewModelResult>;
 export function MarketPriceSectionView(viewModel: MarketPriceSectionViewProps) {
   return (
     <div className="flex flex-col gap-8" data-testid="asset-detail-market-price-section">
-      <span className="body-2 text-muted">{viewModel.title}</span>
       {viewModel.showSkeleton ? (
-        <span aria-hidden className="inline-block">
-          <Skeleton className="h-40 w-1/2 rounded-8" />
-        </span>
+        <>
+          <MarketDataSectionTitleSkeleton />
+          <Skeleton className="h-48 w-1/2 rounded-8" aria-hidden />
+        </>
       ) : (
-        <div className="flex flex-wrap items-baseline gap-8">
-          {viewModel.hasPriceData && viewModel.priceValue != null ? (
-            <AmountDisplay
-              value={viewModel.priceValue}
-              formatter={viewModel.priceFormatter}
-              data-testid="asset-detail-market-price"
-            />
-          ) : (
-            <span className="body-1 text-muted" data-testid="asset-detail-market-price">
-              —
-            </span>
-          )}
-          <div className="flex flex-row items-center gap-4">
-            <span
-              data-testid="asset-detail-market-price-percent"
-              className={trendPercentageBody2Styles({ variant: viewModel.variationVariant })}
-            >
-              {viewModel.percentageText}
-            </span>
-            <span
-              className="body-2 tabular-nums text-muted"
-              data-testid="asset-detail-market-price-fiat-variation"
-            >
-              {viewModel.variationText}
-            </span>
-            <span className="body-2 text-muted">
-              <span aria-hidden>&middot;</span> {viewModel.dayLabel}
-            </span>
+        <>
+          <span className="body-2 text-muted">{viewModel.title}</span>
+          <div className="flex flex-wrap items-baseline gap-8">
+            {viewModel.hasPriceData && viewModel.priceValue != null ? (
+              <AmountDisplay
+                value={viewModel.priceValue}
+                formatter={viewModel.priceFormatter}
+                data-testid="asset-detail-market-price"
+              />
+            ) : (
+              <span className="body-1 text-muted" data-testid="asset-detail-market-price">
+                —
+              </span>
+            )}
+            <div className="flex flex-row items-center gap-4">
+              <span
+                data-testid="asset-detail-market-price-percent"
+                className={trendPercentageBody2Styles({ variant: viewModel.variationVariant })}
+              >
+                {viewModel.percentageText}
+              </span>
+              <span
+                className="body-2 tabular-nums text-muted"
+                data-testid="asset-detail-market-price-fiat-variation"
+              >
+                {viewModel.variationText}
+              </span>
+              <span className="body-2 text-muted">
+                <span aria-hidden>&middot;</span> {viewModel.dayLabel}
+              </span>
+            </div>
           </div>
-        </div>
+        </>
       )}
     </div>
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/index.tsx
@@ -8,17 +8,20 @@ type MarketPriceSectionProps = Readonly<{
   distributionItem?: DistributionItem;
   ledgerId?: string;
   marketData: AssetMarketData;
+  isDistributionLoading: boolean;
 }>;
 
 export function MarketPriceSection({
   distributionItem,
   ledgerId,
   marketData,
+  isDistributionLoading,
 }: MarketPriceSectionProps) {
   const viewModel = useMarketPriceSectionViewModel({
     distributionItem,
     ledgerId,
     marketData,
+    isDistributionLoading,
   });
   const { shouldRenderSection, ...viewProps } = viewModel;
   if (!shouldRenderSection) return null;

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/useMarketPriceSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/useMarketPriceSectionViewModel.ts
@@ -14,11 +14,13 @@ import {
   resolveMarketPriceSectionSourceId,
   resolveTrendPercentAndVariant,
 } from "./utils";
+import { resolveAssetDetailSectionLoading } from "../../utils/resolveAssetDetailSectionLoading";
 
 type UseMarketPriceSectionViewModelProps = Readonly<{
   distributionItem?: DistributionItem;
   ledgerId?: string;
   marketData: AssetMarketData;
+  isDistributionLoading: boolean;
 }>;
 
 type UseMarketPriceSectionViewModelResult = Readonly<{
@@ -39,6 +41,7 @@ export function useMarketPriceSectionViewModel({
   distributionItem,
   ledgerId,
   marketData,
+  isDistributionLoading,
 }: UseMarketPriceSectionViewModelProps): UseMarketPriceSectionViewModelResult {
   const { t } = useTranslation();
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
@@ -53,7 +56,10 @@ export function useMarketPriceSectionViewModel({
   const data = marketData.marketCurrencyData;
 
   const hasPriceData = Number.isFinite(data?.price);
-  const showSkeleton = Boolean(marketAssetId && marketData.isLoading && !hasPriceData);
+  const showSkeleton = Boolean(
+    marketAssetId &&
+      resolveAssetDetailSectionLoading(isDistributionLoading, marketData.isLoading, hasPriceData),
+  );
   const dayPercentage = data?.priceChangePercentage?.[KeysPriceChange.day];
   const normalizedDayPercentage = clampDayChangePercentPointsNearZero(dayPercentage);
   const dayVariationFiat = getFiatPriceVariationFromPercentChange(

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MetricsRowSection/MetricsRowSection.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MetricsRowSection/MetricsRowSection.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import type { DistributionItem } from "@ledgerhq/types-live";
+import { PnLSection } from "../PnL";
+import { StakingSection } from "../StakingSection";
+import { useMetricsRowSectionViewModel } from "./useMetricsRowSectionViewModel";
+
+type MetricsRowSectionProps = Readonly<{
+  distributionItem: DistributionItem;
+  sectionLoading: boolean;
+}>;
+
+export function MetricsRowSection({ distributionItem, sectionLoading }: MetricsRowSectionProps) {
+  const { shouldRenderSection, pnlVisible } = useMetricsRowSectionViewModel({ distributionItem });
+
+  if (!shouldRenderSection && !sectionLoading) return null;
+
+  return (
+    <div className="flex items-stretch gap-12">
+      <PnLSection distributionItem={distributionItem} isLoading={sectionLoading} />
+      <StakingSection
+        distributionItem={distributionItem}
+        pnlVisible={pnlVisible}
+        isLoading={sectionLoading}
+      />
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MetricsRowSection/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MetricsRowSection/index.tsx
@@ -2,21 +2,42 @@ import React from "react";
 import type { DistributionItem } from "@ledgerhq/types-live";
 import { PnLSection } from "../PnL";
 import { StakingSection } from "../StakingSection";
-import { useMetricsRowSectionViewModel } from "./useMetricsRowSectionViewModel";
+import { MetricsRowSection as MetricsRowSectionComponent } from "./MetricsRowSection";
+import { resolveAssetDetailSectionLoading } from "../../utils/resolveAssetDetailSectionLoading";
 
 type MetricsRowSectionProps = Readonly<{
-  distributionItem: DistributionItem;
+  distributionItem?: DistributionItem;
+  isDistributionLoading?: boolean;
+  isMarketLoading?: boolean;
 }>;
 
-export function MetricsRowSection({ distributionItem }: MetricsRowSectionProps) {
-  const { shouldRenderSection, pnlVisible } = useMetricsRowSectionViewModel({ distributionItem });
+export function MetricsRowSection({
+  distributionItem,
+  isDistributionLoading = false,
+  isMarketLoading = false,
+}: MetricsRowSectionProps) {
+  const hasData = distributionItem != null;
+  const sectionLoading = resolveAssetDetailSectionLoading(
+    isDistributionLoading,
+    isMarketLoading,
+    hasData,
+  );
 
-  if (!shouldRenderSection) return null;
+  if (!distributionItem) {
+    if (!sectionLoading) return null;
+
+    return (
+      <div className="flex items-stretch gap-12">
+        <PnLSection isLoading />
+        <StakingSection isLoading />
+      </div>
+    );
+  }
 
   return (
-    <div className="flex items-stretch gap-12">
-      <PnLSection distributionItem={distributionItem} />
-      <StakingSection distributionItem={distributionItem} pnlVisible={pnlVisible} />
-    </div>
+    <MetricsRowSectionComponent
+      distributionItem={distributionItem}
+      sectionLoading={sectionLoading}
+    />
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/PnL/PnLSection.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/PnL/PnLSection.tsx
@@ -4,12 +4,13 @@ import { PnLCard } from "LLD/features/PnL/components/PnLCard";
 import { PnlDetail } from "LLD/features/PnL/components/PnlDetail";
 import { useAssetPnlViewModel } from "./useAssetPnlViewModel";
 
-type Props = Readonly<{
+type PnLSectionProps = Readonly<{
   distributionItem: DistributionItem;
 }>;
 
-export function PnLSection({ distributionItem }: Props) {
+export function PnLSection({ distributionItem }: PnLSectionProps) {
   const viewModel = useAssetPnlViewModel({ distributionItem });
+
   if (!viewModel.shouldDisplayPnl) return null;
 
   return (

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/PnL/index.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/PnL/index.ts
@@ -1,1 +1,0 @@
-export { PnLSection } from "./PnLSection";

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/PnL/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/PnL/index.tsx
@@ -1,30 +1,25 @@
 import React from "react";
 import type { DistributionItem } from "@ledgerhq/types-live";
 import { AssetDetailSectionSkeleton } from "../AssetDetailSectionSkeleton";
-import { StakingSection as StakingSectionComponent } from "./StakingSection";
+import { PnLSection as PnLSectionComponent } from "./PnLSection";
 import { shouldShowAssetDetailSectionSkeleton } from "../../utils/shouldShowAssetDetailSectionSkeleton";
 
-type StakingSectionProps = Readonly<{
+type PnLSectionProps = Readonly<{
   distributionItem?: DistributionItem;
-  pnlVisible?: boolean;
   isLoading: boolean;
 }>;
 
-export function StakingSection({
-  distributionItem,
-  pnlVisible = false,
-  isLoading,
-}: StakingSectionProps) {
+export function PnLSection({ distributionItem, isLoading }: PnLSectionProps) {
   if (shouldShowAssetDetailSectionSkeleton(isLoading, distributionItem != null)) {
     return (
       <AssetDetailSectionSkeleton
-        testId="asset-detail-staking-skeleton"
-        contentClassName="h-24 w-full rounded-12"
+        testId="asset-detail-pnl-skeleton"
+        contentClassName="h-40 w-full rounded-12"
       />
     );
   }
 
   if (!distributionItem) return null;
 
-  return <StakingSectionComponent distributionItem={distributionItem} pnlVisible={pnlVisible} />;
+  return <PnLSectionComponent distributionItem={distributionItem} />;
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/StakingSection/StakingSection.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/StakingSection/StakingSection.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import type { DistributionItem } from "@ledgerhq/types-live";
+import { useStakingSectionViewModel } from "./useStakingSectionViewModel";
+import { StakingSectionView } from "./StakingSectionView";
+
+type StakingSectionProps = Readonly<{
+  distributionItem: DistributionItem;
+  pnlVisible: boolean;
+}>;
+
+export function StakingSection({ distributionItem, pnlVisible }: StakingSectionProps) {
+  const viewModel = useStakingSectionViewModel(distributionItem);
+
+  if (viewModel.state.type === "hidden") return null;
+
+  return <StakingSectionView {...viewModel} pnlVisible={pnlVisible} />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TotalBalance/TotalBalance.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TotalBalance/TotalBalance.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import type { DistributionItem } from "@ledgerhq/types-live";
+import { CryptoBalanceText } from "../CryptoBalanceText";
+import { TotalBalanceView } from "./TotalBalanceView";
+import { useTotalBalanceViewModel } from "./useTotalBalanceViewModel";
+
+type TotalBalanceProps = Readonly<{
+  distributionItem: DistributionItem;
+}>;
+
+export function TotalBalance({ distributionItem }: TotalBalanceProps) {
+  const viewModel = useTotalBalanceViewModel(distributionItem);
+
+  return (
+    <TotalBalanceView
+      totalBalanceLabel={viewModel.totalBalanceLabel}
+      fiatDisplayValue={viewModel.fiatDisplayValue}
+      fiatFormatter={viewModel.fiatFormatter}
+      hidden={viewModel.hidden}
+      cryptoBalance={
+        <CryptoBalanceText amount={viewModel.amount} cryptoUnit={viewModel.cryptoUnit} />
+      }
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TotalBalance/TotalBalanceSkeleton.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TotalBalance/TotalBalanceSkeleton.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Skeleton } from "@ledgerhq/lumen-ui-react";
+
+export function TotalBalanceSkeleton() {
+  return (
+    <div
+      className="flex flex-col gap-8"
+      data-testid="asset-detail-total-balance-skeleton"
+      aria-hidden
+    >
+      <Skeleton className="h-12 w-32 rounded-full" />
+      <Skeleton className="h-48 w-1/2 rounded-8" />
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TotalBalance/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TotalBalance/index.tsx
@@ -1,25 +1,20 @@
 import React from "react";
 import type { DistributionItem } from "@ledgerhq/types-live";
-import { CryptoBalanceText } from "../CryptoBalanceText";
-import { TotalBalanceView } from "./TotalBalanceView";
-import { useTotalBalanceViewModel } from "./useTotalBalanceViewModel";
+import { TotalBalanceSkeleton } from "./TotalBalanceSkeleton";
+import { TotalBalance as TotalBalanceComponent } from "./TotalBalance";
+import { shouldShowAssetDetailSectionSkeleton } from "../../utils/shouldShowAssetDetailSectionSkeleton";
 
-type TotalBalanceProps = {
-  readonly distributionItem: DistributionItem;
-};
+type TotalBalanceProps = Readonly<{
+  distributionItem?: DistributionItem;
+  isLoading: boolean;
+}>;
 
-export function TotalBalance({ distributionItem }: TotalBalanceProps) {
-  const viewModel = useTotalBalanceViewModel(distributionItem);
+export function TotalBalance({ distributionItem, isLoading }: TotalBalanceProps) {
+  if (shouldShowAssetDetailSectionSkeleton(isLoading, distributionItem != null)) {
+    return <TotalBalanceSkeleton />;
+  }
 
-  return (
-    <TotalBalanceView
-      totalBalanceLabel={viewModel.totalBalanceLabel}
-      fiatDisplayValue={viewModel.fiatDisplayValue}
-      fiatFormatter={viewModel.fiatFormatter}
-      hidden={viewModel.hidden}
-      cryptoBalance={
-        <CryptoBalanceText amount={viewModel.amount} cryptoUnit={viewModel.cryptoUnit} />
-      }
-    />
-  );
+  if (!distributionItem) return null;
+
+  return <TotalBalanceComponent distributionItem={distributionItem} />;
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TransactionsSection/TransactionsSection.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TransactionsSection/TransactionsSection.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import type { DistributionItem } from "@ledgerhq/types-live";
+import { TransactionsSectionView } from "./TransactionsSectionView";
+import { useTransactionsSectionViewModel } from "./useTransactionsSectionViewModel";
+import { TransactionsSectionSkeleton } from "./TransactionsSectionSkeleton";
+import { shouldShowAssetDetailSectionSkeleton } from "../../utils/shouldShowAssetDetailSectionSkeleton";
+
+type TransactionsSectionProps = Readonly<{
+  distributionItem: DistributionItem;
+  isLoading: boolean;
+  historyLabel: string;
+}>;
+
+export function TransactionsSection({
+  distributionItem,
+  isLoading,
+  historyLabel,
+}: TransactionsSectionProps) {
+  const { visible, table, onRowClick, onSeeAll } =
+    useTransactionsSectionViewModel(distributionItem);
+
+  if (shouldShowAssetDetailSectionSkeleton(isLoading, visible)) {
+    return <TransactionsSectionSkeleton />;
+  }
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <TransactionsSectionView
+      historyLabel={historyLabel}
+      table={table}
+      onRowClick={onRowClick}
+      onSeeAll={onSeeAll}
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TransactionsSection/TransactionsSectionSkeleton.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TransactionsSection/TransactionsSectionSkeleton.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { AssetDetailSectionSkeleton } from "../AssetDetailSectionSkeleton";
+
+export function TransactionsSectionSkeleton() {
+  return (
+    <div data-testid="asset-detail-transactions-section">
+      <AssetDetailSectionSkeleton
+        testId="asset-detail-transactions-skeleton"
+        contentClassName="h-56 w-full rounded-12"
+      />
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TransactionsSection/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TransactionsSection/index.tsx
@@ -1,28 +1,28 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import type { DistributionItem } from "@ledgerhq/types-live";
-import { TransactionsSectionView } from "./TransactionsSectionView";
-import { useTransactionsSectionViewModel } from "./useTransactionsSectionViewModel";
+import { TransactionsSectionSkeleton } from "./TransactionsSectionSkeleton";
+import { TransactionsSection as TransactionsSectionComponent } from "./TransactionsSection";
+import { shouldShowAssetDetailSectionSkeleton } from "../../utils/shouldShowAssetDetailSectionSkeleton";
 
 export type TransactionsSectionProps = Readonly<{
-  distributionItem: DistributionItem;
+  distributionItem?: DistributionItem;
+  isLoading: boolean;
 }>;
 
-export function TransactionsSection({ distributionItem }: TransactionsSectionProps) {
+export function TransactionsSection({ distributionItem, isLoading }: TransactionsSectionProps) {
   const { t } = useTranslation();
-  const { visible, table, onRowClick, onSeeAll } =
-    useTransactionsSectionViewModel(distributionItem);
 
-  if (!visible) {
-    return null;
+  if (!distributionItem) {
+    if (!shouldShowAssetDetailSectionSkeleton(isLoading, false)) return null;
+    return <TransactionsSectionSkeleton />;
   }
 
   return (
-    <TransactionsSectionView
+    <TransactionsSectionComponent
+      distributionItem={distributionItem}
+      isLoading={isLoading}
       historyLabel={t("history.title")}
-      table={table}
-      onRowClick={onRowClick}
-      onSeeAll={onSeeAll}
     />
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/__tests__/useAssetDetailViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/__tests__/useAssetDetailViewModel.test.ts
@@ -31,6 +31,7 @@ const route = (
   useDistribution.mockReturnValue({
     bySlug: distribution.bySlug ?? {},
     list: distribution.list ?? [],
+    isLoading: false,
   });
 };
 
@@ -66,11 +67,16 @@ describe("useAssetDetailViewModel", () => {
   });
 
   describe("mode", () => {
-    it("returns loading while Market is pending and nothing else resolved", () => {
+    it("returns ready while Market is pending when the route identifies an asset", () => {
       mockMarket.hang();
       route("unknown");
 
-      expect(renderVM().result.current.mode).toBe("loading");
+      const { result } = renderVM();
+      expect(result.current.mode).toBe("ready");
+      if (result.current.mode === "ready") {
+        expect(result.current.marketData.isLoading).toBe(true);
+        expect(result.current.distributionItem).toBeUndefined();
+      }
     });
 
     it("returns not-found when Market settled empty and DADA fails", async () => {
@@ -161,12 +167,16 @@ describe("useAssetDetailViewModel", () => {
       mockMarket.withData([
         { id: "bitcoin", ledgerIds: ["bitcoin"], name: "Bitcoin", ticker: "BTC", price: 100 },
       ]);
+      mockDada.empty();
       route("bitcoin");
 
-      const vm = await waitForReady();
+      const { result } = renderVM();
 
-      expect(vm.displayName).toBe("Bitcoin");
-      expect(vm.displayTicker).toBe("BTC");
+      await waitFor(() => {
+        assertReady(result.current);
+        expect(result.current.displayName).toBe("Bitcoin");
+        expect(result.current.displayTicker).toBe("BTC");
+      });
     });
 
     it("falls back to empty strings when neither source provides name/ticker", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/useAssetDetailViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/useAssetDetailViewModel.ts
@@ -54,6 +54,7 @@ export function useAssetDetailViewModel(): AssetDetailViewModel {
       mode: "ready",
       distributionItem,
       marketData: { marketCurrencyData, marketId, isLoading },
+      isDistributionLoading: distribution.isLoading,
       ledgerCurrency,
       displayName: ledgerCurrency?.name ?? marketFallback?.name ?? "",
       displayTicker: (ledgerCurrency?.ticker ?? marketFallback?.ticker ?? "").toUpperCase(),
@@ -61,7 +62,18 @@ export function useAssetDetailViewModel(): AssetDetailViewModel {
     };
   }
 
-  if (isLoading) return { mode: "loading" };
+  if (isLoading || distribution.isLoading) {
+    return {
+      mode: "ready",
+      distributionItem,
+      marketData: { marketCurrencyData, marketId, isLoading },
+      isDistributionLoading: distribution.isLoading,
+      ledgerCurrency,
+      displayName: ledgerCurrency?.name ?? "",
+      displayTicker: (ledgerCurrency?.ticker ?? "").toUpperCase(),
+      ledgerId: ledgerCurrency?.id ?? decodedAssetId,
+    };
+  }
 
   return { mode: "not-found" };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/index.tsx
@@ -7,18 +7,6 @@ const AssetDetail = () => {
   const { t } = useTranslation();
   const viewModel = useAssetDetailViewModel();
 
-  if (viewModel.mode === "loading") {
-    return (
-      <div className="flex w-full shrink-0 flex-col gap-32 pb-32">
-        <div className="h-40 w-1/3 animate-pulse rounded-8 bg-neutral-c20" />
-        <div className="grid grid-cols-2 gap-24">
-          <div className="h-[200px] animate-pulse rounded-16 bg-neutral-c20" />
-          <div className="h-[200px] animate-pulse rounded-16 bg-neutral-c20" />
-        </div>
-      </div>
-    );
-  }
-
   if (viewModel.mode === "not-found") {
     return (
       <section className="rounded-16 border border-dashed border-neutral-c70/30 p-16 text-body text-neutral-c70">

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/types.ts
@@ -2,17 +2,17 @@ import type { DistributionItem } from "@ledgerhq/types-live";
 import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { AssetMarketData } from "@ledgerhq/asset-detail";
 
-type AssetDetailLoading = Readonly<{ mode: "loading" }>;
 type AssetDetailNotFound = Readonly<{ mode: "not-found" }>;
 
 export type AssetDetailReady = Readonly<{
   mode: "ready";
   distributionItem?: DistributionItem;
   marketData: AssetMarketData;
+  isDistributionLoading: boolean;
   ledgerCurrency?: CryptoOrTokenCurrency;
   displayName: string;
   displayTicker: string;
   ledgerId?: string;
 }>;
 
-export type AssetDetailViewModel = AssetDetailLoading | AssetDetailNotFound | AssetDetailReady;
+export type AssetDetailViewModel = AssetDetailNotFound | AssetDetailReady;

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/utils/__tests__/resolveAssetDetailSectionLoading.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/utils/__tests__/resolveAssetDetailSectionLoading.test.ts
@@ -1,0 +1,19 @@
+import { resolveAssetDetailSectionLoading } from "../resolveAssetDetailSectionLoading";
+
+describe("resolveAssetDetailSectionLoading", () => {
+  it("is true while distribution is loading and the section has no data", () => {
+    expect(resolveAssetDetailSectionLoading(true, false, false)).toBe(true);
+  });
+
+  it("is false while distribution is loading when section data is already available", () => {
+    expect(resolveAssetDetailSectionLoading(true, false, true)).toBe(false);
+  });
+
+  it("is true while market is loading and the section has no data", () => {
+    expect(resolveAssetDetailSectionLoading(false, true, false)).toBe(true);
+  });
+
+  it("is false while market is loading when data is already available", () => {
+    expect(resolveAssetDetailSectionLoading(false, true, true)).toBe(false);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/utils/isAssetDetailPageLoading.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/utils/isAssetDetailPageLoading.ts
@@ -1,0 +1,7 @@
+export function isAssetDetailPageLoading(
+  isDistributionLoading: boolean,
+  isMarketLoading: boolean,
+  hasMarketData: boolean,
+): boolean {
+  return isDistributionLoading || (isMarketLoading && !hasMarketData);
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/utils/resolveAssetDetailSectionLoading.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/utils/resolveAssetDetailSectionLoading.ts
@@ -1,0 +1,8 @@
+/** Merges distribution loading with market loading for section skeleton display. */
+export function resolveAssetDetailSectionLoading(
+  isDistributionLoading: boolean,
+  isMarketLoading: boolean,
+  hasData: boolean,
+): boolean {
+  return (isDistributionLoading || isMarketLoading) && !hasData;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/utils/shouldShowAssetDetailSectionSkeleton.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/utils/shouldShowAssetDetailSectionSkeleton.ts
@@ -1,0 +1,6 @@
+export function shouldShowAssetDetailSectionSkeleton(
+  isLoading: boolean,
+  hasData: boolean,
+): boolean {
+  return isLoading && !hasData;
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request introduces per-section loading skeletons to the Asset Detail view in Ledger Live Desktop. Each major section (market price, portfolio, PnL, staking, market data, transactions, and address list) now displays its own skeleton while loading, and the action bar is hidden until all necessary data is ready. The implementation includes new skeleton components, updates to section rendering logic, and enhanced test coverage to ensure correct skeleton display.

**UI/UX Improvements:**
- Added per-section loading skeletons for market price, portfolio, PnL, staking, market data, transactions, and address list sections in the Asset Detail view, providing a more granular loading experience. The action bar is now hidden until all required data is loaded. 

**Component and Logic Enhancements:**
- Introduced new skeleton components such as `AssetDetailSectionSkeleton`, `AddressListSectionSkeleton`, and `MarketDataSectionTitleSkeleton` to standardize and simplify skeleton UI across sections.
- Updated section components to accept `isLoading` props and conditionally render skeletons or content based on loading state and data presence. 

**State Management and Utilities:**
- Improved logic for determining when to show skeletons using new utility functions (`isAssetDetailPageLoading`, `resolveAssetDetailSectionLoading`, and `shouldShowAssetDetailSectionSkeleton`). These ensure skeletons are only shown when appropriate, even if some data is already loaded. 

**Testing:**
- Enhanced integration and unit tests to verify correct per-section skeleton rendering and ensure skeletons are hidden when data becomes available. 

These changes collectively improve the user experience by providing clear loading feedback for each section and preventing premature display of actions or incomplete data.


https://github.com/user-attachments/assets/0a09d98b-a5b0-4c2e-ad8f-a3d81d91bf6b


### ❓ Context

[LIVE-30410](https://ledgerhq.atlassian.net/browse/LIVE-30410)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-30410]: https://ledgerhq.atlassian.net/browse/LIVE-30410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ