### PR TITLE
test(lwd): add e2e for My Wallet popover navigation

### DIFF
--- a/.changeset/real-humans-clean.md
+++ b/.changeset/real-humans-clean.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop-e2e-tests": patch
+---
+
+Add E2E tests for Wallet 4.0 My Wallet popover navigation (Recover, Referral, Help, Settings)

--- a/e2e/desktop/tests/page/index.ts
+++ b/e2e/desktop/tests/page/index.ts
@@ -34,6 +34,7 @@ import { SwapPage } from "./swap.page";
 import { ModularScanAccountsDrawer } from "./drawer/modular.scan.accounts.drawer";
 import { ModularDialog } from "./dialog/modular.dialog";
 import { MarketBannerPage } from "./marketBanner.page";
+import { MyWalletPage } from "./myWallet.page";
 import { FearAndGreedDialog } from "./dialog/fearGreed.dialog";
 import { NewSendModal } from "./modal/new.send.modal";
 import { PrivateBalanceModal } from "./modal/private.balance.modal";
@@ -77,6 +78,7 @@ export class Application extends PageHolder {
   public swap = new SwapPage(this.page, this.electronApp);
   public swapDrawer = new SwapConfirmationDrawer(this.page);
   public marketBanner = new MarketBannerPage(this.page);
+  public myWallet = new MyWalletPage(this.page);
   public fearAndGreedDialog = new FearAndGreedDialog(this.page);
   public history = new HistoryPage(this.page);
   public mainNavigation = new MainNavigationPage(this.page);

--- a/e2e/desktop/tests/page/myWallet.page.ts
+++ b/e2e/desktop/tests/page/myWallet.page.ts
@@ -1,0 +1,65 @@
+import { AppPage } from "./abstractClasses";
+import { step } from "../misc/reporters/step";
+import { expect } from "@playwright/test";
+
+export class MyWalletPage extends AppPage {
+  private readonly avatar = this.page.getByTestId("my-wallet-avatar");
+  private readonly popoverActionsList = this.page.getByTestId("my-wallet-actions-list");
+  private readonly recoverTile = this.page.getByTestId("my-wallet-action-recover");
+  private readonly helpTile = this.page.getByTestId("my-wallet-action-help");
+  private readonly referralTile = this.page.getByTestId("my-wallet-action-refer");
+  private readonly settingsButtonInPopover = this.page.getByTestId("topbar-action-button-settings");
+  private readonly modalCloseButton = this.page.getByTestId("modal-close-button");
+
+  @step("Open My Wallet popover from avatar")
+  async openMyWalletPopover() {
+    await this.avatar.click();
+    await expect(this.popoverActionsList).toBeVisible();
+  }
+
+  @step("Click Backup (Recover) tile")
+  async clickRecoverTile() {
+    await this.recoverTile.click();
+  }
+
+  @step("Click Referral tile")
+  async clickReferralTile() {
+    await this.referralTile.click();
+  }
+
+  @step("Click Help tile")
+  async clickHelpTile() {
+    await this.helpTile.click();
+  }
+
+  @step("Click Settings from My Wallet popover")
+  async clickSettingsFromPopover() {
+    await this.settingsButtonInPopover.click();
+  }
+
+  @step("Expect Ledger Recover discovery modal to be displayed")
+  async expectRecoverDiscoveryModalDisplayed() {
+    await expect(this.modalCloseButton).toBeVisible();
+  }
+
+  @step("Close Ledger Recover discovery modal")
+  async closeRecoverDiscoveryModal() {
+    await this.modalCloseButton.click();
+    await expect(this.modalCloseButton).toBeHidden();
+  }
+
+  @step("Expect Referral live app to be loaded")
+  async expectReferralLiveAppLoaded() {
+    await expect(this.page).toHaveURL(/\/refer(?:-a-friend)?(?:\/|$|\?)/);
+  }
+
+  @step("Expect Help section to be displayed")
+  async expectHelpSectionDisplayed() {
+    await expect(this.page).toHaveURL(/\/settings\/help(?:\/|$|\?)/);
+  }
+
+  @step("Expect Settings page to be displayed")
+  async expectSettingsPageDisplayed() {
+    await expect(this.page).toHaveURL(/\/settings(?:\/|$|\?)/);
+  }
+}

--- a/e2e/desktop/tests/specs/myWallet.spec.ts
+++ b/e2e/desktop/tests/specs/myWallet.spec.ts
@@ -1,0 +1,60 @@
+import { test } from "tests/fixtures/common";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
+import { addTmsLink } from "tests/utils/allureUtils";
+import { getDescription } from "tests/utils/customJsonReporter";
+import { LWD_WALLET_40_Q2_FF_ENABLED } from "tests/utils/featureFlagUtils";
+
+test.describe("Wallet 4.0 - My Wallet", () => {
+  test.use({
+    teamOwner: Team.WALLET_XP,
+    userdata: "skip-onboarding",
+    featureFlags: {
+      ...LWD_WALLET_40_Q2_FF_ENABLED,
+      protectServicesDesktop: { enabled: true },
+      referralProgramDesktopSidebar: {
+        enabled: true,
+        params: { path: "/refer-a-friend" },
+      },
+    },
+  });
+
+  test(
+    "Open My Wallet and navigate to key sections",
+    {
+      tag: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"],
+      annotation: {
+        type: "TMS",
+        description: "B2CQA-5405, B2CQA-5424, B2CQA-5425, B2CQA-5426, B2CQA-5427",
+      },
+    },
+    async ({ app }) => {
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+
+      await app.mainNavigation.openTargetFromMainNavigation("home");
+
+      await app.myWallet.openMyWalletPopover();
+
+      await app.myWallet.clickRecoverTile();
+      await app.myWallet.expectRecoverDiscoveryModalDisplayed();
+      await app.myWallet.closeRecoverDiscoveryModal();
+
+      await app.mainNavigation.openTargetFromMainNavigation("home");
+
+      await app.myWallet.openMyWalletPopover();
+      await app.myWallet.clickReferralTile();
+      await app.myWallet.expectReferralLiveAppLoaded();
+
+      await app.mainNavigation.openTargetFromMainNavigation("home");
+
+      await app.myWallet.openMyWalletPopover();
+      await app.myWallet.clickHelpTile();
+      await app.myWallet.expectHelpSectionDisplayed();
+
+      await app.mainNavigation.openTargetFromMainNavigation("home");
+
+      await app.myWallet.openMyWalletPopover();
+      await app.myWallet.clickSettingsFromPopover();
+      await app.myWallet.expectSettingsPageDisplayed();
+    },
+  );
+});

--- a/e2e/desktop/tests/utils/featureFlagUtils.ts
+++ b/e2e/desktop/tests/utils/featureFlagUtils.ts
@@ -36,6 +36,7 @@ export const LWD_WALLET_40_Q2_FF_ENABLED: OptionalFeatureMap = {
     params: {
       ...lwdWallet40BaseParams,
       operationsList: true,
+      myWallet: true,
     },
   },
 };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - New Playwright spec `Wallet 4.0 - My Wallet` running on all device targets (NanoSP, LNS, NanoX, Stax, Flex, NanoGen5)
      - Verify the My Wallet popover opens from the avatar and that each tile (Recover, Referral, Help, Settings) navigates correctly
      - Relies on the `myWallet` feature flag and on `protectServicesDesktop` + `referralProgramDesktopSidebar` being enabled in the LWD Q2 feature-flag set

### 📝 Description

Adds automated end-to-end coverage for the Wallet 4.0 My Wallet popover on Ledger Live Desktop. The flow was previously only validated manually via TMS scenarios B2CQA-5405 / 5424 / 5425 / 5426 / 5427.

The new spec opens the My Wallet popover from the avatar and checks every entry point:

- **Backup (Recover)** — opens the Ledger Recover discovery modal and closes it
- **Referral** — opens the referral live app at `/refer-a-friend`
- **Help** — navigates to `/settings/help`
- **Settings** — navigates to `/settings`

A dedicated `MyWalletPage` page object encapsulates the locators and steps, and the spec is wired into the `Application` registry. The `myWallet` feature flag is enabled inside `LWD_WALLET_40_Q2_FF_ENABLED` so the popover is rendered during the test.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29334](https://ledgerhq.atlassian.net/browse/LIVE-29334)
- e2e run : https://github.com/LedgerHQ/ledger-live/actions/runs/26438105552

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29334]: https://ledgerhq.atlassian.net/browse/LIVE-29334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ