### PR TITLE
[LWD] fix(desktop): allow blob sources in webview CSP [LIVE-31608]

### DIFF
--- a/.changeset/soft-clouds-load.md
+++ b/.changeset/soft-clouds-load.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Allow blob sources in desktop webview CSP

--- a/apps/ledger-live-desktop/src/main/webviewHandlers.helpers.test.ts
+++ b/apps/ledger-live-desktop/src/main/webviewHandlers.helpers.test.ts
@@ -163,14 +163,18 @@ describe("WEBVIEW_GUEST_CSP", () => {
     expect(WEBVIEW_GUEST_CSP).toContain("form-action");
   });
 
+  it("allows blob sources for SDK-loaded web workers or frames", () => {
+    expect(WEBVIEW_GUEST_CSP).toContain("frame-src 'self' http: https: blob:;");
+    expect(WEBVIEW_GUEST_CSP).toContain("child-src 'self' http: https: blob:;");
+  });
+
   it("does not allow the app-store / office external protocol schemes", () => {
     expect(WEBVIEW_GUEST_CSP).not.toContain("itms-apps");
     expect(WEBVIEW_GUEST_CSP).not.toContain("ms-word");
     expect(WEBVIEW_GUEST_CSP).not.toContain("file:");
   });
 
-  it("does not allow data or blob document sources", () => {
+  it("does not allow data document sources", () => {
     expect(WEBVIEW_GUEST_CSP).not.toContain("data:");
-    expect(WEBVIEW_GUEST_CSP).not.toContain("blob:");
   });
 });

--- a/apps/ledger-live-desktop/src/main/webviewHandlers.helpers.ts
+++ b/apps/ledger-live-desktop/src/main/webviewHandlers.helpers.ts
@@ -72,6 +72,6 @@ export function mergeCspHeaders(
  * NOT set `default-src` / `script-src` here so we don't break Live App JS.
  */
 export const WEBVIEW_GUEST_CSP =
-  "frame-src 'self' http: https:; " +
-  "child-src 'self' http: https:; " +
+  "frame-src 'self' http: https: blob:; " +
+  "child-src 'self' http: https: blob:; " +
   "form-action 'self' http: https:;";


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - desktop webview csp header injection

### 📝 Description

This pull request updates the Content Security Policy (CSP) for the desktop application's webview to allow blob sources as child sources. This change is primarily to support SDK-loaded web workers or frames that require blob URLs. Corresponding tests have been updated to reflect this new policy.

**CSP Policy Update:**

* Updated `WEBVIEW_GUEST_CSP` in `webviewHandlers.helpers.ts` to allow `blob:` in `child-src`, enabling SDK-loaded web workers or frames to function properly.

**Test Adjustments:**

* Added a test to ensure `WEBVIEW_GUEST_CSP` allows `blob:` as a `child-src` source and updated an existing test to no longer check for blob sources being disallowed. (`webviewHandlers.helpers.test.ts`)

**Documentation:**

* Added a changeset describing the minor update to allow blob sources in the desktop webview CSP. (`.changeset/soft-clouds-load.md`)

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31608]
- **ADR link (if any)**: 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31608]: https://ledgerhq.atlassian.net/browse/LIVE-31608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ