### PR TITLE
[LWM] fix(mobile): prevent asset detail tooltip truncation

### DIFF
--- a/.changeset/fresh-maps-smile.md
+++ b/.changeset/fresh-maps-smile.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix Asset Detail market stat tooltip definitions on Android

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/MarketStatsView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/MarketStatsView.tsx
@@ -14,7 +14,6 @@ import {
 } from "@ledgerhq/lumen-ui-rnative";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { Information } from "@ledgerhq/lumen-ui-rnative/symbols";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "~/context/Locale";
 import { ASSET_DETAIL_TEST_IDS } from "LLM/features/AssetDetail/testIds";
 import { SectionContentState } from "../SectionContentState";
@@ -37,7 +36,6 @@ type Props = Readonly<{
 
 export function MarketStatsView({ stats, isLoading, isError, hasData, onTooltipOpen }: Props) {
   const { t } = useTranslation();
-  const { bottom } = useSafeAreaInsets();
 
   if (isLoading && !hasData) {
     return (
@@ -74,13 +72,7 @@ export function MarketStatsView({ stats, isLoading, isError, hasData, onTooltipO
                     </TooltipTrigger>
                     <TooltipContent
                       title={stat.tooltip.title}
-                      content={
-                        <Box style={{ paddingBottom: bottom + 24 }}>
-                          <Text typography="body1" lx={{ color: "base" }}>
-                            {stat.tooltip.content}
-                          </Text>
-                        </Box>
-                      }
+                      content={stat.tooltip.content}
                     />
                   </Tooltip>
                 )}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/__tests__/MarketStatsView.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/__tests__/MarketStatsView.test.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { GlobalTooltipBottomSheet } from "@ledgerhq/lumen-ui-rnative";
+import { render, screen, waitFor } from "@tests/test-renderer";
+import { MarketStatsView } from "../MarketStatsView";
+
+const stats = [
+  {
+    key: "max_supply",
+    label: "Max supply",
+    value: "21M BTC",
+    tooltip: {
+      title: "Max supply",
+      content: "The maximum number of tokens that will ever exist.",
+    },
+  },
+  {
+    key: "trading_volume",
+    label: "24h trading volume",
+    value: "$25B",
+    tooltip: {
+      title: "24h trading volume",
+      content: "The total amount traded in the last 24 hours.",
+    },
+  },
+];
+
+function renderMarketStatsView() {
+  const onTooltipOpen = jest.fn();
+  const rendered = render(
+    <>
+      <MarketStatsView
+        stats={stats}
+        isLoading={false}
+        isError={false}
+        hasData
+        onTooltipOpen={onTooltipOpen}
+      />
+      <GlobalTooltipBottomSheet />
+    </>,
+  );
+
+  return { ...rendered, onTooltipOpen };
+}
+
+describe("MarketStatsView", () => {
+  it("should render market stat tooltip definitions as bottom sheet text", async () => {
+    const { user, onTooltipOpen } = renderMarketStatsView();
+
+    await user.press(screen.getByLabelText("Max supply"));
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Max supply")[1]).toBeVisible();
+      expect(screen.getByText("The maximum number of tokens that will ever exist.")).toBeVisible();
+    });
+    expect(onTooltipOpen).toHaveBeenCalledWith("max_supply", true);
+
+    await user.press(screen.getByLabelText("24h trading volume"));
+
+    await waitFor(() => {
+      expect(screen.getAllByText("24h trading volume")[1]).toBeVisible();
+      expect(screen.getByText("The total amount traded in the last 24 hours.")).toBeVisible();
+    });
+    expect(onTooltipOpen).toHaveBeenCalledWith("trading_volume", true);
+  });
+});


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Android Asset Detail market stat definition bottom sheets
      - Max supply and 24h trading volume tooltip rendering
      - Market stats analytics tracking remains unchanged

### 📝 Description

This PR fixes an Android-only text truncation issue on the Asset Detail screen where market stat definition bottom sheets could cut off the definitions for “Max supply” and “24h trading volume”.

The market stat tooltip content now passes the definition string directly to Lumen `TooltipContent`, matching the way the global tooltip bottom sheet renders descriptions through `BottomSheetHeader`. This avoids nesting a view inside text on React Native Android while preserving existing labels, values, translations, and analytics tracking.

<img width="399" height="848" alt="image" src="https://github.com/user-attachments/assets/5d6c729b-718c-490e-9db8-08605c413883" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31717](https://ledgerhq.atlassian.net/browse/LIVE-31717)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31717]: https://ledgerhq.atlassian.net/browse/LIVE-31717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ