### PR TITLE
[LWD] feat(desktop): auto-select asset and account on Wallet 4.0 right-panel Swap

### DIFF
--- a/.changeset/twenty-oranges-clean.md
+++ b/.changeset/twenty-oranges-clean.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Auto-select the asset and account in the Wallet 4.0 right-panel Swap when the user is on an Asset Detail page: the route's currency is set as the receive asset, and the highest-balance account for that currency is preselected (single account when only one exists, none when there are no accounts). The embedded swap webview is keyed on the currency and account so navigating between asset detail pages reloads the live app with the updated selection instead of showing the asset/account dialog.

--- a/apps/ledger-live-desktop/src/mvvm/components/Page/usePageViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/Page/usePageViewModel.ts
@@ -3,7 +3,7 @@ import { useLocation } from "react-router";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import { SCROLL_UP_BUTTON_THRESHOLD, SCROLL_TO_TOP_EVENT } from "./constants";
 import { shouldDisplayRightPanel as isRightPanelPage } from "./utils";
-import { useRightPanelViewModel } from "LLD/components/RightPanel/useRightPanelViewModel";
+import { useRightPanelVisibility } from "LLD/components/RightPanel/useRightPanelVisibility";
 
 export interface PageViewModelResult {
   readonly pageScrollerRef: (node: HTMLDivElement | null) => void;
@@ -28,7 +28,7 @@ export const usePageViewModel = (): PageViewModelResult => {
     shouldDisplayBrazePlacement,
     shouldDisplayAggregatedAssets,
   } = useWalletFeaturesConfig("desktop");
-  const { shouldDisplay: isRightPanelEnabled } = useRightPanelViewModel();
+  const isRightPanelEnabled = useRightPanelVisibility();
 
   const shouldRenderRightPanel =
     isRightPanelPage(pathname, { shouldDisplayAggregatedAssets }) && isRightPanelEnabled;

--- a/apps/ledger-live-desktop/src/mvvm/components/RightPanel/RightPanelView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/RightPanel/RightPanelView.tsx
@@ -1,15 +1,26 @@
 import React, { memo } from "react";
 import SwapWebViewEmbedded from "~/renderer/screens/dashboard/components/SwapWebViewEmbedded";
+import type { RightPanelViewModel } from "./types";
+
+export interface RightPanelViewProps {
+  readonly viewModel: RightPanelViewModel;
+}
 
 /**
  * RightPanelView
  * Displays the swap sidebar in Wallet 4.0 layout
  * Note: Visibility is controlled by PageView, this component always renders when mounted
  */
-export const RightPanelView = memo(function RightPanelView() {
+export const RightPanelView = memo(function RightPanelView({ viewModel }: RightPanelViewProps) {
+  const { initialSwapState, webviewKey } = viewModel;
   return (
     <div className="flex h-full flex-col pb-32">
-      <SwapWebViewEmbedded height="100%" isWallet40 />
+      <SwapWebViewEmbedded
+        key={webviewKey}
+        height="100%"
+        isWallet40
+        initialSwapState={initialSwapState}
+      />
     </div>
   );
 });

--- a/apps/ledger-live-desktop/src/mvvm/components/RightPanel/__tests__/index.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/RightPanel/__tests__/index.test.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import RightPanel from "../index";
+import { DEFAULT_RIGHT_PANEL_VIEW_MODEL } from "../useRightPanelViewModel";
+
+const mockUseRightPanelViewModel = jest.fn();
+
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
+  useLocation: jest.fn(() => ({ pathname: "/", search: "", hash: "", state: null })),
+}));
+
+jest.mock("../useRightPanelViewModel", () => ({
+  ...jest.requireActual("../useRightPanelViewModel"),
+  useRightPanelViewModel: (...args: unknown[]) => mockUseRightPanelViewModel(...args),
+}));
+
+jest.mock("~/renderer/screens/dashboard/components/SwapWebViewEmbedded", () => ({
+  __esModule: true,
+  default: ({ initialSwapState }: { initialSwapState?: { defaultAccountId?: string } }) => (
+    <div
+      data-testid="swap-webview-embedded"
+      data-default-account-id={initialSwapState?.defaultAccountId}
+    />
+  ),
+}));
+
+const { useLocation } = jest.requireMock("react-router");
+
+describe("RightPanel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useLocation.mockReturnValue({ pathname: "/", search: "", hash: "", state: null });
+  });
+
+  it("renders the default view model on non-asset routes without calling the hook", () => {
+    render(<RightPanel />);
+
+    expect(mockUseRightPanelViewModel).not.toHaveBeenCalled();
+    expect(screen.getByTestId("swap-webview-embedded")).toBeVisible();
+    expect(screen.getByTestId("swap-webview-embedded")).not.toHaveAttribute("data-default-account-id");
+  });
+
+  it("calls the view model hook on asset routes", () => {
+    useLocation.mockReturnValue({
+      pathname: "/asset/bitcoin",
+      search: "",
+      hash: "",
+      state: null,
+    });
+    mockUseRightPanelViewModel.mockReturnValue({
+      webviewKey: "bitcoin::account-1",
+      initialSwapState: {
+        defaultAmountFrom: "0",
+        from: "/asset/bitcoin",
+        defaultCurrency: { toCurrencyId: "bitcoin" },
+        defaultAccountId: "account-1",
+      },
+    });
+
+    render(<RightPanel />);
+
+    expect(mockUseRightPanelViewModel).toHaveBeenCalledWith({
+      pathname: "/asset/bitcoin",
+      routeAssetId: "bitcoin",
+    });
+
+    const swapWebview = screen.getByTestId("swap-webview-embedded");
+    expect(swapWebview).toBeVisible();
+    expect(swapWebview).toHaveAttribute("data-default-account-id", "account-1");
+  });
+
+  it("uses the default view model constants on portfolio routes", () => {
+    render(<RightPanel />);
+
+    expect(DEFAULT_RIGHT_PANEL_VIEW_MODEL.initialSwapState).toBeUndefined();
+    expect(DEFAULT_RIGHT_PANEL_VIEW_MODEL.webviewKey).toBe("none::none");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/RightPanel/__tests__/useRightPanelViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/RightPanel/__tests__/useRightPanelViewModel.test.ts
@@ -1,36 +1,146 @@
-import { renderHook, withFlagOverrides } from "tests/testSetup";
-import { useRightPanelViewModel } from "../useRightPanelViewModel";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import BigNumber from "bignumber.js";
+import { renderHook } from "tests/testSetup";
+import {
+  buildDistributionItem,
+  makeIntegrationTokenCurrency,
+} from "tests/utils/distributionTestUtils";
+import {
+  DEFAULT_RIGHT_PANEL_VIEW_MODEL,
+  getRightPanelRouteAssetId,
+  useRightPanelViewModel,
+} from "../useRightPanelViewModel";
+
+jest.mock("~/renderer/actions/general", () => ({
+  ...jest.requireActual("~/renderer/actions/general"),
+  useDistribution: jest.fn(() => ({ bySlug: {}, list: [] })),
+}));
+
+const { useDistribution } = jest.requireMock("~/renderer/actions/general");
+
+const btc = getCryptoCurrencyById("bitcoin");
+const ethereum = getCryptoCurrencyById("ethereum");
+const usdcToken = makeIntegrationTokenCurrency("ethereum/erc20/usd__coin", "USDC", "USD Coin");
+
+describe("getRightPanelRouteAssetId", () => {
+  it("returns undefined outside asset routes", () => {
+    expect(getRightPanelRouteAssetId("/")).toBeUndefined();
+    expect(getRightPanelRouteAssetId("/analytics")).toBeUndefined();
+  });
+
+  it("returns the route asset id on asset routes", () => {
+    expect(getRightPanelRouteAssetId("/asset/bitcoin")).toBe("bitcoin");
+    expect(getRightPanelRouteAssetId(`/asset/${usdcToken.id}`)).toBe(usdcToken.id);
+  });
+});
 
 describe("useRightPanelViewModel", () => {
-  it("enables the right panel when wallet 4.0 and ptxSwap flags are enabled", () => {
-    const { result } = renderHook(() => useRightPanelViewModel(), {
-      initialState: withFlagOverrides({
-        lwdWallet40: { enabled: true, params: {} },
-        ptxSwapLiveAppOnPortfolio: { enabled: true },
-      }),
-    });
-
-    expect(result.current.shouldDisplay).toBe(true);
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useDistribution.mockReturnValue({ bySlug: {}, list: [] });
   });
 
-  it("disables the right panel when wallet 4.0 is disabled", () => {
-    const { result } = renderHook(() => useRightPanelViewModel(), {
-      initialState: withFlagOverrides({
-        lwdWallet40: { enabled: false, params: {} },
-        ptxSwapLiveAppOnPortfolio: { enabled: true },
-      }),
+  describe("initialSwapState", () => {
+    it("is undefined on asset route when distribution has no matching currency", () => {
+      const { result } = renderHook(() =>
+        useRightPanelViewModel({ pathname: "/asset/bitcoin", routeAssetId: "bitcoin" }),
+      );
+
+      expect(result.current.initialSwapState).toBeUndefined();
+      expect(result.current.webviewKey).toBe("none::none");
     });
 
-    expect(result.current.shouldDisplay).toBe(false);
+    it("builds swap state without account when distribution matches but no account exists", () => {
+      const distributionItem = buildDistributionItem({ currency: btc, accounts: [] });
+
+      useDistribution.mockReturnValue({
+        bySlug: { bitcoin: distributionItem },
+        list: [distributionItem],
+      });
+
+      const { result } = renderHook(() =>
+        useRightPanelViewModel({ pathname: "/asset/bitcoin", routeAssetId: "bitcoin" }),
+      );
+
+      expect(result.current.initialSwapState).toEqual({
+        defaultAmountFrom: "0",
+        from: "/asset/bitcoin",
+        defaultCurrency: { toCurrencyId: "bitcoin" },
+      });
+      expect(result.current.webviewKey).toBe("bitcoin::none");
+    });
+
+    it("preselects highest-balance account for a crypto currency", () => {
+      const lowBalanceBtc = {
+        ...genAccount("btc-low", { currency: btc }),
+        balance: new BigNumber(1),
+      };
+      const highBalanceBtc = {
+        ...genAccount("btc-high", { currency: btc }),
+        balance: new BigNumber(100),
+      };
+      const distributionItem = buildDistributionItem({ currency: btc, accounts: [] });
+
+      useDistribution.mockReturnValue({
+        bySlug: { bitcoin: distributionItem },
+        list: [distributionItem],
+      });
+
+      const { result } = renderHook(
+        () => useRightPanelViewModel({ pathname: "/asset/bitcoin", routeAssetId: "bitcoin" }),
+        { initialState: { accounts: [lowBalanceBtc, highBalanceBtc] } },
+      );
+
+      expect(result.current.initialSwapState).toEqual({
+        defaultAmountFrom: "0",
+        from: "/asset/bitcoin",
+        defaultCurrency: { toCurrencyId: "bitcoin" },
+        defaultAccountId: highBalanceBtc.id,
+      });
+      expect(result.current.initialSwapState?.defaultParentAccountId).toBeUndefined();
+      expect(result.current.webviewKey).toBe(`bitcoin::${highBalanceBtc.id}`);
+    });
+
+    it("resolves parent account when preselected account is a token sub-account", () => {
+      const ethAccount = genAccount("eth-1", { currency: ethereum });
+      const tokenAccount = genTokenAccount(0, ethAccount, usdcToken);
+      ethAccount.subAccounts = [tokenAccount];
+      const distributionItem = buildDistributionItem({ currency: usdcToken, accounts: [] });
+
+      useDistribution.mockReturnValue({
+        bySlug: { [usdcToken.id]: distributionItem },
+        list: [distributionItem],
+      });
+
+      const { result } = renderHook(
+        () =>
+          useRightPanelViewModel({
+            pathname: `/asset/${usdcToken.id}`,
+            routeAssetId: usdcToken.id,
+          }),
+        { initialState: { accounts: [ethAccount] } },
+      );
+
+      expect(result.current.initialSwapState).toEqual(
+        expect.objectContaining({
+          defaultAmountFrom: "0",
+          from: `/asset/${usdcToken.id}`,
+          defaultCurrency: { toCurrencyId: usdcToken.id },
+          defaultAccountId: tokenAccount.id,
+          defaultParentAccountId: ethAccount.id,
+        }),
+      );
+      expect(result.current.webviewKey).toBe(`${usdcToken.id}::${tokenAccount.id}`);
+    });
   });
+});
 
-  it("disables the right panel when ptxSwap flag is absent", () => {
-    const { result } = renderHook(() => useRightPanelViewModel(), {
-      initialState: withFlagOverrides({
-        lwdWallet40: { enabled: true, params: {} },
-      }),
+describe("DEFAULT_RIGHT_PANEL_VIEW_MODEL", () => {
+  it("provides an empty swap state for non-asset routes", () => {
+    expect(DEFAULT_RIGHT_PANEL_VIEW_MODEL).toEqual({
+      initialSwapState: undefined,
+      webviewKey: "none::none",
     });
-
-    expect(result.current.shouldDisplay).toBe(false);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/components/RightPanel/__tests__/useRightPanelVisibility.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/RightPanel/__tests__/useRightPanelVisibility.test.ts
@@ -1,0 +1,36 @@
+import { renderHook, withFlagOverrides } from "tests/testSetup";
+import { useRightPanelVisibility } from "../useRightPanelVisibility";
+
+describe("useRightPanelVisibility", () => {
+  it("returns true when wallet 4.0 and ptxSwap flags are enabled", () => {
+    const { result } = renderHook(() => useRightPanelVisibility(), {
+      initialState: withFlagOverrides({
+        lwdWallet40: { enabled: true, params: {} },
+        ptxSwapLiveAppOnPortfolio: { enabled: true },
+      }),
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("returns false when wallet 4.0 is disabled", () => {
+    const { result } = renderHook(() => useRightPanelVisibility(), {
+      initialState: withFlagOverrides({
+        lwdWallet40: { enabled: false, params: {} },
+        ptxSwapLiveAppOnPortfolio: { enabled: true },
+      }),
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("returns false when ptxSwap flag is absent", () => {
+    const { result } = renderHook(() => useRightPanelVisibility(), {
+      initialState: withFlagOverrides({
+        lwdWallet40: { enabled: true, params: {} },
+      }),
+    });
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/RightPanel/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/RightPanel/index.tsx
@@ -1,14 +1,37 @@
 import React from "react";
+import { useLocation } from "react-router";
 import { RightPanelView } from "./RightPanelView";
+import {
+  DEFAULT_RIGHT_PANEL_VIEW_MODEL,
+  getRightPanelRouteAssetId,
+  useRightPanelViewModel,
+} from "./useRightPanelViewModel";
+
+interface AssetRightPanelProps {
+  readonly pathname: string;
+  readonly routeAssetId: string;
+}
+
+const AssetRightPanel = ({ pathname, routeAssetId }: AssetRightPanelProps) => {
+  const viewModel = useRightPanelViewModel({ pathname, routeAssetId });
+  return <RightPanelView viewModel={viewModel} />;
+};
 
 /**
  * RightPanel component - Sidebar panel on the right side of the app
  * Displays the SwapWebView when enabled on supported pages (Portfolio, Market, Analytics)
  *
- * Note: Visibility is controlled by PageView using useRightPanelViewModel
+ * Note: Visibility is controlled by PageView.
  */
 const RightPanel = () => {
-  return <RightPanelView />;
+  const { pathname } = useLocation();
+  const routeAssetId = getRightPanelRouteAssetId(pathname);
+
+  if (!routeAssetId) {
+    return <RightPanelView viewModel={DEFAULT_RIGHT_PANEL_VIEW_MODEL} />;
+  }
+
+  return <AssetRightPanel pathname={pathname} routeAssetId={routeAssetId} />;
 };
 
 export default RightPanel;

--- a/apps/ledger-live-desktop/src/mvvm/components/RightPanel/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/RightPanel/types.ts
@@ -1,0 +1,6 @@
+import type { SwapNavigationState } from "LLD/features/Market/utils/swapNavigation";
+
+export interface RightPanelViewModel {
+  readonly initialSwapState?: SwapNavigationState;
+  readonly webviewKey: string;
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/RightPanel/useRightPanelViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/RightPanel/useRightPanelViewModel.ts
@@ -1,16 +1,72 @@
-import { useFeature, useWalletFeaturesConfig } from "@features/platform-feature-flags";
+import { useMemo } from "react";
+import { resolveDistributionItem } from "@ledgerhq/asset-aggregation/assetDistribution/index";
+import { flattenAccounts, isTokenAccount } from "@ledgerhq/live-common/account/index";
+import { getAvailableAccountsById } from "@ledgerhq/live-common/exchange/swap/utils/index";
+import { useSelector } from "LLD/hooks/redux";
+import { accountsSelector } from "~/renderer/reducers/accounts";
+import { useDistribution } from "~/renderer/actions/general";
+import { decodeRouteParam } from "LLD/features/AssetDetail/utils/decodeRouteParam";
+import {
+  buildSwapNavigationState,
+  type SwapNavigationState,
+} from "LLD/features/Market/utils/swapNavigation";
+import type { RightPanelViewModel } from "./types";
 
-export interface RightPanelViewModelResult {
-  readonly shouldDisplay: boolean;
+const ASSET_PATH_PREFIX = "/asset/";
+
+const buildSwapWebViewKey = (initialSwapState?: SwapNavigationState): string =>
+  `${initialSwapState?.defaultCurrency?.toCurrencyId ?? "none"}::${initialSwapState?.defaultAccountId ?? "none"}`;
+
+export const DEFAULT_RIGHT_PANEL_VIEW_MODEL: RightPanelViewModel = {
+  initialSwapState: undefined,
+  webviewKey: "none::none",
+};
+
+export const getRightPanelRouteAssetId = (pathname: string): string | undefined => {
+  if (!pathname.startsWith(ASSET_PATH_PREFIX)) return undefined;
+  const routeAssetId = pathname.slice(ASSET_PATH_PREFIX.length);
+  return routeAssetId || undefined;
+};
+
+interface UseRightPanelViewModelParams {
+  readonly pathname: string;
+  readonly routeAssetId: string;
 }
 
-export const useRightPanelViewModel = (): RightPanelViewModelResult => {
-  const { isEnabled: isWallet40Enabled } = useWalletFeaturesConfig("desktop");
-  const ptxSwapLiveAppOnPortfolio = useFeature("ptxSwapLiveAppOnPortfolio");
+export const useRightPanelViewModel = ({
+  pathname,
+  routeAssetId,
+}: UseRightPanelViewModelParams): RightPanelViewModel => {
+  const distribution = useDistribution({ groupBy: "asset" });
+  const allAccounts = useSelector(accountsSelector);
 
-  const shouldDisplay = isWallet40Enabled && !!ptxSwapLiveAppOnPortfolio?.enabled;
+  const currency = useMemo(() => {
+    const decodedAssetId = decodeRouteParam(routeAssetId);
+    return resolveDistributionItem({ routeAssetId, decodedAssetId, distribution })?.currency;
+  }, [routeAssetId, distribution]);
+
+  const initialSwapState = useMemo(() => {
+    if (!currency) return undefined;
+
+    const availableAccounts = getAvailableAccountsById(currency.id, flattenAccounts(allAccounts));
+    const preselectedAccount = availableAccounts[0];
+    const parentAccount =
+      preselectedAccount && isTokenAccount(preselectedAccount)
+        ? allAccounts.find(a => a.id === preselectedAccount.parentId)
+        : undefined;
+
+    return buildSwapNavigationState({
+      defaultCurrency: currency,
+      fromPath: pathname,
+      account: preselectedAccount,
+      parentAccount,
+    });
+  }, [currency, pathname, allAccounts]);
+
+  const webviewKey = useMemo(() => buildSwapWebViewKey(initialSwapState), [initialSwapState]);
 
   return {
-    shouldDisplay,
+    initialSwapState,
+    webviewKey,
   };
 };

--- a/apps/ledger-live-desktop/src/mvvm/components/RightPanel/useRightPanelVisibility.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/RightPanel/useRightPanelVisibility.ts
@@ -1,0 +1,8 @@
+import { useFeature, useWalletFeaturesConfig } from "@features/platform-feature-flags";
+
+export const useRightPanelVisibility = (): boolean => {
+  const { isEnabled: isWallet40Enabled } = useWalletFeaturesConfig("desktop");
+  const ptxSwapLiveAppOnPortfolio = useFeature("ptxSwapLiveAppOnPortfolio");
+
+  return isWallet40Enabled && !!ptxSwapLiveAppOnPortfolio?.enabled;
+};

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/components/SwapWebViewEmbedded.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/components/SwapWebViewEmbedded.tsx
@@ -11,6 +11,7 @@ import SwapWebView from "~/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3
 import { SwapLoader } from "~/renderer/screens/exchange/Swap2/Form/SwapLoader";
 import Card from "~/renderer/components/Box/Card";
 import { NetworkErrorScreen } from "~/renderer/components/Web3AppWebview/NetworkError";
+import type { SwapNavigationState } from "LLD/features/Market/utils/swapNavigation";
 
 const DEFAULT_MANIFEST_ID =
   process.env.DEFAULT_SWAP_MANIFEST_ID || FEATURE_FLAGS_DEFAULTS.ptxSwapLiveApp.params?.manifest_id;
@@ -66,11 +67,13 @@ function SwapCard({
 interface SwapWebViewEmbeddedProps {
   height?: string;
   isWallet40?: boolean;
+  initialSwapState?: SwapNavigationState;
 }
 
 export default function SwapWebViewEmbedded({
   height = "550px",
   isWallet40,
+  initialSwapState,
 }: Readonly<SwapWebViewEmbeddedProps>) {
   const swapLiveEnabledFlag = useSwapLiveConfig();
   const swapLiveAppManifestID = swapLiveEnabledFlag?.params?.manifest_id || DEFAULT_MANIFEST_ID;
@@ -101,7 +104,12 @@ export default function SwapWebViewEmbedded({
   return (
     <SwapCard height={height} isWallet40={isWallet40}>
       <EmbeddedContainer>
-        <SwapWebView manifest={manifest} isEmbedded Loader={SwapLoader} />
+        <SwapWebView
+          manifest={manifest}
+          isEmbedded
+          Loader={SwapLoader}
+          initialState={initialSwapState}
+        />
       </EmbeddedContainer>
     </SwapCard>
   );

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
@@ -103,6 +103,7 @@ export type SwapWebProps = {
   manifest: LiveAppManifest;
   isEmbedded?: boolean;
   Loader?: WebviewLoader;
+  initialState?: SwapLocationState;
 };
 
 type TokenParams = {
@@ -141,7 +142,12 @@ const SWAP_API_BASE = getEnv("SWAP_API_BASE");
 const SWAP_USER_IP = getEnv("SWAP_USER_IP");
 const getSegWitAbandonSeedAddress = (): string => "bc1qed3mqr92zvq2s782aqkyx785u23723w02qfrgs";
 
-const SwapWebView = ({ manifest, isEmbedded = false, Loader = SwapLoader }: SwapWebProps) => {
+const SwapWebView = ({
+  manifest,
+  isEmbedded = false,
+  Loader = SwapLoader,
+  initialState,
+}: SwapWebProps) => {
   const { theme } = useTheme();
   const walletState = useSelector(walletSelector);
   const dispatch = useDispatch();
@@ -164,7 +170,7 @@ const SwapWebView = ({ manifest, isEmbedded = false, Loader = SwapLoader }: Swap
   const { t } = useTranslation();
   const swapDefaultTrack = useGetSwapTrackingProperties();
   const location = useLocation();
-  const state = isSwapLocationState(location.state) ? location.state : null;
+  const state = initialState ?? (isSwapLocationState(location.state) ? location.state : null);
 
   const {
     rawFromAccountId,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Wallet 4.0 right-panel Swap on Asset Detail pages (Portfolio / Market / Analytics routes are unchanged)
  - Account preselection logic for the swap "receive" input
  - Re-mount behaviour of the embedded swap webview when navigating between asset detail pages
  - Existing `/swap` route flow (must remain identical when `initialState` is not provided)

### 📝 Description

When the Wallet 4.0 right-panel Swap was opened from an Asset Detail page, the embedded live app had no preselected receive asset, so it forced the user through the asset/account dialog before they could quote a swap.

This PR resolves the route's currency in `useRightPanelViewModel`, looks up the matching accounts via `getAvailableAccountsById` (already sorted by descending balance), and feeds them into `buildSwapNavigationState` before passing the result to the embedded `SwapWebView` as `initialState`:

- **Receive** input: empty if no account, the only one if one exists, otherwise the highest-balance account.
- **Send** input: left to the swap live app's own "last selected account" behaviour (no `fromAccountId` is forced from native).

The embedded webview is keyed on `${toCurrencyId}::${defaultAccountId}` so navigating between asset detail pages remounts the webview with the new state instead of keeping the stale hash params.


https://github.com/user-attachments/assets/1fcafb61-d20c-4bd5-9d8e-d3a8616e0eb3




### ❓ Context

- **JIRA or GitHub link**: [LIVE-31060](https://ledgerhq.atlassian.net/browse/LIVE-31060)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31060]: https://ledgerhq.atlassian.net/browse/LIVE-31060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ