### PR TITLE
[LWM] fix(mobile): fine tune DeviceIntentExecutor analytics

### DIFF
--- a/.changeset/die-button-tracking.md
+++ b/.changeset/die-button-tracking.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Add missing Device Intent Executor button tracking events.

--- a/apps/ledger-live-mobile/src/components/DeviceAction/Screen/DeviceDeprecationScreen.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/Screen/DeviceDeprecationScreen.tsx
@@ -30,6 +30,8 @@ export const DeviceDeprecationScreen = ({
   coinName,
   date,
   onContinue,
+  onLearnMore,
+  onUpgrade,
   productName,
   displayClearSigningWarning = false,
   screenName,
@@ -37,6 +39,8 @@ export const DeviceDeprecationScreen = ({
   coinName: string;
   date?: Date;
   onContinue?: () => void;
+  onLearnMore?: () => void;
+  onUpgrade?: () => void;
   productName: string;
   displayClearSigningWarning?: boolean;
   screenName: DeviceDeprecationScreens;
@@ -57,10 +61,12 @@ export const DeviceDeprecationScreen = ({
 
   const shopUrl = useLocalizedUrl(urls.deviceDeprecation.shop);
   const learnMoreUrl = useLocalizedUrl(urls.deviceDeprecation.learnMore);
-  const handleUgradeClick = () => {
+  const handleUpgradeClick = () => {
+    onUpgrade?.();
     openURL(shopUrl);
   };
   const handleLearnMoreClick = () => {
+    onLearnMore?.();
     openURL(learnMoreUrl);
   };
   const handleContinue = useCallback(() => {
@@ -154,7 +160,7 @@ export const DeviceDeprecationScreen = ({
         mt={8}
         style={{ width: "100%" }}
         alignSelf="stretch"
-        onPress={handleUgradeClick}
+        onPress={handleUpgradeClick}
         data-testid="update-button"
       >
         <Trans i18nKey="deviceDeprecation.update" />

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectingState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectingState.tsx
@@ -28,6 +28,7 @@ export function ConnectingState({ state }: Readonly<ConnectingStateProps>): Reac
         sourceFlow={sourceFlow}
         modelId={modelId}
         transport={transport}
+        refreshSource
         deviceUxV2
       />
       <Box lx={{ width: "full", alignItems: "center", gap: "s16" }}>

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectionErrorState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectionErrorState.test.tsx
@@ -9,9 +9,14 @@ import {
   type ConnectDeviceUIState,
 } from "@ledgerhq/live-dmk-mobile";
 import { TrackScreen, track } from "~/analytics";
+import { currentRouteNameRef } from "~/analytics/screenRefs";
 import { urls } from "~/utils/urls";
 import { SourceFlowProvider } from "../../utils/SourceFlowContext";
-import { PAGE_CONNECT_DEVICE } from "../../utils/trackDeviceIntent";
+import {
+  PAGE_CONNECT_DEVICE,
+  setIsInTerminalConnectDeviceError,
+  trackDeviceflowCanceled,
+} from "../../utils/trackDeviceIntent";
 import { ConnectionErrorState } from "./ConnectionErrorState";
 
 jest.mock("~/analytics", () => {
@@ -86,6 +91,8 @@ function renderState(errorType: ConnectionErrorTypes) {
 describe("ConnectionErrorState", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    setIsInTerminalConnectDeviceError(false);
+    currentRouteNameRef.current = PAGE_CONNECT_DEVICE.ConnectionError;
     jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
   });
 
@@ -163,5 +170,36 @@ describe("ConnectionErrorState", () => {
       }),
       undefined,
     );
+  });
+
+  it("GIVEN an unknown connection error WHEN cancelling THEN it tracks deviceflow_failed", () => {
+    // GIVEN
+    renderState(ConnectionErrorTypes.Unknown);
+    mockedTrack.mockClear();
+
+    // WHEN
+    trackDeviceflowCanceled({ sourceFlow: "my_ledger" });
+
+    // THEN
+    expect(mockedTrack).toHaveBeenCalledWith("deviceflow_failed", {
+      sourceFlow: "my_ledger",
+      deviceUxV2: true,
+    });
+  });
+
+  it("GIVEN a previous terminal discovery error WHEN rendering a retryable connection error and cancelling THEN it tracks deviceflow_aborted", () => {
+    // GIVEN
+    setIsInTerminalConnectDeviceError(true);
+    renderState(ConnectionErrorTypes.BlePairingRefused);
+    mockedTrack.mockClear();
+
+    // WHEN
+    trackDeviceflowCanceled({ sourceFlow: "my_ledger" });
+
+    // THEN
+    expect(mockedTrack).toHaveBeenCalledWith("deviceflow_aborted", {
+      sourceFlow: "my_ledger",
+      deviceUxV2: true,
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectionErrorState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectionErrorState.test.tsx
@@ -9,7 +9,6 @@ import {
   type ConnectDeviceUIState,
 } from "@ledgerhq/live-dmk-mobile";
 import { TrackScreen, track } from "~/analytics";
-import { previousRouteNameRef } from "~/analytics/screenRefs";
 import { urls } from "~/utils/urls";
 import { SourceFlowProvider } from "../../utils/SourceFlowContext";
 import { PAGE_CONNECT_DEVICE } from "../../utils/trackDeviceIntent";
@@ -26,7 +25,6 @@ jest.mock("~/analytics", () => {
 
 const mockedTrackScreen = jest.mocked(TrackScreen);
 const mockedTrack = jest.mocked(track);
-const TEST_SOURCE = "Connect Device - Connection Error";
 
 type ConnectionErrorUIState = Extract<
   ConnectDeviceUIState,
@@ -88,21 +86,32 @@ function renderState(errorType: ConnectionErrorTypes) {
 describe("ConnectionErrorState", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    previousRouteNameRef.current = TEST_SOURCE;
     jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
   });
 
   it.each(errorCases)(
-    "should render the $type error content",
-    ({ type, title, description, cta }) => {
+    "should render the $type error title and CTA",
+    ({ type, title, cta }) => {
       renderState(type);
 
       expect(screen.getByText(title)).toBeVisible();
       expect(screen.getByText(cta)).toBeVisible();
+    },
+  );
 
-      if (description) {
-        expect(screen.getByText(description)).toBeVisible();
+  it.each(errorCases.filter(({ description }) => description))(
+    "GIVEN a $type error with a description WHEN rendering THEN it renders the error description",
+    ({ type, description }) => {
+      // GIVEN
+      if (!description) {
+        throw new Error("Expected error case to include a description");
       }
+
+      // WHEN
+      renderState(type);
+
+      // THEN
+      expect(screen.getByText(description)).toBeVisible();
     },
   );
 
@@ -119,8 +128,6 @@ describe("ConnectionErrorState", () => {
 
     expect(track).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_CONNECT_DEVICE.ConnectionError,
       deviceUxV2: true,
       button: "Retry",
     });
@@ -134,8 +141,6 @@ describe("ConnectionErrorState", () => {
 
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_CONNECT_DEVICE.ConnectionError,
       deviceUxV2: true,
       button: "Get Help",
     });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectionErrorState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectionErrorState.test.tsx
@@ -120,6 +120,7 @@ describe("ConnectionErrorState", () => {
     expect(track).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
       source: TEST_SOURCE,
+      page: PAGE_CONNECT_DEVICE.ConnectionError,
       deviceUxV2: true,
       button: "Retry",
     });
@@ -134,6 +135,7 @@ describe("ConnectionErrorState", () => {
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
       source: TEST_SOURCE,
+      page: PAGE_CONNECT_DEVICE.ConnectionError,
       deviceUxV2: true,
       button: "Get Help",
     });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectionErrorState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectionErrorState.tsx
@@ -79,7 +79,11 @@ export function ConnectionErrorState({
     return {
       label,
       onPress: () => {
-        trackConnectDeviceButtonClicked({ sourceFlow, button: CONNECT_DEVICE_BUTTON.Retry });
+        trackConnectDeviceButtonClicked({
+          sourceFlow,
+          page: PAGE_CONNECT_DEVICE.ConnectionError,
+          button: CONNECT_DEVICE_BUTTON.Retry,
+        });
         state.retry();
       },
     };
@@ -90,7 +94,11 @@ export function ConnectionErrorState({
     return {
       label,
       onPress: () => {
-        trackConnectDeviceButtonClicked({ sourceFlow, button: CONNECT_DEVICE_BUTTON.GetHelp });
+        trackConnectDeviceButtonClicked({
+          sourceFlow,
+          page: PAGE_CONNECT_DEVICE.ConnectionError,
+          button: CONNECT_DEVICE_BUTTON.GetHelp,
+        });
         Linking.openURL(url).catch(() => undefined);
       },
     };
@@ -137,11 +145,19 @@ export function ConnectionErrorState({
           helpLabel={helpLabel}
           retryLabel={retryLabel}
           onHelp={() => {
-            trackConnectDeviceButtonClicked({ sourceFlow, button: CONNECT_DEVICE_BUTTON.GetHelp });
+            trackConnectDeviceButtonClicked({
+              sourceFlow,
+              page: PAGE_CONNECT_DEVICE.ConnectionError,
+              button: CONNECT_DEVICE_BUTTON.GetHelp,
+            });
             Linking.openURL(bleForgetDeviceUrl).catch(() => undefined);
           }}
           onRetry={() => {
-            trackConnectDeviceButtonClicked({ sourceFlow, button: CONNECT_DEVICE_BUTTON.Retry });
+            trackConnectDeviceButtonClicked({
+              sourceFlow,
+              page: PAGE_CONNECT_DEVICE.ConnectionError,
+              button: CONNECT_DEVICE_BUTTON.Retry,
+            });
             state.retry();
           }}
         />

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectionErrorState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectionErrorState.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Linking } from "react-native";
 import {
   ConnectionErrorTypes,
@@ -16,6 +16,7 @@ import {
   getTrackingSubError,
   getTrackingTransport,
   PAGE_CONNECT_DEVICE,
+  setIsInTerminalConnectDeviceError,
   trackConnectDeviceButtonClicked,
 } from "../../utils/trackDeviceIntent";
 import { PeerRemovedPairingState } from "./PeerRemovedPairingState";
@@ -52,6 +53,10 @@ type ConnectionErrorViewStates = {
   ConnectionErrorViewState
 >;
 
+function isTerminalConnectionError(error: ConnectionError): boolean {
+  return error.type === ConnectionErrorTypes.Unknown;
+}
+
 const connectionErrorTranslationBaseKey =
   "deviceIntentExecutor.connectDevice.states.connectionError.errors";
 
@@ -63,6 +68,12 @@ export function ConnectionErrorState({
   const bleForgetDeviceUrl = useLocalizedUrl(urls.errors.BleForgetDevice);
   const pairingIssuesUrl = useLocalizedUrl(urls.pairingIssues);
   const productName = t("deviceIntentExecutor.connectDevice.common.ledgerDevice");
+
+  useEffect(() => {
+    setIsInTerminalConnectDeviceError(isTerminalConnectionError(state.error));
+    return () => setIsInTerminalConnectDeviceError(false);
+  }, [state.error]);
+
   const trackingScreen = (
     <TrackScreen
       category={PAGE_CONNECT_DEVICE.ConnectionError}

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectionErrorState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectionErrorState.tsx
@@ -53,8 +53,8 @@ type ConnectionErrorViewStates = {
   ConnectionErrorViewState
 >;
 
-function isTerminalConnectionError(error: ConnectionError): boolean {
-  return error.type === ConnectionErrorTypes.Unknown;
+function isTerminalConnectionError(errorType: ConnectionErrorTypes): boolean {
+  return errorType === ConnectionErrorTypes.Unknown;
 }
 
 const connectionErrorTranslationBaseKey =
@@ -70,7 +70,7 @@ export function ConnectionErrorState({
   const productName = t("deviceIntentExecutor.connectDevice.common.ledgerDevice");
 
   useEffect(() => {
-    setIsInTerminalConnectDeviceError(isTerminalConnectionError(state.error));
+    setIsInTerminalConnectDeviceError(isTerminalConnectionError(state.error.type));
     return () => setIsInTerminalConnectDeviceError(false);
   }, [state.error]);
 

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectionErrorState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/ConnectionErrorState.tsx
@@ -70,6 +70,7 @@ export function ConnectionErrorState({
       modelId={state.device.deviceModelId}
       transport={getTrackingTransport(state.device.transport)}
       subError={getTrackingSubError(state.error.type)}
+      refreshSource
       deviceUxV2
     />
   );
@@ -81,7 +82,6 @@ export function ConnectionErrorState({
       onPress: () => {
         trackConnectDeviceButtonClicked({
           sourceFlow,
-          page: PAGE_CONNECT_DEVICE.ConnectionError,
           button: CONNECT_DEVICE_BUTTON.Retry,
         });
         state.retry();
@@ -96,7 +96,6 @@ export function ConnectionErrorState({
       onPress: () => {
         trackConnectDeviceButtonClicked({
           sourceFlow,
-          page: PAGE_CONNECT_DEVICE.ConnectionError,
           button: CONNECT_DEVICE_BUTTON.GetHelp,
         });
         Linking.openURL(url).catch(() => undefined);
@@ -147,7 +146,6 @@ export function ConnectionErrorState({
           onHelp={() => {
             trackConnectDeviceButtonClicked({
               sourceFlow,
-              page: PAGE_CONNECT_DEVICE.ConnectionError,
               button: CONNECT_DEVICE_BUTTON.GetHelp,
             });
             Linking.openURL(bleForgetDeviceUrl).catch(() => undefined);
@@ -155,7 +153,6 @@ export function ConnectionErrorState({
           onRetry={() => {
             trackConnectDeviceButtonClicked({
               sourceFlow,
-              page: PAGE_CONNECT_DEVICE.ConnectionError,
               button: CONNECT_DEVICE_BUTTON.Retry,
             });
             state.retry();

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DeviceListItem.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DeviceListItem.test.tsx
@@ -4,7 +4,6 @@ import { DeviceModelId } from "@ledgerhq/types-devices";
 import type { KnownDevice } from "@ledgerhq/live-dmk-shared";
 import type { DisplayedDevice } from "@ledgerhq/live-dmk-mobile";
 import { track } from "~/analytics";
-import { previousRouteNameRef } from "~/analytics/screenRefs";
 import { SourceFlowProvider } from "../../utils/SourceFlowContext";
 import { DeviceListItem } from "./DeviceListItem";
 
@@ -17,7 +16,6 @@ jest.mock("~/analytics", () => {
 });
 
 const mockedTrack = jest.mocked(track);
-const TEST_SOURCE = "Connect Device - Discovering";
 
 function makeKnownDevice(overrides: Partial<KnownDevice> = {}): KnownDevice {
   return {
@@ -41,7 +39,6 @@ function makeDisplayedDevice(overrides: Partial<DisplayedDevice> = {}): Displaye
 describe("DeviceListItem", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    previousRouteNameRef.current = TEST_SOURCE;
   });
 
   function renderDeviceListItem(device: DisplayedDevice) {
@@ -117,7 +114,6 @@ describe("DeviceListItem", () => {
     // THEN
     expect(mockedTrack).toHaveBeenCalledWith("device_selected", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
       deviceUxV2: true,
       modelId: DeviceModelId.stax,
       transport: "ble",

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveringState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveringState.tsx
@@ -17,7 +17,12 @@ export function DiscoveringState({ state }: Readonly<DiscoveringStateProps>): Re
 
   return (
     <Box lx={{ width: "full", gap: "s16", paddingHorizontal: "s8" }}>
-      <TrackScreen category={PAGE_CONNECT_DEVICE.Discovering} sourceFlow={sourceFlow} deviceUxV2 />
+      <TrackScreen
+        category={PAGE_CONNECT_DEVICE.Discovering}
+        sourceFlow={sourceFlow}
+        refreshSource
+        deviceUxV2
+      />
       <Text typography="heading4SemiBold" lx={{ color: "base", textAlign: "left" }}>
         {t("deviceIntentExecutor.connectDevice.states.discovering.title")}
       </Text>

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveryErrorState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveryErrorState.test.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { render, screen } from "@tests/test-renderer";
-import type { TransportIdentifier } from "@ledgerhq/device-management-kit";
 import {
   ConnectDeviceUIStateTypes,
   DiscoveryErrorTypes,
+  rnBleTransportIdentifier,
   type ConnectDeviceUIState,
   type DiscoveryError,
 } from "@ledgerhq/live-dmk-mobile";
@@ -106,16 +106,92 @@ const errorCases = [
   },
 ] as const;
 
-function makeDiscoveryError(type: DiscoveryErrorTypes): DiscoveryError {
-  if (type === DiscoveryErrorTypes.Unknown) {
-    return { type };
-  }
+const primaryCtaButtonCases = [
+  {
+    type: DiscoveryErrorTypes.BluetoothPermissionDeniedPromptable,
+    label: "Allow",
+    button: "Allow Bluetooth",
+  },
+  {
+    type: DiscoveryErrorTypes.BluetoothPermissionDeniedManualSettings,
+    label: "I enabled it, try again",
+    button: "Open Settings",
+  },
+  {
+    type: DiscoveryErrorTypes.BluetoothPermissionUnauthorizedManualSettings,
+    label: "I enabled it, try again",
+    button: "Open Settings",
+  },
+  {
+    type: DiscoveryErrorTypes.BluetoothDisabledPromptable,
+    label: "Turn on Bluetooth",
+    button: "Turn On Bluetooth",
+  },
+  {
+    type: DiscoveryErrorTypes.BluetoothDisabledManualAction,
+    label: "I enabled Bluetooth, try again",
+    button: "Open Settings",
+  },
+  {
+    type: DiscoveryErrorTypes.LocationPermissionDeniedPromptable,
+    label: "Allow",
+    button: "Allow Location",
+  },
+  {
+    type: DiscoveryErrorTypes.LocationPermissionDeniedManualSettings,
+    label: "I enabled it, try again",
+    button: "Open Settings",
+  },
+  {
+    type: DiscoveryErrorTypes.LocationDisabledPromptable,
+    label: "Turn on Location",
+    button: "Turn On Location",
+  },
+  {
+    type: DiscoveryErrorTypes.LocationDisabledManualAction,
+    label: "I enabled Location, try again",
+    button: "Open Settings",
+  },
+  {
+    type: DiscoveryErrorTypes.LocationServicePermissionMissing,
+    label: "Try again",
+    button: "Retry",
+  },
+  {
+    type: DiscoveryErrorTypes.Unknown,
+    label: "Try again",
+    button: "Retry",
+  },
+] as const;
 
-  return {
-    type,
-    transportId: "ble" as TransportIdentifier,
+function makeDiscoveryError(type: DiscoveryErrorTypes): DiscoveryError {
+  const resolvable: {
+    transportId: typeof rnBleTransportIdentifier;
+    resolution: { type: "none" };
+  } = {
+    transportId: rnBleTransportIdentifier,
     resolution: { type: "none" },
-  } as DiscoveryError;
+  };
+
+  switch (type) {
+    case DiscoveryErrorTypes.BluetoothPermissionDeniedPromptable:
+    case DiscoveryErrorTypes.BluetoothPermissionDeniedManualSettings:
+      return { ...resolvable, type, permissions: [] };
+    case DiscoveryErrorTypes.LocationPermissionDeniedPromptable:
+    case DiscoveryErrorTypes.LocationPermissionDeniedManualSettings:
+      return { ...resolvable, type, permission: "location" };
+    case DiscoveryErrorTypes.BluetoothPermissionUnauthorizedManualSettings:
+    case DiscoveryErrorTypes.BluetoothDisabledPromptable:
+    case DiscoveryErrorTypes.BluetoothDisabledManualAction:
+    case DiscoveryErrorTypes.BluetoothStateUnknownCheckOnly:
+    case DiscoveryErrorTypes.BluetoothUnsupported:
+    case DiscoveryErrorTypes.LocationDisabledPromptable:
+    case DiscoveryErrorTypes.LocationDisabledManualAction:
+    case DiscoveryErrorTypes.LocationServicePermissionMissing:
+      return { ...resolvable, type };
+    case DiscoveryErrorTypes.Unknown:
+      return { type };
+  }
 }
 
 function renderState({
@@ -247,26 +323,32 @@ describe("DiscoveryErrorState", () => {
     expect(mockedTrackScreen.mock.calls[0]?.[0]).not.toHaveProperty("transport");
   });
 
-  it("GIVEN a retry CTA WHEN it is pressed THEN it tracks button_clicked", async () => {
-    // GIVEN
-    const retry = jest.fn();
-    const { user } = renderState({
-      type: DiscoveryErrorTypes.BluetoothPermissionDeniedPromptable,
-      retry,
-    });
+  it.each(primaryCtaButtonCases)(
+    "GIVEN a $type primary CTA WHEN it is pressed THEN it tracks the canonical button value",
+    async ({ type, label, button }) => {
+      // GIVEN
+      const retry = jest.fn();
+      const { user } = renderState({
+        type,
+        retry,
+      });
 
-    // WHEN
-    await user.press(screen.getByText("Allow"));
+      // WHEN
+      const cta = screen.getAllByText(label).at(-1);
+      if (!cta) throw new Error(`Missing CTA: ${label}`);
+      await user.press(cta);
 
-    // THEN
-    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
-      sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      deviceUxV2: true,
-      button: "Retry",
-    });
-    expect(retry).toHaveBeenCalledTimes(1);
-  });
+      // THEN
+      expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+        sourceFlow: "my_ledger",
+        source: TEST_SOURCE,
+        page: PAGE_CONNECT_DEVICE.DiscoveryError,
+        deviceUxV2: true,
+        button,
+      });
+      expect(retry).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it("GIVEN an ignore CTA WHEN it is pressed THEN it tracks button_clicked", async () => {
     // GIVEN
@@ -281,6 +363,7 @@ describe("DiscoveryErrorState", () => {
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
       source: TEST_SOURCE,
+      page: PAGE_CONNECT_DEVICE.DiscoveryError,
       deviceUxV2: true,
       button: "Continue with USB",
     });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveryErrorState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveryErrorState.test.tsx
@@ -9,7 +9,6 @@ import {
 } from "@ledgerhq/live-dmk-mobile";
 import type { AppPlatform } from "@ledgerhq/live-common/platform/types";
 import { TrackScreen, track } from "~/analytics";
-import { previousRouteNameRef } from "~/analytics/screenRefs";
 import { SourceFlowProvider } from "../../utils/SourceFlowContext";
 import { PAGE_CONNECT_DEVICE } from "../../utils/trackDeviceIntent";
 import { DiscoveryErrorState } from "./DiscoveryErrorState";
@@ -25,7 +24,6 @@ jest.mock("~/analytics", () => {
 
 const mockedTrackScreen = jest.mocked(TrackScreen);
 const mockedTrack = jest.mocked(track);
-const TEST_SOURCE = "Connect Device - Discovery Error";
 
 type DiscoveryErrorUIState = Extract<
   ConnectDeviceUIState,
@@ -223,18 +221,27 @@ function renderState({
 describe("DiscoveryErrorState", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    previousRouteNameRef.current = TEST_SOURCE;
   });
 
-  it.each(errorCases)(
-    "should render the $type error title and description",
-    ({ type, title, description }) => {
+  it.each(errorCases)("should render the $type error title", ({ type, title }) => {
+    renderState({ type });
+
+    expect(screen.getByText(title)).toBeVisible();
+  });
+
+  it.each(errorCases.filter(({ description }) => description))(
+    "GIVEN a $type error with a description WHEN rendering THEN it renders the error description",
+    ({ type, description }) => {
+      // GIVEN
+      if (!description) {
+        throw new Error("Expected error case to include a description");
+      }
+
+      // WHEN
       renderState({ type });
 
-      expect(screen.getByText(title)).toBeVisible();
-      if (description) {
-        expect(screen.getByText(description)).toBeVisible();
-      }
+      // THEN
+      expect(screen.getByText(description)).toBeVisible();
     },
   );
 
@@ -341,8 +348,6 @@ describe("DiscoveryErrorState", () => {
       // THEN
       expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
         sourceFlow: "my_ledger",
-        source: TEST_SOURCE,
-        page: PAGE_CONNECT_DEVICE.DiscoveryError,
         deviceUxV2: true,
         button,
       });
@@ -362,8 +367,6 @@ describe("DiscoveryErrorState", () => {
     // THEN
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_CONNECT_DEVICE.DiscoveryError,
       deviceUxV2: true,
       button: "Continue with USB",
     });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveryErrorState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveryErrorState.test.tsx
@@ -9,8 +9,9 @@ import {
 } from "@ledgerhq/live-dmk-mobile";
 import type { AppPlatform } from "@ledgerhq/live-common/platform/types";
 import { TrackScreen, track } from "~/analytics";
+import { currentRouteNameRef } from "~/analytics/screenRefs";
 import { SourceFlowProvider } from "../../utils/SourceFlowContext";
-import { PAGE_CONNECT_DEVICE } from "../../utils/trackDeviceIntent";
+import { PAGE_CONNECT_DEVICE, trackDeviceflowCanceled } from "../../utils/trackDeviceIntent";
 import { DiscoveryErrorState } from "./DiscoveryErrorState";
 
 jest.mock("~/analytics", () => {
@@ -196,15 +197,17 @@ function renderState({
   type,
   retry,
   platform = "android",
+  error,
 }: {
   type: DiscoveryErrorTypes;
   retry?: DiscoveryErrorUIState["retry"];
   platform?: Exclude<AppPlatform, "desktop">;
+  error?: DiscoveryError;
 }) {
   const ignore = jest.fn();
   const state: DiscoveryErrorUIState = {
     type: ConnectDeviceUIStateTypes.DiscoveryError,
-    error: makeDiscoveryError(type),
+    error: error ?? makeDiscoveryError(type),
     retry,
     ignore,
   };
@@ -221,6 +224,7 @@ function renderState({
 describe("DiscoveryErrorState", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    currentRouteNameRef.current = PAGE_CONNECT_DEVICE.DiscoveryError;
   });
 
   it.each(errorCases)("should render the $type error title", ({ type, title }) => {
@@ -328,6 +332,74 @@ describe("DiscoveryErrorState", () => {
       undefined,
     );
     expect(mockedTrackScreen.mock.calls[0]?.[0]).not.toHaveProperty("transport");
+  });
+
+  it("GIVEN an unknown discovery error without resolution WHEN cancelling THEN it tracks deviceflow_failed", () => {
+    // GIVEN
+    renderState({ type: DiscoveryErrorTypes.Unknown });
+    mockedTrack.mockClear();
+
+    // WHEN
+    trackDeviceflowCanceled({ sourceFlow: "my_ledger" });
+
+    // THEN
+    expect(mockedTrack).toHaveBeenCalledWith("deviceflow_failed", {
+      sourceFlow: "my_ledger",
+      deviceUxV2: true,
+    });
+  });
+
+  it("GIVEN a discovery error with no recovery resolution WHEN cancelling THEN it tracks deviceflow_failed", () => {
+    // GIVEN
+    renderState({ type: DiscoveryErrorTypes.BluetoothUnsupported });
+    mockedTrack.mockClear();
+
+    // WHEN
+    trackDeviceflowCanceled({ sourceFlow: "my_ledger" });
+
+    // THEN
+    expect(mockedTrack).toHaveBeenCalledWith("deviceflow_failed", {
+      sourceFlow: "my_ledger",
+      deviceUxV2: true,
+    });
+  });
+
+  it("GIVEN a discovery error with a retryable resolution WHEN cancelling THEN it tracks deviceflow_aborted", () => {
+    // GIVEN
+    renderState({
+      type: DiscoveryErrorTypes.BluetoothDisabledPromptable,
+      error: {
+        type: DiscoveryErrorTypes.BluetoothDisabledPromptable,
+        transportId: rnBleTransportIdentifier,
+        resolution: { type: "prompt", retry: jest.fn() },
+      },
+    });
+    mockedTrack.mockClear();
+
+    // WHEN
+    trackDeviceflowCanceled({ sourceFlow: "my_ledger" });
+
+    // THEN
+    expect(mockedTrack).toHaveBeenCalledWith("deviceflow_aborted", {
+      sourceFlow: "my_ledger",
+      deviceUxV2: true,
+    });
+  });
+
+  it("GIVEN a terminal discovery error unmounted WHEN cancelling THEN it tracks deviceflow_aborted", () => {
+    // GIVEN
+    const { unmount } = renderState({ type: DiscoveryErrorTypes.Unknown });
+    unmount();
+    mockedTrack.mockClear();
+
+    // WHEN
+    trackDeviceflowCanceled({ sourceFlow: "my_ledger" });
+
+    // THEN
+    expect(mockedTrack).toHaveBeenCalledWith("deviceflow_aborted", {
+      sourceFlow: "my_ledger",
+      deviceUxV2: true,
+    });
   });
 
   it.each(primaryCtaButtonCases)(

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveryErrorState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveryErrorState.tsx
@@ -3,6 +3,7 @@ import {
   ConnectDeviceUIStateTypes,
   DiscoveryErrorTypes,
   type ConnectDeviceUIState,
+  type DiscoveryError,
 } from "@ledgerhq/live-dmk-mobile";
 import type { AppPlatform } from "@ledgerhq/live-common/platform/types";
 import { InfoState } from "LLM/components/InfoState";
@@ -15,6 +16,7 @@ import {
   getTrackingSubError,
   getTrackingTransport,
   PAGE_CONNECT_DEVICE,
+  setIsInTerminalConnectDeviceError,
   trackConnectDeviceButtonClicked,
 } from "../../utils/trackDeviceIntent";
 
@@ -43,6 +45,10 @@ type DiscoveryErrorViewStates = {
 const discoveryErrorTranslationBaseKey =
   "deviceIntentExecutor.connectDevice.states.discoveryError.errors";
 
+function isTerminalDiscoveryError(error: DiscoveryError): boolean {
+  return !error.resolution || error.resolution.type === "none";
+}
+
 export function DiscoveryErrorState({
   state,
   platform,
@@ -50,6 +56,12 @@ export function DiscoveryErrorState({
   const { t } = useTranslation();
   const sourceFlow = useSourceFlow();
   const trackingTransport = getTrackingTransport(state.error.transportId);
+
+  React.useEffect(() => {
+    setIsInTerminalConnectDeviceError(isTerminalDiscoveryError(state.error));
+    return () => setIsInTerminalConnectDeviceError(false);
+  }, [state.error]);
+
   const trackingScreen = (
     <TrackScreen
       category={PAGE_CONNECT_DEVICE.DiscoveryError}

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveryErrorState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveryErrorState.tsx
@@ -56,6 +56,7 @@ export function DiscoveryErrorState({
       sourceFlow={sourceFlow}
       {...(trackingTransport ? { transport: trackingTransport } : {})}
       subError={getTrackingSubError(state.error.type)}
+      refreshSource
       deviceUxV2
     />
   );
@@ -68,7 +69,6 @@ export function DiscoveryErrorState({
       onPress: () => {
         trackConnectDeviceButtonClicked({
           sourceFlow,
-          page: PAGE_CONNECT_DEVICE.DiscoveryError,
           button: trackButtonName,
         });
         state.retry?.();
@@ -83,7 +83,6 @@ export function DiscoveryErrorState({
       onPress: () => {
         trackConnectDeviceButtonClicked({
           sourceFlow,
-          page: PAGE_CONNECT_DEVICE.DiscoveryError,
           button: CONNECT_DEVICE_BUTTON.ContinueWithUsb,
         });
         state.ignore();

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveryErrorState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveryErrorState.tsx
@@ -60,13 +60,17 @@ export function DiscoveryErrorState({
     />
   );
 
-  const retryCta = (labelKey: string): InfoStateCta | undefined => {
+  const retryCta = (labelKey: string, trackButtonName: string): InfoStateCta | undefined => {
     if (!state.retry) return undefined;
     const label = t(labelKey);
     return {
       label,
       onPress: () => {
-        trackConnectDeviceButtonClicked({ sourceFlow, button: CONNECT_DEVICE_BUTTON.Retry });
+        trackConnectDeviceButtonClicked({
+          sourceFlow,
+          page: PAGE_CONNECT_DEVICE.DiscoveryError,
+          button: trackButtonName,
+        });
         state.retry?.();
       },
     };
@@ -79,6 +83,7 @@ export function DiscoveryErrorState({
       onPress: () => {
         trackConnectDeviceButtonClicked({
           sourceFlow,
+          page: PAGE_CONNECT_DEVICE.DiscoveryError,
           button: CONNECT_DEVICE_BUTTON.ContinueWithUsb,
         });
         state.ignore();
@@ -93,6 +98,7 @@ export function DiscoveryErrorState({
       description: `${discoveryErrorTranslationBaseKey}.bluetoothPermissionDeniedPromptable.description`,
       primaryCta: retryCta(
         `${discoveryErrorTranslationBaseKey}.bluetoothPermissionDeniedPromptable.cta.retry`,
+        CONNECT_DEVICE_BUTTON.AllowBluetooth,
       ),
       secondaryCta: ignoreCta(
         `${discoveryErrorTranslationBaseKey}.bluetoothPermissionDeniedPromptable.cta.ignore`,
@@ -104,6 +110,7 @@ export function DiscoveryErrorState({
       description: `${discoveryErrorTranslationBaseKey}.bluetoothPermissionDeniedManualSettings.description`,
       primaryCta: retryCta(
         `${discoveryErrorTranslationBaseKey}.bluetoothPermissionDeniedManualSettings.cta.retry`,
+        CONNECT_DEVICE_BUTTON.OpenSettings,
       ),
       secondaryCta: ignoreCta(
         `${discoveryErrorTranslationBaseKey}.bluetoothPermissionDeniedManualSettings.cta.ignore`,
@@ -115,6 +122,7 @@ export function DiscoveryErrorState({
       description: `${discoveryErrorTranslationBaseKey}.bluetoothPermissionUnauthorizedManualSettings.description`,
       primaryCta: retryCta(
         `${discoveryErrorTranslationBaseKey}.bluetoothPermissionUnauthorizedManualSettings.cta.platform.${platform}.retry`,
+        CONNECT_DEVICE_BUTTON.OpenSettings,
       ),
       secondaryCta:
         platform === "android"
@@ -129,6 +137,7 @@ export function DiscoveryErrorState({
       description: `${discoveryErrorTranslationBaseKey}.bluetoothDisabledPromptable.description`,
       primaryCta: retryCta(
         `${discoveryErrorTranslationBaseKey}.bluetoothDisabledPromptable.cta.retry`,
+        CONNECT_DEVICE_BUTTON.TurnOnBluetooth,
       ),
       secondaryCta: ignoreCta(
         `${discoveryErrorTranslationBaseKey}.bluetoothDisabledPromptable.cta.ignore`,
@@ -140,6 +149,7 @@ export function DiscoveryErrorState({
       description: `${discoveryErrorTranslationBaseKey}.bluetoothDisabledManualAction.description`,
       primaryCta: retryCta(
         `${discoveryErrorTranslationBaseKey}.bluetoothDisabledManualAction.cta.platform.${platform}.retry`,
+        CONNECT_DEVICE_BUTTON.OpenSettings,
       ),
       secondaryCta:
         platform === "android"
@@ -165,6 +175,7 @@ export function DiscoveryErrorState({
       description: `${discoveryErrorTranslationBaseKey}.locationPermissionDeniedPromptable.description`,
       primaryCta: retryCta(
         `${discoveryErrorTranslationBaseKey}.locationPermissionDeniedPromptable.cta.retry`,
+        CONNECT_DEVICE_BUTTON.AllowLocation,
       ),
       secondaryCta: ignoreCta(
         `${discoveryErrorTranslationBaseKey}.locationPermissionDeniedPromptable.cta.ignore`,
@@ -176,6 +187,7 @@ export function DiscoveryErrorState({
       description: `${discoveryErrorTranslationBaseKey}.locationPermissionDeniedManualSettings.description`,
       primaryCta: retryCta(
         `${discoveryErrorTranslationBaseKey}.locationPermissionDeniedManualSettings.cta.retry`,
+        CONNECT_DEVICE_BUTTON.OpenSettings,
       ),
       secondaryCta: ignoreCta(
         `${discoveryErrorTranslationBaseKey}.locationPermissionDeniedManualSettings.cta.ignore`,
@@ -187,6 +199,7 @@ export function DiscoveryErrorState({
       description: `${discoveryErrorTranslationBaseKey}.locationDisabledPromptable.description`,
       primaryCta: retryCta(
         `${discoveryErrorTranslationBaseKey}.locationDisabledPromptable.cta.retry`,
+        CONNECT_DEVICE_BUTTON.TurnOnLocation,
       ),
       secondaryCta: ignoreCta(
         `${discoveryErrorTranslationBaseKey}.locationDisabledPromptable.cta.ignore`,
@@ -198,6 +211,7 @@ export function DiscoveryErrorState({
       description: `${discoveryErrorTranslationBaseKey}.locationDisabledManualAction.description`,
       primaryCta: retryCta(
         `${discoveryErrorTranslationBaseKey}.locationDisabledManualAction.cta.retry`,
+        CONNECT_DEVICE_BUTTON.OpenSettings,
       ),
       secondaryCta: ignoreCta(
         `${discoveryErrorTranslationBaseKey}.locationDisabledManualAction.cta.ignore`,
@@ -209,6 +223,7 @@ export function DiscoveryErrorState({
       description: `${discoveryErrorTranslationBaseKey}.locationServicePermissionMissing.description`,
       primaryCta: retryCta(
         `${discoveryErrorTranslationBaseKey}.locationServicePermissionMissing.cta.retry`,
+        CONNECT_DEVICE_BUTTON.Retry,
       ),
       secondaryCta: ignoreCta(
         `${discoveryErrorTranslationBaseKey}.locationServicePermissionMissing.cta.ignore`,
@@ -218,7 +233,10 @@ export function DiscoveryErrorState({
       preset: "error",
       title: `${discoveryErrorTranslationBaseKey}.unknown.title`,
       description: `${discoveryErrorTranslationBaseKey}.unknown.description`,
-      primaryCta: retryCta(`${discoveryErrorTranslationBaseKey}.unknown.cta.retry`),
+      primaryCta: retryCta(
+        `${discoveryErrorTranslationBaseKey}.unknown.cta.retry`,
+        CONNECT_DEVICE_BUTTON.Retry,
+      ),
     },
     [DiscoveryErrorTypes.BluetoothStateUnknownCheckOnly]: {
       title: `${discoveryErrorTranslationBaseKey}.bluetoothStateUnknownCheckOnly.title`,

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/NoKnownDeviceState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/NoKnownDeviceState.test.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { render, screen } from "@tests/test-renderer";
 import { TrackScreen, track } from "~/analytics";
-import { previousRouteNameRef } from "~/analytics/screenRefs";
 import { SourceFlowProvider } from "../../utils/SourceFlowContext";
 import { PAGE_CONNECT_DEVICE } from "../../utils/trackDeviceIntent";
 import { NoKnownDeviceState } from "./NoKnownDeviceState";
@@ -17,7 +16,6 @@ jest.mock("~/analytics", () => {
 
 const mockedTrackScreen = jest.mocked(TrackScreen);
 const mockedTrack = jest.mocked(track);
-const TEST_SOURCE = "Portfolio";
 
 function renderState() {
   const onConnectLedgerDevice = jest.fn();
@@ -37,7 +35,6 @@ function renderState() {
 describe("NoKnownDeviceState", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    previousRouteNameRef.current = TEST_SOURCE;
   });
 
   it("should render the no known device title and description", () => {
@@ -83,15 +80,11 @@ describe("NoKnownDeviceState", () => {
     // THEN
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_CONNECT_DEVICE.NoKnownDevice,
       deviceUxV2: true,
       button: "Connect Device",
     });
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_CONNECT_DEVICE.NoKnownDevice,
       deviceUxV2: true,
       button: "Buy Device",
     });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/NoKnownDeviceState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/NoKnownDeviceState.test.tsx
@@ -84,14 +84,16 @@ describe("NoKnownDeviceState", () => {
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
       source: TEST_SOURCE,
+      page: PAGE_CONNECT_DEVICE.NoKnownDevice,
       deviceUxV2: true,
-      button: "Connect Ledger Device",
+      button: "Connect Device",
     });
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
       source: TEST_SOURCE,
+      page: PAGE_CONNECT_DEVICE.NoKnownDevice,
       deviceUxV2: true,
-      button: "I Don't Have A Ledger Device",
+      button: "Buy Device",
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/NoKnownDeviceState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/NoKnownDeviceState.tsx
@@ -24,7 +24,6 @@ export function NoKnownDeviceState({
   const handleConnectLedgerDevice = () => {
     trackConnectDeviceButtonClicked({
       sourceFlow,
-      page: PAGE_CONNECT_DEVICE.NoKnownDevice,
       button: CONNECT_DEVICE_BUTTON.ConnectDevice,
     });
     onConnectLedgerDevice();
@@ -32,7 +31,6 @@ export function NoKnownDeviceState({
   const handleBuyLedgerDevice = () => {
     trackConnectDeviceButtonClicked({
       sourceFlow,
-      page: PAGE_CONNECT_DEVICE.NoKnownDevice,
       button: CONNECT_DEVICE_BUTTON.BuyDevice,
     });
     onBuyLedgerDevice();
@@ -43,6 +41,7 @@ export function NoKnownDeviceState({
       <TrackScreen
         category={PAGE_CONNECT_DEVICE.NoKnownDevice}
         sourceFlow={sourceFlow}
+        refreshSource
         deviceUxV2
       />
       <Box lx={{ width: "full", alignItems: "center", gap: "s24" }}>

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/NoKnownDeviceState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/NoKnownDeviceState.tsx
@@ -24,12 +24,17 @@ export function NoKnownDeviceState({
   const handleConnectLedgerDevice = () => {
     trackConnectDeviceButtonClicked({
       sourceFlow,
-      button: CONNECT_DEVICE_BUTTON.ConnectLedgerDevice,
+      page: PAGE_CONNECT_DEVICE.NoKnownDevice,
+      button: CONNECT_DEVICE_BUTTON.ConnectDevice,
     });
     onConnectLedgerDevice();
   };
   const handleBuyLedgerDevice = () => {
-    trackConnectDeviceButtonClicked({ sourceFlow, button: CONNECT_DEVICE_BUTTON.NoLedgerDevice });
+    trackConnectDeviceButtonClicked({
+      sourceFlow,
+      page: PAGE_CONNECT_DEVICE.NoKnownDevice,
+      button: CONNECT_DEVICE_BUTTON.BuyDevice,
+    });
     onBuyLedgerDevice();
   };
 

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/WaitingForSelectedDeviceState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/WaitingForSelectedDeviceState.tsx
@@ -34,6 +34,7 @@ export function WaitingForSelectedDeviceState({
         category={PAGE_CONNECT_DEVICE.WaitingForSelectedDevice}
         sourceFlow={sourceFlow}
         modelId={state.device.deviceModelId}
+        refreshSource
         deviceUxV2
       />
       <DeviceActionContent

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/useDeviceConnectionComponentLWMViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/useDeviceConnectionComponentLWMViewModel.test.tsx
@@ -14,7 +14,6 @@ import {
 } from "@ledgerhq/live-dmk-mobile";
 import type { KnownDevice } from "@ledgerhq/live-dmk-shared";
 import { track } from "~/analytics";
-import { previousRouteNameRef } from "~/analytics/screenRefs";
 import { NavigatorName, ScreenName } from "~/const";
 import type { DeviceLike, State } from "~/reducers/types";
 import { urls } from "~/utils/urls";
@@ -110,10 +109,8 @@ function withViewModelState({
 }
 
 const sourceFlow: SourceFlow = "my_ledger";
-const TEST_SOURCE = "Portfolio";
 
 const layerABaseProperties = {
-  source: TEST_SOURCE,
   deviceUxV2: true,
 };
 
@@ -173,7 +170,6 @@ describe("useDeviceConnectionComponentLWMViewModel", () => {
     jest.clearAllMocks();
     connectDeviceObserver = undefined;
     mockUnsubscribe = jest.fn();
-    previousRouteNameRef.current = TEST_SOURCE;
     mockedUseDeviceManagementKit.mockReturnValue(mockDmk);
     mockConnectDeviceSubscription();
   });
@@ -396,21 +392,15 @@ describe("useDeviceConnectionComponentLWMViewModel", () => {
   });
 
   describe("Layer A funnel events", () => {
-    describe("GIVEN the ViewModel mounts", () => {
-      it("WHEN the hook initializes THEN it fires deviceflow_started exactly once with the sourceFlow", () => {
-        // WHEN
-        renderViewModel();
+    it("GIVEN the ViewModel mounts WHEN the hook initializes THEN it does not fire deviceflow_started", () => {
+      // WHEN
+      renderViewModel();
 
-        // THEN
-        const startedCalls = mockedTrack.mock.calls.filter(
-          ([eventName]) => eventName === "deviceflow_started",
-        );
-        expect(startedCalls).toHaveLength(1);
-        expect(startedCalls[0]).toEqual([
-          "deviceflow_started",
-          { ...layerABaseProperties, sourceFlow: "my_ledger" },
-        ]);
-      });
+      // THEN
+      const startedCalls = mockedTrack.mock.calls.filter(
+        ([eventName]) => eventName === "deviceflow_started",
+      );
+      expect(startedCalls).toHaveLength(0);
     });
 
     describe("GIVEN the connect-device SM transitions to Discovering", () => {

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/useDeviceConnectionComponentLWMViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/useDeviceConnectionComponentLWMViewModel.ts
@@ -25,7 +25,6 @@ import type { AppPlatform } from "@ledgerhq/live-common/platform/types";
 import {
   trackDeviceConnected,
   trackDeviceConnecting,
-  trackDeviceflowStarted,
   trackDevicePrompted,
 } from "../utils/trackDeviceIntent";
 import { useSourceFlow } from "../utils/SourceFlowContext";
@@ -67,19 +66,11 @@ export function useDeviceConnectionComponentLWMViewModel({
     throw new Error("Device Management Kit is not available");
   }
 
-  // Funnel-firing guards: each of `deviceflow_started`, `device_prompted`,
-  // `device_connecting` fires at most once per ViewModel lifetime.
-  const firedRef = useRef<{ started: boolean; prompted: boolean; connecting: boolean }>({
-    started: false,
+  // Funnel-firing guards: each event fires at most once per ViewModel lifetime.
+  const firedRef = useRef<{ prompted: boolean; connecting: boolean }>({
     prompted: false,
     connecting: false,
   });
-
-  useEffect(() => {
-    if (firedRef.current.started) return;
-    firedRef.current.started = true;
-    trackDeviceflowStarted({ sourceFlow });
-  }, [sourceFlow]);
 
   useEffect(() => {
     switch (state.type) {

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/useDeviceConnectionComponentLWMViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/useDeviceConnectionComponentLWMViewModel.ts
@@ -67,9 +67,10 @@ export function useDeviceConnectionComponentLWMViewModel({
   }
 
   // Funnel-firing guards: each event fires at most once per ViewModel lifetime.
-  const firedRef = useRef<{ prompted: boolean; connecting: boolean }>({
+  const firedRef = useRef({
     prompted: false,
     connecting: false,
+    connected: false,
   });
 
   useEffect(() => {
@@ -127,7 +128,10 @@ export function useDeviceConnectionComponentLWMViewModel({
       const modelId = dmkToLedgerDeviceIdMap[result.connectedDevice.modelId];
       const transport: "ble" | "usb" = result.connectedDevice.type === "USB" ? "usb" : "ble";
 
-      trackDeviceConnected({ sourceFlow, modelId, transport });
+      if (!firedRef.current.connected) {
+        firedRef.current.connected = true;
+        trackDeviceConnected({ sourceFlow, modelId, transport });
+      }
 
       dispatch(
         setLastConnectedDevice({

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/AllowSecureConnectionState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/AllowSecureConnectionState.tsx
@@ -19,6 +19,7 @@ export function AllowSecureConnectionState({
         category={PAGE_CONNECT_APP.AllowSecureConnection}
         sourceFlow={sourceFlow}
         modelId={device.modelId}
+        refreshSource
         deviceUxV2
       />
       <ContinueOnDevice

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/ConfirmOpenAppState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/ConfirmOpenAppState.tsx
@@ -16,6 +16,7 @@ export function ConfirmOpenAppState({ device, sourceFlow }: ConfirmOpenAppStateP
         category={PAGE_CONNECT_APP.ConfirmOpenApp}
         sourceFlow={sourceFlow}
         modelId={device.modelId}
+        refreshSource
         deviceUxV2
       />
       <ContinueOnDevice

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceBusyState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceBusyState.test.tsx
@@ -94,13 +94,14 @@ describe("DeviceBusyState", () => {
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
       source: TEST_SOURCE,
+      page: PAGE_CONNECT_APP.DeviceBusy,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Retry",
     });
   });
 
-  it("GIVEN the device busy state WHEN pressing Cancel operation THEN it tracks the canonical button value", async () => {
+  it("GIVEN the device busy state WHEN pressing Cancel operation THEN it tracks Close", async () => {
     const { user } = renderState();
 
     await user.press(screen.getByText("Cancel operation"));
@@ -108,9 +109,10 @@ describe("DeviceBusyState", () => {
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
       source: TEST_SOURCE,
+      page: PAGE_CONNECT_APP.DeviceBusy,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
-      button: "Cancel",
+      button: "Close",
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceBusyState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceBusyState.test.tsx
@@ -3,7 +3,6 @@ import { render, screen } from "@tests/test-renderer";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { RetryableStateType } from "@ledgerhq/live-dmk-shared";
 import { TrackScreen, track } from "~/analytics";
-import { previousRouteNameRef } from "~/analytics/screenRefs";
 import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import { DeviceBusyState } from "./DeviceBusyState";
 import type { InitializerDevice } from "../types";
@@ -19,7 +18,6 @@ jest.mock("~/analytics", () => {
 
 const mockedTrackScreen = jest.mocked(TrackScreen);
 const mockedTrack = jest.mocked(track);
-const TEST_SOURCE = "Portfolio";
 
 const device: InitializerDevice = {
   id: "device-id",
@@ -50,7 +48,6 @@ function renderState() {
 describe("DeviceBusyState", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    previousRouteNameRef.current = TEST_SOURCE;
   });
 
   it("GIVEN the device busy state WHEN rendering THEN it renders the title, description and action buttons", () => {
@@ -93,8 +90,6 @@ describe("DeviceBusyState", () => {
 
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_CONNECT_APP.DeviceBusy,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Retry",
@@ -108,8 +103,6 @@ describe("DeviceBusyState", () => {
 
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_CONNECT_APP.DeviceBusy,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Close",

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceBusyState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceBusyState.tsx
@@ -18,11 +18,21 @@ export function DeviceBusyState({ state, device, sourceFlow, onCancel }: DeviceB
   const modelId = device.modelId;
 
   const handleRetry = () => {
-    trackConnectAppButtonClicked({ sourceFlow, modelId, button: CONNECT_APP_BUTTON.Retry });
+    trackConnectAppButtonClicked({
+      sourceFlow,
+      page: PAGE_CONNECT_APP.DeviceBusy,
+      modelId,
+      button: CONNECT_APP_BUTTON.Retry,
+    });
     state.retry();
   };
   const handleCancel = () => {
-    trackConnectAppButtonClicked({ sourceFlow, modelId, button: CONNECT_APP_BUTTON.Cancel });
+    trackConnectAppButtonClicked({
+      sourceFlow,
+      page: PAGE_CONNECT_APP.DeviceBusy,
+      modelId,
+      button: CONNECT_APP_BUTTON.Close,
+    });
     onCancel();
   };
 

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceBusyState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceBusyState.tsx
@@ -20,7 +20,6 @@ export function DeviceBusyState({ state, device, sourceFlow, onCancel }: DeviceB
   const handleRetry = () => {
     trackConnectAppButtonClicked({
       sourceFlow,
-      page: PAGE_CONNECT_APP.DeviceBusy,
       modelId,
       button: CONNECT_APP_BUTTON.Retry,
     });
@@ -29,7 +28,6 @@ export function DeviceBusyState({ state, device, sourceFlow, onCancel }: DeviceB
   const handleCancel = () => {
     trackConnectAppButtonClicked({
       sourceFlow,
-      page: PAGE_CONNECT_APP.DeviceBusy,
       modelId,
       button: CONNECT_APP_BUTTON.Close,
     });
@@ -42,6 +40,7 @@ export function DeviceBusyState({ state, device, sourceFlow, onCancel }: DeviceB
         category={PAGE_CONNECT_APP.DeviceBusy}
         sourceFlow={sourceFlow}
         modelId={modelId}
+        refreshSource
         deviceUxV2
       />
       <InfoState

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceDeprecatedBlockingState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceDeprecatedBlockingState.test.tsx
@@ -5,7 +5,6 @@ import { getDeviceModel } from "@ledgerhq/devices";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { BlockingStateType } from "@ledgerhq/live-dmk-shared";
 import { TrackScreen, track } from "~/analytics";
-import { previousRouteNameRef } from "~/analytics/screenRefs";
 import { DeviceDeprecatedBlockingState } from "./DeviceDeprecatedBlockingState";
 import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import type { InitializerDevice } from "../types";
@@ -21,7 +20,6 @@ jest.mock("~/analytics", () => {
 
 const mockedTrackScreen = jest.mocked(TrackScreen);
 const mockedTrack = jest.mocked(track);
-const TEST_SOURCE = "Portfolio";
 
 const device: InitializerDevice = {
   id: "device-id",
@@ -56,7 +54,6 @@ describe("DeviceDeprecatedBlockingState", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
-    previousRouteNameRef.current = TEST_SOURCE;
   });
 
   it("GIVEN the blocking deprecation state WHEN rendering THEN it renders the error screen with the decision details", () => {
@@ -98,8 +95,6 @@ describe("DeviceDeprecatedBlockingState", () => {
     // THEN
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_CONNECT_APP.DeviceDeprecatedBlocking,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Learn More",
@@ -116,8 +111,6 @@ describe("DeviceDeprecatedBlockingState", () => {
     // THEN
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_CONNECT_APP.DeviceDeprecatedBlocking,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Discover Upgrade Program",

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceDeprecatedBlockingState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceDeprecatedBlockingState.test.tsx
@@ -1,14 +1,12 @@
 import React from "react";
-import { render } from "@tests/test-renderer";
+import { Linking } from "react-native";
+import { render, screen } from "@tests/test-renderer";
 import { getDeviceModel } from "@ledgerhq/devices";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { BlockingStateType } from "@ledgerhq/live-dmk-shared";
-import { TrackScreen } from "~/analytics";
+import { TrackScreen, track } from "~/analytics";
+import { previousRouteNameRef } from "~/analytics/screenRefs";
 import { DeviceDeprecatedBlockingState } from "./DeviceDeprecatedBlockingState";
-import {
-  DeviceDeprecationScreen,
-  DeviceDeprecationScreens,
-} from "~/components/DeviceAction/Screen/DeviceDeprecationScreen";
 import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import type { InitializerDevice } from "../types";
 
@@ -17,19 +15,13 @@ jest.mock("~/analytics", () => {
   return {
     ...actual,
     TrackScreen: jest.fn(() => null),
-  };
-});
-
-jest.mock("~/components/DeviceAction/Screen/DeviceDeprecationScreen", () => {
-  const actual = jest.requireActual("~/components/DeviceAction/Screen/DeviceDeprecationScreen");
-  return {
-    ...actual,
-    DeviceDeprecationScreen: jest.fn(() => null),
+    track: jest.fn(),
   };
 });
 
 const mockedTrackScreen = jest.mocked(TrackScreen);
-const mockedDeviceDeprecationScreen = jest.mocked(DeviceDeprecationScreen);
+const mockedTrack = jest.mocked(track);
+const TEST_SOURCE = "Portfolio";
 
 const device: InitializerDevice = {
   id: "device-id",
@@ -63,20 +55,23 @@ function renderState() {
 describe("DeviceDeprecatedBlockingState", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
+    previousRouteNameRef.current = TEST_SOURCE;
   });
 
   it("GIVEN the blocking deprecation state WHEN rendering THEN it renders the error screen with the decision details", () => {
     renderState();
 
-    expect(mockedDeviceDeprecationScreen).toHaveBeenCalledTimes(1);
-    expect(mockedDeviceDeprecationScreen.mock.calls[0][0]).toEqual(
-      expect.objectContaining({
-        coinName: "Bitcoin",
-        date: supportEndDate,
-        productName: getDeviceModel(DeviceModelId.nanoS).productName,
-        screenName: DeviceDeprecationScreens.errorScreen,
-      }),
-    );
+    expect(
+      screen.getByText(
+        `${getDeviceModel(DeviceModelId.nanoS).productName}™ does not support this feature`,
+      ),
+    ).toBeVisible();
+    expect(
+      screen.getByText(
+        "Upgrade to a more recent Ledger device today to ensure access to all the latest Ledger Live features.",
+      ),
+    ).toBeVisible();
   });
 
   it("GIVEN the blocking deprecation state WHEN rendering THEN it fires the page event with sourceFlow and modelId", () => {
@@ -91,5 +86,41 @@ describe("DeviceDeprecatedBlockingState", () => {
       }),
       undefined,
     );
+  });
+
+  it("GIVEN the blocking deprecation state WHEN pressing Learn More THEN it tracks the canonical button value", async () => {
+    // GIVEN
+    const { user } = renderState();
+
+    // WHEN
+    await user.press(screen.getByText("Learn more"));
+
+    // THEN
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      page: PAGE_CONNECT_APP.DeviceDeprecatedBlocking,
+      deviceUxV2: true,
+      modelId: DeviceModelId.europa,
+      button: "Learn More",
+    });
+  });
+
+  it("GIVEN the blocking deprecation state WHEN pressing the upgrade CTA THEN it tracks the canonical button value", async () => {
+    // GIVEN
+    const { user } = renderState();
+
+    // WHEN
+    await user.press(screen.getByText("Discover your Upgrade Program"));
+
+    // THEN
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      page: PAGE_CONNECT_APP.DeviceDeprecatedBlocking,
+      deviceUxV2: true,
+      modelId: DeviceModelId.europa,
+      button: "Discover Upgrade Program",
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceDeprecatedBlockingState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceDeprecatedBlockingState.tsx
@@ -6,7 +6,11 @@ import {
   DeviceDeprecationScreens,
 } from "~/components/DeviceAction/Screen/DeviceDeprecationScreen";
 import { TrackScreen } from "~/analytics";
-import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
+import {
+  CONNECT_APP_BUTTON,
+  PAGE_CONNECT_APP,
+  trackConnectAppButtonClicked,
+} from "../../utils/trackDeviceIntent";
 import type { BaseInitializerStateProps } from "../types";
 
 type DeviceDeprecatedBlockingStateProps = BaseInitializerStateProps<
@@ -19,19 +23,40 @@ export function DeviceDeprecatedBlockingState({
   sourceFlow,
 }: DeviceDeprecatedBlockingStateProps) {
   const { decision } = state;
+  const modelId = device.modelId;
+
+  const handleLearnMore = () => {
+    trackConnectAppButtonClicked({
+      sourceFlow,
+      page: PAGE_CONNECT_APP.DeviceDeprecatedBlocking,
+      modelId,
+      button: CONNECT_APP_BUTTON.LearnMore,
+    });
+  };
+
+  const handleUpgrade = () => {
+    trackConnectAppButtonClicked({
+      sourceFlow,
+      page: PAGE_CONNECT_APP.DeviceDeprecatedBlocking,
+      modelId,
+      button: CONNECT_APP_BUTTON.DiscoverUpgradeProgram,
+    });
+  };
 
   return (
     <>
       <TrackScreen
         category={PAGE_CONNECT_APP.DeviceDeprecatedBlocking}
         sourceFlow={sourceFlow}
-        modelId={device.modelId}
+        modelId={modelId}
         deviceUxV2
       />
       <DeviceDeprecationScreen
         coinName={decision.currencyName}
         date={decision.supportEndDate}
         onContinue={() => undefined}
+        onLearnMore={handleLearnMore}
+        onUpgrade={handleUpgrade}
         productName={getDeviceModel(decision.deviceModelId).productName}
         screenName={DeviceDeprecationScreens.errorScreen}
       />

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceDeprecatedBlockingState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceDeprecatedBlockingState.tsx
@@ -28,7 +28,6 @@ export function DeviceDeprecatedBlockingState({
   const handleLearnMore = () => {
     trackConnectAppButtonClicked({
       sourceFlow,
-      page: PAGE_CONNECT_APP.DeviceDeprecatedBlocking,
       modelId,
       button: CONNECT_APP_BUTTON.LearnMore,
     });
@@ -37,7 +36,6 @@ export function DeviceDeprecatedBlockingState({
   const handleUpgrade = () => {
     trackConnectAppButtonClicked({
       sourceFlow,
-      page: PAGE_CONNECT_APP.DeviceDeprecatedBlocking,
       modelId,
       button: CONNECT_APP_BUTTON.DiscoverUpgradeProgram,
     });
@@ -49,6 +47,7 @@ export function DeviceDeprecatedBlockingState({
         category={PAGE_CONNECT_APP.DeviceDeprecatedBlocking}
         sourceFlow={sourceFlow}
         modelId={modelId}
+        refreshSource
         deviceUxV2
       />
       <DeviceDeprecationScreen

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceDeprecatedNonBlockingState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceDeprecatedNonBlockingState.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { render } from "@tests/test-renderer";
-import { getDeviceModel } from "@ledgerhq/devices";
+import { Linking } from "react-native";
+import { render, screen } from "@tests/test-renderer";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import {
   AppInteractionRequiredStateType,
@@ -9,10 +9,6 @@ import {
 import { TrackScreen, track } from "~/analytics";
 import { previousRouteNameRef } from "~/analytics/screenRefs";
 import { DeviceDeprecatedNonBlockingState } from "./DeviceDeprecatedNonBlockingState";
-import {
-  DeviceDeprecationScreen,
-  DeviceDeprecationScreens,
-} from "~/components/DeviceAction/Screen/DeviceDeprecationScreen";
 import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import type { InitializerDevice } from "../types";
 
@@ -25,17 +21,8 @@ jest.mock("~/analytics", () => {
   };
 });
 
-jest.mock("~/components/DeviceAction/Screen/DeviceDeprecationScreen", () => {
-  const actual = jest.requireActual("~/components/DeviceAction/Screen/DeviceDeprecationScreen");
-  return {
-    ...actual,
-    DeviceDeprecationScreen: jest.fn(() => null),
-  };
-});
-
 const mockedTrackScreen = jest.mocked(TrackScreen);
 const mockedTrack = jest.mocked(track);
-const mockedDeviceDeprecationScreen = jest.mocked(DeviceDeprecationScreen);
 const TEST_SOURCE = "Portfolio";
 
 const device: InitializerDevice = {
@@ -74,56 +61,43 @@ function renderState(screenSequence: DeprecationScreenKind[]) {
 const screenSequenceCases: {
   name: string;
   screenSequence: DeprecationScreenKind[];
-  expectedScreenName: DeviceDeprecationScreens;
-  expectedDisplayClearSigningWarning: boolean;
+  expectedTitle: RegExp;
 }[] = [
   {
     name: "warning + clearSigning",
     screenSequence: ["warning", "clearSigning"],
-    expectedScreenName: DeviceDeprecationScreens.warningScreen,
-    expectedDisplayClearSigningWarning: true,
+    expectedTitle: /Bitcoin support on Ledger Nano S™ via Ledger Live™ will end/,
   },
   {
     name: "warning only",
     screenSequence: ["warning"],
-    expectedScreenName: DeviceDeprecationScreens.warningScreen,
-    expectedDisplayClearSigningWarning: false,
+    expectedTitle: /Bitcoin support on Ledger Nano S™ via Ledger Live™ will end/,
   },
   {
     name: "clearSigning only",
     screenSequence: ["clearSigning"],
-    expectedScreenName: DeviceDeprecationScreens.clearSigningScreen,
-    expectedDisplayClearSigningWarning: true,
+    expectedTitle: /Ledger Nano S™ can not Clear Sign this transaction/,
   },
   {
     name: "empty sequence",
     screenSequence: [],
-    expectedScreenName: DeviceDeprecationScreens.clearSigningScreen,
-    expectedDisplayClearSigningWarning: false,
+    expectedTitle: /Ledger Nano S™ can not Clear Sign this transaction/,
   },
 ];
 
 describe("DeviceDeprecatedNonBlockingState", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
     previousRouteNameRef.current = TEST_SOURCE;
   });
 
   it.each(screenSequenceCases)(
     "GIVEN the $name screen sequence WHEN rendering THEN it renders the matching deprecation screen",
-    ({ screenSequence, expectedScreenName, expectedDisplayClearSigningWarning }) => {
+    ({ screenSequence, expectedTitle }) => {
       renderState(screenSequence);
 
-      expect(mockedDeviceDeprecationScreen).toHaveBeenCalledTimes(1);
-      expect(mockedDeviceDeprecationScreen.mock.calls[0][0]).toEqual(
-        expect.objectContaining({
-          coinName: "Bitcoin",
-          date: supportEndDate,
-          productName: getDeviceModel(DeviceModelId.nanoS).productName,
-          screenName: expectedScreenName,
-          displayClearSigningWarning: expectedDisplayClearSigningWarning,
-        }),
-      );
+      expect(screen.getByText(expectedTitle)).toBeVisible();
     },
   );
 
@@ -141,18 +115,34 @@ describe("DeviceDeprecatedNonBlockingState", () => {
     );
   });
 
-  it("GIVEN the non-blocking deprecation state WHEN invoking continue THEN it tracks Continue and forwards to onContinue", () => {
-    const { onContinue } = renderState(["warning"]);
+  it("GIVEN the non-blocking deprecation state WHEN pressing Continue THEN it tracks Continue and forwards to onContinue", async () => {
+    const { onContinue, user } = renderState(["warning"]);
 
-    mockedDeviceDeprecationScreen.mock.calls[0][0].onContinue?.();
+    await user.press(screen.getByTestId("enabled-warning-deprecation-continue"));
 
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
       source: TEST_SOURCE,
+      page: PAGE_CONNECT_APP.DeviceDeprecatedWarning,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Continue",
     });
     expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+
+  it("GIVEN the non-blocking deprecation state WHEN pressing the upgrade CTA THEN it tracks the canonical button value", async () => {
+    const { user } = renderState(["warning"]);
+
+    await user.press(screen.getByText("Discover your Upgrade Program"));
+
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      page: PAGE_CONNECT_APP.DeviceDeprecatedWarning,
+      deviceUxV2: true,
+      modelId: DeviceModelId.europa,
+      button: "Discover Upgrade Program",
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceDeprecatedNonBlockingState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceDeprecatedNonBlockingState.test.tsx
@@ -7,7 +7,6 @@ import {
   type DeprecationScreenKind,
 } from "@ledgerhq/live-dmk-shared";
 import { TrackScreen, track } from "~/analytics";
-import { previousRouteNameRef } from "~/analytics/screenRefs";
 import { DeviceDeprecatedNonBlockingState } from "./DeviceDeprecatedNonBlockingState";
 import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import type { InitializerDevice } from "../types";
@@ -23,7 +22,6 @@ jest.mock("~/analytics", () => {
 
 const mockedTrackScreen = jest.mocked(TrackScreen);
 const mockedTrack = jest.mocked(track);
-const TEST_SOURCE = "Portfolio";
 
 const device: InitializerDevice = {
   id: "device-id",
@@ -89,7 +87,6 @@ describe("DeviceDeprecatedNonBlockingState", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
-    previousRouteNameRef.current = TEST_SOURCE;
   });
 
   it.each(screenSequenceCases)(
@@ -122,8 +119,6 @@ describe("DeviceDeprecatedNonBlockingState", () => {
 
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_CONNECT_APP.DeviceDeprecatedWarning,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Continue",
@@ -138,8 +133,6 @@ describe("DeviceDeprecatedNonBlockingState", () => {
 
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_CONNECT_APP.DeviceDeprecatedWarning,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Discover Upgrade Program",

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceDeprecatedNonBlockingState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceDeprecatedNonBlockingState.tsx
@@ -35,7 +35,6 @@ export function DeviceDeprecatedNonBlockingState({
   const handleContinue = () => {
     trackConnectAppButtonClicked({
       sourceFlow,
-      page: PAGE_CONNECT_APP.DeviceDeprecatedWarning,
       modelId,
       button: CONNECT_APP_BUTTON.Continue,
     });
@@ -45,7 +44,6 @@ export function DeviceDeprecatedNonBlockingState({
   const handleUpgrade = () => {
     trackConnectAppButtonClicked({
       sourceFlow,
-      page: PAGE_CONNECT_APP.DeviceDeprecatedWarning,
       modelId,
       button: CONNECT_APP_BUTTON.DiscoverUpgradeProgram,
     });
@@ -57,6 +55,7 @@ export function DeviceDeprecatedNonBlockingState({
         category={PAGE_CONNECT_APP.DeviceDeprecatedWarning}
         sourceFlow={sourceFlow}
         modelId={modelId}
+        refreshSource
         deviceUxV2
       />
       <DeviceDeprecationScreen

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceDeprecatedNonBlockingState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceDeprecatedNonBlockingState.tsx
@@ -33,8 +33,22 @@ export function DeviceDeprecatedNonBlockingState({
   const displayClearSigningWarning = decision.screenSequence.includes("clearSigning");
 
   const handleContinue = () => {
-    trackConnectAppButtonClicked({ sourceFlow, modelId, button: CONNECT_APP_BUTTON.Continue });
+    trackConnectAppButtonClicked({
+      sourceFlow,
+      page: PAGE_CONNECT_APP.DeviceDeprecatedWarning,
+      modelId,
+      button: CONNECT_APP_BUTTON.Continue,
+    });
     onContinue();
+  };
+
+  const handleUpgrade = () => {
+    trackConnectAppButtonClicked({
+      sourceFlow,
+      page: PAGE_CONNECT_APP.DeviceDeprecatedWarning,
+      modelId,
+      button: CONNECT_APP_BUTTON.DiscoverUpgradeProgram,
+    });
   };
 
   return (
@@ -49,6 +63,7 @@ export function DeviceDeprecatedNonBlockingState({
         coinName={decision.currencyName}
         date={decision.supportEndDate}
         onContinue={handleContinue}
+        onUpgrade={handleUpgrade}
         productName={getDeviceModel(decision.deviceModelId).productName}
         screenName={
           decision.screenSequence.includes("warning")

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceDeprecatedNonBlockingState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceDeprecatedNonBlockingState.tsx
@@ -49,6 +49,14 @@ export function DeviceDeprecatedNonBlockingState({
     });
   };
 
+  const handleLearnMore = () => {
+    trackConnectAppButtonClicked({
+      sourceFlow,
+      modelId,
+      button: CONNECT_APP_BUTTON.LearnMore,
+    });
+  };
+
   return (
     <>
       <TrackScreen
@@ -63,6 +71,7 @@ export function DeviceDeprecatedNonBlockingState({
         date={decision.supportEndDate}
         onContinue={handleContinue}
         onUpgrade={handleUpgrade}
+        onLearnMore={handleLearnMore}
         productName={getDeviceModel(decision.deviceModelId).productName}
         screenName={
           decision.screenSequence.includes("warning")

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceNotOnboarded/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceNotOnboarded/index.tsx
@@ -18,6 +18,7 @@ export function DeviceNotOnboarded({ device, sourceFlow }: DeviceNotOnboardedPro
         category={PAGE_CONNECT_APP.DeviceNotOnboarded}
         sourceFlow={sourceFlow}
         modelId={device.modelId}
+        refreshSource
         deviceUxV2
       />
       <DeviceNotOnboardedView {...viewModel} />

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceNotOnboarded/useDeviceNotOnboardedViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceNotOnboarded/useDeviceNotOnboardedViewModel.test.tsx
@@ -2,6 +2,7 @@ import { act, renderHook } from "@tests/test-renderer";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { track } from "~/analytics";
 import { previousRouteNameRef } from "~/analytics/screenRefs";
+import { PAGE_CONNECT_APP } from "../../../utils/trackDeviceIntent";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
 import { useDeviceNotOnboardedViewModel } from "./useDeviceNotOnboardedViewModel";
 import type { InitializerDevice } from "../../types";
@@ -66,6 +67,7 @@ describe("useDeviceNotOnboardedViewModel", () => {
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
       source: TEST_SOURCE,
+      page: PAGE_CONNECT_APP.DeviceNotOnboarded,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Set Up Device",

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceNotOnboarded/useDeviceNotOnboardedViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceNotOnboarded/useDeviceNotOnboardedViewModel.test.tsx
@@ -1,8 +1,6 @@
 import { act, renderHook } from "@tests/test-renderer";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { track } from "~/analytics";
-import { previousRouteNameRef } from "~/analytics/screenRefs";
-import { PAGE_CONNECT_APP } from "../../../utils/trackDeviceIntent";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
 import { useDeviceNotOnboardedViewModel } from "./useDeviceNotOnboardedViewModel";
 import type { InitializerDevice } from "../../types";
@@ -19,7 +17,6 @@ jest.mock("../../hooks/useInitializerActions");
 
 const mockedTrack = jest.mocked(track);
 const mockedUseInitializerActions = jest.mocked(useInitializerActions);
-const TEST_SOURCE = "Portfolio";
 const SOURCE_FLOW = "my_ledger";
 const openOnboarding = jest.fn();
 
@@ -34,7 +31,6 @@ const device: InitializerDevice = {
 describe("useDeviceNotOnboardedViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    previousRouteNameRef.current = TEST_SOURCE;
     mockedUseInitializerActions.mockReturnValue({
       openMyLedger: jest.fn(),
       openMyLedgerFirmwareUpdate: jest.fn(),
@@ -66,8 +62,6 @@ describe("useDeviceNotOnboardedViewModel", () => {
 
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_CONNECT_APP.DeviceNotOnboarded,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Set Up Device",

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceNotOnboarded/useDeviceNotOnboardedViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceNotOnboarded/useDeviceNotOnboardedViewModel.ts
@@ -2,7 +2,11 @@ import { useCallback } from "react";
 import type { InitializerDevice } from "../../types";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
 import type { SourceFlow } from "../../../utils/SourceFlowContext";
-import { CONNECT_APP_BUTTON, trackConnectAppButtonClicked } from "../../../utils/trackDeviceIntent";
+import {
+  CONNECT_APP_BUTTON,
+  PAGE_CONNECT_APP,
+  trackConnectAppButtonClicked,
+} from "../../../utils/trackDeviceIntent";
 
 type Params = Readonly<{
   device: InitializerDevice;
@@ -14,7 +18,12 @@ export function useDeviceNotOnboardedViewModel({ device, sourceFlow }: Params) {
   const modelId = device.modelId;
 
   const onSetupDevice = useCallback(() => {
-    trackConnectAppButtonClicked({ sourceFlow, modelId, button: CONNECT_APP_BUTTON.SetUpDevice });
+    trackConnectAppButtonClicked({
+      sourceFlow,
+      page: PAGE_CONNECT_APP.DeviceNotOnboarded,
+      modelId,
+      button: CONNECT_APP_BUTTON.SetUpDevice,
+    });
     openOnboarding();
   }, [openOnboarding, sourceFlow, modelId]);
 

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceNotOnboarded/useDeviceNotOnboardedViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceNotOnboarded/useDeviceNotOnboardedViewModel.ts
@@ -4,7 +4,6 @@ import { useInitializerActions } from "../../hooks/useInitializerActions";
 import type { SourceFlow } from "../../../utils/SourceFlowContext";
 import {
   CONNECT_APP_BUTTON,
-  PAGE_CONNECT_APP,
   trackConnectAppButtonClicked,
 } from "../../../utils/trackDeviceIntent";
 
@@ -20,7 +19,6 @@ export function useDeviceNotOnboardedViewModel({ device, sourceFlow }: Params) {
   const onSetupDevice = useCallback(() => {
     trackConnectAppButtonClicked({
       sourceFlow,
-      page: PAGE_CONNECT_APP.DeviceNotOnboarded,
       modelId,
       button: CONNECT_APP_BUTTON.SetUpDevice,
     });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceOutOfStorageSpace/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceOutOfStorageSpace/index.tsx
@@ -26,6 +26,7 @@ export function DeviceOutOfStorageSpace({
         category={PAGE_CONNECT_APP.OutOfStorage}
         sourceFlow={sourceFlow}
         modelId={device.modelId}
+        refreshSource
         deviceUxV2
       />
       <DeviceOutOfStorageSpaceView {...viewModel} />

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceOutOfStorageSpace/useDeviceOutOfStorageSpaceViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceOutOfStorageSpace/useDeviceOutOfStorageSpaceViewModel.test.tsx
@@ -3,6 +3,7 @@ import { DeviceModelId } from "@ledgerhq/types-devices";
 import { BlockingStateType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
 import { track } from "~/analytics";
 import { previousRouteNameRef } from "~/analytics/screenRefs";
+import { PAGE_CONNECT_APP } from "../../../utils/trackDeviceIntent";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
 import { useDeviceOutOfStorageSpaceViewModel } from "./useDeviceOutOfStorageSpaceViewModel";
 import type { InitializerDevice } from "../../types";
@@ -72,6 +73,7 @@ describe("useDeviceOutOfStorageSpaceViewModel", () => {
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
       source: TEST_SOURCE,
+      page: PAGE_CONNECT_APP.OutOfStorage,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Manage Apps",

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceOutOfStorageSpace/useDeviceOutOfStorageSpaceViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceOutOfStorageSpace/useDeviceOutOfStorageSpaceViewModel.test.tsx
@@ -2,8 +2,6 @@ import { act, renderHook } from "@tests/test-renderer";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { BlockingStateType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
 import { track } from "~/analytics";
-import { previousRouteNameRef } from "~/analytics/screenRefs";
-import { PAGE_CONNECT_APP } from "../../../utils/trackDeviceIntent";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
 import { useDeviceOutOfStorageSpaceViewModel } from "./useDeviceOutOfStorageSpaceViewModel";
 import type { InitializerDevice } from "../../types";
@@ -20,7 +18,6 @@ jest.mock("../../hooks/useInitializerActions");
 
 const mockedTrack = jest.mocked(track);
 const mockedUseInitializerActions = jest.mocked(useInitializerActions);
-const TEST_SOURCE = "Portfolio";
 const SOURCE_FLOW = "my_ledger";
 const openMyLedger = jest.fn();
 
@@ -40,7 +37,6 @@ const state = {
 describe("useDeviceOutOfStorageSpaceViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    previousRouteNameRef.current = TEST_SOURCE;
     mockedUseInitializerActions.mockReturnValue({
       openMyLedger,
       openMyLedgerFirmwareUpdate: jest.fn(),
@@ -72,8 +68,6 @@ describe("useDeviceOutOfStorageSpaceViewModel", () => {
 
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_CONNECT_APP.OutOfStorage,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Manage Apps",

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceOutOfStorageSpace/useDeviceOutOfStorageSpaceViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceOutOfStorageSpace/useDeviceOutOfStorageSpaceViewModel.ts
@@ -5,7 +5,6 @@ import { useInitializerActions } from "../../hooks/useInitializerActions";
 import type { SourceFlow } from "../../../utils/SourceFlowContext";
 import {
   CONNECT_APP_BUTTON,
-  PAGE_CONNECT_APP,
   trackConnectAppButtonClicked,
 } from "../../../utils/trackDeviceIntent";
 
@@ -27,7 +26,6 @@ export function useDeviceOutOfStorageSpaceViewModel({ state, device, sourceFlow 
   const onOpenMyLedger = useCallback(() => {
     trackConnectAppButtonClicked({
       sourceFlow,
-      page: PAGE_CONNECT_APP.OutOfStorage,
       modelId,
       button: CONNECT_APP_BUTTON.ManageApps,
     });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceOutOfStorageSpace/useDeviceOutOfStorageSpaceViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceOutOfStorageSpace/useDeviceOutOfStorageSpaceViewModel.ts
@@ -3,7 +3,11 @@ import type { BlockingStateType, EnsureAppReadyState } from "@ledgerhq/live-dmk-
 import type { InitializerDevice } from "../../types";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
 import type { SourceFlow } from "../../../utils/SourceFlowContext";
-import { CONNECT_APP_BUTTON, trackConnectAppButtonClicked } from "../../../utils/trackDeviceIntent";
+import {
+  CONNECT_APP_BUTTON,
+  PAGE_CONNECT_APP,
+  trackConnectAppButtonClicked,
+} from "../../../utils/trackDeviceIntent";
 
 type DeviceOutOfStorageSpaceState = Extract<
   EnsureAppReadyState,
@@ -21,7 +25,12 @@ export function useDeviceOutOfStorageSpaceViewModel({ state, device, sourceFlow 
   const modelId = device.modelId;
   const searchQuery = useMemo(() => state.appNames.join(", "), [state.appNames]);
   const onOpenMyLedger = useCallback(() => {
-    trackConnectAppButtonClicked({ sourceFlow, modelId, button: CONNECT_APP_BUTTON.ManageApps });
+    trackConnectAppButtonClicked({
+      sourceFlow,
+      page: PAGE_CONNECT_APP.OutOfStorage,
+      modelId,
+      button: CONNECT_APP_BUTTON.ManageApps,
+    });
     openMyLedger(searchQuery);
   }, [openMyLedger, searchQuery, sourceFlow, modelId]);
 

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/FinalError/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/FinalError/index.tsx
@@ -18,6 +18,7 @@ export function FinalError({ state, device, sourceFlow, onCancel }: FinalErrorPr
         category={PAGE_CONNECT_APP.Error}
         sourceFlow={sourceFlow}
         modelId={device.modelId}
+        refreshSource
         deviceUxV2
       />
       <FinalErrorView {...viewModel} />

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/FinalError/useFinalErrorViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/FinalError/useFinalErrorViewModel.test.tsx
@@ -2,8 +2,6 @@ import { act, renderHook } from "@tests/test-renderer";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { FinalStateType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
 import { track } from "~/analytics";
-import { previousRouteNameRef } from "~/analytics/screenRefs";
-import { PAGE_CONNECT_APP } from "../../../utils/trackDeviceIntent";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
 import { useFinalErrorViewModel } from "./useFinalErrorViewModel";
 import type { InitializerDevice } from "../../types";
@@ -20,7 +18,6 @@ jest.mock("../../hooks/useInitializerActions");
 
 const mockedTrack = jest.mocked(track);
 const mockedUseInitializerActions = jest.mocked(useInitializerActions);
-const TEST_SOURCE = "Portfolio";
 const SOURCE_FLOW = "my_ledger";
 const openSupport = jest.fn();
 const onCancel = jest.fn();
@@ -42,7 +39,6 @@ const state = {
 describe("useFinalErrorViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    previousRouteNameRef.current = TEST_SOURCE;
     mockedUseInitializerActions.mockReturnValue({
       openMyLedger: jest.fn(),
       openMyLedgerFirmwareUpdate: jest.fn(),
@@ -74,8 +70,6 @@ describe("useFinalErrorViewModel", () => {
 
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_CONNECT_APP.Error,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Contact Ledger Support",
@@ -94,8 +88,6 @@ describe("useFinalErrorViewModel", () => {
 
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_CONNECT_APP.Error,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Close",

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/FinalError/useFinalErrorViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/FinalError/useFinalErrorViewModel.test.tsx
@@ -3,6 +3,7 @@ import { DeviceModelId } from "@ledgerhq/types-devices";
 import { FinalStateType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
 import { track } from "~/analytics";
 import { previousRouteNameRef } from "~/analytics/screenRefs";
+import { PAGE_CONNECT_APP } from "../../../utils/trackDeviceIntent";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
 import { useFinalErrorViewModel } from "./useFinalErrorViewModel";
 import type { InitializerDevice } from "../../types";
@@ -74,6 +75,7 @@ describe("useFinalErrorViewModel", () => {
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
       source: TEST_SOURCE,
+      page: PAGE_CONNECT_APP.Error,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Contact Ledger Support",
@@ -93,6 +95,7 @@ describe("useFinalErrorViewModel", () => {
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
       source: TEST_SOURCE,
+      page: PAGE_CONNECT_APP.Error,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Close",

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/FinalError/useFinalErrorViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/FinalError/useFinalErrorViewModel.ts
@@ -6,7 +6,6 @@ import { useInitializerActions } from "../../hooks/useInitializerActions";
 import type { SourceFlow } from "../../../utils/SourceFlowContext";
 import {
   CONNECT_APP_BUTTON,
-  PAGE_CONNECT_APP,
   trackConnectAppButtonClicked,
 } from "../../../utils/trackDeviceIntent";
 
@@ -26,7 +25,6 @@ export function useFinalErrorViewModel({ state, device, sourceFlow, onCancel }: 
   const onCancelWithTracking = useCallback(() => {
     trackConnectAppButtonClicked({
       sourceFlow,
-      page: PAGE_CONNECT_APP.Error,
       modelId,
       button: CONNECT_APP_BUTTON.Close,
     });
@@ -36,7 +34,6 @@ export function useFinalErrorViewModel({ state, device, sourceFlow, onCancel }: 
   const onContactSupport = useCallback(() => {
     trackConnectAppButtonClicked({
       sourceFlow,
-      page: PAGE_CONNECT_APP.Error,
       modelId,
       button: CONNECT_APP_BUTTON.ContactLedgerSupport,
     });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/FinalError/useFinalErrorViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/FinalError/useFinalErrorViewModel.ts
@@ -4,7 +4,11 @@ import type { FinalStateType, EnsureAppReadyState } from "@ledgerhq/live-dmk-sha
 import type { InitializerDevice } from "../../types";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
 import type { SourceFlow } from "../../../utils/SourceFlowContext";
-import { CONNECT_APP_BUTTON, trackConnectAppButtonClicked } from "../../../utils/trackDeviceIntent";
+import {
+  CONNECT_APP_BUTTON,
+  PAGE_CONNECT_APP,
+  trackConnectAppButtonClicked,
+} from "../../../utils/trackDeviceIntent";
 
 type FinalErrorState = Extract<EnsureAppReadyState, { type: FinalStateType.Error }>;
 
@@ -20,13 +24,19 @@ export function useFinalErrorViewModel({ state, device, sourceFlow, onCancel }: 
   const modelId = device.modelId;
 
   const onCancelWithTracking = useCallback(() => {
-    trackConnectAppButtonClicked({ sourceFlow, modelId, button: CONNECT_APP_BUTTON.Close });
+    trackConnectAppButtonClicked({
+      sourceFlow,
+      page: PAGE_CONNECT_APP.Error,
+      modelId,
+      button: CONNECT_APP_BUTTON.Close,
+    });
     onCancel();
   }, [onCancel, sourceFlow, modelId]);
 
   const onContactSupport = useCallback(() => {
     trackConnectAppButtonClicked({
       sourceFlow,
+      page: PAGE_CONNECT_APP.Error,
       modelId,
       button: CONNECT_APP_BUTTON.ContactLedgerSupport,
     });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/InstallingAppState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/InstallingAppState.tsx
@@ -18,6 +18,7 @@ export function InstallingAppState({ device, sourceFlow }: InstallingAppStatePro
         category={PAGE_CONNECT_APP.InstallingApp}
         sourceFlow={sourceFlow}
         modelId={device.modelId}
+        refreshSource
         deviceUxV2
       />
       <LoadingContent

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/LoadingState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/LoadingState.tsx
@@ -32,6 +32,7 @@ export function LoadingState({ device, sourceFlow }: LoadingStateProps) {
           category={PAGE_CONNECT_APP.Loading}
           sourceFlow={sourceFlow}
           modelId={device.modelId}
+          refreshSource
           deviceUxV2
         />
       )}

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/OutdatedAppWarning/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/OutdatedAppWarning/index.tsx
@@ -21,6 +21,7 @@ export function OutdatedAppWarning({ state, device, sourceFlow }: OutdatedAppWar
         category={PAGE_CONNECT_APP.OutdatedAppWarning}
         sourceFlow={sourceFlow}
         modelId={device.modelId}
+        refreshSource
         deviceUxV2
       />
       <OutdatedAppWarningView {...viewModel} />

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/OutdatedAppWarning/useOutdatedAppWarningViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/OutdatedAppWarning/useOutdatedAppWarningViewModel.test.tsx
@@ -6,6 +6,7 @@ import {
 } from "@ledgerhq/live-dmk-shared";
 import { track } from "~/analytics";
 import { previousRouteNameRef } from "~/analytics/screenRefs";
+import { PAGE_CONNECT_APP } from "../../../utils/trackDeviceIntent";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
 import { useOutdatedAppWarningViewModel } from "./useOutdatedAppWarningViewModel";
 import type { InitializerDevice } from "../../types";
@@ -80,6 +81,7 @@ describe("useOutdatedAppWarningViewModel", () => {
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
       source: TEST_SOURCE,
+      page: PAGE_CONNECT_APP.OutdatedAppWarning,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Manage Apps",
@@ -99,6 +101,7 @@ describe("useOutdatedAppWarningViewModel", () => {
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
       source: TEST_SOURCE,
+      page: PAGE_CONNECT_APP.OutdatedAppWarning,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Continue",

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/OutdatedAppWarning/useOutdatedAppWarningViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/OutdatedAppWarning/useOutdatedAppWarningViewModel.test.tsx
@@ -5,8 +5,6 @@ import {
   type EnsureAppReadyState,
 } from "@ledgerhq/live-dmk-shared";
 import { track } from "~/analytics";
-import { previousRouteNameRef } from "~/analytics/screenRefs";
-import { PAGE_CONNECT_APP } from "../../../utils/trackDeviceIntent";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
 import { useOutdatedAppWarningViewModel } from "./useOutdatedAppWarningViewModel";
 import type { InitializerDevice } from "../../types";
@@ -23,7 +21,6 @@ jest.mock("../../hooks/useInitializerActions");
 
 const mockedTrack = jest.mocked(track);
 const mockedUseInitializerActions = jest.mocked(useInitializerActions);
-const TEST_SOURCE = "Portfolio";
 const SOURCE_FLOW = "my_ledger";
 const openMyLedger = jest.fn();
 const onContinue = jest.fn();
@@ -48,7 +45,6 @@ const state = {
 describe("useOutdatedAppWarningViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    previousRouteNameRef.current = TEST_SOURCE;
     mockedUseInitializerActions.mockReturnValue({
       openMyLedger,
       openMyLedgerFirmwareUpdate: jest.fn(),
@@ -80,8 +76,6 @@ describe("useOutdatedAppWarningViewModel", () => {
 
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_CONNECT_APP.OutdatedAppWarning,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Manage Apps",
@@ -100,8 +94,6 @@ describe("useOutdatedAppWarningViewModel", () => {
 
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_CONNECT_APP.OutdatedAppWarning,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Continue",

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/OutdatedAppWarning/useOutdatedAppWarningViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/OutdatedAppWarning/useOutdatedAppWarningViewModel.ts
@@ -6,7 +6,11 @@ import type {
 import type { InitializerDevice } from "../../types";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
 import type { SourceFlow } from "../../../utils/SourceFlowContext";
-import { CONNECT_APP_BUTTON, trackConnectAppButtonClicked } from "../../../utils/trackDeviceIntent";
+import {
+  CONNECT_APP_BUTTON,
+  PAGE_CONNECT_APP,
+  trackConnectAppButtonClicked,
+} from "../../../utils/trackDeviceIntent";
 
 type OutdatedAppWarningState = Extract<
   EnsureAppReadyState,
@@ -24,12 +28,22 @@ export function useOutdatedAppWarningViewModel({ state, device, sourceFlow }: Pa
   const modelId = device.modelId;
 
   const onOpenMyLedger = useCallback(() => {
-    trackConnectAppButtonClicked({ sourceFlow, modelId, button: CONNECT_APP_BUTTON.ManageApps });
+    trackConnectAppButtonClicked({
+      sourceFlow,
+      page: PAGE_CONNECT_APP.OutdatedAppWarning,
+      modelId,
+      button: CONNECT_APP_BUTTON.ManageApps,
+    });
     openMyLedger(state.appName);
   }, [openMyLedger, state.appName, sourceFlow, modelId]);
 
   const onContinue = useCallback(() => {
-    trackConnectAppButtonClicked({ sourceFlow, modelId, button: CONNECT_APP_BUTTON.Continue });
+    trackConnectAppButtonClicked({
+      sourceFlow,
+      page: PAGE_CONNECT_APP.OutdatedAppWarning,
+      modelId,
+      button: CONNECT_APP_BUTTON.Continue,
+    });
     state.onContinue();
   }, [state, sourceFlow, modelId]);
 

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/OutdatedAppWarning/useOutdatedAppWarningViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/OutdatedAppWarning/useOutdatedAppWarningViewModel.ts
@@ -8,7 +8,6 @@ import { useInitializerActions } from "../../hooks/useInitializerActions";
 import type { SourceFlow } from "../../../utils/SourceFlowContext";
 import {
   CONNECT_APP_BUTTON,
-  PAGE_CONNECT_APP,
   trackConnectAppButtonClicked,
 } from "../../../utils/trackDeviceIntent";
 
@@ -30,7 +29,6 @@ export function useOutdatedAppWarningViewModel({ state, device, sourceFlow }: Pa
   const onOpenMyLedger = useCallback(() => {
     trackConnectAppButtonClicked({
       sourceFlow,
-      page: PAGE_CONNECT_APP.OutdatedAppWarning,
       modelId,
       button: CONNECT_APP_BUTTON.ManageApps,
     });
@@ -40,7 +38,6 @@ export function useOutdatedAppWarningViewModel({ state, device, sourceFlow }: Pa
   const onContinue = useCallback(() => {
     trackConnectAppButtonClicked({
       sourceFlow,
-      page: PAGE_CONNECT_APP.OutdatedAppWarning,
       modelId,
       button: CONNECT_APP_BUTTON.Continue,
     });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/RetryableDeviceLockedState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/RetryableDeviceLockedState.test.tsx
@@ -3,7 +3,6 @@ import { render, screen } from "@tests/test-renderer";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { RetryableStateType } from "@ledgerhq/live-dmk-shared";
 import { TrackScreen, track } from "~/analytics";
-import { previousRouteNameRef } from "~/analytics/screenRefs";
 import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import { RetryableDeviceLockedState } from "./RetryableDeviceLockedState";
 import type { InitializerDevice } from "../types";
@@ -19,7 +18,6 @@ jest.mock("~/analytics", () => {
 
 const mockedTrackScreen = jest.mocked(TrackScreen);
 const mockedTrack = jest.mocked(track);
-const TEST_SOURCE = "Portfolio";
 
 const device: InitializerDevice = {
   id: "device-id",
@@ -50,7 +48,6 @@ function renderState() {
 describe("RetryableDeviceLockedState", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    previousRouteNameRef.current = TEST_SOURCE;
   });
 
   it("GIVEN the retryable device locked state WHEN rendering THEN it renders the locked title and retry CTA", () => {
@@ -89,8 +86,6 @@ describe("RetryableDeviceLockedState", () => {
 
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_CONNECT_APP.DeviceLocked,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Retry",

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/RetryableDeviceLockedState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/RetryableDeviceLockedState.test.tsx
@@ -90,6 +90,7 @@ describe("RetryableDeviceLockedState", () => {
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
       source: TEST_SOURCE,
+      page: PAGE_CONNECT_APP.DeviceLocked,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Retry",

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/RetryableDeviceLockedState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/RetryableDeviceLockedState.tsx
@@ -23,7 +23,6 @@ export function RetryableDeviceLockedState({
   const handleRetry = () => {
     trackConnectAppButtonClicked({
       sourceFlow,
-      page: PAGE_CONNECT_APP.DeviceLocked,
       modelId,
       button: CONNECT_APP_BUTTON.Retry,
     });
@@ -36,6 +35,7 @@ export function RetryableDeviceLockedState({
         category={PAGE_CONNECT_APP.DeviceLocked}
         sourceFlow={sourceFlow}
         modelId={modelId}
+        refreshSource
         deviceUxV2
       />
       <RetryableDeviceLocked

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/RetryableDeviceLockedState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/RetryableDeviceLockedState.tsx
@@ -21,7 +21,12 @@ export function RetryableDeviceLockedState({
   const modelId = device.modelId;
 
   const handleRetry = () => {
-    trackConnectAppButtonClicked({ sourceFlow, modelId, button: CONNECT_APP_BUTTON.Retry });
+    trackConnectAppButtonClicked({
+      sourceFlow,
+      page: PAGE_CONNECT_APP.DeviceLocked,
+      modelId,
+      button: CONNECT_APP_BUTTON.Retry,
+    });
     state.retry();
   };
 

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnlockDeviceState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnlockDeviceState.tsx
@@ -16,6 +16,7 @@ export function UnlockDeviceState({ device, sourceFlow }: UnlockDeviceStateProps
         category={PAGE_CONNECT_APP.UnlockDevice}
         sourceFlow={sourceFlow}
         modelId={device.modelId}
+        refreshSource
         deviceUxV2
       />
       <UnlockDevice

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedApplication/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedApplication/index.tsx
@@ -18,6 +18,7 @@ export function UnsupportedApplication({ device, sourceFlow }: UnsupportedApplic
         category={PAGE_CONNECT_APP.UnsupportedApplication}
         sourceFlow={sourceFlow}
         modelId={device.modelId}
+        refreshSource
         deviceUxV2
       />
       <UnsupportedApplicationView {...viewModel} />

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedApplication/useUnsupportedApplicationViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedApplication/useUnsupportedApplicationViewModel.test.tsx
@@ -2,6 +2,7 @@ import { act, renderHook } from "@tests/test-renderer";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { track } from "~/analytics";
 import { previousRouteNameRef } from "~/analytics/screenRefs";
+import { PAGE_CONNECT_APP } from "../../../utils/trackDeviceIntent";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
 import { useUnsupportedApplicationViewModel } from "./useUnsupportedApplicationViewModel";
 import type { InitializerDevice } from "../../types";
@@ -66,6 +67,7 @@ describe("useUnsupportedApplicationViewModel", () => {
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
       source: TEST_SOURCE,
+      page: PAGE_CONNECT_APP.UnsupportedApplication,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Contact Ledger Support",

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedApplication/useUnsupportedApplicationViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedApplication/useUnsupportedApplicationViewModel.test.tsx
@@ -1,8 +1,6 @@
 import { act, renderHook } from "@tests/test-renderer";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { track } from "~/analytics";
-import { previousRouteNameRef } from "~/analytics/screenRefs";
-import { PAGE_CONNECT_APP } from "../../../utils/trackDeviceIntent";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
 import { useUnsupportedApplicationViewModel } from "./useUnsupportedApplicationViewModel";
 import type { InitializerDevice } from "../../types";
@@ -19,7 +17,6 @@ jest.mock("../../hooks/useInitializerActions");
 
 const mockedTrack = jest.mocked(track);
 const mockedUseInitializerActions = jest.mocked(useInitializerActions);
-const TEST_SOURCE = "Portfolio";
 const SOURCE_FLOW = "my_ledger";
 const openSupport = jest.fn();
 
@@ -34,7 +31,6 @@ const device: InitializerDevice = {
 describe("useUnsupportedApplicationViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    previousRouteNameRef.current = TEST_SOURCE;
     mockedUseInitializerActions.mockReturnValue({
       openMyLedger: jest.fn(),
       openMyLedgerFirmwareUpdate: jest.fn(),
@@ -66,8 +62,6 @@ describe("useUnsupportedApplicationViewModel", () => {
 
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_CONNECT_APP.UnsupportedApplication,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Contact Ledger Support",

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedApplication/useUnsupportedApplicationViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedApplication/useUnsupportedApplicationViewModel.ts
@@ -2,7 +2,11 @@ import { useCallback } from "react";
 import type { InitializerDevice } from "../../types";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
 import type { SourceFlow } from "../../../utils/SourceFlowContext";
-import { CONNECT_APP_BUTTON, trackConnectAppButtonClicked } from "../../../utils/trackDeviceIntent";
+import {
+  CONNECT_APP_BUTTON,
+  PAGE_CONNECT_APP,
+  trackConnectAppButtonClicked,
+} from "../../../utils/trackDeviceIntent";
 
 type Params = Readonly<{
   device: InitializerDevice;
@@ -16,6 +20,7 @@ export function useUnsupportedApplicationViewModel({ device, sourceFlow }: Param
   const onContactSupport = useCallback(() => {
     trackConnectAppButtonClicked({
       sourceFlow,
+      page: PAGE_CONNECT_APP.UnsupportedApplication,
       modelId,
       button: CONNECT_APP_BUTTON.ContactLedgerSupport,
     });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedApplication/useUnsupportedApplicationViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedApplication/useUnsupportedApplicationViewModel.ts
@@ -4,7 +4,6 @@ import { useInitializerActions } from "../../hooks/useInitializerActions";
 import type { SourceFlow } from "../../../utils/SourceFlowContext";
 import {
   CONNECT_APP_BUTTON,
-  PAGE_CONNECT_APP,
   trackConnectAppButtonClicked,
 } from "../../../utils/trackDeviceIntent";
 
@@ -20,7 +19,6 @@ export function useUnsupportedApplicationViewModel({ device, sourceFlow }: Param
   const onContactSupport = useCallback(() => {
     trackConnectAppButtonClicked({
       sourceFlow,
-      page: PAGE_CONNECT_APP.UnsupportedApplication,
       modelId,
       button: CONNECT_APP_BUTTON.ContactLedgerSupport,
     });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFeature/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFeature/index.tsx
@@ -18,6 +18,7 @@ export function UnsupportedFeature({ device, sourceFlow }: UnsupportedFeaturePro
         category={PAGE_CONNECT_APP.UnsupportedFeature}
         sourceFlow={sourceFlow}
         modelId={device.modelId}
+        refreshSource
         deviceUxV2
       />
       <UnsupportedFeatureView {...viewModel} />

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFeature/useUnsupportedFeatureViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFeature/useUnsupportedFeatureViewModel.test.tsx
@@ -1,8 +1,6 @@
 import { act, renderHook } from "@tests/test-renderer";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { track } from "~/analytics";
-import { previousRouteNameRef } from "~/analytics/screenRefs";
-import { PAGE_CONNECT_APP } from "../../../utils/trackDeviceIntent";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
 import { useUnsupportedFeatureViewModel } from "./useUnsupportedFeatureViewModel";
 import type { InitializerDevice } from "../../types";
@@ -19,7 +17,6 @@ jest.mock("../../hooks/useInitializerActions");
 
 const mockedTrack = jest.mocked(track);
 const mockedUseInitializerActions = jest.mocked(useInitializerActions);
-const TEST_SOURCE = "Portfolio";
 const SOURCE_FLOW = "my_ledger";
 const openSupport = jest.fn();
 
@@ -34,7 +31,6 @@ const device: InitializerDevice = {
 describe("useUnsupportedFeatureViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    previousRouteNameRef.current = TEST_SOURCE;
     mockedUseInitializerActions.mockReturnValue({
       openMyLedger: jest.fn(),
       openMyLedgerFirmwareUpdate: jest.fn(),
@@ -66,8 +62,6 @@ describe("useUnsupportedFeatureViewModel", () => {
 
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_CONNECT_APP.UnsupportedFeature,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Contact Ledger Support",

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFeature/useUnsupportedFeatureViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFeature/useUnsupportedFeatureViewModel.test.tsx
@@ -2,6 +2,7 @@ import { act, renderHook } from "@tests/test-renderer";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { track } from "~/analytics";
 import { previousRouteNameRef } from "~/analytics/screenRefs";
+import { PAGE_CONNECT_APP } from "../../../utils/trackDeviceIntent";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
 import { useUnsupportedFeatureViewModel } from "./useUnsupportedFeatureViewModel";
 import type { InitializerDevice } from "../../types";
@@ -66,6 +67,7 @@ describe("useUnsupportedFeatureViewModel", () => {
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
       source: TEST_SOURCE,
+      page: PAGE_CONNECT_APP.UnsupportedFeature,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Contact Ledger Support",

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFeature/useUnsupportedFeatureViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFeature/useUnsupportedFeatureViewModel.ts
@@ -2,7 +2,11 @@ import { useCallback } from "react";
 import type { InitializerDevice } from "../../types";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
 import type { SourceFlow } from "../../../utils/SourceFlowContext";
-import { CONNECT_APP_BUTTON, trackConnectAppButtonClicked } from "../../../utils/trackDeviceIntent";
+import {
+  CONNECT_APP_BUTTON,
+  PAGE_CONNECT_APP,
+  trackConnectAppButtonClicked,
+} from "../../../utils/trackDeviceIntent";
 
 type Params = Readonly<{
   device: InitializerDevice;
@@ -16,6 +20,7 @@ export function useUnsupportedFeatureViewModel({ device, sourceFlow }: Params) {
   const onContactSupport = useCallback(() => {
     trackConnectAppButtonClicked({
       sourceFlow,
+      page: PAGE_CONNECT_APP.UnsupportedFeature,
       modelId,
       button: CONNECT_APP_BUTTON.ContactLedgerSupport,
     });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFeature/useUnsupportedFeatureViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFeature/useUnsupportedFeatureViewModel.ts
@@ -4,7 +4,6 @@ import { useInitializerActions } from "../../hooks/useInitializerActions";
 import type { SourceFlow } from "../../../utils/SourceFlowContext";
 import {
   CONNECT_APP_BUTTON,
-  PAGE_CONNECT_APP,
   trackConnectAppButtonClicked,
 } from "../../../utils/trackDeviceIntent";
 
@@ -20,7 +19,6 @@ export function useUnsupportedFeatureViewModel({ device, sourceFlow }: Params) {
   const onContactSupport = useCallback(() => {
     trackConnectAppButtonClicked({
       sourceFlow,
-      page: PAGE_CONNECT_APP.UnsupportedFeature,
       modelId,
       button: CONNECT_APP_BUTTON.ContactLedgerSupport,
     });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFirmwareVersion/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFirmwareVersion/index.tsx
@@ -26,6 +26,7 @@ export function UnsupportedFirmwareVersion({
         category={PAGE_CONNECT_APP.UnsupportedFirmware}
         sourceFlow={sourceFlow}
         modelId={device.modelId}
+        refreshSource
         deviceUxV2
       />
       <UnsupportedFirmwareVersionView {...viewModel} />

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFirmwareVersion/useUnsupportedFirmwareVersionViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFirmwareVersion/useUnsupportedFirmwareVersionViewModel.test.tsx
@@ -1,8 +1,6 @@
 import { act, renderHook } from "@tests/test-renderer";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { track } from "~/analytics";
-import { previousRouteNameRef } from "~/analytics/screenRefs";
-import { PAGE_CONNECT_APP } from "../../../utils/trackDeviceIntent";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
 import { useUnsupportedFirmwareVersionViewModel } from "./useUnsupportedFirmwareVersionViewModel";
 import type { InitializerDevice } from "../../types";
@@ -19,7 +17,6 @@ jest.mock("../../hooks/useInitializerActions");
 
 const mockedTrack = jest.mocked(track);
 const mockedUseInitializerActions = jest.mocked(useInitializerActions);
-const TEST_SOURCE = "Portfolio";
 const SOURCE_FLOW = "my_ledger";
 const openMyLedgerFirmwareUpdate = jest.fn();
 const onCancel = jest.fn();
@@ -35,7 +32,6 @@ const device: InitializerDevice = {
 describe("useUnsupportedFirmwareVersionViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    previousRouteNameRef.current = TEST_SOURCE;
     mockedUseInitializerActions.mockReturnValue({
       openMyLedger: jest.fn(),
       openMyLedgerFirmwareUpdate,
@@ -76,8 +72,6 @@ describe("useUnsupportedFirmwareVersionViewModel", () => {
 
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_CONNECT_APP.UnsupportedFirmware,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Update Firmware",
@@ -100,8 +94,6 @@ describe("useUnsupportedFirmwareVersionViewModel", () => {
 
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_CONNECT_APP.UnsupportedFirmware,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Close",

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFirmwareVersion/useUnsupportedFirmwareVersionViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFirmwareVersion/useUnsupportedFirmwareVersionViewModel.test.tsx
@@ -2,6 +2,7 @@ import { act, renderHook } from "@tests/test-renderer";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { track } from "~/analytics";
 import { previousRouteNameRef } from "~/analytics/screenRefs";
+import { PAGE_CONNECT_APP } from "../../../utils/trackDeviceIntent";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
 import { useUnsupportedFirmwareVersionViewModel } from "./useUnsupportedFirmwareVersionViewModel";
 import type { InitializerDevice } from "../../types";
@@ -76,6 +77,7 @@ describe("useUnsupportedFirmwareVersionViewModel", () => {
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
       source: TEST_SOURCE,
+      page: PAGE_CONNECT_APP.UnsupportedFirmware,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Update Firmware",
@@ -83,7 +85,7 @@ describe("useUnsupportedFirmwareVersionViewModel", () => {
     expect(openMyLedgerFirmwareUpdate).toHaveBeenCalledTimes(1);
   });
 
-  it("GIVEN a device WHEN cancelling THEN it tracks Cancel and forwards to onCancel", () => {
+  it("GIVEN a device WHEN cancelling THEN it tracks Close and forwards to onCancel", () => {
     const { result } = renderHook(() =>
       useUnsupportedFirmwareVersionViewModel({
         device,
@@ -99,9 +101,10 @@ describe("useUnsupportedFirmwareVersionViewModel", () => {
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
       source: TEST_SOURCE,
+      page: PAGE_CONNECT_APP.UnsupportedFirmware,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
-      button: "Cancel",
+      button: "Close",
     });
     expect(onCancel).toHaveBeenCalledTimes(1);
   });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFirmwareVersion/useUnsupportedFirmwareVersionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFirmwareVersion/useUnsupportedFirmwareVersionViewModel.ts
@@ -4,7 +4,6 @@ import { useInitializerActions } from "../../hooks/useInitializerActions";
 import type { SourceFlow } from "../../../utils/SourceFlowContext";
 import {
   CONNECT_APP_BUTTON,
-  PAGE_CONNECT_APP,
   trackConnectAppButtonClicked,
 } from "../../../utils/trackDeviceIntent";
 
@@ -21,7 +20,6 @@ export function useUnsupportedFirmwareVersionViewModel({ device, sourceFlow, onC
   const onUpdateLedgerOs = useCallback(() => {
     trackConnectAppButtonClicked({
       sourceFlow,
-      page: PAGE_CONNECT_APP.UnsupportedFirmware,
       modelId,
       button: CONNECT_APP_BUTTON.UpdateFirmware,
     });
@@ -31,7 +29,6 @@ export function useUnsupportedFirmwareVersionViewModel({ device, sourceFlow, onC
   const onCancelWithTracking = useCallback(() => {
     trackConnectAppButtonClicked({
       sourceFlow,
-      page: PAGE_CONNECT_APP.UnsupportedFirmware,
       modelId,
       button: CONNECT_APP_BUTTON.Close,
     });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFirmwareVersion/useUnsupportedFirmwareVersionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFirmwareVersion/useUnsupportedFirmwareVersionViewModel.ts
@@ -2,7 +2,11 @@ import { useCallback } from "react";
 import type { InitializerDevice } from "../../types";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
 import type { SourceFlow } from "../../../utils/SourceFlowContext";
-import { CONNECT_APP_BUTTON, trackConnectAppButtonClicked } from "../../../utils/trackDeviceIntent";
+import {
+  CONNECT_APP_BUTTON,
+  PAGE_CONNECT_APP,
+  trackConnectAppButtonClicked,
+} from "../../../utils/trackDeviceIntent";
 
 type Params = Readonly<{
   device: InitializerDevice;
@@ -17,6 +21,7 @@ export function useUnsupportedFirmwareVersionViewModel({ device, sourceFlow, onC
   const onUpdateLedgerOs = useCallback(() => {
     trackConnectAppButtonClicked({
       sourceFlow,
+      page: PAGE_CONNECT_APP.UnsupportedFirmware,
       modelId,
       button: CONNECT_APP_BUTTON.UpdateFirmware,
     });
@@ -24,7 +29,12 @@ export function useUnsupportedFirmwareVersionViewModel({ device, sourceFlow, onC
   }, [openMyLedgerFirmwareUpdate, sourceFlow, modelId]);
 
   const onCancelWithTracking = useCallback(() => {
-    trackConnectAppButtonClicked({ sourceFlow, modelId, button: CONNECT_APP_BUTTON.Cancel });
+    trackConnectAppButtonClicked({
+      sourceFlow,
+      page: PAGE_CONNECT_APP.UnsupportedFirmware,
+      modelId,
+      button: CONNECT_APP_BUTTON.Close,
+    });
     onCancel();
   }, [onCancel, sourceFlow, modelId]);
 

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UserRefusedOnDeviceState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UserRefusedOnDeviceState.test.tsx
@@ -3,7 +3,6 @@ import { render, screen } from "@tests/test-renderer";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { RetryableStateType } from "@ledgerhq/live-dmk-shared";
 import { TrackScreen, track } from "~/analytics";
-import { previousRouteNameRef } from "~/analytics/screenRefs";
 import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import { UserRefusedOnDeviceState } from "./UserRefusedOnDeviceState";
 import type { InitializerDevice } from "../types";
@@ -19,7 +18,6 @@ jest.mock("~/analytics", () => {
 
 const mockedTrackScreen = jest.mocked(TrackScreen);
 const mockedTrack = jest.mocked(track);
-const TEST_SOURCE = "Portfolio";
 
 const device: InitializerDevice = {
   id: "device-id",
@@ -50,7 +48,6 @@ function renderState() {
 describe("UserRefusedOnDeviceState", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    previousRouteNameRef.current = TEST_SOURCE;
   });
 
   it("GIVEN the user refused state WHEN rendering THEN it renders the title and action buttons", () => {
@@ -92,8 +89,6 @@ describe("UserRefusedOnDeviceState", () => {
 
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_CONNECT_APP.UserRefused,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Close",
@@ -107,8 +102,6 @@ describe("UserRefusedOnDeviceState", () => {
 
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_CONNECT_APP.UserRefused,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Retry",

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UserRefusedOnDeviceState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UserRefusedOnDeviceState.test.tsx
@@ -93,6 +93,7 @@ describe("UserRefusedOnDeviceState", () => {
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
       source: TEST_SOURCE,
+      page: PAGE_CONNECT_APP.UserRefused,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Close",
@@ -107,6 +108,7 @@ describe("UserRefusedOnDeviceState", () => {
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
       source: TEST_SOURCE,
+      page: PAGE_CONNECT_APP.UserRefused,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Retry",

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UserRefusedOnDeviceState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UserRefusedOnDeviceState.tsx
@@ -23,11 +23,21 @@ export function UserRefusedOnDeviceState({
   const modelId = device.modelId;
 
   const handleClose = () => {
-    trackConnectAppButtonClicked({ sourceFlow, modelId, button: CONNECT_APP_BUTTON.Close });
+    trackConnectAppButtonClicked({
+      sourceFlow,
+      page: PAGE_CONNECT_APP.UserRefused,
+      modelId,
+      button: CONNECT_APP_BUTTON.Close,
+    });
     onCancel();
   };
   const handleRetry = () => {
-    trackConnectAppButtonClicked({ sourceFlow, modelId, button: CONNECT_APP_BUTTON.Retry });
+    trackConnectAppButtonClicked({
+      sourceFlow,
+      page: PAGE_CONNECT_APP.UserRefused,
+      modelId,
+      button: CONNECT_APP_BUTTON.Retry,
+    });
     state.retry();
   };
 

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UserRefusedOnDeviceState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UserRefusedOnDeviceState.tsx
@@ -25,7 +25,6 @@ export function UserRefusedOnDeviceState({
   const handleClose = () => {
     trackConnectAppButtonClicked({
       sourceFlow,
-      page: PAGE_CONNECT_APP.UserRefused,
       modelId,
       button: CONNECT_APP_BUTTON.Close,
     });
@@ -34,7 +33,6 @@ export function UserRefusedOnDeviceState({
   const handleRetry = () => {
     trackConnectAppButtonClicked({
       sourceFlow,
-      page: PAGE_CONNECT_APP.UserRefused,
       modelId,
       button: CONNECT_APP_BUTTON.Retry,
     });
@@ -47,6 +45,7 @@ export function UserRefusedOnDeviceState({
         category={PAGE_CONNECT_APP.UserRefused}
         sourceFlow={sourceFlow}
         modelId={modelId}
+        refreshSource
         deviceUxV2
       />
       <InfoState

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/WrongDeviceForAccount/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/WrongDeviceForAccount/index.tsx
@@ -26,6 +26,7 @@ export function WrongDeviceForAccount({
         category={PAGE_CONNECT_APP.WrongDeviceForAccount}
         sourceFlow={sourceFlow}
         modelId={device.modelId}
+        refreshSource
         deviceUxV2
       />
       <WrongDeviceForAccountView {...viewModel} />

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/WrongDeviceForAccount/useWrongDeviceForAccountViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/WrongDeviceForAccount/useWrongDeviceForAccountViewModel.test.tsx
@@ -2,6 +2,7 @@ import { act, renderHook } from "@tests/test-renderer";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { track } from "~/analytics";
 import { previousRouteNameRef } from "~/analytics/screenRefs";
+import { PAGE_CONNECT_APP } from "../../../utils/trackDeviceIntent";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
 import { useWrongDeviceForAccountViewModel } from "./useWrongDeviceForAccountViewModel";
 import type { InitializerDevice } from "../../types";
@@ -68,6 +69,7 @@ describe("useWrongDeviceForAccountViewModel", () => {
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
       source: TEST_SOURCE,
+      page: PAGE_CONNECT_APP.WrongDeviceForAccount,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Close",
@@ -87,6 +89,7 @@ describe("useWrongDeviceForAccountViewModel", () => {
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
       source: TEST_SOURCE,
+      page: PAGE_CONNECT_APP.WrongDeviceForAccount,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Contact Ledger Support",

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/WrongDeviceForAccount/useWrongDeviceForAccountViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/WrongDeviceForAccount/useWrongDeviceForAccountViewModel.test.tsx
@@ -1,8 +1,6 @@
 import { act, renderHook } from "@tests/test-renderer";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { track } from "~/analytics";
-import { previousRouteNameRef } from "~/analytics/screenRefs";
-import { PAGE_CONNECT_APP } from "../../../utils/trackDeviceIntent";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
 import { useWrongDeviceForAccountViewModel } from "./useWrongDeviceForAccountViewModel";
 import type { InitializerDevice } from "../../types";
@@ -19,7 +17,6 @@ jest.mock("../../hooks/useInitializerActions");
 
 const mockedTrack = jest.mocked(track);
 const mockedUseInitializerActions = jest.mocked(useInitializerActions);
-const TEST_SOURCE = "Portfolio";
 const SOURCE_FLOW = "my_ledger";
 const openSupport = jest.fn();
 const onCancel = jest.fn();
@@ -35,7 +32,6 @@ const device: InitializerDevice = {
 describe("useWrongDeviceForAccountViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    previousRouteNameRef.current = TEST_SOURCE;
     mockedUseInitializerActions.mockReturnValue({
       openMyLedger: jest.fn(),
       openMyLedgerFirmwareUpdate: jest.fn(),
@@ -68,8 +64,6 @@ describe("useWrongDeviceForAccountViewModel", () => {
 
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_CONNECT_APP.WrongDeviceForAccount,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Close",
@@ -88,8 +82,6 @@ describe("useWrongDeviceForAccountViewModel", () => {
 
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_CONNECT_APP.WrongDeviceForAccount,
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
       button: "Contact Ledger Support",

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/WrongDeviceForAccount/useWrongDeviceForAccountViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/WrongDeviceForAccount/useWrongDeviceForAccountViewModel.ts
@@ -2,7 +2,11 @@ import { useCallback } from "react";
 import type { InitializerDevice } from "../../types";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
 import type { SourceFlow } from "../../../utils/SourceFlowContext";
-import { CONNECT_APP_BUTTON, trackConnectAppButtonClicked } from "../../../utils/trackDeviceIntent";
+import {
+  CONNECT_APP_BUTTON,
+  PAGE_CONNECT_APP,
+  trackConnectAppButtonClicked,
+} from "../../../utils/trackDeviceIntent";
 
 type Params = Readonly<{
   device: InitializerDevice;
@@ -15,13 +19,19 @@ export function useWrongDeviceForAccountViewModel({ device, sourceFlow, onCancel
   const modelId = device.modelId;
 
   const onCancelWithTracking = useCallback(() => {
-    trackConnectAppButtonClicked({ sourceFlow, modelId, button: CONNECT_APP_BUTTON.Close });
+    trackConnectAppButtonClicked({
+      sourceFlow,
+      page: PAGE_CONNECT_APP.WrongDeviceForAccount,
+      modelId,
+      button: CONNECT_APP_BUTTON.Close,
+    });
     onCancel();
   }, [onCancel, sourceFlow, modelId]);
 
   const onContactSupport = useCallback(() => {
     trackConnectAppButtonClicked({
       sourceFlow,
+      page: PAGE_CONNECT_APP.WrongDeviceForAccount,
       modelId,
       button: CONNECT_APP_BUTTON.ContactLedgerSupport,
     });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/WrongDeviceForAccount/useWrongDeviceForAccountViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/WrongDeviceForAccount/useWrongDeviceForAccountViewModel.ts
@@ -4,7 +4,6 @@ import { useInitializerActions } from "../../hooks/useInitializerActions";
 import type { SourceFlow } from "../../../utils/SourceFlowContext";
 import {
   CONNECT_APP_BUTTON,
-  PAGE_CONNECT_APP,
   trackConnectAppButtonClicked,
 } from "../../../utils/trackDeviceIntent";
 
@@ -21,7 +20,6 @@ export function useWrongDeviceForAccountViewModel({ device, sourceFlow, onCancel
   const onCancelWithTracking = useCallback(() => {
     trackConnectAppButtonClicked({
       sourceFlow,
-      page: PAGE_CONNECT_APP.WrongDeviceForAccount,
       modelId,
       button: CONNECT_APP_BUTTON.Close,
     });
@@ -31,7 +29,6 @@ export function useWrongDeviceForAccountViewModel({ device, sourceFlow, onCancel
   const onContactSupport = useCallback(() => {
     trackConnectAppButtonClicked({
       sourceFlow,
-      page: PAGE_CONNECT_APP.WrongDeviceForAccount,
       modelId,
       button: CONNECT_APP_BUTTON.ContactLedgerSupport,
     });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/DeviceDisconnected.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/DeviceDisconnected.test.tsx
@@ -6,7 +6,6 @@ import {
 } from "@ledgerhq/device-management-kit";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { TrackScreen, track } from "~/analytics";
-import { previousRouteNameRef } from "~/analytics/screenRefs";
 import { SourceFlowProvider } from "../utils/SourceFlowContext";
 import { PAGE_DEVICE_ACTION } from "../utils/trackDeviceIntent";
 import { DeviceDisconnected } from "./DeviceDisconnected";
@@ -22,7 +21,6 @@ jest.mock("~/analytics", () => {
 
 const mockedTrackScreen = jest.mocked(TrackScreen);
 const mockedTrack = jest.mocked(track);
-const TEST_SOURCE = "Portfolio";
 
 const device = {
   id: "device-id",
@@ -44,7 +42,6 @@ function renderState(props: Partial<React.ComponentProps<typeof DeviceDisconnect
 describe("DeviceDisconnected", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    previousRouteNameRef.current = TEST_SOURCE;
   });
 
   it("renders title, description and the primary Retry / secondary Close CTAs", () => {
@@ -71,8 +68,6 @@ describe("DeviceDisconnected", () => {
 
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_DEVICE_ACTION.Disconnected,
       deviceUxV2: true,
       modelId: DeviceModelId.stax,
       transport: "ble",
@@ -92,8 +87,6 @@ describe("DeviceDisconnected", () => {
 
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_DEVICE_ACTION.Disconnected,
       deviceUxV2: true,
       modelId: DeviceModelId.stax,
       transport: "ble",

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/DeviceDisconnected.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/DeviceDisconnected.test.tsx
@@ -5,7 +5,8 @@ import {
   DeviceModelId as DMKDeviceModelId,
 } from "@ledgerhq/device-management-kit";
 import { DeviceModelId } from "@ledgerhq/types-devices";
-import { TrackScreen } from "~/analytics";
+import { TrackScreen, track } from "~/analytics";
+import { previousRouteNameRef } from "~/analytics/screenRefs";
 import { SourceFlowProvider } from "../utils/SourceFlowContext";
 import { PAGE_DEVICE_ACTION } from "../utils/trackDeviceIntent";
 import { DeviceDisconnected } from "./DeviceDisconnected";
@@ -15,10 +16,13 @@ jest.mock("~/analytics", () => {
   return {
     ...actual,
     TrackScreen: jest.fn(() => null),
+    track: jest.fn(),
   };
 });
 
 const mockedTrackScreen = jest.mocked(TrackScreen);
+const mockedTrack = jest.mocked(track);
+const TEST_SOURCE = "Portfolio";
 
 const device = {
   id: "device-id",
@@ -40,6 +44,7 @@ function renderState(props: Partial<React.ComponentProps<typeof DeviceDisconnect
 describe("DeviceDisconnected", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    previousRouteNameRef.current = TEST_SOURCE;
   });
 
   it("renders title, description and the primary Retry / secondary Close CTAs", () => {
@@ -64,6 +69,15 @@ describe("DeviceDisconnected", () => {
 
     await user.press(screen.getByText("Retry"));
 
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      page: PAGE_DEVICE_ACTION.Disconnected,
+      deviceUxV2: true,
+      modelId: DeviceModelId.stax,
+      transport: "ble",
+      button: "Retry",
+    });
     expect(onRetry).toHaveBeenCalledTimes(1);
     expect(onClose).not.toHaveBeenCalled();
   });
@@ -76,6 +90,15 @@ describe("DeviceDisconnected", () => {
 
     await user.press(screen.getByText("Close"));
 
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      page: PAGE_DEVICE_ACTION.Disconnected,
+      deviceUxV2: true,
+      modelId: DeviceModelId.stax,
+      transport: "ble",
+      button: "Close",
+    });
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(onRetry).not.toHaveBeenCalled();
   });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/DeviceDisconnected.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/DeviceDisconnected.tsx
@@ -5,8 +5,10 @@ import { TrackScreen } from "~/analytics";
 import { InfoState } from "LLM/components/InfoState";
 import { useSourceFlow } from "../utils/SourceFlowContext";
 import {
+  DEVICE_ACTION_BUTTON,
   getConnectedDeviceTrackingProperties,
   PAGE_DEVICE_ACTION,
+  trackDeviceActionButtonClicked,
 } from "../utils/trackDeviceIntent";
 
 /**
@@ -16,6 +18,26 @@ import {
 export const DeviceDisconnected: DeviceDisconnectedComponent = ({ device, onRetry, onClose }) => {
   const sourceFlow = useSourceFlow();
   const { modelId, transport } = getConnectedDeviceTrackingProperties(device);
+  const handleRetry = () => {
+    trackDeviceActionButtonClicked({
+      sourceFlow,
+      page: PAGE_DEVICE_ACTION.Disconnected,
+      button: DEVICE_ACTION_BUTTON.Retry,
+      modelId,
+      transport,
+    });
+    onRetry();
+  };
+  const handleClose = () => {
+    trackDeviceActionButtonClicked({
+      sourceFlow,
+      page: PAGE_DEVICE_ACTION.Disconnected,
+      button: DEVICE_ACTION_BUTTON.Close,
+      modelId,
+      transport,
+    });
+    onClose();
+  };
 
   return (
     <>
@@ -33,11 +55,11 @@ export const DeviceDisconnected: DeviceDisconnectedComponent = ({ device, onRetr
         description={<Trans i18nKey="deviceIntentExecutor.errors.connectionError.description" />}
         primaryCta={{
           label: <Trans i18nKey="common.retry" />,
-          onPress: onRetry,
+          onPress: handleRetry,
         }}
         secondaryCta={{
           label: <Trans i18nKey="common.close" />,
-          onPress: onClose,
+          onPress: handleClose,
         }}
         testID="device-intent-executor-device-disconnected"
       />

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/DeviceDisconnected.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/DeviceDisconnected.tsx
@@ -21,7 +21,6 @@ export const DeviceDisconnected: DeviceDisconnectedComponent = ({ device, onRetr
   const handleRetry = () => {
     trackDeviceActionButtonClicked({
       sourceFlow,
-      page: PAGE_DEVICE_ACTION.Disconnected,
       button: DEVICE_ACTION_BUTTON.Retry,
       modelId,
       transport,
@@ -31,7 +30,6 @@ export const DeviceDisconnected: DeviceDisconnectedComponent = ({ device, onRetr
   const handleClose = () => {
     trackDeviceActionButtonClicked({
       sourceFlow,
-      page: PAGE_DEVICE_ACTION.Disconnected,
       button: DEVICE_ACTION_BUTTON.Close,
       modelId,
       transport,
@@ -46,6 +44,7 @@ export const DeviceDisconnected: DeviceDisconnectedComponent = ({ device, onRetr
         sourceFlow={sourceFlow}
         modelId={modelId}
         transport={transport}
+        refreshSource
         deviceUxV2
       />
       <InfoState

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/IntentError.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/IntentError.test.tsx
@@ -5,7 +5,8 @@ import {
   DeviceModelId as DMKDeviceModelId,
 } from "@ledgerhq/device-management-kit";
 import { DeviceModelId } from "@ledgerhq/types-devices";
-import { TrackScreen } from "~/analytics";
+import { TrackScreen, track } from "~/analytics";
+import { previousRouteNameRef } from "~/analytics/screenRefs";
 import { SourceFlowProvider } from "../utils/SourceFlowContext";
 import { PAGE_DEVICE_ACTION } from "../utils/trackDeviceIntent";
 import { IntentError } from "./IntentError";
@@ -15,10 +16,13 @@ jest.mock("~/analytics", () => {
   return {
     ...actual,
     TrackScreen: jest.fn(() => null),
+    track: jest.fn(),
   };
 });
 
 const mockedTrackScreen = jest.mocked(TrackScreen);
+const mockedTrack = jest.mocked(track);
+const TEST_SOURCE = "Portfolio";
 
 const device = {
   id: "device-id",
@@ -46,6 +50,7 @@ function renderState(props: Partial<React.ComponentProps<typeof IntentError>> = 
 describe("IntentError", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    previousRouteNameRef.current = TEST_SOURCE;
   });
 
   it("renders title, description and the primary Retry / secondary Close CTAs", () => {
@@ -82,6 +87,15 @@ describe("IntentError", () => {
 
     await user.press(screen.getByText("Retry"));
 
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      page: PAGE_DEVICE_ACTION.UnknownIntentError,
+      deviceUxV2: true,
+      modelId: DeviceModelId.stax,
+      transport: "ble",
+      button: "Retry",
+    });
     expect(onRetry).toHaveBeenCalledTimes(1);
     expect(onClose).not.toHaveBeenCalled();
   });
@@ -94,11 +108,20 @@ describe("IntentError", () => {
 
     await user.press(screen.getByText("Close"));
 
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      page: PAGE_DEVICE_ACTION.UnknownIntentError,
+      deviceUxV2: true,
+      modelId: DeviceModelId.stax,
+      transport: "ble",
+      button: "Close",
+    });
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(onRetry).not.toHaveBeenCalled();
   });
 
-  it("fires the Device Action - Unknown Intent Error page event with sourceFlow, deviceUxV2 and modelId", () => {
+  it("fires the Device Action - Unknown Intent Error page event with sourceFlow, deviceUxV2, modelId and transport", () => {
     renderState();
 
     expect(mockedTrackScreen).toHaveBeenCalledWith(
@@ -107,6 +130,7 @@ describe("IntentError", () => {
         sourceFlow: "my_ledger",
         deviceUxV2: true,
         modelId: DeviceModelId.stax,
+        transport: "ble",
       }),
       undefined,
     );

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/IntentError.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/IntentError.test.tsx
@@ -6,7 +6,6 @@ import {
 } from "@ledgerhq/device-management-kit";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { TrackScreen, track } from "~/analytics";
-import { previousRouteNameRef } from "~/analytics/screenRefs";
 import { SourceFlowProvider } from "../utils/SourceFlowContext";
 import { PAGE_DEVICE_ACTION } from "../utils/trackDeviceIntent";
 import { IntentError } from "./IntentError";
@@ -22,7 +21,6 @@ jest.mock("~/analytics", () => {
 
 const mockedTrackScreen = jest.mocked(TrackScreen);
 const mockedTrack = jest.mocked(track);
-const TEST_SOURCE = "Portfolio";
 
 const device = {
   id: "device-id",
@@ -50,7 +48,6 @@ function renderState(props: Partial<React.ComponentProps<typeof IntentError>> = 
 describe("IntentError", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    previousRouteNameRef.current = TEST_SOURCE;
   });
 
   it("renders title, description and the primary Retry / secondary Close CTAs", () => {
@@ -89,8 +86,6 @@ describe("IntentError", () => {
 
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_DEVICE_ACTION.UnknownIntentError,
       deviceUxV2: true,
       modelId: DeviceModelId.stax,
       transport: "ble",
@@ -110,8 +105,6 @@ describe("IntentError", () => {
 
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_DEVICE_ACTION.UnknownIntentError,
       deviceUxV2: true,
       modelId: DeviceModelId.stax,
       transport: "ble",

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/IntentError.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/IntentError.tsx
@@ -7,8 +7,10 @@ import TranslatedError from "~/components/TranslatedError";
 import { InfoState } from "LLM/components/InfoState";
 import { useSourceFlow } from "../utils/SourceFlowContext";
 import {
+  DEVICE_ACTION_BUTTON,
   getConnectedDeviceTrackingProperties,
   PAGE_DEVICE_ACTION,
+  trackDeviceActionButtonClicked,
 } from "../utils/trackDeviceIntent";
 
 // Dev-only hint surfaced in the banner slot. This screen means the running intent let
@@ -33,7 +35,27 @@ const devBanner = __DEV__
 export const IntentError: ErrorComponent = ({ device, onRetry, onClose, error }) => {
   const errorIsTranslatable = error && (isDmkError(error) || error instanceof Error);
   const sourceFlow = useSourceFlow();
-  const { modelId } = getConnectedDeviceTrackingProperties(device);
+  const { modelId, transport } = getConnectedDeviceTrackingProperties(device);
+  const handleRetry = () => {
+    trackDeviceActionButtonClicked({
+      sourceFlow,
+      page: PAGE_DEVICE_ACTION.UnknownIntentError,
+      button: DEVICE_ACTION_BUTTON.Retry,
+      modelId,
+      transport,
+    });
+    onRetry();
+  };
+  const handleClose = () => {
+    trackDeviceActionButtonClicked({
+      sourceFlow,
+      page: PAGE_DEVICE_ACTION.UnknownIntentError,
+      button: DEVICE_ACTION_BUTTON.Close,
+      modelId,
+      transport,
+    });
+    onClose();
+  };
 
   return (
     <>
@@ -41,6 +63,7 @@ export const IntentError: ErrorComponent = ({ device, onRetry, onClose, error })
         category={PAGE_DEVICE_ACTION.UnknownIntentError}
         sourceFlow={sourceFlow}
         modelId={modelId}
+        transport={transport}
         deviceUxV2
       />
       <InfoState
@@ -63,11 +86,11 @@ export const IntentError: ErrorComponent = ({ device, onRetry, onClose, error })
         banner={devBanner}
         primaryCta={{
           label: <Trans i18nKey="common.retry" />,
-          onPress: onRetry,
+          onPress: handleRetry,
         }}
         secondaryCta={{
           label: <Trans i18nKey="common.close" />,
-          onPress: onClose,
+          onPress: handleClose,
         }}
         testID="device-intent-executor-intent-error"
       />

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/IntentError.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/IntentError.tsx
@@ -39,7 +39,6 @@ export const IntentError: ErrorComponent = ({ device, onRetry, onClose, error })
   const handleRetry = () => {
     trackDeviceActionButtonClicked({
       sourceFlow,
-      page: PAGE_DEVICE_ACTION.UnknownIntentError,
       button: DEVICE_ACTION_BUTTON.Retry,
       modelId,
       transport,
@@ -49,7 +48,6 @@ export const IntentError: ErrorComponent = ({ device, onRetry, onClose, error })
   const handleClose = () => {
     trackDeviceActionButtonClicked({
       sourceFlow,
-      page: PAGE_DEVICE_ACTION.UnknownIntentError,
       button: DEVICE_ACTION_BUTTON.Close,
       modelId,
       transport,
@@ -64,6 +62,7 @@ export const IntentError: ErrorComponent = ({ device, onRetry, onClose, error })
         sourceFlow={sourceFlow}
         modelId={modelId}
         transport={transport}
+        refreshSource
         deviceUxV2
       />
       <InfoState

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/InvalidOperation.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/InvalidOperation.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { render, screen } from "@tests/test-renderer";
-import { TrackScreen } from "~/analytics";
+import { TrackScreen, track } from "~/analytics";
+import { previousRouteNameRef } from "~/analytics/screenRefs";
 import { SourceFlowProvider } from "../utils/SourceFlowContext";
 import { PAGE_DEVICE_ACTION } from "../utils/trackDeviceIntent";
 import { InvalidOperation } from "./InvalidOperation";
@@ -10,10 +11,13 @@ jest.mock("~/analytics", () => {
   return {
     ...actual,
     TrackScreen: jest.fn(() => null),
+    track: jest.fn(),
   };
 });
 
 const mockedTrackScreen = jest.mocked(TrackScreen);
+const mockedTrack = jest.mocked(track);
+const TEST_SOURCE = "Portfolio";
 
 function renderState(props: Partial<React.ComponentProps<typeof InvalidOperation>> = {}) {
   return render(
@@ -26,6 +30,7 @@ function renderState(props: Partial<React.ComponentProps<typeof InvalidOperation
 describe("InvalidOperation", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    previousRouteNameRef.current = TEST_SOURCE;
   });
 
   it("renders title, description and the primary Close CTA", () => {
@@ -48,6 +53,13 @@ describe("InvalidOperation", () => {
 
     await user.press(screen.getByText("Close"));
 
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      sourceFlow: "my_ledger",
+      source: TEST_SOURCE,
+      page: PAGE_DEVICE_ACTION.InvalidState,
+      deviceUxV2: true,
+      button: "Close",
+    });
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/InvalidOperation.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/InvalidOperation.test.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { render, screen } from "@tests/test-renderer";
 import { TrackScreen, track } from "~/analytics";
-import { previousRouteNameRef } from "~/analytics/screenRefs";
 import { SourceFlowProvider } from "../utils/SourceFlowContext";
 import { PAGE_DEVICE_ACTION } from "../utils/trackDeviceIntent";
 import { InvalidOperation } from "./InvalidOperation";
@@ -17,7 +16,6 @@ jest.mock("~/analytics", () => {
 
 const mockedTrackScreen = jest.mocked(TrackScreen);
 const mockedTrack = jest.mocked(track);
-const TEST_SOURCE = "Portfolio";
 
 function renderState(props: Partial<React.ComponentProps<typeof InvalidOperation>> = {}) {
   return render(
@@ -30,7 +28,6 @@ function renderState(props: Partial<React.ComponentProps<typeof InvalidOperation
 describe("InvalidOperation", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    previousRouteNameRef.current = TEST_SOURCE;
   });
 
   it("renders title, description and the primary Close CTA", () => {
@@ -55,8 +52,6 @@ describe("InvalidOperation", () => {
 
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
-      source: TEST_SOURCE,
-      page: PAGE_DEVICE_ACTION.InvalidState,
       deviceUxV2: true,
       button: "Close",
     });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/InvalidOperation.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/InvalidOperation.tsx
@@ -33,7 +33,6 @@ export const InvalidOperation: InvalidOperationComponent = ({ onClose }) => {
   const handleClose = () => {
     trackDeviceActionButtonClicked({
       sourceFlow,
-      page: PAGE_DEVICE_ACTION.InvalidState,
       button: DEVICE_ACTION_BUTTON.Close,
     });
     onClose();
@@ -41,7 +40,12 @@ export const InvalidOperation: InvalidOperationComponent = ({ onClose }) => {
 
   return (
     <>
-      <TrackScreen category={PAGE_DEVICE_ACTION.InvalidState} sourceFlow={sourceFlow} deviceUxV2 />
+      <TrackScreen
+        category={PAGE_DEVICE_ACTION.InvalidState}
+        sourceFlow={sourceFlow}
+        refreshSource
+        deviceUxV2
+      />
       <InfoState
         preset="error"
         size="hug"

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/InvalidOperation.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/InvalidOperation.tsx
@@ -4,7 +4,11 @@ import { Trans } from "~/context/Locale";
 import { TrackScreen } from "~/analytics";
 import { InfoState } from "LLM/components/InfoState";
 import { useSourceFlow } from "../utils/SourceFlowContext";
-import { PAGE_DEVICE_ACTION } from "../utils/trackDeviceIntent";
+import {
+  DEVICE_ACTION_BUTTON,
+  PAGE_DEVICE_ACTION,
+  trackDeviceActionButtonClicked,
+} from "../utils/trackDeviceIntent";
 
 // Dev-only hint surfaced in the banner slot. This screen means the caller drove the
 // executor into an invalid state (e.g. swapping intents while one is still running),
@@ -26,6 +30,14 @@ const devBanner = __DEV__
  */
 export const InvalidOperation: InvalidOperationComponent = ({ onClose }) => {
   const sourceFlow = useSourceFlow();
+  const handleClose = () => {
+    trackDeviceActionButtonClicked({
+      sourceFlow,
+      page: PAGE_DEVICE_ACTION.InvalidState,
+      button: DEVICE_ACTION_BUTTON.Close,
+    });
+    onClose();
+  };
 
   return (
     <>
@@ -38,7 +50,7 @@ export const InvalidOperation: InvalidOperationComponent = ({ onClose }) => {
         banner={devBanner}
         primaryCta={{
           label: <Trans i18nKey="common.close" />,
-          onPress: onClose,
+          onPress: handleClose,
         }}
         testID="device-intent-executor-invalid-operation"
       />

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.test.tsx
@@ -227,6 +227,24 @@ describe("useDeviceIntentExecutorLWMViewModel", () => {
   });
 
   describe("GIVEN a ViewModel that has not yet completed", () => {
+    it("WHEN the user cancels THEN it tracks the Close button click", () => {
+      // GIVEN
+      const { result } = renderViewModel();
+      mockedTrack.mockClear();
+
+      // WHEN
+      act(() => {
+        result.current.wrappedProps.onUserCancel();
+      });
+
+      // THEN
+      expect(mockedTrack).toHaveBeenNthCalledWith(1, "button_clicked", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+        button: "Close",
+      });
+    });
+
     it("WHEN the user cancels from a non-blocking page THEN it fires deviceflow_aborted and forwards to the original onUserCancel", () => {
       // GIVEN
       const onUserCancel = jest.fn();

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.test.tsx
@@ -8,9 +8,10 @@ import type {
 import { DeviceModelId as DMKDeviceModelId } from "@ledgerhq/device-management-kit";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { track } from "~/analytics";
-import { previousRouteNameRef } from "~/analytics/screenRefs";
+import { currentRouteNameRef } from "~/analytics/screenRefs";
 import type { InitializerConfig } from "./DeviceContextInitializerComponentLWM";
 import type { InitializationInput } from "./types";
+import { PAGE_CONNECT_APP } from "./utils/trackDeviceIntent";
 import { useDeviceIntentExecutorLWMViewModel } from "./useDeviceIntentExecutorLWMViewModel";
 
 jest.mock("~/analytics", () => {
@@ -22,10 +23,8 @@ jest.mock("~/analytics", () => {
 });
 
 const mockedTrack = jest.mocked(track);
-const TEST_SOURCE = "Connect Device - Connecting";
 
 const layerABaseProperties = {
-  source: TEST_SOURCE,
   deviceUxV2: true,
 };
 
@@ -91,13 +90,32 @@ function executingIntentState(
 describe("useDeviceIntentExecutorLWMViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    previousRouteNameRef.current = TEST_SOURCE;
+    currentRouteNameRef.current = "Connect Device - Connecting";
+  });
+
+  describe("GIVEN the ViewModel mounts", () => {
+    it("WHEN the hook renders again THEN it fires deviceflow_started exactly once with the sourceFlow", () => {
+      // WHEN
+      const { rerender } = renderViewModel();
+      rerender(undefined);
+
+      // THEN
+      const startedCalls = mockedTrack.mock.calls.filter(
+        ([eventName]) => eventName === "deviceflow_started",
+      );
+      expect(startedCalls).toHaveLength(1);
+      expect(startedCalls[0]).toEqual([
+        "deviceflow_started",
+        { ...layerABaseProperties, sourceFlow: "swap" },
+      ]);
+    });
   });
 
   describe("GIVEN the executor reaches executingIntent for the first time", () => {
     it("WHEN the connection result is BLE THEN it fires app_ready THEN deviceflow_completed with the data carried by the state", () => {
       // GIVEN
       const { result } = renderViewModel();
+      mockedTrack.mockClear();
 
       // WHEN
       act(() => {
@@ -125,6 +143,7 @@ describe("useDeviceIntentExecutorLWMViewModel", () => {
     it("WHEN the connection result is USB THEN deviceflow_completed reports transport: usb", () => {
       // GIVEN
       const { result } = renderViewModel();
+      mockedTrack.mockClear();
 
       // WHEN
       act(() => {
@@ -192,9 +211,10 @@ describe("useDeviceIntentExecutorLWMViewModel", () => {
       { type: "idle" },
     ];
 
-    it.each(nonCompleting)("WHEN state is $type THEN no Layer A event fires", state => {
+    it.each(nonCompleting)("WHEN state is $type THEN no additional Layer A event fires", state => {
       // GIVEN
       const { result } = renderViewModel();
+      mockedTrack.mockClear();
 
       // WHEN
       act(() => {
@@ -207,7 +227,7 @@ describe("useDeviceIntentExecutorLWMViewModel", () => {
   });
 
   describe("GIVEN a ViewModel that has not yet completed", () => {
-    it("WHEN the user cancels THEN it fires deviceflow_aborted and forwards to the original onUserCancel", () => {
+    it("WHEN the user cancels from a non-blocking page THEN it fires deviceflow_aborted and forwards to the original onUserCancel", () => {
       // GIVEN
       const onUserCancel = jest.fn();
       const { result } = renderViewModel({ onUserCancel });
@@ -219,6 +239,25 @@ describe("useDeviceIntentExecutorLWMViewModel", () => {
 
       // THEN
       expect(mockedTrack).toHaveBeenCalledWith("deviceflow_aborted", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+      });
+      expect(onUserCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it("WHEN the user cancels from a blocking page THEN it fires deviceflow_failed and forwards to the original onUserCancel", () => {
+      // GIVEN
+      currentRouteNameRef.current = PAGE_CONNECT_APP.UnsupportedFirmware;
+      const onUserCancel = jest.fn();
+      const { result } = renderViewModel({ onUserCancel });
+
+      // WHEN
+      act(() => {
+        result.current.wrappedProps.onUserCancel();
+      });
+
+      // THEN
+      expect(mockedTrack).toHaveBeenCalledWith("deviceflow_failed", {
         ...layerABaseProperties,
         sourceFlow: "swap",
       });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.test.tsx
@@ -53,11 +53,16 @@ function makeProps(overrides: Partial<Props> = {}): Props {
 }
 
 function renderViewModel(initialProps?: Partial<Props>) {
-  const props = makeProps(initialProps);
+  let props = makeProps(initialProps);
   const { result, rerender, unmount } = renderHook(() =>
     useDeviceIntentExecutorLWMViewModel(props),
   );
-  return { result, rerender, unmount, props };
+  const rerenderWithProps = (overrides: Partial<Props>) => {
+    props = { ...props, ...overrides };
+    rerender(undefined);
+  };
+
+  return { result, rerender, rerenderWithProps, unmount, props };
 }
 
 // Builds the minimum DeviceConnectionResult shape that the VM reads from.
@@ -108,6 +113,31 @@ describe("useDeviceIntentExecutorLWMViewModel", () => {
         "deviceflow_started",
         { ...layerABaseProperties, sourceFlow: "swap" },
       ]);
+    });
+
+    it("WHEN the executor is disabled THEN it does not fire deviceflow_started", () => {
+      // WHEN
+      renderViewModel({ enabled: false });
+
+      // THEN
+      expect(mockedTrack).not.toHaveBeenCalledWith("deviceflow_started", expect.anything());
+    });
+  });
+
+  describe("GIVEN a disabled ViewModel", () => {
+    it("WHEN the executor is enabled THEN it fires deviceflow_started", () => {
+      // GIVEN
+      const { rerenderWithProps } = renderViewModel({ enabled: false });
+      mockedTrack.mockClear();
+
+      // WHEN
+      rerenderWithProps({ enabled: true });
+
+      // THEN
+      expect(mockedTrack).toHaveBeenCalledWith("deviceflow_started", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+      });
     });
   });
 
@@ -200,6 +230,61 @@ describe("useDeviceIntentExecutorLWMViewModel", () => {
 
       // THEN
       expect(mockedTrack).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("GIVEN a completed flow is disabled and reenabled", () => {
+    it("WHEN the executor reaches executingIntent again THEN it tracks the new flow completion", () => {
+      // GIVEN
+      const { result, rerenderWithProps } = renderViewModel();
+      act(() => {
+        result.current.wrappedProps.onExecutorStateChanged(executingIntentState());
+      });
+      rerenderWithProps({ enabled: false });
+      rerenderWithProps({ enabled: true });
+      mockedTrack.mockClear();
+
+      // WHEN
+      act(() => {
+        result.current.wrappedProps.onExecutorStateChanged(executingIntentState());
+      });
+
+      // THEN
+      expect(mockedTrack).toHaveBeenNthCalledWith(1, "app_ready", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+        modelId: DeviceModelId.stax,
+      });
+      expect(mockedTrack).toHaveBeenNthCalledWith(2, "deviceflow_completed", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+        modelId: DeviceModelId.stax,
+        transport: "ble",
+      });
+    });
+
+    it("WHEN the user cancels before executingIntent again THEN it tracks the new flow cancellation", () => {
+      // GIVEN
+      const onUserCancel = jest.fn();
+      const { result, rerenderWithProps } = renderViewModel({ onUserCancel });
+      act(() => {
+        result.current.wrappedProps.onExecutorStateChanged(executingIntentState());
+      });
+      rerenderWithProps({ enabled: false });
+      rerenderWithProps({ enabled: true });
+      mockedTrack.mockClear();
+
+      // WHEN
+      act(() => {
+        result.current.wrappedProps.onUserCancel();
+      });
+
+      // THEN
+      expect(mockedTrack).toHaveBeenCalledWith("deviceflow_aborted", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+      });
+      expect(onUserCancel).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.ts
@@ -77,7 +77,7 @@ export function useDeviceIntentExecutorLWMViewModel<JobState, Input, ExtraProps>
       trackDeviceflowCanceled({ sourceFlow });
     }
     onUserCancel();
-  }, [sourceFlow]);
+  }, [onUserCancel, sourceFlow]);
 
   return {
     sourceFlow,

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.ts
@@ -11,6 +11,7 @@ import {
   trackDeviceflowCanceled,
   trackDeviceflowCompleted,
   trackDeviceflowStarted,
+  trackDrawerCloseButtonClicked,
 } from "./utils/trackDeviceIntent";
 import type { InitializerConfig } from "./DeviceContextInitializerComponentLWM";
 import type { InitializationInput } from "./types";
@@ -71,11 +72,12 @@ export function useDeviceIntentExecutorLWMViewModel<JobState, Input, ExtraProps>
   );
 
   const wrappedOnUserCancel = useCallback(() => {
+    trackDrawerCloseButtonClicked({ sourceFlow });
     if (!initializationCompletedRef.current) {
       trackDeviceflowCanceled({ sourceFlow });
     }
     onUserCancel();
-  }, [onUserCancel, sourceFlow]);
+  }, [sourceFlow]);
 
   return {
     sourceFlow,

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.ts
@@ -47,20 +47,27 @@ function mapConnectionResult(result: DeviceConnectionResult): ConnectionTracking
 export function useDeviceIntentExecutorLWMViewModel<JobState, Input, ExtraProps>(
   props: Props<JobState, Input, ExtraProps>,
 ): DeviceIntentExecutorLWMViewModel<JobState, Input, ExtraProps> {
-  const { sourceFlow, onExecutorStateChanged, onUserCancel } = props;
+  const { enabled, sourceFlow, onExecutorStateChanged, onUserCancel } = props;
 
   const flowStartedRef = useRef(false);
   const initializationCompletedRef = useRef(false);
 
   useEffect(() => {
+    if (!enabled) {
+      flowStartedRef.current = false;
+      initializationCompletedRef.current = false;
+      return;
+    }
+
     if (flowStartedRef.current) return;
     flowStartedRef.current = true;
+    initializationCompletedRef.current = false;
     trackDeviceflowStarted({ sourceFlow });
-  }, [sourceFlow]);
+  }, [enabled, sourceFlow]);
 
   const wrappedOnExecutorStateChanged = useCallback(
     (state: ExecutorState) => {
-      if (state.type === "executingIntent" && !initializationCompletedRef.current) {
+      if (enabled && state.type === "executingIntent" && !initializationCompletedRef.current) {
         initializationCompletedRef.current = true;
         const { modelId, transport } = mapConnectionResult(state.connectionResult);
         trackAppReady({ sourceFlow, modelId });
@@ -68,7 +75,7 @@ export function useDeviceIntentExecutorLWMViewModel<JobState, Input, ExtraProps>
       }
       onExecutorStateChanged(state);
     },
-    [onExecutorStateChanged, sourceFlow],
+    [enabled, onExecutorStateChanged, sourceFlow],
   );
 
   const wrappedOnUserCancel = useCallback(() => {

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import type {
   DeviceConnectionResult,
   DeviceIntentExecutorProps,
@@ -8,8 +8,9 @@ import { dmkToLedgerDeviceIdMap } from "@ledgerhq/live-dmk-shared";
 import type { DeviceModelId } from "@ledgerhq/types-devices";
 import {
   trackAppReady,
-  trackDeviceflowAborted,
+  trackDeviceflowCanceled,
   trackDeviceflowCompleted,
+  trackDeviceflowStarted,
 } from "./utils/trackDeviceIntent";
 import type { InitializerConfig } from "./DeviceContextInitializerComponentLWM";
 import type { InitializationInput } from "./types";
@@ -47,7 +48,14 @@ export function useDeviceIntentExecutorLWMViewModel<JobState, Input, ExtraProps>
 ): DeviceIntentExecutorLWMViewModel<JobState, Input, ExtraProps> {
   const { sourceFlow, onExecutorStateChanged, onUserCancel } = props;
 
+  const flowStartedRef = useRef(false);
   const initializationCompletedRef = useRef(false);
+
+  useEffect(() => {
+    if (flowStartedRef.current) return;
+    flowStartedRef.current = true;
+    trackDeviceflowStarted({ sourceFlow });
+  }, [sourceFlow]);
 
   const wrappedOnExecutorStateChanged = useCallback(
     (state: ExecutorState) => {
@@ -64,7 +72,7 @@ export function useDeviceIntentExecutorLWMViewModel<JobState, Input, ExtraProps>
 
   const wrappedOnUserCancel = useCallback(() => {
     if (!initializationCompletedRef.current) {
-      trackDeviceflowAborted({ sourceFlow });
+      trackDeviceflowCanceled({ sourceFlow });
     }
     onUserCancel();
   }, [onUserCancel, sourceFlow]);

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import type {
   DeviceConnectionResult,
   DeviceIntentExecutorProps,

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 import type {
   DeviceConnectionResult,
   DeviceIntentExecutorProps,
@@ -51,11 +51,13 @@ export function useDeviceIntentExecutorLWMViewModel<JobState, Input, ExtraProps>
 
   const flowStartedRef = useRef(false);
   const initializationCompletedRef = useRef(false);
+  const closeTrackedRef = useRef(false);
 
   useEffect(() => {
     if (!enabled) {
       flowStartedRef.current = false;
       initializationCompletedRef.current = false;
+      closeTrackedRef.current = false;
       return;
     }
 
@@ -79,9 +81,12 @@ export function useDeviceIntentExecutorLWMViewModel<JobState, Input, ExtraProps>
   );
 
   const wrappedOnUserCancel = useCallback(() => {
-    trackDrawerCloseButtonClicked({ sourceFlow });
-    if (!initializationCompletedRef.current) {
-      trackDeviceflowCanceled({ sourceFlow });
+    if (!closeTrackedRef.current) {
+      closeTrackedRef.current = true;
+      trackDrawerCloseButtonClicked({ sourceFlow });
+      if (!initializationCompletedRef.current) {
+        trackDeviceflowCanceled({ sourceFlow });
+      }
     }
     onUserCancel();
   }, [onUserCancel, sourceFlow]);

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.test.ts
@@ -14,7 +14,9 @@ import {
   getTrackingSubError,
   getTrackingTransport,
   PAGE_CONNECT_APP,
+  PAGE_CONNECT_DEVICE,
   PAGE_DEVICE_ACTION,
+  setIsInTerminalConnectDeviceError,
   trackDeviceActionButtonClicked,
   trackConnectAppButtonClicked,
   trackConnectDeviceButtonClicked,
@@ -56,6 +58,7 @@ const layerABaseProperties = {
 describe("trackDeviceIntent — Layer A tracking helpers", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    setIsInTerminalConnectDeviceError(false);
     currentRouteNameRef.current = "Connect Device - Connecting";
   });
 
@@ -237,6 +240,41 @@ describe("trackDeviceIntent — Layer A tracking helpers", () => {
         sourceFlow: "send",
       });
     });
+
+    it.each([PAGE_CONNECT_DEVICE.DiscoveryError, PAGE_CONNECT_DEVICE.ConnectionError])(
+      "GIVEN a non-terminal Connect Device error page %s WHEN called THEN it tracks deviceflow_aborted",
+      page => {
+        // GIVEN
+        currentRouteNameRef.current = page;
+
+        // WHEN
+        trackDeviceflowCanceled({ sourceFlow: "swap" });
+
+        // THEN
+        expect(mockedTrack).toHaveBeenCalledWith("deviceflow_aborted", {
+          ...layerABaseProperties,
+          sourceFlow: "swap",
+        });
+      },
+    );
+
+    it.each([PAGE_CONNECT_DEVICE.DiscoveryError, PAGE_CONNECT_DEVICE.ConnectionError])(
+      "GIVEN a terminal Connect Device error page %s WHEN called THEN it tracks deviceflow_failed",
+      page => {
+        // GIVEN
+        currentRouteNameRef.current = page;
+        setIsInTerminalConnectDeviceError(true);
+
+        // WHEN
+        trackDeviceflowCanceled({ sourceFlow: "swap" });
+
+        // THEN
+        expect(mockedTrack).toHaveBeenCalledWith("deviceflow_failed", {
+          ...layerABaseProperties,
+          sourceFlow: "swap",
+        });
+      },
+    );
   });
 
   describe("getTrackingSubError", () => {

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.test.ts
@@ -9,10 +9,14 @@ import { DeviceModelId } from "@ledgerhq/types-devices";
 import { track } from "~/analytics";
 import { previousRouteNameRef } from "~/analytics/screenRefs";
 import {
+  DEVICE_ACTION_BUTTON,
   getConnectedDeviceTrackingProperties,
   getTrackingSubError,
   getTrackingTransport,
+  PAGE_CONNECT_APP,
+  PAGE_CONNECT_DEVICE,
   PAGE_DEVICE_ACTION,
+  trackDeviceActionButtonClicked,
   trackConnectAppButtonClicked,
   trackConnectDeviceButtonClicked,
   trackAppReady,
@@ -268,17 +272,19 @@ describe("trackDeviceIntent — Layer A tracking helpers", () => {
   });
 
   describe("trackConnectDeviceButtonClicked", () => {
-    describe("Given a sourceFlow and button", () => {
+    describe("Given a sourceFlow, page and button", () => {
       describe("When called", () => {
         it("Then tracks button_clicked with the Layer B properties", () => {
           trackConnectDeviceButtonClicked({
             sourceFlow: "send",
+            page: PAGE_CONNECT_DEVICE.DiscoveryError,
             button: "Retry",
           });
 
           expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
             ...layerABaseProperties,
             sourceFlow: "send",
+            page: PAGE_CONNECT_DEVICE.DiscoveryError,
             button: "Retry",
           });
         });
@@ -287,9 +293,10 @@ describe("trackDeviceIntent — Layer A tracking helpers", () => {
   });
 
   describe("trackConnectAppButtonClicked", () => {
-    it("GIVEN sourceFlow modelId and button WHEN called THEN it tracks button_clicked with the Layer B properties", () => {
+    it("GIVEN sourceFlow page modelId and button WHEN called THEN it tracks button_clicked with the Layer B properties", () => {
       trackConnectAppButtonClicked({
         sourceFlow: "send",
+        page: PAGE_CONNECT_APP.DeviceBusy,
         modelId: DeviceModelId.stax,
         button: "Retry",
       });
@@ -297,8 +304,30 @@ describe("trackDeviceIntent — Layer A tracking helpers", () => {
       expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
         ...layerABaseProperties,
         sourceFlow: "send",
+        page: PAGE_CONNECT_APP.DeviceBusy,
         modelId: DeviceModelId.stax,
         button: "Retry",
+      });
+    });
+  });
+
+  describe("trackDeviceActionButtonClicked", () => {
+    it("GIVEN sourceFlow page button and device properties WHEN called THEN it tracks button_clicked with the Device Action properties", () => {
+      trackDeviceActionButtonClicked({
+        sourceFlow: "send",
+        page: PAGE_DEVICE_ACTION.Disconnected,
+        button: DEVICE_ACTION_BUTTON.Close,
+        modelId: DeviceModelId.stax,
+        transport: "ble",
+      });
+
+      expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+        ...layerABaseProperties,
+        sourceFlow: "send",
+        page: PAGE_DEVICE_ACTION.Disconnected,
+        button: DEVICE_ACTION_BUTTON.Close,
+        modelId: DeviceModelId.stax,
+        transport: "ble",
       });
     });
   });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.test.ts
@@ -7,14 +7,13 @@ import { rnHidTransportIdentifier } from "@ledgerhq/device-transport-kit-react-n
 import { ConnectionErrorTypes, DiscoveryErrorTypes } from "@ledgerhq/live-dmk-mobile";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { track } from "~/analytics";
-import { previousRouteNameRef } from "~/analytics/screenRefs";
+import { currentRouteNameRef } from "~/analytics/screenRefs";
 import {
   DEVICE_ACTION_BUTTON,
   getConnectedDeviceTrackingProperties,
   getTrackingSubError,
   getTrackingTransport,
   PAGE_CONNECT_APP,
-  PAGE_CONNECT_DEVICE,
   PAGE_DEVICE_ACTION,
   trackDeviceActionButtonClicked,
   trackConnectAppButtonClicked,
@@ -24,7 +23,9 @@ import {
   trackDeviceConnecting,
   trackDeviceSelected,
   trackDeviceflowAborted,
+  trackDeviceflowCanceled,
   trackDeviceflowCompleted,
+  trackDeviceflowFailed,
   trackDeviceflowStarted,
   trackDevicePrompted,
 } from "./trackDeviceIntent";
@@ -38,7 +39,6 @@ jest.mock("~/analytics", () => {
 });
 
 const mockedTrack = jest.mocked(track);
-const TEST_SOURCE = "Portfolio";
 const TEST_BLE_TRANSPORT: TransportIdentifier = "RN_BLE";
 const connectedDevice: ConnectedDevice = {
   id: "device-id",
@@ -50,14 +50,13 @@ const connectedDevice: ConnectedDevice = {
 };
 
 const layerABaseProperties = {
-  source: TEST_SOURCE,
   deviceUxV2: true,
 };
 
 describe("trackDeviceIntent — Layer A tracking helpers", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    previousRouteNameRef.current = TEST_SOURCE;
+    currentRouteNameRef.current = "Connect Device - Connecting";
   });
 
   describe("trackDeviceflowStarted", () => {
@@ -190,6 +189,56 @@ describe("trackDeviceIntent — Layer A tracking helpers", () => {
     });
   });
 
+  describe("trackDeviceflowFailed", () => {
+    describe("Given a sourceFlow", () => {
+      describe("When called", () => {
+        it("Then tracks deviceflow_failed with the Layer A base properties", () => {
+          trackDeviceflowFailed({ sourceFlow: "my_ledger" });
+
+          expect(mockedTrack).toHaveBeenCalledWith("deviceflow_failed", {
+            ...layerABaseProperties,
+            sourceFlow: "my_ledger",
+          });
+        });
+      });
+    });
+  });
+
+  describe("trackDeviceflowCanceled", () => {
+    it("GIVEN the current page is non-blocking WHEN called THEN it tracks deviceflow_aborted", () => {
+      currentRouteNameRef.current = PAGE_CONNECT_APP.DeviceBusy;
+
+      trackDeviceflowCanceled({ sourceFlow: "swap" });
+
+      expect(mockedTrack).toHaveBeenCalledWith("deviceflow_aborted", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+      });
+    });
+
+    it("GIVEN the current page is blocking WHEN called THEN it tracks deviceflow_failed", () => {
+      currentRouteNameRef.current = PAGE_CONNECT_APP.UnsupportedFirmware;
+
+      trackDeviceflowCanceled({ sourceFlow: "swap" });
+
+      expect(mockedTrack).toHaveBeenCalledWith("deviceflow_failed", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+      });
+    });
+
+    it("GIVEN the current page is a generic device action error WHEN called THEN it tracks deviceflow_failed", () => {
+      currentRouteNameRef.current = PAGE_DEVICE_ACTION.Disconnected;
+
+      trackDeviceflowCanceled({ sourceFlow: "send" });
+
+      expect(mockedTrack).toHaveBeenCalledWith("deviceflow_failed", {
+        ...layerABaseProperties,
+        sourceFlow: "send",
+      });
+    });
+  });
+
   describe("getTrackingSubError", () => {
     describe("Given a Connect Device error type", () => {
       describe("When called", () => {
@@ -272,19 +321,17 @@ describe("trackDeviceIntent — Layer A tracking helpers", () => {
   });
 
   describe("trackConnectDeviceButtonClicked", () => {
-    describe("Given a sourceFlow, page and button", () => {
+    describe("Given a sourceFlow and button", () => {
       describe("When called", () => {
-        it("Then tracks button_clicked with the Layer B properties", () => {
+        it("Then tracks button_clicked without overriding the current page", () => {
           trackConnectDeviceButtonClicked({
             sourceFlow: "send",
-            page: PAGE_CONNECT_DEVICE.DiscoveryError,
             button: "Retry",
           });
 
           expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
             ...layerABaseProperties,
             sourceFlow: "send",
-            page: PAGE_CONNECT_DEVICE.DiscoveryError,
             button: "Retry",
           });
         });
@@ -293,10 +340,9 @@ describe("trackDeviceIntent — Layer A tracking helpers", () => {
   });
 
   describe("trackConnectAppButtonClicked", () => {
-    it("GIVEN sourceFlow page modelId and button WHEN called THEN it tracks button_clicked with the Layer B properties", () => {
+    it("GIVEN sourceFlow modelId and button WHEN called THEN it tracks button_clicked without overriding the current page", () => {
       trackConnectAppButtonClicked({
         sourceFlow: "send",
-        page: PAGE_CONNECT_APP.DeviceBusy,
         modelId: DeviceModelId.stax,
         button: "Retry",
       });
@@ -304,7 +350,6 @@ describe("trackDeviceIntent — Layer A tracking helpers", () => {
       expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
         ...layerABaseProperties,
         sourceFlow: "send",
-        page: PAGE_CONNECT_APP.DeviceBusy,
         modelId: DeviceModelId.stax,
         button: "Retry",
       });
@@ -312,10 +357,9 @@ describe("trackDeviceIntent — Layer A tracking helpers", () => {
   });
 
   describe("trackDeviceActionButtonClicked", () => {
-    it("GIVEN sourceFlow page button and device properties WHEN called THEN it tracks button_clicked with the Device Action properties", () => {
+    it("GIVEN sourceFlow button and device properties WHEN called THEN it tracks button_clicked without overriding the current page", () => {
       trackDeviceActionButtonClicked({
         sourceFlow: "send",
-        page: PAGE_DEVICE_ACTION.Disconnected,
         button: DEVICE_ACTION_BUTTON.Close,
         modelId: DeviceModelId.stax,
         transport: "ble",
@@ -324,7 +368,6 @@ describe("trackDeviceIntent — Layer A tracking helpers", () => {
       expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
         ...layerABaseProperties,
         sourceFlow: "send",
-        page: PAGE_DEVICE_ACTION.Disconnected,
         button: DEVICE_ACTION_BUTTON.Close,
         modelId: DeviceModelId.stax,
         transport: "ble",

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
@@ -19,15 +19,18 @@ export const PAGE_CONNECT_DEVICE = {
 /**
  * Canonical, locale-independent `button` values for Connect Device `button_clicked`
  * events. The displayed CTA label stays localized; analytics receives these stable
- * strings so the property is not fragmented across languages. The error screen is
- * already disambiguated by the `subError` property, so primary retry/allow CTAs
- * collapse to a single `Retry` value.
+ * strings so the property is not fragmented across languages.
  */
 export const CONNECT_DEVICE_BUTTON = {
-  ConnectLedgerDevice: "Connect Ledger Device",
-  NoLedgerDevice: "I Don't Have A Ledger Device",
+  ConnectDevice: "Connect Device",
+  BuyDevice: "Buy Device",
   Retry: "Retry",
   ContinueWithUsb: "Continue with USB",
+  OpenSettings: "Open Settings",
+  AllowBluetooth: "Allow Bluetooth",
+  TurnOnBluetooth: "Turn On Bluetooth",
+  AllowLocation: "Allow Location",
+  TurnOnLocation: "Turn On Location",
   GetHelp: "Get Help",
 } as const;
 
@@ -71,11 +74,21 @@ export const CONNECT_APP_BUTTON = {
   SetUpDevice: "Set Up Device",
   UpdateFirmware: "Update Firmware",
   ContactLedgerSupport: "Contact Ledger Support",
+  LearnMore: "Learn More",
+  DiscoverUpgradeProgram: "Discover Upgrade Program",
   ManageApps: "Manage Apps",
+} as const;
+
+export const DEVICE_ACTION_BUTTON = {
+  Retry: CONNECT_APP_BUTTON.Retry,
+  Close: CONNECT_APP_BUTTON.Close,
 } as const;
 
 export type TrackingTransport = "ble" | "usb";
 type ConnectDeviceErrorType = ConnectionErrorTypes | DiscoveryErrorTypes;
+type ConnectDevicePage = (typeof PAGE_CONNECT_DEVICE)[keyof typeof PAGE_CONNECT_DEVICE];
+type ConnectAppPage = (typeof PAGE_CONNECT_APP)[keyof typeof PAGE_CONNECT_APP];
+type DeviceActionPage = (typeof PAGE_DEVICE_ACTION)[keyof typeof PAGE_DEVICE_ACTION];
 
 const TRACKING_SUB_ERRORS: Record<ConnectDeviceErrorType, string> = {
   [DiscoveryErrorTypes.BluetoothPermissionDeniedPromptable]: "BluetoothPermissionDeniedPromptable",
@@ -111,7 +124,9 @@ export const getTrackingTransport = (
   return transportId === rnHidTransportIdentifier ? "usb" : "ble";
 };
 
-export const getConnectedDeviceTrackingProperties = (device: ConnectedDevice) => ({
+export const getConnectedDeviceTrackingProperties = (
+  device: ConnectedDevice,
+): { modelId: DeviceModelId; transport: TrackingTransport } => ({
   modelId: dmkToLedgerDeviceIdMap[device.modelId],
   transport: device.type === "USB" ? "usb" : "ble",
 });
@@ -189,22 +204,42 @@ export const trackDeviceSelected = (params: {
 
 export const trackConnectDeviceButtonClicked = (params: {
   sourceFlow: SourceFlow;
+  page: ConnectDevicePage;
   button: string;
 }): void => {
   track("button_clicked", {
     ...getDeviceUxV2BaseProperties(params.sourceFlow),
+    page: params.page,
     button: params.button,
   });
 };
 
 export const trackConnectAppButtonClicked = (params: {
   sourceFlow: SourceFlow;
+  page: ConnectAppPage;
   modelId: DeviceModelId;
   button: string;
 }): void => {
   track("button_clicked", {
     ...getDeviceUxV2BaseProperties(params.sourceFlow),
+    page: params.page,
     modelId: params.modelId,
     button: params.button,
+  });
+};
+
+export const trackDeviceActionButtonClicked = (params: {
+  sourceFlow: SourceFlow;
+  page: DeviceActionPage;
+  button: string;
+  modelId?: DeviceModelId;
+  transport?: TrackingTransport;
+}): void => {
+  track("button_clicked", {
+    ...getDeviceUxV2BaseProperties(params.sourceFlow),
+    page: params.page,
+    button: params.button,
+    ...(params.modelId ? { modelId: params.modelId } : {}),
+    ...(params.transport ? { transport: params.transport } : {}),
   });
 };

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
@@ -4,7 +4,7 @@ import type { DeviceModelId } from "@ledgerhq/types-devices";
 import { dmkToLedgerDeviceIdMap, type KnownDevice } from "@ledgerhq/live-dmk-shared";
 import { ConnectionErrorTypes, DiscoveryErrorTypes } from "@ledgerhq/live-dmk-mobile";
 import { track } from "~/analytics";
-import { previousRouteNameRef } from "~/analytics/screenRefs";
+import { currentRouteNameRef } from "~/analytics/screenRefs";
 import type { SourceFlow } from "./SourceFlowContext";
 
 export const PAGE_CONNECT_DEVICE = {
@@ -86,9 +86,6 @@ export const DEVICE_ACTION_BUTTON = {
 
 export type TrackingTransport = "ble" | "usb";
 type ConnectDeviceErrorType = ConnectionErrorTypes | DiscoveryErrorTypes;
-type ConnectDevicePage = (typeof PAGE_CONNECT_DEVICE)[keyof typeof PAGE_CONNECT_DEVICE];
-type ConnectAppPage = (typeof PAGE_CONNECT_APP)[keyof typeof PAGE_CONNECT_APP];
-type DeviceActionPage = (typeof PAGE_DEVICE_ACTION)[keyof typeof PAGE_DEVICE_ACTION];
 
 const TRACKING_SUB_ERRORS: Record<ConnectDeviceErrorType, string> = {
   [DiscoveryErrorTypes.BluetoothPermissionDeniedPromptable]: "BluetoothPermissionDeniedPromptable",
@@ -111,9 +108,24 @@ const TRACKING_SUB_ERRORS: Record<ConnectDeviceErrorType, string> = {
   [ConnectionErrorTypes.BlePairingPeerRemovedPairing]: "BlePairingPeerRemovedPairing",
 };
 
+const DEVICEFLOW_FAILED_CLOSE_PAGES = new Set<string>([
+  PAGE_CONNECT_DEVICE.DiscoveryError,
+  PAGE_CONNECT_DEVICE.ConnectionError,
+  PAGE_CONNECT_APP.DeviceNotOnboarded,
+  PAGE_CONNECT_APP.UnsupportedFirmware,
+  PAGE_CONNECT_APP.UnsupportedApplication,
+  PAGE_CONNECT_APP.UnsupportedFeature,
+  PAGE_CONNECT_APP.DeviceDeprecatedBlocking,
+  PAGE_CONNECT_APP.WrongDeviceForAccount,
+  PAGE_CONNECT_APP.OutOfStorage,
+  PAGE_CONNECT_APP.Error,
+  PAGE_DEVICE_ACTION.Disconnected,
+  PAGE_DEVICE_ACTION.UnknownIntentError,
+  PAGE_DEVICE_ACTION.InvalidState,
+]);
+
 export const getDeviceUxV2BaseProperties = (sourceFlow: SourceFlow) => ({
   sourceFlow,
-  source: previousRouteNameRef.current,
   deviceUxV2: true,
 });
 
@@ -191,6 +203,20 @@ export const trackDeviceflowAborted = (params: { sourceFlow: SourceFlow }): void
   track("deviceflow_aborted", getDeviceUxV2BaseProperties(params.sourceFlow));
 };
 
+export const trackDeviceflowFailed = (params: { sourceFlow: SourceFlow }): void => {
+  track("deviceflow_failed", getDeviceUxV2BaseProperties(params.sourceFlow));
+};
+
+export const trackDeviceflowCanceled = (params: { sourceFlow: SourceFlow }): void => {
+  const currentPage = currentRouteNameRef.current;
+  if (currentPage && DEVICEFLOW_FAILED_CLOSE_PAGES.has(currentPage)) {
+    trackDeviceflowFailed(params);
+    return;
+  }
+
+  trackDeviceflowAborted(params);
+};
+
 export const trackDeviceSelected = (params: {
   sourceFlow: SourceFlow;
   device: KnownDevice;
@@ -204,25 +230,21 @@ export const trackDeviceSelected = (params: {
 
 export const trackConnectDeviceButtonClicked = (params: {
   sourceFlow: SourceFlow;
-  page: ConnectDevicePage;
   button: string;
 }): void => {
   track("button_clicked", {
     ...getDeviceUxV2BaseProperties(params.sourceFlow),
-    page: params.page,
     button: params.button,
   });
 };
 
 export const trackConnectAppButtonClicked = (params: {
   sourceFlow: SourceFlow;
-  page: ConnectAppPage;
   modelId: DeviceModelId;
   button: string;
 }): void => {
   track("button_clicked", {
     ...getDeviceUxV2BaseProperties(params.sourceFlow),
-    page: params.page,
     modelId: params.modelId,
     button: params.button,
   });
@@ -230,14 +252,12 @@ export const trackConnectAppButtonClicked = (params: {
 
 export const trackDeviceActionButtonClicked = (params: {
   sourceFlow: SourceFlow;
-  page: DeviceActionPage;
   button: string;
   modelId?: DeviceModelId;
   transport?: TrackingTransport;
 }): void => {
   track("button_clicked", {
     ...getDeviceUxV2BaseProperties(params.sourceFlow),
-    page: params.page,
     button: params.button,
     ...(params.modelId ? { modelId: params.modelId } : {}),
     ...(params.transport ? { transport: params.transport } : {}),

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
@@ -84,6 +84,8 @@ export const DEVICE_ACTION_BUTTON = {
   Close: CONNECT_APP_BUTTON.Close,
 } as const;
 
+let isInTerminalConnectDeviceError = false;
+
 export type TrackingTransport = "ble" | "usb";
 type ConnectDeviceErrorType = ConnectionErrorTypes | DiscoveryErrorTypes;
 
@@ -109,8 +111,6 @@ const TRACKING_SUB_ERRORS: Record<ConnectDeviceErrorType, string> = {
 };
 
 const DEVICEFLOW_FAILED_CLOSE_PAGES = new Set<string>([
-  PAGE_CONNECT_DEVICE.DiscoveryError,
-  PAGE_CONNECT_DEVICE.ConnectionError,
   PAGE_CONNECT_APP.DeviceNotOnboarded,
   PAGE_CONNECT_APP.UnsupportedFirmware,
   PAGE_CONNECT_APP.UnsupportedApplication,
@@ -128,6 +128,10 @@ export const getDeviceUxV2BaseProperties = (sourceFlow: SourceFlow) => ({
   sourceFlow,
   deviceUxV2: true,
 });
+
+export const setIsInTerminalConnectDeviceError = (value: boolean): void => {
+  isInTerminalConnectDeviceError = value;
+};
 
 export const getTrackingTransport = (
   transportId: TransportIdentifier | undefined,
@@ -209,7 +213,14 @@ export const trackDeviceflowFailed = (params: { sourceFlow: SourceFlow }): void 
 
 export const trackDeviceflowCanceled = (params: { sourceFlow: SourceFlow }): void => {
   const currentPage = currentRouteNameRef.current;
-  if (currentPage && DEVICEFLOW_FAILED_CLOSE_PAGES.has(currentPage)) {
+  const isTerminalConnectDeviceErrorPage =
+    currentPage === PAGE_CONNECT_DEVICE.DiscoveryError ||
+    currentPage === PAGE_CONNECT_DEVICE.ConnectionError;
+
+  if (
+    (isTerminalConnectDeviceErrorPage && isInTerminalConnectDeviceError) ||
+    (currentPage && DEVICEFLOW_FAILED_CLOSE_PAGES.has(currentPage))
+  ) {
     trackDeviceflowFailed(params);
     return;
   }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
@@ -278,6 +278,6 @@ export const trackDeviceActionButtonClicked = (params: {
 export const trackDrawerCloseButtonClicked = (params: { sourceFlow: SourceFlow }): void => {
   track("button_clicked", {
     ...getDeviceUxV2BaseProperties(params.sourceFlow),
-    button: "Close",
+    button: DEVICE_ACTION_BUTTON.Close,
   });
 };

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
@@ -263,3 +263,10 @@ export const trackDeviceActionButtonClicked = (params: {
     ...(params.transport ? { transport: params.transport } : {}),
   });
 };
+
+export const trackDrawerCloseButtonClicked = (params: { sourceFlow: SourceFlow }): void => {
+  track("button_clicked", {
+    ...getDeviceUxV2BaseProperties(params.sourceFlow),
+    button: "Close",
+  });
+};


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Device Intent Executor analytics events on Ledger Wallet Mobile.

### 📝 Description

- Fixes missing or incorrect `button_clicked` events across Device Intent Executor CTAs and error states.
- Makes DIE `TrackScreen` calls refresh the analytics source/page context, so track events can inherit `page` automatically instead of setting it manually.
- Removes `source` from DIE track events because `source` is reserved for screen events.
- Moves `deviceflow_started` ownership into the DIE view model, where the overall executor lifecycle is handled.
- Adds `deviceflow_failed` when the user closes DIE from blocking or terminal error screens; other early closes still use `deviceflow_aborted`.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31757](https://ledgerhq.atlassian.net/browse/LIVE-31757)
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31757]: https://ledgerhq.atlassian.net/browse/LIVE-31757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ