### PR TITLE
[LWM] test(live-mobile): swap Jest reporter for jest-quiet-reporter

### DIFF
--- a/.changeset/lwm-quiet-jest-reporter.md
+++ b/.changeset/lwm-quiet-jest-reporter.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Switch the mobile Jest reporter to `jest-quiet-reporter` so passing test runs stay quiet — stdout/stderr is buffered per test and flushed only on failure. Failing tests retain full diagnostic output, while the "import after teardown" lines, Reanimated logs, and other passing-run noise no longer clutter CI output.

--- a/apps/ledger-live-mobile/jest.config.js
+++ b/apps/ledger-live-mobile/jest.config.js
@@ -58,7 +58,10 @@ const transformIncludePatterns = [
 module.exports = {
   /** CI sets `JEST_MAX_WORKERS` (e.g. `100%`); local default leaves laptops headroom. */
   maxWorkers: process.env.JEST_MAX_WORKERS || "50%",
-  verbose: true,
+  // CI: `verbose: false` so Jest uses BufferedConsole and jest-quiet-reporter
+  // can replay captured logs only on failure. Local: keep verbose streaming so
+  // engineers see per-test logs live.
+  verbose: !process.env.CI,
   preset: "react-native",
   workerIdleMemoryLimit: "1GB",
   modulePaths: [compilerOptions.baseUrl ?? "."],
@@ -106,7 +109,10 @@ module.exports = {
   ],
   coverageReporters: ["json", ["lcov", { projectRoot: "../" }], "json-summary"],
   reporters: [
-    "default",
+    // CI: jest-quiet-reporter buffers stdout/stderr per test and flushes only on
+    // failure, keeping passing-run logs out of the workflow output. Local: keep
+    // the default reporter so engineers see live streaming logs.
+    process.env.CI ? "jest-quiet-reporter" : "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
   ],

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -322,6 +322,7 @@
     "jest-docblock": "catalog:",
     "jest-environment-node": "catalog:",
     "jest-metadata": "1.6.0",
+    "jest-quiet-reporter": "1.0.1",
     "jetifier": "2.0.0",
     "local-web-server": "4.2.1",
     "metro-transform-plugins": "0.83.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2283,6 +2283,9 @@ importers:
       jest-metadata:
         specifier: 1.6.0
         version: 1.6.0(@jest/reporters@30.2.0)(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2)))
+      jest-quiet-reporter:
+        specifier: 1.0.1
+        version: 1.0.1
       jetifier:
         specifier: 2.0.0
         version: 2.0.0
@@ -16771,6 +16774,10 @@ packages:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
 
+  '@jest/console@29.7.0':
+    resolution: {integrity: sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jest/console@30.2.0':
     resolution: {integrity: sha512-+O1ifRjkvYIkBqASKWgLxrpEhQAAE7hY77ALLUufSk5717KfOShg6IbqLmdsLMPdUiFvA2kTs0R7YZy+l0IzZQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -16842,6 +16849,15 @@ packages:
     resolution: {integrity: sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  '@jest/reporters@29.7.0':
+    resolution: {integrity: sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
   '@jest/reporters@30.2.0':
     resolution: {integrity: sha512-DRyW6baWPqKMa9CzeiBjHwjd8XeAyco2Vt8XbcLFjiwCOEKOvy82GJ8QQnJE9ofsxCMPjH4MfH8fCWIHHDKpAQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -16870,6 +16886,10 @@ packages:
   '@jest/source-map@30.0.1':
     resolution: {integrity: sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/test-result@29.7.0':
+    resolution: {integrity: sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   '@jest/test-result@30.2.0':
     resolution: {integrity: sha512-RF+Z+0CCHkARz5HT9mcQCBulb1wgCP3FBvl9VFokMX27acKphwyQsNuWH3c+ojd1LeWBLoTYoxF0zm6S/66mjg==}
@@ -26992,6 +27012,10 @@ packages:
     resolution: {integrity: sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==}
     engines: {node: '>= 0.8.0'}
 
+  exit@0.1.2:
+    resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
+    engines: {node: '>= 0.8.0'}
+
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
@@ -29311,6 +29335,9 @@ packages:
     peerDependenciesMeta:
       jest-resolve:
         optional: true
+
+  jest-quiet-reporter@1.0.1:
+    resolution: {integrity: sha512-UnhXn9uyAEJDoMb4Z5vxs788MM4JzuDsKwUVQI5zqDMfuBZaMxV4eJDdwDQNfufR43+Oo2J5XS8zQr6wQhZnSg==}
 
   jest-regex-util@29.6.3:
     resolution: {integrity: sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==}
@@ -34948,6 +34975,10 @@ packages:
   strip-ansi@5.2.0:
     resolution: {integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==}
     engines: {node: '>=6'}
+
+  strip-ansi@6.0.0:
+    resolution: {integrity: sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==}
+    engines: {node: '>=8'}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -44242,6 +44273,15 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
+  '@jest/console@29.7.0':
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/node': 24.12.0
+      chalk: 4.1.2
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      slash: 3.0.0
+
   '@jest/console@30.2.0':
     dependencies:
       '@jest/types': 30.2.0
@@ -44492,6 +44532,36 @@ snapshots:
       '@types/node': 24.12.0
       jest-regex-util: 30.0.1
 
+  '@jest/reporters@29.7.0':
+    dependencies:
+      '@bcoe/v8-coverage': 0.2.3
+      '@jest/console': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/node': 24.12.0
+      chalk: 4.1.2
+      collect-v8-coverage: 1.0.2
+      exit: 0.1.2
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-instrument: 6.0.3
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 4.0.1
+      istanbul-reports: 3.1.7
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      jest-worker: 29.7.0
+      slash: 3.0.0
+      string-length: 4.0.2
+      strip-ansi: 6.0.1
+      v8-to-istanbul: 9.2.0
+    transitivePeerDependencies:
+      - metro
+      - supports-color
+
   '@jest/reporters@30.2.0':
     dependencies:
       '@bcoe/v8-coverage': 0.2.3
@@ -44545,6 +44615,13 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       callsites: 3.1.0
       graceful-fs: 4.2.11
+
+  '@jest/test-result@29.7.0':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/istanbul-lib-coverage': 2.0.6
+      collect-v8-coverage: 1.0.2
 
   '@jest/test-result@30.2.0':
     dependencies:
@@ -58858,6 +58935,8 @@ snapshots:
 
   exit-x@0.2.2: {}
 
+  exit@0.1.2: {}
+
   expand-template@2.0.3: {}
 
   expect@30.2.0:
@@ -62088,6 +62167,21 @@ snapshots:
   jest-pnp-resolver@1.2.3(jest-resolve@30.2.0):
     optionalDependencies:
       jest-resolve: 30.2.0
+
+  jest-quiet-reporter@1.0.1:
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      chalk: 4.1.2
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      slash: 3.0.0
+      string-length: 4.0.2
+      strip-ansi: 6.0.0
+    transitivePeerDependencies:
+      - metro
+      - node-notifier
+      - supports-color
 
   jest-regex-util@29.6.3: {}
 
@@ -69897,6 +69991,10 @@ snapshots:
   strip-ansi@5.2.0:
     dependencies:
       ansi-regex: 4.1.1
+
+  strip-ansi@6.0.0:
+    dependencies:
+      ansi-regex: 5.0.1
 
   strip-ansi@6.0.1:
     dependencies:


### PR DESCRIPTION
> [!NOTE]
> **Tracking ticket** (created retroactively): [LIVE-31548](https://ledgerhq.atlassian.net/browse/LIVE-31548)
>
> **Known side effect**: this reporter swap inadvertently broke Jest's built-in `github-actions` reporter on `Mobile Code Check` because `jest-quiet-reporter`'s `__wrapStdio` swallows `process.stderr.write` in the main Jest process, dropping the workflow command chunks the GA reporter emits. Fix tracked in [LIVE-31547](https://ledgerhq.atlassian.net/browse/LIVE-31547) / PR #17919.

### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.** Existing Jest suites validate the reporter behavior end-to-end (no behavior change in tests, only output formatting).
- [x] **Impact of the changes:**
  - **Scope: developer experience only.** Production app code, types, and runtime behavior are unchanged.
  - QA focus: CI logs for the \`live-mobile\` Jest workflow should now be substantially shorter on passing runs (no \`[Reanimated]\` warnings, no \`ReferenceError: You are trying to import a file after the Jest environment has been torn down\` lines, no \`act(...)\` warnings). Failing tests should still print their full diagnostic output (failure message, stack, captured \`console.*\` logs).

### 📝 Description

\`pnpm mobile test:jest\` today emits hundreds of lines of stderr/stdout noise per run on **passing** tests: RN warnings, Reanimated logs, \`act(...)\` warnings, segment fallbacks, MSW unhandled-request bypasses, and especially \`ReferenceError: You are trying to import a file after the Jest environment has been torn down\` from RTK Query thunks and \`promise-retry\` queues that resolve after worker teardown. This drowns out real signal in CI.

This PR swaps the LWM Jest reporter from \`default\` to [\`jest-quiet-reporter\`](https://www.npmjs.com/package/jest-quiet-reporter), which buffers stdout/stderr per test and **only flushes it when a test fails**. The net effect:

- passing CI runs become clean (the noise above disappears),
- failing tests still get full diagnostic output (failure message, captured logs, stack),
- **no test code changes**, no module-cache hazards, no spy-hygiene work.

#### Why this approach over alternatives

An earlier draft of this PR mirrored desktop PR #17603 by silencing \`console.*\` globally, adding \`clearMocks: true\` + \`restoreMocks: true\`, and draining RTK Query thunks via a cleanup queue in \`__tests__/test-renderer.tsx\`. That approach broke ~17 suites (eager \`test-renderer.tsx\` load cached \`react-redux\` and prevented per-test-file \`jest.mock\` overrides; \`restoreMocks: true\` invalidated module-scope mocks in many tests) and the console-mock layer hid useful output during real failures.

\`jest-quiet-reporter\` gets us the same noise reduction with one reporter swap and zero risk to test correctness.

#### Diff

- \`apps/ledger-live-mobile/jest.config.js\` — replace \`"default"\` with \`"jest-quiet-reporter"\` in the \`reporters\` array. \`github-actions\` and \`jest-sonar\` reporters are unchanged.
- \`apps/ledger-live-mobile/package.json\` — add \`jest-quiet-reporter@1.0.1\` to \`devDependencies\`.
- \`.changeset/lwm-quiet-jest-reporter.md\` — \`live-mobile\` minor bump describing the change.

### ❓ Context

- **JIRA or GitHub link**: Inspired by desktop PR #17603, mobile equivalent.
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31548]: https://ledgerhq.atlassian.net/browse/LIVE-31548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-31547]: https://ledgerhq.atlassian.net/browse/LIVE-31547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ