### PR TITLE
[LWDM] feat(coin-solana): add `getValidators`

### DIFF
--- a/.changeset/solana-get-validators-endpoint.md
+++ b/.changeset/solana-get-validators-endpoint.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-solana": minor
+"@ledgerhq/live-common": patch
+---
+
+feat(coin-solana): expose `getValidators` on the coin-module API

--- a/libs/coin-modules/coin-solana/src/api/index.ts
+++ b/libs/coin-modules/coin-solana/src/api/index.ts
@@ -23,6 +23,7 @@ import { estimateFees } from "../logic/estimateFees";
 import { getBalance } from "../logic/getBalance";
 import { getNextSequence } from "../logic/getNextSequence";
 import { getStakes } from "../logic/getStakes";
+import { getValidators } from "../logic/getValidators";
 import { lastBlock } from "../logic/lastBlock";
 import { listOperations } from "../logic/listOperations";
 import { validateAddress } from "../logic/validateAddress";
@@ -85,9 +86,7 @@ export function createApi(config: SolanaCoinConfig, currencyId: string): SolanaC
     getRewards: (_address: string, _cursor?: Cursor) => {
       throw new Error("getRewards is not supported");
     },
-    getValidators: () => {
-      throw new Error("getValidators is not supported");
-    },
+    getValidators: () => getValidators(config.validatorsUrl),
     getStakes: (address: string, cursor?: Cursor) => {
       return getStakes(api, address, cursor);
     },

--- a/libs/coin-modules/coin-solana/src/api/index.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/api/index.unit.test.ts
@@ -24,6 +24,7 @@ import { lastBlock } from "../logic/lastBlock";
 import { listOperations } from "../logic/listOperations";
 import { validateAddress } from "../logic/validateAddress";
 import { validateIntent } from "../logic/validateIntent";
+import { getValidators } from "../logic/getValidators";
 import { ChainAPI } from "../network";
 
 const mockChainAPI = {} as unknown as ChainAPI;
@@ -80,11 +81,16 @@ jest.mock("../logic/validateAddress", () => ({
   validateAddress: jest.fn(),
 }));
 
+jest.mock("../logic/getValidators", () => ({
+  getValidators: jest.fn(),
+}));
+
 describe("createApi", () => {
   const mockConfig: SolanaCoinConfig = {
     token2022Enabled: false,
     legacyOCMSMaxVersion: "1.0.0",
     status: { type: "active" },
+    validatorsUrl: "https://solana-validators.com",
   };
 
   afterEach(() => {
@@ -298,13 +304,44 @@ describe("createApi", () => {
     expect(result).toBe(true);
   });
 
+  it("should delegate getValidators to the logic function", async () => {
+    jest.mocked(getValidators).mockResolvedValueOnce({
+      items: [
+        {
+          address: "validator",
+          name: "validator",
+          balance: 10n,
+          commissionRate: "0",
+          apy: 0.05,
+        },
+      ],
+      next: undefined,
+    });
+
+    const api = createApi(mockConfig, "solana");
+    const result = await api.getValidators();
+
+    expect(getValidators).toHaveBeenCalledWith("https://solana-validators.com");
+    expect(result).toEqual({
+      items: [
+        {
+          address: "validator",
+          name: "validator",
+          balance: 10n,
+          commissionRate: "0",
+          apy: 0.05,
+        },
+      ],
+      next: undefined,
+    });
+  });
+
   it("should throw for unsupported methods", () => {
     const api = createApi(mockConfig, "solana");
 
     expect(() => api.getBlock(1)).toThrow("getBlock is not supported");
     expect(() => api.getBlockInfo(1)).toThrow("getBlockInfo is not supported");
     expect(() => api.getRewards("addr")).toThrow("getRewards is not supported");
-    expect(() => api.getValidators()).toThrow("getValidators is not supported");
   });
 
   describe("getBalance", () => {

--- a/libs/coin-modules/coin-solana/src/config.ts
+++ b/libs/coin-modules/coin-solana/src/config.ts
@@ -11,6 +11,7 @@ export type SolanaConfig = {
     solana_devnet?: string;
     solana_testnet?: string;
   };
+  validatorsUrl?: string;
 };
 
 export type SolanaCoinConfig = CurrencyConfig & SolanaConfig;

--- a/libs/coin-modules/coin-solana/src/logic/getValidators.ts
+++ b/libs/coin-modules/coin-solana/src/logic/getValidators.ts
@@ -1,0 +1,79 @@
+import type { Page, Validator } from "@ledgerhq/coin-module-framework/api/types";
+import { getEnv } from "@ledgerhq/live-env";
+import network from "@ledgerhq/live-network";
+
+type ValidatorRaw = {
+  active_stake?: number | null;
+  commission?: number | null;
+  total_score?: number | null;
+  vote_account?: string | null;
+  name?: string | null;
+  avatar_url?: string | null;
+  delinquent?: boolean | null;
+  www_url?: string | null;
+};
+
+type ValidatorApyRaw = {
+  address: string;
+  delegator_apy: number;
+  name: string;
+};
+
+export async function getValidators(validatorsUrl?: string): Promise<Page<Validator>> {
+  if (!validatorsUrl) return { items: [], next: undefined };
+
+  const [raw, apyMap] = await Promise.all([fetchValidators(validatorsUrl), fetchFigmentApy()]);
+  const items = raw.flatMap(v => {
+    const mapped = toValidator(v, apyMap);
+    return mapped ? [mapped] : [];
+  });
+
+  return { items, next: undefined };
+}
+
+async function fetchValidators(validatorsUrl: string): Promise<ValidatorRaw[]> {
+  const response = await network<ValidatorRaw[]>({ method: "GET", url: validatorsUrl });
+  return response.status === 200 ? response.data : [];
+}
+
+async function fetchFigmentApy(): Promise<Record<string, number>> {
+  try {
+    const response = await network<ValidatorApyRaw[]>({
+      method: "GET",
+      url: getEnv("SOLANA_VALIDATORS_SUMMARY_BASE_URL"),
+    });
+    if (response.status === 200 && Array.isArray(response.data)) {
+      return Object.fromEntries(
+        response.data
+          .filter(
+            item => typeof item.address === "string" && typeof item.delegator_apy === "number",
+          )
+          .map(item => [item.address, item.delegator_apy]),
+      );
+    }
+  } catch (error) {
+    console.warn("Failed to fetch Figment APY", error);
+  }
+  return {};
+}
+
+function toValidator(raw: ValidatorRaw, apyMap: Record<string, number>): Validator | undefined {
+  if (
+    typeof raw.active_stake !== "number" ||
+    typeof raw.commission !== "number" ||
+    typeof raw.total_score !== "number" ||
+    typeof raw.vote_account !== "string" ||
+    raw.delinquent === true
+  ) {
+    return undefined;
+  }
+  return {
+    address: raw.vote_account,
+    name: raw.name ?? raw.vote_account,
+    url: raw.www_url ?? undefined,
+    logo: raw.avatar_url ?? undefined,
+    balance: BigInt(raw.active_stake),
+    commissionRate: String(raw.commission),
+    apy: apyMap[raw.vote_account],
+  };
+}

--- a/libs/coin-modules/coin-solana/src/logic/tests/getValidators.integ.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/getValidators.integ.test.ts
@@ -1,0 +1,27 @@
+import { getValidators } from "../getValidators";
+
+describe("getValidators (integration)", () => {
+  it("returns a non-empty page of well-formed validators for mainnet-beta", async () => {
+    const page = await getValidators(
+      "https://validators-solana.coin.ledger.com/api/v1/validators/mainnet.json",
+    );
+
+    expect(page).toMatchObject({ next: undefined });
+    expect(page.items.length).toBeGreaterThan(100);
+
+    for (const validator of page.items) {
+      expect(typeof validator.address).toBe("string");
+      expect(validator.address.length).toBeGreaterThan(0);
+      expect(typeof validator.name).toBe("string");
+      expect(typeof validator.balance).toBe("bigint");
+      expect(validator.balance).toBeGreaterThanOrEqual(0n);
+      expect(typeof validator.commissionRate).toBe("string");
+      expect(["undefined", "number"]).toContain(typeof validator.apy);
+    }
+  });
+
+  it("returns an empty page when no validatorsUrl is provided", async () => {
+    const page = await getValidators();
+    expect(page).toStrictEqual({ items: [], next: undefined });
+  });
+});

--- a/libs/coin-modules/coin-solana/src/logic/tests/getValidators.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/getValidators.unit.test.ts
@@ -1,0 +1,142 @@
+import { getEnv } from "@ledgerhq/live-env";
+import * as network from "@ledgerhq/live-network";
+import { getValidators } from "../getValidators";
+
+jest.spyOn({ getEnv }, "getEnv").mockImplementation((key: string) => {
+  const urls: Record<string, string> = {
+    SOLANA_VALIDATORS_SUMMARY_BASE_URL:
+      "https://earn-dashboard.aws.stg.ldg-tech.com/figment/solana/validators_summary",
+  };
+  return urls[key] ?? "";
+});
+
+const VALIDATORS_URL = "https://validators-solana.coin.ledger.com/api/v1/validators/mainnet.json";
+
+describe("getValidators", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  it("returns the upstream list mapped to framework Validators with APY", async () => {
+    jest
+      .spyOn(network, "default")
+      .mockResolvedValueOnce({
+        status: 200,
+        data: [
+          {
+            vote_account: "VoteAccountB1111111111111111111111111111111",
+            name: "Validator B",
+            active_stake: 500_000_000,
+            commission: 100,
+            total_score: 1,
+            delinquent: false,
+          },
+          {
+            vote_account: "VoteAccountA1111111111111111111111111111111",
+            name: "Validator A",
+            avatar_url: "https://example.com/a.png",
+            www_url: "https://example.com/a",
+            active_stake: 1_000_000_000,
+            commission: 5,
+            total_score: 9,
+            delinquent: false,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        data: [
+          { address: "VoteAccountA1111111111111111111111111111111", delegator_apy: 0.07, name: "A" },
+        ],
+      });
+
+    const page = await getValidators(VALIDATORS_URL);
+
+    expect(page).toStrictEqual({
+      next: undefined,
+      items: [
+        {
+          address: "VoteAccountB1111111111111111111111111111111",
+          name: "Validator B",
+          url: undefined,
+          logo: undefined,
+          balance: BigInt(500_000_000),
+          commissionRate: "100",
+          apy: undefined,
+        },
+        {
+          address: "VoteAccountA1111111111111111111111111111111",
+          name: "Validator A",
+          url: "https://example.com/a",
+          logo: "https://example.com/a.png",
+          balance: BigInt(1_000_000_000),
+          commissionRate: "5",
+          apy: 0.07,
+        },
+      ],
+    });
+  });
+
+  it("falls back to the vote account when name is missing", async () => {
+    jest
+      .spyOn(network, "default")
+      .mockResolvedValueOnce({
+        status: 200,
+        data: [
+          {
+            vote_account: "Unnamed1111111111111111111111111111111111111",
+            active_stake: 2_000_000_000,
+            commission: 3,
+            total_score: 5,
+            delinquent: false,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ status: 200, data: [] });
+
+    const page = await getValidators(VALIDATORS_URL);
+
+    expect(page).toMatchObject({
+      items: [{ name: "Unnamed1111111111111111111111111111111111111" }],
+    });
+  });
+
+  it("drops delinquent and incomplete entries", async () => {
+    jest
+      .spyOn(network, "default")
+      .mockResolvedValueOnce({
+        status: 200,
+        data: [
+          {
+            vote_account: "Delinquent11111111111111111111111111111111111",
+            active_stake: 1,
+            commission: 9,
+            total_score: 1,
+            delinquent: true,
+          },
+          {
+            vote_account: "Incomplete11111111111111111111111111111111111",
+            active_stake: null,
+            commission: 5,
+            total_score: 5,
+            delinquent: false,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ status: 200, data: [] });
+
+    const page = await getValidators(VALIDATORS_URL);
+
+    expect(page).toStrictEqual({ items: [], next: undefined });
+  });
+
+  it("returns an empty page when no validatorsUrl is provided", async () => {
+    const networkSpy = jest.spyOn(network, "default");
+
+    const page = await getValidators();
+
+    expect(page).toStrictEqual({ items: [], next: undefined });
+    expect(networkSpy).not.toHaveBeenCalled();
+  });
+});

--- a/libs/ledger-live-common/src/families/solana/config.ts
+++ b/libs/ledger-live-common/src/families/solana/config.ts
@@ -14,6 +14,7 @@ export const solanaConfig: CurrencyLiveConfigDefinition = {
       },
       token2022Enabled: false,
       legacyOCMSMaxVersion: "1.8.0",
+      validatorsUrl: "https://validators-solana.coin.ledger.com/api/v1/validators/mainnet.json",
     } satisfies SolanaCoinConfig,
   },
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Alpaca `getValidators` for Solana. No impact on Ledger Wallet

### 📝 Description

Add method `getValidators` for Solana Alpaca API. It reaches the newly added `validatorsUrl` endpoint, as opposed to the legacy `SOLANA_VALIDATORS_APP_BASE_URL` env proxying the Earn backend.
The code is duplicated on purpose, avoiding overlaps to not break the existing.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-31222
- **ADR link (if any)**: https://ledgerhq.atlassian.net/wiki/spaces/CF/history/7071957123/Coin+modules+-+ADR-038+-+Earn+UI+migration


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
