### PR TITLE
[LWDM] fix(asset-detail): display empty accounts in addresses section

### DIFF
--- a/.changeset/asset-detail-show-empty-accounts.md
+++ b/.changeset/asset-detail-show-empty-accounts.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Show empty (zero-balance) accounts in the Asset Detail accounts/addresses section

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/__tests__/useAssetDetailViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/__tests__/useAssetDetailViewModel.test.ts
@@ -106,6 +106,25 @@ describe("useAssetDetailViewModel", () => {
     });
   });
 
+  describe("distribution options", () => {
+    it("requests empty accounts so zero-balance addresses are listed", async () => {
+      route("bitcoin", { bySlug: { bitcoin: buildDistributionItem({ currency: btc }) } });
+
+      const { result } = renderHook(() => useAssetDetailViewModel(), {
+        initialState: { settings: { counterValue: "USD", hideEmptyTokenAccounts: true } },
+      });
+      await waitFor(() => expect(result.current.mode).toBe("ready"));
+
+      expect(useDistribution).toHaveBeenCalledWith(
+        expect.objectContaining({
+          groupBy: "asset",
+          showEmptyAccounts: true,
+          hideEmptyTokenAccount: true,
+        }),
+      );
+    });
+  });
+
   describe("market data source priority", () => {
     beforeEach(() => {
       route("bitcoin", { bySlug: { bitcoin: buildDistributionItem({ currency: btc }) } });

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/useAssetDetailViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/useAssetDetailViewModel.ts
@@ -8,7 +8,10 @@ import {
 import type { LineChartRange } from "LLD/components/LineChart";
 import { useSelector } from "LLD/hooks/redux";
 import { useDistribution } from "~/renderer/actions/general";
-import { counterValueCurrencySelector } from "~/renderer/reducers/settings";
+import {
+  counterValueCurrencySelector,
+  hideEmptyTokenAccountsSelector,
+} from "~/renderer/reducers/settings";
 import { decodeRouteParam } from "../utils/decodeRouteParam";
 import {
   resolveAssetMarketInputs,
@@ -19,7 +22,12 @@ import { type AssetDetailViewModel } from "../types";
 export function useAssetDetailViewModel(): AssetDetailViewModel {
   const { "*": routeAssetId } = useParams<{ "*": string }>();
   const location = useLocation();
-  const distribution = useDistribution({ groupBy: "asset" });
+  const hideEmptyTokenAccount = useSelector(hideEmptyTokenAccountsSelector);
+  const distribution = useDistribution({
+    groupBy: "asset",
+    showEmptyAccounts: true,
+    hideEmptyTokenAccount,
+  });
   const counterCurrency = useSelector(counterValueCurrencySelector).ticker.toLowerCase();
   const [selectedRange, setSelectedRange] = useState<LineChartRange>("1d");
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
@@ -201,6 +201,39 @@ describe("AssetDetail screen layout", () => {
     expect(within(header).getByText("(8)")).toBeVisible();
   });
 
+  describe("empty accounts", () => {
+    it("renders the addresses section when only an empty account exists", async () => {
+      render(
+        <AssetDetailTestNavigator />,
+        withAccounts([{ seed: "bitcoin-empty-0", currencyId: "bitcoin", balance: 0 }]),
+      );
+
+      await waitFor(() =>
+        expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.addresses)).toBeVisible(),
+      );
+    });
+
+    it("includes empty accounts alongside funded ones in the addresses count", async () => {
+      render(
+        <AssetDetailTestNavigator />,
+        withAccounts([
+          { seed: "bitcoin-funded-0", currencyId: "bitcoin", balance: 100_000_000 },
+          { seed: "bitcoin-funded-1", currencyId: "bitcoin", balance: 100_000_000 },
+          { seed: "bitcoin-funded-2", currencyId: "bitcoin", balance: 100_000_000 },
+          { seed: "bitcoin-empty-0", currencyId: "bitcoin", balance: 0 },
+          { seed: "bitcoin-empty-1", currencyId: "bitcoin", balance: 0 },
+          { seed: "bitcoin-empty-2", currencyId: "bitcoin", balance: 0 },
+        ]),
+      );
+
+      await waitFor(() =>
+        expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.addresses)).toBeVisible(),
+      );
+      const header = screen.getByTestId(ASSET_DETAIL_TEST_IDS.addressesHeader);
+      expect(within(header).getByText("(6)")).toBeVisible();
+    });
+  });
+
   it("hides the transactions section when there are no operations", () => {
     render(<AssetDetailTestNavigator />, withBtcAccounts(2, 0));
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 import { useCurrencyById } from "@ledgerhq/cryptoassets/hooks";
+import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import { useRoute } from "@react-navigation/native";
 import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { ScreenName } from "~/const";
@@ -22,7 +23,12 @@ export function useAssetDetailViewModel() {
   const route = useRoute<Route>();
   const { currencyId, source, marketState } = route.params;
 
-  const distribution = useDistribution({ groupBy: "asset" });
+  const hideEmptyTokenAccount = useEnv("HIDE_EMPTY_TOKEN_ACCOUNTS");
+  const distribution = useDistribution({
+    groupBy: "asset",
+    showEmptyAccounts: true,
+    hideEmptyTokenAccount,
+  });
   const distributionItem = useMemo(
     () => resolveDistributionItem({ routeAssetId: currencyId, marketState, distribution }),
     [currencyId, marketState, distribution],


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Asset Detail "Addresses/Accounts" section on both Mobile and Desktop now lists empty (zero-balance) accounts.
  - Opening an asset held with only empty accounts now shows the portfolio sections (Total balance = 0, Addresses) instead of the market-only view.
  - The user's "Hide empty token accounts" setting is now respected on Asset Detail (empty token sub-accounts are hidden when the setting is enabled).
  - Addresses count and "See all" behavior with a mix of funded and empty accounts.

### 📝 Description

**Problem**: On the Asset Detail screen (Ledger Wallet Mobile and Desktop), empty (zero-balance) accounts were not displayed in the accounts/addresses section.

**Solution**: The Addresses section renders `distributionItem.accounts`, which is built by `buildAssetDistribution`. That builder drops zero-balance main accounts unless `showEmptyAccounts: true` is passed. Both Asset Detail view models called `useDistribution({ groupBy: "asset" })` without that flag, unlike Portfolio/Assets. This PR aligns Asset Detail with Portfolio by passing `showEmptyAccounts: true` and forwarding the user's `hideEmptyTokenAccount` setting on both platforms.

- Mobile `useAssetDetailViewModel`: reads `useEnv("HIDE_EMPTY_TOKEN_ACCOUNTS")` and passes `showEmptyAccounts: true` + `hideEmptyTokenAccount`.
- Desktop `useAssetDetailViewModel`: reads `hideEmptyTokenAccountsSelector` and passes `showEmptyAccounts: true` + `hideEmptyTokenAccount`.
- Tests: mobile integration tests assert empty accounts appear in the Addresses section; desktop view-model test asserts `useDistribution` is called with the empty-account options.

<img width="350" height="750" alt="Simulator Screenshot - iOS Simulator - 2026-06-02 at 16 33 29" src="https://github.com/user-attachments/assets/1cbe372f-f1ab-4439-8f30-7753ab806202" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-31722](https://ledgerhq.atlassian.net/browse/LIVE-31722)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31722]: https://ledgerhq.atlassian.net/browse/LIVE-31722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ