### PR TITLE
[LWM] fix(live-mobile): source Asset Detail counter-value from settings (LIVE-31540)

### DIFF
--- a/.changeset/fix-asset-detail-counter-value-selector.md
+++ b/.changeset/fix-asset-detail-counter-value-selector.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Asset Detail market price now follows the user's settings counter-value. The hook previously sourced the counter-value from the Market screen's Redux state, which defaulted to USD and only changed when the user opened the Market list. It now reads `counterValueCurrencySelector` from settings, matching the desktop behaviour.

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/__tests__/useAssetMarketData.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/__tests__/useAssetMarketData.test.ts
@@ -1,9 +1,17 @@
 import { renderHook, waitFor } from "@tests/test-renderer";
 import { server, http, HttpResponse } from "@tests/server";
-import { useAssetMarketData } from "../useAssetMarketData";
 import { mockBtcCryptoCurrency } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
+import type { State } from "~/reducers/types";
+import { useAssetMarketData } from "../useAssetMarketData";
 
 const COUNTERVALUES_API = "https://countervalues.live.ledger.com";
+
+const withCounterValue =
+  (ticker: string) =>
+  (state: State): State => ({
+    ...state,
+    settings: { ...state.settings, counterValue: ticker },
+  });
 
 describe("useAssetMarketData", () => {
   describe("data forwarding", () => {
@@ -19,10 +27,39 @@ describe("useAssetMarketData", () => {
       expect(result.current.isError).toBe(false);
     });
 
-    it("returns counterCurrency from market params", () => {
+    it("defaults counterCurrency to the USD settings value", () => {
       const { result } = renderHook(() => useAssetMarketData(mockBtcCryptoCurrency));
 
-      expect(result.current.counterCurrency).toBe("USD");
+      expect(result.current.counterCurrency).toBe("usd");
+    });
+  });
+
+  describe("settings counter-value reactivity", () => {
+    it("derives counterCurrency from the user's settings counter-value (not market screen state)", () => {
+      const { result } = renderHook(() => useAssetMarketData(mockBtcCryptoCurrency), {
+        overrideInitialState: withCounterValue("EUR"),
+      });
+
+      expect(result.current.counterCurrency).toBe("eur");
+    });
+
+    it("forwards the settings counter-value as the `to` query param to /v3/markets", async () => {
+      const requestedToValues: string[] = [];
+      server.use(
+        http.get(`${COUNTERVALUES_API}/v3/markets`, ({ request }) => {
+          const to = new URL(request.url).searchParams.get("to");
+          if (to) requestedToValues.push(to);
+          return HttpResponse.json([]);
+        }),
+      );
+
+      renderHook(() => useAssetMarketData(mockBtcCryptoCurrency), {
+        overrideInitialState: withCounterValue("GBP"),
+      });
+
+      await waitFor(() => {
+        expect(requestedToValues).toContain("gbp");
+      });
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/useAssetMarketData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/useAssetMarketData.ts
@@ -1,12 +1,11 @@
 import VersionNumber from "react-native-version-number";
 import { useAssetMarketData as useSharedAssetMarketData } from "@ledgerhq/asset-detail";
 import { useSelector } from "~/context/hooks";
-import { marketParamsSelector } from "~/reducers/market";
+import { counterValueCurrencySelector } from "~/reducers/settings";
 import type { AssetDetailCurrencyProps } from "LLM/features/AssetDetail/types";
 
 export function useAssetMarketData(currency: AssetDetailCurrencyProps) {
-  const marketParams = useSelector(marketParamsSelector);
-  const { counterCurrency = "usd" } = marketParams;
+  const counterCurrency = useSelector(counterValueCurrencySelector).ticker.toLowerCase();
 
   const knownLedgerIds = currency ? [currency.id] : undefined;
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Asset Detail screen on mobile (W4.0): market price, market cap, 24h delta and DADA USD → fiat conversion now react to the user's settings counter-value. QA should switch the counter-value in Settings → General → Counter-value and confirm the Asset Detail header price + Market Stats + Price Performance sections all re-render in the selected fiat.

### 📝 Description

**Problem.** On mobile, `useAssetMarketData` was reading `counterCurrency` from `marketParamsSelector` — i.e. the Market screen's local Redux state (`state.market.marketParams`). That state is initialised to `"USD"` and only mutated when the user opens the Market list and changes the dropdown there. As a result, the Asset Detail price stayed in USD regardless of the user's settings counter-value (and the DADA USD → fiat conversion in the shared `@ledgerhq/asset-detail` hook ran with the wrong target currency).

**Fix.** Source `counterCurrency` from `counterValueCurrencySelector` in settings instead, mirroring the desktop wiring (`useAssetDetailViewModel.ts`). The shared hook already handles USD → fiat conversion for DADA payloads ([be85ca35a3](https://github.com/LedgerHQ/ledger-live/commit/be85ca35a3)), so once the right counter-value is threaded in, price/marketcap/24h delta all follow the user's selection.



https://github.com/user-attachments/assets/eebc4f81-9656-4e23-acf9-bce4f687efa0


**Tests.** Updated `useAssetMarketData.test.ts` to:
- assert the default `counterCurrency` matches the USD settings value;
- assert that overriding `settings.counterValue` to `"EUR"` makes the hook return `"eur"`;
- assert that the `/v3/markets` request receives the matching `to=<fiat>` query param (MSW handler captures the URL).

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31540](https://ledgerhq.atlassian.net/browse/LIVE-31540)
- **ADR link (if any)**: n/a

[LIVE-31540]: https://ledgerhq.atlassian.net/browse/LIVE-31540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ