### PR TITLE
[LWM] fix(mobile): reduce asset detail tooltip spacing

### DIFF
--- a/.changeset/tidy-tooltips-rest.md
+++ b/.changeset/tidy-tooltips-rest.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix Asset Detail tooltip bottom spacing on mobile

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/EarnCardsView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/EarnCardsView.tsx
@@ -14,7 +14,6 @@ import {
 } from "@ledgerhq/lumen-ui-rnative";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { ChevronRight, Information } from "@ledgerhq/lumen-ui-rnative/symbols";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "~/context/Locale";
 import { ASSET_DETAIL_TEST_IDS } from "LLM/features/AssetDetail/testIds";
 
@@ -32,7 +31,6 @@ export function EarnCardsView({
   onAvailableBalanceTooltipOpen,
 }: Props) {
   const { t } = useTranslation();
-  const { bottom } = useSafeAreaInsets();
 
   return (
     <Box lx={rowStyle}>
@@ -58,11 +56,9 @@ export function EarnCardsView({
           <TooltipContent
             title={t("assetDetail.balanceDetails.availableBalance")}
             content={
-              <Box style={{ paddingBottom: bottom + 24 }}>
-                <Text typography="body1" lx={{ color: "base" }}>
-                  {t("assetDetail.balanceDetails.availableBalanceTooltip")}
-                </Text>
-              </Box>
+              <Text typography="body1" lx={{ color: "base" }}>
+                {t("assetDetail.balanceDetails.availableBalanceTooltip")}
+              </Text>
             }
           />
         </Tooltip>

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/MarketStatsView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/MarketStatsView.tsx
@@ -14,7 +14,6 @@ import {
 } from "@ledgerhq/lumen-ui-rnative";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { Information } from "@ledgerhq/lumen-ui-rnative/symbols";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "~/context/Locale";
 import { ASSET_DETAIL_TEST_IDS } from "LLM/features/AssetDetail/testIds";
 import { SectionContentState } from "../SectionContentState";
@@ -37,7 +36,6 @@ type Props = Readonly<{
 
 export function MarketStatsView({ stats, isLoading, isError, hasData, onTooltipOpen }: Props) {
   const { t } = useTranslation();
-  const { bottom } = useSafeAreaInsets();
 
   if (isLoading && !hasData) {
     return (
@@ -75,11 +73,9 @@ export function MarketStatsView({ stats, isLoading, isError, hasData, onTooltipO
                     <TooltipContent
                       title={stat.tooltip.title}
                       content={
-                        <Box style={{ paddingBottom: bottom + 24 }}>
-                          <Text typography="body1" lx={{ color: "base" }}>
-                            {stat.tooltip.content}
-                          </Text>
-                        </Box>
+                        <Text typography="body1" lx={{ color: "base" }}>
+                          {stat.tooltip.content}
+                        </Text>
                       }
                     />
                   </Tooltip>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Mobile typecheck and the existing MarketStats Jest tests pass; the exact sheet spacing is a visual regression and should be checked manually._
- [x] **Impact of the changes:**
      - Asset Detail market stats tooltip bottom spacing
      - Asset Detail available balance tooltip bottom spacing
      - iOS and Android bottom-sheet safe-area rendering

### 📝 Description

Asset Detail tooltips were adding local safe-area bottom padding inside the content passed to the global Lumen tooltip bottom sheet. Because Lumen already renders tooltip content inside a `BottomSheetHeader` and bottom-sheet container with their own spacing, this created too much empty space below short tooltip descriptions.

This PR removes the extra local `bottom + 24` padding from the Asset Detail tooltip content and renders the text directly in `TooltipContent`, letting the Lumen tooltip sheet handle its own layout.

| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

Click `...` → `Edit` on the PR description, then drag & drop your screenshots into the table.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-31716

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)