### PR TITLE
[LWM] feat(mobile): add market insight error placeholders

### DIFF
--- a/.changeset/market-insight-error-placeholders.md
+++ b/.changeset/market-insight-error-placeholders.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add isolated market insight card error placeholders on mobile

--- a/apps/ledger-live-mobile/src/mvvm/components/AltcoinSeason/AltcoinSeasonView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/AltcoinSeason/AltcoinSeasonView.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "~/context/Locale";
 import { Box, Pressable, Skeleton, Text } from "@ledgerhq/lumen-ui-rnative";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import MarketInsightDefinitionSheet from "LLM/components/MarketInsightDefinitionSheet";
+import MarketInsightErrorCard from "LLM/components/MarketInsightErrorCard";
 import type { AltcoinSeasonViewProps } from "./types";
 import { AltcoinSeasonArc } from "./AltcoinSeasonArc";
 
@@ -33,7 +34,16 @@ export function AltcoinSeasonView({
     );
   }
 
-  if (!data || isError) return null;
+  if (!data || isError) {
+    return (
+      <MarketInsightErrorCard
+        title={t("altcoinSeason.title")}
+        message={t("marketBanner.connectionFailed")}
+        width={width}
+        testID="altcoin-season-card-error"
+      />
+    );
+  }
 
   const { value } = data;
 

--- a/apps/ledger-live-mobile/src/mvvm/components/AltcoinSeason/__integrations__/AltcoinSeason.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/AltcoinSeason/__integrations__/AltcoinSeason.test.tsx
@@ -54,4 +54,15 @@ describe("AltcoinSeason Integration", () => {
       ),
     ).toBeVisible();
   });
+
+  it("should render an isolated error placeholder when API fails", async () => {
+    server.use(http.get(API_ENDPOINT, () => new HttpResponse(null, { status: 500 })));
+
+    render(<AltcoinSeason width={276} />);
+
+    expect(await screen.findByTestId("altcoin-season-card-error")).toBeVisible();
+    expect(screen.getByTestId("altcoin-season-card-error-icon")).toBeVisible();
+    expect(screen.getByText("Season")).toBeVisible();
+    expect(screen.getByText("Connection failed")).toBeVisible();
+  });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/FearAndGreed/FearAndGreedView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/FearAndGreed/FearAndGreedView.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { useTranslation } from "~/context/Locale";
+import MarketInsightErrorCard from "LLM/components/MarketInsightErrorCard";
 import type { FearAndGreedViewProps } from "./types";
 import FearAndGreedCard from "./components/FearAndGreedCard";
 import FearAndGreedExpandedCard, {
@@ -16,11 +18,26 @@ export const FearAndGreedView = ({
   appearance,
   width,
 }: FearAndGreedViewProps) => {
+  const { t } = useTranslation();
+
   if (appearance === "expanded" && isLoading) {
     return <FearAndGreedExpandedCardSkeleton width={width} testID="fear-and-greed-card-skeleton" />;
   }
 
-  if (!data || isError) return null;
+  if (!data || isError) {
+    if (appearance === "expanded") {
+      return (
+        <MarketInsightErrorCard
+          title={t("fearAndGreed.title")}
+          message={t("marketBanner.connectionFailed")}
+          width={width}
+          testID="fear-and-greed-card-error"
+        />
+      );
+    }
+
+    return null;
+  }
 
   return (
     <>

--- a/apps/ledger-live-mobile/src/mvvm/components/FearAndGreed/__integrations__/FearAndGreed.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/FearAndGreed/__integrations__/FearAndGreed.test.tsx
@@ -34,6 +34,17 @@ describe("FearAndGreed Integration", () => {
 
       expect(queryByTestId("fear-and-greed-card")).toBeNull();
     });
+
+    it("should render an isolated error placeholder when expanded API fails", async () => {
+      server.use(http.get(API_ENDPOINT, () => new HttpResponse(null, { status: 500 })));
+
+      render(<FearAndGreed appearance="expanded" width={276} />);
+
+      expect(await screen.findByTestId("fear-and-greed-card-error")).toBeVisible();
+      expect(screen.getByTestId("fear-and-greed-card-error-icon")).toBeVisible();
+      expect(screen.getByText("Mood index")).toBeVisible();
+      expect(screen.getByText("Connection failed")).toBeVisible();
+    });
   });
 
   describe("Mood levels", () => {

--- a/apps/ledger-live-mobile/src/mvvm/components/MarketCapCard/MarketCapCardView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/MarketCapCard/MarketCapCardView.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "~/context/Locale";
 import { Box, Pressable, Skeleton, Text, Trend } from "@ledgerhq/lumen-ui-rnative";
 import { useTheme, type LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import MarketInsightDefinitionSheet from "LLM/components/MarketInsightDefinitionSheet";
+import MarketInsightErrorCard from "LLM/components/MarketInsightErrorCard";
 import type { MarketCapCardViewProps } from "./types";
 
 const MARKET_CAP_CARD_HEIGHT = 68;
@@ -30,7 +31,16 @@ export function MarketCapCardView({
     );
   }
 
-  if (isError) return null;
+  if (isError) {
+    return (
+      <MarketInsightErrorCard
+        title={t("marketCapCard.title")}
+        message={t("marketBanner.connectionFailed")}
+        width={width}
+        testID="market-cap-card-error"
+      />
+    );
+  }
 
   return (
     <>

--- a/apps/ledger-live-mobile/src/mvvm/components/MarketCapCard/__integrations__/MarketCapCard.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/MarketCapCard/__integrations__/MarketCapCard.test.tsx
@@ -51,4 +51,15 @@ describe("MarketCapCard Integration", () => {
       ),
     ).toBeVisible();
   });
+
+  it("should render an isolated error placeholder when market data fails", async () => {
+    server.use(http.get(API_ENDPOINT, () => new HttpResponse(null, { status: 500 })));
+
+    render(<MarketCapCard width={276} />);
+
+    expect(await screen.findByTestId("market-cap-card-error")).toBeVisible();
+    expect(screen.getByTestId("market-cap-card-error-icon")).toBeVisible();
+    expect(screen.getByText("Total market cap")).toBeVisible();
+    expect(screen.getByText("Connection failed")).toBeVisible();
+  });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/MarketInsightErrorCard/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/MarketInsightErrorCard/index.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
+import { Warning } from "@ledgerhq/lumen-ui-rnative/symbols";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+
+export const MARKET_INSIGHT_ERROR_CARD_HEIGHT = 68;
+
+type Props = Readonly<{
+  title: string;
+  message: string;
+  width?: number;
+  testID?: string;
+}>;
+
+export default function MarketInsightErrorCard({ title, message, width, testID }: Props) {
+  return (
+    <Box testID={testID} lx={cardStyle} style={{ width, height: MARKET_INSIGHT_ERROR_CARD_HEIGHT }}>
+      <Text typography="body3" numberOfLines={1} lx={{ color: "muted", marginBottom: "s4" }}>
+        {title}
+      </Text>
+      <Box lx={messageStyle}>
+        <Box testID={testID ? `${testID}-icon` : undefined} lx={{ flexShrink: 0 }}>
+          <Warning size={16} color="error" />
+        </Box>
+        <Text typography="body2SemiBold" numberOfLines={1} lx={{ color: "base", flexShrink: 1 }}>
+          {message}
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+const cardStyle: LumenViewStyle = {
+  backgroundColor: "muted",
+  borderRadius: "md",
+  padding: "s12",
+  justifyContent: "center",
+};
+
+const messageStyle: LumenViewStyle = {
+  flexDirection: "row",
+  alignItems: "center",
+  gap: "s6",
+};


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Added integration assertions for isolated error placeholders on Mood index, Altcoin Season, and Total market cap cards. Local Jest is still blocked before running specs by the stale `ledger-live-common/lib-es` XRP import noted in the parent PR; targeted oxlint and mobile typecheck pass._
- [x] **Impact of the changes:**
      - Market insight card failure states
      - Per-card loading/error isolation
      - Existing compact Portfolio Fear & Greed error behavior

### 📝 Description

This PR adds the placeholder error state required for Market insight cards.

Each expanded card now keeps its own slot when its data source fails, rendering a generic `Data unavailable` placeholder without hiding or blocking the other cards. The existing compact Portfolio Fear & Greed card keeps its current behavior and still renders nothing on API failure.
<img width="197" height="97" alt="image" src="https://github.com/user-attachments/assets/1402b16e-3953-4a8b-a72b-ecd81f590e78" />

<img width="425" height="157" alt="image" src="https://github.com/user-attachments/assets/83df0cd3-6102-4749-ace5-9630b0cb7a4a" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-30033](https://ledgerhq.atlassian.net/browse/LIVE-30033)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-30033]: https://ledgerhq.atlassian.net/browse/LIVE-30033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ