### PR TITLE
[LWM] feat(mobile): add altcoin season card

### DIFF
--- a/.changeset/altcoin-season-index-card.md
+++ b/.changeset/altcoin-season-index-card.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add altcoin season index market card on mobile

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -9636,6 +9636,16 @@
     },
     "tileTitle": "Mood"
   },
+  "altcoinSeason": {
+    "title": "Season",
+    "definitionTitle": "Altcoin index",
+    "description": "The Altcoin index shows how Bitcoin is performing compared to alternative cryptocurrencies. The higher the number, the better altcoins are doing compared to Bitcoin.",
+    "disclaimer": "Data is sourced from CoinMarketCap's Fear and Greed Index and provided for informational purposes only.",
+    "levels": {
+      "bitcoin": "Bitcoin",
+      "altcoin": "Altcoin"
+    }
+  },
   "analyticsAllocation": {
     "header": {
       "main": "Analytics"

--- a/apps/ledger-live-mobile/src/mvvm/components/AltcoinSeason/AltcoinSeasonArc.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/AltcoinSeason/AltcoinSeasonArc.tsx
@@ -1,0 +1,132 @@
+import React, { useEffect, useState } from "react";
+import { View } from "react-native";
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useDerivedValue,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
+import { scheduleOnRN } from "react-native-worklets";
+import Svg, { Circle, Defs, LinearGradient, Path, Stop, Text as SvgText } from "react-native-svg";
+import { useTheme } from "@ledgerhq/lumen-ui-rnative/styles";
+
+const WIDTH = 68;
+const HEIGHT = 44;
+const STROKE_WIDTH = 6;
+const CX = 34;
+const CY = 34;
+const R = 28;
+const CURSOR_RADIUS = 5;
+const CURSOR_STROKE_WIDTH = 1.5;
+const ANIMATION_DURATION = 1200;
+
+type Props = Readonly<{
+  value: number;
+}>;
+
+export function AltcoinSeasonArc({ value }: Props) {
+  const { theme } = useTheme();
+  const animatedValue = useSharedValue(0);
+  const [displayValue, setDisplayValue] = useState(0);
+  const lastDisplayValue = useSharedValue(0);
+
+  useEffect(() => {
+    animatedValue.value = withTiming(value, {
+      duration: ANIMATION_DURATION,
+      easing: Easing.out(Easing.cubic),
+    });
+  }, [value, animatedValue]);
+
+  const startX = 6;
+  const startY = 40;
+  const endX = 62;
+  const endY = 40;
+
+  const startAngle = Math.atan2(startY - CY, startX - CX);
+  const endAngle = Math.atan2(endY - CY, endX - CX);
+
+  let angleRange = endAngle - startAngle;
+  if (angleRange < 0) {
+    angleRange += 2 * Math.PI;
+  }
+
+  const cursorPosition = useDerivedValue(() => {
+    "worklet";
+    const currentAngle = startAngle + (animatedValue.value / 100) * angleRange;
+    return {
+      x: CX + R * Math.cos(currentAngle),
+      y: CY + R * Math.sin(currentAngle),
+    };
+  }, [animatedValue, startAngle, angleRange]);
+
+  useDerivedValue(() => {
+    "worklet";
+    const rounded = Math.round(animatedValue.value);
+    if (rounded !== lastDisplayValue.value) {
+      lastDisplayValue.value = rounded;
+      scheduleOnRN(setDisplayValue, rounded);
+    }
+  }, [animatedValue, lastDisplayValue]);
+
+  const cursorStyle = useAnimatedStyle(() => {
+    "worklet";
+    return {
+      position: "absolute" as const,
+      left: cursorPosition.value.x - CURSOR_RADIUS - CURSOR_STROKE_WIDTH,
+      top: cursorPosition.value.y - CURSOR_RADIUS - CURSOR_STROKE_WIDTH,
+    };
+  }, [cursorPosition]);
+
+  const cursorSize = (CURSOR_RADIUS + CURSOR_STROKE_WIDTH) * 2;
+
+  return (
+    <View style={{ width: WIDTH, height: HEIGHT, position: "relative" }}>
+      <Svg width={WIDTH} height={HEIGHT} viewBox={`0 0 ${WIDTH} ${HEIGHT}`}>
+        <Defs>
+          <LinearGradient
+            id="altcoinSeasonGradient"
+            x1="4"
+            y1="22"
+            x2="64"
+            y2="22"
+            gradientUnits="userSpaceOnUse"
+          >
+            <Stop offset="0" stopColor="#FF9416" />
+            <Stop offset="1" stopColor="#3F51B5" />
+          </LinearGradient>
+        </Defs>
+        <Path
+          d="M6 40C4.7 36.7 4 33.1 4 29.3C4 12.7 17.4 4 34 4C50.6 4 64 12.7 64 29.3C64 33.1 63.3 36.7 62 40"
+          stroke="url(#altcoinSeasonGradient)"
+          strokeWidth={STROKE_WIDTH}
+          strokeLinecap="round"
+          fill="none"
+        />
+        <SvgText
+          transform={[{ translateX: CX }, { translateY: CY - 1 }]}
+          fill={theme.colors.text.base}
+          fontSize={20}
+          fontWeight="600"
+          textAnchor="middle"
+          alignmentBaseline="middle"
+          fontFamily="Inter"
+        >
+          {displayValue}
+        </SvgText>
+      </Svg>
+      <Animated.View style={cursorStyle}>
+        <Svg width={cursorSize} height={cursorSize} viewBox={`0 0 ${cursorSize} ${cursorSize}`}>
+          <Circle
+            cx={CURSOR_RADIUS + CURSOR_STROKE_WIDTH}
+            cy={CURSOR_RADIUS + CURSOR_STROKE_WIDTH}
+            r={CURSOR_RADIUS}
+            fill="#FFF"
+            stroke="#000"
+            strokeWidth={CURSOR_STROKE_WIDTH}
+          />
+        </Svg>
+      </Animated.View>
+    </View>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/components/AltcoinSeason/AltcoinSeasonView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/AltcoinSeason/AltcoinSeasonView.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { useTranslation } from "~/context/Locale";
+import { Box, Pressable, Skeleton, Text } from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import MarketInsightDefinitionSheet from "LLM/components/MarketInsightDefinitionSheet";
+import type { AltcoinSeasonViewProps } from "./types";
+import { AltcoinSeasonArc } from "./AltcoinSeasonArc";
+
+const ALTCOIN_SEASON_CARD_HEIGHT = 68;
+
+function getAltcoinSeasonTranslationKey(value: number) {
+  return value < 50 ? "altcoinSeason.levels.bitcoin" : "altcoinSeason.levels.altcoin";
+}
+
+export function AltcoinSeasonView({
+  data,
+  isLoading,
+  isError,
+  isDrawerOpen,
+  handleOpenDrawer,
+  handleCloseDrawer,
+  width,
+}: AltcoinSeasonViewProps) {
+  const { t } = useTranslation();
+
+  if (isLoading) {
+    return (
+      <Skeleton
+        testID="altcoin-season-card-skeleton"
+        lx={{ borderRadius: "md" }}
+        style={{ width, height: ALTCOIN_SEASON_CARD_HEIGHT }}
+      />
+    );
+  }
+
+  if (!data || isError) return null;
+
+  const { value } = data;
+
+  return (
+    <>
+      <Pressable
+        accessibilityRole="button"
+        onPress={handleOpenDrawer}
+        testID="altcoin-season-card"
+        lx={cardStyle}
+        style={{ width, height: ALTCOIN_SEASON_CARD_HEIGHT }}
+      >
+        <Box lx={contentStyle}>
+          <Box lx={{ flexShrink: 1 }}>
+            <Text typography="body3" numberOfLines={1} lx={{ color: "muted", marginBottom: "s4" }}>
+              {t("altcoinSeason.title")}
+            </Text>
+            <Text typography="body1SemiBold" numberOfLines={1} lx={{ color: "base" }}>
+              {t(getAltcoinSeasonTranslationKey(value))}
+            </Text>
+          </Box>
+          <Box lx={{ flexShrink: 0 }}>
+            <AltcoinSeasonArc value={value} />
+          </Box>
+        </Box>
+      </Pressable>
+      <MarketInsightDefinitionSheet
+        title={t("altcoinSeason.definitionTitle")}
+        description={t("altcoinSeason.description")}
+        disclaimer={t("altcoinSeason.disclaimer")}
+        isOpen={isDrawerOpen}
+        onClose={handleCloseDrawer}
+      />
+    </>
+  );
+}
+
+const cardStyle: LumenViewStyle = {
+  backgroundColor: "muted",
+  borderRadius: "md",
+  padding: "s12",
+  justifyContent: "center",
+};
+
+const contentStyle: LumenViewStyle = {
+  flexDirection: "row",
+  justifyContent: "space-between",
+  alignItems: "center",
+  gap: "s12",
+};

--- a/apps/ledger-live-mobile/src/mvvm/components/AltcoinSeason/__integrations__/AltcoinSeason.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/AltcoinSeason/__integrations__/AltcoinSeason.test.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import { server } from "@tests/server";
+import { http, HttpResponse } from "msw";
+import { AltcoinSeason } from "../index";
+
+const API_ENDPOINT = "https://proxycmc.api.live.ledger.com/v3/altcoin-season-index/latest";
+
+const createMockResponse = (value: number) => ({
+  data: {
+    altcoin_index: value,
+    altcoin_marketcap: 1_200_000_000_000,
+  },
+  status: {
+    timestamp: "2026-01-14T12:00:00Z",
+    error_code: 0,
+    error_message: null,
+    elapsed: 10,
+    credit_count: 1,
+    notice: null,
+  },
+});
+
+describe("AltcoinSeason Integration", () => {
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  it.each([
+    { value: 49, label: "Bitcoin" },
+    { value: 50, label: "Altcoin" },
+    { value: 70, label: "Altcoin" },
+  ])("should render $label when value is $value", async ({ value, label }) => {
+    server.use(http.get(API_ENDPOINT, () => HttpResponse.json(createMockResponse(value))));
+
+    render(<AltcoinSeason width={276} />);
+
+    expect(await screen.findByText("Season")).toBeVisible();
+    expect(await screen.findByText(label)).toBeVisible();
+  });
+
+  it("should open definition drawer when card is pressed", async () => {
+    server.use(http.get(API_ENDPOINT, () => HttpResponse.json(createMockResponse(70))));
+
+    const { user } = render(<AltcoinSeason width={276} />);
+
+    const card = await screen.findByText("Altcoin");
+    await user.press(card);
+
+    expect(screen.getByText("Altcoin index")).toBeVisible();
+    expect(
+      screen.getByText(
+        /The Altcoin index shows how Bitcoin is performing compared to alternative cryptocurrencies./i,
+      ),
+    ).toBeVisible();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/AltcoinSeason/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/AltcoinSeason/index.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { useAltcoinSeasonViewModel } from "./useAltcoinSeasonViewModel";
+import { AltcoinSeasonView } from "./AltcoinSeasonView";
+import type { AltcoinSeasonProps } from "./types";
+
+export function AltcoinSeason({ width }: AltcoinSeasonProps) {
+  const viewModel = useAltcoinSeasonViewModel();
+  return <AltcoinSeasonView {...viewModel} width={width} />;
+}

--- a/apps/ledger-live-mobile/src/mvvm/components/AltcoinSeason/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/AltcoinSeason/types.ts
@@ -1,0 +1,16 @@
+import type { AltcoinSeasonIndex } from "@ledgerhq/live-common/cmc-client/state-manager/types";
+
+export interface AltcoinSeasonViewModel {
+  readonly data: AltcoinSeasonIndex | undefined;
+  readonly isLoading: boolean;
+  readonly isError: boolean | undefined;
+  readonly isDrawerOpen: boolean;
+  readonly handleOpenDrawer: () => void;
+  readonly handleCloseDrawer: () => void;
+}
+
+export type AltcoinSeasonProps = Readonly<{
+  width?: number;
+}>;
+
+export type AltcoinSeasonViewProps = AltcoinSeasonViewModel & AltcoinSeasonProps;

--- a/apps/ledger-live-mobile/src/mvvm/components/AltcoinSeason/useAltcoinSeasonViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/AltcoinSeason/useAltcoinSeasonViewModel.ts
@@ -1,0 +1,41 @@
+import { useCallback, useState } from "react";
+import {
+  FIFTEEN_MINUTES_IN_MS,
+  useGetAltcoinSeasonIndexLatestQuery,
+} from "@ledgerhq/live-common/cmc-client/state-manager/api";
+import { track } from "~/analytics";
+import type { AltcoinSeasonViewModel } from "./types";
+
+const BUTTON_NAME = "altcoin_index_definition";
+
+function trackDefinitionPressed() {
+  track("button_clicked", {
+    button: BUTTON_NAME,
+  });
+}
+
+export function useAltcoinSeasonViewModel(): AltcoinSeasonViewModel {
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+
+  const { data, isLoading, isError } = useGetAltcoinSeasonIndexLatestQuery(undefined, {
+    pollingInterval: FIFTEEN_MINUTES_IN_MS,
+  });
+
+  const handleOpenDrawer = useCallback(() => {
+    trackDefinitionPressed();
+    setIsDrawerOpen(true);
+  }, []);
+
+  const handleCloseDrawer = useCallback(() => {
+    setIsDrawerOpen(false);
+  }, []);
+
+  return {
+    data,
+    isLoading,
+    isError,
+    isDrawerOpen,
+    handleOpenDrawer,
+    handleCloseDrawer,
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/components/MarketInsightDefinitionSheet/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/MarketInsightDefinitionSheet/index.tsx
@@ -1,0 +1,60 @@
+import React, { memo } from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { BottomSheetHeader, BottomSheetView, Text } from "@ledgerhq/lumen-ui-rnative";
+import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
+import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
+import QueuedDrawerGorhom, {
+  BottomSheetView as GorhomBottomSheetView,
+} from "LLM/components/QueuedDrawer/temp/QueuedDrawerGorhom";
+
+type Props = Readonly<{
+  title: string;
+  description: string;
+  disclaimer: string;
+  isOpen: boolean;
+  onClose: () => void;
+}>;
+
+function MarketInsightDefinitionSheet({ title, description, disclaimer, isOpen, onClose }: Props) {
+  const { bottom: bottomInset } = useSafeAreaInsets();
+  const { isEnabled } = useWalletFeaturesConfig("mobile");
+
+  const content = (
+    <>
+      <Text typography="heading2SemiBold" lx={{ color: "base", marginBottom: "s12" }}>
+        {title}
+      </Text>
+      <Text typography="body1" lx={{ color: "base" }}>
+        {description}
+      </Text>
+      <Text typography="body4" lx={{ color: "muted", marginTop: "s16" }}>
+        {disclaimer}
+      </Text>
+    </>
+  );
+
+  if (isEnabled) {
+    return (
+      <QueuedDrawerBottomSheet
+        isRequestingToBeOpened={isOpen}
+        onClose={onClose}
+        enableDynamicSizing
+      >
+        <BottomSheetView style={{ paddingBottom: bottomInset + 24 }}>
+          <BottomSheetHeader />
+          {content}
+        </BottomSheetView>
+      </QueuedDrawerBottomSheet>
+    );
+  }
+
+  return (
+    <QueuedDrawerGorhom isRequestingToBeOpened={isOpen} onClose={onClose} enableDynamicSizing>
+      <GorhomBottomSheetView style={{ paddingBottom: bottomInset + 24, paddingTop: 32 }}>
+        {content}
+      </GorhomBottomSheetView>
+    </QueuedDrawerGorhom>
+  );
+}
+
+export default memo(MarketInsightDefinitionSheet);

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/MarketScreenView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/MarketScreenView.tsx
@@ -4,6 +4,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { TrackScreen } from "~/analytics";
+import { AltcoinSeason } from "LLM/components/AltcoinSeason";
 import { FearAndGreed } from "LLM/components/FearAndGreed";
 import { MARKET_SCREEN_TEST_IDS } from "./testIds";
 import type { MarketScreenHighlightCard, MarketScreenViewModel } from "./useMarketScreenViewModel";
@@ -33,6 +34,7 @@ export function MarketScreenView({ cardWidth, snapToInterval, highlightCards }: 
         {item.type === "fearAndGreed" ? (
           <FearAndGreed appearance="expanded" width={cardWidth} />
         ) : null}
+        {item.type === "altcoinSeason" ? <AltcoinSeason width={cardWidth} /> : null}
       </Box>
     ),
     [cardWidth],

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketScreenViewModel.ts
@@ -6,7 +6,7 @@ const CARD_GAP = 8;
 
 export type MarketScreenHighlightCard = {
   key: string;
-  type: "fearAndGreed";
+  type: "fearAndGreed" | "altcoinSeason";
 };
 
 export type MarketScreenViewModel = {
@@ -27,7 +27,10 @@ export function useMarketScreenViewModel(): MarketScreenViewModel {
       cardWidth,
       cardGap: CARD_GAP,
       snapToInterval: cardWidth + CARD_GAP,
-      highlightCards: [{ key: "market-highlight-fear-and-greed", type: "fearAndGreed" }],
+      highlightCards: [
+        { key: "market-highlight-fear-and-greed", type: "fearAndGreed" },
+        { key: "market-highlight-altcoin-season", type: "altcoinSeason" },
+      ],
     };
   }, [width]);
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Added an integration test for the Altcoin Season card and drawer. Local Jest is still blocked before running specs by the stale `ledger-live-common/lib-es` XRP import noted in the parent PR; targeted oxlint and mobile typecheck pass._
- [x] **Impact of the changes:**
      - Market screen asset discoverability highlight rail
      - Altcoin Season data fetching and display
      - Altcoin index definition drawer and analytics tracking

### 📝 Description

This PR adds the Altcoin Season index card to the mobile Market screen stack.

It reuses the market insight card, gauge, skeleton, and drawer primitives from the parent PR, wires `useGetAltcoinSeasonIndexLatestQuery`, and maps the index thresholds to `Bitcoin` for `0-49` and `Altcoin` for `50-100`.

https://github.com/user-attachments/assets/9e39acf8-834e-469d-ad9f-669d88b6db2e



### ❓ Context

- **JIRA or GitHub link**: [LIVE-30031](https://ledgerhq.atlassian.net/browse/LIVE-30031)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-30031]: https://ledgerhq.atlassian.net/browse/LIVE-30031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ