### PR TITLE
fix(scripts): use `-p` instead of invalid `--include` flag in `build:tests`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "release": "changeset publish",
     "build:libs": "nx run-many -t build -p \"@ledgerhq/*\" --exclude \"@ledgerhq/dummy-*-app,@ledgerhq/live-cli,@ledgerhq/web-tools,@ledgerhq/wallet-cli\" --parallel=20",
     "build:libs:force": "pnpm run build:libs --skip-nx-cache",
-    "build:tests": "nx run-many -t build --include \"@ledgerhq/dummy-*-app\"",
+    "build:tests": "nx run-many -t build -p \"@ledgerhq/dummy-*-app\"",
     "build:dummy-apps": "nx run-many -t build -p \"@ledgerhq/dummy-*-app\"",
     "build:dummy-wallet-app": "nx run-many -t build -p @ledgerhq/dummy-wallet-app",
     "build:dummy-live-app": "nx run-many -t build -p @ledgerhq/dummy-live-app",


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. Only a script change for devs
- [ ] **Covered by automatic tests.** Only a script change for devs
- [x] **Impact of the changes:**
  - package json script

### 📝 Description

`nx run-many` does not support `--include`; the flag was silently ignored, causing the script to attempt building every project instead of only the dummy apps. Switched to `-p "@ledgerhq/dummy-*-app"` to correctly scope the build, matching the pattern used by `build:dummy-apps`.

### ❓ Context

- **JIRA or GitHub link**:
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
