### PR TITLE
[LWM] feat(mobile): add empty Market screen + FF navigator switch

### DIFF
--- a/.changeset/quiet-otters-explore.md
+++ b/.changeset/quiet-otters-explore.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add empty Market screen shell shown behind the asset discoverability feature flag, with a navigator switch between MarketScreen and MarketList

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -436,7 +436,6 @@ export enum ScreenName {
   RequestAccountsSelectCrypto = "RequestAccountsSelectCrypto",
   RequestAccountsSelectAccount = "RequestAccountsSelectAccount",
   MarketList = "MarketList",
-  MarketScreen = "MarketScreen",
   MarketCurrencySelect = "MarketCurrencySelect",
   MarketDetail = "MarketDetail",
   VerifyAccount = "VerifyAccount",

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -436,6 +436,7 @@ export enum ScreenName {
   RequestAccountsSelectCrypto = "RequestAccountsSelectCrypto",
   RequestAccountsSelectAccount = "RequestAccountsSelectAccount",
   MarketList = "MarketList",
+  MarketScreen = "MarketScreen",
   MarketCurrencySelect = "MarketCurrencySelect",
   MarketDetail = "MarketDetail",
   VerifyAccount = "VerifyAccount",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8037,6 +8037,7 @@
   },
   "market": {
     "title": "Market",
+    "exploreTitle": "Explore the market",
     "filters": {
       "sort": "Sort",
       "filter": "Filter",

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/Navigator.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/Navigator.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import { useTranslation } from "~/context/Locale";
+import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import { ScreenName } from "~/const";
 import MarketCurrencySelect from "LLM/features/Market/screens/MarketCurrencySelect";
 import MarketDetail from "LLM/features/Market/screens//MarketDetail";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import MarketList from "LLM/features/Market/screens/MarketList";
+import MarketScreen from "LLM/features/Market/screens/MarketScreen";
 import {
   MarketListHeaderLeft,
   MarketListHeaderTitle,
@@ -26,19 +28,29 @@ interface NavigatorProps {
 
 export default function MarketNavigator({ Stack }: NavigatorProps) {
   const { t } = useTranslation();
+  const { shouldDisplayAssetDiscoverability } = useWalletFeaturesConfig("mobile");
   return (
     <Stack.Group>
       <Stack.Screen
         name={ScreenName.MarketList}
-        component={MarketList}
-        options={{
-          title: t("market.title"),
-          headerShown: true,
-          headerTitle: MarketListHeaderTitle,
-          headerTransparent: true,
-          headerLeft: MarketListHeaderLeft,
-          headerRight: () => null,
-        }}
+        component={shouldDisplayAssetDiscoverability ? MarketScreen : MarketList}
+        options={
+          shouldDisplayAssetDiscoverability
+            ? {
+                title: t("market.exploreTitle"),
+                headerShown: true,
+                headerLeft: MarketListHeaderLeft,
+                headerRight: () => null,
+              }
+            : {
+                title: t("market.title"),
+                headerShown: true,
+                headerTitle: MarketListHeaderTitle,
+                headerTransparent: true,
+                headerLeft: MarketListHeaderLeft,
+                headerRight: () => null,
+              }
+        }
       />
       <Stack.Screen
         name={ScreenName.MarketCurrencySelect}

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/WalletTabNavigator.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/WalletTabNavigator.tsx
@@ -1,8 +1,11 @@
 import React, { useMemo } from "react";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTheme } from "styled-components/native";
+import { useTranslation } from "~/context/Locale";
+import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import { ScreenName } from "~/const";
 import MarketList from "LLM/features/Market/screens/MarketList";
+import MarketScreen from "LLM/features/Market/screens/MarketScreen";
 import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
 import { MarketNavigatorStackParamList } from "./Navigator";
 import TransparentHeaderNavigationOptions from "~/navigation/TransparentHeaderNavigationOptions";
@@ -18,10 +21,17 @@ const options = {
 
 export default function MarketWalletTabNavigator() {
   const { colors } = useTheme();
+  const { t } = useTranslation();
+  const { shouldDisplayAssetDiscoverability } = useWalletFeaturesConfig("mobile");
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
+  const marketScreenOptions = useMemo(() => ({ ...options, title: t("market.exploreTitle") }), [t]);
   return (
     <Stack.Navigator screenOptions={stackNavigationConfig} initialRouteName={ScreenName.MarketList}>
-      <Stack.Screen name={ScreenName.MarketList} component={MarketList} options={options} />
+      <Stack.Screen
+        name={ScreenName.MarketList}
+        component={shouldDisplayAssetDiscoverability ? MarketScreen : MarketList}
+        options={shouldDisplayAssetDiscoverability ? marketScreenOptions : options}
+      />
     </Stack.Navigator>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/__integrations__/marketScreenSwitch.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/__integrations__/marketScreenSwitch.integration.test.tsx
@@ -1,0 +1,55 @@
+import * as React from "react";
+import { renderWithReactQuery, screen, waitFor, withFlagOverrides } from "@tests/test-renderer";
+import { server, http, HttpResponse } from "@tests/server";
+import { MOCK_MARKET_PERFORMERS } from "@ledgerhq/live-common/market/utils/fixtures";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import { ScreenName } from "~/const";
+import MarketNavigator from "../Navigator";
+import { MARKET_SCREEN_TEST_IDS } from "../screens/MarketScreen/testIds";
+
+const COUNTERVALUES_API = "https://countervalues.live.ledger.com";
+
+const Stack = createNativeStackNavigator<BaseNavigatorStackParamList>();
+
+const NavigatorWrapper = () => (
+  <Stack.Navigator initialRouteName={ScreenName.MarketList}>
+    {MarketNavigator({ Stack })}
+  </Stack.Navigator>
+);
+
+const enableAssetDiscoverability = withFlagOverrides({
+  lwmWallet40: { enabled: true, params: { assetDiscoverability: true } },
+});
+
+describe("Market screen navigator switch", () => {
+  beforeEach(() => {
+    server.use(
+      http.get(`${COUNTERVALUES_API}/v3/markets`, () => HttpResponse.json(MOCK_MARKET_PERFORMERS)),
+    );
+  });
+
+  it("should render MarketList when asset discoverability is off", async () => {
+    renderWithReactQuery(<NavigatorWrapper />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("market-list")).toBeVisible();
+    });
+    expect(screen.queryByTestId(MARKET_SCREEN_TEST_IDS.screen)).toBeNull();
+  });
+
+  it("should render the new MarketScreen with its placeholder blocks when asset discoverability is on", async () => {
+    renderWithReactQuery(<NavigatorWrapper />, {
+      overrideInitialState: enableAssetDiscoverability,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.screen)).toBeVisible();
+    });
+    expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.searchBar)).toBeVisible();
+    expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.highlights)).toBeVisible();
+    expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.list)).toBeVisible();
+    expect(screen.getAllByTestId(MARKET_SCREEN_TEST_IDS.highlightCard).length).toBeGreaterThan(0);
+    expect(screen.queryByTestId("market-list")).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/__integrations__/marketScreenSwitch.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/__integrations__/marketScreenSwitch.integration.test.tsx
@@ -1,14 +1,11 @@
 import * as React from "react";
 import { renderWithReactQuery, screen, waitFor, withFlagOverrides } from "@tests/test-renderer";
-import { server, http, HttpResponse } from "@tests/server";
-import { MOCK_MARKET_PERFORMERS } from "@ledgerhq/live-common/market/utils/fixtures";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { ScreenName } from "~/const";
 import MarketNavigator from "../Navigator";
+import MarketWalletTabNavigator from "../WalletTabNavigator";
 import { MARKET_SCREEN_TEST_IDS } from "../screens/MarketScreen/testIds";
-
-const COUNTERVALUES_API = "https://countervalues.live.ledger.com";
 
 const Stack = createNativeStackNavigator<BaseNavigatorStackParamList>();
 
@@ -23,12 +20,6 @@ const enableAssetDiscoverability = withFlagOverrides({
 });
 
 describe("Market screen navigator switch", () => {
-  beforeEach(() => {
-    server.use(
-      http.get(`${COUNTERVALUES_API}/v3/markets`, () => HttpResponse.json(MOCK_MARKET_PERFORMERS)),
-    );
-  });
-
   it("should render MarketList when asset discoverability is off", async () => {
     renderWithReactQuery(<NavigatorWrapper />);
 
@@ -50,6 +41,17 @@ describe("Market screen navigator switch", () => {
     expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.highlights)).toBeVisible();
     expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.list)).toBeVisible();
     expect(screen.getAllByTestId(MARKET_SCREEN_TEST_IDS.highlightCard).length).toBeGreaterThan(0);
+    expect(screen.queryByTestId("market-list")).toBeNull();
+  });
+
+  it("should render the new MarketScreen from the wallet tab navigator when asset discoverability is on", async () => {
+    renderWithReactQuery(<MarketWalletTabNavigator />, {
+      overrideInitialState: enableAssetDiscoverability,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.screen)).toBeVisible();
+    });
     expect(screen.queryByTestId("market-list")).toBeNull();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/MarketScreenView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/MarketScreenView.tsx
@@ -1,0 +1,100 @@
+import React, { useCallback } from "react";
+import { FlatList, ListRenderItemInfo, ScrollView } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { TrackScreen } from "~/analytics";
+import { MARKET_SCREEN_TEST_IDS } from "./testIds";
+import type { MarketScreenHighlightCard, MarketScreenViewModel } from "./useMarketScreenViewModel";
+
+const HORIZONTAL_PADDING = 16;
+const CARD_GAP = 8;
+const SECTION_GAP = 24;
+const HIGHLIGHT_CARD_HEIGHT = 160;
+const LIST_PLACEHOLDER_HEIGHT = 320;
+const SEARCH_BAR_HEIGHT = 48;
+
+type Props = Readonly<MarketScreenViewModel>;
+
+function HighlightCardSeparator() {
+  return <Box style={{ width: CARD_GAP }} />;
+}
+
+export function MarketScreenView({ cardWidth, snapToInterval, highlightCards }: Props) {
+  const { bottom } = useSafeAreaInsets();
+
+  const renderHighlightCard = useCallback(
+    ({ item }: ListRenderItemInfo<MarketScreenHighlightCard>) => (
+      <Box
+        key={item.key}
+        testID={MARKET_SCREEN_TEST_IDS.highlightCard}
+        lx={highlightCardStyle}
+        style={{ width: cardWidth, height: HIGHLIGHT_CARD_HEIGHT }}
+      />
+    ),
+    [cardWidth],
+  );
+
+  return (
+    <Box testID={MARKET_SCREEN_TEST_IDS.screen} lx={screenStyle}>
+      <TrackScreen category="Market" />
+      {/* Block 1: sticky search bar placeholder, kept outside the ScrollView so it stays visible. */}
+      <Box testID={MARKET_SCREEN_TEST_IDS.searchBar} lx={searchBarStyle} style={searchBarSize} />
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ paddingBottom: bottom + SECTION_GAP }}
+      >
+        <Box lx={contentStyle}>
+          {/* Block 2: horizontal carousel of placeholder cards (~2 cards + a peek of the third). */}
+          <FlatList
+            horizontal
+            testID={MARKET_SCREEN_TEST_IDS.highlights}
+            data={highlightCards}
+            keyExtractor={item => item.key}
+            renderItem={renderHighlightCard}
+            ItemSeparatorComponent={HighlightCardSeparator}
+            showsHorizontalScrollIndicator={false}
+            snapToInterval={snapToInterval}
+            snapToAlignment="start"
+            decelerationRate="fast"
+            disableIntervalMomentum
+            contentContainerStyle={{ paddingHorizontal: HORIZONTAL_PADDING }}
+          />
+          {/* Block 3: placeholder for the upcoming market list. */}
+          <Box testID={MARKET_SCREEN_TEST_IDS.list} lx={listStyle} style={listSize} />
+        </Box>
+      </ScrollView>
+    </Box>
+  );
+}
+
+const screenStyle: LumenViewStyle = {
+  flex: 1,
+};
+
+const searchBarStyle: LumenViewStyle = {
+  marginTop: "s16",
+  marginHorizontal: "s16",
+  backgroundColor: "muted",
+  borderRadius: "md",
+};
+
+const searchBarSize = { height: SEARCH_BAR_HEIGHT };
+
+const contentStyle: LumenViewStyle = {
+  paddingTop: "s24",
+  gap: "s24",
+};
+
+const highlightCardStyle: LumenViewStyle = {
+  backgroundColor: "accent",
+  borderRadius: "md",
+};
+
+const listStyle: LumenViewStyle = {
+  marginHorizontal: "s16",
+  backgroundColor: "interactive",
+  borderRadius: "md",
+};
+
+const listSize = { height: LIST_PLACEHOLDER_HEIGHT };

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/MarketScreenView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/MarketScreenView.tsx
@@ -37,15 +37,13 @@ export function MarketScreenView({ cardWidth, snapToInterval, highlightCards }: 
 
   return (
     <Box testID={MARKET_SCREEN_TEST_IDS.screen} lx={screenStyle}>
-      <TrackScreen category="Market" />
-      {/* Block 1: sticky search bar placeholder, kept outside the ScrollView so it stays visible. */}
+      <TrackScreen category="Page" name="Market" access />
       <Box testID={MARKET_SCREEN_TEST_IDS.searchBar} lx={searchBarStyle} style={searchBarSize} />
       <ScrollView
         showsVerticalScrollIndicator={false}
         contentContainerStyle={{ paddingBottom: bottom + SECTION_GAP }}
       >
         <Box lx={contentStyle}>
-          {/* Block 2: horizontal carousel of placeholder cards (~2 cards + a peek of the third). */}
           <FlatList
             horizontal
             testID={MARKET_SCREEN_TEST_IDS.highlights}
@@ -60,7 +58,6 @@ export function MarketScreenView({ cardWidth, snapToInterval, highlightCards }: 
             disableIntervalMomentum
             contentContainerStyle={{ paddingHorizontal: HORIZONTAL_PADDING }}
           />
-          {/* Block 3: placeholder for the upcoming market list. */}
           <Box testID={MARKET_SCREEN_TEST_IDS.list} lx={listStyle} style={listSize} />
         </Box>
       </ScrollView>

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/index.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+import { MarketScreenView } from "./MarketScreenView";
+import { useMarketScreenViewModel } from "./useMarketScreenViewModel";
+
+const MarketScreen = () => <MarketScreenView {...useMarketScreenViewModel()} />;
+
+export default MarketScreen;

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/testIds.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/testIds.ts
@@ -1,0 +1,7 @@
+export const MARKET_SCREEN_TEST_IDS = {
+  screen: "market-screen",
+  searchBar: "market-screen-search-bar",
+  highlights: "market-screen-highlights",
+  highlightCard: "market-screen-highlight-card",
+  list: "market-screen-list",
+} as const;

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketScreenViewModel.ts
@@ -1,0 +1,41 @@
+import { useMemo } from "react";
+import { useWindowDimensions } from "react-native";
+
+const HORIZONTAL_PADDING = 16;
+const CARD_GAP = 8;
+const HIGHLIGHT_CARD_COUNT = 4;
+
+export type MarketScreenHighlightCard = {
+  key: string;
+};
+
+export type MarketScreenViewModel = {
+  cardWidth: number;
+  cardGap: number;
+  snapToInterval: number;
+  highlightCards: MarketScreenHighlightCard[];
+};
+
+/**
+ * View model for the empty Market screen shell.
+ *
+ * Card sizing follows the design spec: two cards plus a peek of the third must
+ * fit within the horizontal padding, so the width is half of the available row
+ * minus half of the inter-card gap.
+ */
+export function useMarketScreenViewModel(): MarketScreenViewModel {
+  const { width } = useWindowDimensions();
+
+  return useMemo(() => {
+    const cardWidth = (width - HORIZONTAL_PADDING * 2) / 2 - CARD_GAP;
+
+    return {
+      cardWidth,
+      cardGap: CARD_GAP,
+      snapToInterval: cardWidth + CARD_GAP,
+      highlightCards: Array.from({ length: HIGHLIGHT_CARD_COUNT }, (_, index) => ({
+        key: `market-highlight-${index}`,
+      })),
+    };
+  }, [width]);
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketScreenViewModel.ts
@@ -16,18 +16,12 @@ export type MarketScreenViewModel = {
   highlightCards: MarketScreenHighlightCard[];
 };
 
-/**
- * View model for the empty Market screen shell.
- *
- * Card sizing follows the design spec: two cards plus a peek of the third must
- * fit within the horizontal padding, so the width is half of the available row
- * minus half of the inter-card gap.
- */
 export function useMarketScreenViewModel(): MarketScreenViewModel {
   const { width } = useWindowDimensions();
 
   return useMemo(() => {
-    const cardWidth = (width - HORIZONTAL_PADDING * 2) / 2 - CARD_GAP;
+    const availableWidth = width - HORIZONTAL_PADDING * 2;
+    const cardWidth = availableWidth / 2 - CARD_GAP;
 
     return {
       cardWidth,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Integration test covers the navigator switch (FF on/off) and that the new screen renders its placeholder blocks. The `Page Market` tracking event and the exact spacing/snap behaviour are not asserted in tests (visual placeholders, replaced in later tasks)._
- [x] **Impact of the changes:**
      - FF OFF (`assetDiscoverability` off): the existing Market list must render as before (no regression).
      - FF ON: the new "Explore the market" screen renders with the 3 coloured placeholder blocks.
      - The search-bar block stays visible while scrolling.
      - Block 2 scrolls/snaps horizontally (~2 cards fully visible + a peek of the third).
      - Spacing is correct on both iOS and Android (16px horizontal padding, 24px gaps).

### 📝 Description

Creates the empty `MarketScreen` shell and wires the feature-flag-based navigator switch for the W4.0 asset-discoverability experience.

When `shouldDisplayAssetDiscoverability` is ON, the first Market route now renders the new `MarketScreen` instead of `MarketList`; when OFF, behaviour is unchanged. The switch is done by swapping only the `component`/`options` on the existing `ScreenName.MarketList` route, so every existing entry point (portfolio MarketBanner, deeplinks, LargeMover, accountActions) keeps working without changes. The same swap is mirrored in `WalletTabNavigator.tsx` for consistency across entry paths.

The new screen is an MVVM shell (container → ViewModel → View) with:
- Title "Explore the market" shown via the navigation header.
- Block 1 (search-bar placeholder): sticky, kept outside the `ScrollView` so it stays visible.
- Blocks 2 + 3 inside a single vertical `ScrollView`; Block 2 is a horizontal snapping `FlatList` with card width `(screenWidth - 32) / 2 - 8` and `snapToInterval = cardWidth + 8` (~2 cards + peek of the third).
- `Page Market` analytics fired on mount via `TrackScreen`.

Blocks are coloured placeholders (Lumen tokens) to be replaced in subsequent tasks.

### 📸 Screenshots
<img width="1206" height="2622" alt="Simulator Screenshot - build2 - 2026-06-01 at 15 22 35" src="https://github.com/user-attachments/assets/6646729b-e4b5-4975-8d87-b031a4951d73" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30029](https://ledgerhq.atlassian.net/browse/LIVE-30029)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30029]: https://ledgerhq.atlassian.net/browse/LIVE-30029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ