### PR TITLE
test(LIVE-28107): adopt tests

### DIFF
--- a/.changeset/swift-forks-give.md
+++ b/.changeset/swift-forks-give.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-mobile-e2e-tests": patch
+---
+
+Update data-testId

--- a/e2e/mobile/page/liveApps/swapLiveApp.ts
+++ b/e2e/mobile/page/liveApps/swapLiveApp.ts
@@ -26,7 +26,8 @@ export default class SwapLiveAppPage {
   incompatibilityBannerPartnerId = "incompatibility-banner-partner";
   swapMainContainerCssSelector = "main";
   swapMainContainerWebElement = getWebElementByCssSelector(this.swapMainContainerCssSelector);
-  swapMaxToggle = "mobile-keyboard-percentage-max";
+  percentageToggle = (percent: "25%" | "50%" | "75%" | "max") =>
+    `mobile-keyboard-percentage-${percent}`;
   switchButton = "to-account-switch-accounts";
   lnsUnsupportedBannerPattern =
     /Ledger Nano S[\s\S]*(not supported|unsupported|does not support|not compatible)/i;
@@ -45,10 +46,15 @@ export default class SwapLiveAppPage {
 
   @Step("Expect swap live app page")
   async expectSwapLiveApp() {
-    await waitWebElementByTestId(this.fromSelector);
-    await detoxExpect(getWebElementByTestId(this.fromSelector)).toExist();
-    await detoxExpect(getWebElementByTestId(this.toSelector)).toExist();
-    await detoxExpect(getWebElementByTestId(this.quotesButtonDisabled)).toExist();
+    const required = [
+      this.fromSelector,
+      this.toSelector,
+      ...(["max", "75%", "50%", "25%"] as const).map(this.percentageToggle),
+    ];
+    for (const testId of required) {
+      await waitWebElementByTestId(testId);
+      await detoxExpect(getWebElementByTestId(testId)).toExist();
+    }
   }
 
   @Step("Expect swap live app form")
@@ -333,7 +339,7 @@ export default class SwapLiveAppPage {
 
   @Step("Click on swap max")
   async clickSwapMax() {
-    await tapWebElementByTestId(this.swapMaxToggle);
+    await tapWebElementByTestId(this.percentageToggle("max"));
     await waitForWebElementToMatchRegex(app.swapLiveApp.toAmountInput, floatNumberRegex);
   }
 

--- a/e2e/mobile/page/liveApps/swapLiveApp.ts
+++ b/e2e/mobile/page/liveApps/swapLiveApp.ts
@@ -26,7 +26,7 @@ export default class SwapLiveAppPage {
   incompatibilityBannerPartnerId = "incompatibility-banner-partner";
   swapMainContainerCssSelector = "main";
   swapMainContainerWebElement = getWebElementByCssSelector(this.swapMainContainerCssSelector);
-  swapMaxToggle = "from-account-max-toggle";
+  swapMaxToggle = "mobile-keyboard-percentage-max";
   switchButton = "to-account-switch-accounts";
   lnsUnsupportedBannerPattern =
     /Ledger Nano S[\s\S]*(not supported|unsupported|does not support|not compatible)/i;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

Update data-testid attributes for custom keyboard

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-28107
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
