### PR TITLE
[LWDM] feat(asset-detail): display infinite symbol for uncapped max supply

### DIFF
--- a/.changeset/asset-detail-infinite-max-supply.md
+++ b/.changeset/asset-detail-infinite-max-supply.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/asset-detail": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Show an infinite symbol (∞) instead of a dash for the Asset Detail max supply when a coin is uncapped but has market data

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/MarketStats/hooks/useMarketStatsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/MarketStats/hooks/useMarketStatsViewModel.ts
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { track } from "~/renderer/analytics/segment";
 import { ASSET_DETAIL_TRACKING_PAGE_NAME } from "LLD/features/AssetDetail/constants";
 import counterValueFormatter from "@ledgerhq/live-common/market/utils/countervalueFormatter";
+import { resolveMaxSupplyDisplay } from "@ledgerhq/asset-detail";
 import type { MarketDataSectionCurrencyData } from "../../hooks/useMarketDataSectionCurrencyData";
 import type { MarketStatRow } from "../../types";
 
@@ -30,11 +31,11 @@ export function useMarketStatsViewModel(currencyData: MarketDataSectionCurrencyD
       ticker: data?.ticker,
     });
 
-    const maxSupply = counterValueFormatter({
-      value: data?.maxSupply,
-      locale,
-      shorten: true,
-      ticker: data?.ticker,
+    const maxSupply = resolveMaxSupplyDisplay({
+      maxSupply: data?.maxSupply,
+      circulatingSupply: data?.circulatingSupply,
+      formatValue: value =>
+        counterValueFormatter({ value, locale, shorten: true, ticker: data?.ticker }),
     });
 
     const volume24h = counterValueFormatter({

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/__tests__/useMarketDataSectionViewModels.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/__tests__/useMarketDataSectionViewModels.test.ts
@@ -142,6 +142,34 @@ describe("useMarketStatsViewModel", () => {
     expect(result.current.rows.find(r => r.key === "circulating_supply")?.value).toMatch(/BTC$/);
     expect(result.current.rows.find(r => r.key === "max_supply")?.value).toMatch(/BTC$/);
   });
+
+  it("shows the ∞ symbol for max supply when the coin is uncapped but has market data", () => {
+    const { result } = renderHook(
+      () =>
+        useMarketStatsViewModel(
+          buildCurrencyData({
+            data: createMockMarketCurrencyData({ maxSupply: 0, circulatingSupply: 19_000_000 }),
+          }),
+        ),
+      hookOptions(),
+    );
+
+    expect(result.current.rows.find(r => r.key === "max_supply")?.value).toBe("∞");
+  });
+
+  it("shows a hyphen for max supply when no supply data is available", () => {
+    const { result } = renderHook(
+      () =>
+        useMarketStatsViewModel(
+          buildCurrencyData({
+            data: createMockMarketCurrencyData({ maxSupply: 0, circulatingSupply: 0 }),
+          }),
+        ),
+      hookOptions(),
+    );
+
+    expect(result.current.rows.find(r => r.key === "max_supply")?.value).toBe("-");
+  });
 });
 
 describe("usePricePerformanceViewModel", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/__tests__/useMarketStatsViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/__tests__/useMarketStatsViewModel.test.ts
@@ -77,7 +77,7 @@ describe("useMarketStatsViewModel", () => {
 
     it("returns '-' for missing values", () => {
       mockMarketData({
-        marketCurrency: { ...marketCurrencyData, marketcap: undefined, maxSupply: 0 } as any,
+        marketCurrency: { ...marketCurrencyData, marketcap: undefined } as any,
       });
 
       const { result } = renderHook(() =>
@@ -85,6 +85,29 @@ describe("useMarketStatsViewModel", () => {
       );
 
       expect(result.current.stats.find(s => s.key === "market_cap")?.value).toBe("-");
+    });
+
+    it("returns the ∞ symbol for max supply when the coin is uncapped but has market data", () => {
+      mockMarketData({
+        marketCurrency: { ...marketCurrencyData, maxSupply: 0 } as any,
+      });
+
+      const { result } = renderHook(() =>
+        useMarketStatsViewModel({ currency: mockBtcCryptoCurrency }),
+      );
+
+      expect(result.current.stats.find(s => s.key === "max_supply")?.value).toBe("∞");
+    });
+
+    it("returns '-' for max supply when no supply data is available", () => {
+      mockMarketData({
+        marketCurrency: { ...marketCurrencyData, maxSupply: 0, circulatingSupply: 0 } as any,
+      });
+
+      const { result } = renderHook(() =>
+        useMarketStatsViewModel({ currency: mockBtcCryptoCurrency }),
+      );
+
       expect(result.current.stats.find(s => s.key === "max_supply")?.value).toBe("-");
     });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/useMarketStatsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/useMarketStatsViewModel.ts
@@ -3,6 +3,7 @@ import type { AssetDetailCurrencyProps } from "LLM/features/AssetDetail/types";
 import { useTranslation, useLocale } from "~/context/Locale";
 import { track } from "~/analytics";
 import { counterValueFormatter } from "LLM/features/Market/utils";
+import { resolveMaxSupplyDisplay } from "@ledgerhq/asset-detail";
 import { useAssetMarketData } from "../../hooks/useAssetMarketData";
 
 type StatRow = {
@@ -83,15 +84,12 @@ export function useMarketStatsViewModel({
       {
         key: "max_supply",
         label: t("assetDetail.marketStats.maxSupply"),
-        value: maxSupply
-          ? counterValueFormatter({
-              value: maxSupply,
-              shorten: true,
-              locale,
-              t,
-              ticker: supplyTicker,
-            })
-          : "-",
+        value: resolveMaxSupplyDisplay({
+          maxSupply,
+          circulatingSupply,
+          formatValue: value =>
+            counterValueFormatter({ value, shorten: true, locale, t, ticker: supplyTicker }),
+        }),
         tooltip: {
           title: t("assetDetail.marketStats.maxSupply"),
           content: t("assetDetail.marketStats.maxSupplyTooltip"),

--- a/libs/asset-detail/src/index.ts
+++ b/libs/asset-detail/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./hooks/useAssetMarketData";
 export * from "./hooks/useReceiveNetworkLedgerIds";
 export * from "./utils/assetDetailMarketInfo";
+export * from "./utils/resolveMaxSupplyDisplay";
 export type {
   AssetDetailMarketInfo,
   AssetMarketData,

--- a/libs/asset-detail/src/utils/__tests__/resolveMaxSupplyDisplay.test.ts
+++ b/libs/asset-detail/src/utils/__tests__/resolveMaxSupplyDisplay.test.ts
@@ -1,0 +1,63 @@
+import {
+  resolveMaxSupplyDisplay,
+  INFINITE_SUPPLY_SYMBOL,
+  MISSING_VALUE,
+} from "../resolveMaxSupplyDisplay";
+
+describe("resolveMaxSupplyDisplay", () => {
+  const formatValue = (value: number) => `${value} BTC`;
+
+  describe("with a finite max supply", () => {
+    it("formats the value through the provided formatter", () => {
+      const result = resolveMaxSupplyDisplay({
+        maxSupply: 21_000_000,
+        circulatingSupply: 19_500_000,
+        formatValue,
+      });
+
+      expect(result).toBe("21000000 BTC");
+    });
+  });
+
+  describe("with no max supply", () => {
+    it("returns the infinite symbol when circulating supply is present (uncapped coin)", () => {
+      const result = resolveMaxSupplyDisplay({
+        maxSupply: undefined,
+        circulatingSupply: 120_000_000,
+        formatValue,
+      });
+
+      expect(result).toBe(INFINITE_SUPPLY_SYMBOL);
+    });
+
+    it("treats a 0 max supply as infinite when circulating supply is present", () => {
+      const result = resolveMaxSupplyDisplay({
+        maxSupply: 0,
+        circulatingSupply: 120_000_000,
+        formatValue,
+      });
+
+      expect(result).toBe(INFINITE_SUPPLY_SYMBOL);
+    });
+
+    it("returns the missing-value placeholder when no market data is available", () => {
+      const result = resolveMaxSupplyDisplay({
+        maxSupply: undefined,
+        circulatingSupply: undefined,
+        formatValue,
+      });
+
+      expect(result).toBe(MISSING_VALUE);
+    });
+
+    it("returns the missing-value placeholder when circulating supply is 0", () => {
+      const result = resolveMaxSupplyDisplay({
+        maxSupply: 0,
+        circulatingSupply: 0,
+        formatValue,
+      });
+
+      expect(result).toBe(MISSING_VALUE);
+    });
+  });
+});

--- a/libs/asset-detail/src/utils/resolveMaxSupplyDisplay.ts
+++ b/libs/asset-detail/src/utils/resolveMaxSupplyDisplay.ts
@@ -1,0 +1,26 @@
+export const INFINITE_SUPPLY_SYMBOL = "∞";
+export const MISSING_VALUE = "-";
+
+type ResolveMaxSupplyDisplayParams = {
+  maxSupply: number | undefined;
+  circulatingSupply: number | undefined;
+  formatValue: (value: number) => string;
+};
+
+/**
+ * Resolve what to display for the "Max Supply" market stat.
+ *
+ * A coin without a supply cap (e.g. ETH, DOGE) reports no `maxSupply`, which is
+ * an infinite max supply. We only treat a missing `maxSupply` as infinite when
+ * market data is actually loaded — detected via `circulatingSupply` — otherwise
+ * the value is simply unknown and we keep the missing-value placeholder.
+ */
+export function resolveMaxSupplyDisplay({
+  maxSupply,
+  circulatingSupply,
+  formatValue,
+}: ResolveMaxSupplyDisplayParams): string {
+  if (maxSupply) return formatValue(maxSupply);
+  if (circulatingSupply) return INFINITE_SUPPLY_SYMBOL;
+  return MISSING_VALUE;
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Asset Detail "Max Supply" market stat on **Desktop** and **Mobile**
      - Uncapped coins (e.g. ETH, DOGE) now render `∞` once market data is loaded
      - Coins with a real cap still show the formatted value; the `-` placeholder remains only while the value is genuinely unknown / not yet loaded

### 📝 Description

**Problem**: A coin without a supply cap (e.g. ETH, DOGE) reports no `maxSupply` from the market API. The Asset Detail "Max Supply" stat fell back to a `-` placeholder, which is ambiguous — it is indistinguishable from the case where market data simply has not loaded yet, so users could not tell that the supply is actually uncapped.

**Solution**: Added a shared `resolveMaxSupplyDisplay` helper in `@ledgerhq/asset-detail` and wired both the Desktop and Mobile `MarketStats` view models to it. When `maxSupply` is missing but market data is loaded (detected via `circulatingSupply`), the stat now renders the infinite symbol `∞`. A formatted value is shown when a cap exists, and the `-` placeholder is kept only when the value is genuinely unknown.

```ts
export function resolveMaxSupplyDisplay({
  maxSupply,
  circulatingSupply,
  formatValue,
}: ResolveMaxSupplyDisplayParams): string {
  if (maxSupply) return formatValue(maxSupply);
  if (circulatingSupply) return INFINITE_SUPPLY_SYMBOL; // "∞"
  return MISSING_VALUE; // "-"
}
```

### 📸 Screenshots

<img width="348" height="300" alt="image" src="https://github.com/user-attachments/assets/a4a7618a-9db6-47cd-9bb9-83fd0f021966" />

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-31718

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)