### PR TITLE
[LWDM] fix(common): make Recover URI templating actually replace protectId, drop unused params

### DIFF
--- a/.changeset/recover-protect-id-templating.md
+++ b/.changeset/recover-protect-id-templating.md
@@ -6,8 +6,10 @@
 "live-mobile": patch
 ---
 
-Make Recover URI templating actually replace `protectId` and drop unused `protectServicesDesktop` / `protectServicesMobile` params.
+Make Recover URI templating actually replace `protectId`, drop unused `protectServicesDesktop` / `protectServicesMobile` params, and replace `compatibleDevices` with a hardcoded Nano S exclusion in `isRecoverDisplayed`.
 
 `useReplacedURI` previously only rewrote the placeholders `protect-simu`, `protect-local-dev` and `protect-staging`, so any URI hard-coded with `protect-prod` (e.g. the values shipped to PROD via Firebase Remote Config) was never re-templated when `protectId` changed. Switching the active Recover environment therefore required a manual find-and-replace across every URI in the feature flag. The regex now matches any `protect-<env>` segment, which is a no-op when `protectId` already equals that segment and a true substitution otherwise.
+
+`compatibleDevices` is replaced by a hardcoded check in `isRecoverDisplayed` — Nano S is the only device that does not support Recover and the rule is not expected to change. Dropping the array from the schema keeps the FF lean and removes the need to update Remote Config when a new device is supported.
 
 Also remove keys that have no consumer in either app — `isNew`, `ledgerliveStorageState`, `onboardingCompleted.alreadySubscribedURI`, and the entire `onboardingRestore` block on desktop; `ledgerliveStorageState`, `restoreInfoDrawer.manualStepsURI`, `managerStatesData.NEW.learnMoreURI` and `managerStatesData.NEW.alreadySubscribedURI` on mobile. `usePostOnboardingURI` is narrowed to `Feature_ProtectServicesMobile` since it is only called from the mobile app. Unknown keys still in Firebase are silently stripped by Zod, so this is forward-compatible with existing Remote Config payloads.

--- a/.changeset/recover-protect-id-templating.md
+++ b/.changeset/recover-protect-id-templating.md
@@ -1,0 +1,13 @@
+---
+"@ledgerhq/live-common": minor
+"@ledgerhq/types-live": minor
+"@shared/feature-flags": minor
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Make Recover URI templating actually replace `protectId` and drop unused `protectServicesDesktop` / `protectServicesMobile` params.
+
+`useReplacedURI` previously only rewrote the placeholders `protect-simu`, `protect-local-dev` and `protect-staging`, so any URI hard-coded with `protect-prod` (e.g. the values shipped to PROD via Firebase Remote Config) was never re-templated when `protectId` changed. Switching the active Recover environment therefore required a manual find-and-replace across every URI in the feature flag. The regex now matches any `protect-<env>` segment, which is a no-op when `protectId` already equals that segment and a true substitution otherwise.
+
+Also remove keys that have no consumer in either app — `isNew`, `ledgerliveStorageState`, `onboardingCompleted.alreadySubscribedURI`, and the entire `onboardingRestore` block on desktop; `ledgerliveStorageState`, `restoreInfoDrawer.manualStepsURI`, `managerStatesData.NEW.learnMoreURI` and `managerStatesData.NEW.alreadySubscribedURI` on mobile. `usePostOnboardingURI` is narrowed to `Feature_ProtectServicesMobile` since it is only called from the mobile app. Unknown keys still in Firebase are silently stripped by Zod, so this is forward-compatible with existing Remote Config payloads.

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__integrations__/RecoverWidget.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__integrations__/RecoverWidget.integration.test.tsx
@@ -44,7 +44,6 @@ const protectServicesFeature = ({
         ...protectDesktopDefaultParams,
         protectId: "protect-prod",
         bannerSubscriptionNotification,
-        compatibleDevices: [],
         onboardingCompleted: {
           ...protectDesktopDefaultParams.onboardingCompleted,
           upsellURI: onboardingUpsellUri,

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/__tests__/useNavigateToPostOnboardingHubCallback.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/__tests__/useNavigateToPostOnboardingHubCallback.test.ts
@@ -31,7 +31,6 @@ function featureFlagsWithRecover() {
         ...protectDesktopDefaultParams,
         protectId: PROTECT_ID,
         availableOnDesktop: true,
-        compatibleDevices: [{ name: DeviceModelId.nanoX, available: true, comingSoon: false }],
         onboardingCompleted: {
           ...protectDesktopDefaultParams.onboardingCompleted,
           upsellURI: RECOVER_UPSELL_URI,

--- a/apps/ledger-live-desktop/src/renderer/hooks/useAutoRedirectToPostOnboarding/__tests__/useOpenPostOnboardingCallback.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useAutoRedirectToPostOnboarding/__tests__/useOpenPostOnboardingCallback.test.ts
@@ -28,7 +28,6 @@ const recoverFeature = {
   enabled: true,
   params: {
     protectId: PROTECT_ID,
-    compatibleDevices: [{ name: DeviceModelId.stax, available: true }],
   },
 };
 

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/__integrations__/useCaseSelection.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/__integrations__/useCaseSelection.integration.test.tsx
@@ -37,7 +37,6 @@ const withRecoverForNanoX = withFlagOverrides({
   protectServicesMobile: {
     enabled: true,
     params: {
-      compatibleDevices: [{ name: DeviceModelId.nanoX, available: true, comingSoon: false }],
       deeplink: "ledgerrecover://subscribe",
     },
   },

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -222,8 +222,6 @@ export const DEFAULT_FEATURES: Features = {
     params: {
       openWithDevTools: false,
       availableOnDesktop: false,
-      isNew: false,
-      ledgerliveStorageState: false,
       bannerSubscriptionNotification: false,
       account: {
         homeURI:
@@ -232,23 +230,12 @@ export const DEFAULT_FEATURES: Features = {
       compatibleDevices: [],
       discoverTheBenefitsLink: "https://www.ledger.com/recover",
       onboardingCompleted: {
-        alreadySubscribedURI: "ledgerlive://recover/protect-simu?redirectTo=login",
         alreadyDeviceSeededURI:
           "ledgerlive://recover/protect-simu?redirectTo=upsell&source=lld-pairing&ajs_recover_source=lld-pairing&ajs_recover_campaign=recover-launch",
         upsellURI:
           "ledgerlive://recover/protect-simu?redirectTo=upsell&source=lld-onboarding-24&ajs_recover_source=lld-onboarding-24&ajs_recover_campaign=recover-launch",
         restore24URI:
           "ledgerlive://recover/protect-simu?redirectTo=upsell&source=lld-restore-24&ajs_recover_source=lld-restore-24&ajs_recover_campaign=recover-launch",
-      },
-      onboardingRestore: {
-        postOnboardingURI:
-          "ledgerlive://recover/protect-simu?redirectTo=restore&source=lld-restore",
-        restoreInfoDrawer: {
-          enabled: true,
-          manualStepsURI: "https://support.ledger.com/article/360013349800-zd",
-
-          supportLinkURI: "https://support.ledger.com",
-        },
       },
       openRecoverFromSidebar: true,
       protectId: "protect-simu",
@@ -383,7 +370,6 @@ export const DEFAULT_FEATURES: Features = {
   protectServicesMobile: {
     enabled: false,
     params: {
-      ledgerliveStorageState: false,
       bannerSubscriptionNotification: false,
       deeplink: "",
       compatibleDevices: [],
@@ -393,10 +379,6 @@ export const DEFAULT_FEATURES: Features = {
       },
       managerStatesData: {
         NEW: {
-          learnMoreURI:
-            "ledgerlive://recover/protect-simu?redirectTo=upsell&source=llm-onboarding-24&ajs_prop_source=llm-onboarding-24&ajs_prop_campaign=recover-launch",
-          alreadySubscribedURI:
-            "ledgerlive://recover/protect-simu?redirectTo=login&source=llm-onboarding-24&ajs_prop_source=llm-onboarding-24&ajs_prop_campaign=recover-launch",
           quickAccessURI:
             "ledgerlive://recover/protect-simu?redirectTo=upsell&source=llm-navbar-quick-access&ajs_prop_source=llm-navbar-quick-access&ajs_prop_campaign=recover-launch",
           alreadyOnboardedURI:
@@ -408,7 +390,6 @@ export const DEFAULT_FEATURES: Features = {
           "ledgerlive://recover/protect-simu?redirectTo=restore&source=llm-restore-24&ajs_prop_source=llm-restore-24&ajs_prop_campaign=recover-launch",
         restoreInfoDrawer: {
           enabled: true,
-          manualStepsURI: "https://support.ledger.com/article/360013349800-zd",
           supportLinkURI: "https://support.ledger.com",
         },
       },

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -227,7 +227,6 @@ export const DEFAULT_FEATURES: Features = {
         homeURI:
           "ledgerlive://recover/protect-simu?source=lld-sidebar-navigation&ajs_recover_source=lld-sidebar-navigation&ajs_recover_campaign=recover-launch",
       },
-      compatibleDevices: [],
       discoverTheBenefitsLink: "https://www.ledger.com/recover",
       onboardingCompleted: {
         alreadyDeviceSeededURI:
@@ -372,7 +371,6 @@ export const DEFAULT_FEATURES: Features = {
     params: {
       bannerSubscriptionNotification: false,
       deeplink: "",
-      compatibleDevices: [],
       account: {
         homeURI:
           "ledgerlive://recover/protect-simu?source=llm-myledger-access-card&ajs_prop_source=llm-myledger-access-card&ajs_prop_campaign=recover-launch",

--- a/libs/ledger-live-common/src/featureFlags/helper.tsx
+++ b/libs/ledger-live-common/src/featureFlags/helper.tsx
@@ -1,9 +1,19 @@
-export function isRecoverDisplayed(feature, deviceModelId) {
-  return (
-    feature?.enabled &&
-    feature?.params?.compatibleDevices?.find(
-      (device: { name: string; available: boolean }) =>
-        device.name === deviceModelId && device.available,
-    )
-  );
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import type {
+  Feature_ProtectServicesDesktop,
+  Feature_ProtectServicesMobile,
+} from "@ledgerhq/types-live";
+
+/**
+ * Whether the Recover entry point should be offered for the given device model.
+ *
+ * Recover is offered on every Ledger device except the Nano S, which is the
+ * only model that does not support Recover today and the rule is not expected
+ * to change.
+ */
+export function isRecoverDisplayed(
+  feature: Feature_ProtectServicesDesktop | Feature_ProtectServicesMobile | null | undefined,
+  deviceModelId: DeviceModelId | null | undefined,
+): boolean {
+  return Boolean(feature?.enabled && deviceModelId && deviceModelId !== DeviceModelId.nanoS);
 }

--- a/libs/ledger-live-common/src/hooks/recoverFeatureFlag.test.ts
+++ b/libs/ledger-live-common/src/hooks/recoverFeatureFlag.test.ts
@@ -1,0 +1,136 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from "@testing-library/react";
+import {
+  useReplacedURI,
+  useUpsellURI,
+  useAccountURI,
+  useCustomURI,
+  usePostOnboardingURI,
+} from "./recoverFeatureFlag";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyConfig = any;
+
+describe("useReplacedURI", () => {
+  it("returns undefined when uri is missing", () => {
+    const { result } = renderHook(() => useReplacedURI(undefined, "protect-staging"));
+    expect(result.current).toBeUndefined();
+  });
+
+  it("returns undefined when id is missing", () => {
+    const { result } = renderHook(() =>
+      useReplacedURI("ledgerlive://recover/protect-prod", undefined),
+    );
+    expect(result.current).toBeUndefined();
+  });
+
+  it("replaces protect-prod placeholder with the active protectId", () => {
+    const { result } = renderHook(() =>
+      useReplacedURI(
+        "ledgerlive://recover/protect-prod?redirectTo=upsell",
+        "protect-staging",
+      ),
+    );
+    expect(result.current).toBe("ledgerlive://recover/protect-staging?redirectTo=upsell");
+  });
+
+  it.each([
+    "protect-simu",
+    "protect-local-dev",
+    "protect-local",
+    "protect-staging",
+    "protect-preprod",
+    "protect-lumen-staging",
+    "protect-lumen-preprod",
+  ])("replaces %s placeholder with the active protectId", placeholder => {
+    const { result } = renderHook(() =>
+      useReplacedURI(`ledgerlive://recover/${placeholder}?redirectTo=login`, "protect-prod"),
+    );
+    expect(result.current).toBe("ledgerlive://recover/protect-prod?redirectTo=login");
+  });
+
+  it("is a no-op when the placeholder already matches the active protectId", () => {
+    const uri =
+      "ledgerlive://recover/protect-prod?redirectTo=upsell&ajs_recover_campaign=recover-launch";
+    const { result } = renderHook(() => useReplacedURI(uri, "protect-prod"));
+    expect(result.current).toBe(uri);
+  });
+
+  it("does not rewrite unrelated dashed segments such as recover-launch", () => {
+    const { result } = renderHook(() =>
+      useReplacedURI(
+        "ledgerlive://recover/protect-prod?source=lld-restore-24&ajs_recover_campaign=recover-launch",
+        "protect-staging",
+      ),
+    );
+    expect(result.current).toBe(
+      "ledgerlive://recover/protect-staging?source=lld-restore-24&ajs_recover_campaign=recover-launch",
+    );
+  });
+});
+
+describe("URI hooks template through useReplacedURI", () => {
+  it("useUpsellURI substitutes protectId across the upsellURI param", () => {
+    const config: AnyConfig = {
+      enabled: true,
+      params: {
+        protectId: "protect-staging",
+        onboardingCompleted: {
+          upsellURI:
+            "ledgerlive://recover/protect-prod?redirectTo=upsell&source=lld-onboarding-24",
+        },
+      },
+    };
+    const { result } = renderHook(() => useUpsellURI(config));
+    expect(result.current).toBe(
+      "ledgerlive://recover/protect-staging?redirectTo=upsell&source=lld-onboarding-24",
+    );
+  });
+
+  it("useAccountURI substitutes protectId across the homeURI param", () => {
+    const config: AnyConfig = {
+      enabled: true,
+      params: {
+        protectId: "protect-staging",
+        account: {
+          homeURI:
+            "ledgerlive://recover/protect-prod?source=lld-sidebar-navigation&ajs_recover_campaign=recover-launch",
+        },
+      },
+    };
+    const { result } = renderHook(() => useAccountURI(config));
+    expect(result.current).toBe(
+      "ledgerlive://recover/protect-staging?source=lld-sidebar-navigation&ajs_recover_campaign=recover-launch",
+    );
+  });
+
+  it("useCustomURI builds the URI directly from protectId", () => {
+    const config: AnyConfig = { enabled: true, params: { protectId: "protect-lumen-staging" } };
+    const { result } = renderHook(() =>
+      useCustomURI(config, "upsell", "lld-pairing", "recover-launch"),
+    );
+    expect(result.current).toContain("ledgerlive://recover/protect-lumen-staging");
+    expect(result.current).toContain("redirectTo=upsell");
+    expect(result.current).toContain("source=lld-pairing");
+    expect(result.current).toContain("ajs_recover_campaign=recover-launch");
+  });
+
+  it("usePostOnboardingURI templates protectId on mobile config", () => {
+    const config: AnyConfig = {
+      enabled: true,
+      params: {
+        protectId: "protect-staging",
+        onboardingRestore: {
+          postOnboardingURI:
+            "ledgerlive://recover/protect-prod?redirectTo=restore&source=llm-restore-24",
+        },
+      },
+    };
+    const { result } = renderHook(() => usePostOnboardingURI(config));
+    expect(result.current).toBe(
+      "ledgerlive://recover/protect-staging?redirectTo=restore&source=llm-restore-24",
+    );
+  });
+});

--- a/libs/ledger-live-common/src/hooks/recoverFeatureFlag.ts
+++ b/libs/ledger-live-common/src/hooks/recoverFeatureFlag.ts
@@ -5,9 +5,15 @@ import {
   Feature_ProtectServicesMobile,
 } from "@ledgerhq/types-live";
 
+// Matches a `protect-<env>` segment (e.g. `protect-prod`, `protect-staging`,
+// `protect-lumen-preprod`). Used to substitute the env placeholder in a URI
+// with the active `protectId` from the feature flag, so changing `protectId`
+// alone is enough to switch every templated URI to a different Recover env.
+const PROTECT_ID_SEGMENT_REGEX = /protect-[a-z0-9-]+/g;
+
 export function useReplacedURI(uri?: string, id?: string): string | undefined {
   return useMemo(() => {
-    return uri && id ? uri.replace(/protect-(simu|local-dev|staging)/, id) : undefined;
+    return uri && id ? uri.replace(PROTECT_ID_SEGMENT_REGEX, id) : undefined;
   }, [id, uri]);
 }
 
@@ -18,7 +24,7 @@ function usePath(servicesConfig: Feature<unknown> | null, uri?: string) {
 }
 
 export function usePostOnboardingURI(
-  servicesConfig: Feature_ProtectServicesDesktop | Feature_ProtectServicesMobile | null,
+  servicesConfig: Feature_ProtectServicesMobile | null,
 ): string | undefined {
   const uri = servicesConfig?.params?.onboardingRestore?.postOnboardingURI;
   const id = servicesConfig?.params?.protectId;

--- a/libs/ledger-live-common/src/hooks/recoverFeatureFlag.ts
+++ b/libs/ledger-live-common/src/hooks/recoverFeatureFlag.ts
@@ -5,10 +5,7 @@ import {
   Feature_ProtectServicesMobile,
 } from "@ledgerhq/types-live";
 
-// Matches a `protect-<env>` segment (e.g. `protect-prod`, `protect-staging`,
-// `protect-lumen-preprod`). Used to substitute the env placeholder in a URI
-// with the active `protectId` from the feature flag, so changing `protectId`
-// alone is enough to switch every templated URI to a different Recover env.
+// Matches any `protect-<env>` segment so changing `protectId` re-templates every URI.
 const PROTECT_ID_SEGMENT_REGEX = /protect-[a-z0-9-]+/g;
 
 export function useReplacedURI(uri?: string, id?: string): string | undefined {

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -517,16 +517,9 @@ export type Feature_NewsfeedPage = Feature<{
   whitelistedLocales: string[];
 }>;
 
-export type CompatibleDevice = {
-  available: boolean;
-  comingSoon: boolean;
-  name: string;
-};
-
 export type Feature_ProtectServicesMobile = Feature<{
   deeplink: string;
   bannerSubscriptionNotification: boolean;
-  compatibleDevices: CompatibleDevice[];
   onboardingRestore: {
     restoreInfoDrawer: {
       enabled: boolean;
@@ -552,7 +545,6 @@ export type Feature_ProtectServicesDesktop = Feature<{
   openRecoverFromSidebar: boolean;
   discoverTheBenefitsLink: string;
   bannerSubscriptionNotification: boolean;
-  compatibleDevices: CompatibleDevice[];
   onboardingCompleted: {
     upsellURI: string;
     restore24URI: string;

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -525,21 +525,17 @@ export type CompatibleDevice = {
 
 export type Feature_ProtectServicesMobile = Feature<{
   deeplink: string;
-  ledgerliveStorageState: boolean;
   bannerSubscriptionNotification: boolean;
   compatibleDevices: CompatibleDevice[];
   onboardingRestore: {
     restoreInfoDrawer: {
       enabled: boolean;
-      manualStepsURI: string;
       supportLinkURI: string;
     };
     postOnboardingURI: string;
   };
   managerStatesData: {
     NEW: {
-      learnMoreURI: string;
-      alreadySubscribedURI: string;
       quickAccessURI: string;
       alreadyOnboardedURI: string;
     };
@@ -553,24 +549,13 @@ export type Feature_ProtectServicesMobile = Feature<{
 export type Feature_ProtectServicesDesktop = Feature<{
   openWithDevTools: boolean;
   availableOnDesktop: boolean;
-  isNew: boolean;
   openRecoverFromSidebar: boolean;
   discoverTheBenefitsLink: string;
-  ledgerliveStorageState: boolean;
   bannerSubscriptionNotification: boolean;
   compatibleDevices: CompatibleDevice[];
-  onboardingRestore: {
-    restoreInfoDrawer: {
-      enabled: boolean;
-      manualStepsURI: string;
-      supportLinkURI: string;
-    };
-    postOnboardingURI: string;
-  };
   onboardingCompleted: {
     upsellURI: string;
     restore24URI: string;
-    alreadySubscribedURI: string;
     alreadyDeviceSeededURI: string;
   };
   account: {

--- a/shared/feature-flags/src/flags/team-recover-software/protectServicesDesktop.ts
+++ b/shared/feature-flags/src/flags/team-recover-software/protectServicesDesktop.ts
@@ -1,12 +1,6 @@
 import { z } from "zod";
 import { flagWith } from "../../define";
 
-const compatibleDeviceSchema = z.object({
-  available: z.boolean(),
-  comingSoon: z.boolean(),
-  name: z.string(),
-});
-
 const onboardingCompletedSchema = z.object({
   upsellURI: z.string(),
   restore24URI: z.string(),
@@ -24,7 +18,6 @@ export const protectServicesDesktop = flagWith(
     openRecoverFromSidebar: z.boolean(),
     discoverTheBenefitsLink: z.string(),
     bannerSubscriptionNotification: z.boolean(),
-    compatibleDevices: z.array(compatibleDeviceSchema),
     onboardingCompleted: onboardingCompletedSchema,
     account: accountSchema,
     protectId: z.string(),
@@ -39,7 +32,6 @@ export const protectServicesDesktop = flagWith(
         homeURI:
           "ledgerlive://recover/protect-simu?source=lld-sidebar-navigation&ajs_recover_source=lld-sidebar-navigation&ajs_recover_campaign=recover-launch",
       },
-      compatibleDevices: [],
       discoverTheBenefitsLink: "https://www.ledger.com/recover",
       onboardingCompleted: {
         alreadyDeviceSeededURI:

--- a/shared/feature-flags/src/flags/team-recover-software/protectServicesDesktop.ts
+++ b/shared/feature-flags/src/flags/team-recover-software/protectServicesDesktop.ts
@@ -7,21 +7,9 @@ const compatibleDeviceSchema = z.object({
   name: z.string(),
 });
 
-const restoreInfoDrawerSchema = z.object({
-  enabled: z.boolean(),
-  manualStepsURI: z.string(),
-  supportLinkURI: z.string(),
-});
-
-const onboardingRestoreSchema = z.object({
-  restoreInfoDrawer: restoreInfoDrawerSchema,
-  postOnboardingURI: z.string(),
-});
-
 const onboardingCompletedSchema = z.object({
   upsellURI: z.string(),
   restore24URI: z.string(),
-  alreadySubscribedURI: z.string(),
   alreadyDeviceSeededURI: z.string(),
 });
 
@@ -33,13 +21,10 @@ export const protectServicesDesktop = flagWith(
   {
     openWithDevTools: z.boolean(),
     availableOnDesktop: z.boolean(),
-    isNew: z.boolean(),
     openRecoverFromSidebar: z.boolean(),
     discoverTheBenefitsLink: z.string(),
-    ledgerliveStorageState: z.boolean(),
     bannerSubscriptionNotification: z.boolean(),
     compatibleDevices: z.array(compatibleDeviceSchema),
-    onboardingRestore: onboardingRestoreSchema,
     onboardingCompleted: onboardingCompletedSchema,
     account: accountSchema,
     protectId: z.string(),
@@ -49,8 +34,6 @@ export const protectServicesDesktop = flagWith(
     params: {
       openWithDevTools: false,
       availableOnDesktop: false,
-      isNew: false,
-      ledgerliveStorageState: false,
       bannerSubscriptionNotification: false,
       account: {
         homeURI:
@@ -59,23 +42,12 @@ export const protectServicesDesktop = flagWith(
       compatibleDevices: [],
       discoverTheBenefitsLink: "https://www.ledger.com/recover",
       onboardingCompleted: {
-        alreadySubscribedURI:
-          "ledgerlive://recover/protect-simu?redirectTo=login",
         alreadyDeviceSeededURI:
           "ledgerlive://recover/protect-simu?redirectTo=upsell&source=lld-pairing&ajs_recover_source=lld-pairing&ajs_recover_campaign=recover-launch",
         upsellURI:
           "ledgerlive://recover/protect-simu?redirectTo=upsell&source=lld-onboarding-24&ajs_recover_source=lld-onboarding-24&ajs_recover_campaign=recover-launch",
         restore24URI:
           "ledgerlive://recover/protect-simu?redirectTo=upsell&source=lld-restore-24&ajs_recover_source=lld-restore-24&ajs_recover_campaign=recover-launch",
-      },
-      onboardingRestore: {
-        postOnboardingURI:
-          "ledgerlive://recover/protect-simu?redirectTo=restore&source=lld-restore",
-        restoreInfoDrawer: {
-          enabled: true,
-          manualStepsURI: "https://support.ledger.com/article/360013349800-zd",
-          supportLinkURI: "https://support.ledger.com",
-        },
       },
       openRecoverFromSidebar: true,
       protectId: "protect-simu",

--- a/shared/feature-flags/src/flags/team-recover-software/protectServicesMobile.ts
+++ b/shared/feature-flags/src/flags/team-recover-software/protectServicesMobile.ts
@@ -9,7 +9,6 @@ const compatibleDeviceSchema = z.object({
 
 const restoreInfoDrawerSchema = z.object({
   enabled: z.boolean(),
-  manualStepsURI: z.string(),
   supportLinkURI: z.string(),
 });
 
@@ -19,8 +18,6 @@ const onboardingRestoreSchema = z.object({
 });
 
 const managerStatesNewSchema = z.object({
-  learnMoreURI: z.string(),
-  alreadySubscribedURI: z.string(),
   quickAccessURI: z.string(),
   alreadyOnboardedURI: z.string(),
 });
@@ -36,7 +33,6 @@ const accountSchema = z.object({
 export const protectServicesMobile = flagWith(
   {
     deeplink: z.string(),
-    ledgerliveStorageState: z.boolean(),
     bannerSubscriptionNotification: z.boolean(),
     compatibleDevices: z.array(compatibleDeviceSchema),
     onboardingRestore: onboardingRestoreSchema,
@@ -47,7 +43,6 @@ export const protectServicesMobile = flagWith(
   {
     enabled: false,
     params: {
-      ledgerliveStorageState: false,
       bannerSubscriptionNotification: false,
       deeplink: "",
       compatibleDevices: [],
@@ -57,10 +52,6 @@ export const protectServicesMobile = flagWith(
       },
       managerStatesData: {
         NEW: {
-          learnMoreURI:
-            "ledgerlive://recover/protect-simu?redirectTo=upsell&source=llm-onboarding-24&ajs_prop_source=llm-onboarding-24&ajs_prop_campaign=recover-launch",
-          alreadySubscribedURI:
-            "ledgerlive://recover/protect-simu?redirectTo=login&source=llm-onboarding-24&ajs_prop_source=llm-onboarding-24&ajs_prop_campaign=recover-launch",
           quickAccessURI:
             "ledgerlive://recover/protect-simu?redirectTo=upsell&source=llm-navbar-quick-access&ajs_prop_source=llm-navbar-quick-access&ajs_prop_campaign=recover-launch",
           alreadyOnboardedURI:
@@ -72,7 +63,6 @@ export const protectServicesMobile = flagWith(
           "ledgerlive://recover/protect-simu?redirectTo=restore&source=llm-restore-24&ajs_prop_source=llm-restore-24&ajs_prop_campaign=recover-launch",
         restoreInfoDrawer: {
           enabled: true,
-          manualStepsURI: "https://support.ledger.com/article/360013349800-zd",
           supportLinkURI: "https://support.ledger.com",
         },
       },

--- a/shared/feature-flags/src/flags/team-recover-software/protectServicesMobile.ts
+++ b/shared/feature-flags/src/flags/team-recover-software/protectServicesMobile.ts
@@ -1,12 +1,6 @@
 import { z } from "zod";
 import { flagWith } from "../../define";
 
-const compatibleDeviceSchema = z.object({
-  available: z.boolean(),
-  comingSoon: z.boolean(),
-  name: z.string(),
-});
-
 const restoreInfoDrawerSchema = z.object({
   enabled: z.boolean(),
   supportLinkURI: z.string(),
@@ -34,7 +28,6 @@ export const protectServicesMobile = flagWith(
   {
     deeplink: z.string(),
     bannerSubscriptionNotification: z.boolean(),
-    compatibleDevices: z.array(compatibleDeviceSchema),
     onboardingRestore: onboardingRestoreSchema,
     managerStatesData: managerStatesDataSchema,
     account: accountSchema,
@@ -45,7 +38,6 @@ export const protectServicesMobile = flagWith(
     params: {
       bannerSubscriptionNotification: false,
       deeplink: "",
-      compatibleDevices: [],
       account: {
         homeURI:
           "ledgerlive://recover/protect-simu?source=llm-myledger-access-card&ajs_prop_source=llm-myledger-access-card&ajs_prop_campaign=recover-launch",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** New Jest tests for `useReplacedURI` and the URI hooks built on top of it. Existing test fixtures that previously enumerated `compatibleDevices` were updated.
- [x] **Impact of the changes:**
  - Switching the active Recover environment now only requires changing `protectServicesDesktop.params.protectId` (or `protectServicesMobile.params.protectId`). All URIs templated through the `recoverFeatureFlag` hooks follow automatically.
  - Drops keys from `protectServicesDesktop` / `protectServicesMobile` that no code reads. Backward-compatible with existing Firebase Remote Config payloads (Zod silently strips unknown keys).
  - Replaces the `compatibleDevices` FF array with a hardcoded `deviceModelId !== nanoS` check in `isRecoverDisplayed`. Nano S is the only Ledger device that does not support Recover and the rule is not expected to change; remoting it through Firebase added complexity without flexibility we actually want.
  - Areas QA should sanity-check on Recover-related flows: post-onboarding redirection (`useOpenRecoverCallback`, `useOpenRecoverUpsellCallback`), recover entry from sidebar / My Wallet, dashboard `RecoverBanner`, mobile transfer drawer quick access, deeplink handling, the device-model gating on the use-case selection screen. PROD behavior is unchanged because the regex substitution is a no-op when the URI placeholder already matches `protectId` and `compatibleDevices` already excluded Nano S.

### 📝 Description

#### 1. `useReplacedURI` did not replace `protect-prod`

`protectServicesDesktop` and `protectServicesMobile` carry a `protectId` plus several deeplink URIs hard-coded with that same id (e.g. `ledgerlive://recover/protect-prod?...`). The intent is that `protectId` is the single switch for the active Recover environment, and `useReplacedURI` re-templates every URI to match. In practice the regex only matched three placeholders:

```ts
return uri && id ? uri.replace(/protect-(simu|local-dev|staging)/, id) : undefined;
```

Any URI containing `protect-prod` (the values shipped to PROD via Firebase Remote Config) was therefore never re-templated. Switching environments locally required a manual find-and-replace of the id across every URI in the feature flag JSON — error-prone and easy to forget.

`useReplacedURI` now matches any `protect-<env>` segment:

```ts
const PROTECT_ID_SEGMENT_REGEX = /protect-[a-z0-9-]+/g;
return uri && id ? uri.replace(PROTECT_ID_SEGMENT_REGEX, id) : undefined;
```

The substitution is a no-op whenever the URI placeholder already equals the active `protectId`, so PROD behavior is unchanged. Changing `protectId` from `protect-prod` to e.g. `protect-staging` or `protect-lumen-preprod` now re-templates every URI consumed through the `recoverFeatureFlag` hooks (`useUpsellURI`, `useRestore24URI`, `useAlreadySeededDeviceURI`, `useAccountURI`, `useHomeURI`, `useQuickAccessURI`, `useAlreadyOnboardedURI`, `usePostOnboardingURI`).

`usePostOnboardingURI` is also narrowed to `Feature_ProtectServicesMobile`. It is only called from `live-mobile`, and the desktop type no longer carries `onboardingRestore`.

#### 2. `compatibleDevices` → hardcoded Nano S exclusion

`compatibleDevices` was a remotely controllable list of which Ledger devices can use Recover, consumed only through `isRecoverDisplayed` in `libs/ledger-live-common/src/featureFlags/helper.tsx`. In practice the rule is and will remain "every device except the Nano S" — the Nano S is the only model that does not support Recover today and there is no plan for that to change.

Replacing the array lookup with `deviceModelId !== DeviceModelId.nanoS` removes:

- A nested array in two Firebase Remote Config payloads (desktop + mobile) per environment.
- The `CompatibleDevice` type from `@ledgerhq/types-live`.
- The need to keep Remote Config in sync whenever a new device model is supported.

The four existing test fixtures that enumerated `compatibleDevices` are updated.

#### 3. Drop params with no runtime consumer

- **Desktop** (`Feature_ProtectServicesDesktop`): `isNew`, `ledgerliveStorageState`, `onboardingCompleted.alreadySubscribedURI`, and the entire `onboardingRestore` block (the two `restoreInfoDrawer` keys read at runtime, `enabled` and `supportLinkURI`, are read from the **mobile** flag; `postOnboardingURI` likewise).
- **Mobile** (`Feature_ProtectServicesMobile`): `ledgerliveStorageState`, `onboardingRestore.restoreInfoDrawer.manualStepsURI` (mobile uses the hardcoded `urls.lnxFirmwareUpdate` instead), `managerStatesData.NEW.learnMoreURI`, `managerStatesData.NEW.alreadySubscribedURI`.

Existing Firebase Remote Config payloads keep working: Zod silently strips unknown keys, so any of these values still set in Remote Config are simply dropped at parse time.

> **FYI** — the current PROD `protectServicesMobile` payload also still ships `staxCompatible` and `onboardingLogin`, which were **already** absent from the Zod schema and from any consuming code on `develop`. They are dead keys that Zod has been stripping for some time before this PR; mentioned here so reviewers comparing this PR's "minimum mobile payload" against a live Firebase dump don't get surprised by the extra noise.

#### After this PR

The minimum PROD payload for `protectServicesDesktop` is:

```json
{
  "enabled": true,
  "params": {
    "openWithDevTools": false,
    "availableOnDesktop": true,
    "openRecoverFromSidebar": true,
    "bannerSubscriptionNotification": true,
    "discoverTheBenefitsLink": "https://www.ledger.com/recover",
    "onboardingCompleted": {
      "upsellURI": "ledgerlive://recover/protect-prod?redirectTo=upsell&source=lld-onboarding-24&ajs_recover_source=lld-onboarding-24&ajs_recover_campaign=recover-launch",
      "alreadyDeviceSeededURI": "ledgerlive://recover/protect-prod?redirectTo=upsell&source=lld-pairing&ajs_recover_source=lld-pairing&ajs_recover_campaign=recover-launch",
      "restore24URI": "ledgerlive://recover/protect-prod?redirectTo=upsell&source=lld-restore-24&ajs_recover_source=lld-restore-24&ajs_recover_campaign=recover-launch"
    },
    "account": {
      "homeURI": "ledgerlive://recover/protect-prod?source=lld-sidebar-navigation&ajs_recover_source=lld-sidebar-navigation&ajs_recover_campaign=recover-launch"
    },
    "protectId": "protect-prod"
  }
}
```

Switching to staging means flipping a single field:

```diff
- "protectId": "protect-prod"
+ "protectId": "protect-staging"
```

The minimum PROD payload for `protectServicesMobile` is:

```json
{
  "enabled": true,
  "params": {
    "deeplink": "",
    "bannerSubscriptionNotification": true,
    "onboardingRestore": {
      "restoreInfoDrawer": {
        "enabled": true,
        "supportLinkURI": "https://support.ledger.com"
      },
      "postOnboardingURI": "ledgerlive://recover/protect-prod?redirectTo=upsell&source=llm-restore-24&ajs_recover_source=llm-restore-24&ajs_recover_campaign=recover-launch"
    },
    "managerStatesData": {
      "NEW": {
        "quickAccessURI": "ledgerlive://recover/protect-prod?redirectTo=upsell&source=llm-navbar-quick-access&ajs_recover_source=llm-navbar-quick-access&ajs_recover_campaign=recover-launch",
        "alreadyOnboardedURI": "ledgerlive://recover/protect-prod?redirectTo=upsell&source=llm-pairing&ajs_recover_source=llm-pairing&ajs_recover_campaign=recover-launch"
      }
    },
    "account": {
      "homeURI": "ledgerlive://recover/protect-prod?source=llm-onboarding-24&ajs_recover_source=llm-onboarding-24&ajs_recover_campaign=recover-launch"
    },
    "protectId": "protect-prod"
  }
}
```

Same single-field switch story:

```diff
- "protectId": "protect-prod"
+ "protectId": "protect-staging"
```

Note: `deeplink` is consumed by `useCaseSelection` on mobile (Nano X "Start Protect" path) and is therefore kept in the schema. The current PROD payload ships `"deeplink": null`, which is technically a type mismatch against `z.string()` — the consumer treats falsy values as "no deeplink, fall through to nav", so behavior is fine, but this is a latent inconsistency that pre-dates this PR and is not addressed here.

### ❓ Context

- **JIRA or GitHub link**: _none — internal cleanup, no ticket._
- **ADR link (if any)**: _n/a_

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
