### PR TITLE
[LWD] fix(lld): prevent dev server full reload on renderer source edits

### DIFF
--- a/.changeset/lld-dev-server-hmr-full-reload.md
+++ b/.changeset/lld-dev-server-hmr-full-reload.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": patch
+---
+
+fix(dev): stop the renderer dev server full-reloading on every source edit
+
+The dev server watched `src/renderer` as a static directory, so any source change triggered a full-page `liveReload` that pre-empted React Fast Refresh. Disabling `static.watch` lets HMR apply component updates in place.

--- a/apps/ledger-live-desktop/tools/rspack/devServer.ts
+++ b/apps/ledger-live-desktop/tools/rspack/devServer.ts
@@ -40,6 +40,7 @@ export async function createDevServer(options: DevServerOptions): Promise<Rspack
     static: {
       directory: path.join(lldRoot, "src", "renderer"),
       publicPath: "/",
+      watch: false,
     },
     headers: {
       "Access-Control-Allow-Origin": "*",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Dev-tooling only (HMR behaviour of the local dev server); not unit-testable, verified manually by editing a renderer component and observing in-place Fast Refresh instead of a full reload.
- [x] **Impact of the changes:** Local desktop dev experience only. No runtime/production impact (`static.watch` only affects `pnpm desktop start`).
  - QA: none — dev server config change, not shipped in builds.

### 📝 Description

The renderer dev server declared `static.directory: src/renderer`, i.e. the whole renderer **source** tree, with `static.watch` defaulting to `true`. Any edit under `src/renderer/**` was caught by the static-file watcher and triggered a full-page `liveReload`, pre-empting React Fast Refresh — so every component edit reloaded the entire app instead of hot-updating in place.

Setting `static.watch: false` lets compilation/HMR flow through the compiler so Fast Refresh applies component updates without a full reload. `liveReload` is kept as a genuine fallback for non-React modules.

### ❓ Context

- **JIRA or GitHub link**: N/A
- **ADR link (if any)**: N/A
