### PR TITLE
feat(cli): hint to run pnpm build:device-deps when bindings are missing

### DIFF
--- a/.changeset/cli-device-deps-hint.md
+++ b/.changeset/cli-device-deps-hint.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-cli": patch
+---
+
+Detect missing native USB/HID bindings in the CLI and hint to run `pnpm build:device-deps`. The hint is printed at startup when the `node-hid` native module is not compiled, and again from the HID transport `open` hook when a binding-related error is thrown at runtime (e.g. proxy lazily opens the device).

--- a/apps/cli/src/live-common-setup.ts
+++ b/apps/cli/src/live-common-setup.ts
@@ -1,4 +1,6 @@
 export * from "./live-common-setup-base";
+import fs from "node:fs";
+import path from "node:path";
 import invariant from "invariant";
 import { openTransportReplayer, RecordStore } from "@ledgerhq/hw-transport-mocker";
 import { Observable } from "rxjs";
@@ -103,18 +105,75 @@ if (SPECULOS_API_PORT) {
 
 const cacheBle = {};
 
-async function init() {
-  const {
-    default: TransportNodeHid,
+const DEVICE_DEPS_HINT =
+  "\n[device-deps] Native USB/HID bindings look missing or broken. " +
+  "Run this from the monorepo root, then retry:\n  pnpm build:device-deps\n";
+
+let deviceDepsHintShown = false;
+function printDeviceDepsHint() {
+  if (deviceDepsHintShown) return;
+  deviceDepsHintShown = true;
+  console.error(DEVICE_DEPS_HINT);
+}
+
+function isMissingNativeBinding(e: unknown): boolean {
+  const msg = (e as { message?: string })?.message ?? "";
+  return (
+    msg.includes("Could not locate the bindings file") ||
+    msg.includes("HID.node") ||
+    msg.includes("HID_hidraw.node") ||
+    msg.includes("NODE_MODULE_VERSION") ||
+    (msg.includes("dlopen") && msg.includes(".node")) ||
+    /Cannot find module ['"]node-hid['"]/.test(msg)
+  );
+}
+
+function isNodeHidNativeBindingBuilt(): boolean {
+  try {
     // oxlint-disable-next-line typescript/no-require-imports
-  } = require("@ledgerhq/hw-transport-node-hid");
+    const pkgDir = path.dirname(require.resolve("node-hid"));
+    const releaseDir = path.join(pkgDir, "build", "Release");
+    return ["HID.node", "HID_hidraw.node"].some(c =>
+      fs.existsSync(path.join(releaseDir, c)),
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function init() {
+  if (!SPECULOS_APDU_PORT && !isNodeHidNativeBindingBuilt()) {
+    printDeviceDepsHint();
+  }
+
+  let TransportNodeHid: any;
+  try {
+    // oxlint-disable-next-line typescript/no-require-imports
+    TransportNodeHid = require("@ledgerhq/hw-transport-node-hid").default;
+  } catch (e) {
+    if (isMissingNativeBinding(e)) {
+      // HID is optional when targeting Speculos over TCP; skip its registration
+      // instead of crashing, and only hint when HID is actually needed.
+      if (!SPECULOS_APDU_PORT) printDeviceDepsHint();
+      return;
+    }
+    throw e;
+  }
 
   registerTransportModule({
     id: "hid",
-    open: devicePath =>
-      retry(() => TransportNodeHid.open(devicePath), {
-        context: "open-hid",
-      }),
+    open: async devicePath => {
+      try {
+        return await retry(() => TransportNodeHid.open(devicePath), {
+          context: "open-hid",
+        });
+      } catch (e) {
+        if (isMissingNativeBinding(e)) {
+          printDeviceDepsHint();
+        }
+        throw e;
+      }
+    },
     discovery: new Observable(TransportNodeHid.listen).pipe(
       map((e: any) => ({
         type: e.type,

--- a/apps/cli/src/live-common-setup.ts
+++ b/apps/cli/src/live-common-setup.ts
@@ -152,8 +152,6 @@ async function init() {
     TransportNodeHid = require("@ledgerhq/hw-transport-node-hid").default;
   } catch (e) {
     if (isMissingNativeBinding(e)) {
-      // HID is optional when targeting Speculos over TCP; skip its registration
-      // instead of crashing, and only hint when HID is actually needed.
       if (!SPECULOS_APDU_PORT) printDeviceDepsHint();
       return;
     }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Manual: hint shows on startup when `node-hid/build/Release/HID.node` is absent, and again from the HID transport `open` hook when a binding-related error is thrown.
- [ ] **Impact of the changes:** CLI startup prints one extra line when device deps are not built. No impact when CI / SPECULOS / DEVICE_PROXY_URL env is set (init is skipped). No runtime impact when bindings are present.

### 📝 Description

The CLI silently misbehaves when `node-hid` native bindings are missing or stale — `pnpm run:cli proxy` starts fine, then APDU exchanges fail and the error is logged via `log("proxy", ...)` (only visible with `-v`). Users see "Device not recognised" on mobile with no actionable hint.

This PR makes `apps/cli` self-aware:
- **Filesystem probe at startup**: checks `node-hid/build/Release/HID.node` (or `HID_hidraw.node` on Linux). If absent → prints a one-line hint.
- **`open` hook catch**: wraps the registered HID transport `open` and re-prints the hint when the error message looks like a missing/incompatible native binding (`Could not locate the bindings file`, `HID.node`, `NODE_MODULE_VERSION` mismatch, `dlopen` errors).

```
[device-deps] Native USB/HID bindings look missing or broken. Run this from the monorepo root, then retry:
  pnpm build:device-deps
```

### ❓ Context

- **JIRA or GitHub link**: n/a (DX improvement)
- **ADR link (if any)**: n/a