### PR TITLE
[LWD] fix(desktop): correct navbar padding on Asset Detail

### DIFF
--- a/.changeset/eleven-berries-report.md
+++ b/.changeset/eleven-berries-report.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix padding on Asset Detail navbar

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AssetHeader/AssetHeaderView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AssetHeader/AssetHeaderView.tsx
@@ -33,7 +33,7 @@ export function AssetHeaderView({
   return (
     <NavBar
       data-testid="asset-detail-header"
-      className="sticky top-0 z-10 w-full min-w-0 items-center gap-4 bg-canvas mb-12"
+      className="sticky top-0 z-10 w-full min-w-0 items-center gap-4 bg-canvas pb-12"
     >
       <NavBarBackButton onClick={onBack} />
       <NavBarCoinCapsule className="min-w-0 max-w-full" ticker={assetTicker} icon={icon} />


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Visual padding tweak — not covered by unit/integration tests._
- [x] **Impact of the changes:**
  - Asset Detail page navbar layout
  - Sticky header behavior on scroll
  - Spacing between header and content below

### 📝 Description

The Asset Detail navbar (sticky `AssetHeader`) used a bottom margin (`mb-12`) to space itself from the content below. Because the element is `sticky top-0`, the margin sits *outside* the sticky box, which produces incorrect spacing on scroll and offsets siblings rather than reserving room inside the header.

Swap `mb-12` for `pb-12` so the spacing lives inside the sticky container. The visual result on the initial layout is identical, while the sticky behavior on scroll now renders correctly.

<img width="332" height="128" alt="Screenshot 2026-05-26 at 19 07 10" src="https://github.com/user-attachments/assets/3645cbf6-5d7b-4ab7-9322-12c0aa761201" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31376](https://ledgerhq.atlassian.net/browse/LIVE-31376)

---



### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31376]: https://ledgerhq.atlassian.net/browse/LIVE-31376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ