### PR TITLE
[LWDM] feat(cardano): add craftTransaction CoinModule API

### DIFF
--- a/.changeset/four-carrots-sip.md
+++ b/.changeset/four-carrots-sip.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-cardano": minor
+---
+
+Add craftTransaction method to Coin Cardano CoinModule API

--- a/libs/coin-modules/coin-cardano/src/api/craftTransaction.test.ts
+++ b/libs/coin-modules/coin-cardano/src/api/craftTransaction.test.ts
@@ -1,15 +1,51 @@
+import type {
+  FeeEstimation,
+  StringMemo,
+  TransactionIntent,
+} from "@ledgerhq/coin-module-framework/api/index";
 import { createApi } from ".";
 import { type CardanoConfig } from "../config";
-import type { StringMemo, TransactionIntent } from "@ledgerhq/coin-module-framework/api/index";
+import { craftTransaction } from "../logic/craftTransaction";
+
+jest.mock("../logic/craftTransaction");
+const mockCraftTransaction = jest.mocked(craftTransaction);
 
 const config: CardanoConfig = { maxFeesWarning: 0, maxFeesError: 0 };
 
+const intent = {
+  intentType: "transaction",
+  type: "send",
+  sender: "addr1sender",
+  recipient: "addr1recipient",
+  amount: 1_000_000n,
+  asset: { type: "native" },
+} as TransactionIntent<StringMemo>;
+
 describe("craftTransaction", () => {
-  it("throws an unsupported error", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("delegates to logic craftTransaction with the resolved currency, intent and custom fees", async () => {
+    const crafted = { transaction: "deadbeef", details: { fees: "170000" } };
+    mockCraftTransaction.mockResolvedValue(crafted);
+    const customFees: FeeEstimation = { value: 200_000n };
+
+    const api = createApi(config, "cardano");
+    const result = await api.craftTransaction(intent, customFees);
+
+    expect(result).toBe(crafted);
+    expect(mockCraftTransaction).toHaveBeenCalledTimes(1);
+    expect(mockCraftTransaction.mock.calls[0][0].id).toBe("cardano");
+    expect(mockCraftTransaction.mock.calls[0][1]).toBe(intent);
+    expect(mockCraftTransaction.mock.calls[0][2]).toBe(customFees);
+  });
+
+  it("propagates errors from logic craftTransaction", async () => {
+    mockCraftTransaction.mockRejectedValue(new Error("boom"));
+
     const api = createApi(config, "cardano");
 
-    expect(() => api.craftTransaction({} as TransactionIntent<StringMemo>)).toThrow(
-      "craftTransaction is not supported",
-    );
+    await expect(api.craftTransaction(intent)).rejects.toThrow("boom");
   });
 });

--- a/libs/coin-modules/coin-cardano/src/api/index.ts
+++ b/libs/coin-modules/coin-cardano/src/api/index.ts
@@ -24,6 +24,7 @@ import { rejectBalanceOptions } from "@ledgerhq/coin-module-framework/api/getBal
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import coinConfig, { type CardanoConfig } from "../config";
 import { broadcast } from "../logic/broadcast";
+import { craftTransaction } from "../logic/craftTransaction";
 import { getBalance } from "../logic/getBalance";
 import { getValidators } from "../logic/getValidators";
 import { lastBlock } from "../logic/lastBlock";
@@ -54,11 +55,9 @@ export function createApi(config: CardanoConfig, currencyId: string): CoinModule
       throw new Error("getRewards is not supported");
     },
     craftTransaction: (
-      _transactionIntent: TransactionIntent<StringMemo>,
-      _customFees?: FeeEstimation,
-    ): Promise<CraftedTransaction> => {
-      throw new Error("craftTransaction is not supported");
-    },
+      transactionIntent: TransactionIntent<StringMemo>,
+      customFees?: FeeEstimation,
+    ): Promise<CraftedTransaction> => craftTransaction(currency, transactionIntent, customFees),
     craftRawTransaction: (
       _transaction: string,
       _sender: string,

--- a/libs/coin-modules/coin-cardano/src/logic.ts
+++ b/libs/coin-modules/coin-cardano/src/logic.ts
@@ -202,6 +202,51 @@ export function mergeTokens(tokens: Array<TyphonTypes.Token>): Array<TyphonTypes
   }));
 }
 
+export type DerivedUtxo = {
+  txId: string;
+  index: number;
+  amount: BigNumber;
+  tokens: TyphonTypes.Token[];
+};
+
+/**
+ * Derive the unspent outputs held by a single payment credential from its transaction history:
+ * outputs paying that credential, minus those later consumed as inputs. Retains the outpoint
+ * (txId + index) needed to reference a UTXO as a transaction input — balance callers that only
+ * need the amounts can ignore it. Shared by getBalance and craftTransaction so the derivation
+ * can't drift between them.
+ *
+ * Per-address only — a Cardano account spreads funds across many payment credentials (derived
+ * from the xpub), but the single-address CoinModule path covers just the passed credential.
+ */
+export function deriveUtxos(transactions: APITransaction[], paymentKey: string): DerivedUtxo[] {
+  const spent = new Set<string>();
+  for (const tx of transactions) {
+    for (const input of tx.inputs) {
+      if (input.paymentKey === paymentKey) spent.add(`${input.txId}#${input.index}`);
+    }
+  }
+
+  const utxos: DerivedUtxo[] = [];
+  for (const tx of transactions) {
+    tx.outputs.forEach((output, index) => {
+      if (output.paymentKey !== paymentKey) return;
+      if (spent.has(`${tx.hash}#${index}`)) return;
+      utxos.push({
+        txId: tx.hash,
+        index,
+        amount: new BigNumber(output.value),
+        tokens: output.tokens.map(t => ({
+          policyId: t.policyId,
+          assetName: t.assetName,
+          amount: new BigNumber(t.value),
+        })),
+      });
+    });
+  }
+  return utxos;
+}
+
 /**
  * @param { Array<TyphonTypes.Token> } b
  * @param { Array<TyphonTypes.Token> } a

--- a/libs/coin-modules/coin-cardano/src/logic/craftTransaction.test.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/craftTransaction.test.ts
@@ -1,0 +1,411 @@
+import type {
+  StakingTransactionIntent,
+  StringMemo,
+  TransactionIntent,
+} from "@ledgerhq/coin-module-framework/api/index";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { types as TyphonTypes } from "@stricahq/typhonjs";
+import BigNumber from "bignumber.js";
+import { APITransaction } from "../api/api-types";
+import { getAllTransactionsByKeys } from "../api/fetchTransactions";
+import { getDelegationInfo } from "../api/getDelegationInfo";
+import { fetchNetworkInfo } from "../api/getNetworkInfo";
+import { getProtocolParamsFixture } from "../fixtures/protocolParams";
+import { extractPaymentKeyFromAddress } from "../utils";
+import { buildUnsignedTransaction, craftTransaction } from "./craftTransaction";
+
+jest.mock("../api/fetchTransactions");
+jest.mock("../api/getDelegationInfo");
+jest.mock("../api/getNetworkInfo");
+
+const mockFetchTxs = jest.mocked(getAllTransactionsByKeys);
+const mockGetDelegation = jest.mocked(getDelegationInfo);
+const mockFetchNetworkInfo = jest.mocked(fetchNetworkInfo);
+
+// getAllTransactionsByKeys returns the paginated result shape; craftTransaction only reads the
+// transaction list, so wrap a plain list with a dummy blockHeight in the tests.
+const paged = (transactions: APITransaction[]) => ({ transactions, blockHeight: 1 });
+
+const currency = getCryptoCurrencyById("cardano");
+// Real mainnet base addresses; Typhon parses them for real.
+const SENDER =
+  "addr1q8mgw8geggkl2hs0m6rq3pgt69uxttpqcgu6euxje5tt6plxjtjrnskhhtt03g6l3sr98p9t8mtlajr26vmwjzep77pqxn8cms";
+const RECIPIENT =
+  "addr1qxqm3nxwzf70ke9jqa2zrtrevjznpv6yykptxnv34perjc8a7zgxmpv5pgk4hhhe0m9kfnlsf5pt7d2ahkxaul2zygrq3nura9";
+const PAYMENT_KEY = extractPaymentKeyFromAddress(SENDER);
+const POLICY_ID = "a".repeat(56);
+const POOL_HASH = "b".repeat(56);
+
+function makeTx(partial: Partial<APITransaction>): APITransaction {
+  return {
+    fees: "0",
+    hash: "tx-hash",
+    timestamp: "1700000000",
+    blockHeight: 1,
+    inputs: [],
+    outputs: [],
+    certificate: { stakeRegistrations: [], stakeDeRegistrations: [], stakeDelegations: [] },
+    ...partial,
+  };
+}
+
+function output(value: string, tokens: APITransaction["outputs"][number]["tokens"] = []) {
+  return { address: SENDER, value, paymentKey: PAYMENT_KEY, tokens };
+}
+
+function sendIntent(over: Partial<TransactionIntent> = {}): TransactionIntent<StringMemo> {
+  return {
+    intentType: "transaction",
+    type: "send",
+    sender: SENDER,
+    recipient: RECIPIENT,
+    amount: 2_000_000n,
+    asset: { type: "native" },
+    ...over,
+  } as TransactionIntent<StringMemo>;
+}
+
+function stakeIntent(
+  over: Partial<StakingTransactionIntent> = {},
+): StakingTransactionIntent<StringMemo> {
+  return {
+    intentType: "staking",
+    type: "delegate",
+    sender: SENDER,
+    recipient: SENDER,
+    amount: 0n,
+    asset: { type: "native" },
+    mode: "delegate",
+    valAddress: POOL_HASH,
+    ...over,
+  } as StakingTransactionIntent<StringMemo>;
+}
+
+const registeredDelegation = (over: Record<string, unknown> = {}) => ({
+  status: true,
+  deposit: "2000000",
+  poolId: "pool1old",
+  dRepHex: undefined,
+  ticker: undefined,
+  name: undefined,
+  rewards: new BigNumber(0),
+  ...over,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockFetchNetworkInfo.mockResolvedValue({ protocolParams: getProtocolParamsFixture() });
+  mockGetDelegation.mockResolvedValue(undefined);
+  mockFetchTxs.mockResolvedValue(paged([makeTx({ hash: "a", outputs: [output("10000000")] })]));
+});
+
+describe("craftTransaction", () => {
+  it("serializes the unsigned tx to a hex payload and reports the resolved fee", async () => {
+    const { transaction, details } = await craftTransaction(currency, sendIntent());
+
+    expect(transaction).toMatch(/^[0-9a-f]+$/);
+    expect(new BigNumber(details?.fees as string).gt(0)).toBe(true);
+  });
+});
+
+describe("buildUnsignedTransaction — native ADA", () => {
+  it("adds a recipient output and lets Typhon return change to the sender", async () => {
+    const tx = await buildUnsignedTransaction(currency, sendIntent());
+
+    expect(mockFetchTxs).toHaveBeenCalledWith([PAYMENT_KEY], 0, currency);
+    expect(tx.getInputs()).toHaveLength(1);
+    expect(tx.getOutputs()).toHaveLength(2); // recipient + change
+    expect(tx.getFee().gt(0)).toBe(true);
+  });
+
+  it("sends the whole balance to the recipient (no change output) when useAllAmount is set", async () => {
+    const tx = await buildUnsignedTransaction(currency, sendIntent({ useAllAmount: true }));
+
+    expect(tx.getOutputs()).toHaveLength(1); // recipient is the sole sink
+  });
+
+  it("sweeps every UTXO to the recipient on send-all (not just the first selected)", async () => {
+    // Typhon does minimal coin selection over the available inputs; a sweep must override that
+    // and spend the whole UTXO set, or the recipient silently receives less than the balance.
+    mockFetchTxs.mockResolvedValue(
+      paged([
+        makeTx({ hash: "a", outputs: [output("10000000")] }),
+        makeTx({ hash: "b", outputs: [output("5000000")] }),
+        makeTx({ hash: "c", outputs: [output("7000000")] }),
+      ]),
+    );
+
+    const tx = await buildUnsignedTransaction(currency, sendIntent({ useAllAmount: true }));
+
+    expect(tx.getInputs()).toHaveLength(3); // every UTXO consumed
+    const recipientOut = tx.getOutputs()[0];
+    // recipient receives the full 22 ADA balance minus the fee
+    expect(recipientOut.amount.toFixed()).toBe(
+      new BigNumber(22_000_000).minus(tx.getFee()).toFixed(),
+    );
+  });
+
+  it("keeps the sender's tokens on a send-all instead of transferring them to the recipient", async () => {
+    mockFetchTxs.mockResolvedValue(
+      paged([
+        makeTx({
+          hash: "a",
+          outputs: [output("10000000", [{ policyId: POLICY_ID, assetName: "abcd", value: "100" }])],
+        }),
+      ]),
+    );
+
+    const tx = await buildUnsignedTransaction(currency, sendIntent({ useAllAmount: true }));
+
+    const tokenOutputs = tx.getOutputs().filter(o => o.tokens.length > 0);
+    expect(tokenOutputs).toHaveLength(1);
+    // The token stays with the sender; the recipient only receives ADA.
+    expect((tokenOutputs[0].address as TyphonTypes.ShelleyAddress).getBech32()).toBe(SENDER);
+    const recipientOutput = tx
+      .getOutputs()
+      .find(o => (o.address as TyphonTypes.ShelleyAddress).getBech32() === RECIPIENT);
+    expect(recipientOutput?.tokens).toEqual([]);
+  });
+
+  it("rejects a non-positive amount", async () => {
+    await expect(buildUnsignedTransaction(currency, sendIntent({ amount: 0n }))).rejects.toThrow(
+      "Transaction amount must be positive",
+    );
+  });
+
+  it("rejects an amount below the per-output min-ADA floor", async () => {
+    await expect(buildUnsignedTransaction(currency, sendIntent({ amount: 1n }))).rejects.toThrow(
+      "Transaction amount is below the minimum required for an output",
+    );
+  });
+
+  it("rejects a sender address with no payment credential without hitting the network", async () => {
+    await expect(
+      buildUnsignedTransaction(currency, sendIntent({ sender: "not-an-address" })),
+    ).rejects.toThrow("Unsupported sender address");
+    expect(mockFetchTxs).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the sender has no spendable UTXOs", async () => {
+    mockFetchTxs.mockResolvedValue(paged([]));
+
+    await expect(buildUnsignedTransaction(currency, sendIntent())).rejects.toThrow(
+      "No spendable UTXOs for sender address",
+    );
+  });
+});
+
+describe("buildUnsignedTransaction — token", () => {
+  it("builds a multiasset output carrying the requested token to the recipient", async () => {
+    mockFetchTxs.mockResolvedValue(
+      paged([
+        makeTx({
+          hash: "a",
+          outputs: [output("10000000", [{ policyId: POLICY_ID, assetName: "abcd", value: "100" }])],
+        }),
+      ]),
+    );
+
+    const tx = await buildUnsignedTransaction(
+      currency,
+      // Canonical Cardano asset id: policyId (56 hex) concatenated with the asset name, no
+      // separator — the same identifier getBalance/listOperations emit.
+      sendIntent({ amount: 100n, asset: { type: "token", assetReference: `${POLICY_ID}abcd` } }),
+    );
+
+    const recipientOutput = tx.getOutputs()[0];
+    expect(recipientOutput.tokens).toEqual([
+      { policyId: POLICY_ID, assetName: "abcd", amount: new BigNumber(100) },
+    ]);
+  });
+
+  it("sends the full held token balance on useAllAmount (summed across UTXOs)", async () => {
+    mockFetchTxs.mockResolvedValue(
+      paged([
+        makeTx({
+          hash: "a",
+          outputs: [output("10000000", [{ policyId: POLICY_ID, assetName: "abcd", value: "70" }])],
+        }),
+        makeTx({
+          hash: "b",
+          outputs: [output("10000000", [{ policyId: POLICY_ID, assetName: "abcd", value: "30" }])],
+        }),
+      ]),
+    );
+
+    const tx = await buildUnsignedTransaction(
+      currency,
+      sendIntent({
+        useAllAmount: true,
+        amount: 0n,
+        asset: { type: "token", assetReference: `${POLICY_ID}abcd` },
+      }),
+    );
+
+    const recipientOutput = tx.getOutputs()[0];
+    expect(recipientOutput.tokens).toEqual([
+      { policyId: POLICY_ID, assetName: "abcd", amount: new BigNumber(100) }, // 70 + 30
+    ]);
+  });
+
+  it("rejects a token send-all when the sender holds none of that token", async () => {
+    mockFetchTxs.mockResolvedValue(paged([makeTx({ hash: "a", outputs: [output("10000000")] })]));
+
+    await expect(
+      buildUnsignedTransaction(
+        currency,
+        sendIntent({
+          useAllAmount: true,
+          amount: 0n,
+          asset: { type: "token", assetReference: `${POLICY_ID}abcd` },
+        }),
+      ),
+    ).rejects.toThrow("Sender holds none of the requested token");
+  });
+
+  it("accepts a reference with an empty asset name (policy id only)", async () => {
+    mockFetchTxs.mockResolvedValue(
+      paged([
+        makeTx({
+          hash: "a",
+          outputs: [output("10000000", [{ policyId: POLICY_ID, assetName: "", value: "100" }])],
+        }),
+      ]),
+    );
+
+    const tx = await buildUnsignedTransaction(
+      currency,
+      sendIntent({ amount: 100n, asset: { type: "token", assetReference: POLICY_ID } }),
+    );
+
+    expect(tx.getOutputs()[0].tokens).toEqual([
+      { policyId: POLICY_ID, assetName: "", amount: new BigNumber(100) },
+    ]);
+  });
+
+  it.each([
+    ["missing reference", { type: "token" }],
+    ["too short to hold a policy id", { type: "token", assetReference: "abcd" }],
+    ["non-hex policy id", { type: "token", assetReference: `${"z".repeat(56)}abcd` }],
+    ["non-hex asset name", { type: "token", assetReference: `${POLICY_ID}zz` }],
+    ["odd-length asset name", { type: "token", assetReference: `${POLICY_ID}abc` }],
+    [
+      "asset name over 32 bytes",
+      { type: "token", assetReference: `${POLICY_ID}${"a".repeat(66)}` },
+    ],
+  ])("rejects an invalid token asset reference (%s)", async (_label, asset) => {
+    await expect(
+      buildUnsignedTransaction(currency, sendIntent({ amount: 100n, asset })),
+    ).rejects.toThrow("Invalid token asset reference");
+  });
+});
+
+describe("buildUnsignedTransaction — staking", () => {
+  it("registers and delegates when the stake key is not yet registered", async () => {
+    const tx = await buildUnsignedTransaction(currency, stakeIntent());
+
+    const certs = tx.getCertificates();
+    expect(certs.map(c => c.type)).toEqual([
+      TyphonTypes.CertificateType.STAKE_KEY_REGISTRATION,
+      TyphonTypes.CertificateType.STAKE_DELEGATION,
+    ]);
+  });
+
+  it("only delegates when the stake key is already registered", async () => {
+    mockGetDelegation.mockResolvedValue(registeredDelegation());
+
+    const tx = await buildUnsignedTransaction(currency, stakeIntent());
+
+    expect(tx.getCertificates().map(c => c.type)).toEqual([
+      TyphonTypes.CertificateType.STAKE_DELEGATION,
+    ]);
+  });
+
+  it("de-registers the stake key on undelegate", async () => {
+    mockGetDelegation.mockResolvedValue(registeredDelegation());
+
+    const tx = await buildUnsignedTransaction(
+      currency,
+      stakeIntent({ type: "undelegate", mode: "undelegate" }),
+    );
+
+    expect(tx.getCertificates().map(c => c.type)).toEqual([
+      TyphonTypes.CertificateType.STAKE_KEY_DE_REGISTRATION,
+    ]);
+  });
+
+  it("rejects undelegate when the stake key is not registered", async () => {
+    await expect(
+      buildUnsignedTransaction(currency, stakeIntent({ type: "undelegate", mode: "undelegate" })),
+    ).rejects.toThrow("Stake key is not registered");
+  });
+
+  it("rejects an unsupported staking mode", async () => {
+    await expect(
+      buildUnsignedTransaction(
+        currency,
+        stakeIntent({ type: "redelegate", mode: "redelegate" } as never),
+      ),
+    ).rejects.toThrow("Unsupported staking mode");
+  });
+
+  it("rejects delegation without a pool id", async () => {
+    await expect(
+      buildUnsignedTransaction(currency, stakeIntent({ valAddress: "" })),
+    ).rejects.toThrow("Missing pool id for delegation");
+  });
+});
+
+describe("buildUnsignedTransaction — account obligations (Conway)", () => {
+  it("sweeps claimable rewards via a withdrawal when delegated to a dRep", async () => {
+    mockGetDelegation.mockResolvedValue(
+      registeredDelegation({ dRepHex: "drep1abc", rewards: new BigNumber("1500000") }),
+    );
+
+    const tx = await buildUnsignedTransaction(currency, sendIntent());
+
+    expect(tx.getWithdrawals()).toHaveLength(1);
+    expect(tx.getWithdrawals()[0].amount).toEqual(new BigNumber("1500000"));
+  });
+
+  it("adds an ABSTAIN vote certificate when rewards exist but no dRep is set", async () => {
+    mockGetDelegation.mockResolvedValue(
+      registeredDelegation({ dRepHex: undefined, rewards: new BigNumber("1500000") }),
+    );
+
+    const tx = await buildUnsignedTransaction(currency, sendIntent());
+
+    expect(tx.getWithdrawals()).toHaveLength(0);
+    expect(tx.getCertificates().map(c => c.type)).toEqual([
+      TyphonTypes.CertificateType.VOTE_DELEGATION,
+    ]);
+  });
+});
+
+describe("buildUnsignedTransaction — custom fees", () => {
+  it("overrides the estimated fee and absorbs the difference into the change output", async () => {
+    const estimated = await buildUnsignedTransaction(currency, sendIntent());
+    const estimatedChange = estimated.getOutputs()[1].amount;
+    const customFee = estimated.getFee().plus(50_000);
+
+    const tx = await buildUnsignedTransaction(currency, sendIntent(), {
+      value: BigInt(customFee.toFixed()),
+    });
+
+    expect(tx.getFee()).toEqual(customFee);
+    // The extra 50,000 lovelace of fee comes straight out of the change output.
+    expect(tx.getOutputs()[1].amount).toEqual(estimatedChange.minus(50_000));
+  });
+
+  it("rejects a custom fee below the protocol minimum (Typhon's estimate)", async () => {
+    await expect(buildUnsignedTransaction(currency, sendIntent(), { value: 1n })).rejects.toThrow(
+      "Custom fee is below the minimum required fee",
+    );
+  });
+
+  it("rejects a custom fee that would push the change below the min-UTXO amount", async () => {
+    await expect(
+      buildUnsignedTransaction(currency, sendIntent(), { value: 9_999_000_000n }),
+    ).rejects.toThrow("Custom fee too high");
+  });
+});

--- a/libs/coin-modules/coin-cardano/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/craftTransaction.ts
@@ -1,0 +1,406 @@
+import type {
+  AssetInfo,
+  CraftedTransaction,
+  FeeEstimation,
+  StakingTransactionIntent,
+  StringMemo,
+  TransactionIntent,
+} from "@ledgerhq/coin-module-framework/api/index";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import {
+  Transaction as TyphonTransaction,
+  address as TyphonAddress,
+  types as TyphonTypes,
+  utils as TyphonUtils,
+} from "@stricahq/typhonjs";
+import BigNumber from "bignumber.js";
+import { getAllTransactionsByKeys } from "../api/fetchTransactions";
+import { getDelegationInfo } from "../api/getDelegationInfo";
+import { fetchNetworkInfo } from "../api/getNetworkInfo";
+import { CARDANO_MAX_SUPPLY, MEMO_LABEL } from "../constants";
+import { type DerivedUtxo, deriveUtxos, getTTL, isTestnet, mergeTokens } from "../logic";
+import { CardanoDelegation, ProtocolParams } from "../types";
+import {
+  EMPTY_CREDENTIAL_KEY,
+  extractPaymentKeyFromAddress,
+  extractStakeKeyFromAddress,
+} from "../utils";
+
+function toTyphonProtocolParams(pp: ProtocolParams): TyphonTypes.ProtocolParams {
+  return {
+    minFeeA: new BigNumber(pp.minFeeA),
+    minFeeB: new BigNumber(pp.minFeeB),
+    stakeKeyDeposit: new BigNumber(pp.stakeKeyDeposit),
+    lovelacePerUtxoWord: new BigNumber(pp.lovelacePerUtxoWord),
+    collateralPercent: new BigNumber(pp.collateralPercent),
+    priceSteps: new BigNumber(pp.priceSteps),
+    priceMem: new BigNumber(pp.priceMem),
+    languageView: pp.languageView,
+    maxTxSize: Number(pp.maxTxSize),
+    maxValueSize: Number(pp.maxValueSize),
+    utxoCostPerByte: new BigNumber(pp.utxoCostPerByte),
+    minFeeRefScriptCostPerByte: new BigNumber(pp.minFeeRefScriptCostPerByte),
+  };
+}
+
+/**
+ * The CoinModule API receives only the sender address (no xpub), so all inputs share the
+ * sender's payment credential. Using the sender address as each input's address yields the
+ * correct payment credential for Typhon's required-witness tracking; the BIP path (signing
+ * metadata) is intentionally absent and supplied later by the device-signing step.
+ */
+function toTyphonInput(
+  utxo: DerivedUtxo,
+  senderAddress: TyphonTypes.ShelleyAddress,
+): TyphonTypes.Input {
+  return {
+    txId: utxo.txId,
+    index: utxo.index,
+    amount: utxo.amount,
+    tokens: utxo.tokens,
+    address: senderAddress,
+  };
+}
+
+/**
+ * Parse a token asset reference into its parts. Matches the canonical Cardano asset id
+ * (getTokenAssetId in buildSubAccounts, also emitted by getBalance): the 28-byte (56 hex char)
+ * policy id concatenated with the asset name, no separator. The asset name is 0–32 bytes of hex
+ * (empty is valid). Rejects malformed references up front rather than letting Typhon fail
+ * opaquely or craft the wrong asset.
+ */
+function parseTokenAssetReference(asset: AssetInfo): { policyId: string; assetName: string } {
+  const reference = (asset as { assetReference?: string }).assetReference ?? "";
+  const policyId = reference.slice(0, 56);
+  const assetName = reference.slice(56);
+  if (
+    !/^[0-9a-fA-F]{56}$/.test(policyId) ||
+    !/^[0-9a-fA-F]*$/.test(assetName) ||
+    assetName.length % 2 !== 0 ||
+    assetName.length > 64
+  ) {
+    throw new Error("Invalid token asset reference");
+  }
+  return { policyId, assetName };
+}
+
+function stakeHashCredential(stakeKey: string): TyphonTypes.HashCredential {
+  return {
+    hash: Buffer.from(stakeKey, "hex"),
+    type: TyphonTypes.HashType.ADDRESS,
+  };
+}
+
+/**
+ * Account-level obligations that the legacy builder attaches to every transaction:
+ * sweep claimable rewards (only withdrawable once delegated to a dRep — Conway rule) and,
+ * when rewards exist but no dRep is set, add the ABSTAIN vote-delegation certificate the
+ * Conway era requires before such a transaction is valid.
+ */
+function addAccountObligations(
+  typhonTx: TyphonTransaction,
+  currency: CryptoCurrency,
+  stakeKey: string,
+  delegation: CardanoDelegation,
+): void {
+  const rewards = delegation.rewards ?? new BigNumber(0);
+  if (rewards.lte(0)) return;
+
+  const stakeCredential = stakeHashCredential(stakeKey);
+  const networkId = isTestnet(currency)
+    ? TyphonTypes.NetworkId.TESTNET
+    : TyphonTypes.NetworkId.MAINNET;
+
+  if (delegation.dRepHex) {
+    typhonTx.addWithdrawal({
+      rewardAccount: new TyphonAddress.RewardAddress(networkId, stakeCredential),
+      amount: rewards,
+    });
+  } else {
+    const abstainDRep: TyphonTypes.DRep = { type: TyphonTypes.DRepType.ABSTAIN, key: undefined };
+    typhonTx.addCertificate({
+      type: TyphonTypes.CertificateType.VOTE_DELEGATION,
+      cert: { stakeCredential, dRep: abstainDRep },
+    });
+  }
+}
+
+function addStakingCertificates(
+  typhonTx: TyphonTransaction,
+  intent: StakingTransactionIntent<StringMemo>,
+  protocolParams: ProtocolParams,
+  stakeKey: string,
+  delegation: CardanoDelegation | undefined,
+): void {
+  const stakeCredential = stakeHashCredential(stakeKey);
+
+  if (intent.mode === "delegate") {
+    if (!intent.valAddress) throw new Error("Missing pool id for delegation");
+
+    if (!delegation?.status) {
+      typhonTx.addCertificate({
+        type: TyphonTypes.CertificateType.STAKE_KEY_REGISTRATION,
+        cert: {
+          stakeCredential,
+          deposit: new BigNumber(protocolParams.stakeKeyDeposit),
+        },
+      });
+    }
+
+    typhonTx.addCertificate({
+      type: TyphonTypes.CertificateType.STAKE_DELEGATION,
+      cert: { stakeCredential, poolHash: intent.valAddress },
+    });
+    return;
+  }
+
+  if (intent.mode === "undelegate") {
+    if (!delegation?.status) {
+      throw new Error("Stake key is not registered");
+    }
+    typhonTx.addCertificate({
+      type: TyphonTypes.CertificateType.STAKE_KEY_DE_REGISTRATION,
+      cert: {
+        stakeCredential,
+        deposit: new BigNumber(delegation.deposit || 0),
+      },
+    });
+    return;
+  }
+
+  throw new Error(`Unsupported staking mode: ${intent.mode}`);
+}
+
+/**
+ * Add the output(s) for a native ADA send and return the change address. A send-all routes the
+ * remaining ADA to the recipient (via change) while keeping any tokens the sender holds on the
+ * sender — a max-ADA send must not transfer them. A fixed-amount send adds an explicit recipient
+ * output and change returns to the sender. Mirrors the legacy buildSendAdaTransaction behaviour.
+ */
+function addNativeOutputs(
+  typhonTx: TyphonTransaction,
+  intent: TransactionIntent<StringMemo>,
+  senderAddress: TyphonTypes.ShelleyAddress,
+  inputs: TyphonTypes.Input[],
+  protocolParams: ProtocolParams,
+): TyphonTypes.CardanoAddress {
+  if (intent.useAllAmount) {
+    const heldTokens = mergeTokens(inputs.flatMap(i => i.tokens));
+    if (heldTokens.length) {
+      typhonTx.addOutput({
+        address: senderAddress,
+        amount: TyphonUtils.calculateMinUtxoAmountBabbage(
+          { address: senderAddress, amount: new BigNumber(CARDANO_MAX_SUPPLY), tokens: heldTokens },
+          new BigNumber(protocolParams.utxoCostPerByte),
+        ),
+        tokens: heldTokens,
+      });
+    }
+    return TyphonUtils.getAddressFromString(intent.recipient);
+  }
+
+  if (intent.amount <= 0n) throw new Error("Transaction amount must be positive");
+  const recipientAddress = TyphonUtils.getAddressFromString(intent.recipient);
+  const amount = new BigNumber(intent.amount.toString());
+  // Every Cardano output must hold at least the Babbage min-UTXO for its size; an amount below
+  // that floor crafts a body the node rejects. Fail early with a clear error instead.
+  const minAda = TyphonUtils.calculateMinUtxoAmountBabbage(
+    { address: recipientAddress, amount: new BigNumber(CARDANO_MAX_SUPPLY), tokens: [] },
+    new BigNumber(protocolParams.utxoCostPerByte),
+  );
+  if (amount.lt(minAda)) {
+    throw new Error("Transaction amount is below the minimum required for an output");
+  }
+  typhonTx.addOutput({ address: recipientAddress, amount, tokens: [] });
+  return senderAddress;
+}
+
+/**
+ * Add the multiasset output for a token transfer: the recipient receives the requested token
+ * plus the minimum ADA required to carry it. On `useAllAmount` the full held balance of that
+ * token (summed across the sender's UTXOs) is sent — Typhon then pulls every token-bearing UTXO
+ * to cover the output and returns the leftover ADA (and any other tokens) to the sender as change.
+ */
+function addTokenOutput(
+  typhonTx: TyphonTransaction,
+  intent: TransactionIntent<StringMemo>,
+  inputs: TyphonTypes.Input[],
+  protocolParams: ProtocolParams,
+): void {
+  const { policyId, assetName } = parseTokenAssetReference(intent.asset);
+  const heldAmount =
+    mergeTokens(inputs.flatMap(i => i.tokens)).find(
+      t => t.policyId === policyId && t.assetName === assetName,
+    )?.amount ?? new BigNumber(0);
+  const amount = intent.useAllAmount ? heldAmount : new BigNumber(intent.amount.toString());
+  if (amount.lte(0)) {
+    throw new Error(
+      intent.useAllAmount
+        ? "Sender holds none of the requested token"
+        : "Transaction amount must be positive",
+    );
+  }
+  const receiverAddress = TyphonUtils.getAddressFromString(intent.recipient);
+  const tokens: TyphonTypes.Token[] = [{ policyId, assetName, amount }];
+  const requiredMinAda = TyphonUtils.calculateMinUtxoAmountBabbage(
+    { address: receiverAddress, amount: new BigNumber(CARDANO_MAX_SUPPLY), tokens },
+    new BigNumber(protocolParams.utxoCostPerByte),
+  );
+  typhonTx.addOutput({ address: receiverAddress, amount: requiredMinAda, tokens });
+}
+
+/**
+ * Reconcile a user-supplied fee against the fee Typhon estimated while balancing the
+ * transaction. The fee difference is absorbed by the change output (the last output, which
+ * Typhon appends as change), keeping inputs = outputs + fee. Throws when the custom fee is
+ * below the protocol minimum, when there is no change output to absorb the difference, or
+ * when doing so would push that output below the min-UTXO floor.
+ */
+function applyCustomFee(
+  typhonTx: TyphonTransaction,
+  baseOutputCount: number,
+  customFee: BigNumber,
+): void {
+  // Typhon's estimate is the protocol minimum fee for this tx size; a lower custom fee would
+  // balance arithmetically but be rejected on-chain, so refuse it rather than craft a dud.
+  const estimatedFee = typhonTx.getFee();
+  if (customFee.eq(estimatedFee)) return;
+  if (customFee.lt(estimatedFee)) {
+    throw new Error("Custom fee is below the minimum required fee");
+  }
+
+  const outputs = typhonTx.getOutputs();
+  if (outputs.length <= baseOutputCount) {
+    throw new Error("Cannot apply custom fee: transaction has no change output");
+  }
+
+  const changeOutput = outputs[outputs.length - 1];
+  const delta = customFee.minus(estimatedFee);
+  const newAmount = changeOutput.amount.minus(delta);
+  const minUtxo = typhonTx.calculateMinUtxoAmountBabbage(changeOutput);
+  if (newAmount.lt(minUtxo)) {
+    throw new Error("Custom fee too high: change output would fall below the min-UTXO amount");
+  }
+
+  changeOutput.amount = newAmount;
+  typhonTx.setFee(customFee);
+}
+
+/**
+ * Build the unsigned Typhon transaction for a CoinModule intent (native ADA, token, or
+ * staking delegate/undelegate). Inputs are the sender address's UTXOs and change returns to
+ * the sender. Per-input BIP paths required by the device are signing metadata added
+ * downstream, not part of this body — so no xpub/account sync is needed here.
+ */
+export async function buildUnsignedTransaction(
+  currency: CryptoCurrency,
+  intent: TransactionIntent<StringMemo>,
+  customFees?: FeeEstimation,
+): Promise<TyphonTransaction> {
+  const paymentKey = extractPaymentKeyFromAddress(intent.sender);
+  if (paymentKey === EMPTY_CREDENTIAL_KEY) {
+    throw new Error("Unsupported sender address");
+  }
+  // Carried by the sender address; needed for the delegation fetch and Conway obligations below.
+  const stakeKey = extractStakeKeyFromAddress(intent.sender);
+
+  // Protocol params, the sender's tx history (for UTXOs) and the delegation state are independent
+  // network calls — fetch them in parallel rather than serially.
+  const [{ protocolParams }, { transactions }, delegation] = await Promise.all([
+    fetchNetworkInfo(currency),
+    getAllTransactionsByKeys([paymentKey], 0, currency),
+    stakeKey ? getDelegationInfo(currency, stakeKey) : Promise.resolve(undefined),
+  ]);
+
+  const typhonTx = new TyphonTransaction({
+    protocolParams: toTyphonProtocolParams(protocolParams),
+  });
+  typhonTx.setTTL(getTTL(currency.id));
+
+  const memo = "memo" in intent && intent.memo?.type === "string" ? intent.memo.value : undefined;
+  if (memo) {
+    typhonTx.setAuxiliaryData({
+      metadata: [{ label: MEMO_LABEL, data: new Map([["msg", [memo]]]) }],
+    });
+  }
+
+  const senderAddress = TyphonUtils.getAddressFromString(
+    intent.sender,
+  ) as TyphonTypes.ShelleyAddress;
+  // Derived from confirmed history only — with just an address (no pending-operation state) two
+  // craft calls before the first broadcast confirms may select the same UTXO. Same single-address
+  // constraint as getBalance/listOperations.
+  const inputs = deriveUtxos(transactions, paymentKey).map(u => toTyphonInput(u, senderAddress));
+  if (!inputs.length) {
+    throw new Error("No spendable UTXOs for sender address");
+  }
+
+  // Account-level reward/vote obligations (Conway) plus, for staking, the certificates;
+  // both require the stake credential carried by the sender address.
+  if (stakeKey && delegation) {
+    addAccountObligations(typhonTx, currency, stakeKey, delegation);
+  }
+
+  // changeAddress is the sender for sends/staking; for a send-all it is the recipient, so the
+  // entire balance (minus fee) lands there with no explicit recipient output.
+  let changeAddress: TyphonTypes.CardanoAddress = senderAddress;
+
+  if (intent.intentType === "staking") {
+    if (!stakeKey) throw new Error("Sender address has no stake credential");
+    addStakingCertificates(
+      typhonTx,
+      intent as StakingTransactionIntent<StringMemo>,
+      protocolParams,
+      stakeKey,
+      delegation,
+    );
+  } else if (intent.asset.type === "native") {
+    changeAddress = addNativeOutputs(typhonTx, intent, senderAddress, inputs, protocolParams);
+  } else {
+    addTokenOutput(typhonTx, intent, inputs, protocolParams);
+  }
+
+  // Spend the largest UTXOs first so Typhon's coin selection covers the outputs with the fewest
+  // inputs (smaller tx, lower fee) — mirrors the legacy builder's largest-first ordering.
+  inputs.sort((a, b) => b.amount.comparedTo(a.amount));
+
+  // A max-ADA native send must spend the ENTIRE UTXO set. Typhon's prepareTransaction does
+  // minimal coin selection over the inputs it is given (it stops as soon as the outputs + fee are
+  // covered), so for a sweep we force every UTXO as a mandatory input and hand it nothing to
+  // select — all remaining ADA then lands in the change output (whose address is the recipient).
+  // Every other intent lets Typhon select the minimal set from the available inputs.
+  const sweepAll =
+    intent.intentType === "transaction" && intent.asset.type === "native" && !!intent.useAllAmount;
+  if (sweepAll) {
+    inputs.forEach(input => typhonTx.addInput(input));
+  }
+
+  const baseOutputCount = typhonTx.getOutputs().length;
+  const prepared = typhonTx.prepareTransaction({
+    inputs: sweepAll ? [] : inputs,
+    changeAddress,
+  });
+
+  if (customFees) {
+    applyCustomFee(prepared, baseOutputCount, new BigNumber(customFees.value.toString()));
+  }
+
+  return prepared;
+}
+
+/**
+ * Craft an unsigned Cardano transaction from a CoinModule intent. Returns the unsigned CBOR
+ * payload (ready for the downstream device-signing step) and the resolved fee.
+ */
+export async function craftTransaction(
+  currency: CryptoCurrency,
+  intent: TransactionIntent<StringMemo>,
+  customFees?: FeeEstimation,
+): Promise<CraftedTransaction> {
+  const tx = await buildUnsignedTransaction(currency, intent, customFees);
+  const { payload } = tx.buildTransaction();
+  return {
+    transaction: payload,
+    details: { fees: tx.getFee().toFixed(0) },
+  };
+}

--- a/libs/coin-modules/coin-cardano/src/logic/getBalance.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/getBalance.ts
@@ -12,7 +12,7 @@ import { APITransaction } from "../api/api-types";
 import { getAllTransactionsByKeys } from "../api/fetchTransactions";
 import { getDelegationInfo } from "../api/getDelegationInfo";
 import { fetchNetworkInfo } from "../api/getNetworkInfo";
-import { calculateMinAdaForTokens, computeAdaBalance, mergeTokens } from "../logic";
+import { calculateMinAdaForTokens, computeAdaBalance, deriveUtxos, mergeTokens } from "../logic";
 import { CardanoDelegation } from "../types";
 import {
   EMPTY_CREDENTIAL_KEY,
@@ -22,45 +22,6 @@ import {
 } from "../utils";
 
 const NATIVE_ASSET: AssetInfo = { type: "native", name: "ADA" };
-
-type AddressUtxo = { amount: BigNumber; tokens: TyphonTypes.Token[] };
-
-/**
- * Derive the unspent outputs held by a single payment credential from its transaction
- * history: outputs paying that credential, minus those later consumed as inputs.
- *
- * Per-address only — a Cardano account spreads funds across many payment credentials
- * (derived from the xpub), but the CoinModule API receives a single address with no
- * xpub, so this covers just the passed address. See module-level note in getBalance.
- */
-function computeUtxosForPaymentKey(
-  transactions: APITransaction[],
-  paymentKey: string,
-): AddressUtxo[] {
-  const spent = new Set<string>();
-  for (const tx of transactions) {
-    for (const input of tx.inputs) {
-      if (input.paymentKey === paymentKey) spent.add(`${input.txId}#${input.index}`);
-    }
-  }
-
-  const utxos: AddressUtxo[] = [];
-  for (const tx of transactions) {
-    tx.outputs.forEach((output, index) => {
-      if (output.paymentKey !== paymentKey) return;
-      if (spent.has(`${tx.hash}#${index}`)) return;
-      utxos.push({
-        amount: new BigNumber(output.value),
-        tokens: output.tokens.map(t => ({
-          policyId: t.policyId,
-          assetName: t.assetName,
-          amount: new BigNumber(t.value),
-        })),
-      });
-    });
-  }
-  return utxos;
-}
 
 async function computeMinAdaForTokens(
   currency: CryptoCurrency,
@@ -146,7 +107,7 @@ export async function getBalance(currency: CryptoCurrency, address: string): Pro
     stakeKey ? getDelegationInfo(currency, stakeKey) : Promise.resolve(undefined),
   ]);
 
-  const utxos = computeUtxosForPaymentKey(transactions, paymentKey);
+  const utxos = deriveUtxos(transactions, paymentKey);
   const utxosSum = utxos.reduce((sum, u) => sum.plus(u.amount), new BigNumber(0));
   const tokens = mergeTokens(utxos.flatMap(u => u.tokens)).filter(t => t.amount.gt(0));
 

--- a/libs/coin-modules/coin-cardano/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/listOperations.test.ts
@@ -14,6 +14,9 @@ const currency = getCryptoCurrencyById("cardano");
 const PAYMENT_HASH = "11".repeat(28);
 const STAKE_HASH = "22".repeat(28);
 const OTHER_PAYMENT_HASH = "33".repeat(28);
+// Realistic 28-byte (56 hex char) policy ids — the canonical Cardano asset-id shape.
+const POLICY_ID = "aa".repeat(28);
+const POLICY_ID_2 = "bb".repeat(28);
 const POOL_KEY_HASH = "a314a18528d00c5fbd067ecb4a212cf2f307c83d2c08f44a11ebebf6";
 
 function bech32BaseAddress(paymentHashHex: string, stakeHashHex: string): string {
@@ -246,7 +249,7 @@ describe("listOperations", () => {
             address: ADDRESS,
             value: "5000000",
             paymentKey: PAYMENT_HASH,
-            tokens: [{ policyId: "pol1", assetName: assetNameHex, value: "100" }],
+            tokens: [{ policyId: POLICY_ID, assetName: assetNameHex, value: "100" }],
           },
         ],
       }),
@@ -256,10 +259,10 @@ describe("listOperations", () => {
 
     const tokenOp = items.find(op => op.asset.type === "token");
     expect(tokenOp).toMatchObject({
-      id: `cardano-tx-hash-1-pol1.${assetNameHex}`,
+      id: `cardano-tx-hash-1-${POLICY_ID}${assetNameHex}`,
       type: "IN",
       value: 100n,
-      asset: { type: "token", assetReference: `pol1.${assetNameHex}`, assetOwner: ADDRESS },
+      asset: { type: "token", assetReference: `${POLICY_ID}${assetNameHex}`, assetOwner: ADDRESS },
     });
     expect(tokenOp?.details).toMatchObject({ assetNameDecoded: "MYTOKEN" });
   });
@@ -274,7 +277,7 @@ describe("listOperations", () => {
             address: ADDRESS,
             value: "3000000",
             paymentKey: PAYMENT_HASH,
-            tokens: [{ policyId: "pol1", assetName: "abcd", value: "50" }],
+            tokens: [{ policyId: POLICY_ID, assetName: "abcd", value: "50" }],
           },
         ],
         outputs: [
@@ -282,7 +285,7 @@ describe("listOperations", () => {
             address: ADDRESS,
             value: "2800000",
             paymentKey: PAYMENT_HASH,
-            tokens: [{ policyId: "pol1", assetName: "abcd", value: "50" }],
+            tokens: [{ policyId: POLICY_ID, assetName: "abcd", value: "50" }],
           },
         ],
       }),
@@ -303,7 +306,7 @@ describe("listOperations", () => {
             address: ADDRESS,
             value: "3000000",
             paymentKey: PAYMENT_HASH,
-            tokens: [{ policyId: "pol1", assetName: "abcd", value: "50" }],
+            tokens: [{ policyId: POLICY_ID, assetName: "abcd", value: "50" }],
           },
         ],
         outputs: [{ address: ADDRESS, value: "2800000", paymentKey: PAYMENT_HASH, tokens: [] }],
@@ -335,8 +338,8 @@ describe("listOperations", () => {
             value: "5000000",
             paymentKey: PAYMENT_HASH,
             tokens: [
-              { policyId: "pol1", assetName: "a1", value: "10" },
-              { policyId: "pol2", assetName: "a2", value: "20" },
+              { policyId: POLICY_ID, assetName: "a1", value: "10" },
+              { policyId: POLICY_ID_2, assetName: "a2", value: "20" },
             ],
           },
         ],
@@ -361,7 +364,7 @@ describe("listOperations", () => {
             address: ADDRESS,
             value: "1000000",
             paymentKey: PAYMENT_HASH,
-            tokens: [{ policyId: "pol1", assetName: "abcd", value: "20" }],
+            tokens: [{ policyId: POLICY_ID, assetName: "abcd", value: "20" }],
           },
         ],
         outputs: [
@@ -369,13 +372,13 @@ describe("listOperations", () => {
             address: ADDRESS,
             value: "500000",
             paymentKey: PAYMENT_HASH,
-            tokens: [{ policyId: "pol1", assetName: "abcd", value: "40" }],
+            tokens: [{ policyId: POLICY_ID, assetName: "abcd", value: "40" }],
           },
           {
             address: ADDRESS,
             value: "500000",
             paymentKey: PAYMENT_HASH,
-            tokens: [{ policyId: "pol1", assetName: "abcd", value: "10" }],
+            tokens: [{ policyId: POLICY_ID, assetName: "abcd", value: "10" }],
           },
         ],
       }),

--- a/libs/coin-modules/coin-cardano/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/listOperations.ts
@@ -312,7 +312,10 @@ function extractTokenOperations(
     const tokenType = isReceiving ? "IN" : "OUT";
     const tokenValue = tokenData.balance >= 0n ? tokenData.balance : -tokenData.balance;
 
-    const assetReference = `${tokenData.policyId}.${tokenData.assetName}`;
+    // Canonical Cardano asset id: policyId (56 hex) concatenated with the asset name, no
+    // separator — matches getTokenAssetId (buildSubAccounts) and getBalance, so a reference from
+    // any producer is interchangeable (e.g. feeding a listed token into craftTransaction).
+    const assetReference = `${tokenData.policyId}${tokenData.assetName}`;
 
     const assetInfo: AssetInfo = {
       type: "token",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Hermetic unit tests asserting the built Typhon transaction (inputs/outputs/certificates/withdrawals/fee) for native, token and staking intents, including send-all (native sweep of the whole UTXO set with token retention; token full-balance send), custom-fee reconciliation, the per-output min-ADA floor, invalid token-asset-reference rejection and error paths; an API delegation test; and a live-network integration test.
- [x] **Impact of the changes:** Cardano CoinModule API only. Cardano is not yet wired into the generic coin-framework bridge, so there is no impact on live send/sync flows. QA focus: none on current flows.

### 📝 Description

Implements `craftTransaction(intent, customFees?)` for the Cardano CoinModule ("Alpaca") API. Produces the **unsigned** transaction (CBOR payload) plus the resolved fee:

- **Native ADA / token / staking** — inputs are the sender address's UTXOs (`/v1/transaction`, largest-first), change returns to the sender. A native send is rejected below the per-output Babbage min-UTXO floor. Tokens use `calculateMinUtxoAmountBabbage`; the token `assetReference` is the canonical Cardano asset id — policyId (56 hex) concatenated with the asset name, no separator — so a reference from `getBalance`/`listOperations` can be fed straight back in. Staking covers `delegate` (auto stake-registration when unregistered) and `undelegate` (de-registration), throwing on any other mode. Conway obligations (reward sweep when delegated to a dRep; ABSTAIN vote certificate otherwise) mirror the legacy builder.
- **`useAllAmount`** — a native max-ADA send spends the **entire** UTXO set and routes all ADA (minus fee) to the recipient, while retaining any held tokens on the sender with their backing min-ADA (a max-ADA send must not transfer tokens). A token max send transfers the sender's full held balance of that token. Both mirror the legacy builder.
- **Custom fees** — override the locally estimated fee, reconciled into the change output; rejected when below the protocol minimum or when it would push change below the min-UTXO floor.

Signing is downstream and out of scope: per-input BIP paths required by the device are signing metadata, not part of the unsigned body — so no xpub/account sync is needed here.

Also folds in a one-line fix to `listOperations`: its token `assetReference` used a `.` separator, diverging from the canonical concatenated id (`getTokenAssetId`, also emitted by `getBalance`). Aligning it keeps a token reference interchangeable across all three methods. It also extracts the shared `deriveUtxos` helper (UTXO derivation from tx history) into `logic.ts`, which `getBalance` now reuses too — so craft and balance can't drift on how they read the UTXO set.

**Known limitation:** the framework passes a single `freshAddress` (no xpub), so inputs cover only that address's payment credential and change returns to it — same single-address constraint as `getBalance`/`listOperations`. Derived from confirmed history only, so it cannot exclude outpoints spent by an as-yet-unconfirmed transaction.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-18627](https://ledgerhq.atlassian.net/browse/LIVE-18627)
- **ADR link (if any)**:


[LIVE-18627]: https://ledgerhq.atlassian.net/browse/LIVE-18627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

