### PR TITLE
[LWM] chore: fix bottom padding bug in product tour drawer

### DIFF
--- a/.changeset/hip-knives-admire.md
+++ b/.changeset/hip-knives-admire.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix bottom padding bug in product tour drawer

--- a/apps/ledger-live-mobile/src/mvvm/features/ProductTour/Drawer/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ProductTour/Drawer/index.tsx
@@ -3,6 +3,7 @@ import { Slides } from "@ledgerhq/native-ui";
 import Animated from "react-native-reanimated";
 import { FlatList } from "react-native-gesture-handler";
 import { Platform, StyleSheet } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import {
   Box,
   BottomSheetView,
@@ -35,6 +36,7 @@ export const ProductTourDrawer = () => {
     completeProductTour,
   } = useProductTourControls();
   const { t } = useTranslation();
+  const { bottom: bottomInset } = useSafeAreaInsets();
 
   if (!isDrawerOpen) {
     return null;
@@ -47,6 +49,7 @@ export const ProductTourDrawer = () => {
           isRequestingToBeOpened={isDrawerOpen}
           onClose={closeProductTour}
           noCloseButton
+          snapPoints={Platform.OS === "ios" ? ["80%", "90%"] : ["90%"]}
         >
           <BottomSheetView>
             <Box lx={{ flexDirection: "row", justifyContent: "flex-end", paddingBottom: "s12" }}>
@@ -80,7 +83,7 @@ export const ProductTourDrawer = () => {
                 <ProgressIndicator />
               </Slides.ProgressIndicator>
 
-              <Slides.Footer>
+              <Slides.Footer style={{ marginBottom: bottomInset }}>
                 <SlideFooterButton
                   onPrimaryAction={onPrimaryAction}
                   onComplete={completeProductTour}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Bug where not enough spacing was added at bottom of product tour.

Before:
<img width="334" height="694" alt="Screenshot 2026-05-27 at 13 59 57" src="https://github.com/user-attachments/assets/3437b1bc-db7a-4d01-98af-2e817274bc63" />

After:
<img width="336" height="689" alt="Screenshot 2026-05-27 at 13 57 50" src="https://github.com/user-attachments/assets/53a1d74b-6750-4216-9218-8e95b5016d49" />



<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-31371


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
