### PR TITLE
fix: logsviewer crash and add logs cta style

### DIFF
--- a/.changeset/spotty-chicken-flash.md
+++ b/.changeset/spotty-chicken-flash.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/web-tools": minor
+---
+
+Fix Logsviewer crash and cta to load logs style

--- a/apps/web-tools/src/pages/logsviewer.tsx
+++ b/apps/web-tools/src/pages/logsviewer.tsx
@@ -4,6 +4,7 @@ import { ObjectInspector } from "react-inspector";
 import ReactTable from "react-table";
 import styled from "styled-components";
 import "react-table/react-table.css";
+import { Button as LumenButton } from "@ledgerhq/lumen-ui-react";
 import { AccountRaw } from "@ledgerhq/types-live";
 import { decodeAccountId } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { findCryptoCurrencyById } from "@ledgerhq/cryptoassets";
@@ -107,7 +108,7 @@ const HeaderRow = styled.div`
 const dmkLoggerTags = ["live-dmk-logger", "DMK"]; // "live-dmk-logger" is kept for backward compatibility
 
 function isDmkLog(log: Log): boolean {
-  return dmkLoggerTags.some(tag => log.type.startsWith(tag));
+  return typeof log.type === "string" && dmkLoggerTags.some(tag => log.type.startsWith(tag));
 }
 
 const Header = ({
@@ -317,7 +318,12 @@ const Header = ({
   return (
     <HeaderWrapper>
       <HeaderRow>
-        <input type="file" onChange={onChange} accept=".json" />
+        <LumenButton asChild appearance="accent">
+          <label>
+            Load Logs
+            <input type="file" onChange={onChange} accept=".json" className="hidden" />
+          </label>
+        </LumenButton>
 
         {apdusLogs.length ? (
           <Button download="apdus" href={href}>
@@ -588,7 +594,17 @@ class HeaderEmptyState extends Component<{
           <code>Ctrl+E</code> / Export Logs )
         </p>
         <p>
-          <input type="file" onChange={this.onChange} accept=".json,.txt" />
+          <LumenButton asChild appearance="accent">
+            <label>
+              Load Logs
+              <input
+                type="file"
+                onChange={this.onChange}
+                accept=".json,.txt"
+                className="hidden"
+              />
+            </label>
+          </LumenButton>
         </p>
       </header>
     );


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Make the logviewer resilient when type in logs is not a string + fix cta styling.
<img width="851" height="479" alt="image" src="https://github.com/user-attachments/assets/6ee174da-256a-4599-a837-dbfdeb739aff" />

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-31544
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
