### PR TITLE
[LWM] feat(mobile): enhance market stats tooltips in asset details

### DIFF
--- a/.changeset/asset-detail-tooltip-wording.md
+++ b/.changeset/asset-detail-tooltip-wording.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Update tooltip wording on the Asset Details page (Circulating supply, Max supply, Available balance) and add Market cap and 24h trading volume info bubbles in the Market stats section.

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -9069,10 +9069,12 @@
       "marketCap": "Market cap",
       "marketRank": "Market rank",
       "circulatingSupply": "Circulating supply",
-      "circulatingSupplyTooltip": "The number of coins currently available for trading and circulating in the market.",
+      "circulatingSupplyTooltip": "The total number of tokens currently available in the market and held by the public. It excludes locked, reserved, or unminted tokens.",
       "maxSupply": "Max supply",
-      "maxSupplyTooltip": "The maximum number of coins that will ever exist for this cryptocurrency.",
+      "maxSupplyTooltip": "The maximum number of tokens that will ever exist. For some assets, this is fixed to prevent inflation.",
+      "marketCapTooltip": "The total value of all coins in circulation. Think of it as the crypto's total worth on the market.",
       "tradingVolume": "24h trading volume",
+      "tradingVolumeTooltip": "The total amount traded in the last 24 hours.",
       "error": "Unable to load market stats"
     },
     "pricePerformance": {
@@ -9106,7 +9108,7 @@
       "earnBannerGeneric": "Earn with this asset",
       "earnBannerSubtitle": "Hold and earn with this asset",
       "earnBannerAction": "Go to Earn",
-      "availableBalanceTooltip": "Funds available for immediate use, excluding staked or delegated amounts."
+      "availableBalanceTooltip": "The portion of the holdings you can use right now, free to send, swap, or withdraw at any time."
     },
     "coinOptions": {
       "openMenuA11yLabel": "Coin options",

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/__tests__/useMarketStatsViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/__tests__/useMarketStatsViewModel.test.ts
@@ -45,12 +45,17 @@ describe("useMarketStatsViewModel", () => {
       expect(rankStat?.value).toBe("#1");
     });
 
-    it("provides tooltip only for circulating supply and max supply", () => {
+    it("provides tooltip for every stat row except market rank", () => {
       const { result } = renderHook(() => useMarketStatsViewModel(mockBtcCryptoCurrency));
 
       const withTooltip = result.current.stats.filter(s => s.tooltip);
-      expect(withTooltip).toHaveLength(2);
-      expect(withTooltip.map(s => s.key)).toEqual(["circulating_supply", "max_supply"]);
+      expect(withTooltip.map(s => s.key)).toEqual([
+        "market_cap",
+        "circulating_supply",
+        "max_supply",
+        "trading_volume",
+      ]);
+      expect(result.current.stats.find(s => s.key === "market_rank")?.tooltip).toBeUndefined();
     });
 
     it("returns an empty array when no market data", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/useMarketStatsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/useMarketStatsViewModel.ts
@@ -37,6 +37,10 @@ export function useMarketStatsViewModel(currency: AssetDetailCurrencyProps) {
                 t,
               })
             : "-",
+        tooltip: {
+          title: t("assetDetail.marketStats.marketCap"),
+          content: t("assetDetail.marketStats.marketCapTooltip"),
+        },
       },
       {
         key: "market_rank",
@@ -89,6 +93,10 @@ export function useMarketStatsViewModel(currency: AssetDetailCurrencyProps) {
               t,
             })
           : "-",
+        tooltip: {
+          title: t("assetDetail.marketStats.tradingVolume"),
+          content: t("assetDetail.marketStats.tradingVolumeTooltip"),
+        },
       },
     ];
   }, [marketCurrency, counterCurrency, locale, t]);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Asset Detail Market stats tooltip content
  - Market cap and 24h trading volume info bubbles
  - Available balance tooltip wording

### 📝 Description

This PR improves Asset Detail tooltip wording so market stats give clearer explanations for circulating supply, max supply, market cap, 24h trading volume, and available balance.

It adds tooltip metadata for Market cap and 24h trading volume in the Market stats view model, updates the English copy, and expands the related hook tests to assert the expected tooltip coverage while keeping Market rank without a tooltip.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31187](https://ledgerhq.atlassian.net/browse/LIVE-31187)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31187]: https://ledgerhq.atlassian.net/browse/LIVE-31187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ