### PR TITLE
[LWDM] fix(live-common): stabilize getAccountBridge rejection for React.use()

### DIFF
--- a/.changeset/bridge-account-rejection-cache.md
+++ b/.changeset/bridge-account-rejection-cache.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Make `getAccountBridge` return an identity-stable, annotated rejected Promise when `checkAccountSupported` fails so `React.use()` no longer loops on unsupported accounts. Export `clearBridgeCache(family?)` for callers that need to invalidate after toggling `setSupportedCurrencies` / experimental currencies. Family-level caches (`currencyBridge`, `accountBridge`, `mockBridge`) keep rejections cached too — eviction would hand React a fresh Promise per render and re-suspend forever; use `clearBridgeCache` to retry after a transient load failure.

--- a/libs/ledger-live-common/src/bridge/impl.eviction.test.ts
+++ b/libs/ledger-live-common/src/bridge/impl.eviction.test.ts
@@ -1,0 +1,95 @@
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { setSupportedCurrencies } from "../currencies";
+
+jest.mock("../coin-modules/registry", () => ({
+  ...jest.requireActual("../coin-modules/registry"),
+  loadSetupForFamily: jest.fn(),
+  loadMockBridgeForFamily: jest.fn(),
+  loadBridgeExtensionsForFamily: jest.fn(async () => ({})),
+}));
+
+import * as registry from "../coin-modules/registry";
+import { getCurrencyBridge, getAccountBridgeByFamily, clearBridgeCache } from "./impl";
+
+const mockedLoad = registry.loadSetupForFamily as jest.Mock;
+setSupportedCurrencies(["bitcoin", "ethereum"]);
+
+beforeEach(() => {
+  mockedLoad.mockReset();
+  clearBridgeCache();
+});
+
+describe("impl.ts — family cache behavior on rejection (no auto-eviction)", () => {
+  test("currencyBridgePromiseCache MEMOIZES rejection — React.use() would loop without identity stability", async () => {
+    const family = "bitcoin";
+    mockedLoad.mockImplementation(() => Promise.reject(new Error("chunk load failure")));
+
+    const p1 = getCurrencyBridge(getCryptoCurrencyById(family));
+    p1.catch(() => {});
+    await expect(p1).rejects.toThrow(/chunk load failure/);
+    const p2 = getCurrencyBridge(getCryptoCurrencyById(family));
+    p2.catch(() => {});
+    await expect(p2).rejects.toThrow(/chunk load failure/);
+
+    expect(p1).toBe(p2);
+    expect(mockedLoad).toHaveBeenCalledTimes(1);
+  });
+
+  test("accountBridgePromiseCache MEMOIZES rejection across calls (same family)", async () => {
+    const family = "ethereum";
+    mockedLoad.mockImplementation(() => Promise.reject(new Error("chunk load failure")));
+
+    const p1 = getAccountBridgeByFamily(family);
+    p1.catch(() => {});
+    await expect(p1).rejects.toThrow(/chunk load failure/);
+    const p2 = getAccountBridgeByFamily(family);
+    p2.catch(() => {});
+    await expect(p2).rejects.toThrow(/chunk load failure/);
+
+    expect(p1).toBe(p2);
+    expect(mockedLoad).toHaveBeenCalledTimes(1);
+  });
+
+  test("clearBridgeCache(family) allows callers to retry after a transient failure", async () => {
+    const family = "bitcoin";
+    mockedLoad
+      .mockImplementationOnce(() => Promise.reject(new Error("transient")))
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          bridge: {
+            currencyBridge: {},
+            accountBridge: {},
+          },
+        }),
+      );
+
+    const p1 = getCurrencyBridge(getCryptoCurrencyById(family));
+    p1.catch(() => {});
+    await expect(p1).rejects.toThrow(/transient/);
+
+    clearBridgeCache(family);
+
+    const p2 = getCurrencyBridge(getCryptoCurrencyById(family));
+    await expect(p2).resolves.toBeDefined();
+    expect(mockedLoad).toHaveBeenCalledTimes(2);
+  });
+
+  test("clearBridgeCache() with no argument clears every family", async () => {
+    mockedLoad.mockImplementation(() => Promise.reject(new Error("transient")));
+
+    const p1 = getCurrencyBridge(getCryptoCurrencyById("bitcoin"));
+    p1.catch(() => {});
+    await expect(p1).rejects.toThrow(/transient/);
+    const p2 = getAccountBridgeByFamily("ethereum");
+    p2.catch(() => {});
+    await expect(p2).rejects.toThrow(/transient/);
+
+    clearBridgeCache();
+
+    mockedLoad.mockImplementation(() =>
+      Promise.resolve({ bridge: { currencyBridge: {}, accountBridge: {} } }),
+    );
+    await expect(getCurrencyBridge(getCryptoCurrencyById("bitcoin"))).resolves.toBeDefined();
+    await expect(getAccountBridgeByFamily("ethereum")).resolves.toBeDefined();
+  });
+});

--- a/libs/ledger-live-common/src/bridge/impl.test.ts
+++ b/libs/ledger-live-common/src/bridge/impl.test.ts
@@ -1,10 +1,12 @@
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import { BigNumber } from "bignumber.js";
+import { AccountNotSupported, CurrencyNotSupported } from "@ledgerhq/errors";
 import { initialBitcoinResourcesValue } from "@ledgerhq/coin-bitcoin/types";
 import type { BitcoinAccount } from "@ledgerhq/coin-bitcoin/types";
+import type { DerivationMode } from "@ledgerhq/types-live";
 import { genAccount } from "../mock/account";
 import { setSupportedCurrencies } from "../currencies";
-import { getAccountBridge } from ".";
+import { getAccountBridge, clearBridgeCache } from ".";
 
 const BTC = getCryptoCurrencyById("bitcoin");
 const ETH = getCryptoCurrencyById("ethereum");
@@ -50,5 +52,66 @@ describe("wrapAccountBridge — extension routing", () => {
 
     const bridge = await getAccountBridge(account);
     expect(bridge.isAccountEmpty(account)).toBe(true);
+  });
+});
+
+describe("getAccountBridge — unsupported account rejection", () => {
+  function makeUnsupportedCurrencyAccount(id: string) {
+    const account = genAccount(id, { currency: BTC });
+    return { ...account, currency: getCryptoCurrencyById("tron") };
+  }
+
+  function makeUnsupportedDerivationAccount(id: string) {
+    const account = genAccount(id, { currency: BTC });
+    return { ...account, derivationMode: "not-a-real-derivation-mode" as unknown as DerivationMode };
+  }
+
+  test("rejected Promise is annotated with status='rejected' once the microtask runs", async () => {
+    const account = makeUnsupportedCurrencyAccount("annotation");
+    const p = getAccountBridge(account);
+    await p.catch(() => {});
+    expect((p as unknown as { status?: string }).status).toBe("rejected");
+    expect((p as unknown as { reason?: unknown }).reason).toBeInstanceOf(CurrencyNotSupported);
+  });
+
+  test("unsupported-derivation rejection is annotated the same way", async () => {
+    const account = makeUnsupportedDerivationAccount("annotation-derivation");
+    const p = getAccountBridge(account);
+    await p.catch(() => {});
+    expect((p as unknown as { status?: string }).status).toBe("rejected");
+    expect((p as unknown as { reason?: unknown }).reason).toBeInstanceOf(AccountNotSupported);
+  });
+
+  test("rejection identity is stable across calls (avoids React.use() loop)", async () => {
+    const account = makeUnsupportedCurrencyAccount("identity");
+    const p1 = getAccountBridge(account);
+    const p2 = getAccountBridge(account);
+    p1.catch(() => {});
+    expect(p1).toBe(p2);
+    await expect(p1).rejects.toBeInstanceOf(CurrencyNotSupported);
+  });
+
+  test("clearBridgeCache invalidates so a re-supported currency can resolve", async () => {
+    const account = makeUnsupportedCurrencyAccount("dynamic-resupport");
+    const p1 = getAccountBridge(account);
+    p1.catch(() => {});
+    await expect(p1).rejects.toBeInstanceOf(CurrencyNotSupported);
+
+    setSupportedCurrencies(["bitcoin", "ethereum", "tron"]);
+    clearBridgeCache();
+    try {
+      const p2 = getAccountBridge(account);
+      await expect(p2).resolves.toBeDefined();
+    } finally {
+      setSupportedCurrencies(["bitcoin", "ethereum"]);
+      clearBridgeCache();
+    }
+  });
+
+  test("success path identity is preserved (family cache regression guard)", () => {
+    const account = genAccount("supported-identity", { currency: BTC });
+    const p1 = getAccountBridge(account);
+    const p2 = getAccountBridge(account);
+    expect(p1).toBe(p2);
   });
 });

--- a/libs/ledger-live-common/src/bridge/impl.ts
+++ b/libs/ledger-live-common/src/bridge/impl.ts
@@ -26,20 +26,39 @@ import {
 } from "../coin-modules/registry";
 import { defaultBridgeExtensions } from "./defaultBridgeExtensions";
 
-// Promise cache per family — storing the Promise (not the value) means:
-//  1. Concurrent calls share the same in-flight Promise (no duplicate loading)
-//  2. Once settled, React's use() reads the annotated {status, value} and returns synchronously
+// Rejections stay cached: evicting would hand React.use() a fresh Promise per render and re-suspend forever.
+// Callers that want to retry a transient failure must invalidate via clearBridgeCache(family).
 const currencyBridgePromiseCache: Record<string, Promise<CurrencyBridge>> = {};
 const accountBridgePromiseCache: Record<string, Promise<ResolvedAccountBridge<any>>> = {};
 const mockBridgePromiseCache: Record<string, Promise<ResolvedAccountBridge<any>> | undefined> = {};
+// Keyed by currency.id|derivationMode. checkAccountSupported depends on mutable setSupportedCurrencies /
+// EXPERIMENTAL_CURRENCIES — callers that toggle these must invalidate via clearBridgeCache().
+const unsupportedBridgePromiseCache: Record<string, Promise<ResolvedAccountBridge<any>>> = {};
 
 // Annotate a Promise with React's use() hint fields so it returns synchronously after settlement.
-function settleAnnotate<T>(p: Promise<T>): Promise<T> {
+function annotatePromise<T>(p: Promise<T>): Promise<T> {
   p.then(
-    value => Object.assign(p, { status: "fulfilled", value }),
-    reason => Object.assign(p, { status: "rejected", reason }),
+    value => {
+      Object.assign(p, { status: "fulfilled", value });
+    },
+    reason => {
+      Object.assign(p, { status: "rejected", reason });
+    },
   );
   return p;
+}
+
+export function clearBridgeCache(family?: string): void {
+  if (family === undefined) {
+    for (const k of Object.keys(currencyBridgePromiseCache)) delete currencyBridgePromiseCache[k];
+    for (const k of Object.keys(accountBridgePromiseCache)) delete accountBridgePromiseCache[k];
+    for (const k of Object.keys(mockBridgePromiseCache)) delete mockBridgePromiseCache[k];
+    for (const k of Object.keys(unsupportedBridgePromiseCache)) delete unsupportedBridgePromiseCache[k];
+    return;
+  }
+  delete currencyBridgePromiseCache[family];
+  delete accountBridgePromiseCache[family];
+  delete mockBridgePromiseCache[family];
 }
 
 async function buildCurrencyBridge(currency: CryptoCurrency): Promise<CurrencyBridge> {
@@ -69,10 +88,11 @@ async function buildCurrencyBridge(currency: CryptoCurrency): Promise<CurrencyBr
 }
 
 export const getCurrencyBridge = (currency: CryptoCurrency): Promise<CurrencyBridge> => {
-  if (!currencyBridgePromiseCache[currency.family]) {
-    currencyBridgePromiseCache[currency.family] = settleAnnotate(buildCurrencyBridge(currency));
+  const family = currency.family;
+  if (!currencyBridgePromiseCache[family]) {
+    currencyBridgePromiseCache[family] = annotatePromise(buildCurrencyBridge(currency));
   }
-  return currencyBridgePromiseCache[currency.family];
+  return currencyBridgePromiseCache[family];
 };
 
 async function buildAccountBridgeForFamily(family: string): Promise<ResolvedAccountBridge<any>> {
@@ -91,13 +111,11 @@ async function buildAccountBridgeForFamily(family: string): Promise<ResolvedAcco
 
 function getCachedBridgePromise(family: string): Promise<ResolvedAccountBridge<any>> {
   if (!accountBridgePromiseCache[family]) {
-    accountBridgePromiseCache[family] = settleAnnotate(buildAccountBridgeForFamily(family));
+    accountBridgePromiseCache[family] = annotatePromise(buildAccountBridgeForFamily(family));
   }
   return accountBridgePromiseCache[family];
 }
 
-// Returns the same Promise reference per family after the first call.
-// For non-mock accounts this is the settled, annotated Promise — React's use() never suspends twice.
 export function getAccountBridgeByFamily(
   family: string,
   accountId?: string,
@@ -108,7 +126,7 @@ export function getAccountBridgeByFamily(
       if (!mockBridgePromiseCache[family]) {
         const mockP = loadMockBridgeForFamily(family);
         if (mockP) {
-          mockBridgePromiseCache[family] = settleAnnotate(
+          mockBridgePromiseCache[family] = annotatePromise(
             (async () => {
               const mockBridge = await mockP;
               if (mockBridge) {
@@ -130,7 +148,6 @@ export function getAccountBridgeByFamily(
   return getCachedBridgePromise(family);
 }
 
-// Returns the same settled Promise for the same family so React's use() never suspends twice.
 export function getAccountBridge(
   account: AccountLike,
   parentAccount?: Account | null,
@@ -140,7 +157,11 @@ export function getAccountBridge(
   const supportedError = checkAccountSupported(mainAccount);
 
   if (supportedError) {
-    return Promise.reject(supportedError);
+    const key = `${currency.id}|${mainAccount.derivationMode}`;
+    if (!unsupportedBridgePromiseCache[key]) {
+      unsupportedBridgePromiseCache[key] = annotatePromise(Promise.reject(supportedError));
+    }
+    return unsupportedBridgePromiseCache[key];
   }
 
   return getAccountBridgeByFamily(currency.family, mainAccount.id);

--- a/libs/ledger-live-common/src/bridge/index.ts
+++ b/libs/ledger-live-common/src/bridge/index.ts
@@ -1,6 +1,11 @@
 import type { ScanAccountEvent, ScanAccountEventRaw } from "@ledgerhq/types-live";
 import { fromAccountRaw, toAccountRaw } from "../account";
-export { getCurrencyBridge, getAccountBridge, getAccountBridgeByFamily } from "./impl";
+export {
+  getCurrencyBridge,
+  getAccountBridge,
+  getAccountBridgeByFamily,
+  clearBridgeCache,
+} from "./impl";
 
 export async function fromScanAccountEventRaw(raw: ScanAccountEventRaw): Promise<ScanAccountEvent> {
   switch (raw.type) {

--- a/libs/ledger-live-common/src/bridge/useAccountBridge.test.ts
+++ b/libs/ledger-live-common/src/bridge/useAccountBridge.test.ts
@@ -4,7 +4,8 @@
 import "../__tests__/test-helpers/dom-polyfill";
 import React from "react";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
-import { renderHook, act } from "@testing-library/react";
+import { CurrencyNotSupported } from "@ledgerhq/errors";
+import { render, renderHook, act, screen } from "@testing-library/react";
 import { genAccount } from "../mock/account";
 import { setSupportedCurrencies } from "../currencies";
 import { useAccountBridge, useAccountBridgeMany } from "./useAccountBridge";
@@ -49,6 +50,104 @@ describe("useAccountBridge", () => {
     expect(typeof result!.current.createTransaction).toBe("function");
     expect(typeof result!.current.updateTransaction).toBe("function");
     expect(typeof result!.current.prepareTransaction).toBe("function");
+  });
+});
+
+describe("useAccountBridge — unsupported account", () => {
+  function makeUnsupportedAccount(id: string) {
+    const account = genAccount(id, { currency: BTC });
+    return { ...account, currency: getCryptoCurrencyById("tron") };
+  }
+
+  class Boundary extends React.Component<
+    { children: React.ReactNode },
+    { error: Error | null }
+  > {
+    state = { error: null as Error | null };
+    static getDerivedStateFromError(error: Error) {
+      return { error };
+    }
+    render() {
+      if (this.state.error) {
+        return React.createElement("span", { "data-testid": "err" }, this.state.error.message);
+      }
+      return this.props.children;
+    }
+  }
+
+  // Hard cap surfaces the loop as a wrong error message rather than a Jest timeout.
+  function HookProbe({
+    account,
+    cap = 50,
+    counter,
+  }: {
+    account: ReturnType<typeof makeUnsupportedAccount>;
+    cap?: number;
+    counter: { n: number };
+  }) {
+    counter.n++;
+    if (counter.n > cap) {
+      throw new Error(`render loop detected (>${cap} renders)`);
+    }
+    useAccountBridge(account);
+    return null;
+  }
+
+  async function flush() {
+    for (let i = 0; i < 20; i++) {
+      await Promise.resolve();
+    }
+  }
+
+  test("does not enter a render loop on an unsupported account", async () => {
+    const counter = { n: 0 };
+    const account = makeUnsupportedAccount("loop-detect");
+    await act(async () => {
+      render(
+        React.createElement(
+          Boundary,
+          null,
+          React.createElement(
+            React.Suspense,
+            { fallback: null },
+            React.createElement(HookProbe, { account, counter }),
+          ),
+        ),
+      );
+      await flush();
+    });
+    expect(counter.n).toBeLessThan(50);
+    expect(screen.getByTestId("err").textContent).toMatch(/not supported/i);
+  });
+
+  test("error from useAccountBridge propagates to the ErrorBoundary with the right message", async () => {
+    const counter = { n: 0 };
+    const account = makeUnsupportedAccount("boundary-catch");
+    await act(async () => {
+      render(
+        React.createElement(
+          Boundary,
+          null,
+          React.createElement(
+            React.Suspense,
+            { fallback: React.createElement("span", { "data-testid": "fallback" }, "loading") },
+            React.createElement(HookProbe, { account, cap: 100, counter }),
+          ),
+        ),
+      );
+      await flush();
+    });
+    expect(screen.queryByTestId("err")?.textContent).toMatch(/not supported/i);
+    expect(screen.queryByTestId("fallback")).toBeNull();
+  });
+
+  test("rejection from getAccountBridge is identity-stable across direct calls", async () => {
+    const account = makeUnsupportedAccount("direct-identity");
+    const p1 = getAccountBridge(account);
+    const p2 = getAccountBridge(account);
+    p1.catch(() => {});
+    expect(p1).toBe(p2);
+    await expect(p1).rejects.toBeInstanceOf(CurrencyNotSupported);
   });
 });
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - `useAccountBridge` / `useAccountBridgeMany` / `useAccountBridgeOrNull` on an unsupported account: previously infinite suspend-loop, now throws once into the nearest `<ErrorBoundary>`. QA should verify any screen that renders an account bridge for legacy / experimental / unsupported accounts (Account screen, Send modal, Add-Accounts import, mobile wallet boot) reaches its boundary instead of looping.
  - New `clearBridgeCache(family?)` export — callers toggling `setSupportedCurrencies` or `EXPERIMENTAL_CURRENCIES` should call it to invalidate stale rejections.

### 📝 Description

Follow-up to the async coin-module migration. Two interacting issues:

1. `getAccountBridge` used to return `Promise.reject(supportedError)` directly when `checkAccountSupported` failed. The new Promise had no `status` annotation and no identity stability across renders, so `useAccountBridge` would suspend → microtask annotates → React retries → new Promise → suspend, indefinitely. Now we cache an `annotatePromise(Promise.reject(supportedError))` per `${currency.id}|${derivationMode}`; the second render reads `.status === 'rejected'` and throws into the nearest `<ErrorBoundary>`.

2. `currencyBridgePromiseCache` / `accountBridgePromiseCache` / `mockBridgePromiseCache` are not auto-evicted on rejection — eviction would recreate the same loop bug at the family-build layer for genuinely failing imports (chunk load / CDN blip / unregistered family). Callers that want to retry after a transient failure invalidate explicitly:

```diff
+import { clearBridgeCache } from "@ledgerhq/live-common/bridge";
+
 setSupportedCurrencies(ids);
+clearBridgeCache();
```

Renamed internal helper `settleAnnotate` → `annotatePromise` for clarity.

### ❓ Context

- **JIRA or GitHub link**: follow-up to the bridge async migration commits on the parent branch
- **ADR link (if any)**: n/a