### PR TITLE
Release lwm 260529 zcash live 31792

### DIFF
--- a/.changeset/new-cameras-serve.md
+++ b/.changeset/new-cameras-serve.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix Zcash consensus branch ID by adding NU6.2 activation height

--- a/.changeset/zcash-nu62-branchid-fix.md
+++ b/.changeset/zcash-nu62-branchid-fix.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/hw-app-btc": minor
+---
+
+Fix Zcash consensus branch ID by adding NU6.2 activation height

--- a/libs/ledgerjs/packages/hw-app-btc/src/constants.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/constants.ts
@@ -20,6 +20,8 @@ export const OP_RETURN = 0x6a;
 export const ZCASH_ACTIVATION_HEIGHTS = {
   // https://zcash.readthedocs.io/en/latest/rtd_pages/nu_dev_guide.html
   //
+  // https://z.cash/upgrade/nu6.2/
+  NU6_2: 3364600,
   // https://zips.z.cash/zip-0255
   // https://github.com/zcash/zcash/releases/tag/v6.10.0
   NU6_1: 3146400,

--- a/libs/ledgerjs/packages/hw-app-btc/src/createTransaction.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/createTransaction.ts
@@ -38,8 +38,10 @@ const defaultsSignTransaction = {
 
 export const getZcashBranchId = (blockHeight: number | null | undefined): Buffer => {
   const branchId = Buffer.alloc(4);
-  if (!blockHeight || blockHeight >= ZCASH_ACTIVATION_HEIGHTS.NU6_1) {
+  if (!blockHeight || blockHeight >= ZCASH_ACTIVATION_HEIGHTS.NU6_2) {
     // NOTE: null and undefined should default to latest version
+    branchId.writeUInt32LE(0x5437f330, 0);
+  } else if (blockHeight >= ZCASH_ACTIVATION_HEIGHTS.NU6_1) {
     branchId.writeUInt32LE(0x4dec4df0, 0);
   } else if (blockHeight >= ZCASH_ACTIVATION_HEIGHTS.NU6) {
     branchId.writeUInt32LE(0xc8e71055, 0);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Zcash has fixed vulnerability on the blockchain that requires branch ID update on Ledger Wallet side to NU 6.2:
New branch id: 0x5437f330
Activation block: 3,364,600

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:  [LIVE-31792](https://ledgerhq.atlassian.net/browse/LIVE-31792)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31792]: https://ledgerhq.atlassian.net/browse/LIVE-31792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ