### PR TITLE
[LWDM] fix(live-common): wrap curried messageSigner for 5 coin families

### DIFF
--- a/.changeset/fix-curried-message-signer.md
+++ b/.changeset/fix-curried-message-signer.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Fix `messageSigner.signMessage` for casper, filecoin, internet_computer, stacks and ton families. They were exporting a curried `(signerContext) => MessageSignerFn` instead of the un-curried `SignMessage` required by `FamilySetup`, which would throw `TypeError` at runtime when invoked through `hw/signMessage`. Now wrapped with `createMessageSigner(createSigner, signMessage)` matching the evm/solana pattern. Vechain is unchanged (handled separately).

--- a/libs/ledger-live-common/src/coin-modules/loaders.ts
+++ b/libs/ledger-live-common/src/coin-modules/loaders.ts
@@ -61,7 +61,7 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
   },
   {
     family: "casper",
-    loadSetup: () => import("../families/casper/setup.js") as object as Promise<FamilySetup>,
+    loadSetup: () => import("../families/casper/setup.js"),
     loadTransaction: () => import("@ledgerhq/coin-casper/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-casper/deviceTransactionConfig").then(m => m.default),
@@ -114,7 +114,7 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
   },
   {
     family: "filecoin",
-    loadSetup: () => import("../families/filecoin/setup.js") as object as Promise<FamilySetup>,
+    loadSetup: () => import("../families/filecoin/setup.js"),
     loadTransaction: () => import("@ledgerhq/coin-filecoin/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-filecoin/deviceTransactionConfig").then(m => m.default),
@@ -137,8 +137,7 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
   },
   {
     family: "internet_computer",
-    loadSetup: () =>
-      import("../families/internet_computer/setup.js") as object as Promise<FamilySetup>,
+    loadSetup: () => import("../families/internet_computer/setup.js"),
     loadTransaction: () =>
       import("@ledgerhq/coin-internet_computer/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
@@ -204,7 +203,7 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
   },
   {
     family: "stacks",
-    loadSetup: () => import("../families/stacks/setup.js") as object as Promise<FamilySetup>,
+    loadSetup: () => import("../families/stacks/setup.js"),
     loadTransaction: () => import("@ledgerhq/coin-stacks/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-stacks/deviceTransactionConfig").then(m => m.default),
@@ -247,7 +246,7 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
   },
   {
     family: "ton",
-    loadSetup: () => import("../families/ton/setup.js") as object as Promise<FamilySetup>,
+    loadSetup: () => import("../families/ton/setup.js"),
     loadTransaction: () => import("@ledgerhq/coin-ton/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-ton/deviceTransactionConfig").then(m => m.default),

--- a/libs/ledger-live-common/src/families/casper/setup.ts
+++ b/libs/ledger-live-common/src/families/casper/setup.ts
@@ -7,7 +7,12 @@ import casperResolver from "@ledgerhq/coin-casper/signer";
 import { signMessage } from "@ledgerhq/coin-casper/hw-signMessage";
 import type { Account, Bridge } from "@ledgerhq/types-live";
 import makeCliTools from "@ledgerhq/coin-casper/test/cli";
-import { CreateSigner, createResolver, executeWithSigner } from "../../bridge/setup";
+import {
+  CreateSigner,
+  createMessageSigner,
+  createResolver,
+  executeWithSigner,
+} from "../../bridge/setup";
 import { Resolver } from "../../hw/getAddress/types";
 import { TransactionStatus, Transaction } from "@ledgerhq/coin-casper/types";
 import { CasperGetAddrResponse, CasperSignature, CasperSigner } from "./types";
@@ -48,7 +53,7 @@ const bridge: Bridge<Transaction, Account, TransactionStatus> = createBridges(
 );
 
 const messageSigner = {
-  signMessage,
+  signMessage: createMessageSigner(createSigner, signMessage),
 };
 
 const resolver: Resolver = createResolver(createSigner, casperResolver);

--- a/libs/ledger-live-common/src/families/filecoin/setup.ts
+++ b/libs/ledger-live-common/src/families/filecoin/setup.ts
@@ -7,7 +7,12 @@ import filecoinResolver from "@ledgerhq/coin-filecoin/signer/index";
 import { signMessage } from "@ledgerhq/coin-filecoin/hw-signMessage";
 import type { Account, Bridge } from "@ledgerhq/types-live";
 import makeCliTools from "@ledgerhq/coin-filecoin/test/cli";
-import { CreateSigner, createResolver, executeWithSigner } from "../../bridge/setup";
+import {
+  CreateSigner,
+  createMessageSigner,
+  createResolver,
+  executeWithSigner,
+} from "../../bridge/setup";
 import { Resolver } from "../../hw/getAddress/types";
 import { TransactionStatus, Transaction, FilecoinSigner } from "./types";
 import { getPath } from "./common";
@@ -26,7 +31,7 @@ const bridge: Bridge<Transaction, Account, TransactionStatus> = createBridges(
 );
 
 const messageSigner = {
-  signMessage,
+  signMessage: createMessageSigner(createSigner, signMessage),
 };
 
 const resolver: Resolver = createResolver(createSigner, filecoinResolver);

--- a/libs/ledger-live-common/src/families/internet_computer/setup.ts
+++ b/libs/ledger-live-common/src/families/internet_computer/setup.ts
@@ -7,7 +7,12 @@ import icpResolver from "@ledgerhq/coin-internet_computer/signer/index";
 import { signMessage } from "@ledgerhq/coin-internet_computer/hw-signMessage";
 import type { Account, Bridge } from "@ledgerhq/types-live";
 import makeCliTools from "@ledgerhq/coin-internet_computer/test/cli";
-import { CreateSigner, createResolver, executeWithSigner } from "../../bridge/setup";
+import {
+  CreateSigner,
+  createMessageSigner,
+  createResolver,
+  executeWithSigner,
+} from "../../bridge/setup";
 import { Resolver } from "../../hw/getAddress/types";
 import { TransactionStatus, Transaction } from "@ledgerhq/coin-internet_computer/types/index";
 import { ICPGetAddrResponse, ICPSignature, ICPSigner } from "./types";
@@ -42,7 +47,7 @@ const bridge: Bridge<Transaction, Account, TransactionStatus> = createBridges(
 );
 
 const messageSigner = {
-  signMessage,
+  signMessage: createMessageSigner(createSigner, signMessage),
 };
 
 const resolver: Resolver = createResolver(createSigner, icpResolver);

--- a/libs/ledger-live-common/src/families/stacks/setup.ts
+++ b/libs/ledger-live-common/src/families/stacks/setup.ts
@@ -6,7 +6,12 @@ import makeCliTools from "@ledgerhq/coin-stacks/test/cli";
 import Transport from "@ledgerhq/hw-transport";
 import { Bridge } from "@ledgerhq/types-live";
 import BlockstackApp from "@zondax/ledger-stacks";
-import { CreateSigner, createResolver, executeWithSigner } from "../../bridge/setup";
+import {
+  CreateSigner,
+  createMessageSigner,
+  createResolver,
+  executeWithSigner,
+} from "../../bridge/setup";
 import { Resolver } from "../../hw/getAddress/types";
 import { StacksSigner, Transaction } from "./types";
 
@@ -17,7 +22,7 @@ const createSigner: CreateSigner<StacksSigner> = (transport: Transport) => {
 const bridge: Bridge<Transaction> = createBridges(executeWithSigner(createSigner));
 
 const messageSigner = {
-  signMessage,
+  signMessage: createMessageSigner(createSigner, signMessage),
 };
 
 const resolver: Resolver = createResolver(createSigner, stacksResolver);

--- a/libs/ledger-live-common/src/families/ton/setup.ts
+++ b/libs/ledger-live-common/src/families/ton/setup.ts
@@ -10,7 +10,12 @@ import { TonAccount, Transaction } from "@ledgerhq/coin-ton/types";
 import Transport from "@ledgerhq/hw-transport";
 import type { Bridge } from "@ledgerhq/types-live";
 import { TonTransport as Ton } from "@ton-community/ton-ledger";
-import { CreateSigner, createResolver, executeWithSigner } from "../../bridge/setup";
+import {
+  CreateSigner,
+  createMessageSigner,
+  createResolver,
+  executeWithSigner,
+} from "../../bridge/setup";
 import { getCurrencyConfiguration } from "../../config";
 import type { Resolver } from "../../hw/getAddress/types";
 
@@ -25,7 +30,7 @@ const bridge: Bridge<Transaction, TonAccount> = createBridges(
 );
 
 const messageSigner = {
-  signMessage,
+  signMessage: createMessageSigner(createSigner, signMessage),
 };
 
 const resolver: Resolver = createResolver(createSigner, tonResolver);


### PR DESCRIPTION
> [!WARNING]
> The actual usage of message signing on these families isn't clear and the fix wasn't tested end-to-end. We first want to land the main PR (`chore/LIVE-29187`) on `develop` before merging this one.

### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.**
- [x] **Impact of the changes:** message signing on Casper, Filecoin, Internet Computer, Stacks and Ton previously crashed at runtime; QA should verify wallet-api `message.sign` on these coins.

### 📝 Description

5 family setups exported `messageSigner.signMessage` as a curried `(signerContext) => MessageSignerFn` instead of the un-curried `SignMessage`. Wrapped with `createMessageSigner(createSigner, signMessage)` (matching evm/solana) and removed the masking `as object as Promise<FamilySetup>` casts.

> [!NOTE]
> Vechain not fixed here: its `signMessage` is structurally a transaction signer (JSON in, hex out) and needs a separate design decision. Cast kept.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31427](https://ledgerhq.atlassian.net/browse/LIVE-31427)
- **Base branch**: targets `chore/LIVE-29187`.

[LIVE-31427]: https://ledgerhq.atlassian.net/browse/LIVE-31427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
