### PR TITLE
[LWM] fix(live-mobile): make github-actions Jest reporter actually emit annotations

### DIFF
--- a/.changeset/lwm-fix-ga-reporter.md
+++ b/.changeset/lwm-fix-ga-reporter.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Restore GitHub Actions file-bound annotations on `Mobile Code Check` Jest failures by routing the `github-actions` reporter through `fs.writeSync(2, …)` so its workflow commands bypass `jest-quiet-reporter`'s stdio wrap (which silently dropped every chunk written to `process.stderr`). Failing tests now appear as inline annotations in the PR Files tab and the job Annotations panel.

--- a/apps/ledger-live-mobile/jest.config.js
+++ b/apps/ledger-live-mobile/jest.config.js
@@ -113,7 +113,12 @@ module.exports = {
     // failure, keeping passing-run logs out of the workflow output. Local: keep
     // the default reporter so engineers see live streaming logs.
     process.env.CI ? "jest-quiet-reporter" : "default",
-    ...(process.env.CI ? ["github-actions"] : []),
+    // CI: emit GitHub Actions ::error file=… annotations. We use a thin subclass
+    // of the built-in github-actions reporter that writes via fs.writeSync(2, …)
+    // instead of process.stderr.write — jest-quiet-reporter's __wrapStdio replaces
+    // process.stderr.write with a swallow-everything stub, so the built-in
+    // string reporter's annotations would otherwise be dropped on the floor.
+    ...(process.env.CI ? [["<rootDir>/scripts/jestGithubActionsReporter.js", {}]] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
   ],
   resolver: "<rootDir>/scripts/resolver.js",

--- a/apps/ledger-live-mobile/scripts/jestGithubActionsReporter.js
+++ b/apps/ledger-live-mobile/scripts/jestGithubActionsReporter.js
@@ -1,0 +1,15 @@
+const fs = require("fs");
+const { GitHubActionsReporter } = require("@jest/reporters");
+
+// jest-quiet-reporter wraps process.stderr.write at construction time and
+// silently drops every chunk that passes through it. fs.writeSync(2, …)
+// bypasses Node's process.stderr Writable wrapper and writes directly to the
+// stderr file descriptor, so the GitHub Actions workflow commands actually
+// reach the runner log.
+class GitHubActionsReporterFd extends GitHubActionsReporter {
+  log(message) {
+    fs.writeSync(2, `${message}\n`);
+  }
+}
+
+module.exports = GitHubActionsReporterFd;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Existing Jest suites exercise the reporter end-to-end (no test code changes; only how the reporter writes workflow commands).
- [x] **Impact of the changes:**
  - **Scope: developer experience / CI surfacing only.** Production app code, types, and runtime behavior are unchanged.
  - QA focus: on any failing \`Mobile Code Check\` run after this PR, the failing Jest test should show up as a file-bound annotation in the PR **Files** tab and in the job **Annotations** panel — with the file path, the failing test title, and the diff.

### 📝 Description

Restore Jest's GitHub Actions file-bound annotations on \`Mobile Code Check\` after PR #17862. Failing mobile tests now reappear as inline annotations in the PR **Files** tab and the job **Annotations** panel.

#### Root cause

PR #17862 swapped the mobile CI reporter from \`\"default\"\` to \`\"jest-quiet-reporter\"@1.0.1\`. That reporter's constructor wraps \`process.stdout.write\` and \`process.stderr.write\` with a swallow-everything stub in the **main** Jest process (\`QuietReporter.js:44-50\`):

\`\`\`js
__wrapStdio(stream) {
    stream.write = (_chunk) => {
        return true;
    };
}
\`\`\`

The built-in \`\"github-actions\"\` reporter emits each \`::error file=…::…\` workflow command via \`BaseReporter.log → process.stderr.write\` — so every annotation chunk gets dropped on the floor. Stdio is only restored in \`QuietReporter.onRunComplete\`, after all \`onTestResult\` hooks, which is too late for annotations.

Libs are unaffected because they use the plain \`\"default\"\` reporter, whose \`__wrapStdio\` is a buffered passthrough that does not swallow chunks. The console mock at \`__mocks__/console.ts\` is also unrelated — it lives in workers (\`setupFilesAfterEnv\`), only touches \`console.error\`/\`console.warn\`, and was already in place before #17862 when the reporter still worked correctly.

#### Fix

A 5-line subclass of \`@jest/reporters\`' built-in \`GitHubActionsReporter\` that overrides \`log()\` to write directly to file descriptor \`2\` via \`fs.writeSync(2, …)\`. That bypasses Node's \`process.stderr\` Writable wrapper entirely, so the workflow commands reach the runner regardless of any stream wrapping that \`jest-quiet-reporter\` (or any future reporter) installs. All annotation generation, stack parsing, and group/endgroup wrapping is inherited unchanged.

\`\`\`js
const fs = require(\"fs\");
const { GitHubActionsReporter } = require(\"@jest/reporters\");

class GitHubActionsReporterFd extends GitHubActionsReporter {
  log(message) {
    fs.writeSync(2, \`\${message}\\n\`);
  }
}

module.exports = GitHubActionsReporterFd;
\`\`\`

\`apps/ledger-live-mobile/jest.config.js\` is updated to use the new subclass instead of the built-in \`\"github-actions\"\` string, only on CI.

#### Diff

- **new** \`apps/ledger-live-mobile/scripts/jestGithubActionsReporter.js\` — \`fs.writeSync\`-based subclass.
- **modified** \`apps/ledger-live-mobile/jest.config.js\` (+7/-1) — wire it in.
- **new** \`.changeset/lwm-fix-ga-reporter.md\` — \`live-mobile\` minor.

\`apps/ledger-live-desktop\` has the exact same setup (\`verbose: !process.env.CI\`, \`jest-quiet-reporter\` on CI, built-in \`\"github-actions\"\` reporter) and almost certainly the same bug. Out of scope for this LWM branch — follow-up PR.

### ❓ Context

- **JIRA**: [LIVE-31547](https://ledgerhq.atlassian.net/browse/LIVE-31547)
- **GitHub link**: companion to #16878 (introduced the GA reporter) and #17862 (introduced \`jest-quiet-reporter\` on mobile, which silently broke this reporter).
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31547]: https://ledgerhq.atlassian.net/browse/LIVE-31547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ