### PR TITLE
[LWDM] chore(lumen): bump lumen design-system packages & crypto-icons

### DIFF
--- a/.changeset/lumen-bump-live-31810.md
+++ b/.changeset/lumen-bump-live-31810.md
@@ -1,0 +1,13 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Bump Lumen design-system packages: `lumen-design-core` 0.1.16, `lumen-ui-react` 0.1.37, `lumen-ui-rnative` 0.1.38, `lumen-ui-react-visualization` 0.1.16, `lumen-ui-rnative-visualization` 0.1.15, and `crypto-icons` 2.0.4.
+
+Migrations required by the breaking changes in the range:
+
+- **Menu (Radix UI → Base UI, react 0.1.36):** migrated `MenuTrigger asChild` → `render={...}` in the AssetDetail options/chart menus, the Send network-fees and fee-asset selectors.
+- **NavBar (react 0.1.36):** renamed `NavBarCoinCapsule`'s `icon` prop to `leadingContent` on the desktop asset header.
+- **DotIndicator (rnative/react):** size scale was renamed and rescaled. Remapped consumers to preserve the rendered size (`xs`→`lg`, default→`xl`) on the desktop unread indicators and mobile top-bar unread indicator.
+- **Select removal (rnative 0.1.38):** removed the now-deleted `GlobalSelectBottomSheet` from the mobile providers (no `Select` consumers remained).

--- a/.changeset/lumen-bump-live-31810.md
+++ b/.changeset/lumen-bump-live-31810.md
@@ -7,7 +7,7 @@ Bump Lumen design-system packages: `lumen-design-core` 0.1.16, `lumen-ui-react` 
 
 Migrations required by the breaking changes in the range:
 
-- **Menu (Radix UI → Base UI, react 0.1.36):** migrated `MenuTrigger asChild` → `render={...}` in the AssetDetail options/chart menus, the Send network-fees and fee-asset selectors.
+- **Menu (Radix UI → Base UI, react 0.1.36):** migrated `MenuTrigger asChild` → `render={...}` and `MenuItem onSelect` → `onClick` (Base UI fires `onClick`, not `onSelect`) in the AssetDetail options/chart menus and the Send network-fees / fee-asset selectors.
 - **NavBar (react 0.1.36):** renamed `NavBarCoinCapsule`'s `icon` prop to `leadingContent` on the desktop asset header.
 - **DotIndicator (rnative/react):** size scale was renamed and rescaled. Remapped consumers to preserve the rendered size (`xs`→`lg`, default→`xl`) on the desktop unread indicators and mobile top-bar unread indicator.
 - **Select removal (rnative 0.1.38):** removed the now-deleted `GlobalSelectBottomSheet` from the mobile providers (no `Select` consumers remained).

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -112,7 +112,6 @@
     "@noble/curves": "1.9.7",
     "@radix-ui/react-checkbox": "catalog:",
     "@radix-ui/react-dialog": "catalog:",
-    "@radix-ui/react-dropdown-menu": "catalog:",
     "@radix-ui/react-slot": "catalog:",
     "@radix-ui/react-switch": "catalog:",
     "@radix-ui/react-tooltip": "catalog:",

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/HistoryButton.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/HistoryButton.tsx
@@ -17,7 +17,7 @@ export function HistoryButton() {
   );
 
   return hasUnread ? (
-    <DotIndicator appearance="red" size="xs" data-testid="unread-indicator">
+    <DotIndicator appearance="red" size="lg" data-testid="unread-indicator">
       {button}
     </DotIndicator>
   ) : (

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/__integrations__/AssetDetail.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/__integrations__/AssetDetail.integration.test.tsx
@@ -584,7 +584,7 @@ describe("AssetDetail integration", () => {
 
       await user.click(screen.getByTestId(TEST_ID.HEADER_OPTIONS));
 
-      expect(screen.getByRole("menuitem", { name: /add to favorites/i })).toBeVisible();
+      expect(await screen.findByRole("menuitem", { name: /add to favorites/i })).toBeVisible();
       expect(screen.getByRole("menuitem", { name: /hide from portfolio/i })).toBeVisible();
     });
 
@@ -600,7 +600,7 @@ describe("AssetDetail integration", () => {
 
       await user.click(screen.getByTestId(TEST_ID.HEADER_OPTIONS));
 
-      expect(screen.getByRole("menuitem", { name: /hide from portfolio/i })).toBeVisible();
+      expect(await screen.findByRole("menuitem", { name: /hide from portfolio/i })).toBeVisible();
     });
 
     it("USDC - enables the favorite action and stores the coingecko id when toggled", async () => {
@@ -654,7 +654,7 @@ describe("AssetDetail integration", () => {
 
       await user.click(screen.getByTestId(TEST_ID.HEADER_OPTIONS));
 
-      expect(screen.getByRole("menuitem", { name: /show in portfolio/i })).toBeVisible();
+      expect(await screen.findByRole("menuitem", { name: /show in portfolio/i })).toBeVisible();
     });
 
     it("renders the hidden banner when the asset is blacklisted and unhides it from the banner action", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AssetHeader/AssetHeaderView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AssetHeader/AssetHeaderView.tsx
@@ -36,7 +36,11 @@ export function AssetHeaderView({
       className="sticky top-0 z-20 w-full min-w-0 items-center gap-4 bg-canvas pb-12"
     >
       <NavBarBackButton onClick={onBack} />
-      <NavBarCoinCapsule className="min-w-0 max-w-full" ticker={assetTicker} icon={icon} />
+      <NavBarCoinCapsule
+        className="min-w-0 max-w-full"
+        ticker={assetTicker}
+        leadingContent={icon}
+      />
       <NavBarTrailing className="overflow-visible">
         {ledgerCurrency ? (
           <OptionsMenu

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/ChartOptionsMenu/ChartOptionsMenuView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/ChartOptionsMenu/ChartOptionsMenuView.tsx
@@ -12,15 +12,17 @@ export function ChartOptionsMenuView({ viewModel }: ChartOptionsMenuViewProps) {
 
   return (
     <Menu>
-      <MenuTrigger asChild>
-        <IconButton
-          appearance="no-background"
-          size="xs"
-          icon={SettingsAlt2}
-          aria-label={optionsAriaLabel}
-          data-testid="asset-detail-chart-options-trigger"
-        />
-      </MenuTrigger>
+      <MenuTrigger
+        render={
+          <IconButton
+            appearance="no-background"
+            size="xs"
+            icon={SettingsAlt2}
+            aria-label={optionsAriaLabel}
+            data-testid="asset-detail-chart-options-trigger"
+          />
+        }
+      />
       <MenuContent className="w-full min-w-200" side="bottom" align="end">
         <MenuItem
           onSelect={() => {

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/ChartOptionsMenu/ChartOptionsMenuView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/ChartOptionsMenu/ChartOptionsMenuView.tsx
@@ -25,7 +25,7 @@ export function ChartOptionsMenuView({ viewModel }: ChartOptionsMenuViewProps) {
       />
       <MenuContent className="w-full min-w-200" side="bottom" align="end">
         <MenuItem
-          onSelect={() => {
+          onClick={() => {
             onToggle();
           }}
           data-testid="asset-detail-chart-options-toggle-transactions"

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/OptionsMenu/OptionsMenuView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/OptionsMenu/OptionsMenuView.tsx
@@ -43,7 +43,7 @@ export function OptionsMenuView({ viewModel }: OptionsMenuViewProps) {
       <MenuContent className="w-full min-w-200" side="bottom" align="end">
         <MenuItem
           disabled={!isStarEnabled}
-          onSelect={() => {
+          onClick={() => {
             onToggleStar();
           }}
         >
@@ -58,7 +58,7 @@ export function OptionsMenuView({ viewModel }: OptionsMenuViewProps) {
         </MenuItem>
         {isHideFromPortfolioEnabled && (
           <MenuItem
-            onSelect={() => {
+            onClick={() => {
               if (isHiddenFromPortfolio) {
                 onShowInPortfolio();
               } else {

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/OptionsMenu/OptionsMenuView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/OptionsMenu/OptionsMenuView.tsx
@@ -28,16 +28,18 @@ export function OptionsMenuView({ viewModel }: OptionsMenuViewProps) {
 
   return (
     <Menu>
-      <MenuTrigger asChild>
-        <IconButton
-          appearance="gray"
-          size="sm"
-          icon={MoreVertical}
-          aria-label={optionsAriaLabel}
-          data-testid="asset-detail-header-options-trigger"
-          className="mr-4"
-        />
-      </MenuTrigger>
+      <MenuTrigger
+        render={
+          <IconButton
+            appearance="gray"
+            size="sm"
+            icon={MoreVertical}
+            aria-label={optionsAriaLabel}
+            data-testid="asset-detail-header-options-trigger"
+            className="mr-4"
+          />
+        }
+      />
       <MenuContent className="w-full min-w-200" side="bottom" align="end">
         <MenuItem
           disabled={!isStarEnabled}

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/OperationRow.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/OperationRow.tsx
@@ -62,7 +62,7 @@ function OperationRow({ row, onRowClick }: OperationRowProps) {
             <div className="inline-flex items-center gap-12">
               {typeLabel}
               {isUnread && (
-                <DotIndicator appearance="red" size="xs" data-testid="unread-indicator" />
+                <DotIndicator appearance="red" size="lg" data-testid="unread-indicator" />
               )}
             </div>
           }

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/__integrations__/SendFlow.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/__integrations__/SendFlow.integration.test.tsx
@@ -11,6 +11,7 @@ import {
   navigateToAmountScreen,
   openCoinControlScreen,
   openCustomFeesScreen,
+  openFeeMenu,
   renderSendFlow,
   resetSendFlowTestState,
   screen,
@@ -201,6 +202,24 @@ describe("Send Flow Integration", () => {
       await navigateToAmountScreen(user);
 
       expect(screen.getByTestId("send-network-fees-menu-trigger")).toBeVisible();
+    });
+
+    it("should update the selected strategy when picking a preset", async () => {
+      setMockTransaction(
+        createMinimalEvmTransaction({ amount: new BigNumber(0), recipient: VALID_EVM_RECIPIENT }),
+      );
+
+      const { user } = renderSendFlow(ethereumAccount);
+      await navigateToAmountScreen(user);
+
+      expect(screen.getByTestId("send-network-fees-menu-trigger")).toHaveTextContent(/medium/i);
+
+      await openFeeMenu(user);
+      await user.click(await screen.findByTestId("send-fees-preset-fast"));
+
+      await waitFor(() =>
+        expect(screen.getByTestId("send-network-fees-menu-trigger")).toHaveTextContent(/fast/i),
+      );
     });
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/Fees/FeePresetMenuItems.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/Fees/FeePresetMenuItems.tsx
@@ -63,7 +63,7 @@ export function FeePresetMenuItems({
       {hasCustom ? (
         <MenuItem
           data-testid="send-custom-fees-menu-item"
-          onSelect={() => {
+          onClick={() => {
             onSelectCustomFees?.();
           }}
         >
@@ -73,7 +73,7 @@ export function FeePresetMenuItems({
       {hasCoinControl ? (
         <MenuItem
           data-testid="send-coin-control-fees-menu-item"
-          onSelect={() => {
+          onClick={() => {
             onSelectCoinControl?.();
           }}
         >

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/Fees/FeePresetMenuItems.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/Fees/FeePresetMenuItems.tsx
@@ -47,6 +47,8 @@ export function FeePresetMenuItems({
                 <MenuRadioItem
                   key={option.id}
                   value={option.id}
+                  closeOnClick
+                  className="cursor-pointer"
                   data-testid={`send-fees-preset-${option.id}`}
                 >
                   <div className="flex flex-col">
@@ -62,6 +64,7 @@ export function FeePresetMenuItems({
       ) : null}
       {hasCustom ? (
         <MenuItem
+          className="cursor-pointer"
           data-testid="send-custom-fees-menu-item"
           onClick={() => {
             onSelectCustomFees?.();
@@ -72,6 +75,7 @@ export function FeePresetMenuItems({
       ) : null}
       {hasCoinControl ? (
         <MenuItem
+          className="cursor-pointer"
           data-testid="send-coin-control-fees-menu-item"
           onClick={() => {
             onSelectCoinControl?.();

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/Fees/NetworkFeesMenu.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/Fees/NetworkFeesMenu.tsx
@@ -3,6 +3,7 @@ import {
   Menu,
   MenuTrigger,
   MenuContent,
+  MenuGroup,
   MenuLabel,
   TooltipTrigger,
   TooltipContent,
@@ -165,7 +166,7 @@ export function NetworkFeesMenu({ display, selection, presets, actions }: Networ
           render={
             <button
               type="button"
-              className="flex items-center gap-8 transition-colors hover:opacity-70"
+              className="flex items-center gap-8 transition-colors hover:opacity-70  cursor-pointer"
               data-testid="send-network-fees-menu-trigger"
             >
               <span className="body-3 text-base">
@@ -175,19 +176,21 @@ export function NetworkFeesMenu({ display, selection, presets, actions }: Networ
             </button>
           }
         />
-        <MenuContent className="w-256" side="top">
-          <MenuLabel>{feesLabel}</MenuLabel>
-          <FeePresetMenuItems
-            hasPresets={hasPresets}
-            hasCustom={hasCustom}
-            hasCoinControl={showCoinControlMenuItem}
-            selectedStrategy={selectedStrategy}
-            onSelectStrategy={onSelectStrategy}
-            onSelectCustomFees={onSelectCustomFees}
-            onSelectCoinControl={onSelectCoinControl}
-            feeOptionsWithFiat={feeOptionsWithFiat}
-            shouldShowFeeRateLegend={shouldShowFeeRateLegend}
-          />
+        <MenuContent className="pointer-events-auto w-256" side="top">
+          <MenuGroup>
+            <MenuLabel>{feesLabel}</MenuLabel>
+            <FeePresetMenuItems
+              hasPresets={hasPresets}
+              hasCustom={hasCustom}
+              hasCoinControl={showCoinControlMenuItem}
+              selectedStrategy={selectedStrategy}
+              onSelectStrategy={onSelectStrategy}
+              onSelectCustomFees={onSelectCustomFees}
+              onSelectCoinControl={onSelectCoinControl}
+              feeOptionsWithFiat={feeOptionsWithFiat}
+              shouldShowFeeRateLegend={shouldShowFeeRateLegend}
+            />
+          </MenuGroup>
         </MenuContent>
       </Menu>
     </div>

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/Fees/NetworkFeesMenu.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/Fees/NetworkFeesMenu.tsx
@@ -161,18 +161,20 @@ export function NetworkFeesMenu({ display, selection, presets, actions }: Networ
         {informationIcon}
       </span>
       <Menu>
-        <MenuTrigger asChild>
-          <button
-            type="button"
-            className="flex items-center gap-8 transition-colors hover:opacity-70"
-            data-testid="send-network-fees-menu-trigger"
-          >
-            <span className="body-3 text-base">
-              {feesValue} • {feesStrategyLabel}
-            </span>
-            <ChevronUpDown size={16} className="text-muted" />
-          </button>
-        </MenuTrigger>
+        <MenuTrigger
+          render={
+            <button
+              type="button"
+              className="flex items-center gap-8 transition-colors hover:opacity-70"
+              data-testid="send-network-fees-menu-trigger"
+            >
+              <span className="body-3 text-base">
+                {feesValue} • {feesStrategyLabel}
+              </span>
+              <ChevronUpDown size={16} className="text-muted" />
+            </button>
+          }
+        />
         <MenuContent className="w-256" side="top">
           <MenuLabel>{feesLabel}</MenuLabel>
           <FeePresetMenuItems

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/plugins/CeloFeeCurrencyPlugin.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/plugins/CeloFeeCurrencyPlugin.tsx
@@ -89,9 +89,7 @@ function CeloFeeCurrencyPluginInner({
     // when a token fee currency is selected, so the label stays correct even while
     // sub-accounts are still hydrating.
     if (transaction.feeCurrencyUnwrapped) {
-      const matched = FEE_CURRENCY_BY_CONTRACT.get(
-        transaction.feeCurrencyUnwrapped.toLowerCase(),
-      );
+      const matched = FEE_CURRENCY_BY_CONTRACT.get(transaction.feeCurrencyUnwrapped.toLowerCase());
       if (matched) return matched.name;
     }
     const found = tokenOptions.find(t => t.id === transaction.feeCurrencyAccountId);
@@ -129,22 +127,26 @@ function CeloFeeCurrencyPluginInner({
     <div className="flex flex-col gap-4">
       <span className="body-3 text-muted">{t("send.steps.amount.feeCurrency")}</span>
       <Menu>
-        <MenuTrigger asChild>
-          <ListItem className="cursor-pointer" data-testid="send-celo-fee-currency-select">
-            <ListItemLeading>
-              <ListItemContent>
-                <ListItemTitle>{selectedLabel}</ListItemTitle>
-              </ListItemContent>
-            </ListItemLeading>
-            <ListItemTrailing>
-              <ChevronRight size={16} />
-            </ListItemTrailing>
-          </ListItem>
-        </MenuTrigger>
-        <MenuContent side="bottom" align="end">
+        <MenuTrigger
+          render={
+            <ListItem className="cursor-pointer" data-testid="send-celo-fee-currency-select">
+              <ListItemLeading>
+                <ListItemContent>
+                  <ListItemTitle>{selectedLabel}</ListItemTitle>
+                </ListItemContent>
+              </ListItemLeading>
+              <ListItemTrailing>
+                <ChevronRight size={16} />
+              </ListItemTrailing>
+            </ListItem>
+          }
+        />
+        <MenuContent className="pointer-events-auto" side="bottom" align="end">
           <MenuRadioGroup value={selectedId} onValueChange={onValueChange}>
             <MenuRadioItem
               value={NATIVE_CELO_ID}
+              closeOnClick
+              className="cursor-pointer"
               data-testid="send-celo-fee-currency-option-celo"
             >
               {FEE_CURRENCY_OPTIONS[0].name}
@@ -153,6 +155,8 @@ function CeloFeeCurrencyPluginInner({
               <MenuRadioItem
                 key={tokenAccount.id}
                 value={tokenAccount.id}
+                closeOnClick
+                className="cursor-pointer"
                 data-testid={`send-celo-fee-currency-option-${tokenAccount.feeCurrencyName.toLowerCase()}`}
               >
                 {tokenAccount.feeCurrencyName}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CustomFees/components/FeeAssetSelector.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CustomFees/components/FeeAssetSelector.tsx
@@ -46,7 +46,7 @@ function FeeAssetSelectorComponent({
           </ListItem>
         }
       />
-      <MenuContent side="bottom" align="end">
+      <MenuContent className="pointer-events-auto" side="bottom" align="end">
         <MenuRadioGroup value={selectedId} onValueChange={onChange}>
           {options.map(option => (
             <MenuRadioItem

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CustomFees/components/FeeAssetSelector.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CustomFees/components/FeeAssetSelector.tsx
@@ -31,19 +31,21 @@ function FeeAssetSelectorComponent({
 
   return (
     <Menu>
-      <MenuTrigger asChild>
-        <ListItem className="cursor-pointer" data-testid="send-fee-asset-select">
-          <ListItemLeading>
-            <ListItemContent>
-              <ListItemTitle>{payFeesInLabel}</ListItemTitle>
-            </ListItemContent>
-          </ListItemLeading>
-          <ListItemTrailing>
-            <span className="body-2-semi-bold text-base">{selectedOption?.ticker ?? ""}</span>
-            <ChevronRight size={16} />
-          </ListItemTrailing>
-        </ListItem>
-      </MenuTrigger>
+      <MenuTrigger
+        render={
+          <ListItem className="cursor-pointer" data-testid="send-fee-asset-select">
+            <ListItemLeading>
+              <ListItemContent>
+                <ListItemTitle>{payFeesInLabel}</ListItemTitle>
+              </ListItemContent>
+            </ListItemLeading>
+            <ListItemTrailing>
+              <span className="body-2-semi-bold text-base">{selectedOption?.ticker ?? ""}</span>
+              <ChevronRight size={16} />
+            </ListItemTrailing>
+          </ListItem>
+        }
+      />
       <MenuContent side="bottom" align="end">
         <MenuRadioGroup value={selectedId} onValueChange={onChange}>
           {options.map(option => (

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CustomFees/components/FeeAssetSelector.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CustomFees/components/FeeAssetSelector.tsx
@@ -52,6 +52,8 @@ function FeeAssetSelectorComponent({
             <MenuRadioItem
               key={option.id}
               value={option.id}
+              closeOnClick
+              className="cursor-pointer"
               data-testid={`send-fee-asset-option-${option.id}`}
             >
               {option.ticker}

--- a/apps/ledger-live-desktop/tests/testSetup.tsx
+++ b/apps/ledger-live-desktop/tests/testSetup.tsx
@@ -230,7 +230,7 @@ function renderWithMockedCounterValuesProvider(
   return {
     store,
     i18n,
-    user: userEvent.setup(userEventOptions),
+    user: userEvent.setup({ pointerEventsCheck: 0, ...userEventOptions }),
     ...rtlRender(ui, {
       wrapper: ({ children }) => (
         <Providers
@@ -270,7 +270,7 @@ function render(ui: React.JSX.Element, options: ExtraOptions = {}): RenderReturn
   return {
     store,
     i18n,
-    user: userEvent.setup(userEventOptions),
+    user: userEvent.setup({ pointerEventsCheck: 0, ...userEventOptions }),
     ...rtlRender(ui, {
       wrapper: ({ children }) => (
         <Providers

--- a/apps/ledger-live-mobile/src/AppProviders.tsx
+++ b/apps/ledger-live-mobile/src/AppProviders.tsx
@@ -1,8 +1,4 @@
-import {
-  BottomSheetModalProvider,
-  GlobalSelectBottomSheet,
-  GlobalTooltipBottomSheet,
-} from "@ledgerhq/lumen-ui-rnative";
+import { BottomSheetModalProvider, GlobalTooltipBottomSheet } from "@ledgerhq/lumen-ui-rnative";
 import { CounterValuesStateRaw } from "@ledgerhq/live-countervalues/types";
 import { DeviceManagementKitProvider } from "@ledgerhq/live-dmk-mobile";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -40,7 +36,6 @@ function AppProviders({ initialCountervalues, children }: AppProvidersProps) {
                   </InViewProvider>
                 </NotificationsProvider>
               </PostOnboardingProviderWrapped>
-              <GlobalSelectBottomSheet />
               <GlobalTooltipBottomSheet />
             </BottomSheetModalProvider>
           </CountervaluesBridgedProvider>

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/TopBarView/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/TopBarView/index.tsx
@@ -83,7 +83,7 @@ export function TopBarView({
     () =>
       hasUnreadOperations
         ? (children: React.ReactElement) => (
-            <DotIndicator appearance="red" testID="unread-indicator">
+            <DotIndicator appearance="red" size="xl" testID="unread-indicator">
               {children}
             </DotIndicator>
           )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1083,9 +1083,6 @@ importers:
       '@radix-ui/react-dialog':
         specifier: 'catalog:'
         version: 1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@radix-ui/react-dropdown-menu':
-        specifier: 'catalog:'
-        version: 2.1.16(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.0.14)(react@19.0.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ catalogs:
       specifier: 7.21.7
       version: 7.21.7
     '@ledgerhq/crypto-icons':
-      specifier: 2.0.3
-      version: 2.0.3
+      specifier: 2.0.4
+      version: 2.0.4
     '@ledgerhq/device-management-kit':
       specifier: 1.5.1
       version: 1.5.1
@@ -58,20 +58,20 @@ catalogs:
       specifier: 1.2.3
       version: 1.2.3
     '@ledgerhq/lumen-design-core':
-      specifier: 0.1.15
-      version: 0.1.15
+      specifier: 0.1.16
+      version: 0.1.16
     '@ledgerhq/lumen-ui-react':
-      specifier: 0.1.35
-      version: 0.1.35
-    '@ledgerhq/lumen-ui-react-visualization':
-      specifier: 0.1.15
-      version: 0.1.15
-    '@ledgerhq/lumen-ui-rnative':
       specifier: 0.1.37
       version: 0.1.37
+    '@ledgerhq/lumen-ui-react-visualization':
+      specifier: 0.1.16
+      version: 0.1.16
+    '@ledgerhq/lumen-ui-rnative':
+      specifier: 0.1.38
+      version: 0.1.38
     '@ledgerhq/lumen-ui-rnative-visualization':
-      specifier: 0.1.14
-      version: 0.1.14
+      specifier: 0.1.15
+      version: 0.1.15
     '@ledgerhq/speculos-device-controller':
       specifier: 0.3.0
       version: 0.3.0
@@ -599,7 +599,7 @@ importers:
         version: link:tools/create-release-hash
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.15
+        version: 0.1.16
       '@ledgerhq/pnpm-utils':
         specifier: workspace:*
         version: link:tools/pnpm-utils
@@ -974,7 +974,7 @@ importers:
         version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.3(@ledgerhq/lumen-design-core@0.1.15)(@ledgerhq/lumen-ui-react@0.1.35(e90fd83ca17bf10e850de74ae9e31ccb))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 2.0.4(@ledgerhq/lumen-design-core@0.1.16)(@ledgerhq/lumen-ui-react@0.1.37(@ledgerhq/lumen-design-core@0.1.16)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.0.0))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/react-table@8.5.11(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/cryptoassets
@@ -1046,13 +1046,13 @@ importers:
         version: link:../../libs/ledgerjs/packages/logs
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.15
+        version: 0.1.16
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.35(e90fd83ca17bf10e850de74ae9e31ccb)
+        version: 0.1.37(@ledgerhq/lumen-design-core@0.1.16)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.0.0))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/react-table@8.5.11(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
       '@ledgerhq/lumen-ui-react-visualization':
         specifier: 'catalog:'
-        version: 0.1.15(@ledgerhq/lumen-design-core@0.1.15)(@ledgerhq/lumen-ui-react@0.1.35(e90fd83ca17bf10e850de74ae9e31ccb))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
+        version: 0.1.16(5dde4e19906e0aa170870fa4804576b2)
       '@ledgerhq/react-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/react
@@ -1639,7 +1639,7 @@ importers:
         version: 2.1.0(@ledgerhq/device-management-kit@1.5.1(rxjs@7.8.2))
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.3(@ledgerhq/lumen-design-core@0.1.15)(@ledgerhq/lumen-ui-rnative@0.1.37(ea8f19a0282098dfef532dfdbd5aa68b))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+        version: 2.0.4(@ledgerhq/lumen-design-core@0.1.16)(@ledgerhq/lumen-ui-rnative@0.1.38(ceaf05d6712be870d78aa56eadc54145))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/cryptoassets
@@ -1723,13 +1723,13 @@ importers:
         version: link:../../libs/ledgerjs/packages/logs
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.15
+        version: 0.1.16
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.37(ea8f19a0282098dfef532dfdbd5aa68b)
+        version: 0.1.38(ceaf05d6712be870d78aa56eadc54145)
       '@ledgerhq/lumen-ui-rnative-visualization':
         specifier: 'catalog:'
-        version: 0.1.14(f414683eda8335a3c09f695f0b3e96b3)
+        version: 0.1.15(ad386d33d0dddc915925def42557f848)
       '@ledgerhq/native-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/native
@@ -2510,7 +2510,7 @@ importers:
         version: 3.2.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.3(@ledgerhq/lumen-design-core@0.1.15)(@ledgerhq/lumen-ui-react@0.1.35(e90fd83ca17bf10e850de74ae9e31ccb))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 2.0.4(@ledgerhq/lumen-design-core@0.1.16)(@ledgerhq/lumen-ui-react@0.1.37(@ledgerhq/lumen-design-core@0.1.16)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.0.0))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/react-table@8.5.11(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/cryptoassets
@@ -2567,10 +2567,10 @@ importers:
         version: link:../../libs/ledgerjs/packages/logs
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.15
+        version: 0.1.16
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.35(e90fd83ca17bf10e850de74ae9e31ccb)
+        version: 0.1.37(@ledgerhq/lumen-design-core@0.1.16)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.0.0))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/react-table@8.5.11(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
       '@ledgerhq/react-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/react
@@ -2788,10 +2788,10 @@ importers:
     devDependencies:
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.15
+        version: 0.1.16
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.35(@ledgerhq/lumen-design-core@0.1.15)(@radix-ui/react-checkbox@1.3.2(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dialog@1.1.15(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dropdown-menu@2.1.16(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.0.0))(@radix-ui/react-switch@1.2.6(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-tooltip@1.2.8(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/react-table@8.5.11(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
+        version: 0.1.37(@ledgerhq/lumen-design-core@0.1.16)(@radix-ui/react-checkbox@1.3.2(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dialog@1.1.15(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.0.0))(@radix-ui/react-switch@1.2.6(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-tooltip@1.2.8(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/react-table@8.5.11(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
       '@ledgerhq/lumen-utils-shared':
         specifier: 0.1.4
         version: 0.1.4(react@19.0.0)
@@ -2901,13 +2901,13 @@ importers:
         version: 30.2.0
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.15
+        version: 0.1.16
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.35(81c6f3253259a2d7d0395dad4519fe81)
+        version: 0.1.37(247ffb635213f0ea7311ac2b66ffd15f)
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.37(56f019cb75b84e0ca2fc549aaf636d30)
+        version: 0.1.38(52a5a1eabbff617830e50d9c39408722)
       '@radix-ui/react-checkbox':
         specifier: 'catalog:'
         version: 1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -3448,13 +3448,13 @@ importers:
         version: 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.1.6(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.15
+        version: 0.1.16
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.35(@ledgerhq/lumen-design-core@0.1.15)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
+        version: 0.1.37(@ledgerhq/lumen-design-core@0.1.16)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.37(bb139e106ed35527d4639932cad9268c)
+        version: 0.1.38(bd1f1ac6d53a31355451df987c1ff9ae)
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -12051,7 +12051,7 @@ importers:
     dependencies:
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.3(@ledgerhq/lumen-design-core@0.1.15)(@ledgerhq/lumen-ui-rnative@0.1.37(3e7800b232784cf2b3c4cfeb964f9007))(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
+        version: 2.0.4(@ledgerhq/lumen-design-core@0.1.16)(@ledgerhq/lumen-ui-rnative@0.1.38(ed4a91ce2529067bcbfd78c12f2ad1cc))(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
       '@ledgerhq/icons-ui':
         specifier: workspace:^
         version: link:../icons
@@ -12115,10 +12115,10 @@ importers:
         version: 0.19.12
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.15
+        version: 0.1.16
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.37(3e7800b232784cf2b3c4cfeb964f9007)
+        version: 0.1.38(ed4a91ce2529067bcbfd78c12f2ad1cc)
       '@react-native-async-storage/async-storage':
         specifier: 2.1.2
         version: 2.1.2(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))
@@ -12379,7 +12379,7 @@ importers:
     dependencies:
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.3(@ledgerhq/lumen-design-core@0.1.15)(@ledgerhq/lumen-ui-react@0.1.35(e90fd83ca17bf10e850de74ae9e31ccb))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 2.0.4(@ledgerhq/lumen-design-core@0.1.16)(@ledgerhq/lumen-ui-react@0.1.37(@ledgerhq/lumen-design-core@0.1.16)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.0.0))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/react-table@8.5.11(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@ledgerhq/icons-ui':
         specifier: workspace:^
         version: file:libs/ui/packages/icons(@types/react@19.0.14)(react@19.0.0)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@19.0.0(react@19.0.0))(react-is@17.0.2)(react@19.0.0))(styled-system@5.1.5)
@@ -12440,10 +12440,10 @@ importers:
         version: 7.28.5(@babel/core@7.28.5)
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.15
+        version: 0.1.16
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.35(e90fd83ca17bf10e850de74ae9e31ccb)
+        version: 0.1.37(@ledgerhq/lumen-design-core@0.1.16)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.0.0))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/react-table@8.5.11(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
       '@radix-ui/react-checkbox':
         specifier: 'catalog:'
         version: 1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -17292,12 +17292,12 @@ packages:
     peerDependencies:
       '@ledgerhq/device-management-kit': ^1.5.1
 
-  '@ledgerhq/crypto-icons@2.0.3':
-    resolution: {integrity: sha512-GW2UBrhhu/eBb7npbWrmay3lQ5u/YHMjxNmygsBvHC5NE/VzZX463yLaHrFnOTYlNXuYbm0NcZMxz6OdbdrjnA==}
+  '@ledgerhq/crypto-icons@2.0.4':
+    resolution: {integrity: sha512-PbUs85RtyGaq4R/KBcscHxbeSb7s6E69JbISJkBH9q7V7pmKtsABu31Yaq7UmOodiulidQKrYo7lKcZ7UxXO9w==}
     peerDependencies:
       '@ledgerhq/lumen-design-core': '>=0.1.13'
-      '@ledgerhq/lumen-ui-react': '>=0.1.31'
-      '@ledgerhq/lumen-ui-rnative': '>=0.1.32'
+      '@ledgerhq/lumen-ui-react': '>=0.1.36'
+      '@ledgerhq/lumen-ui-rnative': '>=0.1.37'
       react: 19.0.0
       react-dom: 19.0.0
       react-native: '>=0.70'
@@ -17435,28 +17435,27 @@ packages:
   '@ledgerhq/logs@6.16.0':
     resolution: {integrity: sha512-v/PLfb1dq1En35kkpbfRWp8jLYgbPUXxGhmd4pmvPSIe0nRGkNTomsZASmWQAv6pRonVGqHIBVlte7j1MBbOww==}
 
-  '@ledgerhq/lumen-design-core@0.1.15':
-    resolution: {integrity: sha512-y5cUl3GHtd5RLALfhQGZZ4+6WnMkcU/+rW+Cx7wmAtl5kXin9zmje0CVG/jKlbO6s/7QmFXenqKZSQH46kSFEw==}
+  '@ledgerhq/lumen-design-core@0.1.16':
+    resolution: {integrity: sha512-haT2vS5HPPWRuqZHcU582U5drzf15OmRsjCSeKCzRw+6EEHUL++aaBlCBHyAQRboJe20vhWtjpa6czbBc/Iv7w==}
 
-  '@ledgerhq/lumen-ui-react-visualization@0.1.15':
-    resolution: {integrity: sha512-3/zedLhnitebl2a5905m9/03edT7dkDhp3RAVQDs1FowUJAslPYR3i/7LwljKEE1jmkdZ+x9XQZBTERrJlEzZQ==}
+  '@ledgerhq/lumen-ui-react-visualization@0.1.16':
+    resolution: {integrity: sha512-sIJtfwdpJ+Ae6g1nzWX/6PRDuJvwc5DzPl5BpSjRHB8jxj+gY0DSnL7FUyynjhWDG84ciGybP5nCek1GCeTxTw==}
     peerDependencies:
-      '@ledgerhq/lumen-design-core': 0.1.15
-      '@ledgerhq/lumen-ui-react': 0.1.36
+      '@ledgerhq/lumen-design-core': 0.1.16
+      '@ledgerhq/lumen-ui-react': 0.1.37
       class-variance-authority: ^0.7.1
       clsx: ^2.1.1
       react: 19.0.0
       react-dom: 19.0.0
       tailwind-merge: ^2.6.0
 
-  '@ledgerhq/lumen-ui-react@0.1.35':
-    resolution: {integrity: sha512-PBCDITzpeReZACHXDEg5Bs0v6ULYXVizaRREwueXuAFTQJJxGtjdcOUHQsbw/aFgS5J46mliuc29mGpinXSqcQ==}
+  '@ledgerhq/lumen-ui-react@0.1.37':
+    resolution: {integrity: sha512-ZysOEIY1QL0nJJd+oA/i73p4Cevm+rosa/+avr4zBvXr4lof6cULKfCBjXPhC5A/TvWdiMAXPNXYjJUtk0bFvQ==}
     peerDependencies:
       '@base-ui/react': ^1.3.0
-      '@ledgerhq/lumen-design-core': 0.1.14
+      '@ledgerhq/lumen-design-core': 0.1.16
       '@radix-ui/react-checkbox': ^1.3.2
       '@radix-ui/react-dialog': ^1.1.15
-      '@radix-ui/react-dropdown-menu': ^2.1.2
       '@radix-ui/react-slot': ^1.2.4
       '@radix-ui/react-switch': ^1.2.6
       '@radix-ui/react-tooltip': ^1.2.8
@@ -17467,11 +17466,11 @@ packages:
       react-dom: 19.0.0
       tailwind-merge: ^2.6.0
 
-  '@ledgerhq/lumen-ui-rnative-visualization@0.1.14':
-    resolution: {integrity: sha512-GZw9EfH8CuTabGSwbVgyTgwaFkIiW4TZJhAnn3X35x5PQxFyTQMTps7yJWmglXOXGs3pMTmfaX91BHgEZNo47A==}
+  '@ledgerhq/lumen-ui-rnative-visualization@0.1.15':
+    resolution: {integrity: sha512-w+IPqMWhr+n27x0FCKIV73+ha91H8Wp4xce4b0XSK2/UKKbe6wMpa2+TnOVpvE9gRKF2SPf4f7FNDFuXGADssg==}
     peerDependencies:
-      '@ledgerhq/lumen-design-core': 0.1.15
-      '@ledgerhq/lumen-ui-rnative': 0.1.37
+      '@ledgerhq/lumen-design-core': 0.1.16
+      '@ledgerhq/lumen-ui-rnative': 0.1.38
       '@types/react': ^19.0.0
       react: 19.0.0
       react-native: ~0.79.7
@@ -17480,11 +17479,11 @@ packages:
       react-native-svg: ^15.0.0
       react-native-worklets: '>=0.5.0'
 
-  '@ledgerhq/lumen-ui-rnative@0.1.37':
-    resolution: {integrity: sha512-iVxTHDedzES02cS9QCtYGH7t8c0BWGkM70rrd0tM1wWO6SQudvetq4iwU8EHV/9/s0uIgopQzUUcbkKPLI0Ziw==}
+  '@ledgerhq/lumen-ui-rnative@0.1.38':
+    resolution: {integrity: sha512-KbzdRmID/jCDkaIt7ZWe4ptcZLYZFUKXdJ2NVqLp7cNI7wT2JlMDVdxcN4zxXcOWON3CY+EJjpDvdA8A0OBqog==}
     peerDependencies:
       '@gorhom/bottom-sheet': ^5.0.0
-      '@ledgerhq/lumen-design-core': 0.1.15
+      '@ledgerhq/lumen-design-core': 0.1.16
       '@sbaiahmed1/react-native-blur': ^4.5.5
       '@types/react': ^19.0.0
       expo: '>=53.0.0'
@@ -17495,13 +17494,13 @@ packages:
       react-native-safe-area-context: ^4.0.0 || ^5.0.0
       react-native-svg: ^15.0.0
 
-  '@ledgerhq/lumen-utils-shared@0.1.3':
-    resolution: {integrity: sha512-vnYl8joMbicAgcRZs+rnUiwHi6o+LpwmBtjXywWcpVobwxHrgKgTF9Idy3+0mJLGyYYgInIcwKnx2p5ZtG75Yg==}
+  '@ledgerhq/lumen-utils-shared@0.1.4':
+    resolution: {integrity: sha512-jHWlRh7WE7rlv7uoiuWbEIUboyuP0Jaj4R6nW8NWhPkRKDsdFY+TYue3+vNWl4HIZyaIf1xf3xVFJPEjKrQJxw==}
     peerDependencies:
       react: 19.0.0
 
-  '@ledgerhq/lumen-utils-shared@0.1.4':
-    resolution: {integrity: sha512-jHWlRh7WE7rlv7uoiuWbEIUboyuP0Jaj4R6nW8NWhPkRKDsdFY+TYue3+vNWl4HIZyaIf1xf3xVFJPEjKrQJxw==}
+  '@ledgerhq/lumen-utils-shared@0.1.5':
+    resolution: {integrity: sha512-JmjgL2mdOs1/5hdwLQWAhAAV2+a1IcbZq7yl/LCgD6+vzfESvrtm5MGNbEm2WkenhNb4wiq+6AtYv2Q9U+N/QA==}
     peerDependencies:
       react: 19.0.0
 
@@ -21826,7 +21825,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.0.0
       react-dom: 19.0.0
-      webpack: '*'
+      webpack: ^5.89.0
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -24143,7 +24142,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: '*'
+      rxjs: ^5.5.10
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -45344,30 +45343,30 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/crypto-icons@2.0.3(@ledgerhq/lumen-design-core@0.1.15)(@ledgerhq/lumen-ui-react@0.1.35(e90fd83ca17bf10e850de74ae9e31ccb))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@ledgerhq/crypto-icons@2.0.4(@ledgerhq/lumen-design-core@0.1.16)(@ledgerhq/lumen-ui-react@0.1.37(@ledgerhq/lumen-design-core@0.1.16)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.0.0))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/react-table@8.5.11(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       react: 19.0.0
     optionalDependencies:
-      '@ledgerhq/lumen-design-core': 0.1.15
-      '@ledgerhq/lumen-ui-react': 0.1.35(e90fd83ca17bf10e850de74ae9e31ccb)
+      '@ledgerhq/lumen-design-core': 0.1.16
+      '@ledgerhq/lumen-ui-react': 0.1.37(@ledgerhq/lumen-design-core@0.1.16)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.0.0))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/react-table@8.5.11(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
       react-dom: 19.0.0(react@19.0.0)
 
-  '@ledgerhq/crypto-icons@2.0.3(@ledgerhq/lumen-design-core@0.1.15)(@ledgerhq/lumen-ui-rnative@0.1.37(3e7800b232784cf2b3c4cfeb964f9007))(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)':
+  '@ledgerhq/crypto-icons@2.0.4(@ledgerhq/lumen-design-core@0.1.16)(@ledgerhq/lumen-ui-rnative@0.1.38(ceaf05d6712be870d78aa56eadc54145))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
     dependencies:
       react: 19.0.0
     optionalDependencies:
-      '@ledgerhq/lumen-design-core': 0.1.15
-      '@ledgerhq/lumen-ui-rnative': 0.1.37(3e7800b232784cf2b3c4cfeb964f9007)
+      '@ledgerhq/lumen-design-core': 0.1.16
+      '@ledgerhq/lumen-ui-rnative': 0.1.38(ceaf05d6712be870d78aa56eadc54145)
+      react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
+
+  '@ledgerhq/crypto-icons@2.0.4(@ledgerhq/lumen-design-core@0.1.16)(@ledgerhq/lumen-ui-rnative@0.1.38(ed4a91ce2529067bcbfd78c12f2ad1cc))(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@ledgerhq/lumen-design-core': 0.1.16
+      '@ledgerhq/lumen-ui-rnative': 0.1.38(ed4a91ce2529067bcbfd78c12f2ad1cc)
       react-dom: 19.0.0(react@19.0.0)
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0)
-
-  '@ledgerhq/crypto-icons@2.0.3(@ledgerhq/lumen-design-core@0.1.15)(@ledgerhq/lumen-ui-rnative@0.1.37(ea8f19a0282098dfef532dfdbd5aa68b))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
-    dependencies:
-      react: 19.0.0
-    optionalDependencies:
-      '@ledgerhq/lumen-design-core': 0.1.15
-      '@ledgerhq/lumen-ui-rnative': 0.1.37(ea8f19a0282098dfef532dfdbd5aa68b)
-      react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
 
   '@ledgerhq/device-management-kit@1.5.1':
     dependencies:
@@ -45595,16 +45594,16 @@ snapshots:
 
   '@ledgerhq/logs@6.16.0': {}
 
-  '@ledgerhq/lumen-design-core@0.1.15':
+  '@ledgerhq/lumen-design-core@0.1.16':
     dependencies:
       tailwindcss: 4.1.18
       tslib: 2.6.2
 
-  '@ledgerhq/lumen-ui-react-visualization@0.1.15(@ledgerhq/lumen-design-core@0.1.15)(@ledgerhq/lumen-ui-react@0.1.35(e90fd83ca17bf10e850de74ae9e31ccb))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)':
+  '@ledgerhq/lumen-ui-react-visualization@0.1.16(5dde4e19906e0aa170870fa4804576b2)':
     dependencies:
-      '@ledgerhq/lumen-design-core': 0.1.15
-      '@ledgerhq/lumen-ui-react': 0.1.35(e90fd83ca17bf10e850de74ae9e31ccb)
-      '@ledgerhq/lumen-utils-shared': 0.1.4(react@19.0.0)
+      '@ledgerhq/lumen-design-core': 0.1.16
+      '@ledgerhq/lumen-ui-react': 0.1.37(@ledgerhq/lumen-design-core@0.1.16)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.0.0))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/react-table@8.5.11(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
+      '@ledgerhq/lumen-utils-shared': 0.1.5(react@19.0.0)
       class-variance-authority: 0.7.1
       clsx: 2.1.1
       d3-array: 3.2.4
@@ -45614,13 +45613,12 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
       tailwind-merge: 3.4.0
 
-  '@ledgerhq/lumen-ui-react@0.1.35(81c6f3253259a2d7d0395dad4519fe81)':
+  '@ledgerhq/lumen-ui-react@0.1.37(247ffb635213f0ea7311ac2b66ffd15f)':
     dependencies:
-      '@ledgerhq/lumen-design-core': 0.1.15
-      '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
+      '@ledgerhq/lumen-design-core': 0.1.16
+      '@ledgerhq/lumen-utils-shared': 0.1.5(react@19.0.0)
       '@radix-ui/react-checkbox': 1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-slot': 1.2.4(@types/react@19.0.14)(react@19.0.0)
       '@radix-ui/react-switch': 1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -45635,13 +45633,32 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-react@0.1.35(@ledgerhq/lumen-design-core@0.1.15)(@radix-ui/react-checkbox@1.3.2(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dialog@1.1.15(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dropdown-menu@2.1.16(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.0.0))(@radix-ui/react-switch@1.2.6(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-tooltip@1.2.8(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/react-table@8.5.11(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)':
+  '@ledgerhq/lumen-ui-react@0.1.37(@ledgerhq/lumen-design-core@0.1.16)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.0.0))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/react-table@8.5.11(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)':
     dependencies:
-      '@ledgerhq/lumen-design-core': 0.1.15
-      '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
+      '@ledgerhq/lumen-design-core': 0.1.16
+      '@ledgerhq/lumen-utils-shared': 0.1.5(react@19.0.0)
+      '@radix-ui/react-checkbox': 1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.0.14)(react@19.0.0)
+      '@radix-ui/react-switch': 1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@tanstack/react-table': 8.5.11(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      class-variance-authority: 0.7.1
+      clsx: 2.1.1
+      i18next: 23.10.1
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      tailwind-merge: 3.4.0
+    transitivePeerDependencies:
+      - react-native
+
+  '@ledgerhq/lumen-ui-react@0.1.37(@ledgerhq/lumen-design-core@0.1.16)(@radix-ui/react-checkbox@1.3.2(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dialog@1.1.15(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.0.0))(@radix-ui/react-switch@1.2.6(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-tooltip@1.2.8(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/react-table@8.5.11(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)':
+    dependencies:
+      '@ledgerhq/lumen-design-core': 0.1.16
+      '@ledgerhq/lumen-utils-shared': 0.1.5(react@19.0.0)
       '@radix-ui/react-checkbox': 1.3.2(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-dialog': 1.1.15(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@radix-ui/react-dropdown-menu': 2.1.16(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-slot': 1.2.4(@types/react@19.0.14)(react@19.0.0)
       '@radix-ui/react-switch': 1.2.6(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-tooltip': 1.2.8(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -45656,10 +45673,10 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-react@0.1.35(@ledgerhq/lumen-design-core@0.1.15)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)':
+  '@ledgerhq/lumen-ui-react@0.1.37(@ledgerhq/lumen-design-core@0.1.16)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)':
     dependencies:
-      '@ledgerhq/lumen-design-core': 0.1.15
-      '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
+      '@ledgerhq/lumen-design-core': 0.1.16
+      '@ledgerhq/lumen-utils-shared': 0.1.5(react@19.0.0)
       clsx: 2.1.1
       i18next: 23.10.1
       react: 19.0.0
@@ -45669,32 +45686,11 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-react@0.1.35(e90fd83ca17bf10e850de74ae9e31ccb)':
+  '@ledgerhq/lumen-ui-rnative-visualization@0.1.15(ad386d33d0dddc915925def42557f848)':
     dependencies:
-      '@ledgerhq/lumen-design-core': 0.1.15
-      '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
-      '@radix-ui/react-checkbox': 1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@radix-ui/react-slot': 1.2.4(@types/react@19.0.14)(react@19.0.0)
-      '@radix-ui/react-switch': 1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@tanstack/react-table': 8.5.11(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      class-variance-authority: 0.7.1
-      clsx: 2.1.1
-      i18next: 23.10.1
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
-      react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      tailwind-merge: 3.4.0
-    transitivePeerDependencies:
-      - react-native
-
-  '@ledgerhq/lumen-ui-rnative-visualization@0.1.14(f414683eda8335a3c09f695f0b3e96b3)':
-    dependencies:
-      '@ledgerhq/lumen-design-core': 0.1.15
-      '@ledgerhq/lumen-ui-rnative': 0.1.37(ea8f19a0282098dfef532dfdbd5aa68b)
-      '@ledgerhq/lumen-utils-shared': 0.1.4(react@19.0.0)
+      '@ledgerhq/lumen-design-core': 0.1.16
+      '@ledgerhq/lumen-ui-rnative': 0.1.38(ceaf05d6712be870d78aa56eadc54145)
+      '@ledgerhq/lumen-utils-shared': 0.1.5(react@19.0.0)
       '@types/react': 19.0.14
       d3-array: 3.2.4
       d3-scale: 4.0.2
@@ -45706,27 +45702,11 @@ snapshots:
       react-native-svg: 15.15.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react-native-worklets: 0.7.2(@babel/core@7.28.5)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
 
-  '@ledgerhq/lumen-ui-rnative@0.1.37(3e7800b232784cf2b3c4cfeb964f9007)':
-    dependencies:
-      '@ledgerhq/lumen-design-core': 0.1.15
-      '@ledgerhq/lumen-utils-shared': 0.1.4(react@19.0.0)
-      '@types/react': 19.0.14
-      expo: 53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
-      i18next: 23.10.1
-      react: 19.0.0
-      react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
-      react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0)
-      react-native-reanimated: 4.1.6(@babel/core@7.28.5)(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
-      react-native-safe-area-context: 5.6.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
-      react-native-svg: 15.15.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
-    transitivePeerDependencies:
-      - react-dom
-
-  '@ledgerhq/lumen-ui-rnative@0.1.37(56f019cb75b84e0ca2fc549aaf636d30)':
+  '@ledgerhq/lumen-ui-rnative@0.1.38(52a5a1eabbff617830e50d9c39408722)':
     dependencies:
       '@gorhom/bottom-sheet': 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.1.6(react-native-worklets@0.7.2(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-      '@ledgerhq/lumen-design-core': 0.1.15
-      '@ledgerhq/lumen-utils-shared': 0.1.4(react@19.0.0)
+      '@ledgerhq/lumen-design-core': 0.1.16
+      '@ledgerhq/lumen-utils-shared': 0.1.5(react@19.0.0)
       '@types/react': 19.0.14
       expo-haptics: 14.1.4(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       i18next: 23.10.1
@@ -45739,11 +45719,11 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  '@ledgerhq/lumen-ui-rnative@0.1.37(bb139e106ed35527d4639932cad9268c)':
+  '@ledgerhq/lumen-ui-rnative@0.1.38(bd1f1ac6d53a31355451df987c1ff9ae)':
     dependencies:
       '@gorhom/bottom-sheet': 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.1.6(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-      '@ledgerhq/lumen-design-core': 0.1.15
-      '@ledgerhq/lumen-utils-shared': 0.1.4(react@19.0.0)
+      '@ledgerhq/lumen-design-core': 0.1.16
+      '@ledgerhq/lumen-utils-shared': 0.1.5(react@19.0.0)
       '@types/react': 19.0.14
       i18next: 23.10.1
       react: 19.0.0
@@ -45755,11 +45735,11 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  '@ledgerhq/lumen-ui-rnative@0.1.37(ea8f19a0282098dfef532dfdbd5aa68b)':
+  '@ledgerhq/lumen-ui-rnative@0.1.38(ceaf05d6712be870d78aa56eadc54145)':
     dependencies:
       '@gorhom/bottom-sheet': 5.2.6(beb07f7799bea5989bf46dbe8fcef3d9)
-      '@ledgerhq/lumen-design-core': 0.1.15
-      '@ledgerhq/lumen-utils-shared': 0.1.4(react@19.0.0)
+      '@ledgerhq/lumen-design-core': 0.1.16
+      '@ledgerhq/lumen-utils-shared': 0.1.5(react@19.0.0)
       '@sbaiahmed1/react-native-blur': 4.5.5(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@types/react': 19.0.14
       expo: 53.0.25(4b2c01f5a47d338b1c9e7803e0aed015)
@@ -45774,13 +45754,29 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  '@ledgerhq/lumen-utils-shared@0.1.3(react@19.0.0)':
+  '@ledgerhq/lumen-ui-rnative@0.1.38(ed4a91ce2529067bcbfd78c12f2ad1cc)':
+    dependencies:
+      '@ledgerhq/lumen-design-core': 0.1.16
+      '@ledgerhq/lumen-utils-shared': 0.1.5(react@19.0.0)
+      '@types/react': 19.0.14
+      expo: 53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
+      i18next: 23.10.1
+      react: 19.0.0
+      react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
+      react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0)
+      react-native-reanimated: 4.1.6(@babel/core@7.28.5)(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
+      react-native-safe-area-context: 5.6.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
+      react-native-svg: 15.15.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
+    transitivePeerDependencies:
+      - react-dom
+
+  '@ledgerhq/lumen-utils-shared@0.1.4(react@19.0.0)':
     dependencies:
       clsx: 2.1.1
       react: 19.0.0
       tailwind-merge: 2.6.0
 
-  '@ledgerhq/lumen-utils-shared@0.1.4(react@19.0.0)':
+  '@ledgerhq/lumen-utils-shared@0.1.5(react@19.0.0)':
     dependencies:
       clsx: 2.1.1
       react: 19.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,7 +22,7 @@ packages:
 catalog:
   "@jest/globals": 30.2.0
   "@ledgerhq/context-module": 2.1.0
-  "@ledgerhq/crypto-icons": "2.0.3"
+  "@ledgerhq/crypto-icons": "2.0.4"
   "@ledgerhq/device-management-kit": 1.5.1
   "@ledgerhq/device-signer-kit-aleo": 0.3.0
   "@ledgerhq/device-signer-kit-concordium": 0.4.0
@@ -36,11 +36,11 @@ catalog:
   "@ledgerhq/signer-utils": 1.2.0
   "@ledgerhq/device-transport-kit-web-hid": 1.2.3
   "@ledgerhq/speculos-device-controller": 0.3.0
-  "@ledgerhq/lumen-design-core": 0.1.15
-  "@ledgerhq/lumen-ui-react": 0.1.35
-  "@ledgerhq/lumen-ui-rnative": 0.1.37
-  "@ledgerhq/lumen-ui-rnative-visualization": 0.1.14
-  "@ledgerhq/lumen-ui-react-visualization": 0.1.15
+  "@ledgerhq/lumen-design-core": 0.1.16
+  "@ledgerhq/lumen-ui-react": 0.1.37
+  "@ledgerhq/lumen-ui-rnative": 0.1.38
+  "@ledgerhq/lumen-ui-rnative-visualization": 0.1.15
+  "@ledgerhq/lumen-ui-react-visualization": 0.1.16
   "@ledgerhq/zcash-utils": 0.3.1
   # React Native
   react-native: 0.79.7


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Type-only bump + mechanical API migrations. Existing unit tests pass (desktop HistoryButton/OptionsMenu/ChartOptionsMenu, mobile TopBarView). Visual/runtime behaviour of the migrated components (Menu open/close, DotIndicator size, charts) needs manual QA — see table below._
- [x] **Impact of the changes:**
  - Desktop: AssetDetail header/options menus, chart options menu, Send network-fees & fee-asset menus, History unread indicators, asset-detail charts.
  - Mobile: top-bar unread indicator, app providers (Select bottom-sheet removal), charts.

### 📝 Description

Bumps the Lumen design-system packages and `crypto-icons` (LIVE-31810):

| Package | From | To |
|---|---|---|
| `@ledgerhq/lumen-design-core` | 0.1.15 | **0.1.16** |
| `@ledgerhq/lumen-ui-react` | 0.1.35 | **0.1.37** |
| `@ledgerhq/lumen-ui-rnative` | 0.1.37 | **0.1.38** |
| `@ledgerhq/lumen-ui-react-visualization` | 0.1.15 | **0.1.16** |
| `@ledgerhq/lumen-ui-rnative-visualization` | 0.1.14 | **0.1.15** |
| `@ledgerhq/crypto-icons` | 2.0.3 | **2.0.4** |

**Note:** `lumen-ui-react` skips **0.1.36**, which carries the heaviest breaking changes (not in the release Slack thread). All breaking changes in the range were migrated:

- **Menu (Radix UI → Base UI, react 0.1.36):** `<MenuTrigger asChild><X/></MenuTrigger>` → `<MenuTrigger render={<X/>} />`.
- **NavBar (react 0.1.36):** `NavBarCoinCapsule` `icon` prop renamed to `leadingContent`.
- **DotIndicator (react/rnative):** size scale renamed & rescaled (`xs|sm|md|lg` → `sm|md|lg|xl`, default `sm`→`md`). Remapped to **preserve rendered size** (`xs`→`lg`, default→`xl`). ⚠️ Needs design review against Figma.
- **Select removal (rnative 0.1.38):** removed the deleted `GlobalSelectBottomSheet` from mobile `AppProviders` (no `Select` consumers remained).

Additive changes (`AmountInput`/`AmountDisplay` size/align, `MediaImage` 72px, chart `nice` opt-out) require no code changes.

### 🧪 Impacted flows — manual test checklist

> Check each flow as it's tested manually so nothing is missed.

#### Desktop (`ledger-live-desktop`)

| ✅ | Flow | What to verify | Reason |
|----|------|----------------|--------|
|  ✅ | History — top bar History button | Red unread dot shows/size looks right when unread ops exist; click opens history | DotIndicator rescale |
|  ✅ | History — operation rows | Red unread dot next to unread operation type label | DotIndicator rescale |
| ✅ | Asset Detail — header options menu (⋮) | Trigger opens menu; Star/unstar + Hide/Show in portfolio items work | Menu Radix→Base UI |
| ✅ | Asset Detail — header coin capsule | Coin icon + ticker render correctly in the nav bar | NavBar `leadingContent` rename |
| ✅ | Asset Detail — chart options menu (gear) | Trigger opens; toggle "show/hide transactions" works | Menu Radix→Base UI |
| ✅ | Asset Detail — price chart | Renders across all timeframes; ticks/axis/line look correct (x-axis hidden) | visualization bump |
| FIXESD | Send — network fees menu | Trigger opens; fee presets / custom / coin-control selectable | Menu Radix→Base UI |
| FIXED | Send — custom fees, "pay fees in" asset selector | Trigger (list item) opens; radio selection updates ticker | Menu Radix→Base UI |
| ✅ | MyWallet — avatar / context menu | Avatar + notification dot render (sm/md); context menu opens | DotIndicator/Avatar |
| ✅ | Crypto icons across app | Icons render (markets, accounts, send/receive) | crypto-icons 2.0.4 |

#### Mobile (`live-mobile`)

| ✅ | Flow | What to verify | Reason |
|----|------|----------------|--------|
| ✅ | Top bar — transaction history icon | Red unread dot shows/size looks right when unread ops exist | DotIndicator rescale |
| ✅  | Top bar — MyWallet avatar | Avatar + notification dot render correctly (size md) | Avatar showNotification |
| ✅  | App boot / global bottom sheets | App launches; tooltips/bottom sheets still work after `GlobalSelectBottomSheet` removal | Select removal |
| ✅  | Any screen using OptionList / pickers | Selection bottom sheets open and select correctly | Select→OptionList |
| ✅  | Asset Detail / portfolio charts | LineChart renders + scrubber/tooltip work across timeframes | visualization bump |
| ✅  | Crypto icons across app | Icons render (markets, accounts, send/receive) | crypto-icons 2.0.4 |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31810](https://ledgerhq.atlassian.net/browse/LIVE-31810)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-31810]: https://ledgerhq.atlassian.net/browse/LIVE-31810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ