### PR TITLE
[LWDM] test: restore test consolidations from reverted #16345

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/features/History/__integrations__/History.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/__integrations__/History.integration.test.tsx
@@ -285,11 +285,17 @@ describe("History export dialog integration", () => {
     mockExportShouldError = true;
     await selectAllAndExport(user, dialog);
 
-    expect(await screen.findByTestId("history-export-error-title")).toBeVisible();
+    await waitFor(
+      () => expect(screen.getByTestId("history-export-error-title")).toBeVisible(),
+      { timeout: 10000 },
+    );
 
     await user.click(screen.getByRole("button", { name: /try again/i }));
 
-    expect(await screen.findByTestId("history-export-dialog")).toBeVisible();
+    await waitFor(
+      () => expect(screen.getByTestId("history-export-dialog")).toBeVisible(),
+      { timeout: 10000 },
+    );
     expect(screen.queryByTestId("history-export-error-title")).not.toBeInTheDocument();
-  });
+  }, 30000);
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/useRemoveMember.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/useRemoveMember.test.ts
@@ -138,7 +138,7 @@ describe("useRemoveMember", () => {
         step: Step.UnsecuredLedger,
       });
     });
-    expect(result.current.error).toBeInstanceOf(TrustchainNotAllowed);
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(TrustchainNotAllowed));
   });
 
   it("should set error on generic error", async () => {

--- a/apps/ledger-live-desktop/src/renderer/__tests__/Default.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/__tests__/Default.test.tsx
@@ -69,7 +69,7 @@ describe("Default", () => {
       () => {
         expect(screen.getByTestId("fw-update-banner")).toBeInTheDocument();
       },
-      { timeout: 5000 },
+      { timeout: 10000 },
     );
   }, 15_000); // Default mounts a large tree; CI runners need extra time
 

--- a/apps/ledger-live-mobile/src/families/canton/Onboard/CantonReonboardDrawer/__integrations__/CantonReonboardDrawer.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/families/canton/Onboard/CantonReonboardDrawer/__integrations__/CantonReonboardDrawer.integration.test.tsx
@@ -103,7 +103,7 @@ describe("CantonReonboardDrawer integration", () => {
   });
 
   async function acceptDisclaimer(user: ReturnType<typeof render>["user"]) {
-    await user.press(screen.getByTestId("canton-disclaimer-agree-row"));
+    await user.press(await screen.findByTestId("canton-disclaimer-agree-row"));
     await waitFor(() => {
       expect(screen.getByText("Agree")).not.toBeDisabled();
     });
@@ -123,7 +123,7 @@ describe("CantonReonboardDrawer integration", () => {
       { overrideInitialState: overrideInitialStateWithDevice },
     );
 
-    expect(screen.getByText("Setup Canton Network")).toBeOnTheScreen();
+    expect(await screen.findByText("Setup Canton Network")).toBeOnTheScreen();
     expect(screen.queryByText("Confirm")).not.toBeOnTheScreen();
 
     await acceptDisclaimer(user);
@@ -146,7 +146,7 @@ describe("CantonReonboardDrawer integration", () => {
       { overrideInitialState: overrideInitialStateWithDevice },
     );
 
-    await user.press(screen.getByText("Cancel"));
+    await user.press(await screen.findByText("Cancel"));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/ledger-live-mobile/src/families/canton/Onboard/OnboardScreen/__tests__/useOnboardScreenViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/families/canton/Onboard/OnboardScreen/__tests__/useOnboardScreenViewModel.test.ts
@@ -12,8 +12,8 @@ const mockObservable = () => ({
 
 const mockOnboardAccount = jest.fn(mockObservable);
 
-jest.mock("@ledgerhq/live-common/bridge/index", () => ({
-  getCurrencyBridge: jest.fn(() => ({
+jest.mock("@ledgerhq/live-common/bridge/useCurrencyBridge", () => ({
+  useCurrencyBridge: jest.fn(() => ({
     onboardAccount: mockOnboardAccount,
   })),
 }));

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useNetworkFees.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useNetworkFees.test.ts
@@ -27,7 +27,7 @@ jest.mock("~/context/Locale", () => ({
 }));
 jest.mock("../useFeePresetOptions");
 jest.mock("../useFeePresetFiatValues");
-jest.mock("@ledgerhq/live-common/bridge/impl");
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge");
 jest.mock("@ledgerhq/live-common/bridge/descriptor/send/features");
 jest.mock("@ledgerhq/ledger-wallet-framework/account/helpers");
 jest.mock("@ledgerhq/live-countervalues-react");
@@ -48,7 +48,7 @@ const mockUseFeePresetFiatValues = jest.requireMock(
 const { getMainAccount, getAccountCurrency } = jest.requireMock(
   "@ledgerhq/ledger-wallet-framework/account/helpers",
 );
-const { getAccountBridge } = jest.requireMock("@ledgerhq/live-common/bridge/impl");
+const { useAccountBridge } = jest.requireMock("@ledgerhq/live-common/bridge/useAccountBridge");
 const sendFeatures = jest.requireMock(
   "@ledgerhq/live-common/bridge/descriptor/send/features",
 ).sendFeatures;
@@ -145,7 +145,7 @@ describe("useNetworkFees", () => {
     jest
       .mocked(useSelector)
       .mockReturnValue(mockCounterValueCurrency as ReturnType<typeof useSelector>);
-    getAccountBridge.mockReturnValue({
+    useAccountBridge.mockReturnValue({
       updateTransaction: jest.fn((tx: Transaction, patch: Partial<Transaction>) => ({
         ...tx,
         ...patch,
@@ -223,7 +223,7 @@ describe("useNetworkFees", () => {
         ...tx,
         ...patch,
       }));
-      getAccountBridge.mockReturnValue({ updateTransaction: bridgeUpdateTransaction });
+      useAccountBridge.mockReturnValue({ updateTransaction: bridgeUpdateTransaction });
       const params = buildParams();
 
       const { result } = renderHook(() => useNetworkFees(params));
@@ -245,7 +245,7 @@ describe("useNetworkFees", () => {
         ...tx,
         ...patch,
       }));
-      getAccountBridge.mockReturnValue({ updateTransaction: bridgeUpdateTransaction });
+      useAccountBridge.mockReturnValue({ updateTransaction: bridgeUpdateTransaction });
       const params = buildParams();
 
       const { result } = renderHook(() => useNetworkFees(params));


### PR DESCRIPTION
### ✅ Checklist

- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Tests-only. No production code changes.
  - Stabilises 6 desktop/mobile suites and refreshes 2 bridge-mock paths that are required by the async-bridge migration in #17760.

### 📝 Description

PR #16345 (RN 0.81.6) was reverted, but it bundled a set of independent test consolidations that:
- Stand on their own against `develop` (each suite validated locally).
- Unblock / de-risk the async-bridge migration in #17760, where the bridge mocks have to point at `useCurrencyBridge` / `useAccountBridge` rather than the deprecated sync `getCurrencyBridge` / `getAccountBridge`.

Landing them now means #17760 doesn't have to carry these test edits alongside the bridge refactor.

**Test changes**
- `apps/ledger-live-desktop/.../History.integration.test.tsx` — `waitFor` + bumped timeout on the export-error retry path.
- `apps/ledger-live-desktop/.../useRemoveMember.test.ts` — wraps async error assertion in `waitFor`.
- `apps/ledger-live-desktop/.../Default.test.tsx` — drops manual `resolved` mirror (already in `FEATURE_FLAGS_INITIAL_STATE`); bumps FW-update-banner timeout.
- `apps/ledger-live-mobile/.../CantonReonboardDrawer.integration.test.tsx` — `getBy* → await findBy*` for async rendering.
- `apps/ledger-live-mobile/.../useOnboardScreenViewModel.test.ts` — mock path updated to `bridge/useCurrencyBridge` (needed by #17760).
- `apps/ledger-live-mobile/.../useNetworkFees.test.ts` — mock path updated to `bridge/useAccountBridge` (needed by #17760).

> [!NOTE]
> The `password.spec.ts` Detox `disableSynchronization` workaround from #16345 was intentionally **not** included — it only makes sense on top of RN 0.81 and can't be validated outside an e2e run.
> The ProductTour source fix + 3 related tests from #16345 are also intentionally **not** included.

### ❓ Context

- **JIRA or GitHub link**: LIVE-29164 (original PR #16345), benefits #17760 (LIVE-29187)
- **ADR link (if any)**: n/a