### PR TITLE
[LWD] feat(desktop): sync asset detail market price with chart scrubbing

### DIFF
--- a/.changeset/curvy-fishes-build.md
+++ b/.changeset/curvy-fishes-build.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Sync the asset detail market price with chart scrubbing: hovering the line chart now updates the displayed price and date to the scrubbed point (hiding the percentage and fiat variation while scrubbing), wired through a shared ScrubbedPriceContext.

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/LineChartPlotContent.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/LineChartPlotContent.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { LineChart as LumenLineChart } from "@ledgerhq/lumen-ui-react-visualization";
+import { LUMEN_CHART_OVERFLOW_MARGIN } from "./constants";
 import { LineChartLoading } from "./LineChartLoading";
 import { LineChartError } from "./LineChartError";
 import { LineChartPoints } from "./LineChartPoints";
@@ -24,6 +25,7 @@ export type LineChartPlotContentProps = Readonly<{
   enableScrubber: boolean;
   formatValue: LineChartValueFormatter;
   tooltipTitle?: LineChartTooltipTitle;
+  showScrubberTooltip: boolean;
   onScrubberPositionChange?: LineChartScrubberPositionChange;
   showArea: boolean;
   showXAxis: boolean;
@@ -42,6 +44,7 @@ export function LineChartPlotContent({
   enableScrubber,
   formatValue,
   tooltipTitle,
+  showScrubberTooltip,
   onScrubberPositionChange,
   showArea,
   showXAxis,
@@ -58,7 +61,11 @@ export function LineChartPlotContent({
   }
 
   return (
-    <div data-testid="line-chart-plot" className="w-full min-w-0">
+    <div
+      data-testid="line-chart-plot"
+      className="w-full min-w-0"
+      style={{ paddingTop: LUMEN_CHART_OVERFLOW_MARGIN }}
+    >
       <LumenLineChart
         series={chartSeries}
         height={height}
@@ -77,6 +84,7 @@ export function LineChartPlotContent({
             series={chartSeries}
             formatValue={formatValue}
             tooltipTitle={tooltipTitle}
+            showTooltip={showScrubberTooltip}
           />
         )}
       </LumenLineChart>

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/LineChartScrubber.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/LineChartScrubber.tsx
@@ -11,9 +11,16 @@ type LineChartScrubberProps = Readonly<{
   series: LineChartSeries[];
   formatValue: LineChartValueFormatter;
   tooltipTitle?: LineChartTooltipTitle;
+  /** Renders the tooltip box on the scrubbed index. @default true */
+  showTooltip?: boolean;
 }>;
 
-export function LineChartScrubber({ series, formatValue, tooltipTitle }: LineChartScrubberProps) {
+export function LineChartScrubber({
+  series,
+  formatValue,
+  tooltipTitle,
+  showTooltip = true,
+}: LineChartScrubberProps) {
   const buildTooltip = useCallback(
     (dataIndex: number): ScrubberTooltipContent => {
       const items = series
@@ -27,5 +34,5 @@ export function LineChartScrubber({ series, formatValue, tooltipTitle }: LineCha
     [series, formatValue, tooltipTitle],
   );
 
-  return <Scrubber showBeacons tooltip={buildTooltip} />;
+  return <Scrubber showBeacons tooltip={showTooltip ? buildTooltip : undefined} />;
 }

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/LineChartView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/LineChartView.tsx
@@ -19,6 +19,7 @@ export function LineChartView({
   enableScrubber,
   formatValue,
   tooltipTitle,
+  showScrubberTooltip,
   onScrubberPositionChange,
   showArea,
   showXAxis,
@@ -38,6 +39,7 @@ export function LineChartView({
         enableScrubber={enableScrubber}
         formatValue={formatValue}
         tooltipTitle={tooltipTitle}
+        showScrubberTooltip={showScrubberTooltip}
         onScrubberPositionChange={onScrubberPositionChange}
         showArea={showArea}
         showXAxis={showXAxis}

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/__tests__/LineChartPlot.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/__tests__/LineChartPlot.test.tsx
@@ -24,6 +24,7 @@ const defaultProps: LineChartPlotContentProps = {
   points: [],
   enableScrubber: true,
   formatValue: value => `$${value}`,
+  showScrubberTooltip: true,
   showArea: true,
   showXAxis: true,
   showYAxis: true,

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/__tests__/getSeriesExtrema.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/__tests__/getSeriesExtrema.test.ts
@@ -56,8 +56,8 @@ describe("getExtremaPointMarkers", () => {
 
   it("emits a top success max marker and a bottom error min marker", () => {
     expect(getExtremaPointMarkers(makeSeries([3, 1, 4, 9, 2]))).toEqual([
-      { index: 3, value: 9, color: "success", labelPosition: "top" },
-      { index: 1, value: 1, color: "error", labelPosition: "bottom" },
+      { index: 3, value: 9, color: "success", labelPosition: "top", hidePoint: true },
+      { index: 1, value: 1, color: "error", labelPosition: "bottom", hidePoint: true },
     ]);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/constants.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/constants.ts
@@ -5,6 +5,9 @@ export const LINE_CHART_RANGES: readonly LineChartRange[] = ["1d", "1w", "1m", "
 
 export const DEFAULT_LINE_CHART_HEIGHT = 240;
 
+/** Matches @ledgerhq/lumen-ui-react-visualization CartesianChart overflow margins. */
+export const LUMEN_CHART_OVERFLOW_MARGIN = 30;
+
 export const LINE_CHART_COLOR_TO_STROKE = {
   success: cssVar("var(--color-background-success-strong)"),
   error: cssVar("var(--color-background-error-strong)"),

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/types.ts
@@ -50,6 +50,8 @@ export type LineChartProps = Readonly<{
   formatValue?: LineChartValueFormatter;
   /** Returns the tooltip title for the given data index (e.g. a formatted date). */
   tooltipTitle?: LineChartTooltipTitle;
+  /** Renders the scrubber tooltip on hover/scrub. @default true */
+  showScrubberTooltip?: boolean;
   onScrubberPositionChange?: LineChartScrubberPositionChange;
   /** Fills the area under the line. @default true */
   showArea?: boolean;

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/useLineChartViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/useLineChartViewModel.ts
@@ -34,6 +34,7 @@ export type LineChartViewModelResult = Readonly<{
   enableScrubber: boolean;
   formatValue: LineChartValueFormatter;
   tooltipTitle?: LineChartTooltipTitle;
+  showScrubberTooltip: boolean;
   onScrubberPositionChange?: LineChartScrubberPositionChange;
   showArea: boolean;
   showXAxis: boolean;
@@ -55,6 +56,7 @@ export function useLineChartViewModel({
   enableScrubber = true,
   formatValue = defaultFormatValue,
   tooltipTitle,
+  showScrubberTooltip = true,
   onScrubberPositionChange,
   showArea = true,
   showXAxis = true,
@@ -105,6 +107,7 @@ export function useLineChartViewModel({
     enableScrubber,
     formatValue,
     tooltipTitle,
+    showScrubberTooltip,
     onScrubberPositionChange,
     showArea,
     showXAxis,

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/utils/getExtremaPointMarkers.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/utils/getExtremaPointMarkers.ts
@@ -12,12 +12,14 @@ export function getExtremaPointMarkers(series: LineChartSeries[]): LineChartPoin
       value: extrema.max.value,
       color: LINE_CHART_EXTREMA_COLORS.max,
       labelPosition: "top",
+      hidePoint: true,
     },
     {
       index: extrema.min.index,
       value: extrema.min.value,
       color: LINE_CHART_EXTREMA_COLORS.min,
       labelPosition: "bottom",
+      hidePoint: true,
     },
   ];
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/__integrations__/AssetDetail.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/__integrations__/AssetDetail.integration.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import {
+  fireEvent,
   render,
   renderWithMockedCounterValuesProvider,
   screen,
@@ -446,7 +447,7 @@ describe("AssetDetail integration", () => {
         expect(within(section).getAllByTestId("point-group")).toHaveLength(2);
       });
 
-      it("shows the scrubber tooltip when hovering the chart", async () => {
+      it("shows the scrubber without a tooltip when hovering the chart", async () => {
         mockMarket.withData(MarketMockedResponse.bitcoinDetail);
         setupRoute("bitcoin", OWNED_ASSETS[0].buildDistribution());
 
@@ -459,8 +460,48 @@ describe("AssetDetail integration", () => {
 
         await waitFor(() => {
           expect(within(section).getByTestId("scrubber")).toBeVisible();
-          expect(within(section).getByTestId("chart-tooltip")).toBeVisible();
         });
+        // The scrubbed price/date is surfaced in the market price section instead.
+        expect(within(section).queryByTestId("chart-tooltip")).not.toBeInTheDocument();
+      });
+
+      it("drives the market price section from the scrubbed point and reverts on leave", async () => {
+        mockMarket.withData(MarketMockedResponse.bitcoinDetail);
+        setupRoute("bitcoin", OWNED_ASSETS[0].buildDistribution());
+
+        renderWithMockedCounterValuesProvider(<AssetDetail />);
+
+        await waitForMarketPriceSectionShowsQuote();
+
+        const priceSection = screen.getByTestId(TEST_ID.MARKET_PRICE_SECTION);
+        const livePrice = screen.getByTestId(TEST_ID.MARKET_PRICE).textContent;
+        expect(within(priceSection).getByText("1 day")).toBeVisible();
+
+        const chartSection = screen.getByTestId(TEST_ID.CHART_SECTION);
+        const chart = await waitFor(() => within(chartSection).getByTestId("chart-svg"));
+
+        hoverChartSvg(chart);
+
+        // While scrubbing, the trailing range label is replaced by the hovered
+        // point's date, the displayed price tracks the scrubbed value, and the
+        // % / fiat variation are hidden.
+        await waitFor(() => {
+          expect(within(priceSection).queryByText("1 day")).not.toBeInTheDocument();
+          expect(screen.getByTestId(TEST_ID.MARKET_PRICE).textContent).not.toBe(livePrice);
+        });
+        expect(screen.queryByTestId(TEST_ID.MARKET_PRICE_PERCENT)).not.toBeInTheDocument();
+        expect(screen.queryByTestId(TEST_ID.MARKET_PRICE_FIAT_VARIATION)).not.toBeInTheDocument();
+
+        fireEvent.mouseLeave(chart);
+
+        // Leaving the chart reverts to the live price, range label and variation.
+        // The amount re-enables its animation on revert, so wait for it to settle.
+        await waitFor(() => {
+          expect(within(priceSection).getByText("1 day")).toBeVisible();
+          expect(screen.getByTestId(TEST_ID.MARKET_PRICE).textContent).toBe(livePrice);
+        });
+        expect(screen.getByTestId(TEST_ID.MARKET_PRICE_PERCENT)).toBeVisible();
+        expect(screen.getByTestId(TEST_ID.MARKET_PRICE_FIAT_VARIATION)).toBeVisible();
       });
     });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/ChartSectionView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/ChartSectionView.tsx
@@ -4,7 +4,7 @@ import type { ChartSectionViewModelResult } from "./useChartSectionViewModel";
 
 type ChartSectionViewProps = Readonly<ChartSectionViewModelResult>;
 
-export function ChartSectionView({
+function ChartSectionViewComponent({
   series,
   selectedRange,
   onRangeChange,
@@ -13,6 +13,7 @@ export function ChartSectionView({
   isError,
   formatValue,
   tooltipTitle,
+  onScrubberPositionChange,
   showXAxis,
   showYAxis,
   xAxis,
@@ -25,10 +26,13 @@ export function ChartSectionView({
         selectedRange={selectedRange}
         onRangeChange={onRangeChange}
         color={color}
+        height={325}
         isLoading={isLoading}
         isError={isError}
         formatValue={formatValue}
         tooltipTitle={tooltipTitle}
+        showScrubberTooltip={false}
+        onScrubberPositionChange={onScrubberPositionChange}
         showXAxis={showXAxis}
         showYAxis={showYAxis}
         xAxis={xAxis}
@@ -37,3 +41,5 @@ export function ChartSectionView({
     </div>
   );
 }
+
+export const ChartSectionView = React.memo(ChartSectionViewComponent);

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/useChartSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/useChartSectionViewModel.ts
@@ -8,18 +8,20 @@ import {
   resolveLineChartColorFromPercentChange,
   type LineChartColor,
   type LineChartRange,
+  type LineChartScrubberPositionChange,
   type LineChartSeries,
   type LineChartTooltipTitle,
   type LineChartValueFormatter,
   type LineChartXAxisConfig,
   type LineChartYAxisConfig,
 } from "LLD/components/LineChart";
-import { dayFormat, hourFormat, useDateFormatter } from "~/renderer/hooks/useDateFormatter";
 import { counterValueCurrencySelector, localeSelector } from "~/renderer/reducers/settings";
 import {
   clampDayChangePercentPointsNearZero,
   getPriceChangeKeyForRange,
 } from "../MarketPriceSection/utils";
+import { useAssetChartDateFormatter } from "../../hooks/useAssetChartDateFormatter";
+import { useScrubbedPrice } from "../../context/ScrubbedPriceContext";
 
 const MIN_X_AXIS_TICKS = 5;
 const MIN_X_AXIS_TICKS_1D = 8;
@@ -64,6 +66,7 @@ export type ChartSectionViewModelResult = Readonly<{
   isError: boolean;
   formatValue: LineChartValueFormatter;
   tooltipTitle: LineChartTooltipTitle;
+  onScrubberPositionChange: LineChartScrubberPositionChange;
   showXAxis: boolean;
   showYAxis: boolean;
   xAxis: LineChartXAxisConfig;
@@ -127,15 +130,13 @@ export function useChartSectionViewModel({
     [fiatUnit, locale],
   );
 
-  const formatDay = useDateFormatter(dayFormat);
-  const formatHour = useDateFormatter(hourFormat);
-  const formatDate = selectedRange === "1d" ? formatHour : formatDay;
+  const formatDate = useAssetChartDateFormatter(selectedRange);
 
   const tooltipTitle = useCallback<LineChartTooltipTitle>(
     dataIndex => {
       const timestamp = timestamps[dataIndex];
       if (timestamp == null) return undefined;
-      return formatDate(new Date(timestamp));
+      return formatDate(timestamp);
     },
     [timestamps, formatDate],
   );
@@ -149,7 +150,7 @@ export function useChartSectionViewModel({
       ),
       tickLabelFormatter: value => {
         const timestamp = timestamps[Number(value)];
-        return timestamp == null ? "" : formatDate(new Date(timestamp));
+        return timestamp == null ? "" : formatDate(timestamp);
       },
     }),
     [timestamps, formatDate, selectedRange],
@@ -168,15 +169,36 @@ export function useChartSectionViewModel({
     [],
   );
 
+  const { setSelection } = useScrubbedPrice();
+
+  const onScrubberPositionChange = useCallback<LineChartScrubberPositionChange>(
+    index => {
+      if (index == null) return setSelection(undefined);
+      const price = series[0]?.data[index];
+      const timestamp = timestamps[index];
+      setSelection(Number.isFinite(price) && timestamp != null ? { price, timestamp } : undefined);
+    },
+    [series, timestamps, setSelection],
+  );
+
+  const handleRangeChange = useCallback(
+    (range: LineChartRange) => {
+      setSelection(undefined);
+      onRangeChange(range);
+    },
+    [onRangeChange, setSelection],
+  );
+
   return {
     series,
     selectedRange,
-    onRangeChange,
+    onRangeChange: handleRangeChange,
     color,
     isLoading,
     isError,
     formatValue,
     tooltipTitle,
+    onScrubberPositionChange,
     showXAxis: true,
     showYAxis: false,
     xAxis,

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/MarketPriceSectionView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/MarketPriceSectionView.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AmountDisplay, Skeleton } from "@ledgerhq/lumen-ui-react";
-import { trendPercentageBody2Styles } from "LLD/shared/trendPercentageStyles";
 import { MarketDataSectionTitleSkeleton } from "../MarketDataSection/components/MarketDataSectionTitleSkeleton";
+import { MarketPriceMetadata } from "./components/MarketPriceMetadata";
 import type { MarketPriceSectionViewModelResult } from "./useMarketPriceSectionViewModel";
 
 type MarketPriceSectionViewProps = Readonly<MarketPriceSectionViewModelResult>;
@@ -18,10 +18,11 @@ export function MarketPriceSectionView(viewModel: MarketPriceSectionViewProps) {
         <>
           <span className="body-2 text-muted">{viewModel.title}</span>
           <div className="flex flex-wrap items-baseline gap-8">
-            {viewModel.hasPriceData && viewModel.priceValue != null ? (
+            {(viewModel.hasPriceData || viewModel.isScrubbing) && viewModel.priceValue != null ? (
               <AmountDisplay
                 value={viewModel.priceValue}
                 formatter={viewModel.priceFormatter}
+                animate={!viewModel.isScrubbing}
                 data-testid="asset-detail-market-price"
               />
             ) : (
@@ -29,29 +30,15 @@ export function MarketPriceSectionView(viewModel: MarketPriceSectionViewProps) {
                 -----
               </span>
             )}
-            {viewModel.hasPriceData ? (
-              <div className="flex flex-row items-center gap-4">
-                <span
-                  data-testid="asset-detail-market-price-percent"
-                  className={trendPercentageBody2Styles({ variant: viewModel.variationVariant })}
-                >
-                  {viewModel.percentageText}
-                </span>
-                <span
-                  className="body-2 tabular-nums text-muted"
-                  data-testid="asset-detail-market-price-fiat-variation"
-                >
-                  {viewModel.variationText}
-                </span>
-                <span className="body-2 text-muted">
-                  <span aria-hidden>&middot;</span> {viewModel.rangeLabel}
-                </span>
-              </div>
-            ) : (
-              <span className="body-2 text-muted">
-                <span aria-hidden>&middot;</span> {viewModel.rangeLabel}
-              </span>
-            )}
+            <MarketPriceMetadata
+              hasPriceData={viewModel.hasPriceData}
+              isScrubbing={viewModel.isScrubbing}
+              percentageText={viewModel.percentageText}
+              variationText={viewModel.variationText}
+              variationVariant={viewModel.variationVariant}
+              scrubbedDateLabel={viewModel.scrubbedDateLabel}
+              rangeLabel={viewModel.rangeLabel}
+            />
           </div>
         </>
       )}

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/__tests__/MarketPriceSectionView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/__tests__/MarketPriceSectionView.test.tsx
@@ -3,6 +3,26 @@ import { render, screen } from "tests/testSetup";
 import { MarketPriceSectionView } from "../MarketPriceSectionView";
 import type { MarketPriceSectionViewModelResult } from "../useMarketPriceSectionViewModel";
 
+jest.mock("@ledgerhq/lumen-ui-react", () => {
+  const actual = jest.requireActual("@ledgerhq/lumen-ui-react");
+  return {
+    ...actual,
+    AmountDisplay: ({
+      value,
+      animate,
+      ["data-testid"]: testId,
+    }: {
+      value: number;
+      animate?: boolean;
+      "data-testid"?: string;
+    }) => (
+      <span data-testid={testId} data-animate={String(animate)}>
+        {value}
+      </span>
+    ),
+  };
+});
+
 const baseViewModel: MarketPriceSectionViewModelResult = {
   title: "Market price",
   rangeLabel: "1 day",
@@ -14,6 +34,7 @@ const baseViewModel: MarketPriceSectionViewModelResult = {
   showSkeleton: false,
   hasPriceData: true,
   hasVariationData: true,
+  isScrubbing: false,
 };
 
 describe("MarketPriceSectionView", () => {
@@ -33,5 +54,33 @@ describe("MarketPriceSectionView", () => {
       screen.queryByTestId("asset-detail-market-price-fiat-variation"),
     ).not.toBeInTheDocument();
     expect(screen.getByText("1 day")).toBeVisible();
+  });
+
+  it("animates the amount and shows the range label when not scrubbing", () => {
+    render(<MarketPriceSectionView {...baseViewModel} />);
+
+    expect(screen.getByTestId("asset-detail-market-price")).toHaveAttribute("data-animate", "true");
+    expect(screen.getByText("1 day")).toBeVisible();
+  });
+
+  it("disables the amount animation, hides the % and variation, and shows the scrubbed date while scrubbing", () => {
+    render(
+      <MarketPriceSectionView
+        {...baseViewModel}
+        priceValue={99.99}
+        isScrubbing
+        scrubbedDateLabel="Jan 1, 2024"
+      />,
+    );
+
+    const amount = screen.getByTestId("asset-detail-market-price");
+    expect(amount).toHaveTextContent("99.99");
+    expect(amount).toHaveAttribute("data-animate", "false");
+    expect(screen.getByText("Jan 1, 2024")).toBeVisible();
+    expect(screen.queryByText("1 day")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("asset-detail-market-price-percent")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("asset-detail-market-price-fiat-variation"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/__tests__/useMarketPriceSectionViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/__tests__/useMarketPriceSectionViewModel.test.ts
@@ -1,8 +1,13 @@
+import React from "react";
 import type { AssetMarketData } from "@ledgerhq/asset-detail";
 import { createMockMarketCurrencyData } from "@ledgerhq/live-common/market/utils/fixtures";
 import { KeysPriceChange } from "@ledgerhq/live-common/market/utils/types";
 import { renderHook } from "tests/testSetup";
 import { useMarketPriceSectionViewModel } from "../useMarketPriceSectionViewModel";
+import {
+  ScrubbedPriceContext,
+  type ScrubSelection,
+} from "../../../context/ScrubbedPriceContext";
 
 const baseMarketCurrencyData = createMockMarketCurrencyData();
 
@@ -17,6 +22,15 @@ const marketData: AssetMarketData = {
     },
   }),
 };
+
+const makeScrubWrapper = (selection: ScrubSelection | undefined) =>
+  function ScrubWrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(
+      ScrubbedPriceContext.Provider,
+      { value: { selection, setSelection: () => {} } },
+      children,
+    );
+  };
 
 describe("useMarketPriceSectionViewModel", () => {
   it("shows day change percentage and fiat variation in discreet mode", () => {
@@ -39,5 +53,61 @@ describe("useMarketPriceSectionViewModel", () => {
     expect(result.current.variationText).toMatch(/^\+/);
     expect(result.current.variationText).not.toBe("—");
     expect(result.current.variationText).not.toBe("***");
+  });
+
+  it("uses the live price and no scrubbed date when not scrubbing", () => {
+    const { result } = renderHook(
+      () =>
+        useMarketPriceSectionViewModel({
+          ledgerId: "bitcoin",
+          marketData,
+          isDistributionLoading: false,
+          selectedRange: "1d",
+        }),
+      { initialState: { settings: { counterValue: "USD", locale: "en-US" } } },
+    );
+
+    expect(result.current.isScrubbing).toBe(false);
+    expect(result.current.priceValue).toBe(100);
+    expect(result.current.scrubbedDateLabel).toBeUndefined();
+  });
+
+  it("prefers the scrubbed price and exposes the formatted scrubbed date while scrubbing", () => {
+    const { result } = renderHook(
+      () =>
+        useMarketPriceSectionViewModel({
+          ledgerId: "bitcoin",
+          marketData,
+          isDistributionLoading: false,
+          selectedRange: "1y",
+        }),
+      {
+        initialState: { settings: { counterValue: "USD", locale: "en-US" } },
+        wrapper: makeScrubWrapper({ price: 250, timestamp: Date.UTC(2024, 0, 2) }),
+      },
+    );
+
+    expect(result.current.isScrubbing).toBe(true);
+    expect(result.current.priceValue).toBe(250);
+    expect(result.current.scrubbedDateLabel).toContain("2024");
+  });
+
+  it("treats a scrubbed price of 0 as scrubbing (not a missing value)", () => {
+    const { result } = renderHook(
+      () =>
+        useMarketPriceSectionViewModel({
+          ledgerId: "bitcoin",
+          marketData,
+          isDistributionLoading: false,
+          selectedRange: "1d",
+        }),
+      {
+        initialState: { settings: { counterValue: "USD", locale: "en-US" } },
+        wrapper: makeScrubWrapper({ price: 0, timestamp: Date.UTC(2024, 0, 2) }),
+      },
+    );
+
+    expect(result.current.isScrubbing).toBe(true);
+    expect(result.current.priceValue).toBe(0);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/components/MarketPriceMetadata.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/components/MarketPriceMetadata.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { trendPercentageBody2Styles } from "LLD/shared/trendPercentageStyles";
+
+type MarketPriceMetadataProps = Readonly<{
+  hasPriceData: boolean;
+  isScrubbing: boolean;
+  percentageText: string;
+  variationText: string;
+  variationVariant: "positive" | "negative" | "neutral";
+  scrubbedDateLabel?: string;
+  rangeLabel: string;
+}>;
+
+type RangeLabelProps = Readonly<{
+  isScrubbing: boolean;
+  label: string;
+}>;
+
+function RangeLabel({ isScrubbing, label }: RangeLabelProps) {
+  return (
+    <span className="body-2 text-muted">
+      {!isScrubbing && <span aria-hidden>&middot; </span>}
+      {label}
+    </span>
+  );
+}
+
+type PriceVariationMetricsProps = Readonly<{
+  percentageText: string;
+  variationText: string;
+  variationVariant: "positive" | "negative" | "neutral";
+}>;
+
+function PriceVariationMetrics({
+  percentageText,
+  variationText,
+  variationVariant,
+}: PriceVariationMetricsProps) {
+  return (
+    <>
+      <span
+        data-testid="asset-detail-market-price-percent"
+        className={trendPercentageBody2Styles({ variant: variationVariant })}
+      >
+        {percentageText}
+      </span>
+      <span
+        className="body-2 tabular-nums text-muted"
+        data-testid="asset-detail-market-price-fiat-variation"
+      >
+        {variationText}
+      </span>
+    </>
+  );
+}
+
+export function MarketPriceMetadata({
+  hasPriceData,
+  isScrubbing,
+  percentageText,
+  variationText,
+  variationVariant,
+  scrubbedDateLabel,
+  rangeLabel,
+}: MarketPriceMetadataProps) {
+  const dateLabel = scrubbedDateLabel ?? rangeLabel;
+
+  if (!hasPriceData) {
+    return <RangeLabel isScrubbing={isScrubbing} label={dateLabel} />;
+  }
+
+  return (
+    <div className="flex flex-row items-center gap-4">
+      {/* While scrubbing, % and fiat variation are hidden; only price and date show. */}
+      {!isScrubbing && (
+        <PriceVariationMetrics
+          percentageText={percentageText}
+          variationText={variationText}
+          variationVariant={variationVariant}
+        />
+      )}
+      <RangeLabel isScrubbing={isScrubbing} label={dateLabel} />
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/useMarketPriceSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/useMarketPriceSectionViewModel.ts
@@ -16,6 +16,8 @@ import {
   resolveTrendPercentAndVariant,
 } from "./utils";
 import { resolveAssetDetailSectionLoading } from "../../utils/resolveAssetDetailSectionLoading";
+import { useAssetChartDateFormatter } from "../../hooks/useAssetChartDateFormatter";
+import { useScrubbedPrice } from "../../context/ScrubbedPriceContext";
 
 type UseMarketPriceSectionViewModelProps = Readonly<{
   distributionItem?: DistributionItem;
@@ -37,6 +39,8 @@ type UseMarketPriceSectionViewModelResult = Readonly<{
   showSkeleton: boolean;
   hasPriceData: boolean;
   hasVariationData: boolean;
+  isScrubbing: boolean;
+  scrubbedDateLabel?: string;
 }>;
 
 const RANGE_I18N_KEY: Record<LineChartRange, string> = {
@@ -103,11 +107,15 @@ export function useMarketPriceSectionViewModel({
     trendVariant,
   });
 
+  const { selection } = useScrubbedPrice();
+  const isScrubbing = selection != null;
+  const formatDate = useAssetChartDateFormatter(selectedRange);
+
   return {
     shouldRenderSection,
     title: t("assetDetails.marketPrice"),
     rangeLabel: t(RANGE_I18N_KEY[selectedRange]),
-    priceValue: hasPriceData ? data?.price : undefined,
+    priceValue: isScrubbing ? selection.price : hasPriceData ? data?.price : undefined,
     priceFormatter,
     variationText,
     percentageText,
@@ -115,6 +123,8 @@ export function useMarketPriceSectionViewModel({
     showSkeleton,
     hasPriceData,
     hasVariationData,
+    isScrubbing,
+    scrubbedDateLabel: isScrubbing ? formatDate(selection.timestamp) : undefined,
   };
 }
 

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/context/ScrubbedPriceContext.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/context/ScrubbedPriceContext.tsx
@@ -1,0 +1,29 @@
+import React, { createContext, useContext, useMemo, useState, type ReactNode } from "react";
+
+/**
+ * A point selected by scrubbing the asset detail chart. Modelled as an object
+ * so it can grow (e.g. percentage, volume) without changing the context API.
+ * Values are raw and never pre-formatted; consumers own their formatting.
+ */
+export type ScrubSelection = Readonly<{
+  price: number;
+  timestamp: number;
+}>;
+
+type ScrubbedPriceContextValue = Readonly<{
+  selection: ScrubSelection | undefined;
+  setSelection: (selection: ScrubSelection | undefined) => void;
+}>;
+
+export const ScrubbedPriceContext = createContext<ScrubbedPriceContextValue>({
+  selection: undefined,
+  setSelection: () => {},
+});
+
+export const useScrubbedPrice = () => useContext(ScrubbedPriceContext);
+
+export function ScrubbedPriceProvider({ children }: Readonly<{ children: ReactNode }>) {
+  const [selection, setSelection] = useState<ScrubSelection | undefined>(undefined);
+  const value = useMemo(() => ({ selection, setSelection }), [selection]);
+  return <ScrubbedPriceContext.Provider value={value}>{children}</ScrubbedPriceContext.Provider>;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/__tests__/useAssetChartDateFormatter.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/__tests__/useAssetChartDateFormatter.test.ts
@@ -1,0 +1,25 @@
+import { renderHook } from "tests/testSetup";
+import { useAssetChartDateFormatter } from "../useAssetChartDateFormatter";
+
+// 2024-01-02T03:04:00Z
+const TIMESTAMP = Date.UTC(2024, 0, 2, 3, 4);
+
+const renderFormatter = (range: Parameters<typeof useAssetChartDateFormatter>[0]) =>
+  renderHook(() => useAssetChartDateFormatter(range), {
+    initialState: { settings: { locale: "en-US" } },
+  });
+
+describe("useAssetChartDateFormatter", () => {
+  it("formats with an hour-level format for the intraday (1d) range", () => {
+    const { result } = renderFormatter("1d");
+    const label = result.current(TIMESTAMP);
+    // Hour format includes a time component (digits + AM/PM in en-US), no year.
+    expect(label).toMatch(/\d/);
+    expect(label).not.toMatch(/2024/);
+  });
+
+  it("formats with a day-level format for non-intraday ranges", () => {
+    const { result } = renderFormatter("1y");
+    expect(result.current(TIMESTAMP)).toContain("2024");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/useAssetChartDateFormatter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/useAssetChartDateFormatter.ts
@@ -1,0 +1,10 @@
+import { useCallback } from "react";
+import type { LineChartRange } from "LLD/components/LineChart";
+import { dayFormat, hourFormat, useDateFormatter } from "~/renderer/hooks/useDateFormatter";
+
+export function useAssetChartDateFormatter(range: LineChartRange) {
+  const formatDay = useDateFormatter(dayFormat);
+  const formatHour = useDateFormatter(hourFormat);
+  const formatDate = range === "1d" ? formatHour : formatDay;
+  return useCallback((ms: number) => formatDate(new Date(ms)), [formatDate]);
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { AssetDetailView } from "./AssetDetailView";
+import { ScrubbedPriceProvider } from "./context/ScrubbedPriceContext";
 import { useAssetDetailViewModel } from "./hooks/useAssetDetailViewModel";
 
 const AssetDetail = () => {
@@ -15,7 +16,11 @@ const AssetDetail = () => {
     );
   }
 
-  return <AssetDetailView viewModel={viewModel} />;
+  return (
+    <ScrubbedPriceProvider>
+      <AssetDetailView viewModel={viewModel} />
+    </ScrubbedPriceProvider>
+  );
 };
 
 export default AssetDetail;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Asset Detail market price section: price and date update while scrubbing the chart, and reset when scrubbing ends or the range changes
  - Percentage and fiat variation are hidden during scrubbing, restored afterwards
  - Line chart scrubber behaviour with the new `onScrubberPositionChange` callback and optional `showTooltip` prop (verify the standalone tooltip still renders where used)
  - Date formatting across ranges (1d uses hour format, others use day format)

### 📝 Description

The Asset Detail market price header showed a static price and percentage variation, disconnected from the line chart. Scrubbing the chart gave no feedback in the price header.

This PR syncs the market price header with chart scrubbing. Hovering/scrubbing the line chart now updates the displayed price and date to the scrubbed point, while hiding the percentage and fiat variation (which are only meaningful for the full range). When scrubbing ends — or the selected range changes — the header resets to its default state.

The shared state flows through a new `ScrubbedPriceContext` that wraps the Asset Detail tree, so the chart section publishes the scrubbed selection and the market price section consumes it without prop drilling. Supporting changes:

- `useAssetChartDateFormatter` hook centralises range-aware date formatting (reused by both the chart and price sections).
- `MarketPriceMetadata` component extracts the variation/date rendering out of the view.
- `LineChartScrubber` gains an `onScrubberPositionChange` callback and an optional `showTooltip` prop so the scrubber can drive external state without forcing a tooltip.

### 🖼️ Screenshots


https://github.com/user-attachments/assets/becc4c3e-c79b-4256-ac3c-a6457fbd1d23



### ❓ Context

- **JIRA or GitHub link**: [LIVE-31634](https://ledgerhq.atlassian.net/browse/LIVE-31634)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31634]: https://ledgerhq.atlassian.net/browse/LIVE-31634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ