### PR TITLE
[LWDM] chore(coin-evm): loop through the validators pages

### DIFF
--- a/.changeset/paginate-evm-validators.md
+++ b/.changeset/paginate-evm-validators.md
@@ -1,0 +1,11 @@
+---
+"@ledgerhq/coin-evm": patch
+"@ledgerhq/live-common": patch
+---
+
+feat(coin-evm): paginate EVM staking validators
+
+`getValidators` is now cursor-based and returns a `Page<StakingValidatorItem>`, and the
+`useEvmStakingValidators` hook walks every page (following `next`) instead of reading only
+the first one. Each page is cached independently in the LRU cache (`currencyId-cursor` key).
+Sei stays single-page (`next: undefined`), so its behaviour is unchanged.

--- a/libs/coin-modules/coin-evm/src/api/index.test.ts
+++ b/libs/coin-modules/coin-evm/src/api/index.test.ts
@@ -91,5 +91,9 @@ describe("staking support capability", () => {
     const api = createApi({ explorer: { type: "ledger" } } as EvmConfig, "sei_evm");
 
     await expect(api.getValidators()).resolves.toEqual(expectedPage);
+    expect(mockGetValidatorsPage).toHaveBeenCalledWith("sei_evm", undefined);
+
+    await expect(api.getValidators("42")).resolves.toEqual(expectedPage);
+    expect(mockGetValidatorsPage).toHaveBeenCalledWith("sei_evm", "42");
   });
 });

--- a/libs/coin-modules/coin-evm/src/api/index.ts
+++ b/libs/coin-modules/coin-evm/src/api/index.ts
@@ -96,7 +96,8 @@ export function createApi(
     getRewards(_address: string, _cursor?: Cursor): Promise<Page<Reward>> {
       throw new Error("getRewards is not supported");
     },
-    getValidators: (): Promise<Page<Validator>> => getValidatorsPage(currency.id),
+    getValidators: (cursor?: Cursor): Promise<Page<Validator>> =>
+      getValidatorsPage(currency.id, cursor),
     getNextSequence: (address: string): Promise<bigint> => getNextSequence(currency, address),
     validateAddress,
     validateIntent: (

--- a/libs/coin-modules/coin-evm/src/logic/getStakes.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/getStakes.test.ts
@@ -105,10 +105,10 @@ describe("EVM Staking - getStakes", () => {
   it("should handle multiple validators and filter zero amounts", async () => {
     const currency = getCryptoCurrencyById("sei_evm");
 
-    mockGetValidators.mockResolvedValue([
-      makeValidator("seivaloper1abc"),
-      makeValidator("seivaloper1def"),
-    ]);
+    mockGetValidators.mockResolvedValue({
+      items: [makeValidator("seivaloper1abc"), makeValidator("seivaloper1def")],
+      next: undefined,
+    });
 
     mockWithApi.mockImplementation(async (_cur, fn) => {
       const api = { call: jest.fn().mockResolvedValue("0x") } as unknown as JsonRpcProvider;
@@ -179,7 +179,10 @@ describe("EVM Staking - getStakes", () => {
   it("should treat SEI missing delegation reverts as an empty stake without logging", async () => {
     const currency = getCryptoCurrencyById("sei_evm");
 
-    mockGetValidators.mockResolvedValue([makeValidator("seivaloper1abc")]);
+    mockGetValidators.mockResolvedValue({
+      items: [makeValidator("seivaloper1abc")],
+      next: undefined,
+    });
     mockWithApi.mockImplementation(async (_cur, fn) => {
       const api = {
         call: jest.fn().mockRejectedValue(
@@ -207,7 +210,7 @@ describe("EVM Staking - getStakes", () => {
   it("should handle SEI when no validators are available", async () => {
     const currency = getCryptoCurrencyById("sei_evm");
 
-    mockGetValidators.mockResolvedValue([]);
+    mockGetValidators.mockResolvedValue({ items: [], next: undefined });
 
     const result = await getStakes(currency, address);
 

--- a/libs/coin-modules/coin-evm/src/staking/fetchers.ts
+++ b/libs/coin-modules/coin-evm/src/staking/fetchers.ts
@@ -39,9 +39,12 @@ const createStakingFetcher = (
 
 export const STAKING_CONFIG: Record<string, StakingStrategy> = {
   sei_evm: {
-    fetcher: createStakingFetcher(
-      async (config, currency) => await getValidators(currency.id, config.apiConfig),
-    ),
+    // Sei returns its whole validator set in a single page, so the first page's
+    // items are the complete list.
+    fetcher: createStakingFetcher(async (_config, currency) => {
+      const { items } = await getValidators(currency.id);
+      return items;
+    }),
   },
   celo: {
     fetcher: createStakingFetcher(async config => [

--- a/libs/coin-modules/coin-evm/src/staking/validators.test.ts
+++ b/libs/coin-modules/coin-evm/src/staking/validators.test.ts
@@ -54,27 +54,56 @@ describe("staking/validators", () => {
           method: "GET",
         }),
       );
-      expect(first).toEqual([
-        expect.objectContaining({
-          validatorAddress: "seivaloper1abc",
-          name: "John",
-          commission: 0.05,
-          tokens: "100",
-          votingPower: 0,
-          estimatedYearlyRewardsRate: 0,
-        }),
-        expect.objectContaining({
-          validatorAddress: "seivaloper1def",
-          name: "Doe",
-          commission: 1,
-          tokens: "999",
-          votingPower: 1,
-          estimatedYearlyRewardsRate: 0,
-        }),
-      ]);
+      expect(first).toEqual({
+        items: [
+          expect.objectContaining({
+            validatorAddress: "seivaloper1abc",
+            name: "John",
+            commission: 0.05,
+            tokens: "100",
+            votingPower: 0,
+            estimatedYearlyRewardsRate: 0,
+          }),
+          expect.objectContaining({
+            validatorAddress: "seivaloper1def",
+            name: "Doe",
+            commission: 1,
+            tokens: "999",
+            votingPower: 1,
+            estimatedYearlyRewardsRate: 0,
+          }),
+        ],
+        next: undefined,
+      });
 
       expect(await getValidators("sei_evm")).toEqual(first);
       expect(mockedNetwork).toHaveBeenCalledTimes(1);
+    });
+
+    it("caches each cursor page under a separate key", async () => {
+      mockedNetwork.mockResolvedValue(cosmosValidatorsPayload);
+
+      await getValidators("sei_evm");
+      await getValidators("sei_evm", "5");
+      expect(mockedNetwork).toHaveBeenCalledTimes(2);
+
+      await getValidators("sei_evm");
+      await getValidators("sei_evm", "5");
+      expect(mockedNetwork).toHaveBeenCalledTimes(2);
+    });
+
+    it("clearValidatorsCache(currencyId) evicts every cached page of that currency", async () => {
+      mockedNetwork.mockResolvedValue(cosmosValidatorsPayload);
+
+      await getValidators("sei_evm");
+      await getValidators("sei_evm", "5");
+      expect(mockedNetwork).toHaveBeenCalledTimes(2);
+
+      clearValidatorsCache("sei_evm");
+
+      await getValidators("sei_evm");
+      await getValidators("sei_evm", "5");
+      expect(mockedNetwork).toHaveBeenCalledTimes(4);
     });
 
     it("returns cached data without a second network call while fresh", async () => {
@@ -104,17 +133,8 @@ describe("staking/validators", () => {
       expect(mockedNetwork).toHaveBeenCalledTimes(2);
     });
 
-    it("bypasses cache when apiConfig is passed explicitly", async () => {
-      mockedNetwork.mockResolvedValue(cosmosValidatorsPayload);
-
-      await getValidators("sei_evm");
-      await getValidators("sei_evm", { baseUrl: "https://x", validatorsEndpoint: "/y" });
-
-      expect(mockedNetwork).toHaveBeenCalledTimes(2);
-    });
-
-    it("returns [] for currencies without a validator API", async () => {
-      expect(await getValidators("ethereum")).toEqual([]);
+    it("returns an empty page for currencies without a validator API", async () => {
+      expect(await getValidators("ethereum")).toEqual({ items: [], next: undefined });
       expect(mockedNetwork).not.toHaveBeenCalled();
     });
 
@@ -133,10 +153,13 @@ describe("staking/validators", () => {
 
       const second = await getValidators("sei_evm");
 
-      expect(second).toEqual([
-        expect.objectContaining({ validatorAddress: "seivaloper1abc" }),
-        expect.objectContaining({ validatorAddress: "seivaloper1def" }),
-      ]);
+      expect(second).toEqual({
+        items: [
+          expect.objectContaining({ validatorAddress: "seivaloper1abc" }),
+          expect.objectContaining({ validatorAddress: "seivaloper1def" }),
+        ],
+        next: undefined,
+      });
       expect(mockedNetwork).toHaveBeenCalledTimes(2);
 
       releaseFirst(cosmosValidatorsPayload);

--- a/libs/coin-modules/coin-evm/src/staking/validators.ts
+++ b/libs/coin-modules/coin-evm/src/staking/validators.ts
@@ -1,14 +1,14 @@
 import network from "@ledgerhq/live-network";
 import { makeLRUCache } from "@ledgerhq/live-network/cache";
-import type { Page, Validator } from "@ledgerhq/coin-module-framework/api/index";
+import type { Cursor, Page, Validator } from "@ledgerhq/coin-module-framework/api/index";
 import type { StakingValidatorItem } from "@ledgerhq/types-live";
 import { STAKING_CONTRACTS } from "./contracts";
 
 export type ValidatorApi = {
-  fetchValidators: (config: {
-    baseUrl: string;
-    validatorsEndpoint: string;
-  }) => Promise<StakingValidatorItem[]>;
+  fetchValidators: (
+    currencyId: string,
+    cursor?: Cursor,
+  ) => Promise<Page<StakingValidatorItem>>;
 };
 
 type CosmosValidatorDescription = {
@@ -36,10 +36,14 @@ const CACHE_MAX_AGE_MS = 30 * 1000;
 
 type CosmosValidatorsResponse = { validators: CosmosValidator[] };
 
+// Sei's REST endpoint returns the whole validator set in one response, so it
+// ignores the cursor and always reports `next: undefined` (single page).
 const seiValidatorApi: ValidatorApi = {
-  fetchValidators: async config => {
-    const { baseUrl, validatorsEndpoint } = config;
-    if (!baseUrl) return [];
+  fetchValidators: async (currencyId): Promise<Page<StakingValidatorItem>> => {
+    const apiConfig = STAKING_CONTRACTS[currencyId]?.apiConfig;
+    if (!apiConfig?.baseUrl) return { items: [], next: undefined };
+
+    const { baseUrl, validatorsEndpoint } = apiConfig;
 
     try {
       const { data } = await network<CosmosValidatorsResponse>({
@@ -47,26 +51,26 @@ const seiValidatorApi: ValidatorApi = {
         method: "GET",
       });
 
-      return Array.isArray(data?.validators)
+      const items: StakingValidatorItem[] = Array.isArray(data?.validators)
         ? data.validators
             .filter((v): v is CosmosValidator => typeof v?.operator_address === "string")
-            .map(
-              (v, index): StakingValidatorItem => ({
-                validatorAddress: v.operator_address,
-                name: v.description?.moniker ?? v.operator_address,
-                commission: Number.parseFloat(v.commission?.commission_rates?.rate ?? "0"),
-                tokens: v.tokens ?? "0",
-                votingPower: index,
-                estimatedYearlyRewardsRate: 0,
-              }),
-            )
+            .map((v, index) => ({
+              validatorAddress: v.operator_address,
+              name: v.description?.moniker ?? v.operator_address,
+              commission: Number.parseFloat(v.commission?.commission_rates?.rate ?? "0"),
+              tokens: v.tokens ?? "0",
+              votingPower: index,
+              estimatedYearlyRewardsRate: 0,
+            }))
         : [];
+
+      return { items, next: undefined };
     } catch (error) {
       console.error("Failed to fetch SEI validators", {
         error: error instanceof Error ? error.message : String(error),
         baseUrl,
       });
-      return [];
+      return { items: [], next: undefined };
     }
   },
 };
@@ -82,48 +86,73 @@ export const getValidatorApi = (currencyId: string): ValidatorApi | undefined =>
 
 const resolveValidators = async (
   currencyId: string,
-  apiConfig?: { baseUrl: string; validatorsEndpoint: string },
-): Promise<StakingValidatorItem[]> => {
+  cursor?: Cursor,
+): Promise<Page<StakingValidatorItem>> => {
   const api = getValidatorApi(currencyId);
-  const config = apiConfig ?? STAKING_CONTRACTS[currencyId]?.apiConfig;
-  if (!api || !config) return [];
-  return api.fetchValidators(config);
+  if (!api) return { items: [], next: undefined };
+  return api.fetchValidators(currencyId, cursor);
 };
 
-// Single LRU cache keyed by currencyId. Because makeLRUCache stores the pending
+// One cache key per page, so each page of a paginated chain (e.g. Monad) is
+// cached and deduplicated independently. Because makeLRUCache stores the pending
 // promise, concurrent callers (e.g. Info modal + Delegate modal opening in quick
 // succession) share one in-flight fetch — no separate request-deduplication map needed.
+const pageKey = (currencyId: string, cursor?: Cursor): string => `${currencyId}-${cursor ?? ""}`;
+
 const validatorsCache = makeLRUCache(
-  (currencyId: string) => resolveValidators(currencyId),
-  (currencyId: string) => currencyId,
+  (currencyId: string, cursor?: Cursor) => resolveValidators(currencyId, cursor),
+  (currencyId: string, cursor?: Cursor) => pageKey(currencyId, cursor),
   { max: 50, ttl: CACHE_MAX_AGE_MS },
 );
 
+// makeLRUCache exposes no key enumeration, so we track the page keys we've issued
+// to support clearing every page of a single currency (keys are `currencyId-cursor`).
+const issuedKeys = new Set<string>();
+
 export const clearValidatorsCache = (currencyId?: string): void => {
-  if (currencyId) {
-    validatorsCache.clear(currencyId);
-  } else {
+  if (!currencyId) {
     validatorsCache.reset();
+    issuedKeys.clear();
+    return;
+  }
+
+  // Evict every cached page of this currency (the `-` delimiter keeps e.g.
+  // "monad" from matching "monad2").
+  for (const key of issuedKeys) {
+    if (key.startsWith(`${currencyId}-`)) {
+      validatorsCache.clear(key);
+      issuedKeys.delete(key);
+    }
   }
 };
 
 export const getValidators = async (
   currencyId: string,
-  apiConfig?: { baseUrl: string; validatorsEndpoint: string },
-): Promise<StakingValidatorItem[]> => {
-  // Explicit apiConfig bypasses the cache (callers opt out on purpose, e.g. tests).
-  if (apiConfig) return resolveValidators(currencyId, apiConfig);
+  cursor?: Cursor,
+): Promise<Page<StakingValidatorItem>> => {
+  const key = pageKey(currencyId, cursor);
+  issuedKeys.add(key);
 
-  const data = await validatorsCache(currencyId);
-  // Never keep an empty list cached, so a transient empty response is retried next time.
-  if (data.length === 0) validatorsCache.clear(currencyId);
-  return data;
+  try {
+    const page = await validatorsCache(currencyId, cursor);
+    // Never keep an empty page cached, so a transient empty response is retried next time.
+    if (page.items.length === 0) {
+      validatorsCache.clear(key);
+      issuedKeys.delete(key);
+    }
+    return page;
+  } catch (error) {
+    // makeLRUCache already evicted the rejected entry; keep issuedKeys in sync.
+    issuedKeys.delete(key);
+    throw error;
+  }
 };
 
 /**
  * Fire-and-forget warm-up of the validators cache. Called before the user
  * reaches the validator selection step so the list appears instantly. A fresh
  * cache entry already returns without a network call, so repeated calls are cheap.
+ * Only the first page is warmed; subsequent pages are fetched lazily by the hook.
  */
 export const prefetchValidators = (currencyId: string): void => {
   void getValidators(currencyId).catch(() => {
@@ -154,16 +183,19 @@ const toValidatorBalance = (tokens: string): bigint => {
   }
 };
 
-export const getValidatorsPage = async (currencyId: string): Promise<Page<Validator>> => {
-  const items = await getValidators(currencyId);
+export const getValidatorsPage = async (
+  currencyId: string,
+  cursor?: Cursor,
+): Promise<Page<Validator>> => {
+  const page = await getValidators(currencyId, cursor);
   return {
-    items: items.map(v => ({
+    items: page.items.map(v => ({
       address: v.validatorAddress,
       name: v.name,
       balance: toValidatorBalance(v.tokens),
       commissionRate: v.commission.toString(),
       apy: v.estimatedYearlyRewardsRate,
     })),
-    next: undefined,
+    next: page.next,
   };
 };

--- a/libs/ledger-live-common/src/families/evm/staking/react.test.ts
+++ b/libs/ledger-live-common/src/families/evm/staking/react.test.ts
@@ -4,6 +4,7 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import BigNumber from "bignumber.js";
 import type { Unit } from "@ledgerhq/types-cryptoassets";
+import type { Page } from "@ledgerhq/coin-module-framework/api/index";
 import type { StakingValidatorItem, StakingAccount, StakingDelegation } from "@ledgerhq/types-live";
 import * as stakingIndex from "@ledgerhq/coin-evm/staking/index";
 import * as accountModule from "../../../account";
@@ -63,7 +64,7 @@ describe("useEvmStakingValidators", () => {
   });
 
   it("should filter out 100% commission validators, sort by total stake desc, and finish loading", async () => {
-    mockedGetValidators.mockResolvedValue(sampleValidators);
+    mockedGetValidators.mockResolvedValue({ items: sampleValidators, next: undefined });
 
     const { result } = renderHook(() => useEvmStakingValidators("sei_evm"));
 
@@ -72,38 +73,56 @@ describe("useEvmStakingValidators", () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(mockedGetValidators).toHaveBeenCalledWith("sei_evm");
+    expect(mockedGetValidators).toHaveBeenCalledWith("sei_evm", undefined);
     expect(result.current.error).toBeNull();
     expect(result.current.validators.map(v => v.validatorAddress)).toEqual(["addr-c", "addr-a"]);
   });
 
+  it("should walk every page until the cursor is exhausted and merge the results", async () => {
+    mockedGetValidators
+      .mockResolvedValueOnce({ items: [sampleValidators[0]], next: "1" })
+      .mockResolvedValueOnce({ items: [sampleValidators[2]], next: undefined });
+
+    const { result } = renderHook(() => useEvmStakingValidators("sei_evm"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mockedGetValidators).toHaveBeenCalledTimes(2);
+    expect(mockedGetValidators).toHaveBeenNthCalledWith(1, "sei_evm", undefined);
+    expect(mockedGetValidators).toHaveBeenNthCalledWith(2, "sei_evm", "1");
+    expect(result.current.validators.map(v => v.validatorAddress)).toEqual(["addr-c", "addr-a"]);
+  });
+
   it("should sort validators by token amount in descending order", async () => {
-    mockedGetValidators.mockResolvedValue([
-      {
-        validatorAddress: "addr-small",
-        name: "Small",
-        commission: 0.05,
-        tokens: "999",
-        votingPower: 1,
-        estimatedYearlyRewardsRate: 0,
-      },
-      {
-        validatorAddress: "addr-huge",
-        name: "Huge",
-        commission: 0.05,
-        tokens: "1000000000000000000000",
-        votingPower: 3,
-        estimatedYearlyRewardsRate: 0,
-      },
-      {
-        validatorAddress: "addr-mid",
-        name: "Mid",
-        commission: 0.05,
-        tokens: "1500",
-        votingPower: 2,
-        estimatedYearlyRewardsRate: 0,
-      },
-    ]);
+    mockedGetValidators.mockResolvedValue({
+      items: [
+        {
+          validatorAddress: "addr-small",
+          name: "Small",
+          commission: 0.05,
+          tokens: "999",
+          votingPower: 1,
+          estimatedYearlyRewardsRate: 0,
+        },
+        {
+          validatorAddress: "addr-huge",
+          name: "Huge",
+          commission: 0.05,
+          tokens: "1000000000000000000000",
+          votingPower: 3,
+          estimatedYearlyRewardsRate: 0,
+        },
+        {
+          validatorAddress: "addr-mid",
+          name: "Mid",
+          commission: 0.05,
+          tokens: "1500",
+          votingPower: 2,
+          estimatedYearlyRewardsRate: 0,
+        },
+      ],
+      next: undefined,
+    });
 
     const { result } = renderHook(() => useEvmStakingValidators("sei_evm"));
 
@@ -138,7 +157,7 @@ describe("useEvmStakingValidators", () => {
   });
 
   it("should narrow validators by case-insensitive name search", async () => {
-    mockedGetValidators.mockResolvedValue(sampleValidators);
+    mockedGetValidators.mockResolvedValue({ items: sampleValidators, next: undefined });
 
     const { result, rerender } = renderHook(
       ({ search }: { search?: string }) => useEvmStakingValidators("sei_evm", search),
@@ -191,13 +210,13 @@ describe("useEvmStakingValidators", () => {
     ];
 
     // sei_evm resolves after celo to simulate a slow first request.
-    let resolveSei!: (v: StakingValidatorItem[]) => void;
-    const seiPromise = new Promise<StakingValidatorItem[]>(res => {
+    let resolveSei!: (v: Page<StakingValidatorItem>) => void;
+    const seiPromise = new Promise<Page<StakingValidatorItem>>(res => {
       resolveSei = res;
     });
 
     mockedGetValidators.mockImplementation(currencyId =>
-      currencyId === "sei_evm" ? seiPromise : Promise.resolve(celoValidators),
+      currencyId === "sei_evm" ? seiPromise : Promise.resolve({ items: celoValidators, next: undefined }),
     );
 
     const { result, rerender } = renderHook(
@@ -214,7 +233,7 @@ describe("useEvmStakingValidators", () => {
     expect(result.current.validators.map(v => v.validatorAddress)).toEqual(["celo-addr"]);
 
     // Now let the stale sei_evm request resolve — state must not change.
-    resolveSei(seiValidators);
+    resolveSei({ items: seiValidators, next: undefined });
     await Promise.resolve();
     await Promise.resolve();
 
@@ -236,7 +255,7 @@ describe("useEvmFamilyPreloadData", () => {
   });
 
   it("should return validators once loaded", async () => {
-    mockedGetValidators.mockResolvedValue(sampleValidators);
+    mockedGetValidators.mockResolvedValue({ items: sampleValidators, next: undefined });
 
     const { result } = renderHook(() => useEvmFamilyPreloadData("sei_evm"));
 
@@ -254,7 +273,7 @@ describe("useEvmFamilyPreloadData", () => {
   });
 
   it("should not expose loading or error fields", async () => {
-    mockedGetValidators.mockResolvedValue(sampleValidators);
+    mockedGetValidators.mockResolvedValue({ items: sampleValidators, next: undefined });
 
     const { result } = renderHook(() => useEvmFamilyPreloadData("sei_evm"));
 
@@ -274,7 +293,7 @@ describe("useEvmFamilyMappedDelegations", () => {
   });
 
   it("should return mapped delegations enriched with matching validator and rank", async () => {
-    mockedGetValidators.mockResolvedValue(sampleValidators);
+    mockedGetValidators.mockResolvedValue({ items: sampleValidators, next: undefined });
 
     const delegations: StakingDelegation[] = [
       {
@@ -299,7 +318,7 @@ describe("useEvmFamilyMappedDelegations", () => {
   });
 
   it("should set validator to undefined when no matching validator is found", async () => {
-    mockedGetValidators.mockResolvedValue(sampleValidators);
+    mockedGetValidators.mockResolvedValue({ items: sampleValidators, next: undefined });
 
     const delegations: StakingDelegation[] = [
       {
@@ -320,7 +339,7 @@ describe("useEvmFamilyMappedDelegations", () => {
   });
 
   it("should return an empty array when account has no delegations", async () => {
-    mockedGetValidators.mockResolvedValue(sampleValidators);
+    mockedGetValidators.mockResolvedValue({ items: sampleValidators, next: undefined });
 
     const account = makeAccount([]);
 
@@ -332,7 +351,7 @@ describe("useEvmFamilyMappedDelegations", () => {
   });
 
   it("should return an empty array when stakingResources is absent", async () => {
-    mockedGetValidators.mockResolvedValue(sampleValidators);
+    mockedGetValidators.mockResolvedValue({ items: sampleValidators, next: undefined });
 
     const account = {
       currency: { id: "sei_evm" },

--- a/libs/ledger-live-common/src/families/evm/staking/react.ts
+++ b/libs/ledger-live-common/src/families/evm/staking/react.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { getValidators, mapDelegations } from "@ledgerhq/coin-evm/staking/index";
+import type { Cursor } from "@ledgerhq/coin-module-framework/api/index";
 import type { StakingValidatorItem } from "@ledgerhq/types-live";
 import type { StakingAccount, StakingMappedDelegation } from "./types";
 import { getAccountCurrency } from "../../../account";
@@ -42,23 +43,33 @@ export function useEvmStakingValidators(
 
     setFetchState({ items: [], loading: true, error: null });
 
-    // A warm LRU entry resolves on the next microtask, so the loading state is momentary.
-    getValidators(currencyId)
-      .then(items => {
-        if (cancelled) return;
-        setFetchState(s => ({ ...s, items }));
-      })
-      .catch(err => {
+    // Walk every page: keep fetching while the API hands back a cursor. Items are
+    // appended progressively so the list grows as pages arrive (a warm LRU entry
+    // resolves on the next microtask, so for single-page chains this is momentary).
+    const getAllValidators = async () => {
+      try {
+        const items: StakingValidatorItem[] = [];
+        let cursor: Cursor | undefined;
+
+        do {
+          const result = await getValidators(currencyId, cursor);
+          if (cancelled) return;
+
+          items.push(...result.items);
+          cursor = result.next;
+          setFetchState({ items: [...items], loading: typeof cursor === "string", error: null });
+        } while (typeof cursor === "string");
+      } catch (err) {
         if (cancelled) return;
         setFetchState(s => ({
           ...s,
+          loading: false,
           error: err instanceof Error ? err : new Error(String(err)),
         }));
-      })
-      .finally(() => {
-        if (cancelled) return;
-        setFetchState(s => ({ ...s, loading: false }));
-      });
+      }
+    };
+
+    void getAllValidators();
 
     return () => {
       cancelled = true;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Sei validators list

### 📝 Description

  Makes EVM staking validator retrieval cursor-based end-to-end so paginated chains
  (Monad) get their full validator set instead of just the first page.

  `getValidators` now takes an optional `cursor` and returns a `Page<StakingValidatorItem>`
  instead of a flat array. The `useEvmStakingValidators` hook walks every page — fetching
  while the API hands back a `next` cursor and appending results progressively so the list
  grows as pages arrive.

  This entails:
  - each page is cached independently in the existing `makeLRUCache` under a `currencyId-cursor`
    key, so per-page fetches are deduplicated/cached on their own (`clearValidatorsCache`
    still evicts every page of a currency),
  - the `ValidatorApi` contract is now `(currencyId, cursor?) => Promise<Page<…>>`; the
    per-call `apiConfig` bypass was dropped — Sei resolves its own config from `STAKING_CONTRACTS`,
  - **Sei stays single-page**: its REST endpoint returns the whole set in one response, so it
    ignores the cursor and reports `next: undefined` — no behavioral change.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
