### PR TITLE
[LWM] feat(mobile): track generic awareness modal interactions

### DIFF
--- a/.changeset/generic-awareness-modal-analytics.md
+++ b/.changeset/generic-awareness-modal-analytics.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add mobile analytics tracking for Generic Awareness Modal feature intro and carousel interactions

--- a/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/__integrations__/GenericAwarenessModal.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/__integrations__/GenericAwarenessModal.integration.test.tsx
@@ -1,9 +1,14 @@
 import React from "react";
 import { Linking } from "react-native";
 import { act, fireEvent, render, screen, waitFor } from "@tests/test-renderer";
+import { screen as analyticsScreen, track } from "~/analytics";
 import type { State } from "~/reducers/types";
 import { carouselMockData, featureIntroMockData } from "../mockData";
 import { GenericAwarenessModalDrawer } from "../screens/GenericAwarenessModalDrawer";
+import {
+  GENERIC_AWARENESS_MODAL_CAROUSEL_PAGE,
+  GENERIC_AWARENESS_MODAL_FEATURE_INTRO_PAGE,
+} from "../analytics";
 
 describe("GenericAwarenessModalDrawer", () => {
   if (featureIntroMockData.layout !== "featureIntro") {
@@ -26,6 +31,7 @@ describe("GenericAwarenessModalDrawer", () => {
   const carouselSlides = carouselMockData.data;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     jest.useFakeTimers();
   });
 
@@ -115,12 +121,35 @@ describe("GenericAwarenessModalDrawer", () => {
       expect(screen.getByText(featureIntroContent.subtitle)).toBeOnTheScreen();
       expect(screen.getByText("Full ownership")).toBeOnTheScreen();
       expect(screen.getByText("Your private keys never leave the device.")).toBeOnTheScreen();
+      expect(screen.getByText(featureIntroContent.title)).toHaveProp("numberOfLines", 2);
+      expect(screen.getByText(featureIntroContent.subtitle)).toHaveProp("numberOfLines", 3);
+      expect(screen.getByText("Full ownership")).toHaveProp("numberOfLines", 1);
+      expect(screen.getByText("Your private keys never leave the device.")).toHaveProp(
+        "numberOfLines",
+        2,
+      );
+      expect(analyticsScreen).toHaveBeenCalledWith(
+        GENERIC_AWARENESS_MODAL_FEATURE_INTRO_PAGE,
+        undefined,
+        {
+          name: GENERIC_AWARENESS_MODAL_FEATURE_INTRO_PAGE,
+          contentId: featureIntroMockData.id,
+        },
+      );
 
       await user.press(screen.getByText("Buy your Ledger device"));
       act(() => jest.runOnlyPendingTimers());
+
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "Buy your Ledger device",
+        page: GENERIC_AWARENESS_MODAL_FEATURE_INTRO_PAGE,
+        contentId: featureIntroMockData.id,
+        ctaPosition: "secondary",
+        link: featureIntroContent.secondaryButtonLink,
+      });
     });
 
-    it("should close the modal when the main button is pressed", async () => {
+    it("should close the modal and track the primary CTA when the main button is pressed", async () => {
       const { user } = render(<GenericAwarenessModalDrawer />, {
         overrideInitialState: withGenericAwarenessModal({
           isOpen: true,
@@ -131,6 +160,19 @@ describe("GenericAwarenessModalDrawer", () => {
 
       await user.press(screen.getByText("Connect"));
       act(() => jest.runOnlyPendingTimers());
+
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "Connect",
+        page: GENERIC_AWARENESS_MODAL_FEATURE_INTRO_PAGE,
+        contentId: featureIntroMockData.id,
+        ctaPosition: "primary",
+        link: featureIntroContent.primaryButtonLink,
+      });
+      expect(track).toHaveBeenCalledWith("drawer_dismissed", {
+        drawer: GENERIC_AWARENESS_MODAL_FEATURE_INTRO_PAGE,
+        page: GENERIC_AWARENESS_MODAL_FEATURE_INTRO_PAGE,
+        contentId: featureIntroMockData.id,
+      });
     });
 
     it("should close the modal when the close button is pressed", async () => {
@@ -147,6 +189,12 @@ describe("GenericAwarenessModalDrawer", () => {
       await user.press(closeButton);
       fireEvent(closeButton, "dismiss");
       act(() => jest.runOnlyPendingTimers());
+
+      expect(track).toHaveBeenCalledWith("drawer_dismissed", {
+        drawer: GENERIC_AWARENESS_MODAL_FEATURE_INTRO_PAGE,
+        page: GENERIC_AWARENESS_MODAL_FEATURE_INTRO_PAGE,
+        contentId: featureIntroMockData.id,
+      });
     });
   });
 
@@ -165,10 +213,33 @@ describe("GenericAwarenessModalDrawer", () => {
 
       expect(await screen.findAllByText(carouselSlides[0].title)).not.toHaveLength(0);
       expect(screen.getAllByText(carouselSlides[0].subtitle)).not.toHaveLength(0);
+      expect(screen.getAllByText(carouselSlides[0].title)[0]).toHaveProp("numberOfLines", 1);
+      expect(screen.getAllByText(carouselSlides[0].subtitle)[0]).toHaveProp("numberOfLines", 3);
       expect(screen.getAllByText("Continue")).not.toHaveLength(0);
+      expect(analyticsScreen).toHaveBeenCalledWith(
+        GENERIC_AWARENESS_MODAL_CAROUSEL_PAGE,
+        undefined,
+        {
+          name: GENERIC_AWARENESS_MODAL_CAROUSEL_PAGE,
+          contentId: carouselMockData.id,
+          step: 1,
+          stepName: carouselSlides[0].title,
+          totalSteps: carouselSlides.length,
+        },
+      );
 
       await user.press(screen.getAllByText("Continue")[0]);
       act(() => jest.runOnlyPendingTimers());
+
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "Continue",
+        page: GENERIC_AWARENESS_MODAL_CAROUSEL_PAGE,
+        contentId: carouselMockData.id,
+        ctaPosition: "primary",
+        step: 1,
+        stepName: carouselSlides[0].title,
+        totalSteps: carouselSlides.length,
+      });
     });
 
     it("should open the primary http link without closing the modal when the primary button is pressed", async () => {
@@ -197,6 +268,16 @@ describe("GenericAwarenessModalDrawer", () => {
 
       await waitFor(() => {
         expect(openURLSpy).toHaveBeenCalledWith(primarySlide.primaryButtonLink);
+      });
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: primarySlide.primaryButtonLabel,
+        page: GENERIC_AWARENESS_MODAL_CAROUSEL_PAGE,
+        contentId: carouselMockData.id,
+        ctaPosition: "secondary",
+        link: primarySlide.primaryButtonLink,
+        step: 1,
+        stepName: carouselSlides[0].title,
+        totalSteps: carouselSlides.length,
       });
       act(() => jest.runOnlyPendingTimers());
 
@@ -250,6 +331,15 @@ describe("GenericAwarenessModalDrawer", () => {
       await user.press(closeButton);
       fireEvent(closeButton, "dismiss");
       act(() => jest.runOnlyPendingTimers());
+
+      expect(track).toHaveBeenCalledWith("drawer_dismissed", {
+        drawer: GENERIC_AWARENESS_MODAL_CAROUSEL_PAGE,
+        page: GENERIC_AWARENESS_MODAL_CAROUSEL_PAGE,
+        contentId: carouselMockData.id,
+        step: 1,
+        stepName: carouselSlides[0].title,
+        totalSteps: carouselSlides.length,
+      });
 
       await waitFor(() => {
         expect(screen.queryAllByText(carouselSlides[0].title)).toHaveLength(0);

--- a/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/analytics.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/analytics.ts
@@ -1,0 +1,112 @@
+import {
+  GenericAwarenessModalLayout,
+  type GenericAwarenessModalCarousel,
+  type GenericAwarenessModalCarouselSlide,
+  type GenericAwarenessModalContentCard,
+  type GenericAwarenessModalFeatureIntro,
+} from "@ledgerhq/live-common/genericAwarenessModal";
+import { screen, track } from "~/analytics";
+
+export const GENERIC_AWARENESS_MODAL_FEATURE_INTRO_PAGE = "Awareness Modal Feature Intro";
+export const GENERIC_AWARENESS_MODAL_CAROUSEL_PAGE = "Awareness Modal Carousel";
+
+type CtaPosition = "primary" | "secondary";
+
+type ButtonClickedProperties = Readonly<{
+  ctaPosition?: CtaPosition;
+  slideIndex?: number;
+  link?: string;
+}>;
+
+const getGenericAwarenessModalPage = (content: GenericAwarenessModalContentCard): string =>
+  content.layout === GenericAwarenessModalLayout.Carousel
+    ? GENERIC_AWARENESS_MODAL_CAROUSEL_PAGE
+    : GENERIC_AWARENESS_MODAL_FEATURE_INTRO_PAGE;
+
+const getCarouselStepProperties = (
+  carousel: GenericAwarenessModalCarousel,
+  slideIndex: number,
+) => ({
+  step: slideIndex + 1,
+  stepName: carousel.data[slideIndex]?.title ?? "",
+  totalSteps: carousel.data.length,
+});
+
+export const trackGenericAwarenessModalFeatureIntroViewed = (
+  featureIntro: GenericAwarenessModalFeatureIntro,
+) => {
+  screen(GENERIC_AWARENESS_MODAL_FEATURE_INTRO_PAGE, undefined, {
+    name: GENERIC_AWARENESS_MODAL_FEATURE_INTRO_PAGE,
+    contentId: featureIntro.id,
+  });
+};
+
+export const trackGenericAwarenessModalCarouselStepViewed = (
+  carousel: GenericAwarenessModalCarousel,
+  slideIndex: number,
+) => {
+  screen(GENERIC_AWARENESS_MODAL_CAROUSEL_PAGE, undefined, {
+    name: GENERIC_AWARENESS_MODAL_CAROUSEL_PAGE,
+    contentId: carousel.id,
+    ...getCarouselStepProperties(carousel, slideIndex),
+  });
+};
+
+export const trackGenericAwarenessModalButtonClicked = (
+  content: GenericAwarenessModalContentCard,
+  button: string,
+  { ctaPosition, slideIndex, link }: ButtonClickedProperties = {},
+) => {
+  track("button_clicked", {
+    button,
+    page: getGenericAwarenessModalPage(content),
+    contentId: content.id,
+    ...(ctaPosition ? { ctaPosition } : {}),
+    ...(link !== undefined ? { link } : {}),
+    ...(content.layout === GenericAwarenessModalLayout.Carousel && slideIndex !== undefined
+      ? getCarouselStepProperties(content, slideIndex)
+      : {}),
+  });
+};
+
+export const trackGenericAwarenessModalDismissed = (
+  content: GenericAwarenessModalContentCard,
+  slideIndex?: number,
+) => {
+  const page = getGenericAwarenessModalPage(content);
+
+  track("drawer_dismissed", {
+    drawer: page,
+    page,
+    contentId: content.id,
+    ...(content.layout === GenericAwarenessModalLayout.Carousel && slideIndex !== undefined
+      ? getCarouselStepProperties(content, slideIndex)
+      : {}),
+  });
+};
+
+export const trackGenericAwarenessModalTourCompleted = (
+  carousel: GenericAwarenessModalCarousel,
+  slideIndex: number,
+) => {
+  track("tour_completed", {
+    page: GENERIC_AWARENESS_MODAL_CAROUSEL_PAGE,
+    contentId: carousel.id,
+    ...getCarouselStepProperties(carousel, slideIndex),
+  });
+};
+
+export const trackGenericAwarenessModalMalformedUrl = (
+  carousel: GenericAwarenessModalCarousel,
+  slideIndex: number,
+) => {
+  track("malformed_url", {
+    page: GENERIC_AWARENESS_MODAL_CAROUSEL_PAGE,
+    contentId: carousel.id,
+    ...getCarouselStepProperties(carousel, slideIndex),
+  });
+};
+
+export const isGenericAwarenessModalExternalLink = (
+  slide: GenericAwarenessModalCarouselSlide,
+): boolean => slide.primaryButtonLink.startsWith("http");

--- a/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/components/CarouselContent.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/components/CarouselContent.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useMemo, useState } from "react";
-import { Slides } from "@ledgerhq/native-ui";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Slides, useSlidesContext } from "@ledgerhq/native-ui";
 import { StyleSheet } from "react-native";
 import { FlatList } from "react-native-gesture-handler";
 import Animated from "react-native-reanimated";
@@ -11,13 +11,24 @@ import { CarouselSlideItem } from "./CarouselSlideItem";
 type CarouselContentProps = Readonly<{
   slides: GenericAwarenessModalCarouselSlide[];
   onClose: () => void;
+  onSlideViewed: (slideIndex: number, isLastSlide: boolean) => void;
+  onNavigationPress: (slideIndex: number, button: string, isLastSlide: boolean) => void;
+  onPrimaryPress: (slideIndex: number) => void;
+  onMalformedUrl: (slideIndex: number) => void;
 }>;
 
 const AnimatedGestureHandlerFlatList = Animated.createAnimatedComponent(FlatList);
 
 const DEFAULT_LINE_COUNT = 1;
 
-export function CarouselContent({ slides, onClose }: CarouselContentProps) {
+export function CarouselContent({
+  slides,
+  onClose,
+  onSlideViewed,
+  onNavigationPress,
+  onPrimaryPress,
+  onMalformedUrl,
+}: CarouselContentProps) {
   const [titleLineCounts, setTitleLineCounts] = useState<number[]>(() =>
     slides.map(() => DEFAULT_LINE_COUNT),
   );
@@ -80,10 +91,31 @@ export function CarouselContent({ slides, onClose }: CarouselContentProps) {
       </Slides.ProgressIndicator>
 
       <Slides.Footer>
-        <CarouselFooterButton slides={slides} onClose={onClose} />
+        <CarouselSlideViewedTracker onSlideViewed={onSlideViewed} />
+        <CarouselFooterButton
+          slides={slides}
+          onClose={onClose}
+          onNavigationPress={onNavigationPress}
+          onPrimaryPress={onPrimaryPress}
+          onMalformedUrl={onMalformedUrl}
+        />
       </Slides.Footer>
     </Slides>
   );
+}
+
+type CarouselSlideViewedTrackerProps = Readonly<{
+  onSlideViewed: (slideIndex: number, isLastSlide: boolean) => void;
+}>;
+
+function CarouselSlideViewedTracker({ onSlideViewed }: CarouselSlideViewedTrackerProps) {
+  const { currentIndex, totalSlides } = useSlidesContext();
+
+  useEffect(() => {
+    onSlideViewed(currentIndex, currentIndex === totalSlides - 1);
+  }, [currentIndex, onSlideViewed, totalSlides]);
+
+  return null;
 }
 
 const styles = StyleSheet.create({

--- a/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/components/CarouselFooterButton.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/components/CarouselFooterButton.tsx
@@ -9,6 +9,9 @@ import type { GenericAwarenessModalCarouselSlide } from "@ledgerhq/live-common/g
 type CarouselFooterButtonProps = Readonly<{
   slides: GenericAwarenessModalCarouselSlide[];
   onClose: () => void;
+  onNavigationPress: (slideIndex: number, button: string, isLastSlide: boolean) => void;
+  onPrimaryPress: (slideIndex: number) => void;
+  onMalformedUrl: (slideIndex: number) => void;
 }>;
 
 const PRIMARY_BUTTON_SPACING = 12;
@@ -16,7 +19,13 @@ const PRIMARY_BUTTON_SPACING = 12;
 const hasPrimaryButton = (slide: GenericAwarenessModalCarouselSlide) =>
   Boolean(slide.primaryButtonLink && slide.primaryButtonLabel);
 
-export function CarouselFooterButton({ slides, onClose }: CarouselFooterButtonProps) {
+export function CarouselFooterButton({
+  slides,
+  onClose,
+  onNavigationPress,
+  onPrimaryPress,
+  onMalformedUrl,
+}: CarouselFooterButtonProps) {
   const { t } = useTranslation();
   const { currentIndex, goToNext, scrollProgressSharedValue } = useSlidesContext();
   const primaryButtonHeight = useSharedValue(0);
@@ -54,12 +63,16 @@ export function CarouselFooterButton({ slides, onClose }: CarouselFooterButtonPr
     [primaryButtonHeight],
   );
 
-  const onPrimaryPress = async (slide: GenericAwarenessModalCarouselSlide) => {
+  const handlePrimaryPress = async (
+    slide: GenericAwarenessModalCarouselSlide,
+    slideIndex: number,
+  ) => {
     if (!slide.primaryButtonLink) {
       return;
     }
 
     const isExternalLink = slide.primaryButtonLink.startsWith("http");
+    onPrimaryPress(slideIndex);
 
     try {
       await Linking.openURL(slide.primaryButtonLink);
@@ -67,11 +80,14 @@ export function CarouselFooterButton({ slides, onClose }: CarouselFooterButtonPr
         requestAnimationFrame(onClose);
       }
     } catch {
-      // TODO: track("malformed_url")
+      onMalformedUrl(slideIndex);
     }
   };
 
-  const onNavigationPress = () => {
+  const handleNavigationPress = () => {
+    const button = isLastSlide ? t("common.close") : t("common.continue");
+    onNavigationPress(currentIndex, button, isLastSlide);
+
     if (!isLastSlide) {
       goToNext();
       return;
@@ -82,7 +98,7 @@ export function CarouselFooterButton({ slides, onClose }: CarouselFooterButtonPr
 
   return (
     <Box lx={{ position: "relative" }}>
-      <Button appearance="base" size="lg" onPress={onNavigationPress}>
+      <Button appearance="base" size="lg" onPress={handleNavigationPress}>
         {isLastSlide ? t("common.close") : t("common.continue")}
       </Button>
       <Box pointerEvents="none" style={styles.primaryButtonMeasurer} accessibilityElementsHidden>
@@ -93,7 +109,11 @@ export function CarouselFooterButton({ slides, onClose }: CarouselFooterButtonPr
 
           return (
             <Box key={slideIndex} onLayout={onPrimaryButtonLayout}>
-              <Button appearance="gray" size="lg" onPress={() => onPrimaryPress(slide)}>
+              <Button
+                appearance="gray"
+                size="lg"
+                onPress={() => handlePrimaryPress(slide, slideIndex)}
+              >
                 {slide.primaryButtonLabel}
               </Button>
             </Box>
@@ -111,7 +131,7 @@ export function CarouselFooterButton({ slides, onClose }: CarouselFooterButtonPr
             key={slideIndex}
             slide={slide}
             slideIndex={slideIndex}
-            onPress={onPrimaryPress}
+            onPress={handlePrimaryPress}
           />
         ))}
       </Animated.View>
@@ -122,7 +142,7 @@ export function CarouselFooterButton({ slides, onClose }: CarouselFooterButtonPr
 type CarouselPrimaryButtonProps = Readonly<{
   slide: GenericAwarenessModalCarouselSlide;
   slideIndex: number;
-  onPress: (slide: GenericAwarenessModalCarouselSlide) => void;
+  onPress: (slide: GenericAwarenessModalCarouselSlide, slideIndex: number) => void;
 }>;
 
 function CarouselPrimaryButton({ slide, slideIndex, onPress }: CarouselPrimaryButtonProps) {
@@ -150,7 +170,7 @@ function CarouselPrimaryButton({ slide, slideIndex, onPress }: CarouselPrimaryBu
       accessibilityElementsHidden={!isCurrentSlide}
       importantForAccessibility={isCurrentSlide ? "auto" : "no-hide-descendants"}
     >
-      <Button appearance="gray" size="lg" onPress={() => onPress(slide)}>
+      <Button appearance="gray" size="lg" onPress={() => onPress(slide, slideIndex)}>
         {slide.primaryButtonLabel}
       </Button>
     </Animated.View>

--- a/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/components/CarouselSlideItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/components/CarouselSlideItem.tsx
@@ -4,7 +4,7 @@ import { StyleSheet } from "react-native";
 import FastImage from "react-native-fast-image";
 import type { GenericAwarenessModalCarouselSlide } from "@ledgerhq/live-common/genericAwarenessModal";
 
-const TITLE_NUMBER_OF_LINES = 2;
+const TITLE_NUMBER_OF_LINES = 1;
 const SUBTITLE_NUMBER_OF_LINES = 3;
 
 type CarouselSlideItemProps = GenericAwarenessModalCarouselSlide &
@@ -93,6 +93,6 @@ export function CarouselSlideItem({
 const styles = StyleSheet.create({
   image: {
     width: "80%",
-    aspectRatio: 9 / 16,
+    aspectRatio: 2 / 3,
   },
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/components/FeatureIntroContent.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/components/FeatureIntroContent.tsx
@@ -7,9 +7,21 @@ import type { GenericAwarenessModalFeatureIntro } from "@ledgerhq/live-common/ge
 type FeatureIntroContentProps = Readonly<{
   content: GenericAwarenessModalFeatureIntro;
   onClose: () => void;
+  onPrimaryPress: () => void;
+  onSecondaryPress: () => void;
 }>;
 
-export function FeatureIntroContent({ content, onClose }: FeatureIntroContentProps) {
+const TITLE_NUMBER_OF_LINES = 2;
+const SUBTITLE_NUMBER_OF_LINES = 3;
+const ITEM_TITLE_NUMBER_OF_LINES = 1;
+const ITEM_SUBTITLE_NUMBER_OF_LINES = 2;
+
+export function FeatureIntroContent({
+  content,
+  onClose,
+  onPrimaryPress,
+  onSecondaryPress,
+}: FeatureIntroContentProps) {
   const {
     imageUrl,
     title,
@@ -21,7 +33,9 @@ export function FeatureIntroContent({ content, onClose }: FeatureIntroContentPro
     secondaryButtonLink,
   } = content;
 
-  const handleButtonPress = async (link: string) => {
+  const handleButtonPress = async (link: string, onPress: () => void) => {
+    onPress();
+
     if (link) {
       try {
         await Linking.openURL(link);
@@ -52,6 +66,7 @@ export function FeatureIntroContent({ content, onClose }: FeatureIntroContentPro
           color: "base",
           marginBottom: "s2",
         }}
+        numberOfLines={TITLE_NUMBER_OF_LINES}
       >
         {title}
       </Text>
@@ -62,6 +77,7 @@ export function FeatureIntroContent({ content, onClose }: FeatureIntroContentPro
           color: "muted",
           marginBottom: "s8",
         }}
+        numberOfLines={SUBTITLE_NUMBER_OF_LINES}
       >
         {subtitle}
       </Text>
@@ -79,10 +95,15 @@ export function FeatureIntroContent({ content, onClose }: FeatureIntroContentPro
                   lx={{
                     color: "base",
                   }}
+                  numberOfLines={ITEM_TITLE_NUMBER_OF_LINES}
                 >
                   {item.title}
                 </Text>
-                <Text typography="body2" lx={{ color: "muted" }}>
+                <Text
+                  typography="body2"
+                  lx={{ color: "muted" }}
+                  numberOfLines={ITEM_SUBTITLE_NUMBER_OF_LINES}
+                >
                   {item.subtitle}
                 </Text>
               </Box>
@@ -91,10 +112,18 @@ export function FeatureIntroContent({ content, onClose }: FeatureIntroContentPro
         })}
       </Box>
 
-      <Button appearance="base" size="lg" onPress={() => handleButtonPress(primaryButtonLink)}>
+      <Button
+        appearance="base"
+        size="lg"
+        onPress={() => handleButtonPress(primaryButtonLink, onPrimaryPress)}
+      >
         {primaryButtonLabel}
       </Button>
-      <Button appearance="gray" size="lg" onPress={() => handleButtonPress(secondaryButtonLink)}>
+      <Button
+        appearance="gray"
+        size="lg"
+        onPress={() => handleButtonPress(secondaryButtonLink, onSecondaryPress)}
+      >
         {secondaryButtonLabel}
       </Button>
     </Box>

--- a/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/components/GenericAwarenessModalDrawer.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/components/GenericAwarenessModalDrawer.tsx
@@ -11,6 +11,12 @@ type GenericAwarenessModalDrawerViewProps = Readonly<{
   onClose: () => void;
   data: GenericAwarenessModalContentCard | undefined;
   bottomInset: number;
+  onFeatureIntroPrimaryPress: () => void;
+  onFeatureIntroSecondaryPress: () => void;
+  onCarouselSlideViewed: (slideIndex: number, isLastSlide: boolean) => void;
+  onCarouselNavigationPress: (slideIndex: number, button: string, isLastSlide: boolean) => void;
+  onCarouselPrimaryPress: (slideIndex: number) => void;
+  onCarouselMalformedUrl: (slideIndex: number) => void;
 }>;
 
 export function GenericAwarenessModalDrawerView({
@@ -18,6 +24,12 @@ export function GenericAwarenessModalDrawerView({
   onClose,
   data,
   bottomInset,
+  onFeatureIntroPrimaryPress,
+  onFeatureIntroSecondaryPress,
+  onCarouselSlideViewed,
+  onCarouselNavigationPress,
+  onCarouselPrimaryPress,
+  onCarouselMalformedUrl,
 }: GenericAwarenessModalDrawerViewProps) {
   if (!data) {
     return null;
@@ -29,11 +41,27 @@ export function GenericAwarenessModalDrawerView({
     if (!isOpen) return null;
 
     if (data.layout === "carousel") {
-      return <CarouselContent slides={data.data} onClose={onClose} />;
+      return (
+        <CarouselContent
+          slides={data.data}
+          onClose={onClose}
+          onSlideViewed={onCarouselSlideViewed}
+          onNavigationPress={onCarouselNavigationPress}
+          onPrimaryPress={onCarouselPrimaryPress}
+          onMalformedUrl={onCarouselMalformedUrl}
+        />
+      );
     }
 
     if (data.layout === "featureIntro") {
-      return <FeatureIntroContent content={data} onClose={onClose} />;
+      return (
+        <FeatureIntroContent
+          content={data}
+          onClose={onClose}
+          onPrimaryPress={onFeatureIntroPrimaryPress}
+          onSecondaryPress={onFeatureIntroSecondaryPress}
+        />
+      );
     }
 
     return null;

--- a/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/components/__tests__/FeatureIntroContent.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/components/__tests__/FeatureIntroContent.test.tsx
@@ -31,8 +31,23 @@ const content: GenericAwarenessModalFeatureIntro = {
 };
 
 describe("FeatureIntroContent", () => {
+  const renderFeatureIntroContent = (props?: {
+    readonly onClose?: () => void;
+    readonly onPrimaryPress?: () => void;
+    readonly onSecondaryPress?: () => void;
+    readonly content?: GenericAwarenessModalFeatureIntro;
+  }) =>
+    render(
+      <FeatureIntroContent
+        content={props?.content ?? content}
+        onClose={props?.onClose ?? jest.fn()}
+        onPrimaryPress={props?.onPrimaryPress ?? jest.fn()}
+        onSecondaryPress={props?.onSecondaryPress ?? jest.fn()}
+      />,
+    );
+
   it("should render the feature intro content", () => {
-    render(<FeatureIntroContent content={content} onClose={jest.fn()} />);
+    renderFeatureIntroContent();
 
     expect(screen.getByText("Connect a Ledger device")).toBeOnTheScreen();
     expect(
@@ -46,7 +61,7 @@ describe("FeatureIntroContent", () => {
 
   it("should call onClose when action buttons are pressed", async () => {
     const onClose = jest.fn();
-    const { user } = render(<FeatureIntroContent content={content} onClose={onClose} />);
+    const { user } = renderFeatureIntroContent({ onClose });
 
     await user.press(screen.getByText("Connect"));
     await user.press(screen.getByText("Buy your Ledger device"));
@@ -66,7 +81,7 @@ describe("FeatureIntroContent", () => {
       ],
     };
 
-    render(<FeatureIntroContent content={contentWithInvalidIcon} onClose={jest.fn()} />);
+    renderFeatureIntroContent({ content: contentWithInvalidIcon });
 
     expect(screen.getByText("Fallback icon item")).toBeOnTheScreen();
     expect(screen.getByText("This item still renders.")).toBeOnTheScreen();

--- a/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/screens/useGenericAwarenessModalDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/screens/useGenericAwarenessModalDrawerViewModel.ts
@@ -1,7 +1,8 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useIsFocused } from "@react-navigation/native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { GenericAwarenessModalLayout } from "@ledgerhq/live-common/genericAwarenessModal";
 import { useDispatch, useSelector } from "~/context/hooks";
 import { setDismissedContentCard } from "~/actions/settings";
 import {
@@ -14,9 +15,19 @@ import {
   selectIsGenericAwarenessModalOpen,
 } from "~/reducers/genericAwarenessModal";
 import { useGenericAwarenessModalLogic } from "./useGenericAwarenessModalLogic";
+import {
+  trackGenericAwarenessModalButtonClicked,
+  trackGenericAwarenessModalCarouselStepViewed,
+  trackGenericAwarenessModalDismissed,
+  trackGenericAwarenessModalFeatureIntroViewed,
+  trackGenericAwarenessModalMalformedUrl,
+  trackGenericAwarenessModalTourCompleted,
+} from "../analytics";
 
 export function useGenericAwarenessModalDrawerViewModel() {
   const dispatch = useDispatch();
+  const currentCarouselSlideIndexRef = useRef(0);
+  const displayedFeatureIntroIdRef = useRef<string | undefined>(undefined);
   const isPortfolioFocused = useIsFocused();
   const { bottom: bottomInset } = useSafeAreaInsets();
   const genericAwarenessModalFlag = useFeature("lwmGenericAwarenessModal");
@@ -42,7 +53,110 @@ export function useGenericAwarenessModalDrawerViewModel() {
     },
   );
 
+  useEffect(() => {
+    if (!isOpen) {
+      displayedFeatureIntroIdRef.current = undefined;
+      currentCarouselSlideIndexRef.current = 0;
+      return;
+    }
+
+    if (
+      data?.layout === GenericAwarenessModalLayout.FeatureIntro &&
+      displayedFeatureIntroIdRef.current !== data.id
+    ) {
+      displayedFeatureIntroIdRef.current = data.id;
+      trackGenericAwarenessModalFeatureIntroViewed(data);
+    }
+  }, [data, isOpen]);
+
+  const onFeatureIntroPrimaryPress = useCallback(() => {
+    if (data?.layout !== GenericAwarenessModalLayout.FeatureIntro) {
+      return;
+    }
+
+    trackGenericAwarenessModalButtonClicked(data, data.primaryButtonLabel, {
+      ctaPosition: "primary",
+      link: data.primaryButtonLink,
+    });
+  }, [data]);
+
+  const onFeatureIntroSecondaryPress = useCallback(() => {
+    if (data?.layout !== GenericAwarenessModalLayout.FeatureIntro) {
+      return;
+    }
+
+    trackGenericAwarenessModalButtonClicked(data, data.secondaryButtonLabel, {
+      ctaPosition: "secondary",
+      link: data.secondaryButtonLink,
+    });
+  }, [data]);
+
+  const onCarouselSlideViewed = useCallback(
+    (slideIndex: number, isLastSlide: boolean) => {
+      if (data?.layout !== GenericAwarenessModalLayout.Carousel) {
+        return;
+      }
+
+      currentCarouselSlideIndexRef.current = slideIndex;
+      trackGenericAwarenessModalCarouselStepViewed(data, slideIndex);
+
+      if (isLastSlide) {
+        trackGenericAwarenessModalTourCompleted(data, slideIndex);
+      }
+    },
+    [data],
+  );
+
+  const onCarouselNavigationPress = useCallback(
+    (slideIndex: number, button: string) => {
+      if (data?.layout !== GenericAwarenessModalLayout.Carousel) {
+        return;
+      }
+
+      trackGenericAwarenessModalButtonClicked(data, button, {
+        ctaPosition: "primary",
+        slideIndex,
+      });
+    },
+    [data],
+  );
+
+  const onCarouselPrimaryPress = useCallback(
+    (slideIndex: number) => {
+      if (data?.layout !== GenericAwarenessModalLayout.Carousel) {
+        return;
+      }
+
+      const slide = data.data[slideIndex];
+      if (!slide) {
+        return;
+      }
+
+      trackGenericAwarenessModalButtonClicked(data, slide.primaryButtonLabel, {
+        ctaPosition: "secondary",
+        slideIndex,
+        link: slide.primaryButtonLink,
+      });
+    },
+    [data],
+  );
+
+  const onCarouselMalformedUrl = useCallback(
+    (slideIndex: number) => {
+      if (data?.layout !== GenericAwarenessModalLayout.Carousel) {
+        return;
+      }
+
+      trackGenericAwarenessModalMalformedUrl(data, slideIndex);
+    },
+    [data],
+  );
+
   const onClose = useCallback(() => {
+    if (data) {
+      trackGenericAwarenessModalDismissed(data, currentCarouselSlideIndexRef.current);
+    }
+
     if (data && shouldMarkAsRead) {
       dispatch(setDismissedContentCard({ [data.id]: Date.now() }));
       dispatch(markGenericAwarenessModalContentCardAsRead({ id: data.id }));
@@ -56,5 +170,11 @@ export function useGenericAwarenessModalDrawerViewModel() {
     data,
     bottomInset: bottomInset + 20,
     onClose,
+    onFeatureIntroPrimaryPress,
+    onFeatureIntroSecondaryPress,
+    onCarouselSlideViewed,
+    onCarouselNavigationPress,
+    onCarouselPrimaryPress,
+    onCarouselMalformedUrl,
   };
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Generic Awareness Modal Feature Intro analytics on mobile
  - Generic Awareness Modal Carousel analytics on mobile
  - CTA, dismissal, slide-view, and tour-completion tracking payloads

### 📝 Description

This PR implements the mobile tracking plan for Generic Awareness Modals so Feature Intro and Carousel exposures/interactions can be measured with their campaign-backed `contentId`.

The implementation adds mobile-only analytics helpers, wires the modal view model to emit display, CTA, dismiss, slide-view, and tour-completion events, and covers the product tracking behavior in integration tests. Prompt tracking remains out of scope because there is no Generic Awareness Modal Prompt layout in the current mobile implementation.


https://github.com/user-attachments/assets/ecb77e04-5a05-451e-9467-292c1c563d9d


https://github.com/user-attachments/assets/fb2a9faf-4fda-46f6-a28d-5b8d83cd6014



### ❓ Context

- **JIRA or GitHub link**: [LIVE-29134](https://ledgerhq.atlassian.net/browse/LIVE-29134)
- https://ledgerhq.atlassian.net/browse/LIVE-31465
- https://ledgerhq.atlassian.net/browse/LIVE-31466

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-29134]: https://ledgerhq.atlassian.net/browse/LIVE-29134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ