### PR TITLE
[LWM] feat(mobile): add transaction markers and timeframes to asset-detail balance graph

### DIFF
--- a/.changeset/quick-pumas-rush.md
+++ b/.changeset/quick-pumas-rush.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add transaction markers, 6m/all timeframes, point tooltips and series downsampling to the asset-detail balance graph

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -9113,16 +9113,25 @@
       "marketPrice": "Market price",
       "timeframeSelector": "Timeframe",
       "timeLabel": {
-        "1d": "1 day",
+        "1d": "24 hours",
         "1w": "1 week",
         "1m": "1 month",
-        "1y": "1 year"
+        "6m": "6 months",
+        "1y": "1 year",
+        "all": "All time"
       },
       "range": {
         "1d": "1D",
         "1w": "1W",
         "1m": "1M",
-        "1y": "1Y"
+        "6m": "6M",
+        "1y": "1Y",
+        "all": "ALL"
+      },
+      "chart": {
+        "received": "Received",
+        "sent": "Sent",
+        "transactionsCount": "{{count}} transactions"
       }
     },
     "addresses": {

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/LineChartPoints.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/LineChartPoints.tsx
@@ -19,10 +19,14 @@ export function LineChartPoints({ points, formatValue }: LineChartPointsProps) {
     <>
       {points.map(marker => (
         <Point
-          key={`${marker.index}-${marker.value}-${marker.labelPosition ?? "top"}`}
+          // `hidePoint`/`color` discriminate markers that share an index, value and
+          // label position (e.g. a transaction dot landing on a min/max marker).
+          key={`${marker.index}-${marker.value}-${marker.labelPosition ?? "top"}-${
+            marker.hidePoint ? "h" : "v"
+          }-${marker.color ?? ""}`}
           dataX={marker.index}
           dataY={marker.value}
-          label={marker.label ?? formatValue(marker.value)}
+          label={marker.hideLabel ? undefined : marker.label ?? formatValue(marker.value)}
           labelPosition={marker.labelPosition ?? "top"}
           hidePoint={marker.hidePoint}
           size={LINE_CHART_POINT_SIZE}

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/LineChartScrubber.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/LineChartScrubber.tsx
@@ -5,7 +5,14 @@ import {
   type ScrubberTooltipContent,
 } from "@ledgerhq/lumen-ui-rnative-visualization";
 import { buildTooltipRow } from "./utils/buildTooltipRow";
-import type { LineChartSeries, LineChartTooltipTitle, LineChartValueFormatter } from "./types";
+import { estimateTooltipMinWidth } from "./utils/estimateTooltipMinWidth";
+import { resolveNearestPointTooltip } from "./utils/resolveNearestPointTooltip";
+import type {
+  LineChartPointTooltip,
+  LineChartSeries,
+  LineChartTooltipTitle,
+  LineChartValueFormatter,
+} from "./types";
 
 type LineChartScrubberProps = Readonly<{
   series: LineChartSeries[];
@@ -13,6 +20,16 @@ type LineChartScrubberProps = Readonly<{
   tooltipTitle?: LineChartTooltipTitle;
   /** Renders the floating tooltip. Beacons/line still render when false. @default true */
   showTooltip?: boolean;
+  /** Renders the beacon dots on the scrubbed data point. @default true */
+  showBeacons?: boolean;
+  /** Tooltip content keyed by data index, consulted when `pointTooltipsOnly` is set. */
+  pointTooltips?: ReadonlyMap<number, LineChartPointTooltip>;
+  /**
+   * Restricts the tooltip to `pointTooltips`: it appears only when the scrubbed index
+   * resolves to a marker, and the standard per-series value tooltip is suppressed.
+   * @default false
+   */
+  pointTooltipsOnly?: boolean;
 }>;
 
 export function LineChartScrubber({
@@ -20,19 +37,46 @@ export function LineChartScrubber({
   formatValue,
   tooltipTitle,
   showTooltip = true,
+  showBeacons = true,
+  pointTooltips,
+  pointTooltipsOnly = false,
 }: LineChartScrubberProps) {
   const buildTooltip = useCallback(
     (dataIndex: number): ScrubberTooltipContent => {
+      // In point-only mode the scrubber surfaces a tooltip exclusively on marked data
+      // points (e.g. transactions); every other index is hidden. The scrubber snaps to
+      // the nearest data index, which may differ from a marker's exact index (notably on
+      // dense ranges where several data points share a pixel), so we resolve the nearest
+      // marker within a density-aware tolerance rather than an exact match.
+      if (pointTooltipsOnly) {
+        const pointTooltip = pointTooltips
+          ? resolveNearestPointTooltip(pointTooltips, dataIndex, series[0]?.data?.length ?? 0)
+          : undefined;
+        if (!pointTooltip) return { items: [] };
+
+        const items = [...pointTooltip.rows];
+        // Pin a content-derived width floor so the right-aligned value never
+        // overlaps the label when the tooltip's async measurement is stale.
+        const minWidth = estimateTooltipMinWidth(pointTooltip);
+        return pointTooltip.title != null && pointTooltip.title !== ""
+          ? { items, title: pointTooltip.title, minWidth }
+          : { items, minWidth };
+      }
+
       const items = series
         .map(entry => buildTooltipRow(entry, dataIndex, formatValue))
         .filter((row): row is ChartTooltipItemData => row !== null);
 
       const title = tooltipTitle?.(dataIndex);
+      const minWidth = estimateTooltipMinWidth({
+        title: title != null && title !== "" ? title : undefined,
+        rows: items.map(item => ({ label: String(item.label), value: String(item.value) })),
+      });
 
-      return title != null && title !== "" ? { items, title } : { items };
+      return title != null && title !== "" ? { items, title, minWidth } : { items, minWidth };
     },
-    [series, formatValue, tooltipTitle],
+    [series, formatValue, tooltipTitle, pointTooltips, pointTooltipsOnly],
   );
 
-  return <Scrubber showBeacons tooltip={showTooltip ? buildTooltip : undefined} />;
+  return <Scrubber showBeacons={showBeacons} tooltip={showTooltip ? buildTooltip : undefined} />;
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/LineChartView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/LineChartView.tsx
@@ -23,8 +23,11 @@ export function LineChartView<TRange extends string>({
   isLoading,
   testID,
   points,
+  pointTooltips,
   enableScrubber,
   showScrubberTooltip,
+  showScrubberBeacons,
+  pointTooltipsOnly,
   formatValue,
   tooltipTitle,
   onScrubberPositionChange,
@@ -57,6 +60,9 @@ export function LineChartView<TRange extends string>({
               formatValue={formatValue}
               tooltipTitle={tooltipTitle}
               showTooltip={showScrubberTooltip}
+              showBeacons={showScrubberBeacons}
+              pointTooltips={pointTooltips}
+              pointTooltipsOnly={pointTooltipsOnly}
             />
           )}
         </LumenLineChart>
@@ -78,5 +84,5 @@ export function LineChartView<TRange extends string>({
 }
 
 const containerStyle: LumenViewStyle = {
-  gap: "s32",
+  gap: "s24",
 };

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/__tests__/LineChart.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/__tests__/LineChart.test.tsx
@@ -94,4 +94,14 @@ describe("LineChart", () => {
 
     expect(screen.getByTestId("line-chart")).toBeOnTheScreen();
   });
+
+  it("renders with point-only tooltips and a tooltip-carrying marker without crashing", () => {
+    renderLineChart({
+      pointTooltipsOnly: true,
+      showScrubberBeacons: false,
+      points: [{ index: 2, value: 5, color: "success", hideLabel: true, tooltip: { rows: [] } }],
+    });
+
+    expect(screen.getByTestId("line-chart")).toBeOnTheScreen();
+  });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/__tests__/LineChartPoints.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/__tests__/LineChartPoints.test.tsx
@@ -44,4 +44,9 @@ describe("LineChartPoints", () => {
     expect(typeof points[1].color).toBe("string");
     expect(points[2].color).toBe("#abc");
   });
+
+  it("omits the label when hideLabel is set, even if a label is provided", () => {
+    renderPoints([{ index: 1, value: 99, label: "Peak", hideLabel: true }]);
+    expect(points[0].label).toBeUndefined();
+  });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/__tests__/LineChartScrubber.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/__tests__/LineChartScrubber.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render } from "@tests/test-renderer";
 import { LineChartScrubber } from "../LineChartScrubber";
-import type { LineChartSeries } from "../types";
+import type { LineChartPointTooltip, LineChartSeries } from "../types";
 import type { ScrubberTooltipContent } from "@ledgerhq/lumen-ui-rnative-visualization";
 
 let buildTooltip: ((dataIndex: number) => ScrubberTooltipContent) | undefined;
@@ -30,10 +30,20 @@ const renderScrubber = (tooltipTitle?: (i: number) => string | undefined, showTo
     />,
   );
 
+const renderPointOnly = (pointTooltips: ReadonlyMap<number, LineChartPointTooltip>) =>
+  render(
+    <LineChartScrubber
+      series={series}
+      formatValue={v => `$${v}`}
+      pointTooltips={pointTooltips}
+      pointTooltipsOnly
+    />,
+  );
+
 describe("LineChartScrubber", () => {
   it("builds a row per series with a valid value at the index", () => {
     renderScrubber();
-    expect(buildTooltip?.(0)).toEqual({
+    expect(buildTooltip?.(0)).toMatchObject({
       items: [
         { label: "Price", value: "$10" },
         { label: "Volume", value: "$1" },
@@ -43,7 +53,12 @@ describe("LineChartScrubber", () => {
 
   it("skips series whose value is null or missing", () => {
     renderScrubber();
-    expect(buildTooltip?.(1)).toEqual({ items: [{ label: "Volume", value: "$2" }] });
+    expect(buildTooltip?.(1)).toMatchObject({ items: [{ label: "Volume", value: "$2" }] });
+  });
+
+  it("pins a content-derived minWidth so values cannot clip labels", () => {
+    renderScrubber();
+    expect(buildTooltip?.(0)?.minWidth).toBeGreaterThanOrEqual(80);
   });
 
   it("adds the title when tooltipTitle returns a non-empty string", () => {
@@ -66,5 +81,29 @@ describe("LineChartScrubber", () => {
     renderScrubber(undefined, false);
     expect(buildTooltip).toBeUndefined();
     expect(showBeacons).toBe(true);
+  });
+
+  describe("pointTooltipsOnly", () => {
+    const pointTooltips = new Map<number, LineChartPointTooltip>([
+      [2, { title: "2 transactions", rows: [{ label: "Received", value: "$5" }] }],
+    ]);
+
+    it("returns the resolved marker tooltip when the scrubbed index matches a point", () => {
+      renderPointOnly(pointTooltips);
+      expect(buildTooltip?.(2)).toMatchObject({
+        title: "2 transactions",
+        items: [{ label: "Received", value: "$5" }],
+      });
+    });
+
+    it("pins a content-derived minWidth on the resolved marker tooltip", () => {
+      renderPointOnly(pointTooltips);
+      expect(buildTooltip?.(2)?.minWidth).toBeGreaterThanOrEqual(80);
+    });
+
+    it("hides the tooltip (empty items, no per-series rows) away from any point", () => {
+      renderPointOnly(pointTooltips);
+      expect(buildTooltip?.(0)).toEqual({ items: [] });
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/__tests__/estimateTooltipMinWidth.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/__tests__/estimateTooltipMinWidth.test.ts
@@ -1,0 +1,46 @@
+import { estimateTooltipMinWidth } from "../utils/estimateTooltipMinWidth";
+import type { LineChartPointTooltip } from "../types";
+
+describe("estimateTooltipMinWidth", () => {
+  it("never returns less than the default floor", () => {
+    expect(estimateTooltipMinWidth({ rows: [] })).toBe(80);
+    expect(estimateTooltipMinWidth({ rows: [{ label: "a", value: "1" }] })).toBe(80);
+  });
+
+  it("reserves room for the widest label/value row", () => {
+    // (label "Received" 8 + value "$1.02" 5) * 8px + gap(12) + padding(16) = 132
+    const tooltip: LineChartPointTooltip = {
+      rows: [{ label: "Received", value: "$1.02" }],
+    };
+    expect(estimateTooltipMinWidth(tooltip)).toBe(132);
+  });
+
+  it("accounts for the title width", () => {
+    // "15 transactions" = 15 chars * 8 + padding(16) = 136
+    const tooltip: LineChartPointTooltip = {
+      title: "15 transactions",
+      rows: [{ label: "Sent", value: "$1" }],
+    };
+    expect(estimateTooltipMinWidth(tooltip)).toBe(136);
+  });
+
+  it("takes the maximum across the title and every row", () => {
+    const tooltip: LineChartPointTooltip = {
+      title: "9 transactions",
+      rows: [
+        { label: "Received", value: "$1,234,567.89" },
+        { label: "Sent", value: "$0.13" },
+      ],
+    };
+    // widest row: "Received"(8) + "$1,234,567.89"(13) = 21 chars * 8 + 12 + 16 = 196
+    expect(estimateTooltipMinWidth(tooltip)).toBe(196);
+  });
+
+  it("grows with longer fiat values so they never clip the label", () => {
+    const shortValue = estimateTooltipMinWidth({ rows: [{ label: "Received", value: "$1" }] });
+    const longValue = estimateTooltipMinWidth({
+      rows: [{ label: "Received", value: "$1,234,567.89" }],
+    });
+    expect(longValue).toBeGreaterThan(shortValue);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/__tests__/resolveNearestPointTooltip.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/__tests__/resolveNearestPointTooltip.test.ts
@@ -1,0 +1,39 @@
+import { resolveNearestPointTooltip } from "../utils/resolveNearestPointTooltip";
+import type { LineChartPointTooltip } from "../types";
+
+const tooltip = (label: string): LineChartPointTooltip => ({ rows: [{ label, value: "1" }] });
+const a = tooltip("a");
+const b = tooltip("b");
+
+type Case = [
+  string,
+  ReadonlyMap<number, LineChartPointTooltip>,
+  number,
+  number,
+  LineChartPointTooltip | undefined,
+];
+
+describe("resolveNearestPointTooltip", () => {
+  it.each<Case>([
+    ["no point tooltips → undefined", new Map(), 5, 100, undefined],
+    ["exact index match", new Map([[10, a]]), 10, 1000, a],
+    // length 1000 → tolerance round(1000 / 100) = 10
+    ["nearest within tolerance", new Map([[100, a]]), 108, 1000, a],
+    ["nearest beyond tolerance → undefined", new Map([[100, a]]), 120, 1000, undefined],
+    [
+      "closest among several candidates",
+      new Map([
+        [100, a],
+        [140, b],
+      ]),
+      138,
+      1000,
+      b,
+    ],
+    // short series → minimum tolerance of 1
+    ["short series, within min tolerance", new Map([[5, a]]), 6, 10, a],
+    ["short series, beyond min tolerance → undefined", new Map([[5, a]]), 7, 10, undefined],
+  ])("%s", (_label, map, index, length, expected) => {
+    expect(resolveNearestPointTooltip(map, index, length)).toEqual(expected);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/__tests__/useLineChartViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/__tests__/useLineChartViewModel.test.ts
@@ -161,4 +161,27 @@ describe("useLineChartViewModel", () => {
 
     expect(result.current.points).toEqual(points);
   });
+
+  it("defaults pointTooltipsOnly to false and exposes an empty pointTooltips map", () => {
+    const { result } = renderHook(() => useLineChartViewModel(buildProps()));
+
+    expect(result.current.pointTooltipsOnly).toBe(false);
+    expect(result.current.showScrubberBeacons).toBe(true);
+    expect(result.current.pointTooltips.size).toBe(0);
+  });
+
+  it("derives pointTooltips keyed by index from markers that carry a tooltip", () => {
+    const tooltip = { rows: [{ label: "Received", value: "$5" }] };
+    const points = [
+      { index: 0, value: 1, color: "muted" as const },
+      { index: 2, value: 3, color: "success" as const, tooltip },
+    ];
+    const { result } = renderHook(() =>
+      useLineChartViewModel(buildProps({ points, pointTooltipsOnly: true })),
+    );
+
+    expect(result.current.pointTooltipsOnly).toBe(true);
+    expect(result.current.pointTooltips.size).toBe(1);
+    expect(result.current.pointTooltips.get(2)).toEqual(tooltip);
+  });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/index.tsx
@@ -14,6 +14,7 @@ export type {
   LineChartRangeOption,
   LineChartSeries,
   LineChartPointMarker,
+  LineChartPointTooltip,
   LineChartPointLabelPosition,
   LineChartValueFormatter,
   LineChartTooltipTitle,

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/types.ts
@@ -9,6 +9,11 @@ export type LineChartColor = "success" | "error" | "muted";
 
 export type LineChartPointLabelPosition = "top" | "bottom";
 
+export type LineChartPointTooltip = Readonly<{
+  title?: string;
+  rows: ReadonlyArray<{ label: string; value: string }>;
+}>;
+
 export type LineChartPointMarker = Readonly<{
   index: number;
   value: number;
@@ -16,6 +21,8 @@ export type LineChartPointMarker = Readonly<{
   color?: LineChartColor | (string & {});
   labelPosition?: LineChartPointLabelPosition;
   hidePoint?: boolean;
+  hideLabel?: boolean;
+  tooltip?: LineChartPointTooltip;
 }>;
 
 export type LineChartValueFormatter = (value: number) => string;
@@ -53,6 +60,14 @@ export type LineChartProps<TRange extends string = string> = Readonly<{
   enableScrubber?: boolean;
   /** Shows the floating tooltip while scrubbing. @default true */
   showScrubberTooltip?: boolean;
+  /** Shows the beacon dots on the scrubbed data point. @default true */
+  showScrubberBeacons?: boolean;
+  /**
+   * Restricts the scrubber tooltip to point markers that carry a `tooltip`: it
+   * appears only when the scrubbed index resolves to such a marker, and the
+   * standard per-series value tooltip is suppressed. @default false
+   */
+  pointTooltipsOnly?: boolean;
   /** Formats numeric values for point labels and the scrubber tooltip. @default String */
   formatValue?: LineChartValueFormatter;
   /** Returns the tooltip title for the given data index (e.g. a formatted date). */

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/useLineChartViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/useLineChartViewModel.ts
@@ -3,6 +3,7 @@ import { useTheme } from "@ledgerhq/lumen-ui-rnative/styles";
 import { DEFAULT_LINE_CHART_HEIGHT } from "./constants";
 import type {
   LineChartPointMarker,
+  LineChartPointTooltip,
   LineChartProps,
   LineChartRangeOption,
   LineChartScrubberPositionChange,
@@ -27,8 +28,11 @@ export type LineChartViewModelResult<TRange extends string = string> = Readonly<
   isLoading: boolean;
   testID?: string;
   points: LineChartPointMarker[];
+  pointTooltips: ReadonlyMap<number, LineChartPointTooltip>;
   enableScrubber: boolean;
   showScrubberTooltip: boolean;
+  showScrubberBeacons: boolean;
+  pointTooltipsOnly: boolean;
   formatValue: LineChartValueFormatter;
   tooltipTitle?: LineChartTooltipTitle;
   onScrubberPositionChange?: LineChartScrubberPositionChange;
@@ -53,6 +57,8 @@ export function useLineChartViewModel<TRange extends string>({
   points,
   enableScrubber = true,
   showScrubberTooltip = true,
+  showScrubberBeacons = true,
+  pointTooltipsOnly = false,
   formatValue = defaultFormatValue,
   tooltipTitle,
   onScrubberPositionChange,
@@ -76,6 +82,14 @@ export function useLineChartViewModel<TRange extends string>({
     [points, chartSeries],
   );
 
+  const pointTooltips = useMemo(() => {
+    const map = new Map<number, LineChartPointTooltip>();
+    for (const marker of resolvedPoints) {
+      if (marker.tooltip) map.set(marker.index, marker.tooltip);
+    }
+    return map;
+  }, [resolvedPoints]);
+
   const handleSelectedChange = useCallback(
     (value: string) => {
       if (isRangeValue && !isRangeValue(value)) return;
@@ -94,8 +108,11 @@ export function useLineChartViewModel<TRange extends string>({
     isLoading,
     testID,
     points: resolvedPoints,
+    pointTooltips,
     enableScrubber,
     showScrubberTooltip,
+    showScrubberBeacons,
+    pointTooltipsOnly,
     formatValue,
     tooltipTitle,
     onScrubberPositionChange,

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/utils/estimateTooltipMinWidth.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/utils/estimateTooltipMinWidth.ts
@@ -1,0 +1,46 @@
+import type { LineChartPointTooltip } from "../types";
+
+/**
+ * The scrubber tooltip auto-fits its width from async `getBBox` measurements of
+ * the rendered SVG text. On native, `getBBox` can resolve to `0` (or stay stale
+ * when moving between markers that share the same labels), which collapses the
+ * box to its `minWidth` floor. The right-aligned value then overlaps the
+ * left-aligned label and clips it (e.g. "Received" renders as "Receive").
+ *
+ * To make the layout robust to unreliable measurement, we pass a `minWidth`
+ * derived from the tooltip's own content: a conservative pixel estimate that is
+ * guaranteed to reserve enough room for the widest row even if `getBBox` fails.
+ * Over-estimating only widens the box slightly; it never clips.
+ *
+ * The structural constants below mirror `DefaultScrubberTooltip` in
+ * `@ledgerhq/lumen-ui-rnative-visualization` (PADDING_X, LABEL_VALUE_GAP). The
+ * per-character width is an upper bound for the `body4` sans font used by the
+ * tooltip (covering `$`, digits and capitals).
+ */
+const APPROX_CHAR_WIDTH = 8;
+const PADDING_X = 8;
+const LABEL_VALUE_GAP = 12;
+
+/** Floor matching the library's `DEFAULT_TOOLTIP_MIN_WIDTH`, so we never shrink below it. */
+const DEFAULT_MIN_WIDTH = 80;
+
+function estimateTextWidth(text: string): number {
+  return text.length * APPROX_CHAR_WIDTH;
+}
+
+/**
+ * Estimates a safe `minWidth` (in pixels) for a scrubber tooltip from its title
+ * and rows. A title spans the full row; each label/value row needs room for the
+ * label, the gap, and the right-aligned value. Returns at least
+ * {@link DEFAULT_MIN_WIDTH}.
+ */
+export function estimateTooltipMinWidth(tooltip: LineChartPointTooltip): number {
+  const titleWidth = tooltip.title ? estimateTextWidth(tooltip.title) : 0;
+
+  const rowWidths = tooltip.rows.map(
+    row => estimateTextWidth(row.label) + LABEL_VALUE_GAP + estimateTextWidth(row.value),
+  );
+
+  const contentWidth = Math.max(titleWidth, ...rowWidths, 0);
+  return Math.max(DEFAULT_MIN_WIDTH, Math.ceil(contentWidth + PADDING_X * 2));
+}

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/utils/resolveNearestPointTooltip.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/utils/resolveNearestPointTooltip.ts
@@ -1,0 +1,35 @@
+import type { LineChartPointTooltip } from "../types";
+
+/**
+ * Caps how far (in data indices) the scrubbed index may sit from a marker while
+ * still resolving to its tooltip. Scaled to ~1% of the data length so the catch
+ * area stays roughly constant in pixels across dense and sparse ranges.
+ */
+function getToleranceForDataLength(dataLength: number): number {
+  return Math.max(1, Math.round(dataLength / 100));
+}
+
+/**
+ * Resolves the tooltip of the marker nearest to `dataIndex`, or `undefined` when the
+ * nearest marker is farther than the density-aware tolerance allows.
+ */
+export function resolveNearestPointTooltip(
+  pointTooltips: ReadonlyMap<number, LineChartPointTooltip>,
+  dataIndex: number,
+  dataLength: number,
+): LineChartPointTooltip | undefined {
+  const tolerance = getToleranceForDataLength(dataLength);
+
+  let nearest: LineChartPointTooltip | undefined;
+  let nearestDistance = Number.POSITIVE_INFINITY;
+
+  for (const [index, tooltip] of pointTooltips) {
+    const distance = Math.abs(index - dataIndex);
+    if (distance < nearestDistance) {
+      nearestDistance = distance;
+      nearest = tooltip;
+    }
+  }
+
+  return nearestDistance <= tolerance ? nearest : undefined;
+}

--- a/apps/ledger-live-mobile/src/mvvm/components/TrendSection/__tests__/TrendSection.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TrendSection/__tests__/TrendSection.test.tsx
@@ -3,10 +3,17 @@ import { render, screen } from "@tests/test-renderer";
 import { TrendSection } from "../index";
 
 describe("TrendSection", () => {
-  it.each([0, NaN])("renders a dash when percentage is %s", percentage => {
-    render(<TrendSection percentage={percentage} />);
+  it("renders a dash when percentage is NaN (no data)", () => {
+    render(<TrendSection percentage={NaN} />);
 
     expect(screen.getByText("−")).toBeVisible();
+  });
+
+  it("renders a neutral 0.00% when percentage is exactly 0", () => {
+    render(<TrendSection percentage={0} timeLabel="1 day" testID="trend" />);
+
+    expect(screen.getByText("0.00%")).toBeVisible();
+    expect(screen.getByText("1 day")).toBeVisible();
   });
 
   it("renders positive percentage", () => {

--- a/apps/ledger-live-mobile/src/mvvm/components/TrendSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TrendSection/index.tsx
@@ -10,7 +10,10 @@ type Props = Readonly<{
 }>;
 
 export function TrendSection({ percentage, formattedChange, timeLabel, testID }: Props) {
-  if (Number.isNaN(percentage) || percentage === 0) {
+  // NaN signals missing data → neutral dash. A real 0 is rendered as a neutral
+  // (grey) trend so the row (and its time label) stays visible, e.g. while
+  // scrubbing back to the start of the range.
+  if (Number.isNaN(percentage)) {
     return (
       <Text typography="body2" lx={{ color: "muted" }} testID={testID}>
         &minus;

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
@@ -71,6 +71,7 @@ export function AssetDetailView({
           <HiddenAssetBanner show={coinOptions.isHidden} onShowAsset={coinOptions.onShowAsset} />
           <BalanceGraph
             currency={currency}
+            distributionItem={distributionItem}
             marketApiId={marketApiId}
             knownLedgerIds={knownLedgerIds}
             knownMarketId={knownMarketId}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/BalanceGraphView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/BalanceGraphView.tsx
@@ -8,6 +8,7 @@ import { TrendSection } from "LLM/components/TrendSection";
 import { LineChart } from "LLM/components/LineChart";
 import type {
   LineChartColor,
+  LineChartPointMarker,
   LineChartScrubberPositionChange,
   LineChartSeries,
   LineChartTooltipTitle,
@@ -18,6 +19,9 @@ import type {
 import { ASSET_DETAIL_TEST_IDS } from "LLM/features/AssetDetail/testIds";
 import type { RangeKey } from "../../utils/rangeMapping";
 
+/** Figma asset-detail chart height (343 × 208). Width follows the screen inset. */
+export const ASSET_DETAIL_CHART_HEIGHT = 208;
+
 type Range = Readonly<{ label: string; value: RangeKey }>;
 
 type Props = Readonly<{
@@ -26,7 +30,7 @@ type Props = Readonly<{
   hasMarketData: boolean;
   priceChangePercentage: number;
   formattedPriceChange: string | undefined;
-  rangeTimeLabel: string;
+  timeLabel: string | undefined;
   ranges: Range[];
   selectedRange: RangeKey;
   onRangeChange: (value: RangeKey) => void;
@@ -36,11 +40,12 @@ type Props = Readonly<{
   isLoading: boolean;
   series: LineChartSeries[];
   chartColor: LineChartColor;
+  points: LineChartPointMarker[];
+  pointTooltipsOnly: boolean;
   formatValue: LineChartValueFormatter;
   tooltipTitle: LineChartTooltipTitle;
   onScrubberPositionChange: LineChartScrubberPositionChange;
   isScrubbing: boolean;
-  scrubbedDateLabel: string | undefined;
   showXAxis: boolean;
   showYAxis: boolean;
   xAxis: LineChartXAxisConfig;
@@ -55,6 +60,8 @@ type ChartProps = Readonly<{
   isRangeValue: (value: string) => value is RangeKey;
   chartColor: LineChartColor;
   isLoading: boolean;
+  points: LineChartPointMarker[];
+  pointTooltipsOnly: boolean;
   formatValue: LineChartValueFormatter;
   tooltipTitle: LineChartTooltipTitle;
   onScrubberPositionChange: LineChartScrubberPositionChange;
@@ -78,6 +85,8 @@ const BalanceGraphChart = React.memo(function BalanceGraphChart({
   isRangeValue,
   chartColor,
   isLoading,
+  points,
+  pointTooltipsOnly,
   formatValue,
   tooltipTitle,
   onScrubberPositionChange,
@@ -96,17 +105,20 @@ const BalanceGraphChart = React.memo(function BalanceGraphChart({
       isRangeValue={isRangeValue}
       color={chartColor}
       isLoading={isLoading}
+      points={points}
       formatValue={formatValue}
       tooltipTitle={tooltipTitle}
       onScrubberPositionChange={onScrubberPositionChange}
-      showScrubberTooltip={false}
+      showScrubberTooltip
+      showScrubberBeacons={false}
+      pointTooltipsOnly={pointTooltipsOnly}
       showXAxis={showXAxis}
       showYAxis={showYAxis}
       xAxis={xAxis}
       yAxis={yAxis}
       accessibilityLabel={accessibilityLabel}
       testID={ASSET_DETAIL_TEST_IDS.chart}
-      height={275}
+      height={ASSET_DETAIL_CHART_HEIGHT}
     />
   );
 });
@@ -117,7 +129,7 @@ export function BalanceGraphView({
   hasMarketData,
   priceChangePercentage,
   formattedPriceChange,
-  rangeTimeLabel,
+  timeLabel,
   ranges,
   selectedRange,
   onRangeChange,
@@ -127,11 +139,12 @@ export function BalanceGraphView({
   isLoading,
   series,
   chartColor,
+  points,
+  pointTooltipsOnly,
   formatValue,
   tooltipTitle,
   onScrubberPositionChange,
   isScrubbing,
-  scrubbedDateLabel,
   showXAxis,
   showYAxis,
   xAxis,
@@ -161,17 +174,11 @@ export function BalanceGraphView({
                 testID={ASSET_DETAIL_TEST_IDS.marketPrice}
               />
 
-              {isScrubbing ? (
-                <Text typography="body2" lx={{ color: "muted" }}>
-                  {scrubbedDateLabel}
-                </Text>
-              ) : (
-                <TrendSection
-                  percentage={priceChangePercentage}
-                  formattedChange={formattedPriceChange}
-                  timeLabel={rangeTimeLabel}
-                />
-              )}
+              <TrendSection
+                percentage={priceChangePercentage}
+                formattedChange={formattedPriceChange}
+                timeLabel={timeLabel}
+              />
             </>
           )}
         </Box>
@@ -185,6 +192,8 @@ export function BalanceGraphView({
         isRangeValue={isRangeValue}
         chartColor={chartColor}
         isLoading={isLoading}
+        points={points}
+        pointTooltipsOnly={pointTooltipsOnly}
         formatValue={formatValue}
         tooltipTitle={tooltipTitle}
         onScrubberPositionChange={onScrubberPositionChange}
@@ -214,7 +223,7 @@ export function BalanceGraphView({
 }
 
 const containerStyle: LumenViewStyle = {
-  gap: "s16",
+  gap: "s24",
 };
 
 const headerStyle: LumenViewStyle = {

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/BalanceGraphView.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/BalanceGraphView.test.tsx
@@ -68,7 +68,7 @@ const buildProps = (overrides: Partial<ViewProps> = {}): ViewProps => ({
   hasMarketData: true,
   priceChangePercentage: 2.35,
   formattedPriceChange: "+$1,000.00",
-  rangeTimeLabel: "Today",
+  timeLabel: "Today",
   ranges: [
     { label: "1D", value: "1d" },
     { label: "1W", value: "1w" },
@@ -81,12 +81,13 @@ const buildProps = (overrides: Partial<ViewProps> = {}): ViewProps => ({
   isLoading: false,
   series,
   chartColor: "success",
+  points: [],
+  pointTooltipsOnly: true,
   formatValue: (value: number) => String(value),
   tooltipTitle: () => undefined,
   onScrubberPositionChange: noopScrub,
   isScrubbing: false,
-  scrubbedDateLabel: undefined,
-  showXAxis: true,
+  showXAxis: false,
   showYAxis: false,
   xAxis,
   yAxis,
@@ -99,12 +100,16 @@ describe("BalanceGraphView", () => {
     for (const key of Object.keys(mockLineChartProps)) delete mockLineChartProps[key];
   });
 
-  it("forwards the scrub callback and disables the floating tooltip", () => {
+  it("forwards the scrub callback, enables point-only tooltips and keeps beacons hidden", () => {
     const onScrubberPositionChange: LineChartScrubberPositionChange = jest.fn();
-    render(<BalanceGraphView {...buildProps({ onScrubberPositionChange })} />);
+    const points = [{ index: 1, value: 110, color: "success" as const, tooltip: { rows: [] } }];
+    render(<BalanceGraphView {...buildProps({ onScrubberPositionChange, points })} />);
 
     expect(mockLineChartProps.onScrubberPositionChange).toBe(onScrubberPositionChange);
-    expect(mockLineChartProps.showScrubberTooltip).toBe(false);
+    expect(mockLineChartProps.showScrubberTooltip).toBe(true);
+    expect(mockLineChartProps.showScrubberBeacons).toBe(false);
+    expect(mockLineChartProps.pointTooltipsOnly).toBe(true);
+    expect(mockLineChartProps.points).toBe(points);
   });
 
   describe("when not scrubbing", () => {
@@ -119,16 +124,23 @@ describe("BalanceGraphView", () => {
   });
 
   describe("while scrubbing", () => {
-    it("disables the amount animation and shows only the scrubbed date, hiding the variation and percentage", () => {
+    it("disables the amount animation and shows the scrubbed variation, fiat change and date", () => {
       render(
-        <BalanceGraphView {...buildProps({ isScrubbing: true, scrubbedDateLabel: "5/29/2026" })} />,
+        <BalanceGraphView
+          {...buildProps({
+            isScrubbing: true,
+            priceChangePercentage: 1.8,
+            formattedPriceChange: "+$220.00",
+            timeLabel: "5/29/2026",
+          })}
+        />,
       );
 
       expect(mockAmountDisplayAnimate).toBe(false);
+      expect(screen.getByText("1.80%")).toBeVisible();
+      expect(screen.getByText("+$220.00")).toBeVisible();
       expect(screen.getByText("5/29/2026")).toBeVisible();
       expect(screen.queryByText("Today")).toBeNull();
-      expect(screen.queryByText("2.35%")).toBeNull();
-      expect(screen.queryByText("+$1,000.00")).toBeNull();
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/buildTransactionPointMarker.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/buildTransactionPointMarker.test.ts
@@ -1,0 +1,58 @@
+import { buildTransactionPointMarker } from "../utils/buildTransactionPointMarker";
+import type { LineChartColor } from "LLM/components/LineChart";
+import type { TransactionChartGroup } from "../utils/getTransactionPointMarkers";
+
+const t = (key: string, options?: { count: number }) => (options ? `${key}:${options.count}` : key);
+const formatFiat = (value: number) => `$${value}`;
+const KEY = "assetDetail.balanceGraph.chart";
+
+const group = (overrides: Partial<TransactionChartGroup>): TransactionChartGroup => ({
+  index: 2,
+  value: 30,
+  dateMs: 0,
+  receivedCount: 0,
+  sentCount: 0,
+  receivedFiat: 0,
+  sentFiat: 0,
+  ...overrides,
+});
+
+type Row = { label: string; value: string };
+
+describe("buildTransactionPointMarker", () => {
+  it.each<[string, Partial<TransactionChartGroup>, LineChartColor, string | undefined, Row[]]>([
+    [
+      "single received → green, no title, Received row",
+      { receivedCount: 1, receivedFiat: 12 },
+      "success",
+      undefined,
+      [{ label: `${KEY}.received`, value: "$12" }],
+    ],
+    [
+      "single sent → red, no title, Sent row",
+      { sentCount: 1, sentFiat: 7 },
+      "error",
+      undefined,
+      [{ label: `${KEY}.sent`, value: "$7" }],
+    ],
+    [
+      "cluster → grey, count title, both rows",
+      { receivedCount: 2, sentCount: 1, receivedFiat: 5, sentFiat: 3 },
+      "muted",
+      `${KEY}.transactionsCount:3`,
+      [
+        { label: `${KEY}.received`, value: "$5" },
+        { label: `${KEY}.sent`, value: "$3" },
+      ],
+    ],
+  ])("%s", (_label, overrides, color, title, rows) => {
+    expect(buildTransactionPointMarker(group(overrides), t, formatFiat)).toEqual({
+      index: 2,
+      value: 30,
+      color,
+      hidePoint: false,
+      hideLabel: true,
+      tooltip: { title, rows },
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/downsampleChartPoints.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/downsampleChartPoints.test.ts
@@ -1,0 +1,65 @@
+import { downsampleChartPoints, MAX_SERIES_POINTS } from "../utils/downsampleChartPoints";
+
+const ramp = (length: number, fn: (i: number) => number = i => i): number[] =>
+  Array.from({ length }, (_, i) => fn(i));
+
+describe("downsampleChartPoints", () => {
+  it("returns the input untouched when already at or below the cap", () => {
+    const timestamps = [1, 2, 3];
+    const values = [10, 20, 30];
+
+    const result = downsampleChartPoints(timestamps, values, 5);
+
+    expect(result.timestamps).toBe(timestamps);
+    expect(result.values).toBe(values);
+  });
+
+  it("reduces a long series to at most maxPoints", () => {
+    const length = 350;
+
+    const result = downsampleChartPoints(ramp(length), ramp(length, Math.sin), MAX_SERIES_POINTS);
+
+    expect(result.values.length).toBeLessThanOrEqual(MAX_SERIES_POINTS + 2);
+    expect(result.values.length).toBeLessThan(length);
+    expect(result.timestamps.length).toBe(result.values.length);
+  });
+
+  it("keeps timestamps and values aligned on the same kept indices", () => {
+    // values[i] === index, timestamps[i] === index * 1000, so the pairing must hold.
+    const result = downsampleChartPoints(
+      ramp(300, i => i * 1000),
+      ramp(300),
+      50,
+    );
+
+    result.values.forEach((value, i) => {
+      expect(result.timestamps[i]).toBe(value * 1000);
+    });
+  });
+
+  it("preserves the first, last, min and max points", () => {
+    const length = 200;
+    const values = ramp(length);
+    values[123] = -999; // global min
+    values[77] = 9999; // global max
+
+    const result = downsampleChartPoints(ramp(length), values, 30);
+
+    expect(result.values[0]).toBe(values[0]);
+    expect(result.values[result.values.length - 1]).toBe(values[length - 1]);
+    expect(result.values).toContain(-999);
+    expect(result.values).toContain(9999);
+  });
+
+  it("returns a strictly increasing timestamp sequence (sorted, de-duplicated indices)", () => {
+    const result = downsampleChartPoints(
+      ramp(250),
+      ramp(250, i => (i % 7) - 3),
+      40,
+    );
+
+    for (let i = 1; i < result.timestamps.length; i++) {
+      expect(result.timestamps[i]).toBeGreaterThan(result.timestamps[i - 1]);
+    }
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/getTransactionPointMarkers.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/getTransactionPointMarkers.test.ts
@@ -1,0 +1,118 @@
+import {
+  groupTransactionsByChartIndex,
+  MIN_SERIES_POINTS_BETWEEN_TX_MARKERS,
+  type TransactionChartGroup,
+  type TransactionInput,
+} from "../utils/getTransactionPointMarkers";
+
+const tx = (
+  dateMs: number,
+  direction: TransactionInput["direction"],
+  fiat: number | null,
+): TransactionInput => ({ dateMs, direction, fiat });
+
+const expectedGroup = (overrides: Partial<TransactionChartGroup>): TransactionChartGroup => ({
+  index: 0,
+  value: 10,
+  dateMs: 0,
+  receivedCount: 0,
+  sentCount: 0,
+  receivedFiat: 0,
+  sentFiat: 0,
+  ...overrides,
+});
+
+describe("groupTransactionsByChartIndex", () => {
+  const timestamps = [0, 100, 200, 300];
+  const values = [10, 20, 30, 40];
+  const run = (
+    transactions: TransactionInput[],
+    overrides: Partial<Parameters<typeof groupTransactionsByChartIndex>[0]> = {},
+  ) => groupTransactionsByChartIndex({ timestamps, values, transactions, ...overrides });
+
+  it("returns no groups when there are fewer than two timestamps", () => {
+    expect(run([tx(0, "in", 1)], { timestamps: [0], values: [10] })).toEqual([]);
+  });
+
+  it("maps a transaction to the nearest chart index", () => {
+    expect(run([tx(190, "in", 5)])).toEqual([
+      expectedGroup({ index: 2, value: 30, dateMs: 190, receivedCount: 1, receivedFiat: 5 }),
+    ]);
+  });
+
+  it("aggregates several transactions landing on the same index", () => {
+    expect(run([tx(95, "in", 2), tx(105, "out", 3), tx(110, "in", 4)])).toEqual([
+      expectedGroup({
+        index: 1,
+        value: 20,
+        dateMs: 95,
+        receivedCount: 2,
+        sentCount: 1,
+        receivedFiat: 6,
+        sentFiat: 3,
+      }),
+    ]);
+  });
+
+  it("drops transactions outside the window", () => {
+    expect(run([tx(-50, "in", 1), tx(400, "out", 1)])).toEqual([]);
+  });
+
+  it("excludes null/NaN fiat from totals but still counts the transaction", () => {
+    expect(run([tx(0, "in", null), tx(0, "in", NaN)])).toEqual([
+      expectedGroup({ receivedCount: 2 }),
+    ]);
+  });
+
+  it("drops transactions mapping to a point with a missing value", () => {
+    expect(run([tx(100, "in", 5)], { values: [10, NaN, 30, 40] })).toEqual([]);
+  });
+
+  it("keeps the lower index on a tie (pointer does not advance)", () => {
+    expect(run([tx(50, "in", 1)], { timestamps: [0, 100], values: [10, 20] })[0].index).toBe(0);
+  });
+
+  describe("minimum marker spacing (series-points)", () => {
+    const longTimestamps = Array.from({ length: 100 }, (_, i) => i * 100);
+    const longValues = Array.from({ length: 100 }, (_, i) => i + 1);
+    // `at(index, direction)` places a transaction on the given series index; fiat is
+    // irrelevant to spacing so it is fixed at 1.
+    const at = (index: number, direction: TransactionInput["direction"]) =>
+      tx(index * 100, direction, 1);
+    const runLong = (transactions: TransactionInput[], minSeriesPointsBetweenMarkers?: number) =>
+      groupTransactionsByChartIndex({
+        timestamps: longTimestamps,
+        values: longValues,
+        transactions,
+        minSeriesPointsBetweenMarkers,
+      });
+
+    it("merges transactions within the gap into the cluster anchor and opens a new marker beyond it", () => {
+      const groups = runLong([at(0, "in"), at(10, "in"), at(25, "out"), at(30, "in")], 20);
+
+      expect(groups.map(g => g.index)).toEqual([0, 25]);
+      expect(groups[0]).toMatchObject({ receivedCount: 2, sentCount: 0 });
+      expect(groups[1]).toMatchObject({ index: 25, receivedCount: 1, sentCount: 1 });
+    });
+
+    it("collapses everything into one marker when the gap exceeds the window", () => {
+      const groups = runLong([at(0, "in"), at(40, "in"), at(90, "out")], 1000);
+
+      expect(groups).toHaveLength(1);
+      expect(groups[0]).toMatchObject({ index: 0, receivedCount: 2, sentCount: 1 });
+    });
+
+    it("keeps adjacent distinct indices separate when the gap is 1", () => {
+      expect(runLong([at(0, "in"), at(1, "in"), at(2, "out")], 1).map(g => g.index)).toEqual([
+        0, 1, 2,
+      ]);
+    });
+
+    it("applies the default spacing when none is provided", () => {
+      const groups = runLong([at(0, "in"), at(MIN_SERIES_POINTS_BETWEEN_TX_MARKERS - 1, "in")]);
+
+      expect(groups).toHaveLength(1);
+      expect(groups[0].receivedCount).toBe(2);
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/useBalanceGraphViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/useBalanceGraphViewModel.test.ts
@@ -53,11 +53,19 @@ const CHART_DATA_BY_RANGE: Record<RangeKey, Array<[number, number]>> = {
     [2, 210],
   ],
   "1m": [[1, 300]],
+  "6m": [
+    [1, 350],
+    [2, 385],
+  ],
   "1y": [
     [1, 400],
     [2, 410],
     [3, 420],
     [4, 430],
+  ],
+  all: [
+    [1, 100],
+    [2, 220],
   ],
 };
 
@@ -141,7 +149,7 @@ describe("useBalanceGraphViewModel", () => {
 
       expect(result.current.price).toBe(0);
       expect(result.current.hasMarketData).toBe(false);
-      expect(result.current.priceChangePercentage).toBe(0);
+      expect(result.current.priceChangePercentage).toBeNaN();
     });
 
     it("uses the correct priceChangePercentage key after range change", () => {
@@ -350,11 +358,11 @@ describe("useBalanceGraphViewModel", () => {
   });
 
   describe("ranges", () => {
-    it("exposes the full range list in chronological order (1d → 1y)", () => {
+    it("exposes the full range list in chronological order (1d → all)", () => {
       const { result } = renderVM();
 
       const values = result.current.ranges.map(r => r.value);
-      expect(values).toEqual(["1d", "1w", "1m", "1y"]);
+      expect(values).toEqual(["1d", "1w", "1m", "6m", "1y", "all"]);
     });
 
     it("exposes a runtime guard that accepts only known range keys", () => {
@@ -446,10 +454,10 @@ describe("useBalanceGraphViewModel", () => {
       expect(result.current.tooltipTitle(99)).toBeUndefined();
     });
 
-    it("renders the x-axis and keeps the y-axis hidden", () => {
+    it("hides the x-axis and keeps the y-axis hidden", () => {
       const { result } = renderVM();
 
-      expect(result.current.showXAxis).toBe(true);
+      expect(result.current.showXAxis).toBe(false);
       expect(result.current.showYAxis).toBe(false);
     });
 
@@ -474,7 +482,7 @@ describe("useBalanceGraphViewModel", () => {
   });
 
   describe("scrubbing", () => {
-    it("drives the price and date from the hovered point and flags isScrubbing", () => {
+    it("drives the price, date and range-start variation from the hovered point", () => {
       const { result } = renderVM();
 
       // 1d series data is [100, 110, 120] with timestamps [1, 2, 3].
@@ -482,12 +490,17 @@ describe("useBalanceGraphViewModel", () => {
 
       expect(result.current.isScrubbing).toBe(true);
       expect(result.current.price).toBe(110);
-      expect(typeof result.current.scrubbedDateLabel).toBe("string");
-      expect(result.current.scrubbedDateLabel).not.toBe("");
+      // Variation from the range start (100) to the hovered point (110) = +10%.
+      expect(result.current.priceChangePercentage).toBeCloseTo(10);
+      expect(result.current.formattedPriceChange).toMatch(/^\+/);
+      expect(typeof result.current.timeLabel).toBe("string");
+      expect(result.current.timeLabel).not.toBe("");
     });
 
-    it("reverts to the live price and clears the date when scrubbing ends", () => {
+    it("reverts to the live price and range label when scrubbing ends", () => {
       const { result } = renderVM();
+
+      const rangeLabel = result.current.timeLabel;
 
       act(() => result.current.onScrubberPositionChange(2));
       expect(result.current.price).toBe(120);
@@ -496,7 +509,7 @@ describe("useBalanceGraphViewModel", () => {
 
       expect(result.current.isScrubbing).toBe(false);
       expect(result.current.price).toBe(50000);
-      expect(result.current.scrubbedDateLabel).toBeUndefined();
+      expect(result.current.timeLabel).toBe(rangeLabel);
     });
 
     it("ignores an out-of-range index (no scrub)", () => {
@@ -528,7 +541,7 @@ describe("useBalanceGraphViewModel", () => {
 
       expect(result.current.isScrubbing).toBe(true);
       expect(result.current.price).toBe(0);
-      expect(result.current.scrubbedDateLabel).toBeDefined();
+      expect(result.current.timeLabel).toBeDefined();
     });
 
     it("clears the selection when the range changes mid-scrub", () => {
@@ -541,6 +554,24 @@ describe("useBalanceGraphViewModel", () => {
 
       expect(result.current.isScrubbing).toBe(false);
       expect(result.current.price).toBe(50000);
+    });
+  });
+
+  describe("transaction points", () => {
+    it("always enables point-only tooltips", () => {
+      const { result } = renderVM();
+
+      expect(result.current.pointTooltipsOnly).toBe(true);
+    });
+
+    it("exposes the extrema markers when there are no scoped operations", () => {
+      const { result } = renderVM();
+
+      // 1d series data is [100, 110, 120] → min at index 0, max at index 2.
+      expect(result.current.points).toEqual([
+        { index: 2, value: 120, color: "success", labelPosition: "top", hidePoint: true },
+        { index: 0, value: 100, color: "error", labelPosition: "bottom", hidePoint: true },
+      ]);
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import type { DistributionItem } from "@ledgerhq/types-live";
 import type { AssetDetailCurrencyProps } from "LLM/features/AssetDetail/types";
 import { useBalanceGraphViewModel } from "./useBalanceGraphViewModel";
 import { BalanceGraphView } from "./BalanceGraphView";
@@ -10,6 +11,7 @@ type Props = Readonly<{
   knownMarketId?: string;
   hideReceive?: boolean;
   ledgerIds?: string[];
+  distributionItem?: DistributionItem;
 }>;
 
 export function BalanceGraph({
@@ -19,6 +21,7 @@ export function BalanceGraph({
   knownMarketId,
   hideReceive,
   ledgerIds,
+  distributionItem,
 }: Props) {
   const viewModel = useBalanceGraphViewModel({
     currency,
@@ -27,6 +30,7 @@ export function BalanceGraph({
     knownMarketId,
     hideReceive,
     ledgerIds,
+    distributionItem,
   });
   return <BalanceGraphView {...viewModel} />;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
@@ -1,22 +1,31 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import BigNumber from "bignumber.js";
 import type { AssetDetailCurrencyProps } from "LLM/features/AssetDetail/types";
 import type { FormattedValue } from "@ledgerhq/lumen-ui-rnative";
+import type { Account, AccountLike, DistributionItem, Operation } from "@ledgerhq/types-live";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
+import { getOperationAmountNumber } from "@ledgerhq/live-common/operation";
+import { flattenAccounts } from "@ledgerhq/ledger-wallet-framework/account/helpers";
+import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { useAssetChartData } from "@ledgerhq/live-common/market/hooks/useMarketDataProvider";
+import { calculate } from "@ledgerhq/live-countervalues/logic";
 import {
   formatPrice,
   formatPriceFragment,
   formatSignedFiatVariation,
 } from "@ledgerhq/live-currency-format";
 import { useSelector } from "~/context/hooks";
-import { flattenAccountsSelector } from "~/reducers/accounts";
-import { counterValueCurrencySelector } from "~/reducers/settings";
+import { accountsSelector, flattenAccountsSelector } from "~/reducers/accounts";
+import { counterValueCurrencySelector, discreetModeSelector } from "~/reducers/settings";
+import { useCountervaluesState } from "~/reducers/countervalues";
+import { useOperationsV1 } from "~/screens/Analytics/Operations/useOperationsV1";
 import { track } from "~/analytics";
 import { useTranslation, useLocale } from "~/context/Locale";
 import { useOpenReceiveDrawer } from "LLM/features/Receive";
 import {
+  getExtremaPointMarkers,
   resolveLineChartColorFromPercentChange,
+  type LineChartPointMarker,
   type LineChartScrubberPositionChange,
   type LineChartSeries,
   type LineChartTooltipTitle,
@@ -27,10 +36,23 @@ import {
 import {
   BALANCE_GRAPH_RANGES,
   RANGE_TO_PRICE_CHANGE_KEY,
+  computeChartRangeChangePercentage,
+  isChartDerivedPriceChangeRange,
   isRangeKey,
   type RangeKey,
 } from "../../utils/rangeMapping";
 import { useAssetMarketData } from "../../hooks/useAssetMarketData";
+import {
+  groupTransactionsByChartIndex,
+  type TransactionInput,
+} from "./utils/getTransactionPointMarkers";
+import { buildTransactionPointMarker } from "./utils/buildTransactionPointMarker";
+import { downsampleChartPoints } from "./utils/downsampleChartPoints";
+
+// Upper bound on operations pulled for the chart's transaction dots. The chart only
+// marks operations inside the visible window, so this just caps the lookback; raise it
+// if assets with very dense histories should surface older dots on long ranges.
+const TRANSACTION_DOTS_MAX_OPERATIONS = 1000;
 
 const MIN_X_AXIS_TICKS = 5;
 const MIN_X_AXIS_TICKS_1D = 8;
@@ -72,6 +94,7 @@ type Params = {
   knownMarketId?: string;
   hideReceive?: boolean;
   ledgerIds?: string[];
+  distributionItem?: DistributionItem;
 };
 
 export function useBalanceGraphViewModel({
@@ -81,6 +104,7 @@ export function useBalanceGraphViewModel({
   knownMarketId,
   hideReceive,
   ledgerIds,
+  distributionItem,
 }: Params) {
   const { t } = useTranslation();
   const { locale } = useLocale();
@@ -137,19 +161,68 @@ export function useBalanceGraphViewModel({
   );
 
   const price = marketCurrency?.price;
-  const priceChangePercentage =
-    marketCurrency?.priceChangePercentage[RANGE_TO_PRICE_CHANGE_KEY[range]];
 
   const priceFormatter = useCallback(
     (value: number): FormattedValue => formatPriceFragment(counterValueUnit, value, locale),
     [counterValueUnit, locale],
   );
 
+  const { series, timestamps } = useMemo(() => {
+    const points = chartData?.[range] ?? [];
+    const rawValues: number[] = [];
+    const rawTimestamps: number[] = [];
+    points.forEach(([timestamp, value]) => {
+      rawValues.push(value);
+      rawTimestamps.push(timestamp);
+    });
+    // Cap the points fed to the SVG path: the market API returns ~350 points on
+    // some ranges, which is far more than the chart width can show and is the main
+    // source of render jank on mobile. Timestamps + values are reduced together so
+    // scrubber indices, x-axis ticks and markers stay aligned with the line.
+    const { timestamps: tsList, values: data } = downsampleChartPoints(rawTimestamps, rawValues);
+    return {
+      series: [
+        {
+          id: "asset-detail-price",
+          data,
+          label: "Price",
+          // `stroke` is required by the Series type but is overridden by the
+          // shared LineChart from the `color` prop.
+          stroke: "",
+        },
+      ] satisfies LineChartSeries[],
+      timestamps: tsList,
+    };
+  }, [chartData, range]);
+  const prices = series[0].data;
+
+  const priceChangePercentage = useMemo(() => {
+    // No market-API key exists for 6m/all, so the change is derived purely from the
+    // rendered series. When the series is too short to derive it, surface undefined
+    // (→ neutral dash) rather than mislabel another period's change under this range.
+    if (isChartDerivedPriceChangeRange(range)) {
+      return computeChartRangeChangePercentage(prices);
+    }
+    const key = RANGE_TO_PRICE_CHANGE_KEY[range];
+    return key != null ? marketCurrency?.priceChangePercentage[key] : undefined;
+  }, [range, prices, marketCurrency?.priceChangePercentage]);
+
   const formattedPriceChange = useMemo(() => {
-    if (priceChangePercentage == null || price == null) return undefined;
+    if (priceChangePercentage == null) return undefined;
+    // For chart-derived ranges (6m/all) the percentage comes from the rendered series,
+    // so derive the fiat change from the same series endpoints — multiplying the live
+    // price by a series-based percentage would yield an amount inconsistent with both
+    // the percentage and the line. Other ranges keep using the live market price.
+    if (isChartDerivedPriceChangeRange(range)) {
+      const first = prices[0];
+      const last = prices[prices.length - 1];
+      if (!Number.isFinite(first) || !Number.isFinite(last)) return undefined;
+      return formatSignedFiatVariation(last - first, counterValueUnit, locale);
+    }
+    if (price == null) return undefined;
     const delta = price * (priceChangePercentage / 100);
     return formatSignedFiatVariation(delta, counterValueUnit, locale);
-  }, [priceChangePercentage, price, locale, counterValueUnit]);
+  }, [priceChangePercentage, range, prices, price, locale, counterValueUnit]);
 
   const rangeTimeLabel = t(`assetDetail.balanceGraph.timeLabel.${range}`);
 
@@ -185,29 +258,6 @@ export function useBalanceGraphViewModel({
     handleOpenReceiveDrawer();
   }, [handleOpenReceiveDrawer, currency?.id]);
 
-  const { series, timestamps } = useMemo(() => {
-    const points = chartData?.[range] ?? [];
-    const data: number[] = [];
-    const tsList: number[] = [];
-    points.forEach(([timestamp, value]) => {
-      data.push(value);
-      tsList.push(timestamp);
-    });
-    return {
-      series: [
-        {
-          id: "asset-detail-price",
-          data,
-          label: "Price",
-          // `stroke` is required by the Series type but is overridden by the
-          // shared LineChart from the `color` prop.
-          stroke: "",
-        },
-      ] satisfies LineChartSeries[],
-      timestamps: tsList,
-    };
-  }, [chartData, range]);
-  const prices = series[0].data;
   const onScrubberPositionChange = useCallback<LineChartScrubberPositionChange>(
     index => {
       if (index == null) return setSelection(undefined);
@@ -261,6 +311,30 @@ export function useBalanceGraphViewModel({
   const scrubbedDateLabel =
     selection != null ? formatDate(new Date(selection.timestamp)) : undefined;
 
+  // While scrubbing, the trend reflects the change from the start of the selected
+  // range up to the scrubbed point (the line color stays tied to the range below).
+  const scrubVariation = useMemo(() => {
+    if (selection == null) return undefined;
+    const baselinePrice = prices[0];
+    if (!Number.isFinite(baselinePrice)) return undefined;
+    const variationFiat = selection.price - baselinePrice;
+    const percentage = baselinePrice !== 0 ? (variationFiat / baselinePrice) * 100 : 0;
+    return { percentage, variationFiat };
+  }, [selection, prices]);
+
+  // Unknown range variation surfaces as NaN so the trend renders a neutral dash,
+  // distinct from a genuine 0% (flat or scrubbed back to the range start).
+  const displayedPriceChangePercentage = scrubVariation
+    ? scrubVariation.percentage
+    : priceChangePercentage ?? NaN;
+
+  const displayedFormattedPriceChange = useMemo(() => {
+    if (scrubVariation == null) return formattedPriceChange;
+    return formatSignedFiatVariation(scrubVariation.variationFiat, counterValueUnit, locale);
+  }, [scrubVariation, formattedPriceChange, counterValueUnit, locale]);
+
+  const timeLabel = isScrubbing ? scrubbedDateLabel : rangeTimeLabel;
+
   const tooltipTitle = useCallback<LineChartTooltipTitle>(
     dataIndex => {
       const timestamp = timestamps[dataIndex];
@@ -298,13 +372,127 @@ export function useBalanceGraphViewModel({
     [],
   );
 
+  // Scope operations to the asset's accounts so the chart only marks the
+  // transactions it represents, mirroring the Transactions section's scoping.
+  const allAccounts = useSelector(accountsSelector);
+  const discreet = useSelector(discreetModeSelector);
+  // Read through a ref so countervalue polling (which swaps the state reference on
+  // every tick) does not invalidate the `transactions` memo and force the memoized
+  // chart to re-render. Historical fiat is treated as stable; if rates land after the
+  // operation set settles, the dots refresh on the next change to that set.
+  const countervaluesState = useCountervaluesState();
+  const countervaluesStateRef = useRef(countervaluesState);
+  countervaluesStateRef.current = countervaluesState;
+
+  const allowedIds = useMemo(() => {
+    if (distributionItem) {
+      return new Set(distributionItem.accounts.map(a => a.id));
+    }
+    if (currency?.type === "CryptoCurrency") {
+      return new Set(allAccounts.filter(a => a.currency.id === currency.id).map(a => a.id));
+    }
+    return new Set<string>();
+  }, [distributionItem, currency, allAccounts]);
+
+  const rootAccounts: Account[] = useMemo(() => {
+    if (allowedIds.size === 0) return [];
+    return allAccounts.filter(root => flattenAccounts([root]).some(a => allowedIds.has(a.id)));
+  }, [allAccounts, allowedIds]);
+
+  const scopedFilter = useCallback(
+    (_op: Operation, account: AccountLike) => allowedIds.has(account.id),
+    [allowedIds],
+  );
+
+  const { sections } = useOperationsV1(rootAccounts, TRANSACTION_DOTS_MAX_OPERATIONS, {
+    filterOperation: scopedFilter,
+  });
+
+  // `useOperationsV1` rebuilds `sections` on every render, so flattening it is the
+  // only per-render work we keep here. The downstream fiat conversion and marker
+  // build are gated behind a stable operation signature below.
+  const flatOperations = useMemo<Operation[]>(
+    () => sections.flatMap(section => section.data),
+    [sections],
+  );
+
+  // Identity-stable operation list: the reference only changes when the actual set
+  // of operations changes (not on countervalue polls or unrelated re-renders), which
+  // keeps `transactions`/`points` — and therefore the memoized chart — stable. The
+  // signature stays cheap (count + boundary ids) instead of joining every id on each
+  // render: the list is date-ordered, so its length and endpoints identify the set.
+  const operationsSignature = `${flatOperations.length}:${flatOperations[0]?.id ?? ""}:${
+    flatOperations[flatOperations.length - 1]?.id ?? ""
+  }`;
+  const operationsRef = useRef(flatOperations);
+  const operationsSignatureRef = useRef(operationsSignature);
+  if (operationsSignatureRef.current !== operationsSignature) {
+    operationsSignatureRef.current = operationsSignature;
+    operationsRef.current = flatOperations;
+  }
+  const operations = operationsRef.current;
+
+  const currencyByAccountId = useMemo(() => {
+    const map = new Map<string, ReturnType<typeof getAccountCurrency>>();
+    for (const account of flattenAccounts(rootAccounts)) {
+      map.set(account.id, getAccountCurrency(account));
+    }
+    return map;
+  }, [rootAccounts]);
+
+  const transactions = useMemo<TransactionInput[]>(() => {
+    const windowStartMs = timestamps[0];
+    const windowEndMs = timestamps[timestamps.length - 1];
+    if (windowStartMs == null || windowEndMs == null) return [];
+    return operations.flatMap(op => {
+      const dateMs = op.date.getTime();
+      // Only operations inside the rendered window can become a marker; skip the rest
+      // before the (relatively costly) per-op countervalue conversion below.
+      if (dateMs < windowStartMs || dateMs > windowEndMs) return [];
+      const opCurrency = currencyByAccountId.get(op.accountId);
+      if (!opCurrency) return [];
+      const amount = getOperationAmountNumber(op);
+      const fiat = calculate(countervaluesStateRef.current, {
+        from: opCurrency,
+        to: counterValueCurrency,
+        value: amount.abs().toNumber(),
+        date: op.date,
+        disableRounding: true,
+      });
+      return [
+        {
+          dateMs,
+          direction: amount.isNegative() ? ("out" as const) : ("in" as const),
+          fiat: fiat ?? null,
+        },
+      ];
+    });
+  }, [operations, currencyByAccountId, counterValueCurrency, timestamps]);
+
+  const formatFiat = useCallback(
+    (value: number) =>
+      formatCurrencyUnit(counterValueUnit, new BigNumber(value), {
+        showCode: true,
+        locale,
+        discreet,
+      }),
+    [counterValueUnit, locale, discreet],
+  );
+
+  const points = useMemo<LineChartPointMarker[]>(() => {
+    const extrema = getExtremaPointMarkers(series);
+    if (transactions.length === 0 || timestamps.length < 2) return extrema;
+    const groups = groupTransactionsByChartIndex({ timestamps, values: prices, transactions });
+    return [...extrema, ...groups.map(group => buildTransactionPointMarker(group, t, formatFiat))];
+  }, [series, transactions, timestamps, prices, t, formatFiat]);
+
   return {
     price: displayedPrice,
     priceFormatter,
     hasMarketData: price != null,
-    priceChangePercentage: priceChangePercentage ?? 0,
-    formattedPriceChange,
-    rangeTimeLabel,
+    priceChangePercentage: displayedPriceChangePercentage,
+    formattedPriceChange: displayedFormattedPriceChange,
+    timeLabel,
     ranges,
     selectedRange: range,
     onRangeChange,
@@ -314,12 +502,13 @@ export function useBalanceGraphViewModel({
     isLoading: isLoading || isChartLoading,
     series,
     chartColor,
+    points,
+    pointTooltipsOnly: true,
     formatValue,
     tooltipTitle,
     onScrubberPositionChange,
     isScrubbing,
-    scrubbedDateLabel,
-    showXAxis: true,
+    showXAxis: false,
     showYAxis: false,
     xAxis,
     yAxis,

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/utils/buildTransactionPointMarker.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/utils/buildTransactionPointMarker.ts
@@ -1,0 +1,52 @@
+import type { LineChartColor, LineChartPointMarker } from "LLM/components/LineChart";
+import type { TransactionChartGroup } from "./getTransactionPointMarkers";
+
+type TranslateFn = (key: string, options?: { count: number }) => string;
+
+/**
+ * Maps an aggregated transaction group to a chart point marker.
+ *
+ * - A single received transaction is green (`success`), a single sent one is red (`error`),
+ *   and any point holding several transactions is neutral (`muted`).
+ * - The tooltip lists a Received and/or Sent row (only when that direction has activity) and,
+ *   for points with more than one transaction, a "{count} transactions" title.
+ */
+export function buildTransactionPointMarker(
+  group: TransactionChartGroup,
+  t: TranslateFn,
+  formatFiat: (value: number) => string,
+): LineChartPointMarker {
+  const count = group.receivedCount + group.sentCount;
+
+  const rows: { label: string; value: string }[] = [];
+  if (group.receivedCount > 0) {
+    rows.push({
+      label: t("assetDetail.balanceGraph.chart.received"),
+      value: formatFiat(group.receivedFiat),
+    });
+  }
+  if (group.sentCount > 0) {
+    rows.push({
+      label: t("assetDetail.balanceGraph.chart.sent"),
+      value: formatFiat(group.sentFiat),
+    });
+  }
+
+  let color: LineChartColor = "muted";
+  if (count === 1) {
+    color = group.sentCount === 1 ? "error" : "success";
+  }
+
+  return {
+    index: group.index,
+    value: group.value,
+    color,
+    hidePoint: false,
+    hideLabel: true,
+    tooltip: {
+      title:
+        count > 1 ? t("assetDetail.balanceGraph.chart.transactionsCount", { count }) : undefined,
+      rows,
+    },
+  } satisfies LineChartPointMarker;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/utils/downsampleChartPoints.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/utils/downsampleChartPoints.ts
@@ -1,0 +1,47 @@
+/**
+ * Target ceiling for the number of points fed to the SVG line chart. The market
+ * API returns ~350 points for some ranges; rendering that many in an SVG path on
+ * mobile is wasteful (well below 1 visible point per pixel) and noticeably janky.
+ * ~120 keeps the curve visually identical while cutting the path/scrubber cost.
+ */
+export const MAX_SERIES_POINTS = 125;
+
+type DownsampledPoints = Readonly<{ timestamps: number[]; values: number[] }>;
+
+/**
+ * Reduces a (timestamps, values) series to at most `maxPoints` while preserving:
+ * - the first and last points (range bounds / % change),
+ * - the global min and max points (amplitude + extrema markers),
+ * - even spacing in between (overall shape).
+ *
+ * Timestamps and values are reduced together so downstream indices (scrubber,
+ * x-axis ticks, transaction markers) stay aligned with the rendered line.
+ */
+export function downsampleChartPoints(
+  timestamps: number[],
+  values: number[],
+  maxPoints: number = MAX_SERIES_POINTS,
+): DownsampledPoints {
+  const length = Math.min(timestamps.length, values.length);
+  if (length <= maxPoints || maxPoints < 2) {
+    return { timestamps, values };
+  }
+
+  let minIndex = 0;
+  let maxIndex = 0;
+  for (let i = 1; i < length; i++) {
+    if (values[i] < values[minIndex]) minIndex = i;
+    if (values[i] > values[maxIndex]) maxIndex = i;
+  }
+
+  const kept = new Set<number>([0, length - 1, minIndex, maxIndex]);
+  for (let i = 0; i < maxPoints; i++) {
+    kept.add(Math.round((i * (length - 1)) / (maxPoints - 1)));
+  }
+
+  const indices = Array.from(kept).sort((a, b) => a - b);
+  return {
+    timestamps: indices.map(i => timestamps[i]),
+    values: indices.map(i => values[i]),
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/utils/getTransactionPointMarkers.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/utils/getTransactionPointMarkers.ts
@@ -1,0 +1,141 @@
+/**
+ * Minimum spacing, expressed in series-points (data indices, not pixels), between
+ * two RECEIVE/SEND markers. Transactions closer than this to the current cluster's
+ * anchor are merged into it, capping marker density to at most one every N points.
+ *
+ * This is applied to the indices of the *rendered* series, which the caller caps via
+ * downsampling (see MAX_SERIES_POINTS). Spacing is therefore a fraction of the visible
+ * width (≈ N / point-count) and stays roughly constant in pixels across ranges, rather
+ * than a fixed wall-clock window. Tune here to taste.
+ */
+export const MIN_SERIES_POINTS_BETWEEN_TX_MARKERS = 20;
+
+export type TransactionInput = Readonly<{
+  dateMs: number;
+  direction: "in" | "out";
+  fiat: number | null;
+}>;
+
+export type TransactionChartGroup = Readonly<{
+  index: number;
+  value: number;
+  dateMs: number;
+  receivedCount: number;
+  sentCount: number;
+  receivedFiat: number;
+  sentFiat: number;
+}>;
+
+type GroupTransactionsByChartIndexParams = Readonly<{
+  timestamps: number[];
+  values: number[];
+  transactions: TransactionInput[];
+  /**
+   * Minimum gap, in series-points, between two emitted markers.
+   * @default MIN_SERIES_POINTS_BETWEEN_TX_MARKERS
+   */
+  minSeriesPointsBetweenMarkers?: number;
+}>;
+
+function advanceNearestChartIndex(
+  timestamps: number[],
+  dateMs: number,
+  nearestIndex: number,
+): number {
+  let index = nearestIndex;
+  while (
+    index + 1 < timestamps.length &&
+    Math.abs(timestamps[index + 1] - dateMs) < Math.abs(timestamps[index] - dateMs)
+  ) {
+    index += 1;
+  }
+  return index;
+}
+
+function createEmptyChartGroup(
+  nearestIndex: number,
+  value: number,
+  dateMs: number,
+): TransactionChartGroup {
+  return {
+    index: nearestIndex,
+    value,
+    dateMs,
+    receivedCount: 0,
+    sentCount: 0,
+    receivedFiat: 0,
+    sentFiat: 0,
+  };
+}
+
+function mergeTransactionIntoGroup(
+  existing: TransactionChartGroup,
+  direction: TransactionInput["direction"],
+  fiat: number | null,
+): TransactionChartGroup {
+  const fiatValue = fiat == null || Number.isNaN(fiat) ? 0 : fiat;
+  return {
+    ...existing,
+    receivedCount: existing.receivedCount + (direction === "in" ? 1 : 0),
+    sentCount: existing.sentCount + (direction === "out" ? 1 : 0),
+    receivedFiat: existing.receivedFiat + (direction === "in" ? fiatValue : 0),
+    sentFiat: existing.sentFiat + (direction === "out" ? fiatValue : 0),
+  };
+}
+
+/**
+ * Groups transactions onto chart data points within the visible window, aggregating
+ * received/sent counts and fiat totals. Marker density is capped so two markers are
+ * never closer than `minSeriesPointsBetweenMarkers` series-points apart: a transaction
+ * within that gap of the current cluster's anchor is merged into it, otherwise it opens
+ * a new marker. Transactions outside the window or mapping to a point with a missing
+ * value are dropped. Null fiat values are excluded from the totals but still counted.
+ *
+ * Both the chart timestamps and (after sorting) the transactions are ascending, so the
+ * nearest data point only ever moves forward. We sweep them with a single shared pointer:
+ * O(n + m) for the merge, plus O(m log m) to sort the transactions — instead of a nearest
+ * lookup per transaction. On a tie, the lower index wins (the pointer does not advance).
+ */
+export function groupTransactionsByChartIndex({
+  timestamps,
+  values,
+  transactions,
+  minSeriesPointsBetweenMarkers = MIN_SERIES_POINTS_BETWEEN_TX_MARKERS,
+}: GroupTransactionsByChartIndexParams): TransactionChartGroup[] {
+  if (timestamps.length < 2) return [];
+
+  const windowStart = timestamps[0];
+  const windowEnd = timestamps.at(-1)!;
+
+  const transactionsInWindow = transactions
+    .filter(({ dateMs }) => dateMs >= windowStart && dateMs <= windowEnd)
+    .sort((a, b) => a.dateMs - b.dateMs);
+
+  const groups: TransactionChartGroup[] = [];
+  let nearestIndex = 0;
+
+  for (const { dateMs, direction, fiat } of transactionsInWindow) {
+    nearestIndex = advanceNearestChartIndex(timestamps, dateMs, nearestIndex);
+
+    const value = values[nearestIndex];
+    if (value == null || Number.isNaN(value)) continue;
+
+    // Anchor of the current cluster (markers and transactions are both ascending,
+    // so the last group always holds the smallest, left-most index of its cluster).
+    const last = groups[groups.length - 1];
+    if (last && nearestIndex - last.index < minSeriesPointsBetweenMarkers) {
+      groups[groups.length - 1] = mergeTransactionIntoGroup(last, direction, fiat);
+      continue;
+    }
+
+    groups.push(
+      mergeTransactionIntoGroup(
+        createEmptyChartGroup(nearestIndex, value, dateMs),
+        direction,
+        fiat,
+      ),
+    );
+  }
+
+  return groups;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/utils/rangeMapping.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/utils/rangeMapping.ts
@@ -1,18 +1,32 @@
 import { KeysPriceChange } from "@ledgerhq/live-common/market/utils/types";
 
 // Range buckets surfaced in the BalanceGraph segmented control.
-export const BALANCE_GRAPH_RANGES = ["1d", "1w", "1m", "1y"] as const;
+export const BALANCE_GRAPH_RANGES = ["1d", "1w", "1m", "6m", "1y", "all"] as const;
 
 export type RangeKey = (typeof BALANCE_GRAPH_RANGES)[number];
 
 const RANGE_KEY_SET: ReadonlySet<string> = new Set(BALANCE_GRAPH_RANGES);
 
-export const RANGE_TO_PRICE_CHANGE_KEY: Record<RangeKey, KeysPriceChange> = {
+export const RANGE_TO_PRICE_CHANGE_KEY: Partial<Record<RangeKey, KeysPriceChange>> = {
   "1d": KeysPriceChange.day,
   "1w": KeysPriceChange.week,
   "1m": KeysPriceChange.month,
   "1y": KeysPriceChange.year,
 };
+
+const CHART_DERIVED_PRICE_CHANGE_RANGES = new Set<RangeKey>(["6m", "all"]);
+
+export function isChartDerivedPriceChangeRange(range: RangeKey): boolean {
+  return CHART_DERIVED_PRICE_CHANGE_RANGES.has(range);
+}
+
+export function computeChartRangeChangePercentage(prices: readonly number[]): number | undefined {
+  if (prices.length < 2) return undefined;
+  const first = prices[0];
+  const last = prices[prices.length - 1];
+  if (first === 0) return 0;
+  return ((last - first) / first) * 100;
+}
 
 export function isRangeKey(value: string): value is RangeKey {
   return RANGE_KEY_SET.has(value);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Asset-detail balance graph: transaction dots (Received/Sent/clustered), tooltips and colors
  - New 6m / All timeframes and the timeframe selector
  - Trend row while scrubbing (percentage, fiat change and date driven by the hovered point)
  - Chart-derived % change for 6m/All (derived from the rendered series, not the market API)
  - Series downsampling — confirm the curve still looks correct and scrubbing/markers stay aligned
  - Performance of the Asset Detail screen on assets with many accounts/operations

### 📝 Description

The asset-detail balance graph previously offered only 1D/1W/1M/1Y timeframes, no transaction context on the curve, and only swapped the price for a date while scrubbing.

This PR enriches the graph:

- **Transaction markers**: operations scoped to the asset are mapped onto the curve as dots — green for a single receive, red for a single send, neutral grey for clusters — each with a point-only scrubber tooltip listing Received/Sent fiat totals (and a "{count} transactions" title for clusters). Marker density is capped via a configurable series-point spacing.
- **New timeframes**: 6M and All time are added. Because the market API has no key for these, their percentage change is derived from the rendered series endpoints; the displayed fiat change is derived from the same endpoints so the amount, percentage and line stay consistent.
- **Scrubbing**: the trend row now shows the variation from the range start to the hovered point (percentage + fiat) alongside the scrubbed date, instead of hiding the trend.
- **Performance**: the series fed to the SVG path is downsampled (preserving first/last/min/max) to cut render jank; operations are window-filtered before the per-op countervalue conversion, and the operation set is kept reference-stable across countervalue polls.

Review fixes applied on top of the feature: replaced an O(n) per-render id-join (and its `exhaustive-deps` violation) with a cheap reference-stable signature, removed a fallback that mislabeled the 1-year change under the All-time range, and corrected the chart-derived fiat change.


https://github.com/user-attachments/assets/5b2737ad-5299-4cad-a442-5b912513dba4



### ❓ Context

- **JIRA or GitHub link**: [LIVE-31679](https://ledgerhq.atlassian.net/browse/LIVE-31679)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31679]: https://ledgerhq.atlassian.net/browse/LIVE-31679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ