### PR TITLE
[LWDM] feat(LIVE-28050): hedera testnet support - part 5

### DIFF
--- a/.changeset/cool-lizards-rhyme.md
+++ b/.changeset/cool-lizards-rhyme.md
@@ -1,0 +1,13 @@
+---
+"@ledgerhq/cryptoassets": minor
+"@domain/entity-currency-crypto": minor
+"@ledgerhq/coin-hedera": minor
+"@ledgerhq/ledger-wallet-framework": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+"@ledgerhq/web-tools": minor
+"@ledgerhq/live-cli": minor
+---
+
+feat: add hedera_testnet

--- a/apps/cli/src/live-common-setup-base.ts
+++ b/apps/cli/src/live-common-setup-base.ts
@@ -53,6 +53,7 @@ setSupportedCurrencies([
   "crypto_org_croeseid",
   "celo",
   "hedera",
+  "hedera_testnet",
   "cardano",
   "solana",
   "solana_testnet",

--- a/apps/ledger-live-desktop/src/live-common-set-supported-currencies.ts
+++ b/apps/ledger-live-desktop/src/live-common-set-supported-currencies.ts
@@ -55,6 +55,7 @@ setSupportedCurrencies([
   "ethereum_sepolia",
   "ethereum_hoodi",
   "hedera",
+  "hedera_testnet",
   "cardano",
   "filecoin",
   "osmosis",

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/shared/staking/ValidatorsSelect.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/shared/staking/ValidatorsSelect.tsx
@@ -82,7 +82,7 @@ export default function ValidatorsSelect({
         value={value}
         error={error}
         options={options}
-        getOptionValue={option => option.name}
+        getOptionValue={option => option.address}
         renderValue={renderItem}
         renderOption={renderItem}
         onInputChange={setQuery}

--- a/apps/ledger-live-desktop/tests/fixtures/wallet-api.ts
+++ b/apps/ledger-live-desktop/tests/fixtures/wallet-api.ts
@@ -611,6 +611,15 @@ export const expectedCurrencyList = [
   },
   {
     type: "CryptoCurrency",
+    id: "hedera_testnet",
+    ticker: "HBAR",
+    name: "Hedera (Testnet)",
+    family: "hedera",
+    color: "#000",
+    decimals: 8,
+  },
+  {
+    type: "CryptoCurrency",
     id: "cardano",
     ticker: "ADA",
     name: "Cardano",

--- a/apps/ledger-live-mobile/src/live-common-setup.ts
+++ b/apps/ledger-live-mobile/src/live-common-setup.ts
@@ -82,6 +82,7 @@ setSupportedCurrencies([
   "ethereum_hoodi",
   "elrond", // NOTE: legacy 'multiversx' name, kept for compatibility
   "hedera",
+  "hedera_testnet",
   "cardano",
   "osmosis",
   "filecoin",

--- a/apps/ledger-live-mobile/src/mvvm/features/Web3Hub/utils/api/mocks/manifests.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Web3Hub/utils/api/mocks/manifests.ts
@@ -99,6 +99,7 @@ export const mocks: AppManifest[] = [
       "ethereum_goerli/**",
       "ethereum_sepolia/**",
       "hedera",
+      "hedera_testnet",
       "cardano/**",
       "filecoin",
       "osmo",

--- a/apps/web-tools/src/live-common-setup.ts
+++ b/apps/web-tools/src/live-common-setup.ts
@@ -54,6 +54,7 @@ setSupportedCurrencies([
   "crypto_org_croeseid",
   "celo",
   "hedera",
+  "hedera_testnet",
   "cardano",
   "solana",
   "osmosis",

--- a/domain/entity/currency-crypto/src/currencies/hedera_testnet.ts
+++ b/domain/entity/currency-crypto/src/currencies/hedera_testnet.ts
@@ -1,0 +1,28 @@
+import { currency } from "../define";
+
+export const hedera_testnet = currency({
+  type: "CryptoCurrency",
+  id: "hedera_testnet",
+  coinType: 3030,
+  name: "Hedera (Testnet)",
+  managerAppName: "Hedera",
+  ticker: "HBAR",
+  scheme: "hedera_testnet",
+  color: "#000",
+  family: "hedera",
+  isTestnetFor: "hedera",
+  units: [
+    {
+      name: "HBAR",
+      code: "HBAR",
+      magnitude: 8,
+    },
+  ],
+  explorerViews: [
+    {
+      tx: "https://hashscan.io/testnet/transaction/$hash",
+      address: "https://hashscan.io/testnet/account/$address",
+    },
+  ],
+  tokenTypes: ["hts", "erc20"],
+});

--- a/domain/entity/currency-crypto/src/currencies/index.ts
+++ b/domain/entity/currency-crypto/src/currencies/index.ts
@@ -85,6 +85,7 @@ export * from "./gochain";
 export * from "./groestcoin";
 export * from "./hcash";
 export * from "./hedera";
+export * from "./hedera_testnet";
 export * from "./helium";
 export * from "./hpb";
 export * from "./hycon";

--- a/libs/coin-modules/coin-hedera/src/logic/estimateFees.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/estimateFees.test.ts
@@ -96,7 +96,7 @@ describe("getEstimatedFees", () => {
     const gasPriceTinybars = new BigNumber(900);
     const transferAmount = BigInt(1000000);
 
-    (apiClient.getAccount as jest.Mock).mockImplementation(address => ({
+    (apiClient.getAccount as jest.Mock).mockImplementation(({ address }) => ({
       address,
       evm_address: "0x0000000000000000000000000000000000012345",
     }));

--- a/libs/coin-modules/coin-hedera/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.test.ts
@@ -45,6 +45,9 @@ import {
 
 jest.mock("./api");
 jest.mock("./hgraph");
+jest.mock("./rpc", () => ({
+  rpcClient: require("../test/fixtures/rpc.fixture").getMockedRpcClient(),
+}));
 
 describe("network utils", () => {
   const defaultConfig = getMockedConfig();

--- a/libs/coin-modules/coin-hedera/src/preload-data.test.ts
+++ b/libs/coin-modules/coin-hedera/src/preload-data.test.ts
@@ -1,0 +1,72 @@
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import {
+  getCurrentHederaPreloadData,
+  getHederaPreloadData,
+  setHederaPreloadData,
+} from "./preload-data";
+import type { HederaPreloadData } from "./types";
+import { getMockedCurrency } from "./test/fixtures/currency.fixture";
+
+describe("preload-data", () => {
+  const hedera = getCryptoCurrencyById("hedera");
+  const hederaTestnet = getCryptoCurrencyById("hedera_testnet");
+  const testData = { validators: [{ nodeId: 1 }] } as HederaPreloadData;
+
+  beforeEach(() => {
+    setHederaPreloadData({ validators: [] }, hedera);
+    setHederaPreloadData({ validators: [] }, hederaTestnet);
+  });
+
+  describe("getCurrentHederaPreloadData", () => {
+    it("should return data set for the currency", () => {
+      setHederaPreloadData(testData, hedera);
+
+      expect(getCurrentHederaPreloadData(hedera)).toBe(testData);
+    });
+
+    it("should keep preload data isolated per currency", () => {
+      setHederaPreloadData(testData, hedera);
+
+      expect(getCurrentHederaPreloadData(hedera).validators).toHaveLength(1);
+      expect(getCurrentHederaPreloadData(hederaTestnet).validators).toHaveLength(0);
+    });
+
+    it("should throw for unsupported currency", () => {
+      const unsupportedCurrency = getMockedCurrency({ id: "bitcoin", family: "bitcoin" });
+
+      expect(() => getCurrentHederaPreloadData(unsupportedCurrency)).toThrow(
+        "unsupported currency bitcoin",
+      );
+    });
+  });
+
+  describe("getHederaPreloadData", () => {
+    it("should emit updates when preload data changes", () => {
+      const mockListener = jest.fn();
+      const subscription = getHederaPreloadData(hedera).subscribe(mockListener);
+
+      setHederaPreloadData(testData, hedera);
+
+      expect(mockListener).toHaveBeenLastCalledWith(testData);
+      subscription.unsubscribe();
+    });
+
+    it("should throw for unsupported currency", () => {
+      const unsupportedCurrency = getMockedCurrency({ id: "bitcoin", family: "bitcoin" });
+
+      expect(() => getHederaPreloadData(unsupportedCurrency)).toThrow(
+        "unsupported currency bitcoin",
+      );
+    });
+  });
+
+  describe("setHederaPreloadData", () => {
+    it("should throw for unsupported currency", () => {
+      const unsupportedCurrency = getMockedCurrency({ id: "bitcoin", family: "bitcoin" });
+
+      expect(() => setHederaPreloadData({ validators: [] }, unsupportedCurrency)).toThrow(
+        "unsupported currency bitcoin",
+      );
+    });
+  });
+});

--- a/libs/coin-modules/coin-hedera/src/preload-data.ts
+++ b/libs/coin-modules/coin-hedera/src/preload-data.ts
@@ -2,18 +2,25 @@ import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { BehaviorSubject, Observable } from "rxjs";
 import type { HederaPreloadData } from "./types";
 
-const initialData: HederaPreloadData = {
+const createInitialData = (): HederaPreloadData => ({
   validators: [],
-};
+});
 
-const dataByCurrency = new Map<string, HederaPreloadData>([["hedera", initialData]]);
+const initialData = createInitialData();
+const initialDataTestnet = createInitialData();
+
+const dataByCurrency = new Map<string, HederaPreloadData>([
+  ["hedera", initialData],
+  ["hedera_testnet", initialDataTestnet],
+]);
 
 const dataUpdatesByCurrency = new Map([
   ["hedera", new BehaviorSubject<HederaPreloadData>(initialData)],
+  ["hedera_testnet", new BehaviorSubject<HederaPreloadData>(initialDataTestnet)],
 ]);
 
 export function setHederaPreloadData(data: HederaPreloadData, currency: CryptoCurrency): void {
-  dataByCurrency.set(currency.id, data ?? initialData);
+  dataByCurrency.set(currency.id, data);
   const subject = dataUpdatesByCurrency.get(currency.id);
   if (subject === undefined) {
     throw new Error(`unsupported currency ${currency.id}`);

--- a/libs/ledger-live-common/src/__tests__/test-helpers/environment.ts
+++ b/libs/ledger-live-common/src/__tests__/test-helpers/environment.ts
@@ -60,6 +60,7 @@ setSupportedCurrencies([
   "solana",
   "celo",
   "hedera",
+  "hedera_testnet",
   "cardano",
   "cardano_testnet",
   "osmosis",

--- a/libs/ledger-live-common/src/e2e/speculos.ts
+++ b/libs/ledger-live-common/src/e2e/speculos.ts
@@ -338,6 +338,14 @@ export const specs: Specs = {
     },
     dependencies: [],
   },
+  Hedera_Testnet: {
+    currency: getCryptoCurrencyById("hedera_testnet"),
+    appQuery: {
+      model: getSpeculosModel(),
+      appName: "Hedera",
+    },
+    dependencies: [],
+  },
   Sui: {
     currency: getCryptoCurrencyById("sui"),
     appQuery: {

--- a/libs/ledger-live-common/src/exchange/swap/getIncompatibleCurrencyKeys.ts
+++ b/libs/ledger-live-common/src/exchange/swap/getIncompatibleCurrencyKeys.ts
@@ -63,6 +63,10 @@ const INCOMPATIBLE_NANO_S_CURRENCY_KEYS: Keys = {
     title: "swap.incompatibility.hedera_title",
     description: "swap.incompatibility.hedera_description",
   },
+  hedera_testnet: {
+    title: "swap.incompatibility.hedera_title",
+    description: "swap.incompatibility.hedera_description",
+  },
   osmo: {
     title: "swap.incompatibility.osmo_title",
     description: "swap.incompatibility.osmo_description",

--- a/libs/ledger-wallet-framework/src/derivation.test.ts
+++ b/libs/ledger-wallet-framework/src/derivation.test.ts
@@ -153,6 +153,11 @@ describe("getSeedIdentifierDerivation", () => {
       expectedSeedPath: `44/3030`,
     },
     {
+      currencyId: "hedera_testnet",
+      mode: asDerivationMode("hederaBip44"),
+      expectedSeedPath: `44/3030`,
+    },
+    {
       currencyId: "casper",
       mode: asDerivationMode("casper_wallet"),
       expectedSeedPath: `44'/506'/0'/0/0`,

--- a/libs/ledger-wallet-framework/src/derivation.ts
+++ b/libs/ledger-wallet-framework/src/derivation.ts
@@ -239,6 +239,7 @@ const legacyDerivations: Partial<Record<CryptoCurrency["id"], DerivationMode[]>>
   assethub_polkadot: ["polkadotbip44"],
   assethub_westend: ["polkadotbip44"],
   hedera: ["hederaBip44"],
+  hedera_testnet: ["hederaBip44"],
   filecoin: ["glifLegacy", "filecoinBIP44", "glif"],
   internet_computer: ["internet_computer"],
   mina: ["minabip44"],
@@ -396,6 +397,7 @@ const disableBIP44: Record<string, boolean> = {
   assethub_westend: true,
   solana: true,
   hedera: true,
+  hedera_testnet: true,
   cardano: true,
   cardano_testnet: true,
   near: true,
@@ -438,6 +440,7 @@ const seedIdentifierPath = (currencyId: string): SeedPathFn => {
     case "solana":
       return ({ purpose, coinType }) => `${purpose}'/${coinType}'`;
     case "hedera":
+    case "hedera_testnet":
       return ({ purpose, coinType }) => `${purpose}/${coinType}`;
     case "near":
       return ({ purpose, coinType }) => `${purpose}'/${coinType}'/0'/0'/0'`;

--- a/libs/ledgerjs/packages/cryptoassets/src/abandonseed.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/abandonseed.ts
@@ -70,6 +70,7 @@ const abandonSeedAddresses: Partial<Record<CryptoCurrency["id"], string>> = {
   ethereum_sepolia: EVM_DEAD_ADDRESS,
   ethereum_hoodi: EVM_DEAD_ADDRESS,
   hedera: "0.0.163372",
+  hedera_testnet: "0.0.163372",
   cardano_testnet:
     "addr1qykrup76qz622wxgmqtuumr6mn3vvkqc4jgxj6ytqudchccayfawlf9hwv2fzuygt2km5v92kvf8e3s3mk7ynxw77cwq80z2rm",
   cardano:

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
@@ -1646,6 +1646,32 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     ],
     tokenTypes: ["hts", "erc20"],
   },
+  hedera_testnet: {
+    type: "CryptoCurrency",
+    id: "hedera_testnet",
+    coinType: CoinType.HEDERA,
+    name: "Hedera (Testnet)",
+    managerAppName: "Hedera",
+    ticker: "HBAR",
+    scheme: "hedera_testnet",
+    color: "#000",
+    family: "hedera",
+    isTestnetFor: "hedera",
+    units: [
+      {
+        name: "HBAR",
+        code: "HBAR",
+        magnitude: 8,
+      },
+    ],
+    explorerViews: [
+      {
+        tx: "https://hashscan.io/testnet/transaction/$hash",
+        address: "https://hashscan.io/testnet/account/$address",
+      },
+    ],
+    tokenTypes: ["hts", "erc20"],
+  },
   helium: {
     type: "CryptoCurrency",
     id: "helium",

--- a/libs/live-currency-format/src/__snapshots__/formatCurrencyUnit.test.ts.snap
+++ b/libs/live-currency-format/src/__snapshots__/formatCurrencyUnit.test.ts.snap
@@ -172,6 +172,8 @@ exports[`formatCurrencyUnit with custom options with locale de-DE should correct
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Hcash unit (hcash) 1`] = `"123.456.789,00000000- -HSR"`;
 
+exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Hedera (Testnet) unit (HBAR) 1`] = `"123.456.789,00000000- -HBAR"`;
+
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Hedera unit (HBAR) 1`] = `"123.456.789,00000000- -HBAR"`;
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Helium unit (HNT) 1`] = `"123.456.789,00000000- -HNT"`;
@@ -585,6 +587,8 @@ exports[`formatCurrencyUnit with custom options with locale en-US should correct
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Groestlcoin unit (GRS) 2`] = `"123,456,789.00000000- -GRS"`;
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Hcash unit (hcash) 1`] = `"123,456,789.00000000- -HSR"`;
+
+exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Hedera (Testnet) unit (HBAR) 1`] = `"123,456,789.00000000- -HBAR"`;
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Hedera unit (HBAR) 1`] = `"123,456,789.00000000- -HBAR"`;
 
@@ -1000,6 +1004,8 @@ exports[`formatCurrencyUnit with custom options with locale es-ES should correct
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Hcash unit (hcash) 1`] = `"123.456.789,00000000- -HSR"`;
 
+exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Hedera (Testnet) unit (HBAR) 1`] = `"123.456.789,00000000- -HBAR"`;
+
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Hedera unit (HBAR) 1`] = `"123.456.789,00000000- -HBAR"`;
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Helium unit (HNT) 1`] = `"123.456.789,00000000- -HNT"`;
@@ -1413,6 +1419,8 @@ exports[`formatCurrencyUnit with custom options with locale fr-FR should correct
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Groestlcoin unit (GRS) 2`] = `"123 456 789,00000000- -GRS"`;
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Hcash unit (hcash) 1`] = `"123 456 789,00000000- -HSR"`;
+
+exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Hedera (Testnet) unit (HBAR) 1`] = `"123 456 789,00000000- -HBAR"`;
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Hedera unit (HBAR) 1`] = `"123 456 789,00000000- -HBAR"`;
 
@@ -1828,6 +1836,8 @@ exports[`formatCurrencyUnit with custom options with locale ja-JP should correct
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Hcash unit (hcash) 1`] = `"123,456,789.00000000- -HSR"`;
 
+exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Hedera (Testnet) unit (HBAR) 1`] = `"123,456,789.00000000- -HBAR"`;
+
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Hedera unit (HBAR) 1`] = `"123,456,789.00000000- -HBAR"`;
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Helium unit (HNT) 1`] = `"123,456,789.00000000- -HNT"`;
@@ -2241,6 +2251,8 @@ exports[`formatCurrencyUnit with custom options with locale ko-KR should correct
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Groestlcoin unit (GRS) 2`] = `"123,456,789.00000000- -GRS"`;
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Hcash unit (hcash) 1`] = `"123,456,789.00000000- -HSR"`;
+
+exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Hedera (Testnet) unit (HBAR) 1`] = `"123,456,789.00000000- -HBAR"`;
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Hedera unit (HBAR) 1`] = `"123,456,789.00000000- -HBAR"`;
 
@@ -2656,6 +2668,8 @@ exports[`formatCurrencyUnit with custom options with locale pt-BR should correct
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Hcash unit (hcash) 1`] = `"123.456.789,00000000- -HSR"`;
 
+exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Hedera (Testnet) unit (HBAR) 1`] = `"123.456.789,00000000- -HBAR"`;
+
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Hedera unit (HBAR) 1`] = `"123.456.789,00000000- -HBAR"`;
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Helium unit (HNT) 1`] = `"123.456.789,00000000- -HNT"`;
@@ -3069,6 +3083,8 @@ exports[`formatCurrencyUnit with custom options with locale ru-RU should correct
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Groestlcoin unit (GRS) 2`] = `"123 456 789,00000000- -GRS"`;
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Hcash unit (hcash) 1`] = `"123 456 789,00000000- -HSR"`;
+
+exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Hedera (Testnet) unit (HBAR) 1`] = `"123 456 789,00000000- -HBAR"`;
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Hedera unit (HBAR) 1`] = `"123 456 789,00000000- -HBAR"`;
 
@@ -3484,6 +3500,8 @@ exports[`formatCurrencyUnit with custom options with locale tr-TR should correct
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Hcash unit (hcash) 1`] = `"123.456.789,00000000- -HSR"`;
 
+exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Hedera (Testnet) unit (HBAR) 1`] = `"123.456.789,00000000- -HBAR"`;
+
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Hedera unit (HBAR) 1`] = `"123.456.789,00000000- -HBAR"`;
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Helium unit (HNT) 1`] = `"123.456.789,00000000- -HNT"`;
@@ -3898,6 +3916,8 @@ exports[`formatCurrencyUnit with custom options with locale zh-CN should correct
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Hcash unit (hcash) 1`] = `"123,456,789.00000000- -HSR"`;
 
+exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Hedera (Testnet) unit (HBAR) 1`] = `"123,456,789.00000000- -HBAR"`;
+
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Hedera unit (HBAR) 1`] = `"123,456,789.00000000- -HBAR"`;
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Helium unit (HNT) 1`] = `"123,456,789.00000000- -HNT"`;
@@ -4311,6 +4331,8 @@ exports[`formatCurrencyUnit with default options should correctly format Groestl
 exports[`formatCurrencyUnit with default options should correctly format Groestlcoin unit (GRS) 2`] = `"123,456,789"`;
 
 exports[`formatCurrencyUnit with default options should correctly format Hcash unit (hcash) 1`] = `"123,456,789"`;
+
+exports[`formatCurrencyUnit with default options should correctly format Hedera (Testnet) unit (HBAR) 1`] = `"123,456,789"`;
 
 exports[`formatCurrencyUnit with default options should correctly format Hedera unit (HBAR) 1`] = `"123,456,789"`;
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - add "hedera_testnet" currency

### 📝 Description

This PR contains last batch of changes from [testnet support feature branch](https://github.com/LedgerHQ/ledger-live/compare/develop...feat/hedera-testnet-v2).

Scope:
- add "hedera_testnet" currency support
- fix non-unique option value in ValidatorSelect
- fix network dependent network/utils.test.ts

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-28050

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
