### PR TITLE
[LWDM] fix(speculos): repair e2e recorder pipeline (SSE events + node 22+ loader)

### DIFF
--- a/.changeset/speculos-recorder-infra.md
+++ b/.changeset/speculos-recorder-infra.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/live-dmk-speculos": patch
+"@ledgerhq/ledger-key-ring-protocol": patch
+---
+
+Repair the speculos e2e recording pipeline:
+
+- `live-dmk-speculos` now consumes the speculos `/events?stream=true` SSE feed and forwards events to `automationEvents`. The wiring had been silently dropped, so any scenario that drives on-device prompts (e.g. `pnpm lkrp e2e`) would stall waiting for button presses that never fired. The stream is opened lazily on first subscription and torn down when the last subscriber leaves, so APDU-only consumers (e.g. desktop e2e smoke tests) pay no socket cost. `automationEvents` is now an `Observable` rather than a `Subject` — existing `.subscribe()` / `.pipe()` consumers are unaffected.
+- `ledger-key-ring-protocol`'s e2e runner script switches its dynamic scenario loader from `await import()` to `createRequire` so Node 22+ resolves the `.ts` scenario files through the ts-node CJS hook instead of the native ESM resolver.

--- a/libs/ledger-key-ring-protocol/scripts/e2e.ts
+++ b/libs/ledger-key-ring-protocol/scripts/e2e.ts
@@ -1,9 +1,15 @@
 /* oxlint-disable eslint/no-console */
 import fsPromises from "fs/promises";
+import { createRequire } from "module";
 import { listen } from "@ledgerhq/logs";
 import { recordTestTrustchainSdk } from "../tests/test-helpers/recordTrustchainSdkTests";
 import path from "path";
 import expect from "expect";
+
+// Use CJS require so ts-node's CJS hook handles .ts scenario files.
+// Dynamic `import()` would go through Node's native ESM resolver, which
+// does not understand TypeScript paths (broken on Node 22+).
+const requireScenario = createRequire(__filename);
 
 // we force inject expect to allow us to have expect() code in the test-scenarios
 (global as any).expect = expect;
@@ -24,7 +30,7 @@ async function main() {
     if (file.endsWith(".ts") && !file.startsWith("_")) {
       const slug = file.slice(0, -3);
       const e2eFile = path.join(scenarioFolder, file);
-      const mod = await import(e2eFile);
+      const mod = requireScenario(e2eFile);
       const scenario = mod.scenario;
       const snapshotFile = path.join(mockFolder, slug + ".json");
       const snapshotFileExists = await exists(snapshotFile);

--- a/libs/live-dmk-speculos/src/transport/DeviceManagementKitTransportSpeculos.ts
+++ b/libs/live-dmk-speculos/src/transport/DeviceManagementKitTransportSpeculos.ts
@@ -1,13 +1,16 @@
 import Transport from "@ledgerhq/hw-transport";
 import { log } from "@ledgerhq/logs";
-import { Subject, firstValueFrom } from "rxjs";
+import { Observable, firstValueFrom, share } from "rxjs";
 import { filter, timeout as rxTimeout } from "rxjs/operators";
 import {
   DeviceManagementKitBuilder,
   DeviceManagementKit,
   type DiscoveredDevice,
 } from "@ledgerhq/device-management-kit";
-import { speculosTransportFactory } from "@ledgerhq/device-transport-kit-speculos";
+import {
+  HttpSpeculosDatasource,
+  speculosTransportFactory,
+} from "@ledgerhq/device-transport-kit-speculos";
 import { getEnv } from "@ledgerhq/live-env";
 import { ButtonKey, deviceControllerClientFactory } from "@ledgerhq/speculos-device-controller";
 import { withTransientHttpRetries } from "./speculosTransientHttpRetry";
@@ -51,14 +54,16 @@ export default class SpeculosHttpTransport extends Transport {
     [SpeculosButton.RIGHT]: "right",
     [SpeculosButton.LEFT]: "left",
   } as const;
-  private eventStream: ReadableStream<Uint8Array> | null = null;
   private buttonClient: ButtonsController | undefined;
 
   readonly dmk: DeviceManagementKit;
   sessionId: string;
 
-  // emits events coming from Speculos automation SSE stream.
-  automationEvents: Subject<Record<string, unknown>> = new Subject();
+  // Emits events from the Speculos automation SSE stream.
+  // Lazy: the SSE stream is opened on first subscription and torn down when
+  // the last subscriber leaves. Smoke e2e tests never subscribe, so they pay
+  // no socket cost; the LKRP recorder subscribes and gets prompt events.
+  readonly automationEvents: Observable<Record<string, unknown>>;
 
   constructor(options: SpeculosHttpTransportOpts, dmk: DeviceManagementKit, sessionId: string) {
     super();
@@ -66,6 +71,39 @@ export default class SpeculosHttpTransport extends Transport {
     this.baseUrl = SpeculosHttpTransport.resolveBaseFromEnv(options);
     this.dmk = dmk;
     this.sessionId = sessionId;
+    this.automationEvents = this.createAutomationEvents$();
+  }
+
+  private createAutomationEvents$(): Observable<Record<string, unknown>> {
+    return new Observable<Record<string, unknown>>(observer => {
+      const datasource = new HttpSpeculosDatasource(this.baseUrl);
+      let stream: ReadableStream<Uint8Array> | null = null;
+      let unsubscribed = false;
+
+      datasource
+        .openEventStream(
+          evt => observer.next(evt),
+          () => observer.complete(),
+        )
+        .then(s => {
+          if (unsubscribed) {
+            s.cancel?.().catch(() => {});
+          } else {
+            stream = s;
+          }
+        })
+        .catch(e => {
+          log("speculos-event", `SSE connection error: ${String(e)}`);
+          observer.error(e);
+        });
+
+      return () => {
+        unsubscribed = true;
+        if (stream && typeof stream.cancel === "function") {
+          stream.cancel().catch(() => {});
+        }
+      };
+    }).pipe(share({ resetOnRefCountZero: true }));
   }
 
   private static resolveBaseFromEnv(options: SpeculosHttpTransportOpts): string {
@@ -228,18 +266,6 @@ export default class SpeculosHttpTransport extends Transport {
   }
 
   async close() {
-    try {
-      const s = this.eventStream;
-      if (!s) return;
-      if (typeof s.cancel === "function") {
-        await s.cancel();
-      }
-    } catch {
-      // ignore cleanup errors
-    } finally {
-      this.eventStream = null;
-      this.buttonClient = undefined;
-      this.automationEvents.complete?.();
-    }
+    this.buttonClient = undefined;
   }
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Existing live-dmk-speculos jest suite still passes. End-to-end SSE wiring was verified against a real Speculos (Ledger Sync 1.0.1, NanoSP): no SSE socket is opened until first subscribe, then events flow after a button press.
- [x] **Impact of the changes:**
  - `@ledgerhq/live-dmk-speculos` consumers subscribing to `transport.automationEvents` receive on-device prompt events again. APDU exchange and button presses are unchanged.
  - The SSE stream is now opened **lazily** on first subscription and torn down when the last subscriber leaves, so smoke e2e tests that never read automation events pay no socket cost (root cause of the [Ethereum scan-accounts](https://github.com/LedgerHQ/ledger-live/actions/runs/26558941546/job/78256485383) / Bitcoin speculos-setup timeouts we were seeing on this PR).
  - `pnpm lkrp e2e` now resolves `.ts` scenario files via `createRequire` instead of `await import()`; identical behaviour on Node ≤ 21 and unblocks Node 22+.

> [!IMPORTANT]
> Public type change: `automationEvents` is now `Observable<Record<string, unknown>>` instead of `Subject<...>`. Existing `.subscribe()` / `.pipe()` consumers are unaffected; nothing in the repo calls `.next()` / `.complete()` externally.

```diff
- transport.automationEvents.subscribe(evt => ...) // still works
+ // no behavioural change for consumers — SSE just opens lazily on first subscribe
```

### 📝 Description

Two regressions silently broke the speculos e2e recording pipeline used by `@ledgerhq/ledger-key-ring-protocol`.

**1. `live-dmk-speculos` stopped forwarding speculos SSE events.**

`DeviceManagementKitTransportSpeculos.automationEvents` was declared, but the subscription to speculos `/events?stream=true` had been removed at some point. Scenarios relying on automation events (e.g. `pnpm lkrp e2e`, which auto-clicks Ledger Sync prompts on `"Login request"` etc.) silently stalled — recorder waiting for prompt events that never arrived, speculos waiting for button presses that never came.

Fix: expose `automationEvents` as a lazy `Observable` that opens the speculos SSE stream on first subscription (`share({ resetOnRefCountZero: true })`) and cancels the underlying `ReadableStream` on the last unsubscribe. Eager subscription on `open()` was rejected because it leaked an SSE socket per transport even when no consumer needed automation events — that is what was tripping up the desktop NanoSP smoke e2e job (Ethereum add-account + Bitcoin send-tx were timing out across retries).

**2. lkrp e2e runner broke on Node 22+.**

`libs/ledger-key-ring-protocol/scripts/e2e.ts` discovered scenarios via `await import(e2eFile)`. On Node 22+, dynamic `import()` of a `.ts` file is routed through Node's native ESM resolver which doesn't know about ts-node's TypeScript hook, so extensionless relative imports fail with `ERR_MODULE_NOT_FOUND`. Switched to `createRequire(__filename)` so ts-node's CJS resolver handles `.ts`.

### ❓ Context

- **JIRA or GitHub link**: Precursor to a non-regression test for the Ledger Sync × wallet-cli ring init trustchain ejection bug discussed in Slack (`live-securityproj-wallet_sync`, 2026-05-25). Follow-up PR #17817 adds the scenario on top.
- **ADR link (if any)**: n/a
