### PR TITLE
[LWD] feat(desktop): hide x-axis on asset detail chart

### DIFF
--- a/.changeset/smooth-planes-flash.md
+++ b/.changeset/smooth-planes-flash.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Hide x-axis on asset detail chart section

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/__integrations__/AssetDetail.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/__integrations__/AssetDetail.integration.test.tsx
@@ -443,7 +443,7 @@ describe("AssetDetail integration", () => {
         });
 
         expect(within(section).queryByTestId("y-axis")).not.toBeInTheDocument();
-        expect(within(section).getByTestId("x-axis")).toBeVisible();
+        expect(within(section).queryByTestId("x-axis")).not.toBeInTheDocument();
         expect(within(section).getAllByTestId("point-group")).toHaveLength(2);
       });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/useChartSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/useChartSectionViewModel.ts
@@ -300,7 +300,7 @@ export function useChartSectionViewModel({
     formatValue,
     tooltipTitle,
     onScrubberPositionChange,
-    showXAxis: true,
+    showXAxis: false,
     showYAxis: false,
     xAxis,
     yAxis,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Asset detail chart section rendering (x-axis no longer displayed)
      - No functional change to chart data or interactions

### 📝 Description

**Problem**: The asset detail chart currently displays the x-axis labels, which adds visual clutter that does not align with the updated design direction.

**Solution**: Set `showXAxis` to `false` in the chart section view model and updated the integration test to assert the new expected behavior (x-axis hidden, matching y-axis which was already hidden).


https://github.com/user-attachments/assets/6454ff6f-70af-4f06-bbd8-c66e69ac9d65

### ❓ Context


- **JIRA or GitHub link**: [LIVE-31779](https://ledgerhq.atlassian.net/browse/LIVE-31779)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31779]: https://ledgerhq.atlassian.net/browse/LIVE-31779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ