### PR TITLE
[LWDM] test(desktop): cover dapp provider injection under a strict CSP

### DIFF
--- a/apps/ledger-live-desktop/tests/models/LiveAppWebview.ts
+++ b/apps/ledger-live-desktop/tests/models/LiveAppWebview.ts
@@ -29,9 +29,10 @@ export class LiveAppWebview {
   static async startLiveApp(
     liveAppDirectory: string,
     liveAppManifest: Partial<AppManifest> & Pick<AppManifest, "id">,
+    options: { csp?: string } = {},
   ) {
     try {
-      const port = await startDummyServer(`${liveAppDirectory}`);
+      const port = await startDummyServer(`${liveAppDirectory}`, 0, options);
 
       const url = `http://localhost:${port}`;
       const response = await fetch(url);

--- a/apps/ledger-live-desktop/tests/specs/services/dapp-csp.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/services/dapp-csp.spec.ts
@@ -1,0 +1,124 @@
+import test from "../../fixtures/common";
+import { expect } from "@playwright/test";
+import { DiscoverPage } from "../../page/discover.page";
+import { Layout } from "../../component/layout.component";
+import { Drawer } from "../../component/drawer.component";
+import { LiveAppWebview } from "../../models/LiveAppWebview";
+
+test.use({
+  userdata: "1AccountBTC1AccountETH1AccountPOLYGON",
+  featureFlags: {
+    lldModularDrawer: {
+      enabled: false,
+      params: {
+        add_account: false,
+        live_app: false,
+        receive_flow: false,
+        send_flow: false,
+        enableModularization: false,
+      },
+    },
+  },
+});
+
+let testServerIsRunning = false;
+
+// Regression test for dapps shipping a strict Content-Security-Policy.
+//
+// The dummy dapp is served with `script-src 'self'`, which forbids inline
+// scripts. Its own logic is loaded from a same-origin file (dapp.js) so it
+// stays allowed, isolating what the policy actually exercises: Ledger Live's
+// injected Ethereum provider.
+//
+// With the previous implementation (an inline <script> appended to the DOM)
+// the provider is blocked by this CSP and never attaches, so EIP-6963
+// announcement never fires and the provider button reports "Provider not
+// found" - this test fails. Evaluating the provider via
+// `webFrame.executeJavaScript` bypasses the page CSP, so it keeps working and
+// this test passes.
+test.describe("Local Test Dapp with strict CSP", () => {
+  test.beforeAll(async () => {
+    testServerIsRunning = await LiveAppWebview.startLiveApp(
+      "dummy-dapp",
+      {
+        id: "dummy-live-app",
+        name: "Local Test Dapp CSP",
+        apiVersion: "2.0.0",
+        homepageUrl: "http://localhost",
+        dapp: {
+          provider: "evm",
+          nanoApp: "Ethereum",
+          networks: [
+            {
+              currency: "ethereum",
+              chainID: 1,
+            },
+          ],
+        },
+        currencies: ["ethereum"],
+        content: {
+          shortDescription: {
+            en: "Local dapp used by Playwright",
+          },
+          description: {
+            en: "Local dapp used to test Ledger Live dapp browser methods under a strict CSP",
+          },
+        },
+        permissions: [],
+        domains: ["http://"],
+      },
+      { csp: "script-src 'self'" },
+    );
+
+    if (!testServerIsRunning) {
+      throw new Error("Dummy dapp server failed to start");
+    }
+  });
+
+  test.afterAll(async () => {
+    if (testServerIsRunning) {
+      await LiveAppWebview.stopLiveApp();
+    }
+  });
+
+  test("injected provider survives a strict script-src CSP @smoke", async ({
+    page,
+    electronApp,
+  }) => {
+    const discoverPage = new DiscoverPage(page);
+    const drawer = new Drawer(page);
+    const layout = new Layout(page);
+
+    await layout.goToDiscover();
+    await discoverPage.openTestApp();
+    await drawer.continue();
+    await page.getByTestId("drawer-continue-button").waitFor({ state: "detached" });
+
+    await drawer.waitForDrawerToBeVisible();
+    await expect(drawer.selectAccountTitle).toBeVisible();
+    await drawer.selectAccount("Ethereum", 0);
+    await drawer.waitForDrawerToDisappear();
+
+    // Wait for webview window - React 19's concurrent rendering may delay its creation
+    const windows = electronApp.windows();
+    const webview =
+      windows.length > 1
+        ? windows[1]
+        : await electronApp.waitForEvent("window", { timeout: 30000 });
+    await webview.waitForLoadState("domcontentloaded", { timeout: 30000 });
+
+    // EIP-6963 announcement + eth_chainId / eth_accounts all rely on the
+    // injected provider being present in the page's main world. Under the
+    // strict CSP this only succeeds if the provider was injected in a way the
+    // CSP does not block.
+    await webview.click("#provider > button");
+
+    await expect(webview.getByText("Name: Ledger Live")).toBeVisible();
+    await expect(webview.getByText("Network: 1")).toBeVisible();
+    await expect(webview.getByText("ChainId: 0x1")).toBeVisible();
+    await expect(
+      webview.getByText("Accounts: 0x6EB963EFD0FEF7A4CFAB6CE6F1421C3279D11707"),
+    ).toBeVisible();
+    await expect(webview.getByText("Provider not found")).toBeHidden();
+  });
+});

--- a/libs/test-utils/src/index.ts
+++ b/libs/test-utils/src/index.ts
@@ -5,9 +5,15 @@ import path from "path";
 import { AppManifest } from "@ledgerhq/live-common/wallet-api/types";
 
 let dummyAppPath: string;
+// Test-only Content-Security-Policy header for dummy Live Apps.
+let dummyAppCsp: string | undefined;
 
 export const dummyAppServer: http.Server = http.createServer(
   (request: http.IncomingMessage, response: http.ServerResponse) => {
+    if (dummyAppCsp) {
+      response.setHeader("Content-Security-Policy", dummyAppCsp);
+    }
+
     // You pass two more arguments for config and middleware
     // More details here: https://github.com/vercel/serve-handler#options
 
@@ -17,8 +23,13 @@ export const dummyAppServer: http.Server = http.createServer(
   },
 );
 
-export function startDummyServer(appPath: string, port = 0): Promise<number> {
+export function startDummyServer(
+  appPath: string,
+  port = 0,
+  options: { csp?: string } = {},
+): Promise<number> {
   dummyAppPath = appPath;
+  dummyAppCsp = options.csp;
 
   return new Promise((resolve, reject) => {
     dummyAppServer
@@ -83,6 +94,7 @@ export function getLiveAppManifest(
 }
 
 export function stopDummyServer(): Promise<void> {
+  dummyAppCsp = undefined;
   dummyAppServer.close();
   return new Promise(resolve => {
     dummyAppServer.on("close", () => {

--- a/tests/dummy-dapp/dapp.js
+++ b/tests/dummy-dapp/dapp.js
@@ -1,0 +1,57 @@
+const output = document.getElementById("output");
+let announcedProvider;
+let announcedProviderInfo;
+let currentAccount;
+
+const appendLine = text => {
+  const line = document.createElement("div");
+  line.textContent = text;
+  output.appendChild(line);
+};
+
+const request = (provider, method, params = []) =>
+  provider.request({
+    method,
+    params,
+  });
+
+window.addEventListener("eip6963:announceProvider", event => {
+  announcedProvider = event.detail.provider;
+  announcedProviderInfo = event.detail.info;
+});
+
+document.querySelector("#provider > button").addEventListener("click", async () => {
+  output.replaceChildren();
+  window.dispatchEvent(new Event("eip6963:requestProvider"));
+
+  const provider = announcedProvider || window.ethereum;
+  if (!provider) {
+    appendLine("Provider not found");
+    return;
+  }
+
+  const chainId = await request(provider, "eth_chainId");
+  const accounts = await request(provider, "eth_accounts");
+  currentAccount = accounts[0];
+  const network = Number.parseInt(chainId, 16).toString();
+
+  appendLine(`Name: ${announcedProviderInfo?.name || "Ledger Live"}`);
+  appendLine(`Network: ${network}`);
+  appendLine(`ChainId: ${chainId}`);
+  appendLine(`Accounts: ${accounts.join(", ")}`);
+});
+
+document.getElementById("getAccounts").addEventListener("click", async () => {
+  const provider = announcedProvider || window.ethereum;
+  const accounts = await request(provider, "eth_accounts");
+  currentAccount = accounts[0];
+  appendLine(`eth_accounts result: ${accounts.join(", ")}`);
+});
+
+document.getElementById("personalSign").addEventListener("click", async () => {
+  const provider = announcedProvider || window.ethereum;
+  const account = currentAccount || (await request(provider, "eth_accounts"))[0];
+  const message = "0x4c6564676572204c697665206c6f63616c2064617070";
+  const result = await request(provider, "personal_sign", [message, account]);
+  appendLine(`personal_sign result: ${result}`);
+});

--- a/tests/dummy-dapp/index.html
+++ b/tests/dummy-dapp/index.html
@@ -9,7 +9,12 @@
         color: #f5f5f5;
         background: #161616;
         font-family:
-          Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+          Inter,
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          sans-serif;
         margin: 0;
         padding: 32px;
       }
@@ -36,64 +41,7 @@
     <button id="personalSign" type="button">Personal sign</button>
     <div id="output" aria-live="polite"></div>
 
-    <script>
-      const output = document.getElementById("output");
-      let announcedProvider;
-      let announcedProviderInfo;
-      let currentAccount;
-
-      const appendLine = text => {
-        const line = document.createElement("div");
-        line.textContent = text;
-        output.appendChild(line);
-      };
-
-      const request = (provider, method, params = []) =>
-        provider.request({
-          method,
-          params,
-        });
-
-      window.addEventListener("eip6963:announceProvider", event => {
-        announcedProvider = event.detail.provider;
-        announcedProviderInfo = event.detail.info;
-      });
-
-      document.querySelector("#provider > button").addEventListener("click", async () => {
-        output.replaceChildren();
-        window.dispatchEvent(new Event("eip6963:requestProvider"));
-
-        const provider = announcedProvider || window.ethereum;
-        if (!provider) {
-          appendLine("Provider not found");
-          return;
-        }
-
-        const chainId = await request(provider, "eth_chainId");
-        const accounts = await request(provider, "eth_accounts");
-        currentAccount = accounts[0];
-        const network = Number.parseInt(chainId, 16).toString();
-
-        appendLine(`Name: ${announcedProviderInfo?.name || "Ledger Live"}`);
-        appendLine(`Network: ${network}`);
-        appendLine(`ChainId: ${chainId}`);
-        appendLine(`Accounts: ${accounts.join(", ")}`);
-      });
-
-      document.getElementById("getAccounts").addEventListener("click", async () => {
-        const provider = announcedProvider || window.ethereum;
-        const accounts = await request(provider, "eth_accounts");
-        currentAccount = accounts[0];
-        appendLine(`eth_accounts result: ${accounts.join(", ")}`);
-      });
-
-      document.getElementById("personalSign").addEventListener("click", async () => {
-        const provider = announcedProvider || window.ethereum;
-        const account = currentAccount || (await request(provider, "eth_accounts"))[0];
-        const message = "0x4c6564676572204c697665206c6f63616c2064617070";
-        const result = await request(provider, "personal_sign", [message, account]);
-        appendLine(`personal_sign result: ${result}`);
-      });
-    </script>
+    <!-- Keep dapp logic external so strict CSP tests can use script-src 'self'. -->
+    <script src="dapp.js"></script>
   </body>
 </html>


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. only tests for the previous fix
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - only tests

### 📝 Description

Add an e2e regression test for Live Apps that ship a strict Content-Security-Policy. The dummy dapp is now served with `script-src 'self'`, and its own logic is moved to a same-origin external file so the policy isolates what it exercises: whether Ledger Live's injected Ethereum provider survives a CSP that forbids inline scripts.

- test-utils: let the dummy server send a configurable CSP response header
- LiveAppWebview: thread a `csp` option through `startLiveApp`
- dummy-dapp: extract the inline <script> into dapp.js so it stays allowed
- add dapp-csp.spec.ts asserting EIP-6963 / eth_accounts still work

### ❓ Context

- **JIRA or GitHub link**: 
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
