### PR TITLE
[LWDM] chore(llc): bump coin-xrp to 7.21.7

### DIFF
--- a/.changeset/itchy-wasps-tickle.md
+++ b/.changeset/itchy-wasps-tickle.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+chore(llc): Update coin-xrp to 7.21.7

--- a/libs/ledger-live-common/src/coin-modules/loaders.ts
+++ b/libs/ledger-live-common/src/coin-modules/loaders.ts
@@ -108,8 +108,7 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
       ),
     loadSigner: () =>
       import("../bridge/generic-coin-framework/families/evm/signer.js").then(m => m.default),
-    loadBridgeExtensions: () =>
-      import("../families/evm/bridgeExtensions.js").then(m => m.default),
+    loadBridgeExtensions: () => import("../families/evm/bridgeExtensions.js").then(m => m.default),
   },
   {
     family: "filecoin",
@@ -258,8 +257,7 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-tron/deviceTransactionConfig").then(m => m.default),
     loadMockBridge: () => import("../families/tron/bridge/mock.js").then(m => m.default),
-    loadBridgeExtensions: () =>
-      import("../families/tron/bridgeExtensions.js").then(m => m.default),
+    loadBridgeExtensions: () => import("../families/tron/bridgeExtensions.js").then(m => m.default),
   },
   {
     family: "vechain",
@@ -281,7 +279,7 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
     loadPlatformAdapter: () => import("../families/xrp/platformAdapter.js").then(m => m.default),
     loadMockBridge: () => import("../families/xrp/bridge/mock.js").then(m => m.default),
     loadValidateAddress: () =>
-      import("@ledgerhq/coin-xrp/logic/validateAddress").then(
+      import("@ledgerhq/coin-xrp/api/validateAddress").then(
         ({ validateAddress }): ValidateAddressFn => validateAddress,
       ),
     loadSigner: () =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ catalogs:
       specifier: 3.1.0
       version: 3.1.0
     '@ledgerhq/coin-xrp':
-      specifier: 7.21.5
-      version: 7.21.5
+      specifier: 7.21.7
+      version: 7.21.7
     '@ledgerhq/crypto-icons':
       specifier: 2.0.3
       version: 2.0.3
@@ -7702,7 +7702,7 @@ importers:
         version: link:../coin-modules/coin-vechain
       '@ledgerhq/coin-xrp':
         specifier: 'catalog:'
-        version: 7.21.5(@ledgerhq/errors@libs+ledgerjs+packages+errors)(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)
+        version: 7.21.7(@ledgerhq/errors@libs+ledgerjs+packages+errors)(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../ledgerjs/packages/cryptoassets
@@ -17052,8 +17052,8 @@ packages:
     peerDependencies:
       '@ledgerhq/errors': ^6.33.0
 
-  '@ledgerhq/coin-xrp@7.21.5':
-    resolution: {integrity: sha512-N43q2AvOCJO2hAd+oEHYfU1HZH+W4cmqtwBvT6p1Hk9CYDYuuvPziV1NIiGinhuk36eBsBzJDIFn7q8J+tDC6A==}
+  '@ledgerhq/coin-xrp@7.21.7':
+    resolution: {integrity: sha512-g6LCOiECPU2sdYKb70+3kpmWHJtw+Dg3N8mAAuHxX5vDbmucqIz3WZRaMfchI6PY2zz34Vlt6i+hjeUgTtywUg==}
     peerDependencies:
       '@ledgerhq/errors': ^6.33.0
       '@ledgerhq/live-network': ^2.4.0
@@ -44554,7 +44554,7 @@ snapshots:
       '@ledgerhq/errors': link:libs/ledgerjs/packages/errors
       bignumber.js: 9.1.2
 
-  '@ledgerhq/coin-xrp@7.21.5(@ledgerhq/errors@libs+ledgerjs+packages+errors)(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)':
+  '@ledgerhq/coin-xrp@7.21.7(@ledgerhq/errors@libs+ledgerjs+packages+errors)(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)':
     dependencies:
       '@ledgerhq/coin-module-framework': 3.1.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/errors': link:libs/ledgerjs/packages/errors

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -198,7 +198,7 @@ catalog:
   oxfmt: 0.36.0
   # Modules published by coin-modules
   "@ledgerhq/coin-module-framework": 3.1.0
-  "@ledgerhq/coin-xrp": 7.21.5
+  "@ledgerhq/coin-xrp": 7.21.7
   detox: 20.51.1
 
 overrides:


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Version bump only — covered by existing coin-xrp tests._

### 📝 Description

Bumps `@ledgerhq/coin-xrp` from `7.21.5` to `7.21.7` in the workspace catalog.

Also updates the `loadValidateAddress` import path in `coin-modules/loaders.ts` from `@ledgerhq/coin-xrp/logic/validateAddress` to `@ledgerhq/coin-xrp/api/validateAddress` to match the new module layout shipped by coin-xrp 7.21.7.

### ❓ Context

- **JIRA or GitHub link**: _N/A_

- **E2E**
  - Desktop: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/b8dff3bb-362a-453b-b761-9891769b834a/
  - Mobile: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/0004234f-bd37-45b2-a52b-93752487691e/
---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)