### PR TITLE
fix(mobile): preselect asset in Asset Detail Receive

### DIFF
--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/__integrations__/TransferDrawer.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/__integrations__/TransferDrawer.integration.test.tsx
@@ -2,9 +2,13 @@ import { renderHook } from "@tests/test-renderer";
 import { useTransferDrawerViewModel } from "../useTransferDrawerViewModel";
 import { NavigatorName, ScreenName } from "~/const";
 import { track } from "~/analytics";
-import { overrideStateWithFunds } from "LLM/features/QuickActions/__integrations__/shared";
+import {
+  mockBitcoinCurrency,
+  overrideStateWithFunds,
+} from "LLM/features/QuickActions/__integrations__/shared";
 import { State } from "~/reducers/types";
 import type { Account } from "@ledgerhq/types-live";
+import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 
 const mockNavigate = jest.fn();
 const mockHandleOpenReceiveDrawer = jest.fn();
@@ -48,8 +52,8 @@ describe("TransferDrawer Navigation", () => {
     jest.clearAllMocks();
   });
 
-  const renderViewModel = () =>
-    renderHook(() => useTransferDrawerViewModel(), {
+  const renderViewModel = (currency?: CryptoOrTokenCurrency) =>
+    renderHook(() => useTransferDrawerViewModel(currency ? { currency } : undefined), {
       overrideInitialState: overrideWithOpenDrawer,
     });
 
@@ -65,6 +69,22 @@ describe("TransferDrawer Navigation", () => {
 
     expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.SendFunds, {
       screen: ScreenName.SendCoin,
+    });
+    expect(track).toHaveBeenCalledWith("button_clicked", {
+      button: "send",
+      buttonLocation: "quick_action_transfer",
+      page: SOURCE_SCREEN,
+    });
+  });
+
+  it("send navigates to SendFunds/SendCoin with selected currency when provided", () => {
+    const { result } = renderViewModel(mockBitcoinCurrency);
+
+    findAction(result, "send").onPress();
+
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.SendFunds, {
+      screen: ScreenName.SendCoin,
+      params: { selectedCurrency: mockBitcoinCurrency },
     });
     expect(track).toHaveBeenCalledWith("button_clicked", {
       button: "send",

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/useTransferDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/useTransferDrawerViewModel.ts
@@ -89,8 +89,9 @@ export const useTransferDrawerViewModel = ({
     closeDrawer();
     navigation.navigate(NavigatorName.SendFunds, {
       screen: ScreenName.SendCoin,
+      ...(currency ? { params: { selectedCurrency: currency } } : {}),
     });
-  }, [closeDrawer, navigation, sourceScreenName]);
+  }, [closeDrawer, currency, navigation, sourceScreenName]);
 
   const handleBankTransferPress = useCallback(() => {
     track("button_clicked", {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Integration tests cover both the Asset Detail flow and the existing Portfolio/bank transfer behavior.
- [x] **Impact of the changes:**
      - LWM Asset Detail Receive flow
      - Transfer drawer Receive preselection
      - Bank Transfer visibility remains unchanged

### 📝 Description

Asset Detail on mobile now forwards the selected asset into the Transfer drawer's Receive flow, so opening `Receive` from an asset detail screen preselects the current asset instead of forcing the user to choose it again.

The change is intentionally narrow: the Transfer drawer only passes a currency when it was already provided by the caller, so Portfolio and other entry points keep the current unfiltered Receive behavior. The existing Bank Transfer visibility logic is preserved.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31240](https://ledgerhq.atlassian.net/browse/LIVE-31240)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31240]: https://ledgerhq.atlassian.net/browse/LIVE-31240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ