### PR TITLE
ci(desktop): make speculos allure publishing non-blocking

### DIFF
--- a/.github/workflows/test-desktop-reusable.yml
+++ b/.github/workflows/test-desktop-reusable.yml
@@ -217,6 +217,7 @@ jobs:
           SPECULOS_FIRMWARE_VERSION: ${{ env.SMOKE_SPECULOS_FIRMWARE_VERSION }}
       - name: Upload Allure Results
         if: ${{ !cancelled() }}
+        continue-on-error: true
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: allure-results-speculos-smoke
@@ -224,6 +225,7 @@ jobs:
       - name: Publish Allure report
         id: publish-allure
         if: ${{ !cancelled() }}
+        continue-on-error: true
         uses: LedgerHQ/ledger-live/tools/actions/composites/upload-allure-report@develop
         with:
           login: ${{ vars.ALLURE_USERNAME }}


### PR DESCRIPTION
### ✅ Checklist

- [x] Changeset not required: workflow-only CI change.
- [ ] **Covered by automatic tests.** _Workflow YAML was validated with Prettier and IDE diagnostics; this change affects GitHub Actions behavior._
- [x] **Impact of the changes:**
      - Desktop Speculos E2E required check behavior
      - Allure artifact upload and report publication failure handling
      - PR check summary fallback when the Allure URL is unavailable

### 📝 Description

This PR makes the Allure upload and publication steps in the Desktop Speculos smoke E2E workflow non-blocking.

The Speculos E2E test step remains blocking for CI, so failed tests still fail the required check. If the tests pass but Allure upload or report publication fails, the job can still succeed and developers can merge.

### ❓ Context

- **JIRA or GitHub link**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)