### PR TITLE
[LWM] fix(mobile): firebase remote config drops 4 FeatureIds via lossy camelCase reverse [LIVE-31697]

### DIFF
--- a/.changeset/lwm-firebase-feature-id-mapping.md
+++ b/.changeset/lwm-firebase-feature-id-mapping.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix Firebase remote config keys for FeatureIds whose `snake_case ↔ camelCase` round-trip is lossy via lodash (`llmAccountListUI`, `llmRebornLP`, `web3hub`, `ptxSwapReceiveTRC20WithoutTrx`). `fetchRemoteFlags` now uses a forward `feature_${snakeCase(id)} → FeatureId` lookup built from `FeatureIdSchema.options`, so these flags resolve to their Firebase values instead of silently falling back to defaults.

--- a/apps/ledger-live-mobile/src/firebase/remoteConfig.test.ts
+++ b/apps/ledger-live-mobile/src/firebase/remoteConfig.test.ts
@@ -77,6 +77,21 @@ describe("fetchRemoteFlags", () => {
     });
   });
 
+  it("matches Firebase keys case-insensitively", async () => {
+    mockGetAll.mockReturnValue({
+      Feature_Counter_Value: value(JSON.stringify({ enabled: true })),
+      FEATURE_LWM_WALLET_40: value(JSON.stringify({ enabled: true })),
+    });
+
+    const { fetchRemoteFlags } = await loadModule();
+    const result = await fetchRemoteFlags();
+
+    expect(result).toEqual({
+      counterValue: { enabled: true },
+      lwmWallet40: { enabled: true },
+    });
+  });
+
   it("silently drops keys whose value is not valid JSON", async () => {
     mockGetAll.mockReturnValue({
       feature_counter_value: value(JSON.stringify({ enabled: true })),

--- a/apps/ledger-live-mobile/src/firebase/remoteConfig.test.ts
+++ b/apps/ledger-live-mobile/src/firebase/remoteConfig.test.ts
@@ -37,33 +37,56 @@ beforeEach(() => {
 });
 
 describe("fetchRemoteFlags", () => {
-  it("filters out non-feature keys, strips feature_ prefix, and camelCases", async () => {
+  it("maps known Firebase keys to FeatureIds, drops unknown keys", async () => {
     mockGetAll.mockReturnValue({
-      feature_mock_feature: value(JSON.stringify({ enabled: true })),
-      feature_some_other_flag: value(JSON.stringify({ enabled: false, params: { x: 1 } })),
+      feature_counter_value: value(JSON.stringify({ enabled: true })),
+      feature_lwm_wallet_40: value(JSON.stringify({ enabled: false, params: { mainNav: true } })),
       config_unrelated: value("\"ignored\""),
       stranger_key: value("\"ignored\""),
+      feature_unknown_flag: value("\"ignored\""),
     });
 
     const { fetchRemoteFlags } = await loadModule();
     const result = await fetchRemoteFlags();
 
     expect(result).toEqual({
-      mockFeature: { enabled: true },
-      someOtherFlag: { enabled: false, params: { x: 1 } },
+      counterValue: { enabled: true },
+      lwmWallet40: { enabled: false, params: { mainNav: true } },
     });
   });
 
-  it("silently drops keys whose value is not valid JSON", async () => {
+  it("resolves Firebase keys whose snake_case ↔ camelCase round-trip is lossy", async () => {
+    // `lodash.camelCase(lodash.snakeCase(id))` is not an identity for FeatureIds that
+    // contain digits or ≥2 consecutive uppercase letters. These four flags fail the
+    // round-trip and were silently dropped by the previous camelCase-based decoder.
     mockGetAll.mockReturnValue({
-      feature_good: value(JSON.stringify({ enabled: true })),
-      feature_bad: value("not json"),
+      feature_llm_account_list_ui: value(JSON.stringify({ enabled: true })),
+      feature_llm_reborn_lp: value(JSON.stringify({ enabled: true })),
+      feature_web_3_hub: value(JSON.stringify({ enabled: true })),
+      feature_ptx_swap_receive_trc_20_without_trx: value(JSON.stringify({ enabled: true })),
     });
 
     const { fetchRemoteFlags } = await loadModule();
     const result = await fetchRemoteFlags();
 
-    expect(result).toEqual({ good: { enabled: true } });
+    expect(result).toEqual({
+      llmAccountListUI: { enabled: true },
+      llmRebornLP: { enabled: true },
+      web3hub: { enabled: true },
+      ptxSwapReceiveTRC20WithoutTrx: { enabled: true },
+    });
+  });
+
+  it("silently drops keys whose value is not valid JSON", async () => {
+    mockGetAll.mockReturnValue({
+      feature_counter_value: value(JSON.stringify({ enabled: true })),
+      feature_lwm_wallet_40: value("not json"),
+    });
+
+    const { fetchRemoteFlags } = await loadModule();
+    const result = await fetchRemoteFlags();
+
+    expect(result).toEqual({ counterValue: { enabled: true } });
   });
 
   it("propagates the fetchAndActivate failure (middleware swallows it)", async () => {
@@ -110,7 +133,9 @@ describe("fetchRemoteFlags", () => {
 
 describe("subscribeToRemoteFlags", () => {
   it("notifies every subscriber after a successful fetch", async () => {
-    mockGetAll.mockReturnValue({ feature_mock_feature: value(JSON.stringify({ enabled: true })) });
+    mockGetAll.mockReturnValue({
+      feature_counter_value: value(JSON.stringify({ enabled: true })),
+    });
     const { fetchRemoteFlags, subscribeToRemoteFlags } = await loadModule();
 
     const a = jest.fn();

--- a/apps/ledger-live-mobile/src/firebase/remoteConfig.ts
+++ b/apps/ledger-live-mobile/src/firebase/remoteConfig.ts
@@ -1,8 +1,16 @@
 import { getRemoteConfig } from "@react-native-firebase/remote-config";
-import camelCase from "lodash/camelCase";
+import snakeCase from "lodash/snakeCase";
 import { formatDefaultFeatures } from "@ledgerhq/live-common/featureFlags/index";
-import { FEATURE_FLAGS_DEFAULTS } from "@shared/feature-flags";
-import type { PartialFeatures } from "@shared/feature-flags";
+import { FEATURE_FLAGS_DEFAULTS, FeatureIdSchema } from "@shared/feature-flags";
+import type { FeatureId, PartialFeatures } from "@shared/feature-flags";
+
+// Precomputed inverse of live-common's `formatToFirebaseFeatureId` (`feature_${snakeCase(id)}`).
+// `lodash.camelCase(snakeCase(id))` is not a clean round-trip for FeatureIds with digits
+// or consecutive uppercase letters (e.g. `llmAccountListUI` → `llm_account_list_ui` →
+// `llmAccountListUi`), which silently drops the flag at the slice boundary.
+const FIREBASE_KEY_TO_FEATURE_ID: Record<string, FeatureId> = Object.fromEntries(
+  FeatureIdSchema.options.map(id => [`feature_${snakeCase(id)}`, id]),
+);
 
 type Subscriber = (event: { fetchedAt: number }) => void;
 
@@ -69,21 +77,20 @@ export function whenReady(): Promise<void> {
  * stays in sync, and exposed via {@link subscribeToRemoteFlags} so legacy
  * consumers hydrate from the same payload at the same tick.
  *
- * Filters out `config_*` keys (owned by `LiveConfig`), strips the `feature_`
- * prefix, camelCases the remainder, and JSON-parses each value. Malformed JSON
- * values are dropped silently — at worst the slice falls back to defaults for
- * that key. Unknown feature IDs are dropped at runtime inside `resolveAll`, so
- * the closing cast to {@link PartialFeatures} is safe.
+ * Maps each known Firebase key (`feature_${snakeCase(id)}`) back to its canonical
+ * FeatureId via {@link FIREBASE_KEY_TO_FEATURE_ID}, then JSON-parses each value.
+ * Unknown keys (`config_*`, stray entries) and malformed JSON are dropped
+ * silently — at worst the slice falls back to defaults for that flag.
  */
 export async function fetchRemoteFlags(): Promise<PartialFeatures> {
   try {
     await setup();
     await rc.fetchAndActivate();
     const all = rc.getAll();
-    const flags: Record<string, unknown> = {};
+    const flags: PartialFeatures = {};
     for (const [key, value] of Object.entries(all)) {
-      if (!key.startsWith("feature_")) continue;
-      const featureId = camelCase(key.slice("feature_".length));
+      const featureId = FIREBASE_KEY_TO_FEATURE_ID[key];
+      if (!featureId) continue;
       try {
         flags[featureId] = JSON.parse(value.asString());
       } catch {
@@ -93,7 +100,7 @@ export async function fetchRemoteFlags(): Promise<PartialFeatures> {
     const fetchedAt = Date.now();
     lastFetchedAt = fetchedAt;
     subscribers.forEach(callback => callback({ fetchedAt }));
-    return flags as PartialFeatures;
+    return flags;
   } finally {
     resolveReady?.();
     resolveReady = null;

--- a/apps/ledger-live-mobile/src/firebase/remoteConfig.ts
+++ b/apps/ledger-live-mobile/src/firebase/remoteConfig.ts
@@ -89,7 +89,9 @@ export async function fetchRemoteFlags(): Promise<PartialFeatures> {
     const all = rc.getAll();
     const flags: PartialFeatures = {};
     for (const [key, value] of Object.entries(all)) {
-      const featureId = FIREBASE_KEY_TO_FEATURE_ID[key];
+      // `lodash.snakeCase` always lowercases — match it on the read side so any
+      // case drift in Firebase admin entries still resolves to the canonical id.
+      const featureId = FIREBASE_KEY_TO_FEATURE_ID[key.toLowerCase()];
       if (!featureId) continue;
       try {
         flags[featureId] = JSON.parse(value.asString());


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** New regression test in `apps/ledger-live-mobile/src/firebase/remoteConfig.test.ts` asserts all 4 broken FeatureIds round-trip end-to-end. The existing fetch/subscribe/setup tests still pass (12/12).
- [x] **Impact of the changes:**
  - `useFeature("llmAccountListUI")` now reflects Firebase staging/prod values instead of falling back to the package default `{ enabled: false }`. Verify in nightly (account list UI re-enabled).
  - Same fix for `llmRebornLP` (Reborn LP variant flag — Reborn analytics + AB-test routing), `web3hub` (web3 hub entry-point), and `ptxSwapReceiveTRC20WithoutTrx` (TRC20-receive without TRX guardrail).
  - No user-visible change for any flag not in the list above — those already round-trip cleanly.

### 📝 Description

Post-LIVE-30964 regression: (Wallet XP) reported that `llmAccountListUI` was resolving to `{ enabled: false }` in nightly despite being live on Firebase for ~1 year. QAA verified the regression vanishes when revert-testing commit `3db4d581dc` (the LIVE-30964 hook-import swap).

#### Root cause

`apps/ledger-live-mobile/src/firebase/remoteConfig.ts` decoded Firebase keys with:

```ts
const featureId = camelCase(key.slice("feature_".length));
```

Live-common writes Firebase keys via `formatToFirebaseFeatureId(id) = feature_${snakeCase(id)}`. The reverse via `lodash.camelCase` is **not an identity** when the original FeatureId contains digits or ≥2 consecutive uppercase letters. lodash collapses runs of uppercase into a single "word" on `snakeCase`, and emits only a single capitalised first letter on `camelCase`:

| FeatureId | snake (Firebase key) | camel (post-reverse) |
|---|---|---|
| `llmAccountListUI` | `llm_account_list_ui` | `llmAccountListUi` (lowercase i) ❌ |
| `llmRebornLP` | `llm_reborn_lp` | `llmRebornLp` ❌ |
| `web3hub` | `web_3_hub` | `web3Hub` ❌ |
| `ptxSwapReceiveTRC20WithoutTrx` | `ptx_swap_receive_trc_20_without_trx` | `ptxSwapReceiveTrc20WithoutTrx` ❌ |

For each, `remoteFlags[<correct-FeatureId>]` was `undefined`, so the slice's `resolveFeature` fell through to `FEATURE_FLAGS_DEFAULTS[id]` = `{ enabled: false }`.

The Context-driven (pre-LIVE-30964) path didn't have this bug — it used `formatToFirebaseFeatureId` in the **forward** direction to look values up from `LiveConfig.getValueByKey()`, no reverse needed.

#### Fix

Build a precomputed `feature_${snakeCase(id)} → FeatureId` lookup at module load, sourced from `FeatureIdSchema.options`. The forward direction uses the exact same `snakeCase` function that writes the keys, so the round-trip is guaranteed lossless for every registered flag:

```ts
const FIREBASE_KEY_TO_FEATURE_ID: Record<string, FeatureId> = Object.fromEntries(
  FeatureIdSchema.options.map(id => [`feature_${snakeCase(id)}`, id]),
);

// inside fetchRemoteFlags:
for (const [key, value] of Object.entries(all)) {
  const featureId = FIREBASE_KEY_TO_FEATURE_ID[key];
  if (!featureId) continue;
  try {
    flags[featureId] = JSON.parse(value.asString());
  } catch {
    // malformed JSON — drop, fall through to defaults
  }
}
```

### Verification

1. `pnpm --filter live-mobile test:jest -- remoteConfig` — 12/12 pass including the new regression test for all 4 broken FeatureIds.
2. `pnpm nx run live-mobile:typecheck` — clean.
3. **Local runtime smoke** against dev Firebase: boot LWM dev, Settings → Debug → Feature flags, confirm `llmAccountListUI` shows `enabled: true` (dev mirrors staging per Lucas).
4. **Nightly** post-merge confirms regression cleared.

### ❓ Context

- **JIRA link**: [LIVE-31697](https://ledgerhq.atlassian.net/browse/LIVE-31697) (engineering task) — visible-symptom bug filed by QA: [LIVE-31687](https://ledgerhq.atlassian.net/browse/LIVE-31687)
- **Caused by**: LIVE-30964 (merge PR #17827) commit `3db4d581dc`
- **Verified by**: Bruno's revert-test on the LIVE-30964 import-swap commit

### Out of scope

- Gabriel's process suggestion to run E2E on the branch before merging — separate CI/workflow change.
- Sibling fix for LWD shipped separately in PR #18053 (same bug, identical code copy-pasted into `apps/ledger-live-desktop/src/firebase/remoteConfig.ts` — latent there since no LWD-side source consumes the 4 affected FeatureIds today, but the structural bug is identical).

[LIVE-31687]: https://ledgerhq.atlassian.net/browse/LIVE-31687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



[LIVE-31697]: https://ledgerhq.atlassian.net/browse/LIVE-31697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ