### PR TITLE
[LWD] fix(desktop): asset header spacing on Asset Detail

### DIFF
--- a/.changeset/fuzzy-ears-drop.md
+++ b/.changeset/fuzzy-ears-drop.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix Asset Detail header spacing by replacing vertical padding with bottom margin so the sticky NavBar no longer compresses content above it.

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AssetHeader/AssetHeaderView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AssetHeader/AssetHeaderView.tsx
@@ -33,7 +33,7 @@ export function AssetHeaderView({
   return (
     <NavBar
       data-testid="asset-detail-header"
-      className="sticky top-0 z-10 w-full min-w-0 items-center gap-4 bg-canvas py-12"
+      className="sticky top-0 z-10 w-full min-w-0 items-center gap-4 bg-canvas mb-12"
     >
       <NavBarBackButton onClick={onBack} />
       <NavBarCoinCapsule className="min-w-0 max-w-full" ticker={assetTicker} icon={icon} />


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _CSS-only styling change — not unit-testable._
- [x] **Impact of the changes:**
  - AssetHeader layout on the Asset Detail screen (sticky NavBar spacing across viewports and themes)

### 📝 Description

The sticky `AssetHeader` NavBar on the Asset Detail screen used vertical padding (`py-12`), which combined with the sticky positioning caused the header to compress / overlap content directly below it.

Replace the vertical padding with bottom margin (`mb-12`) so the sticky header reserves space below itself instead of inside itself.

| Before | After |
| ------ | ----- |
|  <img width="256" height="92" alt="Screenshot 2026-05-26 at 09 45 17" src="https://github.com/user-attachments/assets/48d24879-72b5-4ce7-b409-87aa4b901c44" /> |  <img width="532" height="89" alt="Screenshot 2026-05-26 at 10 24 31" src="https://github.com/user-attachments/assets/550c27ae-75e8-4a70-afff-339b5defd34b" />  |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31376](https://ledgerhq.atlassian.net/browse/LIVE-31376)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31376]: https://ledgerhq.atlassian.net/browse/LIVE-31376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ