### PR TITLE
[LWDM] feat(cardano): add lastBlock CoinModule API method

### DIFF
--- a/.changeset/quick-lemons-rest.md
+++ b/.changeset/quick-lemons-rest.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-cardano": minor
+---
+
+Add lastBlock method to Coin Cardano CoinModule API

--- a/libs/coin-modules/coin-cardano/src/api/api-types.ts
+++ b/libs/coin-modules/coin-cardano/src/api/api-types.ts
@@ -92,6 +92,10 @@ export type APINetworkInfo = {
   protocolParams: ProtocolParams;
 };
 
+export type APILatestBlock = {
+  blockHeight: number;
+};
+
 export type APIDelegation = {
   deposit: string;
   stakeHex: string;

--- a/libs/coin-modules/coin-cardano/src/api/getLatestBlock.test.ts
+++ b/libs/coin-modules/coin-cardano/src/api/getLatestBlock.test.ts
@@ -1,0 +1,42 @@
+import network from "@ledgerhq/live-network/network";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { isTestnet } from "../logic";
+import { fetchLatestBlock } from "./getLatestBlock";
+
+jest.mock("@ledgerhq/live-network/network");
+jest.mock("../logic", () => ({ isTestnet: jest.fn() }));
+
+const mockNetwork = jest.mocked(network);
+const mockIsTestnet = jest.mocked(isTestnet);
+
+// isTestnet is mocked, so the concrete currency value is irrelevant to routing.
+const currency = { id: "cardano" } as CryptoCurrency;
+
+describe("fetchLatestBlock", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("GETs the mainnet block/latest endpoint and returns the payload", async () => {
+    mockIsTestnet.mockReturnValue(false);
+    mockNetwork.mockResolvedValue({ data: { blockHeight: 13494170 } } as never);
+
+    const result = await fetchLatestBlock(currency);
+
+    expect(result).toEqual({ blockHeight: 13494170 });
+    const call = mockNetwork.mock.calls[0][0];
+    expect(call.method).toBe("GET");
+    expect(call.url).toContain("cardano.coin.ledger.com");
+    expect(call.url).toMatch(/\/v1\/block\/latest$/);
+  });
+
+  it("routes to the testnet endpoint for a testnet currency", async () => {
+    mockIsTestnet.mockReturnValue(true);
+    mockNetwork.mockResolvedValue({ data: { blockHeight: 1 } } as never);
+
+    await fetchLatestBlock(currency);
+
+    expect(mockIsTestnet).toHaveBeenCalledWith(currency);
+    expect(mockNetwork.mock.calls[0][0].url).toContain("cardanoscan");
+  });
+});

--- a/libs/coin-modules/coin-cardano/src/api/getLatestBlock.ts
+++ b/libs/coin-modules/coin-cardano/src/api/getLatestBlock.ts
@@ -1,0 +1,15 @@
+import network from "@ledgerhq/live-network/network";
+import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { CARDANO_API_ENDPOINT, CARDANO_TESTNET_API_ENDPOINT } from "../constants";
+import { isTestnet } from "../logic";
+import { APILatestBlock } from "./api-types";
+
+export async function fetchLatestBlock(currency: CryptoCurrency): Promise<APILatestBlock> {
+  const res = await network({
+    method: "GET",
+    url: isTestnet(currency)
+      ? `${CARDANO_TESTNET_API_ENDPOINT}/v1/block/latest`
+      : `${CARDANO_API_ENDPOINT}/v1/block/latest`,
+  });
+  return res && (res.data as APILatestBlock);
+}

--- a/libs/coin-modules/coin-cardano/src/api/index.ts
+++ b/libs/coin-modules/coin-cardano/src/api/index.ts
@@ -23,6 +23,7 @@ import type {
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import coinConfig, { type CardanoConfig } from "../config";
 import { broadcast } from "../logic/broadcast";
+import { lastBlock } from "../logic/lastBlock";
 
 export function createApi(config: CardanoConfig, currencyId: string): CoinModuleApi<StringMemo> {
   coinConfig.setCoinConfig(() => ({ ...config, status: { type: "active" } }));
@@ -30,9 +31,7 @@ export function createApi(config: CardanoConfig, currencyId: string): CoinModule
   const currency = getCryptoCurrencyById(currencyId);
 
   return {
-    lastBlock: (): Promise<BlockInfo> => {
-      throw new Error("lastBlock is not supported");
-    },
+    lastBlock: (): Promise<BlockInfo> => lastBlock(currency),
     getBlockInfo: (_height: number): Promise<BlockInfo> => {
       throw new Error("getBlockInfo is not supported");
     },

--- a/libs/coin-modules/coin-cardano/src/api/lastBlock.test.ts
+++ b/libs/coin-modules/coin-cardano/src/api/lastBlock.test.ts
@@ -1,12 +1,34 @@
 import { createApi } from ".";
 import { type CardanoConfig } from "../config";
+import { lastBlock } from "../logic/lastBlock";
+
+jest.mock("../logic/lastBlock");
+const mockLastBlock = jest.mocked(lastBlock);
 
 const config: CardanoConfig = { maxFeesWarning: 0, maxFeesError: 0 };
 
 describe("lastBlock", () => {
-  it("throws an unsupported error", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("delegates to logic lastBlock with the resolved currency", async () => {
+    const blockInfo = { height: 42, hash: "", time: new Date() };
+    mockLastBlock.mockResolvedValue(blockInfo);
+
+    const api = createApi(config, "cardano");
+    const result = await api.lastBlock();
+
+    expect(result).toBe(blockInfo);
+    expect(mockLastBlock).toHaveBeenCalledTimes(1);
+    expect(mockLastBlock.mock.calls[0][0].id).toBe("cardano");
+  });
+
+  it("propagates errors from logic lastBlock", async () => {
+    mockLastBlock.mockRejectedValue(new Error("boom"));
+
     const api = createApi(config, "cardano");
 
-    expect(() => api.lastBlock()).toThrow("lastBlock is not supported");
+    await expect(api.lastBlock()).rejects.toThrow("boom");
   });
 });

--- a/libs/coin-modules/coin-cardano/src/logic/lastBlock.integ.test.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/lastBlock.integ.test.ts
@@ -1,0 +1,16 @@
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { lastBlock } from "./lastBlock";
+
+describe("lastBlock (integration)", () => {
+  it("fetches the current tip height from the Cardano API", async () => {
+    const currency = getCryptoCurrencyById("cardano");
+
+    const result = await lastBlock(currency);
+
+    expect(result.height).toBeGreaterThan(0);
+    // The Ledger Cardano API exposes only the tip height, so hash is intentionally empty
+    // and time is approximated as ~now. Asserted explicitly to document the limitation.
+    expect(result.hash).toBe("");
+    expect(result.time).toBeInstanceOf(Date);
+  });
+});

--- a/libs/coin-modules/coin-cardano/src/logic/lastBlock.test.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/lastBlock.test.ts
@@ -1,0 +1,62 @@
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { fetchLatestBlock } from "../api/getLatestBlock";
+import { lastBlock } from "./lastBlock";
+
+jest.mock("../api/getLatestBlock");
+const mockFetchLatestBlock = jest.mocked(fetchLatestBlock);
+
+const currency = getCryptoCurrencyById("cardano");
+
+describe("lastBlock", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns the tip height reported by the API", async () => {
+    mockFetchLatestBlock.mockResolvedValue({ blockHeight: 13494170 });
+
+    const result = await lastBlock(currency);
+
+    expect(result.height).toBe(13494170);
+    expect(mockFetchLatestBlock).toHaveBeenCalledWith(currency);
+  });
+
+  it("returns an empty hash (not exposed by the Cardano API)", async () => {
+    mockFetchLatestBlock.mockResolvedValue({ blockHeight: 1 });
+
+    const result = await lastBlock(currency);
+
+    expect(result.hash).toBe("");
+  });
+
+  it("approximates the tip timestamp as the current time", async () => {
+    mockFetchLatestBlock.mockResolvedValue({ blockHeight: 1 });
+
+    const before = Date.now();
+    const result = await lastBlock(currency);
+    const after = Date.now();
+
+    expect(result.time).toBeInstanceOf(Date);
+    expect(result.time.getTime()).toBeGreaterThanOrEqual(before);
+    expect(result.time.getTime()).toBeLessThanOrEqual(after);
+  });
+
+  it("propagates fetch errors", async () => {
+    mockFetchLatestBlock.mockRejectedValue(new Error("network down"));
+
+    await expect(lastBlock(currency)).rejects.toThrow("network down");
+  });
+
+  it.each([
+    ["undefined", undefined],
+    ["zero", 0],
+    ["negative", -1],
+    ["NaN", NaN],
+    ["non-integer", 12.5],
+    ["non-number", "1000"],
+  ])("throws on an invalid block height (%s)", async (_label, blockHeight) => {
+    mockFetchLatestBlock.mockResolvedValue({ blockHeight } as never);
+
+    await expect(lastBlock(currency)).rejects.toThrow("invalid block height");
+  });
+});

--- a/libs/coin-modules/coin-cardano/src/logic/lastBlock.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/lastBlock.ts
@@ -1,0 +1,26 @@
+import type { BlockInfo } from "@ledgerhq/coin-module-framework/api/index";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { fetchLatestBlock } from "../api/getLatestBlock";
+
+export async function lastBlock(currency: CryptoCurrency): Promise<BlockInfo> {
+  const { blockHeight } = await fetchLatestBlock(currency);
+
+  // The endpoint is untyped at runtime: guard against a missing/malformed height so a
+  // bad payload surfaces a clear error instead of leaking undefined/NaN/negative into
+  // BlockInfo.height (which the sync engine persists as the account block height).
+  if (!Number.isInteger(blockHeight) || blockHeight <= 0) {
+    throw new Error(`Cardano lastBlock: invalid block height from API: ${blockHeight}`);
+  }
+
+  return {
+    height: blockHeight,
+    // The Ledger Cardano API's /v1/block/latest only returns the tip height, not its
+    // hash. Left empty until a block-by-height endpoint exposes it (matches coin-canton,
+    // the other height-only backend).
+    hash: "",
+    // Cardano targets ~20s between blocks, so the tip was produced within the last block
+    // interval; we approximate its timestamp as "now" (matches coin-canton's lastBlock).
+    // Only valid for the tip — getBlock/getBlockInfo throw rather than fake historic times.
+    time: new Date(),
+  };
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Hermetic unit tests (mapping + error/boundary cases), an API delegation test, and a live-network integration test.
- [ ] **Impact of the changes:** Cardano CoinModule API only. Cardano is not yet wired into the generic coin-framework bridge, so there is no impact on the live sync/send flows. QA focus: none on current flows.
  - ...

### 📝 Description

Implements `lastBlock()` for the Cardano CoinModule ("Alpaca") API. It fetches the chain tip via the Ledger Cardano API `GET /v1/block/latest` (`{ blockHeight }`) and maps it to `BlockInfo`.

Backend limitation: `/v1/block/latest` exposes **only the tip height** — no hash, no timestamp, and there is no block-by-height endpoint. So:

- `height` ← `blockHeight` (guarded: a missing/`NaN`/non-positive value throws instead of leaking into `BlockInfo.height`).
- `hash` ← `""` (not exposed by the API; same approach as coin-canton, the other height-only backend).
- `time` ← `new Date()` — the tip is produced within one ~20s block interval, so it is approximated as "now". Valid only for the tip; `getBlock` / `getBlockInfo` remain `not supported` rather than fabricate historic block data.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-18628](https://ledgerhq.atlassian.net/browse/LIVE-18628)
- **ADR link (if any)**:


[LIVE-18628]: https://ledgerhq.atlassian.net/browse/LIVE-18628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ