### PR TITLE
[LWD] fix(desktop): hide mobile webview toggle with dev tools off

### DIFF
--- a/.changeset/quiet-cats-hide.md
+++ b/.changeset/quiet-cats-hide.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Hide webview mobile view toggle when platform dev tools are disabled

--- a/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/TopBar.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/TopBar.test.tsx
@@ -110,6 +110,7 @@ describe("Top Bar", () => {
     );
     expect(screen.getByText("Refresh")).toBeInTheDocument();
     expect(screen.queryByText("common.sync.devTools")).toBeNull();
+    expect(screen.queryByTestId("mobile-view-toggle")).toBeNull();
   });
 
   it("toggles mobile view when mobile view switch is clicked", () => {

--- a/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/TopBar.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/TopBar.tsx
@@ -273,7 +273,7 @@ export const TopBar = ({
           </ItemContainer>
         </>
       ) : null}
-      {!!mobileView && (
+      {!!mobileView && enablePlatformDevTools && (
         <>
           <Separator />
           <ItemContainer


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - webviews topbar button

### 📝 Description

Hide the webview mobile view toggle when platform dev tools are disabled.
Add a regression test for the external app topbar state.

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
