### PR TITLE
[LWDM] fix(desktop, mobile): wire FEATURE_FLAGS env into the feature-flags middleware (LIVE-31377)

### DIFF
--- a/.changeset/ff-middleware-env-flags-both-apps.md
+++ b/.changeset/ff-middleware-env-flags-both-apps.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Wire `getEnv("FEATURE_FLAGS")` into `createFeatureFlagsMiddleware`'s `resolutionConfig.envFlags` so env-injected feature flag overrides reach Redux-backed consumers (parity with live-common's Context behavior). Unblocks the LWD and LLM migrations whose Playwright/Detox env-injection paths went silent after the slice became the source of truth.

--- a/apps/ledger-live-desktop/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-desktop/src/state-manager/configureStore.ts
@@ -1,11 +1,12 @@
 import { configureStore, Middleware, ThunkDispatch } from "@reduxjs/toolkit";
 import { UnknownAction } from "redux";
+import { getEnv } from "@ledgerhq/live-env";
 import logger from "~/renderer/middlewares/logger";
 import reducers, { State } from "~/renderer/reducers";
 import { applyLldRTKApiMiddlewares } from "~/renderer/reducers/rtkQueryApi";
 import { createIdentitiesSyncMiddleware } from "@ledgerhq/client-ids/store";
 import { canPushDeviceIdsSelector } from "~/renderer/reducers/settings";
-import { createFeatureFlagsMiddleware } from "@shared/feature-flags";
+import { createFeatureFlagsMiddleware, type PartialFeatures } from "@shared/feature-flags";
 import { fetchRemoteFlags } from "~/firebase/remoteConfig";
 type Props = {
   state?: State;
@@ -32,7 +33,11 @@ const customCreateStore = ({ state, dbMiddleware, analyticsMiddleware }: Props) 
         )
         .concat(
           createFeatureFlagsMiddleware({
-            resolutionConfig: { platform: "desktop", appVersion: __APP_VERSION__ },
+            resolutionConfig: {
+              platform: "desktop",
+              appVersion: __APP_VERSION__,
+              envFlags: getEnv("FEATURE_FLAGS") as PartialFeatures,
+            },
             fetchRemoteFlags,
           }),
         ),

--- a/apps/ledger-live-mobile/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-mobile/src/state-manager/configureStore.ts
@@ -13,7 +13,8 @@ import { setupRecentAddressesStore } from "LLM/storage/recentAddresses";
 import { createIdentitiesSyncMiddleware } from "@ledgerhq/client-ids/store";
 import { State } from "~/reducers/types";
 import { canPushDeviceIdsSelector } from "~/reducers/settings";
-import { createFeatureFlagsMiddleware } from "@shared/feature-flags";
+import { getEnv } from "@ledgerhq/live-env";
+import { createFeatureFlagsMiddleware, type PartialFeatures } from "@shared/feature-flags";
 import { fetchRemoteFlags } from "~/firebase/remoteConfig";
 
 export const store = configureStore({
@@ -35,6 +36,7 @@ export const store = configureStore({
           resolutionConfig: {
             platform: Platform.OS === "ios" ? "ios" : "android",
             appVersion: VersionNumber.appVersion ?? undefined,
+            envFlags: getEnv("FEATURE_FLAGS") as PartialFeatures,
           },
           fetchRemoteFlags,
         }),


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.** Existing slice resolution coverage in \`shared/feature-flags/src/data/utils.test.ts\` already exercises the env-flags layer (\`utils.test.ts:139\`); no new test needed for the wiring itself.
- [x] **Impact of the changes:**
  - **Playwright (LWD)** — `apps/ledger-live-desktop/tests/fixtures/common.ts:102` injects `FEATURE_FLAGS` into the Electron launch env. Tests that override flags (e.g. `newSendFlow.params.families`, `receiveStakingFlowConfigDesktop`) now reach consumers reading from the Redux slice.
  - **Detox / QA (LWM)** — same env-launch override mechanism works for the slice on mobile.
  - **Dev/prod** — no behaviour change. `getEnv("FEATURE_FLAGS")` returns `{}` when the env is unset.

### 📝 Description

Both apps mount `createFeatureFlagsMiddleware` without passing `envFlags`, so the `FEATURE_FLAGS` environment variable is silently ignored by any consumer reading from the Redux-backed slice.

- Live-common's legacy `getFeature` honored this via `getEnv("FEATURE_FLAGS")` (`libs/ledger-live-common/src/featureFlags/firebaseFeatureFlags.ts:82`).
- The slice's resolution chain (`shared/feature-flags/src/data/utils.ts:113-125`) supports the same env layer via `resolutionConfig.envFlags` — but no app was wiring it in.

This surfaced in [LIVE-30412](https://ledgerhq.atlassian.net/browse/LIVE-30412): after migrating ~189 LLD hook call sites to the slice, multiple Playwright suites (`newSendFlow.spec.ts`, `delegate.evmNativeStaking.smoke.spec.ts`) timed out because env-injected overrides bypassed the new consumers. Same gap exists in LWM and would block the LLM migration sibling [LIVE-30964](https://ledgerhq.atlassian.net/browse/LIVE-30964).

### Change

Pass `getEnv("FEATURE_FLAGS")` (registered in `@ledgerhq/live-env/src/env.ts:966` with `jsonParser`, default `"{}"`) to the middleware's resolution config in both apps. Type-cast to `PartialFeatures` for shape parity with the slice.

**LWD** `apps/ledger-live-desktop/src/state-manager/configureStore.ts`:

```ts
+import { getEnv } from "@ledgerhq/live-env";
+import { createFeatureFlagsMiddleware, type PartialFeatures } from "@shared/feature-flags";
 // ...
   resolutionConfig: {
     platform: "desktop",
     appVersion: __APP_VERSION__,
+    envFlags: getEnv("FEATURE_FLAGS") as PartialFeatures,
   },
```

**LWM** `apps/ledger-live-mobile/src/state-manager/configureStore.ts` — same pattern with the mobile-specific platform/version.

### ❓ Context

- **JIRA link**: [LIVE-31377](https://ledgerhq.atlassian.net/browse/LIVE-31377)
- **Parent**: [LIVE-30412](https://ledgerhq.atlassian.net/browse/LIVE-30412) (LWD migration) — currently has a duplicate-content commit on \`refactor/use-platform-ff-hooks-lwd\` that will drop on rebase after this lands
- **Sibling**: [LIVE-30964](https://ledgerhq.atlassian.net/browse/LIVE-30964) (LLM migration) — preempts the same regression on mobile
- **Related**: [LIVE-31275](https://ledgerhq.atlassian.net/browse/LIVE-31275) (\`fetchRemoteFlags\` wiring) — same pattern, this PR completes the \`resolutionConfig\` wiring it left

[LIVE-30412]: https://ledgerhq.atlassian.net/browse/LIVE-30412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ