### PR TITLE
docs(qaa): update e2e README entrypoints

### DIFF
--- a/e2e/desktop/README.md
+++ b/e2e/desktop/README.md
@@ -1,13 +1,14 @@
 # E2E Tests - Desktop
 
-This folder contains the end-to-end (E2E) tests for the **Ledger Wallet Desktop** app.  
+This folder contains the end-to-end (E2E) tests for the **Ledger Wallet Desktop** app.
 Dev teams are responsible for **adding/updating tests** when implementing new features.
 
 ---
 
 ## Interactive Setup (Recommended)
 
-Use the Cursor command `/e2e-desktop-onboard` for a guided, interactive walkthrough that checks every prerequisite, validates your environment, builds the app, and runs a smoke test.
+Use the `/e2e-desktop-onboard` skill (from an agent tool that supports repo skills) for a guided walkthrough that checks every
+prerequisite, validates your environment, builds the app, and runs a smoke test.
 
 ---
 
@@ -17,7 +18,6 @@ All build and test commands below are run from the **repo root** (`ledger-live/`
 
 ### 1. Prerequisites
 
-- Ledger Live repository (as mentioned in the full wiki)
 - Read the e2e environment [guide](https://ledgerhq.atlassian.net/wiki/spaces/QA/pages/6945013939/Ledger+Wallet+E2E+Environment)❗
 - Docker Desktop installed and running (Speculos runs in Docker)
 - Pull the Speculos Docker image:
@@ -77,7 +77,7 @@ pnpm e2e:desktop test:playwright
 pnpm e2e:desktop test:playwright <testFileName>
 ```
 
-### 5. Full Documentation
+### 5. More Documentation
 
 For detailed setup, debugging, and contribution guidelines, see:
 [Ledger Wallet Desktop E2E Wiki](https://github.com/LedgerHQ/ledger-live/wiki/LLD:E2ETesting)

--- a/e2e/desktop/docs/README.md
+++ b/e2e/desktop/docs/README.md
@@ -1,1 +1,0 @@
-This directory contains skills relevant to the parent directory

--- a/e2e/mobile/README.md
+++ b/e2e/mobile/README.md
@@ -1,9 +1,9 @@
 # E2E Tests - Mobile
 
-This folder contains the end-to-end (E2E) tests for the **Ledger Wallet Mobile** app.  
+This folder contains the end-to-end (E2E) tests for the **Ledger Wallet Mobile** app.
 Dev teams are responsible for **adding/updating tests** for new features.
 
-> **Cursor users:** Run the `/e2e-mobile-onboard` command for an interactive setup wizard.
+> In an agent tool that supports repo skills, run the `/e2e-mobile-onboard` skill for an interactive setup wizard.
 > It checks every prerequisite on your machine, validates environment variables, and guides you through fixes step by step.
 
 ---
@@ -65,8 +65,6 @@ pnpm mobile e2e:build -c ios.sim.debug
 
 - iOS: Create a simulator named `iOS Simulator` in Xcode
 - Android: Create an emulator named `Android_Emulator` in Android Studio
-
-Follow the full wiki if you need setup details.
 
 ### 5. Run Tests
 


### PR DESCRIPTION
### 📝 Description

These changes are split out from #17976 for the @LedgerHQ/qaa-owned README files.

These changes follow a review of README files in the repo. The AI went looking for README files that are empty, stale, duplicative, or oversized enough to deserve cleanup.

Files in this slice:

- `e2e/desktop/README.md`
- `e2e/desktop/docs/README.md`
- `e2e/mobile/README.md`

### ❓ Context

- Source PR: #17976
- Jira: https://ledgerhq.atlassian.net/browse/LIVE-28131
- CODEOWNERS: @LedgerHQ/qaa

### 🤔 Reviewer notes

- Confirm accuracy of information in the new README files.
- Run commands to test they work where relevant.
- Follow links to confirm they are valid.
- Consider all deletions. If one or more of the following apply, it's okay to delete:
  - Is it general community knowledge, not specific to this repo?
  - Is it covered elsewhere?
  - Have the details been moved into a separate file and linked to in progressive-disclosure style?