### PR TITLE
[LWD] fix(desktop): open asset detail ramp actions on network selection

### DIFF
--- a/.changeset/bright-maps-select.md
+++ b/.changeset/bright-maps-select.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix desktop Asset Detail Buy/Sell network selection for multi-network assets.

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/AssetDetailView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/AssetDetailView.tsx
@@ -24,6 +24,7 @@ export function AssetDetailView({ viewModel }: AssetDetailViewProps) {
     marketData,
     displayTicker,
     ledgerId,
+    ledgerIds,
     ledgerCurrency,
     isDistributionLoading,
     selectedRange,
@@ -73,6 +74,7 @@ export function AssetDetailView({ viewModel }: AssetDetailViewProps) {
       <ActionBar
         distributionItem={distributionItem}
         ledgerCurrency={ledgerCurrency}
+        ledgerIds={ledgerIds}
         marketCurrencyData={marketCurrencyData}
         tickerHint={displayTicker}
         isDistributionLoading={isDistributionLoading}

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ActionBar/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ActionBar/index.tsx
@@ -8,6 +8,7 @@ import { useActionBarViewModel } from "./useActionBarViewModel";
 type ActionBarProps = Readonly<{
   distributionItem?: DistributionItem;
   ledgerCurrency?: CryptoOrTokenCurrency;
+  ledgerIds?: readonly string[];
   marketCurrencyData?: MarketCurrencyData;
   tickerHint: string;
   isDistributionLoading: boolean;
@@ -17,6 +18,7 @@ type ActionBarProps = Readonly<{
 export function ActionBar({
   distributionItem,
   ledgerCurrency,
+  ledgerIds,
   marketCurrencyData,
   tickerHint,
   isDistributionLoading,
@@ -25,6 +27,7 @@ export function ActionBar({
   const viewModel = useActionBarViewModel({
     distributionItem,
     ledgerCurrency,
+    ledgerIds,
     marketCurrencyData,
     tickerHint,
     isDistributionLoading,

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ActionBar/useActionBarViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ActionBar/useActionBarViewModel.ts
@@ -30,6 +30,7 @@ import { useSellNavigation } from "LLD/features/Market/hooks/useSellNavigation";
 type UseActionBarViewModelProps = Readonly<{
   distributionItem?: DistributionItem;
   ledgerCurrency?: CryptoOrTokenCurrency;
+  ledgerIds?: readonly string[];
   marketCurrencyData?: MarketCurrencyData;
   tickerHint: string;
   isDistributionLoading: boolean;
@@ -101,6 +102,7 @@ function resolvePrimaryAccount(
 export function useActionBarViewModel({
   distributionItem,
   ledgerCurrency,
+  ledgerIds,
   marketCurrencyData,
   tickerHint,
   isDistributionLoading,
@@ -116,6 +118,9 @@ export function useActionBarViewModel({
   const { deactivatedCurrencyIds } = useCurrenciesUnderFeatureFlag();
 
   const ledgerIdsForRamp = useMemo(() => {
+    if (ledgerIds?.length) {
+      return [...ledgerIds];
+    }
     if (marketCurrencyData?.ledgerIds?.length) {
       return marketCurrencyData.ledgerIds;
     }
@@ -127,7 +132,7 @@ export function useActionBarViewModel({
       return ledgerIdsFromLedgerCurrency(ledgerCurrency);
     }
     return [];
-  }, [marketCurrencyData, distributionItem, ledgerCurrency]);
+  }, [ledgerIds, marketCurrencyData, distributionItem, ledgerCurrency]);
 
   const rampActiveLedgerIds = useMemo(
     () => ledgerIdsForRamp.filter(id => !deactivatedCurrencyIds.has(id)),
@@ -187,6 +192,8 @@ export function useActionBarViewModel({
 
   const trackingCurrencyId =
     ledgerCurrency?.id ?? distributionItem?.currency.id ?? rampActiveLedgerIds[0];
+  const rampNavigationCurrencyIds =
+    rampActiveLedgerIds.length > 1 ? rampActiveLedgerIds : undefined;
 
   const onBuy = useCallback(() => {
     track("button_clicked", {
@@ -195,8 +202,8 @@ export function useActionBarViewModel({
       page: ASSET_DETAIL_TRACKING_PAGE_NAME,
     });
     setTrackingSource(ASSET_DETAIL_TRACKING_PAGE_NAME);
-    navigateToBuy(ledgerCurrency, tickerHint);
-  }, [ledgerCurrency, tickerHint, navigateToBuy, trackingCurrencyId]);
+    navigateToBuy(ledgerCurrency, tickerHint, { currencyIds: rampNavigationCurrencyIds });
+  }, [ledgerCurrency, tickerHint, navigateToBuy, trackingCurrencyId, rampNavigationCurrencyIds]);
 
   const onSell = useCallback(() => {
     track("button_clicked", {
@@ -205,8 +212,8 @@ export function useActionBarViewModel({
       page: ASSET_DETAIL_TRACKING_PAGE_NAME,
     });
     setTrackingSource(ASSET_DETAIL_TRACKING_PAGE_NAME);
-    navigateToSell(ledgerCurrency, tickerHint);
-  }, [ledgerCurrency, tickerHint, navigateToSell, trackingCurrencyId]);
+    navigateToSell(ledgerCurrency, tickerHint, { currencyIds: rampNavigationCurrencyIds });
+  }, [ledgerCurrency, tickerHint, navigateToSell, trackingCurrencyId, rampNavigationCurrencyIds]);
 
   const onSend = useCallback(() => {
     track("button_clicked", {

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/__tests__/useAssetDetailViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/__tests__/useAssetDetailViewModel.test.ts
@@ -161,6 +161,7 @@ describe("useAssetDetailViewModel", () => {
       expect(vm.displayTicker).toBe(btc.ticker);
       expect(vm.ledgerCurrency).toBe(btc);
       expect(vm.ledgerId).toBe(btc.id);
+      expect(vm.ledgerIds).toEqual([btc.id]);
     });
 
     it("falls back to marketCurrencyData for name/ticker in discovery mode", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/useAssetDetailViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/useAssetDetailViewModel.ts
@@ -41,7 +41,13 @@ export function useAssetDetailViewModel(): AssetDetailViewModel {
     [distributionItem, marketState, decodedAssetId],
   );
 
-  const { marketCurrencyData, marketId, ledgerCurrencyFromDada, isLoading } = useAssetMarketData({
+  const {
+    marketCurrencyData,
+    marketId,
+    ledgerCurrencyFromDada,
+    ledgerIds: assetMarketLedgerIds,
+    isLoading,
+  } = useAssetMarketData({
     marketApiId,
     knownLedgerIds,
     counterCurrency,
@@ -53,6 +59,11 @@ export function useAssetDetailViewModel(): AssetDetailViewModel {
   const marketFallback = resolveAssetDetailMarketInfo(marketCurrencyData, marketState);
 
   const ledgerCurrency = distributionItem?.currency ?? ledgerCurrencyFromDada;
+  const ledgerIds = useMemo(() => {
+    if (assetMarketLedgerIds?.length) return assetMarketLedgerIds;
+    if (marketCurrencyData?.ledgerIds?.length) return marketCurrencyData.ledgerIds;
+    return knownLedgerIds ? [...knownLedgerIds] : [];
+  }, [assetMarketLedgerIds, marketCurrencyData?.ledgerIds, knownLedgerIds]);
 
   if (distributionItem || marketFallback) {
     return {
@@ -61,6 +72,7 @@ export function useAssetDetailViewModel(): AssetDetailViewModel {
       marketData: { marketCurrencyData, marketId, isLoading },
       isDistributionLoading: distribution.isLoading,
       ledgerCurrency,
+      ledgerIds,
       displayName: ledgerCurrency?.name ?? marketFallback?.name ?? "",
       displayTicker: (ledgerCurrency?.ticker ?? marketFallback?.ticker ?? "").toUpperCase(),
       ledgerId: ledgerCurrency?.id ?? marketFallback?.ledgerIds?.[0],
@@ -76,6 +88,7 @@ export function useAssetDetailViewModel(): AssetDetailViewModel {
       marketData: { marketCurrencyData, marketId, isLoading },
       isDistributionLoading: distribution.isLoading,
       ledgerCurrency,
+      ledgerIds,
       displayName: ledgerCurrency?.name ?? "",
       displayTicker: (ledgerCurrency?.ticker ?? "").toUpperCase(),
       ledgerId: ledgerCurrency?.id ?? decodedAssetId,

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/types.ts
@@ -11,6 +11,7 @@ export type AssetDetailReady = Readonly<{
   marketData: AssetMarketData;
   isDistributionLoading: boolean;
   ledgerCurrency?: CryptoOrTokenCurrency;
+  ledgerIds: string[];
   displayName: string;
   displayTicker: string;
   ledgerId?: string;

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/__tests__/useBuySellNavigation.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/__tests__/useBuySellNavigation.test.ts
@@ -5,7 +5,7 @@ import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/m
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { usdcToken } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
 import type { Account } from "@ledgerhq/types-live";
-import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type { CryptoCurrency, CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 
 const mockNavigate = jest.fn();
 const mockOpenAssetAndAccount = jest.fn();
@@ -21,10 +21,18 @@ jest.mock("LLD/features/ModularDialog/Web3AppWebview/AssetAndAccountDrawer", () 
 }));
 
 const bitcoin = getCryptoCurrencyById("bitcoin");
+const ethereum = getCryptoCurrencyById("ethereum");
+const base = getCryptoCurrencyById("base");
+const arbitrum = getCryptoCurrencyById("arbitrum");
+const multiNetworkCurrencyIds = [ethereum.id, base.id, arbitrum.id];
+
+function createCryptoAccount(id: string, currency: CryptoCurrency): Account {
+  const account = genAccount(id, { currency });
+  return { ...account, id };
+}
 
 function createBitcoinAccount(id: string): Account {
-  const account = genAccount(id, { currency: bitcoin });
-  return { ...account, id };
+  return createCryptoAccount(id, bitcoin);
 }
 
 const cases = [
@@ -163,6 +171,31 @@ describe.each(cases)(
       expect(mockNavigate).not.toHaveBeenCalled();
     });
 
+    test("should open drawer with all provided currency ids when asset detail has multiple networks", () => {
+      const ethAccount = createCryptoAccount("eth-1", ethereum);
+      const baseAccount = createCryptoAccount("base-1", base);
+      const arbitrumAccount = createCryptoAccount("arbitrum-1", arbitrum);
+      const { result } = renderHook(() => useHook(), {
+        initialState: { accounts: [ethAccount, baseAccount, arbitrumAccount] },
+      });
+
+      act(() => {
+        getNavigate(result.current as never)(ethereum, "eth", {
+          currencyIds: multiNetworkCurrencyIds,
+        });
+      });
+
+      expect(mockOpenAssetAndAccount).toHaveBeenCalledTimes(1);
+      expect(mockOpenAssetAndAccount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          currencies: multiNetworkCurrencyIds,
+          areCurrenciesFiltered: true,
+          useCase,
+        }),
+      );
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
     test("should navigate to exchange when drawer onSuccess is called with selected account", () => {
       const account1 = createBitcoinAccount("btc-1");
       const account2 = createBitcoinAccount("btc-2");
@@ -192,6 +225,40 @@ describe.each(cases)(
       expect(mockNavigate).toHaveBeenCalledTimes(1);
       expect(mockNavigate).toHaveBeenCalledWith("/exchange", {
         state: { currency: bitcoin.id, account: account1.id, mode, returnTo: "/market" },
+      });
+    });
+
+    test("should navigate with selected network currency when multi-network drawer succeeds", () => {
+      const ethAccount = createCryptoAccount("eth-1", ethereum);
+      const baseAccount = createCryptoAccount("base-1", base);
+      let onSuccessCallback: ((account: Account, parentAccount?: Account) => void) | undefined;
+
+      mockOpenAssetAndAccount.mockImplementation(
+        ({ onSuccess }: { onSuccess?: (a: Account, p?: Account) => void }) => {
+          onSuccessCallback = onSuccess;
+        },
+      );
+
+      const { result } = renderHook(() => useHook(), {
+        initialState: { accounts: [ethAccount, baseAccount] },
+      });
+
+      act(() => {
+        getNavigate(result.current as never)(ethereum, "eth", {
+          currencyIds: multiNetworkCurrencyIds,
+        });
+      });
+
+      expect(mockOpenAssetAndAccount).toHaveBeenCalled();
+      expect(onSuccessCallback).toBeDefined();
+
+      act(() => {
+        onSuccessCallback?.(baseAccount);
+      });
+
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith("/exchange", {
+        state: { currency: base.id, account: baseAccount.id, mode, returnTo: "/market" },
       });
     });
   },

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useBuyNavigation.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useBuyNavigation.ts
@@ -1,9 +1,13 @@
 import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { useRampExchangeNavigation } from "./useRampExchangeNavigation";
+import {
+  type RampExchangeNavigationOptions,
+  useRampExchangeNavigation,
+} from "./useRampExchangeNavigation";
 
 type NavigateToBuy = (
   ledgerCurrency: CryptoOrTokenCurrency | null | undefined,
   ticker?: string,
+  options?: RampExchangeNavigationOptions,
 ) => void;
 
 interface UseBuyNavigationResult {

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useRampExchangeNavigation.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useRampExchangeNavigation.ts
@@ -2,7 +2,11 @@ import { useCallback } from "react";
 import { useSelector } from "LLD/hooks/redux";
 import { useLocation, useNavigate } from "react-router";
 import { accountsSelector } from "~/renderer/reducers/accounts";
-import { flattenAccounts, isTokenAccount } from "@ledgerhq/live-common/account/index";
+import {
+  flattenAccounts,
+  getAccountCurrency,
+  isTokenAccount,
+} from "@ledgerhq/live-common/account/index";
 import { getAvailableAccountsById } from "@ledgerhq/live-common/exchange/swap/utils/index";
 import { useOpenAssetAndAccount } from "LLD/features/ModularDialog/Web3AppWebview/AssetAndAccountDrawer";
 import { buildBuyNavigationState, type BuyNavigationOnRampState } from "../utils/buyNavigation";
@@ -12,9 +16,14 @@ import type { Account, AccountLike } from "@ledgerhq/types-live";
 
 type RampExchangeKind = "buy" | "sell";
 
+export type RampExchangeNavigationOptions = Readonly<{
+  currencyIds?: readonly string[];
+}>;
+
 type NavigateToRamp = (
   ledgerCurrency: CryptoOrTokenCurrency | null | undefined,
   ticker?: string,
+  options?: RampExchangeNavigationOptions,
 ) => void;
 
 type BuildRampStateParams = {
@@ -39,6 +48,10 @@ function emptyLedgerRampState(
   return { mode: "offRamp", defaultTicker: ticker?.toUpperCase(), returnTo };
 }
 
+function uniqueCurrencyIds(currencyIds: readonly string[] | undefined): string[] {
+  return [...new Set(currencyIds?.filter(Boolean) ?? [])];
+}
+
 export function useRampExchangeNavigation(kind: RampExchangeKind): NavigateToRamp {
   const navigate = useNavigate();
   const location = useLocation();
@@ -47,10 +60,31 @@ export function useRampExchangeNavigation(kind: RampExchangeKind): NavigateToRam
   const { openAssetAndAccount } = useOpenAssetAndAccount();
 
   return useCallback<NavigateToRamp>(
-    (ledgerCurrency, ticker) => {
+    (ledgerCurrency, ticker, options) => {
       if (!ledgerCurrency) {
         navigate("/exchange", {
           state: emptyLedgerRampState(kind, ticker, location.pathname),
+        });
+        return;
+      }
+
+      const currencyIds = uniqueCurrencyIds(options?.currencyIds);
+      if (currencyIds.length > 1) {
+        openAssetAndAccount({
+          currencies: currencyIds,
+          areCurrenciesFiltered: true,
+          useCase: kind,
+          drawerConfiguration: {},
+          onSuccess: (account, parentAccount) => {
+            navigate("/exchange", {
+              state: buildRampNavigationState(kind, {
+                ledgerCurrency: getAccountCurrency(account),
+                account,
+                parentAccount,
+                returnTo: location.pathname,
+              }),
+            });
+          },
         });
         return;
       }
@@ -93,7 +127,7 @@ export function useRampExchangeNavigation(kind: RampExchangeKind): NavigateToRam
         onSuccess: (account, parentAccount) => {
           navigate("/exchange", {
             state: buildRampNavigationState(kind, {
-              ledgerCurrency,
+              ledgerCurrency: getAccountCurrency(account),
               account,
               parentAccount,
               returnTo: location.pathname,

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useSellNavigation.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useSellNavigation.ts
@@ -1,9 +1,13 @@
 import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { useRampExchangeNavigation } from "./useRampExchangeNavigation";
+import {
+  type RampExchangeNavigationOptions,
+  useRampExchangeNavigation,
+} from "./useRampExchangeNavigation";
 
 type NavigateToSell = (
   ledgerCurrency: CryptoOrTokenCurrency | null | undefined,
   ticker?: string,
+  options?: RampExchangeNavigationOptions,
 ) => void;
 
 interface UseSellNavigationResult {


### PR DESCRIPTION

### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Desktop Asset Detail Buy/Sell quick actions
  - Multi-network assets such as ETH, USDC, and USDT across Ethereum, Base, and Arbitrum
  - Exchange preselection after choosing a network and account

### 📝 Description

Desktop Asset Detail could open the account-selection step directly for Buy/Sell when the asset was available on multiple networks and the wallet had accounts on several of them. For LIVE-31581, this should follow the mobile behavior and let users select the network first.

This PR threads the Asset Detail `ledgerIds` list into the desktop ramp navigation. When more than one active ledger id is available, Buy/Sell opens the ModularDialog with the full filtered currency list so users land on network selection first. The final exchange navigation uses the currency from the selected account, ensuring Base, Arbitrum, and Ethereum choices are preserved.

Before: Buy/Sell from a multi-network asset could jump straight to Select Account for a single ledger currency.

After: Buy/Sell opens Select Network first, then navigates to `/exchange` with the selected network and account.


https://github.com/user-attachments/assets/5c5e27a3-da49-4f58-9ccc-45b4863e8907

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31581](https://ledgerhq.atlassian.net/browse/LIVE-31581)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31581]: https://ledgerhq.atlassian.net/browse/LIVE-31581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ