### PR TITLE
[LWD] fix(desktop): firebase remote config drops 4 FeatureIds via lossy camelCase reverse [LIVE-31698]

### DIFF
--- a/.changeset/lwd-firebase-feature-id-mapping.md
+++ b/.changeset/lwd-firebase-feature-id-mapping.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix Firebase remote config keys for FeatureIds whose `snake_case ↔ camelCase` round-trip is lossy via lodash (`web3hub`, `ptxSwapReceiveTRC20WithoutTrx`, `llmAccountListUI`, `llmRebornLP`). `fetchRemoteFlags` now uses a forward `feature_${snakeCase(id)} → FeatureId` lookup built from `FeatureIdSchema.options`, and matches Firebase keys case-insensitively. No LWD-side flag currently consumes the affected names, but the bug was structurally present and would silently drop any future `lld*`/`lwd*` flag ending in ≥2 consecutive uppercase letters or containing digits.

--- a/apps/ledger-live-desktop/src/firebase/remoteConfig.test.ts
+++ b/apps/ledger-live-desktop/src/firebase/remoteConfig.test.ts
@@ -39,33 +39,71 @@ beforeEach(() => {
 });
 
 describe("fetchRemoteFlags", () => {
-  it("filters out non-feature keys, strips feature_ prefix, and camelCases", async () => {
+  it("maps known Firebase keys to FeatureIds, drops unknown keys", async () => {
     mockGetAll.mockReturnValue({
-      feature_mock_feature: value(JSON.stringify({ enabled: true })),
-      feature_some_other_flag: value(JSON.stringify({ enabled: false, params: { x: 1 } })),
+      feature_counter_value: value(JSON.stringify({ enabled: true })),
+      feature_lwd_wallet_40: value(JSON.stringify({ enabled: false, params: { mainNav: true } })),
       config_unrelated: value("\"ignored\""),
       stranger_key: value("\"ignored\""),
+      feature_unknown_flag: value("\"ignored\""),
     });
 
     const { fetchRemoteFlags } = await loadModule();
     const result = await fetchRemoteFlags();
 
     expect(result).toEqual({
-      mockFeature: { enabled: true },
-      someOtherFlag: { enabled: false, params: { x: 1 } },
+      counterValue: { enabled: true },
+      lwdWallet40: { enabled: false, params: { mainNav: true } },
     });
   });
 
-  it("silently drops keys whose value is not valid JSON", async () => {
+  it("resolves Firebase keys whose snake_case ↔ camelCase round-trip is lossy", async () => {
+    // `lodash.camelCase(lodash.snakeCase(id))` is not an identity for FeatureIds that
+    // contain digits or ≥2 consecutive uppercase letters. These four flags fail the
+    // round-trip and were silently dropped by the previous camelCase-based decoder.
     mockGetAll.mockReturnValue({
-      feature_good: value(JSON.stringify({ enabled: true })),
-      feature_bad: value("not json"),
+      feature_llm_account_list_ui: value(JSON.stringify({ enabled: true })),
+      feature_llm_reborn_lp: value(JSON.stringify({ enabled: true })),
+      feature_web_3_hub: value(JSON.stringify({ enabled: true })),
+      feature_ptx_swap_receive_trc_20_without_trx: value(JSON.stringify({ enabled: true })),
     });
 
     const { fetchRemoteFlags } = await loadModule();
     const result = await fetchRemoteFlags();
 
-    expect(result).toEqual({ good: { enabled: true } });
+    expect(result).toEqual({
+      llmAccountListUI: { enabled: true },
+      llmRebornLP: { enabled: true },
+      web3hub: { enabled: true },
+      ptxSwapReceiveTRC20WithoutTrx: { enabled: true },
+    });
+  });
+
+  it("matches Firebase keys case-insensitively", async () => {
+    mockGetAll.mockReturnValue({
+      Feature_Counter_Value: value(JSON.stringify({ enabled: true })),
+      FEATURE_LWD_WALLET_40: value(JSON.stringify({ enabled: true })),
+    });
+
+    const { fetchRemoteFlags } = await loadModule();
+    const result = await fetchRemoteFlags();
+
+    expect(result).toEqual({
+      counterValue: { enabled: true },
+      lwdWallet40: { enabled: true },
+    });
+  });
+
+  it("silently drops keys whose value is not valid JSON", async () => {
+    mockGetAll.mockReturnValue({
+      feature_counter_value: value(JSON.stringify({ enabled: true })),
+      feature_lwd_wallet_40: value("not json"),
+    });
+
+    const { fetchRemoteFlags } = await loadModule();
+    const result = await fetchRemoteFlags();
+
+    expect(result).toEqual({ counterValue: { enabled: true } });
   });
 
   it("propagates the fetchAndActivate failure (middleware swallows it)", async () => {
@@ -101,7 +139,9 @@ describe("fetchRemoteFlags", () => {
 
 describe("subscribeToRemoteFlags", () => {
   it("notifies every subscriber after a successful fetch", async () => {
-    mockGetAll.mockReturnValue({ feature_mock_feature: value(JSON.stringify({ enabled: true })) });
+    mockGetAll.mockReturnValue({
+      feature_counter_value: value(JSON.stringify({ enabled: true })),
+    });
     const { fetchRemoteFlags, subscribeToRemoteFlags } = await loadModule();
 
     const a = jest.fn();

--- a/apps/ledger-live-desktop/src/firebase/remoteConfig.ts
+++ b/apps/ledger-live-desktop/src/firebase/remoteConfig.ts
@@ -5,11 +5,20 @@ import {
   getAll,
   RemoteConfig,
 } from "firebase/remote-config";
-import camelCase from "lodash/camelCase";
+import snakeCase from "lodash/snakeCase";
 import { formatDefaultFeatures } from "@ledgerhq/live-common/featureFlags/index";
-import { FEATURE_FLAGS_DEFAULTS } from "@shared/feature-flags";
-import type { PartialFeatures } from "@shared/feature-flags";
+import { FEATURE_FLAGS_DEFAULTS, FeatureIdSchema } from "@shared/feature-flags";
+import type { FeatureId, PartialFeatures } from "@shared/feature-flags";
 import { getFirebaseConfig } from "~/firebase-setup";
+
+// Precomputed inverse of live-common's `formatToFirebaseFeatureId` (`feature_${snakeCase(id)}`).
+// `lodash.camelCase(snakeCase(id))` is not a clean round-trip for FeatureIds with digits
+// or consecutive uppercase letters (e.g. `web3hub` → `web_3_hub` → `web3Hub`,
+// `ptxSwapReceiveTRC20WithoutTrx` → `..._trc_20_..._trx` → `ptxSwapReceiveTrc20WithoutTrx`),
+// which would silently drop the flag at the slice boundary.
+const FIREBASE_KEY_TO_FEATURE_ID: Record<string, FeatureId> = Object.fromEntries(
+  FeatureIdSchema.options.map(id => [`feature_${snakeCase(id)}`, id]),
+);
 
 type Subscriber = (event: { fetchedAt: number }) => void;
 
@@ -84,21 +93,22 @@ export function whenReady(): Promise<void> {
  * stays in sync, and exposed via {@link subscribeToRemoteFlags} so the legacy
  * Context provider hydrates from the same payload at the same tick.
  *
- * Filters out `config_*` keys (owned by `LiveConfig`), strips the `feature_`
- * prefix, camelCases the remainder, and JSON-parses each value. Malformed JSON
- * values are dropped silently — at worst the slice falls back to defaults for
- * that key. Unknown feature IDs are dropped at runtime inside `resolveAll`, so
- * the closing cast to {@link PartialFeatures} is safe.
+ * Maps each known Firebase key (`feature_${snakeCase(id)}`) back to its canonical
+ * FeatureId via {@link FIREBASE_KEY_TO_FEATURE_ID}, then JSON-parses each value.
+ * Unknown keys (`config_*`, stray entries) and malformed JSON are dropped
+ * silently — at worst the slice falls back to defaults for that flag.
  */
 export async function fetchRemoteFlags(): Promise<PartialFeatures> {
   try {
     const rc = getRemoteConfigSingleton();
     await fetchAndActivate(rc);
     const all = getAll(rc);
-    const flags: Record<string, unknown> = {};
+    const flags: PartialFeatures = {};
     for (const [key, value] of Object.entries(all)) {
-      if (!key.startsWith("feature_")) continue;
-      const featureId = camelCase(key.slice("feature_".length));
+      // `lodash.snakeCase` always lowercases — match it on the read side so any
+      // case drift in Firebase admin entries still resolves to the canonical id.
+      const featureId = FIREBASE_KEY_TO_FEATURE_ID[key.toLowerCase()];
+      if (!featureId) continue;
       try {
         flags[featureId] = JSON.parse(value.asString());
       } catch {
@@ -108,7 +118,7 @@ export async function fetchRemoteFlags(): Promise<PartialFeatures> {
     const fetchedAt = Date.now();
     lastFetchedAt = fetchedAt;
     subscribers.forEach(callback => callback({ fetchedAt }));
-    return flags as PartialFeatures;
+    return flags;
   } finally {
     resolveReady?.();
     resolveReady = null;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** New regression test in `apps/ledger-live-desktop/src/firebase/remoteConfig.test.ts` asserts all 4 broken FeatureIds round-trip end-to-end + a case-insensitive Firebase-key fixture. 13/13 pass.
- [x] **Impact of the changes:**
  - **No current user-visible change** — LWD source today doesn't read any of the 4 affected FeatureIds (`llmAccountListUI`, `llmRebornLP`, `web3hub`, `ptxSwapReceiveTRC20WithoutTrx`).
  - **Latent fix** — closes the same structural bug as the LWM hotfix (#18051) before any future `lld*`/`lwd*` flag with digits or ≥2 consecutive uppercase letters lands and silently breaks.

### 📝 Description

Sibling of PR #18051 (LWM). `apps/ledger-live-desktop/src/firebase/remoteConfig.ts:101` had the **exact same lossy `camelCase`-reverse decoder** as the LWM version — copy-pasted in the original wiring PR.

#### Root cause (same as LWM, repeated for context)

`lodash.snakeCase` and `lodash.camelCase` are **not inverses** when the original camelCase identifier contains digits or ≥2 consecutive uppercase letters. The 4 affected FeatureIds are in the shared registry under `shared/feature-flags/src/flags/`:

| FeatureId | snake (Firebase key) | camel (post-reverse) |
|---|---|---|
| `llmAccountListUI` | `llm_account_list_ui` | `llmAccountListUi` ❌ |
| `llmRebornLP` | `llm_reborn_lp` | `llmRebornLp` ❌ |
| `web3hub` | `web_3_hub` | `web3Hub` ❌ |
| `ptxSwapReceiveTRC20WithoutTrx` | `ptx_swap_receive_trc_20_without_trx` | `ptxSwapReceiveTrc20WithoutTrx` ❌ |

For each, `remoteFlags[<correct-FeatureId>]` would be `undefined` at the slice boundary, and `resolveFeature` would fall through to `FEATURE_FLAGS_DEFAULTS[id]` = `{ enabled: false }`.

#### Why LWD didn't surface it yet

Grep across `apps/ledger-live-desktop/src` for any of the 4 FeatureId strings → zero hits. None of those flags is read on the LWD side today, so the bug stayed latent.

#### Fix

Identical to LWM's #18051:

```ts
const FIREBASE_KEY_TO_FEATURE_ID: Record<string, FeatureId> = Object.fromEntries(
  FeatureIdSchema.options.map(id => [`feature_${snakeCase(id)}`, id]),
);

// inside fetchRemoteFlags:
for (const [key, value] of Object.entries(all)) {
  const featureId = FIREBASE_KEY_TO_FEATURE_ID[key.toLowerCase()];
  if (!featureId) continue;
  ...
}
```

`.toLowerCase()` on the lookup defends against any case drift in Firebase admin entries (snake_case from lodash is always lowercase, but admins can manually set whatever case).

### Verification

1. `pnpm --filter ledger-live-desktop test src/firebase/remoteConfig.test.ts` — 13/13 pass.
2. `pnpm nx run ledger-live-desktop:typecheck` — clean.

### ❓ Context

- **JIRA link**: [LIVE-31698](https://ledgerhq.atlassian.net/browse/LIVE-31698) (engineering task, latent fix)
- **Sibling PR (LWM)**: #18051
- **Caused by**: original wiring PR that introduced LWD's `apps/ledger-live-desktop/src/firebase/remoteConfig.ts` (pre-dates LIVE-30964; same code shape copied into the LWM file).

[LIVE-31687]: https://ledgerhq.atlassian.net/browse/LIVE-31687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[LIVE-31698]: https://ledgerhq.atlassian.net/browse/LIVE-31698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ