### PR TITLE
[LWM] fix(llm): prevent duplicate transaction broadcast on device action re…

### DIFF
--- a/.changeset/hedera-duplicate-broadcast.md
+++ b/.changeset/hedera-duplicate-broadcast.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix duplicate transaction broadcast in the send flow. The broadcast was triggered from a render prop, so any re-render of the device action result state re-submitted the same signed transaction (e.g. Hedera DUPLICATE_TRANSACTION). The broadcast now fires only once per device-action result.

--- a/apps/ledger-live-mobile/src/screens/ConnectDevice.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/ConnectDevice.test.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import ConnectDevice from "./ConnectDevice";
+import { ScreenName } from "~/const";
+
+const handleTx = jest.fn();
+
+jest.mock("~/logic/screenTransactionHooks", () => ({
+  useSignedTxHandler: () => handleTx,
+}));
+
+jest.mock("~/hooks/deviceActions", () => ({
+  useTransactionDeviceAction: () => ({}),
+}));
+
+jest.mock("LLM/hooks/useAccountScreen", () => ({
+  useAccountScreen: () => ({
+    account: { type: "Account", currency: { family: "hedera", id: "hedera" } },
+    parentAccount: null,
+  }),
+}));
+
+jest.mock("~/components/DeviceAction/rendering", () => ({
+  renderLoading: () => null,
+}));
+
+jest.mock("~/analytics", () => ({
+  TrackScreen: () => null,
+}));
+
+// Simulates the real DeviceAction component: once the device action reaches its
+// result state it calls `renderOnResult(payload)` on every render, including the
+// internal re-renders caused by subsequent device-action emissions.
+jest.mock("~/components/DeviceAction", () => {
+  const React = require("react");
+  const { Pressable, Text } = require("react-native");
+  const payload = { signedOperation: { signature: "sig", operation: {} } };
+  const MockDeviceAction = ({
+    renderOnResult,
+  }: {
+    renderOnResult?: (p: unknown) => React.ReactNode;
+  }) => {
+    const [, forceRender] = React.useState(0);
+    const ui = renderOnResult ? renderOnResult(payload) : null;
+    return React.createElement(
+      React.Fragment,
+      null,
+      ui,
+      React.createElement(
+        Pressable,
+        { testID: "rerender", onPress: () => forceRender((n: number) => n + 1) },
+        React.createElement(Text, null, "rerender"),
+      ),
+    );
+  };
+  return { __esModule: true, default: MockDeviceAction };
+});
+
+const baseRoute = {
+  key: "connect",
+  name: ScreenName.SendConnectDevice,
+  params: {
+    appName: "Hedera",
+    transaction: { mode: "send", family: "hedera" },
+    status: {},
+    device: { deviceId: "device-1", modelId: "stax", wired: false },
+    analyticsPropertyFlow: "send",
+  },
+};
+
+const navigation = {
+  navigate: jest.fn(),
+  replace: jest.fn(),
+  setOptions: jest.fn(),
+};
+
+describe("ConnectDevice broadcast (send flow)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("broadcasts only once even when the device action re-renders in the result state", async () => {
+    const { user } = render(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      <ConnectDevice route={baseRoute as any} navigation={navigation as any} />,
+    );
+
+    // The device action re-renders internally after reaching the signed result
+    // (e.g. a further connection/state emission). This must not re-broadcast.
+    await user.press(screen.getByTestId("rerender"));
+    await user.press(screen.getByTestId("rerender"));
+
+    expect(handleTx).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/ConnectDevice.tsx
@@ -1,5 +1,5 @@
 import invariant from "invariant";
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useMemo, useRef } from "react";
 import { StyleSheet } from "react-native";
 import { Edge, SafeAreaView } from "react-native-safe-area-context";
 import { useTranslation } from "~/context/Locale";
@@ -150,9 +150,17 @@ export default function ConnectDevice({ route, navigation }: Props) {
     account,
     parentAccount,
   });
+  // `renderOnResult` is invoked on every render of the DeviceAction result state,
+  // so guard the broadcast side-effect to fire only once per mount. Without this,
+  // any re-render while the signed result is shown re-broadcasts the same signed
+  // transaction (e.g. Hedera DUPLICATE_TRANSACTION).
+  const hasHandledTx = useRef(false);
   const onResult = useCallback(
     (payload: { signedOperation: SignedOperation; transactionSignError?: Error }) => {
-      handleTx(payload);
+      if (!hasHandledTx.current) {
+        hasHandledTx.current = true;
+        handleTx(payload);
+      }
       return renderLoading({
         t,
       });


### PR DESCRIPTION
…-render


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

The send flow fired the broadcast from a render prop (renderOnResult), so any re-render while the signed result was shown re-submitted the same signed transaction. On Hedera this surfaced as DUPLICATE_TRANSACTION.

Guard the broadcast so it runs once per device-action result, and add a regression test that re-renders the result state and asserts a single broadcast.

Sending this fix to the prerelease (fix blocker ref: https://ledger.slack.com/archives/C03MHGMAMRQ/p1780412961077209)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **[JIRA or GitHub link](https://ledger.slack.com/archives/C03MHGMAMRQ/p1780412961077209)**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
