### PR TITLE
[LWD] fix(desktop): persist starred market assets after refresh

### DIFF
--- a/.changeset/strong-trains-lick.md
+++ b/.changeset/strong-trains-lick.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Persist starred market assets after refresh by saving settings changes triggered by MARKET_* actions

--- a/apps/ledger-live-desktop/src/renderer/middlewares/__tests__/db.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/__tests__/db.test.ts
@@ -1,0 +1,157 @@
+import type { Dispatch, MiddlewareAPI, UnknownAction } from "@reduxjs/toolkit";
+import { setKey } from "~/renderer/storage";
+import type { State } from "../../reducers";
+import DBMiddleware from "../db";
+
+jest.mock("~/renderer/storage", () => ({
+  setKey: jest.fn(),
+}));
+
+jest.mock("@ledgerhq/live-common/postOnboarding/reducer", () => ({
+  postOnboardingSelector: jest.fn(() => ({})),
+}));
+
+jest.mock("@ledgerhq/live-common/postOnboarding/actions", () => ({
+  actionTypePrefix: "POST_ONBOARDING_",
+}));
+
+jest.mock("../../reducers/settings", () => ({
+  settingsStoreSelector: (state: FakeState) => state.settings,
+  areSettingsLoaded: (state: FakeState) => state.settings.loaded === true,
+}));
+
+jest.mock("@ledgerhq/live-wallet/store", () => ({
+  accountUserDataExportSelector: jest.fn(() => null),
+  walletStateExportShouldDiffer: jest.fn(() => false),
+  exportWalletState: jest.fn(s => s),
+}));
+
+jest.mock("@ledgerhq/ledger-key-ring-protocol/store", () => ({
+  trustchainStoreActionTypePrefix: "TRUSTCHAIN_STORE_",
+  trustchainStoreSelector: jest.fn(state => state.trustchain),
+}));
+
+jest.mock("@ledgerhq/cryptoassets/cal-client/persistence", () => ({
+  extractPersistedCALFromState: jest.fn(() => ({ tokens: [] })),
+  persistedCALContentEqual: jest.fn(() => true),
+}));
+
+jest.mock("../../reducers/market", () => ({
+  marketStoreSelector: (state: FakeState) => state.market,
+}));
+
+jest.mock("@ledgerhq/client-ids/store", () => ({
+  exportIdentitiesForPersistence: jest.fn(s => s),
+}));
+
+jest.mock("@ledgerhq/live-common/account/index", () => ({
+  accountsPersistedStateChanged: jest.fn(() => false),
+}));
+
+const mockedSetKey = jest.mocked(setKey);
+
+type FakeState = {
+  settings: { loaded: boolean; starredMarketCoins: string[] };
+  market: Record<string, unknown>;
+  application: { isLocked: boolean };
+  wallet: unknown;
+  accounts: unknown[];
+  identities: unknown;
+  history: unknown;
+  featureFlags: { overrides: unknown; bannerVisible: unknown };
+  trustchain?: unknown;
+};
+
+const baseState = (): FakeState => ({
+  settings: { loaded: true, starredMarketCoins: [] },
+  market: { currentPage: 1 },
+  application: { isLocked: false },
+  wallet: {},
+  accounts: [],
+  identities: {},
+  history: {},
+  featureFlags: { overrides: {}, bannerVisible: false },
+});
+
+function runMiddleware(states: FakeState[], action: { type: string; payload?: unknown }) {
+  let callCount = 0;
+  const store = {
+    getState: () => states[Math.min(callCount, states.length - 1)] as unknown as State,
+    dispatch: jest.fn(),
+  } as MiddlewareAPI<Dispatch<UnknownAction>, State>;
+  const next = jest.fn(() => {
+    callCount += 1;
+    return action;
+  });
+
+  return DBMiddleware(store)(next)(action);
+}
+
+describe("DBMiddleware - MARKET branch", () => {
+  beforeEach(() => {
+    mockedSetKey.mockReset();
+  });
+
+  it("persists settings when a MARKET_* action mutates the settings slice (e.g. MARKET_ADD_STARRED_COINS)", () => {
+    const before = baseState();
+    const after: FakeState = {
+      ...before,
+      settings: { ...before.settings, starredMarketCoins: ["bitcoin"] },
+    };
+
+    runMiddleware([before, after], { type: "MARKET_ADD_STARRED_COINS", payload: "bitcoin" });
+
+    expect(mockedSetKey).toHaveBeenCalledTimes(1);
+    expect(mockedSetKey).toHaveBeenCalledWith("app", "settings", after.settings);
+    expect(mockedSetKey).not.toHaveBeenCalledWith("app", "market", expect.anything());
+  });
+
+  it("persists market (only) when a MARKET_* action mutates the market slice", () => {
+    const before = baseState();
+    const after: FakeState = {
+      ...before,
+      market: { currentPage: 2 },
+    };
+
+    runMiddleware([before, after], { type: "MARKET_SET_CURRENT_PAGE", payload: 2 });
+
+    expect(mockedSetKey).toHaveBeenCalledTimes(1);
+    expect(mockedSetKey).toHaveBeenCalledWith("app", "market", after.market);
+    expect(mockedSetKey).not.toHaveBeenCalledWith("app", "settings", expect.anything());
+  });
+
+  it("persists both market and settings if both slices change on a MARKET_* action", () => {
+    const before = baseState();
+    const after: FakeState = {
+      ...before,
+      market: { currentPage: 2 },
+      settings: { ...before.settings, starredMarketCoins: ["bitcoin"] },
+    };
+
+    runMiddleware([before, after], { type: "MARKET_ADD_STARRED_COINS", payload: "bitcoin" });
+
+    expect(mockedSetKey).toHaveBeenCalledTimes(2);
+    expect(mockedSetKey).toHaveBeenNthCalledWith(1, "app", "market", after.market);
+    expect(mockedSetKey).toHaveBeenNthCalledWith(2, "app", "settings", after.settings);
+  });
+
+  it("does not persist anything when neither slice changed", () => {
+    const state = baseState();
+    runMiddleware([state, state], { type: "MARKET_NOOP" });
+
+    expect(mockedSetKey).not.toHaveBeenCalled();
+  });
+
+  it("does not persist settings on a MARKET_* action when settings are not loaded yet", () => {
+    const before = baseState();
+    const after: FakeState = {
+      ...before,
+      settings: { loaded: false, starredMarketCoins: ["bitcoin"] },
+    };
+
+    runMiddleware([before, after], { type: "MARKET_ADD_STARRED_COINS", payload: "bitcoin" });
+
+    expect(mockedSetKey).toHaveBeenCalledTimes(0);
+    expect(mockedSetKey).not.toHaveBeenCalledWith("app", "settings", expect.anything());
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
@@ -89,9 +89,19 @@ const DBMiddleware: Middleware<object, State> = store => next => action => {
   }
 
   if (action.type.startsWith("MARKET")) {
+    const oldState = store.getState();
     const res = next(action);
-    const state = store.getState();
-    setKey("app", "market", marketStoreSelector(state));
+    const newState = store.getState();
+
+    if (oldState.market !== newState.market) {
+      setKey("app", "market", marketStoreSelector(newState));
+    }
+    // Some MARKET_* actions (e.g. MARKET_ADD_STARRED_COINS) are handled by the
+    // settings reducer, so settings persistence must also run on this branch.
+    if (areSettingsLoaded(newState) && oldState.settings !== newState.settings) {
+      setKey("app", "settings", settingsStoreSelector(newState));
+    }
+
     return res;
   }
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Starring/unstarring assets persists after refresh

### 📝 Description

Starred assets on the LWD Market page were lost whenever the user refreshed the app.

**Problem**: The DB middleware (`apps/ledger-live-desktop/src/renderer/middlewares/db.ts`) short-circuits on any `MARKET_*` action and only persists the `market` slice. However, several `MARKET_*` actions — notably `MARKET_ADD_STARRED_COINS` and `MARKET_REMOVE_STARRED_COINS` — are handled by the **settings** reducer (`starredMarketCoins` lives in settings). As a result, starring an asset never triggered a settings persist, and the change was lost on the next app load.

**Solution**: In the `MARKET_*` branch, capture state before and after `next(action)`, then:
- Persist `market` only if the `market` slice changed.
- Additionally persist `settings` if `settings` changed and are loaded, mirroring the logic used in the default branch.

Unit tests in `__tests__/db.test.ts` cover the four relevant cases: settings-only change, market-only change, both slices changing, no change, and the not-yet-loaded settings guard.


https://github.com/user-attachments/assets/0f5fd6fe-0ac5-4099-97e9-9b905b232fe5




### ❓ Context

- **JIRA or GitHub link**: [LIVE-31301](https://ledgerhq.atlassian.net/browse/LIVE-31301)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31301]: https://ledgerhq.atlassian.net/browse/LIVE-31301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ