### PR TITLE
[LWDM] feat: check if utxos are already spent before broadcast

### DIFF
--- a/.changeset/dirty-panthers-switch.md
+++ b/.changeset/dirty-panthers-switch.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-bitcoin": minor
+---
+
+Feat: check if UTXOs are already spent before broadcast

--- a/libs/coin-modules/coin-bitcoin/src/__tests__/unit/signOperation.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/__tests__/unit/signOperation.test.ts
@@ -25,7 +25,7 @@ jest.mock("../../cache", () => ({
 
 jest.mock("../../buildTransaction", () => ({
   buildTransaction: jest.fn().mockResolvedValue({
-    // shape not relevant for test, passed through to wallet.signAccountTx
+    inputs: [],
   }),
 }));
 

--- a/libs/coin-modules/coin-bitcoin/src/broadcast.integ.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/broadcast.integ.test.ts
@@ -4,30 +4,34 @@ import { broadcast } from "./broadcast";
 import Xpub from "./wallet-btc/xpub";
 import BitcoinLikeExplorer from "./wallet-btc/explorer";
 
+function buildSignedTxHex(): { txHex: string; address: string } {
+  const privateKey = secp256k1.utils.randomSecretKey();
+  const publicKey = Buffer.from(secp256k1.getPublicKey(privateKey, true));
+  const { address, output: p2wpkhScript } = bitcoin.payments.p2wpkh({
+    pubkey: publicKey,
+    network: bitcoin.networks.bitcoin,
+  });
+
+  const psbt = new bitcoin.Psbt({ network: bitcoin.networks.bitcoin });
+  psbt.addInput({
+    hash: Buffer.alloc(32, 0xab),
+    index: 0,
+    witnessUtxo: { value: 100000, script: p2wpkhScript! },
+  });
+  psbt.addOutput({ address: address!, value: 10000 - 500 });
+
+  psbt.signInput(0, {
+    publicKey,
+    sign: (hash: Buffer) =>
+      Buffer.from(secp256k1.sign(new Uint8Array(hash), privateKey).toBytes("compact")),
+  });
+  psbt.finalizeAllInputs();
+  return { txHex: psbt.extractTransaction().toHex(), address: address! };
+}
+
 describe("Broadcast", () => {
   it("throws when broadcasting a transaction spending nonexistent inputs", async () => {
-    const privateKey = secp256k1.utils.randomSecretKey();
-    const publicKey = Buffer.from(secp256k1.getPublicKey(privateKey, true));
-    const { address, output: p2wpkhScript } = bitcoin.payments.p2wpkh({
-      pubkey: publicKey,
-      network: bitcoin.networks.bitcoin,
-    });
-
-    const psbt = new bitcoin.Psbt({ network: bitcoin.networks.bitcoin });
-    psbt.addInput({
-      hash: Buffer.alloc(32, 0xab),
-      index: 0,
-      witnessUtxo: { value: 100000, script: p2wpkhScript! },
-    });
-    psbt.addOutput({ address: address!, value: 10000 - 500 });
-
-    psbt.signInput(0, {
-      publicKey,
-      sign: (hash: Buffer) =>
-        Buffer.from(secp256k1.sign(new Uint8Array(hash), privateKey).toBytes("compact")),
-    });
-    psbt.finalizeAllInputs();
-    const txHex = psbt.extractTransaction().toHex();
+    const { txHex, address } = buildSignedTxHex();
 
     const explorer = new BitcoinLikeExplorer({
       cryptoCurrency: {
@@ -35,17 +39,85 @@ describe("Broadcast", () => {
         explorerId: "btc",
       },
     } as any);
-    const xpub = new Xpub({
-      explorer,
-    } as any);
+
+    const xpub = new Xpub({ explorer } as any);
 
     await expect(
       broadcast({
         account: { id: "js:2:bitcoin", bitcoinResources: { walletAccount: { xpub } } },
         signedOperation: {
           signature: txHex,
+          operation: { senders: [address], extra: {} },
         },
       } as any),
     ).rejects.toThrow(/bad-txns-inputs-missingorspent/);
+  });
+
+  it("throws InvalidTransactionError when pre-broadcast UTXO check detects the input UTXO is already spent", async () => {
+    const { txHex, address } = buildSignedTxHex();
+
+    const explorer = new BitcoinLikeExplorer({
+      cryptoCurrency: {
+        id: "bitcoin",
+        explorerId: "btc",
+      },
+    } as any);
+
+    const xpub = new Xpub({ explorer } as any);
+
+    // Real mainnet tx whose output 0 is confirmed-spent (spent_at_height: 949644)
+    const spentTxHash = "1a7df85fd5afdb6ed9630f23b49379bcff840d570ab80ad4dc3ce02a53c3ca9b";
+
+    await expect(
+      broadcast({
+        account: { id: "js:2:bitcoin", bitcoinResources: { walletAccount: { xpub } } },
+        signedOperation: {
+          signature: txHex,
+          operation: {
+            senders: [address],
+            extra: {
+              inputRefs: [{ hash: spentTxHash, outputIndex: 0, address }],
+            },
+          },
+        },
+      } as any),
+    ).rejects.toMatchObject({
+      name: "InvalidTransactionError",
+      message: "utxos already spent",
+    });
+  });
+
+  it("throws InvalidTransactionError when pre-broadcast UTXO check detects the input UTXO is not found", async () => {
+    const { txHex, address } = buildSignedTxHex();
+
+    const explorer = new BitcoinLikeExplorer({
+      cryptoCurrency: {
+        id: "bitcoin",
+        explorerId: "btc",
+      },
+    } as any);
+
+    const xpub = new Xpub({ explorer } as any);
+
+    // Non-existent tx hash
+    const nonExistentTxHash = "non-existent-tx-hash";
+
+    await expect(
+      broadcast({
+        account: { id: "js:2:bitcoin", bitcoinResources: { walletAccount: { xpub } } },
+        signedOperation: {
+          signature: txHex,
+          operation: {
+            senders: [address],
+            extra: {
+              inputRefs: [{ hash: nonExistentTxHash, outputIndex: 0, address }],
+            },
+          },
+        },
+      } as any),
+    ).rejects.toMatchObject({
+      name: "InvalidTransactionError",
+      message: "tx not found",
+    });
   });
 });

--- a/libs/coin-modules/coin-bitcoin/src/broadcast.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/broadcast.test.ts
@@ -1,7 +1,8 @@
 import BigNumber from "bignumber.js";
+import { InvalidTransactionError } from "@ledgerhq/errors";
 import { broadcast } from "./broadcast";
 import wallet, { getWalletAccount } from "./wallet-btc";
-import { Account, SignedOperation } from "@ledgerhq/types-live";
+import type { Account, SignedOperation } from "@ledgerhq/types-live";
 
 jest.mock("./wallet-btc");
 
@@ -14,10 +15,15 @@ describe("broadcast", () => {
     },
   } as unknown as Account;
 
+  const mockExplorer = {
+    fetchUtxoTx: jest.fn(),
+  };
+
   const mockWalletAccount = {
     xpub: {
       crypto: "bitcoin",
       xpub: "mock-xpub",
+      explorer: mockExplorer,
     },
   };
 
@@ -39,9 +45,17 @@ describe("broadcast", () => {
     signature: "mock-signature",
   };
 
+  const makeTxOutput = (output_index: number, spent_at_height: number | null) => ({
+    output_index,
+    value: "1000000",
+    address: "some-address",
+    spent_at_height,
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
     (getWalletAccount as jest.Mock).mockReturnValue(mockWalletAccount);
+    mockExplorer.fetchUtxoTx.mockResolvedValue({ outputs: [] });
   });
 
   it("should broadcast transaction without broadcastConfig", async () => {
@@ -116,5 +130,329 @@ describe("broadcast", () => {
 
       mockBroadcastTx.mockClear();
     }
+  });
+
+  describe("UTXO spent detection", () => {
+    describe("skipping the check", () => {
+      it("should skip check entirely when extra.inputRefs is absent", async () => {
+        jest.spyOn(wallet, "broadcastTx").mockResolvedValue("mock-hash");
+
+        await broadcast({ account: mockAccount, signedOperation: mockSignedOperation });
+
+        expect(mockExplorer.fetchUtxoTx).not.toHaveBeenCalled();
+      });
+
+      it("should skip check when extra.inputRefs is an empty array", async () => {
+        jest.spyOn(wallet, "broadcastTx").mockResolvedValue("mock-hash");
+
+        const signedOp: SignedOperation = {
+          ...mockSignedOperation,
+          operation: { ...mockSignedOperation.operation, extra: { inputRefs: [] } },
+        };
+
+        await broadcast({ account: mockAccount, signedOperation: signedOp });
+
+        expect(mockExplorer.fetchUtxoTx).not.toHaveBeenCalled();
+      });
+
+      it("should throw InvalidTransactionError and not broadcast when fetchUtxoTx rejects (explorer error)", async () => {
+        const mockBroadcastTx = jest.spyOn(wallet, "broadcastTx").mockResolvedValue("mock-hash");
+        mockExplorer.fetchUtxoTx.mockRejectedValue(new Error("network error"));
+
+        const signedOp: SignedOperation = {
+          ...mockSignedOperation,
+          operation: {
+            ...mockSignedOperation.operation,
+            extra: { inputRefs: [{ hash: "tx-hash", outputIndex: 0, address: "addr-a" }] },
+          },
+        };
+
+        await expect(
+          broadcast({ account: mockAccount, signedOperation: signedOp }),
+        ).rejects.toMatchObject({
+          name: "InvalidTransactionError",
+          message: "tx not found",
+        });
+        expect(mockBroadcastTx).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("spent_at_height is set (UTXO already confirmed-spent)", () => {
+      it("should throw InvalidTransactionError and not call broadcastTx", async () => {
+        const mockBroadcastTx = jest.spyOn(wallet, "broadcastTx").mockResolvedValue("mock-hash");
+        mockExplorer.fetchUtxoTx.mockResolvedValue({
+          outputs: [makeTxOutput(0, 949619)],
+        });
+
+        const signedOp: SignedOperation = {
+          ...mockSignedOperation,
+          operation: {
+            ...mockSignedOperation.operation,
+            extra: { inputRefs: [{ hash: "tx-hash", outputIndex: 0, address: "addr-a" }] },
+          },
+        };
+
+        await expect(
+          broadcast({ account: mockAccount, signedOperation: signedOp }),
+        ).rejects.toMatchObject({
+          name: "InvalidTransactionError",
+          message: "utxos already spent",
+        });
+        expect(mockBroadcastTx).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("spent_at_height is not set (UTXO still available)", () => {
+      it("should not throw when spent_at_height is null", async () => {
+        jest.spyOn(wallet, "broadcastTx").mockResolvedValue("mock-hash");
+        mockExplorer.fetchUtxoTx.mockResolvedValue({
+          outputs: [makeTxOutput(0, null)],
+        });
+
+        const signedOp: SignedOperation = {
+          ...mockSignedOperation,
+          operation: {
+            ...mockSignedOperation.operation,
+            extra: { inputRefs: [{ hash: "tx-hash", outputIndex: 0, address: "addr-a" }] },
+          },
+        };
+
+        await expect(
+          broadcast({ account: mockAccount, signedOperation: signedOp }),
+        ).resolves.toBeDefined();
+      });
+
+      it("should not throw when spent_at_height is 0", async () => {
+        jest.spyOn(wallet, "broadcastTx").mockResolvedValue("mock-hash");
+        mockExplorer.fetchUtxoTx.mockResolvedValue({
+          outputs: [makeTxOutput(0, 0)],
+        });
+
+        const signedOp: SignedOperation = {
+          ...mockSignedOperation,
+          operation: {
+            ...mockSignedOperation.operation,
+            extra: { inputRefs: [{ hash: "tx-hash", outputIndex: 0, address: "addr-a" }] },
+          },
+        };
+
+        await expect(
+          broadcast({ account: mockAccount, signedOperation: signedOp }),
+        ).resolves.toBeDefined();
+      });
+
+      it("should not throw when the outputIndex is not found in tx outputs", async () => {
+        jest.spyOn(wallet, "broadcastTx").mockResolvedValue("mock-hash");
+        // tx has output at index 1, we're looking for index 0
+        mockExplorer.fetchUtxoTx.mockResolvedValue({
+          outputs: [makeTxOutput(1, 949619)],
+        });
+
+        const signedOp: SignedOperation = {
+          ...mockSignedOperation,
+          operation: {
+            ...mockSignedOperation.operation,
+            extra: { inputRefs: [{ hash: "tx-hash", outputIndex: 0, address: "addr-a" }] },
+          },
+        };
+
+        await expect(
+          broadcast({ account: mockAccount, signedOperation: signedOp }),
+        ).resolves.toBeDefined();
+      });
+    });
+
+    describe("multiple outputs in the same source tx (same hash, different outputIndex)", () => {
+      it("should not throw when all outputs are unspent", async () => {
+        jest.spyOn(wallet, "broadcastTx").mockResolvedValue("mock-hash");
+        mockExplorer.fetchUtxoTx.mockResolvedValue({
+          outputs: [makeTxOutput(0, null), makeTxOutput(1, null)],
+        });
+
+        const signedOp: SignedOperation = {
+          ...mockSignedOperation,
+          operation: {
+            ...mockSignedOperation.operation,
+            extra: {
+              inputRefs: [
+                { hash: "tx-hash", outputIndex: 0, address: "addr-a" },
+                { hash: "tx-hash", outputIndex: 1, address: "addr-a" },
+              ],
+            },
+          },
+        };
+
+        await expect(
+          broadcast({ account: mockAccount, signedOperation: signedOp }),
+        ).resolves.toBeDefined();
+      });
+
+      it("should throw when the first output is spent", async () => {
+        mockExplorer.fetchUtxoTx.mockResolvedValue({
+          outputs: [makeTxOutput(0, 949619), makeTxOutput(1, null)],
+        });
+
+        const signedOp: SignedOperation = {
+          ...mockSignedOperation,
+          operation: {
+            ...mockSignedOperation.operation,
+            extra: {
+              inputRefs: [
+                { hash: "tx-hash", outputIndex: 0, address: "addr-a" },
+                { hash: "tx-hash", outputIndex: 1, address: "addr-a" },
+              ],
+            },
+          },
+        };
+
+        await expect(
+          broadcast({ account: mockAccount, signedOperation: signedOp }),
+        ).rejects.toThrow(InvalidTransactionError);
+      });
+
+      it("should throw when the second output is spent", async () => {
+        mockExplorer.fetchUtxoTx.mockResolvedValue({
+          outputs: [makeTxOutput(0, null), makeTxOutput(1, 949619)],
+        });
+
+        const signedOp: SignedOperation = {
+          ...mockSignedOperation,
+          operation: {
+            ...mockSignedOperation.operation,
+            extra: {
+              inputRefs: [
+                { hash: "tx-hash", outputIndex: 0, address: "addr-a" },
+                { hash: "tx-hash", outputIndex: 1, address: "addr-a" },
+              ],
+            },
+          },
+        };
+
+        await expect(
+          broadcast({ account: mockAccount, signedOperation: signedOp }),
+        ).rejects.toThrow(InvalidTransactionError);
+      });
+
+      it("should throw when both outputs are spent", async () => {
+        mockExplorer.fetchUtxoTx.mockResolvedValue({
+          outputs: [makeTxOutput(0, 949619), makeTxOutput(1, 950000)],
+        });
+
+        const signedOp: SignedOperation = {
+          ...mockSignedOperation,
+          operation: {
+            ...mockSignedOperation.operation,
+            extra: {
+              inputRefs: [
+                { hash: "tx-hash", outputIndex: 0, address: "addr-a" },
+                { hash: "tx-hash", outputIndex: 1, address: "addr-a" },
+              ],
+            },
+          },
+        };
+
+        await expect(
+          broadcast({ account: mockAccount, signedOperation: signedOp }),
+        ).rejects.toThrow(InvalidTransactionError);
+      });
+    });
+
+    describe("multiple inputs from different source txs", () => {
+      it("should not throw when all source txs have unspent outputs", async () => {
+        jest.spyOn(wallet, "broadcastTx").mockResolvedValue("mock-hash");
+        mockExplorer.fetchUtxoTx
+          .mockResolvedValueOnce({ outputs: [makeTxOutput(0, null)] })
+          .mockResolvedValueOnce({ outputs: [makeTxOutput(0, null)] });
+
+        const signedOp: SignedOperation = {
+          ...mockSignedOperation,
+          operation: {
+            ...mockSignedOperation.operation,
+            extra: {
+              inputRefs: [
+                { hash: "tx-hash-a", outputIndex: 0, address: "addr-a" },
+                { hash: "tx-hash-b", outputIndex: 0, address: "addr-b" },
+              ],
+            },
+          },
+        };
+
+        await expect(
+          broadcast({ account: mockAccount, signedOperation: signedOp }),
+        ).resolves.toBeDefined();
+      });
+
+      it("should throw when the second source tx has a spent output", async () => {
+        mockExplorer.fetchUtxoTx
+          .mockResolvedValueOnce({ outputs: [makeTxOutput(0, null)] })
+          .mockResolvedValueOnce({ outputs: [makeTxOutput(0, 949619)] });
+
+        const signedOp: SignedOperation = {
+          ...mockSignedOperation,
+          operation: {
+            ...mockSignedOperation.operation,
+            extra: {
+              inputRefs: [
+                { hash: "tx-hash-a", outputIndex: 0, address: "addr-a" },
+                { hash: "tx-hash-b", outputIndex: 0, address: "addr-b" },
+              ],
+            },
+          },
+        };
+
+        await expect(
+          broadcast({ account: mockAccount, signedOperation: signedOp }),
+        ).rejects.toThrow(InvalidTransactionError);
+      });
+    });
+
+    describe("API call counts", () => {
+      it("should call fetchUtxoTx once per unique hash, not per input", async () => {
+        jest.spyOn(wallet, "broadcastTx").mockResolvedValue("mock-hash");
+        mockExplorer.fetchUtxoTx.mockResolvedValue({
+          outputs: [makeTxOutput(0, null), makeTxOutput(1, null)],
+        });
+
+        const signedOp: SignedOperation = {
+          ...mockSignedOperation,
+          operation: {
+            ...mockSignedOperation.operation,
+            extra: {
+              inputRefs: [
+                { hash: "tx-hash-a", outputIndex: 0, address: "addr-a" },
+                { hash: "tx-hash-a", outputIndex: 1, address: "addr-a" }, // same tx hash
+                { hash: "tx-hash-b", outputIndex: 0, address: "addr-b" },
+              ],
+            },
+          },
+        };
+
+        await broadcast({ account: mockAccount, signedOperation: signedOp });
+
+        expect(mockExplorer.fetchUtxoTx).toHaveBeenCalledTimes(2);
+        expect(mockExplorer.fetchUtxoTx.mock.calls.map(([hash]: [string]) => hash)).toEqual(
+          expect.arrayContaining(["tx-hash-a", "tx-hash-b"]),
+        );
+      });
+
+      it("should call broadcastTx after a successful check", async () => {
+        const mockBroadcastTx = jest.spyOn(wallet, "broadcastTx").mockResolvedValue("final-hash");
+        mockExplorer.fetchUtxoTx.mockResolvedValue({
+          outputs: [makeTxOutput(0, null)],
+        });
+
+        const signedOp: SignedOperation = {
+          ...mockSignedOperation,
+          operation: {
+            ...mockSignedOperation.operation,
+            extra: { inputRefs: [{ hash: "our-hash", outputIndex: 0, address: "addr-a" }] },
+          },
+        };
+
+        await broadcast({ account: mockAccount, signedOperation: signedOp });
+
+        expect(mockBroadcastTx).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 });

--- a/libs/coin-modules/coin-bitcoin/src/broadcast.ts
+++ b/libs/coin-modules/coin-bitcoin/src/broadcast.ts
@@ -1,12 +1,13 @@
 import type { AccountBridge } from "@ledgerhq/types-live";
+import { InvalidTransactionError } from "@ledgerhq/errors";
 import { patchOperationWithHash } from "@ledgerhq/ledger-wallet-framework/operation";
 import wallet, { getWalletAccount } from "./wallet-btc";
-import { Transaction } from "./types";
-
+import { Transaction, BtcOperationExtra } from "./types";
 /**
  * Broadcast a signed transaction
  * @param {signature: string, operation: string} signedOperation
  */
+
 export const broadcast: AccountBridge<Transaction>["broadcast"] = async ({
   account,
   signedOperation,
@@ -14,6 +15,29 @@ export const broadcast: AccountBridge<Transaction>["broadcast"] = async ({
 }) => {
   const { signature, operation } = signedOperation;
   const walletAccount = getWalletAccount(account);
+  const extra = operation.extra as BtcOperationExtra | undefined;
+  const inputRefs = extra?.inputRefs ?? [];
+
+  if (inputRefs.length > 0) {
+    // Check each UTXO we're about to spend by fetching its source tx.
+    // If the relevant output already has spent_at_height > 0 it has been
+    // confirmed-spent by another transaction → double-spend → abort.
+    const uniqueHashes = new Set(inputRefs.map(r => r.hash));
+    for (const txHash of uniqueHashes) {
+      const tx = await walletAccount.xpub.explorer.fetchUtxoTx(txHash).catch(() => {
+        throw new InvalidTransactionError("tx not found");
+      });
+      const refsForHash = inputRefs.filter(r => r.hash === txHash);
+
+      for (const ref of refsForHash) {
+        const output = tx.outputs.find(o => o.output_index === ref.outputIndex);
+        if (output && typeof output.spent_at_height === "number" && output.spent_at_height > 0) {
+          throw new InvalidTransactionError("utxos already spent");
+        }
+      }
+    }
+  }
+
   const hash = await wallet.broadcastTx(walletAccount, signature, broadcastConfig);
   return patchOperationWithHash(operation, hash);
 };

--- a/libs/coin-modules/coin-bitcoin/src/signOperation.ts
+++ b/libs/coin-modules/coin-bitcoin/src/signOperation.ts
@@ -102,6 +102,12 @@ async function executeSignOperation(
   const expiryHeight = perCoin?.hasExpiryHeight ? Buffer.from([0x00, 0x00, 0x00, 0x00]) : undefined;
 
   const hasExtraData = perCoin?.hasExtraData || false;
+  const inputRefs = txInfo.inputs.flatMap(i =>
+    i.output_hash !== undefined && i.address !== undefined
+      ? [{ hash: i.output_hash, outputIndex: i.output_index, address: i.address }]
+      : [],
+  );
+  const inputs = inputRefs.map(r => `${r.hash}-${r.outputIndex}`);
 
   const signature: string = await signerContext(deviceId, currency, signer =>
     wallet.signAccountTx({
@@ -138,6 +144,7 @@ async function executeSignOperation(
     value: new BigNumber(transaction.amount).plus(fee),
     senders: Array.from(senders),
     recipients,
+    extra: { inputs, inputRefs },
   });
 
   o.next({

--- a/libs/coin-modules/coin-bitcoin/src/types.ts
+++ b/libs/coin-modules/coin-bitcoin/src/types.ts
@@ -182,8 +182,17 @@ export type BitcoinAccountRaw = AccountRaw & {
   bitcoinResources: BitcoinResourcesRaw;
 };
 
+export type BtcInputRef = {
+  hash: string;
+  outputIndex: number;
+  address: string;
+};
+
 export type BtcOperationExtra = {
+  /** Input outpoints in "txid-index" format. Used by RBF/conflict-dedup logic. */
   inputs?: string[];
+  /** Structured input references with address metadata. Parallel to `inputs`. */
+  inputRefs?: BtcInputRef[];
 };
 
 export type BtcOperation = Operation<BtcOperationExtra>;

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/__tests__/wallet.explorer.integ.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/__tests__/wallet.explorer.integ.test.ts
@@ -38,5 +38,24 @@ describe("Integration tests for bitcoin v4 explorer api", () => {
     expect(hex).toEqual(
       "0100000001c858ba5f607d762fe5be1dfe97ddc121827895c2562c4348d69d02b91dbb408e010000008b4830450220446df4e6b875af246800c8c976de7cd6d7d95016c4a8f7bcdbba81679cbda242022100c1ccfacfeb5e83087894aa8d9e37b11f5c054a75d030d5bfd94d17c5bc953d4a0141045901f6367ea950a5665335065342b952c5d5d60607b3cdc6c69a03df1a6b915aa02eb5e07095a2548a98dcdd84d875c6a3e130bafadfd45e694a3474e71405a4ffffffff020000000000000000156a13636861726c6579206c6f766573206865696469400d0300000000001976a914b8268ce4d481413c4e848ff353cd16104291c45b88ac00000000",
     );
+
+    const tx = await explorer.fetchUtxoTx(
+      "1a7df85fd5afdb6ed9630f23b49379bcff840d570ab80ad4dc3ce02a53c3ca9b",
+    );
+    expect(tx.outputs).toBeInstanceOf(Array);
+    expect(tx.outputs).toEqual([
+      {
+        address: "15nxZ8k9UJy9q7vhE21JdA54UfNrnFE9Hn",
+        output_index: 0,
+        spent_at_height: 949644,
+        value: "25451",
+      },
+      {
+        address: "bc1q237wagrhxka9d3h6f5c8kjjq8g86nnuzqfy0xq",
+        output_index: 1,
+        spent_at_height: 952097,
+        value: "74974941",
+      },
+    ]);
   }, 60000);
 });

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/__tests__/wallet.explorer.unit.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/__tests__/wallet.explorer.unit.test.ts
@@ -228,6 +228,64 @@ describe("BitcoinApi", () => {
     });
   });
 
+  describe("fetchUtxoTx unit test", () => {
+    const txHash = "8bae12b5f4c088d940733dcd1455efc6a3a69cf9340e17a981286d3778615684";
+
+    beforeEach(() => {
+      // @ts-expect-error method is mocked
+      network.mockResolvedValue({
+        data: {
+          id: txHash,
+          outputs: [
+            {
+              output_index: 0,
+              value: "25451",
+              address: "15nxZ8k9UJy9q7vhE21JdA54UfNrnFE9Hn",
+              spent_at_height: 949644,
+            },
+            {
+              output_index: 1,
+              value: "74974941",
+              address: "bc1q237wagrhxka9d3h6f5c8kjjq8g86nnuzqfy0xq",
+              spent_at_height: null,
+            },
+          ],
+        },
+      });
+    });
+
+    it("should return the transaction with its outputs", async () => {
+      const tx = await explorer.fetchUtxoTx(txHash);
+
+      expect(tx.outputs).toEqual([
+        {
+          address: "15nxZ8k9UJy9q7vhE21JdA54UfNrnFE9Hn",
+          output_index: 0,
+          spent_at_height: 949644,
+          value: "25451",
+        },
+        {
+          address: "bc1q237wagrhxka9d3h6f5c8kjjq8g86nnuzqfy0xq",
+          output_index: 1,
+          spent_at_height: null,
+          value: "74974941",
+        },
+      ]);
+    });
+
+    it("should call the correct endpoint with verbosity=Minimal", async () => {
+      const mockNetwork = network as jest.MockedFunction<typeof network>;
+      await explorer.fetchUtxoTx(txHash);
+      expect(mockNetwork).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "GET",
+          url: expect.stringContaining(`/tx/${txHash}`),
+          params: { verbosity: "Minimal" },
+        }),
+      );
+    });
+  });
+
   describe("hydrateTx unit test rbf", () => {
     let mockAddress: { account: number; index: number; address: string };
     beforeEach(() => {

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/explorer/index.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/explorer/index.ts
@@ -1,7 +1,7 @@
 import type { BroadcastConfig } from "@ledgerhq/coin-module-framework/api/types";
 import { Address, Block, TX } from "../storage/types";
 import network from "@ledgerhq/live-network/network";
-import { IExplorer, NetworkInfoResponse } from "./types";
+import type { IExplorer, NetworkInfoResponse, UtxoTx } from "./types";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { blockchainBaseURL } from "../../explorer";
 
@@ -129,6 +129,15 @@ class BitcoinLikeExplorer implements IExplorer {
       method: "GET",
       url: `${this.baseUrl}/address/${address.address}/txs/pending`,
       params: { verbosity: "Minimal", ...params },
+    });
+    return data;
+  }
+
+  async fetchUtxoTx(hash: string): Promise<UtxoTx> {
+    const { data } = await network({
+      method: "GET",
+      url: `${this.baseUrl}/tx/${hash}`,
+      params: { verbosity: "Minimal" },
     });
     return data;
   }

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/explorer/types.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/explorer/types.ts
@@ -7,6 +7,15 @@ export type NetworkInfoResponse = {
   version: string; // e.g. "290000"
   subversion: string; // e.g. "/Satoshi:29.0.0/"
 };
+export type UtxoTxOutput = {
+  output_index: number;
+  spent_at_height: number | null;
+} & Record<string, unknown>;
+
+export type UtxoTx = {
+  outputs: UtxoTxOutput[];
+} & Record<string, unknown>;
+
 // abstract explorer api used, abstract batching logic, pagination, and retries
 export interface IExplorer {
   baseUrl: string;
@@ -20,6 +29,7 @@ export interface IExplorer {
   getCurrentBlock(): Promise<Block | null>;
   getBlockByHeight(height: number): Promise<Block | null>;
   getPendings(address: Address, nbMax?: number): Promise<TX[]>;
+  fetchUtxoTx(hash: string): Promise<UtxoTx>;
   getTxBlockHeight(hash: string): Promise<number | null>;
   getTxsSinceBlockheight(
     batchSize: number,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - We return an error if utxos are spent before broadcast

### 📝 Description

Before broadcasting, the Bitcoin bridge checks each sender address for already-spent UTXOs. When all UTXOs are detected as spent, it now throws an InvalidTransactionError("utxos already spent") or InvalidTransactionError("tx not found") instead of the previous BitcoinUtxoSpent error.

This aligns with the pattern used by the EVM coin module's validateTransaction and ensures both frontends display a user-friendly error instead of a generic broadcast failure screen:

Desktop: renders via ErrorDisplay instead of the NodeError broadcast error screen.
Mobile: triggers shouldRestartFlow, letting the user retry cleanly.
Tests added in broadcast.test.ts and broadcast.integ.test.ts covering the spent/unspent UTXO scenarios.

https://github.com/user-attachments/assets/97e7f2eb-4310-4935-860c-0a38281ebda8

### ❓ Context

- **JIRA or GitHub link**:  [LIVE-23827](https://ledgerhq.atlassian.net/browse/LIVE-23827)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-23827]: https://ledgerhq.atlassian.net/browse/LIVE-23827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ