### PR TITLE
[LWM] feat(mobile): switch device mode from polling to event

### DIFF
--- a/.changeset/swift-devices-stream.md
+++ b/.changeset/swift-devices-stream.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Switch device mode from polling to event-based transport

--- a/apps/ledger-live-mobile/src/live-common-setup.ts
+++ b/apps/ledger-live-mobile/src/live-common-setup.ts
@@ -23,7 +23,7 @@ listen(log => {
 });
 
 setGlobalOnBridgeError(e => logger.critical(e));
-setDeviceMode("polling");
+setDeviceMode("event");
 setWalletAPIVersion(WALLET_API_VERSION);
 liveBlindSigningReporter.setContext({
   platform: "mobile",


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Transport mode change verified via manual QA on physical devices (BLE/USB on iOS and Android); not feasible to cover with unit tests at this layer._
- [x] **Impact of the changes:**
  - BLE and USB device connections on mobile
  - Firmware update flow (OTA)
  - App install/uninstall via Manager
  - iOS and Android platforms

### Description

This PR switches the mobile device transport mode from `"polling"` to `"event"` in the live-common setup.

**Problem**: The mobile app currently uses the `"polling"` transport mode. Polling is less reliable and creates an inconsistent runtime behavior compared to desktop, which already runs on the event-based transport.

**Solution**: Set `setDeviceMode("event")` in `apps/ledger-live-mobile/src/live-common-setup.ts`. The event-based transport is more stable and aligns mobile with desktop, giving us a single, consistent device-communication path across platforms.

\`\`\`diff
-setDeviceMode(\"polling\");
+setDeviceMode(\"event\");
\`\`\`

### Context

- **JIRA or GitHub link**: [LIVE-25566](https://ledgerhq.atlassian.net/browse/LIVE-25566)

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-25566]: https://ledgerhq.atlassian.net/browse/LIVE-25566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ