### PR TITLE
[LWM] feat(mobile): adapt asset detail balance graph skeleton (LIVE-31600)

### DIFF
--- a/.changeset/asset-detail-adapt-balance-graph-skeleton.md
+++ b/.changeset/asset-detail-adapt-balance-graph-skeleton.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Adapt the Asset Detail balance graph skeleton to match the Figma design, preventing the screen from jumping when market data finishes loading.

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/BalanceGraphView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/BalanceGraphView.tsx
@@ -52,7 +52,10 @@ export function BalanceGraphView({
   return (
     <Box testID={ASSET_DETAIL_TEST_IDS.balanceGraph} lx={containerStyle}>
       {isLoading && !hasMarketData ? (
-        <Skeleton lx={{ height: "s56", width: "s256", borderRadius: "md" }} />
+        <Box lx={{ gap: "s16" }}>
+          <Skeleton lx={{ height: "s12", width: "s128", borderRadius: "full" }} />
+          <Skeleton lx={{ height: "s80", width: "s224", borderRadius: "md" }} />
+        </Box>
       ) : (
         <Box lx={headerStyle}>
           <Text typography="body2" lx={{ color: "muted" }}>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Purely visual skeleton adjustment on the Asset Detail balance graph; verified manually against the Figma design._
- [x] **Impact of the changes:**
  - Asset Detail screen — balance graph loading state (skeleton layout/sizing)
  - Layout stability: confirm the screen no longer jumps when market data finishes loading
  - Both light and dark themes

### 📝 Description

The Asset Detail balance graph previously rendered a single skeleton block while loading market data, which did not match the final layout. When data arrived, the header reflowed and the screen visibly jumped.

This PR adapts the loading skeleton to match the Figma design: a small rounded label skeleton above a larger value skeleton, wrapped in a `Box` with consistent spacing. The skeleton now mirrors the loaded layout's footprint, preventing the screen from jumping when market data is loaded.


https://github.com/user-attachments/assets/01ebff5c-b414-468a-81ab-7049703ae406



### ❓ Context

- **JIRA or GitHub link**: [LIVE-31600](https://ledgerhq.atlassian.net/browse/LIVE-31600)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31600]: https://ledgerhq.atlassian.net/browse/LIVE-31600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ