### PR TITLE
[LWDM] fix(asset-detail): improve supply formatting and fallback handling

### DIFF
--- a/.changeset/fix-asset-detail-supply-formatting.md
+++ b/.changeset/fix-asset-detail-supply-formatting.md
@@ -1,0 +1,8 @@
+---
+"live-mobile": minor
+"ledger-live-desktop": minor
+"@ledgerhq/asset-detail": minor
+"@ledgerhq/live-common": minor
+---
+
+Fix circulating and max supply formatting on the asset detail screen (mobile + desktop) so large values always render with locale thousands separators and the asset ticker, and backfill missing supply caps from CoinGecko when DADA market data omits them

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/MarketStats/hooks/useMarketStatsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/MarketStats/hooks/useMarketStatsViewModel.ts
@@ -25,12 +25,14 @@ export function useMarketStatsViewModel(currencyData: MarketDataSectionCurrencyD
       value: data?.circulatingSupply,
       locale,
       shorten: true,
+      ticker: data?.ticker,
     });
 
     const maxSupply = counterValueFormatter({
       value: data?.maxSupply,
       locale,
       shorten: true,
+      ticker: data?.ticker,
     });
 
     const volume24h = counterValueFormatter({
@@ -76,6 +78,7 @@ export function useMarketStatsViewModel(currencyData: MarketDataSectionCurrencyD
     data?.marketcap,
     data?.marketcapRank,
     data?.maxSupply,
+    data?.ticker,
     data?.totalVolume,
     locale,
     t,

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/__tests__/useMarketDataSectionViewModels.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/__tests__/useMarketDataSectionViewModels.test.ts
@@ -97,6 +97,16 @@ describe("useMarketStatsViewModel", () => {
     expect(result.current.sectionTitle).toBeTruthy();
     expect(result.current.sectionTooltip).toBeTruthy();
   });
+
+  it("appends the asset ticker on supply rows", () => {
+    const { result } = renderHook(
+      () => useMarketStatsViewModel(buildCurrencyData()),
+      hookOptions(),
+    );
+
+    expect(result.current.rows.find(r => r.key === "circulating_supply")?.value).toMatch(/BTC$/);
+    expect(result.current.rows.find(r => r.key === "max_supply")?.value).toMatch(/BTC$/);
+  });
 });
 
 describe("usePricePerformanceViewModel", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/__tests__/useMarketStatsViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/__tests__/useMarketStatsViewModel.test.ts
@@ -71,6 +71,40 @@ describe("useMarketStatsViewModel", () => {
       expect(result.current.stats.find(s => s.key === "market_cap")?.value).toBe("-");
       expect(result.current.stats.find(s => s.key === "max_supply")?.value).toBe("-");
     });
+
+    it("formats supply rows with the ticker suffix from market data", () => {
+      const { result } = renderHook(() => useMarketStatsViewModel(mockBtcCryptoCurrency));
+
+      const circulating = result.current.stats.find(s => s.key === "circulating_supply")?.value;
+      const maxSupply = result.current.stats.find(s => s.key === "max_supply")?.value;
+
+      expect(circulating).toMatch(/BTC$/);
+      expect(maxSupply).toMatch(/BTC$/);
+      expect(circulating).not.toMatch(/^\d+$/);
+    });
+
+    it("falls back to the currency prop ticker when market data ticker is missing", () => {
+      mockMarketData({
+        marketCurrency: { ...marketCurrencyData, ticker: "" } as any,
+      });
+
+      const { result } = renderHook(() => useMarketStatsViewModel(mockBtcCryptoCurrency));
+
+      const circulating = result.current.stats.find(s => s.key === "circulating_supply")?.value;
+      expect(circulating).toMatch(/BTC$/);
+    });
+
+    it("never renders a raw unformatted integer for very large supply values", () => {
+      mockMarketData({
+        marketCurrency: { ...marketCurrencyData, circulatingSupply: 124329543825 } as any,
+      });
+
+      const { result } = renderHook(() => useMarketStatsViewModel(mockBtcCryptoCurrency));
+
+      const circulating = result.current.stats.find(s => s.key === "circulating_supply")?.value;
+      expect(circulating).not.toBe("124329543825");
+      expect(circulating).toMatch(/BTC$/);
+    });
   });
 
   describe("loading state", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/useMarketStatsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/useMarketStatsViewModel.ts
@@ -20,8 +20,8 @@ export function useMarketStatsViewModel(currency: AssetDetailCurrencyProps) {
   const stats: StatRow[] = useMemo(() => {
     if (!marketCurrency) return [];
 
-    const { marketcap, marketcapRank, circulatingSupply, maxSupply, totalVolume, ticker } =
-      marketCurrency;
+    const { marketcap, marketcapRank, circulatingSupply, maxSupply, totalVolume } = marketCurrency;
+    const supplyTicker = marketCurrency.ticker || currency?.ticker || "";
 
     return [
       {
@@ -52,7 +52,7 @@ export function useMarketStatsViewModel(currency: AssetDetailCurrencyProps) {
               shorten: true,
               locale,
               t,
-              ticker,
+              ticker: supplyTicker,
             })
           : "-",
         tooltip: {
@@ -69,7 +69,7 @@ export function useMarketStatsViewModel(currency: AssetDetailCurrencyProps) {
               shorten: true,
               locale,
               t,
-              ticker,
+              ticker: supplyTicker,
             })
           : "-",
         tooltip: {
@@ -91,7 +91,7 @@ export function useMarketStatsViewModel(currency: AssetDetailCurrencyProps) {
           : "-",
       },
     ];
-  }, [marketCurrency, counterCurrency, locale, t]);
+  }, [marketCurrency, counterCurrency, locale, t, currency?.ticker]);
 
   const onTooltipOpen = useCallback(
     (statName: string, open: boolean) => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/utils/index.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/utils/index.test.ts
@@ -71,12 +71,31 @@ describe("counterValueFormatter", () => {
       expect(result).toContain("BTC");
     });
 
-    it("returns string value when no formatter is available", () => {
+    it("applies locale thousands separator when no currency and no ticker", () => {
       const result = counterValueFormatter({
-        value: 123.456,
+        value: 1234567,
         locale: "en-US",
       });
-      expect(result).toBe("123.456");
+      expect(result).toBe("1,234,567");
+    });
+
+    it("formats large numbers with ticker instead of returning the raw integer", () => {
+      const result = counterValueFormatter({
+        value: 124329543825,
+        locale: "en-US",
+        ticker: "xyz",
+      });
+      expect(result).not.toBe("124329543825");
+      expect(result).toBe("124,329,543,825 XYZ");
+    });
+
+    it("formats with empty ticker without trailing whitespace", () => {
+      const result = counterValueFormatter({
+        value: 1234567,
+        locale: "en-US",
+        ticker: "",
+      });
+      expect(result).toBe("1,234,567");
     });
   });
 
@@ -150,6 +169,43 @@ describe("counterValueFormatter", () => {
         t: i18next.t,
       });
       expect(result).toContain("50");
+    });
+
+    it("does not insert double whitespace when compact notation is empty (value < 1000)", () => {
+      const result = counterValueFormatter({
+        value: 500,
+        locale: "en-US",
+        shorten: true,
+        t: i18next.t,
+        ticker: "btc",
+      });
+      expect(result).not.toMatch(/\s{2,}/);
+      expect(result).toMatch(/BTC$/);
+    });
+
+    it("appends the ticker after the compact notation when no currency is given", () => {
+      const result = counterValueFormatter({
+        value: 120_685_000,
+        locale: "en-US",
+        shorten: true,
+        t: i18next.t,
+        ticker: "eth",
+      });
+      expect(result).toMatch(/120\.685/);
+      expect(result).toMatch(/M|million/i);
+      expect(result).toMatch(/ETH$/);
+    });
+
+    it("returns compact notation without ticker when ticker is missing", () => {
+      const result = counterValueFormatter({
+        value: 124_329_543_825,
+        locale: "en-US",
+        shorten: true,
+        t: i18next.t,
+      });
+      expect(result).not.toBe("124329543825");
+      expect(result).toMatch(/B|billion/i);
+      expect(result.trim()).toBe(result);
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/utils/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/utils/index.ts
@@ -68,23 +68,22 @@ export const counterValueFormatter = ({
     return "-";
   }
 
-  if (!formatters[locale]) formatters[locale] = {};
-  if (currency && !formatters[locale]?.[currency]) {
-    formatters[locale][currency] = new Intl.NumberFormat(locale, {
-      style: currency ? "currency" : "decimal",
-      currency,
-      maximumFractionDigits: 8,
-      maximumSignificantDigits: 8,
-    });
+  if (currency) {
+    if (!formatters[locale]) formatters[locale] = {};
+    if (!formatters[locale][currency]) {
+      formatters[locale][currency] = new Intl.NumberFormat(locale, {
+        style: "currency",
+        currency,
+        maximumFractionDigits: 8,
+        maximumSignificantDigits: 8,
+      });
+    }
   }
 
-  const formatter = currency
-    ? formatters[locale][currency]
-    : ticker
-      ? new Intl.NumberFormat(locale)
-      : undefined;
+  const formatter = currency ? formatters[locale][currency] : new Intl.NumberFormat(locale);
+  const upperCaseTicker = ticker.trim().toLocaleUpperCase();
 
-  if (shorten && t && formatter) {
+  if (shorten && t) {
     const sign = value > 0 ? "" : "-";
     const v = Math.abs(value);
     const index = Math.min(Math.floor(Math.log(v + 1) / Math.log(10) / 3) || 0, indexes.length - 1);
@@ -97,18 +96,13 @@ export const counterValueFormatter = ({
 
     const I = t(`numberCompactNotation.${i}`);
 
-    const formattedNumber = number.replace(/([0-9,. ]+)/, `${sign}$1 ${I} `);
+    const suffix = I ? ` ${I}` : "";
+    const formattedNumber = number.replace(/([0-9,. ]+)/, `${sign}$1${suffix}`);
 
-    return formattedNumber;
+    return `${formattedNumber} ${upperCaseTicker}`.trim();
   }
 
-  if (formatter) {
-    const formattedValue = formatter.format(value);
-    const upperCaseTicker = ticker?.trim()?.toLocaleUpperCase();
-    return `${formattedValue} ${upperCaseTicker}`.trim();
-  }
-
-  return String(value);
+  return `${formatter.format(value)} ${upperCaseTicker}`.trim();
 };
 
 export function getAnalyticsProperties<P extends object>(

--- a/libs/asset-detail/src/hooks/useAssetMarketData.ts
+++ b/libs/asset-detail/src/hooks/useAssetMarketData.ts
@@ -10,6 +10,7 @@ import { REFETCH_TIME_ONE_MINUTE, BASIC_REFETCH } from "@ledgerhq/live-common/ma
 import { assetsDataApi } from "@ledgerhq/live-common/dada-client/state-manager/api";
 import { selectCurrency } from "@ledgerhq/live-common/dada-client/utils/currencySelection";
 import { useUsdToFiatRate } from "@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate";
+import { applyDadaMarketFallback } from "../utils/applyDadaMarketFallback";
 import type { AssetMarketDataInput, AssetMarketDataResult } from "../types";
 
 export function useAssetMarketData({
@@ -61,11 +62,12 @@ export function useAssetMarketData({
   const marketCurrencyData = useMemo<MarketCurrencyData | undefined>(() => {
     if (dadaMarket) {
       const formattedDadaMarket = format(dadaMarket as MarketItemResponse);
+      const merged = applyDadaMarketFallback(formattedDadaMarket, marketFromHook);
       if (rateStatus === "ready" && rate != null) {
-        return applyUsdRateToMarket(formattedDadaMarket, rate);
+        return applyUsdRateToMarket(merged, rate);
       }
       // Return USD-formatted data while rate is loading/errored, instead of falling back to undefined
-      return formattedDadaMarket;
+      return merged;
     }
     return marketFromHook;
   }, [dadaMarket, marketFromHook, rateStatus, rate]);

--- a/libs/asset-detail/src/utils/__tests__/applyDadaMarketFallback.test.ts
+++ b/libs/asset-detail/src/utils/__tests__/applyDadaMarketFallback.test.ts
@@ -1,0 +1,89 @@
+import type { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
+import { applyDadaMarketFallback } from "../applyDadaMarketFallback";
+
+const baseMarket = (overrides: Partial<MarketCurrencyData> = {}): MarketCurrencyData =>
+  ({
+    id: "bitcoin",
+    ledgerIds: ["bitcoin"],
+    name: "Bitcoin",
+    ticker: "BTC",
+    price: 50_000,
+    circulatingSupply: 19_500_000,
+    totalSupply: 19_500_000,
+    maxSupply: 21_000_000,
+    ...overrides,
+  }) as MarketCurrencyData;
+
+describe("applyDadaMarketFallback", () => {
+  it("returns DADA values verbatim when all merged fields are present", () => {
+    const dada = baseMarket();
+    const cg = baseMarket({
+      ticker: "XXX",
+      circulatingSupply: 999,
+      totalSupply: 999,
+      maxSupply: 999,
+    });
+    const out = applyDadaMarketFallback(dada, cg);
+
+    expect(out.ticker).toBe("BTC");
+    expect(out.circulatingSupply).toBe(19_500_000);
+    expect(out.totalSupply).toBe(19_500_000);
+    expect(out.maxSupply).toBe(21_000_000);
+  });
+
+  it("falls back to CoinGecko ticker when DADA returns an empty string", () => {
+    const dada = baseMarket({ ticker: "" });
+    const cg = baseMarket({ ticker: "XRP" });
+    const out = applyDadaMarketFallback(dada, cg);
+
+    expect(out.ticker).toBe("XRP");
+  });
+
+  it("falls back to CoinGecko when DADA returns 0 for a supply cap", () => {
+    const dada = baseMarket({ maxSupply: 0 });
+    const cg = baseMarket({ maxSupply: 21_000_000 });
+    const out = applyDadaMarketFallback(dada, cg);
+
+    expect(out.maxSupply).toBe(21_000_000);
+  });
+
+  it("falls back to CoinGecko for circulatingSupply and totalSupply when DADA returns 0", () => {
+    const dada = baseMarket({ circulatingSupply: 0, totalSupply: 0 });
+    const cg = baseMarket({ circulatingSupply: 19_500_000, totalSupply: 19_500_000 });
+    const out = applyDadaMarketFallback(dada, cg);
+
+    expect(out.circulatingSupply).toBe(19_500_000);
+    expect(out.totalSupply).toBe(19_500_000);
+  });
+
+  it("defaults ticker to an empty string when both sources are missing", () => {
+    const dada = baseMarket({ ticker: "" });
+    const out = applyDadaMarketFallback(dada, undefined);
+
+    expect(out.ticker).toBe("");
+  });
+
+  it("leaves maxSupply/totalSupply undefined when both sources are missing", () => {
+    const dada = baseMarket({ maxSupply: 0, totalSupply: 0 });
+    const out = applyDadaMarketFallback(dada, undefined);
+
+    expect(out.maxSupply).toBeUndefined();
+    expect(out.totalSupply).toBeUndefined();
+  });
+
+  it("defaults circulatingSupply to 0 when both sources are missing", () => {
+    const dada = baseMarket({ circulatingSupply: 0 });
+    const out = applyDadaMarketFallback(dada, undefined);
+
+    expect(out.circulatingSupply).toBe(0);
+  });
+
+  it("preserves all non-merged fields from DADA", () => {
+    const dada = baseMarket({ price: 12_345, marketcap: 1_000 });
+    const cg = baseMarket({ price: 1, marketcap: 1 });
+    const out = applyDadaMarketFallback(dada, cg);
+
+    expect(out.price).toBe(12_345);
+    expect(out.marketcap).toBe(1_000);
+  });
+});

--- a/libs/asset-detail/src/utils/applyDadaMarketFallback.ts
+++ b/libs/asset-detail/src/utils/applyDadaMarketFallback.ts
@@ -1,0 +1,21 @@
+import type { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
+import { applySupplyFallback } from "./applySupplyFallback";
+
+/**
+ * Merge DADA-derived market data with a CoinGecko fallback for the asset ticker.
+ *
+ * The `||` (not `??`) fallback is intentional: DADA returns "" instead of
+ * omitting the ticker when it has no data.
+ */
+export function applyDadaMarketFallback(
+  dadaMarket: MarketCurrencyData,
+  coinGeckoMarket: MarketCurrencyData | undefined,
+): MarketCurrencyData {
+  return applySupplyFallback(
+    {
+      ...dadaMarket,
+      ticker: dadaMarket.ticker || coinGeckoMarket?.ticker || "",
+    },
+    coinGeckoMarket,
+  );
+}

--- a/libs/asset-detail/src/utils/applySupplyFallback.ts
+++ b/libs/asset-detail/src/utils/applySupplyFallback.ts
@@ -1,0 +1,25 @@
+import type { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
+
+type MarketCurrencyDataWithOptionalSupply = Omit<MarketCurrencyData, "totalSupply" | "maxSupply"> &
+  Partial<Pick<MarketCurrencyData, "totalSupply" | "maxSupply">>;
+
+/**
+ * Merge DADA-derived market data with a CoinGecko fallback for supply fields.
+ *
+ * DADA returns 0 instead of omitting missing supply fields, so the `||` (not `??`)
+ * fallback is intentional: any 0 from DADA is treated as "no value" and replaced
+ * by the CoinGecko value when available.
+ */
+export function applySupplyFallback(
+  dadaMarket: MarketCurrencyData,
+  coinGeckoMarket: MarketCurrencyData | undefined,
+): MarketCurrencyData {
+  const marketWithSupplyFallback: MarketCurrencyDataWithOptionalSupply = {
+    ...dadaMarket,
+    circulatingSupply: dadaMarket.circulatingSupply || coinGeckoMarket?.circulatingSupply || 0,
+    totalSupply: dadaMarket.totalSupply || coinGeckoMarket?.totalSupply,
+    maxSupply: dadaMarket.maxSupply || coinGeckoMarket?.maxSupply,
+  };
+
+  return marketWithSupplyFallback as MarketCurrencyData;
+}

--- a/libs/ledger-live-common/src/market/utils/__tests__/countervalueFormatter.test.ts
+++ b/libs/ledger-live-common/src/market/utils/__tests__/countervalueFormatter.test.ts
@@ -1,0 +1,46 @@
+import { counterValueFormatter } from "../countervalueFormatter";
+
+describe("counterValueFormatter (live-common)", () => {
+  it("returns '-' for falsy values", () => {
+    expect(counterValueFormatter({ value: 0, locale: "en-US" })).toBe("-");
+    expect(counterValueFormatter({ value: undefined, locale: "en-US" })).toBe("-");
+  });
+
+  it("formats a currency value", () => {
+    const result = counterValueFormatter({
+      value: 1234.56,
+      locale: "en-US",
+      currency: "USD",
+    });
+    expect(result).toContain("$");
+    expect(result).toContain("1,234.56");
+  });
+
+  it("formats in compact notation when shorten is true", () => {
+    const result = counterValueFormatter({
+      value: 21_000_000,
+      locale: "en-US",
+      shorten: true,
+    });
+    expect(result).toMatch(/21M/i);
+  });
+
+  it("appends an uppercased ticker after the formatted value", () => {
+    const result = counterValueFormatter({
+      value: 21_000_000,
+      locale: "en-US",
+      shorten: true,
+      ticker: "btc",
+    });
+    expect(result).toMatch(/^21M BTC$/);
+  });
+
+  it("does not append anything when ticker is empty or whitespace", () => {
+    expect(counterValueFormatter({ value: 100, locale: "en-US", ticker: "" })).toBe("100");
+    expect(counterValueFormatter({ value: 100, locale: "en-US", ticker: "   " })).toBe("100");
+  });
+
+  it("does not append a ticker for the falsy '-' branch", () => {
+    expect(counterValueFormatter({ value: 0, locale: "en-US", ticker: "btc" })).toBe("-");
+  });
+});

--- a/libs/ledger-live-common/src/market/utils/countervalueFormatter.ts
+++ b/libs/ledger-live-common/src/market/utils/countervalueFormatter.ts
@@ -3,21 +3,25 @@ export const counterValueFormatter = ({
   value,
   shorten,
   locale,
+  ticker,
 }: {
   currency?: string;
   value?: number;
   shorten?: boolean;
   locale: string;
+  ticker?: string;
 }): string => {
   if (!value) {
     return "-";
   }
-  return new Intl.NumberFormat(locale, {
+  const formatted = new Intl.NumberFormat(locale, {
     style: currency ? "currency" : "decimal",
     currency,
     notation: shorten ? "compact" : "standard",
     maximumFractionDigits: shorten ? 3 : 8,
   }).format(value);
+  const upperTicker = ticker?.trim().toUpperCase();
+  return upperTicker ? `${formatted} ${upperTicker}` : formatted;
 };
 
 export default counterValueFormatter;

--- a/libs/ledger-live-common/src/market/utils/types.ts
+++ b/libs/ledger-live-common/src/market/utils/types.ts
@@ -79,8 +79,8 @@ export type MarketCurrencyData = {
   priceChangePercentage: Record<KeysPriceChange, number>;
   marketCapChangePercentage24h: number;
   circulatingSupply: number;
-  totalSupply: number;
-  maxSupply: number;
+  totalSupply?: number;
+  maxSupply?: number;
   ath: number;
   athDate: Date;
   atl: number;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Mobile and desktop Asset Detail market stats display
  - Circulating supply and max supply formatting with locale thousands separators and asset ticker
  - Fallback behavior when DADA market data omits supply values that CoinGecko still provides

### 📝 Description

Asset detail screens displayed supply values inconsistently: large circulating and max supply values could render without locale thousands separators or the asset ticker, and DADA market data can report `0` when supply caps are unavailable even though CoinGecko still has usable fallback values.

This PR adds a shared `applySupplyFallback` utility in `@ledgerhq/asset-detail`, wires it into market data composition, and updates mobile, desktop, and shared formatter usage so supply rows render as readable localized values with the asset ticker. It also adds focused tests for the fallback behavior and formatter outputs across the affected mobile, desktop, asset-detail, and live-common scopes.

<img width="350" height="750" alt="Simulator Screenshot - iOS Simulator - 2026-05-26 at 09 19 34" src="https://github.com/user-attachments/assets/2c141ab1-3af3-4b9e-b6a6-4364946aed83" />

<img width="1392" height="257" alt="image" src="https://github.com/user-attachments/assets/986c796d-80b6-4c70-9df8-6d8281683dba" />
### ❓ Context

- **JIRA or GitHub link**: [LIVE-30918](https://ledgerhq.atlassian.net/browse/LIVE-30918)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30918]: https://ledgerhq.atlassian.net/browse/LIVE-30918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ