### PR TITLE
[LWM] fix(mobile): return to asset detail after closing buy

### DIFF
--- a/.changeset/brave-buys-return.md
+++ b/.changeset/brave-buys-return.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix Buy close navigation from Asset Detail

--- a/apps/ledger-live-mobile/src/components/RootNavigator/ExchangeLiveAppNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/ExchangeLiveAppNavigator.tsx
@@ -34,6 +34,7 @@ const createExchangeScreen =
       platform,
       referrer,
       mode,
+      returnToPreviousScreenOnClose,
     } = props.route.params || {};
     const resolvedCurrency = currency
       ? findCryptoCurrencyByKeyword(currency)?.id
@@ -44,6 +45,7 @@ const createExchangeScreen =
         config={{
           screen: screenName,
           btnText: t("common.quote"),
+          returnToPreviousScreenOnClose,
         }}
         route={{
           ...props.route,

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/PtxNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/PtxNavigator.ts
@@ -16,6 +16,7 @@ type ExchangeParams = CommonParams & {
   defaultCurrencyId?: string;
   defaultTicker?: string;
   mode?: "offRamp" | "onRamp";
+  returnToPreviousScreenOnClose?: boolean;
 };
 
 export type PtxNavigatorParamList = {

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/BackToLwButton.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/BackToLwButton.tsx
@@ -20,6 +20,7 @@ export type BackConfig = {
     | ScreenName.Card
     | NavigatorName.CardTab;
   btnText?: string;
+  returnToPreviousScreenOnClose?: boolean;
 };
 
 type BackToInternalDomainProps = {

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/CustomHandlers.ts
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/CustomHandlers.ts
@@ -11,6 +11,7 @@ import {
 } from "@ledgerhq/live-common/wallet-api/types";
 import { AccountLike } from "@ledgerhq/types-live";
 import { useNavigation, useRoute } from "@react-navigation/native";
+import type { NavigationProp, ParamListBase } from "@react-navigation/native";
 import { useMemo, useState, useRef, useEffect, useCallback } from "react";
 import { track } from "~/analytics";
 import { currentRouteNameRef } from "~/analytics/screenRefs";
@@ -65,7 +66,33 @@ type CustomExchangeHandlersHookType = {
   onCompleteResult?: (exchangeParams: CompleteExchangeUiRequest, operationHash: string) => void;
   onCompleteError?: (error: Error) => void;
   handleLoaderDrawer?: () => void;
+  returnToPreviousScreenOnClose?: boolean;
 };
+
+type CloseNavigation = Pick<
+  NavigationProp<ParamListBase>,
+  "canGoBack" | "goBack" | "navigate"
+>;
+
+export function handlePTXCustomClose(
+  navigation: CloseNavigation | undefined,
+  {
+    screenName,
+    returnToPreviousScreenOnClose,
+  }: { screenName?: string; returnToPreviousScreenOnClose?: boolean },
+) {
+  const isExchangeScreen =
+    screenName === ScreenName.ExchangeBuy || screenName === ScreenName.ExchangeSell;
+
+  if (isExchangeScreen && returnToPreviousScreenOnClose && navigation?.canGoBack()) {
+    navigation.goBack();
+    return;
+  }
+
+  navigation?.navigate(NavigatorName.Base, {
+    screen: NavigatorName.Main,
+  });
+}
 
 export function useCustomExchangeHandlers({
   manifest,
@@ -74,6 +101,7 @@ export function useCustomExchangeHandlers({
   sendAppReady,
   onCompleteError,
   handleLoaderDrawer,
+  returnToPreviousScreenOnClose,
 }: CustomExchangeHandlersHookType) {
   const navigation = useNavigation<StackNavigatorNavigation<BaseNavigatorStackParamList>>();
   const route = useRoute();
@@ -188,8 +216,9 @@ export function useCustomExchangeHandlers({
   return useMemo<WalletAPICustomHandlers>(() => {
     const ptxCustomHandlers = {
       "custom.close": () => {
-        navigation.getParent()?.navigate(NavigatorName.Base, {
-          screen: NavigatorName.Main,
+        handlePTXCustomClose(navigation.getParent(), {
+          screenName: route.name,
+          returnToPreviousScreenOnClose,
         });
       },
       "custom.getFunds": (request: { params?: { accountId?: string; currencyId?: string } }) => {
@@ -516,11 +545,22 @@ export function useCustomExchangeHandlers({
     getManifestById,
     getAccount,
     dispatch,
+    route.name,
+    returnToPreviousScreenOnClose,
   ]);
 }
 
-export function usePTXCustomHandlers(manifest: WebviewProps["manifest"], accounts: AccountLike[]) {
-  return useCustomExchangeHandlers({ manifest, accounts, sendAppReady: sendEarnLiveAppReady });
+export function usePTXCustomHandlers(
+  manifest: WebviewProps["manifest"],
+  accounts: AccountLike[],
+  returnToPreviousScreenOnClose?: boolean,
+) {
+  return useCustomExchangeHandlers({
+    manifest,
+    accounts,
+    sendAppReady: sendEarnLiveAppReady,
+    returnToPreviousScreenOnClose,
+  });
 }
 
 export function createOpenInfoBottomSheetHandler(dispatch: Dispatch) {

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/__tests__/CustomHandlers.test.ts
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/__tests__/CustomHandlers.test.ts
@@ -1,6 +1,7 @@
 import {
   createOpenInfoBottomSheetHandler,
   createOpenMenuBottomSheetHandler,
+  handlePTXCustomClose,
 } from "../CustomHandlers";
 import { createOpenActionDialogHandler, resolveActionDialog } from "../actionDialogStore";
 import {
@@ -8,6 +9,83 @@ import {
   makeSetEarnMenuBottomSheetAction,
   makeSetEarnActionDialogAction,
 } from "~/actions/earn";
+import { NavigatorName, ScreenName } from "~/const";
+
+describe("handlePTXCustomClose", () => {
+  it("should go back when closing an exchange screen with navigation history", () => {
+    const navigation = {
+      canGoBack: jest.fn(() => true),
+      goBack: jest.fn(),
+      navigate: jest.fn(),
+    };
+
+    handlePTXCustomClose(navigation, {
+      screenName: ScreenName.ExchangeBuy,
+      returnToPreviousScreenOnClose: true,
+    });
+
+    expect(navigation.canGoBack).toHaveBeenCalledTimes(1);
+    expect(navigation.goBack).toHaveBeenCalledTimes(1);
+    expect(navigation.navigate).not.toHaveBeenCalled();
+  });
+
+  it("should navigate to main when closing an exchange screen without navigation history", () => {
+    const navigation = {
+      canGoBack: jest.fn(() => false),
+      goBack: jest.fn(),
+      navigate: jest.fn(),
+    };
+
+    handlePTXCustomClose(navigation, {
+      screenName: ScreenName.ExchangeBuy,
+      returnToPreviousScreenOnClose: true,
+    });
+
+    expect(navigation.canGoBack).toHaveBeenCalledTimes(1);
+    expect(navigation.goBack).not.toHaveBeenCalled();
+    expect(navigation.navigate).toHaveBeenCalledWith(NavigatorName.Base, {
+      screen: NavigatorName.Main,
+    });
+  });
+
+  it("should navigate to main when closing a non-exchange screen", () => {
+    const navigation = {
+      canGoBack: jest.fn(() => true),
+      goBack: jest.fn(),
+      navigate: jest.fn(),
+    };
+
+    handlePTXCustomClose(navigation, {
+      screenName: ScreenName.Card,
+      returnToPreviousScreenOnClose: true,
+    });
+
+    expect(navigation.canGoBack).not.toHaveBeenCalled();
+    expect(navigation.goBack).not.toHaveBeenCalled();
+    expect(navigation.navigate).toHaveBeenCalledWith(NavigatorName.Base, {
+      screen: NavigatorName.Main,
+    });
+  });
+
+  it("should navigate to main when closing an exchange screen without the previous-screen flag", () => {
+    const navigation = {
+      canGoBack: jest.fn(() => true),
+      goBack: jest.fn(),
+      navigate: jest.fn(),
+    };
+
+    handlePTXCustomClose(navigation, {
+      screenName: ScreenName.ExchangeBuy,
+      returnToPreviousScreenOnClose: false,
+    });
+
+    expect(navigation.canGoBack).not.toHaveBeenCalled();
+    expect(navigation.goBack).not.toHaveBeenCalled();
+    expect(navigation.navigate).toHaveBeenCalledWith(NavigatorName.Base, {
+      screen: NavigatorName.Main,
+    });
+  });
+});
 
 describe("createOpenInfoBottomSheetHandler", () => {
   it("should dispatch with validated params", async () => {

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/index.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/index.tsx
@@ -161,7 +161,11 @@ export const WebPTXPlayer = ({
   }, [config, disableHeader, isInternalApp, manifest, navigation, webviewState?.url, softExit]);
 
   const accounts = useSelector(flattenAccountsSelector);
-  const customPTXHandlers = usePTXCustomHandlers(manifest, accounts);
+  const customPTXHandlers = usePTXCustomHandlers(
+    manifest,
+    accounts,
+    config.returnToPreviousScreenOnClose,
+  );
   const customDeeplinkHandlers = useDeeplinkCustomHandlers();
   const customHandlers = useMemo<WalletAPICustomHandlers>(() => {
     return {

--- a/apps/ledger-live-mobile/src/mvvm/features/Buy/__tests__/useOpenBuySell.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Buy/__tests__/useOpenBuySell.test.ts
@@ -60,6 +60,30 @@ describe("useOpenBuySell (Market / QuickActions origin)", () => {
     expect(mockOpenDrawer).not.toHaveBeenCalled();
   });
 
+  test("should request previous-screen close behavior when opening buy from Asset Detail", () => {
+    const account = createBitcoinAccount("account-1");
+    const { result } = renderHook(
+      () => useOpenBuySell({ currency: bitcoin, sourceScreenName: "Asset Detail" }),
+      {
+        overrideInitialState: (state: State) => ({
+          ...state,
+          accounts: { ...state.accounts, active: [account] },
+        }),
+      },
+    );
+
+    act(() => {
+      result.current.handleOpenBuySell("buy");
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Exchange, {
+      screen: ScreenName.ExchangeBuy,
+      params: expect.objectContaining({
+        returnToPreviousScreenOnClose: true,
+      }),
+    });
+  });
+
   test("should navigate to exchange sell with defaultAccountId when account for currency exists", () => {
     const account = createBitcoinAccount("account-1");
     const { result } = renderHook(

--- a/apps/ledger-live-mobile/src/mvvm/features/Buy/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Buy/index.ts
@@ -11,6 +11,8 @@ import { NavigatorName, ScreenName } from "~/const";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { useModularDrawerController } from "../ModularDrawer";
 
+const ASSET_DETAIL_SOURCE_SCREEN_NAME = "Asset Detail";
+
 type UseOpenBuySellProps = {
   currency?: CryptoOrTokenCurrency;
   sourceScreenName: string;
@@ -63,10 +65,13 @@ export function useOpenBuySell({ currency, sourceScreenName }: UseOpenBuySellPro
           defaultCurrencyId: currency?.id,
           ...(defaultAccountId && { defaultAccountId }),
           ...(parentId && { parentId }),
+          ...(sourceScreenName === ASSET_DETAIL_SOURCE_SCREEN_NAME && {
+            returnToPreviousScreenOnClose: true,
+          }),
         },
       });
     },
-    [currency, navigation],
+    [currency, navigation, sourceScreenName],
   );
 
   const openAccountSelectionDrawer = useCallback(


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Buy/Sell close navigation from Asset Detail on iOS and Android
  - Buy/Sell close fallback from direct, deeplink, or cold-start flows

### 📝 Description

Closing the Buy flow from an Asset Detail entry point currently forces navigation back to the main Portfolio, so users lose the asset page context they came from.

This PR marks Buy/Sell flows opened from Asset Detail with an internal close-navigation flag. The PTX `custom.close` handler only goes back through the parent navigator when that flag is present and the Exchange screen has navigation history. It preserves the existing Portfolio fallback for all other Buy/Sell entries, direct/deeplink/cold-start flows, and non-Exchange live app contexts.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31721](https://ledgerhq.atlassian.net/browse/LIVE-31721)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31721]: https://ledgerhq.atlassian.net/browse/LIVE-31721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ