### PR TITLE
[LWDM] fix(evm-staking): sei validator total stake decimals + mobile validator row amount

### DIFF
--- a/.changeset/sei-validators-stake-decimals.md
+++ b/.changeset/sei-validators-stake-decimals.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-evm": patch
+"live-mobile": patch
+---
+
+Fix SEI_EVM validator total stake decimals: scale usei (6 decimals) to the native 18-decimal unit so displayed amounts are correct. Also fix the mobile EVM validator row to show the total staked amount instead of a hardcoded "0.00 % APR".

--- a/apps/ledger-live-mobile/src/families/evm/DelegationFlow/01-SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/DelegationFlow/01-SelectValidator.tsx
@@ -100,9 +100,9 @@ export default function SelectValidator({ navigation, route }: Props) {
 
   const renderItem = useCallback(
     ({ item }: { item: StakingValidatorItem }) => (
-      <ValidatorRow validator={item} onPress={onItemPress} />
+      <ValidatorRow account={account} validator={item} onPress={onItemPress} />
     ),
-    [onItemPress],
+    [account, onItemPress],
   );
 
   if (!isFeatureEnabled) {

--- a/apps/ledger-live-mobile/src/families/evm/DelegationFlow/ValidatorRow.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/DelegationFlow/ValidatorRow.tsx
@@ -1,21 +1,29 @@
 import type { StakingValidatorItem } from "@ledgerhq/live-common/families/evm/staking/types";
+import type { AccountLike } from "@ledgerhq/types-live";
 import { Text } from "@ledgerhq/native-ui";
-import React, { useCallback } from "react";
+import { BigNumber } from "bignumber.js";
+import React, { useCallback, useMemo } from "react";
 import { Trans } from "~/context/Locale";
 import { StyleSheet, View } from "react-native";
+import CurrencyUnitValue from "~/components/CurrencyUnitValue";
 import Touchable from "~/components/Touchable";
+import { useAccountUnit } from "LLM/hooks/useAccountUnit";
 import ValidatorImage from "../shared/ValidatorImage";
 
 const ValidatorRow = ({
   onPress,
   validator,
+  account,
 }: {
   onPress: (_: StakingValidatorItem) => void;
   validator: StakingValidatorItem;
+  account: AccountLike;
 }) => {
   const onPressT = useCallback(() => {
     onPress(validator);
   }, [validator, onPress]);
+  const unit = useAccountUnit(account);
+  const tokens = useMemo(() => new BigNumber(validator.tokens), [validator.tokens]);
 
   return (
     <Touchable
@@ -41,8 +49,8 @@ const ValidatorRow = ({
             %
           </Text>
         </View>
-        <Text fontWeight="semiBold" numberOfLines={1} style={styles.apr} color="smoke">
-          {(validator.estimatedYearlyRewardsRate * 100).toFixed(2)} % APR
+        <Text fontWeight="semiBold" numberOfLines={1} style={styles.totalStake} color="smoke">
+          <CurrencyUnitValue showCode unit={unit} value={tokens} />
         </Text>
       </View>
     </Touchable>
@@ -66,7 +74,7 @@ const styles = StyleSheet.create({
   commission: {
     fontSize: 12,
   },
-  apr: {
+  totalStake: {
     fontSize: 14,
   },
 });

--- a/libs/coin-modules/coin-evm/src/staking/validators.test.ts
+++ b/libs/coin-modules/coin-evm/src/staking/validators.test.ts
@@ -60,7 +60,8 @@ describe("staking/validators", () => {
             validatorAddress: "seivaloper1abc",
             name: "John",
             commission: 0.05,
-            tokens: "100",
+            // REST returns usei (6 decimals); scaled to sei_evm's 18-decimal unit (×10^12).
+            tokens: "100000000000000",
             votingPower: 0,
             estimatedYearlyRewardsRate: 0,
           }),
@@ -68,7 +69,7 @@ describe("staking/validators", () => {
             validatorAddress: "seivaloper1def",
             name: "Doe",
             commission: 1,
-            tokens: "999",
+            tokens: "999000000000000",
             votingPower: 1,
             estimatedYearlyRewardsRate: 0,
           }),
@@ -271,7 +272,7 @@ describe("staking/validators", () => {
               operator_address: "seivaloper1x",
               description: { moniker: "X" },
               commission: { commission_rates: { rate: "0.1" } },
-              // Token amounts coming from Sei validator API are strings that represent integers
+              // Token amounts coming from Sei validator API are usei (6 decimals) integer strings
               tokens: "42",
             },
           ],
@@ -285,7 +286,8 @@ describe("staking/validators", () => {
         {
           address: "seivaloper1x",
           name: "X",
-          balance: 42n,
+          // 42 usei scaled to sei_evm's 18-decimal unit (×10^12).
+          balance: 42000000000000n,
           commissionRate: "0.1",
           apy: 0,
         },

--- a/libs/coin-modules/coin-evm/src/staking/validators/sei.ts
+++ b/libs/coin-modules/coin-evm/src/staking/validators/sei.ts
@@ -2,6 +2,7 @@ import network from "@ledgerhq/live-network";
 import type { Page } from "@ledgerhq/coin-module-framework/api/index";
 import type { StakingValidatorItem } from "@ledgerhq/types-live";
 import { STAKING_CONTRACTS } from "../contracts";
+import { seiBalanceAmountToNativeMinUnit } from "../../utils";
 import type { ValidatorApi } from "./types";
 
 type CosmosValidatorDescription = {
@@ -45,7 +46,7 @@ const seiValidatorApi: ValidatorApi = {
               validatorAddress: v.operator_address,
               name: v.description?.moniker ?? v.operator_address,
               commission: Number.parseFloat(v.commission?.commission_rates?.rate ?? "0"),
-              tokens: v.tokens ?? "0",
+              tokens: seiBalanceAmountToNativeMinUnit(v.tokens, "usei").toString(),
               votingPower: index,
               estimatedYearlyRewardsRate: 0,
             }))

--- a/libs/coin-modules/coin-evm/src/utils.ts
+++ b/libs/coin-modules/coin-evm/src/utils.ts
@@ -288,11 +288,10 @@ function normalizeSeiDelegation(outer: unknown): SeiDelegation | undefined {
 }
 
 /**
- * SEI staking precompile returns `balance.amount` in usei (6 decimals).
- * Native `sei_evm` currency uses magnitude 18 (wei-like); convert so balances match `getCoinBalance` / account totals.
- * @see https://docs.sei.io/evm/precompiles/staking (delegation query)
+ * Scales a SEI staking amount in usei (6 decimals) to the `sei_evm` native min unit (18 decimals).
+ * Non-usei denoms are returned unchanged.
  */
-function seiBalanceAmountToNativeMinUnit(amount: unknown, denom: string): bigint {
+export function seiBalanceAmountToNativeMinUnit(amount: unknown, denom: string): bigint {
   const n = toBigIntLoose(amount);
   if (n === null) {
     return 0n;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Decimals conversion is covered by `validators.test.ts`; the mobile row change is UI-only and not unit-tested._
- [x] **Impact of the changes:**
  - SEI_EVM delegation flow — validator list "Total stake" amount per validator (desktop & mobile)
  - Mobile EVM validator row now shows the total staked amount instead of "0.00 % APR"
  - Overall total staked displayed (`getValidatorsPage` → `toValidatorBalance`)
  - No regression on Monad (already returns 18-decimal values from the precompile)

### 📝 Description

This PR fixes two issues on the EVM staking validator list.

**1. SEI_EVM validator total stake decimals (desktop & mobile)**

The validator total stake was ~10^12 too small. Validator `tokens` come from the Cosmos REST API in usei (6 decimals) but are displayed with `sei_evm`'s 18-decimal unit. The usei→EVM conversion (`USEI_TO_EVM_SCALE` / `seiBalanceAmountToNativeMinUnit`) was already used for delegations but not for validator tokens. Fixed at fetch time in `coin-evm/src/staking/validators/sei.ts`, reusing the now-exported `seiBalanceAmountToNativeMinUnit` helper. Monad is unaffected (precompile already returns 18-decimal values).

```ts
tokens: seiBalanceAmountToNativeMinUnit(v.tokens, "usei").toString(),
```

**2. Mobile EVM validator row showed "0.00 % APR"**

On mobile the validator row displayed `estimatedYearlyRewardsRate`, which is always `0`, resulting in a useless "0.00 % APR". It now shows the validator's total staked amount (formatted with the account unit), matching the desktop row and the existing "Total Stake" column header. Implemented with the standard mobile pattern (`useAccountUnit` + `CurrencyUnitValue`), same as cosmos/near/sui rows.

### 📸 Screenshots

| Before | After |
| ------ | ----- |
| <img width="525" height="365" alt="Screenshot 2026-06-04 at 15 55 09" src="https://github.com/user-attachments/assets/fae5d73d-6dba-4b45-8a55-d18ebf1f8a00" /> | <img width="530" height="371" alt="Screenshot 2026-06-04 at 15 56 49" src="https://github.com/user-attachments/assets/c1dd95e5-5212-41e3-9daa-d7eeb8c97c53" /> |
| <img width="547" height="1041" alt="image" src="https://github.com/user-attachments/assets/f8667bf7-742d-4050-8101-1cba20ccd610" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-05 at 11 09 23" src="https://github.com/user-attachments/assets/0a6dbaae-f145-4bfc-abc5-a63e3748126f" />  |


### ❓ Context

- **JIRA or GitHub link**: [LIVE-31852](https://ledgerhq.atlassian.net/browse/LIVE-31852)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31852]: https://ledgerhq.atlassian.net/browse/LIVE-31852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ