### PR TITLE
[LWM] fix(LIVE-30737): route Swap to the Wallet 4.0 tab from native entry points

### DIFF
--- a/.changeset/swap-w40-tab-routing.md
+++ b/.changeset/swap-w40-tab-routing.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+LIVE-30737: Fix Swap opening on the legacy (pre-Wallet 4.0) navigation stack from several entry points. When the Wallet 4.0 main navigation is enabled, the SwapNavigator is a tab inside the Main navigator (with the top header and bottom tab bar); navigating to the base-level SwapNavigator instead lands on the legacy stack with no header and no tab bar. A shared `navigateToSwapTab` helper now centralises the Wallet 4.0-aware routing, and the No-funds drawer and the staking "not enough balance" swap CTA route through it (previously they always opened the legacy stack).

--- a/apps/ledger-live-mobile/src/components/NoFunds/NoFunds.tsx
+++ b/apps/ledger-live-mobile/src/components/NoFunds/NoFunds.tsx
@@ -18,6 +18,9 @@ import {
   getAccountCurrency,
   isTokenAccount,
 } from "@ledgerhq/ledger-wallet-framework/account/helpers";
+import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
+import { navigateToSwapTab } from "~/screens/Swap/navigation/navigateToSwapTab";
+import { BaseNavigatorStackParamList } from "../RootNavigator/types/BaseNavigator";
 
 const useText = (
   entryPoint: "noFunds" | "getFunds",
@@ -75,6 +78,7 @@ export default function NoFunds({ route }: Readonly<Props>) {
   }, [currency, swapAvailableIds]);
 
   const { page, track } = useAnalytics();
+  const { shouldDisplayWallet40MainNav } = useWalletFeaturesConfig("mobile");
   const onNavigate = useCallback(
     (name: string, options?: object) => {
       (navigation as NativeStackNavigationProp<{ [key: string]: object | undefined }>).navigate(
@@ -112,10 +116,11 @@ export default function NoFunds({ route }: Readonly<Props>) {
       button: "swap",
       page,
     });
-    onNavigate(NavigatorName.Swap, {
-      screen: ScreenName.SwapForm,
+    navigateToSwapTab({
+      navigation: navigation as unknown as NativeStackNavigationProp<BaseNavigatorStackParamList>,
+      shouldDisplayWallet40MainNav,
     });
-  }, [onNavigate, page, track]);
+  }, [navigation, page, shouldDisplayWallet40MainNav, track]);
 
   const onBuy = useCallback(() => {
     track("button_clicked", {

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BorrowLiveAppNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BorrowLiveAppNavigator.tsx
@@ -10,6 +10,7 @@ import { BorrowLiveAppNavigatorParamList } from "./types/BorrowLiveAppNavigator"
 import { BorrowLiveAppWrapper } from "LLM/features/Borrow";
 import type { BorrowSwapNavigationParams } from "@ledgerhq/live-common/wallet-api/Borrow/types";
 import type { DefaultAccountSwapParamList } from "~/screens/Swap/types";
+import { navigateToSwapTab } from "~/screens/Swap/navigation/navigateToSwapTab";
 import type { BaseComposite, BaseNavigation, StackNavigatorProps } from "./types/helpers";
 
 const Stack = createNativeStackNavigator<BorrowLiveAppNavigatorParamList>();
@@ -63,20 +64,7 @@ const Borrow = (props: NavigationProps) => {
         fromPath: ScreenName.Borrow,
       };
 
-      if (shouldDisplayWallet40MainNav) {
-        baseNavigation.navigate(NavigatorName.Main, {
-          screen: NavigatorName.Swap,
-          params: {
-            screen: ScreenName.SwapTab,
-            params,
-          },
-        });
-      } else {
-        baseNavigation.navigate(NavigatorName.Swap, {
-          screen: ScreenName.SwapTab,
-          params,
-        });
-      }
+      navigateToSwapTab({ navigation: baseNavigation, shouldDisplayWallet40MainNav, params });
     },
     [baseNavigation, shouldDisplayWallet40MainNav],
   );

--- a/apps/ledger-live-mobile/src/families/shared/StakingErrors/NotEnoughFundFeesAlert/index.tsx
+++ b/apps/ledger-live-mobile/src/families/shared/StakingErrors/NotEnoughFundFeesAlert/index.tsx
@@ -15,6 +15,8 @@ import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { AccountLike } from "@ledgerhq/types-live";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { EntryOf } from "~/types/helpers";
+import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
+import { navigateToSwapTab } from "~/screens/Swap/navigation/navigateToSwapTab";
 
 type Props = {
   account: AccountLike;
@@ -27,6 +29,7 @@ const NotEnoughFundFeesAlert: React.FC<Props> = ({ account }) => {
   const { t } = useTranslation();
   const { locale } = useSettings();
   const navigation = useNavigation<Navigation>();
+  const { shouldDisplayWallet40MainNav } = useWalletFeaturesConfig("mobile");
   const accounts = useSelector(shallowAccountsSelector);
 
   const unit = useAccountUnit(account);
@@ -66,18 +69,41 @@ const NotEnoughFundFeesAlert: React.FC<Props> = ({ account }) => {
     [currency.name, navigation, routeToButtonLabel],
   );
 
-  const renderLink = useCallback(
-    (route: Route) => (
+  const renderTextLink = useCallback(
+    (onPress: () => void) => (
       <Text
         variant="bodyLineHeight"
         fontWeight="bold"
         style={{ textDecorationLine: "underline" }}
         fontSize={14}
-        onPress={() => onNavigate(route)}
+        onPress={onPress}
       />
     ),
-    [onNavigate],
+    [],
   );
+
+  const renderLink = useCallback(
+    (route: Route) => renderTextLink(() => onNavigate(route)),
+    [onNavigate, renderTextLink],
+  );
+
+  // Swap is reached via the Wallet 4.0-aware helper so it lands on the Main > Swap
+  // tab (with header + tab bar) instead of the legacy base-level Swap stack.
+  const goToSwap = useCallback(() => {
+    track("button_clicked", {
+      button: "swap",
+      asset: currency.name,
+      source: "UndelegateFlowScreen",
+    });
+    navigateToSwapTab({
+      navigation,
+      shouldDisplayWallet40MainNav,
+      params: {
+        currency,
+        accountId: account.id,
+      },
+    });
+  }, [account.id, currency, navigation, shouldDisplayWallet40MainNav, track]);
 
   const ctasSupported = useMemo(() => {
     const ctas = [];
@@ -99,16 +125,7 @@ const NotEnoughFundFeesAlert: React.FC<Props> = ({ account }) => {
     if (canBeSwapped) {
       ctas.push({
         label: t("errors.NotEnoughBalanceForUnstaking.ctas.swap"),
-        component: renderLink([
-          NavigatorName.Swap,
-          {
-            screen: ScreenName.SwapTab,
-            params: {
-              currency,
-              accountId: account.id,
-            },
-          },
-        ]),
+        component: renderTextLink(goToSwap),
       });
     }
     ctas.push({
@@ -126,7 +143,17 @@ const NotEnoughFundFeesAlert: React.FC<Props> = ({ account }) => {
       ]),
     });
     return ctas;
-  }, [account.id, canBeBought, canBeSwapped, currency, parentAccount.id, renderLink, t]);
+  }, [
+    account.id,
+    canBeBought,
+    canBeSwapped,
+    currency,
+    parentAccount.id,
+    renderLink,
+    renderTextLink,
+    goToSwap,
+    t,
+  ]);
 
   const ctasKey =
     ctasSupported.length === 3

--- a/apps/ledger-live-mobile/src/families/shared/StakingErrors/NotEnoughFundFeesAlert/index.tsx
+++ b/apps/ledger-live-mobile/src/families/shared/StakingErrors/NotEnoughFundFeesAlert/index.tsx
@@ -103,7 +103,7 @@ const NotEnoughFundFeesAlert: React.FC<Props> = ({ account }) => {
         accountId: account.id,
       },
     });
-  }, [account.id, currency, navigation, shouldDisplayWallet40MainNav, track]);
+  }, [account.id, currency, navigation, shouldDisplayWallet40MainNav]);
 
   const ctasSupported = useMemo(() => {
     const ctas = [];

--- a/apps/ledger-live-mobile/src/mvvm/features/Swap/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Swap/index.ts
@@ -9,10 +9,10 @@ import { isTokenCurrency } from "@ledgerhq/live-common/currencies/index";
 import { isTokenAccount } from "@ledgerhq/live-common/account/index";
 import { DefaultAccountSwapParamList } from "~/screens/Swap/types";
 import { shallowAccountsSelector, flattenAccountsSelector } from "~/reducers/accounts";
-import { NavigatorName, ScreenName } from "~/const";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { useModularDrawerController } from "../ModularDrawer";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
+import { navigateToSwapTab } from "~/screens/Swap/navigation/navigateToSwapTab";
 
 type UseOpenSwapProps = {
   currency?: CryptoOrTokenCurrency;
@@ -74,20 +74,7 @@ export function useOpenSwap({
           ...(currency && isTokenCurrency(currency) && { toTokenId: currency.id }),
         };
 
-        if (shouldDisplayWallet40MainNav) {
-          navigation.navigate(NavigatorName.Main, {
-            screen: NavigatorName.Swap,
-            params: {
-              screen: ScreenName.SwapTab,
-              params: swapParams,
-            },
-          });
-        } else {
-          navigation.navigate(NavigatorName.Swap, {
-            screen: ScreenName.SwapTab,
-            params: swapParams,
-          });
-        }
+        navigateToSwapTab({ navigation, shouldDisplayWallet40MainNav, params: swapParams });
         return;
       }
 
@@ -105,20 +92,7 @@ export function useOpenSwap({
         defaultParentAccount: parentAcc,
       };
 
-      if (shouldDisplayWallet40MainNav) {
-        navigation.navigate(NavigatorName.Main, {
-          screen: NavigatorName.Swap,
-          params: {
-            screen: ScreenName.SwapTab,
-            params: swapParams,
-          },
-        });
-      } else {
-        navigation.navigate(NavigatorName.Swap, {
-          screen: ScreenName.SwapTab,
-          params: swapParams,
-        });
-      }
+      navigateToSwapTab({ navigation, shouldDisplayWallet40MainNav, params: swapParams });
     },
     [currency, sourceScreenName, shallowAccounts, navigation, shouldDisplayWallet40MainNav],
   );

--- a/apps/ledger-live-mobile/src/screens/Swap/navigation/__tests__/navigateToSwapTab.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/navigation/__tests__/navigateToSwapTab.test.ts
@@ -1,0 +1,53 @@
+import { NavigatorName, ScreenName } from "~/const";
+import { navigateToSwapTab } from "../navigateToSwapTab";
+
+describe("navigateToSwapTab", () => {
+  const createNavigation = () => {
+    const navigate = jest.fn();
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    return { navigation: { navigate } as never, navigate };
+  };
+
+  const params = { toTokenId: "ethereum", fromPath: "Portfolio" };
+
+  it("targets the Main > Swap tab when Wallet 4.0 main navigation is enabled", () => {
+    const { navigation, navigate } = createNavigation();
+
+    navigateToSwapTab({ navigation, shouldDisplayWallet40MainNav: true, params });
+
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith(NavigatorName.Main, {
+      screen: NavigatorName.Swap,
+      params: {
+        screen: ScreenName.SwapTab,
+        params,
+      },
+    });
+  });
+
+  it("targets the base-level Swap navigator when Wallet 4.0 main navigation is disabled", () => {
+    const { navigation, navigate } = createNavigation();
+
+    navigateToSwapTab({ navigation, shouldDisplayWallet40MainNav: false, params });
+
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith(NavigatorName.Swap, {
+      screen: ScreenName.SwapTab,
+      params,
+    });
+  });
+
+  it("defaults to empty params when none are provided (opens Swap with no preselection)", () => {
+    const { navigation, navigate } = createNavigation();
+
+    navigateToSwapTab({ navigation, shouldDisplayWallet40MainNav: true });
+
+    expect(navigate).toHaveBeenCalledWith(NavigatorName.Main, {
+      screen: NavigatorName.Swap,
+      params: {
+        screen: ScreenName.SwapTab,
+        params: {},
+      },
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/Swap/navigation/navigateToSwapTab.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/navigation/navigateToSwapTab.ts
@@ -1,0 +1,51 @@
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { NavigatorName, ScreenName } from "~/const";
+import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import { SwapNavigatorParamList } from "~/components/RootNavigator/types/SwapNavigator";
+
+type SwapTabParams = SwapNavigatorParamList[ScreenName.SwapTab];
+
+/** Minimal navigation surface needed to open the Swap tab. */
+type SwapTabNavigation = Pick<NativeStackNavigationProp<BaseNavigatorStackParamList>, "navigate">;
+
+/**
+ * Opens the Swap Live App on the correct navigation stack.
+ *
+ * The SwapNavigator is registered twice: once at the base stack level (legacy,
+ * pre-4.0) and once as a tab inside the Main tab navigator (Wallet 4.0). Only the
+ * Main tab provides the Wallet 4.0 top navigation header and the bottom tab bar, so
+ * when `shouldDisplayWallet40MainNav` is ON we must target `Main > Swap > SwapTab`.
+ * Navigating to the base-level Swap navigator there lands on the legacy stack with no
+ * header and no tab bar.
+ *
+ * Centralising the branch here keeps every Swap entry point (deeplinks, no-funds
+ * drawers, staking error CTAs, …) consistent and prevents the chrome from going
+ * missing again.
+ */
+export function navigateToSwapTab({
+  navigation,
+  shouldDisplayWallet40MainNav,
+  // `{}` is a valid (all-optional) DefaultAccountSwapParamList and keeps `params`
+  // defined, which the typed `navigate` requires for the SwapTab screen.
+  params = {},
+}: {
+  navigation: SwapTabNavigation;
+  shouldDisplayWallet40MainNav: boolean;
+  params?: SwapTabParams;
+}): void {
+  if (shouldDisplayWallet40MainNav) {
+    navigation.navigate(NavigatorName.Main, {
+      screen: NavigatorName.Swap,
+      params: {
+        screen: ScreenName.SwapTab,
+        params,
+      },
+    });
+    return;
+  }
+
+  navigation.navigate(NavigatorName.Swap, {
+    screen: ScreenName.SwapTab,
+    params,
+  });
+}


### PR DESCRIPTION
## Context

[LIVE-30737](https://ledgerhq.atlassian.net/browse/LIVE-30737) — *[EARN][LWM] Redirect from EARN opens swap without header/bottom nav bar*.

On Ledger Wallet Mobile, the `SwapNavigator` is registered **twice**:
- at the **base stack level** (legacy, pre‑Wallet 4.0), with `headerShown: false` and sitting *above* the tab navigator → **no top header, no bottom tab bar**;
- as a **tab inside the `Main` navigator** (Wallet 4.0), which provides the `Wallet40SwapTabHeader` and the bottom tab bar.

Several entry points navigated straight to the base‑level `NavigatorName.Swap`, so in Wallet 4.0 they opened Swap on the legacy stack with no chrome.

## Changes

- Add a shared `navigateToSwapTab` helper (`screens/Swap/navigation/navigateToSwapTab.ts`) that centralises the Wallet 4.0‑aware routing (`Main → Swap → SwapTab` vs base‑level `Swap`), so the chrome never goes missing again.
- Route the **No‑funds drawer** (`NoFunds`) and the **staking "not enough balance" Swap CTA** (`StakingErrors/NotEnoughFundFeesAlert`) through the helper — both previously always opened the legacy stack.
- Refactor `useOpenSwap` and the **Borrow** flow to reuse the helper instead of duplicating the branch (no behaviour change).
- Unit test for the helper.

## Investigation note (please read before reviewing)

The original Earn → Swap **deeplink** (`ledgerlive://swap?toToken=…&toAccountId=…`) was verified to already route correctly to the Wallet 4.0 Swap tab **with params** on `develop` (covered by `75be1060197 "fix(mobile): deeplink to swap on lwm40"`, March 2026). The ticket was reproduced against a **deployed LLM build that predates that fix**, so the deeplink symptom should already be resolved once that build catches up to `develop`.

This PR fixes the **remaining** Wallet 4.0 Swap entry points that are still broken on `develop` (native No‑funds / staking CTAs). The Earn‑side RECEIVE‑prefill symptom (the app sends `toToken=<currencyId>` for every asset, incl. native coins) is tracked separately on the Earn live‑app side.

## Testing

- `navigateToSwapTab` unit test (W40 on/off + default params).
- ⚠️ Jest/tsc were not run in the `tracks` worktree (no installed deps); please rely on CI.

[LIVE-30737]: https://ledgerhq.atlassian.net/browse/LIVE-30737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
