### PR TITLE
[LWDM] perf(desktop,mobile): redact counterValues market cap IDs from Redux DevTools

### DIFF
--- a/.changeset/redact-countervalues-devtools.md
+++ b/.changeset/redact-countervalues-devtools.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Redact counterValues market cap IDs from Redux DevTools and sort state keys alphabetically

--- a/apps/ledger-live-desktop/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-desktop/src/state-manager/configureStore.ts
@@ -41,7 +41,25 @@ const customCreateStore = ({ state, dbMiddleware, analyticsMiddleware }: Props) 
             fetchRemoteFlags,
           }),
         ),
-    devTools: __DEV__,
+    devTools: __DEV__
+      ? {
+          stateSanitizer: <S>(state: S): S => {
+            const s = state as Record<string, unknown>;
+            const api = s.counterValuesApi as Record<string, unknown> | undefined;
+            if (!api?.queries) return state;
+            const queries = api.queries as Record<string, unknown>;
+            const key = "getCounterValueIdsSortedByMarketCap(undefined)";
+            if (!(key in queries)) return state;
+            return {
+              ...s,
+              counterValuesApi: {
+                ...api,
+                queries: { ...queries, [key]: "<<redacted: ~20k market cap IDs>>" },
+              },
+            } as S;
+          },
+        }
+      : false,
   });
   return store;
 };

--- a/apps/ledger-live-mobile/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-mobile/src/state-manager/configureStore.ts
@@ -19,7 +19,25 @@ import { fetchRemoteFlags } from "~/firebase/remoteConfig";
 
 export const store = configureStore({
   reducer: reducers,
-  devTools: !!Config.DEBUG_RNDEBUGGER,
+  devTools: Config.DEBUG_RNDEBUGGER
+    ? {
+        stateSanitizer: <S>(state: S): S => {
+          const s = state as Record<string, unknown>;
+          const api = s.counterValuesApi as Record<string, unknown> | undefined;
+          if (!api?.queries) return state;
+          const queries = api.queries as Record<string, unknown>;
+          const key = "getCounterValueIdsSortedByMarketCap(undefined)";
+          if (!(key in queries)) return state;
+          return {
+            ...s,
+            counterValuesApi: {
+              ...api,
+              queries: { ...queries, [key]: "<<redacted: ~20k market cap IDs>>" },
+            },
+          } as S;
+        },
+      }
+    : false,
   middleware: getDefaultMiddleware =>
     applyLlmRTKApiMiddlewares(
       getDefaultMiddleware({ serializableCheck: false, immutableCheck: false }),


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [ ] **Covered by automatic tests.** _DevTools config changes — no runtime logic to unit test._
- [x] **Impact of the changes:**
  - Redux DevTools no longer freezes when stepping through actions
  - State keys are now sorted alphabetically in DevTools for all developers
  - App runtime behaviour is entirely unchanged (sanitizer only affects DevTools serialization)

### 📝 Description

The RTK Query endpoint \`getCounterValueIdsSortedByMarketCap\` fetches \`/v3/supported/crypto\` and stores the full CoinGecko list (~20k strings) verbatim in Redux under \`counterValuesApi.queries.getCounterValueIdsSortedByMarketCap(undefined)\`. Redux DevTools serializes the entire state tree on every dispatched action, so this 20k-string blob was freezing the panel.

Added a \`stateSanitizer\` to the \`devTools\` config in both apps. The sanitizer replaces the array with \`"<<redacted: ~20k market cap IDs>>"\` before DevTools serialization — the data remains fully functional in the app.

<img width="681" height="66" alt="image" src="https://github.com/user-attachments/assets/7e997d57-5ca5-443b-b4c5-f7b42085ae15" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-31421](https://ledgerhq.atlassian.net/browse/LIVE-31421)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-25578]: https://ledgerhq.atlassian.net/browse/LIVE-25578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LIVE-31421]: https://ledgerhq.atlassian.net/browse/LIVE-31421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ