### PR TITLE
fix: [react-ui] type useDebouncedCallback timer ref as setTimeout han…

### DIFF
--- a/.changeset/tasty-cheetahs-drum.md
+++ b/.changeset/tasty-cheetahs-drum.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/react-ui": minor
+---
+
+fix: [react-ui] type useDebouncedCallback timer ref as setTimeout handle, init undefined

--- a/libs/ui/packages/react/src/pre-ldls/hooks/useDebouncedCallback.ts
+++ b/libs/ui/packages/react/src/pre-ldls/hooks/useDebouncedCallback.ts
@@ -5,7 +5,7 @@ export function useDebouncedCallback<T extends unknown[]>(
   delay?: number,
 ) {
   const [debouncedCallback, setDebouncedCallback] = useState<(...args: T) => void>();
-  const timeout = useRef<number>(3000);
+  const timeout = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   useEffect(() => {
     if (!callback) return setDebouncedCallback(undefined);


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - None in practice — the ref's value is overwritten before it's ever meaningfully read, so debounce behavior is unchanged. The only difference is removing a harmless clearTimeout(3000) on first call. It's a type-correctness/safety cleanup, not a functional change.

### 📝 Description

## What

Fix the `timeout` ref in `useDebouncedCallback` (react/ui): type it as `ReturnType<typeof setTimeout> | undefined` initialized to `undefined`, instead of `number` initialized to `3000`.

## Why

The ref only ever holds a `setTimeout` handle (written on L15, cleared on L14/L18) — it's never read as a value. The old `3000` was meaningless and caused `clearTimeout(3000)` to run on the first invocation, risking cancellation of an unrelated timer. `clearTimeout(undefined)` is a guaranteed no-op, and the new type is portable across DOM/Node. This also aligns react with the existing native implementation.

No behavior change beyond removing that first-call edge case.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
