### PR TITLE
[LWM] feat(mobile): filter Send crypto account list by asset networks

### DIFF
--- a/.changeset/tidy-spoons-camp.md
+++ b/.changeset/tidy-spoons-camp.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Filter the Asset Detail "Send crypto" flow by the asset's networks: the "Account to debit" screen now lists only accounts holding the asset across all of its networks (e.g. both USDT accounts on Ethereum and Algorand), reusing the multi-network `ledgerIds` resolved for the Receive flow, instead of showing the full unfiltered account list.

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/SendFundsNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/SendFundsNavigator.ts
@@ -51,6 +51,12 @@ export type SendFundsNavigatorStackParamList = {
     | {
         currency?: string;
         selectedCurrency?: CryptoCurrency | TokenCurrency;
+        /**
+         * Ledger currency ids to filter the account list by. Covers every network
+         * of a multi-network asset (e.g. all USDT networks), unlike the single
+         * `selectedCurrency`. When set, takes precedence over `selectedCurrency`.
+         */
+        currencyIds?: string[];
         next?: string;
         category?: string;
         notEmptyAccounts?: boolean;

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/__integrations__/TransferDrawer.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/__integrations__/TransferDrawer.integration.test.tsx
@@ -1,4 +1,5 @@
 import { renderHook } from "@tests/test-renderer";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { useTransferDrawerViewModel } from "../useTransferDrawerViewModel";
 import { NavigatorName, ScreenName } from "~/const";
 import { track } from "~/analytics";
@@ -9,11 +10,9 @@ import type { useOpenReceiveDrawer } from "LLM/features/Receive";
 
 const mockNavigate = jest.fn();
 const mockHandleOpenReceiveDrawer = jest.fn();
-const mockUseOpenReceiveDrawer = jest.fn(
-  (..._args: Parameters<typeof useOpenReceiveDrawer>) => ({
-    handleOpenReceiveDrawer: mockHandleOpenReceiveDrawer,
-  }),
-);
+const mockUseOpenReceiveDrawer = jest.fn((..._args: Parameters<typeof useOpenReceiveDrawer>) => ({
+  handleOpenReceiveDrawer: mockHandleOpenReceiveDrawer,
+}));
 
 jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
   useAccountBridge: jest.fn(),
@@ -80,6 +79,20 @@ describe("TransferDrawer Navigation", () => {
     });
   });
 
+  it("send forwards selectedCurrency and currencyIds when opened from an asset", () => {
+    const currency = getCryptoCurrencyById("ethereum");
+    const ledgerIds = ["ethereum", "arbitrum", "base"];
+
+    const { result } = renderViewModel({ currency, ledgerIds });
+
+    findAction(result, "send").onPress();
+
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.SendFunds, {
+      screen: ScreenName.SendCoin,
+      params: { selectedCurrency: currency, currencyIds: ledgerIds },
+    });
+  });
+
   it("bank_transfer navigates to ReceiveFunds/ReceiveProvider with noah manifest and tracks", () => {
     const { result } = renderViewModel();
 
@@ -111,11 +124,7 @@ describe("TransferDrawer Navigation", () => {
   });
 
   it("forwards ledgerIds to useOpenReceiveDrawer for multi-network pre-selection", () => {
-    const ledgerIds = [
-      "ethereum/erc20/usd_coin",
-      "polygon/erc20/usd_coin",
-      "base/erc20/usd_coin",
-    ];
+    const ledgerIds = ["ethereum/erc20/usd_coin", "polygon/erc20/usd_coin", "base/erc20/usd_coin"];
 
     renderViewModel({ ledgerIds });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/useTransferDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/useTransferDrawerViewModel.ts
@@ -91,10 +91,21 @@ export const useTransferDrawerViewModel = ({
       page: sourceScreenName,
     });
     closeDrawer();
-    navigation.navigate(NavigatorName.SendFunds, {
-      screen: ScreenName.SendCoin,
-    });
-  }, [closeDrawer, navigation, sourceScreenName]);
+    // When opened from an asset, filter the account list to that asset.
+    // `currencyIds` covers every network of a multi-network asset (e.g. USDT on
+    // Ethereum + Tron), which a single `selectedCurrency` cannot. Without a
+    // currency (generic transfer entry) we keep the unfiltered list.
+    if (currency) {
+      navigation.navigate(NavigatorName.SendFunds, {
+        screen: ScreenName.SendCoin,
+        params: { selectedCurrency: currency, currencyIds: ledgerIds },
+      });
+    } else {
+      navigation.navigate(NavigatorName.SendFunds, {
+        screen: ScreenName.SendCoin,
+      });
+    }
+  }, [closeDrawer, navigation, sourceScreenName, currency, ledgerIds]);
 
   const handleBankTransferPress = useCallback(() => {
     track("button_clicked", {

--- a/apps/ledger-live-mobile/src/screens/SelectAccount.tsx
+++ b/apps/ledger-live-mobile/src/screens/SelectAccount.tsx
@@ -32,6 +32,7 @@ function ReceiveFunds({ navigation, route }: Props) {
   const {
     selectedCurrency,
     currency: initialCurrencySelected,
+    currencyIds,
     next,
     category,
     notEmptyAccounts,
@@ -42,6 +43,15 @@ function ReceiveFunds({ navigation, route }: Props) {
 
   const accounts = useSelector(accountsSelector);
   const enhancedAccounts = useMemo(() => {
+    // Filter by an explicit list of ledger currency ids: keeps every account
+    // (token sub-accounts included) holding one of the asset's networks, so a
+    // multi-network asset (e.g. USDT on Ethereum + Tron) shows all its accounts.
+    if (currencyIds?.length) {
+      const idSet = new Set(currencyIds);
+      return flattenAccounts(accounts).filter(acc =>
+        idSet.has(acc.type === "TokenAccount" ? acc.token.id : acc.currency.id),
+      );
+    }
     if (selectedCurrency) {
       const filteredAccounts = accounts.filter(
         acc =>
@@ -63,8 +73,14 @@ function ReceiveFunds({ navigation, route }: Props) {
       return flattenAccounts(filteredAccounts);
     }
     return flattenAccounts(accounts);
-  }, [accounts, selectedCurrency]);
-  const mainAccounts = enhancedAccounts.filter((a): a is Account => a.type === "Account");
+  }, [accounts, selectedCurrency, currencyIds]);
+  // Resolve the parent (main) accounts of everything displayed — including token
+  // sub-accounts whose parent is not itself in the list (the `currencyIds` case)
+  // — so the `notEmptyAccounts` filter below can read each account's bridge.
+  const parentAccountIds = new Set(
+    enhancedAccounts.map(a => (a.type === "Account" ? a.id : a.parentId)),
+  );
+  const mainAccounts = accounts.filter((a): a is Account => parentAccountIds.has(a.id));
   const bridges = useAccountBridgeMany(mainAccounts);
   const bridgeById = new Map(mainAccounts.map((a, i) => [a.id, bridges[i]]));
   const allAccounts = notEmptyAccounts

--- a/apps/ledger-live-mobile/src/screens/__tests__/SelectAccount.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/__tests__/SelectAccount.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
-import {
-  genAccount,
-  genTokenAccount,
-} from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import BigNumber from "bignumber.js";
+import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
 import { setSupportedCurrencies } from "@ledgerhq/live-common/currencies/index";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
@@ -12,9 +10,9 @@ import SelectAccount from "../SelectAccount";
 import type { State } from "~/reducers/types";
 
 jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => {
-  const {
-    defaultIsAccountEmpty,
-  } = jest.requireActual("@ledgerhq/live-common/bridge/defaultBridgeExtensions");
+  const { defaultIsAccountEmpty } = jest.requireActual(
+    "@ledgerhq/live-common/bridge/defaultBridgeExtensions",
+  );
   return {
     useAccountBridge: jest.fn(),
     useAccountBridgeOrNull: jest.fn(),
@@ -47,10 +45,13 @@ jest.mock("LLM/features/Send/hooks/useNewSendFlowFeature", () => ({
   }),
 }));
 
-setSupportedCurrencies(["ethereum"]);
+setSupportedCurrencies(["ethereum", "polygon"]);
 
 const ethereum = getCryptoCurrencyById("ethereum");
+const polygon = getCryptoCurrencyById("polygon");
 const usdc = { parentCurrency: ethereum } as unknown as TokenCurrency;
+const usdtEth = { id: "ethereum/erc20/usdt", parentCurrency: ethereum } as unknown as TokenCurrency;
+const usdtPoly = { id: "polygon/erc20/usdt", parentCurrency: polygon } as unknown as TokenCurrency;
 
 const EMPTY_ETH = genAccount("sa-empty-eth", {
   currency: ethereum,
@@ -63,6 +64,19 @@ const FUNDED_ETH = genAccount("sa-funded-eth", {
   subAccountsCount: 0,
 });
 const FUNDED_TOKEN = genTokenAccount(0, FUNDED_ETH, usdc);
+
+const ETH_PARENT = genAccount("sa-eth-parent", {
+  currency: ethereum,
+  operationsSize: 5,
+  subAccountsCount: 0,
+});
+const POLY_PARENT = genAccount("sa-poly-parent", {
+  currency: polygon,
+  operationsSize: 5,
+  subAccountsCount: 0,
+});
+const USDT_ETH = genTokenAccount(0, ETH_PARENT, usdtEth);
+const USDT_POLY = genTokenAccount(0, POLY_PARENT, usdtPoly);
 
 function makeRoute(params: Record<string, unknown> = {}) {
   return {
@@ -135,5 +149,57 @@ describe("SelectAccount — notEmptyAccounts filter via bridge", () => {
 
     expect(screen.queryByTestId(`account-${FUNDED_ETH.id}`)).not.toBeNull();
     expect(screen.queryByTestId(`account-${FUNDED_TOKEN.id}`)).not.toBeNull();
+  });
+});
+
+describe("SelectAccount — currencyIds multi-network filter", () => {
+  it("keeps only accounts matching one of the currencyIds, across networks", () => {
+    render(
+      <SelectAccount
+        // oxlint-disable-next-line typescript/no-explicit-any
+        navigation={makeNavigation() as any}
+        // oxlint-disable-next-line typescript/no-explicit-any
+        route={makeRoute({ currencyIds: [usdtEth.id, usdtPoly.id] }) as any}
+      />,
+      {
+        overrideInitialState: withAccounts([
+          { ...ETH_PARENT, subAccounts: [USDT_ETH] },
+          { ...POLY_PARENT, subAccounts: [USDT_POLY] },
+        ]),
+      },
+    );
+
+    expect(screen.getByTestId(`account-${USDT_ETH.id}`)).toBeVisible();
+    expect(screen.getByTestId(`account-${USDT_POLY.id}`)).toBeVisible();
+    expect(screen.queryByTestId(`account-${ETH_PARENT.id}`)).toBeNull();
+    expect(screen.queryByTestId(`account-${POLY_PARENT.id}`)).toBeNull();
+  });
+
+  it("still filters empty token accounts via their parent bridge when notEmptyAccounts is set", () => {
+    const EMPTY_USDT_POLY = {
+      ...USDT_POLY,
+      operations: [],
+      operationsCount: 0,
+      balance: new BigNumber(0),
+      spendableBalance: new BigNumber(0),
+    };
+
+    render(
+      <SelectAccount
+        // oxlint-disable-next-line typescript/no-explicit-any
+        navigation={makeNavigation() as any}
+        // oxlint-disable-next-line typescript/no-explicit-any
+        route={makeRoute({ currencyIds: [usdtEth.id, usdtPoly.id], notEmptyAccounts: true }) as any}
+      />,
+      {
+        overrideInitialState: withAccounts([
+          { ...ETH_PARENT, subAccounts: [USDT_ETH] },
+          { ...POLY_PARENT, subAccounts: [EMPTY_USDT_POLY] },
+        ]),
+      },
+    );
+
+    expect(screen.getByTestId(`account-${USDT_ETH.id}`)).toBeVisible();
+    expect(screen.queryByTestId(`account-${EMPTY_USDT_POLY.id}`)).toBeNull();
   });
 });


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Asset Detail → Transfer drawer → "Send crypto" for a multi-network token (e.g. USDT held on Ethereum + Algorand/Tron): the "Account to debit" screen should list all accounts of that asset across every network it lives on.
  - Native multi-network asset (e.g. ETH with L2s): only the native accounts across those networks are listed.
  - Generic Transfer/Send entry point (not opened from an asset): the account list stays unfiltered — verify no regression.
  - After selecting an account, the rest of the send flow (recipient → amount → summary) still works, and the new-send-flow feature flag is respected.
  - `notEmptyAccounts` behaviour preserved: empty accounts are still filtered out (including token sub-accounts whose parent account is not itself displayed).

### 📝 Description

When opening **Send crypto** from an asset's detail page, the "Account to debit" screen previously showed the **full, unfiltered** account list even though the user came from a specific asset. For multi-network assets (e.g. USDT on Ethereum + Algorand), there was no way to narrow the list down to the accounts actually holding that asset.

This PR reuses the multi-network `ledgerIds` already resolved for the Receive flow and forwards them to the send entry point:

- `useTransferDrawerViewModel.handleSendPress` now passes `{ selectedCurrency, currencyIds: ledgerIds }` to `SendCoin` when the drawer is opened from an asset (and nothing when opened generically, preserving the unfiltered list).
- `SendCoin` route params gain an optional `currencyIds?: string[]`.
- `SelectAccount` ("Account to debit") gains a filtering branch: when `currencyIds` is provided it keeps every account (token sub-accounts included) whose `token.id` / `currency.id` is in the list, i.e. all networks of the asset. It falls back to the single `selectedCurrency` (or the unfiltered list) when `currencyIds` is absent. The `notEmptyAccounts` bridge filter now derives main accounts from the parents of everything displayed, so token sub-accounts are filtered correctly even when their parent is not listed.

https://github.com/user-attachments/assets/e70f7fc6-50f2-4e8b-9d1a-78f20cbf23c4


### ❓ Context

- **JIRA or GitHub link**: [LIVE-31241](https://ledgerhq.atlassian.net/browse/LIVE-31241)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31241]: https://ledgerhq.atlassian.net/browse/LIVE-31241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ