### PR TITLE
[LWM] feat(mobile): add marketListConfig RTK slice

### DIFF
--- a/.changeset/market-list-config-slice.md
+++ b/.changeset/market-list-config-slice.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add the v4 `marketListConfig` RTK slice (sorting, timeframe, network, category) shared by the Market screen and the modular asset drawer. Persisted as a user preference (never reset). Gated by the asset discoverability feature flag.

--- a/apps/ledger-live-mobile/src/components/DBSave.ts
+++ b/apps/ledger-live-mobile/src/components/DBSave.ts
@@ -18,6 +18,7 @@ import {
   saveKnownDevices,
   saveLargeMoverState,
   saveMarketState,
+  saveMarketListConfig,
   savePostOnboardingState,
   saveSettings,
   saveTrustchainState,
@@ -28,7 +29,7 @@ import { countervaluesStateSelector } from "~/reducers/countervalues";
 import { exportSelector as bleSelector } from "~/reducers/ble";
 import { exportSelector as knownDevicesExportSelector } from "~/reducers/knownDevices";
 import { exportLargeMoverSelector } from "~/reducers/largeMover";
-import { exportMarketSelector } from "~/reducers/market";
+import { exportMarketSelector, exportMarketListConfigSelector } from "~/reducers/market";
 import { settingsStoreSelector } from "~/reducers/settings";
 import type { State } from "~/reducers/types";
 import { walletSelector } from "~/reducers/wallet";
@@ -174,6 +175,7 @@ const getPostOnboardingStateChanged = (a: State, b: State) =>
   !isEqual(a.postOnboarding, b.postOnboarding);
 
 const marketNotEquals = (a: State, b: State) => a.market !== b.market;
+const marketListConfigNotEquals = (a: State, b: State) => a.marketListConfig !== b.marketListConfig;
 const trustchainNotEquals = (a: State, b: State) => a.trustchain !== b.trustchain;
 const compareWalletState = (a: State, b: State) =>
   walletStateExportShouldDiffer(a.wallet, b.wallet);
@@ -257,6 +259,14 @@ export const ConfigureDBSaveEffects = () => {
     throttle: 500,
     getChangesStats: marketNotEquals,
     lense: exportMarketSelector,
+  });
+
+  useDBSaveEffect({
+    stateSelector: (state: State) => state.marketListConfig,
+    save: saveMarketListConfig,
+    throttle: 500,
+    getChangesStats: marketListConfigNotEquals,
+    lense: exportMarketListConfigSelector,
   });
 
   useDBSaveEffect({

--- a/apps/ledger-live-mobile/src/context/LedgerStore.tsx
+++ b/apps/ledger-live-mobile/src/context/LedgerStore.tsx
@@ -26,6 +26,7 @@ import {
   getPostOnboardingState,
   getProtect,
   getMarketState,
+  getMarketListConfig,
   getTrustchainState,
   getWalletExportState,
   getLargeMoverState,
@@ -40,6 +41,7 @@ import { updateProtectData, updateProtectStatus } from "~/actions/protect";
 import { INITIAL_STATE as settingsState } from "~/reducers/settings";
 import { listCachedCurrencyIds, hydrateCurrency } from "~/bridge/cache";
 import { importMarket } from "~/actions/market";
+import { importMarketListConfig } from "~/reducers/market";
 import { importTrustchainStoreState } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { importWalletState } from "@ledgerhq/live-wallet/store";
 import { importLargeMoverState } from "~/actions/largeMoverLandingPage";
@@ -96,6 +98,7 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
         accountsData,
         postOnboardingState,
         marketState,
+        marketListConfigState,
         trustchainStore,
         walletStore,
         protect,
@@ -113,6 +116,7 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
         retry(getAccounts, MAX_RETRIES, RETRY_DELAY),
         retry(getPostOnboardingState, MAX_RETRIES, RETRY_DELAY),
         retry(getMarketState, MAX_RETRIES, RETRY_DELAY),
+        retry(getMarketListConfig, MAX_RETRIES, RETRY_DELAY),
         retry(getTrustchainState, MAX_RETRIES, RETRY_DELAY),
         retry(getWalletExportState, MAX_RETRIES, RETRY_DELAY),
         retry(getProtect, MAX_RETRIES, RETRY_DELAY),
@@ -168,6 +172,10 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
 
       if (marketState) {
         store.dispatch(importMarket(marketState));
+      }
+
+      if (marketListConfigState) {
+        store.dispatch(importMarketListConfig(marketListConfigState));
       }
 
       if (trustchainStore) {

--- a/apps/ledger-live-mobile/src/db.ts
+++ b/apps/ledger-live-mobile/src/db.ts
@@ -11,6 +11,7 @@ import { useCallback } from "react";
 import storage from "LLM/storage";
 import type { User } from "./types/store";
 import type {
+  MarketListConfigState,
   BleState,
   LargeMoverState,
   MarketState,
@@ -278,6 +279,14 @@ export function getMarketState(): Promise<MarketState> {
 
 export async function saveMarketState(obj: MarketState): Promise<void> {
   await storage.save("market", obj);
+}
+
+export function getMarketListConfig(): Promise<MarketListConfigState | null> {
+  return storage.get("marketListConfig") as Promise<MarketListConfigState | null>;
+}
+
+export async function saveMarketListConfig(obj: MarketListConfigState): Promise<void> {
+  await storage.save("marketListConfig", obj);
 }
 
 export function getTrustchainState(): Promise<TrustchainStore> {

--- a/apps/ledger-live-mobile/src/reducers/__tests__/marketListConfig.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/__tests__/marketListConfig.test.ts
@@ -1,0 +1,64 @@
+import {
+  MARKET_LIST_CONFIG_INITIAL_STATE,
+  marketListConfigReducer,
+  importMarketListConfig,
+  selectMarketListCategory,
+  selectMarketListNetwork,
+  selectMarketListSorting,
+  selectMarketListTimeframe,
+  setMarketListCategory,
+  setMarketListNetwork,
+  setMarketListSorting,
+  setMarketListTimeframe,
+} from "../market";
+import type { MarketListConfigState, State } from "../types";
+
+const asState = (marketListConfig: MarketListConfigState = MARKET_LIST_CONFIG_INITIAL_STATE) =>
+  ({ marketListConfig }) as State;
+
+describe("marketListConfig slice", () => {
+  it("exposes the documented defaults through its selectors", () => {
+    expect(selectMarketListSorting(asState())).toBe("marketCap");
+    expect(selectMarketListTimeframe(asState())).toBe("1D");
+    expect(selectMarketListNetwork(asState())).toBeUndefined();
+    expect(selectMarketListCategory(asState())).toBe("all");
+  });
+
+  it("updates each preference through its action", () => {
+    let state = marketListConfigReducer(undefined, setMarketListSorting("volume"));
+    expect(state.sorting).toBe("volume");
+
+    state = marketListConfigReducer(state, setMarketListTimeframe("7D"));
+    expect(state.timeframe).toBe("7D");
+
+    state = marketListConfigReducer(state, setMarketListNetwork("ethereum"));
+    expect(state.network).toBe("ethereum");
+
+    state = marketListConfigReducer(state, setMarketListCategory("starred"));
+    expect(state.category).toBe("starred");
+  });
+
+  it("resets the network back to all networks", () => {
+    const withNetwork = marketListConfigReducer(undefined, setMarketListNetwork("ethereum"));
+    const reset = marketListConfigReducer(withNetwork, setMarketListNetwork(undefined));
+    expect(reset.network).toBeUndefined();
+  });
+
+  it("rehydrates a persisted payload on top of the defaults", () => {
+    const state = marketListConfigReducer(
+      undefined,
+      importMarketListConfig({
+        sorting: "gainers",
+        timeframe: "1Y",
+        network: "bitcoin",
+        category: "stocks",
+      }),
+    );
+    expect(state).toEqual({
+      sorting: "gainers",
+      timeframe: "1Y",
+      network: "bitcoin",
+      category: "stocks",
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/reducers/index.ts
+++ b/apps/ledger-live-mobile/src/reducers/index.ts
@@ -16,7 +16,7 @@ import history from "./history";
 import inView from "./inView";
 import knownDevices from "./knownDevices";
 import largeMover from "./largeMover";
-import market from "./market";
+import market, { marketListConfigReducer } from "./market";
 import modularDrawer from "./modularDrawer";
 import receiveOptionsDrawer from "./receiveOptionsDrawer";
 import rebornBuyDeviceDrawer from "./rebornBuyDeviceDrawer";
@@ -58,6 +58,7 @@ const appReducer = combineReducers({
   knownDevices,
   largeMover,
   market,
+  marketListConfig: marketListConfigReducer,
   modularDrawer,
   receiveOptionsDrawer,
   rebornBuyDeviceDrawer,

--- a/apps/ledger-live-mobile/src/reducers/market.ts
+++ b/apps/ledger-live-mobile/src/reducers/market.ts
@@ -1,5 +1,13 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import { Action, ReducerMap, handleActions } from "redux-actions";
-import { MarketState, State } from "./types";
+import {
+  MarketListCategory,
+  MarketListConfigState,
+  MarketListSorting,
+  MarketListTimeframe,
+  MarketState,
+  State,
+} from "./types";
 import {
   MarketSetCurrentPagePayload,
   MarketSetMarketFilterByStarredCurrenciesPayload,
@@ -13,6 +21,7 @@ import { Order } from "@ledgerhq/live-common/market/utils/types";
 
 export const LIMIT = 20;
 
+/** @legacy MarketList (v3) state — will be removed when MarketList is dropped. Use marketListConfigSlice for v4. */
 export const INITIAL_STATE: MarketState = {
   marketParams: {
     range: "24h",
@@ -29,6 +38,7 @@ export const INITIAL_STATE: MarketState = {
   hideTransactionsOnChart: false,
 };
 
+/** @legacy MarketList (v3) handlers — will be removed when MarketList is dropped. Use marketListConfigSlice for v4. */
 const handlers: ReducerMap<MarketState, MarketPayload> = {
   [MarketStateActionTypes.SET_MARKET_REQUEST_PARAMS]: (state, action) => ({
     ...state,
@@ -85,3 +95,59 @@ export const exportMarketSelector = (s: State) => s.market;
 // Exporting reducer
 
 export default handleActions<MarketState, MarketPayload>(handlers, INITIAL_STATE);
+
+/**
+ * V4 asset list config — shared between MarketScreen and modularAssetDrawer.
+ * Gated by llmAssetDiscoverability. Persisted as a user preference (never reset).
+ */
+export const MARKET_LIST_CONFIG_INITIAL_STATE: MarketListConfigState = {
+  sorting: "marketCap",
+  timeframe: "1D",
+  network: undefined,
+  category: "all",
+};
+
+const marketListConfigSlice = createSlice({
+  name: "marketListConfig",
+  initialState: MARKET_LIST_CONFIG_INITIAL_STATE,
+  reducers: {
+    setMarketListSorting: (state, action: PayloadAction<MarketListSorting>) => {
+      state.sorting = action.payload;
+    },
+    setMarketListTimeframe: (state, action: PayloadAction<MarketListTimeframe>) => {
+      state.timeframe = action.payload;
+    },
+    setMarketListNetwork: (state, action: PayloadAction<string | undefined>) => {
+      state.network = action.payload;
+    },
+    setMarketListCategory: (state, action: PayloadAction<MarketListCategory>) => {
+      state.category = action.payload;
+    },
+    importMarketListConfig: (_state, action: PayloadAction<MarketListConfigState>) => ({
+      ...MARKET_LIST_CONFIG_INITIAL_STATE,
+      ...action.payload,
+    }),
+  },
+});
+
+export const {
+  setMarketListSorting,
+  setMarketListTimeframe,
+  setMarketListNetwork,
+  setMarketListCategory,
+  importMarketListConfig,
+} = marketListConfigSlice.actions;
+
+export const selectMarketListSorting = (state: State): MarketListSorting =>
+  state.marketListConfig.sorting;
+export const selectMarketListTimeframe = (state: State): MarketListTimeframe =>
+  state.marketListConfig.timeframe;
+export const selectMarketListNetwork = (state: State): string | undefined =>
+  state.marketListConfig.network;
+export const selectMarketListCategory = (state: State): MarketListCategory =>
+  state.marketListConfig.category;
+
+export const exportMarketListConfigSelector = (state: State): MarketListConfigState =>
+  state.marketListConfig;
+
+export const marketListConfigReducer = marketListConfigSlice.reducer;

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -382,6 +382,20 @@ export type MarketState = {
   hideTransactionsOnChart: boolean;
 };
 
+// === ASSET LIST CONFIG STATE (V4) ===
+
+export type MarketListSorting = "marketCap" | "volume" | "gainers" | "losers";
+export type MarketListTimeframe = "1D" | "7D" | "30D" | "1Y" | "all";
+export type MarketListCategory = "all" | "starred" | "stocks";
+
+export type MarketListConfigState = {
+  sorting: MarketListSorting;
+  timeframe: MarketListTimeframe;
+  /** Selected network id, or `undefined` for all networks (consumed by LIVE-29972). */
+  network: string | undefined;
+  category: MarketListCategory;
+};
+
 // === WALLETSYNC STATE ===
 
 export type WalletSyncState = {
@@ -423,6 +437,7 @@ export type State = LLMRTKApiState & {
   knownDevices: KnownDevicesState;
   largeMover: LargeMoverState;
   market: MarketState;
+  marketListConfig: MarketListConfigState;
   modularDrawer: ModularDrawerState;
   receiveOptionsDrawer: ReceiveOptionsDrawerState;
   rebornBuyDeviceDrawer: RebornBuyDeviceDrawerState;


### PR DESCRIPTION
> **Stacked on #18182** (base branch: `feat/live-30034-market-assets-list`). Review/merge that PR first.

### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - New `marketListConfig` Redux slice (pure data layer, no UI) — sorting / timeframe / network / category
  - Persistence wiring (DBSave + startup hydration) — verify the preference survives an app restart and is never reset
  - No behavioural change to the legacy `market` (v3) reducer

### 📝 Description

Creates the v4 `marketListConfig` RTK slice — the shared data layer that unblocks the filter BottomSheet, search bar, category switcher, Stocks category and deeplink tasks.

- Slice added to the existing `src/reducers/market.ts` (the legacy v3 reducer is annotated `@legacy`).
- State: `{ sorting: "marketCap", timeframe: "1D", network: undefined, category: "all" }`.
- Actions: `setMarketListSorting`, `setMarketListTimeframe`, `setMarketListNetwork`, `setMarketListCategory`, `importMarketListConfig`.
- Selectors: `selectMarketListSorting`, `selectMarketListTimeframe`, `selectMarketListNetwork`, `selectMarketListCategory`.
- Registered in the root reducer as `marketListConfig` and added to the `State` type.
- Persisted as a user preference via the existing `DBSave` mechanism and rehydrated at startup (`LedgerStore`), so it never resets.

> Naming note: the spec called this `AssetListConfig`; renamed to `marketListConfig` to avoid confusion with the generic `AssetListItem` / MAD "asset" naming.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30035](https://ledgerhq.atlassian.net/browse/LIVE-30035)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.


[LIVE-30035]: https://ledgerhq.atlassian.net/browse/LIVE-30035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ