### PR TITLE
[LWDM] feat(desktop,mobile): add go-to-swap action to borrow custom.navigate handler

### DIFF
--- a/.changeset/borrow-go-to-swap-action.md
+++ b/.changeset/borrow-go-to-swap-action.md
@@ -1,6 +1,7 @@
 ---
 "live-mobile": minor
 "ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
 ---
 
-Add `go-to-swap` action to the Borrow live app `custom.navigate` wallet API handler so the embedded webview can deep-link users into the Swap flow with prefilled currency, token, account, amount and affiliate parameters. Unify the desktop handler naming with mobile (`custom.borrow.navigate` → `custom.navigate`) and drop the redundant desktop `PageHeader` now that navigation is driven from the webview.
+Add `go-to-swap` action to the Borrow live app `custom.navigate` wallet API handler so the embedded webview can deep-link users into the Swap flow with prefilled currency, token, account, amount and affiliate parameters. Unify the desktop handler naming with mobile (`custom.borrow.navigate` → `custom.navigate`), share the handler implementation across apps via a new `@ledgerhq/live-common/wallet-api/Borrow/navigate` module, and drop the redundant desktop `PageHeader` now that navigation is driven from the webview.

--- a/.changeset/borrow-go-to-swap-action.md
+++ b/.changeset/borrow-go-to-swap-action.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"ledger-live-desktop": minor
+---
+
+Add `go-to-swap` action to the Borrow live app `custom.navigate` wallet API handler so the embedded webview can deep-link users into the Swap flow with prefilled currency, token, account, amount and affiliate parameters. Unify the desktop handler naming with mobile (`custom.borrow.navigate` → `custom.navigate`) and drop the redundant desktop `PageHeader` now that navigation is driven from the webview.

--- a/apps/ledger-live-desktop/src/mvvm/features/Borrow/screens/BorrowApp/__tests__/BorrowApp.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Borrow/screens/BorrowApp/__tests__/BorrowApp.test.tsx
@@ -31,6 +31,7 @@ const baseViewModel: BorrowAppViewModel = {
   webviewState: {} as BorrowAppViewModel["webviewState"],
   onStateChange: jest.fn(),
   onBack: jest.fn(),
+  onGoToSwap: jest.fn(),
 };
 
 const mockViewModel = (overrides: Partial<BorrowAppViewModel> = {}) => {
@@ -45,27 +46,14 @@ describe("BorrowApp", () => {
 
     expect(screen.getByText("network error")).toBeVisible();
     expect(screen.queryByTestId("borrow-webview")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("page-header")).not.toBeInTheDocument();
   });
 
-  it("renders borrow webview and page header when manifest is available", () => {
+  it("renders borrow webview when manifest is available", () => {
     mockViewModel();
 
     render(<BorrowApp />);
 
     expect(screen.getByTestId("borrow-webview")).toBeVisible();
-    expect(screen.getByTestId("page-header")).toBeVisible();
     expect(screen.queryByText("network error")).not.toBeInTheDocument();
-  });
-
-  it("invokes onBack from view model when the back button is clicked", async () => {
-    const onBack = jest.fn();
-    mockViewModel({ onBack });
-
-    const { user } = render(<BorrowApp />);
-
-    await user.click(screen.getByRole("button", { name: /back/i }));
-
-    expect(onBack).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Borrow/screens/BorrowApp/__tests__/useBorrowAppViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Borrow/screens/BorrowApp/__tests__/useBorrowAppViewModel.test.ts
@@ -174,4 +174,64 @@ describe("useBorrowAppViewModel", () => {
       expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true });
     });
   });
+
+  describe("onGoToSwap", () => {
+    it("builds /swap state with defaultCurrency/Token/AccountId and forwards amount, affiliate and from pathname", () => {
+      jest.mocked(useLocation).mockReturnValue({
+        pathname: "/borrow/active",
+        search: "",
+        hash: "",
+        state: null,
+        key: "default",
+      });
+
+      const { result } = renderHook(() => useBorrowAppViewModel(), { initialState });
+
+      act(() =>
+        result.current.onGoToSwap({
+          fromCurrencyId: "ethereum",
+          toCurrencyId: "bitcoin",
+          fromTokenId: "ethereum/erc20/usdt",
+          toTokenId: "bitcoin/erc20/wbtc",
+          fromAccountId: "account-from",
+          toAccountId: "account-to",
+          amountFrom: "12.5",
+          affiliate: "borrow-app",
+        }),
+      );
+
+      expect(mockNavigate).toHaveBeenCalledWith("/swap", {
+        state: {
+          defaultCurrency: { fromCurrencyId: "ethereum", toCurrencyId: "bitcoin" },
+          defaultToken: {
+            fromTokenId: "ethereum/erc20/usdt",
+            toTokenId: "bitcoin/erc20/wbtc",
+          },
+          defaultAccountId: {
+            fromAccountId: "account-from",
+            toAccountId: "account-to",
+          },
+          defaultAmountFrom: "12.5",
+          affiliate: "borrow-app",
+          from: "/borrow/active",
+        },
+      });
+    });
+
+    it("omits defaultCurrency / defaultToken / defaultAccountId when no related ids are provided", () => {
+      const { result } = renderHook(() => useBorrowAppViewModel(), { initialState });
+
+      act(() => result.current.onGoToSwap({ amountFrom: "1" }));
+
+      expect(mockNavigate).toHaveBeenCalledWith("/swap", {
+        state: expect.objectContaining({
+          defaultCurrency: undefined,
+          defaultToken: undefined,
+          defaultAccountId: undefined,
+          defaultAmountFrom: "1",
+          affiliate: undefined,
+        }),
+      });
+    });
+  });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Borrow/screens/BorrowApp/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Borrow/screens/BorrowApp/index.tsx
@@ -1,12 +1,9 @@
 import React from "react";
-import { useTranslation } from "react-i18next";
-import PageHeader from "LLD/components/PageHeader";
 import { NetworkErrorScreen } from "~/renderer/components/Web3AppWebview/NetworkError";
 import { BorrowWebView } from "LLD/features/Borrow/screens/BorrowWebView";
 import { useBorrowAppViewModel } from "./useBorrowAppViewModel";
 
 export function BorrowApp() {
-  const { t } = useTranslation();
   const {
     manifest,
     refreshManifests,
@@ -16,6 +13,7 @@ export function BorrowApp() {
     webviewState,
     onStateChange,
     onBack,
+    onGoToSwap,
   } = useBorrowAppViewModel();
 
   if (!manifest) {
@@ -24,7 +22,6 @@ export function BorrowApp() {
 
   return (
     <div className="flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden">
-      <PageHeader title={t("borrow.pageHeader")} onBack={onBack} />
       <BorrowWebView
         manifest={manifest}
         inputs={inputs}
@@ -32,6 +29,8 @@ export function BorrowApp() {
         webviewAPIRef={webviewAPIRef}
         webviewState={webviewState}
         onStateChange={onStateChange}
+        onWalletApiGoBack={onBack}
+        onWalletApiGoToSwap={onGoToSwap}
       />
     </div>
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/Borrow/screens/BorrowApp/useBorrowAppViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Borrow/screens/BorrowApp/useBorrowAppViewModel.ts
@@ -20,7 +20,7 @@ import {
 } from "~/renderer/reducers/settings";
 import { getParsedSystemDeviceLocale } from "~/helpers/systemLocale";
 import { useBorrowLiveConfig } from "LLD/features/Borrow/hooks/useBorrowLiveConfig";
-import type { BorrowSwapNavigationParams } from "@ledgerhq/live-common/wallet-api/Borrow/navigate";
+import type { BorrowSwapNavigationParams } from "@ledgerhq/live-common/wallet-api/Borrow/types";
 
 type BorrowLocationState = { returnTo?: string };
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Borrow/screens/BorrowApp/useBorrowAppViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Borrow/screens/BorrowApp/useBorrowAppViewModel.ts
@@ -20,7 +20,7 @@ import {
 } from "~/renderer/reducers/settings";
 import { getParsedSystemDeviceLocale } from "~/helpers/systemLocale";
 import { useBorrowLiveConfig } from "LLD/features/Borrow/hooks/useBorrowLiveConfig";
-import type { BorrowSwapNavigationParams } from "LLD/features/Borrow/screens/BorrowWebView/BorrowWebView";
+import type { BorrowSwapNavigationParams } from "@ledgerhq/live-common/wallet-api/Borrow/navigate";
 
 type BorrowLocationState = { returnTo?: string };
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Borrow/screens/BorrowApp/useBorrowAppViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Borrow/screens/BorrowApp/useBorrowAppViewModel.ts
@@ -20,6 +20,7 @@ import {
 } from "~/renderer/reducers/settings";
 import { getParsedSystemDeviceLocale } from "~/helpers/systemLocale";
 import { useBorrowLiveConfig } from "LLD/features/Borrow/hooks/useBorrowLiveConfig";
+import type { BorrowSwapNavigationParams } from "LLD/features/Borrow/screens/BorrowWebView/BorrowWebView";
 
 type BorrowLocationState = { returnTo?: string };
 
@@ -79,6 +80,39 @@ export function useBorrowAppViewModel() {
     navigate(returnTo, { replace: true });
   }, [navigate, returnTo]);
 
+  const onGoToSwap = useCallback(
+    (swapParams: BorrowSwapNavigationParams) => {
+      const {
+        fromCurrencyId,
+        toCurrencyId,
+        fromTokenId,
+        toTokenId,
+        fromAccountId,
+        toAccountId,
+        amountFrom,
+        affiliate,
+      } = swapParams;
+
+      const defaultCurrency =
+        fromCurrencyId || toCurrencyId ? { fromCurrencyId, toCurrencyId } : undefined;
+      const defaultToken = fromTokenId || toTokenId ? { fromTokenId, toTokenId } : undefined;
+      const defaultAccountId =
+        fromAccountId || toAccountId ? { fromAccountId, toAccountId } : undefined;
+
+      navigate("/swap", {
+        state: {
+          defaultCurrency,
+          defaultToken,
+          defaultAccountId,
+          defaultAmountFrom: amountFrom,
+          affiliate,
+          from: location.pathname,
+        },
+      });
+    },
+    [navigate, location.pathname],
+  );
+
   const onStateChange = (state: WebviewState) => {
     setWebviewState(state);
   };
@@ -107,5 +141,6 @@ export function useBorrowAppViewModel() {
     webviewState,
     onStateChange,
     onBack,
+    onGoToSwap,
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Borrow/screens/BorrowWebView/BorrowWebView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Borrow/screens/BorrowWebView/BorrowWebView.tsx
@@ -12,21 +12,12 @@ import { BorrowLoader } from "LLD/features/Borrow/components/BorrowLoader";
 import type { BorrowWebviewInputs } from "../BorrowApp/useBorrowAppViewModel";
 import { useDeeplinkCustomHandlers } from "~/renderer/components/WebPlatformPlayer/CustomHandlers";
 import { WalletAPICustomHandlers } from "@ledgerhq/live-common/wallet-api/types";
+import {
+  BorrowSwapNavigationParams,
+  createBorrowNavigateHandler,
+} from "@ledgerhq/live-common/wallet-api/Borrow/navigate";
 
-export type BorrowSwapNavigationParams = {
-  fromCurrencyId?: string;
-  toCurrencyId?: string;
-  fromTokenId?: string;
-  toTokenId?: string;
-  fromAccountId?: string;
-  toAccountId?: string;
-  amountFrom?: string;
-  affiliate?: string;
-};
-
-type BorrowNavigateRequestParams = {
-  action?: string;
-} & BorrowSwapNavigationParams;
+export type { BorrowSwapNavigationParams };
 
 export type BorrowWebProps = {
   manifest: LiveAppManifest;
@@ -55,40 +46,10 @@ export const BorrowWebView = ({
   const customHandlers = useMemo<WalletAPICustomHandlers>(
     () => ({
       ...customDeeplinkHandlers,
-      "custom.navigate": async (request: { params?: BorrowNavigateRequestParams }) => {
-        const requestAction = request.params?.action;
-
-        if (requestAction === "go-back") {
-          onWalletApiGoBack?.();
-          return { success: true };
-        }
-
-        if (requestAction === "go-to-swap") {
-          const {
-            fromCurrencyId,
-            toCurrencyId,
-            fromTokenId,
-            toTokenId,
-            fromAccountId,
-            toAccountId,
-            amountFrom,
-            affiliate,
-          } = request.params ?? {};
-          onWalletApiGoToSwap?.({
-            fromCurrencyId,
-            toCurrencyId,
-            fromTokenId,
-            toTokenId,
-            fromAccountId,
-            toAccountId,
-            amountFrom,
-            affiliate,
-          });
-          return { success: true };
-        }
-
-        throw new Error("Unknown borrow navigation action");
-      },
+      "custom.navigate": createBorrowNavigateHandler({
+        onGoBack: onWalletApiGoBack,
+        onGoToSwap: onWalletApiGoToSwap,
+      }),
     }),
     [customDeeplinkHandlers, onWalletApiGoBack, onWalletApiGoToSwap],
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/Borrow/screens/BorrowWebView/BorrowWebView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Borrow/screens/BorrowWebView/BorrowWebView.tsx
@@ -12,12 +12,8 @@ import { BorrowLoader } from "LLD/features/Borrow/components/BorrowLoader";
 import type { BorrowWebviewInputs } from "../BorrowApp/useBorrowAppViewModel";
 import { useDeeplinkCustomHandlers } from "~/renderer/components/WebPlatformPlayer/CustomHandlers";
 import { WalletAPICustomHandlers } from "@ledgerhq/live-common/wallet-api/types";
-import {
-  BorrowSwapNavigationParams,
-  createBorrowNavigateHandler,
-} from "@ledgerhq/live-common/wallet-api/Borrow/navigate";
-
-export type { BorrowSwapNavigationParams };
+import { createBorrowNavigateHandler } from "@ledgerhq/live-common/wallet-api/Borrow/navigate";
+import type { BorrowSwapNavigationParams } from "@ledgerhq/live-common/wallet-api/Borrow/types";
 
 export type BorrowWebProps = {
   manifest: LiveAppManifest;

--- a/apps/ledger-live-desktop/src/mvvm/features/Borrow/screens/BorrowWebView/BorrowWebView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Borrow/screens/BorrowWebView/BorrowWebView.tsx
@@ -13,6 +13,21 @@ import type { BorrowWebviewInputs } from "../BorrowApp/useBorrowAppViewModel";
 import { useDeeplinkCustomHandlers } from "~/renderer/components/WebPlatformPlayer/CustomHandlers";
 import { WalletAPICustomHandlers } from "@ledgerhq/live-common/wallet-api/types";
 
+export type BorrowSwapNavigationParams = {
+  fromCurrencyId?: string;
+  toCurrencyId?: string;
+  fromTokenId?: string;
+  toTokenId?: string;
+  fromAccountId?: string;
+  toAccountId?: string;
+  amountFrom?: string;
+  affiliate?: string;
+};
+
+type BorrowNavigateRequestParams = {
+  action?: string;
+} & BorrowSwapNavigationParams;
+
 export type BorrowWebProps = {
   manifest: LiveAppManifest;
   inputs: BorrowWebviewInputs;
@@ -20,6 +35,8 @@ export type BorrowWebProps = {
   webviewState: WebviewState;
   onStateChange: WebviewProps["onStateChange"];
   enablePlatformDevTools: boolean;
+  onWalletApiGoBack?: () => void;
+  onWalletApiGoToSwap?: (params: BorrowSwapNavigationParams) => void;
   Loader?: WebviewLoader;
 };
 
@@ -30,12 +47,50 @@ export const BorrowWebView = ({
   webviewState,
   onStateChange,
   enablePlatformDevTools,
+  onWalletApiGoBack,
+  onWalletApiGoToSwap,
   Loader = BorrowLoader,
 }: BorrowWebProps) => {
   const customDeeplinkHandlers = useDeeplinkCustomHandlers();
   const customHandlers = useMemo<WalletAPICustomHandlers>(
-    () => ({ ...customDeeplinkHandlers }),
-    [customDeeplinkHandlers],
+    () => ({
+      ...customDeeplinkHandlers,
+      "custom.navigate": async (request: { params?: BorrowNavigateRequestParams }) => {
+        const requestAction = request.params?.action;
+
+        if (requestAction === "go-back") {
+          onWalletApiGoBack?.();
+          return { success: true };
+        }
+
+        if (requestAction === "go-to-swap") {
+          const {
+            fromCurrencyId,
+            toCurrencyId,
+            fromTokenId,
+            toTokenId,
+            fromAccountId,
+            toAccountId,
+            amountFrom,
+            affiliate,
+          } = request.params ?? {};
+          onWalletApiGoToSwap?.({
+            fromCurrencyId,
+            toCurrencyId,
+            fromTokenId,
+            toTokenId,
+            fromAccountId,
+            toAccountId,
+            amountFrom,
+            affiliate,
+          });
+          return { success: true };
+        }
+
+        throw new Error("Unknown borrow navigation action");
+      },
+    }),
+    [customDeeplinkHandlers, onWalletApiGoBack, onWalletApiGoToSwap],
   );
 
   return (

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BorrowLiveAppNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BorrowLiveAppNavigator.tsx
@@ -1,11 +1,17 @@
 import type { NavigationProp, ParamListBase } from "@react-navigation/native";
+import { useNavigation } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import React, { useCallback, useEffect, useMemo } from "react";
 import { useTheme } from "styled-components/native";
 import { NavigatorName, ScreenName } from "~/const";
 import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
 import { BorrowLiveAppNavigatorParamList } from "./types/BorrowLiveAppNavigator";
+import { BaseNavigatorStackParamList } from "./types/BaseNavigator";
 import { BorrowLiveAppWrapper } from "LLM/features/Borrow";
+import type { BorrowSwapNavigationParams } from "LLM/features/Borrow/screens/BorrowLiveApp/BorrowLiveAppWrapper";
+import type { DefaultAccountSwapParamList } from "~/screens/Swap/types";
 import type { BaseComposite, StackNavigatorProps } from "./types/helpers";
 
 const Stack = createNativeStackNavigator<BorrowLiveAppNavigatorParamList>();
@@ -19,6 +25,9 @@ type BorrowNavigation = NavigationProp<ParamListBase>;
 const Borrow = (props: NavigationProps) => {
   const paramAction = props.route.params?.action;
   const navigation: BorrowNavigation = props.navigation as unknown as BorrowNavigation;
+  const baseNavigation =
+    useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
+  const { shouldDisplayWallet40MainNav } = useWalletFeaturesConfig("mobile");
 
   const triggerGoBackAction = useCallback(() => {
     navigation.navigate(NavigatorName.Borrow, {
@@ -50,6 +59,31 @@ const Borrow = (props: NavigationProps) => {
     });
   }, [navigation, props.route.params]);
 
+  const goToSwap = useCallback(
+    (swapParams: BorrowSwapNavigationParams) => {
+      const params: DefaultAccountSwapParamList = {
+        ...swapParams,
+        fromPath: ScreenName.Borrow,
+      };
+
+      if (shouldDisplayWallet40MainNav) {
+        baseNavigation.navigate(NavigatorName.Main, {
+          screen: NavigatorName.Swap,
+          params: {
+            screen: ScreenName.SwapTab,
+            params,
+          },
+        });
+      } else {
+        baseNavigation.navigate(NavigatorName.Swap, {
+          screen: ScreenName.SwapTab,
+          params,
+        });
+      }
+    },
+    [baseNavigation, shouldDisplayWallet40MainNav],
+  );
+
   useEffect(() => {
     if (!paramAction || paramAction === "go-back") {
       return;
@@ -65,6 +99,7 @@ const Borrow = (props: NavigationProps) => {
       onNativeGoBack={goBackNative}
       onActionHandled={clearDeepLink}
       onWalletApiGoBack={triggerGoBackAction}
+      onWalletApiGoToSwap={goToSwap}
     />
   );
 };

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BorrowLiveAppNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BorrowLiveAppNavigator.tsx
@@ -1,7 +1,9 @@
 import type { NavigationProp, ParamListBase } from "@react-navigation/native";
 import { useNavigation } from "@react-navigation/native";
-import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import {
+  createNativeStackNavigator,
+  NativeStackNavigationProp,
+} from "@react-navigation/native-stack";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import React, { useCallback, useEffect, useMemo } from "react";
 import { useTheme } from "styled-components/native";
@@ -25,8 +27,7 @@ type BorrowNavigation = NavigationProp<ParamListBase>;
 const Borrow = (props: NavigationProps) => {
   const paramAction = props.route.params?.action;
   const navigation: BorrowNavigation = props.navigation as unknown as BorrowNavigation;
-  const baseNavigation =
-    useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
+  const baseNavigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
   const { shouldDisplayWallet40MainNav } = useWalletFeaturesConfig("mobile");
 
   const triggerGoBackAction = useCallback(() => {
@@ -110,11 +111,7 @@ export default function BorrowLiveAppNavigator() {
 
   return (
     <Stack.Navigator screenOptions={{ ...stackNavigationConfig }}>
-      <Stack.Screen
-        name={ScreenName.Borrow}
-        component={Borrow}
-        options={{ headerShown: false }}
-      />
+      <Stack.Screen name={ScreenName.Borrow} component={Borrow} options={{ headerShown: false }} />
     </Stack.Navigator>
   );
 }

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BorrowLiveAppNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BorrowLiveAppNavigator.tsx
@@ -12,7 +12,7 @@ import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
 import { BorrowLiveAppNavigatorParamList } from "./types/BorrowLiveAppNavigator";
 import { BaseNavigatorStackParamList } from "./types/BaseNavigator";
 import { BorrowLiveAppWrapper } from "LLM/features/Borrow";
-import type { BorrowSwapNavigationParams } from "LLM/features/Borrow/screens/BorrowLiveApp/BorrowLiveAppWrapper";
+import type { BorrowSwapNavigationParams } from "@ledgerhq/live-common/wallet-api/Borrow/navigate";
 import type { DefaultAccountSwapParamList } from "~/screens/Swap/types";
 import type { BaseComposite, StackNavigatorProps } from "./types/helpers";
 

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BorrowLiveAppNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BorrowLiveAppNavigator.tsx
@@ -1,20 +1,16 @@
 import type { NavigationProp, ParamListBase } from "@react-navigation/native";
 import { useNavigation } from "@react-navigation/native";
-import {
-  createNativeStackNavigator,
-  NativeStackNavigationProp,
-} from "@react-navigation/native-stack";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import React, { useCallback, useEffect, useMemo } from "react";
 import { useTheme } from "styled-components/native";
 import { NavigatorName, ScreenName } from "~/const";
 import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
 import { BorrowLiveAppNavigatorParamList } from "./types/BorrowLiveAppNavigator";
-import { BaseNavigatorStackParamList } from "./types/BaseNavigator";
 import { BorrowLiveAppWrapper } from "LLM/features/Borrow";
-import type { BorrowSwapNavigationParams } from "@ledgerhq/live-common/wallet-api/Borrow/navigate";
+import type { BorrowSwapNavigationParams } from "@ledgerhq/live-common/wallet-api/Borrow/types";
 import type { DefaultAccountSwapParamList } from "~/screens/Swap/types";
-import type { BaseComposite, StackNavigatorProps } from "./types/helpers";
+import type { BaseComposite, BaseNavigation, StackNavigatorProps } from "./types/helpers";
 
 const Stack = createNativeStackNavigator<BorrowLiveAppNavigatorParamList>();
 
@@ -27,7 +23,7 @@ type BorrowNavigation = NavigationProp<ParamListBase>;
 const Borrow = (props: NavigationProps) => {
   const paramAction = props.route.params?.action;
   const navigation: BorrowNavigation = props.navigation as unknown as BorrowNavigation;
-  const baseNavigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
+  const baseNavigation = useNavigation<BaseNavigation>();
   const { shouldDisplayWallet40MainNav } = useWalletFeaturesConfig("mobile");
 
   const triggerGoBackAction = useCallback(() => {

--- a/apps/ledger-live-mobile/src/components/RootNavigator/__tests__/BorrowLiveAppNavigator.test.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/__tests__/BorrowLiveAppNavigator.test.tsx
@@ -1,22 +1,108 @@
 import React from "react";
-import { Text } from "react-native";
+import { Pressable, Text } from "react-native";
 import { render, screen } from "@tests/test-renderer";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import type { BorrowSwapNavigationParams } from "@ledgerhq/live-common/wallet-api/Borrow/navigate";
+import { NavigatorName, ScreenName } from "~/const";
 import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
 import BorrowLiveAppNavigator from "../BorrowLiveAppNavigator";
 
+const baseNavigate = jest.fn();
+
+jest.mock("@ledgerhq/live-common/featureFlags/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/featureFlags/index"),
+  useWalletFeaturesConfig: jest.fn(),
+}));
+
+jest.mock("@react-navigation/native", () => {
+  const actual = jest.requireActual("@react-navigation/native");
+  return {
+    ...actual,
+    useNavigation: () => ({ navigate: baseNavigate }),
+  };
+});
+
 jest.mock("LLM/features/Borrow", () => ({
-  BorrowLiveAppWrapper: () => <Text testID="borrow-live-app-wrapper">Borrow Live App</Text>,
+  BorrowLiveAppWrapper: ({
+    onWalletApiGoToSwap,
+  }: {
+    onWalletApiGoToSwap?: (params: BorrowSwapNavigationParams) => void;
+  }) => (
+    <>
+      <Text testID="borrow-live-app-wrapper">Borrow Live App</Text>
+      <Pressable
+        testID="go-to-swap"
+        onPress={() =>
+          onWalletApiGoToSwap?.({
+            fromCurrencyId: "ethereum",
+            toCurrencyId: "bitcoin",
+            amountFrom: "1",
+            affiliate: "borrow-app",
+          })
+        }
+      >
+        <Text>Go to swap</Text>
+      </Pressable>
+    </>
+  ),
 }));
 
 jest.mock("~/navigation/navigatorConfig", () => ({
   getStackNavigatorConfig: jest.fn(() => ({ headerShown: true })),
 }));
 
+const setWallet40Flag = (enabled: boolean) =>
+  jest
+    .mocked(useWalletFeaturesConfig)
+    .mockReturnValue({ shouldDisplayWallet40MainNav: enabled } as ReturnType<
+      typeof useWalletFeaturesConfig
+    >);
+
+const expectedSwapParams = {
+  fromCurrencyId: "ethereum",
+  toCurrencyId: "bitcoin",
+  amountFrom: "1",
+  affiliate: "borrow-app",
+  fromPath: ScreenName.Borrow,
+};
+
 describe("BorrowLiveAppNavigator", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setWallet40Flag(false);
+  });
+
   it("renders the borrow live app wrapper screen", () => {
     render(<BorrowLiveAppNavigator />);
 
     expect(screen.getByTestId("borrow-live-app-wrapper")).toBeOnTheScreen();
     expect(jest.mocked(getStackNavigatorConfig)).toHaveBeenCalled();
+  });
+
+  it("routes go-to-swap to the top-level Swap navigator when shouldDisplayWallet40MainNav is false", async () => {
+    setWallet40Flag(false);
+    const { user } = render(<BorrowLiveAppNavigator />);
+
+    await user.press(screen.getByTestId("go-to-swap"));
+
+    expect(baseNavigate).toHaveBeenCalledWith(NavigatorName.Swap, {
+      screen: ScreenName.SwapTab,
+      params: expectedSwapParams,
+    });
+  });
+
+  it("routes go-to-swap through the Main navigator when shouldDisplayWallet40MainNav is true", async () => {
+    setWallet40Flag(true);
+    const { user } = render(<BorrowLiveAppNavigator />);
+
+    await user.press(screen.getByTestId("go-to-swap"));
+
+    expect(baseNavigate).toHaveBeenCalledWith(NavigatorName.Main, {
+      screen: NavigatorName.Swap,
+      params: {
+        screen: ScreenName.SwapTab,
+        params: expectedSwapParams,
+      },
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/components/RootNavigator/__tests__/BorrowLiveAppNavigator.test.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/__tests__/BorrowLiveAppNavigator.test.tsx
@@ -1,18 +1,11 @@
 import React from "react";
 import { Pressable, Text } from "react-native";
-import { render, screen } from "@tests/test-renderer";
-import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { render, screen, withFlagOverrides } from "@tests/test-renderer";
 import type { BorrowSwapNavigationParams } from "@ledgerhq/live-common/wallet-api/Borrow/navigate";
 import { NavigatorName, ScreenName } from "~/const";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
 import BorrowLiveAppNavigator from "../BorrowLiveAppNavigator";
 
 const baseNavigate = jest.fn();
-
-jest.mock("@ledgerhq/live-common/featureFlags/index", () => ({
-  ...jest.requireActual("@ledgerhq/live-common/featureFlags/index"),
-  useWalletFeaturesConfig: jest.fn(),
-}));
 
 jest.mock("@react-navigation/native", () => {
   const actual = jest.requireActual("@react-navigation/native");
@@ -47,17 +40,6 @@ jest.mock("LLM/features/Borrow", () => ({
   ),
 }));
 
-jest.mock("~/navigation/navigatorConfig", () => ({
-  getStackNavigatorConfig: jest.fn(() => ({ headerShown: true })),
-}));
-
-const setWallet40Flag = (enabled: boolean) =>
-  jest
-    .mocked(useWalletFeaturesConfig)
-    .mockReturnValue({ shouldDisplayWallet40MainNav: enabled } as ReturnType<
-      typeof useWalletFeaturesConfig
-    >);
-
 const expectedSwapParams = {
   fromCurrencyId: "ethereum",
   toCurrencyId: "bitcoin",
@@ -69,19 +51,20 @@ const expectedSwapParams = {
 describe("BorrowLiveAppNavigator", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    setWallet40Flag(false);
   });
 
   it("renders the borrow live app wrapper screen", () => {
     render(<BorrowLiveAppNavigator />);
 
     expect(screen.getByTestId("borrow-live-app-wrapper")).toBeOnTheScreen();
-    expect(jest.mocked(getStackNavigatorConfig)).toHaveBeenCalled();
   });
 
   it("routes go-to-swap to the top-level Swap navigator when shouldDisplayWallet40MainNav is false", async () => {
-    setWallet40Flag(false);
-    const { user } = render(<BorrowLiveAppNavigator />);
+    const { user } = render(<BorrowLiveAppNavigator />, {
+      overrideInitialState: withFlagOverrides({
+        lwmWallet40: { enabled: true, params: { mainNavigation: false } },
+      }),
+    });
 
     await user.press(screen.getByTestId("go-to-swap"));
 
@@ -92,8 +75,11 @@ describe("BorrowLiveAppNavigator", () => {
   });
 
   it("routes go-to-swap through the Main navigator when shouldDisplayWallet40MainNav is true", async () => {
-    setWallet40Flag(true);
-    const { user } = render(<BorrowLiveAppNavigator />);
+    const { user } = render(<BorrowLiveAppNavigator />, {
+      overrideInitialState: withFlagOverrides({
+        lwmWallet40: { enabled: true, params: { mainNavigation: true } },
+      }),
+    });
 
     await user.press(screen.getByTestId("go-to-swap"));
 

--- a/apps/ledger-live-mobile/src/components/RootNavigator/__tests__/BorrowLiveAppNavigator.test.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/__tests__/BorrowLiveAppNavigator.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Pressable, Text } from "react-native";
 import { render, screen, withFlagOverrides } from "@tests/test-renderer";
-import type { BorrowSwapNavigationParams } from "@ledgerhq/live-common/wallet-api/Borrow/navigate";
+import type { BorrowSwapNavigationParams } from "@ledgerhq/live-common/wallet-api/Borrow/types";
 import { NavigatorName, ScreenName } from "~/const";
 import BorrowLiveAppNavigator from "../BorrowLiveAppNavigator";
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Borrow/screens/BorrowLiveApp/BorrowLiveAppWrapper.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Borrow/screens/BorrowLiveApp/BorrowLiveAppWrapper.tsx
@@ -1,13 +1,9 @@
 import { WalletAPICustomHandlers } from "@ledgerhq/live-common/wallet-api/types";
-import {
-  BorrowSwapNavigationParams,
-  createBorrowNavigateHandler,
-} from "@ledgerhq/live-common/wallet-api/Borrow/navigate";
+import { createBorrowNavigateHandler } from "@ledgerhq/live-common/wallet-api/Borrow/navigate";
+import type { BorrowSwapNavigationParams } from "@ledgerhq/live-common/wallet-api/Borrow/types";
 import React, { useEffect, useMemo } from "react";
 import { BorrowLiveAppView } from ".";
 import { useBorrowLiveAppViewModel } from "LLM/features/Borrow/screens/BorrowLiveApp/useBorrowLiveAppViewModel";
-
-export type { BorrowSwapNavigationParams };
 
 type BorrowLiveAppWrapperProps = Readonly<{
   action?: "go-back";

--- a/apps/ledger-live-mobile/src/mvvm/features/Borrow/screens/BorrowLiveApp/BorrowLiveAppWrapper.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Borrow/screens/BorrowLiveApp/BorrowLiveAppWrapper.tsx
@@ -3,11 +3,27 @@ import React, { useEffect, useMemo } from "react";
 import { BorrowLiveAppView } from ".";
 import { useBorrowLiveAppViewModel } from "LLM/features/Borrow/screens/BorrowLiveApp/useBorrowLiveAppViewModel";
 
+export type BorrowSwapNavigationParams = {
+  fromCurrencyId?: string;
+  toCurrencyId?: string;
+  fromTokenId?: string;
+  toTokenId?: string;
+  fromAccountId?: string;
+  toAccountId?: string;
+  amountFrom?: string;
+  affiliate?: string;
+};
+
+type BorrowNavigateRequestParams = {
+  action?: string;
+} & BorrowSwapNavigationParams;
+
 type BorrowLiveAppWrapperProps = Readonly<{
   action?: "go-back";
   onNativeGoBack?: () => void;
   onActionHandled?: () => void;
   onWalletApiGoBack?: () => void;
+  onWalletApiGoToSwap?: (params: BorrowSwapNavigationParams) => void;
 }>;
 
 export function BorrowLiveAppWrapper({
@@ -15,6 +31,7 @@ export function BorrowLiveAppWrapper({
   onNativeGoBack,
   onActionHandled,
   onWalletApiGoBack,
+  onWalletApiGoToSwap,
 }: BorrowLiveAppWrapperProps) {
   const { manifest, error, isLoading, webviewRef, webviewState, onWebviewStateChange, webviewInputs } =
     useBorrowLiveAppViewModel();
@@ -22,18 +39,42 @@ export function BorrowLiveAppWrapper({
 
   const customHandlers = useMemo<WalletAPICustomHandlers>(
     () => ({
-      "custom.borrow.navigate": async (request: { params?: { action?: string } }) => {
+      "custom.navigate": async (request: { params?: BorrowNavigateRequestParams }) => {
         const requestAction = request.params?.action;
 
-        if (requestAction !== "go-back") {
-          throw new Error("Unknown borrow navigation action");
+        if (requestAction === "go-back") {
+          onWalletApiGoBack?.();
+          return { success: true };
         }
 
-        onWalletApiGoBack?.();
-        return { success: true };
+        if (requestAction === "go-to-swap") {
+          const {
+            fromCurrencyId,
+            toCurrencyId,
+            fromTokenId,
+            toTokenId,
+            fromAccountId,
+            toAccountId,
+            amountFrom,
+            affiliate,
+          } = request.params ?? {};
+          onWalletApiGoToSwap?.({
+            fromCurrencyId,
+            toCurrencyId,
+            fromTokenId,
+            toTokenId,
+            fromAccountId,
+            toAccountId,
+            amountFrom,
+            affiliate,
+          });
+          return { success: true };
+        }
+
+        throw new Error("Unknown borrow navigation action");
       },
     }),
-    [onWalletApiGoBack],
+    [onWalletApiGoBack, onWalletApiGoToSwap],
   );
 
   useEffect(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Borrow/screens/BorrowLiveApp/BorrowLiveAppWrapper.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Borrow/screens/BorrowLiveApp/BorrowLiveAppWrapper.tsx
@@ -1,22 +1,13 @@
 import { WalletAPICustomHandlers } from "@ledgerhq/live-common/wallet-api/types";
+import {
+  BorrowSwapNavigationParams,
+  createBorrowNavigateHandler,
+} from "@ledgerhq/live-common/wallet-api/Borrow/navigate";
 import React, { useEffect, useMemo } from "react";
 import { BorrowLiveAppView } from ".";
 import { useBorrowLiveAppViewModel } from "LLM/features/Borrow/screens/BorrowLiveApp/useBorrowLiveAppViewModel";
 
-export type BorrowSwapNavigationParams = {
-  fromCurrencyId?: string;
-  toCurrencyId?: string;
-  fromTokenId?: string;
-  toTokenId?: string;
-  fromAccountId?: string;
-  toAccountId?: string;
-  amountFrom?: string;
-  affiliate?: string;
-};
-
-type BorrowNavigateRequestParams = {
-  action?: string;
-} & BorrowSwapNavigationParams;
+export type { BorrowSwapNavigationParams };
 
 type BorrowLiveAppWrapperProps = Readonly<{
   action?: "go-back";
@@ -39,40 +30,10 @@ export function BorrowLiveAppWrapper({
 
   const customHandlers = useMemo<WalletAPICustomHandlers>(
     () => ({
-      "custom.navigate": async (request: { params?: BorrowNavigateRequestParams }) => {
-        const requestAction = request.params?.action;
-
-        if (requestAction === "go-back") {
-          onWalletApiGoBack?.();
-          return { success: true };
-        }
-
-        if (requestAction === "go-to-swap") {
-          const {
-            fromCurrencyId,
-            toCurrencyId,
-            fromTokenId,
-            toTokenId,
-            fromAccountId,
-            toAccountId,
-            amountFrom,
-            affiliate,
-          } = request.params ?? {};
-          onWalletApiGoToSwap?.({
-            fromCurrencyId,
-            toCurrencyId,
-            fromTokenId,
-            toTokenId,
-            fromAccountId,
-            toAccountId,
-            amountFrom,
-            affiliate,
-          });
-          return { success: true };
-        }
-
-        throw new Error("Unknown borrow navigation action");
-      },
+      "custom.navigate": createBorrowNavigateHandler({
+        onGoBack: onWalletApiGoBack,
+        onGoToSwap: onWalletApiGoToSwap,
+      }),
     }),
     [onWalletApiGoBack, onWalletApiGoToSwap],
   );

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -306,6 +306,7 @@
     "src/wallet-api/constants.ts",
     "src/wallet-api/converters.ts",
     "src/wallet-api/Borrow/navigate.ts",
+    "src/wallet-api/Borrow/types.ts",
     "src/wallet-api/CustomLogger/client.ts",
     "src/wallet-api/CustomLogger/server.ts",
     "src/wallet-api/CustomDeeplink/server.ts",

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -305,6 +305,7 @@
     "src/wallet-api/ACRE/server.ts",
     "src/wallet-api/constants.ts",
     "src/wallet-api/converters.ts",
+    "src/wallet-api/Borrow/navigate.ts",
     "src/wallet-api/CustomLogger/client.ts",
     "src/wallet-api/CustomLogger/server.ts",
     "src/wallet-api/CustomDeeplink/server.ts",

--- a/libs/ledger-live-common/src/wallet-api/Borrow/navigate.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Borrow/navigate.test.ts
@@ -1,0 +1,92 @@
+import {
+  BorrowSwapNavigationParams,
+  createBorrowNavigateHandler,
+} from "./navigate";
+
+describe("createBorrowNavigateHandler", () => {
+  const buildHooks = () => ({
+    onGoBack: jest.fn(),
+    onGoToSwap: jest.fn(),
+  });
+
+  it("invokes onGoBack and resolves successfully for the 'go-back' action", async () => {
+    const hooks = buildHooks();
+    const handler = createBorrowNavigateHandler(hooks);
+
+    await expect(handler({ params: { action: "go-back" } })).resolves.toEqual({
+      success: true,
+    });
+
+    expect(hooks.onGoBack).toHaveBeenCalledTimes(1);
+    expect(hooks.onGoToSwap).not.toHaveBeenCalled();
+  });
+
+  it("forwards all swap params to onGoToSwap for the 'go-to-swap' action", async () => {
+    const hooks = buildHooks();
+    const handler = createBorrowNavigateHandler(hooks);
+
+    const swapParams: BorrowSwapNavigationParams = {
+      fromCurrencyId: "ethereum",
+      toCurrencyId: "bitcoin",
+      fromTokenId: "ethereum/erc20/usd_tether__erc20_",
+      toTokenId: "bitcoin/erc20/wrapped_bitcoin",
+      fromAccountId: "from-account",
+      toAccountId: "to-account",
+      amountFrom: "1.5",
+      affiliate: "borrow-app",
+    };
+
+    await expect(
+      handler({ params: { action: "go-to-swap", ...swapParams } }),
+    ).resolves.toEqual({ success: true });
+
+    expect(hooks.onGoToSwap).toHaveBeenCalledTimes(1);
+    expect(hooks.onGoToSwap).toHaveBeenCalledWith(swapParams);
+    expect(hooks.onGoBack).not.toHaveBeenCalled();
+  });
+
+  it("calls onGoToSwap with undefined fields when the request has no swap params", async () => {
+    const hooks = buildHooks();
+    const handler = createBorrowNavigateHandler(hooks);
+
+    await expect(handler({ params: { action: "go-to-swap" } })).resolves.toEqual({
+      success: true,
+    });
+
+    expect(hooks.onGoToSwap).toHaveBeenCalledWith({
+      fromCurrencyId: undefined,
+      toCurrencyId: undefined,
+      fromTokenId: undefined,
+      toTokenId: undefined,
+      fromAccountId: undefined,
+      toAccountId: undefined,
+      amountFrom: undefined,
+      affiliate: undefined,
+    });
+  });
+
+  it("is a no-op (still resolves) when hooks are not provided", async () => {
+    const handler = createBorrowNavigateHandler({});
+
+    await expect(handler({ params: { action: "go-back" } })).resolves.toEqual({
+      success: true,
+    });
+    await expect(
+      handler({ params: { action: "go-to-swap", fromCurrencyId: "ethereum" } }),
+    ).resolves.toEqual({ success: true });
+  });
+
+  it("throws for unknown actions", async () => {
+    const hooks = buildHooks();
+    const handler = createBorrowNavigateHandler(hooks);
+
+    await expect(handler({ params: { action: "go-to-mars" } })).rejects.toThrow(
+      "Unknown borrow navigation action",
+    );
+    await expect(handler({})).rejects.toThrow("Unknown borrow navigation action");
+    await expect(handler({ params: {} })).rejects.toThrow("Unknown borrow navigation action");
+
+    expect(hooks.onGoBack).not.toHaveBeenCalled();
+    expect(hooks.onGoToSwap).not.toHaveBeenCalled();
+  });
+});

--- a/libs/ledger-live-common/src/wallet-api/Borrow/navigate.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Borrow/navigate.test.ts
@@ -1,7 +1,5 @@
-import {
-  BorrowSwapNavigationParams,
-  createBorrowNavigateHandler,
-} from "./navigate";
+import { createBorrowNavigateHandler } from "./navigate";
+import type { BorrowSwapNavigationParams } from "./types";
 
 describe("createBorrowNavigateHandler", () => {
   const buildHooks = () => ({
@@ -76,15 +74,24 @@ describe("createBorrowNavigateHandler", () => {
     ).resolves.toEqual({ success: true });
   });
 
-  it("throws for unknown actions", async () => {
+  it("throws a dedicated error when the action is missing", async () => {
+    const hooks = buildHooks();
+    const handler = createBorrowNavigateHandler(hooks);
+
+    await expect(handler({})).rejects.toThrow("Missing action parameter");
+    await expect(handler({ params: {} })).rejects.toThrow("Missing action parameter");
+
+    expect(hooks.onGoBack).not.toHaveBeenCalled();
+    expect(hooks.onGoToSwap).not.toHaveBeenCalled();
+  });
+
+  it("throws and surfaces the unsupported action value for unknown actions", async () => {
     const hooks = buildHooks();
     const handler = createBorrowNavigateHandler(hooks);
 
     await expect(handler({ params: { action: "go-to-mars" } })).rejects.toThrow(
-      "Unknown borrow navigation action",
+      "Unknown borrow navigation action: go-to-mars",
     );
-    await expect(handler({})).rejects.toThrow("Unknown borrow navigation action");
-    await expect(handler({ params: {} })).rejects.toThrow("Unknown borrow navigation action");
 
     expect(hooks.onGoBack).not.toHaveBeenCalled();
     expect(hooks.onGoToSwap).not.toHaveBeenCalled();

--- a/libs/ledger-live-common/src/wallet-api/Borrow/navigate.ts
+++ b/libs/ledger-live-common/src/wallet-api/Borrow/navigate.ts
@@ -6,16 +6,7 @@
  * keep behaviour identical across platforms.
  */
 
-export type BorrowSwapNavigationParams = {
-  fromCurrencyId?: string;
-  toCurrencyId?: string;
-  fromTokenId?: string;
-  toTokenId?: string;
-  fromAccountId?: string;
-  toAccountId?: string;
-  amountFrom?: string;
-  affiliate?: string;
-};
+import type { BorrowSwapNavigationParams } from "./types";
 
 type BorrowNavigateRequestParams = {
   action?: string;
@@ -62,6 +53,10 @@ export const createBorrowNavigateHandler =
   async request => {
     const action = request.params?.action;
 
+    if (!action) {
+      throw new Error("Missing action parameter");
+    }
+
     if (action === "go-back") {
       onGoBack?.();
       return { success: true };
@@ -72,5 +67,5 @@ export const createBorrowNavigateHandler =
       return { success: true };
     }
 
-    throw new Error("Unknown borrow navigation action");
+    throw new Error(`Unknown borrow navigation action: ${action}`);
   };

--- a/libs/ledger-live-common/src/wallet-api/Borrow/navigate.ts
+++ b/libs/ledger-live-common/src/wallet-api/Borrow/navigate.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared wallet-api `custom.navigate` handler for the Borrow live app.
+ *
+ * Desktop and mobile both register the same `custom.navigate` action on the
+ * Borrow webview, so the request parsing and host-side fan-out live here to
+ * keep behaviour identical across platforms.
+ */
+
+export type BorrowSwapNavigationParams = {
+  fromCurrencyId?: string;
+  toCurrencyId?: string;
+  fromTokenId?: string;
+  toTokenId?: string;
+  fromAccountId?: string;
+  toAccountId?: string;
+  amountFrom?: string;
+  affiliate?: string;
+};
+
+type BorrowNavigateRequestParams = {
+  action?: string;
+} & BorrowSwapNavigationParams;
+
+export type BorrowNavigateRequest = { params?: BorrowNavigateRequestParams };
+
+export type BorrowNavigateHooks = {
+  onGoBack?: () => void;
+  onGoToSwap?: (params: BorrowSwapNavigationParams) => void;
+};
+
+export type BorrowNavigateHandler = (
+  request: BorrowNavigateRequest,
+) => Promise<{ success: true }>;
+
+const pickSwapParams = (
+  params: BorrowNavigateRequestParams | undefined,
+): BorrowSwapNavigationParams => {
+  const {
+    fromCurrencyId,
+    toCurrencyId,
+    fromTokenId,
+    toTokenId,
+    fromAccountId,
+    toAccountId,
+    amountFrom,
+    affiliate,
+  } = params ?? {};
+  return {
+    fromCurrencyId,
+    toCurrencyId,
+    fromTokenId,
+    toTokenId,
+    fromAccountId,
+    toAccountId,
+    amountFrom,
+    affiliate,
+  };
+};
+
+export const createBorrowNavigateHandler =
+  ({ onGoBack, onGoToSwap }: BorrowNavigateHooks): BorrowNavigateHandler =>
+  async request => {
+    const action = request.params?.action;
+
+    if (action === "go-back") {
+      onGoBack?.();
+      return { success: true };
+    }
+
+    if (action === "go-to-swap") {
+      onGoToSwap?.(pickSwapParams(request.params));
+      return { success: true };
+    }
+
+    throw new Error("Unknown borrow navigation action");
+  };

--- a/libs/ledger-live-common/src/wallet-api/Borrow/types.ts
+++ b/libs/ledger-live-common/src/wallet-api/Borrow/types.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared types for the Borrow live app wallet-api integration.
+ *
+ * Kept in a dedicated module (instead of co-located with the navigate handler)
+ * so that desktop and mobile consumers can import the navigation contract
+ * without coupling to the handler implementation file.
+ */
+
+export type BorrowSwapNavigationParams = {
+  fromCurrencyId?: string;
+  toCurrencyId?: string;
+  fromTokenId?: string;
+  toTokenId?: string;
+  fromAccountId?: string;
+  toAccountId?: string;
+  amountFrom?: string;
+  affiliate?: string;
+};


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
  - Unit tests for the shared `custom.navigate` handler: `libs/ledger-live-common/src/wallet-api/Borrow/navigate.test.ts` (covers `go-back`, `go-to-swap`, swap-param forwarding, missing/unknown action errors, no-op when hooks are absent).
  - Navigation behavior tests for the mobile navigator: `apps/ledger-live-mobile/src/components/RootNavigator/__tests__/BorrowLiveAppNavigator.test.tsx` (covers `go-to-swap` routing through top-level `Swap` vs. nested `Main > Swap` based on the `shouldDisplayWallet40MainNav` flag).
  - Existing `BorrowApp`, `BorrowWebView` and `BorrowLiveAppWrapper` tests were updated to keep coverage in sync with the refactor (removed desktop `PageHeader`, renamed handler, added `onGoToSwap` to the view model).
- [x] **Impact of the changes:**
  - Desktop & mobile Borrow live app: the embedded webview can now trigger a navigation to the Swap flow via the `custom.navigate` wallet API handler with the `go-to-swap` action.
  - Desktop Borrow screen: the native `PageHeader` is no longer rendered — navigation (back, go-to-swap) is fully delegated to the webview.
  - Mobile Borrow navigator: respects the `shouldDisplayWallet40MainNav` feature flag when routing to Swap (nested `Main > Swap` vs. top-level `Swap`).
  - Mobile wallet API handler renamed `custom.borrow.navigate` → `custom.navigate` to align with desktop.

### Description

The Borrow live app needs to be able to send users into the Swap flow with prefilled context (currency, token, account, amount, affiliate) so that user journeys initiated from the Borrow webview can continue seamlessly inside the native Swap of Ledger Live.

This PR extends the existing Borrow wallet API navigation handler with a new `go-to-swap` action:

- **Desktop** (`BorrowWebView`): registers a `custom.navigate` handler that dispatches `go-back` and `go-to-swap` actions. The new `useBorrowAppViewModel.onGoToSwap` builds the `/swap` location state (`defaultCurrency`, `defaultToken`, `defaultAccountId`, `defaultAmountFrom`, `affiliate`, `from`) from the params received from the webview. The desktop `PageHeader` is removed since navigation now lives in the webview.
- **Mobile** (`BorrowLiveAppWrapper` + `BorrowLiveAppNavigator`): the mobile handler is renamed from `custom.borrow.navigate` to `custom.navigate` and gains the same `go-to-swap` action. The navigator builds a `DefaultAccountSwapParamList`, sets `fromPath: ScreenName.Borrow`, and routes to `NavigatorName.Swap` / `ScreenName.SwapTab`, honoring the `shouldDisplayWallet40MainNav` feature flag.

The shared handler and its public contract live in `@ledgerhq/live-common/wallet-api/Borrow`, split between `navigate.ts` (handler) and a dedicated `types.ts` (params type) so that desktop/mobile consumers do not couple to the handler implementation file.

Shape of the params the webview can send:

```ts
type BorrowSwapNavigationParams = {
  fromCurrencyId?: string;
  toCurrencyId?: string;
  fromTokenId?: string;
  toTokenId?: string;
  fromAccountId?: string;
  toAccountId?: string;
  amountFrom?: string;
  affiliate?: string;
};
```

Mobile:

https://github.com/user-attachments/assets/8b30cde0-dacf-4d3a-a21a-853875b397d2

Web:


https://github.com/user-attachments/assets/f2c56746-b480-4bf2-b409-72d5dcdb10fe



### Context

- **JIRA or GitHub link**: _To be filled_

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)