### PR TITLE
chore(deps): bump axios to 1.13.5 and speculos-device-controller to 0.3.0

### DIFF
--- a/.changeset/bump-axios-and-speculos-controller.md
+++ b/.changeset/bump-axios-and-speculos-controller.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+"@ledgerhq/live-common": patch
+---
+
+Bump axios to 1.13.5 and @ledgerhq/speculos-device-controller to 0.3.0 in the pnpm catalog.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,8 +73,8 @@ catalogs:
       specifier: 0.1.12
       version: 0.1.12
     '@ledgerhq/speculos-device-controller':
-      specifier: 0.2.3
-      version: 0.2.3
+      specifier: 0.3.0
+      version: 0.3.0
     '@ledgerhq/zcash-utils':
       specifier: 0.2.0
       version: 0.2.0
@@ -295,8 +295,8 @@ catalogs:
       specifier: 3.2.1
       version: 3.2.1
     axios:
-      specifier: 1.13.2
-      version: 1.13.2
+      specifier: 1.13.5
+      version: 1.13.5
     babel-jest:
       specifier: 30.2.0
       version: 30.2.0
@@ -1458,7 +1458,7 @@ importers:
         version: 10.4.22(postcss@8.5.6)
       axios:
         specifier: 'catalog:'
-        version: 1.13.2
+        version: 1.13.5
       buffer:
         specifier: 6.0.3
         version: 6.0.3(patch_hash=42321bf7b7c77317e644bb216138271640fb39808e74312037dac216f4b9bc5d)
@@ -3155,7 +3155,7 @@ importers:
         version: 3.2.1(@playwright/test@1.53.0)
       axios:
         specifier: 'catalog:'
-        version: 1.13.2
+        version: 1.13.5
       bignumber.js:
         specifier: 9.1.2
         version: 9.1.2
@@ -3982,7 +3982,7 @@ importers:
         version: 7.7.1
       axios:
         specifier: 'catalog:'
-        version: 1.13.2
+        version: 1.13.5
       jest:
         specifier: 'catalog:'
         version: 30.2.0(@types/node@24.12.0)
@@ -4142,7 +4142,7 @@ importers:
         version: 2.4.4
       axios:
         specifier: 'catalog:'
-        version: 1.13.2
+        version: 1.13.5
       bip32:
         specifier: ^4.0.0
         version: 4.0.0
@@ -4412,7 +4412,7 @@ importers:
         version: 7.7.1
       axios:
         specifier: 'catalog:'
-        version: 1.13.2
+        version: 1.13.5
       expect:
         specifier: 'catalog:'
         version: 30.2.0
@@ -4669,7 +4669,7 @@ importers:
         version: link:../../ledgerjs/packages/types-live
       axios:
         specifier: 'catalog:'
-        version: 1.13.2
+        version: 1.13.5
       bech32:
         specifier: ^1.1.3
         version: 1.1.4
@@ -4772,7 +4772,7 @@ importers:
         version: link:../../ledgerjs/packages/logs
       axios:
         specifier: 'catalog:'
-        version: 1.13.2
+        version: 1.13.5
       bignumber.js:
         specifier: 9.1.2
         version: 9.1.2
@@ -4939,7 +4939,7 @@ importers:
         version: 7.7.1
       axios:
         specifier: 'catalog:'
-        version: 1.13.2
+        version: 1.13.5
       jest:
         specifier: 'catalog:'
         version: 30.2.0(@types/node@24.12.0)
@@ -5206,7 +5206,7 @@ importers:
         version: 7.7.1
       axios:
         specifier: 'catalog:'
-        version: 1.13.2
+        version: 1.13.5
       jest:
         specifier: 'catalog:'
         version: 30.2.0(@types/node@24.12.0)
@@ -5530,7 +5530,7 @@ importers:
         version: 13.17.1(bignumber.js@9.1.2)(protobufjs@7.3.2)
       axios:
         specifier: 'catalog:'
-        version: 1.13.2
+        version: 1.13.5
       bech32:
         specifier: ^1.1.3
         version: 1.1.4
@@ -5882,7 +5882,7 @@ importers:
         version: 7.7.1
       axios:
         specifier: 'catalog:'
-        version: 1.13.2
+        version: 1.13.5
       jest:
         specifier: 'catalog:'
         version: 30.2.0(@types/node@24.12.0)
@@ -5936,7 +5936,7 @@ importers:
         version: 1.0.4
       axios:
         specifier: 'catalog:'
-        version: 1.13.2
+        version: 1.13.5
       bignumber.js:
         specifier: 9.1.2
         version: 9.1.2
@@ -6540,7 +6540,7 @@ importers:
     dependencies:
       axios:
         specifier: 'catalog:'
-        version: 1.13.2
+        version: 1.13.5
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
@@ -7232,7 +7232,7 @@ importers:
         version: 24.12.0
       axios:
         specifier: 'catalog:'
-        version: 1.13.2
+        version: 1.13.5
       jest:
         specifier: 'catalog:'
         version: 30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(typescript@6.0.2))
@@ -7259,7 +7259,7 @@ importers:
         version: link:../ledgerjs/packages/types-live
       axios:
         specifier: 'catalog:'
-        version: 1.13.2
+        version: 1.13.5
       eip55:
         specifier: ^2.1.1
         version: 2.1.1
@@ -7400,7 +7400,7 @@ importers:
         version: link:../env
       axios:
         specifier: 'catalog:'
-        version: 1.13.2
+        version: 1.13.5
       crypto-js:
         specifier: 4.2.0
         version: 4.2.0
@@ -7843,7 +7843,7 @@ importers:
         version: link:../ledgerjs/packages/logs
       '@ledgerhq/speculos-device-controller':
         specifier: 'catalog:'
-        version: 0.2.3(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
+        version: 0.3.0(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
       '@ledgerhq/speculos-transport':
         specifier: workspace:^
         version: link:../speculos-transport
@@ -7921,7 +7921,7 @@ importers:
         version: 3.2.5
       axios:
         specifier: 'catalog:'
-        version: 1.13.2
+        version: 1.13.5
       bech32:
         specifier: ^1.1.3
         version: 1.1.4
@@ -8306,7 +8306,7 @@ importers:
         version: link:../ledgerjs/packages/types-live
       axios:
         specifier: 'catalog:'
-        version: 1.13.2
+        version: 1.13.5
       bignumber.js:
         specifier: 9.1.2
         version: 9.1.2
@@ -8388,7 +8388,7 @@ importers:
     dependencies:
       axios:
         specifier: 'catalog:'
-        version: 1.13.2
+        version: 1.13.5
       invariant:
         specifier: ^2.2.4
         version: 2.2.4
@@ -8718,7 +8718,7 @@ importers:
         version: 24.12.0
       axios:
         specifier: 'catalog:'
-        version: 1.13.2
+        version: 1.13.5
       documentation:
         specifier: 14.0.2
         version: 14.0.2
@@ -8962,7 +8962,7 @@ importers:
         version: link:../types-live
       axios:
         specifier: 'catalog:'
-        version: 1.13.2
+        version: 1.13.5
       bignumber.js:
         specifier: 9.1.2
         version: 9.1.2
@@ -9158,7 +9158,7 @@ importers:
         version: 24.12.0
       axios:
         specifier: 'catalog:'
-        version: 1.13.2
+        version: 1.13.5
       documentation:
         specifier: 14.0.2
         version: 14.0.2
@@ -9271,7 +9271,7 @@ importers:
         version: 13.17.1(bignumber.js@9.1.2)(protobufjs@7.3.2)
       axios:
         specifier: 'catalog:'
-        version: 1.13.2
+        version: 1.13.5
       bignumber.js:
         specifier: 9.1.2
         version: 9.1.2
@@ -9799,7 +9799,7 @@ importers:
         version: link:../logs
       axios:
         specifier: 'catalog:'
-        version: 1.13.2
+        version: 1.13.5
       ws:
         specifier: 'catalog:'
         version: 8.18.3
@@ -10084,7 +10084,7 @@ importers:
         version: link:../logs
       axios:
         specifier: 'catalog:'
-        version: 1.13.2
+        version: 1.13.5
       rxjs:
         specifier: 'catalog:'
         version: 7.8.2
@@ -11050,7 +11050,7 @@ importers:
         version: link:../ledgerjs/packages/logs
       '@ledgerhq/speculos-device-controller':
         specifier: 'catalog:'
-        version: 0.2.3(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
+        version: 0.3.0(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))
     devDependencies:
       '@swc/core':
         specifier: 'catalog:'
@@ -11141,7 +11141,7 @@ importers:
         version: link:../ledgerjs/packages/logs
       axios:
         specifier: 'catalog:'
-        version: 1.13.2
+        version: 1.13.5
       lru-cache:
         specifier: ^7.14.1
         version: 7.18.3
@@ -17259,10 +17259,10 @@ packages:
     peerDependencies:
       '@ledgerhq/device-management-kit': ^1.2.0
 
-  '@ledgerhq/speculos-device-controller@0.2.3':
-    resolution: {integrity: sha512-U1dTtyBomWxTzps8PDWG0szaat9Am58C8Z10hVuEamtfrAZw4QGEce3m7B3TWAuJY+fZN63xE8CZMp49YChWiQ==}
+  '@ledgerhq/speculos-device-controller@0.3.0':
+    resolution: {integrity: sha512-FCOGVs28pTxYEom+Yr8skQ1QUyj1+sC0YDvE+Xk+DfXQx8FMRI1l41x+XT8ZGPNUh8kRTd0hsZc2lqVpxD6a8w==}
     peerDependencies:
-      '@ledgerhq/device-management-kit': ^1.0.1
+      '@ledgerhq/device-management-kit': ^1.5.1
 
   '@ledgerhq/wallet-api-client-react@1.4.25':
     resolution: {integrity: sha512-S+M+CpNOpOF89CVmxMTJUrao4DW7EJgmwLzQ8xmOJEPMj9hLb+Slei4Vd452+ZNSW1rwJ2ZExvbIqawwoJVR5g==}
@@ -44921,11 +44921,10 @@ snapshots:
       '@ledgerhq/device-management-kit': 1.5.0(rxjs@7.8.2)
       semver: 7.7.2
 
-  '@ledgerhq/speculos-device-controller@0.2.3(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))':
+  '@ledgerhq/speculos-device-controller@0.3.0(@ledgerhq/device-management-kit@1.5.0(rxjs@7.8.2))':
     dependencies:
       '@ledgerhq/device-management-kit': 1.5.0(rxjs@7.8.2)
       '@sentry/minimal': 6.19.7
-      axios: 1.13.2
 
   '@ledgerhq/wallet-api-client-react@1.4.25(@ton/crypto@3.3.0)(react@19.0.0)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,7 +35,7 @@ catalog:
   "@ledgerhq/device-transport-kit-speculos": 1.2.0
   "@ledgerhq/signer-utils": 1.2.0
   "@ledgerhq/device-transport-kit-web-hid": 1.2.3
-  "@ledgerhq/speculos-device-controller": 0.2.3
+  "@ledgerhq/speculos-device-controller": 0.3.0
   "@ledgerhq/lumen-design-core": 0.1.14
   "@ledgerhq/lumen-ui-react": 0.1.35
   "@ledgerhq/lumen-ui-rnative": 0.1.36
@@ -123,7 +123,7 @@ catalog:
   typescript: 6.0.2
   "@types/node": 24.12.0
   "@gorhom/bottom-sheet": 5.2.6
-  axios: 1.13.2
+  axios: 1.13.5
   babel-jest: 30.2.0
   bs58: ^4.0.1
   bs58check: ^2.1.2


### PR DESCRIPTION
### Checklist

- [x] npx changeset was attached.
- [x] Covered by automatic tests. CI runs full unit/integration test suites against the catalog.
- [x] Impact of the changes:
  - Pure dependency bump in the pnpm workspace catalog; no source changes.
  - Axios bumped 1.13.2 -> 1.13.5 (patch). Used by 26 packages across desktop, mobile, libs.
  - @ledgerhq/speculos-device-controller bumped 0.2.3 -> 0.3.0; 0.3.0 dropped its direct axios dep, removing the duplicate 1.13.2 pulled in via speculos. Limited API surface used in the repo (deviceControllerClientFactory, ButtonKey, DeviceControllerClient).
  - QA should sanity-check network calls (no behavior change expected) and Speculos-based e2e flows on desktop/mobile.

### Description

Routine catalog dependency bump.

axios 1.13.5 is a patch release. The speculos-device-controller 0.3.0 bump is opportunistic: it removed its own axios pin, which lets the desktop tree deduplicate one of the two remaining axios outliers.

Remaining axios duplicates (out of scope, third-party constrained):
- 1.13.6 pulled in by @stellar/stellar-sdk@14.0.0
- 1.12.2 pulled in by tronweb@6.2.0
- 1.13.2 still pulled in transitively through older published @ledgerhq/live-network@2.4.3 via @mysten/ledgerjs-hw-app-sui@0.8.0

> [!NOTE]
> A further bump to **axios 1.16.x** is on the radar — it ships a slimmer `mime-db` footprint and would dedup `mime-db` in the LLD main renderer bundle. It is too early to do it now: several of our libs (and third-party deps) need to move to a `^1.16`-compatible axios range first. Tracked in [LIVE-31537](https://ledgerhq.atlassian.net/browse/LIVE-31537) (under epic [LIVE-26525](https://ledgerhq.atlassian.net/browse/LIVE-26525)).

### Context

- JIRA or GitHub link: N/A (maintenance)
- ADR link (if any): N/A

[LIVE-31537]: https://ledgerhq.atlassian.net/browse/LIVE-31537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ