### PR TITLE
[LWM] Revert #17806 fix(mobile): restore android permission retries

### DIFF
--- a/.changeset/tall-badgers-retry.md
+++ b/.changeset/tall-badgers-retry.md
@@ -1,6 +1,0 @@
----
-"live-mobile": patch
-"@ledgerhq/live-dmk-mobile": patch
----
-
-Restore Android permission retry behavior after the React Native permission fix

--- a/apps/ledger-live-mobile/src/components/RequiresBLE/hooks/useAndroidBluetoothPermissions.ts
+++ b/apps/ledger-live-mobile/src/components/RequiresBLE/hooks/useAndroidBluetoothPermissions.ts
@@ -175,12 +175,21 @@ export const useAndroidBluetoothPermissions = (
     let cancelled = false;
 
     async function asyncRequestBluetoothPermissions() {
-      const res = await requestBluetoothPermissions();
+      /*
+       * First do a simple check to avoid this issue: https://github.com/facebook/react-native/issues/53887
+       * or the permission state might be stuck in "unknown" state.
+       */
+      const checkResult = await checkBluetoothPermissions();
+      if (cancelled) return;
+      setHasPermissions(checkResult ? "granted" : "denied");
+      if (checkResult) return;
+
+      const requestResult = await requestBluetoothPermissions();
 
       if (!cancelled) {
         /** https://developer.android.com/about/versions/11/privacy/permissions#dialog-visibility */
-        setNeverAskAgain(res.generalStatus === RESULTS.NEVER_ASK_AGAIN);
-        setHasPermissions(res.allGranted ? "granted" : "denied");
+        setNeverAskAgain(requestResult.generalStatus === RESULTS.NEVER_ASK_AGAIN);
+        setHasPermissions(requestResult.allGranted ? "granted" : "denied");
       }
     }
 

--- a/apps/ledger-live-mobile/src/components/RequiresBLE/hooks/useRequireBluetooth.ts
+++ b/apps/ledger-live-mobile/src/components/RequiresBLE/hooks/useRequireBluetooth.ts
@@ -55,7 +55,7 @@ export const useRequireBluetooth = ({
 
   const {
     hasPermissions: androidHasBluetoothPermissions,
-    neverAskAgain: androidBluetoothPermissionsNeverAskAgain,
+    neverAskAgain: _androidBluetoothPermissionsNeverAskAgain,
     requestForPermissionsAgain: androidBluetoothPermissionsRequestForPermissionsAgain,
   } = useAndroidBluetoothPermissions({
     isHookEnabled: isAndroidBluetoothPermissionsHookEnabled,
@@ -81,7 +81,7 @@ export const useRequireBluetooth = ({
 
   const {
     hasPermission: androidHasLocationPermission,
-    neverAskAgain: androidLocationPermissionNeverAskAgain,
+    neverAskAgain: _androidLocationPermissionNeverAskAgain,
     requestForPermissionAgain: androidLocationPermissionRequestForPermissionsAgain,
   } = useAndroidLocationPermission({
     isHookEnabled: isAndroidLocationPermissionHookEnabled,
@@ -115,7 +115,12 @@ export const useRequireBluetooth = ({
     if (androidHasBluetoothPermissions === "denied") {
       bluetoothRequirementsState = "bluetooth_permissions_ungranted";
       retryRequestOnIssue = androidBluetoothPermissionsRequestForPermissionsAgain;
-      cannotRetryRequest = androidBluetoothPermissionsNeverAskAgain;
+      /*
+       * FIXME: temporary fix to avoid this issue: https://github.com/facebook/react-native/issues/53887
+       * Revert `cannotRetryRequest` to `_androidBluetoothPermissionsNeverAskAgain` when React Native gets upgraded to 0.81.5
+       * to include the fix https://github.com/facebook/react-native/commit/447a7a3527e3e38e4c3ceb330d12d77afe7bc0b4
+       */
+      cannotRetryRequest = true;
     } else if (androidHasBluetoothPermissions !== "granted") {
       someUnknown = true;
     }
@@ -125,7 +130,12 @@ export const useRequireBluetooth = ({
     if (androidHasLocationPermission === "denied") {
       bluetoothRequirementsState = "location_permission_ungranted";
       retryRequestOnIssue = androidLocationPermissionRequestForPermissionsAgain;
-      cannotRetryRequest = androidLocationPermissionNeverAskAgain;
+      /*
+       * FIXME: temporary fix to avoid this issue: https://github.com/facebook/react-native/issues/53887
+       * Revert `cannotRetryRequest` to `_androidLocationPermissionNeverAskAgain` when React Native gets upgraded to 0.81.5
+       * to include the fix https://github.com/facebook/react-native/commit/447a7a3527e3e38e4c3ceb330d12d77afe7bc0b4
+       */
+      cannotRetryRequest = true;
     } else if (androidHasLocationPermission !== "granted") {
       someUnknown = true;
     }

--- a/apps/ledger-live-mobile/src/components/RequiresBLE/index.tsx
+++ b/apps/ledger-live-mobile/src/components/RequiresBLE/index.tsx
@@ -23,12 +23,20 @@ type Props = {
  */
 const RequiresBLE: React.FC<Props> = ({ children, forceOpenSettingsOnErrorButton = false }) => {
   if (Platform.OS === "android") {
+    /*
+     * FIXME: temporary fix to avoid this issue: https://github.com/facebook/react-native/issues/53887
+     * To revert to `forceOpenSettingsOnErrorButton` when React Native gets upgraded to 0.81.5
+     * to include the fix https://github.com/facebook/react-native/commit/447a7a3527e3e38e4c3ceb330d12d77afe7bc0b4
+     */
+    const forceOpenSettingsForPermissions = true;
     return (
-      <AndroidRequiresBluetoothPermissions forceOpenSettingsOnErrorButton={forceOpenSettingsOnErrorButton}>
+      <AndroidRequiresBluetoothPermissions
+        forceOpenSettingsOnErrorButton={forceOpenSettingsForPermissions}
+      >
         <RequiresBluetoothEnabled forceOpenSettingsOnErrorButton={forceOpenSettingsOnErrorButton}>
           <AndroidRequiresLocationPermission
             required={Platform.Version <= 30}
-            forceOpenSettingsOnErrorButton={forceOpenSettingsOnErrorButton}
+            forceOpenSettingsOnErrorButton={forceOpenSettingsForPermissions}
           >
             <AndroidRequiresLocationEnabled
               required={Platform.Version <= 30}

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/permissionHelpers.test.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/permissionHelpers.test.ts
@@ -1,6 +1,9 @@
 import { PermissionsAndroid, type Permission } from "react-native";
-import type { DiscoveryError } from "../../../types";
-import { requestPermission, requestPermissions, runPermissionPreflight } from "./permissionHelpers";
+import {
+  DEFAULT_PERMISSION_REQUEST_TIMEOUT_MS,
+  requestPermission,
+  requestPermissions,
+} from "./permissionHelpers";
 
 jest.mock("react-native", () => ({
   PermissionsAndroid: {
@@ -25,106 +28,62 @@ const bluetoothConnectPermission: Permission = PermissionsAndroid.PERMISSIONS.BL
 
 describe("permissionHelpers", () => {
   beforeEach(() => {
-    jest.mocked(PermissionsAndroid.check).mockReset();
+    jest.useFakeTimers();
     jest.mocked(PermissionsAndroid.request).mockReset();
     jest.mocked(PermissionsAndroid.requestMultiple).mockReset();
   });
 
-  it("GIVEN a permission request is denied, WHEN requesting, THEN it should keep the native promptable status", async () => {
-    // GIVEN
-    jest.mocked(PermissionsAndroid.request).mockResolvedValue(RESULTS.DENIED);
-
-    // WHEN
-    const result = await requestPermission(bluetoothScanPermission);
-
-    // THEN
-    expect(result).toEqual({
-      granted: false,
-      neverAskAgain: false,
-      deniedPermissions: [bluetoothScanPermission],
-    });
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
-  it("GIVEN a permission request resolves to never ask again, WHEN requesting, THEN it should require manual settings", async () => {
+  it("GIVEN a single permission request does not resolve, WHEN the timeout is reached, THEN it should require manual settings", async () => {
     // GIVEN
-    jest.mocked(PermissionsAndroid.request).mockResolvedValue(RESULTS.NEVER_ASK_AGAIN);
+    jest.mocked(PermissionsAndroid.request).mockImplementation(() => new Promise(() => undefined));
 
     // WHEN
-    const result = await requestPermission(bluetoothScanPermission);
+    const resultPromise = requestPermission(bluetoothScanPermission);
+    await jest.advanceTimersByTimeAsync(DEFAULT_PERMISSION_REQUEST_TIMEOUT_MS);
 
     // THEN
-    expect(result).toEqual({
+    await expect(resultPromise).resolves.toEqual({
       granted: false,
       neverAskAgain: true,
       deniedPermissions: [bluetoothScanPermission],
     });
   });
 
-  it("GIVEN multiple permission requests are denied, WHEN requesting, THEN it should keep them promptable", async () => {
+  it("GIVEN a multiple permissions request does not resolve, WHEN the timeout is reached, THEN it should require manual settings", async () => {
     // GIVEN
     const permissions = [bluetoothScanPermission, bluetoothConnectPermission];
-    const requestMultipleResult = {
-      [bluetoothScanPermission]: RESULTS.DENIED,
-      [bluetoothConnectPermission]: RESULTS.DENIED,
-    } as Awaited<ReturnType<typeof PermissionsAndroid.requestMultiple>>;
-    jest.mocked(PermissionsAndroid.requestMultiple).mockResolvedValue(requestMultipleResult);
+    jest
+      .mocked(PermissionsAndroid.requestMultiple)
+      .mockImplementation(() => new Promise(() => undefined));
 
     // WHEN
-    const result = await requestPermissions(permissions);
+    const resultPromise = requestPermissions(permissions);
+    await jest.advanceTimersByTimeAsync(DEFAULT_PERMISSION_REQUEST_TIMEOUT_MS);
+
+    // THEN
+    await expect(resultPromise).resolves.toEqual({
+      granted: false,
+      neverAskAgain: true,
+      deniedPermissions: permissions,
+    });
+  });
+
+  it("GIVEN a permission request resolves before the timeout, WHEN requesting, THEN it should keep the native status", async () => {
+    // GIVEN
+    jest.mocked(PermissionsAndroid.request).mockResolvedValue(RESULTS.DENIED);
+
+    // WHEN
+    const result = await requestPermission(bluetoothScanPermission);
 
     // THEN
     expect(result).toEqual({
       granted: false,
       neverAskAgain: false,
-      deniedPermissions: permissions,
+      deniedPermissions: [bluetoothScanPermission],
     });
-  });
-
-  it("GIVEN missing permission remains promptable, WHEN running preflight, THEN it should return a promptable error", async () => {
-    // GIVEN
-    const retry = jest.fn<Promise<true | DiscoveryError>, []>();
-    const promptableError = { type: "promptable" } as unknown as DiscoveryError;
-    const manualSettingsError = { type: "manual-settings" } as unknown as DiscoveryError;
-    const buildPromptableError = jest.fn(() => promptableError);
-    const buildManualSettingsError = jest.fn(() => manualSettingsError);
-    jest.mocked(PermissionsAndroid.check).mockResolvedValue(false);
-    jest.mocked(PermissionsAndroid.request).mockResolvedValue(RESULTS.DENIED);
-
-    // WHEN
-    const result = await runPermissionPreflight({
-      permissions: [bluetoothScanPermission],
-      retry,
-      buildPromptableError,
-      buildManualSettingsError,
-    });
-
-    // THEN
-    expect(result).toEqual({ success: false, discoveryError: promptableError });
-    expect(buildPromptableError).toHaveBeenCalledWith([bluetoothScanPermission], retry);
-    expect(buildManualSettingsError).not.toHaveBeenCalled();
-  });
-
-  it("GIVEN missing permission can no longer be prompted, WHEN running preflight, THEN it should return a manual settings error", async () => {
-    // GIVEN
-    const retry = jest.fn<Promise<true | DiscoveryError>, []>();
-    const promptableError = { type: "promptable" } as unknown as DiscoveryError;
-    const manualSettingsError = { type: "manual-settings" } as unknown as DiscoveryError;
-    const buildPromptableError = jest.fn(() => promptableError);
-    const buildManualSettingsError = jest.fn(() => manualSettingsError);
-    jest.mocked(PermissionsAndroid.check).mockResolvedValue(false);
-    jest.mocked(PermissionsAndroid.request).mockResolvedValue(RESULTS.NEVER_ASK_AGAIN);
-
-    // WHEN
-    const result = await runPermissionPreflight({
-      permissions: [bluetoothScanPermission],
-      retry,
-      buildPromptableError,
-      buildManualSettingsError,
-    });
-
-    // THEN
-    expect(result).toEqual({ success: false, discoveryError: manualSettingsError });
-    expect(buildPromptableError).not.toHaveBeenCalled();
-    expect(buildManualSettingsError).toHaveBeenCalledWith([bluetoothScanPermission], retry);
   });
 });

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/permissionHelpers.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/permissionHelpers.ts
@@ -1,4 +1,4 @@
-import { PermissionsAndroid, type Permission } from "react-native";
+import { PermissionsAndroid, type Permission, type PermissionStatus } from "react-native";
 import type { DiscoveryError } from "../../../types";
 import {
   mapDiscoveryErrorToPreflightResult,
@@ -7,6 +7,11 @@ import {
 } from "../preflightResult";
 
 const { RESULTS } = PermissionsAndroid;
+
+export const DEFAULT_PERMISSION_REQUEST_TIMEOUT_MS = 10_000;
+export const shouldUseManualActionForPermissionDenial = true;
+
+type PermissionRequestStatuses = Partial<Record<Permission, PermissionStatus>>;
 
 export type PermissionRequestResult = {
   granted: boolean;
@@ -38,7 +43,10 @@ export const arePermissionsGranted = async (permissions: Permission[]): Promise<
 export const requestPermissions = async (
   permissions: Permission[],
 ): Promise<PermissionRequestResult> => {
-  const requestResult = await PermissionsAndroid.requestMultiple(permissions);
+  const requestResult = await withPermissionRequestTimeout<PermissionRequestStatuses>(
+    PermissionsAndroid.requestMultiple(permissions),
+    getPermissionRequestTimeoutStatuses(permissions),
+  );
   const deniedPermissions = permissions.filter(
     permission => requestResult[permission] !== RESULTS.GRANTED,
   );
@@ -55,7 +63,10 @@ export const requestPermissions = async (
 export const requestPermission = async (
   permission: Permission,
 ): Promise<PermissionRequestResult> => {
-  const status = await PermissionsAndroid.request(permission);
+  const status = await withPermissionRequestTimeout(
+    PermissionsAndroid.request(permission),
+    RESULTS.NEVER_ASK_AGAIN,
+  );
 
   return {
     granted: status === RESULTS.GRANTED,
@@ -89,7 +100,7 @@ export const runPermissionPreflight = async (
   }
 
   return mapDiscoveryErrorToPreflightResult(
-    requestResult.neverAskAgain
+    shouldUseManualActionForPermissionDenial || requestResult.neverAskAgain
       ? config.buildManualSettingsError(requestResult.deniedPermissions, config.retry)
       : config.buildPromptableError(requestResult.deniedPermissions, config.retry),
   );
@@ -104,4 +115,39 @@ const getMissingPermissions = async (permissions: Permission[]): Promise<Permiss
   );
 
   return results.filter(({ granted }) => !granted).map(({ permission }) => permission);
+};
+
+/**
+ * TODO(LIVE-23757): This workaround for never resolving permission request
+ * can be removed once React Native is upgraded to 0.81.6
+ */
+const withPermissionRequestTimeout = async <T>(
+  request: Promise<T>,
+  timeoutValue: T,
+  timeoutMs = DEFAULT_PERMISSION_REQUEST_TIMEOUT_MS,
+): Promise<T> => {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<T>(resolve => {
+    timeoutId = setTimeout(() => resolve(timeoutValue), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([request, timeout]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+};
+
+const getPermissionRequestTimeoutStatuses = (
+  permissions: Permission[],
+): PermissionRequestStatuses => {
+  const statuses: PermissionRequestStatuses = {};
+
+  permissions.forEach(permission => {
+    statuses[permission] = RESULTS.NEVER_ASK_AGAIN;
+  });
+
+  return statuses;
 };


### PR DESCRIPTION
This reverts commit 938587a605ff9650b1d237405ec1519cfb44b69b, reversing changes made to 8c8204f08ddc6cc4d878f1f8cfb39038b2e9a524.

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

As the react native upgrade is reverted, we have to revert #17806 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
