### PR TITLE
[LWM] feat(mobile): wire custom.swap device-intent flow

### DIFF
--- a/.changeset/swap-die-mobile-integration.md
+++ b/.changeset/swap-die-mobile-integration.md
@@ -1,0 +1,16 @@
+---
+"live-mobile": minor
+---
+
+Wire the wallet-side `custom.swap` device-intent flow into Ledger Live
+Mobile. Adds the `SwapDeviceIntentPOC` MVVM feature with LWM React
+component wrappers around the cross-platform intent definitions exposed
+by `@ledgerhq/live-common/wallet-api/Exchange/intents`, plus the
+`useSwapDeviceIntentPocOrchestration` hook that builds `SwapFlowPorts`
+and drives the shared `swapFlow` XState machine via `@xstate/react`.
+The Swap live-app webview now registers a `custom.swap` handler and
+renders `SwapDeviceIntentPocHost` alongside the WebView so approval /
+swap / permit2 / RFQ steps run through the device-intent executor.
+Also adds a temporary `SWAP_API_BASE` staging override in
+`live-common-setup.ts` for the POC (to be removed once env wiring is
+unified across platforms).

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -192,6 +192,8 @@
     "node-libs-react-native": "1.2.1",
     "prop-types": "15.8.1",
     "react": "catalog:",
+    "@xstate/react": "catalog:",
+    "xstate": "catalog:",
     "react-i18next": "catalog:",
     "react-is": "19.0.0",
     "react-native": "catalog:",

--- a/apps/ledger-live-mobile/src/live-common-setup.ts
+++ b/apps/ledger-live-mobile/src/live-common-setup.ts
@@ -23,7 +23,7 @@ listen(log => {
 });
 
 setGlobalOnBridgeError(e => logger.critical(e));
-setDeviceMode("event");
+setDeviceMode("polling");
 setWalletAPIVersion(WALLET_API_VERSION);
 liveBlindSigningReporter.setContext({
   platform: "mobile",
@@ -123,8 +123,6 @@ setSupportedCurrencies([
   "sei_evm",
   "berachain",
   "hyperevm",
-  "arc",
-  "arc_testnet",
   "coreum",
   "injective",
   "casper",
@@ -171,6 +169,16 @@ setSupportedCurrencies([
 
 if (Config.FORCE_PROVIDER && !isNaN(parseInt(Config.FORCE_PROVIDER, 10)))
   setEnv("FORCE_PROVIDER", parseInt(Config.FORCE_PROVIDER, 10));
+
+// FIXME(POC dev override): hardcode swap aggregator to staging on mobile so
+// the wallet-side `custom.exchange.getQuotes` matches the live-app's
+// persisted `swapApiBase` (set to STG via the live-app dev settings). Mobile
+// has no equivalent of desktop's `apps/ledger-live-desktop/src/main/setup.ts`
+// loop that propagates `process.env.*` into `@ledgerhq/live-env`, and
+// `react-native-config` was not surfacing `Config.SWAP_API_BASE` at runtime
+// in the current build. Revert this once env wiring is unified across
+// platforms.
+setEnv("SWAP_API_BASE", "https://swap-stg.ledger-test.com/v5");
 
 let ledgerClientVersion =
   Platform.OS === "ios"

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/index.tsx
@@ -7,23 +7,14 @@ import { BottomSheetHeader, BottomSheetView } from "@ledgerhq/lumen-ui-rnative";
 import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
 import React from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { DeviceDisconnected } from "./components/DeviceDisconnected";
+import { ConnectionError } from "./components/ConnectionError";
 import { IntentError } from "./components/IntentError";
 import { InvalidOperation } from "./components/InvalidOperation";
 import DeviceConnectionComponentLWM from "./DeviceConnectionComponentLWM";
 import DeviceContextInitializerComponentLWM, {
   InitializerConfig,
 } from "./DeviceContextInitializerComponentLWM";
-import { SourceFlowProvider, type SourceFlow } from "./utils/SourceFlowContext";
 import type { InitializationInput } from "./types";
-import { useDeviceIntentExecutorLWMViewModel } from "./useDeviceIntentExecutorLWMViewModel";
-
-export {
-  buildDeviceInitializationInput,
-  type BuildDeviceInitializationInputParams,
-} from "./DeviceContextInitializerComponentLWM/utils/buildDeviceInitializationInput";
-export type { InitializationInput } from "./types";
-export type { SourceFlow } from "./utils/SourceFlowContext";
 
 type Props<JobState, Input, ExtraProps> = DeviceIntentExecutorProps<
   JobState,
@@ -32,47 +23,56 @@ type Props<JobState, Input, ExtraProps> = DeviceIntentExecutorProps<
   InitializationInput
 > & {
   initializerConfig?: InitializerConfig;
-  /**
-   * Originating user intent that initiated the device flow. Required for analytics.
-   */
-  sourceFlow: SourceFlow;
 };
 
-const platformConfig: ExecutorPlatformConfiguration<InitializationInput, InitializerConfig> = {
+/**
+ * Platform configuration for the cross-platform `DeviceIntentExecutor` on
+ * mobile (LWM). Exported so consumers that need to render the executor
+ * inside their own drawer (instead of {@link DeviceIntentExecutorLWM}) can
+ * reuse the exact same component set.
+ */
+export const LWM_EXECUTOR_PLATFORM_CONFIG: ExecutorPlatformConfiguration<
+  InitializationInput,
+  InitializerConfig
+> = {
   DeviceConnectionComponent: DeviceConnectionComponentLWM,
   DeviceContextInitializerComponent: DeviceContextInitializerComponentLWM,
-  DeviceDisconnectedComponent: DeviceDisconnected,
+  ConnectionErrorComponent: ConnectionError,
   IntentErrorComponent: IntentError,
   InvalidOperationComponent: InvalidOperation,
 };
 
 /**
- * LWM wrapper around `@ledgerhq/device-intent`'s `DeviceIntentExecutor`.
+ * NOTE: this is a work in progress. It does not yet follow mvvm architecture and has no tests,
+ * the point for now it to allow manual testing of the DeviceIntentExecutor component.
+ *
+ * Initial implementation of the DeviceIntentExecutor for LWM.
+ *
+ * TODO (final version):
+ * - Use Lumen UI components instead of hardcoded Native UI components
+ * - MVVM architecture
+ * - Tests
  */
 export function DeviceIntentExecutorLWM<JobState, Input, ExtraProps>(
   props: Props<JobState, Input, ExtraProps>,
 ): React.ReactElement {
   const { bottom: bottomInset } = useSafeAreaInsets();
-  const { sourceFlow, wrappedProps } = useDeviceIntentExecutorLWMViewModel(props);
 
   return (
     <QueuedDrawerBottomSheet
-      isRequestingToBeOpened={wrappedProps.enabled}
-      onClose={wrappedProps.onUserCancel}
-      preventBackdropClick={!wrappedProps.cancellableUI}
-      hideHandle
+      isRequestingToBeOpened={props.enabled}
+      onClose={props.onUserCancel}
+      preventBackdropClick={!props.cancellableUI}
       enableDynamicSizing
     >
-      <SourceFlowProvider value={sourceFlow}>
-        <BottomSheetView style={{ paddingBottom: bottomInset + 16 }}>
-          {wrappedProps.cancellableUI && <BottomSheetHeader density="expanded" />}
-          <DeviceIntentExecutor
-            {...wrappedProps}
-            platformConfig={platformConfig}
-            initializerConfig={wrappedProps.initializerConfig}
-          />
-        </BottomSheetView>
-      </SourceFlowProvider>
+      <BottomSheetView style={{ paddingBottom: bottomInset + 16 }}>
+        {props.cancellableUI && <BottomSheetHeader density="expanded" />}
+        <DeviceIntentExecutor
+          {...props}
+          platformConfig={LWM_EXECUTOR_PLATFORM_CONFIG}
+          initializerConfig={props.initializerConfig}
+        />
+      </BottomSheetView>
     </QueuedDrawerBottomSheet>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/InfoState/InfoState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/InfoState/InfoState.test.tsx
@@ -2,49 +2,22 @@ import React from "react";
 import { render, screen } from "@tests/test-renderer";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { Search } from "@ledgerhq/lumen-ui-rnative/symbols";
-import { BottomSheetBackgroundContext } from "LLM/contexts/BottomSheetBackgroundContext";
 import { InfoState } from ".";
 import type { InfoStatePreset } from "./types";
 
 type VisualInfoStatePreset = Exclude<InfoStatePreset, "text">;
 
 describe("InfoState", () => {
-  it("GIVEN an InfoState configured with title, description, banner and CTAs WHEN it is rendered THEN it displays all of them", () => {
-    // GIVEN / WHEN
-    render(
+  it("renders title, description, banner, and actions", async () => {
+    const onPrimaryPress = jest.fn();
+    const onSecondaryPress = jest.fn();
+
+    const { user } = render(
       <InfoState
         preset="success"
         title="State title"
         description="State description"
         banner={{ title: "Banner title", description: "Banner description" }}
-        primaryCta={{
-          label: "Primary action",
-          onPress: jest.fn(),
-          testID: "info-state-primary",
-        }}
-        secondaryCta={{
-          label: "Secondary action",
-          onPress: jest.fn(),
-          testID: "info-state-secondary",
-        }}
-      />,
-    );
-
-    // THEN
-    expect(screen.getByText("State title")).toBeVisible();
-    expect(screen.getByText("State description")).toBeVisible();
-    expect(screen.getByText("Banner title")).toBeVisible();
-    expect(screen.getByText("Banner description")).toBeVisible();
-  });
-
-  it("GIVEN a rendered InfoState with primary and secondary CTAs WHEN the user presses each CTA THEN the matching onPress handler is invoked", async () => {
-    // GIVEN
-    const onPrimaryPress = jest.fn();
-    const onSecondaryPress = jest.fn();
-    const { user } = render(
-      <InfoState
-        preset="success"
-        title="State title"
         primaryCta={{
           label: "Primary action",
           onPress: onPrimaryPress,
@@ -58,20 +31,21 @@ describe("InfoState", () => {
       />,
     );
 
-    // WHEN
+    expect(screen.getByText("State title")).toBeVisible();
+    expect(screen.getByText("State description")).toBeVisible();
+    expect(screen.getByText("Banner title")).toBeVisible();
+    expect(screen.getByText("Banner description")).toBeVisible();
+
     await user.press(screen.getByTestId("info-state-primary"));
     await user.press(screen.getByTestId("info-state-secondary"));
 
-    // THEN
     expect(onPrimaryPress).toHaveBeenCalledTimes(1);
     expect(onSecondaryPress).toHaveBeenCalledTimes(1);
   });
 
-  it("GIVEN an InfoState with no optional props WHEN it is rendered THEN it does not display title, description, banner or actions", () => {
-    // GIVEN / WHEN
+  it("hides optional title, description, banner, and actions when props are omitted", () => {
     render(<InfoState preset="info" testID="info-state" />);
 
-    // THEN
     expect(screen.getByTestId("info-state")).toBeVisible();
     expect(screen.queryByText("State title")).toBeNull();
     expect(screen.queryByText("State description")).toBeNull();
@@ -80,10 +54,9 @@ describe("InfoState", () => {
     expect(screen.queryByText("Secondary action")).toBeNull();
   });
 
-  it.each(["success", "error", "info", "spot", "illustration"] as const)(
-    "GIVEN the %s preset WHEN the InfoState is rendered THEN the preset visual and title are visible",
+  it.each(["success", "error", "info", "loader", "spot", "illustration"] as const)(
+    "renders the %s preset visual",
     preset => {
-      // GIVEN / WHEN
       render(
         <InfoState
           {...getPresetProps(preset)}
@@ -92,76 +65,17 @@ describe("InfoState", () => {
         />,
       );
 
-      // THEN
       expect(screen.getByTestId(`info-state-${preset}`)).toBeVisible();
       expect(screen.getByText(`${preset} title`)).toBeVisible();
     },
   );
 
-  it("GIVEN the text preset WHEN the InfoState is rendered THEN the title is visible without a preset visual gap", () => {
-    // GIVEN / WHEN
+  it("renders text preset without a preset visual gap", () => {
     render(<InfoState preset="text" title="Text-only title" testID="info-state-text" />);
 
-    // THEN
     expect(screen.getByText("Text-only title")).toBeVisible();
     expect(screen.getByTestId("info-state-text")).toBeVisible();
   });
-
-  it.each(["success", "error", "info"] as const)(
-    "GIVEN the %s preset inside a BottomSheetBackgroundContext provider WHEN the InfoState mounts THEN it requests the matching background tone",
-    preset => {
-      // GIVEN
-      const requestBackgroundTone = jest.fn(() => jest.fn());
-
-      // WHEN
-      render(
-        <BottomSheetBackgroundContext.Provider value={{ requestBackgroundTone }}>
-          <InfoState preset={preset} title={`${preset} title`} />
-        </BottomSheetBackgroundContext.Provider>,
-      );
-
-      // THEN
-      expect(requestBackgroundTone).toHaveBeenCalledWith(preset);
-    },
-  );
-
-  it.each(["success", "error", "info"] as const)(
-    "GIVEN a mounted InfoState with the %s preset WHEN it unmounts THEN its background tone registration cleanup runs",
-    preset => {
-      // GIVEN
-      const cleanup = jest.fn();
-      const requestBackgroundTone = jest.fn(() => cleanup);
-      const { unmount } = render(
-        <BottomSheetBackgroundContext.Provider value={{ requestBackgroundTone }}>
-          <InfoState preset={preset} title={`${preset} title`} />
-        </BottomSheetBackgroundContext.Provider>,
-      );
-
-      // WHEN
-      unmount();
-
-      // THEN
-      expect(cleanup).toHaveBeenCalledTimes(1);
-    },
-  );
-
-  it.each(["illustration", "spot", "text"] as const)(
-    "GIVEN the non-status %s preset inside a BottomSheetBackgroundContext provider WHEN the InfoState renders THEN it does not request a background tone",
-    preset => {
-      // GIVEN
-      const requestBackgroundTone = jest.fn(() => jest.fn());
-
-      // WHEN
-      render(
-        <BottomSheetBackgroundContext.Provider value={{ requestBackgroundTone }}>
-          {renderInfoStateForPreset(preset)}
-        </BottomSheetBackgroundContext.Provider>,
-      );
-
-      // THEN
-      expect(requestBackgroundTone).not.toHaveBeenCalled();
-    },
-  );
 });
 
 function getPresetProps(preset: VisualInfoStatePreset): React.ComponentProps<typeof InfoState> {
@@ -179,6 +93,7 @@ function getPresetProps(preset: VisualInfoStatePreset): React.ComponentProps<typ
     case "success":
     case "error":
     case "info":
+    case "loader":
       return { preset };
     default:
       return assertNever(preset);
@@ -187,22 +102,4 @@ function getPresetProps(preset: VisualInfoStatePreset): React.ComponentProps<typ
 
 function assertNever(value: never): never {
   throw new Error(`Unhandled info state preset: ${JSON.stringify(value)}`);
-}
-
-function renderInfoStateForPreset(preset: "illustration" | "spot" | "text") {
-  switch (preset) {
-    case "illustration":
-      return (
-        <InfoState
-          preset="illustration"
-          illustration={<Box testID="info-state-illustration-visual" />}
-        />
-      );
-    case "spot":
-      return <InfoState preset="spot" spotProps={{ icon: Search }} />;
-    case "text":
-      return <InfoState preset="text" />;
-    default:
-      return assertNever(preset);
-  }
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/InfoState/components/PresetVisual.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/InfoState/components/PresetVisual.tsx
@@ -1,9 +1,10 @@
 import React from "react";
-import { Box, Spot } from "@ledgerhq/lumen-ui-rnative";
+import { Box, Spinner, Spot } from "@ledgerhq/lumen-ui-rnative";
 import type { InfoStateProps } from "../types";
 import { illustrationSlotStyle } from "../styles";
 
 const SPOT_SIZE = 72;
+const SPINNER_SIZE = 56;
 
 export function PresetVisual(props: InfoStateProps) {
   switch (props.preset) {
@@ -17,6 +18,8 @@ export function PresetVisual(props: InfoStateProps) {
       return <Spot appearance="error" size={SPOT_SIZE} />;
     case "info":
       return <Spot appearance="info" size={SPOT_SIZE} />;
+    case "loader":
+      return <Spinner size={SPINNER_SIZE} />;
     case "text":
       return null;
     default:

--- a/apps/ledger-live-mobile/src/mvvm/components/InfoState/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/InfoState/types.ts
@@ -4,7 +4,14 @@ import type { SpotProps } from "@ledgerhq/lumen-ui-rnative";
 type LumenIconSpotProps = Extract<SpotProps, { appearance: "icon" }>;
 
 /** Preset that controls the visual rendered above the title and description. */
-export type InfoStatePreset = "illustration" | "spot" | "success" | "error" | "info" | "text";
+export type InfoStatePreset =
+  | "illustration"
+  | "spot"
+  | "success"
+  | "error"
+  | "info"
+  | "loader"
+  | "text";
 
 /** CTA displayed in the action stack below the content and optional banner. */
 export type InfoStateCta = Readonly<{
@@ -82,6 +89,10 @@ export type InfoStateProps =
   | (InfoStateBaseProps & {
       /** Renders an info status Spot. */
       preset: "info";
+    })
+  | (InfoStateBaseProps & {
+      /** Renders a loader Spot for in-progress states. */
+      preset: "loader";
     })
   | (InfoStateBaseProps & {
       /** Renders only title, description, banner, and actions without visual spacing. */

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/SwapDeviceIntentPocHost.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/SwapDeviceIntentPocHost.tsx
@@ -1,0 +1,123 @@
+import React, { useCallback } from "react";
+import { DeviceIntentExecutor } from "@ledgerhq/device-intent";
+import { BottomSheetHeader, BottomSheetView } from "@ledgerhq/lumen-ui-rnative";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
+import { LWM_EXECUTOR_PLATFORM_CONFIG } from "LLM/components/DeviceIntentExecutor";
+import { InfoState } from "LLM/components/InfoState";
+import type { SwapDeviceIntentPocOrchestrationResult } from "./useSwapDeviceIntentPocOrchestration";
+
+type Props = Pick<
+  SwapDeviceIntentPocOrchestrationResult,
+  "executorProps" | "successScreen" | "enabled" | "onUserCancel"
+>;
+
+/**
+ * Mounts the swap-POC drawer alongside the swap webview.
+ *
+ * The drawer is owned by this host (not by `DeviceIntentExecutorLWM`) so it
+ * stays mounted across the whole flow: sign-approval -> broadcast-approval
+ * -> done. Switching phases only swaps the drawer's inner content, which
+ * avoids triggering `QueuedDrawerBottomSheet`'s unmount cleanup -> onClose
+ * -> orchestration cancel-and-reject path. That path was the original
+ * reason the success sheet flashed shut as soon as the broadcast confirmed.
+ *
+ * Renders nothing while idle so the bottom sheet only appears when the
+ * live app actually requests an approval flow.
+ */
+export function SwapDeviceIntentPocHost({
+  executorProps,
+  successScreen,
+  enabled,
+  onUserCancel,
+}: Props): React.ReactElement | null {
+  const { bottom: bottomInset } = useSafeAreaInsets();
+
+  // The drawer's onClose fires on user dismiss (X / backdrop) AND on the
+  // host unmount cleanup. We dispatch to the most specific handler
+  // available so the success-phase resolution path wins over a generic
+  // CANCEL when both could match during the inter-phase re-render frame.
+  // During `buildSwap` neither executor nor success-screen is mounted, so
+  // we fall back to the orchestration's top-level `onUserCancel`.
+  const onCloseDuringExecutor = executorProps?.onUserCancel;
+  const onCloseDuringSuccess = successScreen?.onClose;
+  const handleClose = useCallback(() => {
+    if (onCloseDuringSuccess) {
+      onCloseDuringSuccess();
+    } else if (onCloseDuringExecutor) {
+      onCloseDuringExecutor();
+    } else {
+      onUserCancel();
+    }
+  }, [onCloseDuringExecutor, onCloseDuringSuccess, onUserCancel]);
+
+  if (!enabled) return null;
+
+  return (
+    <QueuedDrawerBottomSheet
+      isRequestingToBeOpened
+      onClose={handleClose}
+      preventBackdropClick={executorProps ? !executorProps.cancellableUI : false}
+      enableDynamicSizing
+    >
+      <BottomSheetView style={{ paddingBottom: bottomInset + 16 }}>
+        {successScreen ? (
+          <>
+            <BottomSheetHeader density="expanded" />
+            {successScreen.kind === "approval" ? (
+              <InfoState
+                preset="success"
+                title="Token approved"
+                description={
+                  successScreen.nextStep === "permit"
+                    ? "Sign the permit on your device to authorize the swap"
+                    : successScreen.nextStep === "rfq-order"
+                      ? "Sign the swap order on your device to authorize the partner"
+                      : "You can now initiate your swap"
+                }
+                primaryCta={{
+                  label:
+                    successScreen.nextStep === "permit"
+                      ? "Sign permit"
+                      : successScreen.nextStep === "rfq-order"
+                        ? "Sign order"
+                        : "Swap",
+                  onPress: successScreen.onPrimaryPress,
+                }}
+                size="hug"
+              />
+            ) : successScreen.kind === "swap" ? (
+              <InfoState
+                preset="success"
+                title="Swap completed"
+                description="Your swap transaction was confirmed on-chain."
+                primaryCta={{ label: "Done", onPress: successScreen.onDonePress }}
+                size="hug"
+              />
+            ) : (
+              <InfoState
+                preset={successScreen.status === "finished" ? "success" : "info"}
+                title={successScreen.status === "finished" ? "Swap completed" : "Swap refunded"}
+                description={
+                  successScreen.status === "finished"
+                    ? "Your RFQ swap was filled by the partner."
+                    : "The partner could not fill your RFQ order. You have been refunded."
+                }
+                primaryCta={{ label: "Done", onPress: successScreen.onDonePress }}
+                size="hug"
+              />
+            )}
+          </>
+        ) : executorProps ? (
+          <>
+            {executorProps.cancellableUI && <BottomSheetHeader density="expanded" />}
+            <DeviceIntentExecutor
+              {...executorProps}
+              platformConfig={LWM_EXECUTOR_PLATFORM_CONFIG}
+            />
+          </>
+        ) : null}
+      </BottomSheetView>
+    </QueuedDrawerBottomSheet>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/index.ts
@@ -1,0 +1,7 @@
+export { SwapDeviceIntentPocHost } from "./SwapDeviceIntentPocHost";
+export {
+  useSwapDeviceIntentPocOrchestration,
+  type SwapDeviceIntentPocOrchestrationResult,
+  type SwapPocSuccessScreen,
+} from "./useSwapDeviceIntentPocOrchestration";
+export type { CustomSwapParams, CustomSwapResult } from "./types";

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/broadcastEvmIntent/componentLWM.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/broadcastEvmIntent/componentLWM.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { InfoState } from "LLM/components/InfoState";
+import type { BroadcastEvmIntentExtraProps, BroadcastEvmJobState } from "./types";
+
+function describeLoader(jobState: BroadcastEvmJobState | undefined): {
+  title: string;
+  description: string;
+} {
+  if (!jobState) {
+    return { title: "Broadcasting transaction", description: "Preparing broadcast\u2026" };
+  }
+  switch (jobState.type) {
+    case "broadcasting":
+      return {
+        title: "Broadcasting transaction",
+        description: "Broadcasting transaction to the network\u2026",
+      };
+    case "broadcasted":
+    case "waiting-receipt":
+      return {
+        title: "Confirming transaction",
+        description: "Waiting for confirmation\u2026",
+      };
+    case "confirmed":
+      return {
+        title: "Transaction confirmed",
+        description: `Confirmed in block ${jobState.blockHeight}`,
+      };
+    case "failed":
+      return {
+        title: "Broadcast failed",
+        description: jobState.error.message,
+      };
+  }
+}
+
+export function BroadcastEvmIntentComponentLWM({
+  jobState,
+}: {
+  jobState: BroadcastEvmJobState | undefined;
+  extraProps: BroadcastEvmIntentExtraProps;
+  onClose: () => void;
+}) {
+  if (jobState?.type === "failed") {
+    const { title, description } = describeLoader(jobState);
+    return <InfoState preset="error" size="hug" title={title} description={description} />;
+  }
+
+  const { title, description } = describeLoader(jobState);
+  return <InfoState preset="loader" size="hug" title={title} description={description} />;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/broadcastEvmIntent/intentLWMDefinition.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/broadcastEvmIntent/intentLWMDefinition.ts
@@ -1,0 +1,8 @@
+import { broadcastEvmIntentDefinition } from "@ledgerhq/live-common/wallet-api/Exchange/intents/broadcastEvm/index";
+import { BroadcastEvmIntentComponentLWM } from "./componentLWM";
+import type { BroadcastEvmIntentPlatformDefinition } from "./types";
+
+export const broadcastEvmIntentLWMDefinition: BroadcastEvmIntentPlatformDefinition = {
+  ...broadcastEvmIntentDefinition,
+  component: BroadcastEvmIntentComponentLWM,
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/broadcastEvmIntent/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/broadcastEvmIntent/types.ts
@@ -1,0 +1,26 @@
+import type { Intent, IntentPlatformDefinition } from "@ledgerhq/device-intent";
+import type {
+  BroadcastEvmIntentDefinition,
+  BroadcastEvmIntentInput,
+  BroadcastEvmJobState,
+} from "@ledgerhq/live-common/wallet-api/Exchange/intents/broadcastEvm/index";
+
+export type {
+  BroadcastEvmIntentDefinition,
+  BroadcastEvmIntentInput,
+  BroadcastEvmJobState,
+};
+
+export type BroadcastEvmIntentExtraProps = Record<string, never>;
+
+export type BroadcastEvmIntentPlatformDefinition = IntentPlatformDefinition<
+  BroadcastEvmJobState,
+  BroadcastEvmIntentInput,
+  BroadcastEvmIntentExtraProps
+>;
+
+export type BroadcastEvmIntent = Intent<
+  BroadcastEvmJobState,
+  BroadcastEvmIntentInput,
+  BroadcastEvmIntentExtraProps
+>;

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/registry.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/registry.ts
@@ -1,0 +1,24 @@
+import { broadcastEvmIntentLWMDefinition } from "./broadcastEvmIntent/intentLWMDefinition";
+import { signApprovalEvmIntentLWMDefinition } from "./signApprovalEvmIntent/intentLWMDefinition";
+import { signPermit2EvmIntentLWMDefinition } from "./signPermit2EvmIntent/intentLWMDefinition";
+import { signRfqOrderEvmIntentLWMDefinition } from "./signRfqOrderEvmIntent/intentLWMDefinition";
+import { signSwapEvmIntentLWMDefinition } from "./signSwapEvmIntent/intentLWMDefinition";
+import { submitRfqOrderEvmIntentLWMDefinition } from "./submitRfqOrderEvmIntent/intentLWMDefinition";
+
+/**
+ * LWM platform definitions injected into {@link useSwapDeviceIntentPocOrchestration}.
+ *
+ * Splitting them out keeps the orchestrator decoupled from any specific
+ * production intent, which makes the hook trivially unit-testable with
+ * mock intents (per the recommended layout in the device-intent README).
+ */
+export const SWAP_POC_INTENT_DEFS = {
+  signApproval: signApprovalEvmIntentLWMDefinition,
+  signSwap: signSwapEvmIntentLWMDefinition,
+  signPermit2: signPermit2EvmIntentLWMDefinition,
+  signRfqOrder: signRfqOrderEvmIntentLWMDefinition,
+  submitRfqOrder: submitRfqOrderEvmIntentLWMDefinition,
+  broadcast: broadcastEvmIntentLWMDefinition,
+} as const;
+
+export type SwapPocIntentDefinitions = typeof SWAP_POC_INTENT_DEFS;

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/signApprovalEvmIntent/componentLWM.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/signApprovalEvmIntent/componentLWM.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { useSelector } from "react-redux";
+import { InfoState } from "LLM/components/InfoState";
+import { ContinueOnDevice } from "LLM/components/DeviceIntentExecutor/components/DeviceGenericStates/ContinueOnDevice";
+import { lastConnectedDeviceSelector } from "~/reducers/settings";
+import type { SignApprovalEvmIntentExtraProps, SignApprovalEvmJobState } from "./types";
+
+const LOADER_TITLE = "Approving token";
+const LOADER_DESCRIPTION = "Preparing approval transaction\u2026";
+
+const DEVICE_INTERACTION_STATES: ReadonlyArray<SignApprovalEvmJobState["type"]> = [
+  "loading-context",
+  "awaiting-confirmation",
+  "signing",
+];
+
+export function SignApprovalEvmIntentComponentLWM({
+  jobState,
+}: {
+  jobState: SignApprovalEvmJobState | undefined;
+  extraProps: SignApprovalEvmIntentExtraProps;
+  onClose: () => void;
+}) {
+  const device = useSelector(lastConnectedDeviceSelector);
+
+  if (jobState && DEVICE_INTERACTION_STATES.includes(jobState.type) && device) {
+    return (
+      <ContinueOnDevice
+        deviceModelId={device.modelId}
+        deviceName={device.deviceName ?? device.modelId}
+      />
+    );
+  }
+
+  if (jobState?.type === "failed") {
+    return (
+      <InfoState
+        preset="error"
+        size="hug"
+        title="Approval signing failed"
+        description={jobState.error.message}
+      />
+    );
+  }
+
+  return (
+    <InfoState preset="loader" size="hug" title={LOADER_TITLE} description={LOADER_DESCRIPTION} />
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/signApprovalEvmIntent/intentLWMDefinition.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/signApprovalEvmIntent/intentLWMDefinition.ts
@@ -1,0 +1,8 @@
+import { signApprovalEvmIntentDefinition } from "@ledgerhq/live-common/wallet-api/Exchange/intents/signApprovalEvm/index";
+import { SignApprovalEvmIntentComponentLWM } from "./componentLWM";
+import type { SignApprovalEvmIntentPlatformDefinition } from "./types";
+
+export const signApprovalEvmIntentLWMDefinition: SignApprovalEvmIntentPlatformDefinition = {
+  ...signApprovalEvmIntentDefinition,
+  component: SignApprovalEvmIntentComponentLWM,
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/signApprovalEvmIntent/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/signApprovalEvmIntent/types.ts
@@ -1,0 +1,26 @@
+import type { Intent, IntentPlatformDefinition } from "@ledgerhq/device-intent";
+import type {
+  SignApprovalEvmIntentDefinition,
+  SignApprovalEvmIntentInput,
+  SignApprovalEvmJobState,
+} from "@ledgerhq/live-common/wallet-api/Exchange/intents/signApprovalEvm/index";
+
+export type {
+  SignApprovalEvmIntentDefinition,
+  SignApprovalEvmIntentInput,
+  SignApprovalEvmJobState,
+};
+
+export type SignApprovalEvmIntentExtraProps = Record<string, never>;
+
+export type SignApprovalEvmIntentPlatformDefinition = IntentPlatformDefinition<
+  SignApprovalEvmJobState,
+  SignApprovalEvmIntentInput,
+  SignApprovalEvmIntentExtraProps
+>;
+
+export type SignApprovalEvmIntent = Intent<
+  SignApprovalEvmJobState,
+  SignApprovalEvmIntentInput,
+  SignApprovalEvmIntentExtraProps
+>;

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/signPermit2EvmIntent/componentLWM.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/signPermit2EvmIntent/componentLWM.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { useSelector } from "react-redux";
+import { InfoState } from "LLM/components/InfoState";
+import { ContinueOnDevice } from "LLM/components/DeviceIntentExecutor/components/DeviceGenericStates/ContinueOnDevice";
+import { lastConnectedDeviceSelector } from "~/reducers/settings";
+import type { SignPermit2EvmIntentExtraProps, SignPermit2EvmJobState } from "./types";
+
+const LOADER_TITLE = "Signing permit";
+const LOADER_DESCRIPTION = "Preparing permit signature\u2026";
+
+const DEVICE_INTERACTION_STATES: ReadonlyArray<SignPermit2EvmJobState["type"]> = [
+  "loading-context",
+  "awaiting-confirmation",
+  "signing",
+];
+
+export function SignPermit2EvmIntentComponentLWM({
+  jobState,
+}: {
+  jobState: SignPermit2EvmJobState | undefined;
+  extraProps: SignPermit2EvmIntentExtraProps;
+  onClose: () => void;
+}) {
+  const device = useSelector(lastConnectedDeviceSelector);
+
+  if (jobState && DEVICE_INTERACTION_STATES.includes(jobState.type) && device) {
+    return (
+      <ContinueOnDevice
+        deviceModelId={device.modelId}
+        deviceName={device.deviceName ?? device.modelId}
+      />
+    );
+  }
+
+  if (jobState?.type === "failed") {
+    return (
+      <InfoState
+        preset="error"
+        size="hug"
+        title="Permit signing failed"
+        description={jobState.error.message}
+      />
+    );
+  }
+
+  return (
+    <InfoState preset="loader" size="hug" title={LOADER_TITLE} description={LOADER_DESCRIPTION} />
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/signPermit2EvmIntent/intentLWMDefinition.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/signPermit2EvmIntent/intentLWMDefinition.ts
@@ -1,0 +1,8 @@
+import { signPermit2EvmIntentDefinition } from "@ledgerhq/live-common/wallet-api/Exchange/intents/signPermit2Evm/index";
+import { SignPermit2EvmIntentComponentLWM } from "./componentLWM";
+import type { SignPermit2EvmIntentPlatformDefinition } from "./types";
+
+export const signPermit2EvmIntentLWMDefinition: SignPermit2EvmIntentPlatformDefinition = {
+  ...signPermit2EvmIntentDefinition,
+  component: SignPermit2EvmIntentComponentLWM,
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/signPermit2EvmIntent/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/signPermit2EvmIntent/types.ts
@@ -1,0 +1,26 @@
+import type { Intent, IntentPlatformDefinition } from "@ledgerhq/device-intent";
+import type {
+  SignPermit2EvmIntentDefinition,
+  SignPermit2EvmIntentInput,
+  SignPermit2EvmJobState,
+} from "@ledgerhq/live-common/wallet-api/Exchange/intents/signPermit2Evm/index";
+
+export type {
+  SignPermit2EvmIntentDefinition,
+  SignPermit2EvmIntentInput,
+  SignPermit2EvmJobState,
+};
+
+export type SignPermit2EvmIntentExtraProps = Record<string, never>;
+
+export type SignPermit2EvmIntentPlatformDefinition = IntentPlatformDefinition<
+  SignPermit2EvmJobState,
+  SignPermit2EvmIntentInput,
+  SignPermit2EvmIntentExtraProps
+>;
+
+export type SignPermit2EvmIntent = Intent<
+  SignPermit2EvmJobState,
+  SignPermit2EvmIntentInput,
+  SignPermit2EvmIntentExtraProps
+>;

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/signRfqOrderEvmIntent/componentLWM.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/signRfqOrderEvmIntent/componentLWM.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { useSelector } from "react-redux";
+import { InfoState } from "LLM/components/InfoState";
+import { ContinueOnDevice } from "LLM/components/DeviceIntentExecutor/components/DeviceGenericStates/ContinueOnDevice";
+import { lastConnectedDeviceSelector } from "~/reducers/settings";
+import type {
+  SignRfqOrderEvmIntentExtraProps,
+  SignRfqOrderEvmJobState,
+} from "./types";
+
+const LOADER_TITLE = "Signing RFQ order";
+const LOADER_DESCRIPTION = "Preparing RFQ order signature\u2026";
+
+const DEVICE_INTERACTION_STATES: ReadonlyArray<
+  SignRfqOrderEvmJobState["type"]
+> = ["loading-context", "awaiting-confirmation", "signing"];
+
+export function SignRfqOrderEvmIntentComponentLWM({
+  jobState,
+}: {
+  jobState: SignRfqOrderEvmJobState | undefined;
+  extraProps: SignRfqOrderEvmIntentExtraProps;
+  onClose: () => void;
+}) {
+  const device = useSelector(lastConnectedDeviceSelector);
+
+  if (
+    jobState &&
+    DEVICE_INTERACTION_STATES.includes(jobState.type) &&
+    device
+  ) {
+    return (
+      <ContinueOnDevice
+        deviceModelId={device.modelId}
+        deviceName={device.deviceName ?? device.modelId}
+      />
+    );
+  }
+
+  if (jobState?.type === "failed") {
+    return (
+      <InfoState
+        preset="error"
+        size="hug"
+        title="RFQ order signing failed"
+        description={jobState.error.message}
+      />
+    );
+  }
+
+  return (
+    <InfoState
+      preset="loader"
+      size="hug"
+      title={LOADER_TITLE}
+      description={LOADER_DESCRIPTION}
+    />
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/signRfqOrderEvmIntent/intentLWMDefinition.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/signRfqOrderEvmIntent/intentLWMDefinition.ts
@@ -1,0 +1,9 @@
+import { signRfqOrderEvmIntentDefinition } from "@ledgerhq/live-common/wallet-api/Exchange/intents/signRfqOrderEvm/index";
+import { SignRfqOrderEvmIntentComponentLWM } from "./componentLWM";
+import type { SignRfqOrderEvmIntentPlatformDefinition } from "./types";
+
+export const signRfqOrderEvmIntentLWMDefinition: SignRfqOrderEvmIntentPlatformDefinition =
+  {
+    ...signRfqOrderEvmIntentDefinition,
+    component: SignRfqOrderEvmIntentComponentLWM,
+  };

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/signRfqOrderEvmIntent/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/signRfqOrderEvmIntent/types.ts
@@ -1,0 +1,26 @@
+import type { Intent, IntentPlatformDefinition } from "@ledgerhq/device-intent";
+import type {
+  SignRfqOrderEvmIntentDefinition,
+  SignRfqOrderEvmIntentInput,
+  SignRfqOrderEvmJobState,
+} from "@ledgerhq/live-common/wallet-api/Exchange/intents/signRfqOrderEvm/index";
+
+export type {
+  SignRfqOrderEvmIntentDefinition,
+  SignRfqOrderEvmIntentInput,
+  SignRfqOrderEvmJobState,
+};
+
+export type SignRfqOrderEvmIntentExtraProps = Record<string, never>;
+
+export type SignRfqOrderEvmIntentPlatformDefinition = IntentPlatformDefinition<
+  SignRfqOrderEvmJobState,
+  SignRfqOrderEvmIntentInput,
+  SignRfqOrderEvmIntentExtraProps
+>;
+
+export type SignRfqOrderEvmIntent = Intent<
+  SignRfqOrderEvmJobState,
+  SignRfqOrderEvmIntentInput,
+  SignRfqOrderEvmIntentExtraProps
+>;

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/signSwapEvmIntent/componentLWM.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/signSwapEvmIntent/componentLWM.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { useSelector } from "react-redux";
+import { InfoState } from "LLM/components/InfoState";
+import { ContinueOnDevice } from "LLM/components/DeviceIntentExecutor/components/DeviceGenericStates/ContinueOnDevice";
+import { lastConnectedDeviceSelector } from "~/reducers/settings";
+import type { SignSwapEvmIntentExtraProps, SignSwapEvmJobState } from "./types";
+
+const LOADER_TITLE = "Preparing swap";
+const LOADER_DESCRIPTION = "Preparing swap transaction\u2026";
+
+const DEVICE_INTERACTION_STATES: ReadonlyArray<SignSwapEvmJobState["type"]> = [
+  "loading-context",
+  "awaiting-confirmation",
+  "signing",
+];
+
+export function SignSwapEvmIntentComponentLWM({
+  jobState,
+}: {
+  jobState: SignSwapEvmJobState | undefined;
+  extraProps: SignSwapEvmIntentExtraProps;
+  onClose: () => void;
+}) {
+  const device = useSelector(lastConnectedDeviceSelector);
+
+  if (jobState && DEVICE_INTERACTION_STATES.includes(jobState.type) && device) {
+    return (
+      <ContinueOnDevice
+        deviceModelId={device.modelId}
+        deviceName={device.deviceName ?? device.modelId}
+      />
+    );
+  }
+
+  if (jobState?.type === "failed") {
+    return (
+      <InfoState
+        preset="error"
+        size="hug"
+        title="Swap signing failed"
+        description={jobState.error.message}
+      />
+    );
+  }
+
+  return (
+    <InfoState preset="loader" size="hug" title={LOADER_TITLE} description={LOADER_DESCRIPTION} />
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/signSwapEvmIntent/intentLWMDefinition.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/signSwapEvmIntent/intentLWMDefinition.ts
@@ -1,0 +1,8 @@
+import { signSwapEvmIntentDefinition } from "@ledgerhq/live-common/wallet-api/Exchange/intents/signSwapEvm/index";
+import { SignSwapEvmIntentComponentLWM } from "./componentLWM";
+import type { SignSwapEvmIntentPlatformDefinition } from "./types";
+
+export const signSwapEvmIntentLWMDefinition: SignSwapEvmIntentPlatformDefinition = {
+  ...signSwapEvmIntentDefinition,
+  component: SignSwapEvmIntentComponentLWM,
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/signSwapEvmIntent/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/signSwapEvmIntent/types.ts
@@ -1,0 +1,26 @@
+import type { Intent, IntentPlatformDefinition } from "@ledgerhq/device-intent";
+import type {
+  SignSwapEvmIntentDefinition,
+  SignSwapEvmIntentInput,
+  SignSwapEvmJobState,
+} from "@ledgerhq/live-common/wallet-api/Exchange/intents/signSwapEvm/index";
+
+export type {
+  SignSwapEvmIntentDefinition,
+  SignSwapEvmIntentInput,
+  SignSwapEvmJobState,
+};
+
+export type SignSwapEvmIntentExtraProps = Record<string, never>;
+
+export type SignSwapEvmIntentPlatformDefinition = IntentPlatformDefinition<
+  SignSwapEvmJobState,
+  SignSwapEvmIntentInput,
+  SignSwapEvmIntentExtraProps
+>;
+
+export type SignSwapEvmIntent = Intent<
+  SignSwapEvmJobState,
+  SignSwapEvmIntentInput,
+  SignSwapEvmIntentExtraProps
+>;

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/submitRfqOrderEvmIntent/componentLWM.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/submitRfqOrderEvmIntent/componentLWM.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { InfoState } from "LLM/components/InfoState";
+import type {
+  SubmitRfqOrderEvmIntentExtraProps,
+  SubmitRfqOrderEvmJobState,
+} from "./types";
+
+function describeLoader(jobState: SubmitRfqOrderEvmJobState | undefined): {
+  title: string;
+  description: string;
+} {
+  if (!jobState) {
+    return {
+      title: "Submitting RFQ order",
+      description: "Sending signed order to partner\u2026",
+    };
+  }
+  switch (jobState.type) {
+    case "submitting":
+      return {
+        title: "Submitting RFQ order",
+        description: "Sending signed order to partner\u2026",
+      };
+    case "submitted":
+      return {
+        title: "Waiting for partner",
+        description: "Order submitted. Waiting for partner to fill\u2026",
+      };
+    case "polling":
+      return {
+        title: "Waiting for partner",
+        description: "Waiting for order to be filled on-chain\u2026",
+      };
+    case "confirmed":
+      return {
+        title:
+          jobState.status === "finished"
+            ? "Order filled"
+            : "Order refunded",
+        description:
+          jobState.status === "finished"
+            ? "Your RFQ order was filled on-chain."
+            : "Your RFQ order was not filled and you have been refunded.",
+      };
+    case "failed":
+      return {
+        title: "RFQ submit failed",
+        description: jobState.error.message,
+      };
+  }
+}
+
+export function SubmitRfqOrderEvmIntentComponentLWM({
+  jobState,
+}: {
+  jobState: SubmitRfqOrderEvmJobState | undefined;
+  extraProps: SubmitRfqOrderEvmIntentExtraProps;
+  onClose: () => void;
+}) {
+  if (jobState?.type === "failed") {
+    const { title, description } = describeLoader(jobState);
+    return (
+      <InfoState
+        preset="error"
+        size="hug"
+        title={title}
+        description={description}
+      />
+    );
+  }
+
+  const { title, description } = describeLoader(jobState);
+  return (
+    <InfoState
+      preset="loader"
+      size="hug"
+      title={title}
+      description={description}
+    />
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/submitRfqOrderEvmIntent/intentLWMDefinition.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/submitRfqOrderEvmIntent/intentLWMDefinition.ts
@@ -1,0 +1,9 @@
+import { submitRfqOrderEvmIntentDefinition } from "@ledgerhq/live-common/wallet-api/Exchange/intents/submitRfqOrderEvm/index";
+import { SubmitRfqOrderEvmIntentComponentLWM } from "./componentLWM";
+import type { SubmitRfqOrderEvmIntentPlatformDefinition } from "./types";
+
+export const submitRfqOrderEvmIntentLWMDefinition: SubmitRfqOrderEvmIntentPlatformDefinition =
+  {
+    ...submitRfqOrderEvmIntentDefinition,
+    component: SubmitRfqOrderEvmIntentComponentLWM,
+  };

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/submitRfqOrderEvmIntent/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/intents/submitRfqOrderEvmIntent/types.ts
@@ -1,0 +1,27 @@
+import type { Intent, IntentPlatformDefinition } from "@ledgerhq/device-intent";
+import type {
+  SubmitRfqOrderEvmIntentDefinition,
+  SubmitRfqOrderEvmIntentInput,
+  SubmitRfqOrderEvmJobState,
+} from "@ledgerhq/live-common/wallet-api/Exchange/intents/submitRfqOrderEvm/index";
+
+export type {
+  SubmitRfqOrderEvmIntentDefinition,
+  SubmitRfqOrderEvmIntentInput,
+  SubmitRfqOrderEvmJobState,
+};
+
+export type SubmitRfqOrderEvmIntentExtraProps = Record<string, never>;
+
+export type SubmitRfqOrderEvmIntentPlatformDefinition =
+  IntentPlatformDefinition<
+    SubmitRfqOrderEvmJobState,
+    SubmitRfqOrderEvmIntentInput,
+    SubmitRfqOrderEvmIntentExtraProps
+  >;
+
+export type SubmitRfqOrderEvmIntent = Intent<
+  SubmitRfqOrderEvmJobState,
+  SubmitRfqOrderEvmIntentInput,
+  SubmitRfqOrderEvmIntentExtraProps
+>;

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/types.ts
@@ -1,0 +1,12 @@
+/**
+ * Mobile-side aliases for the `custom.swap` wire types.
+ *
+ * The single source of truth lives in `@ledgerhq/wallet-api-exchange-module`
+ * and is re-exported via `@ledgerhq/live-common`. We re-export here so the
+ * rest of the POC keeps importing from a feature-local barrel and we never
+ * end up with two competing shapes.
+ */
+export type {
+  CustomSwapParams,
+  CustomSwapResult,
+} from "@ledgerhq/live-common/wallet-api/Exchange/quotes/types";

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/useSwapDeviceIntentPocOrchestration.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/useSwapDeviceIntentPocOrchestration.ts
@@ -1,0 +1,564 @@
+import { useMachine } from "@xstate/react";
+import { useCallback, useMemo } from "react";
+import {
+  createIntent,
+  type DeviceConnectionParams,
+  type DeviceIntentExecutorProps,
+  type Intent,
+} from "@ledgerhq/device-intent";
+import { createCustomErrorClass } from "@ledgerhq/errors";
+import { getMainAccount, getParentAccount } from "@ledgerhq/live-common/account/index";
+import { getAccountIdFromWalletAccountId } from "@ledgerhq/live-common/wallet-api/converters";
+import {
+  buildProviderTransactionData,
+  DEFAULT_DEX_GAS_LIMIT,
+  DEFAULT_DEX_GAS_LIMIT_MULTIPLIER,
+} from "@ledgerhq/live-common/wallet-api/Exchange/dex/index";
+import {
+  createSwapFlowMachine,
+  planSwapFlow,
+  type SwapFlowPorts,
+  type SwapFlowResolvers,
+} from "@ledgerhq/live-common/wallet-api/Exchange/swapFlow/index";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
+import type { InitializationInput } from "LLM/components/DeviceIntentExecutor/types";
+import { SWAP_POC_INTENT_DEFS } from "./intents/registry";
+import type {
+  SignApprovalEvmIntent,
+  SignApprovalEvmIntentInput,
+  SignApprovalEvmJobState,
+} from "./intents/signApprovalEvmIntent/types";
+import type {
+  SignSwapEvmIntent,
+  SignSwapEvmIntentInput,
+  SignSwapEvmJobState,
+} from "./intents/signSwapEvmIntent/types";
+import type {
+  SignPermit2EvmIntent,
+  SignPermit2EvmIntentInput,
+  SignPermit2EvmJobState,
+} from "./intents/signPermit2EvmIntent/types";
+import type {
+  SignRfqOrderEvmIntent,
+  SignRfqOrderEvmIntentInput,
+  SignRfqOrderEvmJobState,
+} from "./intents/signRfqOrderEvmIntent/types";
+import type {
+  SubmitRfqOrderEvmIntent,
+  SubmitRfqOrderEvmIntentInput,
+  SubmitRfqOrderEvmJobState,
+} from "./intents/submitRfqOrderEvmIntent/types";
+import type {
+  BroadcastEvmIntent,
+  BroadcastEvmIntentInput,
+  BroadcastEvmJobState,
+} from "./intents/broadcastEvmIntent/types";
+import type { CustomSwapParams, CustomSwapResult } from "./types";
+
+const DrawerClosedError = createCustomErrorClass("DrawerClosedError");
+
+const DEFAULT_CONNECTION_PARAMS: DeviceConnectionParams = { acceptedDeviceModelIds: [] };
+
+const ETHEREUM_INITIALIZATION_INPUT: InitializationInput = {
+  appName: "Ethereum",
+  dependencies: [],
+  requireLatestFirmware: false,
+  allowPartialDependencies: false,
+};
+
+/**
+ * Build the device-init input for the swap leg using the partner's
+ * hardware-wallet app id surfaced by `buildProviderTransactionData()`
+ * ("Uniswap" / "1inch" / "Velora" / "Ethereum" for OKX). The subsequent
+ * broadcast phase reuses this same input so the device stays on the
+ * partner app instead of returning to the Ethereum app.
+ */
+function buildSwapInitializationInput(hwAppId: string): InitializationInput {
+  return {
+    appName: hwAppId,
+    dependencies: [],
+    requireLatestFirmware: false,
+    allowPartialDependencies: false,
+  };
+}
+
+// Every POC intent emits through the same executor, so the executor props are
+// typed as the broadest union of their job states and inputs. Each phase
+// keeps the precise Intent instance internally and we cast at the boundary.
+type AnyJobState =
+  | SignApprovalEvmJobState
+  | SignSwapEvmJobState
+  | SignPermit2EvmJobState
+  | SignRfqOrderEvmJobState
+  | SubmitRfqOrderEvmJobState
+  | BroadcastEvmJobState;
+type AnyInput =
+  | SignApprovalEvmIntentInput
+  | SignSwapEvmIntentInput
+  | SignPermit2EvmIntentInput
+  | SignRfqOrderEvmIntentInput
+  | SubmitRfqOrderEvmIntentInput
+  | BroadcastEvmIntentInput;
+type AnyExtraProps = Record<string, never>;
+type AnyIntent =
+  | SignApprovalEvmIntent
+  | SignSwapEvmIntent
+  | SignPermit2EvmIntent
+  | SignRfqOrderEvmIntent
+  | SubmitRfqOrderEvmIntent
+  | BroadcastEvmIntent;
+
+/**
+ * Information needed to render the post-approval or post-swap confirmation
+ * sheet. Populated once the matching broadcast intent confirms on-chain
+ * and consumed by {@link SwapDeviceIntentPocHost}. Dismissing the
+ * approval-success sheet (Swap CTA, X or backdrop) either triggers the
+ * swap step or resolves the live-app `customSwap` Promise with the
+ * approval hash only. Dismissing the swap-success sheet always resolves
+ * with both hashes.
+ */
+export type SwapPocSuccessScreen =
+  | {
+      kind: "approval";
+      /**
+       * Next on-device step the primary CTA will trigger. Mirrors the
+       * swap-live-app `useSwapLabels` ordering (approve → sign_permit
+       * / rfq → swap) so the button copy matches what tapping it
+       * actually does: for an `approval-then-permit-then-swap` plan the
+       * next step is Permit2, for `approval-then-rfq-order` it's the
+       * RFQ order signing, otherwise it's the swap calldata sign.
+       */
+      nextStep: "permit" | "rfq-order" | "swap";
+      /** Hash of the broadcast-and-confirmed approval transaction. */
+      approvalTxHash: string;
+      /** Called when the user taps the primary CTA (kicks off the next step). */
+      onPrimaryPress: () => void;
+      /** Called when the user dismisses the sheet (X or backdrop) — resolves with approval only. */
+      onClose: () => void;
+    }
+  | {
+      kind: "swap";
+      /** Hash of the broadcast-and-confirmed approval transaction (null for direct swaps). */
+      approvalTxHash: string | null;
+      /** Hash of the broadcast-and-confirmed swap transaction. */
+      swapTxHash: string;
+      /** Called when the user taps the primary "Done" CTA. */
+      onDonePress: () => void;
+      /** Called when the user dismisses the sheet (X or backdrop). */
+      onClose: () => void;
+    }
+  | {
+      kind: "rfq";
+      /** Hash of the broadcast-and-confirmed approval transaction (null when no approval was needed). */
+      approvalTxHash: string | null;
+      /** Terminal RFQ status reported by the partner's `/swap/status` endpoint. */
+      status: "finished" | "refunded";
+      /** On-chain transaction hash, when the partner reported one. */
+      txHash?: string;
+      /** Partner-side swap id, when reported. */
+      swapId?: string;
+      /** Final filled amount, when reported. */
+      finalAmount?: string;
+      /** Called when the user taps the primary "Done" CTA. */
+      onDonePress: () => void;
+      /** Called when the user dismisses the sheet (X or backdrop). */
+      onClose: () => void;
+    };
+
+export type SwapDeviceIntentPocOrchestrationResult = {
+  /** Wallet API handler to register as `custom.swap`. */
+  customSwapHandler: (request: { params?: CustomSwapParams }) => Promise<CustomSwapResult>;
+  /** Props to pass to the LWM executor while a flow is running, or `null` if idle. */
+  executorProps: DeviceIntentExecutorProps<
+    AnyJobState,
+    AnyInput,
+    AnyExtraProps,
+    InitializationInput
+  > | null;
+  /** Info needed to render the post-approval / post-swap success sheet, or `null` otherwise. */
+  successScreen: SwapPocSuccessScreen | null;
+  /** Whether the host should mount any swap-POC UI (executor or success sheet). */
+  enabled: boolean;
+  /**
+   * Always-available cancel callback the host should fire on drawer
+   * close when neither {@link executorProps} nor {@link successScreen}
+   * is set (e.g. during the asynchronous `buildSwap` phase). Sends the
+   * machine a `CANCEL` event so the held `customSwap` Promise rejects
+   * and the machine resets to `idle` for the next call.
+   */
+  onUserCancel: () => void;
+};
+
+/**
+ * Resolves the wallet API account id to the parent EVM account that owns the
+ * spending allowance. The handler accepts either a token sub-account id or
+ * a main account id; we always sign from the main account so the bridge can
+ * look up nonce / fees and produce a broadcast-ready signed transaction.
+ */
+function resolveEvmMainAccount(walletAccountId: string, accounts: AccountLike[]): Account {
+  const realAccountId = getAccountIdFromWalletAccountId(walletAccountId);
+  if (!realAccountId) {
+    throw new Error(`accountId ${walletAccountId} unknown`);
+  }
+  const account = accounts.find(acc => acc.id === realAccountId);
+  if (!account) {
+    throw new Error(`accountId ${walletAccountId} unknown`);
+  }
+  const parent = getParentAccount(account, accounts);
+  const main = getMainAccount(account, parent);
+  if (main.currency.family !== "evm") {
+    throw new Error(
+      `custom.swap POC supports EVM source accounts only (got ${main.currency.family})`,
+    );
+  }
+  return main;
+}
+
+/**
+ * Resolves the currency id for a wallet-API account id, picking the token
+ * id for sub-accounts and the crypto-currency id otherwise. Returns
+ * `undefined` when the id cannot be resolved so the caller can decide
+ * whether to fail open (the DEX builders tolerate undefined fields).
+ */
+function resolveCurrencyId(
+  walletAccountId: string,
+  accounts: AccountLike[],
+): string | undefined {
+  const realAccountId = getAccountIdFromWalletAccountId(walletAccountId);
+  if (!realAccountId) return undefined;
+  const account = accounts.find(acc => acc.id === realAccountId);
+  if (!account) return undefined;
+  return account.type === "TokenAccount" ? account.token.id : account.currency.id;
+}
+
+/**
+ * LWM port factories: build {@link Intent} runtime instances for the
+ * shared `swapFlow` machine. Stateless and side-effect-free at module
+ * scope so we can memo a single ports object per render.
+ */
+const LWM_SWAP_FLOW_PORTS: SwapFlowPorts<AnyIntent, InitializationInput> = {
+  createSignApprovalIntent: ({ account, approvalTransaction, currencyId, derivationPath }) => ({
+    intent: createIntent(SWAP_POC_INTENT_DEFS.signApproval, {
+      account,
+      approvalTransaction,
+      currencyId,
+      derivationPath,
+    }),
+    initInput: ETHEREUM_INITIALIZATION_INPUT,
+  }),
+  createSignSwapIntent: ({ account, transactionData, currencyId, derivationPath, hwAppId }) => ({
+    intent: createIntent(SWAP_POC_INTENT_DEFS.signSwap, {
+      account,
+      transactionData,
+      currencyId,
+      derivationPath,
+    }),
+    // Open the partner's embedded app for the swap leg. The follow-up
+    // broadcast phase carries the same init input forward so it absorbs
+    // the intent change as a self-transition (see device-intent README).
+    initInput: buildSwapInitializationInput(hwAppId),
+  }),
+  createSignPermit2Intent: ({ account, typedData, currencyId, derivationPath }) => ({
+    intent: createIntent(SWAP_POC_INTENT_DEFS.signPermit2, {
+      account,
+      typedData,
+      currencyId,
+      derivationPath,
+    }),
+    initInput: ETHEREUM_INITIALIZATION_INPUT,
+  }),
+  createSignRfqOrderIntent: ({ account, typedData, currencyId, derivationPath }) => ({
+    intent: createIntent(SWAP_POC_INTENT_DEFS.signRfqOrder, {
+      account,
+      typedData,
+      currencyId,
+      derivationPath,
+    }),
+    initInput: ETHEREUM_INITIALIZATION_INPUT,
+  }),
+  createSubmitRfqOrderIntent: ({
+    provider,
+    submitBody,
+    precomputedOrderId,
+    network,
+    initInput,
+  }) => ({
+    intent: createIntent(SWAP_POC_INTENT_DEFS.submitRfqOrder, {
+      provider,
+      submitBody,
+      network,
+      // Spread the optional field instead of passing `undefined` so the
+      // resulting Intent input matches `SubmitRfqOrderEvmIntentInput`'s
+      // optional-property shape under `exactOptionalPropertyTypes`.
+      ...(precomputedOrderId !== undefined ? { precomputedOrderId } : {}),
+    }),
+    // Re-use the previous phase's init input so the executor absorbs the
+    // intent change as a self-transition (see device-intent README).
+    initInput,
+  }),
+  createBroadcastIntent: ({ signedTxHex, currencyId, initInput }) => ({
+    intent: createIntent(SWAP_POC_INTENT_DEFS.broadcast, { signedTxHex, currencyId }),
+    // Re-use the previous phase's init input so the executor absorbs the
+    // intent change as a self-transition (see device-intent README).
+    initInput,
+  }),
+  buildSwapTransactionData: async ({ provider, context }) => {
+    const { transactionData, hwAppId } = await buildProviderTransactionData(
+      provider,
+      context,
+    );
+    return { transactionData, hwAppId };
+  },
+};
+
+const SWAP_FLOW_MACHINE = createSwapFlowMachine(LWM_SWAP_FLOW_PORTS);
+
+/**
+ * Adapter hook around the shared {@link createSwapFlowMachine} machine.
+ *
+ * - Resolves wallet-API account ids to wallet-side `Account`s and builds a
+ *   {@link planSwapFlow} plan (already-approved DEX quotes now go through
+ *   a wallet-driven direct-swap path instead of the previous `{}`
+ *   short-circuit).
+ * - Translates `DeviceIntentExecutor` lifecycle callbacks into typed
+ *   machine events (`JOB_SIGNED`, `JOB_CONFIRMED`, `JOB_FAILED`,
+ *   `JOB_ERROR`, `CANCEL`).
+ * - Derives `executorProps` and `successScreen` from the machine state so
+ *   the host stays a thin renderer.
+ */
+export function useSwapDeviceIntentPocOrchestration({
+  accounts,
+}: {
+  accounts: AccountLike[];
+}): SwapDeviceIntentPocOrchestrationResult {
+  // `actorRef` is stable across renders so we can read the live snapshot
+  // inside callbacks instead of capturing potentially stale `state` from
+  // the React render. `state` is still used for derivations that need to
+  // re-render the host (executor / success-screen visibility).
+  const [state, send, actorRef] = useMachine(SWAP_FLOW_MACHINE);
+
+  const handleJobStateChanged = useCallback(
+    (jobState: AnyJobState) => {
+      if (!("type" in jobState)) return;
+      switch (jobState.type) {
+        case "signed":
+          // Sign-approval / sign-swap jobs emit `signedTxHex`; the
+          // Permit2 and RFQ-order jobs emit `signatureHex`. Discriminate
+          // on the payload shape and on the current machine phase so the
+          // host doesn't need to know which phase is currently active.
+          if ("signedTxHex" in jobState) {
+            send({ type: "JOB_SIGNED", signedTxHex: jobState.signedTxHex });
+          } else if ("signatureHex" in jobState) {
+            // The Permit2 and RFQ-order phases share the same
+            // `{ type: "signed", signatureHex }` shape; the machine
+            // state tells us which event to dispatch.
+            const snapshot = actorRef.getSnapshot();
+            if (snapshot.matches("signRfqOrder")) {
+              send({
+                type: "JOB_RFQ_SIGNED",
+                signatureHex: jobState.signatureHex,
+              });
+            } else {
+              send({
+                type: "JOB_PERMIT_SIGNED",
+                signatureHex: jobState.signatureHex,
+              });
+            }
+          }
+          break;
+        case "confirmed":
+          // The `confirmed` shape is shared by the EVM broadcast job
+          // (`{ hash, blockHeight }`) and the RFQ submit job
+          // (`{ status, orderId, txHash?, swapId?, finalAmount? }`).
+          // Discriminate on payload shape: only the RFQ confirmed
+          // state carries `status`.
+          if ("status" in jobState) {
+            send({
+              type: "JOB_RFQ_SUBMITTED",
+              outcome: {
+                status: jobState.status,
+                txHash: jobState.txHash,
+                swapId: jobState.swapId,
+                finalAmount: jobState.finalAmount,
+              },
+            });
+          } else {
+            send({ type: "JOB_CONFIRMED", hash: jobState.hash });
+          }
+          break;
+        case "failed":
+          send({ type: "JOB_FAILED", error: jobState.error });
+          break;
+        default:
+          break;
+      }
+    },
+    [actorRef, send],
+  );
+
+  const handleJobComplete = useCallback(() => {
+    // Job completion is implied by the terminal events forwarded above
+    // (`JOB_SIGNED`, `JOB_CONFIRMED`, `JOB_FAILED`); intentionally a no-op.
+  }, []);
+
+  const handleJobError = useCallback(
+    (err: unknown) => {
+      send({
+        type: "JOB_ERROR",
+        error: err instanceof Error ? err : new Error(String(err)),
+      });
+    },
+    [send],
+  );
+
+  const handleUserCancel = useCallback(() => {
+    send({
+      type: "CANCEL",
+      error: new DrawerClosedError("User closed the swap drawer"),
+    });
+  }, [send]);
+
+  const customSwapHandler = useCallback<
+    SwapDeviceIntentPocOrchestrationResult["customSwapHandler"]
+  >(
+    request =>
+      new Promise<CustomSwapResult>((resolve, reject) => {
+        try {
+          const params = request.params;
+          if (!params) {
+            reject(new Error("custom.swap: missing params"));
+            return;
+          }
+          // Live snapshot — `state` from the closure may be stale if the
+          // live-app holds an old handler reference between renders.
+          if (!actorRef.getSnapshot().matches("idle")) {
+            reject(new Error("custom.swap: another swap flow is already running"));
+            return;
+          }
+
+          const mainAccount = resolveEvmMainAccount(params.fromAccountId, accounts);
+          const plan = planSwapFlow({
+            quote: params.quote,
+            fromAccountId: params.fromAccountId,
+            toAccountId: params.toAccountId,
+            fromAccountAddress: mainAccount.freshAddress,
+            fromCurrencyId: resolveCurrencyId(params.fromAccountId, accounts),
+            toCurrencyId: resolveCurrencyId(params.toAccountId, accounts),
+            defaultGasLimit: DEFAULT_DEX_GAS_LIMIT,
+            gasLimitMultiplier: DEFAULT_DEX_GAS_LIMIT_MULTIPLIER,
+          });
+
+          const resolvers: SwapFlowResolvers = { resolve, reject };
+
+          send({
+            type: "START",
+            input: {
+              plan,
+              mainAccount,
+              currencyId: mainAccount.currency.id,
+              derivationPath: mainAccount.freshAddressPath,
+              initInput: ETHEREUM_INITIALIZATION_INPUT,
+              resolvers,
+            },
+          });
+        } catch (err) {
+          reject(err instanceof Error ? err : new Error(String(err)));
+        }
+      }),
+    [accounts, actorRef, send],
+  );
+
+  const enabled = !state.matches("idle");
+
+  const executorProps = useMemo<
+    DeviceIntentExecutorProps<AnyJobState, AnyInput, AnyExtraProps, InitializationInput> | null
+  >(() => {
+    const isDevicePhase =
+      state.matches("signApproval") ||
+      state.matches("broadcastApproval") ||
+      state.matches("signPermit2") ||
+      state.matches("signSwap") ||
+      state.matches("broadcastSwap") ||
+      state.matches("signRfqOrder") ||
+      state.matches("submitRfqOrder");
+    if (!isDevicePhase) return null;
+    const { currentIntent, currentInitInput } = state.context;
+    if (!currentIntent || !currentInitInput) return null;
+
+    return {
+      enabled: true,
+      deviceConnectionParams: DEFAULT_CONNECTION_PARAMS,
+      deviceInitializationInput: currentInitInput,
+      // The executor accepts a single Intent generic; we cast at the boundary
+      // because each phase carries a strictly narrower instance.
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      intent: currentIntent as unknown as Intent<AnyJobState, AnyInput, AnyExtraProps>,
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      intentComponentExtraProps: {} as AnyExtraProps,
+      onExecutorStateChanged: () => {
+        /* no-op for the POC */
+      },
+      onIntentJobStateChanged: handleJobStateChanged,
+      onIntentJobComplete: handleJobComplete,
+      onIntentJobError: handleJobError,
+      cancellableUI: true,
+      cancelIntentRequestId: undefined,
+      onUserCancel: handleUserCancel,
+    };
+  }, [state, handleJobStateChanged, handleJobComplete, handleJobError, handleUserCancel]);
+
+  const successScreen = useMemo<SwapPocSuccessScreen | null>(() => {
+    if (state.matches("approvalSuccess") && state.context.approvalTxHash) {
+      // The machine already routes `SWAP_PRESSED` to `signPermit2` /
+      // `signRfqOrder` / `buildSwap` via its plan guards; mirror that
+      // decision here so the host can label the CTA after the actual
+      // next phase.
+      let nextStep: "permit" | "rfq-order" | "swap" = "swap";
+      if (state.context.plan?.kind === "approval-then-permit-then-swap") {
+        nextStep = "permit";
+      } else if (state.context.plan?.kind === "approval-then-rfq-order") {
+        nextStep = "rfq-order";
+      }
+      return {
+        kind: "approval",
+        nextStep,
+        approvalTxHash: state.context.approvalTxHash,
+        onPrimaryPress: () => send({ type: "SWAP_PRESSED" }),
+        onClose: () => send({ type: "APPROVAL_DISMISSED" }),
+      };
+    }
+    if (state.matches("swapSuccess") && state.context.swapTxHash) {
+      const dismiss = () => send({ type: "SWAP_DISMISSED" });
+      return {
+        kind: "swap",
+        approvalTxHash: state.context.approvalTxHash,
+        swapTxHash: state.context.swapTxHash,
+        onDonePress: dismiss,
+        onClose: dismiss,
+      };
+    }
+    if (state.matches("rfqSuccess") && state.context.rfqOutcome) {
+      const dismiss = () => send({ type: "SWAP_DISMISSED" });
+      const outcome = state.context.rfqOutcome;
+      return {
+        kind: "rfq",
+        approvalTxHash: state.context.approvalTxHash,
+        status: outcome.status,
+        txHash: outcome.txHash,
+        swapId: outcome.swapId,
+        finalAmount: outcome.finalAmount,
+        onDonePress: dismiss,
+        onClose: dismiss,
+      };
+    }
+    return null;
+  }, [state, send]);
+
+  return {
+    customSwapHandler,
+    executorProps,
+    successScreen,
+    enabled,
+    onUserCancel: handleUserCancel,
+  };
+}

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/InfoStateScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/InfoStateScreen.tsx
@@ -13,10 +13,10 @@ const presetOptions: InfoStatePreset[] = [
   "success",
   "error",
   "info",
+  "loader",
   "text",
 ];
 const sizeOptions: Array<NonNullable<InfoStateProps["size"]>> = ["full-height", "hug"];
-const cyclePresets: InfoStatePreset[] = ["error", "info", "success", "text"];
 
 export default function DebugInfoStateScreen() {
   const { bottom: bottomInset } = useSafeAreaInsets();
@@ -30,8 +30,6 @@ export default function DebugInfoStateScreen() {
   const [useLongTitle, setUseLongTitle] = useState(false);
   const [useLongDescription, setUseLongDescription] = useState(false);
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
-  const [isCyclePreviewOpen, setIsCyclePreviewOpen] = useState(false);
-  const [cycleIndex, setCycleIndex] = useState(0);
 
   const title = useLongTitle ? longTitle : `${formatPresetLabel(preset)} state title`;
   const description = useLongDescription
@@ -123,25 +121,12 @@ export default function DebugInfoStateScreen() {
           >
             Open preview
           </Button>
-
-          <Button
-            appearance="gray"
-            size="lg"
-            onPress={() => {
-              setCycleIndex(0);
-              setIsCyclePreviewOpen(true);
-            }}
-            testID="info-state-open-cycle-preview"
-          >
-            Open tone cycle preview
-          </Button>
         </Box>
       </ScrollView>
 
       <QueuedDrawerBottomSheet
         isRequestingToBeOpened={isPreviewOpen}
         onClose={() => setIsPreviewOpen(false)}
-        hideHandle
         enableDynamicSizing
         testID="info-state-preview-sheet"
       >
@@ -176,59 +161,8 @@ export default function DebugInfoStateScreen() {
           })}
         </BottomSheetView>
       </QueuedDrawerBottomSheet>
-
-      <QueuedDrawerBottomSheet
-        isRequestingToBeOpened={isCyclePreviewOpen}
-        onClose={() => setIsCyclePreviewOpen(false)}
-        hideHandle
-        enableDynamicSizing
-        testID="info-state-cycle-preview-sheet"
-      >
-        <BottomSheetView style={[styles.sheetContent, { paddingBottom: bottomInset + 24 }]}>
-          <BottomSheetHeader />
-          {renderCycleInfoState({
-            preset: cyclePresets[cycleIndex],
-            nextPreset: cyclePresets[(cycleIndex + 1) % cyclePresets.length],
-            onNext: () => setCycleIndex(index => (index + 1) % cyclePresets.length),
-          })}
-        </BottomSheetView>
-      </QueuedDrawerBottomSheet>
     </>
   );
-}
-
-function renderCycleInfoState({
-  preset,
-  nextPreset,
-  onNext,
-}: Readonly<{
-  preset: InfoStatePreset;
-  nextPreset: InfoStatePreset;
-  onNext: () => void;
-}>) {
-  const commonProps: Pick<InfoStateProps, "size" | "title" | "description" | "primaryCta"> = {
-    size: "hug",
-    title: `${formatPresetLabel(preset)} state`,
-    description: "Tap the primary action to cycle to the next tone without closing the drawer.",
-    primaryCta: {
-      label: `Next: ${formatPresetLabel(nextPreset)}`,
-      onPress: onNext,
-      testID: "info-state-cycle-next-cta",
-    },
-  };
-
-  switch (preset) {
-    case "success":
-      return <InfoState {...commonProps} preset="success" testID="info-state-cycle-preview" />;
-    case "error":
-      return <InfoState {...commonProps} preset="error" testID="info-state-cycle-preview" />;
-    case "info":
-      return <InfoState {...commonProps} preset="info" testID="info-state-cycle-preview" />;
-    case "text":
-      return <InfoState {...commonProps} preset="text" testID="info-state-cycle-preview" />;
-    default:
-      throw new Error(`Unsupported cycle preset: ${preset}`);
-  }
 }
 
 function renderInfoStatePreview({
@@ -267,6 +201,8 @@ function renderInfoStatePreview({
       return <InfoState {...commonProps} preset="error" testID="info-state-preview" />;
     case "info":
       return <InfoState {...commonProps} preset="info" testID="info-state-preview" />;
+    case "loader":
+      return <InfoState {...commonProps} preset="loader" testID="info-state-preview" />;
     case "text":
       return <InfoState {...commonProps} preset="text" testID="info-state-preview" />;
     default:

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/SwapLiveAppWallet40.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/SwapLiveAppWallet40.tsx
@@ -16,6 +16,7 @@ import { DefaultAccountSwapParamList } from "../types";
 import { useSwapWallet40HeaderStateUpdater } from "./navigationHandlers/wallet40/useSwapWallet40HeaderState";
 import { useSwapAndroidHardwareBackPress } from "./navigationHandlers/useSwapAndroidHardwareBackPress";
 import { LiveAppBackground } from "LLM/components/LiveAppBackground";
+import { SwapDeviceIntentPocHost } from "LLM/features/SwapDeviceIntentPOC";
 
 type SwapWebviewContentProps = {
   manifest: LiveAppManifest;
@@ -30,16 +31,34 @@ function SwapWebviewContent({
   webviewRef,
   setWebviewState,
 }: Readonly<SwapWebviewContentProps>) {
-  const { customHandlers, inputs } = useSwapWebviewProps({ manifest, params });
+  const {
+    customHandlers,
+    inputs,
+    swapPocExecutorProps,
+    swapPocSuccessScreen,
+    swapPocEnabled,
+    swapPocOnUserCancel,
+  } = useSwapWebviewProps({
+    manifest,
+    params,
+  });
 
   return (
-    <Web3AppWebview
-      ref={webviewRef}
-      manifest={manifest}
-      customHandlers={customHandlers}
-      onStateChange={setWebviewState}
-      inputs={inputs}
-    />
+    <>
+      <Web3AppWebview
+        ref={webviewRef}
+        manifest={manifest}
+        customHandlers={customHandlers}
+        onStateChange={setWebviewState}
+        inputs={inputs}
+      />
+      <SwapDeviceIntentPocHost
+        executorProps={swapPocExecutorProps}
+        successScreen={swapPocSuccessScreen}
+        enabled={swapPocEnabled}
+        onUserCancel={swapPocOnUserCancel}
+      />
+    </>
   );
 }
 

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/WebView.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/WebView.tsx
@@ -3,6 +3,7 @@ import React, { forwardRef } from "react";
 import { Web3AppWebview } from "~/components/Web3AppWebview";
 import { WebviewAPI, WebviewState } from "~/components/Web3AppWebview/types";
 import SafeAreaView from "~/components/SafeAreaView";
+import { SwapDeviceIntentPocHost } from "LLM/features/SwapDeviceIntentPOC";
 import { DefaultAccountSwapParamList } from "../types";
 import { useSwapWebviewProps } from "./hooks/useSwapWebviewProps";
 
@@ -14,7 +15,17 @@ type Props = {
 
 export const WebView = forwardRef<WebviewAPI, Props>(
   ({ manifest, params, setWebviewState }, ref) => {
-    const { customHandlers, inputs } = useSwapWebviewProps({ manifest, params });
+    const {
+      customHandlers,
+      inputs,
+      swapPocExecutorProps,
+      swapPocSuccessScreen,
+      swapPocEnabled,
+      swapPocOnUserCancel,
+    } = useSwapWebviewProps({
+      manifest,
+      params,
+    });
 
     return (
       <SafeAreaView edges={["bottom"]} isFlex>
@@ -24,6 +35,12 @@ export const WebView = forwardRef<WebviewAPI, Props>(
           customHandlers={customHandlers}
           onStateChange={setWebviewState}
           inputs={inputs}
+        />
+        <SwapDeviceIntentPocHost
+          executorProps={swapPocExecutorProps}
+          successScreen={swapPocSuccessScreen}
+          enabled={swapPocEnabled}
+          onUserCancel={swapPocOnUserCancel}
         />
       </SafeAreaView>
     );

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/index.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/index.ts
@@ -16,7 +16,8 @@ import { getTransactionByHash } from "./getTransactionByHash";
 import { saveSwapToHistory } from "./saveSwapToHistory";
 import { useCustomExchangeHandlers } from "~/components/WebPTXPlayer/CustomHandlers";
 import { ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
-import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { useSwapDeviceIntentPocOrchestration } from "LLM/features/SwapDeviceIntentPOC";
 
 export type NavigationType = Omit<NavigationProp<ReactNavigation.RootParamList>, "getState"> & {
   getState(): NavigationState | undefined;
@@ -110,15 +111,26 @@ export function useSwapCustomHandlers(
     handleLoaderDrawer: handleShowLoadingDrawer,
   });
 
+  const swapPoc = useSwapDeviceIntentPocOrchestration({ accounts });
+
   const swapCustomHandlers = {
     "custom.getFee": getFee(accounts, navigation),
     "custom.getTransactionByHash": getTransactionByHash(accounts),
     "custom.saveSwapToHistory": saveSwapToHistory(accounts, dispatch),
     "custom.swapRedirectToHistory": navigateToSwapHistory,
+    "custom.swap": swapPoc.customSwapHandler,
   };
 
-  return {
+  const customHandlers = {
     ...walletAPISwapHandlers,
     ...swapCustomHandlers,
   } as WalletAPICustomHandlers;
+
+  return {
+    customHandlers,
+    swapPocExecutorProps: swapPoc.executorProps,
+    swapPocSuccessScreen: swapPoc.successScreen,
+    swapPocEnabled: swapPoc.enabled,
+    swapPocOnUserCancel: swapPoc.onUserCancel,
+  };
 }

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/hooks/useSwapWebviewProps.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/hooks/useSwapWebviewProps.ts
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { Platform } from "react-native";
 import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
-import { useFeature, useWalletFeaturesConfig } from "@features/platform-feature-flags";
+import { useFeature, useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import { WalletAPICustomHandlers } from "@ledgerhq/live-common/wallet-api/types";
 import { useSelector, useDispatch } from "~/context/hooks";
 import { useTheme } from "styled-components/native";
@@ -38,7 +38,13 @@ export function useSwapWebviewProps({ manifest, params }: UseSwapWebviewPropsPar
   // to avoid complexifying the logic in the shared custom handlers.
   const accounts = useSelector(flattenAccountsSelector);
   const dispatch = useDispatch();
-  const customSwapHandlers = useSwapCustomHandlers(manifest, accounts, dispatch);
+  const {
+    customHandlers: customSwapHandlers,
+    swapPocExecutorProps,
+    swapPocSuccessScreen,
+    swapPocEnabled,
+    swapPocOnUserCancel,
+  } = useSwapCustomHandlers(manifest, accounts, dispatch);
   const customDeeplinkHandlers = useDeeplinkCustomHandlers();
   const customHandlers = useMemo<WalletAPICustomHandlers>(() => {
     return {
@@ -121,5 +127,9 @@ export function useSwapWebviewProps({ manifest, params }: UseSwapWebviewPropsPar
   return {
     customHandlers,
     inputs,
+    swapPocExecutorProps,
+    swapPocSuccessScreen,
+    swapPocEnabled,
+    swapPocOnUserCancel,
   };
 }

--- a/libs/exchange-module/src/types.ts
+++ b/libs/exchange-module/src/types.ts
@@ -118,10 +118,10 @@ export type QuotesInput = {
   amount: string;
   sendAccountId: string;
   receiveAccountId: string;
-  sendAddress: string;
-  receiveAddress: string;
-  sendCurrencyId: string;
-  receiveCurrencyId: string;
+  sendAddress?: string;
+  receiveAddress?: string;
+  sendCurrencyId?: string;
+  receiveCurrencyId?: string;
   networkFeesCurrencyId?: string;
   slippage?: number;
   uniswapOrderType?: UniswapOrderType;
@@ -140,9 +140,24 @@ export type TradeMethod = "fixed" | "float";
 
 export type ProviderTypes = "DEX" | "CEX";
 
-export type QuoteWarning = { code: "unrealisticQuote"; gainPercent: number };
+export enum QuoteWarningCodes {
+  HIGH_VALUE_LOSS = "highValueLoss",
+  NANO_S_PROVIDER_INCOMPATIBILITY = "nanoSProviderIncompatibility",
+  UNREALISTIC_QUOTE = "unrealisticQuote",
+  UNKNOWN_RECEIVE_FIAT_PRICE = "unknownReceiveFiatPrice",
+}
 
-export type QuoteError = "notEnoughBalanceForFees";
+export type QuoteWarning =
+  | { code: QuoteWarningCodes.HIGH_VALUE_LOSS; lossPercent: number }
+  | { code: QuoteWarningCodes.NANO_S_PROVIDER_INCOMPATIBILITY; provider: string }
+  | { code: QuoteWarningCodes.UNREALISTIC_QUOTE; gainPercent: number }
+  | { code: QuoteWarningCodes.UNKNOWN_RECEIVE_FIAT_PRICE };
+
+export enum QuoteErrorCodes {
+  NOT_ENOUGH_BALANCE_FOR_FEES = "notEnoughBalanceForFees",
+}
+
+export type QuoteError = { code: QuoteErrorCodes.NOT_ENOUGH_BALANCE_FOR_FEES };
 
 export type ProviderDetails = {
   name: string;
@@ -155,6 +170,7 @@ export type ProviderDetails = {
 
 export type QuoteNetworkFees = {
   currencyId: string;
+  value?: number;
   gasLimit?: string;
 };
 
@@ -312,8 +328,8 @@ export type Quote = {
   provider: string;
   providerDetails: ProviderDetails;
   quoteDetails: QuoteDetails;
-  warning: QuoteWarning | null;
-  error: QuoteError | null;
+  warnings: QuoteWarning[];
+  errors: QuoteError[];
   /**
    * Optional wallet-formatted display strings. Additive field:
    * producers that cannot format (no locale / counter-value fiat context)
@@ -374,7 +390,40 @@ export type QuoteProviderError = {
   parameter: { [key: string]: string };
 };
 
+/**
+ * Digested global state attached to {@link GetQuotesResponse.errors}.
+ * Discriminated by `code`; multiple variants can stack (e.g. `noQuotes`
+ * alongside `amountTooLow`). Empty array means "nothing to surface".
+ *
+ * Producers live wallet-side; this is the contract consumers read.
+ */
+export enum QuotesErrorCodes {
+  NO_QUOTES = "noQuotes",
+  QUOTE_INPUT_RESOLUTION_FAILED = "quoteInputResolutionFailed",
+  AMOUNT_TOO_LOW = "amountTooLow",
+  AMOUNT_TOO_HIGH = "amountTooHigh",
+}
+
+export type QuotesError =
+  | { code: QuotesErrorCodes.NO_QUOTES }
+  | { code: QuotesErrorCodes.QUOTE_INPUT_RESOLUTION_FAILED }
+  | { code: QuotesErrorCodes.AMOUNT_TOO_LOW; minAmount: string }
+  | { code: QuotesErrorCodes.AMOUNT_TOO_HIGH; maxAmount: string };
+
 export type GetQuotesResponse = {
   quotes: Quote[];
-  errors: QuoteProviderError[];
+  /**
+   * Per-provider rejection rows from the aggregator. Each row is one
+   * provider declining to quote with a reason (e.g. `amount_off_limits`).
+   * Pure pass-through of the aggregator response — the wallet does not
+   * digest these into globals here, that lives in {@link errors}.
+   */
+  providerErrors: QuoteProviderError[];
+  /**
+   * Digested global state for the whole batch (e.g. `noQuotes` when no
+   * successful quotes came back, `amountTooLow` / `amountTooHigh` when
+   * every provider rejected on amount bounds). Empty array when there is
+   * nothing to surface.
+   */
+  errors: QuotesError[];
 };

--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ledgerhq/live-common",
   "description": "Common ground for the Ledger Live apps",
-  "version": "34.71.0",
+  "version": "35.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/LedgerHQ/ledger-live.git"
@@ -56,6 +56,11 @@
     ".": {
       "require": "./lib/index.js",
       "default": "./lib-es/index.js"
+    },
+    "./genericAwarenessModal": {
+      "@ledgerhq/source": "./src/genericAwarenessModal/index.ts",
+      "require": "./lib/genericAwarenessModal/index.js",
+      "default": "./lib-es/genericAwarenessModal/index.js"
     },
     "./currencies/*": {
       "@ledgerhq/source": "./src/currencies/*.ts",

--- a/libs/ledger-live-common/src/wallet-api/Exchange/intents/broadcastEvm/job.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/intents/broadcastEvm/job.ts
@@ -25,10 +25,12 @@ function buildBroadcastObservable(input: BroadcastEvmIntentInput): Observable<Br
     let cancelled = false;
 
     (async () => {
+      // The `broadcasting` state is emitted synchronously by the outer
+      // `concat(of(...), ...)` wrapper below; we go straight to the actual
+      // broadcast call here to avoid a duplicate transition.
       const currency = getCryptoCurrencyById(input.currencyId);
       const nodeApi = getNodeApi(currency);
 
-      subscriber.next({ type: "broadcasting" });
       const hash = await nodeApi.broadcastTransaction(currency, input.signedTxHex);
       if (cancelled) return;
       subscriber.next({ type: "broadcasted", hash });

--- a/libs/ledger-live-common/src/wallet-api/Exchange/intents/submitRfqOrderEvm/job.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/intents/submitRfqOrderEvm/job.ts
@@ -20,6 +20,18 @@ const DEFAULT_POLL_INTERVAL_MS = 5_000;
  */
 const DEFAULT_MAX_POLL_ATTEMPTS = 60;
 
+/**
+ * Known RFQ partners exposed by the Ledger swap-api `${baseURL}/${provider}/submit`
+ * routes. Constrains the dynamic path segment to a closed set so the URL
+ * cannot be redirected to an arbitrary route via the wallet-api input
+ * (CodeQL SSRF guard).
+ */
+const ALLOWED_RFQ_PROVIDERS = new Set<string>([
+  "uniswap",
+  "oneinch",
+  "oneinchfusion",
+]);
+
 function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -67,7 +79,13 @@ function buildSubmitObservable(
     const baseURL = input.swapApiBaseURL ?? getSwapAPIBaseURL();
 
     (async () => {
-      subscriber.next({ type: "submitting" });
+      // The `submitting` state is emitted synchronously by the outer
+      // `concat(of(...), ...)` wrapper below; don't re-emit it here.
+      if (!ALLOWED_RFQ_PROVIDERS.has(input.provider)) {
+        throw new Error(
+          `Unsupported RFQ provider "${input.provider}" — refusing to issue swap-api submit request`,
+        );
+      }
       const submitResponse = await fetchImpl(
         `${baseURL}/${input.provider}/submit`,
         {

--- a/libs/ledger-live-common/src/wallet-api/Exchange/swapFlow/machine.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/swapFlow/machine.ts
@@ -45,9 +45,11 @@ export type SwapFlowStartInput<TIntent, TInitInput> = {
    * machine itself does not depend on this; we just keep it on context).
    */
   meta?: Record<string, unknown>;
-  // Phantom marker so TInitInput contributes to the inferred input shape
-  // even when `meta` is omitted; without it TS widens TInitInput to `unknown`.
-  _phantom?: TIntent;
+  // Phantom markers so both `TIntent` and `TInitInput` contribute to the
+  // inferred input shape even when `meta` is omitted; without them TS
+  // widens these type parameters to `unknown` at the call site.
+  _intent?: TIntent;
+  _initInput?: TInitInput;
 };
 
 export type SwapFlowContext<TIntent, TInitInput> = {

--- a/libs/ledger-live-common/src/wallet-api/Exchange/swapFlow/planSwapFlow.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/swapFlow/planSwapFlow.test.ts
@@ -96,8 +96,8 @@ function makeQuote(overrides: {
         : undefined,
       permitData,
     },
-    warning: null,
-    error: null,
+    warnings: [],
+    errors: [],
     customFields,
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1817,6 +1817,9 @@ importers:
       '@tanstack/react-query':
         specifier: 5.28.9
         version: 5.28.9(react@19.0.0)
+      '@xstate/react':
+        specifier: 'catalog:'
+        version: 5.0.2(@types/react@19.0.14)(react@19.0.0)(xstate@5.19.2)
       asyncstorage-down:
         specifier: 4.2.0
         version: 4.2.0(patch_hash=de0963775da5b91d167469189fc2683439a7c96f70ab510ccbcb6d01c11e365c)(@react-native-async-storage/async-storage@2.1.2(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)))
@@ -2063,6 +2066,9 @@ importers:
       uuid:
         specifier: 8.3.2
         version: 8.3.2
+      xstate:
+        specifier: 'catalog:'
+        version: 5.19.2
     devDependencies:
       '@babel/core':
         specifier: 7.28.5


### PR DESCRIPTION
## Summary

Mobile-side consumer of the shared `custom.swap` flow added in the foundation PR #18013 (stacked — please merge #18013 first). This is the second half of the 2-PR split of `feat/swap-die-poc`.

### What's in this PR

- **`SwapDeviceIntentPOC` MVVM feature** (`apps/ledger-live-mobile/src/mvvm/features/SwapDeviceIntentPOC/`):
  - LWM React component wrappers around the cross-platform intent definitions exposed by `@ledgerhq/live-common/wallet-api/Exchange/intents` (`signApproval`, `signSwap`, `signPermit2`, `signRfqOrder`, `submitRfqOrder`, `broadcast`).
  - `useSwapDeviceIntentPocOrchestration` — builds the `SwapFlowPorts` adapter and drives the shared `swapFlow` XState machine via `@xstate/react#useMachine`, deriving `executorProps`, `successScreen`, `enabled`, and `onUserCancel` from machine state.
  - `SwapDeviceIntentPocHost` — mounted alongside the Swap WebView.
- **Swap live-app wiring** (`apps/ledger-live-mobile/src/screens/Swap/LiveApp/`):
  - Registers a `custom.swap` custom handler that delegates to the orchestration hook.
  - `SwapLiveAppWallet40` / `WebView` / `useSwapWebviewProps` thread the new executor props through to the host.
- Small adjustments to `DeviceIntentExecutor` and `InfoState` for the new success / progress screens.
- Adds `xstate` and `@xstate/react` from the catalog to `apps/ledger-live-mobile`.

### Note

`apps/ledger-live-mobile/src/live-common-setup.ts` includes a temporary `setEnv("SWAP_API_BASE", "https://swap-stg.ledger-test.com/v5")` for the POC (see FIXME comment) — to be removed once `react-native-config` → `@ledgerhq/live-env` propagation is wired up like on desktop.

### Stack

```
develop
  └─ #18013  feat(common): add wallet-api custom swap device-intent flow
       └─ THIS PR  feat(mobile): wire custom.swap device-intent flow
```

## Test plan

- [ ] CI typecheck / unit tests for `live-mobile`
- [ ] `pnpm mobile test:jest` (targeted: `SwapDeviceIntentPOC`, `SwapLiveAppWallet40`, `InfoState`)
- [ ] Manual smoke: open Swap on mobile against the staging swap-api, run an EVM token-approval + swap end-to-end (Uniswap classic AMM, Permit2, RFQ paths)

Made with [Cursor](https://cursor.com)