### PR TITLE
feat(tools): add @ledgerhq/esm-fix-extensions (LIVE-31760 spike)

### DIFF
--- a/.changeset/esm-fix-extensions-tool.md
+++ b/.changeset/esm-fix-extensions-tool.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/esm-fix-extensions": minor
+---
+
+Add @ledgerhq/esm-fix-extensions: a post-build tool that makes a `tsc --moduleResolution bundler` ESM output (`lib-es`) loadable by Node's native ESM resolver — adds explicit relative import extensions, injects `createRequire`/`__dirname` shims for surviving CJS globals, and writes a `{ "type": "module" }` marker. Proven mechanism for LIVE-31760 (validated on the device-core graph); not yet wired into lib builds.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13073,6 +13073,15 @@ importers:
 
   tools/create-release-hash: {}
 
+  tools/esm-fix-extensions:
+    dependencies:
+      es-module-lexer:
+        specifier: ^1.7.0
+        version: 1.7.0
+      magic-string:
+        specifier: ^0.30.21
+        version: 0.30.21
+
   tools/pnpm-utils: {}
 
 packages:
@@ -21827,7 +21836,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.0.0
       react-dom: 19.0.0
-      webpack: '*'
+      webpack: ^5.89.0
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -23806,7 +23815,7 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version has critical issues, please update to the latest version
+    deprecated: this version is no longer supported, please update to at least 0.8.*
 
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
@@ -24144,7 +24153,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: '*'
+      rxjs: ^5.5.10
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -42220,7 +42229,7 @@ snapshots:
       make-fetch-happen: 10.2.1
       nopt: 6.0.0
       proc-log: 2.0.1
-      semver: 7.7.3
+      semver: 7.8.1
       tar: 6.2.1
       which: 2.0.2
     transitivePeerDependencies:
@@ -46293,13 +46302,13 @@ snapshots:
   '@npmcli/fs@1.1.1':
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.7.3
+      semver: 7.8.1
     optional: true
 
   '@npmcli/fs@2.1.2':
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.7.3
+      semver: 7.8.1
 
   '@npmcli/move-file@1.1.2':
     dependencies:

--- a/tools/esm-fix-extensions/README.md
+++ b/tools/esm-fix-extensions/README.md
@@ -1,0 +1,49 @@
+# @ledgerhq/esm-fix-extensions
+
+Post-build tool that makes a `tsc --moduleResolution bundler` ESM output (`lib-es`)
+loadable by Node's **native ESM** resolver, without touching source.
+
+Given a built output directory it:
+
+- rewrites relative import/export specifiers to concrete targets (`./x` → `./x.js`,
+  directory → `./x/index.js`) — Node ESM does not do extension/index resolution;
+- injects `createRequire` / `__dirname` shims into files that still contain those CJS
+  globals verbatim (e.g. a lazy `require("https")`), which are `undefined` under ESM;
+- writes `<dir>/package.json` `{ "type": "module" }` so Node treats the output as ESM
+  without syntax-detection reparsing.
+
+Source stays extensionless (bundler-style), so this is **complementary** to the
+`moduleResolution: bundler` direction (LIVE-29251 / #18120), not a reversal.
+
+## Usage
+
+```sh
+esm-fix-extensions lib-es
+```
+
+Wire it after the `lib-es` emit in a package's build script:
+
+```jsonc
+"build": "tsc -p tsconfig.build.json && tsc -p tsconfig.build.json -m esnext --moduleResolution bundler --outDir lib-es && esm-fix-extensions lib-es"
+```
+
+It is idempotent (already-explicit specifiers and already-shimmed files are skipped).
+
+## Scope / LIVE-31760
+
+This tool is the proven mechanism for [LIVE-31760](https://ledgerhq.atlassian.net/browse/LIVE-31760)
+(make `lib-es` Node-native-ESM loadable). It was validated end-to-end on the
+`@ledgerhq/device-core` dependency graph (12 workspace libs load under
+`node --input-type=module`).
+
+A **full** rollout (every consumer loads in native ESM, drop the e2e CJS shim from
+[#18119]) is **not** achievable from this repo alone:
+
+- ~24 external published `@ledgerhq/*` catalog deps (e.g. `coin-module-framework`,
+  `coin-xrp`, `device-management-kit`, `wallet-api-*`) ship extensionless `lib-es`
+  from the immutable pnpm store and would each need republishing with this transform;
+- workspace libs build `lib-es` in heterogeneous ways (CLI `--outDir` vs tsconfig
+  `outDir`), so wiring must cover both.
+
+This package is therefore landed standalone as the foundation; wiring it into lib
+builds is a follow-up gated on the external-dependency republish strategy.

--- a/tools/esm-fix-extensions/index.mjs
+++ b/tools/esm-fix-extensions/index.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// Make a `tsc --moduleResolution bundler` ESM build (extensionless relative imports)
+// loadable by Node's native ESM resolver: rewrite each relative import/export specifier
+// to its concrete target (`./x` -> `./x.js`, dir -> `./x/index.js`) and drop a
+// `{ "type": "module" }` marker into the output dir. Source stays extensionless. See LIVE-31760.
+import fs from "node:fs";
+import path from "node:path";
+import { init, parse } from "es-module-lexer";
+import MagicString from "magic-string";
+
+function collect(dir, out) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) collect(full, out);
+    else if (entry.name.endsWith(".js")) out.push(full);
+  }
+}
+
+function resolveSpecifier(fromFile, spec) {
+  if (!spec.startsWith(".")) return null; // bare specifiers resolve via package `exports`
+  if (/\.(m?js|cjs|json)$/.test(spec)) return null; // already explicit
+  const base = path.resolve(path.dirname(fromFile), spec);
+  if (fs.existsSync(base + ".js")) return spec + ".js";
+  if (fs.existsSync(path.join(base, "index.js"))) return (spec.endsWith("/") ? spec : spec + "/") + "index.js";
+  return null;
+}
+
+// CJS globals that survive a `tsc -m esnext` build when present verbatim in source
+// (e.g. a lazy `require("https")`). They are undefined under `type: module`, so the
+// ESM output must define them itself via the standard `import.meta` shims.
+const REQUIRE_BANNER =
+  'import { createRequire as __esmCreateRequire } from "node:module";\n' +
+  "const require = __esmCreateRequire(import.meta.url);\n";
+const DIRNAME_BANNER =
+  'import { fileURLToPath as __esmFileURLToPath } from "node:url";\n' +
+  'import { dirname as __esmDirname } from "node:path";\n' +
+  "const __filename = __esmFileURLToPath(import.meta.url);\n" +
+  "const __dirname = __esmDirname(__filename);\n";
+
+async function run(dir) {
+  const root = path.resolve(dir);
+  if (!fs.existsSync(root)) return;
+  await init;
+
+  const files = [];
+  collect(root, files);
+
+  let rewritten = 0;
+  for (const file of files) {
+    const code = fs.readFileSync(file, "utf8");
+    const [imports] = parse(code, file);
+    const ms = new MagicString(code);
+    let dirty = false;
+    for (const imp of imports) {
+      if (imp.n == null) continue; // dynamic import with a non-literal argument
+      const fixed = resolveSpecifier(file, imp.n);
+      if (fixed) {
+        ms.overwrite(imp.s, imp.e, fixed);
+        dirty = true;
+      }
+    }
+    if (/(^|[^\w.])require\s*\(/m.test(code) && !code.includes("createRequire")) {
+      ms.prepend(REQUIRE_BANNER);
+      dirty = true;
+    }
+    if (/\b__dirname\b|\b__filename\b/.test(code) && !code.includes("fileURLToPath")) {
+      ms.prepend(DIRNAME_BANNER);
+      dirty = true;
+    }
+    if (dirty) {
+      fs.writeFileSync(file, ms.toString());
+      rewritten++;
+    }
+  }
+
+  fs.writeFileSync(path.join(root, "package.json"), JSON.stringify({ type: "module" }, null, 2) + "\n");
+  return { files: files.length, rewritten };
+}
+
+const target = process.argv[2];
+if (!target) {
+  console.error("usage: esm-fix-extensions <dir>");
+  process.exit(1);
+}
+run(target).catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tools/esm-fix-extensions/package.json
+++ b/tools/esm-fix-extensions/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@ledgerhq/esm-fix-extensions",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "esm-fix-extensions": "index.mjs"
+  },
+  "scripts": {
+    "lint": "oxlint .",
+    "lint:fix": "oxfmt . && oxlint . --fix"
+  },
+  "dependencies": {
+    "es-module-lexer": "^1.7.0",
+    "magic-string": "^0.30.21"
+  }
+}


### PR DESCRIPTION
> [!NOTE]
> Spike outcome for LIVE-31760. Lands the proven tool only; mass wiring is deferred (see Description).

### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Tooling-only; validated manually end-to-end on the `@ledgerhq/device-core` graph (12 workspace libs load under `node --input-type=module`). No app/runtime code changes.
- [x] **Impact of the changes:**
  - Adds an unused internal build tool (`tools/esm-fix-extensions`). Not wired into any build yet → zero impact on apps, libs, or CI build output. QA: none.

### 📝 Description

Spike for [LIVE-31760](https://ledgerhq.atlassian.net/browse/LIVE-31760): make the `lib-es` ESM builds loadable by Node's **native** ESM resolver (so the e2e CJS shim #18119 could eventually be dropped, CLI/raw-Node consumers work).

Adds **`@ledgerhq/esm-fix-extensions`**, a post-build tool that, given a `lib-es` dir:
- rewrites relative import/export specifiers to concrete targets (`./x` → `./x.js`, dir → `./x/index.js`);
- injects `createRequire` / `__dirname` shims into files that still contain those CJS globals (e.g. a lazy `require("https")`), which are `undefined` under ESM;
- writes `lib-es/package.json` `{ "type": "module" }`.

Source stays extensionless, so this is **complementary to #18120 / LIVE-29251** (bundler-style source), not a reversal.

**Why tool-only:** a full rollout (wire into every lib, drop the shim) is **not achievable from this repo**:
- ~24 external published `@ledgerhq/*` catalog deps (`coin-module-framework`, `coin-xrp`, `device-management-kit`, `wallet-api-*`, …) ship extensionless `lib-es` from the immutable pnpm store — they'd each need republishing with this transform;
- workspace libs build `lib-es` heterogeneously (CLI `--outDir` vs tsconfig `outDir`);
- writing `lib-es/package.json` under `**` workspace globs (`ledgerjs/**`, `ledger-services/**`) turns those dirs into phantom workspace packages — the globs would need a `!**/lib-es` exclusion first.

So this PR lands the validated mechanism as the foundation; wiring is a follow-up gated on the external-dependency republish strategy.

TL;DR for a consumer once wired:
```sh
esm-fix-extensions lib-es   # appended after the lib-es emit in a package build
```

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31760](https://ledgerhq.atlassian.net/browse/LIVE-31760) — relates to #18120 (LIVE-29251) and #18119
- **ADR link (if any)**: N/A


[LIVE-31760]: https://ledgerhq.atlassian.net/browse/LIVE-31760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-31760]: https://ledgerhq.atlassian.net/browse/LIVE-31760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ