### PR TITLE
[LWD] fix: improve tracking consistency

### DIFF
--- a/.changeset/fix-asset-detail-page-tracking.md
+++ b/.changeset/fix-asset-detail-page-tracking.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix Asset Detail analytics: report page name as `Asset`, set `market banner` as navigation source when opening from the portfolio market banner, and track average entry price tooltip via `market_stat_definition`.

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/HiddenBanner/__tests__/useHiddenBannerViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/HiddenBanner/__tests__/useHiddenBannerViewModel.test.ts
@@ -47,7 +47,7 @@ describe("useHiddenBannerViewModel", () => {
     expect(track).toHaveBeenCalledWith("button_clicked", {
       button: "show_in_portfolio",
       currency: "bitcoin",
-      page: "Asset detail",
+      page: "Asset",
     });
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/PnL/__tests__/useAssetPnlViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/PnL/__tests__/useAssetPnlViewModel.test.ts
@@ -5,7 +5,10 @@ import { act, renderHook, withFlagOverrides } from "tests/testSetup";
 import { buildDistributionItem } from "tests/utils/distributionTestUtils";
 import { BTC_ACCOUNT } from "LLD/features/__mocks__/accounts.mock";
 import type { PnLCardProps } from "LLD/features/PnL/components/PnLCard/types";
+import { track } from "~/renderer/analytics/segment";
 import { useAssetPnlViewModel } from "../useAssetPnlViewModel";
+
+const mockedTrack = jest.mocked(track);
 
 jest.mock("@ledgerhq/wallet-pnl/hooks", () => ({
   useAssetGroupPnL: jest.fn(),
@@ -93,5 +96,22 @@ describe("useAssetPnlViewModel", () => {
     act(() => card.onClick());
 
     expect(result.current.dialog.isOpen).toBe(true);
+  });
+
+  it("tracks market_stat_definition when the average entry price tooltip opens", () => {
+    const { result } = renderAssetPnlViewModel({ initialState: flagsOn });
+    const averageEntryCard = result.current.items.find(item => item.id === "averageEntryPrice");
+
+    expect(averageEntryCard?.type).toBe("info");
+    if (averageEntryCard?.type !== "info") throw new Error("expected info card");
+
+    act(() => averageEntryCard.onTooltipOpenChange?.(true));
+
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      button: "market_stat_definition",
+      currency: "bitcoin",
+      type: "average_entry_price",
+      page: "Asset",
+    });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/PnL/useAssetPnlViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/PnL/useAssetPnlViewModel.ts
@@ -1,11 +1,14 @@
+import { useCallback, useMemo } from "react";
 import { BigNumber } from "bignumber.js";
 import { useCountervaluesState } from "@ledgerhq/live-countervalues-react";
 import { useAssetGroupPnL } from "@ledgerhq/wallet-pnl/hooks";
 import type { DistributionItem } from "@ledgerhq/types-live";
 import { useSelector } from "LLD/hooks/redux";
 import { counterValueCurrencySelector } from "~/renderer/reducers/settings";
+import { track } from "~/renderer/analytics/segment";
 import { usePnlViewModelBase } from "LLD/features/PnL/hooks/usePnlViewModelBase";
 import type { PnlViewModel } from "LLD/features/PnL/types";
+import { ASSET_DETAIL_TRACKING_PAGE_NAME } from "LLD/features/AssetDetail/constants";
 
 const ZERO = new BigNumber(0);
 
@@ -16,11 +19,26 @@ type Props = {
 export function useAssetPnlViewModel({ distributionItem }: Props): PnlViewModel {
   const fiatCurrency = useSelector(counterValueCurrencySelector);
   const countervalues = useCountervaluesState();
+  const currencyId = distributionItem.currency.id;
 
   const groupPnl = useAssetGroupPnL(distributionItem.accounts, countervalues, fiatCurrency);
   const { averageEntryPrice = ZERO } = groupPnl ?? {};
 
-  return usePnlViewModelBase({
+  const onAverageEntryPriceTooltipOpen = useCallback(
+    (open: boolean) => {
+      if (open) {
+        track("button_clicked", {
+          button: "market_stat_definition",
+          currency: currencyId,
+          type: "average_entry_price",
+          page: ASSET_DETAIL_TRACKING_PAGE_NAME,
+        });
+      }
+    },
+    [currencyId],
+  );
+
+  const viewModel = usePnlViewModelBase({
     namespace: "pnl.asset",
     pnlData: groupPnl,
     secondaryCard: {
@@ -31,4 +49,16 @@ export function useAssetPnlViewModel({ distributionItem }: Props): PnlViewModel 
     },
     accountsCount: distributionItem.accounts.length,
   });
+
+  const items = useMemo(
+    () =>
+      viewModel.items.map(item =>
+        item.id === "averageEntryPrice" && item.type === "info"
+          ? { ...item, onTooltipOpenChange: onAverageEntryPriceTooltipOpen }
+          : item,
+      ),
+    [viewModel.items, onAverageEntryPriceTooltipOpen],
+  );
+
+  return { ...viewModel, items };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/StakingSection/__tests__/useStakingSectionViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/StakingSection/__tests__/useStakingSectionViewModel.test.ts
@@ -63,7 +63,7 @@ describe("useStakingSectionViewModel", () => {
 
     expect(mockStartStakeFlow).toHaveBeenCalledWith({
       currencies: ["bitcoin"],
-      source: "Asset detail",
+      source: "Asset",
     });
   });
 
@@ -236,12 +236,12 @@ describe("useStakingSectionViewModel", () => {
 
     expect(mockStartStakeFlow).toHaveBeenCalledWith({
       currencies: ["tron"],
-      source: "Asset detail",
+      source: "Asset",
     });
     expect(track).toHaveBeenCalledWith("button_clicked", {
       button: "earn_banner",
       currency: "tron",
-      page: "Asset detail",
+      page: "Asset",
     });
   });
 
@@ -258,12 +258,12 @@ describe("useStakingSectionViewModel", () => {
 
     expect(mockStartStakeFlow).toHaveBeenCalledWith({
       currencies: ["bitcoin"],
-      source: "Asset detail",
+      source: "Asset",
     });
     expect(track).toHaveBeenCalledWith("button_clicked", {
       button: "earn_deposit",
       currency: "bitcoin",
-      page: "Asset detail",
+      page: "Asset",
     });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/constants.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/constants.ts
@@ -1,1 +1,1 @@
-export const ASSET_DETAIL_TRACKING_PAGE_NAME = "Asset detail";
+export const ASSET_DETAIL_TRACKING_PAGE_NAME = "Asset";

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/TrendingAssetsList.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/TrendingAssetsList.test.tsx
@@ -4,13 +4,21 @@ import { TrendingAssetsList } from "../components/TrendingAssetsList";
 import { useNavigate } from "react-router";
 import { MOCK_MARKET_PERFORMERS } from "@ledgerhq/live-common/market/utils/fixtures";
 import { useHorizontalScroll } from "../hooks/useHorizontalScroll";
+import { setTrackingSource } from "~/renderer/analytics/TrackPage";
+import { MARKET_BANNER_TRACKING_SOURCE } from "../utils/constants";
 
 jest.mock("react-router", () => ({
   ...jest.requireActual("react-router"),
   useNavigate: jest.fn(),
 }));
 
+jest.mock("~/renderer/analytics/TrackPage", () => ({
+  setTrackingSource: jest.fn(),
+}));
+
 jest.mock("../hooks/useHorizontalScroll");
+
+const mockSetTrackingSource = jest.mocked(setTrackingSource);
 
 const mockNavigate = jest.fn();
 (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
@@ -50,6 +58,7 @@ describe("TrendingAssetsList", () => {
     const { user } = render(<TrendingAssetsList items={MOCK_MARKET_PERFORMERS} />);
 
     await user.click(screen.getByTestId("market-banner-asset-bitcoin"));
+    expect(mockSetTrackingSource).toHaveBeenCalledWith(MARKET_BANNER_TRACKING_SOURCE);
     expect(mockNavigate).toHaveBeenCalledWith("/market/bitcoin");
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/TrendingAssetsList.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/TrendingAssetsList.tsx
@@ -5,11 +5,13 @@ import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import { ViewAllTile } from "./ViewAllTile";
 import { TrendingAssetTile } from "./TrendingAssetTile";
 import { track } from "~/renderer/analytics/segment";
+import { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import FearAndGreed from "LLD/features/FearAndGreed";
 import { useHorizontalScroll } from "../hooks/useHorizontalScroll";
 import { ScrollArrowButton } from "./ScrollArrowButton";
 import { PORTFOLIO_TRACKING_PAGE_NAME } from "LLD/utils/constants";
 import { getMarketOrAssetDetailPath } from "LLD/utils/marketAssetNavigation";
+import { MARKET_BANNER_TRACKING_SOURCE } from "../utils/constants";
 
 type TrendingAssetsListProps = {
   readonly items: MarketItemPerformer[];
@@ -27,6 +29,7 @@ export const TrendingAssetsList = ({ items }: TrendingAssetsListProps) => {
         currency: id,
         page: PORTFOLIO_TRACKING_PAGE_NAME,
       });
+      setTrackingSource(MARKET_BANNER_TRACKING_SOURCE);
       navigate(getMarketOrAssetDetailPath(id, shouldDisplayAggregatedAssets));
     },
     [navigate, shouldDisplayAggregatedAssets],

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/utils/constants.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/utils/constants.ts
@@ -1,1 +1,4 @@
 export const MARKET_BANNER_ITEMS_COUNT = 11;
+
+/** Analytics source when navigating from a market banner tile to asset detail. */
+export const MARKET_BANNER_TRACKING_SOURCE = "market banner";

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/analytics/modularDialog.types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/analytics/modularDialog.types.ts
@@ -72,5 +72,5 @@ export const MODULAR_DIALOG_PAGE_NAME = {
 export const MAD_SOURCE_PAGES = {
   ACCOUNTS_PAGE: "Accounts",
   CRYPTOS_PAGE: "Cryptos",
-  ASSET_DETAIL: "Asset detail",
+  ASSET_DETAIL: "Asset",
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnLCard/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnLCard/index.tsx
@@ -54,7 +54,7 @@ export const PnLCard = (props: PnLCardProps) => {
                 <span className="body-3">{title}</span>
               </CardContentTitle>
               {type === "info" && (
-                <Tooltip>
+                <Tooltip onOpenChange={props.onTooltipOpenChange}>
                   <TooltipTrigger asChild>
                     <span className="inline-flex cursor-help">
                       <Information size={16} />

--- a/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnLCard/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnLCard/types.ts
@@ -16,6 +16,7 @@ type DisplayCard = TrendCard & {
 type InfoCard = {
   type: "info";
   tooltipContent: string;
+  onTooltipOpenChange?: (open: boolean) => void;
 };
 
 type PnLCardProps = {

--- a/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/useNavigateToStakeForAccount.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/useNavigateToStakeForAccount.test.ts
@@ -66,7 +66,7 @@ describe("useNavigateToStakeForAccount", () => {
     let outcome: ReturnType<typeof result.current.navigateToStakeForAccount> | undefined;
     act(() => {
       outcome = result.current.navigateToStakeForAccount(account, undefined, {
-        source: "Asset detail",
+        source: "Asset",
       });
     });
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request focuses on improving analytics consistency and user experience in the Asset Detail and Market Banner features. The main changes include standardizing tracking page/source names from "Asset detail" to "Asset" and enhancing analytics tracking for specific user interactions. Additionally, it introduces a new analytics source for market banner navigation and ensures tooltips in PnL cards are tracked.

### ❓ Context

[LIVE-28844](https://ledgerhq.atlassian.net/browse/LIVE-28844)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-28844]: https://ledgerhq.atlassian.net/browse/LIVE-28844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ