### PR TITLE
[LWM] feat(mobile): add Connect App layer B analytics

### DIFF
--- a/.changeset/connect-app-layer-b-tracking.md
+++ b/.changeset/connect-app-layer-b-tracking.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add Connect App phase (Layer B) Device UX V2 analytics: a `Connect App - *` page event per EnsureAppReady state (with a 250ms dwell gate on loading) and `button_clicked` with canonical values, all carrying `sourceFlow`, `source`, `deviceUxV2` and `modelId`.

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/DeviceContextInitializerComponentLWMView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/DeviceContextInitializerComponentLWMView.tsx
@@ -35,18 +35,19 @@ function assertNever(value: never): never {
 export function DeviceContextInitializerComponentLWMView({
   state,
   device,
+  sourceFlow,
   onCancel,
 }: Readonly<DeviceContextInitializerComponentLWMViewProps>) {
-  const commonProps = { device, onCancel } as const;
+  const commonProps = { device, sourceFlow, onCancel } as const;
 
   return (
     <Box lx={rootStyle}>
       {(() => {
         switch (state.type) {
           case LoadingStateType.Loading:
-            return <LoadingState />;
+            return <LoadingState device={device} sourceFlow={sourceFlow} />;
           case LoadingStateType.InstallingApp:
-            return <InstallingAppState />;
+            return <InstallingAppState device={device} sourceFlow={sourceFlow} />;
           case DeviceInteractionRequiredType.UnlockDevice:
             return <UnlockDeviceState state={state} {...commonProps} />;
           case DeviceInteractionRequiredType.AllowSecureConnection:

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/__tests__/DeviceContextInitializerComponentLWMView.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/__tests__/DeviceContextInitializerComponentLWMView.test.tsx
@@ -20,18 +20,23 @@ const device: InitializerDevice = {
 
 function renderView(state: EnsureAppReadyState) {
   return render(
-    <DeviceContextInitializerComponentLWMView state={state} device={device} onCancel={jest.fn()} />,
+    <DeviceContextInitializerComponentLWMView
+      state={state}
+      device={device}
+      sourceFlow="my_ledger"
+      onCancel={jest.fn()}
+    />,
   );
 }
 
 describe("DeviceContextInitializerComponentLWMView", () => {
-  it("should render the loading state", () => {
+  it("GIVEN the loading state WHEN rendering THEN it renders the loading content", () => {
     renderView({ type: LoadingStateType.Loading });
 
     expect(screen.getByText("Loading")).toBeVisible();
   });
 
-  it("should render the device storage blocking state", () => {
+  it("GIVEN the device storage blocking state WHEN rendering THEN it renders the storage content", () => {
     renderView({
       type: BlockingStateType.DeviceOutOfStorageSpace,
       appNames: ["Ethereum"],
@@ -41,7 +46,7 @@ describe("DeviceContextInitializerComponentLWMView", () => {
     expect(screen.getByText("Go to My Ledger")).toBeVisible();
   });
 
-  it("should render no content for the success state", () => {
+  it("GIVEN the success state WHEN rendering THEN it renders no content", () => {
     const { queryByText } = renderView({
       type: FinalStateType.Success,
       extractedContext: {

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/__tests__/index.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/__tests__/index.test.tsx
@@ -42,6 +42,7 @@ describe("DeviceContextInitializerComponentLWM", () => {
     jest.clearAllMocks();
     mockedUseViewModel.mockReturnValue({
       state: { type: LoadingStateType.Loading },
+      sourceFlow: "my_ledger",
       device: {
         id: "device-id",
         modelId: DeviceModelId.nanoX,

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/__tests__/useDeviceContextInitializerComponentLWMViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/__tests__/useDeviceContextInitializerComponentLWMViewModel.test.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Observable, Subject } from "rxjs";
 import { act, renderHook } from "@tests/test-renderer";
 import type { DeviceConnectionResult } from "@ledgerhq/device-intent";
@@ -13,6 +14,7 @@ import {
 import { ensureAppReadyUseCase } from "@ledgerhq/live-common/device/use-cases/ensureAppReady/ensureAppReadyUseCase";
 import type { State } from "~/reducers/types";
 import { useDeviceContextInitializerComponentLWMViewModel } from "../useDeviceContextInitializerComponentLWMViewModel";
+import { SourceFlowProvider } from "../../utils/SourceFlowContext";
 import type { InitializationInput } from "../../types";
 
 jest.mock("@ledgerhq/live-common/device/use-cases/ensureAppReady/ensureAppReadyUseCase", () => ({
@@ -60,6 +62,9 @@ function withDeprecationDoNotRemind(deprecationDoNotRemind = ["Ethereum"]) {
         deprecationDoNotRemind,
       },
     }),
+    innerWrapper: ({ children }: { children?: React.ReactNode }) => (
+      <SourceFlowProvider value="my_ledger">{children}</SourceFlowProvider>
+    ),
   };
 }
 
@@ -102,6 +107,7 @@ describe("useDeviceContextInitializerComponentLWMViewModel", () => {
         wired: false,
       }),
     );
+    expect(result.current.sourceFlow).toBe("my_ledger");
   });
 
   it("should start ensureAppReadyUseCase with connection, input and dismissed deprecations", () => {

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/AllowSecureConnectionState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/AllowSecureConnectionState.test.tsx
@@ -2,8 +2,20 @@ import React from "react";
 import { render, screen } from "@tests/test-renderer";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { DeviceInteractionRequiredType } from "@ledgerhq/live-dmk-shared";
+import { TrackScreen } from "~/analytics";
+import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import { AllowSecureConnectionState } from "./AllowSecureConnectionState";
 import type { InitializerDevice } from "../types";
+
+jest.mock("~/analytics", () => {
+  const actual = jest.requireActual("~/analytics");
+  return {
+    ...actual,
+    TrackScreen: jest.fn(() => null),
+  };
+});
+
+const mockedTrackScreen = jest.mocked(TrackScreen);
 
 const device: InitializerDevice = {
   id: "device-id",
@@ -13,19 +25,42 @@ const device: InitializerDevice = {
   wired: false,
 };
 
+function renderState() {
+  return render(
+    <AllowSecureConnectionState
+      state={{ type: DeviceInteractionRequiredType.AllowSecureConnection }}
+      device={device}
+      sourceFlow="my_ledger"
+      onCancel={jest.fn()}
+    />,
+  );
+}
+
 describe("AllowSecureConnectionState", () => {
-  it("should render the pending action title and description", () => {
-    render(
-      <AllowSecureConnectionState
-        state={{ type: DeviceInteractionRequiredType.AllowSecureConnection }}
-        device={device}
-        onCancel={jest.fn()}
-      />,
-    );
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("GIVEN the allow secure connection state WHEN rendering THEN it renders the pending action copy", () => {
+    renderState();
 
     expect(screen.getByText("Continue on your Ledger Flex")).toBeVisible();
     expect(
       screen.getByText(/Follow the instructions displayed on your Secure.Screen/),
     ).toBeVisible();
+  });
+
+  it("GIVEN the allow secure connection state WHEN rendering THEN it fires the page event with sourceFlow and modelId", () => {
+    renderState();
+
+    expect(mockedTrackScreen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: PAGE_CONNECT_APP.AllowSecureConnection,
+        sourceFlow: "my_ledger",
+        modelId: DeviceModelId.europa,
+        deviceUxV2: true,
+      }),
+      undefined,
+    );
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/AllowSecureConnectionState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/AllowSecureConnectionState.tsx
@@ -1,18 +1,28 @@
 import React from "react";
 import { DeviceInteractionRequiredType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
 import { ContinueOnDevice } from "LLM/components/DeviceIntentExecutor/components/DeviceGenericStates/ContinueOnDevice";
+import { TrackScreen } from "~/analytics";
+import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import type { BaseInitializerStateProps } from "../types";
 
 type AllowSecureConnectionStateProps = BaseInitializerStateProps<
   Extract<EnsureAppReadyState, { type: DeviceInteractionRequiredType.AllowSecureConnection }>
 >;
 
-export function AllowSecureConnectionState({ device }: AllowSecureConnectionStateProps) {
+export function AllowSecureConnectionState({ device, sourceFlow }: AllowSecureConnectionStateProps) {
   return (
-    <ContinueOnDevice
-      deviceModelId={device.modelId}
-      deviceName={device.name}
-      testID="device-initializer-allow-secure-connection"
-    />
+    <>
+      <TrackScreen
+        category={PAGE_CONNECT_APP.AllowSecureConnection}
+        sourceFlow={sourceFlow}
+        modelId={device.modelId}
+        deviceUxV2
+      />
+      <ContinueOnDevice
+        deviceModelId={device.modelId}
+        deviceName={device.name}
+        testID="device-initializer-allow-secure-connection"
+      />
+    </>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/ConfirmOpenAppState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/ConfirmOpenAppState.test.tsx
@@ -2,8 +2,20 @@ import React from "react";
 import { render, screen } from "@tests/test-renderer";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { DeviceInteractionRequiredType } from "@ledgerhq/live-dmk-shared";
+import { TrackScreen } from "~/analytics";
+import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import { ConfirmOpenAppState } from "./ConfirmOpenAppState";
 import type { InitializerDevice } from "../types";
+
+jest.mock("~/analytics", () => {
+  const actual = jest.requireActual("~/analytics");
+  return {
+    ...actual,
+    TrackScreen: jest.fn(() => null),
+  };
+});
+
+const mockedTrackScreen = jest.mocked(TrackScreen);
 
 const device: InitializerDevice = {
   id: "device-id",
@@ -13,19 +25,42 @@ const device: InitializerDevice = {
   wired: false,
 };
 
+function renderState() {
+  return render(
+    <ConfirmOpenAppState
+      state={{ type: DeviceInteractionRequiredType.ConfirmOpenApp }}
+      device={device}
+      sourceFlow="my_ledger"
+      onCancel={jest.fn()}
+    />,
+  );
+}
+
 describe("ConfirmOpenAppState", () => {
-  it("should render the pending action title and description", () => {
-    render(
-      <ConfirmOpenAppState
-        state={{ type: DeviceInteractionRequiredType.ConfirmOpenApp }}
-        device={device}
-        onCancel={jest.fn()}
-      />,
-    );
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("GIVEN the confirm open app state WHEN rendering THEN it renders the pending action copy", () => {
+    renderState();
 
     expect(screen.getByText("Continue on your Ledger Flex")).toBeVisible();
     expect(
       screen.getByText(/Follow the instructions displayed on your Secure.Screen/),
     ).toBeVisible();
+  });
+
+  it("GIVEN the confirm open app state WHEN rendering THEN it fires the page event with sourceFlow and modelId", () => {
+    renderState();
+
+    expect(mockedTrackScreen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: PAGE_CONNECT_APP.ConfirmOpenApp,
+        sourceFlow: "my_ledger",
+        modelId: DeviceModelId.europa,
+        deviceUxV2: true,
+      }),
+      undefined,
+    );
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/ConfirmOpenAppState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/ConfirmOpenAppState.tsx
@@ -1,18 +1,28 @@
 import React from "react";
 import { DeviceInteractionRequiredType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
 import { ContinueOnDevice } from "LLM/components/DeviceIntentExecutor/components/DeviceGenericStates/ContinueOnDevice";
+import { TrackScreen } from "~/analytics";
+import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import type { BaseInitializerStateProps } from "../types";
 
 type ConfirmOpenAppStateProps = BaseInitializerStateProps<
   Extract<EnsureAppReadyState, { type: DeviceInteractionRequiredType.ConfirmOpenApp }>
 >;
 
-export function ConfirmOpenAppState({ device }: ConfirmOpenAppStateProps) {
+export function ConfirmOpenAppState({ device, sourceFlow }: ConfirmOpenAppStateProps) {
   return (
-    <ContinueOnDevice
-      deviceModelId={device.modelId}
-      deviceName={device.name}
-      testID="device-initializer-confirm-open-app"
-    />
+    <>
+      <TrackScreen
+        category={PAGE_CONNECT_APP.ConfirmOpenApp}
+        sourceFlow={sourceFlow}
+        modelId={device.modelId}
+        deviceUxV2
+      />
+      <ContinueOnDevice
+        deviceModelId={device.modelId}
+        deviceName={device.name}
+        testID="device-initializer-confirm-open-app"
+      />
+    </>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceBusyState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceBusyState.test.tsx
@@ -2,8 +2,24 @@ import React from "react";
 import { render, screen } from "@tests/test-renderer";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { RetryableStateType } from "@ledgerhq/live-dmk-shared";
+import { TrackScreen, track } from "~/analytics";
+import { previousRouteNameRef } from "~/analytics/screenRefs";
+import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import { DeviceBusyState } from "./DeviceBusyState";
 import type { InitializerDevice } from "../types";
+
+jest.mock("~/analytics", () => {
+  const actual = jest.requireActual("~/analytics");
+  return {
+    ...actual,
+    TrackScreen: jest.fn(() => null),
+    track: jest.fn(),
+  };
+});
+
+const mockedTrackScreen = jest.mocked(TrackScreen);
+const mockedTrack = jest.mocked(track);
+const TEST_SOURCE = "Portfolio";
 
 const device: InitializerDevice = {
   id: "device-id",
@@ -22,6 +38,7 @@ function renderState() {
       <DeviceBusyState
         state={{ type: RetryableStateType.DeviceBusy, retry }}
         device={device}
+        sourceFlow="my_ledger"
         onCancel={onCancel}
       />,
     ),
@@ -31,7 +48,12 @@ function renderState() {
 }
 
 describe("DeviceBusyState", () => {
-  it("should render the device busy title, description and action buttons", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    previousRouteNameRef.current = TEST_SOURCE;
+  });
+
+  it("GIVEN the device busy state WHEN rendering THEN it renders the title, description and action buttons", () => {
     renderState();
 
     expect(screen.getByText("Action pending on your Ledger device")).toBeVisible();
@@ -40,7 +62,7 @@ describe("DeviceBusyState", () => {
     expect(screen.getByText("Cancel operation")).toBeVisible();
   });
 
-  it("should call retry and onCancel when action buttons are pressed", async () => {
+  it("GIVEN the device busy state WHEN pressing the action buttons THEN it calls retry and onCancel", async () => {
     const { user, retry, onCancel } = renderState();
 
     await user.press(screen.getByText("Retry"));
@@ -48,5 +70,47 @@ describe("DeviceBusyState", () => {
 
     expect(retry).toHaveBeenCalledTimes(1);
     expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("GIVEN the device busy state WHEN rendering THEN it fires the page event with sourceFlow and modelId", () => {
+    renderState();
+
+    expect(mockedTrackScreen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: PAGE_CONNECT_APP.DeviceBusy,
+        sourceFlow: "my_ledger",
+        modelId: DeviceModelId.europa,
+        deviceUxV2: true,
+      }),
+      undefined,
+    );
+  });
+
+  it("GIVEN the device busy state WHEN pressing Retry THEN it tracks the canonical button value", async () => {
+    const { user } = renderState();
+
+    await user.press(screen.getByText("Retry"));
+
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      deviceUxV2: true,
+      modelId: DeviceModelId.europa,
+      button: "Retry",
+    });
+  });
+
+  it("GIVEN the device busy state WHEN pressing Cancel operation THEN it tracks the canonical button value", async () => {
+    const { user } = renderState();
+
+    await user.press(screen.getByText("Cancel operation"));
+
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      deviceUxV2: true,
+      modelId: DeviceModelId.europa,
+      button: "Cancel",
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceBusyState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceBusyState.tsx
@@ -2,30 +2,55 @@ import React from "react";
 import { RetryableStateType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
 import { Trans } from "~/context/Locale";
 import { InfoState } from "LLM/components/InfoState";
+import { TrackScreen } from "~/analytics";
+import {
+  CONNECT_APP_BUTTON,
+  PAGE_CONNECT_APP,
+  trackConnectAppButtonClicked,
+} from "../../utils/trackDeviceIntent";
 import type { BaseInitializerStateProps } from "../types";
 
 type DeviceBusyStateProps = BaseInitializerStateProps<
   Extract<EnsureAppReadyState, { type: RetryableStateType.DeviceBusy }>
 >;
 
-export function DeviceBusyState({ state, onCancel }: DeviceBusyStateProps) {
+export function DeviceBusyState({ state, device, sourceFlow, onCancel }: DeviceBusyStateProps) {
+  const modelId = device.modelId;
+
+  const handleRetry = () => {
+    trackConnectAppButtonClicked({ sourceFlow, modelId, button: CONNECT_APP_BUTTON.Retry });
+    state.retry();
+  };
+  const handleCancel = () => {
+    trackConnectAppButtonClicked({ sourceFlow, modelId, button: CONNECT_APP_BUTTON.Cancel });
+    onCancel();
+  };
+
   return (
-    <InfoState
-      preset="info"
-      size="hug"
-      title={<Trans i18nKey="deviceIntentExecutor.initialization.retryable.deviceBusy.title" />}
-      description={
-        <Trans i18nKey="deviceIntentExecutor.initialization.retryable.deviceBusy.description" />
-      }
-      primaryCta={{
-        label: <Trans i18nKey="common.retry" />,
-        onPress: state.retry,
-      }}
-      secondaryCta={{
-        label: <Trans i18nKey="deviceIntentExecutor.initialization.cta.cancelOperation" />,
-        onPress: onCancel,
-      }}
-      testID="device-initializer-device-busy"
-    />
+    <>
+      <TrackScreen
+        category={PAGE_CONNECT_APP.DeviceBusy}
+        sourceFlow={sourceFlow}
+        modelId={modelId}
+        deviceUxV2
+      />
+      <InfoState
+        preset="info"
+        size="hug"
+        title={<Trans i18nKey="deviceIntentExecutor.initialization.retryable.deviceBusy.title" />}
+        description={
+          <Trans i18nKey="deviceIntentExecutor.initialization.retryable.deviceBusy.description" />
+        }
+        primaryCta={{
+          label: <Trans i18nKey="common.retry" />,
+          onPress: handleRetry,
+        }}
+        secondaryCta={{
+          label: <Trans i18nKey="deviceIntentExecutor.initialization.cta.cancelOperation" />,
+          onPress: handleCancel,
+        }}
+        testID="device-initializer-device-busy"
+      />
+    </>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceDeprecatedBlockingState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceDeprecatedBlockingState.test.tsx
@@ -1,14 +1,24 @@
 import React from "react";
-import { render, screen } from "@tests/test-renderer";
+import { render } from "@tests/test-renderer";
 import { getDeviceModel } from "@ledgerhq/devices";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { BlockingStateType } from "@ledgerhq/live-dmk-shared";
+import { TrackScreen } from "~/analytics";
 import { DeviceDeprecatedBlockingState } from "./DeviceDeprecatedBlockingState";
 import {
   DeviceDeprecationScreen,
   DeviceDeprecationScreens,
 } from "~/components/DeviceAction/Screen/DeviceDeprecationScreen";
+import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import type { InitializerDevice } from "../types";
+
+jest.mock("~/analytics", () => {
+  const actual = jest.requireActual("~/analytics");
+  return {
+    ...actual,
+    TrackScreen: jest.fn(() => null),
+  };
+});
 
 jest.mock("~/components/DeviceAction/Screen/DeviceDeprecationScreen", () => {
   const actual = jest.requireActual("~/components/DeviceAction/Screen/DeviceDeprecationScreen");
@@ -18,6 +28,7 @@ jest.mock("~/components/DeviceAction/Screen/DeviceDeprecationScreen", () => {
   };
 });
 
+const mockedTrackScreen = jest.mocked(TrackScreen);
 const mockedDeviceDeprecationScreen = jest.mocked(DeviceDeprecationScreen);
 
 const device: InitializerDevice = {
@@ -30,27 +41,32 @@ const device: InitializerDevice = {
 
 const supportEndDate = new Date("2026-01-01T00:00:00Z");
 
+function renderState() {
+  return render(
+    <DeviceDeprecatedBlockingState
+      state={{
+        type: BlockingStateType.DeviceDeprecatedBlocking,
+        decision: {
+          status: "block",
+          currencyName: "Bitcoin",
+          deviceModelId: DeviceModelId.nanoS,
+          supportEndDate,
+        },
+      }}
+      device={device}
+      sourceFlow="my_ledger"
+      onCancel={jest.fn()}
+    />,
+  );
+}
+
 describe("DeviceDeprecatedBlockingState", () => {
   beforeEach(() => {
-    mockedDeviceDeprecationScreen.mockClear();
+    jest.clearAllMocks();
   });
 
-  it("should render the deprecation error screen with the decision details", () => {
-    render(
-      <DeviceDeprecatedBlockingState
-        state={{
-          type: BlockingStateType.DeviceDeprecatedBlocking,
-          decision: {
-            status: "block",
-            currencyName: "Bitcoin",
-            deviceModelId: DeviceModelId.nanoS,
-            supportEndDate,
-          },
-        }}
-        device={device}
-        onCancel={jest.fn()}
-      />,
-    );
+  it("GIVEN the blocking deprecation state WHEN rendering THEN it renders the error screen with the decision details", () => {
+    renderState();
 
     expect(mockedDeviceDeprecationScreen).toHaveBeenCalledTimes(1);
     expect(mockedDeviceDeprecationScreen.mock.calls[0][0]).toEqual(
@@ -61,6 +77,19 @@ describe("DeviceDeprecatedBlockingState", () => {
         screenName: DeviceDeprecationScreens.errorScreen,
       }),
     );
-    expect(screen.toJSON()).toBeNull();
+  });
+
+  it("GIVEN the blocking deprecation state WHEN rendering THEN it fires the page event with sourceFlow and modelId", () => {
+    renderState();
+
+    expect(mockedTrackScreen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: PAGE_CONNECT_APP.DeviceDeprecatedBlocking,
+        sourceFlow: "my_ledger",
+        modelId: DeviceModelId.europa,
+        deviceUxV2: true,
+      }),
+      undefined,
+    );
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceDeprecatedBlockingState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceDeprecatedBlockingState.tsx
@@ -5,22 +5,36 @@ import {
   DeviceDeprecationScreen,
   DeviceDeprecationScreens,
 } from "~/components/DeviceAction/Screen/DeviceDeprecationScreen";
+import { TrackScreen } from "~/analytics";
+import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import type { BaseInitializerStateProps } from "../types";
 
 type DeviceDeprecatedBlockingStateProps = BaseInitializerStateProps<
   Extract<EnsureAppReadyState, { type: BlockingStateType.DeviceDeprecatedBlocking }>
 >;
 
-export function DeviceDeprecatedBlockingState({ state }: DeviceDeprecatedBlockingStateProps) {
+export function DeviceDeprecatedBlockingState({
+  state,
+  device,
+  sourceFlow,
+}: DeviceDeprecatedBlockingStateProps) {
   const { decision } = state;
 
   return (
-    <DeviceDeprecationScreen
-      coinName={decision.currencyName}
-      date={decision.supportEndDate}
-      onContinue={() => undefined}
-      productName={getDeviceModel(decision.deviceModelId).productName}
-      screenName={DeviceDeprecationScreens.errorScreen}
-    />
+    <>
+      <TrackScreen
+        category={PAGE_CONNECT_APP.DeviceDeprecatedBlocking}
+        sourceFlow={sourceFlow}
+        modelId={device.modelId}
+        deviceUxV2
+      />
+      <DeviceDeprecationScreen
+        coinName={decision.currencyName}
+        date={decision.supportEndDate}
+        onContinue={() => undefined}
+        productName={getDeviceModel(decision.deviceModelId).productName}
+        screenName={DeviceDeprecationScreens.errorScreen}
+      />
+    </>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceDeprecatedNonBlockingState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceDeprecatedNonBlockingState.test.tsx
@@ -6,12 +6,24 @@ import {
   AppInteractionRequiredStateType,
   type DeprecationScreenKind,
 } from "@ledgerhq/live-dmk-shared";
+import { TrackScreen, track } from "~/analytics";
+import { previousRouteNameRef } from "~/analytics/screenRefs";
 import { DeviceDeprecatedNonBlockingState } from "./DeviceDeprecatedNonBlockingState";
 import {
   DeviceDeprecationScreen,
   DeviceDeprecationScreens,
 } from "~/components/DeviceAction/Screen/DeviceDeprecationScreen";
+import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import type { InitializerDevice } from "../types";
+
+jest.mock("~/analytics", () => {
+  const actual = jest.requireActual("~/analytics");
+  return {
+    ...actual,
+    TrackScreen: jest.fn(() => null),
+    track: jest.fn(),
+  };
+});
 
 jest.mock("~/components/DeviceAction/Screen/DeviceDeprecationScreen", () => {
   const actual = jest.requireActual("~/components/DeviceAction/Screen/DeviceDeprecationScreen");
@@ -21,7 +33,10 @@ jest.mock("~/components/DeviceAction/Screen/DeviceDeprecationScreen", () => {
   };
 });
 
+const mockedTrackScreen = jest.mocked(TrackScreen);
+const mockedTrack = jest.mocked(track);
 const mockedDeviceDeprecationScreen = jest.mocked(DeviceDeprecationScreen);
+const TEST_SOURCE = "Portfolio";
 
 const device: InitializerDevice = {
   id: "device-id",
@@ -49,6 +64,7 @@ function renderState(screenSequence: DeprecationScreenKind[]) {
         onContinue,
       }}
       device={device}
+      sourceFlow="my_ledger"
       onCancel={jest.fn()}
     />,
   );
@@ -89,20 +105,20 @@ const screenSequenceCases: {
 
 describe("DeviceDeprecatedNonBlockingState", () => {
   beforeEach(() => {
-    mockedDeviceDeprecationScreen.mockClear();
+    jest.clearAllMocks();
+    previousRouteNameRef.current = TEST_SOURCE;
   });
 
   it.each(screenSequenceCases)(
-    "should render the deprecation screen for sequence: $name",
+    "GIVEN the $name screen sequence WHEN rendering THEN it renders the matching deprecation screen",
     ({ screenSequence, expectedScreenName, expectedDisplayClearSigningWarning }) => {
-      const { onContinue } = renderState(screenSequence);
+      renderState(screenSequence);
 
       expect(mockedDeviceDeprecationScreen).toHaveBeenCalledTimes(1);
       expect(mockedDeviceDeprecationScreen.mock.calls[0][0]).toEqual(
         expect.objectContaining({
           coinName: "Bitcoin",
           date: supportEndDate,
-          onContinue,
           productName: getDeviceModel(DeviceModelId.nanoS).productName,
           screenName: expectedScreenName,
           displayClearSigningWarning: expectedDisplayClearSigningWarning,
@@ -110,4 +126,33 @@ describe("DeviceDeprecatedNonBlockingState", () => {
       );
     },
   );
+
+  it("GIVEN the non-blocking deprecation state WHEN rendering THEN it fires the page event with sourceFlow and modelId", () => {
+    renderState(["warning"]);
+
+    expect(mockedTrackScreen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: PAGE_CONNECT_APP.DeviceDeprecatedWarning,
+        sourceFlow: "my_ledger",
+        modelId: DeviceModelId.europa,
+        deviceUxV2: true,
+      }),
+      undefined,
+    );
+  });
+
+  it("GIVEN the non-blocking deprecation state WHEN invoking continue THEN it tracks Continue and forwards to onContinue", () => {
+    const { onContinue } = renderState(["warning"]);
+
+    mockedDeviceDeprecationScreen.mock.calls[0][0].onContinue?.();
+
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      deviceUxV2: true,
+      modelId: DeviceModelId.europa,
+      button: "Continue",
+    });
+    expect(onContinue).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceDeprecatedNonBlockingState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceDeprecatedNonBlockingState.tsx
@@ -8,6 +8,12 @@ import {
   DeviceDeprecationScreen,
   DeviceDeprecationScreens,
 } from "~/components/DeviceAction/Screen/DeviceDeprecationScreen";
+import { TrackScreen } from "~/analytics";
+import {
+  CONNECT_APP_BUTTON,
+  PAGE_CONNECT_APP,
+  trackConnectAppButtonClicked,
+} from "../../utils/trackDeviceIntent";
 import type { BaseInitializerStateProps } from "../types";
 
 type DeviceDeprecatedNonBlockingStateProps = BaseInitializerStateProps<
@@ -17,22 +23,40 @@ type DeviceDeprecatedNonBlockingStateProps = BaseInitializerStateProps<
   >
 >;
 
-export function DeviceDeprecatedNonBlockingState({ state }: DeviceDeprecatedNonBlockingStateProps) {
+export function DeviceDeprecatedNonBlockingState({
+  state,
+  device,
+  sourceFlow,
+}: DeviceDeprecatedNonBlockingStateProps) {
   const { decision, onContinue } = state;
+  const modelId = device.modelId;
   const displayClearSigningWarning = decision.screenSequence.includes("clearSigning");
 
+  const handleContinue = () => {
+    trackConnectAppButtonClicked({ sourceFlow, modelId, button: CONNECT_APP_BUTTON.Continue });
+    onContinue();
+  };
+
   return (
-    <DeviceDeprecationScreen
-      coinName={decision.currencyName}
-      date={decision.supportEndDate}
-      onContinue={onContinue}
-      productName={getDeviceModel(decision.deviceModelId).productName}
-      screenName={
-        decision.screenSequence.includes("warning")
-          ? DeviceDeprecationScreens.warningScreen
-          : DeviceDeprecationScreens.clearSigningScreen
-      }
-      displayClearSigningWarning={displayClearSigningWarning}
-    />
+    <>
+      <TrackScreen
+        category={PAGE_CONNECT_APP.DeviceDeprecatedWarning}
+        sourceFlow={sourceFlow}
+        modelId={modelId}
+        deviceUxV2
+      />
+      <DeviceDeprecationScreen
+        coinName={decision.currencyName}
+        date={decision.supportEndDate}
+        onContinue={handleContinue}
+        productName={getDeviceModel(decision.deviceModelId).productName}
+        screenName={
+          decision.screenSequence.includes("warning")
+            ? DeviceDeprecationScreens.warningScreen
+            : DeviceDeprecationScreens.clearSigningScreen
+        }
+        displayClearSigningWarning={displayClearSigningWarning}
+      />
+    </>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceNotOnboarded/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceNotOnboarded/index.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { BlockingStateType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
+import { TrackScreen } from "~/analytics";
+import { PAGE_CONNECT_APP } from "../../../utils/trackDeviceIntent";
 import type { BaseInitializerStateProps } from "../../types";
 import { DeviceNotOnboardedView } from "./DeviceNotOnboardedView";
 import { useDeviceNotOnboardedViewModel } from "./useDeviceNotOnboardedViewModel";
@@ -8,7 +10,17 @@ type DeviceNotOnboardedProps = BaseInitializerStateProps<
   Extract<EnsureAppReadyState, { type: BlockingStateType.DeviceNotOnboarded }>
 >;
 
-export function DeviceNotOnboarded({ device }: DeviceNotOnboardedProps) {
-  const viewModel = useDeviceNotOnboardedViewModel({ device });
-  return <DeviceNotOnboardedView {...viewModel} />;
+export function DeviceNotOnboarded({ device, sourceFlow }: DeviceNotOnboardedProps) {
+  const viewModel = useDeviceNotOnboardedViewModel({ device, sourceFlow });
+  return (
+    <>
+      <TrackScreen
+        category={PAGE_CONNECT_APP.DeviceNotOnboarded}
+        sourceFlow={sourceFlow}
+        modelId={device.modelId}
+        deviceUxV2
+      />
+      <DeviceNotOnboardedView {...viewModel} />
+    </>
+  );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceNotOnboarded/useDeviceNotOnboardedViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceNotOnboarded/useDeviceNotOnboardedViewModel.test.tsx
@@ -1,0 +1,75 @@
+import { act, renderHook } from "@tests/test-renderer";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { track } from "~/analytics";
+import { previousRouteNameRef } from "~/analytics/screenRefs";
+import { useInitializerActions } from "../../hooks/useInitializerActions";
+import { useDeviceNotOnboardedViewModel } from "./useDeviceNotOnboardedViewModel";
+import type { InitializerDevice } from "../../types";
+
+jest.mock("~/analytics", () => {
+  const actual = jest.requireActual("~/analytics");
+  return {
+    ...actual,
+    track: jest.fn(),
+  };
+});
+
+jest.mock("../../hooks/useInitializerActions");
+
+const mockedTrack = jest.mocked(track);
+const mockedUseInitializerActions = jest.mocked(useInitializerActions);
+const TEST_SOURCE = "Portfolio";
+const SOURCE_FLOW = "my_ledger";
+const openOnboarding = jest.fn();
+
+const device: InitializerDevice = {
+  id: "device-id",
+  modelId: DeviceModelId.europa,
+  name: "Lily's Ledger",
+  productName: "Flex",
+  wired: false,
+};
+
+describe("useDeviceNotOnboardedViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    previousRouteNameRef.current = TEST_SOURCE;
+    mockedUseInitializerActions.mockReturnValue({
+      openMyLedger: jest.fn(),
+      openMyLedgerFirmwareUpdate: jest.fn(),
+      openOnboarding,
+      openSupport: jest.fn(),
+    });
+  });
+
+  it("GIVEN a device WHEN rendering THEN it exposes the view props", () => {
+    const { result } = renderHook(() =>
+      useDeviceNotOnboardedViewModel({ device, sourceFlow: SOURCE_FLOW }),
+    );
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        productName: "Flex",
+      }),
+    );
+  });
+
+  it("GIVEN a device WHEN invoking setup device THEN it tracks Set Up Device and opens onboarding", () => {
+    const { result } = renderHook(() =>
+      useDeviceNotOnboardedViewModel({ device, sourceFlow: SOURCE_FLOW }),
+    );
+
+    act(() => {
+      result.current.onSetupDevice();
+    });
+
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      deviceUxV2: true,
+      modelId: DeviceModelId.europa,
+      button: "Set Up Device",
+    });
+    expect(openOnboarding).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceNotOnboarded/useDeviceNotOnboardedViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceNotOnboarded/useDeviceNotOnboardedViewModel.ts
@@ -1,15 +1,25 @@
+import { useCallback } from "react";
 import type { InitializerDevice } from "../../types";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
+import type { SourceFlow } from "../../../utils/SourceFlowContext";
+import { CONNECT_APP_BUTTON, trackConnectAppButtonClicked } from "../../../utils/trackDeviceIntent";
 
 type Params = Readonly<{
   device: InitializerDevice;
+  sourceFlow: SourceFlow;
 }>;
 
-export function useDeviceNotOnboardedViewModel({ device }: Params) {
+export function useDeviceNotOnboardedViewModel({ device, sourceFlow }: Params) {
   const { openOnboarding } = useInitializerActions(device);
+  const modelId = device.modelId;
+
+  const onSetupDevice = useCallback(() => {
+    trackConnectAppButtonClicked({ sourceFlow, modelId, button: CONNECT_APP_BUTTON.SetUpDevice });
+    openOnboarding();
+  }, [openOnboarding, sourceFlow, modelId]);
 
   return {
     productName: device.productName,
-    onSetupDevice: openOnboarding,
+    onSetupDevice,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceOutOfStorageSpace/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceOutOfStorageSpace/index.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { BlockingStateType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
+import { TrackScreen } from "~/analytics";
+import { PAGE_CONNECT_APP } from "../../../utils/trackDeviceIntent";
 import type { BaseInitializerStateProps } from "../../types";
 import { DeviceOutOfStorageSpaceView } from "./DeviceOutOfStorageSpaceView";
 import { useDeviceOutOfStorageSpaceViewModel } from "./useDeviceOutOfStorageSpaceViewModel";
@@ -8,7 +10,25 @@ type DeviceOutOfStorageSpaceProps = BaseInitializerStateProps<
   Extract<EnsureAppReadyState, { type: BlockingStateType.DeviceOutOfStorageSpace }>
 >;
 
-export function DeviceOutOfStorageSpace({ state, device }: DeviceOutOfStorageSpaceProps) {
-  const viewModel = useDeviceOutOfStorageSpaceViewModel({ state, device });
-  return <DeviceOutOfStorageSpaceView {...viewModel} />;
+export function DeviceOutOfStorageSpace({
+  state,
+  device,
+  sourceFlow,
+}: DeviceOutOfStorageSpaceProps) {
+  const viewModel = useDeviceOutOfStorageSpaceViewModel({
+    state,
+    device,
+    sourceFlow,
+  });
+  return (
+    <>
+      <TrackScreen
+        category={PAGE_CONNECT_APP.OutOfStorage}
+        sourceFlow={sourceFlow}
+        modelId={device.modelId}
+        deviceUxV2
+      />
+      <DeviceOutOfStorageSpaceView {...viewModel} />
+    </>
+  );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceOutOfStorageSpace/useDeviceOutOfStorageSpaceViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceOutOfStorageSpace/useDeviceOutOfStorageSpaceViewModel.test.tsx
@@ -1,0 +1,84 @@
+import { act, renderHook } from "@tests/test-renderer";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { BlockingStateType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
+import { track } from "~/analytics";
+import { previousRouteNameRef } from "~/analytics/screenRefs";
+import { useInitializerActions } from "../../hooks/useInitializerActions";
+import { useDeviceOutOfStorageSpaceViewModel } from "./useDeviceOutOfStorageSpaceViewModel";
+import type { InitializerDevice } from "../../types";
+
+jest.mock("~/analytics", () => {
+  const actual = jest.requireActual("~/analytics");
+  return {
+    ...actual,
+    track: jest.fn(),
+  };
+});
+
+jest.mock("../../hooks/useInitializerActions");
+
+const mockedTrack = jest.mocked(track);
+const mockedUseInitializerActions = jest.mocked(useInitializerActions);
+const TEST_SOURCE = "Portfolio";
+const SOURCE_FLOW = "my_ledger";
+const openMyLedger = jest.fn();
+
+const device: InitializerDevice = {
+  id: "device-id",
+  modelId: DeviceModelId.europa,
+  name: "Lily's Ledger",
+  productName: "Flex",
+  wired: false,
+};
+
+const state = {
+  type: BlockingStateType.DeviceOutOfStorageSpace,
+  appNames: ["Ethereum", "Bitcoin"],
+} satisfies Extract<
+  EnsureAppReadyState,
+  { type: BlockingStateType.DeviceOutOfStorageSpace }
+>;
+
+describe("useDeviceOutOfStorageSpaceViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    previousRouteNameRef.current = TEST_SOURCE;
+    mockedUseInitializerActions.mockReturnValue({
+      openMyLedger,
+      openMyLedgerFirmwareUpdate: jest.fn(),
+      openOnboarding: jest.fn(),
+      openSupport: jest.fn(),
+    });
+  });
+
+  it("GIVEN a device WHEN rendering THEN it exposes the view handlers", () => {
+    const { result } = renderHook(() =>
+      useDeviceOutOfStorageSpaceViewModel({ state, device, sourceFlow: SOURCE_FLOW }),
+    );
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        onOpenMyLedger: expect.any(Function),
+      }),
+    );
+  });
+
+  it("GIVEN missing apps WHEN opening My Ledger THEN it tracks Manage Apps and forwards the app search query", () => {
+    const { result } = renderHook(() =>
+      useDeviceOutOfStorageSpaceViewModel({ state, device, sourceFlow: SOURCE_FLOW }),
+    );
+
+    act(() => {
+      result.current.onOpenMyLedger();
+    });
+
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      deviceUxV2: true,
+      modelId: DeviceModelId.europa,
+      button: "Manage Apps",
+    });
+    expect(openMyLedger).toHaveBeenCalledWith("Ethereum, Bitcoin");
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceOutOfStorageSpace/useDeviceOutOfStorageSpaceViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceOutOfStorageSpace/useDeviceOutOfStorageSpaceViewModel.ts
@@ -2,6 +2,8 @@ import { useMemo, useCallback } from "react";
 import type { BlockingStateType, EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
 import type { InitializerDevice } from "../../types";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
+import type { SourceFlow } from "../../../utils/SourceFlowContext";
+import { CONNECT_APP_BUTTON, trackConnectAppButtonClicked } from "../../../utils/trackDeviceIntent";
 
 type DeviceOutOfStorageSpaceState = Extract<
   EnsureAppReadyState,
@@ -11,12 +13,17 @@ type DeviceOutOfStorageSpaceState = Extract<
 type Params = Readonly<{
   state: DeviceOutOfStorageSpaceState;
   device: InitializerDevice;
+  sourceFlow: SourceFlow;
 }>;
 
-export function useDeviceOutOfStorageSpaceViewModel({ state, device }: Params) {
+export function useDeviceOutOfStorageSpaceViewModel({ state, device, sourceFlow }: Params) {
   const { openMyLedger } = useInitializerActions(device);
+  const modelId = device.modelId;
   const searchQuery = useMemo(() => state.appNames.join(", "), [state.appNames]);
-  const onOpenMyLedger = useCallback(() => openMyLedger(searchQuery), [openMyLedger, searchQuery]);
+  const onOpenMyLedger = useCallback(() => {
+    trackConnectAppButtonClicked({ sourceFlow, modelId, button: CONNECT_APP_BUTTON.ManageApps });
+    openMyLedger(searchQuery);
+  }, [openMyLedger, searchQuery, sourceFlow, modelId]);
 
   return {
     onOpenMyLedger,

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/FinalError/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/FinalError/index.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { FinalStateType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
+import { TrackScreen } from "~/analytics";
+import { PAGE_CONNECT_APP } from "../../../utils/trackDeviceIntent";
 import type { BaseInitializerStateProps } from "../../types";
 import { FinalErrorView } from "./FinalErrorView";
 import { useFinalErrorViewModel } from "./useFinalErrorViewModel";
@@ -8,7 +10,17 @@ type FinalErrorProps = BaseInitializerStateProps<
   Extract<EnsureAppReadyState, { type: FinalStateType.Error }>
 >;
 
-export function FinalError({ state, device, onCancel }: FinalErrorProps) {
-  const viewModel = useFinalErrorViewModel({ state, device, onCancel });
-  return <FinalErrorView {...viewModel} />;
+export function FinalError({ state, device, sourceFlow, onCancel }: FinalErrorProps) {
+  const viewModel = useFinalErrorViewModel({ state, device, sourceFlow, onCancel });
+  return (
+    <>
+      <TrackScreen
+        category={PAGE_CONNECT_APP.Error}
+        sourceFlow={sourceFlow}
+        modelId={device.modelId}
+        deviceUxV2
+      />
+      <FinalErrorView {...viewModel} />
+    </>
+  );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/FinalError/useFinalErrorViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/FinalError/useFinalErrorViewModel.test.tsx
@@ -1,0 +1,102 @@
+import { act, renderHook } from "@tests/test-renderer";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { FinalStateType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
+import { track } from "~/analytics";
+import { previousRouteNameRef } from "~/analytics/screenRefs";
+import { useInitializerActions } from "../../hooks/useInitializerActions";
+import { useFinalErrorViewModel } from "./useFinalErrorViewModel";
+import type { InitializerDevice } from "../../types";
+
+jest.mock("~/analytics", () => {
+  const actual = jest.requireActual("~/analytics");
+  return {
+    ...actual,
+    track: jest.fn(),
+  };
+});
+
+jest.mock("../../hooks/useInitializerActions");
+
+const mockedTrack = jest.mocked(track);
+const mockedUseInitializerActions = jest.mocked(useInitializerActions);
+const TEST_SOURCE = "Portfolio";
+const SOURCE_FLOW = "my_ledger";
+const openSupport = jest.fn();
+const onCancel = jest.fn();
+
+const device: InitializerDevice = {
+  id: "device-id",
+  modelId: DeviceModelId.europa,
+  name: "Lily's Ledger",
+  productName: "Flex",
+  wired: false,
+};
+
+const error = new Error("boom");
+const state = {
+  type: FinalStateType.Error,
+  error,
+} satisfies Extract<EnsureAppReadyState, { type: FinalStateType.Error }>;
+
+describe("useFinalErrorViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    previousRouteNameRef.current = TEST_SOURCE;
+    mockedUseInitializerActions.mockReturnValue({
+      openMyLedger: jest.fn(),
+      openMyLedgerFirmwareUpdate: jest.fn(),
+      openOnboarding: jest.fn(),
+      openSupport,
+    });
+  });
+
+  it("GIVEN an error WHEN rendering THEN it exposes the view props", () => {
+    const { result } = renderHook(() =>
+      useFinalErrorViewModel({ state, device, sourceFlow: SOURCE_FLOW, onCancel }),
+    );
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        error,
+      }),
+    );
+  });
+
+  it("GIVEN an error WHEN contacting support THEN it tracks Contact Ledger Support and opens support", () => {
+    const { result } = renderHook(() =>
+      useFinalErrorViewModel({ state, device, sourceFlow: SOURCE_FLOW, onCancel }),
+    );
+
+    act(() => {
+      result.current.onContactSupport();
+    });
+
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      deviceUxV2: true,
+      modelId: DeviceModelId.europa,
+      button: "Contact Ledger Support",
+    });
+    expect(openSupport).toHaveBeenCalledTimes(1);
+  });
+
+  it("GIVEN an error WHEN cancelling THEN it tracks Close and forwards to onCancel", () => {
+    const { result } = renderHook(() =>
+      useFinalErrorViewModel({ state, device, sourceFlow: SOURCE_FLOW, onCancel }),
+    );
+
+    act(() => {
+      result.current.onCancel();
+    });
+
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      deviceUxV2: true,
+      modelId: DeviceModelId.europa,
+      button: "Close",
+    });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/FinalError/useFinalErrorViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/FinalError/useFinalErrorViewModel.ts
@@ -1,23 +1,42 @@
+import { useCallback } from "react";
 import { isDmkError, type DmkError } from "@ledgerhq/live-dmk-mobile";
 import type { FinalStateType, EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
 import type { InitializerDevice } from "../../types";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
+import type { SourceFlow } from "../../../utils/SourceFlowContext";
+import { CONNECT_APP_BUTTON, trackConnectAppButtonClicked } from "../../../utils/trackDeviceIntent";
 
 type FinalErrorState = Extract<EnsureAppReadyState, { type: FinalStateType.Error }>;
 
 type Params = Readonly<{
   state: FinalErrorState;
   device: InitializerDevice;
+  sourceFlow: SourceFlow;
   onCancel: () => void;
 }>;
 
-export function useFinalErrorViewModel({ state, device, onCancel }: Params) {
+export function useFinalErrorViewModel({ state, device, sourceFlow, onCancel }: Params) {
   const { openSupport } = useInitializerActions(device);
+  const modelId = device.modelId;
+
+  const onCancelWithTracking = useCallback(() => {
+    trackConnectAppButtonClicked({ sourceFlow, modelId, button: CONNECT_APP_BUTTON.Close });
+    onCancel();
+  }, [onCancel, sourceFlow, modelId]);
+
+  const onContactSupport = useCallback(() => {
+    trackConnectAppButtonClicked({
+      sourceFlow,
+      modelId,
+      button: CONNECT_APP_BUTTON.ContactLedgerSupport,
+    });
+    openSupport();
+  }, [openSupport, sourceFlow, modelId]);
 
   return {
     error: getTranslatedErrorInput(state.error),
-    onCancel,
-    onContactSupport: openSupport,
+    onCancel: onCancelWithTracking,
+    onContactSupport,
   };
 }
 

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/InstallingAppState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/InstallingAppState.test.tsx
@@ -1,11 +1,55 @@
 import React from "react";
 import { render, screen } from "@tests/test-renderer";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { TrackScreen } from "~/analytics";
+import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import { InstallingAppState } from "./InstallingAppState";
+import type { InitializerDevice } from "../types";
+
+jest.mock("~/analytics", () => {
+  const actual = jest.requireActual("~/analytics");
+  return {
+    ...actual,
+    TrackScreen: jest.fn(() => null),
+  };
+});
+
+const mockedTrackScreen = jest.mocked(TrackScreen);
+
+const device: InitializerDevice = {
+  id: "device-id",
+  modelId: DeviceModelId.stax,
+  name: "Lily's Ledger",
+  productName: "Stax",
+  wired: false,
+};
+
+function renderState() {
+  return render(<InstallingAppState device={device} sourceFlow="my_ledger" />);
+}
 
 describe("InstallingAppState", () => {
-  it("should render the installing app title", () => {
-    render(<InstallingAppState />);
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("GIVEN the installing app state WHEN rendering THEN it renders the installing app title", () => {
+    renderState();
 
     expect(screen.getByText("Installing app")).toBeVisible();
+  });
+
+  it("GIVEN the installing app state WHEN rendering THEN it fires the page event with sourceFlow and modelId", () => {
+    renderState();
+
+    expect(mockedTrackScreen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: PAGE_CONNECT_APP.InstallingApp,
+        sourceFlow: "my_ledger",
+        modelId: DeviceModelId.stax,
+        deviceUxV2: true,
+      }),
+      undefined,
+    );
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/InstallingAppState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/InstallingAppState.tsx
@@ -1,12 +1,29 @@
 import React from "react";
 import { Trans } from "~/context/Locale";
+import { TrackScreen } from "~/analytics";
+import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
+import type { InitializerDevice } from "../types";
+import type { SourceFlow } from "../../utils/SourceFlowContext";
 import { LoadingContent } from "./LoadingContent";
 
-export function InstallingAppState() {
+type InstallingAppStateProps = Readonly<{
+  device: InitializerDevice;
+  sourceFlow: SourceFlow;
+}>;
+
+export function InstallingAppState({ device, sourceFlow }: InstallingAppStateProps) {
   return (
-    <LoadingContent
-      title={<Trans i18nKey="deviceIntentExecutor.initialization.installingApp.title" />}
-      testID="device-initializer-installing-app"
-    />
+    <>
+      <TrackScreen
+        category={PAGE_CONNECT_APP.InstallingApp}
+        sourceFlow={sourceFlow}
+        modelId={device.modelId}
+        deviceUxV2
+      />
+      <LoadingContent
+        title={<Trans i18nKey="deviceIntentExecutor.initialization.installingApp.title" />}
+        testID="device-initializer-installing-app"
+      />
+    </>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/LoadingState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/LoadingState.test.tsx
@@ -1,11 +1,74 @@
-import { render, screen } from "@tests/test-renderer";
 import React from "react";
+import { act, render, screen } from "@tests/test-renderer";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { TrackScreen } from "~/analytics";
+import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import { LoadingState } from "./LoadingState";
+import type { InitializerDevice } from "../types";
+
+jest.mock("~/analytics", () => {
+  const actual = jest.requireActual("~/analytics");
+  return {
+    ...actual,
+    TrackScreen: jest.fn(() => null),
+  };
+});
+
+const mockedTrackScreen = jest.mocked(TrackScreen);
+
+const device: InitializerDevice = {
+  id: "device-id",
+  modelId: DeviceModelId.stax,
+  name: "Lily's Ledger",
+  productName: "Stax",
+  wired: false,
+};
+
+function renderState() {
+  return render(<LoadingState device={device} sourceFlow="my_ledger" />);
+}
 
 describe("LoadingState", () => {
-  it("should render the loading title", () => {
-    render(<LoadingState />);
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("GIVEN the loading state WHEN rendering THEN it renders the loading title", () => {
+    jest.useRealTimers();
+    renderState();
 
     expect(screen.getByText("Loading")).toBeVisible();
+  });
+
+  it("GIVEN the loading state WHEN rendering for less than 250ms THEN it does not fire the page event", () => {
+    jest.useFakeTimers();
+    renderState();
+
+    act(() => {
+      jest.advanceTimersByTime(249);
+    });
+
+    expect(mockedTrackScreen).not.toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+
+  it("GIVEN the loading state WHEN rendering for 250ms THEN it fires the page event with sourceFlow and modelId", () => {
+    jest.useFakeTimers();
+    renderState();
+
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+
+    expect(mockedTrackScreen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: PAGE_CONNECT_APP.Loading,
+        sourceFlow: "my_ledger",
+        modelId: DeviceModelId.stax,
+        deviceUxV2: true,
+      }),
+      undefined,
+    );
+    jest.useRealTimers();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/LoadingState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/LoadingState.test.tsx
@@ -33,8 +33,11 @@ describe("LoadingState", () => {
     jest.clearAllMocks();
   });
 
-  it("GIVEN the loading state WHEN rendering THEN it renders the loading title", () => {
+  afterEach(() => {
     jest.useRealTimers();
+  });
+
+  it("GIVEN the loading state WHEN rendering THEN it renders the loading title", () => {
     renderState();
 
     expect(screen.getByText("Loading")).toBeVisible();
@@ -49,7 +52,6 @@ describe("LoadingState", () => {
     });
 
     expect(mockedTrackScreen).not.toHaveBeenCalled();
-    jest.useRealTimers();
   });
 
   it("GIVEN the loading state WHEN rendering for 250ms THEN it fires the page event with sourceFlow and modelId", () => {
@@ -69,6 +71,5 @@ describe("LoadingState", () => {
       }),
       undefined,
     );
-    jest.useRealTimers();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/LoadingState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/LoadingState.tsx
@@ -1,12 +1,44 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Trans } from "~/context/Locale";
+import { TrackScreen } from "~/analytics";
+import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
+import type { InitializerDevice } from "../types";
+import type { SourceFlow } from "../../utils/SourceFlowContext";
 import { LoadingContent } from "./LoadingContent";
 
-export function LoadingState() {
+type LoadingStateProps = Readonly<{
+  device: InitializerDevice;
+  sourceFlow: SourceFlow;
+}>;
+
+/**
+ * Gate the page event behind a short dwell so transient loading flashes
+ * (state resolves in < 250ms) don't emit a `Connect App - Loading` event.
+ */
+const LOADING_PAGE_EVENT_DWELL_MS = 250;
+
+export function LoadingState({ device, sourceFlow }: LoadingStateProps) {
+  const [dwellElapsed, setDwellElapsed] = useState(false);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => setDwellElapsed(true), LOADING_PAGE_EVENT_DWELL_MS);
+    return () => clearTimeout(timeout);
+  }, []);
+
   return (
-    <LoadingContent
-      title={<Trans i18nKey="deviceIntentExecutor.initialization.loading.title" />}
-      testID="device-initializer-loading"
-    />
+    <>
+      {dwellElapsed && (
+        <TrackScreen
+          category={PAGE_CONNECT_APP.Loading}
+          sourceFlow={sourceFlow}
+          modelId={device.modelId}
+          deviceUxV2
+        />
+      )}
+      <LoadingContent
+        title={<Trans i18nKey="deviceIntentExecutor.initialization.loading.title" />}
+        testID="device-initializer-loading"
+      />
+    </>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/OutdatedAppWarning/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/OutdatedAppWarning/index.tsx
@@ -3,6 +3,8 @@ import {
   AppInteractionRequiredStateType,
   type EnsureAppReadyState,
 } from "@ledgerhq/live-dmk-shared";
+import { TrackScreen } from "~/analytics";
+import { PAGE_CONNECT_APP } from "../../../utils/trackDeviceIntent";
 import type { BaseInitializerStateProps } from "../../types";
 import { OutdatedAppWarningView } from "./OutdatedAppWarningView";
 import { useOutdatedAppWarningViewModel } from "./useOutdatedAppWarningViewModel";
@@ -11,7 +13,17 @@ type OutdatedAppWarningProps = BaseInitializerStateProps<
   Extract<EnsureAppReadyState, { type: AppInteractionRequiredStateType.OutdatedAppWarning }>
 >;
 
-export function OutdatedAppWarning({ state, device }: OutdatedAppWarningProps) {
-  const viewModel = useOutdatedAppWarningViewModel({ state, device });
-  return <OutdatedAppWarningView {...viewModel} />;
+export function OutdatedAppWarning({ state, device, sourceFlow }: OutdatedAppWarningProps) {
+  const viewModel = useOutdatedAppWarningViewModel({ state, device, sourceFlow });
+  return (
+    <>
+      <TrackScreen
+        category={PAGE_CONNECT_APP.OutdatedAppWarning}
+        sourceFlow={sourceFlow}
+        modelId={device.modelId}
+        deviceUxV2
+      />
+      <OutdatedAppWarningView {...viewModel} />
+    </>
+  );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/OutdatedAppWarning/useOutdatedAppWarningViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/OutdatedAppWarning/useOutdatedAppWarningViewModel.test.tsx
@@ -1,0 +1,108 @@
+import { act, renderHook } from "@tests/test-renderer";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import {
+  AppInteractionRequiredStateType,
+  type EnsureAppReadyState,
+} from "@ledgerhq/live-dmk-shared";
+import { track } from "~/analytics";
+import { previousRouteNameRef } from "~/analytics/screenRefs";
+import { useInitializerActions } from "../../hooks/useInitializerActions";
+import { useOutdatedAppWarningViewModel } from "./useOutdatedAppWarningViewModel";
+import type { InitializerDevice } from "../../types";
+
+jest.mock("~/analytics", () => {
+  const actual = jest.requireActual("~/analytics");
+  return {
+    ...actual,
+    track: jest.fn(),
+  };
+});
+
+jest.mock("../../hooks/useInitializerActions");
+
+const mockedTrack = jest.mocked(track);
+const mockedUseInitializerActions = jest.mocked(useInitializerActions);
+const TEST_SOURCE = "Portfolio";
+const SOURCE_FLOW = "my_ledger";
+const openMyLedger = jest.fn();
+const onContinue = jest.fn();
+
+const device: InitializerDevice = {
+  id: "device-id",
+  modelId: DeviceModelId.europa,
+  name: "Lily's Ledger",
+  productName: "Flex",
+  wired: false,
+};
+
+const state = {
+  type: AppInteractionRequiredStateType.OutdatedAppWarning,
+  appName: "Ethereum",
+  onContinue,
+} satisfies Extract<
+  EnsureAppReadyState,
+  { type: AppInteractionRequiredStateType.OutdatedAppWarning }
+>;
+
+describe("useOutdatedAppWarningViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    previousRouteNameRef.current = TEST_SOURCE;
+    mockedUseInitializerActions.mockReturnValue({
+      openMyLedger,
+      openMyLedgerFirmwareUpdate: jest.fn(),
+      openOnboarding: jest.fn(),
+      openSupport: jest.fn(),
+    });
+  });
+
+  it("GIVEN an outdated app WHEN rendering THEN it exposes the view props", () => {
+    const { result } = renderHook(() =>
+      useOutdatedAppWarningViewModel({ state, device, sourceFlow: SOURCE_FLOW }),
+    );
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        appName: "Ethereum",
+      }),
+    );
+  });
+
+  it("GIVEN an outdated app WHEN opening My Ledger THEN it tracks Manage Apps and forwards the app name", () => {
+    const { result } = renderHook(() =>
+      useOutdatedAppWarningViewModel({ state, device, sourceFlow: SOURCE_FLOW }),
+    );
+
+    act(() => {
+      result.current.onOpenMyLedger();
+    });
+
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      deviceUxV2: true,
+      modelId: DeviceModelId.europa,
+      button: "Manage Apps",
+    });
+    expect(openMyLedger).toHaveBeenCalledWith("Ethereum");
+  });
+
+  it("GIVEN an outdated app WHEN continuing THEN it tracks Continue and forwards to onContinue", () => {
+    const { result } = renderHook(() =>
+      useOutdatedAppWarningViewModel({ state, device, sourceFlow: SOURCE_FLOW }),
+    );
+
+    act(() => {
+      result.current.onContinue();
+    });
+
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      deviceUxV2: true,
+      modelId: DeviceModelId.europa,
+      button: "Continue",
+    });
+    expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/OutdatedAppWarning/useOutdatedAppWarningViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/OutdatedAppWarning/useOutdatedAppWarningViewModel.ts
@@ -5,6 +5,8 @@ import type {
 } from "@ledgerhq/live-dmk-shared";
 import type { InitializerDevice } from "../../types";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
+import type { SourceFlow } from "../../../utils/SourceFlowContext";
+import { CONNECT_APP_BUTTON, trackConnectAppButtonClicked } from "../../../utils/trackDeviceIntent";
 
 type OutdatedAppWarningState = Extract<
   EnsureAppReadyState,
@@ -14,18 +16,26 @@ type OutdatedAppWarningState = Extract<
 type Params = Readonly<{
   state: OutdatedAppWarningState;
   device: InitializerDevice;
+  sourceFlow: SourceFlow;
 }>;
 
-export function useOutdatedAppWarningViewModel({ state, device }: Params) {
+export function useOutdatedAppWarningViewModel({ state, device, sourceFlow }: Params) {
   const { openMyLedger } = useInitializerActions(device);
-  const onOpenMyLedger = useCallback(
-    () => openMyLedger(state.appName),
-    [openMyLedger, state.appName],
-  );
+  const modelId = device.modelId;
+
+  const onOpenMyLedger = useCallback(() => {
+    trackConnectAppButtonClicked({ sourceFlow, modelId, button: CONNECT_APP_BUTTON.ManageApps });
+    openMyLedger(state.appName);
+  }, [openMyLedger, state.appName, sourceFlow, modelId]);
+
+  const onContinue = useCallback(() => {
+    trackConnectAppButtonClicked({ sourceFlow, modelId, button: CONNECT_APP_BUTTON.Continue });
+    state.onContinue();
+  }, [state, sourceFlow, modelId]);
 
   return {
     appName: state.appName,
     onOpenMyLedger,
-    onContinue: state.onContinue,
+    onContinue,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/RetryableDeviceLockedState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/RetryableDeviceLockedState.test.tsx
@@ -2,8 +2,24 @@ import React from "react";
 import { render, screen } from "@tests/test-renderer";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { RetryableStateType } from "@ledgerhq/live-dmk-shared";
+import { TrackScreen, track } from "~/analytics";
+import { previousRouteNameRef } from "~/analytics/screenRefs";
+import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import { RetryableDeviceLockedState } from "./RetryableDeviceLockedState";
 import type { InitializerDevice } from "../types";
+
+jest.mock("~/analytics", () => {
+  const actual = jest.requireActual("~/analytics");
+  return {
+    ...actual,
+    TrackScreen: jest.fn(() => null),
+    track: jest.fn(),
+  };
+});
+
+const mockedTrackScreen = jest.mocked(TrackScreen);
+const mockedTrack = jest.mocked(track);
+const TEST_SOURCE = "Portfolio";
 
 const device: InitializerDevice = {
   id: "device-id",
@@ -22,6 +38,7 @@ function renderState() {
       <RetryableDeviceLockedState
         state={{ type: RetryableStateType.DeviceLocked, retry }}
         device={device}
+        sourceFlow="my_ledger"
         onCancel={onCancel}
       />,
     ),
@@ -31,18 +48,51 @@ function renderState() {
 }
 
 describe("RetryableDeviceLockedState", () => {
-  it("should render the locked title and the retry CTA", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    previousRouteNameRef.current = TEST_SOURCE;
+  });
+
+  it("GIVEN the retryable device locked state WHEN rendering THEN it renders the locked title and retry CTA", () => {
     renderState();
 
     expect(screen.getByText("Device is locked")).toBeVisible();
     expect(screen.getByText("Retry")).toBeVisible();
   });
 
-  it("should call retry when the retry button is pressed", async () => {
+  it("GIVEN the retryable device locked state WHEN pressing retry THEN it calls retry", async () => {
     const { user, retry } = renderState();
 
     await user.press(screen.getByText("Retry"));
 
     expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  it("GIVEN the retryable device locked state WHEN rendering THEN it fires the page event with sourceFlow and modelId", () => {
+    renderState();
+
+    expect(mockedTrackScreen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: PAGE_CONNECT_APP.DeviceLocked,
+        sourceFlow: "my_ledger",
+        modelId: DeviceModelId.europa,
+        deviceUxV2: true,
+      }),
+      undefined,
+    );
+  });
+
+  it("GIVEN the retryable device locked state WHEN pressing retry THEN it tracks the canonical button value", async () => {
+    const { user } = renderState();
+
+    await user.press(screen.getByText("Retry"));
+
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      deviceUxV2: true,
+      modelId: DeviceModelId.europa,
+      button: "Retry",
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/RetryableDeviceLockedState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/RetryableDeviceLockedState.tsx
@@ -1,18 +1,43 @@
 import React from "react";
 import { RetryableStateType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
 import { RetryableDeviceLocked } from "LLM/components/DeviceIntentExecutor/components/DeviceGenericStates/RetryableDeviceLocked";
+import { TrackScreen } from "~/analytics";
+import {
+  CONNECT_APP_BUTTON,
+  PAGE_CONNECT_APP,
+  trackConnectAppButtonClicked,
+} from "../../utils/trackDeviceIntent";
 import type { BaseInitializerStateProps } from "../types";
 
 type RetryableDeviceLockedStateProps = BaseInitializerStateProps<
   Extract<EnsureAppReadyState, { type: RetryableStateType.DeviceLocked }>
 >;
 
-export function RetryableDeviceLockedState({ state, device }: RetryableDeviceLockedStateProps) {
+export function RetryableDeviceLockedState({
+  state,
+  device,
+  sourceFlow,
+}: RetryableDeviceLockedStateProps) {
+  const modelId = device.modelId;
+
+  const handleRetry = () => {
+    trackConnectAppButtonClicked({ sourceFlow, modelId, button: CONNECT_APP_BUTTON.Retry });
+    state.retry();
+  };
+
   return (
-    <RetryableDeviceLocked
-      deviceModelId={device.modelId}
-      onRetry={state.retry}
-      testID="device-initializer-retryable-device-locked"
-    />
+    <>
+      <TrackScreen
+        category={PAGE_CONNECT_APP.DeviceLocked}
+        sourceFlow={sourceFlow}
+        modelId={modelId}
+        deviceUxV2
+      />
+      <RetryableDeviceLocked
+        deviceModelId={device.modelId}
+        onRetry={handleRetry}
+        testID="device-initializer-retryable-device-locked"
+      />
+    </>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnlockDeviceState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnlockDeviceState.test.tsx
@@ -2,8 +2,20 @@ import React from "react";
 import { render, screen } from "@tests/test-renderer";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { DeviceInteractionRequiredType } from "@ledgerhq/live-dmk-shared";
+import { TrackScreen } from "~/analytics";
+import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import { UnlockDeviceState } from "./UnlockDeviceState";
 import type { InitializerDevice } from "../types";
+
+jest.mock("~/analytics", () => {
+  const actual = jest.requireActual("~/analytics");
+  return {
+    ...actual,
+    TrackScreen: jest.fn(() => null),
+  };
+});
+
+const mockedTrackScreen = jest.mocked(TrackScreen);
 
 const device: InitializerDevice = {
   id: "device-id",
@@ -13,16 +25,39 @@ const device: InitializerDevice = {
   wired: false,
 };
 
+function renderState() {
+  return render(
+    <UnlockDeviceState
+      state={{ type: DeviceInteractionRequiredType.UnlockDevice }}
+      device={device}
+      sourceFlow="my_ledger"
+      onCancel={jest.fn()}
+    />,
+  );
+}
+
 describe("UnlockDeviceState", () => {
-  it("should render the unlock title interpolated with the product name", () => {
-    render(
-      <UnlockDeviceState
-        state={{ type: DeviceInteractionRequiredType.UnlockDevice }}
-        device={device}
-        onCancel={jest.fn()}
-      />,
-    );
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("GIVEN the unlock device state WHEN rendering THEN it renders the unlock title with the product name", () => {
+    renderState();
 
     expect(screen.getByText("Unlock your Ledger Flex")).toBeVisible();
+  });
+
+  it("GIVEN the unlock device state WHEN rendering THEN it fires the page event with sourceFlow and modelId", () => {
+    renderState();
+
+    expect(mockedTrackScreen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: PAGE_CONNECT_APP.UnlockDevice,
+        sourceFlow: "my_ledger",
+        modelId: DeviceModelId.europa,
+        deviceUxV2: true,
+      }),
+      undefined,
+    );
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnlockDeviceState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnlockDeviceState.tsx
@@ -1,18 +1,28 @@
 import React from "react";
 import { DeviceInteractionRequiredType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
 import { UnlockDevice } from "LLM/components/DeviceIntentExecutor/components/DeviceGenericStates/UnlockDevice";
+import { TrackScreen } from "~/analytics";
+import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import type { BaseInitializerStateProps } from "../types";
 
 type UnlockDeviceStateProps = BaseInitializerStateProps<
   Extract<EnsureAppReadyState, { type: DeviceInteractionRequiredType.UnlockDevice }>
 >;
 
-export function UnlockDeviceState({ device }: UnlockDeviceStateProps) {
+export function UnlockDeviceState({ device, sourceFlow }: UnlockDeviceStateProps) {
   return (
-    <UnlockDevice
-      deviceModelId={device.modelId}
-      deviceName={device.name}
-      testID="device-initializer-unlock-device"
-    />
+    <>
+      <TrackScreen
+        category={PAGE_CONNECT_APP.UnlockDevice}
+        sourceFlow={sourceFlow}
+        modelId={device.modelId}
+        deviceUxV2
+      />
+      <UnlockDevice
+        deviceModelId={device.modelId}
+        deviceName={device.name}
+        testID="device-initializer-unlock-device"
+      />
+    </>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedApplication/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedApplication/index.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { BlockingStateType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
+import { TrackScreen } from "~/analytics";
+import { PAGE_CONNECT_APP } from "../../../utils/trackDeviceIntent";
 import type { BaseInitializerStateProps } from "../../types";
 import { UnsupportedApplicationView } from "./UnsupportedApplicationView";
 import { useUnsupportedApplicationViewModel } from "./useUnsupportedApplicationViewModel";
@@ -8,7 +10,17 @@ type UnsupportedApplicationProps = BaseInitializerStateProps<
   Extract<EnsureAppReadyState, { type: BlockingStateType.UnsupportedApplication }>
 >;
 
-export function UnsupportedApplication({ device }: UnsupportedApplicationProps) {
-  const viewModel = useUnsupportedApplicationViewModel({ device });
-  return <UnsupportedApplicationView {...viewModel} />;
+export function UnsupportedApplication({ device, sourceFlow }: UnsupportedApplicationProps) {
+  const viewModel = useUnsupportedApplicationViewModel({ device, sourceFlow });
+  return (
+    <>
+      <TrackScreen
+        category={PAGE_CONNECT_APP.UnsupportedApplication}
+        sourceFlow={sourceFlow}
+        modelId={device.modelId}
+        deviceUxV2
+      />
+      <UnsupportedApplicationView {...viewModel} />
+    </>
+  );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedApplication/useUnsupportedApplicationViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedApplication/useUnsupportedApplicationViewModel.test.tsx
@@ -1,0 +1,75 @@
+import { act, renderHook } from "@tests/test-renderer";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { track } from "~/analytics";
+import { previousRouteNameRef } from "~/analytics/screenRefs";
+import { useInitializerActions } from "../../hooks/useInitializerActions";
+import { useUnsupportedApplicationViewModel } from "./useUnsupportedApplicationViewModel";
+import type { InitializerDevice } from "../../types";
+
+jest.mock("~/analytics", () => {
+  const actual = jest.requireActual("~/analytics");
+  return {
+    ...actual,
+    track: jest.fn(),
+  };
+});
+
+jest.mock("../../hooks/useInitializerActions");
+
+const mockedTrack = jest.mocked(track);
+const mockedUseInitializerActions = jest.mocked(useInitializerActions);
+const TEST_SOURCE = "Portfolio";
+const SOURCE_FLOW = "my_ledger";
+const openSupport = jest.fn();
+
+const device: InitializerDevice = {
+  id: "device-id",
+  modelId: DeviceModelId.europa,
+  name: "Lily's Ledger",
+  productName: "Flex",
+  wired: false,
+};
+
+describe("useUnsupportedApplicationViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    previousRouteNameRef.current = TEST_SOURCE;
+    mockedUseInitializerActions.mockReturnValue({
+      openMyLedger: jest.fn(),
+      openMyLedgerFirmwareUpdate: jest.fn(),
+      openOnboarding: jest.fn(),
+      openSupport,
+    });
+  });
+
+  it("GIVEN a device WHEN rendering THEN it exposes the view handlers", () => {
+    const { result } = renderHook(() =>
+      useUnsupportedApplicationViewModel({ device, sourceFlow: SOURCE_FLOW }),
+    );
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        onContactSupport: expect.any(Function),
+      }),
+    );
+  });
+
+  it("GIVEN a device WHEN contacting support THEN it tracks Contact Ledger Support and opens support", () => {
+    const { result } = renderHook(() =>
+      useUnsupportedApplicationViewModel({ device, sourceFlow: SOURCE_FLOW }),
+    );
+
+    act(() => {
+      result.current.onContactSupport();
+    });
+
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      deviceUxV2: true,
+      modelId: DeviceModelId.europa,
+      button: "Contact Ledger Support",
+    });
+    expect(openSupport).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedApplication/useUnsupportedApplicationViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedApplication/useUnsupportedApplicationViewModel.ts
@@ -1,14 +1,28 @@
+import { useCallback } from "react";
 import type { InitializerDevice } from "../../types";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
+import type { SourceFlow } from "../../../utils/SourceFlowContext";
+import { CONNECT_APP_BUTTON, trackConnectAppButtonClicked } from "../../../utils/trackDeviceIntent";
 
 type Params = Readonly<{
   device: InitializerDevice;
+  sourceFlow: SourceFlow;
 }>;
 
-export function useUnsupportedApplicationViewModel({ device }: Params) {
+export function useUnsupportedApplicationViewModel({ device, sourceFlow }: Params) {
   const { openSupport } = useInitializerActions(device);
+  const modelId = device.modelId;
+
+  const onContactSupport = useCallback(() => {
+    trackConnectAppButtonClicked({
+      sourceFlow,
+      modelId,
+      button: CONNECT_APP_BUTTON.ContactLedgerSupport,
+    });
+    openSupport();
+  }, [openSupport, sourceFlow, modelId]);
 
   return {
-    onContactSupport: openSupport,
+    onContactSupport,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFeature/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFeature/index.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { BlockingStateType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
+import { TrackScreen } from "~/analytics";
+import { PAGE_CONNECT_APP } from "../../../utils/trackDeviceIntent";
 import type { BaseInitializerStateProps } from "../../types";
 import { UnsupportedFeatureView } from "./UnsupportedFeatureView";
 import { useUnsupportedFeatureViewModel } from "./useUnsupportedFeatureViewModel";
@@ -8,7 +10,17 @@ type UnsupportedFeatureProps = BaseInitializerStateProps<
   Extract<EnsureAppReadyState, { type: BlockingStateType.UnsupportedFeature }>
 >;
 
-export function UnsupportedFeature({ device }: UnsupportedFeatureProps) {
-  const viewModel = useUnsupportedFeatureViewModel({ device });
-  return <UnsupportedFeatureView {...viewModel} />;
+export function UnsupportedFeature({ device, sourceFlow }: UnsupportedFeatureProps) {
+  const viewModel = useUnsupportedFeatureViewModel({ device, sourceFlow });
+  return (
+    <>
+      <TrackScreen
+        category={PAGE_CONNECT_APP.UnsupportedFeature}
+        sourceFlow={sourceFlow}
+        modelId={device.modelId}
+        deviceUxV2
+      />
+      <UnsupportedFeatureView {...viewModel} />
+    </>
+  );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFeature/useUnsupportedFeatureViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFeature/useUnsupportedFeatureViewModel.test.tsx
@@ -1,0 +1,75 @@
+import { act, renderHook } from "@tests/test-renderer";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { track } from "~/analytics";
+import { previousRouteNameRef } from "~/analytics/screenRefs";
+import { useInitializerActions } from "../../hooks/useInitializerActions";
+import { useUnsupportedFeatureViewModel } from "./useUnsupportedFeatureViewModel";
+import type { InitializerDevice } from "../../types";
+
+jest.mock("~/analytics", () => {
+  const actual = jest.requireActual("~/analytics");
+  return {
+    ...actual,
+    track: jest.fn(),
+  };
+});
+
+jest.mock("../../hooks/useInitializerActions");
+
+const mockedTrack = jest.mocked(track);
+const mockedUseInitializerActions = jest.mocked(useInitializerActions);
+const TEST_SOURCE = "Portfolio";
+const SOURCE_FLOW = "my_ledger";
+const openSupport = jest.fn();
+
+const device: InitializerDevice = {
+  id: "device-id",
+  modelId: DeviceModelId.europa,
+  name: "Lily's Ledger",
+  productName: "Flex",
+  wired: false,
+};
+
+describe("useUnsupportedFeatureViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    previousRouteNameRef.current = TEST_SOURCE;
+    mockedUseInitializerActions.mockReturnValue({
+      openMyLedger: jest.fn(),
+      openMyLedgerFirmwareUpdate: jest.fn(),
+      openOnboarding: jest.fn(),
+      openSupport,
+    });
+  });
+
+  it("GIVEN a device WHEN rendering THEN it exposes the view handlers", () => {
+    const { result } = renderHook(() =>
+      useUnsupportedFeatureViewModel({ device, sourceFlow: SOURCE_FLOW }),
+    );
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        onContactSupport: expect.any(Function),
+      }),
+    );
+  });
+
+  it("GIVEN a device WHEN contacting support THEN it tracks Contact Ledger Support and opens support", () => {
+    const { result } = renderHook(() =>
+      useUnsupportedFeatureViewModel({ device, sourceFlow: SOURCE_FLOW }),
+    );
+
+    act(() => {
+      result.current.onContactSupport();
+    });
+
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      deviceUxV2: true,
+      modelId: DeviceModelId.europa,
+      button: "Contact Ledger Support",
+    });
+    expect(openSupport).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFeature/useUnsupportedFeatureViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFeature/useUnsupportedFeatureViewModel.ts
@@ -1,14 +1,28 @@
+import { useCallback } from "react";
 import type { InitializerDevice } from "../../types";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
+import type { SourceFlow } from "../../../utils/SourceFlowContext";
+import { CONNECT_APP_BUTTON, trackConnectAppButtonClicked } from "../../../utils/trackDeviceIntent";
 
 type Params = Readonly<{
   device: InitializerDevice;
+  sourceFlow: SourceFlow;
 }>;
 
-export function useUnsupportedFeatureViewModel({ device }: Params) {
+export function useUnsupportedFeatureViewModel({ device, sourceFlow }: Params) {
   const { openSupport } = useInitializerActions(device);
+  const modelId = device.modelId;
+
+  const onContactSupport = useCallback(() => {
+    trackConnectAppButtonClicked({
+      sourceFlow,
+      modelId,
+      button: CONNECT_APP_BUTTON.ContactLedgerSupport,
+    });
+    openSupport();
+  }, [openSupport, sourceFlow, modelId]);
 
   return {
-    onContactSupport: openSupport,
+    onContactSupport,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFirmwareVersion/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFirmwareVersion/index.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { BlockingStateType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
+import { TrackScreen } from "~/analytics";
+import { PAGE_CONNECT_APP } from "../../../utils/trackDeviceIntent";
 import type { BaseInitializerStateProps } from "../../types";
 import { UnsupportedFirmwareVersionView } from "./UnsupportedFirmwareVersionView";
 import { useUnsupportedFirmwareVersionViewModel } from "./useUnsupportedFirmwareVersionViewModel";
@@ -8,7 +10,25 @@ type UnsupportedFirmwareVersionProps = BaseInitializerStateProps<
   Extract<EnsureAppReadyState, { type: BlockingStateType.UnsupportedFirmwareVersion }>
 >;
 
-export function UnsupportedFirmwareVersion({ device, onCancel }: UnsupportedFirmwareVersionProps) {
-  const viewModel = useUnsupportedFirmwareVersionViewModel({ device, onCancel });
-  return <UnsupportedFirmwareVersionView {...viewModel} />;
+export function UnsupportedFirmwareVersion({
+  device,
+  sourceFlow,
+  onCancel,
+}: UnsupportedFirmwareVersionProps) {
+  const viewModel = useUnsupportedFirmwareVersionViewModel({
+    device,
+    sourceFlow,
+    onCancel,
+  });
+  return (
+    <>
+      <TrackScreen
+        category={PAGE_CONNECT_APP.UnsupportedFirmware}
+        sourceFlow={sourceFlow}
+        modelId={device.modelId}
+        deviceUxV2
+      />
+      <UnsupportedFirmwareVersionView {...viewModel} />
+    </>
+  );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFirmwareVersion/useUnsupportedFirmwareVersionViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFirmwareVersion/useUnsupportedFirmwareVersionViewModel.test.tsx
@@ -1,0 +1,111 @@
+import { act, renderHook } from "@tests/test-renderer";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { track } from "~/analytics";
+import { previousRouteNameRef } from "~/analytics/screenRefs";
+import { useInitializerActions } from "../../hooks/useInitializerActions";
+import { useUnsupportedFirmwareVersionViewModel } from "./useUnsupportedFirmwareVersionViewModel";
+import type { InitializerDevice } from "../../types";
+
+jest.mock("~/analytics", () => {
+  const actual = jest.requireActual("~/analytics");
+  return {
+    ...actual,
+    track: jest.fn(),
+  };
+});
+
+jest.mock("../../hooks/useInitializerActions");
+
+const mockedTrack = jest.mocked(track);
+const mockedUseInitializerActions = jest.mocked(useInitializerActions);
+const TEST_SOURCE = "Portfolio";
+const SOURCE_FLOW = "my_ledger";
+const openMyLedgerFirmwareUpdate = jest.fn();
+const onCancel = jest.fn();
+
+const device: InitializerDevice = {
+  id: "device-id",
+  modelId: DeviceModelId.europa,
+  name: "Lily's Ledger",
+  productName: "Flex",
+  wired: false,
+};
+
+describe("useUnsupportedFirmwareVersionViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    previousRouteNameRef.current = TEST_SOURCE;
+    mockedUseInitializerActions.mockReturnValue({
+      openMyLedger: jest.fn(),
+      openMyLedgerFirmwareUpdate,
+      openOnboarding: jest.fn(),
+      openSupport: jest.fn(),
+    });
+  });
+
+  it("GIVEN a device WHEN rendering THEN it exposes the view handlers", () => {
+    const { result } = renderHook(
+      () =>
+        useUnsupportedFirmwareVersionViewModel({
+          device,
+          sourceFlow: SOURCE_FLOW,
+          onCancel,
+        }),
+    );
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        onCancel: expect.any(Function),
+        onUpdateLedgerOs: expect.any(Function),
+      }),
+    );
+  });
+
+  it("GIVEN a device WHEN updating Ledger OS THEN it tracks Update Firmware and opens the firmware update", () => {
+    const { result } = renderHook(
+      () =>
+        useUnsupportedFirmwareVersionViewModel({
+          device,
+          sourceFlow: SOURCE_FLOW,
+          onCancel,
+        }),
+    );
+
+    act(() => {
+      result.current.onUpdateLedgerOs();
+    });
+
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      deviceUxV2: true,
+      modelId: DeviceModelId.europa,
+      button: "Update Firmware",
+    });
+    expect(openMyLedgerFirmwareUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("GIVEN a device WHEN cancelling THEN it tracks Cancel and forwards to onCancel", () => {
+    const { result } = renderHook(
+      () =>
+        useUnsupportedFirmwareVersionViewModel({
+          device,
+          sourceFlow: SOURCE_FLOW,
+          onCancel,
+        }),
+    );
+
+    act(() => {
+      result.current.onCancel();
+    });
+
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      deviceUxV2: true,
+      modelId: DeviceModelId.europa,
+      button: "Cancel",
+    });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFirmwareVersion/useUnsupportedFirmwareVersionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFirmwareVersion/useUnsupportedFirmwareVersionViewModel.ts
@@ -1,16 +1,31 @@
+import { useCallback } from "react";
 import type { InitializerDevice } from "../../types";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
+import type { SourceFlow } from "../../../utils/SourceFlowContext";
+import { CONNECT_APP_BUTTON, trackConnectAppButtonClicked } from "../../../utils/trackDeviceIntent";
 
 type Params = Readonly<{
   device: InitializerDevice;
+  sourceFlow: SourceFlow;
   onCancel: () => void;
 }>;
 
-export function useUnsupportedFirmwareVersionViewModel({ device, onCancel }: Params) {
+export function useUnsupportedFirmwareVersionViewModel({ device, sourceFlow, onCancel }: Params) {
   const { openMyLedgerFirmwareUpdate } = useInitializerActions(device);
+  const modelId = device.modelId;
+
+  const onUpdateLedgerOs = useCallback(() => {
+    trackConnectAppButtonClicked({ sourceFlow, modelId, button: CONNECT_APP_BUTTON.UpdateFirmware });
+    openMyLedgerFirmwareUpdate();
+  }, [openMyLedgerFirmwareUpdate, sourceFlow, modelId]);
+
+  const onCancelWithTracking = useCallback(() => {
+    trackConnectAppButtonClicked({ sourceFlow, modelId, button: CONNECT_APP_BUTTON.Cancel });
+    onCancel();
+  }, [onCancel, sourceFlow, modelId]);
 
   return {
-    onCancel,
-    onUpdateLedgerOs: openMyLedgerFirmwareUpdate,
+    onCancel: onCancelWithTracking,
+    onUpdateLedgerOs,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UserRefusedOnDeviceState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UserRefusedOnDeviceState.test.tsx
@@ -2,8 +2,24 @@ import React from "react";
 import { render, screen } from "@tests/test-renderer";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { RetryableStateType } from "@ledgerhq/live-dmk-shared";
+import { TrackScreen, track } from "~/analytics";
+import { previousRouteNameRef } from "~/analytics/screenRefs";
+import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import { UserRefusedOnDeviceState } from "./UserRefusedOnDeviceState";
 import type { InitializerDevice } from "../types";
+
+jest.mock("~/analytics", () => {
+  const actual = jest.requireActual("~/analytics");
+  return {
+    ...actual,
+    TrackScreen: jest.fn(() => null),
+    track: jest.fn(),
+  };
+});
+
+const mockedTrackScreen = jest.mocked(TrackScreen);
+const mockedTrack = jest.mocked(track);
+const TEST_SOURCE = "Portfolio";
 
 const device: InitializerDevice = {
   id: "device-id",
@@ -22,6 +38,7 @@ function renderState() {
       <UserRefusedOnDeviceState
         state={{ type: RetryableStateType.UserRefusedOnDevice, retry }}
         device={device}
+        sourceFlow="my_ledger"
         onCancel={onCancel}
       />,
     ),
@@ -31,7 +48,12 @@ function renderState() {
 }
 
 describe("UserRefusedOnDeviceState", () => {
-  it("should render the user refused title and action buttons", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    previousRouteNameRef.current = TEST_SOURCE;
+  });
+
+  it("GIVEN the user refused state WHEN rendering THEN it renders the title and action buttons", () => {
     renderState();
 
     expect(screen.getByText("Operation rejected on device")).toBeVisible();
@@ -39,7 +61,7 @@ describe("UserRefusedOnDeviceState", () => {
     expect(screen.getByText("Retry")).toBeVisible();
   });
 
-  it("should call onCancel and retry when buttons are pressed", async () => {
+  it("GIVEN the user refused state WHEN pressing the action buttons THEN it calls onCancel and retry", async () => {
     const { user, onCancel, retry } = renderState();
 
     await user.press(screen.getByText("Close"));
@@ -47,5 +69,47 @@ describe("UserRefusedOnDeviceState", () => {
 
     expect(onCancel).toHaveBeenCalledTimes(1);
     expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  it("GIVEN the user refused state WHEN rendering THEN it fires the page event with sourceFlow and modelId", () => {
+    renderState();
+
+    expect(mockedTrackScreen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: PAGE_CONNECT_APP.UserRefused,
+        sourceFlow: "my_ledger",
+        modelId: DeviceModelId.europa,
+        deviceUxV2: true,
+      }),
+      undefined,
+    );
+  });
+
+  it("GIVEN the user refused state WHEN pressing Close THEN it tracks the canonical button value", async () => {
+    const { user } = renderState();
+
+    await user.press(screen.getByText("Close"));
+
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      deviceUxV2: true,
+      modelId: DeviceModelId.europa,
+      button: "Close",
+    });
+  });
+
+  it("GIVEN the user refused state WHEN pressing Retry THEN it tracks the canonical button value", async () => {
+    const { user } = renderState();
+
+    await user.press(screen.getByText("Retry"));
+
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      deviceUxV2: true,
+      modelId: DeviceModelId.europa,
+      button: "Retry",
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UserRefusedOnDeviceState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UserRefusedOnDeviceState.tsx
@@ -2,27 +2,57 @@ import React from "react";
 import { RetryableStateType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
 import { Trans } from "~/context/Locale";
 import { InfoState } from "LLM/components/InfoState";
+import { TrackScreen } from "~/analytics";
+import {
+  CONNECT_APP_BUTTON,
+  PAGE_CONNECT_APP,
+  trackConnectAppButtonClicked,
+} from "../../utils/trackDeviceIntent";
 import type { BaseInitializerStateProps } from "../types";
 
 type UserRefusedOnDeviceStateProps = BaseInitializerStateProps<
   Extract<EnsureAppReadyState, { type: RetryableStateType.UserRefusedOnDevice }>
 >;
 
-export function UserRefusedOnDeviceState({ state, onCancel }: UserRefusedOnDeviceStateProps) {
+export function UserRefusedOnDeviceState({
+  state,
+  device,
+  sourceFlow,
+  onCancel,
+}: UserRefusedOnDeviceStateProps) {
+  const modelId = device.modelId;
+
+  const handleClose = () => {
+    trackConnectAppButtonClicked({ sourceFlow, modelId, button: CONNECT_APP_BUTTON.Close });
+    onCancel();
+  };
+  const handleRetry = () => {
+    trackConnectAppButtonClicked({ sourceFlow, modelId, button: CONNECT_APP_BUTTON.Retry });
+    state.retry();
+  };
+
   return (
-    <InfoState
-      preset="info"
-      size="hug"
-      title={<Trans i18nKey="deviceIntentExecutor.initialization.retryable.userRefused.title" />}
-      primaryCta={{
-        label: <Trans i18nKey="common.close" />,
-        onPress: onCancel,
-      }}
-      secondaryCta={{
-        label: <Trans i18nKey="common.retry" />,
-        onPress: state.retry,
-      }}
-      testID="device-initializer-user-refused-on-device"
-    />
+    <>
+      <TrackScreen
+        category={PAGE_CONNECT_APP.UserRefused}
+        sourceFlow={sourceFlow}
+        modelId={modelId}
+        deviceUxV2
+      />
+      <InfoState
+        preset="info"
+        size="hug"
+        title={<Trans i18nKey="deviceIntentExecutor.initialization.retryable.userRefused.title" />}
+        primaryCta={{
+          label: <Trans i18nKey="common.close" />,
+          onPress: handleClose,
+        }}
+        secondaryCta={{
+          label: <Trans i18nKey="common.retry" />,
+          onPress: handleRetry,
+        }}
+        testID="device-initializer-user-refused-on-device"
+      />
+    </>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/WrongDeviceForAccount/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/WrongDeviceForAccount/index.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { BlockingStateType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
+import { TrackScreen } from "~/analytics";
+import { PAGE_CONNECT_APP } from "../../../utils/trackDeviceIntent";
 import type { BaseInitializerStateProps } from "../../types";
 import { WrongDeviceForAccountView } from "./WrongDeviceForAccountView";
 import { useWrongDeviceForAccountViewModel } from "./useWrongDeviceForAccountViewModel";
@@ -8,7 +10,25 @@ type WrongDeviceForAccountProps = BaseInitializerStateProps<
   Extract<EnsureAppReadyState, { type: BlockingStateType.WrongDeviceForAccount }>
 >;
 
-export function WrongDeviceForAccount({ device, onCancel }: WrongDeviceForAccountProps) {
-  const viewModel = useWrongDeviceForAccountViewModel({ device, onCancel });
-  return <WrongDeviceForAccountView {...viewModel} />;
+export function WrongDeviceForAccount({
+  device,
+  sourceFlow,
+  onCancel,
+}: WrongDeviceForAccountProps) {
+  const viewModel = useWrongDeviceForAccountViewModel({
+    device,
+    sourceFlow,
+    onCancel,
+  });
+  return (
+    <>
+      <TrackScreen
+        category={PAGE_CONNECT_APP.WrongDeviceForAccount}
+        sourceFlow={sourceFlow}
+        modelId={device.modelId}
+        deviceUxV2
+      />
+      <WrongDeviceForAccountView {...viewModel} />
+    </>
+  );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/WrongDeviceForAccount/useWrongDeviceForAccountViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/WrongDeviceForAccount/useWrongDeviceForAccountViewModel.test.tsx
@@ -1,0 +1,96 @@
+import { act, renderHook } from "@tests/test-renderer";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { track } from "~/analytics";
+import { previousRouteNameRef } from "~/analytics/screenRefs";
+import { useInitializerActions } from "../../hooks/useInitializerActions";
+import { useWrongDeviceForAccountViewModel } from "./useWrongDeviceForAccountViewModel";
+import type { InitializerDevice } from "../../types";
+
+jest.mock("~/analytics", () => {
+  const actual = jest.requireActual("~/analytics");
+  return {
+    ...actual,
+    track: jest.fn(),
+  };
+});
+
+jest.mock("../../hooks/useInitializerActions");
+
+const mockedTrack = jest.mocked(track);
+const mockedUseInitializerActions = jest.mocked(useInitializerActions);
+const TEST_SOURCE = "Portfolio";
+const SOURCE_FLOW = "my_ledger";
+const openSupport = jest.fn();
+const onCancel = jest.fn();
+
+const device: InitializerDevice = {
+  id: "device-id",
+  modelId: DeviceModelId.europa,
+  name: "Lily's Ledger",
+  productName: "Flex",
+  wired: false,
+};
+
+describe("useWrongDeviceForAccountViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    previousRouteNameRef.current = TEST_SOURCE;
+    mockedUseInitializerActions.mockReturnValue({
+      openMyLedger: jest.fn(),
+      openMyLedgerFirmwareUpdate: jest.fn(),
+      openOnboarding: jest.fn(),
+      openSupport,
+    });
+  });
+
+  it("GIVEN a device WHEN rendering THEN it exposes the view handlers", () => {
+    const { result } = renderHook(() =>
+      useWrongDeviceForAccountViewModel({ device, sourceFlow: SOURCE_FLOW, onCancel }),
+    );
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        onCancel: expect.any(Function),
+        onContactSupport: expect.any(Function),
+      }),
+    );
+  });
+
+  it("GIVEN a device WHEN cancelling THEN it tracks Close and forwards to onCancel", () => {
+    const { result } = renderHook(() =>
+      useWrongDeviceForAccountViewModel({ device, sourceFlow: SOURCE_FLOW, onCancel }),
+    );
+
+    act(() => {
+      result.current.onCancel();
+    });
+
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      deviceUxV2: true,
+      modelId: DeviceModelId.europa,
+      button: "Close",
+    });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("GIVEN a device WHEN contacting support THEN it tracks Contact Ledger Support and opens support", () => {
+    const { result } = renderHook(() =>
+      useWrongDeviceForAccountViewModel({ device, sourceFlow: SOURCE_FLOW, onCancel }),
+    );
+
+    act(() => {
+      result.current.onContactSupport();
+    });
+
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      deviceUxV2: true,
+      modelId: DeviceModelId.europa,
+      button: "Contact Ledger Support",
+    });
+    expect(openSupport).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/WrongDeviceForAccount/useWrongDeviceForAccountViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/WrongDeviceForAccount/useWrongDeviceForAccountViewModel.ts
@@ -1,16 +1,35 @@
+import { useCallback } from "react";
 import type { InitializerDevice } from "../../types";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
+import type { SourceFlow } from "../../../utils/SourceFlowContext";
+import { CONNECT_APP_BUTTON, trackConnectAppButtonClicked } from "../../../utils/trackDeviceIntent";
 
 type Params = Readonly<{
   device: InitializerDevice;
+  sourceFlow: SourceFlow;
   onCancel: () => void;
 }>;
 
-export function useWrongDeviceForAccountViewModel({ device, onCancel }: Params) {
+export function useWrongDeviceForAccountViewModel({ device, sourceFlow, onCancel }: Params) {
   const { openSupport } = useInitializerActions(device);
+  const modelId = device.modelId;
+
+  const onCancelWithTracking = useCallback(() => {
+    trackConnectAppButtonClicked({ sourceFlow, modelId, button: CONNECT_APP_BUTTON.Close });
+    onCancel();
+  }, [onCancel, sourceFlow, modelId]);
+
+  const onContactSupport = useCallback(() => {
+    trackConnectAppButtonClicked({
+      sourceFlow,
+      modelId,
+      button: CONNECT_APP_BUTTON.ContactLedgerSupport,
+    });
+    openSupport();
+  }, [openSupport, sourceFlow, modelId]);
 
   return {
-    onCancel,
-    onContactSupport: openSupport,
+    onCancel: onCancelWithTracking,
+    onContactSupport,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/index.tsx
@@ -15,7 +15,7 @@ const DeviceContextInitializerComponentLWM: DeviceContextInitializerComponent<
   InitializationInput,
   InitializerConfig
 > = ({ connectionResult, deviceInitializationInput, onContextInitialized, config, onClose }) => {
-  const { state, device } = useDeviceContextInitializerComponentLWMViewModel({
+  const { state, device, sourceFlow } = useDeviceContextInitializerComponentLWMViewModel({
     connectionResult,
     deviceInitializationInput,
     onContextInitialized,
@@ -23,7 +23,12 @@ const DeviceContextInitializerComponentLWM: DeviceContextInitializerComponent<
   });
 
   return (
-    <DeviceContextInitializerComponentLWMView state={state} device={device} onCancel={onClose} />
+    <DeviceContextInitializerComponentLWMView
+      state={state}
+      device={device}
+      sourceFlow={sourceFlow}
+      onCancel={onClose}
+    />
   );
 };
 

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/types.ts
@@ -1,5 +1,6 @@
 import type { EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
 import type { DeviceModelId } from "@ledgerhq/types-devices";
+import type { SourceFlow } from "../utils/SourceFlowContext";
 
 export type InitializerDevice = Readonly<{
   id: string;
@@ -12,11 +13,13 @@ export type InitializerDevice = Readonly<{
 export type DeviceContextInitializerComponentLWMViewProps = Readonly<{
   state: EnsureAppReadyState;
   device: InitializerDevice;
+  sourceFlow: SourceFlow;
   onCancel: () => void;
 }>;
 
 export type BaseInitializerStateProps<State extends EnsureAppReadyState> = Readonly<{
   state: State;
   device: InitializerDevice;
+  sourceFlow: SourceFlow;
   onCancel: () => void;
 }>;

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/useDeviceContextInitializerComponentLWMViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/useDeviceContextInitializerComponentLWMViewModel.ts
@@ -17,6 +17,7 @@ import { settingsStoreSelector } from "~/reducers/settings";
 import type { InitializationInput } from "../types";
 import { buildInitializerDevice } from "./utils/buildInitializerDevice";
 import type { InitializerDevice } from "./types";
+import { useSourceFlow, type SourceFlow } from "../utils/SourceFlowContext";
 
 type UseDeviceContextInitializerComponentLWMViewModelParams = {
   connectionResult: DeviceConnectionResult;
@@ -28,6 +29,7 @@ type UseDeviceContextInitializerComponentLWMViewModelParams = {
 type UseDeviceContextInitializerComponentLWMViewModelResult = {
   state: EnsureAppReadyState;
   device: InitializerDevice;
+  sourceFlow: SourceFlow;
 };
 
 const LOADING_STATE: EnsureAppReadyState = { type: LoadingStateType.Loading };
@@ -39,6 +41,7 @@ export function useDeviceContextInitializerComponentLWMViewModel({
   dependencies,
 }: UseDeviceContextInitializerComponentLWMViewModelParams): UseDeviceContextInitializerComponentLWMViewModelResult {
   const dispatch = useDispatch();
+  const sourceFlow = useSourceFlow();
   const deprecationDismissedCurrencyNames =
     useSelector(settingsStoreSelector).deprecationDoNotRemind;
   const [state, setState] = useState<EnsureAppReadyState>(LOADING_STATE);
@@ -103,5 +106,5 @@ export function useDeviceContextInitializerComponentLWMViewModel({
     sideEffects,
   ]);
 
-  return { state, device };
+  return { state, device, sourceFlow };
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.test.ts
@@ -7,6 +7,7 @@ import { previousRouteNameRef } from "~/analytics/screenRefs";
 import {
   getTrackingSubError,
   getTrackingTransport,
+  trackConnectAppButtonClicked,
   trackConnectDeviceButtonClicked,
   trackAppReady,
   trackDeviceConnected,
@@ -238,6 +239,23 @@ describe("trackDeviceIntent — Layer A tracking helpers", () => {
             button: "Retry",
           });
         });
+      });
+    });
+  });
+
+  describe("trackConnectAppButtonClicked", () => {
+    it("GIVEN sourceFlow modelId and button WHEN called THEN it tracks button_clicked with the Layer B properties", () => {
+      trackConnectAppButtonClicked({
+        sourceFlow: "send",
+        modelId: DeviceModelId.stax,
+        button: "Retry",
+      });
+
+      expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+        ...layerABaseProperties,
+        sourceFlow: "send",
+        modelId: DeviceModelId.stax,
+        button: "Retry",
       });
     });
   });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
@@ -31,6 +31,43 @@ export const CONNECT_DEVICE_BUTTON = {
   GetHelp: "Get Help",
 } as const;
 
+export const PAGE_CONNECT_APP = {
+  Loading: "Connect App - Loading",
+  InstallingApp: "Connect App - Installing App",
+  UnlockDevice: "Connect App - Unlock Device",
+  AllowSecureConnection: "Connect App - Allow Secure Connection",
+  ConfirmOpenApp: "Connect App - Confirm Open App",
+  DeviceDeprecatedWarning: "Connect App - Device Deprecated Warning",
+  OutdatedAppWarning: "Connect App - Outdated App Warning",
+  DeviceLocked: "Connect App - Device Locked",
+  UserRefused: "Connect App - User Refused",
+  DeviceBusy: "Connect App - Device Busy",
+  DeviceNotOnboarded: "Connect App - Device Not Onboarded",
+  UnsupportedFirmware: "Connect App - Unsupported Firmware",
+  UnsupportedApplication: "Connect App - Unsupported Application",
+  UnsupportedFeature: "Connect App - Unsupported Feature",
+  DeviceDeprecatedBlocking: "Connect App - Device Deprecated Blocking",
+  WrongDeviceForAccount: "Connect App - Wrong Device For Account",
+  OutOfStorage: "Connect App - Out Of Storage",
+  Error: "Connect App - Error",
+} as const;
+
+/**
+ * Canonical, locale-independent `button` values for Connect App `button_clicked`
+ * events. The displayed CTA label stays localized; analytics receives these stable
+ * strings so the property is not fragmented across languages.
+ */
+export const CONNECT_APP_BUTTON = {
+  Continue: "Continue",
+  Cancel: "Cancel",
+  Retry: "Retry",
+  Close: "Close",
+  SetUpDevice: "Set Up Device",
+  UpdateFirmware: "Update Firmware",
+  ContactLedgerSupport: "Contact Ledger Support",
+  ManageApps: "Manage Apps",
+} as const;
+
 export type TrackingTransport = "ble" | "usb";
 type ConnectDeviceErrorType = ConnectionErrorTypes | DiscoveryErrorTypes;
 
@@ -145,6 +182,18 @@ export const trackConnectDeviceButtonClicked = (params: {
 }): void => {
   track("button_clicked", {
     ...getDeviceUxV2BaseProperties(params.sourceFlow),
+    button: params.button,
+  });
+};
+
+export const trackConnectAppButtonClicked = (params: {
+  sourceFlow: SourceFlow;
+  modelId: DeviceModelId;
+  button: string;
+}): void => {
+  track("button_clicked", {
+    ...getDeviceUxV2BaseProperties(params.sourceFlow),
+    modelId: params.modelId,
     button: params.button,
   });
 };

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/InitializerStatesScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/InitializerStatesScreen.tsx
@@ -246,6 +246,7 @@ export default function DebugInitializerStatesScreen() {
             <DeviceContextInitializerComponentLWMView
               state={selectedScenario.state}
               device={mockDevice}
+              sourceFlow="debug"
               onCancel={() => setSelectedScenario(null)}
             />
           ) : null}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Connect App phase analytics only (no behavior/UI change)
      - Verify each `EnsureAppReady` state fires its `Connect App - *` page event with `sourceFlow`, `source`, `deviceUxV2`, `modelId`
      - Verify `Connect App - Loading` only fires when loading dwells past 250ms
      - Verify each in-app CTA fires `button_clicked` with the canonical `button` value

### 📝 Description

Implements §5 (Connect App phase — granular, Layer B) of the Device UX V2 tracking plan.

- Adds a `Connect App - *` `TrackScreen` page event to each `EnsureAppReady` state component, with a 250ms dwell gate on `loading` to avoid noise from transient flashes.
- Adds `button_clicked` on every in-app CTA using canonical, locale-independent `button` values (e.g. `Retry`, `Continue`, `Manage Apps`, `Set Up Device`, `Contact Ledger Support`).
- All events carry `sourceFlow`, `source`, `deviceUxV2` and `modelId`.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31527](https://ledgerhq.atlassian.net/browse/LIVE-31527)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31527]: https://ledgerhq.atlassian.net/browse/LIVE-31527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ