### PR TITLE
[LWDM] fix(coin-monitoring): run CLI as ESM for ESM-only live-common

### DIFF
--- a/.changeset/coin-monitoring-esm-loader.md
+++ b/.changeset/coin-monitoring-esm-loader.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-modules-monitoring": patch
+---
+
+Run the monitoring CLI as native ESM and build ESM-only, so it can consume the now ESM-only live-common. Reworked the ESM loader to keep `@ledgerhq/*` resolved as ESM (single `LiveConfig` instance) while patching the bundler-targeted `lib-es` output: extensionless/directory/bare-subpath import resolution, `type: "json"` import attributes, a `require()` shim, and `esModuleInterop` emulation for third-party CommonJS deps.

--- a/libs/coin-modules-monitoring/loader.mjs
+++ b/libs/coin-modules-monitoring/loader.mjs
@@ -1,62 +1,208 @@
-// Problems this loader solves when running CJS code that transitively pulls
-// in @mysten/ledgerjs-hw-app-sui (ESM-only):
-//
-// 1. @ledgerhq/* lib-es files use extensionless relative imports (e.g.
-//    `import './helpers'`) which Node's strict ESM resolver rejects.
-//
-// 2. @ledgerhq/* lib-es files are compiled for bundlers and contain `require()`
-//    calls that are invalid in native ESM context.
-//
-// 3. Some @ledgerhq/* packages (e.g. @ledgerhq/live-dmk-shared) only ship
-//    lib-es/, so the require→CJS swap doesn't apply — and their files contain
-//    directory imports like `export * from "./hooks"` which Node's ESM resolver
-//    rejects with ERR_UNSUPPORTED_DIR_IMPORT.
-//
-// Fix for (1) and (2): when @ledgerhq/* packages are resolved in ESM context,
-// force the `require` condition so Node picks lib/ (CJS) instead of lib-es/.
-//
-// Fix for (3): on ERR_UNSUPPORTED_DIR_IMPORT or ERR_MODULE_NOT_FOUND, retry by
-// appending `/index.js` (directory) or `.js` (extensionless file).
+// Runs the monitoring CLI and its @ledgerhq/* deps under Node's native ESM
+// resolver. Those packages ship bundler-targeted lib-es that breaks Node's
+// strict-ESM rules. We keep @ledgerhq/* as ESM (so a singleton like LiveConfig
+// stays a single instance) and patch the gaps:
+//  - resolve hook: extensionless / directory / bare-subpath imports.
+//  - load hook: missing `type: "json"` attributes, stray `require()` calls, and
+//    esModuleInterop. lib-es is emitted assuming a bundler unwraps CommonJS
+//    default/named exports, which native ESM does not, so we rewrite imports of
+//    third-party CJS deps to require() + the interop helpers tsc would inject.
 
-import { existsSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-function tryResolveAsFileOrDir(url) {
+// --- resolve hook -----------------------------------------------------------
+
+// Try the target as-is, then a sibling `<base>.js`, then `<base>/index.js`.
+// Node reports a missing dir/extensionless import as `<base>/index.js`, so we
+// strip that suffix to also cover a sibling file (e.g. `serialization.js`
+// alongside a `serialization/` dir).
+function tryResolve(targetUrl) {
+  let path;
   try {
-    const path = fileURLToPath(url);
-    if (existsSync(path) && statSync(path).isDirectory()) {
-      const indexUrl = url.endsWith("/") ? `${url}index.js` : `${url}/index.js`;
-      if (existsSync(fileURLToPath(indexUrl))) return indexUrl;
-    }
-    const withJs = `${path}.js`;
-    if (existsSync(withJs)) return pathToFileURL(withJs).href;
+    path = fileURLToPath(targetUrl);
   } catch {
-    // ignore
+    return null;
+  }
+  const base = path.endsWith("/index.js") ? path.slice(0, -"/index.js".length) : path;
+  for (const candidate of [path, `${base}.js`, `${base}/index.js`]) {
+    try {
+      if (existsSync(candidate) && statSync(candidate).isFile()) {
+        return pathToFileURL(candidate).href;
+      }
+    } catch {
+      // ignore
+    }
   }
   return null;
 }
 
 export async function resolve(specifier, context, nextResolve) {
-  // Fix (1)/(2): redirect @ledgerhq/* to CJS path when in ESM import context.
-  if (specifier.startsWith("@ledgerhq/") && context.conditions?.includes("import")) {
-    const conditions = context.conditions.map(c => (c === "import" ? "require" : c));
-    return nextResolve(specifier, { ...context, conditions });
-  }
-
   try {
     return await nextResolve(specifier, context);
   } catch (err) {
-    // Fix (3): handle directory and extensionless relative imports inside
-    // packages whose lib-es files were compiled for bundlers.
-    if (err?.code === "ERR_UNSUPPORTED_DIR_IMPORT" && err.url) {
-      const indexUrl = err.url.endsWith("/") ? `${err.url}index.js` : `${err.url}/index.js`;
-      return nextResolve(indexUrl, context);
-    }
-    if (err?.code === "ERR_MODULE_NOT_FOUND" && specifier.startsWith(".") && context.parentURL) {
-      const baseUrl = new URL(specifier, context.parentURL).href;
-      const fixed = tryResolveAsFileOrDir(baseUrl);
-      if (fixed) return nextResolve(fixed, context);
+    // Recover extensionless/dir/bare-subpath imports. err.url holds the
+    // resolved-but-missing target; reconstruct it for relative specifiers.
+    if (err?.code === "ERR_MODULE_NOT_FOUND" || err?.code === "ERR_UNSUPPORTED_DIR_IMPORT") {
+      const targetUrl =
+        err.url ??
+        (specifier.startsWith(".") && context.parentURL
+          ? new URL(specifier, context.parentURL).href
+          : null);
+      if (targetUrl) {
+        const fixed = tryResolve(targetUrl);
+        if (fixed) return nextResolve(fixed, context);
+      }
     }
     throw err;
   }
+}
+
+// --- load hook --------------------------------------------------------------
+
+const pkgTypeCache = new Map();
+function nearestPackageType(filePath) {
+  let dir = dirname(filePath);
+  for (;;) {
+    if (pkgTypeCache.has(dir)) return pkgTypeCache.get(dir);
+    const pkgPath = join(dir, "package.json");
+    if (existsSync(pkgPath)) {
+      let type;
+      try {
+        type = JSON.parse(readFileSync(pkgPath, "utf8")).type;
+      } catch {
+        type = undefined;
+      }
+      pkgTypeCache.set(dir, type);
+      return type;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return undefined;
+    dir = parent;
+  }
+}
+
+const cjsCache = new Map();
+// A specifier needs interop rewriting when it resolves to a third-party CJS
+// module. We never touch relative imports (our own lib-es, handled at resolve
+// time), node builtins, or @ledgerhq/* (kept as ESM for shared singletons).
+function isThirdPartyCjs(specifier, parentUrl) {
+  if (
+    specifier.startsWith(".") ||
+    specifier.startsWith("/") ||
+    specifier.startsWith("node:") ||
+    specifier.startsWith("@ledgerhq/")
+  ) {
+    return false;
+  }
+  const key = `${parentUrl}|${specifier}`;
+  if (cjsCache.has(key)) return cjsCache.get(key);
+  let result = false;
+  try {
+    const resolved = createRequire(parentUrl).resolve(specifier);
+    if (resolved.endsWith(".mjs") || resolved.endsWith(".json")) result = false;
+    else if (resolved.endsWith(".cjs") || resolved.endsWith(".node")) result = true;
+    else result = nearestPackageType(resolved) !== "module";
+  } catch {
+    result = false;
+  }
+  cjsCache.set(key, result);
+  return result;
+}
+
+function destructureNamed(clause) {
+  return clause
+    .replace(/^\{|\}$/g, "")
+    .split(",")
+    .map(s => s.trim())
+    .filter(Boolean)
+    .map(s => {
+      const m = s.match(/^(.+?)\s+as\s+(.+)$/);
+      return m ? `${m[1]}: ${m[2]}` : s;
+    })
+    .join(", ");
+}
+
+let tmpId = 0;
+// Rewrite a single-line `import` of a third-party CJS dep into require() + the
+// interop helpers tsc emits under esModuleInterop. Returns null to leave a line
+// untouched (ESM dep, our own code, relative import, etc.).
+function rewriteImportLine(line, parentUrl) {
+  const sideEffect = line.match(/^(\s*)import\s+(['"])([^'"]+)\2\s*;?\s*$/);
+  if (sideEffect) {
+    const [, indent, , spec] = sideEffect;
+    return isThirdPartyCjs(spec, parentUrl) ? `${indent}require(${JSON.stringify(spec)});` : null;
+  }
+  const m = line.match(/^(\s*)import\s+(.+?)\s+from\s*(['"])([^'"]+)\3\s*;?\s*$/);
+  if (!m) return null;
+  const [, indent, clause, , spec] = m;
+  if (!isThirdPartyCjs(spec, parentUrl)) return null;
+
+  const req = `require(${JSON.stringify(spec)})`;
+  const c = clause.trim();
+  if (c.startsWith("{")) {
+    return `${indent}const { ${destructureNamed(c)} } = ${req};`;
+  }
+  if (c.startsWith("* as ")) {
+    return `${indent}const ${c.slice(5).trim()} = __interopStar(${req});`;
+  }
+  const comma = c.indexOf(",");
+  if (comma === -1) {
+    return `${indent}const ${c} = __interopDefault(${req});`;
+  }
+  const def = c.slice(0, comma).trim();
+  const rest = c.slice(comma + 1).trim();
+  if (rest.startsWith("* as ")) {
+    return `${indent}const ${rest.slice(5).trim()} = __interopStar(${req}); const ${def} = __interopDefault(${req});`;
+  }
+  const tmp = `__cjs${tmpId++}`;
+  return `${indent}const ${tmp} = ${req}; const ${def} = __interopDefault(${tmp}); const { ${destructureNamed(rest)} } = ${tmp};`;
+}
+
+const PREAMBLE =
+  'import { createRequire as __createRequire } from "node:module";\n' +
+  "const require = __createRequire(import.meta.url);\n" +
+  "const __interopDefault = m => (m && m.__esModule ? m.default : m);\n" +
+  "const __interopStar = m => {\n" +
+  "  if (m && m.__esModule) return m;\n" +
+  "  const r = {};\n" +
+  "  if (m != null) for (const k in m) if (Object.prototype.hasOwnProperty.call(m, k)) r[k] = m[k];\n" +
+  "  r.default = m;\n" +
+  "  return r;\n" +
+  "};\n";
+
+export async function load(url, context, nextLoad) {
+  // Inject the `type: "json"` import attribute Node requires for .json modules.
+  if (url.endsWith(".json")) {
+    return nextLoad(url, {
+      ...context,
+      importAttributes: { ...context.importAttributes, type: "json" },
+    });
+  }
+
+  if (url.startsWith("file:") && url.includes("/lib-es/") && url.endsWith(".js")) {
+    const source = readFileSync(fileURLToPath(url), "utf8");
+    let changed = false;
+    const out = source
+      .split("\n")
+      .map(line => {
+        if (!line.startsWith("import")) return line;
+        const rewritten = rewriteImportLine(line, url);
+        if (rewritten == null) return line;
+        changed = true;
+        return rewritten;
+      })
+      .join("\n");
+
+    // Even without an interop rewrite, lib-es may reference `require()` directly.
+    const needsRequire =
+      changed || (/\brequire\s*\(/.test(source) && !source.includes("createRequire"));
+    if (needsRequire) {
+      return { format: "module", shortCircuit: true, source: PREAMBLE + out };
+    }
+  }
+
+  return nextLoad(url, context);
 }

--- a/libs/coin-modules-monitoring/package.json
+++ b/libs/coin-modules-monitoring/package.json
@@ -5,13 +5,13 @@
   "license": "Apache-2.0",
   "scripts": {
     "clean": "rimraf lib lib-es",
-    "build": "tsc --project tsconfig.build.json && tsc --project tsconfig.build.json -m esnext --moduleResolution bundler --outDir lib-es",
+    "build": "rimraf lib lib-es && tsc --project tsconfig.build.json -m esnext --moduleResolution bundler --outDir lib-es",
     "lint": "eslint .",
     "lint:fix": "pnpm lint --fix",
     "test": "jest",
     "typecheck": "tsc --project ./tsconfig.json --noEmit --customConditions node",
-    "start": "node --import ./register.mjs lib/cli.js",
-    "start:debug": "node --import ./register.mjs --inspect-brk lib/cli.js"
+    "start": "node --import ./register.mjs lib-es/cli.js",
+    "start:debug": "node --import ./register.mjs --inspect-brk lib-es/cli.js"
   },
   "dependencies": {
     "@datadog/datadog-api-client": "^1.40",
@@ -39,23 +39,18 @@
   },
   "typesVersions": {
     "*": {
-      "lib/*": [
-        "lib/*"
-      ],
       "lib-es/*": [
         "lib-es/*"
       ],
       "*": [
-        "lib/*"
+        "lib-es/*"
       ]
     }
   },
   "exports": {
-    "./lib/*": "./lib/*.js",
     "./lib-es/*": "./lib-es/*.js",
     "./*": {
       "@ledgerhq/source": "./src/*.ts",
-      "require": "./lib/*.js",
       "default": "./lib-es/*.js"
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
> [!NOTE]
> Stacked on top of #18028 (live-common ESM-only). Merge into that branch to turn its `coin-modules-monitoring` CI job green.

### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Existing `run.test.ts` passes; validated by running `monitor --currencies all --account-types pristine` end-to-end.
- [ ] **Impact of the changes:** `coin-modules-monitoring` tooling only. No app/runtime impact.

### 📝 Description

#18028 makes live-common **ESM-only**, which broke the `coin-modules-monitoring` CLI (`ERR_MODULE_NOT_FOUND: lodash/memoize`). The CLI ran as CJS and force-loaded every `@ledgerhq/*` as CJS; with live-common having no CJS build anymore, it loaded as native ESM and its bundler-targeted `lib-es` violated Node's strict-ESM rules.

Fix:
- Run the CLI as **native ESM** (`lib-es/cli.js`) and build ESM-only — so `@ledgerhq/*` resolve to a single ESM instance graph (fixes a `LiveConfig` singleton split that surfaced as "Config not set" on ~14 currencies).
- Rework `loader.mjs` to keep `@ledgerhq/*` as ESM and patch the bundler-targeted `lib-es`:
  - resolve extensionless / directory / bare-subpath imports (e.g. `lodash/memoize`)
  - inject the `type: "json"` import attribute Node requires
  - shim `require()` calls left in `lib-es` (e.g. `live-network`)
  - emulate `esModuleInterop` for third-party CJS deps (`lodash/fp`, `@apollo/client`, `bip32`, `casper-js-sdk`, `icon-sdk-js`)

Validated locally: `monitor --currencies all` runs every currency end-to-end (the lone skip was a transient `LedgerAPI4xx: Not Enough CU` API quota on mina, unrelated to module loading). `typecheck` + `jest` pass.


<img width="642" height="274" alt="Screenshot 2026-06-02 at 12 08 29" src="https://github.com/user-attachments/assets/89b43188-d84b-4f0e-92d0-bde0642718c1" />



### ❓ Context

- **JIRA or GitHub link**: LIVE-29648
- **ADR link (if any)**: