### PR TITLE
chore(e2e): bump allure 3.2.2 → 3.9.0 and restore attachments

### DIFF
--- a/e2e/desktop/playwright.config.ts
+++ b/e2e/desktop/playwright.config.ts
@@ -29,6 +29,7 @@ const config: PlaywrightTestConfig = {
         [
           "allure-playwright",
           {
+            detail: false,
             links: {
               issue: {
                 nameTemplate: "%s",
@@ -43,7 +44,7 @@ const config: PlaywrightTestConfig = {
         ],
         ["./tests/utils/customJsonReporter.ts"],
       ]
-    : [["allure-playwright"]],
+    : [["allure-playwright", {detail: false}]],
 };
 
 export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,11 +289,11 @@ catalogs:
       specifier: 5.0.2
       version: 5.0.2
     allure-js-commons:
-      specifier: 3.2.2
-      version: 3.2.2
+      specifier: 3.9.0
+      version: 3.9.0
     allure-playwright:
-      specifier: 3.2.2
-      version: 3.2.2
+      specifier: 3.9.0
+      version: 3.9.0
     axios:
       specifier: 1.13.5
       version: 1.13.5
@@ -1452,7 +1452,7 @@ importers:
         version: 4.0.17(msw@2.7.3(@types/node@24.12.0)(typescript@6.0.2))
       allure-playwright:
         specifier: 'catalog:'
-        version: 3.2.2(@playwright/test@1.60.0)
+        version: 3.9.0(@playwright/test@1.60.0)
       autoprefixer:
         specifier: 10.4.22
         version: 10.4.22(postcss@8.5.6)
@@ -3200,10 +3200,10 @@ importers:
         version: 24.12.0
       allure-js-commons:
         specifier: 'catalog:'
-        version: 3.2.2(allure-playwright@3.2.2(@playwright/test@1.60.0))
+        version: 3.9.0(allure-playwright@3.9.0(@playwright/test@1.60.0))
       allure-playwright:
         specifier: 'catalog:'
-        version: 3.2.2(@playwright/test@1.60.0)
+        version: 3.9.0(@playwright/test@1.60.0)
       axios:
         specifier: 'catalog:'
         version: 1.13.5
@@ -23509,18 +23509,18 @@ packages:
     resolution: {integrity: sha512-TZ3oxop0zseJp2bRKb8Zzkxa4/aB+RvKEMnhylbY6UiOkqhNAHovRJx03bFA9bbvE/nsR70sX+ktU5xI2WJiqQ==}
     hasBin: true
 
-  allure-js-commons@3.2.2:
-    resolution: {integrity: sha512-qr9r9+HpyNmbaaAtNDK6qXXar7RcYQECf8hOtH/e8DFKZNahIkfFYU0LP4Q7SPbqyAZsGbocTKikVx9L2po+eg==}
+  allure-js-commons@3.9.0:
+    resolution: {integrity: sha512-uVQcGE6MWIvGR/zW1XEUwHXUQa1EJKY0Cah+0TZK1qKuw6ptyhftDr34XE3wExTyCZirRrI98dbRtPeYYuyI+g==}
     peerDependencies:
-      allure-playwright: 3.2.2
+      allure-playwright: 3.9.0
     peerDependenciesMeta:
       allure-playwright:
         optional: true
 
-  allure-playwright@3.2.2:
-    resolution: {integrity: sha512-nBZsUkMOpMfvwuNaHOC+RYwjV6EjJ1NsznlTEeZAjcMSvhmbSPC5HLruDATwUctZu33DFwbk/ub/HhMfFisYHQ==}
+  allure-playwright@3.9.0:
+    resolution: {integrity: sha512-bv8J4BaHhs7Cd7GaAz7xEuD6vthZuw235YtHpe/9y7FDPn3oB6n6KcxZOhU0lYvwVKO5cUVqnquHKqoLkSCrgA==}
     peerDependencies:
-      '@playwright/test': '>=1.36.0'
+      '@playwright/test': '>=1.53.0'
 
   allure-store@1.1.2:
     resolution: {integrity: sha512-8C4Hh3twQx39Poj4URHwaiHVPk9e8cQEQil9/9GWmYlzaq/QPeF/tOWNzpGGROufCXHKDyLMafLF0hZmA46Lqg==}
@@ -54405,16 +54405,16 @@ snapshots:
 
   allure-commandline@2.28.0: {}
 
-  allure-js-commons@3.2.2(allure-playwright@3.2.2(@playwright/test@1.60.0)):
+  allure-js-commons@3.9.0(allure-playwright@3.9.0(@playwright/test@1.60.0)):
     dependencies:
       md5: 2.3.0
     optionalDependencies:
-      allure-playwright: 3.2.2(@playwright/test@1.60.0)
+      allure-playwright: 3.9.0(@playwright/test@1.60.0)
 
-  allure-playwright@3.2.2(@playwright/test@1.60.0):
+  allure-playwright@3.9.0(@playwright/test@1.60.0):
     dependencies:
       '@playwright/test': 1.60.0
-      allure-js-commons: 3.2.2(allure-playwright@3.2.2(@playwright/test@1.60.0))
+      allure-js-commons: 3.9.0(allure-playwright@3.9.0(@playwright/test@1.60.0))
 
   allure-store@1.1.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -192,8 +192,8 @@ catalog:
   "@tanstack/react-table": 8.5.11
   "@playwright/test": 1.60.0
   playwright: 1.60.0
-  allure-playwright: 3.2.2
-  allure-js-commons: 3.2.2
+  allure-playwright: 3.9.0
+  allure-js-commons: 3.9.0
   oxlint: 1.51.0
   oxfmt: 0.36.0
   # Modules published by coin-modules


### PR DESCRIPTION
## Goal

Adopt the latest `allure-playwright` / `allure-js-commons` `3.9.0` line on LWD E2E and fix the report regressions the bump introduced.

## What changed

- Bump `allure-playwright` and `allure-js-commons` `3.2.2` → `3.9.0` in `pnpm-workspace.yaml` (catalog).
- Configure the `allure-playwright` reporter with `detail: false` in `e2e/desktop/playwright.config.ts` (both the CI reporter array and the default fallback).

## Why `detail: false`

Starting with `allure-playwright` 3.x, the reporter defaults to `detail: true`, which nests Playwright `testInfo.attach()` outputs inside an auto-generated step group in the Allure report. On our LWD runs this caused failure screenshots (and likely Speculos screenshots, test logs, network/webview logs, video) to be hidden behind the step details rather than rendered at the test level.

Setting `detail: false` restores 3.2.2-era behavior: attachments are emitted at the top level of the test, so failure screenshots and the other artifacts produced by [`e2e/desktop/tests/utils/allureUtils.ts`](../blob/chore/e2e-investigate-allure-3.9.0/e2e/desktop/tests/utils/allureUtils.ts) show up where reviewers expect them.

## Dependency

Sits on top of the Playwright `1.60.0` bump from #17661 so this reproduces against the Playwright version we're shipping. Rebase on `develop` once #17661 merges; the diff then shrinks to just the allure delta + the `detail: false` flag.

## Test plan

- [x] CI run on this branch shows failure screenshots at the test level in the Allure report
- [x] Speculos screenshots, test logs, network logs, webview logs, and video attachments are all visible in the report: https://github.com/LedgerHQ/ledger-live/actions/runs/26818902539/job/79071116889 
- [x] No regression in pass/fail counts or step rendering vs. `develop` : https://github.com/LedgerHQ/ledger-live/actions/runs/26818902539/job/79071116889 