### PR TITLE
[LWD] fix(desktop): center webview network error screen

### DIFF
--- a/.changeset/calm-webviews-center.md
+++ b/.changeset/calm-webviews-center.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix webview network error screen centering

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
@@ -522,6 +522,11 @@ export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
       customWebviewStyle,
       manifestDomainCheckEnabled,
     );
+    const isNetworkErrorVisible = !webviewState.loading && webviewState.isAppUnavailable;
+    const displayedWebviewStyle = useMemo(
+      () => (isNetworkErrorVisible ? { ...webviewStyle, display: "none" } : webviewStyle),
+      [isNetworkErrorVisible, webviewStyle],
+    );
 
     const isDapp = !!manifest.dapp;
     const preloader = isDapp ? "webviewDappPreloader" : "webviewPreloader";
@@ -540,9 +545,7 @@ export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
 
     return (
       <>
-        {!webviewState.loading && webviewState.isAppUnavailable && (
-          <NetworkErrorScreen refresh={handleRefresh} />
-        )}
+        {isNetworkErrorVisible && <NetworkErrorScreen refresh={handleRefresh} />}
         <webview
           ref={webviewRef}
           /**
@@ -551,7 +554,7 @@ export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
            * When using a styled webview componennt, the `allowpopups` prop does not
            * seem to be set
            */
-          style={webviewStyle}
+          style={displayedWebviewStyle}
           preload={`file://${window.api.appDirname}/${preloader}.bundle.js`}
           /**
            * There seems to be an issue between Electron webview and react


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Tested manually
- [x] **Impact of the changes:**
  - webviews error message position on desktop

### 📝 Description

Hide the failed webview from layout while the network error fallback is visible so the fallback centers in the full webview area.

| Before        | After         |
| ------------- | ------------- |
| <img width="1912" height="1242" alt="Screenshot 2026-05-29 at 19 33 53" src="https://github.com/user-attachments/assets/0b40b421-792e-4cee-8c19-b78ff75c39be" /> | <img width="1912" height="1242" alt="Screenshot 2026-05-29 at 19 28 25" src="https://github.com/user-attachments/assets/ff1b187c-9716-4e2a-b27e-6da425f3d1c3" /> |

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
