### PR TITLE
[LWD] fix(lld): show webview network error screen on first load

### DIFF
--- a/.changeset/wise-pillows-share.md
+++ b/.changeset/wise-pillows-share.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix webview NetworkErrorScreen not appearing on the first load by attaching webview event listeners through a callback ref instead of a one-shot mounted latch

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/PlatformAPIWebview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/PlatformAPIWebview.tsx
@@ -51,14 +51,15 @@ import { setOriginFlow } from "~/renderer/analytics/originFlow";
 export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
   ({ manifest, inputs = {}, onStateChange }, ref) => {
     const manifestDomainCheckEnabled = useFeature("lldWebviewManifestDomainCheck")?.enabled;
-    const { webviewState, webviewRef, webviewProps, webviewPartition } = useWebviewState(
-      {
-        manifest,
-        inputs,
-        manifestDomainCheckEnabled,
-      },
-      ref,
-    );
+    const { webviewState, webviewRef, setWebviewRef, webviewProps, webviewPartition } =
+      useWebviewState(
+        {
+          manifest,
+          inputs,
+          manifestDomainCheckEnabled,
+        },
+        ref,
+      );
 
     const tracking = useMemo(
       () =>
@@ -460,7 +461,7 @@ export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
     return (
       <>
         <webview
-          ref={webviewRef}
+          ref={setWebviewRef}
           /**
            * There seems to be an issue between Electron webview and styled-components
            * (and React more broadly, cf. comment below).

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
@@ -492,7 +492,7 @@ export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
 
     const serverRef = useRef<WalletAPIServer>(undefined);
 
-    const { webviewState, webviewRef, webviewProps, handleRefresh, webviewPartition } =
+    const { webviewState, webviewRef, setWebviewRef, webviewProps, handleRefresh, webviewPartition } =
       useWebviewState(
         {
           manifest,
@@ -544,7 +544,7 @@ export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
           <NetworkErrorScreen refresh={handleRefresh} />
         )}
         <webview
-          ref={webviewRef}
+          ref={setWebviewRef}
           /**
            * There seem to be an issue between Electron webview and styled-components
            * (and React more broadly, cf. comment below).

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.test.ts
@@ -1,7 +1,8 @@
-import { renderHook } from "tests/testSetup";
+import { act, renderHook } from "tests/testSetup";
 import { useWebviewState } from "./helpers";
 import { getInitialURL } from "@ledgerhq/live-common/wallet-api/helpers";
 import type { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
+import type { WebviewTag } from "./types";
 
 jest.mock("@ledgerhq/live-common/wallet-api/helpers", () => ({
   getInitialURL: jest.fn(),
@@ -124,6 +125,52 @@ describe("useWebviewState", () => {
       const { result } = renderHook(() => useWebviewState({ manifest: manifestWithCache }, null));
 
       expect(result.current.webviewPartition).toEqual({ partition: "persist:myapp-2" });
+    });
+  });
+
+  describe("setWebviewRef", () => {
+    const webviewEvents = [
+      "page-title-updated",
+      "did-navigate",
+      "did-navigate-in-page",
+      "did-start-loading",
+      "did-stop-loading",
+      "dom-ready",
+      "did-fail-load",
+      "render-process-gone",
+    ];
+
+    it("should attach listeners when the webview node is set and detach them on cleanup", () => {
+      mockGetInitialURL.mockReturnValue("https://example.com/");
+      const addEventListener = jest.fn();
+      const removeEventListener = jest.fn();
+      const mockWebview = {
+        addEventListener,
+        removeEventListener,
+      } as unknown as WebviewTag;
+
+      const { result } = renderHook(() => useWebviewState({ manifest: mockManifest }, null));
+
+      let cleanup: () => void = jest.fn();
+      act(() => {
+        cleanup = result.current.setWebviewRef(mockWebview);
+      });
+
+      expect(result.current.webviewRef.current).toBe(mockWebview);
+      expect(addEventListener).toHaveBeenCalledTimes(webviewEvents.length);
+      webviewEvents.forEach(eventName => {
+        expect(addEventListener).toHaveBeenCalledWith(eventName, expect.any(Function));
+      });
+
+      act(() => {
+        cleanup();
+      });
+
+      expect(result.current.webviewRef.current).toBeNull();
+      expect(removeEventListener).toHaveBeenCalledTimes(webviewEvents.length);
+      addEventListener.mock.calls.forEach(([eventName, handler]) => {
+        expect(removeEventListener).toHaveBeenCalledWith(eventName, handler);
+      });
     });
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.ts
@@ -56,6 +56,7 @@ type UseWebviewStateReturn = {
     src: string;
   };
   webviewRef: RefObject<WebviewTag | null>;
+  setWebviewRef: (node: WebviewTag) => () => void;
   webviewPartition: WebviewPartition;
   handleRefresh: () => void;
 };
@@ -137,10 +138,19 @@ export function useWebviewState(
     [manifest.domains, manifestDomainCheckEnabled, serverRef],
   );
 
-  const [isMounted, setMounted] = useState<boolean>(false);
-  useEffect(() => {
-    setMounted(true);
-  }, [isMounted]);
+  // Track the actual webview DOM node via a callback ref. Unlike a plain ref,
+  // a state update re-triggers the listener-attach effect exactly when the
+  // <webview> element mounts/unmounts, avoiding a race where the node appears
+  // after a one-shot "mounted" latch has already settled.
+  const [webviewNode, setWebviewNode] = useState<WebviewTag | null>(null);
+  const setWebviewRef = useCallback((node: WebviewTag) => {
+    webviewRef.current = node;
+    setWebviewNode(node);
+    return () => {
+      webviewRef.current = null;
+      setWebviewNode(null);
+    };
+  }, []);
 
   const handlePageTitleUpdated = useCallback((event: Electron.PageTitleUpdatedEvent) => {
     setState(oldState => ({
@@ -254,9 +264,9 @@ export function useWebviewState(
   }, [webviewRef]);
 
   useEffect(() => {
-    const webview = webviewRef.current;
+    const webview = webviewNode;
 
-    if (!isMounted || !webview) {
+    if (!webview) {
       return;
     }
 
@@ -288,8 +298,7 @@ export function useWebviewState(
     handleDomReady,
     handleFailLoad,
     handleCrashed,
-    webviewRef,
-    isMounted,
+    webviewNode,
   ]);
 
   const props = {
@@ -313,6 +322,7 @@ export function useWebviewState(
     webviewState: state,
     webviewProps: props,
     webviewRef,
+    setWebviewRef,
     webviewPartition,
     handleRefresh,
   };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Tested manually
- [x] **Impact of the changes:**
  - discover webviews error handling on first load

### 📝 Description

The NetworkErrorScreen depends on webview listeners (did-fail-load / render-process-gone) that set isAppUnavailable. These were attached in an effect gated behind a one-shot isMounted latch. On a cold first load, isMounted latched true before the <webview> ref was populated, so the effect bailed and never re-ran (refs don't retrigger effects), leaving listeners unattached.

Replace the isMounted latch with a callback ref that stores the webview node in state. The attach effect now keys off that node, so listeners attach exactly when the element mounts, regardless of timing. The ref callback returns a React 19 cleanup to detach on unmount.

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
