### PR TITLE
[LWM] fix(mobile): add account network selection

### DIFF
--- a/.changeset/lwm-add-account-network-selection.md
+++ b/.changeset/lwm-add-account-network-selection.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Open the Modular Drawer from the Asset Detail "Add account" button so multi-network assets (e.g. USDT, ETH) show a network-selection step, while single-network assets (e.g. BTC) go straight to the device flow

--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/hooks/useOpenAddAccountDrawer.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/hooks/useOpenAddAccountDrawer.ts
@@ -1,0 +1,42 @@
+import { useCallback } from "react";
+import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { useModularDrawerController } from "LLM/features/ModularDrawer";
+
+type Props = {
+  currency?: CryptoOrTokenCurrency;
+  /**
+   * Pre-selection list of ledger currency ids forwarded to the Modular Drawer.
+   * When non-empty, takes priority over `currency` to pre-select every network
+   * of a multi-network asset (e.g. USDT on Ethereum + Tron + others) so the
+   * drawer can offer the network-selection step.
+   */
+  currencyIds?: string[];
+  sourceScreenName: string;
+};
+
+/**
+ * Opens the Modular Drawer for the add-account flow, mirroring
+ * `useOpenReceiveDrawer`. Unlike receive, account selection is disabled so the
+ * drawer routes to the device/add-account flow once an asset (and network when
+ * relevant) is selected. A single-network asset (e.g. BTC) skips straight to
+ * the device flow.
+ */
+export function useOpenAddAccountDrawer({ currency, currencyIds, sourceScreenName }: Props) {
+  const { openDrawer } = useModularDrawerController();
+
+  const handleOpenAddAccountDrawer = useCallback(() => {
+    const hasCurrencyIds = !!currencyIds?.length;
+    const currencies = hasCurrencyIds ? currencyIds : currency ? [currency.id] : [];
+    return openDrawer({
+      currencies,
+      flow: "add_account",
+      source: sourceScreenName,
+      areCurrenciesFiltered: hasCurrencyIds || !!currency,
+      enableAccountSelection: false,
+    });
+  }, [currency, currencyIds, sourceScreenName, openDrawer]);
+
+  return {
+    handleOpenAddAccountDrawer,
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
@@ -87,6 +87,7 @@ export function AssetDetailView({
             currency={currency}
             distributionItem={distributionItem}
             isLoading={isLoading}
+            ledgerIds={ledgerIds}
           />
           <MarketData
             currency={currency}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/__tests__/useAddressesViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/__tests__/useAddressesViewModel.test.ts
@@ -11,15 +11,20 @@ import {
 } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
 import { track } from "~/analytics";
 import { NavigatorName, ScreenName } from "~/const";
-import { AddAccountContexts } from "LLM/features/Accounts/screens/AddAccount/enums";
 import type { State } from "~/reducers/types";
 import { useAddressesViewModel } from "../useAddressesViewModel";
 
 const mockNavigate = jest.fn();
+const mockOpenDrawer = jest.fn();
 
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
   useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+jest.mock("LLM/features/ModularDrawer", () => ({
+  ...jest.requireActual("LLM/features/ModularDrawer"),
+  useModularDrawerController: () => ({ openDrawer: mockOpenDrawer }),
 }));
 
 function withRawAccounts(accounts: Account[]) {
@@ -397,7 +402,7 @@ describe("useAddressesViewModel", () => {
   });
 
   describe("onAddAccount", () => {
-    it("navigates to device selection and fires analytics", () => {
+    it("opens the modular drawer for the add-account flow and fires analytics", () => {
       const btcAccounts = [
         genAccount("bitcoin-0", { currency: mockBtcCryptoCurrency, operationsSize: 0 }),
       ];
@@ -413,16 +418,54 @@ describe("useAddressesViewModel", () => {
 
       act(() => result.current.onAddAccount());
 
-      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.DeviceSelection, {
-        screen: ScreenName.SelectDevice,
-        params: {
-          currency: mockBtcCryptoCurrency,
-          context: AddAccountContexts.AddAccounts,
-        },
+      expect(mockOpenDrawer).toHaveBeenCalledWith({
+        currencies: [mockBtcCryptoCurrency.id],
+        flow: "add_account",
+        source: "Asset Detail",
+        areCurrenciesFiltered: true,
+        enableAccountSelection: false,
       });
+      expect(mockNavigate).not.toHaveBeenCalled();
       expect(track).toHaveBeenCalledWith("button_clicked", {
         button: "add_account",
         currency: "bitcoin",
+        page: "Asset Detail",
+      });
+    });
+
+    it("forwards the multi-network ledgerIds list so the network step can be shown", () => {
+      const ledgerIds = [usdtEthToken.id, usdtAlgoToken.id];
+
+      const { result } = renderHook(() =>
+        useAddressesViewModel(usdtEthToken, undefined, ledgerIds),
+      );
+
+      act(() => result.current.onAddAccount());
+
+      expect(mockOpenDrawer).toHaveBeenCalledWith({
+        currencies: ledgerIds,
+        flow: "add_account",
+        source: "Asset Detail",
+        areCurrenciesFiltered: true,
+        enableAccountSelection: false,
+      });
+    });
+
+    it("falls back to the currency id when no ledgerIds are provided", () => {
+      const { result } = renderHook(() => useAddressesViewModel(usdcToken, undefined));
+
+      act(() => result.current.onAddAccount());
+
+      expect(mockOpenDrawer).toHaveBeenCalledWith({
+        currencies: [usdcToken.id],
+        flow: "add_account",
+        source: "Asset Detail",
+        areCurrenciesFiltered: true,
+        enableAccountSelection: false,
+      });
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "add_account",
+        currency: usdcToken.id,
         page: "Asset Detail",
       });
     });
@@ -432,27 +475,8 @@ describe("useAddressesViewModel", () => {
 
       act(() => result.current.onAddAccount());
 
-      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(mockOpenDrawer).not.toHaveBeenCalled();
       expect(track).not.toHaveBeenCalled();
-    });
-
-    it("navigates with parentCurrency when currency is a token", () => {
-      const { result } = renderHook(() => useAddressesViewModel(usdcToken, undefined));
-
-      act(() => result.current.onAddAccount());
-
-      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.DeviceSelection, {
-        screen: ScreenName.SelectDevice,
-        params: {
-          currency: mockEthCryptoCurrency,
-          context: AddAccountContexts.AddAccounts,
-        },
-      });
-      expect(track).toHaveBeenCalledWith("button_clicked", {
-        button: "add_account",
-        currency: usdcToken.id,
-        page: "Asset Detail",
-      });
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/index.tsx
@@ -8,9 +8,10 @@ type Props = Readonly<{
   currency: AssetDetailCurrencyProps;
   distributionItem: DistributionItem | undefined;
   isLoading: boolean;
+  ledgerIds?: string[];
 }>;
 
-export function Addresses({ currency, distributionItem, isLoading }: Props) {
-  const viewModel = useAddressesViewModel(currency, distributionItem);
+export function Addresses({ currency, distributionItem, isLoading, ledgerIds }: Props) {
+  const viewModel = useAddressesViewModel(currency, distributionItem, ledgerIds);
   return <AddressesView {...viewModel} isLoading={isLoading} />;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/useAddressesViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/useAddressesViewModel.ts
@@ -10,7 +10,7 @@ import { accountsSelector } from "~/reducers/accounts";
 import { useSortAccountsComparator } from "~/actions/general";
 import { NavigatorName, ScreenName } from "~/const";
 import { track } from "~/analytics";
-import { AddAccountContexts } from "LLM/features/Accounts/screens/AddAccount/enums";
+import { useOpenAddAccountDrawer } from "LLM/features/Accounts/hooks/useOpenAddAccountDrawer";
 import { buildMainAccountByIdMap } from "@ledgerhq/asset-aggregation/assetDistribution/index";
 
 export const MAX_PREVIEW_ADDRESSES = 5;
@@ -26,11 +26,18 @@ export type AddressAccountData = Readonly<{
 export function useAddressesViewModel(
   currency: AssetDetailCurrencyProps,
   distributionItem: DistributionItem | undefined,
+  ledgerIds?: string[],
 ) {
   const navigation = useNavigation();
   const walletState = useSelector(walletSelector);
   const allAccounts = useSelector(accountsSelector);
   const comparator = useSortAccountsComparator();
+
+  const { handleOpenAddAccountDrawer } = useOpenAddAccountDrawer({
+    currency: currency ?? undefined,
+    currencyIds: ledgerIds,
+    sourceScreenName: "Asset Detail",
+  });
 
   const mainAccountById = useMemo(() => buildMainAccountByIdMap(allAccounts), [allAccounts]);
 
@@ -80,15 +87,8 @@ export function useAddressesViewModel(
       currency: currency.id,
       page: "Asset Detail",
     });
-    const cryptoCurrency = currency.type === "TokenCurrency" ? currency.parentCurrency : currency;
-    navigation.navigate(NavigatorName.DeviceSelection, {
-      screen: ScreenName.SelectDevice,
-      params: {
-        currency: cryptoCurrency,
-        context: AddAccountContexts.AddAccounts,
-      },
-    });
-  }, [navigation, currency]);
+    handleOpenAddAccountDrawer();
+  }, [currency, handleOpenAddAccountDrawer]);
 
   const onSeeAll = useCallback(() => {
     if (!currency) return;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Asset Detail → "Add" on a multi-network asset (e.g. USDT, ETH): the network-selection step should appear before the device flow.
  - Asset Detail → "Add" on a single-network asset (e.g. BTC): should go straight to the device/add-account flow with no extra step.
  - Completing the flow afterwards (device selection → scan → import accounts) still works, including token assets creating the correct token account.

### 📝 Description

On the Asset Detail screen, the "Add" button in the Accounts section navigated **directly** to the device-connection flow ("Connect Device – Step 2 of 3"), skipping network selection. For multi-network assets (e.g. USDT, ETH) the user had no way to choose the network — unlike the Receive flow, which already offers it.

This PR makes the "Add" button open the Modular Drawer like Receive does. A new reusable `useOpenAddAccountDrawer` hook (mirroring `useOpenReceiveDrawer`) opens the drawer with `flow: "add_account"` and `enableAccountSelection: false`, and the existing multi-network `ledgerIds` list is threaded down into the Addresses section. As a result, multi-network assets land directly on the network list, while single-network assets (BTC) skip straight to the device/add-account flow.


https://github.com/user-attachments/assets/7200b9cb-d018-4e56-94a1-eb95ae1a33f3



### ❓ Context

- **JIRA or GitHub link**: [LIVE-31773](https://ledgerhq.atlassian.net/browse/LIVE-31773)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31773]: https://ledgerhq.atlassian.net/browse/LIVE-31773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ