### PR TITLE
[LWDM] chore(tests): [perf] V8 coverage provider for mobile & desktop jest (measurement)

### DIFF
--- a/apps/ledger-live-desktop/jest.config.js
+++ b/apps/ledger-live-desktop/jest.config.js
@@ -110,6 +110,10 @@ module.exports = {
   /** CI sets `JEST_MAX_WORKERS` (e.g. `100%`); local default leaves laptops headroom. */
   maxWorkers: process.env.JEST_MAX_WORKERS || "50%",
   workerIdleMemoryLimit: "1GB",
+  // Use V8's native coverage instead of babel/istanbul instrumentation: it avoids
+  // rewriting every loaded (and every collectCoverageFrom-matched) source file,
+  // which is the dominant per-suite penalty for render-heavy tests on CI.
+  coverageProvider: "v8",
   collectCoverageFrom: [
     "src/**/*.{ts,tsx}",
     "!src/**/*.test.{ts,tsx}",

--- a/apps/ledger-live-mobile/jest.config.js
+++ b/apps/ledger-live-mobile/jest.config.js
@@ -99,6 +99,10 @@ module.exports = {
   ],
   testPathIgnorePatterns: ["<rootDir>/node_modules/"],
   moduleDirectories: ["node_modules"],
+  // Use V8's native coverage instead of babel/istanbul instrumentation: it avoids
+  // rewriting every loaded (and every collectCoverageFrom-matched) source file,
+  // which is the dominant per-suite penalty for render-heavy tests on CI.
+  coverageProvider: "v8",
   collectCoverageFrom: [
     "src/**/*.{ts,tsx}",
     "!src/**/*.test.{ts,tsx}",


### PR DESCRIPTION
Draft / measurement PR — switches `coverageProvider` to `v8` for both apps to cut the per-suite coverage instrumentation penalty on CI.

Local (render-heavy mobile suite): no-coverage 10.6s · istanbul 25.9s · **v8 15.4s**.

Goal of this draft: measure the real **jest_wall_seconds** delta on CI (mobile + desktop) vs the istanbul baseline, and confirm coverage/Sonar reports still generate. Not for merge as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)