### PR TITLE
[LWM] feat(mobile): improve asset detail balance sizing

### DIFF
--- a/.changeset/bright-stones-rise.md
+++ b/.changeset/bright-stones-rise.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Improve mobile asset detail balance sizing.

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/TotalBalanceView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/TotalBalanceView.tsx
@@ -30,7 +30,12 @@ export function TotalBalanceView({
           {t("assetDetail.balanceDetails.totalBalance")}
         </Text>
         {counterValue != null && (
-          <AmountDisplay value={counterValue} formatter={counterValueFormatter} hidden={discreet} />
+          <AmountDisplay
+            value={counterValue}
+            formatter={counterValueFormatter}
+            hidden={discreet}
+            size="sm"
+          />
         )}
         <Text typography="body3" lx={{ color: "muted" }}>
           {formattedTotalBalance}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/BalanceGraphView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/BalanceGraphView.tsx
@@ -158,6 +158,7 @@ export function BalanceGraphView({
                 value={price}
                 formatter={priceFormatter}
                 animate={!isScrubbing}
+                size="md"
                 testID={ASSET_DETAIL_TEST_IDS.marketPrice}
               />
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/BalanceGraphView.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/BalanceGraphView.test.tsx
@@ -22,6 +22,7 @@ jest.mock("LLM/components/LineChart", () => ({
 // Override AmountDisplay to expose the `animate` prop (the real one renders an
 // odometer that is awkward to assert against).
 let mockAmountDisplayAnimate: boolean | undefined;
+let mockAmountDisplaySize: "sm" | "md" | undefined;
 jest.mock("@ledgerhq/lumen-ui-rnative", () => {
   const actual = jest.requireActual("@ledgerhq/lumen-ui-rnative");
   const ReactActual = jest.requireActual("react");
@@ -31,13 +32,16 @@ jest.mock("@ledgerhq/lumen-ui-rnative", () => {
     AmountDisplay: ({
       value,
       animate,
+      size,
       testID,
     }: {
       value: number;
       animate?: boolean;
+      size?: "sm" | "md";
       testID?: string;
     }) => {
       mockAmountDisplayAnimate = animate;
+      mockAmountDisplaySize = size;
       return ReactActual.createElement(Text, { testID }, String(value));
     },
   };
@@ -96,6 +100,7 @@ const buildProps = (overrides: Partial<ViewProps> = {}): ViewProps => ({
 describe("BalanceGraphView", () => {
   beforeEach(() => {
     mockAmountDisplayAnimate = undefined;
+    mockAmountDisplaySize = undefined;
     for (const key of Object.keys(mockLineChartProps)) delete mockLineChartProps[key];
   });
 
@@ -112,6 +117,7 @@ describe("BalanceGraphView", () => {
       render(<BalanceGraphView {...buildProps()} />);
 
       expect(mockAmountDisplayAnimate).toBe(true);
+      expect(mockAmountDisplaySize).toBe("md");
       expect(screen.getByText("Today")).toBeVisible();
       expect(screen.getByText("2.35%")).toBeVisible();
       expect(screen.getByText("+$1,000.00")).toBeVisible();


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Targeted Jest test covers the market price AmountDisplay size, and mobile typecheck passes.
- [x] **Impact of the changes:**
      - Asset Detail total balance sizing on mobile
      - Asset Detail market price amount sizing on mobile

### 📝 Description

This PR adjusts the mobile Asset Detail balance hierarchy to match the expected Lumen sizing.

The market price amount in the chart header now uses the large `AmountDisplay` variant explicitly, while the total balance amount in the balance details section uses the smaller `AmountDisplay` variant.

| Before | After |
| ------ | ----- |
| _Drag and drop screenshot here_ | _Drag and drop screenshot here_ |

### ❓ Context

- **JIRA or GitHub link**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)