### PR TITLE
[LWDM] fix(zcash): total balance calculation [LIVE-31284]

### DIFF
--- a/.changeset/shiny-maps-shake.md
+++ b/.changeset/shiny-maps-shake.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-bitcoin": patch
+"ledger-live-desktop": patch
+---
+
+Add private balance on the account's total balance

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/AccountBalanceSummaryFooter.tsx
@@ -370,9 +370,9 @@ const AccountBalanceSummaryFooter = ({ account }: Props) => {
     locale,
   };
 
-  const _transparentBalance = balance ?? BigNumber(0);
+  const _availableBalance = balance ?? BigNumber(0);
   const _privateBalance = orchardBalance.plus(saplingBalance);
-  const _availableBalance = _transparentBalance.plus(_privateBalance);
+  const _transparentBalance = _availableBalance.minus(_privateBalance);
 
   const transparentBalanceLabel = formatCurrencyUnit(unit, _transparentBalance, formatConfig);
   const privateBalanceLabel = formatCurrencyUnit(unit, _privateBalance, formatConfig);

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/types.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/types.ts
@@ -38,7 +38,7 @@ export interface ChainAdapter {
    * off-transparent funds (e.g. Zcash shielded notes) to produce the account
    * balance. Omit to use the transparent balance unchanged.
    */
-  computeTransparentBalance?(
+  computeAccountBalance?(
     account: BitcoinAccount | undefined,
     transparentBalance: BigNumber,
   ): BigNumber;

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/types.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/types.ts
@@ -33,6 +33,16 @@ export interface ChainAdapter {
     syncConfig: SyncConfig,
   ): Observable<Partial<BitcoinAccount>> | undefined;
 
+  /**
+   * Combine the freshly-synced transparent balance with any chain-specific
+   * off-transparent funds (e.g. Zcash shielded notes) to produce the account
+   * balance. Omit to use the transparent balance unchanged.
+   */
+  computeTransparentBalance?(
+    account: BitcoinAccount | undefined,
+    transparentBalance: BigNumber,
+  ): BigNumber;
+
   /** Serialize chain-specific account fields into their raw form. */
   assignToAccountRaw?(account: Account, accountRaw: AccountRaw): void;
 

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/adapter.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/adapter.test.ts
@@ -1,6 +1,6 @@
 import BigNumber from "bignumber.js";
 import type { Account } from "@ledgerhq/types-live";
-import type { TransactionStatus } from "../../../types";
+import type { BitcoinAccount, TransactionStatus } from "../../../types";
 import type { SignerContext } from "../../../signer";
 import type {
   ZcashTransferType,
@@ -327,6 +327,25 @@ describe("zcash chain adapter — transaction routing", () => {
 
       expect(result.estimatedFees.toNumber()).toBe(10_000);
       expect(result.totalSpent.toNumber()).toBe(110_000);
+    });
+  });
+
+  // ── computeTransparentBalance ──────────────────────────────────────
+
+  describe("computeTransparentBalance", () => {
+    it("returns transparent + private (orchard + sapling)", () => {
+      const account = makeZcashAccount({
+        orchardBalance: new BigNumber(5_000),
+        saplingBalance: new BigNumber(2_000),
+      }) as unknown as BitcoinAccount;
+      const result = adapter.computeTransparentBalance!(account, new BigNumber(10_000));
+      expect(result).toEqual(new BigNumber(17_000));
+    });
+
+    it("returns the transparent balance when there is no privateInfo", () => {
+      const account = { currency: { id: "zcash" } } as unknown as BitcoinAccount;
+      const result = adapter.computeTransparentBalance!(account, new BigNumber(10_000));
+      expect(result).toEqual(new BigNumber(10_000));
     });
   });
 

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/adapter.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/adapter.test.ts
@@ -330,21 +330,21 @@ describe("zcash chain adapter — transaction routing", () => {
     });
   });
 
-  // ── computeTransparentBalance ──────────────────────────────────────
+  // ── computeAccountBalance ──────────────────────────────────────
 
-  describe("computeTransparentBalance", () => {
+  describe("computeAccountBalance", () => {
     it("returns transparent + private (orchard + sapling)", () => {
       const account = makeZcashAccount({
         orchardBalance: new BigNumber(5_000),
         saplingBalance: new BigNumber(2_000),
       }) as unknown as BitcoinAccount;
-      const result = adapter.computeTransparentBalance!(account, new BigNumber(10_000));
+      const result = adapter.computeAccountBalance!(account, new BigNumber(10_000));
       expect(result).toEqual(new BigNumber(17_000));
     });
 
     it("returns the transparent balance when there is no privateInfo", () => {
       const account = { currency: { id: "zcash" } } as unknown as BitcoinAccount;
-      const result = adapter.computeTransparentBalance!(account, new BigNumber(10_000));
+      const result = adapter.computeAccountBalance!(account, new BigNumber(10_000));
       expect(result).toEqual(new BigNumber(10_000));
     });
   });

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/balance.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/balance.test.ts
@@ -1,0 +1,43 @@
+import { BigNumber } from "bignumber.js";
+import { computeZcashBalance, getPrivateBalance, getTransparentBalance } from "../balance";
+
+describe("getTransparentBalance", () => {
+  it("returns 0 when there are no utxos", () => {
+    expect(getTransparentBalance(undefined)).toEqual(new BigNumber(0));
+    expect(getTransparentBalance([])).toEqual(new BigNumber(0));
+  });
+
+  it("sums the value of all utxos", () => {
+    const utxos = [{ value: new BigNumber(1000) }, { value: new BigNumber(2500) }];
+    expect(getTransparentBalance(utxos)).toEqual(new BigNumber(3500));
+  });
+});
+
+describe("getPrivateBalance", () => {
+  it("returns 0 when privateInfo is missing", () => {
+    expect(getPrivateBalance(undefined)).toEqual(new BigNumber(0));
+    expect(getPrivateBalance(null)).toEqual(new BigNumber(0));
+  });
+
+  it("sums orchard and sapling balances", () => {
+    const privateInfo = {
+      orchardBalance: new BigNumber(5000),
+      saplingBalance: new BigNumber(2000),
+    };
+    expect(getPrivateBalance(privateInfo)).toEqual(new BigNumber(7000));
+  });
+});
+
+describe("computeZcashBalance", () => {
+  it("returns the transparent balance when there is no private balance", () => {
+    expect(computeZcashBalance(new BigNumber(4200), undefined)).toEqual(new BigNumber(4200));
+  });
+
+  it("returns transparent + private", () => {
+    const privateInfo = {
+      orchardBalance: new BigNumber(5000),
+      saplingBalance: new BigNumber(2000),
+    };
+    expect(computeZcashBalance(new BigNumber(10000), privateInfo)).toEqual(new BigNumber(17000));
+  });
+});

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/sync.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/sync.test.ts
@@ -36,14 +36,27 @@ beforeEach(() => {
 });
 
 describe("reduceShieldedSyncResult", () => {
-  const createMockInfo = (overrides?: Partial<ZcashAccount>): any => ({
-    currency: getCryptoCurrencyById("zcash"),
-    address: "zs1test",
-    index: 0,
-    derivationPath: "44'/133'/0'/0'",
-    derivationMode: 0,
-    initialAccount: overrides || undefined,
-  });
+  const createMockInfo = (overrides?: Partial<ZcashAccount>): any => {
+    // `account.balance` now holds the transparent + private total. The transparent
+    // portion is derived from the account's UTXOs, so back the provided `balance`
+    // override with a single matching UTXO to represent the transparent balance.
+    const transparent = overrides?.balance ?? new BigNumber(0);
+    return {
+      currency: getCryptoCurrencyById("zcash"),
+      address: "zs1test",
+      index: 0,
+      derivationPath: "44'/133'/0'/0'",
+      derivationMode: 0,
+      initialAccount: overrides
+        ? {
+            ...overrides,
+            bitcoinResources: overrides.bitcoinResources ?? {
+              utxos: transparent.gt(0) ? [{ value: transparent }] : [],
+            },
+          }
+        : undefined,
+    };
+  };
 
   it("should return accumulated with blockHeight when no new transactions", () => {
     const accumulated = {
@@ -131,7 +144,7 @@ describe("reduceShieldedSyncResult", () => {
     expect(output.accountUpdate.privateInfo?.orchardBalance).toEqual(new BigNumber(0));
   });
 
-  it("should never set balance or spendableBalance on the accountUpdate when processing shielded transactions", () => {
+  it("should set balance to transparent + private and leave spendableBalance unset when processing shielded transactions", () => {
     const incomingTx: ShieldedTransaction = {
       id: "tx1",
       hex: "00",
@@ -160,7 +173,8 @@ describe("reduceShieldedSyncResult", () => {
 
     const output = reduceShieldedSyncResult(accumulated, result, info, "acc-1");
 
-    expect(output.accountUpdate).not.toHaveProperty("balance");
+    // balance = transparent(100000) + orchard(50000) = 150000; spendableBalance left to jsHelpers
+    expect(output.accountUpdate.balance).toEqual(new BigNumber(150000));
     expect(output.accountUpdate).not.toHaveProperty("spendableBalance");
   });
 
@@ -311,7 +325,8 @@ describe("reduceShieldedSyncResult", () => {
     const output = reduceShieldedSyncResult(accumulated, result, info, "acc-1");
 
     expect(output.accountUpdate.privateInfo?.orchardBalance).toEqual(incomingAmount);
-    expect(output.accountUpdate).not.toHaveProperty("balance");
+    // balance = transparent(100000) + orchard(5000)
+    expect(output.accountUpdate.balance).toEqual(initialBalance.plus(incomingAmount));
     expect(output.accountUpdate).not.toHaveProperty("spendableBalance");
   });
 
@@ -378,7 +393,8 @@ describe("reduceShieldedSyncResult", () => {
       "acc-1",
     );
     expect(chunk1.accountUpdate.privateInfo?.orchardBalance).toEqual(new BigNumber(4000));
-    expect(chunk1.accountUpdate).not.toHaveProperty("balance");
+    // balance = transparent(10000) + orchard(4000)
+    expect(chunk1.accountUpdate.balance).toEqual(new BigNumber(14000));
 
     const chunk2 = reduceShieldedSyncResult(
       chunk1,
@@ -392,7 +408,8 @@ describe("reduceShieldedSyncResult", () => {
       "acc-1",
     );
     expect(chunk2.accountUpdate.privateInfo?.orchardBalance).toEqual(new BigNumber(4500));
-    expect(chunk2.accountUpdate).not.toHaveProperty("balance");
+    // balance = transparent(10000) + orchard(4500)
+    expect(chunk2.accountUpdate.balance).toEqual(new BigNumber(14500));
   });
 
   it("should populate privateInfo in accountUpdate", () => {
@@ -511,7 +528,8 @@ describe("reduceShieldedSyncResult", () => {
       "acc-1",
     );
     expect(output.accountUpdate.privateInfo?.orchardBalance).toEqual(new BigNumber(1000));
-    expect(output.accountUpdate).not.toHaveProperty("balance");
+    // balance = transparent(100000) + orchard(1000)
+    expect(output.accountUpdate.balance).toEqual(new BigNumber(101000));
   });
 
   it("should compute private deltas for both orchard and sapling notes (LIVE-27917)", () => {
@@ -539,7 +557,8 @@ describe("reduceShieldedSyncResult", () => {
     );
     expect(output.accountUpdate.privateInfo?.orchardBalance).toEqual(new BigNumber(5000));
     expect(output.accountUpdate.privateInfo?.saplingBalance).toEqual(new BigNumber(0));
-    expect(output.accountUpdate).not.toHaveProperty("balance");
+    // balance = transparent(0) + orchard(5000)
+    expect(output.accountUpdate.balance).toEqual(new BigNumber(5000));
   });
 
   it("should credit orchard balance for a transparent→shielded (shielding) tx without touching the transparent balance", () => {
@@ -564,7 +583,8 @@ describe("reduceShieldedSyncResult", () => {
       "acc-1",
     );
     expect(output.accountUpdate.privateInfo?.orchardBalance).toEqual(new BigNumber(9000));
-    expect(output.accountUpdate).not.toHaveProperty("balance");
+    // balance = transparent(50000) + orchard(9000)
+    expect(output.accountUpdate.balance).toEqual(new BigNumber(59000));
   });
 
   it("should debit orchard balance for a shielded→transparent (deshielding) tx without touching the transparent balance", () => {
@@ -589,7 +609,8 @@ describe("reduceShieldedSyncResult", () => {
       "acc-1",
     );
     expect(output.accountUpdate.privateInfo?.orchardBalance).toEqual(new BigNumber(0));
-    expect(output.accountUpdate).not.toHaveProperty("balance");
+    // balance = transparent(50000) + orchard(0)
+    expect(output.accountUpdate.balance).toEqual(new BigNumber(50000));
   });
 
   it("should debit orchard balance for a shielded→shielded (Orchard→Orchard) outgoing tx without touching the transparent balance", () => {
@@ -615,7 +636,8 @@ describe("reduceShieldedSyncResult", () => {
       "acc-1",
     );
     expect(output.accountUpdate.privateInfo?.orchardBalance).toEqual(new BigNumber(1000));
-    expect(output.accountUpdate).not.toHaveProperty("balance");
+    // balance = transparent(100000) + orchard(1000)
+    expect(output.accountUpdate.balance).toEqual(new BigNumber(101000));
   });
 
   it("should filter out already processed operations by blockHash", () => {
@@ -646,10 +668,11 @@ describe("reduceShieldedSyncResult", () => {
       processedBlocks: 0,
       remainingBlocks: 0,
     };
-    const info = createMockInfo();
+    const info = createMockInfo({ balance: new BigNumber(700) });
 
     const output = reduceShieldedSyncResult(accumulated, result, info, "acc-1");
 
+    // balance = transparent(700) + orchard(0)
     expect(output).toMatchObject({
       processedOperations: [tx],
       accountUpdate: {

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/balance.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/balance.ts
@@ -1,0 +1,32 @@
+import { BigNumber } from "bignumber.js";
+import type { BitcoinOutput } from "../../types";
+import type { ZcashPrivateInfo } from "./types";
+
+type PrivateBalances = Pick<ZcashPrivateInfo, "orchardBalance" | "saplingBalance">;
+
+/**
+ * Transparent balance = sum of the account's unspent transparent UTXOs.
+ *
+ * This is kept independent from `account.balance` (which now holds the
+ * transparent + private total) so the two syncs can recompute the total
+ * without double-counting the shielded funds.
+ */
+export function getTransparentBalance(utxos: Pick<BitcoinOutput, "value">[] | undefined): BigNumber {
+  return (utxos ?? []).reduce((sum, utxo) => sum.plus(utxo.value), new BigNumber(0));
+}
+
+/** Private (shielded) balance = orchard + sapling. */
+export function getPrivateBalance(privateInfo: PrivateBalances | undefined | null): BigNumber {
+  if (!privateInfo) return new BigNumber(0);
+  return (privateInfo.orchardBalance ?? new BigNumber(0)).plus(
+    privateInfo.saplingBalance ?? new BigNumber(0),
+  );
+}
+
+/** Total balance shown to the user = transparent + private. */
+export function computeZcashBalance(
+  transparentBalance: BigNumber,
+  privateInfo: PrivateBalances | undefined | null,
+): BigNumber {
+  return transparentBalance.plus(getPrivateBalance(privateInfo));
+}

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/index.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/index.ts
@@ -51,8 +51,11 @@ const zcashChainAdapter: ChainAdapter = {
 
   buildExtraSyncObservable,
 
-  computeTransparentBalance(account: BitcoinAccount | undefined, transparentBalance: BigNumber) {
-    return computeZcashBalance(transparentBalance, (account as ZcashAccount | undefined)?.privateInfo);
+  computeAccountBalance(account: BitcoinAccount | undefined, transparentBalance: BigNumber) {
+    return computeZcashBalance(
+      transparentBalance,
+      (account as ZcashAccount | undefined)?.privateInfo,
+    );
   },
 
   assignToAccountRaw(account: Account, accountRaw: AccountRaw) {
@@ -138,7 +141,8 @@ const zcashChainAdapter: ChainAdapter = {
     } else {
       // Verify selected notes actually cover the spend (consistency check)
       const selectedTotal = tx.selectedNotes.reduce(
-        (sum, n) => sum.plus(n.amount), new BigNumber(0),
+        (sum, n) => sum.plus(n.amount),
+        new BigNumber(0),
       );
       if (selectedTotal.lt(totalSpent)) {
         errors.amount = new Error("Selected notes do not cover amount + fee");

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/index.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/index.ts
@@ -13,6 +13,8 @@ import { buildExtraSyncObservable } from "./sync";
 import { collectSpendableNotes } from "./operations";
 import { selectNotes, estimateMaxSpendableAmount, ZIP317_MINIMUM_FEE } from "./coin-selection";
 import { composeXpub } from "./xpub";
+import { computeZcashBalance } from "./balance";
+import type { BitcoinAccount } from "../../types";
 
 type DmkTransport = {
   dmk: ConstructorParameters<typeof DmkSignerZcash>[0];
@@ -48,6 +50,10 @@ const zcashChainAdapter: ChainAdapter = {
   // ── Sync ────────────────────────────────────────────────────────────
 
   buildExtraSyncObservable,
+
+  computeTransparentBalance(account: BitcoinAccount | undefined, transparentBalance: BigNumber) {
+    return computeZcashBalance(transparentBalance, (account as ZcashAccount | undefined)?.privateInfo);
+  },
 
   assignToAccountRaw(account: Account, accountRaw: AccountRaw) {
     const zcashAccount = account as ZcashAccount;

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/sync.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/sync.ts
@@ -13,6 +13,7 @@ import type { BtcOperation } from "../../types";
 import { removeReplaced } from "../../synchronisation";
 import type { ZcashAccount } from "./types";
 import { convertShieldedTransactionsToOperations, computeBalanceFromNotes } from "./operations";
+import { computeZcashBalance, getTransparentBalance } from "./balance";
 
 // ─── Zcash native sync (formerly familyConfig.ts) ───────────────────────────
 
@@ -124,6 +125,10 @@ export function reduceShieldedSyncResult(
   const processedIds = new Set(accumulated.processedOperations.map(tx => tx.id));
   const newTransactions = result.transactions.filter(tx => !processedIds.has(tx.id));
 
+  // Transparent balance comes from the transparent sync's UTXOs (stable source),
+  // so we can recompute the transparent + private total here without double-counting.
+  const transparentBalance = getTransparentBalance(info.initialAccount?.bitcoinResources?.utxos);
+
   if (newTransactions.length === 0) {
     const totalBlocks = result.processedBlocks + result.remainingBlocks;
     // Even without new transactions, spentKnownNullifiers may mark existing notes as spent.
@@ -145,10 +150,18 @@ export function reduceShieldedSyncResult(
         };
       });
     }
+    const orchardBalance =
+      spentNfs.length > 0
+        ? computeBalanceFromNotes(updatedTransactions)
+        : existingPrivateInfo.orchardBalance;
     return {
       ...accumulated,
       accountUpdate: {
         ...accumulated.accountUpdate,
+        balance: computeZcashBalance(transparentBalance, {
+          orchardBalance,
+          saplingBalance: existingPrivateInfo.saplingBalance,
+        }),
         blockHeight: result.lastProcessedBlock ?? accumulated.accountUpdate.blockHeight ?? 0,
         privateInfo: {
           ...existingPrivateInfo,
@@ -158,10 +171,7 @@ export function reduceShieldedSyncResult(
           lastProcessedBlock: result.lastProcessedBlock ?? null,
           lastSyncTimestamp: Date.now(),
           transactions: updatedTransactions,
-          orchardBalance:
-            spentNfs.length > 0
-              ? computeBalanceFromNotes(updatedTransactions)
-              : existingPrivateInfo.orchardBalance,
+          orchardBalance,
         },
       },
     };
@@ -245,6 +255,7 @@ export function reduceShieldedSyncResult(
     processedOperations: [...result.transactions],
     accountUpdate: {
       ...accumulated.accountUpdate,
+      balance: computeZcashBalance(transparentBalance, { orchardBalance, saplingBalance }),
       operations,
       operationsCount: missingOpsCount + operations.length,
       blockHeight: result.lastProcessedBlock ?? info.initialAccount?.blockHeight ?? 0,

--- a/libs/coin-modules/coin-bitcoin/src/synchronisation.ts
+++ b/libs/coin-modules/coin-bitcoin/src/synchronisation.ts
@@ -354,8 +354,8 @@ export async function performTransparentSync(
   // into `account.balance` via their chain adapter; others use the transparent
   // balance as-is.
   const adapter = getChainAdapter(currency.id);
-  const balance = adapter.computeTransparentBalance
-    ? adapter.computeTransparentBalance(initialAccount, transparentBalance)
+  const balance = adapter.computeAccountBalance
+    ? adapter.computeAccountBalance(initialAccount, transparentBalance)
     : transparentBalance;
 
   return {

--- a/libs/coin-modules/coin-bitcoin/src/synchronisation.ts
+++ b/libs/coin-modules/coin-bitcoin/src/synchronisation.ts
@@ -345,13 +345,24 @@ export async function performTransparentSync(
       ? utxos.filter(utxo => finalOperationHashes.has(utxo.hash))
       : utxos;
 
-  const balance = finalUtxos.reduce((total, utxo) => total.plus(utxo.value), new BigNumber(0));
+  const transparentBalance = finalUtxos.reduce(
+    (total, utxo) => total.plus(utxo.value),
+    new BigNumber(0),
+  );
+
+  // Chains with off-transparent funds (e.g. Zcash shielded notes) combine them
+  // into `account.balance` via their chain adapter; others use the transparent
+  // balance as-is.
+  const adapter = getChainAdapter(currency.id);
+  const balance = adapter.computeTransparentBalance
+    ? adapter.computeTransparentBalance(initialAccount, transparentBalance)
+    : transparentBalance;
 
   return {
     id: accountId,
     xpub,
     balance,
-    spendableBalance: balance,
+    spendableBalance: transparentBalance,
     operations,
     operationsCount: operations.length,
     freshAddress: walletAccount.xpub.freshAddress,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - @ledgerhq/coin-bitcoin
  - ledger-live-desktop

### 📝 Description

Show Zcash total balance correctly on the accounts list and on the Zcash account page.
Previously it was showing just the transparent balance and not the sum of transparent + private balance.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:
https://ledgerhq.atlassian.net/browse/LIVE-31284
https://ledgerhq.atlassian.net/browse/LIVE-31705


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
