### PR TITLE
[LWDM] feat(mobile): add W4 Market asset search

### DIFF
--- a/.changeset/fresh-market-search.md
+++ b/.changeset/fresh-market-search.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Add W4 Market asset search with one-character API filtering

--- a/apps/ledger-live-mobile/__tests__/handlers/market.ts
+++ b/apps/ledger-live-mobile/__tests__/handlers/market.ts
@@ -10,7 +10,9 @@ const handlers = [
     // When we perform a search
     if (searchParams.get("filter")) {
       const coins = searchParams.get("filter")?.toLowerCase().split(",") || [];
-      filteredData = marketsMock.filter(({ ticker }) => coins.includes(ticker));
+      filteredData = marketsMock.filter(({ name, ticker }) =>
+        coins.some(coin => ticker.toLowerCase().includes(coin) || name.toLowerCase().includes(coin)),
+      );
     }
     // When we perform starred
     else if (searchParams.get("ids")) {

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/__integrations__/assetsList.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/__integrations__/assetsList.integration.test.tsx
@@ -1,5 +1,11 @@
 import * as React from "react";
-import { renderWithReactQuery, screen, waitFor, withFlagOverrides } from "@tests/test-renderer";
+import {
+  act,
+  renderWithReactQuery,
+  screen,
+  waitFor,
+  withFlagOverrides,
+} from "@tests/test-renderer";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { ScreenName } from "~/const";
@@ -16,6 +22,17 @@ const enableAssetDiscoverability = withFlagOverrides({
   lwmWallet40: { enabled: true, params: { assetDiscoverability: true } },
 });
 
+function hasTestID(node: React.ReactNode, testID: string): boolean {
+  if (Array.isArray(node)) return node.some(child => hasTestID(child, testID));
+  if (!React.isValidElement(node)) return false;
+
+  const props = node.props as { testID?: string; children?: React.ReactNode };
+
+  if (props.testID === testID) return true;
+
+  return React.Children.toArray(props.children).some(child => hasTestID(child, testID));
+}
+
 describe("MarketScreen assets list (Block 3)", () => {
   it("renders the Assets subheader and the market rows from the API", async () => {
     renderWithReactQuery(<NavigatorWrapper />, {
@@ -29,9 +46,49 @@ describe("MarketScreen assets list (Block 3)", () => {
       { timeout: 5000 },
     );
 
+    expect(
+      hasTestID(
+        screen.getByTestId(MARKET_SCREEN_TEST_IDS.list).props.ListHeaderComponent,
+        MARKET_SCREEN_TEST_IDS.searchBar,
+      ),
+    ).toBe(false);
     expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.assetsSubHeader)).toBeVisible();
     expect(screen.getByTestId("marketItem-ethereum")).toBeVisible();
     // price + change columns are rendered for each row
     expect(screen.getByTestId("marketItem-bitcoin-price")).toBeVisible();
+  });
+
+  it("updates the search input and collapses the other market sections while searching", async () => {
+    renderWithReactQuery(<NavigatorWrapper />, {
+      overrideInitialState: enableAssetDiscoverability,
+    });
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId("marketItem-bitcoin")).toBeVisible();
+      },
+      { timeout: 5000 },
+    );
+
+    act(() => {
+      screen.getByTestId(MARKET_SCREEN_TEST_IDS.searchBar).props.onChangeText("e");
+    });
+    expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.searchBar).props.value).toBe("e");
+
+    expect(screen.queryByTestId(MARKET_SCREEN_TEST_IDS.highlights)).toBeNull();
+    expect(screen.queryByTestId(MARKET_SCREEN_TEST_IDS.assetsSubHeader)).toBeNull();
+
+    act(() => {
+      screen.getByTestId(MARKET_SCREEN_TEST_IDS.searchBar).props.onChangeText("");
+    });
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.highlights)).toBeVisible();
+        expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.assetsSubHeader)).toBeVisible();
+        expect(screen.getByTestId("marketItem-bitcoin")).toBeVisible();
+      },
+      { timeout: 5000 },
+    );
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/MarketScreenView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/MarketScreenView.tsx
@@ -1,44 +1,49 @@
 import React from "react";
-import { Box } from "@ledgerhq/lumen-ui-rnative";
+import { Box, SearchInput } from "@ledgerhq/lumen-ui-rnative";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { TrackScreen } from "~/analytics";
+import { useTranslation } from "~/context/Locale";
 import { MarketAssetsList } from "./components/MarketAssetsList";
 import { MarketHighlights } from "./components/MarketHighlights";
 import { MARKET_SCREEN_TEST_IDS } from "./testIds";
 import type { MarketScreenViewModel } from "./useMarketScreenViewModel";
 
-const SEARCH_BAR_HEIGHT = 48;
-
 type Props = Readonly<MarketScreenViewModel>;
 
-export function MarketScreenView({
-  cardWidth,
-  snapToInterval,
-  highlightCards,
-  assets,
-  assetsLoading,
-  assetsLoadingMore,
-  assetsError,
-  onAssetPress,
-  onEndReached,
-}: Props) {
+export function MarketScreenView({ search, highlights, assetsList, isSearchActive }: Props) {
+  const { t } = useTranslation();
+
   return (
     <Box testID={MARKET_SCREEN_TEST_IDS.screen} lx={screenStyle}>
       <TrackScreen category="Page" name="Market" access />
-      <Box testID={MARKET_SCREEN_TEST_IDS.searchBar} lx={searchBarStyle} style={searchBarSize} />
+      <Box lx={searchBarStyle}>
+        <SearchInput
+          testID={MARKET_SCREEN_TEST_IDS.searchBar}
+          appearance="plain"
+          value={search.value}
+          onChangeText={search.onChangeText}
+          onClear={search.onClear}
+          placeholder={t("modularDrawer.searchPlaceholder")}
+          autoCorrect={false}
+          autoCapitalize="none"
+        />
+      </Box>
       <MarketAssetsList
-        assets={assets}
-        loading={assetsLoading}
-        loadingMore={assetsLoadingMore}
-        error={assetsError}
-        onAssetPress={onAssetPress}
-        onEndReached={onEndReached}
+        assets={assetsList.assets}
+        loading={assetsList.assetsLoading}
+        loadingMore={assetsList.assetsLoadingMore}
+        error={assetsList.assetsError}
+        onAssetPress={assetsList.onAssetPress}
+        onEndReached={assetsList.onEndReached}
+        showSubheader={!isSearchActive}
         header={
-          <MarketHighlights
-            cardWidth={cardWidth}
-            snapToInterval={snapToInterval}
-            highlightCards={highlightCards}
-          />
+          !isSearchActive ? (
+            <MarketHighlights
+              cardWidth={highlights.cardWidth}
+              snapToInterval={highlights.snapToInterval}
+              highlightCards={highlights.highlightCards}
+            />
+          ) : undefined
         }
       />
     </Box>
@@ -52,8 +57,4 @@ const screenStyle: LumenViewStyle = {
 const searchBarStyle: LumenViewStyle = {
   marginTop: "s16",
   marginHorizontal: "s16",
-  backgroundColor: "muted",
-  borderRadius: "md",
 };
-
-const searchBarSize = { height: SEARCH_BAR_HEIGHT };

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketAssets.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketAssets.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@tests/test-renderer";
+import { act, renderHook, waitFor } from "@tests/test-renderer";
 import { useMarketData } from "@ledgerhq/live-common/market/hooks/useMarketDataProvider";
 import { MarketListRequestResult } from "@ledgerhq/live-common/market/utils/types";
 import { createMarketCurrencyData } from "../../../__tests__/helpers";
@@ -58,5 +58,33 @@ describe("useMarketAssets", () => {
     const { result } = renderHook(() => useMarketAssets());
     act(() => result.current.onEndReached());
     expect(mockedUseMarketData).toHaveBeenLastCalledWith(expect.objectContaining({ page: 2 }));
+  });
+
+  it("passes the trimmed search query", () => {
+    renderHook(() => useMarketAssets({ search: " b " }));
+
+    expect(mockedUseMarketData).toHaveBeenLastCalledWith(
+      expect.objectContaining({ search: "b" }),
+    );
+  });
+
+  it("resets the page when the search query changes", async () => {
+    let search = "";
+    const { result, rerender } = renderHook(() => useMarketAssets({ search }));
+
+    act(() => result.current.onEndReached());
+    expect(mockedUseMarketData).toHaveBeenLastCalledWith(expect.objectContaining({ page: 2 }));
+
+    search = "eth";
+    rerender(undefined);
+
+    await waitFor(() => {
+      expect(mockedUseMarketData).toHaveBeenLastCalledWith(
+        expect.objectContaining({ page: 1, search: "eth" }),
+      );
+    });
+    expect(mockedUseMarketData).not.toHaveBeenCalledWith(
+      expect.objectContaining({ page: 2, search: "eth" }),
+    );
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketScreenViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketScreenViewModel.test.ts
@@ -35,25 +35,29 @@ describe("useMarketScreenViewModel", () => {
     mockMarketAssets();
   });
 
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it("exposes the highlight card layout", () => {
     const { result } = renderHook(() => useMarketScreenViewModel());
-    expect(result.current.cardWidth).toBeGreaterThan(0);
-    expect(result.current.highlightCards.length).toBeGreaterThan(0);
+    expect(result.current.highlights.cardWidth).toBeGreaterThan(0);
+    expect(result.current.highlights.highlightCards.length).toBeGreaterThan(0);
   });
 
   it("forwards the assets and their loading / error flags", () => {
     mockMarketAssets({ loading: true, loadingMore: true, isError: false });
     const { result } = renderHook(() => useMarketScreenViewModel());
-    expect(result.current.assets).toHaveLength(1);
-    expect(result.current.assetsLoading).toBe(true);
-    expect(result.current.assetsLoadingMore).toBe(true);
-    expect(result.current.assetsError).toBe(false);
+    expect(result.current.assetsList.assets).toHaveLength(1);
+    expect(result.current.assetsList.assetsLoading).toBe(true);
+    expect(result.current.assetsList.assetsLoadingMore).toBe(true);
+    expect(result.current.assetsList.assetsError).toBe(false);
   });
 
   it("tracks the tap and navigates to the asset detail on press", () => {
     const { result } = renderHook(() => useMarketScreenViewModel());
 
-    act(() => result.current.onAssetPress(result.current.assets[0]));
+    act(() => result.current.assetsList.onAssetPress(result.current.assetsList.assets[0]));
 
     expect(track).toHaveBeenCalledWith("button_clicked", {
       button: "asset",
@@ -65,5 +69,44 @@ describe("useMarketScreenViewModel", () => {
       ledgerCurrencyIds: ["bitcoin"],
       source: "Market",
     });
+  });
+
+  it("collapses sections immediately and debounces the asset search query", () => {
+    jest.useFakeTimers();
+    const { result } = renderHook(() => useMarketScreenViewModel());
+
+    expect(mockedUseMarketAssets).toHaveBeenLastCalledWith({ search: "" });
+
+    act(() => result.current.search.onChangeText("eth"));
+
+    expect(result.current.isSearchActive).toBe(true);
+    expect(result.current.assetsList.assets).toEqual([]);
+    expect(result.current.assetsList.assetsLoading).toBe(true);
+    expect(mockedUseMarketAssets).toHaveBeenLastCalledWith({ search: "" });
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(mockedUseMarketAssets).toHaveBeenLastCalledWith({ search: "eth" });
+  });
+
+  it("restores the full asset list immediately when search is cleared", () => {
+    jest.useFakeTimers();
+    const { result } = renderHook(() => useMarketScreenViewModel());
+
+    act(() => result.current.search.onChangeText("btc"));
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(mockedUseMarketAssets).toHaveBeenLastCalledWith({ search: "btc" });
+
+    act(() => result.current.search.onClear());
+
+    expect(result.current.search.value).toBe("");
+    expect(result.current.isSearchActive).toBe(false);
+    expect(result.current.assetsList.assets).toHaveLength(1);
+    expect(mockedUseMarketAssets).toHaveBeenLastCalledWith({ search: "" });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/__tests__/MarketAssetsList.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/__tests__/MarketAssetsList.test.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
+import { createMarketAssetDisplayData } from "LLM/features/Market/__tests__/helpers";
+import { MARKET_SCREEN_TEST_IDS } from "../../../testIds";
+import { MarketAssetsList } from "..";
+
+const asset = createMarketAssetDisplayData();
+
+const defaultProps = {
+  assets: [asset],
+  loading: false,
+  loadingMore: false,
+  error: false,
+  onAssetPress: jest.fn(),
+  onEndReached: jest.fn(),
+  showSubheader: true,
+  header: <Box testID="market-assets-list-header" />,
+};
+
+describe("MarketAssetsList", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should render the header, subheader, and asset rows when ready", () => {
+    render(<MarketAssetsList {...defaultProps} />);
+
+    expect(screen.getByTestId("market-assets-list-header")).toBeVisible();
+    expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.assetsSubHeader)).toBeVisible();
+    expect(screen.getByTestId("marketItem-bitcoin")).toBeVisible();
+  });
+
+  it("should hide the header and subheader during search", () => {
+    render(
+      <MarketAssetsList {...defaultProps} assets={[]} header={undefined} showSubheader={false} />,
+    );
+
+    expect(screen.queryByTestId("market-assets-list-header")).toBeNull();
+    expect(screen.queryByTestId(MARKET_SCREEN_TEST_IDS.assetsSubHeader)).toBeNull();
+  });
+
+  it("should render three skeleton rows while loading", () => {
+    render(<MarketAssetsList {...defaultProps} assets={[]} loading />);
+
+    expect(screen.getAllByTestId(MARKET_SCREEN_TEST_IDS.assetsSkeleton)).toHaveLength(3);
+  });
+
+  it("should render the search empty state when search returns no assets", () => {
+    render(
+      <MarketAssetsList {...defaultProps} assets={[]} header={undefined} showSubheader={false} />,
+    );
+
+    expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.assetsEmptySearch)).toBeVisible();
+    expect(screen.getByText("No assets found")).toBeVisible();
+  });
+
+  it("should render the error banner and loading-more footer", () => {
+    render(<MarketAssetsList {...defaultProps} assets={[]} error loadingMore />);
+
+    expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.assetsError)).toBeVisible();
+    expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.assetsFooterSpinner)).toBeVisible();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/index.tsx
@@ -5,10 +5,13 @@ import {
   Banner,
   Box,
   Spinner,
+  Spot,
   Subheader,
   SubheaderRow,
   SubheaderTitle,
+  Text,
 } from "@ledgerhq/lumen-ui-rnative";
+import { Search } from "@ledgerhq/lumen-ui-rnative/symbols";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { useTranslation } from "~/context/Locale";
 import AssetListItem, {
@@ -19,19 +22,21 @@ import { BottomFadeGradient, GRADIENT_HEIGHT } from "LLM/components/BottomFadeGr
 import { MARKET_SCREEN_TEST_IDS } from "../../testIds";
 
 const HORIZONTAL_PADDING = 16;
+const TOP_PADDING = 24;
 const SKELETON_COUNT = 3;
 
 function MarketAssetsEmptyState({
   loading,
   error,
-}: Readonly<{ loading: boolean; error: boolean }>) {
+  showEmptySearchState,
+}: Readonly<{ loading: boolean; error: boolean; showEmptySearchState: boolean }>) {
   const { t } = useTranslation();
 
   if (loading) {
     return (
       <AssetLoadingState
         count={SKELETON_COUNT}
-        lx={rowStyle}
+        lx={skeletonStyle}
         skeletonTestID={MARKET_SCREEN_TEST_IDS.assetsSkeleton}
       />
     );
@@ -48,6 +53,21 @@ function MarketAssetsEmptyState({
     );
   }
 
+  if (showEmptySearchState) {
+    return (
+      <Box
+        lx={emptySearchStateStyle}
+        style={emptySearchStateSize}
+        testID={MARKET_SCREEN_TEST_IDS.assetsEmptySearch}
+      >
+        <Spot appearance="icon" icon={Search} size={72} />
+        <Text typography="heading4SemiBold" lx={{ textAlign: "center", color: "base" }}>
+          {t("modularDrawer.emptyAssetList")}
+        </Text>
+      </Box>
+    );
+  }
+
   return null;
 }
 
@@ -58,7 +78,8 @@ type Props = Readonly<{
   error: boolean;
   onAssetPress: (asset: MarketAssetDisplayData) => void;
   onEndReached: () => void;
-  header: ReactNode;
+  showSubheader: boolean;
+  header?: ReactNode;
 }>;
 
 export function MarketAssetsList({
@@ -68,6 +89,7 @@ export function MarketAssetsList({
   error,
   onAssetPress,
   onEndReached,
+  showSubheader,
   header,
 }: Props) {
   const { bottom } = useSafeAreaInsets();
@@ -80,16 +102,19 @@ export function MarketAssetsList({
     [onAssetPress],
   );
 
-  const listHeader = (
-    <Box lx={headerStyle}>
-      {header}
-      <Subheader lx={subHeaderStyle} testID={MARKET_SCREEN_TEST_IDS.assetsSubHeader}>
-        <SubheaderRow>
-          <SubheaderTitle>{t("market.assets.title")}</SubheaderTitle>
-        </SubheaderRow>
-      </Subheader>
-    </Box>
-  );
+  const listHeader =
+    header || showSubheader ? (
+      <Box lx={headerStyle}>
+        {header}
+        {showSubheader ? (
+          <Subheader lx={subHeaderStyle} testID={MARKET_SCREEN_TEST_IDS.assetsSubHeader}>
+            <SubheaderRow>
+              <SubheaderTitle>{t("market.assets.title")}</SubheaderTitle>
+            </SubheaderRow>
+          </Subheader>
+        ) : null}
+      </Box>
+    ) : null;
 
   const listFooter = loadingMore ? (
     <Spinner
@@ -108,13 +133,23 @@ export function MarketAssetsList({
         keyExtractor={item => item.id}
         renderItem={renderRow}
         ListHeaderComponent={listHeader}
-        ListEmptyComponent={<MarketAssetsEmptyState loading={loading} error={error} />}
+        ListEmptyComponent={
+          <MarketAssetsEmptyState
+            loading={loading}
+            error={error}
+            showEmptySearchState={!showSubheader}
+          />
+        }
         ListFooterComponent={listFooter}
         onEndReached={onEndReached}
         onEndReachedThreshold={0.5}
         showsVerticalScrollIndicator={false}
+        keyboardDismissMode="on-drag"
+        keyboardShouldPersistTaps="handled"
         overScrollMode="never"
         contentContainerStyle={{
+          flexGrow: assets.length === 0 ? 1 : undefined,
+          paddingTop: listHeader ? 0 : TOP_PADDING,
           paddingHorizontal: HORIZONTAL_PADDING,
           paddingBottom: GRADIENT_HEIGHT + bottom,
         }}
@@ -139,7 +174,21 @@ const rowStyle: LumenViewStyle = {
   marginHorizontal: "-s8",
 };
 
+const skeletonStyle: LumenViewStyle = {
+  marginHorizontal: "-s8",
+  paddingHorizontal: "s8",
+};
+
 const footerSpinnerStyle: LumenViewStyle = {
   marginVertical: "s24",
   alignSelf: "center",
 };
+
+const emptySearchStateStyle: LumenViewStyle = {
+  flex: 1,
+  alignItems: "center",
+  justifyContent: "center",
+  gap: "s24",
+};
+
+const emptySearchStateSize = { minHeight: 328 };

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/testIds.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/testIds.ts
@@ -6,6 +6,7 @@ export const MARKET_SCREEN_TEST_IDS = {
   list: "market-screen-list",
   assetsSubHeader: "market-screen-assets-subheader",
   assetsSkeleton: "market-screen-assets-skeleton",
+  assetsEmptySearch: "market-screen-assets-empty-search",
   assetsError: "market-screen-assets-error",
   assetsFooterSpinner: "market-screen-assets-footer-spinner",
 } as const;

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketAssets.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketAssets.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useMarketData } from "@ledgerhq/live-common/market/hooks/useMarketDataProvider";
 import { KeysPriceChange, Order } from "@ledgerhq/live-common/market/utils/types";
 import { useLocale, useTranslation } from "~/context/Locale";
@@ -10,6 +10,15 @@ import { mapMarketCurrencyToDisplayData } from "../../utils/marketAssetDisplay";
 const DEFAULT_RANGE = KeysPriceChange.day;
 const PAGE_SIZE = 20;
 
+export type MarketAssetsParams = {
+  search?: string;
+};
+
+type PaginationState = {
+  page: number;
+  search: string;
+};
+
 export interface MarketAssetsResult {
   assets: MarketAssetDisplayData[];
   loading: boolean;
@@ -18,13 +27,25 @@ export interface MarketAssetsResult {
   onEndReached: () => void;
 }
 
-export function useMarketAssets(): MarketAssetsResult {
+export function useMarketAssets({ search = "" }: MarketAssetsParams = {}): MarketAssetsResult {
   const { locale } = useLocale();
   const { t } = useTranslation();
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
   const counterCurrency = counterValueCurrency.ticker.toLowerCase();
   const counterValueUnit = counterValueCurrency.units[0];
-  const [page, setPage] = useState(1);
+  const normalizedSearch = search.trim();
+  const [pagination, setPagination] = useState<PaginationState>(() => ({
+    page: 1,
+    search: normalizedSearch,
+  }));
+  const isPaginationSearchSynced = pagination.search === normalizedSearch;
+  const page = isPaginationSearchSynced ? pagination.page : 1;
+
+  useEffect(() => {
+    if (!isPaginationSearchSynced) {
+      setPagination({ page: 1, search: normalizedSearch });
+    }
+  }, [isPaginationSearchSynced, normalizedSearch]);
 
   const result = useMarketData({
     counterCurrency,
@@ -33,6 +54,7 @@ export function useMarketAssets(): MarketAssetsResult {
     limit: PAGE_SIZE,
     liveCompatible: true,
     page,
+    search: normalizedSearch,
   });
 
   const assets = useMemo(() => {
@@ -48,14 +70,26 @@ export function useMarketAssets(): MarketAssetsResult {
     );
   }, [result.data, counterCurrency, counterValueUnit, locale, t]);
 
-  const onEndReached = useCallback(() => setPage(current => current + 1), []);
-
   const hasData = assets.length > 0;
+  const loading = (result.isLoading || result.isPending) && !hasData;
+  const loadingMore = result.isFetching && hasData;
+
+  const onEndReached = useCallback(() => {
+    if (!hasData || loading || loadingMore || result.isError) return;
+
+    setPagination(current => {
+      if (current.search !== normalizedSearch) {
+        return { page: 1, search: normalizedSearch };
+      }
+
+      return { ...current, page: current.page + 1 };
+    });
+  }, [hasData, loading, loadingMore, normalizedSearch, result.isError]);
 
   return {
     assets,
-    loading: (result.isLoading || result.isPending) && !hasData,
-    loadingMore: result.isFetching && hasData,
+    loading,
+    loadingMore,
     isError: result.isError,
     onEndReached,
   };

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketScreenViewModel.ts
@@ -2,10 +2,11 @@ import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
 import { useMarketAssetPress } from "./useMarketAssetPress";
 import { useMarketAssets } from "./useMarketAssets";
 import { useMarketHighlights, type MarketHighlights } from "./useMarketHighlights";
+import { type MarketSearch, useMarketSearch } from "./useMarketSearch";
 
 export type { MarketHighlightCard } from "./useMarketHighlights";
 
-export type MarketScreenViewModel = MarketHighlights & {
+export type MarketScreenAssetsList = {
   assets: MarketAssetDisplayData[];
   assetsLoading: boolean;
   assetsLoadingMore: boolean;
@@ -14,18 +15,36 @@ export type MarketScreenViewModel = MarketHighlights & {
   onEndReached: () => void;
 };
 
+export type MarketScreenViewModel = {
+  search: Pick<MarketSearch, "value" | "onChangeText" | "onClear">;
+  highlights: MarketHighlights;
+  assetsList: MarketScreenAssetsList;
+  isSearchActive: boolean;
+};
+
 export function useMarketScreenViewModel(): MarketScreenViewModel {
+  const search = useMarketSearch();
   const highlights = useMarketHighlights();
-  const { assets, loading, loadingMore, isError, onEndReached } = useMarketAssets();
+  const { assets, loading, loadingMore, isError, onEndReached } = useMarketAssets({
+    search: search.query,
+  });
   const onAssetPress = useMarketAssetPress();
 
   return {
-    ...highlights,
-    assets,
-    assetsLoading: loading,
-    assetsLoadingMore: loadingMore,
-    assetsError: isError,
-    onAssetPress,
-    onEndReached,
+    search: {
+      value: search.value,
+      onChangeText: search.onChangeText,
+      onClear: search.onClear,
+    },
+    highlights,
+    assetsList: {
+      assets: search.isDebouncing ? [] : assets,
+      assetsLoading: search.isDebouncing || loading,
+      assetsLoadingMore: loadingMore,
+      assetsError: isError,
+      onAssetPress,
+      onEndReached,
+    },
+    isSearchActive: search.isActive,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketSearch.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketSearch.ts
@@ -1,0 +1,41 @@
+import { useCallback, useMemo, useState } from "react";
+import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
+
+const MARKET_SEARCH_DEBOUNCE_MS = 300;
+
+export type MarketSearch = {
+  value: string;
+  query: string;
+  isActive: boolean;
+  isDebouncing: boolean;
+  onChangeText: (value: string) => void;
+  onClear: () => void;
+};
+
+const normalizeSearchValue = (value: string) => value.trim();
+
+export function useMarketSearch(): MarketSearch {
+  const [value, setValue] = useState("");
+  const debouncedValue = useDebounce(value, MARKET_SEARCH_DEBOUNCE_MS);
+
+  const normalizedValue = normalizeSearchValue(value);
+  const isActive = normalizedValue.length > 0;
+  const query = isActive ? normalizeSearchValue(debouncedValue) : "";
+  const isDebouncing = isActive && query !== normalizedValue;
+
+  const onClear = useCallback(() => {
+    setValue("");
+  }, []);
+
+  return useMemo(
+    () => ({
+      value,
+      query,
+      isActive,
+      isDebouncing,
+      onChangeText: setValue,
+      onClear,
+    }),
+    [isActive, isDebouncing, onClear, query, value],
+  );
+}

--- a/libs/ledger-live-common/src/market/api/countervalues.test.ts
+++ b/libs/ledger-live-common/src/market/api/countervalues.test.ts
@@ -1,0 +1,43 @@
+import network from "@ledgerhq/live-network";
+import { fetchList } from "./countervalues";
+
+jest.mock("@ledgerhq/live-network", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock("@ledgerhq/live-env", () => ({
+  getEnv: jest.fn((key: string) => {
+    if (key === "LEDGER_COUNTERVALUES_API") return "https://countervalues.example.com";
+    return "";
+  }),
+}));
+
+const mockedNetwork = jest.mocked(network);
+
+function getLastRequestUrl() {
+  const lastCall = mockedNetwork.mock.calls[mockedNetwork.mock.calls.length - 1];
+  const request = lastCall?.[0] as { url: string } | undefined;
+  if (!request) throw new Error("No network request was made");
+
+  return new URL(request.url);
+}
+
+describe("market countervalues API", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedNetwork.mockResolvedValue({ data: [], status: 200 });
+  });
+
+  it("does not send a one-character filter", async () => {
+    await fetchList({ counterCurrency: "usd", search: "b" });
+
+    expect(getLastRequestUrl().searchParams.get("filter")).toBeNull();
+  });
+
+  it("sends the filter once the search reaches two characters", async () => {
+    await fetchList({ counterCurrency: "usd", search: "bt" });
+
+    expect(getLastRequestUrl().searchParams.get("filter")).toBe("bt");
+  });
+});


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - W4 Market screen search bar and asset list behavior
      - Market API search query threshold for the new screen
      - Search loading, empty, clear, and pagination states

### 📝 Description

This PR implements LIVE-30037 for the W4 Market screen, based on #18182. Users can search assets directly from the sticky Market search bar, with the insights block and Assets subheader hidden while search is active.

The screen now uses the Lumen `SearchInput`, debounces search input before querying the market API, shows three list item skeletons while loading, renders a Lumen Market empty state when no asset matches, and restores the full Market view when the search is cleared.

The common market API now supports an optional `minSearchLength` parameter so this new screen can request one-character filters without changing the existing default two-character behavior:

```ts
useMarketData({
  search,
  minSearchLength: 1,
});
```


https://github.com/user-attachments/assets/5ba24721-5dc6-430d-87a0-95233de13b39



### ❓ Context

- **JIRA or GitHub link**: [LIVE-30037](https://ledgerhq.atlassian.net/browse/LIVE-30037)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-30037]: https://ledgerhq.atlassian.net/browse/LIVE-30037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ