### PR TITLE
[LWM] feat(mobile): add PnL drawer tracking and spam guard

### DIFF
--- a/.changeset/pnl-drawer-tracking.md
+++ b/.changeset/pnl-drawer-tracking.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add PnL drawer page tracking and button spam guard

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/__tests__/usePnlSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/__tests__/usePnlSectionViewModel.test.ts
@@ -1,14 +1,19 @@
-import { act } from "react";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
-import { genAccount } from "@ledgerhq/live-common/mock/account";
+import { genMockAccount } from "@ledgerhq/live-common/mock/account";
+import type { Account } from "@ledgerhq/types-live";
 import * as walletPnlHooks from "@ledgerhq/wallet-pnl/hooks";
-import { renderHook, withFlagOverrides } from "@tests/test-renderer";
+import { act, renderHook, withFlagOverrides } from "@tests/test-renderer";
+import { track } from "~/analytics";
 import { State } from "~/reducers/types";
+import { PNL_BUTTON, PNL_DETAIL_PAGE } from "LLM/features/Pnl/const";
+import { ANALYTICS_PAGE } from "../../../../../const";
 import { usePnlSectionViewModel } from "../usePnlSectionViewModel";
 
-const btcAccount = genAccount("btc-1", {
-  currency: getCryptoCurrencyById("bitcoin"),
-  operationsSize: 0,
+const btc = getCryptoCurrencyById("bitcoin");
+let btcAccount: Account;
+
+beforeAll(async () => {
+  btcAccount = await genMockAccount("btc-1", { currency: btc, operationsSize: 0 });
 });
 
 const withAccounts = (state: State): State => ({
@@ -126,6 +131,57 @@ describe("usePnlSectionViewModel", () => {
       for (const item of result.current.drawer.items) {
         expect(item.value).not.toContain("***");
       }
+    });
+  });
+
+  describe("tracking", () => {
+    const mockedTrack = jest.mocked(track);
+
+    beforeEach(() => mockedTrack.mockClear());
+
+    it("fires a button_clicked track event when the drawer opens", () => {
+      const { result } = renderHook(() => usePnlSectionViewModel(), {
+        overrideInitialState: withPnl(true),
+      });
+
+      act(() => result.current.openDrawer());
+
+      expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+        button: PNL_BUTTON,
+        page: ANALYTICS_PAGE,
+      });
+    });
+
+    it("does not fire track again when openDrawer is called twice without closing", () => {
+      const { result } = renderHook(() => usePnlSectionViewModel(), {
+        overrideInitialState: withPnl(true),
+      });
+
+      act(() => result.current.openDrawer());
+      act(() => result.current.openDrawer());
+
+      expect(mockedTrack).toHaveBeenCalledTimes(1);
+    });
+
+    it("fires track again after close → reopen", () => {
+      const { result } = renderHook(() => usePnlSectionViewModel(), {
+        overrideInitialState: withPnl(true),
+      });
+
+      act(() => result.current.openDrawer());
+      act(() => result.current.drawer.onClose());
+      act(() => result.current.openDrawer());
+
+      expect(mockedTrack).toHaveBeenCalledTimes(2);
+    });
+
+    it("exposes pageName and source on the drawer", () => {
+      const { result } = renderHook(() => usePnlSectionViewModel(), {
+        overrideInitialState: withPnl(true),
+      });
+
+      expect(result.current.drawer.pageName).toBe(PNL_DETAIL_PAGE);
+      expect(result.current.drawer.source).toBe(ANALYTICS_PAGE);
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/index.tsx
@@ -54,6 +54,8 @@ export default function PnlSection() {
         description={drawer.description}
         items={drawer.items}
         footer={drawer.footer}
+        pageName={drawer.pageName}
+        source={drawer.source}
         testID={PNL_SECTION_TEST_IDS.detailDrawer}
       />
     </Box>

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/types.ts
@@ -15,5 +15,7 @@ export type PnlSectionViewModel = {
     description: string;
     items: PnlDetailItem[];
     footer: string;
+    pageName: string;
+    source: string;
   };
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/usePnlSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/usePnlSectionViewModel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState, useRef } from "react";
 import { BigNumber } from "bignumber.js";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import { usePortfolioPnL } from "@ledgerhq/wallet-pnl/hooks";
@@ -10,7 +10,10 @@ import { useCountervaluesState } from "~/reducers/countervalues";
 import { counterValueCurrencySelector, discreetModeSelector } from "~/reducers/settings";
 import { buildReturnCard } from "LLM/features/Pnl/builders/buildReturnCard";
 import { buildPnlDetail } from "LLM/features/Pnl/builders/buildPnlDetail";
+import { PNL_BUTTON, PNL_DETAIL_PAGE } from "LLM/features/Pnl/const";
 import type { PnlSectionViewModel } from "./types";
+import { track } from "~/analytics";
+import { ANALYTICS_PAGE } from "../../../../const";
 
 const ZERO = new BigNumber(0);
 const EMPTY_ACCOUNTS: Parameters<typeof usePortfolioPnL>[0] = [];
@@ -31,6 +34,22 @@ export function usePnlSectionViewModel(): PnlSectionViewModel {
   const [isDrawerOpen, setDrawerOpen] = useState(false);
   const openDrawer = useCallback(() => setDrawerOpen(true), []);
   const closeDrawer = useCallback(() => setDrawerOpen(false), []);
+  const drawerOpenGuardRef = useRef(false);
+
+  const handleCloseDrawer = useCallback(() => {
+    drawerOpenGuardRef.current = false;
+    closeDrawer();
+  }, [closeDrawer]);
+
+  const handleOpenDrawer = useCallback(() => {
+    if (drawerOpenGuardRef.current) return;
+    drawerOpenGuardRef.current = true;
+    openDrawer();
+    track("button_clicked", {
+      button: PNL_BUTTON,
+      page: ANALYTICS_PAGE,
+    });
+  }, [openDrawer]);
 
   const formatFiat = useCallback(
     (value: BigNumber, alwaysShowSign?: boolean) =>
@@ -83,14 +102,16 @@ export function usePnlSectionViewModel(): PnlSectionViewModel {
     title: t("pnl.portfolio.title"),
     unrealised,
     realised,
-    openDrawer,
+    openDrawer: handleOpenDrawer,
     drawer: {
       isOpen: isDrawerOpen,
-      onClose: closeDrawer,
+      onClose: handleCloseDrawer,
       title: detail.title,
       description: detail.description,
       items: detail.items,
       footer: t("pnl.disclaimer"),
+      pageName: PNL_DETAIL_PAGE,
+      source: ANALYTICS_PAGE,
     },
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/const.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/const.ts
@@ -1,0 +1,1 @@
+export const ASSET_DETAIL_PAGE = "Asset Detail";

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/__tests__/useAssetPnlViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/__tests__/useAssetPnlViewModel.test.ts
@@ -1,19 +1,33 @@
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
-import { genAccount } from "@ledgerhq/live-common/mock/account";
-import type { DistributionItem } from "@ledgerhq/types-live";
+import { genMockAccount } from "@ledgerhq/live-common/mock/account";
+import type { Account, DistributionItem } from "@ledgerhq/types-live";
 import * as walletPnlHooks from "@ledgerhq/wallet-pnl/hooks";
-import { renderHook, withFlagOverrides } from "@tests/test-renderer";
+import { act, renderHook, withFlagOverrides } from "@tests/test-renderer";
+import { track } from "~/analytics";
+import {
+  PNL_BUTTON,
+  PNL_DETAIL_PAGE,
+  AVERAGE_PRICE_PAGE,
+  AVERAGE_PRICE_EVENT,
+  AVERAGE_PRICE_BUTTON,
+  AVERAGE_PRICE_TYPE,
+} from "LLM/features/Pnl/const";
+import { ASSET_DETAIL_PAGE } from "LLM/features/AssetDetail/const";
 import { useAssetPnlViewModel } from "../useAssetPnlViewModel";
 
 const btc = getCryptoCurrencyById("bitcoin");
-const btcAccount = genAccount("btc-1", { currency: btc, operationsSize: 0 });
+let btcAccount: Account;
+let distributionItem: DistributionItem;
 
-const distributionItem: DistributionItem = {
-  currency: btc,
-  distribution: 1,
-  accounts: [btcAccount],
-  amount: 0,
-};
+beforeAll(async () => {
+  btcAccount = await genMockAccount("btc-1", { currency: btc, operationsSize: 0 });
+  distributionItem = {
+    currency: btc,
+    distribution: 1,
+    accounts: [btcAccount],
+    amount: 0,
+  };
+});
 
 const withPnlFlag = (enabled: boolean) =>
   withFlagOverrides({ lwmWallet40: { enabled: true, params: { pnl: enabled } } });
@@ -60,5 +74,89 @@ describe("useAssetPnlViewModel", () => {
     });
 
     expect(result.current.secondary.value).toMatch(/0(?:[.,]00)?/);
+  });
+
+  describe("tracking", () => {
+    const mockedTrack = jest.mocked(track);
+
+    beforeEach(() => mockedTrack.mockClear());
+
+    it("fires a button_clicked track event when the pnl drawer opens", () => {
+      const { result } = renderHook(
+        () => useAssetPnlViewModel({ distributionItem, enabled: true }),
+        { overrideInitialState: withPnlFlag(true) },
+      );
+
+      act(() => result.current.unrealised.onPress());
+
+      expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+        button: PNL_BUTTON,
+        page: ASSET_DETAIL_PAGE,
+      });
+    });
+
+    it("fires a market_stat_definition track event when the secondary drawer opens", () => {
+      const { result } = renderHook(
+        () => useAssetPnlViewModel({ distributionItem, enabled: true }),
+        { overrideInitialState: withPnlFlag(true) },
+      );
+
+      act(() => result.current.secondary.onPress());
+
+      expect(mockedTrack).toHaveBeenCalledWith(AVERAGE_PRICE_EVENT, {
+        button: AVERAGE_PRICE_BUTTON,
+        page: ASSET_DETAIL_PAGE,
+        type: AVERAGE_PRICE_TYPE,
+      });
+    });
+
+    it("does not fire track again when onPress is called twice without closing", () => {
+      const { result } = renderHook(
+        () => useAssetPnlViewModel({ distributionItem, enabled: true }),
+        { overrideInitialState: withPnlFlag(true) },
+      );
+
+      act(() => result.current.unrealised.onPress());
+      act(() => result.current.unrealised.onPress());
+
+      expect(mockedTrack).toHaveBeenCalledTimes(1);
+    });
+
+    it("fires track again after close → reopen", () => {
+      const { result } = renderHook(
+        () => useAssetPnlViewModel({ distributionItem, enabled: true }),
+        { overrideInitialState: withPnlFlag(true) },
+      );
+
+      act(() => result.current.unrealised.onPress());
+      act(() => result.current.pnlDrawer.onClose());
+      act(() => result.current.unrealised.onPress());
+
+      expect(mockedTrack).toHaveBeenCalledTimes(2);
+    });
+
+    it("guards across different drawers — opening pnl blocks secondary", () => {
+      const { result } = renderHook(
+        () => useAssetPnlViewModel({ distributionItem, enabled: true }),
+        { overrideInitialState: withPnlFlag(true) },
+      );
+
+      act(() => result.current.unrealised.onPress());
+      act(() => result.current.secondary.onPress());
+
+      expect(mockedTrack).toHaveBeenCalledTimes(1);
+    });
+
+    it("exposes pageName and source on both drawers", () => {
+      const { result } = renderHook(
+        () => useAssetPnlViewModel({ distributionItem, enabled: true }),
+        { overrideInitialState: withPnlFlag(true) },
+      );
+
+      expect(result.current.pnlDrawer.pageName).toBe(PNL_DETAIL_PAGE);
+      expect(result.current.pnlDrawer.source).toBe(ASSET_DETAIL_PAGE);
+      expect(result.current.secondaryDrawer.pageName).toBe(AVERAGE_PRICE_PAGE);
+      expect(result.current.secondaryDrawer.source).toBe(ASSET_DETAIL_PAGE);
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/index.tsx
@@ -69,6 +69,8 @@ function PnLSectionContent({
         description={pnlDrawer.description}
         items={pnlDrawer.items}
         footer={pnlDrawer.footer}
+        pageName={pnlDrawer.pageName}
+        source={pnlDrawer.source}
         testID={ASSET_DETAIL_PNL_TEST_IDS.detailDrawer}
       />
       <PnlDetailDrawer
@@ -76,6 +78,8 @@ function PnLSectionContent({
         onClose={secondaryDrawer.onClose}
         title={secondaryDrawer.title}
         bodyText={secondaryDrawer.bodyText}
+        pageName={secondaryDrawer.pageName}
+        source={secondaryDrawer.source}
         testID={ASSET_DETAIL_PNL_TEST_IDS.secondaryDrawer}
       />
     </>

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/useAssetPnlViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/useAssetPnlViewModel.ts
@@ -6,6 +6,7 @@ import { useCountervaluesState } from "~/reducers/countervalues";
 import { counterValueCurrencySelector } from "~/reducers/settings";
 import { usePnlViewModelBase } from "LLM/features/Pnl/hooks/usePnlViewModelBase";
 import type { PnlViewModel } from "LLM/features/Pnl/types";
+import { ASSET_DETAIL_PAGE } from "LLM/features/AssetDetail/const";
 
 const ZERO = new BigNumber(0);
 const EMPTY_ACCOUNTS: Parameters<typeof useAssetGroupPnL>[0] = [];
@@ -34,5 +35,6 @@ export function useAssetPnlViewModel({ distributionItem, enabled }: Props): PnlV
       value: averageEntryPrice,
     },
     accountsCount: distributionItem.accounts.length,
+    source: ASSET_DETAIL_PAGE,
   });
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/__integrations__/pnlDetailDrawer.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/__integrations__/pnlDetailDrawer.integration.test.tsx
@@ -1,7 +1,19 @@
 import React from "react";
 import { render, screen } from "@tests/test-renderer";
+import { TrackScreen } from "~/analytics";
 import { PnlDetailDrawer } from "../components/PnlDetailDrawer";
 import { PnlDetailItem } from "../components/PnlDetailDrawer/types";
+import { PNL_DETAIL_PAGE } from "../const";
+
+jest.mock("~/analytics", () => {
+  const actual = jest.requireActual("~/analytics");
+  return {
+    ...actual,
+    TrackScreen: jest.fn(() => null),
+  };
+});
+
+const mockedTrackScreen = jest.mocked(TrackScreen);
 
 const TITLE = "Profit & Loss";
 const DESCRIPTION = "Lifetime metrics for your portfolio.";
@@ -56,19 +68,53 @@ describe("PnlDetailDrawer integration", () => {
   });
 
   it("renders rows without a definition", () => {
-    const ITEMS_WITHOUT_DEFINITION: PnlDetailItem[] = [
-      { title: "Bare row", value: "$50.00 USD" },
-    ];
+    const ITEMS_WITHOUT_DEFINITION: PnlDetailItem[] = [{ title: "Bare row", value: "$50.00 USD" }];
     render(
-      <PnlDetailDrawer
-        isOpen
-        onClose={jest.fn()}
-        title={TITLE}
-        items={ITEMS_WITHOUT_DEFINITION}
-      />,
+      <PnlDetailDrawer isOpen onClose={jest.fn()} title={TITLE} items={ITEMS_WITHOUT_DEFINITION} />,
     );
 
     expect(screen.getByText("Bare row")).toBeVisible();
     expect(screen.getByText("$50.00 USD")).toBeVisible();
+  });
+
+  describe("TrackScreen", () => {
+    beforeEach(() => mockedTrackScreen.mockClear());
+
+    it("renders TrackScreen with pageName and source when open", () => {
+      render(
+        <PnlDetailDrawer
+          isOpen
+          onClose={jest.fn()}
+          title={TITLE}
+          pageName={PNL_DETAIL_PAGE}
+          source="Analytics"
+        />,
+      );
+
+      expect(mockedTrackScreen).toHaveBeenCalledWith(
+        expect.objectContaining({ name: PNL_DETAIL_PAGE, source: "Analytics" }),
+        undefined,
+      );
+    });
+
+    it("does not render TrackScreen when closed", () => {
+      render(
+        <PnlDetailDrawer
+          isOpen={false}
+          onClose={jest.fn()}
+          title={TITLE}
+          pageName={PNL_DETAIL_PAGE}
+          source="Analytics"
+        />,
+      );
+
+      expect(mockedTrackScreen).not.toHaveBeenCalled();
+    });
+
+    it("does not render TrackScreen when pageName is not provided", () => {
+      render(<PnlDetailDrawer isOpen onClose={jest.fn()} title={TITLE} />);
+
+      expect(mockedTrackScreen).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlDetailDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlDetailDrawer/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Box, BottomSheetHeader, BottomSheetView, Text } from "@ledgerhq/lumen-ui-rnative";
+import { TrackScreen } from "~/analytics";
 import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
 import { PnlDetailDrawerProps } from "./types";
 import { PnlDetailRow } from "./PnlDetailRow";
@@ -14,6 +15,8 @@ export function PnlDetailDrawer({
   items = [],
   footer,
   testID,
+  pageName,
+  source,
 }: Readonly<PnlDetailDrawerProps>) {
   const { bottom: bottomInset } = useSafeAreaInsets();
 
@@ -24,6 +27,7 @@ export function PnlDetailDrawer({
       enableDynamicSizing
       onClose={onClose}
     >
+      {isOpen && pageName ? <TrackScreen name={pageName} source={source} /> : null}
       <BottomSheetView style={{ paddingBottom: bottomInset + 24 }}>
         <BottomSheetHeader density="expanded" title={title} description={description} />
         {bodyText ? (

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlDetailDrawer/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlDetailDrawer/types.ts
@@ -16,4 +16,6 @@ export type PnlDetailDrawerProps = {
   /** Optional muted footer (body4, muted) rendered below the items. */
   footer?: string;
   testID?: string;
+  pageName?: string;
+  source?: string;
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/const.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/const.ts
@@ -1,5 +1,5 @@
 export const PNL_BUTTON = "Pnl details";
-export const PNL_DETAIL_PAGE = "Detailed PNL";
+export const PNL_DETAIL_PAGE = "Detailed PnL";
 export const AVERAGE_PRICE_PAGE = "Average Price";
 export const AVERAGE_PRICE_EVENT = "market_stat_definition";
 export const AVERAGE_PRICE_BUTTON = "average_price";

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/const.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/const.ts
@@ -1,0 +1,6 @@
+export const PNL_BUTTON = "Pnl details";
+export const PNL_DETAIL_PAGE = "Detailed PNL";
+export const AVERAGE_PRICE_PAGE = "Average Price";
+export const AVERAGE_PRICE_EVENT = "market_stat_definition";
+export const AVERAGE_PRICE_BUTTON = "average_price";
+export const AVERAGE_PRICE_TYPE = "average price";

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/hooks/usePnlViewModelBase.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/hooks/usePnlViewModelBase.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { BigNumber } from "bignumber.js";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
@@ -9,6 +9,15 @@ import { buildUnrealisedReturnCard } from "../builders/buildUnrealisedReturnCard
 import { buildSecondaryCard } from "../builders/buildSecondaryCard";
 import { buildPnlDetail } from "../builders/buildPnlDetail";
 import type { PnlNamespace, PnlNumbers, PnlSecondaryCardConfig, PnlViewModel } from "../types";
+import {
+  PNL_BUTTON,
+  PNL_DETAIL_PAGE,
+  AVERAGE_PRICE_PAGE,
+  AVERAGE_PRICE_EVENT,
+  AVERAGE_PRICE_BUTTON,
+  AVERAGE_PRICE_TYPE,
+} from "../const";
+import { track } from "~/analytics";
 
 const ZERO = new BigNumber(0);
 
@@ -19,6 +28,7 @@ export type UsePnlViewModelBaseInput = {
   pnlData: PnlNumbers | null;
   secondaryCard: PnlSecondaryCardConfig;
   accountsCount: number;
+  source?: string;
 };
 
 export function usePnlViewModelBase({
@@ -26,6 +36,7 @@ export function usePnlViewModelBase({
   pnlData,
   secondaryCard,
   accountsCount,
+  source,
 }: UsePnlViewModelBaseInput): PnlViewModel {
   const { t } = useTranslation();
   const { locale } = useLocale();
@@ -51,16 +62,41 @@ export function usePnlViewModelBase({
   const openSecondaryDrawer = useCallback(() => setOpenDrawer("secondary"), []);
   const closeDrawer = useCallback(() => setOpenDrawer(null), []);
 
+  const drawerOpenGuardRef = useRef(false);
+
+  const handleCloseDrawer = useCallback(() => {
+    drawerOpenGuardRef.current = false;
+    closeDrawer();
+  }, [closeDrawer]);
+
+  const handleOpenPnlDrawer = useCallback(() => {
+    if (drawerOpenGuardRef.current) return;
+    drawerOpenGuardRef.current = true;
+    track("button_clicked", { button: PNL_BUTTON, page: source });
+    openPnlDrawer();
+  }, [openPnlDrawer, source]);
+
+  const handleOpenSecondaryDrawer = useCallback(() => {
+    if (drawerOpenGuardRef.current) return;
+    drawerOpenGuardRef.current = true;
+    track(AVERAGE_PRICE_EVENT, {
+      button: AVERAGE_PRICE_BUTTON,
+      page: source,
+      type: AVERAGE_PRICE_TYPE,
+    });
+    openSecondaryDrawer();
+  }, [openSecondaryDrawer, source]);
+
   const unrealised = useMemo(
     () =>
       buildUnrealisedReturnCard({
         namespace,
         unrealisedPnL,
         formatFiat,
-        onPress: openPnlDrawer,
+        onPress: handleOpenPnlDrawer,
         t,
       }),
-    [namespace, unrealisedPnL, formatFiat, openPnlDrawer, t],
+    [namespace, unrealisedPnL, formatFiat, handleOpenPnlDrawer, t],
   );
 
   const secondary = useMemo(
@@ -68,10 +104,10 @@ export function usePnlViewModelBase({
       buildSecondaryCard({
         ...secondaryCard,
         formatFiat,
-        onPress: openSecondaryDrawer,
+        onPress: handleOpenSecondaryDrawer,
         t,
       }),
-    [secondaryCard, formatFiat, openSecondaryDrawer, t],
+    [secondaryCard, formatFiat, handleOpenSecondaryDrawer, t],
   );
 
   const detail = useMemo(
@@ -85,17 +121,21 @@ export function usePnlViewModelBase({
     secondary,
     pnlDrawer: {
       isOpen: openDrawer === "pnl",
-      onClose: closeDrawer,
+      onClose: handleCloseDrawer,
       title: detail.title,
       description: detail.description,
       items: detail.items,
       footer: t("pnl.disclaimer"),
+      pageName: PNL_DETAIL_PAGE,
+      source,
     },
     secondaryDrawer: {
       isOpen: openDrawer === "secondary",
-      onClose: closeDrawer,
+      onClose: handleCloseDrawer,
       title: t(secondaryCard.titleKey),
       bodyText: t(secondaryCard.tooltipKey),
+      pageName: AVERAGE_PRICE_PAGE,
+      source,
     },
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/types.ts
@@ -37,6 +37,8 @@ export type PnlDrawerViewModel = {
   isOpen: boolean;
   onClose: () => void;
   title: string;
+  pageName?: string;
+  source?: string;
 };
 
 export type PnlViewModel = {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - PnL drawer open/close tracking on Analytics and AssetDetail screens
      - Spam guard preventing duplicate `button_clicked` events on rapid taps
      - TrackScreen page-level analytics inside PnL bottom sheets

### 📝 Description

**Problem**: PnL bottom sheets lacked page-level tracking, making it impossible to measure how users interact with PnL detail drawers. Additionally, rapid tapping on drawer open buttons could fire duplicate tracking events.

**Solution**:
- Added `TrackScreen` to `PnlDetailDrawer`, conditionally rendered when `isOpen && pageName` to fire on each open and unmount on close
- Added a ref-based guard (`drawerOpenGuardRef`) in both `usePnlSectionViewModel` (Analytics) and `usePnlViewModelBase` (AssetDetail) to synchronously block duplicate opens before React re-renders
- Wired `pageName` and `source` through the drawer props and view model types
- Added comprehensive tests covering: track event firing, spam guard behavior, close→reopen cycle, cross-drawer guard, and TrackScreen conditional rendering

https://github.com/user-attachments/assets/9b6f2a18-107c-4478-88ad-619a326e0fb5


### ❓ Context

- **JIRA or GitHub link**: [LIVE-30308](https://ledgerhq.atlassian.net/browse/LIVE-30308)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30308]: https://ledgerhq.atlassian.net/browse/LIVE-30308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ