### PR TITLE
[LWM] fix(mobile): apply nav-passed transaction on (re)mount

### DIFF
--- a/.changeset/fix-tezos-baker-change-nav-rehydrate.md
+++ b/.changeset/fix-tezos-baker-change-nav-rehydrate.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix Tezos (re-)delegation silently keeping the previous baker when the user changes it from the summary screen. `useTransactionChangeFromNavigation` now applies `route.params.transaction` on (re)mount instead of only on subsequent changes.

--- a/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
+++ b/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
@@ -124,7 +124,10 @@ const completeSignedTxBroadcast = ({
 export const useTransactionChangeFromNavigation = (setTransaction: (_: Transaction) => void) => {
   const route = useRoute<Route>();
   const navigationTransaction = route.params?.transaction;
-  const navigationTxRef = useRef(navigationTransaction);
+  // Start at `undefined` so the first time `navigationTransaction` is set we
+  // dispatch — including the case where the screen mounts (or remounts via
+  // Suspense / native-stack) with the value already in route.params.
+  const navigationTxRef = useRef<typeof navigationTransaction>(undefined);
   useEffect(() => {
     if (navigationTransaction && navigationTxRef.current !== navigationTransaction) {
       navigationTxRef.current = navigationTransaction;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached. <!-- mobile app only — no published package affected -->
- [x] **Covered by automatic tests.** https://github.com/LedgerHQ/ledger-live/actions/runs/26451705090
- [x] **Impact of the changes:**
  - Hardens `useTransactionChangeFromNavigation` so it dispatches the first non-empty `navigationTransaction` even when the screen mounts with it already in `route.params`.
  - Other consumers (Send / EVM EditTransaction / Bitcoin EditTransaction) are no-ops — they already seed `route.params.transaction` into the `useBridgeTransaction` init, so the extra dispatch hits the reducer's identity short-circuit (`if (state.transaction === action.transaction) return state`).
  - QA focus: Send / Edit-fees flows on Tezos, EVM, Bitcoin (multiple consecutive edits, cold + warm screens).

### 📝 Description

- manual end-to-end repro on the parent async-bridge branch ([chore/LIVE-29187](https://github.com/LedgerHQ/ledger-live/pull/17760)) verified the fix; no existing test covers this nav<->useBridgeTransaction edge.

Latent bug in `useTransactionChangeFromNavigation`:

``` diff
- const navigationTxRef = useRef(navigationTransaction);
+ const navigationTxRef = useRef<typeof navigationTransaction>(undefined);
```

The previous form initialized the tracking ref with the **current** `route.params.transaction`. If the screen mounted (or remounted) while `navigationTransaction` was already set, the `useEffect`'s `ref.current !== navigationTransaction` diff was false on the first run, so `setTransaction` was never called — silently dropping the value the previous screen tried to hand back. Starting the ref at `undefined` makes the first non-empty `navigationTransaction` always dispatch.

### Was develop ever affected?

In practice, no. The Tezos delegation summary is the only consumer whose `useBridgeTransaction` init does **not** also seed `transaction: route.params.transaction`, so it's the only flow that depends on this hook for the initial-mount case. On `develop` (sync bridges, no Suspense wrappers around flow screens), the navigation stack keeps the Summary instance mounted through Summary → SelectValidator → Summary, so the buggy code path is not hit and the user sees the new baker as expected.

The fix becomes user-visible on the async-bridge branch (`chore/LIVE-29187`), where each flow screen is wrapped in `<Suspense fallback={null}>` and the bridge resolves asynchronously: the combination raises the odds of the Summary subtree being remounted on its way back from SelectValidator, surfacing the bug as "baker change is silently ignored" and `delegate.unchanged` from Taquito.

Backporting to `develop` is defensive — it removes the latent bug ahead of the async-bridge merge and makes the hook's contract match its docstring (apply whatever `route.params.transaction` you find).

Cherry-pick of `fd5a9225ff` from `chore/LIVE-29187`.

### ❓ Context

- **JIRA or GitHub link**: anticipation of what's needed for [LIVE-29187](https://ledgerhq.atlassian.net/browse/LIVE-29187) — no dedicated ticket.
- **ADR link (if any)**: n/a.

[LIVE-29187]: https://ledgerhq.atlassian.net/browse/LIVE-29187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ