### PR TITLE
[LWDM] feat(LIVE-28050): hedera testnet support - part 4

### DIFF
--- a/.changeset/rare-points-jump.md
+++ b/.changeset/rare-points-jump.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-hedera": minor
+---
+
+refactor: hedera api client based on config

--- a/libs/coin-modules/coin-hedera/src/api/index.ts
+++ b/libs/coin-modules/coin-hedera/src/api/index.ts
@@ -131,7 +131,7 @@ export function createApi(
         });
         invariant(evmAddress, `hedera: evm address is missing for ${address}`);
         const [mirrorTokens, erc20TokenBalances] = await Promise.all([
-          apiClient.getAccountTokens(address),
+          apiClient.getAccountTokens({ configOrCurrencyId: coinConfig, address }),
           getERC20BalancesForAccountV2({ configOrCurrencyId: coinConfig, address }),
         ]);
 
@@ -151,7 +151,10 @@ export function createApi(
           useSyntheticBlocks: true,
         });
       } else {
-        const mirrorTokens = await apiClient.getAccountTokens(address);
+        const mirrorTokens = await apiClient.getAccountTokens({
+          configOrCurrencyId: coinConfig,
+          address,
+        });
 
         latestAccountOperations = await logicListOperations({
           config: coinConfig,

--- a/libs/coin-modules/coin-hedera/src/bridge/synchronisation.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/synchronisation.ts
@@ -53,8 +53,8 @@ const getAccountShapeV2 = async ({
   // tokens are fetched with separate requests to get "created_timestamp" for each token
   // based on this, ASSOCIATE_TOKEN operations can be connected with tokens
   const [mirrorAccount, mirrorTokens, erc20Tokens] = await Promise.all([
-    apiClient.getAccount(address),
-    apiClient.getAccountTokens(address),
+    apiClient.getAccount({ configOrCurrencyId: config, address }),
+    apiClient.getAccountTokens({ configOrCurrencyId: config, address }),
     getERC20BalancesForAccountV2({ configOrCurrencyId: config, address }),
   ]);
 
@@ -172,8 +172,8 @@ export const getAccountShape: GetAccountShape<HederaAccount> = async (
   // tokens are fetched with separate requests to get "created_timestamp" for each token
   // based on this, ASSOCIATE_TOKEN operations can be connected with tokens
   const [mirrorAccount, mirrorTokens, erc20TokenBalances] = await Promise.all([
-    apiClient.getAccount(address),
-    apiClient.getAccountTokens(address),
+    apiClient.getAccount({ configOrCurrencyId: config, address }),
+    apiClient.getAccountTokens({ configOrCurrencyId: config, address }),
     getERC20BalancesForAccount({ configOrCurrencyId: config, evmAccountId: evmAddress }),
   ]);
 
@@ -299,17 +299,15 @@ export const getAccountShape: GetAccountShape<HederaAccount> = async (
 };
 
 export const buildIterateResult: IterateResultBuilder = async ({ result: rootResult }) => {
-  const mirrorAccounts = await apiClient.getAccountsForPublicKey(rootResult.publicKey);
-  const addresses = mirrorAccounts.map(a => a.account);
-
   return async ({ currency, derivationMode, index }) => {
-    const derivationScheme = getDerivationScheme({
-      derivationMode,
-      currency,
+    const mirrorAccounts = await apiClient.getAccountsForPublicKey({
+      configOrCurrencyId: currency.id,
+      publicKey: rootResult.publicKey,
     });
-    const freshAddressPath = runDerivationScheme(derivationScheme, currency, {
-      account: index,
-    });
+
+    const addresses = mirrorAccounts.map(a => a.account);
+    const derivationScheme = getDerivationScheme({ derivationMode, currency });
+    const freshAddressPath = runDerivationScheme(derivationScheme, currency, { account: index });
 
     return addresses[index]
       ? ({

--- a/libs/coin-modules/coin-hedera/src/logic/estimateFees.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/estimateFees.test.ts
@@ -139,18 +139,19 @@ describe("getEstimatedFees", () => {
     expect(apiClient.getAccount).toHaveBeenCalledTimes(2);
     expect(apiClient.getNetworkFees).toHaveBeenCalledTimes(1);
     expect(apiClient.estimateContractCallGas).toHaveBeenCalledTimes(1);
-    expect(apiClient.estimateContractCallGas).toHaveBeenCalledWith(
-      await toEVMAddress({
+    expect(apiClient.estimateContractCallGas).toHaveBeenCalledWith({
+      configOrCurrencyId: mockedAccount.currency.id,
+      senderEvmAddress: await toEVMAddress({
         configOrCurrencyId: mockedAccount.currency.id,
         accountId: senderAddress,
       }),
-      await toEVMAddress({
+      recipientEvmAddress: await toEVMAddress({
         configOrCurrencyId: mockedAccount.currency.id,
         accountId: recipientAddress,
       }),
-      mockedTokenCurrencyERC20.contractAddress,
-      transferAmount,
-    );
+      contractEvmAddress: mockedTokenCurrencyERC20.contractAddress,
+      amount: transferAmount,
+    });
     expect(result).toMatchObject({
       tinybars: expectedTinybars,
       gas: expectedGas,

--- a/libs/coin-modules/coin-hedera/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/estimateFees.ts
@@ -40,13 +40,14 @@ const estimateContractCallFees = async ({
 
   try {
     const [networkFees, gasLimit] = await Promise.all([
-      apiClient.getNetworkFees(),
-      apiClient.estimateContractCallGas(
+      apiClient.getNetworkFees({ configOrCurrencyId }),
+      apiClient.estimateContractCallGas({
+        configOrCurrencyId,
         senderEvmAddress,
         recipientEvmAddress,
-        tokenEvmAddress,
-        txIntent.amount,
-      ),
+        contractEvmAddress: tokenEvmAddress,
+        amount: txIntent.amount,
+      }),
     ]);
 
     const contractCallFees = networkFees.fees.find(

--- a/libs/coin-modules/coin-hedera/src/logic/getBalance.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBalance.test.ts
@@ -44,9 +44,12 @@ describe("getBalance", () => {
     const result = await getBalance({ currencyId: mockCurrency.id, address });
 
     expect(apiClient.getAccount).toHaveBeenCalledTimes(1);
-    expect(apiClient.getAccount).toHaveBeenCalledWith(address);
+    expect(apiClient.getAccount).toHaveBeenCalledWith({ configOrCurrencyId: mockConfig, address });
     expect(apiClient.getAccountTokens).toHaveBeenCalledTimes(1);
-    expect(apiClient.getAccountTokens).toHaveBeenCalledWith(address);
+    expect(apiClient.getAccountTokens).toHaveBeenCalledWith({
+      configOrCurrencyId: mockConfig,
+      address,
+    });
     // non-staking account: no node lookup should happen
     expect(apiClient.getNode).not.toHaveBeenCalled();
     expect(apiClient.getNodes).not.toHaveBeenCalled();
@@ -95,9 +98,12 @@ describe("getBalance", () => {
     const result = await getBalance({ currencyId: mockCurrency.id, address });
 
     expect(apiClient.getAccount).toHaveBeenCalledTimes(1);
-    expect(apiClient.getAccount).toHaveBeenCalledWith(address);
+    expect(apiClient.getAccount).toHaveBeenCalledWith({ configOrCurrencyId: mockConfig, address });
     expect(apiClient.getAccountTokens).toHaveBeenCalledTimes(1);
-    expect(apiClient.getAccountTokens).toHaveBeenCalledWith(address);
+    expect(apiClient.getAccountTokens).toHaveBeenCalledWith({
+      configOrCurrencyId: mockConfig,
+      address,
+    });
     expect(networkUtils.getERC20BalancesForAccountV2).toHaveBeenCalledTimes(1);
     expect(networkUtils.getERC20BalancesForAccountV2).toHaveBeenCalledWith({
       configOrCurrencyId: mockConfig,
@@ -161,9 +167,12 @@ describe("getBalance", () => {
     const result = await getBalance({ currencyId: mockCurrency.id, address });
 
     expect(apiClient.getAccount).toHaveBeenCalledTimes(1);
-    expect(apiClient.getAccount).toHaveBeenCalledWith(address);
+    expect(apiClient.getAccount).toHaveBeenCalledWith({ configOrCurrencyId: mockConfig, address });
     expect(apiClient.getNode).toHaveBeenCalledTimes(1);
-    expect(apiClient.getNode).toHaveBeenCalledWith(mockMirrorAccount.staked_node_id);
+    expect(apiClient.getNode).toHaveBeenCalledWith({
+      configOrCurrencyId: mockConfig,
+      nodeId: mockMirrorAccount.staked_node_id,
+    });
     expect(apiClient.getNodes).not.toHaveBeenCalled();
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
@@ -327,7 +336,7 @@ describe("getBalance", () => {
     const result = await getBalance({ currencyId: mockCurrency.id, address });
 
     expect(apiClient.getAccount).toHaveBeenCalledTimes(1);
-    expect(apiClient.getAccount).toHaveBeenCalledWith(address);
+    expect(apiClient.getAccount).toHaveBeenCalledWith({ configOrCurrencyId: mockConfig, address });
     expect(result).toEqual([]);
   });
 });

--- a/libs/coin-modules/coin-hedera/src/logic/getBalance.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBalance.ts
@@ -25,15 +25,15 @@ export async function getBalance({
     // accounts) instead of paginating the full /network/nodes list. The
     // validator lookup is chained on the account promise so it still runs
     // concurrently with the token fetches.
-    const mirrorAccountPromise = apiClient.getAccount(address);
+    const mirrorAccountPromise = apiClient.getAccount({ configOrCurrencyId: coinConfig, address });
     const validatorPromise = mirrorAccountPromise.then(account =>
       typeof account.staked_node_id === "number" && account.staked_node_id >= 0
-        ? apiClient.getNode(account.staked_node_id)
+        ? apiClient.getNode({ configOrCurrencyId: coinConfig, nodeId: account.staked_node_id })
         : null,
     );
     const [mirrorAccount, mirrorTokens, erc20TokenBalances, validator] = await Promise.all([
       mirrorAccountPromise,
-      apiClient.getAccountTokens(address),
+      apiClient.getAccountTokens({ configOrCurrencyId: coinConfig, address }),
       coinConfig.useHgraphForErc20
         ? getERC20BalancesForAccountV2({ configOrCurrencyId: coinConfig, address })
         : Promise.resolve([]),

--- a/libs/coin-modules/coin-hedera/src/logic/getBlock.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBlock.test.ts
@@ -60,6 +60,7 @@ describe("getBlock", () => {
     expect(getBlockInfo).toHaveBeenCalledWith(42);
     expect(apiClient.getTransactionsByTimestampRange).toHaveBeenCalledTimes(1);
     expect(apiClient.getTransactionsByTimestampRange).toHaveBeenCalledWith({
+      configOrCurrencyId: "hedera",
       startTimestamp: `gte:1704067200.123`,
       endTimestamp: `lt:1704067260.456`,
     });

--- a/libs/coin-modules/coin-hedera/src/logic/getBlock.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBlock.ts
@@ -76,6 +76,7 @@ export async function getBlock({
 
   const blockInfo = await getBlockInfo(height);
   const transactions = await apiClient.getTransactionsByTimestampRange({
+    configOrCurrencyId,
     startTimestamp: `gte:${start.getTime() / 1000}`,
     endTimestamp: `lt:${end.getTime() / 1000}`,
   });

--- a/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.test.ts
@@ -85,6 +85,7 @@ describe("getBlockV2", () => {
     expect(getBlockInfo).toHaveBeenCalledWith(42);
     expect(apiClient.getTransactionsByTimestampRange).toHaveBeenCalledTimes(1);
     expect(apiClient.getTransactionsByTimestampRange).toHaveBeenCalledWith({
+      configOrCurrencyId,
       startTimestamp: `gte:1704067200.123`,
       endTimestamp: `lt:1704067260.456`,
       limit: 100,

--- a/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.ts
@@ -168,6 +168,7 @@ export async function getBlockV2({
   const [blockInfo, mirrorTransactions, enrichedERC20Transfers] = await Promise.all([
     getBlockInfo(height),
     apiClient.getTransactionsByTimestampRange({
+      configOrCurrencyId,
       startTimestamp: `gte:${startSeconds}`,
       endTimestamp: `lt:${endSeconds}`,
       limit,

--- a/libs/coin-modules/coin-hedera/src/logic/getRewards.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getRewards.test.ts
@@ -32,6 +32,7 @@ describe("getRewards", () => {
     expect(result.items).toEqual([]);
     expect(mockGetAccountTransactions).toHaveBeenCalledTimes(1);
     expect(mockGetAccountTransactions).toHaveBeenCalledWith({
+      configOrCurrencyId: mockCurrency.id,
       address: mockAddress,
       fetchAllPages: false,
       pagingToken: null,
@@ -181,6 +182,7 @@ describe("getRewards", () => {
     expect(result.next).toBe(nextCursor);
     expect(mockGetAccountTransactions).toHaveBeenCalledTimes(1);
     expect(mockGetAccountTransactions).toHaveBeenCalledWith({
+      configOrCurrencyId: mockCurrency.id,
       address: mockAddress,
       fetchAllPages: false,
       pagingToken: cursor,

--- a/libs/coin-modules/coin-hedera/src/logic/getRewards.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getRewards.ts
@@ -6,7 +6,7 @@ import { apiClient } from "../network/api";
  * Fetch staking rewards for a given Hedera account.
  */
 export async function getRewards({
-  configOrCurrencyId: _,
+  configOrCurrencyId,
   address,
   cursor,
 }: {
@@ -15,6 +15,7 @@ export async function getRewards({
   cursor: string | undefined;
 }): Promise<Page<Reward>> {
   const mirrorTransactions = await apiClient.getAccountTransactions({
+    configOrCurrencyId,
     address,
     fetchAllPages: false,
     pagingToken: cursor ?? null,

--- a/libs/coin-modules/coin-hedera/src/logic/getStakes.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getStakes.test.ts
@@ -27,7 +27,10 @@ describe("getStakes", () => {
 
     expect(result.items).toEqual([]);
     expect(mockGetAccount).toHaveBeenCalledTimes(1);
-    expect(mockGetAccount).toHaveBeenCalledWith(mockAddress);
+    expect(mockGetAccount).toHaveBeenCalledWith({
+      configOrCurrencyId: mockCurrency.id,
+      address: mockAddress,
+    });
     // when there's no staked_node_id we must not hit the nodes endpoint at all
     expect(mockGetNode).not.toHaveBeenCalled();
     expect(mockGetNodes).not.toHaveBeenCalled();
@@ -87,7 +90,10 @@ describe("getStakes", () => {
     const result = await getStakes({ configOrCurrencyId: mockCurrency.id, address: mockAddress });
 
     expect(mockGetNode).toHaveBeenCalledTimes(1);
-    expect(mockGetNode).toHaveBeenCalledWith(stakedNodeId);
+    expect(mockGetNode).toHaveBeenCalledWith({
+      configOrCurrencyId: mockCurrency.id,
+      nodeId: stakedNodeId,
+    });
     expect(result.items).toEqual([
       {
         uid: mockAddress,
@@ -134,7 +140,10 @@ describe("getStakes", () => {
 
     const result = await getStakes({ configOrCurrencyId: mockCurrency.id, address: mockAddress });
 
-    expect(mockGetNode).toHaveBeenCalledWith(nodeId);
+    expect(mockGetNode).toHaveBeenCalledWith({
+      configOrCurrencyId: mockCurrency.id,
+      nodeId,
+    });
     expect(result.items).toEqual([
       {
         uid: mockAddress,

--- a/libs/coin-modules/coin-hedera/src/logic/getStakes.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getStakes.ts
@@ -6,13 +6,13 @@ import { apiClient } from "../network/api";
  * Fetch stakes for a given Hedera account.
  */
 export async function getStakes({
-  configOrCurrencyId: _,
+  configOrCurrencyId,
   address,
 }: {
   configOrCurrencyId: HederaCoinConfig | string;
   address: string;
 }): Promise<Page<Stake>> {
-  const mirrorAccount = await apiClient.getAccount(address);
+  const mirrorAccount = await apiClient.getAccount({ configOrCurrencyId, address });
   const stakedNodeId = mirrorAccount.staked_node_id;
 
   if (typeof stakedNodeId !== "number") {
@@ -21,7 +21,10 @@ export async function getStakes({
 
   // -1 is used by the mirror node to indicate the account is no longer delegated
   // to any node (e.g. after an undelegation). In that case we skip the node lookup.
-  const delegatedNode = stakedNodeId >= 0 ? await apiClient.getNode(stakedNodeId) : null;
+  const delegatedNode =
+    stakedNodeId >= 0
+      ? await apiClient.getNode({ configOrCurrencyId, nodeId: stakedNodeId })
+      : null;
   const balance = BigInt(mirrorAccount.balance.balance);
   const pendingReward = BigInt(mirrorAccount.pending_reward);
 

--- a/libs/coin-modules/coin-hedera/src/logic/getValidators.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getValidators.test.ts
@@ -47,7 +47,11 @@ describe("getValidators", () => {
 
     const result = await getValidators({ configOrCurrencyId: mockCurrency.id, cursor: "100" });
 
-    expect(apiClient.getNodes).toHaveBeenCalledWith({ cursor: "100", fetchAllPages: false });
+    expect(apiClient.getNodes).toHaveBeenCalledWith({
+      configOrCurrencyId: mockCurrency.id,
+      cursor: "100",
+      fetchAllPages: false,
+    });
     expect(result.next).toBe("123");
   });
 });

--- a/libs/coin-modules/coin-hedera/src/logic/getValidators.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getValidators.ts
@@ -4,13 +4,14 @@ import { apiClient } from "../network/api";
 import { calculateAPY, extractCompanyFromNodeDescription } from "./utils";
 
 export async function getValidators({
-  configOrCurrencyId: _,
+  configOrCurrencyId,
   cursor,
 }: {
   configOrCurrencyId: HederaCoinConfig | string;
   cursor: Cursor | undefined;
 }): Promise<Page<Validator>> {
   const res = await apiClient.getNodes({
+    configOrCurrencyId,
     fetchAllPages: false,
     ...(cursor && { cursor }),
   });

--- a/libs/coin-modules/coin-hedera/src/logic/lastBlock.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/lastBlock.test.ts
@@ -41,14 +41,16 @@ describe("lastBlock", () => {
     const now = Date.now();
     await lastBlock({ configOrCurrencyId: mockCurrency.id });
 
-    // lastBlock() accounts for block window size: a transaction at the start of a block
+    // lastBlock({ configOrCurrencyId: "hedera" }) accounts for block window size: a transaction at the start of a block
     // creates a block whose END time is BLOCK_WINDOW later, so we query transactions
     // before (now - FINALITY_MS - BLOCK_WINDOW) to ensure getBlock() can fetch it.
     const expectedBefore = now - FINALITY_MS - BLOCK_WINDOW_MS;
 
+    const call = (apiClient.getLatestTransaction as jest.Mock).mock.calls[0][0];
+    const callDate = call.before as Date;
+
     expect(apiClient.getLatestTransaction).toHaveBeenCalledTimes(1);
-    const calledWithDate = (apiClient.getLatestTransaction as jest.Mock).mock.calls[0][0] as Date;
-    expect(calledWithDate.getTime()).toBeGreaterThanOrEqual(expectedBefore - 500);
-    expect(calledWithDate.getTime()).toBeLessThanOrEqual(expectedBefore + 500);
+    expect(callDate.getTime()).toBeGreaterThanOrEqual(expectedBefore - 500);
+    expect(callDate.getTime()).toBeLessThanOrEqual(expectedBefore + 500);
   });
 });

--- a/libs/coin-modules/coin-hedera/src/logic/lastBlock.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/lastBlock.ts
@@ -14,14 +14,14 @@ import { getSyntheticBlock } from "./utils";
  * 3. Convert this timestamp into a synthetic block using a hardcoded time window (10 seconds by default)
  */
 export async function lastBlock({
-  configOrCurrencyId: _,
+  configOrCurrencyId,
 }: {
   configOrCurrencyId: HederaCoinConfig | string;
 }): Promise<BlockInfo> {
   // see getBlock implementation, block data should be immutable: we do not allow querying blocks on non-finalized time range
   // => we search the most recent transaction, but only in finalized time range (ending 10 seconds ago).
   const before = new Date(Date.now() - FINALITY_MS - SYNTHETIC_BLOCK_WINDOW_SECONDS * 1000);
-  const latestTransaction = await apiClient.getLatestTransaction(before);
+  const latestTransaction = await apiClient.getLatestTransaction({ configOrCurrencyId, before });
   const syntheticBlock = getSyntheticBlock(latestTransaction.consensus_timestamp);
 
   return {

--- a/libs/coin-modules/coin-hedera/src/logic/lastBlock.v2.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/lastBlock.v2.test.ts
@@ -50,7 +50,8 @@ describe("lastBlockV2", () => {
     const expectedBefore = now - FINALITY_MS - BLOCK_WINDOW_MS;
 
     expect(apiClient.getLatestTransaction).toHaveBeenCalledTimes(1);
-    const calledWithDate = (apiClient.getLatestTransaction as jest.Mock).mock.calls[0][0] as Date;
+    const calledWithDate = (apiClient.getLatestTransaction as jest.Mock).mock.calls[0][0]
+      .before as Date;
     expect(calledWithDate.getTime()).toBeGreaterThanOrEqual(expectedBefore - 500);
     expect(calledWithDate.getTime()).toBeLessThanOrEqual(expectedBefore + 500);
   });

--- a/libs/coin-modules/coin-hedera/src/logic/lastBlock.v2.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/lastBlock.v2.ts
@@ -24,7 +24,7 @@ export async function lastBlockV2({
   // => we search the most recent transaction, but only in finalized time range (ending 10 seconds ago).
   const before = new Date(Date.now() - FINALITY_MS - SYNTHETIC_BLOCK_WINDOW_SECONDS * 1000);
   const [latestTransaction, latestHgraphTimestampNs] = await Promise.all([
-    apiClient.getLatestTransaction(before),
+    apiClient.getLatestTransaction({ configOrCurrencyId, before }),
     hgraphClient.getLatestIndexedConsensusTimestamp({ configOrCurrencyId }),
   ]);
 

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.test.ts
@@ -63,6 +63,7 @@ describe("listOperations", () => {
 
     expect(apiClient.getAccountTransactions).toHaveBeenCalledTimes(1);
     expect(apiClient.getAccountTransactions).toHaveBeenCalledWith({
+      configOrCurrencyId: mockCurrency.id,
       address,
       fetchAllPages: true,
       pagingToken: null,
@@ -333,6 +334,7 @@ describe("listOperations", () => {
 
     expect(apiClient.getAccountTransactions).toHaveBeenCalledTimes(1);
     expect(apiClient.getAccountTransactions).toHaveBeenCalledWith({
+      configOrCurrencyId: mockCurrency.id,
       address,
       fetchAllPages: true,
       pagingToken: "1625097500.000000000",

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.ts
@@ -273,6 +273,7 @@ export async function listOperations({
   const coinOperations: Operation<HederaOperationExtra>[] = [];
   const tokenOperations: Operation<HederaOperationExtra>[] = [];
   const mirrorResult = await apiClient.getAccountTransactions({
+    configOrCurrencyId: config ?? currencyId,
     address,
     pagingToken: cursor ?? null,
     order: order,

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
@@ -105,6 +105,7 @@ describe("listOperationsV2", () => {
 
     expect(apiClient.getAccountTransactions).toHaveBeenCalledTimes(1);
     expect(apiClient.getAccountTransactions).toHaveBeenCalledWith({
+      configOrCurrencyId: mockCurrency.id,
       address: mockMirrorAccount.account,
       fetchAllPages: true,
       pagingToken: null,
@@ -637,6 +638,7 @@ describe("listOperationsV2", () => {
 
     expect(apiClient.getAccountTransactions).toHaveBeenCalledTimes(1);
     expect(apiClient.getAccountTransactions).toHaveBeenCalledWith({
+      configOrCurrencyId: mockCurrency.id,
       address: mockMirrorAccount.account,
       fetchAllPages: true,
       pagingToken: lastPagingToken,

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
@@ -514,6 +514,7 @@ export async function listOperationsV2({
   const [mirrorTransactions, enrichedERC20Transfers, latestHgraphIndexedTimestampNs] =
     await Promise.all([
       apiClient.getAccountTransactions({
+        configOrCurrencyId: config ?? currencyId,
         address,
         order,
         limit,

--- a/libs/coin-modules/coin-hedera/src/network/api.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/api.test.ts
@@ -1,5 +1,8 @@
+import { LedgerAPI4xx } from "@ledgerhq/errors";
 import network from "@ledgerhq/live-network";
 import BigNumber from "bignumber.js";
+import { resolveConfig } from "../logic/utils";
+import { getMockedConfig } from "../test/fixtures/config.fixture";
 import { getMockResponse } from "../test/fixtures/network.fixture";
 import type {
   HederaMirrorContractCallResult,
@@ -9,293 +12,341 @@ import type {
 import { apiClient } from "./api";
 
 jest.mock("@ledgerhq/live-network");
+jest.mock("../logic/utils", () => ({
+  ...jest.requireActual("../logic/utils"),
+  resolveConfig: jest.fn(),
+}));
+
 const mockedNetwork = jest.mocked(network);
+const mockedResolveConfig = jest.mocked(resolveConfig);
 
-describe("getAccountTransactions", () => {
-  beforeEach(() => {
-    jest.resetAllMocks();
-  });
-
-  it("should include 'account.id', 'limit=100' and 'order=desc' query params", async () => {
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({ transactions: [], links: { next: null } }),
-    );
-
-    await apiClient.getAccountTransactions({
-      address: "0.0.1234",
-      pagingToken: null,
-      fetchAllPages: true,
-    });
-
-    const requestUrl = mockedNetwork.mock.calls[0][0].url;
-    expect(requestUrl).toContain("account.id=0.0.1234");
-    expect(requestUrl).toContain("limit=100");
-    expect(requestUrl).toContain("order=desc");
-  });
-
-  it("should keep fetching if fetchAllPages is set and links.next is present", async () => {
-    mockedNetwork
-      .mockResolvedValueOnce(
-        getMockResponse({
-          transactions: [{ consensus_timestamp: "1" }],
-          links: { next: "/next-1" },
-        }),
-      )
-      .mockResolvedValueOnce(
-        getMockResponse({
-          transactions: [],
-          links: { next: "/next-2" },
-        }),
-      )
-      .mockResolvedValueOnce(
-        getMockResponse({
-          transactions: [{ consensus_timestamp: "3" }],
-          links: { next: "/next-3" },
-        }),
-      )
-      .mockResolvedValueOnce(
-        getMockResponse({
-          transactions: [{ consensus_timestamp: "4" }],
-          links: { next: "/next-4" },
-        }),
-      )
-      .mockResolvedValueOnce(
-        getMockResponse({
-          transactions: [],
-          links: { next: null },
-        }),
-      );
-
-    const result = await apiClient.getAccountTransactions({
-      address: "0.0.1234",
-      pagingToken: null,
-      fetchAllPages: true,
-    });
-
-    expect(result.transactions.map(tx => tx.consensus_timestamp)).toEqual(["1", "3", "4"]);
-    expect(result.nextCursor).toBeNull();
-    expect(mockedNetwork).toHaveBeenCalledTimes(5);
-  });
-
-  it("should paginate if fetchAllPages is not set", async () => {
-    mockedNetwork
-      .mockResolvedValueOnce(
-        getMockResponse({
-          transactions: [{ consensus_timestamp: "1" }],
-          links: { next: "/next-1" },
-        }),
-      )
-      .mockResolvedValueOnce(
-        getMockResponse({
-          transactions: [],
-          links: { next: "/next-2" },
-        }),
-      )
-      .mockResolvedValueOnce(
-        getMockResponse({
-          transactions: [{ consensus_timestamp: "3" }],
-          links: { next: "/next-3" },
-        }),
-      )
-      .mockResolvedValueOnce(
-        getMockResponse({
-          transactions: [{ consensus_timestamp: "4" }],
-          links: { next: "/next-4" },
-        }),
-      )
-      .mockResolvedValueOnce(
-        getMockResponse({
-          transactions: [],
-          links: { next: null },
-        }),
-      );
-
-    const result = await apiClient.getAccountTransactions({
-      address: "0.0.1234",
-      pagingToken: null,
-      limit: 2,
-      fetchAllPages: false,
-    });
-
-    expect(result.transactions.map(tx => tx.consensus_timestamp)).toEqual(["1", "3"]);
-    expect(result.nextCursor).toBe("3");
-    expect(mockedNetwork).toHaveBeenCalledTimes(3);
-  });
-});
-
-describe("getAccount", () => {
+describe("apiClient", () => {
   const mockAddress = "0.0.1234";
+  const mockConfig = getMockedConfig();
 
   beforeEach(() => {
     jest.resetAllMocks();
+
+    mockedResolveConfig.mockReturnValue(mockConfig);
   });
 
-  it("should call the correct endpoint and return account data", async () => {
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({
-        account: mockAddress,
-        max_automatic_token_associations: 0,
-        balance: {
-          balance: 1000,
-          timestamp: "1749047764.000113442",
-          tokens: [],
-        },
-      }),
-    );
+  describe("getAccountsForPublicKey", () => {
+    it("should call the correct endpoint and return accounts", async () => {
+      const mockAccounts = [{ account: "0.0.1234" }, { account: "0.0.5678" }];
+      mockedNetwork.mockResolvedValueOnce(getMockResponse({ accounts: mockAccounts }));
 
-    const result = await apiClient.getAccount(mockAddress);
-    const requestUrl = mockedNetwork.mock.calls[0][0].url;
+      const result = await apiClient.getAccountsForPublicKey({
+        configOrCurrencyId: mockConfig,
+        publicKey: "abc123",
+      });
+      const requestUrl = mockedNetwork.mock.calls[0][0].url;
 
-    expect(result.account).toEqual(mockAddress);
-    expect(requestUrl).toContain(`/api/v1/accounts/${mockAddress}?transactions=false`);
-    expect(mockedNetwork).toHaveBeenCalledTimes(1);
-  });
+      expect(result).toEqual(mockAccounts);
+      expect(requestUrl).toContain("/api/v1/accounts");
+      expect(requestUrl).toContain("account.publicKey=abc123");
+      expect(requestUrl).toContain("balance=true");
+      expect(requestUrl).toContain("limit=100");
+      expect(mockedNetwork).toHaveBeenCalledTimes(1);
+    });
 
-  it("supports timestamp filter", async () => {
-    const mockAccount = { account: mockAddress, staked_node_id: null };
-    const timestamp = "lt:1762202064.065172388";
+    it("should return empty array on LedgerAPI4xx error", async () => {
+      mockedNetwork.mockRejectedValueOnce(new LedgerAPI4xx());
 
-    (network as jest.Mock).mockResolvedValueOnce({ data: mockAccount });
+      const result = await apiClient.getAccountsForPublicKey({
+        configOrCurrencyId: mockConfig,
+        publicKey: "abc123",
+      });
 
-    const result = await apiClient.getAccount(mockAddress, timestamp);
-    const requestUrl = mockedNetwork.mock.calls[0][0].url;
+      expect(result).toEqual([]);
+    });
 
-    expect(mockedNetwork).toHaveBeenCalledTimes(1);
-    expect(result).toEqual(mockAccount);
-    expect(requestUrl).toContain(
-      `/api/v1/accounts/${mockAddress}?transactions=false&timestamp=${encodeURIComponent(timestamp)}`,
-    );
-  });
-});
+    it("should rethrow non-LedgerAPI4xx errors", async () => {
+      const error = new Error("network error");
+      mockedNetwork.mockRejectedValueOnce(error);
 
-describe("getAccountTokens", () => {
-  beforeEach(() => {
-    jest.resetAllMocks();
-  });
-
-  it("should return all tokens if only one page is needed", async () => {
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({
-        tokens: [
-          { token_id: "0.0.1001", balance: 10 },
-          { token_id: "0.0.1002", balance: 20 },
-        ],
-        links: { next: null },
-      }),
-    );
-
-    const result = await apiClient.getAccountTokens("0.0.1234");
-    const requestUrl = mockedNetwork.mock.calls[0][0].url;
-
-    expect(result.map(t => t.token_id)).toEqual(["0.0.1001", "0.0.1002"]);
-    expect(requestUrl).toContain("/api/v1/accounts/0.0.1234/tokens");
-    expect(requestUrl).toContain("limit=100");
-    expect(mockedNetwork).toHaveBeenCalledTimes(1);
-  });
-
-  it("should keep fetching if links.next is present and new tokens are returned", async () => {
-    mockedNetwork
-      .mockResolvedValueOnce(
-        getMockResponse({
-          tokens: [{ token_id: "0.0.1001", balance: 10 }],
-          links: { next: "/next-1" },
+      await expect(
+        apiClient.getAccountsForPublicKey({
+          configOrCurrencyId: mockConfig,
+          publicKey: "abc123",
         }),
-      )
-      .mockResolvedValueOnce(
+      ).rejects.toThrow(error);
+    });
+  });
+
+  describe("getAccountTransactions", () => {
+    it("should include 'account.id', 'limit=100' and 'order=desc' query params", async () => {
+      mockedNetwork.mockResolvedValueOnce(
+        getMockResponse({ transactions: [], links: { next: null } }),
+      );
+
+      await apiClient.getAccountTransactions({
+        configOrCurrencyId: mockConfig,
+        address: "0.0.1234",
+        pagingToken: null,
+        fetchAllPages: true,
+      });
+
+      const requestUrl = mockedNetwork.mock.calls[0][0].url;
+      expect(requestUrl).toContain("account.id=0.0.1234");
+      expect(requestUrl).toContain("limit=100");
+      expect(requestUrl).toContain("order=desc");
+    });
+
+    it("should keep fetching if fetchAllPages is set and links.next is present", async () => {
+      mockedNetwork
+        .mockResolvedValueOnce(
+          getMockResponse({
+            transactions: [{ consensus_timestamp: "1" }],
+            links: { next: "/next-1" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          getMockResponse({
+            transactions: [],
+            links: { next: "/next-2" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          getMockResponse({
+            transactions: [{ consensus_timestamp: "3" }],
+            links: { next: "/next-3" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          getMockResponse({
+            transactions: [{ consensus_timestamp: "4" }],
+            links: { next: "/next-4" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          getMockResponse({
+            transactions: [],
+            links: { next: null },
+          }),
+        );
+
+      const result = await apiClient.getAccountTransactions({
+        configOrCurrencyId: mockConfig,
+        address: "0.0.1234",
+        pagingToken: null,
+        fetchAllPages: true,
+      });
+
+      expect(result.transactions.map(tx => tx.consensus_timestamp)).toEqual(["1", "3", "4"]);
+      expect(result.nextCursor).toBeNull();
+      expect(mockedNetwork).toHaveBeenCalledTimes(5);
+    });
+
+    it("should paginate if fetchAllPages is not set", async () => {
+      mockedNetwork
+        .mockResolvedValueOnce(
+          getMockResponse({
+            transactions: [{ consensus_timestamp: "1" }],
+            links: { next: "/next-1" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          getMockResponse({
+            transactions: [],
+            links: { next: "/next-2" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          getMockResponse({
+            transactions: [{ consensus_timestamp: "3" }],
+            links: { next: "/next-3" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          getMockResponse({
+            transactions: [{ consensus_timestamp: "4" }],
+            links: { next: "/next-4" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          getMockResponse({
+            transactions: [],
+            links: { next: null },
+          }),
+        );
+
+      const result = await apiClient.getAccountTransactions({
+        configOrCurrencyId: mockConfig,
+        address: "0.0.1234",
+        pagingToken: null,
+        limit: 2,
+        fetchAllPages: false,
+      });
+
+      expect(result.transactions.map(tx => tx.consensus_timestamp)).toEqual(["1", "3"]);
+      expect(result.nextCursor).toBe("3");
+      expect(mockedNetwork).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe("getAccount", () => {
+    it("should call the correct endpoint and return account data", async () => {
+      mockedNetwork.mockResolvedValueOnce(
         getMockResponse({
-          tokens: [{ token_id: "0.0.1002", balance: 20 }],
+          account: mockAddress,
+          max_automatic_token_associations: 0,
+          balance: {
+            balance: 1000,
+            timestamp: "1749047764.000113442",
+            tokens: [],
+          },
+        }),
+      );
+
+      const result = await apiClient.getAccount({
+        configOrCurrencyId: mockConfig,
+        address: mockAddress,
+      });
+      const requestUrl = mockedNetwork.mock.calls[0][0].url;
+
+      expect(result.account).toEqual(mockAddress);
+      expect(requestUrl).toContain(`/api/v1/accounts/${mockAddress}?transactions=false`);
+      expect(mockedNetwork).toHaveBeenCalledTimes(1);
+    });
+
+    it("supports timestamp filter", async () => {
+      const mockAccount = { account: mockAddress, staked_node_id: null };
+      const timestamp = "lt:1762202064.065172388";
+
+      (network as jest.Mock).mockResolvedValueOnce({ data: mockAccount });
+
+      const result = await apiClient.getAccount({
+        configOrCurrencyId: mockConfig,
+        address: mockAddress,
+        timestamp,
+      });
+      const requestUrl = mockedNetwork.mock.calls[0][0].url;
+
+      expect(mockedNetwork).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(mockAccount);
+      expect(requestUrl).toContain(
+        `/api/v1/accounts/${mockAddress}?transactions=false&timestamp=${encodeURIComponent(timestamp)}`,
+      );
+    });
+  });
+
+  describe("getAccountTokens", () => {
+    it("should return all tokens if only one page is needed", async () => {
+      mockedNetwork.mockResolvedValueOnce(
+        getMockResponse({
+          tokens: [
+            { token_id: "0.0.1001", balance: 10 },
+            { token_id: "0.0.1002", balance: 20 },
+          ],
           links: { next: null },
         }),
       );
 
-    const result = await apiClient.getAccountTokens("0.0.1234");
+      const result = await apiClient.getAccountTokens({
+        configOrCurrencyId: mockConfig,
+        address: "0.0.1234",
+      });
+      const requestUrl = mockedNetwork.mock.calls[0][0].url;
 
-    expect(result.map(t => t.token_id)).toEqual(["0.0.1001", "0.0.1002"]);
-    expect(mockedNetwork).toHaveBeenCalledTimes(2);
-  });
-});
+      expect(result.map(t => t.token_id)).toEqual(["0.0.1001", "0.0.1002"]);
+      expect(requestUrl).toContain("/api/v1/accounts/0.0.1234/tokens");
+      expect(requestUrl).toContain("limit=100");
+      expect(mockedNetwork).toHaveBeenCalledTimes(1);
+    });
 
-describe("getNetworkFees", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
+    it("should keep fetching if links.next is present and new tokens are returned", async () => {
+      mockedNetwork
+        .mockResolvedValueOnce(
+          getMockResponse({
+            tokens: [{ token_id: "0.0.1001", balance: 10 }],
+            links: { next: "/next-1" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          getMockResponse({
+            tokens: [{ token_id: "0.0.1002", balance: 20 }],
+            links: { next: null },
+          }),
+        );
 
-  it("should call the correct endpoint and return network fees", async () => {
-    const mockedResults: HederaMirrorNetworkFees = {
-      fees: [{ gas: 39, transaction_type: "ContractCall" }],
-      timestamp: "1758733200.632122898",
-    };
+      const result = await apiClient.getAccountTokens({
+        configOrCurrencyId: mockConfig,
+        address: "0.0.1234",
+      });
 
-    mockedNetwork.mockResolvedValueOnce(getMockResponse(mockedResults));
-
-    const result = await apiClient.getNetworkFees();
-    const requestUrl = mockedNetwork.mock.calls[0][0].url;
-
-    expect(result).toEqual(mockedResults);
-    expect(requestUrl).toContain("/api/v1/network/fees");
-    expect(mockedNetwork).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("getLatestBlock", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it("should return latest block", async () => {
-    const latestBlock = {
-      timestamp: { from: "1758733199.000000000", to: "1758733200.632122898" },
-    };
-
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({
-        blocks: [latestBlock],
-        links: { next: null },
-      }),
-    );
-
-    const result = await apiClient.getLatestBlock();
-
-    expect(result).toEqual(latestBlock);
-    expect(mockedNetwork).toHaveBeenCalledTimes(1);
-    expect(mockedNetwork.mock.calls[0][0].url).toContain("/api/v1/blocks");
-    expect(mockedNetwork.mock.calls[0][0].url).toContain("limit=1");
-    expect(mockedNetwork.mock.calls[0][0].url).toContain("order=desc");
+      expect(result.map(t => t.token_id)).toEqual(["0.0.1001", "0.0.1002"]);
+      expect(mockedNetwork).toHaveBeenCalledTimes(2);
+    });
   });
 
-  it("should throw when no blocks are returned", async () => {
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({
-        blocks: [],
-        links: { next: null },
-      }),
-    );
+  describe("getNetworkFees", () => {
+    it("should call the correct endpoint and return network fees", async () => {
+      const mockedResults: HederaMirrorNetworkFees = {
+        fees: [{ gas: 39, transaction_type: "ContractCall" }],
+        timestamp: "1758733200.632122898",
+      };
 
-    await expect(apiClient.getLatestBlock()).rejects.toThrow(
-      "No blocks found on the Hedera network",
-    );
-    expect(mockedNetwork).toHaveBeenCalledTimes(1);
-  });
-});
+      mockedNetwork.mockResolvedValueOnce(getMockResponse(mockedResults));
 
-describe("getContractCallResult", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
+      const result = await apiClient.getNetworkFees({ configOrCurrencyId: mockConfig });
+      const requestUrl = mockedNetwork.mock.calls[0][0].url;
+
+      expect(result).toEqual(mockedResults);
+      expect(requestUrl).toContain("/api/v1/network/fees");
+      expect(mockedNetwork).toHaveBeenCalledTimes(1);
+    });
   });
 
-  it("should call the correct endpoint and return results for contract call", async () => {
-    const mockedResults: HederaMirrorContractCallResult = {
-      contract_id: "0.0.4321",
-      block_gas_used: 100,
-      block_hash: "0xabc",
-      gas_consumed: 200,
-      gas_limit: 10000,
-      gas_used: 150,
-      timestamp: "xxxxxxxxx",
-    };
+  describe("getLatestBlock", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
 
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({
+    it("should return latest block", async () => {
+      const latestBlock = {
+        timestamp: { from: "1758733199.000000000", to: "1758733200.632122898" },
+      };
+
+      mockedNetwork.mockResolvedValueOnce(
+        getMockResponse({
+          blocks: [latestBlock],
+          links: { next: null },
+        }),
+      );
+
+      const result = await apiClient.getLatestBlock({
+        configOrCurrencyId: mockConfig,
+      });
+
+      expect(result).toEqual(latestBlock);
+      expect(mockedNetwork).toHaveBeenCalledTimes(1);
+      expect(mockedNetwork.mock.calls[0][0].url).toContain("/api/v1/blocks");
+      expect(mockedNetwork.mock.calls[0][0].url).toContain("limit=1");
+      expect(mockedNetwork.mock.calls[0][0].url).toContain("order=desc");
+    });
+
+    it("should throw when no blocks are returned", async () => {
+      mockedNetwork.mockResolvedValueOnce(
+        getMockResponse({
+          blocks: [],
+          links: { next: null },
+        }),
+      );
+
+      await expect(apiClient.getLatestBlock({ configOrCurrencyId: mockConfig })).rejects.toThrow(
+        "No blocks found on the Hedera network",
+      );
+      expect(mockedNetwork).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("getContractCallResult", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("should call the correct endpoint and return results for contract call", async () => {
+      const mockedResults: HederaMirrorContractCallResult = {
         contract_id: "0.0.4321",
         block_gas_used: 100,
         block_hash: "0xabc",
@@ -303,490 +354,507 @@ describe("getContractCallResult", () => {
         gas_limit: 10000,
         gas_used: 150,
         timestamp: "xxxxxxxxx",
-      }),
-    );
+      };
 
-    const result = await apiClient.getContractCallResult(
-      "0xa9059cbb000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000186a0",
-    );
-    const requestUrl = mockedNetwork.mock.calls[0][0].url;
-
-    expect(result).toEqual(mockedResults);
-    expect(requestUrl).toContain("/api/v1/contracts/results");
-    expect(mockedNetwork).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("findTransactionByContractCall", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it("should call the correct endpoint and return transaction details", async () => {
-    const mockedResults: HederaMirrorTransaction = {
-      transfers: [],
-      token_transfers: [],
-      staking_reward_transfers: [],
-      charged_tx_fee: 100,
-      transaction_id: "xxxxxxxxxxxxxx",
-      transaction_hash: "xxxxxxxxxxxxx",
-      consensus_timestamp: "xxxxxxxxxxxxx",
-      result: "xxxxxxxxxxxxx",
-      entity_id: "0.0.1234",
-      name: "CONTRACTCALL",
-      node: null,
-      nonce: 0,
-      parent_consensus_timestamp: null,
-    };
-
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({
-        transactions: [mockedResults],
-      }),
-    );
-
-    const result = await apiClient.findTransactionByContractCall(
-      "xxxxxxxxxxxxxxxxxxxx",
-      "0.0.1234",
-    );
-    const requestUrl = mockedNetwork.mock.calls[0][0].url;
-
-    expect(result).toEqual(mockedResults);
-    expect(requestUrl).toContain("/api/v1/transactions?timestamp=");
-    expect(mockedNetwork).toHaveBeenCalledTimes(1);
-  });
-
-  it("should call the correct endpoint and return null for non existing contract calls", async () => {
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({
-        transactions: [
-          {
-            transfers: [],
-            token_transfers: [],
-            staking_reward_transfers: [],
-            charged_tx_fee: 100,
-            transaction_hash: "xxxxxxxxxxxxx",
-            consensus_timestamp: "xxxxxxxxxxxxx",
-            result: "xxxxxxxxxxxxx",
-            entity_id: "0.0.1234",
-            name: "NOT_CONTRACTCALL",
-          },
-          {
-            transfers: [],
-            token_transfers: [],
-            staking_reward_transfers: [],
-            charged_tx_fee: 100,
-            transaction_hash: "xxxxxxxxxxxxx",
-            consensus_timestamp: "xxxxxxxxxxxxx",
-            result: "xxxxxxxxxxxxx",
-            entity_id: "0.0.1111",
-            name: "CONTRACTCALL",
-          },
-        ] satisfies Partial<HederaMirrorTransaction>[],
-      }),
-    );
-
-    const result = await apiClient.findTransactionByContractCall(
-      "xxxxxxxxxxxxxxxxxxxx",
-      "0.0.1234",
-    );
-    const requestUrl = mockedNetwork.mock.calls[0][0].url;
-
-    expect(result).toEqual(null);
-    expect(requestUrl).toContain("/api/v1/transactions?timestamp=");
-    expect(mockedNetwork).toHaveBeenCalledTimes(1);
-  });
-
-  it("should call the correct endpoint and return null for empty transactions list", async () => {
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({
-        transactions: [],
-      }),
-    );
-
-    const result = await apiClient.findTransactionByContractCall(
-      "xxxxxxxxxxxxxxxxxxxx",
-      "0.0.1234",
-    );
-    const requestUrl = mockedNetwork.mock.calls[0][0].url;
-
-    expect(result).toEqual(null);
-    expect(requestUrl).toContain("/api/v1/transactions?timestamp=");
-    expect(mockedNetwork).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("findTransactionByContractCallV2", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it("should call the correct endpoint and return transaction details", async () => {
-    const mockConsensusTimestamp = "1758733200.632122898";
-    const mockPayerAddress = "0.0.1234";
-    const mockedResults: HederaMirrorTransaction = {
-      transfers: [],
-      token_transfers: [],
-      staking_reward_transfers: [],
-      charged_tx_fee: 100,
-      transaction_hash: "",
-      result: "",
-      consensus_timestamp: mockConsensusTimestamp,
-      entity_id: "0.0.1",
-      transaction_id: `${mockPayerAddress}-${mockConsensusTimestamp}`,
-      name: "CONTRACTCALL",
-      node: null,
-      nonce: 0,
-      parent_consensus_timestamp: null,
-    };
-
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({
-        transactions: [mockedResults],
-      }),
-    );
-
-    const result = await apiClient.findTransactionByContractCallV2({
-      timestamp: mockConsensusTimestamp,
-      payerAddress: mockPayerAddress,
-    });
-    const requestUrl = mockedNetwork.mock.calls[0][0].url;
-
-    expect(result).toEqual(mockedResults);
-    expect(requestUrl).toContain("/api/v1/transactions?limit=100&order=desc");
-    expect(requestUrl).toContain("timestamp=gte");
-    expect(requestUrl).toContain("timestamp=lte");
-    expect(mockedNetwork).toHaveBeenCalledTimes(1);
-  });
-
-  it("should return null for non existing contract calls", async () => {
-    const mockConsensusTimestamp1 = "1758733200.632122898";
-    const mockConsensusTimestamp2 = "1758733300.632122898";
-    const mockPayerAddress1 = "0.0.1234";
-    const mockPayerAddress2 = "0.0.4321";
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({
-        transactions: [
-          {
-            transfers: [],
-            token_transfers: [],
-            staking_reward_transfers: [],
-            charged_tx_fee: 100,
-            transaction_hash: "zzz",
-            transaction_id: `${mockPayerAddress1}-${mockConsensusTimestamp1}`,
-            consensus_timestamp: mockConsensusTimestamp1,
-            result: "",
-            entity_id: "0.0.1",
-            name: "NOT_CONTRACTCALL",
-          },
-          {
-            transfers: [],
-            token_transfers: [],
-            staking_reward_transfers: [],
-            charged_tx_fee: 100,
-            transaction_hash: "yyy",
-            transaction_id: `${mockPayerAddress2}-${mockConsensusTimestamp2}`,
-            consensus_timestamp: mockConsensusTimestamp2,
-            result: "",
-            entity_id: "0.0.2",
-            name: "CONTRACTCALL",
-          },
-        ] satisfies Partial<HederaMirrorTransaction>[],
-      }),
-    );
-
-    const result = await apiClient.findTransactionByContractCallV2({
-      timestamp: mockConsensusTimestamp1,
-      payerAddress: mockPayerAddress1,
-    });
-
-    expect(result).toEqual(null);
-  });
-
-  it("should call the correct endpoint and return null for empty transactions list", async () => {
-    const mockConsensusTimestamp = "1758733200.632122898";
-    const mockPayerAddress = "0.0.1234";
-
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({
-        transactions: [],
-      }),
-    );
-
-    const result = await apiClient.findTransactionByContractCallV2({
-      timestamp: mockConsensusTimestamp,
-      payerAddress: mockPayerAddress,
-    });
-
-    expect(result).toEqual(null);
-  });
-});
-
-describe("getERC20Balance", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it("should call the correct endpoint and return the contract balance", async () => {
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({
-        result: "1000000000",
-      }),
-    );
-
-    const result = await apiClient.getERC20Balance(
-      "0x0000000000000000000000000000000000000001",
-      "0x0000000000000000000000000000000000000002",
-    );
-    const requestUrl = mockedNetwork.mock.calls[0][0].url;
-
-    expect(result).toEqual(BigNumber("1000000000"));
-    expect(requestUrl).toContain("/api/v1/contracts/call");
-    expect(mockedNetwork).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("estimateContractCallGas", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it("should call the correct endpoint and return estimated contract call gas", async () => {
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({
-        result: "1000000000",
-      }),
-    );
-
-    const result = await apiClient.estimateContractCallGas(
-      "0x0000000000000000000000000000000000000001",
-      "0x0000000000000000000000000000000000000002",
-      "0xa9059cbb000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000186a0",
-      BigInt(1000),
-    );
-    const requestUrl = mockedNetwork.mock.calls[0][0].url;
-
-    expect(result).toEqual(BigNumber("1000000000"));
-    expect(requestUrl).toContain("/api/v1/contracts/call");
-    expect(mockedNetwork).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("getTransactionsByTimestampRange", () => {
-  beforeEach(() => {
-    jest.resetAllMocks();
-  });
-
-  it("should include account.id query param if address is provided", async () => {
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({ transactions: [], links: { next: null } }),
-    );
-
-    await apiClient.getTransactionsByTimestampRange({
-      address: "0.0.1234",
-      startTimestamp: "gte:1000.000000000",
-      endTimestamp: "lt:2000.000000000",
-    });
-
-    const requestUrl = mockedNetwork.mock.calls[0][0].url;
-    expect(requestUrl).toContain("account.id=0.0.1234");
-  });
-
-  it("should include correct query params with timestamp range", async () => {
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({ transactions: [], links: { next: null } }),
-    );
-
-    await apiClient.getTransactionsByTimestampRange({
-      startTimestamp: "gte:1000.000000000",
-      endTimestamp: "lt:2000.000000000",
-    });
-
-    const requestUrl = mockedNetwork.mock.calls[0][0].url;
-    expect(requestUrl).not.toContain("account.id=");
-    expect(requestUrl).toContain("timestamp=gte%3A1000.000000000");
-    expect(requestUrl).toContain("timestamp=lt%3A2000.000000000");
-    expect(requestUrl).toContain("limit=100");
-    expect(requestUrl).toContain("order=desc");
-  });
-
-  it("should return empty array when no transactions found", async () => {
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({ transactions: [], links: { next: null } }),
-    );
-
-    const result = await apiClient.getTransactionsByTimestampRange({
-      startTimestamp: "gte:1000.000000000",
-      endTimestamp: "lt:2000.000000000",
-    });
-
-    expect(result).toEqual([]);
-    expect(mockedNetwork).toHaveBeenCalledTimes(1);
-  });
-
-  it("should return all transactions when only one page is needed", async () => {
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({
-        transactions: [
-          { consensus_timestamp: "1500.123456789" },
-          { consensus_timestamp: "1750.987654321" },
-        ],
-        links: { next: null },
-      }),
-    );
-
-    const result = await apiClient.getTransactionsByTimestampRange({
-      startTimestamp: "gte:1000.000000000",
-      endTimestamp: "lt:2000.000000000",
-    });
-
-    expect(result.map(tx => tx.consensus_timestamp)).toEqual(["1500.123456789", "1750.987654321"]);
-    expect(mockedNetwork).toHaveBeenCalledTimes(1);
-  });
-
-  it("should keep fetching all pages when links.next is present", async () => {
-    mockedNetwork
-      .mockResolvedValueOnce(
+      mockedNetwork.mockResolvedValueOnce(
         getMockResponse({
-          transactions: [{ consensus_timestamp: "1100.000000000" }],
-          links: { next: "/next-1" },
-        }),
-      )
-      .mockResolvedValueOnce(
-        getMockResponse({
-          transactions: [{ consensus_timestamp: "1200.000000000" }],
-          links: { next: "/next-2" },
-        }),
-      )
-      .mockResolvedValueOnce(
-        getMockResponse({
-          transactions: [{ consensus_timestamp: "1300.000000000" }],
-          links: { next: null },
+          contract_id: "0.0.4321",
+          block_gas_used: 100,
+          block_hash: "0xabc",
+          gas_consumed: 200,
+          gas_limit: 10000,
+          gas_used: 150,
+          timestamp: "xxxxxxxxx",
         }),
       );
 
-    const result = await apiClient.getTransactionsByTimestampRange({
-      startTimestamp: "gte:1000.000000000",
-      endTimestamp: "lt:2000.000000000",
-    });
+      const result = await apiClient.getContractCallResult({
+        configOrCurrencyId: mockConfig,
+        transactionHash:
+          "0xa9059cbb000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000186a0",
+      });
+      const requestUrl = mockedNetwork.mock.calls[0][0].url;
 
-    expect(result.map(tx => tx.consensus_timestamp)).toEqual([
-      "1100.000000000",
-      "1200.000000000",
-      "1300.000000000",
-    ]);
-    expect(mockedNetwork).toHaveBeenCalledTimes(3);
+      expect(result).toEqual(mockedResults);
+      expect(requestUrl).toContain("/api/v1/contracts/results");
+      expect(mockedNetwork).toHaveBeenCalledTimes(1);
+    });
   });
 
-  it("should handle empty pages and continue fetching", async () => {
-    mockedNetwork
-      .mockResolvedValueOnce(
+  describe("findTransactionByContractCall", () => {
+    it("should call the correct endpoint and return transaction details", async () => {
+      const mockedResults: HederaMirrorTransaction = {
+        transfers: [],
+        token_transfers: [],
+        staking_reward_transfers: [],
+        charged_tx_fee: 100,
+        transaction_id: "xxxxxxxxxxxxxx",
+        transaction_hash: "xxxxxxxxxxxxx",
+        consensus_timestamp: "xxxxxxxxxxxxx",
+        result: "xxxxxxxxxxxxx",
+        entity_id: "0.0.1234",
+        name: "CONTRACTCALL",
+        node: null,
+        nonce: 0,
+        parent_consensus_timestamp: null,
+      };
+
+      mockedNetwork.mockResolvedValueOnce(
         getMockResponse({
-          transactions: [{ consensus_timestamp: "1100.000000000" }],
-          links: { next: "/next-1" },
+          transactions: [mockedResults],
         }),
-      )
-      .mockResolvedValueOnce(
+      );
+
+      const result = await apiClient.findTransactionByContractCall({
+        configOrCurrencyId: mockConfig,
+        timestamp: "xxxxxxxxxxxxxxxxxxxx",
+        contractId: "0.0.1234",
+      });
+      const requestUrl = mockedNetwork.mock.calls[0][0].url;
+
+      expect(result).toEqual(mockedResults);
+      expect(requestUrl).toContain("/api/v1/transactions?timestamp=");
+      expect(mockedNetwork).toHaveBeenCalledTimes(1);
+    });
+
+    it("should call the correct endpoint and return null for non existing contract calls", async () => {
+      mockedNetwork.mockResolvedValueOnce(
+        getMockResponse({
+          transactions: [
+            {
+              transfers: [],
+              token_transfers: [],
+              staking_reward_transfers: [],
+              charged_tx_fee: 100,
+              transaction_hash: "xxxxxxxxxxxxx",
+              consensus_timestamp: "xxxxxxxxxxxxx",
+              result: "xxxxxxxxxxxxx",
+              entity_id: "0.0.1234",
+              name: "NOT_CONTRACTCALL",
+            },
+            {
+              transfers: [],
+              token_transfers: [],
+              staking_reward_transfers: [],
+              charged_tx_fee: 100,
+              transaction_hash: "xxxxxxxxxxxxx",
+              consensus_timestamp: "xxxxxxxxxxxxx",
+              result: "xxxxxxxxxxxxx",
+              entity_id: "0.0.1111",
+              name: "CONTRACTCALL",
+            },
+          ] satisfies Partial<HederaMirrorTransaction>[],
+        }),
+      );
+
+      const result = await apiClient.findTransactionByContractCall({
+        configOrCurrencyId: mockConfig,
+        timestamp: "xxxxxxxxxxxxxxxxxxxx",
+        contractId: "0.0.1234",
+      });
+      const requestUrl = mockedNetwork.mock.calls[0][0].url;
+
+      expect(result).toEqual(null);
+      expect(requestUrl).toContain("/api/v1/transactions?timestamp=");
+      expect(mockedNetwork).toHaveBeenCalledTimes(1);
+    });
+
+    it("should call the correct endpoint and return null for empty transactions list", async () => {
+      mockedNetwork.mockResolvedValueOnce(
         getMockResponse({
           transactions: [],
-          links: { next: "/next-2" },
-        }),
-      )
-      .mockResolvedValueOnce(
-        getMockResponse({
-          transactions: [{ consensus_timestamp: "1300.000000000" }],
-          links: { next: null },
         }),
       );
 
-    const result = await apiClient.getTransactionsByTimestampRange({
-      startTimestamp: "gte:1000.000000000",
-      endTimestamp: "lt:2000.000000000",
+      const result = await apiClient.findTransactionByContractCall({
+        configOrCurrencyId: mockConfig,
+        timestamp: "xxxxxxxxxxxxxxxxxxxx",
+        contractId: "0.0.1234",
+      });
+      const requestUrl = mockedNetwork.mock.calls[0][0].url;
+
+      expect(result).toEqual(null);
+      expect(requestUrl).toContain("/api/v1/transactions?timestamp=");
+      expect(mockedNetwork).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("findTransactionByContractCallV2", () => {
+    it("should call the correct endpoint and return transaction details", async () => {
+      const mockConsensusTimestamp = "1758733200.632122898";
+      const mockPayerAddress = "0.0.1234";
+      const mockedResults: HederaMirrorTransaction = {
+        transfers: [],
+        token_transfers: [],
+        staking_reward_transfers: [],
+        charged_tx_fee: 100,
+        transaction_hash: "",
+        result: "",
+        consensus_timestamp: mockConsensusTimestamp,
+        entity_id: "0.0.1",
+        transaction_id: `${mockPayerAddress}-${mockConsensusTimestamp}`,
+        name: "CONTRACTCALL",
+        node: null,
+        nonce: 0,
+        parent_consensus_timestamp: null,
+      };
+
+      mockedNetwork.mockResolvedValueOnce(
+        getMockResponse({
+          transactions: [mockedResults],
+        }),
+      );
+
+      const result = await apiClient.findTransactionByContractCallV2({
+        configOrCurrencyId: mockConfig,
+        timestamp: mockConsensusTimestamp,
+        payerAddress: mockPayerAddress,
+      });
+      const requestUrl = mockedNetwork.mock.calls[0][0].url;
+
+      expect(result).toEqual(mockedResults);
+      expect(requestUrl).toContain("/api/v1/transactions?limit=100&order=desc");
+      expect(requestUrl).toContain("timestamp=gte");
+      expect(requestUrl).toContain("timestamp=lte");
+      expect(mockedNetwork).toHaveBeenCalledTimes(1);
     });
 
-    expect(result.map(tx => tx.consensus_timestamp)).toEqual(["1100.000000000", "1300.000000000"]);
-    expect(mockedNetwork).toHaveBeenCalledTimes(3);
-  });
-});
-
-describe("getNodes", () => {
-  beforeEach(() => {
-    jest.resetAllMocks();
-  });
-
-  it("should return all nodes if only one page is needed", async () => {
-    mockedNetwork.mockResolvedValueOnce(
-      getMockResponse({
-        nodes: [
-          { node_id: 0, node_account_id: "0.0.3" },
-          { node_id: 1, node_account_id: "0.0.4" },
-        ],
-        links: { next: null },
-      }),
-    );
-
-    const result = await apiClient.getNodes({ fetchAllPages: true });
-    const requestUrl = mockedNetwork.mock.calls[0][0].url;
-
-    expect(result.nodes.map(n => n.node_id)).toEqual([0, 1]);
-    expect(requestUrl).toContain("/api/v1/network/nodes");
-    expect(requestUrl).toContain("limit=100");
-    expect(requestUrl).toContain("order=desc");
-    expect(mockedNetwork).toHaveBeenCalledTimes(1);
-  });
-
-  it("should keep fetching if fetchAllPages and links.next is present", async () => {
-    mockedNetwork
-      .mockResolvedValueOnce(
+    it("should return null for non existing contract calls", async () => {
+      const mockConsensusTimestamp1 = "1758733200.632122898";
+      const mockConsensusTimestamp2 = "1758733300.632122898";
+      const mockPayerAddress1 = "0.0.1234";
+      const mockPayerAddress2 = "0.0.4321";
+      mockedNetwork.mockResolvedValueOnce(
         getMockResponse({
-          nodes: [{ node_id: 0, node_account_id: "0.0.3" }],
-          links: { next: "/next-1" },
+          transactions: [
+            {
+              transfers: [],
+              token_transfers: [],
+              staking_reward_transfers: [],
+              charged_tx_fee: 100,
+              transaction_hash: "zzz",
+              transaction_id: `${mockPayerAddress1}-${mockConsensusTimestamp1}`,
+              consensus_timestamp: mockConsensusTimestamp1,
+              result: "",
+              entity_id: "0.0.1",
+              name: "NOT_CONTRACTCALL",
+            },
+            {
+              transfers: [],
+              token_transfers: [],
+              staking_reward_transfers: [],
+              charged_tx_fee: 100,
+              transaction_hash: "yyy",
+              transaction_id: `${mockPayerAddress2}-${mockConsensusTimestamp2}`,
+              consensus_timestamp: mockConsensusTimestamp2,
+              result: "",
+              entity_id: "0.0.2",
+              name: "CONTRACTCALL",
+            },
+          ] satisfies Partial<HederaMirrorTransaction>[],
         }),
-      )
-      .mockResolvedValueOnce(
+      );
+
+      const result = await apiClient.findTransactionByContractCallV2({
+        configOrCurrencyId: mockConfig,
+        timestamp: mockConsensusTimestamp1,
+        payerAddress: mockPayerAddress1,
+      });
+
+      expect(result).toEqual(null);
+    });
+
+    it("should call the correct endpoint and return null for empty transactions list", async () => {
+      const mockConsensusTimestamp = "1758733200.632122898";
+      const mockPayerAddress = "0.0.1234";
+
+      mockedNetwork.mockResolvedValueOnce(
         getMockResponse({
-          nodes: [{ node_id: 1, node_account_id: "0.0.4" }],
-          links: { next: "/next-2" },
+          transactions: [],
         }),
-      )
-      .mockResolvedValueOnce(
+      );
+
+      const result = await apiClient.findTransactionByContractCallV2({
+        configOrCurrencyId: mockConfig,
+        timestamp: mockConsensusTimestamp,
+        payerAddress: mockPayerAddress,
+      });
+
+      expect(result).toEqual(null);
+    });
+  });
+
+  describe("getERC20Balance", () => {
+    it("should call the correct endpoint and return the contract balance", async () => {
+      mockedNetwork.mockResolvedValueOnce(
         getMockResponse({
-          nodes: [{ node_id: 2, node_account_id: "0.0.5" }],
+          result: "1000000000",
+        }),
+      );
+
+      const result = await apiClient.getERC20Balance({
+        configOrCurrencyId: mockConfig,
+        accountEvmAddress: "0x0000000000000000000000000000000000000001",
+        contractEvmAddress: "0x0000000000000000000000000000000000000002",
+      });
+      const requestUrl = mockedNetwork.mock.calls[0][0].url;
+
+      expect(result).toEqual(BigNumber("1000000000"));
+      expect(requestUrl).toContain("/api/v1/contracts/call");
+      expect(mockedNetwork).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("estimateContractCallGas", () => {
+    it("should call the correct endpoint and return estimated contract call gas", async () => {
+      mockedNetwork.mockResolvedValueOnce(
+        getMockResponse({
+          result: "1000000000",
+        }),
+      );
+
+      const result = await apiClient.estimateContractCallGas({
+        configOrCurrencyId: mockConfig,
+        senderEvmAddress: "0x0000000000000000000000000000000000000001",
+        recipientEvmAddress: "0x0000000000000000000000000000000000000002",
+        contractEvmAddress: "0x0000000000000000000000000000000000000002",
+        amount: BigInt(1000),
+      });
+      const requestUrl = mockedNetwork.mock.calls[0][0].url;
+
+      expect(result).toEqual(BigNumber("1000000000"));
+      expect(requestUrl).toContain("/api/v1/contracts/call");
+      expect(mockedNetwork).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("getTransactionsByTimestampRange", () => {
+    it("should include account.id query param if address is provided", async () => {
+      mockedNetwork.mockResolvedValueOnce(
+        getMockResponse({ transactions: [], links: { next: null } }),
+      );
+
+      await apiClient.getTransactionsByTimestampRange({
+        configOrCurrencyId: mockConfig,
+        address: "0.0.1234",
+        startTimestamp: "gte:1000.000000000",
+        endTimestamp: "lt:2000.000000000",
+      });
+
+      const requestUrl = mockedNetwork.mock.calls[0][0].url;
+      expect(requestUrl).toContain("account.id=0.0.1234");
+    });
+
+    it("should include correct query params with timestamp range", async () => {
+      mockedNetwork.mockResolvedValueOnce(
+        getMockResponse({ transactions: [], links: { next: null } }),
+      );
+
+      await apiClient.getTransactionsByTimestampRange({
+        configOrCurrencyId: mockConfig,
+        startTimestamp: "gte:1000.000000000",
+        endTimestamp: "lt:2000.000000000",
+      });
+
+      const requestUrl = mockedNetwork.mock.calls[0][0].url;
+      expect(requestUrl).not.toContain("account.id=");
+      expect(requestUrl).toContain("timestamp=gte%3A1000.000000000");
+      expect(requestUrl).toContain("timestamp=lt%3A2000.000000000");
+      expect(requestUrl).toContain("limit=100");
+      expect(requestUrl).toContain("order=desc");
+    });
+
+    it("should return empty array when no transactions found", async () => {
+      mockedNetwork.mockResolvedValueOnce(
+        getMockResponse({ transactions: [], links: { next: null } }),
+      );
+
+      const result = await apiClient.getTransactionsByTimestampRange({
+        configOrCurrencyId: mockConfig,
+        startTimestamp: "gte:1000.000000000",
+        endTimestamp: "lt:2000.000000000",
+      });
+
+      expect(result).toEqual([]);
+      expect(mockedNetwork).toHaveBeenCalledTimes(1);
+    });
+
+    it("should return all transactions when only one page is needed", async () => {
+      mockedNetwork.mockResolvedValueOnce(
+        getMockResponse({
+          transactions: [
+            { consensus_timestamp: "1500.123456789" },
+            { consensus_timestamp: "1750.987654321" },
+          ],
           links: { next: null },
         }),
       );
 
-    const result = await apiClient.getNodes({ fetchAllPages: true });
+      const result = await apiClient.getTransactionsByTimestampRange({
+        configOrCurrencyId: mockConfig,
+        startTimestamp: "gte:1000.000000000",
+        endTimestamp: "lt:2000.000000000",
+      });
 
-    expect(result.nodes.map(n => n.node_id)).toEqual([0, 1, 2]);
-    expect(mockedNetwork).toHaveBeenCalledTimes(3);
+      expect(result.map(tx => tx.consensus_timestamp)).toEqual([
+        "1500.123456789",
+        "1750.987654321",
+      ]);
+      expect(mockedNetwork).toHaveBeenCalledTimes(1);
+    });
+
+    it("should keep fetching all pages when links.next is present", async () => {
+      mockedNetwork
+        .mockResolvedValueOnce(
+          getMockResponse({
+            transactions: [{ consensus_timestamp: "1100.000000000" }],
+            links: { next: "/next-1" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          getMockResponse({
+            transactions: [{ consensus_timestamp: "1200.000000000" }],
+            links: { next: "/next-2" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          getMockResponse({
+            transactions: [{ consensus_timestamp: "1300.000000000" }],
+            links: { next: null },
+          }),
+        );
+
+      const result = await apiClient.getTransactionsByTimestampRange({
+        configOrCurrencyId: mockConfig,
+        startTimestamp: "gte:1000.000000000",
+        endTimestamp: "lt:2000.000000000",
+      });
+
+      expect(result.map(tx => tx.consensus_timestamp)).toEqual([
+        "1100.000000000",
+        "1200.000000000",
+        "1300.000000000",
+      ]);
+      expect(mockedNetwork).toHaveBeenCalledTimes(3);
+    });
+
+    it("should handle empty pages and continue fetching", async () => {
+      mockedNetwork
+        .mockResolvedValueOnce(
+          getMockResponse({
+            transactions: [{ consensus_timestamp: "1100.000000000" }],
+            links: { next: "/next-1" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          getMockResponse({
+            transactions: [],
+            links: { next: "/next-2" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          getMockResponse({
+            transactions: [{ consensus_timestamp: "1300.000000000" }],
+            links: { next: null },
+          }),
+        );
+
+      const result = await apiClient.getTransactionsByTimestampRange({
+        configOrCurrencyId: mockConfig,
+        startTimestamp: "gte:1000.000000000",
+        endTimestamp: "lt:2000.000000000",
+      });
+
+      expect(result.map(tx => tx.consensus_timestamp)).toEqual([
+        "1100.000000000",
+        "1300.000000000",
+      ]);
+      expect(mockedNetwork).toHaveBeenCalledTimes(3);
+    });
   });
 
-  it("should paginate if fetchAllPages is not set", async () => {
-    mockedNetwork
-      .mockResolvedValueOnce(
+  describe("getNodes", () => {
+    it("should return all nodes if only one page is needed", async () => {
+      mockedNetwork.mockResolvedValueOnce(
         getMockResponse({
           nodes: [
             { node_id: 0, node_account_id: "0.0.3" },
             { node_id: 1, node_account_id: "0.0.4" },
           ],
-          links: { next: "/next-1" },
-        }),
-      )
-      .mockResolvedValueOnce(
-        getMockResponse({
-          nodes: [{ node_id: 2, node_account_id: "0.0.5" }],
           links: { next: null },
         }),
       );
 
-    const result = await apiClient.getNodes({
-      limit: 2,
-      fetchAllPages: false,
+      const result = await apiClient.getNodes({
+        configOrCurrencyId: mockConfig,
+        fetchAllPages: true,
+      });
+      const requestUrl = mockedNetwork.mock.calls[0][0].url;
+
+      expect(result.nodes.map(n => n.node_id)).toEqual([0, 1]);
+      expect(requestUrl).toContain("/api/v1/network/nodes");
+      expect(requestUrl).toContain("limit=100");
+      expect(requestUrl).toContain("order=desc");
+      expect(mockedNetwork).toHaveBeenCalledTimes(1);
     });
 
-    expect(result.nodes.map(tx => tx.node_id)).toEqual([0, 1]);
-    expect(result.nextCursor).toBe("1");
-    expect(mockedNetwork).toHaveBeenCalledTimes(1);
+    it("should keep fetching if fetchAllPages and links.next is present", async () => {
+      mockedNetwork
+        .mockResolvedValueOnce(
+          getMockResponse({
+            nodes: [{ node_id: 0, node_account_id: "0.0.3" }],
+            links: { next: "/next-1" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          getMockResponse({
+            nodes: [{ node_id: 1, node_account_id: "0.0.4" }],
+            links: { next: "/next-2" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          getMockResponse({
+            nodes: [{ node_id: 2, node_account_id: "0.0.5" }],
+            links: { next: null },
+          }),
+        );
+
+      const result = await apiClient.getNodes({
+        configOrCurrencyId: mockConfig,
+        fetchAllPages: true,
+      });
+
+      expect(result.nodes.map(n => n.node_id)).toEqual([0, 1, 2]);
+      expect(mockedNetwork).toHaveBeenCalledTimes(3);
+    });
+
+    it("should paginate if fetchAllPages is not set", async () => {
+      mockedNetwork
+        .mockResolvedValueOnce(
+          getMockResponse({
+            nodes: [
+              { node_id: 0, node_account_id: "0.0.3" },
+              { node_id: 1, node_account_id: "0.0.4" },
+            ],
+            links: { next: "/next-1" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          getMockResponse({
+            nodes: [{ node_id: 2, node_account_id: "0.0.5" }],
+            links: { next: null },
+          }),
+        );
+
+      const result = await apiClient.getNodes({
+        configOrCurrencyId: mockConfig,
+        limit: 2,
+        fetchAllPages: false,
+      });
+
+      expect(result.nodes.map(tx => tx.node_id)).toEqual([0, 1]);
+      expect(result.nextCursor).toBe("1");
+      expect(mockedNetwork).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/libs/coin-modules/coin-hedera/src/network/api.ts
+++ b/libs/coin-modules/coin-hedera/src/network/api.ts
@@ -1,11 +1,12 @@
 import { LedgerAPI4xx } from "@ledgerhq/errors";
-import { getEnv } from "@ledgerhq/live-env";
 import network from "@ledgerhq/live-network";
 import type { LiveNetworkResponse } from "@ledgerhq/live-network/network";
 import BigNumber from "bignumber.js";
 import { encodeFunctionData, erc20Abi } from "viem";
+import { type HederaCoinConfig } from "../config";
 import { HEDERA_TRANSACTION_NAMES } from "../constants";
 import { HederaAddAccountError } from "../errors";
+import { resolveConfig } from "../logic/utils";
 import type {
   HederaMirrorAccountTokensResponse,
   HederaMirrorBlocksResponse,
@@ -23,14 +24,26 @@ import type {
   HederaMirrorNodesResponse,
 } from "../types";
 
-const API_URL = getEnv("API_HEDERA_MIRROR");
+// keeps old behavior when all pages are fetched
+const getPaginationDirection = (fetchAllPages: boolean, order: string) => {
+  if (fetchAllPages) return "gt";
+  return order === "asc" ? "gt" : "lt";
+};
 
-async function getAccountsForPublicKey(publicKey: string): Promise<HederaMirrorAccount[]> {
+async function getAccountsForPublicKey({
+  configOrCurrencyId,
+  publicKey,
+}: {
+  configOrCurrencyId: HederaCoinConfig | string;
+  publicKey: string;
+}): Promise<HederaMirrorAccount[]> {
+  const config = resolveConfig(configOrCurrencyId);
+
   let res;
   try {
     res = await network<HederaMirrorAccountsResponse>({
       method: "GET",
-      url: `${API_URL}/api/v1/accounts?account.publicKey=${publicKey}&balance=true&limit=100`,
+      url: `${config.apiUrls.mirrorNode}/api/v1/accounts?account.publicKey=${publicKey}&balance=true&limit=100`,
     });
   } catch (e: unknown) {
     if (e instanceof LedgerAPI4xx) return [];
@@ -45,6 +58,7 @@ async function getAccountsForPublicKey(publicKey: string): Promise<HederaMirrorA
 /**
  * Fetches account information from the Hedera Mirror Node API, excluding transactions.
  *
+ * @param configOrCurrencyId - Coin config object or currency ID string used to resolve the mirror node URL.
  * @param address - The Hedera account ID (e.g., "0.0.12345")
  * @param timestamp - Optional timestamp filter to get historical account state.
  *                    Supports comparison operators:
@@ -54,7 +68,17 @@ async function getAccountsForPublicKey(publicKey: string): Promise<HederaMirrorA
  * @returns Promise resolving to account data
  * @throws HederaAddAccountError if account not found (404)
  */
-async function getAccount(address: string, timestamp?: string): Promise<HederaMirrorAccount> {
+async function getAccount({
+  configOrCurrencyId,
+  address,
+  timestamp,
+}: {
+  configOrCurrencyId: HederaCoinConfig | string;
+  address: string;
+  timestamp?: string;
+}): Promise<HederaMirrorAccount> {
+  const config = resolveConfig(configOrCurrencyId);
+
   try {
     const params = new URLSearchParams({
       transactions: "false",
@@ -63,7 +87,7 @@ async function getAccount(address: string, timestamp?: string): Promise<HederaMi
 
     const res = await network<HederaMirrorAccount>({
       method: "GET",
-      url: `${API_URL}/api/v1/accounts/${address}?${params.toString()}`,
+      url: `${config.apiUrls.mirrorNode}/api/v1/accounts/${address}?${params.toString()}`,
     });
     const account = res.data;
 
@@ -77,25 +101,22 @@ async function getAccount(address: string, timestamp?: string): Promise<HederaMi
   }
 }
 
-// keeps old behavior when all pages are fetched
-const getPaginationDirection = (fetchAllPages: boolean, order: string) => {
-  if (fetchAllPages) return "gt";
-  return order === "asc" ? "gt" : "lt";
-};
-
 async function getAccountTransactions({
+  configOrCurrencyId,
   address,
   pagingToken,
   limit = 100,
   order = "desc",
   fetchAllPages,
 }: {
+  configOrCurrencyId: HederaCoinConfig | string;
   address: string;
   pagingToken: string | null;
   limit?: number | undefined;
   order?: "asc" | "desc" | undefined;
   fetchAllPages: boolean;
 }): Promise<{ transactions: HederaMirrorTransaction[]; nextCursor: string | null }> {
+  const config = resolveConfig(configOrCurrencyId);
   const transactions: HederaMirrorTransaction[] = [];
   const params = new URLSearchParams({
     "account.id": address,
@@ -116,7 +137,7 @@ async function getAccountTransactions({
   while (nextPath) {
     const res: LiveNetworkResponse<HederaMirrorTransactionsResponse> = await network({
       method: "GET",
-      url: `${API_URL}${nextPath}`,
+      url: `${config.apiUrls.mirrorNode}${nextPath}`,
     });
     const newTransactions = res.data.transactions;
     transactions.push(...newTransactions);
@@ -142,7 +163,14 @@ async function getAccountTransactions({
   return { transactions, nextCursor };
 }
 
-async function getAccountTokens(address: string): Promise<HederaMirrorToken[]> {
+async function getAccountTokens({
+  configOrCurrencyId,
+  address,
+}: {
+  configOrCurrencyId: HederaCoinConfig | string;
+  address: string;
+}): Promise<HederaMirrorToken[]> {
+  const config = resolveConfig(configOrCurrencyId);
   const tokens: HederaMirrorToken[] = [];
   const params = new URLSearchParams({
     limit: "100",
@@ -153,7 +181,7 @@ async function getAccountTokens(address: string): Promise<HederaMirrorToken[]> {
   while (nextPath) {
     const res: LiveNetworkResponse<HederaMirrorAccountTokensResponse> = await network({
       method: "GET",
-      url: `${API_URL}${nextPath}`,
+      url: `${config.apiUrls.mirrorNode}${nextPath}`,
     });
     const newTokens = res.data.tokens;
     tokens.push(...newTokens);
@@ -163,7 +191,14 @@ async function getAccountTokens(address: string): Promise<HederaMirrorToken[]> {
   return tokens;
 }
 
-async function getLatestTransaction(before: Date): Promise<HederaMirrorTransaction> {
+async function getLatestTransaction({
+  configOrCurrencyId,
+  before,
+}: {
+  configOrCurrencyId: HederaCoinConfig | string;
+  before: Date;
+}): Promise<HederaMirrorTransaction> {
+  const config = resolveConfig(configOrCurrencyId);
   const params = new URLSearchParams({
     limit: "1",
     order: "desc",
@@ -172,7 +207,7 @@ async function getLatestTransaction(before: Date): Promise<HederaMirrorTransacti
 
   const res = await network<HederaMirrorTransactionsResponse>({
     method: "GET",
-    url: `${API_URL}/api/v1/transactions?${params.toString()}`,
+    url: `${config.apiUrls.mirrorNode}/api/v1/transactions?${params.toString()}`,
   });
   const transaction = res.data.transactions[0];
 
@@ -183,7 +218,12 @@ async function getLatestTransaction(before: Date): Promise<HederaMirrorTransacti
   return transaction;
 }
 
-async function getLatestBlock(): Promise<HederaMirrorBlock> {
+async function getLatestBlock({
+  configOrCurrencyId,
+}: {
+  configOrCurrencyId: HederaCoinConfig | string;
+}): Promise<HederaMirrorBlock> {
+  const config = resolveConfig(configOrCurrencyId);
   const params = new URLSearchParams({
     limit: "1",
     order: "desc",
@@ -191,7 +231,7 @@ async function getLatestBlock(): Promise<HederaMirrorBlock> {
 
   const res = await network<HederaMirrorBlocksResponse>({
     method: "GET",
-    url: `${API_URL}/api/v1/blocks?${params.toString()}`,
+    url: `${config.apiUrls.mirrorNode}/api/v1/blocks?${params.toString()}`,
   });
   const block = res.data.blocks[0];
 
@@ -202,34 +242,51 @@ async function getLatestBlock(): Promise<HederaMirrorBlock> {
   return block;
 }
 
-async function getNetworkFees(): Promise<HederaMirrorNetworkFees> {
+async function getNetworkFees({
+  configOrCurrencyId,
+}: {
+  configOrCurrencyId: HederaCoinConfig | string;
+}): Promise<HederaMirrorNetworkFees> {
+  const config = resolveConfig(configOrCurrencyId);
   const res = await network<HederaMirrorNetworkFees>({
     method: "GET",
-    url: `${API_URL}/api/v1/network/fees`,
+    url: `${config.apiUrls.mirrorNode}/api/v1/network/fees`,
   });
 
   return res.data;
 }
 
-async function getContractCallResult(
-  transactionHash: string,
-): Promise<HederaMirrorContractCallResult> {
+async function getContractCallResult({
+  configOrCurrencyId,
+  transactionHash,
+}: {
+  configOrCurrencyId: HederaCoinConfig | string;
+  transactionHash: string;
+}): Promise<HederaMirrorContractCallResult> {
+  const config = resolveConfig(configOrCurrencyId);
   const res = await network<HederaMirrorContractCallResult>({
     method: "GET",
-    url: `${API_URL}/api/v1/contracts/results/${transactionHash}`,
+    url: `${config.apiUrls.mirrorNode}/api/v1/contracts/results/${transactionHash}`,
   });
 
   return res.data;
 }
 
 // TODO: remove once migration to new API is complete
-async function findTransactionByContractCall(
-  timestamp: string,
-  contractId: string,
-): Promise<HederaMirrorTransaction | null> {
+async function findTransactionByContractCall({
+  configOrCurrencyId,
+  timestamp,
+  contractId,
+}: {
+  configOrCurrencyId: HederaCoinConfig | string;
+  timestamp: string;
+  contractId: string;
+}): Promise<HederaMirrorTransaction | null> {
+  const config = resolveConfig(configOrCurrencyId);
+
   const res = await network<HederaMirrorTransactionsResponse>({
     method: "GET",
-    url: `${API_URL}/api/v1/transactions?timestamp=${timestamp}`,
+    url: `${config.apiUrls.mirrorNode}/api/v1/transactions?timestamp=${timestamp}`,
   });
   const transactions = res.data.transactions;
   const relatedTx = transactions.find(
@@ -240,12 +297,16 @@ async function findTransactionByContractCall(
 }
 
 async function findTransactionByContractCallV2({
+  configOrCurrencyId,
   timestamp,
   payerAddress,
 }: {
+  configOrCurrencyId: HederaCoinConfig | string;
   timestamp: string;
   payerAddress: string;
 }): Promise<HederaMirrorTransaction | null> {
+  const config = resolveConfig(configOrCurrencyId);
+
   // Hgraph API returns timestamp as number and nanoseconds precision is lost during parsing
   // instead of using `timestamp=eq:${timestamp}`, we need to fetch transactions in a small range
   // +-10 microseconds is used to bypass hgraph precision issue
@@ -260,7 +321,7 @@ async function findTransactionByContractCallV2({
 
   const res = await network<HederaMirrorTransactionsResponse>({
     method: "GET",
-    url: `${API_URL}/api/v1/transactions?${params.toString()}`,
+    url: `${config.apiUrls.mirrorNode}/api/v1/transactions?${params.toString()}`,
   });
 
   // try to find main CONTRACT_CALL transaction related to the given address
@@ -276,13 +337,19 @@ async function findTransactionByContractCallV2({
 }
 
 // TODO: remove once migration to new API is complete
-async function getERC20Balance(
-  accountEvmAddress: string,
-  contractEvmAddress: string,
-): Promise<BigNumber> {
+async function getERC20Balance({
+  configOrCurrencyId,
+  accountEvmAddress,
+  contractEvmAddress,
+}: {
+  configOrCurrencyId: HederaCoinConfig | string;
+  accountEvmAddress: string;
+  contractEvmAddress: string;
+}): Promise<BigNumber> {
+  const config = resolveConfig(configOrCurrencyId);
   const res = await network<HederaMirrorContractCallBalance>({
     method: "POST",
-    url: `${API_URL}/api/v1/contracts/call`,
+    url: `${config.apiUrls.mirrorNode}/api/v1/contracts/call`,
     data: {
       block: "latest",
       to: contractEvmAddress,
@@ -297,15 +364,24 @@ async function getERC20Balance(
   return new BigNumber(res.data.result);
 }
 
-async function estimateContractCallGas(
-  senderEvmAddress: string,
-  recipientEvmAddress: string,
-  contractEvmAddress: string,
-  amount: bigint,
-): Promise<BigNumber> {
+async function estimateContractCallGas({
+  configOrCurrencyId,
+  senderEvmAddress,
+  recipientEvmAddress,
+  contractEvmAddress,
+  amount,
+}: {
+  configOrCurrencyId: HederaCoinConfig | string;
+  senderEvmAddress: string;
+  recipientEvmAddress: string;
+  contractEvmAddress: string;
+  amount: bigint;
+}): Promise<BigNumber> {
+  const config = resolveConfig(configOrCurrencyId);
+
   const res = await network<HederaMirrorContractCallEstimate>({
     method: "POST",
-    url: `${API_URL}/api/v1/contracts/call`,
+    url: `${config.apiUrls.mirrorNode}/api/v1/contracts/call`,
     data: {
       block: "latest",
       estimate: true,
@@ -323,18 +399,21 @@ async function estimateContractCallGas(
 }
 
 async function getTransactionsByTimestampRange({
+  configOrCurrencyId,
   address,
   startTimestamp,
   endTimestamp,
   limit = 100,
   order = "desc",
 }: {
+  configOrCurrencyId: HederaCoinConfig | string;
   address?: string;
   startTimestamp: `${string}:${string}`;
   endTimestamp: `${string}:${string}`;
   limit?: number;
   order?: "asc" | "desc";
 }): Promise<HederaMirrorTransaction[]> {
+  const config = resolveConfig(configOrCurrencyId);
   const transactions: HederaMirrorTransaction[] = [];
   const params = new URLSearchParams({
     limit: limit.toString(),
@@ -350,7 +429,7 @@ async function getTransactionsByTimestampRange({
   while (nextPath) {
     const res: LiveNetworkResponse<HederaMirrorTransactionsResponse> = await network({
       method: "GET",
-      url: `${API_URL}${nextPath}`,
+      url: `${config.apiUrls.mirrorNode}${nextPath}`,
     });
     const newTransactions = res.data.transactions;
     transactions.push(...newTransactions);
@@ -360,7 +439,14 @@ async function getTransactionsByTimestampRange({
   return transactions;
 }
 
-async function getNode(nodeId: number): Promise<HederaMirrorNode | null> {
+async function getNode({
+  configOrCurrencyId,
+  nodeId,
+}: {
+  configOrCurrencyId: HederaCoinConfig | string;
+  nodeId: number;
+}): Promise<HederaMirrorNode | null> {
+  const config = resolveConfig(configOrCurrencyId);
   const params = new URLSearchParams({
     "node.id": `eq:${nodeId}`,
     limit: "1",
@@ -368,22 +454,25 @@ async function getNode(nodeId: number): Promise<HederaMirrorNode | null> {
 
   const res = await network<HederaMirrorNodesResponse>({
     method: "GET",
-    url: `${API_URL}/api/v1/network/nodes?${params.toString()}`,
+    url: `${config.apiUrls.mirrorNode}/api/v1/network/nodes?${params.toString()}`,
   });
   return res.data.nodes[0] ?? null;
 }
 
 async function getNodes({
+  configOrCurrencyId,
   cursor,
   limit = 100,
   order = "desc",
   fetchAllPages,
 }: {
+  configOrCurrencyId: HederaCoinConfig | string;
   cursor?: string;
   limit?: number;
   order?: "asc" | "desc";
   fetchAllPages: boolean;
 }): Promise<{ nodes: HederaMirrorNode[]; nextCursor: string | null }> {
+  const config = resolveConfig(configOrCurrencyId);
   const nodes: HederaMirrorNode[] = [];
   const params = new URLSearchParams({
     order,
@@ -400,7 +489,7 @@ async function getNodes({
   while (nextPath) {
     const res: LiveNetworkResponse<HederaMirrorNodesResponse> = await network({
       method: "GET",
-      url: `${API_URL}${nextPath}`,
+      url: `${config.apiUrls.mirrorNode}${nextPath}`,
     });
     const newNodes = res.data.nodes;
     nodes.push(...newNodes);

--- a/libs/coin-modules/coin-hedera/src/network/thirdweb.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/thirdweb.test.ts
@@ -137,7 +137,7 @@ describe("getERC20TransactionsForAccount", () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    (apiClient.getAccount as jest.Mock).mockImplementation(address => ({
+    (apiClient.getAccount as jest.Mock).mockImplementation(({ address }) => ({
       address,
       evm_address: "0x0000000000000000000000000000000000012345",
     }));

--- a/libs/coin-modules/coin-hedera/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.test.ts
@@ -325,10 +325,11 @@ describe("network utils", () => {
       });
 
       expect(apiClient.getERC20Balance).toHaveBeenCalledTimes(mockedSupportedTokenIds.length);
-      expect(apiClient.getERC20Balance).toHaveBeenCalledWith(
-        mockAccount.freshAddress,
-        erc20Token.contractAddress,
-      );
+      expect(apiClient.getERC20Balance).toHaveBeenCalledWith({
+        configOrCurrencyId: mockCurrency.id,
+        accountEvmAddress: mockAccount.freshAddress,
+        contractEvmAddress: erc20Token.contractAddress,
+      });
 
       expect(res).toEqual(mockedResponse);
     });
@@ -439,14 +440,16 @@ describe("network utils", () => {
         },
       ]);
       expect(apiClient.getContractCallResult).toHaveBeenCalledTimes(1);
-      expect(apiClient.getContractCallResult).toHaveBeenCalledWith(
-        mockThirdwebTransaction.transactionHash,
-      );
+      expect(apiClient.getContractCallResult).toHaveBeenCalledWith({
+        configOrCurrencyId: mockCurrency.id,
+        transactionHash: mockThirdwebTransaction.transactionHash,
+      });
       expect(apiClient.findTransactionByContractCall).toHaveBeenCalledTimes(1);
-      expect(apiClient.findTransactionByContractCall).toHaveBeenCalledWith(
-        mockContractCallResult.timestamp,
-        mockTokenERC20.contractAddress,
-      );
+      expect(apiClient.findTransactionByContractCall).toHaveBeenCalledWith({
+        configOrCurrencyId: mockCurrency.id,
+        timestamp: mockContractCallResult.timestamp,
+        contractId: mockTokenERC20.contractAddress,
+      });
     });
 
     it("should skip transactions for tokens not found in currency list", async () => {
@@ -581,9 +584,13 @@ describe("network utils", () => {
         },
       ]);
       expect(apiClient.getContractCallResult).toHaveBeenCalledTimes(1);
-      expect(apiClient.getContractCallResult).toHaveBeenCalledWith("hash123");
+      expect(apiClient.getContractCallResult).toHaveBeenCalledWith({
+        configOrCurrencyId: mockCurrency.id,
+        transactionHash: mockMirrorTransaction.transaction_hash,
+      });
       expect(apiClient.findTransactionByContractCallV2).toHaveBeenCalledTimes(1);
       expect(apiClient.findTransactionByContractCallV2).toHaveBeenCalledWith({
+        configOrCurrencyId: mockCurrency.id,
         timestamp: "1704067200.000000000",
         payerAddress: `0.0.${payerAccountId}`,
       });
@@ -645,6 +652,7 @@ describe("network utils", () => {
 
       expect(apiClient.findTransactionByContractCallV2).toHaveBeenCalledTimes(1);
       expect(apiClient.findTransactionByContractCallV2).toHaveBeenCalledWith({
+        configOrCurrencyId: mockCurrency.id,
         timestamp: "1768092990.000000000",
         payerAddress: `0.0.${payerAccountId}`,
       });
@@ -742,7 +750,10 @@ describe("network utils", () => {
 
       await checkAccountTokenAssociationStatus(addressWithChecksum, htsToken);
       expect(apiClient.getAccount).toHaveBeenCalledTimes(1);
-      expect(apiClient.getAccount).toHaveBeenCalledWith("0.0.9124531");
+      expect(apiClient.getAccount).toHaveBeenCalledWith({
+        configOrCurrencyId: htsToken.parentCurrency.id,
+        address: "0.0.9124531",
+      });
     });
   });
 
@@ -805,7 +816,10 @@ describe("network utils", () => {
       });
 
       expect(apiClient.getAccount).toHaveBeenCalledTimes(1);
-      expect(apiClient.getAccount).toHaveBeenCalledWith(mockMirrorAccount.account);
+      expect(apiClient.getAccount).toHaveBeenCalledWith({
+        configOrCurrencyId: defaultConfig,
+        address: mockMirrorAccount.account,
+      });
       expect(evmAddress).toBe(mockMirrorAccount.evm_address);
     });
 
@@ -844,6 +858,7 @@ describe("network utils", () => {
       expect(result).toEqual(new BigNumber(0));
       expect(apiClient.getTransactionsByTimestampRange).toHaveBeenCalledTimes(1);
       expect(apiClient.getTransactionsByTimestampRange).toHaveBeenCalledWith({
+        configOrCurrencyId: defaultConfig,
         address: mockAddress,
         startTimestamp: `gt:${mockStartTimestamp}`,
         endTimestamp: `lte:${mockEndTimestamp}`,
@@ -978,8 +993,16 @@ describe("network utils", () => {
         stakedAmount: BigInt(1000),
       });
       expect(apiClient.getAccount).toHaveBeenCalledTimes(2);
-      expect(apiClient.getAccount).toHaveBeenCalledWith(mockAddress, `lt:${mockTimestamp}`);
-      expect(apiClient.getAccount).toHaveBeenCalledWith(mockAddress, `eq:${mockTimestamp}`);
+      expect(apiClient.getAccount).toHaveBeenCalledWith({
+        configOrCurrencyId: defaultConfig,
+        address: mockAddress,
+        timestamp: `lt:${mockTimestamp}`,
+      });
+      expect(apiClient.getAccount).toHaveBeenCalledWith({
+        configOrCurrencyId: defaultConfig,
+        address: mockAddress,
+        timestamp: `eq:${mockTimestamp}`,
+      });
     });
 
     it("detects UNDELEGATE operation when staking stops", async () => {
@@ -1065,6 +1088,7 @@ describe("network utils", () => {
 
       expect(apiClient.getTransactionsByTimestampRange).toHaveBeenCalledTimes(1);
       expect(apiClient.getTransactionsByTimestampRange).toHaveBeenCalledWith({
+        configOrCurrencyId: defaultConfig,
         address: mockAddress,
         startTimestamp: `gt:${mockAccountBefore.balance.timestamp}`,
         endTimestamp: `lte:${mockTimestamp}`,

--- a/libs/coin-modules/coin-hedera/src/network/utils.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.ts
@@ -39,7 +39,7 @@ export async function createTransactionId(
   }
 
   try {
-    const lastBlock = await apiClient.getLatestBlock();
+    const lastBlock = await apiClient.getLatestBlock({ configOrCurrencyId: config });
     const validStart = toTimestamp(lastBlock.timestamp.to ?? lastBlock.timestamp.from);
 
     return TransactionId.withValidStart(AccountId.fromString(accountId), validStart);
@@ -116,7 +116,7 @@ export function parseTransfers(
 
 // TODO: remove once migration to new API is complete
 export async function getERC20BalancesForAccount({
-  configOrCurrencyId: _,
+  configOrCurrencyId,
   evmAccountId,
   supportedTokenIds = SUPPORTED_ERC20_TOKENS.map(token => token.id),
 }: {
@@ -135,7 +135,11 @@ export async function getERC20BalancesForAccount({
   }
 
   const promises = availableTokens.map(async erc20token => {
-    const balance = await apiClient.getERC20Balance(evmAccountId, erc20token.contractAddress);
+    const balance = await apiClient.getERC20Balance({
+      configOrCurrencyId,
+      accountEvmAddress: evmAccountId,
+      contractEvmAddress: erc20token.contractAddress,
+    });
 
     return {
       balance,
@@ -187,7 +191,7 @@ export async function getERC20BalancesForAccountV2({
 
 // TODO: remove once migration to new API is complete
 export const getERC20Operations = async ({
-  config: _,
+  config,
   currencyId,
   latestERC20Transactions,
 }: {
@@ -204,11 +208,15 @@ export const getERC20Operations = async ({
     if (!token) continue;
 
     const hash = thirdwebTransaction.transactionHash;
-    const contractCallResult = await apiClient.getContractCallResult(hash);
-    const mirrorTransaction = await apiClient.findTransactionByContractCall(
-      contractCallResult.timestamp,
-      contractCallResult.contract_id,
-    );
+    const contractCallResult = await apiClient.getContractCallResult({
+      configOrCurrencyId: config ?? currencyId,
+      transactionHash: hash,
+    });
+    const mirrorTransaction = await apiClient.findTransactionByContractCall({
+      configOrCurrencyId: config ?? currencyId,
+      timestamp: contractCallResult.timestamp,
+      contractId: contractCallResult.contract_id,
+    });
 
     if (!mirrorTransaction) continue;
 
@@ -245,7 +253,7 @@ export function parseThirdwebTransactionParams(
  * @returns Array of enriched transfers with complete operation data, filtered to supported tokens only
  */
 export const enrichERC20Transfers = async ({
-  configOrCurrencyId: _,
+  configOrCurrencyId,
   erc20Transfers,
 }: {
   configOrCurrencyId: HederaCoinConfig | string;
@@ -272,8 +280,9 @@ export const enrichERC20Transfers = async ({
     const inaccurateConsensusTimestamp = nanosToSeconds(inaccurateConsensusTimestampNs).toFixed(9);
 
     const [contractCallResult, mirrorTransaction] = await Promise.all([
-      apiClient.getContractCallResult(txHash),
+      apiClient.getContractCallResult({ configOrCurrencyId, transactionHash: txHash }),
       apiClient.findTransactionByContractCallV2({
+        configOrCurrencyId,
         payerAddress,
         timestamp: inaccurateConsensusTimestamp,
       }),
@@ -332,7 +341,10 @@ export const checkAccountTokenAssociationStatus = makeLRUCache(
     }
 
     const addressWithoutChecksum = parsingResult.accountId;
-    const mirrorAccount = await apiClient.getAccount(addressWithoutChecksum);
+    const mirrorAccount = await apiClient.getAccount({
+      configOrCurrencyId: token.parentCurrency.id,
+      address: addressWithoutChecksum,
+    });
 
     // auto association is enabled
     if (mirrorAccount.max_automatic_token_associations === -1) {
@@ -391,14 +403,17 @@ export const safeParseAccountId = async ({
  * @returns EVM address (`0x...`) or null if fetch fails
  */
 export const toEVMAddress = async ({
-  configOrCurrencyId: _,
+  configOrCurrencyId,
   accountId,
 }: {
   configOrCurrencyId: HederaCoinConfig | string;
   accountId: string;
 }): Promise<string | null> => {
   try {
-    const account = await apiClient.getAccount(accountId);
+    const account = await apiClient.getAccount({
+      configOrCurrencyId,
+      address: accountId,
+    });
 
     return account.evm_address;
   } catch {
@@ -419,7 +434,7 @@ export const toEVMAddress = async ({
  * @returns The net balance change as BigInt (sum of all transfers to/from the account)
  */
 export const calculateUncommittedBalanceChange = async ({
-  configOrCurrencyId: _,
+  configOrCurrencyId,
   address,
   startTimestamp,
   endTimestamp,
@@ -434,6 +449,7 @@ export const calculateUncommittedBalanceChange = async ({
   }
 
   const uncommittedTransactions = await apiClient.getTransactionsByTimestampRange({
+    configOrCurrencyId,
     address,
     startTimestamp: `gt:${startTimestamp}`,
     endTimestamp: `lte:${endTimestamp}`,
@@ -484,8 +500,16 @@ export const analyzeStakingOperation = async ({
   mirrorTx: HederaMirrorTransaction;
 }): Promise<StakingAnalysis | null> => {
   const [accountBefore, accountAfter] = await Promise.all([
-    apiClient.getAccount(address, `lt:${mirrorTx.consensus_timestamp}`),
-    apiClient.getAccount(address, `eq:${mirrorTx.consensus_timestamp}`),
+    apiClient.getAccount({
+      configOrCurrencyId,
+      address,
+      timestamp: `lt:${mirrorTx.consensus_timestamp}`,
+    }),
+    apiClient.getAccount({
+      configOrCurrencyId,
+      address,
+      timestamp: `eq:${mirrorTx.consensus_timestamp}`,
+    }),
   ]);
 
   let operationType: OperationType | null = null;

--- a/libs/coin-modules/coin-hedera/src/preload.ts
+++ b/libs/coin-modules/coin-hedera/src/preload.ts
@@ -12,7 +12,7 @@ export const getPreloadStrategy = () => ({
 
 export async function preload(currency: CryptoCurrency): Promise<HederaPreloadData> {
   log("hedera/preload", "preloading hedera data...");
-  const result = await apiClient.getNodes({ fetchAllPages: true });
+  const result = await apiClient.getNodes({ configOrCurrencyId: currency.id, fetchAllPages: true });
 
   const validators: HederaValidator[] = result.nodes.map(mirrorNode => {
     const minStake = new BigNumber(mirrorNode.min_stake);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - apiClient are based on `networkType` in coin-hedera 

### 📝 Description

This PR contains second batch of changes from [testnet support feature branch](https://github.com/LedgerHQ/ledger-live/compare/develop...feat/hedera-testnet-v2).

Scope:
- update Hedera apiClient with `configOrCurrencyId` support and usage

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-28050

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
