### PR TITLE
[LWDM] chore(live-common): privatize @ledgerhq/live-common and its published dependents

### DIFF
--- a/.changeset/privatize-live-common.md
+++ b/.changeset/privatize-live-common.md
@@ -1,0 +1,10 @@
+---
+"@ledgerhq/live-common": minor
+"@ledgerhq/asset-detail": minor
+"@ledgerhq/coin-modules-monitoring": minor
+"@ledgerhq/coin-tester-evm": minor
+"@ledgerhq/coin-tester-solana": minor
+"@ledgerhq/coin-tester-tezos": minor
+---
+
+Privatize `@ledgerhq/live-common` so it is no longer published to npm and can depend on private workspace packages. Its published runtime dependents (`@ledgerhq/asset-detail`, `@ledgerhq/coin-modules-monitoring`, `@ledgerhq/coin-tester-evm`, `-solana`, `-tezos`) are privatized in lockstep; internal consumers keep resolving it through the workspace.

--- a/README.md
+++ b/README.md
@@ -247,8 +247,6 @@ These packages are deployed to the official npm repository under the `@ledgerhq`
 
 | Name                                                                                                                                                         | Alias                          | Umbrella                                                                       | Package                                                                                                                                                       |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------ | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [**@ledgerhq/ledger-live-common**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledger-live-common)                                             | `pnpm common`                  | -----                                                                          |
-| ----                                                                                                                                                         | -----                          | -----                                                                          | -------                                                                                                                                                       |
 | [**@ledgerhq/cryptoassets**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/cryptoassets)                                       | `pnpm ljs:cryoptoassets`       | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/cryptoassets.svg)](https://www.npmjs.com/package/@ledgerhq/cryptoassets)                                       |
 | [**@ledgerhq/devices**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/devices)                                                 | `pnpm ljs:devices`             | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/devices.svg)](https://www.npmjs.com/package/@ledgerhq/devices)                                                 |
 | [**@ledgerhq/errors**](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/errors)                                                   | `pnpm ljs:errors`              | [ledgerjs](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) | [![npm](https://img.shields.io/npm/v/@ledgerhq/errors.svg)](https://www.npmjs.com/package/@ledgerhq/errors)                                                   |
@@ -330,7 +328,7 @@ Nightly versions of library packages are pushed every night to npm.
 To install a nightly library use the `@nightly` dist-tag.
 
 ```sh
-npm i @ledgerhq/live-common@nightly
+npm i @ledgerhq/hw-app-eth@nightly
 ```
 
 ## License

--- a/libs/asset-detail/package.json
+++ b/libs/asset-detail/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ledgerhq/asset-detail",
   "version": "0.3.0",
+  "private": true,
   "description": "Ledger Live asset-detail shared module – market data hook, types and utils",
   "keywords": [
     "Ledger"
@@ -13,9 +14,6 @@
     "url": "https://github.com/LedgerHQ/ledger-live/issues"
   },
   "homepage": "https://github.com/LedgerHQ/ledger-live/tree/develop/libs/asset-detail",
-  "publishConfig": {
-    "access": "public"
-  },
   "main": "lib/index.js",
   "module": "lib-es/index.js",
   "types": "lib/index.d.ts",

--- a/libs/coin-modules-monitoring/package.json
+++ b/libs/coin-modules-monitoring/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ledgerhq/coin-modules-monitoring",
   "version": "2.21.0",
+  "private": true,
   "description": "Push monitoring metrics to Datadog",
   "license": "Apache-2.0",
   "scripts": {

--- a/libs/coin-tester-modules/coin-tester-evm/package.json
+++ b/libs/coin-tester-modules/coin-tester-evm/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ledgerhq/coin-tester-evm",
   "version": "1.25.0",
+  "private": true,
   "description": "Ledger EVM Coin Tester",
   "main": "src/scenarii.test.ts",
   "keywords": [
@@ -18,9 +19,6 @@
     "url": "https://github.com/LedgerHQ/ledger-live/issues"
   },
   "homepage": "https://github.com/LedgerHQ/ledger-live/tree/develop/libs/coin-tester-modules/coin-tester-evm",
-  "publishConfig": {
-    "access": "public"
-  },
   "typesVersions": {
     "*": {
       "lib/*": [

--- a/libs/coin-tester-modules/coin-tester-solana/package.json
+++ b/libs/coin-tester-modules/coin-tester-solana/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ledgerhq/coin-tester-solana",
   "version": "1.20.0",
+  "private": true,
   "description": "Ledger Solana Coin Tester",
   "main": "src/scenarii.test.ts",
   "keywords": [
@@ -17,9 +18,6 @@
     "url": "https://github.com/LedgerHQ/ledger-live/issues"
   },
   "homepage": "https://github.com/LedgerHQ/ledger-live/tree/develop/libs/coin-tester-modules/coin-tester-solana",
-  "publishConfig": {
-    "access": "public"
-  },
   "typesVersions": {
     "*": {
       "lib/*": [

--- a/libs/coin-tester-modules/coin-tester-tezos/package.json
+++ b/libs/coin-tester-modules/coin-tester-tezos/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ledgerhq/coin-tester-tezos",
   "version": "1.0.1",
+  "private": true,
   "description": "Ledger Tezos Coin Tester",
   "main": "src/scenarii.test.ts",
   "keywords": [
@@ -17,9 +18,6 @@
     "url": "https://github.com/LedgerHQ/ledger-live/issues"
   },
   "homepage": "https://github.com/LedgerHQ/ledger-live/tree/develop/libs/coin-tester-modules/coin-tester-tezos",
-  "publishConfig": {
-    "access": "public"
-  },
   "typesVersions": {
     "*": {
       "lib/*": [

--- a/libs/ledger-live-common/README.md
+++ b/libs/ledger-live-common/README.md
@@ -23,7 +23,7 @@
 
 `````
 
-Ledger Live Common (`@ledgerhq/live-common`) is a JavaScript library available via a [NPM package](https://npmjs.com/@ledgerhq/live-common).
+Ledger Live Common (`@ledgerhq/live-common`) is a JavaScript library that powers the Ledger Live apps. It is an internal package of this monorepo (`"private": true`) and is no longer published to npm — consume it through the workspace.
 
 This library depends on a bunch of [ledgerjs packages](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) and put together the core business logic behind [Ledger Live Desktop](https://github.com/LedgerHQ/ledger-live/tree/develop/apps/ledger-live-desktop) and [Ledger Live Mobile](https://github.com/LedgerHQ/ledger-live/tree/develop/apps/ledger-live-mobile).
 

--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -2,6 +2,7 @@
   "name": "@ledgerhq/live-common",
   "description": "Common ground for the Ledger Live apps",
   "version": "35.0.0",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/LedgerHQ/ledger-live.git"


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Config-only change (no runtime code). Verified by a full clean lib rebuild (`pnpm build:libs:force` → 131 projects) and the CLI build (`pnpm build:cli` → live-cli + 103 deps), plus the Nx `enforce-boundaries` validator.
- [x] **Impact of the changes:** these packages stop being published to npm. QA should confirm no external/partner integration installs them from the registry.
  - `@ledgerhq/live-common` and 5 internal libs (`asset-detail`, `coin-modules-monitoring`, `coin-tester-evm/solana/tezos`) become `private`.
  - No app behavior change — LLD / LLM / CLI all resolve live-common through the workspace.

### 📝 Description

`@ledgerhq/live-common` was a **public, published** npm package, which prevented it from depending on private workspace packages (`@shared/*`, `@features/*`): an external `npm i @ledgerhq/live-common` could not resolve those packages, and it violates the Nx public→private boundary.

This PR flips live-common to `"private": true` so it stops publishing and can consume those private packages — **unblocking the Feature Flags migration (LIVE-31640)**.

Privatizing live-common would break `npm i` of any **published** package that depends on it at runtime, so the published runtime dependents are privatized in lockstep:

- `@ledgerhq/asset-detail`
- `@ledgerhq/coin-modules-monitoring`
- `@ledgerhq/coin-tester-evm`
- `@ledgerhq/coin-tester-solana`
- `@ledgerhq/coin-tester-tezos`

`@ledgerhq/live-cli` is **unaffected**: it bundles its dependencies and strips all `@ledgerhq/*` keys from its published manifest, so it never resolves live-common from npm.

**No Nx `enforce-boundaries` change is required.** That rule only constrains packages carrying `scope:shared` / `scope:domain` / `scope:features` / `type:*` source tags; live-common's tags were never constrained, so it can already import the private packages. (Reverse direction stays one-way: live-common → shared/features, never the reverse.)

Docs updated: removed the live-common row from the published-libraries table and the `npm i @ledgerhq/live-common@nightly` example in `README.md`; updated the install note in `libs/ledger-live-common/README.md`.

**Verification**
- `pnpm build:libs:force` → 131 projects built clean (no TS errors)
- `pnpm build:cli` → `@ledgerhq/live-cli` + 103 dependency tasks built clean
- `node tools/nx-plugins/enforce-boundaries/validate.js` → ✓ module boundaries ok
- `changeset status` → the 6 packages bump as `major`
- No public package retains a runtime dependency on live-common (live-cli bundles)

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31646](https://ledgerhq.atlassian.net/browse/LIVE-31646) — blocks [LIVE-31640](https://ledgerhq.atlassian.net/browse/LIVE-31640) (Phase C), transitively LIVE-30413 (LWM) + LIVE-31228 (LWD). Epic: LIVE-30799.
- **ADR link (if any)**: —

---

### 🧐 Checklist for the PR Reviewers

<\!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31646]: https://ledgerhq.atlassian.net/browse/LIVE-31646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ