### PR TITLE
[LWD] fix: display user-renamed account names in address list

### DIFF
--- a/.changeset/fix-asset-detail-renamed-account-name.md
+++ b/.changeset/fix-asset-detail-renamed-account-name.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix asset detail address list showing default account names instead of user-renamed names from wallet state.

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AddressList/hooks/__tests__/useAddressListItemViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AddressList/hooks/__tests__/useAddressListItemViewModel.test.ts
@@ -1,15 +1,67 @@
 import type { Account } from "@ledgerhq/types-live";
+import type { WalletState } from "@ledgerhq/live-wallet/store";
 import { renderHook } from "tests/testSetup";
 import { genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { usdcToken } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
 import { useAddressListItemViewModel } from "../useAddressListItemViewModel";
 import { ETH_ACCOUNT } from "LLD/features/__mocks__/accounts.mock";
 
+const walletStateWithAccountName = (accountId: string, name: string): WalletState => ({
+  accountNames: new Map([[accountId, name]]),
+  starredAccountIds: new Set(),
+  walletSyncState: { data: null, version: 0 },
+  nonImportedAccountInfos: [],
+  recentAddresses: {},
+});
+
 const initialState = {
   settings: { counterValue: "USD", locale: "en-US", discreetMode: false },
 };
 
 describe("useAddressListItemViewModel", () => {
+  it("uses renamed account name from wallet state", () => {
+    const customName = "My Custom ETH";
+
+    const { result } = renderHook(
+      () =>
+        useAddressListItemViewModel(
+          ETH_ACCOUNT,
+          () => null,
+          () => {},
+        ),
+      {
+        initialState: {
+          ...initialState,
+          wallet: walletStateWithAccountName(ETH_ACCOUNT.id, customName),
+        },
+      },
+    );
+
+    expect(result.current.displayName).toBe(customName);
+  });
+
+  it("uses parent account renamed name for token accounts", () => {
+    const customName = "My Custom ETH";
+    const tokenAccount = genTokenAccount(0, ETH_ACCOUNT, usdcToken);
+
+    const { result } = renderHook(
+      () =>
+        useAddressListItemViewModel(
+          tokenAccount,
+          () => ETH_ACCOUNT,
+          () => {},
+        ),
+      {
+        initialState: {
+          ...initialState,
+          wallet: walletStateWithAccountName(ETH_ACCOUNT.id, customName),
+        },
+      },
+    );
+
+    expect(result.current.displayName).toBe(customName);
+  });
+
   it.each([
     {
       label: "parent account is resolved",

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AddressList/hooks/useAddressListItemViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AddressList/hooks/useAddressListItemViewModel.ts
@@ -5,7 +5,7 @@ import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
 import { formatAddress } from "@ledgerhq/live-common/utils/addressUtils";
 import { useSelector } from "LLD/hooks/redux";
 import { discreetModeSelector, localeSelector } from "~/renderer/reducers/settings";
-import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
+import { useAccountName } from "~/renderer/reducers/wallet";
 import { getCryptoAccountAddress } from "LLD/features/CryptoAddresses/utils/getCryptoAccountAddress";
 import { useCounterValueCellViewModel } from "LLD/components/Cells/CounterValueCell/useCounterValueCellViewModel";
 
@@ -35,7 +35,11 @@ export function useAddressListItemViewModel(
       ? parentAccount?.currency ?? account.token.parentCurrency
       : currency;
 
-  const displayName = getDefaultAccountName(account);
+  const accountForDisplayName =
+    account.type === "TokenAccount"
+      ? parentAccount ?? lookupParentAccount(account.parentId)
+      : account;
+  const displayName = useAccountName(accountForDisplayName ?? account);
   const rawAddress = getCryptoAccountAddress(account, lookupParentAccount);
   const formattedAddress = formatAddress(rawAddress, { prefixLength: 5, suffixLength: 5 });
   const { formattedCounterValue } = useCounterValueCellViewModel(currency, account.balance);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request fixes an issue where the asset detail address list was displaying default account names instead of user-renamed names from the wallet state. The update ensures that renamed account names are shown correctly, both for regular accounts and token accounts. Tests have been added to verify this behavior.

**Bug Fixes and Feature Improvements:**

* The address list in the asset detail view now correctly displays user-renamed account names by using the `useAccountName` hook, sourcing names from the wallet state instead of falling back to defaults. This also applies to token accounts, which will display the renamed parent account name. 

**Testing Enhancements:**

* Added tests to ensure that renamed account names (including for token accounts) are correctly used in the address list item view model.


https://github.com/user-attachments/assets/4853266f-6432-4c08-baa3-1b8321222cf1



### ❓ Context

[LIVE-31731](https://ledgerhq.atlassian.net/browse/LIVE-31731)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31731]: https://ledgerhq.atlassian.net/browse/LIVE-31731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ