### PR TITLE
[LWD] feat(lld): generic awareness modal tracking

### DIFF
--- a/.changeset/curly-wasps-join.md
+++ b/.changeset/curly-wasps-join.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
+---
+
+Add analytics tracking for Generic Awareness Modal

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/GenericAwarenessModalView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/GenericAwarenessModalView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 import { useSelector } from "LLD/hooks/redux";
 import { Dialog, DialogBody, DialogContent, DialogHeader } from "@ledgerhq/lumen-ui-react";
 import { selectGenericAwarenessModalHasStoredContentCards } from "~/renderer/reducers/genericAwarenessModalSlice";
@@ -6,6 +6,7 @@ import {
   GenericAwarenessModalLayout,
   type GenericAwarenessModalContentCard,
 } from "@ledgerhq/live-common/genericAwarenessModal";
+import { AWARENESS_MODAL_DISMISS_METHOD, type AwarenessModalDismissMethod } from "./analytics/const";
 import type { GenericAwarenessModalViewProps } from "./hooks/useGenericAwarenessModalViewModel";
 import useGenericAwarenessModalFeatureIntroViewModel, {
   type GenericAwarenessModalFeatureIntroViewModel,
@@ -15,6 +16,30 @@ import useGenericAwarenessModalCarouselViewModel, {
 } from "./hooks/useGenericAwarenessModalCarouselViewModel";
 import CarouselContent from "./components/CarouselContent";
 import FeatureIntroContent from "./components/FeatureIntroContent";
+
+type GenericAwarenessModalLayoutHandlers = {
+  readonly onDismiss: (dismissMethod: AwarenessModalDismissMethod) => void;
+  readonly onHeaderClose: () => void;
+};
+
+const getLayoutHandlers = (
+  layout: GenericAwarenessModalLayout,
+  carouselViewModel: GenericAwarenessModalCarouselViewModel,
+  featureIntroViewModel: GenericAwarenessModalFeatureIntroViewModel,
+  onClose: () => void,
+): GenericAwarenessModalLayoutHandlers => {
+  switch (layout) {
+    case GenericAwarenessModalLayout.Carousel:
+      return carouselViewModel;
+    case GenericAwarenessModalLayout.FeatureIntro:
+      return featureIntroViewModel;
+    default:
+      return {
+        onDismiss: () => onClose(),
+        onHeaderClose: onClose,
+      };
+  }
+};
 
 function renderModalContent(
   contentCard: GenericAwarenessModalContentCard,
@@ -37,12 +62,26 @@ const GenericAwarenessModalView = ({
   contentCard,
 }: GenericAwarenessModalViewProps) => {
   const hasStoredContentCards = useSelector(selectGenericAwarenessModalHasStoredContentCards);
-  const carouselViewModel = useGenericAwarenessModalCarouselViewModel(contentCard);
-  const featureIntroViewModel = useGenericAwarenessModalFeatureIntroViewModel(contentCard);
+  const carouselViewModel = useGenericAwarenessModalCarouselViewModel(contentCard, isOpen);
+  const featureIntroViewModel = useGenericAwarenessModalFeatureIntroViewModel(contentCard, isOpen);
 
-  const handleOpenChange = (open: boolean) => {
-    if (!open) onClose();
-  };
+  const layoutHandlers = useMemo(
+    () =>
+      contentCard
+        ? getLayoutHandlers(contentCard.layout, carouselViewModel, featureIntroViewModel, onClose)
+        : { onDismiss: () => onClose(), onHeaderClose: onClose },
+    [carouselViewModel, contentCard, featureIntroViewModel, onClose],
+  );
+
+  const handleBackdropDismiss = useCallback(
+    () => layoutHandlers.onDismiss(AWARENESS_MODAL_DISMISS_METHOD.backdropTap),
+    [layoutHandlers],
+  );
+
+  const handleEscapeDismiss = useCallback(
+    () => layoutHandlers.onDismiss(AWARENESS_MODAL_DISMISS_METHOD.backButton),
+    [layoutHandlers],
+  );
 
   useEffect(() => {
     if (isOpen && !contentCard && hasStoredContentCards) {
@@ -55,14 +94,16 @@ const GenericAwarenessModalView = ({
   }
 
   return (
-    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+    <Dialog open={isOpen} onOpenChange={() => {}}>
       <DialogContent
         className="max-h-[90vh] rounded-xl"
         aria-describedby={undefined}
         data-testid="generic-awareness-modal"
         data-campaign-id={contentCard.id}
+        onPointerDownOutside={handleBackdropDismiss}
+        onEscapeKeyDown={handleEscapeDismiss}
       >
-        <DialogHeader density="expanded" onClose={onClose} />
+        <DialogHeader density="expanded" onClose={layoutHandlers.onHeaderClose} />
         <DialogBody className="flex min-h-0 flex-1 flex-col gap-24 overflow-hidden">
           {renderModalContent(contentCard, carouselViewModel, featureIntroViewModel)}
         </DialogBody>

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/__tests__/GenericAwarenessModalView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/__tests__/GenericAwarenessModalView.test.tsx
@@ -8,6 +8,10 @@ jest.mock("../hooks/useGenericAwarenessModalCarouselViewModel", () => ({
   default: jest.fn(() => ({
     slides: [],
     onSlidePrimaryClick: jest.fn(),
+    onSlideChange: jest.fn(),
+    onContinueClick: jest.fn(),
+    onHeaderClose: jest.fn(),
+    onDismiss: jest.fn(),
     onClose: jest.fn(),
   })),
 }));
@@ -22,6 +26,8 @@ jest.mock("../hooks/useGenericAwarenessModalFeatureIntroViewModel", () => ({
     secondaryButtonLabel: "",
     onPrimaryClick: jest.fn(),
     onSecondaryClick: jest.fn(),
+    onHeaderClose: jest.fn(),
+    onDismiss: jest.fn(),
   })),
 }));
 

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/analytics/__tests__/carouselAnalytics.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/analytics/__tests__/carouselAnalytics.test.ts
@@ -1,0 +1,73 @@
+import { track, trackPage } from "~/renderer/analytics/segment";
+import { carouselCampaignCard } from "../../__tests__/fixtures";
+import {
+  getCarouselAnalyticsContext,
+  normalizeCarouselButtonName,
+  trackCarouselContinueClick,
+  trackCarouselInitialStep,
+  trackCarouselTourCompleted,
+} from "../carouselAnalytics";
+import { CAROUSEL_NAVIGATION_METHOD, PAGE_TRACKING_AWARENESS_MODAL_CAROUSEL } from "../const";
+
+describe("carouselAnalytics", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should build analytics context from carousel campaign id", () => {
+    const context = getCarouselAnalyticsContext(carouselCampaignCard, 1);
+
+    expect(context).toEqual({
+      page: PAGE_TRACKING_AWARENESS_MODAL_CAROUSEL,
+      contentId: carouselCampaignCard.id,
+      step: 2,
+      totalSteps: 4,
+    });
+  });
+
+  it("should normalize button labels for tracking", () => {
+    expect(normalizeCarouselButtonName("  Discover Flex  ")).toBe("discover flex");
+  });
+
+  it("should track carousel page on initial step", () => {
+    trackCarouselInitialStep(carouselCampaignCard);
+
+    expect(trackPage).toHaveBeenCalledWith(
+      PAGE_TRACKING_AWARENESS_MODAL_CAROUSEL,
+      undefined,
+      expect.objectContaining({
+        name: PAGE_TRACKING_AWARENESS_MODAL_CAROUSEL,
+        contentId: carouselCampaignCard.id,
+        step: 1,
+        navigationMethod: CAROUSEL_NAVIGATION_METHOD.initial,
+      }),
+      true,
+      false,
+    );
+  });
+
+  it("should track continue and tour completed events", () => {
+    const context = getCarouselAnalyticsContext(carouselCampaignCard, 3);
+
+    trackCarouselContinueClick(context);
+    trackCarouselTourCompleted(context);
+
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({
+        button: "continue",
+        contentId: carouselCampaignCard.id,
+        step: 4,
+        ctaPosition: "secondary",
+      }),
+    );
+    expect(track).toHaveBeenCalledWith(
+      "tour_completed",
+      expect.objectContaining({
+        contentId: carouselCampaignCard.id,
+        step: 4,
+        completed: "yes",
+      }),
+    );
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/analytics/__tests__/featureIntroAnalytics.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/analytics/__tests__/featureIntroAnalytics.test.ts
@@ -1,0 +1,68 @@
+import { track, trackPage } from "~/renderer/analytics/segment";
+import { appStartFeatureIntroCard } from "../../__tests__/fixtures";
+import {
+  getFeatureIntroAnalyticsContext,
+  normalizeFeatureIntroButtonName,
+  trackFeatureIntroPage,
+  trackFeatureIntroPrimaryClick,
+  trackFeatureIntroSecondaryClick,
+} from "../featureIntroAnalytics";
+import { PAGE_TRACKING_AWARENESS_MODAL_FEATURE_INTRO } from "../const";
+
+describe("featureIntroAnalytics", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should build analytics context from feature intro campaign id", () => {
+    const context = getFeatureIntroAnalyticsContext(appStartFeatureIntroCard);
+
+    expect(context).toEqual({
+      page: PAGE_TRACKING_AWARENESS_MODAL_FEATURE_INTRO,
+      contentId: appStartFeatureIntroCard.id,
+    });
+  });
+
+  it("should normalize button labels for tracking", () => {
+    expect(normalizeFeatureIntroButtonName("  Got it  ")).toBe("got it");
+  });
+
+  it("should track feature intro page on display", () => {
+    trackFeatureIntroPage(appStartFeatureIntroCard);
+
+    expect(trackPage).toHaveBeenCalledWith(
+      PAGE_TRACKING_AWARENESS_MODAL_FEATURE_INTRO,
+      undefined,
+      expect.objectContaining({
+        name: PAGE_TRACKING_AWARENESS_MODAL_FEATURE_INTRO,
+        contentId: appStartFeatureIntroCard.id,
+      }),
+      true,
+      false,
+    );
+  });
+
+  it("should track primary and secondary button clicks", () => {
+    const context = getFeatureIntroAnalyticsContext(appStartFeatureIntroCard);
+
+    trackFeatureIntroPrimaryClick(context, "Got it");
+    trackFeatureIntroSecondaryClick(context, "Compare signers");
+
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({
+        button: "got it",
+        contentId: appStartFeatureIntroCard.id,
+        ctaPosition: "primary",
+      }),
+    );
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({
+        button: "compare signers",
+        contentId: appStartFeatureIntroCard.id,
+        ctaPosition: "secondary",
+      }),
+    );
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/analytics/carouselAnalytics.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/analytics/carouselAnalytics.ts
@@ -1,0 +1,121 @@
+import type { GenericAwarenessModalCarousel } from "@ledgerhq/live-common/genericAwarenessModal";
+import { track, trackPage } from "~/renderer/analytics/segment";
+import {
+  CAROUSEL_NAVIGATION_METHOD,
+  PAGE_TRACKING_AWARENESS_MODAL_CAROUSEL,
+  type AwarenessModalDismissMethod,
+} from "./const";
+
+export type CarouselAnalyticsContext = {
+  readonly page: typeof PAGE_TRACKING_AWARENESS_MODAL_CAROUSEL;
+  readonly contentId: string;
+  readonly step: number;
+  readonly totalSteps: number;
+};
+
+export const normalizeCarouselButtonName = (label: string): string => label.trim().toLowerCase();
+
+export const getCarouselAnalyticsContext = (
+  carousel: GenericAwarenessModalCarousel,
+  slideIndex: number,
+): CarouselAnalyticsContext => ({
+  page: PAGE_TRACKING_AWARENESS_MODAL_CAROUSEL,
+  contentId: carousel.id,
+  step: slideIndex + 1,
+  totalSteps: carousel.data.length,
+});
+
+const getCarouselPageProperties = (
+  context: CarouselAnalyticsContext,
+  navigationMethod: string,
+) => ({
+  name: PAGE_TRACKING_AWARENESS_MODAL_CAROUSEL,
+  contentId: context.contentId,
+  step: context.step,
+  totalSteps: context.totalSteps,
+  navigationMethod,
+});
+
+const getCarouselInteractionProperties = (context: CarouselAnalyticsContext) => ({
+  page: context.page,
+  contentId: context.contentId,
+  step: context.step,
+  totalSteps: context.totalSteps,
+});
+
+export const trackCarouselStepPage = (
+  context: CarouselAnalyticsContext,
+  navigationMethod: string,
+): void => {
+  trackPage(
+    PAGE_TRACKING_AWARENESS_MODAL_CAROUSEL,
+    undefined,
+    getCarouselPageProperties(context, navigationMethod),
+    true,
+    false,
+  );
+};
+
+export const trackCarouselContinueClick = (context: CarouselAnalyticsContext): void => {
+  track("button_clicked", {
+    button: "continue",
+    ...getCarouselInteractionProperties(context),
+    ctaPosition: "secondary",
+  });
+};
+
+export const trackCarouselPrimaryClick = (
+  context: CarouselAnalyticsContext,
+  buttonLabel: string,
+): void => {
+  track("button_clicked", {
+    button: normalizeCarouselButtonName(buttonLabel),
+    ...getCarouselInteractionProperties(context),
+    ctaPosition: "primary",
+  });
+};
+
+export const trackCarouselCloseClick = (context: CarouselAnalyticsContext): void => {
+  track("button_clicked", {
+    button: "close",
+    ...getCarouselInteractionProperties(context),
+  });
+};
+
+export const trackCarouselDismissed = (
+  context: CarouselAnalyticsContext,
+  dismissMethod: AwarenessModalDismissMethod,
+): void => {
+  track("drawer_dismissed", {
+    drawer: PAGE_TRACKING_AWARENESS_MODAL_CAROUSEL,
+    page: context.page,
+    contentId: context.contentId,
+    step: context.step,
+    totalSteps: context.totalSteps,
+    dismissMethod,
+  });
+};
+
+export const trackCarouselTourCompleted = (context: CarouselAnalyticsContext): void => {
+  track("tour_completed", {
+    ...getCarouselInteractionProperties(context),
+    completed: "yes",
+  });
+};
+
+export const trackCarouselInitialStep = (carousel: GenericAwarenessModalCarousel): void => {
+  trackCarouselStepPage(
+    getCarouselAnalyticsContext(carousel, 0),
+    CAROUSEL_NAVIGATION_METHOD.initial,
+  );
+};
+
+export const trackCarouselStepNavigation = (
+  carousel: GenericAwarenessModalCarousel,
+  slideIndex: number,
+): void => {
+  trackCarouselStepPage(
+    getCarouselAnalyticsContext(carousel, slideIndex),
+    CAROUSEL_NAVIGATION_METHOD.nextButton,
+  );
+};

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/analytics/const.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/analytics/const.ts
@@ -1,0 +1,17 @@
+export const PAGE_TRACKING_AWARENESS_MODAL_CAROUSEL = "Awareness Modal Carousel" as const;
+
+export const PAGE_TRACKING_AWARENESS_MODAL_FEATURE_INTRO = "Awareness Modal Feature Intro" as const;
+
+export const CAROUSEL_NAVIGATION_METHOD = {
+  initial: "initial",
+  nextButton: "next_button",
+} as const;
+
+export const AWARENESS_MODAL_DISMISS_METHOD = {
+  backdropTap: "backdrop_tap",
+  backButton: "back_button",
+  swipeDown: "swipe_down",
+} as const;
+
+export type AwarenessModalDismissMethod =
+  (typeof AWARENESS_MODAL_DISMISS_METHOD)[keyof typeof AWARENESS_MODAL_DISMISS_METHOD];

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/analytics/featureIntroAnalytics.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/analytics/featureIntroAnalytics.ts
@@ -1,0 +1,82 @@
+import type { GenericAwarenessModalFeatureIntro } from "@ledgerhq/live-common/genericAwarenessModal";
+import { track, trackPage } from "~/renderer/analytics/segment";
+import {
+  PAGE_TRACKING_AWARENESS_MODAL_FEATURE_INTRO,
+  type AwarenessModalDismissMethod,
+} from "./const";
+
+export type FeatureIntroAnalyticsContext = {
+  readonly page: typeof PAGE_TRACKING_AWARENESS_MODAL_FEATURE_INTRO;
+  readonly contentId: string;
+};
+
+export const normalizeFeatureIntroButtonName = (label: string): string => label.trim().toLowerCase();
+
+export const getFeatureIntroAnalyticsContext = (
+  featureIntro: GenericAwarenessModalFeatureIntro,
+): FeatureIntroAnalyticsContext => ({
+  page: PAGE_TRACKING_AWARENESS_MODAL_FEATURE_INTRO,
+  contentId: featureIntro.id,
+});
+
+const getFeatureIntroPageProperties = (context: FeatureIntroAnalyticsContext) => ({
+  name: PAGE_TRACKING_AWARENESS_MODAL_FEATURE_INTRO,
+  contentId: context.contentId,
+});
+
+const getFeatureIntroInteractionProperties = (context: FeatureIntroAnalyticsContext) => ({
+  page: context.page,
+  contentId: context.contentId,
+});
+
+export const trackFeatureIntroPage = (featureIntro: GenericAwarenessModalFeatureIntro): void => {
+  const context = getFeatureIntroAnalyticsContext(featureIntro);
+  trackPage(
+    PAGE_TRACKING_AWARENESS_MODAL_FEATURE_INTRO,
+    undefined,
+    getFeatureIntroPageProperties(context),
+    true,
+    false,
+  );
+};
+
+export const trackFeatureIntroPrimaryClick = (
+  context: FeatureIntroAnalyticsContext,
+  buttonLabel: string,
+): void => {
+  track("button_clicked", {
+    button: normalizeFeatureIntroButtonName(buttonLabel),
+    ...getFeatureIntroInteractionProperties(context),
+    ctaPosition: "primary",
+  });
+};
+
+export const trackFeatureIntroSecondaryClick = (
+  context: FeatureIntroAnalyticsContext,
+  buttonLabel: string,
+): void => {
+  track("button_clicked", {
+    button: normalizeFeatureIntroButtonName(buttonLabel),
+    ...getFeatureIntroInteractionProperties(context),
+    ctaPosition: "secondary",
+  });
+};
+
+export const trackFeatureIntroCloseClick = (context: FeatureIntroAnalyticsContext): void => {
+  track("button_clicked", {
+    button: "close",
+    ...getFeatureIntroInteractionProperties(context),
+  });
+};
+
+export const trackFeatureIntroDismissed = (
+  context: FeatureIntroAnalyticsContext,
+  dismissMethod: AwarenessModalDismissMethod,
+): void => {
+  track("drawer_dismissed", {
+    drawer: PAGE_TRACKING_AWARENESS_MODAL_FEATURE_INTRO,
+    page: context.page,
+    contentId: context.contentId,
+    dismissMethod,
+  });
+};

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/components/CarouselContent.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/components/CarouselContent.tsx
@@ -47,6 +47,8 @@ function CarouselContentSlide({ title, subtitle, imageUrl }: Readonly<CarouselCo
 export type CarouselContentProps = {
   slides: GenericAwarenessModalCarouselSlide[];
   onSlidePrimaryClick: (slide: GenericAwarenessModalCarouselSlide) => void;
+  onSlideChange: (index: number) => void;
+  onContinueClick: (slideIndex: number, isLastSlide: boolean) => void;
   onClose: () => void;
 };
 
@@ -62,10 +64,12 @@ function CarouselContentProgress() {
 function CarouselContentFooter({
   slides,
   onSlidePrimaryClick,
+  onContinueClick,
   onClose,
 }: Readonly<{
   slides: GenericAwarenessModalCarouselSlide[];
   onSlidePrimaryClick: (slide: GenericAwarenessModalCarouselSlide) => void;
+  onContinueClick: (slideIndex: number, isLastSlide: boolean) => void;
   onClose: () => void;
 }>) {
   const { t } = useTranslation();
@@ -74,12 +78,13 @@ function CarouselContentFooter({
   const currentSlide = slides[currentIndex];
 
   const handleContinue = useCallback(() => {
+    onContinueClick(currentIndex, isLastSlide);
     if (isLastSlide) {
       onClose();
     } else {
       goToNext();
     }
-  }, [goToNext, isLastSlide, onClose]);
+  }, [currentIndex, goToNext, isLastSlide, onClose, onContinueClick]);
 
   const handlePrimary = useCallback(() => {
     if (currentSlide) {
@@ -114,10 +119,12 @@ function CarouselContentFooter({
 export default function CarouselContent({
   slides,
   onSlidePrimaryClick,
+  onSlideChange,
+  onContinueClick,
   onClose,
 }: Readonly<CarouselContentProps>) {
   return (
-    <Slides initialSlideIndex={0}>
+    <Slides initialSlideIndex={0} onSlideChange={onSlideChange}>
       <Slides.Content>
         {slides.map((slide, index) => (
           <Slides.Content.Item key={`${slide.title}-carousel-slide-${index}`}>
@@ -132,6 +139,7 @@ export default function CarouselContent({
         <CarouselContentFooter
           slides={slides}
           onSlidePrimaryClick={onSlidePrimaryClick}
+          onContinueClick={onContinueClick}
           onClose={onClose}
         />
       </Slides.Footer>

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/components/__tests__/CarouselContent.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/components/__tests__/CarouselContent.test.tsx
@@ -25,7 +25,13 @@ describe("CarouselContent", () => {
     const onSlidePrimaryClick = jest.fn();
     const onClose = jest.fn();
     render(
-      <CarouselContent slides={slides} onSlidePrimaryClick={onSlidePrimaryClick} onClose={onClose} />,
+      <CarouselContent
+        slides={slides}
+        onSlidePrimaryClick={onSlidePrimaryClick}
+        onSlideChange={jest.fn()}
+        onContinueClick={jest.fn()}
+        onClose={onClose}
+      />,
     );
 
     expect(screen.getByText("First slide title")).toBeVisible();
@@ -39,7 +45,13 @@ describe("CarouselContent", () => {
     const onSlidePrimaryClick = jest.fn();
     const onClose = jest.fn();
     const { user } = render(
-      <CarouselContent slides={slides} onSlidePrimaryClick={onSlidePrimaryClick} onClose={onClose} />,
+      <CarouselContent
+        slides={slides}
+        onSlidePrimaryClick={onSlidePrimaryClick}
+        onSlideChange={jest.fn()}
+        onContinueClick={jest.fn()}
+        onClose={onClose}
+      />,
     );
 
     await user.click(screen.getByTestId("generic-awareness-modal-continue-button"));
@@ -61,7 +73,13 @@ describe("CarouselContent", () => {
     const onSlidePrimaryClick = jest.fn();
     const onClose = jest.fn();
     const { user } = render(
-      <CarouselContent slides={slides} onSlidePrimaryClick={onSlidePrimaryClick} onClose={onClose} />,
+      <CarouselContent
+        slides={slides}
+        onSlidePrimaryClick={onSlidePrimaryClick}
+        onSlideChange={jest.fn()}
+        onContinueClick={jest.fn()}
+        onClose={onClose}
+      />,
     );
 
     await user.click(screen.getByTestId("generic-awareness-modal-primary-button"));
@@ -74,7 +92,13 @@ describe("CarouselContent", () => {
     const onSlidePrimaryClick = jest.fn();
     const onClose = jest.fn();
     const { user } = render(
-      <CarouselContent slides={slides} onSlidePrimaryClick={onSlidePrimaryClick} onClose={onClose} />,
+      <CarouselContent
+        slides={slides}
+        onSlidePrimaryClick={onSlidePrimaryClick}
+        onSlideChange={jest.fn()}
+        onContinueClick={jest.fn()}
+        onClose={onClose}
+      />,
     );
 
     await user.click(screen.getByTestId("generic-awareness-modal-continue-button"));

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/__tests__/useGenericAwarenessModalCarouselAnalytics.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/__tests__/useGenericAwarenessModalCarouselAnalytics.test.tsx
@@ -1,0 +1,86 @@
+import { act } from "tests/testSetup";
+import { track, trackPage } from "~/renderer/analytics/segment";
+import { openURL } from "~/renderer/linking";
+import { closeGenericAwarenessModalDialog } from "LLD/features/GenericAwarenessModal/genericAwarenessModalDialog";
+import { carouselCampaignCard } from "../../__tests__/fixtures";
+import { AWARENESS_MODAL_DISMISS_METHOD } from "../../analytics/const";
+import useGenericAwarenessModalCarouselAnalytics from "../useGenericAwarenessModalCarouselAnalytics";
+import { renderHookWithStore } from "../testHelpers/renderHookWithStore";
+
+jest.mock("~/renderer/linking", () => ({
+  openURL: jest.fn(),
+}));
+
+jest.mock("LLD/features/GenericAwarenessModal/genericAwarenessModalDialog", () => ({
+  closeGenericAwarenessModalDialog: jest.fn(() => jest.fn()),
+}));
+
+describe("useGenericAwarenessModalCarouselAnalytics", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should track initial page when carousel opens", () => {
+    renderHookWithStore(() =>
+      useGenericAwarenessModalCarouselAnalytics(carouselCampaignCard, true),
+    );
+
+    expect(trackPage).toHaveBeenCalledWith(
+      "Awareness Modal Carousel",
+      undefined,
+      expect.objectContaining({ step: 1, navigationMethod: "initial" }),
+      true,
+      false,
+    );
+  });
+
+  it("should track primary click, close, dismiss, and tour completion", () => {
+    const { result } = renderHookWithStore(() =>
+      useGenericAwarenessModalCarouselAnalytics(carouselCampaignCard, true),
+    );
+
+    act(() => {
+      result.current.onSlidePrimaryClick(carouselCampaignCard.data[0]);
+    });
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({ button: "discover flex", ctaPosition: "primary" }),
+    );
+    expect(openURL).toHaveBeenCalledWith(carouselCampaignCard.data[0].primaryButtonLink);
+    expect(jest.mocked(closeGenericAwarenessModalDialog)).toHaveBeenCalled();
+
+    jest.clearAllMocks();
+
+    act(() => {
+      result.current.onHeaderClose();
+    });
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({ button: "close" }),
+    );
+
+    jest.clearAllMocks();
+
+    act(() => {
+      result.current.onDismiss(AWARENESS_MODAL_DISMISS_METHOD.backdropTap);
+    });
+    expect(track).toHaveBeenCalledWith(
+      "drawer_dismissed",
+      expect.objectContaining({ dismissMethod: AWARENESS_MODAL_DISMISS_METHOD.backdropTap }),
+    );
+
+    jest.clearAllMocks();
+
+    act(() => {
+      result.current.onContinueClick(3, true);
+    });
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({ button: "continue", step: 4 }),
+    );
+    expect(track).toHaveBeenCalledWith(
+      "tour_completed",
+      expect.objectContaining({ completed: "yes", step: 4 }),
+    );
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/__tests__/useGenericAwarenessModalCarouselViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/__tests__/useGenericAwarenessModalCarouselViewModel.test.tsx
@@ -1,4 +1,5 @@
 import { act } from "tests/testSetup";
+import { track, trackPage } from "~/renderer/analytics/segment";
 import { openURL } from "~/renderer/linking";
 import { closeGenericAwarenessModalDialog } from "LLD/features/GenericAwarenessModal/genericAwarenessModalDialog";
 import { appStartFeatureIntroCard, carouselCampaignCard } from "../../__tests__/fixtures";
@@ -20,7 +21,7 @@ describe("useGenericAwarenessModalCarouselViewModel", () => {
 
   it("should return empty slides when content card is undefined", () => {
     const { result } = renderHookWithStore(() =>
-      useGenericAwarenessModalCarouselViewModel(undefined),
+      useGenericAwarenessModalCarouselViewModel(undefined, false),
     );
 
     expect(result.current.slides).toEqual([]);
@@ -28,7 +29,7 @@ describe("useGenericAwarenessModalCarouselViewModel", () => {
 
   it("should return empty slides when content card is not a carousel", () => {
     const { result } = renderHookWithStore(() =>
-      useGenericAwarenessModalCarouselViewModel(appStartFeatureIntroCard),
+      useGenericAwarenessModalCarouselViewModel(appStartFeatureIntroCard, false),
     );
 
     expect(result.current.slides).toEqual([]);
@@ -36,16 +37,17 @@ describe("useGenericAwarenessModalCarouselViewModel", () => {
 
   it("should expose carousel slides from the content card", () => {
     const { result } = renderHookWithStore(() =>
-      useGenericAwarenessModalCarouselViewModel(carouselCampaignCard),
+      useGenericAwarenessModalCarouselViewModel(carouselCampaignCard, true),
     );
 
     expect(result.current.slides).toEqual(carouselCampaignCard.data);
     expect(result.current.slides).toHaveLength(4);
+    expect(trackPage).toHaveBeenCalled();
   });
 
   it("should open slide link and close dialog on primary click", () => {
     const { result } = renderHookWithStore(() =>
-      useGenericAwarenessModalCarouselViewModel(carouselCampaignCard),
+      useGenericAwarenessModalCarouselViewModel(carouselCampaignCard, true),
     );
     expect(result.current.slides[0]).toEqual(carouselCampaignCard.data[0]);
 
@@ -53,13 +55,17 @@ describe("useGenericAwarenessModalCarouselViewModel", () => {
       result.current.onSlidePrimaryClick(carouselCampaignCard.data[0]);
     });
 
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({ ctaPosition: "primary" }),
+    );
     expect(openURL).toHaveBeenCalledWith("https://www.ledger.com/products/ledger-flex");
     expect(jest.mocked(closeGenericAwarenessModalDialog)).toHaveBeenCalled();
   });
 
   it("should close dialog when onClose is called", () => {
     const { result } = renderHookWithStore(() =>
-      useGenericAwarenessModalCarouselViewModel(carouselCampaignCard),
+      useGenericAwarenessModalCarouselViewModel(carouselCampaignCard, true),
     );
 
     act(() => {

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/__tests__/useGenericAwarenessModalFeatureIntroAnalytics.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/__tests__/useGenericAwarenessModalFeatureIntroAnalytics.test.tsx
@@ -1,0 +1,85 @@
+import { act } from "tests/testSetup";
+import { track, trackPage } from "~/renderer/analytics/segment";
+import { openURL } from "~/renderer/linking";
+import { closeGenericAwarenessModalDialog } from "LLD/features/GenericAwarenessModal/genericAwarenessModalDialog";
+import { appStartFeatureIntroCard } from "../../__tests__/fixtures";
+import { AWARENESS_MODAL_DISMISS_METHOD } from "../../analytics/const";
+import useGenericAwarenessModalFeatureIntroAnalytics from "../useGenericAwarenessModalFeatureIntroAnalytics";
+import { renderHookWithStore } from "../testHelpers/renderHookWithStore";
+
+jest.mock("~/renderer/linking", () => ({
+  openURL: jest.fn(),
+}));
+
+jest.mock("LLD/features/GenericAwarenessModal/genericAwarenessModalDialog", () => ({
+  closeGenericAwarenessModalDialog: jest.fn(() => jest.fn()),
+}));
+
+describe("useGenericAwarenessModalFeatureIntroAnalytics", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should track page when feature intro opens", () => {
+    renderHookWithStore(() =>
+      useGenericAwarenessModalFeatureIntroAnalytics(appStartFeatureIntroCard, true),
+    );
+
+    expect(trackPage).toHaveBeenCalledWith(
+      "Awareness Modal Feature Intro",
+      undefined,
+      expect.objectContaining({ contentId: appStartFeatureIntroCard.id }),
+      true,
+      false,
+    );
+  });
+
+  it("should track primary, secondary, close, and dismiss interactions", () => {
+    const { result } = renderHookWithStore(() =>
+      useGenericAwarenessModalFeatureIntroAnalytics(appStartFeatureIntroCard, true),
+    );
+
+    act(() => {
+      result.current.onPrimaryClick();
+    });
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({ button: "got it", ctaPosition: "primary" }),
+    );
+    expect(openURL).toHaveBeenCalledWith(appStartFeatureIntroCard.primaryButtonLink);
+    expect(jest.mocked(closeGenericAwarenessModalDialog)).toHaveBeenCalled();
+
+    jest.clearAllMocks();
+
+    act(() => {
+      result.current.onSecondaryClick();
+    });
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({ button: "compare signers", ctaPosition: "secondary" }),
+    );
+
+    jest.clearAllMocks();
+
+    act(() => {
+      result.current.onHeaderClose();
+    });
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({ button: "close" }),
+    );
+
+    jest.clearAllMocks();
+
+    act(() => {
+      result.current.onDismiss(AWARENESS_MODAL_DISMISS_METHOD.backdropTap);
+    });
+    expect(track).toHaveBeenCalledWith(
+      "drawer_dismissed",
+      expect.objectContaining({
+        dismissMethod: AWARENESS_MODAL_DISMISS_METHOD.backdropTap,
+        contentId: appStartFeatureIntroCard.id,
+      }),
+    );
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/__tests__/useGenericAwarenessModalFeatureIntroViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/__tests__/useGenericAwarenessModalFeatureIntroViewModel.test.tsx
@@ -1,4 +1,5 @@
 import { act } from "tests/testSetup";
+import { track, trackPage } from "~/renderer/analytics/segment";
 import { openURL } from "~/renderer/linking";
 import { closeGenericAwarenessModalDialog } from "LLD/features/GenericAwarenessModal/genericAwarenessModalDialog";
 import { appStartFeatureIntroCard, carouselCampaignCard } from "../../__tests__/fixtures";
@@ -20,7 +21,7 @@ describe("useGenericAwarenessModalFeatureIntroViewModel", () => {
 
   it("should return empty content when content card is undefined", () => {
     const { result } = renderHookWithStore(() =>
-      useGenericAwarenessModalFeatureIntroViewModel(undefined),
+      useGenericAwarenessModalFeatureIntroViewModel(undefined, false),
     );
 
     expect(result.current).toEqual({
@@ -32,12 +33,14 @@ describe("useGenericAwarenessModalFeatureIntroViewModel", () => {
       imageUrl: undefined,
       onPrimaryClick: expect.any(Function),
       onSecondaryClick: expect.any(Function),
+      onHeaderClose: expect.any(Function),
+      onDismiss: expect.any(Function),
     });
   });
 
   it("should return empty content when content card is not feature intro", () => {
     const { result } = renderHookWithStore(() =>
-      useGenericAwarenessModalFeatureIntroViewModel(carouselCampaignCard),
+      useGenericAwarenessModalFeatureIntroViewModel(carouselCampaignCard, false),
     );
 
     expect(result.current.title).toBe("");
@@ -46,7 +49,7 @@ describe("useGenericAwarenessModalFeatureIntroViewModel", () => {
 
   it("should map feature intro content from the content card", () => {
     const { result } = renderHookWithStore(() =>
-      useGenericAwarenessModalFeatureIntroViewModel(appStartFeatureIntroCard),
+      useGenericAwarenessModalFeatureIntroViewModel(appStartFeatureIntroCard, true),
     );
 
     expect(result.current.title).toBe("Connect a Ledger device");
@@ -61,6 +64,7 @@ describe("useGenericAwarenessModalFeatureIntroViewModel", () => {
       subtitle: "Build your portfolio with the simplicity of exchanges and security of a signer.",
       icon: "HandCoins",
     });
+    expect(trackPage).toHaveBeenCalled();
   });
 
   it("should fall back to Gift icon when icon name is invalid", () => {
@@ -70,7 +74,7 @@ describe("useGenericAwarenessModalFeatureIntroViewModel", () => {
     };
 
     const { result } = renderHookWithStore(() =>
-      useGenericAwarenessModalFeatureIntroViewModel(cardWithInvalidIcon),
+      useGenericAwarenessModalFeatureIntroViewModel(cardWithInvalidIcon, true),
     );
 
     expect(result.current.items[0]?.icon).toBe("Gift");
@@ -78,26 +82,34 @@ describe("useGenericAwarenessModalFeatureIntroViewModel", () => {
 
   it("should open primary link and close dialog on primary click", () => {
     const { result } = renderHookWithStore(() =>
-      useGenericAwarenessModalFeatureIntroViewModel(appStartFeatureIntroCard),
+      useGenericAwarenessModalFeatureIntroViewModel(appStartFeatureIntroCard, true),
     );
 
     act(() => {
       result.current.onPrimaryClick();
     });
 
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({ button: "got it", ctaPosition: "primary" }),
+    );
     expect(openURL).toHaveBeenCalledWith("https://www.ledger.com");
     expect(jest.mocked(closeGenericAwarenessModalDialog)).toHaveBeenCalled();
   });
 
   it("should open secondary link and close dialog on secondary click", () => {
     const { result } = renderHookWithStore(() =>
-      useGenericAwarenessModalFeatureIntroViewModel(appStartFeatureIntroCard),
+      useGenericAwarenessModalFeatureIntroViewModel(appStartFeatureIntroCard, true),
     );
 
     act(() => {
       result.current.onSecondaryClick();
     });
 
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({ button: "compare signers", ctaPosition: "secondary" }),
+    );
     expect(openURL).toHaveBeenCalledWith("https://www.ledger.com/compare-ledger-signers");
     expect(jest.mocked(closeGenericAwarenessModalDialog)).toHaveBeenCalled();
   });

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/useGenericAwarenessModalCarouselAnalytics.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/useGenericAwarenessModalCarouselAnalytics.ts
@@ -1,0 +1,140 @@
+import { useCallback, useEffect, useRef } from "react";
+import { useDispatch } from "LLD/hooks/redux";
+import {
+  GenericAwarenessModalLayout,
+  type GenericAwarenessModalCarousel,
+  type GenericAwarenessModalCarouselSlide,
+  type GenericAwarenessModalContentCard,
+} from "@ledgerhq/live-common/genericAwarenessModal";
+import { openURL } from "~/renderer/linking";
+import { closeGenericAwarenessModalDialog } from "../genericAwarenessModalDialog";
+import {
+  getCarouselAnalyticsContext,
+  trackCarouselCloseClick,
+  trackCarouselContinueClick,
+  trackCarouselDismissed,
+  trackCarouselInitialStep,
+  trackCarouselPrimaryClick,
+  trackCarouselStepNavigation,
+  trackCarouselTourCompleted,
+} from "../analytics/carouselAnalytics";
+import type { AwarenessModalDismissMethod } from "../analytics/const";
+
+export interface GenericAwarenessModalCarouselAnalyticsHandlers {
+  readonly onSlideChange: (index: number) => void;
+  readonly onSlidePrimaryClick: (slide: GenericAwarenessModalCarouselSlide) => void;
+  readonly onContinueClick: (slideIndex: number, isLastSlide: boolean) => void;
+  readonly onHeaderClose: () => void;
+  readonly onDismiss: (dismissMethod: AwarenessModalDismissMethod) => void;
+  readonly onClose: () => void;
+}
+
+const useGenericAwarenessModalCarouselAnalytics = (
+  contentCard: GenericAwarenessModalContentCard | undefined,
+  isOpen: boolean,
+): GenericAwarenessModalCarouselAnalyticsHandlers => {
+  const dispatch = useDispatch();
+  const currentIndexRef = useRef(0);
+  const hasTrackedOpenRef = useRef(false);
+
+  const carousel: GenericAwarenessModalCarousel | undefined =
+    contentCard?.layout === GenericAwarenessModalLayout.Carousel ? contentCard : undefined;
+
+  const closeDialog = useCallback(() => {
+    dispatch(closeGenericAwarenessModalDialog());
+  }, [dispatch]);
+
+  const getContext = useCallback(
+    (slideIndex: number) => {
+      if (!carousel) {
+        return undefined;
+      }
+      return getCarouselAnalyticsContext(carousel, slideIndex);
+    },
+    [carousel],
+  );
+
+  useEffect(() => {
+    if (!isOpen || !carousel) {
+      hasTrackedOpenRef.current = false;
+      return;
+    }
+
+    if (hasTrackedOpenRef.current) {
+      return;
+    }
+
+    hasTrackedOpenRef.current = true;
+    currentIndexRef.current = 0;
+    trackCarouselInitialStep(carousel);
+  }, [carousel, isOpen]);
+
+  const onSlideChange = useCallback(
+    (index: number) => {
+      currentIndexRef.current = index;
+      if (!carousel) {
+        return;
+      }
+      trackCarouselStepNavigation(carousel, index);
+    },
+    [carousel],
+  );
+
+  const onSlidePrimaryClick = useCallback(
+    (slide: GenericAwarenessModalCarouselSlide) => {
+      const context = getContext(currentIndexRef.current);
+      if (context) {
+        trackCarouselPrimaryClick(context, slide.primaryButtonLabel);
+      }
+      openURL(slide.primaryButtonLink);
+      closeDialog();
+    },
+    [closeDialog, getContext],
+  );
+
+  const onContinueClick = useCallback(
+    (slideIndex: number, isLastSlide: boolean) => {
+      currentIndexRef.current = slideIndex;
+      const context = getContext(slideIndex);
+      if (!context) {
+        return;
+      }
+
+      trackCarouselContinueClick(context);
+      if (isLastSlide) {
+        trackCarouselTourCompleted(context);
+      }
+    },
+    [getContext],
+  );
+
+  const onHeaderClose = useCallback(() => {
+    const context = getContext(currentIndexRef.current);
+    if (context) {
+      trackCarouselCloseClick(context);
+    }
+    closeDialog();
+  }, [closeDialog, getContext]);
+
+  const onDismiss = useCallback(
+    (dismissMethod: AwarenessModalDismissMethod) => {
+      const context = getContext(currentIndexRef.current);
+      if (context) {
+        trackCarouselDismissed(context, dismissMethod);
+      }
+      closeDialog();
+    },
+    [closeDialog, getContext],
+  );
+
+  return {
+    onSlideChange,
+    onSlidePrimaryClick,
+    onContinueClick,
+    onHeaderClose,
+    onDismiss,
+    onClose: closeDialog,
+  };
+};
+
+export default useGenericAwarenessModalCarouselAnalytics;

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/useGenericAwarenessModalCarouselViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/useGenericAwarenessModalCarouselViewModel.ts
@@ -1,46 +1,42 @@
-import { useCallback, useMemo } from "react";
-import { useDispatch } from "LLD/hooks/redux";
+import { useMemo } from "react";
 import {
   GenericAwarenessModalLayout,
   type GenericAwarenessModalCarouselSlide,
   type GenericAwarenessModalContentCard,
 } from "@ledgerhq/live-common/genericAwarenessModal";
-import { closeGenericAwarenessModalDialog } from "../genericAwarenessModalDialog";
-import { openURL } from "~/renderer/linking";
+import type { AwarenessModalDismissMethod } from "../analytics/const";
+import useGenericAwarenessModalCarouselAnalytics from "./useGenericAwarenessModalCarouselAnalytics";
 
 export interface GenericAwarenessModalCarouselViewModel {
   slides: GenericAwarenessModalCarouselSlide[];
   onSlidePrimaryClick: (slide: GenericAwarenessModalCarouselSlide) => void;
+  onSlideChange: (index: number) => void;
+  onContinueClick: (slideIndex: number, isLastSlide: boolean) => void;
+  onHeaderClose: () => void;
+  onDismiss: (dismissMethod: AwarenessModalDismissMethod) => void;
   onClose: () => void;
 }
 
 const useGenericAwarenessModalCarouselViewModel = (
   contentCard: GenericAwarenessModalContentCard | undefined,
+  isOpen: boolean,
 ): GenericAwarenessModalCarouselViewModel => {
-  const dispatch = useDispatch();
-
   const carousel =
     contentCard?.layout === GenericAwarenessModalLayout.Carousel ? contentCard : undefined;
 
-  const onClose = useCallback(() => {
-    dispatch(closeGenericAwarenessModalDialog());
-  }, [dispatch]);
-
-  const onSlidePrimaryClick = useCallback(
-    (slide: GenericAwarenessModalCarouselSlide) => {
-      openURL(slide.primaryButtonLink);
-      onClose();
-    },
-    [onClose],
-  );
+  const analytics = useGenericAwarenessModalCarouselAnalytics(contentCard, isOpen);
 
   return useMemo(
     () => ({
       slides: carousel?.data ?? [],
-      onSlidePrimaryClick,
-      onClose,
+      onSlidePrimaryClick: analytics.onSlidePrimaryClick,
+      onSlideChange: analytics.onSlideChange,
+      onContinueClick: analytics.onContinueClick,
+      onHeaderClose: analytics.onHeaderClose,
+      onDismiss: analytics.onDismiss,
+      onClose: analytics.onClose,
     }),
-    [carousel, onClose, onSlidePrimaryClick],
+    [analytics, carousel?.data],
   );
 };
 

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/useGenericAwarenessModalFeatureIntroAnalytics.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/useGenericAwarenessModalFeatureIntroAnalytics.ts
@@ -1,0 +1,107 @@
+import { useCallback, useEffect, useRef } from "react";
+import { useDispatch } from "LLD/hooks/redux";
+import {
+  GenericAwarenessModalLayout,
+  type GenericAwarenessModalContentCard,
+  type GenericAwarenessModalFeatureIntro,
+} from "@ledgerhq/live-common/genericAwarenessModal";
+import { openURL } from "~/renderer/linking";
+import { closeGenericAwarenessModalDialog } from "../genericAwarenessModalDialog";
+import {
+  getFeatureIntroAnalyticsContext,
+  trackFeatureIntroCloseClick,
+  trackFeatureIntroDismissed,
+  trackFeatureIntroPage,
+  trackFeatureIntroPrimaryClick,
+  trackFeatureIntroSecondaryClick,
+} from "../analytics/featureIntroAnalytics";
+import type { AwarenessModalDismissMethod } from "../analytics/const";
+
+export interface GenericAwarenessModalFeatureIntroAnalyticsHandlers {
+  readonly onPrimaryClick: () => void;
+  readonly onSecondaryClick: () => void;
+  readonly onHeaderClose: () => void;
+  readonly onDismiss: (dismissMethod: AwarenessModalDismissMethod) => void;
+}
+
+const useGenericAwarenessModalFeatureIntroAnalytics = (
+  contentCard: GenericAwarenessModalContentCard | undefined,
+  isOpen: boolean,
+): GenericAwarenessModalFeatureIntroAnalyticsHandlers => {
+  const dispatch = useDispatch();
+  const hasTrackedOpenRef = useRef(false);
+
+  const featureIntro: GenericAwarenessModalFeatureIntro | undefined =
+    contentCard?.layout === GenericAwarenessModalLayout.FeatureIntro ? contentCard : undefined;
+
+  const closeDialog = useCallback(() => {
+    dispatch(closeGenericAwarenessModalDialog());
+  }, [dispatch]);
+
+  const getContext = useCallback(() => {
+    if (!featureIntro) {
+      return undefined;
+    }
+    return getFeatureIntroAnalyticsContext(featureIntro);
+  }, [featureIntro]);
+
+  useEffect(() => {
+    if (!isOpen || !featureIntro) {
+      hasTrackedOpenRef.current = false;
+      return;
+    }
+
+    if (hasTrackedOpenRef.current) {
+      return;
+    }
+
+    hasTrackedOpenRef.current = true;
+    trackFeatureIntroPage(featureIntro);
+  }, [featureIntro, isOpen]);
+
+  const onPrimaryClick = useCallback(() => {
+    const context = getContext();
+    if (context && featureIntro) {
+      trackFeatureIntroPrimaryClick(context, featureIntro.primaryButtonLabel);
+      openURL(featureIntro.primaryButtonLink);
+    }
+    closeDialog();
+  }, [closeDialog, featureIntro, getContext]);
+
+  const onSecondaryClick = useCallback(() => {
+    const context = getContext();
+    if (context && featureIntro) {
+      trackFeatureIntroSecondaryClick(context, featureIntro.secondaryButtonLabel);
+      openURL(featureIntro.secondaryButtonLink);
+    }
+    closeDialog();
+  }, [closeDialog, featureIntro, getContext]);
+
+  const onHeaderClose = useCallback(() => {
+    const context = getContext();
+    if (context) {
+      trackFeatureIntroCloseClick(context);
+    }
+    closeDialog();
+  }, [closeDialog, getContext]);
+
+  const onDismiss = useCallback(
+    (dismissMethod: AwarenessModalDismissMethod) => {
+      const context = getContext();
+      if (context) {
+        trackFeatureIntroDismissed(context, dismissMethod);
+      }
+      closeDialog();
+    },
+    [closeDialog, getContext],
+  );
+
+  return {
+    onPrimaryClick,
+    onSecondaryClick,
+    onHeaderClose,
+    onDismiss,
+  };
+};
+
+export default useGenericAwarenessModalFeatureIntroAnalytics;

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/useGenericAwarenessModalFeatureIntroViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/useGenericAwarenessModalFeatureIntroViewModel.ts
@@ -1,17 +1,16 @@
-import { useCallback, useMemo } from "react";
-import { useDispatch } from "LLD/hooks/redux";
+import { useMemo } from "react";
 import * as Icons from "@ledgerhq/lumen-ui-react/symbols";
 import {
   GenericAwarenessModalLayout,
   type GenericAwarenessModalContentCard,
   type GenericAwarenessModalFeatureIntro,
 } from "@ledgerhq/live-common/genericAwarenessModal";
-import { closeGenericAwarenessModalDialog } from "../genericAwarenessModalDialog";
 import type {
   FeatureIntroContentItem,
   LumenSymbolName,
 } from "../components/FeatureIntroContent";
-import { openURL } from "~/renderer/linking";
+import type { AwarenessModalDismissMethod } from "../analytics/const";
+import useGenericAwarenessModalFeatureIntroAnalytics from "./useGenericAwarenessModalFeatureIntroAnalytics";
 
 export interface GenericAwarenessModalFeatureIntroViewModel {
   title: string;
@@ -22,6 +21,8 @@ export interface GenericAwarenessModalFeatureIntroViewModel {
   imageUrl?: string;
   onPrimaryClick: () => void;
   onSecondaryClick: () => void;
+  onHeaderClose: () => void;
+  onDismiss: (dismissMethod: AwarenessModalDismissMethod) => void;
 }
 
 // hasOwn checks only exported symbol keys; `in` would also match Object.prototype names (e.g. "toString").
@@ -38,25 +39,12 @@ const mapFeatureIntroItems = (
 
 const useGenericAwarenessModalFeatureIntroViewModel = (
   contentCard: GenericAwarenessModalContentCard | undefined,
+  isOpen: boolean,
 ): GenericAwarenessModalFeatureIntroViewModel => {
-  const dispatch = useDispatch();
-
   const featureIntro =
     contentCard?.layout === GenericAwarenessModalLayout.FeatureIntro ? contentCard : undefined;
 
-  const onPrimaryClick = useCallback(() => {
-    if (featureIntro) {
-      openURL(featureIntro.primaryButtonLink);
-      dispatch(closeGenericAwarenessModalDialog());
-    }
-  }, [dispatch, featureIntro]);
-
-  const onSecondaryClick = useCallback(() => {
-    if (featureIntro) {
-      openURL(featureIntro.secondaryButtonLink);
-      dispatch(closeGenericAwarenessModalDialog());
-    }
-  }, [dispatch, featureIntro]);
+  const analytics = useGenericAwarenessModalFeatureIntroAnalytics(contentCard, isOpen);
 
   return useMemo(
     () => ({
@@ -66,10 +54,12 @@ const useGenericAwarenessModalFeatureIntroViewModel = (
       primaryButtonLabel: featureIntro?.primaryButtonLabel ?? "",
       secondaryButtonLabel: featureIntro?.secondaryButtonLabel ?? "",
       imageUrl: featureIntro?.imageUrl || undefined,
-      onPrimaryClick,
-      onSecondaryClick,
+      onPrimaryClick: analytics.onPrimaryClick,
+      onSecondaryClick: analytics.onSecondaryClick,
+      onHeaderClose: analytics.onHeaderClose,
+      onDismiss: analytics.onDismiss,
     }),
-    [featureIntro, onPrimaryClick, onSecondaryClick],
+    [analytics, featureIntro],
   );
 };
 


### PR DESCRIPTION
## Summary
- Add/adjust Generic Awareness Modal tracking for carousel + feature intro flows.
- Align tracking payload key from `campaignId` to `contentId` (value unchanged).
- Simplify modal view handlers and update related Jest coverage.

## Test plan
- `pnpm desktop test:jest \"GenericAwarenessModal/analytics\" \"GenericAwarenessModal/hooks/__tests__\"`