### PR TITLE
[LWD] fix: ensure consistent metric card widths in asset detail

### DIFF
--- a/.changeset/asset-detail-metrics-card-width-consistency.md
+++ b/.changeset/asset-detail-metrics-card-width-consistency.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Ensure Asset Detail PnL and staking cards use consistent widths when only three metric cards are displayed

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MetricsRowSection/MetricsRowSection.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MetricsRowSection/MetricsRowSection.tsx
@@ -10,18 +10,14 @@ type MetricsRowSectionProps = Readonly<{
 }>;
 
 export function MetricsRowSection({ distributionItem, sectionLoading }: MetricsRowSectionProps) {
-  const { shouldRenderSection, pnlVisible } = useMetricsRowSectionViewModel({ distributionItem });
+  const { shouldRenderSection } = useMetricsRowSectionViewModel({ distributionItem });
 
   if (!shouldRenderSection && !sectionLoading) return null;
 
   return (
     <div className="flex items-stretch gap-12">
       <PnLSection distributionItem={distributionItem} isLoading={sectionLoading} />
-      <StakingSection
-        distributionItem={distributionItem}
-        pnlVisible={pnlVisible}
-        isLoading={sectionLoading}
-      />
+      <StakingSection distributionItem={distributionItem} isLoading={sectionLoading} />
     </div>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MetricsRowSection/__tests__/useMetricsRowSectionViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MetricsRowSection/__tests__/useMetricsRowSectionViewModel.test.ts
@@ -35,7 +35,7 @@ describe("useMetricsRowSectionViewModel", () => {
       initialState: flagsOn,
     });
 
-    expect(result.current).toEqual({ shouldRenderSection: true, pnlVisible: true });
+    expect(result.current).toEqual({ shouldRenderSection: true });
   });
 
   it("shows the section when staking is visible but PnL is off", () => {
@@ -43,7 +43,7 @@ describe("useMetricsRowSectionViewModel", () => {
       initialState: flagsOff,
     });
 
-    expect(result.current).toEqual({ shouldRenderSection: true, pnlVisible: false });
+    expect(result.current).toEqual({ shouldRenderSection: true });
   });
 
   it("hides the section when neither PnL nor staking is visible", () => {
@@ -57,6 +57,6 @@ describe("useMetricsRowSectionViewModel", () => {
       { initialState: flagsOff },
     );
 
-    expect(result.current).toEqual({ shouldRenderSection: false, pnlVisible: false });
+    expect(result.current).toEqual({ shouldRenderSection: false });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MetricsRowSection/useMetricsRowSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MetricsRowSection/useMetricsRowSectionViewModel.ts
@@ -14,6 +14,5 @@ export function useMetricsRowSectionViewModel({ distributionItem }: Props) {
 
   return {
     shouldRenderSection: pnlVisible || stakingVisible,
-    pnlVisible,
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/StakingSection/StakingSection.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/StakingSection/StakingSection.tsx
@@ -5,13 +5,12 @@ import { StakingSectionView } from "./StakingSectionView";
 
 type StakingSectionProps = Readonly<{
   distributionItem: DistributionItem;
-  pnlVisible: boolean;
 }>;
 
-export function StakingSection({ distributionItem, pnlVisible }: StakingSectionProps) {
+export function StakingSection({ distributionItem }: StakingSectionProps) {
   const viewModel = useStakingSectionViewModel(distributionItem);
 
   if (viewModel.state.type === "hidden") return null;
 
-  return <StakingSectionView {...viewModel} pnlVisible={pnlVisible} />;
+  return <StakingSectionView {...viewModel} />;
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/StakingSection/StakingSectionView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/StakingSection/StakingSectionView.tsx
@@ -8,11 +8,7 @@ import { StakingCard } from "./components/StakingCard";
 const cardClassName = "min-w-0 flex-1";
 export const STAKING_SECTION_TEST_ID = "asset-detail-staking-section";
 
-type StakingSectionViewProps = Readonly<
-  StakingSectionViewModelResult & {
-    pnlVisible?: boolean;
-  }
->;
+type StakingSectionViewProps = Readonly<StakingSectionViewModelResult>;
 
 export function StakingSectionView({
   state,
@@ -23,7 +19,6 @@ export function StakingSectionView({
   earnBannerActionLabel,
   onEarnBannerPress,
   onEarnDepositPress,
-  pnlVisible = false,
 }: StakingSectionViewProps) {
   if (state.type === "hidden") return null;
 
@@ -34,7 +29,7 @@ export function StakingSectionView({
           cardType="interactive"
           onClick={onEarnBannerPress}
           data-testid="asset-detail-earn-banner"
-          className={cn("flex flex-col", pnlVisible ? "min-w-0 flex-[2]" : cardClassName)}
+          className={cn("flex flex-col", cardClassName)}
           title={<span className="body-2-semi-bold text-base">{state.label}</span>}
           description={<span className="body-3 text-muted">{earnBannerSubtitle}</span>}
           trailing={

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/StakingSection/__tests__/StakingSectionView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/StakingSection/__tests__/StakingSectionView.test.tsx
@@ -59,15 +59,9 @@ describe("StakingSectionView", () => {
     expect(screen.getByText("$200.00")).toBeVisible();
   });
 
-  it("spans two columns for the earn banner when PnL is visible", () => {
-    render(
-      <StakingSectionView
-        {...baseViewModel}
-        pnlVisible
-        state={{ type: "banner", label: "Earn up to 12.0% APY" }}
-      />,
-    );
+  it("keeps earn banner width aligned with other cards", () => {
+    render(<StakingSectionView {...baseViewModel} state={{ type: "banner", label: "Earn up to 12.0% APY" }} />);
 
-    expect(screen.getByTestId("asset-detail-earn-banner")).toHaveClass("flex-[2]");
+    expect(screen.getByTestId("asset-detail-earn-banner")).toHaveClass("flex-1");
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/StakingSection/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/StakingSection/index.tsx
@@ -6,13 +6,11 @@ import { shouldShowAssetDetailSectionSkeleton } from "../../utils/shouldShowAsse
 
 type StakingSectionProps = Readonly<{
   distributionItem?: DistributionItem;
-  pnlVisible?: boolean;
   isLoading: boolean;
 }>;
 
 export function StakingSection({
   distributionItem,
-  pnlVisible = false,
   isLoading,
 }: StakingSectionProps) {
   if (shouldShowAssetDetailSectionSkeleton(isLoading, distributionItem != null)) {
@@ -26,5 +24,5 @@ export function StakingSection({
 
   if (!distributionItem) return null;
 
-  return <StakingSectionComponent distributionItem={distributionItem} pnlVisible={pnlVisible} />;
+  return <StakingSectionComponent distributionItem={distributionItem} />;
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request improves the consistency of the Asset Detail page by ensuring that the PnL and staking cards use the same widths when only three metric cards are displayed. It also simplifies the logic and props related to the visibility of the PnL section, removing unnecessary `pnlVisible` props and related conditional styling. Tests and view models have been updated accordingly.

**UI Consistency Improvements:**
* Ensured that Asset Detail PnL and staking cards use consistent widths when only three metric cards are displayed, aligning the earn banner width with other cards 

**Code Simplification and Cleanup:**
* Removed the `pnlVisible` prop from `StakingSection`, `StakingSectionView`, and related components, simplifying component interfaces and internal logic 
* Updated the `useMetricsRowSectionViewModel` hook and its usage to no longer return or depend on `pnlVisible`



https://github.com/user-attachments/assets/fc80cc3a-e4f2-4286-8e41-04d39ddda8d9


### ❓ Context

[LIVE-31372](https://ledgerhq.atlassian.net/browse/LIVE-31372)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31372]: https://ledgerhq.atlassian.net/browse/LIVE-31372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ