### PR TITLE
[LWDM] fix hook error artifact gathering

### DIFF
--- a/e2e/mobile/jest.environment.ts
+++ b/e2e/mobile/jest.environment.ts
@@ -243,9 +243,14 @@ export default class TestEnvironment extends DetoxEnvironment {
   }
 
   async handleTestEvent(event: Circus.Event, state: Circus.State) {
+    if (event.name === "hook_failure") {
+      this.global.IS_FAILED = true;
+      await captureFailureDiagnostics();
+    }
+
     await super.handleTestEvent(event, state);
 
-    if (["hook_failure", "test_fn_failure"].includes(event.name)) {
+    if (event.name === "test_fn_failure") {
       this.global.IS_FAILED = true;
       await captureFailureDiagnostics();
     }

--- a/e2e/mobile/types/global.d.ts
+++ b/e2e/mobile/types/global.d.ts
@@ -29,6 +29,7 @@ declare global {
   var speculosDevices: Map<string, number>;
   var speculosStartupErrorMessage: string | undefined;
   var speculosFailureStderr: string | undefined;
+  var speculosFailedRunIds: Set<string> | undefined;
   var webSocket: {
     wss: Server | undefined;
     ws: WebSocket | undefined;

--- a/e2e/mobile/utils/speculosUtils.ts
+++ b/e2e/mobile/utils/speculosUtils.ts
@@ -12,6 +12,7 @@ import {
   waitForSpeculosReady,
   fetchSpeculinhoLogs,
   fetchSpeculinhoStatus,
+  getSpeculinhoRunIdFromError,
 } from "@ledgerhq/live-common/e2e/speculosCI";
 import { isSpeculosRemote } from "../helpers/commonHelpers";
 import { addKnownSpeculos, getEnvs, removeKnownSpeculos } from "../bridge/server";
@@ -106,6 +107,10 @@ export async function launchSpeculos(appName: string) {
     const err = e instanceof Error ? e : new Error(String(e));
     globalThis.speculosStartupErrorMessage = err.message;
     globalThis.speculosFailureStderr = getCapturedStderr();
+    const failedRunId = getSpeculinhoRunIdFromError(e);
+    if (failedRunId) {
+      (globalThis.speculosFailedRunIds ??= new Set()).add(failedRunId);
+    }
     await attachSpeculosOutputToAllure(err.message);
     const message = ["[E2E Setup] Speculos failed to start.", err.message]
       .filter(Boolean)
@@ -217,11 +222,17 @@ export async function deleteSpeculos(deviceId?: string): Promise<number | undefi
 }
 
 export async function attachSpeculinhoLogsToAllure() {
-  if (!speculosDevices.size && !isSpeculosRemote()) {
+  if (!isSpeculosRemote()) {
     return;
   }
 
-  for (const [deviceId] of speculosDevices.entries()) {
+  const deviceIds = new Set<string>(speculosDevices.keys());
+  for (const runId of globalThis.speculosFailedRunIds ?? []) {
+    deviceIds.add(runId);
+  }
+  globalThis.speculosFailedRunIds?.clear();
+
+  for (const deviceId of deviceIds) {
     try {
       const [logs, status] = await Promise.all([
         fetchSpeculinhoLogs(deviceId),

--- a/libs/ledger-live-common/src/e2e/index.ts
+++ b/libs/ledger-live-common/src/e2e/index.ts
@@ -76,6 +76,10 @@ export const sanitizeError = (error: unknown): Error => {
       if (error.stack) {
         sanitized.stack = error.stack;
       }
+      const runId = (error as { runId?: unknown }).runId;
+      if (typeof runId === "string") {
+        Object.assign(sanitized, { runId });
+      }
       return sanitized;
     }
     return new Error(String(error ?? "Unknown error"));

--- a/libs/ledger-live-common/src/e2e/speculos.ts
+++ b/libs/ledger-live-common/src/e2e/speculos.ts
@@ -457,10 +457,10 @@ export async function startSpeculos(
   if (!isSpeculosRemote) {
     invariant(COINAPPS, "COINAPPS is not set");
     const assertElfExists = (n: string, v: string) => {
-      const fullPath = path.join(COINAPPS!, conventionalAppSubpath(model, firmware, n, v));
+      const fullPath = path.join(COINAPPS, conventionalAppSubpath(model, firmware, n, v));
       invariant(existsSync(fullPath), "%s: app binary not found at %s", testName, fullPath);
     };
-    assertElfExists(appName, appVersion!);
+    assertElfExists(appName, appVersion);
     dependencies?.forEach(dep => {
       assertElfExists(dep.name, dep.appVersion);
     });
@@ -470,8 +470,8 @@ export async function startSpeculos(
     model,
     firmware,
     appName,
-    appVersion: appVersion!,
-    seed: SEED!,
+    appVersion: appVersion,
+    seed: SEED,
     coinapps: COINAPPS ?? "",
     dependencies,
     onSpeculosDeviceCreated,

--- a/libs/ledger-live-common/src/e2e/speculosCI.ts
+++ b/libs/ledger-live-common/src/e2e/speculosCI.ts
@@ -141,6 +141,28 @@ function formatAcquireFailure(status: number, data: unknown): string {
   return `Speculinho POST /acquire failed with HTTP ${status}${body ? `: ${body}` : ""}`;
 }
 
+/**
+ * Error thrown when Speculinho `/acquire` fails.
+ * Carries the `run_id` so we can still fetch `/status` and `/logs`.
+ */
+export class SpeculinhoAcquireError extends Error {
+  readonly runId: string;
+  constructor(message: string, runId: string) {
+    super(message);
+    this.name = "SpeculinhoAcquireError";
+    this.runId = runId;
+  }
+}
+
+export function getSpeculinhoRunIdFromError(error: unknown): string | undefined {
+  if (error instanceof SpeculinhoAcquireError) return error.runId;
+  if (error && typeof error === "object" && "runId" in error) {
+    const { runId } = error as { runId?: unknown };
+    if (typeof runId === "string" && runId) return runId;
+  }
+  return undefined;
+}
+
 export async function createSpeculosDeviceCI(
   deviceParams: DeviceParams,
 ): Promise<SpeculosDevice | undefined> {
@@ -188,11 +210,12 @@ export async function createSpeculosDeviceCI(
       continue;
     }
 
-    throw new Error(formatAcquireFailure(res.status, res.data));
+    throw new SpeculinhoAcquireError(formatAcquireFailure(res.status, res.data), runId);
   }
 
-  throw new Error(
+  throw new SpeculinhoAcquireError(
     `[speculosCI] Speculinho /acquire failed after retries (run_id collisions). Last run_id: ${runId}`,
+    runId,
   );
 }
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached. (no need)
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - E2E mobile

### 📝 Description

This PR improves E2E mobile CI diagnostics for remote Speculos (Speculinho) startup failures—especially when failures happen in Jest hooks—by propagating the Speculinho run_id through errors so /status and /logs can still be fetched and attached to Allure.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- Mobile [run](https://github.com/LedgerHQ/ledger-live/actions/runs/26736580158)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
