### PR TITLE
[LWM] feat(mobile): add generic Device Action analytics

### DIFF
--- a/.changeset/generic-device-action-tracking.md
+++ b/.changeset/generic-device-action-tracking.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/device-intent": minor
+"live-mobile": minor
+---
+
+Add generic Device UX V2 error page tracking and surface disconnected device data from the device intent executor.

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/DeviceDisconnected.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/DeviceDisconnected.test.tsx
@@ -1,10 +1,49 @@
 import React from "react";
 import { render, screen } from "@tests/test-renderer";
+import {
+  type ConnectedDevice,
+  DeviceModelId as DMKDeviceModelId,
+} from "@ledgerhq/device-management-kit";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { TrackScreen } from "~/analytics";
+import { SourceFlowProvider } from "../utils/SourceFlowContext";
+import { PAGE_DEVICE_ACTION } from "../utils/trackDeviceIntent";
 import { DeviceDisconnected } from "./DeviceDisconnected";
 
+jest.mock("~/analytics", () => {
+  const actual = jest.requireActual("~/analytics");
+  return {
+    ...actual,
+    TrackScreen: jest.fn(() => null),
+  };
+});
+
+const mockedTrackScreen = jest.mocked(TrackScreen);
+
+const device = {
+  id: "device-id",
+  name: "Ledger Stax",
+  modelId: DMKDeviceModelId.STAX,
+  sessionId: "session-id",
+  type: "BLE",
+  transport: "ble",
+} as ConnectedDevice;
+
+function renderState(props: Partial<React.ComponentProps<typeof DeviceDisconnected>> = {}) {
+  return render(
+    <SourceFlowProvider value="my_ledger">
+      <DeviceDisconnected device={device} onRetry={jest.fn()} onClose={jest.fn()} {...props} />
+    </SourceFlowProvider>,
+  );
+}
+
 describe("DeviceDisconnected", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("renders title, description and the primary Retry / secondary Close CTAs", () => {
-    render(<DeviceDisconnected onRetry={jest.fn()} onClose={jest.fn()} />);
+    renderState();
 
     expect(screen.getByTestId("device-intent-executor-device-disconnected")).toBeVisible();
     expect(screen.getByText("Device disconnected")).toBeVisible();
@@ -21,7 +60,7 @@ describe("DeviceDisconnected", () => {
     const onRetry = jest.fn();
     const onClose = jest.fn();
 
-    const { user } = render(<DeviceDisconnected onRetry={onRetry} onClose={onClose} />);
+    const { user } = renderState({ onRetry, onClose });
 
     await user.press(screen.getByText("Retry"));
 
@@ -33,11 +72,26 @@ describe("DeviceDisconnected", () => {
     const onRetry = jest.fn();
     const onClose = jest.fn();
 
-    const { user } = render(<DeviceDisconnected onRetry={onRetry} onClose={onClose} />);
+    const { user } = renderState({ onRetry, onClose });
 
     await user.press(screen.getByText("Close"));
 
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it("fires the Device Action - Disconnected page event with sourceFlow, deviceUxV2, modelId and transport", () => {
+    renderState();
+
+    expect(mockedTrackScreen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: PAGE_DEVICE_ACTION.Disconnected,
+        sourceFlow: "my_ledger",
+        deviceUxV2: true,
+        modelId: DeviceModelId.stax,
+        transport: "ble",
+      }),
+      undefined,
+    );
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/DeviceDisconnected.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/DeviceDisconnected.tsx
@@ -1,26 +1,46 @@
 import React from "react";
 import type { DeviceDisconnectedComponent } from "@ledgerhq/device-intent";
 import { Trans } from "~/context/Locale";
+import { TrackScreen } from "~/analytics";
 import { InfoState } from "LLM/components/InfoState";
+import { useSourceFlow } from "../utils/SourceFlowContext";
+import {
+  getConnectedDeviceTrackingProperties,
+  PAGE_DEVICE_ACTION,
+} from "../utils/trackDeviceIntent";
 
 /**
  * Generic state displayed when the device disconnects mid-flow (during the
  * device-context initialization, intent execution, or while idle).
  */
-export const DeviceDisconnected: DeviceDisconnectedComponent = ({ onRetry, onClose }) => (
-  <InfoState
-    preset="error"
-    size="hug"
-    title={<Trans i18nKey="deviceIntentExecutor.errors.connectionError.title" />}
-    description={<Trans i18nKey="deviceIntentExecutor.errors.connectionError.description" />}
-    primaryCta={{
-      label: <Trans i18nKey="common.retry" />,
-      onPress: onRetry,
-    }}
-    secondaryCta={{
-      label: <Trans i18nKey="common.close" />,
-      onPress: onClose,
-    }}
-    testID="device-intent-executor-device-disconnected"
-  />
-);
+export const DeviceDisconnected: DeviceDisconnectedComponent = ({ device, onRetry, onClose }) => {
+  const sourceFlow = useSourceFlow();
+  const { modelId, transport } = getConnectedDeviceTrackingProperties(device);
+
+  return (
+    <>
+      <TrackScreen
+        category={PAGE_DEVICE_ACTION.Disconnected}
+        sourceFlow={sourceFlow}
+        modelId={modelId}
+        transport={transport}
+        deviceUxV2
+      />
+      <InfoState
+        preset="error"
+        size="hug"
+        title={<Trans i18nKey="deviceIntentExecutor.errors.connectionError.title" />}
+        description={<Trans i18nKey="deviceIntentExecutor.errors.connectionError.description" />}
+        primaryCta={{
+          label: <Trans i18nKey="common.retry" />,
+          onPress: onRetry,
+        }}
+        secondaryCta={{
+          label: <Trans i18nKey="common.close" />,
+          onPress: onClose,
+        }}
+        testID="device-intent-executor-device-disconnected"
+      />
+    </>
+  );
+};

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/IntentError.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/IntentError.test.tsx
@@ -1,10 +1,55 @@
 import React from "react";
 import { render, screen } from "@tests/test-renderer";
+import {
+  type ConnectedDevice,
+  DeviceModelId as DMKDeviceModelId,
+} from "@ledgerhq/device-management-kit";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { TrackScreen } from "~/analytics";
+import { SourceFlowProvider } from "../utils/SourceFlowContext";
+import { PAGE_DEVICE_ACTION } from "../utils/trackDeviceIntent";
 import { IntentError } from "./IntentError";
 
+jest.mock("~/analytics", () => {
+  const actual = jest.requireActual("~/analytics");
+  return {
+    ...actual,
+    TrackScreen: jest.fn(() => null),
+  };
+});
+
+const mockedTrackScreen = jest.mocked(TrackScreen);
+
+const device = {
+  id: "device-id",
+  name: "Ledger Stax",
+  modelId: DMKDeviceModelId.STAX,
+  sessionId: "session-id",
+  type: "BLE",
+  transport: "ble",
+} as ConnectedDevice;
+
+function renderState(props: Partial<React.ComponentProps<typeof IntentError>> = {}) {
+  return render(
+    <SourceFlowProvider value="my_ledger">
+      <IntentError
+        device={device}
+        error={new Error("job failed")}
+        onRetry={jest.fn()}
+        onClose={jest.fn()}
+        {...props}
+      />
+    </SourceFlowProvider>,
+  );
+}
+
 describe("IntentError", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("renders title, description and the primary Retry / secondary Close CTAs", () => {
-    render(<IntentError error={new Error("job failed")} onRetry={jest.fn()} onClose={jest.fn()} />);
+    renderState();
 
     expect(screen.getByTestId("device-intent-executor-intent-error")).toBeVisible();
     expect(screen.getByText("job failed")).toBeVisible();
@@ -18,13 +63,7 @@ describe("IntentError", () => {
   });
 
   it("falls back to the generic i18n title/description when the error is not translatable", () => {
-    render(
-      <IntentError
-        error={"not-an-error" as unknown as Error}
-        onRetry={jest.fn()}
-        onClose={jest.fn()}
-      />,
-    );
+    renderState({ error: "not-an-error" });
 
     expect(screen.getByTestId("device-intent-executor-intent-error")).toBeVisible();
     expect(screen.getByText("Unknown error")).toBeVisible();
@@ -39,9 +78,7 @@ describe("IntentError", () => {
     const onRetry = jest.fn();
     const onClose = jest.fn();
 
-    const { user } = render(
-      <IntentError error={new Error("job failed")} onRetry={onRetry} onClose={onClose} />,
-    );
+    const { user } = renderState({ onRetry, onClose });
 
     await user.press(screen.getByText("Retry"));
 
@@ -53,13 +90,25 @@ describe("IntentError", () => {
     const onRetry = jest.fn();
     const onClose = jest.fn();
 
-    const { user } = render(
-      <IntentError error={new Error("job failed")} onRetry={onRetry} onClose={onClose} />,
-    );
+    const { user } = renderState({ onRetry, onClose });
 
     await user.press(screen.getByText("Close"));
 
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it("fires the Device Action - Unknown Intent Error page event with sourceFlow, deviceUxV2 and modelId", () => {
+    renderState();
+
+    expect(mockedTrackScreen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: PAGE_DEVICE_ACTION.UnknownIntentError,
+        sourceFlow: "my_ledger",
+        deviceUxV2: true,
+        modelId: DeviceModelId.stax,
+      }),
+      undefined,
+    );
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/IntentError.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/IntentError.tsx
@@ -2,8 +2,14 @@ import React from "react";
 import type { ErrorComponent } from "@ledgerhq/device-intent";
 import { isDmkError } from "@ledgerhq/live-dmk-mobile/errors";
 import { Trans } from "~/context/Locale";
+import { TrackScreen } from "~/analytics";
 import TranslatedError from "~/components/TranslatedError";
 import { InfoState } from "LLM/components/InfoState";
+import { useSourceFlow } from "../utils/SourceFlowContext";
+import {
+  getConnectedDeviceTrackingProperties,
+  PAGE_DEVICE_ACTION,
+} from "../utils/trackDeviceIntent";
 
 // Dev-only hint surfaced in the banner slot. This screen means the running intent let
 // an error escape its job observable, which is an implementation mistake that should
@@ -24,36 +30,47 @@ const devBanner = __DEV__
  * Intents are expected to handle their own errors internally; this component is the
  * last-resort fallback used by the executor when that does not happen.
  */
-export const IntentError: ErrorComponent = ({ onRetry, onClose, error }) => {
+export const IntentError: ErrorComponent = ({ device, onRetry, onClose, error }) => {
   const errorIsTranslatable = error && (isDmkError(error) || error instanceof Error);
+  const sourceFlow = useSourceFlow();
+  const { modelId } = getConnectedDeviceTrackingProperties(device);
+
   return (
-    <InfoState
-      preset="error"
-      size="hug"
-      title={
-        errorIsTranslatable ? (
-          <TranslatedError error={error} field="title" />
-        ) : (
-          <Trans i18nKey="deviceIntentExecutor.errors.intentError.title" />
-        )
-      }
-      description={
-        errorIsTranslatable ? (
-          <TranslatedError error={error} field="description" />
-        ) : (
-          <Trans i18nKey="deviceIntentExecutor.errors.intentError.description" />
-        )
-      }
-      banner={devBanner}
-      primaryCta={{
-        label: <Trans i18nKey="common.retry" />,
-        onPress: onRetry,
-      }}
-      secondaryCta={{
-        label: <Trans i18nKey="common.close" />,
-        onPress: onClose,
-      }}
-      testID="device-intent-executor-intent-error"
-    />
+    <>
+      <TrackScreen
+        category={PAGE_DEVICE_ACTION.UnknownIntentError}
+        sourceFlow={sourceFlow}
+        modelId={modelId}
+        deviceUxV2
+      />
+      <InfoState
+        preset="error"
+        size="hug"
+        title={
+          errorIsTranslatable ? (
+            <TranslatedError error={error} field="title" />
+          ) : (
+            <Trans i18nKey="deviceIntentExecutor.errors.intentError.title" />
+          )
+        }
+        description={
+          errorIsTranslatable ? (
+            <TranslatedError error={error} field="description" />
+          ) : (
+            <Trans i18nKey="deviceIntentExecutor.errors.intentError.description" />
+          )
+        }
+        banner={devBanner}
+        primaryCta={{
+          label: <Trans i18nKey="common.retry" />,
+          onPress: onRetry,
+        }}
+        secondaryCta={{
+          label: <Trans i18nKey="common.close" />,
+          onPress: onClose,
+        }}
+        testID="device-intent-executor-intent-error"
+      />
+    </>
   );
 };

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/InvalidOperation.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/InvalidOperation.test.tsx
@@ -1,10 +1,35 @@
 import React from "react";
 import { render, screen } from "@tests/test-renderer";
+import { TrackScreen } from "~/analytics";
+import { SourceFlowProvider } from "../utils/SourceFlowContext";
+import { PAGE_DEVICE_ACTION } from "../utils/trackDeviceIntent";
 import { InvalidOperation } from "./InvalidOperation";
 
+jest.mock("~/analytics", () => {
+  const actual = jest.requireActual("~/analytics");
+  return {
+    ...actual,
+    TrackScreen: jest.fn(() => null),
+  };
+});
+
+const mockedTrackScreen = jest.mocked(TrackScreen);
+
+function renderState(props: Partial<React.ComponentProps<typeof InvalidOperation>> = {}) {
+  return render(
+    <SourceFlowProvider value="my_ledger">
+      <InvalidOperation onClose={jest.fn()} error={null} {...props} />
+    </SourceFlowProvider>,
+  );
+}
+
 describe("InvalidOperation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("renders title, description and the primary Close CTA", () => {
-    render(<InvalidOperation onClose={jest.fn()} error={null} />);
+    renderState();
 
     expect(screen.getByTestId("device-intent-executor-invalid-operation")).toBeVisible();
     expect(screen.getByText("Invalid state")).toBeVisible();
@@ -19,10 +44,23 @@ describe("InvalidOperation", () => {
   it("invokes onClose when the primary CTA is pressed", async () => {
     const onClose = jest.fn();
 
-    const { user } = render(<InvalidOperation onClose={onClose} error={null} />);
+    const { user } = renderState({ onClose });
 
     await user.press(screen.getByText("Close"));
 
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires the Device Action - Invalid State page event with sourceFlow and deviceUxV2", () => {
+    renderState();
+
+    expect(mockedTrackScreen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: PAGE_DEVICE_ACTION.InvalidState,
+        sourceFlow: "my_ledger",
+        deviceUxV2: true,
+      }),
+      undefined,
+    );
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/InvalidOperation.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/InvalidOperation.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import type { InvalidOperationComponent } from "@ledgerhq/device-intent";
 import { Trans } from "~/context/Locale";
+import { TrackScreen } from "~/analytics";
 import { InfoState } from "LLM/components/InfoState";
+import { useSourceFlow } from "../utils/SourceFlowContext";
+import { PAGE_DEVICE_ACTION } from "../utils/trackDeviceIntent";
 
 // Dev-only hint surfaced in the banner slot. This screen means the caller drove the
 // executor into an invalid state (e.g. swapping intents while one is still running),
@@ -21,17 +24,24 @@ const devBanner = __DEV__
  * Generic error displayed when the executor enters the terminal `invalidOperation`
  * state, signalling a caller-side orchestration bug. Not expected in production.
  */
-export const InvalidOperation: InvalidOperationComponent = ({ onClose }) => (
-  <InfoState
-    preset="error"
-    size="hug"
-    title={<Trans i18nKey="deviceIntentExecutor.errors.invalidOperation.title" />}
-    description={<Trans i18nKey="deviceIntentExecutor.errors.invalidOperation.description" />}
-    banner={devBanner}
-    primaryCta={{
-      label: <Trans i18nKey="common.close" />,
-      onPress: onClose,
-    }}
-    testID="device-intent-executor-invalid-operation"
-  />
-);
+export const InvalidOperation: InvalidOperationComponent = ({ onClose }) => {
+  const sourceFlow = useSourceFlow();
+
+  return (
+    <>
+      <TrackScreen category={PAGE_DEVICE_ACTION.InvalidState} sourceFlow={sourceFlow} deviceUxV2 />
+      <InfoState
+        preset="error"
+        size="hug"
+        title={<Trans i18nKey="deviceIntentExecutor.errors.invalidOperation.title" />}
+        description={<Trans i18nKey="deviceIntentExecutor.errors.invalidOperation.description" />}
+        banner={devBanner}
+        primaryCta={{
+          label: <Trans i18nKey="common.close" />,
+          onPress: onClose,
+        }}
+        testID="device-intent-executor-invalid-operation"
+      />
+    </>
+  );
+};

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.test.tsx
@@ -187,7 +187,7 @@ describe("useDeviceIntentExecutorLWMViewModel", () => {
   describe("GIVEN a non-completing executor state", () => {
     const nonCompleting: ExecutorState[] = [
       { type: "connectingDevice" },
-      { type: "deviceDisconnected" },
+      { type: "deviceDisconnected", device: makeConnectionResult().connectedDevice },
       { type: "initializingDeviceContext", connectionResult: makeConnectionResult() },
       { type: "idle" },
     ];

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.test.ts
@@ -1,12 +1,18 @@
-import type { TransportIdentifier } from "@ledgerhq/device-management-kit";
+import {
+  type ConnectedDevice,
+  DeviceModelId as DMKDeviceModelId,
+  type TransportIdentifier,
+} from "@ledgerhq/device-management-kit";
 import { rnHidTransportIdentifier } from "@ledgerhq/device-transport-kit-react-native-hid";
 import { ConnectionErrorTypes, DiscoveryErrorTypes } from "@ledgerhq/live-dmk-mobile";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { track } from "~/analytics";
 import { previousRouteNameRef } from "~/analytics/screenRefs";
 import {
+  getConnectedDeviceTrackingProperties,
   getTrackingSubError,
   getTrackingTransport,
+  PAGE_DEVICE_ACTION,
   trackConnectAppButtonClicked,
   trackConnectDeviceButtonClicked,
   trackAppReady,
@@ -29,7 +35,15 @@ jest.mock("~/analytics", () => {
 
 const mockedTrack = jest.mocked(track);
 const TEST_SOURCE = "Portfolio";
-const TEST_BLE_TRANSPORT = "RN_BLE" as TransportIdentifier;
+const TEST_BLE_TRANSPORT: TransportIdentifier = "RN_BLE";
+const connectedDevice: ConnectedDevice = {
+  id: "device-id",
+  name: "Ledger Stax",
+  modelId: DMKDeviceModelId.STAX,
+  sessionId: "session-id",
+  type: "BLE",
+  transport: "ble",
+};
 
 const layerABaseProperties = {
   source: TEST_SOURCE,
@@ -195,6 +209,35 @@ describe("trackDeviceIntent — Layer A tracking helpers", () => {
           expect(getTrackingTransport(TEST_BLE_TRANSPORT)).toBe("ble");
           expect(getTrackingTransport(undefined)).toBeUndefined();
         });
+      });
+    });
+  });
+
+  describe("getConnectedDeviceTrackingProperties", () => {
+    it("GIVEN a connected device WHEN called THEN it maps DMK model and transport to tracking values", () => {
+      const usbDevice: ConnectedDevice = {
+        ...connectedDevice,
+        modelId: DMKDeviceModelId.NANO_X,
+        type: "USB",
+      };
+
+      expect(getConnectedDeviceTrackingProperties(connectedDevice)).toEqual({
+        modelId: DeviceModelId.stax,
+        transport: "ble",
+      });
+      expect(getConnectedDeviceTrackingProperties(usbDevice)).toEqual({
+        modelId: DeviceModelId.nanoX,
+        transport: "usb",
+      });
+    });
+  });
+
+  describe("PAGE_DEVICE_ACTION", () => {
+    it("GIVEN generic DIE error pages THEN it exposes the expected page event names", () => {
+      expect(PAGE_DEVICE_ACTION).toEqual({
+        Disconnected: "Device Action - Disconnected",
+        UnknownIntentError: "Device Action - Unknown Intent Error",
+        InvalidState: "Device Action - Invalid State",
       });
     });
   });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
@@ -1,7 +1,7 @@
-import type { TransportIdentifier } from "@ledgerhq/device-management-kit";
+import type { ConnectedDevice, TransportIdentifier } from "@ledgerhq/device-management-kit";
 import { rnHidTransportIdentifier } from "@ledgerhq/device-transport-kit-react-native-hid";
 import type { DeviceModelId } from "@ledgerhq/types-devices";
-import type { KnownDevice } from "@ledgerhq/live-dmk-shared";
+import { dmkToLedgerDeviceIdMap, type KnownDevice } from "@ledgerhq/live-dmk-shared";
 import { ConnectionErrorTypes, DiscoveryErrorTypes } from "@ledgerhq/live-dmk-mobile";
 import { track } from "~/analytics";
 import { previousRouteNameRef } from "~/analytics/screenRefs";
@@ -50,6 +50,12 @@ export const PAGE_CONNECT_APP = {
   WrongDeviceForAccount: "Connect App - Wrong Device For Account",
   OutOfStorage: "Connect App - Out Of Storage",
   Error: "Connect App - Error",
+} as const;
+
+export const PAGE_DEVICE_ACTION = {
+  Disconnected: "Device Action - Disconnected",
+  UnknownIntentError: "Device Action - Unknown Intent Error",
+  InvalidState: "Device Action - Invalid State",
 } as const;
 
 /**
@@ -104,6 +110,11 @@ export const getTrackingTransport = (
   if (!transportId) return undefined;
   return transportId === rnHidTransportIdentifier ? "usb" : "ble";
 };
+
+export const getConnectedDeviceTrackingProperties = (device: ConnectedDevice) => ({
+  modelId: dmkToLedgerDeviceIdMap[device.modelId],
+  transport: device.type === "USB" ? "usb" : "ble",
+});
 
 export const getTrackingSubError = (errorType: ConnectDeviceErrorType): string =>
   TRACKING_SUB_ERRORS[errorType];

--- a/libs/device-intent/src/DeviceIntentExecutor.test.tsx
+++ b/libs/device-intent/src/DeviceIntentExecutor.test.tsx
@@ -103,6 +103,7 @@ const InitializerComponent: React.FC<{
 );
 
 const DeviceDisconnectedComponent: React.FC<{
+  device: DeviceConnectionResult["connectedDevice"];
   onRetry: () => void;
   onClose: () => void;
 }> = ({ onRetry, onClose }) => (
@@ -118,6 +119,7 @@ const DeviceDisconnectedComponent: React.FC<{
 
 const IntentErrorComponent: React.FC<{
   error: unknown;
+  device: DeviceConnectionResult["connectedDevice"];
   onRetry: () => void;
   onClose: () => void;
 }> = ({ onRetry, onClose }) => (
@@ -343,15 +345,16 @@ describe("DeviceIntentExecutor (unit)", () => {
       const mockConfig = makeMockPlatformConfig();
       const onRetry = jest.fn();
       const onClose = jest.fn();
+      const device = makeConnectionResult().connectedDevice;
       const props = makeUnitProps(
-        { phase: "deviceDisconnected", onRetry, onClose },
+        { phase: "deviceDisconnected", device, onRetry, onClose },
         { platformConfig: mockConfig },
       );
       render(<DeviceIntentExecutor {...props} />);
 
       expect(screen.getByTestId("device-disconnected")).toBeTruthy();
       expect(mockConfig.DeviceDisconnectedComponent).toHaveBeenCalledWith(
-        { onRetry, onClose },
+        { device, onRetry, onClose },
         undefined,
       );
     });
@@ -419,15 +422,16 @@ describe("DeviceIntentExecutor (unit)", () => {
       const error = new Error("job fail");
       const onRetry = jest.fn();
       const onClose = jest.fn();
+      const device = makeConnectionResult().connectedDevice;
       const props = makeUnitProps(
-        { phase: "intentError", error, onRetry, onClose },
+        { phase: "intentError", error, device, onRetry, onClose },
         { platformConfig: mockConfig },
       );
       render(<DeviceIntentExecutor {...props} />);
 
       expect(screen.getByTestId("intent-error")).toBeTruthy();
       expect(mockConfig.IntentErrorComponent).toHaveBeenCalledWith(
-        { error, onRetry, onClose },
+        { error, device, onRetry, onClose },
         undefined,
       );
     });

--- a/libs/device-intent/src/DeviceIntentExecutor.tsx
+++ b/libs/device-intent/src/DeviceIntentExecutor.tsx
@@ -50,7 +50,13 @@ export function DeviceIntentExecutor<JobState, Input, ExtraProps, InitInput, Ini
         />
       );
     case "deviceDisconnected":
-      return <DeviceDisconnectedComponent onRetry={state.onRetry} onClose={state.onClose} />;
+      return (
+        <DeviceDisconnectedComponent
+          device={state.device}
+          onRetry={state.onRetry}
+          onClose={state.onClose}
+        />
+      );
     case "deviceInitialization":
       return (
         <DeviceContextInitializerComponent
@@ -73,7 +79,12 @@ export function DeviceIntentExecutor<JobState, Input, ExtraProps, InitInput, Ini
     }
     case "intentError":
       return (
-        <IntentErrorComponent error={state.error} onRetry={state.onRetry} onClose={state.onClose} />
+        <IntentErrorComponent
+          error={state.error}
+          device={state.device}
+          onRetry={state.onRetry}
+          onClose={state.onClose}
+        />
       );
     case "invalidOperation":
       return <InvalidOperationComponent error={state.error} onClose={state.onClose} />;

--- a/libs/device-intent/src/DeviceIntentExecutorStateMachine.test.ts
+++ b/libs/device-intent/src/DeviceIntentExecutorStateMachine.test.ts
@@ -146,9 +146,13 @@ describe("DeviceIntentExecutorStateMachine", () => {
   describe("GIVEN the machine is in deviceDisconnected state", () => {
     it("WHEN RETRY is received THEN it transitions back to connectingDevice", () => {
       const { sm, listeners } = createSM();
-      sm.deviceConnected(makeConnectionResult());
+      const connectionResult = makeConnectionResult();
+      sm.deviceConnected(connectionResult);
       sm.deviceDisconnected();
-      expect(lastExecutorState(listeners)).toEqual({ type: "deviceDisconnected" });
+      expect(lastExecutorState(listeners)).toEqual({
+        type: "deviceDisconnected",
+        device: connectionResult.connectedDevice,
+      });
 
       sm.retry();
       expect(lastExecutorState(listeners)).toEqual({ type: "connectingDevice" });
@@ -167,9 +171,13 @@ describe("DeviceIntentExecutorStateMachine", () => {
 
     it("WHEN DEVICE_DISCONNECTED is received THEN it transitions to deviceDisconnected", () => {
       const { sm, listeners } = createSM();
-      sm.deviceConnected(makeConnectionResult());
+      const connectionResult = makeConnectionResult();
+      sm.deviceConnected(connectionResult);
       sm.deviceDisconnected();
-      expect(lastExecutorState(listeners)).toEqual({ type: "deviceDisconnected" });
+      expect(lastExecutorState(listeners)).toEqual({
+        type: "deviceDisconnected",
+        device: connectionResult.connectedDevice,
+      });
       sm.stop();
     });
 
@@ -266,9 +274,13 @@ describe("DeviceIntentExecutorStateMachine", () => {
 
     it("WHEN DEVICE_DISCONNECTED is received THEN it transitions to deviceDisconnected", () => {
       const { sm, listeners } = createSM({ job: () => NEVER });
-      driveToExecution(sm);
+      const connectionResult = makeConnectionResult();
+      driveToExecution(sm, connectionResult);
       sm.deviceDisconnected();
-      expect(lastExecutorState(listeners)).toEqual({ type: "deviceDisconnected" });
+      expect(lastExecutorState(listeners)).toEqual({
+        type: "deviceDisconnected",
+        device: connectionResult.connectedDevice,
+      });
       sm.stop();
     });
 
@@ -465,11 +477,15 @@ describe("DeviceIntentExecutorStateMachine", () => {
 
     it("WHEN DEVICE_DISCONNECTED is received THEN it transitions to deviceDisconnected", () => {
       const { sm, listeners } = createSM({ job: () => of({ step: "done" as const }) });
-      driveToExecution(sm);
+      const connectionResult = makeConnectionResult();
+      driveToExecution(sm, connectionResult);
       expect(lastExecutorState(listeners)).toEqual({ type: "idle" });
 
       sm.deviceDisconnected();
-      expect(lastExecutorState(listeners)).toEqual({ type: "deviceDisconnected" });
+      expect(lastExecutorState(listeners)).toEqual({
+        type: "deviceDisconnected",
+        device: connectionResult.connectedDevice,
+      });
       sm.stop();
     });
   });
@@ -578,11 +594,15 @@ describe("DeviceIntentExecutorStateMachine", () => {
       };
       const { sm, listeners } = createSM({ job: jobFn });
 
-      driveToExecution(sm);
+      const connectionResult = makeConnectionResult();
+      driveToExecution(sm, connectionResult);
       expect(lastExecutorState(listeners)).toMatchObject({ type: "executingIntent" });
 
       sm.deviceDisconnected();
-      expect(lastExecutorState(listeners)).toEqual({ type: "deviceDisconnected" });
+      expect(lastExecutorState(listeners)).toEqual({
+        type: "deviceDisconnected",
+        device: connectionResult.connectedDevice,
+      });
 
       sm.retry();
       expect(lastExecutorState(listeners)).toEqual({ type: "connectingDevice" });

--- a/libs/device-intent/src/DeviceIntentExecutorStateMachine.ts
+++ b/libs/device-intent/src/DeviceIntentExecutorStateMachine.ts
@@ -92,6 +92,12 @@ function createExecutorMachine<JobState, Input, ExtraProps>() {
       ),
     },
     actions: {
+      notifyDeviceDisconnected: ({ context }) => {
+        context.listeners.onExecutorStateChanged({
+          type: "deviceDisconnected",
+          device: context.deviceConnectionResult!.connectedDevice,
+        });
+      },
       resetConnection: assign({
         deviceConnectionResult: () => null,
         deviceExtractedContext: () => null,
@@ -127,7 +133,6 @@ function createExecutorMachine<JobState, Input, ExtraProps>() {
       deviceDisconnected: {
         entry: ({ context }) => {
           log(LOG_TYPE, "state: deviceDisconnected");
-          context.listeners.onExecutorStateChanged({ type: "deviceDisconnected" });
         },
         on: {
           RETRY: {
@@ -156,7 +161,7 @@ function createExecutorMachine<JobState, Input, ExtraProps>() {
           },
           DEVICE_DISCONNECTED: {
             target: "deviceDisconnected",
-            actions: "resetConnection",
+            actions: ["notifyDeviceDisconnected", "resetConnection"],
           },
           REINITIALIZE: {
             target: "deviceInitialization",
@@ -217,7 +222,7 @@ function createExecutorMachine<JobState, Input, ExtraProps>() {
         on: {
           DEVICE_DISCONNECTED: {
             target: "deviceDisconnected",
-            actions: "resetConnection",
+            actions: ["notifyDeviceDisconnected", "resetConnection"],
           },
           SET_INTENT: {
             target: "invalidOperation",
@@ -287,7 +292,7 @@ function createExecutorMachine<JobState, Input, ExtraProps>() {
           },
           DEVICE_DISCONNECTED: {
             target: "deviceDisconnected",
-            actions: "resetConnection",
+            actions: ["notifyDeviceDisconnected", "resetConnection"],
           },
           REINITIALIZE: {
             target: "deviceInitialization",

--- a/libs/device-intent/src/deriveHookState.test.ts
+++ b/libs/device-intent/src/deriveHookState.test.ts
@@ -11,6 +11,7 @@ const noop = () => {};
 
 const defaultConnectionResult = makeConnectionResult();
 const defaultExtractedContext = makeExtractedContext();
+const defaultDevice = defaultConnectionResult.connectedDevice;
 
 const DummyComponent = () => null;
 
@@ -55,16 +56,17 @@ describe("deriveHookState", () => {
     });
   });
 
-  it("maps deviceDisconnected to deviceDisconnected phase with onRetry and onClose", () => {
+  it("maps deviceDisconnected to deviceDisconnected phase with device, onRetry and onClose", () => {
     const onRetry = jest.fn();
     const onUserCancel = jest.fn();
     const params = makeParams({ onRetry, onUserCancel });
-    const state: ExecutorState = { type: "deviceDisconnected" };
+    const state: ExecutorState = { type: "deviceDisconnected", device: defaultDevice };
 
     const result = deriveHookState(state, params);
 
     expect(result).toEqual({
       phase: "deviceDisconnected",
+      device: defaultDevice,
       onRetry,
       onClose: onUserCancel,
     });
@@ -155,6 +157,7 @@ describe("deriveHookState", () => {
     expect(result).toEqual({
       phase: "intentError",
       error,
+      device: defaultDevice,
       onRetry,
       onClose: onUserCancel,
     });
@@ -214,7 +217,7 @@ describe("deriveHookState", () => {
 
     const phases: ExecutorState[] = [
       { type: "connectingDevice" },
-      { type: "deviceDisconnected" },
+      { type: "deviceDisconnected", device: defaultDevice },
       {
         type: "initializingDeviceContext",
         connectionResult: defaultConnectionResult,

--- a/libs/device-intent/src/deriveHookState.ts
+++ b/libs/device-intent/src/deriveHookState.ts
@@ -1,4 +1,5 @@
 import type React from "react";
+import type { ConnectedDevice } from "@ledgerhq/device-management-kit";
 import type {
   DeviceConnectionParams,
   DeviceConnectionResult,
@@ -27,6 +28,7 @@ export type DeviceIntentExecutorHookState<JobState, _Input, ExtraProps, InitInpu
     }
   | {
       phase: "deviceDisconnected";
+      device: ConnectedDevice;
       onRetry: () => void;
       onClose: () => void;
     }
@@ -51,6 +53,7 @@ export type DeviceIntentExecutorHookState<JobState, _Input, ExtraProps, InitInpu
   | {
       phase: "intentError";
       error: unknown;
+      device: ConnectedDevice;
       onRetry: () => void;
       onClose: () => void;
     }
@@ -98,6 +101,7 @@ export function deriveHookState<JobState, Input, ExtraProps, InitInput>(
     case "deviceDisconnected":
       return {
         phase: "deviceDisconnected",
+        device: executorState.device,
         onRetry: params.onRetry,
         onClose: params.onUserCancel,
       };
@@ -121,6 +125,7 @@ export function deriveHookState<JobState, Input, ExtraProps, InitInput>(
       return {
         phase: "intentError",
         error: executorState.error,
+        device: executorState.connectionResult.connectedDevice,
         onRetry: params.onRetry,
         onClose: params.onUserCancel,
       };

--- a/libs/device-intent/src/executor.ts
+++ b/libs/device-intent/src/executor.ts
@@ -1,4 +1,5 @@
 import type React from "react";
+import type { ConnectedDevice } from "@ledgerhq/device-management-kit";
 import type {
   DeviceConnectionParams,
   DeviceConnectionResult,
@@ -49,6 +50,7 @@ export type DeviceContextInitializerComponent<
  */
 export type ErrorComponent = React.ComponentType<{
   error: unknown;
+  device: ConnectedDevice;
   onRetry: () => void;
   /** Call to request the executor to close (forwards to `DeviceIntentExecutorProps.onUserCancel`). */
   onClose: () => void;
@@ -61,6 +63,7 @@ export type ErrorComponent = React.ComponentType<{
  * Injected into the executor via {@link ExecutorPlatformConfiguration}.
  */
 export type DeviceDisconnectedComponent = React.ComponentType<{
+  device: ConnectedDevice;
   onRetry: () => void;
   /** Call to request the executor to close (forwards to `DeviceIntentExecutorProps.onUserCancel`). */
   onClose: () => void;
@@ -104,10 +107,11 @@ export interface ExecutorPlatformConfiguration<InitInput = void, InitializerConf
  * - `executingIntent` → `connectionResult` and `extractedContext`
  *   (set on `DEVICE_CONNECTED` and `DEVICE_INITIALIZED` respectively).
  * - `executingIntentError` → both, plus the original error.
+ * - `deviceDisconnected` → the disconnected device from the last successful connection.
  */
 export type ExecutorState =
   | { type: "connectingDevice" }
-  | { type: "deviceDisconnected" }
+  | { type: "deviceDisconnected"; device: ConnectedDevice }
   | {
       type: "initializingDeviceContext";
       connectionResult: DeviceConnectionResult;

--- a/libs/device-intent/src/useDeviceIntentExecutor.test.tsx
+++ b/libs/device-intent/src/useDeviceIntentExecutor.test.tsx
@@ -86,6 +86,7 @@ const makeConnectionResult = (
 // the SM, so the values just need to exist to satisfy the union.
 const TEST_CONNECTION_RESULT = makeBaseConnectionResult();
 const TEST_EXTRACTED_CONTEXT = makeExtractedContext();
+const TEST_DEVICE = TEST_CONNECTION_RESULT.connectedDevice;
 
 type TestProps = DeviceIntentExecutorProps<
   unknown,
@@ -619,7 +620,10 @@ describe("useDeviceIntentExecutor — integration smoke tests (real SM)", () => 
       });
 
       // The second (latest) callback should be called, not the first
-      expect(secondCallback).toHaveBeenCalledWith({ type: "deviceDisconnected" });
+      expect(secondCallback).toHaveBeenCalledWith({
+        type: "deviceDisconnected",
+        device: connectionResult.connectedDevice,
+      });
     });
 
     it("WHEN onUserCancel prop changes between renders THEN onClose forwards to the latest callback", () => {
@@ -779,7 +783,7 @@ describe("useDeviceIntentExecutor — unit (mocked SM)", () => {
       const { result, sm, listeners } = renderWithMockSM();
 
       act(() => {
-        listeners.onExecutorStateChanged({ type: "deviceDisconnected" });
+        listeners.onExecutorStateChanged({ type: "deviceDisconnected", device: TEST_DEVICE });
       });
 
       act(() => {
@@ -869,7 +873,7 @@ describe("useDeviceIntentExecutor — unit (mocked SM)", () => {
       });
 
       act(() => {
-        listeners.onExecutorStateChanged({ type: "deviceDisconnected" });
+        listeners.onExecutorStateChanged({ type: "deviceDisconnected", device: TEST_DEVICE });
       });
 
       inPhase(result.current, "deviceDisconnected");
@@ -959,11 +963,17 @@ describe("useDeviceIntentExecutor — unit (mocked SM)", () => {
       rerender({ p: { ...props, onExecutorStateChanged: secondCallback } });
 
       act(() => {
-        listeners.onExecutorStateChanged({ type: "deviceDisconnected" });
+        listeners.onExecutorStateChanged({ type: "deviceDisconnected", device: TEST_DEVICE });
       });
 
-      expect(secondCallback).toHaveBeenCalledWith({ type: "deviceDisconnected" });
-      expect(firstCallback).not.toHaveBeenCalledWith({ type: "deviceDisconnected" });
+      expect(secondCallback).toHaveBeenCalledWith({
+        type: "deviceDisconnected",
+        device: TEST_DEVICE,
+      });
+      expect(firstCallback).not.toHaveBeenCalledWith({
+        type: "deviceDisconnected",
+        device: TEST_DEVICE,
+      });
     });
   });
 
@@ -1107,7 +1117,7 @@ describe("useDeviceIntentExecutor — unit (mocked SM)", () => {
       expect(onUserCancel).toHaveBeenCalledTimes(1);
 
       act(() => {
-        listeners.onExecutorStateChanged({ type: "deviceDisconnected" });
+        listeners.onExecutorStateChanged({ type: "deviceDisconnected", device: TEST_DEVICE });
       });
       inPhase(result.current, "deviceDisconnected").onClose();
       expect(onUserCancel).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Generic Device Action error page analytics
      - Device intent executor `deviceDisconnected` state data

### 📝 Description

Adds `TrackScreen` page events for generic Device Action errors: disconnected device, unknown intent error, and invalid state.

The shared device intent executor now exposes the disconnected device on `deviceDisconnected`, so mobile can send `modelId` and `transport` from the UI component without caching connection data.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31528](https://ledgerhq.atlassian.net/browse/LIVE-31528)
- **Stacked on**: #18000

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31528]: https://ledgerhq.atlassian.net/browse/LIVE-31528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ