### PR TITLE
[LWDM] feat: cardano coin module api combine

### DIFF
--- a/.changeset/two-eagles-appear.md
+++ b/.changeset/two-eagles-appear.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-cardano": minor
+---
+
+Add combine method to Coin Cardano CoinModule API

--- a/libs/coin-modules/coin-cardano/package.json
+++ b/libs/coin-modules/coin-cardano/package.json
@@ -64,6 +64,7 @@
     "@ledgerhq/types-cryptoassets": "workspace:^",
     "@ledgerhq/types-live": "workspace:^",
     "@stricahq/bip32ed25519": "^1.0.3",
+    "@stricahq/cbors": "1.0.2",
     "@stricahq/typhonjs": "^3.0.0",
     "bech32": "^1.1.3",
     "bignumber.js": "^9.1.2",

--- a/libs/coin-modules/coin-cardano/src/api/combine.test.ts
+++ b/libs/coin-modules/coin-cardano/src/api/combine.test.ts
@@ -1,12 +1,39 @@
-import { createApi } from ".";
 import { type CardanoConfig } from "../config";
+import { combine } from "../logic/combine";
+import { createApi } from ".";
+
+jest.mock("../logic/combine", () => ({
+  combine: jest.fn(),
+}));
+
+const mockCombine = jest.mocked(combine);
 
 const config: CardanoConfig = { maxFeesWarning: 0, maxFeesError: 0 };
 
-describe("combine", () => {
-  it("throws an unsupported error", () => {
+describe("api.combine", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("delegates to the combine logic and returns the signed payload", () => {
+    mockCombine.mockReturnValue("signedTxPayload");
     const api = createApi(config, "cardano");
 
-    expect(() => api.combine("transaction", "signature")).toThrow("combine is not supported");
+    const result = api.combine("unsignedTx", "signature", "pubkey");
+
+    expect(mockCombine).toHaveBeenCalledTimes(1);
+    expect(mockCombine).toHaveBeenCalledWith("unsignedTx", "signature", "pubkey");
+    expect(result).toBe("signedTxPayload");
+  });
+
+  it("propagates errors thrown by the combine logic", () => {
+    mockCombine.mockImplementation(() => {
+      throw new Error("cardano: combine requires the signing public key");
+    });
+    const api = createApi(config, "cardano");
+
+    expect(() => api.combine("unsignedTx", "signature")).toThrow(
+      "cardano: combine requires the signing public key",
+    );
   });
 });

--- a/libs/coin-modules/coin-cardano/src/api/index.ts
+++ b/libs/coin-modules/coin-cardano/src/api/index.ts
@@ -24,6 +24,7 @@ import { rejectBalanceOptions } from "@ledgerhq/coin-module-framework/api/getBal
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import coinConfig, { type CardanoConfig } from "../config";
 import { broadcast } from "../logic/broadcast";
+import { combine } from "../logic/combine";
 import { craftTransaction } from "../logic/craftTransaction";
 import { estimateFees } from "../logic/estimateFees";
 import { getBalance } from "../logic/getBalance";
@@ -71,9 +72,7 @@ export function createApi(config: CardanoConfig, currencyId: string): CoinModule
       transactionIntent: TransactionIntent<StringMemo>,
       _customFeesParameters?: FeeEstimation["parameters"],
     ): Promise<FeeEstimation> => estimateFees(currency, transactionIntent),
-    combine: (_tx: string, _signature: string, _pubkey?: string): string => {
-      throw new Error("combine is not supported");
-    },
+    combine,
     broadcast: (tx: string, broadcastConfig?: BroadcastConfig): Promise<string> =>
       broadcast(currency, { signature: tx, broadcastConfig }),
     validateIntent: (

--- a/libs/coin-modules/coin-cardano/src/logic/combine.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/combine.ts
@@ -1,0 +1,90 @@
+import * as cbors from "@stricahq/cbors";
+
+// A Cardano signed transaction is the CBOR array
+// [transaction_body, transaction_witness_set, is_valid, auxiliary_data].
+// Vkey witnesses live in the witness-set map at key 0, each as a
+// [public_key(32B), signature(64B)] pair.
+const VKEY_WITNESS_SET_KEY = 0;
+const ED25519_SIGNATURE_LENGTH = 64;
+const ED25519_PUBLIC_KEY_LENGTH = 32;
+
+type VKeyWitness = [Buffer, Buffer];
+type Transaction = [unknown, Map<number, unknown>, unknown, unknown];
+
+// Buffer.from(.., "hex") silently truncates at the first non-hex pair, so verify
+// the round-trip to reject malformed hex with an actionable message.
+function decodeHex(value: string, label: string): Buffer {
+  const buffer = Buffer.from(value, "hex");
+  if (buffer.toString("hex") !== value.toLowerCase()) {
+    throw new Error(`cardano: ${label} is not valid hex`);
+  }
+  return buffer;
+}
+
+function decodeFixedHex(value: string, label: string, expectedLength: number): Buffer {
+  const buffer = decodeHex(value, label);
+  if (buffer.length !== expectedLength) {
+    throw new Error(
+      `cardano: invalid ${label} length, expected ${expectedLength} bytes, got ${buffer.length}`,
+    );
+  }
+  return buffer;
+}
+
+function decodeTransaction(tx: string): Transaction {
+  const bytes = decodeHex(tx, "transaction");
+  let value: unknown;
+  try {
+    ({ value } = cbors.Decoder.decode(bytes));
+  } catch {
+    throw new Error("cardano: invalid transaction, not valid CBOR");
+  }
+  if (!Array.isArray(value) || value.length !== 4) {
+    throw new TypeError("cardano: invalid transaction, expected a 4-element CBOR array");
+  }
+  if (!(value[1] instanceof Map)) {
+    throw new TypeError("cardano: invalid transaction, witness set is not a CBOR map");
+  }
+  return value as Transaction;
+}
+
+/**
+ * Combine an unsigned crafted Cardano transaction with a device signature to
+ * produce the signed transaction ready for {@link broadcast}.
+ *
+ * Attaches a single vkey witness, matching the CoinModule signing contract (one path → one
+ * signature → one combine). This fully covers single-witness transactions (native and token
+ * sends). Staking and reward-withdrawal transactions additionally require the stake credential's
+ * witness, which the single-signature CoinModule path cannot produce yet — see LIVE-18625
+ * follow-up; the legacy account bridge handles those via the xpub-based multi-witness device flow.
+ *
+ * @param tx unsigned transaction as returned by craftTransaction — hex CBOR of
+ *   [body, witness_set, is_valid, auxiliary_data]. As crafted the witness set is empty; any
+ *   witnesses already present are preserved (combining onto a partially-signed tx).
+ * @param signature hex ed25519 signature (64 bytes) from the device.
+ * @param pubkey hex ed25519 public key (32 bytes); required to build the vkey witness.
+ * @returns the signed transaction as hex CBOR.
+ */
+export function combine(tx: string, signature: string, pubkey?: string): string {
+  if (!pubkey) {
+    throw new Error("cardano: combine requires the signing public key");
+  }
+
+  const signatureBuffer = decodeFixedHex(signature, "signature", ED25519_SIGNATURE_LENGTH);
+  const publicKeyBuffer = decodeFixedHex(pubkey, "public key", ED25519_PUBLIC_KEY_LENGTH);
+
+  const transaction = decodeTransaction(tx);
+  const witnessSet = transaction[1];
+
+  // Add this witness to any already in the set; a freshly crafted transaction
+  // starts empty, but combining onto a partially-signed one must not drop them.
+  const existing = witnessSet.get(VKEY_WITNESS_SET_KEY);
+  if (existing !== undefined && !Array.isArray(existing)) {
+    throw new TypeError("cardano: invalid transaction, vkey witnesses is not a CBOR array");
+  }
+  const vkeyWitnesses = (existing as VKeyWitness[] | undefined) ?? [];
+  vkeyWitnesses.push([publicKeyBuffer, signatureBuffer]);
+  witnessSet.set(VKEY_WITNESS_SET_KEY, vkeyWitnesses);
+
+  return cbors.Encoder.encode(transaction).toString("hex");
+}

--- a/libs/coin-modules/coin-cardano/src/logic/combine.unit.test.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/combine.unit.test.ts
@@ -1,0 +1,223 @@
+import type { StringMemo, TransactionIntent } from "@ledgerhq/coin-module-framework/api/index";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import * as cbors from "@stricahq/cbors";
+import { crypto } from "@stricahq/typhonjs";
+import { getAllTransactionsByKeys } from "../api/fetchTransactions";
+import { getDelegationInfo } from "../api/getDelegationInfo";
+import { fetchNetworkInfo } from "../api/getNetworkInfo";
+import { getProtocolParamsFixture } from "../fixtures/protocolParams";
+import { extractPaymentKeyFromAddress } from "../utils";
+import { combine } from "./combine";
+import { buildUnsignedTransaction } from "./craftTransaction";
+
+jest.mock("../api/fetchTransactions");
+jest.mock("../api/getDelegationInfo");
+jest.mock("../api/getNetworkInfo");
+
+const mockFetchTxs = jest.mocked(getAllTransactionsByKeys);
+const mockGetDelegation = jest.mocked(getDelegationInfo);
+const mockFetchNetworkInfo = jest.mocked(fetchNetworkInfo);
+
+const currency = getCryptoCurrencyById("cardano");
+const SENDER =
+  "addr1q8mgw8geggkl2hs0m6rq3pgt69uxttpqcgu6euxje5tt6plxjtjrnskhhtt03g6l3sr98p9t8mtlajr26vmwjzep77pqxn8cms";
+const RECIPIENT =
+  "addr1qxqm3nxwzf70ke9jqa2zrtrevjznpv6yykptxnv34perjc8a7zgxmpv5pgk4hhhe0m9kfnlsf5pt7d2ahkxaul2zygrq3nura9";
+const PAYMENT_KEY = extractPaymentKeyFromAddress(SENDER);
+
+// Stand-ins for a device witness: a 32-byte ed25519 public key and 64-byte signature.
+const PUBKEY = "cd".repeat(32);
+const SIGNATURE = "ab".repeat(64);
+const VKEY_WITNESS_SET_KEY = 0;
+const POLICY_ID = "a".repeat(56);
+const POOL_HASH = "b".repeat(56);
+
+/**
+ * Assert that combining a signature onto the crafted unsigned tx leaves the body bytes
+ * (hence its hash — what the device signed) unchanged through the cbors decode/re-encode.
+ */
+async function expectBodyPreserved(intent: TransactionIntent<StringMemo>): Promise<void> {
+  const tx = await buildUnsignedTransaction(currency, intent);
+  const { payload, hash } = tx.buildTransaction();
+  const { value } = cbors.Decoder.decode(Buffer.from(combine(payload, SIGNATURE, PUBKEY), "hex"));
+  expect(crypto.hash32(cbors.Encoder.encode(value[0])).toString("hex")).toBe(hash);
+}
+
+function sendIntent(): TransactionIntent<StringMemo> {
+  return {
+    intentType: "transaction",
+    type: "send",
+    sender: SENDER,
+    recipient: RECIPIENT,
+    amount: 2_000_000n,
+    asset: { type: "native" },
+  } as TransactionIntent<StringMemo>;
+}
+
+/** Build a realistic unsigned tx and return its CBOR payload + canonical body hash. */
+async function craftUnsigned(): Promise<{ payload: string; bodyHash: string }> {
+  const tx = await buildUnsignedTransaction(currency, sendIntent());
+  const { payload, hash } = tx.buildTransaction();
+  return { payload, bodyHash: hash };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockFetchNetworkInfo.mockResolvedValue({ protocolParams: getProtocolParamsFixture() });
+  mockGetDelegation.mockResolvedValue(undefined);
+  mockFetchTxs.mockResolvedValue({
+    transactions: [
+      {
+        fees: "0",
+        hash: "a",
+        timestamp: "1700000000",
+        blockHeight: 1,
+        inputs: [],
+        certificate: { stakeRegistrations: [], stakeDeRegistrations: [], stakeDelegations: [] },
+        outputs: [{ address: SENDER, value: "10000000", paymentKey: PAYMENT_KEY, tokens: [] }],
+      },
+    ],
+    blockHeight: 1,
+  });
+});
+
+describe("combine", () => {
+  it("injects the vkey witness into the unsigned transaction's witness set", async () => {
+    const { payload } = await craftUnsigned();
+
+    const signedHex = combine(payload, SIGNATURE, PUBKEY);
+
+    const { value } = cbors.Decoder.decode(Buffer.from(signedHex, "hex"));
+    const witnessSet = value[1] as Map<number, [Buffer, Buffer][]>;
+    const vkeyWitnesses = witnessSet.get(VKEY_WITNESS_SET_KEY);
+
+    expect(vkeyWitnesses).toHaveLength(1);
+    expect(vkeyWitnesses?.[0][0].toString("hex")).toBe(PUBKEY);
+    expect(vkeyWitnesses?.[0][1].toString("hex")).toBe(SIGNATURE);
+  });
+
+  it("appends to existing witnesses when combining onto a partially-signed transaction", async () => {
+    const { payload } = await craftUnsigned();
+    const PUBKEY_2 = "ef".repeat(32);
+    const SIGNATURE_2 = "12".repeat(64);
+
+    // Combine onto an already-combined (partially-signed) payload — the first witness must survive.
+    const onceSigned = combine(payload, SIGNATURE, PUBKEY);
+    const twiceSigned = combine(onceSigned, SIGNATURE_2, PUBKEY_2);
+
+    const { value } = cbors.Decoder.decode(Buffer.from(twiceSigned, "hex"));
+    const witnessSet = value[1] as Map<number, [Buffer, Buffer][]>;
+    const vkeyWitnesses = witnessSet.get(VKEY_WITNESS_SET_KEY);
+
+    expect(vkeyWitnesses).toHaveLength(2);
+    expect(vkeyWitnesses?.[0][0].toString("hex")).toBe(PUBKEY); // original witness preserved
+    expect(vkeyWitnesses?.[0][1].toString("hex")).toBe(SIGNATURE);
+    expect(vkeyWitnesses?.[1][0].toString("hex")).toBe(PUBKEY_2); // new one appended
+    expect(vkeyWitnesses?.[1][1].toString("hex")).toBe(SIGNATURE_2);
+  });
+
+  it("preserves the transaction body so the signed hash still matches what was signed", async () => {
+    const { payload, bodyHash } = await craftUnsigned();
+
+    const signedHex = combine(payload, SIGNATURE, PUBKEY);
+
+    const { value } = cbors.Decoder.decode(Buffer.from(signedHex, "hex"));
+    const reencodedBodyHash = crypto.hash32(cbors.Encoder.encode(value[0])).toString("hex");
+    expect(reencodedBodyHash).toBe(bodyHash);
+    expect(value[2]).toBe(true); // is_valid is untouched
+  });
+
+  // The body hash is what the device signs, so cbors decode→re-encode must be byte-faithful for
+  // every transaction shape, not just a bare native send — token multiasset maps, staking
+  // certificates and memo auxiliary-data all add structure to the body.
+  it("preserves the body for a token transfer", async () => {
+    mockFetchTxs.mockResolvedValue({
+      transactions: [
+        {
+          fees: "0",
+          hash: "a",
+          timestamp: "1700000000",
+          blockHeight: 1,
+          inputs: [],
+          certificate: { stakeRegistrations: [], stakeDeRegistrations: [], stakeDelegations: [] },
+          outputs: [
+            {
+              address: SENDER,
+              value: "10000000",
+              paymentKey: PAYMENT_KEY,
+              tokens: [{ policyId: POLICY_ID, assetName: "abcd", value: "100" }],
+            },
+          ],
+        },
+      ],
+      blockHeight: 1,
+    });
+
+    await expectBodyPreserved({
+      ...sendIntent(),
+      amount: 100n,
+      asset: { type: "token", assetReference: `${POLICY_ID}abcd` },
+    } as TransactionIntent<StringMemo>);
+  });
+
+  it("preserves the body for a staking delegation (certificates)", async () => {
+    await expectBodyPreserved({
+      intentType: "staking",
+      type: "delegate",
+      sender: SENDER,
+      recipient: SENDER,
+      amount: 0n,
+      asset: { type: "native" },
+      mode: "delegate",
+      valAddress: POOL_HASH,
+    } as TransactionIntent<StringMemo>);
+  });
+
+  it("preserves the body for a send with a memo (auxiliary data)", async () => {
+    await expectBodyPreserved({
+      ...sendIntent(),
+      memo: { type: "string", value: "gm" },
+    } as TransactionIntent<StringMemo>);
+  });
+
+  // The signature/public-key cases never reach tx decoding (validation runs
+  // first), so a dummy "00" tx suffices; the tx cases pass a valid SIGNATURE/PUBKEY.
+  // 0x82 is a CBOR array header announcing two items, with none following.
+  it.each<[string, string, string, string | undefined, string]>([
+    ["the public key is missing", "00", SIGNATURE, undefined, "requires the signing public key"],
+    ["the signature length is wrong", "00", "ab".repeat(32), PUBKEY, "invalid signature length"],
+    [
+      "the public key length is wrong",
+      "00",
+      SIGNATURE,
+      "cd".repeat(16),
+      "invalid public key length",
+    ],
+    ["the signature is not hex", "00", "zz".repeat(64), PUBKEY, "signature is not valid hex"],
+    ["the transaction is not hex", "nothex", SIGNATURE, PUBKEY, "transaction is not valid hex"],
+    ["the transaction is not CBOR", "82", SIGNATURE, PUBKEY, "not valid CBOR"],
+    [
+      "the transaction is not a 4-element array",
+      cbors.Encoder.encode([1, 2]).toString("hex"),
+      SIGNATURE,
+      PUBKEY,
+      "expected a 4-element CBOR array",
+    ],
+    [
+      "the witness set is not a map",
+      cbors.Encoder.encode([new Map(), [], true, null]).toString("hex"),
+      SIGNATURE,
+      PUBKEY,
+      "witness set is not a CBOR map",
+    ],
+    [
+      "the vkey witnesses are not an array",
+      cbors.Encoder.encode([new Map(), new Map([[0, "not-an-array"]]), true, null]).toString("hex"),
+      SIGNATURE,
+      PUBKEY,
+      "vkey witnesses is not a CBOR array",
+    ],
+  ])("rejects when %s", (_label, tx, signature, pubkey, expected) => {
+    expect(() => combine(tx, signature, pubkey)).toThrow(expected);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4354,6 +4354,9 @@ importers:
       '@stricahq/bip32ed25519':
         specifier: ^1.0.3
         version: 1.0.4
+      '@stricahq/cbors':
+        specifier: 1.0.2
+        version: 1.0.2
       '@stricahq/typhonjs':
         specifier: ^3.0.0
         version: 3.0.0


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Real-CBOR unit tests: witness injection, body-hash preservation across native/token/staking/memo shapes (the body is what the device signs), and malformed-input rejection (bad hex, non-CBOR, wrong array shape, non-map witness set, wrong signature/pubkey length); plus a mocked API-level delegation test.
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Cardano CoinModule API only.

### 📝 Description

Implements `combine(tx, signature, pubkey)` for the Cardano CoinModule ("Alpaca") API — the step between `craftTransaction` and `broadcast`.

It takes the unsigned crafted transaction (hex CBOR `[body, witness_set, is_valid, aux]`), injects a vkey witness `[pubkey, signature]` into the witness set, and re-encodes to the broadcast-ready signed transaction. CBOR is handled with `@stricahq/cbors` (typhonjs's own codec) so the body round-trips byte-for-byte and the signed hash stays valid.

- **`pubkey` is required** — a Cardano vkey witness is the `(pubkey, signature)` pair.
- Validates signature/public-key length and rejects malformed `tx` (bad hex, non-CBOR, wrong shape) with actionable errors; preserves any witnesses already present (partial-sign safe).

**Dependency — `@stricahq/cbors`.** Already a transitive dependency of `@stricahq/typhonjs` (coin-cardano's existing dep), pinned to the exact same `1.0.2`, so promoting it to a direct dependency adds **zero** bundle weight — it's the very codec Typhon uses to build the body, which is why decode→re-encode round-trips byte-for-byte and keeps the signed hash valid. Pinned exact (no caret) so it can't drift away from the version Typhon resolves.

**Known limitation — staking/withdrawal need multiple witnesses.** `combine` attaches a single vkey witness, matching the CoinModule signing contract (one derivation path → one signature → one `combine`) — the same shape as every other coin-module's `combine`. This fully covers single-witness transactions (**native and token sends**). A **staking or reward-withdrawal** transaction additionally requires the **stake credential's** witness, which the single-signature CoinModule sign path cannot produce; the legacy account bridge handles those because it is xpub-based and the device returns one witness per derivation path. Supporting staking through the CoinModule path needs framework-level multi-witness signing (or gating staking intents) — tracked as a follow-up on the "wire Cardano into the generic coin-framework" work. No live impact today (Cardano is not yet wired into the generic bridge).

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:
- https://ledgerhq.atlassian.net/browse/LIVE-18625


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


