### PR TITLE
[LWM] feat(mobile): improve asset detail graph scrubbing

### DIFF
--- a/.changeset/asset-detail-graph-scrubber-improvements.md
+++ b/.changeset/asset-detail-graph-scrubber-improvements.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Improve asset detail graph scrubbing: show the scrubbed date and price in the market header while dragging, hide the floating tooltip, and keep the chart subtree stable for smoother gestures

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/LineChartScrubber.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/LineChartScrubber.tsx
@@ -11,9 +11,16 @@ type LineChartScrubberProps = Readonly<{
   series: LineChartSeries[];
   formatValue: LineChartValueFormatter;
   tooltipTitle?: LineChartTooltipTitle;
+  /** Renders the floating tooltip. Beacons/line still render when false. @default true */
+  showTooltip?: boolean;
 }>;
 
-export function LineChartScrubber({ series, formatValue, tooltipTitle }: LineChartScrubberProps) {
+export function LineChartScrubber({
+  series,
+  formatValue,
+  tooltipTitle,
+  showTooltip = true,
+}: LineChartScrubberProps) {
   const buildTooltip = useCallback(
     (dataIndex: number): ScrubberTooltipContent => {
       const items = series
@@ -27,5 +34,5 @@ export function LineChartScrubber({ series, formatValue, tooltipTitle }: LineCha
     [series, formatValue, tooltipTitle],
   );
 
-  return <Scrubber showBeacons tooltip={buildTooltip} />;
+  return <Scrubber showBeacons tooltip={showTooltip ? buildTooltip : undefined} />;
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/LineChartView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/LineChartView.tsx
@@ -24,6 +24,7 @@ export function LineChartView<TRange extends string>({
   testID,
   points,
   enableScrubber,
+  showScrubberTooltip,
   formatValue,
   tooltipTitle,
   onScrubberPositionChange,
@@ -55,6 +56,7 @@ export function LineChartView<TRange extends string>({
               series={chartSeries}
               formatValue={formatValue}
               tooltipTitle={tooltipTitle}
+              showTooltip={showScrubberTooltip}
             />
           )}
         </LumenLineChart>

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/__tests__/LineChartScrubber.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/__tests__/LineChartScrubber.test.tsx
@@ -4,11 +4,13 @@ import { LineChartScrubber } from "../LineChartScrubber";
 import type { LineChartSeries } from "../types";
 import type { ScrubberTooltipContent } from "@ledgerhq/lumen-ui-rnative-visualization";
 
-let buildTooltip: (dataIndex: number) => ScrubberTooltipContent;
+let buildTooltip: ((dataIndex: number) => ScrubberTooltipContent) | undefined;
+let showBeacons: boolean | undefined;
 
 jest.mock("@ledgerhq/lumen-ui-rnative-visualization", () => ({
-  Scrubber: (props: { tooltip: typeof buildTooltip }) => {
+  Scrubber: (props: { tooltip?: typeof buildTooltip; showBeacons?: boolean }) => {
     buildTooltip = props.tooltip;
+    showBeacons = props.showBeacons;
     return null;
   },
 }));
@@ -18,15 +20,20 @@ const series: LineChartSeries[] = [
   { id: "volume", data: [1, 2, 3], label: "Volume", stroke: "" },
 ];
 
-const renderScrubber = (tooltipTitle?: (i: number) => string | undefined) =>
+const renderScrubber = (tooltipTitle?: (i: number) => string | undefined, showTooltip?: boolean) =>
   render(
-    <LineChartScrubber series={series} formatValue={v => `$${v}`} tooltipTitle={tooltipTitle} />,
+    <LineChartScrubber
+      series={series}
+      formatValue={v => `$${v}`}
+      tooltipTitle={tooltipTitle}
+      showTooltip={showTooltip}
+    />,
   );
 
 describe("LineChartScrubber", () => {
   it("builds a row per series with a valid value at the index", () => {
     renderScrubber();
-    expect(buildTooltip(0)).toEqual({
+    expect(buildTooltip?.(0)).toEqual({
       items: [
         { label: "Price", value: "$10" },
         { label: "Volume", value: "$1" },
@@ -36,16 +43,28 @@ describe("LineChartScrubber", () => {
 
   it("skips series whose value is null or missing", () => {
     renderScrubber();
-    expect(buildTooltip(1)).toEqual({ items: [{ label: "Volume", value: "$2" }] });
+    expect(buildTooltip?.(1)).toEqual({ items: [{ label: "Volume", value: "$2" }] });
   });
 
   it("adds the title when tooltipTitle returns a non-empty string", () => {
     renderScrubber(i => `Point ${i}`);
-    expect(buildTooltip(2)).toMatchObject({ title: "Point 2" });
+    expect(buildTooltip?.(2)).toMatchObject({ title: "Point 2" });
   });
 
   it("omits the title when tooltipTitle is empty or undefined", () => {
     renderScrubber(() => "");
-    expect("title" in buildTooltip(2)).toBe(false);
+    expect("title" in (buildTooltip?.(2) ?? {})).toBe(false);
+  });
+
+  it("renders the tooltip by default", () => {
+    renderScrubber();
+    expect(buildTooltip).toBeDefined();
+    expect(showBeacons).toBe(true);
+  });
+
+  it("omits the tooltip but keeps beacons when showTooltip is false", () => {
+    renderScrubber(undefined, false);
+    expect(buildTooltip).toBeUndefined();
+    expect(showBeacons).toBe(true);
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/__tests__/getSeriesExtrema.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/__tests__/getSeriesExtrema.test.ts
@@ -56,8 +56,8 @@ describe("getExtremaPointMarkers", () => {
 
   it("emits a top success max marker and a bottom error min marker", () => {
     expect(getExtremaPointMarkers(makeSeries([3, 1, 4, 9, 2]))).toEqual([
-      { index: 3, value: 9, color: "success", labelPosition: "top" },
-      { index: 1, value: 1, color: "error", labelPosition: "bottom" },
+      { index: 3, value: 9, color: "success", labelPosition: "top", hidePoint: true },
+      { index: 1, value: 1, color: "error", labelPosition: "bottom", hidePoint: true },
     ]);
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/__tests__/useLineChartViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/__tests__/useLineChartViewModel.test.ts
@@ -124,10 +124,19 @@ describe("useLineChartViewModel", () => {
     const { result } = renderHook(() => useLineChartViewModel(buildProps()));
 
     expect(result.current.enableScrubber).toBe(true);
+    expect(result.current.showScrubberTooltip).toBe(true);
     expect(result.current.showArea).toBe(true);
     expect(result.current.showXAxis).toBe(true);
     expect(result.current.showYAxis).toBe(true);
     expect(result.current.formatValue(42)).toBe("42");
+  });
+
+  it("forwards an explicit showScrubberTooltip=false", () => {
+    const { result } = renderHook(() =>
+      useLineChartViewModel(buildProps({ showScrubberTooltip: false })),
+    );
+
+    expect(result.current.showScrubberTooltip).toBe(false);
   });
 
   it("defaults points to the high/low extrema of the primary series", () => {
@@ -135,8 +144,8 @@ describe("useLineChartViewModel", () => {
     const { result } = renderHook(() => useLineChartViewModel(buildProps()));
 
     expect(result.current.points).toEqual([
-      { index: 2, value: 3, color: "success", labelPosition: "top" },
-      { index: 0, value: 1, color: "error", labelPosition: "bottom" },
+      { index: 2, value: 3, color: "success", labelPosition: "top", hidePoint: true },
+      { index: 0, value: 1, color: "error", labelPosition: "bottom", hidePoint: true },
     ]);
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/types.ts
@@ -51,6 +51,8 @@ export type LineChartProps<TRange extends string = string> = Readonly<{
   points?: LineChartPointMarker[];
   /** Enables touch scrubbing with a tooltip. @default true */
   enableScrubber?: boolean;
+  /** Shows the floating tooltip while scrubbing. @default true */
+  showScrubberTooltip?: boolean;
   /** Formats numeric values for point labels and the scrubber tooltip. @default String */
   formatValue?: LineChartValueFormatter;
   /** Returns the tooltip title for the given data index (e.g. a formatted date). */

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/useLineChartViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/useLineChartViewModel.ts
@@ -28,6 +28,7 @@ export type LineChartViewModelResult<TRange extends string = string> = Readonly<
   testID?: string;
   points: LineChartPointMarker[];
   enableScrubber: boolean;
+  showScrubberTooltip: boolean;
   formatValue: LineChartValueFormatter;
   tooltipTitle?: LineChartTooltipTitle;
   onScrubberPositionChange?: LineChartScrubberPositionChange;
@@ -51,6 +52,7 @@ export function useLineChartViewModel<TRange extends string>({
   testID,
   points,
   enableScrubber = true,
+  showScrubberTooltip = true,
   formatValue = defaultFormatValue,
   tooltipTitle,
   onScrubberPositionChange,
@@ -93,6 +95,7 @@ export function useLineChartViewModel<TRange extends string>({
     testID,
     points: resolvedPoints,
     enableScrubber,
+    showScrubberTooltip,
     formatValue,
     tooltipTitle,
     onScrubberPositionChange,

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/utils/getExtremaPointMarkers.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/utils/getExtremaPointMarkers.ts
@@ -12,12 +12,14 @@ export function getExtremaPointMarkers(series: LineChartSeries[]): LineChartPoin
       value: extrema.max.value,
       color: LINE_CHART_EXTREMA_COLORS.max,
       labelPosition: "top",
+      hidePoint: true,
     },
     {
       index: extrema.min.index,
       value: extrema.min.value,
       color: LINE_CHART_EXTREMA_COLORS.min,
       labelPosition: "bottom",
+      hidePoint: true,
     },
   ];
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/BalanceGraphView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/BalanceGraphView.tsx
@@ -8,6 +8,7 @@ import { TrendSection } from "LLM/components/TrendSection";
 import { LineChart } from "LLM/components/LineChart";
 import type {
   LineChartColor,
+  LineChartScrubberPositionChange,
   LineChartSeries,
   LineChartTooltipTitle,
   LineChartValueFormatter,
@@ -37,11 +38,78 @@ type Props = Readonly<{
   chartColor: LineChartColor;
   formatValue: LineChartValueFormatter;
   tooltipTitle: LineChartTooltipTitle;
+  onScrubberPositionChange: LineChartScrubberPositionChange;
+  isScrubbing: boolean;
+  scrubbedDateLabel: string | undefined;
   showXAxis: boolean;
   showYAxis: boolean;
   xAxis: LineChartXAxisConfig;
   yAxis: LineChartYAxisConfig;
 }>;
+
+type ChartProps = Readonly<{
+  series: LineChartSeries[];
+  selectedRange: RangeKey;
+  onRangeChange: (value: RangeKey) => void;
+  ranges: Range[];
+  isRangeValue: (value: string) => value is RangeKey;
+  chartColor: LineChartColor;
+  isLoading: boolean;
+  formatValue: LineChartValueFormatter;
+  tooltipTitle: LineChartTooltipTitle;
+  onScrubberPositionChange: LineChartScrubberPositionChange;
+  showXAxis: boolean;
+  showYAxis: boolean;
+  xAxis: LineChartXAxisConfig;
+  yAxis: LineChartYAxisConfig;
+  accessibilityLabel: string;
+}>;
+
+/**
+ * Memoized chart subtree. The market-price header re-renders on every scrub
+ * frame; wrapping the chart keeps its (already memoized) props stable so the
+ * Lumen chart + scrubber are not re-rendered mid-gesture.
+ */
+const BalanceGraphChart = React.memo(function BalanceGraphChart({
+  series,
+  selectedRange,
+  onRangeChange,
+  ranges,
+  isRangeValue,
+  chartColor,
+  isLoading,
+  formatValue,
+  tooltipTitle,
+  onScrubberPositionChange,
+  showXAxis,
+  showYAxis,
+  xAxis,
+  yAxis,
+  accessibilityLabel,
+}: ChartProps) {
+  return (
+    <LineChart<RangeKey>
+      series={series}
+      selectedRange={selectedRange}
+      onRangeChange={onRangeChange}
+      ranges={ranges}
+      isRangeValue={isRangeValue}
+      color={chartColor}
+      isLoading={isLoading}
+      formatValue={formatValue}
+      tooltipTitle={tooltipTitle}
+      onScrubberPositionChange={onScrubberPositionChange}
+      showScrubberTooltip={false}
+      showXAxis={showXAxis}
+      showYAxis={showYAxis}
+      xAxis={xAxis}
+      yAxis={yAxis}
+      accessibilityLabel={accessibilityLabel}
+      testID={ASSET_DETAIL_TEST_IDS.chart}
+      height={275}
+    />
+  );
+});
 
 export function BalanceGraphView({
   price,
@@ -61,6 +129,9 @@ export function BalanceGraphView({
   chartColor,
   formatValue,
   tooltipTitle,
+  onScrubberPositionChange,
+  isScrubbing,
+  scrubbedDateLabel,
   showXAxis,
   showYAxis,
   xAxis,
@@ -81,40 +152,47 @@ export function BalanceGraphView({
             {t("assetDetail.balanceGraph.marketPrice")}
           </Text>
 
-          {hasMarketData && (
+          {(hasMarketData || isScrubbing) && (
             <>
               <AmountDisplay
                 value={price}
                 formatter={priceFormatter}
+                animate={!isScrubbing}
                 testID={ASSET_DETAIL_TEST_IDS.marketPrice}
               />
 
-              <TrendSection
-                percentage={priceChangePercentage}
-                formattedChange={formattedPriceChange}
-                timeLabel={rangeTimeLabel}
-              />
+              {isScrubbing ? (
+                <Text typography="body2" lx={{ color: "muted" }}>
+                  {scrubbedDateLabel}
+                </Text>
+              ) : (
+                <TrendSection
+                  percentage={priceChangePercentage}
+                  formattedChange={formattedPriceChange}
+                  timeLabel={rangeTimeLabel}
+                />
+              )}
             </>
           )}
         </Box>
       )}
 
-      <LineChart<RangeKey>
+      <BalanceGraphChart
         series={series}
         selectedRange={selectedRange}
         onRangeChange={onRangeChange}
         ranges={ranges}
         isRangeValue={isRangeValue}
-        color={chartColor}
+        chartColor={chartColor}
         isLoading={isLoading}
         formatValue={formatValue}
         tooltipTitle={tooltipTitle}
+        onScrubberPositionChange={onScrubberPositionChange}
         showXAxis={showXAxis}
         showYAxis={showYAxis}
         xAxis={xAxis}
         yAxis={yAxis}
         accessibilityLabel={t("assetDetail.balanceGraph.timeframeSelector")}
-        testID={ASSET_DETAIL_TEST_IDS.chart}
       />
 
       {showReceive && (

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/BalanceGraphView.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/BalanceGraphView.test.tsx
@@ -1,0 +1,134 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import type { FormattedValue } from "@ledgerhq/lumen-ui-rnative";
+import { BalanceGraphView } from "../BalanceGraphView";
+import type {
+  LineChartScrubberPositionChange,
+  LineChartSeries,
+  LineChartXAxisConfig,
+  LineChartYAxisConfig,
+} from "LLM/components/LineChart";
+import type { RangeKey } from "../../../utils/rangeMapping";
+
+// Capture the props the chart receives so we can assert on the scrub wiring.
+const mockLineChartProps: Record<string, unknown> = {};
+jest.mock("LLM/components/LineChart", () => ({
+  LineChart: (props: Record<string, unknown>) => {
+    Object.assign(mockLineChartProps, props);
+    return null;
+  },
+}));
+
+// Override AmountDisplay to expose the `animate` prop (the real one renders an
+// odometer that is awkward to assert against).
+let mockAmountDisplayAnimate: boolean | undefined;
+jest.mock("@ledgerhq/lumen-ui-rnative", () => {
+  const actual = jest.requireActual("@ledgerhq/lumen-ui-rnative");
+  const ReactActual = jest.requireActual("react");
+  const { Text } = jest.requireActual("react-native");
+  return {
+    ...actual,
+    AmountDisplay: ({
+      value,
+      animate,
+      testID,
+    }: {
+      value: number;
+      animate?: boolean;
+      testID?: string;
+    }) => {
+      mockAmountDisplayAnimate = animate;
+      return ReactActual.createElement(Text, { testID }, String(value));
+    },
+  };
+});
+
+const priceFormatter = (value: number): FormattedValue => ({
+  integerPart: String(value),
+  decimalPart: "",
+  decimalSeparator: ".",
+  currencyText: "$",
+  currencyPosition: "start",
+});
+
+const isRangeValue = (value: string): value is RangeKey => value === "1d" || value === "1w";
+
+const series: LineChartSeries[] = [
+  { id: "price", data: [100, 110, 120], label: "Price", stroke: "" },
+];
+const xAxis: LineChartXAxisConfig = {};
+const yAxis: LineChartYAxisConfig = {};
+const noopScrub: LineChartScrubberPositionChange = jest.fn();
+
+type ViewProps = Parameters<typeof BalanceGraphView>[0];
+
+const buildProps = (overrides: Partial<ViewProps> = {}): ViewProps => ({
+  price: 50000,
+  priceFormatter,
+  hasMarketData: true,
+  priceChangePercentage: 2.35,
+  formattedPriceChange: "+$1,000.00",
+  rangeTimeLabel: "Today",
+  ranges: [
+    { label: "1D", value: "1d" },
+    { label: "1W", value: "1w" },
+  ],
+  selectedRange: "1d",
+  onRangeChange: jest.fn(),
+  isRangeValue,
+  showReceive: false,
+  onReceivePress: jest.fn(),
+  isLoading: false,
+  series,
+  chartColor: "success",
+  formatValue: (value: number) => String(value),
+  tooltipTitle: () => undefined,
+  onScrubberPositionChange: noopScrub,
+  isScrubbing: false,
+  scrubbedDateLabel: undefined,
+  showXAxis: true,
+  showYAxis: false,
+  xAxis,
+  yAxis,
+  ...overrides,
+});
+
+describe("BalanceGraphView", () => {
+  beforeEach(() => {
+    mockAmountDisplayAnimate = undefined;
+    for (const key of Object.keys(mockLineChartProps)) delete mockLineChartProps[key];
+  });
+
+  it("forwards the scrub callback and disables the floating tooltip", () => {
+    const onScrubberPositionChange: LineChartScrubberPositionChange = jest.fn();
+    render(<BalanceGraphView {...buildProps({ onScrubberPositionChange })} />);
+
+    expect(mockLineChartProps.onScrubberPositionChange).toBe(onScrubberPositionChange);
+    expect(mockLineChartProps.showScrubberTooltip).toBe(false);
+  });
+
+  describe("when not scrubbing", () => {
+    it("animates the amount and shows the range label with the variation and percentage", () => {
+      render(<BalanceGraphView {...buildProps()} />);
+
+      expect(mockAmountDisplayAnimate).toBe(true);
+      expect(screen.getByText("Today")).toBeVisible();
+      expect(screen.getByText("2.35%")).toBeVisible();
+      expect(screen.getByText("+$1,000.00")).toBeVisible();
+    });
+  });
+
+  describe("while scrubbing", () => {
+    it("disables the amount animation and shows only the scrubbed date, hiding the variation and percentage", () => {
+      render(
+        <BalanceGraphView {...buildProps({ isScrubbing: true, scrubbedDateLabel: "5/29/2026" })} />,
+      );
+
+      expect(mockAmountDisplayAnimate).toBe(false);
+      expect(screen.getByText("5/29/2026")).toBeVisible();
+      expect(screen.queryByText("Today")).toBeNull();
+      expect(screen.queryByText("2.35%")).toBeNull();
+      expect(screen.queryByText("+$1,000.00")).toBeNull();
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/useBalanceGraphViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/useBalanceGraphViewModel.test.ts
@@ -446,6 +446,77 @@ describe("useBalanceGraphViewModel", () => {
     });
   });
 
+  describe("scrubbing", () => {
+    it("drives the price and date from the hovered point and flags isScrubbing", () => {
+      const { result } = renderVM();
+
+      // 1d series data is [100, 110, 120] with timestamps [1, 2, 3].
+      act(() => result.current.onScrubberPositionChange(1));
+
+      expect(result.current.isScrubbing).toBe(true);
+      expect(result.current.price).toBe(110);
+      expect(typeof result.current.scrubbedDateLabel).toBe("string");
+      expect(result.current.scrubbedDateLabel).not.toBe("");
+    });
+
+    it("reverts to the live price and clears the date when scrubbing ends", () => {
+      const { result } = renderVM();
+
+      act(() => result.current.onScrubberPositionChange(2));
+      expect(result.current.price).toBe(120);
+
+      act(() => result.current.onScrubberPositionChange(undefined));
+
+      expect(result.current.isScrubbing).toBe(false);
+      expect(result.current.price).toBe(50000);
+      expect(result.current.scrubbedDateLabel).toBeUndefined();
+    });
+
+    it("ignores an out-of-range index (no scrub)", () => {
+      const { result } = renderVM();
+
+      act(() => result.current.onScrubberPositionChange(99));
+
+      expect(result.current.isScrubbing).toBe(false);
+      expect(result.current.price).toBe(50000);
+    });
+
+    it("ignores a non-finite value at the hovered index", () => {
+      mockChart({ data: { ...CHART_DATA_BY_RANGE, "1d": [[1, NaN]] } });
+
+      const { result } = renderVM();
+
+      act(() => result.current.onScrubberPositionChange(0));
+
+      expect(result.current.isScrubbing).toBe(false);
+      expect(result.current.price).toBe(50000);
+    });
+
+    it("shows a 0 price / 0 timestamp point instead of swallowing it", () => {
+      mockChart({ data: { ...CHART_DATA_BY_RANGE, "1d": [[0, 0]] } });
+
+      const { result } = renderVM();
+
+      act(() => result.current.onScrubberPositionChange(0));
+
+      expect(result.current.isScrubbing).toBe(true);
+      expect(result.current.price).toBe(0);
+      expect(result.current.scrubbedDateLabel).toBeDefined();
+    });
+
+    it("clears the selection when the range changes mid-scrub", () => {
+      const { result } = renderVM();
+
+      act(() => result.current.onScrubberPositionChange(1));
+      expect(result.current.isScrubbing).toBe(true);
+
+      act(() => result.current.onRangeChange("1w"));
+
+      expect(result.current.isScrubbing).toBe(false);
+      expect(result.current.price).toBe(50000);
+    });
+  });
+
   describe("isLoading", () => {
     it("reflects the fetching state of useCurrencyData", () => {
       mockCurrency({ data: undefined, isFetching: true });

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import BigNumber from "bignumber.js";
 import type { AssetDetailCurrencyProps } from "LLM/features/AssetDetail/types";
 import type { FormattedValue } from "@ledgerhq/lumen-ui-rnative";
@@ -17,6 +17,7 @@ import { useTranslation, useLocale } from "~/context/Locale";
 import { useOpenReceiveDrawer } from "LLM/features/Receive";
 import {
   resolveLineChartColorFromPercentChange,
+  type LineChartScrubberPositionChange,
   type LineChartSeries,
   type LineChartTooltipTitle,
   type LineChartValueFormatter,
@@ -57,6 +58,13 @@ function getEvenlySpacedTicks(length: number, minTicks: number): number[] {
   return Array.from(new Set(ticks));
 }
 
+/**
+ * Hovered chart point while scrubbing. Holds raw values only (formatting stays
+ * in the view model); shaped as an object so more fields (e.g. variation) can be
+ * added later without touching the scrub plumbing.
+ */
+type ScrubSelection = Readonly<{ price: number; timestamp: number }>;
+
 type Params = {
   currency?: AssetDetailCurrencyProps;
   marketApiId?: string;
@@ -83,6 +91,7 @@ export function useBalanceGraphViewModel({
   });
 
   const [range, setRange] = useState<RangeKey>("1d");
+  const [selection, setSelection] = useState<ScrubSelection | undefined>(undefined);
 
   const id =
     knownLedgerIds?.[0] ?? marketCurrency?.ledgerIds?.[0] ?? marketCurrency?.id ?? marketApiId;
@@ -104,6 +113,7 @@ export function useBalanceGraphViewModel({
   const onRangeChange = useCallback(
     (value: RangeKey) => {
       if (value === range) return;
+      setSelection(undefined);
       setRange(value);
       track("button_clicked", {
         button: "timeframe",
@@ -185,6 +195,28 @@ export function useBalanceGraphViewModel({
       timestamps: tsList,
     };
   }, [chartData, range]);
+  const prices = series[0].data;
+  const onScrubberPositionChange = useCallback<LineChartScrubberPositionChange>(
+    index => {
+      if (index == null) return setSelection(undefined);
+      const scrubPrice = prices[index];
+      const timestamp = timestamps[index];
+      setSelection(
+        Number.isFinite(scrubPrice) && timestamp != null
+          ? { price: scrubPrice, timestamp }
+          : undefined,
+      );
+    },
+    [prices, timestamps],
+  );
+
+  useEffect(() => {
+    setSelection(undefined);
+  }, [id]);
+
+  const isScrubbing = selection != null;
+  const displayedPrice = selection?.price ?? price ?? 0;
+
   const chartColor = resolveLineChartColorFromPercentChange(priceChangePercentage);
 
   const formatValue = useCallback<LineChartValueFormatter>(
@@ -213,6 +245,9 @@ export function useBalanceGraphViewModel({
     (date: Date) => (range === "1d" ? dateFormatters.hour : dateFormatters.day).format(date),
     [range, dateFormatters],
   );
+
+  const scrubbedDateLabel =
+    selection != null ? formatDate(new Date(selection.timestamp)) : undefined;
 
   const tooltipTitle = useCallback<LineChartTooltipTitle>(
     dataIndex => {
@@ -252,7 +287,7 @@ export function useBalanceGraphViewModel({
   );
 
   return {
-    price: price ?? 0,
+    price: displayedPrice,
     priceFormatter,
     hasMarketData: price != null,
     priceChangePercentage: priceChangePercentage ?? 0,
@@ -269,6 +304,9 @@ export function useBalanceGraphViewModel({
     chartColor,
     formatValue,
     tooltipTitle,
+    onScrubberPositionChange,
+    isScrubbing,
+    scrubbedDateLabel,
     showXAxis: true,
     showYAxis: false,
     xAxis,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Asset Detail balance graph: scrubbing interaction (drag across the chart)
      - Market header updating to the scrubbed date + price while dragging, and restoring the trend section on release
      - Floating scrubber tooltip no longer rendered (beacons/line still shown), extrema points hidden
      - Chart render stability during the scrub gesture (memoized subtree)

### 📝 Description

Improves the graph scrubbing experience on the Asset Detail screen.

**Problem**: While scrubbing the balance graph, the market header (`MarketSection`) did not reflect the scrubbed point, and the floating tooltip plus extrema markers added visual noise. The chart subtree also re-rendered on every scrub frame because the header re-renders continuously during the gesture.

**Solution**:

- Update the market header while scrubbing: the `AmountDisplay` shows the scrubbed price (animation disabled mid-gesture) and a muted date label replaces the `TrendSection`; the trend section is restored on release.
- Add an optional `showScrubberTooltip` prop to the `LineChart` (defaulting to `true`); the Asset Detail chart opts out so beacons and the guide line still render without the floating tooltip.
- Hide extrema point markers (`hidePoint: true`) to reduce clutter.
- Wrap the chart in a memoized `BalanceGraphChart` subtree so the already-memoized chart props stay stable and the Lumen chart + scrubber are not re-rendered while the header updates each frame.

### 🖼 Screenshots


https://github.com/user-attachments/assets/72376ed5-821e-4820-8f7e-bffaf1e06fbb


### ❓ Context

- **JIRA or GitHub link**: [LIVE-31662](https://ledgerhq.atlassian.net/browse/LIVE-31662)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31662]: https://ledgerhq.atlassian.net/browse/LIVE-31662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ