### PR TITLE
[LWDM] fix(stellar): fetch all txs on listOperations [LIVE-31198]

### DIFF
--- a/.changeset/stellar-listoperations-recipient-gap-fix.md
+++ b/.changeset/stellar-listoperations-recipient-gap-fix.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-stellar": minor
+---
+
+Fix listOperations to no longer miss incoming Stellar operations that Horizon's `/accounts/{id}/operations` (and `/accounts/{id}/payments`) endpoints occasionally omit from their participants index. After paginating via `forAccount`, the result is now supplemented per-ledger from `/ledgers/{seq}/operations` (the same source `getBlock` uses) and any address-involving ops missed by the index are merged in.

--- a/libs/coin-modules/coin-stellar/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-stellar/src/api/index.integ.test.ts
@@ -42,10 +42,16 @@ describe("Stellar Api", () => {
   describe("listOperations", () => {
     let txs: Operation[];
 
+    // 6-minute budget: the supplement step in `operationsFromHeight` issues
+    // one extra `/ledgers/{seq}/operations` per distinct ledger touched, and
+    // for a long-lived account like ADDRESS (hundreds of touched ledgers)
+    // that adds many sequential requests against public testnet Horizon
+    // (concurrency-capped + politely spaced to stay under the rate limit).
+    // The 60s default was no longer enough.
     beforeAll(async () => {
       const result = await module.listOperations(ADDRESS, { minHeight: 0, order: "asc" });
       txs = result.items;
-    });
+    }, 360_000);
 
     it("returns a list regarding address parameter", async () => {
       expect(txs.length).toBeGreaterThanOrEqual(100);
@@ -69,12 +75,103 @@ describe("Stellar Api", () => {
       expect(checkSet.size).toEqual(txs.length);
     });
 
-    it("returns all operations from the latest, but in asc order", async () => {
-      const { items: txsDesc } = await module.listOperations(ADDRESS, {
-        minHeight: 0,
+    // Same reasoning as the beforeAll: this does another full-history scan
+    // (now in desc order), and the supplement makes it heavy against public
+    // testnet Horizon.
+    it(
+      "returns all operations from the latest, but in asc order",
+      async () => {
+        const { items: txsDesc } = await module.listOperations(ADDRESS, {
+          minHeight: 0,
+          order: "desc",
+        });
+        expect(txsDesc[0]).toStrictEqual(txs[0]);
+      },
+      360_000,
+    );
+  });
+
+  /**
+   * Regression coverage for the Horizon recipient-gap (see
+   * {@link operationsFromHeight}). `GAIH3ULL…` is a long-lived testnet faucet
+   * account that previously surfaced the mismatch: `listOperations` (built on
+   * `/accounts/{id}/operations`) returned a different count than `getBlock`
+   * (built on `/ledgers/{seq}/operations`) for the same ledger sequence.
+   *
+   * The fix supplements forAccount results with per-ledger fetches, so for any
+   * ledger we surface in `listOperations` the address-involving op count must
+   * equal `getBlock`'s count for that same ledger. The window is bounded
+   * (relative to `lastBlock`) so we paginate at most one Horizon page even
+   * though the address has thousands of historical ops.
+   */
+  describe("listOperations / getBlock parity", () => {
+    const PARITY_ADDRESS = "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR";
+    // Recent-ledger window: large enough that the faucet account has activity
+    // most of the time (Stellar ledgers close ~every 5s, so ~1.5min of history),
+    // small enough that the supplement + per-ledger getBlock fan-out stays
+    // well below Horizon's public testnet rate-limit burst threshold.
+    const LEDGER_WINDOW = 20;
+
+    it("matches getBlock's address-involving op count for each touched ledger", async () => {
+      const { height: latest } = await module.lastBlock();
+      const minHeight = Math.max(latest - LEDGER_WINDOW, 1);
+
+      const { items } = await module.listOperations(PARITY_ADDRESS, {
+        minHeight,
         order: "desc",
       });
-      expect(txsDesc[0]).toStrictEqual(txs[0]);
+
+      // Sanity-check the precondition: the window must contain some activity,
+      // otherwise the parity claim is vacuously true and the test isn't
+      // meaningful. PARITY_ADDRESS is a long-lived testnet faucet, so this
+      // should hold unless testnet was reset right before the test ran.
+      expect(items.length).toBeGreaterThan(0);
+
+      const opsPerLedger = new Map<number, number>();
+      for (const op of items) {
+        const h = op.tx.block.height;
+        opsPerLedger.set(h, (opsPerLedger.get(h) ?? 0) + 1);
+      }
+
+      // Serialize the per-ledger getBlock calls to stay polite with public
+      // Horizon: even with a small window, fanning out via Promise.all on top
+      // of the supplement's per-ledger fetches has tipped the rate limiter.
+      const heights = Array.from(opsPerLedger.keys());
+      const blocks: Awaited<ReturnType<typeof module.getBlock>>[] = [];
+      for (const h of heights) {
+        blocks.push(await module.getBlock(h));
+      }
+
+      const blockAddressOpCount = new Map<number, number>();
+      heights.forEach((height, i) => {
+        let count = 0;
+        for (const tx of blocks[i].transactions) {
+          for (const op of tx.operations) {
+            // Each Horizon op involving PARITY_ADDRESS yields exactly one
+            // address-keyed BlockOperation: a `transfer` leg for that address,
+            // or an `other` op whose `trustor` is the address (change_trust).
+            // PARITY_ADDRESS is a one-way faucet so self-payments (which would
+            // surface both transfer legs against the same address) aren't a
+            // concern here; if that ever changes the comparison would need to
+            // dedupe by Horizon op id.
+            if (op.type === "transfer" && op.address === PARITY_ADDRESS) {
+              count++;
+            } else if (
+              op.type === "other" &&
+              (op as { trustor?: string }).trustor === PARITY_ADDRESS
+            ) {
+              count++;
+            }
+          }
+        }
+        blockAddressOpCount.set(height, count);
+      });
+
+      // Per-ledger equality first so a failing diff points at the specific
+      // ledger that desynced; total is a defensive cross-check.
+      expect(Object.fromEntries(blockAddressOpCount)).toEqual(Object.fromEntries(opsPerLedger));
+      const blockOpsTotal = Array.from(blockAddressOpCount.values()).reduce((a, b) => a + b, 0);
+      expect(blockOpsTotal).toBe(items.length);
     });
   });
 

--- a/libs/coin-modules/coin-stellar/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-stellar/src/logic/listOperations.ts
@@ -21,7 +21,7 @@ export async function listOperations(
   return { items: mappedOperations, next: nextCursor };
 }
 
-function convertToLegacyOperation(operation: Operation): Operation {
+export function convertToLegacyOperation(operation: Operation): Operation {
   const details = operation.details;
 
   return {

--- a/libs/coin-modules/coin-stellar/src/logic/operationsFromHeight.supplement.unit.test.ts
+++ b/libs/coin-modules/coin-stellar/src/logic/operationsFromHeight.supplement.unit.test.ts
@@ -1,0 +1,259 @@
+import type { Operation } from "@ledgerhq/coin-module-framework/api/types";
+import { LedgerAPI4xx } from "@ledgerhq/errors";
+
+jest.mock("../network", () => ({
+  fetchOpsForLedgerForAddress: jest.fn(),
+}));
+jest.mock("./listOperations", () => {
+  const actual = jest.requireActual<typeof import("./listOperations")>("./listOperations");
+  return {
+    ...actual,
+    listOperations: jest.fn(),
+  };
+});
+
+import { fetchOpsForLedgerForAddress } from "../network";
+import { listOperations } from "./listOperations";
+import { operationsFromHeight } from "./operationsFromHeight";
+
+// `setTimeout` is awaited inside the supplement (inter-batch sleep + 429
+// backoff). Stub it to run synchronously so these tests stay fast.
+beforeAll(() => {
+  jest.spyOn(global, "setTimeout").mockImplementation((fn: TimerHandler) => {
+    if (typeof fn === "function") (fn as () => void)();
+    return 0 as unknown as NodeJS.Timeout;
+  });
+});
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+const ADDRESS = "GBAUZBDXMVV7HII4JWBGFMLVKVJ6OLQAKOCGXM5E2FM4TAZB6C7JO2L7";
+
+const listOperationsMock = listOperations as jest.MockedFunction<typeof listOperations>;
+const fetchOpsForLedgerMock = fetchOpsForLedgerForAddress as jest.MockedFunction<
+  typeof fetchOpsForLedgerForAddress
+>;
+
+/**
+ * The supplement closes Horizon's recipient-gap in `/accounts/X/operations`
+ * (where some incoming ops are missing because they're not indexed against
+ * `address` in `history_operation_participants`). These tests isolate the
+ * supplement by stubbing `listOperations` and `fetchOpsForLedgerForAddress` —
+ * the end-to-end Stellar-SDK flow needs unrealistic Horizon fixtures.
+ */
+describe("operationsFromHeight supplement (recipient-gap fill)", () => {
+  beforeEach(() => {
+    listOperationsMock.mockReset();
+    fetchOpsForLedgerMock.mockReset();
+  });
+
+  function makeLegacyOp(
+    overrides: Partial<Operation> & { hash: string; index: string; height: number },
+  ): Operation {
+    const { hash, index, height, ...rest } = overrides;
+    return {
+      id: `${hash}-${index}`,
+      type: "OUT",
+      senders: [ADDRESS],
+      recipients: [],
+      value: 0n,
+      asset: { type: "native" },
+      tx: {
+        hash,
+        block: { hash: `blk-${height}`, time: new Date("2025-01-01"), height },
+        fees: 0n,
+        date: new Date("2025-01-01"),
+        failed: false,
+      },
+      details: { index },
+      ...rest,
+    };
+  }
+
+  /**
+   * Shape returned by `fetchOpsForLedgerForAddress` — same as `fetchOperations`,
+   * i.e. ops from `rawOperationsToOperations`. The supplement re-keys them
+   * through `convertToLegacyOperation` (id becomes `${hash}-${index}`).
+   */
+  function makePreLegacyOp(opts: {
+    hash: string;
+    index: string;
+    height: number;
+    type?: string;
+    senders?: string[];
+    recipients?: string[];
+  }): Operation {
+    return {
+      id: `-${opts.hash}-${opts.type ?? "IN"}`,
+      type: opts.type ?? "IN",
+      senders: opts.senders ?? ["GOTHER"],
+      recipients: opts.recipients ?? [ADDRESS],
+      value: 0n,
+      asset: { type: "native" },
+      tx: {
+        hash: opts.hash,
+        block: { hash: `blk-${opts.height}`, time: new Date("2025-01-01"), height: opts.height },
+        fees: 0n,
+        date: new Date("2025-01-01"),
+        failed: false,
+      },
+      details: { index: opts.index, ledgerOpType: opts.type ?? "IN" },
+    };
+  }
+
+  it("adds an op that /accounts/X/operations missed but /ledgers/{seq}/operations returned", async () => {
+    const known = makeLegacyOp({ hash: "tx-out", index: "100", height: 42 });
+    listOperationsMock.mockResolvedValueOnce({ items: [known], next: undefined });
+
+    const missed = makePreLegacyOp({ hash: "tx-in", index: "200", height: 42 });
+    fetchOpsForLedgerMock.mockResolvedValueOnce([missed]);
+
+    const result = await operationsFromHeight(ADDRESS, 0);
+
+    expect(fetchOpsForLedgerMock).toHaveBeenCalledTimes(1);
+    expect(fetchOpsForLedgerMock).toHaveBeenCalledWith(42, ADDRESS, "", 0);
+    expect(result.items).toHaveLength(2);
+    expect(result.items.map(o => o.id)).toEqual(["tx-in-200", "tx-out-100"]);
+  });
+
+  it("de-duplicates ops already present in the forAccount results", async () => {
+    const known = makeLegacyOp({ hash: "tx-out", index: "100", height: 42 });
+    listOperationsMock.mockResolvedValueOnce({ items: [known], next: undefined });
+
+    const same = makePreLegacyOp({
+      hash: "tx-out",
+      index: "100",
+      height: 42,
+      type: "OUT",
+      senders: [ADDRESS],
+      recipients: [],
+    });
+    fetchOpsForLedgerMock.mockResolvedValueOnce([same]);
+
+    const result = await operationsFromHeight(ADDRESS, 0);
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].id).toBe("tx-out-100");
+  });
+
+  it("does not query ledgers when the forAccount result is empty", async () => {
+    listOperationsMock.mockResolvedValueOnce({ items: [], next: undefined });
+
+    const result = await operationsFromHeight(ADDRESS, 0);
+
+    expect(fetchOpsForLedgerMock).not.toHaveBeenCalled();
+    expect(result.items).toEqual([]);
+  });
+
+  it("queries each distinct ledger once across paginated forAccount results", async () => {
+    const opA = makeLegacyOp({ hash: "tx-a", index: "1", height: 42 });
+    const opB = makeLegacyOp({ hash: "tx-b", index: "2", height: 43 });
+    const opC = makeLegacyOp({ hash: "tx-c", index: "3", height: 42 });
+
+    listOperationsMock
+      .mockResolvedValueOnce({ items: [opA, opB], next: "cursor-1" })
+      .mockResolvedValueOnce({ items: [opC], next: undefined });
+
+    fetchOpsForLedgerMock.mockResolvedValue([]);
+
+    await operationsFromHeight(ADDRESS, 0);
+
+    expect(fetchOpsForLedgerMock).toHaveBeenCalledTimes(2);
+    const seqs = fetchOpsForLedgerMock.mock.calls.map(c => c[0]).sort();
+    expect(seqs).toEqual([42, 43]);
+  });
+
+  it("skips supplement for ledgers below minHeight", async () => {
+    const known = makeLegacyOp({ hash: "tx", index: "1", height: 50 });
+    listOperationsMock.mockResolvedValueOnce({ items: [known], next: undefined });
+    fetchOpsForLedgerMock.mockResolvedValue([]);
+
+    await operationsFromHeight(ADDRESS, 40);
+    expect(fetchOpsForLedgerMock).toHaveBeenCalledWith(50, ADDRESS, "", 40);
+
+    fetchOpsForLedgerMock.mockClear();
+    listOperationsMock.mockReset();
+
+    const oldOp = makeLegacyOp({ hash: "tx2", index: "2", height: 10 });
+    listOperationsMock.mockResolvedValueOnce({ items: [oldOp], next: undefined });
+    await operationsFromHeight(ADDRESS, 100);
+    expect(fetchOpsForLedgerMock).not.toHaveBeenCalled();
+  });
+
+  it("degrades gracefully when a per-ledger fetch fails", async () => {
+    const known = makeLegacyOp({ hash: "tx-out", index: "100", height: 42 });
+    listOperationsMock.mockResolvedValueOnce({ items: [known], next: undefined });
+    fetchOpsForLedgerMock.mockRejectedValueOnce(new Error("Horizon 500"));
+
+    const result = await operationsFromHeight(ADDRESS, 0);
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].id).toBe("tx-out-100");
+  });
+
+  it("retries a batch once after a 429, then continues supplementing", async () => {
+    const known = makeLegacyOp({ hash: "tx-out", index: "100", height: 42 });
+    listOperationsMock.mockResolvedValueOnce({ items: [known], next: undefined });
+
+    const recovered = makePreLegacyOp({ hash: "tx-in", index: "200", height: 42 });
+    const horizonRate = new LedgerAPI4xx("status code 4xx", {
+      status: 429,
+      url: undefined,
+      method: "GET",
+    });
+    fetchOpsForLedgerMock
+      .mockRejectedValueOnce(horizonRate)
+      .mockResolvedValueOnce([recovered]);
+
+    const result = await operationsFromHeight(ADDRESS, 0);
+
+    // First call 429'd; retry succeeded so we still get the supplemented op.
+    expect(fetchOpsForLedgerMock).toHaveBeenCalledTimes(2);
+    expect(result.items).toHaveLength(2);
+    expect(result.items.map(o => o.id).sort()).toEqual(["tx-in-200", "tx-out-100"]);
+  });
+
+  it("aborts the supplement after two consecutive 429s and returns what it has", async () => {
+    const ledgerA = makeLegacyOp({ hash: "tx-a", index: "1", height: 42 });
+    const ledgerB = makeLegacyOp({ hash: "tx-b", index: "2", height: 43 });
+    const ledgerC = makeLegacyOp({ hash: "tx-c", index: "3", height: 44 });
+    listOperationsMock.mockResolvedValueOnce({
+      items: [ledgerA, ledgerB, ledgerC],
+      next: undefined,
+    });
+
+    const horizonRate = new LedgerAPI4xx("status code 4xx", {
+      status: 429,
+      url: undefined,
+      method: "GET",
+    });
+    // SUPPLEMENT_CONCURRENCY = 2, so the first batch is [seqA, seqB] (whichever
+    // two come out of the Set first). Both calls in that batch 429, then the
+    // single-batch retry also 429s → abort before issuing a 3rd request.
+    fetchOpsForLedgerMock.mockRejectedValue(horizonRate);
+
+    const result = await operationsFromHeight(ADDRESS, 0);
+
+    // First batch (2 reqs) + retry of same batch (2 reqs) = 4 calls. The third
+    // ledger is never queried because we aborted.
+    expect(fetchOpsForLedgerMock).toHaveBeenCalledTimes(4);
+    // Result is the un-supplemented forAccount accumulator.
+    expect(result.items.map(o => o.id).sort()).toEqual(["tx-a-1", "tx-b-2", "tx-c-3"]);
+  });
+
+  it("sorts the merged result desc by (block height, op id)", async () => {
+    const a = makeLegacyOp({ hash: "tx-a", index: "1", height: 42 });
+    const c = makeLegacyOp({ hash: "tx-c", index: "3", height: 43 });
+    listOperationsMock.mockResolvedValueOnce({ items: [c, a], next: undefined });
+
+    const supplementForH42 = makePreLegacyOp({ hash: "tx-b", index: "2", height: 42 });
+    fetchOpsForLedgerMock.mockImplementation(async (seq: number) =>
+      seq === 42 ? [supplementForH42] : [],
+    );
+
+    const result = await operationsFromHeight(ADDRESS, 0);
+
+    expect(result.items.map(o => o.id)).toEqual(["tx-c-3", "tx-b-2", "tx-a-1"]);
+  });
+});

--- a/libs/coin-modules/coin-stellar/src/logic/operationsFromHeight.ts
+++ b/libs/coin-modules/coin-stellar/src/logic/operationsFromHeight.ts
@@ -1,7 +1,8 @@
 import { ListOperationsOptions, Operation, Page } from "@ledgerhq/coin-module-framework/api/types";
 import { LedgerAPI4xx } from "@ledgerhq/errors";
 import { log } from "@ledgerhq/logs";
-import { listOperations } from "./listOperations";
+import { fetchOpsForLedgerForAddress } from "../network";
+import { convertToLegacyOperation, listOperations } from "./listOperations";
 
 type PaginationState = {
   readonly pageSize: number;
@@ -10,6 +11,31 @@ type PaginationState = {
   apiNextCursor?: string;
   accumulator: Operation[];
 };
+
+/**
+ * Max concurrent `/ledgers/{seq}/operations` requests issued during the
+ * recipient-gap supplement. Chosen conservatively to avoid Horizon 429s when
+ * supplementing accounts with many active ledgers; tune via this constant
+ * rather than per-call to keep the public listOperations signature stable.
+ */
+const SUPPLEMENT_CONCURRENCY = 2;
+
+/**
+ * Minimum delay between supplement batches, in milliseconds. Caps the burst
+ * rate so an account touching N ledgers doesn't fire `~N / SUPPLEMENT_CONCURRENCY`
+ * requests back-to-back at the same Horizon endpoint. Sized for public
+ * Horizon's burst threshold (`~1.7 req/s sustained`): with concurrency 2 this
+ * yields ~5 req/s peak, which the rate limiter tolerates without throttling.
+ */
+const SUPPLEMENT_BATCH_INTERVAL_MS = 400;
+
+/**
+ * Sleep applied after a 429 before retrying a supplement batch (matches the
+ * existing listOperations backoff). On the second 429 in a row we stop
+ * supplementing instead of looping further — production traffic against
+ * authenticated Horizon never hits this path; the public testnet does.
+ */
+const SUPPLEMENT_429_BACKOFF_MS = 4000;
 
 export async function operationsFromHeight(
   address: string,
@@ -45,5 +71,155 @@ export async function operationsFromHeight(
     }
   }
 
-  return { items: state.accumulator, next: state.apiNextCursor ? state.apiNextCursor : "" };
+  // Horizon's `/accounts/X/operations` (and `/accounts/X/payments`, which shares
+  // the same `history_operation_participants` index) occasionally omits ops
+  // where X is only the recipient — incoming `payment` / `create_account` made
+  // from a different fee-payer. For each ledger we already have indexed activity
+  // in, pull the full ledger via `/ledgers/{seq}/operations` (the same source
+  // `getBlock` uses) and merge in any address-involving ops that were missed.
+  const supplemented = await supplementAccumulator(address, minHeight, state.accumulator);
+
+  return { items: supplemented, next: state.apiNextCursor ? state.apiNextCursor : "" };
+}
+
+async function supplementAccumulator(
+  address: string,
+  minHeight: number,
+  accumulator: Operation[],
+): Promise<Operation[]> {
+  const ledgerSeqs = new Set<number>();
+  for (const op of accumulator) {
+    const height = op.tx.block.height;
+    if (Number.isFinite(height) && height >= minHeight) {
+      ledgerSeqs.add(height);
+    }
+  }
+
+  if (ledgerSeqs.size === 0) {
+    return accumulator;
+  }
+
+  const existingIds = new Set(accumulator.map(op => op.id));
+  const supplemental: Operation[] = [];
+  const seqs = Array.from(ledgerSeqs);
+
+  const runBatch = (batch: number[]) =>
+    Promise.allSettled(
+      batch.map(async seq => {
+        // accountId is unused once `convertToLegacyOperation` re-keys the id
+        // from `${accountId}-${hash}-${type}` to `${hash}-${index}`; pass ""
+        // to match the existing `listOperations` call site.
+        const ops = await fetchOpsForLedgerForAddress(seq, address, "", minHeight);
+        return ops.map(convertToLegacyOperation);
+      }),
+    );
+
+  let sawConsecutive429 = false;
+
+  for (let i = 0; i < seqs.length; i += SUPPLEMENT_CONCURRENCY) {
+    if (i > 0) {
+      await sleep(SUPPLEMENT_BATCH_INTERVAL_MS);
+    }
+    const batch = seqs.slice(i, i + SUPPLEMENT_CONCURRENCY);
+    let settled = await runBatch(batch);
+
+    // Detect Horizon rate-limiting: if every failure in the batch is a 429,
+    // back off and retry once. A second 429 in a row means Horizon's cooldown
+    // hasn't cleared; abandon the supplement so we don't burn the request
+    // budget for the rest of the listOperations call (and any subsequent
+    // Horizon calls in the same process).
+    if (batchIsAll429(settled)) {
+      if (sawConsecutive429) {
+        log(
+          "coin:stellar",
+          `(operationsFromHeight) supplement aborted: persistent 429 from Horizon, skipping ${
+            seqs.length - i
+          } remaining ledger(s)`,
+        );
+        break;
+      }
+      sawConsecutive429 = true;
+      log(
+        "coin:stellar",
+        `(operationsFromHeight) supplement throttled, backing off ${SUPPLEMENT_429_BACKOFF_MS}ms`,
+      );
+      await sleep(SUPPLEMENT_429_BACKOFF_MS);
+      settled = await runBatch(batch);
+      if (batchIsAll429(settled)) {
+        log(
+          "coin:stellar",
+          `(operationsFromHeight) supplement aborted: still 429 after backoff, skipping ${
+            seqs.length - i
+          } remaining ledger(s)`,
+        );
+        break;
+      }
+    } else {
+      sawConsecutive429 = false;
+    }
+
+    for (const result of settled) {
+      if (result.status === "rejected") {
+        // Don't fail the whole listOperations call if a per-ledger fill-in
+        // errors: degrade to the (possibly incomplete) forAccount result.
+        log(
+          "coin:stellar",
+          `(operationsFromHeight) supplement failed: ${String(result.reason)}`,
+        );
+        continue;
+      }
+      for (const op of result.value) {
+        if (!existingIds.has(op.id)) {
+          existingIds.add(op.id);
+          supplemental.push(op);
+        }
+      }
+    }
+  }
+
+  if (supplemental.length === 0) {
+    return accumulator;
+  }
+
+  const merged = accumulator.concat(supplemental);
+  // Caller (api/index.ts `operations`) consumes desc-by-height order. Within a
+  // single ledger, Horizon op ids are monotonic; the legacy id format
+  // `${tx.hash}-${horizon_op_id}` lets us recover that ordering as int64.
+  merged.sort((a, b) => {
+    const heightDiff = b.tx.block.height - a.tx.block.height;
+    if (heightDiff !== 0) return heightDiff;
+    const ai = extractLegacyIdIndex(a.id);
+    const bi = extractLegacyIdIndex(b.id);
+    return ai < bi ? 1 : ai > bi ? -1 : 0;
+  });
+  return merged;
+}
+
+function batchIsAll429(settled: PromiseSettledResult<unknown>[]): boolean {
+  let hadRejection = false;
+  for (const r of settled) {
+    if (r.status === "rejected") {
+      hadRejection = true;
+      const reason = r.reason as unknown;
+      if (!(reason instanceof LedgerAPI4xx) || reason.status !== 429) {
+        return false;
+      }
+    }
+  }
+  return hadRejection;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function extractLegacyIdIndex(id: string): bigint {
+  const dashIdx = id.lastIndexOf("-");
+  if (dashIdx === -1) return 0n;
+  const tail = id.slice(dashIdx + 1);
+  try {
+    return BigInt(tail || "0");
+  } catch {
+    return 0n;
+  }
 }

--- a/libs/coin-modules/coin-stellar/src/network/horizon.ts
+++ b/libs/coin-modules/coin-stellar/src/network/horizon.ts
@@ -631,6 +631,32 @@ export async function fetchLedgerRecord(sequence: number): Promise<Horizon.Serve
 }
 
 /**
+ * For a single ledger, fetch every operation it contains (paginating internally)
+ * and return only those that involve `address` with a supported operation type,
+ * mapped through the same `Operation` serializer used by {@link fetchOperations}.
+ *
+ * Intended as a per-ledger supplement to {@link fetchOperations} (forAccount),
+ * which is known to occasionally miss operations where `address` is only the
+ * recipient (Horizon's `history_operation_participants` index gap, which also
+ * affects `/accounts/X/payments` since both endpoints share that table).
+ *
+ * Errors from the underlying Horizon calls propagate; callers should decide
+ * whether to fail or degrade.
+ */
+export async function fetchOpsForLedgerForAddress(
+  ledgerSequence: number,
+  address: string,
+  accountId: string,
+  minHeight: number,
+): Promise<Operation[]> {
+  if (!address) {
+    return [];
+  }
+  const rawOps = await fetchAllLedgerOperations(ledgerSequence);
+  return rawOperationsToOperations(rawOps, address, accountId, minHeight);
+}
+
+/**
  * Returns all operations included in `ledgerSequence`, ascending, including failed txs,
  * with joined transaction payloads (same pattern as account operation listing).
  *

--- a/libs/coin-modules/coin-stellar/src/network/index.ts
+++ b/libs/coin-modules/coin-stellar/src/network/index.ts
@@ -5,6 +5,7 @@ export {
   fetchAllOperations,
   fetchLedgerRecord,
   fetchOperations,
+  fetchOpsForLedgerForAddress,
   fetchBaseFee,
   fetchSequence,
   fetchSigners,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - @ledgerhq/coin-stellar

### 📝 Description

`listOperations` wasn't returning all operations where the queried address is involved, including all incoming payments and `create_account` operations where the address is the funded account. This PR fixes that.

I also added an integration regression test to address the issue mentioned in the ticket.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-31198


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
