### PR TITLE
[LWD] feat: centralize and standardize staking/earn navigation

### DIFF
--- a/.changeset/calm-staking-earn-redirect.md
+++ b/.changeset/calm-staking-earn-redirect.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix Asset Detail earn banner to redirect to the correct Earn or native staking flow via shared navigation hook

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/__integrations__/AssetDetail.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/__integrations__/AssetDetail.integration.test.tsx
@@ -59,10 +59,13 @@ const TEST_ID = {
 
 const mockGetCanStakeCurrency = jest.fn().mockReturnValue(false);
 const mockUseInterestRatesByCurrencies = jest.fn().mockReturnValue({});
+const mockStartStakeFlow = jest.fn();
 
 jest.mock("LLD/hooks/useStake", () => ({
   useStake: () => ({ getCanStakeCurrency: mockGetCanStakeCurrency }),
 }));
+
+jest.mock("~/renderer/screens/stake", () => () => mockStartStakeFlow);
 
 jest.mock("@ledgerhq/live-common/dada-client/hooks/useInterestRatesByCurrencies", () => ({
   useInterestRatesByCurrencies: (...args: unknown[]) => mockUseInterestRatesByCurrencies(...args),

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/StakingSection/__tests__/useStakingSectionViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/StakingSection/__tests__/useStakingSectionViewModel.test.ts
@@ -7,24 +7,22 @@ import { track } from "~/renderer/analytics/segment";
 import { computeFiatPortionsFromDistribution } from "LLD/features/AssetDetail/utils/computeFiatPortionsFromDistribution";
 import { useStakingSectionViewModel } from "../useStakingSectionViewModel";
 
-const mockNavigate = jest.fn();
 const mockGetCanStakeCurrency = jest.fn().mockReturnValue(false);
 const mockUseInterestRatesByCurrencies = jest.fn().mockReturnValue({});
-
-jest.mock("react-router", () => ({
-  ...jest.requireActual("react-router"),
-  useNavigate: () => mockNavigate,
-}));
+const mockStartStakeFlow = jest.fn();
 
 jest.mock("LLD/hooks/useStake", () => ({
   useStake: () => ({ getCanStakeCurrency: mockGetCanStakeCurrency }),
 }));
+
+jest.mock("~/renderer/screens/stake", () => () => mockStartStakeFlow);
 
 jest.mock("@ledgerhq/live-common/dada-client/hooks/useInterestRatesByCurrencies", () => ({
   useInterestRatesByCurrencies: (...args: unknown[]) => mockUseInterestRatesByCurrencies(...args),
 }));
 
 const btc = getCryptoCurrencyById("bitcoin");
+const tron = getCryptoCurrencyById("tron");
 
 const defaultSettingsState = {
   settings: { counterValue: "USD", locale: "en-US", discreetMode: false },
@@ -60,6 +58,13 @@ describe("useStakingSectionViewModel", () => {
     if (result.current.state.type === "banner") {
       expect(result.current.state.label).toBe("Earn with this asset");
     }
+
+    act(() => result.current.onEarnBannerPress());
+
+    expect(mockStartStakeFlow).toHaveBeenCalledWith({
+      currencies: ["bitcoin"],
+      source: "Asset detail",
+    });
   });
 
   it("shows APY in the earn banner when stakeable without accounts and interest rate is available", () => {
@@ -220,26 +225,27 @@ describe("useStakingSectionViewModel", () => {
     }
   });
 
-  it("navigates to earn and tracks analytics on banner press", () => {
+  it("opens the stake drawer when earn banner is pressed", () => {
     mockGetCanStakeCurrency.mockReturnValue(true);
-    const account = genAccount("staking-btc-nav", { currency: btc });
-    const item = buildDistributionItem({ currency: btc, accounts: [account] });
+    const account = genAccount("staking-tron-nav", { currency: tron });
+    const item = buildDistributionItem({ currency: tron, accounts: [account] });
 
     const { result } = renderHook(() => useStakingSectionViewModel(item));
 
     act(() => result.current.onEarnBannerPress());
 
-    expect(mockNavigate).toHaveBeenCalledWith("/earn", {
-      state: { intent: "deposit", cryptoAssetId: "bitcoin" },
+    expect(mockStartStakeFlow).toHaveBeenCalledWith({
+      currencies: ["tron"],
+      source: "Asset detail",
     });
     expect(track).toHaveBeenCalledWith("button_clicked", {
       button: "earn_banner",
-      currency: "bitcoin",
+      currency: "tron",
       page: "Asset detail",
     });
   });
 
-  it("navigates to earn and tracks analytics on earn deposit press", () => {
+  it("opens the stake drawer when earn deposit card is pressed", () => {
     mockGetCanStakeCurrency.mockReturnValue(true);
     const account = genAccount("staking-btc-deposit-nav", { currency: btc });
     account.balance = new BigNumber(10);
@@ -250,8 +256,9 @@ describe("useStakingSectionViewModel", () => {
 
     act(() => result.current.onEarnDepositPress());
 
-    expect(mockNavigate).toHaveBeenCalledWith("/earn", {
-      state: { intent: "deposit", cryptoAssetId: "bitcoin" },
+    expect(mockStartStakeFlow).toHaveBeenCalledWith({
+      currencies: ["bitcoin"],
+      source: "Asset detail",
     });
     expect(track).toHaveBeenCalledWith("button_clicked", {
       button: "earn_deposit",

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/StakingSection/useStakingSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/StakingSection/useStakingSectionViewModel.ts
@@ -2,7 +2,6 @@ import { useCallback, useMemo } from "react";
 import type { DistributionItem } from "@ledgerhq/types-live";
 import { useInterestRatesByCurrencies } from "@ledgerhq/live-common/dada-client/hooks/useInterestRatesByCurrencies";
 import { getInterestRateForAsset } from "@ledgerhq/live-common/modularDrawer/utils/getInterestRateForAsset";
-import { useNavigate } from "react-router";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "LLD/hooks/redux";
 import {
@@ -12,6 +11,7 @@ import {
 } from "~/renderer/reducers/settings";
 import { track } from "~/renderer/analytics/segment";
 import { useStake } from "LLD/hooks/useStake";
+import useStakeFlow from "~/renderer/screens/stake";
 import { ASSET_DETAIL_TRACKING_PAGE_NAME } from "LLD/features/AssetDetail/constants";
 import { computeAvailableAndEarnDeposit } from "LLD/features/AssetDetail/utils/computeAvailableAndEarnDeposit";
 import { computeFiatPortionsFromDistribution } from "LLD/features/AssetDetail/utils/computeFiatPortionsFromDistribution";
@@ -24,7 +24,6 @@ export type StakingSectionState =
 
 export function useStakingSectionViewModel(distributionItem: DistributionItem) {
   const { t } = useTranslation();
-  const navigate = useNavigate();
   const discreet = useSelector(discreetModeSelector);
   const locale = useSelector(localeSelector);
   const fiatCurrency = useSelector(counterValueCurrencySelector);
@@ -38,6 +37,7 @@ export function useStakingSectionViewModel(distributionItem: DistributionItem) {
   );
 
   const { getCanStakeCurrency } = useStake();
+  const startStakeFlow = useStakeFlow();
   const isStakeable = getCanStakeCurrency(currencyId);
   const hasEarnDeposit = earnDeposit.gt(0);
 
@@ -101,14 +101,12 @@ export function useStakingSectionViewModel(distributionItem: DistributionItem) {
     locale,
   ]);
 
-  const navigateToEarn = useCallback(() => {
-    navigate("/earn", {
-      state: {
-        intent: "deposit",
-        cryptoAssetId: currencyId,
-      },
+  const openStakeDrawer = useCallback(() => {
+    startStakeFlow({
+      currencies: [currencyId],
+      source: ASSET_DETAIL_TRACKING_PAGE_NAME,
     });
-  }, [navigate, currencyId]);
+  }, [currencyId, startStakeFlow]);
 
   const onEarnBannerPress = useCallback(() => {
     track("button_clicked", {
@@ -116,8 +114,8 @@ export function useStakingSectionViewModel(distributionItem: DistributionItem) {
       currency: currencyId,
       page: ASSET_DETAIL_TRACKING_PAGE_NAME,
     });
-    navigateToEarn();
-  }, [currencyId, navigateToEarn]);
+    openStakeDrawer();
+  }, [currencyId, openStakeDrawer]);
 
   const onEarnDepositPress = useCallback(() => {
     track("button_clicked", {
@@ -125,8 +123,8 @@ export function useStakingSectionViewModel(distributionItem: DistributionItem) {
       currency: currencyId,
       page: ASSET_DETAIL_TRACKING_PAGE_NAME,
     });
-    navigateToEarn();
-  }, [currencyId, navigateToEarn]);
+    openStakeDrawer();
+  }, [currencyId, openStakeDrawer]);
 
   return {
     state,

--- a/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/useNavigateToStakeForAccount.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/useNavigateToStakeForAccount.test.ts
@@ -1,0 +1,106 @@
+import { renderHook, act } from "tests/testSetup";
+import BigNumber from "bignumber.js";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { useNavigateToStakeForAccount } from "../useNavigateToStakeForAccount";
+
+const mockNavigate = jest.fn();
+const mockGetCanStakeUsingLedgerLive = jest.fn().mockReturnValue(false);
+const mockGetRouteToPlatformApp = jest.fn().mockReturnValue(null);
+
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock("LLD/hooks/useStake", () => ({
+  useStake: () => ({
+    getCanStakeUsingLedgerLive: mockGetCanStakeUsingLedgerLive,
+    getRouteToPlatformApp: mockGetRouteToPlatformApp,
+  }),
+}));
+
+const btc = getCryptoCurrencyById("bitcoin");
+const tron = getCryptoCurrencyById("tron");
+
+describe("useNavigateToStakeForAccount", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCanStakeUsingLedgerLive.mockReturnValue(false);
+    mockGetRouteToPlatformApp.mockReturnValue(null);
+  });
+
+  it("navigates to Earn for partner routes, not /platform", () => {
+    const account = genAccount("tron-stake", { currency: tron });
+    const platformState = {
+      appId: "partner-app",
+      customDappUrl: "https://earn.example/?yieldId=tron-native-staking",
+      returnTo: "/asset/tron",
+    };
+    mockGetRouteToPlatformApp.mockReturnValue({
+      pathname: "/platform/partner-app",
+      state: platformState,
+    });
+
+    const { result } = renderHook(() => useNavigateToStakeForAccount());
+
+    let outcome: ReturnType<typeof result.current.navigateToStakeForAccount> | undefined;
+    act(() => {
+      outcome = result.current.navigateToStakeForAccount(account, undefined, {
+        returnTo: "/asset/tron",
+      });
+    });
+
+    expect(outcome).toEqual({ outcome: "platform_earn", provider: "partner-app" });
+    expect(mockNavigate).toHaveBeenCalledWith("/earn", { state: platformState });
+    expect(mockNavigate).not.toHaveBeenCalledWith("/platform/partner-app", expect.anything());
+  });
+
+  it("opens the native staking modal for Ledger Live staking currencies", () => {
+    mockGetCanStakeUsingLedgerLive.mockReturnValue(true);
+    const account = genAccount("eth-stake", { currency: getCryptoCurrencyById("ethereum") });
+    account.spendableBalance = new BigNumber(1);
+
+    const { result, store } = renderHook(() => useNavigateToStakeForAccount());
+
+    let outcome: ReturnType<typeof result.current.navigateToStakeForAccount> | undefined;
+    act(() => {
+      outcome = result.current.navigateToStakeForAccount(account, undefined, {
+        source: "Asset detail",
+      });
+    });
+
+    expect(outcome).toEqual({ outcome: "native_stake" });
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(store.getState().modals.MODAL_START_STAKE?.isOpened).toBe(true);
+  });
+
+  it("falls back to earn deposit intent when no partner or native route exists", () => {
+    const account = genAccount("btc-stake", { currency: btc });
+    account.spendableBalance = new BigNumber(1);
+
+    const { result } = renderHook(() => useNavigateToStakeForAccount());
+
+    act(() => {
+      result.current.navigateToStakeForAccount(account, undefined);
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith("/earn", {
+      state: { intent: "deposit", cryptoAssetId: "bitcoin" },
+    });
+  });
+
+  it("opens no-funds when alwaysShowNoFunds is set", () => {
+    const account = genAccount("btc-no-funds", { currency: btc });
+    account.spendableBalance = new BigNumber(10);
+
+    const { result, store } = renderHook(() => useNavigateToStakeForAccount());
+
+    act(() => {
+      result.current.navigateToStakeForAccount(account, undefined, { alwaysShowNoFunds: true });
+    });
+
+    expect(mockGetRouteToPlatformApp).not.toHaveBeenCalled();
+    expect(store.getState().modals.MODAL_NO_FUNDS_STAKE?.isOpened).toBe(true);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/hooks/useNavigateToStakeForAccount.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/useNavigateToStakeForAccount.ts
@@ -1,0 +1,122 @@
+import { useCallback } from "react";
+import { useNavigate } from "react-router";
+import { getAccountCurrency } from "@ledgerhq/ledger-wallet-framework/account/index";
+import type { Account, TokenAccount } from "@ledgerhq/types-live";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
+import { openModal } from "~/renderer/actions/modals";
+import { walletSelector } from "~/renderer/reducers/wallet";
+import { useStake } from "LLD/hooks/useStake";
+
+export type NavigateToStakeForAccountOptions = {
+  returnTo?: string;
+  source?: string;
+  entryPoint?: "get-funds";
+  alwaysShowNoFunds?: boolean;
+};
+
+export type NavigateToStakeForAccountResult =
+  | { outcome: "platform_earn"; provider: string }
+  | { outcome: "native_stake" }
+  | { outcome: "no_funds" }
+  | { outcome: "earn_deposit_fallback" };
+
+/**
+ * Navigates to Earn (partner or deposit intent) or opens the native Ledger Live staking flow.
+ * Partner staking always uses `/earn` with route state (`customDappUrl`, etc.), never `/platform/*`.
+ */
+export function useNavigateToStakeForAccount() {
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const walletState = useSelector(walletSelector);
+  const { getCanStakeUsingLedgerLive, getRouteToPlatformApp } = useStake();
+
+  const navigateToEarnScreen = useCallback(
+    (state?: Record<string, string | undefined>) => {
+      navigate("/earn", state ? { state } : undefined);
+    },
+    [navigate],
+  );
+
+  const openNoFundsStakeModal = useCallback(
+    (
+      account: Account | TokenAccount,
+      parentAccount: Account | undefined | null,
+      entryPoint?: "get-funds",
+    ) => {
+      dispatch(
+        openModal("MODAL_NO_FUNDS_STAKE", {
+          account,
+          parentAccount: parentAccount ?? undefined,
+          entryPoint,
+        }),
+      );
+    },
+    [dispatch],
+  );
+
+  const navigateToStakeForAccount = useCallback(
+    (
+      account: Account | TokenAccount,
+      parentAccount: Account | undefined | null,
+      {
+        returnTo,
+        source,
+        entryPoint,
+        alwaysShowNoFunds = false,
+      }: NavigateToStakeForAccountOptions = {},
+    ): NavigateToStakeForAccountResult => {
+      if (alwaysShowNoFunds) {
+        openNoFundsStakeModal(account, parentAccount, entryPoint);
+        return { outcome: "no_funds" };
+      }
+
+      const platformAppRoute = getRouteToPlatformApp(
+        account,
+        walletState,
+        parentAccount,
+        returnTo,
+      );
+
+      if (platformAppRoute) {
+        navigateToEarnScreen(platformAppRoute.state);
+        return { outcome: "platform_earn", provider: platformAppRoute.state.appId };
+      }
+
+      const currencyId = getAccountCurrency(account).id;
+
+      if (getCanStakeUsingLedgerLive(currencyId)) {
+        if (account.spendableBalance.isZero()) {
+          openNoFundsStakeModal(account, parentAccount, entryPoint);
+          return { outcome: "no_funds" };
+        }
+
+        dispatch(
+          openModal("MODAL_START_STAKE", {
+            account,
+            parentAccount: parentAccount ?? undefined,
+            source,
+          }),
+        );
+        return { outcome: "native_stake" };
+      }
+
+      if (account.spendableBalance.isZero()) {
+        openNoFundsStakeModal(account, parentAccount, entryPoint);
+        return { outcome: "no_funds" };
+      }
+
+      navigateToEarnScreen({ intent: "deposit", cryptoAssetId: currencyId });
+      return { outcome: "earn_deposit_fallback" };
+    },
+    [
+      dispatch,
+      getCanStakeUsingLedgerLive,
+      getRouteToPlatformApp,
+      navigateToEarnScreen,
+      openNoFundsStakeModal,
+      walletState,
+    ],
+  );
+
+  return { navigateToStakeForAccount };
+}

--- a/apps/ledger-live-desktop/src/renderer/modals/StartStake/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/StartStake/index.tsx
@@ -39,13 +39,8 @@ const ModalStartStake: FC<ModalStartStakeProps> = ({ account, parentAccount, sou
     const platformAppRoute = getRouteToPlatformApp(account, walletState, parentAccount);
 
     if (platformAppRoute) {
-      // Redirect to the platform app preferentially
       dispatch(closeModal("MODAL_START_STAKE"));
-      navigate(platformAppRoute.pathname, {
-        state: {
-          ...platformAppRoute.state,
-        },
-      });
+      navigate("/earn", { state: platformAppRoute.state });
       return;
     }
 

--- a/apps/ledger-live-desktop/src/renderer/screens/earn/buildEarnGoToURL.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/earn/buildEarnGoToURL.test.ts
@@ -1,0 +1,24 @@
+import { buildEarnGoToURL } from "./buildEarnGoToURL";
+
+describe("buildEarnGoToURL", () => {
+  it("appends Earn initialization params to the partner dapp URL", () => {
+    const result = buildEarnGoToURL("https://earn.example/?yieldId=tron&accountId=abc", {
+      theme: "dark",
+      lang: "en",
+      uiVersion: "v2",
+      lw40enabled: "true",
+    });
+
+    const url = new URL(result);
+    expect(url.searchParams.get("yieldId")).toBe("tron");
+    expect(url.searchParams.get("accountId")).toBe("abc");
+    expect(url.searchParams.get("theme")).toBe("dark");
+    expect(url.searchParams.get("lang")).toBe("en");
+    expect(url.searchParams.get("uiVersion")).toBe("v2");
+    expect(url.searchParams.get("lw40enabled")).toBe("true");
+  });
+
+  it("returns the original URL when parsing fails", () => {
+    expect(buildEarnGoToURL("not-a-valid-url", { theme: "dark" })).toBe("not-a-valid-url");
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/screens/earn/buildEarnGoToURL.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/earn/buildEarnGoToURL.ts
@@ -1,0 +1,15 @@
+import { addParamsToURL } from "@ledgerhq/live-common/wallet-api/helpers";
+
+/** Merges Earn init params into a partner dapp URL (getInitialURL does not merge `inputs` when goToURL is set). */
+export function buildEarnGoToURL(
+  customDappUrl: string,
+  initParams: Record<string, string | undefined>,
+): string {
+  try {
+    const url = new URL(customDappUrl);
+    addParamsToURL(url, initParams);
+    return url.toString();
+  } catch {
+    return customDappUrl;
+  }
+}

--- a/apps/ledger-live-desktop/src/renderer/screens/earn/index.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/earn/index.test.tsx
@@ -89,6 +89,60 @@ describe("Earn screen", () => {
     expect(lastCall.inputs.ethDepositCohort).toBe("cohort-a");
   });
 
+  it("passes goToURL when location state includes customDappUrl", () => {
+    const customDappUrl = "https://earn.example/?yieldId=tron-native-staking&accountId=abc";
+    const useLocationSpy = jest.spyOn(require("react-router"), "useLocation").mockReturnValue({
+      pathname: "/earn",
+      search: "",
+      hash: "",
+      state: { customDappUrl },
+    });
+
+    render(<Earn />, {
+      initialState: withFlagOverrides({
+        ptxEarnLiveApp: { enabled: true, params: { manifest_id: "earn-manifest-id" } },
+        stakePrograms: { enabled: true, params: { list: [], redirects: {} } } as never,
+      }),
+    });
+
+    const lastCall = mockWebPlatformPlayer.mock.calls.at(-1)?.[0] as unknown as {
+      inputs: Record<string, string | undefined>;
+    };
+
+    const goToURL = lastCall.inputs.goToURL as string;
+    expect(goToURL).toContain("yieldId=tron-native-staking");
+    expect(goToURL).toContain("accountId=abc");
+    expect(goToURL).toContain("theme=");
+    expect(goToURL).toContain("lang=");
+    expect(goToURL).toContain("uiVersion=");
+    expect(goToURL).toContain("lw40enabled=");
+    useLocationSpy.mockRestore();
+  });
+
+  it("passes deposit intent params in inputs like mobile route params", () => {
+    const useLocationSpy = jest.spyOn(require("react-router"), "useLocation").mockReturnValue({
+      pathname: "/earn",
+      search: "",
+      hash: "",
+      state: { intent: "deposit", cryptoAssetId: "bitcoin" },
+    });
+
+    render(<Earn />, {
+      initialState: withFlagOverrides({
+        ptxEarnLiveApp: { enabled: true, params: { manifest_id: "earn-manifest-id" } },
+        stakePrograms: { enabled: true, params: { list: [], redirects: {} } } as never,
+      }),
+    });
+
+    const lastCall = mockWebPlatformPlayer.mock.calls.at(-1)?.[0] as unknown as {
+      inputs: Record<string, string | undefined>;
+    };
+
+    expect(lastCall.inputs.intent).toBe("deposit");
+    expect(lastCall.inputs.cryptoAssetId).toBe("bitcoin");
+    useLocationSpy.mockRestore();
+  });
+
   it("passes fallback uiVersion and lw40enabled=false when feature is disabled", () => {
     render(<Earn />, {
       initialState: withFlagOverrides({

--- a/apps/ledger-live-desktop/src/renderer/screens/earn/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/earn/index.tsx
@@ -28,6 +28,7 @@ import { useVersionedStakePrograms } from "LLD/hooks/useVersionedStakePrograms";
 import { NetworkErrorScreen } from "~/renderer/components/Web3AppWebview/NetworkError";
 import Box from "~/renderer/components/Box";
 import { computeEarnUiVersion } from "@ledgerhq/live-common/domain/computeEarnUiVersion";
+import { buildEarnGoToURL } from "./buildEarnGoToURL";
 
 const DEFAULT_MANIFEST_ID =
   process.env.DEFAULT_EARN_MANIFEST_ID || FEATURE_FLAGS_DEFAULTS.ptxEarnLiveApp.params?.manifest_id;
@@ -73,11 +74,52 @@ const Earn = () => {
 
   const { updateManifests } = useRemoteLiveAppContext();
 
+  const inputs = useMemo(() => {
+    const routeState = (location.state as Record<string, string | undefined> | null) ?? {};
+    const { customDappUrl, ...earnRouteParams } = routeState;
+
+    const earnInitParams = {
+      theme: themeType,
+      lang: language,
+      locale,
+      countryLocale,
+      currencyTicker: fiatCurrency.ticker,
+      discreetMode: discreetMode ? "true" : "false",
+      OS: "web",
+      uiVersion: isLwd40Enabled ? computedUiVersion : "v1",
+      lw40enabled: isLwd40Enabled ? "true" : "false",
+      stakeProgramsParam: stakeProgramsParam ? JSON.stringify(stakeProgramsParam) : undefined,
+      stakeCurrenciesParam: stakeCurrenciesParam ? JSON.stringify(stakeCurrenciesParam) : undefined,
+      ethDepositCohort,
+    };
+
+    return {
+      ...earnInitParams,
+      ...earnRouteParams,
+      devMode,
+      routerState: JSON.stringify(location.state ?? {}),
+      goToURL: customDappUrl ? buildEarnGoToURL(customDappUrl, earnInitParams) : undefined,
+    };
+  }, [
+    location.state,
+    themeType,
+    language,
+    locale,
+    countryLocale,
+    fiatCurrency.ticker,
+    discreetMode,
+    devMode,
+    isLwd40Enabled,
+    computedUiVersion,
+    stakeProgramsParam,
+    stakeCurrenciesParam,
+    ethDepositCohort,
+  ]);
+
   if (!manifest) {
     return <NetworkErrorScreen refresh={updateManifests} type="warning" />;
   }
 
-  // if LWM40 is enabled, use Box for transparency, otherwise use Card
   const Container = isLwd40Enabled ? Box : Card;
 
   return (
@@ -92,24 +134,7 @@ const Earn = () => {
           },
         }}
         manifest={manifest}
-        inputs={{
-          theme: themeType,
-          lang: language,
-          locale: locale,
-          countryLocale,
-          currencyTicker: fiatCurrency.ticker,
-          devMode,
-          discreetMode: discreetMode ? "true" : "false",
-          OS: "web",
-          routerState: JSON.stringify(location.state ?? {}),
-          stakeProgramsParam: stakeProgramsParam ? JSON.stringify(stakeProgramsParam) : undefined,
-          stakeCurrenciesParam: stakeCurrenciesParam
-            ? JSON.stringify(stakeCurrenciesParam)
-            : undefined,
-          ethDepositCohort,
-          uiVersion: isLwd40Enabled ? computedUiVersion : "v1",
-          lw40enabled: isLwd40Enabled ? "true" : "false",
-        }}
+        inputs={inputs}
       />
     </Container>
   );

--- a/apps/ledger-live-desktop/src/renderer/screens/stake/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/stake/index.tsx
@@ -4,11 +4,10 @@ import { setDrawer } from "~/renderer/drawers/Provider";
 import { useNavigate, useLocation } from "react-router";
 import { stakeDefaultTrack } from "./constants";
 import { track, trackPage } from "~/renderer/analytics/segment";
-import { useDispatch, useSelector } from "LLD/hooks/redux";
-import { openModal } from "~/renderer/actions/modals";
+import { useDispatch } from "LLD/hooks/redux";
 import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
 import { useStake } from "LLD/hooks/useStake";
-import { walletSelector } from "~/renderer/reducers/wallet";
+import { useNavigateToStakeForAccount } from "LLD/hooks/useNavigateToStakeForAccount";
 import { Account, AccountLike } from "@ledgerhq/types-live";
 import { ModularDrawerLocation } from "@ledgerhq/live-common/modularDrawer/enums";
 import { useModularDrawerVisibility } from "@ledgerhq/live-common/modularDrawer/useModularDrawerVisibility";
@@ -34,8 +33,8 @@ const useStakeFlow = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const dispatch = useDispatch();
-  const walletState = useSelector(walletSelector);
-  const { enabledCurrencies, partnerSupportedAssets, getRouteToPlatformApp } = useStake();
+  const { navigateToStakeForAccount } = useNavigateToStakeForAccount();
+  const { enabledCurrencies, partnerSupportedAssets } = useStake();
   const list = useMemo(() => {
     return enabledCurrencies.concat(partnerSupportedAssets);
   }, [enabledCurrencies, partnerSupportedAssets]);
@@ -71,41 +70,28 @@ const useStakeFlow = () => {
       });
       setDrawer();
 
-      const platformAppRoute = getRouteToPlatformApp(account, walletState, parentAccount);
+      const outcome = navigateToStakeForAccount(account, parentAccount, {
+        returnTo,
+        alwaysShowNoFunds,
+        entryPoint,
+        source,
+      });
 
-      if (alwaysShowNoFunds || account.spendableBalance.isZero()) {
-        dispatch(
-          openModal("MODAL_NO_FUNDS_STAKE", {
-            account,
-            parentAccount,
-            entryPoint,
-          }),
-        );
-      } else if (platformAppRoute) {
+      if (outcome.outcome === "platform_earn") {
         track("button_clicked2", {
           ...stakeDefaultTrack,
           button: "delegate",
           page: location.pathname,
-          provider: platformAppRoute.state.appId,
+          provider: outcome.provider,
           currency: account.type === "Account" ? account.currency.ticker : account.token.ticker,
         });
-        navigate(platformAppRoute.pathname.toString(), {
-          state: {
-            ...platformAppRoute.state,
-            returnTo,
-          },
-        });
-      } else {
-        dispatch(openModal("MODAL_START_STAKE", { account, parentAccount, source }));
       }
 
-      const isNoFundsFlow = account.spendableBalance.isZero();
-
-      if (shouldRedirect && !platformAppRoute && !isNoFundsFlow) {
+      if (shouldRedirect && outcome.outcome === "native_stake") {
         navigate(returnTo ?? `/account/${account.id}`);
       }
     },
-    [dispatch, navigate, location, getRouteToPlatformApp, walletState],
+    [navigate, location, navigateToStakeForAccount],
   );
 
   const handleRequestClose = useCallback(() => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request refactors the navigation logic for staking and Earn flows in the Asset Detail feature, introducing a new abstraction to handle navigation to staking-related screens and modals. It ensures consistent handling of different staking entry points, improves test coverage, and clarifies the logic for selecting which account to use when initiating staking actions.

**Navigation and Account Selection Improvements:**

* Introduced `useNavigateToStakeForAccount` hook to centralize logic for navigating to Earn screens, opening staking modals, and handling partner routes, ensuring `/earn` is always used for partner apps instead of `/platform/*`. This hook is now used throughout the Asset Detail feature and is thoroughly unit-tested. 
* Added utility functions `pickAccountForEarnNavigation` and `accountHasEarnDeposit` to select the most appropriate account for staking navigation, preferring accounts with spendable balance, then those with an earn deposit, and defaulting to the first account. These functions are also unit-tested.

**Integration into Asset Detail Feature:**

* Refactored `useStakingSectionViewModel` to use the new navigation hook and account selection utilities. The navigation logic now delegates to the new abstraction, and tests have been updated to reflect this change. 

**Partner App Routing Consistency:**

* Modified partner staking routes to always use `/earn` with route state, never `/platform/*`, including in the staking modal and navigation hook.

**Underlying Stake Hook Update:**

* Updated the `getRouteToPlatformApp` logic in `useStake` to accept an option for allowing zero spendable balance, supporting the new navigation scenarios. 



https://github.com/user-attachments/assets/db8ef3de-af65-4402-9054-0dd1bc0f0e2b



### ❓ Context

[LIVE-31058](https://ledgerhq.atlassian.net/browse/LIVE-31058)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31058]: https://ledgerhq.atlassian.net/browse/LIVE-31058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ