### PR TITLE
[LWDM] feat(live-mobile): display PnL section on asset detail (LIVE-30306)

### DIFF
--- a/.changeset/add-asset-detail-pnl-section.md
+++ b/.changeset/add-asset-detail-pnl-section.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@ledgerhq/wallet-pnl": minor
+---
+
+Add PnL section to the mobile Asset Detail screen (Unrealised return + Average entry price cards, opens a detail drawer). Extracts a shared `usePnlViewModelBase` + builders under `mvvm/features/Pnl` so the Analytics (portfolio) and Asset Detail (asset) consumers share the same logic, and exposes `trendFromSign` / `PnlTrend` from `@ledgerhq/wallet-pnl` so mobile and desktop derive trends from the same primitive.

--- a/apps/ledger-live-desktop/src/mvvm/features/PnL/builders/trend.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PnL/builders/trend.ts
@@ -1,13 +1,14 @@
 import type { BigNumber } from "bignumber.js";
 import { TriangleUp, TriangleDown } from "@ledgerhq/lumen-ui-react/symbols";
+import { type PnlTrend, trendFromSign } from "@ledgerhq/wallet-pnl";
 import type { TrendIconConfig } from "../components/PnLCard/types";
 
-const UP: TrendIconConfig = { Icon: TriangleUp, className: "text-success" };
-const DOWN: TrendIconConfig = { Icon: TriangleDown, className: "text-error" };
-const NEUTRAL: TrendIconConfig = { Icon: TriangleUp, className: "text-disabled" };
+const ICONS: Record<PnlTrend, TrendIconConfig> = {
+  up: { Icon: TriangleUp, className: "text-success" },
+  down: { Icon: TriangleDown, className: "text-error" },
+  neutral: { Icon: TriangleUp, className: "text-disabled" },
+};
 
 export function getTrendIcon(value: BigNumber): TrendIconConfig {
-  if (value.isZero()) return NEUTRAL;
-  if (value.isNegative()) return DOWN;
-  return UP;
+  return ICONS[trendFromSign(value)];
 }

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8115,30 +8115,55 @@
     }
   },
   "pnl": {
-    "unrealisedReturn": {
-      "title": "Unrealised return"
-    },
-    "costBasis": {
-      "title": "Cost basis",
+    "disclaimer": "This data is provided for informational purposes only and is not financial advice. Not to be used for tax purposes.",
+    "asset": {
+      "return": {
+        "title": "Unrealised return"
+      },
+      "entry": {
+        "title": "Average entry price",
+        "tooltip": "The average price you paid for this asset through Ledger Wallet, including everything you’ve bought or received from other wallets. This is used to track your profit or loss."
+      },
       "drawer": {
-        "title": "Cost basis",
-        "body": "The total amount you paid to acquire your current holdings, including fees."
+        "title": "Asset profit and loss",
+        "description": "A summary of how this asset has performed in your portfolio.",
+        "estimatedReturn": {
+          "title": "Estimated return",
+          "description": "The estimated profit or loss if sold at current price."
+        },
+        "realisedReturn": {
+          "title": "Realised return",
+          "description": "Profit or loss confirmed from previous sale, send, or swap."
+        },
+        "totalReturn": {
+          "title": "Total return",
+          "description": "The sum of estimated and realised returns."
+        }
       }
     },
-    "drawer": {
-      "title": "Profit and loss",
-      "description": "Your portfolio performance broken down into realised and unrealised returns.",
-      "totalReturn": {
-        "title": "Total return",
-        "definition": "Realised and unrealised returns combined, reflecting your overall position."
+    "portfolio": {
+      "return": {
+        "title": "Unrealised return"
       },
-      "unrealisedReturn": {
-        "title": "Unrealised return",
-        "definition": "Estimated gain or loss on your current holdings."
+      "costBasis": {
+        "title": "Cost basis",
+        "tooltip": "The total amount you paid to acquire your current holdings, including fees."
       },
-      "realisedReturn": {
-        "title": "Realised return",
-        "definition": "Profit or loss confirmed from previous sales or outgoing transfers."
+      "drawer": {
+        "title": "Portfolio profit and loss",
+        "description": "Your portfolio performance broken down into estimated and realised returns.",
+        "estimatedReturn": {
+          "title": "Estimated return",
+          "description": "The estimated profit or loss if sold at current price."
+        },
+        "realisedReturn": {
+          "title": "Realised return",
+          "description": "Profit or loss confirmed from previous sale, send, or swap."
+        },
+        "totalReturn": {
+          "title": "Total return",
+          "description": "The sum of estimated and realised returns."
+        }
       }
     }
   },

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/__tests__/PnlSection.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/__tests__/PnlSection.integration.test.tsx
@@ -1,11 +1,32 @@
 import React, { useState } from "react";
 import { Pressable, Text } from "react-native";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { genAccount } from "@ledgerhq/live-common/mock/account";
 import { render, screen, withFlagOverrides } from "@tests/test-renderer";
+import { State } from "~/reducers/types";
 import { PnlDetailDrawer } from "LLM/features/Pnl/components/PnlDetailDrawer";
 import PnlSection, { PNL_SECTION_TEST_IDS } from "..";
 
+const btcAccount = genAccount("btc-1", {
+  currency: getCryptoCurrencyById("bitcoin"),
+  operationsSize: 0,
+});
+
+const withAccounts = (state: State): State => ({
+  ...state,
+  accounts: { ...state.accounts, active: [btcAccount] },
+});
+
+const compose =
+  (...transforms: Array<(state: State) => State>) =>
+  (state: State): State =>
+    transforms.reduce((acc, t) => t(acc), state);
+
 const withPnl = (enabled: boolean) =>
-  withFlagOverrides({ lwmWallet40: { enabled: true, params: { pnl: enabled } } });
+  compose(
+    withAccounts,
+    withFlagOverrides({ lwmWallet40: { enabled: true, params: { pnl: enabled } } }),
+  );
 
 const OPEN_BUTTON_TEST_ID = "open-drawer-button";
 
@@ -23,15 +44,16 @@ function DrawerOpener({ variant }: { variant: Variant }) {
           <PnlDetailDrawer
             isOpen
             onClose={() => setOpen(false)}
-            title="Total profit and loss"
-            description="A summary of how your portfolio has performed."
+            title="Portfolio profit and loss"
+            description="Your portfolio performance broken down into estimated and realised returns."
             items={[
               {
-                title: "Unrealised return",
+                title: "Estimated return",
                 value: "+ $243.32",
-                definition: "The estimated gain or loss if sold at today's price.",
+                definition: "The estimated profit or loss if sold at current price.",
               },
             ]}
+            footer="This data is provided for informational purposes only and is not financial advice. Not to be used for tax purposes."
           />
         ) : (
           <PnlDetailDrawer
@@ -48,7 +70,7 @@ function DrawerOpener({ variant }: { variant: Variant }) {
 
 describe("PnlSection integration", () => {
   describe("feature flag gating", () => {
-    it("renders both PnL cards when shouldDisplayPnl is true", () => {
+    it("renders both PnL cards when shouldDisplayPnl is true and there are accounts", () => {
       render(<PnlSection />, { overrideInitialState: withPnl(true) });
 
       expect(screen.getByTestId(PNL_SECTION_TEST_IDS.root)).toBeVisible();
@@ -61,19 +83,38 @@ describe("PnlSection integration", () => {
 
       expect(screen.queryByTestId(PNL_SECTION_TEST_IDS.root)).toBeNull();
     });
+
+    it("renders nothing when there are no accounts", () => {
+      render(<PnlSection />, {
+        overrideInitialState: withFlagOverrides({
+          lwmWallet40: { enabled: true, params: { pnl: true } },
+        }),
+      });
+
+      expect(screen.queryByTestId(PNL_SECTION_TEST_IDS.root)).toBeNull();
+    });
   });
 
   describe("drawer opening", () => {
-    it("renders the PnL detail drawer when its open button is pressed", async () => {
+    it("renders the PnL detail drawer with header, items and disclaimer when its open button is pressed", async () => {
       const { user } = render(<DrawerOpener variant="pnl" />);
 
-      expect(screen.queryByText("Total profit and loss")).toBeNull();
+      expect(screen.queryByText("Portfolio profit and loss")).toBeNull();
 
       await user.press(screen.getByTestId(OPEN_BUTTON_TEST_ID));
 
-      expect(screen.getByText("Total profit and loss")).toBeVisible();
-      expect(screen.getByText("A summary of how your portfolio has performed.")).toBeVisible();
-      expect(screen.getByText("Unrealised return")).toBeVisible();
+      expect(screen.getByText("Portfolio profit and loss")).toBeVisible();
+      expect(
+        screen.getByText(
+          "Your portfolio performance broken down into estimated and realised returns.",
+        ),
+      ).toBeVisible();
+      expect(screen.getByText("Estimated return")).toBeVisible();
+      expect(
+        screen.getByText(
+          "This data is provided for informational purposes only and is not financial advice. Not to be used for tax purposes.",
+        ),
+      ).toBeVisible();
     });
 
     it("renders the cost basis drawer when its open button is pressed", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/__tests__/usePnlSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/__tests__/usePnlSectionViewModel.test.ts
@@ -1,11 +1,20 @@
 import { act } from "react";
-import { renderHook, withFlagOverrides } from "@tests/test-renderer";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { genAccount } from "@ledgerhq/live-common/mock/account";
 import * as walletPnlHooks from "@ledgerhq/wallet-pnl/hooks";
+import { renderHook, withFlagOverrides } from "@tests/test-renderer";
 import { State } from "~/reducers/types";
 import { usePnlSectionViewModel } from "../usePnlSectionViewModel";
 
-const withPnl = (enabled: boolean) =>
-  withFlagOverrides({ lwmWallet40: { enabled: true, params: { pnl: enabled } } });
+const btcAccount = genAccount("btc-1", {
+  currency: getCryptoCurrencyById("bitcoin"),
+  operationsSize: 0,
+});
+
+const withAccounts = (state: State): State => ({
+  ...state,
+  accounts: { ...state.accounts, active: [btcAccount] },
+});
 
 const withDiscreet =
   (discreetMode: boolean) =>
@@ -19,6 +28,12 @@ const compose =
   (state: State): State =>
     transforms.reduce((acc, t) => t(acc), state);
 
+const withPnl = (enabled: boolean) =>
+  compose(
+    withAccounts,
+    withFlagOverrides({ lwmWallet40: { enabled: true, params: { pnl: enabled } } }),
+  );
+
 describe("usePnlSectionViewModel", () => {
   it("keeps both drawers closed by default", () => {
     const { result } = renderHook(() => usePnlSectionViewModel(), {
@@ -26,7 +41,7 @@ describe("usePnlSectionViewModel", () => {
     });
 
     expect(result.current.pnlDrawer.isOpen).toBe(false);
-    expect(result.current.costBasisDrawer.isOpen).toBe(false);
+    expect(result.current.secondaryDrawer.isOpen).toBe(false);
   });
 
   it("opens the PnL drawer when the unrealised card press handler runs", () => {
@@ -37,18 +52,18 @@ describe("usePnlSectionViewModel", () => {
     act(() => result.current.unrealised.onPress());
 
     expect(result.current.pnlDrawer.isOpen).toBe(true);
-    expect(result.current.costBasisDrawer.isOpen).toBe(false);
+    expect(result.current.secondaryDrawer.isOpen).toBe(false);
   });
 
-  it("opens the cost basis drawer when the cost basis card press handler runs", () => {
+  it("opens the secondary drawer when the secondary card press handler runs", () => {
     const { result } = renderHook(() => usePnlSectionViewModel(), {
       overrideInitialState: withPnl(true),
     });
 
-    act(() => result.current.costBasis.onPress());
+    act(() => result.current.secondary.onPress());
 
     expect(result.current.pnlDrawer.isOpen).toBe(false);
-    expect(result.current.costBasisDrawer.isOpen).toBe(true);
+    expect(result.current.secondaryDrawer.isOpen).toBe(true);
   });
 
   it("closes the open drawer when its onClose runs", () => {
@@ -62,11 +77,11 @@ describe("usePnlSectionViewModel", () => {
     act(() => result.current.pnlDrawer.onClose());
     expect(result.current.pnlDrawer.isOpen).toBe(false);
 
-    act(() => result.current.costBasis.onPress());
-    expect(result.current.costBasisDrawer.isOpen).toBe(true);
+    act(() => result.current.secondary.onPress());
+    expect(result.current.secondaryDrawer.isOpen).toBe(true);
 
-    act(() => result.current.costBasisDrawer.onClose());
-    expect(result.current.costBasisDrawer.isOpen).toBe(false);
+    act(() => result.current.secondaryDrawer.onClose());
+    expect(result.current.secondaryDrawer.isOpen).toBe(false);
   });
 
   it("opening one drawer closes the other (single-drawer state machine)", () => {
@@ -77,9 +92,29 @@ describe("usePnlSectionViewModel", () => {
     act(() => result.current.unrealised.onPress());
     expect(result.current.pnlDrawer.isOpen).toBe(true);
 
-    act(() => result.current.costBasis.onPress());
+    act(() => result.current.secondary.onPress());
     expect(result.current.pnlDrawer.isOpen).toBe(false);
-    expect(result.current.costBasisDrawer.isOpen).toBe(true);
+    expect(result.current.secondaryDrawer.isOpen).toBe(true);
+  });
+
+  describe("rendering gate", () => {
+    it("disables the section when there are no accounts even if the flag is on", () => {
+      const { result } = renderHook(() => usePnlSectionViewModel(), {
+        overrideInitialState: withFlagOverrides({
+          lwmWallet40: { enabled: true, params: { pnl: true } },
+        }),
+      });
+
+      expect(result.current.shouldDisplayPnl).toBe(false);
+    });
+
+    it("enables the section when the flag is on and there are accounts", () => {
+      const { result } = renderHook(() => usePnlSectionViewModel(), {
+        overrideInitialState: withPnl(true),
+      });
+
+      expect(result.current.shouldDisplayPnl).toBe(true);
+    });
   });
 
   describe("discreet mode", () => {
@@ -89,7 +124,7 @@ describe("usePnlSectionViewModel", () => {
       });
 
       expect(result.current.unrealised.value).toContain("***");
-      expect(result.current.costBasis.value).toContain("***");
+      expect(result.current.secondary.value).toContain("***");
     });
 
     it("masks every drawer item value when discreet mode is on", () => {
@@ -108,7 +143,7 @@ describe("usePnlSectionViewModel", () => {
       });
 
       expect(result.current.unrealised.value).not.toContain("***");
-      expect(result.current.costBasis.value).not.toContain("***");
+      expect(result.current.secondary.value).not.toContain("***");
       for (const item of result.current.pnlDrawer.items) {
         expect(item.value).not.toContain("***");
       }
@@ -144,6 +179,18 @@ describe("usePnlSectionViewModel", () => {
 
       const [accountsArg] = spy.mock.calls[0];
       expect(Array.isArray(accountsArg)).toBe(true);
+      expect((accountsArg as unknown[]).length).toBeGreaterThan(0);
+    });
+
+    it("falls back to a zero cost basis when usePortfolioPnL returns an empty object", () => {
+      // @ts-expect-error mockReturnValue expects a PortfolioPnL, but we're returning an empty object
+      spy.mockReturnValue({});
+
+      const { result } = renderHook(() => usePnlSectionViewModel(), {
+        overrideInitialState: withPnl(true),
+      });
+
+      expect(result.current.secondary.value).toMatch(/0(?:[.,]00)?/);
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/index.tsx
@@ -8,10 +8,10 @@ import { usePnlSectionViewModel } from "./usePnlSectionViewModel";
 export { PNL_SECTION_TEST_IDS };
 
 export default function PnlSection() {
-  const { shouldRender, unrealised, costBasis, pnlDrawer, costBasisDrawer } =
+  const { shouldDisplayPnl, unrealised, secondary, pnlDrawer, secondaryDrawer } =
     usePnlSectionViewModel();
 
-  if (!shouldRender) return null;
+  if (!shouldDisplayPnl) return null;
 
   return (
     <>
@@ -32,9 +32,9 @@ export default function PnlSection() {
         <Box lx={{ flex: 1 }}>
           <PnlCard
             type="info"
-            title={costBasis.title}
-            value={costBasis.value}
-            onPress={costBasis.onPress}
+            title={secondary.title}
+            value={secondary.value}
+            onPress={secondary.onPress}
             testID={PNL_SECTION_TEST_IDS.costBasisCard}
           />
         </Box>
@@ -45,13 +45,14 @@ export default function PnlSection() {
         title={pnlDrawer.title}
         description={pnlDrawer.description}
         items={pnlDrawer.items}
+        footer={pnlDrawer.footer}
         testID={PNL_SECTION_TEST_IDS.detailDrawer}
       />
       <PnlDetailDrawer
-        isOpen={costBasisDrawer.isOpen}
-        onClose={costBasisDrawer.onClose}
-        title={costBasisDrawer.title}
-        bodyText={costBasisDrawer.bodyText}
+        isOpen={secondaryDrawer.isOpen}
+        onClose={secondaryDrawer.onClose}
+        title={secondaryDrawer.title}
+        bodyText={secondaryDrawer.bodyText}
         testID={PNL_SECTION_TEST_IDS.costBasisDrawer}
       />
     </>

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/usePnlSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/usePnlSectionViewModel.ts
@@ -1,108 +1,35 @@
-import { useCallback, useMemo, useState } from "react";
 import { BigNumber } from "bignumber.js";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
-import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { usePortfolioPnL } from "@ledgerhq/wallet-pnl/hooks";
 import { useSelector } from "~/context/hooks";
-import { useLocale, useTranslation } from "~/context/Locale";
 import { shallowAccountsSelector } from "~/reducers/accounts";
 import { useCountervaluesState } from "~/reducers/countervalues";
-import { counterValueCurrencySelector, discreetModeSelector } from "~/reducers/settings";
-import { PnlDetailItem } from "LLM/features/Pnl/components/PnlDetailDrawer/types";
-import { PnlTrend, trendFromSign } from "./utils";
+import { counterValueCurrencySelector } from "~/reducers/settings";
+import { usePnlViewModelBase } from "LLM/features/Pnl/hooks/usePnlViewModelBase";
+import type { PnlViewModel } from "LLM/features/Pnl/types";
 
-type Drawer = "pnl" | "costBasis" | null;
-
-type CardViewModel = {
-  title: string;
-  value: string;
-  onPress: () => void;
-};
-
-type DrawerViewModel = {
-  isOpen: boolean;
-  onClose: () => void;
-  title: string;
-};
-
-export type PnlSectionViewModel = {
-  shouldRender: boolean;
-  unrealised: CardViewModel & { trend: PnlTrend };
-  costBasis: CardViewModel;
-  pnlDrawer: DrawerViewModel & { description: string; items: PnlDetailItem[] };
-  costBasisDrawer: DrawerViewModel & { bodyText: string };
-};
-
-const DRAWER_ROW_KEYS = ["unrealisedReturn", "realisedReturn", "totalReturn"] as const;
-
+const ZERO = new BigNumber(0);
 const EMPTY_ACCOUNTS: Parameters<typeof usePortfolioPnL>[0] = [];
 
-export function usePnlSectionViewModel(): PnlSectionViewModel {
-  const { t } = useTranslation();
-  const { locale } = useLocale();
+export function usePnlSectionViewModel(): PnlViewModel {
   const { shouldDisplayPnl } = useWalletFeaturesConfig("mobile");
   const accounts = useSelector(shallowAccountsSelector);
   const countervalues = useCountervaluesState();
   const fiat = useSelector(counterValueCurrencySelector);
-  const discreet = useSelector(discreetModeSelector);
-  const [openDrawer, setOpenDrawer] = useState<Drawer>(null);
 
   // Skip the (potentially expensive) portfolio walk when the section is hidden.
   const pnl = usePortfolioPnL(shouldDisplayPnl ? accounts : EMPTY_ACCOUNTS, countervalues, fiat);
+  const { costBasis = ZERO } = pnl;
 
-  const format = useCallback(
-    (value: BigNumber, alwaysShowSign?: boolean) =>
-      formatCurrencyUnit(fiat.units[0], value, {
-        showCode: true,
-        locale,
-        discreet,
-        alwaysShowSign,
-      }),
-    [fiat, locale, discreet],
-  );
-
-  const pnlDrawerItems = useMemo<PnlDetailItem[]>(() => {
-    const valueByKey: Record<(typeof DRAWER_ROW_KEYS)[number], BigNumber> = {
-      unrealisedReturn: pnl.unrealisedPnL,
-      realisedReturn: pnl.realisedPnL,
-      totalReturn: pnl.totalPnL,
-    };
-    return DRAWER_ROW_KEYS.map(key => ({
-      title: t(`pnl.drawer.${key}.title`),
-      value: format(valueByKey[key], true),
-      definition: t(`pnl.drawer.${key}.definition`),
-    }));
-  }, [pnl.unrealisedPnL, pnl.realisedPnL, pnl.totalPnL, format, t]);
-
-  const openPnlDrawer = useCallback(() => setOpenDrawer("pnl"), []);
-  const openCostBasisDrawer = useCallback(() => setOpenDrawer("costBasis"), []);
-  const closeDrawer = useCallback(() => setOpenDrawer(null), []);
-
-  return {
-    shouldRender: shouldDisplayPnl,
-    unrealised: {
-      title: t("pnl.unrealisedReturn.title"),
-      value: format(pnl.unrealisedPnL),
-      trend: trendFromSign(pnl.unrealisedPnL),
-      onPress: openPnlDrawer,
+  return usePnlViewModelBase({
+    namespace: "pnl.portfolio",
+    pnlData: pnl,
+    secondaryCard: {
+      id: "costBasis",
+      titleKey: "pnl.portfolio.costBasis.title",
+      tooltipKey: "pnl.portfolio.costBasis.tooltip",
+      value: costBasis,
     },
-    costBasis: {
-      title: t("pnl.costBasis.title"),
-      value: format(pnl.costBasis),
-      onPress: openCostBasisDrawer,
-    },
-    pnlDrawer: {
-      isOpen: openDrawer === "pnl",
-      onClose: closeDrawer,
-      title: t("pnl.drawer.title"),
-      description: t("pnl.drawer.description"),
-      items: pnlDrawerItems,
-    },
-    costBasisDrawer: {
-      isOpen: openDrawer === "costBasis",
-      onClose: closeDrawer,
-      title: t("pnl.costBasis.drawer.title"),
-      bodyText: t("pnl.costBasis.drawer.body"),
-    },
-  };
+    accountsCount: accounts.length,
+  });
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/utils.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/utils.ts
@@ -1,8 +1,0 @@
-import { BigNumber } from "bignumber.js";
-
-export type PnlTrend = "up" | "down" | "neutral";
-
-export const trendFromSign = (value: BigNumber): PnlTrend => {
-  if (value.isZero()) return "neutral";
-  return value.isPositive() ? "up" : "down";
-};

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
@@ -101,5 +101,5 @@ const screenStyle: LumenViewStyle = {
 
 const contentStyle: LumenViewStyle = {
   padding: "s16",
-  gap: "s32",
+  gap: "s24",
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/BalanceDetailsView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/BalanceDetailsView.tsx
@@ -2,12 +2,14 @@ import React from "react";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import type { FormattedValue } from "@ledgerhq/lumen-ui-rnative";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import type { DistributionItem } from "@ledgerhq/types-live";
 import { ASSET_DETAIL_TEST_IDS } from "LLM/features/AssetDetail/testIds";
 import type { BalanceDetailsViewModelResult } from "./useBalanceDetailsViewModel";
 import { TotalBalanceView } from "./TotalBalanceView";
 import { EarnBannerView } from "./EarnBannerView";
 import { EarnCardsView } from "./EarnCardsView";
 import { SectionSkeleton } from "../SectionSkeleton";
+import { PnLSection } from "../PnLSection";
 
 type EarnState = BalanceDetailsViewModelResult["earnState"];
 
@@ -22,6 +24,7 @@ type Props = Readonly<{
   onEarnBannerPress: () => void;
   onEarnDepositPress: () => void;
   isLoading: boolean;
+  distributionItem: DistributionItem | undefined;
 }>;
 
 export function BalanceDetailsView({
@@ -35,6 +38,7 @@ export function BalanceDetailsView({
   onEarnBannerPress,
   onEarnDepositPress,
   isLoading,
+  distributionItem,
 }: Props) {
   if (isLoading && !hasAccounts) {
     return <SectionSkeleton rows={1} rowHeight="s56" />;
@@ -43,14 +47,14 @@ export function BalanceDetailsView({
   if (!hasAccounts) {
     if (earnState.type !== "banner") return null;
     return (
-      <Box testID={ASSET_DETAIL_TEST_IDS.balanceDetails} lx={containerStyle}>
+      <Box testID={ASSET_DETAIL_TEST_IDS.balanceDetails}>
         <EarnBannerView label={earnState.label} onPress={onEarnBannerPress} />
       </Box>
     );
   }
 
   return (
-    <Box testID={ASSET_DETAIL_TEST_IDS.balanceDetails} lx={containerStyle}>
+    <Box testID={ASSET_DETAIL_TEST_IDS.balanceDetails}>
       <TotalBalanceView
         discreet={discreet}
         counterValue={counterValue}
@@ -59,21 +63,26 @@ export function BalanceDetailsView({
         onTransferPress={onTransferPress}
       />
 
-      {earnState.type === "banner" && (
-        <EarnBannerView label={earnState.label} onPress={onEarnBannerPress} />
-      )}
+      <Box lx={earnPnlGroupStyle}>
+        <PnLSection distributionItem={distributionItem} isLoading={isLoading} />
 
-      {earnState.type === "staked" && (
-        <EarnCardsView
-          formattedAvailable={earnState.formattedAvailable}
-          formattedDeposit={earnState.formattedDeposit}
-          onEarnDepositPress={onEarnDepositPress}
-        />
-      )}
+        {earnState.type === "banner" && (
+          <EarnBannerView label={earnState.label} onPress={onEarnBannerPress} />
+        )}
+
+        {earnState.type === "staked" && (
+          <EarnCardsView
+            formattedAvailable={earnState.formattedAvailable}
+            formattedDeposit={earnState.formattedDeposit}
+            onEarnDepositPress={onEarnDepositPress}
+          />
+        )}
+      </Box>
     </Box>
   );
 }
 
-const containerStyle: LumenViewStyle = {
+const earnPnlGroupStyle: LumenViewStyle = {
+  marginTop: "s24",
   gap: "s12",
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/index.tsx
@@ -12,5 +12,7 @@ type Props = Readonly<{
 
 export function BalanceDetails({ currency, distributionItem, isLoading }: Props) {
   const viewModel = useBalanceDetailsViewModel(currency, distributionItem);
-  return <BalanceDetailsView {...viewModel} isLoading={isLoading} />;
+  return (
+    <BalanceDetailsView {...viewModel} distributionItem={distributionItem} isLoading={isLoading} />
+  );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/__tests__/PnLSection.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/__tests__/PnLSection.integration.test.tsx
@@ -1,0 +1,106 @@
+import React from "react";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { genAccount } from "@ledgerhq/live-common/mock/account";
+import type { DistributionItem } from "@ledgerhq/types-live";
+import * as walletPnlHooks from "@ledgerhq/wallet-pnl/hooks";
+import { render, screen, withFlagOverrides } from "@tests/test-renderer";
+import { PnLSection, ASSET_DETAIL_PNL_TEST_IDS } from "..";
+
+const btc = getCryptoCurrencyById("bitcoin");
+const btcAccount = genAccount("btc-1", { currency: btc, operationsSize: 0 });
+
+const distributionItem: DistributionItem = {
+  currency: btc,
+  distribution: 1,
+  accounts: [btcAccount],
+  amount: 0,
+};
+
+const emptyDistributionItem: DistributionItem = {
+  currency: btc,
+  distribution: 0,
+  accounts: [],
+  amount: 0,
+};
+
+const withPnl = (enabled: boolean) =>
+  withFlagOverrides({ lwmWallet40: { enabled: true, params: { pnl: enabled } } });
+
+describe("AssetDetail PnLSection", () => {
+  it("renders the section when the pnl flag is on and the asset has accounts", () => {
+    render(<PnLSection distributionItem={distributionItem} isLoading={false} />, {
+      overrideInitialState: withPnl(true),
+    });
+
+    expect(screen.getByTestId(ASSET_DETAIL_PNL_TEST_IDS.root)).toBeVisible();
+    expect(screen.getByTestId(ASSET_DETAIL_PNL_TEST_IDS.unrealisedCard)).toBeVisible();
+    expect(screen.getByTestId(ASSET_DETAIL_PNL_TEST_IDS.secondaryCard)).toBeVisible();
+  });
+
+  it("renders nothing when the pnl flag is off", () => {
+    render(<PnLSection distributionItem={distributionItem} isLoading={false} />, {
+      overrideInitialState: withPnl(false),
+    });
+
+    expect(screen.queryByTestId(ASSET_DETAIL_PNL_TEST_IDS.root)).toBeNull();
+  });
+
+  it("renders nothing when the asset has no accounts", () => {
+    render(<PnLSection distributionItem={emptyDistributionItem} isLoading={false} />, {
+      overrideInitialState: withPnl(true),
+    });
+
+    expect(screen.queryByTestId(ASSET_DETAIL_PNL_TEST_IDS.root)).toBeNull();
+  });
+
+  it("renders nothing when distributionItem is undefined and not loading", () => {
+    render(<PnLSection distributionItem={undefined} isLoading={false} />, {
+      overrideInitialState: withPnl(true),
+    });
+
+    expect(screen.queryByTestId(ASSET_DETAIL_PNL_TEST_IDS.root)).toBeNull();
+  });
+
+  it("renders a skeleton when loading without a distributionItem", () => {
+    render(<PnLSection distributionItem={undefined} isLoading />, {
+      overrideInitialState: withPnl(true),
+    });
+
+    expect(screen.getByTestId("asset-detail-section-skeleton")).toBeVisible();
+  });
+
+  describe("useAssetGroupPnL short-circuit", () => {
+    let spy: jest.SpyInstance<
+      ReturnType<typeof walletPnlHooks.useAssetGroupPnL>,
+      Parameters<typeof walletPnlHooks.useAssetGroupPnL>
+    >;
+
+    beforeEach(() => {
+      spy = jest.spyOn(walletPnlHooks, "useAssetGroupPnL");
+    });
+
+    afterEach(() => {
+      spy.mockRestore();
+    });
+
+    it("does not invoke useAssetGroupPnL when the flag is off (section unmounted)", () => {
+      render(<PnLSection distributionItem={distributionItem} isLoading={false} />, {
+        overrideInitialState: withPnl(false),
+      });
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it("forwards the real accounts when the flag is on and the asset has accounts", () => {
+      render(<PnLSection distributionItem={distributionItem} isLoading={false} />, {
+        overrideInitialState: withPnl(true),
+      });
+
+      expect(spy).toHaveBeenCalledWith(
+        distributionItem.accounts,
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/__tests__/useAssetPnlViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/__tests__/useAssetPnlViewModel.test.ts
@@ -1,0 +1,64 @@
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { genAccount } from "@ledgerhq/live-common/mock/account";
+import type { DistributionItem } from "@ledgerhq/types-live";
+import * as walletPnlHooks from "@ledgerhq/wallet-pnl/hooks";
+import { renderHook, withFlagOverrides } from "@tests/test-renderer";
+import { useAssetPnlViewModel } from "../useAssetPnlViewModel";
+
+const btc = getCryptoCurrencyById("bitcoin");
+const btcAccount = genAccount("btc-1", { currency: btc, operationsSize: 0 });
+
+const distributionItem: DistributionItem = {
+  currency: btc,
+  distribution: 1,
+  accounts: [btcAccount],
+  amount: 0,
+};
+
+const withPnlFlag = (enabled: boolean) =>
+  withFlagOverrides({ lwmWallet40: { enabled: true, params: { pnl: enabled } } });
+
+describe("useAssetPnlViewModel", () => {
+  let spy: jest.SpyInstance<
+    ReturnType<typeof walletPnlHooks.useAssetGroupPnL>,
+    Parameters<typeof walletPnlHooks.useAssetGroupPnL>
+  >;
+
+  beforeEach(() => {
+    spy = jest.spyOn(walletPnlHooks, "useAssetGroupPnL");
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+  });
+
+  it("forwards the distribution accounts to useAssetGroupPnL when enabled", () => {
+    renderHook(() => useAssetPnlViewModel({ distributionItem, enabled: true }), {
+      overrideInitialState: withPnlFlag(true),
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      distributionItem.accounts,
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it("short-circuits to an empty accounts list when disabled", () => {
+    renderHook(() => useAssetPnlViewModel({ distributionItem, enabled: false }), {
+      overrideInitialState: withPnlFlag(true),
+    });
+
+    expect(spy).toHaveBeenCalledWith([], expect.anything(), expect.anything());
+  });
+
+  it("falls back to a zero average entry price when useAssetGroupPnL returns null", () => {
+    spy.mockReturnValue(null);
+
+    const { result } = renderHook(() => useAssetPnlViewModel({ distributionItem, enabled: true }), {
+      overrideInitialState: withPnlFlag(true),
+    });
+
+    expect(result.current.secondary.value).toMatch(/0(?:[.,]00)?/);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/index.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
+import type { DistributionItem } from "@ledgerhq/types-live";
+import { PnlCard } from "LLM/features/Pnl/components/PnlCard";
+import { PnlDetailDrawer } from "LLM/features/Pnl/components/PnlDetailDrawer";
+import { SectionSkeleton } from "../SectionSkeleton";
+import { ASSET_DETAIL_PNL_TEST_IDS } from "./testIds";
+import { useShouldDisplayAssetPnl } from "./useShouldDisplayAssetPnl";
+import { useAssetPnlViewModel } from "./useAssetPnlViewModel";
+
+export { ASSET_DETAIL_PNL_TEST_IDS };
+
+type Props = Readonly<{
+  distributionItem: DistributionItem | undefined;
+  isLoading: boolean;
+}>;
+
+export function PnLSection({ distributionItem, isLoading }: Props) {
+  const enabled = useShouldDisplayAssetPnl(distributionItem);
+
+  if (isLoading && !distributionItem) {
+    return <SectionSkeleton rows={1} rowHeight="s56" />;
+  }
+
+  if (!enabled || !distributionItem) return null;
+
+  return <PnLSectionContent distributionItem={distributionItem} enabled={enabled} />;
+}
+
+function PnLSectionContent({
+  distributionItem,
+  enabled,
+}: Readonly<{
+  distributionItem: DistributionItem;
+  enabled: boolean;
+}>) {
+  const { unrealised, secondary, pnlDrawer, secondaryDrawer } = useAssetPnlViewModel({
+    distributionItem,
+    enabled,
+  });
+
+  return (
+    <>
+      <Box lx={{ flexDirection: "row", gap: "s8" }} testID={ASSET_DETAIL_PNL_TEST_IDS.root}>
+        <Box lx={{ flex: 1 }}>
+          <PnlCard
+            type="interactive"
+            title={unrealised.title}
+            value={unrealised.value}
+            trend={unrealised.trend}
+            onPress={unrealised.onPress}
+            testID={ASSET_DETAIL_PNL_TEST_IDS.unrealisedCard}
+          />
+        </Box>
+        <Box lx={{ flex: 1 }}>
+          <PnlCard
+            type="info"
+            title={secondary.title}
+            value={secondary.value}
+            onPress={secondary.onPress}
+            testID={ASSET_DETAIL_PNL_TEST_IDS.secondaryCard}
+          />
+        </Box>
+      </Box>
+      <PnlDetailDrawer
+        isOpen={pnlDrawer.isOpen}
+        onClose={pnlDrawer.onClose}
+        title={pnlDrawer.title}
+        description={pnlDrawer.description}
+        items={pnlDrawer.items}
+        footer={pnlDrawer.footer}
+        testID={ASSET_DETAIL_PNL_TEST_IDS.detailDrawer}
+      />
+      <PnlDetailDrawer
+        isOpen={secondaryDrawer.isOpen}
+        onClose={secondaryDrawer.onClose}
+        title={secondaryDrawer.title}
+        bodyText={secondaryDrawer.bodyText}
+        testID={ASSET_DETAIL_PNL_TEST_IDS.secondaryDrawer}
+      />
+    </>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/testIds.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/testIds.ts
@@ -1,0 +1,7 @@
+export const ASSET_DETAIL_PNL_TEST_IDS = {
+  root: "asset-detail-pnl-section",
+  unrealisedCard: "asset-detail-pnl-unrealised-card",
+  secondaryCard: "asset-detail-pnl-secondary-card",
+  detailDrawer: "asset-detail-pnl-detail-drawer",
+  secondaryDrawer: "asset-detail-pnl-secondary-drawer",
+} as const;

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/useAssetPnlViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/useAssetPnlViewModel.ts
@@ -1,0 +1,38 @@
+import { BigNumber } from "bignumber.js";
+import { useAssetGroupPnL } from "@ledgerhq/wallet-pnl/hooks";
+import type { DistributionItem } from "@ledgerhq/types-live";
+import { useSelector } from "~/context/hooks";
+import { useCountervaluesState } from "~/reducers/countervalues";
+import { counterValueCurrencySelector } from "~/reducers/settings";
+import { usePnlViewModelBase } from "LLM/features/Pnl/hooks/usePnlViewModelBase";
+import type { PnlViewModel } from "LLM/features/Pnl/types";
+
+const ZERO = new BigNumber(0);
+const EMPTY_ACCOUNTS: Parameters<typeof useAssetGroupPnL>[0] = [];
+
+type Props = {
+  distributionItem: DistributionItem;
+  enabled: boolean;
+};
+
+export function useAssetPnlViewModel({ distributionItem, enabled }: Props): PnlViewModel {
+  const fiatCurrency = useSelector(counterValueCurrencySelector);
+  const countervalues = useCountervaluesState();
+
+  // Skip the (potentially expensive) per-asset walk when the section is hidden.
+  const accounts = enabled ? distributionItem.accounts : EMPTY_ACCOUNTS;
+  const groupPnl = useAssetGroupPnL(accounts, countervalues, fiatCurrency);
+  const { averageEntryPrice = ZERO } = groupPnl ?? {};
+
+  return usePnlViewModelBase({
+    namespace: "pnl.asset",
+    pnlData: groupPnl,
+    secondaryCard: {
+      id: "averageEntryPrice",
+      titleKey: "pnl.asset.entry.title",
+      tooltipKey: "pnl.asset.entry.tooltip",
+      value: averageEntryPrice,
+    },
+    accountsCount: distributionItem.accounts.length,
+  });
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/useShouldDisplayAssetPnl.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/useShouldDisplayAssetPnl.ts
@@ -1,0 +1,7 @@
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import type { DistributionItem } from "@ledgerhq/types-live";
+
+export function useShouldDisplayAssetPnl(distributionItem: DistributionItem | undefined): boolean {
+  const { shouldDisplayPnl: isPnlFlagOn } = useWalletFeaturesConfig("mobile");
+  return isPnlFlagOn && !!distributionItem && distributionItem.accounts.length > 0;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/builders/buildPnlDetail.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/builders/buildPnlDetail.ts
@@ -1,0 +1,51 @@
+import type { BigNumber } from "bignumber.js";
+import type { TFunction } from "i18next";
+import type { PnlDetailItem } from "../components/PnlDetailDrawer/types";
+import type { PnlNamespace } from "../types";
+
+export type BuildPnlDetailInput = {
+  namespace: PnlNamespace;
+  totalPnL: BigNumber;
+  unrealisedPnL: BigNumber;
+  realisedPnL: BigNumber;
+  formatFiat: (value: BigNumber, alwaysShowSign?: boolean) => string;
+  t: TFunction;
+};
+
+export type PnlDetailData = {
+  title: string;
+  description: string;
+  items: PnlDetailItem[];
+};
+
+export function buildPnlDetail({
+  namespace,
+  totalPnL,
+  unrealisedPnL,
+  realisedPnL,
+  formatFiat,
+  t,
+}: BuildPnlDetailInput): PnlDetailData {
+  const key = (suffix: string) => `${namespace}.drawer.${suffix}`;
+  return {
+    title: t(key("title")),
+    description: t(key("description")),
+    items: [
+      {
+        title: t(key("estimatedReturn.title")),
+        definition: t(key("estimatedReturn.description")),
+        value: formatFiat(unrealisedPnL, true),
+      },
+      {
+        title: t(key("realisedReturn.title")),
+        definition: t(key("realisedReturn.description")),
+        value: formatFiat(realisedPnL, true),
+      },
+      {
+        title: t(key("totalReturn.title")),
+        definition: t(key("totalReturn.description")),
+        value: formatFiat(totalPnL, true),
+      },
+    ],
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/builders/buildSecondaryCard.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/builders/buildSecondaryCard.ts
@@ -1,0 +1,23 @@
+import type { BigNumber } from "bignumber.js";
+import type { TFunction } from "i18next";
+import type { PnlCardViewModel, PnlSecondaryCardConfig } from "../types";
+
+export type BuildSecondaryCardInput = PnlSecondaryCardConfig & {
+  formatFiat: (value: BigNumber) => string;
+  onPress: () => void;
+  t: TFunction;
+};
+
+export function buildSecondaryCard({
+  titleKey,
+  value,
+  formatFiat,
+  onPress,
+  t,
+}: BuildSecondaryCardInput): PnlCardViewModel {
+  return {
+    title: t(titleKey),
+    value: formatFiat(value),
+    onPress,
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/builders/buildUnrealisedReturnCard.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/builders/buildUnrealisedReturnCard.ts
@@ -1,0 +1,29 @@
+import type { BigNumber } from "bignumber.js";
+import type { TFunction } from "i18next";
+import { trendFromSign } from "@ledgerhq/wallet-pnl";
+import type { PnlCardViewModel, PnlNamespace, PnlTrend } from "../types";
+
+export type BuildUnrealisedReturnCardInput = {
+  namespace: PnlNamespace;
+  unrealisedPnL: BigNumber;
+  formatFiat: (value: BigNumber) => string;
+  onPress: () => void;
+  t: TFunction;
+};
+
+export type UnrealisedReturnCard = PnlCardViewModel & { trend: PnlTrend };
+
+export function buildUnrealisedReturnCard({
+  namespace,
+  unrealisedPnL,
+  formatFiat,
+  onPress,
+  t,
+}: BuildUnrealisedReturnCardInput): UnrealisedReturnCard {
+  return {
+    title: t(`${namespace}.return.title`),
+    value: formatFiat(unrealisedPnL),
+    trend: trendFromSign(unrealisedPnL),
+    onPress,
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlDetailDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlDetailDrawer/index.tsx
@@ -12,6 +12,7 @@ export function PnlDetailDrawer({
   description,
   bodyText,
   items = [],
+  footer,
   testID,
 }: Readonly<PnlDetailDrawerProps>) {
   const { bottom: bottomInset } = useSafeAreaInsets();
@@ -35,6 +36,11 @@ export function PnlDetailDrawer({
             <PnlDetailRow key={item.title} item={item} />
           ))}
         </Box>
+        {footer ? (
+          <Text typography="body4" lx={{ color: "muted", marginTop: "s16" }}>
+            {footer}
+          </Text>
+        ) : null}
       </BottomSheetView>
     </QueuedDrawerBottomSheet>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlDetailDrawer/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlDetailDrawer/types.ts
@@ -13,5 +13,7 @@ export type PnlDetailDrawerProps = {
   /** Longer body text rendered inside the BottomSheetView (body1, base color). */
   bodyText?: string;
   items?: PnlDetailItem[];
+  /** Optional muted footer (body4, muted) rendered below the items. */
+  footer?: string;
   testID?: string;
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/hooks/usePnlViewModelBase.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/hooks/usePnlViewModelBase.ts
@@ -1,0 +1,101 @@
+import { useCallback, useMemo, useState } from "react";
+import { BigNumber } from "bignumber.js";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import { useSelector } from "~/context/hooks";
+import { useLocale, useTranslation } from "~/context/Locale";
+import { counterValueCurrencySelector, discreetModeSelector } from "~/reducers/settings";
+import { buildUnrealisedReturnCard } from "../builders/buildUnrealisedReturnCard";
+import { buildSecondaryCard } from "../builders/buildSecondaryCard";
+import { buildPnlDetail } from "../builders/buildPnlDetail";
+import type { PnlNamespace, PnlNumbers, PnlSecondaryCardConfig, PnlViewModel } from "../types";
+
+const ZERO = new BigNumber(0);
+
+type Drawer = "pnl" | "secondary" | null;
+
+export type UsePnlViewModelBaseInput = {
+  namespace: PnlNamespace;
+  pnlData: PnlNumbers | null;
+  secondaryCard: PnlSecondaryCardConfig;
+  accountsCount: number;
+};
+
+export function usePnlViewModelBase({
+  namespace,
+  pnlData,
+  secondaryCard,
+  accountsCount,
+}: UsePnlViewModelBaseInput): PnlViewModel {
+  const { t } = useTranslation();
+  const { locale } = useLocale();
+  const { shouldDisplayPnl: isPnlFlagOn } = useWalletFeaturesConfig("mobile");
+  const fiat = useSelector(counterValueCurrencySelector);
+  const discreet = useSelector(discreetModeSelector);
+  const [openDrawer, setOpenDrawer] = useState<Drawer>(null);
+
+  const { unrealisedPnL = ZERO, realisedPnL = ZERO, totalPnL = ZERO } = pnlData ?? {};
+
+  const formatFiat = useCallback(
+    (value: BigNumber, alwaysShowSign?: boolean) =>
+      formatCurrencyUnit(fiat.units[0], value, {
+        showCode: true,
+        locale,
+        discreet,
+        alwaysShowSign,
+      }),
+    [fiat, locale, discreet],
+  );
+
+  const openPnlDrawer = useCallback(() => setOpenDrawer("pnl"), []);
+  const openSecondaryDrawer = useCallback(() => setOpenDrawer("secondary"), []);
+  const closeDrawer = useCallback(() => setOpenDrawer(null), []);
+
+  const unrealised = useMemo(
+    () =>
+      buildUnrealisedReturnCard({
+        namespace,
+        unrealisedPnL,
+        formatFiat,
+        onPress: openPnlDrawer,
+        t,
+      }),
+    [namespace, unrealisedPnL, formatFiat, openPnlDrawer, t],
+  );
+
+  const secondary = useMemo(
+    () =>
+      buildSecondaryCard({
+        ...secondaryCard,
+        formatFiat,
+        onPress: openSecondaryDrawer,
+        t,
+      }),
+    [secondaryCard, formatFiat, openSecondaryDrawer, t],
+  );
+
+  const detail = useMemo(
+    () => buildPnlDetail({ namespace, totalPnL, unrealisedPnL, realisedPnL, formatFiat, t }),
+    [namespace, totalPnL, unrealisedPnL, realisedPnL, formatFiat, t],
+  );
+
+  return {
+    shouldDisplayPnl: isPnlFlagOn && accountsCount > 0,
+    unrealised,
+    secondary,
+    pnlDrawer: {
+      isOpen: openDrawer === "pnl",
+      onClose: closeDrawer,
+      title: detail.title,
+      description: detail.description,
+      items: detail.items,
+      footer: t("pnl.disclaimer"),
+    },
+    secondaryDrawer: {
+      isOpen: openDrawer === "secondary",
+      onClose: closeDrawer,
+      title: t(secondaryCard.titleKey),
+      bodyText: t(secondaryCard.tooltipKey),
+    },
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/types.ts
@@ -1,0 +1,45 @@
+import type { BigNumber } from "bignumber.js";
+import type { PnlTrend } from "@ledgerhq/wallet-pnl";
+import type { PnlDetailItem } from "./components/PnlDetailDrawer/types";
+
+export type { PnlTrend };
+
+export type PnlNamespace = "pnl.asset" | "pnl.portfolio";
+
+export type PnlNumbers = {
+  unrealisedPnL: BigNumber;
+  realisedPnL: BigNumber;
+  totalPnL: BigNumber;
+};
+
+export type PnlSecondaryCardConfig = {
+  id: string;
+  titleKey: string;
+  /** i18n key for the body text shown when the secondary card opens its drawer. */
+  tooltipKey: string;
+  value: BigNumber;
+};
+
+export type PnlCardViewModel = {
+  title: string;
+  value: string;
+  onPress: () => void;
+};
+
+export type PnlDrawerViewModel = {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+};
+
+export type PnlViewModel = {
+  shouldDisplayPnl: boolean;
+  unrealised: PnlCardViewModel & { trend: PnlTrend };
+  secondary: PnlCardViewModel;
+  pnlDrawer: PnlDrawerViewModel & {
+    description: string;
+    items: PnlDetailItem[];
+    footer: string;
+  };
+  secondaryDrawer: PnlDrawerViewModel & { bodyText: string };
+};

--- a/libs/wallet-pnl/src/__tests__/trend.test.ts
+++ b/libs/wallet-pnl/src/__tests__/trend.test.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from "bignumber.js";
-import { trendFromSign } from "../utils";
+import { trendFromSign } from "../trend";
 
 describe("trendFromSign", () => {
   it("returns 'neutral' when the value is zero", () => {

--- a/libs/wallet-pnl/src/index.ts
+++ b/libs/wallet-pnl/src/index.ts
@@ -19,3 +19,5 @@ export { computeAssetPnL } from "./assetPnL";
 export { computeAssetGroupPnL } from "./assetGroupPnL";
 export { computePortfolioPnL } from "./portfolioPnL";
 export { pnlPercentage } from "./percentage";
+export { trendFromSign } from "./trend";
+export type { PnlTrend } from "./trend";

--- a/libs/wallet-pnl/src/trend.ts
+++ b/libs/wallet-pnl/src/trend.ts
@@ -1,0 +1,19 @@
+import type { BigNumber } from "bignumber.js";
+
+/**
+ * The trend direction implied by a signed PnL value.
+ *
+ * - `"up"`: value > 0 (profit)
+ * - `"down"`: value < 0 (loss)
+ * - `"neutral"`: value === 0 (no change)
+ */
+export type PnlTrend = "up" | "down" | "neutral";
+
+/**
+ * Maps a signed PnL value to its trend direction. UI-agnostic — apps map the
+ * returned trend to their own icon / color tokens.
+ */
+export function trendFromSign(value: BigNumber): PnlTrend {
+  if (value.isZero()) return "neutral";
+  return value.isPositive() ? "up" : "down";
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Adds a PnL section to the mobile Asset Detail screen, inside `BalanceDetails` between the total balance and the Earn banner. Gated behind `shouldDisplayPnl` + the asset having funds (`distributionItem.accounts.length > 0`). With the flag off or no funds, nothing visible changes.
  - Refactors the merged Analytics PnL section onto the same shared base (`mvvm/features/Pnl/hooks/usePnlViewModelBase` + builders), so both consumers stay thin and rely on i18n namespaces (`pnl.asset` / `pnl.portfolio`).
  - i18n: restructured to per-namespace keys, renamed `dialog → drawer` (mobile is a bottom sheet), renamed the first row from "Unrealised return" to "Estimated return", added a shared `pnl.disclaimer` rendered as a muted footer in the PnL detail drawer. Other locales will need translations.
  - Asset Detail layout: `s24` between TotalBalance and the Earn/PnL group, `s12` between PnL and Earn banner, AssetDetailView `contentStyle.gap` 32 → 24.
  - Promotes `trendFromSign` + `PnlTrend` to `@ledgerhq/wallet-pnl` so desktop and mobile share the trend primitive (desktop's `getTrendIcon` now consumes it).

### 📝 Description

Mirrors the desktop AssetDetail PnL work (see `apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/PnL`) on mobile.

**Shared in `@ledgerhq/wallet-pnl`**
- `trendFromSign(value)` + `PnlTrend` type — UI-agnostic helper used by both apps.
- Desktop's `getTrendIcon` now wraps the shared helper instead of duplicating the sign check.

**Shared on mobile under `mvvm/features/Pnl`**
- `types.ts` — `PnlNamespace`, `PnlNumbers`, `PnlSecondaryCardConfig`, `PnlViewModel`.
- `hooks/usePnlViewModelBase.ts` — reads fiat / locale / discreet, formats values, manages the "open which drawer" state machine, builds drawer items keyed by namespace.
- `builders/buildUnrealisedReturnCard`, `buildSecondaryCard`, `buildPnlDetail` — pure builders mirroring the desktop ones.

**Analytics consumer** (refactored)
- `Analytics/screens/AnalyticsMain/components/PnlSection` now calls `usePnlViewModelBase({ namespace: "pnl.portfolio", ... })`. Field renames (`costBasis → secondary`) reflected in the View + tests. Local `utils.ts`/`utils.test.ts` removed (trend moved to the lib).

**AssetDetail consumer** (new)
- `AssetDetail/screens/AssetDetail/components/PnLSection`:
  - `useShouldDisplayAssetPnl` — gate (flag + accounts present).
  - `useAssetPnlViewModel` — calls `useAssetGroupPnL` (short-circuited to `[]` when gated off) and `usePnlViewModelBase({ namespace: "pnl.asset", ... })`.
  - `index.tsx` — renders the cards row + two drawers, with a section skeleton during loading.
- Wired into `BalanceDetailsView` above the Earn banner, in a group with `marginTop: s24` / `gap: s12`. `AssetDetailView` `contentStyle.gap` lowered to `s24`.

**i18n** (`apps/ledger-live-mobile/src/locales/en/common.json`)
- `pnl.portfolio.*` and `pnl.asset.*` namespaces with mirror-shape keys (`return.title`, `costBasis` / `entry`, `drawer.title|description|estimatedReturn|realisedReturn|totalReturn`).
- Shared `pnl.disclaimer` footer.

**Tests**
- `libs/wallet-pnl`: new `__tests__/trend.test.ts` (3 cases for `trendFromSign`). 203 lib tests pass.
- Mobile: 137 tests pass across `features/Pnl`, `features/Analytics/screens/AnalyticsMain/components/PnlSection` and `features/AssetDetail/screens/AssetDetail/components/PnLSection`. The new `AssetDetail/.../PnLSection/__tests__/PnLSection.integration.test.tsx` covers flag gating, the no-accounts case, the loading skeleton and the `useAssetGroupPnL` short-circuit.


<img width="479" height="314" alt="image" src="https://github.com/user-attachments/assets/3600f479-5498-4211-b8c3-bb68f9b106ac" />



### ❓ Context

- **JIRA or GitHub link**:
  - [LIVE-30306](https://ledgerhq.atlassian.net/browse/LIVE-30306) — main ticket (mobile asset detail PnL section).
  - Also fixes [LIVE-30915](https://ledgerhq.atlassian.net/browse/LIVE-30915) — addressed by the i18n / drawer copy refresh shipped here.
- **ADR link (if any)**: _N/A_

Builds on the Analytics PnL section (LIVE-30305) and the shared `PnlCard` / `PnlDetailDrawer` components (LIVE-30302 / LIVE-30303) already on `develop`.

[LIVE-30306]: https://ledgerhq.atlassian.net/browse/LIVE-30306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ