### PR TITLE
[LWM] feat(mobile): update Analytics profit and loss section

### DIFF
--- a/.changeset/lwm-pnl-update.md
+++ b/.changeset/lwm-pnl-update.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Update the Analytics page Profit and loss section: replace the cost basis card with a realised return card (Unrealised + Realised), add a tappable "Profit and loss" subheader that opens the detail drawer, and refresh the detail drawer copy.

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8163,27 +8163,27 @@
       }
     },
     "portfolio": {
+      "title": "Profit and loss",
       "return": {
         "title": "Unrealised return"
       },
-      "costBasis": {
-        "title": "Cost basis",
-        "tooltip": "The total amount you paid to acquire your current holdings, including fees."
+      "realised": {
+        "title": "Realised return"
       },
       "drawer": {
-        "title": "Portfolio profit and loss",
-        "description": "Your portfolio performance broken down into estimated and realised returns.",
+        "title": "Profit and loss",
+        "description": "Your portfolio performance broken down into estimated unrealised and realised return.",
         "estimatedReturn": {
-          "title": "Estimated return",
+          "title": "Unrealised return",
           "description": "The estimated profit or loss if sold at current price."
         },
         "realisedReturn": {
           "title": "Realised return",
-          "description": "Profit or loss confirmed from previous sale, send, or swap."
+          "description": "Profit or loss estimated from previous sale, send or swap."
         },
         "totalReturn": {
           "title": "Total return",
-          "description": "The sum of estimated and realised returns."
+          "description": "The sum of estimated unrealised and realised returns."
         }
       }
     }

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/__tests__/PnlSection.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/__tests__/PnlSection.integration.test.tsx
@@ -1,10 +1,8 @@
-import React, { useState } from "react";
-import { Pressable, Text } from "react-native";
+import React from "react";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import { genAccount } from "@ledgerhq/live-common/mock/account";
 import { render, screen, withFlagOverrides } from "@tests/test-renderer";
 import { State } from "~/reducers/types";
-import { PnlDetailDrawer } from "LLM/features/Pnl/components/PnlDetailDrawer";
 import PnlSection, { PNL_SECTION_TEST_IDS } from "..";
 
 const btcAccount = genAccount("btc-1", {
@@ -28,54 +26,24 @@ const withPnl = (enabled: boolean) =>
     withFlagOverrides({ lwmWallet40: { enabled: true, params: { pnl: enabled } } }),
   );
 
-const OPEN_BUTTON_TEST_ID = "open-drawer-button";
-
-type Variant = "pnl" | "costBasis";
-
-function DrawerOpener({ variant }: { variant: Variant }) {
-  const [open, setOpen] = useState(false);
-  return (
-    <>
-      <Pressable testID={OPEN_BUTTON_TEST_ID} onPress={() => setOpen(true)}>
-        <Text>Open</Text>
-      </Pressable>
-      {open ? (
-        variant === "pnl" ? (
-          <PnlDetailDrawer
-            isOpen
-            onClose={() => setOpen(false)}
-            title="Portfolio profit and loss"
-            description="Your portfolio performance broken down into estimated and realised returns."
-            items={[
-              {
-                title: "Estimated return",
-                value: "+ $243.32",
-                definition: "The estimated profit or loss if sold at current price.",
-              },
-            ]}
-            footer="This data is provided for informational purposes only and is not financial advice. Not to be used for tax purposes."
-          />
-        ) : (
-          <PnlDetailDrawer
-            isOpen
-            onClose={() => setOpen(false)}
-            title="Cost basis"
-            bodyText="The total amount you paid to acquire your current holdings, including fees."
-          />
-        )
-      ) : null}
-    </>
-  );
-}
+const DRAWER_DESCRIPTION =
+  "Your portfolio performance broken down into estimated unrealised and realised return.";
+const DISCLAIMER =
+  "This data is provided for informational purposes only and is not financial advice. Not to be used for tax purposes.";
 
 describe("PnlSection integration", () => {
   describe("feature flag gating", () => {
-    it("renders both PnL cards when shouldDisplayPnl is true and there are accounts", () => {
+    it("renders the title, both return cards and the detail drawer copy when shouldDisplayPnl is true and there are accounts", () => {
       render(<PnlSection />, { overrideInitialState: withPnl(true) });
 
       expect(screen.getByTestId(PNL_SECTION_TEST_IDS.root)).toBeVisible();
+      expect(screen.getByTestId(PNL_SECTION_TEST_IDS.title)).toBeVisible();
       expect(screen.getByTestId(PNL_SECTION_TEST_IDS.unrealisedCard)).toBeVisible();
-      expect(screen.getByTestId(PNL_SECTION_TEST_IDS.costBasisCard)).toBeVisible();
+      expect(screen.getByTestId(PNL_SECTION_TEST_IDS.realisedCard)).toBeVisible();
+      // The detail drawer copy is wired through the view model.
+      expect(screen.getByText(DRAWER_DESCRIPTION)).toBeVisible();
+      expect(screen.getByText("Total return")).toBeVisible();
+      expect(screen.getByText(DISCLAIMER)).toBeVisible();
     });
 
     it("renders nothing when shouldDisplayPnl is false", () => {
@@ -96,37 +64,12 @@ describe("PnlSection integration", () => {
   });
 
   describe("drawer opening", () => {
-    it("renders the PnL detail drawer with header, items and disclaimer when its open button is pressed", async () => {
-      const { user } = render(<DrawerOpener variant="pnl" />);
+    it("keeps the section mounted when the title is pressed to open the detail drawer", async () => {
+      const { user } = render(<PnlSection />, { overrideInitialState: withPnl(true) });
 
-      expect(screen.queryByText("Portfolio profit and loss")).toBeNull();
+      await user.press(screen.getByTestId(PNL_SECTION_TEST_IDS.title));
 
-      await user.press(screen.getByTestId(OPEN_BUTTON_TEST_ID));
-
-      expect(screen.getByText("Portfolio profit and loss")).toBeVisible();
-      expect(
-        screen.getByText(
-          "Your portfolio performance broken down into estimated and realised returns.",
-        ),
-      ).toBeVisible();
-      expect(screen.getByText("Estimated return")).toBeVisible();
-      expect(
-        screen.getByText(
-          "This data is provided for informational purposes only and is not financial advice. Not to be used for tax purposes.",
-        ),
-      ).toBeVisible();
-    });
-
-    it("renders the cost basis drawer when its open button is pressed", async () => {
-      const { user } = render(<DrawerOpener variant="costBasis" />);
-      const body = "The total amount you paid to acquire your current holdings, including fees.";
-
-      expect(screen.queryByText(body)).toBeNull();
-
-      await user.press(screen.getByTestId(OPEN_BUTTON_TEST_ID));
-
-      expect(screen.getByText("Cost basis")).toBeVisible();
-      expect(screen.getByText(body)).toBeVisible();
+      expect(screen.getByTestId(PNL_SECTION_TEST_IDS.root)).toBeVisible();
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/__tests__/usePnlSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/__tests__/usePnlSectionViewModel.test.ts
@@ -35,66 +35,45 @@ const withPnl = (enabled: boolean) =>
   );
 
 describe("usePnlSectionViewModel", () => {
-  it("keeps both drawers closed by default", () => {
+  it("keeps the detail drawer closed by default", () => {
     const { result } = renderHook(() => usePnlSectionViewModel(), {
       overrideInitialState: withPnl(true),
     });
 
-    expect(result.current.pnlDrawer.isOpen).toBe(false);
-    expect(result.current.secondaryDrawer.isOpen).toBe(false);
+    expect(result.current.drawer.isOpen).toBe(false);
   });
 
-  it("opens the PnL drawer when the unrealised card press handler runs", () => {
+  it("opens the detail drawer when the title press handler runs", () => {
     const { result } = renderHook(() => usePnlSectionViewModel(), {
       overrideInitialState: withPnl(true),
     });
 
-    act(() => result.current.unrealised.onPress());
+    act(() => result.current.openDrawer());
 
-    expect(result.current.pnlDrawer.isOpen).toBe(true);
-    expect(result.current.secondaryDrawer.isOpen).toBe(false);
+    expect(result.current.drawer.isOpen).toBe(true);
   });
 
-  it("opens the secondary drawer when the secondary card press handler runs", () => {
+  it("closes the detail drawer when its onClose runs", () => {
     const { result } = renderHook(() => usePnlSectionViewModel(), {
       overrideInitialState: withPnl(true),
     });
 
-    act(() => result.current.secondary.onPress());
+    act(() => result.current.openDrawer());
+    expect(result.current.drawer.isOpen).toBe(true);
 
-    expect(result.current.pnlDrawer.isOpen).toBe(false);
-    expect(result.current.secondaryDrawer.isOpen).toBe(true);
+    act(() => result.current.drawer.onClose());
+    expect(result.current.drawer.isOpen).toBe(false);
   });
 
-  it("closes the open drawer when its onClose runs", () => {
+  it("exposes an unrealised and a realised return card", () => {
     const { result } = renderHook(() => usePnlSectionViewModel(), {
       overrideInitialState: withPnl(true),
     });
 
-    act(() => result.current.unrealised.onPress());
-    expect(result.current.pnlDrawer.isOpen).toBe(true);
-
-    act(() => result.current.pnlDrawer.onClose());
-    expect(result.current.pnlDrawer.isOpen).toBe(false);
-
-    act(() => result.current.secondary.onPress());
-    expect(result.current.secondaryDrawer.isOpen).toBe(true);
-
-    act(() => result.current.secondaryDrawer.onClose());
-    expect(result.current.secondaryDrawer.isOpen).toBe(false);
-  });
-
-  it("opening one drawer closes the other (single-drawer state machine)", () => {
-    const { result } = renderHook(() => usePnlSectionViewModel(), {
-      overrideInitialState: withPnl(true),
-    });
-
-    act(() => result.current.unrealised.onPress());
-    expect(result.current.pnlDrawer.isOpen).toBe(true);
-
-    act(() => result.current.secondary.onPress());
-    expect(result.current.pnlDrawer.isOpen).toBe(false);
-    expect(result.current.secondaryDrawer.isOpen).toBe(true);
+    expect(result.current.unrealised.title).toBe("Unrealised return");
+    expect(result.current.realised.title).toBe("Realised return");
+    expect(result.current.unrealised.value).toBeTruthy();
+    expect(result.current.realised.value).toBeTruthy();
   });
 
   describe("rendering gate", () => {
@@ -124,7 +103,7 @@ describe("usePnlSectionViewModel", () => {
       });
 
       expect(result.current.unrealised.value).toContain("***");
-      expect(result.current.secondary.value).toContain("***");
+      expect(result.current.realised.value).toContain("***");
     });
 
     it("masks every drawer item value when discreet mode is on", () => {
@@ -132,7 +111,7 @@ describe("usePnlSectionViewModel", () => {
         overrideInitialState: compose(withPnl(true), withDiscreet(true)),
       });
 
-      for (const item of result.current.pnlDrawer.items) {
+      for (const item of result.current.drawer.items) {
         expect(item.value).toContain("***");
       }
     });
@@ -143,8 +122,8 @@ describe("usePnlSectionViewModel", () => {
       });
 
       expect(result.current.unrealised.value).not.toContain("***");
-      expect(result.current.secondary.value).not.toContain("***");
-      for (const item of result.current.pnlDrawer.items) {
+      expect(result.current.realised.value).not.toContain("***");
+      for (const item of result.current.drawer.items) {
         expect(item.value).not.toContain("***");
       }
     });
@@ -182,7 +161,7 @@ describe("usePnlSectionViewModel", () => {
       expect((accountsArg as unknown[]).length).toBeGreaterThan(0);
     });
 
-    it("falls back to a zero cost basis when usePortfolioPnL returns an empty object", () => {
+    it("falls back to zero returns when usePortfolioPnL returns an empty object", () => {
       // @ts-expect-error mockReturnValue expects a PortfolioPnL, but we're returning an empty object
       spy.mockReturnValue({});
 
@@ -190,7 +169,8 @@ describe("usePnlSectionViewModel", () => {
         overrideInitialState: withPnl(true),
       });
 
-      expect(result.current.secondary.value).toMatch(/0(?:[.,]00)?/);
+      expect(result.current.unrealised.value).toMatch(/0(?:[.,]00)?/);
+      expect(result.current.realised.value).toMatch(/0(?:[.,]00)?/);
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/index.tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { Box } from "@ledgerhq/lumen-ui-rnative";
+import {
+  Box,
+  Subheader,
+  SubheaderRow,
+  SubheaderTitle,
+  SubheaderShowMore,
+} from "@ledgerhq/lumen-ui-rnative";
 import { PnlCard } from "LLM/features/Pnl/components/PnlCard";
 import { PnlDetailDrawer } from "LLM/features/Pnl/components/PnlDetailDrawer";
 import { PNL_SECTION_TEST_IDS } from "./testIds";
@@ -8,53 +14,48 @@ import { usePnlSectionViewModel } from "./usePnlSectionViewModel";
 export { PNL_SECTION_TEST_IDS };
 
 export default function PnlSection() {
-  const { shouldDisplayPnl, unrealised, secondary, pnlDrawer, secondaryDrawer } =
+  const { shouldDisplayPnl, title, unrealised, realised, openDrawer, drawer } =
     usePnlSectionViewModel();
 
   if (!shouldDisplayPnl) return null;
 
   return (
-    <>
-      <Box
-        lx={{ flexDirection: "row", gap: "s8", paddingHorizontal: "s16" }}
-        testID={PNL_SECTION_TEST_IDS.root}
-      >
+    <Box lx={{ gap: "s12", paddingHorizontal: "s16" }} testID={PNL_SECTION_TEST_IDS.root}>
+      <Subheader>
+        <SubheaderRow onPress={openDrawer} testID={PNL_SECTION_TEST_IDS.title}>
+          <SubheaderTitle>{title}</SubheaderTitle>
+          <SubheaderShowMore />
+        </SubheaderRow>
+      </Subheader>
+      <Box lx={{ flexDirection: "row", gap: "s8" }}>
         <Box lx={{ flex: 1 }}>
           <PnlCard
-            type="interactive"
+            type="value"
             title={unrealised.title}
             value={unrealised.value}
             trend={unrealised.trend}
-            onPress={unrealised.onPress}
             testID={PNL_SECTION_TEST_IDS.unrealisedCard}
           />
         </Box>
         <Box lx={{ flex: 1 }}>
           <PnlCard
-            type="info"
-            title={secondary.title}
-            value={secondary.value}
-            onPress={secondary.onPress}
-            testID={PNL_SECTION_TEST_IDS.costBasisCard}
+            type="value"
+            title={realised.title}
+            value={realised.value}
+            trend={realised.trend}
+            testID={PNL_SECTION_TEST_IDS.realisedCard}
           />
         </Box>
       </Box>
       <PnlDetailDrawer
-        isOpen={pnlDrawer.isOpen}
-        onClose={pnlDrawer.onClose}
-        title={pnlDrawer.title}
-        description={pnlDrawer.description}
-        items={pnlDrawer.items}
-        footer={pnlDrawer.footer}
+        isOpen={drawer.isOpen}
+        onClose={drawer.onClose}
+        title={drawer.title}
+        description={drawer.description}
+        items={drawer.items}
+        footer={drawer.footer}
         testID={PNL_SECTION_TEST_IDS.detailDrawer}
       />
-      <PnlDetailDrawer
-        isOpen={secondaryDrawer.isOpen}
-        onClose={secondaryDrawer.onClose}
-        title={secondaryDrawer.title}
-        bodyText={secondaryDrawer.bodyText}
-        testID={PNL_SECTION_TEST_IDS.costBasisDrawer}
-      />
-    </>
+    </Box>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/testIds.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/testIds.ts
@@ -1,7 +1,7 @@
 export const PNL_SECTION_TEST_IDS = {
   root: "analytics-pnl-section",
+  title: "analytics-pnl-title",
   unrealisedCard: "analytics-pnl-unrealised-card",
-  costBasisCard: "analytics-pnl-cost-basis-card",
+  realisedCard: "analytics-pnl-realised-card",
   detailDrawer: "analytics-pnl-detail-drawer",
-  costBasisDrawer: "analytics-pnl-cost-basis-drawer",
 } as const;

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/types.ts
@@ -1,0 +1,19 @@
+import type { PnlReturnCard } from "LLM/features/Pnl/types";
+import type { PnlDetailItem } from "LLM/features/Pnl/components/PnlDetailDrawer/types";
+
+export type PnlSectionViewModel = {
+  shouldDisplayPnl: boolean;
+  /** Section heading ("Profit and loss") that opens the detail drawer. */
+  title: string;
+  unrealised: PnlReturnCard;
+  realised: PnlReturnCard;
+  openDrawer: () => void;
+  drawer: {
+    isOpen: boolean;
+    onClose: () => void;
+    title: string;
+    description: string;
+    items: PnlDetailItem[];
+    footer: string;
+  };
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/usePnlSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/usePnlSectionViewModel.ts
@@ -1,35 +1,96 @@
+import { useCallback, useMemo, useState } from "react";
 import { BigNumber } from "bignumber.js";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import { usePortfolioPnL } from "@ledgerhq/wallet-pnl/hooks";
+import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { useSelector } from "~/context/hooks";
+import { useLocale, useTranslation } from "~/context/Locale";
 import { shallowAccountsSelector } from "~/reducers/accounts";
 import { useCountervaluesState } from "~/reducers/countervalues";
-import { counterValueCurrencySelector } from "~/reducers/settings";
-import { usePnlViewModelBase } from "LLM/features/Pnl/hooks/usePnlViewModelBase";
-import type { PnlViewModel } from "LLM/features/Pnl/types";
+import { counterValueCurrencySelector, discreetModeSelector } from "~/reducers/settings";
+import { buildReturnCard } from "LLM/features/Pnl/builders/buildReturnCard";
+import { buildPnlDetail } from "LLM/features/Pnl/builders/buildPnlDetail";
+import type { PnlSectionViewModel } from "./types";
 
 const ZERO = new BigNumber(0);
 const EMPTY_ACCOUNTS: Parameters<typeof usePortfolioPnL>[0] = [];
 
-export function usePnlSectionViewModel(): PnlViewModel {
-  const { shouldDisplayPnl } = useWalletFeaturesConfig("mobile");
+export function usePnlSectionViewModel(): PnlSectionViewModel {
+  const { t } = useTranslation();
+  const { locale } = useLocale();
+  const { shouldDisplayPnl: isPnlFlagOn } = useWalletFeaturesConfig("mobile");
   const accounts = useSelector(shallowAccountsSelector);
   const countervalues = useCountervaluesState();
   const fiat = useSelector(counterValueCurrencySelector);
+  const discreet = useSelector(discreetModeSelector);
 
   // Skip the (potentially expensive) portfolio walk when the section is hidden.
-  const pnl = usePortfolioPnL(shouldDisplayPnl ? accounts : EMPTY_ACCOUNTS, countervalues, fiat);
-  const { costBasis = ZERO } = pnl;
+  const pnl = usePortfolioPnL(isPnlFlagOn ? accounts : EMPTY_ACCOUNTS, countervalues, fiat);
+  const { unrealisedPnL = ZERO, realisedPnL = ZERO, totalPnL = ZERO } = pnl ?? {};
 
-  return usePnlViewModelBase({
-    namespace: "pnl.portfolio",
-    pnlData: pnl,
-    secondaryCard: {
-      id: "costBasis",
-      titleKey: "pnl.portfolio.costBasis.title",
-      tooltipKey: "pnl.portfolio.costBasis.tooltip",
-      value: costBasis,
+  const [isDrawerOpen, setDrawerOpen] = useState(false);
+  const openDrawer = useCallback(() => setDrawerOpen(true), []);
+  const closeDrawer = useCallback(() => setDrawerOpen(false), []);
+
+  const formatFiat = useCallback(
+    (value: BigNumber, alwaysShowSign?: boolean) =>
+      formatCurrencyUnit(fiat.units[0], value, {
+        showCode: true,
+        locale,
+        discreet,
+        alwaysShowSign,
+      }),
+    [fiat, locale, discreet],
+  );
+
+  const unrealised = useMemo(
+    () =>
+      buildReturnCard({
+        titleKey: "pnl.portfolio.return.title",
+        amount: unrealisedPnL,
+        formatFiat,
+        t,
+      }),
+    [unrealisedPnL, formatFiat, t],
+  );
+
+  const realised = useMemo(
+    () =>
+      buildReturnCard({
+        titleKey: "pnl.portfolio.realised.title",
+        amount: realisedPnL,
+        formatFiat,
+        t,
+      }),
+    [realisedPnL, formatFiat, t],
+  );
+
+  const detail = useMemo(
+    () =>
+      buildPnlDetail({
+        namespace: "pnl.portfolio",
+        totalPnL,
+        unrealisedPnL,
+        realisedPnL,
+        formatFiat,
+        t,
+      }),
+    [totalPnL, unrealisedPnL, realisedPnL, formatFiat, t],
+  );
+
+  return {
+    shouldDisplayPnl: isPnlFlagOn && accounts.length > 0,
+    title: t("pnl.portfolio.title"),
+    unrealised,
+    realised,
+    openDrawer,
+    drawer: {
+      isOpen: isDrawerOpen,
+      onClose: closeDrawer,
+      title: detail.title,
+      description: detail.description,
+      items: detail.items,
+      footer: t("pnl.disclaimer"),
     },
-    accountsCount: accounts.length,
-  });
+  };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/builders/buildReturnCard.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/builders/buildReturnCard.ts
@@ -1,0 +1,24 @@
+import type { BigNumber } from "bignumber.js";
+import type { TFunction } from "i18next";
+import { trendFromSign } from "@ledgerhq/wallet-pnl";
+import type { PnlReturnCard } from "../types";
+
+export type BuildReturnCardInput = {
+  titleKey: string;
+  amount: BigNumber;
+  formatFiat: (value: BigNumber) => string;
+  t: TFunction;
+};
+
+export function buildReturnCard({
+  titleKey,
+  amount,
+  formatFiat,
+  t,
+}: BuildReturnCardInput): PnlReturnCard {
+  return {
+    title: t(titleKey),
+    value: formatFiat(amount),
+    trend: trendFromSign(amount),
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlCard/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlCard/types.ts
@@ -1,16 +1,29 @@
+import type { PnlTrend } from "../../types";
+
+type BasePnlCardProps = {
+  title: string;
+  value: string;
+  testID?: string;
+};
+
+/** Pressable card with a trend and a chevron. */
 type InteractivePnlCardProps = {
   type: "interactive";
-  trend: "up" | "down" | "neutral";
+  trend: PnlTrend;
   onPress: () => void;
 };
 
+/** Card with an info icon, optionally pressable. */
 type InfoPnlCardProps = {
   type: "info";
   onPress?: () => void;
 };
 
-export type PnlCardProps = {
-  title: string;
-  value: string;
-  testID?: string;
-} & (InteractivePnlCardProps | InfoPnlCardProps);
+/** Display-only card showing a value with its trend, without chevron or info icon. */
+type ValuePnlCardProps = {
+  type: "value";
+  trend: PnlTrend;
+};
+
+export type PnlCardProps = BasePnlCardProps &
+  (InteractivePnlCardProps | InfoPnlCardProps | ValuePnlCardProps);

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlCard/usePnlCardViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlCard/usePnlCardViewModel.ts
@@ -33,8 +33,10 @@ export function usePnlCardViewModel(props: PnlCardProps): PnlCardViewModel {
   const { shouldDisplayPnl } = useWalletFeaturesConfig("mobile");
 
   const isInteractive = props.type === "interactive";
-  const onPress = props.onPress;
+  const onPress = props.type === "value" ? undefined : props.onPress;
   const cardType: CardType = onPress ? "interactive" : "info";
+  const TrendIcon = props.type === "info" ? undefined : TREND_ICON[props.trend];
+  const trendColor = props.type === "info" ? undefined : TREND_COLOR[props.trend];
 
   return {
     shouldRender: shouldDisplayPnl,
@@ -43,8 +45,8 @@ export function usePnlCardViewModel(props: PnlCardProps): PnlCardViewModel {
     cardType,
     showInfoIcon: props.type === "info",
     showChevron: isInteractive,
-    TrendIcon: isInteractive ? TREND_ICON[props.trend] : undefined,
-    trendColor: isInteractive ? TREND_COLOR[props.trend] : undefined,
+    TrendIcon,
+    trendColor,
     onPress,
     testID: props.testID,
   };

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/types.ts
@@ -26,6 +26,13 @@ export type PnlCardViewModel = {
   onPress: () => void;
 };
 
+/** A display-only return card: a label, a formatted amount and its trend. */
+export type PnlReturnCard = {
+  title: string;
+  value: string;
+  trend: PnlTrend;
+};
+
 export type PnlDrawerViewModel = {
   isOpen: boolean;
   onClose: () => void;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Analytics page → Profit and loss section: Unrealised + Realised return cards (cost basis card removed)
  - Tapping the "Profit and loss" subheader opens the detail drawer (cards are no longer pressable)
  - Detail drawer copy (title, description, item labels/descriptions)
  - Discreet mode masking on cards and drawer rows
  - Feature-flag gating (`lwmWallet40.pnl`) and empty-accounts states
  - Asset detail PnL section should be unaffected (shared base view model untouched)

### 📝 Description

The Analytics page Profit and loss section previously displayed an Unrealised return card alongside a Cost basis card, and exposed the detail drawer by tapping the cards.

This PR aligns the section with the latest design:

- Removes the **Cost basis** card and replaces the secondary card with a **Realised return** card, so the section shows one card per return (Unrealised + Realised on mobile), each with its trend.
- Adds a tappable **"Profit and loss"** Lumen `Subheader` (with a chevron) that opens the detail drawer; the cards themselves are now display-only.
- Refreshes the detail drawer copy (title → "Profit and loss", "Estimated return" → "Unrealised return", and updated descriptions).

The Analytics portfolio section now uses a dedicated view model so the shared PnL base hook (used by the Asset detail screen) is left unchanged. A new `"value"` `PnlCard` variant renders a value with its trend without a chevron or info icon.



https://github.com/user-attachments/assets/17845645-ee27-4d25-8a56-72e5a5a55b5e




### ❓ Context

- **JIRA or GitHub link**: [LIVE-31615](https://ledgerhq.atlassian.net/browse/LIVE-31615)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31615]: https://ledgerhq.atlassian.net/browse/LIVE-31615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ