### PR TITLE
[LWDM] feat: cardano coin module api getValidators

### DIFF
--- a/.changeset/soft-plants-divide.md
+++ b/.changeset/soft-plants-divide.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-cardano": minor
+"@ledgerhq/live-env": minor
+---
+
+feat: cardano coin module api getValidators

--- a/libs/coin-modules/coin-cardano/src/api/api-types.ts
+++ b/libs/coin-modules/coin-cardano/src/api/api-types.ts
@@ -139,3 +139,33 @@ export type APIGetPoolList = {
 export type APIGetPoolsDetail = {
   pools: Array<StakePool>;
 };
+
+// Current-epoch reward-formula params: pledge influence (a0), monetary expansion (rho), treasury
+// cut (tau).
+export type StakeRewardParams = {
+  a0: number;
+  rho: number;
+  tau: number;
+};
+
+// Current-epoch info used to compute validator APY (ADR-038). `reserves` and `activeStake` are
+// lovelace strings; both are required by computePoolApy but not yet served by the endpoint
+// (LIVE-18622), so they are optional and APY stays omitted until they appear.
+export type EpochInfo = {
+  number: number;
+  reserves: string | undefined;
+  activeStake: string | undefined;
+  params: StakeRewardParams;
+};
+
+// Shape of the Ledger node /api/rest/params response (a Hasura saved REST query).
+export type APIEpochParams = {
+  cardano: Array<{
+    currentEpoch: {
+      number: number;
+      reserves?: string;
+      activeStake?: string;
+      protocolParams: StakeRewardParams;
+    };
+  }>;
+};

--- a/libs/coin-modules/coin-cardano/src/api/getEpochInfo.ts
+++ b/libs/coin-modules/coin-cardano/src/api/getEpochInfo.ts
@@ -1,0 +1,32 @@
+import network from "@ledgerhq/live-network/network";
+import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { CARDANO_EPOCH_PARAMS_ENDPOINT, CARDANO_TESTNET_EPOCH_PARAMS_ENDPOINT } from "../constants";
+import { isTestnet } from "../logic";
+import { APIEpochParams, EpochInfo } from "./api-types";
+
+/**
+ * Fetch the current-epoch staking parameters used to compute validator APY (ADR-038 Option 3,
+ * served by Ledger's internal Cardano node). The endpoint currently returns only a0/rho/tau and
+ * the epoch number; `reserves` and `activeStake` are parsed when present (LIVE-18622) and left
+ * undefined otherwise, which keeps APY omitted until the data is exposed.
+ */
+export async function fetchEpochInfo(currency: CryptoCurrency): Promise<EpochInfo> {
+  const { data } = await network<APIEpochParams>({
+    method: "GET",
+    url: isTestnet(currency)
+      ? CARDANO_TESTNET_EPOCH_PARAMS_ENDPOINT
+      : CARDANO_EPOCH_PARAMS_ENDPOINT,
+  });
+
+  const epoch = data?.cardano?.[0]?.currentEpoch;
+  if (!epoch) {
+    throw new Error("Cardano epoch params: unexpected response shape");
+  }
+
+  return {
+    number: epoch.number,
+    reserves: epoch.reserves,
+    activeStake: epoch.activeStake,
+    params: epoch.protocolParams,
+  };
+}

--- a/libs/coin-modules/coin-cardano/src/api/getValidators.test.ts
+++ b/libs/coin-modules/coin-cardano/src/api/getValidators.test.ts
@@ -1,12 +1,38 @@
-import { createApi } from ".";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import { type CardanoConfig } from "../config";
+import { getValidators } from "../logic/getValidators";
+import { createApi } from ".";
+
+jest.mock("../logic/getValidators", () => ({
+  getValidators: jest.fn(),
+}));
+
+const mockGetValidators = jest.mocked(getValidators);
 
 const config: CardanoConfig = { maxFeesWarning: 0, maxFeesError: 0 };
+const currency = getCryptoCurrencyById("cardano");
 
-describe("getValidators", () => {
-  it("throws an unsupported error", () => {
+describe("api.getValidators", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("delegates to the getValidators logic with the resolved currency", async () => {
+    const page = { items: [], next: undefined };
+    mockGetValidators.mockResolvedValue(page);
     const api = createApi(config, "cardano");
 
-    expect(() => api.getValidators()).toThrow("getValidators is not supported");
+    const result = await api.getValidators();
+
+    expect(mockGetValidators).toHaveBeenCalledTimes(1);
+    expect(mockGetValidators).toHaveBeenCalledWith(currency);
+    expect(result).toBe(page);
+  });
+
+  it("propagates errors thrown by the getValidators logic", async () => {
+    mockGetValidators.mockRejectedValue(new Error("pool list fetch failed"));
+    const api = createApi(config, "cardano");
+
+    await expect(api.getValidators()).rejects.toThrow("pool list fetch failed");
   });
 });

--- a/libs/coin-modules/coin-cardano/src/api/index.ts
+++ b/libs/coin-modules/coin-cardano/src/api/index.ts
@@ -25,6 +25,7 @@ import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import coinConfig, { type CardanoConfig } from "../config";
 import { broadcast } from "../logic/broadcast";
 import { getBalance } from "../logic/getBalance";
+import { getValidators } from "../logic/getValidators";
 import { lastBlock } from "../logic/lastBlock";
 import { listOperations } from "../logic/listOperations";
 
@@ -40,9 +41,8 @@ export function createApi(config: CardanoConfig, currencyId: string): CoinModule
     getBlock: (_height: number): Promise<Block> => {
       throw new Error("getBlock is not supported");
     },
-    getValidators: (_cursor?: Cursor): Promise<Page<Validator>> => {
-      throw new Error("getValidators is not supported");
-    },
+    // cursor ignored: Cardano returns every pool in one page (see getValidators).
+    getValidators: (_cursor?: Cursor): Promise<Page<Validator>> => getValidators(currency),
     getBalance: (address: string, options?: BalanceOptions): Promise<Balance[]> =>
       rejectBalanceOptions(() => getBalance(currency, address), options),
     listOperations: (address: string, options: ListOperationsOptions): Promise<Page<Operation>> =>

--- a/libs/coin-modules/coin-cardano/src/constants.ts
+++ b/libs/coin-modules/coin-cardano/src/constants.ts
@@ -9,3 +9,9 @@ export const CARDANO_MAX_SUPPLY = 45e9;
 
 export const CARDANO_API_ENDPOINT = getEnv("CARDANO_API_ENDPOINT");
 export const CARDANO_TESTNET_API_ENDPOINT = getEnv("CARDANO_TESTNET_API_ENDPOINT");
+
+// Current-epoch protocol params (a0/rho/tau, +reserves & active stake once exposed) for validator
+// APY — ADR-038 Option 3, served by Ledger's internal Cardano node (LIVE-18622). Distinct host from
+// the Strica API above.
+export const CARDANO_EPOCH_PARAMS_ENDPOINT = getEnv("CARDANO_EPOCH_PARAMS_ENDPOINT");
+export const CARDANO_TESTNET_EPOCH_PARAMS_ENDPOINT = getEnv("CARDANO_TESTNET_EPOCH_PARAMS_ENDPOINT");

--- a/libs/coin-modules/coin-cardano/src/logic/computePoolApy.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/computePoolApy.ts
@@ -1,0 +1,52 @@
+import BigNumber from "bignumber.js";
+import { EpochInfo, StakePool } from "../api/api-types";
+
+// Optimal number of pools (protocol constant k); saturation point z0 = 1/k.
+const OPTIMAL_POOL_COUNT = 500;
+const Z0 = 1 / OPTIMAL_POOL_COUNT;
+// Cardano epoch is 5 days.
+const EPOCHS_PER_YEAR = 365.25 / 5;
+
+/**
+ * Estimate a delegator's yearly APY for a stake pool from the Shelley reward-sharing scheme
+ * (ADR-038). Models one epoch's expected rewards and annualises with compounding:
+ *
+ *   rewardPot = reserves × rho × (1 − tau)                     // epoch rewards available to pools
+ *   optimalReward = rewardPot/(1+a0) × (σ' + s'·a0·((σ' − s'·(z0−σ')/z0)/z0))
+ *   member share  = max(0, optimalReward − fixedCost) × (1 − margin)
+ *   APY           = (1 + memberShare/poolStake)^epochsPerYear − 1
+ *
+ * where σ' = min(poolStake/totalStake, z0) and s' = min(pledge/totalStake, z0). All amounts are
+ * lovelace. Returns 0 for a retired pool, a pool with no stake, or one whose expected reward does
+ * not cover its fixed cost — and 0 when reserves/activeStake aren't available (the endpoint does
+ * not expose them yet, LIVE-18622), so APY stays omitted until the data lands.
+ */
+export function computePoolApy(pool: StakePool, epoch: EpochInfo): number {
+  if (!epoch.reserves || !epoch.activeStake) return 0;
+  if (pool.retiredEpoch !== undefined && pool.retiredEpoch <= epoch.number) return 0;
+
+  const totalStake = new BigNumber(epoch.activeStake);
+  const poolStake = new BigNumber(pool.liveStake);
+  if (totalStake.lte(0) || poolStake.lte(0)) return 0;
+
+  const { a0, rho, tau } = epoch.params;
+  const rewardPot = new BigNumber(epoch.reserves).times(rho).times(1 - tau);
+
+  const sigmaPrime = Math.min(poolStake.div(totalStake).toNumber(), Z0);
+  const sPrime = Math.min(new BigNumber(pool.pledge).div(totalStake).toNumber(), Z0);
+
+  const pledgeTerm = sPrime * a0 * ((sigmaPrime - (sPrime * (Z0 - sigmaPrime)) / Z0) / Z0);
+  const optimalReward = rewardPot.times((sigmaPrime + pledgeTerm) / (1 + a0));
+
+  const distributable = optimalReward.minus(pool.cost);
+  if (distributable.lte(0)) return 0;
+
+  // margin is a percentage string from the pool list (e.g. "3.00" = 3%); clamp to [0,1] and
+  // treat an unparseable value as 0 rather than letting NaN poison the APY.
+  const rawMargin = Number(pool.margin);
+  const margin = Number.isFinite(rawMargin) ? Math.min(Math.max(rawMargin / 100, 0), 1) : 0;
+  const memberRewards = distributable.times(1 - margin);
+
+  const perEpochRate = memberRewards.div(poolStake).toNumber();
+  return (1 + perEpochRate) ** EPOCHS_PER_YEAR - 1;
+}

--- a/libs/coin-modules/coin-cardano/src/logic/computePoolApy.unit.test.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/computePoolApy.unit.test.ts
@@ -1,0 +1,77 @@
+import { EpochInfo, StakePool } from "../api/api-types";
+import { computePoolApy } from "./computePoolApy";
+
+// 22B ADA active stake → z0 = 1/k = 0.002 of total stake = 44M ADA saturation point.
+const baseEpoch: EpochInfo = {
+  number: 634,
+  reserves: "14000000000000000", // 14B ADA
+  activeStake: "22000000000000000", // 22B ADA
+  params: { a0: 0.3, rho: 0.003, tau: 0.2 },
+};
+
+const basePool: StakePool = {
+  poolId: "pool1abc",
+  name: "Stake Pool",
+  ticker: "STK",
+  website: "https://pool.example",
+  margin: "2.00", // 2%
+  cost: "340000000", // 340 ADA
+  pledge: "1000000000000", // 1M ADA
+  retiredEpoch: undefined,
+  liveStake: "30000000000000", // 30M ADA
+};
+
+describe("computePoolApy", () => {
+  it("returns a plausible mainnet APY for a healthy pool", () => {
+    const apy = computePoolApy(basePool, baseEpoch);
+    // Sanity bounds: real Cardano APY sits ~3–10% depending on reserves / saturation.
+    expect(apy).toBeGreaterThan(0.03);
+    expect(apy).toBeLessThan(0.12);
+  });
+
+  it.each([
+    ["a retired pool", { ...basePool, retiredEpoch: 400 }, baseEpoch],
+    ["a pool with zero stake", { ...basePool, liveStake: "0" }, baseEpoch],
+    // Tiny pool, huge fixed cost → expected reward doesn't cover the cost → no delegator yield.
+    ["a pool whose reward < fixed cost", { ...basePool, liveStake: "1000000000", cost: "100000000000000" }, baseEpoch],
+    // Endpoint doesn't expose these yet (LIVE-18622) → APY stays omitted.
+    ["an epoch missing reserves", basePool, { ...baseEpoch, reserves: undefined }],
+    ["an epoch missing active stake", basePool, { ...baseEpoch, activeStake: undefined }],
+  ])("returns 0 for %s", (_label, pool, epoch) => {
+    expect(computePoolApy(pool, epoch)).toBe(0);
+  });
+
+  it("decreases when the pool saturates beyond z0", () => {
+    // z0 = 1/k = 0.002 of total stake = 44M ADA.
+    const healthy = computePoolApy({ ...basePool, liveStake: "40000000000000" }, baseEpoch);
+    const oversaturated = computePoolApy({ ...basePool, liveStake: "100000000000000" }, baseEpoch);
+    expect(oversaturated).toBeLessThan(healthy);
+  });
+
+  it("decreases when margin increases (delegators lose more to operator)", () => {
+    const low = computePoolApy({ ...basePool, margin: "1.00" }, baseEpoch);
+    const high = computePoolApy({ ...basePool, margin: "10.00" }, baseEpoch);
+    expect(high).toBeLessThan(low);
+  });
+
+  it("increases with higher pledge (a0 incentive)", () => {
+    const lowPledge = computePoolApy({ ...basePool, pledge: "100000000000" }, baseEpoch);
+    const highPledge = computePoolApy(
+      { ...basePool, pledge: "30000000000000" }, // pledge matches liveStake
+      baseEpoch,
+    );
+    expect(highPledge).toBeGreaterThan(lowPledge);
+  });
+
+  it("decreases as reserves are depleted", () => {
+    const lowReserves = computePoolApy(basePool, {
+      ...baseEpoch,
+      reserves: "5000000000000000",
+    });
+    const highReserves = computePoolApy(basePool, {
+      ...baseEpoch,
+      reserves: "14000000000000000",
+    });
+    expect(lowReserves).toBeLessThan(highReserves);
+  });
+});

--- a/libs/coin-modules/coin-cardano/src/logic/getValidators.integ.test.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/getValidators.integ.test.ts
@@ -1,0 +1,32 @@
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getValidators } from "./getValidators";
+
+describe("getValidators (integration)", () => {
+  it("fetches stake pools from the Cardano testnet API and maps them to validators", async () => {
+    const currency = getCryptoCurrencyById("cardano_testnet");
+
+    const { items, next } = await getValidators(currency);
+
+    // All pools are returned in a single page (the framework consumer doesn't follow a cursor).
+    expect(next).toBeUndefined();
+    expect(items.length).toBeGreaterThan(0);
+
+    const validator = items[0];
+    expect(typeof validator.address).toBe("string");
+    expect(validator.address.length).toBeGreaterThan(0);
+    expect(typeof validator.name).toBe("string");
+    expect(validator.name.length).toBeGreaterThan(0);
+    expect(typeof validator.balance).toBe("bigint");
+    expect(validator.balance).toBeGreaterThanOrEqual(0n);
+    expect(typeof validator.commissionRate).toBe("string");
+
+    // APY is gated on the epoch-params endpoint exposing reserves + active stake (LIVE-18622).
+    // Until then it stays omitted; when present it must be a sane fraction in (0, 1).
+    for (const v of items) {
+      if (v.apy !== undefined) {
+        expect(v.apy).toBeGreaterThan(0);
+        expect(v.apy).toBeLessThan(1);
+      }
+    }
+  });
+});

--- a/libs/coin-modules/coin-cardano/src/logic/getValidators.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/getValidators.ts
@@ -1,0 +1,66 @@
+import type { Page, Validator } from "@ledgerhq/coin-module-framework/api/index";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { EpochInfo, StakePool } from "../api/api-types";
+import { fetchEpochInfo } from "../api/getEpochInfo";
+import { fetchPoolList } from "../api/getPools";
+import { computePoolApy } from "./computePoolApy";
+
+const PAGE_LIMIT = 100;
+
+function toValidator(pool: StakePool, epoch: EpochInfo | undefined): Validator | undefined {
+  // Skip a pool whose liveStake can't be parsed rather than letting one bad row throw and
+  // empty the whole list (the consumer falls back to [] on any error).
+  let balance: bigint;
+  try {
+    balance = BigInt(pool.liveStake);
+  } catch {
+    return undefined;
+  }
+
+  // description/logo omitted: not exposed by /v1/pool/list. APY is computed from the current-epoch
+  // params (ADR-038) and only set when non-zero — so it stays omitted until the params endpoint
+  // serves reserves + active stake (LIVE-18622), at which point healthy pools get a real value.
+  const validator: Validator = {
+    address: pool.poolId,
+    name: pool.name ?? pool.ticker ?? pool.poolId,
+    balance,
+    commissionRate: pool.margin,
+  };
+  if (pool.website) validator.url = pool.website;
+  if (epoch) {
+    const apy = computePoolApy(pool, epoch);
+    if (apy > 0) validator.apy = apy;
+  }
+  return validator;
+}
+
+async function fetchAllPools(currency: CryptoCurrency): Promise<StakePool[]> {
+  const pools: StakePool[] = [];
+  let pageNo = 1;
+  let total = 0;
+  do {
+    const res = await fetchPoolList(currency, "", pageNo, PAGE_LIMIT);
+    pools.push(...res.pools);
+    total = res.count;
+    pageNo += 1;
+    if (res.pools.length === 0) break; // safety: stop if a page returns nothing
+  } while (pools.length < total);
+  return pools;
+}
+
+/**
+ * All Cardano stake pools, mapped to framework validators. Returns the full set in a single
+ * page (next: undefined) — the generic-coin-framework consumer reads one page and does not
+ * follow a cursor, so every pool from /v1/pool/list is paged in here. The current-epoch params
+ * are fetched once in parallel for APY; a failure there degrades to validators without APY
+ * rather than failing the whole list.
+ */
+export async function getValidators(currency: CryptoCurrency): Promise<Page<Validator>> {
+  const [pools, epoch] = await Promise.all([
+    fetchAllPools(currency),
+    fetchEpochInfo(currency).catch(() => undefined),
+  ]);
+
+  const items = pools.flatMap(pool => toValidator(pool, epoch) ?? []);
+  return { items, next: undefined };
+}

--- a/libs/coin-modules/coin-cardano/src/logic/getValidators.unit.test.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/getValidators.unit.test.ts
@@ -1,0 +1,166 @@
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { APIGetPoolList, EpochInfo, StakePool } from "../api/api-types";
+import { fetchEpochInfo } from "../api/getEpochInfo";
+import { fetchPoolList } from "../api/getPools";
+import { getValidators } from "./getValidators";
+
+jest.mock("../api/getPools");
+jest.mock("../api/getEpochInfo");
+
+const mockFetchPoolList = jest.mocked(fetchPoolList);
+const mockFetchEpochInfo = jest.mocked(fetchEpochInfo);
+
+const currency = getCryptoCurrencyById("cardano");
+
+// Epoch params the endpoint serves today (no reserves / active stake) → APY stays omitted.
+const epochWithoutStakeData: EpochInfo = {
+  number: 634,
+  reserves: undefined,
+  activeStake: undefined,
+  params: { a0: 0.3, rho: 0.003, tau: 0.2 },
+};
+
+// Fully-populated epoch (reserves + active stake) → APY is computed.
+const epochWithStakeData: EpochInfo = {
+  ...epochWithoutStakeData,
+  reserves: "14000000000000000",
+  activeStake: "22000000000000000",
+};
+
+function pool(over: Partial<StakePool> = {}): StakePool {
+  return {
+    poolId: "pool1abc",
+    name: "Stake Pool",
+    ticker: "STK",
+    website: "https://pool.example",
+    margin: "3.00", // percent string, as the real /v1/pool/list returns (e.g. "6" = 6%)
+    cost: "340000000",
+    pledge: "100000000000",
+    retiredEpoch: undefined,
+    liveStake: "50000000000000",
+    ...over,
+  };
+}
+
+// fetchPoolList stub: serve `pools` in pages of `limit`, reporting the full count.
+function paginate(pools: StakePool[], limit: number) {
+  mockFetchPoolList.mockImplementation(async (_currency, _search, pageNo) => {
+    const start = (pageNo - 1) * limit;
+    return {
+      pageNo,
+      limit,
+      count: pools.length,
+      pools: pools.slice(start, start + limit),
+    } as APIGetPoolList;
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Default: endpoint serves params but not reserves/active stake yet → no APY.
+  mockFetchEpochInfo.mockResolvedValue(epochWithoutStakeData);
+});
+
+describe("getValidators", () => {
+  it("pages through every pool and returns them in a single page", async () => {
+    const pools = Array.from({ length: 250 }, (_, i) => pool({ poolId: `pool${i}` }));
+    paginate(pools, 100);
+
+    const { items, next } = await getValidators(currency);
+
+    expect(mockFetchPoolList).toHaveBeenCalledTimes(3);
+    expect(mockFetchPoolList.mock.calls.map(c => c[2])).toEqual([1, 2, 3]);
+    expect(items).toHaveLength(250);
+    expect(next).toBeUndefined();
+  });
+
+  it("returns a single page without extra calls when all pools fit in one fetch", async () => {
+    paginate([pool({ poolId: "pool1" }), pool({ poolId: "pool2" })], 100);
+
+    const { items } = await getValidators(currency);
+
+    expect(mockFetchPoolList).toHaveBeenCalledTimes(1);
+    expect(items).toHaveLength(2);
+  });
+
+  it("maps a pool to a validator", async () => {
+    paginate([pool()], 100);
+
+    const { items } = await getValidators(currency);
+
+    expect(items[0]).toEqual({
+      address: "pool1abc",
+      name: "Stake Pool",
+      url: "https://pool.example",
+      balance: 50_000_000_000_000n,
+      commissionRate: "3.00",
+    });
+    expect(items[0].apy).toBeUndefined();
+  });
+
+  it("falls back to ticker then poolId for the name, and omits url when absent", async () => {
+    paginate(
+      [
+        pool({ poolId: "p1", name: undefined, ticker: "TICK", website: undefined }),
+        pool({ poolId: "p2", name: undefined, ticker: undefined, website: undefined }),
+      ],
+      100,
+    );
+
+    const { items } = await getValidators(currency);
+
+    expect(items[0].name).toBe("TICK");
+    expect(items[1].name).toBe("p2");
+    expect(items[0].url).toBeUndefined();
+  });
+
+  it("skips a pool with an unparseable liveStake instead of failing the whole list", async () => {
+    paginate(
+      [pool({ poolId: "good" }), pool({ poolId: "bad", liveStake: "not-a-number" })],
+      100,
+    );
+
+    const { items } = await getValidators(currency);
+
+    expect(items).toHaveLength(1);
+    expect(items[0].address).toBe("good");
+  });
+
+  it("includes retired pools (no filtering)", async () => {
+    paginate([pool({ poolId: "retired", retiredEpoch: 400 })], 100);
+
+    const { items } = await getValidators(currency);
+
+    expect(items).toHaveLength(1);
+    expect(items[0].address).toBe("retired");
+  });
+
+  it("sets apy once the epoch endpoint exposes reserves + active stake", async () => {
+    mockFetchEpochInfo.mockResolvedValue(epochWithStakeData);
+    paginate([pool({ liveStake: "30000000000000", pledge: "1000000000000", margin: "2.00" })], 100);
+
+    const { items } = await getValidators(currency);
+
+    expect(items[0].apy).toBeGreaterThan(0.03);
+    expect(items[0].apy).toBeLessThan(0.12);
+  });
+
+  it("omits apy for a retired pool even when epoch data is available", async () => {
+    mockFetchEpochInfo.mockResolvedValue(epochWithStakeData);
+    paginate([pool({ retiredEpoch: 400 })], 100);
+
+    const { items } = await getValidators(currency);
+
+    expect(items[0].apy).toBeUndefined();
+  });
+
+  it("returns validators without apy when the epoch fetch fails", async () => {
+    mockFetchEpochInfo.mockRejectedValue(new Error("epoch endpoint down"));
+    paginate([pool()], 100);
+
+    const { items } = await getValidators(currency);
+
+    expect(items).toHaveLength(1);
+    expect(items[0].apy).toBeUndefined();
+  });
+});

--- a/libs/env/src/env.ts
+++ b/libs/env/src/env.ts
@@ -357,6 +357,16 @@ const envDefinitions = {
     parser: stringParser,
     desc: "Cardano API url",
   },
+  CARDANO_EPOCH_PARAMS_ENDPOINT: {
+    def: "https://ada.api.live.ledger.com/api/rest/params",
+    parser: stringParser,
+    desc: "Cardano current-epoch protocol params url (validator APY)",
+  },
+  CARDANO_TESTNET_EPOCH_PARAMS_ENDPOINT: {
+    def: "https://ada-testnet.api.live.ledger-test.com/api/rest/params",
+    parser: stringParser,
+    desc: "Cardano testnet current-epoch protocol params url (validator APY)",
+  },
   ICON_NODE_ENDPOINT: {
     parser: stringParser,
     def: "https://icon.coin.ledger.com/api/v3",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Cardano CoinModule API only

### 📝 Description

Implements `getValidators()` for the Cardano CoinModule ("Alpaca") API — returns **all** stake pools as `Validator`s.

Pages through the existing `/v1/pool/list` endpoint (`fetchPoolList`) and returns the full set in one `Page` (`next: undefined`), because the generic-coin-framework consumer (`getAccountShape`) reads a single page and ignores the cursor. Maps each pool: `address`=poolId, `name`=name/ticker/poolId, `url`=website, `balance`=liveStake, `commissionRate`=margin. A pool with an unparseable `liveStake` is skipped rather than failing the whole list.

- **APY omitted** — needs epoch/reserve data not yet exposed (LIVE-18622); consumer does `apy ?? 0`.
- **No filtering** — returns every pool (per AC "all validators"); `retiredEpoch` left as a future active-only hook.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: 
- https://ledgerhq.atlassian.net/browse/LIVE-31446


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
