### PR TITLE
[LWM] fix(mobile): preselect asset in Asset Detail Receive

### DIFF
--- a/.changeset/bright-assets-receive.md
+++ b/.changeset/bright-assets-receive.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix mobile Asset Detail Receive asset preselection while preserving network selection for multi-network assets.

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
@@ -19,10 +19,12 @@ import { MarketData } from "./components/MarketData";
 import { CTAS_HEIGHT } from "./utils/constants";
 import { AssetCoinOptionsSheetView } from "./components/CoinOptions/AssetCoinOptionsSheetView";
 import type { AssetCoinOptionsViewModel } from "./components/CoinOptions/useAssetCoinOptionsViewModel";
+import type { ReceiveCurrencyIds } from "LLM/features/Receive/types";
 
 type Props = Readonly<{
   currency: AssetDetailCurrencyProps;
   distributionItem: DistributionItem | undefined;
+  receiveCurrencyIds?: ReceiveCurrencyIds;
   source?: string;
   isRefreshing: boolean;
   onRefresh: () => void;
@@ -36,6 +38,7 @@ type Props = Readonly<{
 export function AssetDetailView({
   currency,
   distributionItem,
+  receiveCurrencyIds,
   source,
   isRefreshing,
   onRefresh,
@@ -82,7 +85,7 @@ export function AssetDetailView({
         </Box>
       </ScrollView>
       <Footer currency={currency} />
-      <TransferDrawer currency={currency} />
+      <TransferDrawer currency={currency} currencyIds={receiveCurrencyIds} />
       <AssetCoinOptionsSheetView
         isOpen={coinOptions.isCoinOptionsSheetOpen}
         onClose={coinOptions.closeCoinOptions}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/useBalanceGraphViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/useBalanceGraphViewModel.test.ts
@@ -1,7 +1,7 @@
 import { renderHook, act } from "@tests/test-renderer";
 import { useBalanceGraphViewModel } from "../useBalanceGraphViewModel";
 import { track } from "~/analytics";
-import { useGetCurrencyDataQuery } from "@ledgerhq/live-common/market/state-manager/marketApi";
+import { useAssetMarketData } from "../../../hooks/useAssetMarketData";
 import { useOpenReceiveDrawer } from "LLM/features/Receive";
 import {
   mockBtcCryptoCurrency,
@@ -53,13 +53,38 @@ function withEthAndEursToken({
   };
 }
 
-jest.mock("@ledgerhq/live-common/market/state-manager/marketApi", () => ({
-  ...jest.requireActual("@ledgerhq/live-common/market/state-manager/marketApi"),
-  useGetCurrencyDataQuery: jest.fn(),
-}));
+jest.mock("../../../hooks/useAssetMarketData");
 jest.mock("LLM/features/Receive");
+jest.mock("@ledgerhq/live-currency-format", () => ({
+  formatPriceFragment: (_unit: unknown, value: number) => {
+    const [integerPart, decimalPart] = value
+      .toLocaleString("en-US", {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 6,
+      })
+      .split(".");
 
-const mockUseGetCurrencyDataQuery = jest.mocked(useGetCurrencyDataQuery);
+    return {
+      integerPart,
+      decimalPart,
+      decimalSeparator: ".",
+      currencyText: "$",
+    };
+  },
+  formatSignedFiatVariation: (amount: number) => {
+    if (amount !== 0 && Math.abs(amount) < 0.000001) {
+      return `${amount > 0 ? "+" : "-"}<$0.000001`;
+    }
+
+    const sign = amount > 0 ? "+" : amount < 0 ? "-" : "";
+    return `${sign}$${Math.abs(amount).toLocaleString("en-US", {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 6,
+    })}`;
+  },
+}));
+
+const mockUseAssetMarketData = jest.mocked(useAssetMarketData);
 const mockUseOpenReceiveDrawer = jest.mocked(useOpenReceiveDrawer);
 const mockHandleOpenReceiveDrawer = jest.fn();
 
@@ -88,10 +113,13 @@ function withAccounts(accounts: Array<{ currencyId: string; balance: number }>) 
 describe("useBalanceGraphViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseGetCurrencyDataQuery.mockReturnValue({
-      data: marketCurrencyData,
-      isFetching: false,
-    } as unknown as ReturnType<typeof useGetCurrencyDataQuery>);
+    mockUseAssetMarketData.mockReturnValue({
+      marketCurrency: marketCurrencyData,
+      marketId: "bitcoin",
+      counterCurrency: "usd",
+      isLoading: false,
+      isError: false,
+    });
     mockUseOpenReceiveDrawer.mockReturnValue({
       handleOpenReceiveDrawer: mockHandleOpenReceiveDrawer,
     });
@@ -106,10 +134,13 @@ describe("useBalanceGraphViewModel", () => {
     });
 
     it("returns price=0 and hasMarketData=false when no market data", () => {
-      mockUseGetCurrencyDataQuery.mockReturnValue({
-        data: undefined,
-        isFetching: false,
-      } as unknown as ReturnType<typeof useGetCurrencyDataQuery>);
+      mockUseAssetMarketData.mockReturnValue({
+        marketCurrency: undefined,
+        marketId: undefined,
+        counterCurrency: "usd",
+        isLoading: false,
+        isError: false,
+      });
 
       const { result } = renderHook(() => useBalanceGraphViewModel(mockBtcCryptoCurrency));
 
@@ -168,10 +199,13 @@ describe("useBalanceGraphViewModel", () => {
     });
 
     it("returns undefined when no market data", () => {
-      mockUseGetCurrencyDataQuery.mockReturnValue({
-        data: undefined,
-        isFetching: false,
-      } as unknown as ReturnType<typeof useGetCurrencyDataQuery>);
+      mockUseAssetMarketData.mockReturnValue({
+        marketCurrency: undefined,
+        marketId: undefined,
+        counterCurrency: "usd",
+        isLoading: false,
+        isError: false,
+      });
 
       const { result } = renderHook(() => useBalanceGraphViewModel(mockBtcCryptoCurrency));
 
@@ -179,10 +213,13 @@ describe("useBalanceGraphViewModel", () => {
     });
 
     it("renders a signed '<' threshold marker for a tiny BONK-like variation", () => {
-      mockUseGetCurrencyDataQuery.mockReturnValue({
-        data: { ...marketCurrencyData, price: 6e-6 },
-        isFetching: false,
-      } as unknown as ReturnType<typeof useGetCurrencyDataQuery>);
+      mockUseAssetMarketData.mockReturnValue({
+        marketCurrency: { ...marketCurrencyData, price: 6e-6 },
+        marketId: "bitcoin",
+        counterCurrency: "usd",
+        isLoading: false,
+        isError: false,
+      });
 
       const { result } = renderHook(() => useBalanceGraphViewModel(mockBtcCryptoCurrency));
 
@@ -282,6 +319,15 @@ describe("useBalanceGraphViewModel", () => {
   });
 
   describe("onReceivePress", () => {
+    it("configures direct receive drawer without asset-scoped currency ids", () => {
+      renderHook(() => useBalanceGraphViewModel(mockBtcCryptoCurrency));
+
+      expect(mockUseOpenReceiveDrawer).toHaveBeenCalledWith({
+        currency: mockBtcCryptoCurrency,
+        sourceScreenName: "Asset Detail",
+      });
+    });
+
     it("tracks analytics and opens the receive drawer", () => {
       const { result } = renderHook(() => useBalanceGraphViewModel(mockBtcCryptoCurrency));
 
@@ -307,10 +353,13 @@ describe("useBalanceGraphViewModel", () => {
 
   describe("isLoading", () => {
     it("reflects the fetching state of useCurrencyData", () => {
-      mockUseGetCurrencyDataQuery.mockReturnValue({
-        data: undefined,
-        isFetching: true,
-      } as unknown as ReturnType<typeof useGetCurrencyDataQuery>);
+      mockUseAssetMarketData.mockReturnValue({
+        marketCurrency: undefined,
+        marketId: undefined,
+        counterCurrency: "usd",
+        isLoading: true,
+        isError: false,
+      });
 
       const { result } = renderHook(() => useBalanceGraphViewModel(mockBtcCryptoCurrency));
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/__tests__/useFooterViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/__tests__/useFooterViewModel.test.ts
@@ -6,6 +6,9 @@ import { useFooterViewModel } from "../useFooterViewModel";
 const mockHandleOpenBuySell = jest.fn();
 const mockHandleOpenSwap = jest.fn();
 const mockHandleOpenReceiveDrawer = jest.fn();
+const mockUseOpenReceiveDrawer = jest.fn((_props: unknown) => ({
+  handleOpenReceiveDrawer: mockHandleOpenReceiveDrawer,
+}));
 const mockIsCurrencyAvailable = jest.fn();
 const mockIsAcceptedCurrency = jest.fn().mockReturnValue(true);
 
@@ -26,7 +29,7 @@ jest.mock("LLM/features/Swap", () => ({
 }));
 
 jest.mock("LLM/features/Receive", () => ({
-  useOpenReceiveDrawer: () => ({ handleOpenReceiveDrawer: mockHandleOpenReceiveDrawer }),
+  useOpenReceiveDrawer: (props: unknown) => mockUseOpenReceiveDrawer(props),
 }));
 
 const bitcoin = getCryptoCurrencyById("bitcoin");
@@ -60,6 +63,15 @@ describe("useFooterViewModel", () => {
   });
 
   describe("press handlers", () => {
+    it("configures direct receive flow without asset-scoped currency ids", () => {
+      renderHook(() => useFooterViewModel(bitcoin));
+
+      expect(mockUseOpenReceiveDrawer).toHaveBeenCalledWith({
+        currency: bitcoin,
+        sourceScreenName: "Asset Detail",
+      });
+    });
+
     it("onBuyPress fires tracking and opens buy flow", () => {
       mockIsCurrencyAvailable.mockReturnValue(true);
       const { result } = renderHook(() => useFooterViewModel(bitcoin));

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/index.tsx
@@ -3,7 +3,11 @@ import type { AssetDetailCurrencyProps } from "LLM/features/AssetDetail/types";
 import { useFooterViewModel } from "./useFooterViewModel";
 import { FooterView } from "./FooterView";
 
-export function Footer({ currency }: Readonly<{ currency: AssetDetailCurrencyProps }>) {
+type Props = Readonly<{
+  currency: AssetDetailCurrencyProps;
+}>;
+
+export function Footer({ currency }: Props) {
   const viewModel = useFooterViewModel(currency);
   return <FooterView {...viewModel} />;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/useAssetDetailReceiveCurrencyIds.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/useAssetDetailReceiveCurrencyIds.ts
@@ -1,0 +1,34 @@
+import { useMemo } from "react";
+import VersionNumber from "react-native-version-number";
+import { assetsDataApi } from "@ledgerhq/live-common/dada-client/state-manager/api";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import useEnv from "@ledgerhq/live-common/hooks/useEnv";
+import type { AssetDetailCurrencyProps } from "LLM/features/AssetDetail/types";
+import { getAssetDetailReceiveCurrencyIds } from "../utils/getAssetDetailReceiveCurrencyIds";
+
+export function useAssetDetailReceiveCurrencyIds(currency: AssetDetailCurrencyProps) {
+  const modularDrawerFeature = useFeature("llmModularDrawer");
+  const devMode = useEnv("MANAGER_DEV_MODE");
+
+  const isStaging = useMemo(
+    () => modularDrawerFeature?.params?.backendEnvironment === "STAGING",
+    [modularDrawerFeature?.params?.backendEnvironment],
+  );
+
+  const { data, isError, isSuccess } = assetsDataApi.useGetAssetDataQuery(
+    {
+      currencyIds: currency ? [currency.id] : [],
+      product: "llm",
+      version: VersionNumber.appVersion,
+      isStaging,
+      includeTestNetworks: devMode,
+    },
+    { skip: !currency },
+  );
+
+  return useMemo(() => {
+    if (!currency) return undefined;
+    if (data || isError || isSuccess) return getAssetDetailReceiveCurrencyIds(currency, data);
+    return [];
+  }, [currency, data, isError, isSuccess]);
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
@@ -11,6 +11,7 @@ import type { AssetDetailNavigatorParamsList } from "../../types";
 import { useIsBuyAvailable, useSecondaryButtonType } from "./components/Footer/useFooterViewModel";
 import { useAssetCoinOptionsViewModel } from "./components/CoinOptions/useAssetCoinOptionsViewModel";
 import { useAssetMarketData } from "./hooks/useAssetMarketData";
+import { useAssetDetailReceiveCurrencyIds } from "./hooks/useAssetDetailReceiveCurrencyIds";
 
 type Route = StackNavigatorProps<AssetDetailNavigatorParamsList, ScreenName.AssetDetail>["route"];
 
@@ -42,10 +43,12 @@ export function useAssetDetailViewModel() {
   const showFallbackBanner = !hasFooter && walletHasFunds && !!currency;
   const { marketId } = useAssetMarketData(currency);
   const coinOptions = useAssetCoinOptionsViewModel({ currency, currencyId, marketId });
+  const receiveCurrencyIds = useAssetDetailReceiveCurrencyIds(currency);
 
   return {
     currency,
     distributionItem,
+    receiveCurrencyIds,
     source,
     isRefreshing,
     onRefresh,

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/utils/__tests__/getAssetDetailReceiveCurrencyIds.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/utils/__tests__/getAssetDetailReceiveCurrencyIds.test.ts
@@ -1,0 +1,117 @@
+import {
+  mockBtcCryptoCurrency,
+  usdcToken,
+} from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
+import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { getAssetDetailReceiveCurrencyIds } from "../getAssetDetailReceiveCurrencyIds";
+
+type AssetDetailReceiveAssetData = NonNullable<
+  Parameters<typeof getAssetDetailReceiveCurrencyIds>[1]
+>;
+
+const polygonUsdcToken: TokenCurrency = {
+  ...usdcToken,
+  id: "polygon/erc20/usd_coin",
+};
+
+function assetData(
+  cryptoAssets: AssetDetailReceiveAssetData["cryptoAssets"],
+): AssetDetailReceiveAssetData {
+  return {
+    cryptoAssets,
+  };
+}
+
+describe("getAssetDetailReceiveCurrencyIds", () => {
+  it("returns undefined when there is no asset currency", () => {
+    expect(getAssetDetailReceiveCurrencyIds(undefined, undefined)).toBeUndefined();
+  });
+
+  it("falls back to the current currency id when DADA has no asset data", () => {
+    expect(getAssetDetailReceiveCurrencyIds(mockBtcCryptoCurrency, undefined)).toEqual([
+      mockBtcCryptoCurrency.id,
+    ]);
+  });
+
+  it("returns the single currency id for a single-network asset", () => {
+    expect(
+      getAssetDetailReceiveCurrencyIds(
+        mockBtcCryptoCurrency,
+        assetData({
+          bitcoin: {
+            id: "bitcoin",
+            ticker: "BTC",
+            name: "Bitcoin",
+            assetsIds: {
+              bitcoin: "bitcoin",
+            },
+          },
+        }),
+      ),
+    ).toEqual(["bitcoin"]);
+  });
+
+  it("returns all DADA asset ids for a multi-network token", () => {
+    expect(
+      getAssetDetailReceiveCurrencyIds(
+        usdcToken,
+        assetData({
+          "urn:crypto:meta-currency:usd_coin": {
+            id: "urn:crypto:meta-currency:usd_coin",
+            ticker: "USDC",
+            name: "USD Coin",
+            assetsIds: {
+              ethereum: usdcToken.id,
+              polygon: polygonUsdcToken.id,
+            },
+          },
+        }),
+      ),
+    ).toEqual([usdcToken.id, polygonUsdcToken.id]);
+  });
+
+  it("selects the DADA asset whose assetsIds contain the current currency id", () => {
+    expect(
+      getAssetDetailReceiveCurrencyIds(
+        usdcToken,
+        assetData({
+          bitcoin: {
+            id: "bitcoin",
+            ticker: "BTC",
+            name: "Bitcoin",
+            assetsIds: {
+              bitcoin: "bitcoin",
+            },
+          },
+          "urn:crypto:meta-currency:usd_coin": {
+            id: "urn:crypto:meta-currency:usd_coin",
+            ticker: "USDC",
+            name: "USD Coin",
+            assetsIds: {
+              ethereum: usdcToken.id,
+              polygon: polygonUsdcToken.id,
+            },
+          },
+        }),
+      ),
+    ).toEqual([usdcToken.id, polygonUsdcToken.id]);
+  });
+
+  it("falls back to the first DADA asset when the current id is absent", () => {
+    expect(
+      getAssetDetailReceiveCurrencyIds(
+        usdcToken,
+        assetData({
+          "urn:crypto:meta-currency:usd_coin": {
+            id: "urn:crypto:meta-currency:usd_coin",
+            ticker: "USDC",
+            name: "USD Coin",
+            assetsIds: {
+              polygon: polygonUsdcToken.id,
+            },
+          },
+        }),
+      ),
+    ).toEqual([polygonUsdcToken.id]);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/utils/getAssetDetailReceiveCurrencyIds.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/utils/getAssetDetailReceiveCurrencyIds.ts
@@ -1,0 +1,22 @@
+import type { AssetsDataWithPagination } from "@ledgerhq/live-common/dada-client/state-manager/types";
+import type { AssetDetailCurrencyProps } from "LLM/features/AssetDetail/types";
+import type { ReceiveCurrencyIds } from "LLM/features/Receive/types";
+
+type AssetDetailReceiveAssetData = Pick<AssetsDataWithPagination, "cryptoAssets">;
+
+export function getAssetDetailReceiveCurrencyIds(
+  currency: AssetDetailCurrencyProps,
+  assetData: AssetDetailReceiveAssetData | undefined,
+): ReceiveCurrencyIds | undefined {
+  if (!currency) return undefined;
+
+  const cryptoAssets = assetData ? Object.values(assetData.cryptoAssets) : [];
+  const matchingAsset =
+    cryptoAssets.find(
+      asset => asset.id === currency.id || Object.values(asset.assetsIds).includes(currency.id),
+    ) ?? cryptoAssets[0];
+
+  const ids = matchingAsset ? Object.values(matchingAsset.assetsIds).filter(Boolean) : [];
+
+  return Array.from(new Set(ids.length > 0 ? ids : [currency.id]));
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/__tests__/useModularDrawerState.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/__tests__/useModularDrawerState.test.ts
@@ -191,6 +191,38 @@ describe("useModularDrawerState", () => {
     expect(store.getState().modularDrawer.step).toBe(ModularDrawerStep.Account);
   });
 
+  it("should auto-select the only filtered asset and show Network when multiple networks exist", () => {
+    const { result, store } = renderHook(
+      () =>
+        useModularDrawerState({
+          currencyIds: [
+            mockEthCryptoCurrency.id,
+            mockArbitrumCryptoCurrency.id,
+            mockBaseCryptoCurrency.id,
+          ],
+          assetsSorted: [assetsSorted[0]],
+          isDrawerOpen: true,
+          onAccountSelected: mockOnAccountSelected,
+        }),
+      {
+        overrideInitialState: (state: State) => ({
+          ...state,
+          modularDrawer: {
+            ...state.modularDrawer,
+            enableAccountSelection: true,
+          },
+        }),
+      },
+    );
+
+    expect(store.getState().modularDrawer.step).toBe(ModularDrawerStep.Network);
+    expect(result.current.availableNetworks).toEqual([
+      mockEthCryptoCurrency,
+      mockArbitrumCryptoCurrency,
+      mockBaseCryptoCurrency,
+    ]);
+  });
+
   it("should navigate to device when there is exactly one network (no account selection)", () => {
     const singleAsset: AssetData[] = [
       {

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/__integrations__/TransferDrawer.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/__integrations__/TransferDrawer.integration.test.tsx
@@ -1,4 +1,5 @@
 import { renderHook } from "@tests/test-renderer";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { useTransferDrawerViewModel } from "../useTransferDrawerViewModel";
 import { NavigatorName, ScreenName } from "~/const";
 import { track } from "~/analytics";
@@ -8,6 +9,9 @@ import type { Account } from "@ledgerhq/types-live";
 
 const mockNavigate = jest.fn();
 const mockHandleOpenReceiveDrawer = jest.fn();
+const mockUseOpenReceiveDrawer = jest.fn((_props: unknown) => ({
+  handleOpenReceiveDrawer: mockHandleOpenReceiveDrawer,
+}));
 
 jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
   useAccountBridge: jest.fn(),
@@ -23,7 +27,7 @@ jest.mock("@react-navigation/native", () => ({
 }));
 
 jest.mock("LLM/features/Receive", () => ({
-  useOpenReceiveDrawer: () => ({ handleOpenReceiveDrawer: mockHandleOpenReceiveDrawer }),
+  useOpenReceiveDrawer: (props: unknown) => mockUseOpenReceiveDrawer(props),
 }));
 
 jest.mock("LLM/features/Noah/useNoahEntryPoint", () => ({
@@ -31,6 +35,8 @@ jest.mock("LLM/features/Noah/useNoahEntryPoint", () => ({
 }));
 
 const SOURCE_SCREEN = "Portfolio";
+const bitcoinCurrency = getCryptoCurrencyById("bitcoin");
+const assetScopedCurrencyIds = [bitcoinCurrency.id];
 
 const overrideWithOpenDrawer = (state: State): State => {
   const base = overrideStateWithFunds(state);
@@ -43,20 +49,20 @@ const overrideWithOpenDrawer = (state: State): State => {
   };
 };
 
+const findAction = (
+  result: { current: ReturnType<typeof useTransferDrawerViewModel> },
+  id: string,
+) => result.current.actions.find(a => a.id === id)!;
+
 describe("TransferDrawer Navigation", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  const renderViewModel = () =>
-    renderHook(() => useTransferDrawerViewModel(), {
+  const renderViewModel = (params?: Parameters<typeof useTransferDrawerViewModel>[0]) =>
+    renderHook(() => useTransferDrawerViewModel(params), {
       overrideInitialState: overrideWithOpenDrawer,
     });
-
-  const findAction = (
-    result: { current: ReturnType<typeof useTransferDrawerViewModel> },
-    id: string,
-  ) => result.current.actions.find(a => a.id === id)!;
 
   it("send navigates to SendFunds/SendCoin and tracks", () => {
     const { result } = renderViewModel();
@@ -100,6 +106,43 @@ describe("TransferDrawer Navigation", () => {
       button: "receive",
       buttonLocation: "quick_action_transfer",
       page: SOURCE_SCREEN,
+    });
+  });
+
+  it("configures receive without a preselected currency when opened outside Asset Detail", () => {
+    renderViewModel();
+
+    expect(mockUseOpenReceiveDrawer).toHaveBeenCalledWith({
+      currency: undefined,
+      currencyIds: undefined,
+      sourceScreenName: SOURCE_SCREEN,
+      fromMenu: true,
+    });
+  });
+
+  it("configures receive with the Asset Detail currency when provided", () => {
+    const { result } = renderViewModel({ currency: bitcoinCurrency });
+
+    expect(mockUseOpenReceiveDrawer).toHaveBeenCalledWith({
+      currency: bitcoinCurrency,
+      currencyIds: undefined,
+      sourceScreenName: SOURCE_SCREEN,
+      fromMenu: true,
+    });
+
+    findAction(result, "receive").onPress();
+
+    expect(mockHandleOpenReceiveDrawer).toHaveBeenCalledTimes(1);
+  });
+
+  it("configures receive with asset-scoped currency ids when provided", () => {
+    renderViewModel({ currency: bitcoinCurrency, currencyIds: assetScopedCurrencyIds });
+
+    expect(mockUseOpenReceiveDrawer).toHaveBeenCalledWith({
+      currency: bitcoinCurrency,
+      currencyIds: assetScopedCurrencyIds,
+      sourceScreenName: SOURCE_SCREEN,
+      fromMenu: true,
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/index.tsx
@@ -6,9 +6,11 @@ import QueuedDrawerGorhom from "LLM/components/QueuedDrawer/temp/QueuedDrawerGor
 import { TransferDrawerView } from "./TransferDrawerView";
 import { TransferDrawerViewLegacy } from "./TransferDrawerViewLegacy";
 import { useTransferDrawerViewModel } from "./useTransferDrawerViewModel";
+import type { ReceiveCurrencyIds } from "LLM/features/Receive/types";
 
 type Props = Readonly<{
   currency?: CryptoOrTokenCurrency;
+  currencyIds?: ReceiveCurrencyIds;
 }>;
 
 /**
@@ -19,9 +21,10 @@ type Props = Readonly<{
  * - Send crypto: Navigates to send flow
  * - Bank transfer: Navigates to buy flow for stablecoin purchases
  */
-export const TransferDrawer = ({ currency }: Props = {}) => {
+export const TransferDrawer = ({ currency, currencyIds }: Props = {}) => {
   const { isOpen, title, actions, handleClose, bottomInset } = useTransferDrawerViewModel({
     currency,
+    currencyIds,
   });
   const { isEnabled } = useWalletFeaturesConfig("mobile");
 

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/useTransferDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/useTransferDrawerViewModel.ts
@@ -14,6 +14,7 @@ import { resolveRemoteCopy } from "@ledgerhq/live-common/featureFlags/remoteABTe
 import { track } from "~/analytics";
 import { useTransferDrawerController } from "../../hooks/useTransferDrawerController";
 import { useOpenReceiveDrawer } from "LLM/features/Receive";
+import type { ReceiveCurrencyIds } from "LLM/features/Receive/types";
 import { TransferAction } from "../../types";
 import { QUICK_ACTIONS_TEST_IDS } from "../../testIds";
 import { useTranslation } from "~/context/Locale";
@@ -33,10 +34,12 @@ interface TransferDrawerViewModel {
 
 interface UseTransferDrawerViewModelParams {
   currency?: CryptoOrTokenCurrency;
+  currencyIds?: ReceiveCurrencyIds;
 }
 
 export const useTransferDrawerViewModel = ({
   currency,
+  currencyIds,
 }: UseTransferDrawerViewModelParams = {}): TransferDrawerViewModel => {
   const { t } = useTranslation();
   const { bottom: bottomInset } = useSafeAreaInsets();
@@ -49,6 +52,8 @@ export const useTransferDrawerViewModel = ({
   const hasFunds = !useAreAccountsEmpty() && hasAnyAccounts;
 
   const { handleOpenReceiveDrawer } = useOpenReceiveDrawer({
+    currency,
+    currencyIds,
     sourceScreenName,
     fromMenu: true,
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/Receive/__tests__/useOpenReceiveDrawer.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Receive/__tests__/useOpenReceiveDrawer.test.tsx
@@ -12,6 +12,7 @@ const mockOpenReceiveOptionsDrawer = jest.fn();
 const mockNavigate = jest.fn();
 const mockShowNoahMenu = jest.fn(() => false);
 const mockSetOriginFlow = jest.fn();
+const customCurrencyIds = ["ethereum/erc20/usd__coin", "polygon/erc20/usd_coin"];
 
 jest.mock("~/analytics/originFlow", () => ({
   setOriginFlow: (...args: unknown[]) => mockSetOriginFlow(...args),
@@ -121,6 +122,25 @@ describe("useOpenReceiveDrawer", () => {
         onAccountSelected: expect.any(Function),
       });
     });
+
+    it("should prefer provided currency ids for asset-scoped filtering", () => {
+      const { result } = renderHook(() =>
+        useOpenReceiveDrawer(createTestProps({ currencyIds: customCurrencyIds })),
+      );
+
+      act(() => {
+        result.current.handleOpenReceiveDrawer();
+      });
+
+      expect(mockOpenDrawer).toHaveBeenCalledWith({
+        currencies: customCurrencyIds,
+        flow: "receive_flow",
+        source: "test_screen",
+        areCurrenciesFiltered: true,
+        enableAccountSelection: true,
+        onAccountSelected: expect.any(Function),
+      });
+    });
   });
 
   describe("when Noah menu is enabled", () => {
@@ -137,6 +157,7 @@ describe("useOpenReceiveDrawer", () => {
 
       expect(mockOpenReceiveOptionsDrawer).toHaveBeenCalledWith({
         currency: mockEthCryptoCurrency,
+        currencyIds: undefined,
         sourceScreenName: "test_screen",
         fromMenu: undefined,
       });
@@ -154,19 +175,46 @@ describe("useOpenReceiveDrawer", () => {
 
       expect(mockOpenReceiveOptionsDrawer).toHaveBeenCalledWith({
         currency: mockEthCryptoCurrency,
+        currencyIds: undefined,
         sourceScreenName: "test_screen",
         fromMenu: true,
       });
     });
 
-    it("should bypass Noah menu when blockNoahMenu parameter is true", () => {
-      const { result } = renderHook(() => useOpenReceiveDrawer(createTestProps()));
+    it("should keep provided currency ids when opening the receive options drawer", () => {
+      const { result } = renderHook(() =>
+        useOpenReceiveDrawer(createTestProps({ currencyIds: customCurrencyIds })),
+      );
+
+      act(() => {
+        result.current.handleOpenReceiveDrawer();
+      });
+
+      expect(mockOpenReceiveOptionsDrawer).toHaveBeenCalledWith({
+        currency: mockEthCryptoCurrency,
+        currencyIds: customCurrencyIds,
+        sourceScreenName: "test_screen",
+        fromMenu: undefined,
+      });
+    });
+
+    it("should bypass Noah menu and preserve currency ids when blockNoahMenu parameter is true", () => {
+      const { result } = renderHook(() =>
+        useOpenReceiveDrawer(createTestProps({ currencyIds: customCurrencyIds })),
+      );
 
       act(() => {
         result.current.handleOpenReceiveDrawer(true);
       });
 
-      expect(mockOpenDrawer).toHaveBeenCalled();
+      expect(mockOpenDrawer).toHaveBeenCalledWith({
+        currencies: customCurrencyIds,
+        flow: "receive_flow",
+        source: "test_screen",
+        areCurrenciesFiltered: true,
+        enableAccountSelection: true,
+        onAccountSelected: expect.any(Function),
+      });
       expect(mockOpenReceiveOptionsDrawer).not.toHaveBeenCalled();
     });
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/Receive/drawers/__tests__/useReceiveFundsOptionsViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Receive/drawers/__tests__/useReceiveFundsOptionsViewModel.test.ts
@@ -1,0 +1,88 @@
+import { renderHook, act } from "@tests/test-renderer";
+import { mockEthCryptoCurrency } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
+import { track } from "~/analytics";
+import { useOpenReceiveDrawer } from "LLM/features/Receive";
+import { useReceiveOptionsDrawerController } from "../../useReceiveOptionsDrawerController";
+import useReceiveFundsOptionsViewModel from "../useReceiveFundsOptionsViewModel";
+
+const mockNavigate = jest.fn();
+const mockCloseDrawer = jest.fn();
+const mockHandleOpenReceiveDrawer = jest.fn();
+const receiveCurrencyIds = ["ethereum/erc20/usd__coin", "polygon/erc20/usd_coin"];
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+jest.mock("@ledgerhq/live-common/featureFlags/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/featureFlags/index"),
+  useWalletFeaturesConfig: () => ({ isEnabled: true }),
+}));
+
+jest.mock("LLM/features/Receive", () => ({
+  useOpenReceiveDrawer: jest.fn(() => ({
+    handleOpenReceiveDrawer: mockHandleOpenReceiveDrawer,
+  })),
+}));
+
+jest.mock("../../useReceiveOptionsDrawerController", () => ({
+  useReceiveOptionsDrawerController: jest.fn(() => ({
+    currency: mockEthCryptoCurrency,
+    currencyIds: receiveCurrencyIds,
+    sourceScreenName: "Asset Detail",
+    fromMenu: true,
+    isOpen: true,
+    closeDrawer: mockCloseDrawer,
+  })),
+}));
+
+const mockUseOpenReceiveDrawer = jest.mocked(useOpenReceiveDrawer);
+const mockUseReceiveOptionsDrawerController = jest.mocked(useReceiveOptionsDrawerController);
+
+describe("useReceiveFundsOptionsViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should keep asset-scoped currency ids when opening crypto address receive", () => {
+    const { result } = renderHook(() => useReceiveFundsOptionsViewModel());
+
+    expect(mockUseOpenReceiveDrawer).toHaveBeenCalledWith({
+      currency: mockEthCryptoCurrency,
+      currencyIds: receiveCurrencyIds,
+      sourceScreenName: "Asset Detail",
+      fromMenu: true,
+    });
+
+    act(() => result.current.handleGoToCrypto());
+
+    expect(track).toHaveBeenCalledWith("button_clicked", {
+      button: "crypto",
+      page: "Asset Detail",
+    });
+    expect(mockCloseDrawer).toHaveBeenCalledTimes(1);
+    expect(mockHandleOpenReceiveDrawer).toHaveBeenCalledWith(true);
+  });
+
+  it("should omit currency when the options drawer state has no crypto currency", () => {
+    mockUseReceiveOptionsDrawerController.mockReturnValue({
+      currency: undefined,
+      currencyIds: receiveCurrencyIds,
+      sourceScreenName: "Portfolio",
+      fromMenu: true,
+      isOpen: true,
+      closeDrawer: mockCloseDrawer,
+      openDrawer: jest.fn(),
+    });
+
+    renderHook(() => useReceiveFundsOptionsViewModel());
+
+    expect(mockUseOpenReceiveDrawer).toHaveBeenCalledWith({
+      currency: undefined,
+      currencyIds: receiveCurrencyIds,
+      sourceScreenName: "Portfolio",
+      fromMenu: true,
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Receive/drawers/useReceiveFundsOptionsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Receive/drawers/useReceiveFundsOptionsViewModel.ts
@@ -16,11 +16,12 @@ function useReceiveFundsOptionsViewModel() {
   const navigation = useNavigation();
   const { isEnabled } = useWalletFeaturesConfig("mobile");
 
-  const { currency, sourceScreenName, fromMenu, isOpen, closeDrawer } =
+  const { currency, currencyIds, sourceScreenName, fromMenu, isOpen, closeDrawer } =
     useReceiveOptionsDrawerController();
 
   const { handleOpenReceiveDrawer } = useOpenReceiveDrawer({
     currency: isCryptoOrTokenCurrency(currency) ? currency : undefined,
+    currencyIds,
     sourceScreenName,
     fromMenu,
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/Receive/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Receive/index.ts
@@ -10,9 +10,11 @@ import { setOriginFlow } from "~/analytics/originFlow";
 import { HOOKS_TRACKING_LOCATIONS } from "~/analytics/hooks/variables";
 import { useReceiveNoahEntry } from "../Noah/useNoahEntryPoint";
 import { useReceiveOptionsDrawerController } from "./useReceiveOptionsDrawerController";
+import type { ReceiveCurrencyIds } from "./types";
 
 type Props = {
   currency?: CryptoOrTokenCurrency;
+  currencyIds?: ReceiveCurrencyIds;
   sourceScreenName: string;
   navigationOverride?: RootNavigation;
   hideBackButton?: boolean;
@@ -20,6 +22,7 @@ type Props = {
 };
 export function useOpenReceiveDrawer({
   currency,
+  currencyIds,
   sourceScreenName,
   navigationOverride,
   hideBackButton,
@@ -74,15 +77,18 @@ export function useOpenReceiveDrawer({
       if (showNoahMenu && !fromReceiveOptionsDrawer) {
         openReceiveOptionsDrawer({
           currency: currency,
+          currencyIds: currencyIds,
           sourceScreenName: sourceScreenName,
           fromMenu: fromMenu,
         });
       } else {
+        const preselectedCurrencies = currencyIds ?? (currency ? [currency.id] : []);
+
         return openDrawer({
-          currencies: currency ? [currency.id] : [],
+          currencies: preselectedCurrencies,
           flow: "receive_flow",
           source: sourceScreenName,
-          areCurrenciesFiltered: !!currency,
+          areCurrenciesFiltered: preselectedCurrencies.length > 0,
           enableAccountSelection: true,
           onAccountSelected: openReceiveConfirmation,
         });
@@ -90,6 +96,7 @@ export function useOpenReceiveDrawer({
     },
     [
       currency,
+      currencyIds,
       openDrawer,
       sourceScreenName,
       openReceiveConfirmation,

--- a/apps/ledger-live-mobile/src/mvvm/features/Receive/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Receive/types.ts
@@ -1,0 +1,4 @@
+import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+
+export type ReceiveCurrencyId = CryptoOrTokenCurrency["id"];
+export type ReceiveCurrencyIds = ReceiveCurrencyId[];

--- a/apps/ledger-live-mobile/src/mvvm/features/Receive/useReceiveOptionsDrawerController.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Receive/useReceiveOptionsDrawerController.ts
@@ -6,6 +6,7 @@ import {
   receiveOptionsDrawerStateSelector,
 } from "~/reducers/receiveOptionsDrawer";
 import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type { ReceiveCurrencyIds } from "./types";
 /**
  * Hook to manage the global state of the Receive Options Drawer.
  *
@@ -16,19 +17,21 @@ import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 export const useReceiveOptionsDrawerController = () => {
   const dispatch = useDispatch();
 
-  const { isOpen, currency, sourceScreenName, fromMenu } = useSelector(
+  const { isOpen, currency, currencyIds, sourceScreenName, fromMenu } = useSelector(
     receiveOptionsDrawerStateSelector,
   );
 
   const openDrawer = useCallback(
     (params?: {
       currency?: CryptoOrTokenCurrency;
+      currencyIds?: ReceiveCurrencyIds;
       sourceScreenName: string;
       fromMenu?: boolean;
     }) => {
       dispatch(
         openReceiveOptionsDrawer({
           currency: params?.currency,
+          currencyIds: params?.currencyIds,
           sourceScreenName: params?.sourceScreenName ?? "",
           fromMenu: params?.fromMenu,
         }),
@@ -44,6 +47,7 @@ export const useReceiveOptionsDrawerController = () => {
   return {
     isOpen,
     currency,
+    currencyIds,
     sourceScreenName,
     fromMenu,
     openDrawer,

--- a/apps/ledger-live-mobile/src/reducers/receiveOptionsDrawer.ts
+++ b/apps/ledger-live-mobile/src/reducers/receiveOptionsDrawer.ts
@@ -1,10 +1,12 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { State } from "~/reducers/types";
 import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type { ReceiveCurrencyIds } from "LLM/features/Receive/types";
 
 export interface ReceiveOptionsDrawerState {
   isOpen: boolean;
   currency?: CryptoOrTokenCurrency;
+  currencyIds?: ReceiveCurrencyIds;
   sourceScreenName: string;
   fromMenu?: boolean;
 }
@@ -12,6 +14,7 @@ export interface ReceiveOptionsDrawerState {
 export const INITIAL_STATE: ReceiveOptionsDrawerState = {
   isOpen: false,
   currency: undefined,
+  currencyIds: undefined,
   sourceScreenName: "",
   fromMenu: false,
 };
@@ -27,26 +30,23 @@ const receiveOptionsDrawerSlice = createSlice({
       state,
       action: PayloadAction<{
         currency?: CryptoOrTokenCurrency;
+        currencyIds?: ReceiveCurrencyIds;
         sourceScreenName: string;
         fromMenu?: boolean;
       }>,
     ) => {
       state.isOpen = true;
-      const { currency, sourceScreenName, fromMenu } = action.payload;
+      const { currency, currencyIds, sourceScreenName, fromMenu } = action.payload;
 
-      if (currency !== undefined) {
-        state.currency = currency;
-      }
-      if (sourceScreenName !== undefined) {
-        state.sourceScreenName = sourceScreenName;
-      }
-      if (fromMenu !== undefined) {
-        state.fromMenu = fromMenu;
-      }
+      state.currency = currency;
+      state.currencyIds = currencyIds;
+      state.sourceScreenName = sourceScreenName;
+      state.fromMenu = fromMenu ?? false;
     },
     closeReceiveOptionsDrawer: state => {
       state.isOpen = false;
       state.currency = undefined;
+      state.currencyIds = undefined;
       state.sourceScreenName = "";
       state.fromMenu = false;
     },


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - LWM Asset Detail Transfer drawer Receive flow
  - Receive asset preselection/filtering
  - Bank Transfer visibility in the Transfer drawer

### 📝 Description

In LWM Asset Detail, opening `Transfer` and then selecting `Receive` did not preselect the current asset. Users had to pick the asset again even though they started the Receive flow from that asset detail page.

This PR forwards the existing optional `currency` from the MVVM Transfer drawer into `useOpenReceiveDrawer`, reusing the Receive drawer's existing filtered-currency behavior. Portfolio and other Transfer drawer entry points still call the drawer without a currency, so their Receive flow remains unfiltered. Integration tests cover both contexts and keep the Bank Transfer visibility rules protected.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31240](https://ledgerhq.atlassian.net/browse/LIVE-31240)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31240]: https://ledgerhq.atlassian.net/browse/LIVE-31240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ