### PR TITLE
[LWM] fix(mobile): fix iOS production build broken by Repack 5.2.5 regressions

### DIFF
--- a/.changeset/broken-ships-fix.md
+++ b/.changeset/broken-ships-fix.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix iOS production build broken by Repack 5.2.5 regressions

--- a/apps/ledger-live-mobile/rspack.config.mjs
+++ b/apps/ledger-live-mobile/rspack.config.mjs
@@ -161,6 +161,12 @@ const detoxAliases = isDetoxBuild
 const hermesNonCompatibleDependencies = [
   "@polkadot/types-codec",
   "@mysten/sui",
+  // ethers v6 ships CJS with native private class fields (#field). Repack 5.2.5 fix #1364
+  // made SWC own the class-properties transform, but SWC targets node:24 (which supports
+  // private fields natively) so it doesn't downlevel them. Hermes for RN 0.81 has no
+  // private field support. Route ethers through babel-loader so @react-native/babel-preset
+  // applies @babel/plugin-transform-class-properties and compiles them away.
+  "ethers",
 ];
 
 /**
@@ -189,6 +195,23 @@ export default withRozeniteUrlFix(
         // and hurt performance with Hermes. Disable async chunk creation globally.
         // When running rsdoctor, also emit main bundle as .js so it's counted as JavaScript (not Other)
         output: { asyncChunks: false, ...(isRsdoctor && { filename: "[name].js" }) },
+        // Repack 5.2.5 forces Terser for rspack ≥1.5.0 (getMinimizerConfig.js shouldUseTerserForRspack)
+        // as a workaround for a SwcJsMinimizerRspackPlugin regression in rspack 1.5.0. That regression
+        // was fixed in later rspack releases. Terser fails on native private class fields (#field) present
+        // in dependencies (e.g. ethers@6). Override with SwcJsMinimizerRspackPlugin which handles them.
+        optimization: {
+          minimizer: [
+            new rspack.SwcJsMinimizerRspackPlugin({
+              test: /\.(js)?bundle(\?.*)?$/i,
+              extractComments: false,
+              minimizerOptions: {
+                format: {
+                  comments: false,
+                },
+              },
+            }),
+          ],
+        },
         resolve: {
           ...Repack.getResolveOptions(platform, {
             enablePackageExports: true,


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [ ] **Covered by automatic tests.** _Build configuration change — verified manually by simulating the full Xcode bundle + hermesc compilation pipeline._
- [x] **Impact of the changes:**
  - iOS production build (`e2e:build -c ios.sim.release` and release builds)
  - Android production build (Terser fix also covers non-Hermes paths)
  - No runtime behaviour change — bundler and minifier config only

### 📝 Description

Upgrading `@callstack/repack` from 5.2.3 to 5.2.5 (merged in #17856) introduced two independent build regressions that together make iOS production builds fail.

**Regression 1 — Terser fails on native private class fields**

`getMinimizerConfig.js` in Repack 5.2.5 added `shouldUseTerserForRspack` which forces Terser instead of `SwcJsMinimizerRspackPlugin` for rspack ≥1.5.0 (workaround for a regression in rspack 1.5.0). We are on rspack 1.7.3 where that regression has since been fixed, but the version check still selects Terser. Terser fails with `Private field must be used in an enclosing class` on `ethers@6` CJS output which ships raw `#field` syntax.

Fix: override `optimization.minimizer` in `rspack.config.mjs` with `SwcJsMinimizerRspackPlugin` directly.

**Regression 2 — hermesc fails on untransformed private class fields**

Repack 5.2.5 fix #1364 made the `babel-swc-loader` own the class-properties transform. The loader targets `node: 24` (which natively supports private fields), so SWC no longer downcomes them — and Hermes for RN 0.81 does not support private class fields at runtime, causing `hermesc` to abort with `private properties are not supported`.

Fix: add `ethers` to `hermesNonCompatibleDependencies` so its files are routed through `babel-loader` + `@react-native/babel-preset`, which applies `@babel/plugin-transform-class-properties` and compiles `#field` away before Hermes sees the bundle.

ios build: https://github.com/LedgerHQ/ledger-live-build/actions/runs/26520330264

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29335](https://ledgerhq.atlassian.net/browse/LIVE-29335)
- **Repack issue**: [callstack/repack#1364](https://github.com/callstack/repack/pull/1364)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29335]: https://ledgerhq.atlassian.net/browse/LIVE-29335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ