### PR TITLE
Support/qaa 1116 wallet 4.0 cleanup

### DIFF
--- a/.github/workflows/test-desktop-reusable.yml
+++ b/.github/workflows/test-desktop-reusable.yml
@@ -206,7 +206,6 @@ jobs:
           invert_filter: false
           shard_index: 1
           shard_total: 1
-          enable_wallet40: true
         env:
           SEED: ${{ secrets.SEED_QAA_B2C }}
           XRAY: false

--- a/.github/workflows/test-ui-e2e-only-desktop.yml
+++ b/.github/workflows/test-ui-e2e-only-desktop.yml
@@ -63,10 +63,6 @@ on:
         required: false
         type: boolean
         default: false
-      enable_wallet40:
-        description: "Enable Wallet 4.0 feature"
-        type: boolean
-        default: true
       feature_flags_json:
         description: "JSON to override feature flags"
         required: false
@@ -111,10 +107,6 @@ on:
         required: false
         type: boolean
         default: false
-      enable_wallet40:
-        description: "Enable Wallet 4.0 feature"
-        type: boolean
-        default: true
       feature_flags_json:
         description: "JSON to override feature flags"
         required: false
@@ -292,7 +284,6 @@ jobs:
             echo "- **Workflow source branch:** ${{ github.workflow_ref }}"
             echo "- **Triggered branch:** ${{ inputs.ref || github.ref_name }}"
             echo "- **Commit SHA:** ${{ github.sha }}"
-            echo "- **Wallet:** ${{ (github.event_name == 'schedule' || inputs.enable_wallet40 != false) && 'Wallet 4.0' || 'Legacy' }}"
             echo "- **Device selected:** $DEVICE"
             echo "- **Filtered pattern:** $FILTER_PATTERN"
             echo "- **Test Execution ticket ID:** $TEST_EXECUTION"
@@ -325,7 +316,6 @@ jobs:
           speculos_device: ${{ env.SPECULOS_DEVICE }}
           test_filter: ${{ steps.test-filter.outputs.filter }}
           invert_filter: ${{ inputs.invert_filter || false }}
-          enable_wallet40: ${{ github.event_name == 'schedule' || inputs.enable_wallet40 != false }}
         env:
           SEED: ${{ secrets.SEED_QAA_B2C }}
           XRAY: ${{ matrix.is_primary && inputs.export_to_xray || false }}

--- a/e2e/desktop/README.md
+++ b/e2e/desktop/README.md
@@ -82,20 +82,7 @@ pnpm e2e:desktop test:playwright <testFileName>
 For detailed setup, debugging, and contribution guidelines, see:
 [Ledger Wallet Desktop E2E Wiki](https://github.com/LedgerHQ/ledger-live/wiki/LLD:E2ETesting)
 
-### 6. Wallet 4.0
-
-The Wallet 4.0 feature is ON by default (regardless of Firebase).
-You can force Wallet 4.0 OFF (legacy) by setting the E2E environment variable:
-
-```bash
-export E2E_ENABLE_WALLET40=0
-```
-
-Individual tests can still switch Wallet 4.0 OFF by explicitly passing the `LWD_WALLET_40_FF_DISABLED` FF.
-
-To switch Wallet 4.0 OFF on CI please untick the checkbox on the Github Workflow.
-
-### 7. Custom feature flags with E2E_FEATURE_FLAGS_JSON
+### 6. Custom feature flags with E2E_FEATURE_FLAGS_JSON
 
 You can inject extra feature flags globally for Desktop E2E by setting `E2E_FEATURE_FLAGS_JSON`.
 

--- a/e2e/desktop/tests/component/layout.component.ts
+++ b/e2e/desktop/tests/component/layout.component.ts
@@ -14,7 +14,6 @@ export class Layout extends Component {
   readonly drawerAccountsButton = this.page.getByTestId("drawer-accounts-button");
   readonly drawerSendButton = this.page.getByTestId("drawer-send-button");
   readonly drawerEarnButton = this.page.getByTestId("drawer-earn-button");
-  readonly drawerBuycryptoButton = this.page.getByTestId("drawer-exchange-button");
   readonly drawerSwapButton = this.page.getByTestId("drawer-swap-button");
   readonly drawerDiscoverButton = this.page.getByTestId("drawer-catalog-button");
   readonly drawerReferButton = this.page.getByTestId("drawer-refer-button");
@@ -47,11 +46,6 @@ export class Layout extends Component {
     await this.drawerSendButton.click();
   }
 
-  @step("Go to buy crypto")
-  async goToBuySellCrypto() {
-    await this.drawerBuycryptoButton.click();
-  }
-
   @step("Go to Settings")
   async goToSettings() {
     await this.topbarSettingsButton.click();
@@ -77,10 +71,5 @@ export class Layout extends Component {
   @step("Wait for accounts sync to be finished")
   async waitForSyncButtonToBeEnabled() {
     await expect(this.topbarSynchronizeButton).not.toHaveAttribute("disabled");
-  }
-
-  @step("Expect buy/sell sidebar to be selected")
-  async verifyBuySellSideBarIsSelected() {
-    await expect(this.drawerBuycryptoButton).toHaveAttribute("data-active", "true");
   }
 }

--- a/e2e/desktop/tests/fixtures/common.ts
+++ b/e2e/desktop/tests/fixtures/common.ts
@@ -18,7 +18,6 @@ import { lastValueFrom, Observable } from "rxjs";
 import { launchSpeculos, cleanSpeculos } from "tests/utils/speculosUtils";
 import { getSpeculosAddress, SpeculosDevice } from "@ledgerhq/live-common/e2e/speculos";
 import { attachNetworkLogging } from "../utils/networkLogging";
-import { LWD_WALLET_40_FF_DISABLED, LWD_WALLET_40_FF_ENABLED } from "tests/utils/featureFlagUtils";
 import type { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import { unregisterAllTransportModules } from "@ledgerhq/live-common/hw/index";
 import { parseExtraFeatureFlags } from "../utils/featureFlagsJsonUtils";
@@ -83,9 +82,6 @@ const DEFAULT_FEATURE_FLAGS: OptionalFeatureMap = {
       live_apps_blocklist: [],
     },
   },
-  ...(process.env.E2E_ENABLE_WALLET40 === "0"
-    ? LWD_WALLET_40_FF_DISABLED
-    : LWD_WALLET_40_FF_ENABLED),
 };
 
 async function executeCliCommand(cmd: CliCommand, userdataDestinationPath?: string) {

--- a/e2e/desktop/tests/page/market.page.ts
+++ b/e2e/desktop/tests/page/market.page.ts
@@ -1,7 +1,6 @@
 import { AppPage } from "./abstractClasses";
 import { step } from "../misc/reporters/step";
 import { expect } from "@playwright/test";
-import { isWallet40Enabled } from "tests/utils/featureFlagUtils";
 
 export class MarketPage extends AppPage {
   private readonly navbarTitle = this.page.getByTestId("page-header-title");
@@ -11,13 +10,6 @@ export class MarketPage extends AppPage {
     this.page.getByTestId(`market-${ticker}-row`).first();
   private coinPageContainer = this.page.getByTestId("market-coin-page-container");
   private swapButtonOnAsset = this.page.getByTestId("market-coin-swap-button");
-
-  private buyButtonLegacy = (ticker: string) =>
-    this.page.locator(`[data-testid="market-${ticker}-buy-button"]:visible`).first();
-  private swapButtonLegacy = (ticker: string) =>
-    this.page.locator(`[data-testid="market-${ticker}-swap-button"]:visible`).first();
-  private stakeButtonLegacy = (ticker: string) =>
-    this.page.locator(`[data-testid="market-${ticker}-stake-button"]:visible`).first();
 
   private readonly buyButton = (ticker: string) =>
     this.coinRow(ticker).getByTestId(`market-${ticker}-buy-button-icon`);
@@ -53,19 +45,13 @@ export class MarketPage extends AppPage {
 
   @step("Open buy page for $0")
   async openBuyPage(ticker: string) {
-    const button = (await isWallet40Enabled(this.page))
-      ? this.buyButton(ticker.toLowerCase())
-      : this.buyButtonLegacy(ticker.toLowerCase());
-
+    const button = this.buyButton(ticker.toLowerCase());
     await button.click();
   }
 
   @step("Click on swap button for $0")
   async startSwapForSelectedTicker(ticker: string) {
-    const button = (await isWallet40Enabled(this.page))
-      ? this.swapButton(ticker.toLowerCase())
-      : this.swapButtonLegacy(ticker.toLowerCase());
-
+    const button = this.swapButton(ticker.toLowerCase());
     await button.click();
   }
 
@@ -76,10 +62,7 @@ export class MarketPage extends AppPage {
 
   @step("Click on stake button for $0")
   async stakeButtonClick(ticker: string) {
-    const button = (await isWallet40Enabled(this.page))
-      ? this.stakeButton(ticker.toLowerCase())
-      : this.stakeButtonLegacy(ticker.toLowerCase());
-
+    const button = this.stakeButton(ticker.toLowerCase());
     await button.click();
   }
 

--- a/e2e/desktop/tests/specs/assets.addresses.spec.ts
+++ b/e2e/desktop/tests/specs/assets.addresses.spec.ts
@@ -5,7 +5,6 @@ import { Currency } from "@ledgerhq/live-common/e2e/enum/Currency";
 import { addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
 import { getModularSelector } from "tests/utils/modularSelectorUtils";
-import { LWD_WALLET_40_FF_ENABLED } from "tests/utils/featureFlagUtils";
 
 /**
  * Suite: Wallet 4.0 - Portfolio-Asset/Address
@@ -29,7 +28,6 @@ test.describe("Wallet 4.0 - Portfolio-Asset/Address", () => {
       teamOwner: Team.WALLET_XP,
       userdata: "skip-onboarding-with-last-seen-device",
       speculosApp: Currency.BTC.speculosApp,
-      featureFlags: LWD_WALLET_40_FF_ENABLED,
     });
 
     test(
@@ -105,7 +103,6 @@ test.describe("Wallet 4.0 - Portfolio-Asset/Address", () => {
     test.use({
       teamOwner: Team.WALLET_XP,
       userdata: "1AccountBTC1AccountETH",
-      featureFlags: LWD_WALLET_40_FF_ENABLED,
     });
 
     test(
@@ -145,7 +142,6 @@ test.describe("Wallet 4.0 - Portfolio-Asset/Address", () => {
     test.use({
       teamOwner: Team.WALLET_XP,
       userdata: "portfolioWithManyStablecoins",
-      featureFlags: LWD_WALLET_40_FF_ENABLED,
     });
 
     test(

--- a/e2e/desktop/tests/specs/buySell.spec.ts
+++ b/e2e/desktop/tests/specs/buySell.spec.ts
@@ -12,7 +12,6 @@ import { BuySell } from "@ledgerhq/live-common/e2e/models/BuySell";
 import { BuySellProvider } from "@ledgerhq/live-common/e2e/enum/Provider";
 import { OperationType } from "@ledgerhq/live-common/e2e/enum/OperationType";
 import { getFamilyByCurrencyId } from "@ledgerhq/live-common/currencies/helpers";
-import { isWallet40Enabled } from "tests/utils/featureFlagUtils";
 import { liveDataCommand } from "@ledgerhq/live-common/e2e/cliCommandsUtils";
 
 const assets: Array<{ buySell: BuySell; xrayTicket: string; provider: BuySellProvider }> = [
@@ -88,13 +87,6 @@ for (const asset of assets) {
         await app.mainNavigation.openTargetFromMainNavigation("home");
         await app.portfolio.clickOnSelectedAssetRow(crypto.currency.name);
         await app.assetPage.startBuyFlow();
-
-        if ((await isWallet40Enabled(app.getPage())) === false) {
-          // TODO: Remove this when wallet 4.0 is permanent
-          // Buy / Sell is only in the side navigation for legacy app
-          await app.layout.verifyBuySellSideBarIsSelected();
-        }
-
         await app.buyAndSell.verifyBuySellLandingAndCryptoAssetSelector(crypto, operation);
         await app.buyAndSell.verifyFiatAssetSelector(fiat.currencyTicker);
       },
@@ -111,22 +103,9 @@ for (const asset of assets) {
       },
       async ({ app }) => {
         await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
-        if (await isWallet40Enabled(app.getPage())) {
-          await app.marketBanner.clickExploreMarketHeader();
-        } else {
-          await app.layout.goToMarket();
-        }
-
+        await app.marketBanner.clickExploreMarketHeader();
         await app.market.search(crypto.currency.ticker);
         await app.market.openBuyPage(crypto.currency.ticker);
-
-        if ((await isWallet40Enabled(app.getPage())) === false) {
-          // TODO: Remove this when wallet 4.0 is permanent
-          // Buy / Sell is only in the side navigation for legacy app
-          await app.layout.verifyBuySellSideBarIsSelected();
-        }
-
         await app.buyAndSell.verifyBuySellLandingAndCryptoAssetSelector(crypto, operation);
         await app.buyAndSell.verifyFiatAssetSelector(fiat.currencyTicker);
       },
@@ -163,13 +142,6 @@ for (const asset of assets) {
             : asset.buySell.crypto.accountName,
         );
         await app.account.clickBuy();
-
-        if ((await isWallet40Enabled(app.getPage())) === false) {
-          // TODO: Remove this when wallet 4.0 is permanent
-          // Buy / Sell is only in the side navigation for legacy app
-          await app.layout.verifyBuySellSideBarIsSelected();
-        }
-
         await app.buyAndSell.verifyBuySellLandingAndCryptoAssetSelector(
           asset.buySell.crypto,
           operation,
@@ -198,23 +170,15 @@ for (const asset of assets) {
       },
       async ({ app, userdataDestinationPath }) => {
         await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-        if (await isWallet40Enabled(app.getPage())) {
-          await app.portfolio.clickBuyButton();
-        } else {
-          await app.portfolio.clickBuySellButton();
-          await app.layout.verifyBuySellSideBarIsSelected();
-        }
-
+        await app.portfolio.clickBuyButton();
         await app.buyAndSell.chooseAssetIfNotSelected(crypto);
         await app.buyAndSell.verifyBuySellLandingAndCryptoAssetSelector(crypto, operation);
         await app.buyAndSell.verifyFiatAssetSelector(fiat.currencyTicker);
         await app.buyAndSell.verifyBuyInfoBox();
         await app.buyAndSell.verifyProviderInfoIsNotVisible();
-
         await app.buyAndSell.setAmountToPay(amount, operation);
         await app.buyAndSell.selectProviderQuote(operation, asset.provider.uiName);
         await app.buyAndSell.selectQuote();
-
         await app.buyAndSell.verifyProviderUrl(
           asset.provider.uiName,
           asset.buySell,
@@ -270,28 +234,16 @@ test.describe("Sell flow - ", () => {
     },
     async ({ app, userdataDestinationPath }) => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-      if (await isWallet40Enabled(app.getPage())) {
-        await app.portfolio.clickSellButton();
-        await app.buyAndSell.verifyBuySellLandingAndCryptoAssetSelector(crypto, OperationType.Sell);
-        await app.buyAndSell.verifyFiatAssetSelector("USD");
-        await app.buyAndSell.verifySellInfoBox();
-        await app.buyAndSell.verifyProviderInfoIsNotVisible();
-      } else {
-        await app.layout.goToBuySellCrypto();
-        await app.layout.verifyBuySellSideBarIsSelected();
-        await app.buyAndSell.verifyBuySellLandingAndCryptoAssetSelector(crypto, OperationType.Buy);
-        await app.buyAndSell.verifyFiatAssetSelector("USD");
-        await app.buyAndSell.verifyBuyInfoBox();
-        await app.buyAndSell.verifyProviderInfoIsNotVisible();
-        await app.buyAndSell.selectTab(operation);
-      }
+      await app.portfolio.clickSellButton();
+      await app.buyAndSell.verifyBuySellLandingAndCryptoAssetSelector(crypto, OperationType.Sell);
+      await app.buyAndSell.verifyFiatAssetSelector("USD");
+      await app.buyAndSell.verifySellInfoBox();
+      await app.buyAndSell.verifyProviderInfoIsNotVisible();
       await app.buyAndSell.changeRegionAndCurrency(fiat);
       await app.buyAndSell.verifyFiatAssetSelector(fiat.currencyTicker);
-
       await app.buyAndSell.setAmountToPay(amount, operation);
       await app.buyAndSell.selectProviderQuote(operation, sellAsset.provider.uiName);
       await app.buyAndSell.selectQuote();
-
       await app.buyAndSell.verifyProviderUrl(
         sellAsset.provider.uiName,
         sellAsset.buySell,

--- a/e2e/desktop/tests/specs/delegate.spec.ts
+++ b/e2e/desktop/tests/specs/delegate.spec.ts
@@ -8,7 +8,6 @@ import { addBugLink, addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
 import { getFamilyByCurrencyId } from "@ledgerhq/live-common/currencies/helpers";
 import { getModularSelector } from "tests/utils/modularSelectorUtils";
-import { isWallet40Enabled, LWD_WALLET_40_FF_DISABLED } from "tests/utils/featureFlagUtils";
 import { liveDataCommand } from "@ledgerhq/live-common/e2e/cliCommandsUtils";
 
 function setupEnv(disableBroadcast?: boolean) {
@@ -431,60 +430,6 @@ for (const validator of validators) {
   });
 }
 
-test.describe("Staking flow from different entry point - legacy", () => {
-  const delegateAccount = new Delegate(Account.ATOM_1, "0.001", "Ledger by Chorus One");
-  test.use({
-    teamOwner: Team.EARN,
-    userdata: "skip-onboarding-with-last-seen-device",
-    speculosApp: delegateAccount.account.currency.speculosApp,
-    featureFlags: LWD_WALLET_40_FF_DISABLED,
-    cliCommands: [liveDataCommand(delegateAccount.account)],
-  });
-
-  const family = getFamilyByCurrencyId(delegateAccount.account.currency.id);
-
-  test(
-    "Staking flow from portfolio entry point",
-    {
-      tag: [
-        "@NanoSP",
-        "@LNS",
-        "@NanoX",
-        "@Stax",
-        "@Flex",
-        "@NanoGen5",
-        `@${delegateAccount.account.currency.id}`,
-        ...(family ? [`@family-${family}`] : []),
-      ],
-      annotation: {
-        type: "TMS",
-        description: "B2CQA-2769, B2CQA-3281, B2CQA-3289",
-      },
-    },
-    async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
-      await app.layout.goToPortfolio();
-      await app.portfolio.startStakeFlow();
-
-      const selector = await getModularSelector(app, "ASSET");
-      if (selector) {
-        await selector.validateItems();
-        await selector.selectAsset(delegateAccount.account.currency);
-        await selector.selectNetwork(delegateAccount.account.currency);
-        await selector.selectAccountByName(delegateAccount.account);
-      } else {
-        await app.portfolio.expectChooseAssetToBeVisible();
-        await app.assetDrawer.selectAsset(delegateAccount.account.currency);
-        await app.assetDrawer.selectAccountByIndex(delegateAccount.account);
-      }
-
-      await app.delegate.verifyFirstProviderName(delegateAccount.provider);
-      await app.delegate.continue();
-    },
-  );
-});
-
 test.describe("Staking flow from different entry point", () => {
   const delegateAccount = new Delegate(Account.ATOM_1, "0.001", "Ledger by Chorus One");
   test.use({
@@ -516,13 +461,7 @@ test.describe("Staking flow from different entry point", () => {
     },
     async ({ app }) => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
-      if (await isWallet40Enabled(app.getPage())) {
-        await app.marketBanner.clickExploreMarketHeader();
-      } else {
-        await app.layout.goToMarket();
-      }
-
+      await app.marketBanner.clickExploreMarketHeader();
       await app.market.search(delegateAccount.account.currency.ticker);
       await app.market.stakeButtonClick(delegateAccount.account.currency.ticker);
 

--- a/e2e/desktop/tests/specs/entrypoint.swap.spec.ts
+++ b/e2e/desktop/tests/specs/entrypoint.swap.spec.ts
@@ -17,7 +17,6 @@ import { overrideNetworkPayload } from "tests/utils/networkUtils";
 import { getModularSelector } from "tests/utils/modularSelectorUtils";
 import { liveDataWithAddressCommand } from "@ledgerhq/live-common/e2e/cliCommandsUtils";
 import { Addresses } from "@ledgerhq/live-common/e2e/enum/Addresses";
-import { isWallet40Enabled } from "tests/utils/featureFlagUtils";
 
 const app: AppInfos = AppInfos.EXCHANGE;
 
@@ -102,13 +101,7 @@ test.describe("Swap flow from different entry point", () => {
     },
     async ({ app }) => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
-      if (await isWallet40Enabled(app.getPage())) {
-        await app.marketBanner.clickExploreMarketHeader();
-      } else {
-        await app.layout.goToMarket();
-      }
-
+      await app.marketBanner.clickExploreMarketHeader();
       await app.swap.goAndWaitForSwapToBeReady(() =>
         app.market.startSwapForSelectedTicker(swapEntryPoint.swap.accountToDebit.currency.ticker),
       );
@@ -139,13 +132,7 @@ test.describe("Swap flow from different entry point", () => {
     },
     async ({ app }) => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
-      if (await isWallet40Enabled(app.getPage())) {
-        await app.marketBanner.clickExploreMarketHeader();
-      } else {
-        await app.layout.goToMarket();
-      }
-
+      await app.marketBanner.clickExploreMarketHeader();
       await app.market.openCoinPage(swapEntryPoint.swap.accountToDebit.currency.ticker);
       await app.swap.goAndWaitForSwapToBeReady(() => app.market.clickOnSwapButtonOnAsset());
       await app.swap.checkAssetToContains(swapEntryPoint.swap.accountToDebit.currency.name);

--- a/e2e/desktop/tests/specs/main.navigation.spec.ts
+++ b/e2e/desktop/tests/specs/main.navigation.spec.ts
@@ -2,7 +2,6 @@ import { test } from "tests/fixtures/common";
 import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
-import { LWD_WALLET_40_FF_ENABLED } from "tests/utils/featureFlagUtils";
 
 const DEVICE_TAGS = ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"] as const;
 
@@ -11,7 +10,6 @@ test.describe("Main navigation", () => {
     teamOwner: Team.WALLET_XP,
     userdata: "1AccountBTC1AccountETH",
     featureFlags: {
-      ...LWD_WALLET_40_FF_ENABLED,
       referralProgramDesktopSidebar: {
         enabled: true,
         params: {

--- a/e2e/desktop/tests/specs/market.spec.ts
+++ b/e2e/desktop/tests/specs/market.spec.ts
@@ -3,13 +3,11 @@ import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
-import { LWD_WALLET_40_FF_ENABLED } from "tests/utils/featureFlagUtils";
 
 test.describe("Market", () => {
   test.use({
     teamOwner: Team.WALLET_XP,
     userdata: "speculos-tests-app",
-    featureFlags: LWD_WALLET_40_FF_ENABLED,
   });
 
   test(

--- a/e2e/desktop/tests/specs/marketBanner.spec.ts
+++ b/e2e/desktop/tests/specs/marketBanner.spec.ts
@@ -3,13 +3,11 @@ import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { expect } from "@playwright/test";
 import { addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
-import { LWD_WALLET_40_FF_ENABLED } from "tests/utils/featureFlagUtils";
 
 test.describe("Market Banner", () => {
   test.use({
     teamOwner: Team.WALLET_XP,
     userdata: "speculos-tests-app",
-    featureFlags: LWD_WALLET_40_FF_ENABLED,
   });
 
   test(
@@ -23,39 +21,25 @@ test.describe("Market Banner", () => {
     },
     async ({ app }) => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
       await app.mainNavigation.openTargetFromMainNavigation("home");
-
       await app.marketBanner.expectMarketBannerToBeVisible();
-
       await app.marketBanner.expectFearAndGreedCardToBeVisible();
-
       await app.marketBanner.expectTrendingAssetsListToBeVisible();
-
       await app.marketBanner.clickFearAndGreedCard();
-
       await app.fearAndGreedDialog.validateFearAndGreedDialogItems();
-
       await app.fearAndGreedDialog.validateFearAndGreedDialogContent();
-
       await app.fearAndGreedDialog.closeFearAndGreedDialogWithCta();
 
       const assetId = await app.marketBanner.clickFirstAssetTile();
 
       await expect(app.layout.getPage()).toHaveURL(new RegExp(`/market/${assetId}`));
-
       await app.mainNavigation.openTargetFromMainNavigation("home");
-
       await app.marketBanner.clickExploreMarketHeader();
-
       await expect(app.layout.getPage()).toHaveURL(/\/market$/);
       await app.market.openCoinPage("BTC");
       await expect(app.layout.getPage()).toHaveURL(new RegExp(`/market/bitcoin`));
-
       await app.mainNavigation.openTargetFromMainNavigation("home");
-
       await app.marketBanner.scrollToAndClickViewAllTile();
-
       await expect(app.layout.getPage()).toHaveURL(/\/market$/);
       await app.market.openCoinPage("BTC");
       await expect(app.layout.getPage()).toHaveURL(new RegExp(`/market/bitcoin`));

--- a/e2e/desktop/tests/specs/portfolio.spec.ts
+++ b/e2e/desktop/tests/specs/portfolio.spec.ts
@@ -2,45 +2,13 @@ import { test } from "tests/fixtures/common";
 import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
-import { LWD_WALLET_40_FF_DISABLED, LWD_WALLET_40_FF_ENABLED } from "tests/utils/featureFlagUtils";
 import { Currency } from "@ledgerhq/live-common/e2e/enum/Currency";
 import { getModularSelector } from "tests/utils/modularSelectorUtils";
-
-// Skipping this suite as legacy is not visible on prod anymore
-test.describe.skip("Portfolio - legacy", () => {
-  test.use({
-    teamOwner: Team.WALLET_XP,
-    userdata: "speculos-subAccount",
-    featureFlags: LWD_WALLET_40_FF_DISABLED,
-  });
-  test(
-    "Charts are displayed when user added his accounts",
-    {
-      tag: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"],
-      annotation: {
-        type: "TMS",
-        description: "B2CQA-927, B2CQA-928, B2CQA-3038",
-      },
-    },
-    async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
-      await app.mainNavigation.openTargetFromMainNavigation("home");
-      await app.portfolio.checkBuySellButtonVisibility();
-      await app.portfolio.checkStakeButtonVisibility();
-      await app.portfolio.checkEmbeddedSwapContainerVisibility();
-      await app.swap.expectSelectedAssetDisplayed(/ETH|BTC/);
-      await app.portfolio.checkChartVisibility();
-      await app.portfolio.checkAssetAllocationSection();
-    },
-  );
-});
 
 test.describe("Portfolio Wallet 4.0 - Zero balance state", () => {
   test.use({
     teamOwner: Team.WALLET_XP,
     userdata: "skip-onboarding-with-last-seen-device",
-    featureFlags: LWD_WALLET_40_FF_ENABLED,
   });
 
   test(
@@ -58,12 +26,10 @@ test.describe("Portfolio Wallet 4.0 - Zero balance state", () => {
       await app.portfolio.checkNoBalanceTitleVisibility();
       await app.portfolio.expectPortfolioTotalBalanceNotVisible();
       await app.portfolio.expectOneDayPerformanceIndicatorNotVisible();
-
       await app.portfolio.checkReceiveButtonVisibility();
       await app.portfolio.checkBuyButtonVisibility();
       await app.portfolio.checkSellButtonDisabled();
       await app.portfolio.checkSendButtonDisabled();
-
       await app.portfolio.checkAddAccountButtonVisibility();
       await app.portfolio.clickAddAccountButton();
     },
@@ -74,7 +40,6 @@ test.describe("Portfolio Wallet 4.0 - With Account", () => {
   test.use({
     teamOwner: Team.WALLET_XP,
     userdata: "1AccountSOL0Balance",
-    featureFlags: LWD_WALLET_40_FF_ENABLED,
   });
 
   test(
@@ -93,7 +58,6 @@ test.describe("Portfolio Wallet 4.0 - With Account", () => {
       await app.portfolio.checkBuyButtonVisibility();
       await app.portfolio.checkSellButtonDisabled();
       await app.portfolio.checkSendButtonDisabled();
-
       await app.portfolio.expectTotalBalanceToBeZero();
       await app.portfolio.checkOneDayPerformanceIndicatorVisibility();
       await app.portfolio.clickOnPerformancePill();
@@ -108,7 +72,6 @@ test.describe("Portfolio Wallet 4.0 - With Funds", () => {
   test.use({
     teamOwner: Team.WALLET_XP,
     userdata: "1AccountBTC1AccountETH",
-    featureFlags: LWD_WALLET_40_FF_ENABLED,
   });
 
   test(
@@ -135,7 +98,6 @@ test.describe("Portfolio Wallet 4.0 - No seen device (Reborn mode)", () => {
   test.use({
     teamOwner: Team.WALLET_XP,
     userdata: "skip-onboarding",
-    featureFlags: LWD_WALLET_40_FF_ENABLED,
   });
 
   test(
@@ -160,7 +122,6 @@ test.describe("Portfolio Wallet 4.0 - add funded account", () => {
   test.use({
     teamOwner: Team.WALLET_XP,
     userdata: "1AccountSOL0Balance",
-    featureFlags: LWD_WALLET_40_FF_ENABLED,
     speculosApp: currency.speculosApp,
   });
 
@@ -180,9 +141,9 @@ test.describe("Portfolio Wallet 4.0 - add funded account", () => {
       await app.portfolio.checkBuyButtonVisibility();
       await app.portfolio.checkSellButtonDisabled();
       await app.portfolio.checkSendButtonDisabled();
-
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.accounts.clickAddAccountButtonFromAccountsPage();
+
       const selector = await getModularSelector(app, "ASSET");
       if (selector) {
         await selector.validateItems();

--- a/e2e/desktop/tests/userdata/1AccountBTC1AccountETH.json
+++ b/e2e/desktop/tests/userdata/1AccountBTC1AccountETH.json
@@ -23,6 +23,7 @@
       "loaded": true,
       "shareAnalytics": false,
       "sharePersonalizedRecommandations": false,
+      "hasSeenWalletV4Tour": true,
       "analyticsConsentInfo": {
         "consentDate": "2099-01-01T00:00:00.000Z",
         "privacyPolicyVersion": 1

--- a/e2e/desktop/tests/userdata/1AccountDOT.json
+++ b/e2e/desktop/tests/userdata/1AccountDOT.json
@@ -7,6 +7,7 @@
     },
     "settings": {
       "hasCompletedOnboarding": true,
+      "hasSeenWalletV4Tour": true,
       "lastSeenDevice": {
         "modelId": "nanoSP",
         "deviceInfo": {

--- a/e2e/desktop/tests/userdata/erc20-0-balance.json
+++ b/e2e/desktop/tests/userdata/erc20-0-balance.json
@@ -5,6 +5,7 @@
     },
     "settings": {
       "hasCompletedOnboarding": true,
+      "hasSeenWalletV4Tour": true,
       "counterValue": "USD",
       "language": "en",
       "theme": null,

--- a/e2e/desktop/tests/userdata/portfolioWithManyStablecoins.json
+++ b/e2e/desktop/tests/userdata/portfolioWithManyStablecoins.json
@@ -7,6 +7,7 @@
     },
     "settings": {
       "hasCompletedOnboarding": true,
+      "hasSeenWalletV4Tour": true,
       "counterValue": "USD",
       "language": "en",
       "theme": null,

--- a/e2e/desktop/tests/userdata/skip-onboarding-with-last-seen-device.json
+++ b/e2e/desktop/tests/userdata/skip-onboarding-with-last-seen-device.json
@@ -7,6 +7,7 @@
     },
     "settings": {
       "hasCompletedOnboarding": true,
+      "hasSeenWalletV4Tour": true,
       "counterValue": "USD",
       "language": "en",
       "theme": null,

--- a/e2e/desktop/tests/userdata/skip-onboarding.json
+++ b/e2e/desktop/tests/userdata/skip-onboarding.json
@@ -7,6 +7,7 @@
     },
     "settings": {
       "hasCompletedOnboarding": true,
+      "hasSeenWalletV4Tour": true,
       "counterValue": "USD",
       "language": "en",
       "theme": null,

--- a/e2e/desktop/tests/userdata/speculos-tests-app.json
+++ b/e2e/desktop/tests/userdata/speculos-tests-app.json
@@ -98,7 +98,7 @@
       "lastOnboardedDevice": null,
       "alwaysShowMemoTagInfo": true,
       "anonymousUserNotifications": {},
-      "hasSeenWalletV4Tour": false,
+      "hasSeenWalletV4Tour": true,
       "doNotAskAgainSkipMemo": false
     },
     "PLAYWRIGHT_RUN": {

--- a/e2e/desktop/tests/userdata/swap-history.json
+++ b/e2e/desktop/tests/userdata/swap-history.json
@@ -5,6 +5,7 @@
     },
     "settings": {
       "hasCompletedOnboarding": true,
+      "hasSeenWalletV4Tour": true,
       "counterValue": "USD",
       "language": "en",
       "locale": "en-US",

--- a/e2e/desktop/tests/utils/featureFlagUtils.ts
+++ b/e2e/desktop/tests/utils/featureFlagUtils.ts
@@ -8,48 +8,25 @@ export const getFeatureFlags = async (page: Page): Promise<OptionalFeatureMap> =
   return featureFlags;
 };
 
-export const isWallet40Enabled = async (page: Page): Promise<boolean> => {
-  const featureFlags = await getFeatureFlags(page);
-  return featureFlags.lwdWallet40?.enabled === true;
-};
-
-const lwdWallet40BaseParams = {
-  marketBanner: true,
-  graphRework: true,
-  quickActionCtas: true,
-  mainNavigation: true,
-  assetSection: true,
-} as const;
-
-// TODO: remove when wallet 4.0 is default
-export const LWD_WALLET_40_FF_ENABLED: OptionalFeatureMap = {
-  lwdWallet40: {
-    enabled: true,
-    params: { ...lwdWallet40BaseParams },
-  },
-};
-
 // TODO: remove when wallet 4.0 Q2 is default
 export const LWD_WALLET_40_Q2_FF_ENABLED: OptionalFeatureMap = {
   lwdWallet40: {
     enabled: true,
     params: {
-      ...lwdWallet40BaseParams,
+      marketBanner: true,
+      graphRework: true,
+      quickActionCtas: true,
+      mainNavigation: true,
+      assetSection: true,
       operationsList: true,
     },
   },
-};
-
-// TODO: remove when wallet 4.0 is default
-export const LWD_WALLET_40_FF_DISABLED: OptionalFeatureMap = {
-  lwdWallet40: { enabled: false },
 };
 
 export const useLocalEarnManifest = process.env.USE_LOCAL_EARN_MANIFEST === "1";
 
 export const EARN_V1_DESKTOP_FLAGS: OptionalFeatureMap = {
   ptxEarnUi: { enabled: false, params: { value: "v1" } },
-  ...LWD_WALLET_40_FF_DISABLED,
 };
 
 export const EARN_V2_DESKTOP_FLAGS: OptionalFeatureMap = {
@@ -57,5 +34,4 @@ export const EARN_V2_DESKTOP_FLAGS: OptionalFeatureMap = {
     ptxEarnLiveApp: { enabled: true, params: { manifest_id: "earn-local-manifest" } },
   }),
   ptxEarnUi: { enabled: true, params: { value: "v2" } },
-  ...LWD_WALLET_40_FF_ENABLED,
 };

--- a/e2e/desktop/tests/utils/global.setup.ts
+++ b/e2e/desktop/tests/utils/global.setup.ts
@@ -36,7 +36,6 @@ export default async function globalSetup(_config: FullConfig) {
     [
       `SPECULOS_DEVICE=${SPECULOS_DEVICE}`,
       `SPECULOS_FIRMWARE_VERSION=${SPECULOS_FIRMWARE_VERSION}`,
-      `WALLET=${process.env.E2E_ENABLE_WALLET40 === "0" ? "Legacy" : "Wallet 4.0"}`,
       "",
     ].join("\n"),
     { encoding: "utf8", flag: "w" },

--- a/tools/actions/composites/run-e2e-playwright-tests/action.yml
+++ b/tools/actions/composites/run-e2e-playwright-tests/action.yml
@@ -16,9 +16,6 @@ inputs:
   shard_total:
     description: "Total number of shards (omit to run all tests)"
     required: false
-  enable_wallet40:
-    description: "Enable Wallet 4.0 features"
-    required: false
 outputs:
   passed:
     description: "Number of passed tests"
@@ -86,14 +83,6 @@ runs:
         SHARD_ARG=""
         if [ -n "${{ inputs.shard_index }}" ] && [ -n "${{ inputs.shard_total }}" ]; then
           SHARD_ARG="--shard=${{ inputs.shard_index }}/${{ inputs.shard_total }}"
-        fi
-
-        if [[ "${{ inputs.enable_wallet40 }}" = "false" ]]; then
-          export E2E_ENABLE_WALLET40=0
-          echo "Wallet 4.0 disabled!"
-        else
-          export E2E_ENABLE_WALLET40=1
-          echo "Wallet 4.0 enabled!"
         fi
 
         set +e


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Desktop E2E test suite (Playwright): buy/sell, swap, delegate, portfolio, market, navigation, addresses
  - Removal of the `E2E_ENABLE_WALLET40` env var and `isWallet40Enabled()` helper from E2E utilities
  - Default feature flags wiring in `fixtures/common.ts` (no more legacy/4.0 conditional spread)
  - Global setup log line in `global.setup.ts` (no more `WALLET=Legacy/Wallet 4.0` output)
  - README: removed the Wallet 4.0 section (#6) and renumbered subsequent sections
  - CI: Removed all Wallet 4.0 options in the github workflow

### ⚠️ Merge Prerequisites — DO NOT MERGE UNTIL

This PR removes the legacy/4.0 toggle in E2E and assumes Wallet 4.0 is the default everywhere. It can **only** be merged once **both** of the following are in place:

- [x] **Mock-side feature flags forced to Wallet 4.0** in:
  - `apps/ledger-live-desktop/tests/specs`
  - `apps/ledger-live-mobile/e2e/specs`
- [x] **Wallet 4.0 feature flag activated on Firebase** for test builds.

Merging before these conditions are met will break test runs that rely on the (now removed) legacy/4.0 conditional path.

### Description

Wallet 4.0 is now the default and permanent UI on desktop. The desktop E2E test suite still carried the dual-mode legacy/4.0 plumbing: the `E2E_ENABLE_WALLET40` env var, the `isWallet40Enabled()` helper, the `LWD_WALLET_40_FF_ENABLED` / `LWD_WALLET_40_FF_DISABLED` flag bundles, plus `if/else` branches inside specs to handle both UIs. This added noise, duplicated assertions, and made specs harder to read.

This PR removes all Wallet 4.0 legacy toggles and conditional branches from the desktop E2E test suite, keeping only the 4.0 path. The `LWD_WALLET_40_Q2_FF_ENABLED` bundle is preserved since the Q2 rollout is still in progress. Touched files: `fixtures/common.ts`, `utils/featureFlagUtils.ts`, `utils/global.setup.ts`, specs (`buySell`, `delegate`, `entrypoint.swap`, `main.navigation`, `market`, `marketBanner`, `portfolio`, `assets.addresses`), `page/market.page.ts`, and the desktop E2E `README.md`.

### Context

- **JIRA or GitHub link**: [QAA-1116](https://ledgerhq.atlassian.net/browse/QAA-1116)
- Desktop Manual CI: https://github.com/LedgerHQ/ledger-live/actions/runs/26572953380
- Test Desktop / UI e2e smoke tests NanoSP: https://github.com/LedgerHQ/ledger-live/actions/runs/26584388866/job/78326442943?pr=17865
---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-1116]: https://ledgerhq.atlassian.net/browse/QAA-1116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ