### PR TITLE
test(e2e): always use ETH app to re-enable 1inch & Velora providers (QAA-1236)

### DIFF
--- a/e2e/desktop/tests/specs/token.approval.swap.spec.ts
+++ b/e2e/desktop/tests/specs/token.approval.swap.spec.ts
@@ -21,11 +21,8 @@ const eligibleProviders = [
   Provider.UNISWAP,
   Provider.LIFI,
   Provider.OKX,
-  // 1inch and Velora are Ethereum plugin apps (applicationType: "plugin", parent: Ethereum).
-  // They cannot be launched as a main Speculos app — the process exits before the signing step,
-  // causing ECONNREFUSED on the Speculos API port at speculos.signTokenApproval(). See QAA-1236.
-  // Provider.ONE_INCH,
-  // Provider.VELORA,
+  Provider.ONE_INCH,
+  Provider.VELORA,
 ];
 const provider = pickRotatingProvider(eligibleProviders);
 
@@ -40,7 +37,7 @@ test.describe("Token approval - flow", () => {
   test.use({
     teamOwner: Team.SWAP,
     userdata: "skip-onboarding-with-last-seen-device",
-    speculosApp: provider.app ?? fromAccount.currency.speculosApp,
+    speculosApp: fromAccount.currency.speculosApp,
 
     cliCommandsOnApp: [
       [

--- a/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenApprovalFlow.ts
+++ b/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenApprovalFlow.ts
@@ -22,7 +22,7 @@ export function runSwapTokenApprovalFlow(
       await app.speculos.setExchangeDependencies(fromAccount, toAccount);
       await beforeAllFunctionSwap({
         userdata: "skip-onboarding",
-        speculosApp: provider.app ?? fromAccount.currency.speculosApp,
+        speculosApp: fromAccount.currency.speculosApp,
         cliCommandsOnApp: [
           {
             app: fromAccount.currency.speculosApp,

--- a/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenApprovalRotatingProvider.spec.ts
+++ b/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenApprovalRotatingProvider.spec.ts
@@ -7,11 +7,8 @@ const eligibleProviders = [
   Provider.UNISWAP,
   Provider.LIFI,
   Provider.OKX,
-  // 1inch and Velora are Ethereum plugin apps (applicationType: "plugin", parent: Ethereum).
-  // They cannot be launched as a main Speculos app — the process exits before the signing step,
-  // causing ECONNREFUSED on the Speculos API port at speculos.signTokenApproval(). See QAA-1236.
-  // Provider.ONE_INCH,
-  // Provider.VELORA,
+  Provider.ONE_INCH,
+  Provider.VELORA,
 ];
 const provider = pickRotatingProvider(eligibleProviders);
 


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _E2E-only changes — no changeset required._
- [x] **Covered by automatic tests.** _This PR is itself the test fix: the rotating token approval spec exercises the formerly-broken providers on every nightly run._
- [x] **Impact of the changes:**
      - Rotating token approval spec stability (desktop & mobile)
      - 1inch & Velora providers signing via the Ethereum Speculos app
      - No regression for previously eligible providers (Uniswap, LiFi, OKX)
      - Allure report shows the selected provider

### 📝 Description

**Problem.** The ERC-20 token approval rotating spec added under QAA-613 had `Provider.ONE_INCH` and `Provider.VELORA` commented out of the eligible pool. With either provider, the test errored at `app.speculos.signTokenApproval()` with `ECONNREFUSED` on the dynamically allocated Speculos API port — the first `GET_APP_AND_VERSION` APDU never reached a listening process. Root cause: both providers are Ethereum plugins (`applicationType: "plugin"`, `parentName: "Ethereum"`) and were being launched as **main** Speculos apps; the plugin process exits before the signing step.

**Solution.** Pin the Speculos main app to `fromAccount.currency.speculosApp` (Ethereum, since these are ERC-20 approvals) instead of falling back to `provider.app`. The Ethereum app stays resident for the whole flow and signs the approval. The plugin remains available via Speculos `dependencies` declared in `libs/ledger-live-common/src/e2e/speculos.ts`. With this change, `Provider.ONE_INCH` and `Provider.VELORA` are re-enabled in the rotation for both desktop and mobile specs.

Changes (3 files):
- `e2e/desktop/tests/specs/token.approval.swap.spec.ts` — re-enable 1inch/Velora; force `speculosApp: fromAccount.currency.speculosApp`
- `e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenApprovalFlow.ts` — same speculosApp pinning in the shared flow
- `e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenApprovalRotatingProvider.spec.ts` — re-enable 1inch/Velora in mobile rotation

### ❓ Context

- **JIRA or GitHub link**: [QAA-1236](https://ledgerhq.atlassian.net/browse/QAA-1236)
- **Parent / stacked on**: #17508 (QAA-613)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-1236]: https://ledgerhq.atlassian.net/browse/QAA-1236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ