### PR TITLE
[LWDM] chore: upgrade rsbuild/rspack stack to v2

### DIFF
--- a/.changeset/rsbuild-rspack-v2-upgrade.md
+++ b/.changeset/rsbuild-rspack-v2-upgrade.md
@@ -1,0 +1,9 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+"@ledgerhq/web-tools": patch
+---
+
+chore: upgrade the Rsbuild/Rspack build stack to v2
+
+Bump `@rsbuild/core` to 2.x, `@rspack/core`/`@rspack/cli`/`@rspack/dev-server`/`@rspack/plugin-react-refresh` to 2.x, `@rslib/core` to 0.22, `@rsdoctor/rspack-plugin` to 2.0.0-alpha.0, related plugins, and `storybook-react-rsbuild` to 3.3.4 (with the Storybook 10.x catalog bumped to 10.4). `@swc/helpers` is aligned to 0.5.23 so the `_wrap_reg_exp` runtime helper emitted by `@swc/core` resolves under Rspack v2's stricter `exports` enforcement (mobile bundle). Desktop rspack config updated for the v2 `ReactRefreshRspackPlugin` named export and a `@sentry/types` v6 resolution alias required by Rspack v2's stricter ESM linking. Rsdoctor loader analysis is disabled on mobile (its loader interceptor is not yet Rspack-v2 compatible); bundle analysis is unaffected.

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -267,7 +267,7 @@
     "react-test-renderer": "catalog:",
     "serve-handler": "6.1.5",
     "storybook": "catalog:",
-    "storybook-react-rsbuild": "3.2.2",
+    "storybook-react-rsbuild": "catalog:",
     "tailwindcss": "catalog:",
     "ts-node": "10.9.2",
     "typescript": "catalog:",

--- a/apps/ledger-live-desktop/tools/rspack/rspack.common.ts
+++ b/apps/ledger-live-desktop/tools/rspack/rspack.common.ts
@@ -1,9 +1,49 @@
 import path from "path";
+import fs from "fs";
 import type { RspackOptions } from "@rspack/core";
 
 export const rootFolder = path.resolve(__dirname, "..", "..");
 export const srcFolder = path.resolve(rootFolder, "src");
 export const outputFolder = path.resolve(rootFolder, ".webpack");
+
+/**
+ * @sentry/utils@6.19.7 (pulled transitively by @ledgerhq/device-transport-kit-web-hid)
+ * imports the `Severity` enum from @sentry/types, which only exists in v6. pnpm nests
+ * @sentry/types@6.19.7 next to it, but Rspack v2's resolver picks the hoisted v8
+ * (type-only) build, breaking with "module has no exports". Force the bare specifier to
+ * v6's CJS build (no `exports` field, and CJS dynamic interop avoids the strict-ESM
+ * check). Runtime-safe for v8 consumers since @sentry/types carries no runtime API there.
+ */
+function resolveSentryTypesV6Alias(): Record<string, string> {
+  const pnpmDir = path.resolve(rootFolder, "..", "..", "node_modules", ".pnpm");
+  const semver = (d: string) =>
+    d.slice("@sentry+types@".length).split("_")[0].split(".").map(Number);
+  const matches = fs.existsSync(pnpmDir)
+    ? fs
+        .readdirSync(pnpmDir)
+        .filter(d => d.startsWith("@sentry+types@6."))
+        .sort((a, b) => {
+          const va = semver(a);
+          const vb = semver(b);
+          for (let i = 0; i < Math.max(va.length, vb.length); i++) {
+            const diff = (vb[i] ?? 0) - (va[i] ?? 0);
+            if (diff !== 0) return diff;
+          }
+          return 0;
+        })
+    : [];
+  if (matches.length === 0) {
+    throw new Error(
+      "rspack.common: expected @sentry/types@6.x in node_modules/.pnpm for the v6 alias " +
+        "(see comment above). If @sentry/utils@6 was dropped from the tree, remove " +
+        "resolveSentryTypesV6Alias; otherwise the renderer build fails with a cryptic " +
+        '"module has no exports" error.',
+    );
+  }
+  return {
+    "@sentry/types$": path.join(pnpmDir, matches[0], "node_modules/@sentry/types/dist/index.js"),
+  };
+}
 
 /**
  * Common rspack configuration shared across all build targets
@@ -20,6 +60,7 @@ export const commonConfig: RspackOptions = {
     extensions: [".web.tsx", ".web.ts", ".tsx", ".ts", ".jsx", ".js", ".json", ".lottie"],
     alias: {
       "~": srcFolder,
+      ...resolveSentryTypesV6Alias(),
     },
   },
   module: {

--- a/apps/ledger-live-desktop/tools/rspack/rspack.renderer.ts
+++ b/apps/ledger-live-desktop/tools/rspack/rspack.renderer.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import { rspack, type RspackOptions } from "@rspack/core";
-import ReactRefreshPlugin from "@rspack/plugin-react-refresh";
+import { ReactRefreshRspackPlugin } from "@rspack/plugin-react-refresh";
 import { commonConfig, rootFolder } from "./rspack.common";
 import {
   buildRendererEnv,
@@ -296,7 +296,7 @@ export function createRendererConfig(
         scriptLoading: "defer",
       }),
       // React Fast Refresh for development
-      ...(useDevServer ? [new ReactRefreshPlugin()] : []),
+      ...(useDevServer ? [new ReactRefreshRspackPlugin()] : []),
     ],
     optimization: {
       minimize: !isDev,

--- a/apps/ledger-live-mobile/rspack.config.mjs
+++ b/apps/ledger-live-mobile/rspack.config.mjs
@@ -93,9 +93,15 @@ function getRsdoctorPlugin() {
   const { RsdoctorRspackPlugin } = require("@rsdoctor/rspack-plugin");
   const isCI = process.env.CI === "true" || process.env.CI === "1";
   const reportDir = path.join(projectRootDir, "rsdoctor", "mobile");
+  // Rsdoctor's loader interceptor crashes on Rspack v2's native resolver
+  // ("Given napi value is not an array on NapiResolveOptions.fallback") because of the
+  // resolve.fallback object below. Disable loader analysis until a fixed Rsdoctor
+  // ships; bundle analysis (the PR report) is unaffected.
+  const features = { loader: false };
   const options = isCI
     ? {
         disableClientServer: true,
+        features,
         linter: RSDOCTOR_LINTER,
         output: {
           mode: "brief",
@@ -104,6 +110,7 @@ function getRsdoctorPlugin() {
         },
       }
     : {
+        features,
         linter: RSDOCTOR_LINTER,
         output: {
           mode: "brief",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,35 +154,35 @@ catalogs:
       specifier: 2.11.2
       version: 2.11.2
     '@rsbuild/core':
-      specifier: 1.7.2
-      version: 1.7.2
+      specifier: 2.0.9
+      version: 2.0.9
     '@rsbuild/plugin-node-polyfill':
-      specifier: 1.4.3
-      version: 1.4.3
+      specifier: 1.4.5
+      version: 1.4.5
     '@rsbuild/plugin-react':
-      specifier: 1.4.3
-      version: 1.4.3
+      specifier: 2.0.1
+      version: 2.0.1
     '@rsbuild/plugin-styled-components':
-      specifier: 1.6.1
-      version: 1.6.1
+      specifier: 1.6.2
+      version: 1.6.2
     '@rsdoctor/rspack-plugin':
-      specifier: 1.5.2
-      version: 1.5.2
+      specifier: 2.0.0-alpha.0
+      version: 2.0.0-alpha.0
     '@rslib/core':
-      specifier: 0.19.3
-      version: 0.19.3
+      specifier: 0.22.0
+      version: 0.22.0
     '@rspack/cli':
-      specifier: 1.7.3
-      version: 1.7.3
+      specifier: 2.0.5
+      version: 2.0.5
     '@rspack/core':
-      specifier: 1.7.3
-      version: 1.7.3
+      specifier: 2.0.5
+      version: 2.0.5
     '@rspack/dev-server':
-      specifier: 1.1.5
-      version: 1.1.5
+      specifier: 2.0.3
+      version: 2.0.3
     '@rspack/plugin-react-refresh':
-      specifier: 1.6.0
-      version: 1.6.0
+      specifier: 2.0.1
+      version: 2.0.1
     '@solana/spl-token':
       specifier: ^0.4.14
       version: 0.4.14
@@ -190,23 +190,23 @@ catalogs:
       specifier: ^1.98.4
       version: 1.98.4
     '@storybook/addon-docs':
-      specifier: 10.2.0
-      version: 10.2.0
+      specifier: 10.4.1
+      version: 10.4.1
     '@storybook/addon-links':
-      specifier: 10.2.0
-      version: 10.2.0
+      specifier: 10.4.1
+      version: 10.4.1
     '@storybook/addon-ondevice-actions':
-      specifier: 10.1.11
-      version: 10.1.11
+      specifier: 10.4.4
+      version: 10.4.4
     '@storybook/addon-ondevice-backgrounds':
-      specifier: 10.1.11
-      version: 10.1.11
+      specifier: 10.4.4
+      version: 10.4.4
     '@storybook/addon-ondevice-controls':
-      specifier: 10.1.11
-      version: 10.1.11
+      specifier: 10.4.4
+      version: 10.4.4
     '@storybook/addon-ondevice-notes':
-      specifier: 10.1.11
-      version: 10.1.11
+      specifier: 10.4.4
+      version: 10.4.4
     '@storybook/addon-react-native-web':
       specifier: 0.0.29
       version: 0.0.29
@@ -217,11 +217,11 @@ catalogs:
       specifier: 0.2.3
       version: 0.2.3
     '@storybook/react':
-      specifier: 10.2.0
-      version: 10.2.0
+      specifier: 10.4.1
+      version: 10.4.1
     '@storybook/react-native':
-      specifier: 10.1.11
-      version: 10.1.11
+      specifier: 10.4.4
+      version: 10.4.4
     '@storybook/test':
       specifier: 8.6.15
       version: 8.6.15
@@ -232,8 +232,8 @@ catalogs:
       specifier: 1.15.11
       version: 1.15.11
     '@swc/helpers':
-      specifier: 0.5.17
-      version: 0.5.17
+      specifier: 0.5.23
+      version: 0.5.23
     '@swc/jest':
       specifier: 0.2.39
       version: 0.2.39
@@ -442,11 +442,11 @@ catalogs:
       specifier: 7.7.3
       version: 7.7.3
     storybook:
-      specifier: 10.2.0
-      version: 10.2.0
+      specifier: 10.4.1
+      version: 10.4.1
     storybook-react-rsbuild:
-      specifier: 3.2.2
-      version: 3.2.2
+      specifier: 3.3.4
+      version: 3.3.4
     styled-components:
       specifier: 6.1.19
       version: 6.1.19
@@ -855,7 +855,7 @@ importers:
         version: 1000.0.6
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.19.3(typescript@6.0.2)
+        version: 0.22.0(typescript@6.0.2)
       '@types/asciichart':
         specifier: 1.5.8
         version: 1.5.8
@@ -1332,28 +1332,28 @@ importers:
         version: 1.60.0
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 1.7.2
+        version: 2.0.9
       '@rsbuild/plugin-node-polyfill':
         specifier: 'catalog:'
-        version: 1.4.3(@rsbuild/core@1.7.2)
+        version: 1.4.5(@rsbuild/core@2.0.9)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 1.4.3(@rsbuild/core@1.7.2)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)
       '@rsdoctor/rspack-plugin':
         specifier: 'catalog:'
-        version: 1.5.2(@rsbuild/core@1.7.2)(@rspack/core@1.7.3)
+        version: 2.0.0-alpha.0(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)
       '@rspack/cli':
         specifier: 'catalog:'
-        version: 1.7.3(@rspack/core@1.7.3)
+        version: 2.0.5(@rspack/core@2.0.5)(@rspack/dev-server@2.0.3(@rspack/core@2.0.5))
       '@rspack/core':
         specifier: 'catalog:'
-        version: 1.7.3
+        version: 2.0.5
       '@rspack/dev-server':
         specifier: 'catalog:'
-        version: 1.1.5(@rspack/core@1.7.3)
+        version: 2.0.3(@rspack/core@2.0.5)
       '@rspack/plugin-react-refresh':
         specifier: 'catalog:'
-        version: 1.6.0(react-refresh@0.18.0)
+        version: 2.0.1(@rspack/core@2.0.5)(react-refresh@0.18.0)
       '@sentry/cli':
         specifier: 2.31.0
         version: 2.31.0
@@ -1365,10 +1365,10 @@ importers:
         version: 5.0.0
       '@storybook/react':
         specifier: 'catalog:'
-        version: 10.2.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
+        version: 10.4.1(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
       '@storybook/test':
         specifier: 'catalog:'
-        version: 8.6.15(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+        version: 8.6.15(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -1527,7 +1527,7 @@ importers:
         version: 8.5.6
       postcss-loader:
         specifier: 8.2.0
-        version: 8.2.0(@rspack/core@1.7.3)(postcss@8.5.6)(typescript@6.0.2)
+        version: 8.2.0(@rspack/core@2.0.5)(postcss@8.5.6)(typescript@6.0.2)
       prebuild-install:
         specifier: 7.1.3
         version: 7.1.3
@@ -1542,10 +1542,10 @@ importers:
         version: 6.1.5
       storybook:
         specifier: 'catalog:'
-        version: 10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       storybook-react-rsbuild:
-        specifier: 3.2.2
-        version: 3.2.2(@rsbuild/core@1.7.2)(@rspack/core@1.7.3)(msw@2.7.3(@types/node@24.12.0)(typescript@6.0.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
+        specifier: 'catalog:'
+        version: 3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(msw@2.7.3(@types/node@24.12.0)(typescript@6.0.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.1.18
@@ -2108,13 +2108,13 @@ importers:
         version: 7.28.4
       '@callstack/repack':
         specifier: 5.2.5
-        version: 5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@1.7.3(@swc/helpers@0.5.17))(@swc/core@1.15.11(@swc/helpers@0.5.17))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))
+        version: 5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.0.5(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))
       '@callstack/repack-plugin-expo-modules':
         specifier: 5.2.5
-        version: 5.2.5(@callstack/repack@5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@1.7.3(@swc/helpers@0.5.17))(@swc/core@1.15.11(@swc/helpers@0.5.17))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)))
+        version: 5.2.5(@callstack/repack@5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.0.5(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)))
       '@callstack/repack-plugin-reanimated':
         specifier: 5.2.5
-        version: 5.2.5(@babel/core@7.28.5)(@callstack/repack@5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@1.7.3(@swc/helpers@0.5.17))(@swc/core@1.15.11(@swc/helpers@0.5.17))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)))
+        version: 5.2.5(@babel/core@7.28.5)(@callstack/repack@5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.0.5(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)))
       '@features/flow-market-banner':
         specifier: workspace:^
         version: link:../../features/flow/market-banner
@@ -2171,25 +2171,25 @@ importers:
         version: 1.2.0(@types/react@19.0.14)(react-native-get-random-values@1.11.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react-redux@9.2.0(@types/react@19.0.14)(react@19.0.0)(redux@5.0.1))(react@19.0.0)(redux@5.0.1)
       '@rozenite/repack':
         specifier: 1.2.0
-        version: 1.2.0(@callstack/repack@5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@1.7.3(@swc/helpers@0.5.17))(@swc/core@1.15.11(@swc/helpers@0.5.17))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)))
+        version: 1.2.0(@callstack/repack@5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.0.5(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)))
       '@rsdoctor/rspack-plugin':
         specifier: 'catalog:'
-        version: 1.5.2(@rspack/core@1.7.3(@swc/helpers@0.5.17))
+        version: 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
       '@rspack/core':
         specifier: 'catalog:'
-        version: 1.7.3(@swc/helpers@0.5.17)
+        version: 2.0.5(@swc/helpers@0.5.23)
       '@swc/core':
         specifier: 'catalog:'
-        version: 1.15.11(@swc/helpers@0.5.17)
+        version: 1.15.11(@swc/helpers@0.5.23)
       '@swc/helpers':
         specifier: 'catalog:'
-        version: 0.5.17
+        version: 0.5.23
       '@swc/jest':
         specifier: 'catalog:'
-        version: 0.2.39(@swc/core@1.15.11(@swc/helpers@0.5.17))
+        version: 0.2.39(@swc/core@1.15.11(@swc/helpers@0.5.23))
       '@testing-library/react-native':
         specifier: 13.3.3
-        version: 13.3.3(patch_hash=4f93e75372e62b6dc0f0b2635b62a322b37a3727637bd94a38df1ed8648e2e76)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2)))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react-test-renderer@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 13.3.3(patch_hash=4f93e75372e62b6dc0f0b2635b62a322b37a3727637bd94a38df1ed8648e2e76)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2)))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react-test-renderer@19.0.0(react@19.0.0))(react@19.0.0)
       '@types/color':
         specifier: 3.0.6
         version: 3.0.6
@@ -2252,10 +2252,10 @@ importers:
         version: 0.4.4
       detox:
         specifier: 'catalog:'
-        version: 20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2)))
+        version: 20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2)))
       detox-allure2-adapter:
         specifier: 1.0.0-alpha.42
-        version: 1.0.0-alpha.42(patch_hash=c0c5e6419e53a25ed902cac4ce3608f467d0332b34c90b669fed2089e2bf97ba)(detox@20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2))))(jest-allure2-reporter@2.2.8(@jest/reporters@30.2.0)(jest-docblock@30.2.0)(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2))))
+        version: 1.0.0-alpha.42(patch_hash=c0c5e6419e53a25ed902cac4ce3608f467d0332b34c90b669fed2089e2bf97ba)(detox@20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2))))(jest-allure2-reporter@2.2.8(@jest/reporters@30.2.0)(jest-docblock@30.2.0)(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2))))
       eslint:
         specifier: 8.57.0
         version: 8.57.0
@@ -2270,10 +2270,10 @@ importers:
         version: 0.32.1
       jest:
         specifier: 'catalog:'
-        version: 30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2))
+        version: 30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2))
       jest-allure2-reporter:
         specifier: 2.2.8
-        version: 2.2.8(@jest/reporters@30.2.0)(jest-docblock@30.2.0)(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2)))
+        version: 2.2.8(@jest/reporters@30.2.0)(jest-docblock@30.2.0)(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2)))
       jest-circus:
         specifier: 'catalog:'
         version: 30.2.0
@@ -2285,7 +2285,7 @@ importers:
         version: 30.2.0
       jest-metadata:
         specifier: 1.6.0
-        version: 1.6.0(@jest/reporters@30.2.0)(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2)))
+        version: 1.6.0(@jest/reporters@30.2.0)(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2)))
       jest-quiet-reporter:
         specifier: 1.0.1
         version: 1.0.1
@@ -2330,7 +2330,7 @@ importers:
         version: 6.0.1
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2)
+        version: 10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2)
       tslib:
         specifier: 2.6.2
         version: 2.6.2
@@ -2700,19 +2700,19 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 1.7.2
+        version: 2.0.9
       '@rsbuild/plugin-node-polyfill':
         specifier: 'catalog:'
-        version: 1.4.3(@rsbuild/core@1.7.2)
+        version: 1.4.5(@rsbuild/core@2.0.9)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 1.4.3(@rsbuild/core@1.7.2)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)
       '@rsbuild/plugin-styled-components':
         specifier: 'catalog:'
-        version: 1.6.1(@rsbuild/core@1.7.2)
+        version: 1.6.2(@rsbuild/core@2.0.9)
       '@rspack/core':
         specifier: 'catalog:'
-        version: 1.7.3
+        version: 2.0.5
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -3760,7 +3760,7 @@ importers:
         version: link:../ledgerjs/packages/types-live
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.19.3(typescript@6.0.2)
+        version: 0.22.0(typescript@6.0.2)
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -7409,10 +7409,10 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 'catalog:'
-        version: 1.7.3(@rspack/core@1.7.3)
+        version: 2.0.5(@rspack/core@2.0.5)
       '@rspack/core':
         specifier: 'catalog:'
-        version: 1.7.3
+        version: 2.0.5
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -11915,7 +11915,7 @@ importers:
     devDependencies:
       '@rspack/core':
         specifier: 'catalog:'
-        version: 1.7.3
+        version: 2.0.5
       '@svgr/core':
         specifier: ^5.5.0
         version: 5.5.0(@svgr/plugin-svgo@5.5.0)
@@ -12051,25 +12051,25 @@ importers:
         version: 0.79.7(@babel/core@7.28.5)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 1.7.2
+        version: 2.0.9
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 1.4.3(@rsbuild/core@1.7.2)
+        version: 2.0.1(@rsbuild/core@2.0.9)
       '@storybook/addon-links':
         specifier: 'catalog:'
-        version: 10.2.0(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+        version: 10.4.1(@types/react@19.0.14)(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@storybook/addon-ondevice-actions':
         specifier: 'catalog:'
-        version: 10.1.11(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+        version: 10.4.4(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@storybook/addon-ondevice-backgrounds':
         specifier: 'catalog:'
-        version: 10.1.11(@emotion/native@11.11.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+        version: 10.4.4(@emotion/native@11.11.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@storybook/addon-ondevice-controls':
         specifier: 'catalog:'
-        version: 10.1.11(@react-native-community/datetimepicker@6.7.5)(@react-native-community/slider@4.5.7)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
+        version: 10.4.4(@react-native-community/datetimepicker@6.7.5)(@react-native-community/slider@4.5.7)(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
       '@storybook/addon-ondevice-notes':
         specifier: 'catalog:'
-        version: 10.1.11(@storybook/react@10.2.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+        version: 10.4.4(@storybook/react@10.4.1(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@storybook/addon-react-native-web':
         specifier: 'catalog:'
         version: 0.0.29(@react-native/babel-preset@0.79.7(@babel/core@7.28.5))(babel-plugin-react-native-web@0.19.10)(metro-react-native-babel-preset@0.77.0(@babel/core@7.28.5))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -12078,13 +12078,13 @@ importers:
         version: 0.2.3
       '@storybook/react':
         specifier: 'catalog:'
-        version: 10.2.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
+        version: 10.4.1(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
       '@storybook/react-native':
         specifier: 'catalog:'
-        version: 10.1.11(4e06fedd534340d0c70a53aab4171e9a)
+        version: 10.4.4(4456eb5993e2623de263be6daf0d0865)
       '@storybook/test':
         specifier: 'catalog:'
-        version: 8.6.15(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+        version: 8.6.15(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@storybook/testing-library':
         specifier: 'catalog:'
         version: 0.2.2
@@ -12261,10 +12261,10 @@ importers:
         version: 4.4.1
       storybook:
         specifier: 'catalog:'
-        version: 10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       storybook-react-rsbuild:
         specifier: 'catalog:'
-        version: 3.2.2(@rsbuild/core@1.7.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
+        version: 3.3.4(@rsbuild/core@2.0.9)(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
       styled-components:
         specifier: 'catalog:'
         version: 6.1.19(patch_hash=810073718ccefe69fd016893be54d80d86cc6e5ee521455028b93c7cbf3103d7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -12376,28 +12376,28 @@ importers:
         version: 1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 1.7.2
+        version: 2.0.9
       '@rsbuild/plugin-node-polyfill':
         specifier: 'catalog:'
-        version: 1.4.3(@rsbuild/core@1.7.2)
+        version: 1.4.5(@rsbuild/core@2.0.9)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 1.4.3(@rsbuild/core@1.7.2)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)
       '@rspack/core':
         specifier: 'catalog:'
-        version: 1.7.3
+        version: 2.0.5
       '@storybook/addon-docs':
         specifier: 'catalog:'
-        version: 10.2.0(@types/react@19.0.14)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+        version: 10.4.1(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@storybook/addon-links':
         specifier: 'catalog:'
-        version: 10.2.0(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+        version: 10.4.1(@types/react@19.0.14)(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@storybook/react':
         specifier: 'catalog:'
-        version: 10.2.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
+        version: 10.4.1(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
       '@storybook/test':
         specifier: 'catalog:'
-        version: 8.6.15(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+        version: 8.6.15(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@svgr/core':
         specifier: ^5.5.0
         version: 5.5.0(@svgr/plugin-svgo@5.5.0)
@@ -12493,10 +12493,10 @@ importers:
         version: 4.4.1
       storybook:
         specifier: 'catalog:'
-        version: 10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       storybook-react-rsbuild:
         specifier: 'catalog:'
-        version: 3.2.2(@rsbuild/core@1.7.2)(@rspack/core@1.7.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
+        version: 3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
       styled-components:
         specifier: ^5.3.3
         version: 5.3.11(@babel/core@7.28.5)(react-dom@19.0.0(react@19.0.0))(react-is@17.0.2)(react@19.0.0)
@@ -12529,7 +12529,7 @@ importers:
     devDependencies:
       '@rspack/core':
         specifier: 'catalog:'
-        version: 1.7.3
+        version: 2.0.5
       tiny-glob:
         specifier: ^0.2.9
         version: 0.2.9
@@ -12687,10 +12687,10 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 'catalog:'
-        version: 1.7.3(@rspack/core@1.7.3)
+        version: 2.0.5(@rspack/core@2.0.5)
       '@rspack/core':
         specifier: 'catalog:'
-        version: 1.7.3
+        version: 2.0.5
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.0
@@ -12748,10 +12748,10 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 'catalog:'
-        version: 1.7.3(@rspack/core@1.7.3)
+        version: 2.0.5(@rspack/core@2.0.5)
       '@rspack/core':
         specifier: 'catalog:'
-        version: 1.7.3
+        version: 2.0.5
       '@types/jest':
         specifier: 'catalog:'
         version: 30.0.0
@@ -12803,7 +12803,7 @@ importers:
         version: 6.0.0
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.19.3(typescript@6.0.2)
+        version: 0.22.0(typescript@6.0.2)
       '@types/stream-json':
         specifier: 1.7.7
         version: 1.7.7
@@ -12830,7 +12830,7 @@ importers:
         version: 6.0.0
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.19.3(typescript@6.0.2)
+        version: 0.22.0(typescript@6.0.2)
 
   tools/actions/desktop-report-build:
     devDependencies:
@@ -12842,7 +12842,7 @@ importers:
         version: 6.0.0
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.19.3(typescript@6.0.2)
+        version: 0.22.0(typescript@6.0.2)
       node-fetch:
         specifier: 3.3.2
         version: 3.3.2
@@ -12857,7 +12857,7 @@ importers:
         version: 6.0.0
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.19.3(typescript@6.0.2)
+        version: 0.22.0(typescript@6.0.2)
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.0
@@ -12887,7 +12887,7 @@ importers:
         version: 6.0.0
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.19.3(typescript@6.0.2)
+        version: 0.22.0(typescript@6.0.2)
       semver:
         specifier: 'catalog:'
         version: 7.7.3
@@ -12902,7 +12902,7 @@ importers:
         version: 6.0.0
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.19.3(typescript@6.0.2)
+        version: 0.22.0(typescript@6.0.2)
       semver:
         specifier: 'catalog:'
         version: 7.7.3
@@ -12917,7 +12917,7 @@ importers:
         version: 6.0.0
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.19.3(typescript@6.0.2)
+        version: 0.22.0(typescript@6.0.2)
 
   tools/actions/mobile-performance-test:
     dependencies:
@@ -12942,7 +12942,7 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.19.3(typescript@6.0.2)
+        version: 0.22.0(typescript@6.0.2)
       '@types/adm-zip':
         specifier: 0.5.7
         version: 0.5.7
@@ -12960,7 +12960,7 @@ importers:
         version: 6.0.0
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.19.3(typescript@6.0.2)
+        version: 0.22.0(typescript@6.0.2)
 
   tools/actions/submit-bot-report:
     devDependencies:
@@ -12972,7 +12972,7 @@ importers:
         version: 6.0.0
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.19.3(typescript@6.0.2)
+        version: 0.22.0(typescript@6.0.2)
       node-fetch:
         specifier: 3.3.2
         version: 3.3.2
@@ -12990,7 +12990,7 @@ importers:
         version: 3.540.0
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.19.3(typescript@6.0.2)
+        version: 0.22.0(typescript@6.0.2)
 
   tools/create-release-hash: {}
 
@@ -15398,14 +15398,29 @@ packages:
     resolution: {integrity: sha512-fKpv9kg4SPmt+hY7SVBnIYULE9QJl8L3sCfcBsnqbJwwBwAeTLokJ9TRt9y7bK0JAzIW2y78TVVjvnQEms/yyA==}
     engines: {node: '>=16.4'}
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
   '@emnapi/core@1.7.1':
     resolution: {integrity: sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==}
+
+  '@emnapi/core@1.9.2':
+    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@emnapi/runtime@1.7.1':
     resolution: {integrity: sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==}
 
+  '@emnapi/runtime@1.9.2':
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@emotion/babel-plugin@11.13.5':
     resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
@@ -17055,8 +17070,20 @@ packages:
     peerDependencies:
       tslib: 2.6.2
 
+  '@jsonjoy.com/base64@17.67.0':
+    resolution: {integrity: sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: 2.6.2
+
   '@jsonjoy.com/buffers@1.2.1':
     resolution: {integrity: sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: 2.6.2
+
+  '@jsonjoy.com/buffers@17.67.0':
+    resolution: {integrity: sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: 2.6.2
@@ -17067,8 +17094,68 @@ packages:
     peerDependencies:
       tslib: 2.6.2
 
+  '@jsonjoy.com/codegen@17.67.0':
+    resolution: {integrity: sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: 2.6.2
+
+  '@jsonjoy.com/fs-core@4.57.3':
+    resolution: {integrity: sha512-IvO50vkGydDZwS1e9rz/JXEtCCt9XvqxoGI6FlrVIvVm4/HpygMKW4ETtREWtMTsN5CLJ9FR6GuCduoQPZLBiw==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: 2.6.2
+
+  '@jsonjoy.com/fs-fsa@4.57.3':
+    resolution: {integrity: sha512-JlIDGUWPl7Y6zl+/ISnZuh8z2aMr/xoR66D18zlaVAuL192CvlNJEzOlzp27x4P52HRtDnCSOk6f59vTsmp5vw==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: 2.6.2
+
+  '@jsonjoy.com/fs-node-builtins@4.57.3':
+    resolution: {integrity: sha512-JAI3PqNuY8BR7ovy4h0bADLrqJLIcUauONNZfyTxUnj3Wf3tpTYe39eJ6z7FzYyA+tdMt33VpiQQUikGr3QOBw==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: 2.6.2
+
+  '@jsonjoy.com/fs-node-to-fsa@4.57.3':
+    resolution: {integrity: sha512-uZGxyC0zDmcmW5bfHd4YivAZ54BLlbF9G0K5rBaksI/tZdJSGM7/AC+1TY7yvFu0Wc6gUHR7mFwf6SbQ3J1BTQ==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: 2.6.2
+
+  '@jsonjoy.com/fs-node-utils@4.57.3':
+    resolution: {integrity: sha512-quCil8AvfcOxob4pn0drGdcQWpkPVgkt9q1+EjeyXXT40/L3l5lvYrr6hR8LmHu0eg+DNNaUwqjLT6Hr7V4sdQ==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: 2.6.2
+
+  '@jsonjoy.com/fs-node@4.57.3':
+    resolution: {integrity: sha512-089gZoKvbeOsT2jeBaVKSz91oFXQWFG7a62sMY6gVMHnoWbyGzTb6OVUP/V7G3wLQLJ555BEsHt8SD1nj1dgaQ==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: 2.6.2
+
+  '@jsonjoy.com/fs-print@4.57.3':
+    resolution: {integrity: sha512-ITwaLZpGIqD9jHndwMvDFZDIvbVzGRsJZDQ5HKln0vyMculu1c1nb7zbEBgY8BVSBZ9S2xO138OWIBGeRsrF3Q==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: 2.6.2
+
+  '@jsonjoy.com/fs-snapshot@4.57.3':
+    resolution: {integrity: sha512-wdNaG2DxCtvj9lKldAnEV3ycYPEpk+p2cP2lHD1qdxkoQGlWUtQverqvG9KZSkm6BHFha4PP6XRZbpARNfHRxA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: 2.6.2
+
   '@jsonjoy.com/json-pack@1.21.0':
     resolution: {integrity: sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: 2.6.2
+
+  '@jsonjoy.com/json-pack@17.67.0':
+    resolution: {integrity: sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: 2.6.2
@@ -17079,8 +17166,20 @@ packages:
     peerDependencies:
       tslib: 2.6.2
 
+  '@jsonjoy.com/json-pointer@17.67.0':
+    resolution: {integrity: sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: 2.6.2
+
   '@jsonjoy.com/util@1.9.0':
     resolution: {integrity: sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: 2.6.2
+
+  '@jsonjoy.com/util@17.67.0':
+    resolution: {integrity: sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: 2.6.2
@@ -17430,24 +17529,6 @@ packages:
       '@types/react': '>=16'
       react: 19.0.0
 
-  '@module-federation/error-codes@0.22.0':
-    resolution: {integrity: sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==}
-
-  '@module-federation/runtime-core@0.22.0':
-    resolution: {integrity: sha512-GR1TcD6/s7zqItfhC87zAp30PqzvceoeDGYTgF3Vx2TXvsfDrhP6Qw9T4vudDQL3uJRne6t7CzdT29YyVxlgIA==}
-
-  '@module-federation/runtime-tools@0.22.0':
-    resolution: {integrity: sha512-4ScUJ/aUfEernb+4PbLdhM/c60VHl698Gn1gY21m9vyC1Ucn69fPCA1y2EwcCB7IItseRMoNhdcWQnzt/OPCNA==}
-
-  '@module-federation/runtime@0.22.0':
-    resolution: {integrity: sha512-38g5iPju2tPC3KHMPxRKmy4k4onNp6ypFPS1eKGsNLUkXgHsPMBFqAjDw96iEcjri91BrahG4XcdyKi97xZzlA==}
-
-  '@module-federation/sdk@0.22.0':
-    resolution: {integrity: sha512-x4aFNBKn2KVQRuNVC5A7SnrSCSqyfIWmm1DvubjbO9iKFe7ith5niw8dqSFBekYBg2Fwy+eMg4sEFNVvCAdo6g==}
-
-  '@module-federation/webpack-bundler-runtime@0.22.0':
-    resolution: {integrity: sha512-aM8gCqXu+/4wBmJtVeMeeMN5guw3chf+2i6HajKtQv7SJfxV/f4IyNQJUeUQu9HfiAZHjqtMV5Lvq/Lvh8LdyA==}
-
   '@msgpack/msgpack@3.1.3':
     resolution: {integrity: sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==}
     engines: {node: '>= 18'}
@@ -17505,8 +17586,11 @@ packages:
   '@napi-rs/wasm-runtime@0.2.4':
     resolution: {integrity: sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==}
 
-  '@napi-rs/wasm-runtime@1.0.7':
-    resolution: {integrity: sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==}
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
 
   '@near-js/accounts@1.0.2':
     resolution: {integrity: sha512-KpyY9r+f55vJ0XCk17vyHeiiNbsmKY9T3ztXKLWQEr661XWJKyetQUBb3dyehf6DHXXnlxwwQNdYDK8d0x1nOQ==}
@@ -17630,6 +17714,9 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@nozbe/microfuzz@1.0.0':
+    resolution: {integrity: sha512-XKIg/guk+s1tkPTkHch9hfGOWgsKojT7BqSQddXTppOfVr3SWQhhTCqbgQaPTbppf9gc2kFeG0gpBZZ612UXHA==}
 
   '@npmcli/fs@1.1.1':
     resolution: {integrity: sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==}
@@ -18036,6 +18123,239 @@ packages:
       react: 19.0.0
       react-devtools-core: ^7.0.1
       ws: ^8.18.0
+
+  '@oxc-parser/binding-android-arm-eabi@0.127.0':
+    resolution: {integrity: sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.127.0':
+    resolution: {integrity: sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-darwin-arm64@0.127.0':
+    resolution: {integrity: sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.127.0':
+    resolution: {integrity: sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.127.0':
+    resolution: {integrity: sha512-SDQ/3MQFw58fqQz3Z1PhSKFF3JoCF4gmlNjziDm8X02tTahCw0qJbd7FGPDKw1i4VTBZene9JPyC3mHtSvi+wA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.127.0':
+    resolution: {integrity: sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.127.0':
+    resolution: {integrity: sha512-Cs2fdJ8cPpFdeebj6p4dag8A4+56hPvZ0AhQQzlaLswGz1tz7bXt1nETLeorrM9+AMcWFFkqxcXwDGfTVidY8g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.127.0':
+    resolution: {integrity: sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.127.0':
+    resolution: {integrity: sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
+    resolution: {integrity: sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
+    resolution: {integrity: sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
+    resolution: {integrity: sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
+    resolution: {integrity: sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.127.0':
+    resolution: {integrity: sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-musl@0.127.0':
+    resolution: {integrity: sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-openharmony-arm64@0.127.0':
+    resolution: {integrity: sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-wasm32-wasi@0.127.0':
+    resolution: {integrity: sha512-T6KVD7rhLzFlwGRXMnxUFfkCZD8FHnb968wVXW1mXzgRFc5RNXOBY2mPPDZ77x5Ln76ltLMgtPg0cOkU1NSrEQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.127.0':
+    resolution: {integrity: sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.127.0':
+    resolution: {integrity: sha512-0cwxKO7KHQQQfo4Uf4B2SQrhgm+cJaP9OvFFhx52Tkg4bezsacu83GB2/In5bC415Ueeym+kXdnge/57rbSfTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.127.0':
+    resolution: {integrity: sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
+  '@oxc-resolver/binding-android-arm-eabi@11.20.0':
+    resolution: {integrity: sha512-IjfWOXRgJFNdORDl+Uf1aibNgZY2guOD3zmOhx1BGVb/MIiqlFTdmjpQNplSN58lhWehnX4UNqC3QwpUo8pjJg==}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-resolver/binding-android-arm64@11.20.0':
+    resolution: {integrity: sha512-QqslZAuFQG8Q9xm7JuIn8JUbvywhSBMVhuQHtYW+auirZJloS41oxUUaBXk7uUhZJgp44c5zQLeVvmFaDQB+2Q==}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-resolver/binding-darwin-arm64@11.20.0':
+    resolution: {integrity: sha512-MUcavykj2ewlR+kc5arpg4tC2RvzJkUxWtNv74pf7lcNk00GpIpN43vXMj+j6r4eMmfZhlb8hueKoIb8e9kAGQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-darwin-x64@11.20.0':
+    resolution: {integrity: sha512-BGB16nRUK5Etiv//ihPyzj8Lj1px0mhh4YIfe0FDf045ywknfSm0GEbiRESpr6Q4K82AvnyaRIhhluHByvS4bg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-freebsd-x64@11.20.0':
+    resolution: {integrity: sha512-JZgtePaqj3qmD5XFHJaSLWzHRxQu0LaPkdoM1KJXYADvAaa83ijXHclV3ej3CueeW0wxfIAbGCZVP45J0CA7uQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.20.0':
+    resolution: {integrity: sha512-hOQ/p3ry3v3SchUBXicrrnszaI/UmYzM4wtS4RGfwgVUX7a+HbyQSzJ5aOzu+o6XZkFkS3ZXN4PZAzhOb77OSg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.20.0':
+    resolution: {integrity: sha512-2ArPksaw0AqeuGBfoS715VF+JvJQAhD2niWgjE5hVO+L+nAfikVQopvngCMX9x4BD8itWoQ3dnikrQyl5Ho5Jg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.20.0':
+    resolution: {integrity: sha512-0bJnmYFp62JdZ4nVMDUZ/C58BCZOCcqgKtnUlp7L9Ojf/czIN+3j72YlLPeWLkzlr6SlYvIQA4SGV/HyO0d+qg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.20.0':
+    resolution: {integrity: sha512-wKHHzPKZo7Ufhv/Bt6yxT7FOgnIgW4gwXcJUipkShGp68W3wGVqvr1Sr0fY65lN0Oy6y41+g2kIDvkgZaMMUkw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.20.0':
+    resolution: {integrity: sha512-RN8goF7Ie0B79L4i4G6OeBocTgSC56vJbQ65VJje+oXnldVpLnOU7j/AQ/dP94TcCS+Yh6WG8u3Qt4ETteXFNQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.20.0':
+    resolution: {integrity: sha512-5l1yU6/xQEqLZRzxqmMxJfWPslpwCmBsdDGaBvABPehxquCXDC7dd7oraNdKSJUMDXSM7VvVj8H2D2FTjU7oWw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.20.0':
+    resolution: {integrity: sha512-xHEvkbgz6UC+A3JOyDQy76LkUaxsNSfIr3/GV8slwZsnuooJiIB34gzJfsyvR4JdCYNUUPsRJc/w/oWkODu+hg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.20.0':
+    resolution: {integrity: sha512-aWPDUUmSeyHvlW+SoEUd+JIJsQhVhu6a5tBpDRMu058naPAchTgAVGCFy35zjbnFlt0i8hLWziff6HX0D3LU4g==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.20.0':
+    resolution: {integrity: sha512-x2YeSimvhJjKLVD8KSu8f/rqU1potcdEMkApIPJqjZWN7c2Fpt4g2X32WDg1p+XDAmyT7nuQGe0vnhvXeLbH+g==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-x64-musl@11.20.0':
+    resolution: {integrity: sha512-kcRLEIxpZefeYfLChjpgFf3ilBzRDZ+yobMrpRsQlSrxuFGtm3U6PMU7AaEpMqo3NfDGVyJJseAjnRLzMFHjwQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-openharmony-arm64@11.20.0':
+    resolution: {integrity: sha512-HHcfnApSZGtKhTiHqe8OZruOZe5XuFQH5/E0Yhj3u8fnFvzkM4/k6WjacUf4SvA0SPEAbfbgYmVPuo0VX/fIBQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-resolver/binding-wasm32-wasi@11.20.0':
+    resolution: {integrity: sha512-Tn0y1XOFYHNfK1wp1Z5QK8Rcld/bsOwRISQXfqAZ5IBpv8Gz1IvV39fUWNprqNdRizgcvFhOzWwFun2zkJsyBg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.20.0':
+    resolution: {integrity: sha512-qPi25YNPe4YenS8MgsQU2+bIFHxxpLx1LVna2444cEHqNPhNjvWf9zqj4aWE43H9LpAsTmkkAlA3eL5ElBU3mA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.20.0':
+    resolution: {integrity: sha512-Wb14jWEW8huH6It9F6sXd9vrYmIS7pMrgkU6sxpLxkP+9z+wRgs71hUEhRpcn8FOXAFa27FVWfY2tRpbfTzfLw==}
+    cpu: [x64]
+    os: [win32]
 
   '@oxfmt/binding-android-arm-eabi@0.36.0':
     resolution: {integrity: sha512-Z4yVHJWx/swHHjtr0dXrBZb6LxS+qNz1qdza222mWwPTUK4L790+5i3LTgjx3KYGBzcYpjaiZBw4vOx94dH7MQ==}
@@ -19540,10 +19860,15 @@ packages:
   '@rozenite/tools@1.2.0':
     resolution: {integrity: sha512-I5E4az+EWq2xRf9aKDg02bubm+2l6fvbQG63DmIOykjQtQ50uFR9t65UMv0/nvdwDlK2aSIyXCr8aJF/O6GA6g==}
 
-  '@rsbuild/core@1.7.2':
-    resolution: {integrity: sha512-VAFO6cM+cyg2ntxNW6g3tB2Jc5J5mpLjLluvm7VtW2uceNzyUlVv41o66Yp1t1ikxd3ljtqegViXem62JqzveA==}
-    engines: {node: '>=18.12.0'}
+  '@rsbuild/core@2.0.9':
+    resolution: {integrity: sha512-lK2bMNuwh3TuLXLskS7nG3fnQk+6eaLeeZiquJWcna4JZx9iaI59JSd+iLcg5TeZLjEVygkwn/HcE+yuYDQRAw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
 
   '@rsbuild/plugin-check-syntax@1.6.1':
     resolution: {integrity: sha512-26xtEYN0QjZYoyt0lWnvIztBWjEZJvcfw7MN4f5B4SpNggmnF7F7aNPrgkY3EccXVFx1VGQBhnCkBV//OoS07Q==}
@@ -19553,158 +19878,178 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rsbuild/plugin-node-polyfill@1.4.3':
-    resolution: {integrity: sha512-VzJCgv5UxI0JZDC/UhAQ6Bzu3JaY7LPw18S6yrJFtvfF3Qn3SCLJILspeV1VolbfvfdfomhmdQkcFgliczLcSw==}
+  '@rsbuild/plugin-node-polyfill@1.4.5':
+    resolution: {integrity: sha512-mUyOIVhYu+IPjPY5SoUa4r3SrP/am/LBEUnb5C2RAVdL0QFbi7bAMM5YuRMOBtkU0s+I86hVZIkgCGi3LzX6zw==}
     peerDependencies:
       '@rsbuild/core': ^1.0.0 || ^2.0.0-0
     peerDependenciesMeta:
       '@rsbuild/core':
         optional: true
 
-  '@rsbuild/plugin-react@1.4.3':
-    resolution: {integrity: sha512-Uf9FkKk2TqYDbsypXHgjdivPmEoYFvBTHJT5fPmjCf0Sc3lR2BHtlc0WMdZTCKUJ5jTxREygMs9LbnehX98L8g==}
+  '@rsbuild/plugin-react@2.0.1':
+    resolution: {integrity: sha512-n5m3VxEm6m3Dv1VkI0WnxsildySJ6M+QjGIzkZDy5UebRCIJ1Q/hlQVyhofBL6C+AcsF9fGjlHQkeiteXJSr3Q==}
     peerDependencies:
-      '@rsbuild/core': ^1.0.0 || ^2.0.0-0
+      '@rsbuild/core': ^2.0.0-0
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
 
-  '@rsbuild/plugin-styled-components@1.6.1':
-    resolution: {integrity: sha512-k9VHybrtA9ohzCymSO4EwXwYI7HkQEvr7SnjuwetJwhiyqThsSGnw3kWPL5df3v+htXL2Z3fkxZTS7hzBfY1/g==}
+  '@rsbuild/plugin-styled-components@1.6.2':
+    resolution: {integrity: sha512-JCpv+bUJ+g0MgIu1zOlYsMcPqqQgJFhaLjGq3aX+8ih7UVksD+0OUTUyZIqSI6XiNYJI71UVuC2UiMacV1RdQQ==}
     peerDependencies:
       '@rsbuild/core': ^1.7.0 || ^2.0.0-0
     peerDependenciesMeta:
       '@rsbuild/core':
         optional: true
 
-  '@rsbuild/plugin-type-check@1.3.3':
-    resolution: {integrity: sha512-V+WfrfofOy3zaCZ/CqR6TZDF/jTHqlL9DlwivlsmBjzT3A2zr86e9bzmzprrUwrqZNTAXQBpXiXJP1lJAFJ8Gw==}
+  '@rsbuild/plugin-type-check@1.3.5':
+    resolution: {integrity: sha512-dZaCIBI52qxxgMM7m/LY+gCTEpq2HOQnuGzkNmBfR2rXs+KWwfMuHEnLp+Ro9XEsY8B2w2WTqZgq6t29fUrH/Q==}
     peerDependencies:
       '@rsbuild/core': ^1.0.0 || ^2.0.0-0
     peerDependenciesMeta:
       '@rsbuild/core':
         optional: true
 
-  '@rsdoctor/client@1.5.2':
-    resolution: {integrity: sha512-fufNlCiA4+MDj3ZW8ssEdRI9mwawdqSSYvqOOK01+NNIg3TuQNgEdnF/QVGnkxKLgVXJCtUdOKaZtUq1bwnJVQ==}
+  '@rsdoctor/client@2.0.0-alpha.0':
+    resolution: {integrity: sha512-afWQfLPXcsxyN+/0T/ommhnGxdrUhpNGM3b2LLUNRdD+i6X+fHPdfNI2NBgyniLI3pcxFSyqeDuoBUDCkQQ55A==}
 
-  '@rsdoctor/core@1.5.2':
-    resolution: {integrity: sha512-pAtehxWiOhEef7+nxmeX7EDdABh9maAtmD+G/0MNC5zc/aKqzh2KD/CCrEO9SqSoVnfkTot1BQ54kLgBMFvclw==}
+  '@rsdoctor/core@2.0.0-alpha.0':
+    resolution: {integrity: sha512-p/7/86EBISJ7J/Sgu7sSKQAFV/YSOKFjQlQQjr8B5NUM1qBMZN7RCvHbLLyRX8Lf+4t7Kvxfv85o0dVvQl63Sg==}
 
-  '@rsdoctor/graph@1.5.2':
-    resolution: {integrity: sha512-4Wt/Hg4Z3uSJBJQh1pm9cFeYI8lHhSFdWbR39dPOiIC/Q1/86TVdo63GBYMLYyXWRZ58S5kDL5ZjO9IyDLVgug==}
+  '@rsdoctor/graph@2.0.0-alpha.0':
+    resolution: {integrity: sha512-ALLhzffqQvLof1dsaqH5xjvOHluq6+iwHdhJbkWfq1EwFtLS1tH50IYIexABhaxAiYcuKo+y7Tsl8/Z5gs0cig==}
 
-  '@rsdoctor/rspack-plugin@1.5.2':
-    resolution: {integrity: sha512-l097etdtvz4osG5rDJX0RBbIqLAZ+oSUXOJu11Y9aFg+4/lohrZZa4lj1R/7hxlqC0XuROir2zsbRaAuCGtxzw==}
+  '@rsdoctor/rspack-plugin@2.0.0-alpha.0':
+    resolution: {integrity: sha512-yls+jp5l3C7dEkhTVz7zMBZmzFwe03haXrOUXwzMFQ3QhF6QXFFaRgYslPq2M9A44zocHMcfMpfN6E62fY14Mw==}
     peerDependencies:
       '@rspack/core': '*'
     peerDependenciesMeta:
       '@rspack/core':
         optional: true
 
-  '@rsdoctor/sdk@1.5.2':
-    resolution: {integrity: sha512-VPJoSO1gPIlMDLumzGgphhIyNM8s7NPgbN/AAFwbU/uWzEwC2Gy2joLwoYkOw32UDdMD/MiuXrQoP+fnjAYjjQ==}
+  '@rsdoctor/sdk@2.0.0-alpha.0':
+    resolution: {integrity: sha512-+bTlnJvd9aPEXars7+faN37Mho7JpxtJJM3DBSHSfTpiNuDD5L05TBUx4b4aFALq8NJOkhaeQqdL+MM9s6YbrQ==}
 
-  '@rsdoctor/types@1.5.2':
-    resolution: {integrity: sha512-sOj7H/Dc9F3LPM/04dgJSpBhAb7DNlqcm9uipW6+ZCB/pr4dcwUDo8lHcjaEgQWeUfvHSUHjtzarp9EVpfkFsg==}
+  '@rsdoctor/types@2.0.0-alpha.0':
+    resolution: {integrity: sha512-4Bokg5PFlCUzJu0iO78pi1K02PwJ1L7N7QYeGyjTxLuXEn7xVdx7oisuxfYLpIue0nb3+luFLweh6VcJ8f4xKA==}
     peerDependencies:
       '@rspack/core': '*'
-      webpack: 5.x
     peerDependenciesMeta:
       '@rspack/core':
         optional: true
-      webpack:
-        optional: true
 
-  '@rsdoctor/utils@1.5.2':
-    resolution: {integrity: sha512-Zdvpp4GdJKgQYXLuILM124YU0peMDebr95k2s5zTTuB2LBkHENf8UdjJs7ijKyoaVYKqxXTBdghekXEFcdo6jQ==}
+  '@rsdoctor/utils@2.0.0-alpha.0':
+    resolution: {integrity: sha512-RPwNhwZthQNx/5W+wRCuTPHMyZaCCXgiD4tgKfoArbSaixuhIO5CnUlMJSB8F0SX69QEVLy5Bpa+Rx6bRUSnRw==}
 
-  '@rslib/core@0.19.3':
-    resolution: {integrity: sha512-uk20PPGL9ENTMoxLouEfHuf6pDhLIyewjLvVD2XyggSI+nkuXyafj2hQyd2r/cwkQ8+Gkbm4LXMcw0nFKvH09Q==}
-    engines: {node: '>=18.12.0'}
+  '@rslib/core@0.22.0':
+    resolution: {integrity: sha512-DGTMBDTSdILac0SmeBWvdYf/ZDn09vXgbJQ3/N1J7i6vBpFGWCCKjARoz1R5jYqr1Z9tLJ1OfOVZktbNY/XXuA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@microsoft/api-extractor': ^7
-      typescript: ^5
+      typescript: ^5 || ^6
     peerDependenciesMeta:
       '@microsoft/api-extractor':
         optional: true
       typescript:
         optional: true
 
-  '@rspack/binding-darwin-arm64@1.7.3':
-    resolution: {integrity: sha512-sXha3xG2KDkXLVjrmnw5kGhBriH2gFd9KAyD2ZBq0sH/gNIvqEaWhAFoO1YtrKU6rCgiSBrs0frfGc6DEqWfTA==}
+  '@rspack/binding-darwin-arm64@2.0.5':
+    resolution: {integrity: sha512-++wjLQjQ20GcR0DwbzQmVXg9qy4XCX5NlfSzkzj2icHoDxr3KkrXhyVrQkdWuNG6l/bQrGLPnvLEAqkroC2Y7A==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@1.7.3':
-    resolution: {integrity: sha512-AUWMBgaPo7NgpW7arlw9laj9ZQxg7EjC5pnSCRH4BVPV+8egdoPCn5DZk05M25m73crKnGl8c7CrwTRNZeaPrw==}
+  '@rspack/binding-darwin-x64@2.0.5':
+    resolution: {integrity: sha512-JBD5mCN3JKjV64Mh9nDYx8lLUrWDfEl5tLBuMkREUnqEKbo+z4nfwotyqHHM8/XgZwL+Gr7ps4GLWuQQrZB8+Q==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@1.7.3':
-    resolution: {integrity: sha512-SodEX3+1/GLz0LobX9cY1QdjJ1NftSEh4C2vGpr71iA3MS9HyXuw4giqSeRQ4DpCybqpdS/3RLjVqFQEfGpcnw==}
+  '@rspack/binding-linux-arm64-gnu@2.0.5':
+    resolution: {integrity: sha512-JI8+//woanJPNsfL7iGjX39zyiWumnrKHznWQM/7lEtE5nPmk+j+X7TYXxczSWC9zfZegiqI74D3L5JPDC84Fw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-arm64-musl@1.7.3':
-    resolution: {integrity: sha512-ydD2fNdEy+G7EYJ/a3FfdFZPfrLj/UnZocCNlZTTSHEhu+jURdQk0hwV11CvL+sjnKU5e/8IVMGUzhu3Gu8Ghg==}
+  '@rspack/binding-linux-arm64-musl@2.0.5':
+    resolution: {integrity: sha512-5LujilxLtJFRiiPz5i5iWcWJriK9oy4gN7gZtTo8YRB7wwmwA8LMypTjjO0GLbkPS4/KeCfY4fDfTC29KmK+tA==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-x64-gnu@1.7.3':
-    resolution: {integrity: sha512-adnDbUqafSAI6/N6vZ+iONSo1W3yUpnNtJqP3rVp7+YdABhUpbOhtaY37qpIJ3uFajXctYFyISPrb4MWl1M9Yg==}
+  '@rspack/binding-linux-x64-gnu@2.0.5':
+    resolution: {integrity: sha512-241wqE132jh+/U/pn97qUPV4KpIy4bSrTH0tqfzQCocgw+8hrUj02GqNG+3MXVC3qtwaQeJFYgEBy3TqFKsrIQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-x64-musl@1.7.3':
-    resolution: {integrity: sha512-5jnjdODk5HCUFPN6rTaFukynDU4Fn9eCL+4TSp6mqo6YAnfnJEuzDjfetA8t3aQFcAs7WriQfNwvdcA4HvYtbA==}
+  '@rspack/binding-linux-x64-musl@2.0.5':
+    resolution: {integrity: sha512-BhaXZD064Lci3Kia0kLDAb4TyxO2C+0UidMlj44e8+ctasxIfFZgnrhCJrhTFHAtOiAwqhU3FHun2UuxPqX0Eg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-wasm32-wasi@1.7.3':
-    resolution: {integrity: sha512-WLQK0ksUzMkVeGoHAMIxenmeEU5tMvFDK36Aip7VRj7T6vZTcAwvbMwc38QrIAvlG7dqWoxgPQi35ba1igNNDw==}
+  '@rspack/binding-wasm32-wasi@2.0.5':
+    resolution: {integrity: sha512-duEkRoXrl9SW8uGHv7JURJ5lgKu87qFDQ4Exy6UQPvsUJVXhtRXTfvMHCb/CejVJuW2Bw2D632/axZq3qRSuBQ==}
     cpu: [wasm32]
 
-  '@rspack/binding-win32-arm64-msvc@1.7.3':
-    resolution: {integrity: sha512-RAetPeY45g2NW6fID46VTV7mwY4Lqyw/flLbvCG28yrVOSkekw1KMCr1k335O3VNeqD+5dZDi1n+mwiAx/KMmA==}
+  '@rspack/binding-win32-arm64-msvc@2.0.5':
+    resolution: {integrity: sha512-q2WT3HFoWL+2g84l3s2kY7CiE1gEZ1bwB3txx3eZzQQ6YKP7bE82z6sl6S/pTOHGjHdAO4snQXpSaHwUt3LX5g==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@1.7.3':
-    resolution: {integrity: sha512-X3c1B609DxzW++FdWf7kkoXWwsC/DUEJ1N1qots4T0P2G2V+pDQfjdTRSC0YQ75toAvwZqpwGzToQJ9IwQ4Ayw==}
+  '@rspack/binding-win32-ia32-msvc@2.0.5':
+    resolution: {integrity: sha512-nMJGIY7kvgbyMolEE7tXDe+Z9jSItDshTIqMQQkkD3WTHdjlBQozHxk4kBtKLsunO+3NkCLe5Oa3hXg1yyStIg==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@1.7.3':
-    resolution: {integrity: sha512-f6AvZbJGIg+7NggHXv0+lyMzvIUfeCxcB5DNbo3H5AalIgwkoFpcBXLBqgMVIbqA0yNyP06eiK98rpzc9ulQQg==}
+  '@rspack/binding-win32-x64-msvc@2.0.5':
+    resolution: {integrity: sha512-vP0BR6fxdPL9cb02HAuZATg/CjR07aecWel3s1vqRwW1aDffgXh9PVmqEKIHTgyaNsNR55kSKNJsB9AcQ8/QrA==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@1.7.3':
-    resolution: {integrity: sha512-N943pbPktJPymiYZWZMZMVX/PeSU42cWGpBly82N+ibNCX/Oo4yKWE0v+TyIJm5JaUFhtF2NpvzRbrjg/6skqw==}
+  '@rspack/binding@2.0.5':
+    resolution: {integrity: sha512-Ta1y4WXJA87wM1OstqaMddoPsBGv7Cu779bYToKxEAqR/Yy9DxLkp7bdgBaAx2JH++BwVjV+toWts2V9AaiTFQ==}
 
-  '@rspack/cli@1.7.3':
-    resolution: {integrity: sha512-6fb+cd1RjCK3ByN8oq7dIXZWFkbI7+y7VGlIvt/Nl2roGnL3IzXhEbyQzmXv9X+/fZ/pEKHWEyH05Rnqs3+VUQ==}
+  '@rspack/cli@2.0.5':
+    resolution: {integrity: sha512-AAyuY/8sfegb0IcsFEhn5gLOTxy1uDmwjP49RY81PENz2pCk/7NU0zDdt0ke5wmpOH5s6IxS+Kw4aWdvl8FGpQ==}
     hasBin: true
     peerDependencies:
-      '@rspack/core': ^1.0.0-alpha || ^1.x
-
-  '@rspack/core@1.7.3':
-    resolution: {integrity: sha512-GUiTRTz6+gbfM2g3ixXqrvPSeHmyAFu/qHEZZjbYFeDtZhpy1gVaVAHiZfaaIIm+vRlNi7JmULWFZQFKwpQB9Q==}
-    engines: {node: '>=18.12.0'}
-    peerDependencies:
-      '@swc/helpers': '>=0.5.1'
+      '@rspack/core': ^2.0.0-0
+      '@rspack/dev-server': ^2.0.0-0
     peerDependenciesMeta:
+      '@rspack/dev-server':
+        optional: true
+
+  '@rspack/core@2.0.5':
+    resolution: {integrity: sha512-9tv2HAnSiTote5WPH2tmz1hLZ1zKbzkiZc1eYp7LP/8jcsiJBuf40ihiWidAgbbuYtJo3kWET6q+qOm5UhNiGA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': ^0.5.23
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
       '@swc/helpers':
         optional: true
 
-  '@rspack/dev-server@1.1.5':
-    resolution: {integrity: sha512-cwz0qc6iqqoJhyWqxP7ZqE2wyYNHkBMQUXxoQ0tNoZ4YNRkDyQ4HVJ/3oPSmMKbvJk/iJ16u7xZmwG6sK47q/A==}
-    engines: {node: '>= 18.12.0'}
+  '@rspack/dev-middleware@2.0.2':
+    resolution: {integrity: sha512-vYdJq4AEEOxeTvlr8tEqgcVrNm0JOiOalmB6fc63Obu3RKYD4JAWj9oR+n7/nAd1x4GXjyGWivfel+/jZ+olvQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      '@rspack/core': '*'
+      '@rspack/core': ^2.0.0-0
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+
+  '@rspack/dev-server@2.0.3':
+    resolution: {integrity: sha512-S29nOxXQS9o+0uGNe7SgND2dAKnte5ZTD5tiT3/B4lKbviqpXD4tbH7NZWA3hGwlSkmOIbFlysYPL1bVHuBcSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rspack/core': ^2.0.0-0
+      selfsigned: ^5.0.0
+    peerDependenciesMeta:
+      selfsigned:
+        optional: true
 
   '@rspack/lite-tapable@1.1.0':
     resolution: {integrity: sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==}
@@ -19717,14 +20062,80 @@ packages:
       react-refresh:
         optional: true
 
-  '@rspack/plugin-react-refresh@1.6.0':
-    resolution: {integrity: sha512-OO53gkrte/Ty4iRXxxM6lkwPGxsSsupFKdrPFnjwFIYrPvFLjeolAl5cTx+FzO5hYygJiGnw7iEKTmD+ptxqDA==}
+  '@rspack/plugin-react-refresh@2.0.0':
+    resolution: {integrity: sha512-Cf6CxBStNDJbiXMc/GmsvG1G8PRlUpa0MSfWsMTI+e8npzuTN/p8nwLs3shriBZOLciqgkSZpBtPTd10BLpj1g==}
     peerDependencies:
+      '@rspack/core': ^2.0.0-0
       react-refresh: '>=0.10.0 <1.0.0'
-      webpack-hot-middleware: 2.x
     peerDependenciesMeta:
-      webpack-hot-middleware:
+      '@rspack/core':
         optional: true
+
+  '@rspack/plugin-react-refresh@2.0.1':
+    resolution: {integrity: sha512-rYmxHJeDhN9/neZJgEjSFqG20A2Mu1mKv8+15kgwyuIDFSd3cgP3OVxwXLz5UmZSmWAfSzayDmmU1tBT0j1Nxw==}
+    peerDependencies:
+      '@rspack/core': ^2.0.0-0
+      react-refresh: '>=0.10.0 <1.0.0'
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+
+  '@rspack/resolver-binding-darwin-arm64@0.2.8':
+    resolution: {integrity: sha512-nTnK17kmxXEvR+WpOIZPSIzUFYeWCHoffgU9tvOLOwuTBH41kWnSQXXWu+AiMVwvJ6wdRO6Vo30hPhlXEG7Pyw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rspack/resolver-binding-darwin-x64@0.2.8':
+    resolution: {integrity: sha512-Aqr4TK2rA6XVYUOmM5YCtYyCMZhOIR53P4cOGgGARg99A7OuMBMzUL4r1n0M0Fx35v6/sSx1OBe+odHmPxksEg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/resolver-binding-linux-arm64-gnu@0.2.8':
+    resolution: {integrity: sha512-wGvkxm2G4mNTztslaOzLzx5JuySQSy5DcOWEZxHcjJJzp5L3ODbYLK18HtUc6cvmaVOmjaGrrYPrqJJ0hHTVFg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/resolver-binding-linux-arm64-musl@0.2.8':
+    resolution: {integrity: sha512-EqRJ9zLQsLAvyDKJKVZ45BSqRIMS12f5HtJdy3KkAHU14ZmsGv8e5IKkwUZN5CNBRad8xVlOMMx3dOfF4whJzg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/resolver-binding-linux-x64-gnu@0.2.8':
+    resolution: {integrity: sha512-eXbeotNCTntL4/+mxJRVCxK63YeWzTfp0F3POeHJFSs6Nt0f2J/mZNFlasJmd6xm7zvE80h/HWOwbwjRBLcElA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/resolver-binding-linux-x64-musl@0.2.8':
+    resolution: {integrity: sha512-KWFHlOWGkT+eMngoUgPGXrDi+rU04VCh9jyk0U6Ot2RTWvhGxwKykjmLS+CWZI/EBrzr9A6g2U3jzKTMNz9oCw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/resolver-binding-wasm32-wasi@0.2.8':
+    resolution: {integrity: sha512-I6GIhgICFViE88jejIV74oiiWHnpLpQ5ogaZM1ozM9KDnfqcHoX0IVEyrIh5KqA8iLDyhuoFSW+Hf0qN7VTBBQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rspack/resolver-binding-win32-arm64-msvc@0.2.8':
+    resolution: {integrity: sha512-ZXCt3qUfDAEbtc2sHpvxM7lNFZM+DxfblgXUIl3Jy6BuEZbHe1i6z+t9c34ayHoGTVbVSNCtaYuG/MaWdSnPHw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/resolver-binding-win32-ia32-msvc@0.2.8':
+    resolution: {integrity: sha512-2LRymjDK8MpUERD8CL0PPae5y2crU5TAg4T4EzpeL5jLARVq6izsEruiWzB6Y+D15vUYlvmgs2370GXVSB861w==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rspack/resolver-binding-win32-x64-msvc@0.2.8':
+    resolution: {integrity: sha512-hzRpfbtvv4M4EVrKKIAaHDs5wT8lVcbSUjtwPs5u4IeLEix45nQPQ6ZQjmE4lIH0GP/3L3XQhZroYmTcH/xdsQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rspack/resolver@0.2.8':
+    resolution: {integrity: sha512-FBWqdHhzS8mcf/WN4Ktzr7EaeaN+hsxbN98EweegX3924beZuY6H70CSFWCv1fIHAieCUv/9XCjKggHvhCsLwA==}
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -20569,9 +20980,6 @@ packages:
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     hasBin: true
 
-  '@socket.io/component-emitter@3.1.2':
-    resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
-
   '@soda/friendly-errors-webpack-plugin@1.8.1':
     resolution: {integrity: sha512-h2ooWqP8XuFqTXT+NyAFbrArzfQA7R6HTezADrvD9Re8fxMLTPPniLdqVTdDaO0eIoLaAwKT+d6w+5GeTk7Vbg==}
     engines: {node: '>=8.0.0'}
@@ -21271,29 +21679,36 @@ packages:
     resolution: {integrity: sha512-nZUxsxdCCF+YygS4ViUKjNUkCXY9Ly+En3Wsrd9jc5pdV9b+lWXiyv5AM5WLGLVB+qQrOeQWIBrQQuiYLsxTIQ==}
     engines: {node: '>=20.0.0'}
 
-  '@storybook/addon-docs@10.2.0':
-    resolution: {integrity: sha512-2iVQmbgguRWQAxJ7HFje7PQFHZIDCYjFNt9zKLaF8NmCS3OI1qVON5Tb/KH30f9epa5Y42OarPEewJE9J+Tw9A==}
+  '@storybook/addon-docs@10.4.1':
+    resolution: {integrity: sha512-IYqUdjoZe4VO2LFZlKL/gwy7DsQSWCq6hX+zc1MBmZo04yycDASk1tte57n9pdlW3ajw9yYMF/+lVBi+xQjyvw==}
     peerDependencies:
-      storybook: ^10.2.0
-
-  '@storybook/addon-links@10.2.0':
-    resolution: {integrity: sha512-QOZLlcJwK6RkhizxBqDzipfYNqVrQNbWMFLHDcSfdA7suszgelxLyUVK9pC0McMmkpjw14bMH22urLjrjHUOuw==}
-    peerDependencies:
-      react: 19.0.0
-      storybook: ^10.2.0
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.4.1
     peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@storybook/addon-links@10.4.1':
+    resolution: {integrity: sha512-h/5D23GwMuHA55sB7XDyhByF9psF7UFmaQOn72pjNAarew5eOpue5A+jXk3AKEYokHbvgQaoz+FrvWo9GEfSKQ==}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: 19.0.0
+      storybook: ^10.4.1
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
       react:
         optional: true
 
-  '@storybook/addon-ondevice-actions@10.1.11':
-    resolution: {integrity: sha512-MQj8Ei2yKcGI5cHAzygmgRSNQALEutKDnO+nI/0XS0wFOFudz0xKcRFhEaK48rtqm5vTdvpvqrIAM3mQTCdoNQ==}
+  '@storybook/addon-ondevice-actions@10.4.4':
+    resolution: {integrity: sha512-yuh+h0ULqXoFcK8ONdfm9dSUObE0v5wZkXFrET5K1mh8+JZbUGyM3NVH0MmxQse3G71/mpNbVPb0rlj7Ui+MvA==}
     peerDependencies:
       react: 19.0.0
       react-native: '*'
       storybook: '>=10 || ^10'
 
-  '@storybook/addon-ondevice-backgrounds@10.1.11':
-    resolution: {integrity: sha512-I+9HPlW7GK1KwWLfWmn0yOrKNH/QcZPXim/NGk54eGcIaOfpn3nUPWTwJdujy/LbKV4aTsdB3JEAMmdoY1EEUg==}
+  '@storybook/addon-ondevice-backgrounds@10.4.4':
+    resolution: {integrity: sha512-4dBAtfIlYivTO5lHIhdKoqMOcyp9QqVV3SgyiudcngugoG/B6rMeAyF9wJl7nSqbvj1fdSf1GmdHL/Uz/OqI6A==}
     peerDependencies:
       '@emotion/native': '*'
       react: 19.0.0
@@ -21303,8 +21718,8 @@ packages:
       '@emotion/native':
         optional: true
 
-  '@storybook/addon-ondevice-controls@10.1.11':
-    resolution: {integrity: sha512-IdLcmhK6giGajyQvXpQ7qI75PUAWZRqv9+LeqcZjGWDWZR20g594++NOxevs5JggXUbIdE6/BQqCZHW7gNq4AQ==}
+  '@storybook/addon-ondevice-controls@10.4.4':
+    resolution: {integrity: sha512-CS/bSw/Jaa0m+ENxcHVuhRNSX/A5wzV2sbp0yB/YvjbeFedQMPuyMJABtdX0NGBvTHxpa6GHQ5V6UQXlMoDpBA==}
     peerDependencies:
       '@gorhom/bottom-sheet': '>=4'
       '@react-native-community/datetimepicker': '*'
@@ -21316,8 +21731,8 @@ packages:
       '@gorhom/bottom-sheet':
         optional: true
 
-  '@storybook/addon-ondevice-notes@10.1.11':
-    resolution: {integrity: sha512-CBRSr2Lf5FY5Q4JtnoBowrBH8bAi/wC1TZ1j/sDG0uq04yK1pXMTan1QsO6VbEi6zpI6rSBu6qRyqMnbqiGHQA==}
+  '@storybook/addon-ondevice-notes@10.4.4':
+    resolution: {integrity: sha512-KnEKUI37uT/HmxWMDuaeB+Kdg/AeXqLVpoL+70P859SsdZy5Y+UkzLzvXxgWhH3yawDfoELkPRceRyGtlsN46A==}
     peerDependencies:
       '@storybook/react': ^10
       react: 19.0.0
@@ -21346,12 +21761,12 @@ packages:
       webpack:
         optional: true
 
-  '@storybook/csf-plugin@10.2.0':
-    resolution: {integrity: sha512-Cty+tZ0r1AZhwBBzqI4RyCpMVGt9wHGTtG4YCRUuNgVFO1MnjaFBHKRT+oT7md28+BWYjFz4Qtpge/fcWANJ0w==}
+  '@storybook/csf-plugin@10.4.1':
+    resolution: {integrity: sha512-WdPepGBxDGOUDjYd8KxMtcf+us/2PAcnBczl77XtrnxxHNs0jWesxKkiJ9yiuGrge4BPhDeAj6rxjbBoaHxLBA==}
     peerDependencies:
       esbuild: '*'
       rollup: '*'
-      storybook: ^10.2.0
+      storybook: ^10.4.1
       vite: '*'
       webpack: '*'
     peerDependenciesMeta:
@@ -21371,8 +21786,8 @@ packages:
   '@storybook/global@5.0.0':
     resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
 
-  '@storybook/icons@2.0.1':
-    resolution: {integrity: sha512-/smVjw88yK3CKsiuR71vNgWQ9+NuY2L+e8X7IMrFjexjm6ZR8ULrV2DRkTA61aV6ryefslzHEGDInGpnNeIocg==}
+  '@storybook/icons@2.0.2':
+    resolution: {integrity: sha512-KZBCpXsshAIjczYNXR/rlxEtCUX/eAbpFNwKi8bcOomrLA4t/SyPz5RF+lVPO2oZBUE4sAkt43mfJUevQDSEEw==}
     peerDependencies:
       react: 19.0.0
       react-dom: 19.0.0
@@ -21386,35 +21801,45 @@ packages:
     resolution: {integrity: sha512-ov5izrmbAFObzKeh9AOC5MlmFxAcf0o5i6YFGae9sDx6DGh6alXsRM+chIbucVkUwVHVlSzdfbLDEFGY/ShaYw==}
     deprecated: In Storybook 8, this package functionality has been integrated to a new package called @storybook/test, which uses Vitest APIs for an improved experience. When upgrading to Storybook 8 with 'npx storybook@latest upgrade', you will get prompted and will get an automigration for the new package. Please migrate when you can.
 
+  '@storybook/mcp@0.7.0':
+    resolution: {integrity: sha512-Pr4E61tM5e7aDzqgNOL/Ylw8CGdb+BIDGOf3vbmFfkR8ZnXjPxaV/vhTEsiXynnIpjQWCzySCxOU1icxZsgjrA==}
+
   '@storybook/react-docgen-typescript-plugin@1.0.1':
     resolution: {integrity: sha512-dqbHa+5gaxaklFCuV1WTvljVPTo3QIJgpW4Ln+QeME7osPZUnUhjN2/djvo+sxrWUrTTuqX5jkn291aDngu9Tw==}
     peerDependencies:
       typescript: '>= 3.x'
       webpack: '>= 4'
 
-  '@storybook/react-dom-shim@10.2.0':
-    resolution: {integrity: sha512-PEQofiruE6dBGzUQPXZZREbuh1t62uRBWoUPRFNAZi79zddlk7+b9qu08VV9cvf68mwOqqT1+VJ1P+3ClD2ZVw==}
+  '@storybook/react-dom-shim@10.4.1':
+    resolution: {integrity: sha512-6QFqfDNH4DMrt7yHKRfpqRopsVUc/Az+sXIdJ39IetYnHUxL3nW4NVaPc6uy/8Qi8urzUyEXL/nn7cpSIP2aPQ==}
     peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react: 19.0.0
       react-dom: 19.0.0
-      storybook: ^10.2.0
+      storybook: ^10.4.1
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
-  '@storybook/react-native-theming@10.1.11':
-    resolution: {integrity: sha512-r3LcjOeNz7BWI8/midlEG1iQo1niiPo/kAMYzbSddw1QU5nlUnOtaVPpqUDn7bmZDhovTjahNvHu4mKJw6s3ww==}
+  '@storybook/react-native-theming@10.4.4':
+    resolution: {integrity: sha512-6OBvQeuk9AG/pBs3nyLR4/JUcJjMmUM8rxoWoR5v3HT9daYB+TtUT+6AEZJ2r1XqUZiSQifgsTIjoYajTj4FFA==}
     peerDependencies:
       react: 19.0.0
       react-native: '>=0.57.0'
 
-  '@storybook/react-native-ui-common@10.1.11':
-    resolution: {integrity: sha512-5Ez4fvs8DAPp1MR06tpdOFUip+LDU0pSFB0uVVhBnQBp7/i+AYVAM7h8M3geah4mWLnX1EsMqLlbVMALqLt5EA==}
+  '@storybook/react-native-ui-common@10.4.4':
+    resolution: {integrity: sha512-LFFJVl71biMVaa0x2yHBVV0N5aye/xaFuc5OvN3bkFVRz5lB8vydC7tZ47vlf/QdfsLqEC7hn46F4v3pIxkV0Q==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: 19.0.0
       react-native: '>=0.57.0'
       storybook: '>=10 || ^10'
 
-  '@storybook/react-native-ui@10.1.11':
-    resolution: {integrity: sha512-1rXt7jgfbgpYk/VZUlyHri7MbN2Zg+ENpxrotFZjjg9pSh6NlP5AXrut6564BnjSLZ7cJOgYPl/7kLiqtuOlZw==}
+  '@storybook/react-native-ui@10.4.4':
+    resolution: {integrity: sha512-7IjzVUNfHBJNrHh3nChoNb1lty4LDMRMEimH8g6T75oIvL5CP25DZatu3RsDLkaiJReSSSqvJg3O2dPwbfCkAw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@gorhom/bottom-sheet': '>=4'
@@ -21426,8 +21851,8 @@ packages:
       react-native-svg: '>=14'
       storybook: '>=10 || ^10'
 
-  '@storybook/react-native@10.1.11':
-    resolution: {integrity: sha512-Ti5ueMCjCTqHMHmanV2kaCHLpHiD9VVbbQjhko7gkYSsLoAp8m9EZ1188fsY2CBKMlooLsStc+5yjuE8fHdCwA==}
+  '@storybook/react-native@10.4.4':
+    resolution: {integrity: sha512-qNkbZbyK9w8Iwn/BV08KyBHFDqbtHa64agqLrSYRjyeRjCcNv67tmDLPemW49TvsctA5f4LdfhwD3U4hXlei0w==}
     engines: {node: '>=20'}
     hasBin: true
     peerDependencies:
@@ -21445,17 +21870,21 @@ packages:
         optional: true
       react-native-reanimated:
         optional: true
-      react-native-safe-area-context:
-        optional: true
 
-  '@storybook/react@10.2.0':
-    resolution: {integrity: sha512-ciJlh1UGm0GBXQgqrYFeLmiix+KGFB3v37OnAYjGghPS9OP6S99XyshxY/6p0sMOYtS+eWS2gPsOKNXNnLDGYw==}
+  '@storybook/react@10.4.1':
+    resolution: {integrity: sha512-WuYz4NaUk4gmFAMliSpCbV8w6jP5OY9juBfw1huwzu2S/k5FhnVXwmrUaL0fmf3Bq/7NgkzmBBbZr6I6LuHayQ==}
     peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react: 19.0.0
       react-dom: 19.0.0
-      storybook: ^10.2.0
+      storybook: ^10.4.1
       typescript: '>= 4.9.x'
     peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
       typescript:
         optional: true
 
@@ -21667,11 +22096,11 @@ packages:
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
-  '@swc/helpers@0.5.17':
-    resolution: {integrity: sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==}
-
   '@swc/helpers@0.5.18':
     resolution: {integrity: sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==}
+
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
   '@swc/jest@0.2.39':
     resolution: {integrity: sha512-eyokjOwYd0Q8RnMHri+8/FS1HIrIUKK/sRrFp8c1dThUOfNeCWbLmBP1P5VsKdvmkd25JaH+OKYwEYiAYg9YAA==}
@@ -21679,8 +22108,8 @@ packages:
     peerDependencies:
       '@swc/core': '*'
 
-  '@swc/plugin-styled-components@12.3.0':
-    resolution: {integrity: sha512-GjhVd6l5EqQXFcobTP3YZ6u9PNXj1TsNLHWdPm3xFEmCiEByh38etDr4lbXujp11iJ8grnX0csMqcJnbn5g0Qw==}
+  '@swc/plugin-styled-components@12.12.0':
+    resolution: {integrity: sha512-BvbpMvUpEKkGg+CXVbYl8bYGbTnWj4W5j+z9I4aniDigIgGoXnjt21SCoJZ9U+1GlcQKxdQIptlR3wpvc1vLpQ==}
 
   '@swc/types@0.1.25':
     resolution: {integrity: sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==}
@@ -21934,6 +22363,25 @@ packages:
     peerDependencies:
       react: 19.0.0
       react-dom: 19.0.0
+
+  '@tmcp/adapter-valibot@0.1.6':
+    resolution: {integrity: sha512-drirZeNinhYLiRSMksN+m//u0ImFxtGRk1Vp425Xp/7CbBXFQdjAG+f7grssyHAukbVTGzmWsMMP6ejrGVErUA==}
+    peerDependencies:
+      tmcp: ^1.17.0
+
+  '@tmcp/session-manager@0.2.2':
+    resolution: {integrity: sha512-UrCRpTsxh5XnMbplspvftEYboiZWgAiXqqAUbyFTHoHMJ0LoNDy8bQd0+7qtxtT4S5Qsnv650gvs/Nbec5NTCQ==}
+    peerDependencies:
+      tmcp: ^1.16.3
+
+  '@tmcp/transport-http@0.8.6':
+    resolution: {integrity: sha512-iLcxu+tEMbkVHbhFfyXQhxfPDDTfm+F0kEw8Xg/a1rm29s4cBg1vwcpbtk02XTxsdDh8RJ1AZkQwF9WDGeb/IA==}
+    peerDependencies:
+      '@tmcp/auth': ^0.3.3 || ^0.4.0
+      tmcp: ^1.18.0
+    peerDependenciesMeta:
+      '@tmcp/auth':
+        optional: true
 
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
@@ -22650,8 +23098,8 @@ packages:
   '@types/supports-color@8.1.3':
     resolution: {integrity: sha512-Hy6UMpxhE3j1tLpl27exp1XqHD7n8chAiNPzWfz16LPZoMMoSc4dzLl6w9qijkEb/r5O1ozdu1CWGA2L83ZeZg==}
 
-  '@types/tapable@2.2.7':
-    resolution: {integrity: sha512-D6QzACV9vNX3r8HQQNTOnpG+Bv1rko+yEA82wKs3O9CQ5+XW7HI7TED17/UE7+5dIxyxZIWTxKbsBeF6uKFCwA==}
+  '@types/tapable@2.3.0':
+    resolution: {integrity: sha512-oMnbAXeVo+KUnje3hzdORXUbfnzTfqD0H92mLl19NE5hFqH9Q4ktq+xehNSxcNeeLm1COopYwa0zeP6Iz+oIXg==}
 
   '@types/tern@0.23.9':
     resolution: {integrity: sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==}
@@ -22703,9 +23151,6 @@ packages:
 
   '@types/ws@7.4.7':
     resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
-
-  '@types/ws@8.18.1':
-    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@types/ws@8.5.10':
     resolution: {integrity: sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==}
@@ -23242,6 +23687,9 @@ packages:
   '@webassemblyjs/wast-printer@1.12.1':
     resolution: {integrity: sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==}
 
+  '@webcontainer/env@1.1.1':
+    resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
+
   '@webgpu/types@0.1.69':
     resolution: {integrity: sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==}
 
@@ -23429,6 +23877,10 @@ packages:
 
   acorn-walk@8.3.4:
     resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+    engines: {node: '>=0.4.0'}
+
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
     engines: {node: '>=0.4.0'}
 
   acorn@8.15.0:
@@ -24083,6 +24535,10 @@ packages:
   balanced-match@2.0.0:
     resolution: {integrity: sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   bare-events@2.4.2:
     resolution: {integrity: sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q==}
 
@@ -24330,6 +24786,10 @@ packages:
 
   brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -25994,9 +26454,13 @@ packages:
       babel-plugin-macros:
         optional: true
 
-  deep-eql@4.1.3:
-    resolution: {integrity: sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==}
-    engines: {node: '>=6'}
+  dedent@1.7.2:
+    resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
+    peerDependencies:
+      babel-plugin-macros: ^3.1.0
+    peerDependenciesMeta:
+      babel-plugin-macros:
+        optional: true
 
   deep-eql@4.1.4:
     resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
@@ -26515,18 +26979,6 @@ packages:
   endent@2.1.0:
     resolution: {integrity: sha512-r8VyPX7XL8U01Xgnb1CjZ3XV+z90cXIJ9JPE/R9SEC9vpw2P6CfsRPJmp20DppC5N7ZAMCmjYkJIa744Iyg96w==}
 
-  engine.io-parser@5.2.3:
-    resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
-    engines: {node: '>=10.0.0'}
-
-  engine.io@6.6.7:
-    resolution: {integrity: sha512-DgOngfDKM2EviOH3Mr9m7ks1q8roetLy/IMmYthAYzbpInMbYc/GS+fWFA3rl1gvwKVsQrVV61fo5emD1y3OJQ==}
-    engines: {node: '>=10.2.0'}
-
-  enhanced-resolve@5.12.0:
-    resolution: {integrity: sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==}
-    engines: {node: '>=10.13.0'}
-
   enhanced-resolve@5.17.1:
     resolution: {integrity: sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==}
     engines: {node: '>=10.13.0'}
@@ -26574,11 +27026,6 @@ packages:
   env-paths@3.0.0:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  envinfo@7.14.0:
-    resolution: {integrity: sha512-CO40UI41xDQzhLB1hWyqUKgFhs250pNcGbyGKe1l/e4FSaI/+YE4IMG76GDt0In67WLPACIITC+sOi08x4wIvg==}
-    engines: {node: '>=4'}
-    hasBin: true
 
   envinfo@7.21.0:
     resolution: {integrity: sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==}
@@ -26648,6 +27095,9 @@ packages:
 
   es-toolkit@1.44.0:
     resolution: {integrity: sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==}
+
+  es-toolkit@1.47.0:
+    resolution: {integrity: sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==}
 
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
@@ -26850,6 +27300,9 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
+
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
 
   esm@3.2.25:
     resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
@@ -27431,9 +27884,9 @@ packages:
     resolution: {integrity: sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==}
     engines: {node: '>=8'}
 
-  filesize@10.1.6:
-    resolution: {integrity: sha512-sJslQKU2uM33qH5nqewAwVB2QgR6w1aMNsYUp3aN5rMRyXEwJGmZvaWzeJFNTOXWlHQyBFCWrdj3fV/fsTOX8w==}
-    engines: {node: '>= 10.4.0'}
+  filesize@11.0.17:
+    resolution: {integrity: sha512-oHLTvMLw6imZUl1se/RBQrFlyy50nXce4sU7yGR6Qc0JgCwqnfiFsAnEwotdGmfKLD7SArGUk2/5STU0k8LOBQ==}
+    engines: {node: '>= 10.8.0'}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -27674,6 +28127,10 @@ packages:
     resolution: {integrity: sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==}
     engines: {node: '>=14.14'}
 
+  fs-extra@11.3.5:
+    resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
+    engines: {node: '>=14.14'}
+
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -27909,6 +28366,10 @@ packages:
     engines: {node: 20 || >=22}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
 
   glob@6.0.4:
     resolution: {integrity: sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==}
@@ -29541,6 +30002,9 @@ packages:
   json-rpc-2.0@1.7.0:
     resolution: {integrity: sha512-asnLgC1qD5ytP+fvBP8uL0rvj+l8P6iYICbzZ8dVxCpESffVjzA7KkYkbKCIbavs7cllwH1ZUaNtJwphdeRqpg==}
 
+  json-rpc-2.0@1.7.1:
+    resolution: {integrity: sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg==}
+
   json-schema-compare@0.2.2:
     resolution: {integrity: sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==}
 
@@ -29819,6 +30283,9 @@ packages:
 
   launch-editor@2.12.0:
     resolution: {integrity: sha512-giOHXoOtifjdHqUamwKq6c49GzBdLjvxrd2D+Q4V6uOHopJv7p9VJxikDsQ/CBXZbEITgUqSVHXLTG3VhPP1Dg==}
+
+  launch-editor@2.14.0:
+    resolution: {integrity: sha512-Pj3ZOx9dD1BClS7YcSQx0An1PCF9wz4JpvbEmKvDxQtm0jxlkk5NhW8x0SBAKA/acHBKZaqdd5FFOWlXo500JA==}
 
   lazy-cache@1.0.4:
     resolution: {integrity: sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ==}
@@ -30588,6 +31055,9 @@ packages:
   memfs@4.51.1:
     resolution: {integrity: sha512-Eyt3XrufitN2ZL9c/uIRMyDwXanLI88h/L3MoWqNY747ha3dMR9dWqp8cRT5ntjZ0U1TNuq4U91ZXK0sMBjYOQ==}
 
+  memfs@4.57.3:
+    resolution: {integrity: sha512-dlvqataP1zUOlfj6pv9wgCSC5pRIooNntXgdLfR7FWlcKi1p8fMfJADtHp/+8Dhu5JFvMHNh7L0QVcuaaBKqqA==}
+
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
 
@@ -31039,6 +31509,10 @@ packages:
     resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
     engines: {node: 20 || >=22}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -31107,6 +31581,10 @@ packages:
 
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minizlib@2.1.2:
@@ -31753,6 +32231,13 @@ packages:
       typescript:
         optional: true
 
+  oxc-parser@0.127.0:
+    resolution: {integrity: sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxc-resolver@11.20.0:
+    resolution: {integrity: sha512-CblytBiV/a/ZXY34dsVU2NxhIOxMXst8CvDCtyBelVITgd7PLrKzbEbA6oKLdPjvDKDzCiW48qzmzZ+mYaqn+g==}
+
   oxfmt@0.36.0:
     resolution: {integrity: sha512-/ejJ+KoSW6J9bcNT9a9UtJSJNWhJ3yOLSBLbkoFHJs/8CZjmaZVZAJe4YgO1KMJlKpNQasrn/G9JQUEZI3p0EQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -31994,6 +32479,10 @@ packages:
   path-scurry@2.0.0:
     resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
     engines: {node: 20 || >=22}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
@@ -33026,6 +33515,10 @@ packages:
     resolution: {integrity: sha512-+NRMYs2DyTP4/tqWz371Oo50JqmWltR1h2gcdgUMAWZJIAvrd0/SqlCfx7tpzpl/s36rzw6qH2MjoNrxtRNYhA==}
     engines: {node: ^20.9.0 || >=22}
 
+  react-docgen@8.0.3:
+    resolution: {integrity: sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w==}
+    engines: {node: ^20.9.0 || >=22}
+
   react-dom@19.0.0:
     resolution: {integrity: sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==}
     peerDependencies:
@@ -33660,8 +34153,8 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
-  reduce-configs@1.1.1:
-    resolution: {integrity: sha512-EYtsVGAQarE8daT54cnaY1PIknF2VB78ug6Zre2rs36EsJfC40EG6hmTU2A2P1ZuXnKAt2KI0fzOGHcX7wzdPw==}
+  reduce-configs@1.1.2:
+    resolution: {integrity: sha512-AgBP55V8FC7NaqoOP2RCbTpu6LE+YuX3LUZkNAoitcfyS3/PIC8Obg/TJrBzTkJ+lDvZv0TTAeDpLkzjTtYlbw==}
 
   reduce-flatten@2.0.0:
     resolution: {integrity: sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==}
@@ -33875,6 +34368,11 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
   resolve@1.22.8:
     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
     hasBin: true
@@ -34021,14 +34519,14 @@ packages:
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
 
-  rsbuild-plugin-dts@0.19.3:
-    resolution: {integrity: sha512-TMHNAg+AehA3ERJ7Z3zASsPyyIIoLd7gLFZAFOfyzvttyMH5qEaQ1HtIzC4bKH17dDLVNduh8aCFtwNpUEfJvQ==}
-    engines: {node: '>=18.12.0'}
+  rsbuild-plugin-dts@0.22.0:
+    resolution: {integrity: sha512-Oyiu5oJDHWOnBv7yRr8eAGfoEddwxfPqUbAX6HvcJxrnR/h6Zd0VgTBWVTgqALYhLcL2ZdyZ2vwnqfhan4krwA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@microsoft/api-extractor': ^7
-      '@rsbuild/core': 1.x
+      '@rsbuild/core': ^1.0.0 || ^2.0.0-0
       '@typescript/native-preview': 7.x
-      typescript: ^5
+      typescript: ^5 || ^6
     peerDependenciesMeta:
       '@microsoft/api-extractor':
         optional: true
@@ -34045,8 +34543,9 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  rslog@1.3.2:
-    resolution: {integrity: sha512-1YyYXBvN0a2b1MSIDLwDTqqgjDzRKxUg/S/+KO6EAgbtZW1B3fdLHAMhEEtvk1patJYMqcRvlp3HQwnxj7AdGQ==}
+  rslog@2.1.2:
+    resolution: {integrity: sha512-jHUtwes07RKZ/UXJAqCKPViDEargkoCvTha+MuVXDc9xcSqXodHAu2B/QyAM+iRCEgHqQ7ztazH1rAtqD3WyNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
 
   run-applescript@7.0.0:
     resolution: {integrity: sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==}
@@ -34211,6 +34710,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.1:
+    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@0.18.0:
     resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
     engines: {node: '>= 0.8.0'}
@@ -34341,6 +34845,10 @@ packages:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
 
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+    engines: {node: '>= 0.4'}
+
   shimmer@1.2.1:
     resolution: {integrity: sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==}
 
@@ -34461,17 +34969,6 @@ packages:
   smoldot@2.0.26:
     resolution: {integrity: sha512-F+qYmH4z2s2FK+CxGj8moYcd1ekSIKH8ywkdqlOz88Dat35iB1DIYL11aILN46YSGMzQW/lbJNS307zBSDN5Ig==}
 
-  socket.io-adapter@2.5.6:
-    resolution: {integrity: sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==}
-
-  socket.io-parser@4.2.6:
-    resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
-    engines: {node: '>=10.0.0'}
-
-  socket.io@4.8.1:
-    resolution: {integrity: sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==}
-    engines: {node: '>=10.2.0'}
-
   socketcluster-client@19.2.7:
     resolution: {integrity: sha512-c6caNOr/49FUjlVnQfXb0TasMnrqY1uN/uevT99xicF+7NkvGSNwjP6rlMP0v1ZZjz+MosT2/qJNDDc2b3v/Jw==}
 
@@ -34591,6 +35088,9 @@ packages:
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
+  sqids@0.3.0:
+    resolution: {integrity: sha512-lOQK1ucVg+W6n3FhRwwSeUijxe93b51Bfz5PMRMihVf1iVkl82ePQG7V5vwrhzB11v0NtsR25PSZRGiSomJaJw==}
+
   sqlite3@5.1.7:
     resolution: {integrity: sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==}
 
@@ -34669,13 +35169,13 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
-  storybook-builder-rsbuild@3.2.2:
-    resolution: {integrity: sha512-8UDSyIndp0rG7K51qa/jhU5MRbUaY7lbgvIg5VbdkU9/sxpiwhUzM90WPgNekefbT8m6jzAluH+OniT82E88Ew==}
+  storybook-builder-rsbuild@3.3.4:
+    resolution: {integrity: sha512-TZT4EotVtrOO2p7aYcIVcuoHPua2dHNFflVThQwDOkQdeXIY+dAQ53hMLUP7pgTOJovMSkFwpy3Domq22vAYKA==}
     peerDependencies:
-      '@rsbuild/core': ^1.5.0
+      '@rsbuild/core': ^1.5.0 || ^2.0.0-0
       react: 19.0.0
       react-dom: 19.0.0
-      storybook: ^10.1.0
+      storybook: ^10.3.5
       typescript: '*'
     peerDependenciesMeta:
       react:
@@ -34685,26 +35185,32 @@ packages:
       typescript:
         optional: true
 
-  storybook-react-rsbuild@3.2.2:
-    resolution: {integrity: sha512-6+OlgoJuJ5TV48IMQNyRdoiI/VMWn018i6IslPMSWlkj/AVo9f8aKF/lmXpqKPnzOa3wFgVioWPwe4pqrqje5g==}
+  storybook-react-rsbuild@3.3.4:
+    resolution: {integrity: sha512-UitB+5+cXBWywmLGKl4XNYbmgOySp9/0ee6j+mOewumAm5NoBX57gB1Udkfs7X62R5bWEHXjiEwCi6+pRyCJBg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      '@rsbuild/core': ^1.5.0
+      '@rsbuild/core': ^1.5.0 || ^2.0.0-0
       react: 19.0.0
       react-dom: 19.0.0
-      storybook: ^10.1.0
+      storybook: ^10.3.5
       typescript: '>= 4.2.x'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  storybook@10.2.0:
-    resolution: {integrity: sha512-fIQnFtpksRRgHR1CO1onGX3djaog4qsW/c5U8arqYTkUEr2TaWpn05mIJDOBoPJFlOdqFrB4Ttv0PZJxV7avhw==}
+  storybook@10.4.1:
+    resolution: {integrity: sha512-V1Zd2e+gBFufqAQVZ1JR8KLqALsEZ3JYSBnWwQbKa6zCfWWanR6AFMyuOkLt2gZOgGp3h2Riuz88pGNVTQSG0A==}
     hasBin: true
     peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       prettier: ^2 || ^3
+      vite-plus: ^0.1.15
     peerDependenciesMeta:
+      '@types/react':
+        optional: true
       prettier:
+        optional: true
+      vite-plus:
         optional: true
 
   stream-browserify@3.0.0:
@@ -35114,6 +35620,10 @@ packages:
     resolution: {integrity: sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg==}
     engines: {node: '>=6'}
 
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
   tar-fs@2.1.1:
     resolution: {integrity: sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==}
 
@@ -35342,6 +35852,9 @@ packages:
     resolution: {integrity: sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==}
     hasBin: true
 
+  tmcp@1.19.4:
+    resolution: {integrity: sha512-fMoUJ3Gef9iA0yKZNeW2SQCCKTluCwghUyOz/qxPS8XxrQk6Jlw4lgql3S+s6L//FteLeSJ7erKxMWl727mZoQ==}
+
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
 
@@ -35475,8 +35988,8 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
-  ts-checker-rspack-plugin@1.2.6:
-    resolution: {integrity: sha512-aAJIfoNr2cPu8G6mqp/oPoNlUT/LgNoqt2n3SsbxWG0TwQogbjsYsr2f/fdsufUDoGDu8Jolmpf3L4PmIH/cEg==}
+  ts-checker-rspack-plugin@1.3.1:
+    resolution: {integrity: sha512-4VBjKblnJwypq+2aWZ9V65HENAmU/2s04d717YhLjC65MKitTTnqKeHE6GGB5C4S+2BnqZ9MtJt5AvS7nldaLQ==}
     peerDependencies:
       '@rspack/core': ^1.0.0 || ^2.0.0-0
       typescript: '>=3.8.0'
@@ -35997,6 +36510,9 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  uri-template-matcher@1.1.2:
+    resolution: {integrity: sha512-uZc1h12jdO3m/R77SfTEOuo6VbMhgWznaawKpBjRGSJb7i91x5PgI37NQJtG+Cerxkk0yr1pylBY2qG1kQ+aEQ==}
+
   urijs@1.19.11:
     resolution: {integrity: sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==}
 
@@ -36155,6 +36671,14 @@ packages:
 
   valibot@1.2.0:
     resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  valibot@1.4.1:
+    resolution: {integrity: sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -36397,34 +36921,12 @@ packages:
     peerDependencies:
       webpack: ^4.0.0 || ^5.0.0
 
-  webpack-dev-middleware@7.4.5:
-    resolution: {integrity: sha512-uxQ6YqGdE4hgDKNf7hUiPXOdtkXvBJXrfEGYSx7P7LC8hnUYGK70X6xQXUvXeNyBDDcsiQXpG2m3G9vxowaEuA==}
-    engines: {node: '>= 18.12.0'}
-    peerDependencies:
-      webpack: ^5.0.0
-    peerDependenciesMeta:
-      webpack:
-        optional: true
-
   webpack-dev-server@4.15.2:
     resolution: {integrity: sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==}
     engines: {node: '>= 12.13.0'}
     hasBin: true
     peerDependencies:
       webpack: ^4.37.0 || ^5.0.0
-      webpack-cli: '*'
-    peerDependenciesMeta:
-      webpack:
-        optional: true
-      webpack-cli:
-        optional: true
-
-  webpack-dev-server@5.2.2:
-    resolution: {integrity: sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==}
-    engines: {node: '>= 18.12.0'}
-    hasBin: true
-    peerDependencies:
-      webpack: ^5.0.0
       webpack-cli: '*'
     peerDependenciesMeta:
       webpack:
@@ -36658,6 +37160,30 @@ packages:
 
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -40681,17 +41207,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@callstack/repack-plugin-expo-modules@5.2.5(@callstack/repack@5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@1.7.3(@swc/helpers@0.5.17))(@swc/core@1.15.11(@swc/helpers@0.5.17))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)))':
+  '@callstack/repack-plugin-expo-modules@5.2.5(@callstack/repack@5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.0.5(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)))':
     dependencies:
-      '@callstack/repack': 5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@1.7.3(@swc/helpers@0.5.17))(@swc/core@1.15.11(@swc/helpers@0.5.17))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))
+      '@callstack/repack': 5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.0.5(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))
 
-  '@callstack/repack-plugin-reanimated@5.2.5(@babel/core@7.28.5)(@callstack/repack@5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@1.7.3(@swc/helpers@0.5.17))(@swc/core@1.15.11(@swc/helpers@0.5.17))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)))':
+  '@callstack/repack-plugin-reanimated@5.2.5(@babel/core@7.28.5)(@callstack/repack@5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.0.5(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)))':
     dependencies:
       '@babel/core': 7.28.5
-      '@callstack/repack': 5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@1.7.3(@swc/helpers@0.5.17))(@swc/core@1.15.11(@swc/helpers@0.5.17))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))
+      '@callstack/repack': 5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.0.5(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))
       semver: 7.7.3
 
-  '@callstack/repack@5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@1.7.3(@swc/helpers@0.5.17))(@swc/core@1.15.11(@swc/helpers@0.5.17))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))':
+  '@callstack/repack@5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.0.5(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))':
     dependencies:
       '@callstack/repack-dev-server': 5.2.5
       '@discoveryjs/json-ext': 0.5.7
@@ -40716,11 +41242,11 @@ snapshots:
       semver: 7.7.3
       shallowequal: 1.1.0
       tapable: 2.2.3
-      terser-webpack-plugin: 5.3.16(@swc/core@1.15.11(@swc/helpers@0.5.17))
+      terser-webpack-plugin: 5.3.16(@swc/core@1.15.11(@swc/helpers@0.5.23))
       throttleit: 2.1.0
       webpack-merge: 6.0.1
     optionalDependencies:
-      '@rspack/core': 1.7.3(@swc/helpers@0.5.17)
+      '@rspack/core': 2.0.5(@swc/helpers@0.5.23)
     transitivePeerDependencies:
       - '@babel/core'
       - '@swc/core'
@@ -41680,18 +42206,45 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.6.2
+    optional: true
+
   '@emnapi/core@1.7.1':
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
       tslib: 2.6.2
 
+  '@emnapi/core@1.9.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.6.2
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.6.2
+    optional: true
+
   '@emnapi/runtime@1.7.1':
     dependencies:
       tslib: 2.6.2
 
+  '@emnapi/runtime@1.9.2':
+    dependencies:
+      tslib: 2.6.2
+    optional: true
+
   '@emnapi/wasi-threads@1.1.0':
     dependencies:
       tslib: 2.6.2
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.6.2
+    optional: true
 
   '@emotion/babel-plugin@11.13.5':
     dependencies:
@@ -43912,7 +44465,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@30.2.0(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2))':
+  '@jest/core@30.2.0(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2))':
     dependencies:
       '@jest/console': 30.2.0
       '@jest/pattern': 30.0.1
@@ -43927,7 +44480,7 @@ snapshots:
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.2.0
-      jest-config: 30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2))
+      jest-config: 30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2))
       jest-haste-map: 30.2.0
       jest-message-util: 30.2.0
       jest-regex-util: 30.0.1
@@ -44549,12 +45102,80 @@ snapshots:
     dependencies:
       tslib: 2.6.2
 
+  '@jsonjoy.com/base64@17.67.0(tslib@2.6.2)':
+    dependencies:
+      tslib: 2.6.2
+
   '@jsonjoy.com/buffers@1.2.1(tslib@2.6.2)':
+    dependencies:
+      tslib: 2.6.2
+
+  '@jsonjoy.com/buffers@17.67.0(tslib@2.6.2)':
     dependencies:
       tslib: 2.6.2
 
   '@jsonjoy.com/codegen@1.0.0(tslib@2.6.2)':
     dependencies:
+      tslib: 2.6.2
+
+  '@jsonjoy.com/codegen@17.67.0(tslib@2.6.2)':
+    dependencies:
+      tslib: 2.6.2
+
+  '@jsonjoy.com/fs-core@4.57.3(tslib@2.6.2)':
+    dependencies:
+      '@jsonjoy.com/fs-node-builtins': 4.57.3(tslib@2.6.2)
+      '@jsonjoy.com/fs-node-utils': 4.57.3(tslib@2.6.2)
+      thingies: 2.5.0(tslib@2.6.2)
+      tslib: 2.6.2
+
+  '@jsonjoy.com/fs-fsa@4.57.3(tslib@2.6.2)':
+    dependencies:
+      '@jsonjoy.com/fs-core': 4.57.3(tslib@2.6.2)
+      '@jsonjoy.com/fs-node-builtins': 4.57.3(tslib@2.6.2)
+      '@jsonjoy.com/fs-node-utils': 4.57.3(tslib@2.6.2)
+      thingies: 2.5.0(tslib@2.6.2)
+      tslib: 2.6.2
+
+  '@jsonjoy.com/fs-node-builtins@4.57.3(tslib@2.6.2)':
+    dependencies:
+      tslib: 2.6.2
+
+  '@jsonjoy.com/fs-node-to-fsa@4.57.3(tslib@2.6.2)':
+    dependencies:
+      '@jsonjoy.com/fs-fsa': 4.57.3(tslib@2.6.2)
+      '@jsonjoy.com/fs-node-builtins': 4.57.3(tslib@2.6.2)
+      '@jsonjoy.com/fs-node-utils': 4.57.3(tslib@2.6.2)
+      tslib: 2.6.2
+
+  '@jsonjoy.com/fs-node-utils@4.57.3(tslib@2.6.2)':
+    dependencies:
+      '@jsonjoy.com/fs-node-builtins': 4.57.3(tslib@2.6.2)
+      tslib: 2.6.2
+
+  '@jsonjoy.com/fs-node@4.57.3(tslib@2.6.2)':
+    dependencies:
+      '@jsonjoy.com/fs-core': 4.57.3(tslib@2.6.2)
+      '@jsonjoy.com/fs-node-builtins': 4.57.3(tslib@2.6.2)
+      '@jsonjoy.com/fs-node-utils': 4.57.3(tslib@2.6.2)
+      '@jsonjoy.com/fs-print': 4.57.3(tslib@2.6.2)
+      '@jsonjoy.com/fs-snapshot': 4.57.3(tslib@2.6.2)
+      glob-to-regex.js: 1.2.0(tslib@2.6.2)
+      thingies: 2.5.0(tslib@2.6.2)
+      tslib: 2.6.2
+
+  '@jsonjoy.com/fs-print@4.57.3(tslib@2.6.2)':
+    dependencies:
+      '@jsonjoy.com/fs-node-utils': 4.57.3(tslib@2.6.2)
+      tree-dump: 1.1.0(tslib@2.6.2)
+      tslib: 2.6.2
+
+  '@jsonjoy.com/fs-snapshot@4.57.3(tslib@2.6.2)':
+    dependencies:
+      '@jsonjoy.com/buffers': 17.67.0(tslib@2.6.2)
+      '@jsonjoy.com/fs-node-utils': 4.57.3(tslib@2.6.2)
+      '@jsonjoy.com/json-pack': 17.67.0(tslib@2.6.2)
+      '@jsonjoy.com/util': 17.67.0(tslib@2.6.2)
       tslib: 2.6.2
 
   '@jsonjoy.com/json-pack@1.21.0(tslib@2.6.2)':
@@ -44569,16 +45190,39 @@ snapshots:
       tree-dump: 1.1.0(tslib@2.6.2)
       tslib: 2.6.2
 
+  '@jsonjoy.com/json-pack@17.67.0(tslib@2.6.2)':
+    dependencies:
+      '@jsonjoy.com/base64': 17.67.0(tslib@2.6.2)
+      '@jsonjoy.com/buffers': 17.67.0(tslib@2.6.2)
+      '@jsonjoy.com/codegen': 17.67.0(tslib@2.6.2)
+      '@jsonjoy.com/json-pointer': 17.67.0(tslib@2.6.2)
+      '@jsonjoy.com/util': 17.67.0(tslib@2.6.2)
+      hyperdyperid: 1.2.0
+      thingies: 2.5.0(tslib@2.6.2)
+      tree-dump: 1.1.0(tslib@2.6.2)
+      tslib: 2.6.2
+
   '@jsonjoy.com/json-pointer@1.0.2(tslib@2.6.2)':
     dependencies:
       '@jsonjoy.com/codegen': 1.0.0(tslib@2.6.2)
       '@jsonjoy.com/util': 1.9.0(tslib@2.6.2)
       tslib: 2.6.2
 
+  '@jsonjoy.com/json-pointer@17.67.0(tslib@2.6.2)':
+    dependencies:
+      '@jsonjoy.com/util': 17.67.0(tslib@2.6.2)
+      tslib: 2.6.2
+
   '@jsonjoy.com/util@1.9.0(tslib@2.6.2)':
     dependencies:
       '@jsonjoy.com/buffers': 1.2.1(tslib@2.6.2)
       '@jsonjoy.com/codegen': 1.0.0(tslib@2.6.2)
+      tslib: 2.6.2
+
+  '@jsonjoy.com/util@17.67.0(tslib@2.6.2)':
+    dependencies:
+      '@jsonjoy.com/buffers': 17.67.0(tslib@2.6.2)
+      '@jsonjoy.com/codegen': 17.67.0(tslib@2.6.2)
       tslib: 2.6.2
 
   '@keplr-wallet/proto-types@0.12.306':
@@ -45243,31 +45887,6 @@ snapshots:
       '@types/react': 19.0.14
       react: 19.0.0
 
-  '@module-federation/error-codes@0.22.0': {}
-
-  '@module-federation/runtime-core@0.22.0':
-    dependencies:
-      '@module-federation/error-codes': 0.22.0
-      '@module-federation/sdk': 0.22.0
-
-  '@module-federation/runtime-tools@0.22.0':
-    dependencies:
-      '@module-federation/runtime': 0.22.0
-      '@module-federation/webpack-bundler-runtime': 0.22.0
-
-  '@module-federation/runtime@0.22.0':
-    dependencies:
-      '@module-federation/error-codes': 0.22.0
-      '@module-federation/runtime-core': 0.22.0
-      '@module-federation/sdk': 0.22.0
-
-  '@module-federation/sdk@0.22.0': {}
-
-  '@module-federation/webpack-bundler-runtime@0.22.0':
-    dependencies:
-      '@module-federation/runtime': 0.22.0
-      '@module-federation/sdk': 0.22.0
-
   '@msgpack/msgpack@3.1.3': {}
 
   '@mswjs/interceptors@0.37.6':
@@ -45404,10 +46023,22 @@ snapshots:
       '@emnapi/runtime': 1.7.1
       '@tybys/wasm-util': 0.9.0
 
-  '@napi-rs/wasm-runtime@1.0.7':
+  '@napi-rs/wasm-runtime@1.1.4':
     dependencies:
-      '@emnapi/core': 1.7.1
-      '@emnapi/runtime': 1.7.1
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -45577,6 +46208,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
+
+  '@nozbe/microfuzz@1.0.0': {}
 
   '@npmcli/fs@1.1.1':
     dependencies:
@@ -46040,6 +46673,133 @@ snapshots:
       - stage-js
       - typescript
       - web-tree-sitter
+
+  '@oxc-parser/binding-android-arm-eabi@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.127.0':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.127.0':
+    optional: true
+
+  '@oxc-project/types@0.127.0': {}
+
+  '@oxc-resolver/binding-android-arm-eabi@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-android-arm64@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-arm64@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-x64@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-freebsd-x64@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-musl@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-openharmony-arm64@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-wasm32-wasi@11.20.0':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.20.0':
+    optional: true
 
   '@oxfmt/binding-android-arm-eabi@0.36.0':
     optional: true
@@ -47289,7 +48049,7 @@ snapshots:
       chalk: 4.1.2
       command-exists: 1.2.9
       deepmerge: 4.3.1
-      envinfo: 7.14.0
+      envinfo: 7.21.0
       execa: 5.1.1
       node-stream-zip: 1.15.0
       ora: 5.4.1
@@ -48596,9 +49356,9 @@ snapshots:
       - tedious
       - utf-8-validate
 
-  '@rozenite/repack@1.2.0(@callstack/repack@5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@1.7.3(@swc/helpers@0.5.17))(@swc/core@1.15.11(@swc/helpers@0.5.17))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)))':
+  '@rozenite/repack@1.2.0(@callstack/repack@5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.0.5(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)))':
     dependencies:
-      '@callstack/repack': 5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@1.7.3(@swc/helpers@0.5.17))(@swc/core@1.15.11(@swc/helpers@0.5.17))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))
+      '@callstack/repack': 5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.0.5(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))
       '@rozenite/middleware': 1.2.0
       '@rozenite/tools': 1.2.0
       semver: 7.7.3
@@ -48612,13 +49372,12 @@ snapshots:
 
   '@rozenite/tools@1.2.0': {}
 
-  '@rsbuild/core@1.7.2':
+  '@rsbuild/core@2.0.9':
     dependencies:
-      '@rspack/core': 1.7.3(@swc/helpers@0.5.18)
-      '@rspack/lite-tapable': 1.1.0
-      '@swc/helpers': 0.5.18
-      core-js: 3.47.0
-      jiti: 2.6.1
+      '@rspack/core': 2.0.5(@swc/helpers@0.5.23)
+      '@swc/helpers': 0.5.23
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
 
   '@rsbuild/plugin-check-syntax@1.6.1':
     dependencies:
@@ -48628,7 +49387,7 @@ snapshots:
       picocolors: 1.1.1
       source-map: 0.7.6
 
-  '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@1.7.2)':
+  '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@2.0.9)':
     dependencies:
       acorn: 8.15.0
       browserslist-to-es-version: 1.4.1
@@ -48636,9 +49395,9 @@ snapshots:
       picocolors: 1.1.1
       source-map: 0.7.6
     optionalDependencies:
-      '@rsbuild/core': 1.7.2
+      '@rsbuild/core': 2.0.9
 
-  '@rsbuild/plugin-node-polyfill@1.4.3(@rsbuild/core@1.7.2)':
+  '@rsbuild/plugin-node-polyfill@1.4.5(@rsbuild/core@2.0.9)':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -48664,205 +49423,211 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 1.7.2
+      '@rsbuild/core': 2.0.9
 
-  '@rsbuild/plugin-react@1.4.3(@rsbuild/core@1.7.2)':
+  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.0.9)':
     dependencies:
-      '@rsbuild/core': 1.7.2
-      '@rspack/plugin-react-refresh': 1.6.0(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.0(react-refresh@0.18.0)
       react-refresh: 0.18.0
-    transitivePeerDependencies:
-      - webpack-hot-middleware
-
-  '@rsbuild/plugin-styled-components@1.6.1(@rsbuild/core@1.7.2)':
-    dependencies:
-      '@swc/plugin-styled-components': 12.3.0
-      reduce-configs: 1.1.1
     optionalDependencies:
-      '@rsbuild/core': 1.7.2
+      '@rsbuild/core': 2.0.9
+    transitivePeerDependencies:
+      - '@rspack/core'
 
-  '@rsbuild/plugin-type-check@1.3.3(@rsbuild/core@1.7.2)(@rspack/core@1.7.3)(typescript@6.0.2)':
+  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)':
+    dependencies:
+      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.5)(react-refresh@0.18.0)
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rsbuild/core': 2.0.9
+    transitivePeerDependencies:
+      - '@rspack/core'
+
+  '@rsbuild/plugin-styled-components@1.6.2(@rsbuild/core@2.0.9)':
+    dependencies:
+      '@swc/plugin-styled-components': 12.12.0
+      reduce-configs: 1.1.2
+    optionalDependencies:
+      '@rsbuild/core': 2.0.9
+
+  '@rsbuild/plugin-type-check@1.3.5(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(typescript@6.0.2)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
-      reduce-configs: 1.1.1
-      ts-checker-rspack-plugin: 1.2.6(@rspack/core@1.7.3)(typescript@6.0.2)
+      reduce-configs: 1.1.2
+      ts-checker-rspack-plugin: 1.3.1(@rspack/core@2.0.5)(typescript@6.0.2)
     optionalDependencies:
-      '@rsbuild/core': 1.7.2
+      '@rsbuild/core': 2.0.9
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-type-check@1.3.3(@rsbuild/core@1.7.2)(typescript@6.0.2)':
+  '@rsbuild/plugin-type-check@1.3.5(@rsbuild/core@2.0.9)(typescript@6.0.2)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
-      reduce-configs: 1.1.1
-      ts-checker-rspack-plugin: 1.2.6(typescript@6.0.2)
+      reduce-configs: 1.1.2
+      ts-checker-rspack-plugin: 1.3.1(typescript@6.0.2)
     optionalDependencies:
-      '@rsbuild/core': 1.7.2
+      '@rsbuild/core': 2.0.9
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsdoctor/client@1.5.2': {}
+  '@rsdoctor/client@2.0.0-alpha.0': {}
 
-  '@rsdoctor/core@1.5.2(@rsbuild/core@1.7.2)(@rspack/core@1.7.3)':
+  '@rsdoctor/core@2.0.0-alpha.0(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)':
     dependencies:
-      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@1.7.2)
-      '@rsdoctor/graph': 1.5.2(@rspack/core@1.7.3)
-      '@rsdoctor/sdk': 1.5.2(@rspack/core@1.7.3)
-      '@rsdoctor/types': 1.5.2(@rspack/core@1.7.3)
-      '@rsdoctor/utils': 1.5.2(@rspack/core@1.7.3)
+      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.0.9)
+      '@rsdoctor/graph': 2.0.0-alpha.0(@rspack/core@2.0.5)
+      '@rsdoctor/sdk': 2.0.0-alpha.0(@rspack/core@2.0.5)
+      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.0.5)
+      '@rsdoctor/utils': 2.0.0-alpha.0(@rspack/core@2.0.5)
+      '@rspack/resolver': 0.2.8
       browserslist-load-config: 1.0.1
-      enhanced-resolve: 5.12.0
-      es-toolkit: 1.44.0
-      filesize: 10.1.6
+      es-toolkit: 1.47.0
+      filesize: 11.0.17
       fs-extra: 11.3.3
-      semver: 7.7.3
+      semver: 7.8.1
       source-map: 0.7.6
     transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
       - '@rsbuild/core'
       - '@rspack/core'
       - bufferutil
-      - supports-color
       - utf-8-validate
-      - webpack
 
-  '@rsdoctor/core@1.5.2(@rspack/core@1.7.3(@swc/helpers@0.5.17))':
+  '@rsdoctor/core@2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))':
     dependencies:
       '@rsbuild/plugin-check-syntax': 1.6.1
-      '@rsdoctor/graph': 1.5.2(@rspack/core@1.7.3(@swc/helpers@0.5.17))
-      '@rsdoctor/sdk': 1.5.2(@rspack/core@1.7.3(@swc/helpers@0.5.17))
-      '@rsdoctor/types': 1.5.2(@rspack/core@1.7.3(@swc/helpers@0.5.17))
-      '@rsdoctor/utils': 1.5.2(@rspack/core@1.7.3(@swc/helpers@0.5.17))
+      '@rsdoctor/graph': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
+      '@rsdoctor/sdk': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
+      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
+      '@rsdoctor/utils': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
+      '@rspack/resolver': 0.2.8
       browserslist-load-config: 1.0.1
-      enhanced-resolve: 5.12.0
-      es-toolkit: 1.44.0
-      filesize: 10.1.6
+      es-toolkit: 1.47.0
+      filesize: 11.0.17
       fs-extra: 11.3.3
-      semver: 7.7.3
+      semver: 7.8.1
       source-map: 0.7.6
     transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
       - '@rsbuild/core'
       - '@rspack/core'
       - bufferutil
-      - supports-color
       - utf-8-validate
-      - webpack
 
-  '@rsdoctor/graph@1.5.2(@rspack/core@1.7.3(@swc/helpers@0.5.17))':
+  '@rsdoctor/graph@2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))':
     dependencies:
-      '@rsdoctor/types': 1.5.2(@rspack/core@1.7.3(@swc/helpers@0.5.17))
-      '@rsdoctor/utils': 1.5.2(@rspack/core@1.7.3(@swc/helpers@0.5.17))
-      es-toolkit: 1.44.0
+      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
+      '@rsdoctor/utils': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
+      es-toolkit: 1.47.0
       path-browserify: 1.0.1
       source-map: 0.7.6
     transitivePeerDependencies:
       - '@rspack/core'
-      - webpack
 
-  '@rsdoctor/graph@1.5.2(@rspack/core@1.7.3)':
+  '@rsdoctor/graph@2.0.0-alpha.0(@rspack/core@2.0.5)':
     dependencies:
-      '@rsdoctor/types': 1.5.2(@rspack/core@1.7.3)
-      '@rsdoctor/utils': 1.5.2(@rspack/core@1.7.3)
-      es-toolkit: 1.44.0
+      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.0.5)
+      '@rsdoctor/utils': 2.0.0-alpha.0(@rspack/core@2.0.5)
+      es-toolkit: 1.47.0
       path-browserify: 1.0.1
       source-map: 0.7.6
     transitivePeerDependencies:
       - '@rspack/core'
-      - webpack
 
-  '@rsdoctor/rspack-plugin@1.5.2(@rsbuild/core@1.7.2)(@rspack/core@1.7.3)':
+  '@rsdoctor/rspack-plugin@2.0.0-alpha.0(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)':
     dependencies:
-      '@rsdoctor/core': 1.5.2(@rsbuild/core@1.7.2)(@rspack/core@1.7.3)
-      '@rsdoctor/graph': 1.5.2(@rspack/core@1.7.3)
-      '@rsdoctor/sdk': 1.5.2(@rspack/core@1.7.3)
-      '@rsdoctor/types': 1.5.2(@rspack/core@1.7.3)
-      '@rsdoctor/utils': 1.5.2(@rspack/core@1.7.3)
+      '@rsdoctor/core': 2.0.0-alpha.0(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)
+      '@rsdoctor/graph': 2.0.0-alpha.0(@rspack/core@2.0.5)
+      '@rsdoctor/sdk': 2.0.0-alpha.0(@rspack/core@2.0.5)
+      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.0.5)
+      '@rsdoctor/utils': 2.0.0-alpha.0(@rspack/core@2.0.5)
     optionalDependencies:
-      '@rspack/core': 1.7.3
+      '@rspack/core': 2.0.5
     transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
       - '@rsbuild/core'
       - bufferutil
-      - supports-color
       - utf-8-validate
-      - webpack
 
-  '@rsdoctor/rspack-plugin@1.5.2(@rspack/core@1.7.3(@swc/helpers@0.5.17))':
+  '@rsdoctor/rspack-plugin@2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))':
     dependencies:
-      '@rsdoctor/core': 1.5.2(@rspack/core@1.7.3(@swc/helpers@0.5.17))
-      '@rsdoctor/graph': 1.5.2(@rspack/core@1.7.3(@swc/helpers@0.5.17))
-      '@rsdoctor/sdk': 1.5.2(@rspack/core@1.7.3(@swc/helpers@0.5.17))
-      '@rsdoctor/types': 1.5.2(@rspack/core@1.7.3(@swc/helpers@0.5.17))
-      '@rsdoctor/utils': 1.5.2(@rspack/core@1.7.3(@swc/helpers@0.5.17))
+      '@rsdoctor/core': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
+      '@rsdoctor/graph': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
+      '@rsdoctor/sdk': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
+      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
+      '@rsdoctor/utils': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
     optionalDependencies:
-      '@rspack/core': 1.7.3(@swc/helpers@0.5.17)
+      '@rspack/core': 2.0.5(@swc/helpers@0.5.23)
     transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
       - '@rsbuild/core'
       - bufferutil
-      - supports-color
       - utf-8-validate
-      - webpack
 
-  '@rsdoctor/sdk@1.5.2(@rspack/core@1.7.3(@swc/helpers@0.5.17))':
+  '@rsdoctor/sdk@2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))':
     dependencies:
-      '@rsdoctor/client': 1.5.2
-      '@rsdoctor/graph': 1.5.2(@rspack/core@1.7.3(@swc/helpers@0.5.17))
-      '@rsdoctor/types': 1.5.2(@rspack/core@1.7.3(@swc/helpers@0.5.17))
-      '@rsdoctor/utils': 1.5.2(@rspack/core@1.7.3(@swc/helpers@0.5.17))
+      '@rsdoctor/client': 2.0.0-alpha.0
+      '@rsdoctor/graph': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
+      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
+      '@rsdoctor/utils': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
+      launch-editor: 2.14.0
       safer-buffer: 2.1.2
-      socket.io: 4.8.1
-      tapable: 2.2.3
+      tapable: 2.3.3
+      ws: 8.20.1
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
-      - supports-color
       - utf-8-validate
-      - webpack
 
-  '@rsdoctor/sdk@1.5.2(@rspack/core@1.7.3)':
+  '@rsdoctor/sdk@2.0.0-alpha.0(@rspack/core@2.0.5)':
     dependencies:
-      '@rsdoctor/client': 1.5.2
-      '@rsdoctor/graph': 1.5.2(@rspack/core@1.7.3)
-      '@rsdoctor/types': 1.5.2(@rspack/core@1.7.3)
-      '@rsdoctor/utils': 1.5.2(@rspack/core@1.7.3)
+      '@rsdoctor/client': 2.0.0-alpha.0
+      '@rsdoctor/graph': 2.0.0-alpha.0(@rspack/core@2.0.5)
+      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.0.5)
+      '@rsdoctor/utils': 2.0.0-alpha.0(@rspack/core@2.0.5)
+      launch-editor: 2.14.0
       safer-buffer: 2.1.2
-      socket.io: 4.8.1
-      tapable: 2.2.3
+      tapable: 2.3.3
+      ws: 8.20.1
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
-      - supports-color
       - utf-8-validate
-      - webpack
 
-  '@rsdoctor/types@1.5.2(@rspack/core@1.7.3(@swc/helpers@0.5.17))':
+  '@rsdoctor/types@2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))':
     dependencies:
       '@types/connect': 3.4.38
       '@types/estree': 1.0.5
-      '@types/tapable': 2.2.7
+      '@types/tapable': 2.3.0
       source-map: 0.7.6
     optionalDependencies:
-      '@rspack/core': 1.7.3(@swc/helpers@0.5.17)
+      '@rspack/core': 2.0.5(@swc/helpers@0.5.23)
 
-  '@rsdoctor/types@1.5.2(@rspack/core@1.7.3)':
+  '@rsdoctor/types@2.0.0-alpha.0(@rspack/core@2.0.5)':
     dependencies:
       '@types/connect': 3.4.38
       '@types/estree': 1.0.5
-      '@types/tapable': 2.2.7
+      '@types/tapable': 2.3.0
       source-map: 0.7.6
     optionalDependencies:
-      '@rspack/core': 1.7.3
+      '@rspack/core': 2.0.5
 
-  '@rsdoctor/utils@1.5.2(@rspack/core@1.7.3(@swc/helpers@0.5.17))':
+  '@rsdoctor/utils@2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@rsdoctor/types': 1.5.2(@rspack/core@1.7.3(@swc/helpers@0.5.17))
+      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
       '@types/estree': 1.0.5
       acorn: 8.15.0
       acorn-import-attributes: 1.9.5(acorn@8.15.0)
-      acorn-walk: 8.3.4
+      acorn-walk: 8.3.5
       deep-eql: 4.1.4
       envinfo: 7.21.0
       fs-extra: 11.3.3
@@ -48870,20 +49635,19 @@ snapshots:
       json-stream-stringify: 3.0.1
       lines-and-columns: 2.0.4
       picocolors: 1.1.1
-      rslog: 1.3.2
+      rslog: 2.1.2
       strip-ansi: 6.0.1
     transitivePeerDependencies:
       - '@rspack/core'
-      - webpack
 
-  '@rsdoctor/utils@1.5.2(@rspack/core@1.7.3)':
+  '@rsdoctor/utils@2.0.0-alpha.0(@rspack/core@2.0.5)':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@rsdoctor/types': 1.5.2(@rspack/core@1.7.3)
+      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.0.5)
       '@types/estree': 1.0.5
       acorn: 8.15.0
       acorn-import-attributes: 1.9.5(acorn@8.15.0)
-      acorn-walk: 8.3.4
+      acorn-walk: 8.3.5
       deep-eql: 4.1.4
       envinfo: 7.21.0
       fs-extra: 11.3.3
@@ -48891,118 +49655,97 @@ snapshots:
       json-stream-stringify: 3.0.1
       lines-and-columns: 2.0.4
       picocolors: 1.1.1
-      rslog: 1.3.2
+      rslog: 2.1.2
       strip-ansi: 6.0.1
     transitivePeerDependencies:
       - '@rspack/core'
-      - webpack
 
-  '@rslib/core@0.19.3(typescript@6.0.2)':
+  '@rslib/core@0.22.0(typescript@6.0.2)':
     dependencies:
-      '@rsbuild/core': 1.7.2
-      rsbuild-plugin-dts: 0.19.3(@rsbuild/core@1.7.2)(typescript@6.0.2)
+      '@rsbuild/core': 2.0.9
+      rsbuild-plugin-dts: 0.22.0(@rsbuild/core@2.0.9)(typescript@6.0.2)
     optionalDependencies:
       typescript: 6.0.2
     transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - '@typescript/native-preview'
+      - core-js
 
-  '@rspack/binding-darwin-arm64@1.7.3':
+  '@rspack/binding-darwin-arm64@2.0.5':
     optional: true
 
-  '@rspack/binding-darwin-x64@1.7.3':
+  '@rspack/binding-darwin-x64@2.0.5':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@1.7.3':
+  '@rspack/binding-linux-arm64-gnu@2.0.5':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@1.7.3':
+  '@rspack/binding-linux-arm64-musl@2.0.5':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@1.7.3':
+  '@rspack/binding-linux-x64-gnu@2.0.5':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@1.7.3':
+  '@rspack/binding-linux-x64-musl@2.0.5':
     optional: true
 
-  '@rspack/binding-wasm32-wasi@1.7.3':
+  '@rspack/binding-wasm32-wasi@2.0.5':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.0.7
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@1.7.3':
+  '@rspack/binding-win32-arm64-msvc@2.0.5':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@1.7.3':
+  '@rspack/binding-win32-ia32-msvc@2.0.5':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@1.7.3':
+  '@rspack/binding-win32-x64-msvc@2.0.5':
     optional: true
 
-  '@rspack/binding@1.7.3':
+  '@rspack/binding@2.0.5':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.7.3
-      '@rspack/binding-darwin-x64': 1.7.3
-      '@rspack/binding-linux-arm64-gnu': 1.7.3
-      '@rspack/binding-linux-arm64-musl': 1.7.3
-      '@rspack/binding-linux-x64-gnu': 1.7.3
-      '@rspack/binding-linux-x64-musl': 1.7.3
-      '@rspack/binding-wasm32-wasi': 1.7.3
-      '@rspack/binding-win32-arm64-msvc': 1.7.3
-      '@rspack/binding-win32-ia32-msvc': 1.7.3
-      '@rspack/binding-win32-x64-msvc': 1.7.3
+      '@rspack/binding-darwin-arm64': 2.0.5
+      '@rspack/binding-darwin-x64': 2.0.5
+      '@rspack/binding-linux-arm64-gnu': 2.0.5
+      '@rspack/binding-linux-arm64-musl': 2.0.5
+      '@rspack/binding-linux-x64-gnu': 2.0.5
+      '@rspack/binding-linux-x64-musl': 2.0.5
+      '@rspack/binding-wasm32-wasi': 2.0.5
+      '@rspack/binding-win32-arm64-msvc': 2.0.5
+      '@rspack/binding-win32-ia32-msvc': 2.0.5
+      '@rspack/binding-win32-x64-msvc': 2.0.5
 
-  '@rspack/cli@1.7.3(@rspack/core@1.7.3)':
+  '@rspack/cli@2.0.5(@rspack/core@2.0.5)':
     dependencies:
-      '@discoveryjs/json-ext': 0.5.7
-      '@rspack/core': 1.7.3
-      '@rspack/dev-server': 1.1.5(@rspack/core@1.7.3)
-      exit-hook: 4.0.0
-      webpack-bundle-analyzer: 4.10.2
-    transitivePeerDependencies:
-      - '@types/express'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - webpack
-      - webpack-cli
+      '@rspack/core': 2.0.5
 
-  '@rspack/core@1.7.3':
+  '@rspack/cli@2.0.5(@rspack/core@2.0.5)(@rspack/dev-server@2.0.3(@rspack/core@2.0.5))':
     dependencies:
-      '@module-federation/runtime-tools': 0.22.0
-      '@rspack/binding': 1.7.3
-      '@rspack/lite-tapable': 1.1.0
-
-  '@rspack/core@1.7.3(@swc/helpers@0.5.17)':
-    dependencies:
-      '@module-federation/runtime-tools': 0.22.0
-      '@rspack/binding': 1.7.3
-      '@rspack/lite-tapable': 1.1.0
+      '@rspack/core': 2.0.5
     optionalDependencies:
-      '@swc/helpers': 0.5.17
+      '@rspack/dev-server': 2.0.3(@rspack/core@2.0.5)
 
-  '@rspack/core@1.7.3(@swc/helpers@0.5.18)':
+  '@rspack/core@2.0.5':
     dependencies:
-      '@module-federation/runtime-tools': 0.22.0
-      '@rspack/binding': 1.7.3
-      '@rspack/lite-tapable': 1.1.0
+      '@rspack/binding': 2.0.5
+
+  '@rspack/core@2.0.5(@swc/helpers@0.5.23)':
+    dependencies:
+      '@rspack/binding': 2.0.5
     optionalDependencies:
-      '@swc/helpers': 0.5.18
+      '@swc/helpers': 0.5.23
 
-  '@rspack/dev-server@1.1.5(@rspack/core@1.7.3)':
+  '@rspack/dev-middleware@2.0.2(@rspack/core@2.0.5)':
+    optionalDependencies:
+      '@rspack/core': 2.0.5
+
+  '@rspack/dev-server@2.0.3(@rspack/core@2.0.5)':
     dependencies:
-      '@rspack/core': 1.7.3
-      chokidar: 3.6.0
-      http-proxy-middleware: 2.0.9
-      p-retry: 6.2.0
-      webpack-dev-server: 5.2.2
-      ws: 8.18.3
-    transitivePeerDependencies:
-      - '@types/express'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - webpack
-      - webpack-cli
+      '@rspack/core': 2.0.5
+      '@rspack/dev-middleware': 2.0.2(@rspack/core@2.0.5)
 
   '@rspack/lite-tapable@1.1.0': {}
 
@@ -49013,11 +49756,72 @@ snapshots:
     optionalDependencies:
       react-refresh: 0.14.2
 
-  '@rspack/plugin-react-refresh@1.6.0(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.5)(react-refresh@0.18.0)':
     dependencies:
-      error-stack-parser: 2.1.4
-      html-entities: 2.6.0
       react-refresh: 0.18.0
+    optionalDependencies:
+      '@rspack/core': 2.0.5
+
+  '@rspack/plugin-react-refresh@2.0.0(react-refresh@0.18.0)':
+    dependencies:
+      react-refresh: 0.18.0
+
+  '@rspack/plugin-react-refresh@2.0.1(@rspack/core@2.0.5)(react-refresh@0.18.0)':
+    dependencies:
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rspack/core': 2.0.5
+
+  '@rspack/resolver-binding-darwin-arm64@0.2.8':
+    optional: true
+
+  '@rspack/resolver-binding-darwin-x64@0.2.8':
+    optional: true
+
+  '@rspack/resolver-binding-linux-arm64-gnu@0.2.8':
+    optional: true
+
+  '@rspack/resolver-binding-linux-arm64-musl@0.2.8':
+    optional: true
+
+  '@rspack/resolver-binding-linux-x64-gnu@0.2.8':
+    optional: true
+
+  '@rspack/resolver-binding-linux-x64-musl@0.2.8':
+    optional: true
+
+  '@rspack/resolver-binding-wasm32-wasi@0.2.8':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.4
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
+  '@rspack/resolver-binding-win32-arm64-msvc@0.2.8':
+    optional: true
+
+  '@rspack/resolver-binding-win32-ia32-msvc@0.2.8':
+    optional: true
+
+  '@rspack/resolver-binding-win32-x64-msvc@0.2.8':
+    optional: true
+
+  '@rspack/resolver@0.2.8':
+    optionalDependencies:
+      '@rspack/resolver-binding-darwin-arm64': 0.2.8
+      '@rspack/resolver-binding-darwin-x64': 0.2.8
+      '@rspack/resolver-binding-linux-arm64-gnu': 0.2.8
+      '@rspack/resolver-binding-linux-arm64-musl': 0.2.8
+      '@rspack/resolver-binding-linux-x64-gnu': 0.2.8
+      '@rspack/resolver-binding-linux-x64-musl': 0.2.8
+      '@rspack/resolver-binding-wasm32-wasi': 0.2.8
+      '@rspack/resolver-binding-win32-arm64-msvc': 0.2.8
+      '@rspack/resolver-binding-win32-ia32-msvc': 0.2.8
+      '@rspack/resolver-binding-win32-x64-msvc': 0.2.8
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
   '@rtsao/scc@1.1.0': {}
 
@@ -50300,8 +51104,6 @@ snapshots:
       ignore: 5.3.1
       p-map: 4.0.0
 
-  '@socket.io/component-emitter@3.1.2': {}
-
   '@soda/friendly-errors-webpack-plugin@1.8.1(webpack@5.94.0(@swc/core@1.15.11))':
     dependencies:
       chalk: 3.0.0
@@ -51244,71 +52046,77 @@ snapshots:
       toml: 3.0.0
       urijs: 1.19.11
 
-  '@storybook/addon-docs@10.2.0(@types/react@19.0.14)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
+  '@storybook/addon-docs@10.4.1(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
     dependencies:
       '@mdx-js/react': 3.1.0(@types/react@19.0.14)(react@19.0.0)
-      '@storybook/csf-plugin': 10.2.0(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
-      '@storybook/icons': 2.0.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@storybook/react-dom-shim': 10.2.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+      '@storybook/csf-plugin': 10.4.1(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+      '@storybook/icons': 2.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@storybook/react-dom-shim': 10.4.1(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      storybook: 10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       ts-dedent: 2.2.0
+    optionalDependencies:
+      '@types/react': 19.0.14
     transitivePeerDependencies:
-      - '@types/react'
+      - '@types/react-dom'
       - esbuild
       - rollup
       - vite
       - webpack
 
-  '@storybook/addon-links@10.2.0(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
+  '@storybook/addon-links@10.4.1(@types/react@19.0.14)(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
     optionalDependencies:
+      '@types/react': 19.0.14
       react: 19.0.0
 
-  '@storybook/addon-ondevice-actions@10.1.11(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
+  '@storybook/addon-ondevice-actions@10.4.4(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
     dependencies:
+      '@storybook/react-native-theming': 10.4.4(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
       fast-deep-equal: 3.1.3
       react: 19.0.0
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0)
-      storybook: 10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
 
-  '@storybook/addon-ondevice-backgrounds@10.1.11(@emotion/native@11.11.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
+  '@storybook/addon-ondevice-backgrounds@10.4.4(@emotion/native@11.11.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
     dependencies:
-      '@storybook/react-native-theming': 10.1.11(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
+      '@storybook/react-native-theming': 10.4.4(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0)
-      storybook: 10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
     optionalDependencies:
       '@emotion/native': 11.11.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
 
-  '@storybook/addon-ondevice-controls@10.1.11(@react-native-community/datetimepicker@6.7.5)(@react-native-community/slider@4.5.7)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)':
+  '@storybook/addon-ondevice-controls@10.4.4(@react-native-community/datetimepicker@6.7.5)(@react-native-community/slider@4.5.7)(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)':
     dependencies:
       '@gorhom/portal': 1.0.14(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
       '@react-native-community/datetimepicker': 6.7.5
       '@react-native-community/slider': 4.5.7
-      '@storybook/react-native-theming': 10.1.11(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
-      '@storybook/react-native-ui-common': 10.1.11(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
+      '@storybook/react-native-theming': 10.4.4(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
+      '@storybook/react-native-ui-common': 10.4.4(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
       polished: 4.3.1
       react: 19.0.0
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0)
       react-native-modal-datetime-picker: 18.0.0(@react-native-community/datetimepicker@6.7.5)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))
-      storybook: 10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       tinycolor2: 1.6.0
     transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
       - react-dom
       - supports-color
       - typescript
 
-  '@storybook/addon-ondevice-notes@10.1.11(@storybook/react@10.2.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
+  '@storybook/addon-ondevice-notes@10.4.4(@storybook/react@10.4.1(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
     dependencies:
-      '@storybook/react': 10.2.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
-      '@storybook/react-native-theming': 10.1.11(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
+      '@storybook/react': 10.4.1(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
+      '@storybook/react-native-theming': 10.4.4(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0)
-      storybook: 10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
 
   '@storybook/addon-react-native-web@0.0.29(@react-native/babel-preset@0.79.7(@babel/core@7.28.5))(babel-plugin-react-native-web@0.19.10)(metro-react-native-babel-preset@0.77.0(@babel/core@7.28.5))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
@@ -51319,9 +52127,9 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
-  '@storybook/csf-plugin@10.2.0(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
+  '@storybook/csf-plugin@10.4.1(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
     dependencies:
-      storybook: 10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       unplugin: 2.3.11
 
   '@storybook/expect@28.1.3-5':
@@ -51330,16 +52138,16 @@ snapshots:
 
   '@storybook/global@5.0.0': {}
 
-  '@storybook/icons@2.0.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@storybook/icons@2.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
-  '@storybook/instrumenter@8.6.15(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
+  '@storybook/instrumenter@8.6.15(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
     dependencies:
       '@storybook/global': 5.0.0
       '@vitest/utils': 2.1.9
-      storybook: 10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
 
   '@storybook/jest@0.2.3':
     dependencies:
@@ -51347,6 +52155,16 @@ snapshots:
       '@testing-library/jest-dom': 6.9.1
       '@types/jest': 28.1.3
       jest-mock: 27.5.1
+
+  '@storybook/mcp@0.7.0(typescript@6.0.2)':
+    dependencies:
+      '@tmcp/adapter-valibot': 0.1.6(tmcp@1.19.4(typescript@6.0.2))(typescript@6.0.2)
+      '@tmcp/transport-http': 0.8.6(tmcp@1.19.4(typescript@6.0.2))
+      tmcp: 1.19.4(typescript@6.0.2)
+      valibot: 1.2.0(typescript@6.0.2)
+    transitivePeerDependencies:
+      - '@tmcp/auth'
+      - typescript
 
   '@storybook/react-docgen-typescript-plugin@1.0.1(typescript@6.0.2)':
     dependencies:
@@ -51361,73 +52179,97 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/react-dom-shim@10.2.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
+  '@storybook/react-dom-shim@10.4.1(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
     dependencies:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      storybook: 10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.14
+      '@types/react-dom': 19.0.0(@types/react@19.0.14)
 
-  '@storybook/react-native-theming@10.1.11(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)':
+  '@storybook/react-dom-shim@10.4.1(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
+    dependencies:
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.14
+
+  '@storybook/react-native-theming@10.4.4(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)':
     dependencies:
       polished: 4.3.1
       react: 19.0.0
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0)
 
-  '@storybook/react-native-ui-common@10.1.11(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)':
+  '@storybook/react-native-ui-common@10.4.4(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)':
     dependencies:
-      '@storybook/react': 10.2.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
-      '@storybook/react-native-theming': 10.1.11(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
-      es-toolkit: 1.44.0
-      fuse.js: 7.1.0
+      '@nozbe/microfuzz': 1.0.0
+      '@storybook/react': 10.4.1(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
+      '@storybook/react-native-theming': 10.4.4(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
+      es-toolkit: 1.47.0
       memoizerific: 1.11.3
       react: 19.0.0
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0)
-      storybook: 10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
       - react-dom
       - supports-color
       - typescript
 
-  '@storybook/react-native-ui@10.1.11(4e06fedd534340d0c70a53aab4171e9a)':
+  '@storybook/react-native-ui@10.4.4(4456eb5993e2623de263be6daf0d0865)':
     dependencies:
       '@gorhom/portal': 1.0.14(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
-      '@storybook/react': 10.2.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
-      '@storybook/react-native-theming': 10.1.11(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
-      '@storybook/react-native-ui-common': 10.1.11(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
-      fuse.js: 7.1.0
+      '@nozbe/microfuzz': 1.0.0
+      '@storybook/react': 10.4.1(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
+      '@storybook/react-native-theming': 10.4.4(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
+      '@storybook/react-native-ui-common': 10.4.4(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
       polished: 4.3.1
       react: 19.0.0
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0)
       react-native-reanimated: 4.1.6(@babel/core@7.28.5)(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
       react-native-safe-area-context: 5.6.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
       react-native-svg: 15.15.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
-      storybook: 10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
     transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
       - react-dom
       - supports-color
       - typescript
 
-  '@storybook/react-native@10.1.11(4e06fedd534340d0c70a53aab4171e9a)':
+  '@storybook/react-native@10.4.4(4456eb5993e2623de263be6daf0d0865)':
     dependencies:
-      '@storybook/react': 10.2.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
-      '@storybook/react-native-theming': 10.1.11(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
-      '@storybook/react-native-ui': 10.1.11(4e06fedd534340d0c70a53aab4171e9a)
-      '@storybook/react-native-ui-common': 10.1.11(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
+      '@storybook/mcp': 0.7.0(typescript@6.0.2)
+      '@storybook/react': 10.4.1(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
+      '@storybook/react-native-theming': 10.4.4(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
+      '@storybook/react-native-ui': 10.4.4(4456eb5993e2623de263be6daf0d0865)
+      '@storybook/react-native-ui-common': 10.4.4(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
+      '@tmcp/adapter-valibot': 0.1.6(tmcp@1.19.4(typescript@6.0.2))(typescript@6.0.2)
+      '@tmcp/transport-http': 0.8.6(tmcp@1.19.4(typescript@6.0.2))
       commander: 14.0.2
-      dedent: 1.7.0
+      dedent: 1.7.2
       deepmerge: 4.3.1
       esbuild-register: 3.6.0
+      glob: 13.0.6
       react: 19.0.0
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0)
+      react-native-safe-area-context: 5.6.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
       react-native-url-polyfill: 3.0.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))
       setimmediate: 1.0.5
-      storybook: 10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      ws: 8.18.3
+      storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      tmcp: 1.19.4(typescript@6.0.2)
+      valibot: 1.4.1(typescript@6.0.2)
+      ws: 8.21.0
     optionalDependencies:
       react-native-reanimated: 4.1.6(@babel/core@7.28.5)(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
-      react-native-safe-area-context: 5.6.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
     transitivePeerDependencies:
+      - '@tmcp/auth'
+      - '@types/react'
+      - '@types/react-dom'
       - babel-plugin-macros
       - bufferutil
       - esbuild
@@ -51437,29 +52279,47 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@storybook/react@10.2.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)':
+  '@storybook/react@10.4.1(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.2.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+      '@storybook/react-dom-shim': 10.4.1(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       react: 19.0.0
       react-docgen: 8.0.2
+      react-docgen-typescript: 2.4.0(typescript@6.0.2)
       react-dom: 19.0.0(react@19.0.0)
-      storybook: 10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
     optionalDependencies:
+      '@types/react': 19.0.14
+      '@types/react-dom': 19.0.0(@types/react@19.0.14)
       typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/test@8.6.15(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
+  '@storybook/react@10.4.1(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/instrumenter': 8.6.15(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+      '@storybook/react-dom-shim': 10.4.1(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+      react: 19.0.0
+      react-docgen: 8.0.2
+      react-docgen-typescript: 2.4.0(typescript@6.0.2)
+      react-dom: 19.0.0(react@19.0.0)
+      storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.14
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@storybook/test@8.6.15(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/instrumenter': 8.6.15(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@testing-library/dom': 10.4.0
       '@testing-library/jest-dom': 6.5.0
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
       '@vitest/expect': 2.0.5
       '@vitest/spy': 2.0.5
-      storybook: 10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
 
   '@storybook/testing-library@0.2.2':
     dependencies:
@@ -51684,7 +52544,7 @@ snapshots:
       '@swc/core-win32-ia32-msvc': 1.15.11
       '@swc/core-win32-x64-msvc': 1.15.11
 
-  '@swc/core@1.15.11(@swc/helpers@0.5.17)':
+  '@swc/core@1.15.11(@swc/helpers@0.5.23)':
     dependencies:
       '@swc/counter': 0.1.3
       '@swc/types': 0.1.25
@@ -51699,22 +52559,22 @@ snapshots:
       '@swc/core-win32-arm64-msvc': 1.15.11
       '@swc/core-win32-ia32-msvc': 1.15.11
       '@swc/core-win32-x64-msvc': 1.15.11
-      '@swc/helpers': 0.5.17
+      '@swc/helpers': 0.5.23
 
   '@swc/counter@0.1.3': {}
-
-  '@swc/helpers@0.5.17':
-    dependencies:
-      tslib: 2.6.2
 
   '@swc/helpers@0.5.18':
     dependencies:
       tslib: 2.6.2
 
-  '@swc/jest@0.2.39(@swc/core@1.15.11(@swc/helpers@0.5.17))':
+  '@swc/helpers@0.5.23':
+    dependencies:
+      tslib: 2.6.2
+
+  '@swc/jest@0.2.39(@swc/core@1.15.11(@swc/helpers@0.5.23))':
     dependencies:
       '@jest/create-cache-key-function': 30.2.0
-      '@swc/core': 1.15.11(@swc/helpers@0.5.17)
+      '@swc/core': 1.15.11(@swc/helpers@0.5.23)
       '@swc/counter': 0.1.3
       jsonc-parser: 3.2.1
 
@@ -51725,7 +52585,7 @@ snapshots:
       '@swc/counter': 0.1.3
       jsonc-parser: 3.2.1
 
-  '@swc/plugin-styled-components@12.3.0':
+  '@swc/plugin-styled-components@12.12.0':
     dependencies:
       '@swc/counter': 0.1.3
 
@@ -52006,7 +52866,7 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react-native@13.3.3(patch_hash=4f93e75372e62b6dc0f0b2635b62a322b37a3727637bd94a38df1ed8648e2e76)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2)))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react-test-renderer@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@testing-library/react-native@13.3.3(patch_hash=4f93e75372e62b6dc0f0b2635b62a322b37a3727637bd94a38df1ed8648e2e76)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2)))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react-test-renderer@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       jest-matcher-utils: 30.2.0
       picocolors: 1.1.1
@@ -52016,7 +52876,7 @@ snapshots:
       react-test-renderer: 19.0.0(react@19.0.0)
       redent: 3.0.0
     optionalDependencies:
-      jest: 30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2))
+      jest: 30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2))
 
   '@testing-library/react-native@13.3.3(patch_hash=4f93e75372e62b6dc0f0b2635b62a322b37a3727637bd94a38df1ed8648e2e76)(jest@30.2.0(@types/node@24.12.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react-test-renderer@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
@@ -52094,6 +52954,25 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       tippy.js: 6.3.7
+
+  '@tmcp/adapter-valibot@0.1.6(tmcp@1.19.4(typescript@6.0.2))(typescript@6.0.2)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@valibot/to-json-schema': 1.5.0(valibot@1.4.1(typescript@6.0.2))
+      tmcp: 1.19.4(typescript@6.0.2)
+      valibot: 1.4.1(typescript@6.0.2)
+    transitivePeerDependencies:
+      - typescript
+
+  '@tmcp/session-manager@0.2.2(tmcp@1.19.4(typescript@6.0.2))':
+    dependencies:
+      tmcp: 1.19.4(typescript@6.0.2)
+
+  '@tmcp/transport-http@0.8.6(tmcp@1.19.4(typescript@6.0.2))':
+    dependencies:
+      '@tmcp/session-manager': 0.2.2(tmcp@1.19.4(typescript@6.0.2))
+      esm-env: 1.2.2
+      tmcp: 1.19.4(typescript@6.0.2)
 
   '@tokenizer/token@0.3.0': {}
 
@@ -52849,9 +53728,9 @@ snapshots:
 
   '@types/supports-color@8.1.3': {}
 
-  '@types/tapable@2.2.7':
+  '@types/tapable@2.3.0':
     dependencies:
-      tapable: 2.2.3
+      tapable: 2.3.3
 
   '@types/tern@0.23.9':
     dependencies:
@@ -52895,10 +53774,6 @@ snapshots:
       '@types/node': 24.12.0
 
   '@types/ws@7.4.7':
-    dependencies:
-      '@types/node': 24.12.0
-
-  '@types/ws@8.18.1':
     dependencies:
       '@types/node': 24.12.0
 
@@ -53197,6 +54072,10 @@ snapshots:
   '@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@6.0.2))':
     dependencies:
       valibot: 1.2.0(typescript@6.0.2)
+
+  '@valibot/to-json-schema@1.5.0(valibot@1.4.1(typescript@6.0.2))':
+    dependencies:
+      valibot: 1.4.1(typescript@6.0.2)
 
   '@vechain/sdk-core@2.0.0(typescript@6.0.2)':
     dependencies:
@@ -54012,6 +54891,8 @@ snapshots:
       '@webassemblyjs/ast': 1.12.1
       '@xtuc/long': 4.2.2
 
+  '@webcontainer/env@1.1.1': {}
+
   '@webgpu/types@0.1.69':
     optional: true
 
@@ -54029,10 +54910,10 @@ snapshots:
       detox: 20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(@jest/types@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(typescript@6.0.2)))
       expect: 30.2.0
 
-  '@wix-pilot/detox@1.0.13(@wix-pilot/core@3.4.2(expect@30.2.0))(detox@20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2))))(expect@30.2.0)':
+  '@wix-pilot/detox@1.0.13(@wix-pilot/core@3.4.2(expect@30.2.0))(detox@20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2))))(expect@30.2.0)':
     dependencies:
       '@wix-pilot/core': 3.4.2(expect@30.2.0)
-      detox: 20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2)))
+      detox: 20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2)))
       expect: 30.2.0
 
   '@wry/caches@1.0.1':
@@ -54309,6 +55190,10 @@ snapshots:
       acorn: 8.15.0
 
   acorn-walk@8.3.4:
+    dependencies:
+      acorn: 8.15.0
+
+  acorn-walk@8.3.5:
     dependencies:
       acorn: 8.15.0
 
@@ -55245,6 +56130,8 @@ snapshots:
 
   balanced-match@2.0.0: {}
 
+  balanced-match@4.0.4: {}
+
   bare-events@2.4.2:
     optional: true
 
@@ -55539,6 +56426,10 @@ snapshots:
   brace-expansion@2.0.1:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -56045,7 +56936,7 @@ snapshots:
     dependencies:
       assertion-error: 1.1.0
       check-error: 1.0.3
-      deep-eql: 4.1.3
+      deep-eql: 4.1.4
       get-func-name: 2.0.2
       loupe: 2.3.7
       pathval: 1.1.1
@@ -56056,7 +56947,7 @@ snapshots:
       assertion-error: 2.0.1
       check-error: 2.1.1
       deep-eql: 5.0.2
-      loupe: 3.1.3
+      loupe: 3.2.1
       pathval: 2.0.0
 
   chainsaw@0.1.0:
@@ -57307,9 +58198,7 @@ snapshots:
 
   dedent@1.7.0: {}
 
-  deep-eql@4.1.3:
-    dependencies:
-      type-detect: 4.0.8
+  dedent@1.7.2: {}
 
   deep-eql@4.1.4:
     dependencies:
@@ -57456,11 +58345,11 @@ snapshots:
       tslib: 2.6.2
       videokitten: 1.0.1
 
-  detox-allure2-adapter@1.0.0-alpha.42(patch_hash=c0c5e6419e53a25ed902cac4ce3608f467d0332b34c90b669fed2089e2bf97ba)(detox@20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2))))(jest-allure2-reporter@2.2.8(@jest/reporters@30.2.0)(jest-docblock@30.2.0)(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2)))):
+  detox-allure2-adapter@1.0.0-alpha.42(patch_hash=c0c5e6419e53a25ed902cac4ce3608f467d0332b34c90b669fed2089e2bf97ba)(detox@20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2))))(jest-allure2-reporter@2.2.8(@jest/reporters@30.2.0)(jest-docblock@30.2.0)(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2)))):
     dependencies:
       archiver: 6.0.2
-      detox: 20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2)))
-      jest-allure2-reporter: 2.2.8(@jest/reporters@30.2.0)(jest-docblock@30.2.0)(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2)))
+      detox: 20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2)))
+      jest-allure2-reporter: 2.2.8(@jest/reporters@30.2.0)(jest-docblock@30.2.0)(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2)))
       logkitten: 1.3.3
       screenkitten: 1.0.0
       tslib: 2.6.2
@@ -57523,11 +58412,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  detox@20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2))):
+  detox@20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2))):
     dependencies:
       '@jest/reporters': 30.2.0
       '@wix-pilot/core': 3.4.2(expect@30.2.0)
-      '@wix-pilot/detox': 1.0.13(@wix-pilot/core@3.4.2(expect@30.2.0))(detox@20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2))))(expect@30.2.0)
+      '@wix-pilot/detox': 1.0.13(@wix-pilot/core@3.4.2(expect@30.2.0))(detox@20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2))))(expect@30.2.0)
       ajv: 8.17.1
       bunyan: 1.8.15
       bunyan-debug-stream: 3.1.0(bunyan@1.8.15)
@@ -57541,7 +58430,7 @@ snapshots:
       glob: 8.1.0
       ini: 1.3.8
       jest-circus: 30.2.0
-      jest-environment-emit: 1.2.0(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2)))
+      jest-environment-emit: 1.2.0(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2)))
       jest-environment-node: 30.2.0
       json-cycle: 1.5.0
       lodash: 4.17.21
@@ -57567,7 +58456,7 @@ snapshots:
       yargs-parser: 21.1.1
       yargs-unparser: 2.0.0
     optionalDependencies:
-      jest: 30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2))
+      jest: 30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2))
     transitivePeerDependencies:
       - '@jest/environment'
       - '@jest/types'
@@ -58043,30 +58932,6 @@ snapshots:
       fast-json-parse: 1.0.3
       objectorarray: 1.0.5
 
-  engine.io-parser@5.2.3: {}
-
-  engine.io@6.6.7:
-    dependencies:
-      '@types/cors': 2.8.17
-      '@types/node': 24.12.0
-      '@types/ws': 8.18.1
-      accepts: 1.3.8
-      base64id: 2.0.0
-      cookie: 0.7.2
-      cors: 2.8.5
-      debug: 4.4.3
-      engine.io-parser: 5.2.3
-      ws: 8.18.3
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  enhanced-resolve@5.12.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      tapable: 2.2.3
-
   enhanced-resolve@5.17.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -58104,8 +58969,6 @@ snapshots:
   env-paths@2.2.1: {}
 
   env-paths@3.0.0: {}
-
-  envinfo@7.14.0: {}
 
   envinfo@7.21.0: {}
 
@@ -58246,6 +59109,8 @@ snapshots:
       is-symbol: 1.1.1
 
   es-toolkit@1.44.0: {}
+
+  es-toolkit@1.47.0: {}
 
   es6-error@4.1.1: {}
 
@@ -58568,6 +59433,8 @@ snapshots:
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
+
+  esm-env@1.2.2: {}
 
   esm@3.2.25: {}
 
@@ -59289,7 +60156,7 @@ snapshots:
       strip-outer: 1.0.1
       trim-repeated: 1.0.0
 
-  filesize@10.1.6: {}
+  filesize@11.0.17: {}
 
   fill-range@7.1.1:
     dependencies:
@@ -59617,6 +60484,12 @@ snapshots:
       jsonfile: 6.1.0
       universalify: 2.0.1
 
+  fs-extra@11.3.5:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.1
+
   fs-extra@7.0.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -59876,6 +60749,12 @@ snapshots:
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.0
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   glob@6.0.4:
     dependencies:
@@ -60478,14 +61357,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  http-proxy-middleware@2.0.9:
-    dependencies:
-      '@types/http-proxy': 1.17.17
-      http-proxy: 1.18.1
-      is-glob: 4.0.3
-      is-plain-obj: 3.0.0
-      micromatch: 4.0.8
 
   http-proxy-middleware@2.0.9(@types/express@4.17.21):
     dependencies:
@@ -61294,13 +62165,13 @@ snapshots:
       - jest-environment-jsdom
       - jest-environment-node
 
-  jest-allure2-reporter@2.2.8(@jest/reporters@30.2.0)(jest-docblock@30.2.0)(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2))):
+  jest-allure2-reporter@2.2.8(@jest/reporters@30.2.0)(jest-docblock@30.2.0)(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2))):
     dependencies:
       allure-store: 1.1.2
       bunyamin: 1.6.3
       handlebars: 4.7.8
       import-from: 4.0.0
-      jest-metadata: 1.6.0(@jest/reporters@30.2.0)(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2)))
+      jest-metadata: 1.6.0(@jest/reporters@30.2.0)(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2)))
       lodash: 4.17.21
       node-fetch: 2.7.0
       pkg-up: 3.1.0
@@ -61310,7 +62181,7 @@ snapshots:
       tslib: 2.6.2
       uuid: 8.3.2
     optionalDependencies:
-      jest: 30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2))
+      jest: 30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2))
       jest-docblock: 30.2.0
     transitivePeerDependencies:
       - '@jest/environment'
@@ -61400,15 +62271,15 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2)):
+  jest-cli@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2)):
     dependencies:
-      '@jest/core': 30.2.0(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2))
+      '@jest/core': 30.2.0(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2))
       '@jest/test-result': 30.2.0
       '@jest/types': 30.2.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2))
+      jest-config: 30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2))
       jest-util: 30.2.0
       jest-validate: 30.2.0
       yargs: 17.7.2
@@ -61524,7 +62395,7 @@ snapshots:
       - metro
       - supports-color
 
-  jest-config@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2)):
+  jest-config@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2)):
     dependencies:
       '@babel/core': 7.28.5
       '@jest/get-type': 30.1.0
@@ -61552,7 +62423,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 24.12.0
-      ts-node: 10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2)
+      ts-node: 10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - metro
@@ -61676,7 +62547,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/bunyan'
 
-  jest-environment-emit@1.2.0(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2))):
+  jest-environment-emit@1.2.0(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2))):
     dependencies:
       bunyamin: 1.6.3(bunyan@2.0.5)
       bunyan: 2.0.5
@@ -61687,7 +62558,7 @@ snapshots:
       strip-ansi: 6.0.1
       tslib: 2.6.2
     optionalDependencies:
-      jest: 30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2))
+      jest: 30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2))
       jest-environment-node: 30.2.0
     transitivePeerDependencies:
       - '@types/bunyan'
@@ -61863,11 +62734,11 @@ snapshots:
       - '@types/bunyan'
       - bunyan
 
-  jest-metadata@1.6.0(@jest/reporters@30.2.0)(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2))):
+  jest-metadata@1.6.0(@jest/reporters@30.2.0)(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2))):
     dependencies:
       bunyamin: 1.6.3
       funpermaproxy: 1.1.0
-      jest-environment-emit: 1.2.0(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2)))
+      jest-environment-emit: 1.2.0(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2)))
       lodash.merge: 4.6.2
       lodash.snakecase: 4.1.1
       node-ipc: 9.2.1
@@ -61875,7 +62746,7 @@ snapshots:
       tslib: 2.6.2
     optionalDependencies:
       '@jest/reporters': 30.2.0
-      jest: 30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2))
+      jest: 30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2))
       jest-environment-node: 30.2.0
     transitivePeerDependencies:
       - '@types/bunyan'
@@ -62144,12 +63015,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2)):
+  jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2)):
     dependencies:
-      '@jest/core': 30.2.0(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2))
+      '@jest/core': 30.2.0(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2))
       '@jest/types': 30.2.0
       import-local: 3.2.0
-      jest-cli: 30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2))
+      jest-cli: 30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -62415,6 +63286,8 @@ snapshots:
   json-rpc-2.0@0.2.19: {}
 
   json-rpc-2.0@1.7.0: {}
+
+  json-rpc-2.0@1.7.1: {}
 
   json-schema-compare@0.2.2:
     dependencies:
@@ -62763,6 +63636,11 @@ snapshots:
     dependencies:
       picocolors: 1.1.1
       shell-quote: 1.8.3
+
+  launch-editor@2.14.0:
+    dependencies:
+      picocolors: 1.1.1
+      shell-quote: 1.8.4
 
   lazy-cache@1.0.4: {}
 
@@ -63648,6 +64526,23 @@ snapshots:
 
   memfs@4.51.1:
     dependencies:
+      '@jsonjoy.com/json-pack': 1.21.0(tslib@2.6.2)
+      '@jsonjoy.com/util': 1.9.0(tslib@2.6.2)
+      glob-to-regex.js: 1.2.0(tslib@2.6.2)
+      thingies: 2.5.0(tslib@2.6.2)
+      tree-dump: 1.1.0(tslib@2.6.2)
+      tslib: 2.6.2
+
+  memfs@4.57.3:
+    dependencies:
+      '@jsonjoy.com/fs-core': 4.57.3(tslib@2.6.2)
+      '@jsonjoy.com/fs-fsa': 4.57.3(tslib@2.6.2)
+      '@jsonjoy.com/fs-node': 4.57.3(tslib@2.6.2)
+      '@jsonjoy.com/fs-node-builtins': 4.57.3(tslib@2.6.2)
+      '@jsonjoy.com/fs-node-to-fsa': 4.57.3(tslib@2.6.2)
+      '@jsonjoy.com/fs-node-utils': 4.57.3(tslib@2.6.2)
+      '@jsonjoy.com/fs-print': 4.57.3(tslib@2.6.2)
+      '@jsonjoy.com/fs-snapshot': 4.57.3(tslib@2.6.2)
       '@jsonjoy.com/json-pack': 1.21.0(tslib@2.6.2)
       '@jsonjoy.com/util': 1.9.0(tslib@2.6.2)
       glob-to-regex.js: 1.2.0(tslib@2.6.2)
@@ -64583,6 +65478,10 @@ snapshots:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.11
@@ -64657,6 +65556,8 @@ snapshots:
   minipass@5.0.0: {}
 
   minipass@7.1.2: {}
+
+  minipass@7.1.3: {}
 
   minizlib@2.1.2:
     dependencies:
@@ -65441,6 +66342,53 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
+  oxc-parser@0.127.0:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.127.0
+      '@oxc-parser/binding-android-arm64': 0.127.0
+      '@oxc-parser/binding-darwin-arm64': 0.127.0
+      '@oxc-parser/binding-darwin-x64': 0.127.0
+      '@oxc-parser/binding-freebsd-x64': 0.127.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.127.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.127.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.127.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.127.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.127.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-x64-musl': 0.127.0
+      '@oxc-parser/binding-openharmony-arm64': 0.127.0
+      '@oxc-parser/binding-wasm32-wasi': 0.127.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.127.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.127.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.127.0
+
+  oxc-resolver@11.20.0:
+    optionalDependencies:
+      '@oxc-resolver/binding-android-arm-eabi': 11.20.0
+      '@oxc-resolver/binding-android-arm64': 11.20.0
+      '@oxc-resolver/binding-darwin-arm64': 11.20.0
+      '@oxc-resolver/binding-darwin-x64': 11.20.0
+      '@oxc-resolver/binding-freebsd-x64': 11.20.0
+      '@oxc-resolver/binding-linux-arm-gnueabihf': 11.20.0
+      '@oxc-resolver/binding-linux-arm-musleabihf': 11.20.0
+      '@oxc-resolver/binding-linux-arm64-gnu': 11.20.0
+      '@oxc-resolver/binding-linux-arm64-musl': 11.20.0
+      '@oxc-resolver/binding-linux-ppc64-gnu': 11.20.0
+      '@oxc-resolver/binding-linux-riscv64-gnu': 11.20.0
+      '@oxc-resolver/binding-linux-riscv64-musl': 11.20.0
+      '@oxc-resolver/binding-linux-s390x-gnu': 11.20.0
+      '@oxc-resolver/binding-linux-x64-gnu': 11.20.0
+      '@oxc-resolver/binding-linux-x64-musl': 11.20.0
+      '@oxc-resolver/binding-openharmony-arm64': 11.20.0
+      '@oxc-resolver/binding-wasm32-wasi': 11.20.0
+      '@oxc-resolver/binding-win32-arm64-msvc': 11.20.0
+      '@oxc-resolver/binding-win32-x64-msvc': 11.20.0
+
   oxfmt@0.36.0:
     dependencies:
       tinypool: 2.1.0
@@ -65714,6 +66662,11 @@ snapshots:
     dependencies:
       lru-cache: 11.2.6
       minipass: 7.1.2
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.2.6
+      minipass: 7.1.3
 
   path-to-regexp@0.1.12: {}
 
@@ -66062,7 +67015,7 @@ snapshots:
     transitivePeerDependencies:
       - browserslist
 
-  postcss-loader@8.2.0(@rspack/core@1.7.3)(postcss@8.5.6)(typescript@6.0.2):
+  postcss-loader@8.2.0(@rspack/core@2.0.5)(postcss@8.5.6)(typescript@6.0.2):
     dependencies:
       cosmiconfig: 9.0.0(typescript@6.0.2)
       jiti: 2.6.1
@@ -66072,7 +67025,7 @@ snapshots:
       postcss-preset-env: 7.8.3(postcss@8.5.6)
       semver: 7.7.3
     optionalDependencies:
-      '@rspack/core': 1.7.3
+      '@rspack/core': 2.0.5
     transitivePeerDependencies:
       - browserslist
       - typescript
@@ -66854,6 +67807,21 @@ snapshots:
       '@types/resolve': 1.20.6
       doctrine: 3.0.0
       resolve: 1.22.11
+      strip-indent: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  react-docgen@8.0.3:
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@types/babel__core': 7.20.5
+      '@types/babel__traverse': 7.28.0
+      '@types/doctrine': 0.0.9
+      '@types/resolve': 1.20.6
+      doctrine: 3.0.0
+      resolve: 1.22.12
       strip-indent: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -67884,7 +68852,7 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
-  reduce-configs@1.1.1: {}
+  reduce-configs@1.1.2: {}
 
   reduce-flatten@2.0.0: {}
 
@@ -68147,6 +69115,13 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
   resolve@1.22.8:
     dependencies:
       is-core-module: 2.16.1
@@ -68328,21 +69303,21 @@ snapshots:
 
   rrweb-cssom@0.8.0: {}
 
-  rsbuild-plugin-dts@0.19.3(@rsbuild/core@1.7.2)(typescript@6.0.2):
+  rsbuild-plugin-dts@0.22.0(@rsbuild/core@2.0.9)(typescript@6.0.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 1.7.2
+      '@rsbuild/core': 2.0.9
     optionalDependencies:
       typescript: 6.0.2
 
-  rsbuild-plugin-html-minifier-terser@1.1.3(@rsbuild/core@1.7.2):
+  rsbuild-plugin-html-minifier-terser@1.1.3(@rsbuild/core@2.0.9):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 1.7.2
+      '@rsbuild/core': 2.0.9
 
-  rslog@1.3.2: {}
+  rslog@2.1.2: {}
 
   run-applescript@7.0.0: {}
 
@@ -68491,6 +69466,8 @@ snapshots:
   semver@7.7.2: {}
 
   semver@7.7.3: {}
+
+  semver@7.8.1: {}
 
   send@0.18.0:
     dependencies:
@@ -68713,6 +69690,8 @@ snapshots:
 
   shell-quote@1.8.3: {}
 
+  shell-quote@1.8.4: {}
+
   shimmer@1.2.1: {}
 
   side-channel-list@1.0.0:
@@ -68850,36 +69829,6 @@ snapshots:
       - bufferutil
       - utf-8-validate
     optional: true
-
-  socket.io-adapter@2.5.6:
-    dependencies:
-      debug: 4.4.3
-      ws: 8.18.3
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  socket.io-parser@4.2.6:
-    dependencies:
-      '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  socket.io@4.8.1:
-    dependencies:
-      accepts: 1.3.8
-      base64id: 2.0.0
-      cors: 2.8.5
-      debug: 4.3.4
-      engine.io: 6.6.7
-      socket.io-adapter: 2.5.6
-      socket.io-parser: 4.2.6
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
 
   socketcluster-client@19.2.7:
     dependencies:
@@ -69068,6 +70017,8 @@ snapshots:
   sprintf-js@1.1.3:
     optional: true
 
+  sqids@0.3.0: {}
+
   sqlite3@5.1.7:
     dependencies:
       bindings: 1.5.0
@@ -69170,24 +70121,24 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  storybook-builder-rsbuild@3.2.2(@rsbuild/core@1.7.2)(@rspack/core@1.7.3)(msw@2.7.3(@types/node@24.12.0)(typescript@6.0.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2):
+  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(msw@2.7.3(@types/node@24.12.0)(typescript@6.0.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2):
     dependencies:
-      '@rsbuild/core': 1.7.2
-      '@rsbuild/plugin-type-check': 1.3.3(@rsbuild/core@1.7.2)(@rspack/core@1.7.3)(typescript@6.0.2)
+      '@rsbuild/core': 2.0.9
+      '@rsbuild/plugin-type-check': 1.3.5(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(typescript@6.0.2)
       '@vitest/mocker': 3.2.4(msw@2.7.3(@types/node@24.12.0)(typescript@6.0.2))
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 2.2.0
       constants-browserify: 1.0.0
       es-module-lexer: 1.7.0
-      fs-extra: 11.3.3
+      fs-extra: 11.3.5
       magic-string: 0.30.21
       path-browserify: 1.0.1
       picocolors: 1.1.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@1.7.2)
+      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.0.9)
       sirv: 2.0.4
-      storybook: 10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       ts-dedent: 2.2.0
       url: 0.11.4
       util: 0.12.5
@@ -69201,24 +70152,24 @@ snapshots:
       - msw
       - vite
 
-  storybook-builder-rsbuild@3.2.2(@rsbuild/core@1.7.2)(@rspack/core@1.7.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2):
+  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2):
     dependencies:
-      '@rsbuild/core': 1.7.2
-      '@rsbuild/plugin-type-check': 1.3.3(@rsbuild/core@1.7.2)(@rspack/core@1.7.3)(typescript@6.0.2)
+      '@rsbuild/core': 2.0.9
+      '@rsbuild/plugin-type-check': 1.3.5(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(typescript@6.0.2)
       '@vitest/mocker': 3.2.4
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 2.2.0
       constants-browserify: 1.0.0
       es-module-lexer: 1.7.0
-      fs-extra: 11.3.3
+      fs-extra: 11.3.5
       magic-string: 0.30.21
       path-browserify: 1.0.1
       picocolors: 1.1.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@1.7.2)
+      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.0.9)
       sirv: 2.0.4
-      storybook: 10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       ts-dedent: 2.2.0
       url: 0.11.4
       util: 0.12.5
@@ -69232,24 +70183,24 @@ snapshots:
       - msw
       - vite
 
-  storybook-builder-rsbuild@3.2.2(@rsbuild/core@1.7.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2):
+  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.0.9)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2):
     dependencies:
-      '@rsbuild/core': 1.7.2
-      '@rsbuild/plugin-type-check': 1.3.3(@rsbuild/core@1.7.2)(typescript@6.0.2)
+      '@rsbuild/core': 2.0.9
+      '@rsbuild/plugin-type-check': 1.3.5(@rsbuild/core@2.0.9)(typescript@6.0.2)
       '@vitest/mocker': 3.2.4
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 2.2.0
       constants-browserify: 1.0.0
       es-module-lexer: 1.7.0
-      fs-extra: 11.3.3
+      fs-extra: 11.3.5
       magic-string: 0.30.21
       path-browserify: 1.0.1
       picocolors: 1.1.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@1.7.2)
+      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.0.9)
       sirv: 2.0.4
-      storybook: 10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       ts-dedent: 2.2.0
       url: 0.11.4
       util: 0.12.5
@@ -69263,99 +70214,109 @@ snapshots:
       - msw
       - vite
 
-  storybook-react-rsbuild@3.2.2(@rsbuild/core@1.7.2)(@rspack/core@1.7.3)(msw@2.7.3(@types/node@24.12.0)(typescript@6.0.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2):
+  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(msw@2.7.3(@types/node@24.12.0)(typescript@6.0.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2):
     dependencies:
       '@rollup/pluginutils': 5.3.0
-      '@rsbuild/core': 1.7.2
-      '@storybook/react': 10.2.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
+      '@rsbuild/core': 2.0.9
+      '@storybook/react': 10.4.1(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@6.0.2)
       find-up: 5.0.0
       magic-string: 0.30.21
       react: 19.0.0
-      react-docgen: 8.0.2
+      react-docgen: 8.0.3
       react-docgen-typescript: 2.4.0(typescript@6.0.2)
       react-dom: 19.0.0(react@19.0.0)
-      resolve: 1.22.11
-      storybook: 10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      storybook-builder-rsbuild: 3.2.2(@rsbuild/core@1.7.2)(@rspack/core@1.7.3)(msw@2.7.3(@types/node@24.12.0)(typescript@6.0.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
+      resolve: 1.22.12
+      storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(msw@2.7.3(@types/node@24.12.0)(typescript@6.0.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 6.0.2
     transitivePeerDependencies:
       - '@rspack/core'
+      - '@types/react'
+      - '@types/react-dom'
       - msw
       - rollup
       - supports-color
       - vite
       - webpack
 
-  storybook-react-rsbuild@3.2.2(@rsbuild/core@1.7.2)(@rspack/core@1.7.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2):
+  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2):
     dependencies:
       '@rollup/pluginutils': 5.3.0
-      '@rsbuild/core': 1.7.2
-      '@storybook/react': 10.2.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
+      '@rsbuild/core': 2.0.9
+      '@storybook/react': 10.4.1(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@6.0.2)
       find-up: 5.0.0
       magic-string: 0.30.21
       react: 19.0.0
-      react-docgen: 8.0.2
+      react-docgen: 8.0.3
       react-docgen-typescript: 2.4.0(typescript@6.0.2)
       react-dom: 19.0.0(react@19.0.0)
-      resolve: 1.22.11
-      storybook: 10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      storybook-builder-rsbuild: 3.2.2(@rsbuild/core@1.7.2)(@rspack/core@1.7.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
+      resolve: 1.22.12
+      storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 6.0.2
     transitivePeerDependencies:
       - '@rspack/core'
+      - '@types/react'
+      - '@types/react-dom'
       - msw
       - rollup
       - supports-color
       - vite
       - webpack
 
-  storybook-react-rsbuild@3.2.2(@rsbuild/core@1.7.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2):
+  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.0.9)(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2):
     dependencies:
       '@rollup/pluginutils': 5.3.0
-      '@rsbuild/core': 1.7.2
-      '@storybook/react': 10.2.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
+      '@rsbuild/core': 2.0.9
+      '@storybook/react': 10.4.1(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@6.0.2)
       find-up: 5.0.0
       magic-string: 0.30.21
       react: 19.0.0
-      react-docgen: 8.0.2
+      react-docgen: 8.0.3
       react-docgen-typescript: 2.4.0(typescript@6.0.2)
       react-dom: 19.0.0(react@19.0.0)
-      resolve: 1.22.11
-      storybook: 10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      storybook-builder-rsbuild: 3.2.2(@rsbuild/core@1.7.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
+      resolve: 1.22.12
+      storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.9)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@6.0.2)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 6.0.2
     transitivePeerDependencies:
       - '@rspack/core'
+      - '@types/react'
+      - '@types/react-dom'
       - msw
       - rollup
       - supports-color
       - vite
       - webpack
 
-  storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(prettier@3.2.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/icons': 2.0.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@storybook/icons': 2.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@testing-library/jest-dom': 6.9.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/expect': 3.2.4
       '@vitest/spy': 3.2.4
+      '@webcontainer/env': 1.1.1
       esbuild: 0.25.5
       open: 10.2.0
+      oxc-parser: 0.127.0
+      oxc-resolver: 11.20.0
       recast: 0.23.11
       semver: 7.7.3
       use-sync-external-store: 1.6.0(react@19.0.0)
       ws: 8.18.3
     optionalDependencies:
+      '@types/react': 19.0.14
       prettier: 3.2.5
     transitivePeerDependencies:
       - '@testing-library/dom'
@@ -69878,6 +70839,8 @@ snapshots:
 
   tapable@2.2.3: {}
 
+  tapable@2.3.3: {}
+
   tar-fs@2.1.1:
     dependencies:
       chownr: 1.1.4
@@ -69962,7 +70925,7 @@ snapshots:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
 
-  terser-webpack-plugin@5.3.16(@swc/core@1.15.11(@swc/helpers@0.5.17)):
+  terser-webpack-plugin@5.3.16(@swc/core@1.15.11(@swc/helpers@0.5.23)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
@@ -69970,7 +70933,7 @@ snapshots:
       serialize-javascript: 6.0.2
       terser: 5.36.0
     optionalDependencies:
-      '@swc/core': 1.15.11(@swc/helpers@0.5.17)
+      '@swc/core': 1.15.11(@swc/helpers@0.5.23)
     transitivePeerDependencies:
       - metro
 
@@ -70134,6 +71097,16 @@ snapshots:
     dependencies:
       tldts-core: 7.0.19
 
+  tmcp@1.19.4(typescript@6.0.2):
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      json-rpc-2.0: 1.7.1
+      sqids: 0.3.0
+      uri-template-matcher: 1.1.2
+      valibot: 1.4.1(typescript@6.0.2)
+    transitivePeerDependencies:
+      - typescript
+
   tmp-promise@3.0.3:
     dependencies:
       tmp: 0.2.3
@@ -70268,27 +71241,21 @@ snapshots:
     dependencies:
       typescript: 6.0.2
 
-  ts-checker-rspack-plugin@1.2.6(@rspack/core@1.7.3)(typescript@6.0.2):
+  ts-checker-rspack-plugin@1.3.1(@rspack/core@2.0.5)(typescript@6.0.2):
     dependencies:
-      '@babel/code-frame': 7.29.0
       '@rspack/lite-tapable': 1.1.0
       chokidar: 3.6.0
-      is-glob: 4.0.3
-      memfs: 4.51.1
-      minimatch: 9.0.5
+      memfs: 4.57.3
       picocolors: 1.1.1
       typescript: 6.0.2
     optionalDependencies:
-      '@rspack/core': 1.7.3
+      '@rspack/core': 2.0.5
 
-  ts-checker-rspack-plugin@1.2.6(typescript@6.0.2):
+  ts-checker-rspack-plugin@1.3.1(typescript@6.0.2):
     dependencies:
-      '@babel/code-frame': 7.29.0
       '@rspack/lite-tapable': 1.1.0
       chokidar: 3.6.0
-      is-glob: 4.0.3
-      memfs: 4.51.1
-      minimatch: 9.0.5
+      memfs: 4.57.3
       picocolors: 1.1.1
       typescript: 6.0.2
 
@@ -70310,7 +71277,7 @@ snapshots:
       typescript: 6.0.2
       webpack: 5.94.0(@swc/core@1.15.11)
 
-  ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.0)(typescript@6.0.2):
+  ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(typescript@6.0.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -70328,7 +71295,7 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
-      '@swc/core': 1.15.11(@swc/helpers@0.5.17)
+      '@swc/core': 1.15.11(@swc/helpers@0.5.23)
     transitivePeerDependencies:
       - source-map-support
 
@@ -70879,6 +71846,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  uri-template-matcher@1.1.2: {}
+
   urijs@1.19.11: {}
 
   url-join@4.0.1: {}
@@ -71020,6 +71989,10 @@ snapshots:
       convert-source-map: 2.0.0
 
   valibot@1.2.0(typescript@6.0.2):
+    optionalDependencies:
+      typescript: 6.0.2
+
+  valibot@1.4.1(typescript@6.0.2):
     optionalDependencies:
       typescript: 6.0.2
 
@@ -71341,15 +72314,6 @@ snapshots:
       schema-utils: 4.3.3
       webpack: 5.94.0(@swc/core@1.15.11)
 
-  webpack-dev-middleware@7.4.5:
-    dependencies:
-      colorette: 2.0.20
-      memfs: 4.51.1
-      mime-types: 3.0.1
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      schema-utils: 4.3.3
-
   webpack-dev-server@4.15.2(webpack@5.94.0(@swc/core@1.15.11)):
     dependencies:
       '@types/bonjour': 3.5.13
@@ -71384,41 +72348,6 @@ snapshots:
       ws: 8.18.3
     optionalDependencies:
       webpack: 5.94.0(@swc/core@1.15.11)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  webpack-dev-server@5.2.2:
-    dependencies:
-      '@types/bonjour': 3.5.13
-      '@types/connect-history-api-fallback': 1.5.4
-      '@types/express': 4.17.21
-      '@types/express-serve-static-core': 4.17.43
-      '@types/serve-index': 1.9.4
-      '@types/serve-static': 1.15.5
-      '@types/sockjs': 0.3.36
-      '@types/ws': 8.5.10
-      ansi-html-community: 0.0.8
-      bonjour-service: 1.2.1
-      chokidar: 3.6.0
-      colorette: 2.0.20
-      compression: 1.7.4
-      connect-history-api-fallback: 2.0.0
-      express: 4.22.0
-      graceful-fs: 4.2.11
-      http-proxy-middleware: 2.0.9(@types/express@4.17.21)
-      ipaddr.js: 2.1.0
-      launch-editor: 2.12.0
-      open: 10.2.0
-      p-retry: 6.2.0
-      schema-utils: 4.3.3
-      selfsigned: 2.4.1
-      serve-index: 1.9.1
-      sockjs: 0.3.24
-      spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5
-      ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -71719,6 +72648,10 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6
+
+  ws@8.20.1: {}
+
+  ws@8.21.0: {}
 
   wsl-utils@0.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -70,32 +70,32 @@ catalog:
   expo-modules-core: 2.5.0
   "@jest/reporters": 30.2.0
   "@reduxjs/toolkit": 2.11.2
-  "@rsbuild/core": 1.7.2
-  "@rsbuild/plugin-node-polyfill": 1.4.3
-  "@rsbuild/plugin-react": 1.4.3
-  "@rsbuild/plugin-styled-components": 1.6.1
-  "@rsdoctor/rspack-plugin": "1.5.2"
-  "@rspack/cli": 1.7.3
-  "@rspack/core": 1.7.3
-  "@rspack/dev-server": 1.1.5
-  "@rspack/plugin-react-refresh": 1.6.0
-  "@rslib/core": 0.19.3
+  "@rsbuild/core": 2.0.9
+  "@rsbuild/plugin-node-polyfill": 1.4.5
+  "@rsbuild/plugin-react": 2.0.1
+  "@rsbuild/plugin-styled-components": 1.6.2
+  "@rsdoctor/rspack-plugin": "2.0.0-alpha.0"
+  "@rspack/cli": 2.0.5
+  "@rspack/core": 2.0.5
+  "@rspack/dev-server": 2.0.3
+  "@rspack/plugin-react-refresh": 2.0.1
+  "@rslib/core": 0.22.0
   react-refresh: 0.18.0
-  storybook: 10.2.0
-  "@storybook/react": 10.2.0
-  "@storybook/react-native": 10.1.11
-  "@storybook/react-webpack5": 10.1.11
+  storybook: 10.4.1
+  "@storybook/react": 10.4.1
+  "@storybook/react-native": 10.4.4
+  "@storybook/react-webpack5": 10.4.1
   "@storybook/core": 8.6.14
   "@storybook/addon-essentials": 8.6.14
   "@storybook/addon-interactions": 8.6.14
   "@storybook/addon-actions": 9.0.8
-  "@storybook/addon-docs": 10.2.0
-  "@storybook/addon-links": 10.2.0
+  "@storybook/addon-docs": 10.4.1
+  "@storybook/addon-links": 10.4.1
   "@storybook/addon-controls": 9.0.8
-  "@storybook/addon-ondevice-actions": 10.1.11
-  "@storybook/addon-ondevice-backgrounds": 10.1.11
-  "@storybook/addon-ondevice-controls": 10.1.11
-  "@storybook/addon-ondevice-notes": 10.1.11
+  "@storybook/addon-ondevice-actions": 10.4.4
+  "@storybook/addon-ondevice-backgrounds": 10.4.4
+  "@storybook/addon-ondevice-controls": 10.4.4
+  "@storybook/addon-ondevice-notes": 10.4.4
   "@storybook/addon-react-native-web": 0.0.29
   "@storybook/blocks": 8.6.14
   "@storybook/docs-tools": 8.6.14
@@ -106,9 +106,9 @@ catalog:
   "@storybook/testing-library": 0.2.2
   "@storybook/theming": 8.6.14
   storybook-dark-mode: 4.0.2
-  storybook-react-rsbuild: 3.2.2
+  storybook-react-rsbuild: 3.3.4
   "@swc/core": 1.15.11
-  "@swc/helpers": 0.5.17
+  "@swc/helpers": 0.5.23
   "@swc/jest": 0.2.39
   "@testing-library/dom": 10.4.1
   "@testing-library/jest-dom": 6.9.1


### PR DESCRIPTION
> [!NOTE]
> Build-toolchain upgrade. Desktop and Web Tools builds, Mobile Android/iOS JS bundles, the Wallet CLI / rslib builds, and Rsdoctor (Desktop + Mobile) were all validated on CI and locally.

### ✅ Checklist

- [x] npx changeset was attached.
- [ ] **Covered by automatic tests.** Build-tooling change; relies on existing build/CI jobs as the regression signal.
- [ ] **Impact of the changes:**
  - Build toolchain only (devDependencies). QA should smoke-test the Desktop app (built on Rspack v2) and the Mobile Hermes bundle (repack now runs on Rspack v2).

### 📝 Description

Upgrades the Rsbuild/Rspack build stack from v1 to v2 across the monorepo catalog:

- @rsbuild/core 1.7.2 to 2.0.9, plugin-react 2.0.1, plugin-node-polyfill 1.4.5, plugin-styled-components 1.6.2
- @rspack/core + cli 1.7.3 to 2.0.5, dev-server 2.0.3, plugin-react-refresh 2.0.1
- @rsdoctor/rspack-plugin 1.5.2 to 2.0.0-alpha.0 (the Rspack v2 line)
- @rslib/core 0.19.3 to 0.22.0
- @swc/helpers 0.5.17 to 0.5.23 (see below)
- storybook-react-rsbuild 3.2.2 to 3.3.4, which requires Storybook >= 10.3.5, so the Storybook 10.x catalog entries move to 10.4

Changes required by v2:

- @rspack/plugin-react-refresh switched from a default export to a named export (ReactRefreshRspackPlugin) in the desktop rspack config.
- Added a @sentry/types v6 resolution alias. Rspack v2's stricter ESM linking resolves the bare @sentry/types specifier to the hoisted v8 (type-only) build instead of the nested v6 that @sentry/utils@6 needs for its Severity enum, which fails the build with "module has no exports". The alias forces v6's CJS build and throws a clear error if the v6 package ever disappears from the tree.
- Aligned @swc/helpers to 0.5.23. The _wrap_reg_exp runtime helper emitted by @swc/core 1.15.11 is absent from 0.5.17; Rspack v2's stricter exports enforcement (with repack enablePackageExports) then fails to resolve it in the mobile bundle.
- Disabled Rsdoctor loader analysis on mobile (features.loader = false). Rsdoctor's loader interceptor crashes on Rspack v2's native resolver (NapiResolveOptions.fallback) because of mobile's resolve.fallback object. This reproduces on both 1.5.x and 2.0.0-alpha.0, so it is a known Rsdoctor-vs-Rspack-v2 limitation pending a fixed Rsdoctor release. Bundle analysis (the PR report) is unaffected.

The freshly-published v2 releases are added to minimumReleaseAgeExclude (intentional upgrade), mirroring the existing pattern used for oxlint/zx.

The three rsbuild.config files (web-tools, libs/ui react and native) needed no changes: they already use v2-style top-level resolve / resolve.alias and use no removed options.

> [!WARNING]
> The Rsdoctor PR comment may report some packages (e.g. coin-aptos, coin-stacks, coin-tezos) as "New / +100%". This is a false positive from the v1 to v2 bundler change: module/package identities shift across the major bump (and there is no comparable Rspack-v2 mobile baseline on develop yet), so Rsdoctor cannot match them and reports them as newly added. These are pre-existing modules already bundled on develop; the report will normalize once develop has a v2 baseline.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-31617
- **ADR link (if any)**: N/A