### PR TITLE
ci(mobile): run Detox with 4 shards on PRs (was 2)

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -78,6 +78,13 @@ jobs:
     with:
       macos-specificity-runner-label: "performance-pool"
       skip-pod-checks: "false"
+      # Detox shards: 4-way (was default 2). Steady-state (warm timing cache)
+      # this cut the longest detox shard ~773s->~339s iOS / ~707s->~191s
+      # Android, ~7 min off the mobile merge-gate critical path. iOS caps at
+      # 3 shards regardless; Android uses 4. Timing cache is keyed by shard
+      # count, so the first develop run after this merges is cold (slow) until
+      # the per-shard timing data repopulates over a run or two.
+      max-shards: 4
 
   # Tests
   test-libraries:


### PR DESCRIPTION
## What

Bump the **Detox** shard count for the `build-test-mobile` job from the default `2` to `4` on PRs. One line in the caller (`max-shards: 4`).

## Why

`build-test-mobile` (Detox E2E) is in the `OK` merge-gate's `needs`, so it blocks merge — and its longest shard is the critical path for the ~70% of PRs that touch mobile. Detox was only sharded 2-way.

## Measured (workflow_dispatch on `develop`, warm timing cache)

Longest detox shard:

| | Baseline (2-shard) | 4-shard (warm) | Change |
|---|---|---|---|
| **iOS** | 773s | **339s** (339/284/283) | **−56%** |
| **Android** | 707s | **191s** (191/188/186/183) | **−73%** |

On the mobile merge gate: `determine(45) + iOS build(374) + iOS detox(773→339)` ≈ **1192s → ~758s, ~7 min (~36%) faster**.

## Caveats (both measured/verified)

- **iOS caps at 3 shards** regardless of `max-shards` (consistent across runs) — a limit in `generate-shards-matrix`. 3 balanced iOS shards at ~339s is still the win above. Android uses all 4.
- **Cold-start penalty:** the detox timing cache key includes the shard count, so the **first `develop` run after merge is cold** — poorly balanced and ~as slow as (a cold first run measured 1125s iOS). It self-corrects over a run or two as per-shard timings repopulate. Steady state is the table above.
- Single warm sample; Detox has run-to-run variance, so exact seconds will wobble — direction is decisive.

## Cost

iOS detox runs on self-hosted macOS ($0); Android on 8-CPU hosted-larger (per-vCPU-min) — 2× more Android shard jobs but each ~half as long, so vCPU-minutes are ~conserved. Net cost ~neutral; main risk is runner-pool capacity for 4 parallel shards (monitor the macOS performance-pool + 8-CPU pool for queueing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
