### PR TITLE
[LWDM] fix(LIVE-23777): update LiFi support link to https://scan.li.fi/

### DIFF
--- a/.changeset/lifi-support-link-scan.md
+++ b/.changeset/lifi-support-link-scan.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/ledger-cal-service": patch
+"@ledgerhq/live-common": patch
+---
+
+Update the LiFi provider support link shown on the swap success screen (mobile & desktop) to https://scan.li.fi/

--- a/libs/ledger-live-common/src/exchange/providers/swap.ts
+++ b/libs/ledger-live-common/src/exchange/providers/swap.ts
@@ -267,7 +267,7 @@ const DEFAULT_SWAP_PROVIDERS: Record<string, ProviderConfig & Partial<Additional
     name: "lifi",
     needsBearerToken: false,
     termsOfUseUrl: "https://li.fi/legal/terms-and-conditions/",
-    supportUrl: "https://discord.gg/jumperexchange",
+    supportUrl: "https://scan.li.fi/",
     mainUrl: "https://li.fi/",
     needsKYC: false,
     version: 2,

--- a/libs/ledger-services/cal/src/partners/default.ts
+++ b/libs/ledger-services/cal/src/partners/default.ts
@@ -148,7 +148,7 @@ export const SWAP_DATA_CDN: Record<string, AdditionalProviderConfig> = {
     displayName: "LI.FI",
     mainUrl: "https://li.fi/",
     needsKYC: false,
-    supportUrl: "https://discord.gg/jumperexchange",
+    supportUrl: "https://scan.li.fi/",
     termsOfUseUrl: "https://li.fi/legal/terms-and-conditions/",
     type: "CEX",
   },


### PR DESCRIPTION
## Context

[LIVE-23777](https://ledgerhq.atlassian.net/browse/LIVE-23777)

After a successful Swap, the Transaction Success screen (mobile & desktop) shows a link to the provider's support. For provider **LiFi**, this link must be updated to **https://scan.li.fi/**.

## Changes

- `libs/ledger-services/cal/src/partners/default.ts` — LiFi `supportUrl` → `https://scan.li.fi/` (this is the source of truth, served via `SWAP_DATA_CDN` / `getSwapProvider`, consumed by both apps' success screens).
- `libs/ledger-live-common/src/exchange/providers/swap.ts` — same update in the offline `DEFAULT_SWAP_PROVIDERS` fallback, for consistency.
- Changeset (patch) for `@ledgerhq/ledger-cal-service` and `@ledgerhq/live-common`.

The new value matches the existing scan-domain pattern (`scan.swaps.xyz` for the swaps.xyz aggregator) and the `scan.li.fi/tx/...` explorer URL already used in `SwapOperationDetails`.

## Notes

- This duplicates the already-open PR #17399 (same change), opened intentionally at the requester's instruction.

REVIEW OUTCOME: pass

[LIVE-23777]: https://ledgerhq.atlassian.net/browse/LIVE-23777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ