### PR TITLE
[LWM] refactor(mobile): migrate Asset Detail market sections to DescriptionItem

### DIFF
--- a/.changeset/asset-detail-description-item.md
+++ b/.changeset/asset-detail-description-item.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Migrate Asset Detail Market stats and Price performance sections to the Lumen `DescriptionItem` compound component

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/MarketStatsView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/MarketStatsView.tsx
@@ -1,5 +1,17 @@
 import React from "react";
-import { Box, Text, Tooltip, TooltipTrigger, TooltipContent } from "@ledgerhq/lumen-ui-rnative";
+import {
+  Box,
+  Text,
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  DescriptionItem,
+  DescriptionItemLeading,
+  DescriptionItemLabel,
+  DescriptionItemTrailing,
+  DescriptionItemValue,
+  InteractiveIcon,
+} from "@ledgerhq/lumen-ui-rnative";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { Information } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -47,15 +59,18 @@ export function MarketStatsView({ stats, isLoading, isError, hasData, onTooltipO
       >
         <Box lx={listStyle}>
           {stats.map(stat => (
-            <Box key={stat.key} lx={rowStyle}>
-              <Box lx={labelContainerStyle}>
-                <Text typography="body2" lx={{ color: "muted" }}>
-                  {stat.label}
-                </Text>
+            <DescriptionItem key={stat.key} size="md">
+              <DescriptionItemLeading>
+                <DescriptionItemLabel>{stat.label}</DescriptionItemLabel>
                 {stat.tooltip && (
                   <Tooltip onOpenChange={open => onTooltipOpen(stat.key, open)}>
-                    <TooltipTrigger>
-                      <Information size={16} color="muted" />
+                    <TooltipTrigger asChild>
+                      <InteractiveIcon
+                        icon={Information}
+                        size={16}
+                        iconType="stroked"
+                        accessibilityLabel={stat.tooltip.title}
+                      />
                     </TooltipTrigger>
                     <TooltipContent
                       title={stat.tooltip.title}
@@ -69,11 +84,11 @@ export function MarketStatsView({ stats, isLoading, isError, hasData, onTooltipO
                     />
                   </Tooltip>
                 )}
-              </Box>
-              <Text typography="body2SemiBold" lx={{ color: "base" }}>
-                {stat.value}
-              </Text>
-            </Box>
+              </DescriptionItemLeading>
+              <DescriptionItemTrailing>
+                <DescriptionItemValue>{stat.value}</DescriptionItemValue>
+              </DescriptionItemTrailing>
+            </DescriptionItem>
           ))}
         </Box>
       </SectionContentState>
@@ -87,16 +102,4 @@ const containerStyle: LumenViewStyle = {
 
 const listStyle: LumenViewStyle = {
   gap: "s12",
-};
-
-const rowStyle: LumenViewStyle = {
-  flexDirection: "row",
-  justifyContent: "space-between",
-  alignItems: "center",
-};
-
-const labelContainerStyle: LumenViewStyle = {
-  flexDirection: "row",
-  alignItems: "center",
-  gap: "s4",
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/PricePerformanceView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/PricePerformanceView.tsx
@@ -1,5 +1,13 @@
 import React from "react";
-import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
+import {
+  Box,
+  Text,
+  DescriptionItem,
+  DescriptionItemLeading,
+  DescriptionItemLabel,
+  DescriptionItemTrailing,
+  DescriptionItemValue,
+} from "@ledgerhq/lumen-ui-rnative";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { useTranslation } from "~/context/Locale";
 import { ASSET_DETAIL_TEST_IDS } from "LLM/features/AssetDetail/testIds";
@@ -45,24 +53,24 @@ export function PricePerformanceView({ records, isLoading, isError, hasData }: P
       >
         <Box lx={listStyle}>
           {records.map(record => (
-            <Box key={record.id} lx={recordStyle}>
-              <Box lx={recordLeftStyle}>
-                <Text typography="body2" lx={{ color: "muted" }}>
-                  {record.label}
-                </Text>
-                <Text typography="body3" lx={{ color: "muted" }}>
-                  {record.date} ({record.relativeTime})
-                </Text>
-              </Box>
-              <Box lx={recordRightStyle}>
-                <Text typography="body2SemiBold" lx={{ color: "base" }}>
-                  {record.value}
-                </Text>
-                <Text typography="body3" lx={{ color: "muted" }}>
-                  {record.changePercentage}
-                </Text>
-              </Box>
-            </Box>
+            <DescriptionItem key={record.id} size="md">
+              <DescriptionItemLeading>
+                <Box lx={leadingColumnStyle}>
+                  <DescriptionItemLabel>{record.label}</DescriptionItemLabel>
+                  <Text typography="body3" lx={{ color: "muted" }}>
+                    {record.date} ({record.relativeTime})
+                  </Text>
+                </Box>
+              </DescriptionItemLeading>
+              <DescriptionItemTrailing>
+                <Box lx={trailingColumnStyle}>
+                  <DescriptionItemValue>{record.value}</DescriptionItemValue>
+                  <Text typography="body3" lx={{ color: "muted" }}>
+                    {record.changePercentage}
+                  </Text>
+                </Box>
+              </DescriptionItemTrailing>
+            </DescriptionItem>
           ))}
         </Box>
       </SectionContentState>
@@ -78,17 +86,13 @@ const listStyle: LumenViewStyle = {
   gap: "s16",
 };
 
-const recordStyle: LumenViewStyle = {
-  flexDirection: "row",
-  justifyContent: "space-between",
-  alignItems: "flex-start",
-};
-
-const recordLeftStyle: LumenViewStyle = {
+const leadingColumnStyle: LumenViewStyle = {
+  flex: 1,
+  minWidth: "s0",
   gap: "s2",
 };
 
-const recordRightStyle: LumenViewStyle = {
+const trailingColumnStyle: LumenViewStyle = {
   alignItems: "flex-end",
   gap: "s2",
 };


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Asset Detail screen on mobile — **Market stats** section (Market cap, Market rank, Circulating supply, Max supply, 24h trading volume) and **Price performance** section (All-time high, All-time low).
  - Info tooltips on Market stats rows (press the `(i)` icon — should open the bottom sheet with title + content).
  - Layout parity: rows should be visually identical to the previous design (typography, spacing, alignment).
  - Analytics: `info_bubble_pressed` tracking on tooltip open is preserved.
  - Accessibility: info icons now expose an `accessibilityLabel` (the tooltip title).

### Description

Migrate the Asset Detail Market stats and Price performance sections to the new Lumen `DescriptionItem` compound component released in [LedgerHQ/lumen#699](https://github.com/LedgerHQ/lumen/pull/699) and bundled in `@ledgerhq/lumen-ui-rnative@0.1.36`.

**Why**: replace the hand-rolled Box/Text/Tooltip row layout with the canonical design-system component so the screen aligns with the rest of the app, gets accessibility / hit-slop for free on the info icon, and is easier to maintain.

**What changes**:

- `MarketStatsView` now composes each row with `DescriptionItem` (size `md`) + `DescriptionItemLeading` / `DescriptionItemLabel` / `DescriptionItemTrailing` / `DescriptionItemValue`. The bare `Information` symbol is replaced by an `InteractiveIcon` (iconType `stroked`) wrapped in `TooltipTrigger asChild` — `asChild` is mandatory here, otherwise the `TooltipTrigger` own `Pressable` and the `InteractiveIcon` `Pressable` nest and the inner one swallows the press, leaving the tooltip closed.
- `PricePerformanceView` is migrated to the same primitive. Because each side carries a secondary line (date + relative time on the left, % change on the right), a column `Box` is nested inside `Leading` / `Trailing` — a pattern explicitly supported by `DescriptionItem` (`Leading`/`Trailing` accept any custom content per the Lumen JSDoc and the `TruncationBehavior` storybook).
- View-models (`useMarketStatsViewModel`, `usePricePerformanceViewModel`) are untouched — the `{ key, label, value, tooltip? }` shape already matched `DescriptionItem` semantics 1:1, so this is a view-only refactor.

| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### Context

- **JIRA or GitHub link**: [LIVE-31468](https://ledgerhq.atlassian.net/browse/LIVE-31468)
- **Lumen component PR**: [LedgerHQ/lumen#699](https://github.com/LedgerHQ/lumen/pull/699)

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-31468]: https://ledgerhq.atlassian.net/browse/LIVE-31468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ