### PR TITLE
[LWDM] docs(coin-tezos): update account model README link

### DIFF
--- a/libs/coin-modules/coin-tezos/src/README.md
+++ b/libs/coin-modules/coin-tezos/src/README.md
@@ -22,7 +22,9 @@ The public key is the account main identifier, expressed as uncompress hex: `02e
 
 This public key is needed for making transaction and also is used to hash the account address. (`tz1PTxfn1fge2tJwGGpW9zNuYf6BseM3GJXt` in this case)
 
-The Account type as defined in https://github.com/LedgerHQ/ledger-live/wiki/LLC:account will be used with:
+The Ledger account model is defined in
+[`@ledgerhq/types-live`](../../../ledgerjs/packages/types-live/src/account.ts)
+and is used with:
 
 - `.id` to be the id explained as above
 - `.xpub` to be the public key


### PR DESCRIPTION
### 📝 Description

These changes are split out from #17976 for the Tezos README owned by @LedgerHQ/ledger-partner-hoodies and @LedgerHQ/ledger-third-party-leads.

These changes follow a review of README files in the repo. The AI went looking for README files that are empty, stale, duplicative, or oversized enough to deserve cleanup.

Files in this slice:

- `libs/coin-modules/coin-tezos/src/README.md`

### ❓ Context

- Source PR: #17976
- Jira: https://ledgerhq.atlassian.net/browse/LIVE-28131
- CODEOWNERS: @LedgerHQ/ledger-partner-hoodies, @LedgerHQ/ledger-third-party-leads

### 🤔 Reviewer notes

- Confirm accuracy of information in the new README files.
- Run commands to test they work where relevant.
- Follow links to confirm they are valid.
- Consider all deletions. If one or more of the following apply, it's okay to delete:
  - Is it general community knowledge, not specific to this repo?
  - Is it covered elsewhere?
  - Have the details been moved into a separate file and linked to in progressive-disclosure style?