### PR TITLE
[LWD] chore: add lastSeenDevice as fallback for onboarding completion scree…

### DIFF
--- a/.changeset/great-numbers-drive.md
+++ b/.changeset/great-numbers-drive.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add lastSeenDevice as fallback for onboarding completion screen to avoid confetti loop

--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompletion/__tests__/useCompletionScreenViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompletion/__tests__/useCompletionScreenViewModel.test.tsx
@@ -6,7 +6,7 @@ import { useRedirectToPostOnboardingCallback } from "~/renderer/hooks/useAutoRed
 import { State } from "~/renderer/reducers";
 import { Device, DeviceModelId } from "@ledgerhq/types-devices";
 import { useCompletionScreenViewModel } from "../useCompletionScreenViewModel";
-import { SettingsState } from "~/renderer/reducers/settings";
+import { AFTER_ONBOARDING_STATE, SettingsState } from "~/renderer/reducers/settings";
 
 const mockRedirectToPostOnboarding = jest.fn();
 
@@ -80,5 +80,28 @@ describe("useCompletionScreenViewModel", () => {
     });
 
     expect(mockRedirectToPostOnboarding).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to lastSeenDevice when currentDevice is null (disconnected)", () => {
+    const deviceId = DeviceModelId.stax;
+    const initialState: Partial<State> = {
+      devices: {
+        devices: [],
+        currentDevice: null,
+      },
+      settings: {
+        ...AFTER_ONBOARDING_STATE,
+        lastSeenDevice: {
+          modelId: deviceId,
+          deviceInfo: {} as never,
+          apps: [],
+        },
+      },
+    };
+
+    const { store } = renderHook(() => useCompletionScreenViewModel(), { initialState });
+
+    const { settings } = store.getState() as { settings: SettingsState };
+    expect(settings.lastOnboardedDevice).toHaveProperty("modelId", deviceId);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompletion/useCompletionScreenViewModel.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompletion/useCompletionScreenViewModel.tsx
@@ -41,14 +41,18 @@ export function useCompletionScreenViewModel(): ViewProps {
       dispatch(setHasRedirectedToPostOnboarding(false));
       dispatch(setHasBeenUpsoldRecover(false));
     }
-    dispatch(setLastOnboardedDevice(currentDevice));
+    // Fall back to lastSeenDevice when disconnected, so post-onboarding redirect still fires.
+    const onboardedDevice: Device | null =
+      currentDevice ??
+      (lastSeenDevice ? { deviceId: "", modelId: lastSeenDevice.modelId, wired: false } : null);
+    dispatch(setLastOnboardedDevice(onboardedDevice));
     const timeout = setTimeout(() => {
       redirectToPostOnboarding();
     }, COMPLETION_SCREEN_TIMEOUT);
     return () => {
       clearTimeout(timeout);
     };
-  }, [currentDevice, dispatch, redirectToPostOnboarding]);
+  }, [currentDevice, lastSeenDevice, dispatch, redirectToPostOnboarding]);
 
   return {
     seedConfiguration: state?.seedConfiguration,


### PR DESCRIPTION
…n to avoid confetti loop

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

When a device is disconnected whilst doing app installs in sync onboarding flow the confetti animation is looping indefinitely. This fix adds a fallback of lastSeenDevice to the completion screen which then fixes the infinite loop.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-28069


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
