### PR TITLE
[LWDM] feat(LIVE-30160): Celo pay with token - new send flow

### DIFF
--- a/.changeset/dry-lobsters-kick.md
+++ b/.changeset/dry-lobsters-kick.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/coin-celo": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Implements the Celo fee currency selection plugin across mobile and desktop. Users can now select a fee currency (CELO or supported tokens) to pay transaction fees. Updates include UI integration, gas estimation adjustments, and descriptor enhancements for Celo transactions.

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendFlowLayout.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendFlowLayout.tsx
@@ -9,11 +9,6 @@ import {
   type SendFlowStep,
   type SendFlowBusinessContext,
 } from "@ledgerhq/live-common/flows/send/types";
-import {
-  getAccountCurrency,
-  getMainAccount,
-} from "@ledgerhq/ledger-wallet-framework/account/helpers";
-import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
 import type { SendStepConfig } from "../types";
 import { SendHeader } from "./SendHeader";
 import { AnimatedHeight } from "./AnimatedHeight";
@@ -27,7 +22,7 @@ type SendFlowLayoutProps = Readonly<{
 
 export function SendFlowLayout({ isOpen, onClose }: SendFlowLayoutProps) {
   const wizard = useFlowWizard<SendFlowStep, SendFlowBusinessContext, SendStepConfig>();
-  const { state } = useSendFlowData();
+  const { state, uiConfig } = useSendFlowData();
 
   const currentStepConfig = wizard.currentStepConfig;
   const StepComponent = wizard.currentStepRenderer;
@@ -50,15 +45,8 @@ export function SendFlowLayout({ isOpen, onClose }: SendFlowLayoutProps) {
     [onClose, wizard.currentStep, sendFlowTrackingProperties],
   );
 
-  const accountCurrency = useMemo(() => {
-    if (!state.account.account) return undefined;
-    return getAccountCurrency(
-      getMainAccount(state.account.account, state.account.parentAccount ?? undefined),
-    );
-  }, [state.account.account, state.account.parentAccount]);
   const hasAmountPlugins =
-    wizard.currentStep === SEND_FLOW_STEP.AMOUNT &&
-    sendFeatures.getAmountPlugins(accountCurrency).length > 0;
+    wizard.currentStep === SEND_FLOW_STEP.AMOUNT && uiConfig.hasAmountPlugins;
 
   const dialogHeight = hasAmountPlugins ? "fixed" : (currentStepConfig?.height ?? "fixed");
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendFlowLayout.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendFlowLayout.tsx
@@ -4,7 +4,16 @@ import { cn } from "LLD/utils/cn";
 import { useFlowWizard } from "../../FlowWizard/FlowWizardContext";
 import { useSendFlowData } from "../context/SendFlowContext";
 import { FLOW_STATUS } from "@ledgerhq/live-common/flows/wizard/types";
-import type { SendFlowStep, SendFlowBusinessContext } from "@ledgerhq/live-common/flows/send/types";
+import {
+  SEND_FLOW_STEP,
+  type SendFlowStep,
+  type SendFlowBusinessContext,
+} from "@ledgerhq/live-common/flows/send/types";
+import {
+  getAccountCurrency,
+  getMainAccount,
+} from "@ledgerhq/ledger-wallet-framework/account/helpers";
+import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
 import type { SendStepConfig } from "../types";
 import { SendHeader } from "./SendHeader";
 import { AnimatedHeight } from "./AnimatedHeight";
@@ -41,7 +50,17 @@ export function SendFlowLayout({ isOpen, onClose }: SendFlowLayoutProps) {
     [onClose, wizard.currentStep, sendFlowTrackingProperties],
   );
 
-  const dialogHeight = currentStepConfig?.height ?? "fixed";
+  const accountCurrency = useMemo(() => {
+    if (!state.account.account) return undefined;
+    return getAccountCurrency(
+      getMainAccount(state.account.account, state.account.parentAccount ?? undefined),
+    );
+  }, [state.account.account, state.account.parentAccount]);
+  const hasAmountPlugins =
+    wizard.currentStep === SEND_FLOW_STEP.AMOUNT &&
+    sendFeatures.getAmountPlugins(accountCurrency).length > 0;
+
+  const dialogHeight = hasAmountPlugins ? "fixed" : (currentStepConfig?.height ?? "fixed");
 
   const shouldShowStatusGradient =
     state.flowStatus === FLOW_STATUS.ERROR || state.flowStatus === FLOW_STATUS.SUCCESS;

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/constants.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/constants.ts
@@ -30,7 +30,7 @@ export const SEND_STEP_CONFIGS: Record<SendFlowStep, SendStepConfig> = {
     id: SEND_FLOW_STEP.AMOUNT,
     canGoBack: true,
     addressInput: true,
-    height: "fit",
+    height: "fixed",
   },
   [SEND_FLOW_STEP.CUSTOM_FEES]: {
     id: SEND_FLOW_STEP.CUSTOM_FEES,

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/constants.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/constants.ts
@@ -30,7 +30,7 @@ export const SEND_STEP_CONFIGS: Record<SendFlowStep, SendStepConfig> = {
     id: SEND_FLOW_STEP.AMOUNT,
     canGoBack: true,
     addressInput: true,
-    height: "fixed",
+    height: "fit",
   },
   [SEND_FLOW_STEP.CUSTOM_FEES]: {
     id: SEND_FLOW_STEP.CUSTOM_FEES,

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useFeeInfo.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useFeeInfo.test.ts
@@ -1,0 +1,132 @@
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+import { BigNumber } from "bignumber.js";
+import { renderHook } from "tests/testSetup";
+import { INITIAL_STATE as INITIAL_STATE_SETTINGS } from "~/renderer/reducers/settings";
+import { useFeeInfo } from "../useFeeInfo";
+import {
+  getAccountCurrency,
+  getMainAccount,
+} from "@ledgerhq/ledger-wallet-framework/account/helpers";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { createMockAccount } from "../../screens/Recipient/__integrations__/__fixtures__/accounts";
+import type { Account } from "@ledgerhq/types-live";
+import type { TransactionStatus } from "@ledgerhq/live-common/generated/types";
+
+jest.mock("@ledgerhq/ledger-wallet-framework/account/helpers");
+
+const mockedGetMainAccount = jest.mocked(getMainAccount);
+const mockedGetAccountCurrency = jest.mocked(getAccountCurrency);
+
+function isAccount(account: unknown): account is Account {
+  return (
+    typeof account === "object" &&
+    account !== null &&
+    "type" in account &&
+    (account as Account).type === "Account"
+  );
+}
+
+const usdcUnit = { name: "USD Coin", code: "USDC", magnitude: 6 };
+const usdcToken = {
+  type: "TokenCurrency",
+  id: "celo/erc20/usdc",
+  contractAddress: "0xceba9300f2b948710d2653dd7b07f33a8b32118c",
+  parentCurrency: { id: "celo" },
+  name: "USD Coin",
+  ticker: "USDC",
+  disableCountervalue: false,
+  units: [usdcUnit],
+};
+const usdcSubAccount = {
+  type: "TokenAccount",
+  id: "usdc-sub-account-id",
+  token: usdcToken,
+  balance: new BigNumber(100000),
+};
+
+function buildParams(overrides?: {
+  feeCurrencyAccountId?: string | null;
+  subAccounts?: unknown[];
+  estimatedFees?: BigNumber;
+}) {
+  const currency = getCryptoCurrencyById("bitcoin");
+  mockedGetAccountCurrency.mockReturnValue(currency);
+  mockedGetMainAccount.mockImplementation((account: Account | unknown) => {
+    if (!isAccount(account)) {
+      throw new Error("TokenAccount is not supported by this test helper");
+    }
+    return account;
+  });
+
+  const account = createMockAccount({
+    id: "acc",
+    currency,
+    subAccounts: (overrides?.subAccounts ?? []) as Account["subAccounts"],
+  });
+  const status = {
+    errors: {},
+    warnings: {},
+    estimatedFees: overrides?.estimatedFees ?? new BigNumber(500000),
+    amount: new BigNumber(0),
+    totalSpent: new BigNumber(0),
+  } as TransactionStatus;
+
+  return {
+    account,
+    parentAccount: null as Account | null,
+    status,
+    feeCurrencyAccountId: overrides?.feeCurrencyAccountId,
+  };
+}
+
+describe("useFeeInfo", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("formats crypto value with the token unit when feeCurrencyAccountId resolves to a sub-account", () => {
+    const params = buildParams({
+      feeCurrencyAccountId: "usdc-sub-account-id",
+      subAccounts: [usdcSubAccount],
+    });
+    const { result } = renderHook(() => useFeeInfo(params), {
+      initialState: { settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" } },
+    });
+
+    expect(result.current.feeSummary).not.toBeNull();
+    expect(result.current.feeSummary?.cryptoLabel).toContain("USDC");
+    expect(result.current.feeSummary?.cryptoValue).toContain("USDC");
+  });
+
+  it("falls back to the parent account unit when feeCurrencyAccountId is not provided", () => {
+    const params = buildParams({ feeCurrencyAccountId: null });
+    const { result } = renderHook(() => useFeeInfo(params), {
+      initialState: { settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" } },
+    });
+
+    expect(result.current.feeSummary?.cryptoLabel).toContain("BTC");
+    expect(result.current.feeSummary?.cryptoValue).toContain("BTC");
+  });
+
+  it("falls back to the parent account unit when feeCurrencyAccountId is stale", () => {
+    const params = buildParams({
+      feeCurrencyAccountId: "missing-id",
+      subAccounts: [],
+    });
+    const { result } = renderHook(() => useFeeInfo(params), {
+      initialState: { settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" } },
+    });
+
+    expect(result.current.feeSummary?.cryptoLabel).toContain("BTC");
+    expect(result.current.feeSummary?.cryptoValue).toContain("BTC");
+  });
+
+  it("returns null feeSummary when estimatedFees is zero and no countervalue is available", () => {
+    const params = buildParams({ estimatedFees: new BigNumber(0) });
+    const { result } = renderHook(() => useFeeInfo(params), {
+      initialState: { settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" } },
+    });
+
+    expect(result.current.feeSummary).toBeNull();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useNetworkFees.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useNetworkFees.test.ts
@@ -23,6 +23,7 @@ jest.mock("@ledgerhq/live-common/bridge/descriptor/send/features", () => ({
     hasFeePresets: jest.fn(() => false),
     shouldEstimateFeePresetsWithBridge: jest.fn(() => false),
     getFeePresetOptions: jest.fn(() => []),
+    getFeeCurrencyAccountId: jest.fn(() => null),
   },
 }));
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useFeeInfo.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useFeeInfo.ts
@@ -3,7 +3,7 @@ import { BigNumber } from "bignumber.js";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "LLD/hooks/redux";
 import { useCalculate } from "@ledgerhq/live-countervalues-react";
-import type { Account, AccountLike } from "@ledgerhq/types-live";
+import type { Account, AccountLike, TokenAccount } from "@ledgerhq/types-live";
 import type { TransactionStatus } from "@ledgerhq/live-common/generated/types";
 import { counterValueCurrencySelector, localeSelector } from "~/renderer/reducers/settings";
 import { useMaybeAccountUnit } from "~/renderer/hooks/useAccountUnit";
@@ -17,9 +17,15 @@ type UseFeeInfoParams = Readonly<{
   account: AccountLike;
   parentAccount: Account | null;
   status: TransactionStatus;
+  feeCurrencyAccountId?: string | null;
 }>;
 
-export function useFeeInfo({ account, parentAccount, status }: UseFeeInfoParams) {
+export function useFeeInfo({
+  account,
+  parentAccount,
+  status,
+  feeCurrencyAccountId,
+}: UseFeeInfoParams) {
   const { t } = useTranslation();
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
   const locale = useSelector(localeSelector);
@@ -33,12 +39,24 @@ export function useFeeInfo({ account, parentAccount, status }: UseFeeInfoParams)
   const accountUnit = useMaybeAccountUnit(mainAccount) ?? accountCurrency.units[0];
   const fiatUnit = counterValueCurrency.units[0];
 
+  const feeCurrencySubAccount = useMemo(() => {
+    if (!feeCurrencyAccountId) return null;
+    return (
+      ((mainAccount.subAccounts ?? []).find(
+        sub => sub.id === feeCurrencyAccountId && sub.type === "TokenAccount",
+      ) as TokenAccount | undefined) ?? null
+    );
+  }, [feeCurrencyAccountId, mainAccount.subAccounts]);
+
+  const displayUnit = feeCurrencySubAccount?.token.units[0] ?? accountUnit;
+  const displayCurrency = feeCurrencySubAccount?.token ?? accountCurrency;
+
   const estimatedFees = useMemo(
     () => status.estimatedFees ?? new BigNumber(0),
     [status.estimatedFees],
   );
   const estimatedFeesCountervalue = useCalculate({
-    from: accountCurrency,
+    from: displayCurrency,
     to: counterValueCurrency,
     value: estimatedFees.toNumber(),
     disableRounding: true,
@@ -61,9 +79,9 @@ export function useFeeInfo({ account, parentAccount, status }: UseFeeInfoParams)
               locale,
             }),
             cryptoLabel: t("newSendFlow.feesAmount", {
-              unit: accountUnit.code,
+              unit: displayUnit.code,
             }),
-            cryptoValue: formatCurrencyUnit(accountUnit, estimatedFees, {
+            cryptoValue: formatCurrencyUnit(displayUnit, estimatedFees, {
               showCode: true,
               disableRounding: true,
               locale,
@@ -72,7 +90,7 @@ export function useFeeInfo({ account, parentAccount, status }: UseFeeInfoParams)
           }
         : null,
     [
-      accountUnit,
+      displayUnit,
       counterValueCurrency.ticker,
       estimatedFees,
       estimatedFeesFiat,

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useFeeInfo.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useFeeInfo.ts
@@ -39,13 +39,13 @@ export function useFeeInfo({
   const accountUnit = useMaybeAccountUnit(mainAccount) ?? accountCurrency.units[0];
   const fiatUnit = counterValueCurrency.units[0];
 
-  const feeCurrencySubAccount = useMemo(() => {
+  const feeCurrencySubAccount = useMemo<TokenAccount | null>(() => {
     if (!feeCurrencyAccountId) return null;
-    return (
-      ((mainAccount.subAccounts ?? []).find(
-        sub => sub.id === feeCurrencyAccountId && sub.type === "TokenAccount",
-      ) as TokenAccount | undefined) ?? null
+    const found = (mainAccount.subAccounts ?? []).find(
+      (sub): sub is TokenAccount =>
+        sub.id === feeCurrencyAccountId && sub.type === "TokenAccount",
     );
+    return found ?? null;
   }, [feeCurrencyAccountId, mainAccount.subAccounts]);
 
   const displayUnit = feeCurrencySubAccount?.token.units[0] ?? accountUnit;

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useNetworkFees.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useNetworkFees.ts
@@ -74,8 +74,7 @@ export function useNetworkFees({
     feePresetOptions,
   });
 
-  const feeCurrencyAccountId =
-    transaction.family === "celo" ? (transaction.feeCurrencyAccountId ?? null) : null;
+  const feeCurrencyAccountId = sendFeatures.getFeeCurrencyAccountId(accountCurrency, transaction);
 
   const { feeSummary } = useFeeInfo({
     account,

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useNetworkFees.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useNetworkFees.ts
@@ -75,7 +75,7 @@ export function useNetworkFees({
   });
 
   const feeCurrencyAccountId =
-    (transaction as { feeCurrencyAccountId?: string | null }).feeCurrencyAccountId ?? null;
+    transaction.family === "celo" ? (transaction.feeCurrencyAccountId ?? null) : null;
 
   const { feeSummary } = useFeeInfo({
     account,

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useNetworkFees.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useNetworkFees.ts
@@ -74,10 +74,14 @@ export function useNetworkFees({
     feePresetOptions,
   });
 
+  const feeCurrencyAccountId =
+    (transaction as { feeCurrencyAccountId?: string | null }).feeCurrencyAccountId ?? null;
+
   const { feeSummary } = useFeeInfo({
     account,
     parentAccount,
     status,
+    feeCurrencyAccountId,
   });
 
   const bridge = useAccountBridge<Transaction>(account, parentAccount);

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/AmountScreenInner.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/AmountScreenInner.tsx
@@ -66,20 +66,25 @@ export function AmountScreenInner({
     onReview();
   }, [onReview, viewModel.quickActions, viewModel.selectedFeeStrategy, sendFlowTrackingProperties]);
 
-  return (
-    <>
+  const pluginsSlot = useMemo(
+    () => (
       <AmountPluginsHost
         account={account}
         parentAccount={parentAccount}
         transaction={transaction}
         transactionActions={transactionActions}
       />
-      <AmountScreenView
-        {...viewModel}
-        onReview={handleReview}
-        onGetFunds={onGetFunds}
-        onSelectCoinControl={onSelectCoinControl}
-      />
-    </>
+    ),
+    [account, parentAccount, transaction, transactionActions],
+  );
+
+  return (
+    <AmountScreenView
+      {...viewModel}
+      onReview={handleReview}
+      onGetFunds={onGetFunds}
+      onSelectCoinControl={onSelectCoinControl}
+      pluginsSlot={pluginsSlot}
+    />
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/AmountScreenView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/AmountScreenView.tsx
@@ -34,6 +34,7 @@ export function AmountScreenView({
   onSelectCoinControl,
   onReview,
   onGetFunds,
+  pluginsSlot,
 }: AmountScreenViewProps) {
   return (
     <>
@@ -53,6 +54,8 @@ export function AmountScreenView({
           />
 
           {showQuickActions ? <QuickActionsRow actions={quickActions} /> : null}
+
+          {pluginsSlot}
         </div>
       </DialogBody>
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/plugins/CeloFeeCurrencyPlugin.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/plugins/CeloFeeCurrencyPlugin.tsx
@@ -1,0 +1,164 @@
+import React, { useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import BigNumber from "bignumber.js";
+import type { Account, AccountLike, TokenAccount } from "@ledgerhq/types-live";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import type { Transaction as CeloTransaction } from "@ledgerhq/live-common/families/celo/types";
+import type { SendFlowTransactionActions } from "@ledgerhq/live-common/flows/send/types";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import {
+  FEE_CURRENCY_BY_CONTRACT,
+  FEE_CURRENCY_OPTIONS,
+} from "@ledgerhq/live-common/families/celo/logic";
+import {
+  Menu,
+  MenuTrigger,
+  MenuContent,
+  MenuRadioGroup,
+  MenuRadioItem,
+  ListItem,
+  ListItemLeading,
+  ListItemContent,
+  ListItemTitle,
+  ListItemTrailing,
+} from "@ledgerhq/lumen-ui-react";
+import { ChevronRight } from "@ledgerhq/lumen-ui-react/symbols";
+
+type Props = Readonly<{
+  account: AccountLike;
+  parentAccount: Account | null;
+  transaction: Transaction;
+  transactionActions: SendFlowTransactionActions;
+}>;
+
+const NATIVE_CELO_ID = "celo";
+
+function isCeloTransaction(tx: Transaction): tx is CeloTransaction {
+  return tx.family === "celo";
+}
+
+function CeloFeeCurrencyPluginInner({
+  account,
+  parentAccount,
+  transaction,
+  transactionActions,
+}: Props & { transaction: CeloTransaction }) {
+  const { t } = useTranslation();
+
+  const mainAccount = useMemo(
+    () => getMainAccount(account, parentAccount ?? undefined),
+    [account, parentAccount],
+  );
+
+  const tokenOptions: (TokenAccount & { feeCurrencyName: string })[] = useMemo(
+    () =>
+      (mainAccount.subAccounts ?? [])
+        .filter((sub): sub is TokenAccount => sub.type === "TokenAccount")
+        .filter(sub => new BigNumber(sub.balance).gt(0))
+        .filter(sub => FEE_CURRENCY_BY_CONTRACT.has(sub.token.contractAddress.toLowerCase()))
+        .map(sub => ({
+          ...sub,
+          feeCurrencyName:
+            FEE_CURRENCY_BY_CONTRACT.get(sub.token.contractAddress.toLowerCase())?.name ??
+            sub.token.name,
+        })),
+    [mainAccount.subAccounts],
+  );
+
+  const selectedId = transaction.feeCurrencyAccountId ?? NATIVE_CELO_ID;
+
+  const selectedLabel = useMemo(() => {
+    if (!transaction.feeCurrencyAccountId) return FEE_CURRENCY_OPTIONS[0].name;
+    const found = tokenOptions.find(t => t.id === transaction.feeCurrencyAccountId);
+    return found?.feeCurrencyName ?? FEE_CURRENCY_OPTIONS[0].name;
+  }, [transaction.feeCurrencyAccountId, tokenOptions]);
+
+  const onValueChange = useCallback(
+    (id: string) => {
+      if (id === NATIVE_CELO_ID) {
+        transactionActions.updateTransaction(tx => ({
+          ...tx,
+          feeCurrency: null,
+          feeCurrencyUnwrapped: null,
+          feeCurrencyAccountId: null,
+        }));
+        return;
+      }
+
+      const tokenAccount = tokenOptions.find(t => t.id === id);
+      if (!tokenAccount) return;
+
+      const contractAddress = tokenAccount.token.contractAddress;
+      const matchedOption = FEE_CURRENCY_BY_CONTRACT.get(contractAddress.toLowerCase());
+      if (!matchedOption) return;
+
+      const feeCurrency = matchedOption.adapterAddress ?? matchedOption.contractAddress ?? null;
+      const feeCurrencyUnwrapped = matchedOption.contractAddress ?? null;
+
+      transactionActions.updateTransaction(tx => ({
+        ...tx,
+        feeCurrency,
+        feeCurrencyUnwrapped,
+        feeCurrencyAccountId: tokenAccount.id,
+      }));
+    },
+    [tokenOptions, transactionActions],
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <span className="body-3 text-muted">{t("send.steps.amount.feeCurrency")}</span>
+      <Menu>
+        <MenuTrigger asChild>
+          <ListItem className="cursor-pointer" data-testid="send-celo-fee-currency-select">
+            <ListItemLeading>
+              <ListItemContent>
+                <ListItemTitle>{selectedLabel}</ListItemTitle>
+              </ListItemContent>
+            </ListItemLeading>
+            <ListItemTrailing>
+              <ChevronRight size={16} />
+            </ListItemTrailing>
+          </ListItem>
+        </MenuTrigger>
+        <MenuContent side="bottom" align="end">
+          <MenuRadioGroup value={selectedId} onValueChange={onValueChange}>
+            <MenuRadioItem
+              value={NATIVE_CELO_ID}
+              data-testid="send-celo-fee-currency-option-celo"
+            >
+              {FEE_CURRENCY_OPTIONS[0].name}
+            </MenuRadioItem>
+            {tokenOptions.map(tokenAccount => (
+              <MenuRadioItem
+                key={tokenAccount.id}
+                value={tokenAccount.id}
+                data-testid={`send-celo-fee-currency-option-${tokenAccount.feeCurrencyName.toLowerCase()}`}
+              >
+                {tokenAccount.feeCurrencyName}
+              </MenuRadioItem>
+            ))}
+          </MenuRadioGroup>
+        </MenuContent>
+      </Menu>
+    </div>
+  );
+}
+
+export function CeloFeeCurrencyPlugin({
+  account,
+  parentAccount,
+  transaction,
+  transactionActions,
+}: Props) {
+  if (!isCeloTransaction(transaction)) return null;
+
+  return (
+    <CeloFeeCurrencyPluginInner
+      account={account}
+      parentAccount={parentAccount}
+      transaction={transaction}
+      transactionActions={transactionActions}
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/plugins/CeloFeeCurrencyPlugin.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/plugins/CeloFeeCurrencyPlugin.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import BigNumber from "bignumber.js";
 import type { Account, AccountLike, TokenAccount } from "@ledgerhq/types-live";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import type { Transaction as CeloTransaction } from "@ledgerhq/live-common/families/celo/types";
@@ -54,7 +53,7 @@ function CeloFeeCurrencyPluginInner({
     () =>
       (mainAccount.subAccounts ?? [])
         .filter((sub): sub is TokenAccount => sub.type === "TokenAccount")
-        .filter(sub => new BigNumber(sub.balance).gt(0))
+        .filter(sub => sub.balance.gt(0))
         .filter(sub => FEE_CURRENCY_BY_CONTRACT.has(sub.token.contractAddress.toLowerCase()))
         .map(sub => ({
           ...sub,
@@ -67,18 +66,22 @@ function CeloFeeCurrencyPluginInner({
 
   const selectedId = transaction.feeCurrencyAccountId ?? NATIVE_CELO_ID;
 
-  useEffect(() => {
-    if (!transaction.feeCurrencyAccountId) return;
-    if (mainAccount.subAccounts === undefined) return;
-    const stillSelectable = tokenOptions.some(t => t.id === transaction.feeCurrencyAccountId);
-    if (stillSelectable) return;
+  const resetFeeCurrency = useCallback(() => {
     transactionActions.updateTransaction(tx => ({
       ...tx,
       feeCurrency: null,
       feeCurrencyUnwrapped: null,
       feeCurrencyAccountId: null,
     }));
-  }, [transaction.feeCurrencyAccountId, mainAccount.subAccounts, tokenOptions, transactionActions]);
+  }, [transactionActions]);
+
+  useEffect(() => {
+    if (!transaction.feeCurrencyAccountId) return;
+    if (mainAccount.subAccounts === undefined) return;
+    const stillSelectable = tokenOptions.some(t => t.id === transaction.feeCurrencyAccountId);
+    if (stillSelectable) return;
+    resetFeeCurrency();
+  }, [transaction.feeCurrencyAccountId, mainAccount.subAccounts, tokenOptions, resetFeeCurrency]);
 
   const selectedLabel = useMemo(() => {
     if (!transaction.feeCurrencyAccountId) return FEE_CURRENCY_OPTIONS[0].name;
@@ -98,12 +101,7 @@ function CeloFeeCurrencyPluginInner({
   const onValueChange = useCallback(
     (id: string) => {
       if (id === NATIVE_CELO_ID) {
-        transactionActions.updateTransaction(tx => ({
-          ...tx,
-          feeCurrency: null,
-          feeCurrencyUnwrapped: null,
-          feeCurrencyAccountId: null,
-        }));
+        resetFeeCurrency();
         return;
       }
 
@@ -124,7 +122,7 @@ function CeloFeeCurrencyPluginInner({
         feeCurrencyAccountId: tokenAccount.id,
       }));
     },
-    [tokenOptions, transactionActions],
+    [tokenOptions, transactionActions, resetFeeCurrency],
   );
 
   return (

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/plugins/CeloFeeCurrencyPlugin.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/plugins/CeloFeeCurrencyPlugin.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import BigNumber from "bignumber.js";
 import type { Account, AccountLike, TokenAccount } from "@ledgerhq/types-live";
@@ -66,6 +66,19 @@ function CeloFeeCurrencyPluginInner({
   );
 
   const selectedId = transaction.feeCurrencyAccountId ?? NATIVE_CELO_ID;
+
+  useEffect(() => {
+    if (!transaction.feeCurrencyAccountId) return;
+    if (mainAccount.subAccounts === undefined) return;
+    const stillSelectable = tokenOptions.some(t => t.id === transaction.feeCurrencyAccountId);
+    if (stillSelectable) return;
+    transactionActions.updateTransaction(tx => ({
+      ...tx,
+      feeCurrency: null,
+      feeCurrencyUnwrapped: null,
+      feeCurrencyAccountId: null,
+    }));
+  }, [transaction.feeCurrencyAccountId, mainAccount.subAccounts, tokenOptions, transactionActions]);
 
   const selectedLabel = useMemo(() => {
     if (!transaction.feeCurrencyAccountId) return FEE_CURRENCY_OPTIONS[0].name;

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/plugins/CeloFeeCurrencyPlugin.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/plugins/CeloFeeCurrencyPlugin.tsx
@@ -82,9 +82,18 @@ function CeloFeeCurrencyPluginInner({
 
   const selectedLabel = useMemo(() => {
     if (!transaction.feeCurrencyAccountId) return FEE_CURRENCY_OPTIONS[0].name;
+    // Resolve via the contract address on the transaction itself — always present
+    // when a token fee currency is selected, so the label stays correct even while
+    // sub-accounts are still hydrating.
+    if (transaction.feeCurrencyUnwrapped) {
+      const matched = FEE_CURRENCY_BY_CONTRACT.get(
+        transaction.feeCurrencyUnwrapped.toLowerCase(),
+      );
+      if (matched) return matched.name;
+    }
     const found = tokenOptions.find(t => t.id === transaction.feeCurrencyAccountId);
     return found?.feeCurrencyName ?? FEE_CURRENCY_OPTIONS[0].name;
-  }, [transaction.feeCurrencyAccountId, tokenOptions]);
+  }, [transaction.feeCurrencyAccountId, transaction.feeCurrencyUnwrapped, tokenOptions]);
 
   const onValueChange = useCallback(
     (id: string) => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/plugins/__tests__/CeloFeeCurrencyPlugin.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/plugins/__tests__/CeloFeeCurrencyPlugin.test.tsx
@@ -193,6 +193,19 @@ describe("CeloFeeCurrencyPlugin (mvvm)", () => {
     expect(mockUpdateTransaction).not.toHaveBeenCalled();
   });
 
+  it("shows the token label while sub-accounts are unhydrated when feeCurrencyUnwrapped is set", () => {
+    renderPlugin({
+      account: { subAccounts: undefined } as unknown as Partial<CeloAccount>,
+      transaction: {
+        feeCurrencyAccountId: "usdc-sub-account-id",
+        feeCurrencyUnwrapped: usdcContractAddress,
+      } as unknown as Partial<Transaction>,
+    });
+
+    const trigger = screen.getByTestId("send-celo-fee-currency-select");
+    expect(trigger).toHaveTextContent("USDC");
+  });
+
   it("falls back to CELO label when feeCurrencyAccountId points to an unknown contract", () => {
     renderPlugin({
       account: { subAccounts: [unknownTokenSubAccount] } as unknown as Partial<CeloAccount>,

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/plugins/__tests__/CeloFeeCurrencyPlugin.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/plugins/__tests__/CeloFeeCurrencyPlugin.test.tsx
@@ -1,0 +1,207 @@
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+import React from "react";
+import BigNumber from "bignumber.js";
+import { render, screen } from "tests/testSetup";
+import { CeloFeeCurrencyPlugin } from "../CeloFeeCurrencyPlugin";
+import type { Account } from "@ledgerhq/types-live";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import type { CeloAccount } from "@ledgerhq/live-common/families/celo/types";
+
+const mockUpdateTransaction = jest.fn();
+const transactionActions = {
+  updateTransaction: mockUpdateTransaction,
+  setTransaction: jest.fn(),
+  setRecipient: jest.fn(),
+  setAccount: jest.fn(),
+} as never;
+
+const usdcContractAddress = "0xceba9300f2b948710d2653dd7b07f33a8b32118c";
+const unknownContractAddress = "0x0000000000000000000000000000000000000001";
+
+const usdcSubAccount = {
+  type: "TokenAccount",
+  id: "usdc-sub-account-id",
+  parentId: "celo-account-id",
+  token: {
+    type: "TokenCurrency",
+    id: "celo/erc20/usdc",
+    contractAddress: usdcContractAddress,
+    parentCurrency: { id: "celo" },
+    name: "USD Coin",
+    ticker: "USDC",
+    units: [{ name: "USDC", code: "USDC", magnitude: 6 }],
+  },
+  balance: new BigNumber(100),
+  spendableBalance: new BigNumber(100),
+  creationDate: new Date(),
+  operationsCount: 0,
+  operations: [],
+  pendingOperations: [],
+  balanceHistoryCache: {
+    HOUR: { latestDate: null, balances: [] },
+    DAY: { latestDate: null, balances: [] },
+    WEEK: { latestDate: null, balances: [] },
+  },
+  swapHistory: [],
+};
+
+const unknownTokenSubAccount = {
+  ...usdcSubAccount,
+  id: "unknown-sub-account-id",
+  token: {
+    ...usdcSubAccount.token,
+    contractAddress: unknownContractAddress,
+    name: "Unknown Token",
+    ticker: "UNK",
+  },
+};
+
+const mockCeloAccount = {
+  type: "Account",
+  id: "celo-account-id",
+  seedIdentifier: "seed",
+  derivationMode: "",
+  index: 0,
+  freshAddress: "0xabc",
+  freshAddressPath: "44'/52752'/0'/0/0",
+  used: true,
+  balance: new BigNumber(1000),
+  spendableBalance: new BigNumber(1000),
+  creationDate: new Date(),
+  blockHeight: 100000,
+  currency: { id: "celo", family: "celo" },
+  operationsCount: 0,
+  operations: [],
+  pendingOperations: [],
+  lastSyncDate: new Date(),
+  balanceHistoryCache: {
+    HOUR: { latestDate: null, balances: [] },
+    DAY: { latestDate: null, balances: [] },
+    WEEK: { latestDate: null, balances: [] },
+  },
+  swapHistory: [],
+  subAccounts: [usdcSubAccount],
+};
+
+const baseTransaction = {
+  family: "celo" as const,
+  amount: new BigNumber(0),
+  recipient: "",
+  useAllAmount: false,
+  mode: "send" as const,
+  index: null,
+  fees: null,
+  feeCurrency: null,
+  feeCurrencyUnwrapped: null,
+  feeCurrencyAccountId: null,
+};
+
+function runUpdater(currentTx: object) {
+  return mockUpdateTransaction.mock.calls[0][0](currentTx);
+}
+
+function renderPlugin(overrides?: {
+  account?: Partial<CeloAccount>;
+  transaction?: Partial<Transaction>;
+}) {
+  const account = { ...mockCeloAccount, ...overrides?.account } as unknown as Account;
+  const transaction = { ...baseTransaction, ...overrides?.transaction } as unknown as Transaction;
+  return render(
+    <CeloFeeCurrencyPlugin
+      account={account}
+      parentAccount={null}
+      transaction={transaction}
+      transactionActions={transactionActions}
+    />,
+  );
+}
+
+describe("CeloFeeCurrencyPlugin (mvvm)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns null for non-celo transactions", () => {
+    const { container } = renderPlugin({
+      transaction: { family: "bitcoin" } as Partial<Transaction>,
+    });
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders CELO selected by default", () => {
+    renderPlugin();
+
+    const trigger = screen.getByTestId("send-celo-fee-currency-select");
+    expect(trigger).toHaveTextContent("CELO");
+  });
+
+  it("shows USDC as selected when feeCurrencyAccountId matches a USDC sub-account", () => {
+    renderPlugin({
+      transaction: { feeCurrencyAccountId: "usdc-sub-account-id" } as Partial<Transaction>,
+    });
+
+    const trigger = screen.getByTestId("send-celo-fee-currency-select");
+    expect(trigger).toHaveTextContent("USDC");
+  });
+
+  it("filters out token sub-accounts with zero balance from the selectable list", () => {
+    const zeroBalance = {
+      ...usdcSubAccount,
+      balance: new BigNumber(0),
+      spendableBalance: new BigNumber(0),
+    };
+    renderPlugin({
+      account: { subAccounts: [zeroBalance] } as unknown as Partial<CeloAccount>,
+      transaction: { feeCurrencyAccountId: "usdc-sub-account-id" } as Partial<Transaction>,
+    });
+
+    // Stale-id reset should fire because the zero-balance token is filtered out
+    expect(mockUpdateTransaction).toHaveBeenCalledTimes(1);
+    const patched = runUpdater({
+      ...baseTransaction,
+      feeCurrencyAccountId: "usdc-sub-account-id",
+    });
+    expect(patched).toMatchObject({
+      feeCurrency: null,
+      feeCurrencyUnwrapped: null,
+      feeCurrencyAccountId: null,
+    });
+  });
+
+  it("resets feeCurrencyAccountId when the persisted sub-account is no longer selectable", () => {
+    renderPlugin({
+      account: { subAccounts: [] } as unknown as Partial<CeloAccount>,
+      transaction: { feeCurrencyAccountId: "missing-id" } as Partial<Transaction>,
+    });
+
+    expect(mockUpdateTransaction).toHaveBeenCalledTimes(1);
+    const patched = runUpdater({ ...baseTransaction, feeCurrencyAccountId: "missing-id" });
+    expect(patched).toMatchObject({
+      feeCurrency: null,
+      feeCurrencyUnwrapped: null,
+      feeCurrencyAccountId: null,
+    });
+  });
+
+  it("does not reset feeCurrencyAccountId while sub-accounts are unhydrated", () => {
+    renderPlugin({
+      account: { subAccounts: undefined } as unknown as Partial<CeloAccount>,
+      transaction: { feeCurrencyAccountId: "usdc-sub-account-id" } as Partial<Transaction>,
+    });
+
+    expect(mockUpdateTransaction).not.toHaveBeenCalled();
+  });
+
+  it("falls back to CELO label when feeCurrencyAccountId points to an unknown contract", () => {
+    renderPlugin({
+      account: { subAccounts: [unknownTokenSubAccount] } as unknown as Partial<CeloAccount>,
+      transaction: { feeCurrencyAccountId: "unknown-sub-account-id" } as Partial<Transaction>,
+    });
+
+    // Stale-id reset fires because the unknown-contract token isn't in tokenOptions
+    expect(mockUpdateTransaction).toHaveBeenCalledTimes(1);
+    const trigger = screen.getByTestId("send-celo-fee-currency-select");
+    expect(trigger).toHaveTextContent("CELO");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/types.ts
@@ -1,4 +1,4 @@
-import type { ChangeEvent } from "react";
+import type { ChangeEvent, ReactNode } from "react";
 import type { FeePresetOption } from "../../hooks/useFeePresetOptions";
 import type { FeeFiatMap } from "../../hooks/useFeePresetFiatValues";
 import type { FeePresetLegendMap } from "../../hooks/useFeePresetLegends";
@@ -70,7 +70,10 @@ type ReviewProps = Readonly<{
   onGetFunds?: () => void;
 }>;
 
-export type AmountScreenViewProps = AmountInputProps & FeesProps & QuickActionsProps & ReviewProps;
+export type AmountScreenViewProps = AmountInputProps &
+  FeesProps &
+  QuickActionsProps &
+  ReviewProps & { pluginsSlot?: ReactNode };
 
 export type AmountScreenViewModel = Omit<AmountScreenViewProps, "onReview" | "onGetFunds"> &
   Readonly<{

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useNetworkFees.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useNetworkFees.test.ts
@@ -108,6 +108,7 @@ function buildParams(overrides?: {
     hasFeePresets: false,
     hasCustomFees: false,
     hasCoinControl: false,
+    hasAmountPlugins: false,
     ...overrides?.uiConfig,
   };
   const transactionActions: SendFlowTransactionActions = {
@@ -152,6 +153,10 @@ describe("useNetworkFees", () => {
       })),
     });
     sendFeatures.shouldEstimateFeePresetsWithBridge = jest.fn(() => false);
+    sendFeatures.getFeeCurrencyAccountId = jest.fn(
+      (_currency: unknown, transaction: { feeCurrencyAccountId?: string | null }) =>
+        transaction?.feeCurrencyAccountId ?? null,
+    );
     mockUseFeePresetOptions.mockReturnValue(defaultPresetOptions);
     mockUseFeePresetFiatValues.mockReturnValue(defaultFiatValues);
     useCalculate.mockReturnValue(undefined);

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useNetworkFees.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useNetworkFees.test.ts
@@ -347,6 +347,94 @@ describe("useNetworkFees", () => {
     });
   });
 
+  describe("Celo fee currency", () => {
+    const usdcUnit = { name: "USD Coin", code: "USDC", magnitude: 6 };
+    const usdcToken = {
+      type: "TokenCurrency",
+      id: "celo/erc20/usdc",
+      contractAddress: "0xceba9300f2b948710d2653dd7b07f33a8b32118c",
+      name: "USD Coin",
+      ticker: "USDC",
+      disableCountervalue: false,
+      units: [usdcUnit],
+    };
+    const usdcSubAccount = {
+      type: "TokenAccount",
+      id: "usdc-sub-account-id",
+      token: usdcToken,
+      balance: new BigNumber(100000),
+    };
+
+    it("formats fee with token unit when feeCurrencyAccountId is set", () => {
+      const { formatCurrencyUnit } = jest.requireMock("@ledgerhq/live-common/currencies/index");
+      formatCurrencyUnit.mockReturnValue("0.5 USDC");
+      useCalculate.mockReturnValue(undefined);
+
+      const params = buildParams({
+        account: { subAccounts: [usdcSubAccount] } as Partial<Account>,
+        transaction: {
+          family: "celo",
+          feeCurrencyAccountId: "usdc-sub-account-id",
+        } as Partial<Transaction>,
+        status: { estimatedFees: new BigNumber(500000) },
+      });
+      const { result } = renderHook(() => useNetworkFees(params));
+
+      expect(result.current.value).toBe("0.5 USDC");
+      expect(formatCurrencyUnit).toHaveBeenCalledWith(
+        expect.objectContaining({ code: "USDC", magnitude: 6 }),
+        expect.any(BigNumber),
+        expect.anything(),
+      );
+      expect(useCalculate).toHaveBeenCalledWith(
+        expect.objectContaining({ from: expect.objectContaining({ ticker: "USDC" }) }),
+      );
+    });
+
+    it("falls back to account unit when feeCurrencyAccountId is null", () => {
+      const { formatCurrencyUnit } = jest.requireMock("@ledgerhq/live-common/currencies/index");
+      formatCurrencyUnit.mockReturnValue("0.5 BTC");
+      useCalculate.mockReturnValue(undefined);
+
+      const params = buildParams({
+        transaction: {
+          family: "celo",
+          feeCurrencyAccountId: null,
+        } as Partial<Transaction>,
+        status: { estimatedFees: new BigNumber(500000) },
+      });
+      renderHook(() => useNetworkFees(params));
+
+      expect(formatCurrencyUnit).toHaveBeenCalledWith(
+        expect.objectContaining({ code: "BTC", magnitude: 8 }),
+        expect.any(BigNumber),
+        expect.anything(),
+      );
+    });
+
+    it("falls back to account unit when feeCurrencyAccountId references a missing sub-account", () => {
+      const { formatCurrencyUnit } = jest.requireMock("@ledgerhq/live-common/currencies/index");
+      formatCurrencyUnit.mockReturnValue("0.5 BTC");
+      useCalculate.mockReturnValue(undefined);
+
+      const params = buildParams({
+        account: { subAccounts: [] } as Partial<Account>,
+        transaction: {
+          family: "celo",
+          feeCurrencyAccountId: "missing-id",
+        } as Partial<Transaction>,
+        status: { estimatedFees: new BigNumber(500000) },
+      });
+      renderHook(() => useNetworkFees(params));
+
+      expect(formatCurrencyUnit).toHaveBeenCalledWith(
+        expect.objectContaining({ code: "BTC", magnitude: 8 }),
+        expect.any(BigNumber),
+        expect.anything(),
+      );
+    });
+  });
+
   describe("EVM fallback presets", () => {
     it("calls useFeePresetFiatValues with fallbackPresetIds when hasFeePresets, evm family, and empty feePresetOptions", () => {
       mockUseFeePresetOptions.mockReturnValue([]);

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useNetworkFees.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useNetworkFees.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from "react";
 import { BigNumber } from "bignumber.js";
 import { useTranslation, useLocale } from "~/context/Locale";
-import type { Account, AccountLike } from "@ledgerhq/types-live";
+import type { Account, AccountLike, TokenAccount } from "@ledgerhq/types-live";
 import type { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
 import type {
   SendFlowTransactionActions,
@@ -60,6 +60,20 @@ export function useNetworkFees({
   const accountUnit = useMaybeAccountUnit(mainAccount) ?? accountCurrency.units[0];
   const fiatUnit = counterValueCurrency.units[0];
 
+  const feeCurrencyAccountId =
+    transaction.family === "celo" ? (transaction.feeCurrencyAccountId ?? null) : null;
+
+  const feeCurrencySubAccount = useMemo<TokenAccount | null>(() => {
+    if (!feeCurrencyAccountId) return null;
+    const found = (mainAccount.subAccounts ?? []).find(
+      sub => sub.id === feeCurrencyAccountId && sub.type === "TokenAccount",
+    );
+    return (found as TokenAccount | undefined) ?? null;
+  }, [feeCurrencyAccountId, mainAccount.subAccounts]);
+
+  const displayUnit = feeCurrencySubAccount?.token.units[0] ?? accountUnit;
+  const displayCurrency = feeCurrencySubAccount?.token ?? accountCurrency;
+
   const feePresetOptions = useFeePresetOptions(accountCurrency, transaction);
   const hasFeePresets = uiConfig.hasFeePresets;
   const shouldEstimateFeePresetsWithBridge = sendFeatures.shouldEstimateFeePresetsWithBridge(
@@ -117,7 +131,7 @@ export function useNetworkFees({
   );
 
   const estimatedFeesCountervalue = useCalculate({
-    from: accountCurrency,
+    from: displayCurrency,
     to: counterValueCurrency,
     value: estimatedFees.toNumber(),
     disableRounding: true,
@@ -135,12 +149,12 @@ export function useNetworkFees({
       });
     }
 
-    return formatCurrencyUnit(accountUnit, estimatedFees, {
+    return formatCurrencyUnit(displayUnit, estimatedFees, {
       showCode: true,
       disableRounding: true,
       locale,
     });
-  }, [estimatedFees, estimatedFeesCountervalue, fiatUnit, accountUnit, locale]);
+  }, [estimatedFees, estimatedFeesCountervalue, fiatUnit, displayUnit, locale]);
 
   const feePresetOptionsMapped = useMemo(() => {
     return feePresetOptions.map(opt => ({

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useNetworkFees.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useNetworkFees.ts
@@ -60,8 +60,7 @@ export function useNetworkFees({
   const accountUnit = useMaybeAccountUnit(mainAccount) ?? accountCurrency.units[0];
   const fiatUnit = counterValueCurrency.units[0];
 
-  const feeCurrencyAccountId =
-    transaction.family === "celo" ? (transaction.feeCurrencyAccountId ?? null) : null;
+  const feeCurrencyAccountId = sendFeatures.getFeeCurrencyAccountId(accountCurrency, transaction);
 
   const feeCurrencySubAccount = useMemo<TokenAccount | null>(() => {
     if (!feeCurrencyAccountId) return null;

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useNetworkFees.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useNetworkFees.ts
@@ -66,9 +66,10 @@ export function useNetworkFees({
   const feeCurrencySubAccount = useMemo<TokenAccount | null>(() => {
     if (!feeCurrencyAccountId) return null;
     const found = (mainAccount.subAccounts ?? []).find(
-      sub => sub.id === feeCurrencyAccountId && sub.type === "TokenAccount",
+      (sub): sub is TokenAccount =>
+        sub.id === feeCurrencyAccountId && sub.type === "TokenAccount",
     );
-    return (found as TokenAccount | undefined) ?? null;
+    return found ?? null;
   }, [feeCurrencyAccountId, mainAccount.subAccounts]);
 
   const displayUnit = feeCurrencySubAccount?.token.units[0] ?? accountUnit;

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/AmountPluginsHost.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/AmountPluginsHost.tsx
@@ -5,9 +5,8 @@ import type { SendFlowTransactionActions } from "@ledgerhq/live-common/flows/sen
 import {
   getAccountCurrency,
   getMainAccount,
-} from "@ledgerhq/ledger-wallet-framework/account/helpers";
+} from "@ledgerhq/live-common/account/index";
 import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
-import { EvmGasOptionsSyncPlugin } from "./plugins/EvmGasOptionsSyncPlugin";
 import { CeloFeeCurrencyPlugin } from "./plugins/CeloFeeCurrencyPlugin";
 
 type AmountPluginProps = Readonly<{
@@ -20,7 +19,6 @@ type AmountPluginProps = Readonly<{
 type AmountPluginComponent = (props: AmountPluginProps) => React.ReactElement | null;
 
 const pluginRegistry: Readonly<Record<string, AmountPluginComponent>> = {
-  evmGasOptionsSync: EvmGasOptionsSyncPlugin,
   celoFeeCurrency: CeloFeeCurrencyPlugin,
 };
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/AmountScreenInner.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/AmountScreenInner.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 import type { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
 import type {
@@ -7,6 +7,7 @@ import type {
 } from "@ledgerhq/live-common/flows/send/types";
 import { useAmountScreenViewModel } from "../hooks/useAmountScreenViewModel";
 import { AmountScreenView } from "./AmountScreenView";
+import { AmountPluginsHost } from "./AmountPluginsHost";
 
 type AmountScreenInnerProps = Readonly<{
   account: AccountLike;
@@ -25,9 +26,21 @@ type AmountScreenInnerProps = Readonly<{
 export function AmountScreenInner(props: AmountScreenInnerProps) {
   const viewModel = useAmountScreenViewModel(props);
 
+  const pluginsSlot = useMemo(
+    () => (
+      <AmountPluginsHost
+        account={props.account}
+        parentAccount={props.parentAccount}
+        transaction={props.transaction}
+        transactionActions={props.transactionActions}
+      />
+    ),
+    [props.account, props.parentAccount, props.transaction, props.transactionActions],
+  );
+
   if (!viewModel.ready) {
     return null;
   }
 
-  return <AmountScreenView viewModel={viewModel} />;
+  return <AmountScreenView viewModel={viewModel} pluginsSlot={pluginsSlot} />;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/AmountScreenView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/AmountScreenView.tsx
@@ -12,9 +12,10 @@ import { useTranslation } from "~/context/Locale";
 
 type AmountScreenViewProps = Readonly<{
   viewModel: Extract<AmountScreenViewModel, { ready: true }>;
+  pluginsSlot?: React.ReactNode;
 }>;
 
-export function AmountScreenView({ viewModel }: AmountScreenViewProps) {
+export function AmountScreenView({ viewModel, pluginsSlot }: AmountScreenViewProps) {
   const { t } = useTranslation();
   const styles = useStyleSheet(
     theme => ({
@@ -68,6 +69,7 @@ export function AmountScreenView({ viewModel }: AmountScreenViewProps) {
       </View>
 
       <View style={styles.middleSection}>
+        {pluginsSlot}
         <NetworkFeesRow viewModel={viewModel.networkFees} />
         <Divider />
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/plugins/CeloFeeCurrencyPlugin.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/plugins/CeloFeeCurrencyPlugin.tsx
@@ -49,7 +49,7 @@ function CeloFeeCurrencyPluginInner({
   const selectedName = useMemo(() => {
     if (!transaction.feeCurrencyAccountId) return FEE_CURRENCY_OPTIONS[0].name;
     const sub = findSubAccountById(mainAccount, transaction.feeCurrencyAccountId);
-    if (!sub || sub.type !== "TokenAccount") return FEE_CURRENCY_OPTIONS[0].name;
+    if (sub?.type !== "TokenAccount") return FEE_CURRENCY_OPTIONS[0].name;
     return (
       FEE_CURRENCY_BY_CONTRACT.get(sub.token.contractAddress.toLowerCase())?.name ??
       FEE_CURRENCY_OPTIONS[0].name

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/plugins/CeloFeeCurrencyPlugin.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/plugins/CeloFeeCurrencyPlugin.tsx
@@ -1,0 +1,226 @@
+import React, { useCallback, useMemo, useState } from "react";
+import { TouchableOpacity, StyleSheet, View } from "react-native";
+import BigNumber from "bignumber.js";
+import { useTranslation } from "~/context/Locale";
+import { useTheme } from "@react-navigation/native";
+import { Icons, Text } from "@ledgerhq/native-ui";
+import Circle from "~/components/Circle";
+import QueuedDrawer from "~/components/QueuedDrawer";
+import LText from "~/components/LText";
+import type { Account, AccountLike, TokenAccount } from "@ledgerhq/types-live";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import type { Transaction as CeloTransaction } from "@ledgerhq/live-common/families/celo/types";
+import type { SendFlowTransactionActions } from "@ledgerhq/live-common/flows/send/types";
+import {
+  findSubAccountById,
+  getMainAccount,
+} from "@ledgerhq/live-common/account/index";
+import {
+  FEE_CURRENCY_BY_CONTRACT,
+  FEE_CURRENCY_OPTIONS,
+} from "@ledgerhq/live-common/families/celo/logic";
+
+type Props = Readonly<{
+  account: AccountLike;
+  parentAccount: Account | null;
+  transaction: Transaction;
+  transactionActions: SendFlowTransactionActions;
+}>;
+
+function isCeloTransaction(tx: Transaction): tx is CeloTransaction {
+  return tx.family === "celo";
+}
+
+function CeloFeeCurrencyPluginInner({
+  account,
+  parentAccount,
+  transaction,
+  transactionActions,
+}: Props & { transaction: CeloTransaction }) {
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  const mainAccount = useMemo(
+    () => getMainAccount(account, parentAccount ?? undefined),
+    [account, parentAccount],
+  );
+
+  const feeCurrencyAccount = transaction.feeCurrencyAccountId
+    ? findSubAccountById(mainAccount, transaction.feeCurrencyAccountId)
+    : null;
+
+  const selectedName = feeCurrencyAccount
+    ? (FEE_CURRENCY_BY_CONTRACT.get(
+        (feeCurrencyAccount as TokenAccount).token.contractAddress.toLowerCase(),
+      )?.name ?? FEE_CURRENCY_OPTIONS[0].name)
+    : FEE_CURRENCY_OPTIONS[0].name;
+
+  const tokenOptions: (TokenAccount & { feeCurrencyName: string })[] = useMemo(
+    () =>
+      (mainAccount.subAccounts ?? [])
+        .filter((sub): sub is TokenAccount => sub.type === "TokenAccount")
+        .filter(sub => new BigNumber(sub.balance).gt(0))
+        .filter(sub => FEE_CURRENCY_BY_CONTRACT.has(sub.token.contractAddress.toLowerCase()))
+        .map(sub => ({
+          ...sub,
+          feeCurrencyName:
+            FEE_CURRENCY_BY_CONTRACT.get(sub.token.contractAddress.toLowerCase())?.name ??
+            sub.token.name,
+        })),
+    [mainAccount.subAccounts],
+  );
+
+  const onSelectNative = useCallback(() => {
+    transactionActions.updateTransaction(tx => ({
+      ...tx,
+      feeCurrency: null,
+      feeCurrencyUnwrapped: null,
+      feeCurrencyAccountId: null,
+    }));
+    setDrawerOpen(false);
+  }, [transactionActions]);
+
+  const onSelectToken = useCallback(
+    (tokenAccount: AccountLike) => {
+      if (tokenAccount.type !== "TokenAccount") return;
+      const contractAddress = tokenAccount.token.contractAddress;
+      const matchedOption = FEE_CURRENCY_BY_CONTRACT.get(contractAddress.toLowerCase());
+
+      if (!matchedOption) {
+        transactionActions.updateTransaction(tx => ({
+          ...tx,
+          feeCurrency: null,
+          feeCurrencyUnwrapped: null,
+          feeCurrencyAccountId: null,
+        }));
+        setDrawerOpen(false);
+        return;
+      }
+
+      const feeCurrency = matchedOption.adapterAddress ?? matchedOption.contractAddress ?? null;
+      const feeCurrencyUnwrapped = matchedOption.contractAddress ?? null;
+
+      transactionActions.updateTransaction(tx => ({
+        ...tx,
+        feeCurrency,
+        feeCurrencyUnwrapped,
+        feeCurrencyAccountId: tokenAccount.id,
+      }));
+      setDrawerOpen(false);
+    },
+    [transactionActions],
+  );
+
+  return (
+    <View style={styles.container}>
+      <LText style={styles.label} color="grey">
+        {t("celo.send.feeCurrency")}
+      </LText>
+      <TouchableOpacity
+        style={[styles.selector, { borderColor: colors.lightGrey }]}
+        onPress={() => setDrawerOpen(true)}
+      >
+        <LText semiBold style={styles.selectorText}>
+          {selectedName}
+        </LText>
+        <Icons.ChevronDown size="S" color="neutral.c70" />
+      </TouchableOpacity>
+
+      <QueuedDrawer
+        title={
+          <Text variant="h4" textTransform="none">
+            {t("celo.send.feeCurrency")}
+          </Text>
+        }
+        isRequestingToBeOpened={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+      >
+        <FeeCurrencyOption
+          label={FEE_CURRENCY_OPTIONS[0].name}
+          selected={!transaction.feeCurrencyAccountId}
+          onPress={onSelectNative}
+        />
+        {tokenOptions.map(tokenAccount => (
+          <FeeCurrencyOption
+            key={tokenAccount.id}
+            label={tokenAccount.feeCurrencyName}
+            selected={transaction.feeCurrencyAccountId === tokenAccount.id}
+            onPress={() => onSelectToken(tokenAccount)}
+          />
+        ))}
+      </QueuedDrawer>
+    </View>
+  );
+}
+
+type OptionProps = {
+  readonly label: string;
+  readonly selected: boolean;
+  readonly onPress: () => void;
+};
+
+function FeeCurrencyOption({ label, selected, onPress }: OptionProps) {
+  return (
+    <TouchableOpacity style={styles.option} onPress={onPress}>
+      <Text fontSize="body" fontWeight="semiBold" color={selected ? "primary.c80" : "neutral.c100"}>
+        {label}
+      </Text>
+      {selected && (
+        <Circle size={24} style={styles.checkIcon}>
+          <Icons.CheckmarkCircleFill size="M" color="primary.c80" />
+        </Circle>
+      )}
+    </TouchableOpacity>
+  );
+}
+
+export function CeloFeeCurrencyPlugin({
+  account,
+  parentAccount,
+  transaction,
+  transactionActions,
+}: Props) {
+  if (!isCeloTransaction(transaction)) return null;
+
+  return (
+    <CeloFeeCurrencyPluginInner
+      account={account}
+      parentAccount={parentAccount}
+      transaction={transaction}
+      transactionActions={transactionActions}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 8,
+    marginBottom: 8,
+  },
+  label: {
+    fontSize: 12,
+    marginBottom: 4,
+  },
+  selector: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 8,
+    borderWidth: 1,
+  },
+  selectorText: {
+    fontSize: 16,
+  },
+  option: {
+    padding: 16,
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  checkIcon: {
+    position: "absolute",
+    right: 0,
+  },
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/plugins/CeloFeeCurrencyPlugin.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/plugins/CeloFeeCurrencyPlugin.tsx
@@ -48,13 +48,22 @@ function CeloFeeCurrencyPluginInner({
 
   const selectedName = useMemo(() => {
     if (!transaction.feeCurrencyAccountId) return FEE_CURRENCY_OPTIONS[0].name;
+    // Resolve via the contract address on the transaction itself — always present
+    // when a token fee currency is selected, so the label stays correct even while
+    // sub-accounts are still hydrating.
+    if (transaction.feeCurrencyUnwrapped) {
+      const matched = FEE_CURRENCY_BY_CONTRACT.get(
+        transaction.feeCurrencyUnwrapped.toLowerCase(),
+      );
+      if (matched) return matched.name;
+    }
     const sub = findSubAccountById(mainAccount, transaction.feeCurrencyAccountId);
     if (sub?.type !== "TokenAccount") return FEE_CURRENCY_OPTIONS[0].name;
     return (
       FEE_CURRENCY_BY_CONTRACT.get(sub.token.contractAddress.toLowerCase())?.name ??
       FEE_CURRENCY_OPTIONS[0].name
     );
-  }, [transaction.feeCurrencyAccountId, mainAccount]);
+  }, [transaction.feeCurrencyAccountId, transaction.feeCurrencyUnwrapped, mainAccount]);
 
   const tokenOptions: (TokenAccount & { feeCurrencyName: string })[] = useMemo(
     () =>

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/plugins/CeloFeeCurrencyPlugin.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/plugins/CeloFeeCurrencyPlugin.tsx
@@ -46,15 +46,15 @@ function CeloFeeCurrencyPluginInner({
     [account, parentAccount],
   );
 
-  const feeCurrencyAccount = transaction.feeCurrencyAccountId
-    ? findSubAccountById(mainAccount, transaction.feeCurrencyAccountId)
-    : null;
-
-  const selectedName = feeCurrencyAccount
-    ? (FEE_CURRENCY_BY_CONTRACT.get(
-        (feeCurrencyAccount as TokenAccount).token.contractAddress.toLowerCase(),
-      )?.name ?? FEE_CURRENCY_OPTIONS[0].name)
-    : FEE_CURRENCY_OPTIONS[0].name;
+  const selectedName = useMemo(() => {
+    if (!transaction.feeCurrencyAccountId) return FEE_CURRENCY_OPTIONS[0].name;
+    const sub = findSubAccountById(mainAccount, transaction.feeCurrencyAccountId);
+    if (!sub || sub.type !== "TokenAccount") return FEE_CURRENCY_OPTIONS[0].name;
+    return (
+      FEE_CURRENCY_BY_CONTRACT.get(sub.token.contractAddress.toLowerCase())?.name ??
+      FEE_CURRENCY_OPTIONS[0].name
+    );
+  }, [transaction.feeCurrencyAccountId, mainAccount]);
 
   const tokenOptions: (TokenAccount & { feeCurrencyName: string })[] = useMemo(
     () =>

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/plugins/CeloFeeCurrencyPlugin.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/plugins/CeloFeeCurrencyPlugin.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { TouchableOpacity, StyleSheet, View } from "react-native";
 import BigNumber from "bignumber.js";
 import { useTranslation } from "~/context/Locale";
@@ -70,6 +70,19 @@ function CeloFeeCurrencyPluginInner({
         })),
     [mainAccount.subAccounts],
   );
+
+  useEffect(() => {
+    if (!transaction.feeCurrencyAccountId) return;
+    if (mainAccount.subAccounts === undefined) return;
+    const stillSelectable = tokenOptions.some(t => t.id === transaction.feeCurrencyAccountId);
+    if (stillSelectable) return;
+    transactionActions.updateTransaction(tx => ({
+      ...tx,
+      feeCurrency: null,
+      feeCurrencyUnwrapped: null,
+      feeCurrencyAccountId: null,
+    }));
+  }, [transaction.feeCurrencyAccountId, mainAccount.subAccounts, tokenOptions, transactionActions]);
 
   const onSelectNative = useCallback(() => {
     transactionActions.updateTransaction(tx => ({

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/plugins/CeloFeeCurrencyPlugin.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/plugins/CeloFeeCurrencyPlugin.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { TouchableOpacity, StyleSheet, View } from "react-native";
-import BigNumber from "bignumber.js";
 import { useTranslation } from "~/context/Locale";
 import { useTheme } from "@react-navigation/native";
 import { Icons, Text } from "@ledgerhq/native-ui";
@@ -69,7 +68,7 @@ function CeloFeeCurrencyPluginInner({
     () =>
       (mainAccount.subAccounts ?? [])
         .filter((sub): sub is TokenAccount => sub.type === "TokenAccount")
-        .filter(sub => new BigNumber(sub.balance).gt(0))
+        .filter(sub => sub.balance.gt(0))
         .filter(sub => FEE_CURRENCY_BY_CONTRACT.has(sub.token.contractAddress.toLowerCase()))
         .map(sub => ({
           ...sub,

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/plugins/__tests__/CeloFeeCurrencyPlugin.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/plugins/__tests__/CeloFeeCurrencyPlugin.test.tsx
@@ -262,6 +262,30 @@ describe("CeloFeeCurrencyPlugin (mvvm)", () => {
     expect(mockUpdateTransaction).not.toHaveBeenCalled();
   });
 
+  it("shows the token label while sub-accounts are unhydrated when feeCurrencyUnwrapped is set", () => {
+    const accountUnhydrated: CeloAccount = {
+      ...mockCeloAccount,
+      subAccounts: undefined as never,
+    };
+
+    render(
+      <CeloFeeCurrencyPlugin
+        account={accountUnhydrated as never}
+        parentAccount={null}
+        transaction={
+          {
+            ...baseTransaction,
+            feeCurrencyAccountId: "usdc-sub-account-id",
+            feeCurrencyUnwrapped: usdcContractAddress,
+          } as never
+        }
+        transactionActions={transactionActions}
+      />,
+    );
+
+    expect(screen.getByText("USDC")).toBeDefined();
+  });
+
   it("falls back to CELO label when feeCurrencyAccountId points to an unknown contract", () => {
     const account: CeloAccount = { ...mockCeloAccount, subAccounts: [unknownTokenSubAccount] };
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/plugins/__tests__/CeloFeeCurrencyPlugin.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/plugins/__tests__/CeloFeeCurrencyPlugin.test.tsx
@@ -1,0 +1,279 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { render, screen } from "@tests/test-renderer";
+import { CeloFeeCurrencyPlugin } from "../CeloFeeCurrencyPlugin";
+import type { CeloAccount } from "@ledgerhq/live-common/families/celo/types";
+import type { TokenAccount } from "@ledgerhq/types-live";
+
+const mockUpdateTransaction = jest.fn();
+const transactionActions = {
+  updateTransaction: mockUpdateTransaction,
+  setTransaction: jest.fn(),
+  setRecipient: jest.fn(),
+  setAccount: jest.fn(),
+} as never;
+
+jest.mock("@ledgerhq/live-common/account/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/account/index"),
+  getMainAccount: (account: unknown, parentAccount: unknown) => parentAccount ?? account,
+  findSubAccountById: (account: { subAccounts?: { id: string }[] }, id: string | null) =>
+    account.subAccounts?.find(sub => sub.id === id) ?? null,
+}));
+
+const usdcContractAddress = "0xceba9300f2b948710d2653dd7b07f33a8b32118c";
+const unknownContractAddress = "0x0000000000000000000000000000000000000001";
+
+const usdcSubAccount: TokenAccount = {
+  type: "TokenAccount",
+  id: "usdc-sub-account-id",
+  parentId: "celo-account-id",
+  token: {
+    type: "TokenCurrency",
+    id: "celo/erc20/usdc",
+    contractAddress: usdcContractAddress,
+    parentCurrency: { id: "celo" } as never,
+    name: "USD Coin",
+    ticker: "USDC",
+    units: [{ name: "USDC", code: "USDC", magnitude: 6 }],
+  } as never,
+  balance: new BigNumber(100) as never,
+  spendableBalance: new BigNumber(100) as never,
+  creationDate: new Date(),
+  operationsCount: 0,
+  operations: [],
+  pendingOperations: [],
+  balanceHistoryCache: {
+    HOUR: { latestDate: null, balances: [] },
+    DAY: { latestDate: null, balances: [] },
+    WEEK: { latestDate: null, balances: [] },
+  },
+  swapHistory: [],
+};
+
+const unknownTokenSubAccount: TokenAccount = {
+  ...usdcSubAccount,
+  id: "unknown-sub-account-id",
+  token: {
+    ...usdcSubAccount.token,
+    contractAddress: unknownContractAddress,
+    name: "Unknown Token",
+    ticker: "UNK",
+  } as never,
+};
+
+const mockCeloAccount: CeloAccount = {
+  type: "Account",
+  id: "celo-account-id",
+  seedIdentifier: "seed",
+  derivationMode: "",
+  index: 0,
+  freshAddress: "0xabc",
+  freshAddressPath: "44'/52752'/0'/0/0",
+  used: true,
+  balance: new BigNumber(1000) as never,
+  spendableBalance: new BigNumber(1000) as never,
+  creationDate: new Date(),
+  blockHeight: 100000,
+  currency: { id: "celo", family: "celo" } as never,
+  operationsCount: 0,
+  operations: [],
+  pendingOperations: [],
+  lastSyncDate: new Date(),
+  balanceHistoryCache: {
+    HOUR: { latestDate: null, balances: [] },
+    DAY: { latestDate: null, balances: [] },
+    WEEK: { latestDate: null, balances: [] },
+  },
+  swapHistory: [],
+  subAccounts: [usdcSubAccount],
+  celoResources: {
+    registrationStatus: false,
+    lockedBalance: new BigNumber(0) as never,
+    nonvotingLockedBalance: new BigNumber(0) as never,
+    pendingWithdrawals: null,
+    votes: null,
+    electionAddress: null,
+    lockedGoldAddress: null,
+    maxNumGroupsVotedFor: new BigNumber(0) as never,
+  },
+};
+
+const baseTransaction = {
+  family: "celo" as const,
+  amount: new BigNumber(0),
+  recipient: "",
+  useAllAmount: false,
+  mode: "send" as const,
+  index: null,
+  fees: null,
+  feeCurrency: null,
+  feeCurrencyUnwrapped: null,
+  feeCurrencyAccountId: null,
+};
+
+function runUpdater(currentTx: object) {
+  return mockUpdateTransaction.mock.calls[0][0](currentTx);
+}
+
+describe("CeloFeeCurrencyPlugin (mvvm)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns null for non-celo transactions", () => {
+    const { toJSON } = render(
+      <CeloFeeCurrencyPlugin
+        account={mockCeloAccount as never}
+        parentAccount={null}
+        transaction={{ ...baseTransaction, family: "bitcoin" } as never}
+        transactionActions={transactionActions}
+      />,
+    );
+
+    expect(toJSON()).toBeNull();
+  });
+
+  it("renders CELO selected by default", () => {
+    render(
+      <CeloFeeCurrencyPlugin
+        account={mockCeloAccount as never}
+        parentAccount={null}
+        transaction={baseTransaction as never}
+        transactionActions={transactionActions}
+      />,
+    );
+
+    expect(screen.getByText("CELO")).toBeDefined();
+  });
+
+  it("shows USDC as selected when feeCurrencyAccountId matches a USDC sub-account", () => {
+    render(
+      <CeloFeeCurrencyPlugin
+        account={mockCeloAccount as never}
+        parentAccount={null}
+        transaction={{ ...baseTransaction, feeCurrencyAccountId: "usdc-sub-account-id" } as never}
+        transactionActions={transactionActions}
+      />,
+    );
+
+    expect(screen.getByText("USDC")).toBeDefined();
+  });
+
+  it("calls updateTransaction with USDC fields when USDC is selected from the drawer", async () => {
+    const { user } = render(
+      <CeloFeeCurrencyPlugin
+        account={mockCeloAccount as never}
+        parentAccount={null}
+        transaction={baseTransaction as never}
+        transactionActions={transactionActions}
+      />,
+    );
+
+    await user.press(screen.getByText("CELO"));
+    await user.press(screen.getAllByText("USDC")[0]);
+
+    expect(mockUpdateTransaction).toHaveBeenCalled();
+    const patched = runUpdater(baseTransaction);
+    expect(patched).toMatchObject({
+      feeCurrencyAccountId: "usdc-sub-account-id",
+      feeCurrency: expect.any(String),
+      feeCurrencyUnwrapped: expect.any(String),
+    });
+  });
+
+  it("calls updateTransaction with null fee currency when native CELO is selected from the drawer", async () => {
+    const { user } = render(
+      <CeloFeeCurrencyPlugin
+        account={mockCeloAccount as never}
+        parentAccount={null}
+        transaction={{ ...baseTransaction, feeCurrencyAccountId: "usdc-sub-account-id" } as never}
+        transactionActions={transactionActions}
+      />,
+    );
+
+    await user.press(screen.getByText("USDC"));
+    const celoOptions = screen.getAllByText("CELO");
+    await user.press(celoOptions[celoOptions.length - 1]);
+
+    expect(mockUpdateTransaction).toHaveBeenCalled();
+    const patched = runUpdater({ ...baseTransaction, feeCurrencyAccountId: "usdc-sub-account-id" });
+    expect(patched).toMatchObject({
+      feeCurrency: null,
+      feeCurrencyUnwrapped: null,
+      feeCurrencyAccountId: null,
+    });
+  });
+
+  it("filters out token sub-accounts with zero balance", async () => {
+    const zeroBalance: TokenAccount = {
+      ...usdcSubAccount,
+      balance: new BigNumber(0) as never,
+      spendableBalance: new BigNumber(0) as never,
+    };
+    const account: CeloAccount = { ...mockCeloAccount, subAccounts: [zeroBalance] };
+
+    const { user } = render(
+      <CeloFeeCurrencyPlugin
+        account={account as never}
+        parentAccount={null}
+        transaction={baseTransaction as never}
+        transactionActions={transactionActions}
+      />,
+    );
+
+    await user.press(screen.getByText("CELO"));
+    expect(screen.queryAllByText("USDC").length).toBe(0);
+  });
+
+  it("resets feeCurrencyAccountId when the persisted sub-account is no longer selectable", () => {
+    render(
+      <CeloFeeCurrencyPlugin
+        account={mockCeloAccount as never}
+        parentAccount={null}
+        transaction={{ ...baseTransaction, feeCurrencyAccountId: "missing-id" } as never}
+        transactionActions={transactionActions}
+      />,
+    );
+
+    expect(mockUpdateTransaction).toHaveBeenCalledTimes(1);
+    const patched = runUpdater({ ...baseTransaction, feeCurrencyAccountId: "missing-id" });
+    expect(patched).toMatchObject({
+      feeCurrency: null,
+      feeCurrencyUnwrapped: null,
+      feeCurrencyAccountId: null,
+    });
+  });
+
+  it("does not reset feeCurrencyAccountId while sub-accounts are unhydrated", () => {
+    const accountUnhydrated: CeloAccount = {
+      ...mockCeloAccount,
+      subAccounts: undefined as never,
+    };
+
+    render(
+      <CeloFeeCurrencyPlugin
+        account={accountUnhydrated as never}
+        parentAccount={null}
+        transaction={{ ...baseTransaction, feeCurrencyAccountId: "usdc-sub-account-id" } as never}
+        transactionActions={transactionActions}
+      />,
+    );
+
+    expect(mockUpdateTransaction).not.toHaveBeenCalled();
+  });
+
+  it("falls back to CELO label when feeCurrencyAccountId points to an unknown contract", () => {
+    const account: CeloAccount = { ...mockCeloAccount, subAccounts: [unknownTokenSubAccount] };
+
+    render(
+      <CeloFeeCurrencyPlugin
+        account={account as never}
+        parentAccount={null}
+        transaction={{ ...baseTransaction, feeCurrencyAccountId: "unknown-sub-account-id" } as never}
+        transactionActions={transactionActions}
+      />,
+    );
+
+    expect(screen.getByText("CELO")).toBeDefined();
+  });
+});

--- a/libs/coin-modules/coin-celo/src/__tests__/bridge/buildTransaction.test.ts
+++ b/libs/coin-modules/coin-celo/src/__tests__/bridge/buildTransaction.test.ts
@@ -17,7 +17,7 @@ const ACCOUNTS_ADDRESS = "0x000000000000000000000000000000000000aa10";
 const STABLE_TOKEN_ADDRESS = "0x765DE816845861e75A25fCA122bb6898B8B1282a";
 const VALID_RECIPIENT = "0x79D5A290D7ba4b99322d91b577589e8d0BF87072";
 
-const estimateGasMock = jest.fn(async () => BigInt(3));
+const estimateGasMock = jest.fn(async (..._args: unknown[]) => BigInt(3));
 const getChainIdMock = jest.fn(async () => 42220);
 const getTransactionCountMock = jest.fn(async () => 1);
 const readContractMock = jest.fn<Promise<unknown>, [{ functionName: string }]>(
@@ -35,6 +35,7 @@ jest.mock("../../network/client", () => ({
     getTransactionCount: getTransactionCountMock,
     readContract: readContractMock,
   })),
+  celoEstimateGas: (...args: unknown[]) => estimateGasMock(...args),
 }));
 
 jest.mock("../../network/registry", () => ({

--- a/libs/coin-modules/coin-celo/src/__tests__/bridge/getFeesForTransaction.test.ts
+++ b/libs/coin-modules/coin-celo/src/__tests__/bridge/getFeesForTransaction.test.ts
@@ -29,6 +29,7 @@ const readContractMock = jest.fn(async ({ functionName }: { functionName: string
 
 jest.mock("../../network/client", () => ({
   celoGasPrice: (...args: unknown[]) => celoGasPriceMock(...args),
+  celoEstimateGas: (...args: unknown[]) => estimateGasMock(...args),
   getCeloClient: jest.fn(() => ({
     estimateGas: (...args: unknown[]) => estimateGasMock(...args),
     estimateMaxPriorityFeePerGas: (...args: unknown[]) => estimateMaxPriorityFeePerGasMock(...args),

--- a/libs/coin-modules/coin-celo/src/__tests__/bridge/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-celo/src/__tests__/bridge/prepareTransaction.test.ts
@@ -11,6 +11,7 @@ import prepareTransaction from "../../bridge/prepareTransaction";
 
 jest.mock("../../network/client", () => ({
   celoGasPrice: jest.fn(async () => BigInt(2)),
+  celoEstimateGas: jest.fn(async () => BigInt(3)),
   getCeloClient: jest.fn(() => ({
     estimateGas: jest.fn(async () => BigInt(3)),
     estimateMaxPriorityFeePerGas: jest.fn(async () => BigInt(1)),

--- a/libs/coin-modules/coin-celo/src/__tests__/network/client.test.ts
+++ b/libs/coin-modules/coin-celo/src/__tests__/network/client.test.ts
@@ -80,4 +80,93 @@ describe("network/client", () => {
       params: [],
     });
   });
+
+  describe("celoEstimateGas", () => {
+    const from = "0x1111111111111111111111111111111111111111" as `0x${string}`;
+    const to = "0x2222222222222222222222222222222222222222" as `0x${string}`;
+    const feeCurrency = "0x765DE816845861e75A25fCA122bb6898B8B1282a" as `0x${string}`;
+
+    const setupClient = (returnValue: string) => {
+      const requestMock = jest.fn(async () => returnValue);
+      createPublicClientMock.mockReturnValue({ request: requestMock });
+      getEnvMock.mockReturnValue("https://celo-rpc.ledger.com");
+      httpMock.mockReturnValue({ type: "http" });
+      return requestMock;
+    };
+
+    it("returns the gas estimate as a bigint", async () => {
+      const { celoEstimateGas } = loadClientModule();
+      const requestMock = setupClient("0x5208");
+
+      const gas = await celoEstimateGas({ from, to });
+
+      expect(gas).toBe(BigInt(0x5208));
+      expect(requestMock).toHaveBeenCalledWith({
+        method: "eth_estimateGas",
+        params: [{ from, to }],
+      });
+    });
+
+    it("threads feeCurrency to the RPC params when provided", async () => {
+      const { celoEstimateGas } = loadClientModule();
+      const requestMock = setupClient("0x1");
+
+      await celoEstimateGas({ from, to, feeCurrency });
+
+      expect(requestMock).toHaveBeenCalledWith({
+        method: "eth_estimateGas",
+        params: [{ from, to, feeCurrency }],
+      });
+    });
+
+    it("omits feeCurrency when null", async () => {
+      const { celoEstimateGas } = loadClientModule();
+      const requestMock = setupClient("0x1");
+
+      await celoEstimateGas({ from, to, feeCurrency: null });
+
+      expect(requestMock).toHaveBeenCalledWith({
+        method: "eth_estimateGas",
+        params: [{ from, to }],
+      });
+    });
+
+    it("hex-encodes bigint value and gas price fields", async () => {
+      const { celoEstimateGas } = loadClientModule();
+      const requestMock = setupClient("0x1");
+
+      await celoEstimateGas({
+        from,
+        to,
+        value: BigInt(1000),
+        maxFeePerGas: BigInt(500),
+        maxPriorityFeePerGas: BigInt(2),
+      });
+
+      expect(requestMock).toHaveBeenCalledWith({
+        method: "eth_estimateGas",
+        params: [
+          {
+            from,
+            to,
+            value: "0x3e8",
+            maxFeePerGas: "0x1f4",
+            maxPriorityFeePerGas: "0x2",
+          },
+        ],
+      });
+    });
+
+    it("omits optional fields that are undefined", async () => {
+      const { celoEstimateGas } = loadClientModule();
+      const requestMock = setupClient("0x1");
+
+      await celoEstimateGas({ from });
+
+      expect(requestMock).toHaveBeenCalledWith({
+        method: "eth_estimateGas",
+        params: [{ from }],
+      });
+    });
+  });
 });

--- a/libs/coin-modules/coin-celo/src/__tests__/network/client.test.ts
+++ b/libs/coin-modules/coin-celo/src/__tests__/network/client.test.ts
@@ -119,18 +119,6 @@ describe("network/client", () => {
       });
     });
 
-    it("omits feeCurrency when null", async () => {
-      const { celoEstimateGas } = loadClientModule();
-      const requestMock = setupClient("0x1");
-
-      await celoEstimateGas({ from, to, feeCurrency: null });
-
-      expect(requestMock).toHaveBeenCalledWith({
-        method: "eth_estimateGas",
-        params: [{ from, to }],
-      });
-    });
-
     it("hex-encodes bigint value and gas price fields", async () => {
       const { celoEstimateGas } = loadClientModule();
       const requestMock = setupClient("0x1");

--- a/libs/coin-modules/coin-celo/src/bridge/buildTransaction.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/buildTransaction.ts
@@ -329,7 +329,7 @@ const buildTransaction = async (
     ...(celoTransaction.to !== undefined && { to: celoTransaction.to }),
     ...(celoTransaction.data !== undefined && { data: celoTransaction.data }),
     ...(celoTransaction.value !== undefined && { value: BigInt(celoTransaction.value) }),
-    ...(celoTransaction.feeCurrency != null && { feeCurrency: celoTransaction.feeCurrency }),
+    ...(celoTransaction.feeCurrency && { feeCurrency: celoTransaction.feeCurrency }),
   });
 
   const gas = Math.ceil(Number(estimatedGas) * MAX_FEES_THRESHOLD_MULTIPLIER).toString();

--- a/libs/coin-modules/coin-celo/src/bridge/buildTransaction.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/buildTransaction.ts
@@ -326,10 +326,10 @@ const buildTransaction = async (
 
   const estimatedGas = await celoEstimateGas({
     from: celoTransaction.from,
-    to: celoTransaction.to,
-    data: celoTransaction.data,
-    value: celoTransaction.value === undefined ? undefined : BigInt(celoTransaction.value),
-    feeCurrency: celoTransaction.feeCurrency,
+    ...(celoTransaction.to !== undefined && { to: celoTransaction.to }),
+    ...(celoTransaction.data !== undefined && { data: celoTransaction.data }),
+    ...(celoTransaction.value !== undefined && { value: BigInt(celoTransaction.value) }),
+    ...(celoTransaction.feeCurrency != null && { feeCurrency: celoTransaction.feeCurrency }),
   });
 
   const gas = Math.ceil(Number(estimatedGas) * MAX_FEES_THRESHOLD_MULTIPLIER).toString();

--- a/libs/coin-modules/coin-celo/src/bridge/buildTransaction.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/buildTransaction.ts
@@ -9,7 +9,7 @@ import {
   ZERO_ADDRESS,
 } from "../constants";
 import { getPendingStakingOperationAmounts, getVote } from "../logic";
-import { getCeloClient } from "../network/client";
+import { celoEstimateGas, getCeloClient } from "../network/client";
 import { getRegistryAddressFor } from "../network/registry";
 import type { CeloAccount, CeloTransactionRequest, Transaction } from "../types";
 import { valueToHex, isSameTokenAsFee, normalizeAndSubtract, convertNumberDecimals } from "./utils";
@@ -324,25 +324,13 @@ const buildTransaction = async (
       break;
   }
 
-  const valueAsBigInt =
-    celoTransaction.value === undefined ? undefined : BigInt(celoTransaction.value);
-
-  // Use eth_estimateGas directly so we can pass feeCurrency (viem's estimateGas doesn't expose it).
-  // Without feeCurrency the node underestimates gas for non-native fee token transactions.
-  const estimateParams: Record<string, string | undefined> = {
+  const estimatedGas = await celoEstimateGas({
     from: celoTransaction.from,
     to: celoTransaction.to,
     data: celoTransaction.data,
-    value: valueAsBigInt !== undefined ? `0x${valueAsBigInt.toString(16)}` : undefined,
-  };
-  if (celoTransaction.feeCurrency) {
-    estimateParams.feeCurrency = celoTransaction.feeCurrency;
-  }
-  const estimatedGasHex = await client.request({
-    method: "eth_estimateGas",
-    params: [estimateParams],
-  } as Parameters<typeof client.request>[0]);
-  const estimatedGas = BigInt(estimatedGasHex as string);
+    value: celoTransaction.value === undefined ? undefined : BigInt(celoTransaction.value),
+    feeCurrency: celoTransaction.feeCurrency,
+  });
 
   const gas = Math.ceil(Number(estimatedGas) * MAX_FEES_THRESHOLD_MULTIPLIER).toString();
   const [chainId, nonce] = await Promise.all([

--- a/libs/coin-modules/coin-celo/src/bridge/buildTransaction.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/buildTransaction.ts
@@ -326,12 +326,23 @@ const buildTransaction = async (
 
   const valueAsBigInt =
     celoTransaction.value === undefined ? undefined : BigInt(celoTransaction.value);
-  const estimatedGas = await client.estimateGas({
-    account: celoTransaction.from,
+
+  // Use eth_estimateGas directly so we can pass feeCurrency (viem's estimateGas doesn't expose it).
+  // Without feeCurrency the node underestimates gas for non-native fee token transactions.
+  const estimateParams: Record<string, string | undefined> = {
+    from: celoTransaction.from,
     to: celoTransaction.to,
     data: celoTransaction.data,
-    value: valueAsBigInt,
-  });
+    value: valueAsBigInt !== undefined ? `0x${valueAsBigInt.toString(16)}` : undefined,
+  };
+  if (celoTransaction.feeCurrency) {
+    estimateParams.feeCurrency = celoTransaction.feeCurrency;
+  }
+  const estimatedGasHex = await client.request({
+    method: "eth_estimateGas",
+    params: [estimateParams],
+  } as Parameters<typeof client.request>[0]);
+  const estimatedGas = BigInt(estimatedGasHex as string);
 
   const gas = Math.ceil(Number(estimatedGas) * MAX_FEES_THRESHOLD_MULTIPLIER).toString();
   const [chainId, nonce] = await Promise.all([

--- a/libs/coin-modules/coin-celo/src/bridge/getFeesForTransaction.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/getFeesForTransaction.ts
@@ -10,7 +10,7 @@ import {
   ZERO_ADDRESS,
 } from "../constants";
 import { getPendingStakingOperationAmounts, getVote } from "../logic";
-import { celoGasPrice, getCeloClient } from "../network/client";
+import { celoEstimateGas, celoGasPrice, getCeloClient } from "../network/client";
 import { getRegistryAddressFor } from "../network/registry";
 import type { CeloAccount, Transaction } from "../types";
 import buildTransaction from "./buildTransaction";
@@ -210,22 +210,14 @@ const getFeesForTransaction = async ({
       args: [transaction.recipient as `0x${string}`, BigInt(value.toFixed())],
     });
 
-    // Use eth_estimateGas directly so we can pass feeCurrency (viem's estimateGas doesn't expose it).
-    const estimateParams: Record<string, string | undefined> = {
-      from: account.freshAddress,
+    const estimatedGas = await celoEstimateGas({
+      from: account.freshAddress as `0x${string}`,
       to: tokenAddress,
       data,
-      maxFeePerGas: `0x${tokenMaxFeePerGas.toString(16)}`,
-      maxPriorityFeePerGas: `0x${maxPriorityFeePerGas.toString(16)}`,
-    };
-    if (transaction.feeCurrency) {
-      estimateParams.feeCurrency = transaction.feeCurrency;
-    }
-    const estimatedGasHex = await client.request({
-      method: "eth_estimateGas",
-      params: [estimateParams],
-    } as Parameters<typeof client.request>[0]);
-    const estimatedGas = BigInt(estimatedGasHex as string);
+      maxFeePerGas: tokenMaxFeePerGas,
+      maxPriorityFeePerGas,
+      feeCurrency: transaction.feeCurrency,
+    });
 
     gas = Number(Math.ceil(Number(estimatedGas) * MAX_FEES_THRESHOLD_MULTIPLIER).toString());
   } else {

--- a/libs/coin-modules/coin-celo/src/bridge/getFeesForTransaction.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/getFeesForTransaction.ts
@@ -216,7 +216,7 @@ const getFeesForTransaction = async ({
       data,
       maxFeePerGas: tokenMaxFeePerGas,
       maxPriorityFeePerGas,
-      ...(transaction.feeCurrency != null && { feeCurrency: transaction.feeCurrency }),
+      ...(transaction.feeCurrency && { feeCurrency: transaction.feeCurrency }),
     });
 
     gas = Number(Math.ceil(Number(estimatedGas) * MAX_FEES_THRESHOLD_MULTIPLIER).toString());

--- a/libs/coin-modules/coin-celo/src/bridge/getFeesForTransaction.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/getFeesForTransaction.ts
@@ -210,13 +210,22 @@ const getFeesForTransaction = async ({
       args: [transaction.recipient as `0x${string}`, BigInt(value.toFixed())],
     });
 
-    const estimatedGas = await client.estimateGas({
-      account: account.freshAddress as `0x${string}`,
+    // Use eth_estimateGas directly so we can pass feeCurrency (viem's estimateGas doesn't expose it).
+    const estimateParams: Record<string, string | undefined> = {
+      from: account.freshAddress,
       to: tokenAddress,
       data,
-      maxFeePerGas: tokenMaxFeePerGas,
-      maxPriorityFeePerGas,
-    });
+      maxFeePerGas: `0x${tokenMaxFeePerGas.toString(16)}`,
+      maxPriorityFeePerGas: `0x${maxPriorityFeePerGas.toString(16)}`,
+    };
+    if (transaction.feeCurrency) {
+      estimateParams.feeCurrency = transaction.feeCurrency;
+    }
+    const estimatedGasHex = await client.request({
+      method: "eth_estimateGas",
+      params: [estimateParams],
+    } as Parameters<typeof client.request>[0]);
+    const estimatedGas = BigInt(estimatedGasHex as string);
 
     gas = Number(Math.ceil(Number(estimatedGas) * MAX_FEES_THRESHOLD_MULTIPLIER).toString());
   } else {

--- a/libs/coin-modules/coin-celo/src/bridge/getFeesForTransaction.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/getFeesForTransaction.ts
@@ -216,7 +216,7 @@ const getFeesForTransaction = async ({
       data,
       maxFeePerGas: tokenMaxFeePerGas,
       maxPriorityFeePerGas,
-      feeCurrency: transaction.feeCurrency,
+      ...(transaction.feeCurrency != null && { feeCurrency: transaction.feeCurrency }),
     });
 
     gas = Number(Math.ceil(Number(estimatedGas) * MAX_FEES_THRESHOLD_MULTIPLIER).toString());

--- a/libs/coin-modules/coin-celo/src/network/client.ts
+++ b/libs/coin-modules/coin-celo/src/network/client.ts
@@ -34,12 +34,12 @@ export const celoGasPrice = async (feeCurrency?: `0x${string}`): Promise<bigint>
 
 export type CeloEstimateGasParams = {
   from: `0x${string}`;
-  to?: `0x${string}` | undefined;
-  data?: `0x${string}` | undefined;
-  value?: bigint | undefined;
-  maxFeePerGas?: bigint | undefined;
-  maxPriorityFeePerGas?: bigint | undefined;
-  feeCurrency?: `0x${string}` | null | undefined;
+  to?: `0x${string}`;
+  data?: `0x${string}`;
+  value?: bigint;
+  maxFeePerGas?: bigint;
+  maxPriorityFeePerGas?: bigint;
+  feeCurrency?: `0x${string}`;
 };
 
 /**
@@ -59,7 +59,7 @@ export const celoEstimateGas = async (params: CeloEstimateGasParams): Promise<bi
   if (params.maxPriorityFeePerGas !== undefined) {
     rpcParams.maxPriorityFeePerGas = `0x${params.maxPriorityFeePerGas.toString(16)}`;
   }
-  if (params.feeCurrency) rpcParams.feeCurrency = params.feeCurrency;
+  if (params.feeCurrency !== undefined) rpcParams.feeCurrency = params.feeCurrency;
   const result = await c.request({
     method: "eth_estimateGas",
     params: [rpcParams],

--- a/libs/coin-modules/coin-celo/src/network/client.ts
+++ b/libs/coin-modules/coin-celo/src/network/client.ts
@@ -31,3 +31,38 @@ export const celoGasPrice = async (feeCurrency?: `0x${string}`): Promise<bigint>
   } as Parameters<typeof c.request>[0]);
   return BigInt(result as string);
 };
+
+export type CeloEstimateGasParams = {
+  from: `0x${string}`;
+  to?: `0x${string}` | undefined;
+  data?: `0x${string}` | undefined;
+  value?: bigint | undefined;
+  maxFeePerGas?: bigint | undefined;
+  maxPriorityFeePerGas?: bigint | undefined;
+  feeCurrency?: `0x${string}` | null | undefined;
+};
+
+/**
+ * Estimates gas via Celo's `eth_estimateGas` RPC. Used instead of viem's
+ * `estimateGas` because the latter does not expose the fee-currency param —
+ * without it, the node underestimates gas for non-native fee-token transactions.
+ */
+export const celoEstimateGas = async (params: CeloEstimateGasParams): Promise<bigint> => {
+  const c = getCeloClient();
+  const rpcParams: Record<string, string> = { from: params.from };
+  if (params.to !== undefined) rpcParams.to = params.to;
+  if (params.data !== undefined) rpcParams.data = params.data;
+  if (params.value !== undefined) rpcParams.value = `0x${params.value.toString(16)}`;
+  if (params.maxFeePerGas !== undefined) {
+    rpcParams.maxFeePerGas = `0x${params.maxFeePerGas.toString(16)}`;
+  }
+  if (params.maxPriorityFeePerGas !== undefined) {
+    rpcParams.maxPriorityFeePerGas = `0x${params.maxPriorityFeePerGas.toString(16)}`;
+  }
+  if (params.feeCurrency) rpcParams.feeCurrency = params.feeCurrency;
+  const result = await c.request({
+    method: "eth_estimateGas",
+    params: [rpcParams],
+  } as Parameters<typeof c.request>[0]);
+  return BigInt(result as string);
+};

--- a/libs/ledger-live-common/src/bridge/descriptor/send/features.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor/send/features.ts
@@ -45,6 +45,13 @@ export const sendFeatures = {
     return d?.fees.presets?.shouldEstimateWithBridge?.(transaction) ?? false;
   },
   getAmountPlugins: fromDescriptor(d => d.amount?.getPlugins?.(), [] as readonly string[]),
+  getFeeCurrencyAccountId: (
+    currency: CryptoOrTokenCurrency | undefined,
+    transaction: unknown,
+  ): string | null => {
+    const d = getSendDescriptor(currency);
+    return d?.fees.getFeeCurrencyAccountId?.(transaction) ?? null;
+  },
   getMemoType: fromDescriptor(d => d.inputs.memo?.type, undefined),
   getMemoMaxLength: fromDescriptor(d => d.inputs.memo?.maxLength, undefined),
   getMemoMaxValue: fromDescriptor(d => d.inputs.memo?.maxValue, undefined),

--- a/libs/ledger-live-common/src/bridge/descriptor/types.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor/types.ts
@@ -204,6 +204,13 @@ export type FeeDescriptor = {
   customAssets?: FeeAssetsConfig;
   /** When `hasCoinControl` is true, describes rows and patches for the coin control step. */
   coinControl?: CoinControlConfig;
+  /**
+   * Optional accessor that exposes the sub-account id used to pay fees in a
+   * non-native currency, or `null` when fees are paid in the parent account's
+   * native currency. Lets the UI resolve the fee display unit without
+   * inspecting `transaction.family`.
+   */
+  getFeeCurrencyAccountId?: (transaction: unknown) => string | null;
 };
 
 export type SendAmountDescriptor = Readonly<{

--- a/libs/ledger-live-common/src/families/celo/descriptor.ts
+++ b/libs/ledger-live-common/src/families/celo/descriptor.ts
@@ -1,1 +1,0 @@
-export { descriptor } from "./descriptor/index";

--- a/libs/ledger-live-common/src/families/celo/descriptor.ts
+++ b/libs/ledger-live-common/src/families/celo/descriptor.ts
@@ -1,0 +1,1 @@
+export { descriptor } from "./descriptor/index";

--- a/libs/ledger-live-common/src/families/celo/descriptor/fees.ts
+++ b/libs/ledger-live-common/src/families/celo/descriptor/fees.ts
@@ -62,7 +62,7 @@ const celoCustomInputs: readonly CustomFeeInputDescriptor[] = [
 export const fees: FeeDescriptor = {
   hasPresets: false,
   hasCustom: true,
-  hasCustomAssets: true,
+  hasCustomAssets: false,
   custom: {
     inputs: celoCustomInputs,
     getInitialValues: (transaction): Record<string, string> => {
@@ -83,15 +83,5 @@ export const fees: FeeDescriptor = {
 
       return patch;
     },
-  },
-  customAssets: {
-    options: [
-      { id: "eth", ticker: "ETH", label: "Ethereum", unitLabel: "Gwei" },
-      { id: "btc", ticker: "BTC", label: "Bitcoin", unitLabel: "sat" },
-      { id: "usdc", ticker: "USDC", label: "USD Coin", unitLabel: "USDC" },
-      { id: "usdt", ticker: "USDT", label: "Tether", unitLabel: "USDT" },
-      { id: "celo", ticker: "Celo", label: "Celo", unitLabel: "Gwei" },
-    ],
-    defaultId: "eth",
   },
 };

--- a/libs/ledger-live-common/src/families/celo/descriptor/fees.ts
+++ b/libs/ledger-live-common/src/families/celo/descriptor/fees.ts
@@ -1,4 +1,5 @@
 import type { CustomFeeInputDescriptor, FeeDescriptor } from "../../../bridge/descriptor/types";
+import type { Transaction as CeloTransaction } from "../types";
 import { BigNumber } from "bignumber.js";
 
 const GWEI_DIVISOR = new BigNumber(10).pow(9);
@@ -84,4 +85,6 @@ export const fees: FeeDescriptor = {
       return patch;
     },
   },
+  getFeeCurrencyAccountId: transaction =>
+    (transaction as CeloTransaction).feeCurrencyAccountId ?? null,
 };

--- a/libs/ledger-live-common/src/families/celo/descriptor/index.ts
+++ b/libs/ledger-live-common/src/families/celo/descriptor/index.ts
@@ -5,5 +5,8 @@ export const descriptor: CoinDescriptor = {
   send: {
     inputs: {},
     fees,
+    amount: {
+      getPlugins: () => ["celoFeeCurrency"],
+    },
   },
 };

--- a/libs/ledger-live-common/src/flows/__tests__/uiConfig.test.ts
+++ b/libs/ledger-live-common/src/flows/__tests__/uiConfig.test.ts
@@ -16,6 +16,7 @@ jest.mock("../../bridge/descriptor/send/features", () => ({
     hasFeePresets: jest.fn(),
     hasCustomFees: jest.fn(),
     hasCoinControl: jest.fn(),
+    getAmountPlugins: jest.fn(() => []),
   },
 }));
 
@@ -95,6 +96,7 @@ describe("getSendUiConfig", () => {
         hasFeePresets: true,
         hasCustomFees: true,
         hasCoinControl: true,
+        hasAmountPlugins: false,
       });
     });
   });
@@ -126,6 +128,7 @@ describe("getSendUiConfig", () => {
         hasFeePresets: true,
         hasCustomFees: true,
         hasCoinControl: false,
+        hasAmountPlugins: false,
       });
     });
   });
@@ -159,6 +162,7 @@ describe("getSendUiConfig", () => {
         hasFeePresets: false,
         hasCustomFees: true,
         hasCoinControl: false,
+        hasAmountPlugins: false,
       });
     });
   });
@@ -175,6 +179,7 @@ describe("getSendUiConfig", () => {
         hasFeePresets: false,
         hasCustomFees: false,
         hasCoinControl: false,
+        hasAmountPlugins: false,
       });
     });
   });

--- a/libs/ledger-live-common/src/flows/__tests__/uiConfig.test.ts
+++ b/libs/ledger-live-common/src/flows/__tests__/uiConfig.test.ts
@@ -48,6 +48,14 @@ const mockSolanaCurrency: CryptoCurrency = {
   family: "solana",
 } as unknown as CryptoCurrency;
 
+const mockCeloCurrency: CryptoCurrency = {
+  type: "CryptoCurrency",
+  id: "celo",
+  name: "Celo",
+  ticker: "CELO",
+  family: "celo",
+} as unknown as CryptoCurrency;
+
 describe("getSendUiConfig", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -164,6 +172,49 @@ describe("getSendUiConfig", () => {
         hasCoinControl: false,
         hasAmountPlugins: false,
       });
+    });
+  });
+
+  describe("for a coin with Amount plugins (e.g. Celo)", () => {
+    it("returns hasAmountPlugins: true when the descriptor advertises plugins", () => {
+      mockedGetSendDescriptor.mockReturnValue({
+        inputs: {},
+        fees: { hasPresets: false, hasCustom: true },
+      });
+      mockedSendFeatures.hasMemo.mockReturnValue(false);
+      mockedSendFeatures.getMemoMaxLength.mockReturnValue(undefined);
+      mockedSendFeatures.getMemoMaxValue.mockReturnValue(undefined);
+      mockedSendFeatures.getMemoOptions.mockReturnValue(undefined);
+      mockedSendFeatures.supportsDomain.mockReturnValue(false);
+      mockedSendFeatures.hasFeePresets.mockReturnValue(false);
+      mockedSendFeatures.hasCustomFees.mockReturnValue(true);
+      mockedSendFeatures.hasCoinControl.mockReturnValue(false);
+      mockedSendFeatures.getAmountPlugins.mockReturnValue(["celoFeeCurrency"]);
+
+      const result = getSendUiConfig(mockCeloCurrency);
+
+      expect(result.hasAmountPlugins).toBe(true);
+      expect(mockedSendFeatures.getAmountPlugins).toHaveBeenCalledWith(mockCeloCurrency);
+    });
+
+    it("returns hasAmountPlugins: false when the descriptor advertises no plugins", () => {
+      mockedGetSendDescriptor.mockReturnValue({
+        inputs: {},
+        fees: { hasPresets: false, hasCustom: true },
+      });
+      mockedSendFeatures.hasMemo.mockReturnValue(false);
+      mockedSendFeatures.getMemoMaxLength.mockReturnValue(undefined);
+      mockedSendFeatures.getMemoMaxValue.mockReturnValue(undefined);
+      mockedSendFeatures.getMemoOptions.mockReturnValue(undefined);
+      mockedSendFeatures.supportsDomain.mockReturnValue(false);
+      mockedSendFeatures.hasFeePresets.mockReturnValue(false);
+      mockedSendFeatures.hasCustomFees.mockReturnValue(true);
+      mockedSendFeatures.hasCoinControl.mockReturnValue(false);
+      mockedSendFeatures.getAmountPlugins.mockReturnValue([]);
+
+      const result = getSendUiConfig(mockCeloCurrency);
+
+      expect(result.hasAmountPlugins).toBe(false);
     });
   });
 

--- a/libs/ledger-live-common/src/flows/send/types.ts
+++ b/libs/ledger-live-common/src/flows/send/types.ts
@@ -34,6 +34,7 @@ export type SendFlowUiConfig = Readonly<{
   hasFeePresets: boolean;
   hasCustomFees: boolean;
   hasCoinControl: boolean;
+  hasAmountPlugins: boolean;
 }>;
 
 export type Memo = { value: string; type?: string };

--- a/libs/ledger-live-common/src/flows/send/uiConfig.ts
+++ b/libs/ledger-live-common/src/flows/send/uiConfig.ts
@@ -13,6 +13,7 @@ export const DEFAULT_SEND_UI_CONFIG: SendFlowUiConfig = {
   hasFeePresets: false,
   hasCustomFees: false,
   hasCoinControl: false,
+  hasAmountPlugins: false,
 };
 
 export function getSendUiConfig(currency: CryptoOrTokenCurrency | null): SendFlowUiConfig {
@@ -35,5 +36,6 @@ export function getSendUiConfig(currency: CryptoOrTokenCurrency | null): SendFlo
     hasFeePresets: sendFeatures.hasFeePresets(currency),
     hasCustomFees: sendFeatures.hasCustomFees(currency),
     hasCoinControl: sendFeatures.hasCoinControl(currency),
+    hasAmountPlugins: sendFeatures.getAmountPlugins(currency).length > 0,
   };
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Bridge helper, descriptor capability, plugin (render / selection / stale-id reset / hydration / unhydrated-label), and the fee-display branch on both LLD and LLM.
- [x] **Impact of the changes:**
  - **Celo send flow (MVVM, LLD + LLM):** AMOUNT step gains a fee-currency picker; verify native CELO + allow-listed tokens (USDT, USDC, USDm, WETH, and regional mTokens — full list in `FEE_CURRENCY_OPTIONS`) and that estimated fees re-compute in the selected token's unit.
  - **Non-Celo coins on the AMOUNT step (LLD):** dialog height stays at `"fit"` unless an Amount plugin is registered for the current account. Sanity-check BTC / ETH / SOL / XRP for visual regressions.
  - **Classic Celo send flow:** shares the `coin-celo` bridge changes — verify the legacy token-fee selector still works.

### 📝 Description

Adapts the Celo "pay gas with tokens" feature — already shipped in the classic send flow — to the new MVVM send flow, while aligning with [ADR-034](https://ledgerhq.atlassian.net/wiki/spaces/CF/pages/7043678209/Coin+modules+-+ADR-034+-+FlowWizard) (no `family === "..."` branching in shared UI).

**What changed**

- **Descriptor surface (live-common):** new `FeeDescriptor.getFeeCurrencyAccountId?(transaction)` capability + `SendFlowUiConfig.hasAmountPlugins` flag, so shared hooks and the layout consume coin-agnostic config.
- **Celo descriptor:** implements `getFeeCurrencyAccountId`; declares `amount.getPlugins: () => ["celoFeeCurrency"]`. Placeholder `customAssets` stub removed.
- **`coin-celo` bridge:** new `celoEstimateGas` helper that threads `feeCurrency` into raw `eth_estimateGas` (viem's wrapper does not expose it); used by `buildTransaction` and `getFeesForTransaction`.
- **Shared hooks:** desktop `useFeeInfo` + both `useNetworkFees` resolve the display unit from the selected fee sub-account via the new descriptor accessor — no family checks.
- **`SendFlowLayout` (LLD):** reads `uiConfig.hasAmountPlugins` to pin AMOUNT dialog height when a plugin is registered.
- **`CeloFeeCurrencyPlugin` (LLD + LLM):** new picker — Lumen `Menu` on desktop, `QueuedDrawer` on mobile. Filters sub-accounts by allow-list + positive balance; resets stale `feeCurrencyAccountId` (with hydration guard); resolves the trigger label from `feeCurrencyUnwrapped` so it stays correct during sub-account hydration.

### ❓ Context

- **JIRA:** [LIVE-30160](https://ledgerhq.atlassian.net/browse/LIVE-30160)
- **ADR:** [Coin modules — ADR-034 — FlowWizard](https://ledgerhq.atlassian.net/wiki/spaces/CF/pages/7043678209/Coin+modules+-+ADR-034+-+FlowWizard)

[LIVE-30160]: https://ledgerhq.atlassian.net/browse/LIVE-30160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
