### PR TITLE
[LWD] fix(desktop): inject dapp ethereum provider via webFrame to bypass CSP

### DIFF
--- a/.changeset/spicy-dapps-inject.md
+++ b/.changeset/spicy-dapps-inject.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix dapp integration breaking when a Live App's Content-Security-Policy blocks inline script injection, by evaluating the Ethereum provider in the page main world via webFrame.executeJavaScript instead of an inline <script> tag

--- a/apps/ledger-live-desktop/src/webviewPreloader/dappPreloader.ts
+++ b/apps/ledger-live-desktop/src/webviewPreloader/dappPreloader.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from "electron";
+import { contextBridge, ipcRenderer, webFrame } from "electron";
 import ethereumProvider from "@ledgerhq/ethereum-provider/lib/ethereum-provider.umd.json";
 
 contextBridge.exposeInMainWorld("ElectronWebview", {
@@ -6,10 +6,10 @@ contextBridge.exposeInMainWorld("ElectronWebview", {
 });
 
 // `${ethereumProvider.code}` is interpolated once here at preload eval time,
-// producing a plain string that we then assign to `script.textContent`. Any
-// backticks or `${...}` sequences that exist inside the bundled UMD source
+// producing a plain string that we then hand to `webFrame.executeJavaScript`.
+// Any backticks or `${...}` sequences that exist inside the bundled UMD source
 // are therefore inert at this point — they only get re-tokenized as JS when
-// the browser parses the injected <script>, where they're valid template
+// the page's main world evaluates the string, where they're valid template
 // literals again. Do not refactor this into a concatenation that would let
 // `${...}` be re-evaluated by the outer template.
 const ethereumProviderInjection = `
@@ -22,23 +22,10 @@ if (document.readyState === "complete") {
 }
 `;
 
-const injectEthereumProvider = () => {
-  const parent = document.head || document.documentElement;
-
-  if (!parent) {
-    document.addEventListener("DOMContentLoaded", injectEthereumProvider, { once: true });
-    return;
-  }
-
-  const script = document.createElement("script");
-  script.textContent = ethereumProviderInjection;
-
-  // Inline <script> execution is synchronous on insertion into a parented
-  // document, so by the time `appendChild` returns the provider has already
-  // attached itself to the page's `window` and registered its load listener.
-  // We can safely detach the node to keep the DOM clean.
-  parent.appendChild(script);
-  script.remove();
-};
-
-injectEthereumProvider();
+// We evaluate the provider in the page's main world via `webFrame.executeJavaScript`
+// rather than appending an inline <script> to the DOM. Embedder-evaluated code runs
+// in the main world (so `window.ethereum` is visible to the dapp) but is NOT governed
+// by the page's Content-Security-Policy, whereas an injected inline <script> is blocked
+// by a restrictive `script-src`. The preload runs before the page's own scripts, so the
+// provider is attached in time; no DOM node or readiness check is required.
+webFrame.executeJavaScript(ethereumProviderInjection);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Tested manually for now
- [x] **Impact of the changes:**
  - desktop dApp injected provider

### 📝 Description

Live Apps that ship a restrictive Content-Security-Policy (script-src without 'unsafe-inline') blocked the inline <script> we injected into the page, breaking the dapp integration.

Evaluate the provider in the page main world via
webFrame.executeJavaScript instead. Embedder-evaluated code runs in the main world (so window.ethereum stays visible to the dapp) but is not governed by the page CSP, so a restrictive script-src no longer blocks it. This also removes the DOM node and readiness-check plumbing, which is no longer needed.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-31610
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[PROD-12395]: https://ledgerhq.atlassian.net/browse/PROD-12395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ