### PR TITLE
[LWDM] feat(LIVE-28050): hedera testnet support - part 3

### DIFF
--- a/.changeset/silver-tigers-whisper.md
+++ b/.changeset/silver-tigers-whisper.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-hedera": minor
+---
+
+refactor: hedera hgraph & rpc clients based on network type from config

--- a/libs/coin-modules/coin-hedera/src/bridge/broadcast.integ.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/broadcast.integ.test.ts
@@ -22,7 +22,7 @@ describe("Broadcast", () => {
     const senderKey = PrivateKey.generateED25519();
     const senderAccountId = AccountId.fromString("0.0.999999999");
     const recipient = AccountId.fromString("0.0.2");
-    const client = await rpcClient.getInstance();
+    const client = await rpcClient.getInstance(coinConfig);
 
     const tx = new TransferTransaction()
       .addHbarTransfer(senderAccountId, Hbar.fromTinybars(-1))

--- a/libs/coin-modules/coin-hedera/src/logic/broadcast.integ.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/broadcast.integ.test.ts
@@ -15,7 +15,7 @@ describe("Broadcast", () => {
     const senderKey = PrivateKey.generateED25519();
     const senderAccountId = AccountId.fromString("0.0.999999999");
     const recipient = AccountId.fromString("0.0.2");
-    const client = await rpcClient.getInstance();
+    const client = await rpcClient.getInstance(coinConfig);
 
     const tx = new TransferTransaction()
       .addHbarTransfer(senderAccountId, Hbar.fromTinybars(-1))

--- a/libs/coin-modules/coin-hedera/src/logic/broadcast.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/broadcast.test.ts
@@ -26,7 +26,10 @@ describe("broadcast", () => {
     expect(deserializeTransaction).toHaveBeenCalledTimes(1);
     expect(deserializeTransaction).toHaveBeenCalledWith(txWithSignature);
     expect(rpcClient.broadcastTransaction).toHaveBeenCalledTimes(1);
-    expect(rpcClient.broadcastTransaction).toHaveBeenCalledWith(mockDeserializedTx);
+    expect(rpcClient.broadcastTransaction).toHaveBeenCalledWith({
+      configOrCurrencyId: mockCurrency.id,
+      transaction: mockDeserializedTx,
+    });
     expect(result).toBe(mockResponse);
   });
 
@@ -60,6 +63,9 @@ describe("broadcast", () => {
     expect(deserializeTransaction).toHaveBeenCalledTimes(1);
     expect(deserializeTransaction).toHaveBeenCalledWith(txWithSignature);
     expect(rpcClient.broadcastTransaction).toHaveBeenCalledTimes(1);
-    expect(rpcClient.broadcastTransaction).toHaveBeenCalledWith(mockDeserializedTx);
+    expect(rpcClient.broadcastTransaction).toHaveBeenCalledWith({
+      configOrCurrencyId: mockCurrency.id,
+      transaction: mockDeserializedTx,
+    });
   });
 });

--- a/libs/coin-modules/coin-hedera/src/logic/broadcast.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/broadcast.ts
@@ -4,12 +4,12 @@ import { rpcClient } from "../network/rpc";
 import { deserializeTransaction } from "./utils";
 
 export const broadcast = async ({
-  configOrCurrencyId: _,
+  configOrCurrencyId,
   txWithSignature,
 }: {
   configOrCurrencyId: HederaCoinConfig | string;
   txWithSignature: string;
 }): Promise<TransactionResponse> => {
   const transaction = deserializeTransaction(txWithSignature);
-  return await rpcClient.broadcastTransaction(transaction);
+  return await rpcClient.broadcastTransaction({ configOrCurrencyId, transaction });
 };

--- a/libs/coin-modules/coin-hedera/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/craftTransaction.ts
@@ -67,7 +67,7 @@ interface BuilderUpdateAccountTransaction extends BuilderCommonTransactionFields
 }
 
 async function buildUnsignedCoinTransaction({
-  config: _,
+  config,
   account,
   transaction,
 }: {
@@ -89,11 +89,11 @@ async function buildUnsignedCoinTransaction({
     tx.setMaxTransactionFee(Hbar.fromTinybars(transaction.maxFee.toNumber()));
   }
 
-  return tx.freezeWith(await rpcClient.getInstance());
+  return tx.freezeWith(await rpcClient.getInstance(config));
 }
 
 async function buildUnsignedHTSTokenTransaction({
-  config: _,
+  config,
   account,
   transaction,
 }: {
@@ -115,7 +115,7 @@ async function buildUnsignedHTSTokenTransaction({
     tx.setMaxTransactionFee(Hbar.fromTinybars(transaction.maxFee.toNumber()));
   }
 
-  return tx.freezeWith(await rpcClient.getInstance());
+  return tx.freezeWith(await rpcClient.getInstance(config));
 }
 
 async function buildUnsignedERC20TokenTransaction({
@@ -151,11 +151,11 @@ async function buildUnsignedERC20TokenTransaction({
     tx.setMaxTransactionFee(Hbar.fromTinybars(transaction.maxFee.toNumber()));
   }
 
-  return tx.freezeWith(await rpcClient.getInstance());
+  return tx.freezeWith(await rpcClient.getInstance(config));
 }
 
 async function buildTokenAssociateTransaction({
-  config: _,
+  config,
   account,
   transaction,
 }: {
@@ -176,11 +176,11 @@ async function buildTokenAssociateTransaction({
     tx.setMaxTransactionFee(Hbar.fromTinybars(transaction.maxFee.toNumber()));
   }
 
-  return tx.freezeWith(await rpcClient.getInstance());
+  return tx.freezeWith(await rpcClient.getInstance(config));
 }
 
 async function buildUnsignedUpdateAccountTransaction({
-  config: _,
+  config,
   account,
   transaction,
 }: {
@@ -208,7 +208,7 @@ async function buildUnsignedUpdateAccountTransaction({
     tx.clearStakedNodeId();
   }
 
-  return tx.freezeWith(await rpcClient.getInstance());
+  return tx.freezeWith(await rpcClient.getInstance(config));
 }
 
 function isStakingMode(type: string): type is BuilderUpdateAccountTransaction["type"] {

--- a/libs/coin-modules/coin-hedera/src/logic/getBalance.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBalance.test.ts
@@ -100,7 +100,7 @@ describe("getBalance", () => {
     expect(apiClient.getAccountTokens).toHaveBeenCalledWith(address);
     expect(networkUtils.getERC20BalancesForAccountV2).toHaveBeenCalledTimes(1);
     expect(networkUtils.getERC20BalancesForAccountV2).toHaveBeenCalledWith({
-      configOrCurrencyId: mockCurrency.id,
+      configOrCurrencyId: mockConfig,
       address,
     });
     expect(findTokenByAddressInCurrencyMock).toHaveBeenCalledTimes(2);

--- a/libs/coin-modules/coin-hedera/src/logic/getBalance.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBalance.ts
@@ -35,7 +35,7 @@ export async function getBalance({
       mirrorAccountPromise,
       apiClient.getAccountTokens(address),
       coinConfig.useHgraphForErc20
-        ? getERC20BalancesForAccountV2({ configOrCurrencyId: config ?? currencyId, address })
+        ? getERC20BalancesForAccountV2({ configOrCurrencyId: coinConfig, address })
         : Promise.resolve([]),
       validatorPromise,
     ]);

--- a/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.test.ts
@@ -92,6 +92,7 @@ describe("getBlockV2", () => {
     });
     expect(hgraphClient.getERC20TransfersByTimestampRange).toHaveBeenCalledTimes(1);
     expect(hgraphClient.getERC20TransfersByTimestampRange).toHaveBeenCalledWith({
+      configOrCurrencyId,
       startTimestamp: "1704067200.123000000",
       endTimestamp: "1704067260.456000000",
       limit: 100,

--- a/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.ts
@@ -151,7 +151,9 @@ export async function getBlockV2({
     throw new Error(`Block ${height} is not available yet`);
   }
 
-  const latestHgraphIndexedTimestampNs = await hgraphClient.getLatestIndexedConsensusTimestamp();
+  const latestHgraphIndexedTimestampNs = await hgraphClient.getLatestIndexedConsensusTimestamp({
+    configOrCurrencyId,
+  });
   const startSeconds = millisToSeconds(start.getTime());
   const endSeconds = millisToSeconds(end.getTime());
   const endNanos = secondsToNanos(endSeconds);
@@ -173,6 +175,7 @@ export async function getBlockV2({
     }),
     hgraphClient
       .getERC20TransfersByTimestampRange({
+        configOrCurrencyId,
         startTimestamp: startSeconds.toFixed(9),
         endTimestamp: endSeconds.toFixed(9),
         limit,

--- a/libs/coin-modules/coin-hedera/src/logic/lastBlock.v2.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/lastBlock.v2.ts
@@ -16,7 +16,7 @@ import { getSyntheticBlock, nanosToSeconds } from "./utils";
  * 3. Convert this timestamp into a synthetic block using a hardcoded time window (10 seconds by default)
  */
 export async function lastBlockV2({
-  configOrCurrencyId: _,
+  configOrCurrencyId,
 }: {
   configOrCurrencyId: HederaCoinConfig | string;
 }): Promise<BlockInfo> {
@@ -25,7 +25,7 @@ export async function lastBlockV2({
   const before = new Date(Date.now() - FINALITY_MS - SYNTHETIC_BLOCK_WINDOW_SECONDS * 1000);
   const [latestTransaction, latestHgraphTimestampNs] = await Promise.all([
     apiClient.getLatestTransaction(before),
-    hgraphClient.getLatestIndexedConsensusTimestamp(),
+    hgraphClient.getLatestIndexedConsensusTimestamp({ configOrCurrencyId }),
   ]);
 
   const lastMirrorTimestamp = latestTransaction.consensus_timestamp;

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
@@ -113,6 +113,7 @@ describe("listOperationsV2", () => {
     });
     expect(hgraphClient.getERC20Transfers).toHaveBeenCalledTimes(1);
     expect(hgraphClient.getERC20Transfers).toHaveBeenCalledWith({
+      configOrCurrencyId: mockCurrency.id,
       address: mockMirrorAccount.account,
       fetchAllPages: true,
       order: mockOrder,

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
@@ -522,6 +522,7 @@ export async function listOperationsV2({
       }),
       hgraphClient
         .getERC20Transfers({
+          configOrCurrencyId: config ?? currencyId,
           address,
           order,
           limit,
@@ -532,7 +533,7 @@ export async function listOperationsV2({
         .then(erc20Transfers =>
           enrichERC20Transfers({ configOrCurrencyId: config ?? currencyId, erc20Transfers }),
         ),
-      hgraphClient.getLatestIndexedConsensusTimestamp(),
+      hgraphClient.getLatestIndexedConsensusTimestamp({ configOrCurrencyId: config ?? currencyId }),
     ]);
 
   // merge transactions, ensuring no duplicates, correct ordering and pagination handling

--- a/libs/coin-modules/coin-hedera/src/network/hgraph.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/hgraph.test.ts
@@ -1,466 +1,515 @@
 import network from "@ledgerhq/live-network";
 import BigNumber from "bignumber.js";
+import { resolveConfig } from "../logic/utils";
+import { getMockedConfig } from "../test/fixtures/config.fixture";
 import { getMockResponse } from "../test/fixtures/network.fixture";
 import { hgraphClient } from "./hgraph";
 
 jest.mock("@ledgerhq/live-network");
+jest.mock("../logic/utils", () => ({
+  ...jest.requireActual("../logic/utils"),
+  resolveConfig: jest.fn(),
+}));
+
 const mockedNetwork = jest.mocked(network);
+const mockedResolveConfig = jest.mocked(resolveConfig);
+
 const getRequestData = (callIndex = 0) =>
   (mockedNetwork.mock.calls[callIndex][0] as { data: { query: string; variables: any } }).data;
 
-describe("getLatestIndexedConsensusTimestamp", () => {
+describe("hgraphClient", () => {
+  const mockConfig = getMockedConfig();
+
   beforeEach(() => {
     jest.resetAllMocks();
+
+    mockedResolveConfig.mockReturnValue(mockConfig);
   });
 
-  it("should fetch and return the latest indexed consensus timestamp", async () => {
-    const mockTimestamp = "1234567890123456789";
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({
-        data: {
-          ethereum_transaction: [{ consensus_timestamp: mockTimestamp }],
+  describe("getLatestIndexedConsensusTimestamp", () => {
+    it("uses the hgraph URL from the resolved config", async () => {
+      const customUrl = "https://custom-hgraph.example.com/graphql";
+
+      mockedResolveConfig.mockReturnValue({
+        ...mockConfig,
+        apiUrls: { ...mockConfig.apiUrls, hgraph: customUrl },
+      });
+      mockedNetwork.mockResolvedValueOnce(
+        getMockResponse({ data: { ethereum_transaction: [{ consensus_timestamp: "1" }] } }),
+      );
+
+      await hgraphClient.getLatestIndexedConsensusTimestamp({ configOrCurrencyId: mockConfig });
+
+      expect(mockedNetwork.mock.calls[0][0].url).toBe(customUrl);
+    });
+
+    it("should fetch and return the latest indexed consensus timestamp", async () => {
+      const mockTimestamp = "1234567890123456789";
+      mockedNetwork.mockResolvedValueOnce(
+        getMockResponse({
+          data: {
+            ethereum_transaction: [{ consensus_timestamp: mockTimestamp }],
+          },
+        }),
+      );
+
+      const result = await hgraphClient.getLatestIndexedConsensusTimestamp({
+        configOrCurrencyId: mockConfig,
+      });
+
+      expect(mockedNetwork).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(new BigNumber(mockTimestamp));
+    });
+
+    it("should throw error when API returns errors", async () => {
+      mockedNetwork.mockResolvedValueOnce(
+        getMockResponse({
+          errors: [{ message: "Database error" }],
+        }),
+      );
+
+      await expect(
+        hgraphClient.getLatestIndexedConsensusTimestamp({ configOrCurrencyId: mockConfig }),
+      ).rejects.toThrow();
+    });
+
+    it("should throw error when no transactions found", async () => {
+      mockedNetwork.mockResolvedValueOnce(
+        getMockResponse({
+          data: {
+            ethereum_transaction: [],
+          },
+        }),
+      );
+
+      await expect(
+        hgraphClient.getLatestIndexedConsensusTimestamp({ configOrCurrencyId: mockConfig }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("getERC20Balances", () => {
+    it("should fetch and return ERC20 balances for an account", async () => {
+      const mockAddress = "0.0.1234";
+      const mockBalances = [
+        {
+          token_id: "0.0.5001",
+          balance: "1000000",
+          balance_timestamp: "1234567890.123456789",
+          created_timestamp: "1234567800.000000000",
         },
-      }),
-    );
-
-    const result = await hgraphClient.getLatestIndexedConsensusTimestamp();
-
-    expect(mockedNetwork).toHaveBeenCalledTimes(1);
-    expect(result).toEqual(new BigNumber(mockTimestamp));
-  });
-
-  it("should throw error when API returns errors", async () => {
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({
-        errors: [{ message: "Database error" }],
-      }),
-    );
-
-    await expect(hgraphClient.getLatestIndexedConsensusTimestamp()).rejects.toThrow();
-  });
-
-  it("should throw error when no transactions found", async () => {
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({
-        data: {
-          ethereum_transaction: [],
+        {
+          token_id: "0.0.5002",
+          balance: "2000000",
+          balance_timestamp: "1234567890.123456789",
+          created_timestamp: "1234567800.000000000",
         },
-      }),
-    );
+      ];
 
-    await expect(hgraphClient.getLatestIndexedConsensusTimestamp()).rejects.toThrow();
+      mockedNetwork.mockResolvedValueOnce(
+        getMockResponse({
+          data: {
+            erc_token_account: mockBalances,
+          },
+        }),
+      );
+
+      const result = await hgraphClient.getERC20Balances({
+        configOrCurrencyId: mockConfig,
+        address: mockAddress,
+      });
+
+      const queryVariables = getRequestData(0).variables;
+      expect(mockedNetwork).toHaveBeenCalledTimes(1);
+      expect(queryVariables.accountId).toBe("1234");
+      expect(result).toEqual(mockBalances);
+    });
+
+    it("should extract account ID correctly from address", async () => {
+      mockedNetwork.mockResolvedValueOnce(
+        getMockResponse({
+          data: {
+            erc_token_account: [],
+          },
+        }),
+      );
+
+      await hgraphClient.getERC20Balances({
+        configOrCurrencyId: mockConfig,
+        address: "0.0.9999",
+      });
+
+      expect(getRequestData(0).variables.accountId).toBe("9999");
+    });
+
+    it("should throw error when API returns errors", async () => {
+      mockedNetwork.mockResolvedValueOnce(
+        getMockResponse({
+          errors: [{ message: "Account not found" }],
+        }),
+      );
+
+      await expect(
+        hgraphClient.getERC20Balances({
+          configOrCurrencyId: mockConfig,
+          address: "0.0.1234",
+        }),
+      ).rejects.toThrow();
+    });
   });
-});
 
-describe("getERC20Balances", () => {
-  beforeEach(() => {
-    jest.resetAllMocks();
-  });
+  describe("getERC20Transfers", () => {
+    it("should return empty array when no token addresses provided", async () => {
+      const result = await hgraphClient.getERC20Transfers({
+        configOrCurrencyId: mockConfig,
+        address: "0.0.1234",
+        tokenEvmAddresses: [],
+        fetchAllPages: true,
+      });
 
-  it("should fetch and return ERC20 balances for an account", async () => {
-    const mockAddress = "0.0.1234";
-    const mockBalances = [
-      {
+      expect(mockedNetwork).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it("should fetch transfers with default parameters", async () => {
+      const mockTransfer = {
         token_id: "0.0.5001",
-        balance: "1000000",
-        balance_timestamp: "1234567890.123456789",
-        created_timestamp: "1234567800.000000000",
-      },
-      {
-        token_id: "0.0.5002",
-        balance: "2000000",
-        balance_timestamp: "1234567890.123456789",
-        created_timestamp: "1234567800.000000000",
-      },
-    ];
+        token_evm_address: "0xabc123",
+        sender_evm_address: "0x111",
+        sender_account_id: "0.0.1234",
+        receiver_evm_address: "0x222",
+        receiver_account_id: "0.0.5678",
+        payer_account_id: "0.0.1234",
+        amount: "1000",
+        transfer_type: "transfer",
+        consensus_timestamp: "1234567890123456789",
+        transaction_hash: "0xhash1",
+      };
 
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({
-        data: {
-          erc_token_account: mockBalances,
-        },
-      }),
-    );
-
-    const result = await hgraphClient.getERC20Balances({ address: mockAddress });
-
-    const queryVariables = getRequestData(0).variables;
-    expect(mockedNetwork).toHaveBeenCalledTimes(1);
-    expect(queryVariables.accountId).toBe("1234");
-    expect(result).toEqual(mockBalances);
-  });
-
-  it("should extract account ID correctly from address", async () => {
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({
-        data: {
-          erc_token_account: [],
-        },
-      }),
-    );
-
-    await hgraphClient.getERC20Balances({ address: "0.0.9999" });
-
-    expect(getRequestData(0).variables.accountId).toBe("9999");
-  });
-
-  it("should throw error when API returns errors", async () => {
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({
-        errors: [{ message: "Account not found" }],
-      }),
-    );
-
-    await expect(hgraphClient.getERC20Balances({ address: "0.0.1234" })).rejects.toThrow();
-  });
-});
-
-describe("getERC20Transfers", () => {
-  beforeEach(() => {
-    jest.resetAllMocks();
-  });
-
-  it("should return empty array when no token addresses provided", async () => {
-    const result = await hgraphClient.getERC20Transfers({
-      address: "0.0.1234",
-      tokenEvmAddresses: [],
-      fetchAllPages: true,
-    });
-
-    expect(mockedNetwork).not.toHaveBeenCalled();
-    expect(result).toEqual([]);
-  });
-
-  it("should fetch transfers with default parameters", async () => {
-    const mockTransfer = {
-      token_id: "0.0.5001",
-      token_evm_address: "0xabc123",
-      sender_evm_address: "0x111",
-      sender_account_id: "0.0.1234",
-      receiver_evm_address: "0x222",
-      receiver_account_id: "0.0.5678",
-      payer_account_id: "0.0.1234",
-      amount: "1000",
-      transfer_type: "transfer",
-      consensus_timestamp: "1234567890123456789",
-      transaction_hash: "0xhash1",
-    };
-
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({
-        data: {
-          erc_token_transfer: [mockTransfer],
-        },
-      }),
-    );
-
-    const result = await hgraphClient.getERC20Transfers({
-      address: mockTransfer.payer_account_id,
-      tokenEvmAddresses: [mockTransfer.token_evm_address],
-      fetchAllPages: true,
-    });
-
-    const queryVariables = getRequestData(0).variables;
-    expect(mockedNetwork).toHaveBeenCalledTimes(1);
-    expect(result).toEqual([mockTransfer]);
-    expect(queryVariables.accountId).toBe("1234");
-    expect(queryVariables.limit).toBe(100);
-  });
-
-  it("should keep fetching all pages when fetchAllPages is true", async () => {
-    const mockTransfers1 = [
-      { consensus_timestamp: "1000000000000000000", transaction_hash: "0xhash1" },
-    ];
-    const mockTransfers2 = [
-      { consensus_timestamp: "2000000000000000000", transaction_hash: "0xhash2" },
-    ];
-    const mockTransfers3 = [
-      { consensus_timestamp: "3000000000000000000", transaction_hash: "0xhash3" },
-    ];
-
-    mockedNetwork
-      .mockResolvedValueOnce(
+      mockedNetwork.mockResolvedValueOnce(
         getMockResponse({
-          data: { erc_token_transfer: mockTransfers1 },
-        }),
-      )
-      .mockResolvedValueOnce(
-        getMockResponse({
-          data: { erc_token_transfer: mockTransfers2 },
-        }),
-      )
-      .mockResolvedValueOnce(
-        getMockResponse({
-          data: { erc_token_transfer: mockTransfers3 },
-        }),
-      )
-      .mockResolvedValueOnce(
-        getMockResponse({
-          data: { erc_token_transfer: [] },
+          data: {
+            erc_token_transfer: [mockTransfer],
+          },
         }),
       );
 
-    const result = await hgraphClient.getERC20Transfers({
-      address: "0.0.1234",
-      tokenEvmAddresses: ["0xabc123"],
-      limit: 1,
-      fetchAllPages: true,
+      const result = await hgraphClient.getERC20Transfers({
+        configOrCurrencyId: mockConfig,
+        address: mockTransfer.payer_account_id,
+        tokenEvmAddresses: [mockTransfer.token_evm_address],
+        fetchAllPages: true,
+      });
+
+      const queryVariables = getRequestData(0).variables;
+      expect(mockedNetwork).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([mockTransfer]);
+      expect(queryVariables.accountId).toBe("1234");
+      expect(queryVariables.limit).toBe(100);
     });
 
-    expect(mockedNetwork).toHaveBeenCalledTimes(4);
-    expect(result.map(t => t.consensus_timestamp)).toEqual([
-      "1000000000000000000",
-      "2000000000000000000",
-      "3000000000000000000",
-    ]);
-  });
+    it("should keep fetching all pages when fetchAllPages is true", async () => {
+      const mockTransfers1 = [
+        { consensus_timestamp: "1000000000000000000", transaction_hash: "0xhash1" },
+      ];
+      const mockTransfers2 = [
+        { consensus_timestamp: "2000000000000000000", transaction_hash: "0xhash2" },
+      ];
+      const mockTransfers3 = [
+        { consensus_timestamp: "3000000000000000000", transaction_hash: "0xhash3" },
+      ];
 
-  it("should paginate when fetchAllPages is false", async () => {
-    const mockTransfers1 = [
-      { consensus_timestamp: "1000000000000000000", transaction_hash: "0xhash1" },
-      { consensus_timestamp: "1100000000000000000", transaction_hash: "0xhash1a" },
-    ];
-    const mockTransfers2 = [
-      { consensus_timestamp: "2000000000000000000", transaction_hash: "0xhash2" },
-      { consensus_timestamp: "2100000000000000000", transaction_hash: "0xhash2a" },
-    ];
+      mockedNetwork
+        .mockResolvedValueOnce(
+          getMockResponse({
+            data: { erc_token_transfer: mockTransfers1 },
+          }),
+        )
+        .mockResolvedValueOnce(
+          getMockResponse({
+            data: { erc_token_transfer: mockTransfers2 },
+          }),
+        )
+        .mockResolvedValueOnce(
+          getMockResponse({
+            data: { erc_token_transfer: mockTransfers3 },
+          }),
+        )
+        .mockResolvedValueOnce(
+          getMockResponse({
+            data: { erc_token_transfer: [] },
+          }),
+        );
 
-    mockedNetwork
-      .mockResolvedValueOnce(
-        getMockResponse({
-          data: { erc_token_transfer: mockTransfers1 },
-        }),
-      )
-      .mockResolvedValueOnce(
-        getMockResponse({
-          data: { erc_token_transfer: mockTransfers2 },
-        }),
-      );
-
-    const result = await hgraphClient.getERC20Transfers({
-      address: "0.0.1234",
-      tokenEvmAddresses: ["0xabc123"],
-      limit: 2,
-      fetchAllPages: false,
-    });
-
-    expect(mockedNetwork).toHaveBeenCalledTimes(1);
-    expect(result.map(t => t.consensus_timestamp)).toEqual([
-      "1000000000000000000",
-      "1100000000000000000",
-    ]);
-  });
-
-  it("should handle timestamp parameter correctly", async () => {
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({
-        data: { erc_token_transfer: [] },
-      }),
-    );
-
-    await hgraphClient.getERC20Transfers({
-      address: "0.0.1234",
-      tokenEvmAddresses: ["0xabc123"],
-      timestamp: "1234567890.123456789",
-      fetchAllPages: true,
-    });
-
-    const query = getRequestData(0).query;
-    const queryVariables = getRequestData(0).variables;
-    expect(query).toContain("consensus_timestamp: { _gt: $cursor }");
-    expect(queryVariables.cursor).toBe("1234567890123456789");
-  });
-
-  it("should use correct pagination direction for desc order", async () => {
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({
-        data: { erc_token_transfer: [] },
-      }),
-    );
-
-    await hgraphClient.getERC20Transfers({
-      address: "0.0.1234",
-      tokenEvmAddresses: ["0xabc123"],
-      order: "desc",
-      fetchAllPages: false,
-    });
-
-    const query = getRequestData(0).query;
-    expect(query).toContain("order_by: { consensus_timestamp: desc }");
-  });
-
-  it("should throw error when API returns errors", async () => {
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({
-        errors: [{ message: "Query failed" }],
-      }),
-    );
-
-    await expect(
-      hgraphClient.getERC20Transfers({
+      const result = await hgraphClient.getERC20Transfers({
+        configOrCurrencyId: mockConfig,
         address: "0.0.1234",
         tokenEvmAddresses: ["0xabc123"],
+        limit: 1,
         fetchAllPages: true,
-      }),
-    ).rejects.toThrow();
-  });
-});
+      });
 
-describe("getERC20TransfersByTimestampRange", () => {
-  beforeEach(() => {
-    jest.resetAllMocks();
-  });
-
-  it("should fetch transfers within timestamp range", async () => {
-    const mockTransfers = [
-      {
-        token_id: "0.0.5001",
-        consensus_timestamp: "1500000000000000000",
-        transaction_hash: "0xhash1",
-      },
-    ];
-
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({
-        data: { erc_token_transfer: mockTransfers },
-      }),
-    );
-
-    const result = await hgraphClient.getERC20TransfersByTimestampRange({
-      startTimestamp: "1000.000000000",
-      endTimestamp: "2000.000000000",
+      expect(mockedNetwork).toHaveBeenCalledTimes(4);
+      expect(result.map(t => t.consensus_timestamp)).toEqual([
+        "1000000000000000000",
+        "2000000000000000000",
+        "3000000000000000000",
+      ]);
     });
 
-    const queryVariables = getRequestData(0).variables;
-    expect(mockedNetwork).toHaveBeenCalledTimes(1);
-    expect(result).toEqual(mockTransfers);
-    expect(queryVariables.startTimestamp).toBe("1000000000000");
-    expect(queryVariables.endTimestamp).toBe("2000000000000");
-  });
+    it("should paginate when fetchAllPages is false", async () => {
+      const mockTransfers1 = [
+        { consensus_timestamp: "1000000000000000000", transaction_hash: "0xhash1" },
+        { consensus_timestamp: "1100000000000000000", transaction_hash: "0xhash1a" },
+      ];
+      const mockTransfers2 = [
+        { consensus_timestamp: "2000000000000000000", transaction_hash: "0xhash2" },
+        { consensus_timestamp: "2100000000000000000", transaction_hash: "0xhash2a" },
+      ];
 
-  it("should normalize timestamps by removing dots", async () => {
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({
-        data: { erc_token_transfer: [] },
-      }),
-    );
+      mockedNetwork
+        .mockResolvedValueOnce(
+          getMockResponse({
+            data: { erc_token_transfer: mockTransfers1 },
+          }),
+        )
+        .mockResolvedValueOnce(
+          getMockResponse({
+            data: { erc_token_transfer: mockTransfers2 },
+          }),
+        );
 
-    await hgraphClient.getERC20TransfersByTimestampRange({
-      startTimestamp: "1234.567890123",
-      endTimestamp: "5678.901234567",
+      const result = await hgraphClient.getERC20Transfers({
+        configOrCurrencyId: mockConfig,
+        address: "0.0.1234",
+        tokenEvmAddresses: ["0xabc123"],
+        limit: 2,
+        fetchAllPages: false,
+      });
+
+      expect(mockedNetwork).toHaveBeenCalledTimes(1);
+      expect(result.map(t => t.consensus_timestamp)).toEqual([
+        "1000000000000000000",
+        "1100000000000000000",
+      ]);
     });
 
-    const queryVariables = getRequestData(0).variables;
-    expect(queryVariables.startTimestamp).toBe("1234567890123");
-    expect(queryVariables.endTimestamp).toBe("5678901234567");
-  });
-
-  it("should fetch all pages until no more results", async () => {
-    mockedNetwork
-      .mockResolvedValueOnce(
-        getMockResponse({
-          data: {
-            erc_token_transfer: [
-              { consensus_timestamp: "1100000000000000000", transaction_hash: "0xhash1" },
-            ],
-          },
-        }),
-      )
-      .mockResolvedValueOnce(
-        getMockResponse({
-          data: {
-            erc_token_transfer: [
-              { consensus_timestamp: "1200000000000000000", transaction_hash: "0xhash2" },
-            ],
-          },
-        }),
-      )
-      .mockResolvedValueOnce(
+    it("should handle timestamp parameter correctly", async () => {
+      mockedNetwork.mockResolvedValueOnce(
         getMockResponse({
           data: { erc_token_transfer: [] },
         }),
       );
 
-    const result = await hgraphClient.getERC20TransfersByTimestampRange({
-      startTimestamp: "1000.000000000",
-      endTimestamp: "2000.000000000",
-      limit: 1,
+      await hgraphClient.getERC20Transfers({
+        configOrCurrencyId: mockConfig,
+        address: "0.0.1234",
+        tokenEvmAddresses: ["0xabc123"],
+        timestamp: "1234567890.123456789",
+        fetchAllPages: true,
+      });
+
+      const query = getRequestData(0).query;
+      const queryVariables = getRequestData(0).variables;
+      expect(query).toContain("consensus_timestamp: { _gt: $cursor }");
+      expect(queryVariables.cursor).toBe("1234567890123456789");
     });
 
-    expect(mockedNetwork).toHaveBeenCalledTimes(3);
-    expect(result.map(t => t.consensus_timestamp)).toEqual([
-      "1100000000000000000",
-      "1200000000000000000",
-    ]);
-  });
-
-  it("should use cursor for subsequent pages", async () => {
-    mockedNetwork
-      .mockResolvedValueOnce(
-        getMockResponse({
-          data: {
-            erc_token_transfer: [
-              { consensus_timestamp: "1100000000000000000", transaction_hash: "0xhash1" },
-            ],
-          },
-        }),
-      )
-      .mockResolvedValueOnce(
+    it("should use correct pagination direction for desc order", async () => {
+      mockedNetwork.mockResolvedValueOnce(
         getMockResponse({
           data: { erc_token_transfer: [] },
         }),
       );
 
-    await hgraphClient.getERC20TransfersByTimestampRange({
-      startTimestamp: "1000.000000000",
-      endTimestamp: "2000.000000000",
-      limit: 1,
+      await hgraphClient.getERC20Transfers({
+        configOrCurrencyId: mockConfig,
+        address: "0.0.1234",
+        tokenEvmAddresses: ["0xabc123"],
+        order: "desc",
+        fetchAllPages: false,
+      });
+
+      const query = getRequestData(0).query;
+      expect(query).toContain("order_by: { consensus_timestamp: desc }");
     });
 
-    const firstCall = mockedNetwork.mock.calls[0][0] as {
-      data: { query: string; variables: Record<string, unknown> };
-    };
-    const secondCall = mockedNetwork.mock.calls[1][0] as {
-      data: { query: string; variables: Record<string, unknown> };
-    };
+    it("should throw error when API returns errors", async () => {
+      mockedNetwork.mockResolvedValueOnce(
+        getMockResponse({
+          errors: [{ message: "Query failed" }],
+        }),
+      );
 
-    // First call should use _gte with startTimestamp
-    expect(firstCall.data.query).toContain("_gte: $startTimestamp");
-    expect(firstCall.data.variables).not.toHaveProperty("cursor");
-    // Second call should use _gt with cursor
-    expect(secondCall.data.query).toContain("_gt: $cursor");
-    expect(secondCall.data.variables.cursor).toBe("1100000000000000000");
-  });
-
-  it("should support custom order parameter", async () => {
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({
-        data: { erc_token_transfer: [] },
-      }),
-    );
-
-    await hgraphClient.getERC20TransfersByTimestampRange({
-      startTimestamp: "1000.000000000",
-      endTimestamp: "2000.000000000",
-      order: "asc",
+      await expect(
+        hgraphClient.getERC20Transfers({
+          configOrCurrencyId: mockConfig,
+          address: "0.0.1234",
+          tokenEvmAddresses: ["0xabc123"],
+          fetchAllPages: true,
+        }),
+      ).rejects.toThrow();
     });
-
-    const query = getRequestData(0).query;
-    expect(query).toContain("order_by: { consensus_timestamp: asc }");
   });
 
-  it("should throw error when API returns errors", async () => {
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({
-        errors: [{ message: "Invalid timestamp range" }],
-      }),
-    );
+  describe("getERC20TransfersByTimestampRange", () => {
+    it("should fetch transfers within timestamp range", async () => {
+      const mockTransfers = [
+        {
+          token_id: "0.0.5001",
+          consensus_timestamp: "1500000000000000000",
+          transaction_hash: "0xhash1",
+        },
+      ];
 
-    await expect(
-      hgraphClient.getERC20TransfersByTimestampRange({
+      mockedNetwork.mockResolvedValueOnce(
+        getMockResponse({
+          data: { erc_token_transfer: mockTransfers },
+        }),
+      );
+
+      const result = await hgraphClient.getERC20TransfersByTimestampRange({
+        configOrCurrencyId: mockConfig,
         startTimestamp: "1000.000000000",
         endTimestamp: "2000.000000000",
-      }),
-    ).rejects.toThrow();
+      });
+
+      const queryVariables = getRequestData(0).variables;
+      expect(mockedNetwork).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(mockTransfers);
+      expect(queryVariables.startTimestamp).toBe("1000000000000");
+      expect(queryVariables.endTimestamp).toBe("2000000000000");
+    });
+
+    it("should normalize timestamps by removing dots", async () => {
+      mockedNetwork.mockResolvedValueOnce(
+        getMockResponse({
+          data: { erc_token_transfer: [] },
+        }),
+      );
+
+      await hgraphClient.getERC20TransfersByTimestampRange({
+        configOrCurrencyId: mockConfig,
+        startTimestamp: "1234.567890123",
+        endTimestamp: "5678.901234567",
+      });
+
+      const queryVariables = getRequestData(0).variables;
+      expect(queryVariables.startTimestamp).toBe("1234567890123");
+      expect(queryVariables.endTimestamp).toBe("5678901234567");
+    });
+
+    it("should fetch all pages until no more results", async () => {
+      mockedNetwork
+        .mockResolvedValueOnce(
+          getMockResponse({
+            data: {
+              erc_token_transfer: [
+                { consensus_timestamp: "1100000000000000000", transaction_hash: "0xhash1" },
+              ],
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          getMockResponse({
+            data: {
+              erc_token_transfer: [
+                { consensus_timestamp: "1200000000000000000", transaction_hash: "0xhash2" },
+              ],
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          getMockResponse({
+            data: { erc_token_transfer: [] },
+          }),
+        );
+
+      const result = await hgraphClient.getERC20TransfersByTimestampRange({
+        configOrCurrencyId: mockConfig,
+        startTimestamp: "1000.000000000",
+        endTimestamp: "2000.000000000",
+        limit: 1,
+      });
+
+      expect(mockedNetwork).toHaveBeenCalledTimes(3);
+      expect(result.map(t => t.consensus_timestamp)).toEqual([
+        "1100000000000000000",
+        "1200000000000000000",
+      ]);
+    });
+
+    it("should use cursor for subsequent pages", async () => {
+      mockedNetwork
+        .mockResolvedValueOnce(
+          getMockResponse({
+            data: {
+              erc_token_transfer: [
+                { consensus_timestamp: "1100000000000000000", transaction_hash: "0xhash1" },
+              ],
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          getMockResponse({
+            data: { erc_token_transfer: [] },
+          }),
+        );
+
+      await hgraphClient.getERC20TransfersByTimestampRange({
+        configOrCurrencyId: mockConfig,
+        startTimestamp: "1000.000000000",
+        endTimestamp: "2000.000000000",
+        limit: 1,
+      });
+
+      const firstCall = mockedNetwork.mock.calls[0][0] as {
+        data: { query: string; variables: Record<string, unknown> };
+      };
+      const secondCall = mockedNetwork.mock.calls[1][0] as {
+        data: { query: string; variables: Record<string, unknown> };
+      };
+
+      // First call should use _gte with startTimestamp
+      expect(firstCall.data.query).toContain("_gte: $startTimestamp");
+      expect(firstCall.data.variables).not.toHaveProperty("cursor");
+      // Second call should use _gt with cursor
+      expect(secondCall.data.query).toContain("_gt: $cursor");
+      expect(secondCall.data.variables.cursor).toBe("1100000000000000000");
+    });
+
+    it("should support custom order parameter", async () => {
+      mockedNetwork.mockResolvedValueOnce(
+        getMockResponse({
+          data: { erc_token_transfer: [] },
+        }),
+      );
+
+      await hgraphClient.getERC20TransfersByTimestampRange({
+        configOrCurrencyId: mockConfig,
+        startTimestamp: "1000.000000000",
+        endTimestamp: "2000.000000000",
+        order: "asc",
+      });
+
+      const query = getRequestData(0).query;
+      expect(query).toContain("order_by: { consensus_timestamp: asc }");
+    });
+
+    it("should throw error when API returns errors", async () => {
+      mockedNetwork.mockResolvedValueOnce(
+        getMockResponse({
+          errors: [{ message: "Invalid timestamp range" }],
+        }),
+      );
+
+      await expect(
+        hgraphClient.getERC20TransfersByTimestampRange({
+          configOrCurrencyId: mockConfig,
+          startTimestamp: "1000.000000000",
+          endTimestamp: "2000.000000000",
+        }),
+      ).rejects.toThrow();
+    });
   });
 });

--- a/libs/coin-modules/coin-hedera/src/network/hgraph.ts
+++ b/libs/coin-modules/coin-hedera/src/network/hgraph.ts
@@ -1,8 +1,9 @@
-import { getEnv } from "@ledgerhq/live-env";
 import network from "@ledgerhq/live-network";
 import type { LiveNetworkResponse } from "@ledgerhq/live-network/network";
 import BigNumber from "bignumber.js";
 import invariant from "invariant";
+import { type HederaCoinConfig } from "../config";
+import { resolveConfig } from "../logic/utils";
 import type {
   ERC20TokenAccount,
   ERC20TokenTransfer,
@@ -27,9 +28,14 @@ const throwOnGraphQLErrors: <T>(
   }
 };
 
-async function getLatestIndexedConsensusTimestamp(): Promise<BigNumber> {
+async function getLatestIndexedConsensusTimestamp({
+  configOrCurrencyId,
+}: {
+  configOrCurrencyId: HederaCoinConfig | string;
+}): Promise<BigNumber> {
+  const config = resolveConfig(configOrCurrencyId);
   const res = await network<HgraphLatestIndexedConsensusTimestampResponse>({
-    url: getEnv("API_HEDERA_HGRAPH"),
+    url: config.apiUrls.hgraph,
     method: "POST",
     data: {
       query: `
@@ -53,9 +59,17 @@ async function getLatestIndexedConsensusTimestamp(): Promise<BigNumber> {
   return new BigNumber(lastTransactionTimestamp);
 }
 
-async function getERC20Balances({ address }: { address: string }): Promise<ERC20TokenAccount[]> {
+async function getERC20Balances({
+  configOrCurrencyId,
+  address,
+}: {
+  configOrCurrencyId: HederaCoinConfig | string;
+  address: string;
+}): Promise<ERC20TokenAccount[]> {
+  const config = resolveConfig(configOrCurrencyId);
+
   const res = await network<HgraphErcTokenAccountResponse>({
-    url: getEnv("API_HEDERA_HGRAPH"),
+    url: config.apiUrls.hgraph,
     method: "POST",
     data: {
       query: `
@@ -84,6 +98,7 @@ async function getERC20Balances({ address }: { address: string }): Promise<ERC20
 }
 
 async function getERC20Transfers({
+  configOrCurrencyId,
   address,
   tokenEvmAddresses,
   timestamp,
@@ -91,6 +106,7 @@ async function getERC20Transfers({
   order = "desc",
   fetchAllPages,
 }: {
+  configOrCurrencyId: HederaCoinConfig | string;
   address: string;
   tokenEvmAddresses: string[];
   fetchAllPages: boolean;
@@ -102,6 +118,7 @@ async function getERC20Transfers({
     return [];
   }
 
+  const config = resolveConfig(configOrCurrencyId);
   let hasMorePages = true;
   let cursor = timestamp?.replace(".", "") ?? null;
   const transfers: ERC20TokenTransfer[] = [];
@@ -109,7 +126,7 @@ async function getERC20Transfers({
 
   while (hasMorePages) {
     const res = await network<HgraphErcTokenTransferResponse>({
-      url: getEnv("API_HEDERA_HGRAPH"),
+      url: config.apiUrls.hgraph,
       method: "POST",
       data: {
         query: `
@@ -182,16 +199,19 @@ async function getERC20Transfers({
 }
 
 async function getERC20TransfersByTimestampRange({
+  configOrCurrencyId,
   startTimestamp,
   endTimestamp,
   order = "desc",
   limit = 100,
 }: {
+  configOrCurrencyId: HederaCoinConfig | string;
   startTimestamp: string;
   endTimestamp: string;
   order?: "asc" | "desc";
   limit?: number;
 }): Promise<ERC20TokenTransfer[]> {
+  const config = resolveConfig(configOrCurrencyId);
   const transfers: ERC20TokenTransfer[] = [];
   let hasMorePages = true;
   let cursor: string | null = null;
@@ -200,7 +220,7 @@ async function getERC20TransfersByTimestampRange({
 
   while (hasMorePages) {
     const res: LiveNetworkResponse<HgraphErcTokenTransferResponse> = await network({
-      url: getEnv("API_HEDERA_HGRAPH"),
+      url: config.apiUrls.hgraph,
       method: "POST",
       data: {
         query: `

--- a/libs/coin-modules/coin-hedera/src/network/rpc.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/rpc.test.ts
@@ -1,77 +1,120 @@
 import { Client, Transaction, TransactionResponse } from "@hashgraph/sdk";
+import coinConfig from "../config";
+import { getMockedConfig } from "../test/fixtures/config.fixture";
+import { getMockedCurrency } from "../test/fixtures/currency.fixture";
 import { rpcClient } from "./rpc";
+
+const mockCurrency = getMockedCurrency();
 
 const mockClient = {
   close: jest.fn(),
   setMaxNodesPerTransaction: jest.fn().mockReturnThis(),
   setNetwork: jest.fn().mockReturnThis(),
+  updateNetwork: jest.fn(),
+} as unknown as Client;
+
+const mockTestnetClient = {
+  close: jest.fn(),
+  setMaxNodesPerTransaction: jest.fn().mockReturnThis(),
+  setNetwork: jest.fn().mockReturnThis(),
+  updateNetwork: jest.fn(),
 } as unknown as Client;
 
 jest.mock("@hashgraph/sdk", () => {
   return {
     Transaction: jest.fn(),
     Client: {
-      forMainnetAsync: jest.fn(async () => mockClient),
+      forMainnetAsync: jest.fn(() => Promise.resolve(mockClient)),
+      forTestnetAsync: jest.fn(() => Promise.resolve(mockTestnetClient)),
     },
   };
 });
 
-describe("getInstance", () => {
+describe("rpcClient", () => {
+  const mockConfig = getMockedConfig();
+
+  beforeAll(() => {
+    coinConfig.setCoinConfig(() => mockConfig);
+  });
+
   beforeEach(async () => {
     jest.clearAllMocks();
     await rpcClient._resetInstance();
   });
 
-  it("returns cached client instance for multiple calls", async () => {
-    const client1 = await rpcClient.getInstance();
-    const client2 = await rpcClient.getInstance();
+  describe("getInstance", () => {
+    it("returns cached client instance for multiple calls", async () => {
+      const client1 = await rpcClient.getInstance(mockCurrency.id);
+      const client2 = await rpcClient.getInstance(mockCurrency.id);
 
-    expect(Client.forMainnetAsync).toHaveBeenCalledTimes(1);
-    expect(client1).toBe(mockClient);
-    expect(client2).toBe(client1);
+      expect(Client.forMainnetAsync).toHaveBeenCalledTimes(1);
+      expect(client1).toBe(mockClient);
+      expect(client2).toBe(client1);
+    });
+
+    it("handles concurrent calls without creating multiple clients", async () => {
+      const promises = [...Array(10)].map(() => rpcClient.getInstance(mockCurrency.id));
+      const clients = await Promise.all(promises);
+
+      expect(Client.forMainnetAsync).toHaveBeenCalledTimes(1);
+      expect(clients.every(c => c === clients[0])).toBe(true);
+    });
+
+    it("creates separate cached clients for mainnet and testnet", async () => {
+      const testnetConfig = { ...mockConfig, networkType: "testnet" as const };
+
+      const mainnetClient = await rpcClient.getInstance(mockConfig);
+      const testnetClient = await rpcClient.getInstance(testnetConfig);
+      // second call to each - must still be cached
+      const mainnetClient2 = await rpcClient.getInstance(mockConfig);
+      const testnetClient2 = await rpcClient.getInstance(testnetConfig);
+
+      expect(Client.forMainnetAsync).toHaveBeenCalledTimes(1);
+      expect(Client.forTestnetAsync).toHaveBeenCalledTimes(1);
+      expect(mainnetClient).toBe(mockClient);
+      expect(testnetClient).toBe(mockTestnetClient);
+      expect(mainnetClient2).toBe(mainnetClient);
+      expect(testnetClient2).toBe(testnetClient);
+    });
   });
 
-  it("handles concurrent calls without creating multiple clients", async () => {
-    const promises = [...Array(10)].map(() => rpcClient.getInstance());
-    const clients = await Promise.all(promises);
+  describe("broadcastTransaction", () => {
+    it("executes the transaction using the client", async () => {
+      const expectedResponse = { transactionId: "test-tx-id" } as unknown as TransactionResponse;
+      const mockedExecute = jest.fn().mockResolvedValue(expectedResponse);
+      const mockTransaction = { execute: mockedExecute } as unknown as Transaction;
 
-    expect(Client.forMainnetAsync).toHaveBeenCalledTimes(1);
-    expect(clients.every(c => c === clients[0])).toBe(true);
-  });
-});
+      const response = await rpcClient.broadcastTransaction({
+        configOrCurrencyId: mockCurrency.id,
+        transaction: mockTransaction,
+      });
 
-describe("broadcastTransaction", () => {
-  beforeEach(async () => {
-    jest.clearAllMocks();
-    await rpcClient._resetInstance();
-  });
+      expect(mockedExecute).toHaveBeenCalledTimes(1);
+      expect(mockedExecute).toHaveBeenCalledWith(mockClient);
+      expect(response).toBe(expectedResponse);
+    });
 
-  it("executes the transaction using the client", async () => {
-    const expectedResponse = { transactionId: "test-tx-id" } as unknown as TransactionResponse;
-    const mockedExecute = jest.fn().mockResolvedValue(expectedResponse);
-    const mockTransaction = { execute: mockedExecute } as unknown as Transaction;
+    it("reuses the same client instance for multiple calls", async () => {
+      const mockedExecute1 = jest.fn();
+      const mockedExecute2 = jest.fn();
 
-    const response = await rpcClient.broadcastTransaction(mockTransaction);
+      const mockTransaction1 = { execute: mockedExecute1 } as unknown as Transaction;
+      const mockTransaction2 = { execute: mockedExecute2 } as unknown as Transaction;
 
-    expect(mockedExecute).toHaveBeenCalledTimes(1);
-    expect(mockedExecute).toHaveBeenCalledWith(mockClient);
-    expect(response).toBe(expectedResponse);
-  });
+      await rpcClient.broadcastTransaction({
+        configOrCurrencyId: mockCurrency.id,
+        transaction: mockTransaction1,
+      });
+      await rpcClient.broadcastTransaction({
+        configOrCurrencyId: mockCurrency.id,
+        transaction: mockTransaction2,
+      });
 
-  it("reuses the same client instance for multiple calls", async () => {
-    const mockedExecute1 = jest.fn();
-    const mockedExecute2 = jest.fn();
-
-    const mockTransaction1 = { execute: mockedExecute1 } as unknown as Transaction;
-    const mockTransaction2 = { execute: mockedExecute2 } as unknown as Transaction;
-
-    await rpcClient.broadcastTransaction(mockTransaction1);
-    await rpcClient.broadcastTransaction(mockTransaction2);
-
-    expect(Client.forMainnetAsync).toHaveBeenCalledTimes(1);
-    expect(mockedExecute1).toHaveBeenCalledTimes(1);
-    expect(mockedExecute2).toHaveBeenCalledTimes(1);
-    expect(mockedExecute1).toHaveBeenCalledWith(mockClient);
-    expect(mockedExecute2).toHaveBeenCalledWith(mockClient);
+      expect(Client.forMainnetAsync).toHaveBeenCalledTimes(1);
+      expect(mockedExecute1).toHaveBeenCalledTimes(1);
+      expect(mockedExecute2).toHaveBeenCalledTimes(1);
+      expect(mockedExecute1).toHaveBeenCalledWith(mockClient);
+      expect(mockedExecute2).toHaveBeenCalledWith(mockClient);
+    });
   });
 });

--- a/libs/coin-modules/coin-hedera/src/network/rpc.ts
+++ b/libs/coin-modules/coin-hedera/src/network/rpc.ts
@@ -1,37 +1,59 @@
 import type { Transaction as HederaTransaction, TransactionResponse } from "@hashgraph/sdk";
 import { Client } from "@hashgraph/sdk";
+import { type HederaCoinConfig } from "../config";
+import { resolveConfig } from "../logic/utils";
 
-let _hederaClientPromise: Promise<Client> | null = null;
-
-async function broadcastTransaction(transaction: HederaTransaction): Promise<TransactionResponse> {
-  return transaction.execute(await getInstance());
+async function broadcastTransaction({
+  configOrCurrencyId,
+  transaction,
+}: {
+  configOrCurrencyId: HederaCoinConfig | string;
+  transaction: HederaTransaction;
+}): Promise<TransactionResponse> {
+  return transaction.execute(await getInstance(configOrCurrencyId));
 }
 
-async function createClient(): Promise<Client> {
-  const client = await Client.forMainnetAsync();
+const _hederaClients: Map<string, Promise<Client>> = new Map();
+
+async function createClient(networkType: string): Promise<Client> {
+  const client =
+    networkType === "mainnet" ? await Client.forMainnetAsync() : await Client.forTestnetAsync();
+
+  // limit max nodes per transaction to 1 to avoid multiple signatures
   client.setMaxNodesPerTransaction(1);
+
   return client;
 }
 
-async function getInstance(): Promise<Client> {
-  _hederaClientPromise ??= createClient().catch(error => {
-    _hederaClientPromise = null;
-    throw error;
-  });
+async function getInstance(configOrCurrencyId: HederaCoinConfig | string): Promise<Client> {
+  const { networkType } = resolveConfig(configOrCurrencyId);
 
-  return _hederaClientPromise;
+  if (!_hederaClients.has(networkType)) {
+    const promise = createClient(networkType).catch(error => {
+      _hederaClients.delete(networkType);
+      throw error;
+    });
+
+    _hederaClients.set(networkType, promise);
+  }
+
+  return _hederaClients.get(networkType)!;
 }
 
-// for testing purposes only, used to reset singleton client instance
+// for testing purposes only, used to reset singleton client instances
 async function _resetInstance() {
-  try {
-    const client = await _hederaClientPromise;
-    client?.close();
-  } catch {
-    // intentionally ignored during clean up
-  } finally {
-    _hederaClientPromise = null;
+  const promises = [..._hederaClients.values()];
+
+  for (const promise of promises) {
+    try {
+      const client = await promise;
+      client?.close();
+    } catch {
+      // intentionally ignored during clean up
+    }
   }
+
+  _hederaClients.clear();
 }
 
 export const rpcClient = {

--- a/libs/coin-modules/coin-hedera/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.test.ts
@@ -27,6 +27,7 @@ import { getMockedThirdwebTransaction } from "../test/fixtures/thirdweb.fixture"
 import type { HederaMirrorCoinTransfer, HederaMirrorTransaction } from "../types";
 import { apiClient } from "./api";
 import { hgraphClient } from "./hgraph";
+import { rpcClient } from "./rpc";
 import {
   analyzeStakingOperation,
   calculateUncommittedBalanceChange,
@@ -55,6 +56,10 @@ describe("network utils", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await rpcClient._resetInstance();
   });
 
   afterEach(() => {
@@ -363,6 +368,7 @@ describe("network utils", () => {
 
       expect(hgraphClient.getERC20Balances).toHaveBeenCalledTimes(1);
       expect(hgraphClient.getERC20Balances).toHaveBeenCalledWith({
+        configOrCurrencyId: mockCurrency.id,
         address: mockAccount.freshAddress,
       });
       expect(res).toEqual([

--- a/libs/coin-modules/coin-hedera/src/network/utils.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.ts
@@ -149,7 +149,7 @@ export async function getERC20BalancesForAccount({
 }
 
 export async function getERC20BalancesForAccountV2({
-  configOrCurrencyId: _,
+  configOrCurrencyId,
   address,
 }: {
   configOrCurrencyId: HederaCoinConfig | string;
@@ -157,7 +157,7 @@ export async function getERC20BalancesForAccountV2({
 }): Promise<HederaERC20TokenBalance[]> {
   const balances: HederaERC20TokenBalance[] = [];
 
-  const rawBalances = await hgraphClient.getERC20Balances({ address });
+  const rawBalances = await hgraphClient.getERC20Balances({ configOrCurrencyId, address });
 
   for (const rawBalance of rawBalances) {
     const rawBalanceTokenId = toEntityId({ num: rawBalance.token_id });
@@ -350,7 +350,7 @@ export const checkAccountTokenAssociationStatus = makeLRUCache(
 );
 
 export const safeParseAccountId = async ({
-  configOrCurrencyId: _,
+  configOrCurrencyId,
   address,
 }: {
   configOrCurrencyId: HederaCoinConfig | string;
@@ -364,7 +364,7 @@ export const safeParseAccountId = async ({
     const checksum = getChecksum(address);
 
     if (checksum) {
-      const client = await rpcClient.getInstance();
+      const client = await rpcClient.getInstance(configOrCurrencyId);
       const expectedChecksum = accountId.toStringWithChecksum(client).split("-")[1];
 
       if (checksum !== expectedChecksum) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - rpcClient and hgraphClient are based on `networkType` in coin-hedera 

### 📝 Description

This PR contains second batch of changes from [testnet support feature branch](https://github.com/LedgerHQ/ledger-live/compare/develop...feat/hedera-testnet-v2).

Scope:
- update Hedera rpcClient with `configOrCurrencyId` support and usage
- update Hedera hgraphClient with `configOrCurrencyId` support and usage

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-28050

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
