### PR TITLE
[LWM] fix(llm): prevent duplicate transaction broadcast on device action re-render

### DIFF
--- a/.changeset/hedera-duplicate-broadcast.md
+++ b/.changeset/hedera-duplicate-broadcast.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix duplicate transaction broadcast in the send flow. The broadcast was triggered from a render prop, so any re-render of the device action result state re-submitted the same signed transaction (e.g. Hedera DUPLICATE_TRANSACTION). The broadcast now fires only once per device-action result.

--- a/apps/ledger-live-mobile/src/screens/ConnectDevice.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/ConnectDevice.test.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import ConnectDevice from "./ConnectDevice";
+import { ScreenName } from "~/const";
+
+const handleTx = jest.fn();
+
+jest.mock("~/logic/screenTransactionHooks", () => ({
+  useSignedTxHandler: () => handleTx,
+}));
+
+jest.mock("~/hooks/deviceActions", () => ({
+  useTransactionDeviceAction: () => ({}),
+}));
+
+jest.mock("LLM/hooks/useAccountScreen", () => ({
+  useAccountScreen: () => ({
+    account: { type: "Account", currency: { family: "hedera", id: "hedera" } },
+    parentAccount: null,
+  }),
+}));
+
+jest.mock("~/components/DeviceAction/rendering", () => ({
+  renderLoading: () => null,
+}));
+
+jest.mock("~/analytics", () => ({
+  TrackScreen: () => null,
+}));
+
+// Simulates the real DeviceAction component: once the device action reaches its
+// result state it calls `renderOnResult(payload)` on every render, including the
+// internal re-renders caused by subsequent device-action emissions.
+jest.mock("~/components/DeviceAction", () => {
+  const React = require("react");
+  const { Pressable, Text } = require("react-native");
+  const payload = { signedOperation: { signature: "sig", operation: {} } };
+  const MockDeviceAction = ({
+    renderOnResult,
+  }: {
+    renderOnResult?: (p: unknown) => React.ReactNode;
+  }) => {
+    const [, forceRender] = React.useState(0);
+    const ui = renderOnResult ? renderOnResult(payload) : null;
+    return React.createElement(
+      React.Fragment,
+      null,
+      ui,
+      React.createElement(
+        Pressable,
+        { testID: "rerender", onPress: () => forceRender((n: number) => n + 1) },
+        React.createElement(Text, null, "rerender"),
+      ),
+    );
+  };
+  return { __esModule: true, default: MockDeviceAction };
+});
+
+const baseRoute = {
+  key: "connect",
+  name: ScreenName.SendConnectDevice,
+  params: {
+    appName: "Hedera",
+    transaction: { mode: "send", family: "hedera" },
+    status: {},
+    device: { deviceId: "device-1", modelId: "stax", wired: false },
+    analyticsPropertyFlow: "send",
+  },
+};
+
+const navigation = {
+  navigate: jest.fn(),
+  replace: jest.fn(),
+  setOptions: jest.fn(),
+};
+
+describe("ConnectDevice broadcast (send flow)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("broadcasts only once even when the device action re-renders in the result state", async () => {
+    const { user } = render(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      <ConnectDevice route={baseRoute as any} navigation={navigation as any} />,
+    );
+
+    // The device action re-renders internally after reaching the signed result
+    // (e.g. a further connection/state emission). This must not re-broadcast.
+    await user.press(screen.getByTestId("rerender"));
+    await user.press(screen.getByTestId("rerender"));
+
+    expect(handleTx).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/ConnectDevice.tsx
@@ -1,5 +1,5 @@
 import invariant from "invariant";
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useMemo, useRef } from "react";
 import { StyleSheet } from "react-native";
 import { Edge, SafeAreaView } from "react-native-safe-area-context";
 import { useTranslation } from "~/context/Locale";
@@ -150,9 +150,17 @@ export default function ConnectDevice({ route, navigation }: Props) {
     account,
     parentAccount,
   });
+  // `renderOnResult` is invoked on every render of the DeviceAction result state,
+  // so guard the broadcast side-effect to fire only once per mount. Without this,
+  // any re-render while the signed result is shown re-broadcasts the same signed
+  // transaction (e.g. Hedera DUPLICATE_TRANSACTION).
+  const hasHandledTx = useRef(false);
   const onResult = useCallback(
     (payload: { signedOperation: SignedOperation; transactionSignError?: Error }) => {
-      handleTx(payload);
+      if (!hasHandledTx.current) {
+        hasHandledTx.current = true;
+        handleTx(payload);
+      }
       return renderLoading({
         t,
       });


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Added `ConnectDevice.test.tsx` (red→green): re-rendering the device-action result state broadcasts 3× before the fix, 1× after.
- [x] **Impact of the changes:** Mobile send/operation flow (all coin families using `ConnectDevice`). QA should focus on send + staking operations, confirming a single broadcast and no `DUPLICATE_TRANSACTION` (notably Hedera).

### 📝 Description

The mobile send flow fired the transaction broadcast from a **render prop**: `ConnectDevice` passed `renderOnResult={onResult}` where `onResult` called `handleTx(payload)` (→ broadcast) and `DeviceAction` invokes `renderOnResult(payload)` on **every render** of the result state.

Broadcast takes ~3s (`execAndWaitAtLeast`) before navigation unmounts the screen, so any re-render in that window re-submitted the **same signed transaction**. The first submission succeeds; the duplicate fails precheck — on Hedera this surfaced as `DUPLICATE_TRANSACTION` (the tx still went through, but the user saw a broadcast error screen).

Fix: guard the broadcast with a `useRef` so it fires once per device-action result. The loading UI is still rendered on every render; only the side-effect is gated. On a legitimate flow restart the screen remounts, resetting the guard.

The sibling `onResult` path was already guarded via `RenderOnResultCallback` (`useEffect([])`); this brings the `renderOnResult` send path in line.

### ❓ Context

- **JIRA or GitHub link**: N/A
- **ADR link (if any)**: N/A
