### PR TITLE
[LWDM] feat(asset-detail): add hide activity on price chart toggle

### DIFF
--- a/.changeset/lwm-d-hide-activity-on-price-chart.md
+++ b/.changeset/lwm-d-hide-activity-on-price-chart.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Add a chart options menu on the asset detail price chart letting users hide/show transaction (activity) markers. A new settings icon next to the range selector opens a menu (desktop) / bottom sheet (mobile) with a "Hide activity on price chart" toggle. The preference is persisted in the market store and applied across assets; when enabled, transaction markers are omitted from the chart while the all-time high/low markers remain.

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/LineChartView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/LineChartView.tsx
@@ -28,6 +28,7 @@ export function LineChartView({
   showYAxis,
   xAxis,
   yAxis,
+  rangeSelectorTrailing,
 }: LineChartViewProps) {
   return (
     <div className="flex w-full min-w-0 flex-col gap-24" data-testid="line-chart">
@@ -52,24 +53,27 @@ export function LineChartView({
         yAxis={yAxis}
       />
 
-      <SegmentedControl
-        selectedValue={selectedRange}
-        onSelectedChange={handleSelectedChange}
-        tabLayout="fixed"
-        aria-label={rangeSelectorLabel}
-        data-testid="line-chart-range-selector"
-        className="w-full"
-      >
-        {rangeButtons.map(({ value, label }) => (
-          <SegmentedControlButton
-            key={value}
-            value={value}
-            data-testid={`line-chart-range-${value}`}
-          >
-            {label}
-          </SegmentedControlButton>
-        ))}
-      </SegmentedControl>
+      <div className="flex w-full min-w-0 items-center gap-8">
+        <SegmentedControl
+          selectedValue={selectedRange}
+          onSelectedChange={handleSelectedChange}
+          tabLayout="fixed"
+          aria-label={rangeSelectorLabel}
+          data-testid="line-chart-range-selector"
+          className="min-w-0 flex-1"
+        >
+          {rangeButtons.map(({ value, label }) => (
+            <SegmentedControlButton
+              key={value}
+              value={value}
+              data-testid={`line-chart-range-${value}`}
+            >
+              {label}
+            </SegmentedControlButton>
+          ))}
+        </SegmentedControl>
+        {rangeSelectorTrailing}
+      </div>
     </div>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/__tests__/index.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/__tests__/index.test.tsx
@@ -44,6 +44,16 @@ describe("LineChart", () => {
     expect(onRangeChange).toHaveBeenCalledWith("1y");
   });
 
+  it("renders rangeSelectorTrailing alongside the range selector without losing its a11y label", () => {
+    renderLineChart({
+      rangeSelectorTrailing: <button data-testid="chart-trailing-slot">options</button>,
+    });
+
+    expect(screen.getByTestId("chart-trailing-slot")).toBeVisible();
+    expect(screen.getByTestId("line-chart-range-selector")).toBeVisible();
+    expect(screen.getByTestId("line-chart-range-1d")).toHaveAttribute("aria-checked", "true");
+  });
+
   it("shows the loading skeleton when isLoading is true", () => {
     renderLineChart({ isLoading: true });
 

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/__tests__/useLineChartViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/__tests__/useLineChartViewModel.test.ts
@@ -68,6 +68,17 @@ describe("useLineChartViewModel", () => {
     expect(result.current.selectedRange).toBe("1y");
   });
 
+  it("forwards the rangeSelectorTrailing slot unchanged and defaults it to undefined", () => {
+    const { result: withoutTrailing } = renderHook(() => useLineChartViewModel(defaultProps));
+    expect(withoutTrailing.current.rangeSelectorTrailing).toBeUndefined();
+
+    const trailing = "trailing-node";
+    const { result: withTrailing } = renderHook(() =>
+      useLineChartViewModel({ ...defaultProps, rangeSelectorTrailing: trailing }),
+    );
+    expect(withTrailing.current.rangeSelectorTrailing).toBe(trailing);
+  });
+
   it("calls onRangeChange when handleSelectedChange is invoked", () => {
     const onRangeChange = jest.fn();
     const { result } = renderHook(() =>

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/types.ts
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import type {
   LineChartProps as LumenLineChartProps,
   Series,
@@ -76,4 +77,6 @@ export type LineChartProps = Readonly<{
   xAxis?: LineChartXAxisConfig;
   /** Passthrough y-axis configuration (ticks, tickLabelFormatter, domain, ...). */
   yAxis?: LineChartYAxisConfig;
+  /** Optional control rendered inline at the end of the range-selector row (e.g. a chart options menu). */
+  rangeSelectorTrailing?: ReactNode;
 }>;

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/useLineChartViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/useLineChartViewModel.ts
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from "react";
+import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import {
   DEFAULT_LINE_CHART_HEIGHT,
@@ -44,6 +45,7 @@ export type LineChartViewModelResult = Readonly<{
   showYAxis: boolean;
   xAxis?: LineChartXAxisConfig;
   yAxis?: LineChartYAxisConfig;
+  rangeSelectorTrailing?: ReactNode;
 }>;
 
 export function useLineChartViewModel({
@@ -67,6 +69,7 @@ export function useLineChartViewModel({
   showYAxis = true,
   xAxis,
   yAxis,
+  rangeSelectorTrailing,
 }: LineChartProps): LineChartViewModelResult {
   const { t } = useTranslation();
   const stroke = LINE_CHART_COLOR_TO_STROKE[color];
@@ -128,5 +131,6 @@ export function useLineChartViewModel({
     showYAxis,
     xAxis,
     yAxis,
+    rangeSelectorTrailing,
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/ChartOptionsMenu/ChartOptionsMenuView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/ChartOptionsMenu/ChartOptionsMenuView.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { Menu, MenuTrigger, MenuContent, MenuItem, IconButton } from "@ledgerhq/lumen-ui-react";
+import { Eye, EyeCross, SettingsAlt2 } from "@ledgerhq/lumen-ui-react/symbols";
+import type { ChartOptionsMenuViewModel } from "./useChartOptionsMenuViewModel";
+
+export type ChartOptionsMenuViewProps = Readonly<{
+  viewModel: ChartOptionsMenuViewModel;
+}>;
+
+export function ChartOptionsMenuView({ viewModel }: ChartOptionsMenuViewProps) {
+  const { optionsAriaLabel, toggleLabel, isHidden, onToggle } = viewModel;
+
+  return (
+    <Menu>
+      <MenuTrigger asChild>
+        <IconButton
+          appearance="no-background"
+          size="xs"
+          icon={SettingsAlt2}
+          aria-label={optionsAriaLabel}
+          data-testid="asset-detail-chart-options-trigger"
+        />
+      </MenuTrigger>
+      <MenuContent className="w-full min-w-200" side="bottom" align="end">
+        <MenuItem
+          onSelect={() => {
+            onToggle();
+          }}
+          data-testid="asset-detail-chart-options-toggle-transactions"
+        >
+          <span className="flex items-center gap-12">
+            {isHidden ? (
+              <Eye size={20} className="shrink-0" />
+            ) : (
+              <EyeCross size={20} className="shrink-0" />
+            )}
+            {toggleLabel}
+          </span>
+        </MenuItem>
+      </MenuContent>
+    </Menu>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/ChartOptionsMenu/__tests__/useChartOptionsMenuViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/ChartOptionsMenu/__tests__/useChartOptionsMenuViewModel.test.ts
@@ -1,0 +1,40 @@
+import { renderHook, act } from "tests/testSetup";
+import { useChartOptionsMenuViewModel } from "../useChartOptionsMenuViewModel";
+
+function renderViewModel({
+  hideTransactionsOnChart = false,
+  currencyId = "bitcoin",
+}: {
+  hideTransactionsOnChart?: boolean;
+  currencyId?: string;
+} = {}) {
+  return renderHook(() => useChartOptionsMenuViewModel({ currencyId }), {
+    initialState: { market: { hideTransactionsOnChart } },
+  });
+}
+
+describe("useChartOptionsMenuViewModel", () => {
+  it("shows the 'hide' label and is not hidden by default", () => {
+    const { result } = renderViewModel();
+    expect(result.current.isHidden).toBe(false);
+    expect(result.current.toggleLabel).toBe("Hide activity on price chart");
+  });
+
+  it("shows the 'show' label when transactions are already hidden", () => {
+    const { result } = renderViewModel({ hideTransactionsOnChart: true });
+    expect(result.current.isHidden).toBe(true);
+    expect(result.current.toggleLabel).toBe("Show activity on price chart");
+  });
+
+  it("persists hiding transactions when toggled from the visible state", () => {
+    const { result, store } = renderViewModel({ hideTransactionsOnChart: false });
+    act(() => result.current.onToggle());
+    expect(store.getState().market.hideTransactionsOnChart).toBe(true);
+  });
+
+  it("persists showing transactions when toggled from the hidden state", () => {
+    const { result, store } = renderViewModel({ hideTransactionsOnChart: true });
+    act(() => result.current.onToggle());
+    expect(store.getState().market.hideTransactionsOnChart).toBe(false);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/ChartOptionsMenu/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/ChartOptionsMenu/index.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import {
+  useChartOptionsMenuViewModel,
+  type UseChartOptionsMenuViewModelProps,
+} from "./useChartOptionsMenuViewModel";
+import { ChartOptionsMenuView } from "./ChartOptionsMenuView";
+
+export function ChartOptionsMenu(props: UseChartOptionsMenuViewModelProps) {
+  const viewModel = useChartOptionsMenuViewModel(props);
+  return <ChartOptionsMenuView viewModel={viewModel} />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/ChartOptionsMenu/useChartOptionsMenuViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/ChartOptionsMenu/useChartOptionsMenuViewModel.ts
@@ -1,0 +1,49 @@
+import { useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
+import { setHideTransactionsOnChart } from "~/renderer/actions/market";
+import { hideTransactionsOnChartSelector } from "~/renderer/reducers/market";
+import { track } from "~/renderer/analytics/segment";
+import { ASSET_DETAIL_TRACKING_PAGE_NAME } from "LLD/features/AssetDetail/constants";
+
+export type UseChartOptionsMenuViewModelProps = Readonly<{
+  currencyId?: string;
+}>;
+
+export type ChartOptionsMenuViewModel = Readonly<{
+  optionsAriaLabel: string;
+  toggleLabel: string;
+  isHidden: boolean;
+  onToggle: () => void;
+}>;
+
+export function useChartOptionsMenuViewModel({
+  currencyId,
+}: UseChartOptionsMenuViewModelProps): ChartOptionsMenuViewModel {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const isHidden = useSelector(hideTransactionsOnChartSelector);
+
+  const onToggle = useCallback(() => {
+    const nextHidden = !isHidden;
+    track("button_clicked", {
+      button: "hide_transactions_graph",
+      page: ASSET_DETAIL_TRACKING_PAGE_NAME,
+      currency: currencyId,
+      is_hidden: nextHidden,
+    });
+    dispatch(setHideTransactionsOnChart(nextHidden));
+  }, [dispatch, isHidden, currencyId]);
+
+  return useMemo(
+    () => ({
+      optionsAriaLabel: t("assetDetails.chartOptions.menu"),
+      toggleLabel: isHidden
+        ? t("assetDetails.chartOptions.showTransactions")
+        : t("assetDetails.chartOptions.hideTransactions"),
+      isHidden,
+      onToggle,
+    }),
+    [t, isHidden, onToggle],
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/ChartSectionView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/ChartSectionView.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { LineChart } from "LLD/components/LineChart";
 import type { ChartSectionViewModelResult } from "./useChartSectionViewModel";
+import { ChartOptionsMenu } from "./ChartOptionsMenu";
 
 type ChartSectionViewProps = Readonly<ChartSectionViewModelResult>;
 
@@ -20,6 +21,7 @@ function ChartSectionViewComponent({
   xAxis,
   yAxis,
   points,
+  currencyId,
 }: ChartSectionViewProps) {
   return (
     <div className="w-full min-w-0" data-testid="asset-detail-chart-section">
@@ -41,6 +43,7 @@ function ChartSectionViewComponent({
         xAxis={xAxis}
         yAxis={yAxis}
         points={points}
+        rangeSelectorTrailing={<ChartOptionsMenu currencyId={currencyId} />}
       />
     </div>
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/useChartSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/useChartSectionViewModel.ts
@@ -30,6 +30,7 @@ import {
   discreetModeSelector,
   localeSelector,
 } from "~/renderer/reducers/settings";
+import { hideTransactionsOnChartSelector } from "~/renderer/reducers/market";
 import { useHistoryOperationItemsForRootAccounts } from "LLD/features/History/hooks/useHistoryOperationItemsForRootAccounts";
 import {
   filterOperationTableItemsByAllowedAccountIds,
@@ -95,6 +96,7 @@ export type ChartSectionViewModelResult = Readonly<{
   xAxis: LineChartXAxisConfig;
   yAxis: LineChartYAxisConfig;
   points: LineChartPointMarker[];
+  currencyId?: string;
 }>;
 
 export function useChartSectionViewModel({
@@ -111,6 +113,7 @@ export function useChartSectionViewModel({
   const fiatUnit = counterValueCurrency.units[0];
   const locale = useSelector(localeSelector);
   const discreet = useSelector(discreetModeSelector);
+  const hideTransactionsOnChart = useSelector(hideTransactionsOnChartSelector);
   const allAccounts = useSelector(accountsSelector);
   const countervaluesState = useCountervaluesState();
 
@@ -193,6 +196,8 @@ export function useChartSectionViewModel({
   const points = useMemo<LineChartPointMarker[]>(() => {
     const extremaMarkers = getExtremaPointMarkers(series);
 
+    if (hideTransactionsOnChart) return extremaMarkers;
+
     const groups = groupTransactionsByChartIndex({
       timestamps,
       values: series[0]?.data ?? [],
@@ -204,7 +209,7 @@ export function useChartSectionViewModel({
     );
 
     return [...extremaMarkers, ...transactionMarkers];
-  }, [series, timestamps, transactions, formatFiat, t]);
+  }, [series, timestamps, transactions, formatFiat, t, hideTransactionsOnChart]);
 
   const formatValue = useCallback<LineChartValueFormatter>(
     value =>
@@ -305,5 +310,6 @@ export function useChartSectionViewModel({
     xAxis,
     yAxis,
     points,
+    currencyId,
   };
 }

--- a/apps/ledger-live-desktop/src/renderer/actions/market.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/market.ts
@@ -11,6 +11,11 @@ export const setMarketCurrentPage = (payload: number) => ({
   payload,
 });
 
+export const setHideTransactionsOnChart = (payload: boolean) => ({
+  type: "MARKET_SET_HIDE_TRANSACTIONS_ON_CHART",
+  payload,
+});
+
 export const importMarketState = (payload: MarketState) => ({
   type: "MARKET_IMPORT_STATE",
   payload,

--- a/apps/ledger-live-desktop/src/renderer/reducers/market.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/market.ts
@@ -5,6 +5,7 @@ import { MarketListRequestParams, Order } from "@ledgerhq/live-common/market/uti
 export type MarketState = {
   marketParams: MarketListRequestParams;
   currentPage: number;
+  hideTransactionsOnChart: boolean;
 };
 
 const initialState: MarketState = {
@@ -19,6 +20,7 @@ const initialState: MarketState = {
     counterCurrency: "USD",
   },
   currentPage: 1,
+  hideTransactionsOnChart: false,
 };
 
 type HandlersPayloads = {
@@ -26,6 +28,7 @@ type HandlersPayloads = {
 
   MARKET_SET_VALUES: MarketListRequestParams;
   MARKET_SET_CURRENT_PAGE: number;
+  MARKET_SET_HIDE_TRANSACTIONS_ON_CHART: boolean;
 };
 
 type MarketHandlers<PreciseKey = true> = Handlers<MarketState, HandlersPayloads, PreciseKey>;
@@ -42,9 +45,17 @@ const handlers: MarketHandlers = {
     ...state,
     currentPage: payload,
   }),
+  MARKET_SET_HIDE_TRANSACTIONS_ON_CHART: (
+    state: MarketState,
+    { payload }: { payload: boolean },
+  ) => ({
+    ...state,
+    hideTransactionsOnChart: payload,
+  }),
 
   MARKET_IMPORT_STATE: (state, { payload }: { payload: MarketState }) => ({
     ...state,
+    hideTransactionsOnChart: payload.hideTransactionsOnChart ?? state.hideTransactionsOnChart,
     marketParams: {
       ...state.marketParams,
       range: payload.marketParams.range,
@@ -61,6 +72,9 @@ export const marketCurrentPageSelector = (state: { market: MarketState }) =>
   state.market.currentPage;
 
 export const marketStoreSelector = (state: { market: MarketState }) => state.market;
+
+export const hideTransactionsOnChartSelector = (state: { market: MarketState }) =>
+  state.market.hideTransactionsOnChart === true;
 
 // Exporting reducer
 

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9064,6 +9064,11 @@
       "hideFromPortfolio": "Hide from portfolio",
       "showInPortfolio": "Show in portfolio"
     },
+    "chartOptions": {
+      "menu": "Chart options",
+      "hideTransactions": "Hide activity on price chart",
+      "showTransactions": "Show activity on price chart"
+    },
     "hiddenBanner": {
       "description": "This asset is hidden from your portfolio.",
       "showAsset": "Show asset"

--- a/apps/ledger-live-mobile/src/actions/market.ts
+++ b/apps/ledger-live-mobile/src/actions/market.ts
@@ -4,6 +4,7 @@ import {
   MarketStateActionTypes,
   MarketSetCurrentPagePayload,
   MarketSetMarketFilterByStarredCurrenciesPayload,
+  MarketSetHideTransactionsOnChartPayload,
   MarketImportPayload,
 } from "./types";
 
@@ -18,6 +19,10 @@ export const setMarketFilterByStarredCurrencies =
 
 export const setMarketCurrentPage = createAction<MarketSetCurrentPagePayload>(
   MarketStateActionTypes.MARKET_SET_CURRENT_PAGE,
+);
+
+export const setHideTransactionsOnChart = createAction<MarketSetHideTransactionsOnChartPayload>(
+  MarketStateActionTypes.MARKET_SET_HIDE_TRANSACTIONS_ON_CHART,
 );
 
 export const importMarket = createAction<MarketImportPayload>(MarketStateActionTypes.MARKET_IMPORT);

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -543,6 +543,7 @@ export enum MarketStateActionTypes {
   SET_MARKET_REQUEST_PARAMS = "SET_MARKET_REQUEST_PARAMS",
   SET_MARKET_FILTER_BY_STARRED_CURRENCIES = "SET_MARKET_FILTER_BY_STARRED_CURRENCIES",
   MARKET_SET_CURRENT_PAGE = "MARKET_SET_CURRENT_PAGE",
+  MARKET_SET_HIDE_TRANSACTIONS_ON_CHART = "MARKET_SET_HIDE_TRANSACTIONS_ON_CHART",
   MARKET_IMPORT = "MARKET_IMPORT",
 }
 
@@ -550,6 +551,7 @@ export type MarketSetMarketFilterByStarredCurrenciesPayload =
   MarketState["marketFilterByStarredCurrencies"];
 export type MarketSetCurrentPagePayload = MarketState["marketCurrentPage"];
 export type MarketSetMarketRequestParamsPayload = MarketState["marketParams"];
+export type MarketSetHideTransactionsOnChartPayload = MarketState["hideTransactionsOnChart"];
 
 export type MarketImportPayload = Partial<MarketState>;
 
@@ -557,6 +559,7 @@ export type MarketPayload =
   | MarketSetMarketFilterByStarredCurrenciesPayload
   | MarketSetMarketRequestParamsPayload
   | MarketSetCurrentPagePayload
+  | MarketSetHideTransactionsOnChartPayload
   | MarketImportPayload;
 
 // === LARGE MOVER ACTIONS ===

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -9231,6 +9231,11 @@
       "removeFavourite": "Remove from favourites",
       "hideFromPortfolio": "Hide from portfolio",
       "showInPortfolio": "Show in portfolio"
+    },
+    "chartOptions": {
+      "openMenuA11yLabel": "Chart options",
+      "hideTransactions": "Hide activity on price chart",
+      "showTransactions": "Show activity on price chart"
     }
   },
   "assetSelection": {

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/LineChartView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/LineChartView.tsx
@@ -38,6 +38,20 @@ export function LineChartView<TRange extends string>({
   yAxis,
   rangeSelectorTrailing,
 }: Props<TRange>) {
+  const segmentedControl = (
+    <SegmentedControl
+      selectedValue={selectedRange}
+      onSelectedChange={handleSelectedChange}
+      accessibilityLabel={accessibilityLabel}
+    >
+      {ranges.map(({ value, label }) => (
+        <SegmentedControlButton key={value} value={value}>
+          {label}
+        </SegmentedControlButton>
+      ))}
+    </SegmentedControl>
+  );
+
   return (
     <Box lx={containerStyle} testID={testID}>
       {isLoading ? (
@@ -71,33 +85,11 @@ export function LineChartView<TRange extends string>({
 
       {rangeSelectorTrailing ? (
         <Box lx={rangeSelectorRowStyle}>
-          <Box lx={rangeSelectorControlStyle}>
-            <SegmentedControl
-              selectedValue={selectedRange}
-              onSelectedChange={handleSelectedChange}
-              accessibilityLabel={accessibilityLabel}
-            >
-              {ranges.map(({ value, label }) => (
-                <SegmentedControlButton key={value} value={value}>
-                  {label}
-                </SegmentedControlButton>
-              ))}
-            </SegmentedControl>
-          </Box>
+          <Box lx={rangeSelectorControlStyle}>{segmentedControl}</Box>
           {rangeSelectorTrailing}
         </Box>
       ) : (
-        <SegmentedControl
-          selectedValue={selectedRange}
-          onSelectedChange={handleSelectedChange}
-          accessibilityLabel={accessibilityLabel}
-        >
-          {ranges.map(({ value, label }) => (
-            <SegmentedControlButton key={value} value={value}>
-              {label}
-            </SegmentedControlButton>
-          ))}
-        </SegmentedControl>
+        segmentedControl
       )}
     </Box>
   );

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/LineChartView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/LineChartView.tsx
@@ -36,6 +36,7 @@ export function LineChartView<TRange extends string>({
   showYAxis,
   xAxis,
   yAxis,
+  rangeSelectorTrailing,
 }: Props<TRange>) {
   return (
     <Box lx={containerStyle} testID={testID}>
@@ -68,21 +69,51 @@ export function LineChartView<TRange extends string>({
         </LumenLineChart>
       )}
 
-      <SegmentedControl
-        selectedValue={selectedRange}
-        onSelectedChange={handleSelectedChange}
-        accessibilityLabel={accessibilityLabel}
-      >
-        {ranges.map(({ value, label }) => (
-          <SegmentedControlButton key={value} value={value}>
-            {label}
-          </SegmentedControlButton>
-        ))}
-      </SegmentedControl>
+      {rangeSelectorTrailing ? (
+        <Box lx={rangeSelectorRowStyle}>
+          <Box lx={rangeSelectorControlStyle}>
+            <SegmentedControl
+              selectedValue={selectedRange}
+              onSelectedChange={handleSelectedChange}
+              accessibilityLabel={accessibilityLabel}
+            >
+              {ranges.map(({ value, label }) => (
+                <SegmentedControlButton key={value} value={value}>
+                  {label}
+                </SegmentedControlButton>
+              ))}
+            </SegmentedControl>
+          </Box>
+          {rangeSelectorTrailing}
+        </Box>
+      ) : (
+        <SegmentedControl
+          selectedValue={selectedRange}
+          onSelectedChange={handleSelectedChange}
+          accessibilityLabel={accessibilityLabel}
+        >
+          {ranges.map(({ value, label }) => (
+            <SegmentedControlButton key={value} value={value}>
+              {label}
+            </SegmentedControlButton>
+          ))}
+        </SegmentedControl>
+      )}
     </Box>
   );
 }
 
 const containerStyle: LumenViewStyle = {
   gap: "s24",
+};
+
+const rangeSelectorRowStyle: LumenViewStyle = {
+  flexDirection: "row",
+  alignItems: "center",
+  gap: "s8",
+};
+
+const rangeSelectorControlStyle: LumenViewStyle = {
+  flex: 1,
+  minWidth: "s0",
 };

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/__tests__/LineChart.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/__tests__/LineChart.test.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Text } from "react-native";
 import { render, screen } from "@tests/test-renderer";
 import { LineChart } from "..";
 import type { LineChartProps, LineChartSeries } from "../types";
@@ -58,6 +59,17 @@ describe("LineChart", () => {
     renderLineChart({ accessibilityLabel: "Choose timeframe" });
 
     expect(screen.getByLabelText("Choose timeframe")).toBeOnTheScreen();
+  });
+
+  it("renders rangeSelectorTrailing next to the range selector while keeping its a11y label", () => {
+    renderLineChart({
+      accessibilityLabel: "Choose timeframe",
+      rangeSelectorTrailing: <Text>chart-options-slot</Text>,
+    });
+
+    expect(screen.getByText("chart-options-slot")).toBeOnTheScreen();
+    expect(screen.getByLabelText("Choose timeframe")).toBeOnTheScreen();
+    expect(screen.getByText("1D")).toBeVisible();
   });
 
   it("renders the Skeleton while isLoading", () => {

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/__tests__/useLineChartViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/__tests__/useLineChartViewModel.test.ts
@@ -76,6 +76,17 @@ describe("useLineChartViewModel", () => {
     expect(onRangeChange).toHaveBeenCalledWith("1w");
   });
 
+  it("forwards the rangeSelectorTrailing slot unchanged and defaults it to undefined", () => {
+    const { result: withoutTrailing } = renderHook(() => useLineChartViewModel(buildProps()));
+    expect(withoutTrailing.current.rangeSelectorTrailing).toBeUndefined();
+
+    const trailing = "trailing-node";
+    const { result: withTrailing } = renderHook(() =>
+      useLineChartViewModel(buildProps({ rangeSelectorTrailing: trailing })),
+    );
+    expect(withTrailing.current.rangeSelectorTrailing).toBe(trailing);
+  });
+
   it("skips onRangeChange when isRangeValue rejects the emitted value", () => {
     const onRangeChange = jest.fn();
     const { result } = renderHook(() =>

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/types.ts
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import type {
   LineChartProps as LumenLineChartProps,
   Series,
@@ -83,4 +84,6 @@ export type LineChartProps<TRange extends string = string> = Readonly<{
   xAxis?: LineChartXAxisConfig;
   /** Passthrough y-axis configuration (ticks, tickLabelFormatter, domain, ...). */
   yAxis?: LineChartYAxisConfig;
+  /** Optional control rendered inline at the end of the range-selector row (e.g. a chart options trigger). */
+  rangeSelectorTrailing?: ReactNode;
 }>;

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/useLineChartViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/useLineChartViewModel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, type ReactNode } from "react";
 import { useTheme } from "@ledgerhq/lumen-ui-rnative/styles";
 import { DEFAULT_LINE_CHART_HEIGHT } from "./constants";
 import type {
@@ -41,6 +41,7 @@ export type LineChartViewModelResult<TRange extends string = string> = Readonly<
   showYAxis: boolean;
   xAxis?: LineChartXAxisConfig;
   yAxis?: LineChartYAxisConfig;
+  rangeSelectorTrailing?: ReactNode;
 }>;
 
 export function useLineChartViewModel<TRange extends string>({
@@ -67,6 +68,7 @@ export function useLineChartViewModel<TRange extends string>({
   showYAxis = true,
   xAxis,
   yAxis,
+  rangeSelectorTrailing,
 }: LineChartProps<TRange>): LineChartViewModelResult<TRange> {
   const { theme } = useTheme();
 
@@ -121,5 +123,6 @@ export function useLineChartViewModel<TRange extends string>({
     showYAxis,
     xAxis,
     yAxis,
+    rangeSelectorTrailing,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/BalanceGraphView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/BalanceGraphView.tsx
@@ -18,6 +18,7 @@ import type {
 } from "LLM/components/LineChart";
 import { ASSET_DETAIL_TEST_IDS } from "LLM/features/AssetDetail/testIds";
 import type { RangeKey } from "../../utils/rangeMapping";
+import { ChartOptions } from "./ChartOptions";
 
 /** Figma asset-detail chart height (343 × 208). Width follows the screen inset. */
 export const ASSET_DETAIL_CHART_HEIGHT = 208;
@@ -50,6 +51,7 @@ type Props = Readonly<{
   showYAxis: boolean;
   xAxis: LineChartXAxisConfig;
   yAxis: LineChartYAxisConfig;
+  currencyId?: string;
 }>;
 
 type ChartProps = Readonly<{
@@ -70,6 +72,7 @@ type ChartProps = Readonly<{
   xAxis: LineChartXAxisConfig;
   yAxis: LineChartYAxisConfig;
   accessibilityLabel: string;
+  currencyId?: string;
 }>;
 
 /**
@@ -95,6 +98,7 @@ const BalanceGraphChart = React.memo(function BalanceGraphChart({
   xAxis,
   yAxis,
   accessibilityLabel,
+  currencyId,
 }: ChartProps) {
   return (
     <LineChart<RangeKey>
@@ -119,6 +123,7 @@ const BalanceGraphChart = React.memo(function BalanceGraphChart({
       accessibilityLabel={accessibilityLabel}
       testID={ASSET_DETAIL_TEST_IDS.chart}
       height={ASSET_DETAIL_CHART_HEIGHT}
+      rangeSelectorTrailing={<ChartOptions currencyId={currencyId} />}
     />
   );
 });
@@ -149,6 +154,7 @@ export function BalanceGraphView({
   showYAxis,
   xAxis,
   yAxis,
+  currencyId,
 }: Props) {
   const { t } = useTranslation();
 
@@ -203,6 +209,7 @@ export function BalanceGraphView({
         xAxis={xAxis}
         yAxis={yAxis}
         accessibilityLabel={t("assetDetail.balanceGraph.timeframeSelector")}
+        currencyId={currencyId}
       />
 
       {showReceive && (

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/ChartOptions/ChartOptionsSheetView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/ChartOptions/ChartOptionsSheetView.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import {
+  BottomSheetHeader,
+  BottomSheetView,
+  ListItem,
+  ListItemContent,
+  ListItemLeading,
+  ListItemTitle,
+  Spot,
+} from "@ledgerhq/lumen-ui-rnative";
+import { Eye, EyeCross } from "@ledgerhq/lumen-ui-rnative/symbols";
+import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
+import { ASSET_DETAIL_TEST_IDS } from "LLM/features/AssetDetail/testIds";
+
+type Props = Readonly<{
+  isOpen: boolean;
+  onClose: () => void;
+  isHidden: boolean;
+  toggleTransactionsTitle: string;
+  onToggleTransactions: () => void;
+}>;
+
+export function ChartOptionsSheetView({
+  isOpen,
+  onClose,
+  isHidden,
+  toggleTransactionsTitle,
+  onToggleTransactions,
+}: Props) {
+  const { bottom: bottomInset } = useSafeAreaInsets();
+
+  return (
+    <QueuedDrawerBottomSheet
+      testID={ASSET_DETAIL_TEST_IDS.chartOptionsSheet}
+      isRequestingToBeOpened={isOpen}
+      enableDynamicSizing
+      onClose={onClose}
+    >
+      <BottomSheetView style={{ paddingBottom: bottomInset + 24 }}>
+        <BottomSheetHeader />
+        <ListItem
+          onPress={onToggleTransactions}
+          testID={ASSET_DETAIL_TEST_IDS.chartOptionsToggleTransactionsRow}
+        >
+          <ListItemLeading>
+            <Spot appearance="icon" icon={isHidden ? Eye : EyeCross} />
+            <ListItemContent>
+              <ListItemTitle>{toggleTransactionsTitle}</ListItemTitle>
+            </ListItemContent>
+          </ListItemLeading>
+        </ListItem>
+      </BottomSheetView>
+    </QueuedDrawerBottomSheet>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/ChartOptions/ChartOptionsTrailing.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/ChartOptions/ChartOptionsTrailing.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { IconButton } from "@ledgerhq/lumen-ui-rnative";
+import { SettingsAlt2 } from "@ledgerhq/lumen-ui-rnative/symbols";
+
+type Props = Readonly<{
+  onPress: () => void;
+  accessibilityLabel: string;
+  testID: string;
+}>;
+
+export function ChartOptionsTrailing({ onPress, accessibilityLabel, testID }: Props) {
+  return (
+    <IconButton
+      appearance="no-background"
+      size="xs"
+      icon={SettingsAlt2}
+      accessibilityLabel={accessibilityLabel}
+      onPress={onPress}
+      testID={testID}
+    />
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/ChartOptions/__tests__/useChartOptionsViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/ChartOptions/__tests__/useChartOptionsViewModel.test.ts
@@ -1,0 +1,48 @@
+import { renderHook, act } from "@tests/test-renderer";
+import type { State } from "~/reducers/types";
+import { useChartOptionsViewModel } from "../useChartOptionsViewModel";
+
+const withHidden = (hideTransactionsOnChart: boolean) => (state: State) => ({
+  ...state,
+  market: { ...state.market, hideTransactionsOnChart },
+});
+
+describe("useChartOptionsViewModel", () => {
+  it("is not hidden and shows the 'hide' label by default", () => {
+    const { result } = renderHook(() => useChartOptionsViewModel({ currencyId: "bitcoin" }), {
+      overrideInitialState: withHidden(false),
+    });
+    expect(result.current.isHidden).toBe(false);
+    expect(result.current.toggleTransactionsTitle).toBe("Hide activity on price chart");
+  });
+
+  it("shows the 'show' label when transactions are already hidden", () => {
+    const { result } = renderHook(() => useChartOptionsViewModel({ currencyId: "bitcoin" }), {
+      overrideInitialState: withHidden(true),
+    });
+    expect(result.current.isHidden).toBe(true);
+    expect(result.current.toggleTransactionsTitle).toBe("Show activity on price chart");
+  });
+
+  it("opens and closes the options sheet", () => {
+    const { result } = renderHook(() => useChartOptionsViewModel({ currencyId: "bitcoin" }), {
+      overrideInitialState: withHidden(false),
+    });
+    expect(result.current.isSheetOpen).toBe(false);
+    act(() => result.current.openSheet());
+    expect(result.current.isSheetOpen).toBe(true);
+    act(() => result.current.closeSheet());
+    expect(result.current.isSheetOpen).toBe(false);
+  });
+
+  it("persists the toggle and closes the sheet when toggled", () => {
+    const { result, store } = renderHook(
+      () => useChartOptionsViewModel({ currencyId: "bitcoin" }),
+      { overrideInitialState: withHidden(false) },
+    );
+    act(() => result.current.openSheet());
+    act(() => result.current.onToggleTransactions());
+    expect(store.getState().market.hideTransactionsOnChart).toBe(true);
+    expect(result.current.isSheetOpen).toBe(false);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/ChartOptions/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/ChartOptions/index.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { ASSET_DETAIL_TEST_IDS } from "LLM/features/AssetDetail/testIds";
+import { useChartOptionsViewModel } from "./useChartOptionsViewModel";
+import { ChartOptionsTrailing } from "./ChartOptionsTrailing";
+import { ChartOptionsSheetView } from "./ChartOptionsSheetView";
+
+type Props = Readonly<{
+  currencyId?: string;
+}>;
+
+export function ChartOptions({ currencyId }: Props) {
+  const {
+    isHidden,
+    isSheetOpen,
+    openSheet,
+    closeSheet,
+    onToggleTransactions,
+    trailingAccessibilityLabel,
+    toggleTransactionsTitle,
+  } = useChartOptionsViewModel({ currencyId });
+
+  return (
+    <>
+      <ChartOptionsTrailing
+        onPress={openSheet}
+        accessibilityLabel={trailingAccessibilityLabel}
+        testID={ASSET_DETAIL_TEST_IDS.chartOptionsTrailing}
+      />
+      <ChartOptionsSheetView
+        isOpen={isSheetOpen}
+        onClose={closeSheet}
+        isHidden={isHidden}
+        toggleTransactionsTitle={toggleTransactionsTitle}
+        onToggleTransactions={onToggleTransactions}
+      />
+    </>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/ChartOptions/useChartOptionsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/ChartOptions/useChartOptionsViewModel.ts
@@ -1,0 +1,50 @@
+import { useCallback, useMemo, useState } from "react";
+import { useDispatch, useSelector } from "~/context/hooks";
+import { setHideTransactionsOnChart } from "~/actions/market";
+import { hideTransactionsOnChartSelector } from "~/reducers/market";
+import { track } from "~/analytics";
+import { useTranslation } from "~/context/Locale";
+
+type Params = Readonly<{
+  currencyId?: string;
+}>;
+
+export function useChartOptionsViewModel({ currencyId }: Params) {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const isHidden = useSelector(hideTransactionsOnChartSelector);
+
+  const [isSheetOpen, setSheetOpen] = useState(false);
+
+  const openSheet = useCallback(() => setSheetOpen(true), []);
+  const closeSheet = useCallback(() => setSheetOpen(false), []);
+
+  const onToggleTransactions = useCallback(() => {
+    const nextHidden = !isHidden;
+    track("button_clicked", {
+      button: "hide_transactions_graph",
+      page: "Asset Detail",
+      currency: currencyId,
+      is_hidden: nextHidden,
+    });
+    dispatch(setHideTransactionsOnChart(nextHidden));
+    closeSheet();
+  }, [dispatch, isHidden, closeSheet, currencyId]);
+
+  return useMemo(
+    () => ({
+      isHidden,
+      isSheetOpen,
+      openSheet,
+      closeSheet,
+      onToggleTransactions,
+      trailingAccessibilityLabel: t("assetDetail.chartOptions.openMenuA11yLabel"),
+      toggleTransactionsTitle: isHidden
+        ? t("assetDetail.chartOptions.showTransactions")
+        : t("assetDetail.chartOptions.hideTransactions"),
+    }),
+    [isHidden, isSheetOpen, openSheet, closeSheet, onToggleTransactions, t],
+  );
+}
+
+export type ChartOptionsViewModel = ReturnType<typeof useChartOptionsViewModel>;

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
@@ -17,6 +17,7 @@ import {
 import { useSelector } from "~/context/hooks";
 import { accountsSelector, flattenAccountsSelector } from "~/reducers/accounts";
 import { counterValueCurrencySelector, discreetModeSelector } from "~/reducers/settings";
+import { hideTransactionsOnChartSelector } from "~/reducers/market";
 import { useCountervaluesState } from "~/reducers/countervalues";
 import { useOperationsV1 } from "~/screens/Analytics/Operations/useOperationsV1";
 import { track } from "~/analytics";
@@ -376,6 +377,7 @@ export function useBalanceGraphViewModel({
   // transactions it represents, mirroring the Transactions section's scoping.
   const allAccounts = useSelector(accountsSelector);
   const discreet = useSelector(discreetModeSelector);
+  const hideTransactionsOnChart = useSelector(hideTransactionsOnChartSelector);
   // Read through a ref so countervalue polling (which swaps the state reference on
   // every tick) does not invalidate the `transactions` memo and force the memoized
   // chart to re-render. Historical fiat is treated as stable; if rates land after the
@@ -481,10 +483,12 @@ export function useBalanceGraphViewModel({
 
   const points = useMemo<LineChartPointMarker[]>(() => {
     const extrema = getExtremaPointMarkers(series);
-    if (transactions.length === 0 || timestamps.length < 2) return extrema;
+    // The user can hide transaction markers from the price chart (persisted setting).
+    if (hideTransactionsOnChart || transactions.length === 0 || timestamps.length < 2)
+      return extrema;
     const groups = groupTransactionsByChartIndex({ timestamps, values: prices, transactions });
     return [...extrema, ...groups.map(group => buildTransactionPointMarker(group, t, formatFiat))];
-  }, [series, transactions, timestamps, prices, t, formatFiat]);
+  }, [series, transactions, timestamps, prices, t, formatFiat, hideTransactionsOnChart]);
 
   return {
     price: displayedPrice,
@@ -512,5 +516,6 @@ export function useBalanceGraphViewModel({
     showYAxis: false,
     xAxis,
     yAxis,
+    currencyId: currency?.id,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/testIds.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/testIds.ts
@@ -29,4 +29,7 @@ export const ASSET_DETAIL_TEST_IDS = {
   coinOptionsSheet: "asset-detail-coin-options-sheet",
   coinOptionsFavouriteRow: "asset-detail-coin-options-favourite-row",
   coinOptionsHideRow: "asset-detail-coin-options-hide-row",
+  chartOptionsTrailing: "asset-detail-chart-options-trailing",
+  chartOptionsSheet: "asset-detail-chart-options-sheet",
+  chartOptionsToggleTransactionsRow: "asset-detail-chart-options-toggle-transactions-row",
 } as const;

--- a/apps/ledger-live-mobile/src/reducers/market.ts
+++ b/apps/ledger-live-mobile/src/reducers/market.ts
@@ -4,6 +4,7 @@ import {
   MarketSetCurrentPagePayload,
   MarketSetMarketFilterByStarredCurrenciesPayload,
   MarketSetMarketRequestParamsPayload,
+  MarketSetHideTransactionsOnChartPayload,
   MarketStateActionTypes,
   MarketPayload,
   MarketImportPayload,
@@ -25,6 +26,7 @@ export const INITIAL_STATE: MarketState = {
   },
   marketFilterByStarredCurrencies: false,
   marketCurrentPage: 1,
+  hideTransactionsOnChart: false,
 };
 
 const handlers: ReducerMap<MarketState, MarketPayload> = {
@@ -47,11 +49,19 @@ const handlers: ReducerMap<MarketState, MarketPayload> = {
     marketCurrentPage: (action as Action<MarketSetCurrentPagePayload>).payload,
   }),
 
+  [MarketStateActionTypes.MARKET_SET_HIDE_TRANSACTIONS_ON_CHART]: (state, action) => ({
+    ...state,
+    hideTransactionsOnChart: (action as Action<MarketSetHideTransactionsOnChartPayload>).payload,
+  }),
+
   [MarketStateActionTypes.MARKET_IMPORT]: (state, action) => ({
     ...state,
     marketFilterByStarredCurrencies:
       (action as Action<MarketImportPayload>).payload.marketFilterByStarredCurrencies ||
       state.marketFilterByStarredCurrencies,
+    hideTransactionsOnChart:
+      (action as Action<MarketImportPayload>).payload.hideTransactionsOnChart ??
+      state.hideTransactionsOnChart,
 
     marketParams: {
       ...state.marketParams,
@@ -69,6 +79,8 @@ export const marketParamsSelector = (state: State) => state.market.marketParams;
 export const marketFilterByStarredCurrenciesSelector = (state: State) =>
   state.market.marketFilterByStarredCurrencies;
 export const marketCurrentPageSelector = (state: State) => state.market.marketCurrentPage;
+export const hideTransactionsOnChartSelector = (state: State) =>
+  state.market.hideTransactionsOnChart === true;
 export const exportMarketSelector = (s: State) => s.market;
 // Exporting reducer
 

--- a/apps/ledger-live-mobile/src/reducers/market.ts
+++ b/apps/ledger-live-mobile/src/reducers/market.ts
@@ -57,7 +57,7 @@ const handlers: ReducerMap<MarketState, MarketPayload> = {
   [MarketStateActionTypes.MARKET_IMPORT]: (state, action) => ({
     ...state,
     marketFilterByStarredCurrencies:
-      (action as Action<MarketImportPayload>).payload.marketFilterByStarredCurrencies ||
+      (action as Action<MarketImportPayload>).payload.marketFilterByStarredCurrencies ??
       state.marketFilterByStarredCurrencies,
     hideTransactionsOnChart:
       (action as Action<MarketImportPayload>).payload.hideTransactionsOnChart ??

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -379,6 +379,7 @@ export type MarketState = {
   marketParams: MarketListRequestParams;
   marketFilterByStarredCurrencies: boolean;
   marketCurrentPage: number;
+  hideTransactionsOnChart: boolean;
 };
 
 // === WALLETSYNC STATE ===


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Toggle logic (label flip, persistence, sheet open/close) and the default "markers shown" path are covered by unit tests; the menu/bottom-sheet rendering itself is not snapshot-tested._
- [x] **Impact of the changes:**
      - Asset detail price chart on **both** LWD and LWM
      - New "Chart options" trigger (sliders icon) next to the range selector
      - Hide/Show **activity (transaction) markers** toggle — desktop menu, mobile bottom sheet
      - Persistence of the preference across app restarts (stored in the market store) and that it applies across assets
      - All-time **high/low markers must remain** when activity is hidden
      - Analytics: `button_clicked` / `hide_transactions_graph` with `page`, `currency`, `is_hidden`

### 📝 Description

The W4.0 asset detail price chart renders transaction "activity" markers (in/out dots) on the line. Per the Figma ("Hide / Show transaction dots on graph"), users should be able to hide these from the chart — as an opt-in toggle, not an unconditional removal.

This PR adds a chart options control: a settings icon (`SettingsAlt2`) inline with the range selector that opens a contextual menu (desktop) / bottom sheet (mobile) with a single action whose label toggles between **"Hide activity on price chart"** and **"Show activity on price chart"**. The preference is persisted in the **market store** (already persisted in both apps) and applied globally across assets; when enabled, the view models omit the transaction markers from the chart's `points` while the all-time high/low markers stay. A shared, optional `rangeSelectorTrailing` slot was added to the MVVM `LineChart` so the trigger renders inline without coupling the generic chart to asset-detail concerns.

### 🎥 Demo

| LWD | LWM |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/4cc8164c-e421-49d4-a032-7a66a6be0780" />|<video src="https://github.com/user-attachments/assets/e917520e-676c-4bad-8c80-9a46b12cf8f7" />|

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31794](https://ledgerhq.atlassian.net/browse/LIVE-31794)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31794]: https://ledgerhq.atlassian.net/browse/LIVE-31794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ