### PR TITLE
[LWM] feat(mobile): add notification prompt target contracts

### DIFF
--- a/.changeset/brave-prompts-target.md
+++ b/.changeset/brave-prompts-target.md
@@ -1,0 +1,7 @@
+---
+"live-mobile": minor
+"@ledgerhq/types-live": minor
+"@shared/feature-flags": minor
+---
+
+Add notification drawer prompt target contracts

--- a/apps/ledger-live-mobile/src/actions/notifications.ts
+++ b/apps/ledger-live-mobile/src/actions/notifications.ts
@@ -2,6 +2,7 @@ import { createAction } from "redux-actions";
 import type {
   NotificationsSetDataOfUserPayload,
   NotificationsSetModalOpenPayload,
+  NotificationsSetDrawerPromptTargetPayload,
   NotificationsSetDrawerSourcePayload,
   NotificationSetPermissionStatusPayload,
 } from "./types";
@@ -13,6 +14,10 @@ export const setNotificationsModalOpen = createAction<NotificationsSetModalOpenP
 export const setNotificationsDrawerSource = createAction<NotificationsSetDrawerSourcePayload>(
   NotificationsActionTypes.NOTIFICATIONS_SET_DRAWER_SOURCE,
 );
+export const setNotificationsDrawerPromptTarget =
+  createAction<NotificationsSetDrawerPromptTargetPayload>(
+    NotificationsActionTypes.NOTIFICATIONS_SET_DRAWER_PROMPT_TARGET,
+  );
 export const setNotificationsDataOfUser = createAction<NotificationsSetDataOfUserPayload>(
   NotificationsActionTypes.NOTIFICATIONS_SET_DATA_OF_USER,
 );

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -152,6 +152,7 @@ export type CountervaluesPayload =
 export enum NotificationsActionTypes {
   NOTIFICATIONS_SET_MODAL_OPEN = "NOTIFICATIONS_SET_MODAL_OPEN",
   NOTIFICATIONS_SET_DRAWER_SOURCE = "NOTIFICATIONS_SET_DRAWER_SOURCE",
+  NOTIFICATIONS_SET_DRAWER_PROMPT_TARGET = "NOTIFICATIONS_SET_DRAWER_PROMPT_TARGET",
   NOTIFICATIONS_SET_DATA_OF_USER = "NOTIFICATIONS_SET_DATA_OF_USER",
   DANGEROUSLY_OVERRIDE_STATE = "DANGEROUSLY_OVERRIDE_STATE",
   NOTIFICATIONS_SET_PERMISSION_STATUS = "NOTIFICATIONS_SET_PERMISSION_STATUS",
@@ -161,6 +162,8 @@ export type NotificationsSetModalOpenPayload = NotificationsState["isPushNotific
 
 export type NotificationsSetDrawerSourcePayload = NotificationsState["drawerSource"];
 
+export type NotificationsSetDrawerPromptTargetPayload = NotificationsState["drawerPromptTarget"];
+
 export type NotificationSetPermissionStatusPayload = NotificationsState["permissionStatus"];
 
 export type NotificationsSetDataOfUserPayload = NotificationsState["dataOfUser"];
@@ -168,6 +171,7 @@ export type NotificationsSetDataOfUserPayload = NotificationsState["dataOfUser"]
 export type NotificationsPayload =
   | NotificationsSetModalOpenPayload
   | NotificationsSetDrawerSourcePayload
+  | NotificationsSetDrawerPromptTargetPayload
   | NotificationsSetDataOfUserPayload
   | NotificationSetPermissionStatusPayload;
 

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/index.ts
@@ -13,7 +13,12 @@ export {
   getNextRepromptDelay,
   shouldPromptOptInDrawerAfterAction,
 } from "./utils/notificationsPromptEngine";
-export type { DataOfUser, InitPushNotificationsDataResult } from "./types";
+export type {
+  DataOfUser,
+  InitPushNotificationsDataResult,
+  NotificationCategory,
+  NotificationPromptTarget,
+} from "./types";
 export type {
   AfterActionTriggerDecision,
   InactivityTriggerDecision,

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/types.ts
@@ -1,8 +1,17 @@
 import type { AuthorizationStatus } from "@react-native-firebase/messaging";
+import type { NotificationsSettings } from "~/reducers/types";
+
+export type NotificationCategory = Exclude<
+  keyof NotificationsSettings,
+  "areNotificationsAllowed" | "announcementsCategory" | "largeMoverCategory"
+>;
+
+export type NotificationPromptTarget = "globalPushNotifications" | NotificationCategory;
 
 export type DataOfUser = {
   // timestamps in ms of every time the user dismisses the opt in prompt (until he opts in)
   dismissedOptInDrawerAtList?: number[];
+  dismissedPromptAtListByTarget?: Partial<Record<NotificationPromptTarget, number[]>>;
 
   // timestamp in ms of the last action user did (swap, receive, send, favorite, etc.)
   lastActionAt?: number;

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/types.ts
@@ -1,4 +1,4 @@
-import type { AuthorizationStatus } from "@react-native-firebase/messaging";
+import { AuthorizationStatus } from "@react-native-firebase/messaging";
 import type { NotificationsSettings } from "~/reducers/types";
 
 export type NotificationCategory = Exclude<

--- a/apps/ledger-live-mobile/src/reducers/notifications.ts
+++ b/apps/ledger-live-mobile/src/reducers/notifications.ts
@@ -5,6 +5,7 @@ import type {
   NotificationsPayload,
   NotificationsSetDataOfUserPayload,
   NotificationsSetModalOpenPayload,
+  NotificationsSetDrawerPromptTargetPayload,
   NotificationsSetDrawerSourcePayload,
   DangerouslyOverrideStatePayload,
   NotificationSetPermissionStatusPayload,
@@ -14,6 +15,7 @@ import { NotificationsActionTypes } from "../actions/types";
 export const INITIAL_STATE: NotificationsState = {
   isPushNotificationsModalOpen: false,
   drawerSource: undefined,
+  drawerPromptTarget: undefined,
   dataOfUser: undefined,
   permissionStatus: undefined,
 };
@@ -26,6 +28,10 @@ const handlers: ReducerMap<NotificationsState, NotificationsPayload> = {
   [NotificationsActionTypes.NOTIFICATIONS_SET_DRAWER_SOURCE]: (state, action) => ({
     ...state,
     drawerSource: (action as Action<NotificationsSetDrawerSourcePayload>).payload,
+  }),
+  [NotificationsActionTypes.NOTIFICATIONS_SET_DRAWER_PROMPT_TARGET]: (state, action) => ({
+    ...state,
+    drawerPromptTarget: (action as Action<NotificationsSetDrawerPromptTargetPayload>).payload,
   }),
   [NotificationsActionTypes.NOTIFICATIONS_SET_DATA_OF_USER]: (state, action) => ({
     ...state,
@@ -49,6 +55,8 @@ export const notificationsModalOpenSelector = (s: State) =>
   s.notifications.isPushNotificationsModalOpen;
 
 export const notificationsDrawerSource = (s: State) => s.notifications.drawerSource;
+
+export const notificationsDrawerPromptTarget = (s: State) => s.notifications.drawerPromptTarget;
 
 export const notificationsDataOfUserSelector = (s: State) => s.notifications.dataOfUser;
 

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -6,7 +6,7 @@ import type { DeviceModelId } from "@ledgerhq/devices";
 import type { Currency, Unit } from "@ledgerhq/types-cryptoassets";
 import { MarketListRequestParams } from "@ledgerhq/live-common/market/utils/types";
 import { PostOnboardingState } from "@ledgerhq/types-live";
-import type { DataOfUser } from "LLM/features/NotificationsPrompt/types";
+import type { DataOfUser, NotificationPromptTarget } from "LLM/features/NotificationsPrompt/types";
 import type { RatingsHappyMoment, RatingsDataOfUser } from "../logic/ratings";
 import { WalletTabNavigatorStackParamList } from "../components/RootNavigator/types/WalletTabNavigator";
 import {
@@ -133,6 +133,7 @@ export type NotificationsState = {
     | "stake"
     | "add_favorite_coin"
     | "inactivity";
+  drawerPromptTarget?: NotificationPromptTarget;
   /** Data related to the user's app usage. We use this data to prompt the push notifications modal on certain conditions only */
   dataOfUser?: DataOfUser;
 };

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -390,6 +390,22 @@ export type Feature_TransactionsAlerts = Feature<{
   networks: ChainwatchNetwork[];
 }>;
 
+export type NotificationsPromptAfterActionSource =
+  | "onboarding"
+  | "send"
+  | "dapp_complete"
+  | "receive"
+  | "swap"
+  | "stake"
+  | "add_favorite_coin";
+
+export type NotificationsCategoryConfig = {
+  displayed: boolean;
+  category: string;
+  drawerPromptEnabled?: boolean;
+  drawerPromptActions?: NotificationsPromptAfterActionSource[];
+};
+
 export type Feature_SwapWalletApiPartnerList = Feature<{
   list: string[];
 }>;
@@ -479,10 +495,7 @@ export type Feature_BrazePushNotifications = Feature<{
     minutes: number;
     seconds: number;
   };
-  notificationsCategories: {
-    displayed: boolean;
-    category: string;
-  }[];
+  notificationsCategories: NotificationsCategoryConfig[];
 }>;
 
 export type Feature_ReceiveStakingFlowConfigDesktop = Feature<{

--- a/shared/feature-flags/src/flags/team-engagement/brazePushNotifications.ts
+++ b/shared/feature-flags/src/flags/team-engagement/brazePushNotifications.ts
@@ -33,9 +33,21 @@ const inactivityRepromptSchema = z.object({
   seconds: z.number(),
 });
 
+const notificationsPromptAfterActionSourceSchema = z.enum([
+  "onboarding",
+  "send",
+  "dapp_complete",
+  "receive",
+  "swap",
+  "stake",
+  "add_favorite_coin",
+]);
+
 const notificationsCategorySchema = z.object({
   displayed: z.boolean(),
   category: z.string(),
+  drawerPromptEnabled: z.boolean().optional(),
+  drawerPromptActions: z.array(notificationsPromptAfterActionSourceSchema).optional(),
 });
 
 export const brazePushNotifications = flagWith({


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Notification drawer state contracts on mobile
  - Stored notification user data shape
  - Braze push notification remote config category schema

### 📝 Description

The notification drawer currently tracks where it was triggered from, but Transaction Alerts needs the shared contracts to also identify what the drawer is asking the user to enable.

This PR adds the contract-only model for drawer prompt targets, stores an optional `drawerPromptTarget` next to `drawerSource`, adds per-target dismissal storage, and extends notification category remote config entries with optional drawer prompt fields. It intentionally does not change prompt eligibility, drawer rendering, CTA behavior, analytics, or dismissal migration.

Validation run locally:

- `pnpm --filter @shared/feature-flags typecheck`
- `pnpm --filter @ledgerhq/types-live build`
- `pnpm --filter @features/platform-feature-flags typecheck`
- `pnpm mobile test:jest apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/__tests__/notificationsPromptEngine.test.ts --runInBand`
- `pnpm --filter @shared/feature-flags test --runInBand`

Note: full `pnpm mobile typecheck` is currently blocked locally by unresolved `@features/platform-feature-flags` imports across the mobile app, unrelated to this change.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31496](https://ledgerhq.atlassian.net/browse/LIVE-31496)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-31496]: https://ledgerhq.atlassian.net/browse/LIVE-31496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ