### PR TITLE
[LWM] fix: prevent duplicate transaction broadcast on device action re-render

### DIFF
--- a/.changeset/yellow-frogs-talk.md
+++ b/.changeset/yellow-frogs-talk.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix: prevent duplicate transaction broadcast on device action re-render, protecting all chains (including Tron) from double-submission via a mount-once guard

--- a/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
@@ -804,7 +804,7 @@ export function DeviceActionDefaultRendering<R, H extends Status, P>({
   }
 
   if (renderOnResult) {
-    return renderOnResult(payload);
+    return <RenderOnResultWithJSX renderOnResult={renderOnResult} payload={payload} />;
   }
 
   return null;
@@ -823,4 +823,19 @@ const RenderOnResultCallback = <P,>({
     // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   return null;
+};
+
+/**
+ * Calls renderOnResult exactly once (on mount) via useState lazy initializer,
+ * preventing re-renders from re-invoking side-effectful callbacks like broadcast.
+ */
+const RenderOnResultWithJSX = <P,>({
+  renderOnResult,
+  payload,
+}: {
+  renderOnResult: (_: NonNullable<P>) => React.JSX.Element | null;
+  payload: NonNullable<P>;
+}) => {
+  const [result] = useState<React.JSX.Element | null>(() => renderOnResult(payload));
+  return result;
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description
DeviceAction accepts a renderOnResult prop which is a render function. Because it was called inline during rendering, any re-render while the signed result was on screen would re-invoke the function — including the broadcast side-effect. On Hedera this surfaced visibly as DUPLICATE_TRANSACTION, but Tron would be equally vulnerable since its broadcast.ts just fires a raw HTTP call to the Tron network.

RenderOnResultWithJSX (lines 832–841) — a defensive wrapper at the DeviceAction level that uses a useState lazy initializer so renderOnResult is called exactly once on mount, not on every render. This is a belt-and-suspenders guard in case other callers of DeviceAction pass a side-effectful renderOnResult without their own ref guard.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31607](https://ledgerhq.atlassian.net/browse/LIVE-31607)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31607]: https://ledgerhq.atlassian.net/browse/LIVE-31607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ