### PR TITLE
[LWDM] fix(coin-tron): use real bandwidth and energy for framework estimateFees

### DIFF
--- a/.changeset/tron-fee-estimation-dynamic.md
+++ b/.changeset/tron-fee-estimation-dynamic.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tron": minor
+---
+
+Fix coin-framework `estimateFees` to use real on-chain data (chain parameters, simulated energy via triggerConstantContract) instead of hardcoded constants, and stop adding the 1.1 TRX native activation fee on TRC20/TRC10 transfers to inactive recipients

--- a/libs/coin-modules/coin-tron/src/logic/estimateFees.integ.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/estimateFees.integ.test.ts
@@ -1,0 +1,113 @@
+import { TransactionIntent } from "@ledgerhq/coin-module-framework/api/index";
+import { randomBytes } from "crypto";
+import coinConfig from "../config";
+import { getChainParameters, getTronAccountNetwork } from "../network";
+import { encode58Check } from "../network/format";
+import { estimateFees } from "./estimateFees";
+
+const USDT_CONTRACT = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t";
+// SR account — staked TRX for both resources absorbs all per-tx fees.
+const SUPER_REPRESENTATIVE = "TJvaAeFb8Lykt9RQcVyyTFN2iDvGMuyD4M";
+const ACTIVE_RECIPIENT = "TPswDDCAWhJAZGdHPidFg5nEf8TkNToDX1";
+// BitTorrent (BTT) TRC10 — long-lived asset useful for end-to-end testing.
+const BTT_ASSET = "1002000";
+
+// Collision with an existing on-chain account is ~2^-160.
+const freshAddress = (): string => encode58Check("41" + randomBytes(20).toString("hex"));
+
+const sendIntent = (overrides: Partial<TransactionIntent>): TransactionIntent => ({
+  intentType: "transaction",
+  type: "send",
+  sender: SUPER_REPRESENTATIVE,
+  recipient: ACTIVE_RECIPIENT,
+  amount: BigInt(1),
+  asset: { type: "native" },
+  ...overrides,
+});
+
+describe("estimateFees [integ]", () => {
+  beforeAll(() => {
+    coinConfig.setCoinConfig(() => ({
+      status: { type: "active" },
+      explorer: { url: "https://tron.coin.ledger.com" },
+    }));
+  });
+
+  describe("sanity", () => {
+    // If this fails, the SR changed its staking policy — pick another one.
+    it("the Super Representative has enough bandwidth and energy to absorb tx-level fees", async () => {
+      const info = await getTronAccountNetwork(SUPER_REPRESENTATIVE);
+
+      const bandwidth = info.freeNetLimit
+        .minus(info.freeNetUsed)
+        .plus(info.netLimit)
+        .minus(info.netUsed);
+      const energy = info.energyLimit.minus(info.energyUsed);
+
+      expect(bandwidth.toNumber()).toBeGreaterThan(500);
+      expect(energy.toNumber()).toBeGreaterThan(100_000);
+    });
+  });
+
+  describe("Super Representative sender (bandwidth + energy fully covered)", () => {
+    describe("native", () => {
+      it("to an active recipient costs 0", async () => {
+        const fee = await estimateFees(sendIntent({ recipient: ACTIVE_RECIPIENT }));
+
+        expect(fee).toBe(0n);
+      });
+
+      it("to a fresh recipient costs exactly createAccountFee + createNewAccountFeeInSystemContract", async () => {
+        const [fee, params] = await Promise.all([
+          estimateFees(sendIntent({ recipient: freshAddress() })),
+          getChainParameters(),
+        ]);
+
+        expect(fee).toBe(
+          BigInt(params.createAccountFee + params.createNewAccountFeeInSystemContract),
+        );
+      });
+    });
+
+    describe("TRC10", () => {
+      it("to an active recipient costs 0", async () => {
+        const fee = await estimateFees(
+          sendIntent({ asset: { type: "trc10", assetReference: BTT_ASSET } }),
+        );
+
+        expect(fee).toBe(0n);
+      });
+    });
+
+    describe("TRC20", () => {
+      it("to an active recipient costs 0", async () => {
+        const fee = await estimateFees(
+          sendIntent({ asset: { type: "trc20", assetReference: USDT_CONTRACT } }),
+        );
+
+        expect(fee).toBe(0n);
+      });
+
+      it("to a fresh recipient costs 0 — no native activation fee for contracts", async () => {
+        const fee = await estimateFees(
+          sendIntent({
+            recipient: freshAddress(),
+            asset: { type: "trc20", assetReference: USDT_CONTRACT },
+          }),
+        );
+
+        expect(fee).toBe(0n);
+      });
+    });
+
+    it("is deterministic — same intent twice returns the same fee", async () => {
+      const intent = sendIntent({
+        asset: { type: "trc20", assetReference: USDT_CONTRACT },
+      });
+
+      const [first, second] = await Promise.all([estimateFees(intent), estimateFees(intent)]);
+
+      expect(first).toBe(second);
+    });
+  });
+});

--- a/libs/coin-modules/coin-tron/src/logic/estimateFees.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/estimateFees.test.ts
@@ -1,54 +1,262 @@
 import { TransactionIntent } from "@ledgerhq/coin-module-framework/api/index";
-import { ACTIVATION_FEES_TRC_20, STANDARD_FEES_NATIVE } from "./constants";
+import BigNumber from "bignumber.js";
+import {
+  fetchTronAccount,
+  getChainParameters,
+  getTronAccountNetwork,
+  triggerConstantContract,
+} from "../network";
+import type { AccountTronAPI, ChainParameters } from "../network/types";
+import type { NetworkInfo } from "../types";
+import { ACTIVATION_FEES, STANDARD_FEES_NATIVE, STANDARD_FEES_TRC_20 } from "./constants";
 import { estimateFees } from "./estimateFees";
 
+jest.mock("../network", () => ({
+  fetchTronAccount: jest.fn(),
+  getChainParameters: jest.fn(),
+  getTronAccountNetwork: jest.fn(),
+  triggerConstantContract: jest.fn(),
+}));
+
+const mockGetTronAccountNetwork = jest.mocked(getTronAccountNetwork);
+const mockFetchTronAccount = jest.mocked(fetchTronAccount);
+const mockGetChainParameters = jest.mocked(getChainParameters);
+const mockTriggerConstantContract = jest.mocked(triggerConstantContract);
+
+const TRC20_CONTRACT = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t";
+
+const buildNetworkInfo = (overrides: Partial<NetworkInfo> = {}): NetworkInfo => ({
+  family: "tron",
+  freeNetUsed: new BigNumber(0),
+  freeNetLimit: new BigNumber(0),
+  netUsed: new BigNumber(0),
+  netLimit: new BigNumber(0),
+  energyUsed: new BigNumber(0),
+  energyLimit: new BigNumber(0),
+  ...overrides,
+});
+
+const chainParams: ChainParameters = {
+  energyFee: 210,
+  transactionFee: 1000,
+  createAccountFee: 100_000,
+  createNewAccountFeeInSystemContract: 1_000_000,
+};
+
+const activeRecipient: AccountTronAPI[] = [{ address: "recipient", trc20: [] }];
+const activeRecipientWithToken: AccountTronAPI[] = [
+  { address: "recipient", trc20: [{ [TRC20_CONTRACT]: "1000" }] },
+];
+const inactiveRecipient: AccountTronAPI[] = [];
+
+const SENDER = "TF17BgPaZYbz8oxbjhriubPDsA7ArKoLX3";
+const RECIPIENT = "TJRabPrwbZy45sbavfcjinPJC18kjpRTv8";
+
+const sendNative: TransactionIntent = {
+  intentType: "transaction",
+  type: "send",
+  sender: SENDER,
+  recipient: RECIPIENT,
+  amount: BigInt(1000),
+  asset: { type: "native" },
+};
+
+const sendTrc10: TransactionIntent = {
+  intentType: "transaction",
+  type: "send",
+  sender: SENDER,
+  recipient: RECIPIENT,
+  amount: BigInt(1000),
+  asset: { type: "trc10", assetReference: "1002000" },
+};
+
+const sendTrc20: TransactionIntent = {
+  intentType: "transaction",
+  type: "send",
+  sender: SENDER,
+  recipient: RECIPIENT,
+  amount: BigInt(1000),
+  asset: { type: "trc20", assetReference: TRC20_CONTRACT },
+};
+
 describe("estimateFees", () => {
-  it("should calculate fees for native trx transactionIntent", async () => {
-    const transactionIntent: TransactionIntent = {
-      intentType: "transaction",
-      type: "send",
-      sender: "sender1",
-      recipient: "recipient1",
-      amount: BigInt(1000),
-      asset: { type: "native" },
-    };
-
-    const result = await estimateFees(transactionIntent);
-
-    expect(result).toEqual(BigInt(STANDARD_FEES_NATIVE.toString()));
-  });
-  it("should calculate fees for trc10 transactionIntent", async () => {
-    const transactionIntent: TransactionIntent = {
-      intentType: "transaction",
-      type: "send",
-      sender: "sender1",
-      recipient: "recipient1",
-      amount: BigInt(1000),
-      asset: {
-        type: "trc10",
-        assetReference: "1002000",
-      },
-    };
-
-    const result = await estimateFees(transactionIntent);
-
-    expect(result).toEqual(BigInt(STANDARD_FEES_NATIVE.toString()));
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetChainParameters.mockResolvedValue(chainParams);
+    mockTriggerConstantContract.mockResolvedValue({ energy_used: 0 });
   });
 
-  it("should calculate fees for trc20 transactionIntent", async () => {
-    const transactionIntent: TransactionIntent = {
-      intentType: "transaction",
-      type: "send",
-      sender: "sender1",
-      recipient: "recipient1",
-      amount: BigInt(1000),
-      asset: {
-        type: "trc20",
-        assetReference: "T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb",
-      },
-    };
-    const result = await estimateFees(transactionIntent);
+  describe("native send", () => {
+    it("returns 0 when sender has enough free bandwidth", async () => {
+      mockGetTronAccountNetwork.mockResolvedValue(
+        buildNetworkInfo({ freeNetLimit: new BigNumber(5000) }),
+      );
+      mockFetchTronAccount.mockResolvedValue(activeRecipient);
 
-    expect(result).toEqual(BigInt(ACTIVATION_FEES_TRC_20.toString()));
+      const result = await estimateFees(sendNative);
+
+      expect(result).toBe(0n);
+    });
+
+    it("charges (size - available) * transactionFee when bandwidth is insufficient", async () => {
+      mockGetTronAccountNetwork.mockResolvedValue(buildNetworkInfo());
+      mockFetchTronAccount.mockResolvedValue(activeRecipient);
+
+      const result = await estimateFees(sendNative);
+
+      expect(result).toBe(BigInt(270 * chainParams.transactionFee));
+    });
+
+    it("adds activation fee when recipient is inactive", async () => {
+      mockGetTronAccountNetwork.mockResolvedValue(
+        buildNetworkInfo({ freeNetLimit: new BigNumber(5000) }),
+      );
+      mockFetchTronAccount.mockResolvedValue(inactiveRecipient);
+
+      const result = await estimateFees(sendNative);
+
+      expect(result).toBe(
+        BigInt(chainParams.createAccountFee + chainParams.createNewAccountFeeInSystemContract),
+      );
+    });
+  });
+
+  describe("trc10 send", () => {
+    it("returns 0 when sender has enough bandwidth", async () => {
+      mockGetTronAccountNetwork.mockResolvedValue(
+        buildNetworkInfo({ freeNetLimit: new BigNumber(5000) }),
+      );
+      mockFetchTronAccount.mockResolvedValue(activeRecipient);
+
+      const result = await estimateFees(sendTrc10);
+
+      expect(result).toBe(0n);
+    });
+
+    it("charges (size - available) * transactionFee when bandwidth is insufficient", async () => {
+      mockGetTronAccountNetwork.mockResolvedValue(buildNetworkInfo());
+      mockFetchTronAccount.mockResolvedValue(activeRecipient);
+
+      const result = await estimateFees(sendTrc10);
+
+      expect(result).toBe(BigInt(285 * chainParams.transactionFee));
+    });
+
+    it("does NOT add native activation fee when recipient is inactive", async () => {
+      mockGetTronAccountNetwork.mockResolvedValue(
+        buildNetworkInfo({ freeNetLimit: new BigNumber(5000) }),
+      );
+      mockFetchTronAccount.mockResolvedValue(inactiveRecipient);
+
+      const result = await estimateFees(sendTrc10);
+
+      expect(result).toBe(0n);
+    });
+
+    it("does not invoke triggerConstantContract (non-contract asset)", async () => {
+      mockGetTronAccountNetwork.mockResolvedValue(
+        buildNetworkInfo({ freeNetLimit: new BigNumber(5000) }),
+      );
+      mockFetchTronAccount.mockResolvedValue(activeRecipient);
+
+      await estimateFees(sendTrc10);
+
+      expect(mockTriggerConstantContract).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("trc20 send", () => {
+    it("returns 0 when sender has enough bandwidth and energy", async () => {
+      mockGetTronAccountNetwork.mockResolvedValue(
+        buildNetworkInfo({
+          freeNetLimit: new BigNumber(5000),
+          energyLimit: new BigNumber(100_000),
+        }),
+      );
+      mockFetchTronAccount.mockResolvedValue(activeRecipientWithToken);
+      mockTriggerConstantContract.mockResolvedValue({ energy_used: 31_895 });
+
+      const result = await estimateFees(sendTrc20);
+
+      expect(result).toBe(0n);
+    });
+
+    it("charges energy fee when sender has no energy", async () => {
+      mockGetTronAccountNetwork.mockResolvedValue(
+        buildNetworkInfo({ freeNetLimit: new BigNumber(5000) }),
+      );
+      mockFetchTronAccount.mockResolvedValue(activeRecipientWithToken);
+      mockTriggerConstantContract.mockResolvedValue({ energy_used: 31_895 });
+
+      const result = await estimateFees(sendTrc20);
+
+      expect(result).toBe(BigInt(31_895 * chainParams.energyFee));
+    });
+
+    it("partially covers energy when sender has some", async () => {
+      mockGetTronAccountNetwork.mockResolvedValue(
+        buildNetworkInfo({
+          freeNetLimit: new BigNumber(5000),
+          energyLimit: new BigNumber(20_000),
+        }),
+      );
+      mockFetchTronAccount.mockResolvedValue(activeRecipientWithToken);
+      mockTriggerConstantContract.mockResolvedValue({ energy_used: 31_895 });
+
+      const result = await estimateFees(sendTrc20);
+
+      expect(result).toBe(BigInt((31_895 - 20_000) * chainParams.energyFee));
+    });
+
+    it("does NOT add native activation fee when recipient is inactive (contract storage handled via energy)", async () => {
+      mockGetTronAccountNetwork.mockResolvedValue(
+        buildNetworkInfo({
+          freeNetLimit: new BigNumber(5000),
+          energyLimit: new BigNumber(100_000),
+        }),
+      );
+      mockFetchTronAccount.mockResolvedValue(inactiveRecipient);
+      mockTriggerConstantContract.mockResolvedValue({ energy_used: 64_285 });
+
+      const result = await estimateFees(sendTrc20);
+
+      expect(result).toBe(0n);
+    });
+
+    it("falls back when the simulation reverts", async () => {
+      mockGetTronAccountNetwork.mockResolvedValue(
+        buildNetworkInfo({
+          freeNetLimit: new BigNumber(5000),
+          energyLimit: new BigNumber(100_000),
+        }),
+      );
+      mockFetchTronAccount.mockResolvedValue(activeRecipientWithToken);
+      mockTriggerConstantContract.mockResolvedValue({
+        result: { result: false, code: "REVERT", message: "insufficient balance" },
+        energy_used: 0,
+      });
+
+      const result = await estimateFees(sendTrc20);
+
+      expect(result).toBe(BigInt(STANDARD_FEES_TRC_20.toString()));
+    });
+  });
+
+  describe("fallback", () => {
+    it("returns activation + bandwidth worst case when network fails for native send", async () => {
+      mockGetTronAccountNetwork.mockRejectedValue(new Error("network down"));
+
+      const result = await estimateFees(sendNative);
+
+      expect(result).toBe(BigInt(ACTIVATION_FEES.plus(STANDARD_FEES_NATIVE).toString()));
+    });
+
+    it("returns STANDARD_FEES_TRC_20 when network fails for TRC20 send", async () => {
+      mockGetChainParameters.mockRejectedValue(new Error("chain params unreachable"));
+
+      const result = await estimateFees(sendTrc20);
+
+      expect(result).toBe(BigInt(STANDARD_FEES_TRC_20.toString()));
+    });
   });
 });

--- a/libs/coin-modules/coin-tron/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-tron/src/logic/estimateFees.ts
@@ -1,13 +1,128 @@
 import type { TransactionIntent } from "@ledgerhq/coin-module-framework/api/index";
-import { TronMemo } from "../types";
-import { ACTIVATION_FEES_TRC_20, STANDARD_FEES_NATIVE } from "./constants";
+import { log } from "@ledgerhq/logs";
+import BigNumber from "bignumber.js";
+import {
+  fetchTronAccount,
+  getChainParameters,
+  getTronAccountNetwork,
+  triggerConstantContract,
+} from "../network";
+import { decode58Check } from "../network/format";
+import type { AccountTronAPI, ChainParameters } from "../network/types";
+import { abiEncodeTrc20Transfer } from "../network/utils";
+import type { NetworkInfo, TronMemo } from "../types";
+import { ACTIVATION_FEES, STANDARD_FEES_NATIVE, STANDARD_FEES_TRC_20 } from "./constants";
+
+// Byte sizes of the fully signed transaction (raw_data + signature + protobuf wrapping).
+// Mirrors bridge/utils.ts:getEstimatedBlockSize. Using craftTransaction's raw_data_hex alone
+// would underestimate by ~50% because it doesn't include the signature/outer envelope.
+const estimatedTxSize = (intent: TransactionIntent<TronMemo>): number => {
+  switch (intent.type) {
+    case "send":
+      if (intent.asset.type === "trc10") return 285; // TransferAssetContract
+      if (intent.asset.type === "trc20") return 350; // TriggerSmartContract
+      return 270; // TransferContract
+    case "freeze":
+    case "unfreeze":
+    case "claimReward":
+    case "withdrawExpireUnfreeze":
+    case "unDelegateResource":
+    case "legacyUnfreeze":
+      return 260;
+    case "vote":
+      return 290;
+    default:
+      throw new Error(`unsupported Tron intent type for fee estimation: ${intent.type}`);
+  }
+};
+
+const estimateEnergy = async (intent: TransactionIntent<TronMemo>): Promise<number> => {
+  if (intent.asset.type !== "trc20" || !intent.asset.assetReference) {
+    return 0;
+  }
+  const response = await triggerConstantContract({
+    ownerAddress: decode58Check(intent.sender),
+    contractAddress: decode58Check(intent.asset.assetReference),
+    functionSelector: "transfer(address,uint256)",
+    parameter: abiEncodeTrc20Transfer(
+      decode58Check(intent.recipient),
+      new BigNumber(intent.amount.toString()),
+    ),
+  });
+  // A reverted simulation reports an unreliable energy_used — surface it.
+  if (response.result?.result === false) {
+    throw new Error(
+      `triggerConstantContract failed: ${response.result.code ?? "unknown"} ${response.result.message ?? ""}`.trim(),
+    );
+  }
+  return response.energy_used ?? 0;
+};
+
+const computeBandwidthFee = (
+  size: number,
+  networkInfo: NetworkInfo,
+  params: ChainParameters,
+): BigNumber => {
+  const freeAvailable = networkInfo.freeNetLimit.minus(networkInfo.freeNetUsed);
+  const stakedAvailable = networkInfo.netLimit.minus(networkInfo.netUsed);
+  const available = freeAvailable.plus(stakedAvailable);
+  const missing = BigNumber.maximum(0, new BigNumber(size).minus(available));
+  return missing.multipliedBy(params.transactionFee);
+};
+
+const computeEnergyFee = (
+  energyNeeded: number,
+  networkInfo: NetworkInfo,
+  params: ChainParameters,
+): BigNumber => {
+  const available = networkInfo.energyLimit.minus(networkInfo.energyUsed);
+  const missing = BigNumber.maximum(0, new BigNumber(energyNeeded).minus(available));
+  return missing.multipliedBy(params.energyFee);
+};
+
+const computeActivationFee = (
+  intent: TransactionIntent<TronMemo>,
+  recipientAccount: AccountTronAPI | undefined,
+  params: ChainParameters,
+): BigNumber => {
+  if (intent.type !== "send") return new BigNumber(0);
+  if (recipientAccount) return new BigNumber(0);
+  // Only TRX TransferContract triggers the protocol-level activation fee;
+  // TRC20/TRC10 transfers to a new recipient are covered by energy/bandwidth.
+  if (intent.asset.type !== "native") return new BigNumber(0);
+  return new BigNumber(params.createAccountFee).plus(params.createNewAccountFeeInSystemContract);
+};
+
+// Pessimistic fallback when on-chain estimation fails — over-estimates rather than failing.
+// Native/TRC10 worst case: activation fee (recipient inactive) + standard bandwidth burn.
+const fallbackFee = (intent: TransactionIntent<TronMemo>): bigint => {
+  if (intent.type === "send" && intent.asset.type === "trc20") {
+    return BigInt(STANDARD_FEES_TRC_20.toString());
+  }
+  return BigInt(ACTIVATION_FEES.plus(STANDARD_FEES_NATIVE).toString());
+};
 
 export async function estimateFees(
   transactionIntent: TransactionIntent<TronMemo>,
 ): Promise<bigint> {
-  if (transactionIntent.asset.type === "trc20") {
-    return BigInt(ACTIVATION_FEES_TRC_20.toString());
-  } else {
-    return BigInt(STANDARD_FEES_NATIVE.toString());
+  try {
+    const [networkInfo, recipientAccount, chainParams, energyNeeded] = await Promise.all([
+      getTronAccountNetwork(transactionIntent.sender),
+      // Only native sends need the recipient account for the activation-fee branch.
+      transactionIntent.type === "send" && transactionIntent.asset.type === "native"
+        ? fetchTronAccount(transactionIntent.recipient).then(accounts => accounts[0])
+        : Promise.resolve<AccountTronAPI | undefined>(undefined),
+      getChainParameters(),
+      estimateEnergy(transactionIntent),
+    ]);
+
+    const total = computeBandwidthFee(estimatedTxSize(transactionIntent), networkInfo, chainParams)
+      .plus(computeEnergyFee(energyNeeded, networkInfo, chainParams))
+      .plus(computeActivationFee(transactionIntent, recipientAccount, chainParams));
+
+    return BigInt(total.integerValue(BigNumber.ROUND_CEIL).toFixed());
+  } catch (err) {
+    log("tron/estimateFees", "falling back to pessimistic constants", { err });
+    return fallbackFee(transactionIntent);
   }
 }

--- a/libs/coin-modules/coin-tron/src/network/index.integ.test.ts
+++ b/libs/coin-modules/coin-tron/src/network/index.integ.test.ts
@@ -5,8 +5,14 @@ import {
   defaultFetchParams,
   fetchTronAccount,
   fetchTronAccountTxs,
+  getChainParameters,
   getTronAccountNetwork,
+  triggerConstantContract,
 } from ".";
+import { decode58Check } from "./format";
+import { abiEncodeTrc20Transfer } from "./utils";
+
+const USDT_CONTRACT = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t";
 
 /**
  * Tests used to help to develop and debug. Can't be reliable for the CI.
@@ -83,6 +89,38 @@ describe("TronGrid", () => {
       ]) {
         expect(result).toHaveProperty(p);
       }
+    });
+  });
+
+  describe("getChainParameters", () => {
+    beforeEach(() => {
+      getChainParameters.reset();
+    });
+
+    it("returns the four parameters used by fee estimation with mainnet values", async () => {
+      const params = await getChainParameters();
+
+      expect(params.transactionFee).toBe(1000);
+      expect(params.createAccountFee).toBe(100_000);
+      expect(params.createNewAccountFeeInSystemContract).toBe(1_000_000);
+      // gov-voted; historical values 100, 280, 420 sun/energy.
+      expect(params.energyFee).toBeGreaterThanOrEqual(50);
+      expect(params.energyFee).toBeLessThanOrEqual(500);
+    });
+  });
+
+  describe("triggerConstantContract", () => {
+    it("returns energy_used within the documented USDT transfer range", async () => {
+      const response = await triggerConstantContract({
+        ownerAddress: decode58Check(address),
+        contractAddress: decode58Check(USDT_CONTRACT),
+        functionSelector: "transfer(address,uint256)",
+        parameter: abiEncodeTrc20Transfer(decode58Check(address), new BigNumber(1)),
+      });
+
+      // Revert overhead ~5k; transfer to existing holder ~14k; to brand-new ~65k.
+      expect(response.energy_used).toBeGreaterThanOrEqual(5_000);
+      expect(response.energy_used).toBeLessThanOrEqual(100_000);
     });
   });
 });

--- a/libs/coin-modules/coin-tron/src/network/index.test.ts
+++ b/libs/coin-modules/coin-tron/src/network/index.test.ts
@@ -20,6 +20,7 @@ import {
   getAccountName,
   getBlock,
   getBlockWithTransactions,
+  getChainParameters,
   getContractUserEnergyRatioConsumption,
   getDelegatedResource,
   getLastBlock,
@@ -32,6 +33,7 @@ import {
   hydrateSuperRepresentatives,
   legacyUnfreezeTronTransaction,
   post,
+  triggerConstantContract,
   unDelegateResourceTransaction,
   unfreezeTronTransaction,
   validateAddress,
@@ -899,5 +901,114 @@ describe("claimRewardTronTransaction", () => {
     expect(mockedNetwork).toHaveBeenCalledWith(
       expect.objectContaining({ url: expect.stringContaining("/wallet/withdrawbalance") }),
     );
+  });
+});
+
+describe("getChainParameters", () => {
+  beforeEach(() => {
+    getChainParameters.reset();
+  });
+
+  const fullParams = {
+    chainParameter: [
+      { key: "getEnergyFee", value: 100 },
+      { key: "getTransactionFee", value: 1000 },
+      { key: "getCreateAccountFee", value: 100_000 },
+      { key: "getCreateNewAccountFeeInSystemContract", value: 1_000_000 },
+      { key: "getMaintenanceTimeInterval", value: 21_600_000 },
+    ],
+  };
+
+  it("parses the four governance-voted parameters used for fee estimation", async () => {
+    mockedNetwork.mockResolvedValueOnce(mockResponse(fullParams));
+
+    const params = await getChainParameters();
+
+    expect(params).toEqual({
+      energyFee: 100,
+      transactionFee: 1000,
+      createAccountFee: 100_000,
+      createNewAccountFeeInSystemContract: 1_000_000,
+    });
+  });
+
+  it("falls back to hardcoded values for missing keys", async () => {
+    mockedNetwork.mockResolvedValueOnce(
+      mockResponse({
+        chainParameter: [
+          { key: "getTransactionFee", value: 1000 },
+          { key: "getCreateAccountFee" }, // value omitted
+        ],
+      }),
+    );
+
+    const params = await getChainParameters();
+
+    expect(params.transactionFee).toBe(1000);
+    expect(params.energyFee).toBe(100); // fallback
+    expect(params.createAccountFee).toBe(100_000); // fallback
+    expect(params.createNewAccountFeeInSystemContract).toBe(1_000_000); // fallback
+  });
+
+  it("caches the result across calls (no second HTTP request)", async () => {
+    mockedNetwork.mockResolvedValueOnce(mockResponse(fullParams));
+
+    await getChainParameters();
+    await getChainParameters();
+    await getChainParameters();
+
+    expect(mockedNetwork).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("triggerConstantContract", () => {
+  const okResponse = {
+    result: { result: true },
+    energy_used: 14_170,
+    constant_result: ["0".repeat(64)],
+  };
+  const revertResponse = {
+    result: { result: false, code: "REVERT", message: "transfer amount exceeds balance" },
+    energy_used: 0,
+  };
+
+  it("forwards parameters and returns the parsed response on success", async () => {
+    mockedNetwork.mockResolvedValueOnce(mockResponse(okResponse));
+
+    const response = await triggerConstantContract({
+      ownerAddress: senderHex,
+      contractAddress: recipientHex,
+      functionSelector: "transfer(address,uint256)",
+      parameter: "deadbeef",
+    });
+
+    expect(mockedNetwork).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "POST",
+        url: expect.stringContaining("/wallet/triggerconstantcontract"),
+        data: {
+          owner_address: senderHex,
+          contract_address: recipientHex,
+          function_selector: "transfer(address,uint256)",
+          parameter: "deadbeef",
+        },
+      }),
+    );
+    expect(response.energy_used).toBe(14_170);
+    expect(response.result?.result).toBe(true);
+  });
+
+  it("returns the revert payload without throwing (caller decides what to do)", async () => {
+    mockedNetwork.mockResolvedValueOnce(mockResponse(revertResponse));
+
+    const response = await triggerConstantContract({
+      ownerAddress: senderHex,
+      contractAddress: recipientHex,
+      functionSelector: "transfer(address,uint256)",
+      parameter: "deadbeef",
+    });
+
+    expect(response.result?.result).toBe(false);
+    expect(response.result?.code).toBe("REVERT");
   });
 });

--- a/libs/coin-modules/coin-tron/src/network/index.ts
+++ b/libs/coin-modules/coin-tron/src/network/index.ts
@@ -38,12 +38,16 @@ import {
   AccountTronAPI,
   Block,
   BlockWithTransactionsAPI,
+  ChainParameters,
+  ChainParametersAPI,
   isTransactionTronAPI,
   MalformedTransactionTronAPI,
   TransactionInfoByBlockNumAPI,
   TransactionResponseTronAPI,
   TransactionTronAPI,
   Trc20API,
+  TriggerConstantContractParams,
+  TriggerConstantContractResponse,
 } from "./types";
 import { abiEncodeTrc20Transfer, hexToAscii } from "./utils";
 
@@ -209,6 +213,53 @@ export async function getDelegatedResource(
 }
 
 export const DEFAULT_TRC20_FEES_LIMIT = 50000000;
+
+export async function triggerConstantContract({
+  ownerAddress,
+  contractAddress,
+  functionSelector,
+  parameter,
+}: TriggerConstantContractParams): Promise<TriggerConstantContractResponse> {
+  return await post<unknown, TriggerConstantContractResponse>(`/wallet/triggerconstantcontract`, {
+    owner_address: ownerAddress,
+    contract_address: contractAddress,
+    function_selector: functionSelector,
+    parameter,
+  });
+}
+
+const CHAIN_PARAMETER_KEYS = {
+  energyFee: "getEnergyFee",
+  transactionFee: "getTransactionFee",
+  createAccountFee: "getCreateAccountFee",
+  createNewAccountFeeInSystemContract: "getCreateNewAccountFeeInSystemContract",
+} as const;
+
+const FALLBACK_CHAIN_PARAMETERS: ChainParameters = {
+  energyFee: 100,
+  transactionFee: 1000,
+  createAccountFee: 100_000,
+  createNewAccountFeeInSystemContract: 1_000_000,
+};
+
+const fetchChainParameters = async (): Promise<ChainParameters> => {
+  const data = await fetch<ChainParametersAPI>(`/wallet/getchainparameters`);
+  const byKey = new Map(data.chainParameter.map(entry => [entry.key, entry.value]));
+  const resolved = {} as ChainParameters;
+  let key: keyof ChainParameters;
+  for (key in CHAIN_PARAMETER_KEYS) {
+    const value = byKey.get(CHAIN_PARAMETER_KEYS[key]);
+    if (typeof value === "number") {
+      resolved[key] = value;
+    } else {
+      log("tron/chainParameters", `missing ${CHAIN_PARAMETER_KEYS[key]}, using fallback`);
+      resolved[key] = FALLBACK_CHAIN_PARAMETERS[key];
+    }
+  }
+  return resolved;
+};
+
+export const getChainParameters = makeLRUCache(fetchChainParameters, getBaseApiUrl, hours(1, 8));
 
 export async function craftTrc20Transaction(
   tokenAddress: string,

--- a/libs/coin-modules/coin-tron/src/network/types.ts
+++ b/libs/coin-modules/coin-tron/src/network/types.ts
@@ -222,3 +222,38 @@ export function isMalformedTransactionTronAPI(
     (tx as MalformedTransactionTronAPI).tx_id !== undefined
   );
 }
+
+//-- Chain parameters
+export type ChainParameterEntryAPI = {
+  key: string;
+  value?: number;
+};
+
+export type ChainParametersAPI = {
+  chainParameter: ChainParameterEntryAPI[];
+};
+
+export type ChainParameters = {
+  energyFee: number;
+  transactionFee: number;
+  createAccountFee: number;
+  createNewAccountFeeInSystemContract: number;
+};
+
+//-- Trigger constant contract
+export type TriggerConstantContractParams = {
+  ownerAddress: string;
+  contractAddress: string;
+  functionSelector: string;
+  parameter: string;
+};
+
+export type TriggerConstantContractResponse = {
+  energy_used?: number;
+  constant_result?: string[];
+  result?: {
+    result?: boolean;
+    code?: string;
+    message?: string;
+  };
+};

--- a/libs/coin-modules/coin-tron/src/test/bridgeDatasetTest.ts
+++ b/libs/coin-modules/coin-tron/src/test/bridgeDatasetTest.ts
@@ -492,16 +492,18 @@ const tron: CurrenciesData<Transaction> = {
             ),
             amount: new BigNumber("1000000"),
           }),
-          expectedStatus: {
+          // estimatedFees is now computed dynamically from chain params + simulation;
+          // we only assert the validation shape (NotEnoughGas + totalSpent).
+          expectedStatus: (_account, _transaction, status) => ({
             amount: new BigNumber("1000000"),
             errors: {
               gasLimit: new NotEnoughGas(),
             },
             warnings: {},
             totalSpent: new BigNumber("1000000"),
-            estimatedFees: new BigNumber("27600900"),
-          },
-        }, // FIXME account have moved...
+            estimatedFees: status.estimatedFees,
+          }),
+        },
 
         /*
       {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - The framework `estimateFees` path (wallet-cli, future MVVM screens via `CoinModuleApi`) now returns on-chain–accurate fees instead of constants.
  - The legacy bridge (`bridge/getEstimateFees.ts`) is mostly untouched, but its TRC20-to-inactive-recipient branch delegates to `logic/estimateFees`, so Ledger Wallet desktop/mobile will now show a real (smaller) fee for that case instead of the hardcoded `ACTIVATION_FEES_TRC_20 ≈ 27.6 TRX`.
  - New network calls per fee estimation: `triggerconstantcontract` (for TRC20) + `getchainparameters` (cached 1h LRU, keyed by base API URL).
  - QA focus: wallet-cli + LW Tron flows — native send, TRC10, TRC20 USDT — with senders that have vs. don't have frozen energy/bandwidth, and recipients that are active vs. inactive.

### 📝 Description

**Problem**: `libs/coin-modules/coin-tron/src/logic/estimateFees.ts` was returning hardcoded constants (`STANDARD_FEES_TRC_20 ≈ 13.74 TRX`, `STANDARD_FEES_NATIVE = 0.27 TRX`, etc.) regardless of the sender's on-chain state. It behaved as if the sender always had 0 bandwidth and 0 energy, so users with frozen TRX got phantom fees and the estimate diverged from reality whenever Tron governance updated `getEnergyFee`.

**Solution**: Rewrote `estimateFees` to compute the fee from real on-chain data:

- **Bandwidth fee** = `max(0, txSize - availableBandwidth) × transactionFee`. `txSize` is an empirical constant per intent type/asset (270/285/350/260/290 bytes) that mirrors `bridge/utils.ts:getEstimatedBlockSize`. These cover the **signed** tx (raw_data + signature + outer protobuf wrapping) — using `craftTransaction`'s `raw_data_hex` alone would underestimate by ~50%.
- **Energy fee** = `max(0, energy_used - availableEnergy) × energyFee`, where `energy_used` comes from a `/wallet/triggerconstantcontract` simulation of the actual transfer (only for TRC20). The simulation's `energy_used` already includes the dynamic energy penalty applied to popular contracts.
- **Activation fee** = `createAccountFee + createNewAccountFeeInSystemContract` only when the recipient is not active **and** the asset is native TRX — TRC20/TRC10 contract-implicit creation is covered by the higher `energy_used` returned by the simulation.
- **Chain parameters** (`energyFee`, `transactionFee`, `createAccountFee`, `createNewAccountFeeInSystemContract`) are fetched dynamically via a new `getChainParameters()` helper (cached 1h via `makeLRUCache`, keyed by base API URL) instead of being hardcoded.
- A pessimistic fallback is returned when any network call fails or when `triggerconstantcontract` reports a reverted simulation: `ACTIVATION_FEES` (1.1 TRX) for native/TRC10 and `STANDARD_FEES_TRC_20` (13.74 TRX) for TRC20 — both worst-case so the user never under-pays.

New network helpers added in `src/network/index.ts`:
- `triggerConstantContract({ ownerAddress, contractAddress, functionSelector, parameter })` — POSTs `/wallet/triggerconstantcontract` and returns `{ energy_used, result, ... }`.
- `getChainParameters()` — cached fetch of governance-voted chain params, with per-key fallbacks.

**Bridge impact**: `bridge/getEstimateFees.ts` is unchanged, but its TRC20-to-inactive-recipient branch already delegates to `logic/estimateFees`. The new framework implementation now returns a real dynamic value instead of the old hardcoded `ACTIVATION_FEES_TRC_20` (27.6 TRX). The bridge dataset test fixture `tronSendTrc20ToNewAccountForbidden` is updated to accept the dynamic value.

Test coverage:
- **Unit** (`src/logic/estimateFees.test.ts`, `src/network/index.test.ts`): 14 cases on `estimateFees` (native/TRC10/TRC20 × bandwidth states × activation × revert × fallback) + 5 on the new helpers (parse, missing-key fallback, cache, success, revert).
- **Integ** (`src/logic/estimateFees.integ.test.ts`, `src/network/index.integ.test.ts`): 7 cases against Tron mainnet, including a Super Representative sender (exact-value assertions like `= 0n` and `= createAccountFee + createNewAccountFeeInSystemContract`) and a determinism check.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31399](https://ledgerhq.atlassian.net/browse/LIVE-31399)

- **E2E**
  - Mobile: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/6ae254d6-a732-4335-a7ce-8be66c9685c6/#
  - Desktop: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/08d06c59-2d9d-4376-bd69-7e15c7f7d6c5/
---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31399]: https://ledgerhq.atlassian.net/browse/LIVE-31399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ