### PR TITLE
[LWM] fix(live-mobile): ble device drawer overflow

### DIFF
--- a/.changeset/little-fans-deliver.md
+++ b/.changeset/little-fans-deliver.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix: ble device drawer overflow

--- a/apps/ledger-live-mobile/src/components/SelectDevice2/BleDeviceNotAvailableDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice2/BleDeviceNotAvailableDrawer.tsx
@@ -1,10 +1,10 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "~/context/Locale";
-import Button from "~/components/Button";
 import QueuedDrawer from "~/components/QueuedDrawer";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { ConnectYourDevice } from "../DeviceAction/rendering";
-import { Flex, Alert, IconsLegacy } from "@ledgerhq/native-ui";
+import { Banner, Box, Button } from "@ledgerhq/lumen-ui-rnative";
+import { ExternalLink } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { Linking } from "react-native";
 import { urls } from "~/utils/urls";
 import { TrackScreen } from "~/analytics";
@@ -33,6 +33,10 @@ export default function BleDeviceNotAvailableDrawer({
     redirectToScan();
   }, [onClose, redirectToScan]);
 
+  const handleOpenHelpCenter = useCallback(() => {
+    Linking.openURL(urls.errors.PeerRemovedPairing);
+  }, []);
+
   useEffect(() => {
     const timeout = setTimeout(() => {
       setShowHelp(true);
@@ -49,46 +53,34 @@ export default function BleDeviceNotAvailableDrawer({
   return (
     <QueuedDrawer isRequestingToBeOpened={isOpen && Boolean(device)} onClose={onClose}>
       <TrackScreen name="Drawer: Power on and unlock" {...trackingProps} />
-      <Flex paddingBottom={8}>
+      <Box lx={{ paddingBottom: "s32"}}>
         <ConnectYourDevice device={device} fullScreen={false} />
-      </Flex>
+      </Box>
       {showHelp && (
-        <Flex
-          borderRadius={8}
-          pb={16}
-          backgroundColor="primary.c10"
-          flexDirection="column"
-          justifyContent="space-evenly"
-          alignItems="center"
-          alignSelf="stretch"
-        >
-          <Alert
-            type="info"
-            title={t("SelectDevice.bleDeviceNotAvailableDrawer.bannerHintTitle")}
-          />
-          <Flex
-            pl={32}
-            flexDirection="row"
-            justifyContent="flex-end"
-            alignItems="center"
-            columnGap={16}
-          >
+        <Banner
+          appearance="info"
+          title={t("SelectDevice.bleDeviceNotAvailableDrawer.bannerHintTitle")}
+          primaryAction={
+            <Button 
+              appearance="gray" 
+              size="sm" 
+              onPress={handleRedirectToScan}               
+              lx={{ flexShrink: 1}}
+            >
+              {t("SelectDevice.bleDeviceNotAvailableDrawer.scanSignersCta")}
+            </Button>
+          }
+          secondaryAction={ 
             <Button
-              type="main"
-              size="small"
-              onPress={handleRedirectToScan}
-              title={t("SelectDevice.bleDeviceNotAvailableDrawer.scanSignersCta")}
-            />
-            <Button
-              type="main"
-              outline
-              size="small"
-              onPress={() => Linking.openURL(urls.errors.PeerRemovedPairing)}
-              title={t("SelectDevice.bleDeviceNotAvailableDrawer.helpCenterCta")}
-              Icon={IconsLegacy.ExternalLinkMedium}
-            />
-          </Flex>
-        </Flex>
+              appearance="no-background"
+              size="sm"
+              icon={ExternalLink}
+              onPress={handleOpenHelpCenter}
+              lx={{ flexShrink: 1}}
+            >
+              {t("SelectDevice.bleDeviceNotAvailableDrawer.helpCenterCta")}
+            </Button>}
+        />
       )}
     </QueuedDrawer>
   );


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Not covered by automatic tests: this is a visual/layout fix for a mobile drawer overflow.
- [x] **Impact of the changes:**
  - Ledger Live Mobile BLE device connection flow.
  - “Power on and unlock” drawer shown when a BLE device is not available.
  - QA should check the delayed help banner, both CTAs, and small-screen layouts.

### 📝 Description

This PR fixes an overflow issue in the BLE device not available drawer.

The drawer has been refactored to use Lumen components, including the `Banner` component: 

<img width="432" height="960" alt="Screenshot_20260525_164001" src="https://github.com/user-attachments/assets/68e920e1-bace-45ad-a083-e55265aa60fa" />

As discussed with Lumen team, the `Banner` component will be updated to handle responsiveness more generally. In the meantime, this PR applies `flexShrink: 1` to the two banner action buttons as a quick fix to prevent the CTA row from overflowing on constrained screen sizes.

| Before        | After         |
| ------------- | ------------- |
| <img width="1116" height="2484" alt="image" src="https://github.com/user-attachments/assets/fae9100e-0363-439c-b7ea-a4db5a37e0ed" />    | <img width="1080" height="2400" alt="Screenshot_20260525_164408" src="https://github.com/user-attachments/assets/7b3bd179-ac78-430a-b18e-4df853fa26ca" /> |

### ❓ Context

- **JIRA link**: [LIVE-31313](https://ledgerhq.atlassian.net/browse/LIVE-31313)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31313]: https://ledgerhq.atlassian.net/browse/LIVE-31313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ