### PR TITLE
[LWM] fix(live-mobile): correct transaction history tracking events

### DIFF
--- a/.changeset/fix-txhistory-tracking.md
+++ b/.changeset/fix-txhistory-tracking.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix transaction-history analytics: the top-bar transaction-history icon now emits a `button_clicked` event with `button: "operation_list"`, and the `Page OperationList` screen event now reports the missing `has_pending_operations` property. For consistency, all top-bar entries (My Ledger, My Wallet, Discover, Notifications, Settings, transaction history) now emit `button_clicked` instead of `menuentry_clicked`.

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/__integrations__/TopBar.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/__integrations__/TopBar.integration.test.tsx
@@ -1,5 +1,9 @@
 import React from "react";
-import { renderWithReactQuery, withReadOnlyDisabled, withFlagOverrides } from "@tests/test-renderer";
+import {
+  renderWithReactQuery,
+  withReadOnlyDisabled,
+  withFlagOverrides,
+} from "@tests/test-renderer";
 import { expectedNavigationParams } from "../const";
 import { TopBar } from "../index";
 import { track } from "~/analytics";
@@ -47,7 +51,7 @@ describe("TopBar navigation", () => {
       expectedNavigationParams.myLedger.params,
     );
 
-    expect(track).toHaveBeenCalledWith("menuentry_clicked", {
+    expect(track).toHaveBeenCalledWith("button_clicked", {
       button: "MyLedger",
       page: ScreenName.Portfolio,
     });
@@ -63,7 +67,7 @@ describe("TopBar navigation", () => {
       expectedNavigationParams.discover.params,
     );
 
-    expect(track).toHaveBeenCalledWith("menuentry_clicked", {
+    expect(track).toHaveBeenCalledWith("button_clicked", {
       button: "Discover",
       page: ScreenName.Portfolio,
     });
@@ -79,7 +83,7 @@ describe("TopBar navigation", () => {
       expectedNavigationParams.notifications.params,
     );
 
-    expect(track).toHaveBeenCalledWith("menuentry_clicked", {
+    expect(track).toHaveBeenCalledWith("button_clicked", {
       button: "Notifications",
       page: ScreenName.Portfolio,
     });
@@ -92,7 +96,7 @@ describe("TopBar navigation", () => {
 
     expect(mockNavigate).toHaveBeenCalledWith(expectedNavigationParams.settings.name);
 
-    expect(track).toHaveBeenCalledWith("menuentry_clicked", {
+    expect(track).toHaveBeenCalledWith("button_clicked", {
       button: "Settings",
       page: ScreenName.Portfolio,
     });
@@ -100,7 +104,9 @@ describe("TopBar navigation", () => {
 
   it("should navigate to operations list with expected params when transaction history button is pressed", async () => {
     const { user, getByTestId } = renderWithReactQuery(<TopBar />, {
-      overrideInitialState: withFlagOverrides({ lwmWallet40: { enabled: true, params: { operationsList: true } } }),
+      overrideInitialState: withFlagOverrides({
+        lwmWallet40: { enabled: true, params: { operationsList: true } },
+      }),
     });
 
     await user.press(getByTestId("topbar-transaction-history"));
@@ -109,7 +115,7 @@ describe("TopBar navigation", () => {
       screen: ScreenName.OperationsList,
     });
 
-    expect(track).toHaveBeenCalledWith("menuentry_clicked", {
+    expect(track).toHaveBeenCalledWith("button_clicked", {
       button: "operation_list",
       page: ScreenName.Portfolio,
     });

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/useTopBarViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/useTopBarViewModel.ts
@@ -14,6 +14,8 @@ import { useRebornFlow } from "LLM/features/Reborn/hooks/useRebornFlow";
 import { useSyncIndicator } from "./hooks/useSyncIndicator";
 import { usePortfolioBalance } from "LLM/hooks/usePortfolioBalance";
 
+const BUTTON_CLICKED_EVENT = "button_clicked";
+
 export function useTopBarViewModel(
   navigation: NativeStackNavigationProp<{ [key: string]: object | undefined }>,
   screenName?: string,
@@ -61,7 +63,7 @@ export function useTopBarViewModel(
   const hasUnreadOperations = useSelector(hasUnreadOperationsSelector);
 
   const onMyLedgerPress = useCallback(() => {
-    track("menuentry_clicked", { button: "MyLedger", page });
+    track(BUTTON_CLICKED_EVENT, { button: "MyLedger", page });
     if (readOnlyModeEnabled) {
       setOriginFlow(HOOKS_TRACKING_LOCATIONS.myLedger);
       navigateToRebornFlow();
@@ -78,14 +80,14 @@ export function useTopBarViewModel(
   }, [navigation, page, readOnlyModeEnabled, navigateToRebornFlow]);
 
   const onMyWalletPress = useCallback(() => {
-    track("button_clicked", { button: "My Wallet", page });
+    track(BUTTON_CLICKED_EVENT, { button: "My Wallet", page });
     navigation.navigate(NavigatorName.MyWallet, {
       screen: ScreenName.MyWallet,
     });
   }, [navigation, page]);
 
   const onDiscoverPress = useCallback(() => {
-    track("menuentry_clicked", { button: "Discover", page });
+    track(BUTTON_CLICKED_EVENT, { button: "Discover", page });
     if (web3hub?.enabled) {
       navigation.navigate(NavigatorName.Web3HubTab, {
         screen: ScreenName.Web3HubMain,
@@ -98,19 +100,19 @@ export function useTopBarViewModel(
   }, [navigation, page, web3hub?.enabled]);
 
   const onNotificationsPress = useCallback(() => {
-    track("menuentry_clicked", { button: "Notifications", page });
+    track(BUTTON_CLICKED_EVENT, { button: "Notifications", page });
     navigation.navigate(NavigatorName.NotificationCenter, {
       screen: ScreenName.NotificationCenter,
     });
   }, [navigation, page]);
 
   const onSettingsPress = useCallback(() => {
-    track("menuentry_clicked", { button: "Settings", page });
+    track(BUTTON_CLICKED_EVENT, { button: "Settings", page });
     navigation.navigate(NavigatorName.Settings);
   }, [navigation, page]);
 
   const onTransactionHistoryPress = useCallback(() => {
-    track("menuentry_clicked", { button: "operation_list", page });
+    track(BUTTON_CLICKED_EVENT, { button: "operation_list", page });
     navigation.navigate(NavigatorName.OperationsHistory, {
       screen: ScreenName.OperationsList,
     });

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/OperationsList.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/OperationsList.test.tsx
@@ -58,7 +58,15 @@ const MockNavigator = () => (
 describe("OperationsList", () => {
   it("tracks the OperationsList screen on focus", () => {
     render(<MockNavigator />);
-    expect(screen).toHaveBeenCalledWith(undefined, "OperationsList", {}, true, true, false, false);
+    expect(screen).toHaveBeenCalledWith(
+      undefined,
+      "OperationsList",
+      { has_pending_operations: false },
+      true,
+      true,
+      false,
+      false,
+    );
   });
 
   describe("when the list is empty", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
@@ -32,6 +32,11 @@ describe("useOperationsListViewModel", () => {
     expect(result.current.isEmpty).toBe(false);
   });
 
+  it("hasPendingOperations is false when there are no pending sections", () => {
+    const { result } = renderHook(() => useOperationsListViewModel());
+    expect(result.current.hasPendingOperations).toBe(false);
+  });
+
   it("onEndReached increments the operation count when not completed", () => {
     mockUseOperationsV1.mockReturnValue({ sections: [], completed: false });
     const { result } = renderHook(() => useOperationsListViewModel());

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/index.tsx
@@ -35,6 +35,7 @@ export default function OperationsList({ route }: Props) {
     sections,
     completed,
     isEmpty,
+    hasPendingOperations,
     onEndReached,
   } = useOperationsListViewModel(accountIds);
 
@@ -89,7 +90,7 @@ export default function OperationsList({ route }: Props) {
 
   return (
     <Box lx={rootStyle}>
-      <TrackScreen name="OperationsList" />
+      <TrackScreen name="OperationsList" has_pending_operations={hasPendingOperations} />
       <SectionList
         sections={sections}
         testID="operations-list-section-list"

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
@@ -75,6 +75,8 @@ export function useOperationsListViewModel(accountIds?: string[]) {
 
   const isEmpty = completed && sections.length === 0;
 
+  const hasPendingOperations = useMemo(() => sections.some(s => s.isPending), [sections]);
+
   return {
     accounts,
     flattenedAccounts,
@@ -83,6 +85,7 @@ export function useOperationsListViewModel(accountIds?: string[]) {
     sections,
     completed,
     isEmpty,
+    hasPendingOperations,
     onEndReached,
   };
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - **Top bar (Portfolio/Wallet header):** all entries — My Ledger, My Wallet, Discover, Notifications, Settings and the transaction-history icon — now emit a single `button_clicked` event. Verify each still navigates correctly and the `button`/`page` properties are unchanged.
  - **`Page OperationList` screen event**: now includes a `has_pending_operations` boolean. Verify it is `true` when the list shows a pending section and `false` otherwise. `operationsCount` continues to be attached automatically.

### 📝 Description

Two transaction-history analytics events on LWM did not match the [tracking plan](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/6808731649/Asset+address+detail+-+Tracking+Plan) (red-cross items in the LWM QA column).

This PR aligns them with the plan:

| Action | Before | After |
| ------ | ------ | ----- |
| Click on tx-history icon | event `menuentry_clicked`, `button: "operation_list"` | event `button_clicked`, `button: "operation_list"` |
| View tx history (`Page OperationList`) | `has_pending_operations` missing | `has_pending_operations: true/false` added |

To avoid leaving the tx-history icon as the lone `button_clicked` among `menuentry_clicked` siblings, **all top-bar entries are now unified on `button_clicked`** through a single shared constant in `useTopBarViewModel.ts`. This changes the event name for My Ledger, Discover, Notifications and Settings from `menuentry_clicked` to `button_clicked` (their `button` values are unchanged).

> **Note on `operationsCount`:** the plan lists it as a property of `Page OperationList`, but it is already attached to **every** event via `extraProperties` in `analytics/segment.ts` (`accounts.reduce((sum, acc) => sum + acc.operationsCount, 0)`). No change was needed for it — only `has_pending_operations` was missing.

> **Analytics impact to confirm:** dashboards/funnels that rely on the `menuentry_clicked` event for top-bar entries will need to switch to `button_clicked`.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31576](https://ledgerhq.atlassian.net/browse/LIVE-31576)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31576]: https://ledgerhq.atlassian.net/browse/LIVE-31576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ