### PR TITLE
[LWDM] feat(wallet-api): support `allowManager` in `device.transport` / `device.select` [LIVE-28359]

### DIFF
--- a/.changeset/wallet-api-allow-manager-transport.md
+++ b/.changeset/wallet-api-allow-manager-transport.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/live-common": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Support `allowManager` in wallet-api `device.transport` / `device.select` so wallet apps can request a Manager-ready transport (BOLOS dashboard) and issue Manager APDUs.
+
+Also fixes an inverted version check in `device.transport` / `device.select` that rejected app versions satisfying `appVersionRange` (and accepted ones that didn't).

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
@@ -239,21 +239,23 @@ function useUiHook(manifest: AppManifest, tracking: TrackingAPI): UiHook {
           },
         });
       },
-      "device.transport": ({ appName, onSuccess, onCancel }) => {
+      "device.transport": ({ appName, allowManager, onSuccess, onCancel }) => {
         ipcRenderer.send("show-app", {});
         dispatch(
           openModal("MODAL_CONNECT_DEVICE", {
             appName,
+            allowManager,
             onResult: onSuccess,
             onCancel,
           }),
         );
       },
-      "device.select": ({ appName, onSuccess, onCancel }) => {
+      "device.select": ({ appName, allowManager, onSuccess, onCancel }) => {
         ipcRenderer.send("show-app", {});
         dispatch(
           openModal("MODAL_CONNECT_DEVICE", {
             appName,
+            allowManager,
             onResult: onSuccess,
             onCancel,
           }),

--- a/apps/ledger-live-desktop/src/renderer/modals/ConnectDevice/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/ConnectDevice/index.tsx
@@ -3,10 +3,14 @@ import Modal, { ModalBody } from "~/renderer/components/Modal";
 import Box from "~/renderer/components/Box";
 import DeviceAction from "~/renderer/components/DeviceAction";
 import { AppResult } from "@ledgerhq/live-common/hw/actions/app";
-import useConnectAppAction from "~/renderer/hooks/useConnectAppAction";
+import { managerResultToAppResult } from "@ledgerhq/live-common/wallet-api/helpers";
+import useConnectAppAction, { useConnectManagerAction } from "~/renderer/hooks/useConnectAppAction";
+
+const MANAGER_REQUEST = {} as const;
 
 export type Data = {
   appName?: string;
+  allowManager?: boolean;
   requireLatestFirmware?: boolean;
   allowPartialDependencies?: boolean;
   skipAppInstallIfNotFound?: boolean;
@@ -16,19 +20,22 @@ export type Data = {
 
 export default function ConnectDevice({
   appName = "BOLOS",
+  allowManager,
   requireLatestFirmware,
   allowPartialDependencies,
   skipAppInstallIfNotFound,
 }: Data) {
-  const action = useConnectAppAction();
-  const request = useMemo(() => {
-    return {
+  const connectAppAction = useConnectAppAction();
+  const connectManagerAction = useConnectManagerAction();
+  const request = useMemo(
+    () => ({
       appName,
       requireLatestFirmware,
       allowPartialDependencies,
       skipAppInstallIfNotFound,
-    };
-  }, [appName, requireLatestFirmware, allowPartialDependencies, skipAppInstallIfNotFound]);
+    }),
+    [appName, requireLatestFirmware, allowPartialDependencies, skipAppInstallIfNotFound],
+  );
 
   return (
     <Modal
@@ -45,14 +52,27 @@ export default function ConnectDevice({
           }}
           render={() => (
             <Box alignItems={"center"} px={32}>
-              <DeviceAction
-                action={action}
-                request={request}
-                onResult={res => {
-                  data?.onResult(res);
-                  onClose?.();
-                }}
-              />
+              {allowManager ? (
+                <DeviceAction
+                  key="connect-manager"
+                  action={connectManagerAction}
+                  request={MANAGER_REQUEST}
+                  onResult={res => {
+                    data?.onResult(managerResultToAppResult(res));
+                    onClose?.();
+                  }}
+                />
+              ) : (
+                <DeviceAction
+                  key="connect-app"
+                  action={connectAppAction}
+                  request={request}
+                  onResult={res => {
+                    data?.onResult(res);
+                    onClose?.();
+                  }}
+                />
+              )}
             </Box>
           )}
         />

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
@@ -335,6 +335,7 @@ export type BaseNavigatorStackParamList = {
 
   [ScreenName.DeviceConnect]: {
     appName?: string;
+    allowManager?: boolean;
     requireLatestFirmware?: boolean;
     allowPartialDependencies?: boolean;
     skipAppInstallIfNotFound?: boolean;

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/helpers.ts
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/helpers.ts
@@ -614,16 +614,18 @@ function useUiHook({ manifest, onTransactionBroadcast }: Props): UiHook {
       "transaction.broadcast": () => {
         onTransactionBroadcast?.();
       },
-      "device.transport": ({ appName, onSuccess, onCancel }) => {
+      "device.transport": ({ appName, allowManager, onSuccess, onCancel }) => {
         navigation.navigate(ScreenName.DeviceConnect, {
           appName,
+          allowManager,
           onSuccess,
           onClose: onCancel,
         });
       },
-      "device.select": ({ appName, onSuccess, onCancel }) => {
+      "device.select": ({ appName, allowManager, onSuccess, onCancel }) => {
         navigation.navigate(ScreenName.DeviceConnect, {
           appName,
+          allowManager,
           onSuccess,
           onClose: onCancel,
         });

--- a/apps/ledger-live-mobile/src/screens/DeviceConnect/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/DeviceConnect/index.tsx
@@ -6,6 +6,8 @@ import { useTranslation } from "~/context/Locale";
 import { useTheme } from "@react-navigation/native";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { AppResult } from "@ledgerhq/live-common/hw/actions/app";
+import { Result as ManagerResult } from "@ledgerhq/live-common/hw/actions/manager";
+import { managerResultToAppResult } from "@ledgerhq/live-common/wallet-api/helpers";
 import { Flex } from "@ledgerhq/native-ui";
 import { TrackScreen } from "~/analytics";
 import SelectDevice2, { SetHeaderOptionsRequest } from "~/components/SelectDevice2";
@@ -18,7 +20,9 @@ import {
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { ScreenName } from "~/const";
 import { NavigationHeaderBackButton } from "~/components/NavigationHeaderBackButton";
-import { useAppDeviceAction } from "~/hooks/deviceActions";
+import { useAppDeviceAction, useManagerDeviceAction } from "~/hooks/deviceActions";
+
+const MANAGER_REQUEST = {} as const;
 
 type NavigationProps = RootComposite<
   StackNavigatorProps<BaseNavigatorStackParamList, ScreenName.DeviceConnect>
@@ -38,6 +42,7 @@ export default function DeviceConnect({ navigation, route }: NavigationProps) {
   const hasHandledSuccessRef = useRef(false);
   const {
     appName = "BOLOS",
+    allowManager,
     requireLatestFirmware,
     allowPartialDependencies,
     skipAppInstallIfNotFound,
@@ -52,7 +57,8 @@ export default function DeviceConnect({ navigation, route }: NavigationProps) {
     }),
     [appName, requireLatestFirmware, allowPartialDependencies, skipAppInstallIfNotFound],
   );
-  const action = useAppDeviceAction();
+  const connectAppAction = useAppDeviceAction();
+  const connectManagerAction = useManagerDeviceAction();
 
   const onDone = useCallback(() => {
     navigation.pop();
@@ -66,6 +72,13 @@ export default function DeviceConnect({ navigation, route }: NavigationProps) {
       onDone();
     },
     [onDone, onSuccess],
+  );
+
+  const handleManagerSuccess = useCallback(
+    (result: ManagerResult) => {
+      handleSuccess(managerResultToAppResult(result));
+    },
+    [handleSuccess],
   );
 
   const resetDevice = useCallback(() => {
@@ -110,14 +123,27 @@ export default function DeviceConnect({ navigation, route }: NavigationProps) {
           requestToSetHeaderOptions={requestToSetHeaderOptions}
         />
       </Flex>
-      <DeviceActionModal
-        action={action}
-        device={device}
-        onResult={handleSuccess}
-        onClose={resetDevice}
-        request={request}
-        analyticsPropertyFlow={"device connect"}
-      />
+      {allowManager ? (
+        <DeviceActionModal
+          key="connect-manager"
+          action={connectManagerAction}
+          device={device}
+          onResult={handleManagerSuccess}
+          onClose={resetDevice}
+          request={MANAGER_REQUEST}
+          analyticsPropertyFlow={"device connect"}
+        />
+      ) : (
+        <DeviceActionModal
+          key="connect-app"
+          action={connectAppAction}
+          device={device}
+          onResult={handleSuccess}
+          onClose={resetDevice}
+          request={request}
+          analyticsPropertyFlow={"device connect"}
+        />
+      )}
     </SafeAreaView>
   );
 }

--- a/libs/ledger-live-common/src/wallet-api/helpers.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/helpers.test.ts
@@ -1,4 +1,12 @@
-import { getInitialURL } from "./helpers";
+import type { DeviceInfo } from "@ledgerhq/types-live";
+import type { Result as ManagerResult } from "../hw/actions/manager";
+import type { AppAndVersion } from "../hw/connectApp";
+import {
+  bolosAppAndVersionFromDeviceInfo,
+  getInitialURL,
+  isAppVersionOutOfRange,
+  managerResultToAppResult,
+} from "./helpers";
 
 describe("wallet-api helpers", () => {
   describe("isWhitelistedDomain (via getInitialURL)", () => {
@@ -530,6 +538,61 @@ describe("wallet-api helpers", () => {
       const resultUrl = new URL(result);
       expect(resultUrl.searchParams.get("params")).toBe(JSON.stringify({ foo: "bar" }));
       expect(result).not.toContain("other");
+    });
+  });
+
+  describe("bolosAppAndVersionFromDeviceInfo", () => {
+    it("should synthesize a BOLOS AppAndVersion from the device info", () => {
+      const seFlags = Buffer.from([42]);
+      const deviceInfo = { version: "2.2.3", seFlags } as unknown as DeviceInfo;
+
+      expect(bolosAppAndVersionFromDeviceInfo(deviceInfo)).toEqual({
+        name: "BOLOS",
+        version: "2.2.3",
+        flags: seFlags,
+      });
+    });
+  });
+
+  describe("managerResultToAppResult", () => {
+    it("should map the device through and synthesize the BOLOS appAndVersion", () => {
+      const device = { deviceId: "device-1", modelId: "nanoX" };
+      const seFlags = Buffer.from([7]);
+      const deviceInfo = { version: "1.4.0", seFlags } as unknown as DeviceInfo;
+      const result = {
+        device,
+        deviceInfo,
+        result: null,
+      } as unknown as ManagerResult;
+
+      expect(managerResultToAppResult(result)).toEqual({
+        device,
+        appAndVersion: { name: "BOLOS", version: "1.4.0", flags: seFlags },
+      });
+    });
+  });
+
+  describe("isAppVersionOutOfRange", () => {
+    const appAndVersion: AppAndVersion = { name: "BOLOS", version: "2.2.3", flags: 0 };
+
+    it("should return false when the version satisfies the range", () => {
+      expect(isAppVersionOutOfRange(">=2.0.0", appAndVersion)).toBe(false);
+    });
+
+    it("should return true when the version does not satisfy the range", () => {
+      expect(isAppVersionOutOfRange(">=3.0.0", appAndVersion)).toBe(true);
+    });
+
+    it("should return false when no range is provided", () => {
+      expect(isAppVersionOutOfRange(undefined, appAndVersion)).toBe(false);
+    });
+
+    it("should return false when no appAndVersion is provided", () => {
+      expect(isAppVersionOutOfRange(">=3.0.0", undefined)).toBe(false);
+    });
+
+    it("should return false when appAndVersion is null", () => {
+      expect(isAppVersionOutOfRange(">=3.0.0", null)).toBe(false);
     });
   });
 });

--- a/libs/ledger-live-common/src/wallet-api/helpers.ts
+++ b/libs/ledger-live-common/src/wallet-api/helpers.ts
@@ -1,7 +1,12 @@
+import semver from "semver";
 import { log } from "@ledgerhq/logs";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import type { DeviceInfo } from "@ledgerhq/types-live";
 import { isCryptoCurrency, isTokenCurrency } from "../currencies";
 import { Currency } from "@ledgerhq/types-cryptoassets";
+import type { AppResult } from "../hw/actions/app";
+import type { Result as ManagerResult } from "../hw/actions/manager";
+import type { AppAndVersion } from "../hw/connectApp";
 import type {
   WalletAPICurrency,
   WalletAPISupportedCurrency,
@@ -215,3 +220,35 @@ export function objectToURLSearchParams(obj: Record<string, unknown>): URLSearch
 
   return searchParams;
 }
+
+/**
+ * The dashboard firmware (BOLOS) responds to GET_APP_AND_VERSION with its
+ * own name and the firmware version when no app is open. We synthesize the
+ * same shape here so that wallet-api `device.transport` / `device.select`
+ * with `allowManager: true` resolve with a consistent `AppResult` payload
+ * without needing an extra APDU round-trip.
+ */
+export const bolosAppAndVersionFromDeviceInfo = (deviceInfo: DeviceInfo): AppAndVersion => ({
+  name: "BOLOS",
+  version: deviceInfo.version,
+  flags: deviceInfo.seFlags,
+});
+
+export const managerResultToAppResult = (result: ManagerResult): AppResult => ({
+  device: result.device,
+  appAndVersion: bolosAppAndVersionFromDeviceInfo(result.deviceInfo),
+});
+
+/**
+ * Returns true when the resolved version falls outside the requested range.
+ * In the `allowManager` flow the version is the BOLOS firmware version (see
+ * `bolosAppAndVersionFromDeviceInfo`), which is validated against
+ * `appVersionRange` the same way an app version would be.
+ */
+export const isAppVersionOutOfRange = (
+  appVersionRange: string | undefined,
+  appAndVersion: AppAndVersion | null | undefined,
+): boolean =>
+  !!appVersionRange &&
+  !!appAndVersion &&
+  !semver.satisfies(appAndVersion.version, appVersionRange);

--- a/libs/ledger-live-common/src/wallet-api/react.ts
+++ b/libs/ledger-live-common/src/wallet-api/react.ts
@@ -1,6 +1,5 @@
 import { useMemo, useState, useEffect, useRef, useCallback, RefObject } from "react";
 import { useDispatch } from "react-redux";
-import semver from "semver";
 import { intervalToDuration } from "date-fns";
 import { Account, AccountLike, AnyMessage, Operation, SignedOperation } from "@ledgerhq/types-live";
 import { WalletHandlers, ServerConfig, WalletAPIServer } from "@ledgerhq/wallet-api-server";
@@ -25,7 +24,7 @@ import {
   currencyToWalletAPICurrency,
   setWalletApiIdForAccountId,
 } from "./converters";
-import { isWalletAPISupportedCurrency } from "./helpers";
+import { isAppVersionOutOfRange, isWalletAPISupportedCurrency } from "./helpers";
 import {
   WalletAPICurrency,
   AppManifest,
@@ -147,13 +146,27 @@ export interface UiHook {
     mainAccount: Account,
     optimisticOperation: Operation,
   ) => void;
+  /**
+   * Opens a device transport for the wallet app.
+   * When `allowManager` is true, the platform leaves the device on the
+   * Manager screen and the subscribed transport can be used to issue
+   * Manager APDUs. In that mode `appName` is ignored and `onSuccess` is
+   * called with the BOLOS dashboard's app-and-version (name: "BOLOS",
+   * version: firmware version, flags: SE flags), matching what
+   * `getAppAndVersion` would return on a device sitting at Manager.
+   */
   "device.transport": (params: {
     appName: string | undefined;
+    allowManager?: boolean;
     onSuccess: (result: AppResult) => void;
     onCancel: () => void;
   }) => void;
+  /**
+   * See `device.transport` for the `allowManager` semantics.
+   */
   "device.select": (params: {
     appName: string | undefined;
+    allowManager?: boolean;
     onSuccess: (result: AppResult) => void;
     onCancel: () => void;
   }) => void;
@@ -1046,7 +1059,7 @@ export function useWalletAPIServer({
 
     server.setHandler(
       "device.transport",
-      ({ appName, appVersionRange, devices }) =>
+      ({ appName, appVersionRange, devices, allowManager }) =>
         new Promise((resolve, reject) => {
           if (device.ref.current) {
             return reject(new Error("Device already opened"));
@@ -1057,6 +1070,7 @@ export function useWalletAPIServer({
           let done = false;
           return uiDeviceTransport({
             appName,
+            allowManager,
             onSuccess: ({ device: deviceParam, appAndVersion }) => {
               if (done) return;
               done = true;
@@ -1070,12 +1084,8 @@ export function useWalletAPIServer({
                 reject(new Error("Device not in the devices list"));
                 return;
               }
-              if (
-                appVersionRange &&
-                appAndVersion &&
-                semver.satisfies(appAndVersion.version, appVersionRange)
-              ) {
-                reject(new Error("App version doesn't satisfies the range"));
+              if (isAppVersionOutOfRange(appVersionRange, appAndVersion)) {
+                reject(new Error("App version doesn't satisfy the range"));
                 return;
               }
               // TODO handle appFirmwareRange & seeded params
@@ -1098,7 +1108,7 @@ export function useWalletAPIServer({
 
     server.setHandler(
       "device.select",
-      ({ appName, appVersionRange, devices }) =>
+      ({ appName, appVersionRange, devices, allowManager }) =>
         new Promise((resolve, reject) => {
           if (device.ref.current) {
             return reject(new Error("Device already opened"));
@@ -1109,6 +1119,7 @@ export function useWalletAPIServer({
           let done = false;
           return uiDeviceSelect({
             appName,
+            allowManager,
             onSuccess: ({ device: deviceParam, appAndVersion }) => {
               if (done) return;
               done = true;
@@ -1122,12 +1133,8 @@ export function useWalletAPIServer({
                 reject(new Error("Device not in the devices list"));
                 return;
               }
-              if (
-                appVersionRange &&
-                appAndVersion &&
-                semver.satisfies(appAndVersion.version, appVersionRange)
-              ) {
-                reject(new Error("App version doesn't satisfies the range"));
+              if (isAppVersionOutOfRange(appVersionRange, appAndVersion)) {
+                reject(new Error("App version doesn't satisfy the range"));
                 return;
               }
               resolve(deviceParam.deviceId);
@@ -1141,7 +1148,7 @@ export function useWalletAPIServer({
           });
         }),
     );
-  }, [device.ref, manifest, server, tracking, uiDeviceSelect]);
+  }, [device, manifest, server, tracking, uiDeviceSelect]);
 
   useEffect(() => {
     server.setHandler("device.open", params => {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Tested manually to make sure we ask for the manager (we could probably cover with speculos at some point)
- [x] **Impact of the changes:**
  - wallet-api device module so mostly recover

### 📝 Description

Bumps `@ledgerhq/wallet-api-*` (core 1.31.0, client 1.14.2, server 3.3.2, client-react 1.4.27, simulator 2.2.4) which add an `allowManager` flag to `device.transport` and `device.select`.

When a wallet app sets `allowManager: true`, the platform now runs only the Manager device action (instead of `connectApp`). The device is left on the Manager screen and the subscribed transport is Manager-ready, so the app can issue Manager APDUs (list/install/uninstall apps, etc.) via `device.exchange`.

`onSuccess` still receives an `AppResult`: the BOLOS dashboard reports itself through `GET_APP_AND_VERSION`, so we synthesize an authentic `AppAndVersion` (`name: "BOLOS"`, `version: deviceInfo.version`, `flags: deviceInfo.seFlags`) from `ManagerResult` without an extra APDU round-trip — exposed as `managerResultToAppResult` / `bolosAppAndVersionFromDeviceInfo` in `wallet-api/helpers.ts`.

Also fixes a pre-existing inverted `appVersionRange` check in both handlers (it rejected versions that satisfied the range and accepted those that didn't), now centralized in `isAppVersionOutOfRange` in `wallet-api/helpers.ts` and covered by unit tests.

Plumbed the new flag end-to-end on desktop (`ConnectDevice` modal + `WalletAPIWebview`) and mobile (`DeviceConnect` screen + `BaseNavigator` route params + Web3AppWebview helpers), and documented the semantics on the `UiHook` interface in `wallet-api/react.ts`.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28359]
- **ADR link (if any)**: 


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-28359]: https://ledgerhq.atlassian.net/browse/LIVE-28359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ