### PR TITLE
[LWM] ci: run jest unit tests on 16-CPU runner

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -50,20 +50,27 @@ jobs:
   # LLD
   build-desktop:
     name: "Build Desktop"
-    needs: determine-affected
+    needs: [determine-affected]
     if: ${{contains(needs.determine-affected.outputs.paths, 'ledger-live-desktop') && !github.event.pull_request.head.repo.fork}}
     uses: LedgerHQ/ledger-live/.github/workflows/build-desktop-reusable.yml@develop
     secrets: inherit
 
   test-desktop:
-    name: "Test Desktop"
+    name: "Desktop E2E & Mock Tests"
     needs: determine-affected
     if: ${{contains(needs.determine-affected.outputs.paths, 'ledger-live-desktop') && !github.event.pull_request.head.repo.fork}}
     uses: LedgerHQ/ledger-live/.github/workflows/test-desktop-reusable.yml@develop
     secrets: inherit
 
+  codecheck-desktop:
+    name: "Desktop Lint & Unit Tests"
+    needs: determine-affected
+    if: ${{contains(needs.determine-affected.outputs.paths, 'ledger-live-desktop') && !github.event.pull_request.head.repo.fork}}
+    uses: LedgerHQ/ledger-live/.github/workflows/test-desktop-codechecks-reusable.yml@develop
+    secrets: inherit
+
   test-mobile:
-    name: "Test Mobile"
+    name: "Codecheck Mobile"
     needs: determine-affected
     if: ${{contains(needs.determine-affected.outputs.paths, 'ledger-live-mobile') && !github.event.pull_request.head.repo.fork}}
     uses: LedgerHQ/ledger-live/.github/workflows/test-mobile-reusable.yml@develop
@@ -186,7 +193,7 @@ jobs:
   scan-sonar:
     name: "Sonar Cloud"
     needs:
-      - test-desktop
+      - codecheck-desktop
       - test-mobile
       - test-libraries
       - test-features
@@ -196,10 +203,10 @@ jobs:
       - build-wallet-cli
       - determine-affected
     uses: LedgerHQ/ledger-live/.github/workflows/scan-sonar-reusable.yml@develop
-    if: ${{ always() && !cancelled() && !github.event.pull_request.head.repo.fork && (needs.test-desktop.result == 'success' || needs.test-mobile.result == 'success' || needs.test-libraries.result == 'success' || needs.test-features.result == 'success' || needs.test-shared.result == 'success' || needs.test-domain.result == 'success' || needs.test-devtools.result == 'success' || needs.build-wallet-cli.result == 'success' || contains(needs.determine-affected.outputs.paths, 'e2e')) }}
+    if: ${{ always() && !cancelled() && !github.event.pull_request.head.repo.fork && (needs.codecheck-desktop.result == 'success' || needs.test-mobile.result == 'success' || needs.test-libraries.result == 'success' || needs.test-features.result == 'success' || needs.test-shared.result == 'success' || needs.test-domain.result == 'success' || needs.test-devtools.result == 'success' || needs.build-wallet-cli.result == 'success' || contains(needs.determine-affected.outputs.paths, 'e2e')) }}
     secrets: inherit
     with:
-      should_download_desktop_coverage: ${{ needs.test-desktop.outputs.coverage_generated }}
+      should_download_desktop_coverage: ${{ needs.codecheck-desktop.outputs.coverage_generated }}
       should_download_mobile_coverage: ${{ needs.test-mobile.outputs.coverage_generated }}
       should_download_libs_coverage: ${{ needs.test-libraries.outputs.coverage_generated }}
       should_download_features_coverage: ${{ needs.test-features.outputs.coverage_generated }}
@@ -214,6 +221,7 @@ jobs:
     needs:
       - build-desktop
       - test-desktop
+      - codecheck-desktop
       - test-mobile
       - build-test-mobile
       - test-libraries

--- a/.github/workflows/build-and-test-push.yml
+++ b/.github/workflows/build-and-test-push.yml
@@ -20,8 +20,13 @@ jobs:
     secrets: inherit
 
   test-desktop:
-    name: "Test Desktop"
+    name: "Desktop E2E & Mock Tests"
     uses: LedgerHQ/ledger-live/.github/workflows/test-desktop-reusable.yml@develop
+    secrets: inherit
+
+  codecheck-desktop:
+    name: "Desktop Lint & Unit Tests"
+    uses: LedgerHQ/ledger-live/.github/workflows/test-desktop-codechecks-reusable.yml@develop
     secrets: inherit
 
   test-mobile:
@@ -78,6 +83,7 @@ jobs:
     needs:
       - build-desktop
       - test-desktop
+      - codecheck-desktop
       - test-mobile
       - build-test-mobile
       - test-libraries

--- a/.github/workflows/scan-sonar-reusable.yml
+++ b/.github/workflows/scan-sonar-reusable.yml
@@ -55,19 +55,6 @@ jobs:
         run: |
           git fetch origin develop
 
-      - name: Setup the caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
-        id: setup-caches
-        with:
-          use-mise: true
-          gh-token: ${{ secrets.GITHUB_TOKEN }}
-          cache-develop-role-arn: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
-          cache-branch-role-arn: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_BRANCH }}
-          nx-key: ${{ secrets.NX_KEY }}
-          accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
-          roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
-          region: ${{ secrets.AWS_CACHE_REGION }}
-
       - name: Download desktop unit test coverage
         if: ${{ inputs.should_download_desktop_coverage == 'true' }}
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0

--- a/.github/workflows/test-desktop-codechecks-reusable.yml
+++ b/.github/workflows/test-desktop-codechecks-reusable.yml
@@ -1,0 +1,230 @@
+name: "[Desktop] - Lint & Unit Tests - Called"
+
+on:
+  workflow_call:
+    outputs:
+      coverage_generated:
+        value: ${{ jobs.unit-tests.outputs.coverage_generated }}
+
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: |
+          If you run this manually, and want to run on a PR, the correct ref should be refs/pull/{PR_NUMBER}/merge to
+          have the "normal" scenario involving checking out a merge commit between your branch and the base branch.
+          If you want to run only on a branch or specific commit, you can use either the sha or the branch name instead (prefer the first version for PRs).
+        type: string
+        required: false
+      login:
+        description: The GitHub username that triggered the workflow
+        type: string
+        required: false
+      base_ref:
+        description: The base branch to merge the head into when checking out the code
+        type: string
+        required: false
+      prNumber:
+        description: PR number
+        type: string
+        required: false
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  SMOKE_SPECULOS_IMAGE_TAG: ghcr.io/ledgerhq/speculos:v0.26.5
+  SMOKE_SPECULOS_FIRMWARE_VERSION: 1.6.0
+
+jobs:
+  codechecks:
+    name: "Desktop Code Check"
+    env:
+      NODE_OPTIONS: "--max-old-space-size=7168"
+      FORCE_COLOR: 3
+      CI_OS: ubuntu-22.04
+    runs-on: ubuntu-22.04
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+      - name: Setup the caches
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        id: setup-caches
+        with:
+          use-mise: true
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          cache-develop-role-arn: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
+          cache-branch-role-arn: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_BRANCH }}
+          nx-key: ${{ secrets.NX_KEY }}
+          accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
+          roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
+          region: ${{ secrets.AWS_CACHE_REGION }}
+
+      - uses: LedgerHQ/ledger-live/tools/actions/composites/setup-test-desktop@develop
+        id: setup-test-desktop
+        with:
+          skip_builds: true
+
+      - name: format check
+        # TODO(LIVE-31553): remove continue-on-error once format:check exists on
+        # release HEAD (~2 weeks); kept non-blocking to not break release flows.
+        continue-on-error: true
+        run: pnpm desktop format:check
+
+      - name: lint
+        run: pnpm desktop lint:ci
+
+      - name: lint (guardrails)
+        run: pnpm desktop lint:guardrails
+
+      - name: typecheck
+        run: pnpm desktop typecheck
+
+      - name: check for dead code
+        run: pnpm desktop knip-check
+
+  unit-tests:
+    name: "Desktop Unit Tests"
+    timeout-minutes: 10
+    env:
+      NODE_OPTIONS: "--max-old-space-size=7168 --no-network-family-autoselection"
+      FORCE_COLOR: 3
+      CI_OS: ledger-live-linux-16CPU-64RAM
+      JEST_MAX_WORKERS: "95%"
+    runs-on: [ledger-live-linux-16CPU-64RAM]
+    outputs:
+      coverage_generated: ${{ contains(steps.generate_coverage.outcome, 'success') }}
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Setup the caches
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        id: setup-caches
+        with:
+          use-mise: true
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          cache-develop-role-arn: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
+          cache-branch-role-arn: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_BRANCH }}
+          nx-key: ${{ secrets.NX_KEY }}
+          accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
+          roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
+          region: ${{ secrets.AWS_CACHE_REGION }}
+
+      - name: Install dependencies
+        run: pnpm i --filter="ledger-live-desktop..." --filter="ledger-live"
+
+      - name: Build dependencies
+        run: pnpm exec nx run ledger-live-desktop:build-lib-deps
+
+      - name: Run unit tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          CPUS="$(nproc 2>/dev/null || echo "?")"
+          echo "::group::Jest CI metrics (desktop coverage)"
+          echo "runner_os=${CI_OS:-unknown} cpu_count=${CPUS} JEST_MAX_WORKERS=${JEST_MAX_WORKERS:-}"
+          node -e '
+            const os = require("os");
+            const n = os.cpus().length;
+            const w = process.env.JEST_MAX_WORKERS || "50%";
+            let m;
+            if (String(w).endsWith("%")) {
+              m = Math.max(1, Math.floor((n * parseFloat(String(w))) / 100));
+            } else if (/^\d+$/.test(String(w))) {
+              m = Math.max(1, parseInt(w, 10));
+            } else {
+              m = w;
+            }
+            console.log("effective_max_workers_estimate=" + m);
+          '
+          echo "::endgroup::"
+          START_TS=$(date +%s)
+          pnpm desktop test:jest:coverage
+          END_TS=$(date +%s)
+          echo "::notice::jest_ci_metrics app=ledger-live-desktop jest_wall_seconds=$((END_TS - START_TS)) cpu_count=${CPUS} JEST_MAX_WORKERS=${JEST_MAX_WORKERS:-}"
+
+      - name: Upload unit test coverage
+        id: generate_coverage
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: coverage-desktop
+          path: ${{ github.workspace }}/apps/ledger-live-desktop/coverage
+
+  report:
+    name: "Desktop Lint & Unit Tests > Report"
+    needs: [codechecks, unit-tests]
+    runs-on: ubuntu-22.04
+    # Only report on push events (e.g. develop, main, release, hotfix).
+    if: ${{ !cancelled() && github.event_name == 'push' }}
+    steps:
+      - uses: actions/github-script@v7
+        name: prepare status
+        id: status
+        with:
+          script: |
+            const fs = require("fs");
+
+            const typecheck = {
+              pass: ${{ needs.codechecks.result == 'success' }},
+              status: "${{ needs.codechecks.result }}",
+            };
+
+            const unitTests = {
+              pass: ${{ needs.unit-tests.result == 'success' }},
+              status: "${{ needs.unit-tests.result }}",
+            };
+
+            const slackPayload = {
+              "text": "[Alert] Ledger Live Desktop lint & unit tests failed on ${{ github.ref_name }}",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":warning: [Alert] Ledger Live Desktop lint & unit tests failed on ${{ github.ref_name }}",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": `Code Checks: ${typecheck.pass ? "✅" : "❌"} (${typecheck.status})\n`
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": `Unit Tests: ${unitTests.pass ? "✅" : "❌"} (${unitTests.status})\n`
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Commit by ${{ github.event.head_commit.author.username || '' }}\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            };
+
+            fs.writeFileSync("payload-slack-content.json", JSON.stringify(slackPayload), "utf-8");
+
+      - name: post to a Slack channel
+        id: slack
+        uses: slackapi/slack-github-action@v1.23.0
+        if: ${{ !cancelled() && github.event_name == 'push' && contains(join(needs.*.result, ','), 'failure') }}
+        with:
+          channel-id: "C05FKJ7DFAP"
+          payload-file-path: ${{ github.workspace }}/payload-slack-content.json
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_LIVE_CI_BOT_TOKEN }}

--- a/.github/workflows/test-desktop-reusable.yml
+++ b/.github/workflows/test-desktop-reusable.yml
@@ -1,10 +1,7 @@
-name: "[Desktop] - Test - Called"
+name: "[Desktop] - E2E & Mock Tests - Called"
 
 on:
   workflow_call:
-    outputs:
-      coverage_generated:
-        value: ${{ jobs.unit-tests.outputs.coverage_generated }}
 
   workflow_dispatch:
     inputs:
@@ -37,124 +34,6 @@ env:
   SMOKE_SPECULOS_FIRMWARE_VERSION: 1.6.0
 
 jobs:
-  codechecks:
-    name: "Desktop Code Check"
-    env:
-      NODE_OPTIONS: "--max-old-space-size=7168"
-      FORCE_COLOR: 3
-      CI_OS: ubuntu-22.04
-    runs-on: ubuntu-22.04
-    timeout-minutes: 40
-    steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        with:
-          ref: ${{ inputs.ref || github.sha }}
-      - name: Setup the caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
-        id: setup-caches
-        with:
-          use-mise: true
-          gh-token: ${{ secrets.GITHUB_TOKEN }}
-          cache-develop-role-arn: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
-          cache-branch-role-arn: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_BRANCH }}
-          nx-key: ${{ secrets.NX_KEY }}
-          accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
-          roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
-          region: ${{ secrets.AWS_CACHE_REGION }}
-
-      - uses: LedgerHQ/ledger-live/tools/actions/composites/setup-test-desktop@develop
-        id: setup-test-desktop
-        with:
-          skip_builds: true
-
-      - name: format check
-        # TODO(LIVE-31553): remove continue-on-error once format:check exists on
-        # release HEAD (~2 weeks); kept non-blocking to not break release flows.
-        continue-on-error: true
-        run: pnpm desktop format:check
-
-      - name: lint
-        run: pnpm desktop lint:ci
-
-      - name: lint (guardrails)
-        run: pnpm desktop lint:guardrails
-
-      - name: typecheck
-        run: pnpm desktop typecheck
-
-      - name: check for dead code
-        run: pnpm desktop knip-check
-
-  unit-tests:
-    name: "Desktop Unit Tests"
-    timeout-minutes: 40
-    env:
-      NODE_OPTIONS: "--max-old-space-size=7168 --no-network-family-autoselection"
-      FORCE_COLOR: 3
-      CI_OS: ledger-live-linux-16CPU-64RAM
-      JEST_MAX_WORKERS: "75%"
-    runs-on: [ledger-live-linux-16CPU-64RAM]
-    outputs:
-      coverage_generated: ${{ contains(steps.generate_coverage.outcome, 'success') }}
-    steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        with:
-          ref: ${{ inputs.ref || github.sha }}
-
-      - name: Setup the caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
-        id: setup-caches
-        with:
-          use-mise: true
-          gh-token: ${{ secrets.GITHUB_TOKEN }}
-          cache-develop-role-arn: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
-          cache-branch-role-arn: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_BRANCH }}
-          nx-key: ${{ secrets.NX_KEY }}
-          accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
-          roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
-          region: ${{ secrets.AWS_CACHE_REGION }}
-
-      - name: Install dependencies
-        run: pnpm i --filter="ledger-live-desktop..." --filter="ledger-live"
-
-      - name: Build dependencies
-        run: pnpm exec nx run ledger-live-desktop:build-lib-deps
-
-      - name: Run unit tests
-        shell: bash
-        run: |
-          set -euo pipefail
-          CPUS="$(nproc 2>/dev/null || echo "?")"
-          echo "::group::Jest CI metrics (desktop coverage)"
-          echo "runner_os=${CI_OS:-unknown} cpu_count=${CPUS} JEST_MAX_WORKERS=${JEST_MAX_WORKERS:-}"
-          node -e '
-            const os = require("os");
-            const n = os.cpus().length;
-            const w = process.env.JEST_MAX_WORKERS || "50%";
-            let m;
-            if (String(w).endsWith("%")) {
-              m = Math.max(1, Math.floor((n * parseFloat(String(w))) / 100));
-            } else if (/^\d+$/.test(String(w))) {
-              m = Math.max(1, parseInt(w, 10));
-            } else {
-              m = w;
-            }
-            console.log("effective_max_workers_estimate=" + m);
-          '
-          echo "::endgroup::"
-          START_TS=$(date +%s)
-          pnpm desktop test:jest:coverage
-          END_TS=$(date +%s)
-          echo "::notice::jest_ci_metrics app=ledger-live-desktop jest_wall_seconds=$((END_TS - START_TS)) cpu_count=${CPUS} JEST_MAX_WORKERS=${JEST_MAX_WORKERS:-}"
-
-      - name: Upload unit test coverage
-        id: generate_coverage
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        with:
-          name: coverage-desktop
-          path: ${{ github.workspace }}/apps/ledger-live-desktop/coverage
-
   speculos-e2e-tests-linux:
     name: "UI e2e smoke tests NanoSP"
     outputs:
@@ -337,19 +216,22 @@ jobs:
             apps/ledger-live-desktop/tests/artifacts/*.log
 
   report:
-    name: "Test Desktop > Report"
-    needs: [codechecks, unit-tests, e2e-tests-linux, speculos-e2e-tests-linux]
+    name: "Desktop E2E & Mock > Report"
+    needs: [e2e-tests-linux, speculos-e2e-tests-linux]
     runs-on: ubuntu-22.04
     if: ${{ !cancelled() }}
     steps:
+
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           ref: ${{ inputs.ref || github.sha }}
+
       - name: download images artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         continue-on-error: true
         with:
           name: images
+
       - name: parse images
         uses: actions/github-script@v7
         with:
@@ -367,12 +249,14 @@ jobs:
               }
             }
             fs.writeFileSync("./images.json", JSON.stringify(result, null, 2));
+
       - name: prepare comment with screenshots
         id: comment
         uses: LedgerHQ/ledger-live/tools/actions/prepare-comment-screenshots@develop
         with:
           images: images.json
           no-actor: true
+
       - uses: actions/github-script@v7
         name: prepare status
         id: status
@@ -403,16 +287,6 @@ jobs:
               },
             };
 
-            const typecheck = {
-              pass: ${{ needs.codechecks.result == 'success' }},
-              status: "${{ needs.codechecks.result }}",
-            };
-
-            const unitTests = {
-              pass: ${{ needs.unit-tests.result == 'success' }},
-              status: "${{ needs.unit-tests.result }}",
-            };
-
             const speculosAllureUrl = "${{ needs.speculos-e2e-tests-linux.outputs.allure_url }}";
 
             const report = {
@@ -426,17 +300,7 @@ jobs:
               },
             };
 
-
-            let summary = `### TypeCheck
-
-            ${typecheck.pass ? "Typechecks are fine" : "Unfortunately typechecks did not pass"}
-              - ${typecheck.pass ? "✅" : "❌"} **Type checks** ended with status \`${typecheck.status}\`
-
-            ### Unit Tests (Jest)
-            ${unitTests.pass ? "Unit tests are fine" : "Unit tests did not pass"}
-              - ${unitTests.pass ? "✅" : "❌"} **Unit tests** ended with status \`${unitTests.status}\`
-
-            ### Screenshot Tests (Playwright)
+            let summary = `### Screenshot Tests (Playwright)
             `
 
             summary += `|`
@@ -503,20 +367,6 @@ jobs:
                     "emoji": true
                   }
                 },
-              {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": `Code Checks: ${typecheck.pass ? "✅" : "❌"}\n`
-                  }
-                },
-              {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": `Unit Tests: ${unitTests.pass ? "✅" : "❌"}\n`
-                  }
-                },
                 {
                   "type": "section",
                   "text": {
@@ -545,6 +395,7 @@ jobs:
             };
 
             fs.writeFileSync("payload-slack-content.json", JSON.stringify(slackPayload), "utf-8");
+
       - name: post to a Slack channel
         id: slack
         uses: slackapi/slack-github-action@v1.23.0
@@ -554,6 +405,7 @@ jobs:
           payload-file-path: ${{ github.workspace }}/payload-slack-content.json
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_LIVE_CI_BOT_TOKEN }}
+
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         name: upload summary
         with:

--- a/.github/workflows/test-desktop-reusable.yml
+++ b/.github/workflows/test-desktop-reusable.yml
@@ -91,9 +91,9 @@ jobs:
     env:
       NODE_OPTIONS: "--max-old-space-size=7168 --no-network-family-autoselection"
       FORCE_COLOR: 3
-      CI_OS: ubuntu-22.04
+      CI_OS: ledger-live-linux-16CPU-64RAM
       JEST_MAX_WORKERS: "75%"
-    runs-on: ubuntu-22.04
+    runs-on: [ledger-live-linux-16CPU-64RAM]
     outputs:
       coverage_generated: ${{ contains(steps.generate_coverage.outcome, 'success') }}
     steps:

--- a/.github/workflows/test-libs-reusable.yml
+++ b/.github/workflows/test-libs-reusable.yml
@@ -63,7 +63,7 @@ jobs:
           touch ${{ github.workspace }}/coverage/lcov.info
           touch ${{ github.workspace }}/coverage/sonar-executionTests-report.xml
 
-          pnpm exec nx run-many -t coverage --projects=tag:scope:libs-non-ui --parallel=4 -- --runInBand=1
+          pnpm exec nx run-many -t coverage --projects=tag:scope:libs-non-ui --parallel=6 -- --runInBand=1
 
       - name: Test libraries without coverage script & Process coverage files
         id: test-libs
@@ -101,10 +101,10 @@ jobs:
 
           if [ ${#nx_test_args[@]} -eq 0 ]; then
             echo "Running tests for libs without coverage (all non-ui libs)"
-            pnpm exec nx run-many -t test --projects=tag:scope:libs-non-ui --parallel=4
+            pnpm exec nx run-many -t test --projects=tag:scope:libs-non-ui --parallel=6
           else
-            echo "Running tests for libs without coverage: pnpm exec nx run-many -t test --parallel=4 ${nx_test_args[*]}"
-            pnpm exec nx run-many -t test --parallel=4 "${nx_test_args[@]}"
+            echo "Running tests for libs without coverage: pnpm exec nx run-many -t test --parallel=6 ${nx_test_args[*]}"
+            pnpm exec nx run-many -t test --parallel=6 "${nx_test_args[@]}"
           fi
         shell: bash
 

--- a/.github/workflows/test-mobile-reusable.yml
+++ b/.github/workflows/test-mobile-reusable.yml
@@ -35,9 +35,9 @@ jobs:
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
       FORCE_COLOR: 3
-      CI_OS: ubuntu-22.04
+      CI_OS: ledger-live-linux-16CPU-64RAM
       JEST_MAX_WORKERS: "75%"
-    runs-on: ubuntu-22.04
+    runs-on: [ledger-live-linux-16CPU-64RAM]
     outputs:
       coverage_generated: ${{ contains(steps.generate_coverage.outcome, 'success') }}
     steps:

--- a/.github/workflows/test-mobile-reusable.yml
+++ b/.github/workflows/test-mobile-reusable.yml
@@ -41,6 +41,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           ref: ${{ inputs.ref || github.sha }}
+
       - name: Setup the caches
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
         id: setup-caches
@@ -53,23 +54,30 @@ jobs:
           accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
+
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.3.0
+
       - name: Install dependencies
         run: pnpm i --filter="live-mobile..." --filter="ledger-live" --no-frozen-lockfile --unsafe-perm
+
       - name: Run format check
         # TODO(LIVE-31553): remove continue-on-error once format:check exists on
         # release HEAD (~2 weeks); kept non-blocking to not break release flows.
         continue-on-error: true
         run: pnpm exec nx run live-mobile:format:check
+
       - name: Run linter
         run: pnpm exec nx run live-mobile:lint -- --quiet
+
       - name: Run lint (i18n)
         run: pnpm exec nx run live-mobile:lint:i18n
+
       - name: check for dead code
         run: pnpm mobile knip-check
         shell: bash
+
       - name: Run code checkers
         run: pnpm exec nx run live-mobile:typecheck
 
@@ -79,7 +87,7 @@ jobs:
       NODE_OPTIONS: "--max-old-space-size=7168"
       FORCE_COLOR: 3
       CI_OS: ledger-live-linux-16CPU-64RAM
-      JEST_MAX_WORKERS: "75%"
+      JEST_MAX_WORKERS: "95%"
     runs-on: [ledger-live-linux-16CPU-64RAM]
     outputs:
       coverage_generated: ${{ contains(steps.generate_coverage.outcome, 'success') }}
@@ -87,6 +95,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           ref: ${{ inputs.ref || github.sha }}
+
       - name: Setup the caches
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
         id: setup-caches
@@ -99,10 +108,13 @@ jobs:
           accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
+
       - name: Install dependencies
-        run: pnpm i --filter="live-mobile..." --filter="ledger-live" --no-frozen-lockfile --unsafe-perm
+        run: pnpm i --filter="live-mobile..." --filter="ledger-live" --filter="./libs/**" --no-frozen-lockfile --unsafe-perm
+
       - name: Build dependencies
-        run: pnpm exec nx run live-mobile:build-lib-deps
+        run: pnpm exec nx run-many -t build --projects=tag:scope:libs
+
       - name: Run unit tests
         shell: bash
         run: |
@@ -129,6 +141,7 @@ jobs:
           pnpm mobile test:jest:coverage
           END_TS=$(date +%s)
           echo "::notice::jest_ci_metrics app=live-mobile jest_wall_seconds=$((END_TS - START_TS)) cpu_count=${CPUS} JEST_MAX_WORKERS=${JEST_MAX_WORKERS:-}"
+
       - name: upload coverage
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: ${{ !cancelled() }}

--- a/.github/workflows/test-mobile-reusable.yml
+++ b/.github/workflows/test-mobile-reusable.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     outputs:
       coverage_generated:
-        value: ${{ jobs.codecheck.outputs.coverage_generated }}
+        value: ${{ jobs.unit-tests.outputs.coverage_generated }}
 
   workflow_dispatch:
     inputs:
@@ -35,11 +35,8 @@ jobs:
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
       FORCE_COLOR: 3
-      CI_OS: ledger-live-linux-16CPU-64RAM
-      JEST_MAX_WORKERS: "75%"
-    runs-on: [ledger-live-linux-16CPU-64RAM]
-    outputs:
-      coverage_generated: ${{ contains(steps.generate_coverage.outcome, 'success') }}
+      CI_OS: ubuntu-22.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
@@ -75,6 +72,35 @@ jobs:
         shell: bash
       - name: Run code checkers
         run: pnpm exec nx run live-mobile:typecheck
+
+  unit-tests:
+    name: "Mobile Unit Tests"
+    env:
+      NODE_OPTIONS: "--max-old-space-size=7168"
+      FORCE_COLOR: 3
+      CI_OS: ledger-live-linux-16CPU-64RAM
+      JEST_MAX_WORKERS: "75%"
+    runs-on: [ledger-live-linux-16CPU-64RAM]
+    outputs:
+      coverage_generated: ${{ contains(steps.generate_coverage.outcome, 'success') }}
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+      - name: Setup the caches
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        id: setup-caches
+        with:
+          use-mise: true
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          cache-develop-role-arn: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
+          cache-branch-role-arn: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_BRANCH }}
+          nx-key: ${{ secrets.NX_KEY }}
+          accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
+          roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
+          region: ${{ secrets.AWS_CACHE_REGION }}
+      - name: Install dependencies
+        run: pnpm i --filter="live-mobile..." --filter="ledger-live" --no-frozen-lockfile --unsafe-perm
       - name: Run unit tests
         shell: bash
         run: |

--- a/.github/workflows/test-mobile-reusable.yml
+++ b/.github/workflows/test-mobile-reusable.yml
@@ -101,6 +101,8 @@ jobs:
           region: ${{ secrets.AWS_CACHE_REGION }}
       - name: Install dependencies
         run: pnpm i --filter="live-mobile..." --filter="ledger-live" --no-frozen-lockfile --unsafe-perm
+      - name: Build dependencies
+        run: pnpm exec nx run live-mobile:build-lib-deps
       - name: Run unit tests
         shell: bash
         run: |

--- a/apps/ledger-live-mobile/project.json
+++ b/apps/ledger-live-mobile/project.json
@@ -58,6 +58,12 @@
     "build": {
       "executor": "nx:noop"
     },
+    "build-lib-deps": {
+      "executor": "nx:noop",
+      "dependsOn": [
+        "^build"
+      ]
+    },
     "android:apk": {
       "outputs": [
         "{projectRoot}/android/app/build/generated/**",


### PR DESCRIPTION
## What

**Jest on the 16-CPU runner**
  - Desktop and mobile Jest unit suites now run on `ledger-live-linux-16CPU-64RAM` with higher worker counts.
  - Jest-only jobs build their workspace lib deps explicitly via a dedicated `build-lib-deps` nx target (mirroring desktop), since Jest — unlike the
  nx lint/typecheck steps — doesn't build them implicitly.

  **Mobile codecheck split**
  - `Codecheck Mobile` keeps lint / i18n-lint / knip / typecheck on the free `ubuntu-22.04` runner; a new `Mobile Unit Tests` job runs Jest on the
  16-CPU runner. The two run in parallel, and the workflow's `coverage_generated` output now comes from the unit-tests job.

  **Desktop workflow split (faster Sonar start)**
  - The desktop reusable workflow is split in two: `Desktop E2E & Mock Tests` (Playwright mock + Speculos smoke) and a new `Desktop Lint & Unit
  Tests` workflow (lint/format/typecheck/knip + Jest).
  - Sonar now depends on `Desktop Lint & Unit Tests` instead of the full e2e workflow, so coverage upload + Sonar are no longer gated behind the
  slower e2e/mock suite.

  **Reporting**
  - Both desktop report jobs now fire on **push events only** (develop/main/release/hotfix), not on PRs/merge_group.
  - Re-added the lint & unit-tests push Slack alert in the new desktop codechecks workflow (it was lost when those jobs moved out of the e2e 
  workflow).
  - Renamed the desktop jobs for clarity: `Test Desktop` → `Desktop E2E & Mock Tests`, and the codechecks/unit workflow → `Desktop Lint & Unit 
  Tests`.

  **Sonar / misc cleanup**
  - Rewired the Sonar job to pull desktop coverage from the new codechecks workflow, and removed a now-dead `coverage_generated` output.
  - Removed an unused `Setup the caches` step from the Sonar job (the SonarQube scanner is self-contained and consumes none of it).
  - Bumped libs coverage parallelism `4 → 6`.

  ## Measured results (workflow_dispatch on this branch, all green)

  **Jest wall time:**

  | App | Baseline (ubuntu-22.04, ~3 workers) | 16-CPU runner (~12 workers) | Change |
  |-----|-----|-----|--------|
  | Desktop | 681s | **202s** | **−70% (3.4×)** |
  | Mobile | 292s | **177s** | **−39% (1.6×)** |

  **Mobile gate wall (parallel jobs):** ~422s → **~299s**.

  ## Where the speedup actually lands (PR time-to-green)

  A PR's total time-to-green is the **critical path** through all jobs, not the sum. These Jest jobs are only the bottleneck on some PRs:

  | PR type | ~Share of PRs | Critical path | Effect on total PR time |
  |---|---|---|---|
  | **Mobile affected** | ~70% | Mobile **Detox E2E** chain (native build → emulator, ~22 min) | **~2%** — Detox is the wall; Jest runs in parallel below it |
  | **Desktop-only** | ~15% | `Desktop Lint & Unit Tests` → Sonar | **~28% (~6 min)** — faster Jest + Sonar no longer waiting on e2e |
  | Mobile-only | ~8% | Mobile Detox E2E chain | ~2% |

  So the win concentrates on **desktop-only PRs**, where there's no Detox chain and the lint+unit gate genuinely fronts Sonar. On mobile-affected PRs
  the unit jobs get 40–70% faster but the Detox E2E chain dominates, so overall PR duration moves little. (Detox = end-to-end tests on a real 
  emulator/simulator — unrelated to these Jest unit tests.)

  Next levers after this: mobile Detox build→test chain (~22 min); then desktop e2e (Ubuntu Mock) + Sonar tail for desktop-only PRs.

Test runs: 
- https://github.com/LedgerHQ/ledger-live/actions/runs/27015079127
- https://github.com/LedgerHQ/ledger-live/actions/runs/27021838252

Tickets: 
- https://ledgerhq.atlassian.net/browse/LIVE-31561
- https://ledgerhq.atlassian.net/browse/LIVE-31597

Follow up tracking ticket for 2 releases time: https://ledgerhq.atlassian.net/browse/LIVE-31963
