### PR TITLE
[LWDM] feat(cardano): add estimateFees CoinModule API

### DIFF
--- a/.changeset/sweet-beers-melt.md
+++ b/.changeset/sweet-beers-melt.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-cardano": minor
+---
+
+Add estimateFees method to Coin Cardano CoinModule API

--- a/libs/coin-modules/coin-cardano/src/api/estimateFees.test.ts
+++ b/libs/coin-modules/coin-cardano/src/api/estimateFees.test.ts
@@ -1,15 +1,58 @@
+import type { TransactionIntent, StringMemo } from "@ledgerhq/coin-module-framework/api/index";
 import { createApi } from ".";
 import { type CardanoConfig } from "../config";
-import type { StringMemo, TransactionIntent } from "@ledgerhq/coin-module-framework/api/index";
+import { estimateFees } from "../logic/estimateFees";
+
+jest.mock("../logic/estimateFees");
+const mockEstimateFees = jest.mocked(estimateFees);
 
 const config: CardanoConfig = { maxFeesWarning: 0, maxFeesError: 0 };
 
+const intent = {
+  intentType: "transaction",
+  type: "send",
+  sender: "addr1sender",
+  recipient: "addr1recipient",
+  amount: 1_000_000n,
+  asset: { type: "native" },
+} as TransactionIntent<StringMemo>;
+
 describe("estimateFees", () => {
-  it("throws an unsupported error", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("delegates to logic estimateFees with the resolved currency and intent", async () => {
+    const estimation = { value: 170_000n };
+    mockEstimateFees.mockResolvedValue(estimation);
+
+    const api = createApi(config, "cardano");
+    const result = await api.estimateFees(intent);
+
+    expect(result).toBe(estimation);
+    expect(mockEstimateFees).toHaveBeenCalledTimes(1);
+    expect(mockEstimateFees.mock.calls[0][0].id).toBe("cardano");
+    expect(mockEstimateFees.mock.calls[0][1]).toBe(intent);
+  });
+
+  it("accepts but ignores customFeesParameters (no fee market on Cardano)", async () => {
+    const estimation = { value: 170_000n };
+    mockEstimateFees.mockResolvedValue(estimation);
+
+    const api = createApi(config, "cardano");
+    const result = await api.estimateFees(intent, { priority: "high" });
+
+    expect(result).toBe(estimation);
+    // The second positional arg (customFeesParameters) is not forwarded to the logic layer.
+    expect(mockEstimateFees.mock.calls[0]).toHaveLength(2);
+    expect(mockEstimateFees.mock.calls[0][1]).toBe(intent);
+  });
+
+  it("propagates errors from logic estimateFees", async () => {
+    mockEstimateFees.mockRejectedValue(new Error("boom"));
+
     const api = createApi(config, "cardano");
 
-    expect(() => api.estimateFees({} as TransactionIntent<StringMemo>)).toThrow(
-      "estimateFees is not supported",
-    );
+    await expect(api.estimateFees(intent)).rejects.toThrow("boom");
   });
 });

--- a/libs/coin-modules/coin-cardano/src/api/index.ts
+++ b/libs/coin-modules/coin-cardano/src/api/index.ts
@@ -25,6 +25,7 @@ import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import coinConfig, { type CardanoConfig } from "../config";
 import { broadcast } from "../logic/broadcast";
 import { craftTransaction } from "../logic/craftTransaction";
+import { estimateFees } from "../logic/estimateFees";
 import { getBalance } from "../logic/getBalance";
 import { getValidators } from "../logic/getValidators";
 import { lastBlock } from "../logic/lastBlock";
@@ -67,11 +68,9 @@ export function createApi(config: CardanoConfig, currencyId: string): CoinModule
       throw new Error("craftRawTransaction is not supported");
     },
     estimateFees: (
-      _transactionIntent: TransactionIntent<StringMemo>,
+      transactionIntent: TransactionIntent<StringMemo>,
       _customFeesParameters?: FeeEstimation["parameters"],
-    ): Promise<FeeEstimation> => {
-      throw new Error("estimateFees is not supported");
-    },
+    ): Promise<FeeEstimation> => estimateFees(currency, transactionIntent),
     combine: (_tx: string, _signature: string, _pubkey?: string): string => {
       throw new Error("combine is not supported");
     },

--- a/libs/coin-modules/coin-cardano/src/logic/estimateFees.test.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/estimateFees.test.ts
@@ -1,0 +1,140 @@
+import type {
+  StakingTransactionIntent,
+  StringMemo,
+  TransactionIntent,
+} from "@ledgerhq/coin-module-framework/api/index";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { APITransaction } from "../api/api-types";
+import { getAllTransactionsByKeys } from "../api/fetchTransactions";
+import { getDelegationInfo } from "../api/getDelegationInfo";
+import { fetchNetworkInfo } from "../api/getNetworkInfo";
+import { getProtocolParamsFixture } from "../fixtures/protocolParams";
+import { extractPaymentKeyFromAddress } from "../utils";
+import { craftTransaction } from "./craftTransaction";
+import { estimateFees } from "./estimateFees";
+
+jest.mock("../api/fetchTransactions");
+jest.mock("../api/getDelegationInfo");
+jest.mock("../api/getNetworkInfo");
+
+const mockFetchTxs = jest.mocked(getAllTransactionsByKeys);
+const mockGetDelegation = jest.mocked(getDelegationInfo);
+const mockFetchNetworkInfo = jest.mocked(fetchNetworkInfo);
+
+// getAllTransactionsByKeys returns the paginated result shape; the fee build only reads the
+// transaction list, so wrap a plain list with a dummy blockHeight in the tests.
+const paged = (transactions: APITransaction[]) => ({ transactions, blockHeight: 1 });
+
+const currency = getCryptoCurrencyById("cardano");
+const SENDER =
+  "addr1q8mgw8geggkl2hs0m6rq3pgt69uxttpqcgu6euxje5tt6plxjtjrnskhhtt03g6l3sr98p9t8mtlajr26vmwjzep77pqxn8cms";
+const RECIPIENT =
+  "addr1qxqm3nxwzf70ke9jqa2zrtrevjznpv6yykptxnv34perjc8a7zgxmpv5pgk4hhhe0m9kfnlsf5pt7d2ahkxaul2zygrq3nura9";
+const PAYMENT_KEY = extractPaymentKeyFromAddress(SENDER);
+const POLICY_ID = "a".repeat(56);
+const POOL_HASH = "b".repeat(56);
+
+function makeTx(partial: Partial<APITransaction>): APITransaction {
+  return {
+    fees: "0",
+    hash: "tx-hash",
+    timestamp: "1700000000",
+    blockHeight: 1,
+    inputs: [],
+    outputs: [],
+    certificate: { stakeRegistrations: [], stakeDeRegistrations: [], stakeDelegations: [] },
+    ...partial,
+  };
+}
+
+function output(value: string, tokens: APITransaction["outputs"][number]["tokens"] = []) {
+  return { address: SENDER, value, paymentKey: PAYMENT_KEY, tokens };
+}
+
+function sendIntent(over: Partial<TransactionIntent> = {}): TransactionIntent<StringMemo> {
+  return {
+    intentType: "transaction",
+    type: "send",
+    sender: SENDER,
+    recipient: RECIPIENT,
+    amount: 2_000_000n,
+    asset: { type: "native" },
+    ...over,
+  } as TransactionIntent<StringMemo>;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockFetchNetworkInfo.mockResolvedValue({ protocolParams: getProtocolParamsFixture() });
+  mockGetDelegation.mockResolvedValue(undefined);
+  mockFetchTxs.mockResolvedValue(paged([makeTx({ hash: "a", outputs: [output("10000000")] })]));
+});
+
+describe("estimateFees", () => {
+  it("returns the fee Typhon computes for a native send", async () => {
+    const { value } = await estimateFees(currency, sendIntent());
+
+    expect(typeof value).toBe("bigint");
+    expect(value).toBeGreaterThan(0n);
+  });
+
+  it("computes the exact deterministic fee for a fixed native send", async () => {
+    // Pins the lovelace fee for a stable mocked tx so a fee regression that affects the shared
+    // build path (not just estimate-vs-craft parity) is caught.
+    const { value } = await estimateFees(currency, sendIntent());
+
+    expect(value).toBe(166865n);
+  });
+
+  it("estimates a token transfer (size-based, same behaviour as a native send)", async () => {
+    mockFetchTxs.mockResolvedValue(
+      paged([
+        makeTx({
+          hash: "a",
+          outputs: [output("10000000", [{ policyId: POLICY_ID, assetName: "abcd", value: "100" }])],
+        }),
+      ]),
+    );
+
+    const { value } = await estimateFees(
+      currency,
+      sendIntent({ amount: 100n, asset: { type: "token", assetReference: `${POLICY_ID}abcd` } }),
+    );
+
+    expect(value).toBeGreaterThan(0n);
+  });
+
+  it("estimates a staking delegation", async () => {
+    const intent = {
+      intentType: "staking",
+      type: "delegate",
+      sender: SENDER,
+      recipient: SENDER,
+      amount: 0n,
+      asset: { type: "native" },
+      mode: "delegate",
+      valAddress: POOL_HASH,
+    } as StakingTransactionIntent<StringMemo>;
+
+    const { value } = await estimateFees(currency, intent);
+
+    expect(value).toBeGreaterThan(0n);
+  });
+
+  it("matches the fee craftTransaction reports for the same intent (no custom fee)", async () => {
+    const intent = sendIntent();
+
+    const { value } = await estimateFees(currency, intent);
+    const crafted = await craftTransaction(currency, intent);
+
+    expect(value.toString()).toBe(crafted.details?.fees);
+  });
+
+  it("propagates errors when the transaction cannot be built", async () => {
+    mockFetchTxs.mockResolvedValue(paged([]));
+
+    await expect(estimateFees(currency, sendIntent())).rejects.toThrow(
+      "No spendable UTXOs for sender address",
+    );
+  });
+});

--- a/libs/coin-modules/coin-cardano/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/estimateFees.ts
@@ -1,0 +1,24 @@
+import type {
+  FeeEstimation,
+  StringMemo,
+  TransactionIntent,
+} from "@ledgerhq/coin-module-framework/api/index";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { buildUnsignedTransaction } from "./craftTransaction";
+
+/**
+ * Estimate the fee for a Cardano transaction intent. On Cardano the fee is deterministic —
+ * derived purely from the transaction size against the protocol parameters — so the estimate
+ * is identical in nature for native, token and staking transactions: build the unsigned
+ * transaction and read the fee Typhon computed while balancing it.
+ *
+ * Cardano has no fee market or priority, so there is nothing to parameterize; the API layer
+ * accepts the contract's `customFeesParameters` but ignores it for Cardano.
+ */
+export async function estimateFees(
+  currency: CryptoCurrency,
+  intent: TransactionIntent<StringMemo>,
+): Promise<FeeEstimation> {
+  const tx = await buildUnsignedTransaction(currency, intent);
+  return { value: BigInt(tx.getFee().toFixed(0)) };
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Hermetic unit tests for native/token/staking estimates (real Typhon fee via a mocked network boundary), an exact-lovelace fee assertion for a fixed mocked send, a consistency test locking `estimateFees` to `craftTransaction`'s reported fee for the same intent, error propagation, and an API delegation test (including that `customFeesParameters` is accepted and ignored).
- [x] **Impact of the changes:** Cardano CoinModule API only. Cardano is not yet wired into the generic coin-framework bridge, so there is no impact on live send/sync flows. QA focus: none on current flows.

### 📝 Description

Implements `estimateFees(intent, customFeesParameters?)` for the Cardano CoinModule ("Alpaca") API.

On Cardano the fee is deterministic — derived purely from the transaction size against the protocol parameters — so the estimate is identical in nature for native, token and staking transactions. The implementation builds the unsigned transaction (reusing `buildUnsignedTransaction`) and returns the fee Typhon computed while balancing it.

`customFeesParameters` is intentionally not consumed: Cardano has no fee market or priority, so the contract's parameters carry nothing actionable (same convention as other coin-modules that document-but-ignore the argument).

### ❓ Context

- **JIRA or GitHub link**: [LIVE-18626](https://ledgerhq.atlassian.net/browse/LIVE-18626)
- **ADR link (if any)**:


[LIVE-18626]: https://ledgerhq.atlassian.net/browse/LIVE-18626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
