### PR TITLE
[LWDM] chore(polkadot): target polkadot-rest-api endpoints in config

### DIFF
--- a/.changeset/polkadot-rest-api-westend-endpoint.md
+++ b/.changeset/polkadot-rest-api-westend-endpoint.md
@@ -1,0 +1,13 @@
+---
+"@ledgerhq/coin-polkadot": patch
+"@ledgerhq/live-common": patch
+"@ledgerhq/live-env": patch
+---
+
+Migrate the Polkadot family (mainnet and Westend, relay chain and asset hub) to the new polkadot-rest-api endpoints, served under a `/v1` prefix (`/v1/rc` for the relay chain).
+
+Adapt the coin-polkadot client to the rest-api, which is not fully 1:1 with substrate-api-sidecar:
+
+- staking storage queries use `keys[]` only (drop the legacy `key1` query param, rejected by the rest-api);
+- tolerate a missing `ss58Format` in `/runtime/spec` (e.g. Westend Asset Hub) instead of producing `NaN`;
+- parse the new `/transaction/dry-run` response shape (`resultType` at the root, error under `result.error`, plus the `TransactionValidityError` case).

--- a/libs/coin-modules/coin-polkadot/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/api/index.integ.test.ts
@@ -14,7 +14,7 @@ describe("Polkadot Api", () => {
         url: "https://polkadot-asset-hub-fullnodes.api.live.ledger.com",
       },
       sidecar: {
-        url: "https://polkadot-asset-hub-sidecar.coin.ledger.com",
+        url: "https://polkadot-mainnet-rest-api.coin.ledger.com/v1",
       },
       indexer: {
         url: "https://explorers.api.live.ledger.com/blockchain/dot_asset_hub",

--- a/libs/coin-modules/coin-polkadot/src/bridge/broadcast.integ.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/bridge/broadcast.integ.test.ts
@@ -18,7 +18,7 @@ describe("broadcast", () => {
         url: "https://polkadot-asset-hub-fullnodes.api.live.ledger.com",
       },
       sidecar: {
-        url: "https://polkadot-asset-hub-sidecar.coin.ledger.com",
+        url: "https://polkadot-mainnet-rest-api.coin.ledger.com/v1",
       },
       indexer: {
         url: "https://explorers.api.live.ledger.com/blockchain/dot_asset_hub",

--- a/libs/coin-modules/coin-polkadot/src/bridge/buildTransaction.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/bridge/buildTransaction.test.ts
@@ -37,7 +37,7 @@ describe("buildTransaction", () => {
           type: "active",
         },
         sidecar: {
-          url: "https://polkadot-sidecar.coin.ledger.com",
+          url: "https://polkadot-mainnet-rest-api.coin.ledger.com/v1",
           credentials: "",
         },
         staking: {

--- a/libs/coin-modules/coin-polkadot/src/bridge/getFeesForTransaction.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/bridge/getFeesForTransaction.test.ts
@@ -35,7 +35,7 @@ describe("getEstimatedFees", () => {
           type: "active",
         },
         sidecar: {
-          url: "https://polkadot-sidecar.coin.ledger.com",
+          url: "https://polkadot-mainnet-rest-api.coin.ledger.com/v1",
           credentials: "",
         },
         staking: {

--- a/libs/coin-modules/coin-polkadot/src/bridge/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/bridge/prepareTransaction.test.ts
@@ -21,7 +21,7 @@ describe("prepareTransaction", () => {
           type: "active",
         },
         sidecar: {
-          url: "https://polkadot-sidecar.coin.ledger.com",
+          url: "https://polkadot-mainnet-rest-api.coin.ledger.com/v1",
           credentials: "",
         },
         staking: {

--- a/libs/coin-modules/coin-polkadot/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/bridge/signOperation.test.ts
@@ -67,7 +67,7 @@ describe("signOperation", () => {
           type: "active",
         },
         sidecar: {
-          url: "https://polkadot-sidecar.coin.ledger.com",
+          url: "https://polkadot-mainnet-rest-api.coin.ledger.com/v1",
           credentials: "",
         },
         staking: {

--- a/libs/coin-modules/coin-polkadot/src/logic/broadcast.integ.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/logic/broadcast.integ.test.ts
@@ -12,7 +12,7 @@ describe("Broadcast", () => {
         url: "https://polkadot-asset-hub-fullnodes.api.live.ledger.com",
       },
       sidecar: {
-        url: "https://polkadot-asset-hub-sidecar.coin.ledger.com",
+        url: "https://polkadot-mainnet-rest-api.coin.ledger.com/v1",
       },
       indexer: {
         url: "https://explorers.api.live.ledger.com/blockchain/dot_asset_hub",

--- a/libs/coin-modules/coin-polkadot/src/logic/estimateFees.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/logic/estimateFees.test.ts
@@ -43,7 +43,7 @@ describe("estimatedFees", () => {
         url: "https://polkadot-rpc.publicnode.com",
       },
       sidecar: {
-        url: "https://polkadot-sidecar.coin.ledger.com",
+        url: "https://polkadot-mainnet-rest-api.coin.ledger.com/v1",
       },
       indexer: {
         url: "https://polkadot.coin.ledger.com",

--- a/libs/coin-modules/coin-polkadot/src/network/common.ts
+++ b/libs/coin-modules/coin-polkadot/src/network/common.ts
@@ -24,7 +24,9 @@ export const createRegistryAndExtrinsics = (
   // Register the chain properties for this registry
   registry.setChainProperties(
     registry.createType("ChainProperties", {
-      ss58Format: Number(spec.properties.ss58Format),
+      // ss58Format may be absent (e.g. Westend Asset Hub): leave it unset (None) instead of NaN.
+      ss58Format:
+        spec.properties.ss58Format !== undefined ? Number(spec.properties.ss58Format) : undefined,
       tokenDecimals: Number(spec.properties.tokenDecimals),
       tokenSymbol: spec.properties.tokenSymbol,
     }),

--- a/libs/coin-modules/coin-polkadot/src/network/sidecar.integ.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/network/sidecar.integ.test.ts
@@ -23,7 +23,7 @@ const CURRENCY_CONFIGS = {
     config: {
       status: { type: "active" as const },
       node: { url: "https://polkadot-rpc.publicnode.com" },
-      sidecar: { url: "https://polkadot-sidecar.coin.ledger.com" },
+      sidecar: { url: "https://polkadot-mainnet-rest-api.coin.ledger.com/v1/rc" },
       indexer: { url: "https://polkadot.coin.ledger.com" },
       staking: { electionStatusThreshold: 25 },
     },
@@ -33,19 +33,20 @@ const CURRENCY_CONFIGS = {
     currency: getCryptoCurrencyById("assethub_polkadot"),
     config: {
       status: { type: "active" as const },
-      sidecar: { url: "https://polkadot-asset-hub-sidecar.coin.ledger.com" },
+      sidecar: { url: "https://polkadot-mainnet-rest-api.coin.ledger.com/v1" },
       node: { url: "https://polkadot-asset-hub-fullnodes.api.live.ledger.com" },
       indexer: { url: "https://explorers.api.live.ledger.com/blockchain/dot_asset_hub" },
       staking: { electionStatusThreshold: 25 },
       hasBeenMigrated: true,
     },
-    testAddress: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+    // Asset Hub Polkadot uses SS58 prefix 0, so a polkadot-format address is required.
+    testAddress: "163WJAxWrQzsAVEZdn2w6mq4gmT4FmEgvCfex3uEEUHTE9GL",
   },
   westend: {
     currency: getCryptoCurrencyById("westend"),
     config: {
       status: { type: "active" as const },
-      sidecar: { url: "https://polkadot-westend-sidecar.coin.ledger.com/rc" },
+      sidecar: { url: "https://polkadot-westend-rest-api.coin.ledger.com/v1/rc" },
       node: { url: "https://polkadot-westend-fullnodes.api.live.ledger.com" },
       indexer: { url: "https://explorers.api.live.ledger.com/blockchain/dot_westend" },
     },
@@ -55,7 +56,7 @@ const CURRENCY_CONFIGS = {
     currency: getCryptoCurrencyById("assethub_westend"),
     config: {
       status: { type: "active" as const },
-      sidecar: { url: "https://polkadot-westend-sidecar.coin.ledger.com" },
+      sidecar: { url: "https://polkadot-westend-rest-api.coin.ledger.com/v1" },
       node: { url: "https://polkadot-westend-asset-hub-fullnodes.api.live.ledger.com" },
       indexer: { url: "https://explorers.api.live.ledger.com/blockchain/dot_asset_hub_westend" },
     },

--- a/libs/coin-modules/coin-polkadot/src/network/sidecar.mock.ts
+++ b/libs/coin-modules/coin-polkadot/src/network/sidecar.mock.ts
@@ -6,7 +6,7 @@ import {
   fixtureTxMaterialWithMetadata,
 } from "./sidecar.fixture";
 
-export const SIDECAR_BASE_URL_TEST = "https://polkadot-asset-hub-sidecar.coin.ledger.com";
+export const SIDECAR_BASE_URL_TEST = "https://polkadot-mainnet-rest-api.coin.ledger.com/v1";
 
 const handlers = [
   http.get(`${SIDECAR_BASE_URL_TEST}/accounts/:addr/balance-info`, () => {

--- a/libs/coin-modules/coin-polkadot/src/network/sidecar.ts
+++ b/libs/coin-modules/coin-polkadot/src/network/sidecar.ts
@@ -168,7 +168,7 @@ const fetchStashAddr = async (addr: string, currency?: CryptoCurrency): Promise<
     data,
   }: {
     data: SidecarPalletStorageItem;
-  } = await callSidecar(`/pallets/staking/storage/ledger?keys[]=${addr}&key1=${addr}`, currency);
+  } = await callSidecar(`/pallets/staking/storage/ledger?keys[]=${addr}`, currency);
   return data.value?.stash ?? null;
 };
 
@@ -188,7 +188,7 @@ const fetchControllerAddr = async (
     data,
   }: {
     data: SidecarPalletStorageItem;
-  } = await callSidecar(`/pallets/staking/storage/bonded?keys[]=${addr}&key1=${addr}`, currency);
+  } = await callSidecar(`/pallets/staking/storage/bonded?keys[]=${addr}`, currency);
   return data.value ?? null;
 };
 
@@ -522,22 +522,17 @@ export const getTransactionParams = async (currency?: CryptoCurrency) => {
   };
 };
 
-type PostInfo = {
-  actualWeight: { refTime: string; proofSize: string } | null;
-  paysFee: "Yes" | "No";
-};
-
 type SubmitExtrinsicDryRunResponse = {
-  at: { hash: string; height: string };
-  result:
-    | {
-        resultType: "DispatchOutcome";
-        result: { postInfo: PostInfo; ok?: null };
-      }
-    | {
-        resultType: "DispatchError";
-        result: { postInfo: PostInfo; error: Record<string, unknown> };
-      };
+  // "DispatchOutcome": the call would succeed.
+  // "DispatchError": the call would be dispatched but fail (result holds { post_info, error }).
+  // "TransactionValidityError": the tx is invalid (result holds the validity error directly).
+  resultType: "DispatchOutcome" | "DispatchError" | "TransactionValidityError";
+  result: {
+    post_info?: Record<string, unknown>;
+    // present when resultType === "DispatchError"
+    error?: Record<string, unknown>;
+    [key: string]: unknown;
+  };
 };
 
 /**
@@ -562,8 +557,11 @@ export const submitExtrinsicDryRun = async (
     },
   );
 
-  if (data.result.resultType === "DispatchError") {
-    throw new Error(`polkadot: ${JSON.stringify(data.result.result.error)}`);
+  if (data.resultType === "DispatchError") {
+    throw new Error(`polkadot: ${JSON.stringify(data.result.error ?? data.result)}`);
+  }
+  if (data.resultType === "TransactionValidityError") {
+    throw new Error(`polkadot: ${JSON.stringify(data.result)}`);
   }
 
   return data;

--- a/libs/coin-modules/coin-polkadot/src/network/sidecar.unit.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/network/sidecar.unit.test.ts
@@ -106,9 +106,8 @@ describe("getAccount", () => {
       http.get(`${SIDECAR_BASE_URL_TEST}/pallets/staking/storage/bonded`, ({ request }) => {
         const url = new URL(request.url);
         const keys = url.searchParams.get("keys[]");
-        const key1 = url.searchParams.get("key1");
 
-        if (keys === "addr" && key1 === "addr") {
+        if (keys === "addr") {
           return HttpResponse.json({ value: {} });
         }
 
@@ -193,9 +192,8 @@ describe("getAccount", () => {
       http.get(`${SIDECAR_BASE_URL_TEST}/pallets/staking/storage/bonded`, ({ request }) => {
         const url = new URL(request.url);
         const keys = url.searchParams.get("keys[]");
-        const key1 = url.searchParams.get("key1");
 
-        if (keys === "addr" && key1 === "addr") {
+        if (keys === "addr") {
           return HttpResponse.json({ value: {} });
         }
 

--- a/libs/coin-modules/coin-polkadot/src/network/types.ts
+++ b/libs/coin-modules/coin-polkadot/src/network/types.ts
@@ -59,7 +59,8 @@ interface IChainType {
   asCustom?: Text;
 }
 interface IChainProperties {
-  ss58Format: string;
+  // Some chains (e.g. Westend Asset Hub) do not expose ss58Format in /runtime/spec.
+  ss58Format?: string;
   tokenDecimals: string;
   tokenSymbol: string;
 }

--- a/libs/env/src/env.ts
+++ b/libs/env/src/env.ts
@@ -139,8 +139,8 @@ const envDefinitions = {
   },
   API_POLKADOT_SIDECAR: {
     parser: stringParser,
-    def: "https://polkadot-sidecar.coin.ledger.com",
-    desc: "Polkadot Sidecar API url",
+    def: "https://polkadot-mainnet-rest-api.coin.ledger.com/v1/rc",
+    desc: "Polkadot rest-api base URL",
   },
   API_POLKADOT_SIDECAR_CREDENTIALS: {
     parser: stringParser,

--- a/libs/ledger-live-common/src/families/polkadot/config.ts
+++ b/libs/ledger-live-common/src/families/polkadot/config.ts
@@ -38,7 +38,7 @@ export const polkadotConfig: Record<string, ConfigInfo> = {
         ],
       },
       sidecar: {
-        url: "https://polkadot-asset-hub-sidecar.coin.ledger.com",
+        url: "https://polkadot-mainnet-rest-api.coin.ledger.com/v1",
       },
       node: {
         url: "https://polkadot-asset-hub-fullnodes.api.live.ledger.com",
@@ -63,7 +63,7 @@ export const polkadotConfig: Record<string, ConfigInfo> = {
         ],
       },
       sidecar: {
-        url: "https://polkadot-westend-sidecar.coin.ledger.com/rc",
+        url: "https://polkadot-westend-rest-api.coin.ledger.com/v1/rc",
       },
       node: {
         url: "https://polkadot-westend-fullnodes.api.live.ledger.com",
@@ -84,7 +84,7 @@ export const polkadotConfig: Record<string, ConfigInfo> = {
         ],
       },
       sidecar: {
-        url: "https://polkadot-westend-sidecar.coin.ledger.com",
+        url: "https://polkadot-westend-rest-api.coin.ledger.com/v1",
       },
       node: {
         url: "https://polkadot-westend-asset-hub-fullnodes.api.live.ledger.com",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _coin-polkadot integration tests (`sidecar.integ`, `broadcast.integ`, `api/index.integ`) and unit tests updated and green against the rest-api._
- [x] **Impact of the changes:**
  - Polkadot mainnet (relay chain + asset hub): account sync, balances, staking info, send/broadcast, fee estimation
  - Westend testnet (relay chain + asset hub): same flows
  - All requests now hit the new polkadot-rest-api host under the `/v1` (asset hub) / `/v1/rc` (relay) prefix

### 📝 Description

Migrate the Polkadot family off `substrate-api-sidecar` onto the new [`polkadot-rest-api`](https://github.com/paritytech/polkadot-rest-api) (a Rust rewrite), served under a `/v1` prefix (`/v1/rc` for the relay chain).

**Endpoints** — point each Polkadot currency's `sidecar.url` to the new rest-api:

| currency | new endpoint |
| --- | --- |
| `config_currency_polkadot` (relay) | `https://polkadot-mainnet-rest-api.coin.ledger.com/v1/rc` (via `API_POLKADOT_SIDECAR` default) |
| `config_currency_assethub_polkadot` | `https://polkadot-mainnet-rest-api.coin.ledger.com/v1` |
| `config_currency_westend` (relay) | `https://polkadot-westend-rest-api.coin.ledger.com/v1/rc` |
| `config_currency_assethub_westend` | `https://polkadot-westend-rest-api.coin.ledger.com/v1` |

**Client adaptations** — the rest-api turned out **not** to be fully 1:1 with `substrate-api-sidecar`, so `coin-polkadot` needed a few fixes:

- **Staking storage queries**: use `keys[]` only and drop the legacy `key1` query param — the rest-api rejects it (`unknown field 'key1'`), which broke `getAccount` / `getStakingInfo` / `isControllerAddress` on every network.
- **`ss58Format`**: tolerate it being absent from `/runtime/spec` (e.g. Westend Asset Hub) instead of producing `NaN` when building the registry.
- **Dry-run response**: parse the new `/transaction/dry-run` shape (`resultType` at the root, error under `result.error`, plus the new `TransactionValidityError` case). The rest-api dry-run also had a runtime-API arity bug (`DryRunApi.dry_run_call` called with 2 args instead of 3) — reported and **fixed server-side**.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29111](https://ledgerhq.atlassian.net/browse/LIVE-29111) (epic [LIVE-29106](https://ledgerhq.atlassian.net/browse/LIVE-29106))

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29111]: https://ledgerhq.atlassian.net/browse/LIVE-29111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
