### PR TITLE
[LWDM] chore(llc): log `rawData` on broadcast failure

### DIFF
--- a/.changeset/chilled-pots-wait.md
+++ b/.changeset/chilled-pots-wait.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+chore(llc): log raw data on broadcast error

--- a/apps/ledger-live-desktop/src/datadog/logs.test.ts
+++ b/apps/ledger-live-desktop/src/datadog/logs.test.ts
@@ -201,7 +201,7 @@ describe("datadog logs", () => {
       broadcastLogger({
         status: "failure",
         error,
-        txPayload: "payload",
+        txPayload: { signature: "signature" },
         appVersion: "1.0.0",
         currencyId: "ethereum",
         family: "evm",
@@ -212,7 +212,7 @@ describe("datadog logs", () => {
         {
           event: {
             status: "failure",
-            txPayload: "payload",
+            txPayload: { signature: "signature" },
             appVersion: "1.0.0",
             currencyId: "ethereum",
             family: "evm",

--- a/apps/ledger-live-mobile/src/datadog.test.ts
+++ b/apps/ledger-live-mobile/src/datadog.test.ts
@@ -35,7 +35,7 @@ describe("broadcastLogger", () => {
     broadcastLogger({
       status: "failure",
       error,
-      txPayload: "payload",
+      txPayload: { signature: "signature" },
       appVersion: "1.0.0",
       currencyId: "ethereum",
       family: "family",
@@ -49,7 +49,7 @@ describe("broadcastLogger", () => {
       {
         event: {
           status: "failure",
-          txPayload: "payload",
+          txPayload: { signature: "signature" },
           appVersion: "1.0.0",
           currencyId: "ethereum",
           family: "family",

--- a/libs/ledger-live-common/src/hooks/useBroadcast.test.ts
+++ b/libs/ledger-live-common/src/hooks/useBroadcast.test.ts
@@ -105,6 +105,7 @@ describe("useBroadcast", () => {
         await expect(
           result.current({
             signature: "signed-transaction",
+            rawData: { raw_hex: "raw-hex" }
           } as any),
         ).rejects.toThrow(new Error("Broadcast failed"));
       });
@@ -117,7 +118,7 @@ describe("useBroadcast", () => {
         family: "family",
         appVersion: "llc/test",
         source: { type: "coin-module", name: "ledger-live-desktop" },
-        txPayload: "signed-transaction",
+        txPayload: { signature: "signed-transaction", rawData: { raw_hex: "raw-hex" } },
       });
     });
   });

--- a/libs/ledger-live-common/src/hooks/useBroadcast.ts
+++ b/libs/ledger-live-common/src/hooks/useBroadcast.ts
@@ -21,7 +21,13 @@ type CommonLogEvent = {
   tokenId?: string;
 };
 
-type ErrorLogEvent = { status: "failure"; error: Error; txPayload: string } & CommonLogEvent;
+type ErrorLogEvent = {
+  status: "failure"; error: Error; txPayload:
+  {
+    signature: string;
+    rawData?: Record<string, unknown>;
+  }
+} & CommonLogEvent;
 
 type SuccessLogEvent = { status: "success" } & CommonLogEvent;
 
@@ -92,7 +98,10 @@ export const useBroadcast = ({
             logger({
               status: "failure",
               error,
-              txPayload: signedOperation.signature,
+              txPayload: {
+                signature: signedOperation.signature,
+                ...(signedOperation.rawData ? { rawData: signedOperation.rawData } : {})
+              },
               ...commonLogEvent,
             });
           }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

We log `signedOperation.signature` when broadcasts fail. On some chains, this does not include the whole transaction payload ... making things hard to debug.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
