### PR TITLE
[LWM] feat(mobile): add Connect Device Layer B analytics

### DIFF
--- a/.changeset/selfish-rice-flow.md
+++ b/.changeset/selfish-rice-flow.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-dmk-mobile": patch
+"live-mobile": patch
+---
+
+Add Connect Device Layer B analytics events on mobile and expose the selected device on connection-error UI states.

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/DeviceConnectionComponentLWMView.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/DeviceConnectionComponentLWMView.test.tsx
@@ -119,6 +119,7 @@ describe("DeviceConnectionComponentLWMView", () => {
     renderView({
       type: ConnectDeviceUIStateTypes.ConnectionError,
       error: { type: ConnectionErrorTypes.Unknown },
+      device: makeKnownDevice(),
       retry: jest.fn(),
       ignore: jest.fn(),
     });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectingState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectingState.test.tsx
@@ -62,7 +62,6 @@ describe("ConnectingState", () => {
         category: PAGE_CONNECT_DEVICE.Connecting,
         sourceFlow: "my_ledger",
         modelId: DeviceModelId.nanoX,
-        matchedDevice: DeviceModelId.nanoX,
         transport: "ble",
         deviceUxV2: true,
       }),

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectingState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectingState.tsx
@@ -27,7 +27,6 @@ export function ConnectingState({ state }: Readonly<ConnectingStateProps>): Reac
         category={PAGE_CONNECT_DEVICE.Connecting}
         sourceFlow={sourceFlow}
         modelId={modelId}
-        matchedDevice={modelId}
         transport={transport}
         deviceUxV2
       />

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectionErrorState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectionErrorState.test.tsx
@@ -121,7 +121,7 @@ describe("ConnectionErrorState", () => {
       sourceFlow: "my_ledger",
       source: TEST_SOURCE,
       deviceUxV2: true,
-      button: "Try again",
+      button: "Retry",
     });
     expect(retry).toHaveBeenCalledTimes(1);
   });
@@ -135,7 +135,7 @@ describe("ConnectionErrorState", () => {
       sourceFlow: "my_ledger",
       source: TEST_SOURCE,
       deviceUxV2: true,
-      button: "Get help",
+      button: "Get Help",
     });
     expect(Linking.openURL).toHaveBeenCalledWith(urls.pairingIssues);
   });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectionErrorState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectionErrorState.test.tsx
@@ -1,18 +1,47 @@
 import React from "react";
 import { Linking } from "react-native";
 import { render, screen } from "@tests/test-renderer";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import type { KnownDevice } from "@ledgerhq/live-dmk-shared";
 import {
   ConnectionErrorTypes,
   ConnectDeviceUIStateTypes,
   type ConnectDeviceUIState,
 } from "@ledgerhq/live-dmk-mobile";
+import { TrackScreen, track } from "~/analytics";
+import { previousRouteNameRef } from "~/analytics/screenRefs";
 import { urls } from "~/utils/urls";
+import { SourceFlowProvider } from "../../utils/SourceFlowContext";
+import { PAGE_CONNECT_DEVICE } from "../../utils/trackDeviceIntent";
 import { ConnectionErrorState } from "./ConnectionErrorState";
+
+jest.mock("~/analytics", () => {
+  const actual = jest.requireActual("~/analytics");
+  return {
+    ...actual,
+    TrackScreen: jest.fn(() => null),
+    track: jest.fn(),
+  };
+});
+
+const mockedTrackScreen = jest.mocked(TrackScreen);
+const mockedTrack = jest.mocked(track);
+const TEST_SOURCE = "Connect Device - Connection Error";
 
 type ConnectionErrorUIState = Extract<
   ConnectDeviceUIState,
   { type: ConnectDeviceUIStateTypes.ConnectionError }
 >;
+
+function makeKnownDevice(overrides: Partial<KnownDevice> = {}): KnownDevice {
+  return {
+    id: "device-id",
+    name: "Ledger Nano X",
+    deviceModelId: DeviceModelId.nanoX,
+    transport: "ble" as KnownDevice["transport"],
+    ...overrides,
+  };
+}
 
 const errorCases = [
   {
@@ -42,17 +71,24 @@ function renderState(errorType: ConnectionErrorTypes) {
   const state: ConnectionErrorUIState = {
     type: ConnectDeviceUIStateTypes.ConnectionError,
     error: { type: errorType },
+    device: makeKnownDevice(),
     retry,
     ignore,
   };
 
-  const view = render(<ConnectionErrorState state={state} />);
+  const view = render(
+    <SourceFlowProvider value="my_ledger">
+      <ConnectionErrorState state={state} />
+    </SourceFlowProvider>,
+  );
 
   return { ...view, retry, ignore };
 }
 
 describe("ConnectionErrorState", () => {
   beforeEach(() => {
+    jest.clearAllMocks();
+    previousRouteNameRef.current = TEST_SOURCE;
     jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
   });
 
@@ -81,6 +117,12 @@ describe("ConnectionErrorState", () => {
 
     await user.press(screen.getByText("Try again"));
 
+    expect(track).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      deviceUxV2: true,
+      button: "Try again",
+    });
     expect(retry).toHaveBeenCalledTimes(1);
   });
 
@@ -89,6 +131,30 @@ describe("ConnectionErrorState", () => {
 
     await user.press(screen.getByText("Get help"));
 
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      deviceUxV2: true,
+      button: "Get help",
+    });
     expect(Linking.openURL).toHaveBeenCalledWith(urls.pairingIssues);
+  });
+
+  it("GIVEN a connection error WHEN rendering THEN it tracks the Device UX V2 page event", () => {
+    // GIVEN / WHEN
+    renderState(ConnectionErrorTypes.Unknown);
+
+    // THEN
+    expect(mockedTrackScreen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: PAGE_CONNECT_DEVICE.ConnectionError,
+        sourceFlow: "my_ledger",
+        modelId: DeviceModelId.nanoX,
+        transport: "ble",
+        subError: "Unknown",
+        deviceUxV2: true,
+      }),
+      undefined,
+    );
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectionErrorState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectionErrorState.tsx
@@ -6,9 +6,17 @@ import {
   type ConnectDeviceUIState,
 } from "@ledgerhq/live-dmk-mobile";
 import { InfoState } from "LLM/components/InfoState";
+import { TrackScreen } from "~/analytics";
 import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
 import { useTranslation } from "~/context/Locale";
 import { urls } from "~/utils/urls";
+import { useSourceFlow } from "../../utils/SourceFlowContext";
+import {
+  getTrackingSubError,
+  getTrackingTransport,
+  PAGE_CONNECT_DEVICE,
+  trackConnectDeviceButtonClicked,
+} from "../../utils/trackDeviceIntent";
 import { PeerRemovedPairingState } from "./PeerRemovedPairingState";
 
 type ConnectionErrorStateProps = {
@@ -45,21 +53,42 @@ const connectionErrorTranslationBaseKey =
 
 export function ConnectionErrorState({ state }: Readonly<ConnectionErrorStateProps>): React.ReactNode {
   const { t } = useTranslation();
+  const sourceFlow = useSourceFlow();
   const bleForgetDeviceUrl = useLocalizedUrl(urls.errors.BleForgetDevice);
   const pairingIssuesUrl = useLocalizedUrl(urls.pairingIssues);
   const productName = t("deviceIntentExecutor.connectDevice.common.ledgerDevice");
+  const trackingScreen = (
+    <TrackScreen
+      category={PAGE_CONNECT_DEVICE.ConnectionError}
+      sourceFlow={sourceFlow}
+      modelId={state.device.deviceModelId}
+      transport={getTrackingTransport(state.device.transport)}
+      subError={getTrackingSubError(state.error.type)}
+      deviceUxV2
+    />
+  );
 
-  const retryCta = (labelKey: string): InfoStateCta => ({
-    label: t(labelKey),
-    onPress: state.retry,
-  });
+  const retryCta = (labelKey: string): InfoStateCta => {
+    const label = t(labelKey);
+    return {
+      label,
+      onPress: () => {
+        trackConnectDeviceButtonClicked({ sourceFlow, button: label });
+        state.retry();
+      },
+    };
+  };
 
-  const helpCta = (labelKey: string, url: string): InfoStateCta => ({
-    label: t(labelKey),
-    onPress: () => {
-      Linking.openURL(url).catch(() => undefined);
-    },
-  });
+  const helpCta = (labelKey: string, url: string): InfoStateCta => {
+    const label = t(labelKey);
+    return {
+      label,
+      onPress: () => {
+        trackConnectDeviceButtonClicked({ sourceFlow, button: label });
+        Linking.openURL(url).catch(() => undefined);
+      },
+    };
+  };
 
   const connectionErrorViewStates: ConnectionErrorViewStates = {
     [ConnectionErrorTypes.BlePairingRefused]: {
@@ -87,32 +116,44 @@ export function ConnectionErrorState({ state }: Readonly<ConnectionErrorStatePro
 
   if (state.error.type === ConnectionErrorTypes.BlePairingPeerRemovedPairing) {
     const errorState = connectionErrorViewStates[state.error.type];
+    const helpLabel = t(errorState.helpLabel);
+    const retryLabel = t(errorState.retryLabel);
 
     return (
-      <PeerRemovedPairingState
-        title={t(errorState.title, { productName })}
-        description={t(errorState.description, { productName })}
-        helpLabel={t(errorState.helpLabel)}
-        retryLabel={t(errorState.retryLabel)}
-        onHelp={() => {
-          Linking.openURL(bleForgetDeviceUrl).catch(() => undefined);
-        }}
-        onRetry={state.retry}
-      />
+      <>
+        {trackingScreen}
+        <PeerRemovedPairingState
+          title={t(errorState.title, { productName })}
+          description={t(errorState.description, { productName })}
+          helpLabel={helpLabel}
+          retryLabel={retryLabel}
+          onHelp={() => {
+            trackConnectDeviceButtonClicked({ sourceFlow, button: helpLabel });
+            Linking.openURL(bleForgetDeviceUrl).catch(() => undefined);
+          }}
+          onRetry={() => {
+            trackConnectDeviceButtonClicked({ sourceFlow, button: retryLabel });
+            state.retry();
+          }}
+        />
+      </>
     );
   }
 
   const errorState = connectionErrorViewStates[state.error.type];
 
   return (
-    <InfoState
-      preset={errorState.preset}
-      size="hug"
-      title={t(errorState.title)}
-      description={errorState.description ? t(errorState.description) : undefined}
-      banner={errorState.banner ? { title: t(errorState.banner.title) } : undefined}
-      primaryCta={errorState.primaryCta}
-      secondaryCta={errorState.secondaryCta}
-    />
+    <>
+      {trackingScreen}
+      <InfoState
+        preset={errorState.preset}
+        size="hug"
+        title={t(errorState.title)}
+        description={errorState.description ? t(errorState.description) : undefined}
+        banner={errorState.banner ? { title: t(errorState.banner.title) } : undefined}
+        primaryCta={errorState.primaryCta}
+        secondaryCta={errorState.secondaryCta}
+      />
+    </>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectionErrorState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectionErrorState.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from "~/context/Locale";
 import { urls } from "~/utils/urls";
 import { useSourceFlow } from "../../utils/SourceFlowContext";
 import {
+  CONNECT_DEVICE_BUTTON,
   getTrackingSubError,
   getTrackingTransport,
   PAGE_CONNECT_DEVICE,
@@ -73,7 +74,7 @@ export function ConnectionErrorState({ state }: Readonly<ConnectionErrorStatePro
     return {
       label,
       onPress: () => {
-        trackConnectDeviceButtonClicked({ sourceFlow, button: label });
+        trackConnectDeviceButtonClicked({ sourceFlow, button: CONNECT_DEVICE_BUTTON.Retry });
         state.retry();
       },
     };
@@ -84,7 +85,7 @@ export function ConnectionErrorState({ state }: Readonly<ConnectionErrorStatePro
     return {
       label,
       onPress: () => {
-        trackConnectDeviceButtonClicked({ sourceFlow, button: label });
+        trackConnectDeviceButtonClicked({ sourceFlow, button: CONNECT_DEVICE_BUTTON.GetHelp });
         Linking.openURL(url).catch(() => undefined);
       },
     };
@@ -128,11 +129,11 @@ export function ConnectionErrorState({ state }: Readonly<ConnectionErrorStatePro
           helpLabel={helpLabel}
           retryLabel={retryLabel}
           onHelp={() => {
-            trackConnectDeviceButtonClicked({ sourceFlow, button: helpLabel });
+            trackConnectDeviceButtonClicked({ sourceFlow, button: CONNECT_DEVICE_BUTTON.GetHelp });
             Linking.openURL(bleForgetDeviceUrl).catch(() => undefined);
           }}
           onRetry={() => {
-            trackConnectDeviceButtonClicked({ sourceFlow, button: retryLabel });
+            trackConnectDeviceButtonClicked({ sourceFlow, button: CONNECT_DEVICE_BUTTON.Retry });
             state.retry();
           }}
         />

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DeviceListItem.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DeviceListItem.test.tsx
@@ -3,7 +3,21 @@ import { render, screen } from "@tests/test-renderer";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import type { KnownDevice } from "@ledgerhq/live-dmk-shared";
 import type { DisplayedDevice } from "@ledgerhq/live-dmk-mobile";
+import { track } from "~/analytics";
+import { previousRouteNameRef } from "~/analytics/screenRefs";
+import { SourceFlowProvider } from "../../utils/SourceFlowContext";
 import { DeviceListItem } from "./DeviceListItem";
+
+jest.mock("~/analytics", () => {
+  const actual = jest.requireActual("~/analytics");
+  return {
+    ...actual,
+    track: jest.fn(),
+  };
+});
+
+const mockedTrack = jest.mocked(track);
+const TEST_SOURCE = "Connect Device - Discovering";
 
 function makeKnownDevice(overrides: Partial<KnownDevice> = {}): KnownDevice {
   return {
@@ -25,13 +39,26 @@ function makeDisplayedDevice(overrides: Partial<DisplayedDevice> = {}): Displaye
 }
 
 describe("DeviceListItem", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    previousRouteNameRef.current = TEST_SOURCE;
+  });
+
+  function renderDeviceListItem(device: DisplayedDevice) {
+    return render(
+      <SourceFlowProvider value="my_ledger">
+        <DeviceListItem device={device} />
+      </SourceFlowProvider>,
+    );
+  }
+
   it("should render an available device with its status", () => {
     const device = makeDisplayedDevice({
       type: "available",
       knownDevice: makeKnownDevice({ name: "Available Ledger" }),
     });
 
-    render(<DeviceListItem device={device} />);
+    renderDeviceListItem(device);
 
     expect(screen.getByText("Available Ledger")).toBeVisible();
     expect(screen.getByText("Available")).toBeVisible();
@@ -43,7 +70,7 @@ describe("DeviceListItem", () => {
       knownDevice: makeKnownDevice({ name: "Unavailable Ledger" }),
     });
 
-    render(<DeviceListItem device={device} />);
+    renderDeviceListItem(device);
 
     expect(screen.getByText("Unavailable Ledger")).toBeVisible();
     expect(screen.getByText("Not connected")).toBeVisible();
@@ -54,7 +81,7 @@ describe("DeviceListItem", () => {
       knownDevice: makeKnownDevice({ name: null }),
     });
 
-    render(<DeviceListItem device={device} />);
+    renderDeviceListItem(device);
 
     expect(screen.getByText("Ledger device")).toBeVisible();
   });
@@ -65,10 +92,35 @@ describe("DeviceListItem", () => {
       knownDevice: makeKnownDevice({ name: "Available Ledger" }),
       onSelect,
     });
-    const { user } = render(<DeviceListItem device={device} />);
+    const { user } = renderDeviceListItem(device);
 
     await user.press(screen.getByText("Available Ledger"));
 
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("GIVEN a device row WHEN it is pressed THEN it tracks device_selected", async () => {
+    // GIVEN
+    const onSelect = jest.fn();
+    const device = makeDisplayedDevice({
+      knownDevice: makeKnownDevice({
+        name: "Ledger Stax",
+        deviceModelId: DeviceModelId.stax,
+      }),
+      onSelect,
+    });
+    const { user } = renderDeviceListItem(device);
+
+    // WHEN
+    await user.press(screen.getByText("Ledger Stax"));
+
+    // THEN
+    expect(mockedTrack).toHaveBeenCalledWith("device_selected", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      deviceUxV2: true,
+      modelId: DeviceModelId.stax,
+    });
     expect(onSelect).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DeviceListItem.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DeviceListItem.test.tsx
@@ -120,6 +120,7 @@ describe("DeviceListItem", () => {
       source: TEST_SOURCE,
       deviceUxV2: true,
       modelId: DeviceModelId.stax,
+      transport: "ble",
     });
     expect(onSelect).toHaveBeenCalledTimes(1);
   });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DeviceListItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DeviceListItem.tsx
@@ -28,10 +28,7 @@ export function DeviceListItem({ device }: Readonly<DeviceListItemProps>): React
   const DeviceIcon = getDeviceSymbolByModelId(device.knownDevice.deviceModelId);
   const isAvailable = device.type === "available";
   const handleSelect = () => {
-    trackDeviceSelected({
-      sourceFlow,
-      modelId: device.knownDevice.deviceModelId,
-    });
+    trackDeviceSelected({ sourceFlow, device: device.knownDevice });
     device.onSelect();
   };
 

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DeviceListItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DeviceListItem.tsx
@@ -11,6 +11,8 @@ import {
 import type { DisplayedDevice } from "@ledgerhq/live-dmk-mobile";
 import { getDeviceSymbolByModelId } from "LLM/utils/getDeviceIcon";
 import { useTranslation } from "~/context/Locale";
+import { useSourceFlow } from "../../utils/SourceFlowContext";
+import { trackDeviceSelected } from "../../utils/trackDeviceIntent";
 
 type DeviceListItemProps = {
   device: DisplayedDevice;
@@ -22,11 +24,19 @@ function getDeviceName(device: DisplayedDevice["knownDevice"], fallbackName: str
 
 export function DeviceListItem({ device }: Readonly<DeviceListItemProps>): React.ReactNode {
   const { t } = useTranslation();
+  const sourceFlow = useSourceFlow();
   const DeviceIcon = getDeviceSymbolByModelId(device.knownDevice.deviceModelId);
   const isAvailable = device.type === "available";
+  const handleSelect = () => {
+    trackDeviceSelected({
+      sourceFlow,
+      modelId: device.knownDevice.deviceModelId,
+    });
+    device.onSelect();
+  };
 
   return (
-    <ListItem onPress={device.onSelect}>
+    <ListItem onPress={handleSelect}>
       <ListItemLeading>
         <Spot size={48} appearance="icon" icon={DeviceIcon} />
         <ListItemContent>

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveryErrorState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveryErrorState.test.tsx
@@ -227,6 +227,23 @@ describe("DiscoveryErrorState", () => {
     );
   });
 
+  it("GIVEN an unknown discovery error without transport WHEN rendering THEN it does not invent a transport", () => {
+    // GIVEN / WHEN
+    renderState({ type: DiscoveryErrorTypes.Unknown });
+
+    // THEN
+    expect(mockedTrackScreen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: PAGE_CONNECT_DEVICE.DiscoveryError,
+        sourceFlow: "my_ledger",
+        subError: "Unknown",
+        deviceUxV2: true,
+      }),
+      undefined,
+    );
+    expect(mockedTrackScreen.mock.calls[0]?.[0]).not.toHaveProperty("transport");
+  });
+
   it("GIVEN a retry CTA WHEN it is pressed THEN it tracks button_clicked", async () => {
     // GIVEN
     const retry = jest.fn();

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveryErrorState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveryErrorState.test.tsx
@@ -8,7 +8,24 @@ import {
   type DiscoveryError,
 } from "@ledgerhq/live-dmk-mobile";
 import type { AppPlatform } from "@ledgerhq/live-common/platform/types";
+import { TrackScreen, track } from "~/analytics";
+import { previousRouteNameRef } from "~/analytics/screenRefs";
+import { SourceFlowProvider } from "../../utils/SourceFlowContext";
+import { PAGE_CONNECT_DEVICE } from "../../utils/trackDeviceIntent";
 import { DiscoveryErrorState } from "./DiscoveryErrorState";
+
+jest.mock("~/analytics", () => {
+  const actual = jest.requireActual("~/analytics");
+  return {
+    ...actual,
+    TrackScreen: jest.fn(() => null),
+    track: jest.fn(),
+  };
+});
+
+const mockedTrackScreen = jest.mocked(TrackScreen);
+const mockedTrack = jest.mocked(track);
+const TEST_SOURCE = "Connect Device - Discovery Error";
 
 type DiscoveryErrorUIState = Extract<
   ConnectDeviceUIState,
@@ -115,12 +132,21 @@ function renderState({
     ignore,
   };
 
-  const view = render(<DiscoveryErrorState state={state} platform={platform} />);
+  const view = render(
+    <SourceFlowProvider value="my_ledger">
+      <DiscoveryErrorState state={state} platform={platform} />
+    </SourceFlowProvider>,
+  );
 
   return { ...view, ignore };
 }
 
 describe("DiscoveryErrorState", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    previousRouteNameRef.current = TEST_SOURCE;
+  });
+
   it.each(errorCases)(
     "should render the $type error title and description",
     ({ type, title, description }) => {
@@ -182,5 +208,62 @@ describe("DiscoveryErrorState", () => {
       ),
     ).toBeVisible();
     expect(screen.queryByText("Continue with USB")).toBeNull();
+  });
+
+  it("GIVEN a discovery error WHEN rendering THEN it tracks the Device UX V2 page event", () => {
+    // GIVEN / WHEN
+    renderState({ type: DiscoveryErrorTypes.BluetoothDisabledPromptable });
+
+    // THEN
+    expect(mockedTrackScreen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: PAGE_CONNECT_DEVICE.DiscoveryError,
+        sourceFlow: "my_ledger",
+        transport: "ble",
+        subError: "BluetoothDisabledPromptable",
+        deviceUxV2: true,
+      }),
+      undefined,
+    );
+  });
+
+  it("GIVEN a retry CTA WHEN it is pressed THEN it tracks button_clicked", async () => {
+    // GIVEN
+    const retry = jest.fn();
+    const { user } = renderState({
+      type: DiscoveryErrorTypes.BluetoothPermissionDeniedPromptable,
+      retry,
+    });
+
+    // WHEN
+    await user.press(screen.getByText("Allow"));
+
+    // THEN
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      deviceUxV2: true,
+      button: "Allow",
+    });
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  it("GIVEN an ignore CTA WHEN it is pressed THEN it tracks button_clicked", async () => {
+    // GIVEN
+    const { user, ignore } = renderState({
+      type: DiscoveryErrorTypes.LocationDisabledManualAction,
+    });
+
+    // WHEN
+    await user.press(screen.getByText("Continue with USB"));
+
+    // THEN
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      deviceUxV2: true,
+      button: "Continue with USB",
+    });
+    expect(ignore).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveryErrorState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveryErrorState.test.tsx
@@ -260,7 +260,7 @@ describe("DiscoveryErrorState", () => {
       sourceFlow: "my_ledger",
       source: TEST_SOURCE,
       deviceUxV2: true,
-      button: "Allow",
+      button: "Retry",
     });
     expect(retry).toHaveBeenCalledTimes(1);
   });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveryErrorState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveryErrorState.tsx
@@ -48,6 +48,16 @@ export function DiscoveryErrorState({
 }: Readonly<DiscoveryErrorStateProps>): React.ReactNode {
   const { t } = useTranslation();
   const sourceFlow = useSourceFlow();
+  const trackingTransport = getTrackingTransport(state.error.transportId);
+  const trackingScreen = (
+    <TrackScreen
+      category={PAGE_CONNECT_DEVICE.DiscoveryError}
+      sourceFlow={sourceFlow}
+      {...(trackingTransport ? { transport: trackingTransport } : {})}
+      subError={getTrackingSubError(state.error.type)}
+      deviceUxV2
+    />
+  );
 
   const retryCta = (labelKey: string): InfoStateCta | undefined => {
     if (!state.retry) return undefined;
@@ -176,13 +186,7 @@ export function DiscoveryErrorState({
 
     return (
       <Box lx={{ width: "full", alignItems: "center", paddingTop: "s16" }}>
-        <TrackScreen
-          category={PAGE_CONNECT_DEVICE.DiscoveryError}
-          sourceFlow={sourceFlow}
-          transport={getTrackingTransport(state.error.transportId)}
-          subError={getTrackingSubError(state.error.type)}
-          deviceUxV2
-        />
+        {trackingScreen}
         <Spinner size={32} color="base" />
         <Text
           typography="heading4SemiBold"
@@ -198,13 +202,7 @@ export function DiscoveryErrorState({
 
   return (
     <>
-      <TrackScreen
-        category={PAGE_CONNECT_DEVICE.DiscoveryError}
-        sourceFlow={sourceFlow}
-        transport={getTrackingTransport(state.error.transportId)}
-        subError={getTrackingSubError(state.error.type)}
-        deviceUxV2
-      />
+      {trackingScreen}
       <InfoState
         preset={errorState.preset}
         size="hug"

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveryErrorState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveryErrorState.tsx
@@ -6,8 +6,16 @@ import {
 } from "@ledgerhq/live-dmk-mobile";
 import type { AppPlatform } from "@ledgerhq/live-common/platform/types";
 import { InfoState } from "LLM/components/InfoState";
+import { TrackScreen } from "~/analytics";
 import { useTranslation } from "~/context/Locale";
 import { Box, Spinner, Text } from "@ledgerhq/lumen-ui-rnative";
+import { useSourceFlow } from "../../utils/SourceFlowContext";
+import {
+  getTrackingSubError,
+  getTrackingTransport,
+  PAGE_CONNECT_DEVICE,
+  trackConnectDeviceButtonClicked,
+} from "../../utils/trackDeviceIntent";
 
 type DiscoveryErrorStateProps = {
   state: Extract<ConnectDeviceUIState, { type: ConnectDeviceUIStateTypes.DiscoveryError }>;
@@ -39,19 +47,30 @@ export function DiscoveryErrorState({
   platform,
 }: Readonly<DiscoveryErrorStateProps>): React.ReactNode {
   const { t } = useTranslation();
+  const sourceFlow = useSourceFlow();
 
-  const retryCta = (labelKey: string): InfoStateCta | undefined =>
-    state.retry
-      ? {
-          label: t(labelKey),
-          onPress: state.retry,
-        }
-      : undefined;
+  const retryCta = (labelKey: string): InfoStateCta | undefined => {
+    if (!state.retry) return undefined;
+    const label = t(labelKey);
+    return {
+      label,
+      onPress: () => {
+        trackConnectDeviceButtonClicked({ sourceFlow, button: label });
+        state.retry?.();
+      },
+    };
+  };
 
-  const ignoreCta = (labelKey: string): InfoStateCta => ({
-    label: t(labelKey),
-    onPress: state.ignore,
-  });
+  const ignoreCta = (labelKey: string): InfoStateCta => {
+    const label = t(labelKey);
+    return {
+      label,
+      onPress: () => {
+        trackConnectDeviceButtonClicked({ sourceFlow, button: label });
+        state.ignore();
+      },
+    };
+  };
 
   const discoveryErrorViewStates: DiscoveryErrorViewStates = {
     [DiscoveryErrorTypes.BluetoothPermissionDeniedPromptable]: {
@@ -157,6 +176,13 @@ export function DiscoveryErrorState({
 
     return (
       <Box lx={{ width: "full", alignItems: "center", paddingTop: "s16" }}>
+        <TrackScreen
+          category={PAGE_CONNECT_DEVICE.DiscoveryError}
+          sourceFlow={sourceFlow}
+          transport={getTrackingTransport(state.error.transportId)}
+          subError={getTrackingSubError(state.error.type)}
+          deviceUxV2
+        />
         <Spinner size={32} color="base" />
         <Text
           typography="heading4SemiBold"
@@ -171,13 +197,22 @@ export function DiscoveryErrorState({
   const errorState = discoveryErrorViewStates[state.error.type];
 
   return (
-    <InfoState
-      preset={errorState.preset}
-      size="hug"
-      title={t(errorState.title)}
-      description={errorState.description ? t(errorState.description) : undefined}
-      primaryCta={errorState.primaryCta}
-      secondaryCta={errorState.secondaryCta}
-    />
+    <>
+      <TrackScreen
+        category={PAGE_CONNECT_DEVICE.DiscoveryError}
+        sourceFlow={sourceFlow}
+        transport={getTrackingTransport(state.error.transportId)}
+        subError={getTrackingSubError(state.error.type)}
+        deviceUxV2
+      />
+      <InfoState
+        preset={errorState.preset}
+        size="hug"
+        title={t(errorState.title)}
+        description={errorState.description ? t(errorState.description) : undefined}
+        primaryCta={errorState.primaryCta}
+        secondaryCta={errorState.secondaryCta}
+      />
+    </>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveryErrorState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveryErrorState.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from "~/context/Locale";
 import { Box, Spinner, Text } from "@ledgerhq/lumen-ui-rnative";
 import { useSourceFlow } from "../../utils/SourceFlowContext";
 import {
+  CONNECT_DEVICE_BUTTON,
   getTrackingSubError,
   getTrackingTransport,
   PAGE_CONNECT_DEVICE,
@@ -65,7 +66,7 @@ export function DiscoveryErrorState({
     return {
       label,
       onPress: () => {
-        trackConnectDeviceButtonClicked({ sourceFlow, button: label });
+        trackConnectDeviceButtonClicked({ sourceFlow, button: CONNECT_DEVICE_BUTTON.Retry });
         state.retry?.();
       },
     };
@@ -76,7 +77,10 @@ export function DiscoveryErrorState({
     return {
       label,
       onPress: () => {
-        trackConnectDeviceButtonClicked({ sourceFlow, button: label });
+        trackConnectDeviceButtonClicked({
+          sourceFlow,
+          button: CONNECT_DEVICE_BUTTON.ContinueWithUsb,
+        });
         state.ignore();
       },
     };

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/NoKnownDeviceState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/NoKnownDeviceState.test.tsx
@@ -1,21 +1,45 @@
 import React from "react";
 import { render, screen } from "@tests/test-renderer";
+import { TrackScreen, track } from "~/analytics";
+import { previousRouteNameRef } from "~/analytics/screenRefs";
+import { SourceFlowProvider } from "../../utils/SourceFlowContext";
+import { PAGE_CONNECT_DEVICE } from "../../utils/trackDeviceIntent";
 import { NoKnownDeviceState } from "./NoKnownDeviceState";
+
+jest.mock("~/analytics", () => {
+  const actual = jest.requireActual("~/analytics");
+  return {
+    ...actual,
+    TrackScreen: jest.fn(() => null),
+    track: jest.fn(),
+  };
+});
+
+const mockedTrackScreen = jest.mocked(TrackScreen);
+const mockedTrack = jest.mocked(track);
+const TEST_SOURCE = "Portfolio";
 
 function renderState() {
   const onConnectLedgerDevice = jest.fn();
   const onBuyLedgerDevice = jest.fn();
   const view = render(
-    <NoKnownDeviceState
-      onConnectLedgerDevice={onConnectLedgerDevice}
-      onBuyLedgerDevice={onBuyLedgerDevice}
-    />,
+    <SourceFlowProvider value="my_ledger">
+      <NoKnownDeviceState
+        onConnectLedgerDevice={onConnectLedgerDevice}
+        onBuyLedgerDevice={onBuyLedgerDevice}
+      />
+    </SourceFlowProvider>,
   );
 
   return { ...view, onConnectLedgerDevice, onBuyLedgerDevice };
 }
 
 describe("NoKnownDeviceState", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    previousRouteNameRef.current = TEST_SOURCE;
+  });
+
   it("should render the no known device title and description", () => {
     renderState();
 
@@ -31,5 +55,43 @@ describe("NoKnownDeviceState", () => {
 
     expect(onConnectLedgerDevice).toHaveBeenCalledTimes(1);
     expect(onBuyLedgerDevice).toHaveBeenCalledTimes(1);
+  });
+
+  it("GIVEN no known device WHEN rendering THEN it tracks the Device UX V2 page event", () => {
+    // GIVEN / WHEN
+    renderState();
+
+    // THEN
+    expect(mockedTrackScreen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: PAGE_CONNECT_DEVICE.NoKnownDevice,
+        sourceFlow: "my_ledger",
+        deviceUxV2: true,
+      }),
+      undefined,
+    );
+  });
+
+  it("GIVEN no known device WHEN buttons are pressed THEN it tracks button clicks", async () => {
+    // GIVEN
+    const { user } = renderState();
+
+    // WHEN
+    await user.press(screen.getByText("Connect Ledger device"));
+    await user.press(screen.getByText("I don't have a Ledger device"));
+
+    // THEN
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      deviceUxV2: true,
+      button: "Connect Ledger device",
+    });
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      deviceUxV2: true,
+      button: "I don't have a Ledger device",
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/NoKnownDeviceState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/NoKnownDeviceState.test.tsx
@@ -85,13 +85,13 @@ describe("NoKnownDeviceState", () => {
       sourceFlow: "my_ledger",
       source: TEST_SOURCE,
       deviceUxV2: true,
-      button: "Connect Ledger device",
+      button: "Connect Ledger Device",
     });
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
       source: TEST_SOURCE,
       deviceUxV2: true,
-      button: "I don't have a Ledger device",
+      button: "I Don't Have A Ledger Device",
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/NoKnownDeviceState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/NoKnownDeviceState.tsx
@@ -4,7 +4,11 @@ import { LedgerDevices } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { TrackScreen } from "~/analytics";
 import { useTranslation } from "~/context/Locale";
 import { useSourceFlow } from "../../utils/SourceFlowContext";
-import { PAGE_CONNECT_DEVICE, trackConnectDeviceButtonClicked } from "../../utils/trackDeviceIntent";
+import {
+  CONNECT_DEVICE_BUTTON,
+  PAGE_CONNECT_DEVICE,
+  trackConnectDeviceButtonClicked,
+} from "../../utils/trackDeviceIntent";
 
 type NoKnownDeviceStateProps = {
   onConnectLedgerDevice: () => void;
@@ -17,16 +21,15 @@ export function NoKnownDeviceState({
 }: Readonly<NoKnownDeviceStateProps>): React.ReactNode {
   const { t } = useTranslation();
   const sourceFlow = useSourceFlow();
-  const connectLedgerDeviceLabel = t(
-    "deviceIntentExecutor.connectDevice.states.noKnownDevice.connectLedgerDevice",
-  );
-  const noLedgerDeviceLabel = t("deviceIntentExecutor.connectDevice.states.noKnownDevice.noLedgerDevice");
   const handleConnectLedgerDevice = () => {
-    trackConnectDeviceButtonClicked({ sourceFlow, button: connectLedgerDeviceLabel });
+    trackConnectDeviceButtonClicked({
+      sourceFlow,
+      button: CONNECT_DEVICE_BUTTON.ConnectLedgerDevice,
+    });
     onConnectLedgerDevice();
   };
   const handleBuyLedgerDevice = () => {
-    trackConnectDeviceButtonClicked({ sourceFlow, button: noLedgerDeviceLabel });
+    trackConnectDeviceButtonClicked({ sourceFlow, button: CONNECT_DEVICE_BUTTON.NoLedgerDevice });
     onBuyLedgerDevice();
   };
 
@@ -49,11 +52,16 @@ export function NoKnownDeviceState({
         </Box>
       </Box>
       <Box lx={{ width: "full", gap: "s16" }}>
-        <Button appearance="base" size="lg" lx={{ width: "full" }} onPress={handleConnectLedgerDevice}>
-          {connectLedgerDeviceLabel}
+        <Button
+          appearance="base"
+          size="lg"
+          lx={{ width: "full" }}
+          onPress={handleConnectLedgerDevice}
+        >
+          {t("deviceIntentExecutor.connectDevice.states.noKnownDevice.connectLedgerDevice")}
         </Button>
         <Button appearance="gray" size="lg" lx={{ width: "full" }} onPress={handleBuyLedgerDevice}>
-          {noLedgerDeviceLabel}
+          {t("deviceIntentExecutor.connectDevice.states.noKnownDevice.noLedgerDevice")}
         </Button>
       </Box>
     </Box>

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/NoKnownDeviceState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/NoKnownDeviceState.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import { Box, Button, Spot, Text } from "@ledgerhq/lumen-ui-rnative";
 import { LedgerDevices } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { TrackScreen } from "~/analytics";
 import { useTranslation } from "~/context/Locale";
+import { useSourceFlow } from "../../utils/SourceFlowContext";
+import { PAGE_CONNECT_DEVICE, trackConnectDeviceButtonClicked } from "../../utils/trackDeviceIntent";
 
 type NoKnownDeviceStateProps = {
   onConnectLedgerDevice: () => void;
@@ -13,9 +16,27 @@ export function NoKnownDeviceState({
   onBuyLedgerDevice,
 }: Readonly<NoKnownDeviceStateProps>): React.ReactNode {
   const { t } = useTranslation();
+  const sourceFlow = useSourceFlow();
+  const connectLedgerDeviceLabel = t(
+    "deviceIntentExecutor.connectDevice.states.noKnownDevice.connectLedgerDevice",
+  );
+  const noLedgerDeviceLabel = t("deviceIntentExecutor.connectDevice.states.noKnownDevice.noLedgerDevice");
+  const handleConnectLedgerDevice = () => {
+    trackConnectDeviceButtonClicked({ sourceFlow, button: connectLedgerDeviceLabel });
+    onConnectLedgerDevice();
+  };
+  const handleBuyLedgerDevice = () => {
+    trackConnectDeviceButtonClicked({ sourceFlow, button: noLedgerDeviceLabel });
+    onBuyLedgerDevice();
+  };
 
   return (
     <Box lx={{ width: "full", alignItems: "center", gap: "s32" }}>
+      <TrackScreen
+        category={PAGE_CONNECT_DEVICE.NoKnownDevice}
+        sourceFlow={sourceFlow}
+        deviceUxV2
+      />
       <Box lx={{ width: "full", alignItems: "center", gap: "s24" }}>
         <Spot appearance="icon" icon={LedgerDevices} size={72} />
         <Box lx={{ width: "full", alignItems: "center", gap: "s8" }}>
@@ -28,11 +49,11 @@ export function NoKnownDeviceState({
         </Box>
       </Box>
       <Box lx={{ width: "full", gap: "s16" }}>
-        <Button appearance="base" size="lg" lx={{ width: "full" }} onPress={onConnectLedgerDevice}>
-          {t("deviceIntentExecutor.connectDevice.states.noKnownDevice.connectLedgerDevice")}
+        <Button appearance="base" size="lg" lx={{ width: "full" }} onPress={handleConnectLedgerDevice}>
+          {connectLedgerDeviceLabel}
         </Button>
-        <Button appearance="gray" size="lg" lx={{ width: "full" }} onPress={onBuyLedgerDevice}>
-          {t("deviceIntentExecutor.connectDevice.states.noKnownDevice.noLedgerDevice")}
+        <Button appearance="gray" size="lg" lx={{ width: "full" }} onPress={handleBuyLedgerDevice}>
+          {noLedgerDeviceLabel}
         </Button>
       </Box>
     </Box>

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/WaitingForSelectedDeviceState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/WaitingForSelectedDeviceState.test.tsx
@@ -81,6 +81,7 @@ describe("WaitingForSelectedDeviceState", () => {
       expect.objectContaining({
         category: PAGE_CONNECT_DEVICE.WaitingForSelectedDevice,
         sourceFlow: "my_ledger",
+        modelId: DeviceModelId.nanoX,
         deviceUxV2: true,
       }),
       undefined,

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/WaitingForSelectedDeviceState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/WaitingForSelectedDeviceState.tsx
@@ -33,6 +33,7 @@ export function WaitingForSelectedDeviceState({
       <TrackScreen
         category={PAGE_CONNECT_DEVICE.WaitingForSelectedDevice}
         sourceFlow={sourceFlow}
+        modelId={state.device.deviceModelId}
         deviceUxV2
       />
       <DeviceActionContent

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.test.ts
@@ -1,10 +1,17 @@
+import type { TransportIdentifier } from "@ledgerhq/device-management-kit";
+import { rnHidTransportIdentifier } from "@ledgerhq/device-transport-kit-react-native-hid";
+import { ConnectionErrorTypes, DiscoveryErrorTypes } from "@ledgerhq/live-dmk-mobile";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { track } from "~/analytics";
 import { previousRouteNameRef } from "~/analytics/screenRefs";
 import {
+  getTrackingSubError,
+  getTrackingTransport,
+  trackConnectDeviceButtonClicked,
   trackAppReady,
   trackDeviceConnected,
   trackDeviceConnecting,
+  trackDeviceSelected,
   trackDeviceflowAborted,
   trackDeviceflowCompleted,
   trackDeviceflowStarted,
@@ -21,6 +28,7 @@ jest.mock("~/analytics", () => {
 
 const mockedTrack = jest.mocked(track);
 const TEST_SOURCE = "Portfolio";
+const TEST_BLE_TRANSPORT = "RN_BLE" as TransportIdentifier;
 
 const layerABaseProperties = {
   source: TEST_SOURCE,
@@ -157,6 +165,71 @@ describe("trackDeviceIntent — Layer A tracking helpers", () => {
           expect(mockedTrack).toHaveBeenCalledWith("deviceflow_aborted", {
             ...layerABaseProperties,
             sourceFlow: "my_ledger",
+          });
+        });
+      });
+    });
+  });
+
+  describe("getTrackingSubError", () => {
+    describe("Given a Connect Device error type", () => {
+      describe("When called", () => {
+        it("Then returns the mapped PascalCase subError value", () => {
+          expect(getTrackingSubError(DiscoveryErrorTypes.BluetoothDisabledPromptable)).toBe(
+            "BluetoothDisabledPromptable",
+          );
+          expect(getTrackingSubError(ConnectionErrorTypes.BlePairingPeerRemovedPairing)).toBe(
+            "BlePairingPeerRemovedPairing",
+          );
+        });
+      });
+    });
+  });
+
+  describe("getTrackingTransport", () => {
+    describe("Given a transport id", () => {
+      describe("When called", () => {
+        it("Then maps HID to usb and other transports to ble", () => {
+          expect(getTrackingTransport(rnHidTransportIdentifier)).toBe("usb");
+          expect(getTrackingTransport(TEST_BLE_TRANSPORT)).toBe("ble");
+          expect(getTrackingTransport(undefined)).toBe("ble");
+        });
+      });
+    });
+  });
+
+  describe("trackDeviceSelected", () => {
+    describe("Given a sourceFlow and modelId", () => {
+      describe("When called", () => {
+        it("Then tracks device_selected with the Layer B properties", () => {
+          trackDeviceSelected({
+            sourceFlow: "receive",
+            modelId: DeviceModelId.nanoS,
+          });
+
+          expect(mockedTrack).toHaveBeenCalledWith("device_selected", {
+            ...layerABaseProperties,
+            sourceFlow: "receive",
+            modelId: DeviceModelId.nanoS,
+          });
+        });
+      });
+    });
+  });
+
+  describe("trackConnectDeviceButtonClicked", () => {
+    describe("Given a sourceFlow and button", () => {
+      describe("When called", () => {
+        it("Then tracks button_clicked with the Layer B properties", () => {
+          trackConnectDeviceButtonClicked({
+            sourceFlow: "send",
+            button: "Retry",
+          });
+
+          expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+            ...layerABaseProperties,
+            sourceFlow: "send",
+            button: "Retry",
           });
         });
       });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.test.ts
@@ -189,10 +189,10 @@ describe("trackDeviceIntent — Layer A tracking helpers", () => {
   describe("getTrackingTransport", () => {
     describe("Given a transport id", () => {
       describe("When called", () => {
-        it("Then maps HID to usb and other transports to ble", () => {
+        it("Then maps HID to usb, other transports to ble, and keeps unknown transport undefined", () => {
           expect(getTrackingTransport(rnHidTransportIdentifier)).toBe("usb");
           expect(getTrackingTransport(TEST_BLE_TRANSPORT)).toBe("ble");
-          expect(getTrackingTransport(undefined)).toBe("ble");
+          expect(getTrackingTransport(undefined)).toBeUndefined();
         });
       });
     });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.test.ts
@@ -199,18 +199,24 @@ describe("trackDeviceIntent — Layer A tracking helpers", () => {
   });
 
   describe("trackDeviceSelected", () => {
-    describe("Given a sourceFlow and modelId", () => {
+    describe("Given a sourceFlow and a known device", () => {
       describe("When called", () => {
-        it("Then tracks device_selected with the Layer B properties", () => {
+        it("Then tracks device_selected with the modelId and transport derived from the device", () => {
           trackDeviceSelected({
             sourceFlow: "receive",
-            modelId: DeviceModelId.nanoS,
+            device: {
+              id: "device-id",
+              name: "Ledger Nano S",
+              deviceModelId: DeviceModelId.nanoS,
+              transport: TEST_BLE_TRANSPORT,
+            },
           });
 
           expect(mockedTrack).toHaveBeenCalledWith("device_selected", {
             ...layerABaseProperties,
             sourceFlow: "receive",
             modelId: DeviceModelId.nanoS,
+            transport: "ble",
           });
         });
       });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
@@ -1,6 +1,7 @@
 import type { TransportIdentifier } from "@ledgerhq/device-management-kit";
 import { rnHidTransportIdentifier } from "@ledgerhq/device-transport-kit-react-native-hid";
 import type { DeviceModelId } from "@ledgerhq/types-devices";
+import type { KnownDevice } from "@ledgerhq/live-dmk-shared";
 import { ConnectionErrorTypes, DiscoveryErrorTypes } from "@ledgerhq/live-dmk-mobile";
 import { track } from "~/analytics";
 import { previousRouteNameRef } from "~/analytics/screenRefs";
@@ -129,11 +130,12 @@ export const trackDeviceflowAborted = (params: { sourceFlow: SourceFlow }): void
 
 export const trackDeviceSelected = (params: {
   sourceFlow: SourceFlow;
-  modelId: DeviceModelId;
+  device: KnownDevice;
 }): void => {
   track("device_selected", {
     ...getDeviceUxV2BaseProperties(params.sourceFlow),
-    modelId: params.modelId,
+    modelId: params.device.deviceModelId,
+    transport: params.device.transport === rnHidTransportIdentifier ? "usb" : "ble",
   });
 };
 

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
@@ -1,26 +1,63 @@
+import type { TransportIdentifier } from "@ledgerhq/device-management-kit";
+import { rnHidTransportIdentifier } from "@ledgerhq/device-transport-kit-react-native-hid";
 import type { DeviceModelId } from "@ledgerhq/types-devices";
+import { ConnectionErrorTypes, DiscoveryErrorTypes } from "@ledgerhq/live-dmk-mobile";
 import { track } from "~/analytics";
 import { previousRouteNameRef } from "~/analytics/screenRefs";
 import type { SourceFlow } from "./SourceFlowContext";
 
 export const PAGE_CONNECT_DEVICE = {
+  NoKnownDevice: "Connect Device - No Known Device",
   Discovering: "Connect Device - Discovering",
   WaitingForSelectedDevice: "Connect Device - Waiting For Device",
   Connecting: "Connect Device - Connecting",
+  DiscoveryError: "Connect Device - Discovery Error",
+  ConnectionError: "Connect Device - Connection Error",
 } as const;
 
-const getLayerABaseProperties = (sourceFlow: SourceFlow) => ({
+export type TrackingTransport = "ble" | "usb";
+type ConnectDeviceErrorType = ConnectionErrorTypes | DiscoveryErrorTypes;
+
+const TRACKING_SUB_ERRORS: Record<ConnectDeviceErrorType, string> = {
+  [DiscoveryErrorTypes.BluetoothPermissionDeniedPromptable]: "BluetoothPermissionDeniedPromptable",
+  [DiscoveryErrorTypes.BluetoothPermissionDeniedManualSettings]:
+    "BluetoothPermissionDeniedManualSettings",
+  [DiscoveryErrorTypes.BluetoothPermissionUnauthorizedManualSettings]:
+    "BluetoothPermissionUnauthorizedManualSettings",
+  [DiscoveryErrorTypes.BluetoothDisabledPromptable]: "BluetoothDisabledPromptable",
+  [DiscoveryErrorTypes.BluetoothDisabledManualAction]: "BluetoothDisabledManualAction",
+  [DiscoveryErrorTypes.BluetoothStateUnknownCheckOnly]: "BluetoothStateUnknownCheckOnly",
+  [DiscoveryErrorTypes.BluetoothUnsupported]: "BluetoothUnsupported",
+  [DiscoveryErrorTypes.LocationPermissionDeniedPromptable]: "LocationPermissionDeniedPromptable",
+  [DiscoveryErrorTypes.LocationPermissionDeniedManualSettings]:
+    "LocationPermissionDeniedManualSettings",
+  [DiscoveryErrorTypes.LocationDisabledPromptable]: "LocationDisabledPromptable",
+  [DiscoveryErrorTypes.LocationDisabledManualAction]: "LocationDisabledManualAction",
+  [DiscoveryErrorTypes.LocationServicePermissionMissing]: "LocationServicePermissionMissing",
+  [DiscoveryErrorTypes.Unknown]: "Unknown",
+  [ConnectionErrorTypes.BlePairingRefused]: "BlePairingRefused",
+  [ConnectionErrorTypes.BlePairingPeerRemovedPairing]: "BlePairingPeerRemovedPairing",
+};
+
+export const getDeviceUxV2BaseProperties = (sourceFlow: SourceFlow) => ({
   sourceFlow,
   source: previousRouteNameRef.current,
   deviceUxV2: true,
 });
 
+export const getTrackingTransport = (
+  transportId: TransportIdentifier | undefined,
+): TrackingTransport => (transportId === rnHidTransportIdentifier ? "usb" : "ble");
+
+export const getTrackingSubError = (errorType: ConnectDeviceErrorType): string =>
+  TRACKING_SUB_ERRORS[errorType];
+
 export const trackDeviceflowStarted = (params: { sourceFlow: SourceFlow }): void => {
-  track("deviceflow_started", getLayerABaseProperties(params.sourceFlow));
+  track("deviceflow_started", getDeviceUxV2BaseProperties(params.sourceFlow));
 };
 
 export const trackDevicePrompted = (params: { sourceFlow: SourceFlow }): void => {
-  track("device_prompted", getLayerABaseProperties(params.sourceFlow));
+  track("device_prompted", getDeviceUxV2BaseProperties(params.sourceFlow));
 };
 
 export const trackDeviceConnecting = (params: {
@@ -29,7 +66,7 @@ export const trackDeviceConnecting = (params: {
   transport: "ble" | "usb";
 }): void => {
   track("device_connecting", {
-    ...getLayerABaseProperties(params.sourceFlow),
+    ...getDeviceUxV2BaseProperties(params.sourceFlow),
     modelId: params.modelId,
     transport: params.transport,
     matchedDevice: params.modelId,
@@ -42,7 +79,7 @@ export const trackDeviceConnected = (params: {
   transport: "ble" | "usb";
 }): void => {
   track("device_connected", {
-    ...getLayerABaseProperties(params.sourceFlow),
+    ...getDeviceUxV2BaseProperties(params.sourceFlow),
     modelId: params.modelId,
     transport: params.transport,
     matchedDevice: params.modelId,
@@ -51,7 +88,7 @@ export const trackDeviceConnected = (params: {
 
 export const trackAppReady = (params: { sourceFlow: SourceFlow; modelId: DeviceModelId }): void => {
   track("app_ready", {
-    ...getLayerABaseProperties(params.sourceFlow),
+    ...getDeviceUxV2BaseProperties(params.sourceFlow),
     modelId: params.modelId,
   });
 };
@@ -62,12 +99,32 @@ export const trackDeviceflowCompleted = (params: {
   transport: "ble" | "usb";
 }): void => {
   track("deviceflow_completed", {
-    ...getLayerABaseProperties(params.sourceFlow),
+    ...getDeviceUxV2BaseProperties(params.sourceFlow),
     modelId: params.modelId,
     transport: params.transport,
   });
 };
 
 export const trackDeviceflowAborted = (params: { sourceFlow: SourceFlow }): void => {
-  track("deviceflow_aborted", getLayerABaseProperties(params.sourceFlow));
+  track("deviceflow_aborted", getDeviceUxV2BaseProperties(params.sourceFlow));
+};
+
+export const trackDeviceSelected = (params: {
+  sourceFlow: SourceFlow;
+  modelId: DeviceModelId;
+}): void => {
+  track("device_selected", {
+    ...getDeviceUxV2BaseProperties(params.sourceFlow),
+    modelId: params.modelId,
+  });
+};
+
+export const trackConnectDeviceButtonClicked = (params: {
+  sourceFlow: SourceFlow;
+  button: string;
+}): void => {
+  track("button_clicked", {
+    ...getDeviceUxV2BaseProperties(params.sourceFlow),
+    button: params.button,
+  });
 };

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
@@ -15,6 +15,21 @@ export const PAGE_CONNECT_DEVICE = {
   ConnectionError: "Connect Device - Connection Error",
 } as const;
 
+/**
+ * Canonical, locale-independent `button` values for Connect Device `button_clicked`
+ * events. The displayed CTA label stays localized; analytics receives these stable
+ * strings so the property is not fragmented across languages. The error screen is
+ * already disambiguated by the `subError` property, so primary retry/allow CTAs
+ * collapse to a single `Retry` value.
+ */
+export const CONNECT_DEVICE_BUTTON = {
+  ConnectLedgerDevice: "Connect Ledger Device",
+  NoLedgerDevice: "I Don't Have A Ledger Device",
+  Retry: "Retry",
+  ContinueWithUsb: "Continue with USB",
+  GetHelp: "Get Help",
+} as const;
+
 export type TrackingTransport = "ble" | "usb";
 type ConnectDeviceErrorType = ConnectionErrorTypes | DiscoveryErrorTypes;
 

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
@@ -47,7 +47,10 @@ export const getDeviceUxV2BaseProperties = (sourceFlow: SourceFlow) => ({
 
 export const getTrackingTransport = (
   transportId: TransportIdentifier | undefined,
-): TrackingTransport => (transportId === rnHidTransportIdentifier ? "usb" : "ble");
+): TrackingTransport | undefined => {
+  if (!transportId) return undefined;
+  return transportId === rnHidTransportIdentifier ? "usb" : "ble";
+};
 
 export const getTrackingSubError = (errorType: ConnectDeviceErrorType): string =>
   TRACKING_SUB_ERRORS[errorType];

--- a/libs/live-dmk-mobile/src/connectDevice/ConnectDeviceStateMachine.test.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/ConnectDeviceStateMachine.test.ts
@@ -950,6 +950,7 @@ describe("ConnectDeviceStateMachine", () => {
       expect(connectionErrorError).toEqual({
         type: ConnectionErrorTypes.BlePairingRefused,
       });
+      expect(connectionErrorState).toEqual(expect.objectContaining({ device: knownDeviceA }));
     });
 
     it("emits a BLE peer-removed-pairing ConnectionError when connection fails", async () => {
@@ -982,6 +983,7 @@ describe("ConnectDeviceStateMachine", () => {
       expect(connectionErrorError).toEqual({
         type: ConnectionErrorTypes.BlePairingPeerRemovedPairing,
       });
+      expect(connectionErrorState).toEqual(expect.objectContaining({ device: knownDeviceA }));
     });
 
     it("retries the connection when the ConnectionError retry action is used", async () => {

--- a/libs/live-dmk-mobile/src/connectDevice/ConnectDeviceStateMachine.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/ConnectDeviceStateMachine.ts
@@ -184,6 +184,7 @@ const createConnectDeviceStateMachine = () =>
         context.observer.next({
           type: ConnectDeviceUIStateTypes.ConnectionError,
           error: context.connectionError!,
+          device: context.selectedMatchedDevice!.knownDevice,
           retry: () =>
             self.send({ type: ConnectDeviceStateMachineEventTypes.UserTapsConnectionRetry }),
           ignore: () =>

--- a/libs/live-dmk-mobile/src/connectDevice/types.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/types.ts
@@ -344,6 +344,7 @@ export type ConnectDeviceUIState =
   | {
       type: ConnectDeviceUIStateTypes.ConnectionError;
       error: ConnectionError;
+      device: KnownDevice;
       retry: () => void;
       ignore: () => void;
     }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Connect Device (Layer B) analytics for the Device UX V2 flow on Ledger Live Mobile.
  - QA should verify `sourceFlow`, `source`, `page`, `deviceUxV2`, `modelId`, `transport`, `subError`, and the canonical `button` values on emitted events.

### 📝 Description

Implements [LIVE-31525](https://ledgerhq.atlassian.net/browse/LIVE-31525): the granular Connect Device (Layer B) tracking on top of the Layer A DIE funnel.

- Adds the 6 `Connect Device - *` page events (no-known-device, discovering, waiting, connecting, discovery-error, connection-error) plus `device_selected` and `button_clicked`.
- `subError` carries the PascalCase `DiscoveryErrorTypes` / `ConnectionErrorTypes` value; `button_clicked` uses canonical, locale-independent values (not translated labels).
- Exposes the selected `KnownDevice` on the `@ledgerhq/live-dmk-mobile` connection-error UI state so connection-error events include `modelId` / `transport`.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31525](https://ledgerhq.atlassian.net/browse/LIVE-31525)
- **ADR link (if any)**: N/A

[LIVE-31525]: https://ledgerhq.atlassian.net/browse/LIVE-31525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-31525]: https://ledgerhq.atlassian.net/browse/LIVE-31525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ