### PR TITLE
[LWM] fix(mobile): make asset detail available balance card fully pressable

### DIFF
--- a/.changeset/asset-detail-available-balance-pressable.md
+++ b/.changeset/asset-detail-available-balance-pressable.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Asset Detail: make the available balance card fully pressable to open its tooltip, instead of only the small info icon.

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/EarnCardsView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/EarnCardsView.tsx
@@ -37,35 +37,35 @@ export function EarnCardsView({
   return (
     <Box lx={rowStyle}>
       <Box lx={cardWrapperStyle} testID={ASSET_DETAIL_TEST_IDS.availableBalance}>
-        <Card type="info">
-          <CardHeader>
-            <CardLeading>
-              <CardContent>
-                <Box lx={tooltipLabelStyle}>
-                  <CardContentDescription>
-                    {t("assetDetail.balanceDetails.availableBalance")}
-                  </CardContentDescription>
-                  <Tooltip onOpenChange={onAvailableBalanceTooltipOpen}>
-                    <TooltipTrigger>
+        <Tooltip onOpenChange={onAvailableBalanceTooltipOpen}>
+          <TooltipTrigger asChild>
+            <Card type="interactive">
+              <CardHeader>
+                <CardLeading>
+                  <CardContent>
+                    <Box lx={tooltipLabelStyle}>
+                      <CardContentDescription>
+                        {t("assetDetail.balanceDetails.availableBalance")}
+                      </CardContentDescription>
                       <Information size={16} color="muted" />
-                    </TooltipTrigger>
-                    <TooltipContent
-                      title={t("assetDetail.balanceDetails.availableBalance")}
-                      content={
-                        <Box style={{ paddingBottom: bottom + 24 }}>
-                          <Text typography="body1" lx={{ color: "base" }}>
-                            {t("assetDetail.balanceDetails.availableBalanceTooltip")}
-                          </Text>
-                        </Box>
-                      }
-                    />
-                  </Tooltip>
-                </Box>
-                <CardContentTitle>{formattedAvailable}</CardContentTitle>
-              </CardContent>
-            </CardLeading>
-          </CardHeader>
-        </Card>
+                    </Box>
+                    <CardContentTitle>{formattedAvailable}</CardContentTitle>
+                  </CardContent>
+                </CardLeading>
+              </CardHeader>
+            </Card>
+          </TooltipTrigger>
+          <TooltipContent
+            title={t("assetDetail.balanceDetails.availableBalance")}
+            content={
+              <Box style={{ paddingBottom: bottom + 24 }}>
+                <Text typography="body1" lx={{ color: "base" }}>
+                  {t("assetDetail.balanceDetails.availableBalanceTooltip")}
+                </Text>
+              </Box>
+            }
+          />
+        </Tooltip>
       </Box>
       <Box lx={cardWrapperStyle}>
         <Card onPress={onEarnDepositPress} testID={ASSET_DETAIL_TEST_IDS.earnDeposit}>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Pure view/markup change; no component test exists for `EarnCardsView`. Behavior (tooltip open + analytics tracking) is preserved through the unchanged view-model handler._
- [x] **Impact of the changes:**
  - Asset Detail screen → available balance card (staked assets only)
  - Verify tapping anywhere on the available balance card opens the tooltip
  - Verify the card shows a pressed state and the info icon still displays
  - Verify the `market_stat_definition` analytics event still fires when the tooltip opens

### 📝 Description

**Problem**: On the Asset Detail screen, the available balance card only opened its tooltip when tapping the small 16px info icon, which was difficult to hit precisely.

**Solution**: The whole card is now the tooltip trigger. The `Tooltip` wraps the card and uses `<TooltipTrigger asChild>` around an interactive `Card`, so the entire card surface is pressable (with pressed-state feedback). The info icon remains as a visual hint. This mirrors the existing pattern used by the PnL / earn-deposit cards, where the whole card is the touch target and the info icon is purely indicative.

The `Tooltip onOpenChange` handler is unchanged, so the existing `market_stat_definition` analytics tracking still fires on open.

### 🎥 Demo


https://github.com/user-attachments/assets/8f130447-2447-4989-a878-1e6309f5ef28



### ❓ Context

- **JIRA or GitHub link**: [LIVE-31595](https://ledgerhq.atlassian.net/browse/LIVE-31595)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31595]: https://ledgerhq.atlassian.net/browse/LIVE-31595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ