### PR TITLE
[LWDM] feat(feature-flags): add remoteFlagsReady boot-readiness signal (LIVE-31637)

### DIFF
--- a/.changeset/feature-flags-remote-ready-signal.md
+++ b/.changeset/feature-flags-remote-ready-signal.md
@@ -1,0 +1,5 @@
+---
+"@shared/feature-flags": minor
+---
+
+Add a Redux-backed `remoteFlagsReady` boot-readiness signal: a `remoteFlagsReady` state field (initial `false`), an idempotent `setRemoteFlagsReady` reducer, and a `selectRemoteFlagsReady` selector. The middleware dispatches the signal once after the first remote-flag fetch settles — success or failure. The field is transient and never persisted, so it re-arms every session.

--- a/apps/ledger-live-desktop/src/renderer/middlewares/__tests__/db.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/__tests__/db.test.ts
@@ -58,7 +58,7 @@ type FakeState = {
   accounts: unknown[];
   identities: unknown;
   history: unknown;
-  featureFlags: { overrides: unknown; bannerVisible: unknown };
+  featureFlags: { overrides: unknown; bannerVisible: unknown; remoteFlagsReady?: unknown };
   trustchain?: unknown;
 };
 
@@ -153,5 +153,34 @@ describe("DBMiddleware - MARKET branch", () => {
 
     expect(mockedSetKey).toHaveBeenCalledTimes(0);
     expect(mockedSetKey).not.toHaveBeenCalledWith("app", "settings", expect.anything());
+  });
+});
+
+describe("DBMiddleware - featureFlags branch", () => {
+  beforeEach(() => {
+    mockedSetKey.mockReset();
+  });
+
+  it("persists only { overrides, bannerVisible } — never the transient remoteFlagsReady gate", () => {
+    const before = baseState();
+    const after: FakeState = {
+      ...before,
+      featureFlags: {
+        overrides: { mockFeature: { enabled: true } },
+        bannerVisible: false,
+        remoteFlagsReady: true,
+      },
+    };
+
+    runMiddleware([before, after], { type: "FEATURE_FLAGS_SET_OVERRIDE" });
+
+    expect(mockedSetKey).toHaveBeenCalledTimes(1);
+    expect(mockedSetKey).toHaveBeenCalledWith("app", "featureFlags", {
+      overrides: after.featureFlags.overrides,
+      bannerVisible: false,
+    });
+
+    const persisted = mockedSetKey.mock.calls[0][2] as Record<string, unknown>;
+    expect(persisted).not.toHaveProperty("remoteFlagsReady");
   });
 });

--- a/apps/ledger-live-desktop/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-desktop/src/state-manager/configureStore.ts
@@ -7,14 +7,24 @@ import { applyLldRTKApiMiddlewares } from "~/renderer/reducers/rtkQueryApi";
 import { createIdentitiesSyncMiddleware } from "@ledgerhq/client-ids/store";
 import { canPushDeviceIdsSelector } from "~/renderer/reducers/settings";
 import { createFeatureFlagsMiddleware, type PartialFeatures } from "@shared/feature-flags";
-import { fetchRemoteFlags } from "~/firebase/remoteConfig";
+import { fetchRemoteFlags as defaultFetchRemoteFlags } from "~/firebase/remoteConfig";
 type Props = {
   state?: State;
   dbMiddleware?: Middleware;
   analyticsMiddleware?: Middleware;
+  /**
+   * Remote-flags fetcher driving the polling loop. Defaults to the Firebase fetcher.
+   * Pass `null` to disable polling (e.g. unit tests, which must not hit a live backend).
+   */
+  fetchRemoteFlags?: (() => Promise<PartialFeatures>) | null;
 };
 
-const customCreateStore = ({ state, dbMiddleware, analyticsMiddleware }: Props) => {
+const customCreateStore = ({
+  state,
+  dbMiddleware,
+  analyticsMiddleware,
+  fetchRemoteFlags = defaultFetchRemoteFlags,
+}: Props) => {
   const store = configureStore({
     reducer: reducers,
     preloadedState: state,
@@ -38,7 +48,7 @@ const customCreateStore = ({ state, dbMiddleware, analyticsMiddleware }: Props) 
               appVersion: __APP_VERSION__,
               envFlags: getEnv("FEATURE_FLAGS") as PartialFeatures,
             },
-            fetchRemoteFlags,
+            fetchRemoteFlags: fetchRemoteFlags ?? undefined,
           }),
         ),
     devTools: __DEV__,

--- a/apps/ledger-live-desktop/tests/testSetup.tsx
+++ b/apps/ledger-live-desktop/tests/testSetup.tsx
@@ -220,7 +220,7 @@ function renderWithMockedCounterValuesProvider(
   const {
     initialState = {},
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    store = createStore({ state: initialState as State, dbMiddleware }),
+    store = createStore({ state: initialState as State, dbMiddleware, fetchRemoteFlags: null }),
     userEventOptions = {},
     skipRouter = false,
     withRampCatalog = false,
@@ -259,7 +259,7 @@ function render(ui: React.JSX.Element, options: ExtraOptions = {}): RenderReturn
   const {
     initialState = {},
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    store = createStore({ state: initialState as State, dbMiddleware }),
+    store = createStore({ state: initialState as State, dbMiddleware, fetchRemoteFlags: null }),
     userEventOptions = {},
     skipRouter = false,
     initialRoute,
@@ -320,7 +320,7 @@ function renderHook<Result, Props>(
     initialProps,
     initialState = {},
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    store = createStore({ state: initialState as State, dbMiddleware }),
+    store = createStore({ state: initialState as State, dbMiddleware, fetchRemoteFlags: null }),
     minimal = true,
     skipRouter = false,
     initialRoute,
@@ -357,7 +357,7 @@ function renderHookWithLiveAppProvider<Result, Props>(
     initialProps,
     initialState = {},
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    store = createStore({ state: initialState as State, dbMiddleware }),
+    store = createStore({ state: initialState as State, dbMiddleware, fetchRemoteFlags: null }),
   } = options;
 
   return {

--- a/apps/ledger-live-mobile/src/components/DBSave.test.ts
+++ b/apps/ledger-live-mobile/src/components/DBSave.test.ts
@@ -1,0 +1,20 @@
+import { featureFlagsLense } from "./DBSave";
+import type { State } from "~/reducers/types";
+
+describe("featureFlagsLense", () => {
+  it("projects only { overrides, bannerVisible } — never the transient remoteFlagsReady gate", () => {
+    const overrides = { mockFeature: { enabled: true } };
+    const state = {
+      featureFlags: {
+        overrides,
+        bannerVisible: false,
+        remoteFlagsReady: true,
+      },
+    } as unknown as State;
+
+    const projected = featureFlagsLense(state);
+
+    expect(projected).toEqual({ overrides, bannerVisible: false });
+    expect(projected).not.toHaveProperty("remoteFlagsReady");
+  });
+});

--- a/apps/ledger-live-mobile/src/components/DBSave.ts
+++ b/apps/ledger-live-mobile/src/components/DBSave.ts
@@ -184,7 +184,7 @@ const cryptoAssetsNotEquals = (a: State, b: State) =>
 const featureFlagsNotEquals = (a: State, b: State) =>
   a.featureFlags.overrides !== b.featureFlags.overrides ||
   a.featureFlags.bannerVisible !== b.featureFlags.bannerVisible;
-const featureFlagsLense = (state: State) => ({
+export const featureFlagsLense = (state: State) => ({
   overrides: state.featureFlags.overrides,
   bannerVisible: state.featureFlags.bannerVisible,
 });

--- a/shared/feature-flags/src/constants.ts
+++ b/shared/feature-flags/src/constants.ts
@@ -24,6 +24,7 @@ export const FEATURE_FLAGS_INITIAL_STATE: FeatureFlagsState = {
   overrides: {},
   resolved: FEATURE_FLAGS_DEFAULTS,
   bannerVisible: false,
+  remoteFlagsReady: false,
 };
 
 /** Default polling interval for fetching remote flags, in milliseconds: 5 minutes. */

--- a/shared/feature-flags/src/data/middleware.ts
+++ b/shared/feature-flags/src/data/middleware.ts
@@ -1,7 +1,7 @@
 import { type Action, type Middleware, isAction } from "@reduxjs/toolkit";
 import type { PartialFeatures, ResolutionConfig } from "./schema";
 import { FEATURE_FLAGS_REMOTE_POLLING_INTERVAL_MS } from "../constants";
-import { syncRemoteConfig } from "./slice";
+import { syncRemoteConfig, setRemoteFlagsReady } from "./slice";
 
 /** Feature-flags metadata that the middleware injects into every `featureFlags/*` action. */
 export interface FeatureFlagsMeta {
@@ -42,8 +42,20 @@ export function createFeatureFlagsMiddleware(config: FeatureFlagsMiddlewareConfi
   return ({ dispatch }) => {
     const { resolutionConfig, fetchRemoteFlags, refreshInterval } = config;
     if (fetchRemoteFlags) {
-      const dispatchRemoteFlags = () => dispatch(syncRemoteConfig());
-      void pollRemoteFlags(fetchRemoteFlags, remoteFlagsRef, dispatchRemoteFlags, refreshInterval);
+      let readyDispatched = false;
+      const dispatchSync = () => dispatch(syncRemoteConfig());
+      const dispatchReady = () => {
+        if (readyDispatched) return;
+        readyDispatched = true;
+        dispatch(setRemoteFlagsReady());
+      };
+      void pollRemoteFlags(
+        fetchRemoteFlags,
+        remoteFlagsRef,
+        dispatchSync,
+        dispatchReady,
+        refreshInterval,
+      );
     }
     return next => action => {
       if (isAction(action) && action.type.startsWith("featureFlags/")) {
@@ -80,9 +92,9 @@ function getMeta(action: Action<string>) {
 
 /**
  * Self-rescheduling poll loop: fetches remote flags, writes them to the ref on
- * success, dispatches the update, then schedules the next iteration. A failed
- * fetch resolves to `null` (via `.catch`), leaves the ref untouched, and still
- * re-schedules so transient errors don't kill the loop.
+ * success, dispatches the update, signals readiness, then schedules the next
+ * iteration. A failed fetch resolves to `null` (via `.catch`), leaves the ref
+ * untouched, and still re-schedules so transient errors don't kill the loop.
  *
  * @param fetch
  * Async callback that returns the latest remote flags map.
@@ -91,9 +103,14 @@ function getMeta(action: Action<string>) {
  * Mutable container that receives each successful fetch result. Read by the
  * middleware when injecting `action.meta.remoteFlags`.
  *
- * @param dispatch
- * Callback fired after each successful fetch — used to dispatch
+ * @param dispatchSync
+ * Callback fired after each *successful* fetch — used to dispatch
  * `syncRemoteConfig()` so reducers re-resolve.
+ *
+ * @param dispatchReady
+ * Callback fired after each *settled* fetch (resolved or rejected) — used to
+ * dispatch `setRemoteFlagsReady()`. The caller guards it so only the first
+ * settle propagates; idempotent on the reducer side regardless.
  *
  * @param ms
  * Delay between iterations, in milliseconds. Defaults to
@@ -102,15 +119,17 @@ function getMeta(action: Action<string>) {
 async function pollRemoteFlags(
   fetch: () => Promise<PartialFeatures>,
   ref: RemoteFlagsRef,
-  dispatch: () => void,
+  dispatchSync: () => void,
+  dispatchReady: () => void,
   ms: number = FEATURE_FLAGS_REMOTE_POLLING_INTERVAL_MS,
 ) {
   const remote = await fetch().catch(() => null);
   if (remote !== null) {
     ref.current = remote;
-    dispatch();
+    dispatchSync();
   }
-  setTimeout(pollRemoteFlags, ms, fetch, ref, dispatch, ms);
+  dispatchReady();
+  setTimeout(pollRemoteFlags, ms, fetch, ref, dispatchSync, dispatchReady, ms);
 }
 
 /**

--- a/shared/feature-flags/src/data/schema.test.ts
+++ b/shared/feature-flags/src/data/schema.test.ts
@@ -38,6 +38,7 @@ describe("FeatureFlagsStateSchema", () => {
       overrides: { mockFeature: { enabled: true } },
       resolved: { ...FEATURE_FLAGS_DEFAULTS, mockFeature: { enabled: true } },
       bannerVisible: false,
+      remoteFlagsReady: false,
     };
     expect(FeatureFlagsStateSchema.parse(input)).toEqual(input);
   });
@@ -47,6 +48,7 @@ describe("FeatureFlagsStateSchema", () => {
       overrides: {},
       resolved: FEATURE_FLAGS_DEFAULTS,
       bannerVisible: false,
+      remoteFlagsReady: false,
     };
     expect(FeatureFlagsStateSchema.parse(input)).toEqual(input);
   });
@@ -56,9 +58,19 @@ describe("FeatureFlagsStateSchema", () => {
       overrides: {},
       resolved: {},
       bannerVisible: false,
+      remoteFlagsReady: false,
     });
     expect(result.resolved).toEqual(FEATURE_FLAGS_DEFAULTS);
     expect(result.overrides).toEqual({});
+  });
+
+  it("defaults remoteFlagsReady to false when omitted", () => {
+    const result = FeatureFlagsStateSchema.parse({
+      overrides: {},
+      resolved: FEATURE_FLAGS_DEFAULTS,
+      bannerVisible: false,
+    });
+    expect(result.remoteFlagsReady).toBe(false);
   });
 
   it("rejects when resolved is missing", () => {

--- a/shared/feature-flags/src/data/schema.ts
+++ b/shared/feature-flags/src/data/schema.ts
@@ -28,6 +28,12 @@ export interface FeatureFlagsState {
   resolved: Features;
   /** Whether the developer feature flags banner/button is visible in the UI. */
   bannerVisible: boolean;
+  /**
+   * Whether the first remote-flag fetch has settled (resolved or rejected). Readiness
+   * gate, set by the middleware once the first fetch settles. Transient: never persisted,
+   * so it re-arms to `false` every session.
+   */
+  remoteFlagsReady: boolean;
 }
 
 /** Represents the resolved values of all feature flags. */
@@ -55,6 +61,7 @@ export const FeatureFlagsStateSchema = z.object({
   overrides: z.record(z.string(), OverrideValueSchema.optional()).default({}),
   resolved: z.object(flagRegistry),
   bannerVisible: z.boolean(),
+  remoteFlagsReady: z.boolean().default(false),
 }) as z.ZodType<FeatureFlagsState>;
 
 /** Schema that validates the resolution configuration. */

--- a/shared/feature-flags/src/data/selectors.test.ts
+++ b/shared/feature-flags/src/data/selectors.test.ts
@@ -3,6 +3,7 @@ import {
   selectFeature,
   featureFlagsOverridesSelector,
   featureFlagsBannerVisibleSelector,
+  selectRemoteFlagsReady,
 } from "./selectors";
 import type { FeatureFlagsState } from "./schema";
 import { FEATURE_FLAGS_DEFAULTS } from "../constants";
@@ -17,6 +18,7 @@ const state: { featureFlags: FeatureFlagsState } = {
       mockFeature: { enabled: true, params: { color: "blue" } },
     } as FeatureFlagsState["resolved"],
     bannerVisible: false,
+    remoteFlagsReady: false,
   },
 };
 
@@ -38,5 +40,12 @@ describe("feature-flags selectors", () => {
 
   it("featureFlagsBannerVisibleSelector returns bannerVisible", () => {
     expect(featureFlagsBannerVisibleSelector(state)).toBe(false);
+  });
+
+  it("selectRemoteFlagsReady returns remoteFlagsReady", () => {
+    expect(selectRemoteFlagsReady(state)).toBe(false);
+    expect(selectRemoteFlagsReady({ featureFlags: { ...state.featureFlags, remoteFlagsReady: true } })).toBe(
+      true,
+    );
   });
 });

--- a/shared/feature-flags/src/data/selectors.ts
+++ b/shared/feature-flags/src/data/selectors.ts
@@ -37,3 +37,15 @@ export function featureFlagsOverridesSelector(s: WithFeatureFlags): PartialFeatu
 export function featureFlagsBannerVisibleSelector(s: WithFeatureFlags) {
   return s.featureFlags.bannerVisible;
 }
+
+/**
+ * Selects whether the first remote feature-flag fetch has settled (resolved or
+ * rejected). Readiness signal that consumers can gate on while remote flags are
+ * still loading.
+ *
+ * @param s
+ * Any store state containing the `featureFlags` slice.
+ */
+export function selectRemoteFlagsReady(s: WithFeatureFlags): boolean {
+  return s.featureFlags.remoteFlagsReady;
+}

--- a/shared/feature-flags/src/data/slice.test.ts
+++ b/shared/feature-flags/src/data/slice.test.ts
@@ -5,6 +5,7 @@ import {
   setOverride,
   setAllOverrides,
   setBannerVisible,
+  setRemoteFlagsReady,
   importState,
 } from "./slice";
 import { createFeatureFlagsMiddleware, type FeatureFlagsMiddlewareConfig } from "./middleware";
@@ -64,6 +65,7 @@ describe("featureFlagsSlice reducers", () => {
       overrides: {},
       resolved: defaults,
       bannerVisible: false,
+      remoteFlagsReady: false,
     });
   });
 
@@ -80,6 +82,7 @@ describe("featureFlagsSlice reducers", () => {
         overrides: { mockFeature: { enabled: true } },
         resolved: { ...defaults, mockFeature: { enabled: true } },
         bannerVisible: false,
+        remoteFlagsReady: false,
       });
       store.dispatch(
         setOverride({ key: "mockFeature", value: { enabled: false, params: { x: 1 } } }),
@@ -95,6 +98,7 @@ describe("featureFlagsSlice reducers", () => {
         overrides: { mockFeature: { enabled: true } },
         resolved: { ...defaults, mockFeature: { enabled: true } },
         bannerVisible: false,
+        remoteFlagsReady: false,
       });
       store.dispatch(setOverride({ key: "mockFeature", value: undefined }));
       expect(store.getState().featureFlags.overrides.mockFeature).toBeUndefined();
@@ -114,6 +118,7 @@ describe("featureFlagsSlice reducers", () => {
         overrides: { mockFeature: { enabled: true } },
         resolved: { ...defaults, mockFeature: { enabled: true } },
         bannerVisible: false,
+        remoteFlagsReady: false,
       });
       store.dispatch(setAllOverrides({ ptxCard: { enabled: false } }));
       expect(store.getState().featureFlags.overrides).toEqual({ ptxCard: { enabled: false } });
@@ -129,6 +134,25 @@ describe("featureFlagsSlice reducers", () => {
     });
   });
 
+  describe("setRemoteFlagsReady", () => {
+    it("starts false and flips to true once, idempotently", () => {
+      const store = createStore();
+      expect(store.getState().featureFlags.remoteFlagsReady).toBe(false);
+
+      store.dispatch(setRemoteFlagsReady());
+      expect(store.getState().featureFlags.remoteFlagsReady).toBe(true);
+
+      store.dispatch(setRemoteFlagsReady());
+      store.dispatch(setRemoteFlagsReady());
+      expect(store.getState().featureFlags).toEqual({
+        overrides: {},
+        resolved: defaults,
+        bannerVisible: false,
+        remoteFlagsReady: true,
+      });
+    });
+  });
+
   describe("importState", () => {
     it("replaces entire state", () => {
       const store = createStore();
@@ -136,6 +160,7 @@ describe("featureFlagsSlice reducers", () => {
         overrides: { mockFeature: { enabled: true, params: "test" } },
         resolved: { ...defaults, mockFeature: { enabled: true, params: "test" } },
         bannerVisible: true,
+        remoteFlagsReady: true,
       };
       store.dispatch(importState(newState));
       expect(store.getState().featureFlags).toEqual(newState);
@@ -303,6 +328,26 @@ describe("middleware behavior", () => {
     // Reducer state is unchanged because syncRemoteConfig is not dispatched on failure;
     // the previous resolved value remains visible.
     expect(store.getState().featureFlags.resolved.mockFeature.enabled).toBe(true);
+  });
+
+  it("marks remoteFlagsReady after the first successful fetch", async () => {
+    const store = createStore(undefined, {
+      fetchRemoteFlags: () => Promise.resolve({ mockFeature: { enabled: true } }),
+    });
+    expect(store.getState().featureFlags.remoteFlagsReady).toBe(false);
+
+    await flushPromises();
+    expect(store.getState().featureFlags.remoteFlagsReady).toBe(true);
+  });
+
+  it("marks remoteFlagsReady even when the first fetch rejects", async () => {
+    const fetcher = jest.fn().mockRejectedValue(new Error("network down"));
+    const store = createStore(undefined, { fetchRemoteFlags: fetcher, refreshInterval: 1_000 });
+
+    await flushPromises();
+    // syncRemoteConfig never fires on failure, so resolved stays at defaults.
+    expect(store.getState().featureFlags.remoteFlagsReady).toBe(true);
+    expect(store.getState().featureFlags.resolved.mockFeature).toEqual(defaults.mockFeature);
   });
 
   it("does not schedule any timer when fetchRemoteFlags is omitted", () => {

--- a/shared/feature-flags/src/data/slice.ts
+++ b/shared/feature-flags/src/data/slice.ts
@@ -48,7 +48,7 @@ const featureFlagsSlice = createSlice({
      * Re-resolves every flag against the latest remote values. Payload-less:
      * the middleware injects the freshly fetched remote map via
      * `action.meta.remoteFlags`. Dispatched by `createFeatureFlagsMiddleware`
-     * after each successful Firebase fetch.
+     * after each successful remote fetch.
      */
     syncRemoteConfig: {
       prepare: prepareWithoutPayload,
@@ -64,6 +64,15 @@ const featureFlagsSlice = createSlice({
     },
 
     /**
+     * Marks the first remote-flag fetch as settled (readiness gate). Payload-less and
+     * idempotent: the middleware dispatches it once the first fetch settles, whether it
+     * resolved or rejected.
+     */
+    setRemoteFlagsReady(state) {
+      state.remoteFlagsReady = true;
+    },
+
+    /**
      * Replaces the entire feature-flags state. Used during hydration from
      * persisted storage to restore the slice in a single step.
      */
@@ -73,8 +82,14 @@ const featureFlagsSlice = createSlice({
   },
 });
 
-export const { setOverride, setAllOverrides, syncRemoteConfig, setBannerVisible, importState } =
-  featureFlagsSlice.actions;
+export const {
+  setOverride,
+  setAllOverrides,
+  syncRemoteConfig,
+  setBannerVisible,
+  setRemoteFlagsReady,
+  importState,
+} = featureFlagsSlice.actions;
 
 /** Reducer for the `featureFlags` slice — register under `state.featureFlags`. */
 export const featureFlagsReducer = featureFlagsSlice.reducer;

--- a/shared/feature-flags/src/data/utils.ts
+++ b/shared/feature-flags/src/data/utils.ts
@@ -96,7 +96,7 @@ export function applyLanguageFilter(feature: Feature, appLanguage?: string): Fea
  * User-defined local overrides map.
  *
  * @param remoteFlags
- * Remote feature flag values from Firebase/LiveConfig.
+ * Remote feature flag values (the latest fetched remote map).
  *
  * @param config
  * Platform, version, language, and env flags for resolution.
@@ -141,7 +141,7 @@ export function resolveFeature(
  * User-defined local overrides map.
  *
  * @param remoteFlags
- * Remote feature flag values from Firebase/LiveConfig.
+ * Remote feature flag values (the latest fetched remote map).
  *
  * @param config
  * Platform, version, language, and env flags for resolution.


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - `@shared/feature-flags` only — purely additive: new `remoteFlagsReady` state field, `setRemoteFlagsReady` reducer, `selectRemoteFlagsReady` selector, and the middleware now dispatches readiness once on the first settled remote fetch. No change to existing flag resolution or dev-banner persistence.
  - Phase A of the provider-teardown split. **No consumer is wired yet** (apps still use the Firebase `whenReady()` path); Phase B repoints each app's FeatureFlags Context to the new selector.
  - QA focus: no runtime behaviour change expected (the signal is unused so far). Sanity-check feature-flag resolution and dev-banner persistence for non-regression.
  
### E2E runs

- [Mobile](https://github.com/LedgerHQ/ledger-live/actions/runs/26822257017)
- [Desktop](https://github.com/LedgerHQ/ledger-live/actions/runs/26819626845)

### 📝 Description

Adds a Redux-backed `remoteFlagsReady` boot-readiness signal to `@shared/feature-flags` so both apps (LWD/LWM) can gate boot on "first remote feature-flag fetch settled" via a selector, instead of the per-app Firebase `whenReady()` promise / RTK Query lifecycle.

- **schema** (`data/schema.ts`): `remoteFlagsReady: boolean` on `FeatureFlagsState` + `z.boolean()` on `FeatureFlagsStateSchema`; initial state `false` (`constants.ts`).
- **slice** (`data/slice.ts`): idempotent, payload-less `setRemoteFlagsReady` reducer.
- **middleware** (`data/middleware.ts`): `pollRemoteFlags` signals readiness after each settled fetch; a one-shot closure guard ensures it dispatches only on the **first** settle (success **or** failure), mirroring the Firebase module's `whenReady()` `finally` semantics — without re-dispatching a no-op on every poll.
- **selector** (`data/selectors.ts`): `selectRemoteFlagsReady`.

**Not persisted (by design).** Both apps persist only `{ overrides, bannerVisible }` (explicit allowlist projections), so the transient gate re-arms to `false` every session — matching today's fresh in-memory `whenReady()` promise. Guard tests added in both apps (LWD `db` middleware, LWM `featureFlagsLense`) assert `remoteFlagsReady` is absent from the saved projection.

**Tests:** reducer idempotence; middleware readiness on both the success and rejected-fetch paths; the selector; the two not-persisted guards.

> ⚠️ `@shared/feature-flags` `tsc --noEmit` + jest are green (80 tests). The two app persistence tests were validated by full-app typecheck (no new errors in any changed file) but **not executed locally** — the apps' global jest-setup requires a full `build:libs` not present in my worktree. Please confirm via CI.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31637](https://ledgerhq.atlassian.net/browse/LIVE-31637) — Epic LIVE-30799, builds on LIVE-31275, blocks the Phase B tickets ([LWM] + [LWD] repoint Context to Redux).
- **ADR link (if any)**: _n/a_


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31637]: https://ledgerhq.atlassian.net/browse/LIVE-31637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ