### PR TITLE
[LWM] fix(mobile): reduce DIE connecting spinner size

### DIFF
--- a/.changeset/small-spinners-shrink.md
+++ b/.changeset/small-spinners-shrink.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Reduce the Device Intent Executor connecting spinner size on mobile.

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectingState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectingState.tsx
@@ -8,7 +8,7 @@ export function ConnectingState(): React.ReactNode {
   return (
     <Box lx={{ width: "full", alignItems: "center", paddingTop: "s32", paddingBottom: "s32" }}>
       <Box lx={{ width: "full", alignItems: "center", gap: "s16" }}>
-        <Spinner size={40} color="base" />
+        <Spinner size={32} color="base" />
         <Text typography="heading4SemiBold" lx={{ color: "base", textAlign: "center" }}>
           {t("deviceIntentExecutor.connectDevice.states.connecting.title")}
         </Text>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Focused Jest coverage was run for `ConnectingState` and mobile typecheck passes; the visual spinner size itself should be checked manually._
- [x] **Impact of the changes:**
  - Device Intent Executor connecting state on mobile
  - Spinner visual size in the device connection bottom sheet
  - Device connection flow visual consistency

### 📝 Description

The Device Intent Executor connecting state spinner was visually oversized compared with the surrounding connecting screen content.

The reason was a bug with code connect in Figma. The intended size in the design is 32.

This PR reduces the mobile connecting spinner from `40` to `32` so the loading indicator better matches the intended UI scale, and adds a `live-mobile` changeset for the visual adjustment.

| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31524](https://ledgerhq.atlassian.net/browse/LIVE-31524)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31524]: https://ledgerhq.atlassian.net/browse/LIVE-31524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ