### PR TITLE
[LWM] fix(live-mobile): correct asset detail tracking events

### DIFF
--- a/.changeset/fix-asset-detail-tracking.md
+++ b/.changeset/fix-asset-detail-tracking.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix incorrect analytics on the Asset Detail screen to match the tracking plan: the address button now reports `Account`, the favourite/hide toggles report `favourite`/`hide_asset`, the market-stat info bubble fires a `button_clicked` (`market_stat_definition`) event with tracking added on the available-balance bubble, and the Transactions header reports `Transactions`.

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/__tests__/useAddressesViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/__tests__/useAddressesViewModel.test.ts
@@ -333,7 +333,7 @@ describe("useAddressesViewModel", () => {
         params: { accountId: btcAccounts[0].id },
       });
       expect(track).toHaveBeenCalledWith("button_clicked", {
-        button: "address",
+        button: "Account",
         currency: "bitcoin",
         chain: "bitcoin",
         page: "Asset Detail",
@@ -366,7 +366,7 @@ describe("useAddressesViewModel", () => {
         },
       });
       expect(track).toHaveBeenCalledWith("button_clicked", {
-        button: "address",
+        button: "Account",
         currency: usdtEthToken.id,
         chain: mockEthCryptoCurrency.id,
         page: "Asset Detail",

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/useAddressesViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/useAddressesViewModel.ts
@@ -105,7 +105,7 @@ export function useAddressesViewModel(
       if (!currency) return;
       const { account, balanceAccount } = data;
       track("button_clicked", {
-        button: "address",
+        button: "Account",
         currency: currency.id,
         chain: account.currency.id,
         page: "Asset Detail",

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/BalanceDetailsView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/BalanceDetailsView.tsx
@@ -23,6 +23,7 @@ type Props = Readonly<{
   onTransferPress: () => void;
   onEarnBannerPress: () => void;
   onEarnDepositPress: () => void;
+  onAvailableBalanceTooltipOpen: (open: boolean) => void;
   isLoading: boolean;
   distributionItem: DistributionItem | undefined;
 }>;
@@ -37,6 +38,7 @@ export function BalanceDetailsView({
   onTransferPress,
   onEarnBannerPress,
   onEarnDepositPress,
+  onAvailableBalanceTooltipOpen,
   isLoading,
   distributionItem,
 }: Props) {
@@ -75,6 +77,7 @@ export function BalanceDetailsView({
             formattedAvailable={earnState.formattedAvailable}
             formattedDeposit={earnState.formattedDeposit}
             onEarnDepositPress={onEarnDepositPress}
+            onAvailableBalanceTooltipOpen={onAvailableBalanceTooltipOpen}
           />
         )}
       </Box>

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/EarnCardsView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/EarnCardsView.tsx
@@ -22,9 +22,15 @@ type Props = Readonly<{
   formattedAvailable: string;
   formattedDeposit: string;
   onEarnDepositPress: () => void;
+  onAvailableBalanceTooltipOpen: (open: boolean) => void;
 }>;
 
-export function EarnCardsView({ formattedAvailable, formattedDeposit, onEarnDepositPress }: Props) {
+export function EarnCardsView({
+  formattedAvailable,
+  formattedDeposit,
+  onEarnDepositPress,
+  onAvailableBalanceTooltipOpen,
+}: Props) {
   const { t } = useTranslation();
   const { bottom } = useSafeAreaInsets();
 
@@ -39,7 +45,7 @@ export function EarnCardsView({ formattedAvailable, formattedDeposit, onEarnDepo
                   <CardContentDescription>
                     {t("assetDetail.balanceDetails.availableBalance")}
                   </CardContentDescription>
-                  <Tooltip>
+                  <Tooltip onOpenChange={onAvailableBalanceTooltipOpen}>
                     <TooltipTrigger>
                       <Information size={16} color="muted" />
                     </TooltipTrigger>

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/__tests__/useBalanceDetailsViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/__tests__/useBalanceDetailsViewModel.test.ts
@@ -376,6 +376,32 @@ describe("useBalanceDetailsViewModel", () => {
       expect(mockHandleOpenStakeDrawer).toHaveBeenCalledTimes(2);
     });
 
+    it("onAvailableBalanceTooltipOpen tracks market_stat_definition only when the tooltip opens", () => {
+      const btcAccount = genAccount("bitcoin-0", {
+        currency: mockBtcCryptoCurrency,
+        operationsSize: 0,
+      });
+
+      const { result } = renderHook(() =>
+        useBalanceDetailsViewModel(
+          mockBtcCryptoCurrency,
+          buildDistributionItem(mockBtcCryptoCurrency, [btcAccount]),
+        ),
+      );
+
+      act(() => result.current.onAvailableBalanceTooltipOpen(true));
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "market_stat_definition",
+        currency: "bitcoin",
+        type: "available_balance",
+        page: "Asset Detail",
+      });
+
+      jest.mocked(track).mockClear();
+      act(() => result.current.onAvailableBalanceTooltipOpen(false));
+      expect(track).not.toHaveBeenCalled();
+    });
+
     it("configures useOpenStakeDrawer with the current currency and Asset Detail source", () => {
       const btcAccount = genAccount("bitcoin-0", {
         currency: mockBtcCryptoCurrency,

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/useBalanceDetailsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/useBalanceDetailsViewModel.ts
@@ -164,6 +164,20 @@ export function useBalanceDetailsViewModel(
     handleOpenStakeDrawer();
   }, [currency?.id, handleOpenStakeDrawer]);
 
+  const onAvailableBalanceTooltipOpen = useCallback(
+    (open: boolean) => {
+      if (open) {
+        track("button_clicked", {
+          button: "market_stat_definition",
+          currency: currency?.id,
+          type: "available_balance",
+          page: "Asset Detail",
+        });
+      }
+    },
+    [currency?.id],
+  );
+
   return {
     hasAccounts,
     discreet,
@@ -174,6 +188,7 @@ export function useBalanceDetailsViewModel(
     onTransferPress,
     onEarnBannerPress,
     onEarnDepositPress,
+    onAvailableBalanceTooltipOpen,
   };
 }
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/CoinOptions/__tests__/useAssetCoinOptionsViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/CoinOptions/__tests__/useAssetCoinOptionsViewModel.test.ts
@@ -45,7 +45,7 @@ describe("useAssetCoinOptionsViewModel", () => {
     expect(track).toHaveBeenLastCalledWith(
       "button_clicked",
       expect.objectContaining({
-        button: "asset_coin_options_favourite",
+        button: "favourite",
         is_favourite: true,
       }),
     );
@@ -55,7 +55,7 @@ describe("useAssetCoinOptionsViewModel", () => {
     expect(track).toHaveBeenLastCalledWith(
       "button_clicked",
       expect.objectContaining({
-        button: "asset_coin_options_favourite",
+        button: "favourite",
         is_favourite: false,
       }),
     );
@@ -79,7 +79,7 @@ describe("useAssetCoinOptionsViewModel", () => {
     expect(track).toHaveBeenLastCalledWith(
       "button_clicked",
       expect.objectContaining({
-        button: "asset_coin_options_hide_portfolio",
+        button: "hide_asset",
         is_hidden: true,
       }),
     );
@@ -89,7 +89,7 @@ describe("useAssetCoinOptionsViewModel", () => {
     expect(track).toHaveBeenLastCalledWith(
       "button_clicked",
       expect.objectContaining({
-        button: "asset_coin_options_hide_portfolio",
+        button: "hide_asset",
         is_hidden: false,
       }),
     );

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/CoinOptions/useAssetCoinOptionsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/CoinOptions/useAssetCoinOptionsViewModel.ts
@@ -44,7 +44,7 @@ export function useAssetCoinOptionsViewModel({ currency, currencyId, marketId }:
     const nextStarred = !isStarred;
 
     track("button_clicked", {
-      button: "asset_coin_options_favourite",
+      button: "favourite",
       currency: currency.id,
       page: "Asset Detail",
       is_favourite: nextStarred,
@@ -80,7 +80,7 @@ export function useAssetCoinOptionsViewModel({ currency, currencyId, marketId }:
     const nextHidden = !isHidden;
 
     track("button_clicked", {
-      button: "asset_coin_options_hide_portfolio",
+      button: "hide_asset",
       currency: currency.id,
       page: "Asset Detail",
       is_hidden: nextHidden,

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/__tests__/useMarketStatsViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/__tests__/useMarketStatsViewModel.test.ts
@@ -154,16 +154,17 @@ describe("useMarketStatsViewModel", () => {
   });
 
   describe("onTooltipOpen", () => {
-    it("tracks info_bubble_pressed when tooltip opens", () => {
+    it("tracks button_clicked with market_stat_definition when tooltip opens", () => {
       const { result } = renderHook(() =>
         useMarketStatsViewModel({ currency: mockBtcCryptoCurrency }),
       );
 
       result.current.onTooltipOpen("circulating_supply", true);
 
-      expect(track).toHaveBeenCalledWith("info_bubble_pressed", {
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "market_stat_definition",
         currency: "bitcoin",
-        stat_name: "circulating_supply",
+        type: "circulating_supply",
         page: "Asset Detail",
       });
     });

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/useMarketStatsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/useMarketStatsViewModel.ts
@@ -120,9 +120,10 @@ export function useMarketStatsViewModel({
   const onTooltipOpen = useCallback(
     (statName: string, open: boolean) => {
       if (open) {
-        track("info_bubble_pressed", {
+        track("button_clicked", {
+          button: "market_stat_definition",
           currency: currency?.id,
-          stat_name: statName,
+          type: statName,
           page: "Asset Detail",
         });
       }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Transactions/__tests__/useTransactionsViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Transactions/__tests__/useTransactionsViewModel.test.ts
@@ -195,7 +195,7 @@ describe("useTransactionsViewModel", () => {
         params: { accountIds: accounts.map(a => a.id) },
       });
       expect(track).toHaveBeenCalledWith("button_clicked", {
-        button: "transactions_header",
+        button: "Transactions",
         currency: "bitcoin",
         page: "Asset Detail",
       });

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Transactions/useTransactionsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Transactions/useTransactionsViewModel.ts
@@ -89,7 +89,7 @@ export function useTransactionsViewModel(
 
   const onHeaderPress = useCallback(() => {
     track("button_clicked", {
-      button: "transactions_header",
+      button: "Transactions",
       currency: currency?.id,
       page: "Asset Detail",
     });


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Mixpanel `button_clicked` events on the **Asset Detail** screen — verify the `button` values: address row → `Account`, favourite toggle → `favourite`, hide toggle → `hide_asset`, Transactions header → `Transactions`.
  - Market-stats **info bubble**: opening a stat tooltip now fires `button_clicked` with `button: "market_stat_definition"` and `type: <statKey>` (instead of the old `info_bubble_pressed`).
  - The **available-balance** info bubble (earn card) now also fires that event with `type: "available_balance"` (previously untracked).

### 📝 Description

Several analytics events on the Asset Detail screen did not match the [tracking plan](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/6808731649/Asset+address+detail+-+Tracking+Plan) (red-cross items in the LWM QA column).

This PR aligns the event values with the plan:

| Action | Before | After |
| ------ | ------ | ----- |
| Click on address | `button: "address"` | `button: "Account"` |
| Star an asset | `button: "asset_coin_options_favourite"` | `button: "favourite"` |
| Hide an asset | `button: "asset_coin_options_hide_portfolio"` | `button: "hide_asset"` |
| Info bubble (market stat) | event `info_bubble_pressed`, `stat_name` | event `button_clicked`, `button: "market_stat_definition"`, `type` |
| Available-balance bubble | _untracked_ | `button_clicked`, `button: "market_stat_definition"`, `type: "available_balance"` |
| Transactions header | `button: "transactions_header"` | `button: "Transactions"` |

> **Out of scope:** the *operation details* `source` issue (source stays `account selection` instead of `asset` when reached via account selection) is **not** fixed here. It is not a value swap in the `transaction_clicked` call but a cross-cutting navigation/route-source change in `analytics/segment.ts`, and needs separate investigation.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31577](https://ledgerhq.atlassian.net/browse/LIVE-31577)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31577]: https://ledgerhq.atlassian.net/browse/LIVE-31577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ