### PR TITLE
fix(mobile): patch lumen Switch thumb to use RN Animated

### DIFF
--- a/package.json
+++ b/package.json
@@ -326,7 +326,8 @@
       "@callstack/repack@5.2.5": "patches/@callstack__repack@5.2.5.patch",
       "bigint-buffer@1.1.5": "patches/bigint-buffer@1.1.5.patch",
       "usb@2.17.0": "patches/usb@2.17.0.patch",
-      "react-native-worklets@0.8.1": "patches/react-native-worklets@0.8.1.patch"
+      "react-native-worklets@0.8.1": "patches/react-native-worklets@0.8.1.patch",
+      "@ledgerhq/lumen-ui-rnative@0.1.36": "patches/@ledgerhq__lumen-ui-rnative@0.1.36.patch"
     },
     "packageExtensions": {
       "eslint-config-next@*": {

--- a/patches/@ledgerhq__lumen-ui-rnative@0.1.36.patch
+++ b/patches/@ledgerhq__lumen-ui-rnative@0.1.36.patch
@@ -1,0 +1,69 @@
+diff --git a/src/lib/Components/Switch/BaseSwitch.tsx b/src/lib/Components/Switch/BaseSwitch.tsx
+--- a/src/lib/Components/Switch/BaseSwitch.tsx
++++ b/src/lib/Components/Switch/BaseSwitch.tsx
+@@ -1,18 +1,13 @@
+ import { createSafeContext } from '@ledgerhq/lumen-utils-shared';
+-import { useCallback, useEffect } from 'react';
++import { useCallback, useEffect, useRef } from 'react';
+ import {
++  Animated,
++  Easing as RNEasing,
+   Pressable,
+   StyleSheet,
+   type GestureResponderEvent,
+ } from 'react-native';
+-import Animated, {
+-  cancelAnimation,
+-  useAnimatedStyle,
+-  useSharedValue,
+-  withTiming,
+-} from 'react-native-reanimated';
+-import { useStyleSheet } from '../../../styles';
+-import { useTimingConfig } from '../../Animations/useTimingConfig';
++import { useStyleSheet, useTheme } from '../../../styles';
+
+ import type { SlottablePressableProps, SlottableViewProps } from '../../types';
+ import { SlotPressable, SlotView } from '../Slot';
+@@ -101,23 +96,28 @@
+   checked: boolean | undefined;
+   size: Size;
+ }) => {
+-  const timingConfig = useTimingConfig({ duration: 200, easing: 'easeInOut' });
+-  const translateX = useSharedValue(checked ? THUMB_TRANSLATE[size] : 0);
++  // PATCH (ledger-live): Reanimated v4 worklet transform isn't reliable on this
++  // file after the RN 0.81 upgrade — the thumb stops animating. Use RN's built-in
++  // Animated API (native driver) which doesn't depend on the worklets babel plugin.
++  // Revert once @ledgerhq/lumen-ui-rnative is bumped to a version aligned with our RN.
++  const { theme } = useTheme();
++  const translateX = useRef(
++    new Animated.Value(checked ? THUMB_TRANSLATE[size] : 0),
++  ).current;
+
+   useEffect(() => {
+-    translateX.value = withTiming(
+-      checked ? THUMB_TRANSLATE[size] : 0,
+-      timingConfig,
+-    );
+-    return () => cancelAnimation(translateX);
+-  }, [checked, size, translateX, timingConfig]);
++    const bezier = theme.motion.easings.easeInOut;
++    const animation = Animated.timing(translateX, {
++      toValue: checked ? THUMB_TRANSLATE[size] : 0,
++      duration: theme.motion.durations[200],
++      easing: RNEasing.bezier(bezier[0], bezier[1], bezier[2], bezier[3]),
++      useNativeDriver: true,
++    });
++    animation.start();
++    return () => animation.stop();
++  }, [checked, size, translateX, theme]);
+
+-  const animatedStyle = useAnimatedStyle(
+-    () => ({
+-      transform: [{ translateX: translateX.value }],
+-    }),
+-    [translateX],
+-  );
++  const animatedStyle = { transform: [{ translateX }] };
+
+   return { animatedStyle };
+ };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -520,6 +520,9 @@ patchedDependencies:
   '@exodus/patch-broken-hermes-typed-arrays':
     hash: 7deb6c5bd39ee007fca03da7609b2e0dee99dbb9962c3c8715edfd026da0a732
     path: patches/@exodus__patch-broken-hermes-typed-arrays.patch
+  '@ledgerhq/lumen-ui-rnative@0.1.36':
+    hash: d8ced250447dd6b3dabbec10706f8319cec7c8f3ef9a6f97e6be2a12c4326c9e
+    path: patches/@ledgerhq__lumen-ui-rnative@0.1.36.patch
   '@taquito/http-utils':
     hash: fa57afa8cde2dca5953b33875e5797001987caeb346d5a479e7de0c4dd941cb3
     path: patches/@taquito__http-utils.patch
@@ -1639,7 +1642,7 @@ importers:
         version: 1.17.1(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.3(@ledgerhq/lumen-design-core@0.1.14)(@ledgerhq/lumen-ui-rnative@0.1.36(f25fbd70fb9677a120a671a6ec1a1478))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+        version: 2.0.3(@ledgerhq/lumen-design-core@0.1.14)(@ledgerhq/lumen-ui-rnative@0.1.36(patch_hash=d8ced250447dd6b3dabbec10706f8319cec7c8f3ef9a6f97e6be2a12c4326c9e)(f25fbd70fb9677a120a671a6ec1a1478))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/cryptoassets
@@ -1726,10 +1729,10 @@ importers:
         version: 0.1.14
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.36(f25fbd70fb9677a120a671a6ec1a1478)
+        version: 0.1.36(patch_hash=d8ced250447dd6b3dabbec10706f8319cec7c8f3ef9a6f97e6be2a12c4326c9e)(f25fbd70fb9677a120a671a6ec1a1478)
       '@ledgerhq/lumen-ui-rnative-visualization':
         specifier: 'catalog:'
-        version: 0.1.12(371260a69ef7301bdd3573aeb7121e92)
+        version: 0.1.12(d460facf39fd1d53697ad13b3b0b8f09)
       '@ledgerhq/native-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/native
@@ -2856,7 +2859,7 @@ importers:
         version: 0.1.35(1baa9d56e482879c358983cf8c8d87ea)
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.36(48193b58e07f61e330fbd8caf54bd71e)
+        version: 0.1.36(patch_hash=d8ced250447dd6b3dabbec10706f8319cec7c8f3ef9a6f97e6be2a12c4326c9e)(48193b58e07f61e330fbd8caf54bd71e)
       '@radix-ui/react-checkbox':
         specifier: 'catalog:'
         version: 1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
@@ -3397,7 +3400,7 @@ importers:
         version: 0.1.35(@ledgerhq/lumen-design-core@0.1.14)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.36(658842b1049fd42f05db7465b0aad80f)
+        version: 0.1.36(patch_hash=d8ced250447dd6b3dabbec10706f8319cec7c8f3ef9a6f97e6be2a12c4326c9e)(658842b1049fd42f05db7465b0aad80f)
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -11909,7 +11912,7 @@ importers:
     dependencies:
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.3(@ledgerhq/lumen-design-core@0.1.14)(@ledgerhq/lumen-ui-rnative@0.1.36(07776292686fe06c654c0ca130d23f03))(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4))(react@19.1.4)
+        version: 2.0.3(@ledgerhq/lumen-design-core@0.1.14)(@ledgerhq/lumen-ui-rnative@0.1.36(patch_hash=d8ced250447dd6b3dabbec10706f8319cec7c8f3ef9a6f97e6be2a12c4326c9e)(07776292686fe06c654c0ca130d23f03))(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4))(react@19.1.4)
       '@ledgerhq/icons-ui':
         specifier: workspace:^
         version: link:../icons
@@ -11976,7 +11979,7 @@ importers:
         version: 0.1.14
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.36(07776292686fe06c654c0ca130d23f03)
+        version: 0.1.36(patch_hash=d8ced250447dd6b3dabbec10706f8319cec7c8f3ef9a6f97e6be2a12c4326c9e)(07776292686fe06c654c0ca130d23f03)
       '@react-native-async-storage/async-storage':
         specifier: 2.1.2
         version: 2.1.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4))
@@ -44980,21 +44983,21 @@ snapshots:
       '@ledgerhq/lumen-ui-react': 0.1.35(9c392ef3da71dba080453e4dca5a948d)
       react-dom: 19.1.4(react@19.1.4)
 
-  '@ledgerhq/crypto-icons@2.0.3(@ledgerhq/lumen-design-core@0.1.14)(@ledgerhq/lumen-ui-rnative@0.1.36(07776292686fe06c654c0ca130d23f03))(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4))(react@19.1.4)':
+  '@ledgerhq/crypto-icons@2.0.3(@ledgerhq/lumen-design-core@0.1.14)(@ledgerhq/lumen-ui-rnative@0.1.36(patch_hash=d8ced250447dd6b3dabbec10706f8319cec7c8f3ef9a6f97e6be2a12c4326c9e)(07776292686fe06c654c0ca130d23f03))(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4))(react@19.1.4)':
     dependencies:
       react: 19.1.4
     optionalDependencies:
       '@ledgerhq/lumen-design-core': 0.1.14
-      '@ledgerhq/lumen-ui-rnative': 0.1.36(07776292686fe06c654c0ca130d23f03)
+      '@ledgerhq/lumen-ui-rnative': 0.1.36(patch_hash=d8ced250447dd6b3dabbec10706f8319cec7c8f3ef9a6f97e6be2a12c4326c9e)(07776292686fe06c654c0ca130d23f03)
       react-dom: 19.1.4(react@19.1.4)
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4)
 
-  '@ledgerhq/crypto-icons@2.0.3(@ledgerhq/lumen-design-core@0.1.14)(@ledgerhq/lumen-ui-rnative@0.1.36(f25fbd70fb9677a120a671a6ec1a1478))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)':
+  '@ledgerhq/crypto-icons@2.0.3(@ledgerhq/lumen-design-core@0.1.14)(@ledgerhq/lumen-ui-rnative@0.1.36(patch_hash=d8ced250447dd6b3dabbec10706f8319cec7c8f3ef9a6f97e6be2a12c4326c9e)(f25fbd70fb9677a120a671a6ec1a1478))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)':
     dependencies:
       react: 19.1.4
     optionalDependencies:
       '@ledgerhq/lumen-design-core': 0.1.14
-      '@ledgerhq/lumen-ui-rnative': 0.1.36(f25fbd70fb9677a120a671a6ec1a1478)
+      '@ledgerhq/lumen-ui-rnative': 0.1.36(patch_hash=d8ced250447dd6b3dabbec10706f8319cec7c8f3ef9a6f97e6be2a12c4326c9e)(f25fbd70fb9677a120a671a6ec1a1478)
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4)
 
   '@ledgerhq/device-management-kit@1.5.0':
@@ -45297,10 +45300,10 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-rnative-visualization@0.1.12(371260a69ef7301bdd3573aeb7121e92)':
+  '@ledgerhq/lumen-ui-rnative-visualization@0.1.12(d460facf39fd1d53697ad13b3b0b8f09)':
     dependencies:
       '@ledgerhq/lumen-design-core': 0.1.14
-      '@ledgerhq/lumen-ui-rnative': 0.1.36(f25fbd70fb9677a120a671a6ec1a1478)
+      '@ledgerhq/lumen-ui-rnative': 0.1.36(patch_hash=d8ced250447dd6b3dabbec10706f8319cec7c8f3ef9a6f97e6be2a12c4326c9e)(f25fbd70fb9677a120a671a6ec1a1478)
       '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.1.4)
       '@types/react': 19.0.14
       d3-array: 3.2.4
@@ -45313,7 +45316,7 @@ snapshots:
       react-native-svg: 15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       react-native-worklets: 0.8.1(patch_hash=8e8345e8a8ac8f4108e6743d9899f8d9f1e5b8af1901df406704331269df6e25)(@babel/core@7.28.5)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
 
-  '@ledgerhq/lumen-ui-rnative@0.1.36(07776292686fe06c654c0ca130d23f03)':
+  '@ledgerhq/lumen-ui-rnative@0.1.36(patch_hash=d8ced250447dd6b3dabbec10706f8319cec7c8f3ef9a6f97e6be2a12c4326c9e)(07776292686fe06c654c0ca130d23f03)':
     dependencies:
       '@ledgerhq/lumen-design-core': 0.1.14
       '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.1.4)
@@ -45329,7 +45332,7 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  '@ledgerhq/lumen-ui-rnative@0.1.36(48193b58e07f61e330fbd8caf54bd71e)':
+  '@ledgerhq/lumen-ui-rnative@0.1.36(patch_hash=d8ced250447dd6b3dabbec10706f8319cec7c8f3ef9a6f97e6be2a12c4326c9e)(48193b58e07f61e330fbd8caf54bd71e)':
     dependencies:
       '@gorhom/bottom-sheet': 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.3.0(react-native-worklets@0.8.1(patch_hash=8e8345e8a8ac8f4108e6743d9899f8d9f1e5b8af1901df406704331269df6e25)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@ledgerhq/lumen-design-core': 0.1.14
@@ -45346,7 +45349,7 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  '@ledgerhq/lumen-ui-rnative@0.1.36(658842b1049fd42f05db7465b0aad80f)':
+  '@ledgerhq/lumen-ui-rnative@0.1.36(patch_hash=d8ced250447dd6b3dabbec10706f8319cec7c8f3ef9a6f97e6be2a12c4326c9e)(658842b1049fd42f05db7465b0aad80f)':
     dependencies:
       '@gorhom/bottom-sheet': 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.3.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@ledgerhq/lumen-design-core': 0.1.14
@@ -45362,7 +45365,7 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  '@ledgerhq/lumen-ui-rnative@0.1.36(f25fbd70fb9677a120a671a6ec1a1478)':
+  '@ledgerhq/lumen-ui-rnative@0.1.36(patch_hash=d8ced250447dd6b3dabbec10706f8319cec7c8f3ef9a6f97e6be2a12c4326c9e)(f25fbd70fb9677a120a671a6ec1a1478)':
     dependencies:
       '@gorhom/bottom-sheet': 5.2.6(3f437f6f909fcfbc5fc01ac0788b7f98)
       '@ledgerhq/lumen-design-core': 0.1.14
@@ -64355,7 +64358,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3
+      metro: 0.83.3(metro-transform-worker@0.83.3)
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -64479,6 +64482,54 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.83.3(metro-transform-worker@0.83.3):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.28.5
+      '@babel/generator': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 1.3.8
+      chalk: 4.1.2
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.32.0
+      image-size: 1.1.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0(metro@0.83.3)
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.83.3
+      metro-cache: 0.83.3
+      metro-cache-key: 0.83.3
+      metro-config: 0.83.3(metro-transform-worker@0.83.3)
+      metro-core: 0.83.3
+      metro-file-map: 0.83.3(metro@0.83.3)
+      metro-resolver: 0.83.3
+      metro-runtime: 0.83.3
+      metro-source-map: 0.83.3
+      metro-symbolicate: 0.83.3
+      metro-transform-plugins: 0.83.3
+      metro-transform-worker: 0.83.3
+      mime-types: 2.1.35
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.10
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - metro-transform-worker
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Manual QA only — patches a 3rd-party component's animation internals; behavior is visual.
- [x] **Impact of the changes:**
  - QA should verify Switch toggle thumb animates smoothly in Ledger Live Mobile (e.g. Settings toggles) on both iOS and Android.
  - No expected impact on Desktop or non-toggle UI.

### 📝 Description

Patches `@ledgerhq/lumen-ui-rnative@0.1.36` so that `BaseSwitch` drives its thumb translation through React Native's built-in `Animated` API (native driver) instead of `react-native-reanimated`.

**Why:** After the RN 0.81 / React 19 upgrade, the upstream implementation that relies on Reanimated v4 worklet transforms (`useSharedValue` + `useAnimatedStyle` + `withTiming`) stops animating the thumb in our app — the toggle visually snaps with no transition. RN's `Animated.timing` with `useNativeDriver: true` doesn't depend on the worklets babel plugin and produces the expected motion.

**What changes in the patch:**
- Replaces `useSharedValue` / `withTiming` / `cancelAnimation` / `useAnimatedStyle` (from `react-native-reanimated`) with `useRef(new Animated.Value(...))` and `Animated.timing(...).start()` (from `react-native`).
- Reads `theme.motion.durations[200]` and `theme.motion.easings.easeInOut` and forwards the cubic-bezier to `Easing.bezier(...)` so timing matches the design tokens used by the original implementation.
- Returns a plain `{ transform: [{ translateX }] }` style (no `useAnimatedStyle`).

This is a temporary workaround — revert once `@ledgerhq/lumen-ui-rnative` ships a version aligned with our RN/Reanimated setup.

### ❓ Context

- **JIRA or GitHub link**: n/a
- **ADR link (if any)**: n/a

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)