### PR TITLE
ci: workaround EMFILE windows issue

### DIFF
--- a/.github/workflows/test-integration-pr.yml
+++ b/.github/workflows/test-integration-pr.yml
@@ -76,7 +76,36 @@ jobs:
       - name: Install dependencies
         run: pnpm i --filter="live-common..." --filter="ledger-live" --filter="@ledgerhq/ledger-wallet-framework"
 
+      # Seed the local nx cache for live-common's transitive deps in two
+      # chunks. Each chunk runs in its own nx process so the per-task fd burst
+      # inside @nx/s3-cache's createPack() stays under the Windows ceiling.
+      # Smaller libs are safe to go through nx; only live-common (built below)
+      # is too large for a single createPack call.
+      - name: Warm cache (Windows)
+        if: matrix.os == 'windows-2022'
+        shell: bash
+        env:
+          NX_DAEMON: "false"
+        run: |
+          set -euo pipefail
+          pnpm exec nx graph --focus=@ledgerhq/live-common --file=live-common-graph.json
+          node tools/nx/print-build-dep-chunks.mjs live-common-graph.json @ledgerhq/live-common 2 > warm-chunks.txt
+          echo "Warming $(wc -l < warm-chunks.txt) chunks for @ledgerhq/live-common"
+          while IFS= read -r chunk; do
+            [ -z "$chunk" ] && continue
+            echo "::group::Warming chunk: $chunk"
+            pnpm exec nx run-many -t build -p "$chunk" --parallel=1
+            echo "::endgroup::"
+          done < warm-chunks.txt
+
+      # live-common emits ~8k cached files. This results in an EMFILE in windows. Skip NX for this step on windows
+      - name: Build (Windows — bypass nx cache write)
+        if: matrix.os == 'windows-2022'
+        shell: bash
+        run: pnpm --filter @ledgerhq/live-common run build
+
       - name: Build
+        if: matrix.os != 'windows-2022'
         run: pnpm exec nx run @ledgerhq/live-common:build
 
       - name: Test

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -54,7 +54,37 @@ jobs:
           region: ${{ secrets.AWS_CACHE_REGION }}
       - name: Install dependencies
         run: pnpm i --filter="live-common..." --filter="ledger-live" --filter="@ledgerhq/ledger-wallet-framework"
+
+      # Seed the local nx cache for live-common's transitive deps in two
+      # chunks. Each chunk runs in its own nx process so the per-task fd burst
+      # inside @nx/s3-cache's createPack() stays under the Windows ceiling.
+      # Smaller libs are safe to go through nx; only live-common (built below)
+      # is too large for a single createPack call.
+      - name: Warm cache (Windows)
+        if: matrix.os == 'windows-2022'
+        shell: bash
+        env:
+          NX_DAEMON: "false"
+        run: |
+          set -euo pipefail
+          pnpm exec nx graph --focus=@ledgerhq/live-common --file=live-common-graph.json
+          node tools/nx/print-build-dep-chunks.mjs live-common-graph.json @ledgerhq/live-common 2 > warm-chunks.txt
+          echo "Warming $(wc -l < warm-chunks.txt) chunks for @ledgerhq/live-common"
+          while IFS= read -r chunk; do
+            [ -z "$chunk" ] && continue
+            echo "::group::Warming chunk: $chunk"
+            pnpm exec nx run-many -t build -p "$chunk" --parallel=1
+            echo "::endgroup::"
+          done < warm-chunks.txt
+
+      # live-common emits ~8k cached files. This results in an EMFILE in windows. Skip NX for this step on windows
+      - name: Build (Windows — bypass nx cache write)
+        if: matrix.os == 'windows-2022'
+        shell: bash
+        run: pnpm --filter @ledgerhq/live-common run build
+
       - name: Build
+        if: matrix.os != 'windows-2022'
         run: pnpm exec nx run @ledgerhq/live-common:build
       - name: Test
         shell: bash

--- a/tools/nx/print-build-dep-chunks.mjs
+++ b/tools/nx/print-build-dep-chunks.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/**
+ * Reads a graph dumped by `nx graph --focus=<project> --file=<path>` and prints
+ * the focus project's transitive build dependencies, topologically sorted
+ * (leaves first), split into up to chunkCount comma-separated chunks (one per line).
+ * The focus project itself is excluded.
+ *
+ * Used by CI to warm the nx cache across a few separate nx processes on
+ * Windows, where restoring all of live-common's deps in one process exhausts
+ * file descriptors and crashes with EMFILE. Root cause: @nx/s3-cache's
+ * createPack() reads every cached output file concurrently via
+ * node:fs/promises.readFile with no concurrency cap (see @nx/s3-cache source).
+ * Splitting into smaller nx invocations bounds the per-task
+ * fd burst for tasks with very large cached outputs (e.g., live-common).
+ * This is a workaround until upstream adds a concurrency limit.
+ */
+import fs from "node:fs";
+import process from "node:process";
+
+const [graphPath, focusProject, chunkCountArg = "2"] = process.argv.slice(2);
+
+if (!graphPath || !focusProject) {
+  console.error(
+    "Usage: print-build-dep-chunks.mjs <graph.json> <focusProject> [chunkCount]",
+  );
+  process.exit(1);
+}
+
+const chunkCount = Number.parseInt(chunkCountArg, 10);
+if (!Number.isFinite(chunkCount) || chunkCount < 1) {
+  console.error(`Invalid chunk count: ${chunkCountArg}`);
+  process.exit(1);
+}
+
+const { graph } = JSON.parse(fs.readFileSync(graphPath, "utf8"));
+const { nodes, dependencies } = graph;
+
+if (!nodes[focusProject]) {
+  console.error(`Focus project ${focusProject} not found in graph`);
+  process.exit(1);
+}
+
+const visited = new Set();
+const order = [];
+
+function visit(name) {
+  if (visited.has(name) || !nodes[name]) return;
+  visited.add(name);
+  for (const edge of dependencies[name] || []) {
+    visit(edge.target);
+  }
+  order.push(name);
+}
+
+visit(focusProject);
+
+const buildable = order.filter(
+  name => name !== focusProject && nodes[name]?.data?.targets?.build,
+);
+
+const chunkSize = Math.max(1, Math.ceil(buildable.length / chunkCount));
+for (let i = 0; i < buildable.length; i += chunkSize) {
+  console.log(buildable.slice(i, i + chunkSize).join(","));
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Ship NX caching when building live-common on windows. The live-common package is 8.3k files and causes EMFILE issues on cache restoration

This is a workaround and not a permanent fix.

### ❓ Context

Ticket: https://ledgerhq.atlassian.net/browse/LIVE-31318
Green run: https://github.com/LedgerHQ/ledger-live/actions/runs/26514379280

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
