### PR TITLE
[LWM] fix(LIVE-31796): prefill swap Receive field from Earn no-funds redirect

### DIFF
--- a/.changeset/earn-swap-prefill-receive.md
+++ b/.changeset/earn-swap-prefill-receive.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix the Earn "No funds" → Swap redirect not prefilling the Receive field. The Swap button now forwards the selected account as the swap destination (`defaultAccount`/`defaultParentAccount`), so the chosen asset is preselected in the Receive field, matching the Buy and Receive entry points.

--- a/apps/ledger-live-mobile/src/components/NoFunds/NoFunds.tsx
+++ b/apps/ledger-live-mobile/src/components/NoFunds/NoFunds.tsx
@@ -119,8 +119,12 @@ export default function NoFunds({ route }: Readonly<Props>) {
     navigateToSwapTab({
       navigation: navigation as unknown as NativeStackNavigationProp<BaseNavigatorStackParamList>,
       shouldDisplayWallet40MainNav,
+      params: {
+        defaultAccount: account,
+        defaultParentAccount: parentAccount,
+      },
     });
-  }, [navigation, page, shouldDisplayWallet40MainNav, track]);
+  }, [account, navigation, page, parentAccount, shouldDisplayWallet40MainNav, track]);
 
   const onBuy = useCallback(() => {
     track("button_clicked", {


### PR DESCRIPTION
## Bug

[LIVE-31796](https://ledgerhq.atlassian.net/browse/LIVE-31796) — Redirecting to Swap from the Earn **No funds** screen did not prefill the **Receive** field with the selected asset.

**Repro:** Earn → Asset → select an account with zero balance → **Swap** → Swap app opens with an empty Receive field.

## Root cause

On mobile, `NoFunds.tsx`'s `onSwap` called `navigateToSwapTab` **without any params**, so the swap live app opened with nothing to prefill. The sibling `onBuy`/`onReceiveFunds` handlers already forward the selected account/currency.

## Fix

Forward the selected account as the swap **destination**:

```ts
params: {
  defaultAccount: account,
  defaultParentAccount: parentAccount,
}
```

This flows through `useTranslateToSwapAccount` → `toAccountId` (and `toTokenId` for token accounts) → the swap-live-app account bootstrap, which resolves it as the Receive account and prefills the field.

## Scope note (LWMD)

Desktop already forwards the account: `NoFundsStake/index.tsx`'s `onSwap` passes `defaultAccountId: account.id`, which `useSwapDefaultAccounts` treats as the *to* account and forwards as `toAccountId`. So this fix is **mobile-only**.

## Testing

- Type-checked the changed file (no new errors).
- No existing unit tests for `NoFunds.tsx`; behavior verified by tracing the param → `toAccountId` → bootstrap chain.

## Pre-push review

`tracks-reviewer` — **REVIEW OUTCOME: pass**. One non-blocking hint: a regression test guarding the `defaultAccount` forwarding would be a nice safety net (no existing tests for this component).


[LIVE-31796]: https://ledgerhq.atlassian.net/browse/LIVE-31796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ