### PR TITLE
[LWM] Live 31355 earn crowd favourites modal is not a full screen on ios

### DIFF
--- a/.changeset/wicked-llamas-wave.md
+++ b/.changeset/wicked-llamas-wave.md
@@ -1,5 +1,5 @@
 ---
-"live-mobile": major
+"live-mobile": minor
 ---
 
 fix: earn currency modal layout

--- a/.changeset/wicked-llamas-wave.md
+++ b/.changeset/wicked-llamas-wave.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": major
+---
+
+fix: earn currency modal layout

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -711,7 +711,6 @@ export default function BaseNavigator() {
           component={LiveAppModalScreen}
           options={{
             headerShown: false,
-            presentation: "modal",
             gestureEnabled: true,
           }}
         />

--- a/apps/ledger-live-mobile/src/mvvm/features/LiveAppModal/LiveAppModalView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LiveAppModal/LiveAppModalView.tsx
@@ -1,10 +1,16 @@
 import React from "react";
-import { Box, IconButton, Text } from "@ledgerhq/lumen-ui-rnative";
+import {
+  Box,
+  NavBar,
+  NavBarBackButton,
+  NavBarContent,
+  NavBarDescription,
+  NavBarTitle,
+  Spinner,
+} from "@ledgerhq/lumen-ui-rnative";
 import { useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
-import { ArrowLeft } from "@ledgerhq/lumen-ui-rnative/symbols";
 import SafeAreaView from "~/components/SafeAreaView";
 import GenericErrorView from "~/components/GenericErrorView";
-import InfiniteLoader from "~/components/InfiniteLoader";
 import { Web3AppWebview } from "~/components/Web3AppWebview";
 import { useTranslation } from "~/context/Locale";
 import type { LiveAppModalParams } from "~/reducers/liveAppModal";
@@ -43,26 +49,11 @@ const LiveAppModalContent = ({
       root: {
         flex: 1,
       },
-      header: {
-        paddingHorizontal: theme.spacings.s16,
-        paddingTop: theme.spacings.s12,
-        paddingBottom: theme.spacings.s12,
-      },
-      backButton: {
-        alignSelf: "flex-start",
-        marginLeft: -theme.spacings.s12,
-      },
       placeholder: {
         flex: 1,
         justifyContent: "center",
         alignItems: "center",
         padding: theme.spacings.s48,
-      },
-      title: {
-        marginTop: theme.spacings.s12,
-      },
-      description: {
-        marginTop: theme.spacings.s8,
       },
       webviewContainer: {
         flex: 1,
@@ -75,11 +66,7 @@ const LiveAppModalContent = ({
     return (
       <SafeAreaView style={styles.root} edges={["top", "bottom"]} isFlex>
         <Box style={styles.placeholder}>
-          {isManifestLoading ? (
-            <InfiniteLoader />
-          ) : (
-            <GenericErrorView error={appManifestNotFoundError} />
-          )}
+          {isManifestLoading ? <Spinner /> : <GenericErrorView error={appManifestNotFoundError} />}
         </Box>
       </SafeAreaView>
     );
@@ -87,26 +74,13 @@ const LiveAppModalContent = ({
 
   return (
     <SafeAreaView style={styles.root} edges={["top", "bottom"]} isFlex>
-      <Box style={styles.header}>
-        <IconButton
-          appearance="no-background"
-          size="md"
-          icon={ArrowLeft}
-          accessibilityLabel={t("common.close")}
-          onPress={onClose}
-          style={styles.backButton}
-        />
-        {title ? (
-          <Text typography="heading3SemiBold" style={styles.title}>
-            {title}
-          </Text>
-        ) : null}
-        {description ? (
-          <Text typography="body1" lx={{ color: "muted" }} style={styles.description}>
-            {description}
-          </Text>
-        ) : null}
-      </Box>
+      <NavBar density="expanded">
+        <NavBarBackButton onPress={onClose} accessibilityLabel={t("common.close")} />
+        <NavBarContent>
+          {title ? <NavBarTitle>{title}</NavBarTitle> : null}
+          {description ? <NavBarDescription>{description}</NavBarDescription> : null}
+        </NavBarContent>
+      </NavBar>
       <Box style={styles.webviewContainer}>
         <Web3AppWebview
           ref={webviewAPIRef}

--- a/apps/ledger-live-mobile/src/mvvm/features/LiveAppModal/LiveAppModalView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LiveAppModal/LiveAppModalView.tsx
@@ -55,6 +55,9 @@ const LiveAppModalContent = ({
         alignItems: "center",
         padding: theme.spacings.s48,
       },
+      headerContent: {
+        marginTop: theme.spacings.s12,
+      },
       webviewContainer: {
         flex: 1,
       },
@@ -72,14 +75,21 @@ const LiveAppModalContent = ({
     );
   }
 
+  // The live-app renders its own title/header, so when no native title is
+  // passed we use the compact bar (back button only) to avoid the expanded
+  // bar reserving an empty large-title area below the back button.
+  const hasNativeHeader = Boolean(title || description);
+
   return (
     <SafeAreaView style={styles.root} edges={["top", "bottom"]} isFlex>
-      <NavBar density="expanded">
+      <NavBar density={hasNativeHeader ? "expanded" : "compact"}>
         <NavBarBackButton onPress={onClose} accessibilityLabel={t("common.close")} />
-        <NavBarContent>
-          {title ? <NavBarTitle>{title}</NavBarTitle> : null}
-          {description ? <NavBarDescription>{description}</NavBarDescription> : null}
-        </NavBarContent>
+        {hasNativeHeader ? (
+          <NavBarContent style={styles.headerContent}>
+            {title ? <NavBarTitle>{title}</NavBarTitle> : null}
+            {description ? <NavBarDescription>{description}</NavBarDescription> : null}
+          </NavBarContent>
+        ) : null}
       </NavBar>
       <Box style={styles.webviewContainer}>
         <Web3AppWebview


### PR DESCRIPTION

Fix currency selector screen layout.

https://github.com/user-attachments/assets/98936ecc-2afa-458b-94f2-800b57a877c1


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31355](https://ledgerhq.atlassian.net/browse/LIVE-31355)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31355]: https://ledgerhq.atlassian.net/browse/LIVE-31355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ