### PR TITLE
[LWM] fix(e2e): load ESM-only live-common in detox jest

### DIFF
--- a/.changeset/wild-e2e-esm-cjs.md
+++ b/.changeset/wild-e2e-esm-cjs.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-mobile-e2e-tests": patch
+---
+
+Fix mobile e2e jest loading of ESM-only live-common: transpile `lib-es` to CommonJS in the jest main process (config/globalSetup/reporters) via an swc require-hook, and transform `@ledgerhq` packages in jest workers (`ESM_PACKAGES` + babel `modules-commonjs`/`dynamic-import`). Resolves `ERR_MODULE_NOT_FOUND` on extensionless `device-core` imports after live-common became ESM-only.

--- a/e2e/mobile/babel.config.js
+++ b/e2e/mobile/babel.config.js
@@ -3,5 +3,8 @@ module.exports = {
     "@babel/plugin-transform-named-capturing-groups-regex",
     "@babel/plugin-transform-export-namespace-from",
     ["@babel/plugin-proposal-class-properties", { loose: true }],
+    // Convert ESM-only live-common (`lib-es`) to CommonJS in jest workers. See LIVE-31760.
+    "@babel/plugin-transform-modules-commonjs",
+    "@babel/plugin-transform-dynamic-import",
   ],
 };

--- a/e2e/mobile/jest.config.js
+++ b/e2e/mobile/jest.config.js
@@ -1,3 +1,4 @@
+require("./scripts/register-lib-es-cjs");
 const { compilerOptions } = require("./tsconfig.json");
 const {
   getDeviceFirmwareVersion,
@@ -61,7 +62,7 @@ const detoxAllure2AdapterOptions = {
   onError: "warn",
 };
 
-const ESM_PACKAGES = ["ky", "@polkadot"].join("|");
+const ESM_PACKAGES = ["ky", "@polkadot", "@ledgerhq"].join("|");
 
 const config = {
   rootDir: ".",

--- a/e2e/mobile/scripts/register-lib-es-cjs.js
+++ b/e2e/mobile/scripts/register-lib-es-cjs.js
@@ -1,0 +1,20 @@
+const fs = require("node:fs");
+const Module = require("node:module");
+const swc = require("@swc/core");
+
+// live-common is ESM-only with extensionless `lib-es` imports, illegal under Node's
+// native ESM loader. The jest main process (config/globalSetup/reporters) requires it
+// outside jest's transform, so transpile `lib-es` to CJS on require. See LIVE-31760.
+const originalJs = Module._extensions[".js"];
+Module._extensions[".js"] = function (mod, filename) {
+  if (filename.includes("/libs/") && filename.includes("/lib-es/")) {
+    const source = fs.readFileSync(filename, "utf8");
+    const { code } = swc.transformSync(source, {
+      filename,
+      jsc: { parser: { syntax: "ecmascript" }, target: "es2022" },
+      module: { type: "commonjs" },
+    });
+    return mod._compile(code, filename);
+  }
+  return originalJs(mod, filename);
+};


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
  - https://github.com/LedgerHQ/ledger-live/actions/runs/26836348803
- [x] **Impact of the changes:**
  - Mobile e2e (detox) tooling only — no app/runtime code. QA: none beyond the e2e suite running green again.

### 📝 Description

Follow-up bugfix to #18028 (live-common ESM-only). After live-common shipped ESM-only (`lib-es`, extensionless imports from `moduleResolution: bundler`), running mobile e2e locally failed at startup:

```
ERR_MODULE_NOT_FOUND: Cannot find module
  .../libs/device-core/lib-es/managerApi/repositories/HttpManagerApiRepository
imported from .../libs/device-core/lib-es/index.js
```

Root cause: the detox jest setup loads live-common in contexts that bypass jest's transform pipeline, so Node loads the `lib-es` graph as **native ESM**, which rejects the monorepo's extensionless imports. It breaks in three layers:

| Layer | Why | Fix |
| --- | --- | --- |
| config-load (`jest.config.js` top-level `require`) | plain Node → native ESM | swc require-hook (main process) |
| globalSetup / reporters (main process) | `requireAndTranspileModule` skips `moduleNameMapper`/allowlist | same require-hook |
| workers (`bridge/server` → `account/index`, `coin-modules/...`) | `transformIgnorePatterns` skipped `@ledgerhq` | `@ledgerhq` in `ESM_PACKAGES` + babel `modules-commonjs`/`dynamic-import` |

Changes (e2e tooling only):
- `scripts/register-lib-es-cjs.js` — swc require-hook transpiling `/libs/**/lib-es/` to CommonJS on require, so the graph resolves via Node's CJS resolver (`require` condition → `lib`).
- `jest.config.js` — load the hook first; add `@ledgerhq` to `ESM_PACKAGES`.
- `babel.config.js` — add `@babel/plugin-transform-modules-commonjs` + `@babel/plugin-transform-dynamic-import`.

> [!NOTE]
> Cleaner long-term fix is making the `lib-es` builds Node-ESM-correct (extensions / `type:module`) — the follow-up noted in #18028. This is the contained e2e fix.

### ❓ Context

- **JIRA or GitHub link**: follow-up to #18028
- **ADR link (if any)**: N/A
