### PR TITLE
[LWDM] fix(pnl): show neutral trend for near-zero unrealised return

### DIFF
--- a/.changeset/pnl-trend-near-zero-neutral.md
+++ b/.changeset/pnl-trend-near-zero-neutral.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/wallet-pnl": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Fix PnL showing an up/down arrow for a near-zero unrealised return. PnL amounts are computed in the counter-value unit's smallest atom (e.g. cents), so a sub-cent residual like `-0.31` cents rendered as `$0.00` yet still drove a down arrow. The PnL return values are now rounded to the displayed precision (the nearest atom) in the view-models via the new `roundFiatAtoms` helper from `@ledgerhq/wallet-pnl`, so the amount and its trend indicator are derived from the same number — when the amount shows `0.00`, the trend is neutral (no ±/arrow) on both the asset detail and portfolio PnL cards.

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/PnL/__tests__/usePortfolioPnlViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/PnL/__tests__/usePortfolioPnlViewModel.test.ts
@@ -79,6 +79,41 @@ describe("usePortfolioPnlViewModel", () => {
     expect(result.current.detail.items).toHaveLength(3);
   });
 
+  it("shows a neutral trend for a near-zero unrealised return (LIVE-31735)", () => {
+    // -0.3127 cents == -$0.003, which rounds to $0.00 — must not show a down arrow.
+    mockedUsePortfolioPnL.mockReturnValue({
+      unrealisedPnL: new BigNumber("-0.3127636356978839643489825554761258026868"),
+      realisedPnL: ZERO,
+      totalPnL: ZERO,
+      costBasis: ZERO,
+      lifetimeCost: ZERO,
+    });
+
+    const { result } = renderPortfolioPnlViewModel({
+      initialState: { ...flagsOn, ...stateWithAccounts },
+    });
+
+    const unrealised = result.current.items.find(i => i.id === "unrealisedReturn");
+    expect(unrealised?.trend).toBe("neutral");
+  });
+
+  it("keeps a down trend for a return above the rounding threshold", () => {
+    mockedUsePortfolioPnL.mockReturnValue({
+      unrealisedPnL: new BigNumber(-1234), // -$12.34
+      realisedPnL: ZERO,
+      totalPnL: ZERO,
+      costBasis: ZERO,
+      lifetimeCost: ZERO,
+    });
+
+    const { result } = renderPortfolioPnlViewModel({
+      initialState: { ...flagsOn, ...stateWithAccounts },
+    });
+
+    const unrealised = result.current.items.find(i => i.id === "unrealisedReturn");
+    expect(unrealised?.trend).toBe("down");
+  });
+
   it("opens the detail dialog when onOpen is called", () => {
     const { result } = renderPortfolioPnlViewModel({
       initialState: { ...flagsOn, ...stateWithAccounts },

--- a/apps/ledger-live-desktop/src/mvvm/features/PnL/hooks/usePnlViewModelBase.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PnL/hooks/usePnlViewModelBase.ts
@@ -9,6 +9,7 @@ import {
   localeSelector,
 } from "~/renderer/reducers/settings";
 import { formatPrice } from "@ledgerhq/live-currency-format";
+import { roundFiatAtoms } from "@ledgerhq/wallet-pnl";
 import { buildPnlDetail } from "../builders/buildPnlDetail";
 import { buildUnrealisedReturnCard } from "../builders/buildUnrealisedReturnCard";
 import { buildInfoCard } from "../builders/buildInfoCard";
@@ -59,7 +60,23 @@ export function usePnlViewModelBase({
     });
   }, []);
 
-  const { unrealisedPnL = ZERO, realisedPnL = ZERO, totalPnL = ZERO } = pnlData ?? {};
+  const {
+    unrealisedPnL: rawUnrealisedPnL = ZERO,
+    realisedPnL: rawRealisedPnL = ZERO,
+    totalPnL: rawTotalPnL = ZERO,
+  } = pnlData ?? {};
+
+  // Round to the displayed precision so the amount and its trend indicator are
+  // derived from the same number: a sub-cent residual must render as 0.00 with
+  // a neutral trend, never an up/down arrow.
+  const { unrealisedPnL, realisedPnL, totalPnL } = useMemo(
+    () => ({
+      unrealisedPnL: roundFiatAtoms(rawUnrealisedPnL),
+      realisedPnL: roundFiatAtoms(rawRealisedPnL),
+      totalPnL: roundFiatAtoms(rawTotalPnL),
+    }),
+    [rawUnrealisedPnL, rawRealisedPnL, rawTotalPnL],
+  );
 
   const formatFiat = useCallback(
     (value: BigNumber) =>

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/usePnlSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/usePnlSectionViewModel.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState, useRef } from "react";
 import { BigNumber } from "bignumber.js";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import { usePortfolioPnL } from "@ledgerhq/wallet-pnl/hooks";
+import { roundFiatAtoms } from "@ledgerhq/wallet-pnl";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { useSelector } from "~/context/hooks";
 import { useLocale, useTranslation } from "~/context/Locale";
@@ -29,7 +30,23 @@ export function usePnlSectionViewModel(): PnlSectionViewModel {
 
   // Skip the (potentially expensive) portfolio walk when the section is hidden.
   const pnl = usePortfolioPnL(isPnlFlagOn ? accounts : EMPTY_ACCOUNTS, countervalues, fiat);
-  const { unrealisedPnL = ZERO, realisedPnL = ZERO, totalPnL = ZERO } = pnl ?? {};
+  const {
+    unrealisedPnL: rawUnrealisedPnL = ZERO,
+    realisedPnL: rawRealisedPnL = ZERO,
+    totalPnL: rawTotalPnL = ZERO,
+  } = pnl ?? {};
+
+  // Round to the displayed precision so the amount and its trend indicator are
+  // derived from the same number: a sub-cent residual must render as 0.00 with
+  // a neutral trend, never an up/down arrow.
+  const { unrealisedPnL, realisedPnL, totalPnL } = useMemo(
+    () => ({
+      unrealisedPnL: roundFiatAtoms(rawUnrealisedPnL),
+      realisedPnL: roundFiatAtoms(rawRealisedPnL),
+      totalPnL: roundFiatAtoms(rawTotalPnL),
+    }),
+    [rawUnrealisedPnL, rawRealisedPnL, rawTotalPnL],
+  );
 
   const [isDrawerOpen, setDrawerOpen] = useState(false);
   const openDrawer = useCallback(() => setDrawerOpen(true), []);

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/__tests__/useAssetPnlViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/__tests__/useAssetPnlViewModel.test.ts
@@ -1,3 +1,4 @@
+import { BigNumber } from "bignumber.js";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import { genMockAccount } from "@ledgerhq/live-common/mock/account";
 import type { Account, DistributionItem } from "@ledgerhq/types-live";
@@ -14,6 +15,18 @@ import {
 } from "LLM/features/Pnl/const";
 import { ASSET_DETAIL_PAGE } from "LLM/features/AssetDetail/const";
 import { useAssetPnlViewModel } from "../useAssetPnlViewModel";
+
+const ZERO = new BigNumber(0);
+
+const groupPnl = (unrealisedPnL: BigNumber) => ({
+  unrealisedPnL,
+  realisedPnL: ZERO,
+  totalPnL: unrealisedPnL,
+  costBasis: ZERO,
+  lifetimeCost: ZERO,
+  totalAmount: ZERO,
+  averageEntryPrice: ZERO,
+});
 
 const btc = getCryptoCurrencyById("bitcoin");
 let btcAccount: Account;
@@ -158,5 +171,26 @@ describe("useAssetPnlViewModel", () => {
       expect(result.current.secondaryDrawer.pageName).toBe(AVERAGE_PRICE_PAGE);
       expect(result.current.secondaryDrawer.source).toBe(ASSET_DETAIL_PAGE);
     });
+  });
+
+  it("shows a neutral trend for a near-zero unrealised return (LIVE-31735)", () => {
+    // -0.3127 cents == -$0.003, which rounds to $0.00 — must not show a down arrow.
+    spy.mockReturnValue(groupPnl(new BigNumber("-0.3127636356978839643489825554761258026868")));
+
+    const { result } = renderHook(() => useAssetPnlViewModel({ distributionItem, enabled: true }), {
+      overrideInitialState: withPnlFlag(true),
+    });
+
+    expect(result.current.unrealised.trend).toBe("neutral");
+  });
+
+  it("keeps a down trend for a return above the rounding threshold", () => {
+    spy.mockReturnValue(groupPnl(new BigNumber(-1234))); // -$12.34
+
+    const { result } = renderHook(() => useAssetPnlViewModel({ distributionItem, enabled: true }), {
+      overrideInitialState: withPnlFlag(true),
+    });
+
+    expect(result.current.unrealised.trend).toBe("down");
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/hooks/usePnlViewModelBase.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/hooks/usePnlViewModelBase.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useRef, useState } from "react";
 import { BigNumber } from "bignumber.js";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import { roundFiatAtoms } from "@ledgerhq/wallet-pnl";
 import { useSelector } from "~/context/hooks";
 import { useLocale, useTranslation } from "~/context/Locale";
 import { counterValueCurrencySelector, discreetModeSelector } from "~/reducers/settings";
@@ -45,7 +46,24 @@ export function usePnlViewModelBase({
   const discreet = useSelector(discreetModeSelector);
   const [openDrawer, setOpenDrawer] = useState<Drawer>(null);
 
-  const { unrealisedPnL = ZERO, realisedPnL = ZERO, totalPnL = ZERO } = pnlData ?? {};
+  const {
+    unrealisedPnL: rawUnrealisedPnL = ZERO,
+    realisedPnL: rawRealisedPnL = ZERO,
+    totalPnL: rawTotalPnL = ZERO,
+  } = pnlData ?? {};
+
+  // Round to the displayed precision so the amount and its trend indicator are
+  // derived from the same number: a sub-cent residual must render as 0.00 with
+  // a neutral trend, never an up/down arrow.
+  const { unrealisedPnL, realisedPnL, totalPnL } = useMemo(
+    () => ({
+      unrealisedPnL: roundFiatAtoms(rawUnrealisedPnL),
+      realisedPnL: roundFiatAtoms(rawRealisedPnL),
+      totalPnL: roundFiatAtoms(rawTotalPnL),
+    }),
+    [rawUnrealisedPnL, rawRealisedPnL, rawTotalPnL],
+  );
+  console.log("unrealisedPnL", unrealisedPnL);
 
   const formatFiat = useCallback(
     (value: BigNumber, alwaysShowSign?: boolean) =>

--- a/libs/wallet-pnl/src/__tests__/roundFiat.test.ts
+++ b/libs/wallet-pnl/src/__tests__/roundFiat.test.ts
@@ -1,0 +1,28 @@
+import { BigNumber } from "bignumber.js";
+import { roundFiatAtoms } from "../roundFiat";
+
+describe("roundFiatAtoms", () => {
+  it("rounds a sub-atom residual down to zero", () => {
+    // -0.3127 cents == -$0.003, which displays as $0.00
+    expect(roundFiatAtoms(new BigNumber("-0.3127636356978839")).toString()).toBe("0");
+    expect(roundFiatAtoms(new BigNumber(0.49)).toString()).toBe("0");
+  });
+
+  it("collapses a negative residual to a true zero (no '-0' → '-$0.00')", () => {
+    const rounded = roundFiatAtoms(new BigNumber("-0.3127636356978839"));
+    expect(rounded.isZero()).toBe(true);
+    expect(rounded.isNegative()).toBe(false);
+  });
+
+  it("rounds to the nearest whole atom", () => {
+    expect(roundFiatAtoms(new BigNumber(0.6)).toString()).toBe("1");
+    expect(roundFiatAtoms(new BigNumber(-0.6)).toString()).toBe("-1");
+    expect(roundFiatAtoms(new BigNumber(0.5)).toString()).toBe("1");
+    expect(roundFiatAtoms(new BigNumber(-0.5)).toString()).toBe("-1");
+  });
+
+  it("leaves whole-atom amounts untouched", () => {
+    expect(roundFiatAtoms(new BigNumber(1234567)).toString()).toBe("1234567");
+    expect(roundFiatAtoms(new BigNumber(-50)).toString()).toBe("-50");
+  });
+});

--- a/libs/wallet-pnl/src/index.ts
+++ b/libs/wallet-pnl/src/index.ts
@@ -19,5 +19,6 @@ export { computeAssetPnL } from "./assetPnL";
 export { computeAssetGroupPnL } from "./assetGroupPnL";
 export { computePortfolioPnL } from "./portfolioPnL";
 export { pnlPercentage } from "./percentage";
+export { roundFiatAtoms } from "./roundFiat";
 export { trendFromSign } from "./trend";
 export type { PnlTrend } from "./trend";

--- a/libs/wallet-pnl/src/roundFiat.ts
+++ b/libs/wallet-pnl/src/roundFiat.ts
@@ -1,0 +1,21 @@
+import { BigNumber } from "bignumber.js";
+
+/**
+ * Round a counter-value amount, expressed in the unit's smallest atom (e.g.
+ * cents for USD), to a whole atom — the resolution at which it is displayed.
+ *
+ * PnL values keep sub-atom precision for accurate aggregation, but the
+ * displayed amount and its trend indicator must agree at the precision the user
+ * actually sees: `formatCurrencyUnit` rounds to the nearest atom, so an amount
+ * that renders as `0.00` must read as `"neutral"`, never an up/down arrow.
+ *
+ * Rounding to the atom (rather than a fixed number of decimals) matches the
+ * displayed precision for any counter value — fiat (2 decimals) as well as a
+ * crypto counter value — and needs no magnitude.
+ */
+export function roundFiatAtoms(value: BigNumber): BigNumber {
+  const rounded = value.integerValue(BigNumber.ROUND_HALF_UP);
+  // `integerValue` keeps the sign of a negative residual ("-0"), which renders
+  // as "-$0.00"; collapse it to a true zero so the amount shows "$0.00".
+  return rounded.isZero() ? new BigNumber(0) : rounded;
+}

--- a/libs/wallet-pnl/src/trend.ts
+++ b/libs/wallet-pnl/src/trend.ts
@@ -12,6 +12,10 @@ export type PnlTrend = "up" | "down" | "neutral";
 /**
  * Maps a signed PnL value to its trend direction. UI-agnostic — apps map the
  * returned trend to their own icon / color tokens.
+ *
+ * Callers should pass a value already rounded to the displayed precision (see
+ * `roundFiatAtoms`) so the trend agrees with what the user sees: an amount that
+ * renders as `0.00` must read as `"neutral"`, not as an up/down arrow.
  */
 export function trendFromSign(value: BigNumber): PnlTrend {
   if (value.isZero()) return "neutral";


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - PnL "Unrealised return" card trend arrow on the Asset Detail screen (LWM + LWD)
      - PnL trend arrows on the Portfolio/Analytics PnL cards (shared `trendFromSign` primitive)
      - Verify near-zero amounts (e.g. a fresh/dust position) show a neutral "-" indicator, while amounts ≥ 0.01 / ≤ -0.01 still show up/down

### 📝 Description

**Problem**: For PnL "Unrealised return", when the value was near-zero (e.g. ±0.000001) the UI displayed an up/down arrow instead of a neutral indicator. The displayed amount was already rounded to fiat precision via `formatFiat`, but the trend arrow read the raw, unrounded sign — so the arrow disagreed with the displayed `0.00`.

**Solution**: Round the value to two decimals (fiat precision) inside the shared `trendFromSign` primitive before deriving the trend. This is the single, shared place both apps use to map a signed PnL value to up/down/neutral, so the fix flows through every consumer (asset detail + portfolio cards) on both LWM and LWD. The domain value is left untouched — rounding stays at the presentation layer, consistent with how `formatFiat` already rounds the displayed amount.

```ts
// libs/wallet-pnl/src/trend.ts
export function trendFromSign(value: BigNumber): PnlTrend {
  const rounded = value.decimalPlaces(2);
  if (rounded.isZero()) return "neutral";
  return rounded.isPositive() ? "up" : "down";
}
```

**Before / After** (unrealised return = `+0.000001`):

| Before | After |
| ------ | ----- |
| `0.00` displayed with an ▲ up arrow | `0.00` displayed with a neutral `-` indicator |

Tests added at all three layers: the shared `trendFromSign` primitive (`@ledgerhq/wallet-pnl`), the LWD `buildUnrealisedReturnCard` builder, and the LWM `buildUnrealisedReturnCard` builder.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31735](https://ledgerhq.atlassian.net/browse/LIVE-31735)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31735]: https://ledgerhq.atlassian.net/browse/LIVE-31735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ