### PR TITLE
[LWDM] Revert "build(live-common): drop CJS build, ESM-only output"

### DIFF
--- a/.changeset/live-common-esm-only.md
+++ b/.changeset/live-common-esm-only.md
@@ -1,5 +1,0 @@
----
-"@ledgerhq/live-common": patch
----
-
-Drop the CommonJS build: live-common is now ESM-only (single `lib-es` output). Removed the `require` export conditions and the dual `tsc` pass. Consumers (desktop/mobile bundlers, jest, cli) resolve the ESM build via the `default` condition.

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/components/ApyIndicator/__tests__/useApyIndicatorViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/components/ApyIndicator/__tests__/useApyIndicatorViewModel.test.ts
@@ -3,11 +3,6 @@ import * as systemLocale from "~/helpers/systemLocale";
 import * as getApyAppearanceModule from "@ledgerhq/live-common/modularDrawer/utils/getApyAppearance";
 import { useApyIndicatorViewModel } from "../useApyIndicatorViewModel";
 
-jest.mock("@ledgerhq/live-common/modularDrawer/utils/getApyAppearance", () => ({
-  __esModule: true,
-  ...jest.requireActual("@ledgerhq/live-common/modularDrawer/utils/getApyAppearance"),
-}));
-
 jest.mock("~/helpers/systemLocale");
 
 const mockGetParsedSystemDeviceLocale = jest.spyOn(systemLocale, "getParsedSystemDeviceLocale");

--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/__tests__/useSyncOnboardingCompanionViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/__tests__/useSyncOnboardingCompanionViewModel.test.tsx
@@ -10,11 +10,6 @@ import { SeedPhraseType } from "@ledgerhq/types-live";
 import useCompanionSteps, { Step, StepKey, StepStatus } from "../hooks/useCompanionSteps";
 import { Flex } from "@ledgerhq/react-ui/index";
 
-jest.mock("@ledgerhq/live-common/onboarding/hooks/useOnboardingStatePolling", () => ({
-  __esModule: true,
-  ...jest.requireActual("@ledgerhq/live-common/onboarding/hooks/useOnboardingStatePolling"),
-}));
-
 jest.mock("~/renderer/hooks/useRecoverRestoreOnboarding", () => ({
   useRecoverRestoreOnboarding: jest.fn(),
 }));

--- a/apps/ledger-live-desktop/src/renderer/actions/accounts.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/accounts.test.ts
@@ -1,20 +1,19 @@
 import type { Account, AccountUserData } from "@ledgerhq/types-live";
-import {
-  getCryptoCurrencyById,
-  setSupportedCurrencies,
-} from "@ledgerhq/live-common/currencies/index";
+import { checkAccountSupported } from "@ledgerhq/live-common/account/index";
 import { initAccounts } from "./accounts";
 
-function fakeTuple(
-  id: string,
-  currencyId: string,
-  derivationMode = "",
-): [Account, AccountUserData] {
+jest.mock("@ledgerhq/live-common/account/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/account/index"),
+  checkAccountSupported: jest.fn(),
+}));
+
+const mockCheckAccountSupported = checkAccountSupported as jest.Mock;
+
+function fakeTuple(id: string, currencyId: string): [Account, AccountUserData] {
   const account = {
     id,
     type: "Account",
-    currency: getCryptoCurrencyById(currencyId),
-    derivationMode,
+    currency: { id: currencyId },
     name: `name-${id}`,
   } as unknown as Account;
   const userData = { id, name: `custom-${id}` } as unknown as AccountUserData;
@@ -22,8 +21,14 @@ function fakeTuple(
 }
 
 describe("initAccounts", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("drops accounts whose currency is not supported by this build", () => {
-    setSupportedCurrencies(["bitcoin"]);
+    mockCheckAccountSupported.mockImplementation((a: { currency: { id: string } }) =>
+      a.currency.id === "bitcoin" ? null : new Error("currency not supported"),
+    );
 
     const action = initAccounts([
       fakeTuple("btc-1", "bitcoin"),
@@ -37,7 +42,7 @@ describe("initAccounts", () => {
   });
 
   it("keeps all accounts when every currency is supported", () => {
-    setSupportedCurrencies(["bitcoin", "ethereum"]);
+    mockCheckAccountSupported.mockReturnValue(null);
 
     const action = initAccounts([fakeTuple("btc-1", "bitcoin"), fakeTuple("eth-1", "ethereum")]);
 
@@ -45,11 +50,13 @@ describe("initAccounts", () => {
   });
 
   it("drops accounts on any non-currency error (e.g. unsupported derivation mode)", () => {
-    setSupportedCurrencies(["bitcoin"]);
+    mockCheckAccountSupported.mockImplementation((a: { id: string }) =>
+      a.id === "btc-segwit" ? null : new Error("derivation mode not supported"),
+    );
 
     const action = initAccounts([
-      fakeTuple("btc-segwit", "bitcoin", ""),
-      fakeTuple("btc-legacy", "bitcoin", "unsupported_derivation_mode"),
+      fakeTuple("btc-segwit", "bitcoin"),
+      fakeTuple("btc-legacy", "bitcoin"),
     ]);
 
     expect(action.payload.accounts.map(a => a.id)).toEqual(["btc-segwit"]);

--- a/apps/ledger-live-desktop/src/renderer/components/OperationsList/tests/EditOperationPanel.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OperationsList/tests/EditOperationPanel.test.tsx
@@ -1,11 +1,16 @@
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { Account, Operation } from "@ledgerhq/types-live";
 import React from "react";
 import { render, screen, withFlagOverrides } from "tests/testSetup";
 import { closeModal, openModal } from "~/renderer/actions/modals";
 import { getLLDCoinFamily } from "~/renderer/families";
 import EditOperationPanel from "../EditOperationPanel";
+
+jest.mock("@ledgerhq/live-common/account/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/account/index"),
+  getMainAccount: jest.fn(),
+}));
 
 jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
   useAccountBridge: () => ({}),
@@ -21,15 +26,7 @@ jest.mock("~/renderer/families", () => ({
   getLLDCoinFamily: jest.fn(() => ({})),
 }));
 
-const evmAccount = genAccount("edit-operation-panel-account", {
-  currency: getCryptoCurrencyById("ethereum"),
-}) as Account;
-const bitcoinAccount = {
-  ...genAccount("edit-operation-panel-bitcoin-account", {
-    currency: getCryptoCurrencyById("bitcoin"),
-  }),
-  freshAddress: "bc1qfreshaddress",
-} as Account;
+const account = genAccount("edit-operation-panel-account") as Account;
 const parentAccount = undefined;
 const operation = {
   hash: "tx-hash",
@@ -37,7 +34,7 @@ const operation = {
   transactionRaw: undefined,
 } as unknown as Operation;
 
-const renderComponent = (account: Account, overrideInitialState?: Record<string, unknown>) =>
+const renderComponent = (overrideInitialState?: Record<string, unknown>) =>
   render(
     <EditOperationPanel account={account} parentAccount={parentAccount} operation={operation} />,
     {
@@ -60,13 +57,21 @@ describe("EditOperationPanel", () => {
   });
 
   it("should not render panel when no edit flow is supported", () => {
-    renderComponent(evmAccount);
+    (getMainAccount as jest.Mock).mockReturnValue({
+      ...account,
+      currency: { ...account.currency, family: "evm", id: "ethereum" },
+    });
+    renderComponent();
 
     expect(screen.queryByRole("link")).not.toBeInTheDocument();
   });
 
   it("should open family modal with family params when supported by coin family", async () => {
     const familyParams = { accountId: "acc-1", transactionHash: "family-tx-hash" };
+    (getMainAccount as jest.Mock).mockReturnValue({
+      ...account,
+      currency: { ...account.currency, family: "evm", id: "ethereum" },
+    });
     (getLLDCoinFamily as jest.Mock).mockReturnValue({
       handlesEditTransaction: () => ({
         modalName: "MODAL_EVM_EDIT_TRANSACTION",
@@ -74,7 +79,7 @@ describe("EditOperationPanel", () => {
       }),
     });
 
-    const { user } = renderComponent(evmAccount);
+    const { user } = renderComponent();
 
     await user.click(screen.getByText("Speed up or Cancel"));
 
@@ -84,7 +89,7 @@ describe("EditOperationPanel", () => {
 
   it("should open bitcoin modal with family params", async () => {
     const familyParams = {
-      account: bitcoinAccount,
+      account,
       parentAccount,
       transactionRaw: {
         family: "bitcoin" as const,
@@ -98,6 +103,11 @@ describe("EditOperationPanel", () => {
       },
       transactionHash: "tx-hash",
     };
+    (getMainAccount as jest.Mock).mockReturnValue({
+      ...account,
+      freshAddress: "bc1qfreshaddress",
+      currency: { ...account.currency, family: "bitcoin", id: "bitcoin", ticker: "BTC" },
+    });
     (getLLDCoinFamily as jest.Mock).mockReturnValue({
       handlesEditTransaction: () => ({
         modalName: "MODAL_BITCOIN_EDIT_TRANSACTION",
@@ -105,10 +115,7 @@ describe("EditOperationPanel", () => {
       }),
     });
     const { user } = renderComponent(
-      bitcoinAccount,
-      withFlagOverrides({
-        editBitcoinTx: { enabled: true, params: { supportedCurrencyIds: ["bitcoin"] } },
-      }),
+      withFlagOverrides({ editBitcoinTx: { enabled: true, params: { supportedCurrencyIds: ["bitcoin"] } } }),
     );
 
     await user.click(screen.getByText("Speed up or Cancel"));

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/AccountBalanceSummaryFooter.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/AccountBalanceSummaryFooter.test.tsx
@@ -10,10 +10,7 @@ import { useAleoPrivateSync } from "./hooks/useAleoPrivateSync";
 import { ALEO_ACCOUNT_1 } from "./__mocks__/account.mock";
 
 jest.mock("~/renderer/hooks/useAccountUnit");
-jest.mock("@ledgerhq/live-common/currencies/index", () => ({
-  __esModule: true,
-  ...jest.requireActual("@ledgerhq/live-common/currencies/index"),
-}));
+jest.mock("@ledgerhq/live-common/currencies/index");
 jest.mock("./hooks/useAleoPrivateSync");
 
 const mockUseAccountUnit = jest.mocked(useAccountUnit);

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/SelfTransferModal/useHandleChangeAccount.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/SelfTransferModal/useHandleChangeAccount.test.ts
@@ -1,7 +1,15 @@
 import { renderHook } from "tests/testSetup";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { useHandleChangeAccount } from "./useHandleChangeAccount";
-import { ALEO_ACCOUNT_2 } from "../__mocks__/account.mock";
+import { ALEO_ACCOUNT_1, ALEO_ACCOUNT_2 } from "../__mocks__/account.mock";
 import { makeAleoTransaction } from "../__mocks__/transaction.mock";
+
+jest.mock("@ledgerhq/live-common/account/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/account/index"),
+  getMainAccount: jest.fn(),
+}));
+
+const mockGetMainAccount = jest.mocked(getMainAccount);
 
 describe("useHandleChangeAccount", () => {
   const onChangeAccount = jest.fn();
@@ -9,6 +17,7 @@ describe("useHandleChangeAccount", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetMainAccount.mockReturnValue(ALEO_ACCOUNT_1);
   });
 
   it("should do nothing when nextAcc is null", () => {
@@ -44,6 +53,7 @@ describe("useHandleChangeAccount", () => {
   });
 
   it("should call updateTransaction with a function that sets recipient to freshAddress of the main account", () => {
+    mockGetMainAccount.mockReturnValue(ALEO_ACCOUNT_1);
     const { result } = renderHook(() =>
       useHandleChangeAccount({ onChangeAccount, updateTransaction }),
     );
@@ -54,10 +64,11 @@ describe("useHandleChangeAccount", () => {
     const updater = updateTransaction.mock.calls[0][0];
     const nextTx = updater(makeAleoTransaction({ recipient: "old-address" }));
 
-    expect(nextTx.recipient).toBe(ALEO_ACCOUNT_2.freshAddress);
+    expect(nextTx.recipient).toBe(ALEO_ACCOUNT_1.freshAddress);
   });
 
   it("should preserve existing transaction fields when updating recipient", () => {
+    mockGetMainAccount.mockReturnValue(ALEO_ACCOUNT_1);
     const { result } = renderHook(() =>
       useHandleChangeAccount({ onChangeAccount, updateTransaction }),
     );
@@ -69,6 +80,6 @@ describe("useHandleChangeAccount", () => {
     const nextTx = updater(prevTx);
 
     expect(nextTx).toMatchObject({ family: "aleo" });
-    expect(nextTx.recipient).toBe(ALEO_ACCOUNT_2.freshAddress);
+    expect(nextTx.recipient).toBe(ALEO_ACCOUNT_1.freshAddress);
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepAmount.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepAmount.test.tsx
@@ -7,6 +7,10 @@ import { makeStepProps } from "../../../__mocks__/stepProps.mock";
 import { makeAleoTransaction } from "../../../__mocks__/transaction.mock";
 import { mockAleoCoinConfig } from "../../../__mocks__/config.mock";
 
+jest.mock("@ledgerhq/live-common/account/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/account/index"),
+  getMainAccount: jest.fn((account: unknown) => account),
+}));
 jest.mock("../../../shared/utils", () => ({
   ...jest.requireActual("../../../shared/utils"),
   getAleoCurrencyConfig: jest.fn(),

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepRecordPicker.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepRecordPicker.test.tsx
@@ -28,10 +28,7 @@ import { mockAleoCoinConfig } from "../../../__mocks__/config.mock";
 
 jest.mock("~/renderer/hooks/useAccountUnit");
 jest.mock("~/renderer/hooks/useDateFormatter");
-jest.mock("@ledgerhq/live-common/currencies/index", () => ({
-  __esModule: true,
-  ...jest.requireActual("@ledgerhq/live-common/currencies/index"),
-}));
+jest.mock("@ledgerhq/live-common/currencies/index");
 jest.mock("../../../shared/utils", () => ({
   getAleoCurrencyConfig: jest.fn(),
 }));

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepSummaryAdditionalRows.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepSummaryAdditionalRows.test.tsx
@@ -15,6 +15,10 @@ import StepSummaryAdditionalRows from "./StepSummaryAdditionalRows";
 
 jest.mock("@ledgerhq/live-common/families/aleo/utils");
 jest.mock("./utils");
+jest.mock("@ledgerhq/live-common/account/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/account/index"),
+  getMainAccount: jest.fn((account: unknown) => account),
+}));
 jest.mock("../../../shared/utils", () => ({
   ...jest.requireActual("../../../shared/utils"),
   getAleoCurrencyConfig: jest.fn(),

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/__tests__/EditTransactionComponents.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/__tests__/EditTransactionComponents.test.tsx
@@ -1,7 +1,7 @@
 import BigNumber from "bignumber.js";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getFormattedFeeFields } from "@ledgerhq/coin-bitcoin/editTransaction/index";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import React from "react";
 import { render, screen, withFlagOverrides } from "tests/testSetup";
@@ -13,6 +13,11 @@ import type { StepProps } from "../types";
 jest.mock("@ledgerhq/coin-bitcoin/editTransaction/index", () => ({
   ...jest.requireActual("@ledgerhq/coin-bitcoin/editTransaction/index"),
   getFormattedFeeFields: jest.fn(),
+}));
+
+jest.mock("@ledgerhq/live-common/account/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/account/index"),
+  getMainAccount: jest.fn(),
 }));
 
 jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
@@ -40,9 +45,7 @@ jest.mock("~/renderer/components/OperationsList/EditOperationPanel", () => ({
   default: () => <div data-testid="edit-operation-panel" />,
 }));
 
-const account = genAccount("bitcoin-edit-components-account", {
-  currency: getCryptoCurrencyById("bitcoin"),
-});
+const account = genAccount("bitcoin-edit-components-account");
 
 const createStepProps = (overrides: Partial<StepProps> = {}): StepProps =>
   ({
@@ -86,6 +89,10 @@ const createStepProps = (overrides: Partial<StepProps> = {}): StepProps =>
 describe("Bitcoin EditTransaction components", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (getMainAccount as jest.Mock).mockReturnValue({
+      ...account,
+      currency: { ...account.currency, family: "bitcoin", id: "bitcoin", ticker: "BTC" },
+    });
     const { useAccountBridge } = jest.requireMock("@ledgerhq/live-common/bridge/useAccountBridge");
     useAccountBridge.mockReturnValue({
       getStuckAccountAndOperation: mockGetStuckAccountAndOperation,
@@ -134,9 +141,7 @@ describe("Bitcoin EditTransaction components", () => {
     });
 
     render(<EditStuckTransactionPanelBodyHeader account={account} parentAccount={undefined} />, {
-      initialState: withFlagOverrides({
-        editBitcoinTx: { enabled: true, params: { supportedCurrencyIds: ["bitcoin"] } },
-      }),
+      initialState: withFlagOverrides({ editBitcoinTx: { enabled: true, params: { supportedCurrencyIds: ["bitcoin"] } } }),
     });
 
     expect(screen.getByTestId("edit-operation-panel")).toBeInTheDocument();

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/__tests__/StepMethod.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/__tests__/StepMethod.test.tsx
@@ -1,7 +1,7 @@
 import BigNumber from "bignumber.js";
 import { getEditTransactionPatch } from "@ledgerhq/coin-bitcoin/editTransaction/index";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import React from "react";
 import { render, screen, waitFor } from "tests/testSetup";
@@ -23,21 +23,21 @@ jest.mock("@ledgerhq/coin-bitcoin/editTransaction/index", () => ({
   getEditTransactionPatch: jest.fn(),
 }));
 
-jest.mock("@ledgerhq/live-common/bridge/index", () => {
-  const actual = jest.requireActual<Record<PropertyKey, unknown>>(
-    "@ledgerhq/live-common/bridge/index",
-  );
-  const overrides: Record<PropertyKey, unknown> = { __esModule: true, getAccountBridge: jest.fn() };
-  return new Proxy(overrides, { get: (o, k) => (k in o ? o[k] : actual[k]) });
-});
+jest.mock("@ledgerhq/live-common/account/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/account/index"),
+  getMainAccount: jest.fn(),
+}));
+
+jest.mock("@ledgerhq/live-common/bridge/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/bridge/index"),
+  getAccountBridge: jest.fn(),
+}));
 
 jest.mock("../components/TransactionErrorBanner", () => ({
   TransactionErrorBanner: () => null,
 }));
 
-const account = genAccount("bitcoin-step-method-account", {
-  currency: getCryptoCurrencyById("bitcoin"),
-});
+const account = genAccount("bitcoin-step-method-account");
 
 const createProps = (overrides: Partial<StepProps> = {}): StepProps =>
   ({
@@ -74,6 +74,10 @@ const createProps = (overrides: Partial<StepProps> = {}): StepProps =>
 describe("Bitcoin EditTransaction StepMethod", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (getMainAccount as jest.Mock).mockReturnValue({
+      ...account,
+      currency: { ...account.currency, ticker: "BTC", family: "bitcoin" },
+    });
   });
 
   it("opens Bitcoin learn more link", async () => {

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/__tests__/ZCashExportKeyFlowModal.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/__tests__/ZCashExportKeyFlowModal.test.tsx
@@ -7,14 +7,6 @@ import Body from "../Body";
 import { StepId } from "../types";
 import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
 
-jest.mock("@ledgerhq/live-common/bridge/index", () => {
-  const actual = jest.requireActual<Record<PropertyKey, unknown>>(
-    "@ledgerhq/live-common/bridge/index",
-  );
-  const overrides: Record<PropertyKey, unknown> = { __esModule: true, getAccountBridge: jest.fn() };
-  return new Proxy(overrides, { get: (o, k) => (k in o ? o[k] : actual[k]) });
-});
-
 // Mock useConnectAppAction to prevent actual device connection attempts
 jest.mock("~/renderer/hooks/useConnectAppAction", () => {
   const mockDevice: Device = {
@@ -159,9 +151,7 @@ describe("ZCash Export UFVK Flow", () => {
     const bridge = { getFullViewingKey: mockGetFullViewingKey };
     jest
       .spyOn(require("@ledgerhq/live-common/bridge/index"), "getAccountBridge")
-      .mockReturnValue(
-        Object.assign(Promise.resolve(bridge), { status: "fulfilled", value: bridge }),
-      );
+      .mockReturnValue(Object.assign(Promise.resolve(bridge), { status: "fulfilled", value: bridge }));
 
     render(
       <Body

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/__tests__/AccountBalanceSummaryFooter.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/__tests__/AccountBalanceSummaryFooter.test.tsx
@@ -10,10 +10,6 @@ import * as currencies from "@ledgerhq/live-common/currencies/index";
 
 jest.mock("~/renderer/hooks/useAccountUnit");
 jest.mock("@ledgerhq/live-common/currencies/index");
-jest.mock("@ledgerhq/live-common/config/index", () => ({
-  __esModule: true,
-  ...jest.requireActual("@ledgerhq/live-common/config/index"),
-}));
 
 describe("AccountBalanceSummaryFooter", () => {
   describe("Testing disableDelegation in currency config", () => {

--- a/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/__tests__/EditTransactionComponents.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/__tests__/EditTransactionComponents.test.tsx
@@ -1,7 +1,7 @@
 import BigNumber from "bignumber.js";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getFormattedFeeFields } from "@ledgerhq/coin-evm/editTransaction/index";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import React from "react";
 import { render, screen, withFlagOverrides } from "tests/testSetup";
@@ -14,6 +14,11 @@ import evmFamily from "../../index";
 jest.mock("@ledgerhq/coin-evm/editTransaction/index", () => ({
   ...jest.requireActual("@ledgerhq/coin-evm/editTransaction/index"),
   getFormattedFeeFields: jest.fn(),
+}));
+
+jest.mock("@ledgerhq/live-common/account/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/account/index"),
+  getMainAccount: jest.fn(),
 }));
 
 jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
@@ -98,9 +103,7 @@ jest.mock("~/renderer/components/SpeedUpCancel/SharedEditStuckTransactionPanelBo
   ),
 }));
 
-const account = genAccount("evm-edit-components-account", {
-  currency: getCryptoCurrencyById("ethereum"),
-});
+const account = genAccount("evm-edit-components-account");
 
 const createStepProps = (overrides: Partial<StepProps> = {}): StepProps =>
   ({
@@ -145,6 +148,10 @@ const createStepProps = (overrides: Partial<StepProps> = {}): StepProps =>
 describe("EVM EditTransaction components", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (getMainAccount as jest.Mock).mockReturnValue({
+      ...account,
+      currency: { ...account.currency, family: "evm", id: "ethereum", ticker: "ETH" },
+    });
   });
 
   it("StepFees renders EVM specific fee details for type 2 tx", () => {
@@ -193,45 +200,26 @@ describe("EVM EditTransaction components", () => {
     });
 
     render(<EditStuckTransactionPanelBodyHeader account={account} parentAccount={undefined} />, {
-      initialState: withFlagOverrides({
-        editEvmTx: { enabled: true, params: { supportedCurrencyIds: ["ethereum"] } },
-      }),
+      initialState: withFlagOverrides({ editEvmTx: { enabled: true, params: { supportedCurrencyIds: ["ethereum"] } } }),
     });
 
     expect(screen.getByTestId("shared-stuck-header")).toHaveTextContent("true-true-true");
   });
 
   describe("family.handlesEditTransaction", () => {
-    const mainAccount = {
-      ...account,
-      currency: { ...account.currency, family: "evm", id: "ethereum" },
-    };
+    const mainAccount = { ...account, currency: { ...account.currency, family: "evm", id: "ethereum" } };
     const operation = { transactionRaw: { type: 2 } } as never;
     const featureFlags = { evm: { enabled: true, supportedCurrencyIds: ["ethereum"] } };
 
     it("returns null when the bridge marks the operation as non-editable", () => {
       const bridge = { isEditableOperation: jest.fn().mockReturnValue(false) } as never;
-      const result = evmFamily.handlesEditTransaction!({
-        account,
-        parentAccount: undefined,
-        mainAccount,
-        operation,
-        bridge,
-        featureFlags,
-      });
+      const result = evmFamily.handlesEditTransaction!({ account, parentAccount: undefined, mainAccount, operation, bridge, featureFlags });
       expect(result).toBeNull();
     });
 
     it("returns modal config when the bridge marks the operation as editable", () => {
       const bridge = { isEditableOperation: jest.fn().mockReturnValue(true) } as never;
-      const result = evmFamily.handlesEditTransaction!({
-        account,
-        parentAccount: undefined,
-        mainAccount,
-        operation,
-        bridge,
-        featureFlags,
-      });
+      const result = evmFamily.handlesEditTransaction!({ account, parentAccount: undefined, mainAccount, operation, bridge, featureFlags });
       expect(result).toEqual(expect.objectContaining({ modalName: "MODAL_EVM_EDIT_TRANSACTION" }));
     });
   });

--- a/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/__tests__/StepMethod.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/__tests__/StepMethod.test.tsx
@@ -1,7 +1,7 @@
 import BigNumber from "bignumber.js";
 import { getEditTransactionPatch } from "@ledgerhq/coin-evm/editTransaction/index";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import React from "react";
 import { render, screen, waitFor } from "tests/testSetup";
@@ -23,21 +23,21 @@ jest.mock("@ledgerhq/coin-evm/editTransaction/index", () => ({
   getEditTransactionPatch: jest.fn(),
 }));
 
-jest.mock("@ledgerhq/live-common/bridge/index", () => {
-  const actual = jest.requireActual<Record<PropertyKey, unknown>>(
-    "@ledgerhq/live-common/bridge/index",
-  );
-  const overrides: Record<PropertyKey, unknown> = { __esModule: true, getAccountBridge: jest.fn() };
-  return new Proxy(overrides, { get: (o, k) => (k in o ? o[k] : actual[k]) });
-});
+jest.mock("@ledgerhq/live-common/account/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/account/index"),
+  getMainAccount: jest.fn(),
+}));
+
+jest.mock("@ledgerhq/live-common/bridge/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/bridge/index"),
+  getAccountBridge: jest.fn(),
+}));
 
 jest.mock("../components/TransactionErrorBanner", () => ({
   TransactionErrorBanner: () => null,
 }));
 
-const account = genAccount("evm-step-method-account", {
-  currency: getCryptoCurrencyById("ethereum"),
-});
+const account = genAccount("evm-step-method-account");
 
 const createProps = (overrides: Partial<StepProps> = {}): StepProps =>
   ({
@@ -74,6 +74,10 @@ const createProps = (overrides: Partial<StepProps> = {}): StepProps =>
 describe("EVM EditTransaction StepMethod", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (getMainAccount as jest.Mock).mockReturnValue({
+      ...account,
+      currency: { ...account.currency, ticker: "ETH", family: "evm" },
+    });
   });
 
   it("opens EVM learn more link", async () => {

--- a/apps/ledger-live-desktop/src/renderer/families/evm/__tests__/AccountBalanceSummaryFooter.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/__tests__/AccountBalanceSummaryFooter.test.tsx
@@ -13,10 +13,7 @@ jest.mock("~/renderer/hooks/useAccountUnit", () => ({
     magnitude: 18,
   })),
 }));
-jest.mock("@ledgerhq/live-common/currencies/index", () => ({
-  __esModule: true,
-  ...jest.requireActual("@ledgerhq/live-common/currencies/index"),
-}));
+jest.mock("@ledgerhq/live-common/currencies/index");
 
 const footerProps = {
   counterValue: { ticker: "USD", units: [{ code: "USD", magnitude: 2 }] } as unknown as Currency,

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/__tests__/AccountBalanceSummaryFooter.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/__tests__/AccountBalanceSummaryFooter.test.tsx
@@ -10,11 +10,6 @@ import type { TokenAccount } from "@ledgerhq/types-live";
 import { render, screen, withFlagOverrides } from "tests/testSetup";
 import * as currencies from "@ledgerhq/live-common/currencies/index";
 
-jest.mock("@ledgerhq/live-common/currencies/index", () => ({
-  __esModule: true,
-  ...jest.requireActual("@ledgerhq/live-common/currencies/index"),
-}));
-
 jest.mock("~/renderer/hooks/useAccountUnit");
 
 type StakingInfo = ReturnType<

--- a/apps/ledger-live-desktop/src/renderer/hooks/useStepMethodLogic.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useStepMethodLogic.test.ts
@@ -1,5 +1,6 @@
 import BigNumber from "bignumber.js";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { act, renderHook } from "tests/testSetup";
 import { urls } from "~/config/urls";
@@ -10,13 +11,15 @@ jest.mock("~/renderer/linking", () => ({
   openURL: jest.fn(),
 }));
 
-jest.mock("@ledgerhq/live-common/bridge/index", () => {
-  const actual = jest.requireActual<Record<PropertyKey, unknown>>(
-    "@ledgerhq/live-common/bridge/index",
-  );
-  const overrides: Record<PropertyKey, unknown> = { __esModule: true, getAccountBridge: jest.fn() };
-  return new Proxy(overrides, { get: (o, k) => (k in o ? o[k] : actual[k]) });
-});
+jest.mock("@ledgerhq/live-common/account/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/account/index"),
+  getMainAccount: jest.fn(),
+}));
+
+jest.mock("@ledgerhq/live-common/bridge/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/bridge/index"),
+  getAccountBridge: jest.fn(),
+}));
 
 describe("useStepMethodSelection", () => {
   it("sets edit type to speedup when speedup is available", () => {
@@ -110,6 +113,7 @@ describe("useStepMethodContinue", () => {
     const getPatch = jest.fn().mockResolvedValue(patch);
     const bridgeUpdateTransaction = jest.fn().mockReturnValue(updatedTransaction);
 
+    (getMainAccount as jest.Mock).mockReturnValue(account);
     const bridge = { updateTransaction: bridgeUpdateTransaction };
     (getAccountBridge as jest.Mock).mockReturnValue(
       Object.assign(Promise.resolve(bridge), { status: "fulfilled", value: bridge }),

--- a/apps/ledger-live-mobile/babel.config.js
+++ b/apps/ledger-live-mobile/babel.config.js
@@ -33,7 +33,6 @@ module.exports = {
     process.env.DETOX === "1" || process.env.DETOX === "true"
       ? "./babel-plugin-inject-collapsable.js"
       : null,
-    process.env.NODE_ENV === "test" ? "@babel/plugin-transform-dynamic-import" : null,
     // react-native-worklets/plugin has to be listed last
     "react-native-worklets/plugin",
   ].filter(Boolean),

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -253,7 +253,6 @@
     "@babel/plugin-transform-arrow-functions": "7.27.1",
     "@babel/plugin-transform-class-properties": "7.27.1",
     "@babel/plugin-transform-class-static-block": "7.28.3",
-    "@babel/plugin-transform-dynamic-import": "7.27.1",
     "@babel/plugin-transform-export-namespace-from": "7.27.1",
     "@babel/plugin-transform-named-capturing-groups-regex": "7.27.1",
     "@babel/plugin-transform-nullish-coalescing-operator": "7.27.1",

--- a/apps/ledger-live-mobile/src/actions/accounts.test.ts
+++ b/apps/ledger-live-mobile/src/actions/accounts.test.ts
@@ -3,9 +3,8 @@ import { checkAccountSupported } from "@ledgerhq/live-common/account/index";
 import accountModel from "../logic/accountModel";
 import { importStore } from "./accounts";
 
-jest.mock("@ledgerhq/ledger-wallet-framework/account/support", () => ({
-  __esModule: true,
-  ...jest.requireActual("@ledgerhq/ledger-wallet-framework/account/support"),
+jest.mock("@ledgerhq/live-common/account/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/account/index"),
   checkAccountSupported: jest.fn(),
 }));
 

--- a/apps/ledger-live-mobile/src/families/bitcoin/EditTransactionFlow/MethodSelection.test.tsx
+++ b/apps/ledger-live-mobile/src/families/bitcoin/EditTransactionFlow/MethodSelection.test.tsx
@@ -16,6 +16,14 @@ jest.mock("@ledgerhq/ledger-wallet-framework/operation", () => ({
   isOldestBitcoinPendingOperation: jest.fn().mockReturnValue(true),
 }));
 
+jest.mock("@ledgerhq/live-common/account/index", () => {
+  const actual = jest.requireActual("@ledgerhq/live-common/account/index");
+  return {
+    ...actual,
+    getMainAccount: jest.fn(),
+  };
+});
+
 jest.mock("@ledgerhq/live-common/bridge/index", () => {
   const bridge = { updateTransaction: jest.fn() };
   const settledPromise = Object.assign(Promise.resolve(bridge), {
@@ -60,6 +68,8 @@ jest.mock("~/components/EditTransaction/MethodSelectionList", () => {
   };
 });
 
+const mockedGetMainAccount = jest.requireMock("@ledgerhq/live-common/account/index")
+  .getMainAccount as jest.Mock;
 const mockedUseBridgeTransaction = jest.requireMock(
   "@ledgerhq/live-common/bridge/useBridgeTransaction",
 ).default as jest.Mock;
@@ -67,16 +77,15 @@ const mockedUseBridgeTransaction = jest.requireMock(
 describe("Bitcoin MethodSelection", () => {
   it("navigates to already validated error when tx gets confirmed", async () => {
     const navigate = jest.fn();
-    const account = {
-      type: "Account",
-      id: "account-id",
-      freshAddress: "mock-address",
-      currency: { ticker: "BTC", blockAvgTime: 1 },
-      bitcoinResources: { walletAccount: {} },
-    };
+    const account = { id: "account-id" };
     const parentAccount = { id: "parent-id" };
     const operation = { hash: "op-hash", date: new Date().toISOString() };
 
+    mockedGetMainAccount.mockReturnValue({
+      freshAddress: "mock-address",
+      currency: { ticker: "BTC", blockAvgTime: 1 },
+      bitcoinResources: { walletAccount: {} },
+    });
     mockedUseBridgeTransaction.mockReturnValue({
       transaction: { family: "bitcoin" },
       setTransaction: jest.fn(),

--- a/apps/ledger-live-mobile/src/families/cardano/Delegations/__tests__/Delegations.test.tsx
+++ b/apps/ledger-live-mobile/src/families/cardano/Delegations/__tests__/Delegations.test.tsx
@@ -72,6 +72,11 @@ jest.mock("LLM/hooks/useAccountUnit", () => ({
   useAccountUnit: () => ({ code: "ADA", magnitude: 6 }),
 }));
 
+jest.mock("@ledgerhq/live-common/account/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/account/index"),
+  getMainAccount: (account: unknown) => account,
+  flattenAccounts: (accounts: unknown[]) => accounts,
+}));
 jest.mock("@ledgerhq/live-common/explorers", () => ({
   getDefaultExplorerView: jest.fn(),
   getStakePoolExplorer: jest.fn(),

--- a/apps/ledger-live-mobile/src/families/celo/__tests__/SendRowsFee.test.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/__tests__/SendRowsFee.test.tsx
@@ -34,6 +34,23 @@ jest.mock("LLM/hooks/useAccountUnit", () => ({
   }),
 }));
 
+jest.mock("@ledgerhq/live-common/account/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/account/index"),
+  getMainAccount: (_account: unknown) => _account,
+  getAccountCurrency: jest.fn().mockReturnValue({ id: "celo", name: "Celo", units: [] }),
+  findSubAccountById: (_account: unknown, id: string | null) =>
+    id === "usdc-sub-account-id"
+      ? {
+          type: "TokenAccount",
+          id: "usdc-sub-account-id",
+          token: {
+            contractAddress: "0xceba9300f2b948710d2653dd7b07f33a8b32118c",
+            units: [{ name: "USDC", code: "USDC", magnitude: 6 }],
+          },
+        }
+      : null,
+}));
+
 const mockCeloAccount: CeloAccount = {
   type: "Account",
   id: "celo-account-id",

--- a/apps/ledger-live-mobile/src/families/celo/__tests__/SendSelectRecipient.test.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/__tests__/SendSelectRecipient.test.tsx
@@ -24,6 +24,13 @@ jest.mock("@ledgerhq/live-common/bridge/index", () => {
   };
 });
 
+jest.mock("@ledgerhq/live-common/account/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/account/index"),
+  getMainAccount: (_account: unknown, parentAccount: unknown) => parentAccount ?? _account,
+  findSubAccountById: (account: { subAccounts?: { id: string }[] }, id: string | null) =>
+    account.subAccounts?.find(sub => sub.id === id) ?? null,
+}));
+
 const usdcContractAddress = "0xceba9300f2b948710d2653dd7b07f33a8b32118c";
 const unknownContractAddress = "0x0000000000000000000000000000000000000001";
 

--- a/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/MethodSelection.test.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/MethodSelection.test.tsx
@@ -16,6 +16,14 @@ jest.mock("@ledgerhq/ledger-wallet-framework/operation", () => ({
   isOldestPendingOperation: jest.fn().mockReturnValue(true),
 }));
 
+jest.mock("@ledgerhq/live-common/account/index", () => {
+  const actual = jest.requireActual("@ledgerhq/live-common/account/index");
+  return {
+    ...actual,
+    getMainAccount: jest.fn(),
+  };
+});
+
 jest.mock("@ledgerhq/live-common/bridge/index", () => {
   const bridge = { updateTransaction: jest.fn() };
   const settledPromise = Object.assign(Promise.resolve(bridge), {
@@ -66,6 +74,8 @@ jest.mock("~/components/EditTransaction/MethodSelectionList", () => {
   };
 });
 
+const mockedGetMainAccount = jest.requireMock("@ledgerhq/live-common/account/index")
+  .getMainAccount as jest.Mock;
 const mockedUseBridgeTransaction = jest.requireMock(
   "@ledgerhq/live-common/bridge/useBridgeTransaction",
 ).default as jest.Mock;
@@ -73,15 +83,14 @@ const mockedUseBridgeTransaction = jest.requireMock(
 describe("EVM MethodSelection", () => {
   it("navigates to already validated error when tx gets confirmed", async () => {
     const navigate = jest.fn();
-    const account = {
-      type: "Account",
-      id: "account-id",
-      currency: { ticker: "ETH", blockAvgTime: 1 },
-      balance: { toNumber: () => 10 },
-    };
+    const account = { id: "account-id" };
     const parentAccount = { id: "parent-id" };
     const operation = { hash: "op-hash", transactionRaw: { family: "evm" } };
 
+    mockedGetMainAccount.mockReturnValue({
+      currency: { ticker: "ETH", blockAvgTime: 1 },
+      balance: { toNumber: () => 10 },
+    });
     mockedUseBridgeTransaction.mockReturnValue({
       transaction: { family: "evm", nonce: 1 },
       setTransaction: jest.fn(),

--- a/apps/ledger-live-mobile/src/families/tezos/Delegations/__tests__/index.test.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/Delegations/__tests__/index.test.tsx
@@ -46,6 +46,12 @@ jest.mock("~/reducers/wallet", () => ({
   useAccountName: () => "My Tezos Account",
 }));
 
+jest.mock("@ledgerhq/live-common/account/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/account/index"),
+  getAccountCurrency: (a: { currency?: unknown }) =>
+    a.currency ?? { id: "tezos", ticker: "XTZ", units: [] },
+}));
+
 jest.mock("../../BakerImage", () => () => null);
 jest.mock("~/icons/images/Rewards", () => () => null);
 

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/components/ApyIndicator/__tests__/useApyIndicatorViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/components/ApyIndicator/__tests__/useApyIndicatorViewModel.test.ts
@@ -5,11 +5,6 @@ import { useApyIndicatorViewModel } from "../useApyIndicatorViewModel";
 
 jest.mock("~/helpers/getStakeLabelLocaleBased");
 
-jest.mock("@ledgerhq/live-common/modularDrawer/utils/getApyAppearance", () => ({
-  __esModule: true,
-  ...jest.requireActual("@ledgerhq/live-common/modularDrawer/utils/getApyAppearance"),
-}));
-
 const mockGetCountryLocale = jest.spyOn(getStakeLabelLocaleBased, "getCountryLocale");
 
 describe("useApyIndicatorViewModel", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/NotificationsPromptStakeFlow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/NotificationsPromptStakeFlow.test.tsx
@@ -23,11 +23,6 @@ import { NavigatorName, ScreenName } from "~/const";
 import { track } from "~/analytics";
 import { createNotificationsPromptFeatureFlags } from "./testUtils";
 
-jest.mock("@ledgerhq/live-common/families/tezos/react", () => ({
-  __esModule: true,
-  ...jest.requireActual("@ledgerhq/live-common/families/tezos/react"),
-}));
-
 const featureFlagsForStakePrompt = createNotificationsPromptFeatureFlags();
 
 type AccountKey =

--- a/apps/ledger-live-mobile/src/screens/Account/__tests__/ListHeaderComponent.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/__tests__/ListHeaderComponent.test.tsx
@@ -14,30 +14,6 @@ import type { TFunction } from "i18next";
 import { render } from "@testing-library/react-native";
 import React from "react";
 
-jest.mock("@ledgerhq/live-common/config/index", () => ({
-  __esModule: true,
-  ...jest.requireActual("@ledgerhq/live-common/config/index"),
-}));
-
-jest.mock("@ledgerhq/live-common/account/index", () => {
-  const actual = jest.requireActual("@ledgerhq/live-common/account/index");
-  const mocked: Record<string, unknown> = { __esModule: true };
-  for (const key of Object.keys(actual)) {
-    let value: unknown;
-    let assigned = false;
-    Object.defineProperty(mocked, key, {
-      configurable: true,
-      enumerable: true,
-      get: () => (assigned ? value : actual[key]),
-      set: v => {
-        value = v;
-        assigned = true;
-      },
-    });
-  }
-  return mocked;
-});
-
 jest.mock("@features/platform-feature-flags", () => ({
   ...jest.requireActual("@features/platform-feature-flags"),
   useFeature: jest.fn(),

--- a/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.test.tsx
@@ -8,10 +8,6 @@ import { RouteProp } from "@react-navigation/core";
 import { ScreenName } from "~/const";
 import { SendFundsNavigatorStackParamList } from "~/components/RootNavigator/types/SendFundsNavigator";
 
-jest.mock("@ledgerhq/live-common/bridge/useBridgeTransaction", () => ({
-  __esModule: true,
-  ...jest.requireActual("@ledgerhq/live-common/bridge/useBridgeTransaction"),
-}));
 jest.mock("react-native-safe-area-context", () => ({
   useSafeAreaInsets: jest.fn().mockReturnValue({}),
 }));

--- a/libs/coin-modules-monitoring/src/run.test.ts
+++ b/libs/coin-modules-monitoring/src/run.test.ts
@@ -5,25 +5,6 @@ import { encodeAccountId } from "@ledgerhq/ledger-wallet-framework/account/accou
 import BigNumber from "bignumber.js";
 import run from "./run";
 
-jest.mock("@ledgerhq/live-common/bridge/impl", () => {
-  const actual = jest.requireActual("@ledgerhq/live-common/bridge/impl");
-  const mocked: Record<string, unknown> = { __esModule: true };
-  for (const key of Object.keys(actual)) {
-    let value: unknown;
-    let assigned = false;
-    Object.defineProperty(mocked, key, {
-      configurable: true,
-      enumerable: true,
-      get: () => (assigned ? value : actual[key]),
-      set: v => {
-        value = v;
-        assigned = true;
-      },
-    });
-  }
-  return mocked;
-});
-
 describe("Coin Modules Monitoring", () => {
   beforeAll(() => {
     global.console = require("console");

--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -10,26 +10,31 @@
     "url": "https://github.com/LedgerHQ/ledger-live/issues"
   },
   "homepage": "https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledger-live-common",
-  "main": "lib-es/index.js",
+  "main": "lib/index.js",
   "module": "lib-es/index.js",
-  "types": "lib-es/index.d.ts",
+  "types": "lib/index.d.ts",
   "typesVersions": {
     "*": {
       "*.json": [
         "*.json"
       ],
       "*": [
-        "lib-es/*"
+        "lib/*"
+      ],
+      "lib/*": [
+        "lib/*"
       ],
       "lib-es/*": [
         "lib-es/*"
       ],
       "test-helpers/*": [
-        "lib-es/test-helpers/*"
+        "lib/test-helpers/*"
       ]
     }
   },
   "exports": {
+    "./lib/*": "./lib/*.js",
+    "./lib/*.js": "./lib/*.js",
     "./lib-es/*": "./lib-es/*.js",
     "./lib-es/*.js": "./lib-es/*.js",
     "./*": {
@@ -37,6 +42,7 @@
         "./src/*.ts",
         "./src/*.tsx"
       ],
+      "require": "./lib/*.js",
       "default": "./lib-es/*.js"
     },
     "./*.js": {
@@ -44,76 +50,93 @@
         "./src/*.ts",
         "./src/*.tsx"
       ],
+      "require": "./lib/*.js",
       "default": "./lib-es/*.js"
     },
     ".": {
+      "require": "./lib/index.js",
       "default": "./lib-es/index.js"
     },
     "./genericAwarenessModal": {
       "@ledgerhq/source": "./src/genericAwarenessModal/index.ts",
+      "require": "./lib/genericAwarenessModal/index.js",
       "default": "./lib-es/genericAwarenessModal/index.js"
     },
     "./currencies/*": {
       "@ledgerhq/source": "./src/currencies/*.ts",
+      "require": "./lib/currencies/*.js",
       "default": "./lib-es/currencies/*.js"
     },
     "./device-action/*": {
       "@ledgerhq/source": "./src/device-action/*.ts",
+      "require": "./lib/device-action/*.js",
       "default": "./lib-es/device-action/*.js"
     },
     "./hooks": {
+      "require": "./lib/hooks/index.js",
       "default": "./lib-es/hooks/index.js"
     },
     "./e2e": {
       "@ledgerhq/source": "./src/e2e/index.ts",
+      "require": "./lib/e2e/index.js",
       "default": "./lib-es/e2e/index.js"
     },
     "./featureFlags": {
       "@ledgerhq/source": "./src/featureFlags/*.ts",
+      "require": "./lib/featureFlags/*.js",
       "default": "./lib-es/featureFlags/*.js"
     },
     "./bridge/descriptor/registry": {
       "@ledgerhq/source": "./src/bridge/descriptor/registry.ts",
+      "require": "./lib/bridge/descriptor/registry.js",
       "default": "./lib-es/bridge/descriptor/registry.js"
     },
     "./bridge/descriptor/types": {
       "@ledgerhq/source": "./src/bridge/descriptor/types.ts",
+      "require": "./lib/bridge/descriptor/types.js",
       "default": "./lib-es/bridge/descriptor/types.js"
     },
     "./bridge/descriptor/send/features": {
       "@ledgerhq/source": "./src/bridge/descriptor/send/features.ts",
+      "require": "./lib/bridge/descriptor/send/features.js",
       "default": "./lib-es/bridge/descriptor/send/features.js"
     },
     "./bridge/descriptor/send/memo": {
       "@ledgerhq/source": "./src/bridge/descriptor/send/memo.ts",
+      "require": "./lib/bridge/descriptor/send/memo.js",
       "default": "./lib-es/bridge/descriptor/send/memo.js"
     },
     "./test-helpers/cryptoAssetsStore": {
       "@ledgerhq/source": "./src/test-helpers/cryptoAssetsStore.ts",
-      "types": "./lib-es/test-helpers/cryptoAssetsStore.d.ts",
+      "types": "./lib/test-helpers/cryptoAssetsStore.d.ts",
+      "require": "./lib/test-helpers/cryptoAssetsStore.js",
       "default": "./lib-es/test-helpers/cryptoAssetsStore.js"
     },
     "./test-helpers/*": {
       "@ledgerhq/source": "./src/test-helpers/*.ts",
-      "types": "./lib-es/test-helpers/*.d.ts",
+      "types": "./lib/test-helpers/*.d.ts",
+      "require": "./lib/test-helpers/*.js",
       "default": "./lib-es/test-helpers/*.js"
     },
     "./modularDrawer/__mocks__/*": {
       "@ledgerhq/source": "./src/modularDrawer/__mocks__/*.ts",
-      "types": "./lib-es/modularDrawer/__mocks__/*.d.ts",
+      "types": "./lib/modularDrawer/__mocks__/*.d.ts",
+      "require": "./lib/modularDrawer/__mocks__/*.js",
       "default": "./lib-es/modularDrawer/__mocks__/*.js"
     },
     "./cmc-client/__mocks__/*": {
       "@ledgerhq/source": "./src/cmc-client/__mocks__/*.ts",
-      "types": "./lib-es/cmc-client/__mocks__/*.d.ts",
+      "types": "./lib/cmc-client/__mocks__/*.d.ts",
+      "require": "./lib/cmc-client/__mocks__/*.js",
       "default": "./lib-es/cmc-client/__mocks__/*.js"
     },
     "./package.json": "./package.json"
   },
   "license": "Apache-2.0",
   "scripts": {
-    "build": "rimraf lib lib-es && tsc --project src/tsconfig.build.json -m esnext --moduleResolution bundler --outDir lib-es",
-    "watch": "tsc --project src/tsconfig.build.json -m esnext --moduleResolution bundler --outDir lib-es --watch",
+    "build": "zx ./scripts/build-ts.mjs",
+    "watch": "zx ./scripts/watch-ts.mjs",
+    "watch:es": "zx ./scripts/watch-ts-es.mjs",
     "updateAppSupportsQuitApp": "node scripts/updateAppSupportsQuitApp.js",
     "prettier": "prettier --write 'src/**/*.?s'",
     "lint": "oxlint src",
@@ -136,6 +159,7 @@
     "coverage": "env-cmd -f .ci.unit.env pnpm jest --coverage --ci"
   },
   "files": [
+    "lib",
     "lib-es",
     "src"
   ],

--- a/libs/ledger-live-common/scripts/build-ts.mjs
+++ b/libs/ledger-live-common/scripts/build-ts.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env zx
+import "zx/globals";
+import rimraf from "rimraf";
+
+$.verbose = true; // everything works like in v7
+
+if (os.platform() === "win32") {
+  usePowerShell();
+}
+
+cd(path.join(__dirname, ".."));
+
+if (!process.env.CI) {
+  await rimraf(["lib"]);
+}
+
+const prefix = $.prefix;
+
+await within(async () => {
+  $.prefix = prefix;
+  process.env.NODE_ENV = "production";
+  await $`pnpm tsc --project src/tsconfig.build.json`;
+  await $`pnpm tsc --project src/tsconfig.build.json -m esnext --moduleResolution bundler --outDir lib-es`;
+});

--- a/libs/ledger-live-common/scripts/watch-ts-es.mjs
+++ b/libs/ledger-live-common/scripts/watch-ts-es.mjs
@@ -1,0 +1,17 @@
+#!/usr/bin/env zx
+import "zx/globals";
+
+$.verbose = true; // everything works like in v7
+
+if (os.platform() === "win32") {
+  usePowerShell();
+}
+
+try {
+  cd(path.join(__dirname, ".."));
+
+  await $`pnpm tsc --project src/tsconfig.build.json -m esnext --moduleResolution bundler --outDir lib-es --watch`;
+} catch (error) {
+  console.log(chalk.red(error));
+  process.exit(1);
+}

--- a/libs/ledger-live-common/scripts/watch-ts.mjs
+++ b/libs/ledger-live-common/scripts/watch-ts.mjs
@@ -1,0 +1,17 @@
+#!/usr/bin/env zx
+import "zx/globals";
+
+$.verbose = true; // everything works like in v7
+
+if (os.platform() === "win32") {
+  usePowerShell();
+}
+
+try {
+  cd(path.join(__dirname, ".."));
+
+  await $`pnpm tsc --project src/tsconfig.build.json --watch`;
+} catch (error) {
+  console.log(chalk.red(error));
+  process.exit(1);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2076,9 +2076,6 @@ importers:
       '@babel/plugin-transform-class-static-block':
         specifier: 7.28.3
         version: 7.28.3(@babel/core@7.28.5)
-      '@babel/plugin-transform-dynamic-import':
-        specifier: 7.27.1
-        version: 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-transform-export-namespace-from':
         specifier: 7.27.1
         version: 7.27.1(@babel/core@7.28.5)


### PR DESCRIPTION
> [!WARNING]
> while we're trying to fix it. This PR is a pessimistic solution to revert completely the move.
> Reverts #18028. The ESM-only live-common build broke e2e/mobile at runtime.

### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Restores live-common dual CJS (`lib`) + ESM (`lib-es`) output and the `require` export conditions. No consumer code change.

### 📝 Description

Reverts #18028 ("build(live-common): drop CJS build, ESM-only output").

The ESM-only output broke e2e/mobile at runtime: dependent ESM libs use extensionless imports that Node's ESM resolver cannot resolve, e.g.

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
  '/.../libs/device-core/lib-es/managerApi/repositories/HttpManagerApiRepository'
imported from
  '/.../libs/device-core/lib-es/index.js'
```

This restores the previous dual CJS + ESM build so consumers resolve the CJS build via the `require` condition again.

### ❓ Context

- **JIRA or GitHub link**: reverts #18028 (LIVE-29648)
- **ADR link (if any)**:
