### PR TITLE
[LWM] feat(lwm): bottomsheet steps instead of page for the new send flow

### DIFF
--- a/.changeset/four-trains-shout.md
+++ b/.changeset/four-trains-shout.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+feat(lwm): bottomsheet steps for the new send flow

--- a/apps/ledger-live-mobile/src/mvvm/features/FlowWizard/FlowStackNavigator.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/FlowWizard/FlowStackNavigator.tsx
@@ -3,6 +3,7 @@ import { Platform } from "react-native";
 import {
   createNativeStackNavigator,
   type NativeStackHeaderRightProps,
+  type NativeStackNavigationOptions,
 } from "@react-navigation/native-stack";
 import { useTheme } from "styled-components/native";
 import { useNavigation, useRoute } from "@react-navigation/native";
@@ -27,6 +28,32 @@ type NavigationProps = BaseComposite<
 >;
 
 const Stack = createNativeStackNavigator();
+
+const bottomSheetScreenOptions: NativeStackNavigationOptions = {
+  presentation: "transparentModal",
+  animation: "none",
+  headerShown: false,
+  gestureEnabled: false,
+  contentStyle: {
+    backgroundColor: "transparent",
+  },
+};
+
+export function getFlowStackScreenOptions({
+  defaultOptions,
+  customOptions,
+  isBottomSheet,
+}: Readonly<{
+  defaultOptions: NativeStackNavigationOptions;
+  customOptions?: NativeStackNavigationOptions;
+  isBottomSheet?: boolean;
+}>): NativeStackNavigationOptions {
+  return {
+    ...defaultOptions,
+    ...customOptions,
+    ...(isBottomSheet === true ? bottomSheetScreenOptions : {}),
+  };
+}
 
 function FlowHeaderRightClose(props: Readonly<{ onClose: () => void }>) {
   return <CloseWithConfirmation onClose={props.onClose} />;
@@ -133,7 +160,11 @@ export function FlowStackNavigator<
 
         // Apply custom screen options
         const customOptions = getScreenOptions ? getScreenOptions(step, stepConfig) : {};
-        const stepScreenOptions = { ...defaultOptions, ...customOptions };
+        const stepScreenOptions = getFlowStackScreenOptions({
+          defaultOptions,
+          customOptions,
+          isBottomSheet: stepConfig?.bottomSheet,
+        });
 
         // Generate initial params
         const defaultInitialParams = {
@@ -146,7 +177,7 @@ export function FlowStackNavigator<
         return {
           step,
           name: screenName,
-          component: component as (props: Record<string, never>) => React.JSX.Element | null,
+          component,
           options: stepScreenOptions,
           initialParams,
           listeners: stepConfig?.listeners,

--- a/apps/ledger-live-mobile/src/mvvm/features/FlowWizard/__tests__/FlowStackNavigator.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/FlowWizard/__tests__/FlowStackNavigator.test.tsx
@@ -3,7 +3,7 @@ import { Text, TouchableOpacity } from "react-native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useNavigation, useRoute } from "@react-navigation/native";
 import { render, screen } from "@tests/test-renderer";
-import { FlowStackNavigator } from "../FlowStackNavigator";
+import { FlowStackNavigator, getFlowStackScreenOptions } from "../FlowStackNavigator";
 import type { FlowStep, StepRegistry } from "@ledgerhq/live-common/flows/wizard/types";
 import type { ReactNativeFlowConfig } from "../types";
 
@@ -117,6 +117,31 @@ describe("FlowStackNavigator", () => {
     renderFlowNavigator(registryWithMissing, defaultFlowConfig);
     expect(screen.getByTestId("flow-step1")).toBeOnTheScreen();
     expect(screen.getByText("Step 1")).toBeOnTheScreen();
+  });
+
+  it("should apply transparent modal options to bottom sheet steps", () => {
+    const options = getFlowStackScreenOptions({
+      defaultOptions: {
+        title: "Default title",
+      },
+      customOptions: {
+        title: "Custom title",
+      },
+      isBottomSheet: true,
+    });
+
+    expect(options).toEqual(
+      expect.objectContaining({
+        animation: "none",
+        contentStyle: {
+          backgroundColor: "transparent",
+        },
+        gestureEnabled: false,
+        headerShown: false,
+        presentation: "transparentModal",
+        title: "Custom title",
+      }),
+    );
   });
 
   describe("navigation", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/FlowWizard/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/FlowWizard/types.ts
@@ -1,4 +1,5 @@
 import type { NativeStackNavigationOptions } from "@react-navigation/native-stack";
+import type { NavigationProp, ParamListBase } from "@react-navigation/native";
 import type {
   FlowStep,
   FlowStepConfig,
@@ -8,9 +9,16 @@ import type {
 
 type ScreenComponentFunction = (props: Record<string, never>) => React.JSX.Element | null;
 
+export type ReactNativeFlowBottomSheetCloseParams = Readonly<{
+  navigation: NavigationProp<ParamListBase>;
+  close?: () => void;
+}>;
+
 export type ReactNativeFlowStepConfig<TStep extends FlowStep = FlowStep> = FlowStepConfig<TStep> &
   Readonly<{
     screenName?: string;
+    bottomSheet?: boolean;
+    onBottomSheetClose?: (params: ReactNativeFlowBottomSheetCloseParams) => void;
     screenOptions?: NativeStackNavigationOptions;
     initialParams?: Record<string, unknown>;
     listeners?: Record<string, unknown>;

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/SendFlowLayoutView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/SendFlowLayoutView.tsx
@@ -1,12 +1,24 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { View } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { useNavigation } from "@react-navigation/native";
+import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
+import { BottomSheetHeader, BottomSheetView } from "@ledgerhq/lumen-ui-rnative";
 import { useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
+import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
 
 import type { SendFlowLayoutProps } from "./types";
 import { SendHeader } from "./SendHeader";
+import { useSendFlowActions } from "../context/SendFlowContext";
+import { useCurrentSendFlowStep } from "../hooks/useCurrentSendFlowStep";
+import type { SendFlowNavigationProp } from "../types";
 
 export function SendFlowLayoutView({ headerRight, headerContent, children }: SendFlowLayoutProps) {
+  const navigation = useNavigation<SendFlowNavigationProp>();
+  const { bottom: bottomInset } = useSafeAreaInsets();
+  const { close } = useSendFlowActions();
+  const [, currentStepConfig] = useCurrentSendFlowStep();
+  const isBottomSheet = currentStepConfig?.bottomSheet === true;
+
   const styles = useStyleSheet(
     theme => ({
       container: {
@@ -22,9 +34,57 @@ export function SendFlowLayoutView({ headerRight, headerContent, children }: Sen
         paddingHorizontal: theme.spacings.s16,
         flex: 1,
       },
+      bottomSheetContainer: {
+        flex: 1,
+      },
+      bottomSheetContent: {
+        flex: 1,
+        paddingBottom: bottomInset + theme.spacings.s24,
+      },
+      bottomSheetBodyContent: {
+        paddingHorizontal: theme.spacings.s16,
+        paddingBottom: theme.spacings.s24,
+        flex: 1,
+      },
     }),
-    [],
+    [bottomInset],
   );
+
+  const handleBottomSheetClose = useCallback(() => {
+    if (!navigation.isFocused()) {
+      return;
+    }
+
+    if (currentStepConfig?.onBottomSheetClose) {
+      currentStepConfig.onBottomSheetClose({ navigation, close });
+      return;
+    }
+
+    if (navigation.canGoBack()) {
+      navigation.goBack();
+      return;
+    }
+
+    close();
+  }, [close, currentStepConfig, navigation]);
+
+  if (isBottomSheet) {
+    return (
+      <View style={styles.bottomSheetContainer}>
+        <QueuedDrawerBottomSheet
+          isRequestingToBeOpened
+          snapPoints="medium"
+          onClose={handleBottomSheetClose}
+        >
+          <BottomSheetView style={styles.bottomSheetContent}>
+            <BottomSheetHeader density="compact" />
+            {headerContent ? <View style={styles.headerContent}>{headerContent}</View> : null}
+            <View style={styles.bottomSheetBodyContent}>{children}</View>
+          </BottomSheetView>
+        </QueuedDrawerBottomSheet>
+      </View>
+    );
+  }
 
   return (
     <SafeAreaView style={styles.container} edges={["top", "bottom"]}>

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/__tests__/SendFlowLayoutView.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/__tests__/SendFlowLayoutView.test.tsx
@@ -1,0 +1,257 @@
+import React from "react";
+import { Text, View } from "react-native";
+import type { StyleProp, ViewStyle } from "react-native";
+import { useNavigation } from "@react-navigation/native";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+import { SEND_FLOW_STEP } from "@ledgerhq/live-common/flows/send/types";
+
+import { SendFlowLayoutView } from "../SendFlowLayoutView";
+import { useSendFlowActions } from "../../context/SendFlowContext";
+import { useCurrentSendFlowStep } from "../../hooks/useCurrentSendFlowStep";
+import type { SendStepConfig } from "../../types";
+
+const mockQueuedDrawerBottomSheet = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: jest.fn(),
+}));
+
+jest.mock("react-native-safe-area-context", () => {
+  const RN = jest.requireActual<typeof import("react-native")>("react-native");
+
+  return {
+    SafeAreaView: ({
+      children,
+      style,
+    }: {
+      children: React.ReactNode;
+      style?: StyleProp<ViewStyle>;
+    }) => <RN.View style={style}>{children}</RN.View>,
+    useSafeAreaInsets: () => ({
+      top: 0,
+      bottom: 10,
+      left: 0,
+      right: 0,
+    }),
+  };
+});
+
+jest.mock("@ledgerhq/lumen-ui-rnative", () => {
+  const RN = jest.requireActual<typeof import("react-native")>("react-native");
+
+  return {
+    BottomSheetModalProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    BottomSheetHeader: () => <RN.View testID="bottom-sheet-header" />,
+    BottomSheetView: ({
+      children,
+      style,
+    }: {
+      children: React.ReactNode;
+      style?: StyleProp<ViewStyle>;
+    }) => (
+      <RN.View testID="bottom-sheet-view" style={style}>
+        {children}
+      </RN.View>
+    ),
+  };
+});
+
+jest.mock("../SendHeader", () => {
+  const RN = jest.requireActual<typeof import("react-native")>("react-native");
+
+  return {
+    SendHeader: ({ headerRight }: { headerRight?: React.ReactNode }) => (
+      <RN.View testID="send-header">{headerRight}</RN.View>
+    ),
+  };
+});
+
+jest.mock("@ledgerhq/lumen-ui-rnative/styles", () => ({
+  useStyleSheet: (
+    createStyles: (theme: {
+      colors: { bg: { base: string } };
+      spacings: Record<"s12" | "s16" | "s24", number>;
+    }) => unknown,
+  ) =>
+    createStyles({
+      colors: { bg: { base: "#ffffff" } },
+      spacings: { s12: 12, s16: 16, s24: 24 },
+    }),
+}));
+
+jest.mock("LLM/components/QueuedDrawer/QueuedDrawerBottomSheet", () => {
+  const RN = jest.requireActual<typeof import("react-native")>("react-native");
+
+  return function MockQueuedDrawerBottomSheet({
+    children,
+    isRequestingToBeOpened,
+    onClose,
+    snapPoints,
+  }: {
+    children: React.ReactNode;
+    isRequestingToBeOpened?: boolean;
+    onClose?: () => void;
+    snapPoints?: string;
+  }) {
+    mockQueuedDrawerBottomSheet({ isRequestingToBeOpened, onClose, snapPoints });
+
+    if (!isRequestingToBeOpened) return null;
+
+    return (
+      <RN.View testID="queued-drawer-bottom-sheet">
+        <RN.Pressable testID="queued-drawer-close" onPress={onClose}>
+          <RN.Text>Close</RN.Text>
+        </RN.Pressable>
+        {children}
+      </RN.View>
+    );
+  };
+});
+
+jest.mock("../../context/SendFlowContext", () => ({
+  useSendFlowActions: jest.fn(),
+}));
+
+jest.mock("../../hooks/useCurrentSendFlowStep", () => ({
+  useCurrentSendFlowStep: jest.fn(),
+}));
+
+const mockClose = jest.fn();
+const mockNavigation = {
+  isFocused: jest.fn(() => true),
+  canGoBack: jest.fn(),
+  goBack: jest.fn(),
+};
+
+const bottomSheetStepConfig: SendStepConfig = {
+  id: SEND_FLOW_STEP.SIGNATURE,
+  canGoBack: false,
+  bottomSheet: true,
+};
+
+function mockCurrentStepConfig(stepConfig: SendStepConfig = bottomSheetStepConfig) {
+  jest.mocked(useCurrentSendFlowStep).mockReturnValue([SEND_FLOW_STEP.SIGNATURE, stepConfig]);
+}
+
+function mockSendFlowActions(): ReturnType<typeof useSendFlowActions> {
+  return {
+    transaction: {
+      setTransaction: jest.fn(),
+      updateTransaction: jest.fn(),
+      setRecipient: jest.fn(),
+      setAccount: jest.fn(),
+    },
+    operation: {
+      onOperationBroadcasted: jest.fn(),
+      onTransactionError: jest.fn(),
+      onSigned: jest.fn(),
+      onRetry: jest.fn(),
+    },
+    status: {
+      setStatus: jest.fn(),
+      setError: jest.fn(),
+      setSuccess: jest.fn(),
+      resetStatus: jest.fn(),
+    },
+    close: mockClose,
+    setAccountAndNavigate: jest.fn(),
+    setRecipientSearchValue: jest.fn(),
+    clearRecipientSearch: jest.fn(),
+  };
+}
+
+describe("SendFlowLayoutView", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(useNavigation).mockReturnValue(mockNavigation);
+    jest.mocked(useSendFlowActions).mockReturnValue(mockSendFlowActions());
+    mockCurrentStepConfig();
+  });
+
+  it("should render bottom sheet steps in a queued drawer with safe area padding", () => {
+    render(
+      <SendFlowLayoutView>
+        <Text>Signature step</Text>
+      </SendFlowLayoutView>,
+    );
+
+    expect(screen.getByTestId("queued-drawer-bottom-sheet")).toBeOnTheScreen();
+    expect(mockQueuedDrawerBottomSheet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isRequestingToBeOpened: true,
+        snapPoints: "medium",
+      }),
+    );
+    expect(screen.getByTestId("bottom-sheet-view")).toHaveStyle({ paddingBottom: 34 });
+  });
+
+  it("should go back by default when closing a bottom sheet step without custom close handler", () => {
+    mockNavigation.canGoBack.mockReturnValue(true);
+    render(
+      <SendFlowLayoutView>
+        <Text>Signature step</Text>
+      </SendFlowLayoutView>,
+    );
+
+    fireEvent.press(screen.getByTestId("queued-drawer-close"));
+
+    expect(mockNavigation.goBack).toHaveBeenCalledTimes(1);
+    expect(mockClose).not.toHaveBeenCalled();
+  });
+
+  it("should close the flow by default when the bottom sheet step cannot go back", () => {
+    mockNavigation.canGoBack.mockReturnValue(false);
+    render(
+      <SendFlowLayoutView>
+        <Text>Signature step</Text>
+      </SendFlowLayoutView>,
+    );
+
+    fireEvent.press(screen.getByTestId("queued-drawer-close"));
+
+    expect(mockNavigation.goBack).not.toHaveBeenCalled();
+    expect(mockClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("should delegate bottom sheet close to the current step config when provided", () => {
+    const onBottomSheetClose = jest.fn();
+    mockCurrentStepConfig({
+      ...bottomSheetStepConfig,
+      onBottomSheetClose,
+    });
+    mockNavigation.canGoBack.mockReturnValue(true);
+    render(
+      <SendFlowLayoutView>
+        <Text>Signature step</Text>
+      </SendFlowLayoutView>,
+    );
+
+    fireEvent.press(screen.getByTestId("queued-drawer-close"));
+
+    expect(onBottomSheetClose).toHaveBeenCalledWith({
+      navigation: mockNavigation,
+      close: mockClose,
+    });
+    expect(mockNavigation.goBack).not.toHaveBeenCalled();
+    expect(mockClose).not.toHaveBeenCalled();
+  });
+
+  it("should render the page layout for non bottom sheet steps", () => {
+    mockCurrentStepConfig({
+      id: SEND_FLOW_STEP.AMOUNT,
+      canGoBack: true,
+      bottomSheet: false,
+    });
+
+    render(
+      <SendFlowLayoutView headerContent={<Text>Header content</Text>}>
+        <View testID="page-content" />
+      </SendFlowLayoutView>,
+    );
+
+    expect(screen.queryByTestId("queued-drawer-bottom-sheet")).toBeNull();
+    expect(screen.getByText("Header content")).toBeOnTheScreen();
+    expect(screen.getByTestId("page-content")).toBeOnTheScreen();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/types.ts
@@ -1,6 +1,7 @@
 import type React from "react";
 
 export type SendFlowLayoutProps = Readonly<{
+  /** Page-layout only. Bottom sheet steps use the Lumen bottom sheet header. */
   headerRight?: React.ReactNode;
   headerContent?: React.ReactNode;
   children: React.ReactNode;

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/constants.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/constants.ts
@@ -47,6 +47,7 @@ export const SEND_STEP_CONFIGS: Record<SendFlowStep, SendStepConfig> = {
   [SEND_FLOW_STEP.CUSTOM_FEES]: {
     id: SEND_FLOW_STEP.CUSTOM_FEES,
     canGoBack: true,
+    floating: true,
     screenName: ScreenName.SendFlowCustomFees,
     showHeaderRight: false,
     screenOptions: {
@@ -57,6 +58,7 @@ export const SEND_STEP_CONFIGS: Record<SendFlowStep, SendStepConfig> = {
   [SEND_FLOW_STEP.COIN_CONTROL]: {
     id: SEND_FLOW_STEP.COIN_CONTROL,
     canGoBack: true,
+    floating: true,
     screenName: ScreenName.SendFlowCoinControl,
     showHeaderRight: false,
     screenOptions: {
@@ -70,6 +72,14 @@ export const SEND_STEP_CONFIGS: Record<SendFlowStep, SendStepConfig> = {
     showTitle: false,
     showHeaderRight: false,
     screenName: ScreenName.SendFlowSignature,
+    bottomSheet: true,
+    onBottomSheetClose: ({ navigation, close }) => {
+      if (navigation.canGoBack()) {
+        navigation.goBack();
+        return;
+      }
+      close?.();
+    },
     screenOptions: {
       ...TransparentHeaderNavigationOptions,
       title: "",
@@ -78,7 +88,8 @@ export const SEND_STEP_CONFIGS: Record<SendFlowStep, SendStepConfig> = {
   },
   [SEND_FLOW_STEP.CONFIRMATION]: {
     id: SEND_FLOW_STEP.CONFIRMATION,
-    canGoBack: true,
+    canGoBack: false,
+    showHeaderRight: false,
     showTitle: false,
     screenName: ScreenName.SendFlowConfirmation,
     screenOptions: {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useCurrentSendFlowStep.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useCurrentSendFlowStep.ts
@@ -1,0 +1,23 @@
+import { useMemo } from "react";
+import { useRoute } from "@react-navigation/native";
+import type { SendFlowStep } from "@ledgerhq/live-common/flows/send/types";
+
+import { SEND_FLOW_CONFIG } from "../constants";
+import type { SendStepConfig } from "../types";
+
+export function useCurrentSendFlowStep(): readonly [
+  SendFlowStep | undefined,
+  SendStepConfig | undefined,
+] {
+  const route = useRoute();
+
+  return useMemo(() => {
+    const stepConfig = Object.values(SEND_FLOW_CONFIG.stepConfigs).find(
+      config => (config.screenName ?? `SendFlow${config.id}`) === route.name,
+    );
+
+    if (!stepConfig) return [undefined, undefined];
+
+    return [stepConfig.id, stepConfig];
+  }, [route.name]);
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendHeaderViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendHeaderViewModel.ts
@@ -1,12 +1,12 @@
 import { useCallback, useMemo } from "react";
-import { useNavigation, useRoute } from "@react-navigation/native";
+import { useNavigation } from "@react-navigation/native";
 import { BigNumber } from "bignumber.js";
 import { useTranslation } from "~/context/Locale";
 
-import { SEND_FLOW_CONFIG } from "../constants";
-import { SEND_FLOW_STEP, type SendFlowStep } from "@ledgerhq/live-common/flows/send/types";
+import { SEND_FLOW_STEP } from "@ledgerhq/live-common/flows/send/types";
 import { useSendFlowData, useSendFlowActions } from "../context/SendFlowContext";
 import { useAvailableBalance } from "./useAvailableBalance";
+import { useCurrentSendFlowStep } from "./useCurrentSendFlowStep";
 import {
   getRecipientDisplayValue,
   getRecipientSearchPrefillValue,
@@ -38,26 +38,13 @@ export type SendHeaderViewModel = {
 
 export function useSendHeaderViewModel(): SendHeaderViewModel {
   const navigation = useNavigation();
-  const route = useRoute();
   const { t } = useTranslation();
   const { uiConfig, recipientSearch, state } = useSendFlowData();
   const { close, transaction, setRecipientSearchValue, clearRecipientSearch } =
     useSendFlowActions();
 
   const availableText = useAvailableBalance(state.account.account);
-
-  const [currentStep, currentStepConfig] = useMemo<
-    readonly [
-      SendFlowStep | undefined,
-      (typeof SEND_FLOW_CONFIG.stepConfigs)[SendFlowStep] | undefined,
-    ]
-  >(() => {
-    const step = SEND_FLOW_CONFIG.stepOrder.find(
-      step => SEND_FLOW_CONFIG.stepConfigs[step].screenName === route.name,
-    );
-    if (!step) return [undefined, undefined];
-    return [step, SEND_FLOW_CONFIG.stepConfigs[step]];
-  }, [route.name]);
+  const [currentStep, currentStepConfig] = useCurrentSendFlowStep();
 
   const currencyName = state.account.currency?.ticker ?? "";
   const showTitle = currentStepConfig?.showTitle !== false;

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/hooks/useAmountScreen.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/hooks/useAmountScreen.ts
@@ -44,7 +44,7 @@ export function useAmountScreen(): AmountScreenViewModel {
   }, [close]);
 
   const onReview = useCallback(() => {
-    navigation.navigate(ScreenName.SendFlowConfirmation);
+    navigation.navigate(ScreenName.SendFlowSignature);
   }, [navigation]);
 
   const onSelectCoinControl = useCallback(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CoinControl/hooks/useCoinControlScreen.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CoinControl/hooks/useCoinControlScreen.ts
@@ -34,7 +34,7 @@ export function useCoinControlScreen(): CoinControlScreenViewModel {
   const { bridgePending, status, transaction } = state.transaction;
 
   const onReview = useCallback(() => {
-    navigation.navigate(ScreenName.SendFlowConfirmation);
+    navigation.navigate(ScreenName.SendFlowSignature);
   }, [navigation]);
 
   const onGetFunds = useCallback(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Confirmation/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Confirmation/index.tsx
@@ -1,25 +1,15 @@
-import React, { useCallback } from "react";
-import { View, Button } from "react-native";
-import { useNavigation } from "@react-navigation/native";
+import React from "react";
+import { View } from "react-native";
 import { Text } from "@ledgerhq/lumen-ui-rnative";
-import { ScreenName } from "~/const";
 import { SendFlowLayout } from "../../components/SendFlowLayout";
-import type { SendFlowNavigationProp } from "../../types";
 
 export function ConfirmationScreen() {
-  const navigation = useNavigation<SendFlowNavigationProp>();
-
-  const handleContinue = useCallback(() => {
-    navigation.navigate(ScreenName.SendFlowSignature);
-  }, [navigation]);
-
   return (
     <SendFlowLayout>
       <View style={{ flex: 1 }}>
-        <Text typography="body2" lx={{ color: "muted", marginBottom: "s24" }}>
+        <Text typography="body2" lx={{ color: "muted" }}>
           {"Confirmation screen"}
         </Text>
-        <Button title="Continue" onPress={handleContinue} />
       </View>
     </SendFlowLayout>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/index.tsx
@@ -1,15 +1,25 @@
-import React from "react";
-import { View } from "react-native";
+import React, { useCallback } from "react";
+import { View, Button } from "react-native";
+import { useNavigation } from "@react-navigation/native";
 import { Text } from "@ledgerhq/lumen-ui-rnative";
+import { ScreenName } from "~/const";
 import { SendFlowLayout } from "../../components/SendFlowLayout";
+import type { SendFlowNavigationProp } from "../../types";
 
 export function SignatureScreen() {
+  const navigation = useNavigation<SendFlowNavigationProp>();
+
+  const handleContinue = useCallback(() => {
+    navigation.replace(ScreenName.SendFlowConfirmation);
+  }, [navigation]);
+
   return (
     <SendFlowLayout>
       <View style={{ flex: 1 }}>
-        <Text typography="body2" lx={{ color: "muted" }}>
+        <Text typography="body2" lx={{ color: "muted", marginBottom: "s24" }}>
           {"Signature screen"}
         </Text>
+        <Button title="Continue" onPress={handleContinue} />
       </View>
     </SendFlowLayout>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/types.ts
@@ -8,6 +8,7 @@ export type SendStepConfig = ReactNativeFlowStepConfig<SendFlowStep> &
     addressInput?: boolean;
     showTitle?: boolean;
     showHeaderRight?: boolean;
+    floating?: boolean;
   }>;
 
 export type SendFlowConfig = ReactNativeFlowConfig<SendFlowStep, SendStepConfig>;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

For the new send flow in LWM, we have steps that are bottomsheet, however, the current wizard and configs only allow steps to be "full pages"
This PR introduces a new kit of property for the `FlowStepConfig` to changes screens into bottomsheets

https://github.com/user-attachments/assets/4007acce-75db-4951-a74f-fb4978d7c008


### ❓ Context

- **[JIRA or GitHub link](https://ledgerhq.atlassian.net/browse/LIVE-31801)** <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
