### PR TITLE
[LWDM] feat(mobile): add total market cap card

### DIFF
--- a/.changeset/market-cap-insight-card.md
+++ b/.changeset/market-cap-insight-card.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Add total market cap market insight card on mobile

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -9653,6 +9653,10 @@
       "altcoin": "Altcoin"
     }
   },
+  "marketCapCard": {
+    "title": "Total market cap",
+    "description": "The total market cap represents the market capitalization of all cryptocurrencies combined."
+  },
   "analyticsAllocation": {
     "header": {
       "main": "Analytics"

--- a/apps/ledger-live-mobile/src/mvvm/components/MarketCapCard/MarketCapCardView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/MarketCapCard/MarketCapCardView.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { useTranslation } from "~/context/Locale";
+import { Box, Pressable, Skeleton, Text, Trend } from "@ledgerhq/lumen-ui-rnative";
+import { useTheme, type LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import MarketInsightDefinitionSheet from "LLM/components/MarketInsightDefinitionSheet";
+import type { MarketCapCardViewProps } from "./types";
+
+const MARKET_CAP_CARD_HEIGHT = 68;
+
+export function MarketCapCardView({
+  value,
+  changePercentage,
+  isLoading,
+  isError,
+  isDrawerOpen,
+  handleOpenDrawer,
+  handleCloseDrawer,
+  width,
+}: MarketCapCardViewProps) {
+  const { t } = useTranslation();
+  const { theme } = useTheme();
+
+  if (isLoading) {
+    return (
+      <Skeleton
+        testID="market-cap-card-skeleton"
+        lx={{ borderRadius: "md" }}
+        style={{ width, height: MARKET_CAP_CARD_HEIGHT }}
+      />
+    );
+  }
+
+  if (isError) return null;
+
+  return (
+    <>
+      <Pressable
+        accessibilityRole="button"
+        onPress={handleOpenDrawer}
+        testID="market-cap-card"
+        lx={cardStyle}
+        style={({ pressed }) => ({
+          width,
+          height: MARKET_CAP_CARD_HEIGHT,
+          backgroundColor: pressed ? theme.colors.bg.mutedPressed : theme.colors.bg.muted,
+        })}
+      >
+        <Text typography="body3" numberOfLines={1} lx={{ color: "muted", marginBottom: "s4" }}>
+          {t("marketCapCard.title")}
+        </Text>
+        <Box lx={valueStyle}>
+          <Text typography="body1SemiBold" numberOfLines={1} lx={{ color: "base" }}>
+            {value}
+          </Text>
+          {changePercentage !== undefined ? <Trend value={changePercentage} size="md" /> : null}
+        </Box>
+      </Pressable>
+      <MarketInsightDefinitionSheet
+        title={t("marketCapCard.title")}
+        description={t("marketCapCard.description")}
+        isOpen={isDrawerOpen}
+        onClose={handleCloseDrawer}
+      />
+    </>
+  );
+}
+
+const cardStyle: LumenViewStyle = {
+  borderRadius: "md",
+  padding: "s12",
+  justifyContent: "center",
+};
+
+const valueStyle: LumenViewStyle = {
+  flexDirection: "row",
+  alignItems: "center",
+  gap: "s8",
+};

--- a/apps/ledger-live-mobile/src/mvvm/components/MarketCapCard/__integrations__/MarketCapCard.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/MarketCapCard/__integrations__/MarketCapCard.test.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { render, screen, within } from "@tests/test-renderer";
+import { server } from "@tests/server";
+import { http, HttpResponse } from "msw";
+import { MarketCapCard } from "../index";
+
+const API_ENDPOINT = "https://countervalues.live.ledger.com/v3/markets/global";
+
+// percentageChanges are ratios (0.1 => +10.00%).
+const createMockResponse = (marketCap: number, dailyChangeRatio: number) => ({
+  marketCap,
+  percentageChanges: {
+    "1d": dailyChangeRatio,
+    "1w": 0,
+    "1m": 0,
+    "6m": 0,
+    "1y": 0,
+  },
+});
+
+describe("MarketCapCard Integration", () => {
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  it("should render total market cap and 24h variation", async () => {
+    server.use(
+      http.get(API_ENDPOINT, () => HttpResponse.json(createMockResponse(3_000_000_000_000, 0.1))),
+    );
+
+    render(<MarketCapCard width={276} />);
+
+    const card = within(await screen.findByTestId("market-cap-card"));
+    expect(card.getByText("Total market cap")).toBeVisible();
+    expect(card.getByText(/3.*T/i)).toBeVisible();
+    expect(card.getByText("10.00%")).toBeVisible();
+  });
+
+  it("should open definition drawer when card is pressed", async () => {
+    server.use(
+      http.get(API_ENDPOINT, () => HttpResponse.json(createMockResponse(3_000_000_000_000, 0.1))),
+    );
+
+    const { user } = render(<MarketCapCard width={276} />);
+
+    await user.press(await screen.findByTestId("market-cap-card"));
+
+    expect(
+      screen.getByText(
+        "The total market cap represents the market capitalization of all cryptocurrencies combined.",
+      ),
+    ).toBeVisible();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/MarketCapCard/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/MarketCapCard/index.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { useMarketCapCardViewModel } from "./useMarketCapCardViewModel";
+import { MarketCapCardView } from "./MarketCapCardView";
+import type { MarketCapCardProps } from "./types";
+
+export function MarketCapCard({ width }: MarketCapCardProps) {
+  const viewModel = useMarketCapCardViewModel();
+  return <MarketCapCardView {...viewModel} width={width} />;
+}

--- a/apps/ledger-live-mobile/src/mvvm/components/MarketCapCard/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/MarketCapCard/types.ts
@@ -1,0 +1,15 @@
+export interface MarketCapCardViewModel {
+  readonly value: string;
+  readonly changePercentage: number | undefined;
+  readonly isLoading: boolean;
+  readonly isError: boolean | undefined;
+  readonly isDrawerOpen: boolean;
+  readonly handleOpenDrawer: () => void;
+  readonly handleCloseDrawer: () => void;
+}
+
+export type MarketCapCardProps = Readonly<{
+  width?: number;
+}>;
+
+export type MarketCapCardViewProps = MarketCapCardViewModel & MarketCapCardProps;

--- a/apps/ledger-live-mobile/src/mvvm/components/MarketCapCard/useMarketCapCardViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/MarketCapCard/useMarketCapCardViewModel.ts
@@ -1,0 +1,52 @@
+import { useCallback, useState } from "react";
+import { useGlobalMarketData } from "@ledgerhq/live-common/market/hooks/useMarketDataProvider";
+import { useSelector } from "~/context/hooks";
+import { counterValueCurrencySelector } from "~/reducers/settings";
+import { useLocale, useTranslation } from "~/context/Locale";
+import { track } from "~/analytics";
+import { counterValueFormatter } from "LLM/features/Market/utils";
+import type { MarketCapCardViewModel } from "./types";
+
+const BUTTON_NAME = "market_cap_definition";
+
+function trackDefinitionPressed() {
+  track("button_clicked", {
+    button: BUTTON_NAME,
+  });
+}
+
+export function useMarketCapCardViewModel(): MarketCapCardViewModel {
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const { t } = useTranslation();
+  const { locale } = useLocale();
+  const counterCurrency = useSelector(counterValueCurrencySelector).ticker.toLowerCase();
+
+  const { data, isLoading, isError } = useGlobalMarketData({ counterCurrency });
+
+  const handleOpenDrawer = useCallback(() => {
+    trackDefinitionPressed();
+    setIsDrawerOpen(true);
+  }, []);
+
+  const handleCloseDrawer = useCallback(() => {
+    setIsDrawerOpen(false);
+  }, []);
+
+  return {
+    value: data
+      ? counterValueFormatter({
+          currency: counterCurrency,
+          value: data.marketCap,
+          shorten: true,
+          locale,
+          t,
+        })
+      : "",
+    changePercentage: data?.changePercentage24h,
+    isLoading,
+    isError: isError || !data,
+    isDrawerOpen,
+    handleOpenDrawer,
+    handleCloseDrawer,
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/components/MarketInsightDefinitionSheet/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/MarketInsightDefinitionSheet/index.tsx
@@ -10,7 +10,7 @@ import QueuedDrawerGorhom, {
 type Props = Readonly<{
   title: string;
   description: string;
-  disclaimer: string;
+  disclaimer?: string;
   isOpen: boolean;
   onClose: () => void;
 }>;
@@ -27,9 +27,11 @@ function MarketInsightDefinitionSheet({ title, description, disclaimer, isOpen, 
       <Text typography="body1" lx={{ color: "base" }}>
         {description}
       </Text>
-      <Text typography="body4" lx={{ color: "muted", marginTop: "s16" }}>
-        {disclaimer}
-      </Text>
+      {disclaimer ? (
+        <Text typography="body4" lx={{ color: "muted", marginTop: "s16" }}>
+          {disclaimer}
+        </Text>
+      ) : null}
     </>
   );
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketHighlights/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketHighlights/index.tsx
@@ -3,6 +3,7 @@ import { FlatList, ListRenderItemInfo } from "react-native";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { AltcoinSeason } from "LLM/components/AltcoinSeason";
 import { FearAndGreed } from "LLM/components/FearAndGreed";
+import { MarketCapCard } from "LLM/components/MarketCapCard";
 import type { MarketHighlightCard } from "../../useMarketHighlights";
 import { MARKET_SCREEN_TEST_IDS } from "../../testIds";
 
@@ -27,6 +28,7 @@ export function MarketHighlights({ cardWidth, snapToInterval, highlightCards }: 
           <FearAndGreed appearance="expanded" width={cardWidth} />
         ) : null}
         {item.type === "altcoinSeason" ? <AltcoinSeason width={cardWidth} /> : null}
+        {item.type === "marketCap" ? <MarketCapCard width={cardWidth} /> : null}
       </Box>
     ),
     [cardWidth],

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketHighlights.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketHighlights.ts
@@ -6,7 +6,7 @@ const CARD_GAP = 8;
 
 export type MarketHighlightCard = {
   key: string;
-  type: "fearAndGreed" | "altcoinSeason";
+  type: "marketCap" | "fearAndGreed" | "altcoinSeason";
 };
 
 export interface MarketHighlights {
@@ -27,6 +27,7 @@ export function useMarketHighlights(): MarketHighlights {
       cardGap: CARD_GAP,
       snapToInterval: cardWidth + CARD_GAP,
       highlightCards: [
+        { key: "market-highlight-market-cap", type: "marketCap" },
         { key: "market-highlight-fear-and-greed", type: "fearAndGreed" },
         { key: "market-highlight-altcoin-season", type: "altcoinSeason" },
       ],

--- a/libs/ledger-live-common/src/market/hooks/useMarketDataProvider.ts
+++ b/libs/ledger-live-common/src/market/hooks/useMarketDataProvider.ts
@@ -1,6 +1,10 @@
 import { UseQueryResult, useQueries } from "@tanstack/react-query";
 import { fetchList } from "../api";
-import { useGetAssetChartDataQuery, useGetCurrencyDataQuery } from "../state-manager/api";
+import {
+  useGetAssetChartDataQuery,
+  useGetCurrencyDataQuery,
+  useGetGlobalMarketDataQuery,
+} from "../state-manager/api";
 import { currencyFormatter } from "../utils/currencyFormatter";
 import { QUERY_KEY } from "../utils/queryKeys";
 import { REFETCH_TIME_ONE_MINUTE, BASIC_REFETCH } from "../utils/timers";
@@ -14,6 +18,7 @@ import {
   MarketListRequestResult,
   Order,
 } from "../utils/types";
+import { GlobalMarketDataRequestParams } from "../state-manager/types";
 
 export const useCurrencyData = ({ id, counterCurrency }: MarketCurrencyRequestParams) =>
   useGetCurrencyDataQuery(
@@ -32,6 +37,14 @@ export const useAssetChartData = (
     {
       pollingInterval: REFETCH_TIME_ONE_MINUTE * BASIC_REFETCH,
       skip: options?.skip,
+    },
+  );
+
+export const useGlobalMarketData = ({ counterCurrency }: GlobalMarketDataRequestParams) =>
+  useGetGlobalMarketDataQuery(
+    { counterCurrency },
+    {
+      pollingInterval: REFETCH_TIME_ONE_MINUTE * BASIC_REFETCH,
     },
   );
 

--- a/libs/ledger-live-common/src/market/state-manager/marketApi.ts
+++ b/libs/ledger-live-common/src/market/state-manager/marketApi.ts
@@ -11,7 +11,14 @@ import {
 } from "../utils/types";
 import { getChartRangeSegment, getRange } from "../utils";
 import { REFETCH_TIME_ONE_MINUTE, BASIC_REFETCH } from "../utils/timers";
-import { MarketChartApiResponseSchema, MarketDataTags, MarketPerformersQueryParams } from "./types";
+import {
+  GlobalMarketData,
+  GlobalMarketDataRequestParams,
+  GlobalMarketDataResponseSchema,
+  MarketChartApiResponseSchema,
+  MarketDataTags,
+  MarketPerformersQueryParams,
+} from "./types";
 import { format, formatPerformer } from "../utils/currencyFormatter";
 
 export const marketApi = createApi({
@@ -19,7 +26,12 @@ export const marketApi = createApi({
   baseQuery: fetchBaseQuery({
     baseUrl: getEnv("LEDGER_COUNTERVALUES_API"),
   }),
-  tagTypes: [MarketDataTags.Performers, MarketDataTags.CurrencyData, MarketDataTags.ChartData],
+  tagTypes: [
+    MarketDataTags.Performers,
+    MarketDataTags.CurrencyData,
+    MarketDataTags.ChartData,
+    MarketDataTags.GlobalData,
+  ],
   endpoints: build => ({
     getMarketPerformers: build.query<MarketItemPerformer[], MarketPerformersQueryParams>({
       query: ({ counterCurrency, range, limit = 5, top = 50, sort, supported }) => {
@@ -79,8 +91,39 @@ export const marketApi = createApi({
       },
       keepUnusedDataFor: REFETCH_TIME_ONE_MINUTE / 1000,
     }),
+    getGlobalMarketData: build.query<GlobalMarketData, GlobalMarketDataRequestParams>({
+      query: ({ counterCurrency }) => ({
+        url: "/v3/markets/global",
+        params: { to: counterCurrency },
+      }),
+      providesTags: [MarketDataTags.GlobalData],
+      transformResponse: (response: unknown): GlobalMarketData => {
+        const result = GlobalMarketDataResponseSchema.safeParse(response);
+
+        if (!result.success) {
+          log("market", "Invalid global market data response schema:", {
+            errors: result.error.issues,
+          });
+          throw new Error(
+            `[Market API] Global market data schema validation failed: ${result.error.issues
+              .map(e => `${e.path.join(".")}: ${e.message}`)
+              .join(", ")}`,
+          );
+        }
+
+        return {
+          marketCap: result.data.marketCap,
+          changePercentage24h: result.data.percentageChanges["1d"] * 100,
+        };
+      },
+      keepUnusedDataFor: (REFETCH_TIME_ONE_MINUTE * BASIC_REFETCH) / 1000,
+    }),
   }),
 });
 
-export const { useGetMarketPerformersQuery, useGetCurrencyDataQuery, useGetAssetChartDataQuery } =
-  marketApi;
+export const {
+  useGetMarketPerformersQuery,
+  useGetCurrencyDataQuery,
+  useGetAssetChartDataQuery,
+  useGetGlobalMarketDataQuery,
+} = marketApi;

--- a/libs/ledger-live-common/src/market/state-manager/types.ts
+++ b/libs/ledger-live-common/src/market/state-manager/types.ts
@@ -5,6 +5,7 @@ export enum MarketDataTags {
   Performers = "Performers",
   CurrencyData = "CurrencyData",
   ChartData = "ChartData",
+  GlobalData = "GlobalData",
 }
 
 export interface MarketPerformersQueryParams {
@@ -21,3 +22,23 @@ export const MarketChartApiResponseSchema = z.object({
 });
 
 export type MarketChartApiResponse = z.infer<typeof MarketChartApiResponseSchema>;
+
+// Raw /v3/markets/global response: percentageChanges values are ratios (e.g. -0.0171 = -1.71%).
+export const GlobalMarketDataResponseSchema = z.object({
+  marketCap: z.number(),
+  percentageChanges: z.object({
+    "1d": z.number(),
+  }),
+});
+
+export type GlobalMarketDataResponse = z.infer<typeof GlobalMarketDataResponseSchema>;
+
+export interface GlobalMarketDataRequestParams {
+  counterCurrency: string;
+}
+
+export interface GlobalMarketData {
+  marketCap: number;
+  // 24h change expressed as a percentage (e.g. -1.71), ready for display.
+  changePercentage24h: number;
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Added an integration test for the `MarketCapCard` data/display flow and drawer, plus local coverage for the Market screen assets list integration and Market screen ViewModel.
- [x] **Impact of the changes:**
      - Market screen insight card ordering
      - Total market cap aggregation and 24h variation display
      - User countervalue formatting

### 📝 Description

This PR adds the Total market cap insight card to the mobile Market screen.

The card is self-contained under `src/mvvm/components/MarketCapCard`. It uses the existing Market data flow in the user countervalue currency, fetches the global market data endpoint, formats the total market cap with the existing Market formatter, displays the 24h percentage variation, and opens the definition drawer on press.

<img width="350" height="750" alt="Simulator Screenshot - iOS Simulator - 2026-06-04 at 09 28 49" src="https://github.com/user-attachments/assets/7a25a3d1-0518-4223-98ca-627ea9627553" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30032](https://ledgerhq.atlassian.net/browse/LIVE-30032)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30032]: https://ledgerhq.atlassian.net/browse/LIVE-30032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
