### PR TITLE
test(e2e-desktop): surface cliCommands HTTP failures in Allure report

### DIFF
--- a/e2e/desktop/package.json
+++ b/e2e/desktop/package.json
@@ -21,6 +21,7 @@
     "@ledgerhq/live-dmk-speculos": "workspace:^",
     "@ledgerhq/live-env": "workspace:^",
     "@ledgerhq/live-wallet": "workspace:^",
+    "@ledgerhq/logs": "workspace:^",
     "@ledgerhq/types-devices": "workspace:^",
     "@ledgerhq/types-live": "workspace:^",
     "@playwright/test": "catalog:",

--- a/e2e/desktop/tests/fixtures/common.ts
+++ b/e2e/desktop/tests/fixtures/common.ts
@@ -8,7 +8,12 @@ import { setEnv } from "@ledgerhq/live-env";
 import { Application } from "tests/page";
 import { safeAppendFile, NANO_APP_CATALOG_PATH } from "tests/utils/fileUtils";
 import { launchApp } from "tests/utils/electronUtils";
-import { captureArtifacts, addTeamOwner, attachMergedFeatureFlags } from "tests/utils/allureUtils";
+import {
+  captureArtifacts,
+  addTeamOwner,
+  attachMergedFeatureFlags,
+  runCliStep,
+} from "tests/utils/allureUtils";
 import { isLastRetry } from "tests/utils/testInfoUtils";
 import { WebviewLogCollector } from "tests/utils/webviewLogCollector";
 import { randomUUID } from "crypto";
@@ -85,9 +90,11 @@ const DEFAULT_FEATURE_FLAGS: OptionalFeatureMap = {
 };
 
 async function executeCliCommand(cmd: CliCommand, userdataDestinationPath?: string) {
-  const promise = await cmd(`${userdataDestinationPath}/app.json`);
-  const result = promise instanceof Observable ? await lastValueFrom(promise) : await promise;
-  console.log("CLI result: ", result);
+  const label = cmd.name || "anonymous";
+  return runCliStep(label, async () => {
+    const promise = await cmd(`${userdataDestinationPath}/app.json`);
+    return promise instanceof Observable ? await lastValueFrom(promise) : await promise;
+  });
 }
 
 export const test = base.extend<TestFixtures>({

--- a/e2e/desktop/tests/specs/ledgerSync.spec.ts
+++ b/e2e/desktop/tests/specs/ledgerSync.spec.ts
@@ -30,7 +30,7 @@ function initializeThenDeleteTrustchain() {
   return [
     LedgerSyncCliHelper.initializeLedgerKeyRingProtocol,
     LedgerSyncCliHelper.initializeLedgerSync,
-    async () => LedgerSyncCliHelper.deleteLedgerSyncData(),
+    LedgerSyncCliHelper.deleteLedgerSyncData,
   ];
 }
 
@@ -38,11 +38,7 @@ function initializeTrustchain() {
   return [
     LedgerSyncCliHelper.initializeLedgerKeyRingProtocol,
     LedgerSyncCliHelper.initializeLedgerSync,
-    async () =>
-      CLI.ledgerSync({
-        ...LedgerSyncCliHelper.ledgerKeyRingProtocolArgs,
-        ...LedgerSyncCliHelper.ledgerSyncPushDataArgs,
-      }),
+    LedgerSyncCliHelper.pushLedgerSyncData,
   ];
 }
 test.describe(`[${app.name}] Sync Accounts`, () => {

--- a/e2e/desktop/tests/utils/allureUtils.ts
+++ b/e2e/desktop/tests/utils/allureUtils.ts
@@ -2,7 +2,8 @@ import { ElectronApplication, Page, TestInfo } from "@playwright/test";
 import { promisify } from "util";
 import { readFile } from "fs";
 import { takeScreenshot, drainSpeculosScreenshots } from "@ledgerhq/live-common/e2e/speculos";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv, setEnv } from "@ledgerhq/live-env";
+import { listen } from "@ledgerhq/logs";
 import * as allure from "allure-js-commons";
 import { isLastRetry } from "tests/utils/testInfoUtils";
 import { WebviewLogCollector } from "tests/utils/webviewLogCollector";
@@ -22,6 +23,89 @@ async function attachIfExists(
   } catch {
     // File does not exist → silently ignore
   }
+}
+
+export async function runCliStep<T>(label: string, fn: () => Promise<T>): Promise<T> {
+  return allure.step(`CLI: ${label}`, async () => {
+    const start = Date.now();
+    const httpTrace: string[] = [];
+    const prevNetworkLogs = getEnv("ENABLE_NETWORK_LOGS");
+    setEnv("ENABLE_NETWORK_LOGS", true);
+    // log `message` only — `data` may carry JWTs/secrets
+    const unsubscribe = listen(({ type, message, date }) => {
+      if (type.startsWith("network")) {
+        httpTrace.push(`${date.toISOString()} [${type}] ${message ?? ""}`);
+      }
+    });
+    try {
+      const result = await fn();
+      await reportCliOutcome(label, "result", start, () => redactSecrets(result), httpTrace);
+      return result;
+    } catch (error) {
+      await reportCliOutcome(label, "FAILED", start, () => serializeCliError(error), httpTrace);
+      throw error;
+    } finally {
+      try {
+        unsubscribe();
+      } catch {
+        // ignore
+      }
+      setEnv("ENABLE_NETWORK_LOGS", prevNetworkLogs);
+    }
+  });
+}
+
+const SECRET_KEYS = new Set(["privatekey", "privateKey", "walletSyncEncryptionKey"]);
+
+function redactSecrets(value: unknown): unknown {
+  if (typeof value === "string") {
+    try {
+      return JSON.stringify(redactSecrets(JSON.parse(value)), null, 2);
+    } catch {
+      return value;
+    }
+  }
+  if (Array.isArray(value)) return value.map(redactSecrets);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([k, v]) => [k, SECRET_KEYS.has(k) ? "[REDACTED]" : redactSecrets(v)]),
+    );
+  }
+  return value;
+}
+
+// reporting must never flip the command's pass/fail outcome, so payload building runs here too
+async function reportCliOutcome(
+  label: string,
+  status: string,
+  start: number,
+  buildPayload: () => unknown,
+  httpTrace: string[],
+) {
+  try {
+    const payload = buildPayload();
+    console.log(`CLI ${label} — ${status}: `, payload);
+    const title = `CLI ${label} — ${status} (${Date.now() - start}ms)`;
+    if (typeof payload === "string") {
+      await allure.attachment(title, payload, "text/plain");
+    } else {
+      await allure.attachment(title, JSON.stringify(payload ?? null, null, 2), "application/json");
+    }
+    if (httpTrace.length) {
+      await allure.attachment(`CLI ${label} — HTTP trace`, httpTrace.join("\n"), "text/plain");
+    }
+  } catch {
+    // ignore
+  }
+}
+
+function serializeCliError(error: unknown) {
+  // status/url/method are own-enumerable on LedgerAPI5xx; message is not
+  const fields = error && typeof error === "object" ? { ...error } : {};
+  return {
+    message: error instanceof Error ? error.message : String(error),
+    ...fields,
+  };
 }
 
 export async function addTmsLink(ids: string[]) {

--- a/e2e/desktop/tests/utils/ledgerSyncCliUtils.ts
+++ b/e2e/desktop/tests/utils/ledgerSyncCliUtils.ts
@@ -146,6 +146,13 @@ export class LedgerSyncCliHelper {
     return output;
   }
 
+  static async pushLedgerSyncData() {
+    return CLI.ledgerSync({
+      ...LedgerSyncCliHelper.ledgerKeyRingProtocolArgs,
+      ...LedgerSyncCliHelper.ledgerSyncPushDataArgs,
+    });
+  }
+
   static async deleteLedgerSyncData() {
     await CLI.ledgerSync({
       deleteData: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3187,6 +3187,9 @@ importers:
       '@ledgerhq/live-wallet':
         specifier: workspace:^
         version: link:../../libs/live-wallet
+      '@ledgerhq/logs':
+        specifier: workspace:^
+        version: link:../../libs/ledgerjs/packages/logs
       '@ledgerhq/types-devices':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/types-devices


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. <!-- N/A: only the private `ledger-live-desktop-e2e-tests` package is touched (no published package changes). -->
- [x] **Covered by automatic tests.** This *is* test infrastructure; validated by running `ledgerSync.spec` locally (it reproduced the staging 5xx and surfaced it in Allure). E2E runs on this branch — [ledgerSync.spec only](https://github.com/LedgerHQ/ledger-live/actions/runs/26957653524) and [full suite](https://github.com/LedgerHQ/ledger-live/actions/runs/26958151511).
- [x] **Impact of the changes:**
  - E2E desktop only. `cliCommands` setup steps now appear as named Allure steps with downloadable attachments. No app/runtime code changed.

### 📝 Description

**We can now see the CLI errors of Before Hooks like this:**
<img width="1230" height="857" alt="Screenshot 2026-06-04 at 16 29 13" src="https://github.com/user-attachments/assets/60e04297-f248-4f16-8fef-002aa31dbf10" />

Before this changes, when a `cliCommands` setup step failed (e.g. the LedgerSync trustchain/cloud-sync calls), the Allure report shows almost nothing — just two raw `console.log("CLI result", …)` lines and no indication of *which* call broke or why. The failing `ledgerSync.spec` (LIVE-31799) is the prime example.

---

This makes the setup observable. Each `cliCommands` entry is wrapped in a named, timed Allure step (`runCliStep`) that attaches:
- **result** — the command's return value (with `privatekey` / `walletSyncEncryptionKey` redacted),
- **FAILED** — a serialized error including `status` / `url` / `method` for `LedgerAPI5xx`,
- **HTTP trace** — every request/response/error emitted via `@ledgerhq/live-network` during the step (message only — never `data`, which may carry JWTs).

Reporting is isolated from the command's outcome, so an unserializable payload can never flip a passing command to failed. The anonymous inline commands in `ledgerSync.spec` are replaced by named helpers so the Allure steps read clearly.
### ❓ Context

- **JIRA or GitHub link**: [LIVE-31799](https://ledgerhq.atlassian.net/browse/LIVE-31799)
- **ADR link (if any)**: N/A


[LIVE-31799]: https://ledgerhq.atlassian.net/browse/LIVE-31799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
