### PR TITLE
[LWDM] Add prompt layout for generic awareness modal

### DIFF
--- a/.changeset/many-spoons-act.md
+++ b/.changeset/many-spoons-act.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
+---
+
+Implement GAM prompt layout

--- a/.changeset/strange-impalas-raise.md
+++ b/.changeset/strange-impalas-raise.md
@@ -3,4 +3,4 @@
 "@ledgerhq/live-common": minor
 ---
 
-Implement GAM prompt layout
+Add prompt layout

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/GenericAwarenessModalView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/GenericAwarenessModalView.tsx
@@ -13,8 +13,12 @@ import useGenericAwarenessModalFeatureIntroViewModel, {
 import useGenericAwarenessModalCarouselViewModel, {
   type GenericAwarenessModalCarouselViewModel,
 } from "./hooks/useGenericAwarenessModalCarouselViewModel";
+import useGenericAwarenessModalPromptViewModel, {
+  type GenericAwarenessModalPromptViewModel,
+} from "./hooks/useGenericAwarenessModalPromptViewModel";
 import CarouselContent from "./components/CarouselContent";
 import FeatureIntroContent from "./components/FeatureIntroContent";
+import PromptContent from "./components/PromptContent";
 
 type LayoutChromeHandlers = Pick<
   GenericAwarenessModalCarouselViewModel | GenericAwarenessModalFeatureIntroViewModel,
@@ -40,12 +44,15 @@ function renderModalContent(
   contentCard: GenericAwarenessModalContentCard,
   carouselViewModel: GenericAwarenessModalCarouselViewModel,
   featureIntroViewModel: GenericAwarenessModalFeatureIntroViewModel,
+  promptViewModel: GenericAwarenessModalPromptViewModel,
 ) {
   switch (contentCard.layout) {
     case GenericAwarenessModalLayout.Carousel:
       return <CarouselContent {...carouselViewModel} />;
     case GenericAwarenessModalLayout.FeatureIntro:
       return <FeatureIntroContent {...featureIntroViewModel} />;
+    case GenericAwarenessModalLayout.Prompt:
+      return <PromptContent {...promptViewModel} />;
     default:
       return null;
   }
@@ -59,6 +66,7 @@ const GenericAwarenessModalView = ({
   const hasStoredContentCards = useSelector(selectGenericAwarenessModalHasStoredContentCards);
   const carouselViewModel = useGenericAwarenessModalCarouselViewModel(contentCard, isOpen);
   const featureIntroViewModel = useGenericAwarenessModalFeatureIntroViewModel(contentCard, isOpen);
+  const promptViewModel = useGenericAwarenessModalPromptViewModel(contentCard);
 
   useEffect(() => {
     if (isOpen && !contentCard && hasStoredContentCards) {
@@ -91,7 +99,12 @@ const GenericAwarenessModalView = ({
       >
         <DialogHeader density="expanded" onClose={onHeaderClose} />
         <DialogBody className="flex min-h-0 flex-1 flex-col gap-24 overflow-hidden">
-          {renderModalContent(contentCard, carouselViewModel, featureIntroViewModel)}
+          {renderModalContent(
+            contentCard,
+            carouselViewModel,
+            featureIntroViewModel,
+            promptViewModel,
+          )}
         </DialogBody>
       </DialogContent>
     </Dialog>

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/GenericAwarenessModalView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/GenericAwarenessModalView.tsx
@@ -21,7 +21,9 @@ import FeatureIntroContent from "./components/FeatureIntroContent";
 import PromptContent from "./components/PromptContent";
 
 type LayoutChromeHandlers = Pick<
-  GenericAwarenessModalCarouselViewModel | GenericAwarenessModalFeatureIntroViewModel,
+  | GenericAwarenessModalCarouselViewModel
+  | GenericAwarenessModalFeatureIntroViewModel
+  | GenericAwarenessModalPromptViewModel,
   "onDismiss" | "onHeaderClose"
 >;
 
@@ -29,12 +31,15 @@ const getLayoutViewModel = (
   layout: GenericAwarenessModalContentCard["layout"],
   carouselViewModel: GenericAwarenessModalCarouselViewModel,
   featureIntroViewModel: GenericAwarenessModalFeatureIntroViewModel,
+  promptViewModel: GenericAwarenessModalPromptViewModel,
 ): LayoutChromeHandlers | undefined => {
   switch (layout) {
     case GenericAwarenessModalLayout.Carousel:
       return carouselViewModel;
     case GenericAwarenessModalLayout.FeatureIntro:
       return featureIntroViewModel;
+    case GenericAwarenessModalLayout.Prompt:
+      return promptViewModel;
     default:
       return undefined;
   }
@@ -66,7 +71,7 @@ const GenericAwarenessModalView = ({
   const hasStoredContentCards = useSelector(selectGenericAwarenessModalHasStoredContentCards);
   const carouselViewModel = useGenericAwarenessModalCarouselViewModel(contentCard, isOpen);
   const featureIntroViewModel = useGenericAwarenessModalFeatureIntroViewModel(contentCard, isOpen);
-  const promptViewModel = useGenericAwarenessModalPromptViewModel(contentCard);
+  const promptViewModel = useGenericAwarenessModalPromptViewModel(contentCard, isOpen);
 
   useEffect(() => {
     if (isOpen && !contentCard && hasStoredContentCards) {
@@ -82,6 +87,7 @@ const GenericAwarenessModalView = ({
     contentCard.layout,
     carouselViewModel,
     featureIntroViewModel,
+    promptViewModel,
   );
 
   const onDismiss = layoutViewModel?.onDismiss ?? onClose;

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/__integrations__/GenericAwarenessModal.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/__integrations__/GenericAwarenessModal.integration.test.tsx
@@ -20,6 +20,7 @@ import {
 import {
   PAGE_TRACKING_AWARENESS_MODAL_CAROUSEL,
   PAGE_TRACKING_AWARENESS_MODAL_FEATURE_INTRO,
+  PAGE_TRACKING_AWARENESS_MODAL_PROMPT,
 } from "../analytics/const";
 import {
   closeGenericAwarenessModalDialog,
@@ -146,7 +147,7 @@ describe("GenericAwarenessModal Integration", () => {
   });
 
   describe("prompt variant", () => {
-    it("should render prompt when opened with prompt campaign id", async () => {
+    it("should open prompt, track page view, and render actions", async () => {
       const { store } = renderModal();
 
       act(() => {
@@ -169,9 +170,16 @@ describe("GenericAwarenessModal Integration", () => {
       expect(screen.getByTestId("generic-awareness-modal").getAttribute("data-campaign-id")).toBe(
         PROMPT_CAMPAIGN_ID,
       );
+      expect(trackPage).toHaveBeenCalledWith(
+        PAGE_TRACKING_AWARENESS_MODAL_PROMPT,
+        undefined,
+        expect.objectContaining({ contentId: PROMPT_CAMPAIGN_ID }),
+        true,
+        false,
+      );
     });
 
-    it("should close when the prompt primary button is clicked", async () => {
+    it("should track primary click, open the link, and close the modal", async () => {
       const { store, user } = renderModal();
 
       act(() => {
@@ -188,6 +196,53 @@ describe("GenericAwarenessModal Integration", () => {
 
       await user.click(screen.getByTestId("generic-awareness-modal-primary-button"));
 
+      expect(track).toHaveBeenCalledWith(
+        "button_clicked",
+        expect.objectContaining({
+          button: "learn more",
+          contentId: PROMPT_CAMPAIGN_ID,
+          ctaPosition: "primary",
+          link: "https://www.ledger.com/academy",
+        }),
+      );
+      expect(openURL).toHaveBeenCalledWith("https://www.ledger.com/academy");
+      await waitFor(() => {
+        expect(screen.queryByTestId("generic-awareness-modal")).not.toBeInTheDocument();
+      });
+      expect(store.getState().dialogs.GENERIC_AWARENESS_MODAL).toBe(false);
+    });
+
+    it("should track secondary click, open the link, and close the modal", async () => {
+      const { store, user } = renderModal();
+      openModal(store, PROMPT_CAMPAIGN_ID);
+
+      await user.click(await screen.findByRole("button", { name: "Maybe later" }));
+
+      expect(track).toHaveBeenCalledWith(
+        "button_clicked",
+        expect.objectContaining({
+          button: "maybe later",
+          contentId: PROMPT_CAMPAIGN_ID,
+          ctaPosition: "secondary",
+          link: "https://www.ledger.com",
+        }),
+      );
+      expect(openURL).toHaveBeenCalledWith("https://www.ledger.com");
+      await waitFor(() => {
+        expect(screen.queryByTestId("generic-awareness-modal")).not.toBeInTheDocument();
+      });
+    });
+
+    it("should close when the header close button is clicked", async () => {
+      const { store, user } = renderModal();
+      openModal(store, PROMPT_CAMPAIGN_ID);
+
+      await user.click(getGenericAwarenessModalHeaderCloseButton());
+
+      expect(track).toHaveBeenCalledWith(
+        "button_clicked",
+        expect.objectContaining({ button: "close", contentId: PROMPT_CAMPAIGN_ID }),
+      );
       await waitFor(() => {
         expect(screen.queryByTestId("generic-awareness-modal")).not.toBeInTheDocument();
       });

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/__integrations__/GenericAwarenessModal.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/__integrations__/GenericAwarenessModal.integration.test.tsx
@@ -7,6 +7,7 @@ import {
   APP_START_CAMPAIGN_ID,
   CAROUSEL_CAMPAIGN_ID,
   FEATURE_INTRO_CAMPAIGN_ID,
+  PROMPT_CAMPAIGN_ID,
 } from "../testUtils/fixtures";
 import {
   advanceCarouselSlide,
@@ -20,7 +21,10 @@ import {
   PAGE_TRACKING_AWARENESS_MODAL_CAROUSEL,
   PAGE_TRACKING_AWARENESS_MODAL_FEATURE_INTRO,
 } from "../analytics/const";
-import { closeGenericAwarenessModalDialog } from "../genericAwarenessModalDialog";
+import {
+  closeGenericAwarenessModalDialog,
+  openGenericAwarenessModalDialog,
+} from "../genericAwarenessModalDialog";
 
 jest.mock("~/renderer/linking", () => ({
   openURL: jest.fn(),
@@ -134,6 +138,56 @@ describe("GenericAwarenessModal Integration", () => {
         "button_clicked",
         expect.objectContaining({ button: "close", contentId: APP_START_CAMPAIGN_ID }),
       );
+      await waitFor(() => {
+        expect(screen.queryByTestId("generic-awareness-modal")).not.toBeInTheDocument();
+      });
+      expect(store.getState().dialogs.GENERIC_AWARENESS_MODAL).toBe(false);
+    });
+  });
+
+  describe("prompt variant", () => {
+    it("should render prompt when opened with prompt campaign id", async () => {
+      const { store } = renderModal();
+
+      act(() => {
+        seedGenericAwarenessModalContentCards(store);
+        dispatchGenericAwarenessModalThunk(
+          store,
+          openGenericAwarenessModalDialog({ campaignId: PROMPT_CAMPAIGN_ID }),
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Stay in control")).toBeVisible();
+      });
+      expect(
+        screen.getByText("Move assets to a hardware signer for true self-custody."),
+      ).toBeVisible();
+      expect(screen.getByRole("button", { name: "Learn more" })).toBeVisible();
+      expect(screen.getByRole("button", { name: "Maybe later" })).toBeVisible();
+      expect(screen.queryByTestId("generic-awareness-modal-continue-button")).not.toBeInTheDocument();
+      expect(screen.getByTestId("generic-awareness-modal").getAttribute("data-campaign-id")).toBe(
+        PROMPT_CAMPAIGN_ID,
+      );
+    });
+
+    it("should close when the prompt primary button is clicked", async () => {
+      const { store, user } = renderModal();
+
+      act(() => {
+        seedGenericAwarenessModalContentCards(store);
+        dispatchGenericAwarenessModalThunk(
+          store,
+          openGenericAwarenessModalDialog({ campaignId: PROMPT_CAMPAIGN_ID }),
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Learn more" })).toBeVisible();
+      });
+
+      await user.click(screen.getByTestId("generic-awareness-modal-primary-button"));
+
       await waitFor(() => {
         expect(screen.queryByTestId("generic-awareness-modal")).not.toBeInTheDocument();
       });

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/__tests__/GenericAwarenessModalView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/__tests__/GenericAwarenessModalView.test.tsx
@@ -6,12 +6,15 @@ import GenericAwarenessModalView from "../GenericAwarenessModalView";
 import {
   PAGE_TRACKING_AWARENESS_MODAL_CAROUSEL,
   PAGE_TRACKING_AWARENESS_MODAL_FEATURE_INTRO,
+  PAGE_TRACKING_AWARENESS_MODAL_PROMPT,
 } from "../analytics/const";
 import {
   APP_START_CAMPAIGN_ID,
   CAROUSEL_CAMPAIGN_ID,
+  PROMPT_CAMPAIGN_ID,
   appStartFeatureIntroCard,
   carouselCampaignCard,
+  promptCampaignCard,
 } from "../testUtils/fixtures";
 import {
   createGenericAwarenessModalTestState,
@@ -20,18 +23,6 @@ import {
 
 jest.mock("LLD/features/GenericAwarenessModal/genericAwarenessModalDialog", () => ({
   closeGenericAwarenessModalDialog: jest.fn(() => jest.fn()),
-}));
-
-jest.mock("../hooks/useGenericAwarenessModalPromptViewModel", () => ({
-  __esModule: true,
-  default: jest.fn(() => ({
-    title: "",
-    subtitle: "",
-    primaryButtonLabel: "",
-    secondaryButtonLabel: "",
-    onPrimaryClick: jest.fn(),
-    onSecondaryClick: jest.fn(),
-  })),
 }));
 
 describe("GenericAwarenessModalView", () => {
@@ -111,6 +102,24 @@ describe("GenericAwarenessModalView", () => {
     );
   });
 
+  it("should render prompt, track the page, and hide carousel controls", () => {
+    renderOpenAwarenessModalView(promptCampaignCard);
+
+    expect(screen.getByTestId("generic-awareness-modal")).toHaveAttribute(
+      "data-campaign-id",
+      PROMPT_CAMPAIGN_ID,
+    );
+    expect(screen.getByText("Stay in control")).toBeVisible();
+    expect(screen.queryByTestId("generic-awareness-modal-continue-button")).not.toBeInTheDocument();
+    expect(trackPage).toHaveBeenCalledWith(
+      PAGE_TRACKING_AWARENESS_MODAL_PROMPT,
+      undefined,
+      expect.objectContaining({ contentId: PROMPT_CAMPAIGN_ID }),
+      true,
+      false,
+    );
+  });
+
   it("should track dismiss and close the dialog on escape", () => {
     renderOpenAwarenessModalView(carouselCampaignCard);
 
@@ -125,6 +134,21 @@ describe("GenericAwarenessModalView", () => {
         contentId: CAROUSEL_CAMPAIGN_ID,
         stepName: "Ledger Flex",
       }),
+    );
+    expect(jest.mocked(closeGenericAwarenessModalDialog)).toHaveBeenCalled();
+  });
+
+  it("should track prompt dismiss and close the dialog on escape", () => {
+    renderOpenAwarenessModalView(promptCampaignCard);
+
+    fireEvent.keyDown(screen.getByTestId("generic-awareness-modal"), {
+      key: "Escape",
+      code: "Escape",
+    });
+
+    expect(track).toHaveBeenCalledWith(
+      "drawer_dismissed",
+      expect.objectContaining({ contentId: PROMPT_CAMPAIGN_ID }),
     );
     expect(jest.mocked(closeGenericAwarenessModalDialog)).toHaveBeenCalled();
   });

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/__tests__/GenericAwarenessModalView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/__tests__/GenericAwarenessModalView.test.tsx
@@ -22,6 +22,18 @@ jest.mock("LLD/features/GenericAwarenessModal/genericAwarenessModalDialog", () =
   closeGenericAwarenessModalDialog: jest.fn(() => jest.fn()),
 }));
 
+jest.mock("../hooks/useGenericAwarenessModalPromptViewModel", () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    title: "",
+    subtitle: "",
+    primaryButtonLabel: "",
+    secondaryButtonLabel: "",
+    onPrimaryClick: jest.fn(),
+    onSecondaryClick: jest.fn(),
+  })),
+}));
+
 describe("GenericAwarenessModalView", () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/analytics/__tests__/promptAnalytics.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/analytics/__tests__/promptAnalytics.test.ts
@@ -1,0 +1,56 @@
+import { track, trackPage } from "~/renderer/analytics/segment";
+import { promptCampaignCard } from "../../testUtils/fixtures";
+import {
+  getPromptAnalyticsContext,
+  trackPromptPage,
+  trackPromptPrimaryClick,
+  trackPromptSecondaryClick,
+} from "../promptAnalytics";
+import { PAGE_TRACKING_AWARENESS_MODAL_PROMPT } from "../const";
+
+describe("promptAnalytics", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should build context and track the prompt page", () => {
+    expect(getPromptAnalyticsContext(promptCampaignCard)).toEqual({
+      page: PAGE_TRACKING_AWARENESS_MODAL_PROMPT,
+      contentId: promptCampaignCard.id,
+    });
+
+    trackPromptPage(promptCampaignCard);
+
+    expect(trackPage).toHaveBeenCalledWith(
+      PAGE_TRACKING_AWARENESS_MODAL_PROMPT,
+      undefined,
+      expect.objectContaining({ contentId: promptCampaignCard.id }),
+      true,
+      false,
+    );
+  });
+
+  it("should track normalized primary and secondary button clicks", () => {
+    const context = getPromptAnalyticsContext(promptCampaignCard);
+
+    trackPromptPrimaryClick(context, "  Learn more  ", "https://www.ledger.com/academy");
+    trackPromptSecondaryClick(context, "Maybe later", "https://www.ledger.com");
+
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({
+        button: "learn more",
+        ctaPosition: "primary",
+        link: "https://www.ledger.com/academy",
+      }),
+    );
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({
+        button: "maybe later",
+        ctaPosition: "secondary",
+        link: "https://www.ledger.com",
+      }),
+    );
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/analytics/const.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/analytics/const.ts
@@ -1,3 +1,5 @@
 export const PAGE_TRACKING_AWARENESS_MODAL_CAROUSEL = "Awareness Modal Carousel" as const;
 
 export const PAGE_TRACKING_AWARENESS_MODAL_FEATURE_INTRO = "Awareness Modal Feature Intro" as const;
+
+export const PAGE_TRACKING_AWARENESS_MODAL_PROMPT = "Awareness Modal Prompt" as const;

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/analytics/promptAnalytics.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/analytics/promptAnalytics.ts
@@ -1,0 +1,79 @@
+import type { GenericAwarenessModalPrompt } from "@ledgerhq/live-common/genericAwarenessModal";
+import { track, trackPage } from "~/renderer/analytics/segment";
+import { PAGE_TRACKING_AWARENESS_MODAL_PROMPT } from "./const";
+
+type PromptAnalyticsContext = {
+  readonly page: typeof PAGE_TRACKING_AWARENESS_MODAL_PROMPT;
+  readonly contentId: string;
+};
+
+const normalizePromptButtonName = (label: string): string => label.trim().toLowerCase();
+
+export const getPromptAnalyticsContext = (
+  prompt: GenericAwarenessModalPrompt,
+): PromptAnalyticsContext => ({
+  page: PAGE_TRACKING_AWARENESS_MODAL_PROMPT,
+  contentId: prompt.id,
+});
+
+const getPromptPageProperties = (context: PromptAnalyticsContext) => ({
+  name: PAGE_TRACKING_AWARENESS_MODAL_PROMPT,
+  contentId: context.contentId,
+});
+
+const getPromptInteractionProperties = (context: PromptAnalyticsContext) => ({
+  page: context.page,
+  contentId: context.contentId,
+});
+
+export const trackPromptPage = (prompt: GenericAwarenessModalPrompt): void => {
+  const context = getPromptAnalyticsContext(prompt);
+  trackPage(
+    PAGE_TRACKING_AWARENESS_MODAL_PROMPT,
+    undefined,
+    getPromptPageProperties(context),
+    true,
+    false,
+  );
+};
+
+export const trackPromptPrimaryClick = (
+  context: PromptAnalyticsContext,
+  buttonLabel: string,
+  link: string,
+): void => {
+  track("button_clicked", {
+    button: normalizePromptButtonName(buttonLabel),
+    ...getPromptInteractionProperties(context),
+    ctaPosition: "primary",
+    link,
+  });
+};
+
+export const trackPromptSecondaryClick = (
+  context: PromptAnalyticsContext,
+  buttonLabel: string,
+  link: string,
+): void => {
+  track("button_clicked", {
+    button: normalizePromptButtonName(buttonLabel),
+    ...getPromptInteractionProperties(context),
+    ctaPosition: "secondary",
+    link,
+  });
+};
+
+export const trackPromptCloseClick = (context: PromptAnalyticsContext): void => {
+  track("button_clicked", {
+    button: "close",
+    ...getPromptInteractionProperties(context),
+  });
+};
+
+export const trackPromptDismissed = (context: PromptAnalyticsContext): void => {
+  track("drawer_dismissed", {
+    drawer: PAGE_TRACKING_AWARENESS_MODAL_PROMPT,
+    page: context.page,
+    contentId: context.contentId,
+  });
+};

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/components/PromptContent.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/components/PromptContent.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { Button } from "@ledgerhq/lumen-ui-react";
+import { TruncatedText } from "LLD/components/TruncatedText";
+
+export type PromptContentProps = {
+  title: string;
+  subtitle: string;
+  primaryButtonLabel: string;
+  secondaryButtonLabel: string;
+  onPrimaryClick: () => void;
+  onSecondaryClick: () => void;
+  imageUrl?: string;
+};
+
+export default function PromptContent({
+  title,
+  subtitle,
+  imageUrl,
+  primaryButtonLabel,
+  secondaryButtonLabel,
+  onPrimaryClick,
+  onSecondaryClick,
+}: Readonly<PromptContentProps>) {
+  const showImage = imageUrl != null && imageUrl.length > 0;
+
+  return (
+    <div className="flex min-h-0 w-full flex-1 flex-col">
+      <div className="flex min-h-0 flex-1 flex-col gap-24 overflow-y-auto">
+        {showImage ? (
+          <img
+            src={imageUrl}
+            alt=""
+            className="pointer-events-none h-[200px] w-full select-none rounded-xl object-cover"
+            draggable={false}
+            decoding="async"
+          />
+        ) : (
+          <div className="h-[200px] shrink-0 rounded-xl bg-muted" aria-hidden />
+        )}
+        <div className="flex w-full min-w-0 flex-col items-center text-center">
+          <TruncatedText text={title} className="mb-8 text-center heading-4-semi-bold text-base" />
+          <p className="m-0 body-2 text-muted">{subtitle}</p>
+        </div>
+      </div>
+      <div className="flex w-full shrink-0 flex-col items-center gap-16 pt-24">
+        <Button
+          appearance="base"
+          size="lg"
+          onClick={onPrimaryClick}
+          className="w-full"
+          data-testid="generic-awareness-modal-primary-button"
+        >
+          {primaryButtonLabel}
+        </Button>
+        <Button
+          appearance="gray"
+          size="lg"
+          onClick={onSecondaryClick}
+          className="w-full"
+          data-testid="generic-awareness-modal-secondary-button"
+        >
+          {secondaryButtonLabel}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/components/PromptContent.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/components/PromptContent.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Button } from "@ledgerhq/lumen-ui-react";
-import { TruncatedText } from "LLD/components/TruncatedText";
+import { AwarenessModalClampedText, CAROUSEL_SLIDE_TEXT_LINE_LIMITS } from "./clampedText";
 
 export type PromptContentProps = {
   title: string;
@@ -38,8 +38,16 @@ export default function PromptContent({
           <div className="h-[200px] shrink-0 rounded-xl bg-muted" aria-hidden />
         )}
         <div className="flex w-full min-w-0 flex-col items-center text-center">
-          <TruncatedText text={title} className="mb-8 text-center heading-4-semi-bold text-base" />
-          <p className="m-0 body-2 text-muted">{subtitle}</p>
+          <AwarenessModalClampedText
+            text={title}
+            maxLines={CAROUSEL_SLIDE_TEXT_LINE_LIMITS.title}
+            className="mb-8 text-center heading-4-semi-bold text-base"
+          />
+          <AwarenessModalClampedText
+            text={subtitle}
+            maxLines={CAROUSEL_SLIDE_TEXT_LINE_LIMITS.subtitle}
+            className="body-2 text-center text-muted"
+          />
         </div>
       </div>
       <div className="flex w-full shrink-0 flex-col items-center gap-16 pt-24">

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/components/__tests__/PromptContent.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/components/__tests__/PromptContent.test.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import PromptContent from "../PromptContent";
+
+const baseProps = {
+  title: "Test title",
+  subtitle: "Test subtitle",
+  primaryButtonLabel: "Primary",
+  secondaryButtonLabel: "Secondary",
+  onPrimaryClick: jest.fn(),
+  onSecondaryClick: jest.fn(),
+};
+
+describe("PromptContent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should render title, subtitle, and button labels", () => {
+    render(<PromptContent {...baseProps} />);
+
+    expect(screen.getByText("Test title")).toBeVisible();
+    expect(screen.getByText("Test subtitle")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Primary" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Secondary" })).toBeVisible();
+  });
+
+  it("should call onPrimaryClick when the primary button is pressed", async () => {
+    const { user } = render(<PromptContent {...baseProps} />);
+
+    await user.click(screen.getByTestId("generic-awareness-modal-primary-button"));
+
+    expect(baseProps.onPrimaryClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call onSecondaryClick when the secondary button is pressed", async () => {
+    const { user } = render(<PromptContent {...baseProps} />);
+
+    await user.click(screen.getByTestId("generic-awareness-modal-secondary-button"));
+
+    expect(baseProps.onSecondaryClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("should render an image when imageUrl is provided", () => {
+    const { container } = render(
+      <PromptContent {...baseProps} imageUrl="https://example.com/hero.png" />,
+    );
+
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img).toHaveAttribute("src", "https://example.com/hero.png");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/components/__tests__/PromptContent.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/components/__tests__/PromptContent.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen } from "tests/testSetup";
+import { CAROUSEL_SLIDE_TEXT_LINE_LIMITS } from "../clampedText";
 import PromptContent from "../PromptContent";
 
 const baseProps = {
@@ -16,11 +17,13 @@ describe("PromptContent", () => {
     jest.clearAllMocks();
   });
 
-  it("should render title, subtitle, and button labels", () => {
+  it("should render title and subtitle with carousel slide line limits", () => {
     render(<PromptContent {...baseProps} />);
 
-    expect(screen.getByText("Test title")).toBeVisible();
-    expect(screen.getByText("Test subtitle")).toBeVisible();
+    expect(screen.getByText("Test title")).toHaveClass("truncate");
+    expect(
+      screen.getByText("Test subtitle").style.getPropertyValue("-webkit-line-clamp"),
+    ).toBe(String(CAROUSEL_SLIDE_TEXT_LINE_LIMITS.subtitle));
     expect(screen.getByRole("button", { name: "Primary" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Secondary" })).toBeVisible();
   });

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/__tests__/useGenericAwarenessModalPromptViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/__tests__/useGenericAwarenessModalPromptViewModel.test.tsx
@@ -1,6 +1,8 @@
 import { act } from "tests/testSetup";
+import { track, trackPage } from "~/renderer/analytics/segment";
 import { openURL } from "~/renderer/linking";
 import { closeGenericAwarenessModalDialog } from "LLD/features/GenericAwarenessModal/genericAwarenessModalDialog";
+import { PAGE_TRACKING_AWARENESS_MODAL_PROMPT } from "../../analytics/const";
 import { carouselCampaignCard, promptCampaignCard } from "../../testUtils/fixtures";
 import useGenericAwarenessModalPromptViewModel from "../useGenericAwarenessModalPromptViewModel";
 import { renderHookWithStore } from "../testHelpers/renderHookWithStore";
@@ -20,7 +22,7 @@ describe("useGenericAwarenessModalPromptViewModel", () => {
 
   it("should return empty content when content card is undefined", () => {
     const { result } = renderHookWithStore(() =>
-      useGenericAwarenessModalPromptViewModel(undefined),
+      useGenericAwarenessModalPromptViewModel(undefined, false),
     );
 
     expect(result.current).toEqual({
@@ -31,12 +33,14 @@ describe("useGenericAwarenessModalPromptViewModel", () => {
       imageUrl: undefined,
       onPrimaryClick: expect.any(Function),
       onSecondaryClick: expect.any(Function),
+      onHeaderClose: expect.any(Function),
+      onDismiss: expect.any(Function),
     });
   });
 
   it("should return empty content when content card is not prompt", () => {
     const { result } = renderHookWithStore(() =>
-      useGenericAwarenessModalPromptViewModel(carouselCampaignCard),
+      useGenericAwarenessModalPromptViewModel(carouselCampaignCard, false),
     );
 
     expect(result.current.title).toBe("");
@@ -45,7 +49,7 @@ describe("useGenericAwarenessModalPromptViewModel", () => {
 
   it("should map prompt content from the content card", () => {
     const { result } = renderHookWithStore(() =>
-      useGenericAwarenessModalPromptViewModel(promptCampaignCard),
+      useGenericAwarenessModalPromptViewModel(promptCampaignCard, true),
     );
 
     expect(result.current.title).toBe("Stay in control");
@@ -57,28 +61,56 @@ describe("useGenericAwarenessModalPromptViewModel", () => {
     expect(result.current.imageUrl).toBe("https://example.com/prompt.png");
   });
 
-  it("should open primary link and close dialog on primary click", () => {
+  it("should track page view when open with a prompt card", () => {
+    renderHookWithStore(() => useGenericAwarenessModalPromptViewModel(promptCampaignCard, true));
+
+    expect(trackPage).toHaveBeenCalledWith(
+      PAGE_TRACKING_AWARENESS_MODAL_PROMPT,
+      undefined,
+      expect.objectContaining({ contentId: promptCampaignCard.id }),
+      true,
+      false,
+    );
+  });
+
+  it("should track primary click, open the link, and close dialog", () => {
     const { result } = renderHookWithStore(() =>
-      useGenericAwarenessModalPromptViewModel(promptCampaignCard),
+      useGenericAwarenessModalPromptViewModel(promptCampaignCard, true),
     );
 
     act(() => {
       result.current.onPrimaryClick();
     });
 
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({
+        button: "learn more",
+        ctaPosition: "primary",
+        link: "https://www.ledger.com/academy",
+      }),
+    );
     expect(openURL).toHaveBeenCalledWith("https://www.ledger.com/academy");
     expect(jest.mocked(closeGenericAwarenessModalDialog)).toHaveBeenCalled();
   });
 
-  it("should open secondary link and close dialog on secondary click", () => {
+  it("should track secondary click, open the link, and close dialog", () => {
     const { result } = renderHookWithStore(() =>
-      useGenericAwarenessModalPromptViewModel(promptCampaignCard),
+      useGenericAwarenessModalPromptViewModel(promptCampaignCard, true),
     );
 
     act(() => {
       result.current.onSecondaryClick();
     });
 
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({
+        button: "maybe later",
+        ctaPosition: "secondary",
+        link: "https://www.ledger.com",
+      }),
+    );
     expect(openURL).toHaveBeenCalledWith("https://www.ledger.com");
     expect(jest.mocked(closeGenericAwarenessModalDialog)).toHaveBeenCalled();
   });

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/__tests__/useGenericAwarenessModalPromptViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/__tests__/useGenericAwarenessModalPromptViewModel.test.tsx
@@ -1,0 +1,85 @@
+import { act } from "tests/testSetup";
+import { openURL } from "~/renderer/linking";
+import { closeGenericAwarenessModalDialog } from "LLD/features/GenericAwarenessModal/genericAwarenessModalDialog";
+import { carouselCampaignCard, promptCampaignCard } from "../../testUtils/fixtures";
+import useGenericAwarenessModalPromptViewModel from "../useGenericAwarenessModalPromptViewModel";
+import { renderHookWithStore } from "../testHelpers/renderHookWithStore";
+
+jest.mock("~/renderer/linking", () => ({
+  openURL: jest.fn(),
+}));
+
+jest.mock("LLD/features/GenericAwarenessModal/genericAwarenessModalDialog", () => ({
+  closeGenericAwarenessModalDialog: jest.fn(() => jest.fn()),
+}));
+
+describe("useGenericAwarenessModalPromptViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return empty content when content card is undefined", () => {
+    const { result } = renderHookWithStore(() =>
+      useGenericAwarenessModalPromptViewModel(undefined),
+    );
+
+    expect(result.current).toEqual({
+      title: "",
+      subtitle: "",
+      primaryButtonLabel: "",
+      secondaryButtonLabel: "",
+      imageUrl: undefined,
+      onPrimaryClick: expect.any(Function),
+      onSecondaryClick: expect.any(Function),
+    });
+  });
+
+  it("should return empty content when content card is not prompt", () => {
+    const { result } = renderHookWithStore(() =>
+      useGenericAwarenessModalPromptViewModel(carouselCampaignCard),
+    );
+
+    expect(result.current.title).toBe("");
+    expect(result.current.primaryButtonLabel).toBe("");
+  });
+
+  it("should map prompt content from the content card", () => {
+    const { result } = renderHookWithStore(() =>
+      useGenericAwarenessModalPromptViewModel(promptCampaignCard),
+    );
+
+    expect(result.current.title).toBe("Stay in control");
+    expect(result.current.subtitle).toBe(
+      "Move assets to a hardware signer for true self-custody.",
+    );
+    expect(result.current.primaryButtonLabel).toBe("Learn more");
+    expect(result.current.secondaryButtonLabel).toBe("Maybe later");
+    expect(result.current.imageUrl).toBe("https://example.com/prompt.png");
+  });
+
+  it("should open primary link and close dialog on primary click", () => {
+    const { result } = renderHookWithStore(() =>
+      useGenericAwarenessModalPromptViewModel(promptCampaignCard),
+    );
+
+    act(() => {
+      result.current.onPrimaryClick();
+    });
+
+    expect(openURL).toHaveBeenCalledWith("https://www.ledger.com/academy");
+    expect(jest.mocked(closeGenericAwarenessModalDialog)).toHaveBeenCalled();
+  });
+
+  it("should open secondary link and close dialog on secondary click", () => {
+    const { result } = renderHookWithStore(() =>
+      useGenericAwarenessModalPromptViewModel(promptCampaignCard),
+    );
+
+    act(() => {
+      result.current.onSecondaryClick();
+    });
+
+    expect(openURL).toHaveBeenCalledWith("https://www.ledger.com");
+    expect(jest.mocked(closeGenericAwarenessModalDialog)).toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/useGenericAwarenessModalPromptViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/useGenericAwarenessModalPromptViewModel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useDispatch } from "LLD/hooks/redux";
 import {
   GenericAwarenessModalLayout,
@@ -7,6 +7,14 @@ import {
 } from "@ledgerhq/live-common/genericAwarenessModal";
 import { closeGenericAwarenessModalDialog } from "../genericAwarenessModalDialog";
 import { openURL } from "~/renderer/linking";
+import {
+  getPromptAnalyticsContext,
+  trackPromptCloseClick,
+  trackPromptDismissed,
+  trackPromptPage,
+  trackPromptPrimaryClick,
+  trackPromptSecondaryClick,
+} from "../analytics/promptAnalytics";
 
 export interface GenericAwarenessModalPromptViewModel {
   title: string;
@@ -16,29 +24,78 @@ export interface GenericAwarenessModalPromptViewModel {
   imageUrl?: string;
   onPrimaryClick: () => void;
   onSecondaryClick: () => void;
+  onHeaderClose: () => void;
+  onDismiss: () => void;
 }
 
 const useGenericAwarenessModalPromptViewModel = (
   contentCard: GenericAwarenessModalContentCard | undefined,
+  isOpen: boolean,
 ): GenericAwarenessModalPromptViewModel => {
   const dispatch = useDispatch();
+  const hasTrackedOpenRef = useRef(false);
 
   const prompt: GenericAwarenessModalPrompt | undefined =
     contentCard?.layout === GenericAwarenessModalLayout.Prompt ? contentCard : undefined;
 
-  const onPrimaryClick = useCallback(() => {
-    if (prompt) {
-      openURL(prompt.primaryButtonLink);
-      dispatch(closeGenericAwarenessModalDialog());
+  const closeDialog = useCallback(() => {
+    dispatch(closeGenericAwarenessModalDialog());
+  }, [dispatch]);
+
+  const getContext = useCallback(() => {
+    if (!prompt) {
+      return undefined;
     }
-  }, [dispatch, prompt]);
+    return getPromptAnalyticsContext(prompt);
+  }, [prompt]);
+
+  useEffect(() => {
+    if (!isOpen || !prompt) {
+      hasTrackedOpenRef.current = false;
+      return;
+    }
+
+    if (hasTrackedOpenRef.current) {
+      return;
+    }
+
+    hasTrackedOpenRef.current = true;
+    trackPromptPage(prompt);
+  }, [isOpen, prompt]);
+
+  const onPrimaryClick = useCallback(() => {
+    const context = getContext();
+    if (context && prompt) {
+      trackPromptPrimaryClick(context, prompt.primaryButtonLabel, prompt.primaryButtonLink);
+      openURL(prompt.primaryButtonLink);
+    }
+    closeDialog();
+  }, [closeDialog, getContext, prompt]);
 
   const onSecondaryClick = useCallback(() => {
-    if (prompt) {
+    const context = getContext();
+    if (context && prompt) {
+      trackPromptSecondaryClick(context, prompt.secondaryButtonLabel, prompt.secondaryButtonLink);
       openURL(prompt.secondaryButtonLink);
-      dispatch(closeGenericAwarenessModalDialog());
     }
-  }, [dispatch, prompt]);
+    closeDialog();
+  }, [closeDialog, getContext, prompt]);
+
+  const onHeaderClose = useCallback(() => {
+    const context = getContext();
+    if (context) {
+      trackPromptCloseClick(context);
+    }
+    closeDialog();
+  }, [closeDialog, getContext]);
+
+  const onDismiss = useCallback(() => {
+    const context = getContext();
+    if (context) {
+      trackPromptDismissed(context);
+    }
+    closeDialog();
+  }, [closeDialog, getContext]);
 
   return useMemo(
     () => ({
@@ -49,8 +106,10 @@ const useGenericAwarenessModalPromptViewModel = (
       imageUrl: prompt?.imageUrl || undefined,
       onPrimaryClick,
       onSecondaryClick,
+      onHeaderClose,
+      onDismiss,
     }),
-    [onPrimaryClick, onSecondaryClick, prompt],
+    [onDismiss, onHeaderClose, onPrimaryClick, onSecondaryClick, prompt],
   );
 };
 

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/useGenericAwarenessModalPromptViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/useGenericAwarenessModalPromptViewModel.ts
@@ -1,0 +1,57 @@
+import { useCallback, useMemo } from "react";
+import { useDispatch } from "LLD/hooks/redux";
+import {
+  GenericAwarenessModalLayout,
+  type GenericAwarenessModalContentCard,
+  type GenericAwarenessModalPrompt,
+} from "@ledgerhq/live-common/genericAwarenessModal";
+import { closeGenericAwarenessModalDialog } from "../genericAwarenessModalDialog";
+import { openURL } from "~/renderer/linking";
+
+export interface GenericAwarenessModalPromptViewModel {
+  title: string;
+  subtitle: string;
+  primaryButtonLabel: string;
+  secondaryButtonLabel: string;
+  imageUrl?: string;
+  onPrimaryClick: () => void;
+  onSecondaryClick: () => void;
+}
+
+const useGenericAwarenessModalPromptViewModel = (
+  contentCard: GenericAwarenessModalContentCard | undefined,
+): GenericAwarenessModalPromptViewModel => {
+  const dispatch = useDispatch();
+
+  const prompt: GenericAwarenessModalPrompt | undefined =
+    contentCard?.layout === GenericAwarenessModalLayout.Prompt ? contentCard : undefined;
+
+  const onPrimaryClick = useCallback(() => {
+    if (prompt) {
+      openURL(prompt.primaryButtonLink);
+      dispatch(closeGenericAwarenessModalDialog());
+    }
+  }, [dispatch, prompt]);
+
+  const onSecondaryClick = useCallback(() => {
+    if (prompt) {
+      openURL(prompt.secondaryButtonLink);
+      dispatch(closeGenericAwarenessModalDialog());
+    }
+  }, [dispatch, prompt]);
+
+  return useMemo(
+    () => ({
+      title: prompt?.title ?? "",
+      subtitle: prompt?.subtitle ?? "",
+      primaryButtonLabel: prompt?.primaryButtonLabel ?? "",
+      secondaryButtonLabel: prompt?.secondaryButtonLabel ?? "",
+      imageUrl: prompt?.imageUrl || undefined,
+      onPrimaryClick,
+      onSecondaryClick,
+    }),
+    [onPrimaryClick, onSecondaryClick, prompt],
+  );
+};
+
+export default useGenericAwarenessModalPromptViewModel;

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/testUtils/fixtures.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/testUtils/fixtures.ts
@@ -2,6 +2,7 @@ import {
   GenericAwarenessModalLayout,
   type GenericAwarenessModalCarousel,
   type GenericAwarenessModalFeatureIntro,
+  type GenericAwarenessModalPrompt,
 } from "@ledgerhq/live-common/genericAwarenessModal";
 
 /** APP_START campaign — default when opening the modal without a campaign id. */
@@ -12,6 +13,9 @@ export const FEATURE_INTRO_CAMPAIGN_ID = "1";
 
 /** Carousel campaign — open via deeplink with this campaign id. */
 export const CAROUSEL_CAMPAIGN_ID = "2";
+
+/** Prompt campaign — open via deeplink with this campaign id. */
+export const PROMPT_CAMPAIGN_ID = "3";
 
 export const appStartFeatureIntroCard: GenericAwarenessModalFeatureIntro = {
   layout: GenericAwarenessModalLayout.FeatureIntro,
@@ -100,8 +104,21 @@ export const carouselCampaignCard: GenericAwarenessModalCarousel = {
   ],
 };
 
+export const promptCampaignCard: GenericAwarenessModalPrompt = {
+  layout: GenericAwarenessModalLayout.Prompt,
+  id: PROMPT_CAMPAIGN_ID,
+  title: "Stay in control",
+  subtitle: "Move assets to a hardware signer for true self-custody.",
+  imageUrl: "https://example.com/prompt.png",
+  primaryButtonLabel: "Learn more",
+  primaryButtonLink: "https://www.ledger.com/academy",
+  secondaryButtonLabel: "Maybe later",
+  secondaryButtonLink: "https://www.ledger.com",
+};
+
 export const genericAwarenessModalTestContentCards = [
   appStartFeatureIntroCard,
   featureIntroCampaignCard,
   carouselCampaignCard,
+  promptCampaignCard,
 ];

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenericAwarenessModalDevTool/screens/GenericAwarenessModalDevScreen/GenericAwarenessModalDevScreenView.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenericAwarenessModalDevTool/screens/GenericAwarenessModalDevScreen/GenericAwarenessModalDevScreenView.tsx
@@ -22,6 +22,7 @@ import type { GenericAwarenessModalDevScreenViewModel } from "./useGenericAwaren
 const LAYOUT_OPTIONS: SelectOption<DevLayoutMode>[] = [
   { value: "carousel", label: COPY.layoutCarousel },
   { value: "featureIntro", label: COPY.layoutFeatureIntro },
+  { value: "prompt", label: COPY.layoutPrompt },
 ];
 
 const TRIGGER_OPTIONS: SelectOption<DevTriggerMode>[] = [
@@ -154,7 +155,9 @@ export function GenericAwarenessModalDevScreenView({
           </section>
         ) : (
           <section className="flex flex-col gap-8">
-            <DevSectionHeader title={COPY.featureIntroMain} />
+            <DevSectionHeader
+              title={form.layout === "prompt" ? COPY.promptMain : COPY.featureIntroMain}
+            />
             <DevLabeledInput
               label={COPY.fields.title}
               value={form.title}
@@ -191,51 +194,55 @@ export function GenericAwarenessModalDevScreenView({
               onChange={secondaryButtonLink => updateForm({ secondaryButtonLink })}
             />
 
-            <DevSectionHeader
-              title={COPY.featureIntroItems}
-              action={
-                <Button
-                  size="sm"
-                  appearance="accent"
-                  disabled={form.items.length >= MAX_FEATURE_INTRO_ITEMS}
-                  onClick={addItem}
-                >
-                  {COPY.addItem}
-                </Button>
-              }
-            />
-            {form.items.map((item, index) => (
-              <DevFormCard key={itemKeys[index]}>
+            {form.layout === "featureIntro" ? (
+              <>
                 <DevSectionHeader
-                  title={COPY.itemLabel(index)}
+                  title={COPY.featureIntroItems}
                   action={
                     <Button
                       size="sm"
-                      appearance="red"
-                      disabled={form.items.length <= MIN_FEATURE_INTRO_ITEMS}
-                      onClick={() => removeItem(index)}
+                      appearance="accent"
+                      disabled={form.items.length >= MAX_FEATURE_INTRO_ITEMS}
+                      onClick={addItem}
                     >
-                      {COPY.removeItem}
+                      {COPY.addItem}
                     </Button>
                   }
                 />
-                <DevLabeledInput
-                  label={COPY.fields.icon}
-                  value={item.icon}
-                  onChange={icon => updateItem(index, { icon })}
-                />
-                <DevLabeledInput
-                  label={COPY.fields.title}
-                  value={item.title}
-                  onChange={title => updateItem(index, { title })}
-                />
-                <DevLabeledInput
-                  label={COPY.fields.subtitle}
-                  value={item.subtitle}
-                  onChange={subtitle => updateItem(index, { subtitle })}
-                />
-              </DevFormCard>
-            ))}
+                {form.items.map((item, index) => (
+                  <DevFormCard key={itemKeys[index]}>
+                    <DevSectionHeader
+                      title={COPY.itemLabel(index)}
+                      action={
+                        <Button
+                          size="sm"
+                          appearance="red"
+                          disabled={form.items.length <= MIN_FEATURE_INTRO_ITEMS}
+                          onClick={() => removeItem(index)}
+                        >
+                          {COPY.removeItem}
+                        </Button>
+                      }
+                    />
+                    <DevLabeledInput
+                      label={COPY.fields.icon}
+                      value={item.icon}
+                      onChange={icon => updateItem(index, { icon })}
+                    />
+                    <DevLabeledInput
+                      label={COPY.fields.title}
+                      value={item.title}
+                      onChange={title => updateItem(index, { title })}
+                    />
+                    <DevLabeledInput
+                      label={COPY.fields.subtitle}
+                      value={item.subtitle}
+                      onChange={subtitle => updateItem(index, { subtitle })}
+                    />
+                  </DevFormCard>
+                ))}
+              </>
+            ) : null}
           </section>
         )}
 

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenericAwarenessModalDevTool/utils/buildContentCardFromForm.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenericAwarenessModalDevTool/utils/buildContentCardFromForm.ts
@@ -24,6 +24,20 @@ export const buildContentCardFromForm = (
     };
   }
 
+  if (form.layout === "prompt") {
+    return {
+      layout: GenericAwarenessModalLayout.Prompt,
+      id,
+      title: form.title,
+      subtitle: form.subtitle,
+      imageUrl: form.imageUrl,
+      primaryButtonLabel: form.primaryButtonLabel,
+      primaryButtonLink: form.primaryButtonLink,
+      secondaryButtonLabel: form.secondaryButtonLabel,
+      secondaryButtonLink: form.secondaryButtonLink,
+    };
+  }
+
   return {
     layout: GenericAwarenessModalLayout.FeatureIntro,
     id,

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenericAwarenessModalDevTool/utils/campaignIds.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenericAwarenessModalDevTool/utils/campaignIds.ts
@@ -4,20 +4,27 @@ import type { DevLayoutMode, DevTriggerMode } from "./types";
 export const DEV_CAMPAIGN_IDS = {
   appStartFeatureIntro: "APP_START_generic_awareness_modal_feature_intro",
   appStartCarousel: "APP_START_generic_awareness_modal_carousel",
+  appStartPrompt: "APP_START_generic_awareness_modal_prompt",
   bannerFeatureIntro: "debug_generic_awareness_modal_feature_intro",
   bannerCarousel: "debug_generic_awareness_modal_carousel",
+  bannerPrompt: "debug_generic_awareness_modal_prompt",
 } as const;
 
-export const resolveCampaignId = (layout: DevLayoutMode, trigger: DevTriggerMode): string => {
-  if (trigger === "appStart") {
-    return layout === "carousel"
-      ? DEV_CAMPAIGN_IDS.appStartCarousel
-      : DEV_CAMPAIGN_IDS.appStartFeatureIntro;
-  }
-  return layout === "carousel"
-    ? DEV_CAMPAIGN_IDS.bannerCarousel
-    : DEV_CAMPAIGN_IDS.bannerFeatureIntro;
-};
+const CAMPAIGN_IDS_BY_TRIGGER = {
+  appStart: {
+    carousel: DEV_CAMPAIGN_IDS.appStartCarousel,
+    featureIntro: DEV_CAMPAIGN_IDS.appStartFeatureIntro,
+    prompt: DEV_CAMPAIGN_IDS.appStartPrompt,
+  },
+  bannerClick: {
+    carousel: DEV_CAMPAIGN_IDS.bannerCarousel,
+    featureIntro: DEV_CAMPAIGN_IDS.bannerFeatureIntro,
+    prompt: DEV_CAMPAIGN_IDS.bannerPrompt,
+  },
+} as const satisfies Record<DevTriggerMode, Record<DevLayoutMode, string>>;
+
+export const resolveCampaignId = (layout: DevLayoutMode, trigger: DevTriggerMode): string =>
+  CAMPAIGN_IDS_BY_TRIGGER[trigger][layout];
 
 export const campaignIdDeeplinkHint = (campaignId: string): string =>
   `ledgerwallet://generic-awareness-modal?id=${encodeURIComponent(campaignId)}`;

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenericAwarenessModalDevTool/utils/copy.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenericAwarenessModalDevTool/utils/copy.ts
@@ -1,7 +1,7 @@
 export const COPY = {
   rowTitle: "Generic awareness modal (QA)",
   rowDesc:
-    "Build carousel or feature intro content cards, choose app start or banner/deeplink trigger, preview the modal, and clear QA cards from the store.",
+    "Build carousel, feature intro, or prompt content cards, choose app start or banner/deeplink trigger, preview the modal, and clear QA cards from the store.",
   open: "Open",
   back: "Back",
   title: "Generic awareness modal — QA",
@@ -21,6 +21,7 @@ export const COPY = {
   copiedDeeplink: "Copied",
   carouselSlides: "Carousel slides",
   featureIntroMain: "Main content card",
+  promptMain: "Prompt content",
   featureIntroItems: "List items",
   addSlide: "Add slide",
   removeSlide: "Remove slide",

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenericAwarenessModalDevTool/utils/defaults.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenericAwarenessModalDevTool/utils/defaults.ts
@@ -1,4 +1,4 @@
-import { getPicsumImageUrl } from "./placeholderImages";
+import { getDevToolCarouselImageUrl, getDevToolPlaceholderImageUrl } from "./placeholderImages";
 import type {
   CarouselSlideForm,
   DevLayoutMode,
@@ -15,7 +15,7 @@ const CAROUSEL_PRIMARY_BUTTON_LABELS = ["Learn more", "Discover", "Explore"] as 
 const defaultCarouselSlide = (index: number): CarouselSlideForm => ({
   title: `Slide ${index + 1} title`,
   subtitle: `Slide ${index + 1} subtitle`,
-  imageUrl: getPicsumImageUrl(),
+  imageUrl: getDevToolCarouselImageUrl(index),
   primaryButtonLabel: CAROUSEL_PRIMARY_BUTTON_LABELS[index % CAROUSEL_PRIMARY_BUTTON_LABELS.length],
   primaryButtonLink: "https://www.ledger.com",
 });
@@ -48,6 +48,23 @@ const featureIntroDefaults = {
   secondaryButtonLink: "https://www.ledger.com",
 };
 
+const promptDefaults = {
+  title: "Stay in control",
+  subtitle: "Move assets to a hardware signer for true self-custody.",
+  primaryButtonLabel: "Learn more",
+  primaryButtonLink: "https://www.ledger.com/academy",
+  secondaryButtonLabel: "Maybe later",
+  secondaryButtonLink: "https://www.ledger.com",
+};
+
+const layoutContentDefaults: Record<
+  Exclude<DevLayoutMode, "carousel">,
+  typeof featureIntroDefaults
+> = {
+  featureIntro: featureIntroDefaults,
+  prompt: promptDefaults,
+};
+
 export const createInitialFormState = (
   layout: DevLayoutMode = "carousel",
   trigger: DevTriggerMode = "appStart",
@@ -56,8 +73,8 @@ export const createInitialFormState = (
   trigger,
   slides: createDefaultCarouselSlides(),
   items: createDefaultFeatureIntroItems(),
-  ...featureIntroDefaults,
-  imageUrl: getPicsumImageUrl(),
+  ...(layout === "carousel" ? featureIntroDefaults : layoutContentDefaults[layout]),
+  imageUrl: getDevToolPlaceholderImageUrl(),
 });
 
 export const createDefaultCarouselSlideAt = (index: number): CarouselSlideForm =>

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenericAwarenessModalDevTool/utils/placeholderImages.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenericAwarenessModalDevTool/utils/placeholderImages.ts
@@ -1,18 +1,30 @@
-/** Placeholder images from https://picsum.photos (Lorem Picsum). */
-export const PICSUM_IMAGE_WIDTH = 400;
-export const PICSUM_IMAGE_HEIGHT = 300;
+/** Static images from https://shop.ledger.com/pages/ledger-wallet */
+const SHOPIFY_IMAGE_WIDTH = 800;
 
-export const createRandomPicsumSeed = (): string => {
-  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
-    return crypto.randomUUID();
-  }
+const shopifyImage = (file: string, version: number): string =>
+  `https://cdn.shopify.com/s/files/1/2974/4858/files/${file}?v=${version}&width=${SHOPIFY_IMAGE_WIDTH}`;
 
-  return `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
-};
+const NAMED_PLACEHOLDER_IMAGES = {
+  default: shopifyImage("lw.webp", 1775642601),
+  "sample-feature-intro-app-start": shopifyImage("entries_visuals_mob.webp", 1738082910),
+  "sample-feature-intro-banner": shopifyImage("recovery_solutions_desktop.webp", 1760980844),
+  "sample-prompt-app-start":
+    "https://images.ctfassets.net/ge894kijjvls/5Lky02Ow8goZhGWEvYFh4Q/c80cf0db8d69dd5532a3e31bdac73c04/ksp3.webp",
+  "sample-prompt-banner": shopifyImage("ledger-stax-face.webp", 1738140795),
+} as const;
 
-export const getPicsumImageUrl = (seed: string = createRandomPicsumSeed()): string =>
-  `https://picsum.photos/seed/${encodeURIComponent(seed)}/${PICSUM_IMAGE_WIDTH}/${PICSUM_IMAGE_HEIGHT}`;
+export const DEV_TOOL_CAROUSEL_IMAGES = [
+  shopifyImage("flex_magenta_front_desktop.webp", 1760980832),
+  "https://images.ctfassets.net/ge894kijjvls/27KBUAvGe0ux3M1QLsDNkV/bbb4e0279bfb72904375890cd5dc00b5/ksp1.webp",
+  shopifyImage("classic_nanos_desktop.webp", 1760980844),
+] as const;
 
-/** Stable seed per slide index — used for sample cards. */
-export const getPicsumCarouselImageUrl = (slideIndex: number): string =>
-  getPicsumImageUrl(`generic-awareness-modal-carousel-${slideIndex}`);
+export const getDevToolPlaceholderImageUrl = (
+  key: keyof typeof NAMED_PLACEHOLDER_IMAGES | string = "default",
+): string =>
+  key in NAMED_PLACEHOLDER_IMAGES
+    ? NAMED_PLACEHOLDER_IMAGES[key as keyof typeof NAMED_PLACEHOLDER_IMAGES]
+    : NAMED_PLACEHOLDER_IMAGES.default;
+
+export const getDevToolCarouselImageUrl = (slideIndex: number): string =>
+  DEV_TOOL_CAROUSEL_IMAGES[slideIndex % DEV_TOOL_CAROUSEL_IMAGES.length];

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenericAwarenessModalDevTool/utils/sampleContentCards.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenericAwarenessModalDevTool/utils/sampleContentCards.ts
@@ -3,27 +3,27 @@ import {
   type GenericAwarenessModalContentCard,
 } from "@ledgerhq/live-common/genericAwarenessModal";
 import { DEV_CAMPAIGN_IDS } from "./campaignIds";
-import { getPicsumCarouselImageUrl, getPicsumImageUrl } from "./placeholderImages";
+import { getDevToolCarouselImageUrl, getDevToolPlaceholderImageUrl } from "./placeholderImages";
 
 const sampleCarouselSlides = [
   {
     title: "Ledger Flex",
     subtitle: "The new standard to buy, swap, stake, and build your portfolio with ease.",
-    imageUrl: getPicsumCarouselImageUrl(0),
+    imageUrl: getDevToolCarouselImageUrl(0),
     primaryButtonLabel: "Discover Flex",
     primaryButtonLink: "https://www.ledger.com/products/ledger-flex",
   },
   {
     title: "Ledger Wallet clarity",
     subtitle: "Faster trades with real-time market and portfolio insights.",
-    imageUrl: getPicsumCarouselImageUrl(1),
+    imageUrl: getDevToolCarouselImageUrl(1),
     primaryButtonLabel: "Explore the app",
     primaryButtonLink: "https://www.ledger.com/ledger-wallet",
   },
   {
     title: "Bitcoin, secured",
     subtitle: "Manage Bitcoin with keys that never leave your device.",
-    imageUrl: getPicsumCarouselImageUrl(2),
+    imageUrl: getDevToolCarouselImageUrl(2),
     primaryButtonLabel: "Bitcoin wallet",
     primaryButtonLink: "https://www.ledger.com/coin/wallet/bitcoin",
   },
@@ -37,7 +37,7 @@ export const sampleGenericAwarenessModalContentCards: GenericAwarenessModalConte
     title: "Connect a Ledger device",
     subtitle:
       "Go beyond exchanges and software wallets. Pair a signer to unlock the full Ledger Wallet experience.",
-    imageUrl: getPicsumImageUrl("sample-feature-intro-app-start"),
+    imageUrl: getDevToolPlaceholderImageUrl("sample-feature-intro-app-start"),
     primaryButtonLabel: "Got it",
     primaryButtonLink: "https://www.ledger.com",
     secondaryButtonLabel: "Compare signers",
@@ -66,7 +66,7 @@ export const sampleGenericAwarenessModalContentCards: GenericAwarenessModalConte
     title: "Not your keys, not your coins",
     subtitle:
       "Hot wallets and exchanges are convenient, but only a hardware signer gives you true ownership of your crypto.",
-    imageUrl: getPicsumImageUrl("sample-feature-intro-banner"),
+    imageUrl: getDevToolPlaceholderImageUrl("sample-feature-intro-banner"),
     primaryButtonLabel: "Learn about cold storage",
     primaryButtonLink:
       "https://www.ledger.com/academy/topics/ledgersolutions/what-is-a-cold-wallet",
@@ -91,5 +91,27 @@ export const sampleGenericAwarenessModalContentCards: GenericAwarenessModalConte
     layout: GenericAwarenessModalLayout.Carousel,
     id: DEV_CAMPAIGN_IDS.bannerCarousel,
     data: sampleCarouselSlides,
+  },
+  {
+    layout: GenericAwarenessModalLayout.Prompt,
+    id: DEV_CAMPAIGN_IDS.appStartPrompt,
+    title: "Stay in control",
+    subtitle: "Move assets to a hardware signer for true self-custody.",
+    imageUrl: getDevToolPlaceholderImageUrl("sample-prompt-app-start"),
+    primaryButtonLabel: "Learn more",
+    primaryButtonLink: "https://www.ledger.com/academy",
+    secondaryButtonLabel: "Maybe later",
+    secondaryButtonLink: "https://www.ledger.com",
+  },
+  {
+    layout: GenericAwarenessModalLayout.Prompt,
+    id: DEV_CAMPAIGN_IDS.bannerPrompt,
+    title: "Secure your assets",
+    subtitle: "Hardware signers keep your keys offline and under your control.",
+    imageUrl: getDevToolPlaceholderImageUrl("sample-prompt-banner"),
+    primaryButtonLabel: "Discover signers",
+    primaryButtonLink: "https://www.ledger.com/products",
+    secondaryButtonLabel: "Not now",
+    secondaryButtonLink: "https://www.ledger.com",
   },
 ];

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenericAwarenessModalDevTool/utils/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenericAwarenessModalDevTool/utils/types.ts
@@ -1,4 +1,4 @@
-export type DevLayoutMode = "carousel" | "featureIntro";
+export type DevLayoutMode = "carousel" | "featureIntro" | "prompt";
 export type DevTriggerMode = "appStart" | "bannerClick";
 
 export type CarouselSlideForm = {

--- a/apps/ledger-live-mobile/src/dynamicContent/buildLocalGenericAwarenessModalCards.test.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/buildLocalGenericAwarenessModalCards.test.ts
@@ -133,6 +133,8 @@ describe("buildLocalGenericAwarenessModalCards", () => {
       imageUrl: "https://example.com/prompt.png",
       primaryButtonLabel: "Learn more",
       primaryButtonLink: "https://example.com",
+      secondaryButtonLabel: "Maybe later",
+      secondaryButtonLink: "ledgerlive://myledger",
     };
 
     const rawCards = buildLocalGenericAwarenessModalBrazeCards(values);
@@ -148,6 +150,8 @@ describe("buildLocalGenericAwarenessModalCards", () => {
       imageUrl: "https://example.com/prompt.png",
       primaryButtonLabel: "Learn more",
       primaryButtonLink: "https://example.com",
+      secondaryButtonLabel: "Maybe later",
+      secondaryButtonLink: "ledgerlive://myledger",
     });
     expect(rawCards[0].extras).not.toHaveProperty("index");
     expect(rawCards[0].extras).not.toHaveProperty("role");
@@ -161,6 +165,8 @@ describe("buildLocalGenericAwarenessModalCards", () => {
         imageUrl: "https://example.com/prompt.png",
         primaryButtonLabel: "Learn more",
         primaryButtonLink: "https://example.com",
+        secondaryButtonLabel: "Maybe later",
+        secondaryButtonLink: "ledgerlive://myledger",
       },
     ]);
   });

--- a/apps/ledger-live-mobile/src/dynamicContent/buildLocalGenericAwarenessModalCards.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/buildLocalGenericAwarenessModalCards.ts
@@ -180,6 +180,8 @@ function buildPromptBrazeCard(
         imageUrl: values.imageUrl,
         primaryButtonLabel: values.primaryButtonLabel,
         primaryButtonLink: values.primaryButtonLink,
+        secondaryButtonLabel: values.secondaryButtonLabel,
+        secondaryButtonLink: values.secondaryButtonLink,
       },
     },
   ];

--- a/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/mockData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/mockData.ts
@@ -158,4 +158,6 @@ export const promptMockData: GenericAwarenessModalPrompt = {
   subtitle: "Open the feature from Ledger Wallet whenever you need it.",
   primaryButtonLabel: "Learn more",
   primaryButtonLink: "https://www.ledger.com",
+  secondaryButtonLabel: "Buy your Ledger device",
+  secondaryButtonLink: "ledgerlive://buy",
 };

--- a/libs/ledger-live-common/src/genericAwarenessModal/__tests__/buildContentCards.test.ts
+++ b/libs/ledger-live-common/src/genericAwarenessModal/__tests__/buildContentCards.test.ts
@@ -431,4 +431,141 @@ describe("processGenericAwarenessModalBrazeCards", () => {
     expect(contentCards[1]?.layout).toBe(GenericAwarenessModalLayout.FeatureIntro);
     expect(contentCards[2]?.layout).toBe(GenericAwarenessModalLayout.Prompt);
   });
+
+  it("should group cards by campaignId case-insensitively and preserve the first card casing", () => {
+    const firstCampaignCard = makeCard("1", { campaignId: "Campaign-A", layout: "carousel", index: "0" });
+    const secondCampaignCard = makeCard("2", { campaignId: "campaign-a", layout: "CAROUSEL", index: "1" });
+    const otherCampaignCard = makeCard("3", { campaignId: "Other", layout: "carousel", index: "0" });
+
+    const groupedCards = groupByCampaignId([
+      firstCampaignCard,
+      secondCampaignCard,
+      otherCampaignCard,
+    ]);
+
+    expect(groupedCards.size).toBe(2);
+    expect(groupedCards.get("Campaign-A")).toEqual([firstCampaignCard, secondCampaignCard]);
+    expect(groupedCards.get("Other")).toEqual([otherCampaignCard]);
+  });
+
+  it("should preserve the first card campaignId casing in built content cards", () => {
+    const firstCard = makeCard("1", {
+      campaignId: "Campaign-A",
+      layout: "carousel",
+      index: "0",
+      title: "Slide 1",
+    });
+    const secondCard = makeCard("2", {
+      campaignId: "campaign-a",
+      layout: "CAROUSEL",
+      index: "1",
+      title: "Slide 2",
+    });
+
+    const contentCards = processGenericAwarenessModalBrazeCards([firstCard, secondCard]);
+
+    expect(contentCards).toHaveLength(1);
+    expect(contentCards[0]).toEqual({
+      layout: GenericAwarenessModalLayout.Carousel,
+      id: "Campaign-A",
+      data: [
+        expect.objectContaining({ title: "Slide 1" }),
+        expect.objectContaining({ title: "Slide 2" }),
+      ],
+    });
+  });
+
+  it("should accept case-insensitive layout, location, and role extras", () => {
+    const carouselCard = makeCard("carousel-1", {
+      layout: "CAROUSEL",
+      campaignId: "campaign-carousel",
+      location: "GENERIC_AWARENESS_MODAL",
+      index: "0",
+      title: "Slide 1",
+    });
+    const carouselCardTwo = makeCard("carousel-2", {
+      layout: "carousel",
+      campaignId: "campaign-carousel",
+      location: "generic_awareness_modal",
+      index: "1",
+      title: "Slide 2",
+    });
+    const featureIntroMainCard = makeCard("feature-intro-main", {
+      layout: "FEATUREINTRO",
+      campaignId: "campaign-feature-intro",
+      location: "Generic_Awareness_Modal",
+      role: "MAIN",
+      title: "Main title",
+      subtitle: "Main subtitle",
+    });
+    const featureIntroItemCard = makeCard("feature-intro-item", {
+      layout: "featureIntro",
+      campaignId: "campaign-feature-intro",
+      location: "generic_awareness_modal",
+      role: "item",
+      index: "0",
+      icon: "icon",
+      title: "Item title",
+      subtitle: "Item subtitle",
+    });
+    const promptCard = makeCard("prompt", {
+      layout: "PROMPT",
+      campaignId: "campaign-prompt",
+      location: "GENERIC_AWARENESS_MODAL",
+      title: "Prompt title",
+      subtitle: "Prompt subtitle",
+    });
+
+    const contentCards = processGenericAwarenessModalBrazeCards([
+      carouselCard,
+      carouselCardTwo,
+      featureIntroMainCard,
+      featureIntroItemCard,
+      promptCard,
+    ]);
+
+    expect(contentCards).toHaveLength(3);
+    expect(contentCards[0]?.layout).toBe(GenericAwarenessModalLayout.Carousel);
+    expect(contentCards[1]?.layout).toBe(GenericAwarenessModalLayout.FeatureIntro);
+    expect(contentCards[2]?.layout).toBe(GenericAwarenessModalLayout.Prompt);
+  });
+
+  it("should reject campaigns with mixed layouts regardless of casing", () => {
+    const carouselCard = makeCard("1", { campaignId: "mixed", layout: "CAROUSEL", index: "0" });
+    const promptCard = makeCard("2", { campaignId: "mixed", layout: "prompt" });
+
+    const contentCards = processGenericAwarenessModalBrazeCards([carouselCard, promptCard]);
+
+    expect(contentCards).toEqual([]);
+  });
+
+  it("should trim whitespace from braze string fields when building content cards", () => {
+    const promptCard = makeCard("prompt", {
+      layout: ` ${GenericAwarenessModalLayout.Prompt} `,
+      campaignId: " campaign-prompt ",
+      title: "  Prompt title  ",
+      subtitle: "  Prompt subtitle  ",
+      imageUrl: "  https://example.com/prompt.png  ",
+      primaryButtonLabel: "  Primary  ",
+      primaryButtonLink: "  ledgerwallet://primary  ",
+      secondaryButtonLabel: "  Secondary  ",
+      secondaryButtonLink: "  ledgerwallet://secondary  ",
+    });
+
+    const contentCards = processGenericAwarenessModalBrazeCards([promptCard]);
+
+    expect(contentCards).toEqual([
+      {
+        layout: GenericAwarenessModalLayout.Prompt,
+        id: "campaign-prompt",
+        title: "Prompt title",
+        subtitle: "Prompt subtitle",
+        imageUrl: "https://example.com/prompt.png",
+        primaryButtonLabel: "Primary",
+        primaryButtonLink: "ledgerwallet://primary",
+        secondaryButtonLabel: "Secondary",
+        secondaryButtonLink: "ledgerwallet://secondary",
+      },
+    ]);
+  });
 });

--- a/libs/ledger-live-common/src/genericAwarenessModal/__tests__/buildContentCards.test.ts
+++ b/libs/ledger-live-common/src/genericAwarenessModal/__tests__/buildContentCards.test.ts
@@ -195,6 +195,49 @@ describe("buildGenericAwarenessModalContentCards", () => {
     ]);
   });
 
+  it("should build prompt content from grouped braze card extras", () => {
+    const promptCard = makeCard("prompt", {
+      layout: GenericAwarenessModalLayout.Prompt,
+      campaignId: "campaign-prompt",
+      imageUrl: "https://example.com/prompt.png",
+      title: "Prompt title",
+      subtitle: "Prompt subtitle",
+      primaryButtonLabel: "Primary",
+      primaryButtonLink: "ledgerwallet://primary",
+      secondaryButtonLabel: "Secondary",
+      secondaryButtonLink: "ledgerwallet://secondary",
+    });
+    const groupedCards = makeGroupedCards("campaign-prompt", [promptCard]);
+
+    const contentCards = buildGenericAwarenessModalContentCards(groupedCards);
+
+    expect(contentCards).toEqual([
+      {
+        layout: GenericAwarenessModalLayout.Prompt,
+        id: "campaign-prompt",
+        imageUrl: "https://example.com/prompt.png",
+        title: "Prompt title",
+        subtitle: "Prompt subtitle",
+        primaryButtonLabel: "Primary",
+        primaryButtonLink: "ledgerwallet://primary",
+        secondaryButtonLabel: "Secondary",
+        secondaryButtonLink: "ledgerwallet://secondary",
+      },
+    ]);
+  });
+
+  it("should skip prompt campaigns when braze cards do not parse as prompt inputs", () => {
+    const invalidPromptCard = makeCard("invalid", {
+      layout: GenericAwarenessModalLayout.Prompt,
+      title: "Missing campaignId in extras",
+    });
+    const groupedCards = makeGroupedCards("campaign-prompt", [invalidPromptCard]);
+
+    const contentCards = buildGenericAwarenessModalContentCards(groupedCards);
+
+    expect(contentCards).toEqual([]);
+  });
+
   it("should skip feature intro campaigns without a main card", () => {
     const itemCard = makeCard("item-0", {
       layout: GenericAwarenessModalLayout.FeatureIntro,
@@ -235,6 +278,8 @@ describe("buildGenericAwarenessModalContentCards", () => {
         imageUrl: "https://example.com/prompt.png",
         primaryButtonLabel: "Learn more",
         primaryButtonLink: "https://example.com",
+        secondaryButtonLabel: "",
+        secondaryButtonLink: "",
       },
     ]);
   });
@@ -358,18 +403,32 @@ describe("processGenericAwarenessModalBrazeCards", () => {
       secondaryButtonLabel: "Secondary",
       secondaryButtonLink: "ledgerwallet://secondary",
     });
+    const promptCard = makeCard("prompt", {
+      layout: GenericAwarenessModalLayout.Prompt,
+      campaignId: "campaign-prompt",
+      title: "Prompt",
+      subtitle: "Prompt subtitle",
+      imageUrl: "https://example.com/prompt.png",
+      primaryButtonLabel: "Primary",
+      primaryButtonLink: "ledgerwallet://primary",
+      secondaryButtonLabel: "Secondary",
+      secondaryButtonLink: "ledgerwallet://secondary",
+    });
 
     const contentCards = processGenericAwarenessModalBrazeCards([
       carouselCard,
       featureIntroMainCard,
+      promptCard,
     ]);
 
-    expect(contentCards).toHaveLength(2);
+    expect(contentCards).toHaveLength(3);
     expect(contentCards.map(card => card.id)).toEqual([
       "campaign-carousel",
       "campaign-feature-intro",
+      "campaign-prompt",
     ]);
     expect(contentCards[0]?.layout).toBe(GenericAwarenessModalLayout.Carousel);
     expect(contentCards[1]?.layout).toBe(GenericAwarenessModalLayout.FeatureIntro);
+    expect(contentCards[2]?.layout).toBe(GenericAwarenessModalLayout.Prompt);
   });
 });

--- a/libs/ledger-live-common/src/genericAwarenessModal/__tests__/buildPrompt.test.ts
+++ b/libs/ledger-live-common/src/genericAwarenessModal/__tests__/buildPrompt.test.ts
@@ -15,14 +15,16 @@ const makeCard = (
 
 describe("buildPrompt", () => {
   it("should build prompt content from a valid prompt input", () => {
-    const promptCard = makeCard("prompt", {
+    const promptCard = makeCard("prompt-1", {
       layout: GenericAwarenessModalLayout.Prompt,
       campaignId: "campaign-1",
+      imageUrl: "https://example.com/prompt.png",
       title: "Prompt title",
       subtitle: "Prompt subtitle",
-      imageUrl: "https://example.com/prompt.png",
-      primaryButtonLabel: "Learn more",
-      primaryButtonLink: "https://example.com",
+      primaryButtonLabel: "Primary",
+      primaryButtonLink: "ledgerwallet://primary",
+      secondaryButtonLabel: "Secondary",
+      secondaryButtonLink: "ledgerwallet://secondary",
     });
 
     const prompt = buildPrompt("campaign-1", [promptCard]);
@@ -30,16 +32,18 @@ describe("buildPrompt", () => {
     expect(prompt).toEqual({
       layout: GenericAwarenessModalLayout.Prompt,
       id: "campaign-1",
+      imageUrl: "https://example.com/prompt.png",
       title: "Prompt title",
       subtitle: "Prompt subtitle",
-      imageUrl: "https://example.com/prompt.png",
-      primaryButtonLabel: "Learn more",
-      primaryButtonLink: "https://example.com",
+      primaryButtonLabel: "Primary",
+      primaryButtonLink: "ledgerwallet://primary",
+      secondaryButtonLabel: "Secondary",
+      secondaryButtonLink: "ledgerwallet://secondary",
     });
   });
 
   it("should default missing prompt fields to empty strings", () => {
-    const promptCard = makeCard("prompt", {
+    const promptCard = makeCard("prompt-1", {
       layout: GenericAwarenessModalLayout.Prompt,
       campaignId: "campaign-1",
     });
@@ -49,11 +53,13 @@ describe("buildPrompt", () => {
     expect(prompt).toEqual({
       layout: GenericAwarenessModalLayout.Prompt,
       id: "campaign-1",
+      imageUrl: "",
       title: "",
       subtitle: "",
-      imageUrl: "",
       primaryButtonLabel: "",
       primaryButtonLink: "",
+      secondaryButtonLabel: "",
+      secondaryButtonLink: "",
     });
   });
 
@@ -68,5 +74,22 @@ describe("buildPrompt", () => {
     const prompt = buildPrompt("campaign-1", [carouselCard]);
 
     expect(prompt).toBeUndefined();
+  });
+
+  it("should use the first valid prompt card when multiple cards are provided", () => {
+    const firstPromptCard = makeCard("first", {
+      layout: GenericAwarenessModalLayout.Prompt,
+      campaignId: "campaign-1",
+      title: "First",
+    });
+    const secondPromptCard = makeCard("second", {
+      layout: GenericAwarenessModalLayout.Prompt,
+      campaignId: "campaign-1",
+      title: "Second",
+    });
+
+    const prompt = buildPrompt("campaign-1", [secondPromptCard, firstPromptCard]);
+
+    expect(prompt?.title).toBe("Second");
   });
 });

--- a/libs/ledger-live-common/src/genericAwarenessModal/buildContentCards.ts
+++ b/libs/ledger-live-common/src/genericAwarenessModal/buildContentCards.ts
@@ -9,67 +9,80 @@ import {
 
 export type { GenericAwarenessModalBrazeCard } from "./types";
 
+type ContentCardBuilder = (
+  campaignId: string,
+  cards: GenericAwarenessModalBrazeCard[],
+) => GenericAwarenessModalContentCard | undefined;
+
+const CONTENT_CARD_BUILDERS: Record<GenericAwarenessModalLayout, ContentCardBuilder> = {
+  [GenericAwarenessModalLayout.Carousel]: buildCarousel,
+  [GenericAwarenessModalLayout.FeatureIntro]: buildFeatureIntro,
+  [GenericAwarenessModalLayout.Prompt]: buildPrompt,
+};
+
+const isGenericAwarenessModalLayout = (
+  layout: string | undefined,
+): layout is GenericAwarenessModalLayout =>
+  layout !== undefined && layout in CONTENT_CARD_BUILDERS;
+
 export const groupByCampaignId = (
   cards: GenericAwarenessModalBrazeCard[],
 ): Map<string, GenericAwarenessModalBrazeCard[]> => {
   const cardsByCampaignId = new Map<string, GenericAwarenessModalBrazeCard[]>();
 
-  cards.forEach(card => {
+  for (const card of cards) {
     const campaignId = card.extras?.campaignId;
-    if (campaignId !== undefined && campaignId !== "") {
-      const campaignCards = cardsByCampaignId.get(campaignId);
-      if (campaignCards) {
-        campaignCards.push(card);
-      } else {
-        cardsByCampaignId.set(campaignId, [card]);
-      }
+    if (!campaignId) {
+      continue;
     }
-  });
+
+    const campaignCards = cardsByCampaignId.get(campaignId);
+    if (campaignCards) {
+      campaignCards.push(card);
+    } else {
+      cardsByCampaignId.set(campaignId, [card]);
+    }
+  }
 
   return cardsByCampaignId;
 };
 
-export const hasUniqueLayout = (cards: GenericAwarenessModalBrazeCard[]) => {
-  return new Set(cards.map(card => card.extras?.layout)).size === 1;
-};
+export const hasUniqueLayout = (cards: GenericAwarenessModalBrazeCard[]) =>
+  new Set(cards.map(card => card.extras?.layout)).size === 1;
 
 export const getValidGenericAwarenessModalCards = (
   groupedCards: Map<string, GenericAwarenessModalBrazeCard[]>,
-) => {
-  return new Map<string, GenericAwarenessModalBrazeCard[]>(
-    Array.from(groupedCards.entries()).filter(([, cards]) => hasUniqueLayout(cards)),
+) =>
+  new Map(
+    Array.from(groupedCards.entries()).filter(([, campaignCards]) =>
+      hasUniqueLayout(campaignCards),
+    ),
   );
-};
 
 const buildContentCard = (
   campaignId: string,
   cards: GenericAwarenessModalBrazeCard[],
 ): GenericAwarenessModalContentCard | undefined => {
   const layout = cards[0]?.extras?.layout;
-
-  if (layout === GenericAwarenessModalLayout.Carousel) {
-    return buildCarousel(campaignId, cards);
+  if (!isGenericAwarenessModalLayout(layout)) {
+    return undefined;
   }
 
-  if (layout === GenericAwarenessModalLayout.FeatureIntro) {
-    return buildFeatureIntro(campaignId, cards);
+  const builder = CONTENT_CARD_BUILDERS[layout];
+  if (!builder) {
+    return undefined;
   }
 
-  if (layout === GenericAwarenessModalLayout.Prompt) {
-    return buildPrompt(campaignId, cards);
-  }
-
-  return undefined;
+  return builder(campaignId, cards);
 };
 
 export const buildGenericAwarenessModalContentCards = (
   groupedCards: Map<string, GenericAwarenessModalBrazeCard[]>,
-): GenericAwarenessModalContentCard[] => {
-  return Array.from(groupedCards.entries()).flatMap(([campaignId, cards]) => {
+): GenericAwarenessModalContentCard[] =>
+  Array.from(groupedCards.entries()).flatMap(([campaignId, cards]) => {
     const contentCard = buildContentCard(campaignId, cards);
     return contentCard ? [contentCard] : [];
   });
-};
 
 export const processGenericAwarenessModalBrazeCards = (
   cards: GenericAwarenessModalBrazeCard[],

--- a/libs/ledger-live-common/src/genericAwarenessModal/buildContentCards.ts
+++ b/libs/ledger-live-common/src/genericAwarenessModal/buildContentCards.ts
@@ -20,27 +20,44 @@ const CONTENT_CARD_BUILDERS: Record<GenericAwarenessModalLayout, ContentCardBuil
   [GenericAwarenessModalLayout.Prompt]: buildPrompt,
 };
 
-const isGenericAwarenessModalLayout = (
+const normalizeGenericAwarenessModalLayout = (
   layout: string | undefined,
-): layout is GenericAwarenessModalLayout =>
-  layout !== undefined && layout in CONTENT_CARD_BUILDERS;
+): GenericAwarenessModalLayout | undefined => {
+  const trimmedLayout = layout?.trim();
+  if (!trimmedLayout) {
+    return undefined;
+  }
+
+  return Object.values(GenericAwarenessModalLayout).find(
+    value => value.toLowerCase() === trimmedLayout.toLowerCase(),
+  );
+};
 
 export const groupByCampaignId = (
   cards: GenericAwarenessModalBrazeCard[],
 ): Map<string, GenericAwarenessModalBrazeCard[]> => {
-  const cardsByCampaignId = new Map<string, GenericAwarenessModalBrazeCard[]>();
+  const cardsByNormalizedCampaignId = new Map<string, GenericAwarenessModalBrazeCard[]>();
 
   for (const card of cards) {
-    const campaignId = card.extras?.campaignId;
+    const campaignId = card.extras?.campaignId?.trim();
     if (!campaignId) {
       continue;
     }
 
-    const campaignCards = cardsByCampaignId.get(campaignId);
+    const normalizedCampaignId = campaignId.toLowerCase();
+    const campaignCards = cardsByNormalizedCampaignId.get(normalizedCampaignId);
     if (campaignCards) {
       campaignCards.push(card);
     } else {
-      cardsByCampaignId.set(campaignId, [card]);
+      cardsByNormalizedCampaignId.set(normalizedCampaignId, [card]);
+    }
+  }
+
+  const cardsByCampaignId = new Map<string, GenericAwarenessModalBrazeCard[]>();
+  for (const campaignCards of cardsByNormalizedCampaignId.values()) {
+    const canonicalCampaignId = campaignCards[0]?.extras?.campaignId?.trim();
+    if (canonicalCampaignId) {
+      cardsByCampaignId.set(canonicalCampaignId, campaignCards);
     }
   }
 
@@ -48,7 +65,9 @@ export const groupByCampaignId = (
 };
 
 export const hasUniqueLayout = (cards: GenericAwarenessModalBrazeCard[]) =>
-  new Set(cards.map(card => card.extras?.layout)).size === 1;
+  new Set(
+    cards.map(card => normalizeGenericAwarenessModalLayout(card.extras?.layout)?.toLowerCase()),
+  ).size === 1;
 
 export const getValidGenericAwarenessModalCards = (
   groupedCards: Map<string, GenericAwarenessModalBrazeCard[]>,
@@ -63,8 +82,8 @@ const buildContentCard = (
   campaignId: string,
   cards: GenericAwarenessModalBrazeCard[],
 ): GenericAwarenessModalContentCard | undefined => {
-  const layout = cards[0]?.extras?.layout;
-  if (!isGenericAwarenessModalLayout(layout)) {
+  const layout = normalizeGenericAwarenessModalLayout(cards[0]?.extras?.layout);
+  if (!layout) {
     return undefined;
   }
 

--- a/libs/ledger-live-common/src/genericAwarenessModal/buildPrompt.ts
+++ b/libs/ledger-live-common/src/genericAwarenessModal/buildPrompt.ts
@@ -1,5 +1,4 @@
 import {
-  GenericAwarenessModalCarouselSlideSchema,
   GenericAwarenessModalLayout,
   GenericAwarenessModalPromptInputSchema,
   type GenericAwarenessModalBrazeCard,
@@ -38,6 +37,12 @@ export const buildPrompt = (
   return {
     layout: GenericAwarenessModalLayout.Prompt,
     id: campaignId,
-    ...GenericAwarenessModalCarouselSlideSchema.parse(prompt),
+    imageUrl: prompt.imageUrl,
+    title: prompt.title,
+    subtitle: prompt.subtitle,
+    primaryButtonLabel: prompt.primaryButtonLabel,
+    primaryButtonLink: prompt.primaryButtonLink,
+    secondaryButtonLabel: prompt.secondaryButtonLabel,
+    secondaryButtonLink: prompt.secondaryButtonLink,
   };
 };

--- a/libs/ledger-live-common/src/genericAwarenessModal/types.ts
+++ b/libs/ledger-live-common/src/genericAwarenessModal/types.ts
@@ -38,17 +38,6 @@ export const GenericAwarenessModalCarouselInputSchema = z.object({
   primaryButtonLink: z.string().catch(""),
 });
 
-export const GenericAwarenessModalPromptInputSchema = z.object({
-  layout: z.literal(GenericAwarenessModalLayout.Prompt),
-  campaignId: z.string(),
-  location: z.literal("generic_awareness_modal").default("generic_awareness_modal"),
-  title: z.string().catch(""),
-  subtitle: z.string().catch(""),
-  imageUrl: z.string().catch(""),
-  primaryButtonLabel: z.string().catch(""),
-  primaryButtonLink: z.string().catch(""),
-});
-
 export const GenericAwarenessModalFeatureIntroMainInputSchema = z.object({
   layout: z.literal(GenericAwarenessModalLayout.FeatureIntro),
   campaignId: z.string(),
@@ -72,6 +61,19 @@ export const GenericAwarenessModalFeatureIntroItemInputSchema = z.object({
   icon: z.string().catch(""),
   title: z.string().catch(""),
   subtitle: z.string().catch(""),
+});
+
+export const GenericAwarenessModalPromptInputSchema = z.object({
+  layout: z.literal(GenericAwarenessModalLayout.Prompt),
+  campaignId: z.string(),
+  location: z.literal("generic_awareness_modal").default("generic_awareness_modal"),
+  imageUrl: z.string().catch(""),
+  title: z.string().catch(""),
+  subtitle: z.string().catch(""),
+  primaryButtonLabel: z.string().catch(""),
+  primaryButtonLink: z.string().catch(""),
+  secondaryButtonLabel: z.string().catch(""),
+  secondaryButtonLink: z.string().catch(""),
 });
 
 export const GenericAwarenessModalInputSchema = z.union([
@@ -159,11 +161,6 @@ export type GenericAwarenessModalCarousel = {
   data: GenericAwarenessModalCarouselSlide[];
 };
 
-export type GenericAwarenessModalPrompt = {
-  layout: GenericAwarenessModalLayout.Prompt;
-  id: string;
-} & GenericAwarenessModalCarouselSlide;
-
 export type GenericAwarenessModalFeatureIntroItem = {
   icon: string;
   title: string;
@@ -183,10 +180,22 @@ export type GenericAwarenessModalFeatureIntro = {
   items: GenericAwarenessModalFeatureIntroItem[];
 };
 
+export type GenericAwarenessModalPrompt = {
+  layout: GenericAwarenessModalLayout.Prompt;
+  id: string;
+  imageUrl: string;
+  title: string;
+  subtitle: string;
+  primaryButtonLabel: string;
+  primaryButtonLink: string;
+  secondaryButtonLabel: string;
+  secondaryButtonLink: string;
+};
+
 export type GenericAwarenessModalContentCard =
   | GenericAwarenessModalCarousel
-  | GenericAwarenessModalPrompt
-  | GenericAwarenessModalFeatureIntro;
+  | GenericAwarenessModalFeatureIntro
+  | GenericAwarenessModalPrompt;
 
 export type GenericAwarenessModalOutput = GenericAwarenessModalContentCard;
 

--- a/libs/ledger-live-common/src/genericAwarenessModal/types.ts
+++ b/libs/ledger-live-common/src/genericAwarenessModal/types.ts
@@ -13,67 +13,114 @@ export enum FeatureIntroRole {
 
 export type GenericAwarenessModalLocation = "generic_awareness_modal";
 
+const GENERIC_AWARENESS_MODAL_LOCATION = "generic_awareness_modal" satisfies GenericAwarenessModalLocation;
+
+export const GenericAwarenessModalCampaignIdInputSchema = z.string().trim();
+
+export const GenericAwarenessModalStringFieldSchema = z
+  .string()
+  .catch("")
+  .transform(value => value.trim());
+
+export const GenericAwarenessModalLocationInputSchema = z
+  .string()
+  .trim()
+  .refine(value => value.toLowerCase() === GENERIC_AWARENESS_MODAL_LOCATION)
+  .transform(() => GENERIC_AWARENESS_MODAL_LOCATION)
+  .default(GENERIC_AWARENESS_MODAL_LOCATION);
+
+export const GenericAwarenessModalCarouselLayoutInputSchema = z
+  .string()
+  .trim()
+  .refine(value => value.toLowerCase() === GenericAwarenessModalLayout.Carousel.toLowerCase())
+  .transform(() => GenericAwarenessModalLayout.Carousel);
+
+export const GenericAwarenessModalFeatureIntroLayoutInputSchema = z
+  .string()
+  .trim()
+  .refine(value => value.toLowerCase() === GenericAwarenessModalLayout.FeatureIntro.toLowerCase())
+  .transform(() => GenericAwarenessModalLayout.FeatureIntro);
+
+export const GenericAwarenessModalPromptLayoutInputSchema = z
+  .string()
+  .trim()
+  .refine(value => value.toLowerCase() === GenericAwarenessModalLayout.Prompt.toLowerCase())
+  .transform(() => GenericAwarenessModalLayout.Prompt);
+
+export const GenericAwarenessModalFeatureIntroMainRoleInputSchema = z
+  .string()
+  .trim()
+  .refine(value => value.toLowerCase() === FeatureIntroRole.Main)
+  .transform(() => FeatureIntroRole.Main);
+
+export const GenericAwarenessModalFeatureIntroItemRoleInputSchema = z
+  .string()
+  .trim()
+  .refine(value => value.toLowerCase() === FeatureIntroRole.Item)
+  .transform(() => FeatureIntroRole.Item);
+
 export const GenericAwarenessModalInputIndexSchema = z
   .string()
+  .trim()
   .regex(/^\d+$/)
   .transform(value => Number.parseInt(value, 10));
 
 export const GenericAwarenessModalCarouselSlideSchema = z.object({
-  title: z.string().catch(""),
-  subtitle: z.string().catch(""),
-  imageUrl: z.string().catch(""),
-  primaryButtonLabel: z.string().catch(""),
-  primaryButtonLink: z.string().catch(""),
+  title: GenericAwarenessModalStringFieldSchema,
+  subtitle: GenericAwarenessModalStringFieldSchema,
+  imageUrl: GenericAwarenessModalStringFieldSchema,
+  primaryButtonLabel: GenericAwarenessModalStringFieldSchema,
+  primaryButtonLink: GenericAwarenessModalStringFieldSchema,
 });
 
 export const GenericAwarenessModalCarouselInputSchema = z.object({
-  layout: z.literal(GenericAwarenessModalLayout.Carousel),
-  campaignId: z.string(),
+  layout: GenericAwarenessModalCarouselLayoutInputSchema,
+  campaignId: GenericAwarenessModalCampaignIdInputSchema,
   index: GenericAwarenessModalInputIndexSchema,
-  location: z.literal("generic_awareness_modal").default("generic_awareness_modal"),
-  title: z.string().catch(""),
-  subtitle: z.string().catch(""),
-  imageUrl: z.string().catch(""),
-  primaryButtonLabel: z.string().catch(""),
-  primaryButtonLink: z.string().catch(""),
+  location: GenericAwarenessModalLocationInputSchema,
+  title: GenericAwarenessModalStringFieldSchema,
+  subtitle: GenericAwarenessModalStringFieldSchema,
+  imageUrl: GenericAwarenessModalStringFieldSchema,
+  primaryButtonLabel: GenericAwarenessModalStringFieldSchema,
+  primaryButtonLink: GenericAwarenessModalStringFieldSchema,
 });
 
 export const GenericAwarenessModalFeatureIntroMainInputSchema = z.object({
-  layout: z.literal(GenericAwarenessModalLayout.FeatureIntro),
-  campaignId: z.string(),
-  role: z.literal(FeatureIntroRole.Main),
-  location: z.literal("generic_awareness_modal").default("generic_awareness_modal"),
-  title: z.string().catch(""),
-  subtitle: z.string().catch(""),
-  imageUrl: z.string().catch(""),
-  primaryButtonLabel: z.string().catch(""),
-  primaryButtonLink: z.string().catch(""),
-  secondaryButtonLabel: z.string().catch(""),
-  secondaryButtonLink: z.string().catch(""),
+  layout: GenericAwarenessModalFeatureIntroLayoutInputSchema,
+  campaignId: GenericAwarenessModalCampaignIdInputSchema,
+  role: GenericAwarenessModalFeatureIntroMainRoleInputSchema,
+  location: GenericAwarenessModalLocationInputSchema,
+  title: GenericAwarenessModalStringFieldSchema,
+  subtitle: GenericAwarenessModalStringFieldSchema,
+  imageUrl: GenericAwarenessModalStringFieldSchema,
+  primaryButtonLabel: GenericAwarenessModalStringFieldSchema,
+  primaryButtonLink: GenericAwarenessModalStringFieldSchema,
+  secondaryButtonLabel: GenericAwarenessModalStringFieldSchema,
+  secondaryButtonLink: GenericAwarenessModalStringFieldSchema,
 });
 
 export const GenericAwarenessModalFeatureIntroItemInputSchema = z.object({
-  layout: z.literal(GenericAwarenessModalLayout.FeatureIntro),
-  campaignId: z.string(),
-  role: z.literal(FeatureIntroRole.Item),
+  layout: GenericAwarenessModalFeatureIntroLayoutInputSchema,
+  campaignId: GenericAwarenessModalCampaignIdInputSchema,
+  role: GenericAwarenessModalFeatureIntroItemRoleInputSchema,
   index: GenericAwarenessModalInputIndexSchema,
-  location: z.literal("generic_awareness_modal").default("generic_awareness_modal"),
-  icon: z.string().catch(""),
-  title: z.string().catch(""),
-  subtitle: z.string().catch(""),
+  location: GenericAwarenessModalLocationInputSchema,
+  icon: GenericAwarenessModalStringFieldSchema,
+  title: GenericAwarenessModalStringFieldSchema,
+  subtitle: GenericAwarenessModalStringFieldSchema,
 });
 
 export const GenericAwarenessModalPromptInputSchema = z.object({
-  layout: z.literal(GenericAwarenessModalLayout.Prompt),
-  campaignId: z.string(),
-  location: z.literal("generic_awareness_modal").default("generic_awareness_modal"),
-  imageUrl: z.string().catch(""),
-  title: z.string().catch(""),
-  subtitle: z.string().catch(""),
-  primaryButtonLabel: z.string().catch(""),
-  primaryButtonLink: z.string().catch(""),
-  secondaryButtonLabel: z.string().catch(""),
-  secondaryButtonLink: z.string().catch(""),
+  layout: GenericAwarenessModalPromptLayoutInputSchema,
+  campaignId: GenericAwarenessModalCampaignIdInputSchema,
+  location: GenericAwarenessModalLocationInputSchema,
+  imageUrl: GenericAwarenessModalStringFieldSchema,
+  title: GenericAwarenessModalStringFieldSchema,
+  subtitle: GenericAwarenessModalStringFieldSchema,
+  primaryButtonLabel: GenericAwarenessModalStringFieldSchema,
+  primaryButtonLink: GenericAwarenessModalStringFieldSchema,
+  secondaryButtonLabel: GenericAwarenessModalStringFieldSchema,
+  secondaryButtonLink: GenericAwarenessModalStringFieldSchema,
 });
 
 export const GenericAwarenessModalInputSchema = z.union([


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Add prompt layout.

### 📝 Description
This pull request introduces a new "Prompt" layout to the Generic Awareness Modal (GAM) in Ledger Live Desktop, along with comprehensive analytics tracking for user interactions across all modal variants (feature intro, carousel, and prompt). It also refactors and expands integration tests to ensure correct behavior and analytics for each modal type.

https://github.com/user-attachments/assets/96ae509f-2c94-4336-bb49-c353628a1936

The most important changes are:

**Generic Awareness Modal: New Prompt Layout & Refactor**
- Added support for a new "Prompt" layout in `GenericAwarenessModalView`, including new view models, content components, and layout handling logic. This enables the modal to display prompt-style content alongside existing carousel and feature intro layouts. [[1]](diffhunk://#diff-babc29c4ce5830125d5824a4cfbbd4ad718da9072f7cec0eae435e49b93d37faR1-R6) [[2]](diffhunk://#diff-334d539d3ad42f6e38a41278e3793a83a1cd90aa8469d4c26804bac19c7a5445R16-R60) [[3]](diffhunk://#diff-334d539d3ad42f6e38a41278e3793a83a1cd90aa8469d4c26804bac19c7a5445L40-R74) [[4]](diffhunk://#diff-334d539d3ad42f6e38a41278e3793a83a1cd90aa8469d4c26804bac19c7a5445R86-R113)

**Analytics Tracking Enhancements**
- Integrated detailed analytics tracking for all modal actions (page views, button clicks, tour completions, etc.) across carousel, feature intro, and prompt variants. This includes tracking button names, content IDs, CTA positions, and links. [[1]](diffhunk://#diff-93ff254ba68dd4ee73fbbcbc0610d4ad4106e4aecbc59c3fd821e869a673931fR1-R5) [[2]](diffhunk://#diff-cd8963adc3d53a77da6a83e2a9d3d78044edc760b648e71455dd869c5f9c24d1L2-R25) [[3]](diffhunk://#diff-cd8963adc3d53a77da6a83e2a9d3d78044edc760b648e71455dd869c5f9c24d1L33-R258)

**Testing Improvements**
- Refactored and expanded integration tests to cover the new prompt layout and all analytics events. Tests now verify correct rendering, user interaction flows, and that tracking and external link opening are triggered as expected for each modal variant. [[1]](diffhunk://#diff-cd8963adc3d53a77da6a83e2a9d3d78044edc760b648e71455dd869c5f9c24d1L2-R25) [[2]](diffhunk://#diff-cd8963adc3d53a77da6a83e2a9d3d78044edc760b648e71455dd869c5f9c24d1L33-R258) [[3]](diffhunk://#diff-cd8963adc3d53a77da6a83e2a9d3d78044edc760b648e71455dd869c5f9c24d1L136-R328) [[4]](diffhunk://#diff-cd8963adc3d53a77da6a83e2a9d3d78044edc760b648e71455dd869c5f9c24d1L194-R374)

**Test Utilities and Fixtures**
- Introduced new test utilities and fixtures to streamline modal setup, campaign seeding, and user actions in tests, supporting easier and more robust test coverage for all modal types.

**Changelog Updates**
- Added changeset entries documenting the addition of analytics tracking and the new GAM prompt layout for release notes. [[1]](diffhunk://#diff-93ff254ba68dd4ee73fbbcbc0610d4ad4106e4aecbc59c3fd821e869a673931fR1-R5) [[2]](diffhunk://#diff-babc29c4ce5830125d5824a4cfbbd4ad718da9072f7cec0eae435e49b93d37faR1-R6)

### ❓ Context

- **JIRA or GitHub link**:
  - https://ledgerhq.atlassian.net/browse/LIVE-30843
  - https://ledgerhq.atlassian.net/browse/LIVE-30845

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
