### PR TITLE
[LWDM] fix(asset-detail): align graph all-time high/low with market stats table

### DIFF
--- a/.changeset/fix-asset-detail-ath-atl-consistency.md
+++ b/.changeset/fix-asset-detail-ath-atl-consistency.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Fix Asset Detail graph showing all-time high/low values that differed from the market stats table. On the "All" range, the graph's min/max markers are now anchored to the market all-time high/low, so both surfaces stay consistent.

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/useChartSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/useChartSectionViewModel.ts
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import type { AssetMarketData } from "@ledgerhq/asset-detail";
 import type { DistributionItem } from "@ledgerhq/types-live";
 import { useAssetChartData } from "@ledgerhq/live-common/market/hooks/useMarketDataProvider";
+import { injectMarketExtrema } from "@ledgerhq/live-common/market/utils/injectMarketExtrema";
 import { formatPrice } from "@ledgerhq/live-currency-format";
 import { track } from "~/renderer/analytics/segment";
 import { ASSET_DETAIL_TRACKING_PAGE_NAME } from "LLD/features/AssetDetail/constants";
@@ -124,7 +125,13 @@ export function useChartSectionViewModel({
   } = useAssetChartData({ id, counterCurrency, range: selectedRange }, { skip: !id });
 
   const { series, timestamps } = useMemo(() => {
-    const points = chartData?.[selectedRange] ?? [];
+    const rawPoints = chartData?.[selectedRange] ?? [];
+    // On the "all" range, anchor the graph's high/low markers to the market
+    // all-time high/low so they match the stats table (see LIVE-31732).
+    const points =
+      selectedRange === "all"
+        ? injectMarketExtrema(rawPoints, marketData.marketCurrencyData ?? {})
+        : rawPoints;
     const data: number[] = [];
     const tsList: number[] = [];
     points.forEach(([timestamp, value]) => {
@@ -143,7 +150,7 @@ export function useChartSectionViewModel({
       ] satisfies LineChartSeries[],
       timestamps: tsList,
     };
-  }, [chartData, selectedRange]);
+  }, [chartData, selectedRange, marketData.marketCurrencyData]);
 
   const priceChangeKey = getPriceChangeKeyForRange(selectedRange);
   const rangePercentage = marketData.marketCurrencyData?.priceChangePercentage?.[priceChangeKey];

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/useChartSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/useChartSectionViewModel.ts
@@ -124,13 +124,22 @@ export function useChartSectionViewModel({
     isError,
   } = useAssetChartData({ id, counterCurrency, range: selectedRange }, { skip: !id });
 
+  // Extract the all-time extrema as stable primitives: marketCurrencyData is a
+  // new object on every market poll (athDate/atlDate are fresh Date instances),
+  // so depending on it would re-run the series pipeline on each price refresh.
+  const marketCurrencyData = marketData.marketCurrencyData;
+  const ath = marketCurrencyData?.ath;
+  const atl = marketCurrencyData?.atl;
+  const athTime = marketCurrencyData?.athDate?.getTime();
+  const atlTime = marketCurrencyData?.atlDate?.getTime();
+
   const { series, timestamps } = useMemo(() => {
     const rawPoints = chartData?.[selectedRange] ?? [];
     // On the "all" range, anchor the graph's high/low markers to the market
     // all-time high/low so they match the stats table (see LIVE-31732).
     const points =
       selectedRange === "all"
-        ? injectMarketExtrema(rawPoints, marketData.marketCurrencyData ?? {})
+        ? injectMarketExtrema(rawPoints, { ath, athDate: athTime, atl, atlDate: atlTime })
         : rawPoints;
     const data: number[] = [];
     const tsList: number[] = [];
@@ -150,7 +159,7 @@ export function useChartSectionViewModel({
       ] satisfies LineChartSeries[],
       timestamps: tsList,
     };
-  }, [chartData, selectedRange, marketData.marketCurrencyData]);
+  }, [chartData, selectedRange, ath, atl, athTime, atlTime]);
 
   const priceChangeKey = getPriceChangeKeyForRange(selectedRange);
   const rangePercentage = marketData.marketCurrencyData?.priceChangePercentage?.[priceChangeKey];

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
@@ -168,14 +168,22 @@ export function useBalanceGraphViewModel({
     [counterValueUnit, locale],
   );
 
+  // Extract the all-time extrema as stable primitives: marketCurrency is a new
+  // object on every market poll (athDate/atlDate are fresh Date instances), so
+  // depending on it would re-run the series pipeline on each price refresh.
+  const ath = marketCurrency?.ath;
+  const atl = marketCurrency?.atl;
+  const athTime = marketCurrency?.athDate?.getTime();
+  const atlTime = marketCurrency?.atlDate?.getTime();
+
   const { series, timestamps } = useMemo(() => {
     const rawPoints = chartData?.[range] ?? [];
     // On the "all" range, anchor the graph's high/low markers to the market
     // all-time high/low so they match the stats table (see LIVE-31732). Injected
     // before downsampling, which preserves the series min/max.
     const points =
-      range === "all" && marketCurrency
-        ? injectMarketExtrema(rawPoints, marketCurrency)
+      range === "all"
+        ? injectMarketExtrema(rawPoints, { ath, athDate: athTime, atl, atlDate: atlTime })
         : rawPoints;
     const rawValues: number[] = [];
     const rawTimestamps: number[] = [];
@@ -201,7 +209,7 @@ export function useBalanceGraphViewModel({
       ] satisfies LineChartSeries[],
       timestamps: tsList,
     };
-  }, [chartData, range, marketCurrency]);
+  }, [chartData, range, ath, atl, athTime, atlTime]);
   const prices = series[0].data;
 
   const priceChangePercentage = useMemo(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
@@ -48,6 +48,7 @@ import {
 } from "./utils/getTransactionPointMarkers";
 import { buildTransactionPointMarker } from "./utils/buildTransactionPointMarker";
 import { downsampleChartPoints } from "./utils/downsampleChartPoints";
+import { injectMarketExtrema } from "@ledgerhq/live-common/market/utils/injectMarketExtrema";
 
 // Upper bound on operations pulled for the chart's transaction dots. The chart only
 // marks operations inside the visible window, so this just caps the lookback; raise it
@@ -168,7 +169,14 @@ export function useBalanceGraphViewModel({
   );
 
   const { series, timestamps } = useMemo(() => {
-    const points = chartData?.[range] ?? [];
+    const rawPoints = chartData?.[range] ?? [];
+    // On the "all" range, anchor the graph's high/low markers to the market
+    // all-time high/low so they match the stats table (see LIVE-31732). Injected
+    // before downsampling, which preserves the series min/max.
+    const points =
+      range === "all" && marketCurrency
+        ? injectMarketExtrema(rawPoints, marketCurrency)
+        : rawPoints;
     const rawValues: number[] = [];
     const rawTimestamps: number[] = [];
     points.forEach(([timestamp, value]) => {
@@ -193,7 +201,7 @@ export function useBalanceGraphViewModel({
       ] satisfies LineChartSeries[],
       timestamps: tsList,
     };
-  }, [chartData, range]);
+  }, [chartData, range, marketCurrency]);
   const prices = series[0].data;
 
   const priceChangePercentage = useMemo(() => {

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -678,6 +678,7 @@
     "src/market/utils/currencyFormatter.ts",
     "src/market/utils/fixtures.ts",
     "src/market/utils/index.ts",
+    "src/market/utils/injectMarketExtrema.ts",
     "src/market/utils/queryKeys.ts",
     "src/market/utils/timers.ts",
     "src/market/utils/types.ts",

--- a/libs/ledger-live-common/src/market/utils/__tests__/injectMarketExtrema.test.ts
+++ b/libs/ledger-live-common/src/market/utils/__tests__/injectMarketExtrema.test.ts
@@ -1,0 +1,96 @@
+import { injectMarketExtrema } from "../injectMarketExtrema";
+import { ChartDataPoint } from "../types";
+
+const series: ChartDataPoint[] = [
+  [1000, 10],
+  [2000, 30],
+  [3000, 20],
+];
+
+describe("injectMarketExtrema", () => {
+  it("inserts ath and atl at their sorted position", () => {
+    const result = injectMarketExtrema(series, {
+      ath: 100,
+      athDate: 2500,
+      atl: 5,
+      atlDate: 1500,
+    });
+
+    expect(result).toEqual([
+      [1000, 10],
+      [1500, 5],
+      [2000, 30],
+      [2500, 100],
+      [3000, 20],
+    ]);
+  });
+
+  it("makes the injected ath/atl the series extrema", () => {
+    const result = injectMarketExtrema(series, {
+      ath: 100,
+      athDate: 2500,
+      atl: 5,
+      atlDate: 1500,
+    });
+    const values = result.map(([, value]) => value);
+
+    expect(Math.max(...values)).toBe(100);
+    expect(Math.min(...values)).toBe(5);
+  });
+
+  it("accepts Date instances for the dates", () => {
+    const result = injectMarketExtrema(series, {
+      ath: 100,
+      athDate: new Date(2500),
+      atl: 5,
+      atlDate: new Date(1500),
+    });
+
+    expect(result).toContainEqual([2500, 100]);
+    expect(result).toContainEqual([1500, 5]);
+  });
+
+  it("appends when the date is after every point", () => {
+    const result = injectMarketExtrema(series, { ath: 100, athDate: 9000 });
+
+    expect(result[result.length - 1]).toEqual([9000, 100]);
+  });
+
+  it("reconciles a colliding timestamp without lowering a high or raising a low", () => {
+    const result = injectMarketExtrema(series, {
+      ath: 25, // lower than the existing 30 at ts 2000
+      athDate: 2000,
+      atl: 25, // higher than the existing 10 at ts 1000
+      atlDate: 1000,
+    });
+
+    expect(result).toContainEqual([2000, 30]);
+    expect(result).toContainEqual([1000, 10]);
+  });
+
+  it("does not mutate the input", () => {
+    const input: ChartDataPoint[] = [[1000, 10]];
+    injectMarketExtrema(input, { ath: 100, athDate: 2000 });
+
+    expect(input).toEqual([[1000, 10]]);
+  });
+
+  it("skips invalid or missing values and dates", () => {
+    const result = injectMarketExtrema(series, {
+      ath: NaN,
+      athDate: 2500,
+      atl: 5,
+      atlDate: undefined,
+    });
+
+    expect(result).toEqual(series);
+  });
+
+  it("returns a copy of an empty series", () => {
+    const empty: ChartDataPoint[] = [];
+    const result = injectMarketExtrema(empty, { ath: 100, athDate: 2000 });
+
+    expect(result).toEqual([]);
+    expect(result).not.toBe(empty);
+  });
+});

--- a/libs/ledger-live-common/src/market/utils/injectMarketExtrema.ts
+++ b/libs/ledger-live-common/src/market/utils/injectMarketExtrema.ts
@@ -56,7 +56,9 @@ export function injectMarketExtrema(
 ): ChartDataPoint[] {
   if (points.length === 0) return points.slice();
 
-  const result = points.map(point => [...point] as ChartDataPoint);
+  // Shallow copy is enough: insertSorted only inserts new tuples or replaces a
+  // colliding one, it never mutates an existing tuple in place.
+  const result = points.slice();
 
   const athTs = toTimestamp(athDate);
   if (ath != null && Number.isFinite(ath) && ath > 0 && athTs != null) {

--- a/libs/ledger-live-common/src/market/utils/injectMarketExtrema.ts
+++ b/libs/ledger-live-common/src/market/utils/injectMarketExtrema.ts
@@ -1,0 +1,72 @@
+import { ChartDataPoint } from "./types";
+
+export type MarketExtrema = Readonly<{
+  ath?: number;
+  athDate?: Date | number;
+  atl?: number;
+  atlDate?: Date | number;
+}>;
+
+function toTimestamp(date?: Date | number): number | undefined {
+  if (date == null) return undefined;
+  const ts = date instanceof Date ? date.getTime() : date;
+  return Number.isFinite(ts) ? ts : undefined;
+}
+
+/**
+ * Inserts a single [timestamp, value] point into a series already sorted by
+ * timestamp. If a point already shares the timestamp, its value is reconciled
+ * with `reconcile` (Math.max for highs, Math.min for lows) so we never lower a
+ * real high or raise a real low.
+ */
+function insertSorted(
+  points: ChartDataPoint[],
+  timestamp: number,
+  value: number,
+  reconcile: (a: number, b: number) => number,
+): void {
+  const index = points.findIndex(([ts]) => ts >= timestamp);
+  if (index === -1) {
+    points.push([timestamp, value]);
+    return;
+  }
+  if (points[index][0] === timestamp) {
+    points[index] = [timestamp, reconcile(points[index][1], value)];
+    return;
+  }
+  points.splice(index, 0, [timestamp, value]);
+}
+
+/**
+ * Anchors the market all-time high/low onto a price chart series.
+ *
+ * The graph's high/low markers are derived from the extrema of the rendered
+ * series, whereas the market stats table shows the precise `ath`/`atl` scalars
+ * from the market API. On the "all" range both claim to show the all-time
+ * extreme, so a downsampled series whose peak falls between two points diverges
+ * from the table. Injecting the exact ATH/ATL points (at their real dates) makes
+ * the line reach those values and keeps both surfaces consistent.
+ *
+ * Returns a new array; the input is not mutated. Values must already be in the
+ * same counter-currency as `ath`/`atl`.
+ */
+export function injectMarketExtrema(
+  points: readonly ChartDataPoint[],
+  { ath, athDate, atl, atlDate }: MarketExtrema,
+): ChartDataPoint[] {
+  if (points.length === 0) return points.slice();
+
+  const result = points.map(point => [...point] as ChartDataPoint);
+
+  const athTs = toTimestamp(athDate);
+  if (ath != null && Number.isFinite(ath) && ath > 0 && athTs != null) {
+    insertSorted(result, athTs, ath, Math.max);
+  }
+
+  const atlTs = toTimestamp(atlDate);
+  if (atl != null && Number.isFinite(atl) && atl > 0 && atlTs != null) {
+    insertSorted(result, atlTs, atl, Math.min);
+  }
+
+  return result;
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _Pure injection helper (`injectMarketExtrema`) is unit-tested. The desktop/mobile view-model wiring is not covered by new tests — it's a thin, range-gated call into the tested helper._
- [x] **Impact of the changes:**
      - Asset Detail price graph on the **All** range (both LWD & LWM): the high/low markers should now match the All-Time High/Low shown in the market stats table below the graph.
      - Other ranges (1D/1W/1M/6M/1Y/5Y) must be unchanged — markers still reflect the period min/max.
      - On mobile, confirm the injected extrema survive downsampling (the All-range line reaches the ATH/ATL points).
      - Verify on assets whose true ATH/ATL date predates the chart's earliest sampled point.

### 📝 Description

On the Asset Detail page, the All-Time High/Low values shown on the price graph differed from the values in the market stats table below it.

**Problem**: The graph's high/low markers were computed from the extrema of the rendered chart series (`getSeriesExtrema`), which is a downsampled set of points. The market stats table instead reads the precise `ath`/`atl` scalars from the market API. On the **All** range both surfaces claim to show the all-time extreme, but a sampled series whose true peak falls between two points diverges from the API scalar — so the two never agreed.

**Solution**: Added a pure helper `injectMarketExtrema` in `@ledgerhq/live-common` that inserts the exact `(athDate, ath)` and `(atlDate, atl)` points into the chart series at their correct sorted position. It's wired into both view-models **only on the All range**, so the line actually reaches those values and `getSeriesExtrema` picks them up naturally — making the graph and the table consistent. Shorter ranges keep their true period min/max (intended behavior per LIVE-31781). On mobile the injection happens before `downsampleChartPoints`, which preserves the global min/max.

### 🎥 Videos

| LWD | LWM |
| --- | --- |
|https://github.com/user-attachments/assets/2338aa63-7712-432b-bed9-94ea94af90d5|https://github.com/user-attachments/assets/f482f352-771a-4860-82d8-46d2767fc849|

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31732](https://ledgerhq.atlassian.net/browse/LIVE-31732)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31732]: https://ledgerhq.atlassian.net/browse/LIVE-31732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ