### PR TITLE
[LWM] feat(mobile): update asset detail and mood index copy (LIVE-31620)

### DIFF
--- a/.changeset/lwm-copy-update.md
+++ b/.changeset/lwm-copy-update.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Update Asset detail and Mood index copy: refresh market stats labels and add the CoinGecko disclaimer, rename the addresses list to "Accounts", update the PnL detail drawer wording, refresh the Mood index scale labels (Fear+/Fear/Neutral/Greed/Greed+) and add the CoinMarketCap disclaimer, with minor spacing fixes.

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8146,19 +8146,19 @@
         "tooltip": "The average price you paid for this asset through Ledger Wallet, including everything you’ve bought or received from other wallets. This is used to track your profit or loss."
       },
       "drawer": {
-        "title": "Asset profit and loss",
-        "description": "A summary of how this asset has performed in your portfolio.",
+        "title": "Profit and loss",
+        "description": "Your asset performance broken down into estimated unrealised and realised returns.",
         "estimatedReturn": {
-          "title": "Estimated return",
+          "title": "Unrealised return",
           "description": "The estimated profit or loss if sold at current price."
         },
         "realisedReturn": {
           "title": "Realised return",
-          "description": "Profit or loss confirmed from previous sale, send, or swap."
+          "description": "Profit or loss estimated from previous sale, send or swap."
         },
         "totalReturn": {
           "title": "Total return",
-          "description": "The sum of estimated and realised returns."
+          "description": "The sum of estimated unrealised and realised returns."
         }
       }
     },
@@ -9135,10 +9135,10 @@
       }
     },
     "addresses": {
-      "title": "Addresses",
+      "title": "Accounts",
       "addAccount": "Add",
       "seeAll": "See all",
-      "empty": "No addresses yet. Tap Add to get started."
+      "empty": "No accounts yet. Tap Add to get started."
     },
     "marketStats": {
       "title": "Market stats",
@@ -9151,7 +9151,8 @@
       "marketCapTooltip": "The total value of all coins in circulation. Think of it as the crypto's total worth on the market.",
       "tradingVolume": "24h trading volume",
       "tradingVolumeTooltip": "The total amount traded in the last 24 hours.",
-      "error": "Unable to load market stats"
+      "error": "Unable to load market stats",
+      "disclaimer": "Market stats sourced from CoinGecko"
     },
     "pricePerformance": {
       "title": "Price performance",
@@ -9586,7 +9587,8 @@
   },
   "fearAndGreed": {
     "title": "Mood index",
-    "description": "Shows overall market sentiment from 0 to 100, based on trends and activity. Use it to understand how the market is behaving: lower values indicate fear, higher values indicate greed.",
+    "description": "Shows overall market sentiment from 0 to 100, based notably on volatility, market momentum and social trends. Lower values indicate fear, higher values indicate greed.",
+    "disclaimer": "Data is sourced from CoinMarketCap's Fear and Greed Index and provided for informational purposes only.",
     "levels": {
       "fearPlus": "Fear+",
       "fear": "Fear",

--- a/apps/ledger-live-mobile/src/mvvm/components/FearAndGreed/FearAndGreedView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/FearAndGreed/FearAndGreedView.tsx
@@ -39,6 +39,9 @@ export const FearAndGreedView = ({
             <Text typography="body1" lx={{ color: "base" }}>
               {t("fearAndGreed.description")}
             </Text>
+            <Text typography="body4" lx={{ color: "muted", marginTop: "s16" }}>
+              {t("fearAndGreed.disclaimer")}
+            </Text>
           </BottomSheetView>
         </QueuedDrawerBottomSheet>
       </>
@@ -57,6 +60,9 @@ export const FearAndGreedView = ({
           <FearAndGreedTitle />
           <Text typography="body1" lx={{ color: "base" }}>
             {t("fearAndGreed.description")}
+          </Text>
+          <Text typography="body4" lx={{ color: "muted", marginTop: "s20" }}>
+            {t("fearAndGreed.disclaimer")}
           </Text>
         </GorhomBottomSheetView>
       </QueuedDrawerGorhom>

--- a/apps/ledger-live-mobile/src/mvvm/components/FearAndGreed/__integrations__/FearAndGreed.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/FearAndGreed/__integrations__/FearAndGreed.test.tsx
@@ -66,7 +66,13 @@ describe("FearAndGreed Integration", () => {
 
       expect(
         screen.getByText(
-          /Shows overall market sentiment from 0 to 100, based on trends and activity. Use it to understand how the market is behaving: lower values indicate fear, higher values indicate greed./i,
+          /Shows overall market sentiment from 0 to 100, based notably on volatility, market momentum and social trends. Lower values indicate fear, higher values indicate greed./i,
+        ),
+      ).toBeVisible();
+
+      expect(
+        screen.getByText(
+          /Data is sourced from CoinMarketCap's Fear and Greed Index and provided for informational purposes only./i,
         ),
       ).toBeVisible();
     });

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
@@ -164,7 +164,7 @@ describe("AssetDetail screen layout", () => {
 
     await waitFor(() => expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.addresses)).toBeVisible());
     const section = screen.getByTestId(ASSET_DETAIL_TEST_IDS.addresses);
-    expect(within(section).getByText("Addresses")).toBeVisible();
+    expect(within(section).getByText("Accounts")).toBeVisible();
     expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.addAccount)).toBeVisible();
     expect(screen.getByText("Add")).toBeVisible();
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketData/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketData/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { Box } from "@ledgerhq/lumen-ui-rnative";
+import { Box, DescriptionItem, DescriptionItemLabel } from "@ledgerhq/lumen-ui-rnative";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { useTranslation } from "~/context/Locale";
 import type { AssetDetailCurrencyProps } from "LLM/features/AssetDetail/types";
 import { MarketStats } from "../MarketStats";
 import { PricePerformance } from "../PricePerformance";
@@ -13,6 +14,7 @@ type Props = Readonly<{
 }>;
 
 export function MarketData({ currency, marketApiId, knownLedgerIds, knownMarketId }: Props) {
+  const { t } = useTranslation();
   return (
     <Box lx={containerStyle}>
       <MarketStats
@@ -27,10 +29,13 @@ export function MarketData({ currency, marketApiId, knownLedgerIds, knownMarketI
         knownLedgerIds={knownLedgerIds}
         knownMarketId={knownMarketId}
       />
+      <DescriptionItem>
+        <DescriptionItemLabel>{t("assetDetail.marketStats.disclaimer")}</DescriptionItemLabel>
+      </DescriptionItem>
     </Box>
   );
 }
 
 const containerStyle: LumenViewStyle = {
-  gap: "s32",
+  gap: "s16",
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/PricePerformanceView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/PricePerformanceView.tsx
@@ -84,6 +84,7 @@ const containerStyle: LumenViewStyle = {
 
 const listStyle: LumenViewStyle = {
   gap: "s16",
+  marginBottom: "s12",
 };
 
 const leadingColumnStyle: LumenViewStyle = {

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlDetailDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlDetailDrawer/index.tsx
@@ -37,7 +37,7 @@ export function PnlDetailDrawer({
           ))}
         </Box>
         {footer ? (
-          <Text typography="body4" lx={{ color: "muted", marginTop: "s16" }}>
+          <Text typography="body4" lx={{ color: "muted", marginTop: "s20" }}>
             {footer}
           </Text>
         ) : null}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _Copy changes are covered by the updated `FearAndGreed` and `assetDetail` integration tests. The market-stats CoinGecko disclaimer rendering and the spacing tweaks are not covered by dedicated assertions (visual-only)._
- [x] **Impact of the changes:**
  - Asset detail — Market stats section and the new "Market stats sourced from CoinGecko" disclaimer (placement + spacing)
  - Asset detail — accounts list section title is now "Accounts" (was "Addresses") incl. empty state and the "See all" drawer header
  - Asset detail — PnL detail drawer wording: title "Profit and loss", "Unrealised return", and the realised/total return descriptions
  - Mood index — card label across all score ranges (Fear+ / Fear / Neutral / Greed / Greed+), modal description, and the new CoinMarketCap disclaimer
  - Spacing on market data, price performance and the PnL / mood index drawers

### 📝 Description

Copy and wording update for the Ledger Wallet Mobile (LWM) Asset detail screen and the Mood index, following the latest Figma designs.

**Asset detail**
- Added the "Market stats sourced from CoinGecko" disclaimer below the market data sections.
- Renamed the accounts list section from "Addresses" to "Accounts" (title + empty state + drawer header).
- Updated the PnL detail drawer copy: title → "Profit and loss", first item → "Unrealised return", and refreshed the realised/total return descriptions.

**Mood index**
- Updated the scale labels to **Fear+ / Fear / Neutral / Greed / Greed+** (thresholds unchanged: 0–20 / 20–40 / 40–60 / 60–80 / 80–100).
- Updated the modal description and added the "Data is sourced from CoinMarketCap's Fear and Greed Index…" disclaimer.

Plus minor spacing fixes on the market data / price performance / drawer layouts.

> **Note for reviewers/design:** the ticket explicitly asks to use "Accounts" instead of "Addresses" in the list, while the linked Figma still shows "Addresses". I followed the ticket wording — please confirm.

> i18n changes are made in `en/common.json` only (other locales sync via the localization pipeline). Existing translation keys were kept and only their values changed to keep the change scoped to mobile and avoid breaking the shared keys used by desktop.

### 🖼️ Screenshots


<img height="400" alt="Disclaimer AssetDetails" src="https://github.com/user-attachments/assets/31c0e62f-ea99-432b-a99e-2d6ae01b976c" />

<img height="400" alt="image" src="https://github.com/user-attachments/assets/351510a5-eb01-45ae-98c0-271d6c7e57b3" />

<img height="400" alt="image" src="https://github.com/user-attachments/assets/c2dafcbb-07bb-4f80-b5da-191cede41ed0" />

<img height="400" alt="image" src="https://github.com/user-attachments/assets/a2387a6b-a82f-40ba-93a8-7b1939d3567f" />




### ❓ Context

- **JIRA or GitHub link**: [LIVE-31620](https://ledgerhq.atlassian.net/browse/LIVE-31620)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31620]: https://ledgerhq.atlassian.net/browse/LIVE-31620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ