### PR TITLE
[LWM] feat(mobile): preselect asset networks when receiving from Asset Detail

### DIFF
--- a/.changeset/wise-pumas-explore.md
+++ b/.changeset/wise-pumas-explore.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/asset-detail": minor
+"live-mobile": patch
+---
+
+Expose resolved multi-network `ledgerIds` from `useAssetMarketData` so consumers (mobile Asset Detail → Receive flow) get the full CoinGecko list instead of the single id `marketCurrencyData.ledgerIds` collapses to when the DADA market entry wins.
+
+Add `useReceiveNetworkLedgerIds`, which resolves a token's complete network list from DADA so the Receive flow can offer every network (including ones not held yet). CoinGecko's `ledgerIds` is unreliable for tokens — it can collapse to a single network or expose only a partial subset (e.g. WETH surfaces just Ethereum + Neon while DADA knows 11 networks) — so we always query DADA and only keep its list when it is strictly more complete than the CoinGecko fallback.

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
@@ -34,6 +34,7 @@ type Props = Readonly<{
   showFallbackBanner: boolean;
   coinOptions: AssetCoinOptionsViewModel;
   isLoading: boolean;
+  ledgerIds: string[];
 }>;
 
 export function AssetDetailView({
@@ -50,6 +51,7 @@ export function AssetDetailView({
   showFallbackBanner,
   coinOptions,
   isLoading,
+  ledgerIds,
 }: Props) {
   const { bottom } = useSafeAreaInsets();
   const scrollPaddingBottom = useMemo(
@@ -73,6 +75,7 @@ export function AssetDetailView({
             knownLedgerIds={knownLedgerIds}
             knownMarketId={knownMarketId}
             hideReceive={hideReceiveInBalanceGraph}
+            ledgerIds={ledgerIds}
           />
           <BalanceDetails
             currency={currency}
@@ -98,8 +101,8 @@ export function AssetDetailView({
           <FallbackBanner show={showFallbackBanner} />
         </Box>
       </ScrollView>
-      <Footer currency={currency} />
-      <TransferDrawer currency={currency} />
+      <Footer currency={currency} ledgerIds={ledgerIds} />
+      <TransferDrawer currency={currency} ledgerIds={ledgerIds} />
       <AssetCoinOptionsSheetView
         isOpen={coinOptions.isCoinOptionsSheetOpen}
         onClose={coinOptions.closeCoinOptions}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/useBalanceGraphViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/useBalanceGraphViewModel.test.ts
@@ -320,6 +320,33 @@ describe("useBalanceGraphViewModel", () => {
       });
       expect(handleOpenReceiveDrawer).toHaveBeenCalledTimes(1);
     });
+
+    it("forwards the parent-provided ledgerIds list to useOpenReceiveDrawer", () => {
+      const ledgerIds = ["ethereum", "optimism", "arbitrum", "base"];
+
+      renderHook(() =>
+        useBalanceGraphViewModel({
+          currency: mockBtcCryptoCurrency,
+          hideReceive: false,
+          ledgerIds,
+        }),
+      );
+
+      expect(mockUseOpenReceiveDrawer).toHaveBeenCalledWith(
+        expect.objectContaining({ currency: mockBtcCryptoCurrency, currencyIds: ledgerIds }),
+      );
+    });
+
+    it("falls back to the locally derived ledgerIds when no list is threaded down", () => {
+      renderHook(() => useBalanceGraphViewModel({ currency: mockBtcCryptoCurrency }));
+
+      expect(mockUseOpenReceiveDrawer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          currency: mockBtcCryptoCurrency,
+          currencyIds: expect.any(Array),
+        }),
+      );
+    });
   });
 
   describe("ranges", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/index.tsx
@@ -9,6 +9,7 @@ type Props = Readonly<{
   knownLedgerIds?: readonly string[];
   knownMarketId?: string;
   hideReceive?: boolean;
+  ledgerIds?: string[];
 }>;
 
 export function BalanceGraph({
@@ -17,6 +18,7 @@ export function BalanceGraph({
   knownLedgerIds,
   knownMarketId,
   hideReceive,
+  ledgerIds,
 }: Props) {
   const viewModel = useBalanceGraphViewModel({
     currency,
@@ -24,6 +26,7 @@ export function BalanceGraph({
     knownLedgerIds,
     knownMarketId,
     hideReceive,
+    ledgerIds,
   });
   return <BalanceGraphView {...viewModel} />;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
@@ -63,6 +63,7 @@ type Params = {
   knownLedgerIds?: readonly string[];
   knownMarketId?: string;
   hideReceive?: boolean;
+  ledgerIds?: string[];
 };
 
 export function useBalanceGraphViewModel({
@@ -71,16 +72,26 @@ export function useBalanceGraphViewModel({
   knownLedgerIds,
   knownMarketId,
   hideReceive,
+  ledgerIds,
 }: Params) {
   const { t } = useTranslation();
   const { locale } = useLocale();
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
   const counterValueUnit = counterValueCurrency.units[0];
-  const { marketCurrency, counterCurrency, isLoading } = useAssetMarketData({
+  const {
+    marketCurrency,
+    counterCurrency,
+    isLoading,
+    ledgerIds: derivedLedgerIds,
+  } = useAssetMarketData({
     marketApiId,
     knownLedgerIds,
     knownMarketId,
   });
+  // Prefer ledgerIds explicitly threaded down by the parent (which has the
+  // distribution item's `marketId` and resolves tokens correctly). Fall back
+  // to the locally derived list when used standalone (e.g. unit tests).
+  const effectiveLedgerIds = ledgerIds ?? derivedLedgerIds;
 
   const [range, setRange] = useState<RangeKey>("1d");
 
@@ -151,6 +162,7 @@ export function useBalanceGraphViewModel({
 
   const { handleOpenReceiveDrawer } = useOpenReceiveDrawer({
     currency,
+    currencyIds: effectiveLedgerIds,
     sourceScreenName: "Asset Detail",
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/__tests__/useFooterViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/__tests__/useFooterViewModel.test.ts
@@ -6,6 +6,7 @@ import { useFooterViewModel } from "../useFooterViewModel";
 const mockHandleOpenBuySell = jest.fn();
 const mockHandleOpenSwap = jest.fn();
 const mockHandleOpenReceiveDrawer = jest.fn();
+const mockUseOpenReceiveDrawer = jest.fn();
 const mockIsCurrencyAvailable = jest.fn();
 const mockIsAcceptedCurrency = jest.fn().mockReturnValue(true);
 
@@ -26,7 +27,10 @@ jest.mock("LLM/features/Swap", () => ({
 }));
 
 jest.mock("LLM/features/Receive", () => ({
-  useOpenReceiveDrawer: () => ({ handleOpenReceiveDrawer: mockHandleOpenReceiveDrawer }),
+  useOpenReceiveDrawer: (params: unknown) => {
+    mockUseOpenReceiveDrawer(params);
+    return { handleOpenReceiveDrawer: mockHandleOpenReceiveDrawer };
+  },
 }));
 
 const bitcoin = getCryptoCurrencyById("bitcoin");
@@ -98,6 +102,23 @@ describe("useFooterViewModel", () => {
         page: "Asset Detail",
       });
       expect(mockHandleOpenReceiveDrawer).toHaveBeenCalled();
+    });
+
+    it("forwards the multi-network ledgerIds list to useOpenReceiveDrawer", () => {
+      const ledgerIds = ["ethereum", "optimism", "arbitrum", "base"];
+      renderHook(() => useFooterViewModel(bitcoin, ledgerIds));
+
+      expect(mockUseOpenReceiveDrawer).toHaveBeenCalledWith(
+        expect.objectContaining({ currency: bitcoin, currencyIds: ledgerIds }),
+      );
+    });
+
+    it("forwards currencyIds: undefined when no ledgerIds are provided", () => {
+      renderHook(() => useFooterViewModel(bitcoin));
+
+      expect(mockUseOpenReceiveDrawer).toHaveBeenCalledWith(
+        expect.objectContaining({ currency: bitcoin, currencyIds: undefined }),
+      );
     });
 
     it.each(["onBuyPress", "onSwapPress", "onReceivePress"] as const)(

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/index.tsx
@@ -3,7 +3,12 @@ import type { AssetDetailCurrencyProps } from "LLM/features/AssetDetail/types";
 import { useFooterViewModel } from "./useFooterViewModel";
 import { FooterView } from "./FooterView";
 
-export function Footer({ currency }: Readonly<{ currency: AssetDetailCurrencyProps }>) {
-  const viewModel = useFooterViewModel(currency);
+type Props = Readonly<{
+  currency: AssetDetailCurrencyProps;
+  ledgerIds?: string[];
+}>;
+
+export function Footer({ currency, ledgerIds }: Props) {
+  const viewModel = useFooterViewModel(currency, ledgerIds);
   return <FooterView {...viewModel} />;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/useFooterViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/useFooterViewModel.ts
@@ -34,7 +34,7 @@ export function useSecondaryButtonType(currency: AssetDetailCurrencyProps): Seco
   }, [accounts, currency, isAcceptedCurrency]);
 }
 
-export function useFooterViewModel(currency: AssetDetailCurrencyProps) {
+export function useFooterViewModel(currency: AssetDetailCurrencyProps, ledgerIds?: string[]) {
   const { handleOpenBuySell } = useOpenBuySell({
     currency,
     sourceScreenName: "Asset Detail",
@@ -47,6 +47,7 @@ export function useFooterViewModel(currency: AssetDetailCurrencyProps) {
 
   const { handleOpenReceiveDrawer } = useOpenReceiveDrawer({
     currency,
+    currencyIds: ledgerIds,
     sourceScreenName: "Asset Detail",
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/__tests__/useMarketStatsViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/__tests__/useMarketStatsViewModel.test.ts
@@ -14,6 +14,7 @@ function mockMarketData(overrides?: Partial<ReturnType<typeof useAssetMarketData
     marketCurrency: marketCurrencyData as any,
     marketId: "bitcoin",
     counterCurrency: "usd",
+    ledgerIds: ["bitcoin"],
     isLoading: false,
     isError: false,
     ...overrides,

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/__tests__/usePricePerformanceViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/__tests__/usePricePerformanceViewModel.test.ts
@@ -13,6 +13,7 @@ function mockMarketData(overrides?: Partial<ReturnType<typeof useAssetMarketData
     marketCurrency: marketCurrencyData as any,
     marketId: "bitcoin",
     counterCurrency: "usd",
+    ledgerIds: ["bitcoin"],
     isLoading: false,
     isError: false,
     ...overrides,

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/__tests__/useAssetMarketData.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/__tests__/useAssetMarketData.test.ts
@@ -126,4 +126,24 @@ describe("useAssetMarketData", () => {
       expect(result.current.isLoading).toBe(false);
     });
   });
+
+  describe("ledgerIds", () => {
+    it("returns [] when no known ledger ids are provided", () => {
+      const { result } = renderHook(() => useAssetMarketData({}));
+
+      expect(result.current.ledgerIds).toEqual([]);
+    });
+
+    it("falls back to knownLedgerIds while market data has not resolved yet", () => {
+      const { result } = renderHook(() =>
+        useAssetMarketData({
+          marketApiId: mockBtcCryptoCurrency.id,
+          knownLedgerIds: [mockBtcCryptoCurrency.id],
+        }),
+      );
+
+      expect(result.current.marketCurrency).toBeUndefined();
+      expect(result.current.ledgerIds).toEqual([mockBtcCryptoCurrency.id]);
+    });
+  });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/__tests__/useReceiveNetworkLedgerIds.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/__tests__/useReceiveNetworkLedgerIds.test.ts
@@ -1,0 +1,73 @@
+import { renderHook, waitFor } from "@tests/test-renderer";
+import { mockData } from "@ledgerhq/live-common/modularDrawer/__mocks__/dada.mock";
+import { useReceiveNetworkLedgerIds } from "../useReceiveNetworkLedgerIds";
+
+const TETHER_META_ID = "urn:crypto:meta-currency:tether";
+const TETHER_NETWORK_LEDGER_IDS = Object.values(mockData.cryptoAssets[TETHER_META_ID].assetsIds);
+const SINGLE_USDT_ID = "ethereum/erc20/usd_tether__erc20_";
+
+describe("useReceiveNetworkLedgerIds", () => {
+  describe("token expansion", () => {
+    it("expands a token meta-currency to all of its network ledger ids", async () => {
+      const { result } = renderHook(() =>
+        useReceiveNetworkLedgerIds({
+          metaCurrencyId: TETHER_META_ID,
+          ticker: "USDT",
+          fallbackLedgerIds: [SINGLE_USDT_ID],
+        }),
+      );
+
+      await waitFor(() => expect(result.current.length).toBeGreaterThan(1));
+
+      expect(result.current).toEqual(TETHER_NETWORK_LEDGER_IDS);
+      expect(result.current).toContain("tron/trc20/tr7nhqjekqxgtci8q8zy4pl8otszgjlj6t");
+    });
+
+    it("expands when the fallback holds only a partial multi-network list", async () => {
+      // CoinGecko can surface a partial subset (here 2 of the tether networks);
+      // DADA still knows the full list, so we must expand rather than trust it.
+      const partialFallback = [SINGLE_USDT_ID, "tron/trc20/tr7nhqjekqxgtci8q8zy4pl8otszgjlj6t"];
+      const { result } = renderHook(() =>
+        useReceiveNetworkLedgerIds({
+          metaCurrencyId: TETHER_META_ID,
+          ticker: "USDT",
+          fallbackLedgerIds: partialFallback,
+        }),
+      );
+
+      await waitFor(() => expect(result.current.length).toBeGreaterThan(partialFallback.length));
+
+      expect(result.current).toEqual(TETHER_NETWORK_LEDGER_IDS);
+    });
+  });
+
+  describe("fallback", () => {
+    it("returns the fallback when no meta-currency is provided", () => {
+      const fallback = [SINGLE_USDT_ID];
+      const { result } = renderHook(() =>
+        useReceiveNetworkLedgerIds({
+          metaCurrencyId: undefined,
+          ticker: "USDT",
+          fallbackLedgerIds: fallback,
+        }),
+      );
+
+      expect(result.current).toEqual(fallback);
+    });
+
+    it("keeps the fallback when the catalog does not expand the asset to multiple networks", async () => {
+      const fallback = ["dogecoin"];
+      const { result } = renderHook(() =>
+        useReceiveNetworkLedgerIds({
+          metaCurrencyId: TETHER_META_ID,
+          ticker: "DOGE",
+          fallbackLedgerIds: fallback,
+        }),
+      );
+
+      // The DOGE search never yields the tether meta, so the list stays the fallback.
+      await waitFor(() => expect(result.current).toEqual(fallback));
+      expect(result.current).toEqual(fallback);
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/useAssetMarketData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/useAssetMarketData.ts
@@ -19,7 +19,7 @@ type Params = {
 export function useAssetMarketData({ marketApiId, knownLedgerIds, knownMarketId }: Params) {
   const counterCurrency = useSelector(counterValueCurrencySelector).ticker.toLowerCase();
 
-  const { marketCurrencyData, marketId, isLoading, isError } = useSharedAssetMarketData({
+  const { marketCurrencyData, marketId, ledgerIds, isLoading, isError } = useSharedAssetMarketData({
     marketApiId,
     knownLedgerIds,
     counterCurrency,
@@ -32,6 +32,7 @@ export function useAssetMarketData({ marketApiId, knownLedgerIds, knownMarketId 
     marketCurrency: marketCurrencyData,
     marketId,
     counterCurrency,
+    ledgerIds,
     isLoading,
     isError,
   };

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/useReceiveNetworkLedgerIds.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/useReceiveNetworkLedgerIds.ts
@@ -1,0 +1,24 @@
+import VersionNumber from "react-native-version-number";
+import { useReceiveNetworkLedgerIds as useSharedReceiveNetworkLedgerIds } from "@ledgerhq/asset-detail";
+import type { ReceiveNetworkLedgerIdsInput } from "@ledgerhq/asset-detail";
+import useEnv from "@ledgerhq/live-common/hooks/useEnv";
+import { useFeature } from "@features/platform-feature-flags";
+
+type Params = Omit<
+  ReceiveNetworkLedgerIdsInput,
+  "product" | "version" | "isStaging" | "includeTestNetworks"
+>;
+
+export function useReceiveNetworkLedgerIds(params: Params): string[] {
+  const modularDrawerFeature = useFeature("llmModularDrawer");
+  const devMode = useEnv("MANAGER_DEV_MODE");
+  const isStaging = modularDrawerFeature?.params?.backendEnvironment === "STAGING";
+
+  return useSharedReceiveNetworkLedgerIds({
+    ...params,
+    product: "llm",
+    version: VersionNumber.appVersion,
+    isStaging,
+    includeTestNetworks: devMode,
+  });
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
@@ -14,6 +14,7 @@ import type { AssetDetailNavigatorParamsList } from "../../types";
 import { useIsBuyAvailable, useSecondaryButtonType } from "./components/Footer/useFooterViewModel";
 import { useAssetCoinOptionsViewModel } from "./components/CoinOptions/useAssetCoinOptionsViewModel";
 import { useAssetMarketData } from "./hooks/useAssetMarketData";
+import { useReceiveNetworkLedgerIds } from "./hooks/useReceiveNetworkLedgerIds";
 
 type Route = StackNavigatorProps<AssetDetailNavigatorParamsList, ScreenName.AssetDetail>["route"];
 
@@ -57,7 +58,22 @@ export function useAssetDetailViewModel() {
   const accounts = useSelector(shallowAccountsSelector);
   const walletHasFunds = useMemo(() => accounts.some(a => a.balance.gt(0)), [accounts]);
   const showFallbackBanner = !hasFooter && walletHasFunds && !!currency;
-  const { marketId } = useAssetMarketData({ marketApiId, knownLedgerIds, knownMarketId });
+  const { marketId, ledgerIds, marketCurrency } = useAssetMarketData({
+    marketApiId,
+    knownLedgerIds,
+    knownMarketId,
+  });
+  // Tokens (e.g. USDT/USDC) collapse to a single ledger id here because CoinGecko
+  // does not expose their multi-network list. Expand it from DADA so the receive
+  // drawer can offer every network, including ones not held yet. The market ticker
+  // is the fallback for not-held assets, where `currency` may be unresolved.
+  const receiveLedgerIds = useReceiveNetworkLedgerIds({
+    metaCurrencyId: distributionItem?.metaCurrencyId,
+    marketApiId,
+    ticker: currency?.ticker ?? marketCurrency?.ticker,
+    currencyId: currency?.id,
+    fallbackLedgerIds: ledgerIds,
+  });
   const coinOptions = useAssetCoinOptionsViewModel({ currency, currencyId, marketId });
 
   return {
@@ -74,5 +90,6 @@ export function useAssetDetailViewModel() {
     showFallbackBanner,
     coinOptions,
     isLoading,
+    ledgerIds: receiveLedgerIds,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/__integrations__/TransferDrawer.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/__integrations__/TransferDrawer.integration.test.tsx
@@ -5,9 +5,15 @@ import { track } from "~/analytics";
 import { overrideStateWithFunds } from "LLM/features/QuickActions/__integrations__/shared";
 import { State } from "~/reducers/types";
 import type { Account } from "@ledgerhq/types-live";
+import type { useOpenReceiveDrawer } from "LLM/features/Receive";
 
 const mockNavigate = jest.fn();
 const mockHandleOpenReceiveDrawer = jest.fn();
+const mockUseOpenReceiveDrawer = jest.fn(
+  (..._args: Parameters<typeof useOpenReceiveDrawer>) => ({
+    handleOpenReceiveDrawer: mockHandleOpenReceiveDrawer,
+  }),
+);
 
 jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
   useAccountBridge: jest.fn(),
@@ -23,7 +29,8 @@ jest.mock("@react-navigation/native", () => ({
 }));
 
 jest.mock("LLM/features/Receive", () => ({
-  useOpenReceiveDrawer: () => ({ handleOpenReceiveDrawer: mockHandleOpenReceiveDrawer }),
+  useOpenReceiveDrawer: (...args: Parameters<typeof useOpenReceiveDrawer>) =>
+    mockUseOpenReceiveDrawer(...args),
 }));
 
 jest.mock("LLM/features/Noah/useNoahEntryPoint", () => ({
@@ -48,8 +55,8 @@ describe("TransferDrawer Navigation", () => {
     jest.clearAllMocks();
   });
 
-  const renderViewModel = () =>
-    renderHook(() => useTransferDrawerViewModel(), {
+  const renderViewModel = (params?: Parameters<typeof useTransferDrawerViewModel>[0]) =>
+    renderHook(() => useTransferDrawerViewModel(params), {
       overrideInitialState: overrideWithOpenDrawer,
     });
 
@@ -101,5 +108,27 @@ describe("TransferDrawer Navigation", () => {
       buttonLocation: "quick_action_transfer",
       page: SOURCE_SCREEN,
     });
+  });
+
+  it("forwards ledgerIds to useOpenReceiveDrawer for multi-network pre-selection", () => {
+    const ledgerIds = [
+      "ethereum/erc20/usd_coin",
+      "polygon/erc20/usd_coin",
+      "base/erc20/usd_coin",
+    ];
+
+    renderViewModel({ ledgerIds });
+
+    expect(mockUseOpenReceiveDrawer).toHaveBeenCalledWith(
+      expect.objectContaining({ currencyIds: ledgerIds }),
+    );
+  });
+
+  it("does not pass currencyIds when ledgerIds is omitted", () => {
+    renderViewModel();
+
+    expect(mockUseOpenReceiveDrawer).toHaveBeenCalledWith(
+      expect.objectContaining({ currencyIds: undefined }),
+    );
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/index.tsx
@@ -9,6 +9,7 @@ import { useTransferDrawerViewModel } from "./useTransferDrawerViewModel";
 
 type Props = Readonly<{
   currency?: CryptoOrTokenCurrency;
+  ledgerIds?: string[];
 }>;
 
 /**
@@ -19,9 +20,10 @@ type Props = Readonly<{
  * - Send crypto: Navigates to send flow
  * - Bank transfer: Navigates to buy flow for stablecoin purchases
  */
-export const TransferDrawer = ({ currency }: Props = {}) => {
+export const TransferDrawer = ({ currency, ledgerIds }: Props = {}) => {
   const { isOpen, title, actions, handleClose, bottomInset } = useTransferDrawerViewModel({
     currency,
+    ledgerIds,
   });
   const { isEnabled } = useWalletFeaturesConfig("mobile");
 

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/useTransferDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/useTransferDrawerViewModel.ts
@@ -33,10 +33,12 @@ interface TransferDrawerViewModel {
 
 interface UseTransferDrawerViewModelParams {
   currency?: CryptoOrTokenCurrency;
+  ledgerIds?: string[];
 }
 
 export const useTransferDrawerViewModel = ({
   currency,
+  ledgerIds,
 }: UseTransferDrawerViewModelParams = {}): TransferDrawerViewModel => {
   const { t } = useTranslation();
   const { bottom: bottomInset } = useSafeAreaInsets();
@@ -49,8 +51,10 @@ export const useTransferDrawerViewModel = ({
   const hasFunds = !useAreAccountsEmpty() && hasAnyAccounts;
 
   const { handleOpenReceiveDrawer } = useOpenReceiveDrawer({
+    currency,
     sourceScreenName,
     fromMenu: true,
+    currencyIds: ledgerIds,
   });
 
   const { showNoahMenu: showNoahOption } = useReceiveNoahEntry({ currency });

--- a/apps/ledger-live-mobile/src/mvvm/features/Receive/__tests__/useOpenReceiveDrawer.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Receive/__tests__/useOpenReceiveDrawer.test.tsx
@@ -121,6 +121,67 @@ describe("useOpenReceiveDrawer", () => {
         onAccountSelected: expect.any(Function),
       });
     });
+
+    it("should pre-filter on currencyIds when provided (multi-network asset)", () => {
+      const ledgerIds = [
+        "ethereum/erc20/usd_coin",
+        "polygon/erc20/usd_coin",
+        "base/erc20/usd_coin",
+      ];
+
+      const { result } = renderHook(() =>
+        useOpenReceiveDrawer(createTestProps({ currencyIds: ledgerIds })),
+      );
+
+      act(() => {
+        result.current.handleOpenReceiveDrawer();
+      });
+
+      expect(mockOpenDrawer).toHaveBeenCalledWith({
+        currencies: ledgerIds,
+        flow: "receive_flow",
+        source: "test_screen",
+        areCurrenciesFiltered: true,
+        enableAccountSelection: true,
+        onAccountSelected: expect.any(Function),
+      });
+    });
+
+    it("should give currencyIds priority over currency when both are provided", () => {
+      const ledgerIds = ["ethereum/erc20/usd_coin", "polygon/erc20/usd_coin"];
+
+      const { result } = renderHook(() =>
+        useOpenReceiveDrawer(createTestProps({ currencyIds: ledgerIds })),
+      );
+
+      act(() => {
+        result.current.handleOpenReceiveDrawer();
+      });
+
+      expect(mockOpenDrawer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          currencies: ledgerIds,
+          areCurrenciesFiltered: true,
+        }),
+      );
+    });
+
+    it("should fall back to [currency.id] when currencyIds is an empty array", () => {
+      const { result } = renderHook(() =>
+        useOpenReceiveDrawer(createTestProps({ currencyIds: [] })),
+      );
+
+      act(() => {
+        result.current.handleOpenReceiveDrawer();
+      });
+
+      expect(mockOpenDrawer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          currencies: [mockEthCryptoCurrency.id],
+          areCurrenciesFiltered: true,
+        }),
+      );
+    });
   });
 
   describe("when Noah menu is enabled", () => {
@@ -137,6 +198,7 @@ describe("useOpenReceiveDrawer", () => {
 
       expect(mockOpenReceiveOptionsDrawer).toHaveBeenCalledWith({
         currency: mockEthCryptoCurrency,
+        currencyIds: undefined,
         sourceScreenName: "test_screen",
         fromMenu: undefined,
       });
@@ -154,8 +216,28 @@ describe("useOpenReceiveDrawer", () => {
 
       expect(mockOpenReceiveOptionsDrawer).toHaveBeenCalledWith({
         currency: mockEthCryptoCurrency,
+        currencyIds: undefined,
         sourceScreenName: "test_screen",
         fromMenu: true,
+      });
+    });
+
+    it("should forward currencyIds to the receive options drawer (multi-network pre-selection)", () => {
+      const ledgerIds = ["ethereum", "optimism", "arbitrum", "base"];
+
+      const { result } = renderHook(() =>
+        useOpenReceiveDrawer(createTestProps({ currencyIds: ledgerIds })),
+      );
+
+      act(() => {
+        result.current.handleOpenReceiveDrawer();
+      });
+
+      expect(mockOpenReceiveOptionsDrawer).toHaveBeenCalledWith({
+        currency: mockEthCryptoCurrency,
+        currencyIds: ledgerIds,
+        sourceScreenName: "test_screen",
+        fromMenu: undefined,
       });
     });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Receive/drawers/useReceiveFundsOptionsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Receive/drawers/useReceiveFundsOptionsViewModel.ts
@@ -16,11 +16,12 @@ function useReceiveFundsOptionsViewModel() {
   const navigation = useNavigation();
   const { isEnabled } = useWalletFeaturesConfig("mobile");
 
-  const { currency, sourceScreenName, fromMenu, isOpen, closeDrawer } =
+  const { currency, currencyIds, sourceScreenName, fromMenu, isOpen, closeDrawer } =
     useReceiveOptionsDrawerController();
 
   const { handleOpenReceiveDrawer } = useOpenReceiveDrawer({
     currency: isCryptoOrTokenCurrency(currency) ? currency : undefined,
+    currencyIds,
     sourceScreenName,
     fromMenu,
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/Receive/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Receive/index.ts
@@ -13,6 +13,12 @@ import { useReceiveOptionsDrawerController } from "./useReceiveOptionsDrawerCont
 
 type Props = {
   currency?: CryptoOrTokenCurrency;
+  /**
+   * Pre-selection list of ledger currency ids forwarded to the Modular Drawer.
+   * When non-empty, takes priority over `currency` to pre-select every network
+   * of a multi-network asset (e.g. USDC on Ethereum + Polygon + Base).
+   */
+  currencyIds?: string[];
   sourceScreenName: string;
   navigationOverride?: RootNavigation;
   hideBackButton?: boolean;
@@ -20,6 +26,7 @@ type Props = {
 };
 export function useOpenReceiveDrawer({
   currency,
+  currencyIds,
   sourceScreenName,
   navigationOverride,
   hideBackButton,
@@ -74,15 +81,18 @@ export function useOpenReceiveDrawer({
       if (showNoahMenu && !fromReceiveOptionsDrawer) {
         openReceiveOptionsDrawer({
           currency: currency,
+          currencyIds: currencyIds,
           sourceScreenName: sourceScreenName,
           fromMenu: fromMenu,
         });
       } else {
+        const hasCurrencyIds = !!currencyIds?.length;
+        const currencies = hasCurrencyIds ? currencyIds : currency ? [currency.id] : [];
         return openDrawer({
-          currencies: currency ? [currency.id] : [],
+          currencies,
           flow: "receive_flow",
           source: sourceScreenName,
-          areCurrenciesFiltered: !!currency,
+          areCurrenciesFiltered: hasCurrencyIds || !!currency,
           enableAccountSelection: true,
           onAccountSelected: openReceiveConfirmation,
         });
@@ -90,6 +100,7 @@ export function useOpenReceiveDrawer({
     },
     [
       currency,
+      currencyIds,
       openDrawer,
       sourceScreenName,
       openReceiveConfirmation,

--- a/apps/ledger-live-mobile/src/mvvm/features/Receive/useReceiveOptionsDrawerController.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Receive/useReceiveOptionsDrawerController.ts
@@ -16,19 +16,21 @@ import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 export const useReceiveOptionsDrawerController = () => {
   const dispatch = useDispatch();
 
-  const { isOpen, currency, sourceScreenName, fromMenu } = useSelector(
+  const { isOpen, currency, currencyIds, sourceScreenName, fromMenu } = useSelector(
     receiveOptionsDrawerStateSelector,
   );
 
   const openDrawer = useCallback(
     (params?: {
       currency?: CryptoOrTokenCurrency;
+      currencyIds?: string[];
       sourceScreenName: string;
       fromMenu?: boolean;
     }) => {
       dispatch(
         openReceiveOptionsDrawer({
           currency: params?.currency,
+          currencyIds: params?.currencyIds,
           sourceScreenName: params?.sourceScreenName ?? "",
           fromMenu: params?.fromMenu,
         }),
@@ -44,6 +46,7 @@ export const useReceiveOptionsDrawerController = () => {
   return {
     isOpen,
     currency,
+    currencyIds,
     sourceScreenName,
     fromMenu,
     openDrawer,

--- a/apps/ledger-live-mobile/src/reducers/receiveOptionsDrawer.ts
+++ b/apps/ledger-live-mobile/src/reducers/receiveOptionsDrawer.ts
@@ -5,6 +5,7 @@ import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 export interface ReceiveOptionsDrawerState {
   isOpen: boolean;
   currency?: CryptoOrTokenCurrency;
+  currencyIds?: string[];
   sourceScreenName: string;
   fromMenu?: boolean;
 }
@@ -12,6 +13,7 @@ export interface ReceiveOptionsDrawerState {
 export const INITIAL_STATE: ReceiveOptionsDrawerState = {
   isOpen: false,
   currency: undefined,
+  currencyIds: undefined,
   sourceScreenName: "",
   fromMenu: false,
 };
@@ -27,16 +29,18 @@ const receiveOptionsDrawerSlice = createSlice({
       state,
       action: PayloadAction<{
         currency?: CryptoOrTokenCurrency;
+        currencyIds?: string[];
         sourceScreenName: string;
         fromMenu?: boolean;
       }>,
     ) => {
       state.isOpen = true;
-      const { currency, sourceScreenName, fromMenu } = action.payload;
+      const { currency, currencyIds, sourceScreenName, fromMenu } = action.payload;
 
       if (currency !== undefined) {
         state.currency = currency;
       }
+      state.currencyIds = currencyIds;
       if (sourceScreenName !== undefined) {
         state.sourceScreenName = sourceScreenName;
       }
@@ -47,6 +51,7 @@ const receiveOptionsDrawerSlice = createSlice({
     closeReceiveOptionsDrawer: state => {
       state.isOpen = false;
       state.currency = undefined;
+      state.currencyIds = undefined;
       state.sourceScreenName = "";
       state.fromMenu = false;
     },

--- a/libs/asset-detail/package.json
+++ b/libs/asset-detail/package.json
@@ -21,6 +21,7 @@
   "types": "lib/index.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
+    "@ledgerhq/asset-aggregation": "workspace:*",
     "@ledgerhq/live-common": "workspace:*",
     "@ledgerhq/types-cryptoassets": "workspace:*"
   },

--- a/libs/asset-detail/src/hooks/__tests__/resolveNetworkLedgerIds.test.ts
+++ b/libs/asset-detail/src/hooks/__tests__/resolveNetworkLedgerIds.test.ts
@@ -1,0 +1,72 @@
+import type { AssetsDataWithPagination } from "@ledgerhq/live-common/dada-client/state-manager/types";
+import { resolveNetworkLedgerIds } from "../useReceiveNetworkLedgerIds";
+
+const TETHER_META_ID = "urn:crypto:meta-currency:tether";
+const USD_COIN_META_ID = "urn:crypto:meta-currency:usd_coin";
+
+const TETHER_LEDGER_IDS = {
+  ethereum: "ethereum/erc20/usd_tether__erc20_",
+  tron: "tron/trc20/tr7nhqjekqxgtci8q8zy4pl8otszgjlj6t",
+  polygon: "polygon/erc20/_pos__tether_usd",
+};
+const USD_COIN_LEDGER_IDS = {
+  ethereum: "ethereum/erc20/usd_coin",
+  polygon: "polygon/erc20/usd_coin",
+  base: "base/erc20/usd_base_coin",
+};
+
+const data = {
+  cryptoAssets: {
+    [TETHER_META_ID]: {
+      id: TETHER_META_ID,
+      ticker: "USDT",
+      name: "Tether USD",
+      assetsIds: TETHER_LEDGER_IDS,
+    },
+    [USD_COIN_META_ID]: {
+      id: USD_COIN_META_ID,
+      ticker: "USDC",
+      name: "USD Coin",
+      assetsIds: USD_COIN_LEDGER_IDS,
+    },
+  },
+} as unknown as AssetsDataWithPagination;
+
+describe("resolveNetworkLedgerIds", () => {
+  it("returns [] when no data is available yet", () => {
+    expect(resolveNetworkLedgerIds(undefined, { metaCurrencyId: TETHER_META_ID })).toEqual([]);
+  });
+
+  it("resolves by exact meta-currency id (held asset)", () => {
+    expect(resolveNetworkLedgerIds(data, { metaCurrencyId: TETHER_META_ID })).toEqual(
+      Object.values(TETHER_LEDGER_IDS),
+    );
+  });
+
+  it("resolves by market slug when the exact meta id is missing (not held)", () => {
+    expect(resolveNetworkLedgerIds(data, { marketApiId: "usd-coin" })).toEqual(
+      Object.values(USD_COIN_LEDGER_IDS),
+    );
+  });
+
+  it("falls back to scanning by a known currency id", () => {
+    expect(resolveNetworkLedgerIds(data, { currencyId: "polygon/erc20/_pos__tether_usd" })).toEqual(
+      Object.values(TETHER_LEDGER_IDS),
+    );
+  });
+
+  it("prefers the market slug match over the currency id scan", () => {
+    expect(
+      resolveNetworkLedgerIds(data, {
+        marketApiId: "usd-coin",
+        currencyId: "ethereum/erc20/usd_tether__erc20_",
+      }),
+    ).toEqual(Object.values(USD_COIN_LEDGER_IDS));
+  });
+
+  it("returns [] when no hint matches", () => {
+    expect(
+      resolveNetworkLedgerIds(data, { marketApiId: "unknown", currencyId: "unknown" }),
+    ).toEqual([]);
+  });
+});

--- a/libs/asset-detail/src/hooks/useAssetMarketData.ts
+++ b/libs/asset-detail/src/hooks/useAssetMarketData.ts
@@ -77,10 +77,20 @@ export function useAssetMarketData({
     [assetData],
   );
 
+  // CoinGecko's response carries the full multi-network list. `marketCurrencyData`
+  // can lose it when the DADA branch wins (its `ledgerIds` is scoped to a single
+  // id), so prefer `marketFromHook?.ledgerIds` and fall back to whatever's left.
+  const ledgerIds = useMemo<string[]>(() => {
+    if (marketFromHook?.ledgerIds?.length) return marketFromHook.ledgerIds;
+    if (marketCurrencyData?.ledgerIds?.length) return marketCurrencyData.ledgerIds;
+    return knownLedgerIds ? [...knownLedgerIds] : [];
+  }, [marketFromHook?.ledgerIds, marketCurrencyData?.ledgerIds, knownLedgerIds]);
+
   return {
     marketCurrencyData,
     marketId: marketFromHook?.id ?? knownMarketId,
     ledgerCurrencyFromDada,
+    ledgerIds,
     isLoading: isLoadingMarket || isLoadingDada || (!!dadaMarket && rateStatus === "loading"),
     isError: isErrorMarket || isErrorDada || (!!dadaMarket && rateStatus === "error"),
   };

--- a/libs/asset-detail/src/hooks/useReceiveNetworkLedgerIds.ts
+++ b/libs/asset-detail/src/hooks/useReceiveNetworkLedgerIds.ts
@@ -1,0 +1,75 @@
+import { useMemo } from "react";
+import { toSlug } from "@ledgerhq/asset-aggregation/assetDistribution/index";
+import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssetsData";
+import type { AssetsDataWithPagination } from "@ledgerhq/live-common/dada-client/state-manager/types";
+import type { ReceiveNetworkLedgerIdsInput } from "../types";
+
+type MetaHints = Pick<
+  ReceiveNetworkLedgerIdsInput,
+  "metaCurrencyId" | "marketApiId" | "currencyId"
+>;
+
+/**
+ * Resolves the meta-currency network list from the search payload, trying the
+ * exact meta id first (held asset), then the meta whose canonical slug matches
+ * the market id (not held), then scanning for the meta that contains a known
+ * currency id.
+ */
+export function resolveNetworkLedgerIds(
+  data: AssetsDataWithPagination | undefined,
+  { metaCurrencyId, marketApiId, currencyId }: MetaHints,
+): string[] {
+  if (!data) return [];
+
+  const exactMeta = metaCurrencyId ? data.cryptoAssets[metaCurrencyId] : undefined;
+  if (exactMeta) return Object.values(exactMeta.assetsIds);
+
+  let currencyMatch: string[] | undefined;
+  for (const [metaId, meta] of Object.entries(data.cryptoAssets)) {
+    const ledgerIds = Object.values(meta.assetsIds);
+    if (marketApiId && toSlug(metaId) === marketApiId) return ledgerIds;
+    if (!currencyMatch && currencyId && ledgerIds.includes(currencyId)) currencyMatch = ledgerIds;
+  }
+
+  return currencyMatch ?? [];
+}
+
+/**
+ * Resolves a token meta-currency's full network list so a receive flow can offer
+ * every network, including ones not held yet.
+ *
+ * CoinGecko's `ledgerIds` is unreliable for tokens (partial or collapsed), so we
+ * query DADA — the source of truth — and keep its list only when more complete.
+ * Platform-agnostic: callers inject `product`, `version` and the DADA env flags.
+ */
+export function useReceiveNetworkLedgerIds({
+  metaCurrencyId,
+  marketApiId,
+  ticker,
+  currencyId,
+  fallbackLedgerIds,
+  product,
+  version,
+  isStaging = false,
+  includeTestNetworks = false,
+}: ReceiveNetworkLedgerIdsInput): string[] {
+  // DADA owns the complete network list, so query it whenever we can identify the meta.
+  const shouldResolve = Boolean(ticker && (metaCurrencyId || marketApiId || currencyId));
+
+  const { data } = useAssetsData({
+    search: ticker,
+    product,
+    version,
+    areCurrenciesFiltered: false,
+    isStaging,
+    includeTestNetworks,
+    skip: !shouldResolve,
+  });
+
+  return useMemo(() => {
+    if (!shouldResolve) return fallbackLedgerIds;
+    const ledgerIds = resolveNetworkLedgerIds(data, { metaCurrencyId, marketApiId, currencyId });
+    // Keep DADA's list only when it is more complete than the fallback.
+    return ledgerIds.length > fallbackLedgerIds.length ? ledgerIds : fallbackLedgerIds;
+  }, [shouldResolve, data, metaCurrencyId, marketApiId, currencyId, fallbackLedgerIds]);
+}

--- a/libs/asset-detail/src/index.ts
+++ b/libs/asset-detail/src/index.ts
@@ -1,8 +1,10 @@
 export * from "./hooks/useAssetMarketData";
+export * from "./hooks/useReceiveNetworkLedgerIds";
 export * from "./utils/assetDetailMarketInfo";
 export type {
   AssetDetailMarketInfo,
   AssetMarketData,
   AssetMarketDataInput,
   AssetMarketDataResult,
+  ReceiveNetworkLedgerIdsInput,
 } from "./types";

--- a/libs/asset-detail/src/types.ts
+++ b/libs/asset-detail/src/types.ts
@@ -25,8 +25,39 @@ export type AssetMarketData = Readonly<{
   isLoading: boolean;
 }>;
 
+export type ReceiveNetworkLedgerIdsInput = Readonly<{
+  /**
+   * DADA meta-currency id of the focused asset (e.g. "urn:crypto:meta-currency:tether").
+   * Only available when the asset is held (resolved from the distribution item).
+   */
+  metaCurrencyId?: string;
+  /**
+   * Resolved market API id (e.g. "tether", "usd-coin"). Used to locate the
+   * meta-currency when the asset is not held and `metaCurrencyId` is missing —
+   * its slug (`toSlug`) matches the market id.
+   */
+  marketApiId?: string;
+  /** Asset ticker used to search the unfiltered DADA catalog (e.g. "USDT"). */
+  ticker?: string;
+  /** A known ledger currency id of the asset, used as a last-resort meta matcher. */
+  currencyId?: string;
+  /** Ledger ids already resolved by the market data hook, used as a fallback. */
+  fallbackLedgerIds: string[];
+  product: "lld" | "llm";
+  version: string;
+  isStaging?: boolean;
+  includeTestNetworks?: boolean;
+}>;
+
 export type AssetMarketDataResult = AssetMarketData &
   Readonly<{
     ledgerCurrencyFromDada?: CryptoOrTokenCurrency;
+    /**
+     * Resolved full multi-network list of ledger currency ids for the asset
+     * (e.g. USDC on Ethereum + Polygon + Base). Recovers the CoinGecko list
+     * that `marketCurrencyData.ledgerIds` collapses to a single id once the
+     * DADA market entry wins.
+     */
+    ledgerIds: string[];
     isError: boolean;
   }>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3584,6 +3584,9 @@ importers:
 
   libs/asset-detail:
     dependencies:
+      '@ledgerhq/asset-aggregation':
+        specifier: workspace:*
+        version: link:../asset-aggregation
       '@ledgerhq/live-common':
         specifier: workspace:*
         version: link:../ledger-live-common


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Asset Detail screen → tapping the Receive button (or Transfer → Receive) should pre-select every network of the asset in the Modular Drawer (instead of jumping straight to a single-account picker or showing the full asset list)
  - Verify with **multi-network tokens** (USDC on Ethereum + Polygon + Base, USDT, ETH on Ethereum + Optimism + Arbitrum + Base)
  - Verify you can **receive on a network you don't hold yet** (e.g. USDC on a chain with no existing account)
  - Verify with **native single-network crypto** (BTC, SOL) — no regression: still pre-selects the single network
  - Verify the **Noah / Receive Options drawer** path when the Noah menu is enabled
  - Verify the **Send** flow from the same Transfer drawer is unaffected
  - Re-check the **Footer Receive button** on Asset Detail (e.g. when the wallet has funds elsewhere but not on this asset)

### 📝 Description

**Problem**: From the Asset Detail screen, tapping Receive (or Transfer → Receive) opens the Modular Drawer without the asset's networks correctly pre-selected.
- For **native multi-network coins** (ETH on Ethereum + Optimism + Arbitrum + Base) it mostly worked.
- For **multi-network tokens** (USDC, USDT) it collapsed to a **single network** and jumped straight to the account step — the user could not pick another network, nor **receive on a network they don't hold yet**.

**Solution**: Resolve the asset's full multi-network \`ledgerIds\` list and thread it from \`useAssetDetailViewModel\` down through \`BalanceGraph\`, \`Footer\`, and \`TransferDrawer\` to \`useOpenReceiveDrawer\`, which forwards it to the Modular Drawer's pre-selection via an optional \`currencyIds\`. This is **backward compatible**: when \`currencyIds\` is absent/empty, the flow falls back to the previous behavior (\`[currency.id]\`, filtered).

Two sources feed that list:

1. **Native coins** — the multi-network list already comes from CoinGecko, additively exposed on the shared \`@ledgerhq/asset-detail\` \`useAssetMarketData\` hook (no extra query):

\`\`\`ts
// libs/asset-detail/src/hooks/useAssetMarketData.ts
const ledgerIds = useMemo<string[]>(() => {
  if (marketFromHook?.ledgerIds?.length) return marketFromHook.ledgerIds;
  if (marketCurrencyData?.ledgerIds?.length) return marketCurrencyData.ledgerIds;
  return knownLedgerIds ? [...knownLedgerIds] : [];
}, [marketFromHook?.ledgerIds, marketCurrencyData?.ledgerIds, knownLedgerIds]);
\`\`\`

2. **Tokens** — CoinGecko exposes no multi-network list for tokens, and a DADA query filtered by a single id collapses the meta-currency to that one network. New shared, platform-agnostic hook **\`useReceiveNetworkLedgerIds\`** (\`@ledgerhq/asset-detail\`) runs an **unfiltered DADA \`search\`** by ticker and reads the meta-currency's complete \`assetsIds\`, selecting the meta by: exact \`metaCurrencyId\` (held asset) → market slug match via \`toSlug\` (not held) → known currency id scan. This is what enables receiving on **networks not held yet**. The mobile wrapper injects the platform inputs (product \`llm\`, app version → DADA \`minVersion\`, modular-drawer staging flag, dev-mode test networks).

**Notes**
- New dependency edge \`@ledgerhq/asset-detail\` → \`@ledgerhq/asset-aggregation\` (reuse of \`toSlug\`). No cycle: \`asset-aggregation\` is already in \`asset-detail\`'s transitive graph via \`live-common\`.
- \`TransferDrawer\` now also passes \`currency\` to \`useOpenReceiveDrawer\` (consistency with the Footer + safe fallback when \`ledgerIds\` is still empty/loading).
- Changes to the shared lib are additive → **desktop is untouched** behaviorally and can opt-in later.
- Tests: pure resolver unit test (\`resolveNetworkLedgerIds\`) in the lib, mobile MSW hook test, and updated Footer/BalanceGraph/TransferDrawer/\`useOpenReceiveDrawer\` tests.

### 🖼️ Screenshots
https://github.com/user-attachments/assets/0e3db5ac-78a7-4b5e-827a-9b422080aaf8


### ❓ Context

- **JIRA or GitHub link**: [LIVE-31240](https://ledgerhq.atlassian.net/browse/LIVE-31240)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31240]: https://ledgerhq.atlassian.net/browse/LIVE-31240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ