### PR TITLE
[LWD] feat: add detailed analytics tracking to Asset Detail screen

### DIFF
--- a/.changeset/fix-asset-detail-desktop-tracking.md
+++ b/.changeset/fix-asset-detail-desktop-tracking.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix Asset Detail analytics to match the tracking plan: add `button_clicked` tracking on the action bar, chart timeframe, addresses, favourites/hide, staking, market-stat and available-balance tooltips, and transactions; enrich `transaction_clicked` with page and currency; report `currency` as ledger currency id instead of ticker.

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/AssetDetailView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/AssetDetailView.tsx
@@ -82,6 +82,7 @@ export function AssetDetailView({ viewModel }: AssetDetailViewProps) {
       <ChartSection
         marketData={marketData}
         ledgerId={ledgerId}
+        currencyId={ledgerCurrency?.id}
         isDistributionLoading={isDistributionLoading}
         selectedRange={selectedRange}
         onRangeChange={onRangeChange}
@@ -110,6 +111,7 @@ export function AssetDetailView({ viewModel }: AssetDetailViewProps) {
           <MarketDataSection
             marketData={marketData}
             isDistributionLoading={isDistributionLoading}
+            ledgerCurrencyId={ledgerCurrency?.id ?? ledgerId}
           />
         )}
 

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ActionBar/useActionBarViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ActionBar/useActionBarViewModel.ts
@@ -185,29 +185,35 @@ export function useActionBarViewModel({
     [canBuyOnRamp, canSellOnRamp, walletAllowsSellSend],
   );
 
+  const trackingCurrencyId =
+    ledgerCurrency?.id ?? distributionItem?.currency.id ?? rampActiveLedgerIds[0];
+
   const onBuy = useCallback(() => {
-    track("button_clicked2", {
+    track("button_clicked", {
       button: "buy",
-      currency: ledgerCurrency?.ticker ?? tickerHint,
+      currency: trackingCurrencyId,
       page: ASSET_DETAIL_TRACKING_PAGE_NAME,
-      flow: "buy",
     });
     setTrackingSource(ASSET_DETAIL_TRACKING_PAGE_NAME);
     navigateToBuy(ledgerCurrency, tickerHint);
-  }, [ledgerCurrency, tickerHint, navigateToBuy]);
+  }, [ledgerCurrency, tickerHint, navigateToBuy, trackingCurrencyId]);
 
   const onSell = useCallback(() => {
-    track("button_clicked2", {
+    track("button_clicked", {
       button: "sell",
-      currency: ledgerCurrency?.ticker ?? tickerHint,
+      currency: trackingCurrencyId,
       page: ASSET_DETAIL_TRACKING_PAGE_NAME,
-      flow: "sell",
     });
     setTrackingSource(ASSET_DETAIL_TRACKING_PAGE_NAME);
     navigateToSell(ledgerCurrency, tickerHint);
-  }, [ledgerCurrency, tickerHint, navigateToSell]);
+  }, [ledgerCurrency, tickerHint, navigateToSell, trackingCurrencyId]);
 
   const onSend = useCallback(() => {
+    track("button_clicked", {
+      button: "send",
+      currency: trackingCurrencyId,
+      page: ASSET_DETAIL_TRACKING_PAGE_NAME,
+    });
     if (primaryAccount) {
       openSendFlow({
         source: ASSET_DETAIL_TRACKING_PAGE_NAME,
@@ -217,14 +223,13 @@ export function useActionBarViewModel({
     } else {
       openSendFlow({ source: ASSET_DETAIL_TRACKING_PAGE_NAME });
     }
-  }, [openSendFlow, primaryAccount, primaryParentAccount]);
+  }, [openSendFlow, primaryAccount, primaryParentAccount, trackingCurrencyId]);
 
   const onReceive = useCallback(() => {
-    track("button_clicked2", {
+    track("button_clicked", {
       button: "receive",
-      currency: ledgerCurrency?.ticker ?? tickerHint,
+      currency: trackingCurrencyId,
       page: ASSET_DETAIL_TRACKING_PAGE_NAME,
-      flow: "receive",
     });
     dispatch(
       openModal("MODAL_RECEIVE", {
@@ -232,7 +237,7 @@ export function useActionBarViewModel({
         ...(primaryAccount ? { account: primaryAccount, parentAccount: primaryParentAccount } : {}),
       }),
     );
-  }, [dispatch, primaryAccount, primaryParentAccount, ledgerCurrency?.ticker, tickerHint]);
+  }, [dispatch, primaryAccount, primaryParentAccount, trackingCurrencyId]);
 
   return {
     showSkeleton: isPageLoading,

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AddressList/hooks/useAddressListViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AddressList/hooks/useAddressListViewModel.ts
@@ -14,7 +14,6 @@ import { getAccountsSidebarPath } from "LLD/components/SideBar/utils";
 import { useOpenAssetFlow } from "LLD/features/ModularDialog/hooks/useOpenAssetFlow";
 import { MAD_SOURCE_PAGES } from "LLD/features/ModularDialog/analytics/modularDialog.types";
 import { track } from "~/renderer/analytics/segment";
-import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
 import { buildMainAccountByIdMap } from "@ledgerhq/asset-aggregation/assetDistribution/index";
 import { ASSET_DETAIL_TRACKING_PAGE_NAME } from "LLD/features/AssetDetail/constants";
 import { MAX_ADDRESSES_PREVIEW } from "../constants";
@@ -45,6 +44,11 @@ export function useAddressListViewModel(distributionItem: DistributionItem) {
   const [isAllAddressesDialogOpen, setIsAllAddressesDialogOpen] = useState(false);
 
   const onSeeAll = () => {
+    track("button_clicked", {
+      button: "see_all_addresses",
+      currency: distributionItem.currency.id,
+      page: ASSET_DETAIL_TRACKING_PAGE_NAME,
+    });
     setIsAllAddressesDialogOpen(true);
   };
 
@@ -60,17 +64,23 @@ export function useAddressListViewModel(distributionItem: DistributionItem) {
   const onAddAddress = () => {
     track("button_clicked", {
       button: "add_account",
+      currency: distributionItem.currency.id,
       page: ASSET_DETAIL_TRACKING_PAGE_NAME,
     });
     openAddAccountFlow(distributionItem.currency);
   };
 
   const onAccountClick = (account: AccountLike, parentAccount?: Account | null) => {
+    const mainAccount =
+      account.type === "TokenAccount"
+        ? parentAccount ?? lookupParentAccount(account.parentId)
+        : account;
     setTrackingSource(ASSET_DETAIL_TRACKING_PAGE_NAME);
-    track("account_clicked", {
+    track("button_clicked", {
+      button: "Account",
+      currency: distributionItem.currency.id,
+      chain: mainAccount ? getAccountCurrency(mainAccount).id : getAccountCurrency(account).id,
       page: ASSET_DETAIL_TRACKING_PAGE_NAME,
-      currency: getAccountCurrency(account).name,
-      account: getDefaultAccountName(account),
     });
     if (account.type === "TokenAccount" && !parentAccount) {
       navigate(getAccountsSidebarPath(shouldDisplayAssetSection));

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/index.tsx
@@ -7,6 +7,7 @@ import { useChartSectionViewModel } from "./useChartSectionViewModel";
 type ChartSectionProps = Readonly<{
   marketData: AssetMarketData;
   ledgerId?: string;
+  currencyId?: string;
   isDistributionLoading: boolean;
   selectedRange: LineChartRange;
   onRangeChange: (range: LineChartRange) => void;

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/useChartSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/useChartSectionViewModel.ts
@@ -3,6 +3,8 @@ import BigNumber from "bignumber.js";
 import type { AssetMarketData } from "@ledgerhq/asset-detail";
 import { useAssetChartData } from "@ledgerhq/live-common/market/hooks/useMarketDataProvider";
 import { formatPrice } from "@ledgerhq/live-currency-format";
+import { track } from "~/renderer/analytics/segment";
+import { ASSET_DETAIL_TRACKING_PAGE_NAME } from "LLD/features/AssetDetail/constants";
 import { useSelector } from "LLD/hooks/redux";
 import {
   resolveLineChartColorFromPercentChange,
@@ -52,6 +54,7 @@ function getEvenlySpacedTicks(length: number, minTicks: number): number[] {
 type UseChartSectionViewModelProps = Readonly<{
   marketData: AssetMarketData;
   ledgerId?: string;
+  currencyId?: string;
   isDistributionLoading: boolean;
   selectedRange: LineChartRange;
   onRangeChange: (range: LineChartRange) => void;
@@ -76,6 +79,7 @@ export type ChartSectionViewModelResult = Readonly<{
 export function useChartSectionViewModel({
   marketData,
   ledgerId,
+  currencyId,
   selectedRange,
   onRangeChange,
 }: UseChartSectionViewModelProps): ChartSectionViewModelResult {
@@ -183,10 +187,19 @@ export function useChartSectionViewModel({
 
   const handleRangeChange = useCallback(
     (range: LineChartRange) => {
+      if (range === selectedRange) return;
       setSelection(undefined);
       onRangeChange(range);
+      if (currencyId) {
+        track("button_clicked", {
+          button: "timeframe",
+          timeframe: range,
+          page: ASSET_DETAIL_TRACKING_PAGE_NAME,
+          currency: currencyId,
+        });
+      }
     },
-    [onRangeChange, setSelection],
+    [currencyId, selectedRange, onRangeChange, setSelection],
   );
 
   return {

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/MarketStats/MarketStatsView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/MarketStats/MarketStatsView.tsx
@@ -15,7 +15,13 @@ import type { MarketStatsViewModelResult } from "./hooks/useMarketStatsViewModel
 
 type Props = Readonly<MarketStatsViewModelResult>;
 
-export function MarketStatsView({ rows, showSkeleton, sectionTitle, sectionTooltip }: Props) {
+export function MarketStatsView({
+  rows,
+  showSkeleton,
+  sectionTitle,
+  sectionTooltip,
+  onTooltipOpen,
+}: Props) {
   return (
     <div className="flex min-w-0 flex-col gap-16">
       {showSkeleton ? (
@@ -25,7 +31,7 @@ export function MarketStatsView({ rows, showSkeleton, sectionTitle, sectionToolt
           <SubheaderRow className="min-w-0 items-center justify-between gap-4">
             <div className="flex min-w-0 items-center gap-4">
               <SubheaderTitle>{sectionTitle}</SubheaderTitle>
-              <Tooltip>
+              <Tooltip onOpenChange={open => onTooltipOpen("market_stats", open)}>
                 <TooltipTrigger asChild>
                   <span className="inline-flex cursor-help">
                     <Information size={16} />
@@ -43,7 +49,13 @@ export function MarketStatsView({ rows, showSkeleton, sectionTitle, sectionToolt
         ) : (
           <div className="flex flex-col gap-8">
             {rows.map(row => (
-              <StatRow key={row.key} label={row.label} value={row.value} tooltip={row.tooltip} />
+              <StatRow
+                key={row.key}
+                label={row.label}
+                value={row.value}
+                tooltip={row.tooltip}
+                onTooltipOpenChange={open => onTooltipOpen(row.key, open)}
+              />
             ))}
           </div>
         )}

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/MarketStats/hooks/useMarketStatsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/MarketStats/hooks/useMarketStatsViewModel.ts
@@ -1,5 +1,7 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { track } from "~/renderer/analytics/segment";
+import { ASSET_DETAIL_TRACKING_PAGE_NAME } from "LLD/features/AssetDetail/constants";
 import counterValueFormatter from "@ledgerhq/live-common/market/utils/countervalueFormatter";
 import type { MarketDataSectionCurrencyData } from "../../hooks/useMarketDataSectionCurrencyData";
 import type { MarketStatRow } from "../../types";
@@ -8,7 +10,7 @@ const MISSING = "-";
 
 export function useMarketStatsViewModel(currencyData: MarketDataSectionCurrencyData) {
   const { t } = useTranslation();
-  const { data, showSkeleton, counterCurrency, locale } = currencyData;
+  const { data, showSkeleton, counterCurrency, locale, ledgerCurrencyId } = currencyData;
 
   const sectionTitle = t("assetDetails.marketStats");
   const sectionTooltip = t("assetDetails.marketStatsTooltip");
@@ -88,11 +90,26 @@ export function useMarketStatsViewModel(currencyData: MarketDataSectionCurrencyD
     t,
   ]);
 
+  const onTooltipOpen = useCallback(
+    (statType: string, open: boolean) => {
+      if (open && ledgerCurrencyId) {
+        track("button_clicked", {
+          button: "market_stat_definition",
+          currency: ledgerCurrencyId,
+          type: statType,
+          page: ASSET_DETAIL_TRACKING_PAGE_NAME,
+        });
+      }
+    },
+    [ledgerCurrencyId],
+  );
+
   return {
     rows,
     showSkeleton,
     sectionTitle,
     sectionTooltip,
+    onTooltipOpen,
   };
 }
 

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/__tests__/useMarketDataSectionViewModels.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/__tests__/useMarketDataSectionViewModels.test.ts
@@ -1,5 +1,7 @@
-import { renderHook } from "tests/testSetup";
+import { act, renderHook } from "tests/testSetup";
 import { createMockMarketCurrencyData } from "@ledgerhq/live-common/market/utils/fixtures";
+import { track } from "~/renderer/analytics/segment";
+import { ASSET_DETAIL_TRACKING_PAGE_NAME } from "LLD/features/AssetDetail/constants";
 import type { MarketDataSectionCurrencyData } from "../hooks/useMarketDataSectionCurrencyData";
 import { useMarketStatsViewModel } from "../MarketStats/hooks/useMarketStatsViewModel";
 import { usePricePerformanceViewModel } from "../PricePerformance/hooks/usePricePerformanceViewModel";
@@ -46,6 +48,26 @@ describe("useMarketStatsViewModel", () => {
     );
 
     expect(result.current.showSkeleton).toBe(false);
+  });
+
+  it("tracks market_stat_definition when a stat tooltip opens", () => {
+    const { result } = renderHook(
+      () => useMarketStatsViewModel(buildCurrencyData({ ledgerCurrencyId: "bitcoin" })),
+      hookOptions(),
+    );
+
+    act(() => result.current.onTooltipOpen("circulating_supply", true));
+
+    expect(track).toHaveBeenCalledWith("button_clicked", {
+      button: "market_stat_definition",
+      currency: "bitcoin",
+      type: "circulating_supply",
+      page: ASSET_DETAIL_TRACKING_PAGE_NAME,
+    });
+
+    jest.mocked(track).mockClear();
+    act(() => result.current.onTooltipOpen("circulating_supply", false));
+    expect(track).not.toHaveBeenCalled();
   });
 
   it("formats market rank with a sharp sign when CoinGecko rank is positive", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/components/StatRow.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/components/StatRow.tsx
@@ -15,15 +15,16 @@ export type StatRowProps = Readonly<{
   label: string;
   value: string;
   tooltip?: string;
+  onTooltipOpenChange?: (open: boolean) => void;
 }>;
 
-export function StatRow({ label, value, tooltip }: StatRowProps) {
+export function StatRow({ label, value, tooltip, onTooltipOpenChange }: StatRowProps) {
   return (
     <DescriptionItem size="md">
       <DescriptionItemLeading>
         <DescriptionItemLabel>{label}</DescriptionItemLabel>
         {tooltip && (
-          <Tooltip>
+          <Tooltip onOpenChange={onTooltipOpenChange}>
             <TooltipTrigger asChild>
               <span className="inline-flex cursor-help text-muted" aria-label={label}>
                 <Information size={16} />

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/hooks/useMarketDataSectionCurrencyData.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/hooks/useMarketDataSectionCurrencyData.ts
@@ -9,11 +9,13 @@ export type MarketDataSectionCurrencyData = Readonly<{
   showSkeleton: boolean;
   counterCurrency: string;
   locale: string;
+  ledgerCurrencyId?: string;
 }>;
 
 export function useMarketDataSectionCurrencyData(
   marketData: AssetMarketData,
   isDistributionLoading: boolean,
+  ledgerCurrencyId?: string,
 ): MarketDataSectionCurrencyData {
   const counterCurrency = useSelector(counterValueCurrencySelector).ticker.toLowerCase();
   const locale = useSelector(localeSelector);
@@ -28,5 +30,6 @@ export function useMarketDataSectionCurrencyData(
     ),
     counterCurrency,
     locale,
+    ledgerCurrencyId,
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/index.tsx
@@ -7,10 +7,19 @@ import { useMarketDataSectionCurrencyData } from "./hooks/useMarketDataSectionCu
 type MarketDataSectionProps = Readonly<{
   marketData: AssetMarketData;
   isDistributionLoading: boolean;
+  ledgerCurrencyId?: string;
 }>;
 
-export function MarketDataSection({ marketData, isDistributionLoading }: MarketDataSectionProps) {
-  const currencyData = useMarketDataSectionCurrencyData(marketData, isDistributionLoading);
+export function MarketDataSection({
+  marketData,
+  isDistributionLoading,
+  ledgerCurrencyId,
+}: MarketDataSectionProps) {
+  const currencyData = useMarketDataSectionCurrencyData(
+    marketData,
+    isDistributionLoading,
+    ledgerCurrencyId,
+  );
 
   return (
     <div className="grid grid-cols-2 gap-24" data-testid="asset-detail-market-data-section">

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/OptionsMenu/useOptionsMenuViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/OptionsMenu/useOptionsMenuViewModel.ts
@@ -14,6 +14,8 @@ import {
   blacklistedTokenIdsSelector,
   starredMarketCoinsSelector,
 } from "~/renderer/reducers/settings";
+import { track } from "~/renderer/analytics/segment";
+import { ASSET_DETAIL_TRACKING_PAGE_NAME } from "LLD/features/AssetDetail/constants";
 
 export type UseOptionsMenuViewModelProps = Readonly<{
   distributionItem?: DistributionItem;
@@ -67,16 +69,35 @@ export function useOptionsMenuViewModel({
 
   const onToggleStar = useCallback(() => {
     if (!starMarketId) return;
+    const nextStarred = !isStarred;
+    track("button_clicked", {
+      button: "favourite",
+      currency: portfolioCurrencyId,
+      page: ASSET_DETAIL_TRACKING_PAGE_NAME,
+      is_favourite: nextStarred,
+    });
     dispatch(
       isStarred ? removeStarredMarketCoins(starMarketId) : addStarredMarketCoins(starMarketId),
     );
-  }, [dispatch, isStarred, starMarketId]);
+  }, [dispatch, isStarred, portfolioCurrencyId, starMarketId]);
 
   const onHideFromPortfolio = useCallback(() => {
+    track("button_clicked", {
+      button: "hide_asset",
+      currency: portfolioCurrencyId,
+      page: ASSET_DETAIL_TRACKING_PAGE_NAME,
+      is_hidden: true,
+    });
     dispatch(blacklistToken(portfolioCurrencyId));
   }, [dispatch, portfolioCurrencyId]);
 
   const onShowInPortfolio = useCallback(() => {
+    track("button_clicked", {
+      button: "hide_asset",
+      currency: portfolioCurrencyId,
+      page: ASSET_DETAIL_TRACKING_PAGE_NAME,
+      is_hidden: false,
+    });
     dispatch(showToken(portfolioCurrencyId));
   }, [dispatch, portfolioCurrencyId]);
 

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/StakingSection/StakingSectionView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/StakingSection/StakingSectionView.tsx
@@ -19,6 +19,7 @@ export function StakingSectionView({
   earnBannerActionLabel,
   onEarnBannerPress,
   onEarnDepositPress,
+  onAvailableBalanceTooltipOpen,
 }: StakingSectionViewProps) {
   if (state.type === "hidden") return null;
 
@@ -58,7 +59,7 @@ export function StakingSectionView({
         title={
           <div className="flex items-center gap-4 text-muted">
             <span className="body-3">{availableBalanceLabel}</span>
-            <Tooltip>
+            <Tooltip onOpenChange={onAvailableBalanceTooltipOpen}>
               <TooltipTrigger asChild>
                 <span className="inline-flex cursor-help">
                   <Information size={16} />

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/StakingSection/__tests__/StakingSectionView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/StakingSection/__tests__/StakingSectionView.test.tsx
@@ -13,6 +13,7 @@ const baseViewModel: StakingSectionViewModelResult = {
   earnBannerActionLabel: "Go to Earn",
   onEarnBannerPress: jest.fn(),
   onEarnDepositPress: jest.fn(),
+  onAvailableBalanceTooltipOpen: jest.fn(),
 };
 
 describe("StakingSectionView", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/StakingSection/useStakingSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/StakingSection/useStakingSectionViewModel.ts
@@ -126,6 +126,20 @@ export function useStakingSectionViewModel(distributionItem: DistributionItem) {
     openStakeDrawer();
   }, [currencyId, openStakeDrawer]);
 
+  const onAvailableBalanceTooltipOpen = useCallback(
+    (open: boolean) => {
+      if (open) {
+        track("button_clicked", {
+          button: "market_stat_definition",
+          currency: currencyId,
+          type: "available_balance",
+          page: ASSET_DETAIL_TRACKING_PAGE_NAME,
+        });
+      }
+    },
+    [currencyId],
+  );
+
   return {
     state,
     availableBalanceTooltip: t("assetDetails.staking.availableBalanceTooltip"),
@@ -135,6 +149,7 @@ export function useStakingSectionViewModel(distributionItem: DistributionItem) {
     earnBannerActionLabel: t("assetDetails.staking.earnBannerAction"),
     onEarnBannerPress,
     onEarnDepositPress,
+    onAvailableBalanceTooltipOpen,
   };
 }
 

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TransactionsSection/__tests__/useTransactionsSectionViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TransactionsSection/__tests__/useTransactionsSectionViewModel.test.ts
@@ -6,6 +6,7 @@ import { buildDistributionItem } from "tests/utils/distributionTestUtils";
 import { setDrawer } from "~/renderer/drawers/Provider";
 import { OperationDetails } from "~/renderer/drawers/OperationDetails";
 import { track } from "~/renderer/analytics/segment";
+import { ASSET_DETAIL_TRACKING_PAGE_NAME } from "LLD/features/AssetDetail/constants";
 import { useTransactionsSectionViewModel } from "../useTransactionsSectionViewModel";
 
 const mockNavigate = jest.fn();
@@ -69,6 +70,8 @@ describe("useTransactionsSectionViewModel", () => {
 
     expect(track).toHaveBeenCalledWith("transaction_clicked", {
       transaction: operation.type,
+      page: ASSET_DETAIL_TRACKING_PAGE_NAME,
+      currency: "bitcoin",
     });
     expect(setDrawer).toHaveBeenCalledWith(OperationDetails, {
       operationId: operation.id,
@@ -118,6 +121,11 @@ describe("useTransactionsSectionViewModel", () => {
       result.current.onSeeAll();
     });
 
+    expect(track).toHaveBeenCalledWith("button_clicked", {
+      button: "Transactions",
+      currency: "bitcoin",
+      page: ASSET_DETAIL_TRACKING_PAGE_NAME,
+    });
     expect(mockNavigate).toHaveBeenCalledWith(
       `/history?accountIds=${encodeURIComponent(`${account1.id},${account2.id}`)}`,
       { state: { historyBackPath: "/asset/bitcoin" } },

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TransactionsSection/useTransactionsSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TransactionsSection/useTransactionsSectionViewModel.ts
@@ -6,6 +6,7 @@ import { accountsSelector } from "~/renderer/reducers/accounts";
 import { setDrawer } from "~/renderer/drawers/Provider";
 import { OperationDetails } from "~/renderer/drawers/OperationDetails";
 import { track } from "~/renderer/analytics/segment";
+import { ASSET_DETAIL_TRACKING_PAGE_NAME } from "LLD/features/AssetDetail/constants";
 import { useHistoryTable } from "LLD/features/History/hooks/useHistoryTable";
 import { useHistoryOperationItemsForRootAccounts } from "LLD/features/History/hooks/useHistoryOperationItemsForRootAccounts";
 import {
@@ -61,20 +62,27 @@ export function useTransactionsSectionViewModel(
     const { operation, account, parentAccount } = row.original;
     track("transaction_clicked", {
       transaction: operation.type,
+      page: ASSET_DETAIL_TRACKING_PAGE_NAME,
+      currency: distributionItem.currency.id,
     });
     setDrawer(OperationDetails, {
       operationId: operation.id,
       accountId: account.id,
       parentId: parentAccount?.id,
     });
-  }, []);
+  }, [distributionItem.currency.id]);
 
   const onSeeAll = useCallback(() => {
+    track("button_clicked", {
+      button: "Transactions",
+      currency: distributionItem.currency.id,
+      page: ASSET_DETAIL_TRACKING_PAGE_NAME,
+    });
     const query = distributionItem.accounts.map(a => a.id).join(",");
     navigate(`/history?accountIds=${encodeURIComponent(query)}`, {
       state: { historyBackPath: assetDetailPath },
     });
-  }, [assetDetailPath, distributionItem.accounts, navigate]);
+  }, [assetDetailPath, distributionItem.accounts, distributionItem.currency.id, navigate]);
 
   return {
     visible: scopedOperationItems.length > 0,

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/index.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import { ASSET_DETAIL_TRACKING_PAGE_NAME } from "LLD/features/AssetDetail/constants";
 import { AssetDetailView } from "./AssetDetailView";
 import { ScrubbedPriceProvider } from "./context/ScrubbedPriceContext";
 import { useAssetDetailViewModel } from "./hooks/useAssetDetailViewModel";
@@ -16,10 +18,15 @@ const AssetDetail = () => {
     );
   }
 
+  const currencyId = viewModel.distributionItem?.currency.id ?? viewModel.ledgerId;
+
   return (
-    <ScrubbedPriceProvider>
-      <AssetDetailView viewModel={viewModel} />
-    </ScrubbedPriceProvider>
+    <>
+      <TrackPage category={ASSET_DETAIL_TRACKING_PAGE_NAME} currency={currencyId} />
+      <ScrubbedPriceProvider>
+        <AssetDetailView viewModel={viewModel} />
+      </ScrubbedPriceProvider>
+    </>
   );
 };
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request enhances analytics tracking across the Asset Detail feature, ensuring consistent and comprehensive event logging for user interactions. It introduces new tracking events for tooltips, chart range changes, and menu actions, and standardizes the page naming in analytics. Additionally, it refactors component props and view models to support these tracking improvements.

### ❓ Context

[LIVE-28844](https://ledgerhq.atlassian.net/browse/LIVE-28844)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-28844]: https://ledgerhq.atlassian.net/browse/LIVE-28844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ