### PR TITLE
[LWDM] chore(coin-evm): use LRU cache to store EVM validators

### DIFF
--- a/.changeset/lru-validators-cache.md
+++ b/.changeset/lru-validators-cache.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/coin-evm": patch
+"@ledgerhq/live-common": patch
+---
+
+refactor(coin-evm): replace the homemade validators cache with `makeLRUCache` and drop the redundant `inFlightFetches` map
+
+The EVM staking validators cache now uses `@ledgerhq/live-network/cache`'s `makeLRUCache`. Because it stores the in-flight promise, concurrent fetches are coalesced by the cache itself, so the separate `inFlightFetches` request-deduplication map and the synchronous `getCachedValidators` accessor were removed.

--- a/libs/coin-modules/coin-evm/src/staking/index.ts
+++ b/libs/coin-modules/coin-evm/src/staking/index.ts
@@ -10,7 +10,6 @@ export {
   getUnbondingPeriodDays,
   getMaxRedelegations,
   hasUnbondingPeriod,
-  getCachedValidators,
   prefetchValidators,
   clearValidatorsCache,
 } from "./validators";

--- a/libs/coin-modules/coin-evm/src/staking/validators.test.ts
+++ b/libs/coin-modules/coin-evm/src/staking/validators.test.ts
@@ -1,7 +1,6 @@
 import network from "@ledgerhq/live-network";
 import {
   clearValidatorsCache,
-  getCachedValidators,
   getUnbondingPeriodDays,
   getValidatorExplorerUrl,
   getValidators,
@@ -41,7 +40,6 @@ describe("staking/validators", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     clearValidatorsCache();
-    expect(getCachedValidators("sei_evm")).toBeUndefined();
   });
 
   describe("getValidators + cache", () => {
@@ -74,7 +72,9 @@ describe("staking/validators", () => {
           estimatedYearlyRewardsRate: 0,
         }),
       ]);
-      expect(getCachedValidators("sei_evm")).toEqual(first);
+
+      expect(await getValidators("sei_evm")).toEqual(first);
+      expect(mockedNetwork).toHaveBeenCalledTimes(1);
     });
 
     it("returns cached data without a second network call while fresh", async () => {
@@ -98,8 +98,10 @@ describe("staking/validators", () => {
       mockedNetwork.mockResolvedValue({ status: 200, data: { validators: [] } });
 
       await getValidators("sei_evm");
+      await getValidators("sei_evm");
 
-      expect(getCachedValidators("sei_evm")).toBeUndefined();
+      // empty results are not cached, so each call hits the network again
+      expect(mockedNetwork).toHaveBeenCalledTimes(2);
     });
 
     it("bypasses cache when apiConfig is passed explicitly", async () => {
@@ -112,11 +114,8 @@ describe("staking/validators", () => {
     });
 
     it("returns [] for currencies without a validator API", async () => {
-      const result = await getValidators("ethereum");
-
-      expect(result).toEqual([]);
+      expect(await getValidators("ethereum")).toEqual([]);
       expect(mockedNetwork).not.toHaveBeenCalled();
-      expect(getCachedValidators("ethereum")).toBeUndefined();
     });
 
     it("clearValidatorsCache removes an in-flight entry so the next call starts a fresh fetch", async () => {
@@ -147,35 +146,53 @@ describe("staking/validators", () => {
     });
   });
 
-  describe("getCachedValidators TTL", () => {
-    beforeEach(() => {
-      jest.useFakeTimers();
-    });
-    afterEach(() => {
-      jest.useRealTimers();
+  describe("cache TTL", () => {
+    // lru-cache reads its TTL clock from performance.now() (or Date.now() as a
+    // fallback), so we drive both forward to simulate the entry going stale.
+    const setNow = (ms: number) => {
+      jest.spyOn(performance, "now").mockReturnValue(ms);
+      jest.spyOn(Date, "now").mockReturnValue(ms);
+    };
+
+    afterEach(async () => {
+      jest.restoreAllMocks();
+      // The validators cache is a module singleton; let lru-cache's debounced clock
+      // (cachedNow, reset via a 1ms timer) settle so the mocked time doesn't leak
+      // into other tests and make their fresh entries look stale.
+      await new Promise(resolve => setTimeout(resolve, 5));
     });
 
-    it("returns undefined after cache TTL expires", async () => {
+    it("refetches after the cache TTL expires", async () => {
       mockedNetwork.mockResolvedValue(cosmosValidatorsPayload);
 
+      // non-zero base: lru-cache treats a start time of 0 as "no TTL"
+      setNow(1000);
       await getValidators("sei_evm");
-      expect(getCachedValidators("sei_evm")).not.toBeUndefined();
+      expect(mockedNetwork).toHaveBeenCalledTimes(1);
 
-      jest.advanceTimersByTime(31_000);
+      // lru-cache debounces its clock read for `ttlResolution` (1ms) via a real
+      // setTimeout; wait it out so the next read picks up the advanced time.
+      await new Promise(resolve => setTimeout(resolve, 5));
 
-      expect(getCachedValidators("sei_evm")).toBeUndefined();
+      setNow(32000); // 31s later, past the 30s TTL
+      await getValidators("sei_evm");
+
+      expect(mockedNetwork).toHaveBeenCalledTimes(2);
     });
   });
 
   describe("prefetchValidators", () => {
-    it("warms the cache without throwing", async () => {
+    it("warms the cache so a later read hits no network", async () => {
       mockedNetwork.mockResolvedValue(cosmosValidatorsPayload);
 
       prefetchValidators("sei_evm");
       await Promise.resolve();
       await Promise.resolve();
+      expect(mockedNetwork).toHaveBeenCalledTimes(1);
 
-      expect(getCachedValidators("sei_evm")).not.toBeUndefined();
+      // the warmed entry serves the subsequent read without another network call
+      await getValidators("sei_evm");
+      expect(mockedNetwork).toHaveBeenCalledTimes(1);
     });
 
     it("is a no-op when cache is already fresh", async () => {

--- a/libs/coin-modules/coin-evm/src/staking/validators.ts
+++ b/libs/coin-modules/coin-evm/src/staking/validators.ts
@@ -1,4 +1,5 @@
 import network from "@ledgerhq/live-network";
+import { makeLRUCache } from "@ledgerhq/live-network/cache";
 import type { Page, Validator } from "@ledgerhq/coin-module-framework/api/index";
 import type { StakingValidatorItem } from "@ledgerhq/types-live";
 import { STAKING_CONTRACTS } from "./contracts";
@@ -27,16 +28,9 @@ type CosmosValidator = {
   tokens: string;
 };
 
-type CacheEntry = {
-  data: StakingValidatorItem[];
-  fetchedAt: number;
-};
-
 /**
- * In-memory validators cache. Same TTL as Cosmos preload (30s) so that
- * a user navigating across delegation screens reads a hot cache instead of
- * paying a network roundtrip each time. It is intentionally simple: no CurrencyBridge.preload / hydrate
- * contract
+ * Validators cache TTL (30s, same as Cosmos preload) so a user navigating across
+ * delegation screens reads a hot cache instead of paying a network roundtrip each time.
  */
 const CACHE_MAX_AGE_MS = 30 * 1000;
 
@@ -86,31 +80,30 @@ export const getValidatorApi = (currencyId: string): ValidatorApi | undefined =>
   }
 };
 
-const validatorsCache: Map<string, CacheEntry> = new Map();
-// Deduplicates concurrent fetches for the same currency (Info modal + Delegate
-// modal opening in quick succession).
-const inFlightFetches: Map<string, Promise<StakingValidatorItem[]>> = new Map();
-
-const isFresh = (entry: CacheEntry | undefined): entry is CacheEntry =>
-  !!entry && Date.now() - entry.fetchedAt <= CACHE_MAX_AGE_MS;
-
-/**
- * Returns cached validators synchronously when fresh, or `undefined` when the
- * cache is empty/stale. Used to seed React state so the UI does not show an
- * empty list while a background refresh is in flight.
- */
-export const getCachedValidators = (currencyId: string): StakingValidatorItem[] | undefined => {
-  const entry = validatorsCache.get(currencyId);
-  return isFresh(entry) ? entry.data : undefined;
+const resolveValidators = async (
+  currencyId: string,
+  apiConfig?: { baseUrl: string; validatorsEndpoint: string },
+): Promise<StakingValidatorItem[]> => {
+  const api = getValidatorApi(currencyId);
+  const config = apiConfig ?? STAKING_CONTRACTS[currencyId]?.apiConfig;
+  if (!api || !config) return [];
+  return api.fetchValidators(config);
 };
+
+// Single LRU cache keyed by currencyId. Because makeLRUCache stores the pending
+// promise, concurrent callers (e.g. Info modal + Delegate modal opening in quick
+// succession) share one in-flight fetch — no separate request-deduplication map needed.
+const validatorsCache = makeLRUCache(
+  (currencyId: string) => resolveValidators(currencyId),
+  (currencyId: string) => currencyId,
+  { max: 50, ttl: CACHE_MAX_AGE_MS },
+);
 
 export const clearValidatorsCache = (currencyId?: string): void => {
   if (currencyId) {
-    validatorsCache.delete(currencyId);
-    inFlightFetches.delete(currencyId);
+    validatorsCache.clear(currencyId);
   } else {
-    validatorsCache.clear();
-    inFlightFetches.clear();
+    validatorsCache.reset();
   }
 };
 
@@ -119,40 +112,20 @@ export const getValidators = async (
   apiConfig?: { baseUrl: string; validatorsEndpoint: string },
 ): Promise<StakingValidatorItem[]> => {
   // Explicit apiConfig bypasses the cache (callers opt out on purpose, e.g. tests).
-  if (!apiConfig) {
-    const cached = getCachedValidators(currencyId);
-    if (cached) return cached;
+  if (apiConfig) return resolveValidators(currencyId, apiConfig);
 
-    const inFlight = inFlightFetches.get(currencyId);
-    if (inFlight) return inFlight;
-  }
-
-  const api = getValidatorApi(currencyId);
-  const config = apiConfig ?? STAKING_CONTRACTS[currencyId]?.apiConfig;
-  if (!api || !config) return [];
-
-  const request = api
-    .fetchValidators(config)
-    .then(data => {
-      if (!apiConfig && data.length > 0) {
-        validatorsCache.set(currencyId, { data, fetchedAt: Date.now() });
-      }
-      return data;
-    })
-    .finally(() => {
-      if (!apiConfig) inFlightFetches.delete(currencyId);
-    });
-
-  if (!apiConfig) inFlightFetches.set(currencyId, request);
-  return request;
+  const data = await validatorsCache(currencyId);
+  // Never keep an empty list cached, so a transient empty response is retried next time.
+  if (data.length === 0) validatorsCache.clear(currencyId);
+  return data;
 };
 
 /**
  * Fire-and-forget warm-up of the validators cache. Called before the user
- * reaches the validator selection step so the list appears instantly.
+ * reaches the validator selection step so the list appears instantly. A fresh
+ * cache entry already returns without a network call, so repeated calls are cheap.
  */
 export const prefetchValidators = (currencyId: string): void => {
-  if (getCachedValidators(currencyId)) return;
   void getValidators(currencyId).catch(() => {
     /* swallow: the hook surfaces errors via its own flow */
   });

--- a/libs/ledger-live-common/src/families/evm/staking/logic.ts
+++ b/libs/ledger-live-common/src/families/evm/staking/logic.ts
@@ -19,6 +19,5 @@ export {
   getMaxRedelegations,
   hasUnbondingPeriod,
   getValidators,
-  getCachedValidators,
   prefetchValidators,
 } from "@ledgerhq/coin-evm/staking/index";

--- a/libs/ledger-live-common/src/families/evm/staking/react.ts
+++ b/libs/ledger-live-common/src/families/evm/staking/react.ts
@@ -1,9 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import {
-  getValidators,
-  getCachedValidators,
-  mapDelegations,
-} from "@ledgerhq/coin-evm/staking/index";
+import { getValidators, mapDelegations } from "@ledgerhq/coin-evm/staking/index";
 import type { StakingValidatorItem } from "@ledgerhq/types-live";
 import type { StakingAccount, StakingMappedDelegation } from "./types";
 import { getAccountCurrency } from "../../../account";
@@ -34,20 +30,19 @@ export function useEvmStakingValidators(
   currencyId: string,
   searchInput?: string,
 ): EvmStakingValidatorsState {
-  // Seed from the in-memory cache (populated by a previous mount or prefetch).
-  // Single read avoids redundant work and inconsistent TTL boundary at init.
-  const [fetchState, setFetchState] = useState<FetchState>(() => {
-    const cached = getCachedValidators(currencyId);
-    return { items: cached ?? [], loading: !cached, error: null };
+  const [fetchState, setFetchState] = useState<FetchState>({
+    items: [],
+    loading: true,
+    error: null,
   });
 
   useEffect(() => {
     // guards against stale resolutions when currencyId changes
     let cancelled = false;
 
-    const cached = getCachedValidators(currencyId);
-    setFetchState({ items: cached ?? [], loading: !cached, error: null });
+    setFetchState({ items: [], loading: true, error: null });
 
+    // A warm LRU entry resolves on the next microtask, so the loading state is momentary.
     getValidators(currencyId)
       .then(items => {
         if (cancelled) return;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Sei validators list

### 📝 Description

Replaces the homemade EVM staking validators cache with `makeLRUCache` from `@ledgerhq/live-network/cache`.

Because `makeLRUCache` stores the in-flight promise, concurrent callers (e.g. the Info modal and Delegate modal opening in quick succession) already share a single fetch. This lets us drop:
- the separate `inFlightFetches` request-deduplication map,
- the manual `Map<string, CacheEntry>` + freshness/TTL bookkeeping,
- the synchronous `getCachedValidators` accessor — the hook now simply `await`s `getValidators`; a warm entry resolves on the next microtask, so the loading state is momentary.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31557](https://ledgerhq.atlassian.net/browse/LIVE-31557)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.


[LIVE-31557]: https://ledgerhq.atlassian.net/browse/LIVE-31557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ