### PR TITLE
[LWDM] feat: add assetDiscoverability param to lwmWallet40 / lwdWallet40 feature flags

### DIFF
--- a/.changeset/bright-flags-enable.md
+++ b/.changeset/bright-flags-enable.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/types-live": minor
+"@ledgerhq/live-common": minor
+"live-mobile": minor
+"ledger-live-desktop": minor
+---
+
+Add assetDiscoverability param to lwmWallet40 and expose shouldDisplayAssetDiscoverability in usePortfolioViewModel and MainAppLayout

--- a/apps/ledger-live-desktop/src/renderer/Default.tsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -224,11 +224,13 @@ const MainAppContent = ({
   shouldDisplayWallet40MainNav,
   shouldDisplayAssetSection,
   shouldDisplayAggregatedAssets,
+  shouldDisplayAssetDiscoverability,
 }: {
   shouldDisplayMarketBanner: boolean;
   shouldDisplayWallet40MainNav: boolean;
   shouldDisplayAssetSection: boolean;
   shouldDisplayAggregatedAssets: boolean;
+  shouldDisplayAssetDiscoverability: boolean;
 }) => (
   <>
     <Routes>
@@ -315,6 +317,7 @@ export const MainAppLayout = () => {
     shouldDisplayWallet40MainNav,
     shouldDisplayAssetSection,
     shouldDisplayAggregatedAssets,
+    shouldDisplayAssetDiscoverability,
   } = useWalletFeaturesConfig("desktop");
   const shouldShowDeferredModals = useShouldShowDeferredModals();
 
@@ -363,6 +366,7 @@ export const MainAppLayout = () => {
           shouldDisplayWallet40MainNav={shouldDisplayWallet40MainNav}
           shouldDisplayAssetSection={shouldDisplayAssetSection}
           shouldDisplayAggregatedAssets={shouldDisplayAggregatedAssets}
+          shouldDisplayAssetDiscoverability={shouldDisplayAssetDiscoverability}
         />
       </div>
 

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/constants.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/constants.ts
@@ -18,6 +18,7 @@ export const WALLET_FEATURES_PARAMS = [
   { key: "operationsList", label: "TX History" },
   { key: "aggregatedAssets", label: "Aggregated Assets" },
   { key: "myWallet", label: "My Wallet" },
+  { key: "assetDiscoverability", label: "Asset Discoverability" },
   { key: "finishOnboardingWidget", label: "Finish Onboarding Widget" },
   { key: "pnl", label: "PnL" },
 ] as const;

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/usePortfolioViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/usePortfolioViewModel.ts
@@ -34,6 +34,7 @@ interface UsePortfolioViewModelResult {
   hideEmptyTokenAccount: boolean;
   isAWalletCardDisplayed: boolean;
   isAccountListUIEnabled: boolean;
+  shouldDisplayAssetDiscoverability: boolean;
   shouldDisplayQuickActionCtas: boolean;
   shouldDisplayWallet40MainNav: boolean;
   shouldDisplayAssetSection: boolean;
@@ -69,6 +70,7 @@ const usePortfolioViewModel = (navigation: {
     shouldDisplayAssetSection,
     shouldDisplayMarketBanner,
     shouldDisplayOperationsList,
+    shouldDisplayAssetDiscoverability,
   } = useWalletFeaturesConfig("mobile");
   const isAccountListUIEnabled = accountListFF?.enabled ?? false;
   const borrowConfig = useBorrowLiveConfig();
@@ -159,6 +161,7 @@ const usePortfolioViewModel = (navigation: {
     hideEmptyTokenAccount,
     isAWalletCardDisplayed,
     isAccountListUIEnabled,
+    shouldDisplayAssetDiscoverability,
     shouldDisplayQuickActionCtas,
     shouldDisplayWallet40MainNav,
     shouldDisplayAssetSection,

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Wallet40/useWallet40ViewModel.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Wallet40/useWallet40ViewModel.ts
@@ -19,6 +19,7 @@ export const WALLET_40_PARAMS = [
   { key: "operationsList", label: "TX History" },
   { key: "aggregatedAssets", label: "Aggregated Assets" },
   { key: "myWallet", label: "My Wallet" },
+  { key: "assetDiscoverability", label: "Asset Discoverability" },
   { key: "pnl", label: "PnL" },
 ] as const;
 

--- a/e2e/mobile/utils/constants.ts
+++ b/e2e/mobile/utils/constants.ts
@@ -17,6 +17,7 @@ export const WALLET_40_FEATURE_FLAGS = {
       aggregatedAssets: false,
       myWallet: false,
       pnl: false,
+      assetDiscoverability: false,
     },
   },
 } as const;

--- a/e2e/mobile/utils/initUtil.ts
+++ b/e2e/mobile/utils/initUtil.ts
@@ -336,6 +336,7 @@ export class InitializationManager {
           aggregatedAssets: false,
           myWallet: isWallet40,
           pnl: false,
+          assetDiscoverability: false,
         },
       },
       onboardingWidget: {

--- a/features/platform/feature-flags/src/hooks/__tests__/useWalletFeaturesConfig.test.tsx
+++ b/features/platform/feature-flags/src/hooks/__tests__/useWalletFeaturesConfig.test.tsx
@@ -16,10 +16,7 @@ const PLATFORMS: [WalletPlatform, "lwdWallet40" | "lwmWallet40"][] = [
 
 type FlagValue = { enabled: boolean; params?: Wallet40Params };
 
-function renderWalletFeaturesConfig(
-  platform: WalletPlatform,
-  flagValue?: FlagValue,
-) {
+function renderWalletFeaturesConfig(platform: WalletPlatform, flagValue?: FlagValue) {
   const flagKey = FEATURE_FLAG_KEYS[platform];
   const resolved: Features = {
     ...FEATURE_FLAGS_DEFAULTS,
@@ -53,6 +50,7 @@ const makeConfig = (
   shouldDisplayMyWallet: value,
   shouldDisplayAggregatedAssets: value,
   shouldDisplayPnl: value,
+  shouldDisplayAssetDiscoverability: value,
   shouldDisplayFinishOnboardingWidget: value,
   shouldDisplayEarnUpselling: value,
   shouldDisplayEarnSimulator: value,
@@ -75,6 +73,7 @@ const makeParams = (value: boolean): Wallet40Params => ({
   aggregatedAssets: value,
   myWallet: value,
   pnl: value,
+  assetDiscoverability: value,
   finishOnboardingWidget: value,
   earnUpselling: value,
   earnSimulator: value,
@@ -166,6 +165,5 @@ describe("useWalletFeaturesConfig hook", () => {
         expectConfig(result, { ...ENABLED_NO_PARAMS_CONFIG, shouldDisplayMarketBanner: true });
       });
     });
-
   });
 });

--- a/features/platform/feature-flags/src/hooks/useWalletFeaturesConfig.ts
+++ b/features/platform/feature-flags/src/hooks/useWalletFeaturesConfig.ts
@@ -40,6 +40,7 @@ export function useWalletFeaturesConfig(platform: WalletPlatform): WalletFeature
       shouldDisplayAggregatedAssets: isEnabled && Boolean(params?.aggregatedAssets),
       shouldDisplayMyWallet: isEnabled && Boolean(params?.myWallet),
       shouldDisplayPnl: isEnabled && Boolean(params?.pnl),
+      shouldDisplayAssetDiscoverability: isEnabled && Boolean(params?.assetDiscoverability),
       shouldDisplayFinishOnboardingWidget: isEnabled && Boolean(params?.finishOnboardingWidget),
       shouldDisplayEarnUpselling: isEnabled && Boolean(params?.earnUpselling),
       shouldDisplayEarnSimulator: isEnabled && Boolean(params?.earnSimulator),
@@ -100,6 +101,8 @@ export interface WalletFeaturesConfig {
   readonly shouldDisplayMyWallet: boolean;
   /** Whether to show the PNL component */
   readonly shouldDisplayPnl: boolean;
+  /** Whether to show the Asset Discoverability feature */
+  readonly shouldDisplayAssetDiscoverability: boolean;
   /** Whether to show the Finish Onboarding widget on Portfolio (desktop / lwdWallet40) */
   readonly shouldDisplayFinishOnboardingWidget: boolean;
   /** Whether to show the Earn Upselling component */

--- a/libs/ledger-live-common/src/analytics/featureFlagHelpers/wallet40.ts
+++ b/libs/ledger-live-common/src/analytics/featureFlagHelpers/wallet40.ts
@@ -31,6 +31,7 @@ export const getWallet40Attributes = (
     brazePlacement: wallet40FeatureFlag?.params?.brazePlacement ?? false,
     operationsList: wallet40FeatureFlag?.params?.operationsList ?? false,
     myWallet: wallet40FeatureFlag?.params?.myWallet ?? false,
+    assetDiscoverability: wallet40FeatureFlag?.params?.assetDiscoverability ?? false,
     aggregatedAssets: wallet40FeatureFlag?.params?.aggregatedAssets ?? false,
     pnl: wallet40FeatureFlag?.params?.pnl ?? false,
     finishOnboardingWidget:

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -848,6 +848,7 @@ export const DEFAULT_FEATURES: Features = {
       aggregatedAssets: false,
       myWallet: false,
       pnl: false,
+      assetDiscoverability: false,
     },
   },
   lwdWallet40: {
@@ -868,6 +869,7 @@ export const DEFAULT_FEATURES: Features = {
       aggregatedAssets: false,
       myWallet: false,
       pnl: false,
+      assetDiscoverability: false,
       finishOnboardingWidget: false,
     },
   },

--- a/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/types.ts
+++ b/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/types.ts
@@ -16,6 +16,7 @@ export type Wallet40Params = {
   readonly aggregatedAssets?: boolean;
   readonly myWallet?: boolean;
   readonly pnl?: boolean;
+  readonly assetDiscoverability?: boolean;
   readonly finishOnboardingWidget?: boolean;
   readonly earnUpselling?: boolean;
   readonly earnSimulator?: boolean;
@@ -60,6 +61,8 @@ export interface WalletFeaturesConfig {
   readonly shouldDisplayMyWallet: boolean;
   /** Whether to show the PNL component */
   readonly shouldDisplayPnl: boolean;
+  /** Whether to show the Asset Discoverability feature */
+  readonly shouldDisplayAssetDiscoverability: boolean;
   /** Whether to show the Finish Onboarding widget on Portfolio (desktop / lwdWallet40) */
   readonly shouldDisplayFinishOnboardingWidget: boolean;
   /** Whether to show the Earn Upselling component */

--- a/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.test.ts
+++ b/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.test.ts
@@ -51,6 +51,7 @@ const makeConfig = (
   shouldDisplayMyWallet: value,
   shouldDisplayAggregatedAssets: value,
   shouldDisplayPnl: value,
+  shouldDisplayAssetDiscoverability: value,
   shouldDisplayFinishOnboardingWidget: value,
   shouldDisplayEarnUpselling: value,
   shouldDisplayEarnSimulator: value,
@@ -73,6 +74,7 @@ const makeParams = (value: boolean): Wallet40Params => ({
   aggregatedAssets: value,
   myWallet: value,
   pnl: value,
+  assetDiscoverability: value,
   finishOnboardingWidget: value,
   earnUpselling: value,
   earnSimulator: value,
@@ -150,6 +152,11 @@ describe("useWalletFeaturesConfig hook", () => {
         ["earnUpselling", { earnUpselling: true }, { shouldDisplayEarnUpselling: true }],
         ["earnSimulator", { earnSimulator: true }, { shouldDisplayEarnSimulator: true }],
         ["pnl", { pnl: true }, { shouldDisplayPnl: true }],
+        [
+          "assetDiscoverability",
+          { assetDiscoverability: true },
+          { shouldDisplayAssetDiscoverability: true },
+        ],
       ])("should return correct config when only %s is enabled", (_, params, expectedOverrides) => {
         const { result } = renderWalletFeaturesConfig(platform, {
           [flagKey]: createFeatureFlag(true, params),

--- a/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.ts
+++ b/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.ts
@@ -47,6 +47,7 @@ export const useWalletFeaturesConfig = (platform: WalletPlatform): WalletFeature
       shouldDisplayAggregatedAssets: isEnabled && Boolean(params?.aggregatedAssets),
       shouldDisplayMyWallet: isEnabled && Boolean(params?.myWallet),
       shouldDisplayPnl: isEnabled && Boolean(params?.pnl),
+      shouldDisplayAssetDiscoverability: isEnabled && Boolean(params?.assetDiscoverability),
       shouldDisplayFinishOnboardingWidget:
         isEnabled &&
         Boolean(params && "finishOnboardingWidget" in params && params.finishOnboardingWidget),

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -886,6 +886,7 @@ type Feature_Wallet40_Params = {
   aggregatedAssets: boolean;
   myWallet: boolean;
   pnl: boolean;
+  assetDiscoverability: boolean;
   // Specifics
   brazePlacement?: boolean;
   newReceiveDialog?: boolean;

--- a/shared/feature-flags/src/flags/team-wallet-xp/lwdWallet40.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/lwdWallet40.ts
@@ -18,6 +18,7 @@ export const lwdWallet40 = flagWith(
     myWallet: z.boolean(),
     finishOnboardingWidget: z.boolean().optional(),
     pnl: z.boolean(),
+    assetDiscoverability: z.boolean(),
     earnUpselling: z.boolean().optional(),
     earnSimulator: z.boolean().optional(),
   },
@@ -39,6 +40,7 @@ export const lwdWallet40 = flagWith(
       myWallet: false,
       finishOnboardingWidget: false,
       pnl: false,
+      assetDiscoverability: false,
     },
   },
 );

--- a/shared/feature-flags/src/flags/team-wallet-xp/lwmWallet40.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/lwmWallet40.ts
@@ -18,6 +18,7 @@ export const lwmWallet40 = flagWith(
     quickActionsCtasVariant: z.boolean().optional(),
     brazePlacement: z.boolean().optional(),
     pnl: z.boolean(),
+    assetDiscoverability: z.boolean(),
     earnUpselling: z.boolean().optional(),
     earnSimulator: z.boolean().optional(),
   },
@@ -36,6 +37,7 @@ export const lwmWallet40 = flagWith(
       aggregatedAssets: false,
       myWallet: false,
       pnl: false,
+      assetDiscoverability: false,
     },
   },
 );


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [ ] **Covered by automatic tests.** _Foundation flag — no behavioral logic to test yet, covered by TypeScript type-safety._
- [x] **Impact of the changes:**
  - Portfolio screen: `shouldDisplayAssetDiscoverability` now available from `usePortfolioViewModel`
  - `lwmWallet40` feature flag default params updated (`assetDiscoverability: false`)
  - No visual change — FF is disabled by default

### 📝 Description

This PR registers the foundation feature flag for the Asset Discoverability (Customise Home) feature on mobile.

**Problem**: The Asset Discoverability feature needs a dedicated flag to gate its rollout, following the same pattern as other Wallet 4.0 sub-features (`aggregatedAssets`, `pnl`, `myWallet`, etc.).

**Solution**: Added `assetDiscoverability` as a boolean param of the existing `lwmWallet40` feature flag:

- `assetDiscoverability: boolean` added to `Feature_Wallet40_Params` in `@ledgerhq/types-live`
- `assetDiscoverability?: boolean` added to `Wallet40Params` and `shouldDisplayAssetDiscoverability: boolean` added to `WalletFeaturesConfig` in `@ledgerhq/live-common`
- Derivation `shouldDisplayAssetDiscoverability: isEnabled && Boolean(params?.assetDiscoverability)` wired in `useWalletFeaturesConfig`
- Default value `assetDiscoverability: false` registered in `lwmWallet40` params
- `shouldDisplayAssetDiscoverability` exposed in `usePortfolioViewModel` (destructured from `useWalletFeaturesConfig("mobile")`)

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30005](https://ledgerhq.atlassian.net/browse/LIVE-30005)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30005]: https://ledgerhq.atlassian.net/browse/LIVE-30005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ