### PR TITLE
[LWM] fix(mobile): make earn banner fully interactive

### DIFF
--- a/.changeset/fix-earn-banner-interactive.md
+++ b/.changeset/fix-earn-banner-interactive.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix earn banner card to be fully interactive instead of icon-only

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/EarnBannerView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/EarnBannerView.tsx
@@ -6,11 +6,12 @@ import {
   CardContentTitle,
   CardHeader,
   CardLeading,
-  IconButton,
+  Box,
 } from "@ledgerhq/lumen-ui-rnative";
 import { ChevronRight } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { useTranslation } from "~/context/Locale";
 import { ASSET_DETAIL_TEST_IDS } from "LLM/features/AssetDetail/testIds";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 
 type Props = Readonly<{
   label: string;
@@ -22,7 +23,7 @@ export function EarnBannerView({ label, onPress }: Props) {
 
   return (
     <Card
-      type="info"
+      type="interactive"
       onPress={onPress}
       testID={ASSET_DETAIL_TEST_IDS.earnBanner}
       accessibilityLabel={t("assetDetail.balanceDetails.earnBannerAction")}
@@ -36,14 +37,18 @@ export function EarnBannerView({ label, onPress }: Props) {
             </CardContentDescription>
           </CardContent>
         </CardLeading>
-        <IconButton
-          appearance="transparent"
-          size="sm"
-          icon={ChevronRight}
-          accessibilityLabel={t("assetDetail.balanceDetails.earnBannerAction")}
-          onPress={onPress}
-        />
+        <Box lx={iconWrapperStyle}>
+          <ChevronRight size={20} color="base" />
+        </Box>
       </CardHeader>
     </Card>
   );
 }
+
+const iconWrapperStyle: LumenViewStyle = {
+  borderRadius: "full",
+  backgroundColor: "mutedTransparent",
+  justifyContent: "center",
+  alignItems: "center",
+  padding: "s10",
+};


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No automated tests — visual/interactive behavior change._
- [x] **Impact of the changes:**
  - Earn banner on Asset Detail screen (Ethereum and other staking assets)
  - Tappable area of the banner card

### 📝 Description

The earn banner on the Asset Detail screen was only partially interactive: only the chevron icon button triggered the `onPress` action. The rest of the card was inert.

This fix switches the `Card` from `type="info"` to `type="interactive"`, making the entire banner tappable. The `IconButton` is replaced with a plain `Box` + `ChevronRight` icon (styled to match the previous look) since the card itself now owns the press handler.

https://github.com/user-attachments/assets/5368bf0a-8fb3-47c7-8ece-16719a4166d6




### ❓ Context

- **JIRA or GitHub link**: [LIVE-31533](https://ledgerhq.atlassian.net/browse/LIVE-31533)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31533]: https://ledgerhq.atlassian.net/browse/LIVE-31533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ