### PR TITLE
[LWDM] chore(live-common): drop .js extension from relative dynamic imports

### DIFF
--- a/.changeset/drop-js-import-extensions.md
+++ b/.changeset/drop-js-import-extensions.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/live-common": patch
+"@ledgerhq/coin-modules-monitoring": patch
+"@ledgerhq/coin-tester-evm": patch
+"@ledgerhq/coin-tester-tezos": patch
+"@ledgerhq/coin-tester-solana": patch
+---
+
+Drop the `.js` extension from relative dynamic `import()` specifiers in live-common (coin module loaders and the generic coin framework bridge/api). Switch the remaining NodeNext consumers that read live-common source to `moduleResolution: "bundler"` so extensionless imports resolve in the IDE, while keeping their CommonJS build output unchanged.

--- a/libs/coin-modules-monitoring/tsconfig.json
+++ b/libs/coin-modules-monitoring/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../tsconfig.base",
   "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "declaration": true,
     "declarationMap": true,
     "lib": [

--- a/libs/coin-tester-modules/coin-tester-evm/tsconfig.build.json
+++ b/libs/coin-tester-modules/coin-tester-evm/tsconfig.build.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "customConditions": [],
     "types": [
       "node",

--- a/libs/coin-tester-modules/coin-tester-evm/tsconfig.json
+++ b/libs/coin-tester-modules/coin-tester-evm/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../../tsconfig.base",
   "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "lib": ["es2020", "dom"],
     "outDir": "lib",
     "rootDir": "src",

--- a/libs/coin-tester-modules/coin-tester-solana/tsconfig.build.json
+++ b/libs/coin-tester-modules/coin-tester-solana/tsconfig.build.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "customConditions": [],
     "types": [
       "node",

--- a/libs/coin-tester-modules/coin-tester-solana/tsconfig.json
+++ b/libs/coin-tester-modules/coin-tester-solana/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../../tsconfig.base",
   "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "lib": ["es2020", "dom"],
     "outDir": "lib",
     "rootDir": "src",

--- a/libs/coin-tester-modules/coin-tester-tezos/tsconfig.build.json
+++ b/libs/coin-tester-modules/coin-tester-tezos/tsconfig.build.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "customConditions": [],
     "types": [
       "node",

--- a/libs/coin-tester-modules/coin-tester-tezos/tsconfig.json
+++ b/libs/coin-tester-modules/coin-tester-tezos/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../../tsconfig.base",
   "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "lib": ["es2020", "dom"],
     "outDir": "lib",
     "rootDir": "src",

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/api/index.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/api/index.ts
@@ -17,19 +17,19 @@ export async function getCoinModuleApi(
     const currency = findCryptoCurrencyByNetwork(network);
     switch (currency?.family) {
       case "xrp":
-        return (await import("./local/xrp.js")).createLocalXrpApi(currency.id);
+        return (await import("./local/xrp")).createLocalXrpApi(currency.id);
       case "stellar":
-        return (await import("./local/stellar.js")).createLocalStellarApi(currency.id);
+        return (await import("./local/stellar")).createLocalStellarApi(currency.id);
       case "canton":
-        return (await import("./local/canton.js")).createLocalCantonApi(currency.id);
+        return (await import("./local/canton")).createLocalCantonApi(currency.id);
       case "tron":
-        return (await import("./local/tron.js")).createLocalTronApi(currency.id);
+        return (await import("./local/tron")).createLocalTronApi(currency.id);
       case "evm":
-        return (await import("./local/evm.js")).createLocalEvmApi(currency.id);
+        return (await import("./local/evm")).createLocalEvmApi(currency.id);
       case "tezos":
-        return (await import("./local/tezos.js")).createLocalTezosApi(currency.id);
+        return (await import("./local/tezos")).createLocalTezosApi(currency.id);
       case "solana":
-        return (await import("./local/solana.js")).createLocalSolanaApi(currency.id);
+        return (await import("./local/solana")).createLocalSolanaApi(currency.id);
     }
   }
   return getNetworkCoinModuleApi(network) satisfies Partial<CoinModuleApi<any> & BridgeApi>;

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/bridge.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/bridge.ts
@@ -4,13 +4,13 @@ import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 export async function getBridgeApi(currency: CryptoCurrency, network: string): Promise<BridgeApi> {
   switch (network) {
     case "evm":
-      return (await import("./families/evm/bridge.js")).default(currency);
+      return (await import("./families/evm/bridge")).default(currency);
     case "solana":
-      return (await import("./families/solana/bridge.js")).default(currency);
+      return (await import("./families/solana/bridge")).default(currency);
     case "stellar":
-      return (await import("./families/stellar/bridge.js")).default;
+      return (await import("./families/stellar/bridge")).default;
     case "tezos":
-      return (await import("./families/tezos/bridge.js")).default;
+      return (await import("./families/tezos/bridge")).default;
     default:
       return {};
   }

--- a/libs/ledger-live-common/src/coin-modules/loaders.ts
+++ b/libs/ledger-live-common/src/coin-modules/loaders.ts
@@ -3,139 +3,133 @@ import type { CoinModuleLoader, FamilySetup, ValidateAddressFn } from "./types";
 export const coinModuleLoaders: CoinModuleLoader[] = [
   {
     family: "aleo",
-    loadSetup: () => import("../families/aleo/setup.js"),
+    loadSetup: () => import("../families/aleo/setup"),
     loadTransaction: () => import("@ledgerhq/coin-aleo/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-aleo/deviceTransactionConfig").then(m => m.default),
   },
   {
     family: "algorand",
-    loadSetup: () => import("../families/algorand/setup.js"),
+    loadSetup: () => import("../families/algorand/setup"),
     loadTransaction: () => import("@ledgerhq/coin-algorand/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-algorand/deviceTransactionConfig").then(m => m.default),
-    loadMockBridge: () => import("../families/algorand/bridge/mock.js").then(m => m.default),
+    loadMockBridge: () => import("../families/algorand/bridge/mock").then(m => m.default),
     loadMockAccount: () => import("@ledgerhq/coin-algorand/mock").then(m => m.default),
   },
   {
     family: "aptos",
-    loadSetup: () => import("../families/aptos/setup.js"),
+    loadSetup: () => import("../families/aptos/setup"),
     loadTransaction: () => import("@ledgerhq/coin-aptos/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-aptos/deviceTransactionConfig").then(m => m.default),
   },
   {
     family: "bitcoin",
-    loadSetup: () => import("../families/bitcoin/setup.js"),
+    loadSetup: () => import("../families/bitcoin/setup"),
     loadTransaction: () => import("@ledgerhq/coin-bitcoin/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-bitcoin/deviceTransactionConfig").then(m => m.default),
-    loadWalletApiAdapter: () =>
-      import("../families/bitcoin/walletApiAdapter.js").then(m => m.default),
-    loadPlatformAdapter: () =>
-      import("../families/bitcoin/platformAdapter.js").then(m => m.default),
+    loadWalletApiAdapter: () => import("../families/bitcoin/walletApiAdapter").then(m => m.default),
+    loadPlatformAdapter: () => import("../families/bitcoin/platformAdapter").then(m => m.default),
     loadAccount: () => import("@ledgerhq/coin-bitcoin/account").then(m => m.default),
-    loadMockBridge: () => import("../families/bitcoin/bridge/mock.js").then(m => m.default),
-    loadBridgeExtensions: () =>
-      import("../families/bitcoin/bridgeExtensions.js").then(m => m.default),
+    loadMockBridge: () => import("../families/bitcoin/bridge/mock").then(m => m.default),
+    loadBridgeExtensions: () => import("../families/bitcoin/bridgeExtensions").then(m => m.default),
   },
   {
     family: "canton",
-    loadSetup: () => import("../families/canton/setup.js"),
+    loadSetup: () => import("../families/canton/setup"),
     loadTransaction: () => import("@ledgerhq/coin-canton/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-canton/deviceTransactionConfig").then(m => m.default),
-    loadMockBridge: () => import("../families/canton/bridge/mock.js").then(m => m.default),
-    loadBridgeExtensions: () =>
-      import("../families/canton/bridgeExtensions.js").then(m => m.default),
+    loadMockBridge: () => import("../families/canton/bridge/mock").then(m => m.default),
+    loadBridgeExtensions: () => import("../families/canton/bridgeExtensions").then(m => m.default),
   },
   {
     family: "cardano",
-    loadSetup: () => import("../families/cardano/setup.js"),
+    loadSetup: () => import("../families/cardano/setup"),
     loadTransaction: () => import("@ledgerhq/coin-cardano/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-cardano/deviceTransactionConfig").then(m => m.default),
     loadAccount: () => import("@ledgerhq/coin-cardano/account").then(m => m.default),
-    loadMockBridge: () => import("../families/cardano/bridge/mock.js").then(m => m.default),
+    loadMockBridge: () => import("../families/cardano/bridge/mock").then(m => m.default),
   },
   {
     family: "casper",
-    loadSetup: () => import("../families/casper/setup.js"),
+    loadSetup: () => import("../families/casper/setup"),
     loadTransaction: () => import("@ledgerhq/coin-casper/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-casper/deviceTransactionConfig").then(m => m.default),
-    loadMockBridge: () => import("../families/casper/bridge/mock.js").then(m => m.default),
+    loadMockBridge: () => import("../families/casper/bridge/mock").then(m => m.default),
   },
   {
     family: "celo",
-    loadSetup: () => import("../families/celo/setup.js"),
+    loadSetup: () => import("../families/celo/setup"),
     loadTransaction: () => import("@ledgerhq/coin-celo/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-celo/deviceTransactionConfig").then(m => m.default),
   },
   {
     family: "concordium",
-    loadSetup: () => import("../families/concordium/setup.js"),
+    loadSetup: () => import("../families/concordium/setup"),
     loadTransaction: () => import("@ledgerhq/coin-concordium/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-concordium/deviceTransactionConfig").then(m => m.default),
   },
   {
     family: "cosmos",
-    loadSetup: () => import("../families/cosmos/setup.js"),
+    loadSetup: () => import("../families/cosmos/setup"),
     loadTransaction: () => import("@ledgerhq/coin-cosmos/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-cosmos/deviceTransactionConfig").then(m => m.default),
-    loadWalletApiAdapter: () =>
-      import("../families/cosmos/walletApiAdapter.js").then(m => m.default),
-    loadMockBridge: () => import("../families/cosmos/bridge/mock.js").then(m => m.default),
+    loadWalletApiAdapter: () => import("../families/cosmos/walletApiAdapter").then(m => m.default),
+    loadMockBridge: () => import("../families/cosmos/bridge/mock").then(m => m.default),
     loadMockAccount: () => import("@ledgerhq/coin-cosmos/mock").then(m => m.default),
-    loadBridgeExtensions: () =>
-      import("../families/cosmos/bridgeExtensions.js").then(m => m.default),
+    loadBridgeExtensions: () => import("../families/cosmos/bridgeExtensions").then(m => m.default),
   },
   {
     family: "evm",
-    loadSetup: () => import("../families/evm/setup.js"),
+    loadSetup: () => import("../families/evm/setup"),
     loadTransaction: () => import("@ledgerhq/coin-evm/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-evm/deviceTransactionConfig").then(m => m.default),
-    loadWalletApiAdapter: () => import("../families/evm/walletApiAdapter.js").then(m => m.default),
-    loadPlatformAdapter: () => import("../families/evm/platformAdapter.js").then(m => m.default),
-    loadMockBridge: () => import("../families/evm/bridge/mock.js").then(m => m.default),
+    loadWalletApiAdapter: () => import("../families/evm/walletApiAdapter").then(m => m.default),
+    loadPlatformAdapter: () => import("../families/evm/platformAdapter").then(m => m.default),
+    loadMockBridge: () => import("../families/evm/bridge/mock").then(m => m.default),
     loadValidateAddress: () =>
       import("@ledgerhq/coin-evm/logic/validateAddress").then(
         ({ validateAddress }): ValidateAddressFn => validateAddress,
       ),
     loadSigner: () =>
-      import("../bridge/generic-coin-framework/families/evm/signer.js").then(m => m.default),
-    loadBridgeExtensions: () => import("../families/evm/bridgeExtensions.js").then(m => m.default),
+      import("../bridge/generic-coin-framework/families/evm/signer").then(m => m.default),
+    loadBridgeExtensions: () => import("../families/evm/bridgeExtensions").then(m => m.default),
   },
   {
     family: "filecoin",
-    loadSetup: () => import("../families/filecoin/setup.js"),
+    loadSetup: () => import("../families/filecoin/setup"),
     loadTransaction: () => import("@ledgerhq/coin-filecoin/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-filecoin/deviceTransactionConfig").then(m => m.default),
   },
   {
     family: "hedera",
-    loadSetup: () => import("../families/hedera/setup.js"),
+    loadSetup: () => import("../families/hedera/setup"),
     loadTransaction: () => import("@ledgerhq/coin-hedera/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-hedera/deviceTransactionConfig").then(m => m.default),
   },
   {
     family: "icon",
-    loadSetup: () => import("../families/icon/setup.js"),
+    loadSetup: () => import("../families/icon/setup"),
     loadTransaction: () => import("@ledgerhq/coin-icon/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-icon/deviceTransactionConfig").then(m => m.default),
     loadAccount: () => import("@ledgerhq/coin-icon/account").then(m => m.default),
-    loadMockBridge: () => import("../families/icon/bridge/mock.js").then(m => m.default),
+    loadMockBridge: () => import("../families/icon/bridge/mock").then(m => m.default),
   },
   {
     family: "internet_computer",
-    loadSetup: () => import("../families/internet_computer/setup.js"),
+    loadSetup: () => import("../families/internet_computer/setup"),
     loadTransaction: () =>
       import("@ledgerhq/coin-internet_computer/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
@@ -143,29 +137,29 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
   },
   {
     family: "kaspa",
-    loadSetup: () => import("../families/kaspa/setup.js"),
+    loadSetup: () => import("../families/kaspa/setup"),
     loadTransaction: () => import("@ledgerhq/coin-kaspa/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-kaspa/deviceTransactionConfig").then(m => m.default),
   },
   {
     family: "mina",
-    loadSetup: () => import("../families/mina/setup.js"),
+    loadSetup: () => import("../families/mina/setup"),
     loadTransaction: () => import("@ledgerhq/coin-mina/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-mina/deviceTransactionConfig").then(m => m.default),
   },
   {
     family: "multiversx",
-    loadSetup: () => import("../families/multiversx/setup.js"),
+    loadSetup: () => import("../families/multiversx/setup"),
     loadTransaction: () => import("@ledgerhq/coin-multiversx/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-multiversx/deviceTransactionConfig").then(m => m.default),
-    loadMockBridge: () => import("../families/multiversx/bridge/mock.js").then(m => m.default),
+    loadMockBridge: () => import("../families/multiversx/bridge/mock").then(m => m.default),
   },
   {
     family: "near",
-    loadSetup: () => import("../families/near/setup.js"),
+    loadSetup: () => import("../families/near/setup"),
     loadTransaction: () => import("@ledgerhq/coin-near/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-near/deviceTransactionConfig").then(m => m.default),
@@ -173,115 +167,111 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
   },
   {
     family: "polkadot",
-    loadSetup: () => import("../families/polkadot/setup.js"),
+    loadSetup: () => import("../families/polkadot/setup"),
     loadTransaction: () => import("@ledgerhq/coin-polkadot/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-polkadot/deviceTransactionConfig").then(m => m.default),
     loadWalletApiAdapter: () =>
-      import("../families/polkadot/walletApiAdapter.js").then(m => m.default),
-    loadPlatformAdapter: () =>
-      import("../families/polkadot/platformAdapter.js").then(m => m.default),
-    loadMockBridge: () => import("../families/polkadot/bridge/mock.js").then(m => m.default),
+      import("../families/polkadot/walletApiAdapter").then(m => m.default),
+    loadPlatformAdapter: () => import("../families/polkadot/platformAdapter").then(m => m.default),
+    loadMockBridge: () => import("../families/polkadot/bridge/mock").then(m => m.default),
   },
   {
     family: "solana",
-    loadSetup: () => import("../families/solana/setup.js"),
+    loadSetup: () => import("../families/solana/setup"),
     loadTransaction: () => import("@ledgerhq/coin-solana/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-solana/deviceTransactionConfig").then(m => m.default),
-    loadWalletApiAdapter: () =>
-      import("../families/solana/walletApiAdapter.js").then(m => m.default),
-    loadMockBridge: () => import("../families/solana/bridge/mock.js").then(m => m.default),
+    loadWalletApiAdapter: () => import("../families/solana/walletApiAdapter").then(m => m.default),
+    loadMockBridge: () => import("../families/solana/bridge/mock").then(m => m.default),
     loadValidateAddress: () =>
       import("@ledgerhq/coin-solana/logic/validateAddress").then(
         ({ validateAddress }): ValidateAddressFn => validateAddress,
       ),
     loadSigner: () =>
-      import("../bridge/generic-coin-framework/families/solana/signer.js").then(m => m.default),
+      import("../bridge/generic-coin-framework/families/solana/signer").then(m => m.default),
   },
   {
     family: "stacks",
-    loadSetup: () => import("../families/stacks/setup.js"),
+    loadSetup: () => import("../families/stacks/setup"),
     loadTransaction: () => import("@ledgerhq/coin-stacks/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-stacks/deviceTransactionConfig").then(m => m.default),
   },
   {
     family: "stellar",
-    loadSetup: () => import("../families/stellar/setup.js"),
-    loadTransaction: () => import("../families/stellar/transaction.js").then(m => m.default),
+    loadSetup: () => import("../families/stellar/setup"),
+    loadTransaction: () => import("../families/stellar/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
-      import("../families/stellar/deviceTransactionConfig.js").then(m => m.default),
-    loadMockBridge: () => import("../families/stellar/bridge/mock.js").then(m => m.default),
+      import("../families/stellar/deviceTransactionConfig").then(m => m.default),
+    loadMockBridge: () => import("../families/stellar/bridge/mock").then(m => m.default),
     loadValidateAddress: () =>
       import("@ledgerhq/coin-stellar/logic/validateAddress").then(
         ({ validateAddress }): ValidateAddressFn => validateAddress,
       ),
     loadSigner: () =>
-      import("../bridge/generic-coin-framework/families/stellar/signer.js").then(m => m.default),
+      import("../bridge/generic-coin-framework/families/stellar/signer").then(m => m.default),
   },
   {
     family: "sui",
-    loadSetup: () => import("../families/sui/setup.js"),
+    loadSetup: () => import("../families/sui/setup"),
     loadTransaction: () => import("@ledgerhq/coin-sui/transaction").then(m => m.default),
     // No loadDeviceTxConfig: sui has no deviceTransactionConfig
   },
   {
     family: "tezos",
-    loadSetup: () => import("../families/tezos/setup.js"),
+    loadSetup: () => import("../families/tezos/setup"),
     loadTransaction: () => import("@ledgerhq/coin-tezos/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-tezos/deviceTransactionConfig").then(m => m.default),
-    loadMockBridge: () => import("../families/tezos/bridge/mock.js").then(m => m.default),
+    loadMockBridge: () => import("../families/tezos/bridge/mock").then(m => m.default),
     loadValidateAddress: () =>
       import("@ledgerhq/coin-tezos/logic/validateAddress").then(
         ({ validateAddress }): ValidateAddressFn => validateAddress,
       ),
     loadSigner: () =>
-      import("../bridge/generic-coin-framework/families/tezos/signer.js").then(m => m.default),
-    loadBridgeExtensions: () =>
-      import("../families/tezos/bridgeExtensions.js").then(m => m.default),
+      import("../bridge/generic-coin-framework/families/tezos/signer").then(m => m.default),
+    loadBridgeExtensions: () => import("../families/tezos/bridgeExtensions").then(m => m.default),
   },
   {
     family: "ton",
-    loadSetup: () => import("../families/ton/setup.js"),
+    loadSetup: () => import("../families/ton/setup"),
     loadTransaction: () => import("@ledgerhq/coin-ton/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-ton/deviceTransactionConfig").then(m => m.default),
   },
   {
     family: "tron",
-    loadSetup: () => import("../families/tron/setup.js"),
+    loadSetup: () => import("../families/tron/setup"),
     loadTransaction: () => import("@ledgerhq/coin-tron/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-tron/deviceTransactionConfig").then(m => m.default),
-    loadMockBridge: () => import("../families/tron/bridge/mock.js").then(m => m.default),
-    loadBridgeExtensions: () => import("../families/tron/bridgeExtensions.js").then(m => m.default),
+    loadMockBridge: () => import("../families/tron/bridge/mock").then(m => m.default),
+    loadBridgeExtensions: () => import("../families/tron/bridgeExtensions").then(m => m.default),
   },
   {
     family: "vechain",
-    loadSetup: () => import("../families/vechain/setup.js") as object as Promise<FamilySetup>,
+    loadSetup: () => import("../families/vechain/setup") as object as Promise<FamilySetup>,
     loadTransaction: () => import("@ledgerhq/coin-vechain/transaction").then(m => m.default),
     // No loadDeviceTxConfig: vechain has no deviceTransactionConfig
     loadAccount: () => import("@ledgerhq/coin-vechain/account").then(m => m.default),
     loadMockAccount: () => import("@ledgerhq/coin-vechain/mock").then(m => m.default),
-    loadBridgeExtensions: () =>
-      import("../families/vechain/bridgeExtensions.js").then(m => m.default),
+    loadBridgeExtensions: () => import("../families/vechain/bridgeExtensions").then(m => m.default),
   },
   {
     family: "xrp",
-    loadSetup: () => import("../families/xrp/setup.js"),
-    loadTransaction: () => import("../families/xrp/transaction.js").then(m => m.default),
+    loadSetup: () => import("../families/xrp/setup"),
+    loadTransaction: () => import("../families/xrp/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
-      import("../families/xrp/deviceTransactionConfig.js").then(m => m.default),
-    loadWalletApiAdapter: () => import("../families/xrp/walletApiAdapter.js").then(m => m.default),
-    loadPlatformAdapter: () => import("../families/xrp/platformAdapter.js").then(m => m.default),
-    loadMockBridge: () => import("../families/xrp/bridge/mock.js").then(m => m.default),
+      import("../families/xrp/deviceTransactionConfig").then(m => m.default),
+    loadWalletApiAdapter: () => import("../families/xrp/walletApiAdapter").then(m => m.default),
+    loadPlatformAdapter: () => import("../families/xrp/platformAdapter").then(m => m.default),
+    loadMockBridge: () => import("../families/xrp/bridge/mock").then(m => m.default),
     loadValidateAddress: () =>
       import("@ledgerhq/coin-xrp/api/validateAddress").then(
         ({ validateAddress }): ValidateAddressFn => validateAddress,
       ),
     loadSigner: () =>
-      import("../bridge/generic-coin-framework/families/xrp/signer.js").then(m => m.default),
+      import("../bridge/generic-coin-framework/families/xrp/signer").then(m => m.default),
   },
 ];


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** 
- [x] **Impact of the changes:** : only build/runtime load impact. no functional ones.

### 📝 Description

Study LIVE-29251: drop the ".js" extension from relative dynamic import() specifiers so we follow the standard bundler-style imports.

live-common already builds with moduleResolution "bundler", so the extensions were not needed for its own type-check/build. They existed only to satisfy NodeNext consumers that read live-common **source** (via the @ledgerhq/source condition) — under NodeNext, extensionless relative imports raise TS2835.

Changes:
- Removed the ".js" extension from the relative dynamic import() in the coin module loaders and the generic coin framework bridge/api (3 files).
- Switched the only remaining NodeNext source-readers to moduleResolution "bundler": coin-modules-monitoring and coin-tester-evm/tezos/solana. For the coin-testers, the tsconfig.build.json CommonJS pass is pinned back to NodeNext so the emitted lib output is byte-identical.

desktop, mobile, wallet-cli, web-tools and live-dmk already use "bundler"; apps/cli is standalone and reads the built lib-es, so none of them are affected.

No runtime impact: the dynamic imports live in function bodies (they do not appear in the emitted .d.ts), and live-common's lib-es is only ever consumed by bundlers, never run as raw Node ESM.

**For consumers, after merge:** new relative dynamic imports in live-common no longer need the extension:

```diff
- loadSetup: () => import("../families/aleo/setup.js"),
+ loadSetup: () => import("../families/aleo/setup"),
```

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29251](https://ledgerhq.atlassian.net/browse/LIVE-29251)
- **ADR link (if any)**: N/A


[LIVE-29251]: https://ledgerhq.atlassian.net/browse/LIVE-29251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ