### PR TITLE
[LWM] fix(lwm): unnest FlatList in SelectableAccountsList

### DIFF
--- a/.changeset/gorgeous-crabs-grin.md
+++ b/.changeset/gorgeous-crabs-grin.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix(lwm): unnest FlatList in SelectableAccountsList

--- a/apps/ledger-live-mobile/src/components/SelectableAccountsList.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectableAccountsList.tsx
@@ -4,7 +4,6 @@ import {
   View,
   TouchableOpacity,
   PanResponder,
-  FlatList,
   StyleProp,
   ViewStyle,
   LayoutChangeEvent,
@@ -113,34 +112,6 @@ const SelectableAccountsList = ({
 
   const areAllSelected = accounts.every(a => selectedIds.indexOf(a.id) > -1);
 
-  const renderSelectableAccount = useCallback(
-    ({ item, index }: { index: number; item: Account }) => (
-      <SelectableAccount
-        navigation={navigation}
-        showHint={!index && showHint}
-        rowIndex={index}
-        listIndex={listIndex}
-        account={item}
-        onAccountNameChange={onAccountNameChange}
-        isSelected={forceSelected || selectedIds.indexOf(item.id) > -1}
-        isDisabled={isDisabled}
-        onPress={onPressAccount}
-        useFullBalance={useFullBalance}
-      />
-    ),
-    [
-      navigation,
-      showHint,
-      listIndex,
-      selectedIds,
-      forceSelected,
-      isDisabled,
-      onAccountNameChange,
-      onPressAccount,
-      useFullBalance,
-    ],
-  );
-
   return (
     <Flex marginBottom={7} testID="selectable-accounts-list" {...props}>
       {header ? (
@@ -151,16 +122,27 @@ const SelectableAccountsList = ({
           onUnselectAll={onUnselectAllProp ? onUnselectAll : undefined}
         />
       ) : null}
-      <FlatList
-        data={accounts}
-        keyExtractor={(item, index) => item.id + index}
-        renderItem={renderSelectableAccount}
-        ListEmptyComponent={() => (
-          <Flex height="100%" flexDirection="row" justifyContent="center">
-            {emptyState || null}
-          </Flex>
-        )}
-      />
+      {accounts.length > 0 ? (
+        accounts.map((item, index) => (
+          <SelectableAccount
+            key={item.id + index}
+            navigation={navigation}
+            showHint={!index && showHint}
+            rowIndex={index}
+            listIndex={listIndex}
+            account={item}
+            onAccountNameChange={onAccountNameChange}
+            isSelected={forceSelected || selectedIds.indexOf(item.id) > -1}
+            isDisabled={isDisabled}
+            onPress={onPressAccount}
+            useFullBalance={useFullBalance}
+          />
+        ))
+      ) : (
+        <Flex height="100%" flexDirection="row" justifyContent="center">
+          {emptyState || null}
+        </Flex>
+      )}
     </Flex>
   );
 };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached. <!-- still to add -->
- [x] **Covered by automatic tests.** Existing `ScanDeviceAccounts` unit suites (8 tests across common coins, Hedera, Concordium) still pass. The visual regression itself is best caught by the existing Android E2E that already failed on this bug — please re-run the failing nightly to confirm green.
- [x] **Impact of the changes:**
  - Add Account flow on Android (primary): scan an asset that returns multiple accounts (e.g. Polygon, BTC multi-derivation) and stay on the "Select the accounts you want to add" screen for 10+ seconds — all rows must remain visible.
  - Receive flow's account-selection step (same screen, deeplinked from Receive).
  - Canton onboarding screen (uses the same `SelectableAccountsList` component; only ever 1 account but worth a smoke test).
  - Auto-selection of the importable section on scan completion, manual select/deselect of individual rows, and the per-section Select All / Deselect All toggle.
  - BTC creatable section's "More address types" expand/collapse pressable.
  - Swipe-to-edit-name interaction on a row.

### 📝 Description

Follow-up to LIVE-30528. The previous fix ([`a5061b56c38`](https://github.com/LedgerHQ/ledger-live/commit/a5061b56c38)) removed the percent-based height animation on each row, which solved the original layout-collapse symptom — but a separate root cause was still present, and the nightly E2E flagged the bug again on the same screen (count header shows "We found 3 accounts" but only 2 rows render, with the missing row's layout slot reserved but empty).

**Root cause.** `ScanDeviceAccounts` rendered each section's rows via a `FlatList` nested inside a `NavigationScrollView`. On Android this is a long-standing `VirtualizedList`-in-`ScrollView` anti-pattern: the inner FlatList never receives scroll events (the outer ScrollView owns scrolling), its clipping math drifts, and Android's `removeClippedSubviews` (which defaults to `true` for FlatList) detaches a row's native view while `VirtualizedList`'s CellRenderer keeps the layout slot. Likely surfaced (rather than introduced) by the RN 0.79.7 → 0.81.6 + React 18 → 19 upgrade in [`2531585d34e`](https://github.com/LedgerHQ/ledger-live/commit/2531585d34e) — the buggy nesting predates the upgrade by many months, but the bug was first reported four days after it landed.

**Fix.** Refactor the screen to use a single `SectionList` as the only scroll container.
- `ScanDeviceAccounts/index.tsx` is rewritten around `SectionList`: section headers and the "more address types" footer move to `renderSectionHeader` / `renderSectionFooter`; the per-section FlatList wrappers and the outer `NavigationScrollView` are gone.
- `SelectableAccount` is exported from `SelectableAccountsList.tsx` so the screen can use it directly. Its `navigation` prop is dropped in favour of `useNavigation` internally, since the row no longer relies on a parent passing it in.
- The auto-select-on-importable behaviour previously implemented in `ScannedAccountsSection`'s effect moves up to `useScanDeviceAccountsViewModel` as a one-shot effect keyed on the section list.
- `ScannedAccountsSection` is deleted (only consumer was this screen).

As a bonus, the screen now virtualizes correctly: scales cleanly to tens or hundreds of accounts (heavy BTC multi-derivation users, institutional setups) without paying the cost of mounting every row up-front.

`SelectableAccountsList` itself is untouched apart from the `SelectableAccount` export and the navigation hook move, so the Canton onboarding consumer is behaviour-identical.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30528](https://ledgerhq.atlassian.net/browse/LIVE-30528)
- **ADR link (if any)**: n/a

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30528]: https://ledgerhq.atlassian.net/browse/LIVE-30528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ