### PR TITLE
[LWDM] feat(evm-staking): fetch pending rewards for cosmos-evm chains

### DIFF
--- a/.changeset/fetch-evm-staking-rewards.md
+++ b/.changeset/fetch-evm-staking-rewards.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@ledgerhq/coin-evm": minor
+---
+
+Fetch pending staking rewards for Cosmos-EVM hybrid chains (Sei) via the Cosmos distribution REST endpoint so `Stake.amountRewarded` is populated, and wire the per-row "Claim rewards" action on desktop so it opens the claim flow pre-selected on the chosen validator.

--- a/apps/ledger-live-desktop/src/renderer/families/evm/Delegation/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/Delegation/index.tsx
@@ -101,7 +101,12 @@ const Delegation = ({ account }: { account: StakingAccount }) => {
 
   const mappedDelegations = mapDelegations(delegations, validators, unit);
   const mappedUnbondings = mapUnbondings(unbondings, validators, unit);
-  const onRowClaimRewards = useCallback((_validatorAddress: string) => {}, []);
+  const onRowClaimRewards = useCallback(
+    (validatorAddress: string) => {
+      dispatch(openModal("MODAL_EVM_CLAIM_REWARDS", { account, validatorAddress }));
+    },
+    [account, dispatch],
+  );
 
   const hasDelegations = delegations.length > 0;
   // Only surface the "Pending undelegation" section when the chain enforces an unbonding

--- a/libs/coin-modules/coin-evm/src/staking/contracts.ts
+++ b/libs/coin-modules/coin-evm/src/staking/contracts.ts
@@ -32,6 +32,12 @@ export const STAKING_CONTRACTS: Record<string, StakingContractConfig> = {
       hrp: "sei",
       endpoint: "/cosmos/staking/v1beta1/delegators/{address}/redelegations",
     },
+    rewardsStrategy: {
+      type: "cosmos-rest",
+      endpoint: "/cosmos/distribution/v1beta1/delegators/{address}/rewards",
+      denom: "usei",
+      scale: USEI_TO_EVM_SCALE,
+    },
     explorerConfig: {
       validatorUrl: "https://seistream.app/validators/$address",
     },

--- a/libs/coin-modules/coin-evm/src/staking/fetchers.ts
+++ b/libs/coin-modules/coin-evm/src/staking/fetchers.ts
@@ -14,6 +14,7 @@ import type {
 import { extractSeiDelegation, getCeloAmount, getSeiDelegationAmount } from "../utils";
 import { encodeStakingData, decodeStakingResult } from "./encoder";
 import { buildTransactionParams } from "./operations";
+import { fetchRewards } from "./rewards";
 import { getValidators } from "./validators";
 
 /**
@@ -200,6 +201,11 @@ const getStakesForValidators = async (
     return [];
   }
 
+  // Fired here so its latency overlaps the precompile batch loop below;
+  // awaited at the end. Any failure resolves to an empty map so the staking
+  // sync never blocks on the off-chain rewards call.
+  const rewardsPromise = fetchRewards(currency.id, address).catch(() => new Map<string, bigint>());
+
   const allResults: PromiseSettledResult<Stake | null>[] = [];
 
   // Process validators in batches to avoid overwhelming the RPC node.
@@ -236,6 +242,15 @@ const getStakesForValidators = async (
       stakes.push(result.value);
     }
   });
+
+  const rewards = await rewardsPromise;
+  for (const stake of stakes) {
+    if (!stake.delegate) continue;
+    const amountRewarded = rewards.get(stake.delegate);
+    if (amountRewarded !== undefined) {
+      stake.amountRewarded = amountRewarded;
+    }
+  }
 
   return stakes;
 };

--- a/libs/coin-modules/coin-evm/src/staking/redelegations.ts
+++ b/libs/coin-modules/coin-evm/src/staking/redelegations.ts
@@ -34,7 +34,7 @@ import { isExternalNodeConfig } from "../network/node/types";
  * Returns `null` when the address has not been associated yet or the RPC call
  * fails, allowing callers to fall back gracefully.
  */
-async function getCosmosAddr(
+export async function getCosmosAddr(
   evmRpcUrl: string,
   precompile: { address: string; abi: string },
   evmAddress: string,

--- a/libs/coin-modules/coin-evm/src/staking/rewards.test.ts
+++ b/libs/coin-modules/coin-evm/src/staking/rewards.test.ts
@@ -1,0 +1,196 @@
+import { ethers } from "ethers";
+import { fetchRewards } from "./rewards";
+import { USEI_TO_EVM_SCALE } from "../utils";
+
+jest.mock("@ledgerhq/live-network", () => jest.fn());
+jest.mock("../config");
+jest.mock("../network/node/types");
+
+const mockNetwork = jest.mocked(require("@ledgerhq/live-network"));
+const mockGetCoinConfig = jest.mocked(require("../config").getCoinConfig);
+const mockIsExternalNodeConfig = jest.mocked(require("../network/node/types").isExternalNodeConfig);
+
+const EVM_ADDRESS = "0x1234567890abcdef1234567890abcdef12345678";
+const COSMOS_ADDRESS = "sei1defaultcosmosaddressfortest";
+
+type RewardCoin = { denom: string; amount: string };
+const restResponse = (rewards: Array<{ validator_address: string; reward: RewardCoin[] }>) => ({
+  data: { rewards },
+});
+
+describe("fetchRewards", () => {
+  let contractSpy: jest.SpyInstance;
+  let providerSpy: jest.SpyInstance;
+  let mockGetSeiAddr: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetSeiAddr = jest.fn().mockResolvedValue(COSMOS_ADDRESS);
+    providerSpy = jest.spyOn(ethers, "JsonRpcProvider" as any).mockReturnValue({});
+    contractSpy = jest
+      .spyOn(ethers, "Contract" as any)
+      .mockReturnValue({ getSeiAddr: mockGetSeiAddr });
+
+    const mockNode = { type: "external", uri: "https://sei-evm.coin.ledger.com" };
+    mockGetCoinConfig.mockReturnValue({ info: { node: mockNode } });
+    mockIsExternalNodeConfig.mockImplementation((node: unknown) => node === mockNode);
+  });
+
+  afterEach(() => {
+    contractSpy.mockRestore();
+    providerSpy.mockRestore();
+  });
+
+  it.each([
+    { case: "unknown currencyId", currencyId: "unknown_chain", setup: () => {} },
+    { case: "chain has no rewardsStrategy (e.g. Celo)", currencyId: "celo", setup: () => {} },
+    {
+      case: "REST call fails",
+      currencyId: "sei_evm",
+      setup: () => mockNetwork.mockRejectedValue(new Error("network error")),
+    },
+    {
+      case: "API response has no rewards array",
+      currencyId: "sei_evm",
+      setup: () => mockNetwork.mockResolvedValue({ data: {} }),
+    },
+    {
+      case: "address precompile call fails",
+      currencyId: "sei_evm",
+      setup: () => mockGetSeiAddr.mockRejectedValueOnce(new Error("not associated")),
+    },
+  ])("returns an empty map when $case", async ({ currencyId, setup }) => {
+    setup();
+    expect(await fetchRewards(currencyId, EVM_ADDRESS)).toEqual(new Map());
+  });
+
+  it("resolves the EVM address to its canonical Cosmos bech32 via the precompile", async () => {
+    const canonicalCosmosAddress = "sei1qpvm20rgmjq4mlf0m28l088snu8ldm05pf2c5d";
+    mockGetSeiAddr.mockResolvedValueOnce(canonicalCosmosAddress);
+    mockNetwork.mockResolvedValueOnce(restResponse([]));
+
+    await fetchRewards("sei_evm", "0x66c4371aE8FFeD2ec1c2EBbbcCfb7E494181E1E3");
+
+    expect((mockNetwork.mock.calls[0][0] as { url: string }).url).toContain(canonicalCosmosAddress);
+  });
+
+  it("scales the integer usei portion to wei (drops sub-usei sdk.Dec precision)", async () => {
+    // 569 usei integer survives; fractional .024…000 is dropped on-chain at withdrawal.
+    mockNetwork.mockResolvedValue(
+      restResponse([
+        {
+          validator_address: "seivaloper1one",
+          reward: [{ denom: "usei", amount: "569.024692675122000000" }],
+        },
+      ]),
+    );
+
+    const result = await fetchRewards("sei_evm", EVM_ADDRESS);
+
+    expect(result.size).toBe(1);
+    expect(result.get("seivaloper1one")).toBe(569n * USEI_TO_EVM_SCALE);
+  });
+
+  it("aggregates multiple matching-denom coins on the same validator", async () => {
+    mockNetwork.mockResolvedValue(
+      restResponse([
+        {
+          validator_address: "seivaloper1one",
+          reward: [
+            { denom: "usei", amount: "100" },
+            { denom: "usei", amount: "23" },
+          ],
+        },
+      ]),
+    );
+
+    const result = await fetchRewards("sei_evm", EVM_ADDRESS);
+
+    expect(result.get("seivaloper1one")).toBe(123n * USEI_TO_EVM_SCALE);
+  });
+
+  it("ignores reward coins whose denom does not match the strategy", async () => {
+    mockNetwork.mockResolvedValue(
+      restResponse([
+        {
+          validator_address: "seivaloper1one",
+          reward: [
+            { denom: "usei", amount: "500" },
+            { denom: "uatom", amount: "9999" },
+          ],
+        },
+      ]),
+    );
+
+    const result = await fetchRewards("sei_evm", EVM_ADDRESS);
+
+    expect(result.get("seivaloper1one")).toBe(500n * USEI_TO_EVM_SCALE);
+  });
+
+  it("skips validators whose reward integer part is zero (sub-usei amounts)", async () => {
+    mockNetwork.mockResolvedValue(
+      restResponse([
+        {
+          validator_address: "seivaloper1dust",
+          reward: [{ denom: "usei", amount: "0.019211023787000000" }],
+        },
+        { validator_address: "seivaloper1real", reward: [{ denom: "usei", amount: "42" }] },
+      ]),
+    );
+
+    const result = await fetchRewards("sei_evm", EVM_ADDRESS);
+
+    expect(result.has("seivaloper1dust")).toBe(false);
+    expect(result.get("seivaloper1real")).toBe(42n * USEI_TO_EVM_SCALE);
+  });
+
+  it("handles multiple validators independently", async () => {
+    mockNetwork.mockResolvedValue(
+      restResponse([
+        { validator_address: "seivaloper1a", reward: [{ denom: "usei", amount: "10" }] },
+        { validator_address: "seivaloper1b", reward: [{ denom: "usei", amount: "20" }] },
+        { validator_address: "seivaloper1c", reward: [{ denom: "usei", amount: "30" }] },
+      ]),
+    );
+
+    const result = await fetchRewards("sei_evm", EVM_ADDRESS);
+
+    expect(result.size).toBe(3);
+    expect(result.get("seivaloper1a")).toBe(10n * USEI_TO_EVM_SCALE);
+    expect(result.get("seivaloper1b")).toBe(20n * USEI_TO_EVM_SCALE);
+    expect(result.get("seivaloper1c")).toBe(30n * USEI_TO_EVM_SCALE);
+  });
+
+  it("returns an empty map when the malformed amount cannot be parsed", async () => {
+    mockNetwork.mockResolvedValue(
+      restResponse([
+        {
+          validator_address: "seivaloper1bad",
+          reward: [{ denom: "usei", amount: "not-a-number" }],
+        },
+      ]),
+    );
+
+    const result = await fetchRewards("sei_evm", EVM_ADDRESS);
+
+    expect(result.has("seivaloper1bad")).toBe(false);
+  });
+
+  it("keeps the good amount when one coin is malformed alongside a valid one", async () => {
+    mockNetwork.mockResolvedValue(
+      restResponse([
+        {
+          validator_address: "seivaloper1mixed",
+          reward: [
+            { denom: "usei", amount: "100" },
+            { denom: "usei", amount: "not-a-number" },
+          ],
+        },
+      ]),
+    );
+
+    const result = await fetchRewards("sei_evm", EVM_ADDRESS);
+
+    expect(result.get("seivaloper1mixed")).toBe(100n * USEI_TO_EVM_SCALE);
+  });
+});

--- a/libs/coin-modules/coin-evm/src/staking/rewards.ts
+++ b/libs/coin-modules/coin-evm/src/staking/rewards.ts
@@ -1,0 +1,86 @@
+import network from "@ledgerhq/live-network";
+import { log } from "@ledgerhq/logs";
+import { STAKING_CONTRACTS } from "./contracts";
+import { getCoinConfig } from "../config";
+import { isExternalNodeConfig } from "../network/node/types";
+import { parseDecimalIntegerPart } from "../utils";
+import { getCosmosAddr } from "./redelegations";
+import type { RewardsStrategy } from "../types/staking";
+
+type RewardCoin = { denom: string; amount: string };
+type ValidatorReward = {
+  validator_address: string;
+  reward: RewardCoin[];
+};
+type RewardsApiResponse = { rewards: ValidatorReward[] };
+
+async function fetchCosmosRestRewards(
+  baseUrl: string,
+  strategy: Extract<RewardsStrategy, { type: "cosmos-rest" }>,
+  evmAddress: string,
+  evmRpcUrl: string,
+  precompileAddress: { address: string; abi: string },
+): Promise<Map<string, bigint>> {
+  const cosmosAddress = await getCosmosAddr(evmRpcUrl, precompileAddress, evmAddress);
+  if (!cosmosAddress) return new Map();
+
+  const url = `${baseUrl.replace(/\/$/, "")}${strategy.endpoint.replace("{address}", cosmosAddress)}`;
+
+  try {
+    const res = await network<RewardsApiResponse>({ url, method: "GET" });
+    const result = new Map<string, bigint>();
+    for (const r of res.data?.rewards ?? []) {
+      let totalBase = 0n;
+      for (const coin of r.reward ?? []) {
+        if (coin.denom === strategy.denom) {
+          totalBase += parseDecimalIntegerPart(coin.amount);
+        }
+      }
+      if (totalBase > 0n) {
+        result.set(r.validator_address, totalBase * strategy.scale);
+      }
+    }
+    return result;
+  } catch (e) {
+    log("coin-evm/staking", "fetchCosmosRestRewards: REST request or response parsing failed", {
+      url,
+      error: e instanceof Error ? e.message : String(e),
+    });
+    return new Map();
+  }
+}
+
+// Returns a map of `validatorAddress → amountRewarded` (in wei) per the
+// chain's `rewardsStrategy`. Empty map on any failure: rewards display falls
+// back to zero without blocking the staking sync.
+export async function fetchRewards(
+  currencyId: string,
+  evmAddress: string,
+): Promise<Map<string, bigint>> {
+  try {
+    const config = STAKING_CONTRACTS[currencyId];
+    const strategy = config?.rewardsStrategy;
+    if (!strategy || strategy.type === "none") return new Map();
+
+    switch (strategy.type) {
+      case "cosmos-rest": {
+        const apiConfig = config.apiConfig;
+        if (!apiConfig?.baseUrl || !apiConfig.precompileAddress) return new Map();
+        const node = getCoinConfig(currencyId).info.node;
+        const evmRpcUrl = isExternalNodeConfig(node) ? node.uri : undefined;
+        if (!evmRpcUrl) return new Map();
+        return await fetchCosmosRestRewards(
+          apiConfig.baseUrl,
+          strategy,
+          evmAddress,
+          evmRpcUrl,
+          apiConfig.precompileAddress,
+        );
+      }
+      default:
+        return new Map();
+    }
+  } catch {
+    return new Map();
+  }
+}

--- a/libs/coin-modules/coin-evm/src/types/staking.ts
+++ b/libs/coin-modules/coin-evm/src/types/staking.ts
@@ -31,6 +31,26 @@ export type RedelegationStrategy =
     }
   | { type: "none" };
 
+/**
+ * Per-chain strategy for fetching pending delegation rewards.
+ *
+ * - `cosmos-rest`: Cosmos distribution REST endpoint; EVM address resolved
+ *   via `apiConfig.precompileAddress`. Reward coins matching `denom` summed
+ *   (integer base-unit only) and multiplied by `scale` to wei.
+ * - `none`: rewards unavailable off-chain.
+ */
+export type RewardsStrategy =
+  | {
+      type: "cosmos-rest";
+      /** REST endpoint template; `{address}` is replaced with the resolved Cosmos address. */
+      endpoint: string;
+      /** Cosmos denom carrying the reward amount (e.g. "usei"). */
+      denom: string;
+      /** Multiplier converting one base-denom unit to wei. */
+      scale: bigint;
+    }
+  | { type: "none" };
+
 export type StakingContractConfig = {
   contractAddress: string;
   specificContractAddressByOperation?: Partial<Record<StakingOperation, string>>;
@@ -76,6 +96,8 @@ export type StakingContractConfig = {
   };
   /** How to fetch active redelegations from an off-chain source. Defaults to `"none"` when absent. */
   redelegationStrategy?: RedelegationStrategy;
+  /** How to fetch pending delegation rewards from an off-chain source. Defaults to `"none"` when absent. */
+  rewardsStrategy?: RewardsStrategy;
   explorerConfig?: {
     validatorUrl: string;
   };

--- a/libs/coin-modules/coin-evm/src/utils.test.ts
+++ b/libs/coin-modules/coin-evm/src/utils.test.ts
@@ -1,4 +1,9 @@
-import { buildSmartContractDetails, isSmartContractInput, safeEncodeEIP55 } from "./utils";
+import {
+  buildSmartContractDetails,
+  isSmartContractInput,
+  parseDecimalIntegerPart,
+  safeEncodeEIP55,
+} from "./utils";
 
 describe("isSmartContractInput", () => {
   it.each([
@@ -55,5 +60,28 @@ describe("buildSmartContractDetails", () => {
       contractInteraction: "SmartContractDeployment",
       contractPayload: "0xabcdef",
     });
+  });
+});
+
+describe("parseDecimalIntegerPart", () => {
+  it.each([
+    ["100", 100n],
+    ["569.024692675122000000", 569n],
+    ["0.019211023787000000", 0n],
+    ["  42  ", 42n],
+    ["1.", 1n],
+    ["1000000000000000000", 1000000000000000000n],
+    ["-5.9", -5n],
+  ] as const)("parseDecimalIntegerPart(%p) === %s", (input, expected) => {
+    expect(parseDecimalIntegerPart(input)).toBe(expected);
+  });
+
+  it.each([
+    "",
+    ".",
+    "not-a-number",
+    "abc.123",
+  ])("returns 0n when the integer part is not parseable (%p)", input => {
+    expect(parseDecimalIntegerPart(input)).toBe(0n);
   });
 });

--- a/libs/coin-modules/coin-evm/src/utils.ts
+++ b/libs/coin-modules/coin-evm/src/utils.ts
@@ -246,6 +246,17 @@ export const extractSeiDelegation = (decoded: unknown): SeiDelegation | undefine
  */
 export const USEI_TO_EVM_SCALE = 10n ** 12n;
 
+// Truncate to the integer part to match what the chain actually pays out on
+// withdrawal (fractional sub-denom rewards are dropped on-chain).
+export function parseDecimalIntegerPart(amount: string): bigint {
+  const intPart = amount.trim().split(".")[0];
+  try {
+    return BigInt(intPart);
+  } catch {
+    return 0n;
+  }
+}
+
 function normalizeSeiDelegation(outer: unknown): SeiDelegation | undefined {
   if (!isRecord(outer)) return undefined;
 


### PR DESCRIPTION
## Summary

- Adds `RewardsStrategy` config + `fetchRewards()` populating `Stake.amountRewarded`. First impl: `cosmos-rest`, configured for Sei. Queries the Cosmos distribution REST endpoint after resolving the EVM address to its bech32 counterpart via the chain's address precompile.
- Fetch fired in parallel with the per-validator precompile loop so its latency overlaps the existing RPC reads; resolves to an empty map on failure to keep sync non-blocking.
- Wires the previously-empty per-row "Claim rewards" handler on desktop so it opens the claim modal preselected on the chosen validator.

## Context

Before this PR, the EVM staking fetcher only read delegated amounts from the staking precompile (`0x...1005`); rewards from the distribution module were never queried, so `Stake.amountRewarded` was implicitly always `0n`. The header "Claim rewards" button was therefore always disabled, and the per-row claim action did nothing (empty callback). This trio of issues was masked because the claim feature in the parent PR couldn't surface real reward values until they reached the UI.

- **JIRA or GitHub link**: [LIVE-31795](https://ledgerhq.atlassian.net/browse/LIVE-31795)

[LIVE-31795]: https://ledgerhq.atlassian.net/browse/LIVE-31795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

- E2E
   - Desktop: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/e0991a62-61fe-44dc-8b15-8d1d4b29c244/
   - Mobile: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/2838c20c-2151-4c0e-86e7-36d372cecad1/