### PR TITLE
[LWM] feat(mobile): add prompt logic for tx alerts

### DIFF
--- a/.changeset/kind-maps-carry.md
+++ b/.changeset/kind-maps-carry.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add prompt logic for tx alerts

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotifications.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotifications.ts
@@ -25,6 +25,7 @@ const useNotifications = () => {
     useNotificationsPrompt({
       permissionStatus,
       areNotificationsAllowed: notifications.areNotificationsAllowed,
+      transactionsAlertsCategory: notifications.transactionsAlertsCategory,
       pushNotificationsDataOfUser,
     });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsPrompt.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsPrompt.ts
@@ -14,12 +14,14 @@ type UseNotificationsPromptParams = {
     | null
     | undefined;
   areNotificationsAllowed: boolean | undefined;
+  transactionsAlertsCategory: boolean | undefined;
   pushNotificationsDataOfUser: DataOfUser | null | undefined;
 };
 
 export const useNotificationsPrompt = ({
   permissionStatus,
   areNotificationsAllowed,
+  transactionsAlertsCategory,
   pushNotificationsDataOfUser,
 }: UseNotificationsPromptParams) => {
   const featureBrazePushNotifications = useFeature("brazePushNotifications");
@@ -29,17 +31,33 @@ export const useNotificationsPrompt = ({
     return getNextRepromptDelay({
       repromptSchedule,
       pushNotificationsDataOfUser,
+      permissionStatus,
+      areNotificationsAllowed,
+      transactionsAlertsCategory,
     });
-  }, [repromptSchedule, pushNotificationsDataOfUser]);
+  }, [
+    repromptSchedule,
+    pushNotificationsDataOfUser,
+    permissionStatus,
+    areNotificationsAllowed,
+    transactionsAlertsCategory,
+  ]);
 
   const shouldPrompt = useCallback(() => {
     return shouldPromptOptInDrawerAfterAction({
       permissionStatus,
       areNotificationsAllowed,
+      transactionsAlertsCategory,
       pushNotificationsDataOfUser,
       repromptSchedule,
     });
-  }, [permissionStatus, areNotificationsAllowed, pushNotificationsDataOfUser, repromptSchedule]);
+  }, [
+    permissionStatus,
+    areNotificationsAllowed,
+    transactionsAlertsCategory,
+    pushNotificationsDataOfUser,
+    repromptSchedule,
+  ]);
 
   const inactivityEnabled = featureBrazePushNotifications?.params?.inactivity_enabled;
   const inactivityReprompt = featureBrazePushNotifications?.params?.inactivity_reprompt;

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/index.ts
@@ -11,6 +11,8 @@ export {
   evaluateAfterActionTrigger,
   evaluateInactivityTrigger,
   getNextRepromptDelay,
+  canPromptTransactionsAlertsForAction,
+  getNotificationPromptTarget,
   shouldPromptOptInDrawerAfterAction,
 } from "./utils/notificationsPromptEngine";
 export type {

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/new/hooks/useNotificationsPromptDrawerScheduler.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/new/hooks/useNotificationsPromptDrawerScheduler.ts
@@ -1,8 +1,15 @@
 import { useCallback, useEffect, useRef } from "react";
 import { useDispatch, useSelector } from "~/context/hooks";
-import { setNotificationsDrawerSource, setNotificationsModalOpen } from "~/actions/notifications";
+import {
+  setNotificationsDrawerPromptTarget,
+  setNotificationsDrawerSource,
+  setNotificationsModalOpen,
+} from "~/actions/notifications";
 import { notificationsModalOpenSelector } from "~/reducers/notifications";
-import { type NotificationsPromptSource } from "LLM/features/NotificationsPrompt";
+import {
+  type NotificationPromptTarget,
+  type NotificationsPromptSource,
+} from "LLM/features/NotificationsPrompt";
 
 export function useNotificationsPromptDrawerScheduler() {
   const dispatch = useDispatch();
@@ -10,7 +17,11 @@ export function useNotificationsPromptDrawerScheduler() {
   const eventTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const openDrawer = useCallback(
-    (source: NotificationsPromptSource, timer = 0) => {
+    (
+      source: NotificationsPromptSource,
+      timer = 0,
+      drawerPromptTarget?: NotificationPromptTarget,
+    ) => {
       if (eventTimeoutRef.current) {
         clearTimeout(eventTimeoutRef.current);
         eventTimeoutRef.current = null;
@@ -18,8 +29,12 @@ export function useNotificationsPromptDrawerScheduler() {
 
       eventTimeoutRef.current = setTimeout(() => {
         eventTimeoutRef.current = null;
+        const resolvedPromptTarget =
+          source === "inactivity" ? "globalPushNotifications" : drawerPromptTarget;
+
         dispatch(setNotificationsModalOpen(true));
         dispatch(setNotificationsDrawerSource(source));
+        dispatch(setNotificationsDrawerPromptTarget(resolvedPromptTarget));
       }, timer);
     },
     [dispatch],

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/new/hooks/useNotificationsPromptTriggers.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/new/hooks/useNotificationsPromptTriggers.ts
@@ -29,6 +29,7 @@ export function useNotificationsPromptTriggers() {
   const { shouldPromptOptInDrawerAfterAction } = useNotificationsPrompt({
     permissionStatus,
     areNotificationsAllowed: notifications.areNotificationsAllowed,
+    transactionsAlertsCategory: notifications.transactionsAlertsCategory,
     pushNotificationsDataOfUser,
   });
   const { openDrawer, isDrawerPending } = useNotificationsPromptDrawerScheduler();
@@ -40,6 +41,7 @@ export function useNotificationsPromptTriggers() {
           source,
           permissionStatus,
           areNotificationsAllowed: notifications.areNotificationsAllowed,
+          transactionsAlertsCategory: notifications.transactionsAlertsCategory,
           pushNotificationsDataOfUser,
         },
         {
@@ -56,7 +58,7 @@ export function useNotificationsPromptTriggers() {
         return;
       }
 
-      openDrawer(decision.source, decision.delayMs);
+      openDrawer(decision.source, decision.delayMs, decision.drawerPromptTarget);
     },
     [
       featureBrazePushNotifications,
@@ -64,6 +66,7 @@ export function useNotificationsPromptTriggers() {
       isDrawerPending,
       isRatingsModalOpen,
       notifications.areNotificationsAllowed,
+      notifications.transactionsAlertsCategory,
       openDrawer,
       permissionStatus,
       pushNotificationsDataOfUser,
@@ -94,11 +97,14 @@ export function useNotificationsPromptTriggers() {
 
       trackInactivityDecision(decision);
 
-      if (decision.kind === "skip") {
+      if (
+        decision.kind !== "show" ||
+        decision.drawerPromptTarget !== "globalPushNotifications"
+      ) {
         return;
       }
 
-      openDrawer(decision.source, decision.delayMs);
+      openDrawer(decision.source, decision.delayMs, decision.drawerPromptTarget);
     },
     [
       featureBrazePushNotifications,

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/__tests__/notificationsPromptEngine.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/__tests__/notificationsPromptEngine.test.ts
@@ -2,41 +2,72 @@ import { sub } from "date-fns";
 import { AuthorizationStatus } from "@react-native-firebase/messaging";
 import type { Features } from "@shared/feature-flags";
 import { AB_TESTING_VARIANTS, type ABTestingVariants } from "../../types/variants";
-
-type BrazePushNotifications = Features["brazePushNotifications"];
-type LwmNewWordingOptInNotificationsDrawer = Features["lwmNewWordingOptInNotificationsDrawer"];
 import {
   INACTIVITY_DRAWER_DELAY_MS,
+  canPromptTransactionsAlertsForAction,
   evaluateAfterActionTrigger,
   evaluateInactivityTrigger,
   getNextRepromptDelay,
+  getNotificationPromptTarget,
+  shouldPromptOptInDrawerAfterAction,
 } from "../notificationsPromptEngine";
+
+type BrazePushNotifications = Features["brazePushNotifications"];
+type BrazeNotificationsCategoryConfig = NonNullable<
+  BrazePushNotifications["params"]
+>["notificationsCategories"][number];
+type LwmNewWordingOptInNotificationsDrawer = Features["lwmNewWordingOptInNotificationsDrawer"];
+
+const transactionsAlertsCategoryConfig: BrazeNotificationsCategoryConfig = {
+  displayed: true,
+  category: "transactionsAlertsCategory",
+  drawerPromptEnabled: true,
+  drawerPromptActions: ["send", "receive", "swap"] as BrazeNotificationsCategoryConfig["drawerPromptActions"],
+};
+
+const defaultOptInState = {
+  transactionsAlertsCategory: false as boolean | undefined,
+};
 
 const NOW = new Date("2026-01-01T00:00:00.000Z").getTime();
 
+const defaultBrazePushNotificationsParams: NonNullable<BrazePushNotifications["params"]> = {
+  reprompt_schedule: [{ days: 7, hours: 0, minutes: 0, months: 0, seconds: 0 }],
+  action_events: {
+    complete_onboarding: { enabled: true, timer: 100 },
+    send: { enabled: true, timer: 200 },
+    dapp_complete: { enabled: true, timer: 200 },
+    receive: { enabled: true, timer: 300 },
+    buy: { enabled: true, timer: 400 },
+    swap: { enabled: true, timer: 500 },
+    stake: { enabled: true, timer: 600 },
+    add_favorite_coin: { enabled: true, timer: 700 },
+  },
+  inactivity_enabled: true,
+  inactivity_reprompt: { days: 0, hours: 0, minutes: 0, months: 6, seconds: 0 },
+  notificationsCategories: [],
+};
+
 const createBrazePushNotificationsFeature = (
-  overrides?: Partial<BrazePushNotifications>,
+  overrides?: Partial<Omit<BrazePushNotifications, "params">> & {
+    params?: Partial<NonNullable<BrazePushNotifications["params"]>>;
+  },
 ): BrazePushNotifications =>
   ({
     enabled: true,
-    params: {
-      reprompt_schedule: [{ days: 7, hours: 0, minutes: 0, months: 0, seconds: 0 }],
-      action_events: {
-        complete_onboarding: { enabled: true, timer: 100 },
-        send: { enabled: true, timer: 200 },
-        dapp_complete: { enabled: true, timer: 200 },
-        receive: { enabled: true, timer: 300 },
-        buy: { enabled: true, timer: 400 },
-        swap: { enabled: true, timer: 500 },
-        stake: { enabled: true, timer: 600 },
-        add_favorite_coin: { enabled: true, timer: 700 },
-      },
-      inactivity_enabled: true,
-      inactivity_reprompt: { days: 0, hours: 0, minutes: 0, months: 6, seconds: 0 },
-      notificationsCategories: [],
-    },
     ...overrides,
+    params: {
+      ...defaultBrazePushNotificationsParams,
+      ...overrides?.params,
+    },
   }) as BrazePushNotifications;
+
+const createBrazePushNotificationsWithTransactionsAlerts = () =>
+  createBrazePushNotificationsFeature({
+    params: {
+      notificationsCategories: [transactionsAlertsCategoryConfig],
+    },
+  });
 
 const createWordingFeature = (
   variant: ABTestingVariants = AB_TESTING_VARIANTS.B,
@@ -76,6 +107,7 @@ describe("notificationsPromptEngine", () => {
           source: "send",
           permissionStatus: AuthorizationStatus.NOT_DETERMINED,
           areNotificationsAllowed: true,
+          ...defaultOptInState,
           pushNotificationsDataOfUser: null,
         },
         createEvaluationContext(),
@@ -85,6 +117,7 @@ describe("notificationsPromptEngine", () => {
         kind: "show",
         source: "send",
         delayMs: 200,
+        drawerPromptTarget: "globalPushNotifications",
         dismissedCount: 0,
         nextRepromptDelay: null,
         variant: AB_TESTING_VARIANTS.B,
@@ -97,6 +130,7 @@ describe("notificationsPromptEngine", () => {
           source: "send",
           permissionStatus: AuthorizationStatus.AUTHORIZED,
           areNotificationsAllowed: true,
+          transactionsAlertsCategory: true,
           pushNotificationsDataOfUser: null,
         },
         createEvaluationContext(),
@@ -122,6 +156,7 @@ describe("notificationsPromptEngine", () => {
           source: "send",
           permissionStatus: AuthorizationStatus.DENIED,
           areNotificationsAllowed: true,
+          ...defaultOptInState,
           pushNotificationsDataOfUser,
         },
         createEvaluationContext(),
@@ -147,6 +182,7 @@ describe("notificationsPromptEngine", () => {
           source: "send",
           permissionStatus: AuthorizationStatus.DENIED,
           areNotificationsAllowed: true,
+          ...defaultOptInState,
           pushNotificationsDataOfUser,
         },
         createEvaluationContext(),
@@ -156,8 +192,173 @@ describe("notificationsPromptEngine", () => {
         kind: "show",
         source: "send",
         delayMs: 200,
+        drawerPromptTarget: "globalPushNotifications",
         dismissedCount: 1,
         nextRepromptDelay: { days: 7, hours: 0, minutes: 0, months: 0, seconds: 0 },
+        variant: AB_TESTING_VARIANTS.B,
+      });
+    });
+
+    describe("reprompt eligibility", () => {
+      it("skips global push when the reprompt delay has not been reached (per-target dismissals)", () => {
+        const decision = evaluateAfterActionTrigger(
+          {
+            source: "send",
+            permissionStatus: AuthorizationStatus.DENIED,
+            areNotificationsAllowed: true,
+            ...defaultOptInState,
+            pushNotificationsDataOfUser: {
+              dismissedPromptAtListByTarget: {
+                globalPushNotifications: [sub(NOW, { days: 1 }).getTime()],
+              },
+            },
+          },
+          createEvaluationContext(),
+        );
+
+        expect(decision).toEqual({
+          kind: "skip",
+          source: "send",
+          reason: "reprompt_delay_not_reached",
+          dismissedCount: 1,
+          nextRepromptDelay: { days: 7, hours: 0, minutes: 0, months: 0, seconds: 0 },
+          variant: AB_TESTING_VARIANTS.B,
+        });
+      });
+
+      it("skips when dismissals exist but no reprompt schedule is configured", () => {
+        const decision = evaluateAfterActionTrigger(
+          {
+            source: "send",
+            permissionStatus: AuthorizationStatus.DENIED,
+            areNotificationsAllowed: true,
+            ...defaultOptInState,
+            pushNotificationsDataOfUser: {
+              dismissedOptInDrawerAtList: [sub(NOW, { days: 8 }).getTime()],
+            },
+          },
+          createEvaluationContext({
+            brazePushNotifications: createBrazePushNotificationsFeature({
+              params: { reprompt_schedule: [] },
+            }),
+          }),
+        );
+
+        expect(decision).toEqual({
+          kind: "skip",
+          source: "send",
+          reason: "configuration_missing",
+          dismissedCount: 1,
+          nextRepromptDelay: null,
+          variant: AB_TESTING_VARIANTS.B,
+        });
+      });
+    });
+
+    it("shows transactions alerts on first prompt when globally opted in", () => {
+      const decision = evaluateAfterActionTrigger(
+        {
+          source: "receive",
+          permissionStatus: AuthorizationStatus.AUTHORIZED,
+          areNotificationsAllowed: true,
+          transactionsAlertsCategory: false,
+          pushNotificationsDataOfUser: null,
+        },
+        createEvaluationContext({
+          brazePushNotifications: createBrazePushNotificationsWithTransactionsAlerts(),
+        }),
+      );
+
+      expect(decision).toEqual({
+        kind: "show",
+        source: "receive",
+        delayMs: 300,
+        drawerPromptTarget: "transactionsAlertsCategory",
+        dismissedCount: 0,
+        nextRepromptDelay: null,
+        variant: AB_TESTING_VARIANTS.B,
+      });
+    });
+
+    it("shows transactions alerts when globally opted in and the action is eligible", () => {
+      const pushNotificationsDataOfUser = {
+        dismissedPromptAtListByTarget: {
+          transactionsAlertsCategory: [sub(NOW, { days: 8 }).getTime()],
+        },
+      };
+
+      const decision = evaluateAfterActionTrigger(
+        {
+          source: "send",
+          permissionStatus: AuthorizationStatus.AUTHORIZED,
+          areNotificationsAllowed: true,
+          transactionsAlertsCategory: false,
+          pushNotificationsDataOfUser,
+        },
+        createEvaluationContext({
+          brazePushNotifications: createBrazePushNotificationsWithTransactionsAlerts(),
+        }),
+      );
+
+      expect(decision).toEqual({
+        kind: "show",
+        source: "send",
+        delayMs: 200,
+        drawerPromptTarget: "transactionsAlertsCategory",
+        dismissedCount: 1,
+        nextRepromptDelay: { days: 7, hours: 0, minutes: 0, months: 0, seconds: 0 },
+        variant: AB_TESTING_VARIANTS.B,
+      });
+    });
+
+    it("skips transactions alerts when the reprompt delay has not been reached", () => {
+      const decision = evaluateAfterActionTrigger(
+        {
+          source: "swap",
+          permissionStatus: AuthorizationStatus.AUTHORIZED,
+          areNotificationsAllowed: true,
+          transactionsAlertsCategory: false,
+          pushNotificationsDataOfUser: {
+            dismissedPromptAtListByTarget: {
+              transactionsAlertsCategory: [sub(NOW, { days: 2 }).getTime()],
+            },
+          },
+        },
+        createEvaluationContext({
+          brazePushNotifications: createBrazePushNotificationsWithTransactionsAlerts(),
+        }),
+      );
+
+      expect(decision).toEqual({
+        kind: "skip",
+        source: "swap",
+        reason: "reprompt_delay_not_reached",
+        dismissedCount: 1,
+        nextRepromptDelay: { days: 7, hours: 0, minutes: 0, months: 0, seconds: 0 },
+        variant: AB_TESTING_VARIANTS.B,
+      });
+    });
+
+    it("skips transactions alerts when the completed action is not configured", () => {
+      const decision = evaluateAfterActionTrigger(
+        {
+          source: "stake",
+          permissionStatus: AuthorizationStatus.AUTHORIZED,
+          areNotificationsAllowed: true,
+          transactionsAlertsCategory: false,
+          pushNotificationsDataOfUser: null,
+        },
+        createEvaluationContext({
+          brazePushNotifications: createBrazePushNotificationsWithTransactionsAlerts(),
+        }),
+      );
+
+      expect(decision).toEqual({
+        kind: "skip",
+        source: "stake",
+        reason: "transactions_alerts_not_eligible",
+        dismissedCount: 0,
+        nextRepromptDelay: null,
         variant: AB_TESTING_VARIANTS.B,
       });
     });
@@ -170,6 +371,7 @@ describe("notificationsPromptEngine", () => {
           source: "send",
           permissionStatus: AuthorizationStatus.NOT_DETERMINED,
           areNotificationsAllowed: true,
+          ...defaultOptInState,
           pushNotificationsDataOfUser: null,
         },
         createEvaluationContext({ wordingFeature }),
@@ -180,6 +382,7 @@ describe("notificationsPromptEngine", () => {
           source: "onboarding",
           permissionStatus: AuthorizationStatus.NOT_DETERMINED,
           areNotificationsAllowed: true,
+          ...defaultOptInState,
           pushNotificationsDataOfUser: null,
         },
         createEvaluationContext({ wordingFeature }),
@@ -198,6 +401,7 @@ describe("notificationsPromptEngine", () => {
         kind: "show",
         source: "onboarding",
         delayMs: 100,
+        drawerPromptTarget: "globalPushNotifications",
         dismissedCount: 0,
         nextRepromptDelay: null,
         variant: AB_TESTING_VARIANTS.A,
@@ -292,6 +496,32 @@ describe("notificationsPromptEngine", () => {
         kind: "show",
         source: "inactivity",
         delayMs: INACTIVITY_DRAWER_DELAY_MS,
+        drawerPromptTarget: "globalPushNotifications",
+        dismissedCount: 0,
+        nextRepromptDelay: null,
+        variant: AB_TESTING_VARIANTS.B,
+      });
+    });
+
+    it("skips inactivity when globally opted in (transaction alerts only after action)", () => {
+      const decision = evaluateInactivityTrigger(
+        {
+          permissionStatus: AuthorizationStatus.AUTHORIZED,
+          areNotificationsAllowed: true,
+          pushNotificationsDataOfUser: {
+            lastActionAt: sub(NOW, { months: 7 }).getTime(),
+          },
+          hasCompletedOnboarding: true,
+        },
+        createEvaluationContext({
+          brazePushNotifications: createBrazePushNotificationsWithTransactionsAlerts(),
+        }),
+      );
+
+      expect(decision).toEqual({
+        kind: "skip",
+        source: "inactivity",
+        reason: "globally_opted_in_no_inactivity_drawer",
         dismissedCount: 0,
         nextRepromptDelay: null,
         variant: AB_TESTING_VARIANTS.B,
@@ -300,12 +530,74 @@ describe("notificationsPromptEngine", () => {
   });
 
   describe("helper logic", () => {
+    it("checks whether transactions alerts can be prompted for an action", () => {
+      expect(
+        canPromptTransactionsAlertsForAction("send", [transactionsAlertsCategoryConfig]),
+      ).toBe(true);
+      expect(
+        canPromptTransactionsAlertsForAction("stake", [transactionsAlertsCategoryConfig]),
+      ).toBe(false);
+    });
+
+    it("resolves the prompt target from global vs category opt-in state", () => {
+      expect(
+        getNotificationPromptTarget({
+          permissionStatus: AuthorizationStatus.DENIED,
+          areNotificationsAllowed: true,
+          transactionsAlertsCategory: false,
+        }),
+      ).toBe("globalPushNotifications");
+
+      expect(
+        getNotificationPromptTarget({
+          permissionStatus: AuthorizationStatus.AUTHORIZED,
+          areNotificationsAllowed: true,
+          transactionsAlertsCategory: false,
+        }),
+      ).toBe("transactionsAlertsCategory");
+
+      expect(
+        getNotificationPromptTarget({
+          permissionStatus: AuthorizationStatus.AUTHORIZED,
+          areNotificationsAllowed: true,
+          transactionsAlertsCategory: true,
+        }),
+      ).toBeNull();
+    });
+
+    it("does not prompt the legacy global drawer when globally opted in", () => {
+      expect(
+        shouldPromptOptInDrawerAfterAction({
+          permissionStatus: AuthorizationStatus.AUTHORIZED,
+          areNotificationsAllowed: true,
+          transactionsAlertsCategory: false,
+          pushNotificationsDataOfUser: null,
+        }),
+      ).toBe(false);
+    });
+
+    it("prompts the legacy global drawer when not globally opted in and reprompt delay elapsed", () => {
+      expect(
+        shouldPromptOptInDrawerAfterAction({
+          permissionStatus: AuthorizationStatus.DENIED,
+          areNotificationsAllowed: true,
+          transactionsAlertsCategory: false,
+          pushNotificationsDataOfUser: null,
+          repromptSchedule: defaultBrazePushNotificationsParams.reprompt_schedule,
+          now: NOW,
+        }),
+      ).toBe(true);
+    });
+
     it("keeps using the last reprompt bucket after the schedule is exhausted", () => {
       const nextRepromptDelay = getNextRepromptDelay({
         repromptSchedule: [
           { days: 7, hours: 0, minutes: 0, months: 0, seconds: 0 },
           { days: 30, hours: 0, minutes: 0, months: 0, seconds: 0 },
         ],
+        permissionStatus: AuthorizationStatus.DENIED,
+        areNotificationsAllowed: true,
+        transactionsAlertsCategory: false,
         pushNotificationsDataOfUser: {
           dismissedOptInDrawerAtList: [NOW - 1, NOW - 2, NOW - 3],
         },

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/notificationsPromptEngine.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/notificationsPromptEngine.ts
@@ -3,7 +3,7 @@ import { AuthorizationStatus } from "@react-native-firebase/messaging";
 import type { Features } from "@shared/feature-flags";
 import { AB_TESTING_VARIANTS, type ABTestingVariants } from "../types/variants";
 import type { NotificationsState } from "~/reducers/types";
-import type { DataOfUser } from "../types";
+import type { DataOfUser, NotificationPromptTarget } from "../types";
 
 type BrazePushNotifications = Features["brazePushNotifications"];
 type LwmNewWordingOptInNotificationsDrawer = Features["lwmNewWordingOptInNotificationsDrawer"];
@@ -30,10 +30,12 @@ export type NotificationsPromptSkipReason =
   | "fully_opted_in"
   | "reprompt_delay_not_reached"
   | "action_event_disabled"
+  | "transactions_alerts_not_eligible"
   | "variant_a_only_onboarding"
   | "variant_a_inactivity_disabled"
   | "onboarding_incomplete"
-  | "user_not_inactive";
+  | "user_not_inactive"
+  | "globally_opted_in_no_inactivity_drawer";
 
 type NotificationsPromptDecisionBase<TSource extends NotificationsPromptSource> = {
   source: TSource;
@@ -46,6 +48,7 @@ export type NotificationsPromptShowDecision<TSource extends NotificationsPromptS
   NotificationsPromptDecisionBase<TSource> & {
     kind: "show";
     delayMs: number;
+    drawerPromptTarget: NotificationPromptTarget;
   };
 
 export type NotificationsPromptSkipDecision<TSource extends NotificationsPromptSource> =
@@ -62,14 +65,18 @@ export type InactivityTriggerDecision =
   | NotificationsPromptShowDecision<"inactivity">
   | NotificationsPromptSkipDecision<"inactivity">;
 
-type GetNextRepromptDelayInput = {
+type NotificationsPromptOptInStateInput = {
+  permissionStatus: PermissionStatus;
+  areNotificationsAllowed: boolean | undefined;
+  transactionsAlertsCategory: boolean | undefined;
+};
+
+type GetNextRepromptDelayInput = NotificationsPromptOptInStateInput & {
   repromptSchedule?: NotificationsPromptRepromptDelay[] | null;
   pushNotificationsDataOfUser: DataOfUser | null | undefined;
 };
 
-type AfterActionEligibilityInput = {
-  permissionStatus: PermissionStatus;
-  areNotificationsAllowed: boolean | undefined;
+type AfterActionEligibilityInput = NotificationsPromptOptInStateInput & {
   pushNotificationsDataOfUser: DataOfUser | null | undefined;
   repromptSchedule?: NotificationsPromptRepromptDelay[] | null;
   now?: number;
@@ -83,10 +90,8 @@ type NotificationsPromptEvaluationContext = {
   now?: number;
 };
 
-type EvaluateAfterActionTriggerParams = {
+type EvaluateAfterActionTriggerParams = NotificationsPromptOptInStateInput & {
   source: NotificationsPromptAfterActionSource;
-  permissionStatus: PermissionStatus;
-  areNotificationsAllowed: boolean | undefined;
   pushNotificationsDataOfUser: DataOfUser | null | undefined;
 };
 
@@ -122,45 +127,204 @@ const AFTER_ACTION_SOURCE_TO_EVENT_KEY = {
 
 export const INACTIVITY_DRAWER_DELAY_MS = 1000;
 
+const TRANSACTIONS_ALERTS_PROMPT_TARGET =
+  "transactionsAlertsCategory" as const satisfies NotificationPromptTarget;
+
+type BrazeNotificationsCategoryConfig = NonNullable<
+  BrazePushNotifications["params"]
+>["notificationsCategories"][number];
+
 const getVariant = (wordingFeature: WordingFeature) =>
   wordingFeature?.enabled ? wordingFeature.params?.variant : undefined;
 
 const isVariantA = (wordingFeature: WordingFeature) =>
   getVariant(wordingFeature) === AB_TESTING_VARIANTS.A;
 
-const getDismissedCount = (pushNotificationsDataOfUser: DataOfUser | null | undefined) =>
-  pushNotificationsDataOfUser?.dismissedOptInDrawerAtList?.length ?? 0;
-
-const isFullyOptedIn = (
+const isGloballyOptedIn = (
   permissionStatus: PermissionStatus,
   areNotificationsAllowed: boolean | undefined,
 ) => permissionStatus === AuthorizationStatus.AUTHORIZED && areNotificationsAllowed === true;
 
+export const getNotificationPromptTarget = ({
+  permissionStatus,
+  areNotificationsAllowed,
+  transactionsAlertsCategory,
+}: NotificationsPromptOptInStateInput): NotificationPromptTarget | null => {
+  if (!isGloballyOptedIn(permissionStatus, areNotificationsAllowed)) {
+    return "globalPushNotifications";
+  }
+
+  if (transactionsAlertsCategory === true) {
+    return null;
+  }
+
+  return TRANSACTIONS_ALERTS_PROMPT_TARGET;
+};
+
+export const canPromptTransactionsAlertsForAction = (
+  source: NotificationsPromptAfterActionSource,
+  notificationsCategories: BrazeNotificationsCategoryConfig[] | undefined,
+): boolean => {
+  const transactionsAlertsCategoryConfig = notificationsCategories?.find(
+    category => category.category === TRANSACTIONS_ALERTS_PROMPT_TARGET,
+  );
+
+  if (!transactionsAlertsCategoryConfig?.drawerPromptEnabled) {
+    return false;
+  }
+
+  return transactionsAlertsCategoryConfig.drawerPromptActions?.includes(source) ?? false;
+};
+
+const getDismissedPromptAtList = (
+  pushNotificationsDataOfUser: DataOfUser | null | undefined,
+  promptTarget: NotificationPromptTarget,
+): number[] | undefined => {
+  const dismissedPromptAtListByTarget =
+    pushNotificationsDataOfUser?.dismissedPromptAtListByTarget ?? {};
+
+  if (promptTarget === "globalPushNotifications") {
+    return (
+      dismissedPromptAtListByTarget.globalPushNotifications ??
+      pushNotificationsDataOfUser?.dismissedOptInDrawerAtList
+    );
+  }
+
+  return dismissedPromptAtListByTarget[promptTarget];
+};
+
+const hasRepromptDelayElapsed = ({
+  pushNotificationsDataOfUser,
+  promptTarget,
+  repromptSchedule,
+  now,
+}: {
+  pushNotificationsDataOfUser: DataOfUser | null | undefined;
+  promptTarget: NotificationPromptTarget;
+  repromptSchedule: NotificationsPromptRepromptDelay[] | null | undefined;
+  now: number;
+}): { canShow: boolean; nextRepromptDelay: NotificationsPromptRepromptDelay | null } => {
+  const dismissedPromptAtList = getDismissedPromptAtList(pushNotificationsDataOfUser, promptTarget);
+
+  if (!dismissedPromptAtList?.length) {
+    return { canShow: true, nextRepromptDelay: null };
+  }
+
+  const nextRepromptDelay = (() => {
+    if (!repromptSchedule?.length) {
+      return null;
+    }
+
+    const scheduleIndex = Math.min(dismissedPromptAtList.length - 1, repromptSchedule.length - 1);
+    return repromptSchedule[scheduleIndex];
+  })();
+
+  if (!nextRepromptDelay) {
+    return { canShow: false, nextRepromptDelay: null };
+  }
+
+  const lastDismissedAt = dismissedPromptAtList[dismissedPromptAtList.length - 1];
+  return {
+    canShow: add(lastDismissedAt, nextRepromptDelay).getTime() <= now,
+    nextRepromptDelay,
+  };
+};
+
+const getDismissedCount = (
+  pushNotificationsDataOfUser: DataOfUser | null | undefined,
+  promptTarget: NotificationPromptTarget | null,
+) => {
+  if (!promptTarget) {
+    return 0;
+  }
+
+  return getDismissedPromptAtList(pushNotificationsDataOfUser, promptTarget)?.length ?? 0;
+};
+
 const getDecisionBase = <TSource extends NotificationsPromptSource>(
   source: TSource,
   pushNotificationsDataOfUser: DataOfUser | null | undefined,
+  promptTarget: NotificationPromptTarget | null,
   nextRepromptDelay: NotificationsPromptRepromptDelay | null,
   wordingFeature: WordingFeature,
 ): NotificationsPromptDecisionBase<TSource> => ({
   source,
-  dismissedCount: getDismissedCount(pushNotificationsDataOfUser),
+  dismissedCount: getDismissedCount(pushNotificationsDataOfUser, promptTarget),
   nextRepromptDelay,
   variant: getVariant(wordingFeature),
 });
 
+type BuildAfterActionPromptDecisionInput = {
+  source: NotificationsPromptAfterActionSource;
+  pushNotificationsDataOfUser: DataOfUser | null | undefined;
+  promptTarget: NotificationPromptTarget;
+  repromptSchedule: NotificationsPromptRepromptDelay[] | null | undefined;
+  wordingFeature: WordingFeature;
+  now: number;
+  delayMs: number;
+};
+
+const buildAfterActionPromptDecision = ({
+  source,
+  pushNotificationsDataOfUser,
+  promptTarget,
+  repromptSchedule,
+  wordingFeature,
+  now,
+  delayMs,
+}: BuildAfterActionPromptDecisionInput): AfterActionTriggerDecision => {
+  const { canShow, nextRepromptDelay } = hasRepromptDelayElapsed({
+    pushNotificationsDataOfUser,
+    promptTarget,
+    repromptSchedule,
+    now,
+  });
+  const baseDecision = getDecisionBase(
+    source,
+    pushNotificationsDataOfUser,
+    promptTarget,
+    nextRepromptDelay,
+    wordingFeature,
+  );
+
+  if (!canShow) {
+    return {
+      ...baseDecision,
+      kind: "skip",
+      reason: nextRepromptDelay ? "reprompt_delay_not_reached" : "configuration_missing",
+    };
+  }
+
+  return {
+    ...baseDecision,
+    kind: "show",
+    delayMs,
+    drawerPromptTarget: promptTarget,
+  };
+};
+
 export const getNextRepromptDelay = ({
   repromptSchedule,
   pushNotificationsDataOfUser,
+  permissionStatus,
+  areNotificationsAllowed,
+  transactionsAlertsCategory,
 }: GetNextRepromptDelayInput): NotificationsPromptRepromptDelay | null => {
-  const dismissedOptInDrawerAtList = pushNotificationsDataOfUser?.dismissedOptInDrawerAtList;
-  if (!repromptSchedule?.length || !dismissedOptInDrawerAtList?.length) {
+  const promptTarget = getNotificationPromptTarget({
+    permissionStatus,
+    areNotificationsAllowed,
+    transactionsAlertsCategory,
+  });
+  if (!promptTarget) {
     return null;
   }
 
-  const scheduleIndex = Math.min(
-    dismissedOptInDrawerAtList.length - 1,
-    repromptSchedule.length - 1,
-  );
+  const dismissedPromptAtList = getDismissedPromptAtList(pushNotificationsDataOfUser, promptTarget);
+  if (!repromptSchedule?.length || !dismissedPromptAtList?.length) {
+    return null;
+  }
+
+  const scheduleIndex = Math.min(dismissedPromptAtList.length - 1, repromptSchedule.length - 1);
   return repromptSchedule[scheduleIndex];
 };
 
@@ -171,25 +335,17 @@ export const shouldPromptOptInDrawerAfterAction = ({
   repromptSchedule,
   now = Date.now(),
 }: AfterActionEligibilityInput): boolean => {
-  if (isFullyOptedIn(permissionStatus, areNotificationsAllowed)) {
-    return false;
+  if (!isGloballyOptedIn(permissionStatus, areNotificationsAllowed)) {
+    return hasRepromptDelayElapsed({
+      pushNotificationsDataOfUser,
+      promptTarget: "globalPushNotifications",
+      repromptSchedule,
+      now,
+    }).canShow;
   }
 
-  const dismissedOptInDrawerAtList = pushNotificationsDataOfUser?.dismissedOptInDrawerAtList;
-  if (!dismissedOptInDrawerAtList?.length) {
-    return true;
-  }
-
-  const nextRepromptDelay = getNextRepromptDelay({
-    repromptSchedule,
-    pushNotificationsDataOfUser,
-  });
-  if (!nextRepromptDelay) {
-    return false;
-  }
-
-  const lastDismissedAt = dismissedOptInDrawerAtList[dismissedOptInDrawerAtList.length - 1];
-  return add(lastDismissedAt, nextRepromptDelay).getTime() <= now;
+  // Global opt-in drawer only (legacy hook). Category prompts use evaluateAfterActionTrigger.
+  return false;
 };
 
 export const checkIsInactive = ({
@@ -210,6 +366,7 @@ export const evaluateAfterActionTrigger = (
     source,
     permissionStatus,
     areNotificationsAllowed,
+    transactionsAlertsCategory,
     pushNotificationsDataOfUser,
   }: EvaluateAfterActionTriggerParams,
   {
@@ -220,14 +377,18 @@ export const evaluateAfterActionTrigger = (
     now = Date.now(),
   }: NotificationsPromptEvaluationContext,
 ): AfterActionTriggerDecision => {
-  const nextRepromptDelay = getNextRepromptDelay({
-    repromptSchedule: brazePushNotifications?.params?.reprompt_schedule,
-    pushNotificationsDataOfUser,
+  const repromptSchedule = brazePushNotifications?.params?.reprompt_schedule;
+  const globallyOptedIn = isGloballyOptedIn(permissionStatus, areNotificationsAllowed);
+  const drawerPromptTarget = getNotificationPromptTarget({
+    permissionStatus,
+    areNotificationsAllowed,
+    transactionsAlertsCategory,
   });
   const baseDecision = getDecisionBase(
     source,
     pushNotificationsDataOfUser,
-    nextRepromptDelay,
+    drawerPromptTarget,
+    null,
     wordingFeature,
   );
 
@@ -247,22 +408,6 @@ export const evaluateAfterActionTrigger = (
     return { ...baseDecision, kind: "skip", reason: "drawer_already_pending" };
   }
 
-  if (isFullyOptedIn(permissionStatus, areNotificationsAllowed)) {
-    return { ...baseDecision, kind: "skip", reason: "fully_opted_in" };
-  }
-
-  const dismissedOptInDrawerAtList = pushNotificationsDataOfUser?.dismissedOptInDrawerAtList;
-  if (dismissedOptInDrawerAtList?.length) {
-    if (!nextRepromptDelay) {
-      return { ...baseDecision, kind: "skip", reason: "configuration_missing" };
-    }
-
-    const lastDismissedAt = dismissedOptInDrawerAtList[dismissedOptInDrawerAtList.length - 1];
-    if (add(lastDismissedAt, nextRepromptDelay).getTime() > now) {
-      return { ...baseDecision, kind: "skip", reason: "reprompt_delay_not_reached" };
-    }
-  }
-
   if (source !== "onboarding" && isVariantA(wordingFeature)) {
     return { ...baseDecision, kind: "skip", reason: "variant_a_only_onboarding" };
   }
@@ -277,13 +422,42 @@ export const evaluateAfterActionTrigger = (
     return { ...baseDecision, kind: "skip", reason: "action_event_disabled" };
   }
 
-  return {
-    ...baseDecision,
-    kind: "show",
+  if (!globallyOptedIn) {
+    return buildAfterActionPromptDecision({
+      source,
+      pushNotificationsDataOfUser,
+      promptTarget: "globalPushNotifications",
+      repromptSchedule,
+      wordingFeature,
+      now,
+      delayMs: actionEvent.timer,
+    });
+  }
+
+  if (transactionsAlertsCategory === true) {
+    return { ...baseDecision, kind: "skip", reason: "fully_opted_in" };
+  }
+
+  const isTransactionsAlertsEligible = canPromptTransactionsAlertsForAction(
+    source,
+    brazePushNotifications.params.notificationsCategories,
+  );
+  if (!isTransactionsAlertsEligible) {
+    return { ...baseDecision, kind: "skip", reason: "transactions_alerts_not_eligible" };
+  }
+
+  return buildAfterActionPromptDecision({
+    source,
+    pushNotificationsDataOfUser,
+    promptTarget: TRANSACTIONS_ALERTS_PROMPT_TARGET,
+    repromptSchedule,
+    wordingFeature,
+    now,
     delayMs: actionEvent.timer,
-  };
+  });
 };
 
+/** Global push opt-in only. Transaction alerts are handled in {@link evaluateAfterActionTrigger}. */
 export const evaluateInactivityTrigger = (
   {
     permissionStatus,
@@ -299,9 +473,12 @@ export const evaluateInactivityTrigger = (
     now = Date.now(),
   }: NotificationsPromptEvaluationContext,
 ): InactivityTriggerDecision => {
+  const globallyOptedIn = isGloballyOptedIn(permissionStatus, areNotificationsAllowed);
+  const globalPromptTarget = "globalPushNotifications";
   const baseDecision = getDecisionBase(
     "inactivity",
     pushNotificationsDataOfUser,
+    globallyOptedIn ? null : globalPromptTarget,
     null,
     wordingFeature,
   );
@@ -334,8 +511,12 @@ export const evaluateInactivityTrigger = (
     return { ...baseDecision, kind: "skip", reason: "feature_disabled" };
   }
 
-  if (isFullyOptedIn(permissionStatus, areNotificationsAllowed)) {
-    return { ...baseDecision, kind: "skip", reason: "fully_opted_in" };
+  if (globallyOptedIn) {
+    return {
+      ...baseDecision,
+      kind: "skip",
+      reason: "globally_opted_in_no_inactivity_drawer",
+    };
   }
 
   const isInactive = checkIsInactive({
@@ -350,8 +531,15 @@ export const evaluateInactivityTrigger = (
   }
 
   return {
-    ...baseDecision,
+    ...getDecisionBase(
+      "inactivity",
+      pushNotificationsDataOfUser,
+      globalPromptTarget,
+      null,
+      wordingFeature,
+    ),
     kind: "show",
     delayMs: INACTIVITY_DRAWER_DELAY_MS,
+    drawerPromptTarget: globalPromptTarget,
   };
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Add prompt logic for transactions alerts.

### 📝 Description
This pull request introduces enhanced logic for transaction alert prompts in the mobile app's notifications system. The main changes revolve around supporting category-based notification prompts—specifically for transaction alerts—by updating the prompt logic, state management, and related hooks. Additionally, the PR refines the way prompt dismissals are tracked and improves test coverage for the new logic.

**Notification Prompt Logic Enhancements:**

* Added support for transaction alert notification prompts by introducing the `transactionsAlertsCategory` flag throughout the hooks and prompt evaluation logic, enabling more granular control over which notification categories can trigger prompts. [[1]](diffhunk://#diff-98fa182bd9b694e8ab1b1025e02ec1ab8468b4ed1a9a5149ba3380f3cf43ea40R28) [[2]](diffhunk://#diff-79a3b90a7361cb34bb4cb90710bf528583760b32218cb94fc42a3abff1fa1b4fR17-R24) [[3]](diffhunk://#diff-79a3b90a7361cb34bb4cb90710bf528583760b32218cb94fc42a3abff1fa1b4fR34-R60) [[4]](diffhunk://#diff-43a1c041d0a4ac1e1918454d3e8d5692e354d53a280b969cec5313719b1028fbR32) [[5]](diffhunk://#diff-43a1c041d0a4ac1e1918454d3e8d5692e354d53a280b969cec5313719b1028fbR44) [[6]](diffhunk://#diff-43a1c041d0a4ac1e1918454d3e8d5692e354d53a280b969cec5313719b1028fbR87)

* Updated the prompt scheduling and trigger hooks to handle a new `drawerPromptTarget`, allowing the app to distinguish between global and category-specific notification prompts. [[1]](diffhunk://#diff-750e8de65741cd000884c25bcd9f7e1e1d51148f0610f83d795e56a2caf08067L3-R24) [[2]](diffhunk://#diff-750e8de65741cd000884c25bcd9f7e1e1d51148f0610f83d795e56a2caf08067R34) [[3]](diffhunk://#diff-43a1c041d0a4ac1e1918454d3e8d5692e354d53a280b969cec5313719b1028fbL59-R69) [[4]](diffhunk://#diff-43a1c041d0a4ac1e1918454d3e8d5692e354d53a280b969cec5313719b1028fbL101-R113)

**State Management Improvements:**

* Refactored the opt-out logic in `markUserAsOptOut` to track prompt dismissals per notification category (using `dismissedPromptAtListByTarget`), and updated related hook signatures and usages to accept the permission status and prompt target. [[1]](diffhunk://#diff-6e325c69aef2f6ac77b7023c8c7aba25ea81e0f32c87a6f2015c95150b5916efR11-R19) [[2]](diffhunk://#diff-6e325c69aef2f6ac77b7023c8c7aba25ea81e0f32c87a6f2015c95150b5916efL47-R98) [[3]](diffhunk://#diff-5808ec2e87f4aef2632bbdd0437362caaeb9a59dbc5d0f38ac385efbee53fd79L30-R32) [[4]](diffhunk://#diff-5808ec2e87f4aef2632bbdd0437362caaeb9a59dbc5d0f38ac385efbee53fd79L270-R281) [[5]](diffhunk://#diff-5808ec2e87f4aef2632bbdd0437362caaeb9a59dbc5d0f38ac385efbee53fd79L281-R299) [[6]](diffhunk://#diff-5808ec2e87f4aef2632bbdd0437362caaeb9a59dbc5d0f38ac385efbee53fd79L297-R313)

**Testing and Utilities:**

* Enhanced unit tests for the notification prompt engine to cover category-based prompts and prompt target logic, including new test utilities and configurations for transaction alert categories. [[1]](diffhunk://#diff-ec749dd709c977b48ea8d45b3614585b3431a6d71464b2ea3835c785c4442b59R7-R33) [[2]](diffhunk://#diff-ec749dd709c977b48ea8d45b3614585b3431a6d71464b2ea3835c785c4442b59R48-R70) [[3]](diffhunk://#diff-ec749dd709c977b48ea8d45b3614585b3431a6d71464b2ea3835c785c4442b59R109) [[4]](diffhunk://#diff-ec749dd709c977b48ea8d45b3614585b3431a6d71464b2ea3835c785c4442b59R119) [[5]](diffhunk://#diff-ec749dd709c977b48ea8d45b3614585b3431a6d71464b2ea3835c785c4442b59R132) [[6]](diffhunk://#diff-ec749dd709c977b48ea8d45b3614585b3431a6d71464b2ea3835c785c4442b59R158) [[7]](diffhunk://#diff-ec749dd709c977b48ea8d45b3614585b3431a6d71464b2ea3835c785c4442b59R184)

**Exports and Documentation:**

* Exported new utility functions (`canPromptTransactionsAlertsForAction`, `getNotificationPromptTarget`) to support the new category-based prompt logic.

**Documentation/Changelog:**

* Added a changeset entry describing the addition of prompt logic for transaction alerts.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31498]
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31498]: https://ledgerhq.atlassian.net/browse/LIVE-31498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ