### PR TITLE
[LWDM] feat(LIVE-28050): hedera testnet support - part 2

### DIFF
--- a/.changeset/slimy-rivers-refuse.md
+++ b/.changeset/slimy-rivers-refuse.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-hedera": minor
+"@ledgerhq/live-common": minor
+"@ledgerhq/live-env": minor
+---
+
+refactor: upgrade hedera utils with configOrCurrencyId param

--- a/libs/coin-modules/coin-hedera/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-hedera/src/api/index.integ.test.ts
@@ -26,6 +26,10 @@ describe("createApi", () => {
       ...getMockedConfig(),
       useHgraphForErc20: true,
       useNetworkTimestamp: true,
+      apiUrls: {
+        mirrorNode: getEnv("API_HEDERA_MIRROR"),
+        hgraph: getEnv("API_HEDERA_HGRAPH"),
+      },
     },
     "hedera",
   );

--- a/libs/coin-modules/coin-hedera/src/api/index.ts
+++ b/libs/coin-modules/coin-hedera/src/api/index.ts
@@ -7,13 +7,12 @@ import type {
   TransactionValidation,
 } from "@ledgerhq/coin-module-framework/api/index";
 import { craftTransactionData } from "@ledgerhq/coin-module-framework/logic/craftTransactionData";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
 import { BridgeApi } from "@ledgerhq/ledger-wallet-framework/api/types";
 import type { Operation as LiveOperation } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import invariant from "invariant";
 import { validateAddress } from "../bridge/validateAddress";
-import coinConfig, { type HederaConfig } from "../config";
+import hederaCoinConfig, { type HederaCoinConfig, type HederaConfig } from "../config";
 import {
   HARDCODED_BLOCK_HEIGHT,
   HEDERA_OPERATION_TYPES,
@@ -44,18 +43,21 @@ import {
 } from "../logic/utils";
 import { apiClient } from "../network/api";
 import { getERC20BalancesForAccountV2, toEVMAddress } from "../network/utils";
-import type { EstimateFeesParams, HederaMemo, HederaOperationExtra } from "../types";
+import type { EstimateFeesParams, HederaMemo, HederaOperationExtra, HederaTxData } from "../types";
 
 export function createApi(
   config: HederaConfig,
   currencyId: string,
-): CoinModuleApi<HederaMemo> & BridgeApi {
-  coinConfig.setCoinConfig(() => ({ ...config, status: { type: "active" } }));
-  const currency = getCryptoCurrencyById(currencyId);
+): CoinModuleApi<HederaMemo, HederaTxData> & BridgeApi {
+  const coinConfig: HederaCoinConfig = { ...config, status: { type: "active" } };
+  hederaCoinConfig.setCoinConfig(() => coinConfig);
 
   return {
     broadcast: async tx => {
-      const response = await logicBroadcast(tx);
+      const response = await logicBroadcast({
+        configOrCurrencyId: coinConfig,
+        txWithSignature: tx,
+      });
 
       return Buffer.from(response.transactionHash).toString("base64");
     },
@@ -63,9 +65,9 @@ export function createApi(
     craftTransaction: async (txIntent, customFees) => {
       invariant(!txIntent.useAllAmount, "useAllAmount is not supported");
       const { serializedTx } = await craftTransaction({
+        configOrCurrencyId: coinConfig,
         txIntent,
         ...(customFees && { customFees }),
-        config,
       });
 
       return {
@@ -85,9 +87,9 @@ export function createApi(
       const operationType = mapIntentToSDKOperation(txIntent);
 
       if (operationType === HEDERA_OPERATION_TYPES.ContractCall) {
-        estimateFeesParams = { operationType, txIntent };
+        estimateFeesParams = { configOrCurrencyId: coinConfig, operationType, txIntent };
       } else {
-        estimateFeesParams = { currency, operationType };
+        estimateFeesParams = { currencyId, operationType };
       }
 
       const estimatedFee = await logicEstimateFees(estimateFeesParams);
@@ -97,21 +99,21 @@ export function createApi(
       };
     },
     getBalance: (address: string, options?: BalanceOptions) =>
-      rejectBalanceOptions(() => getBalance(currency, address), options),
+      rejectBalanceOptions(() => getBalance({ config: coinConfig, currencyId, address }), options),
     getBlock: height => {
       if (config.useHgraphForErc20) {
-        return getBlockV2(height);
+        return getBlockV2({ configOrCurrencyId: coinConfig, height });
       }
 
-      return getBlock(height);
+      return getBlock({ configOrCurrencyId: coinConfig, height });
     },
     getBlockInfo: height => getBlockInfo(height),
     lastBlock: () => {
       if (config.useHgraphForErc20) {
-        return lastBlockV2();
+        return lastBlockV2({ configOrCurrencyId: coinConfig });
       }
 
-      return lastBlock();
+      return lastBlock({ configOrCurrencyId: coinConfig });
     },
     listOperations: async (address, { cursor, limit, order, minHeight }) => {
       invariant(minHeight === 0, "minHeight is not supported");
@@ -123,15 +125,19 @@ export function createApi(
       };
 
       if (config.useHgraphForErc20) {
-        const evmAddress = await toEVMAddress(address);
+        const evmAddress = await toEVMAddress({
+          configOrCurrencyId: coinConfig,
+          accountId: address,
+        });
         invariant(evmAddress, `hedera: evm address is missing for ${address}`);
         const [mirrorTokens, erc20TokenBalances] = await Promise.all([
           apiClient.getAccountTokens(address),
-          getERC20BalancesForAccountV2(address),
+          getERC20BalancesForAccountV2({ configOrCurrencyId: coinConfig, address }),
         ]);
 
         latestAccountOperations = await logicListOperationsV2({
-          currency,
+          config: coinConfig,
+          currencyId,
           address,
           evmAddress,
           mirrorTokens,
@@ -148,7 +154,8 @@ export function createApi(
         const mirrorTokens = await apiClient.getAccountTokens(address);
 
         latestAccountOperations = await logicListOperations({
-          currency,
+          config: coinConfig,
+          currencyId,
           address,
           cursor,
           limit,
@@ -240,9 +247,10 @@ export function createApi(
         next: latestAccountOperations.nextCursor || undefined,
       };
     },
-    getValidators: cursor => getValidators(cursor),
-    getStakes: async address => getStakes(address),
-    getRewards: async (address, cursor) => getRewards(address, cursor),
+    getValidators: cursor => getValidators({ configOrCurrencyId: coinConfig, cursor }),
+    getStakes: async address => getStakes({ configOrCurrencyId: coinConfig, address }),
+    getRewards: async (address, cursor) =>
+      getRewards({ configOrCurrencyId: coinConfig, address, cursor }),
     validateIntent: async (
       _transactionIntent,
       _balances,

--- a/libs/coin-modules/coin-hedera/src/bridge/broadcast.integ.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/broadcast.integ.test.ts
@@ -1,9 +1,19 @@
 import { AccountId, Hbar, PrivateKey, TransactionId, TransferTransaction } from "@hashgraph/sdk";
+import { broadcast } from "./broadcast";
+import hederaCoinConfig from "../config";
 import { serializeTransaction } from "../logic/utils";
 import { rpcClient } from "../network/rpc";
-import { broadcast } from "./broadcast";
+import { getMockedAccount } from "../test/fixtures/account.fixture";
+import { getMockedConfig } from "../test/fixtures/config.fixture";
 
 describe("Broadcast", () => {
+  const account = getMockedAccount();
+  const coinConfig = getMockedConfig();
+
+  beforeAll(() => {
+    hederaCoinConfig.setCoinConfig(() => coinConfig);
+  });
+
   afterAll(async () => {
     await rpcClient._resetInstance();
   });
@@ -24,6 +34,7 @@ describe("Broadcast", () => {
 
     await expect(
       broadcast({
+        account,
         signedOperation: {
           signature: txHex,
           operation: { id: "integ", hash: "", extra: {} },

--- a/libs/coin-modules/coin-hedera/src/bridge/broadcast.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/broadcast.ts
@@ -5,9 +5,15 @@ import { base64ToUrlSafeBase64, isValidExtra, formatTransactionId } from "../log
 import type { HederaOperationExtra, Transaction } from "../types";
 import { patchOperationWithExtra } from "./utils";
 
-export const broadcast: AccountBridge<Transaction>["broadcast"] = async ({ signedOperation }) => {
+export const broadcast: AccountBridge<Transaction>["broadcast"] = async ({
+  signedOperation,
+  account,
+}) => {
   const { signature, operation } = signedOperation;
-  const response = await logicBroadcast(signature);
+  const response = await logicBroadcast({
+    configOrCurrencyId: account.currency.id,
+    txWithSignature: signature,
+  });
 
   const base64Hash = Buffer.from(response.transactionHash).toString("base64");
   const base64HashUrlSafe = base64ToUrlSafeBase64(base64Hash);

--- a/libs/coin-modules/coin-hedera/src/bridge/buildOptimisticOperation.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/buildOptimisticOperation.ts
@@ -53,7 +53,10 @@ const buildOptimisticCoinOperation = async ({
     transactionType === "FEES" ? transaction.amount : (transaction.maxFee ?? new BigNumber(0));
   const value = transaction.amount;
   const type: OperationType = transactionType ?? "OUT";
-  const [_, recipientAddress] = await safeParseAccountId(transaction.recipient);
+  const [_, recipientAddress] = await safeParseAccountId({
+    configOrCurrencyId: account.currency.id,
+    address: transaction.recipient,
+  });
   const recipientWithoutChecksum = recipientAddress?.accountId ?? transaction.recipient;
   const memo = transaction.memo;
 
@@ -89,7 +92,10 @@ const buildOptimisticHTSTokenOperation = async ({
   const fee = transaction.maxFee ?? new BigNumber(0);
   const value = transaction.amount;
   const type: OperationType = "OUT";
-  const [_, recipientAddress] = await safeParseAccountId(transaction.recipient);
+  const [_, recipientAddress] = await safeParseAccountId({
+    configOrCurrencyId: account.currency.id,
+    address: transaction.recipient,
+  });
   const recipientWithoutChecksum = recipientAddress?.accountId ?? transaction.recipient;
   const memo = transaction.memo;
 

--- a/libs/coin-modules/coin-hedera/src/bridge/estimateMaxSpendable.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/estimateMaxSpendable.ts
@@ -19,7 +19,7 @@ export const estimateMaxSpendable: AccountBridge<Transaction>["estimateMaxSpenda
   }
 
   const estimatedFees = await estimateFees({
-    currency: mainAccount.currency,
+    currencyId: mainAccount.currency.id,
     operationType: HEDERA_OPERATION_TYPES.CryptoTransfer,
   });
   let maxSpendable = balance.minus(estimatedFees.tinybars);

--- a/libs/coin-modules/coin-hedera/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/getTransactionStatus.ts
@@ -50,7 +50,10 @@ async function validateRecipient(account: Account, recipient: string): Promise<E
     return new RecipientRequired();
   }
 
-  const [parsingError, parsingResult] = await safeParseAccountId(recipient);
+  const [parsingError, parsingResult] = await safeParseAccountId({
+    configOrCurrencyId: account.currency.id,
+    address: recipient,
+  });
 
   if (parsingError) {
     return parsingError;
@@ -75,7 +78,7 @@ async function handleTokenAssociateTransaction(
   const [usdRate, estimatedFees] = await Promise.all([
     getCurrencyToUSDRate(account.currency),
     estimateFees({
-      currency: account.currency,
+      currencyId: account.currency.id,
       operationType: HEDERA_OPERATION_TYPES.TokenAssociate,
     }),
   ]);
@@ -120,7 +123,7 @@ async function handleHTSTokenTransaction(
   const [calculatedAmount, estimatedFees] = await Promise.all([
     calculateAmount({ transaction, account }),
     estimateFees({
-      currency: account.currency,
+      currencyId: account.currency.id,
       operationType: HEDERA_OPERATION_TYPES.TokenTransfer,
     }),
   ]);
@@ -184,6 +187,7 @@ async function handleERC20TokenTransaction(
   const [calculatedAmount, estimatedFees] = await Promise.all([
     calculateAmount({ transaction, account }),
     estimateFees({
+      configOrCurrencyId: account.currency.id,
       operationType: HEDERA_OPERATION_TYPES.ContractCall,
       txIntent: {
         intentType: "transaction",
@@ -241,7 +245,7 @@ async function handleCoinTransaction(
   const [calculatedAmount, estimatedFees] = await Promise.all([
     calculateAmount({ transaction, account }),
     estimateFees({
-      currency: account.currency,
+      currencyId: account.currency.id,
       operationType: HEDERA_OPERATION_TYPES.CryptoTransfer,
     }),
   ]);
@@ -281,7 +285,7 @@ async function handleStakingTransaction(account: HederaAccount, transaction: Tra
   const { validators } = getCurrentHederaPreloadData(account.currency);
   const estimatedFees = await estimateFees({
     operationType: HEDERA_OPERATION_TYPES.CryptoUpdate,
-    currency: account.currency,
+    currencyId: account.currency.id,
   });
   const amount = BigNumber(0);
   const totalSpent = amount.plus(estimatedFees.tinybars);

--- a/libs/coin-modules/coin-hedera/src/bridge/js-estimateMaxSpendable.integ.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/js-estimateMaxSpendable.integ.test.ts
@@ -18,7 +18,7 @@ describe("js-estimateMaxSpendable", () => {
 
     const mockedAccount = getMockedAccount();
     const crypto = await estimateFees({
-      currency: mockedAccount.currency,
+      currencyId: mockedAccount.currency.id,
       operationType: HEDERA_OPERATION_TYPES.CryptoTransfer,
     });
 

--- a/libs/coin-modules/coin-hedera/src/bridge/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/prepareTransaction.test.ts
@@ -60,6 +60,7 @@ describe("prepareTransaction", () => {
     await prepareTransaction(accountWithToken, transaction);
 
     expect(estimateFees).toHaveBeenCalledWith({
+      configOrCurrencyId: accountWithToken.currency.id,
       operationType: HEDERA_OPERATION_TYPES.ContractCall,
       txIntent: {
         intentType: "transaction",
@@ -104,7 +105,7 @@ describe("prepareTransaction", () => {
     await prepareTransaction(accountWithToken, transaction);
 
     expect(estimateFees).toHaveBeenCalledWith({
-      currency: accountWithToken.currency,
+      currencyId: accountWithToken.currency.id,
       operationType: HEDERA_OPERATION_TYPES.TokenTransfer,
     });
   });
@@ -121,7 +122,7 @@ describe("prepareTransaction", () => {
     await prepareTransaction(mockAccount, transaction);
 
     expect(estimateFees).toHaveBeenCalledWith({
-      currency: mockAccount.currency,
+      currencyId: mockAccount.currency.id,
       operationType: HEDERA_OPERATION_TYPES.TokenAssociate,
     });
   });
@@ -136,7 +137,7 @@ describe("prepareTransaction", () => {
     await prepareTransaction(mockAccount, transaction);
 
     expect(estimateFees).toHaveBeenCalledWith({
-      currency: mockAccount.currency,
+      currencyId: mockAccount.currency.id,
       operationType: HEDERA_OPERATION_TYPES.CryptoTransfer,
     });
   });

--- a/libs/coin-modules/coin-hedera/src/bridge/prepareTransaction.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/prepareTransaction.ts
@@ -47,6 +47,7 @@ export const prepareTransaction: AccountBridge<Transaction>["prepareTransaction"
   // build different estimation params for ERC20 ContractCall transactions
   if (operationType === HEDERA_OPERATION_TYPES.ContractCall) {
     estimateFeesParams = {
+      configOrCurrencyId: account.currency.id,
       operationType,
       txIntent: {
         intentType: "transaction",
@@ -63,7 +64,7 @@ export const prepareTransaction: AccountBridge<Transaction>["prepareTransaction"
     };
   } else {
     estimateFeesParams = {
-      currency: account.currency,
+      currencyId: account.currency.id,
       operationType,
     };
   }

--- a/libs/coin-modules/coin-hedera/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/signOperation.test.ts
@@ -1,8 +1,6 @@
-import hederaCoinConfig from "../config";
 import { craftTransaction } from "../logic/craftTransaction";
 import { combine } from "../logic/combine";
 import { getMockedAccount } from "../test/fixtures/account.fixture";
-import { getMockedConfig } from "../test/fixtures/config.fixture";
 import { getMockedTransaction } from "../test/fixtures/transaction.fixture";
 import { buildSignOperation } from "./signOperation";
 
@@ -15,12 +13,12 @@ jest.mock("../logic/combine", () => ({
 }));
 
 jest.mock("../logic/utils", () => ({
+  ...jest.requireActual("../logic/utils"),
   serializeSignature: jest.fn(() => "serialized-signature"),
   serializeTransaction: jest.fn(() => "serialized-transaction"),
   getHederaTransactionBodyBytes: jest.fn(() => new Uint8Array([1, 2, 3])),
   isTokenAssociateTransaction: jest.fn(() => false),
   isStakingTransaction: jest.fn(() => false),
-  safeParseAccountId: jest.fn(async (value: string) => [undefined, { accountId: value }]),
 }));
 
 describe("signOperation", () => {
@@ -31,9 +29,7 @@ describe("signOperation", () => {
   it("passes hedera coin config to craftTransaction", async () => {
     const account = getMockedAccount();
     const transaction = getMockedTransaction();
-    const config = getMockedConfig();
 
-    jest.spyOn(hederaCoinConfig, "getCoinConfig").mockReturnValue(config);
     jest
       .mocked(craftTransaction)
       .mockResolvedValue({ tx: {} as never, serializedTx: "serialized-tx" });
@@ -58,12 +54,10 @@ describe("signOperation", () => {
       });
     });
 
-    expect(hederaCoinConfig.getCoinConfig).toHaveBeenCalledTimes(1);
-    expect(hederaCoinConfig.getCoinConfig).toHaveBeenCalledWith(account.currency.id);
     expect(craftTransaction).toHaveBeenCalledTimes(1);
     expect(craftTransaction).toHaveBeenCalledWith({
       txIntent: expect.any(Object),
-      config,
+      configOrCurrencyId: account.currency.id,
     });
     expect(combine).toHaveBeenCalledTimes(1);
   });

--- a/libs/coin-modules/coin-hedera/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/signOperation.ts
@@ -3,7 +3,6 @@ import { findSubAccountById } from "@ledgerhq/ledger-wallet-framework/account/he
 import type { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import type { AccountBridge } from "@ledgerhq/types-live";
 import { Observable } from "rxjs";
-import hederaCoinConfig from "../config";
 import { DEFAULT_GAS_LIMIT, HEDERA_TRANSACTION_MODES } from "../constants";
 import { combine } from "../logic/combine";
 import { craftTransaction } from "../logic/craftTransaction";
@@ -34,7 +33,6 @@ export const buildSignOperation =
           let data: HederaTxData | undefined;
           const accountAddress = account.freshAddress;
           const accountPublicKey = account.seedIdentifier;
-          const coinConfig = hederaCoinConfig.getCoinConfig(account.currency.id);
           const subAccount = findSubAccountById(account, transaction.subAccountId || "");
           const isHTSTokenTransaction =
             transaction.mode === HEDERA_TRANSACTION_MODES.Send &&
@@ -89,6 +87,7 @@ export const buildSignOperation =
 
           const signedTx = await signerContext(deviceId, async signer => {
             const { tx } = await craftTransaction({
+              configOrCurrencyId: account.currency.id,
               txIntent: {
                 intentType: "transaction",
                 type,
@@ -104,7 +103,6 @@ export const buildSignOperation =
                 ...(data && { data }),
               },
               ...(customFees && { customFees }),
-              config: coinConfig,
             });
 
             const txBodyBytes = getHederaTransactionBodyBytes(tx);

--- a/libs/coin-modules/coin-hedera/src/bridge/synchronisation.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/synchronisation.test.ts
@@ -80,7 +80,10 @@ describe("getAccountShape", () => {
     await getAccountShape(mockInfo, { paginationConfig: {} });
 
     expect(mockGetERC20BalancesForAccountV2).toHaveBeenCalledTimes(1);
-    expect(mockGetERC20BalancesForAccountV2).toHaveBeenCalledWith(mockAddress);
+    expect(mockGetERC20BalancesForAccountV2).toHaveBeenCalledWith({
+      configOrCurrencyId: mockConfig,
+      address: mockAddress,
+    });
     expect(networkUtils.getERC20BalancesForAccount).not.toHaveBeenCalled();
   });
 

--- a/libs/coin-modules/coin-hedera/src/bridge/synchronisation.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/synchronisation.ts
@@ -47,13 +47,15 @@ const getAccountShapeV2 = async ({
   initialAccount: HederaAccount | undefined;
   blacklistedTokenIds: string[] | undefined;
 }): Promise<Partial<HederaAccount>> => {
+  const config = resolveConfig(currency.id);
+
   // get current account balance and tokens
   // tokens are fetched with separate requests to get "created_timestamp" for each token
   // based on this, ASSOCIATE_TOKEN operations can be connected with tokens
   const [mirrorAccount, mirrorTokens, erc20Tokens] = await Promise.all([
     apiClient.getAccount(address),
     apiClient.getAccountTokens(address),
-    getERC20BalancesForAccountV2(address),
+    getERC20BalancesForAccountV2({ configOrCurrencyId: config, address }),
   ]);
 
   const accountBalance = new BigNumber(mirrorAccount.balance.balance);
@@ -75,7 +77,7 @@ const getAccountShapeV2 = async ({
   }
 
   const latestAccountOperations = await listOperationsV2({
-    currency,
+    currencyId: currency.id,
     address,
     evmAddress,
     mirrorTokens,
@@ -144,7 +146,7 @@ export const getAccountShape: GetAccountShape<HederaAccount> = async (
   const { currency, derivationMode, address, initialAccount } = info;
   const config = resolveConfig(currency.id);
   invariant(address, "hedera: address is expected");
-  const evmAddress = await toEVMAddress(address);
+  const evmAddress = await toEVMAddress({ configOrCurrencyId: config, accountId: address });
   invariant(evmAddress, `hedera: evm address is missing for ${address}`);
 
   const liveAccountId = encodeAccountId({
@@ -172,7 +174,7 @@ export const getAccountShape: GetAccountShape<HederaAccount> = async (
   const [mirrorAccount, mirrorTokens, erc20TokenBalances] = await Promise.all([
     apiClient.getAccount(address),
     apiClient.getAccountTokens(address),
-    getERC20BalancesForAccount(evmAddress),
+    getERC20BalancesForAccount({ configOrCurrencyId: config, evmAccountId: evmAddress }),
   ]);
 
   const accountBalance = new BigNumber(mirrorAccount.balance.balance);
@@ -206,7 +208,7 @@ export const getAccountShape: GetAccountShape<HederaAccount> = async (
 
   const [latestAccountOperations, erc20Transactions] = await Promise.all([
     listOperations({
-      currency,
+      currencyId: currency.id,
       address,
       mirrorTokens,
       cursor: latestOperationTimestamp?.toString(),
@@ -216,6 +218,7 @@ export const getAccountShape: GetAccountShape<HederaAccount> = async (
       useSyntheticBlocks: false,
     }),
     thirdwebClient.getERC20TransactionsForAccount({
+      configOrCurrencyId: config,
       address,
       contractAddresses: erc20TokenBalances.map(token => token.token.contractAddress),
       since: erc20LatestOperationTimestamp,
@@ -254,6 +257,7 @@ export const getAccountShape: GetAccountShape<HederaAccount> = async (
   // 6. sub accounts must get erc20 tokens and erc20 operations in addition to hts tokens and hts operations
   // 7. postSync must remove pending operations that are already confirmed as erc20 operations
   const { updatedOperations, newERC20TokenOperations } = await integrateERC20Operations({
+    currencyId: currency.id,
     ledgerAccountId: liveAccountId,
     address,
     allOperations: operations,

--- a/libs/coin-modules/coin-hedera/src/bridge/utils.integ.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/utils.integ.test.ts
@@ -19,11 +19,30 @@ import type { EstimateFeesResult } from "../types";
 import { calculateAmount, getSubAccounts, integrateERC20Operations } from "./utils";
 
 describe("utils", () => {
+  const address = "0.0.12345";
+  const evmAddress = "0x0000000000000000000000000000000000003039";
   const mockedAccount = getMockedAccount();
 
   beforeAll(() => {
     // Setup CAL client store (automatically set as global store)
     setupCalClientStore();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.spyOn(apiClient, "getAccount").mockResolvedValue({
+      account: address,
+      evm_address: evmAddress,
+      max_automatic_token_associations: 0,
+      balance: { balance: 1000000000, timestamp: "0", tokens: [] },
+      pending_reward: 0,
+      staked_node_id: null,
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   describe("calculateAmount", () => {
@@ -32,11 +51,11 @@ describe("utils", () => {
     beforeAll(async () => {
       const [crypto, associate] = await Promise.all([
         estimateFees({
-          currency: mockedAccount.currency,
+          currencyId: mockedAccount.currency.id,
           operationType: HEDERA_OPERATION_TYPES.CryptoTransfer,
         }),
         estimateFees({
-          currency: mockedAccount.currency,
+          currencyId: mockedAccount.currency.id,
           operationType: HEDERA_OPERATION_TYPES.TokenAssociate,
         }),
       ]);
@@ -256,14 +275,8 @@ describe("utils", () => {
   });
 
   describe("integrateERC20Operations", () => {
-    const address = "0.0.12345";
-    const evmAddress = "0x0000000000000000000000000000000000003039";
     const ledgerAccountId = `js:2:hedera:${address}:`;
     const tokenCurrency = getTokenCurrencyFromCALByType("erc20");
-
-    afterEach(() => {
-      jest.restoreAllMocks();
-    });
 
     it("creates new operation for erc20 in transfer", async () => {
       const mockGetContractCallResult = jest.spyOn(apiClient, "getContractCallResult");
@@ -311,6 +324,7 @@ describe("utils", () => {
       } as any);
 
       const { updatedOperations, newERC20TokenOperations } = await integrateERC20Operations({
+        currencyId: mockedAccount.currency.id,
         ledgerAccountId,
         address,
         allOperations: oldMirrorOperations,
@@ -389,6 +403,7 @@ describe("utils", () => {
       } as any);
 
       const { updatedOperations, newERC20TokenOperations } = await integrateERC20Operations({
+        currencyId: mockedAccount.currency.id,
         ledgerAccountId,
         address,
         allOperations: oldMirrorOperations,
@@ -484,6 +499,7 @@ describe("utils", () => {
       } as any);
 
       const { updatedOperations } = await integrateERC20Operations({
+        currencyId: mockedAccount.currency.id,
         ledgerAccountId,
         address,
         allOperations: operationsWithDuplicate,
@@ -522,6 +538,7 @@ describe("utils", () => {
       ];
 
       const { updatedOperations } = await integrateERC20Operations({
+        currencyId: mockedAccount.currency.id,
         ledgerAccountId,
         address,
         allOperations: operationsWithPending,
@@ -628,6 +645,7 @@ describe("utils", () => {
       } as any);
 
       const { updatedOperations, newERC20TokenOperations } = await integrateERC20Operations({
+        currencyId: mockedAccount.currency.id,
         ledgerAccountId,
         address,
         allOperations: fridaySyncOperations,

--- a/libs/coin-modules/coin-hedera/src/bridge/utils.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/utils.ts
@@ -11,6 +11,7 @@ import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Account, Operation, OperationType, TokenAccount } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
+import type { HederaCoinConfig } from "../config";
 import { HEDERA_OPERATION_TYPES } from "../constants";
 import { estimateFees } from "../logic/estimateFees";
 import {
@@ -46,7 +47,7 @@ const calculateCoinAmount = async ({
   transaction: Transaction;
   operationType: Exclude<HEDERA_OPERATION_TYPES, HEDERA_OPERATION_TYPES.ContractCall>;
 }): Promise<CalculateAmountResult> => {
-  const estimatedFees = await estimateFees({ currency: account.currency, operationType });
+  const estimatedFees = await estimateFees({ currencyId: account.currency.id, operationType });
   const amount = transaction.useAllAmount
     ? await estimateMaxSpendable({ account, transaction })
     : transaction.amount;
@@ -529,6 +530,8 @@ export const patchContractCallOperation = ({
 
 // TODO: remove once migration to new API is complete
 export const integrateERC20Operations = async ({
+  config,
+  currencyId,
   ledgerAccountId,
   address,
   allOperations,
@@ -536,6 +539,8 @@ export const integrateERC20Operations = async ({
   pendingOperationHashes,
   erc20OperationHashes,
 }: {
+  config?: HederaCoinConfig;
+  currencyId: string;
   ledgerAccountId: string;
   address: string;
   allOperations: Operation[];
@@ -548,8 +553,15 @@ export const integrateERC20Operations = async ({
 }> => {
   const newERC20TokenOperations: Operation[] = [];
   const [latestERC20Operations, evmAddress] = await Promise.all([
-    getERC20Operations(latestERC20Transactions),
-    toEVMAddress(address),
+    getERC20Operations({
+      currencyId,
+      latestERC20Transactions,
+      ...(config && { config }),
+    }),
+    toEVMAddress({
+      configOrCurrencyId: config ?? currencyId,
+      accountId: address,
+    }),
   ]);
 
   // avoid duplicated CONTRACT_CALL operations if ERC20 operations are already present

--- a/libs/coin-modules/coin-hedera/src/bridge/validateAddress.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/validateAddress.test.ts
@@ -1,9 +1,11 @@
 import { safeParseAccountId } from "../network/utils";
+import { getMockedCurrency } from "../test/fixtures/currency.fixture";
 import { validateAddress } from "./validateAddress";
 
 jest.mock("../network/utils");
 
 describe("validateAddress", () => {
+  const mockCurrency = getMockedCurrency();
   const mockedSafeParseAccountId = jest.mocked(safeParseAccountId);
 
   beforeEach(() => {
@@ -20,12 +22,15 @@ describe("validateAddress", () => {
       }
 
       const address = "some random address";
-      const parameters = {};
+      const parameters = { currencyId: mockCurrency.id };
       const result = await validateAddress(address, parameters);
       expect(result).toEqual(expectedValue);
 
       expect(mockedSafeParseAccountId).toHaveBeenCalledTimes(1);
-      expect(mockedSafeParseAccountId).toHaveBeenCalledWith(address);
+      expect(mockedSafeParseAccountId).toHaveBeenCalledWith({
+        configOrCurrencyId: mockCurrency.id,
+        address,
+      });
     },
   );
 });

--- a/libs/coin-modules/coin-hedera/src/bridge/validateAddress.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/validateAddress.ts
@@ -1,10 +1,15 @@
+import invariant from "invariant";
 import type { AddressValidationCurrencyParameters } from "@ledgerhq/coin-module-framework/api/types";
 import { safeParseAccountId } from "../network/utils";
 
 export async function validateAddress(
   address: string,
-  _parameters: Partial<AddressValidationCurrencyParameters>,
+  parameters: Partial<AddressValidationCurrencyParameters>,
 ): Promise<boolean> {
-  const [error] = await safeParseAccountId(address);
+  const { currencyId } = parameters;
+  invariant(currencyId, "hedera: currency id is required for address validation");
+
+  const [error] = await safeParseAccountId({ configOrCurrencyId: currencyId, address });
+
   return error === null;
 }

--- a/libs/coin-modules/coin-hedera/src/config.ts
+++ b/libs/coin-modules/coin-hedera/src/config.ts
@@ -3,14 +3,19 @@ import buildCoinConfig, {
   type CurrencyConfig,
 } from "@ledgerhq/coin-module-framework/config";
 
-export type HederaConfig = {
+export interface HederaConfig {
   useHgraphForErc20: boolean;
   /**
    * When true, the transaction valid-start time is sourced from the latest
    * network block instead of the local machine clock.
    */
   useNetworkTimestamp: boolean;
-};
+  networkType: "mainnet" | "testnet";
+  apiUrls: {
+    mirrorNode: string;
+    hgraph: string;
+  };
+}
 
 export type HederaCoinConfig = CurrencyConfig & HederaConfig;
 

--- a/libs/coin-modules/coin-hedera/src/logic/broadcast.integ.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/broadcast.integ.test.ts
@@ -2,8 +2,11 @@ import { AccountId, Hbar, PrivateKey, TransactionId, TransferTransaction } from 
 import { broadcast } from "./broadcast";
 import { serializeTransaction } from "./utils";
 import { rpcClient } from "../network/rpc";
+import { getMockedConfig } from "../test/fixtures/config.fixture";
 
 describe("Broadcast", () => {
+  const coinConfig = getMockedConfig();
+
   afterAll(async () => {
     await rpcClient._resetInstance();
   });
@@ -22,8 +25,8 @@ describe("Broadcast", () => {
     const signedTx = await tx.sign(senderKey);
     const txHex = serializeTransaction(signedTx);
 
-    await expect(broadcast(txHex)).rejects.toThrow(
-      /failed precheck with status PAYER_ACCOUNT_NOT_FOUND/,
-    );
+    await expect(
+      broadcast({ configOrCurrencyId: coinConfig, txWithSignature: txHex }),
+    ).rejects.toThrow(/failed precheck with status PAYER_ACCOUNT_NOT_FOUND/);
   });
 });

--- a/libs/coin-modules/coin-hedera/src/logic/broadcast.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/broadcast.test.ts
@@ -1,4 +1,5 @@
 import { rpcClient } from "../network/rpc";
+import { getMockedCurrency } from "../test/fixtures/currency.fixture";
 import { broadcast } from "./broadcast";
 import { deserializeTransaction } from "./utils";
 
@@ -6,6 +7,8 @@ jest.mock("../network/rpc");
 jest.mock("./utils");
 
 describe("broadcast", () => {
+  const mockCurrency = getMockedCurrency();
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -18,7 +21,7 @@ describe("broadcast", () => {
     (deserializeTransaction as jest.Mock).mockReturnValue(mockDeserializedTx);
     (rpcClient.broadcastTransaction as jest.Mock).mockResolvedValue(mockResponse);
 
-    const result = await broadcast(txWithSignature);
+    const result = await broadcast({ configOrCurrencyId: mockCurrency.id, txWithSignature });
 
     expect(deserializeTransaction).toHaveBeenCalledTimes(1);
     expect(deserializeTransaction).toHaveBeenCalledWith(txWithSignature);
@@ -35,7 +38,9 @@ describe("broadcast", () => {
       throw error;
     });
 
-    await expect(broadcast(txWithSignature)).rejects.toThrow(error);
+    await expect(
+      broadcast({ configOrCurrencyId: mockCurrency.id, txWithSignature }),
+    ).rejects.toThrow(error);
     expect(deserializeTransaction).toHaveBeenCalledTimes(1);
     expect(deserializeTransaction).toHaveBeenCalledWith(txWithSignature);
     expect(rpcClient.broadcastTransaction).not.toHaveBeenCalled();
@@ -49,7 +54,9 @@ describe("broadcast", () => {
     (deserializeTransaction as jest.Mock).mockReturnValue(mockDeserializedTx);
     (rpcClient.broadcastTransaction as jest.Mock).mockRejectedValue(error);
 
-    await expect(broadcast(txWithSignature)).rejects.toThrow(error);
+    await expect(
+      broadcast({ configOrCurrencyId: mockCurrency.id, txWithSignature }),
+    ).rejects.toThrow(error);
     expect(deserializeTransaction).toHaveBeenCalledTimes(1);
     expect(deserializeTransaction).toHaveBeenCalledWith(txWithSignature);
     expect(rpcClient.broadcastTransaction).toHaveBeenCalledTimes(1);

--- a/libs/coin-modules/coin-hedera/src/logic/broadcast.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/broadcast.ts
@@ -1,8 +1,15 @@
 import type { TransactionResponse } from "@hashgraph/sdk";
+import type { HederaCoinConfig } from "../config";
 import { rpcClient } from "../network/rpc";
 import { deserializeTransaction } from "./utils";
 
-export const broadcast = async (txWithSignature: string): Promise<TransactionResponse> => {
-  const hederaTransaction = deserializeTransaction(txWithSignature);
-  return await rpcClient.broadcastTransaction(hederaTransaction);
+export const broadcast = async ({
+  configOrCurrencyId: _,
+  txWithSignature,
+}: {
+  configOrCurrencyId: HederaCoinConfig | string;
+  txWithSignature: string;
+}): Promise<TransactionResponse> => {
+  const transaction = deserializeTransaction(txWithSignature);
+  return await rpcClient.broadcastTransaction(transaction);
 };

--- a/libs/coin-modules/coin-hedera/src/logic/craftTransaction.integ.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/craftTransaction.integ.test.ts
@@ -47,11 +47,11 @@ describe("craftTransaction", () => {
 
     const resultAccountId = await craftTransaction({
       txIntent: txIntentAccountId,
-      config: defaultConfig,
+      configOrCurrencyId: defaultConfig,
     });
     const resultEVMAddress = await craftTransaction({
       txIntent: txIntentEVMAddress,
-      config: defaultConfig,
+      configOrCurrencyId: defaultConfig,
     });
 
     expect(resultAccountId.tx).toBeInstanceOf(sdk.ContractExecuteTransaction);
@@ -106,11 +106,11 @@ describe("craftTransaction", () => {
 
     const resultAccountId = await craftTransaction({
       txIntent: txIntentAccountId,
-      config: defaultConfig,
+      configOrCurrencyId: defaultConfig,
     });
     const resultEVMAddress = await craftTransaction({
       txIntent: txIntentEVMAddress,
-      config: defaultConfig,
+      configOrCurrencyId: defaultConfig,
     });
 
     expect(resultAccountId.tx).toBeInstanceOf(sdk.ContractExecuteTransaction);

--- a/libs/coin-modules/coin-hedera/src/logic/craftTransaction.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/craftTransaction.test.ts
@@ -62,7 +62,10 @@ describe("craftTransaction", () => {
       },
     } satisfies TransactionIntent<HederaMemo>;
 
-    const result = await craftTransaction({ txIntent, config: mockConfig });
+    const result = await craftTransaction({
+      configOrCurrencyId: mockConfig,
+      txIntent,
+    });
 
     expect(result.tx).toBeInstanceOf(sdk.TransferTransaction);
     invariant(result.tx instanceof sdk.TransferTransaction, "TransferTransaction type guard");
@@ -99,7 +102,10 @@ describe("craftTransaction", () => {
       },
     } satisfies TransactionIntent<HederaMemo>;
 
-    const result = await craftTransaction({ txIntent, config: mockConfig });
+    const result = await craftTransaction({
+      configOrCurrencyId: mockConfig,
+      txIntent,
+    });
 
     expect(result.tx).toBeInstanceOf(sdk.TransferTransaction);
     invariant(result.tx instanceof sdk.TransferTransaction, "TransferTransaction type guard");
@@ -142,7 +148,10 @@ describe("craftTransaction", () => {
       },
     } satisfies TransactionIntent<HederaMemo, HederaTxData>;
 
-    const result = await craftTransaction({ txIntent, config: mockConfig });
+    const result = await craftTransaction({
+      configOrCurrencyId: mockConfig,
+      txIntent,
+    });
 
     expect(result.tx).toBeInstanceOf(sdk.ContractExecuteTransaction);
     invariant(
@@ -180,7 +189,10 @@ describe("craftTransaction", () => {
       },
     } satisfies TransactionIntent<HederaMemo>;
 
-    const result = await craftTransaction({ txIntent, config: mockConfig });
+    const result = await craftTransaction({
+      configOrCurrencyId: mockConfig,
+      txIntent,
+    });
 
     expect(result.tx).toBeInstanceOf(sdk.TokenAssociateTransaction);
     invariant(
@@ -204,6 +216,7 @@ describe("craftTransaction", () => {
     };
 
     const result = await craftTransaction({
+      configOrCurrencyId: mockConfig,
       txIntent: {
         intentType: "transaction",
         type: HEDERA_TRANSACTION_MODES.Send,
@@ -220,7 +233,6 @@ describe("craftTransaction", () => {
         },
       },
       customFees,
-      config: mockConfig,
     });
 
     expect(result.tx).toBeInstanceOf(sdk.TransferTransaction);
@@ -245,7 +257,7 @@ describe("craftTransaction", () => {
       },
     } satisfies TransactionIntent<HederaMemo>;
 
-    await expect(craftTransaction({ txIntent, config: mockConfig })).rejects.toThrow(
+    await expect(craftTransaction({ txIntent, configOrCurrencyId: mockConfig })).rejects.toThrow(
       "hedera: invalid asset type",
     );
   });
@@ -267,7 +279,7 @@ describe("craftTransaction", () => {
       },
     } satisfies TransactionIntent<HederaMemo>;
 
-    await expect(craftTransaction({ txIntent, config: mockConfig })).rejects.toThrow(
+    await expect(craftTransaction({ txIntent, configOrCurrencyId: mockConfig })).rejects.toThrow(
       "hedera: assetReference is missing",
     );
   });
@@ -289,7 +301,7 @@ describe("craftTransaction", () => {
       },
     } satisfies TransactionIntent<HederaMemo>;
 
-    await expect(craftTransaction({ txIntent, config: mockConfig })).rejects.toThrow(
+    await expect(craftTransaction({ txIntent, configOrCurrencyId: mockConfig })).rejects.toThrow(
       "hedera: no assetReference in token transfer",
     );
   });
@@ -318,7 +330,7 @@ describe("craftTransaction", () => {
 
     const result = await craftTransaction({
       txIntent,
-      config: {
+      configOrCurrencyId: {
         ...mockConfig,
         useNetworkTimestamp: true,
       },
@@ -350,7 +362,7 @@ describe("craftTransaction", () => {
 
     const result = await craftTransaction({
       txIntent,
-      config: {
+      configOrCurrencyId: {
         ...mockConfig,
         useNetworkTimestamp: true,
       },
@@ -387,14 +399,14 @@ describe("craftTransaction", () => {
     const [withoutMirror, withMirror] = await Promise.all([
       craftTransaction({
         txIntent,
-        config: {
+        configOrCurrencyId: {
           ...mockConfig,
           useNetworkTimestamp: false,
         },
       }),
       craftTransaction({
         txIntent,
-        config: {
+        configOrCurrencyId: {
           ...mockConfig,
           useNetworkTimestamp: true,
         },

--- a/libs/coin-modules/coin-hedera/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/craftTransaction.ts
@@ -11,7 +11,7 @@ import {
 import type { FeeEstimation, TransactionIntent } from "@ledgerhq/coin-module-framework/api/index";
 import BigNumber from "bignumber.js";
 import invariant from "invariant";
-import type { HederaConfig } from "../config";
+import type { HederaCoinConfig } from "../config";
 import {
   DEFAULT_GAS_LIMIT,
   HEDERA_TRANSACTION_MODES,
@@ -20,7 +20,7 @@ import {
 import { rpcClient } from "../network/rpc";
 import { createTransactionId, toEVMAddress } from "../network/utils";
 import type { HederaMemo, HederaTxData } from "../types";
-import { hasSpecificIntentData, serializeTransaction } from "./utils";
+import { hasSpecificIntentData, resolveConfig, serializeTransaction } from "./utils";
 
 interface BuilderOperator {
   accountId: string;
@@ -67,9 +67,11 @@ interface BuilderUpdateAccountTransaction extends BuilderCommonTransactionFields
 }
 
 async function buildUnsignedCoinTransaction({
+  config: _,
   account,
   transaction,
 }: {
+  config: HederaCoinConfig;
   account: BuilderOperator;
   transaction: BuilderCoinTransferTransaction;
 }): Promise<TransferTransaction> {
@@ -91,9 +93,11 @@ async function buildUnsignedCoinTransaction({
 }
 
 async function buildUnsignedHTSTokenTransaction({
+  config: _,
   account,
   transaction,
 }: {
+  config: HederaCoinConfig;
   account: BuilderOperator;
   transaction: BuilderHTSTokenTransferTransaction;
 }): Promise<TransferTransaction> {
@@ -115,12 +119,17 @@ async function buildUnsignedHTSTokenTransaction({
 }
 
 async function buildUnsignedERC20TokenTransaction({
+  config,
   transaction,
 }: {
   transaction: BuilderERC20TokenTransferTransaction;
+  config: HederaCoinConfig;
 }): Promise<ContractExecuteTransaction> {
   const contractId = ContractId.fromEvmAddress(0, 0, transaction.tokenAddress);
-  const recipientEvmAddress = await toEVMAddress(transaction.recipient);
+  const recipientEvmAddress = await toEVMAddress({
+    configOrCurrencyId: config,
+    accountId: transaction.recipient,
+  });
   invariant(recipientEvmAddress, `hedera: EVM address is missing ${transaction.recipient}`);
   const gas = transaction.gasLimit.toNumber();
 
@@ -146,9 +155,11 @@ async function buildUnsignedERC20TokenTransaction({
 }
 
 async function buildTokenAssociateTransaction({
+  config: _,
   account,
   transaction,
 }: {
+  config: HederaCoinConfig;
   account: BuilderOperator;
   transaction: BuilderTokenAssociateTransaction;
 }): Promise<TokenAssociateTransaction> {
@@ -169,9 +180,11 @@ async function buildTokenAssociateTransaction({
 }
 
 async function buildUnsignedUpdateAccountTransaction({
+  config: _,
   account,
   transaction,
 }: {
+  config: HederaCoinConfig;
   account: BuilderOperator;
   transaction: BuilderUpdateAccountTransaction;
 }): Promise<AccountUpdateTransaction> {
@@ -209,15 +222,15 @@ function isStakingMode(type: string): type is BuilderUpdateAccountTransaction["t
 export async function craftTransaction({
   txIntent,
   customFees,
-  config,
+  configOrCurrencyId,
 }: {
   txIntent: TransactionIntent<HederaMemo, HederaTxData>;
   customFees?: FeeEstimation;
-  config: HederaConfig;
+  configOrCurrencyId: HederaCoinConfig | string;
 }) {
   const account = { accountId: txIntent.sender };
   const maxFee = customFees ? new BigNumber(customFees.value.toString()) : undefined;
-
+  const config = resolveConfig(configOrCurrencyId);
   const transactionId = await createTransactionId(account.accountId, config);
 
   let tx;
@@ -227,6 +240,7 @@ export async function craftTransaction({
     invariant("assetReference" in txIntent.asset, "hedera: assetReference is missing");
 
     tx = await buildTokenAssociateTransaction({
+      config,
       account,
       transaction: {
         type: txIntent.type,
@@ -242,6 +256,7 @@ export async function craftTransaction({
     const amount = new BigNumber(txIntent.amount.toString());
 
     tx = await buildUnsignedHTSTokenTransaction({
+      config,
       account,
       transaction: {
         type: txIntent.type,
@@ -262,6 +277,7 @@ export async function craftTransaction({
       : DEFAULT_GAS_LIMIT;
 
     tx = await buildUnsignedERC20TokenTransaction({
+      config,
       transaction: {
         type: txIntent.type,
         transactionId,
@@ -279,6 +295,7 @@ export async function craftTransaction({
       : undefined;
 
     tx = await buildUnsignedUpdateAccountTransaction({
+      config,
       account,
       transaction: {
         type: txIntent.type,
@@ -294,6 +311,7 @@ export async function craftTransaction({
     const amount = new BigNumber(txIntent.amount.toString());
 
     tx = await buildUnsignedCoinTransaction({
+      config,
       account,
       transaction: {
         type: HEDERA_TRANSACTION_MODES.Send,

--- a/libs/coin-modules/coin-hedera/src/logic/estimateFees.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/estimateFees.test.ts
@@ -36,7 +36,7 @@ describe("getEstimatedFees", () => {
     (cvsApi.fetchLatest as jest.Mock).mockResolvedValueOnce([usdRate]);
 
     const result = await estimateFees({
-      currency: mockedAccount.currency,
+      currencyId: mockedAccount.currency.id,
       operationType: HEDERA_OPERATION_TYPES.CryptoTransfer,
     });
 
@@ -56,7 +56,7 @@ describe("getEstimatedFees", () => {
     (cvsApi.fetchLatest as jest.Mock).mockResolvedValueOnce([usdRate]);
 
     const result = await estimateFees({
-      currency: mockedAccount.currency,
+      currencyId: mockedAccount.currency.id,
       operationType: HEDERA_OPERATION_TYPES.TokenTransfer,
     });
 
@@ -76,7 +76,7 @@ describe("getEstimatedFees", () => {
     (cvsApi.fetchLatest as jest.Mock).mockResolvedValueOnce([usdRate]);
 
     const result = await estimateFees({
-      currency: mockedAccount.currency,
+      currencyId: mockedAccount.currency.id,
       operationType: HEDERA_OPERATION_TYPES.TokenAssociate,
     });
 
@@ -113,6 +113,7 @@ describe("getEstimatedFees", () => {
     (apiClient.estimateContractCallGas as jest.Mock).mockResolvedValueOnce(estimatedGasLimit);
 
     const result = await estimateFees({
+      configOrCurrencyId: mockedAccount.currency.id,
       operationType: HEDERA_OPERATION_TYPES.ContractCall,
       txIntent: {
         intentType: "transaction",
@@ -139,8 +140,14 @@ describe("getEstimatedFees", () => {
     expect(apiClient.getNetworkFees).toHaveBeenCalledTimes(1);
     expect(apiClient.estimateContractCallGas).toHaveBeenCalledTimes(1);
     expect(apiClient.estimateContractCallGas).toHaveBeenCalledWith(
-      await toEVMAddress(senderAddress),
-      await toEVMAddress(recipientAddress),
+      await toEVMAddress({
+        configOrCurrencyId: mockedAccount.currency.id,
+        accountId: senderAddress,
+      }),
+      await toEVMAddress({
+        configOrCurrencyId: mockedAccount.currency.id,
+        accountId: recipientAddress,
+      }),
       mockedTokenCurrencyERC20.contractAddress,
       transferAmount,
     );
@@ -156,6 +163,7 @@ describe("getEstimatedFees", () => {
     (apiClient.getNetworkFees as jest.Mock).mockRejectedValueOnce(new Error("Network error"));
 
     const result = await estimateFees({
+      configOrCurrencyId: mockedAccount.currency.id,
       operationType: HEDERA_OPERATION_TYPES.ContractCall,
       txIntent: {
         intentType: "transaction",
@@ -192,6 +200,7 @@ describe("getEstimatedFees", () => {
     );
 
     const result = await estimateFees({
+      configOrCurrencyId: mockedAccount.currency.id,
       operationType: HEDERA_OPERATION_TYPES.ContractCall,
       txIntent: {
         intentType: "transaction",
@@ -222,7 +231,7 @@ describe("getEstimatedFees", () => {
     (cvsApi.fetchLatest as jest.Mock).mockResolvedValueOnce([usdRate]);
 
     const result = await estimateFees({
-      currency: mockedAccount.currency,
+      currencyId: mockedAccount.currency.id,
       operationType: HEDERA_OPERATION_TYPES.CryptoTransfer,
     });
 
@@ -239,7 +248,7 @@ describe("getEstimatedFees", () => {
     (cvsApi.fetchLatest as jest.Mock).mockRejectedValueOnce(new Error("Network error"));
 
     const result = await estimateFees({
-      currency: mockedAccount.currency,
+      currencyId: mockedAccount.currency.id,
       operationType: HEDERA_OPERATION_TYPES.CryptoTransfer,
     });
 

--- a/libs/coin-modules/coin-hedera/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/estimateFees.ts
@@ -1,6 +1,8 @@
 import type { TransactionIntent } from "@ledgerhq/coin-module-framework/api/types";
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { findCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
 import BigNumber from "bignumber.js";
+import invariant from "invariant";
+import type { HederaCoinConfig } from "../config";
 import {
   BASE_USD_FEE_BY_OPERATION_TYPE,
   DEFAULT_GAS_LIMIT,
@@ -14,16 +16,20 @@ import { apiClient } from "../network/api";
 import { getCurrencyToUSDRate, toEVMAddress } from "../network/utils";
 import type { EstimateFeesParams, EstimateFeesResult } from "../types";
 
-const estimateContractCallFees = async (
-  txIntent: TransactionIntent,
-): Promise<EstimateFeesResult> => {
+const estimateContractCallFees = async ({
+  configOrCurrencyId,
+  txIntent,
+}: {
+  configOrCurrencyId: HederaCoinConfig | string;
+  txIntent: TransactionIntent;
+}): Promise<EstimateFeesResult> => {
   let tinybars = new BigNumber(0);
   let gas = new BigNumber(0);
 
   const tokenEvmAddress = "assetReference" in txIntent.asset ? txIntent.asset.assetReference : null;
   const [senderEvmAddress, recipientEvmAddress] = await Promise.all([
-    toEVMAddress(txIntent.sender),
-    toEVMAddress(txIntent.recipient),
+    toEVMAddress({ configOrCurrencyId, accountId: txIntent.sender }),
+    toEVMAddress({ configOrCurrencyId, accountId: txIntent.recipient }),
   ]);
 
   if (!tokenEvmAddress || !senderEvmAddress || !recipientEvmAddress) {
@@ -61,10 +67,16 @@ const estimateContractCallFees = async (
   };
 };
 
-const estimateStandardFees = async (
-  currency: CryptoCurrency,
-  operationType: HEDERA_OPERATION_TYPES,
-): Promise<EstimateFeesResult> => {
+const estimateStandardFees = async ({
+  currencyId,
+  operationType,
+}: {
+  currencyId: string;
+  operationType: HEDERA_OPERATION_TYPES;
+}): Promise<EstimateFeesResult> => {
+  const currency = findCryptoCurrencyById(currencyId);
+  invariant(currency, `hedera: currency with id ${currencyId} not found`);
+
   let tinybars: BigNumber;
   const usdRate = await getCurrencyToUSDRate(currency).catch(() => null);
 
@@ -84,8 +96,14 @@ const estimateStandardFees = async (
 
 export const estimateFees = async (params: EstimateFeesParams): Promise<EstimateFeesResult> => {
   if (params.operationType === HEDERA_OPERATION_TYPES.ContractCall) {
-    return estimateContractCallFees(params.txIntent);
+    return estimateContractCallFees({
+      configOrCurrencyId: params.configOrCurrencyId,
+      txIntent: params.txIntent,
+    });
   }
 
-  return estimateStandardFees(params.currency, params.operationType);
+  return estimateStandardFees({
+    currencyId: params.currencyId,
+    operationType: params.operationType,
+  });
 };

--- a/libs/coin-modules/coin-hedera/src/logic/getBalance.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBalance.test.ts
@@ -41,7 +41,7 @@ describe("getBalance", () => {
     (apiClient.getAccountTokens as jest.Mock).mockResolvedValue([]);
     (networkUtils.getERC20BalancesForAccountV2 as jest.Mock).mockResolvedValue([]);
 
-    const result = await getBalance(mockCurrency, address);
+    const result = await getBalance({ currencyId: mockCurrency.id, address });
 
     expect(apiClient.getAccount).toHaveBeenCalledTimes(1);
     expect(apiClient.getAccount).toHaveBeenCalledWith(address);
@@ -92,14 +92,17 @@ describe("getBalance", () => {
     (apiClient.getAccountTokens as jest.Mock).mockResolvedValue(mockMirrorTokens);
     (networkUtils.getERC20BalancesForAccountV2 as jest.Mock).mockResolvedValue(mockERC20Balances);
 
-    const result = await getBalance(mockCurrency, address);
+    const result = await getBalance({ currencyId: mockCurrency.id, address });
 
     expect(apiClient.getAccount).toHaveBeenCalledTimes(1);
     expect(apiClient.getAccount).toHaveBeenCalledWith(address);
     expect(apiClient.getAccountTokens).toHaveBeenCalledTimes(1);
     expect(apiClient.getAccountTokens).toHaveBeenCalledWith(address);
     expect(networkUtils.getERC20BalancesForAccountV2).toHaveBeenCalledTimes(1);
-    expect(networkUtils.getERC20BalancesForAccountV2).toHaveBeenCalledWith(address);
+    expect(networkUtils.getERC20BalancesForAccountV2).toHaveBeenCalledWith({
+      configOrCurrencyId: mockCurrency.id,
+      address,
+    });
     expect(findTokenByAddressInCurrencyMock).toHaveBeenCalledTimes(2);
     expect(findTokenByAddressInCurrencyMock).toHaveBeenCalledWith("0.0.7890", "hedera");
     expect(findTokenByAddressInCurrencyMock).toHaveBeenCalledWith("0x12345", "hedera");
@@ -155,7 +158,7 @@ describe("getBalance", () => {
     (apiClient.getNode as jest.Mock).mockResolvedValue(mockMirrorNode);
     (networkUtils.getERC20BalancesForAccountV2 as jest.Mock).mockResolvedValue([]);
 
-    const result = await getBalance(mockCurrency, address);
+    const result = await getBalance({ currencyId: mockCurrency.id, address });
 
     expect(apiClient.getAccount).toHaveBeenCalledTimes(1);
     expect(apiClient.getAccount).toHaveBeenCalledWith(address);
@@ -245,7 +248,7 @@ describe("getBalance", () => {
     (apiClient.getAccountTokens as jest.Mock).mockResolvedValue(mockMirrorTokens);
     (networkUtils.getERC20BalancesForAccountV2 as jest.Mock).mockResolvedValue(mockERC20Balances);
 
-    const result = await getBalance(mockCurrency, address);
+    const result = await getBalance({ currencyId: mockCurrency.id, address });
 
     expect(result).toEqual([
       {
@@ -282,7 +285,7 @@ describe("getBalance", () => {
     (apiClient.getAccountTokens as jest.Mock).mockResolvedValue([]);
     (networkUtils.getERC20BalancesForAccountV2 as jest.Mock).mockResolvedValue([]);
 
-    await expect(getBalance(mockCurrency, address)).rejects.toThrow(error);
+    await expect(getBalance({ currencyId: mockCurrency.id, address })).rejects.toThrow(error);
   });
 
   it("should throw when failing to getAccountTokens data", async () => {
@@ -292,7 +295,7 @@ describe("getBalance", () => {
     (apiClient.getAccountTokens as jest.Mock).mockRejectedValue(error);
     (networkUtils.getERC20BalancesForAccountV2 as jest.Mock).mockResolvedValue([]);
 
-    await expect(getBalance(mockCurrency, address)).rejects.toThrow(error);
+    await expect(getBalance({ currencyId: mockCurrency.id, address })).rejects.toThrow(error);
   });
 
   it("should throw when failing to fetch ERC20 balances", async () => {
@@ -302,7 +305,7 @@ describe("getBalance", () => {
     (apiClient.getAccountTokens as jest.Mock).mockResolvedValue([]);
     (networkUtils.getERC20BalancesForAccountV2 as jest.Mock).mockRejectedValue(error);
 
-    await expect(getBalance(mockCurrency, address)).rejects.toThrow(error);
+    await expect(getBalance({ currencyId: mockCurrency.id, address })).rejects.toThrow(error);
   });
 
   it.each([
@@ -321,7 +324,7 @@ describe("getBalance", () => {
     (apiClient.getAccountTokens as jest.Mock).mockResolvedValue([]);
     (networkUtils.getERC20BalancesForAccountV2 as jest.Mock).mockResolvedValue([]);
 
-    const result = await getBalance(mockCurrency, address);
+    const result = await getBalance({ currencyId: mockCurrency.id, address });
 
     expect(apiClient.getAccount).toHaveBeenCalledTimes(1);
     expect(apiClient.getAccount).toHaveBeenCalledWith(address);

--- a/libs/coin-modules/coin-hedera/src/logic/getBalance.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBalance.ts
@@ -2,16 +2,25 @@ import type { Balance } from "@ledgerhq/coin-module-framework/api/types";
 import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
 import { LedgerAPI4xx } from "@ledgerhq/errors";
 import { promiseAllBatched } from "@ledgerhq/live-promise";
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import BigNumber from "bignumber.js";
+import { type HederaCoinConfig } from "../config";
 import { HederaAddAccountError } from "../errors";
 import { resolveConfig } from "./utils";
 import { apiClient } from "../network/api";
 import { getERC20BalancesForAccountV2 } from "../network/utils";
 
-export async function getBalance(currency: CryptoCurrency, address: string): Promise<Balance[]> {
+export async function getBalance({
+  config,
+  currencyId,
+  address,
+}: {
+  config?: HederaCoinConfig;
+  currencyId: string;
+  address: string;
+}): Promise<Balance[]> {
+  const coinConfig = resolveConfig(config ?? currencyId);
+
   try {
-    const coinConfig = resolveConfig(currency.id);
     // Fetch only the specific staked node (or nothing at all for non-staking
     // accounts) instead of paginating the full /network/nodes list. The
     // validator lookup is chained on the account promise so it still runs
@@ -25,7 +34,9 @@ export async function getBalance(currency: CryptoCurrency, address: string): Pro
     const [mirrorAccount, mirrorTokens, erc20TokenBalances, validator] = await Promise.all([
       mirrorAccountPromise,
       apiClient.getAccountTokens(address),
-      coinConfig.useHgraphForErc20 ? getERC20BalancesForAccountV2(address) : Promise.resolve([]),
+      coinConfig.useHgraphForErc20
+        ? getERC20BalancesForAccountV2({ configOrCurrencyId: config ?? currencyId, address })
+        : Promise.resolve([]),
       validatorPromise,
     ]);
 
@@ -59,7 +70,7 @@ export async function getBalance(currency: CryptoCurrency, address: string): Pro
         const tokenAddress = "token_id" in item ? item.token_id : item.token.contractAddress;
         const calToken = await getCryptoAssetsStore().findTokenByAddressInCurrency(
           tokenAddress,
-          currency.id,
+          currencyId,
         );
 
         if (!calToken || !calToken.units.length) {

--- a/libs/coin-modules/coin-hedera/src/logic/getBlock.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBlock.test.ts
@@ -1,6 +1,7 @@
 import { FINALITY_MS, HEDERA_TRANSACTION_NAMES } from "../constants";
 import { apiClient } from "../network/api";
 import { analyzeStakingOperation } from "../network/utils";
+import { getMockedCurrency } from "../test/fixtures/currency.fixture";
 import type { StakingAnalysis } from "../types";
 import { getBlock } from "./getBlock";
 import { getBlockInfo } from "./getBlockInfo";
@@ -20,6 +21,7 @@ jest.mock("./utils", () => ({
 }));
 
 describe("getBlock", () => {
+  const mockCurrency = getMockedCurrency();
   const mockBlockInfo = {
     height: 100,
     hash: "mock_hash",
@@ -41,7 +43,7 @@ describe("getBlock", () => {
   it("should return empty block when no transactions exist", async () => {
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([]);
 
-    const result = await getBlock(100);
+    const result = await getBlock({ configOrCurrencyId: mockCurrency.id, height: 100 });
 
     expect(result).toEqual({
       info: mockBlockInfo,
@@ -52,7 +54,7 @@ describe("getBlock", () => {
   it("should call dependencies with correct parameters", async () => {
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([]);
 
-    await getBlock(42);
+    await getBlock({ configOrCurrencyId: mockCurrency.id, height: 42 });
 
     expect(getDateRangeFromBlockHeight).toHaveBeenCalledWith(42);
     expect(getBlockInfo).toHaveBeenCalledWith(42);
@@ -77,7 +79,7 @@ describe("getBlock", () => {
 
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([mockTx]);
 
-    const result = await getBlock(100);
+    const result = await getBlock({ configOrCurrencyId: mockCurrency.id, height: 100 });
 
     expect(result.transactions[0].feesPayer).toBe("0.0.999");
   });
@@ -99,7 +101,7 @@ describe("getBlock", () => {
 
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([mockTx]);
 
-    const result = await getBlock(100);
+    const result = await getBlock({ configOrCurrencyId: mockCurrency.id, height: 100 });
     const payerOperation = result.transactions[0].operations.find(op => op.address === "0.0.23");
 
     expect(result.transactions[0].feesPayer).toBe("0.0.23");
@@ -132,7 +134,7 @@ describe("getBlock", () => {
 
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([mockTx]);
 
-    const result = await getBlock(100);
+    const result = await getBlock({ configOrCurrencyId: mockCurrency.id, height: 100 });
     const senderOperation = result.transactions[0].operations.find(op => op.address === "0.0.999");
 
     expect(senderOperation).toMatchObject({
@@ -166,7 +168,7 @@ describe("getBlock", () => {
 
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([mockTx]);
 
-    const result = await getBlock(100);
+    const result = await getBlock({ configOrCurrencyId: mockCurrency.id, height: 100 });
 
     expect(result.transactions[0].operations).toEqual([
       {
@@ -204,7 +206,7 @@ describe("getBlock", () => {
 
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([mockTx]);
 
-    const result = await getBlock(100);
+    const result = await getBlock({ configOrCurrencyId: mockCurrency.id, height: 100 });
 
     expect(result.transactions[0].failed).toBe(true);
   });
@@ -231,10 +233,14 @@ describe("getBlock", () => {
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([mockTx]);
     (analyzeStakingOperation as jest.Mock).mockResolvedValue(mockStakingAnalysis);
 
-    const result = await getBlock(100);
+    const result = await getBlock({ configOrCurrencyId: mockCurrency.id, height: 100 });
 
     expect(analyzeStakingOperation).toHaveBeenCalledTimes(1);
-    expect(analyzeStakingOperation).toHaveBeenCalledWith("0.0.999", mockTx);
+    expect(analyzeStakingOperation).toHaveBeenCalledWith({
+      configOrCurrencyId: mockCurrency.id,
+      address: "0.0.999",
+      mirrorTx: mockTx,
+    });
     expect(result.transactions[0].operations).toHaveLength(1);
     expect(result.transactions[0].operations[0]).toEqual({
       type: "other",
@@ -267,7 +273,7 @@ describe("getBlock", () => {
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([mockTx]);
     (analyzeStakingOperation as jest.Mock).mockResolvedValue(mockStakingAnalysis);
 
-    const result = await getBlock(100);
+    const result = await getBlock({ configOrCurrencyId: mockCurrency.id, height: 100 });
 
     expect(result.transactions[0].operations[0]).toEqual({
       type: "other",
@@ -300,7 +306,7 @@ describe("getBlock", () => {
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([mockTx]);
     (analyzeStakingOperation as jest.Mock).mockResolvedValue(mockStakingAnalysis);
 
-    const result = await getBlock(100);
+    const result = await getBlock({ configOrCurrencyId: mockCurrency.id, height: 100 });
 
     expect(result.transactions[0].operations).toEqual([
       {
@@ -345,7 +351,7 @@ describe("getBlock", () => {
 
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([mockTx]);
 
-    const result = await getBlock(100);
+    const result = await getBlock({ configOrCurrencyId: mockCurrency.id, height: 100 });
 
     expect(result.transactions[0].operations).toEqual([
       {
@@ -400,7 +406,7 @@ describe("getBlock", () => {
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([mockTx]);
     (analyzeStakingOperation as jest.Mock).mockResolvedValue(null);
 
-    const result = await getBlock(100);
+    const result = await getBlock({ configOrCurrencyId: mockCurrency.id, height: 100 });
 
     expect(result.transactions[0].operations).toEqual([
       {
@@ -427,7 +433,9 @@ describe("getBlock", () => {
 
     (getDateRangeFromBlockHeight as jest.Mock).mockReturnValue(futureRange);
 
-    await expect(getBlock(999)).rejects.toThrow("Block 999 is not available yet");
+    await expect(getBlock({ configOrCurrencyId: mockCurrency.id, height: 999 })).rejects.toThrow(
+      "Block 999 is not available yet",
+    );
     expect(getBlockInfo).not.toHaveBeenCalled();
     expect(apiClient.getTransactionsByTimestampRange).not.toHaveBeenCalled();
   });
@@ -441,7 +449,9 @@ describe("getBlock", () => {
 
     (getDateRangeFromBlockHeight as jest.Mock).mockReturnValue(overlappingRange);
 
-    await expect(getBlock(998)).rejects.toThrow("Block 998 is not available yet");
+    await expect(getBlock({ configOrCurrencyId: mockCurrency.id, height: 998 })).rejects.toThrow(
+      "Block 998 is not available yet",
+    );
     expect(getBlockInfo).not.toHaveBeenCalled();
     expect(apiClient.getTransactionsByTimestampRange).not.toHaveBeenCalled();
   });
@@ -456,7 +466,7 @@ describe("getBlock", () => {
     (getDateRangeFromBlockHeight as jest.Mock).mockReturnValue(finalizedRange);
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([]);
 
-    const result = await getBlock(100);
+    const result = await getBlock({ configOrCurrencyId: mockCurrency.id, height: 100 });
 
     expect(result).toEqual({
       info: mockBlockInfo,

--- a/libs/coin-modules/coin-hedera/src/logic/getBlock.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBlock.ts
@@ -4,6 +4,7 @@ import type {
   BlockOperation,
   BlockTransaction,
 } from "@ledgerhq/coin-module-framework/api/types";
+import type { HederaCoinConfig } from "../config";
 import { FINALITY_MS, HEDERA_TRANSACTION_NAMES } from "../constants";
 import { apiClient } from "../network/api";
 import { analyzeStakingOperation } from "../network/utils";
@@ -60,7 +61,13 @@ function createStakingRewardOperations(tx: HederaMirrorTransaction): BlockOperat
   }));
 }
 
-export async function getBlock(height: number): Promise<Block> {
+export async function getBlock({
+  configOrCurrencyId,
+  height,
+}: {
+  configOrCurrencyId: HederaCoinConfig | string;
+  height: number;
+}): Promise<Block> {
   const { start, end } = getDateRangeFromBlockHeight(height);
 
   // block data should be immutable: do not allow querying blocks on non-finalized time range
@@ -80,7 +87,11 @@ export async function getBlock(height: number): Promise<Block> {
       .filter(tx => tx.name === HEDERA_TRANSACTION_NAMES.UpdateAccount)
       .map(async tx => {
         const payerAccount = extractFeesPayer(tx);
-        const analysis = await analyzeStakingOperation(payerAccount, tx);
+        const analysis = await analyzeStakingOperation({
+          configOrCurrencyId,
+          address: payerAccount,
+          mirrorTx: tx,
+        });
 
         return [tx.transaction_hash, analysis] as const;
       }),

--- a/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.test.ts
@@ -39,6 +39,7 @@ jest.mock("./utils", () => ({
 }));
 
 describe("getBlockV2", () => {
+  const configOrCurrencyId = "hedera";
   const mockBlockInfo: BlockInfo = {
     height: 100,
     hash: "mock_hash",
@@ -66,7 +67,7 @@ describe("getBlockV2", () => {
     (hgraphClient.getERC20TransfersByTimestampRange as jest.Mock).mockResolvedValue([]);
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([]);
 
-    const result = await getBlockV2(100);
+    const result = await getBlockV2({ configOrCurrencyId, height: 100 });
 
     expect(result).toEqual({
       info: mockBlockInfo,
@@ -78,7 +79,7 @@ describe("getBlockV2", () => {
     (hgraphClient.getERC20TransfersByTimestampRange as jest.Mock).mockResolvedValue([]);
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([]);
 
-    await getBlockV2(42);
+    await getBlockV2({ configOrCurrencyId, height: 42 });
 
     expect(getDateRangeFromBlockHeight).toHaveBeenCalledWith(42);
     expect(getBlockInfo).toHaveBeenCalledWith(42);
@@ -115,7 +116,7 @@ describe("getBlockV2", () => {
     (hgraphClient.getERC20TransfersByTimestampRange as jest.Mock).mockResolvedValue([]);
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([mockTx]);
 
-    const result = await getBlockV2(100);
+    const result = await getBlockV2({ configOrCurrencyId, height: 100 });
 
     expect(result.transactions[0].feesPayer).toBe("0.0.999");
   });
@@ -138,7 +139,7 @@ describe("getBlockV2", () => {
     (hgraphClient.getERC20TransfersByTimestampRange as jest.Mock).mockResolvedValue([]);
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([mockTx]);
 
-    const result = await getBlockV2(100);
+    const result = await getBlockV2({ configOrCurrencyId, height: 100 });
     const payerOperation = result.transactions[0].operations.find(op => op.address === "0.0.23");
 
     expect(result.transactions[0].feesPayer).toBe("0.0.23");
@@ -172,7 +173,7 @@ describe("getBlockV2", () => {
     (hgraphClient.getERC20TransfersByTimestampRange as jest.Mock).mockResolvedValue([]);
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([mockTx]);
 
-    const result = await getBlockV2(100);
+    const result = await getBlockV2({ configOrCurrencyId, height: 100 });
     const senderOperation = result.transactions[0].operations.find(op => op.address === "0.0.999");
 
     expect(senderOperation).toMatchObject({
@@ -207,7 +208,7 @@ describe("getBlockV2", () => {
     (hgraphClient.getERC20TransfersByTimestampRange as jest.Mock).mockResolvedValue([]);
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([mockTx]);
 
-    const result = await getBlockV2(100);
+    const result = await getBlockV2({ configOrCurrencyId, height: 100 });
 
     expect(result.transactions[0].operations).toEqual([
       {
@@ -281,7 +282,7 @@ describe("getBlockV2", () => {
     ]);
     (enrichERC20Transfers as jest.Mock).mockReturnValue([mockEnrichedERC20Transfer]);
 
-    const result = await getBlockV2(100);
+    const result = await getBlockV2({ configOrCurrencyId, height: 100 });
 
     expect(result.transactions[0].operations).toEqual([
       {
@@ -359,7 +360,7 @@ describe("getBlockV2", () => {
     ]);
     (enrichERC20Transfers as jest.Mock).mockReturnValue([mockEnrichedERC20Transfer]);
 
-    const result = await getBlockV2(100);
+    const result = await getBlockV2({ configOrCurrencyId, height: 100 });
 
     expect(result.transactions).toEqual([expect.objectContaining({ hash: sharedHash })]);
   });
@@ -408,7 +409,7 @@ describe("getBlockV2", () => {
     ]);
     (enrichERC20Transfers as jest.Mock).mockReturnValue([mockEnrichedERC20Transfer]);
 
-    const result = await getBlockV2(100);
+    const result = await getBlockV2({ configOrCurrencyId, height: 100 });
 
     expect(result.transactions).toHaveLength(1);
     expect(result.transactions[0].operations).toEqual([
@@ -481,7 +482,7 @@ describe("getBlockV2", () => {
     ]);
     (enrichERC20Transfers as jest.Mock).mockReturnValue([mockEnrichedERC20Transfer]);
 
-    const result = await getBlockV2(100);
+    const result = await getBlockV2({ configOrCurrencyId, height: 100 });
     const operations = result.transactions[0]?.operations;
     const erc20Operations = operations?.filter(
       op => op.type === "transfer" && op.asset.type === "erc20",
@@ -505,7 +506,7 @@ describe("getBlockV2", () => {
     (hgraphClient.getERC20TransfersByTimestampRange as jest.Mock).mockResolvedValue([]);
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([mockTx]);
 
-    const result = await getBlockV2(100);
+    const result = await getBlockV2({ configOrCurrencyId, height: 100 });
 
     expect(result.transactions[0].failed).toBe(true);
   });
@@ -533,10 +534,14 @@ describe("getBlockV2", () => {
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([mockTx]);
     (analyzeStakingOperation as jest.Mock).mockResolvedValue(mockStakingAnalysis);
 
-    const result = await getBlockV2(100);
+    const result = await getBlockV2({ configOrCurrencyId, height: 100 });
 
     expect(analyzeStakingOperation).toHaveBeenCalledTimes(1);
-    expect(analyzeStakingOperation).toHaveBeenCalledWith("0.0.999", mockTx);
+    expect(analyzeStakingOperation).toHaveBeenCalledWith({
+      configOrCurrencyId,
+      address: "0.0.999",
+      mirrorTx: mockTx,
+    });
     expect(result.transactions[0].operations).toHaveLength(1);
     expect(result.transactions[0].operations[0]).toEqual({
       type: "other",
@@ -570,7 +575,7 @@ describe("getBlockV2", () => {
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([mockTx]);
     (analyzeStakingOperation as jest.Mock).mockResolvedValue(mockStakingAnalysis);
 
-    const result = await getBlockV2(100);
+    const result = await getBlockV2({ configOrCurrencyId, height: 100 });
 
     expect(result.transactions[0].operations[0]).toEqual({
       type: "other",
@@ -604,7 +609,7 @@ describe("getBlockV2", () => {
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([mockTx]);
     (analyzeStakingOperation as jest.Mock).mockResolvedValue(mockStakingAnalysis);
 
-    const result = await getBlockV2(100);
+    const result = await getBlockV2({ configOrCurrencyId, height: 100 });
 
     expect(result.transactions[0].operations).toEqual([
       {
@@ -671,7 +676,7 @@ describe("getBlockV2", () => {
     (hgraphClient.getERC20TransfersByTimestampRange as jest.Mock).mockResolvedValue([]);
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([mockTx]);
 
-    const result = await getBlockV2(100);
+    const result = await getBlockV2({ configOrCurrencyId, height: 100 });
 
     expect(result.transactions[0].operations).toEqual([
       {
@@ -745,7 +750,7 @@ describe("getBlockV2", () => {
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([mockTx]);
     (analyzeStakingOperation as jest.Mock).mockResolvedValue(null);
 
-    const result = await getBlockV2(100);
+    const result = await getBlockV2({ configOrCurrencyId, height: 100 });
 
     expect(result.transactions[0].operations).toEqual([
       {
@@ -772,7 +777,9 @@ describe("getBlockV2", () => {
 
     (getDateRangeFromBlockHeight as jest.Mock).mockReturnValue(futureRange);
 
-    await expect(getBlockV2(999)).rejects.toThrow("Block 999 is not available yet");
+    await expect(getBlockV2({ configOrCurrencyId, height: 999 })).rejects.toThrow(
+      "Block 999 is not available yet",
+    );
     expect(getBlockInfo).not.toHaveBeenCalled();
     expect(apiClient.getTransactionsByTimestampRange).not.toHaveBeenCalled();
   });
@@ -786,7 +793,9 @@ describe("getBlockV2", () => {
 
     (getDateRangeFromBlockHeight as jest.Mock).mockReturnValue(overlappingRange);
 
-    await expect(getBlockV2(998)).rejects.toThrow("Block 998 is not available yet");
+    await expect(getBlockV2({ configOrCurrencyId, height: 998 })).rejects.toThrow(
+      "Block 998 is not available yet",
+    );
     expect(getBlockInfo).not.toHaveBeenCalled();
     expect(apiClient.getTransactionsByTimestampRange).not.toHaveBeenCalled();
   });
@@ -801,7 +810,7 @@ describe("getBlockV2", () => {
     (getDateRangeFromBlockHeight as jest.Mock).mockReturnValue(finalizedRange);
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([]);
 
-    const result = await getBlockV2(100);
+    const result = await getBlockV2({ configOrCurrencyId, height: 100 });
 
     expect(result).toEqual({
       info: mockBlockInfo,
@@ -822,7 +831,7 @@ describe("getBlockV2", () => {
       endTimestampNs,
     );
 
-    await expect(getBlockV2(blockHeight)).rejects.toThrow(
+    await expect(getBlockV2({ configOrCurrencyId, height: blockHeight })).rejects.toThrow(
       `Block ${blockHeight} has no ERC20 synced yet (${endTimestampNs})`,
     );
     expect(getBlockInfo).not.toHaveBeenCalled();

--- a/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.ts
@@ -4,6 +4,7 @@ import type {
   BlockOperation,
   BlockTransaction,
 } from "@ledgerhq/coin-module-framework/api/types";
+import type { HederaCoinConfig } from "../config";
 import { FINALITY_MS, HEDERA_TRANSACTION_NAMES } from "../constants";
 import { apiClient } from "../network/api";
 import { hgraphClient } from "../network/hgraph";
@@ -136,7 +137,13 @@ function createStakingRewardOperations(tx: HederaMirrorTransaction): BlockOperat
   }));
 }
 
-export async function getBlockV2(height: number): Promise<Block> {
+export async function getBlockV2({
+  configOrCurrencyId,
+  height,
+}: {
+  configOrCurrencyId: HederaCoinConfig | string;
+  height: number;
+}): Promise<Block> {
   const { start, end } = getDateRangeFromBlockHeight(height);
 
   // block data should be immutable: do not allow querying blocks on non-finalized time range
@@ -171,7 +178,7 @@ export async function getBlockV2(height: number): Promise<Block> {
         limit,
         order,
       })
-      .then(erc20Transfers => enrichERC20Transfers(erc20Transfers)),
+      .then(erc20Transfers => enrichERC20Transfers({ configOrCurrencyId, erc20Transfers })),
   ]);
 
   const mergeResult = mergeTransactionsFromDifferentSources({
@@ -188,7 +195,11 @@ export async function getBlockV2(height: number): Promise<Block> {
   const stakingAnalyses = await Promise.all(
     mergeResult.merged.filter(isStakingTransactionType).map(async item => {
       const payerAccount = extractFeesPayer(item.data);
-      const analysis = await analyzeStakingOperation(payerAccount, item.data);
+      const analysis = await analyzeStakingOperation({
+        configOrCurrencyId,
+        address: payerAccount,
+        mirrorTx: item.data,
+      });
 
       return [item.data.transaction_hash, analysis] as const;
     }),

--- a/libs/coin-modules/coin-hedera/src/logic/getRewards.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getRewards.test.ts
@@ -1,7 +1,9 @@
 import { apiClient } from "../network/api";
+import { getMockedCurrency } from "../test/fixtures/currency.fixture";
 import { getRewards } from "./getRewards";
 
 describe("getRewards", () => {
+  const mockCurrency = getMockedCurrency();
   const mockAddress = "0.0.123456";
   const mockGetAccountTransactions = jest.spyOn(apiClient, "getAccountTransactions");
 
@@ -21,7 +23,11 @@ describe("getRewards", () => {
       nextCursor: null,
     });
 
-    const result = await getRewards(mockAddress);
+    const result = await getRewards({
+      configOrCurrencyId: mockCurrency.id,
+      address: mockAddress,
+      cursor: undefined,
+    });
 
     expect(result.items).toEqual([]);
     expect(mockGetAccountTransactions).toHaveBeenCalledTimes(1);
@@ -55,7 +61,11 @@ describe("getRewards", () => {
       nextCursor: null,
     });
 
-    const result = await getRewards(mockAddress);
+    const result = await getRewards({
+      configOrCurrencyId: mockCurrency.id,
+      address: mockAddress,
+      cursor: undefined,
+    });
 
     expect(result).toEqual({
       items: [
@@ -92,7 +102,11 @@ describe("getRewards", () => {
       nextCursor: null,
     });
 
-    const result = await getRewards(mockAddress);
+    const result = await getRewards({
+      configOrCurrencyId: mockCurrency.id,
+      address: mockAddress,
+      cursor: undefined,
+    });
 
     expect(result.items).toMatchObject([
       {
@@ -129,7 +143,11 @@ describe("getRewards", () => {
       nextCursor: null,
     });
 
-    const result = await getRewards(mockAddress);
+    const result = await getRewards({
+      configOrCurrencyId: mockCurrency.id,
+      address: mockAddress,
+      cursor: undefined,
+    });
 
     expect(result.items).toMatchObject([{ amount: BigInt(5000000) }, { amount: BigInt(3000000) }]);
   });
@@ -154,7 +172,11 @@ describe("getRewards", () => {
       nextCursor,
     });
 
-    const result = await getRewards(mockAddress, cursor);
+    const result = await getRewards({
+      configOrCurrencyId: mockCurrency.id,
+      address: mockAddress,
+      cursor,
+    });
 
     expect(result.next).toBe(nextCursor);
     expect(mockGetAccountTransactions).toHaveBeenCalledTimes(1);
@@ -184,7 +206,11 @@ describe("getRewards", () => {
       nextCursor: null,
     });
 
-    const result = await getRewards(mockAddress);
+    const result = await getRewards({
+      configOrCurrencyId: mockCurrency.id,
+      address: mockAddress,
+      cursor: undefined,
+    });
 
     expect(result.next).toBeUndefined();
   });

--- a/libs/coin-modules/coin-hedera/src/logic/getRewards.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getRewards.ts
@@ -1,10 +1,19 @@
 import type { Page, Reward } from "@ledgerhq/coin-module-framework/api/types";
+import type { HederaCoinConfig } from "../config";
 import { apiClient } from "../network/api";
 
 /**
  * Fetch staking rewards for a given Hedera account.
  */
-export async function getRewards(address: string, cursor?: string): Promise<Page<Reward>> {
+export async function getRewards({
+  configOrCurrencyId: _,
+  address,
+  cursor,
+}: {
+  configOrCurrencyId: HederaCoinConfig | string;
+  address: string;
+  cursor: string | undefined;
+}): Promise<Page<Reward>> {
   const mirrorTransactions = await apiClient.getAccountTransactions({
     address,
     fetchAllPages: false,

--- a/libs/coin-modules/coin-hedera/src/logic/getStakes.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getStakes.test.ts
@@ -1,7 +1,9 @@
 import { apiClient } from "../network/api";
+import { getMockedCurrency } from "../test/fixtures/currency.fixture";
 import { getStakes } from "./getStakes";
 
 describe("getStakes", () => {
+  const mockCurrency = getMockedCurrency();
   const mockAddress = "0.0.123456";
   const mockGetAccount = jest.spyOn(apiClient, "getAccount");
   const mockGetNode = jest.spyOn(apiClient, "getNode");
@@ -21,7 +23,7 @@ describe("getStakes", () => {
       staked_node_id: null,
     });
 
-    const result = await getStakes(mockAddress);
+    const result = await getStakes({ configOrCurrencyId: mockCurrency.id, address: mockAddress });
 
     expect(result.items).toEqual([]);
     expect(mockGetAccount).toHaveBeenCalledTimes(1);
@@ -44,7 +46,7 @@ describe("getStakes", () => {
       staked_node_id: -1,
     });
 
-    const result = await getStakes(mockAddress);
+    const result = await getStakes({ configOrCurrencyId: mockCurrency.id, address: mockAddress });
 
     expect(result.items).toEqual([
       {
@@ -82,7 +84,7 @@ describe("getStakes", () => {
 
     mockGetNode.mockResolvedValue(null);
 
-    const result = await getStakes(mockAddress);
+    const result = await getStakes({ configOrCurrencyId: mockCurrency.id, address: mockAddress });
 
     expect(mockGetNode).toHaveBeenCalledTimes(1);
     expect(mockGetNode).toHaveBeenCalledWith(stakedNodeId);
@@ -130,7 +132,7 @@ describe("getStakes", () => {
       reward_rate_start: 0,
     });
 
-    const result = await getStakes(mockAddress);
+    const result = await getStakes({ configOrCurrencyId: mockCurrency.id, address: mockAddress });
 
     expect(mockGetNode).toHaveBeenCalledWith(nodeId);
     expect(result.items).toEqual([
@@ -175,7 +177,7 @@ describe("getStakes", () => {
       reward_rate_start: 0,
     });
 
-    const result = await getStakes(mockAddress);
+    const result = await getStakes({ configOrCurrencyId: mockCurrency.id, address: mockAddress });
 
     expect(result.items[0].details?.overstaked).toBe(true);
   });

--- a/libs/coin-modules/coin-hedera/src/logic/getStakes.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getStakes.ts
@@ -1,10 +1,17 @@
 import type { Page, Stake } from "@ledgerhq/coin-module-framework/api/types";
+import type { HederaCoinConfig } from "../config";
 import { apiClient } from "../network/api";
 
 /**
  * Fetch stakes for a given Hedera account.
  */
-export async function getStakes(address: string): Promise<Page<Stake>> {
+export async function getStakes({
+  configOrCurrencyId: _,
+  address,
+}: {
+  configOrCurrencyId: HederaCoinConfig | string;
+  address: string;
+}): Promise<Page<Stake>> {
   const mirrorAccount = await apiClient.getAccount(address);
   const stakedNodeId = mirrorAccount.staked_node_id;
 

--- a/libs/coin-modules/coin-hedera/src/logic/getValidators.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getValidators.test.ts
@@ -1,9 +1,12 @@
 import { apiClient } from "../network/api";
+import { getMockedCurrency } from "../test/fixtures/currency.fixture";
 import { getValidators } from "./getValidators";
 
 jest.mock("../network/api");
 
 describe("getValidators", () => {
+  const mockCurrency = getMockedCurrency();
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -22,7 +25,7 @@ describe("getValidators", () => {
       nextCursor: null,
     });
 
-    const result = await getValidators();
+    const result = await getValidators({ configOrCurrencyId: mockCurrency.id, cursor: undefined });
 
     expect(result.items).toHaveLength(1);
     expect(result.items[0]).toMatchObject({
@@ -42,7 +45,7 @@ describe("getValidators", () => {
       nextCursor: "123",
     });
 
-    const result = await getValidators("100");
+    const result = await getValidators({ configOrCurrencyId: mockCurrency.id, cursor: "100" });
 
     expect(apiClient.getNodes).toHaveBeenCalledWith({ cursor: "100", fetchAllPages: false });
     expect(result.next).toBe("123");

--- a/libs/coin-modules/coin-hedera/src/logic/getValidators.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getValidators.ts
@@ -1,8 +1,15 @@
 import type { Cursor, Page, Validator } from "@ledgerhq/coin-module-framework/api/types";
+import type { HederaCoinConfig } from "../config";
 import { apiClient } from "../network/api";
 import { calculateAPY, extractCompanyFromNodeDescription } from "./utils";
 
-export async function getValidators(cursor?: Cursor): Promise<Page<Validator>> {
+export async function getValidators({
+  configOrCurrencyId: _,
+  cursor,
+}: {
+  configOrCurrencyId: HederaCoinConfig | string;
+  cursor: Cursor | undefined;
+}): Promise<Page<Validator>> {
   const res = await apiClient.getNodes({
     fetchAllPages: false,
     ...(cursor && { cursor }),

--- a/libs/coin-modules/coin-hedera/src/logic/lastBlock.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/lastBlock.test.ts
@@ -1,5 +1,6 @@
 import { FINALITY_MS, SYNTHETIC_BLOCK_WINDOW_SECONDS } from "../constants";
 import { apiClient } from "../network/api";
+import { getMockedCurrency } from "../test/fixtures/currency.fixture";
 import { lastBlock } from "./lastBlock";
 import { getSyntheticBlock } from "./utils";
 
@@ -8,6 +9,8 @@ jest.mock("../network/api");
 const BLOCK_WINDOW_MS = SYNTHETIC_BLOCK_WINDOW_SECONDS * 1000;
 
 describe("lastBlock", () => {
+  const mockCurrency = getMockedCurrency();
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -19,7 +22,7 @@ describe("lastBlock", () => {
 
     (apiClient.getLatestTransaction as jest.Mock).mockResolvedValue(mockTransaction);
 
-    const result = await lastBlock();
+    const result = await lastBlock({ configOrCurrencyId: mockCurrency.id });
     const expectedSyntheticBlock = getSyntheticBlock(mockTransaction.consensus_timestamp);
 
     expect(apiClient.getLatestTransaction).toHaveBeenCalledTimes(1);
@@ -36,7 +39,7 @@ describe("lastBlock", () => {
     (apiClient.getLatestTransaction as jest.Mock).mockResolvedValue(mockTransaction);
 
     const now = Date.now();
-    await lastBlock();
+    await lastBlock({ configOrCurrencyId: mockCurrency.id });
 
     // lastBlock() accounts for block window size: a transaction at the start of a block
     // creates a block whose END time is BLOCK_WINDOW later, so we query transactions

--- a/libs/coin-modules/coin-hedera/src/logic/lastBlock.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/lastBlock.ts
@@ -1,4 +1,5 @@
 import type { BlockInfo } from "@ledgerhq/coin-module-framework/api/index";
+import type { HederaCoinConfig } from "../config";
 import { FINALITY_MS, SYNTHETIC_BLOCK_WINDOW_SECONDS } from "../constants";
 import { apiClient } from "../network/api";
 import { getSyntheticBlock } from "./utils";
@@ -12,8 +13,12 @@ import { getSyntheticBlock } from "./utils";
  * 2. Extract its consensus timestamp
  * 3. Convert this timestamp into a synthetic block using a hardcoded time window (10 seconds by default)
  */
-export async function lastBlock(): Promise<BlockInfo> {
-  // see getBlock implementation, block data should be immutable: we do not allow querying blocks on non-finalized time range.
+export async function lastBlock({
+  configOrCurrencyId: _,
+}: {
+  configOrCurrencyId: HederaCoinConfig | string;
+}): Promise<BlockInfo> {
+  // see getBlock implementation, block data should be immutable: we do not allow querying blocks on non-finalized time range
   // => we search the most recent transaction, but only in finalized time range (ending 10 seconds ago).
   const before = new Date(Date.now() - FINALITY_MS - SYNTHETIC_BLOCK_WINDOW_SECONDS * 1000);
   const latestTransaction = await apiClient.getLatestTransaction(before);

--- a/libs/coin-modules/coin-hedera/src/logic/lastBlock.v2.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/lastBlock.v2.test.ts
@@ -1,5 +1,6 @@
 import BigNumber from "bignumber.js";
 import { FINALITY_MS, SYNTHETIC_BLOCK_WINDOW_SECONDS } from "../constants";
+import { getMockedCurrency } from "../test/fixtures/currency.fixture";
 import { apiClient } from "../network/api";
 import { hgraphClient } from "../network/hgraph";
 import { lastBlockV2 } from "./lastBlock.v2";
@@ -11,6 +12,7 @@ jest.mock("../network/hgraph");
 const BLOCK_WINDOW_MS = SYNTHETIC_BLOCK_WINDOW_SECONDS * 1000;
 
 describe("lastBlockV2", () => {
+  const mockCurrency = getMockedCurrency();
   const mockHgraphTimestampNs = new BigNumber("1625097500000000000");
   const mockHgraphTimestamp = nanosToSeconds(mockHgraphTimestampNs).minus(
     SYNTHETIC_BLOCK_WINDOW_SECONDS,
@@ -28,7 +30,7 @@ describe("lastBlockV2", () => {
   });
 
   it("should return the last block info using the smaller timestamp", async () => {
-    const result = await lastBlockV2();
+    const result = await lastBlockV2({ configOrCurrencyId: mockCurrency.id });
     const expectedSyntheticBlock = getSyntheticBlock(mockHgraphTimestamp.toFixed(9));
 
     expect(apiClient.getLatestTransaction).toHaveBeenCalledTimes(1);
@@ -40,7 +42,7 @@ describe("lastBlockV2", () => {
 
   it("should only query transactions from fully finalized blocks", async () => {
     const now = Date.now();
-    await lastBlockV2();
+    await lastBlockV2({ configOrCurrencyId: mockCurrency.id });
 
     // lastBlockV2() accounts for block window size: a transaction at the start of a block
     // creates a block whose END time is BLOCK_WINDOW later, so we query transactions

--- a/libs/coin-modules/coin-hedera/src/logic/lastBlock.v2.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/lastBlock.v2.ts
@@ -1,5 +1,6 @@
 import type { BlockInfo } from "@ledgerhq/coin-module-framework/api/index";
 import BigNumber from "bignumber.js";
+import type { HederaCoinConfig } from "../config";
 import { FINALITY_MS, SYNTHETIC_BLOCK_WINDOW_SECONDS } from "../constants";
 import { apiClient } from "../network/api";
 import { hgraphClient } from "../network/hgraph";
@@ -14,7 +15,11 @@ import { getSyntheticBlock, nanosToSeconds } from "./utils";
  * 2. Extract its consensus timestamp
  * 3. Convert this timestamp into a synthetic block using a hardcoded time window (10 seconds by default)
  */
-export async function lastBlockV2(): Promise<BlockInfo> {
+export async function lastBlockV2({
+  configOrCurrencyId: _,
+}: {
+  configOrCurrencyId: HederaCoinConfig | string;
+}): Promise<BlockInfo> {
   // see getBlock implementation, block data should be immutable: we do not allow querying blocks on non-finalized time range.
   // => we search the most recent transaction, but only in finalized time range (ending 10 seconds ago).
   const before = new Date(Date.now() - FINALITY_MS - SYNTHETIC_BLOCK_WINDOW_SECONDS * 1000);

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.test.ts
@@ -4,18 +4,20 @@ import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import { getEnv } from "@ledgerhq/live-env";
 import BigNumber from "bignumber.js";
 import { apiClient } from "../network/api";
+import { getMockedConfig } from "../test/fixtures/config.fixture";
 import { getMockedCurrency } from "../test/fixtures/currency.fixture";
 import type { HederaMirrorTransaction } from "../types";
 import { listOperations } from "./listOperations";
 import * as utils from "./utils";
 
-setupMockCryptoAssetsStore();
 jest.mock("@ledgerhq/ledger-wallet-framework/account/accountId");
 jest.mock("@ledgerhq/ledger-wallet-framework/operation");
 jest.mock("../network/api");
 jest.mock("./utils");
 
 describe("listOperations", () => {
+  const mockConfig = getMockedConfig();
+
   beforeEach(() => {
     jest.clearAllMocks();
     (utils.extractFeesPayer as jest.Mock).mockImplementation(input =>
@@ -29,6 +31,7 @@ describe("listOperations", () => {
     (utils.createStakingRewardOperationHash as jest.Mock).mockImplementation(
       hash => `${hash}-reward`,
     );
+    (utils.resolveConfig as jest.Mock).mockImplementation(() => mockConfig);
     (encodeOperationId as jest.Mock).mockImplementation(
       (accountId, hash, type) => `${accountId}-${hash}-${type}`,
     );
@@ -47,7 +50,7 @@ describe("listOperations", () => {
     });
 
     const result = await listOperations({
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address,
       limit: 10,
       order: "asc",
@@ -98,7 +101,7 @@ describe("listOperations", () => {
     });
 
     const result = await listOperations({
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address,
       limit: 10,
       order: "desc",
@@ -171,7 +174,7 @@ describe("listOperations", () => {
     });
 
     const result = await listOperations({
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address,
       limit: 10,
       order: "desc",
@@ -230,7 +233,7 @@ describe("listOperations", () => {
     });
 
     const result = await listOperations({
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address,
       limit: 10,
       order: "desc",
@@ -291,7 +294,7 @@ describe("listOperations", () => {
     });
 
     const result = await listOperations({
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address,
       limit: 10,
       order: "desc",
@@ -316,7 +319,7 @@ describe("listOperations", () => {
     });
 
     await listOperations({
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address,
       limit: 20,
       order: "asc",
@@ -366,7 +369,7 @@ describe("listOperations", () => {
     });
 
     const result = await listOperations({
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address,
       limit: 10,
       order: "desc",
@@ -415,7 +418,7 @@ describe("listOperations", () => {
     });
 
     const result = await listOperations({
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address,
       limit: 10,
       order: "desc",
@@ -458,7 +461,7 @@ describe("listOperations", () => {
     });
 
     const result = await listOperations({
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address,
       limit: 10,
       order: "desc",

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.ts
@@ -5,9 +5,9 @@ import {
 } from "@ledgerhq/ledger-wallet-framework/account/accountId";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import { getEnv } from "@ledgerhq/live-env";
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Operation, OperationType } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
+import type { HederaCoinConfig } from "../config";
 import { HEDERA_TRANSACTION_NAMES } from "../constants";
 import { apiClient } from "../network/api";
 import { parseTransfers, analyzeStakingOperation } from "../network/utils";
@@ -67,14 +67,14 @@ function getCommonOperationData(
 async function processTokenTransfers({
   rawTx,
   address,
-  currency,
+  currencyId,
   ledgerAccountId,
   commonData,
   skipFeesForTokenOperations,
 }: {
   rawTx: HederaMirrorTransaction;
   address: string;
-  currency: CryptoCurrency;
+  currencyId: string;
   ledgerAccountId: string;
   commonData: ReturnType<typeof getCommonOperationData>;
   skipFeesForTokenOperations: boolean;
@@ -86,7 +86,7 @@ async function processTokenTransfers({
   if (tokenTransfers.length === 0) return null;
 
   const tokenId = tokenTransfers[0].token_id;
-  const token = await getCryptoAssetsStore().findTokenByAddressInCurrency(tokenId, currency.id);
+  const token = await getCryptoAssetsStore().findTokenByAddressInCurrency(tokenId, currencyId);
   if (!token) return null;
 
   const encodedTokenId = encodeTokenAccountId(ledgerAccountId, token);
@@ -241,7 +241,8 @@ function processTransfers({
 }
 
 export async function listOperations({
-  currency,
+  config,
+  currencyId,
   address,
   mirrorTokens,
   cursor,
@@ -252,7 +253,8 @@ export async function listOperations({
   useEncodedHash,
   useSyntheticBlocks,
 }: {
-  currency: CryptoCurrency;
+  config?: HederaCoinConfig;
+  currencyId: string;
   address: string;
   mirrorTokens: HederaMirrorToken[];
   cursor?: string | undefined;
@@ -280,7 +282,7 @@ export async function listOperations({
   const ledgerAccountId = encodeAccountId({
     type: "js",
     version: "2",
-    currencyId: currency.id,
+    currencyId: currencyId,
     xpubOrAddress: address,
     derivationMode: "hederaBip44",
   });
@@ -291,14 +293,18 @@ export async function listOperations({
     // try to distinguish staking operations for CRYPTOUPDATEACCOUNT transactions
     const stakingAnalysis =
       rawTx.name === HEDERA_TRANSACTION_NAMES.UpdateAccount
-        ? await analyzeStakingOperation(address, rawTx)
+        ? await analyzeStakingOperation({
+            configOrCurrencyId: config ?? currencyId,
+            address,
+            mirrorTx: rawTx,
+          })
         : null;
 
     // process token transfers
     const tokenResult = await processTokenTransfers({
       rawTx,
       address,
-      currency,
+      currencyId,
       ledgerAccountId,
       commonData,
       skipFeesForTokenOperations,

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
@@ -92,7 +92,7 @@ describe("listOperationsV2", () => {
     const result = await listOperations({
       limit: mockLimit,
       order: mockOrder,
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
@@ -148,7 +148,7 @@ describe("listOperationsV2", () => {
     const result = await listOperations({
       limit: mockLimit,
       order: mockOrder,
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
@@ -211,7 +211,7 @@ describe("listOperationsV2", () => {
     const result = await listOperations({
       limit: mockLimit,
       order: mockOrder,
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
@@ -301,7 +301,7 @@ describe("listOperationsV2", () => {
     const result = await listOperations({
       limit: mockLimit,
       order: mockOrder,
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
@@ -391,7 +391,7 @@ describe("listOperationsV2", () => {
     const result = await listOperations({
       limit: mockLimit,
       order: mockOrder,
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
@@ -454,7 +454,7 @@ describe("listOperationsV2", () => {
     const result = await listOperations({
       limit: mockLimit,
       order: mockOrder,
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
@@ -489,7 +489,7 @@ describe("listOperationsV2", () => {
     const result = await listOperations({
       limit: mockLimit,
       order: mockOrder,
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
@@ -543,7 +543,7 @@ describe("listOperationsV2", () => {
     const result = await listOperations({
       limit: mockLimit,
       order: mockOrder,
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [mockMirrorToken],
@@ -594,7 +594,7 @@ describe("listOperationsV2", () => {
     const result = await listOperations({
       limit: mockLimit,
       order: mockOrder,
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
@@ -623,7 +623,7 @@ describe("listOperationsV2", () => {
       limit: customLimit,
       order: customOrder,
       cursor: lastPagingToken,
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
@@ -670,7 +670,7 @@ describe("listOperationsV2", () => {
       order: mockOrder,
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       mirrorTokens: [],
       erc20Tokens: [],
       fetchAllPages: true,
@@ -710,7 +710,7 @@ describe("listOperationsV2", () => {
       order: mockOrder,
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       mirrorTokens: [],
       erc20Tokens: [],
       fetchAllPages: true,
@@ -752,7 +752,7 @@ describe("listOperationsV2", () => {
       order: mockOrder,
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       mirrorTokens: [],
       erc20Tokens: [],
       fetchAllPages: true,
@@ -833,7 +833,7 @@ describe("listOperationsV2", () => {
     const result = await listOperations({
       limit: mockLimit,
       order: mockOrder,
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
@@ -896,7 +896,7 @@ describe("listOperationsV2", () => {
     const result = await listOperations({
       limit: mockLimit,
       order: mockOrder,
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
@@ -951,7 +951,7 @@ describe("listOperationsV2", () => {
     const result = await listOperations({
       limit: mockLimit,
       order: mockOrder,
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
@@ -1009,7 +1009,7 @@ describe("listOperationsV2", () => {
     const result = await listOperations({
       limit: mockLimit,
       order: mockOrder,
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
@@ -1072,7 +1072,7 @@ describe("listOperationsV2", () => {
     const result = await listOperations({
       limit: mockLimit,
       order: mockOrder,
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
@@ -1141,7 +1141,7 @@ describe("listOperationsV2", () => {
     const result = await listOperations({
       limit: mockLimit,
       order: mockOrder,
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
@@ -1194,7 +1194,7 @@ describe("listOperationsV2", () => {
     const result = await listOperations({
       limit: mockLimit,
       order: mockOrder,
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
@@ -1234,7 +1234,7 @@ describe("listOperationsV2", () => {
     const result = await listOperations({
       limit: mockLimit,
       order: mockOrder,
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
@@ -1273,7 +1273,7 @@ describe("listOperationsV2", () => {
     const result = await listOperations({
       limit: mockLimit,
       order: mockOrder,
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
@@ -1343,7 +1343,7 @@ describe("listOperationsV2", () => {
     const result = await listOperations({
       limit: mockLimit,
       order: mockOrder,
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
@@ -1413,7 +1413,7 @@ describe("listOperationsV2", () => {
     const result = await listOperations({
       limit: mockLimit,
       order: mockOrder,
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
@@ -1470,7 +1470,7 @@ describe("listOperationsV2", () => {
     const result = await listOperations({
       limit: mockLimit,
       order: mockOrder,
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
@@ -1545,7 +1545,7 @@ describe("listOperationsV2", () => {
     const result = await listOperations({
       limit: mockLimit,
       order: mockOrder,
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
@@ -1581,7 +1581,7 @@ describe("listOperationsV2", () => {
     const result = await listOperations({
       limit: mockLimit,
       order: mockOrder,
-      currency: mockCurrency,
+      currencyId: mockCurrency.id,
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
@@ -5,9 +5,9 @@ import {
 } from "@ledgerhq/ledger-wallet-framework/account/accountId";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import { getEnv } from "@ledgerhq/live-env";
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Operation, OperationType } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
+import type { HederaCoinConfig } from "../config";
 import { HARDCODED_BLOCK_HEIGHT, HEDERA_TRANSACTION_NAMES } from "../constants";
 import { apiClient } from "../network/api";
 import { hgraphClient } from "../network/hgraph";
@@ -233,13 +233,13 @@ async function processERC20TokenTransfer({
 async function processHTSTokenTransfers({
   rawTx,
   address,
-  currency,
+  currencyId,
   ledgerAccountId,
   commonData,
 }: {
   rawTx: HederaMirrorTransaction;
   address: string;
-  currency: CryptoCurrency;
+  currencyId: string;
   ledgerAccountId: string;
   commonData: ReturnType<typeof getCommonMirrorOperationData>;
 }): Promise<{
@@ -250,7 +250,7 @@ async function processHTSTokenTransfers({
   if (tokenTransfers.length === 0) return null;
 
   const tokenId = tokenTransfers[0].token_id;
-  const token = await getCryptoAssetsStore().findTokenByAddressInCurrency(tokenId, currency.id);
+  const token = await getCryptoAssetsStore().findTokenByAddressInCurrency(tokenId, currencyId);
   if (!token) return null;
 
   const encodedTokenId = encodeTokenAccountId(ledgerAccountId, token);
@@ -382,7 +382,8 @@ async function processTransactionItem({
   mergedTx,
   address,
   evmAddress,
-  currency,
+  config,
+  currencyId,
   ledgerAccountId,
   mirrorTokens,
   useEncodedHash,
@@ -391,7 +392,8 @@ async function processTransactionItem({
   mergedTx: MergedTransaction;
   address: string;
   evmAddress: string;
-  currency: CryptoCurrency;
+  config?: HederaCoinConfig;
+  currencyId: string;
   ledgerAccountId: string;
   mirrorTokens: HederaMirrorToken[];
   useEncodedHash: boolean;
@@ -417,14 +419,18 @@ async function processTransactionItem({
 
   const stakingAnalysis =
     mirrorTx.name === HEDERA_TRANSACTION_NAMES.UpdateAccount
-      ? await analyzeStakingOperation(address, mirrorTx)
+      ? await analyzeStakingOperation({
+          configOrCurrencyId: config ?? currencyId,
+          address,
+          mirrorTx,
+        })
       : null;
 
   if (mergedTx.type === "mirror") {
     const htsTokenResult = await processHTSTokenTransfers({
       rawTx: mirrorTx,
       address,
-      currency,
+      currencyId,
       ledgerAccountId,
       commonData,
     });
@@ -460,7 +466,8 @@ async function processTransactionItem({
 }
 
 export async function listOperationsV2({
-  currency,
+  config,
+  currencyId,
   address,
   evmAddress,
   mirrorTokens,
@@ -473,7 +480,8 @@ export async function listOperationsV2({
   useEncodedHash,
   useSyntheticBlocks,
 }: {
-  currency: CryptoCurrency;
+  config?: HederaCoinConfig;
+  currencyId: string;
   address: string;
   evmAddress: string;
   mirrorTokens: HederaMirrorToken[];
@@ -497,7 +505,7 @@ export async function listOperationsV2({
   const ledgerAccountId = encodeAccountId({
     type: "js",
     version: "2",
-    currencyId: currency.id,
+    currencyId: currencyId,
     xpubOrAddress: address,
     derivationMode: "hederaBip44",
   });
@@ -521,7 +529,9 @@ export async function listOperationsV2({
           tokenEvmAddresses: erc20Tokens.map(t => t.token.contractAddress.toLowerCase()),
           ...(cursor && { timestamp: cursor }),
         })
-        .then(erc20Transfers => enrichERC20Transfers(erc20Transfers)),
+        .then(erc20Transfers =>
+          enrichERC20Transfers({ configOrCurrencyId: config ?? currencyId, erc20Transfers }),
+        ),
       hgraphClient.getLatestIndexedConsensusTimestamp(),
     ]);
 
@@ -540,11 +550,12 @@ export async function listOperationsV2({
       mergedTx,
       address,
       evmAddress,
-      currency,
+      currencyId,
       ledgerAccountId,
       mirrorTokens,
       useEncodedHash,
       useSyntheticBlocks,
+      ...(config && { config }),
     });
 
     coinOperations.push(...result.newCoinOperations);

--- a/libs/coin-modules/coin-hedera/src/network/thirdweb.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/thirdweb.test.ts
@@ -4,6 +4,7 @@ import { getMockResponse } from "../test/fixtures/common.fixture";
 import { getMockedThirdwebTransaction } from "../test/fixtures/thirdweb.fixture";
 import { apiClient } from "./api";
 import { thirdwebClient } from "./thirdweb";
+import { getMockedCurrency } from "../test/fixtures/currency.fixture";
 
 jest.mock("@ledgerhq/live-network");
 jest.mock("./api");
@@ -131,6 +132,8 @@ describe("fetchERC20Transactions", () => {
 });
 
 describe("getERC20TransactionsForAccount", () => {
+  const mockCurrency = getMockedCurrency();
+
   beforeEach(() => {
     jest.clearAllMocks();
 
@@ -142,6 +145,7 @@ describe("getERC20TransactionsForAccount", () => {
 
   it("should return empty array without balance tokens list", async () => {
     const result = await thirdwebClient.getERC20TransactionsForAccount({
+      configOrCurrencyId: mockCurrency.id,
       address: "0.0.1234",
       contractAddresses: [],
       since: null,
@@ -154,6 +158,7 @@ describe("getERC20TransactionsForAccount", () => {
     const mockFetcher = jest.fn().mockResolvedValue([mockedERC20Transaction]);
 
     const result = await thirdwebClient.getERC20TransactionsForAccount({
+      configOrCurrencyId: mockCurrency.id,
       address: "0.0.1234",
       contractAddresses: [mockedERC20TokenAddress1],
       since: null,
@@ -168,6 +173,7 @@ describe("getERC20TransactionsForAccount", () => {
     const mockFetcher = jest.fn().mockResolvedValue([mockedERC20Transaction]);
 
     const result = await thirdwebClient.getERC20TransactionsForAccount({
+      configOrCurrencyId: mockCurrency.id,
       address: "0.0.1234",
       contractAddresses: [mockedERC20TokenAddress1, mockedERC20TokenAddress2],
       since: null,
@@ -184,6 +190,7 @@ describe("getERC20TransactionsForAccount", () => {
       .mockResolvedValue([mockedERC20Transaction, mockedERC20Transaction]);
 
     const result = await thirdwebClient.getERC20TransactionsForAccount({
+      configOrCurrencyId: mockCurrency.id,
       address: "0.0.1234",
       contractAddresses: [mockedERC20TokenAddress1],
       since: null,

--- a/libs/coin-modules/coin-hedera/src/network/thirdweb.ts
+++ b/libs/coin-modules/coin-hedera/src/network/thirdweb.ts
@@ -1,6 +1,7 @@
 import { getEnv } from "@ledgerhq/live-env";
 import network from "@ledgerhq/live-network";
 import { pad } from "viem";
+import type { HederaCoinConfig } from "../config";
 import { HEDERA_MAINNET_CHAIN_ID, ERC20_TRANSFER_EVENT_TOPIC } from "../constants";
 import type { HederaThirdwebTransaction, HederaThirdwebContractEventsResponse } from "../types";
 import { toEVMAddress } from "./utils";
@@ -45,18 +46,20 @@ async function fetchERC20Transactions(
 }
 
 async function getERC20TransactionsForAccount({
+  configOrCurrencyId,
   address,
   contractAddresses,
   transactionFetcher = fetchERC20Transactions,
   since,
 }: {
+  configOrCurrencyId: HederaCoinConfig | string;
   address: string;
   contractAddresses: string[];
   since?: string | null;
   transactionFetcher?: typeof fetchERC20Transactions; // optional dependency injection for testing
 }): Promise<HederaThirdwebTransaction[]> {
   const allTransactions: HederaThirdwebTransaction[] = [];
-  const evmAddress = await toEVMAddress(address);
+  const evmAddress = await toEVMAddress({ configOrCurrencyId, accountId: address });
 
   if (contractAddresses.length === 0) {
     return allTransactions;

--- a/libs/coin-modules/coin-hedera/src/network/utils.integ.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.integ.test.ts
@@ -10,42 +10,63 @@ describe("toEVMAddress", () => {
   });
 
   it("should resolve from an account id to a long-zero EVM address for an account without EVM alias", async () => {
-    const address = await toEVMAddress("0.0.12345");
+    const address = await toEVMAddress({ configOrCurrencyId: coinConfig, accountId: "0.0.12345" });
     expect(address).toEqual("0x0000000000000000000000000000000000003039");
   });
 
   it("should resolve from a long-zero EVM address to a long-zero EVM address for an account without EVM alias", async () => {
-    const address = await toEVMAddress("0x0000000000000000000000000000000000003039");
+    const address = await toEVMAddress({
+      configOrCurrencyId: coinConfig,
+      accountId: "0x0000000000000000000000000000000000003039",
+    });
     expect(address).toEqual("0x0000000000000000000000000000000000003039");
   });
 
   it("should resolve from a long-zero EVM address without prefix to a long-zero EVM address for an account without EVM alias", async () => {
-    const address = await toEVMAddress("0000000000000000000000000000000000003039");
+    const address = await toEVMAddress({
+      configOrCurrencyId: coinConfig,
+      accountId: "0000000000000000000000000000000000003039",
+    });
     expect(address).toEqual("0x0000000000000000000000000000000000003039");
   });
 
   it("should resolve from an account id to an EVM alias address for an account with an EVM alias", async () => {
-    const address = await toEVMAddress("0.0.9806001");
+    const address = await toEVMAddress({
+      configOrCurrencyId: coinConfig,
+      accountId: "0.0.9806001",
+    });
     expect(address).toEqual("0xcf15538fa293ab04cdd7ce45bcdac8b6e2dc7ebc");
   });
 
   it("should resolve from an EVM alias address to an EVM alias address for an account with an EVM alias", async () => {
-    const address = await toEVMAddress("0xcf15538fa293ab04cdd7ce45bcdac8b6e2dc7ebc");
+    const address = await toEVMAddress({
+      configOrCurrencyId: coinConfig,
+      accountId: "0xcf15538fa293ab04cdd7ce45bcdac8b6e2dc7ebc",
+    });
     expect(address).toEqual("0xcf15538fa293ab04cdd7ce45bcdac8b6e2dc7ebc");
   });
 
   it("should resolve from an EVM alias address without prefix to an EVM alias address for an account with an EVM alias", async () => {
-    const address = await toEVMAddress("cf15538fa293ab04cdd7ce45bcdac8b6e2dc7ebc");
+    const address = await toEVMAddress({
+      configOrCurrencyId: coinConfig,
+      accountId: "cf15538fa293ab04cdd7ce45bcdac8b6e2dc7ebc",
+    });
     expect(address).toEqual("0xcf15538fa293ab04cdd7ce45bcdac8b6e2dc7ebc");
   });
 
   it("should resolve from a long-zero EVM address to an EVM alias address for an account with an EVM alias", async () => {
-    const address = await toEVMAddress("0x000000000000000000000000000000000095a0b1");
+    const address = await toEVMAddress({
+      configOrCurrencyId: coinConfig,
+      accountId: "0x000000000000000000000000000000000095a0b1",
+    });
     expect(address).toEqual("0xcf15538fa293ab04cdd7ce45bcdac8b6e2dc7ebc");
   });
 
   it("should resolve from a long-zero EVM address without prefix to an EVM alias address for an account with an EVM alias", async () => {
-    const address = await toEVMAddress("000000000000000000000000000000000095a0b1");
+    const address = await toEVMAddress({
+      configOrCurrencyId: coinConfig,
+      accountId: "000000000000000000000000000000000095a0b1",
+    });
     expect(address).toEqual("0xcf15538fa293ab04cdd7ce45bcdac8b6e2dc7ebc");
   });
 });

--- a/libs/coin-modules/coin-hedera/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.test.ts
@@ -6,6 +6,7 @@ import { SUPPORTED_ERC20_TOKENS } from "../constants";
 import { HederaRecipientInvalidChecksum } from "../errors";
 import { getMockedAccount } from "../test/fixtures/account.fixture";
 import {
+  getMockedCurrency,
   getMockedERC20TokenCurrency,
   getMockedHTSTokenCurrency,
 } from "../test/fixtures/currency.fixture";
@@ -21,6 +22,7 @@ import {
   getMockedMirrorAccount,
 } from "../test/fixtures/mirror.fixture";
 import { getMockedConfig } from "../test/fixtures/config.fixture";
+import hederaCoinConfig from "../config";
 import { getMockedThirdwebTransaction } from "../test/fixtures/thirdweb.fixture";
 import type { HederaMirrorCoinTransfer, HederaMirrorTransaction } from "../types";
 import { apiClient } from "./api";
@@ -45,6 +47,11 @@ jest.mock("./hgraph");
 
 describe("network utils", () => {
   const defaultConfig = getMockedConfig();
+  const mockCurrency = getMockedCurrency();
+
+  beforeAll(() => {
+    hederaCoinConfig.setCoinConfig(getMockedConfig);
+  });
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -306,10 +313,11 @@ describe("network utils", () => {
         findTokenById: jest.fn().mockReturnValue(erc20Token),
       });
 
-      const res = await getERC20BalancesForAccount(
-        mockAccount.freshAddress,
-        mockedSupportedTokenIds,
-      );
+      const res = await getERC20BalancesForAccount({
+        configOrCurrencyId: mockCurrency.id,
+        evmAccountId: mockAccount.freshAddress,
+        supportedTokenIds: mockedSupportedTokenIds,
+      });
 
       expect(apiClient.getERC20Balance).toHaveBeenCalledTimes(mockedSupportedTokenIds.length);
       expect(apiClient.getERC20Balance).toHaveBeenCalledWith(
@@ -322,7 +330,11 @@ describe("network utils", () => {
 
     it("returns empty array when there are no supported ERC20 tokens", async () => {
       const supportedTokenIds: string[] = [];
-      const res = await getERC20BalancesForAccount("0xaccount", supportedTokenIds);
+      const res = await getERC20BalancesForAccount({
+        configOrCurrencyId: mockCurrency.id,
+        evmAccountId: "0xaccount",
+        supportedTokenIds,
+      });
 
       expect(res).toEqual([]);
       expect(apiClient.getERC20Balance).not.toHaveBeenCalled();
@@ -344,7 +356,10 @@ describe("network utils", () => {
         findTokenById: jest.fn().mockReturnValue(erc20Token),
       });
 
-      const res = await getERC20BalancesForAccountV2(mockAccount.freshAddress);
+      const res = await getERC20BalancesForAccountV2({
+        configOrCurrencyId: mockCurrency.id,
+        address: mockAccount.freshAddress,
+      });
 
       expect(hgraphClient.getERC20Balances).toHaveBeenCalledTimes(1);
       expect(hgraphClient.getERC20Balances).toHaveBeenCalledWith({
@@ -404,7 +419,10 @@ describe("network utils", () => {
         findTokenByAddressInCurrency: jest.fn().mockReturnValue(mockTokenERC20),
       });
 
-      const result = await getERC20Operations([mockThirdwebTransaction]);
+      const result = await getERC20Operations({
+        currencyId: mockCurrency.id,
+        latestERC20Transactions: [mockThirdwebTransaction],
+      });
 
       expect(result).toEqual([
         {
@@ -437,7 +455,10 @@ describe("network utils", () => {
         findTokenByAddressInCurrency: jest.fn().mockReturnValue(undefined),
       });
 
-      const result = await getERC20Operations(mockThirdwebTransactions);
+      const result = await getERC20Operations({
+        currencyId: mockCurrency.id,
+        latestERC20Transactions: mockThirdwebTransactions,
+      });
 
       expect(result).toEqual([]);
       expect(apiClient.getContractCallResult).not.toHaveBeenCalled();
@@ -461,7 +482,10 @@ describe("network utils", () => {
         findTokenByAddressInCurrency: jest.fn().mockReturnValue(mockTokenERC20),
       });
 
-      const result = await getERC20Operations([mockThirdwebTransactions]);
+      const result = await getERC20Operations({
+        currencyId: mockCurrency.id,
+        latestERC20Transactions: [mockThirdwebTransactions],
+      });
 
       expect(result).toEqual([]);
     });
@@ -538,7 +562,10 @@ describe("network utils", () => {
     });
 
     it("should enrich supported ERC20 transfers with contract call result and mirror transaction", async () => {
-      const result = await enrichERC20Transfers([mockERC20Transfer]);
+      const result = await enrichERC20Transfers({
+        configOrCurrencyId: mockCurrency.id,
+        erc20Transfers: [mockERC20Transfer],
+      });
 
       expect(result).toEqual([
         {
@@ -560,7 +587,10 @@ describe("network utils", () => {
       const transfer1 = { ...mockERC20Transfer, amount: 1000 };
       const transfer2 = { ...mockERC20Transfer, amount: 2000 }; // same transaction_hash
 
-      const result = await enrichERC20Transfers([transfer1, transfer2]);
+      const result = await enrichERC20Transfers({
+        configOrCurrencyId: mockCurrency.id,
+        erc20Transfers: [transfer1, transfer2],
+      });
 
       expect(result).toEqual([
         expect.objectContaining({
@@ -572,7 +602,10 @@ describe("network utils", () => {
     it("should skip transfers where mirror transaction is not found", async () => {
       (apiClient.findTransactionByContractCallV2 as jest.Mock).mockResolvedValue(null);
 
-      const result = await enrichERC20Transfers([mockERC20Transfer]);
+      const result = await enrichERC20Transfers({
+        configOrCurrencyId: mockCurrency.id,
+        erc20Transfers: [mockERC20Transfer],
+      });
 
       expect(result).toEqual([]);
     });
@@ -584,7 +617,10 @@ describe("network utils", () => {
         mockMirrorTransaction,
       );
 
-      const result = await enrichERC20Transfers(transfers);
+      const result = await enrichERC20Transfers({
+        configOrCurrencyId: mockCurrency.id,
+        erc20Transfers: transfers,
+      });
       const txHashes = result.flatMap(r => r.transfers.map(t => t.transaction_hash));
 
       expect(txHashes).toEqual([mockERC20Transfer.transaction_hash, "hash456"]);
@@ -596,7 +632,10 @@ describe("network utils", () => {
         consensus_timestamp: 1768092990 * 10 ** 9,
       };
 
-      await enrichERC20Transfers([transferWithTimestamp]);
+      await enrichERC20Transfers({
+        configOrCurrencyId: mockCurrency.id,
+        erc20Transfers: [transferWithTimestamp],
+      });
 
       expect(apiClient.findTransactionByContractCallV2).toHaveBeenCalledTimes(1);
       expect(apiClient.findTransactionByContractCallV2).toHaveBeenCalledWith({
@@ -606,7 +645,10 @@ describe("network utils", () => {
     });
 
     it("should handle empty array", async () => {
-      const result = await enrichERC20Transfers([]);
+      const result = await enrichERC20Transfers({
+        configOrCurrencyId: mockCurrency.id,
+        erc20Transfers: [],
+      });
 
       expect(result).toEqual([]);
       expect(apiClient.getContractCallResult).not.toHaveBeenCalled();
@@ -700,7 +742,10 @@ describe("network utils", () => {
 
   describe("safeParseAccountId", () => {
     it("returns account id and no checksum for valid address without checksum", async () => {
-      const [error, result] = await safeParseAccountId("0.0.9124531");
+      const [error, result] = await safeParseAccountId({
+        configOrCurrencyId: defaultConfig,
+        address: "0.0.9124531",
+      });
 
       expect(error).toBeNull();
       expect(result?.accountId).toBe("0.0.9124531");
@@ -708,7 +753,10 @@ describe("network utils", () => {
     });
 
     it("returns account id and checksum for valid address with correct checksum", async () => {
-      const [error, result] = await safeParseAccountId("0.0.9124531-xrxlv");
+      const [error, result] = await safeParseAccountId({
+        configOrCurrencyId: defaultConfig,
+        address: "0.0.9124531-xrxlv",
+      });
 
       expect(error).toBeNull();
       expect(result?.accountId).toBe("0.0.9124531");
@@ -716,14 +764,20 @@ describe("network utils", () => {
     });
 
     it("returns error for valid address with incorrect checksum", async () => {
-      const [error, accountId] = await safeParseAccountId("0.0.9124531-invld");
+      const [error, accountId] = await safeParseAccountId({
+        configOrCurrencyId: defaultConfig,
+        address: "0.0.9124531-invld",
+      });
 
       expect(error).toBeInstanceOf(HederaRecipientInvalidChecksum);
       expect(accountId).toBeNull();
     });
 
     it("returns error for invalid address format", async () => {
-      const [error, accountId] = await safeParseAccountId("not-a-valid-address");
+      const [error, accountId] = await safeParseAccountId({
+        configOrCurrencyId: defaultConfig,
+        address: "not-a-valid-address",
+      });
 
       expect(error).toBeInstanceOf(InvalidAddress);
       expect(accountId).toBeNull();
@@ -739,7 +793,10 @@ describe("network utils", () => {
     it("returns correct EVM address for valid Hedera account ID", async () => {
       (apiClient.getAccount as jest.Mock).mockResolvedValueOnce(mockMirrorAccount);
 
-      const evmAddress = await toEVMAddress(mockMirrorAccount.account);
+      const evmAddress = await toEVMAddress({
+        configOrCurrencyId: defaultConfig,
+        accountId: mockMirrorAccount.account,
+      });
 
       expect(apiClient.getAccount).toHaveBeenCalledTimes(1);
       expect(apiClient.getAccount).toHaveBeenCalledWith(mockMirrorAccount.account);
@@ -749,7 +806,10 @@ describe("network utils", () => {
     it("returns null when API call fails", async () => {
       (apiClient.getAccount as jest.Mock).mockRejectedValueOnce(new Error("API error"));
 
-      const evmAddress = await toEVMAddress(mockMirrorAccount.account);
+      const evmAddress = await toEVMAddress({
+        configOrCurrencyId: defaultConfig,
+        accountId: mockMirrorAccount.account,
+      });
 
       expect(apiClient.getAccount).toHaveBeenCalledTimes(1);
       expect(evmAddress).toBeNull();
@@ -769,6 +829,7 @@ describe("network utils", () => {
       (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValueOnce([]);
 
       const result = await calculateUncommittedBalanceChange({
+        configOrCurrencyId: defaultConfig,
         address: mockAddress,
         startTimestamp: mockStartTimestamp,
         endTimestamp: mockEndTimestamp,
@@ -813,6 +874,7 @@ describe("network utils", () => {
       );
 
       const result = await calculateUncommittedBalanceChange({
+        configOrCurrencyId: defaultConfig,
         address: mockAddress,
         startTimestamp: mockStartTimestamp,
         endTimestamp: mockEndTimestamp,
@@ -844,6 +906,7 @@ describe("network utils", () => {
       );
 
       const result = await calculateUncommittedBalanceChange({
+        configOrCurrencyId: defaultConfig,
         address: mockAddress,
         startTimestamp: mockStartTimestamp,
         endTimestamp: mockEndTimestamp,
@@ -857,11 +920,13 @@ describe("network utils", () => {
 
       const [resultEqual, resultInvalid] = await Promise.all([
         calculateUncommittedBalanceChange({
+          configOrCurrencyId: defaultConfig,
           address: mockAddress,
           startTimestamp: mockStartTimestamp,
           endTimestamp: mockStartTimestamp,
         }),
         calculateUncommittedBalanceChange({
+          configOrCurrencyId: defaultConfig,
           address: mockAddress,
           startTimestamp: mockEndTimestamp,
           endTimestamp: mockStartTimestamp,
@@ -894,7 +959,11 @@ describe("network utils", () => {
         .mockResolvedValueOnce(accountBefore)
         .mockResolvedValueOnce(accountAfter);
 
-      const result = await analyzeStakingOperation(mockAddress, mockTx);
+      const result = await analyzeStakingOperation({
+        configOrCurrencyId: defaultConfig,
+        address: mockAddress,
+        mirrorTx: mockTx,
+      });
 
       expect(result).toEqual({
         operationType: "DELEGATE",
@@ -916,7 +985,11 @@ describe("network utils", () => {
         .mockResolvedValueOnce(accountBefore)
         .mockResolvedValueOnce(accountAfter);
 
-      const result = await analyzeStakingOperation(mockAddress, mockTx);
+      const result = await analyzeStakingOperation({
+        configOrCurrencyId: defaultConfig,
+        address: mockAddress,
+        mirrorTx: mockTx,
+      });
 
       expect(result).toEqual({
         operationType: "UNDELEGATE",
@@ -935,7 +1008,11 @@ describe("network utils", () => {
         .mockResolvedValueOnce(accountBefore)
         .mockResolvedValueOnce(accountAfter);
 
-      const result = await analyzeStakingOperation(mockAddress, mockTx);
+      const result = await analyzeStakingOperation({
+        configOrCurrencyId: defaultConfig,
+        address: mockAddress,
+        mirrorTx: mockTx,
+      });
 
       expect(result).toEqual({
         operationType: "REDELEGATE",
@@ -974,7 +1051,11 @@ describe("network utils", () => {
         .mockResolvedValueOnce(mockAccountBefore)
         .mockResolvedValueOnce(mockAccountAfter);
 
-      const result = await analyzeStakingOperation(mockAddress, mockTx);
+      const result = await analyzeStakingOperation({
+        configOrCurrencyId: defaultConfig,
+        address: mockAddress,
+        mirrorTx: mockTx,
+      });
 
       expect(apiClient.getTransactionsByTimestampRange).toHaveBeenCalledTimes(1);
       expect(apiClient.getTransactionsByTimestampRange).toHaveBeenCalledWith({
@@ -998,7 +1079,11 @@ describe("network utils", () => {
         .mockResolvedValueOnce(accountBefore)
         .mockResolvedValueOnce(accountAfter);
 
-      const result = await analyzeStakingOperation(mockAddress, mockTx);
+      const result = await analyzeStakingOperation({
+        configOrCurrencyId: defaultConfig,
+        address: mockAddress,
+        mirrorTx: mockTx,
+      });
 
       expect(result).toBeNull();
     });
@@ -1011,7 +1096,11 @@ describe("network utils", () => {
         .mockResolvedValueOnce(accountBefore)
         .mockResolvedValueOnce(accountAfter);
 
-      const result = await analyzeStakingOperation(mockAddress, mockTx);
+      const result = await analyzeStakingOperation({
+        configOrCurrencyId: defaultConfig,
+        address: mockAddress,
+        mirrorTx: mockTx,
+      });
 
       expect(result).toBeNull();
     });

--- a/libs/coin-modules/coin-hedera/src/network/utils.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.ts
@@ -1,16 +1,16 @@
 import invariant from "invariant";
 import { AccountId, TransactionId } from "@hashgraph/sdk";
-import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
-import { findCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
 import { getFiatCurrencyByTicker } from "@ledgerhq/cryptoassets/fiats";
+import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
 import { InvalidAddress } from "@ledgerhq/errors";
-import { getEnv } from "@ledgerhq/live-env";
 import cvsApi from "@ledgerhq/live-countervalues/api/index";
+import { getEnv } from "@ledgerhq/live-env";
 import { makeLRUCache, seconds } from "@ledgerhq/live-network/cache";
 import { TokenCurrency, type Currency } from "@ledgerhq/types-cryptoassets";
 import type { Operation, OperationType } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
-import type { HederaConfig } from "../config";
+import type { HederaCoinConfig } from "../config";
 import { SUPPORTED_ERC20_TOKENS } from "../constants";
 import { HederaRecipientInvalidChecksum } from "../errors";
 import { getChecksum, nanosToSeconds, toEntityId, toTimestamp } from "../logic/utils";
@@ -32,7 +32,7 @@ import { rpcClient } from "./rpc";
 
 export async function createTransactionId(
   accountId: string,
-  config: HederaConfig,
+  config: HederaCoinConfig,
 ): Promise<TransactionId> {
   if (!config.useNetworkTimestamp) {
     return TransactionId.generate(accountId);
@@ -115,10 +115,15 @@ export function parseTransfers(
 }
 
 // TODO: remove once migration to new API is complete
-export async function getERC20BalancesForAccount(
-  evmAccountId: string,
+export async function getERC20BalancesForAccount({
+  configOrCurrencyId: _,
+  evmAccountId,
   supportedTokenIds = SUPPORTED_ERC20_TOKENS.map(token => token.id),
-): Promise<HederaERC20TokenBalance[]> {
+}: {
+  configOrCurrencyId: HederaCoinConfig | string;
+  evmAccountId: string;
+  supportedTokenIds?: string[];
+}): Promise<HederaERC20TokenBalance[]> {
   const availableTokens: TokenCurrency[] = [];
 
   for (const erc20TokenId of supportedTokenIds) {
@@ -143,9 +148,13 @@ export async function getERC20BalancesForAccount(
   return balances;
 }
 
-export async function getERC20BalancesForAccountV2(
-  address: string,
-): Promise<HederaERC20TokenBalance[]> {
+export async function getERC20BalancesForAccountV2({
+  configOrCurrencyId: _,
+  address,
+}: {
+  configOrCurrencyId: HederaCoinConfig | string;
+  address: string;
+}): Promise<HederaERC20TokenBalance[]> {
   const balances: HederaERC20TokenBalance[] = [];
 
   const rawBalances = await hgraphClient.getERC20Balances({ address });
@@ -177,14 +186,20 @@ export async function getERC20BalancesForAccountV2(
 }
 
 // TODO: remove once migration to new API is complete
-export const getERC20Operations = async (
-  latestERC20Transactions: HederaThirdwebTransaction[],
-): Promise<OperationERC20[]> => {
+export const getERC20Operations = async ({
+  config: _,
+  currencyId,
+  latestERC20Transactions,
+}: {
+  config?: HederaCoinConfig;
+  currencyId: string;
+  latestERC20Transactions: HederaThirdwebTransaction[];
+}): Promise<OperationERC20[]> => {
   const latestERC20Operations: OperationERC20[] = [];
 
   for (const thirdwebTransaction of latestERC20Transactions) {
     const tokenId = thirdwebTransaction.address;
-    const token = await getCryptoAssetsStore().findTokenByAddressInCurrency(tokenId, "hedera");
+    const token = await getCryptoAssetsStore().findTokenByAddressInCurrency(tokenId, currencyId);
 
     if (!token) continue;
 
@@ -229,7 +244,13 @@ export function parseThirdwebTransactionParams(
  * @param erc20Transfers - Raw ERC20 transfers from Hgraph API
  * @returns Array of enriched transfers with complete operation data, filtered to supported tokens only
  */
-export const enrichERC20Transfers = async (erc20Transfers: ERC20TokenTransfer[]) => {
+export const enrichERC20Transfers = async ({
+  configOrCurrencyId: _,
+  erc20Transfers,
+}: {
+  configOrCurrencyId: HederaCoinConfig | string;
+  erc20Transfers: ERC20TokenTransfer[];
+}) => {
   const enrichedTransfers: EnrichedERC20Transfer[] = [];
 
   // with hgraph we can get two different transfers with the same transaction hash
@@ -301,7 +322,10 @@ export const checkAccountTokenAssociationStatus = makeLRUCache(
       return true;
     }
 
-    const [parsingError, parsingResult] = await safeParseAccountId(address);
+    const [parsingError, parsingResult] = await safeParseAccountId({
+      configOrCurrencyId: token.parentCurrency.id,
+      address,
+    });
 
     if (parsingError) {
       throw parsingError;
@@ -325,10 +349,14 @@ export const checkAccountTokenAssociationStatus = makeLRUCache(
   seconds(30),
 );
 
-export const safeParseAccountId = async (
-  address: string,
-): Promise<[Error, null] | [null, { accountId: string; checksum: string | null }]> => {
-  const currency = findCryptoCurrencyById("hedera");
+export const safeParseAccountId = async ({
+  configOrCurrencyId: _,
+  address,
+}: {
+  configOrCurrencyId: HederaCoinConfig | string;
+  address: string;
+}): Promise<[Error, null] | [null, { accountId: string; checksum: string | null }]> => {
+  const currency = getCryptoCurrencyById("hedera");
   const currencyName = currency?.name ?? "Hedera";
 
   try {
@@ -362,7 +390,13 @@ export const safeParseAccountId = async (
  * @param accountId - Hedera account ID in the format `shard.realm.num`
  * @returns EVM address (`0x...`) or null if fetch fails
  */
-export const toEVMAddress = async (accountId: string): Promise<string | null> => {
+export const toEVMAddress = async ({
+  configOrCurrencyId: _,
+  accountId,
+}: {
+  configOrCurrencyId: HederaCoinConfig | string;
+  accountId: string;
+}): Promise<string | null> => {
   try {
     const account = await apiClient.getAccount(accountId);
 
@@ -385,10 +419,12 @@ export const toEVMAddress = async (accountId: string): Promise<string | null> =>
  * @returns The net balance change as BigInt (sum of all transfers to/from the account)
  */
 export const calculateUncommittedBalanceChange = async ({
+  configOrCurrencyId: _,
   address,
   startTimestamp,
   endTimestamp,
 }: {
+  configOrCurrencyId: HederaCoinConfig | string;
   address: string;
   startTimestamp: string;
   endTimestamp: string;
@@ -438,10 +474,15 @@ export const calculateUncommittedBalanceChange = async ({
  *
  * Batching would complicate code for minimal gain given low staking op frequency.
  */
-export const analyzeStakingOperation = async (
-  address: string,
-  mirrorTx: HederaMirrorTransaction,
-): Promise<StakingAnalysis | null> => {
+export const analyzeStakingOperation = async ({
+  configOrCurrencyId,
+  address,
+  mirrorTx,
+}: {
+  configOrCurrencyId: HederaCoinConfig | string;
+  address: string;
+  mirrorTx: HederaMirrorTransaction;
+}): Promise<StakingAnalysis | null> => {
   const [accountBefore, accountAfter] = await Promise.all([
     apiClient.getAccount(address, `lt:${mirrorTx.consensus_timestamp}`),
     apiClient.getAccount(address, `eq:${mirrorTx.consensus_timestamp}`),
@@ -474,6 +515,7 @@ export const analyzeStakingOperation = async (
 
   // calculate uncommitted balance changes between the last snapshot and the staking tx
   const uncommittedBalanceChange = await calculateUncommittedBalanceChange({
+    configOrCurrencyId,
     address,
     startTimestamp: accountAfter.balance.timestamp,
     endTimestamp: mirrorTx.consensus_timestamp,

--- a/libs/coin-modules/coin-hedera/src/test/fixtures/config.fixture.ts
+++ b/libs/coin-modules/coin-hedera/src/test/fixtures/config.fixture.ts
@@ -5,5 +5,10 @@ export const getMockedConfig = (): HederaCoinConfig => {
     status: { type: "active" },
     useHgraphForErc20: false,
     useNetworkTimestamp: false,
+    networkType: "mainnet",
+    apiUrls: {
+      hgraph: "https://hedera-indexer-mainnet.coin.ledger.com/v1/graphql",
+      mirrorNode: "https://hedera.coin.ledger.com",
+    },
   };
 };

--- a/libs/coin-modules/coin-hedera/src/types/logic.ts
+++ b/libs/coin-modules/coin-hedera/src/types/logic.ts
@@ -1,7 +1,8 @@
 import type { TransactionIntent } from "@ledgerhq/coin-module-framework/api/types";
-import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { OperationType } from "@ledgerhq/types-live";
 import type BigNumber from "bignumber.js";
+import type { HederaCoinConfig } from "../config";
 import type { HEDERA_OPERATION_TYPES } from "../constants";
 import type { HederaOperationExtra } from "./bridge";
 import type { ERC20TokenTransfer } from "./hgraph";
@@ -10,10 +11,11 @@ import type { HederaThirdwebTransaction } from "./thirdweb";
 
 export type EstimateFeesParams =
   | {
-      currency: CryptoCurrency;
+      currencyId: string;
       operationType: Exclude<HEDERA_OPERATION_TYPES, HEDERA_OPERATION_TYPES.ContractCall>;
     }
   | {
+      configOrCurrencyId: HederaCoinConfig | string;
       operationType: HEDERA_OPERATION_TYPES.ContractCall;
       txIntent: TransactionIntent;
     };

--- a/libs/env/src/env.ts
+++ b/libs/env/src/env.ts
@@ -282,6 +282,11 @@ const envDefinitions = {
     parser: stringParser,
     desc: "mirror node API for Hedera",
   },
+  API_HEDERA_MIRROR_TESTNET: {
+    def: "https://hedera-testnet.coin.ledger.com",
+    parser: stringParser,
+    desc: "testnet mirror node API for Hedera",
+  },
   API_HEDERA_THIRDWEB_URL: {
     def: "https://hedera-tokens.coin.ledger.com",
     parser: stringParser,
@@ -291,6 +296,11 @@ const envDefinitions = {
     def: "https://hedera-indexer-mainnet.coin.ledger.com/v1/graphql",
     parser: stringParser,
     desc: "Hgraph API for Hedera (ERC20 data source)",
+  },
+  API_HEDERA_HGRAPH_TESTNET: {
+    def: "https://hedera-indexer-testnet.coin.ledger.com/v1/graphql",
+    parser: stringParser,
+    desc: "testnet hgraph API for Hedera",
   },
   API_VECHAIN_THOREST: {
     def: "https://vechain.coin.ledger.com",

--- a/libs/ledger-live-common/src/families/hedera/config.ts
+++ b/libs/ledger-live-common/src/families/hedera/config.ts
@@ -1,4 +1,5 @@
 import { ConfigInfo } from "@ledgerhq/live-config/LiveConfig";
+import { getEnv } from "@ledgerhq/live-env";
 
 export const hederaConfig: Record<string, ConfigInfo> = {
   config_currency_hedera: {
@@ -10,6 +11,27 @@ export const hederaConfig: Record<string, ConfigInfo> = {
       },
       useHgraphForErc20: true,
       useNetworkTimestamp: true,
+      networkType: "mainnet",
+      apiUrls: {
+        mirrorNode: getEnv("API_HEDERA_MIRROR"),
+        hgraph: getEnv("API_HEDERA_HGRAPH"),
+      },
+    },
+  },
+  config_currency_hedera_testnet: {
+    type: "object",
+    default: {
+      status: {
+        type: "active",
+        features: [{ id: "blockchain_txs", status: "active" }],
+      },
+      useHgraphForErc20: true,
+      useNetworkTimestamp: true,
+      networkType: "testnet",
+      apiUrls: {
+        mirrorNode: getEnv("API_HEDERA_MIRROR_TESTNET"),
+        hgraph: getEnv("API_HEDERA_HGRAPH_TESTNET"),
+      },
     },
   },
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - `configOrCurrencyId` in coin-hedera utils 
  - new envs for Hedera testnet
  - updated Hedera config with `networkType` and `apiUrls`

### 📝 Description

This PR contains second batch of changes from [testnet support feature branch](https://github.com/LedgerHQ/ledger-live/compare/develop...feat/hedera-testnet-v2).

Scope:
- update Hedera utils with new `configOrCurrencyId` param, ignored with `_` if not applicable yet (waiting for part 3 and part 4)
- add new envs for Hedera testnet
- add `networkType` and `apiUrls` to Hedera config

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-28050

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
