### PR TITLE
[LWDM] docs: update readme files inline with latest rules on docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,338 +1,101 @@
-<h3 align="center">
-  <image src="https://user-images.githubusercontent.com/3428394/165078916-06fe0b1b-c11d-4c6f-9c1a-ac9291333852.png" alt="ledger-logo" height="100" />
-  &nbsp;
-  <image src="https://user-images.githubusercontent.com/3428394/165078595-1b2a55ae-783a-4c8f-8548-c4f050ae5e76.png" alt="js-logo" height="100" />
-  <br/>
-  <h3 align="center">The Ledger Live JavaScript Ecosystem</h3>
-  <h4 align="center">
-    <a href="https://jobs.ashbyhq.com/ledger">
-      We are hiring, join us! 👨‍💻👩‍💻
-    </a>
-  </h4>
-</h3>
+# Ledger Wallet JavaScript Ecosystem
 
-[![gitpoap badge](https://public-api.gitpoap.io/v1/repo/LedgerHQ/ledger-live/badge)](https://www.gitpoap.io/gh/LedgerHQ/ledger-live)
+`ledger-live` is the JavaScript and TypeScript monorepo for Ledger Wallet apps,
+shared packages, tooling, and end-to-end test projects.
 
-## About
+Ledger Wallet is the companion experience for Ledger hardware wallets. It lets
+users manage crypto assets, install device apps, update firmware, verify public
+addresses, and sign transactions.
 
-`ledger-live` is a **monorepository** whose purpose is to centralize all the JavaScript code related to the [**Ledger Live**](https://www.ledger.com/ledger-live) applications in one place.
+## Start Here
 
-[**Ledger Live**](https://www.ledger.com/ledger-live) is our platform of apps and services designed specifically for seamless integration with your Ledger device. Acting as a secure gateway to the crypto ecosystem, it allows direct access to a diverse range of crypto, NFT and DeFi services. This integration ensures a safer and more user-friendly experience that address a common security issue known as 'blind signing'.
-
-Developers looking to integrate their blockchain in Ledger Live are invited to head to the [**Developer Portal**](https://developers.ledger.com) where they will find the section [**Blockchain Support**](https://developers.ledger.com/docs/coin/general-process).
-
-## Installation
-
-> 💡 **This is only a minimal setup. You will need to perform additional installation steps depending on the package you want to work on, please refer to its nested readme file.**
-
-### Cloning
-
-```bash
-git clone git@github.com:LedgerHQ/ledger-live.git
-cd ledger-live
-```
-
-### Mise
-
-**⚠️ Important**: Install the pinned toolchain (Node, pnpm, npm, and other tools) with [mise](https://mise.jdx.dev/). Follow the [installation guide](https://mise.jdx.dev/getting-started.html), then from the repository root:
+Run commands from the repository root unless a local README says otherwise.
 
 ```bash
 mise install
-```
-
-Versions are defined in `mise.toml` at the repo root.
-
-### Dependencies
-
-#### Pre-requisites
-
-1. Install a newer ruby version
-
-We recommend to use [homebrew](https://brew.sh/) to install packages on your MacOs computer.
-
-Make sure to install Ruby in its `3.3.X` version
-
-```sh
-brew install ruby@3.3
-```
-
-Put the following content to your `~/.zshrc` file
-
-```
-if [ -d "/opt/homebrew/opt/ruby@3.3/bin" ]; then
-  export PATH=/opt/homebrew/opt/ruby@3.3/bin:$PATH
-  export PATH=`gem environment gemdir`/bin:$PATH
-fi
-```
-
-Reload the configuration
-
-```sh
-source ~/.zshrc
-```
-
-And check the ruby version
-
-```sh
-ruby --version
-```
-
-It displays the latest stable version among the one you've selected (`3.3.7` at the time writing)
-
-```sh
-ruby 3.3.7 (2025-01-15 revision be31f993d7) [arm64-darwin24]
-```
-
-2. Install `bundler` and `cocoapods` for `ledger-live-mobile` on iOS
-
-```sh
-gem install bundler:2.5.7
-gem install cocoapods
-```
-
-3. Downgrade the version of the `activesupport` gem
-
-There is known bug on the activesupport version with cocoapods (we did not dig into it), so we need to downgrade it to make it works
-
-```sh
-gem uninstall activesupport
-```
-
-You will have the following output
-
-```sh
-cocoapods-core-1.16.2 depends on activesupport (>= 5.0, < 8)
-If you remove this gem, these dependencies will not be met.
-Continue with Uninstall? [yN]
-```
-
-Type `y`, then
-
-```sh
-gem install activesupport -v  7.0.8 # this version was working for the install, an other may work also
-```
-
-And you are done !
-
-#### Install dependencies
-
-Use the [pnpm](https://pnpm.io/fr/) package manager to install the dependencies in the whole workspace:
-
-```bash
 pnpm i
-# Alternatively, if you want to bypass the postinstall scripts which can be long to run
-# pnpm i --ignore-scripts
 ```
 
-> Note: multiple postinstall steps will be triggered and fail if the applications prerequisites are not met.
-> You can safely ignore the errors if you do not plan to work on those apps.
+Use `pnpm i --ignore-scripts` when you only need dependencies and want to skip
+long or app-specific postinstall steps.
 
-#### Optional: CLI with a Ledger device (USB)
+Common workflows live in canonical docs:
 
-To use the **CLI** with a physical Ledger device over USB (Node-based HID transport), the native modules `node-hid` and `usb` must be built. By default they are not built during `pnpm i` (so CI and most devs can install without system deps). Run once after install:
+| Need                                                  | Read                                                                   |
+| ----------------------------------------------------- | ---------------------------------------------------------------------- |
+| Setup, build, dev, lint, typecheck, and test commands | [docs/common-commands.md](docs/common-commands.md)                     |
+| Required checks before finishing a code change        | [docs/validate-before-finishing.md](docs/validate-before-finishing.md) |
+| Documentation structure and README expectations       | [docs/about-docs/docs-locations.md](docs/about-docs/docs-locations.md) |
+
+For app-specific prerequisites, continue with the local app README:
+
+- [Ledger Live Desktop](apps/ledger-live-desktop/README.md)
+- [Ledger Live Mobile](apps/ledger-live-mobile/README.md)
+- [ledger-live CLI](apps/cli/README.md)
+- [wallet-cli](apps/wallet-cli/README.md)
+
+## Workspace Map
+
+| Path                       | Purpose                                                          |
+| -------------------------- | ---------------------------------------------------------------- |
+| `apps/ledger-live-desktop` | Electron desktop app (`pnpm desktop`)                            |
+| `apps/ledger-live-mobile`  | React Native mobile app (`pnpm mobile`)                          |
+| `apps/cli`                 | Published `@ledgerhq/live-cli` package (`pnpm cli`)              |
+| `apps/wallet-cli`          | Experimental DMK-based wallet CLI (`pnpm wallet-cli`)            |
+| `libs/ledger-live-common`  | Shared Ledger Wallet business logic (`pnpm common`)              |
+| `libs/ledgerjs`            | LedgerJS packages for device apps, transports, and crypto assets |
+| `libs/coin-modules`        | Coin family integrations and coin module packages                |
+| `libs/ui`                  | Shared React, React Native, icon, and UI packages                |
+| `e2e/desktop`              | Desktop Playwright and Speculos tests (`pnpm e2e:desktop`)       |
+| `e2e/mobile`               | Mobile Detox and Speculos tests (`pnpm e2e:mobile`)              |
+| `docs`                     | Repo-wide canonical docs                                         |
+| `.agents`                  | Shared agent skills, sub-agents, and agent-facing docs           |
+
+Most packages also have their own `README.md` for local context. Prefer those
+files for package-specific conventions, and prefer `docs/` for repo-wide rules.
+
+## Development Notes
+
+This repo uses:
+
+- [mise](https://mise.jdx.dev/) for pinned local tool versions from `mise.toml`
+- [pnpm workspaces](https://pnpm.io/) for package management
+- [Nx](https://nx.dev/) and [Turborepo](https://turbo.build/repo) for task orchestration
+- [Changesets](https://github.com/changesets/changesets) for changelogs and publishing
+
+Useful root aliases include:
 
 ```bash
-pnpm build:device-deps
+pnpm desktop typecheck
+pnpm mobile test:jest
+pnpm --filter <package-name> test
+pnpm turbo build --filter=@ledgerhq/<lib-name>
 ```
 
-On **Linux** you need system deps first: `libusb-1.0-0-dev` and `libudev-dev` (e.g. `sudo apt-get install -y libusb-1.0-0-dev libudev-dev` on Debian/Ubuntu).
+See [docs/common-commands.md](docs/common-commands.md) for the maintained command
+list instead of duplicating command details here.
 
-## Common setup errors
+## External Developer Documentation
 
-### Out of sync Podfile.lock
+For broader Ledger Wallet contribution and integration guides, including
+blockchain, token, swap, staking, Discover/Live Apps, testing strategy, and git
+conventions, use the [Ledger Developer Portal](https://developers.ledger.com/docs/ledger-live/contributing/getting-started).
 
-You may encounter this error when running `pnpm i`. Try:
+Developers adding blockchain support should start with the
+[Blockchain Support guide](https://developers.ledger.com/docs/coin/general-process).
 
-```sh
-rm -rf ~/.cocoapods/
-pnpm clean && pnpm store prune && mise install && pnpm i && pnpm build:llm:deps
-pnpm mobile pod
-```
+## Releases
 
-> Note: If prompted to run `bundle install` do this in the [ledger-live-mobile](apps/ledger-live-mobile) directory. Restart terminal if the error persists.
+Nightly builds and packages are produced from `develop`.
 
-## Usage
+- Desktop binaries are attached to the desktop build workflow.
+- Mobile Android APKs are attached to the mobile build workflow.
+- Library packages are published nightly to npm with the `@nightly` dist-tag.
 
-**Important: All the commands should be run at the root of the monorepo.**
-
-### Tools
-
-We use [**pnpm workspaces**](https://pnpm.io/) and [**Nx**](https://nx.dev/) under the hood to handle local and external dependencies, orchestrate tasks and perform various optimizations like package hoisting or [**remote caching**](https://nx.dev/docs/features/cache-task-results).
-
-For changelog generation releases and package publishing we rely on the [**changesets**](https://github.com/changesets/changesets) library.
-
-### Root scripts
-
-The scripts that are defined inside the root [`/package.json`](https://github.com/LedgerHQ/ledger-live/blob/develop/package.json) file use _Nx_ under the hood and automatically perform needed tasks before running the action.
-
-```sh
-# This command will first build all the local dependencies needed in the right order.
-# Only then it will attempt to build the `Ledger Live Desktop` app.
-pnpm build:lld
-```
-
-### Aliases
-
-To run nested scripts which are not covered at the root, you should **not** change your working directory.
-Every package has an **alias** defined (see application or library tables or check out the [`package.json`](https://github.com/LedgerHQ/ledger-live/blob/develop/package.json) file) that you can use as a prefix when running the script from the root.
-
-```sh
-# `pnpm desktop` is one of the shorthands written to avoid changing the working directory.
-
-# The following command will run the nested `test` script.
-# `test` is defined inside the `./apps/ledger-live-desktop/package.json` file.
-pnpm desktop test
-```
-
-**Note that when using these kinds of scripts you will have to make sure that the dependencies are built beforehand.**
-
-### Scoping
-
-You can scope _pnpm_ scripts with `--filter`, and run tasks on specific projects with `nx run` / `nx run-many`.
-
-**This is a very powerful feature that you should look into if you are a frequent contributor.**
-
-Please check out the [_pnpm_](https://pnpm.io/filtering) and [_Nx_](https://nx.dev/docs/features/run-tasks) documentation for more details.
-
-Here are some examples:
-
-```sh
-# Install all the dependencies needed for the packages under ./libs
-pnpm i -F "{libs/**}..."
-# Run lint only on packages that have been changed compared to origin/develop
-pnpm lint --filter=[origin/develop]
-# Test every package that has been changed since the last commit excluding the applications
-pnpm run test --continue --filter="!./apps/*" --filter="...[HEAD~1]"
-# Run typechecks for the Ledger Live Mobile project
-pnpm typecheck --filter="live-mobile"
-```
-
-## Documentation
-
-Each project folder has a `README.md` file which contains basic documentation.
-It includes background information about the project and how to setup, run and build it.
-
-Please check the [**wiki**](https://github.com/LedgerHQ/ledger-live/wiki) for additional documentation.
-
-For comprehensive developer documentation — including architecture, MVVM pattern, testing strategy, git conventions, and integration guides (blockchain, tokens, swap, staking, Discover/Live Apps, etc.) — visit the [**Ledger Developer Portal**](https://developers.ledger.com/docs/ledger-live/contributing/getting-started).
-
-## Structure
-
-The sub-packages are (roughly) split into three categories.
-
-### `/app` - Applications
-
-The applications are user-facing programs which depend on one or more libraries.
-
-<details><summary><b>Ledger Live Applications</b></summary>
-<br/>
-<p>
-
-| Name                                                                                                     | Alias          | Download                                                                                                                                                         |
-| -------------------------------------------------------------------------------------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [**Ledger Live Desktop**](https://github.com/LedgerHQ/ledger-live/tree/develop/apps/ledger-live-desktop) | `pnpm desktop` | [Website](https://www.ledger.com/ledger-live/download)                                                                                                           |
-| [**Ledger Live Mobile**](https://github.com/LedgerHQ/ledger-live/tree/develop/apps/ledger-live-mobile)   | `pnpm mobile`  | [Android](https://play.google.com/store/apps/details?id=com.ledger.live&hl=fr&gl=US) / [iOS](https://apps.apple.com/fr/app/ledger-live-web3-wallet/id1361671700) |
-
-</p>
-</details>
-
-### `/libs` - Libraries
-
-Libraries serve as publicly available packages, designed for integration with other libraries or applications.
-These packages are deployed to the official npm repository under the `@ledgerhq` organization.
-
-<details><summary><b>Ledger Live Libraries</b></summary>
-<br/>
-<p>
-
-| Name                                                                                                                                                         | Alias                          | Umbrella                                                                       | Package                                                                                                                                                       |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------ | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [**@ledgerhq/ledger-live-common**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledger-live-common)                                             | `pnpm common`                  | -----                                                                          |
-| ----                                                                                                                                                         | -----                          | -----                                                                          | -------                                                                                                                                                       |
-| [**@ledgerhq/cryptoassets**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/cryptoassets)                                       | `pnpm ljs:cryoptoassets`       | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/cryptoassets.svg)](https://www.npmjs.com/package/@ledgerhq/cryptoassets)                                       |
-| [**@ledgerhq/devices**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/devices)                                                 | `pnpm ljs:devices`             | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/devices.svg)](https://www.npmjs.com/package/@ledgerhq/devices)                                                 |
-| [**@ledgerhq/errors**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/errors)                                                   | `pnpm ljs:errors`              | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/errors.svg)](https://www.npmjs.com/package/@ledgerhq/errors)                                                   |
-| [**@ledgerhq/hw-app-algorand**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/hw-app-algorand)                                 | `pnpm ljs:hw-app-algorand`     | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/hw-app-algorand.svg)](https://www.npmjs.com/package/@ledgerhq/hw-app-algorand)                                 |
-| [**@ledgerhq/hw-app-btc**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/hw-app-btc)                                           | `pnpm ljs:hw-app-btc`          | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/hw-app-btc.svg)](https://www.npmjs.com/package/@ledgerhq/hw-app-btc)                                           |
-| [**@ledgerhq/hw-app-cosmos**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/hw-app-cosmos)                                     | `pnpm ljs:hw-app-cosmos`       | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/hw-app-cosmos.svg)](https://www.npmjs.com/package/@ledgerhq/hw-app-cosmos)                                     |
-| [**@ledgerhq/hw-app-eth**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/hw-app-eth)                                           | `pnpm ljs:hw-app-eth`          | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/hw-app-eth.svg)](https://www.npmjs.com/package/@ledgerhq/hw-app-eth)                                           |
-| [**@ledgerhq/hw-app-helium**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/hw-app-helium)                                     | `pnpm ljs:hw-app-helium`       | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/hw-app-helium.svg)](https://www.npmjs.com/package/@ledgerhq/hw-app-helium)                                     |
-| [**@ledgerhq/hw-app-polkadot**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/hw-app-polkadot)                                 | `pnpm ljs:hw-app-polkadot`     | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/hw-app-polkadot.svg)](https://www.npmjs.com/package/@ledgerhq/hw-app-polkadot)                                 |
-| [**@ledgerhq/hw-app-solana**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/hw-app-solana)                                     | `pnpm ljs:hw-app-solana`       | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/hw-app-solana.svg)](https://www.npmjs.com/package/@ledgerhq/hw-app-solana)                                     |
-| [**@ledgerhq/hw-app-str**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/hw-app-str)                                           | `pnpm ljs:hw-app-str`          | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/hw-app-str.svg)](https://www.npmjs.com/package/@ledgerhq/hw-app-str)                                           |
-| [**@ledgerhq/hw-app-tezos**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/hw-app-tezos)                                       | `pnpm ljs:hw-app-tezos`        | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/hw-app-tezos.svg)](https://www.npmjs.com/package/@ledgerhq/hw-app-tezos)                                       |
-| [**@ledgerhq/hw-app-trx**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/hw-app-trx)                                           | `pnpm ljs:hw-app-trx`          | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/hw-app-trx.svg)](https://www.npmjs.com/package/@ledgerhq/hw-app-trx)                                           |
-| [**@ledgerhq/hw-app-xrp**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/hw-app-xrp)                                           | `pnpm ljs:hw-app-xrp`          | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/hw-app-xrp.svg)](https://www.npmjs.com/package/@ledgerhq/hw-app-xrp)                                           |
-| [**@ledgerhq/hw-transport**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/hw-transport)                                       | `pnpm ljs:hw-transport`        | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/hw-transport.svg)](https://www.npmjs.com/package/@ledgerhq/hw-transport)                                       |
-| [**@ledgerhq/hw-transport-http**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/hw-transport-http)                             | `pnpm ljs:hw-transport-http`   | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/hw-transport-http.svg)](https://www.npmjs.com/package/@ledgerhq/hw-transport-http)                             |
-| [**@ledgerhq/hw-transport-mocker**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/hw-transport-mocker)                         | `pnpm ljs:hw-transport-mocker` | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/hw-transport-mocker.svg)](https://www.npmjs.com/package/@ledgerhq/hw-transport-mocker)                         |
-| [**@ledgerhq/hw-transport-node-hid**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/hw-transport-node-hid)                     | `pnpm ljs:hw-transport-node`   | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/hw-transport-node-hid.svg)](https://www.npmjs.com/package/@ledgerhq/hw-transport-node-hid)                     |
-| [**@ledgerhq/hw-transport-node-hid-noevents**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/hw-transport-node-hid-noevents)   | `pnpm ljs:hw-transport-node`   | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/hw-transport-node-hid-noevents.svg)](https://www.npmjs.com/package/@ledgerhq/hw-transport-node-hid-noevents)   |
-| [**@ledgerhq/hw-transport-node-hid-singleton**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/hw-transport-node-hid-singleton) | `pnpm ljs:hw-transport-node`   | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/hw-transport-node-hid-singleton.svg)](https://www.npmjs.com/package/@ledgerhq/hw-transport-node-hid-singleton) |
-| [**@ledgerhq/hw-transport-node-speculos**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/hw-transport-node-speculos)           | `pnpm ljs:hw-transport-node`   | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/hw-transport-node-speculos.svg)](https://www.npmjs.com/package/@ledgerhq/hw-transport-node-speculos)           |
-| [**@ledgerhq/hw-transport-node-speculos-http**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/hw-transport-node-speculos-http) | `pnpm ljs:hw-transport-node`   | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/hw-transport-node-speculos-http.svg)](https://www.npmjs.com/package/@ledgerhq/hw-transport-node-speculos-http) |
-| [**@ledgerhq/hw-transport-web-ble**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/hw-transport-web-ble)                       | `pnpm ljs:hw-transport-web`    | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/hw-transport-web-ble.svg)](https://www.npmjs.com/package/@ledgerhq/hw-transport-web-ble)                       |
-| [**@ledgerhq/hw-transport-webhid**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/hw-transport-webhid)                         | `pnpm ljs:hw-transport-webhid` | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/hw-transport-webhid.svg)](https://www.npmjs.com/package/@ledgerhq/hw-transport-webhid)                         |
-| [**@ledgerhq/hw-transport-webusb**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/hw-transport-webusb)                         | `pnpm ljs:hw-transport-webusb` | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/hw-transport-webusb.svg)](https://www.npmjs.com/package/@ledgerhq/hw-transport-webusb)                         |
-| [**@ledgerhq/logs**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/logs)                                                       | `pnpm ljs:logs`                | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/logs.svg)](https://www.npmjs.com/package/@ledgerhq/logs)                                                       |
-| [**@ledgerhq/react-native-hid**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/react-native-hid)                               | `pnpm ljs:react-native-hid`    | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/react-native-hid.svg)](https://www.npmjs.com/package/@ledgerhq/react-native-hid)                               |
-| [**@ledgerhq/react-native-hw-transport-ble**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/react-native-hw-transport-ble)     | `pnpm ljs:react-native-hw`     | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/react-native-hw-transport-ble.svg)](https://www.npmjs.com/package/@ledgerhq/react-native-hw-transport-ble)     |
-| [**@ledgerhq/types-cryptoassets**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/types-cryptoassets)                           | `pnpm ljs:types-cryptoassets`  | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/types-cryptoassets.svg)](https://www.npmjs.com/package/@ledgerhq/types-cryptoassets)                           |
-| [**@ledgerhq/types-devices**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/types-devices)                                     | `pnpm ljs:types-devices`       | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/types-devices.svg)](https://www.npmjs.com/package/@ledgerhq/types-devices)                                     |
-| [**@ledgerhq/types-live**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/types-live)                                           | `pnpm ljs:types-live`          | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/types-live.svg)](https://www.npmjs.com/package/@ledgerhq/types-live)                                           |
-| ----                                                                                                                                                         | -----                          | -----                                                                          | -------                                                                                                                                                       |
-| [**@ledgerhq/icons-ui**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ui/packages/icons)                                                        | `pnpm ui:icons`                | [ui](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ui)             | [![npm](https://img.shields.io/npm/v/@ledgerhq/icons-ui.svg)](https://www.npmjs.com/package/@ledgerhq/icons-ui)                                               |
-| [**@ledgerhq/native-ui**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ui/packages/native)                                                      | `pnpm ui:native`               | [ui](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ui)             | [![npm](https://img.shields.io/npm/v/@ledgerhq/native-ui.svg)](https://www.npmjs.com/package/@ledgerhq/native-ui)                                             |
-| [**@ledgerhq/react-ui**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ui/packages/react)                                                        | `pnpm ui:react`                | [ui](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ui)             | [![npm](https://img.shields.io/npm/v/@ledgerhq/react-ui.svg)](https://www.npmjs.com/package/@ledgerhq/react-ui)                                               |
-| [**@ledgerhq/ui-shared**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ui/packages/shared)                                                      | `pnpm ui:shared`               | [ui](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ui)             | [![npm](https://img.shields.io/npm/v/@ledgerhq/ui-shared.svg)](https://www.npmjs.com/package/@ledgerhq/ui-shared)                                             |
-
-</p>
-</details>
-
-### `/tools` - Tools
-
-> ⚠️ Tools are primarily intended for internal use and are largely undocumented.
-
-A tool can be a github action, a shell script or a piece of JavaScript code that is used throughout this repository.
-
-## Contributing
-
-Please check the general guidelines for contributing to Ledger Live projects: [`CONTRIBUTING.md`](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md).
-
-Each individual project may include its own specific guidelines, located within its respective folder.
-
-While you explore these projects, here are some key points to keep in mind:
-
-- Follow the git workflow, prefix your branches and do not create unnecessary merge commits.
-- Be mindful when creating Pull Requests, clearly specify the purpose of your changes and include tests where applicable.
-- Ledger Applications are mostly accepting bugfix contributions. Feature contributions are subject to review; they may be declined if they don't align with our roadmap or our long-term objectives.
-
-## Nightly Releases
-
-Every night a github action merges the `develop` branch into the `nightly` branch.
-
-For more information on the nightly releases, have a look at our [wiki](https://github.com/LedgerHQ/ledger-live/wiki/Release-Process#nightlies).
-
-### Ledger Live Desktop
-
-- Every commit [triggers a workflow](https://github.com/LedgerHQ/ledger-live/actions/workflows/build-desktop.yml) that will build and attach the application binaries to the run.
-- _For Ledger Employees:_ Nightly releases are built every night under the protected [ledger-live-build](https://github.com/LedgerHQ/ledger-live-build) repository.
-
-### Ledger Live Mobile
-
-- Every commit [triggers a workflow](https://github.com/LedgerHQ/ledger-live/actions/workflows/build-mobile.yml) that will build and attach the `Android` apk to the run.
-- _For Ledger Employees:_ Nightly releases are built and published every night to [Testflight](https://developer.apple.com/testflight/) and the [Google Play Console](https://play.google.com/console).
-
-### Libraries
-
-Nightly versions of library packages are pushed every night to npm.
-
-To install a nightly library use the `@nightly` dist-tag.
-
-```sh
+```bash
 npm i @ledgerhq/live-common@nightly
 ```
 
 ## License
 
-Please check each project `LICENSE` file, most of them are under the `MIT` license.
+Check each package `LICENSE` file. Most packages are licensed under MIT.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -14,7 +14,7 @@ npm i --global @ledgerhq/live-cli
 
 ## Run commands
 
-Jump to the [documentation](#Documentation) for more informations on the available commands
+Jump to the [documentation](#documentation) for more information about the available commands.
 
 ```bash
 ledger-live <commands>
@@ -26,14 +26,17 @@ ledger-live <commands>
 
 ### Requirements
 
-- [NodeJS](https://nodejs.org) `lts/fermium` (v14.x)
-- [PnPm](https://pnpm.io) (v7.x)
-- [Python](https://www.python.org/) (v3.5+)
+- Toolchain installed from the repository root with `mise install`
+- Dependencies installed with `pnpm i`
 - On Linux: `sudo apt-get update && sudo apt-get install libudev-dev libusb-1.0-0-dev`
+
+The pinned Node and pnpm versions live in the root [`mise.toml`](../../mise.toml).
+See [common commands](../../docs/common-commands.md) for maintained setup,
+build, and test commands.
 
 ## Install
 
-> Reminder: all commands should be run at the root of the monorepository
+> Reminder: all commands should be run from the repository root.
 
 ```bash
 # install dependencies

--- a/apps/ledger-live-desktop/README.md
+++ b/apps/ledger-live-desktop/README.md
@@ -1,13 +1,13 @@
-**[We are hiring, join us! 👨‍💻👩‍💻](https://jobs.lever.co/ledger/?department=Tech)**
+# Ledger Live Desktop
 
-# Ledger Live (desktop)
+Ledger Live Desktop is the Electron app for Ledger hardware wallets on macOS,
+Windows, and Linux. Users can manage crypto assets, install apps on Ledger
+devices, update firmware, verify public addresses, and sign transactions.
 
-- Related: [ledger-live-mobile](https://github.com/LedgerHQ/ledger-live/tree/develop/apps/ledger-live-mobile)
-- Backed by: [ledger-live-common](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledger-live-common)
-
-> Ledger Live is a desktop companion app for Ledger hardware wallets. It allows users to manage their crypto assets securely, such as Bitcoin, Ethereum, XRP and many others. Ledger Live desktop is available for Mac, Windows (x64) and Linux (x64). It can be downloaded from [ledger.com/ledger-live](https://www.ledger.com/ledger-live/).
-
-Minimum system requirements can be found on [Ledger Support website](https://support.ledger.com/hc/en-us/articles/4403310017041-Ledger-Live-system-requirements-?docs=true).
+- Related app: [Ledger Live Mobile](../ledger-live-mobile/README.md)
+- Shared business logic: [ledger-live-common](../../libs/ledger-live-common/README.md)
+- Download: [ledger.com/ledger-live](https://www.ledger.com/ledger-live/)
+- System requirements: [Ledger Support](https://support.ledger.com/hc/en-us/articles/4403310017041-Ledger-Live-system-requirements-?docs=true)
 
 <a href="https://github.com/LedgerHQ/ledger-live-desktop/releases">
   <p align="center">
@@ -17,115 +17,80 @@ Minimum system requirements can be found on [Ledger Support website](https://sup
 
 ## Architecture
 
-Ledger Live desktop is an hybrid application built using Electron, React, Redux, RxJS. It communicates with [Ledger hardware wallet devices](https://shop.ledger.com/pages/hardware-wallets-comparison) to manage installed applications, update the device firmware, verify public addresses and sign transactions with [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs).
+The app is built with Electron, React, Redux, and RxJS. It uses LedgerJS and
+shared Ledger Wallet logic to communicate with devices, synchronize accounts,
+and prepare transactions.
 
-We also share core business logic with Ledger Live mobile through [@ledgerhq/live-common](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledger-live-common) package.
+Main source areas:
 
-## Signed hashes
+| Path                    | Purpose                                                                 |
+| ----------------------- | ----------------------------------------------------------------------- |
+| `src/main`              | Electron main process                                                   |
+| `src/internal`          | Internal worker process for commands and device logic                   |
+| `src/renderer`          | React UI, screens, modals, bridges, analytics, i18n, and renderer setup |
+| `src/renderer/families` | Per-currency UI logic                                                   |
+| `tests`                 | App-local Playwright/component test helpers and specs                   |
 
-Ledger Live releases are signed. The automatic update mechanism makes use of the signature to verify that each subsequent update is authentic. Instructions for verifying the hash and signatures of the installation packages are available on [Ledger Live tools website](https://live.ledger.tools/lld-signatures), which will be integrated into the [official download page](https://www.ledger.com/ledger-live).
+Releases are signed, and the updater verifies signatures before applying a new
+version. Hash/signature verification details are available on
+[live.ledger.tools/lld-signatures](https://live.ledger.tools/lld-signatures).
 
-# Development
+## Development
 
-## Setup
+Run commands from the repository root.
 
-### Requirements
-
-- [NodeJS](https://nodejs.org) `lts/gallium` (v16.x) + [npm](https://www.npmjs.com/)
-- [PnPm](https://pnpm.io) (v7.x)
-- [Python](https://www.python.org/) (v3.5+)
-- A C/C++ toolchain (see [node-gyp documentation](https://github.com/nodejs/node-gyp#on-unix))
-- On Linux: `sudo apt-get update && sudo apt-get install libudev-dev libusb-1.0-0-dev`
-
-## Install
-
-> Reminder: all commands should be run at the root of the monorepository
+Use the repo root setup first:
 
 ```bash
-# install dependencies
+mise install
 pnpm i
 ```
 
-## Run
+Linux also needs USB/HID native dependencies:
 
 ```bash
-# launch the app in dev mode
+sudo apt-get update
+sudo apt-get install libudev-dev libusb-1.0-0-dev
+```
+
+Common desktop commands:
+
+```bash
 pnpm dev:lld
-```
-
-```bash
-# launch the app in dev mode with MSW
 pnpm dev:lld:msw
-```
-
-## Watch deps
-
-In another terminal and in parallel to `pnpm dev:lld`, you can watch different libs from the monorepo
-LLD is using vite and will import in priority the esm libs so we need to watch and build for esm in some libs
-
-```bash
-# watch common
-pnpm watch:es:common
-
-# watch ljs
-pnpm watch:es:ljs
-
-# watch coin integrations
-pnpm watch:es:coin
-
-# watch specific lib
-nx run @ledgerhq/hw-app-btc:watch:es
-
-# watch specific coin integration
-nx run @ledgerhq/coin-bitcoin:watch:es
-```
-
-## Build
-
-```bash
-# Build & package the whole app
-# Creates a .dmg for Mac, .exe installer for Windows, or .AppImage for Linux
-# Output files will be created in dist/ folder
-
-# build all the required dependencies
-pnpm build:lld:deps
-# then use alias to trigger the `dist` script in ledger-live-desktop project
-pnpm desktop build
-
-# or you can use the top level script (pnpm build:lld:deps not required in this case)
 pnpm build:lld
+pnpm desktop test:jest
+pnpm desktop lint
+pnpm desktop lint:guardrails
+pnpm desktop typecheck
 ```
 
-## Debug
+See the repo-level [common commands](../../docs/common-commands.md) and
+[validation guidance](../../docs/validate-before-finishing.md) for maintained
+command coverage.
 
-If you are using [Visual Studio Code](https://code.visualstudio.com/) IDE, we provide a [default debug configuration](https://github.com/LedgerHQ/ledger-live/tree/develop/.vscode/launch.json) that you can use to debug the main and renderer processes of the application.
+## Watching Dependencies
 
-### Tips
+In another terminal, run the relevant watcher when changing shared packages used
+by Desktop:
 
-- #### **Can't find Node.js binary "pnpm": path does not exist. Make sure Node.js is installed and in your PATH, or set the "runtimeExecutable" in your launch.json\***
+```bash
+pnpm watch:es:common
+pnpm watch:es:ljs
+pnpm watch:es:coin
+pnpm turbo run watch:es --filter="./libs/ledgerjs/packages/hw-app-btc"
+pnpm turbo run watch:es --filter="./libs/coin-modules/coin-bitcoin"
+```
 
-  Add your terminal PATH as environment variable.
+## Testing
 
-  ```json
-    "env": {
-      "ELECTRON_ARGS": "--remote-debugging-port=8315",
-      "PATH": "...",
-    }
-  ```
+- Jest: `pnpm desktop test:jest`
+- App-local Playwright helpers/specs: [tests/README.md](tests/README.md)
+- Full Desktop E2E setup and Speculos flows: [../../e2e/desktop/README.md](../../e2e/desktop/README.md)
 
-  To get the PATH, run in your terminal:
+## Local Notes
 
-  ```bash
-  echo $PATH
-  ```
-
----
-
-## Config (optional helpers)
-
-### Environment variables
-
-(you can use a .env or export environment variables)
+Optional debug environment variables can be set in `.env`:
 
 ```bash
 NO_DEBUG_DB=1
@@ -138,87 +103,14 @@ NO_DEBUG_DEVICE=1
 NO_DEBUG_COUNTERVALUES=1
 ```
 
-Other environment variables can be found in [libs/src/env.ts](https://github.com/LedgerHQ/ledger-live/blob/develop/libs/env/src/env.ts)
+Other environment variables are defined in
+[libs/env/src/env.ts](../../libs/env/src/env.ts).
 
-### Run tests
+Linting uses oxlint for most rules and `pnpm desktop lint:guardrails` for the
+remaining ESLint-only security guardrail around external links.
 
-> Reminder: all commands should be run at the root of the monorepository
+Translations are handled internally. If a translation string is broken, report
+it to Ledger support rather than editing localized content directly.
 
-```bash
-pnpm desktop test
-```
-
-### Run code quality checks
-
-```bash
-pnpm desktop lint          # oxlint (main linter)
-pnpm desktop lint:guardrails   # ESLint guardrails (one rule only)
-pnpm desktop typecheck
-```
-
-### Linting setup
-
-Linting has been migrated from ESLint to **oxlint** for speed and consistency. Almost all rules now live in [`.oxlintrc.json`](.oxlintrc.json) (restricted imports, React/TypeScript/Jest rules, etc.).
-
-**ESLint guardrails** ([`.eslintrc.guardrails.js`](.eslintrc.guardrails.js)) are still run via `pnpm desktop lint:guardrails`. One rule remains there because oxlint does not support it: **`no-restricted-syntax`** with complex AST selectors. That rule forbids direct use of `shell.openExternal()` outside the safe wrappers (`~/renderer/linking` and `src/main/openURL.ts`) for security (RCE prevention). Oxlint’s `no-restricted-syntax` only supports simple node-type selectors, not the property-based selectors needed for this check.
-
-Going forward, when adding or changing lint rules:
-
-- Prefer oxlint; add or adjust rules in `.oxlintrc.json`.
-- If a rule truly requires ESLint-only features (e.g. `excludedFiles` or complex selectors), add it to `.eslintrc.guardrails.js` and document why.
-- Re-evaluate guardrails periodically: as oxlint gains support for more selector types or overrides, rules should be moved from ESLint to oxlint when possible.
-
-The goal is to use oxlint for everything and remove ESLint from this app once the remaining guardrail can be expressed in oxlint or replaced by an equivalent.
-
-## File structure
-
-```
-src
-├── main : the main process is the mother of all process. it boots internal and renderer process and starts the window.
-├── internal : related to internal thread that runs commands, device logic, libcore,..
-├── renderer : everything related to the UI.
-│   ├── screens
-│   ├── modals
-│   ├── components : all components that are not screens or modals, flattened.
-│   ├── animations
-│   ├── icons
-│   ├── images
-│   ├── styles
-│   ├── bridge : logic related to interacting with accounts and currencies.
-│   ├── families : per currency specific logic and components
-│   ├── actions : redux actions
-│   ├── reducers : redux reducers
-│   ├── middlewares
-│   ├── analytics
-│   ├── fonts
-│   ├── hooks
-│   ├── i18n : all translation files
-|   ├── logger : internal logging library. Can be exported through the "save logs" feature.
-│   ├── index.html : html entry point
-│   ├── index.ts : js entry point
-│   ├── init.tsx : initialize rendering
-│   ├── live-common-setup.ts : set up live-common for renderer specific parts
-│   └── ... other files related to renderer
-├── config : constants files. DEPRECATED. Will be moved to live-common.
-├── helpers : helpers. DEPRECATED. Will be moved to live-common or in relevant places.
-├── live-common-set-supported-currencies.ts : generic set up of supported coins
-├── live-common-setup-base.ts : generic set up of live-common
-└── sentry : related to bug report API
-```
-
-## Localization / Translations
-
-Translations from English to other languages are handled internally so it is not possible to directly contribute to them, however if you spot a bug (e.g. a wrong variable name) or any issue in translation files, feel free to report a bug to Ledger's support team and it will be taken care of.
-
----
-
-## Are you adding the support of a blockchain to Ledger Live?
-
-This part of the repository is where you will add the support of your blockchain for the desktop app.
-
-For a smooth and quick integration:
-
-- See the developers’ documentation on the [Developer Portal](https://developers.ledger.com/docs/coin/general-process/) and
-- Go on [Discord](https://developers.ledger.com/discord-pro/) to chat with developer support and the developer community.
-
----
+For blockchain integration guidance, use the
+[Ledger Developer Portal](https://developers.ledger.com/docs/coin/general-process/).

--- a/apps/ledger-live-desktop/tests/README.md
+++ b/apps/ledger-live-desktop/tests/README.md
@@ -1,404 +1,86 @@
-# Table of Contents
+# Ledger Live Desktop Tests
 
-- [Introduction](#introduction)
-- [Pre-requisites](#pre-requisites)
-  - [Visual Studio Code extensions](#visual-studio-code-extensions)
-- [Installation](#installation)
-- [Setup](#setup)
-- [Execution](#execution)
-  - [Build](#build)
-  - [Run tests](#run-tests)
-- [Recorder](#recorder)
-- [Development](#development)
-  - [Workflow](#workflow)
-    - [Step 1 - Identify elements](#step-1---identify-elements)
-    - [Step 2 - Create a page object](#step-2---create-a-page-object)
-    - [Step 3 - Create a test file](#step-3---create-a-test-file)
-    - [Step 4 - Update datasets](#step-4---update-dataset)
-    - [Step 5 - Run test](#step-5---run-test)
-  - [Playwright API](#playwright-api)
-- [Continuous Integration](#continuous-integration)
-  - [Workflow](#workflow-1)
-  - [Commands](#commands)
-- [Debugging](#debugging)
-- [Resources](#resources)
-  - [Releases](#releases)
-  - [Documentation](#documentation)
-    - [Code coverage](#code-coverage)
+This folder contains app-local Playwright fixtures, page objects, component
+tests, mocks, and specs for Ledger Live Desktop.
 
-# Introduction
+For the maintained Desktop E2E environment, Speculos setup, and full run
+commands, start with [../../../e2e/desktop/README.md](../../../e2e/desktop/README.md).
+For adding or updating E2E scenarios, read
+[../../../e2e/desktop/docs/add-or-update-e2e.md](../../../e2e/desktop/docs/add-or-update-e2e.md).
 
-An open source framework for easily writing UI tests for our Electron app. Playwright sets up and tears down your app and allows it to be test-driven remotely. Built on top of Devtools protocol.
+## Structure
 
-# Pre-requisites
+| Path                   | Purpose                                        |
+| ---------------------- | ---------------------------------------------- |
+| `fixtures`             | Playwright test fixtures and app launch setup  |
+| `page`                 | Page objects with reusable UI actions          |
+| `models`               | Test model helpers                             |
+| `specs`                | Test scenarios                                 |
+| `mocks` and `handlers` | Local mock data and MSW handlers               |
+| `utils`                | Test utilities, setup, teardown, and reporters |
 
-> We assume your setup is running [_ledger-live_](https://github.com/LedgerHQ/ledger-live) monorepo or at least _ledger-live-desktop_ app.
-> If not, please check the [installation guide](https://github.com/LedgerHQ/ledger-live#installation) and the [wiki](https://github.com/LedgerHQ/ledger-live#installation).
+## Run
 
-## Visual Studio Code extensions
+Run commands from the repository root.
 
-It's recommended to install those extensions.
-
-- [Typescript](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-next)
-- [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
-- [Playwright Test](https://marketplace.visualstudio.com/items?itemName=ms-playwright.playwright)
-
-# Installation
-
-Clone _ledger-live_ repository, install and build dependencies.
-
-```
-git clone https://github.com/LedgerHQ/ledger-live.git`
-pnpm i --filter="ledger-live-desktop..."`
-pnpm build:lld:deps
-```
-
-# Setup
-
-Playwright launches Ledger Live application using Electron `executablePath` and pass the main bundle and other options as parameters.
-
-> :information_source: Please have a look at `apps/ledger-live-desktop/tests/fixtures/common.ts` .
-
-![Setup](docs/setup.png)
-
-# Execution
-
-## Build
-
-Before executing any test, don’t forget to build the app, do it whenever the source code changed.
-
-```
+```bash
 pnpm desktop build:testing
-```
-
-> It must generate bundles in `apps/ledger-live-desktop/.webpack/` directory.
-
-## Run tests
-
-Please do the setup command if not done yet
-
-```
 pnpm desktop test:playwright:setup
-```
-
-Run a single test
-
-```
-pnpm desktop test:playwright specs/<testFolder>/<testName>
-```
-
-Run all tests in a directory
-
-```
-pnpm desktop test:playwright playwright/specs/onboarding/
-```
-
-Run all the tests
-
-```
 pnpm desktop test:playwright
-```
-
-Run all tests matching a tag
-
-```
+pnpm desktop test:playwright specs/<folder>/<file>.spec.ts
 pnpm desktop test:playwright --grep @onboarding
 ```
 
-# Recorder
+Update snapshots only when visual changes are intentional:
 
-To speed up test development, you can generate tests by recording your actions.
-
+```bash
+pnpm desktop test:playwright:update-snapshots apps/ledger-live-desktop/tests/specs/<folder>/<file>.spec.ts
 ```
+
+Use the recorder sparingly; recorded tests should be refactored into page
+objects before review:
+
+```bash
 pnpm desktop test:playwright:recorder
 ```
 
-> :warning: Fully recorded tests don’t generate maintainable tests. Please see [Development](#development) section.
+## Test Authoring
 
-# Development
+- Prefer `data-testid` for unique elements.
+- Keep page objects in `page/` or `models/` focused on actions and locators.
+- Do not put assertions in page objects; assert from specs.
+- Use visual comparison only when layout-level verification is the intent.
+- Avoid duplicate screenshots of the same screen.
+- Run new or changed tests multiple times before relying on them.
 
-## Workflow
+Example page-object pattern:
 
-![Workflow](docs/development-workflow.png)
-
----
-
-### Step 1 - Identify elements
-
-<u>Path:</u> `src/...`
-
-To interact with web elements (buttons, input fields, images, …), they should be identified using a [_data-testid_](https://playwright.dev/docs/selectors#id-data-testid-data-testid-data-test-selectors) for unique elements or a [_class_](https://developer.mozilla.org/en-US/docs/Web/CSS/Class_selectors) for multiple elements.
-
-> :information_source: As a convention, this is the pattern we must use: `<context>-<text or purpose>-<element type>`.
-
-_I want to identify the Get started CTA button in onboarding flow._
-
-Look for your element in `src/renderer/...` and give it a `data-testid` attribute.
-
-```html
-<button data-testid="”onboarding-getstarted-button”">Get started</button>
-```
-
-> :x: Don’t use a className in this case because the element is unique.
-
----
-
-### Step 2 - Create a page object
-
-> :information_source: [Page objects](https://martinfowler.com/bliki/PageObject.html) are [JavaScript classes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes).
-
-<u>Path:</u> `tests/models/`
-
-A page object regroups all elements you can interact with and all actions you can do in a specific app screen.
-
-_I want to declare get started button element in a page object related to Onboarding._
-
-Create `tests/models/onboardingPage.js`
-
-**Locators**
-
-Declare your element
-
-```javascript
-constructor(page: Page) {
-  this.page = page;
-  this.getStartedButton = page.getByTestId("onboarding-getstarted-button");
-}
-```
-
-**Methods**
-
-> :information_source: Please name your methods according to the [Keyword-driven testing](https://en.wikipedia.org/wiki/Keyword-driven_testing) methodology.
-
-Create an action by interacting with declared elements, you can make multiple actions in one method and wait for a specific state if needed.
-
-```javascript
-async getStarted() {
-  await this.getStartedButton.click();
-  await this.loader.waitFor({ state: "detached" });
-};
-```
-
-> :warning: Don’t write any assertions (with [expect](https://playwright.dev/docs/test-assertions) library) in a page object, make it re-usable by everyone; as an alternative you can use [waitFor](https://playwright.dev/docs/api/class-locator#locator-wait-for) method if you need to have a better control of the app state.
-
-**Example**
-
-At the end, it should look like this:
-
-```javascript
-import { Page, Locator } from "@playwright/test";
+```ts
+import { Locator, Page } from "@playwright/test";
 
 export class OnboardingPage {
-  readonly page: Page;
   readonly getStartedButton: Locator;
 
-  constructor(page: Page) {
-    this.page = page;
+  constructor(readonly page: Page) {
     this.getStartedButton = page.getByTestId("onboarding-get-started-button");
   }
 
   async getStarted() {
     await this.getStartedButton.click();
-    await this.loader.waitFor({ state: "detached" });
   }
 }
 ```
 
----
+## Debug
 
-### Step 3 - Create a test file
-
-<u>Path</u>: `tests/specs/`
-
-A test file regroups a series of actions and assertions to build a test scenario.
-
-_I want to create a file to test onboarding flow._
-
-Create `tests/specs/onboarding/new-device.spec.ts`
-
-```javascript
-test("Onboarding with a new device", ({ page }) => {
-  const onboardingPage = new OnboardingPage(page);
-
-  await test.step("Get started", async () => {
-    await onboardingPage.getStarted();
-    await expect(page).toHaveScreenshot('next-page.png')
-  });
-});
+```bash
+PWDEBUG=1 pnpm desktop test:playwright
+DEV_TOOLS=1 pnpm desktop test:playwright
+DEBUG=pw:api pnpm desktop test:playwright
 ```
 
-Each `test()` declaration will launch a unique electron/chromium session. To understand how tests are executed, please see .
-
-**Matchers**
-
-Playwright uses [expect](https://playwright.dev/docs/test-assertions) library for test assertions;
-
-- on `page` (browser) e.g: `await expect(page).toHaveTitle('Ledger Live');`
-- or a `locator` (web element) e.g: `await expect(getStartedButton).toBeEnabled();`
-
-**Visual comparison**
-
-> :information_source: Because of the Ledger Live application architecture (Hardware device, Market variation, Blockchain), we are forced to mock basically everything when automated tests are executed.
->
-> To make the most of this test framework, we opted for visual comparison, it permits us to assert the whole layout of the app.
-
-Playwright permits to compare screenshots. This assertion should be used **carefully** to avoid **heavy maintenance**, as example:
-
-_I want to check a button is redirecting me to another page._
-
-> Don’t use a visual comparison to check that, `await expect(page).toHaveURL(regexp)` is enough. Choose wisely your assertions, sometimes it's too overkill to take a screenshot.
->
-> Also, be sure to not create duplicates and compare same screen twice.
-
-_I want to compare exactly the page I’m seeing._
-
-```javascript
-await expect(page).toHaveScreenshot(name);
-```
-
-> :information_source: You can take a screenshot of the whole page, including overflowing elements.
->
-> ```javascript
-> await expect(page).toHaveSceeenshot(name, { fullPage: true });
-> ```
->
-> :x: This is currently not working with our application, please see [this](https://github.com/microsoft/playwright/issues/11041) issue.
-
-_I want to organize my screenshot set._
-
-```javascript
-await expect(page).toHaveScreenshot([directory, name]);
-```
-
-_I want to compare a single element on the page._
-
-```javascript
-await expect(onboardingPage.getStartedButton).toHaveScreenshot();
-```
-
-**Example**
-
-At the end, it should look like this:
-
-```javascript
-import test from "../../fixtures/common";
-import { expect } from "@playwright/test";
-import { OnboardingPage } from "../../models/OnboardingPage";
-
-test("Onboarding new device", async ({ page }) => {
-  const onboardingPage = new OnboardingPage(page);
-
-  await test.step("Get started", async () => {
-    await onboardingPage.getStarted();
-    await expect(page).toHaveScreenshot("next-page.png");
-  });
-});
-```
-
----
-
-### Step 4 - Update dataset
-
-Once tests are written, if you made screenshot comparisons, you will need to generate a new dataset of screenshots.
-
-```
-pnpm desktop test:playwright:update-snapshots  app/ledger-live-desktop/tests/specs/onboarding/new-device.spec.ts
-```
-
-### Step 5 - Run test
-
-:warning: **Test your test.**
-
-Run it at least 3 times to be sure it's not flaky.
-
-```
-pnpm desktop test:playwright app/ledger-live-desktop/tests/specs/onboarding/new-device.spec.ts
-```
-
-> :information_source: If you get into troubles, please read [this](https://playwright.dev/docs/test-assertions#page-assertions-to-have-screenshot-1) and [this](https://playwright.dev/docs/test-assertions#locator-assertions-to-have-screenshot-1).
-
-### Playwright API
-
-:note: Here are some resources that might help during a test development.
-
-_I want to interact with the browser._
-
-https://playwright.dev/docs/api/class-page
-
-_I want to interact with an element._
-
-https://playwright.dev/docs/api/class-locator
-
-_I want to create or update a page object._
-
-https://playwright.dev/docs/test-pom
-
-_I want to organize my tests._
-
-https://playwright.dev/docs/api/class-test
-
-_I want to perform assertions._
-
-https://playwright.dev/docs/assertions
-
-_I want to perform visual comparison._
-
-https://playwright.dev/docs/test-snapshots
-
-# Continuous Integration
-
-## Workflow
-
-![Workflow](docs/ci-workflow.png)
-
-### Commands
-
-- Generate new screenshots for all test suites
-
-  `/generate-screenshots`
-
-  > This command is meant to be posted as a comment in your pull request.
-  >
-  > :warning: You might not have the permission to do it.
-
-- Push an empty commit to trigger CI checks
-  ```
-  git commit -m 'Run CI checks' --allow-empty`
-  git push
-  ```
-
-# Debugging
-
-_I want to pause my script execution and check manually what’s going on._
-
-Place `page.pause();` in your test file before the line you want to debug.
-
-_I want to enable the debugger._
-
-    PWDEBUG=1 pnpm desktop test:playwright
-
-_I want Chrome DevTools._
-
-    DEV_TOOLS=1 pnpm desktop test:playwright
-
-_I want verbose logging._
-
-    DEBUG=pw:api pnpm desktop test:playwright
-
-# Resources
-
-## Releases
-
-- [Playwright changelogs](https://github.com/microsoft/playwright/releases)
-- [Electron changelogs](https://releases.electronjs.org/)
-
-## Documentation
-
-- [Playwright Documentation](https://playwright.dev/docs/intro)
-- [Playwright ⨯ Electron](https://playwright.dev/docs/api/class-electron)
-- [Electron Documentation](https://www.electronjs.org/fr/docs/latest)
-
-### Code coverage
-
-- [Documentation](https://playwright.dev/docs/api/class-coverage)
-- [Playwright ⨯ Istanbul](https://github.com/mxschmitt/playwright-test-coverage)
+Useful external references:
+
+- [Playwright assertions](https://playwright.dev/docs/test-assertions)
+- [Page object models](https://playwright.dev/docs/test-pom)
+- [Visual comparisons](https://playwright.dev/docs/test-snapshots)

--- a/apps/ledger-live-mobile/README.md
+++ b/apps/ledger-live-mobile/README.md
@@ -1,221 +1,134 @@
-**[We are hiring, join us! 👨‍💻👩‍💻](https://jobs.lever.co/ledger/?department=Tech)**
+# Ledger Live Mobile
 
-# ledger-live-mobile
+Ledger Live Mobile is the React Native app for Ledger hardware wallets on iOS
+and Android. Users can manage crypto assets, connect to devices over Bluetooth
+or USB, update firmware, verify public addresses, and sign transactions.
 
-- Related: [ledger-live-desktop](https://github.com/LedgerHQ/ledger-live/tree/develop/apps/ledger-live-desktop)
-- Backed by: [ledger-live-common](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledger-live-common)
-
-> Ledger Live is a mobile companion app for Ledger hardware wallets. It allows users to manage their crypto assets securely, such as Bitcoin, Ethereum, XRP and many others. Ledger Live mobile is available for [iOS](https://itunes.apple.com/fr/app/id1361671700) and [Android](https://play.google.com/store/apps/details?id=com.ledger.live).
-
-![](https://user-images.githubusercontent.com/211411/51758554-42edb980-20c6-11e9-89f0-308949a760d6.png)
+- Related app: [Ledger Live Desktop](../ledger-live-desktop/README.md)
+- Shared business logic: [ledger-live-common](../../libs/ledger-live-common/README.md)
+- iOS: [App Store](https://apps.apple.com/fr/app/ledger-live-web3-wallet/id1361671700)
+- Android: [Google Play](https://play.google.com/store/apps/details?id=com.ledger.live)
 
 ## Architecture
 
-Ledger Live mobile is a native mobile application built using React Native, React, Redux, RxJS. It is compatible with iOS and Android. It communicates with [Ledger hardware wallet devices](https://shop.ledger.com/pages/hardware-wallets-comparison) via Bluetooth (when compatible) or USB to manage installed applications, update the device firmware, verify public addresses and sign transactions with [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs).
+The app is built with React Native, React, Redux, and RxJS. It uses LedgerJS and
+shared Ledger Wallet logic to communicate with devices, synchronize accounts,
+and prepare transactions. Core wallet behavior is shared with Desktop through
+`@ledgerhq/live-common`.
 
-We also share core business logic with Ledger Live mobile through [@ledgerhq/live-common library](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledger-live-common) package.
+## Prerequisites
 
-# Developing on ledger-live-mobile
-
-## Pre-requisites
-
-- Node LTS version
-- PNPM
-- [React Native (without Expo)](https://reactnative.dev/docs/environment-setup)
-
-### iOS
-
-- XCode (our CI builds run 15.3, so 15.3 is recommended)
-- Ruby 3.3.0 or above. The macOS built-in Ruby [does not work properly for installing dependencies of the iOS app](https://jeffreymorgan.io/articles/ruby-on-macos-with-rvm/), you have to install Ruby with for instance [Homebrew](https://brew.sh/) or [rvm](https://rvm.io/rvm/install) and make sure that `which ruby` points to that newly installed Ruby.
-
-### Android
-
-- Android Studio
-- JDK 17
-- Required SDK tools: (go to Android Studio > Tools > SDK Manager > SDK Tools > check "Show Package Details" at the bottom right)
-  - Android NDK 21.4.7075529 (in case this doc is outdated, check the version specified as `ndkVersion` in `android/build.gradle`)
-  - CMake 3.10.2
-
-## Scripts
-
-> Reminder: all commands should be run at the root of the monorepository
-
-### `pnpm i`
-
-install dependencies.
-
-### `pnpm dev:llm`
-
-Runs your app in development mode.
-
-Sometimes you may need to reset or clear the React Native packager's cache. To do so, you can pass the `--reset-cache` flag to the start script:
-
-```
-pnpm dev:llm -- --reset-cache
-```
-
-**Faster cold start:** The dev server builds for both iOS and Android by default (~28s cold). To build for one platform only and roughly halve cold start time, use `pnpm dev:llm:ios` or `pnpm dev:llm:android` (or from this app: `pnpm start:ios` / `pnpm start:android`).
-
-### `pnpm mobile test`
-
-### `pnpm mobile ios`
-
-or `open ios/ledgerlivemobile.xcworkspace` in XCode
-
-Note:
-You need to have metro running with `pnpm dev:llm` then `pnpm mobile ios` in another terminal
-
-### `pnpm mobile android`
-
-or open `android/` in Android Studio.
-
-Note:
-You need to have metro running with `pnpm dev:llm` then `pnpm mobile android` in another terminal
-
-### `pnpm mobile android:clean`
-
-Delete the application data for Ledger Live Mobile, equivalent to doing it manually through settings.
-
-### Linting (oxlint + ESLint i18n)
-
-Linting uses [oxlint](https://oxc.rs/docs/guide/usage/linter) with config in `.oxlintrc.json`. Scripts: `pnpm mobile lint`, `pnpm mobile lint:ci`, `pnpm mobile lint:fix`, `pnpm mobile format`, `pnpm mobile format:check`. The rule **`i18next/no-literal-string`** (no raw string literals in JSX) is not supported by oxlint; run it separately with **`pnpm mobile lint:i18n`**, which uses a minimal ESLint config (`.eslintrc.i18n.js`) with only that rule.
-
-### `pnpm build:llm:ios`
-
-Produces a development .ipa signed with the developer's current certificates (can be installed on phones added to our apple dev center). Not eligible for AppStore/TestFlight
-
-### `pnpm build:llm:android`
-
-Produces a development .apk that can be installed on Android phones. Not eligible for Google PlayStore
-
-## Watch deps
-
-In another terminal and in parallel to `pnpm dev:llm`, you can watch different libs from the monorepo
+Run the repo root setup first:
 
 ```bash
-# watch common
+mise install
+pnpm i
+```
+
+Then install the native platform tooling you need:
+
+| Platform | Requirements                                                                 |
+| -------- | ---------------------------------------------------------------------------- |
+| iOS      | Xcode, Ruby 3+, Bundler, CocoaPods                                           |
+| Android  | Android Studio, JDK 17, Android SDK/NDK versions from `android/build.gradle` |
+
+React Native environment guidance lives in the
+[React Native docs](https://reactnative.dev/docs/environment-setup) for the
+"without Expo" flow.
+
+## Development
+
+Run commands from the repository root.
+
+```bash
+pnpm dev:llm
+pnpm dev:llm:ios
+pnpm dev:llm:android
+pnpm mobile ios
+pnpm mobile android
+```
+
+Use `pnpm dev:llm -- --reset-cache` when Metro cache state causes stale bundles.
+
+For native builds:
+
+```bash
+pnpm build:llm:ios
+pnpm build:llm:android
+pnpm mobile pod
+pnpm mobile android:clean
+```
+
+For checks:
+
+```bash
+pnpm mobile lint
+pnpm mobile lint:i18n
+pnpm mobile format:check
+pnpm mobile typecheck
+pnpm mobile test:jest
+```
+
+See the repo-level [common commands](../../docs/common-commands.md) and
+[validation guidance](../../docs/validate-before-finishing.md) for maintained
+command coverage.
+
+## Watching Dependencies
+
+In another terminal, run the relevant watcher when changing shared packages used
+by Mobile:
+
+```bash
 pnpm watch:common
-
-# watch ljs
 pnpm watch:ljs
-
-# watch coin integrations
 pnpm watch:coin
-
-# watch specific lib
-nx run @ledgerhq/hw-app-btc:watch
-
-# watch specific coin integration
-nx run @ledgerhq/coin-bitcoin:watch
+pnpm turbo run watch --filter="./libs/ledgerjs/packages/hw-app-btc"
+pnpm turbo run watch --filter="./libs/coin-modules/coin-bitcoin"
 ```
 
-## Environment variables
+## Environment
 
-Optional environment variables you can put in `.env`, `.env.production` or `.env.staging` for debug, release, or staging release builds respectively.
+Optional variables can go in `.env`, `.env.production`, or `.env.staging`:
 
-[A more exhaustive list of documented environment variables can be found here](https://github.com/LedgerHQ/ledger-live/blob/develop/libs/env/src/env.ts).
-
-- `DEVICE_PROXY_URL=http://localhost:8435` Use the ledger device over HTTP. Useful for debugging on an emulator. More info about this in the section [Connection via HTTP bridge](#connection-via-http-bridge).
-- `BRIDGESTREAM_DATA=...` Come from console.log of the desktop app during the qrcode export. allow to bypass the bridgestream scanning.
-- `DEBUG_RNDEBUGGER=1` Enable react native debugger.
-- `DISABLE_READ_ONLY=1` Disable readonly mode by default.
-- `SKIP_ONBOARDING=1` Skips the onboarding flow.
-
-## Path mappings
-
-Add any desired path mapping in `tsconfig.json`: (for instance `"@utils/*": ["./src/utils/*"]`)
-Then, import `@utils/constants` in your project files and it will automatically resolve to `./src/utils/constants.{js/jsx/ts/tsx}`.
-
-Please respect the following structure: `"@{package}/*": ["{any/path}/*"]`
-
+```bash
+DEVICE_PROXY_URL=http://localhost:8435
+BRIDGESTREAM_DATA=...
+DEBUG_RNDEBUGGER=1
+DISABLE_READ_ONLY=1
+SKIP_ONBOARDING=1
 ```
-// tsconfig.json
- {
-    { ... }
-    "paths": {
-      "@utils/*": ["./src/utils/*"],
-      "@constants/*": ["./src/constants/*"],
-    }
+
+Other environment variables are defined in
+[libs/env/src/env.ts](../../libs/env/src/env.ts).
+
+## E2E Testing
+
+Use [../../e2e/mobile/README.md](../../e2e/mobile/README.md) for the maintained
+Detox and Speculos setup, build, and run commands.
+
+To connect an emulator to a Ledger device over USB, run the CLI proxy:
+
+```bash
+pnpm run:cli proxy
+```
+
+Then use the printed `DEVICE_PROXY_URL` in `.env` or in the app debug settings
+under connectivity HTTP transport.
+
+## Local Notes
+
+Path aliases belong in `tsconfig.json` using the `@name/*` pattern:
+
+```json
+{
+  "paths": {
+    "@utils/*": ["./src/utils/*"],
+    "@constants/*": ["./src/constants/*"]
   }
+}
 ```
 
-## Maintenance
+Use `pnpm mobile sync-locales` when adding a new supported language.
 
-### Refresh the languages (when we add new languages)
-
-```
-pnpm mobile sync-locales
-```
-
-## Debugging
-
-#### Flipper 🐬
-
-[Flipper](https://fbflipper.com/) has been integrated in the project, so you can use it to get debugging information (like network monitoring) and find other useful data you could previously get from scattered places, here neatly presented in a single interface (like logs and crash reports for both platforms).
-
-React Native integration seems pretty bleeding edge right now, so don't expect everything to work just yet.
-
-- Install [Flipper](https://fbflipper.com/) on your computer
-- Launch it 🚀
-- Run Ledger Live Mobile in debug as usual (set `DEBUG_RNDEBUGGER=1` in your `.env`)
-- No need to enable remote debug!
-
-List of Flipper's plugins that will help you to debug efficiently the application:
-
-- Hermes Debugger (RN)
-- Logs
-- React DevTools
-- Redux Debugger
-
-### End to end testing
-
-Refer to the e2e specific [wiki](https://github.com/LedgerHQ/ledger-live/wiki/LLM:End-to-end-testing).
-
-### Native code
-
-#### XCode / Android studio
-
-Run the app from the Apple or Google own IDE to get some native debugging features like breakpoints etc.
-
-### And more
-
-### Working on iOS or Android emulators
-
-#### Connection via HTTP bridge
-
-It is possible to run Ledger Live Mobile on an emulator and connect to a Nano that is plugged in via USB.
-
-- Install the [ledger-live cli](https://developers.ledger.com/docs/coin/ledger-live-cli/).
-- Plug in your Nano to your computer.
-- Run `ledger-live proxy` or `pnpm run:cli proxy`. A server starts and displays variable environments that can be used to build Ledger-Live Mobile. For example:
-  ```
-  DEVICE_PROXY_URL=ws://localhost:8435
-  DEVICE_PROXY_URL=ws://192.168.1.14:8435
-  Nano S proxy started on 192.168.1.14
-  ```
-- Either
-  - First, do `export DEVICE_PROXY_URL=the_adress_given_by_the_server` or paste this variable environment in the `.env` file at the root of the project (create it if it doesn't exist)
-  - Then, build & run Ledger Live Mobile `pnpm mobile ios` or `pnpm mobile android`
-  - OR
-  - First, build & run Ledger Live Mobile `pnpm mobile ios` or `pnpm mobile android`
-  - Then, go to the settings tab, then _debug_ > _connectivity_ > _http transport_ and paste the IP (ex: 192.168.1.14)
-- When prompted to choose a Nano device in Ledger Live Mobile, you will see your Nano available with the adress from above, just select it and it should work normally.
-
-### Extra Docs 📄
-
-- [Deep Linking 🔗](https://github.com/LedgerHQ/ledger-live/wiki/LLM:DeepLinking)
-- [UI Theming 🎨](https://github.com/LedgerHQ/ledger-live/wiki/LLM:Theming)
-
----
-
-## Are you adding the support of a blockchain to Ledger Live?
-
-This part of the repository is where you will add the support of your blockchain for the mobile app.
-
-For a smooth and quick integration:
-
-- See the developers’ documentation on the [Developer Portal](https://developers.ledger.com/docs/coin/general-process/) and
-- Go on [Discord](https://developers.ledger.com/discord-pro/) to chat with developer support and the developer community.
-
----
-
+For blockchain integration guidance, use the
+[Ledger Developer Portal](https://developers.ledger.com/docs/coin/general-process/).

--- a/docs/readme-audit.md
+++ b/docs/readme-audit.md
@@ -1,0 +1,230 @@
+# README Audit
+
+Tracking file for `LIVE-28131` README refinement.
+
+The audit scope is repo-owned `README.md` files only. Vendored/generated trees
+are excluded, including `node_modules`, `.pnpm`, `vendor`, `ios/Pods`, `dist`,
+`build`, `.nx`, `.yarn`, `coverage`, and `.turbo`.
+
+## Audit Rules
+
+- Keep README files as short local entry points.
+- Keep repo-wide rules in `docs/`.
+- Keep repeatable workflows in `.agents/skills/` or narrow local docs.
+- Preserve package API reference READMEs when they are the canonical API surface.
+- Replace stale wiki/setup content with canonical local docs where possible.
+- Work through the queue one file or small related cluster at a time.
+
+## Current Queue
+
+| Status   | Priority | File or cluster                                                                                            | Why                                                                      | Next action                                      |
+| -------- | -------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------ |
+| Done     | P0       | `README.md`                                                                                                | Root entrypoint duplicated setup, package lists, and command guidance    | Keep concise and link to canonical docs          |
+| Done     | P0       | `apps/ledger-live-desktop/README.md`                                                                       | Stale Node/pnpm setup and duplicated command detail                      | Keep as app-local entrypoint                     |
+| Done     | P0       | `apps/ledger-live-mobile/README.md`                                                                        | Stale platform setup and duplicated E2E guidance                         | Keep as app-local entrypoint                     |
+| Done     | P0       | `apps/ledger-live-desktop/tests/README.md`                                                                 | Long old Playwright guide duplicated E2E docs                            | Keep as local tests entrypoint                   |
+| Done     | P1       | `apps/cli/README.md` setup section                                                                         | Stale Node/pnpm requirements                                             | Link to `mise.toml` and common commands          |
+| Done     | P1       | `e2e/desktop/README.md`, `e2e/mobile/README.md`, `e2e/desktop/docs/README.md`                              | E2E entrypoints pointed to stale GitHub wiki pages and placeholder docs  | Link to local E2E docs and onboarding skills     |
+| Done     | P1       | `libs/ledger-live-common/README.md`                                                                        | Stale wiki table of contents and broad library overview                  | Replace with local map and maintained commands   |
+| Done     | P1       | `libs/ledgerjs/README.md`                                                                                  | Stale setup wording and deprecated U2F wiki links                        | Link to local migration doc and pinned toolchain |
+| Done     | P1       | `libs/ui/README.md`                                                                                        | Broad UI umbrella README has old wording and duplicated install detail   | Keep package map and aliases only                |
+| Done     | P2       | `libs/ledger-key-ring-protocol/README.md`, `libs/hw-ledger-key-ring-protocol/README.md`                    | Near-empty package placeholders                                          | Add package purpose and command entrypoint       |
+| Done     | P2       | `libs/live-wallet/src/walletsync/modules/README.md`, `libs/live-wallet/src/walletsync/__mocks__/README.md` | Useful templates need clearer local context and less placeholder wording | Tighten module/mock guidance                     |
+| Done     | P2       | `libs/coin-modules/coin-tezos/src/README.md`                                                               | Links to old wiki account model                                          | Check for local canonical replacement            |
+| Done     | P2       | `libs/coin-modules/coin-evm/docs/evm-family-integration-process/README.md`                                 | Long process doc with older wiki references                              | Review after coin-module docs                    |
+| Done     | P2       | `tests/dummy-wallet-app/README.md`                                                                         | Long local workflow doc                                                  | Check for duplicate E2E setup guidance           |
+| Reviewed | P3       | Long LedgerJS package API READMEs                                                                          | Mostly canonical API references                                          | Leave unless stale setup/wiki content appears    |
+| Reviewed | P3       | Small package READMEs under `domain`, `shared`, `devtools`, `features`                                     | Mostly local package summaries                                           | Spot-check for stale links only                  |
+
+## Residual Search Hits
+
+The final stale-pattern sweep still returns these known false positives or
+intentionally deferred package-reference notes:
+
+- `apps/cli/README.md`: `outdated` appears in a literal CLI scenario name.
+- `libs/live-wallet/src/walletsync/modules/README.md`: `TODO` appears inside the
+  title of an internal Atlassian tutorial URL.
+- `libs/ledgerjs/packages/hw-app-eth/README.md`: `outdated` appears in an API
+  reference warning about static signatures.
+- `libs/ledgerjs/packages/react-native-hw-transport-ble/README.md`: one TODO
+  remains in a long package API README and was left outside this README-entrypoint
+  cleanup pass.
+
+## Full Inventory
+
+Generated with:
+
+```bash
+rg --files --no-ignore -g 'README.md' \
+  -g '!**/node_modules/**' \
+  -g '!**/.pnpm/**' \
+  -g '!**/.git/**' \
+  -g '!**/vendor/**' \
+  -g '!**/ios/Pods/**' \
+  -g '!**/dist/**' \
+  -g '!**/build/**' \
+  -g '!**/.nx/**' \
+  -g '!**/.yarn/**' \
+  -g '!**/coverage/**' \
+  -g '!**/.turbo/**' | sort
+```
+
+### Root
+
+- `README.md`
+
+### Apps
+
+- `apps/cli/README.md`
+- `apps/ledger-live-desktop/README.md`
+- `apps/ledger-live-desktop/src/renderer/webworkers/README.md`
+- `apps/ledger-live-desktop/static/i18n/README.md`
+- `apps/ledger-live-desktop/tests/README.md`
+- `apps/ledger-live-desktop/tests/mocks/local/README.md`
+- `apps/ledger-live-mobile/README.md`
+- `apps/ledger-live-mobile/src/GlobalDrawers/README.md`
+- `apps/ledger-live-mobile/src/components/SelectDevice2/README.md`
+- `apps/ledger-live-mobile/src/devTools/README.md`
+- `apps/ledger-live-mobile/src/mocks/README.md`
+- `apps/ledger-live-mobile/src/mvvm/components/QueuedDrawer/README.md`
+- `apps/ledger-live-mobile/src/transport/bleTransport/README.md`
+- `apps/wallet-cli/README.md`
+- `apps/wallet-cli/src/shared/accountDescriptor/README.md`
+- `apps/wallet-cli/src/test/commands/README.md`
+- `apps/wallet-cli/src/wallet/README.md`
+- `apps/web-tools/README.md`
+
+### Devtools, Domain, E2E, Features
+
+- `devtools/README.md`
+- `devtools/feature-flags/README.md`
+- `devtools/registry/README.md`
+- `devtools/shell/README.md`
+- `domain/api/README.md`
+- `domain/entity/README.md`
+- `domain/entity/currency-crypto/README.md`
+- `domain/entity/currency-fiat/README.md`
+- `domain/entity/currency-token/README.md`
+- `domain/entity/currency-unit/README.md`
+- `domain/entity/currency/README.md`
+- `e2e/desktop/README.md`
+- `e2e/desktop/docs/README.md`
+- `e2e/mobile/README.md`
+- `features/flow/market-banner/README.md`
+- `features/platform/feature-flags/README.md`
+
+### Shared And Tools
+
+- `scripts/README.md`
+- `shared/README.md`
+- `shared/feature-flags/README.md`
+- `shared/schema-primitives/README.md`
+- `tests/dummy-live-app/README.md`
+- `tests/dummy-ptx-app/README.md`
+- `tests/dummy-wallet-app/README.md`
+- `tools/actions/composites/configure-nx-remote-cache-profile/README.md`
+- `tools/actions/composites/nx-affected-packages/README.md`
+
+### Libraries
+
+- `libs/client-ids/README.md`
+- `libs/client-ids/src/ids/README.md`
+- `libs/coin-modules-monitoring/README.md`
+- `libs/coin-modules/README.md`
+- `libs/coin-modules/coin-canton/README.md`
+- `libs/coin-modules/coin-evm/docs/evm-family-integration-process/README.md`
+- `libs/coin-modules/coin-tezos/src/README.md`
+- `libs/coin-tester/README.md`
+- `libs/coin-tester-modules/coin-tester-bitcoin/README.md`
+- `libs/coin-tester-modules/coin-tester-evm/README.md`
+- `libs/coin-tester-modules/coin-tester-polkadot/README.md`
+- `libs/coin-tester-modules/coin-tester-solana/README.md`
+- `libs/concordium-core/README.md`
+- `libs/device-intent/README.md`
+- `libs/disable-network-setup/README.md`
+- `libs/domain-service/README.md`
+- `libs/evm-tools/README.md`
+- `libs/hw-ledger-key-ring-protocol/README.md`
+- `libs/ledger-key-ring-protocol/README.md`
+- `libs/ledger-key-ring-protocol/scripts/README.md`
+- `libs/ledger-live-common/README.md`
+- `libs/ledger-live-common/src/bot/portfolio/README.md`
+- `libs/ledger-live-common/src/cg-client/README.md`
+- `libs/ledger-live-common/src/cmc-client/README.md`
+- `libs/ledger-live-common/src/dada-client/README.md`
+- `libs/ledger-live-common/src/device/use-cases/ensureAppReady/README.md`
+- `libs/live-config/README.md`
+- `libs/live-signer-aleo/README.md`
+- `libs/live-signer-canton/README.md`
+- `libs/live-signer-concordium/README.md`
+- `libs/live-signer-cosmos/README.md`
+- `libs/live-signer-evm/README.md`
+- `libs/live-signer-hyperliquid/README.md`
+- `libs/live-signer-solana/README.md`
+- `libs/live-signer-zcash/README.md`
+- `libs/live-wallet/README.md`
+- `libs/live-wallet/src/walletsync/__mocks__/README.md`
+- `libs/live-wallet/src/walletsync/modules/README.md`
+- `libs/oxc-live-libs/README.md`
+- `libs/psbtv2/README.md`
+- `libs/speculos-transport/README.md`
+- `libs/ui/README.md`
+- `libs/ui/packages/icons/README.md`
+- `libs/ui/packages/native/README.md`
+- `libs/ui/packages/react/README.md`
+- `libs/ui/packages/shared/README.md`
+- `libs/wallet-api-acre-module/README.md`
+
+### LedgerJS
+
+- `libs/ledgerjs/README.md`
+- `libs/ledgerjs/packages/cryptoassets/README.md`
+- `libs/ledgerjs/packages/cryptoassets/src/cal-client/README.md`
+- `libs/ledgerjs/packages/devices/README.md`
+- `libs/ledgerjs/packages/errors/README.md`
+- `libs/ledgerjs/packages/hw-app-algorand/README.md`
+- `libs/ledgerjs/packages/hw-app-aptos/README.md`
+- `libs/ledgerjs/packages/hw-app-btc/README.md`
+- `libs/ledgerjs/packages/hw-app-canton/README.md`
+- `libs/ledgerjs/packages/hw-app-canton/tests/fixtures/README.md`
+- `libs/ledgerjs/packages/hw-app-celo/README.md`
+- `libs/ledgerjs/packages/hw-app-concordium/README.md`
+- `libs/ledgerjs/packages/hw-app-cosmos/README.md`
+- `libs/ledgerjs/packages/hw-app-eth/README.md`
+- `libs/ledgerjs/packages/hw-app-exchange/README.md`
+- `libs/ledgerjs/packages/hw-app-hedera/README.md`
+- `libs/ledgerjs/packages/hw-app-helium/README.md`
+- `libs/ledgerjs/packages/hw-app-icon/README.md`
+- `libs/ledgerjs/packages/hw-app-kaspa/README.md`
+- `libs/ledgerjs/packages/hw-app-multiversx/README.md`
+- `libs/ledgerjs/packages/hw-app-near/README.md`
+- `libs/ledgerjs/packages/hw-app-polkadot/README.md`
+- `libs/ledgerjs/packages/hw-app-solana/README.md`
+- `libs/ledgerjs/packages/hw-app-str/README.md`
+- `libs/ledgerjs/packages/hw-app-sui/README.md`
+- `libs/ledgerjs/packages/hw-app-tezos/README.md`
+- `libs/ledgerjs/packages/hw-app-trx/README.md`
+- `libs/ledgerjs/packages/hw-app-vet/README.md`
+- `libs/ledgerjs/packages/hw-app-xrp/README.md`
+- `libs/ledgerjs/packages/hw-bolos/README.md`
+- `libs/ledgerjs/packages/hw-transport/README.md`
+- `libs/ledgerjs/packages/hw-transport-http/README.md`
+- `libs/ledgerjs/packages/hw-transport-mocker/README.md`
+- `libs/ledgerjs/packages/hw-transport-node-hid/README.md`
+- `libs/ledgerjs/packages/hw-transport-node-hid-noevents/README.md`
+- `libs/ledgerjs/packages/hw-transport-node-hid-singleton/README.md`
+- `libs/ledgerjs/packages/hw-transport-node-speculos/README.md`
+- `libs/ledgerjs/packages/hw-transport-node-speculos-http/README.md`
+- `libs/ledgerjs/packages/hw-transport-vault/README.md`
+- `libs/ledgerjs/packages/hw-transport-web-ble/README.md`
+- `libs/ledgerjs/packages/hw-transport-webhid/README.md`
+- `libs/ledgerjs/packages/hw-transport-webusb/README.md`
+- `libs/ledgerjs/packages/logs/README.md`
+- `libs/ledgerjs/packages/react-native-hid/README.md`
+- `libs/ledgerjs/packages/react-native-hw-transport-ble/README.md`
+- `libs/ledgerjs/packages/swift-bridge-hw-app-eth/README.md`
+- `libs/ledgerjs/packages/swift-bridge-hw-app-solana/README.md`
+- `libs/ledgerjs/packages/swift-bridge-hw-transport-ble/README.md`
+- `libs/ledgerjs/packages/types-cryptoassets/README.md`
+- `libs/ledgerjs/packages/types-devices/README.md`
+- `libs/ledgerjs/packages/types-live/README.md`

--- a/e2e/desktop/README.md
+++ b/e2e/desktop/README.md
@@ -1,13 +1,14 @@
 # E2E Tests - Desktop
 
-This folder contains the end-to-end (E2E) tests for the **Ledger Wallet Desktop** app.  
+This folder contains the end-to-end (E2E) tests for the **Ledger Wallet Desktop** app.
 Dev teams are responsible for **adding/updating tests** when implementing new features.
 
 ---
 
 ## Interactive Setup (Recommended)
 
-Use the Cursor command `/e2e-desktop-onboard` for a guided, interactive walkthrough that checks every prerequisite, validates your environment, builds the app, and runs a smoke test.
+Use the `/e2e-desktop-onboard` skill for a guided walkthrough that checks every
+prerequisite, validates your environment, builds the app, and runs a smoke test.
 
 ---
 
@@ -17,7 +18,6 @@ All build and test commands below are run from the **repo root** (`ledger-live/`
 
 ### 1. Prerequisites
 
-- Ledger Live repository (as mentioned in the full wiki)
 - Read the e2e environment [guide](https://ledgerhq.atlassian.net/wiki/spaces/QA/pages/6945013939/Ledger+Wallet+E2E+Environment)❗
 - Docker Desktop installed and running (Speculos runs in Docker)
 - Pull the Speculos Docker image:
@@ -77,10 +77,10 @@ pnpm e2e:desktop test:playwright
 pnpm e2e:desktop test:playwright <testFileName>
 ```
 
-### 5. Full Documentation
+### 5. More Documentation
 
-For detailed setup, debugging, and contribution guidelines, see:
-[Ledger Wallet Desktop E2E Wiki](https://github.com/LedgerHQ/ledger-live/wiki/LLD:E2ETesting)
+For writing and updating tests, see
+[docs/add-or-update-e2e.md](docs/add-or-update-e2e.md).
 
 ### 6. Custom feature flags with E2E_FEATURE_FLAGS_JSON
 

--- a/e2e/desktop/docs/README.md
+++ b/e2e/desktop/docs/README.md
@@ -1,1 +1,6 @@
-This directory contains skills relevant to the parent directory
+# Desktop E2E Docs
+
+Additional Desktop E2E details live here so the parent
+[README](../README.md) can stay short.
+
+- [Add or update E2E tests](add-or-update-e2e.md)

--- a/e2e/mobile/README.md
+++ b/e2e/mobile/README.md
@@ -1,9 +1,9 @@
 # E2E Tests - Mobile
 
-This folder contains the end-to-end (E2E) tests for the **Ledger Wallet Mobile** app.  
+This folder contains the end-to-end (E2E) tests for the **Ledger Wallet Mobile** app.
 Dev teams are responsible for **adding/updating tests** for new features.
 
-> **Cursor users:** Run the `/e2e-mobile-onboard` command for an interactive setup wizard.
+> Run the `/e2e-mobile-onboard` skill for an interactive setup wizard.
 > It checks every prerequisite on your machine, validates environment variables, and guides you through fixes step by step.
 
 ---
@@ -66,7 +66,7 @@ pnpm mobile e2e:build -c ios.sim.debug
 - iOS: Create a simulator named `iOS Simulator` in Xcode
 - Android: Create an emulator named `Android_Emulator` in Android Studio
 
-Follow the full wiki if you need setup details.
+Use `/e2e-mobile-onboard` if you need setup details checked interactively.
 
 ### 5. Run Tests
 
@@ -92,14 +92,7 @@ pnpm test:android <testFileName>         # single file
 
 > Android debug (`pnpm test:android:debug`) does not work locally due to a known Detox/Espresso bug. Always use the release configuration.
 
-> For CI, sharding, and advanced flags, see [the full wiki](https://github.com/LedgerHQ/ledger-live/wiki/LLM:End-to-end-testing).
-
-### 6. Full Documentation
-
-For complete setup, debugging, workflow, writing tests, and CI integration, see the official wiki:
-[Ledger Wallet Mobile E2E Wiki](https://github.com/LedgerHQ/ledger-live/wiki/LLM:End-to-end-testing)
-
-### 7. Custom feature flags with E2E_FEATURE_FLAGS_JSON
+### 6. Custom feature flags with E2E_FEATURE_FLAGS_JSON
 
 You can inject extra feature flags globally for Mobile E2E by setting `E2E_FEATURE_FLAGS_JSON`.
 

--- a/libs/coin-modules/coin-evm/docs/evm-family-integration-process/README.md
+++ b/libs/coin-modules/coin-evm/docs/evm-family-integration-process/README.md
@@ -28,14 +28,14 @@ Here is an example PR of an EVM currency integration: https://github.com/LedgerH
 
 _Common steps for all new EVM currency integration_
 
-1. Add a new config entry for the new currency under [`libs/ledgerjs/packages/cryptoassets/src/currencies.ts`](https://github.com/LedgerHQ/ledger-live/blob/develop/libs/ledgerjs/packages/cryptoassets/src/currencies.ts) (the `CryptoCurrencyId` type is auto-generated)
-2. Add an entry for the new currency in the `abandonSeedAddresses` (using the currency ID as key and `EVM_DEAD_ADDRESS` as value) under [`libs/ledgerjs/packages/cryptoassets/src/abandonseed.ts`](https://github.com/LedgerHQ/ledger-live/blob/develop/libs/ledgerjs/packages/cryptoassets/src/abandonseed.ts)
-3. Add the new currency ID to the `setSupportedCurrencies` function param on each relevant project ([CLI](https://github.com/LedgerHQ/ledger-live/blob/develop/apps/cli/src/live-common-setup-base.ts), [LLD](https://github.com/LedgerHQ/ledger-live/blob/develop/apps/ledger-live-desktop/src/live-common-set-supported-currencies.ts), [LLM](https://github.com/LedgerHQ/ledger-live/blob/develop/apps/ledger-live-mobile/src/live-common-setup.ts), [LLC test environment](https://github.com/LedgerHQ/ledger-live/blob/develop/libs/ledger-live-common/src/__tests__/test-helpers/environment.ts), [web-tools](https://github.com/LedgerHQ/ledger-live/blob/develop/apps/web-tools/src/live-common-setup.ts) and [account-migration tests](https://github.com/LedgerHQ/ledger-live/blob/develop/libs/ledger-live-common/src/__tests__/migration/account-migration.ts))
+1. Add a new config entry for the new currency under [`libs/ledgerjs/packages/cryptoassets/src/currencies.ts`](../../../../../libs/ledgerjs/packages/cryptoassets/src/currencies.ts) (the `CryptoCurrencyId` type is auto-generated)
+2. Add an entry for the new currency in the `abandonSeedAddresses` (using the currency ID as key and `EVM_DEAD_ADDRESS` as value) under [`libs/ledgerjs/packages/cryptoassets/src/abandonseed.ts`](../../../../../libs/ledgerjs/packages/cryptoassets/src/abandonseed.ts)
+3. Add the new currency ID to the `setSupportedCurrencies` function param on each relevant project ([CLI](../../../../../apps/cli/src/live-common-setup-base.ts), [LLD](../../../../../apps/ledger-live-desktop/src/live-common-set-supported-currencies.ts), [LLM](../../../../../apps/ledger-live-mobile/src/live-common-setup.ts), [LLC test environment](../../../../../libs/ledger-live-common/src/__tests__/test-helpers/environment.ts), [web-tools](../../../../../apps/web-tools/src/live-common-setup.ts) and [account-migration tests](../../../../../libs/ledger-live-common/src/__tests__/migration/account-migration.ts))
 4. Add a new feature flag config for this currency:
-   1. The new feature flag type in the [`CurrencyFeatures`](https://github.com/LedgerHQ/ledger-live/blob/develop/libs/ledgerjs/packages/types-live/src/feature.ts) type under `libs/ledgerjs/packages/types-live/src/feature.ts`
-   2. The new feature flag definition with default value in the [`CURRENCY_DEFAULT_FEATURES`](https://github.com/LedgerHQ/ledger-live/blob/develop/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts) mapping under `libs/ledger-live-common/src/featureFlags/defaultFeatures.ts`
-   3. Use this new feature flag in [`useCurrenciesUnderFeatureFlag.ts`](https://github.com/LedgerHQ/ledger-live/blob/develop/libs/ledger-live-common/src/modularDrawer/hooks/useCurrenciesUnderFeatureFlag.ts)
-5. Add the EVM config for RPC node and explorer under [`libs/ledger-live-common/src/families/evm/config.ts`](https://github.com/LedgerHQ/ledger-live/blob/develop/libs/ledger-live-common/src/families/evm/config.ts)
+   1. The new feature flag type in the [`CurrencyFeatures`](../../../../../libs/ledgerjs/packages/types-live/src/feature.ts) type under `libs/ledgerjs/packages/types-live/src/feature.ts`
+   2. The new feature flag definition with default value in the [`CURRENCY_DEFAULT_FEATURES`](../../../../../libs/ledger-live-common/src/featureFlags/defaultFeatures.ts) mapping under `libs/ledger-live-common/src/featureFlags/defaultFeatures.ts`
+   3. Use this new feature flag in [`useCurrenciesUnderFeatureFlag.ts`](../../../../../libs/ledger-live-common/src/modularDrawer/hooks/useCurrenciesUnderFeatureFlag.ts)
+5. Add the EVM config for RPC node and explorer under [`libs/ledger-live-common/src/families/evm/config.ts`](../../../../../libs/ledger-live-common/src/families/evm/config.ts)
 6. Update snapshot files:
    1. `pnpm test -- -u` from `libs/coin-framework` to update `formatCurrencyUnit.test.ts` snapshots
    2. `pnpm test:playwright tests/specs/services/wallet-api.spec.ts` from `apps/ledger-live-desktop` and update `tests/fixtures/wallet-api.ts` with new currencies
@@ -46,23 +46,21 @@ _Common steps for all new EVM currency integration_
 _Optional / extra steps that might be needed on a case-by-case basis depending on the integration_
 
 - If the related currency public explorer is not an etherscan-like, you might need to add a new implementation for this currency explorer
-  - If needed, create a new explorer implementation of this explorer API in a new file under the [`libs/coin-modules/coin-evm/src/network/explorer`](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/coin-modules/coin-evm/src/network/explorer) folder
+  - If needed, create a new explorer implementation of this explorer API in a new file under the [`libs/coin-modules/coin-evm/src/network/explorer`](../../src/network/explorer) folder
   - Add the new explorer type to:
-    - the `getExplorerApi` function under [`libs/coin-modules/coin-evm/src/network/explorer/index.ts`](https://github.com/LedgerHQ/ledger-live/blob/develop/libs/coin-modules/coin-evm/src/network/explorer/index.ts)
-    - the `EthereumLikeInfo.explorer.type` type under [`libs/ledgerjs/packages/types-cryptoassets/src/index.ts`](https://github.com/LedgerHQ/ledger-live/blob/develop/libs/ledgerjs/packages/types-cryptoassets/src/index.ts)
-    - if the new explorer type follows the etherscan-like API, add it to the `isEtherscanLikeExplorerConfig` type guard under [`libs/coin-modules/coin-evm/src/network/explorer/types.ts`](https://github.com/LedgerHQ/ledger-live/blob/develop/libs/coin-modules/coin-evm/src/network/explorer/types.ts) (this is the case for some custom made explorers that are not blockscan white label implementation, but are still compatible with the blockscan/etherscan API)
+    - the `getExplorerApi` function under [`libs/coin-modules/coin-evm/src/network/explorer/index.ts`](../../src/network/explorer/index.ts)
+    - the `EthereumLikeInfo.explorer.type` type under [`libs/ledgerjs/packages/types-cryptoassets/src/index.ts`](../../../../../libs/ledgerjs/packages/types-cryptoassets/src/index.ts)
+    - if the new explorer type follows the etherscan-like API, add it to the `isEtherscanLikeExplorerConfig` type guard under [`libs/coin-modules/coin-evm/src/network/explorer/types.ts`](../../src/network/explorer/types.ts) (this is the case for some custom made explorers that are not blockscan white label implementation, but are still compatible with the blockscan/etherscan API)
 
 ## Tokens support
 
 Here are the steps to handle the new currencies (ERC20) tokens, if relevant:
 
 - add the new tokens config to the [CAL](https://github.com/LedgerHQ/crypto-assets) (historically handled by @adrienlacombe-ledger)
-- after this update of the CAL, check that the tokens are present on the CDN, replacing `{chainId}` with the actual currency chain ID, specified under `ethereumLikeInfo.chainId` in the currency config (under [libs/ledgerjs/packages/cryptoassets/src/currencies.ts](https://github.com/LedgerHQ/ledger-live/blob/develop/libs/ledgerjs/packages/cryptoassets/src/currencies.ts)) which would be `1` for ethereum mainnet for example, using https://cdn.live.ledger.com/cryptoassets/evm/{chainId}/erc20.json
+- after this update of the CAL, check that the tokens are present on the CDN, replacing `{chainId}` with the actual currency chain ID, specified under `ethereumLikeInfo.chainId` in the currency config (under [libs/ledgerjs/packages/cryptoassets/src/currencies.ts](../../../../../libs/ledgerjs/packages/cryptoassets/src/currencies.ts)) which would be `1` for ethereum mainnet for example, using https://cdn.live.ledger.com/cryptoassets/evm/{chainId}/erc20.json
 
-No change should be needed on Ledger Live side since tokens are automatically imported from CAL at the release stage, cf:
-
-- this GitHub Action [`.github/workflows/test-release-create.yml`](https://github.com/LedgerHQ/ledger-live/blob/develop/.github/workflows/test-release-create.yml)
-- the `import:cal-tokens` job in the [`ledger-js` package](https://github.com/LedgerHQ/ledger-live/blob/develop/libs/ledgerjs/package.json)
+No change should be needed on Ledger Live side since token data is consumed from
+CAL/CDN during the release flow.
 
 ## Counter values support (fiat prices)
 
@@ -78,17 +76,17 @@ Make sure the network being added is present under the `network_info_t` mapping 
 
 In Ledger Live, make sure the ethereum nano app version requirements match the latest version of the ethereum app handling the network being added:
 
-- `appVersion` in `getAppQuery` under [`libs/coin-modules/coin-evm/src/specs.ts`](https://github.com/LedgerHQ/ledger-live/blob/develop/libs/coin-modules/coin-evm/src/specs.ts)
-- `Ethereum` in `appVersionsRequired` under [`libs/ledger-live-common/src/apps/support.ts`](https://github.com/LedgerHQ/ledger-live/blob/develop/libs/ledger-live-common/src/apps/support.ts)
-- related tests for the ethereum app version under [`libs/ledger-live-common/src/apps/support.test.ts`](https://github.com/LedgerHQ/ledger-live/blob/develop/libs/ledger-live-common/src/apps/support.test.ts)
+- `appVersion` in `getAppQuery` under [`libs/coin-modules/coin-evm/src/specs.ts`](../../src/specs.ts)
+- `Ethereum` in `appVersionsRequired` under [`libs/ledger-live-common/src/apps/support.ts`](../../../../../libs/ledger-live-common/src/apps/support.ts)
+- related tests for the ethereum app version under [`libs/ledger-live-common/src/apps/support.test.ts`](../../../../../libs/ledger-live-common/src/apps/support.test.ts)
 
 ## Tests
 
 ### Bot
 
-- Make sure to fund the appropriate bot(s) with coins and tokens of the new network being added (cf. [The different bots](https://github.com/LedgerHQ/ledger-live/wiki/LLC:bot#the-different-bots))
+- Make sure to fund the appropriate bot(s) with coins and tokens of the new network being added. For local portfolio bot context, see [`libs/ledger-live-common/src/bot/portfolio/README.md`](../../../../../libs/ledger-live-common/src/bot/portfolio/README.md).
 - Make sure to make the bot run multiple times on your PR to make sure everything works fine with the new network
-- If the coin related to the network you are adding is somewhat expensive, you can tailor the minimum balance needed to test this coin by updating `minBalancePerCurrencyId` under [`libs/coin-modules/coin-evm/src/specs.ts`](https://github.com/LedgerHQ/ledger-live/blob/develop/libs/coin-modules/coin-evm/src/specs.ts)
+- If the coin related to the network you are adding is somewhat expensive, you can tailor the minimum balance needed to test this coin by updating `minBalancePerCurrencyId` under [`libs/coin-modules/coin-evm/src/specs.ts`](../../src/specs.ts)
 
 ### Manual testing
 

--- a/libs/coin-modules/coin-tezos/src/README.md
+++ b/libs/coin-modules/coin-tezos/src/README.md
@@ -22,7 +22,9 @@ The public key is the account main identifier, expressed as uncompress hex: `02e
 
 This public key is needed for making transaction and also is used to hash the account address. (`tz1PTxfn1fge2tJwGGpW9zNuYf6BseM3GJXt` in this case)
 
-The Account type as defined in https://github.com/LedgerHQ/ledger-live/wiki/LLC:account will be used with:
+The Ledger account model is defined in
+[`@ledgerhq/types-live`](../../../ledgerjs/packages/types-live/src/account.ts)
+and is used with:
 
 - `.id` to be the id explained as above
 - `.xpub` to be the public key

--- a/libs/hw-ledger-key-ring-protocol/README.md
+++ b/libs/hw-ledger-key-ring-protocol/README.md
@@ -1,3 +1,14 @@
-## hw-trustchain
+# @ledgerhq/hw-ledger-key-ring-protocol
 
-Ledger Live trustchain hardware layer.
+Hardware integration layer for Ledger Key Ring Protocol flows.
+
+Use it with the protocol package in
+[../ledger-key-ring-protocol](../ledger-key-ring-protocol/README.md).
+
+Run package commands from the repository root:
+
+```bash
+pnpm hw-lkrp build
+pnpm hw-lkrp test
+pnpm hw-lkrp typecheck
+```

--- a/libs/ledger-key-ring-protocol/README.md
+++ b/libs/ledger-key-ring-protocol/README.md
@@ -1,3 +1,16 @@
-## ledger key ring protocol
+# @ledgerhq/ledger-key-ring-protocol
 
-Ledger Key Ring Protocol layer.
+Core Ledger Key Ring Protocol package.
+
+The hardware-specific integration lives in
+[../hw-ledger-key-ring-protocol](../hw-ledger-key-ring-protocol/README.md), and
+the deterministic E2E replay script is documented in
+[scripts/README.md](scripts/README.md).
+
+Run package commands from the repository root:
+
+```bash
+pnpm lkrp build
+pnpm lkrp test
+pnpm lkrp typecheck
+```

--- a/libs/ledger-live-common/README.md
+++ b/libs/ledger-live-common/README.md
@@ -1,86 +1,55 @@
-**[We are hiring, join us! 👨‍💻👩‍💻](https://jobs.lever.co/ledger/?department=Tech)**
+# @ledgerhq/live-common
 
-## “Ledger Live Common” `@ledgerhq/live-common`
+`@ledgerhq/live-common` contains shared Ledger Wallet business logic used by
+Ledger Live Desktop, Ledger Live Mobile, CLI tooling, tests, and coin
+integrations.
 
-`````
-                ````
-           `.--:::::
-        `.-:::::::::       ````
-       .://///:-..``     `-/+++/-`
-     `://///-`           -++++++o/.
-    `/+++/:`            -+++++osss+`
-   `:++++:`            ./++++-/osss/`
-   .+++++`             `-://- .ooooo.
-   -+ooo/`                ``  `/oooo-
-   .oooo+` .::-.`             `+++++.
-   `+oooo:./+++/.             -++++/`
-    -ossso+++++:`            -/+++/.
-     -ooo+++++:`           .://///.
-      ./+++++/`       ``.-://///:`
-        `---.`      -:::::///:-.
-                    :::::::-.`
-                    ....``
+It depends on LedgerJS packages for device communication and exposes core wallet
+logic for accounts, currencies, bridges, countervalues, apps, firmware flows,
+serialization, and related utilities.
 
-`````
+## Local Map
 
-Ledger Live Common (`@ledgerhq/live-common`) is a JavaScript library available via a [NPM package](https://npmjs.com/@ledgerhq/live-common).
+| Area                      | Purpose                                       |
+| ------------------------- | --------------------------------------------- |
+| `src/account`             | Account models and portfolio helpers          |
+| `src/currencies`          | Currency models, lookup, and metadata helpers |
+| `src/families`            | Coin-family-specific bridge logic             |
+| `src/hw` and `src/device` | Hardware wallet and device flows              |
+| `src/apps`                | Device app catalog and install/update logic   |
+| `src/countervalues`       | Countervalue data and helpers                 |
+| `src/e2e`                 | Shared enums and helpers used by E2E tests    |
 
-This library depends on a bunch of [ledgerjs packages](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) and put together the core business logic behind [Ledger Live Desktop](https://github.com/LedgerHQ/ledger-live/tree/develop/apps/ledger-live-desktop) and [Ledger Live Mobile](https://github.com/LedgerHQ/ledger-live/tree/develop/apps/ledger-live-mobile).
+Narrower local docs:
 
-The stack is pretty standard for a ES6 and FlowType library. The notable dependencies are libraries like **RxJS** and **BigNumber.js**. There is also a bit of React and Redux but exposed in agnostic ways (meaning it's not mandatory to use – there will be dedicated entry point for them to offer utilities like React Hooks).
+- [DADA Client](src/dada-client/README.md)
+- [CG Client](src/cg-client/README.md)
+- [CMC Client](src/cmc-client/README.md)
+- [Portfolio bot helpers](src/bot/portfolio/README.md)
+- [Ensure App Ready](src/device/use-cases/ensureAppReady/README.md)
 
-## Table of Contents
+## Development
 
-- [Introduction, Goals and Tradeoffs](https://github.com/LedgerHQ/ledger-live/wiki/LLC:intro)
-- Getting started
-  - [`ledger-live` CLI](https://github.com/LedgerHQ/ledger-live/wiki/LLC:cli)
-  - **tools** web playground
-  - `mobile-test-app` test project
-- Learn by example
-  - [gist: transaction with a Ledger device](https://github.com/LedgerHQ/ledger-live/wiki/LLC:gist-tx)
-  - [gist: Update firmware of a Ledger device](https://github.com/LedgerHQ/ledger-live/wiki/LLC:gist-firmware)
-  - ...
-- [The Currency models](https://github.com/LedgerHQ/ledger-live/wiki/LLC:currency) and utilities
-- [The Account models and portfolio logic](https://github.com/LedgerHQ/ledger-live/wiki/LLC:account)
-- The [CurrencyBridge](https://github.com/LedgerHQ/ledger-live/wiki/LLC:CurrencyBridge): scan accounts with a device
-- The [AccountBridge](https://github.com/LedgerHQ/ledger-live/wiki/LLC:AccountBridge): synchronize an account and perform transaction
-- [Hardware Wallet logic](https://github.com/LedgerHQ/ledger-live/wiki/LLC:hw)
-- [Apps store logic](https://github.com/LedgerHQ/ledger-live/wiki/LLC:apps)
-- Firmware Update logic
-- [Countervalues logic](https://github.com/LedgerHQ/ledger-live/wiki/LLC:countervalues)
-- Coin integration specifics
-  - [Introduction](https://github.com/LedgerHQ/ledger-live/wiki/LLC:ci-intro)
-  - Bridge implementations, where to start? (JS, Libcore, Mock)
-  - Implementing the hardware wallet logic of a new coin
-  - [The account derivation (BIP44 and exceptions)](https://github.com/LedgerHQ/ledger-live/wiki/LLC:derivation)
-- Advanced
-  - [api/socket `createDeviceSocket` and script runner](https://github.com/LedgerHQ/ledger-live/wiki/LLC:socket)
-  - env.js: live-common configuration system
-  - Serialization and reconciliation
-  - cross.js and "LiveQR" protocol
-  - cache.js helpers
-  - Tokens management and ERC20
-  - [Developing with lib-ledger-core bindings](https://github.com/LedgerHQ/ledger-live/wiki/LLC:adding-libcore-bindings)
+Run commands from the repository root.
 
-### Developing with Ledger Live Common
+```bash
+pnpm common build
+pnpm common watch
+pnpm common lint
+pnpm common lint:fix
+pnpm common format:check
+pnpm common typecheck
+pnpm common test
+```
 
-- **Linting:** uses [oxlint](https://oxc.rs/docs/guide/usage/linter) with `.oxlintrc.json`. Auto-fix: `pnpm common lint:fix` (oxlint `--fix` only; does not reformat files). **Formatting** is optional: [oxfmt](https://oxc.rs/docs/guide/usage/formatter) with `.oxfmtrc.json` (aligned with the repo root `.prettierrc`, e.g. `arrowParens: "avoid"`). Run `pnpm common format` or `pnpm common format:check` when you want to apply or verify oxfmt; some paths are ignored via `ignorePatterns` in `.oxfmtrc.json`. From the repo root: `pnpm common lint` (or `pnpm common lint:ci` for CI-style, errors only).
+Linting uses oxlint with `.oxlintrc.json`. Formatting uses oxfmt with
+`.oxfmtrc.json`; run `pnpm common format` when you intentionally want to apply
+formatting.
 
-- [Developing setup](https://github.com/LedgerHQ/ledger-live/wiki/LLC:developing)
-- The different test approaches
-  - Unit test of live-common logic
-  - End-to-end tests of the `ledger-live` command
-  - Bridge dataset tests
-  - Providing mocks to implement UI tests
+## Related Docs
 
----
-
-## Are you adding the support of a blockchain to Ledger Live?
-
-This part of the repository is where you will add most of your code.
-
-For a smooth and quick integration:
-- See the developers’ documentation on the [Developer Portal](https://developers.ledger.com/docs/coin/general-process/) and 
-- Go on [Discord](https://developers.ledger.com/discord-pro/) to chat with developer support and the developer community.
-
----
+- Repo commands: [../../docs/common-commands.md](../../docs/common-commands.md)
+- Validation before finishing: [../../docs/validate-before-finishing.md](../../docs/validate-before-finishing.md)
+- Coin modules: [../coin-modules/README.md](../coin-modules/README.md)
+- LedgerJS: [../ledgerjs/README.md](../ledgerjs/README.md)
+- Blockchain support process: [Ledger Developer Portal](https://developers.ledger.com/docs/coin/general-process/)

--- a/libs/ledgerjs/README.md
+++ b/libs/ledgerjs/README.md
@@ -29,7 +29,7 @@ Welcome to Ledger's JavaScript libraries.
 | Nano S Plus | DEPRECATED<sup>1</sup> | YES | YES    | NO        |
 | Nano X      | DEPRECATED<sup>1</sup> | YES | YES    | YES       |
 
-1. U2F is deprecated. See https://github.com/LedgerHQ/ledger-live/wiki/LJS:MigrateWebUSB
+1. U2F is deprecated. See [docs/migrate_webusb.md](docs/migrate_webusb.md).
 
 Summary of implementations available per platform
 
@@ -55,7 +55,7 @@ Summary of implementations available per platform
 | Firefox  | DEPRECATED<sup>1</sup> | NO              | NO                 | NO           |
 | IE.      | DEPRECATED<sup>1</sup> | NO              | NO                 | NO           |
 
-1. U2F is deprecated. See https://github.com/LedgerHQ/ledger-live/wiki/LJS:MigrateWebUSB
+1. U2F is deprecated. See [docs/migrate_webusb.md](docs/migrate_webusb.md).
 2. instabilities has been reported
 3. WebHID supported under _Chrome experimental flags_
 
@@ -140,14 +140,11 @@ getBtcAddress().then(a => console.log(a));
 ## Contributing
 
 Please read our [contribution guidelines](./CONTRIBUTING.md) before getting
-started.
-
-**You need to have a recent [Node.js](https://nodejs.org/) and
-[Yarn](https://yarnpkg.com/) installed.**
+started, and install the pinned repo toolchain with `mise install`.
 
 ### Install dependencies
 
-> Reminder: all commands should be run at the root of the monorepository
+Run commands from the repository root.
 
 ```bash
 pnpm i

--- a/libs/live-wallet/src/walletsync/__mocks__/README.md
+++ b/libs/live-wallet/src/walletsync/__mocks__/README.md
@@ -1,26 +1,40 @@
-Each module need to declare mocks under **mocks**/modules with data generators for tests to be testing the modules with them. Here are the object and functions to export:
+# WalletSync Module Mocks
+
+Each WalletSync module declares mocks under `__mocks__/modules`. Tests use these
+generators to exercise module sync behavior deterministically.
+
+Export the objects and functions below for each module.
 
 ### `emptyState`
 
-This is the initial state of the module. It should be an empty object or array.
+Initial module state. It should be an empty object or array.
 
-The module need to consider that this emptyState have no diff with `null`.
+The module should treat `emptyState` as having no diff with `null`.
 
 ### `genState(index)`
 
-This function should generate a deterministic state for a given index. Each state must differ from each other and represent a wide variety of possible states. genState must not return emptyState. It's a good practice to have intersection between states. It is conventional that higher index have more data than lower index. For instance `genState(0)` on accounts have 1 account.
+Generate a deterministic state for a given index. Each state must differ from
+the others and represent a wide variety of possible states. `genState` must not
+return `emptyState`.
+
+Prefer some intersection between states. By convention, higher indexes contain
+more data than lower indexes. For instance, `genState(0)` on accounts has one
+account.
 
 ### `convertLocalToDistantState(localState)`
 
-This function should convert the local state to the distant state. The distant state is the state that is sent to the distant server.
+Convert the local state to the distant state sent to the distant server.
 
 ### `convertDistantToLocalState(distantState)`
 
-This function should guess a conversion of the distant state to the local state. NB: this is a guess because in real life it is not always possible to resolve this synchronously, but we are making so in context of our mocks.
+Guess a conversion from distant state to local state. This is a guess because in
+production it is not always possible to resolve synchronously, but mocks keep it
+synchronous.
 
 ### `similarLocalState(a, b)`
 
-Compare two local state and tells if they are "similar", ignoring possible diff related to Distant<>Local translations or possible change of orders that are acceptable for each module.
+Compare two local states and return whether they are similar, ignoring accepted
+differences from distant/local translations or order changes.
 
 ## Template
 
@@ -28,21 +42,21 @@ Compare two local state and tells if they are "similar", ignoring possible diff 
 type LocalState = ...
 type DistantState = ...
 
-export const emptyState: LocalState = TODO;
+export const emptyState: LocalState = ...
 
 export const genState = (index: number): LocalState => {
-  TODO;
+  ...
 };
 
 export const convertLocalToDistantState = (localState: LocalState): DistantState => {
-  TODO;
+  ...
 };
 
 export const convertDistantToLocalState = (distantState: DistantState): LocalState => {
-  TODO;
+  ...
 };
 
 export const similarLocalState = (a: LocalState, b: LocalState) => {
-  TODO;
+  ...
 };
 ```

--- a/libs/live-wallet/src/walletsync/modules/README.md
+++ b/libs/live-wallet/src/walletsync/modules/README.md
@@ -1,12 +1,17 @@
-For more information about writing a new module, please this follow tutorial: https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/4862509091/TODO+how+to+develop+a+new+WalletSync+module
+# WalletSync Modules
 
-### Template for a new module
+This directory contains WalletSync module implementations. For broader design
+context, see the internal
+[WalletSync module tutorial](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/4862509091/TODO+how+to+develop+a+new+WalletSync+module).
+
+## New Module Template
 
 ```ts
 import { WalletSyncDataManager } from "../types";
 import { z } from "zod";
 
-// schema of the distant data. IMPORTANT: Once the module is written, the schema must not change over time – if you still want to change the schema, only do it by adding optional fields and make sure that any module implementation (from v1) was keeping the unknown properties = the schema must be backward compatible.
+// Schema of the distant data. Once a module ships, keep the schema backward
+// compatible: add optional fields instead of changing existing fields.
 const schema = z.record(z.string());
 
 const manager: WalletSyncDataManager<
@@ -30,12 +35,13 @@ const manager: WalletSyncDataManager<
   },
 
   async resolveIncrementalUpdate(_ctx, localData, latestState, incomingState) {
-    // if incoming state is null, it means the data is no longer available
+    // If incoming state is null, the data is no longer available.
     if (!incomingState) {
       return { hasChanges: false };
     }
 
-    // this module don't need to manage any "local increment update" so we must bail out from doing anything during localIncrementalUpdate() step
+    // Bail out if the module does not need to process a local incremental
+    // update.
     if (latestState === incomingState) {
       return { hasChanges: false };
     }

--- a/libs/ui/README.md
+++ b/libs/ui/README.md
@@ -1,24 +1,24 @@
-# `ui` <br/> [![react storybook](https://img.shields.io/badge/storybook%20📚-react-61DBFB)](https://react-ui-storybook.vercel.app) [![native storybook](https://img.shields.io/badge/storybook%20📚-native-9665B7)](https://native-ui-storybook.vercel.app)
+# UI Packages
 
-### Design and interface resources for React and React Native projects.
+Design and interface resources for React and React Native projects.
 
-##### Status: while perfectly useable the libraries are still in alpha state and are subject to breaking changes without notice :fire:.
+Storybooks:
 
-## About
+- [React UI](https://react-ui-storybook.vercel.app)
+- [Native UI](https://native-ui-storybook.vercel.app)
 
-**The `ui` umbrella is a comprised of the following packages:**
+Status: these libraries are still in alpha and can include breaking changes.
 
-- [**`@ledgerhq/react-ui`**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ui/packages/react): [React](https://reactjs.org/) components and styles.
+## Packages
 
-- [**`@ledgerhq/native-ui`**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ui/packages/native): [React Native](https://reactnative.dev/) components and styles
-
-- [**`@ledgerhq/ui-shared`**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ui/packages/shared): Shared assets and code shared between react and native modules.
-
-- [**`@ledgerhq/icons-ui`**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ui/packages/icons): Shared SVG icons.
+- [@ledgerhq/react-ui](packages/react/README.md): React components and styles.
+- [@ledgerhq/native-ui](packages/native/README.md): React Native components and styles.
+- [@ledgerhq/ui-shared](packages/shared/README.md): shared assets and code used by React and Native packages.
+- [@ledgerhq/icons-ui](packages/icons/README.md): shared SVG icons.
 
 ## Installation
 
-> Reminder: all commands should be run at the root of the monorepository
+Run commands from the repository root.
 
 ```sh
 pnpm i
@@ -26,23 +26,18 @@ pnpm i
 
 ## Usage
 
-Several aliases to the `pnpm --filter` command can be used for convenience.
+Use package aliases as `pnpm --filter` shortcuts.
 
 ```sh
-# pnpm --filter react-ui
 pnpm ui:react
-# pnpm --filter native-ui
 pnpm ui:native
-# pnpm --filter icons-ui
 pnpm ui:icons
-# pnpm --filter shared-ui
 pnpm ui:shared
 ```
 
-You can use them as prefixes to set the scope and run a command for a given submodule.
+Use them as prefixes to run a command for a given package.
 
 ```sh
-# Prefix the command you want to run with an alias like this:
 pnpm ui:react add -D package
 pnpm ui:native storybook
 pnpm ui:shared clean

--- a/tests/dummy-wallet-app/README.md
+++ b/tests/dummy-wallet-app/README.md
@@ -7,40 +7,61 @@ The purpose of this app is to allow automated front end testing of Ledger Live's
 
 The app is a simple React app bundled with Rspack which uses the [Wallet API](https://www.npmjs.com/package/@ledgerhq/wallet-api).
 
-## Local Dummy App setup steps
+## Local Setup
+
+Run commands from the repository root.
 
 ```sh
 pnpm i
 pnpm dummy-wallet-app start # Start development server
 ```
 
-## Serve production build
+## E2E Usage
+
+Use the maintained E2E setup docs for environment prerequisites:
+
+- [Desktop E2E](../../e2e/desktop/README.md)
+- [Mobile E2E](../../e2e/mobile/README.md)
+
+Build the production dummy app before running Wallet API E2E tests:
 
 ```sh
-### Setup
-
-pnpm i
 pnpm build:dummy-wallet-app
+```
 
 ### Desktop
+
+```sh
 pnpm build:lld:deps
 pnpm desktop build:testing
-### Run the setup only once if not done yet
 pnpm desktop test:playwright:setup
-pnpm desktop test:playwright wallet-api.spec.ts
+pnpm desktop test:playwright tests/specs/services/wallet-api.spec.ts
+```
 
-###  Mobie
+### Mobile
+
+Start Metro in a separate terminal when running iOS debug tests:
+
+```sh
 pnpm mobile start
+```
 
 ### iOS
+
+```sh
 pnpm build:llm:deps
 pnpm mobile e2e:build -c ios.sim.debug
 pnpm mobile e2e:test -c ios.sim.debug apps/ledger-live-mobile/e2e/specs/wallet-api/accountRequest.spec.ts
+```
 
 ### Android
+
+Android local E2E runs use release builds.
+
+```sh
 pnpm build:llm:deps
-pnpm mobile e2e:build -c android.emu.debug
-pnpm mobile e2e:test -c android.emu.debug apps/ledger-live-mobile/e2e/specs/wallet-api/accountRequest.spec.ts
+pnpm mobile e2e:build -c android.emu.release
+pnpm mobile e2e:test -c android.emu.release apps/ledger-live-mobile/e2e/specs/wallet-api/accountRequest.spec.ts
 ```
 
 # How does it work?


### PR DESCRIPTION
### 📝 Description

These changes follow a review of all README files in the repo. The AI went looking for README files that are empty, stale, duplicative, or oversized enough to deserve cleanup.

### ❓ Context

- README files are key entry points for docs (inc. agentic context) in the repo
- The current plan for organising repo docs describes well located README files as key entry points for context
- Jira: https://ledgerhq.atlassian.net/browse/LIVE-28131

### 🤔  Reviewer notes

- Conform accuracy of information in the new README files
- Run commands to test they work
- Follow links to confirm they are valid
- Consider all deletions. If one of more of the following apply it's okay to delete
  - Is it general community knowledge (not specific to this repo)? 
  - Is it covered elsewhere?
  - Have the details been moved into a separate file and linked to (progressive disclosure stylee)?