### PR TITLE
fix(wallet-pnl): guard reducers against non-finite counter values

### DIFF
--- a/.changeset/breezy-ravens-judge.md
+++ b/.changeset/breezy-ravens-judge.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-pnl": patch
+---
+
+Guard PnL reducers against non-finite counter values (NaN/Infinity). `typeof === "number"` previously let `Infinity` through, which `new BigNumber()` coerces to an internal NaN and poisons every downstream arithmetic op. Replaces the check with `Number.isFinite` at the three call sites (latest CV in `assetPnL`, historical op-date CV in `costBasis`, and the reconciliation delta CV).

--- a/libs/wallet-pnl/src/__tests__/nonFiniteCV.test.ts
+++ b/libs/wallet-pnl/src/__tests__/nonFiniteCV.test.ts
@@ -1,0 +1,130 @@
+import BigNumber from "bignumber.js";
+import { computeAssetPnL } from "../assetPnL";
+import { computePortfolioPnL } from "../portfolioPnL";
+import { invalidatePnLCache } from "../costBasisCache";
+import { ETH, USD, WEI } from "../scenarios/currencies";
+import { makeAccount } from "../scenarios/accounts";
+import { buy, resetOperationIdCounter } from "../scenarios/operations";
+import { buildCV, dailyHistory } from "../scenarios/countervalues";
+import { expectBN } from "./helpers/bn";
+
+beforeEach(() => {
+  invalidatePnLCache();
+  resetOperationIdCounter();
+});
+
+// `calculate()` in @ledgerhq/live-countervalues computes
+// `value * rate * mult`. With an `Infinity` latest rate it returns `Infinity`;
+// `new BigNumber(Infinity)` coerces to an internal NaN that then poisons every
+// downstream arithmetic op in the reducer. These tests pin the guard that
+// rejects any non-finite CV at the three call sites in wallet-pnl.
+
+const BUY_DATE = new Date(Date.UTC(2025, 0, 15));
+
+describe("non-finite countervalue — latest rate (assetPnL.ts)", () => {
+  it("returns null when latest CV is Infinity and there is no operation history", () => {
+    const account = makeAccount(ETH, { balance: WEI.times(5) });
+    const countervalues = buildCV({ pair: { from: ETH, to: USD }, latest: Infinity });
+
+    const pnl = computeAssetPnL(account, countervalues, USD);
+    expect(pnl).toBeNull();
+  });
+
+  it("keeps unrealisedPnL at zero (not NaN) when latest CV is Infinity but ops exist", () => {
+    const account = makeAccount(ETH, {
+      operations: [buy(WEI.times(5), BUY_DATE)],
+      balance: WEI.times(5),
+    });
+    const countervalues = buildCV({
+      pair: { from: ETH, to: USD },
+      history: dailyHistory([[BUY_DATE, 2000]]),
+      latest: Infinity,
+    });
+
+    const pnl = computeAssetPnL(account, countervalues, USD)!;
+    expect(pnl.unrealisedPnL.isFinite()).toBe(true);
+    expectBN(pnl.unrealisedPnL).toEqualBN(0);
+  });
+
+  it("portfolio aggregate stays finite when a single asset has an Infinity latest CV", () => {
+    const accountWithBuy = makeAccount(ETH, {
+      operations: [buy(WEI.times(5), BUY_DATE)],
+      balance: WEI.times(5),
+    });
+    const countervalues = buildCV({
+      pair: { from: ETH, to: USD },
+      history: dailyHistory([[BUY_DATE, 2000]]),
+      latest: Infinity,
+    });
+
+    const portfolio = computePortfolioPnL([accountWithBuy], countervalues, USD);
+    expect(portfolio.unrealisedPnL.isFinite()).toBe(true);
+    expect(portfolio.realisedPnL.isFinite()).toBe(true);
+    expect(portfolio.totalPnL.isFinite()).toBe(true);
+    expect(portfolio.costBasis.isFinite()).toBe(true);
+    expect(portfolio.lifetimeCost.isFinite()).toBe(true);
+  });
+});
+
+describe("non-finite countervalue — historical rate (costBasis.ts)", () => {
+  it("skips an inflow whose CV at op date is Infinity (treated like a missing rate)", () => {
+    const account = makeAccount(ETH, {
+      operations: [buy(WEI.times(5), BUY_DATE)],
+      balance: WEI.times(5),
+    });
+    const countervalues = buildCV({
+      pair: { from: ETH, to: USD },
+      history: dailyHistory([[BUY_DATE, Infinity]]),
+      latest: 2400,
+    });
+
+    const pnl = computeAssetPnL(account, countervalues, USD)!;
+
+    expect(pnl.costBasis.isFinite()).toBe(true);
+    expect(pnl.unrealisedPnL.isFinite()).toBe(true);
+    expect(pnl.realisedPnL.isFinite()).toBe(true);
+
+    expectBN(pnl.costBasis).toBeCloseToBN(new BigNumber("1200000"), 0);
+  });
+
+  it("opt-out of reconciliation: a rejected op-date CV leaves costBasis at zero", () => {
+    const account = makeAccount(ETH, {
+      operations: [buy(WEI.times(5), BUY_DATE)],
+      balance: WEI.times(5),
+    });
+    const countervalues = buildCV({
+      pair: { from: ETH, to: USD },
+      history: dailyHistory([[BUY_DATE, Infinity]]),
+      latest: 2400,
+    });
+
+    const pnl = computeAssetPnL(account, countervalues, USD, {
+      reconcileWithBalance: false,
+    })!;
+
+    expect(pnl.costBasis.isFinite()).toBe(true);
+    expectBN(pnl.costBasis).toEqualBN(0);
+    expect(pnl.unrealisedPnL.isFinite()).toBe(true);
+  });
+});
+
+describe("non-finite countervalue — reconciliation delta (costBasisReconciliation.ts)", () => {
+  it("does not apply the synthetic inflow when the delta CV is Infinity", () => {
+    const account = makeAccount(ETH, {
+      operations: [buy(WEI.times(10), BUY_DATE)],
+      balance: WEI.times(12),
+    });
+    const countervalues = buildCV({
+      pair: { from: ETH, to: USD },
+      history: dailyHistory([[BUY_DATE, 2000]]),
+      latest: Infinity,
+    });
+
+    const pnl = computeAssetPnL(account, countervalues, USD)!;
+    expect(pnl.reconciliation.isClean).toBe(false);
+    expect(pnl.reconciliation.applied).toBe(false);
+    expect(pnl.costBasis.isFinite()).toBe(true);
+    expect(pnl.unrealisedPnL.isFinite()).toBe(true);
+    expectBN(pnl.costBasis).toBeCloseToBN(new BigNumber("2000000"), 0);
+  });
+});

--- a/libs/wallet-pnl/src/assetPnL.ts
+++ b/libs/wallet-pnl/src/assetPnL.ts
@@ -55,7 +55,7 @@ export function computeAssetPnL(
       to: fiat,
       disableRounding: true,
     });
-    if (typeof latestCV === "number") {
+    if (latestCV != null && Number.isFinite(latestCV)) {
       unrealisedPnL = new BigNumber(latestCV).minus(state.totalCostInCounterValue);
     } else if (!hasHistory) {
       return null;

--- a/libs/wallet-pnl/src/costBasis.ts
+++ b/libs/wallet-pnl/src/costBasis.ts
@@ -86,10 +86,11 @@ function applyOperation(
     date: op.date,
     disableRounding: true,
   });
-  if (typeof cvAtDate !== "number") return acc;
-
-  const cvBN = new BigNumber(cvAtDate);
-  return flow === "inflow" ? applyInflow(acc, op.value, cvBN) : applyOutflow(acc, op.value, cvBN);
+  if (cvAtDate != null && Number.isFinite(cvAtDate)) {
+    const cvBN = new BigNumber(cvAtDate);
+    return flow === "inflow" ? applyInflow(acc, op.value, cvBN) : applyOutflow(acc, op.value, cvBN);
+  }
+  return acc;
 }
 
 /**

--- a/libs/wallet-pnl/src/costBasisReconciliation.ts
+++ b/libs/wallet-pnl/src/costBasisReconciliation.ts
@@ -74,7 +74,7 @@ export function applyBalanceReconciliation(
     date: valuationDate,
     disableRounding: true,
   });
-  if (typeof cvAtDelta !== "number") {
+  if (cvAtDelta == null || !Number.isFinite(cvAtDelta)) {
     return { state, applied: false };
   }
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - PnL display when an asset has a missing/invalid counter value (NaN, Infinity, null)
  - Portfolio aggregate PnL when a single asset's counter value is non-finite
  - Cost basis & reconciliation when a historical rate is non-finite

### 📝 Description

**Problem.** `calculate()` in `@ledgerhq/live-countervalues` computes `value * rate * mult` and returns `Infinity` when the latest rate is `Infinity`. `new BigNumber(Infinity)` coerces to an internal `NaN` that then poisons every downstream arithmetic op in the wallet-pnl reducer, surfacing as `NaN` PnL in the UI.

**Solution.** The three call sites in `wallet-pnl` previously gated on `typeof cv === "number"`, which lets `Infinity` and `NaN` through. Replace with `cv != null && Number.isFinite(cv)` so non-finite CVs are rejected exactly like missing rates:

- `assetPnL.ts` — latest CV guard (unrealised PnL)
- `costBasis.ts` — historical op-date CV guard (cost basis reducer)
- `costBasisReconciliation.ts` — reconciliation delta CV guard

A new test file `nonFiniteCV.test.ts` pins the guard at each of the three sites and asserts that aggregated portfolio PnL stays finite when a single asset has an `Infinity` latest CV.


[App Test Staking (2).json](https://github.com/user-attachments/files/28351815/App.Test.Staking.2.json)

<img width="1354" height="685" alt="Screenshot 2026-05-28 at 16 41 57" src="https://github.com/user-attachments/assets/4ece3802-110c-4466-9a69-370bf066ec3a" />



### ❓ Context

- **JIRA or GitHub link**: [LIVE-31475](https://ledgerhq.atlassian.net/browse/LIVE-31475)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31475]: https://ledgerhq.atlassian.net/browse/LIVE-31475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ