### PR TITLE
[LWDM] feat(coin-tezos): support multi-asset FA2 contracts

### DIFF
--- a/.changeset/tezos-multi-asset-fa2.md
+++ b/.changeset/tezos-multi-asset-fa2.md
@@ -1,0 +1,14 @@
+---
+"@ledgerhq/coin-tezos": minor
+"@ledgerhq/live-common": patch
+---
+
+feat(coin-tezos): support multi-asset FA2 contracts (wrapped tokens)
+
+Remove the tokenId=0 filter in TzKT queries so balances and operations
+for all FA2 tokens are returned, including multi-asset contracts like
+the Wrapped Tokens Contract (KT18fp5rc…).
+
+Parse the assetReference (contract:tokenId) in the Tezos bridge to pass
+tokenIdentifier to findTokenByAddressInCurrency, enabling correct CAL
+token resolution for multi-asset contracts.

--- a/libs/coin-modules/coin-tezos/src/logic/listOperations.integ.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/listOperations.integ.test.ts
@@ -420,3 +420,44 @@ describe("listOperations — mainnet origination ops", () => {
     expect(balance).toEqual(BigInt(account.balance));
   }, 60_000);
 });
+
+/**
+ * Multi-asset FA2 integration tests (LIVE-29210).
+ * Uses tz1ZB8hpQJZdQeEPc3uG2cL1NXwLTPkqeAD6 which holds multiple tokens
+ * on the Wrapped Tokens Contract (KT18fp5rcTW7mbWDmzFwjLDUhs5MeJmagDSZ).
+ */
+const MULTI_ASSET_ADDRESS = "tz1ZB8hpQJZdQeEPc3uG2cL1NXwLTPkqeAD6";
+const WRAPPED_CONTRACT = "KT18fp5rcTW7mbWDmzFwjLDUhs5MeJmagDSZ";
+
+describe("listOperations — mainnet multi-asset FA2 (LIVE-29210)", () => {
+  let originalGetCoinConfig: () => TezosCoinConfig;
+
+  beforeAll(() => {
+    originalGetCoinConfig = coinConfig.getCoinConfig;
+    coinConfig.setCoinConfig(mainnetConfig);
+  });
+
+  afterAll(() => {
+    if (originalGetCoinConfig) {
+      coinConfig.setCoinConfig(originalGetCoinConfig);
+    }
+  });
+
+  it("returns a known multi-asset FA2 operation with tokenId=11", async () => {
+    const [operations] = await listOperations(MULTI_ASSET_ADDRESS, { ...baseOpts, limit: 200 });
+
+    // Known on-chain transfer: tokenId=11 (wMATIC), OUT to KT1V5X...
+    const op = operations.find(
+      op =>
+        "assetReference" in op.asset &&
+        op.asset.assetReference === `${WRAPPED_CONTRACT}:11` &&
+        op.tx.hash === "ooMtaw5H7dtrgAyW5ky4jFzhQjayWn6La2h3BadHvZd56p6jm9g",
+    )!;
+
+    expect(op.type).toBe("OUT");
+    expect(op.asset.type).toBe("fa2");
+    expect(op.value).toBe(18423705864886566n);
+    expect(op.senders).toEqual([MULTI_ASSET_ADDRESS]);
+    expect(op.recipients).toEqual(["KT1V5XKmeypanMS9pR65REpqmVejWBZURuuT"]);
+  });
+});

--- a/libs/coin-modules/coin-tezos/src/network/tzkt.integ.test.ts
+++ b/libs/coin-modules/coin-tezos/src/network/tzkt.integ.test.ts
@@ -1,0 +1,96 @@
+import coinConfig, { type TezosCoinConfig } from "../config";
+import api from "./tzkt";
+
+/**
+ * Mainnet integration tests for multi-asset FA2 support (LIVE-29210).
+ *
+ * Uses tz1ZB8hpQJZdQeEPc3uG2cL1NXwLTPkqeAD6 which holds multiple tokens
+ * on the Wrapped Tokens Contract (KT18fp5rcTW7mbWDmzFwjLDUhs5MeJmagDSZ).
+ *
+ * Explorer: https://tzkt.io/tz1ZB8hpQJZdQeEPc3uG2cL1NXwLTPkqeAD6/balances
+ */
+
+const MULTI_ASSET_HOLDER = "tz1ZB8hpQJZdQeEPc3uG2cL1NXwLTPkqeAD6";
+const WRAPPED_CONTRACT = "KT18fp5rcTW7mbWDmzFwjLDUhs5MeJmagDSZ";
+
+const mainnetConfig = (): TezosCoinConfig =>
+  ({
+    status: { type: "active" },
+    baker: { url: "https://tezos-bakers.api.live.ledger.com" },
+    explorer: { url: "https://xtz-tzkt-explorer.api.vault.ledger.com", maxTxQuery: 100 },
+    node: { url: "https://xtz-node.api.vault.ledger.com" },
+    fees: {
+      minGasLimit: 0,
+      minRevealGasLimit: 0,
+      minStorageLimit: 0,
+      minFees: 0,
+      minEstimatedFees: 0,
+    },
+  }) as TezosCoinConfig;
+
+describe("TzKT multi-asset FA2 — mainnet", () => {
+  let originalGetCoinConfig: () => TezosCoinConfig;
+
+  beforeAll(() => {
+    originalGetCoinConfig = coinConfig.getCoinConfig;
+    coinConfig.setCoinConfig(mainnetConfig);
+  });
+
+  afterAll(() => {
+    if (originalGetCoinConfig) {
+      coinConfig.setCoinConfig(originalGetCoinConfig);
+    }
+  });
+
+  describe("getTokensBalances", () => {
+    it("returns balances for multiple tokenIds on the same contract", async () => {
+      const balances = await api.getTokensBalances(MULTI_ASSET_HOLDER);
+
+      const tokenIds = new Set(
+        balances
+          .filter(b => b.token.contract.address === WRAPPED_CONTRACT)
+          .map(b => b.token.tokenId),
+      );
+
+      // On-chain fact: this account received tokens with at least tokenIds 1, 2, 7
+      expect(tokenIds.has("1")).toBe(true);
+      expect(tokenIds.has("2")).toBe(true);
+      expect(tokenIds.has("7")).toBe(true);
+    });
+
+    it("returns only the requested tokenId when filter is provided", async () => {
+      const balances = await api.getTokensBalances(MULTI_ASSET_HOLDER, {
+        contractAddress: WRAPPED_CONTRACT,
+        tokenId: 1,
+      });
+
+      expect(balances).toHaveLength(1);
+      expect(balances[0].token.tokenId).toBe("1");
+      expect(balances[0].token.contract.address).toBe(WRAPPED_CONTRACT);
+      expect(balances[0].token.standard).toBe("fa2");
+    });
+  });
+
+  describe("getAccountTokenTransfers", () => {
+    it("returns a known transfer with tokenId=11 at level 13371040", async () => {
+      // Pin to the exact block level so the result set is small and deterministic.
+      const transfers = await api.getAccountTokenTransfers(MULTI_ASSET_HOLDER, {
+        "level.ge": 13371040,
+        "level.lt": 13371041,
+        limit: 10,
+      });
+
+      const transfer = transfers.find(
+        t =>
+          t.token.contract.address === WRAPPED_CONTRACT &&
+          t.token.tokenId === "11" &&
+          t.transactionId === 2655251752550400,
+      )!;
+
+      expect(transfer.amount).toBe("18423705864886566");
+      expect(transfer.from?.address).toBe(MULTI_ASSET_HOLDER);
+      expect(transfer.to?.address).toBe("KT1V5XKmeypanMS9pR65REpqmVejWBZURuuT");
+      expect(transfer.hash).toBe("ooMtaw5H7dtrgAyW5ky4jFzhQjayWn6La2h3BadHvZd56p6jm9g");
+    });
+  });
+});

--- a/libs/coin-modules/coin-tezos/src/network/tzkt.test.ts
+++ b/libs/coin-modules/coin-tezos/src/network/tzkt.test.ts
@@ -368,9 +368,9 @@ describe("tzkt network API", () => {
         "level.ge": 10,
         "sort.asc": "id",
         "anyof.from.to": "tz1x",
-        "token.tokenId": "0",
         "token.standard": "fa2",
       });
+      expect(firstCall.params).not.toHaveProperty("token.tokenId");
     });
 
     it("joins operation hashes and uses empty string when no match", async () => {
@@ -703,7 +703,7 @@ describe("tzkt network API", () => {
   // -------------------------------------------------------------------------
 
   describe("api.getTokensBalances", () => {
-    it("requests FA2 tokenId 0 balances for the account", async () => {
+    it("requests all FA2 balances for the account when no filter is passed", async () => {
       const balances = [{ id: 1 } as APITokenBalance];
       mockedNetwork.mockReturnValue(networkResponse(balances) as ReturnType<typeof network>);
 
@@ -716,7 +716,6 @@ describe("tzkt network API", () => {
           params: {
             account: "tz1bal",
             "token.standard": "fa2",
-            "token.tokenId": "0",
           },
         }),
       );

--- a/libs/coin-modules/coin-tezos/src/network/tzkt.ts
+++ b/libs/coin-modules/coin-tezos/src/network/tzkt.ts
@@ -302,8 +302,7 @@ const api = {
   },
 
   /**
-   * Fetches FA2 token transfers (tokenId = 0 only) for a given account.
-   * This is limited to `token.standard=fa2` and `token.tokenId=0` on the TzKT API.
+   * Fetches FA2 token transfers for a given account.
    * Translates `query.sort` to TzKT's `sort.asc=id` / `sort.desc=id`.
    * The lower-level `getTokenTransfers` helper is a generic pass-through and does not pin the sort.
    * https://api.tzkt.io/#operation/Tokens_GetTokenTransfers
@@ -315,7 +314,6 @@ const api = {
     const sortKey = query.sort === "Descending" ? "sort.desc" : "sort.asc";
     const params: Record<string, unknown> = {
       "anyof.from.to": address,
-      "token.tokenId": "0",
       "token.standard": "fa2",
       [sortKey]: "id",
       limit: query.limit,
@@ -375,8 +373,8 @@ const api = {
   },
 
   /**
-   * Fetches FA token balances for a given account.
-   * When `tokenFilter` is omitted, only FA2 tokenId 0 balances are returned (legacy behaviour).
+   * Fetches FA2 token balances for a given account.
+   * When `tokenFilter` is omitted, all FA2 token balances are returned.
    * Pass `tokenFilter` to query a specific FA2 contract + token id (e.g. send-max for FA2).
    * https://api.tzkt.io/#operation/Tokens_GetTokenBalances
    */
@@ -391,8 +389,6 @@ const api = {
     if (tokenFilter) {
       params["token.contract"] = tokenFilter.contractAddress;
       params["token.tokenId"] = String(tokenFilter.tokenId);
-    } else {
-      params["token.tokenId"] = "0";
     }
     const { data } = await network<APITokenBalance[]>({
       url: `${getExplorerUrl()}/v1/tokens/balances`,

--- a/libs/ledger-live-common/src/families/tezos/bridge/api.test.ts
+++ b/libs/ledger-live-common/src/families/tezos/bridge/api.test.ts
@@ -13,9 +13,9 @@ beforeAll(() => {
       tokenIdentifier?: string,
     ) => {
       if (
-        (address === "KT1XnTn74bUtxHfDtBmm2bGZAQfhPbvKWR8o") &&
+        address === "KT1XnTn74bUtxHfDtBmm2bGZAQfhPbvKWR8o" &&
         currencyId === "tezos" &&
-        (tokenIdentifier === "0" || tokenIdentifier === undefined)
+        tokenIdentifier === "0"
       ) {
         const usdt: TokenCurrency = {
           type: "TokenCurrency",
@@ -40,7 +40,7 @@ beforeAll(() => {
           type: "TokenCurrency",
           id: "tezos/fa2/wrapped_usdc_kt18fp5rctw7mbwdmzfwjlduhs5mejmagdsz_17",
           contractAddress: "KT18fp5rcTW7mbWDmzFwjLDUhs5MeJmagDSZ",
-          parentCurrency: tezos,
+          parentCurrencyId: "tezos",
           tokenType: "fa2",
           name: "Wrapped USDC",
           ticker: "wUSDC",
@@ -151,12 +151,11 @@ describe("generic-coin-framework Tezos token", () => {
     });
 
     it("produces assetReference with :tokenId for multi-asset tokens", () => {
-      const tezos = getCryptoCurrencyById("tezos");
       const token: TokenCurrency = {
         type: "TokenCurrency",
         id: "tezos/fa2/wrapped_usdc_kt18fp5rctw7mbwdmzfwjlduhs5mejmagdsz_17",
         contractAddress: "KT18fp5rcTW7mbWDmzFwjLDUhs5MeJmagDSZ",
-        parentCurrency: tezos,
+        parentCurrencyId: "tezos",
         tokenType: "fa2",
         name: "Wrapped USDC",
         ticker: "wUSDC",
@@ -175,12 +174,11 @@ describe("generic-coin-framework Tezos token", () => {
     });
 
     it("round-trips: getAssetFromToken → getTokenFromAsset", async () => {
-      const tezos = getCryptoCurrencyById("tezos");
       const token: TokenCurrency = {
         type: "TokenCurrency",
         id: "tezos/fa2/wrapped_usdc_kt18fp5rctw7mbwdmzfwjlduhs5mejmagdsz_17",
         contractAddress: "KT18fp5rcTW7mbWDmzFwjLDUhs5MeJmagDSZ",
-        parentCurrency: tezos,
+        parentCurrencyId: "tezos",
         tokenType: "fa2",
         name: "Wrapped USDC",
         ticker: "wUSDC",

--- a/libs/ledger-live-common/src/families/tezos/bridge/api.test.ts
+++ b/libs/ledger-live-common/src/families/tezos/bridge/api.test.ts
@@ -7,12 +7,17 @@ beforeAll(() => {
     findTokenById: async (_id: string) => {
       return undefined;
     },
-    findTokenByAddressInCurrency: async (token: string, currencyId: string) => {
+    findTokenByAddressInCurrency: async (
+      address: string,
+      currencyId: string,
+      tokenIdentifier?: string,
+    ) => {
       if (
-        (token === "USDt" || token === "KT1XnTn74bUtxHfDtBmm2bGZAQfhPbvKWR8o") &&
-        currencyId === "tezos"
+        (address === "KT1XnTn74bUtxHfDtBmm2bGZAQfhPbvKWR8o") &&
+        currencyId === "tezos" &&
+        (tokenIdentifier === "0" || tokenIdentifier === undefined)
       ) {
-        const usdc: TokenCurrency = {
+        const usdt: TokenCurrency = {
           type: "TokenCurrency",
           id: "tezos/fa2/tether_usd_kt1xntn74butxhfdtbmm2bgzaqfhpbvkwr8o",
           contractAddress: "KT1XnTn74bUtxHfDtBmm2bGZAQfhPbvKWR8o",
@@ -24,7 +29,26 @@ beforeAll(() => {
           disableCountervalue: false,
           units: [{ name: "Tether USD", code: "USDt", magnitude: 6 }],
         };
-        return usdc;
+        return usdt;
+      }
+      if (
+        address === "KT18fp5rcTW7mbWDmzFwjLDUhs5MeJmagDSZ" &&
+        currencyId === "tezos" &&
+        tokenIdentifier === "17"
+      ) {
+        const wusdc: TokenCurrency = {
+          type: "TokenCurrency",
+          id: "tezos/fa2/wrapped_usdc_kt18fp5rctw7mbwdmzfwjlduhs5mejmagdsz_17",
+          contractAddress: "KT18fp5rcTW7mbWDmzFwjLDUhs5MeJmagDSZ",
+          parentCurrency: tezos,
+          tokenType: "fa2",
+          name: "Wrapped USDC",
+          ticker: "wUSDC",
+          delisted: false,
+          disableCountervalue: false,
+          units: [{ name: "Wrapped USDC", code: "wUSDC", magnitude: 6 }],
+        };
+        return wusdc;
       }
       return undefined;
     },
@@ -36,11 +60,11 @@ beforeAll(() => {
 
 describe("generic-coin-framework Tezos token", () => {
   describe("Tezos token helpers", () => {
-    it("computes the token of a known asset", async () => {
+    it("resolves a single-asset FA2 token by contract:tokenId", async () => {
       await expect(
         getTokenFromAsset({
           type: "token",
-          assetReference: "USDt",
+          assetReference: "KT1XnTn74bUtxHfDtBmm2bGZAQfhPbvKWR8o:0",
           assetOwner: "tz1VUmqS38E45KZevtphpVF4cKiK1YJ1P9eL",
         }),
       ).resolves.toMatchObject({
@@ -51,9 +75,20 @@ describe("generic-coin-framework Tezos token", () => {
         tokenType: "fa2",
         name: "Tether USD",
         ticker: "USDt",
-        delisted: false,
-        disableCountervalue: false,
-        units: [{ name: "Tether USD", code: "USDt", magnitude: 6 }],
+      });
+    });
+
+    it("resolves a multi-asset FA2 token by contract:tokenId", async () => {
+      await expect(
+        getTokenFromAsset({
+          type: "token",
+          assetReference: "KT18fp5rcTW7mbWDmzFwjLDUhs5MeJmagDSZ:17",
+          assetOwner: "tz1VUmqS38E45KZevtphpVF4cKiK1YJ1P9eL",
+        }),
+      ).resolves.toMatchObject({
+        id: "tezos/fa2/wrapped_usdc_kt18fp5rctw7mbwdmzfwjlduhs5mejmagdsz_17",
+        name: "Wrapped USDC",
+        ticker: "wUSDC",
       });
     });
 
@@ -61,7 +96,7 @@ describe("generic-coin-framework Tezos token", () => {
       await expect(
         getTokenFromAsset({
           type: "token",
-          assetReference: "unknown-reference",
+          assetReference: "unknown-reference:0",
           assetOwner: "unknown-owner",
         }),
       ).resolves.toBeUndefined();
@@ -92,7 +127,7 @@ describe("generic-coin-framework Tezos token", () => {
   });
 
   describe("getAssetFromToken", () => {
-    it("returns asset with contractAddress as assetReference and owner as assetOwner", () => {
+    it("produces assetReference with :0 for single-asset tokens", () => {
       const token: TokenCurrency = {
         type: "TokenCurrency",
         id: "tezos/fa2/tether_usd_kt1xntn74butxhfdtbmm2bgzaqfhpbvkwr8o",
@@ -105,15 +140,58 @@ describe("generic-coin-framework Tezos token", () => {
         disableCountervalue: false,
         units: [{ name: "Tether USD", code: "USDt", magnitude: 6 }],
       };
-      const owner = "tz1VUmqS38E45KZevtphpVF4cKiK1YJ1P9eL";
 
-      expect(getAssetFromToken(token, owner)).toEqual({
+      expect(getAssetFromToken(token, "tz1owner")).toEqual({
         type: "fa2",
-        assetReference: "KT1XnTn74bUtxHfDtBmm2bGZAQfhPbvKWR8o",
-        assetOwner: owner,
+        assetReference: "KT1XnTn74bUtxHfDtBmm2bGZAQfhPbvKWR8o:0",
+        assetOwner: "tz1owner",
         name: "Tether USD",
         unit: { name: "Tether USD", code: "USDt", magnitude: 6 },
       });
+    });
+
+    it("produces assetReference with :tokenId for multi-asset tokens", () => {
+      const tezos = getCryptoCurrencyById("tezos");
+      const token: TokenCurrency = {
+        type: "TokenCurrency",
+        id: "tezos/fa2/wrapped_usdc_kt18fp5rctw7mbwdmzfwjlduhs5mejmagdsz_17",
+        contractAddress: "KT18fp5rcTW7mbWDmzFwjLDUhs5MeJmagDSZ",
+        parentCurrency: tezos,
+        tokenType: "fa2",
+        name: "Wrapped USDC",
+        ticker: "wUSDC",
+        delisted: false,
+        disableCountervalue: false,
+        units: [{ name: "Wrapped USDC", code: "wUSDC", magnitude: 6 }],
+      };
+
+      expect(getAssetFromToken(token, "tz1owner")).toEqual({
+        type: "fa2",
+        assetReference: "KT18fp5rcTW7mbWDmzFwjLDUhs5MeJmagDSZ:17",
+        assetOwner: "tz1owner",
+        name: "Wrapped USDC",
+        unit: { name: "Wrapped USDC", code: "wUSDC", magnitude: 6 },
+      });
+    });
+
+    it("round-trips: getAssetFromToken → getTokenFromAsset", async () => {
+      const tezos = getCryptoCurrencyById("tezos");
+      const token: TokenCurrency = {
+        type: "TokenCurrency",
+        id: "tezos/fa2/wrapped_usdc_kt18fp5rctw7mbwdmzfwjlduhs5mejmagdsz_17",
+        contractAddress: "KT18fp5rcTW7mbWDmzFwjLDUhs5MeJmagDSZ",
+        parentCurrency: tezos,
+        tokenType: "fa2",
+        name: "Wrapped USDC",
+        ticker: "wUSDC",
+        delisted: false,
+        disableCountervalue: false,
+        units: [{ name: "Wrapped USDC", code: "wUSDC", magnitude: 6 }],
+      };
+
+      const asset = getAssetFromToken(token, "tz1owner");
+      const resolved = await getTokenFromAsset(asset);
+      expect(resolved?.id).toBe(token.id);
     });
   });
 });

--- a/libs/ledger-live-common/src/families/tezos/bridge/api.ts
+++ b/libs/ledger-live-common/src/families/tezos/bridge/api.ts
@@ -4,18 +4,34 @@ import type { BridgeApi } from "@ledgerhq/ledger-wallet-framework/api/types";
 import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
 
 export async function getTokenFromAsset(asset: AssetInfo): Promise<TokenCurrency | undefined> {
-  return "assetReference" in asset
-    ? await getCryptoAssetsStore().findTokenByAddressInCurrency(
-        asset.assetReference as string,
-        "tezos",
-      )
-    : undefined;
+  if (!("assetReference" in asset) || typeof asset.assetReference !== "string") {
+    return undefined;
+  }
+  const [contractAddress, tokenIdentifier] = asset.assetReference.split(":");
+  const store = getCryptoAssetsStore();
+  const token = await store.findTokenByAddressInCurrency(contractAddress, "tezos", tokenIdentifier);
+  if (token || tokenIdentifier !== "0") return token;
+  // Fallback: retry without tokenIdentifier for backward compatibility with CAL entries
+  // that do not yet carry token_identifier=0.
+  return store.findTokenByAddressInCurrency(contractAddress, "tezos");
+}
+
+/**
+ * Derives the FA2 tokenId from a TokenCurrency's CAL id.
+ * CAL ids follow the pattern `tezos/fa2/{name}_{contract}` (tokenId=0)
+ * or `tezos/fa2/{name}_{contract}_{tokenId}` (multi-asset).
+ */
+function deriveTokenId(token: TokenCurrency): string {
+  const contractLower = token.contractAddress.toLowerCase();
+  const suffix = token.id.split(contractLower)[1];
+  return suffix?.match(/^_(\d+)$/)?.[1] ?? "0";
 }
 
 export function getAssetFromToken(token: TokenCurrency, owner: string): AssetInfo {
+  const tokenId = deriveTokenId(token);
   return {
     type: token.tokenType,
-    assetReference: token.contractAddress,
+    assetReference: `${token.contractAddress}:${tokenId}`,
     assetOwner: owner,
     name: token.name,
     unit: token.units[0],

--- a/libs/ledger-live-common/src/families/tezos/bridge/api.ts
+++ b/libs/ledger-live-common/src/families/tezos/bridge/api.ts
@@ -9,11 +9,7 @@ export async function getTokenFromAsset(asset: AssetInfo): Promise<TokenCurrency
   }
   const [contractAddress, tokenIdentifier] = asset.assetReference.split(":");
   const store = getCryptoAssetsStore();
-  const token = await store.findTokenByAddressInCurrency(contractAddress, "tezos", tokenIdentifier);
-  if (token || tokenIdentifier !== "0") return token;
-  // Fallback: retry without tokenIdentifier for backward compatibility with CAL entries
-  // that do not yet carry token_identifier=0.
-  return store.findTokenByAddressInCurrency(contractAddress, "tezos");
+  return store.findTokenByAddressInCurrency(contractAddress, "tezos", tokenIdentifier);
 }
 
 /**


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [ ] **Impact of the changes:**
  - `@ledgerhq/coin-tezos`: TzKT queries no longer filter on `tokenId=0` — all FA2 token balances and transfers are now returned, including multi-asset contracts (e.g. wrapped tokens).
  - `@ledgerhq/live-common`: Tezos bridge parses `assetReference` (`contract:tokenId`) and passes `tokenIdentifier` to `findTokenByAddressInCurrency` for correct CAL resolution.

### 📝 Description

Tezos FA2 multi-asset contracts (e.g. `KT18fp5rcTW7mbWDmzFwjLDUhs5MeJmagDSZ`) host multiple tokens under a single contract address, each identified by a `tokenId`. Currently, coin-tezos hard-filters to `tokenId=0`, making wrapped tokens (wUSDC, wBUSD, wDAI, etc.) invisible in balances and operations.

**Changes:**

1. **Remove `tokenId=0` filter** in `getAccountTokenTransfers()` and `getTokensBalances()` (`tzkt.ts`) — all FA2 tokens are now discoverable.

2. **Parse `assetReference` in Tezos bridge** (`bridge.ts`) — split `contract:tokenId` and pass `tokenIdentifier` as the 3rd argument to `findTokenByAddressInCurrency()`, leveraging the plumbing from PR #16437.

Backward-compatible: existing single-asset tokens (tokenId=0) continue to resolve with their original CAL ids.

### ❓ Context

- **JIRA**: LIVE-29210
- **Parent epic**: LIVE-27581 (Tezos FA2 wrapped tokens support)
- **Depends on**: LedgerHQ/crypto-assets#2593 (CAL token registration with `token_identifier`)
- **Depends on**: PR #16437 (`tokenIdentifier` param in `findTokenByAddressInCurrency`, merged)

e2e desktop -> https://github.com/LedgerHQ/ledger-live/actions/runs/28575369721
e2e mobile -> https://github.com/LedgerHQ/ledger-live/actions/runs/28451842568
