### PR TITLE
[LWD] fix(desktop): align portfolio PnL return with mobile

### DIFF
--- a/.changeset/fix-lwd-portfolio-pnl-double-count.md
+++ b/.changeset/fix-lwd-portfolio-pnl-double-count.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix portfolio realised/unrealised return on Desktop differing from Mobile for the same synced accounts. The portfolio PnL view model passed an already-flattened accounts list to `computePortfolioPnL`, which flattens internally, double-counting token sub-accounts and inflating the returns. It now passes the top-level (non-flattened) accounts, matching Mobile.

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/PnL/__tests__/usePortfolioPnlViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/PnL/__tests__/usePortfolioPnlViewModel.test.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from "bignumber.js";
 import { usePortfolioPnL } from "@ledgerhq/wallet-pnl/hooks";
 import { act, renderHook, withFlagOverrides } from "tests/testSetup";
-import { BTC_ACCOUNT } from "LLD/features/__mocks__/accounts.mock";
+import { BTC_ACCOUNT, ETH_ACCOUNT_WITH_USDC } from "LLD/features/__mocks__/accounts.mock";
 import { usePortfolioPnlViewModel } from "../usePortfolioPnlViewModel";
 
 jest.mock("@ledgerhq/wallet-pnl/hooks", () => ({
@@ -56,7 +56,7 @@ describe("usePortfolioPnlViewModel", () => {
     expect(result.current.shouldDisplayPnl).toBe(false);
   });
 
-  it("forwards the flattened accounts to usePortfolioPnL", () => {
+  it("forwards the top-level accounts to usePortfolioPnL", () => {
     renderPortfolioPnlViewModel({ initialState: { ...flagsOn, ...stateWithAccounts } });
 
     expect(mockedUsePortfolioPnL).toHaveBeenCalledWith(
@@ -64,6 +64,15 @@ describe("usePortfolioPnlViewModel", () => {
       expect.anything(),
       expect.anything(),
     );
+  });
+
+  it("forwards top-level (non-flattened) accounts so token sub-accounts are not double-counted", () => {
+    renderPortfolioPnlViewModel({
+      initialState: { ...flagsOn, accounts: [ETH_ACCOUNT_WITH_USDC] },
+    });
+
+    const [forwardedAccounts] = mockedUsePortfolioPnL.mock.calls[0];
+    expect(forwardedAccounts).toEqual([ETH_ACCOUNT_WITH_USDC]);
   });
 
   it("emits unrealisedReturn, realisedReturn, and totalReturn cards and a 3-bucket detail", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/PnL/usePortfolioPnlViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/PnL/usePortfolioPnlViewModel.ts
@@ -1,14 +1,14 @@
 import { useCountervaluesState } from "@ledgerhq/live-countervalues-react";
 import { usePortfolioPnL } from "@ledgerhq/wallet-pnl/hooks";
 import { useSelector } from "LLD/hooks/redux";
-import { flattenAccountsSelector } from "~/renderer/reducers/accounts";
+import { shallowAccountsSelector } from "~/renderer/reducers/accounts";
 import { counterValueCurrencySelector } from "~/renderer/reducers/settings";
 import { buildPortfolioReturnCards } from "LLD/features/PnL/builders/buildPortfolioReturnCards";
 import { usePnlViewModelBase } from "LLD/features/PnL/hooks/usePnlViewModelBase";
 import type { PnlViewModel } from "LLD/features/PnL/types";
 
 export function usePortfolioPnlViewModel(): PnlViewModel {
-  const accounts = useSelector(flattenAccountsSelector);
+  const accounts = useSelector(shallowAccountsSelector);
   const fiatCurrency = useSelector(counterValueCurrencySelector);
   const countervalues = useCountervaluesState();
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Portfolio "Return" section on Ledger Live Desktop (Analytics screen): unrealised, realised and total return values.
      - Specifically portfolios holding token (ERC-20 / sub-account) assets — verify the desktop totals now match mobile for the same synced accounts.
      - No change expected for portfolios without token sub-accounts.

### 📝 Description

On the portfolio PnL "Return" section, Ledger Live Desktop (LWD) displayed higher realised/unrealised/total return than Ledger Live Mobile (LLM) for the same synced accounts.

**Problem**: `computePortfolioPnL` (in `@ledgerhq/wallet-pnl`) flattens its input internally before walking accounts, so it must be given the **top-level (non-flattened)** accounts list. The desktop view model passed `flattenAccountsSelector` — an already-flattened list — so the helper re-flattened it and **counted every token sub-account twice**, inflating the returns. Mobile already passes the non-flattened `shallowAccountsSelector`, which is why the two platforms diverged.

**Solution**: Desktop's `usePortfolioPnlViewModel` now selects `shallowAccountsSelector` instead of `flattenAccountsSelector`, matching Mobile and feeding `computePortfolioPnL` the input shape it expects. Added a regression test using an account with a token sub-account asserting only the top-level list is forwarded (no double-count). The Asset Detail PnL path is unaffected (both platforms already use `useAssetGroupPnL`, which does not flatten).

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31845](https://ledgerhq.atlassian.net/browse/LIVE-31845)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31845]: https://ledgerhq.atlassian.net/browse/LIVE-31845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ