### PR TITLE
[LWDM] feat(monad): add undelegate for evm monad staking

### DIFF
--- a/.changeset/brave-pugs-act.md
+++ b/.changeset/brave-pugs-act.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/types-live": minor
+"@ledgerhq/coin-evm": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+add undelegate for monad

--- a/apps/ledger-live-desktop/src/renderer/families/evm/Delegation/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/Delegation/index.tsx
@@ -241,7 +241,7 @@ const Delegation = ({ account }: { account: StakingAccount }) => {
           <UnbondingHeader />
           {mappedUnbondings.map(unbonding => (
             <UnbondingRow
-              key={`${unbonding.validatorAddress}-${unbonding.completionDate.valueOf()}-${unbonding.withdrawId}`}
+              key={`${unbonding.validatorAddress}-${unbonding.completionDate.valueOf()}${unbonding.withdrawId !== undefined ? `-${unbonding.withdrawId}` : ""}`}
               delegation={unbonding}
               onExternalLink={onExternalLink}
             />

--- a/apps/ledger-live-desktop/src/renderer/families/evm/Delegation/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/Delegation/index.tsx
@@ -241,7 +241,7 @@ const Delegation = ({ account }: { account: StakingAccount }) => {
           <UnbondingHeader />
           {mappedUnbondings.map(unbonding => (
             <UnbondingRow
-              key={`${unbonding.validatorAddress}-${unbonding.completionDate.valueOf()}`}
+              key={`${unbonding.validatorAddress}-${unbonding.completionDate.valueOf()}-${unbonding.withdrawId}`}
               delegation={unbonding}
               onExternalLink={onExternalLink}
             />

--- a/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/Body.tsx
@@ -106,6 +106,7 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
       recipient: account.freshAddress,
       amount: delegation?.amount,
       useAllAmount: false,
+      valId: delegation?.validatorId,
     } as unknown as Partial<EvmTransaction>);
     return {
       account,

--- a/apps/ledger-live-mobile/src/families/evm/UndelegationFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/UndelegationFlow/01-Amount.tsx
@@ -65,6 +65,7 @@ export default function UndelegationAmount({ navigation, route }: Props) {
         transaction: bridge.updateTransaction(tx, {
           mode: "undelegate",
           valAddress: delegation.validatorAddress,
+          valId: delegation.validatorId,
           recipient: account.freshAddress,
         }) as unknown as Transaction,
       };

--- a/libs/coin-modules/coin-evm/src/abis/monad.abi.json
+++ b/libs/coin-modules/coin-evm/src/abis/monad.abi.json
@@ -99,6 +99,16 @@
     },
     {
       "type": "function",
+      "name": "getEpoch",
+      "inputs": [],
+      "outputs": [
+        { "name": "epoch", "type": "uint64", "internalType": "uint64" },
+        { "name": "inEpochDelayPeriod", "type": "bool", "internalType": "bool" }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
       "name": "getWithdrawalRequest",
       "inputs": [
         { "name": "validatorId", "type": "uint64", "internalType": "uint64" },

--- a/libs/coin-modules/coin-evm/src/logic/common.ts
+++ b/libs/coin-modules/coin-evm/src/logic/common.ts
@@ -12,7 +12,11 @@ import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import BigNumber from "bignumber.js";
 import { ethers } from "ethers";
 import { getNodeApi } from "../network/node";
-import { buildStakingTransactionParams, findFreeWithdrawId, STAKING_CONTRACTS } from "../staking";
+import {
+  buildStakingTransactionParams,
+  prepareStakingIntent,
+  STAKING_CONTRACTS,
+} from "../staking";
 import {
   ApiFeeData,
   ApiGasOptions,
@@ -20,38 +24,8 @@ import {
   TransactionLikeWithPreparedParams,
   TransactionTypes,
 } from "../types";
-import { isEthAddress, isStakingIntent } from "../utils";
+import { isEthAddress } from "../utils";
 import { getErc20Data } from "./getErc20Data";
-
-/**
- * Monad's `undelegate` needs a free `withdrawId` slot (0–255) per (validator, delegator)
- * pair. Callers don't know which slot is free, so when one isn't already set on the intent
- * we probe the precompile for the lowest free slot and inject it before the (synchronous)
- * calldata is built. No-op for any other chain/operation, and never overwrites a withdrawId
- * the caller explicitly provided.
- */
-async function resolveMonadWithdrawId(
-  currency: CryptoCurrency,
-  intent: TransactionIntent<MemoNotSupported, BufferTxData>,
-): Promise<TransactionIntent<MemoNotSupported, BufferTxData>> {
-  if (currency.id !== "monad" || !isStakingIntent(intent)) return intent;
-  if (intent.mode !== "undelegate" || intent.withdrawId !== undefined || !intent.valId) {
-    return intent;
-  }
-
-  const withdrawId = await findFreeWithdrawId(currency.id, BigInt(intent.valId), intent.sender);
-  if (withdrawId === null) {
-    throw new Error(
-      "No free Monad withdraw slot: all slots (0–255) are in use for this validator. " +
-        "Withdraw a completed undelegation before undelegating again.",
-    );
-  }
-
-  // Bind to the narrowed (EvmStakingIntent) type so the literal isn't checked for
-  // excess props against the wider TransactionIntent return type.
-  const enriched: typeof intent = { ...intent, withdrawId: withdrawId.toString() };
-  return enriched;
-}
 
 export function isApiGasOptions(options: unknown): options is ApiGasOptions {
   if (!options || typeof options !== "object") return false;
@@ -154,7 +128,7 @@ export async function prepareUnsignedTxParams(
       })()
     : buildStakingTransactionParams(
         currency,
-        await resolveMonadWithdrawId(currency, transactionIntent),
+        await prepareStakingIntent(currency, transactionIntent),
       );
   const gasLimit =
     typeof customFeesParameters?.gasLimit === "bigint"

--- a/libs/coin-modules/coin-evm/src/logic/common.ts
+++ b/libs/coin-modules/coin-evm/src/logic/common.ts
@@ -12,7 +12,7 @@ import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import BigNumber from "bignumber.js";
 import { ethers } from "ethers";
 import { getNodeApi } from "../network/node";
-import { buildStakingTransactionParams, STAKING_CONTRACTS } from "../staking";
+import { buildStakingTransactionParams, findFreeWithdrawId, STAKING_CONTRACTS } from "../staking";
 import {
   ApiFeeData,
   ApiGasOptions,
@@ -20,8 +20,38 @@ import {
   TransactionLikeWithPreparedParams,
   TransactionTypes,
 } from "../types";
-import { isEthAddress } from "../utils";
+import { isEthAddress, isStakingIntent } from "../utils";
 import { getErc20Data } from "./getErc20Data";
+
+/**
+ * Monad's `undelegate` needs a free `withdrawId` slot (0–255) per (validator, delegator)
+ * pair. Callers don't know which slot is free, so when one isn't already set on the intent
+ * we probe the precompile for the lowest free slot and inject it before the (synchronous)
+ * calldata is built. No-op for any other chain/operation, and never overwrites a withdrawId
+ * the caller explicitly provided.
+ */
+async function resolveMonadWithdrawId(
+  currency: CryptoCurrency,
+  intent: TransactionIntent<MemoNotSupported, BufferTxData>,
+): Promise<TransactionIntent<MemoNotSupported, BufferTxData>> {
+  if (currency.id !== "monad" || !isStakingIntent(intent)) return intent;
+  if (intent.mode !== "undelegate" || intent.withdrawId !== undefined || !intent.valId) {
+    return intent;
+  }
+
+  const withdrawId = await findFreeWithdrawId(currency.id, BigInt(intent.valId), intent.sender);
+  if (withdrawId === null) {
+    throw new Error(
+      "No free Monad withdraw slot: all slots (0–255) are in use for this validator. " +
+        "Withdraw a completed undelegation before undelegating again.",
+    );
+  }
+
+  // Bind to the narrowed (EvmStakingIntent) type so the literal isn't checked for
+  // excess props against the wider TransactionIntent return type.
+  const enriched: typeof intent = { ...intent, withdrawId: withdrawId.toString() };
+  return enriched;
+}
 
 export function isApiGasOptions(options: unknown): options is ApiGasOptions {
   if (!options || typeof options !== "object") return false;
@@ -122,7 +152,10 @@ export async function prepareUnsignedTxParams(
           value: isNative(asset) ? amount : 0n,
         };
       })()
-    : buildStakingTransactionParams(currency, transactionIntent);
+    : buildStakingTransactionParams(
+        currency,
+        await resolveMonadWithdrawId(currency, transactionIntent),
+      );
   const gasLimit =
     typeof customFeesParameters?.gasLimit === "bigint"
       ? BigNumber(customFeesParameters.gasLimit.toString())

--- a/libs/coin-modules/coin-evm/src/staking/index.ts
+++ b/libs/coin-modules/coin-evm/src/staking/index.ts
@@ -14,6 +14,7 @@ export {
   hasRedelegation,
   prefetchValidators,
   clearValidatorsCache,
+  findFreeWithdrawId,
 } from "./validators";
 export {
   mapDelegations,

--- a/libs/coin-modules/coin-evm/src/staking/index.ts
+++ b/libs/coin-modules/coin-evm/src/staking/index.ts
@@ -14,8 +14,8 @@ export {
   hasRedelegation,
   prefetchValidators,
   clearValidatorsCache,
-  findFreeWithdrawId,
 } from "./validators";
+export { prepareStakingIntent } from "./prepareIntents";
 export {
   mapDelegations,
   mapUnbondings,

--- a/libs/coin-modules/coin-evm/src/staking/operations/index.test.ts
+++ b/libs/coin-modules/coin-evm/src/staking/operations/index.test.ts
@@ -118,6 +118,25 @@ describe("buildTransactionParams", () => {
         });
       }).toThrow("monad staking requires valId");
     });
+
+    it("builds params for undelegate operation (valId, amount, withdrawId as bigints)", () => {
+      const params = buildTransactionParams("monad", "undelegate" as StakingOperation, {
+        valId: "42",
+        amount: 1000000000000000000n,
+        withdrawId: "7",
+      });
+
+      expect(params).toStrictEqual([42n, 1000000000000000000n, 7n]);
+    });
+
+    it("throws when monad undelegate is missing withdrawId", () => {
+      expect(() => {
+        buildTransactionParams("monad", "undelegate" as StakingOperation, {
+          valId: "42",
+          amount: 1000000000000000000n,
+        });
+      }).toThrow("monad undelegate requires withdrawId");
+    });
   });
 
   describe("CELO", () => {

--- a/libs/coin-modules/coin-evm/src/staking/operations/index.ts
+++ b/libs/coin-modules/coin-evm/src/staking/operations/index.ts
@@ -33,5 +33,13 @@ export const buildTransactionParams = (
     throw new Error(`${currencyId} staking requires valId`);
   }
 
+  if (
+    params.withdrawId === undefined &&
+    currencyId === "monad" &&
+    transactionType === "undelegate"
+  ) {
+    throw new Error(`${currencyId} undelegate requires withdrawId`);
+  }
+
   return operation(params);
 };

--- a/libs/coin-modules/coin-evm/src/staking/operations/monad.ts
+++ b/libs/coin-modules/coin-evm/src/staking/operations/monad.ts
@@ -3,12 +3,7 @@ import type { OperationParamsMonad, StakingProtocol } from "./types";
 const monadProtocol: StakingProtocol<OperationParamsMonad> = {
   delegate: ({ valId }) => [BigInt(valId)],
   claimReward: ({ valId }) => [BigInt(valId)],
-  undelegate: ({ valId, amount, withdrawId }) => {
-    if (withdrawId === undefined) {
-      throw new Error("monad undelegate requires withdrawId");
-    }
-    return [BigInt(valId), amount, BigInt(withdrawId)];
-  },
+  undelegate: ({ valId, amount, withdrawId }) => [BigInt(valId), amount, BigInt(withdrawId!)],
 };
 
 export default monadProtocol;

--- a/libs/coin-modules/coin-evm/src/staking/operations/monad.ts
+++ b/libs/coin-modules/coin-evm/src/staking/operations/monad.ts
@@ -1,8 +1,14 @@
-import type { OperationParamsWithValId, StakingProtocol } from "./types";
+import type { OperationParamsMonad, StakingProtocol } from "./types";
 
-const monadProtocol: StakingProtocol<OperationParamsWithValId> = {
+const monadProtocol: StakingProtocol<OperationParamsMonad> = {
   delegate: ({ valId }) => [BigInt(valId)],
   claimReward: ({ valId }) => [BigInt(valId)],
+  undelegate: ({ valId, amount, withdrawId }) => {
+    if (withdrawId === undefined) {
+      throw new Error("monad undelegate requires withdrawId");
+    }
+    return [BigInt(valId), amount, BigInt(withdrawId)];
+  },
 };
 
 export default monadProtocol;

--- a/libs/coin-modules/coin-evm/src/staking/operations/types.ts
+++ b/libs/coin-modules/coin-evm/src/staking/operations/types.ts
@@ -4,14 +4,16 @@ export type OperationParams = {
   valId?: string | undefined;
   dstValAddress?: string | undefined;
   delegator?: string | undefined;
+  withdrawId?: string | undefined;
 };
 
 export type OperationParamsWithValAddress = OperationParams & {
   valAddress: string;
 };
 
-export type OperationParamsWithValId = OperationParams & {
+export type OperationParamsMonad = OperationParams & {
   valId: string;
+  withdrawId?: string | undefined;
 };
 
 export type OperationFn<P extends OperationParams = OperationParams> = (

--- a/libs/coin-modules/coin-evm/src/staking/prepareIntents.ts
+++ b/libs/coin-modules/coin-evm/src/staking/prepareIntents.ts
@@ -1,0 +1,54 @@
+import type {
+  BufferTxData,
+  MemoNotSupported,
+  TransactionIntent,
+} from "@ledgerhq/coin-module-framework/api/index";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { isStakingIntent } from "../utils";
+import { findFirstFreeWithdrawId } from "./validators/monad";
+
+type StakingIntent = TransactionIntent<MemoNotSupported, BufferTxData>;
+
+/**
+ * Per-currency hook that may enrich a staking intent with values that have to be
+ * looked up at submission time (e.g. an on-chain "free slot" id). Returns the
+ * intent unchanged when no enrichment is needed.
+ */
+type IntentPreparer = (intent: StakingIntent) => Promise<StakingIntent>;
+
+const prepareMonadIntent: IntentPreparer = async intent => {
+  if (!isStakingIntent(intent)) return intent;
+  if (intent.mode !== "undelegate" || intent.withdrawId !== undefined || !intent.valId) {
+    return intent;
+  }
+
+  const withdrawId = await findFirstFreeWithdrawId("monad", BigInt(intent.valId), intent.sender);
+  if (withdrawId === null) {
+    throw new Error(
+      "No free Monad withdraw slot: all slots (0–255) are in use for this validator. " +
+        "Withdraw a completed undelegation before undelegating again.",
+    );
+  }
+
+  // Bind to the narrowed (EvmStakingIntent) type so the literal isn't checked for
+  // excess props against the wider TransactionIntent return type.
+  const enriched: typeof intent = { ...intent, withdrawId: withdrawId.toString() };
+  return enriched;
+};
+
+const STAKING_INTENT_PREPARERS: Record<string, IntentPreparer> = {
+  monad: prepareMonadIntent,
+};
+
+/**
+ * Run any currency-specific intent fixup (e.g. resolve a free withdraw-id slot
+ * for Monad) before encoding calldata. No-op for currencies without a registered
+ * preparer.
+ */
+export const prepareStakingIntent = async (
+  currency: CryptoCurrency,
+  intent: StakingIntent,
+): Promise<StakingIntent> => {
+  const prepare = STAKING_INTENT_PREPARERS[currency.id];
+  return prepare ? prepare(intent) : intent;
+};

--- a/libs/coin-modules/coin-evm/src/staking/serialization.test.ts
+++ b/libs/coin-modules/coin-evm/src/staking/serialization.test.ts
@@ -109,14 +109,11 @@ describe("coin-evm/staking/serialization", () => {
 
     it("roundtrips a Monad unbonding `withdrawId` (number ↔ string), omitting them when absent", () => {
       const raw = toStakingResourcesRaw(sampleResources);
-      // serialized as a string on the raw side; withdrawable stays a boolean
       expect(raw.unbondings[0]).toHaveProperty("withdrawId", "3");
 
       const back = fromStakingResourcesRaw(raw);
-      // restored as a number on the account side
       expect(back.unbondings[0].withdrawId).toBe(3);
-      
-      // unbondings without these fields don't gain the keys in either direction
+
       const noId: StakingResources = {
         ...sampleResources,
         unbondings: [

--- a/libs/coin-modules/coin-evm/src/staking/serialization.test.ts
+++ b/libs/coin-modules/coin-evm/src/staking/serialization.test.ts
@@ -44,6 +44,7 @@ const sampleResources: StakingResources = {
       validatorAddress: "seivaloper1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx01",
       amount: new BigNumber("250000000000000000"),
       completionDate,
+      withdrawId: 3,
     },
   ],
   delegatedBalance: new BigNumber("3000000000000000000"),
@@ -104,6 +105,31 @@ describe("coin-evm/staking/serialization", () => {
       expect([back.redelegations[0].completionDate, back.unbondings[0].completionDate]).toEqual(
         Array(2).fill(expect.any(Date)),
       );
+    });
+
+    it("roundtrips a Monad unbonding `withdrawId` (number ↔ string), omitting them when absent", () => {
+      const raw = toStakingResourcesRaw(sampleResources);
+      // serialized as a string on the raw side; withdrawable stays a boolean
+      expect(raw.unbondings[0]).toHaveProperty("withdrawId", "3");
+
+      const back = fromStakingResourcesRaw(raw);
+      // restored as a number on the account side
+      expect(back.unbondings[0].withdrawId).toBe(3);
+      
+      // unbondings without these fields don't gain the keys in either direction
+      const noId: StakingResources = {
+        ...sampleResources,
+        unbondings: [
+          {
+            validatorAddress: sampleResources.unbondings[0].validatorAddress,
+            amount: sampleResources.unbondings[0].amount,
+            completionDate: sampleResources.unbondings[0].completionDate,
+          },
+        ],
+      };
+      const rawNoId = toStakingResourcesRaw(noId);
+      expect(rawNoId.unbondings[0]).not.toHaveProperty("withdrawId");
+      expect(fromStakingResourcesRaw(rawNoId).unbondings[0]).not.toHaveProperty("withdrawId");
     });
 
     it("only propagates `validators` when defined", () => {

--- a/libs/coin-modules/coin-evm/src/staking/serialization.ts
+++ b/libs/coin-modules/coin-evm/src/staking/serialization.ts
@@ -60,6 +60,7 @@ function toStakingUnbondingRaw(u: StakingUnbonding): StakingUnbondingRaw {
     ...(u.validatorName !== undefined ? { validatorName: u.validatorName } : {}),
     amount: u.amount.toString(),
     completionDate: u.completionDate.toISOString(),
+    ...(u.withdrawId !== undefined ? { withdrawId: u.withdrawId.toString() } : {}),
   };
 }
 
@@ -69,6 +70,7 @@ function fromStakingUnbondingRaw(u: StakingUnbondingRaw): StakingUnbonding {
     ...(typeof u.validatorName === "string" ? { validatorName: u.validatorName } : {}),
     amount: new BigNumber(u.amount),
     completionDate: new Date(u.completionDate),
+    ...(u.withdrawId !== undefined ? { withdrawId: Number(u.withdrawId) } : {}),
   };
 }
 

--- a/libs/coin-modules/coin-evm/src/staking/transactionData.ts
+++ b/libs/coin-modules/coin-evm/src/staking/transactionData.ts
@@ -25,7 +25,7 @@ export function buildStakingTransactionParams(
     throw new Error("Intent must be a staking intent");
   }
 
-  const { amount, sender, mode, valAddress, valId, dstValAddress } = intent;
+  const { amount, sender, mode, valAddress, valId, dstValAddress, withdrawId } = intent;
 
   const config = STAKING_CONTRACTS[currency.id];
   if (!config) {
@@ -42,6 +42,7 @@ export function buildStakingTransactionParams(
     amount,
     dstValAddress,
     delegator: sender,
+    withdrawId,
   });
 
   const to = config.specificContractAddressByOperation?.[mode] ?? config.contractAddress;

--- a/libs/coin-modules/coin-evm/src/staking/validators/index.ts
+++ b/libs/coin-modules/coin-evm/src/staking/validators/index.ts
@@ -6,8 +6,6 @@ import monadValidatorApi from "./monad";
 import seiValidatorApi from "./sei";
 import type { ValidatorApi } from "./types";
 
-export { findFreeWithdrawId } from "./monad";
-
 /**
  * Validators cache TTL (30s, same as Cosmos preload) so a user navigating across
  * delegation screens reads a hot cache instead of paying a network roundtrip each time.

--- a/libs/coin-modules/coin-evm/src/staking/validators/index.ts
+++ b/libs/coin-modules/coin-evm/src/staking/validators/index.ts
@@ -6,6 +6,8 @@ import monadValidatorApi from "./monad";
 import seiValidatorApi from "./sei";
 import type { ValidatorApi } from "./types";
 
+export { findFreeWithdrawId } from "./monad";
+
 /**
  * Validators cache TTL (30s, same as Cosmos preload) so a user navigating across
  * delegation screens reads a hot cache instead of paying a network roundtrip each time.

--- a/libs/coin-modules/coin-evm/src/staking/validators/monad.test.ts
+++ b/libs/coin-modules/coin-evm/src/staking/validators/monad.test.ts
@@ -482,8 +482,6 @@ describe("staking/validators/monad", () => {
         0n,
       ]);
 
-    // getWithdrawalRequest returns [withdrawalAmount, accRewardPerToken, withdrawEpoch].
-    // A slot is occupied while amount or epoch is non-zero.
     const encodeWithdrawalRequest = (withdrawalAmount: bigint, withdrawEpoch = 1n): string =>
       monadIface.encodeFunctionResult("getWithdrawalRequest", [withdrawalAmount, 0n, withdrawEpoch]);
 
@@ -714,7 +712,6 @@ describe("staking/validators/monad", () => {
     });
 
     it("emits a deactivating stake per occupied withdrawId slot, dating its completion from the current epoch", async () => {
-      // ~5.5h per epoch, mirroring EPOCH_DURATION_MS in monad.ts.
       const EPOCH_DURATION_MS = 5.5 * 60 * 60 * 1000;
       const NOW = Date.UTC(2026, 5, 4, 12, 0, 0);
       jest.useFakeTimers().setSystemTime(NOW);
@@ -725,8 +722,6 @@ describe("staking/validators/monad", () => {
           getDelegator: () => encodeDelegator(100n),
           getValidator: () => encodeGetValidator({ stake: 0n, commission: 0n, secpPubkey: SECP }),
           getEpoch: () => encodeEpoch(5n),
-          // Slot 2 completed at epoch 3 (< 5 ⇒ already withdrawable, 2 epochs in the past);
-          // slot 5 at epoch 10 (> 5 ⇒ 5 epochs out).
           getWithdrawalRequest: (_valId, withdrawId) => {
             if (withdrawId === 2) return encodeWithdrawalRequest(40n, 3n);
             if (withdrawId === 5) return encodeWithdrawalRequest(60n, 10n);
@@ -738,7 +733,6 @@ describe("staking/validators/monad", () => {
       try {
         const stakes = await fetchStakes();
 
-        // one active + two deactivating, in ascending withdrawId order
         expect(stakes).toHaveLength(3);
         expect(stakes[0]).toMatchObject({ state: "active", amount: 100n });
 

--- a/libs/coin-modules/coin-evm/src/staking/validators/monad.test.ts
+++ b/libs/coin-modules/coin-evm/src/staking/validators/monad.test.ts
@@ -82,6 +82,8 @@ const routeByName = (responses: {
   getValidator?: (valId: bigint) => string | Error;
   getDelegations?: (startValId: bigint) => string | Error;
   getDelegator?: (valId: bigint) => string | Error;
+  getWithdrawalRequest?: (valId: bigint, withdrawId: number) => string | Error;
+  getEpoch?: () => string | Error;
 }): CallHandler => {
   return async ({ data }) => {
     if (!data) throw new Error("missing data");
@@ -113,6 +115,24 @@ const routeByName = (responses: {
       const out = responses.getDelegator?.(valId);
       if (out instanceof Error) throw out;
       if (!out) throw new Error(`no response for getDelegator(${valId})`);
+      return out;
+    }
+    if (desc.name === "getWithdrawalRequest") {
+      const valId = desc.args[0] as bigint;
+      const withdrawId = Number(desc.args[2] as bigint);
+      // Default unhandled slots to "free" (all-zero) so tests that don't care about
+      // withdrawals aren't forced to stub all 256 slots.
+      const out =
+        responses.getWithdrawalRequest?.(valId, withdrawId) ??
+        monadIface.encodeFunctionResult("getWithdrawalRequest", [0n, 0n, 0n]);
+      if (out instanceof Error) throw out;
+      return out;
+    }
+    if (desc.name === "getEpoch") {
+      // Default to epoch 0 so withdrawals are "not yet withdrawable" unless a test opts in.
+      const out =
+        responses.getEpoch?.() ?? monadIface.encodeFunctionResult("getEpoch", [0n, false]);
+      if (out instanceof Error) throw out;
       return out;
     }
     throw new Error(`unexpected function: ${desc.name}`);
@@ -462,6 +482,15 @@ describe("staking/validators/monad", () => {
         0n,
       ]);
 
+    // getWithdrawalRequest returns [withdrawalAmount, accRewardPerToken, withdrawEpoch].
+    // A slot is occupied while amount or epoch is non-zero.
+    const encodeWithdrawalRequest = (withdrawalAmount: bigint, withdrawEpoch = 1n): string =>
+      monadIface.encodeFunctionResult("getWithdrawalRequest", [withdrawalAmount, 0n, withdrawEpoch]);
+
+    // getEpoch returns [epoch, inEpochDelayPeriod].
+    const encodeEpoch = (epoch: bigint): string =>
+      monadIface.encodeFunctionResult("getEpoch", [epoch, false]);
+
     const callNames = (callMock: ReturnType<typeof setupRpc>): (string | undefined)[] =>
       callMock.mock.calls.map(
         ([req]) => monadIface.parseTransaction({ data: req.data ?? "0x" })?.name,
@@ -682,6 +711,115 @@ describe("staking/validators/monad", () => {
 
       expect(await fetchStakes()).toStrictEqual([]);
       expect(mockedWithApi).not.toHaveBeenCalled();
+    });
+
+    it("emits a deactivating stake per occupied withdrawId slot, dating its completion from the current epoch", async () => {
+      // ~5.5h per epoch, mirroring EPOCH_DURATION_MS in monad.ts.
+      const EPOCH_DURATION_MS = 5.5 * 60 * 60 * 1000;
+      const NOW = Date.UTC(2026, 5, 4, 12, 0, 0);
+      jest.useFakeTimers().setSystemTime(NOW);
+
+      setupRpc(
+        routeByName({
+          getDelegations: () => monadIface.encodeFunctionResult("getDelegations", [true, 0, [7n]]),
+          getDelegator: () => encodeDelegator(100n),
+          getValidator: () => encodeGetValidator({ stake: 0n, commission: 0n, secpPubkey: SECP }),
+          getEpoch: () => encodeEpoch(5n),
+          // Slot 2 completed at epoch 3 (< 5 ⇒ already withdrawable, 2 epochs in the past);
+          // slot 5 at epoch 10 (> 5 ⇒ 5 epochs out).
+          getWithdrawalRequest: (_valId, withdrawId) => {
+            if (withdrawId === 2) return encodeWithdrawalRequest(40n, 3n);
+            if (withdrawId === 5) return encodeWithdrawalRequest(60n, 10n);
+            return encodeWithdrawalRequest(0n, 0n);
+          },
+        }),
+      );
+
+      try {
+        const stakes = await fetchStakes();
+
+        // one active + two deactivating, in ascending withdrawId order
+        expect(stakes).toHaveLength(3);
+        expect(stakes[0]).toMatchObject({ state: "active", amount: 100n });
+
+        const deactivating = stakes.filter(s => s.state === "deactivating");
+        expect(deactivating).toStrictEqual([
+          {
+            uid: `${PRECOMPILE}-7-${DELEGATOR}-withdraw-2`,
+            address: DELEGATOR,
+            delegate: ethers.computeAddress(SECP),
+            state: "deactivating",
+            stateUpdatedAt: new Date(NOW - 2 * EPOCH_DURATION_MS),
+            asset: { type: "native", name: "Monad", unit: { name: "MON", code: "MON", magnitude: 18 } },
+            amount: 40n,
+            actions: [],
+            details: {
+              contractAddress: PRECOMPILE,
+              validator: ethers.computeAddress(SECP),
+              validatorId: "7",
+              withdrawId: 2,
+            },
+          },
+          {
+            uid: `${PRECOMPILE}-7-${DELEGATOR}-withdraw-5`,
+            address: DELEGATOR,
+            delegate: ethers.computeAddress(SECP),
+            state: "deactivating",
+            stateUpdatedAt: new Date(NOW + 5 * EPOCH_DURATION_MS),
+            asset: { type: "native", name: "Monad", unit: { name: "MON", code: "MON", magnitude: 18 } },
+            amount: 60n,
+            actions: [],
+            details: {
+              contractAddress: PRECOMPILE,
+              validator: ethers.computeAddress(SECP),
+              validatorId: "7",
+              withdrawId: 5,
+            },
+          },
+        ]);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it("emits a deactivating stake with no completion date when the current epoch can't be read", async () => {
+      setupRpc(
+        routeByName({
+          getDelegations: () => monadIface.encodeFunctionResult("getDelegations", [true, 0, [7n]]),
+          getDelegator: () => encodeDelegator(0n),
+          getValidator: () => encodeGetValidator({ stake: 0n, commission: 0n, secpPubkey: SECP }),
+          getEpoch: () => new Error("rpc timeout"),
+          getWithdrawalRequest: (_valId, withdrawId) =>
+            withdrawId === 1 ? encodeWithdrawalRequest(10n, 1n) : encodeWithdrawalRequest(0n, 0n),
+        }),
+      );
+
+      const stakes = await fetchStakes();
+
+      // epoch unknown ⇒ no completion date rather than a misleading one
+      expect(
+        stakes.map(s => ({ withdrawId: s.details?.withdrawId, stateUpdatedAt: s.stateUpdatedAt })),
+      ).toStrictEqual([{ withdrawId: 1, stateUpdatedAt: undefined }]);
+    });
+
+    it("skips a withdrawal slot whose read fails rather than treating it as occupied", async () => {
+      setupRpc(
+        routeByName({
+          getDelegations: () => monadIface.encodeFunctionResult("getDelegations", [true, 0, [7n]]),
+          getDelegator: () => encodeDelegator(0n), // no active stake, only withdrawals
+          getValidator: () => encodeGetValidator({ stake: 0n, commission: 0n, secpPubkey: SECP }),
+          getWithdrawalRequest: (_valId, withdrawId) => {
+            if (withdrawId === 1) return encodeWithdrawalRequest(10n);
+            if (withdrawId === 3) return new Error("rpc timeout");
+            return encodeWithdrawalRequest(0n, 0n);
+          },
+        }),
+      );
+
+      const stakes = await fetchStakes();
+
+      // slot 3's transient failure is skipped (not surfaced as an unbonding); only slot 1 remains
+      expect(stakes.map(s => s.details?.withdrawId)).toStrictEqual([1]);
     });
 
     it("stops paginating when nextValId does not advance", async () => {

--- a/libs/coin-modules/coin-evm/src/staking/validators/monad.ts
+++ b/libs/coin-modules/coin-evm/src/staking/validators/monad.ts
@@ -344,6 +344,7 @@ const fetchStakeForValId = async (
   contractAddress: string,
   delegator: string,
   valId: bigint,
+  currentEpoch: bigint | null,
 ): Promise<Stake[]> => {
   const data = iface.encodeFunctionData("getDelegator", [valId, delegator]);
   const raw = await provider.call({ to: contractAddress, data });
@@ -352,7 +353,19 @@ const fetchStakeForValId = async (
 
   const [activeStake, , unclaimedRewards, deltaStake, nextDeltaStake] = decoded;
   const deltaStakes = deltaStake + nextDeltaStake;
-  if (activeStake === 0n && deltaStakes === 0n && unclaimedRewards === 0n) return [];
+
+  // Pending withdrawal requests (occupied withdrawId slots) for this (validator, delegator).
+  // Fetched even when the active/activating amounts are zero so a fully-undelegated position
+  // still surfaces its withdrawId(s) for a later `withdraw`.
+  const withdrawals = await fetchWithdrawalRequests(
+    provider,
+    iface,
+    contractAddress,
+    valId,
+    delegator,
+  );
+
+  if (activeStake === 0n && deltaStakes === 0n &&  unclaimedRewards === 0n && withdrawals.length === 0) return [];
 
   const validator = await callGetValidator(provider, iface, contractAddress, valId).catch(
     () => null,
@@ -398,6 +411,21 @@ const fetchStakeForValId = async (
   if (deltaStakes !== 0n) {
     stakes.push(makeStake("activating", deltaStakes));
   }
+  
+  for (const { withdrawId, withdrawalAmount, withdrawEpoch } of withdrawals) {
+    const completionDate = epochToDate(withdrawEpoch, currentEpoch);
+    stakes.push({
+      uid: `${contractAddress}-${valId.toString()}-${delegator}-withdraw-${withdrawId}`,
+      address: delegator,
+      ...(validatorAddress ? { delegate: validatorAddress } : {}),
+      state: "deactivating",
+      ...(completionDate ? { stateUpdatedAt: completionDate } : {}),
+      asset,
+      amount: withdrawalAmount,
+      actions: [],
+      details: { ...details, withdrawId },
+    });
+  }
   return stakes;
 };
 
@@ -417,6 +445,8 @@ export const fetchMonadStakes = async (
         const valIds = await fetchDelegatedValIds(provider, iface, ctx.contractAddress, address);
         if (valIds.length === 0) return [];
 
+        const currentEpoch = await callGetEpoch(provider, iface, ctx.contractAddress);
+
         const stakes: Stake[] = [];
         for (let i = 0; i < valIds.length; i += DETAILS_BATCH_SIZE) {
           const chunk = valIds.slice(i, i + DETAILS_BATCH_SIZE);
@@ -429,6 +459,7 @@ export const fetchMonadStakes = async (
                 ctx.contractAddress,
                 address,
                 valId,
+                currentEpoch,
               ),
             ),
           );
@@ -455,6 +486,209 @@ export const fetchMonadStakes = async (
       error: error instanceof Error ? error.message : String(error),
     });
     return [];
+  }
+};
+
+// getWithdrawalRequest returns [withdrawalAmount, accRewardPerToken, withdrawEpoch].
+type WithdrawalRequestRaw = [bigint, bigint, bigint];
+
+function isWithdrawalRequestRaw(value: unknown): value is WithdrawalRequestRaw {
+  return (
+    Array.isArray(value) &&
+    typeof value[0] === "bigint" &&
+    typeof value[1] === "bigint" &&
+    typeof value[2] === "bigint"
+  );
+}
+
+// A withdrawId slot is "in use" while it holds a pending undelegation that has not
+// yet been withdrawn. The precompile zeroes the request once `withdraw` completes,
+// so a free slot reads back all-zero. We check amount AND epoch (not amount alone)
+// so a slot is never treated as free while any field is still set.
+const isWithdrawIdInUse = (req: WithdrawalRequestRaw): boolean => {
+  const [withdrawalAmount, , withdrawEpoch] = req;
+  return withdrawalAmount !== 0n || withdrawEpoch !== 0n;
+};
+
+const MAX_WITHDRAW_ID = 255;
+
+const WITHDRAW_ID_BATCH_SIZE = 128;
+
+// The precompile exposes a withdrawal's completion epoch but no epoch-to-timestamp mapping,
+// so we project the remaining epochs onto wall-clock time. Per Monad docs an epoch lasts ~5.5h
+// (WITHDRAWAL_DELAY = 1 epoch ≈ 5.5h). Source: https://docs.monad.xyz/monad-arch/consensus/staking
+const EPOCH_DURATION_MS = 5.5 * 60 * 60 * 1000;
+
+/**
+ * Convert an epoch number into its wall-clock start date. The precompile exposes no
+ * epoch-to-timestamp mapping, so we anchor epoch 0 from the live `(currentEpoch, now)` pair and
+ * project the target epoch from there. The result is unbounded in both directions: an epoch
+ * already in the past yields a past date, a future epoch a future date — so for a completion epoch
+ * a `date <= now` check reflects withdrawability. Returns `null` when the current epoch is unknown
+ * so callers carry no (possibly misleading) date.
+ */
+const epochToDate = (epoch: bigint, currentEpoch: bigint | null): Date | null => {
+  if (currentEpoch === null) return null;
+  const epochZeroMs = Date.now() - Number(currentEpoch) * EPOCH_DURATION_MS;
+  return new Date(epochZeroMs + Number(epoch) * EPOCH_DURATION_MS);
+};
+
+type OccupiedWithdrawal = {
+  withdrawId: number;
+  withdrawalAmount: bigint;
+  withdrawEpoch: bigint;
+};
+
+/**
+ * Enumerate the occupied `withdrawId` slots for a (validator, delegator) pair — the inverse of
+ * `findFreeWithdrawId`. A slot is occupied while it holds a pending undelegation that has not
+ * yet been withdrawn (see `isWithdrawIdInUse`). Reads that fail/can't be decoded are skipped, so
+ * a transient RPC error never invents nor drops a slot.
+ */
+const fetchWithdrawalRequests = async (
+  provider: JsonRpcProvider,
+  iface: ethers.Interface,
+  contractAddress: string,
+  valId: bigint,
+  delegator: string,
+): Promise<OccupiedWithdrawal[]> => {
+  const occupied: OccupiedWithdrawal[] = [];
+
+  for (let start = 0; start <= MAX_WITHDRAW_ID; start += WITHDRAW_ID_BATCH_SIZE) {
+    const end = Math.min(start + WITHDRAW_ID_BATCH_SIZE - 1, MAX_WITHDRAW_ID);
+    const ids = Array.from({ length: end - start + 1 }, (_, i) => start + i);
+
+    const settled = await Promise.allSettled(
+      ids.map(withdrawId =>
+        callGetWithdrawalRequest(provider, iface, contractAddress, valId, delegator, withdrawId),
+      ),
+    );
+
+    settled.forEach((res, i) => {
+      const withdrawId = ids[i];
+      if (res.status === "rejected") {
+        log("coin-evm/staking", "fetchWithdrawalRequests: getWithdrawalRequest call failed", {
+          valId: valId.toString(),
+          withdrawId,
+          error: res.reason instanceof Error ? res.reason.message : String(res.reason),
+        });
+        return;
+      }
+      const req = res.value;
+      if (!req || !isWithdrawIdInUse(req)) return;
+      const [withdrawalAmount, , withdrawEpoch] = req;
+      occupied.push({ withdrawId, withdrawalAmount, withdrawEpoch });
+    });
+  }
+
+  return occupied;
+};
+
+/**
+ * Find the lowest free `withdrawId` slot for an undelegation on a given validator.
+ *
+ * A slot is free when its withdrawal request reads back all-zero (no pending
+ * undelegation occupying it). Returns `null` when every slot (0–255) is occupied —
+ * the caller must then have the user `withdraw` a completed request before undelegating
+ * again — or when the chain context can't be resolved.
+ *
+ * Reads that fail/can't be decoded are treated as "unknown" and skipped, so a transient
+ * RPC error never causes an occupied slot to be reported as free.
+ */
+export const findFreeWithdrawId = async (
+  currencyId: string,
+  valId: bigint,
+  delegator: string,
+): Promise<number | null> => {
+  const ctx = resolveContext(currencyId);
+  if (!ctx) return null;
+
+  try {
+    return await withApi(
+      ctx.currency,
+      async provider => {
+        const iface = new ethers.Interface(ctx.abi);
+
+        for (let start = 0; start <= MAX_WITHDRAW_ID; start += WITHDRAW_ID_BATCH_SIZE) {
+          const end = Math.min(start + WITHDRAW_ID_BATCH_SIZE - 1, MAX_WITHDRAW_ID);
+          const ids = Array.from({ length: end - start + 1 }, (_, i) => start + i);
+
+          const settled = await Promise.allSettled(
+            ids.map(withdrawId =>
+              callGetWithdrawalRequest(
+                provider,
+                iface,
+                ctx.contractAddress,
+                valId,
+                delegator,
+                withdrawId,
+              ),
+            ),
+          );
+
+          // Walk the chunk in ascending order so the lowest free slot wins.
+          for (let i = 0; i < settled.length; i++) {
+            const res = settled[i];
+            if (res.status === "rejected") {
+              log("coin-evm/staking", "findFreeWithdrawId: getWithdrawalRequest call failed", {
+                currencyId,
+                valId: valId.toString(),
+                withdrawId: ids[i],
+                error: res.reason instanceof Error ? res.reason.message : String(res.reason),
+              });
+              continue;
+            }
+            if (res.value && !isWithdrawIdInUse(res.value)) return ids[i];
+          }
+        }
+
+        return null;
+      },
+      ctx.node,
+    );
+  } catch (error) {
+    log("coin-evm/staking", "findFreeWithdrawId: lookup failed", {
+      currencyId,
+      valId: valId.toString(),
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+};
+
+const callGetWithdrawalRequest = async (
+  provider: JsonRpcProvider,
+  iface: ethers.Interface,
+  contractAddress: string,
+  valId: bigint,
+  delegator: string,
+  withdrawId: number,
+): Promise<WithdrawalRequestRaw | null> => {
+  const data = iface.encodeFunctionData("getWithdrawalRequest", [valId, delegator, withdrawId]);
+  const raw = await provider.call({ to: contractAddress, data });
+  const decoded = iface.decodeFunctionResult("getWithdrawalRequest", raw);
+  return isWithdrawalRequestRaw(decoded) ? decoded : null;
+};
+
+/**
+ * Read the chain's current epoch via the staking precompile's `getEpoch`. Returns `null` on any
+ * read/decode failure so callers treat withdrawability as "unknown" (conservatively not ready).
+ */
+export const callGetEpoch = async (
+  provider: JsonRpcProvider,
+  iface: ethers.Interface,
+  contractAddress: string,
+): Promise<bigint | null> => {
+  try {
+    const data = iface.encodeFunctionData("getEpoch", []);
+    const raw = await provider.call({ to: contractAddress, data });
+    const decoded = iface.decodeFunctionResult("getEpoch", raw);
+    return Array.isArray(decoded) && typeof decoded[0] === "bigint" ? decoded[0] : null;
+  } catch (error) {
+    log("coin-evm/staking", "callGetEpoch: getEpoch call failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
   }
 };
 

--- a/libs/coin-modules/coin-evm/src/staking/validators/monad.ts
+++ b/libs/coin-modules/coin-evm/src/staking/validators/monad.ts
@@ -354,9 +354,6 @@ const fetchStakeForValId = async (
   const [activeStake, , unclaimedRewards, deltaStake, nextDeltaStake] = decoded;
   const deltaStakes = deltaStake + nextDeltaStake;
 
-  // Pending withdrawal requests (occupied withdrawId slots) for this (validator, delegator).
-  // Fetched even when the active/activating amounts are zero so a fully-undelegated position
-  // still surfaces its withdrawId(s) for a later `withdraw`.
   const withdrawals = await fetchWithdrawalRequests(
     provider,
     iface,
@@ -501,10 +498,6 @@ function isWithdrawalRequestRaw(value: unknown): value is WithdrawalRequestRaw {
   );
 }
 
-// A withdrawId slot is "in use" while it holds a pending undelegation that has not
-// yet been withdrawn. The precompile zeroes the request once `withdraw` completes,
-// so a free slot reads back all-zero. We check amount AND epoch (not amount alone)
-// so a slot is never treated as free while any field is still set.
 const isWithdrawIdInUse = (req: WithdrawalRequestRaw): boolean => {
   const [withdrawalAmount, , withdrawEpoch] = req;
   return withdrawalAmount !== 0n || withdrawEpoch !== 0n;
@@ -519,14 +512,6 @@ const WITHDRAW_ID_BATCH_SIZE = 128;
 // (WITHDRAWAL_DELAY = 1 epoch ≈ 5.5h). Source: https://docs.monad.xyz/monad-arch/consensus/staking
 const EPOCH_DURATION_MS = 5.5 * 60 * 60 * 1000;
 
-/**
- * Convert an epoch number into its wall-clock start date. The precompile exposes no
- * epoch-to-timestamp mapping, so we anchor epoch 0 from the live `(currentEpoch, now)` pair and
- * project the target epoch from there. The result is unbounded in both directions: an epoch
- * already in the past yields a past date, a future epoch a future date — so for a completion epoch
- * a `date <= now` check reflects withdrawability. Returns `null` when the current epoch is unknown
- * so callers carry no (possibly misleading) date.
- */
 const epochToDate = (epoch: bigint, currentEpoch: bigint | null): Date | null => {
   if (currentEpoch === null) return null;
   const epochZeroMs = Date.now() - Number(currentEpoch) * EPOCH_DURATION_MS;
@@ -539,12 +524,6 @@ type OccupiedWithdrawal = {
   withdrawEpoch: bigint;
 };
 
-/**
- * Enumerate the occupied `withdrawId` slots for a (validator, delegator) pair — the inverse of
- * `findFreeWithdrawId`. A slot is occupied while it holds a pending undelegation that has not
- * yet been withdrawn (see `isWithdrawIdInUse`). Reads that fail/can't be decoded are skipped, so
- * a transient RPC error never invents nor drops a slot.
- */
 const fetchWithdrawalRequests = async (
   provider: JsonRpcProvider,
   iface: ethers.Interface,
@@ -584,18 +563,7 @@ const fetchWithdrawalRequests = async (
   return occupied;
 };
 
-/**
- * Find the lowest free `withdrawId` slot for an undelegation on a given validator.
- *
- * A slot is free when its withdrawal request reads back all-zero (no pending
- * undelegation occupying it). Returns `null` when every slot (0–255) is occupied —
- * the caller must then have the user `withdraw` a completed request before undelegating
- * again — or when the chain context can't be resolved.
- *
- * Reads that fail/can't be decoded are treated as "unknown" and skipped, so a transient
- * RPC error never causes an occupied slot to be reported as free.
- */
-export const findFreeWithdrawId = async (
+export const findFirstFreeWithdrawId = async (
   currencyId: string,
   valId: bigint,
   delegator: string,
@@ -626,11 +594,10 @@ export const findFreeWithdrawId = async (
             ),
           );
 
-          // Walk the chunk in ascending order so the lowest free slot wins.
           for (let i = 0; i < settled.length; i++) {
             const res = settled[i];
             if (res.status === "rejected") {
-              log("coin-evm/staking", "findFreeWithdrawId: getWithdrawalRequest call failed", {
+              log("coin-evm/staking", "findFirstFreeWithdrawId: getWithdrawalRequest call failed", {
                 currencyId,
                 valId: valId.toString(),
                 withdrawId: ids[i],
@@ -647,7 +614,7 @@ export const findFreeWithdrawId = async (
       ctx.node,
     );
   } catch (error) {
-    log("coin-evm/staking", "findFreeWithdrawId: lookup failed", {
+    log("coin-evm/staking", "findFirstFreeWithdrawId: lookup failed", {
       currencyId,
       valId: valId.toString(),
       error: error instanceof Error ? error.message : String(error),
@@ -670,10 +637,6 @@ const callGetWithdrawalRequest = async (
   return isWithdrawalRequestRaw(decoded) ? decoded : null;
 };
 
-/**
- * Read the chain's current epoch via the staking precompile's `getEpoch`. Returns `null` on any
- * read/decode failure so callers treat withdrawability as "unknown" (conservatively not ready).
- */
 export const callGetEpoch = async (
   provider: JsonRpcProvider,
   iface: ethers.Interface,

--- a/libs/coin-modules/coin-evm/src/utils.ts
+++ b/libs/coin-modules/coin-evm/src/utils.ts
@@ -360,9 +360,12 @@ export const getCeloAmount = (decoded: unknown): bigint => {
 /**
  * Checks if a transaction intent is a staking intent
  */
-// NOTE: `valId` should eventually be promoted to a first-class property of `StakingTransactionIntent`
-// in @ledgerhq/coin-module-framework. Kept as a local augmentation for now.
-export type EvmStakingIntent = StakingTransactionIntent & { valId?: string };
+// NOTE: `valId`/`withdrawId` should eventually be promoted to first-class properties of
+// `StakingTransactionIntent` in @ledgerhq/coin-module-framework. Kept as local augmentations for now.
+export type EvmStakingIntent = StakingTransactionIntent & {
+  valId?: string;
+  withdrawId?: string;
+};
 
 export function isStakingIntent(intent: TransactionIntent): intent is EvmStakingIntent {
   return intent.intentType === "staking";

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
@@ -419,11 +419,13 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
       const unbondings: StakingUnbonding[] = deactivatingStakes.filter(hasStakeDelegate).map(b => {
         const delegated: bigint = delegatedAmountForStakingResources(b);
         const validatorName = b.stake.details?.validatorName;
+        const withdrawId = b.stake.details?.withdrawId;
         return {
           validatorAddress: b.stake.delegate,
           amount: new BigNumber(delegated.toString()),
           completionDate: b.stake.stateUpdatedAt ?? new Date(),
           ...(typeof validatorName === "string" ? { validatorName } : {}),
+          ...(typeof withdrawId === "number" ? { withdrawId } : {}),
         };
       });
       stakingResources = {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
@@ -114,6 +114,7 @@ type GenericCoinFrameworkTransactionIntent = TransactionIntent & {
   mode?: StakingOperation;
   valAddress?: string;
   valId?: string;
+  withdrawId?: string;
   dstValAddress?: string;
 };
 
@@ -121,7 +122,10 @@ function getDelegationIntentFields(
   delegationMode: StakingOperation | undefined,
   transaction: GenericTransaction,
 ): Partial<
-  Pick<GenericCoinFrameworkTransactionIntent, "mode" | "valAddress" | "valId" | "dstValAddress">
+  Pick<
+    GenericCoinFrameworkTransactionIntent,
+    "mode" | "valAddress" | "valId" | "dstValAddress" | "withdrawId"
+  >
 > {
   return {
     ...(delegationMode !== undefined && transaction.valAddress

--- a/libs/ledgerjs/packages/types-live/src/staking.ts
+++ b/libs/ledgerjs/packages/types-live/src/staking.ts
@@ -45,6 +45,9 @@ export type StakingUnbonding = {
   validatorName?: string;
   amount: BigNumber;
   completionDate: Date;
+  // Monad: the 0-255 withdrawId slot identifying this pending withdrawal request for the
+  // (validator, delegator) pair, needed to later call `withdraw(withdrawId)`.
+  withdrawId?: number;
 };
 
 export type StakingUnbondingRaw = {
@@ -52,6 +55,7 @@ export type StakingUnbondingRaw = {
   validatorName?: string;
   amount: string;
   completionDate: string;
+  withdrawId?: string;
 };
 
 export type StakingResources = {

--- a/libs/ledgerjs/packages/types-live/src/staking.ts
+++ b/libs/ledgerjs/packages/types-live/src/staking.ts
@@ -45,8 +45,6 @@ export type StakingUnbonding = {
   validatorName?: string;
   amount: BigNumber;
   completionDate: Date;
-  // Monad: the 0-255 withdrawId slot identifying this pending withdrawal request for the
-  // (validator, delegator) pair, needed to later call `withdraw(withdrawId)`.
   withdrawId?: number;
 };
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Add unbounding for desktop and mobile (WIP) for Monad

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->
<img width="556" height="599" alt="Screenshot 2026-06-04 at 16 39 02" src="https://github.com/user-attachments/assets/63efd20e-1040-46ad-a741-af41db6792b1" />

<img width="931" height="399" alt="Screenshot 2026-06-04 at 16 34 49" src="https://github.com/user-attachments/assets/8ccb6461-8331-4494-8e06-3d30f6c37d7b" />

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-31672
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
