### PR TITLE
[LWDM] fix(asset-aggregation): normalize cross-network amounts by magnitude

### DIFF
--- a/.changeset/wild-glasses-suffer.md
+++ b/.changeset/wild-glasses-suffer.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/asset-aggregation": patch
+---
+
+Fix cross-network amount aggregation when a meta-currency's network tokens have different magnitudes (e.g. USDT on Ethereum with magnitude 6 and on BSC with magnitude 18). Network balances are now normalized to the meta-currency's reference magnitude before being summed, preventing incorrect totals.

--- a/libs/asset-aggregation/src/assetDistribution/__tests__/buildAssetDistribution.test.ts
+++ b/libs/asset-aggregation/src/assetDistribution/__tests__/buildAssetDistribution.test.ts
@@ -20,13 +20,13 @@ jest.mock("@ledgerhq/live-countervalues/logic", () => ({
   calculate: jest.fn((_state, { value }: { value: number }) => value * 2),
 }));
 
-function makeCurrency(id: string, name = id): CryptoCurrency {
+function makeCurrency(id: string, name = id, magnitude = 8): CryptoCurrency {
   return {
     type: "CryptoCurrency",
     id,
     name,
     ticker: id.toUpperCase(),
-    units: [{ name: id, code: id.toUpperCase(), magnitude: 8 }],
+    units: [{ name: id, code: id.toUpperCase(), magnitude }],
   } as unknown as CryptoCurrency;
 }
 
@@ -224,6 +224,42 @@ describe("buildAssetDistribution", () => {
     );
 
     expect(result.list).toHaveLength(2);
+  });
+
+  it("should normalize cross-network amounts when tokens have different magnitudes", () => {
+    const ethUsdt = makeCurrency("ethereum/erc20/usd_tether__erc20_", "Tether USD", 6);
+    const bscUsdt = makeCurrency("bsc/bep20/binance-peg_bsc-usd", "Tether USD", 18);
+
+    mockFindCryptoCurrencyById.mockImplementation((id: string) => {
+      if (id === "tether") return ethUsdt;
+      return undefined;
+    });
+
+    const tetherAssetsData: AssetsDataLike = {
+      cryptoAssets: {
+        "urn:crypto:meta-currency:tether": {
+          id: "urn:crypto:meta-currency:tether",
+          assetsIds: {
+            ethereum: "ethereum/erc20/usd_tether__erc20_",
+            bsc: "bsc/bep20/binance-peg_bsc-usd",
+          },
+        },
+      },
+      markets: {},
+    };
+
+    const result = distribute(
+      [
+        makeAccount("eth-usdt-1", ethUsdt, 1_000_000),
+        makeAccount("bsc-usdt-1", bscUsdt, 1_000_000_000_000_000),
+      ],
+      undefined,
+      tetherAssetsData,
+    );
+
+    expect(result.list).toHaveLength(1);
+    expect(result.list[0].metaCurrencyId).toBe("urn:crypto:meta-currency:tether");
+    expect(result.list[0].amount).toBe(1_001_000);
   });
 
   describe("DADA id format normalization (LIVE-22557 / LIVE-22558)", () => {

--- a/libs/asset-aggregation/src/assetDistribution/buildAssetDistribution.ts
+++ b/libs/asset-aggregation/src/assetDistribution/buildAssetDistribution.ts
@@ -3,6 +3,7 @@ import type { Account, AccountLike } from "@ledgerhq/types-live";
 import type { CryptoCurrency, Currency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
 import { calculate } from "@ledgerhq/live-countervalues/logic";
+import BigNumber from "bignumber.js";
 import { toSlug } from "./toSlug";
 import type {
   AssetsDataLike,
@@ -52,6 +53,21 @@ function buildSlugIndex(list: DistributionItem[]): Record<string, DistributionIt
     if (item.slug) index[item.slug] = item;
   }
   return index;
+}
+
+function sumNetworkAmountsAtReferenceMagnitude(
+  networks: MetaGroup["networks"],
+  referenceMagnitude: number,
+): number {
+  return Array.from(networks.values())
+    .reduce((total, network) => {
+      const currentMagnitude = network.currency.units[0]?.magnitude ?? 0;
+      const normalizedAmount = new BigNumber(network.amount).shiftedBy(
+        referenceMagnitude - currentMagnitude,
+      );
+      return total.plus(normalizedAmount);
+    }, new BigNumber(0))
+    .toNumber();
 }
 
 const EMPTY_DISTRIBUTION: AssetsDistribution = Object.freeze({
@@ -106,7 +122,6 @@ export function buildAssetDistribution(
     }
 
     group.accounts.push(account);
-    group.amount += balance;
     group.marketId ??= assetsData.markets[apiId]?.id;
 
     let network = group.networks.get(currency.id);
@@ -132,6 +147,9 @@ export function buildAssetDistribution(
       if (primaryCurrency) group.currency = primaryCurrency;
       group.marketId ??= assetsData.markets[primaryAssetId]?.id;
     }
+
+    const referenceMagnitude = group.currency.units[0]?.magnitude ?? 0;
+    group.amount = sumNetworkAmountsAtReferenceMagnitude(group.networks, referenceMagnitude);
 
     let groupCountervalue = 0;
     for (const network of group.networks.values()) {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Portfolio totals for multi-network tokens (e.g. USDT on Ethereum + BSC, USDC across networks)

### 📝 Description

When a meta-currency aggregates network tokens that have different unit magnitudes — for instance USDT on Ethereum (magnitude `6`) and USDT on BSC (magnitude `18`) — the per-network balance integers cannot be summed as-is. Doing so produced wildly incorrect aggregated amounts because raw amounts at different magnitudes were added together.

This change normalizes each network amount to the meta-currency's reference magnitude (taken from `group.currency.units[0].magnitude`) before accumulating, using `BigNumber.shiftedBy()` for safe magnitude shifts. The summation now happens once per group after all networks have been collected, replacing the previous incremental `group.amount += balance` accumulation.

A new test case (`should normalize cross-network amounts when tokens have different magnitudes`) covers the USDT case across Ethereum (6) and BSC (18).


<img width="742" height="341" alt="image" src="https://github.com/user-attachments/assets/317e5f94-b394-42be-8e33-a7ecf7dc0a1d" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-31201](https://ledgerhq.atlassian.net/browse/LIVE-31201)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31201]: https://ledgerhq.atlassian.net/browse/LIVE-31201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ