### PR TITLE
[LWDM] feat: add content card completeness verification

### DIFF
--- a/.changeset/slimy-owls-shop.md
+++ b/.changeset/slimy-owls-shop.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Add content card completeness verification

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/useGenericAwarenessModalViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/useGenericAwarenessModalViewModel.ts
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useRef } from "react";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
-import type { GenericAwarenessModalContentCard } from "@ledgerhq/live-common/genericAwarenessModal";
+import {
+  isGenericAwarenessModalContentCardReady,
+  type GenericAwarenessModalContentCard,
+} from "@ledgerhq/live-common/genericAwarenessModal";
 import type { State } from "~/renderer/reducers";
 import { openDialog } from "~/renderer/reducers/dialogs";
 import {
@@ -37,7 +40,12 @@ const useGenericAwarenessModalViewModel = (): GenericAwarenessModalViewProps => 
 
   // Deeplink may set campaignId before Braze content cards are in the store.
   useEffect(() => {
-    if (isOpen || campaignId === undefined || !contentCard) {
+    if (
+      isOpen ||
+      campaignId === undefined ||
+      !contentCard ||
+      !isGenericAwarenessModalContentCardReady(contentCard)
+    ) {
       return;
     }
     dispatch(openDialog(GENERIC_AWARENESS_MODAL_DIALOG_ID));

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/testUtils/fixtures.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/testUtils/fixtures.ts
@@ -40,6 +40,7 @@ export const appStartFeatureIntroCard: GenericAwarenessModalFeatureIntro = {
       subtitle: "Your private keys never leave your hardware — not even Ledger can access them.",
     },
   ],
+  isReady: true,
 };
 
 export const featureIntroCampaignCard: GenericAwarenessModalFeatureIntro = {
@@ -67,6 +68,7 @@ export const featureIntroCampaignCard: GenericAwarenessModalFeatureIntro = {
         "If an exchange pauses withdrawals, assets on your signer remain under your control.",
     },
   ],
+  isReady: true,
 };
 
 export const carouselCampaignCard: GenericAwarenessModalCarousel = {
@@ -102,6 +104,7 @@ export const carouselCampaignCard: GenericAwarenessModalCarousel = {
       primaryButtonLink: "https://www.ledger.com/coin/wallet/ethereum",
     },
   ],
+  isReady: true,
 };
 
 export const promptCampaignCard: GenericAwarenessModalPrompt = {

--- a/apps/ledger-live-desktop/src/renderer/reducers/__tests__/genericAwarenessModalSlice.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/__tests__/genericAwarenessModalSlice.test.ts
@@ -14,11 +14,13 @@ const cards: GenericAwarenessModalContentCard[] = [
     secondaryButtonLabel: "",
     secondaryButtonLink: "",
     items: [],
+    isReady: true,
   },
   {
     layout: GenericAwarenessModalLayout.Carousel,
     id: "2",
     data: [],
+    isReady: true,
   },
 ];
 

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenericAwarenessModalDevTool/utils/buildContentCardFromForm.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenericAwarenessModalDevTool/utils/buildContentCardFromForm.ts
@@ -21,6 +21,7 @@ export const buildContentCardFromForm = (
         primaryButtonLabel: slide.primaryButtonLabel,
         primaryButtonLink: slide.primaryButtonLink,
       })),
+      isReady: true,
     };
   }
 
@@ -53,5 +54,6 @@ export const buildContentCardFromForm = (
       title: item.title,
       subtitle: item.subtitle,
     })),
+    isReady: true,
   };
 };

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenericAwarenessModalDevTool/utils/sampleContentCards.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenericAwarenessModalDevTool/utils/sampleContentCards.ts
@@ -54,11 +54,13 @@ export const sampleGenericAwarenessModalContentCards: GenericAwarenessModalConte
         subtitle: "Your private keys never leave your hardware — not even Ledger can access them.",
       },
     ],
+    isReady: true,
   },
   {
     layout: GenericAwarenessModalLayout.Carousel,
     id: DEV_CAMPAIGN_IDS.appStartCarousel,
     data: sampleCarouselSlides,
+    isReady: true,
   },
   {
     layout: GenericAwarenessModalLayout.FeatureIntro,
@@ -86,11 +88,13 @@ export const sampleGenericAwarenessModalContentCards: GenericAwarenessModalConte
           "If an exchange pauses withdrawals, assets on your signer remain under your control.",
       },
     ],
+    isReady: true,
   },
   {
     layout: GenericAwarenessModalLayout.Carousel,
     id: DEV_CAMPAIGN_IDS.bannerCarousel,
     data: sampleCarouselSlides,
+    isReady: true,
   },
   {
     layout: GenericAwarenessModalLayout.Prompt,

--- a/apps/ledger-live-mobile/src/dynamicContent/buildLocalGenericAwarenessModalCards.test.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/buildLocalGenericAwarenessModalCards.test.ts
@@ -45,6 +45,7 @@ describe("buildLocalGenericAwarenessModalCards", () => {
         id: "debug-carousel",
         isLocal: true,
         layout: GenericAwarenessModalLayout.Carousel,
+        isReady: true,
         data: [
           {
             title: "Second",
@@ -105,6 +106,7 @@ describe("buildLocalGenericAwarenessModalCards", () => {
         id: "debug-feature-intro",
         isLocal: true,
         layout: GenericAwarenessModalLayout.FeatureIntro,
+        isReady: true,
         title: "Feature intro",
         subtitle: "Feature intro subtitle",
         imageUrl: "https://example.com/main.png",

--- a/apps/ledger-live-mobile/src/dynamicContent/buildLocalGenericAwarenessModalCards.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/buildLocalGenericAwarenessModalCards.ts
@@ -112,12 +112,14 @@ function buildCarouselBrazeCards({
   campaignId,
   items,
 }: GenericAwarenessModalDebugFormValues): GenericAwarenessModalDebugBrazeCard[] {
+  const slideCount = String(items.length);
   return items.map((item, index) => ({
     id: `${campaignId}-${index}`,
     extras: {
       campaignId,
       layout: GenericAwarenessModalLayout.Carousel,
       location: GENERIC_AWARENESS_LOCATION,
+      slideCount,
       index: String(index),
       title: item.title,
       subtitle: item.subtitle,
@@ -131,6 +133,7 @@ function buildCarouselBrazeCards({
 function buildFeatureIntroBrazeCards(
   values: GenericAwarenessModalDebugFormValues,
 ): GenericAwarenessModalDebugBrazeCard[] {
+  const itemCount = String(1 + values.items.length);
   const mainCard: GenericAwarenessModalDebugBrazeCard = {
     id: `${values.campaignId}-main`,
     extras: {
@@ -138,6 +141,7 @@ function buildFeatureIntroBrazeCards(
       layout: GenericAwarenessModalLayout.FeatureIntro,
       role: "main",
       location: GENERIC_AWARENESS_LOCATION,
+      itemCount,
       title: values.title,
       subtitle: values.subtitle,
       imageUrl: values.imageUrl,
@@ -155,6 +159,7 @@ function buildFeatureIntroBrazeCards(
       layout: GenericAwarenessModalLayout.FeatureIntro,
       role: "item",
       location: GENERIC_AWARENESS_LOCATION,
+      itemCount,
       index: String(index),
       icon: item.icon,
       title: item.title,

--- a/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/components/__tests__/FeatureIntroLayout.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/components/__tests__/FeatureIntroLayout.test.tsx
@@ -29,6 +29,7 @@ const content: GenericAwarenessModalFeatureIntro = {
       subtitle: "Verify transactions on a secure screen.",
     },
   ],
+  isReady: true,
 };
 
 describe("FeatureIntroLayout", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/mockData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/mockData.ts
@@ -41,6 +41,7 @@ export const carouselWithoutPrimaryLinksMockData: GenericAwarenessModalContentCa
       primaryButtonLink: "",
     },
   ],
+  isReady: true,
 };
 
 export const carouselWithPrimaryLinksMockData: GenericAwarenessModalContentCard = {
@@ -80,6 +81,7 @@ export const carouselWithPrimaryLinksMockData: GenericAwarenessModalContentCard 
       primaryButtonLink: "ledgerlive://earn",
     },
   ],
+  isReady: true,
 };
 
 export const carouselMockData: GenericAwarenessModalContentCard = {
@@ -119,6 +121,7 @@ export const carouselMockData: GenericAwarenessModalContentCard = {
       primaryButtonLink: "",
     },
   ],
+  isReady: true,
 };
 
 export const featureIntroMockData: GenericAwarenessModalContentCard = {
@@ -148,6 +151,7 @@ export const featureIntroMockData: GenericAwarenessModalContentCard = {
       subtitle: "Manage thousands of assets in one place.",
     },
   ],
+  isReady: true,
 };
 
 export const promptMockData: GenericAwarenessModalPrompt = {

--- a/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/screens/useGenericAwarenessModalLogic.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/screens/useGenericAwarenessModalLogic.ts
@@ -1,6 +1,9 @@
 import { useCallback, useMemo } from "react";
 import { useFocusEffect } from "@react-navigation/native";
-import type { GenericAwarenessModalContentCard } from "@ledgerhq/live-common/genericAwarenessModal";
+import {
+  isGenericAwarenessModalContentCardReady,
+  type GenericAwarenessModalContentCard,
+} from "@ledgerhq/live-common/genericAwarenessModal";
 
 const GENERIC_AWARENESS_MODAL_APP_START_ID_PREFIX = "app_start";
 
@@ -24,10 +27,14 @@ export function getGenericAwarenessModalCardToOpen({
   cards,
 }: GenericAwarenessModalLogicInput): GenericAwarenessModalContentCard | undefined {
   if (campaignId) {
-    return cards.find(card => card.id === campaignId);
+    return cards.find(
+      card => card.id === campaignId && isGenericAwarenessModalContentCardReady(card),
+    );
   }
 
-  return cards.find(card => isGenericAwarenessModalAppStartId(card.id));
+  return cards.find(
+    card => isGenericAwarenessModalAppStartId(card.id) && isGenericAwarenessModalContentCardReady(card),
+  );
 }
 
 export function useGenericAwarenessModalLogic(

--- a/apps/ledger-live-mobile/src/reducers/genericAwarenessModal.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/genericAwarenessModal.test.ts
@@ -11,6 +11,7 @@ const buildCarouselCard = (id: string): GenericAwarenessModalContentCard => ({
   id,
   layout: GenericAwarenessModalLayout.Carousel,
   data: [],
+  isReady: true,
 });
 
 const buildLocalCarouselCard = (id: string): GenericAwarenessModalMobileContentCard => ({

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/index.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/index.test.tsx
@@ -32,6 +32,7 @@ const withExistingBrazeCard = (state: State): State => ({
         id: "braze-card",
         layout: GenericAwarenessModalLayout.Carousel,
         data: [],
+        isReady: true,
       },
     ],
   },

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -635,6 +635,7 @@
     "src/genericAwarenessModal/buildContentCards.ts",
     "src/genericAwarenessModal/buildFeatureIntro.ts",
     "src/genericAwarenessModal/buildPrompt.ts",
+    "src/genericAwarenessModal/campaignCompleteness.ts",
     "src/genericAwarenessModal/getGenericAwarenessModalContentCard.ts",
     "src/genericAwarenessModal/index.ts",
     "src/genericAwarenessModal/types.ts",

--- a/libs/ledger-live-common/src/genericAwarenessModal/__tests__/buildCarousel.test.ts
+++ b/libs/ledger-live-common/src/genericAwarenessModal/__tests__/buildCarousel.test.ts
@@ -19,6 +19,7 @@ describe("buildCarousel", () => {
       layout: GenericAwarenessModalLayout.Carousel,
       campaignId: "campaign-1",
       index: "1",
+      slideCount: "2",
       title: "Slide 2",
       subtitle: "Second",
       imageUrl: "https://example.com/2.png",
@@ -29,6 +30,7 @@ describe("buildCarousel", () => {
       layout: GenericAwarenessModalLayout.Carousel,
       campaignId: "campaign-1",
       index: "0",
+      slideCount: "2",
       title: "Slide 1",
       subtitle: "First",
       imageUrl: "https://example.com/1.png",
@@ -41,6 +43,7 @@ describe("buildCarousel", () => {
     expect(carousel).toEqual({
       layout: GenericAwarenessModalLayout.Carousel,
       id: "campaign-1",
+      isReady: true,
       data: [
         {
           title: "Slide 1",
@@ -65,6 +68,7 @@ describe("buildCarousel", () => {
       layout: GenericAwarenessModalLayout.Carousel,
       campaignId: "campaign-1",
       index: "0",
+      slideCount: "1",
     });
 
     const carousel = buildCarousel("campaign-1", [cardWithoutSlideFields]);
@@ -79,6 +83,42 @@ describe("buildCarousel", () => {
         primaryButtonLink: "",
       },
     ]);
+  });
+
+  it("should return carousel with isReady false when slideCount is set but not all slides have arrived", () => {
+    const firstSlideCard = makeCard("1", {
+      layout: GenericAwarenessModalLayout.Carousel,
+      campaignId: "campaign-1",
+      index: "0",
+      slideCount: "2",
+      title: "Slide 1",
+    });
+
+    const carousel = buildCarousel("campaign-1", [firstSlideCard]);
+
+    expect(carousel?.isReady).toBe(false);
+    expect(carousel?.data).toHaveLength(1);
+  });
+
+  it("should build carousel when received slides match slideCount", () => {
+    const firstSlideCard = makeCard("1", {
+      layout: GenericAwarenessModalLayout.Carousel,
+      campaignId: "campaign-1",
+      index: "0",
+      slideCount: "2",
+      title: "Slide 1",
+    });
+    const secondSlideCard = makeCard("2", {
+      layout: GenericAwarenessModalLayout.Carousel,
+      campaignId: "campaign-1",
+      index: "1",
+      slideCount: "2",
+      title: "Slide 2",
+    });
+
+    const carousel = buildCarousel("campaign-1", [firstSlideCard, secondSlideCard]);
+
+    expect(carousel?.data).toHaveLength(2);
   });
 
   it("should skip invalid carousel inputs", () => {
@@ -97,6 +137,7 @@ describe("buildCarousel", () => {
       layout: GenericAwarenessModalLayout.Carousel,
       campaignId: "campaign-1",
       index: "1",
+      slideCount: "1",
       title: "Valid",
     });
 

--- a/libs/ledger-live-common/src/genericAwarenessModal/__tests__/buildContentCards.test.ts
+++ b/libs/ledger-live-common/src/genericAwarenessModal/__tests__/buildContentCards.test.ts
@@ -2,6 +2,8 @@ import {
   FeatureIntroRole,
   GenericAwarenessModalLayout,
   type GenericAwarenessModalBrazeCard,
+  type GenericAwarenessModalCarousel,
+  type GenericAwarenessModalFeatureIntro,
   type GenericAwarenessModalInputExtras,
 } from "../types";
 import {
@@ -97,6 +99,7 @@ describe("buildGenericAwarenessModalContentCards", () => {
       layout: GenericAwarenessModalLayout.Carousel,
       campaignId: "campaign-1",
       index: "1",
+      slideCount: "2",
       title: "Slide 2",
       subtitle: "Second",
       imageUrl: "https://example.com/2.png",
@@ -107,6 +110,7 @@ describe("buildGenericAwarenessModalContentCards", () => {
       layout: GenericAwarenessModalLayout.Carousel,
       campaignId: "campaign-1",
       index: "0",
+      slideCount: "2",
       title: "Slide 1",
       subtitle: "First",
       imageUrl: "https://example.com/1.png",
@@ -121,6 +125,7 @@ describe("buildGenericAwarenessModalContentCards", () => {
       {
         layout: GenericAwarenessModalLayout.Carousel,
         id: "campaign-1",
+        isReady: true,
         data: [
           {
             title: "Slide 1",
@@ -146,6 +151,7 @@ describe("buildGenericAwarenessModalContentCards", () => {
       layout: GenericAwarenessModalLayout.FeatureIntro,
       campaignId: "campaign-2",
       role: FeatureIntroRole.Main,
+      itemCount: "3",
       title: "Main title",
       subtitle: "Main subtitle",
       imageUrl: "https://example.com/hero.png",
@@ -159,6 +165,7 @@ describe("buildGenericAwarenessModalContentCards", () => {
       campaignId: "campaign-2",
       role: FeatureIntroRole.Item,
       index: "1",
+      itemCount: "3",
       icon: "icon-2",
       title: "Item 2",
       subtitle: "Item 2 subtitle",
@@ -168,6 +175,7 @@ describe("buildGenericAwarenessModalContentCards", () => {
       campaignId: "campaign-2",
       role: FeatureIntroRole.Item,
       index: "0",
+      itemCount: "3",
       icon: "icon-1",
       title: "Item 1",
       subtitle: "Item 1 subtitle",
@@ -180,6 +188,7 @@ describe("buildGenericAwarenessModalContentCards", () => {
       {
         layout: GenericAwarenessModalLayout.FeatureIntro,
         id: "campaign-2",
+        isReady: true,
         title: "Main title",
         subtitle: "Main subtitle",
         imageUrl: "https://example.com/hero.png",
@@ -302,6 +311,7 @@ describe("buildGenericAwarenessModalContentCards", () => {
       layout: GenericAwarenessModalLayout.Carousel,
       campaignId: "campaign-1",
       index: "0",
+      slideCount: "1",
     });
     const groupedCards = makeGroupedCards("campaign-1", [cardWithoutSlideFields]);
 
@@ -311,6 +321,7 @@ describe("buildGenericAwarenessModalContentCards", () => {
       {
         layout: GenericAwarenessModalLayout.Carousel,
         id: "campaign-1",
+        isReady: true,
         data: [
           {
             title: "",
@@ -331,6 +342,7 @@ describe("processGenericAwarenessModalBrazeCards", () => {
       layout: GenericAwarenessModalLayout.Carousel,
       campaignId: "campaign-1",
       index: "0",
+      slideCount: "1",
       title: "Slide 1",
       subtitle: "First",
       imageUrl: "https://example.com/1.png",
@@ -367,6 +379,7 @@ describe("processGenericAwarenessModalBrazeCards", () => {
       {
         layout: GenericAwarenessModalLayout.Carousel,
         id: "campaign-1",
+        isReady: true,
         data: [
           {
             title: "Slide 1",
@@ -385,6 +398,7 @@ describe("processGenericAwarenessModalBrazeCards", () => {
       layout: GenericAwarenessModalLayout.Carousel,
       campaignId: "campaign-carousel",
       index: "0",
+      slideCount: "1",
       title: "Slide",
       subtitle: "Subtitle",
       imageUrl: "https://example.com/slide.png",
@@ -395,6 +409,7 @@ describe("processGenericAwarenessModalBrazeCards", () => {
       layout: GenericAwarenessModalLayout.FeatureIntro,
       campaignId: "campaign-feature-intro",
       role: FeatureIntroRole.Main,
+      itemCount: "1",
       title: "Main",
       subtitle: "Main subtitle",
       imageUrl: "https://example.com/hero.png",
@@ -453,12 +468,14 @@ describe("processGenericAwarenessModalBrazeCards", () => {
       campaignId: "Campaign-A",
       layout: "carousel",
       index: "0",
+      slideCount: "2",
       title: "Slide 1",
     });
     const secondCard = makeCard("2", {
       campaignId: "campaign-a",
       layout: "CAROUSEL",
       index: "1",
+      slideCount: "2",
       title: "Slide 2",
     });
 
@@ -468,6 +485,7 @@ describe("processGenericAwarenessModalBrazeCards", () => {
     expect(contentCards[0]).toEqual({
       layout: GenericAwarenessModalLayout.Carousel,
       id: "Campaign-A",
+      isReady: true,
       data: [
         expect.objectContaining({ title: "Slide 1" }),
         expect.objectContaining({ title: "Slide 2" }),
@@ -481,6 +499,7 @@ describe("processGenericAwarenessModalBrazeCards", () => {
       campaignId: "campaign-carousel",
       location: "GENERIC_AWARENESS_MODAL",
       index: "0",
+      slideCount: "2",
       title: "Slide 1",
     });
     const carouselCardTwo = makeCard("carousel-2", {
@@ -488,6 +507,7 @@ describe("processGenericAwarenessModalBrazeCards", () => {
       campaignId: "campaign-carousel",
       location: "generic_awareness_modal",
       index: "1",
+      slideCount: "2",
       title: "Slide 2",
     });
     const featureIntroMainCard = makeCard("feature-intro-main", {
@@ -495,6 +515,7 @@ describe("processGenericAwarenessModalBrazeCards", () => {
       campaignId: "campaign-feature-intro",
       location: "Generic_Awareness_Modal",
       role: "MAIN",
+      itemCount: "2",
       title: "Main title",
       subtitle: "Main subtitle",
     });
@@ -504,6 +525,7 @@ describe("processGenericAwarenessModalBrazeCards", () => {
       location: "generic_awareness_modal",
       role: "item",
       index: "0",
+      itemCount: "2",
       icon: "icon",
       title: "Item title",
       subtitle: "Item subtitle",
@@ -537,6 +559,64 @@ describe("processGenericAwarenessModalBrazeCards", () => {
     const contentCards = processGenericAwarenessModalBrazeCards([carouselCard, promptCard]);
 
     expect(contentCards).toEqual([]);
+  });
+
+  it("should build carousel campaigns with isReady false until slideCount cards are received", () => {
+    const firstSlideCard = makeCard("1", {
+      layout: GenericAwarenessModalLayout.Carousel,
+      campaignId: "campaign-partial-carousel",
+      index: "0",
+      slideCount: "2",
+      title: "Slide 1",
+    });
+
+    const partialContentCards = processGenericAwarenessModalBrazeCards([firstSlideCard]);
+    const secondSlideCard = makeCard("2", {
+      layout: GenericAwarenessModalLayout.Carousel,
+      campaignId: "campaign-partial-carousel",
+      index: "1",
+      slideCount: "2",
+      title: "Slide 2",
+    });
+
+    const completeContentCards = processGenericAwarenessModalBrazeCards([
+      firstSlideCard,
+      secondSlideCard,
+    ]);
+
+    expect(partialContentCards).toHaveLength(1);
+    expect((partialContentCards[0] as GenericAwarenessModalCarousel).isReady).toBe(false);
+    expect(completeContentCards).toHaveLength(1);
+    expect(completeContentCards[0]?.id).toBe("campaign-partial-carousel");
+    expect((completeContentCards[0] as GenericAwarenessModalCarousel).isReady).toBe(true);
+  });
+
+  it("should build feature intro campaigns with isReady false until itemCount cards are received", () => {
+    const mainCard = makeCard("main", {
+      layout: GenericAwarenessModalLayout.FeatureIntro,
+      campaignId: "campaign-partial-feature-intro",
+      role: FeatureIntroRole.Main,
+      itemCount: "2",
+      title: "Main",
+    });
+
+    const partialContentCards = processGenericAwarenessModalBrazeCards([mainCard]);
+    const itemCard = makeCard("item", {
+      layout: GenericAwarenessModalLayout.FeatureIntro,
+      campaignId: "campaign-partial-feature-intro",
+      role: FeatureIntroRole.Item,
+      index: "0",
+      itemCount: "2",
+      title: "Item",
+    });
+
+    const completeContentCards = processGenericAwarenessModalBrazeCards([mainCard, itemCard]);
+
+    expect(partialContentCards).toHaveLength(1);
+    expect((partialContentCards[0] as GenericAwarenessModalFeatureIntro).isReady).toBe(false);
+    expect(completeContentCards).toHaveLength(1);
+    expect(completeContentCards[0]?.id).toBe("campaign-partial-feature-intro");
+    expect((completeContentCards[0] as GenericAwarenessModalFeatureIntro).isReady).toBe(true);
   });
 
   it("should trim whitespace from braze string fields when building content cards", () => {

--- a/libs/ledger-live-common/src/genericAwarenessModal/__tests__/buildFeatureIntro.test.ts
+++ b/libs/ledger-live-common/src/genericAwarenessModal/__tests__/buildFeatureIntro.test.ts
@@ -21,6 +21,7 @@ describe("buildFeatureIntro", () => {
       campaignId: "campaign-1",
       role: FeatureIntroRole.Item,
       index: "1",
+      itemCount: "3",
       icon: "icon-2",
       title: "Item 2",
       subtitle: "Second item",
@@ -29,6 +30,7 @@ describe("buildFeatureIntro", () => {
       layout: GenericAwarenessModalLayout.FeatureIntro,
       campaignId: "campaign-1",
       role: FeatureIntroRole.Main,
+      itemCount: "3",
       title: "Main title",
       subtitle: "Main subtitle",
       imageUrl: "https://example.com/hero.png",
@@ -42,6 +44,7 @@ describe("buildFeatureIntro", () => {
       campaignId: "campaign-1",
       role: FeatureIntroRole.Item,
       index: "0",
+      itemCount: "3",
       icon: "icon-1",
       title: "Item 1",
       subtitle: "First item",
@@ -52,6 +55,7 @@ describe("buildFeatureIntro", () => {
     expect(featureIntro).toEqual({
       layout: GenericAwarenessModalLayout.FeatureIntro,
       id: "campaign-1",
+      isReady: true,
       title: "Main title",
       subtitle: "Main subtitle",
       imageUrl: "https://example.com/hero.png",
@@ -79,12 +83,14 @@ describe("buildFeatureIntro", () => {
       layout: GenericAwarenessModalLayout.FeatureIntro,
       campaignId: "campaign-1",
       role: FeatureIntroRole.Main,
+      itemCount: "2",
     });
     const itemCard = makeCard("item", {
       layout: GenericAwarenessModalLayout.FeatureIntro,
       campaignId: "campaign-1",
       role: FeatureIntroRole.Item,
       index: "0",
+      itemCount: "2",
     });
 
     const featureIntro = buildFeatureIntro("campaign-1", [mainCard, itemCard]);
@@ -92,6 +98,7 @@ describe("buildFeatureIntro", () => {
     expect(featureIntro).toEqual({
       layout: GenericAwarenessModalLayout.FeatureIntro,
       id: "campaign-1",
+      isReady: true,
       title: "",
       subtitle: "",
       imageUrl: "",
@@ -107,6 +114,44 @@ describe("buildFeatureIntro", () => {
         },
       ],
     });
+  });
+
+  it("should return feature intro with isReady false when itemCount is set but not all cards have arrived", () => {
+    const mainCard = makeCard("main", {
+      layout: GenericAwarenessModalLayout.FeatureIntro,
+      campaignId: "campaign-1",
+      role: FeatureIntroRole.Main,
+      itemCount: "2",
+      title: "Main",
+    });
+
+    const featureIntro = buildFeatureIntro("campaign-1", [mainCard]);
+
+    expect(featureIntro?.isReady).toBe(false);
+    expect(featureIntro?.items).toHaveLength(0);
+  });
+
+  it("should build feature intro when received cards match itemCount", () => {
+    const mainCard = makeCard("main", {
+      layout: GenericAwarenessModalLayout.FeatureIntro,
+      campaignId: "campaign-1",
+      role: FeatureIntroRole.Main,
+      itemCount: "2",
+      title: "Main",
+    });
+    const itemCard = makeCard("item", {
+      layout: GenericAwarenessModalLayout.FeatureIntro,
+      campaignId: "campaign-1",
+      role: FeatureIntroRole.Item,
+      index: "0",
+      itemCount: "2",
+      title: "Item",
+    });
+
+    const featureIntro = buildFeatureIntro("campaign-1", [mainCard, itemCard]);
+
+    expect(featureIntro?.items).toHaveLength(1);
+    expect(featureIntro?.isReady).toBe(true);
   });
 
   it("should return undefined when there is no valid main input", () => {
@@ -128,6 +173,7 @@ describe("buildFeatureIntro", () => {
       layout: GenericAwarenessModalLayout.FeatureIntro,
       campaignId: "campaign-1",
       role: FeatureIntroRole.Main,
+      itemCount: "5",
       title: "Main",
     });
     const itemCards = [0, 1, 2, 3].map(index =>
@@ -136,6 +182,7 @@ describe("buildFeatureIntro", () => {
         campaignId: "campaign-1",
         role: FeatureIntroRole.Item,
         index: String(index),
+        itemCount: "5",
         icon: `icon-${index}`,
         title: `Item ${index}`,
         subtitle: `Subtitle ${index}`,
@@ -157,6 +204,7 @@ describe("buildFeatureIntro", () => {
       layout: GenericAwarenessModalLayout.FeatureIntro,
       campaignId: "campaign-1",
       role: FeatureIntroRole.Main,
+      itemCount: "2",
       title: "Main",
     });
     const missingIndexCard = makeCard("missing-index", {
@@ -170,6 +218,7 @@ describe("buildFeatureIntro", () => {
       campaignId: "campaign-1",
       role: FeatureIntroRole.Item,
       index: "1",
+      itemCount: "2",
       title: "Valid",
     });
 

--- a/libs/ledger-live-common/src/genericAwarenessModal/__tests__/campaignCompleteness.test.ts
+++ b/libs/ledger-live-common/src/genericAwarenessModal/__tests__/campaignCompleteness.test.ts
@@ -1,0 +1,203 @@
+import {
+  countValidCarouselCards,
+  countValidFeatureIntroCards,
+  getExpectedItemCount,
+  getExpectedSlideCount,
+  hasReceivedAllCarouselSlides,
+  hasReceivedAllFeatureIntroCards,
+  parseCampaignCount,
+} from "../campaignCompleteness";
+import {
+  FeatureIntroRole,
+  GenericAwarenessModalLayout,
+  type GenericAwarenessModalBrazeCard,
+  type GenericAwarenessModalInputExtras,
+} from "../types";
+
+const makeCard = (
+  id: string,
+  extras: GenericAwarenessModalInputExtras,
+): GenericAwarenessModalBrazeCard => ({
+  id,
+  extras,
+});
+
+describe("parseCampaignCount", () => {
+  it("should parse positive integer strings and numbers", () => {
+    expect(parseCampaignCount("3")).toBe(3);
+    expect(parseCampaignCount(2)).toBe(2);
+  });
+
+  it("should return undefined for invalid values", () => {
+    expect(parseCampaignCount("0")).toBeUndefined();
+    expect(parseCampaignCount("-1")).toBeUndefined();
+    expect(parseCampaignCount("abc")).toBeUndefined();
+    expect(parseCampaignCount(undefined)).toBeUndefined();
+  });
+});
+
+describe("getExpectedSlideCount", () => {
+  it("should return undefined when slideCount is missing on any card", () => {
+    const card = makeCard("1", {
+      layout: GenericAwarenessModalLayout.Carousel,
+      campaignId: "campaign-1",
+      index: "0",
+    });
+
+    expect(getExpectedSlideCount([card])).toBeUndefined();
+  });
+
+  it("should return undefined when slideCount differs between cards", () => {
+    const firstSlide = makeCard("1", {
+      layout: GenericAwarenessModalLayout.Carousel,
+      campaignId: "campaign-1",
+      index: "0",
+      slideCount: "2",
+    });
+    const secondSlide = makeCard("2", {
+      layout: GenericAwarenessModalLayout.Carousel,
+      campaignId: "campaign-1",
+      index: "1",
+      slideCount: "3",
+    });
+
+    expect(getExpectedSlideCount([firstSlide, secondSlide])).toBeUndefined();
+  });
+});
+
+describe("hasReceivedAllCarouselSlides", () => {
+  it("should return undefined when slideCount is missing", () => {
+    const card = makeCard("1", {
+      layout: GenericAwarenessModalLayout.Carousel,
+      campaignId: "campaign-1",
+      index: "0",
+    });
+
+    expect(hasReceivedAllCarouselSlides([card])).toBeUndefined();
+  });
+
+  it("should return undefined when slideCount differs between cards", () => {
+    const firstSlide = makeCard("1", {
+      layout: GenericAwarenessModalLayout.Carousel,
+      campaignId: "campaign-1",
+      index: "0",
+      slideCount: "2",
+    });
+    const secondSlide = makeCard("2", {
+      layout: GenericAwarenessModalLayout.Carousel,
+      campaignId: "campaign-1",
+      index: "1",
+      slideCount: "3",
+    });
+
+    expect(hasReceivedAllCarouselSlides([firstSlide, secondSlide])).toBeUndefined();
+  });
+
+  it("should return false until all slides are received", () => {
+    const firstSlide = makeCard("1", {
+      layout: GenericAwarenessModalLayout.Carousel,
+      campaignId: "campaign-1",
+      index: "0",
+      slideCount: "2",
+    });
+    const secondSlide = makeCard("2", {
+      layout: GenericAwarenessModalLayout.Carousel,
+      campaignId: "campaign-1",
+      index: "1",
+      slideCount: "2",
+    });
+
+    expect(hasReceivedAllCarouselSlides([firstSlide])).toBe(false);
+    expect(getExpectedSlideCount([firstSlide])).toBe(2);
+    expect(countValidCarouselCards([firstSlide])).toBe(1);
+    expect(hasReceivedAllCarouselSlides([firstSlide, secondSlide])).toBe(true);
+  });
+});
+
+describe("getExpectedItemCount", () => {
+  it("should return undefined when itemCount is missing on any card", () => {
+    const mainCard = makeCard("main", {
+      layout: GenericAwarenessModalLayout.FeatureIntro,
+      campaignId: "campaign-1",
+      role: FeatureIntroRole.Main,
+    });
+
+    expect(getExpectedItemCount([mainCard])).toBeUndefined();
+  });
+
+  it("should return undefined when itemCount differs between cards", () => {
+    const mainCard = makeCard("main", {
+      layout: GenericAwarenessModalLayout.FeatureIntro,
+      campaignId: "campaign-1",
+      role: FeatureIntroRole.Main,
+      itemCount: "2",
+    });
+    const itemCard = makeCard("item", {
+      layout: GenericAwarenessModalLayout.FeatureIntro,
+      campaignId: "campaign-1",
+      role: FeatureIntroRole.Item,
+      index: "0",
+      itemCount: "3",
+    });
+
+    expect(getExpectedItemCount([mainCard, itemCard])).toBeUndefined();
+  });
+});
+
+describe("hasReceivedAllFeatureIntroCards", () => {
+  it("should return undefined when itemCount is missing", () => {
+    const mainCard = makeCard("main", {
+      layout: GenericAwarenessModalLayout.FeatureIntro,
+      campaignId: "campaign-1",
+      role: FeatureIntroRole.Main,
+    });
+
+    expect(hasReceivedAllFeatureIntroCards([mainCard])).toBeUndefined();
+  });
+
+  it("should return undefined when itemCount differs between cards", () => {
+    const mainCard = makeCard("main", {
+      layout: GenericAwarenessModalLayout.FeatureIntro,
+      campaignId: "campaign-1",
+      role: FeatureIntroRole.Main,
+      itemCount: "2",
+    });
+    const itemCard = makeCard("item", {
+      layout: GenericAwarenessModalLayout.FeatureIntro,
+      campaignId: "campaign-1",
+      role: FeatureIntroRole.Item,
+      index: "0",
+      itemCount: "3",
+    });
+
+    expect(hasReceivedAllFeatureIntroCards([mainCard, itemCard])).toBeUndefined();
+  });
+
+  it("should return false until all main and item cards are received", () => {
+    const mainCard = makeCard("main", {
+      layout: GenericAwarenessModalLayout.FeatureIntro,
+      campaignId: "campaign-1",
+      role: FeatureIntroRole.Main,
+      itemCount: "3",
+    });
+    const itemCard = makeCard("item", {
+      layout: GenericAwarenessModalLayout.FeatureIntro,
+      campaignId: "campaign-1",
+      role: FeatureIntroRole.Item,
+      index: "0",
+      itemCount: "3",
+    });
+    const secondItemCard = makeCard("item-1", {
+      layout: GenericAwarenessModalLayout.FeatureIntro,
+      campaignId: "campaign-1",
+      role: FeatureIntroRole.Item,
+      index: "1",
+      itemCount: "3",
+    });
+
+    expect(hasReceivedAllFeatureIntroCards([mainCard])).toBe(false);
+    expect(getExpectedItemCount([mainCard])).toBe(3);
+    expect(countValidFeatureIntroCards([mainCard, itemCard])).toBe(2);
+    expect(hasReceivedAllFeatureIntroCards([mainCard, itemCard, secondItemCard])).toBe(true);
+  });
+});

--- a/libs/ledger-live-common/src/genericAwarenessModal/__tests__/getGenericAwarenessModalContentCard.test.ts
+++ b/libs/ledger-live-common/src/genericAwarenessModal/__tests__/getGenericAwarenessModalContentCard.test.ts
@@ -6,10 +6,12 @@ const contentCards: GenericAwarenessModalContentCard[] = [
     layout: GenericAwarenessModalLayout.Carousel,
     id: "APP_START_carousel",
     data: [],
+    isReady: false,
   },
   {
     layout: GenericAwarenessModalLayout.FeatureIntro,
     id: "feature-intro",
+    isReady: false,
     title: "Feature intro",
     subtitle: "Feature intro subtitle",
     imageUrl: "https://example.com/image.png",

--- a/libs/ledger-live-common/src/genericAwarenessModal/buildCarousel.ts
+++ b/libs/ledger-live-common/src/genericAwarenessModal/buildCarousel.ts
@@ -1,3 +1,4 @@
+import { hasReceivedAllCarouselSlides } from "./campaignCompleteness";
 import {
   GenericAwarenessModalCarouselInputSchema,
   GenericAwarenessModalCarouselSlideSchema,
@@ -35,5 +36,10 @@ export const buildCarousel = (
     return undefined;
   }
 
-  return { layout: GenericAwarenessModalLayout.Carousel, id: campaignId, data };
+  return {
+    layout: GenericAwarenessModalLayout.Carousel,
+    id: campaignId,
+    data,
+    isReady: hasReceivedAllCarouselSlides(cards) === true,
+  };
 };

--- a/libs/ledger-live-common/src/genericAwarenessModal/buildFeatureIntro.ts
+++ b/libs/ledger-live-common/src/genericAwarenessModal/buildFeatureIntro.ts
@@ -1,3 +1,4 @@
+import { hasReceivedAllFeatureIntroCards } from "./campaignCompleteness";
 import {
   GenericAwarenessModalFeatureIntroItemInputSchema,
   GenericAwarenessModalFeatureIntroMainInputSchema,
@@ -66,5 +67,6 @@ export const buildFeatureIntro = (
     secondaryButtonLabel: main.secondaryButtonLabel,
     secondaryButtonLink: main.secondaryButtonLink,
     items,
+    isReady: hasReceivedAllFeatureIntroCards(cards) === true,
   };
 };

--- a/libs/ledger-live-common/src/genericAwarenessModal/campaignCompleteness.ts
+++ b/libs/ledger-live-common/src/genericAwarenessModal/campaignCompleteness.ts
@@ -1,0 +1,93 @@
+import {
+  GenericAwarenessModalCampaignCountSchema,
+  GenericAwarenessModalCarouselInputSchema,
+  GenericAwarenessModalFeatureIntroItemInputSchema,
+  GenericAwarenessModalFeatureIntroMainInputSchema,
+  GenericAwarenessModalLayout,
+  type GenericAwarenessModalBrazeCard,
+  type GenericAwarenessModalContentCard,
+} from "./types";
+
+export const parseCampaignCount = (
+  value: string | number | undefined,
+): number | undefined => {
+  const result = GenericAwarenessModalCampaignCountSchema.safeParse(value);
+  return result.success ? result.data : undefined;
+};
+
+const getConsistentCampaignCount = (
+  cards: readonly GenericAwarenessModalBrazeCard[],
+  field: "slideCount" | "itemCount",
+): number | undefined => {
+  if (cards.length === 0) {
+    return undefined;
+  }
+
+  let expectedCount: number | undefined;
+
+  for (const card of cards) {
+    const count = parseCampaignCount(card.extras?.[field]);
+    if (count === undefined) {
+      return undefined;
+    }
+
+    if (expectedCount === undefined) {
+      expectedCount = count;
+      continue;
+    }
+
+    if (expectedCount !== count) {
+      return undefined;
+    }
+  }
+
+  return expectedCount;
+};
+
+export const getExpectedSlideCount = (
+  cards: readonly GenericAwarenessModalBrazeCard[],
+): number | undefined => getConsistentCampaignCount(cards, "slideCount");
+
+export const getExpectedItemCount = (
+  cards: readonly GenericAwarenessModalBrazeCard[],
+): number | undefined => getConsistentCampaignCount(cards, "itemCount");
+
+export const countValidCarouselCards = (cards: readonly GenericAwarenessModalBrazeCard[]) =>
+  cards.filter(card => GenericAwarenessModalCarouselInputSchema.safeParse(card.extras).success)
+    .length;
+
+export const countValidFeatureIntroCards = (cards: readonly GenericAwarenessModalBrazeCard[]) =>
+  cards.filter(
+    card =>
+      GenericAwarenessModalFeatureIntroMainInputSchema.safeParse(card.extras).success ||
+      GenericAwarenessModalFeatureIntroItemInputSchema.safeParse(card.extras).success,
+  ).length;
+
+export const hasReceivedAllCarouselSlides = (
+  cards: readonly GenericAwarenessModalBrazeCard[],
+): boolean | undefined => {
+  const slideCount = getExpectedSlideCount(cards);
+  if (slideCount === undefined) {
+    return undefined;
+  }
+  return countValidCarouselCards(cards) === slideCount;
+};
+
+export const hasReceivedAllFeatureIntroCards = (
+  cards: readonly GenericAwarenessModalBrazeCard[],
+): boolean | undefined => {
+  const itemCount = getExpectedItemCount(cards);
+  if (itemCount === undefined) {
+    return undefined;
+  }
+  return countValidFeatureIntroCards(cards) === itemCount;
+};
+
+export const isGenericAwarenessModalContentCardReady = (
+  contentCard: GenericAwarenessModalContentCard,
+): boolean => {
+  if (contentCard.layout === GenericAwarenessModalLayout.Prompt) {
+    return true;
+  }
+  return contentCard.isReady;
+};

--- a/libs/ledger-live-common/src/genericAwarenessModal/index.ts
+++ b/libs/ledger-live-common/src/genericAwarenessModal/index.ts
@@ -1,4 +1,11 @@
 export { processGenericAwarenessModalBrazeCards } from "./buildContentCards";
+export {
+  getExpectedItemCount,
+  getExpectedSlideCount,
+  hasReceivedAllCarouselSlides,
+  hasReceivedAllFeatureIntroCards,
+  isGenericAwarenessModalContentCardReady,
+} from "./campaignCompleteness";
 export { getGenericAwarenessModalContentCard } from "./getGenericAwarenessModalContentCard";
 
 export { FeatureIntroRole, GenericAwarenessModalLayout } from "./types";

--- a/libs/ledger-live-common/src/genericAwarenessModal/types.ts
+++ b/libs/ledger-live-common/src/genericAwarenessModal/types.ts
@@ -65,6 +65,22 @@ export const GenericAwarenessModalInputIndexSchema = z
   .regex(/^\d+$/)
   .transform(value => Number.parseInt(value, 10));
 
+/** Expected number of Braze cards for a campaign (positive integer from extras). */
+export const GenericAwarenessModalCampaignCountSchema = z
+  .union([
+    z
+      .string()
+      .trim()
+      .regex(/^\d+$/)
+      .transform(value => Number.parseInt(value, 10)),
+    z.number().int().positive(),
+  ])
+  .pipe(z.number().int().positive());
+
+export const GenericAwarenessModalSlideCountSchema = GenericAwarenessModalCampaignCountSchema;
+
+export const GenericAwarenessModalItemCountSchema = GenericAwarenessModalCampaignCountSchema;
+
 export const GenericAwarenessModalCarouselSlideSchema = z.object({
   title: GenericAwarenessModalStringFieldSchema,
   subtitle: GenericAwarenessModalStringFieldSchema,
@@ -78,6 +94,7 @@ export const GenericAwarenessModalCarouselInputSchema = z.object({
   campaignId: GenericAwarenessModalCampaignIdInputSchema,
   index: GenericAwarenessModalInputIndexSchema,
   location: GenericAwarenessModalLocationInputSchema,
+  slideCount: GenericAwarenessModalSlideCountSchema,
   title: GenericAwarenessModalStringFieldSchema,
   subtitle: GenericAwarenessModalStringFieldSchema,
   imageUrl: GenericAwarenessModalStringFieldSchema,
@@ -90,6 +107,7 @@ export const GenericAwarenessModalFeatureIntroMainInputSchema = z.object({
   campaignId: GenericAwarenessModalCampaignIdInputSchema,
   role: GenericAwarenessModalFeatureIntroMainRoleInputSchema,
   location: GenericAwarenessModalLocationInputSchema,
+  itemCount: GenericAwarenessModalItemCountSchema,
   title: GenericAwarenessModalStringFieldSchema,
   subtitle: GenericAwarenessModalStringFieldSchema,
   imageUrl: GenericAwarenessModalStringFieldSchema,
@@ -105,6 +123,7 @@ export const GenericAwarenessModalFeatureIntroItemInputSchema = z.object({
   role: GenericAwarenessModalFeatureIntroItemRoleInputSchema,
   index: GenericAwarenessModalInputIndexSchema,
   location: GenericAwarenessModalLocationInputSchema,
+  itemCount: GenericAwarenessModalItemCountSchema,
   icon: GenericAwarenessModalStringFieldSchema,
   title: GenericAwarenessModalStringFieldSchema,
   subtitle: GenericAwarenessModalStringFieldSchema,
@@ -186,6 +205,8 @@ export type GenericAwarenessModalInputExtras = Partial<{
   location: GenericAwarenessModalLocation | string;
   role: FeatureIntroRole | string;
   index: GenericAwarenessModalInputIndex;
+  slideCount: z.input<typeof GenericAwarenessModalSlideCountSchema>;
+  itemCount: z.input<typeof GenericAwarenessModalItemCountSchema>;
   title: string;
   subtitle: string;
   imageUrl: string;
@@ -206,6 +227,8 @@ export type GenericAwarenessModalCarousel = {
   layout: GenericAwarenessModalLayout.Carousel;
   id: string;
   data: GenericAwarenessModalCarouselSlide[];
+  /** True when all expected Braze cards for the campaign have been received. */
+  isReady: boolean;
 };
 
 export type GenericAwarenessModalFeatureIntroItem = {
@@ -225,6 +248,8 @@ export type GenericAwarenessModalFeatureIntro = {
   secondaryButtonLabel: string;
   secondaryButtonLink: string;
   items: GenericAwarenessModalFeatureIntroItem[];
+  /** True when all expected Braze cards for the campaign have been received. */
+  isReady: boolean;
 };
 
 export type GenericAwarenessModalPrompt = {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Add content card completeness verification.

### 📝 Description
This pull request introduces a new content card verification mechanism for the Generic Awareness Modal feature across both Ledger Live Desktop and Mobile. The main focus is to ensure that content cards are only shown to users when they are fully ready (i.e., all required slides or items have arrived), improving reliability and user experience. This is achieved by adding an `isReady` flag to content cards, updating logic to check this flag before displaying cards, and enhancing the card-building utilities and tests accordingly.

**Content Card Readiness & Verification:**

- Added an `isReady` property to all `GenericAwarenessModalContentCard` objects and updated fixtures, mock data, and test utilities to include this property, indicating when a card is ready to be displayed. [[1]](diffhunk://#diff-6145842dff019e1298a3005d2e28d7a29246cd4354eea3fc1076c497b9aaf9cdR43) [[2]](diffhunk://#diff-06f398d85f3a7cd4fb8c3d2d193b0d160dc5e6f27cbff0ee6ee947f58d2f39ccR17-R23) [[3]](diffhunk://#diff-e7b51f8860076b5670b71e0f9c43976d98cd414db3c8d06e67861268ef821534R57-R63) [[4]](diffhunk://#diff-ba36c4f63d38091d0b52b4f7f28b2e9cfe1cdda9534539cdc7474dc3b76f414fR44) [[5]](diffhunk://#diff-d830effd3fda54759bcacde94e0a179e11bffef2277946d76c7976d2f9b6352eR14) [[6]](diffhunk://#diff-f1680fc6eea0dde6c6b235689ff80ce8552b4aab132ab66fccd71348bdd8d439R35) [[7]](diffhunk://#diff-80f730724acafcdb8283bf863a0c2145d1464aede66ebb9401bbb3637af29856R32)
- Updated logic in both desktop and mobile hooks (`useGenericAwarenessModalViewModel.ts`, `useGenericAwarenessModalLogic.ts`) to check `isReady` via `isGenericAwarenessModalContentCardReady` before opening or selecting a card, preventing incomplete cards from being shown. [[1]](diffhunk://#diff-79f6e9f853e2bb8e34adf8a4be7c64874fd9d2c346093f1f542a812b37955fc8L3-R6) [[2]](diffhunk://#diff-79f6e9f853e2bb8e34adf8a4be7c64874fd9d2c346093f1f542a812b37955fc8L40-R48) [[3]](diffhunk://#diff-eb4d8d4898cac001dd8715d5a60e47cc713dfa42796c4093d505efef20679076L1-R6) [[4]](diffhunk://#diff-eb4d8d4898cac001dd8715d5a60e47cc713dfa42796c4093d505efef20679076L27-R37)

**Content Card Construction:**

- Modified card-building utilities and developer tools to set `isReady: true` when constructing cards, ensuring cards created via forms or sample data are marked as ready. [[1]](diffhunk://#diff-557215c71e919a109e34807495c1b2837e9b7f8e8b2ecbe4fc952df84efef861R24) [[2]](diffhunk://#diff-557215c71e919a109e34807495c1b2837e9b7f8e8b2ecbe4fc952df84efef861R57) [[3]](diffhunk://#diff-e7b51f8860076b5670b71e0f9c43976d98cd414db3c8d06e67861268ef821534R57-R63) [[4]](diffhunk://#diff-e7b51f8860076b5670b71e0f9c43976d98cd414db3c8d06e67861268ef821534R91-R97) [[5]](diffhunk://#diff-6145842dff019e1298a3005d2e28d7a29246cd4354eea3fc1076c497b9aaf9cdR71) [[6]](diffhunk://#diff-6145842dff019e1298a3005d2e28d7a29246cd4354eea3fc1076c497b9aaf9cdR107) [[7]](diffhunk://#diff-ba36c4f63d38091d0b52b4f7f28b2e9cfe1cdda9534539cdc7474dc3b76f414fR84) [[8]](diffhunk://#diff-ba36c4f63d38091d0b52b4f7f28b2e9cfe1cdda9534539cdc7474dc3b76f414fR124) [[9]](diffhunk://#diff-ba36c4f63d38091d0b52b4f7f28b2e9cfe1cdda9534539cdc7474dc3b76f414fR154) [[10]](diffhunk://#diff-b53af5bd2ac30789c4af1fed2a5a869df37e950b1ee4cc516a4883a60486cfacR48) [[11]](diffhunk://#diff-b53af5bd2ac30789c4af1fed2a5a869df37e950b1ee4cc516a4883a60486cfacR109)

**Carousel and Feature Intro Card Handling:**

- Enhanced carousel and feature intro card construction to include `slideCount` and `itemCount` properties, allowing the system to verify if all slides/items have been received before marking a card as ready. [[1]](diffhunk://#diff-19213453db4df96ed4b448ec9fbf15cff5b7bc7500203255cb3d5801c8b93333R115-R122) [[2]](diffhunk://#diff-19213453db4df96ed4b448ec9fbf15cff5b7bc7500203255cb3d5801c8b93333R136-R144) [[3]](diffhunk://#diff-19213453db4df96ed4b448ec9fbf15cff5b7bc7500203255cb3d5801c8b93333R162) [[4]](diffhunk://#diff-0a0a7fbe5f5d6cdeb75d48c74cea5640beb7187b2453eb955530202832e30c54R22) [[5]](diffhunk://#diff-0a0a7fbe5f5d6cdeb75d48c74cea5640beb7187b2453eb955530202832e30c54R33) [[6]](diffhunk://#diff-0a0a7fbe5f5d6cdeb75d48c74cea5640beb7187b2453eb955530202832e30c54R71)
- Updated and extended tests to verify carousel readiness, including scenarios where not all slides have arrived (`isReady: false`) and when all slides are present (`isReady: true`). [[1]](diffhunk://#diff-0a0a7fbe5f5d6cdeb75d48c74cea5640beb7187b2453eb955530202832e30c54R46) [[2]](diffhunk://#diff-0a0a7fbe5f5d6cdeb75d48c74cea5640beb7187b2453eb955530202832e30c54R88-R123) [[3]](diffhunk://#diff-0a0a7fbe5f5d6cdeb75d48c74cea5640beb7187b2453eb955530202832e30c54R140)

**Miscellaneous:**

- Added new source files to the list of imported modules for content card completeness tracking.
- Updated types and imports to support the new readiness and completeness features.

**Changelog:**

- Added a changeset entry for a minor release to `ledger-live-desktop`, `live-mobile`, and `@ledgerhq/live-common` describing the addition of content card verification.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31762]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31762]: https://ledgerhq.atlassian.net/browse/LIVE-31762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ