### PR TITLE
[LWDM] fix: format market price chart hover date by range

### DIFF
--- a/.changeset/fix-asset-detail-hover-date-formatting.md
+++ b/.changeset/fix-asset-detail-hover-date-formatting.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Fix asset detail market price hover date formatting by range to match spec without changing chart axis formatting.

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/__tests__/useMarketPriceSectionViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/__tests__/useMarketPriceSectionViewModel.test.ts
@@ -94,6 +94,102 @@ describe("useMarketPriceSectionViewModel", () => {
     expect(result.current.scrubbedDateLabel).toContain("2024");
   });
 
+  it("formats 1w scrubbed date as time + date", () => {
+    const { result } = renderHook(
+      () =>
+        useMarketPriceSectionViewModel({
+          ledgerId: "bitcoin",
+          marketData,
+          isDistributionLoading: false,
+          selectedRange: "1w",
+        }),
+      {
+        initialState: { settings: { counterValue: "USD", locale: "en-US" } },
+        wrapper: makeScrubWrapper({
+          price: 250,
+          timestamp: Date.UTC(2024, 0, 2, 13, 45),
+          percentage: 1.5,
+          variationFiat: 150,
+        }),
+      },
+    );
+
+    expect(result.current.scrubbedDateLabel).toContain("2024");
+    expect(result.current.scrubbedDateLabel).toContain(":");
+  });
+
+  it("formats 6m scrubbed date as time + date", () => {
+    const { result } = renderHook(
+      () =>
+        useMarketPriceSectionViewModel({
+          ledgerId: "bitcoin",
+          marketData,
+          isDistributionLoading: false,
+          selectedRange: "6m",
+        }),
+      {
+        initialState: { settings: { counterValue: "USD", locale: "en-US" } },
+        wrapper: makeScrubWrapper({
+          price: 250,
+          timestamp: Date.UTC(2024, 0, 2, 13, 45),
+          percentage: 1.5,
+          variationFiat: 150,
+        }),
+      },
+    );
+
+    expect(result.current.scrubbedDateLabel).toContain("2024");
+    expect(result.current.scrubbedDateLabel).toContain(":");
+  });
+
+  it("formats 1d scrubbed date as time only", () => {
+    const { result } = renderHook(
+      () =>
+        useMarketPriceSectionViewModel({
+          ledgerId: "bitcoin",
+          marketData,
+          isDistributionLoading: false,
+          selectedRange: "1d",
+        }),
+      {
+        initialState: { settings: { counterValue: "USD", locale: "en-US" } },
+        wrapper: makeScrubWrapper({
+          price: 250,
+          timestamp: Date.UTC(2024, 0, 2, 13, 45),
+          percentage: 1.5,
+          variationFiat: 150,
+        }),
+      },
+    );
+
+    expect(result.current.scrubbedDateLabel).toContain(":");
+    expect(result.current.scrubbedDateLabel).not.toContain("2024");
+  });
+
+  it("formats 1y scrubbed date as date only", () => {
+    const { result } = renderHook(
+      () =>
+        useMarketPriceSectionViewModel({
+          ledgerId: "bitcoin",
+          marketData,
+          isDistributionLoading: false,
+          selectedRange: "1y",
+        }),
+      {
+        initialState: { settings: { counterValue: "USD", locale: "en-US" } },
+        wrapper: makeScrubWrapper({
+          price: 250,
+          timestamp: Date.UTC(2024, 0, 2, 13, 45),
+          percentage: 1.5,
+          variationFiat: 150,
+        }),
+      },
+    );
+
+    expect(result.current.scrubbedDateLabel).toContain("2024");
+    expect(result.current.scrubbedDateLabel).not.toContain(":");
+  });
+
   it("treats a scrubbed price of 0 as scrubbing (not a missing value)", () => {
     const { result } = renderHook(
       () =>

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/useMarketPriceSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/useMarketPriceSectionViewModel.ts
@@ -9,6 +9,12 @@ import type { LineChartRange } from "LLD/components/LineChart";
 import { useTranslation } from "react-i18next";
 import { counterValueCurrencySelector, localeSelector } from "~/renderer/reducers/settings";
 import {
+  dayAndHourFormat,
+  dayFormat,
+  hourFormat,
+  useDateFormatter,
+} from "~/renderer/hooks/useDateFormatter";
+import {
   clampDayChangePercentPointsNearZero,
   getFiatPriceVariationFromPercentChange,
   getPriceChangeKeyForRange,
@@ -16,7 +22,6 @@ import {
   resolveTrendPercentAndVariant,
 } from "./utils";
 import { resolveAssetDetailSectionLoading } from "../../utils/resolveAssetDetailSectionLoading";
-import { useAssetChartDateFormatter } from "../../hooks/useAssetChartDateFormatter";
 import { useScrubbedPrice } from "../../context/ScrubbedPriceContext";
 
 type UseMarketPriceSectionViewModelProps = Readonly<{
@@ -52,6 +57,8 @@ const RANGE_I18N_KEY: Record<LineChartRange, string> = {
   "5y": "assetDetails.fiveYears",
   all: "assetDetails.allTime",
 };
+
+const HOVER_RANGE_WITH_TIME_AND_DATE = new Set<LineChartRange>(["1w", "1m", "6m"]);
 
 export function useMarketPriceSectionViewModel({
   distributionItem,
@@ -118,8 +125,18 @@ export function useMarketPriceSectionViewModel({
     trendPercentageText,
     trendVariant,
   });
-
-  const formatDate = useAssetChartDateFormatter(selectedRange);
+  const formatHoverTime = useDateFormatter(hourFormat);
+  const formatHoverDay = useDateFormatter(dayFormat);
+  const formatHoverDateTime = useDateFormatter(dayAndHourFormat);
+  const formatHoverDate = useCallback(
+    (ms: number) => {
+      const date = new Date(ms);
+      if (selectedRange === "1d") return formatHoverTime(date);
+      if (HOVER_RANGE_WITH_TIME_AND_DATE.has(selectedRange)) return formatHoverDateTime(date);
+      return formatHoverDay(date);
+    },
+    [formatHoverDay, formatHoverDateTime, formatHoverTime, selectedRange],
+  );
 
   let priceValue: number | undefined;
   if (isScrubbing) {
@@ -141,7 +158,7 @@ export function useMarketPriceSectionViewModel({
     hasPriceData,
     hasVariationData,
     isScrubbing,
-    scrubbedDateLabel: isScrubbing ? formatDate(selection.timestamp) : undefined,
+    scrubbedDateLabel: isScrubbing ? formatHoverDate(selection.timestamp) : undefined,
   };
 }
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/useBalanceGraphViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/useBalanceGraphViewModel.test.ts
@@ -44,24 +44,24 @@ const eursToken: TokenCurrency = {
 
 const CHART_DATA_BY_RANGE: Record<RangeKey, Array<[number, number]>> = {
   "1d": [
-    [1, 100],
-    [2, 110],
-    [3, 120],
+    [Date.UTC(2024, 0, 2, 10, 0), 100],
+    [Date.UTC(2024, 0, 2, 11, 0), 110],
+    [Date.UTC(2024, 0, 2, 12, 0), 120],
   ],
   "1w": [
-    [1, 200],
-    [2, 210],
+    [Date.UTC(2024, 0, 2, 10, 0), 200],
+    [Date.UTC(2024, 0, 2, 11, 0), 210],
   ],
-  "1m": [[1, 300]],
+  "1m": [[Date.UTC(2024, 0, 2, 10, 0), 300]],
   "1y": [
-    [1, 400],
-    [2, 410],
-    [3, 420],
-    [4, 430],
+    [Date.UTC(2024, 0, 2, 10, 0), 400],
+    [Date.UTC(2024, 0, 2, 11, 0), 410],
+    [Date.UTC(2024, 0, 2, 12, 0), 420],
+    [Date.UTC(2024, 0, 2, 13, 0), 430],
   ],
   all: [
-    [1, 100],
-    [2, 220],
+    [Date.UTC(2024, 0, 2, 10, 0), 100],
+    [Date.UTC(2024, 0, 2, 11, 0), 220],
   ],
 };
 
@@ -550,6 +550,36 @@ describe("useBalanceGraphViewModel", () => {
 
       expect(result.current.isScrubbing).toBe(false);
       expect(result.current.price).toBe(50000);
+    });
+
+    it("formats 1w hover time label as time + date", () => {
+      const { result } = renderVM();
+
+      act(() => result.current.onRangeChange("1w"));
+      act(() => result.current.onScrubberPositionChange(0));
+
+      expect(result.current.timeLabel).toContain("2024");
+      expect(result.current.timeLabel).toContain(":");
+    });
+
+    it("formats 1d hover time label as time only", () => {
+      const { result } = renderVM();
+
+      act(() => result.current.onRangeChange("1d"));
+      act(() => result.current.onScrubberPositionChange(0));
+
+      expect(result.current.timeLabel).toContain(":");
+      expect(result.current.timeLabel).not.toContain("2024");
+    });
+
+    it("formats 1y hover time label as date only", () => {
+      const { result } = renderVM();
+
+      act(() => result.current.onRangeChange("1y"));
+      act(() => result.current.onScrubberPositionChange(0));
+
+      expect(result.current.timeLabel).toContain("2024");
+      expect(result.current.timeLabel).not.toContain(":");
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
@@ -58,6 +58,9 @@ const TRANSACTION_DOTS_MAX_OPERATIONS = 1000;
 
 const MIN_X_AXIS_TICKS = 5;
 const MIN_X_AXIS_TICKS_1D = 8;
+// Keep formatter mapping aligned with desktop. Mobile currently surfaces
+// 1d/1w/1m/1y/all, but we keep 6m in the formatter bucket for parity.
+const HOVER_RANGE_WITH_TIME_AND_DATE: ReadonlySet<string> = new Set(["1w", "1m", "6m"]);
 
 /**
  * Asymmetric padding added to the y-axis domain (as a ratio of the value range).
@@ -307,8 +310,8 @@ export function useBalanceGraphViewModel({
     [counterValueUnit, locale],
   );
 
-  // Mirror desktop's `hourFormat` / `dayFormat`: intraday shows the time, longer
-  // ranges show the full numeric day/month/year (e.g. "5/29/2026").
+  // Keep chart axis/tooltip formatting compact: intraday shows time, longer
+  // ranges show date only. Header hover format has a separate formatter below.
   const dateFormatters = useMemo(
     () => ({
       hour: new Intl.DateTimeFormat(locale, { hour: "numeric", minute: "numeric" }),
@@ -325,8 +328,32 @@ export function useBalanceGraphViewModel({
     [range, dateFormatters],
   );
 
+  const hoverDateFormatters = useMemo(
+    () => ({
+      time: dateFormatters.hour,
+      date: dateFormatters.day,
+      dateTime: new Intl.DateTimeFormat(locale, {
+        hour: "numeric",
+        minute: "numeric",
+        day: "numeric",
+        month: "numeric",
+        year: "numeric",
+      }),
+    }),
+    [dateFormatters.hour, dateFormatters.day, locale],
+  );
+  const formatHoverDate = useCallback(
+    (date: Date) => {
+      if (range === "1d") return hoverDateFormatters.time.format(date);
+      if (HOVER_RANGE_WITH_TIME_AND_DATE.has(range))
+        return hoverDateFormatters.dateTime.format(date);
+      return hoverDateFormatters.date.format(date);
+    },
+    [range, hoverDateFormatters],
+  );
+
   const scrubbedDateLabel =
-    selection != null ? formatDate(new Date(selection.timestamp)) : undefined;
+    selection != null ? formatHoverDate(new Date(selection.timestamp)) : undefined;
 
   // While scrubbing, the trend reflects the change from the start of the selected
   // range up to the scrubbed point (the line color stays tied to the range below).


### PR DESCRIPTION
Adjusts the date and time format displayed when scrubbing the market price chart on Asset Detail screens for both desktop and mobile. Formatting now varies by selected range (e.g., 1d shows time, 1w/1m/6m show time+date, others show date only) to match design specifications without altering chart axis formatting.

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request updates the formatting of the date labels shown when hovering or scrubbing over asset detail charts, ensuring they match the product specification for both desktop and mobile without affecting the chart axis formatting. The changes also include improved test coverage for these formatting behaviors.

**Date hover/scrub formatting improvements:**

* Refactored the date formatting logic for hover labels in the asset detail market price section on desktop, using new `Intl.DateTimeFormat` formatters to ensure:
  - "1d" range shows only the time,
  - "1w", "1m", "6m" ranges show both time and date,
  - "1y" and "all" ranges show only the date.  


* Made equivalent updates for hover date formatting in the balance graph on mobile, introducing consistent logic and formatters for different ranges.  

**Test coverage enhancements:**

* Added new unit tests for both desktop and mobile to verify the correct hover/scrub date formats are applied for "1d", "1w", and "1y" ranges.  

**Test data improvements:**

* Updated test chart data to use realistic UTC timestamps instead of arbitrary numbers, ensuring accurate date formatting in tests.  


https://github.com/user-attachments/assets/14bac813-fd56-47db-8fde-17513f3a02c9



### ❓ Context

[LIVE-31778](https://ledgerhq.atlassian.net/browse/LIVE-31778)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31778]: https://ledgerhq.atlassian.net/browse/LIVE-31778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ