### PR TITLE
[LWDM] fix(assets): refresh stale DADA asset prices via polling

### DIFF
--- a/.changeset/refresh-dada-asset-prices.md
+++ b/.changeset/refresh-dada-asset-prices.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/live-common": minor
+"ledger-live-desktop": minor
+"@ledgerhq/asset-detail": minor
+"live-mobile": minor
+---
+
+Refresh stale DADA-sourced asset prices by enabling polling: discovery/default rows in the desktop Assets section and the market price on the Asset Detail page (desktop & mobile) now refetch periodically instead of showing a one-time snapshot

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/constants.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/constants.ts
@@ -2,6 +2,9 @@ export const MAX_ITEM_DISPLAYED = 6;
 export const EMPTY_STATE_STABLECOINS = 2;
 export const EMPTY_STATE_CRYPTOS = 4;
 
+/** How often to refetch DADA assets data so discovery/default row prices stay fresh. */
+export const ASSETS_PRICE_REFRESH_INTERVAL_MS = 180_000;
+
 /** Query param on `/assets` for which category to show (cryptos-only vs stablecoins-only). */
 export const ASSETS_PAGE_CATEGORY_QUERY = "category";
 export const ASSETS_PAGE_CATEGORY_CRYPTOS = "cryptos";

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useAssetsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useAssetsViewModel.ts
@@ -17,6 +17,7 @@ import { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import {
   ASSETS_PAGE_CATEGORY_CRYPTOS,
   ASSETS_PAGE_CATEGORY_STABLECOINS,
+  ASSETS_PRICE_REFRESH_INTERVAL_MS,
   EMPTY_STATE_CRYPTOS,
   EMPTY_STATE_STABLECOINS,
   MAX_ITEM_DISPLAYED,
@@ -49,6 +50,8 @@ export function useAssetsViewModel(): AssetsViewProps {
     product: "lld",
     version: __APP_VERSION__,
     skip: !needsPadding,
+    pollingInterval: ASSETS_PRICE_REFRESH_INTERVAL_MS,
+    skipPollingIfUnfocused: true,
   });
 
   const navigate = useNavigate();

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/hooks/useCryptoAssetsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/hooks/useCryptoAssetsViewModel.ts
@@ -20,6 +20,7 @@ import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import {
   ASSETS_PAGE_CATEGORY_CRYPTOS,
   ASSETS_PAGE_CATEGORY_STABLECOINS,
+  ASSETS_PRICE_REFRESH_INTERVAL_MS,
   EMPTY_STATE_CRYPTOS,
   EMPTY_STATE_STABLECOINS,
 } from "LLD/features/Assets/constants";
@@ -54,6 +55,8 @@ export default function useCryptoAssetsViewModel(): CryptoAssetsViewModel {
     product: "lld",
     version: __APP_VERSION__,
     skip: !needsCryptoPlaceholders && !needsStablecoinPlaceholders,
+    pollingInterval: ASSETS_PRICE_REFRESH_INTERVAL_MS,
+    skipPollingIfUnfocused: true,
   });
 
   const resolvedDefaults = useMemo(

--- a/libs/asset-detail/src/hooks/useAssetMarketData.ts
+++ b/libs/asset-detail/src/hooks/useAssetMarketData.ts
@@ -50,7 +50,10 @@ export function useAssetMarketData({
       version,
       isStaging,
     },
-    { skip: !effectiveLedgerIds?.length },
+    {
+      skip: !effectiveLedgerIds?.length,
+      pollingInterval: REFETCH_TIME_ONE_MINUTE * BASIC_REFETCH,
+    },
   );
 
   const dadaMarket = effectiveLedgerIds?.[0]

--- a/libs/ledger-live-common/src/dada-client/hooks/__tests__/useAssetsData.test.ts
+++ b/libs/ledger-live-common/src/dada-client/hooks/__tests__/useAssetsData.test.ts
@@ -192,4 +192,33 @@ describe("useAssetsData", () => {
     expect(result.current.data).toBeUndefined();
     expect(result.current.loadNext).toBeUndefined();
   });
+
+  it("should forward polling options to the underlying query", () => {
+    mockuseGetAssetsDataInfiniteQuery.mockReturnValue({ ...defaultMockValues });
+
+    renderHook(() =>
+      useAssetsData({
+        product: "lld",
+        version: "1.0.0",
+        pollingInterval: 60_000,
+        skipPollingIfUnfocused: true,
+      }),
+    );
+
+    expect(mockuseGetAssetsDataInfiniteQuery).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ pollingInterval: 60_000, skipPollingIfUnfocused: true }),
+    );
+  });
+
+  it("should not poll by default", () => {
+    mockuseGetAssetsDataInfiniteQuery.mockReturnValue({ ...defaultMockValues });
+
+    renderHook(() => useAssetsData({ product: "lld", version: "1.0.0" }));
+
+    expect(mockuseGetAssetsDataInfiniteQuery).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ pollingInterval: undefined }),
+    );
+  });
 });

--- a/libs/ledger-live-common/src/dada-client/hooks/useAssetsData.ts
+++ b/libs/ledger-live-common/src/dada-client/hooks/useAssetsData.ts
@@ -27,9 +27,13 @@ export function useAssetsData({
   isStaging,
   includeTestNetworks,
   skip,
+  pollingInterval,
+  skipPollingIfUnfocused,
 }: GetAssetsDataParams & {
   areCurrenciesFiltered?: boolean;
   skip?: boolean;
+  pollingInterval?: number;
+  skipPollingIfUnfocused?: boolean;
 }) {
   const {
     data,
@@ -51,7 +55,7 @@ export function useAssetsData({
       isStaging,
       includeTestNetworks,
     },
-    { skip },
+    { skip, pollingInterval, skipPollingIfUnfocused },
   );
 
   const joinedPages = useMemo(() => {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Unit tests cover the new `useAssetsData` polling options; the end-to-end MSW polling test is deferred (jsdom/undici `clearImmediate` env issue) and the price-refresh behavior is verified manually._
- [x] **Impact of the changes:**
  - Assets section (home + crypto-assets page): discovery/default row prices now refresh (~3 min) instead of being frozen for the session.
  - Asset Detail page (desktop & mobile): market price now refetches periodically.
  - Confirm other `useAssetsData` consumers (Modular Asset Drawer/Dialog, search drawers, mobile screens) are unaffected — they don't opt into polling.

### 📝 Description

**Problem:** Prices coming from the DADA `/assets` API were fetched once and cached for the whole session. As a result, discovery/default rows in the Assets section and the market price on the Asset Detail page never refreshed — the displayed value was effectively frozen. (Owned-asset prices, which flow through the countervalues engine, already refreshed correctly.)

**Solution:** Enable RTK Query polling on the DADA queries that drive those prices, opt-in so shared consumers are unaffected:

- `@ledgerhq/live-common` — `useAssetsData` gains optional `pollingInterval` / `skipPollingIfUnfocused`, forwarded to the underlying infinite query (default off → existing consumers unchanged).
- `ledger-live-desktop` — the Assets section view-models (`useAssetsViewModel`, `useCryptoAssetsViewModel`) enable polling at `ASSETS_PRICE_REFRESH_INTERVAL_MS` (3 min).
- `@ledgerhq/asset-detail` — the shared `useAssetMarketData` hook polls its DADA query (`useGetAssetDataQuery`) at the same 3-min cadence as the sibling CoinGecko query; this covers both desktop and mobile Asset Detail.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-31713
- https://ledgerhq.atlassian.net/browse/LIVE-30366

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
