### PR TITLE
[LWM] feat: remove 6m timeframe option from balance graph

### DIFF
--- a/.changeset/asset-detail-mobile-timeframe-scope.md
+++ b/.changeset/asset-detail-mobile-timeframe-scope.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix Asset Detail mobile timeframe options to expose only 1D, 1W, 1M, 1Y, and ALL.

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/useBalanceGraphViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/useBalanceGraphViewModel.test.ts
@@ -53,10 +53,6 @@ const CHART_DATA_BY_RANGE: Record<RangeKey, Array<[number, number]>> = {
     [2, 210],
   ],
   "1m": [[1, 300]],
-  "6m": [
-    [1, 350],
-    [2, 385],
-  ],
   "1y": [
     [1, 400],
     [2, 410],
@@ -362,7 +358,7 @@ describe("useBalanceGraphViewModel", () => {
       const { result } = renderVM();
 
       const values = result.current.ranges.map(r => r.value);
-      expect(values).toEqual(["1d", "1w", "1m", "6m", "1y", "all"]);
+      expect(values).toEqual(["1d", "1w", "1m", "1y", "all"]);
     });
 
     it("exposes a runtime guard that accepts only known range keys", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/utils/rangeMapping.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/utils/rangeMapping.ts
@@ -1,7 +1,7 @@
 import { KeysPriceChange } from "@ledgerhq/live-common/market/utils/types";
 
 // Range buckets surfaced in the BalanceGraph segmented control.
-export const BALANCE_GRAPH_RANGES = ["1d", "1w", "1m", "6m", "1y", "all"] as const;
+export const BALANCE_GRAPH_RANGES = ["1d", "1w", "1m", "1y", "all"] as const;
 
 export type RangeKey = (typeof BALANCE_GRAPH_RANGES)[number];
 
@@ -14,7 +14,7 @@ export const RANGE_TO_PRICE_CHANGE_KEY: Partial<Record<RangeKey, KeysPriceChange
   "1y": KeysPriceChange.year,
 };
 
-const CHART_DERIVED_PRICE_CHANGE_RANGES = new Set<RangeKey>(["6m", "all"]);
+const CHART_DERIVED_PRICE_CHANGE_RANGES = new Set<RangeKey>(["all"]);
 
 export function isChartDerivedPriceChangeRange(range: RangeKey): boolean {
   return CHART_DERIVED_PRICE_CHANGE_RANGES.has(range);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request removes 6m timeframe option to the Asset Detail balance graph on mobile

### ❓ Context

[LIVE-31776](https://ledgerhq.atlassian.net/browse/LIVE-31776)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31776]: https://ledgerhq.atlassian.net/browse/LIVE-31776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ