### PR TITLE
[LWDM] refactor(LIVE-31333): unify aleo node endpoint env

### DIFF
--- a/.changeset/dirty-bags-eat.md
+++ b/.changeset/dirty-bags-eat.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-aleo": minor
+"@ledgerhq/live-common": minor
+"@ledgerhq/live-env": minor
+---
+
+refactor: unify aleo node endpoint env

--- a/libs/coin-modules/coin-aleo/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.integ.test.ts
@@ -14,7 +14,7 @@ describe("createApi", () => {
     {
       ...mockConfig,
       apiUrls: {
-        node: getEnv("ALEO_TESTNET_NODE_ENDPOINT"),
+        node: getEnv("ALEO_NODE_ENDPOINT"),
         sdk: getEnv("ALEO_TESTNET_SDK_ENDPOINT"),
       },
     },

--- a/libs/coin-modules/coin-aleo/src/logic/craftTransaction.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/craftTransaction.integ.test.ts
@@ -33,7 +33,7 @@ describe("craftTransaction", () => {
       status: { type: "active" },
       networkType: "testnet",
       apiUrls: {
-        node: getEnv("ALEO_TESTNET_NODE_ENDPOINT"),
+        node: getEnv("ALEO_NODE_ENDPOINT"),
         sdk: getEnv("ALEO_TESTNET_SDK_ENDPOINT"),
       },
       feeByTransactionType: {

--- a/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.integ.test.ts
@@ -17,7 +17,7 @@ describe("getPrivateBalance", () => {
       status: { type: "active" },
       networkType: "testnet",
       apiUrls: {
-        node: getEnv("ALEO_TESTNET_NODE_ENDPOINT"),
+        node: getEnv("ALEO_NODE_ENDPOINT"),
         sdk: getEnv("ALEO_TESTNET_SDK_ENDPOINT"),
       },
       feeByTransactionType: {

--- a/libs/env/src/env.ts
+++ b/libs/env/src/env.ts
@@ -307,7 +307,7 @@ const envDefinitions = {
     parser: stringParser,
     desc: "Thorest API for VeChain",
   },
-  ALEO_MAINNET_NODE_ENDPOINT: {
+  ALEO_NODE_ENDPOINT: {
     def: "https://aleo.coin.ledger.com",
     parser: stringParser,
     desc: "Aleo mainnet node URL",
@@ -316,11 +316,6 @@ const envDefinitions = {
     def: "https://aleo-backend.api.live.ledger.com/network/mainnet",
     parser: stringParser,
     desc: "Aleo mainnet SDK URL",
-  },
-  ALEO_TESTNET_NODE_ENDPOINT: {
-    def: "https://aleo.coin.ledger.com",
-    parser: stringParser,
-    desc: "Aleo testnet node URL",
   },
   ALEO_TESTNET_SDK_ENDPOINT: {
     def: "https://aleo-backend.api.live.ledger.com/network/testnet",

--- a/libs/ledger-live-common/src/families/aleo/config.ts
+++ b/libs/ledger-live-common/src/families/aleo/config.ts
@@ -50,7 +50,7 @@ export const aleoConfig: Record<string, ConfigInfo> = {
       },
       networkType: "mainnet",
       apiUrls: {
-        node: getEnv("ALEO_MAINNET_NODE_ENDPOINT"),
+        node: getEnv("ALEO_NODE_ENDPOINT"),
         sdk: getEnv("ALEO_MAINNET_SDK_ENDPOINT"),
       },
       feeByTransactionType: DEFAULT_FEE_BY_TRANSACTION_TYPE,
@@ -69,7 +69,7 @@ export const aleoConfig: Record<string, ConfigInfo> = {
       },
       networkType: "testnet",
       apiUrls: {
-        node: getEnv("ALEO_TESTNET_NODE_ENDPOINT"),
+        node: getEnv("ALEO_NODE_ENDPOINT"),
         sdk: getEnv("ALEO_TESTNET_SDK_ENDPOINT"),
       },
       feeByTransactionType: DEFAULT_FEE_BY_TRANSACTION_TYPE,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - single ALEO_NODE_ENDPOINT env for both mainnet and testnet, because of the `networkType` coming from coin configuration

### 📝 Description

This PR unifies Aleo node endpoint env to avoid confusion. Not every API endpoint starts with `/v2/:network_type` that we could hardcode in the env variable, so we are using `networkType` from coin configuration instead.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-31333

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
