### PR TITLE
[LWDM] MAX on restake fills full wallet balance instead of available unstaked amount

### DIFF
--- a/.changeset/eight-moose-know.md
+++ b/.changeset/eight-moose-know.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tezos": patch
+---
+
+Fix Tezos stake "Use Max" to exclude already-staked funds (was offering the full balance).

--- a/libs/coin-modules/coin-tezos/src/api/index.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.ts
@@ -242,6 +242,7 @@ async function estimate(transactionIntent: TransactionIntent): Promise<TezosFeeE
     address: transactionIntent.sender,
     revealed: senderAccountInfo.revealed,
     balance: BigInt(senderAccountInfo.balance),
+    stakedBalance: BigInt(senderAccountInfo.stakedBalance ?? 0),
   };
 
   const tokenEstimationInfo =

--- a/libs/coin-modules/coin-tezos/src/logic/estimateFees.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/estimateFees.test.ts
@@ -1,5 +1,6 @@
 import { getRevealFee } from "@taquito/taquito";
 import coinConfig from "../config";
+import { STAKE_USE_ALL_RESERVE_MUTEZ } from "../utils";
 import { estimateFees } from "./estimateFees";
 import { getTezosToolkit } from "./tezosToolkit";
 
@@ -330,6 +331,33 @@ describe("estimateFees", () => {
     });
 
     expect(result.amount).toBe(0n);
+  });
+
+  it("useAllAmount stake excludes already-staked funds from maxStakable", async () => {
+    const suggestedFee = 700;
+    const balance = 1_000_000n;
+    const stakedBalance = 300_000n;
+    mockTezosToolkit.estimate.stake.mockResolvedValue({
+      suggestedFeeMutez: suggestedFee,
+      gasLimit: 1100,
+      storageLimit: 5,
+      burnFeeMutez: 0,
+      opSize: 100,
+    });
+
+    const result = await estimateFees({
+      account: { ...revealedAccount, balance, stakedBalance },
+      transaction: {
+        mode: "stake",
+        recipient: "",
+        amount: 0n,
+        useAllAmount: true,
+      },
+    });
+
+    expect(result.amount).toBe(
+      balance - stakedBalance - BigInt(suggestedFee) - STAKE_USE_ALL_RESERVE_MUTEZ,
+    );
   });
 
   it("useAllAmount unstake coerces amount to 1 for Taquito estimation", async () => {

--- a/libs/coin-modules/coin-tezos/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/estimateFees.ts
@@ -5,12 +5,12 @@ import coinConfig from "../config";
 import { UnsupportedTransactionMode } from "../types/errors";
 import { TezosOperationMode } from "../types/model";
 import {
+  computeMaxStakeAmount,
   createFallbackEstimation,
   createMockSigner,
   DUST_MARGIN_MUTEZ,
   MIN_SUGGESTED_FEE_SMALL_TRANSFER,
   OP_SIZE_XTZ_TRANSFER,
-  STAKE_USE_ALL_RESERVE_MUTEZ,
   normalizePublicKeyForAddress,
 } from "../utils";
 import { getTezosToolkit } from "./tezosToolkit";
@@ -18,6 +18,7 @@ import { getTezosToolkit } from "./tezosToolkit";
 export type CoreAccountInfo = {
   address: string;
   balance: bigint;
+  stakedBalance?: bigint;
   revealed: boolean;
   xpub?: string;
 };
@@ -186,9 +187,11 @@ export async function estimateFees({
       const maxMinusBuff = maxAmount - (DUST_MARGIN_MUTEZ - incr);
       estimation.amount = maxMinusBuff > 0 ? BigInt(maxMinusBuff) : 0n;
     } else if (transaction.useAllAmount && transaction.mode === "stake") {
-      const maxStakable =
-        BigInt(account.balance) - BigInt(mainOpFee) - revealFee - STAKE_USE_ALL_RESERVE_MUTEZ;
-      estimation.amount = maxStakable > 0n ? maxStakable : 0n;
+      estimation.amount = computeMaxStakeAmount(
+        BigInt(account.balance),
+        account.stakedBalance ?? 0n,
+        BigInt(mainOpFee) + revealFee,
+      );
     } else {
       estimation.amount = transaction.amount;
     }

--- a/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
@@ -10,6 +10,7 @@ import {
 } from "@ledgerhq/errors";
 import coinConfig from "../config";
 import { InvalidAddressBecauseAlreadyDelegated, MustDelegateBeforeStaking } from "../types/errors";
+import { STAKE_USE_ALL_RESERVE_MUTEZ } from "../utils";
 import { validateIntent } from "./validateIntent";
 
 const mockEstimateFees = jest.fn();
@@ -344,6 +345,37 @@ describe("validateIntent", () => {
 
       expect(result.errors.amount).toBeInstanceOf(NotEnoughBalanceToDelegate);
       expect(result.amount).toBe(0n);
+    });
+
+    it("excludes already-staked funds when stake useAllAmount falls back to balance computation", async () => {
+      mockGetAccountByAddress.mockResolvedValue(
+        makeUserAccount({
+          balance: 5_000_000,
+          stakedBalance: 1_000_000,
+          delegate: { alias: "baker", address: validRecipient, active: true },
+          delegationLevel: 1,
+        }),
+      );
+      // No `amount` field => estimatedAmount is undefined, exercising the fallback path.
+      mockEstimateFees.mockResolvedValueOnce({
+        fees: 1000n,
+        gasLimit: 10000n,
+        storageLimit: 0n,
+        estimatedFees: 1000n,
+      });
+
+      const result = await validateIntent({
+        intentType: "staking",
+        asset: { type: "native" },
+        type: "stake",
+        sender: senderAddress,
+        recipient: "",
+        amount: 0n,
+        useAllAmount: true,
+      });
+
+      expect(result.errors.amount).toBeUndefined();
+      expect(result.amount).toBe(4_000_000n - 1000n - STAKE_USE_ALL_RESERVE_MUTEZ);
     });
 
     it("should return NotEnoughBalance when unstake has no staked balance", async () => {

--- a/libs/coin-modules/coin-tezos/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/validateIntent.ts
@@ -15,11 +15,7 @@ import { validateAddress, ValidationResult } from "@taquito/utils";
 import api from "../network/tzkt";
 import type { APIAccount } from "../network/types";
 import { InvalidAddressBecauseAlreadyDelegated, MustDelegateBeforeStaking } from "../types/errors";
-import {
-  parseTezosTokenAsset,
-  resolveTezosOperationMode,
-  STAKE_USE_ALL_RESERVE_MUTEZ,
-} from "../utils";
+import { computeMaxStakeAmount, parseTezosTokenAsset, resolveTezosOperationMode } from "../utils";
 import { estimateFees } from "./estimateFees";
 import type { TezosOperationMode } from "../types/model";
 
@@ -207,9 +203,11 @@ function calculateAmounts(
       return { amount: estimatedAmount, totalSpent: estimatedAmount + estimatedFees };
     }
     // Mirrors estimateFees() stake-max formula for the !revealed short-circuit path.
-    const balance = BigInt(senderInfo.balance);
-    const reserved = estimatedFees + STAKE_USE_ALL_RESERVE_MUTEZ;
-    const amount = balance > reserved ? balance - reserved : 0n;
+    const amount = computeMaxStakeAmount(
+      BigInt(senderInfo.balance),
+      BigInt(senderInfo.stakedBalance ?? 0),
+      estimatedFees,
+    );
     return { amount, totalSpent: amount + estimatedFees };
   }
 
@@ -272,6 +270,7 @@ async function estimateFeesForIntent(
       address: intent.sender,
       revealed: senderInfo.revealed,
       balance: BigInt(senderInfo.balance),
+      stakedBalance: BigInt(senderInfo.stakedBalance ?? 0),
       xpub: intent.senderPublicKey ?? senderInfo.publicKey,
     },
     transaction: {

--- a/libs/coin-modules/coin-tezos/src/utils.test.ts
+++ b/libs/coin-modules/coin-tezos/src/utils.test.ts
@@ -1,8 +1,10 @@
 import { validatePublicKey, ValidationResult } from "@taquito/utils";
 import {
+  computeMaxStakeAmount,
   normalizePublicKeyForAddress,
   parseTezosTokenAsset,
   resolveTezosOperationMode,
+  STAKE_USE_ALL_RESERVE_MUTEZ,
 } from "./utils";
 
 describe("parseTezosTokenAsset", () => {
@@ -135,5 +137,28 @@ describe("normalizePublicKeyForAddress", () => {
     const result = normalizePublicKeyForAddress(sec1Hex, tz1Address);
 
     expect(result).toBeUndefined();
+  });
+});
+
+describe("computeMaxStakeAmount", () => {
+  it("subtracts already-staked funds, fees and the reserve", () => {
+    expect(computeMaxStakeAmount(1_000_000n, 300_000n, 1000n)).toBe(
+      700_000n - 1000n - STAKE_USE_ALL_RESERVE_MUTEZ,
+    );
+  });
+
+  it("uses the full balance when nothing is staked", () => {
+    expect(computeMaxStakeAmount(1_000_000n, 0n, 1000n)).toBe(
+      1_000_000n - 1000n - STAKE_USE_ALL_RESERVE_MUTEZ,
+    );
+  });
+
+  it("clamps to 0 when staked balance covers the whole balance", () => {
+    expect(computeMaxStakeAmount(300_000n, 300_000n, 1000n)).toBe(0n);
+    expect(computeMaxStakeAmount(200_000n, 300_000n, 1000n)).toBe(0n);
+  });
+
+  it("clamps to 0 when the liquid balance cannot cover fees and reserve", () => {
+    expect(computeMaxStakeAmount(305_000n, 300_000n, 1000n)).toBe(0n);
   });
 });

--- a/libs/coin-modules/coin-tezos/src/utils.ts
+++ b/libs/coin-modules/coin-tezos/src/utils.ts
@@ -16,6 +16,17 @@ export const DUST_MARGIN_MUTEZ = 500;
 // Tezos rejects `empty_implicit_delegated_contract`; stake-max leaves this buffer.
 export const STAKE_USE_ALL_RESERVE_MUTEZ = 10_000n;
 
+/** Stake "Use Max": already-staked funds count toward `balance` but aren't re-stakeable, so subtract them. */
+export function computeMaxStakeAmount(
+  balance: bigint,
+  stakedBalance: bigint,
+  fees: bigint,
+): bigint {
+  const liquid = balance > stakedBalance ? balance - stakedBalance : 0n;
+  const reserved = fees + STAKE_USE_ALL_RESERVE_MUTEZ;
+  return liquid > reserved ? liquid - reserved : 0n;
+}
+
 /**
  * Suggested fee returned by Taquito for a minimal amount pre-estimation (mutez)
  * Used as a stable fallback for send-max when RPC estimation is unavailable.


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Tezos stake "Use Max" now fills the liquid balance (balance − staked), not the full balance.
  - Shared coin-tezos logic → affects both Desktop and Mobile.
  - QA focus: restake on an account with funds already staked (Max ≈ available, not total); first-time stake (nothing staked) unchanged; send / unstake / delegate "Max" unaffected.

### 📝 Description

Stake max computed from full balance, so restaking offered already-staked funds (rejected by the node). Subtract stakedBalance to match availableBalance.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31499](https://ledgerhq.atlassian.net/browse/LIVE-31499?atlOrigin=eyJpIjoiYThjNDhkNjNmNzFmNGU5ZjhiN2UxOWU5ODUzZjhkNTQiLCJwIjoiaiJ9)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31499]: https://ledgerhq.atlassian.net/browse/LIVE-31499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ