### PR TITLE
[LWDM] chore(wallet40): expose earnUpselling and earnSimulator attributes

### DIFF
--- a/.changeset/wallet40-earn-attributes.md
+++ b/.changeset/wallet40-earn-attributes.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/types-live": minor
+"@ledgerhq/live-common": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Add `earnUpselling` and `earnSimulator` as Wallet 4.0 feature flag params, expose them in the Wallet 4.0 analytics attributes, and surface them in the desktop and mobile developer settings toggles.

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/constants.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/constants.ts
@@ -20,6 +20,8 @@ export const WALLET_FEATURES_PARAMS = [
   { key: "myWallet", label: "My Wallet" },
   { key: "assetDiscoverability", label: "Asset Discoverability" },
   { key: "pnl", label: "PnL" },
+  { key: "earnUpselling", label: "Earn Upselling" },
+  { key: "earnSimulator", label: "Earn Simulator" },
 ] as const;
 
 export type WalletFeatureParamKey = (typeof WALLET_FEATURES_PARAMS)[number]["key"];

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Wallet40/useWallet40ViewModel.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Wallet40/useWallet40ViewModel.ts
@@ -21,6 +21,8 @@ export const WALLET_40_PARAMS = [
   { key: "myWallet", label: "My Wallet" },
   { key: "assetDiscoverability", label: "Asset Discoverability" },
   { key: "pnl", label: "PnL" },
+  { key: "earnUpselling", label: "Earn Upselling" },
+  { key: "earnSimulator", label: "Earn Simulator" },
 ] as const;
 
 type WalletFeatureParamKey = (typeof WALLET_40_PARAMS)[number]["key"];

--- a/libs/ledger-live-common/src/analytics/featureFlagHelpers/wallet40.ts
+++ b/libs/ledger-live-common/src/analytics/featureFlagHelpers/wallet40.ts
@@ -33,5 +33,11 @@ export const getWallet40Attributes = (
     assetDiscoverability: wallet40FeatureFlag?.params?.assetDiscoverability ?? false,
     aggregatedAssets: wallet40FeatureFlag?.params?.aggregatedAssets ?? false,
     pnl: wallet40FeatureFlag?.params?.pnl ?? false,
+    finishOnboardingWidget:
+      wallet40FeatureFlag?.params?.finishOnboardingWidget ??
+      onboardingWidgetFeatureFlag?.enabled ??
+      false,
+    earnUpselling: wallet40FeatureFlag?.params?.earnUpselling ?? false,
+    earnSimulator: wallet40FeatureFlag?.params?.earnSimulator ?? false,
   };
 };

--- a/libs/ledger-live-common/src/analytics/featureFlagHelpers/wallet40.ts
+++ b/libs/ledger-live-common/src/analytics/featureFlagHelpers/wallet40.ts
@@ -33,10 +33,6 @@ export const getWallet40Attributes = (
     assetDiscoverability: wallet40FeatureFlag?.params?.assetDiscoverability ?? false,
     aggregatedAssets: wallet40FeatureFlag?.params?.aggregatedAssets ?? false,
     pnl: wallet40FeatureFlag?.params?.pnl ?? false,
-    finishOnboardingWidget:
-      wallet40FeatureFlag?.params?.finishOnboardingWidget ??
-      onboardingWidgetFeatureFlag?.enabled ??
-      false,
     earnUpselling: wallet40FeatureFlag?.params?.earnUpselling ?? false,
     earnSimulator: wallet40FeatureFlag?.params?.earnSimulator ?? false,
   };

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -849,6 +849,8 @@ export const DEFAULT_FEATURES: Features = {
       myWallet: false,
       pnl: false,
       assetDiscoverability: false,
+      earnUpselling: false,
+      earnSimulator: false,
     },
   },
   lwdWallet40: {
@@ -870,6 +872,8 @@ export const DEFAULT_FEATURES: Features = {
       myWallet: false,
       pnl: false,
       assetDiscoverability: false,
+      earnUpselling: false,
+      earnSimulator: false,
     },
   },
   addressPoisoningOperationsFilter: {

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -903,6 +903,10 @@ type Feature_Wallet40_Params = {
   // Specifics
   brazePlacement?: boolean;
   newReceiveDialog?: boolean;
+  finishOnboardingWidget?: boolean;
+  onboardingWidget?: boolean;
+  earnUpselling?: boolean;
+  earnSimulator?: boolean;
 };
 
 export type Feature_LwmWallet40 = Feature<Feature_Wallet40_Params>;

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -904,7 +904,6 @@ type Feature_Wallet40_Params = {
   brazePlacement?: boolean;
   newReceiveDialog?: boolean;
   finishOnboardingWidget?: boolean;
-  onboardingWidget?: boolean;
   earnUpselling?: boolean;
   earnSimulator?: boolean;
 };

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -903,7 +903,6 @@ type Feature_Wallet40_Params = {
   // Specifics
   brazePlacement?: boolean;
   newReceiveDialog?: boolean;
-  finishOnboardingWidget?: boolean;
   earnUpselling?: boolean;
   earnSimulator?: boolean;
 };

--- a/shared/feature-flags/src/flags/team-wallet-xp/lwdWallet40.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/lwdWallet40.ts
@@ -39,6 +39,8 @@ export const lwdWallet40 = flagWith(
       myWallet: false,
       pnl: false,
       assetDiscoverability: false,
+      earnUpselling: false,
+      earnSimulator: false,
     },
   },
 );

--- a/shared/feature-flags/src/flags/team-wallet-xp/lwmWallet40.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/lwmWallet40.ts
@@ -38,6 +38,8 @@ export const lwmWallet40 = flagWith(
       myWallet: false,
       pnl: false,
       assetDiscoverability: false,
+      earnUpselling: false,
+      earnSimulator: false,
     },
   },
 );


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Plumbing change for feature-flag params and analytics attributes; verified manually via the analytics payload (see screenshot)._
- [x] **Impact of the changes:**
  - Wallet 4.0 analytics attributes payload now includes `earnUpselling` and `earnSimulator`
  - Developer Settings > Wallet 4.0 toggles (desktop + mobile) expose the two new params
  - No user-facing UI/behavioural change

### 📝 Description

Adds two new boolean params to the Wallet 4.0 feature flag (`lwdWallet40` / `lwmWallet40`):

- `earnUpselling`
- `earnSimulator`

These are propagated through `getWallet40Attributes` so they appear on the `wallet40Attributes` analytics payload, and exposed as toggles in the desktop and mobile Developer Settings > Wallet 4.0 dev tool. This unblocks experimentation on the Earn upselling and Earn simulator surfaces from the Firebase-side feature flag without further code changes.

#### Verification

The screenshot below shows the Segment `Page` payload with the new `wallet40Attributes.earnUpselling` and `wallet40Attributes.earnSimulator` fields present.

<img width="2972" height="1496" alt="image" src="https://github.com/user-attachments/assets/99ad58b3-9cc9-4d12-89d7-ab1c945d5b22" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31555](https://ledgerhq.atlassian.net/browse/LIVE-31555)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-31555]: https://ledgerhq.atlassian.net/browse/LIVE-31555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ