### PR TITLE
[LWM] feat: forward currencyId to earn app via swapToEarn flag

### DIFF
--- a/.changeset/tricky-houses-turn.md
+++ b/.changeset/tricky-houses-turn.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/types-live": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+"@shared/feature-flags": minor
+---
+
+Forward on the currencyId to the earn deposit screen to support the swap to earn feature

--- a/.changeset/tricky-houses-turn.md
+++ b/.changeset/tricky-houses-turn.md
@@ -1,7 +1,6 @@
 ---
 "@ledgerhq/types-live": minor
 "live-mobile": minor
-"@ledgerhq/live-common": minor
 "@shared/feature-flags": minor
 ---
 

--- a/apps/ledger-live-mobile/src/components/Stake/useStakingDrawer.test.tsx
+++ b/apps/ledger-live-mobile/src/components/Stake/useStakingDrawer.test.tsx
@@ -20,9 +20,8 @@ jest.mock("LLM/hooks/useStake/useStake", () => ({
   }),
 }));
 
-jest.mock("@ledgerhq/live-common/featureFlags/useFeature", () => ({
-  __esModule: true,
-  default: (...args: unknown[]) => mockUseFeature(...args),
+jest.mock("@features/platform-feature-flags", () => ({
+  useFeature: (...args: unknown[]) => mockUseFeature(...args),
 }));
 
 jest.mock("../../generated/accountActions", () => ({

--- a/apps/ledger-live-mobile/src/components/Stake/useStakingDrawer.test.tsx
+++ b/apps/ledger-live-mobile/src/components/Stake/useStakingDrawer.test.tsx
@@ -6,6 +6,8 @@ import { useStakingDrawer } from "./useStakingDrawer";
 
 const mockGetMainActions = jest.fn();
 const mockBridge = { isAccountEmpty: jest.fn().mockReturnValue(false) };
+const mockGetRouteParamsForPlatformApp = jest.fn().mockReturnValue(null);
+const mockUseFeature = jest.fn().mockReturnValue(undefined);
 
 jest.mock("~/context/hooks", () => ({
   useSelector: jest.fn(() => ({})),
@@ -13,8 +15,14 @@ jest.mock("~/context/hooks", () => ({
 
 jest.mock("LLM/hooks/useStake/useStake", () => ({
   useStake: () => ({
-    getRouteParamsForPlatformApp: jest.fn().mockReturnValue(null),
+    getRouteParamsForPlatformApp: (...args: unknown[]) =>
+      mockGetRouteParamsForPlatformApp(...args),
   }),
+}));
+
+jest.mock("@ledgerhq/live-common/featureFlags/useFeature", () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockUseFeature(...args),
 }));
 
 jest.mock("../../generated/accountActions", () => ({
@@ -48,6 +56,8 @@ const parentRoute = {
 describe("useStakingDrawer", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetRouteParamsForPlatformApp.mockReturnValue(null);
+    mockUseFeature.mockReturnValue(undefined);
   });
 
   it("passes resolved bridge to family getMainActions", async () => {
@@ -89,5 +99,48 @@ describe("useStakingDrawer", () => {
         params: { foo: 1, account: bitcoinAccount, parentAccount: undefined },
       },
     });
+  });
+
+  it("forwards currencyId as cryptoAssetId when swapToEarn flag is enabled", async () => {
+    mockUseFeature.mockReturnValue({ enabled: true });
+    const earnNavParams = {
+      screen: NavigatorName.Earn,
+      params: { screen: "Earn", platform: "earn", params: { cryptoAssetId: "ethereum" } },
+    };
+    mockGetRouteParamsForPlatformApp.mockReturnValue(earnNavParams);
+
+    const { result } = renderHook(() =>
+      useStakingDrawer({ navigation, parentRoute, alwaysShowNoFunds: false }),
+    );
+
+    await result.current(bitcoinAccount as never, undefined, "ethereum");
+
+    expect(mockGetRouteParamsForPlatformApp).toHaveBeenCalledWith(
+      bitcoinAccount,
+      {}, // walletState from useSelector mock
+      undefined, // parentAccount
+      "ethereum", // cryptoAssetId forwarded because swapToEarn is enabled
+    );
+    expect(navigation.navigate).toHaveBeenCalledWith(NavigatorName.Base, earnNavParams);
+  });
+
+  it("does not forward currencyId when swapToEarn flag is disabled", async () => {
+    mockUseFeature.mockReturnValue({ enabled: false });
+    mockGetMainActions.mockReturnValue([
+      { id: "stake", navigationParams: ["Stake", { screen: "StakeScreen", params: {} }] },
+    ]);
+
+    const { result } = renderHook(() =>
+      useStakingDrawer({ navigation, parentRoute, alwaysShowNoFunds: false }),
+    );
+
+    await result.current(bitcoinAccount as never, undefined, "ethereum");
+
+    expect(mockGetRouteParamsForPlatformApp).toHaveBeenCalledWith(
+      bitcoinAccount,
+      {},
+      undefined,
+      undefined, // cryptoAssetId is suppressed when swapToEarn is disabled
+    );
   });
 });

--- a/apps/ledger-live-mobile/src/components/Stake/useStakingDrawer.test.tsx
+++ b/apps/ledger-live-mobile/src/components/Stake/useStakingDrawer.test.tsx
@@ -1,27 +1,21 @@
-import { renderHook } from "@testing-library/react-native";
 import BigNumber from "bignumber.js";
 import type { NavigationProp, ParamListBase, RouteProp } from "@react-navigation/native";
 import { NavigatorName } from "~/const";
 import { useStakingDrawer } from "./useStakingDrawer";
+import {
+  customRenderHookWithLiveAppProvider as renderHook,
+  withFlagOverrides,
+} from "@tests/test-renderer";
 
 const mockGetMainActions = jest.fn();
 const mockBridge = { isAccountEmpty: jest.fn().mockReturnValue(false) };
 const mockGetRouteParamsForPlatformApp = jest.fn().mockReturnValue(null);
-const mockUseFeature = jest.fn().mockReturnValue(undefined);
-
-jest.mock("~/context/hooks", () => ({
-  useSelector: jest.fn(() => ({})),
-}));
 
 jest.mock("LLM/hooks/useStake/useStake", () => ({
   useStake: () => ({
     getRouteParamsForPlatformApp: (...args: unknown[]) =>
       mockGetRouteParamsForPlatformApp(...args),
   }),
-}));
-
-jest.mock("@features/platform-feature-flags", () => ({
-  useFeature: (...args: unknown[]) => mockUseFeature(...args),
 }));
 
 jest.mock("../../generated/accountActions", () => ({
@@ -56,7 +50,6 @@ describe("useStakingDrawer", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetRouteParamsForPlatformApp.mockReturnValue(null);
-    mockUseFeature.mockReturnValue(undefined);
   });
 
   it("passes resolved bridge to family getMainActions", async () => {
@@ -101,22 +94,22 @@ describe("useStakingDrawer", () => {
   });
 
   it("forwards currencyId as cryptoAssetId when swapToEarn flag is enabled", async () => {
-    mockUseFeature.mockReturnValue({ enabled: true });
     const earnNavParams = {
       screen: NavigatorName.Earn,
       params: { screen: "Earn", platform: "earn", params: { cryptoAssetId: "ethereum" } },
     };
     mockGetRouteParamsForPlatformApp.mockReturnValue(earnNavParams);
 
-    const { result } = renderHook(() =>
-      useStakingDrawer({ navigation, parentRoute, alwaysShowNoFunds: false }),
+    const { result } = renderHook(
+      () => useStakingDrawer({ navigation, parentRoute, alwaysShowNoFunds: false }),
+      { overrideInitialState: withFlagOverrides({ swapToEarn: { enabled: true } }) },
     );
 
     await result.current(bitcoinAccount as never, undefined, "ethereum");
 
     expect(mockGetRouteParamsForPlatformApp).toHaveBeenCalledWith(
       bitcoinAccount,
-      {}, // walletState from useSelector mock
+      expect.any(Object), // walletState from Redux store
       undefined, // parentAccount
       "ethereum", // cryptoAssetId forwarded because swapToEarn is enabled
     );
@@ -124,20 +117,20 @@ describe("useStakingDrawer", () => {
   });
 
   it("does not forward currencyId when swapToEarn flag is disabled", async () => {
-    mockUseFeature.mockReturnValue({ enabled: false });
     mockGetMainActions.mockReturnValue([
       { id: "stake", navigationParams: ["Stake", { screen: "StakeScreen", params: {} }] },
     ]);
 
-    const { result } = renderHook(() =>
-      useStakingDrawer({ navigation, parentRoute, alwaysShowNoFunds: false }),
+    const { result } = renderHook(
+      () => useStakingDrawer({ navigation, parentRoute, alwaysShowNoFunds: false }),
+      { overrideInitialState: withFlagOverrides({ swapToEarn: { enabled: false } }) },
     );
 
     await result.current(bitcoinAccount as never, undefined, "ethereum");
 
     expect(mockGetRouteParamsForPlatformApp).toHaveBeenCalledWith(
       bitcoinAccount,
-      {},
+      expect.any(Object), // walletState from Redux store
       undefined,
       undefined, // cryptoAssetId is suppressed when swapToEarn is disabled
     );

--- a/apps/ledger-live-mobile/src/components/Stake/useStakingDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/Stake/useStakingDrawer.tsx
@@ -9,7 +9,7 @@ import { useStake } from "LLM/hooks/useStake/useStake";
 import { getAccountSpendableBalance } from "@ledgerhq/ledger-wallet-framework/account/helpers";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { findCryptoCurrencyById } from "@ledgerhq/cryptoassets";
-import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
+import { useFeature } from "@features/platform-feature-flags";
 
 /** Open the family main actions stake flow for a given account from any navigator. Returns to parent route on completion. */
 export function useStakingDrawer({

--- a/apps/ledger-live-mobile/src/components/Stake/useStakingDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/Stake/useStakingDrawer.tsx
@@ -9,6 +9,7 @@ import { useStake } from "LLM/hooks/useStake/useStake";
 import { getAccountSpendableBalance } from "@ledgerhq/ledger-wallet-framework/account/helpers";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { findCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 
 /** Open the family main actions stake flow for a given account from any navigator. Returns to parent route on completion. */
 export function useStakingDrawer({
@@ -23,11 +24,12 @@ export function useStakingDrawer({
   entryPoint?: "get-funds" | undefined;
 }) {
   const walletState = useSelector(walletSelector);
-
   const { getRouteParamsForPlatformApp } = useStake();
+  const swapToEarnFlag = useFeature("swapToEarn");
+  const isSwapToEarnEnabled = swapToEarnFlag?.enabled ?? false;
 
   return useCallback(
-    async (account: AccountLike, parentAccount?: Account) => {
+    async (account: AccountLike, parentAccount?: Account, currencyId?: string) => {
       if (alwaysShowNoFunds || getAccountSpendableBalance(account).isZero()) {
         // get funds to stake with
         navigation.navigate(NavigatorName.Base, {
@@ -46,10 +48,15 @@ export function useStakingDrawer({
         return;
       }
 
-      const redirectionParams = getRouteParamsForPlatformApp(account, walletState, parentAccount);
+      const cryptoAssetId = isSwapToEarnEnabled ? currencyId : undefined;
+      const redirectionParams = getRouteParamsForPlatformApp(
+        account,
+        walletState,
+        parentAccount,
+        cryptoAssetId,
+      );
 
       if (redirectionParams) {
-        // called onSuccess in the SelectAccount flow
         navigation.navigate(NavigatorName.Base, redirectionParams);
         return;
       }
@@ -116,6 +123,7 @@ export function useStakingDrawer({
     [
       alwaysShowNoFunds,
       getRouteParamsForPlatformApp,
+      isSwapToEarnEnabled,
       walletState,
       parentRoute,
       navigation,

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/CustomHandlers.ts
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/CustomHandlers.ts
@@ -274,7 +274,9 @@ export function useCustomExchangeHandlers({
           navigation.goBack();
           return { success: true };
         } else if (action === "redirect-provider") {
-          const { accountId: walletAccountId, currencyId } = request.params || {};
+          const { accountId: rawAccountId, currencyId: rawCurrencyId } = request.params || {};
+          const walletAccountId = typeof rawAccountId === "string" ? rawAccountId : undefined;
+          const currencyId = typeof rawCurrencyId === "string" ? rawCurrencyId : undefined;
 
           if (walletAccountId) {
             const accountId = getAccountIdFromWalletAccountId(walletAccountId);

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/CustomHandlers.ts
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/CustomHandlers.ts
@@ -274,10 +274,9 @@ export function useCustomExchangeHandlers({
           navigation.goBack();
           return { success: true };
         } else if (action === "redirect-provider") {
-          const { accountId: walletAccountId } = request.params || {};
+          const { accountId: walletAccountId, currencyId } = request.params || {};
 
           if (walletAccountId) {
-            // If we have a specific account, go directly to the stake flow for that account
             const accountId = getAccountIdFromWalletAccountId(walletAccountId);
             const account = accounts.find(acc => acc.id === accountId);
 
@@ -286,13 +285,12 @@ export function useCustomExchangeHandlers({
                 ? getParentAccount(account, accounts)
                 : undefined;
 
-              // Go directly to stake flow for this specific account
-              goToAccountStakeFlow(account, parentAccount);
+              goToAccountStakeFlow(account, parentAccount, currencyId);
               return { success: true };
             }
           }
 
-          // If no account specified or not found, open the general stake drawer
+          // No account specified or not found — open the general stake drawer
           handleOpenStakeDrawer();
 
           return { success: true };

--- a/apps/ledger-live-mobile/src/mvvm/hooks/useStake/useStake.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/useStake/useStake.test.ts
@@ -356,4 +356,75 @@ describe("useStake()", () => {
       }),
     );
   });
+
+  it("explicit cryptoAssetId argument is used in earn navigation params when no queryParam value exists", async () => {
+    const { result } = renderHook(() => useStake(), {
+      overrideInitialState: withFlagOverrides({
+        stakePrograms: {
+          ...feature_stake_programs_json,
+          params: {
+            ...feature_stake_programs_json.params,
+            redirects: {
+              ...feature_stake_programs_json.params.redirects,
+              "ethereum/erc20/usds_stablecoin_0xdc035d45d973e3ec169d2276ddab16f1e407384f": {
+                platform: "earn",
+                name: "Earn",
+                queryParams: { intent: "deposit" }, // no cryptoAssetId in queryParams
+              },
+            },
+          },
+        } as unknown as Parameters<typeof withFlagOverrides>[0]["stakePrograms"],
+      }),
+    });
+
+    const explicitCryptoAssetId = "ethereum/erc20/some-token";
+
+    expect(
+      result.current.getRouteParamsForPlatformApp(
+        mockUSDSTokenAccount,
+        walletState,
+        mockEthereumAccount,
+        explicitCryptoAssetId,
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        screen: "EarnNavigator",
+        params: expect.objectContaining({
+          params: expect.objectContaining({
+            cryptoAssetId: explicitCryptoAssetId,
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("explicit cryptoAssetId argument overrides the one from partner queryParams", async () => {
+    const { result } = renderHook(() => useStake(), {
+      overrideInitialState: withStakePrograms,
+    });
+
+    const overriddenCryptoAssetId = "ethereum/erc20/some-other-token";
+
+    const params = result.current.getRouteParamsForPlatformApp(
+      mockUSDSTokenAccount,
+      walletState,
+      mockEthereumAccount,
+      overriddenCryptoAssetId,
+    );
+
+    expect(params).toEqual(
+      expect.objectContaining({
+        screen: "EarnNavigator",
+        params: expect.objectContaining({
+          params: expect.objectContaining({
+            cryptoAssetId: overriddenCryptoAssetId, // explicit arg wins over queryParams value
+          }),
+        }),
+      }),
+    );
+    // Verify the queryParams value is NOT present
+    expect((params as { params: { params: { cryptoAssetId: string } } }).params.params.cryptoAssetId).toBe(
+      overriddenCryptoAssetId,
+    );
+  });
 });

--- a/apps/ledger-live-mobile/src/mvvm/hooks/useStake/useStake.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/useStake/useStake.test.ts
@@ -129,61 +129,62 @@ const userDataTron = accountRawToAccountUserData(rawTron);
 walletState.accountNames.set(userData.id, userData.name);
 walletState.accountNames.set(userDataTron.id, userDataTron.name);
 
-const feature_stake_programs_json = {
-  enabled: true,
-  params: {
-    list: [
-      "mantra",
-      "xion",
-      "ethereum",
-      "solana",
-      "tezos",
-      "cosmos",
-      "osmo",
-      "celo",
-      "near",
-      "elrond",
-      "quicksilver",
-      "persistence",
-      "axelar",
-      "cardano",
-      "dydx",
-      "injective",
-      "aptos",
-    ],
-    redirects: {
-      tron: {
-        platform: "mock-live-app",
-        name: "Live App",
-        queryParams: {
-          yieldId: "native-staking",
-        },
+const feature_stake_programs_params = {
+  list: [
+    "mantra",
+    "xion",
+    "ethereum",
+    "solana",
+    "tezos",
+    "cosmos",
+    "osmo",
+    "celo",
+    "near",
+    "elrond",
+    "quicksilver",
+    "persistence",
+    "axelar",
+    "cardano",
+    "dydx",
+    "injective",
+    "aptos",
+  ],
+  redirects: {
+    tron: {
+      platform: "mock-live-app",
+      name: "Live App",
+      queryParams: {
+        yieldId: "native-staking",
       },
-      "ethereum/erc20/usd_tether__erc20_": {
-        platform: "mock-dapp-v3",
-        name: "Dapp v3",
-        queryParams: {
-          chainId: 1,
-        },
+    },
+    "ethereum/erc20/usd_tether__erc20_": {
+      platform: "mock-dapp-v3",
+      name: "Dapp v3",
+      queryParams: {
+        chainId: 1,
       },
-      "ethereum/erc20/usd__coin": {
-        platform: "mock-dapp-v1",
-        name: "Dapp",
-        queryParams: {
-          chainId: 1,
-        },
+    },
+    "ethereum/erc20/usd__coin": {
+      platform: "mock-dapp-v1",
+      name: "Dapp",
+      queryParams: {
+        chainId: 1,
       },
-      "ethereum/erc20/usds_stablecoin_0xdc035d45d973e3ec169d2276ddab16f1e407384f": {
-        platform: "earn",
-        name: "Earn",
-        queryParams: {
-          intent: "deposit",
-          cryptoAssetId:
-            "ethereum/erc20/usds_stablecoin_0xdc035d45d973e3ec169d2276ddab16f1e407384f",
-        },
+    },
+    "ethereum/erc20/usds_stablecoin_0xdc035d45d973e3ec169d2276ddab16f1e407384f": {
+      platform: "earn",
+      name: "Earn",
+      queryParams: {
+        intent: "deposit",
+        cryptoAssetId: "ethereum/erc20/usds_stablecoin_0xdc035d45d973e3ec169d2276ddab16f1e407384f",
       },
     },
   },
+};
+
+const feature_stake_programs_json = {
+  enabled: true,
+  params: feature_stake_programs_params,
 } as unknown as Parameters<typeof withFlagOverrides>[0]["stakePrograms"];
 
 const withStakePrograms = withFlagOverrides({ stakePrograms: feature_stake_programs_json });
@@ -363,9 +364,9 @@ describe("useStake()", () => {
         stakePrograms: {
           ...feature_stake_programs_json,
           params: {
-            ...feature_stake_programs_json.params,
+            ...feature_stake_programs_params,
             redirects: {
-              ...feature_stake_programs_json.params.redirects,
+              ...feature_stake_programs_params.redirects,
               "ethereum/erc20/usds_stablecoin_0xdc035d45d973e3ec169d2276ddab16f1e407384f": {
                 platform: "earn",
                 name: "Earn",
@@ -421,10 +422,6 @@ describe("useStake()", () => {
           }),
         }),
       }),
-    );
-    // Verify the queryParams value is NOT present
-    expect((params as { params: { params: { cryptoAssetId: string } } }).params.params.cryptoAssetId).toBe(
-      overriddenCryptoAssetId,
     );
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/hooks/useStake/useStake.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/useStake/useStake.tsx
@@ -170,6 +170,7 @@ export function useStake() {
         ...customPartnerParams,
         ...(asset_id ? { asset_id } : {}),
         accountId: accountIdForManifestVersion,
+        ...(cryptoAssetId ? { cryptoAssetId } : {}),
       })?.toString();
 
       const isEarnManifest = ["earn", "earn-stg", "earn-prd-eks"].includes(manifest.id);

--- a/apps/ledger-live-mobile/src/mvvm/hooks/useStake/useStake.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/useStake/useStake.tsx
@@ -88,6 +88,7 @@ export function useStake() {
     account: Account | TokenAccount | AccountLike,
     walletState: WalletState,
     parentAccount?: Account,
+    cryptoAssetId?: string,
   ) =>
     | {
         screen: NavigatorName.Earn;
@@ -111,6 +112,7 @@ export function useStake() {
       account: Account | TokenAccount | AccountLike,
       walletState: WalletState,
       parentAccount?: Account,
+      cryptoAssetId?: string,
     ) => {
       const walletApiAccount = accountToWalletAPIAccount(walletState, account, parentAccount);
       const parentWalletApiAccountId = parentAccount
@@ -187,6 +189,7 @@ export function useStake() {
               ledgerAccountId: account.id,
               walletAccountId: walletApiAccount.id,
               customDappURL: customDappURL ?? undefined,
+              ...(cryptoAssetId ? { cryptoAssetId } : {}),
             },
           },
         };

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -349,6 +349,7 @@ export type Features = CurrencyFeatures & {
   llmTransferButtonCopyVariant: Feature_LlmTransferButtonCopyVariant;
   lldTezosStaking: DefaultFeature;
   llmTezosStaking: DefaultFeature;
+  swapToEarn: DefaultFeature;
 };
 
 /**

--- a/shared/feature-flags/src/flags/team-ptx/index.ts
+++ b/shared/feature-flags/src/flags/team-ptx/index.ts
@@ -26,4 +26,5 @@ export * from "./ptxSwapReceiveTRC20WithoutTrx";
 export * from "./receiveStakingFlowConfigDesktop";
 export * from "./stakeAccountBanner";
 export * from "./stakePrograms";
+export * from "./swapToEarn";
 export * from "./swapWalletApiPartnerList";

--- a/shared/feature-flags/src/flags/team-ptx/swapToEarn.ts
+++ b/shared/feature-flags/src/flags/team-ptx/swapToEarn.ts
@@ -1,0 +1,2 @@
+import { flag } from "../../define";
+export const swapToEarn = flag();


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- Forward `currencyId` from `redirect-provider` params through to the earn live app as `cryptoAssetId`, gated on the new `swapToEarn` feature flag
- Add `swapToEarn` feature flag (shared flags, types-live, defaultFeatures) 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-30514


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
