### PR TITLE
[LWM] feat(mobile): add market category switcher

### DIFF
--- a/.changeset/market-category-switcher.md
+++ b/.changeset/market-category-switcher.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add the Wallet 4.0 Market category switcher with favorites support.

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8082,6 +8082,13 @@
     "title": "Market",
     "assets": {
       "title": "Assets",
+      "emptyFavorites": "No favorites yet",
+      "categories": {
+        "accessibilityLabel": "Asset categories",
+        "all": "All",
+        "stocks": "Stocks",
+        "favorites": "Favorites"
+      },
       "error": {
         "title": "Couldn't load assets",
         "description": "Something went wrong while loading the asset list. Please try again later."

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/__integrations__/assetsList.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/__integrations__/assetsList.integration.test.tsx
@@ -9,6 +9,7 @@ import {
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { ScreenName } from "~/const";
+import type { State } from "~/reducers/types";
 import MarketNavigator from "../Navigator";
 import { MARKET_SCREEN_TEST_IDS } from "../screens/MarketScreen/testIds";
 
@@ -23,6 +24,17 @@ const NavigatorWrapper = () => (
 const enableAssetDiscoverability = withFlagOverrides({
   lwmWallet40: { enabled: true, params: { assetDiscoverability: true } },
 });
+
+function enableFavoritesCategory(starredMarketCoins: string[] = []) {
+  return withFlagOverrides(
+    { lwmWallet40: { enabled: true, params: { assetDiscoverability: true } } },
+    (state: State): State => ({
+      ...state,
+      settings: { ...state.settings, starredMarketCoins },
+      marketListConfig: { ...state.marketListConfig, category: "starred" },
+    }),
+  );
+}
 
 function hasTestID(node: React.ReactNode, testID: string): boolean {
   if (Array.isArray(node)) return node.some(child => hasTestID(child, testID));
@@ -55,8 +67,11 @@ describe("MarketScreen assets list (Block 3)", () => {
       ),
     ).toBe(false);
     expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.assetsSubHeader)).toBeVisible();
+    expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.assetsCategorySwitcher)).toBeVisible();
+    expect(screen.getByText("All")).toBeVisible();
+    expect(screen.getByText("Stocks")).toBeVisible();
+    expect(screen.getByText("Favorites")).toBeVisible();
     expect(screen.getByTestId("marketItem-ethereum")).toBeVisible();
-    // price + change columns are rendered for each row
     expect(screen.getByTestId("marketItem-bitcoin-price")).toBeVisible();
   });
 
@@ -79,6 +94,7 @@ describe("MarketScreen assets list (Block 3)", () => {
 
     expect(screen.queryByTestId(MARKET_SCREEN_TEST_IDS.highlights)).toBeNull();
     expect(screen.queryByTestId(MARKET_SCREEN_TEST_IDS.assetsSubHeader)).toBeNull();
+    expect(screen.queryByTestId(MARKET_SCREEN_TEST_IDS.assetsCategorySwitcher)).toBeNull();
 
     act(() => {
       screen.getByTestId(MARKET_SCREEN_TEST_IDS.searchBar).props.onChangeText("");
@@ -88,9 +104,38 @@ describe("MarketScreen assets list (Block 3)", () => {
       () => {
         expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.highlights)).toBeVisible();
         expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.assetsSubHeader)).toBeVisible();
+        expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.assetsCategorySwitcher)).toBeVisible();
         expect(screen.getByTestId("marketItem-bitcoin")).toBeVisible();
       },
       { timeout: 5000 },
     );
+  });
+
+  it("renders the favorites empty state when no market coin is starred", async () => {
+    renderWithReactQuery(<NavigatorWrapper />, {
+      overrideInitialState: enableFavoritesCategory(),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("No favorites yet")).toBeVisible();
+    });
+
+    expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.assetsFavoritesEmptyIcon)).toBeVisible();
+    expect(screen.queryByTestId("marketItem-bitcoin")).toBeNull();
+  });
+
+  it("renders only starred market coins in the Favorites category", async () => {
+    renderWithReactQuery(<NavigatorWrapper />, {
+      overrideInitialState: enableFavoritesCategory(["bitcoin"]),
+    });
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId("marketItem-bitcoin")).toBeVisible();
+      },
+      { timeout: 5000 },
+    );
+
+    expect(screen.queryByTestId("marketItem-ethereum")).toBeNull();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/MarketScreenView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/MarketScreenView.tsx
@@ -33,6 +33,10 @@ export function MarketScreenView({ search, highlights, assetsList, isSearchActiv
         loading={assetsList.assetsLoading}
         loadingMore={assetsList.assetsLoadingMore}
         error={assetsList.assetsError}
+        emptyState={assetsList.assetsEmptyState}
+        selectedCategory={assetsList.categories.selectedCategory}
+        categoryTabs={assetsList.categories.tabs}
+        onSelectCategory={assetsList.categories.onSelectCategory}
         onAssetPress={assetsList.onAssetPress}
         onEndReached={assetsList.onEndReached}
         showSubheader={!isSearchActive}

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketAssets.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketAssets.test.ts
@@ -63,9 +63,7 @@ describe("useMarketAssets", () => {
   it("passes the trimmed search query", () => {
     renderHook(() => useMarketAssets({ search: " b " }));
 
-    expect(mockedUseMarketData).toHaveBeenLastCalledWith(
-      expect.objectContaining({ search: "b" }),
-    );
+    expect(mockedUseMarketData).toHaveBeenLastCalledWith(expect.objectContaining({ search: "b" }));
   });
 
   it("resets the page when the search query changes", async () => {
@@ -86,5 +84,46 @@ describe("useMarketAssets", () => {
     expect(mockedUseMarketData).not.toHaveBeenCalledWith(
       expect.objectContaining({ page: 2, search: "eth" }),
     );
+  });
+
+  it("requests favorite assets with the starred ids sorted", () => {
+    const { result } = renderHook(() =>
+      useMarketAssets({ category: "starred", starredMarketCoins: ["ethereum", "bitcoin"] }),
+    );
+
+    expect(mockedUseMarketData).toHaveBeenLastCalledWith(
+      expect.objectContaining({ page: 1, starred: ["bitcoin", "ethereum"] }),
+    );
+    expect(result.current.emptyState).toBeUndefined();
+  });
+
+  it("shows the favorites empty state without fetching the full asset list", () => {
+    const { result } = renderHook(() =>
+      useMarketAssets({ category: "starred", starredMarketCoins: [] }),
+    );
+
+    expect(mockedUseMarketData).toHaveBeenLastCalledWith(
+      expect.objectContaining({ page: 0, starred: [] }),
+    );
+    expect(result.current.assets).toEqual([]);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.emptyState).toBe("favorites");
+
+    act(() => result.current.onEndReached());
+
+    expect(mockedUseMarketData).toHaveBeenLastCalledWith(
+      expect.objectContaining({ page: 0, starred: [] }),
+    );
+  });
+
+  it("searches all market assets while search is active", () => {
+    const { result } = renderHook(() =>
+      useMarketAssets({ search: " eth ", category: "starred", starredMarketCoins: [] }),
+    );
+
+    expect(mockedUseMarketData).toHaveBeenLastCalledWith(
+      expect.objectContaining({ page: 1, search: "eth", starred: undefined }),
+    );
+    expect(result.current.emptyState).toBeUndefined();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketScreenViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketScreenViewModel.test.ts
@@ -1,5 +1,6 @@
 import { act, renderHook } from "@tests/test-renderer";
 import { track } from "~/analytics";
+import type { State } from "~/reducers/types";
 import { createMarketAssetDisplayData } from "../../../__tests__/helpers";
 import { useMarketAssets } from "../useMarketAssets";
 import { useMarketScreenViewModel } from "../useMarketScreenViewModel";
@@ -24,6 +25,7 @@ function mockMarketAssets(overrides: Partial<ReturnType<typeof useMarketAssets>>
     loading: false,
     loadingMore: false,
     isError: false,
+    emptyState: undefined,
     onEndReached: jest.fn(),
     ...overrides,
   });
@@ -75,20 +77,32 @@ describe("useMarketScreenViewModel", () => {
     jest.useFakeTimers();
     const { result } = renderHook(() => useMarketScreenViewModel());
 
-    expect(mockedUseMarketAssets).toHaveBeenLastCalledWith({ search: "" });
+    expect(mockedUseMarketAssets).toHaveBeenLastCalledWith({
+      search: "",
+      category: "all",
+      starredMarketCoins: [],
+    });
 
     act(() => result.current.search.onChangeText("eth"));
 
     expect(result.current.isSearchActive).toBe(true);
     expect(result.current.assetsList.assets).toEqual([]);
     expect(result.current.assetsList.assetsLoading).toBe(true);
-    expect(mockedUseMarketAssets).toHaveBeenLastCalledWith({ search: "" });
+    expect(mockedUseMarketAssets).toHaveBeenLastCalledWith({
+      search: "",
+      category: "all",
+      starredMarketCoins: [],
+    });
 
     act(() => {
       jest.advanceTimersByTime(500);
     });
 
-    expect(mockedUseMarketAssets).toHaveBeenLastCalledWith({ search: "eth" });
+    expect(mockedUseMarketAssets).toHaveBeenLastCalledWith({
+      search: "eth",
+      category: "all",
+      starredMarketCoins: [],
+    });
   });
 
   it("restores the full asset list immediately when search is cleared", () => {
@@ -100,13 +114,76 @@ describe("useMarketScreenViewModel", () => {
       jest.advanceTimersByTime(500);
     });
 
-    expect(mockedUseMarketAssets).toHaveBeenLastCalledWith({ search: "btc" });
+    expect(mockedUseMarketAssets).toHaveBeenLastCalledWith({
+      search: "btc",
+      category: "all",
+      starredMarketCoins: [],
+    });
 
     act(() => result.current.search.onClear());
 
     expect(result.current.search.value).toBe("");
     expect(result.current.isSearchActive).toBe(false);
     expect(result.current.assetsList.assets).toHaveLength(1);
-    expect(mockedUseMarketAssets).toHaveBeenLastCalledWith({ search: "" });
+    expect(mockedUseMarketAssets).toHaveBeenLastCalledWith({
+      search: "",
+      category: "all",
+      starredMarketCoins: [],
+    });
+  });
+
+  it("forwards the selected category and starred ids to the assets hook", () => {
+    const starredMarketCoins = ["bitcoin"];
+
+    const { result } = renderHook(() => useMarketScreenViewModel(), {
+      overrideInitialState: (state: State): State => ({
+        ...state,
+        settings: { ...state.settings, starredMarketCoins },
+        marketListConfig: { ...state.marketListConfig, category: "starred" },
+      }),
+    });
+
+    expect(result.current.assetsList.categories.selectedCategory).toBe("starred");
+    expect(mockedUseMarketAssets).toHaveBeenLastCalledWith({
+      search: "",
+      category: "starred",
+      starredMarketCoins,
+    });
+  });
+
+  it("tracks the stocks category tap without selecting it yet", () => {
+    const { result, store } = renderHook(() => useMarketScreenViewModel());
+
+    act(() => result.current.assetsList.categories.onSelectCategory("stocks"));
+
+    expect(track).toHaveBeenCalledWith("button_clicked", {
+      button: "category",
+      category: "stocks",
+      page: "Market",
+    });
+    expect(store.getState().marketListConfig.category).toBe("all");
+    expect(mockedUseMarketAssets).toHaveBeenLastCalledWith({
+      search: "",
+      category: "all",
+      starredMarketCoins: [],
+    });
+  });
+
+  it("tracks and persists the favorites category", () => {
+    const { result, store } = renderHook(() => useMarketScreenViewModel());
+
+    act(() => result.current.assetsList.categories.onSelectCategory("starred"));
+
+    expect(track).toHaveBeenCalledWith("button_clicked", {
+      button: "category",
+      category: "starred",
+      page: "Market",
+    });
+    expect(store.getState().marketListConfig.category).toBe("starred");
+    expect(mockedUseMarketAssets).toHaveBeenLastCalledWith({
+      search: "",
+      category: "starred",
+      starredMarketCoins: [],
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/__tests__/MarketAssetsList.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/__tests__/MarketAssetsList.test.tsx
@@ -3,20 +3,31 @@ import { render, screen } from "@tests/test-renderer";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { createMarketAssetDisplayData } from "LLM/features/Market/__tests__/helpers";
 import { MARKET_SCREEN_TEST_IDS } from "../../../testIds";
+import type { MarketCategoryTab } from "../../../useMarketCategories";
 import { MarketAssetsList } from "..";
 
 const asset = createMarketAssetDisplayData();
+
+const categoryTabs: MarketCategoryTab[] = [
+  { value: "all", labelKey: "market.assets.categories.all" },
+  { value: "stocks", labelKey: "market.assets.categories.stocks" },
+  { value: "starred", labelKey: "market.assets.categories.favorites" },
+];
 
 const defaultProps = {
   assets: [asset],
   loading: false,
   loadingMore: false,
   error: false,
+  emptyState: undefined,
+  selectedCategory: "all",
+  categoryTabs,
+  onSelectCategory: jest.fn(),
   onAssetPress: jest.fn(),
   onEndReached: jest.fn(),
   showSubheader: true,
   header: <Box testID="market-assets-list-header" />,
-};
+} satisfies React.ComponentProps<typeof MarketAssetsList>;
 
 describe("MarketAssetsList", () => {
   beforeEach(() => {
@@ -28,6 +39,7 @@ describe("MarketAssetsList", () => {
 
     expect(screen.getByTestId("market-assets-list-header")).toBeVisible();
     expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.assetsSubHeader)).toBeVisible();
+    expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.assetsCategorySwitcher)).toBeVisible();
     expect(screen.getByTestId("marketItem-bitcoin")).toBeVisible();
   });
 
@@ -38,6 +50,7 @@ describe("MarketAssetsList", () => {
 
     expect(screen.queryByTestId("market-assets-list-header")).toBeNull();
     expect(screen.queryByTestId(MARKET_SCREEN_TEST_IDS.assetsSubHeader)).toBeNull();
+    expect(screen.queryByTestId(MARKET_SCREEN_TEST_IDS.assetsCategorySwitcher)).toBeNull();
   });
 
   it("should render three skeleton rows while loading", () => {
@@ -53,6 +66,13 @@ describe("MarketAssetsList", () => {
 
     expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.assetsEmptySearch)).toBeVisible();
     expect(screen.getByText("No assets found")).toBeVisible();
+  });
+
+  it("should render the favorites empty state", () => {
+    render(<MarketAssetsList {...defaultProps} assets={[]} emptyState="favorites" />);
+
+    expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.assetsFavoritesEmptyIcon)).toBeVisible();
+    expect(screen.getByText("No favorites yet")).toBeVisible();
   });
 
   it("should render the error banner and loading-more footer", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/index.tsx
@@ -4,6 +4,8 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import {
   Banner,
   Box,
+  SegmentedControl,
+  SegmentedControlButton,
   Spinner,
   Spot,
   Subheader,
@@ -11,15 +13,17 @@ import {
   SubheaderTitle,
   Text,
 } from "@ledgerhq/lumen-ui-rnative";
-import { Search } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { Search, StarFill } from "@ledgerhq/lumen-ui-rnative/symbols";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { useTranslation } from "~/context/Locale";
+import type { MarketListCategory } from "~/reducers/types";
 import AssetListItem, {
   AssetLoadingState,
   type MarketAssetDisplayData,
 } from "LLM/components/AssetListItem";
 import { BottomFadeGradient, GRADIENT_HEIGHT } from "LLM/components/BottomFadeGradient";
 import { MARKET_SCREEN_TEST_IDS } from "../../testIds";
+import type { MarketCategoryTab } from "../../useMarketCategories";
 
 const HORIZONTAL_PADDING = 16;
 const TOP_PADDING = 24;
@@ -28,8 +32,14 @@ const SKELETON_COUNT = 3;
 function MarketAssetsEmptyState({
   loading,
   error,
+  emptyState,
   showEmptySearchState,
-}: Readonly<{ loading: boolean; error: boolean; showEmptySearchState: boolean }>) {
+}: Readonly<{
+  loading: boolean;
+  error: boolean;
+  emptyState: "favorites" | undefined;
+  showEmptySearchState: boolean;
+}>) {
   const { t } = useTranslation();
 
   if (loading) {
@@ -53,11 +63,27 @@ function MarketAssetsEmptyState({
     );
   }
 
+  if (emptyState === "favorites") {
+    return (
+      <Box lx={emptyStateStyle} style={emptyStateSize}>
+        <Spot
+          appearance="icon"
+          icon={StarFill}
+          size={72}
+          testID={MARKET_SCREEN_TEST_IDS.assetsFavoritesEmptyIcon}
+        />
+        <Text typography="heading5SemiBold" lx={{ color: "base", textAlign: "center" }}>
+          {t("market.assets.emptyFavorites")}
+        </Text>
+      </Box>
+    );
+  }
+
   if (showEmptySearchState) {
     return (
       <Box
-        lx={emptySearchStateStyle}
-        style={emptySearchStateSize}
+        lx={emptyStateStyle}
+        style={emptyStateSize}
         testID={MARKET_SCREEN_TEST_IDS.assetsEmptySearch}
       >
         <Spot appearance="icon" icon={Search} size={72} />
@@ -71,11 +97,56 @@ function MarketAssetsEmptyState({
   return null;
 }
 
+type MarketCategorySwitcherProps = Readonly<{
+  selectedCategory: MarketListCategory;
+  tabs: MarketCategoryTab[];
+  onSelectCategory: (category: MarketListCategory) => void;
+}>;
+
+function MarketCategorySwitcher({
+  selectedCategory,
+  tabs,
+  onSelectCategory,
+}: MarketCategorySwitcherProps) {
+  const { t } = useTranslation();
+
+  const onSelectedChange = useCallback(
+    (value: string) => {
+      onSelectCategory(value as MarketListCategory);
+    },
+    [onSelectCategory],
+  );
+
+  return (
+    <SegmentedControl
+      selectedValue={selectedCategory}
+      onSelectedChange={onSelectedChange}
+      accessibilityLabel={t("market.assets.categories.accessibilityLabel")}
+      testID={MARKET_SCREEN_TEST_IDS.assetsCategorySwitcher}
+      lx={categorySwitcherStyle}
+    >
+      {tabs.map(tab => (
+        <SegmentedControlButton
+          key={tab.value}
+          value={tab.value}
+          testID={`${MARKET_SCREEN_TEST_IDS.assetsCategorySwitcher}-${tab.value}`}
+        >
+          {t(tab.labelKey)}
+        </SegmentedControlButton>
+      ))}
+    </SegmentedControl>
+  );
+}
+
 type Props = Readonly<{
   assets: MarketAssetDisplayData[];
   loading: boolean;
   loadingMore: boolean;
   error: boolean;
+  emptyState: "favorites" | undefined;
+  selectedCategory: MarketListCategory;
+  categoryTabs: MarketCategoryTab[];
+  onSelectCategory: (category: MarketListCategory) => void;
   onAssetPress: (asset: MarketAssetDisplayData) => void;
   onEndReached: () => void;
   showSubheader: boolean;
@@ -87,6 +158,10 @@ export function MarketAssetsList({
   loading,
   loadingMore,
   error,
+  emptyState,
+  selectedCategory,
+  categoryTabs,
+  onSelectCategory,
   onAssetPress,
   onEndReached,
   showSubheader,
@@ -107,11 +182,18 @@ export function MarketAssetsList({
       <Box lx={headerStyle}>
         {header}
         {showSubheader ? (
-          <Subheader lx={subHeaderStyle} testID={MARKET_SCREEN_TEST_IDS.assetsSubHeader}>
-            <SubheaderRow>
-              <SubheaderTitle>{t("market.assets.title")}</SubheaderTitle>
-            </SubheaderRow>
-          </Subheader>
+          <>
+            <Subheader lx={subHeaderStyle} testID={MARKET_SCREEN_TEST_IDS.assetsSubHeader}>
+              <SubheaderRow>
+                <SubheaderTitle>{t("market.assets.title")}</SubheaderTitle>
+              </SubheaderRow>
+            </Subheader>
+            <MarketCategorySwitcher
+              selectedCategory={selectedCategory}
+              tabs={categoryTabs}
+              onSelectCategory={onSelectCategory}
+            />
+          </>
         ) : null}
       </Box>
     ) : null;
@@ -137,6 +219,7 @@ export function MarketAssetsList({
           <MarketAssetsEmptyState
             loading={loading}
             error={error}
+            emptyState={emptyState}
             showEmptySearchState={!showSubheader}
           />
         }
@@ -162,10 +245,14 @@ export function MarketAssetsList({
 const headerStyle: LumenViewStyle = {
   marginHorizontal: "-s16",
   paddingTop: "s24",
-  gap: "s24",
+  gap: "s12",
 };
 
 const subHeaderStyle: LumenViewStyle = {
+  marginHorizontal: "s16",
+};
+
+const categorySwitcherStyle: LumenViewStyle = {
   marginHorizontal: "s16",
   marginBottom: "s12",
 };
@@ -184,11 +271,11 @@ const footerSpinnerStyle: LumenViewStyle = {
   alignSelf: "center",
 };
 
-const emptySearchStateStyle: LumenViewStyle = {
+const emptyStateStyle: LumenViewStyle = {
   flex: 1,
   alignItems: "center",
   justifyContent: "center",
   gap: "s24",
 };
 
-const emptySearchStateSize = { minHeight: 328 };
+const emptyStateSize = { minHeight: 328 };

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/testIds.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/testIds.ts
@@ -5,6 +5,8 @@ export const MARKET_SCREEN_TEST_IDS = {
   highlightCard: "market-screen-highlight-card",
   list: "market-screen-list",
   assetsSubHeader: "market-screen-assets-subheader",
+  assetsCategorySwitcher: "market-screen-assets-category-switcher",
+  assetsFavoritesEmptyIcon: "market-screen-assets-favorites-empty-icon",
   assetsSkeleton: "market-screen-assets-skeleton",
   assetsEmptySearch: "market-screen-assets-empty-search",
   assetsError: "market-screen-assets-error",

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketAssets.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketAssets.ts
@@ -4,6 +4,7 @@ import { KeysPriceChange, Order } from "@ledgerhq/live-common/market/utils/types
 import { useLocale, useTranslation } from "~/context/Locale";
 import { useSelector } from "~/context/hooks";
 import { counterValueCurrencySelector } from "~/reducers/settings";
+import type { MarketListCategory } from "~/reducers/types";
 import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
 import { mapMarketCurrencyToDisplayData } from "../../utils/marketAssetDisplay";
 
@@ -12,11 +13,15 @@ const PAGE_SIZE = 20;
 
 export type MarketAssetsParams = {
   search?: string;
+  category?: MarketListCategory;
+  starredMarketCoins?: string[];
 };
 
 type PaginationState = {
   page: number;
   search: string;
+  category: MarketListCategory;
+  favoriteIdsKey: string;
 };
 
 export interface MarketAssetsResult {
@@ -24,28 +29,51 @@ export interface MarketAssetsResult {
   loading: boolean;
   loadingMore: boolean;
   isError: boolean;
+  emptyState: "favorites" | undefined;
   onEndReached: () => void;
 }
 
-export function useMarketAssets({ search = "" }: MarketAssetsParams = {}): MarketAssetsResult {
+export function useMarketAssets({
+  search = "",
+  category = "all",
+  starredMarketCoins = [],
+}: MarketAssetsParams = {}): MarketAssetsResult {
   const { locale } = useLocale();
   const { t } = useTranslation();
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
   const counterCurrency = counterValueCurrency.ticker.toLowerCase();
   const counterValueUnit = counterValueCurrency.units[0];
   const normalizedSearch = search.trim();
+  const hasSearch = normalizedSearch.length > 0;
+  const isFavoritesCategory = !hasSearch && category === "starred";
+  const sortedFavoriteIds = useMemo(
+    () =>
+      isFavoritesCategory
+        ? [...starredMarketCoins].sort((firstId, secondId) => firstId.localeCompare(secondId))
+        : undefined,
+    [isFavoritesCategory, starredMarketCoins],
+  );
+  const favoriteIdsKey = sortedFavoriteIds?.join(",") ?? "";
+  const hasFavoriteIds = Boolean(sortedFavoriteIds?.length);
+  const shouldFetchAssets = !isFavoritesCategory || hasFavoriteIds;
   const [pagination, setPagination] = useState<PaginationState>(() => ({
     page: 1,
     search: normalizedSearch,
+    category,
+    favoriteIdsKey,
   }));
-  const isPaginationSearchSynced = pagination.search === normalizedSearch;
-  const page = isPaginationSearchSynced ? pagination.page : 1;
+  const isPaginationSynced =
+    pagination.search === normalizedSearch &&
+    pagination.category === category &&
+    pagination.favoriteIdsKey === favoriteIdsKey;
+  const page = isPaginationSynced ? pagination.page : 1;
+  const requestedPage = shouldFetchAssets ? page : 0;
 
   useEffect(() => {
-    if (!isPaginationSearchSynced) {
-      setPagination({ page: 1, search: normalizedSearch });
+    if (!isPaginationSynced) {
+      setPagination({ page: 1, search: normalizedSearch, category, favoriteIdsKey });
     }
-  }, [isPaginationSearchSynced, normalizedSearch]);
+  }, [category, favoriteIdsKey, isPaginationSynced, normalizedSearch]);
 
   const result = useMarketData({
     counterCurrency,
@@ -53,12 +81,14 @@ export function useMarketAssets({ search = "" }: MarketAssetsParams = {}): Marke
     order: Order.MarketCapDesc,
     limit: PAGE_SIZE,
     liveCompatible: true,
-    page,
+    page: requestedPage,
     search: normalizedSearch,
+    starred: sortedFavoriteIds,
   });
 
   const assets = useMemo(() => {
-    const uniqueById = [...new Map(result.data.map(item => [item.id, item])).values()];
+    const marketData = shouldFetchAssets ? result.data : [];
+    const uniqueById = [...new Map(marketData.map(item => [item.id, item])).values()];
     return uniqueById.map(item =>
       mapMarketCurrencyToDisplayData(item, {
         counterCurrency,
@@ -68,29 +98,43 @@ export function useMarketAssets({ search = "" }: MarketAssetsParams = {}): Marke
         t,
       }),
     );
-  }, [result.data, counterCurrency, counterValueUnit, locale, t]);
+  }, [shouldFetchAssets, result.data, counterCurrency, counterValueUnit, locale, t]);
 
   const hasData = assets.length > 0;
-  const loading = (result.isLoading || result.isPending) && !hasData;
-  const loadingMore = result.isFetching && hasData;
+  const loading = shouldFetchAssets && (result.isLoading || result.isPending) && !hasData;
+  const loadingMore = shouldFetchAssets && result.isFetching && hasData;
 
   const onEndReached = useCallback(() => {
-    if (!hasData || loading || loadingMore || result.isError) return;
+    if (!shouldFetchAssets || !hasData || loading || loadingMore || result.isError) return;
 
     setPagination(current => {
-      if (current.search !== normalizedSearch) {
-        return { page: 1, search: normalizedSearch };
+      if (
+        current.search !== normalizedSearch ||
+        current.category !== category ||
+        current.favoriteIdsKey !== favoriteIdsKey
+      ) {
+        return { page: 1, search: normalizedSearch, category, favoriteIdsKey };
       }
 
       return { ...current, page: current.page + 1 };
     });
-  }, [hasData, loading, loadingMore, normalizedSearch, result.isError]);
+  }, [
+    category,
+    favoriteIdsKey,
+    hasData,
+    loading,
+    loadingMore,
+    normalizedSearch,
+    result.isError,
+    shouldFetchAssets,
+  ]);
 
   return {
     assets,
     loading,
     loadingMore,
-    isError: result.isError,
+    isError: shouldFetchAssets && result.isError,
+    emptyState: isFavoritesCategory && !hasFavoriteIds ? "favorites" : undefined,
     onEndReached,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketCategories.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketCategories.ts
@@ -1,0 +1,66 @@
+import { useCallback, useMemo } from "react";
+import { track } from "~/analytics";
+import { useDispatch, useSelector } from "~/context/hooks";
+import { selectMarketListCategory, setMarketListCategory } from "~/reducers/market";
+import type { MarketListCategory } from "~/reducers/types";
+
+const SELECTABLE_MARKET_CATEGORIES = new Set<MarketListCategory>(["all", "starred"]);
+
+export type MarketCategoryTab = {
+  value: MarketListCategory;
+  labelKey: string;
+};
+
+export type MarketCategories = {
+  selectedCategory: MarketListCategory;
+  tabs: MarketCategoryTab[];
+  onSelectCategory: (category: MarketListCategory) => void;
+};
+
+const categoryTabs: MarketCategoryTab[] = [
+  { value: "all", labelKey: "market.assets.categories.all" },
+  { value: "stocks", labelKey: "market.assets.categories.stocks" },
+  { value: "starred", labelKey: "market.assets.categories.favorites" },
+];
+
+function isSelectableMarketCategory(category: MarketListCategory): boolean {
+  return SELECTABLE_MARKET_CATEGORIES.has(category);
+}
+
+function trackCategoryTap(category: MarketListCategory) {
+  track("button_clicked", {
+    button: "category",
+    category,
+    page: "Market",
+  });
+}
+
+export function useMarketCategories(): MarketCategories {
+  const dispatch = useDispatch();
+  const persistedCategory = useSelector(selectMarketListCategory);
+  const selectedCategory = isSelectableMarketCategory(persistedCategory)
+    ? persistedCategory
+    : "all";
+
+  const onSelectCategory = useCallback(
+    (category: MarketListCategory) => {
+      trackCategoryTap(category);
+
+      if (!isSelectableMarketCategory(category)) {
+        return;
+      }
+
+      dispatch(setMarketListCategory(category));
+    },
+    [dispatch],
+  );
+
+  return useMemo(
+    () => ({
+      selectedCategory,
+      tabs: categoryTabs,
+      onSelectCategory,
+    }),
+    [onSelectCategory, selectedCategory],
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketScreenViewModel.ts
@@ -1,16 +1,23 @@
 import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
+import { useSelector } from "~/context/hooks";
+import { starredMarketCoinsSelector } from "~/reducers/settings";
 import { useMarketAssetPress } from "./useMarketAssetPress";
 import { useMarketAssets } from "./useMarketAssets";
+import { type MarketCategories, useMarketCategories } from "./useMarketCategories";
 import { useMarketHighlights, type MarketHighlights } from "./useMarketHighlights";
 import { type MarketSearch, useMarketSearch } from "./useMarketSearch";
 
 export type { MarketHighlightCard } from "./useMarketHighlights";
+
+export type { MarketCategories, MarketCategoryTab } from "./useMarketCategories";
 
 export type MarketScreenAssetsList = {
   assets: MarketAssetDisplayData[];
   assetsLoading: boolean;
   assetsLoadingMore: boolean;
   assetsError: boolean;
+  assetsEmptyState: "favorites" | undefined;
+  categories: MarketCategories;
   onAssetPress: (asset: MarketAssetDisplayData) => void;
   onEndReached: () => void;
 };
@@ -25,8 +32,12 @@ export type MarketScreenViewModel = {
 export function useMarketScreenViewModel(): MarketScreenViewModel {
   const search = useMarketSearch();
   const highlights = useMarketHighlights();
-  const { assets, loading, loadingMore, isError, onEndReached } = useMarketAssets({
+  const categories = useMarketCategories();
+  const starredMarketCoins = useSelector(starredMarketCoinsSelector);
+  const { assets, loading, loadingMore, isError, emptyState, onEndReached } = useMarketAssets({
     search: search.query,
+    category: categories.selectedCategory,
+    starredMarketCoins,
   });
   const onAssetPress = useMarketAssetPress();
 
@@ -42,6 +53,8 @@ export function useMarketScreenViewModel(): MarketScreenViewModel {
       assetsLoading: search.isDebouncing || loading,
       assetsLoadingMore: loadingMore,
       assetsError: isError,
+      assetsEmptyState: search.isDebouncing ? undefined : emptyState,
+      categories,
       onAssetPress,
       onEndReached,
     },


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** `pnpm --filter live-mobile test:jest --runInBand --forceExit src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketAssets.test.ts src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketScreenViewModel.test.ts src/mvvm/features/Market/__integrations__/assetsList.integration.test.tsx`
- [x] **Impact of the changes:**
      Market W4.0 Assets header, category switcher layout, Favorites API query and empty state, analytics tracking, Stocks tab intentionally blocked.

### 📝 Description

Adds the Wallet 4.0 Market category switcher shown in the mocks with All / Stocks / Favorites. All and Favorites are wired to the persisted market list category. Favorites queries the market API with starred ids and shows a No favorites yet empty state when the user has not starred any market coin. Stocks remains visible from the mock but intentionally does not alter selection until the stocks data source is available.

### 📸 Screenshots

<img width="350" height="750" alt="Simulator Screenshot - build2 - 2026-06-04 at 16 25 10" src="https://github.com/user-attachments/assets/d5455cc5-37f3-47c5-a9ec-d5f8ffbf8561" />

https://github.com/user-attachments/assets/01d306de-4958-4134-ab77-99cd8d6f21d2

https://github.com/user-attachments/assets/aed9a788-f157-440e-9cb9-4bd03373c7aa




### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-30038

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)