### PR TITLE
fix(LIVE-28498): swap history previous uses correct back transition

### DIFF
--- a/.changeset/fix-swap-history-previous-transition.md
+++ b/.changeset/fix-swap-history-previous-transition.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix the Swap history "Previous" button playing the forward (push) transition instead of the back (pop) one in Wallet 4.0. The history sub-screen is pushed on top of Main, so we now pop the parent navigator instead of resetting it, restoring the correct left-to-right back animation.

--- a/apps/ledger-live-mobile/src/screens/Swap/navigation/__tests__/navigateBackToSwapTab.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/navigation/__tests__/navigateBackToSwapTab.test.ts
@@ -1,5 +1,5 @@
 import { CommonActions } from "@react-navigation/native";
-import { NavigatorName, ScreenName } from "~/const";
+import { BASE_NAVIGATOR_ID, ScreenName } from "~/const";
 import { hasSwapTabRoute, navigateBackToSwapTab } from "../navigateBackToSwapTab";
 
 describe("navigateBackToSwapTab", () => {
@@ -12,16 +12,18 @@ describe("navigateBackToSwapTab", () => {
   }) => {
     const dispatch = jest.fn();
     const goBack = jest.fn();
+    const getParent = jest.fn(() => parentNavigation);
 
     return {
       navigation: {
         dispatch,
         getState: () => ({ routeNames }) as const,
-        getParent: () => parentNavigation,
+        getParent,
         goBack,
       },
       dispatch,
       goBack,
+      getParent,
     };
   };
 
@@ -48,10 +50,10 @@ describe("navigateBackToSwapTab", () => {
     expect(goBack).not.toHaveBeenCalled();
   });
 
-  it("should reset root navigation through Main and Swap in Wallet40", () => {
+  it("should go back through the Base navigator in Wallet40", () => {
     const parentDispatch = jest.fn();
     const parentGoBack = jest.fn();
-    const { navigation, dispatch } = createNavigation({
+    const { navigation, dispatch, goBack, getParent } = createNavigation({
       routeNames: [ScreenName.SwapHistory],
       parentNavigation: { dispatch: parentDispatch, goBack: parentGoBack },
     });
@@ -60,24 +62,12 @@ describe("navigateBackToSwapTab", () => {
       navigation,
     });
 
+    // The Base navigator must be targeted explicitly by id, not by tree position.
+    expect(getParent).toHaveBeenCalledWith(BASE_NAVIGATOR_ID);
     expect(dispatch).not.toHaveBeenCalled();
-    expect(parentDispatch).toHaveBeenCalledWith(
-      CommonActions.reset({
-        index: 0,
-        routes: [
-          {
-            name: NavigatorName.Main,
-            params: {
-              screen: NavigatorName.Swap,
-              params: {
-                screen: ScreenName.SwapTab,
-              },
-            },
-          },
-        ],
-      }),
-    );
-    expect(parentGoBack).not.toHaveBeenCalled();
+    expect(goBack).not.toHaveBeenCalled();
+    expect(parentDispatch).not.toHaveBeenCalled();
+    expect(parentGoBack).toHaveBeenCalledTimes(1);
   });
 
   it("should fallback to goBack when no parent navigation exists", () => {

--- a/apps/ledger-live-mobile/src/screens/Swap/navigation/navigateBackToSwapTab.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/navigation/navigateBackToSwapTab.ts
@@ -1,5 +1,5 @@
 import { CommonActions } from "@react-navigation/native";
-import { NavigatorName, ScreenName } from "~/const";
+import { BASE_NAVIGATOR_ID, ScreenName } from "~/const";
 
 type NavigationStateWithRouteNames = {
   routeNames?: string[];
@@ -8,7 +8,7 @@ type NavigationStateWithRouteNames = {
 type NavigationWithState = {
   dispatch(action: ReturnType<typeof CommonActions.reset>): void;
   getState(): NavigationStateWithRouteNames | undefined;
-  getParent():
+  getParent(id?: string):
     | {
         dispatch(action: ReturnType<typeof CommonActions.reset>): void;
         goBack(): void;
@@ -22,23 +22,6 @@ export function hasSwapTabRoute(state: NavigationStateWithRouteNames | undefined
   return Array.isArray(routeNames) && routeNames.includes(ScreenName.SwapTab);
 }
 
-function getResetToSwapTabAction() {
-  return CommonActions.reset({
-    index: 0,
-    routes: [
-      {
-        name: NavigatorName.Main,
-        params: {
-          screen: NavigatorName.Swap,
-          params: {
-            screen: ScreenName.SwapTab,
-          },
-        },
-      },
-    ],
-  });
-}
-
 export function navigateBackToSwapTab({ navigation }: { navigation: NavigationWithState }) {
   if (hasSwapTabRoute(navigation.getState())) {
     navigation.dispatch(
@@ -50,14 +33,23 @@ export function navigateBackToSwapTab({ navigation }: { navigation: NavigationWi
     return;
   }
 
-  const parentNavigation = navigation.getParent();
+  // Wallet 4.0: the Swap sub-screens navigator is pushed on top of Main (which
+  // is already on the Swap tab) directly under the Base navigator. We target
+  // Base explicitly via its id rather than positional getParent() so popping
+  // always removes the whole sub-screens navigator and returns to the Swap tab
+  // — a bare getParent() silently resolves by tree position and would break if
+  // a navigator level were ever inserted in between. See LIVE-28498.
+  const baseNavigation = navigation.getParent(BASE_NAVIGATOR_ID);
 
-  if (!parentNavigation) {
+  if (!baseNavigation) {
     navigation.goBack();
     return;
   }
 
-  parentNavigation.dispatch(getResetToSwapTabAction());
+  // goBack (rather than a reset) so the transition plays the natural back (pop)
+  // animation; a reset replays the forward (push) animation and the screen
+  // slides out the wrong way.
+  baseNavigation.goBack();
 }
 
 export function isGoingToSwapHistory(payload: unknown) {


### PR DESCRIPTION
## ✅ Checklist

- [x] Bug fix (non-breaking change which fixes an issue)

## 📝 Description

Fixes [LIVE-28498](https://ledgerhq.atlassian.net/browse/LIVE-28498).

In Ledger Live Mobile with Wallet 4.0, navigating **Swap → Swap history → Previous** played the wrong screen transition: the history screen slid out **right-to-left** (the forward/push animation) instead of **left-to-right** (the back/pop animation).

### Root cause

The Swap history back button calls `navigateBackToSwapTab`, whose Wallet 4.0 branch dispatched a `CommonActions.reset` on the parent (`BaseNavigator`). A `reset` replays the forward (push) transition, so the screen animated as if a new screen were being pushed.

### Fix

The `SwapSubScreens` navigator (which hosts Swap history) is registered as a single entry in `BaseNavigator` and is **pushed on top of `Main`**, which is already sitting on the Swap tab (`Main → Swap → SwapTab`). So instead of resetting, we resolve the `BaseNavigator` explicitly and call `goBack()` on it to pop the sub-screens navigator off — landing back on the Swap tab and playing the natural back (pop) animation.

We target the Base navigator by its id (`navigation.getParent(BASE_NAVIGATOR_ID)`) rather than relying on positional `getParent()`, in line with the repo convention (and the analogous Earn live-app sub-flow). A bare `getParent()` resolves by tree position and would silently break if a navigator level were ever inserted between `SwapSubScreens` and `BaseNavigator`.

[LIVE-28498]: https://ledgerhq.atlassian.net/browse/LIVE-28498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


https://github.com/user-attachments/assets/09d99a4d-b1ab-46ac-8ae0-4b3e7fb946b2

https://github.com/user-attachments/assets/ef4d8fec-8191-4c3f-9089-c8cd09883009
