### PR TITLE
[LWD] :chart_with_upwards_trend: feat(desktop): add PnL analytics tracking

### DIFF
--- a/.changeset/brave-ears-give.md
+++ b/.changeset/brave-ears-give.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+add PnL tracking

--- a/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnlDetail/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PnL/components/PnlDetail/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Dialog, DialogContent, DialogHeader, DialogBody } from "@ledgerhq/lumen-ui-react";
 import { PnLinfoDetail } from "./PnLinfoDetail";
+import TrackPage from "~/renderer/analytics/TrackPage";
 
 export type PnlDetailItem = {
   title: string;
@@ -26,6 +27,7 @@ export const PnlDetail = ({
   onOpenChange,
 }: PnlDetailProps) => (
   <Dialog open={open} onOpenChange={onOpenChange}>
+    {open ? <TrackPage category="Detailed PnL" refreshSource={false} /> : null}
     <DialogContent>
       <DialogHeader
         density="expanded"

--- a/apps/ledger-live-desktop/src/mvvm/features/PnL/hooks/usePnlViewModelBase.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PnL/hooks/usePnlViewModelBase.ts
@@ -14,6 +14,8 @@ import { buildUnrealisedReturnCard } from "../builders/buildUnrealisedReturnCard
 import { buildInfoCard } from "../builders/buildInfoCard";
 import type { PnlNamespace, PnlNumbers, PnlSecondaryCardConfig, PnlViewModel } from "../types";
 import type { PnLCardProps } from "../components/PnLCard/types";
+import { track } from "~/renderer/analytics/segment";
+import { currentRouteNameRef } from "~/renderer/analytics/screenRefs";
 
 const ZERO = new BigNumber(0);
 
@@ -49,7 +51,13 @@ export function usePnlViewModelBase({
   const fiatCurrency = useSelector(counterValueCurrencySelector);
 
   const [isDetailOpen, setDetailOpen] = useState(false);
-  const openDetail = useCallback(() => setDetailOpen(true), []);
+  const openDetail = useCallback(() => {
+    setDetailOpen(true);
+    track("button_clicked", {
+      button: "Pnl details",
+      page: currentRouteNameRef.current,
+    });
+  }, []);
 
   const { unrealisedPnL = ZERO, realisedPnL = ZERO, totalPnL = ZERO } = pnlData ?? {};
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Analytics-only change (TrackPage + segment track call); no behavioural logic was added, so it is validated manually via Segment events rather than unit tests._
- [x] **Impact of the changes:**
  - Opening the PnL detail dialog fires a `button_clicked` event (`button: "Pnl details"`, `page: <current route>`).
  - The PnL detail dialog renders a `TrackPage` ("Detailed PnL") only while it is open.
  - No regression in the PnL detail dialog's existing open/close behaviour.

### 📝 Description

The detailed PnL dialog had no analytics instrumentation, so we could not measure how often users open it or where they open it from.

This PR adds the missing tracking:

- A `button_clicked` Segment event is emitted in `openDetail`, carrying the originating route via `currentRouteNameRef.current`.
- A `TrackPage` ("Detailed PnL") is mounted in `PnlDetail` while the dialog is open.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-30301

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31581]: https://ledgerhq.atlassian.net/browse/LIVE-31581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ