### PR TITLE
[LWM] feat(mobile): add migration script for dismissals

### DIFF
--- a/.changeset/plenty-brooms-jam.md
+++ b/.changeset/plenty-brooms-jam.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add migration script

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPrompt.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPrompt.test.tsx
@@ -8,6 +8,7 @@ import {
 } from "LLM/features/NotificationsPrompt";
 
 import storage from "LLM/storage";
+import { notificationsDataOfUserSelector } from "~/reducers/notifications";
 import { add, sub, type Duration } from "date-fns";
 import { Button, Text } from "@ledgerhq/lumen-ui-rnative";
 import { AB_TESTING_VARIANTS, type ABTestingVariants } from "../types/variants";
@@ -82,6 +83,7 @@ describe("NotificationsPrompt Integration", () => {
     lastActionAt,
     dateOfNextAllowedRequest,
     alreadyDelayedToLater,
+    dismissedOptInDrawerAtList,
     variant = AB_TESTING_VARIANTS.B,
     skipStorageSetup = false,
   }: {
@@ -91,6 +93,7 @@ describe("NotificationsPrompt Integration", () => {
     lastActionAt?: number;
     dateOfNextAllowedRequest?: Date;
     alreadyDelayedToLater?: boolean;
+    dismissedOptInDrawerAtList?: number[];
     variant?: ABTestingVariants;
     skipStorageSetup?: boolean;
   }) {
@@ -101,6 +104,7 @@ describe("NotificationsPrompt Integration", () => {
         lastActionAt,
         dateOfNextAllowedRequest,
         alreadyDelayedToLater,
+        dismissedOptInDrawerAtList,
       });
     }
 
@@ -232,6 +236,52 @@ describe("NotificationsPrompt Integration", () => {
     jest.setSystemTime(newTime);
     act(() => jest.advanceTimersByTime(newTime.getTime() - now));
   };
+
+  describe("legacy stored user data migration", () => {
+    it("should backfill globalPushNotifications dismissals when loading legacy storage on init", async () => {
+      const legacyDismissals = [sub(new Date(), { days: 1 }).getTime()];
+      const lastActionAt = Date.now();
+
+      await storage.save("pushNotificationsDataOfUser", {
+        dismissedOptInDrawerAtList: legacyDismissals,
+        lastActionAt,
+      });
+
+      const { store } = await setup({
+        skipStorageSetup: true,
+        osPermission: AuthorizationStatus.DENIED,
+        appNotifications: false,
+      });
+
+      const expectedUserData = {
+        dismissedOptInDrawerAtList: legacyDismissals,
+        dismissedPromptAtListByTarget: { globalPushNotifications: legacyDismissals },
+        lastActionAt,
+      };
+
+      await expect(storage.get("pushNotificationsDataOfUser")).resolves.toEqual(expectedUserData);
+      expect(notificationsDataOfUserSelector(store.getState())).toEqual(expectedUserData);
+    });
+
+    it("should keep reprompt behavior for legacy users after dismissals are backfilled", async () => {
+      const legacyDismissals = [sub(new Date(), { days: 8 }).getTime()];
+      const lastActionAt = Date.now();
+
+      await storage.save("pushNotificationsDataOfUser", {
+        dismissedOptInDrawerAtList: legacyDismissals,
+        lastActionAt,
+      });
+
+      const { tryTriggerDrawer } = await setup({
+        skipStorageSetup: true,
+        osPermission: AuthorizationStatus.DENIED,
+        appNotifications: false,
+      });
+
+      await tryTriggerDrawer();
+      expect(screen.getByText(/allow notifications/i)).toBeOnTheScreen();
+    });
+  });
 
   describe("after an action", () => {
     describe("backward compatibility for legacy users", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/__tests__/backfillGlobalPushNotificationsDismissals.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/__tests__/backfillGlobalPushNotificationsDismissals.test.ts
@@ -1,0 +1,50 @@
+import { backfillGlobalPushNotificationsDismissals } from "../backfillGlobalPushNotificationsDismissals";
+import type { DataOfUser } from "../../types";
+
+describe("backfillGlobalPushNotificationsDismissals", () => {
+  it("should return the same object when globalPushNotifications is already defined", () => {
+    const dataOfUser: DataOfUser = {
+      dismissedOptInDrawerAtList: [1, 2],
+      dismissedPromptAtListByTarget: { globalPushNotifications: [3] },
+    };
+
+    expect(backfillGlobalPushNotificationsDismissals(dataOfUser)).toBe(dataOfUser);
+  });
+
+  it("should copy dismissedOptInDrawerAtList when globalPushNotifications is missing", () => {
+    const legacyDismissals = [100, 200];
+
+    expect(
+      backfillGlobalPushNotificationsDismissals({
+        dismissedOptInDrawerAtList: legacyDismissals,
+      }),
+    ).toEqual({
+      dismissedOptInDrawerAtList: legacyDismissals,
+      dismissedPromptAtListByTarget: { globalPushNotifications: legacyDismissals },
+    });
+  });
+
+  it("should preserve other targets when backfilling globalPushNotifications", () => {
+    const legacyDismissals = [100];
+    const categoryDismissals = [300];
+
+    expect(
+      backfillGlobalPushNotificationsDismissals({
+        dismissedOptInDrawerAtList: legacyDismissals,
+        dismissedPromptAtListByTarget: { transactionsAlertsCategory: categoryDismissals },
+      }),
+    ).toEqual({
+      dismissedOptInDrawerAtList: legacyDismissals,
+      dismissedPromptAtListByTarget: {
+        transactionsAlertsCategory: categoryDismissals,
+        globalPushNotifications: legacyDismissals,
+      },
+    });
+  });
+
+  it("should not mutate data when dismissedOptInDrawerAtList is undefined", () => {
+    const dataOfUser: DataOfUser = { lastActionAt: 42 };
+
+    expect(backfillGlobalPushNotificationsDismissals(dataOfUser)).toBe(dataOfUser);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/__tests__/storage.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/__tests__/storage.test.ts
@@ -1,0 +1,40 @@
+import storage from "LLM/storage";
+import { getPushNotificationsDataOfUserFromStorage } from "../storage";
+
+describe("getPushNotificationsDataOfUserFromStorage", () => {
+  beforeEach(async () => {
+    await storage.deleteAll();
+  });
+
+  it("should backfill and persist legacy dismissals before returning stored user data", async () => {
+    const legacyDismissals = [100, 200];
+    await storage.save("pushNotificationsDataOfUser", {
+      dismissedOptInDrawerAtList: legacyDismissals,
+    });
+
+    await expect(getPushNotificationsDataOfUserFromStorage()).resolves.toEqual({
+      dismissedOptInDrawerAtList: legacyDismissals,
+      dismissedPromptAtListByTarget: { globalPushNotifications: legacyDismissals },
+    });
+
+    await expect(storage.get("pushNotificationsDataOfUser")).resolves.toEqual({
+      dismissedOptInDrawerAtList: legacyDismissals,
+      dismissedPromptAtListByTarget: { globalPushNotifications: legacyDismissals },
+    });
+  });
+
+  it("should not persist when globalPushNotifications is already defined", async () => {
+    const dataOfUser = {
+      dismissedOptInDrawerAtList: [100],
+      dismissedPromptAtListByTarget: { globalPushNotifications: [100] },
+    };
+    await storage.save("pushNotificationsDataOfUser", dataOfUser);
+
+    const saveSpy = jest.spyOn(storage, "save");
+
+    await expect(getPushNotificationsDataOfUserFromStorage()).resolves.toEqual(dataOfUser);
+    expect(saveSpy).not.toHaveBeenCalled();
+
+    saveSpy.mockRestore();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/backfillGlobalPushNotificationsDismissals.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/backfillGlobalPushNotificationsDismissals.ts
@@ -1,0 +1,24 @@
+import type { DataOfUser } from "../types";
+
+/**
+ * Migrates legacy `dismissedOptInDrawerAtList` into `dismissedPromptAtListByTarget.globalPushNotifications`
+ * when the target-specific list has not been set yet.
+ */
+export function backfillGlobalPushNotificationsDismissals(dataOfUser: DataOfUser): DataOfUser {
+  if (dataOfUser.dismissedPromptAtListByTarget?.globalPushNotifications !== undefined) {
+    return dataOfUser;
+  }
+
+  const { dismissedOptInDrawerAtList } = dataOfUser;
+  if (dismissedOptInDrawerAtList === undefined) {
+    return dataOfUser;
+  }
+
+  return {
+    ...dataOfUser,
+    dismissedPromptAtListByTarget: {
+      ...dataOfUser.dismissedPromptAtListByTarget,
+      globalPushNotifications: dismissedOptInDrawerAtList,
+    },
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/storage.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/storage.ts
@@ -1,4 +1,6 @@
+import isEqual from "lodash/isEqual";
 import storage from "LLM/storage";
+import { backfillGlobalPushNotificationsDismissals } from "./backfillGlobalPushNotificationsDismissals";
 import { type DataOfUser } from "../types";
 
 const pushNotificationsDataOfUserStorageKey = "pushNotificationsDataOfUser";
@@ -8,7 +10,12 @@ export async function getPushNotificationsDataOfUserFromStorage() {
 
   if (!dataOfUser || Array.isArray(dataOfUser)) return null;
 
-  return dataOfUser;
+  const migratedDataOfUser = backfillGlobalPushNotificationsDismissals(dataOfUser);
+  if (!isEqual(migratedDataOfUser, dataOfUser)) {
+    await storage.save(pushNotificationsDataOfUserStorageKey, migratedDataOfUser);
+  }
+
+  return migratedDataOfUser;
 }
 
 export async function setPushNotificationsDataOfUserInStorage(dataOfUser: DataOfUser) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Add migration function for dismissals;
  - Execute when getting data from storage.

### 📝 Description
This pull request introduces a migration to improve how push notification dismissal data is stored and accessed in the mobile app. The main change is the addition of a migration script and supporting logic to backfill legacy dismissal data into a new, more structured format. This ensures that old user data remains compatible with the latest features and data access patterns. Comprehensive unit tests are also added to verify the migration behavior and storage logic.

**Migration and Data Structure Improvements:**

* Added a migration script to backfill legacy `dismissedOptInDrawerAtList` data into the new `dismissedPromptAtListByTarget.globalPushNotifications` structure, ensuring backward compatibility for user dismissal data. (.changeset/plenty-brooms-jam.md)
* Implemented the `backfillGlobalPushNotificationsDismissals` utility function to perform the migration in-memory when loading user data. (apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/backfillGlobalPushNotificationsDismissals.ts)
* Updated `getPushNotificationsDataOfUserFromStorage` to use the migration function and persist the migrated data if needed, preventing repeated migrations and keeping storage consistent. (apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/storage.ts, [[1]](diffhunk://#diff-dec5e6846eedaad71b4fbc365838a18f4e5f2d723a7b404e0dd5cdc0abcf2969L11-R18) [[2]](diffhunk://#diff-dec5e6846eedaad71b4fbc365838a18f4e5f2d723a7b404e0dd5cdc0abcf2969R1-R3)

**Testing Enhancements:**

* Added unit tests for the migration utility to ensure correct backfilling and data preservation in various scenarios. (apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/__tests__/backfillGlobalPushNotificationsDismissals.test.ts)
* Added unit tests for the storage logic to verify that legacy data is migrated, persisted, and not redundantly saved when already up-to-date. (apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/__tests__/storage.test.ts)

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31497]
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31497]: https://ledgerhq.atlassian.net/browse/LIVE-31497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ