### PR TITLE
[LWDM] fix(ff): apply feature-flag language filtering via the middleware [LIVE-31804]

### DIFF
--- a/.changeset/ff-resolution-lang-desktop.md
+++ b/.changeset/ff-resolution-lang-desktop.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Pass the current app language to the feature-flags middleware (`getAppLanguage` selector in `configureStore`) so it can apply language filtering during resolution, making language-gated remote flags (`languages_whitelisted` / `languages_blacklisted`) resolve correctly.

--- a/.changeset/ff-resolution-lang-mobile.md
+++ b/.changeset/ff-resolution-lang-mobile.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Pass the current app language to the feature-flags middleware (`getAppLanguage` selector in `configureStore`) so it can apply language filtering during resolution, making language-gated remote flags (`languages_whitelisted` / `languages_blacklisted`) resolve correctly.

--- a/.changeset/ff-resolution-lang.md
+++ b/.changeset/ff-resolution-lang.md
@@ -1,0 +1,5 @@
+---
+"@shared/feature-flags": minor
+---
+
+Apply feature-flag language filtering. The feature-flags middleware now injects the current app language into `meta.resolutionConfig.appLanguage` on every `featureFlags/*` action — read from app state via an optional `getAppLanguage` selector — and re-resolves all flags when it changes, so `languages_whitelisted` / `languages_blacklisted` constraints take effect.

--- a/apps/ledger-live-desktop/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-desktop/src/state-manager/configureStore.ts
@@ -5,7 +5,7 @@ import logger from "~/renderer/middlewares/logger";
 import reducers, { State } from "~/renderer/reducers";
 import { applyLldRTKApiMiddlewares } from "~/renderer/reducers/rtkQueryApi";
 import { createIdentitiesSyncMiddleware } from "@ledgerhq/client-ids/store";
-import { canPushDeviceIdsSelector } from "~/renderer/reducers/settings";
+import { canPushDeviceIdsSelector, languageSelector } from "~/renderer/reducers/settings";
 import { createFeatureFlagsMiddleware, type PartialFeatures } from "@shared/feature-flags";
 import { fetchRemoteFlags as defaultFetchRemoteFlags } from "~/firebase/remoteConfig";
 type Props = {
@@ -42,13 +42,14 @@ const customCreateStore = ({
           }),
         )
         .concat(
-          createFeatureFlagsMiddleware({
+          createFeatureFlagsMiddleware<State>({
             resolutionConfig: {
               platform: "desktop",
               appVersion: __APP_VERSION__,
               envFlags: getEnv("FEATURE_FLAGS") as PartialFeatures,
             },
             fetchRemoteFlags: fetchRemoteFlags ?? undefined,
+            getAppLanguage: languageSelector,
           }),
         ),
     devTools: __DEV__,

--- a/apps/ledger-live-mobile/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-mobile/src/state-manager/configureStore.ts
@@ -12,7 +12,7 @@ import { setupCryptoAssetsStore } from "~/config/bridge-setup";
 import { setupRecentAddressesStore } from "LLM/storage/recentAddresses";
 import { createIdentitiesSyncMiddleware } from "@ledgerhq/client-ids/store";
 import { State } from "~/reducers/types";
-import { canPushDeviceIdsSelector } from "~/reducers/settings";
+import { canPushDeviceIdsSelector, languageSelector } from "~/reducers/settings";
 import { getEnv } from "@ledgerhq/live-env";
 import { createFeatureFlagsMiddleware, type PartialFeatures } from "@shared/feature-flags";
 import { fetchRemoteFlags } from "~/firebase/remoteConfig";
@@ -32,13 +32,14 @@ export const store = configureStore({
         }),
       )
       .concat(
-        createFeatureFlagsMiddleware({
+        createFeatureFlagsMiddleware<State>({
           resolutionConfig: {
             platform: Platform.OS === "ios" ? "ios" : "android",
             appVersion: VersionNumber.appVersion ?? undefined,
             envFlags: getEnv("FEATURE_FLAGS") as PartialFeatures,
           },
           fetchRemoteFlags,
+          getAppLanguage: languageSelector,
         }),
       ),
 

--- a/shared/feature-flags/src/data/middleware.ts
+++ b/shared/feature-flags/src/data/middleware.ts
@@ -64,7 +64,6 @@ export function createFeatureFlagsMiddleware<S = unknown>(
       );
     }
     return next => action => {
-      // Only plain actions can mutate state; thunks/functions dispatch actions that re-enter here.
       if (!isAction(action)) return next(action);
 
       if (action.type.startsWith("featureFlags/")) {

--- a/shared/feature-flags/src/data/middleware.ts
+++ b/shared/feature-flags/src/data/middleware.ts
@@ -10,8 +10,8 @@ export interface FeatureFlagsMeta {
 }
 
 /** Configuration for {@link createFeatureFlagsMiddleware}, bound at store creation. */
-export interface FeatureFlagsMiddlewareConfig {
-  /** Static context used by reducers to resolve flags (platform, version, language, env overrides). */
+export interface FeatureFlagsMiddlewareConfig<S = unknown> {
+  /** Static context used by reducers to resolve flags (platform, version, env overrides). */
   resolutionConfig: ResolutionConfig;
   /**
    * Optional async callback that returns the latest remote feature flags. When
@@ -22,6 +22,8 @@ export interface FeatureFlagsMiddlewareConfig {
   fetchRemoteFlags?: () => Promise<PartialFeatures>;
   /** Polling interval for `fetchRemoteFlags`. Defaults to {@link FEATURE_FLAGS_REMOTE_POLLING_INTERVAL_MS}. */
   refreshInterval?: number;
+  /** Optional selector for the current app language, injected into resolution and re-resolved on change. */
+  getAppLanguage?: (state: S) => string;
 }
 
 /**
@@ -37,10 +39,14 @@ export interface FeatureFlagsMiddlewareConfig {
  * @param config
  * Resolution context plus optional fetcher + interval. Bound at store creation.
  */
-export function createFeatureFlagsMiddleware(config: FeatureFlagsMiddlewareConfig): Middleware {
+export function createFeatureFlagsMiddleware<S = unknown>(
+  config: FeatureFlagsMiddlewareConfig<S>,
+): Middleware<object, S> {
   const remoteFlagsRef: RemoteFlagsRef = { current: {} };
-  return ({ dispatch }) => {
-    const { resolutionConfig, fetchRemoteFlags, refreshInterval } = config;
+  return ({ dispatch, getState }) => {
+    const { resolutionConfig, fetchRemoteFlags, refreshInterval, getAppLanguage } = config;
+    const readLang = () => getAppLanguage?.(getState());
+    let lastLang = readLang();
     if (fetchRemoteFlags) {
       let readyDispatched = false;
       const dispatchSync = () => dispatch(syncRemoteConfig());
@@ -58,17 +64,32 @@ export function createFeatureFlagsMiddleware(config: FeatureFlagsMiddlewareConfi
       );
     }
     return next => action => {
-      if (isAction(action) && action.type.startsWith("featureFlags/")) {
+      // Only plain actions can mutate state; thunks/functions dispatch actions that re-enter here.
+      if (!isAction(action)) return next(action);
+
+      if (action.type.startsWith("featureFlags/")) {
         return next({
           ...action,
           meta: {
             ...getMeta(action),
-            resolutionConfig,
+            resolutionConfig: getAppLanguage
+              ? { ...resolutionConfig, appLanguage: readLang() }
+              : resolutionConfig,
             remoteFlags: remoteFlagsRef.current,
           },
         });
       }
-      return next(action);
+
+      const result = next(action);
+      // Re-resolve when the language changes (resolution is event-driven).
+      if (getAppLanguage) {
+        const lang = readLang();
+        if (lang !== lastLang) {
+          lastLang = lang;
+          dispatch(syncRemoteConfig());
+        }
+      }
+      return result;
     };
   };
 }

--- a/shared/feature-flags/src/data/slice.test.ts
+++ b/shared/feature-flags/src/data/slice.test.ts
@@ -380,4 +380,34 @@ describe("middleware behavior", () => {
     });
     expect(store.getState().featureFlags.resolved.ptxCard.enabled).toBe(true);
   });
+
+  it("injects the current language from getAppLanguage and re-resolves when it changes", async () => {
+    let lang = "en";
+    const store = createStore(undefined, {
+      fetchRemoteFlags: () =>
+        Promise.resolve({ mockFeature: { enabled: true, languages_whitelisted: ["en"] } }),
+      getAppLanguage: () => lang,
+    });
+    await flushPromises();
+    expect(store.getState().featureFlags.resolved.mockFeature.enabled).toBe(true);
+
+    // A non-feature-flags action triggers the language-change check.
+    lang = "de";
+    store.dispatch({ type: "settings/setLanguage" });
+    const resolved = store.getState().featureFlags.resolved.mockFeature;
+    expect(resolved.enabled).toBe(false);
+    expect(resolved.enabledOverriddenForCurrentLanguage).toBe(true);
+  });
+
+  it("does not re-resolve when an unrelated action leaves the language unchanged", async () => {
+    const getAppLanguage = jest.fn(() => "en");
+    const store = createStore(undefined, {
+      fetchRemoteFlags: () => Promise.resolve({ mockFeature: { enabled: true } }),
+      getAppLanguage,
+    });
+    await flushPromises();
+    const before = store.getState().featureFlags.resolved;
+    store.dispatch({ type: "settings/somethingElse" });
+    expect(store.getState().featureFlags.resolved).toBe(before);
+  });
 });


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached. <!-- minor: @shared/feature-flags, live-mobile, ledger-live-desktop -->
- [x] **Covered by automatic tests.** `@shared/feature-flags` slice/utils tests + new middleware tests asserting it injects the current language into resolution and re-resolves remote flags when the language changes (whitelist disables under a non-matching language, re-enables on switch). `@shared` jest 83/83; `@shared` + LWM + LWD `typecheck` clean.
- [x] **Impact of the changes:** feature-flag **resolution** — language-gated remote flags now actually filter again. QA focus:
  - A remotely-configured flag with `languages_whitelisted`/`languages_blacklisted` resolves correctly for the current app language, and **re-resolves when the user changes language** (no reload needed), in both apps.
  - Flags without language constraints, local overrides, env (`FEATURE_FLAGS`) overrides, and version filtering are unchanged.

### 📝 Description

Feature-flag **language filtering** (`languages_whitelisted` / `languages_blacklisted`) has been **inert for every Redux-slice consumer** since the call-site migration (LIVE-30964): `resolveFeature` supports it (`applyLanguageFilter`), but resolution only applied it when `resolutionConfig.appLanguage` was set — and no app ever set it. The legacy live-common `getFeature({ appLanguage })` path applied it; once consumers moved to the slice, language gating was silently dropped. (Confirmed still used via Firebase Remote Config, so this is a real gap to close before the FF migration ships.)

**Fix** — let the middleware inject the language during resolution (it already builds the resolution context and has store access):

- **`@shared/feature-flags`**: `createFeatureFlagsMiddleware` takes an optional **`getAppLanguage`** selector. On every `featureFlags/*` action it injects the current language into `meta.resolutionConfig.appLanguage` (so resolution always uses the live value — boot-correct, no race), and it dispatches `syncRemoteConfig()` to re-resolve when the language changes. The language stays sourced from the app's own `settings` state — not duplicated into the slice. `appLanguage` stays part of `ResolutionConfig` (it is resolution context, now supplied by the middleware).
- **LWM + LWD (`configureStore.ts`)**: pass `getAppLanguage: languageSelector` to `createFeatureFlagsMiddleware`. No app-level effect or extra slice state needed.

**Why the middleware, not slice state** (the earlier approach on this branch): resolution is event-driven — the pure reducers re-resolve only on `featureFlags/*` actions. The middleware is the single place that already owns the resolution context and can read the app's language via `getState()`, so it can both inject the live value and detect a change. A language change reaches it because the language only mutates via a dispatched `setLanguage` action, which every middleware observes — no `lang` field, no `setFeatureFlagsLang` action, no root `useEffect`, no duplicated state.

Independent of the Phase B PRs (#18137 LWM, #18168 LWD): this gap is already live on `develop` for the migrated direct consumers, so it lands on its own branch and benefits both the direct consumers and the live-common Context bridge.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31804](https://ledgerhq.atlassian.net/browse/LIVE-31804)
- Surfaced by automated review on #18137 (thread on `FeatureFlagsContextBridge` / `datadogUtils`); resolves the same concern for #18168.
- **ADR link (if any)**: `Phase 1 - Feature Flags` (Data Architecture vault)

[LIVE-31804]: https://ledgerhq.atlassian.net/browse/LIVE-31804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
