### PR TITLE
[LWDM] refactor(coin-cardano): migrate off deprecated @ledgerhq/live-network/network

### DIFF
--- a/.changeset/lucky-otters-migrate.md
+++ b/.changeset/lucky-otters-migrate.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-cardano": patch
+---
+
+refactor(coin-cardano): migrate off the deprecated `@ledgerhq/live-network/network` import
+
+Replace the deprecated `@ledgerhq/live-network/network` default import with `@ledgerhq/live-network` across coin-cardano. Every call site consumes only the response `.data`, so behavior is preserved. Because the new implementation types `data` as `unknown` (instead of `any`), each call now carries an explicit `network<T>(...)` generic and the `res.data as X` casts were dropped, so response shapes are checked at compile time. `fetchDelegationInfo` now returns `APIDelegation | undefined` to match its real runtime behavior.

--- a/.changeset/twelve-toes-wonder.md
+++ b/.changeset/twelve-toes-wonder.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-cardano": minor
+---
+
+feat: cardano coin module api getStakes

--- a/libs/coin-modules/coin-cardano/.unimportedrc.json
+++ b/libs/coin-modules/coin-cardano/.unimportedrc.json
@@ -21,6 +21,7 @@
     "src/api/getTransactions.ts",
     "src/api/submitTransaction.ts",
     "src/fixtures/accounts.ts",
+    "src/fixtures/delegation.ts",
     "src/fixtures/protocolParams.ts",
     "src/getTransactionStatus.unit.test.ts",
     "src/hw-getAddress.ts",

--- a/libs/coin-modules/coin-cardano/.unimportedrc.json
+++ b/libs/coin-modules/coin-cardano/.unimportedrc.json
@@ -25,6 +25,7 @@
     "src/fixtures/protocolParams.ts",
     "src/getTransactionStatus.unit.test.ts",
     "src/hw-getAddress.ts",
+    "src/logic/signCoinModuleTransaction.ts",
     "src/postSyncPatch.ts",
     "src/serialization.ts",
     "src/signer.ts",

--- a/libs/coin-modules/coin-cardano/src/api/fetchTransactions.test.ts
+++ b/libs/coin-modules/coin-cardano/src/api/fetchTransactions.test.ts
@@ -1,8 +1,8 @@
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
-import network from "@ledgerhq/live-network/network";
+import network from "@ledgerhq/live-network";
 import { getAllTransactionsByKeys } from "./fetchTransactions";
 
-jest.mock("@ledgerhq/live-network/network");
+jest.mock("@ledgerhq/live-network");
 const mockNetwork = jest.mocked(network);
 
 const currency = getCryptoCurrencyById("cardano");

--- a/libs/coin-modules/coin-cardano/src/api/fetchTransactions.ts
+++ b/libs/coin-modules/coin-cardano/src/api/fetchTransactions.ts
@@ -1,4 +1,4 @@
-import network from "@ledgerhq/live-network/network";
+import network from "@ledgerhq/live-network";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { CARDANO_API_ENDPOINT, CARDANO_TESTNET_API_ENDPOINT } from "../constants";
 import { isTestnet } from "../logic";
@@ -17,7 +17,12 @@ async function fetchTransactionsPage(
   blockHeight: number;
   transactions: Array<APITransaction>;
 }> {
-  const res = await network({
+  const res = await network<{
+    pageNo: number;
+    limit?: unknown;
+    blockHeight: number;
+    transactions: Array<APITransaction>;
+  }>({
     method: "POST",
     url: isTestnet(currency)
       ? `${CARDANO_TESTNET_API_ENDPOINT}/v1/transaction`

--- a/libs/coin-modules/coin-cardano/src/api/getDelegationInfo.test.ts
+++ b/libs/coin-modules/coin-cardano/src/api/getDelegationInfo.test.ts
@@ -1,0 +1,71 @@
+import network from "@ledgerhq/live-network";
+import BigNumber from "bignumber.js";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { isTestnet } from "../logic";
+import { getDelegationInfo } from "./getDelegationInfo";
+
+jest.mock("@ledgerhq/live-network");
+jest.mock("../logic", () => ({ isTestnet: jest.fn() }));
+
+const mockNetwork = jest.mocked(network);
+const mockIsTestnet = jest.mocked(isTestnet);
+
+// isTestnet is mocked, so the concrete currency value is irrelevant to routing.
+const currency = { id: "cardano" } as CryptoCurrency;
+const stakeKey = "stake1abc";
+
+const apiDelegation = {
+  deposit: "2000000",
+  stakeHex: "deadbeef",
+  status: true,
+  stake: "1000000",
+  rewardsAvailable: "500000",
+  rewardsWithdrawn: "0",
+  poolInfo: { poolId: "pool1xyz", name: "Ledger by Figment", ticker: "LBF" },
+  dRepInfo: { hex: "drep1hex" },
+};
+
+describe("getDelegationInfo", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("GETs the mainnet delegation endpoint with the stake key and maps the payload", async () => {
+    mockIsTestnet.mockReturnValue(false);
+    mockNetwork.mockResolvedValue({ data: { delegation: apiDelegation } } as never);
+
+    const result = await getDelegationInfo(currency, stakeKey);
+
+    expect(result).toEqual({
+      status: true,
+      deposit: "2000000",
+      poolId: "pool1xyz",
+      dRepHex: "drep1hex",
+      ticker: "LBF",
+      name: "Ledger by Figment",
+      rewards: new BigNumber("500000"),
+    });
+    const call = mockNetwork.mock.calls[0][0];
+    expect(call.method).toBe("GET");
+    expect(call.url).toContain("cardano.coin.ledger.com");
+    expect(call.url).toMatch(/\/v1\/delegation$/);
+    expect(call.params).toEqual({ stakeKey });
+  });
+
+  it("returns undefined when the response carries no delegation", async () => {
+    mockIsTestnet.mockReturnValue(false);
+    mockNetwork.mockResolvedValue({ data: {} } as never);
+
+    await expect(getDelegationInfo(currency, stakeKey)).resolves.toBeUndefined();
+  });
+
+  it("routes to the testnet endpoint for a testnet currency", async () => {
+    mockIsTestnet.mockReturnValue(true);
+    mockNetwork.mockResolvedValue({ data: { delegation: apiDelegation } } as never);
+
+    await getDelegationInfo(currency, stakeKey);
+
+    expect(mockIsTestnet).toHaveBeenCalledWith(currency);
+    expect(mockNetwork.mock.calls[0][0].url).toContain("cardanoscan");
+  });
+});

--- a/libs/coin-modules/coin-cardano/src/api/getDelegationInfo.ts
+++ b/libs/coin-modules/coin-cardano/src/api/getDelegationInfo.ts
@@ -1,4 +1,4 @@
-import network from "@ledgerhq/live-network/network";
+import network from "@ledgerhq/live-network";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import BigNumber from "bignumber.js";
 import { CARDANO_API_ENDPOINT, CARDANO_TESTNET_API_ENDPOINT } from "../constants";
@@ -9,8 +9,8 @@ import { APIDelegation } from "./api-types";
 async function fetchDelegationInfo(
   currency: CryptoCurrency,
   stakeKey: string,
-): Promise<APIDelegation> {
-  const res = await network({
+): Promise<APIDelegation | undefined> {
+  const res = await network<{ delegation?: APIDelegation }>({
     method: "GET",
     url: isTestnet(currency)
       ? `${CARDANO_TESTNET_API_ENDPOINT}/v1/delegation`
@@ -19,7 +19,7 @@ async function fetchDelegationInfo(
       stakeKey,
     },
   });
-  return res && res.data && (res.data.delegation as APIDelegation);
+  return res.data?.delegation;
 }
 
 export async function getDelegationInfo(

--- a/libs/coin-modules/coin-cardano/src/api/getEpochInfo.test.ts
+++ b/libs/coin-modules/coin-cardano/src/api/getEpochInfo.test.ts
@@ -1,0 +1,60 @@
+import network from "@ledgerhq/live-network";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { isTestnet } from "../logic";
+import { fetchEpochInfo } from "./getEpochInfo";
+
+jest.mock("@ledgerhq/live-network");
+jest.mock("../logic", () => ({ isTestnet: jest.fn() }));
+
+const mockNetwork = jest.mocked(network);
+const mockIsTestnet = jest.mocked(isTestnet);
+
+// isTestnet is mocked, so the concrete currency value is irrelevant to routing.
+const currency = { id: "cardano" } as CryptoCurrency;
+
+const protocolParams = { a0: 0.3, rho: 0.003, tau: 0.2 };
+const currentEpoch = {
+  number: 500,
+  reserves: "13000000000000",
+  activeStake: "23000000000000",
+  protocolParams,
+};
+
+describe("fetchEpochInfo", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("GETs the epoch-params endpoint and maps the current epoch", async () => {
+    mockIsTestnet.mockReturnValue(false);
+    mockNetwork.mockResolvedValue({ data: { cardano: [{ currentEpoch }] } } as never);
+
+    const result = await fetchEpochInfo(currency);
+
+    expect(result).toEqual({
+      number: 500,
+      reserves: "13000000000000",
+      activeStake: "23000000000000",
+      params: protocolParams,
+    });
+    expect(mockNetwork.mock.calls[0][0].method).toBe("GET");
+  });
+
+  it("throws when the response shape is unexpected", async () => {
+    mockIsTestnet.mockReturnValue(false);
+    mockNetwork.mockResolvedValue({ data: {} } as never);
+
+    await expect(fetchEpochInfo(currency)).rejects.toThrow(
+      "Cardano epoch params: unexpected response shape",
+    );
+  });
+
+  it("routes to the testnet endpoint for a testnet currency", async () => {
+    mockIsTestnet.mockReturnValue(true);
+    mockNetwork.mockResolvedValue({ data: { cardano: [{ currentEpoch }] } } as never);
+
+    await fetchEpochInfo(currency);
+
+    expect(mockIsTestnet).toHaveBeenCalledWith(currency);
+  });
+});

--- a/libs/coin-modules/coin-cardano/src/api/getEpochInfo.ts
+++ b/libs/coin-modules/coin-cardano/src/api/getEpochInfo.ts
@@ -1,4 +1,4 @@
-import network from "@ledgerhq/live-network/network";
+import network from "@ledgerhq/live-network";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { CARDANO_EPOCH_PARAMS_ENDPOINT, CARDANO_TESTNET_EPOCH_PARAMS_ENDPOINT } from "../constants";
 import { isTestnet } from "../logic";

--- a/libs/coin-modules/coin-cardano/src/api/getLatestBlock.test.ts
+++ b/libs/coin-modules/coin-cardano/src/api/getLatestBlock.test.ts
@@ -1,9 +1,9 @@
-import network from "@ledgerhq/live-network/network";
+import network from "@ledgerhq/live-network";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { isTestnet } from "../logic";
 import { fetchLatestBlock } from "./getLatestBlock";
 
-jest.mock("@ledgerhq/live-network/network");
+jest.mock("@ledgerhq/live-network");
 jest.mock("../logic", () => ({ isTestnet: jest.fn() }));
 
 const mockNetwork = jest.mocked(network);

--- a/libs/coin-modules/coin-cardano/src/api/getLatestBlock.ts
+++ b/libs/coin-modules/coin-cardano/src/api/getLatestBlock.ts
@@ -1,15 +1,15 @@
-import network from "@ledgerhq/live-network/network";
+import network from "@ledgerhq/live-network";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { CARDANO_API_ENDPOINT, CARDANO_TESTNET_API_ENDPOINT } from "../constants";
 import { isTestnet } from "../logic";
 import { APILatestBlock } from "./api-types";
 
 export async function fetchLatestBlock(currency: CryptoCurrency): Promise<APILatestBlock> {
-  const res = await network({
+  const res = await network<APILatestBlock>({
     method: "GET",
     url: isTestnet(currency)
       ? `${CARDANO_TESTNET_API_ENDPOINT}/v1/block/latest`
       : `${CARDANO_API_ENDPOINT}/v1/block/latest`,
   });
-  return res && (res.data as APILatestBlock);
+  return res.data;
 }

--- a/libs/coin-modules/coin-cardano/src/api/getNetworkInfo.ts
+++ b/libs/coin-modules/coin-cardano/src/api/getNetworkInfo.ts
@@ -1,15 +1,15 @@
-import network from "@ledgerhq/live-network/network";
+import network from "@ledgerhq/live-network";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { CARDANO_API_ENDPOINT, CARDANO_TESTNET_API_ENDPOINT } from "../constants";
 import { isTestnet } from "../logic";
 import { APINetworkInfo } from "./api-types";
 
 export async function fetchNetworkInfo(currency: CryptoCurrency): Promise<APINetworkInfo> {
-  const res = await network({
+  const res = await network<APINetworkInfo>({
     method: "GET",
     url: isTestnet(currency)
       ? `${CARDANO_TESTNET_API_ENDPOINT}/v1/network/info`
       : `${CARDANO_API_ENDPOINT}/v1/network/info`,
   });
-  return res && (res.data as APINetworkInfo);
+  return res.data;
 }

--- a/libs/coin-modules/coin-cardano/src/api/getPools.test.ts
+++ b/libs/coin-modules/coin-cardano/src/api/getPools.test.ts
@@ -1,8 +1,8 @@
-import network from "@ledgerhq/live-network/network";
+import network from "@ledgerhq/live-network";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { fetchPoolDetails } from "./getPools";
 
-jest.mock("@ledgerhq/live-network/network");
+jest.mock("@ledgerhq/live-network");
 
 const poolIds = ["pool1", "pool2", "pool3"];
 const currency = {

--- a/libs/coin-modules/coin-cardano/src/api/getPools.ts
+++ b/libs/coin-modules/coin-cardano/src/api/getPools.ts
@@ -1,4 +1,4 @@
-import network from "@ledgerhq/live-network/network";
+import network from "@ledgerhq/live-network";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import BigNumber from "bignumber.js";
 import { CARDANO_API_ENDPOINT, CARDANO_TESTNET_API_ENDPOINT } from "../constants";
@@ -11,14 +11,14 @@ export async function fetchPoolList(
   pageNo: number,
   limit: number,
 ): Promise<APIGetPoolList> {
-  const res = await network({
+  const res = await network<APIGetPoolList>({
     method: "GET",
     url: isTestnet(currency)
       ? `${CARDANO_TESTNET_API_ENDPOINT}/v1/pool/list`
       : `${CARDANO_API_ENDPOINT}/v1/pool/list`,
     params: { search, pageNo, limit },
   });
-  return res && (res.data as APIGetPoolList);
+  return res.data;
 }
 
 export async function fetchPoolDetails(

--- a/libs/coin-modules/coin-cardano/src/api/getStakes.test.ts
+++ b/libs/coin-modules/coin-cardano/src/api/getStakes.test.ts
@@ -1,12 +1,38 @@
-import { createApi } from ".";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import { type CardanoConfig } from "../config";
+import { getStakes } from "../logic/getStakes";
+import { createApi } from ".";
+
+jest.mock("../logic/getStakes", () => ({
+  getStakes: jest.fn(),
+}));
+
+const mockGetStakes = jest.mocked(getStakes);
 
 const config: CardanoConfig = { maxFeesWarning: 0, maxFeesError: 0 };
+const currency = getCryptoCurrencyById("cardano");
 
-describe("getStakes", () => {
-  it("throws an unsupported error", () => {
+describe("api.getStakes", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("delegates to the getStakes logic with the resolved currency, address and cursor", async () => {
+    const page = { items: [] };
+    mockGetStakes.mockResolvedValue(page);
     const api = createApi(config, "cardano");
 
-    expect(() => api.getStakes("address")).toThrow("getStakes is not supported");
+    const result = await api.getStakes("addr", "cursor");
+
+    expect(mockGetStakes).toHaveBeenCalledTimes(1);
+    expect(mockGetStakes).toHaveBeenCalledWith(currency, "addr", "cursor");
+    expect(result).toBe(page);
+  });
+
+  it("propagates errors thrown by the getStakes logic", async () => {
+    mockGetStakes.mockRejectedValue(new Error("delegation fetch failed"));
+    const api = createApi(config, "cardano");
+
+    await expect(api.getStakes("addr")).rejects.toThrow("delegation fetch failed");
   });
 });

--- a/libs/coin-modules/coin-cardano/src/api/index.ts
+++ b/libs/coin-modules/coin-cardano/src/api/index.ts
@@ -28,6 +28,7 @@ import { combine } from "../logic/combine";
 import { craftTransaction } from "../logic/craftTransaction";
 import { estimateFees } from "../logic/estimateFees";
 import { getBalance } from "../logic/getBalance";
+import { getStakes } from "../logic/getStakes";
 import { getValidators } from "../logic/getValidators";
 import { lastBlock } from "../logic/lastBlock";
 import { listOperations } from "../logic/listOperations";
@@ -51,9 +52,8 @@ export function createApi(config: CardanoConfig, currencyId: string): CoinModule
       rejectBalanceOptions(() => getBalance(currency, address), options),
     listOperations: (address: string, options: ListOperationsOptions): Promise<Page<Operation>> =>
       listOperations(currency, address, options),
-    getStakes: (_address: string, _cursor?: Cursor): Promise<Page<Stake>> => {
-      throw new Error("getStakes is not supported");
-    },
+    getStakes: (address: string, cursor?: Cursor): Promise<Page<Stake>> =>
+      getStakes(currency, address, cursor),
     getRewards: (_address: string, _cursor?: Cursor): Promise<Page<Reward>> => {
       throw new Error("getRewards is not supported");
     },

--- a/libs/coin-modules/coin-cardano/src/api/submitTransaction.test.ts
+++ b/libs/coin-modules/coin-cardano/src/api/submitTransaction.test.ts
@@ -1,0 +1,43 @@
+import network from "@ledgerhq/live-network";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { isTestnet } from "../logic";
+import { submitTransaction } from "./submitTransaction";
+
+jest.mock("@ledgerhq/live-network");
+jest.mock("../logic", () => ({ isTestnet: jest.fn() }));
+
+const mockNetwork = jest.mocked(network);
+const mockIsTestnet = jest.mocked(isTestnet);
+
+// isTestnet is mocked, so the concrete currency value is irrelevant to routing.
+const currency = { id: "cardano" } as CryptoCurrency;
+
+describe("submitTransaction", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("POSTs the raw transaction to the mainnet submit endpoint and returns the hash", async () => {
+    mockIsTestnet.mockReturnValue(false);
+    mockNetwork.mockResolvedValue({ data: { transaction: { hash: "abc123" } } } as never);
+
+    const result = await submitTransaction({ transaction: "deadbeef", currency });
+
+    expect(result).toEqual({ hash: "abc123" });
+    const call = mockNetwork.mock.calls[0][0];
+    expect(call.method).toBe("POST");
+    expect(call.url).toContain("cardano.coin.ledger.com");
+    expect(call.url).toMatch(/\/v1\/transaction\/submit$/);
+    expect(call.data).toEqual({ transaction: "deadbeef" });
+  });
+
+  it("routes to the testnet endpoint for a testnet currency", async () => {
+    mockIsTestnet.mockReturnValue(true);
+    mockNetwork.mockResolvedValue({ data: { transaction: { hash: "h" } } } as never);
+
+    await submitTransaction({ transaction: "deadbeef", currency });
+
+    expect(mockIsTestnet).toHaveBeenCalledWith(currency);
+    expect(mockNetwork.mock.calls[0][0].url).toContain("cardanoscan");
+  });
+});

--- a/libs/coin-modules/coin-cardano/src/api/submitTransaction.ts
+++ b/libs/coin-modules/coin-cardano/src/api/submitTransaction.ts
@@ -1,4 +1,4 @@
-import network from "@ledgerhq/live-network/network";
+import network from "@ledgerhq/live-network";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { CARDANO_API_ENDPOINT, CARDANO_TESTNET_API_ENDPOINT } from "../constants";
 import { isTestnet } from "../logic";
@@ -10,7 +10,7 @@ export async function submitTransaction({
   transaction: string;
   currency: CryptoCurrency;
 }): Promise<{ hash: string }> {
-  const res = await network({
+  const res = await network<{ transaction: { hash: string } }>({
     method: "POST",
     url: isTestnet(currency)
       ? `${CARDANO_TESTNET_API_ENDPOINT}/v1/transaction/submit`

--- a/libs/coin-modules/coin-cardano/src/fixtures/delegation.ts
+++ b/libs/coin-modules/coin-cardano/src/fixtures/delegation.ts
@@ -1,0 +1,19 @@
+import BigNumber from "bignumber.js";
+import type { CardanoDelegation } from "../types";
+
+// A mainnet base address — carries a stake credential, so staking flows apply.
+export const STAKING_ADDRESS =
+  "addr1q8mgw8geggkl2hs0m6rq3pgt69uxttpqcgu6euxje5tt6plxjtjrnskhhtt03g6l3sr98p9t8mtlajr26vmwjzep77pqxn8cms";
+
+export function getDelegationFixture(over: Partial<CardanoDelegation> = {}): CardanoDelegation {
+  return {
+    status: true,
+    deposit: "2000000",
+    poolId: "pool1xyz",
+    ticker: "TICK",
+    name: "Pool",
+    dRepHex: undefined,
+    rewards: new BigNumber(0),
+    ...over,
+  };
+}

--- a/libs/coin-modules/coin-cardano/src/logic.ts
+++ b/libs/coin-modules/coin-cardano/src/logic.ts
@@ -102,6 +102,11 @@ export function getBipPathString({
   return `${CARDANO_PURPOSE}'/${CARDANO_COIN_TYPE}'/${account}'/${chain}/${index}`;
 }
 
+/** Account-level derivation path (`purpose'/coin'/account'`) — the path the device's getPublicKey expects. */
+export function getAccountPathString(account: number): string {
+  return `${CARDANO_PURPOSE}'/${CARDANO_COIN_TYPE}'/${account}'`;
+}
+
 export function getExtendedPublicKeyFromHex(keyHex: string): Bip32PublicKey {
   return Bip32PublicKey.fromBytes(Buffer.from(keyHex, "hex"));
 }

--- a/libs/coin-modules/coin-cardano/src/logic/assembleWitnesses.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/assembleWitnesses.ts
@@ -1,0 +1,31 @@
+import { Bip32PublicKey } from "@stricahq/bip32ed25519";
+import { Transaction as TyphonTransaction, types as TyphonTypes } from "@stricahq/typhonjs";
+import type { Witness } from "../signer";
+
+/**
+ * Attach the device's witnesses to an unsigned Typhon transaction and build it.
+ *
+ * The Cardano device returns one witness per signing path — payment input path(s) plus the stake
+ * path for a delegation/withdrawal (a staking tx needs both the payment-key and stake-key witnesses,
+ * per the cardano-ledger UTXOW rule). Each witness carries only the signature; the public key is
+ * derived from the account extended key by the path's chain/index to form the vkey witness. Shared by
+ * the legacy bridge and the CoinModule (Alpaca) signing path (the eventual witness-array-aware
+ * framework signer can lift this unchanged).
+ */
+export function assembleWitnesses(
+  unsignedTransaction: TyphonTransaction,
+  accountKey: Bip32PublicKey,
+  witnesses: Array<Witness>,
+): ReturnType<TyphonTransaction["buildTransaction"]> {
+  witnesses.forEach(witness => {
+    const [, , , chainType, index] = witness.path;
+    const publicKey = accountKey.derive(chainType).derive(index).toPublicKey().toBytes();
+    const vKeyWitness: TyphonTypes.VKeyWitness = {
+      signature: Buffer.from(witness.witnessSignatureHex, "hex"),
+      publicKey: Buffer.from(publicKey),
+    };
+    unsignedTransaction.addWitness(vKeyWitness);
+  });
+
+  return unsignedTransaction.buildTransaction();
+}

--- a/libs/coin-modules/coin-cardano/src/logic/assembleWitnesses.unit.test.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/assembleWitnesses.unit.test.ts
@@ -1,0 +1,49 @@
+import type { Witness } from "../signer";
+import { assembleWitnesses } from "./assembleWitnesses";
+
+// Fake account key whose derived pubkey bytes encode the [chain, index] it was derived by, so the
+// test can assert each witness was matched to the right derivation path.
+const fakeAccountKey = {
+  derive: (chain: number) => ({
+    derive: (index: number) => ({
+      toPublicKey: () => ({ toBytes: () => Buffer.from([chain, index]) }),
+    }),
+  }),
+} as never;
+
+describe("assembleWitnesses", () => {
+  it("adds a vkey witness per device witness, pubkey derived by the path's chain/index (payment + stake)", () => {
+    const built = { hash: "txhash", payload: "signedpayload" };
+    const addWitness = jest.fn();
+    const unsignedTransaction = { addWitness, buildTransaction: jest.fn(() => built) } as never;
+
+    const witnesses: Witness[] = [
+      { path: [1852, 1815, 0, 0, 0], witnessSignatureHex: "aa" }, // payment (chain 0)
+      { path: [1852, 1815, 0, 2, 0], witnessSignatureHex: "bb" }, // stake   (chain 2)
+    ];
+
+    const result = assembleWitnesses(unsignedTransaction, fakeAccountKey, witnesses);
+
+    expect(addWitness).toHaveBeenCalledTimes(2);
+    expect(addWitness).toHaveBeenNthCalledWith(1, {
+      signature: Buffer.from("aa", "hex"),
+      publicKey: Buffer.from([0, 0]), // chain 0, index 0
+    });
+    expect(addWitness).toHaveBeenNthCalledWith(2, {
+      signature: Buffer.from("bb", "hex"),
+      publicKey: Buffer.from([2, 0]), // chain 2, index 0
+    });
+    expect(result).toBe(built);
+  });
+
+  it("adds a single witness for a plain send (payment only)", () => {
+    const addWitness = jest.fn();
+    const unsignedTransaction = { addWitness, buildTransaction: jest.fn(() => ({})) } as never;
+
+    assembleWitnesses(unsignedTransaction, fakeAccountKey, [
+      { path: [1852, 1815, 0, 0, 0], witnessSignatureHex: "aa" },
+    ]);
+
+    expect(addWitness).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/coin-modules/coin-cardano/src/logic/craftTransaction.test.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/craftTransaction.test.ts
@@ -11,8 +11,13 @@ import { getAllTransactionsByKeys } from "../api/fetchTransactions";
 import { getDelegationInfo } from "../api/getDelegationInfo";
 import { fetchNetworkInfo } from "../api/getNetworkInfo";
 import { getProtocolParamsFixture } from "../fixtures/protocolParams";
+import typhonSerializer from "../typhonSerializer";
 import { extractPaymentKeyFromAddress } from "../utils";
-import { buildUnsignedTransaction, craftTransaction } from "./craftTransaction";
+import {
+  buildUnsignedTransaction,
+  buildUnsignedTransactionForSigning,
+  craftTransaction,
+} from "./craftTransaction";
 
 jest.mock("../api/fetchTransactions");
 jest.mock("../api/getDelegationInfo");
@@ -407,5 +412,41 @@ describe("buildUnsignedTransaction — custom fees", () => {
     await expect(
       buildUnsignedTransaction(currency, sendIntent(), { value: 9_999_000_000n }),
     ).rejects.toThrow("Custom fee too high");
+  });
+});
+
+describe("buildUnsignedTransactionForSigning — device signing paths", () => {
+  const SIGNING_PATH = "1852'/1815'/0'/0/0";
+
+  it("attaches payment + stake bip paths so the serializer emits both witnesses for a delegation", async () => {
+    mockGetDelegation.mockResolvedValue(registeredDelegation()); // status: true → STAKE_DELEGATION only
+
+    const tx = await buildUnsignedTransactionForSigning(currency, stakeIntent(), SIGNING_PATH);
+    const signerTx = typhonSerializer(tx, 0);
+
+    // Payment witness path on the spent input.
+    expect(signerTx.inputs[0].path).toBe("1852'/1815'/0'/0/0");
+    // Stake witness path on the delegation certificate (fixed CIP-1852 …'/2/0).
+    const delegation = signerTx.certificates.find(c => c.type === "DELEGATION") as
+      | { params: { stakeCredential: { keyPath: string } } }
+      | undefined;
+    expect(delegation?.params.stakeCredential.keyPath).toBe("1852'/1815'/0'/2/0");
+  });
+
+  it("produces an identical tx body/fee to the path-less craft (paths are signing-only metadata)", async () => {
+    mockGetDelegation.mockResolvedValue(registeredDelegation());
+
+    const signed = await buildUnsignedTransactionForSigning(currency, stakeIntent(), SIGNING_PATH);
+    const plain = await buildUnsignedTransaction(currency, stakeIntent());
+
+    expect(signed.buildTransaction().payload).toBe(plain.buildTransaction().payload);
+    expect(signed.getFee().toFixed()).toBe(plain.getFee().toFixed());
+  });
+
+  it("without the signing paths the device serializer cannot emit the stake witness", async () => {
+    mockGetDelegation.mockResolvedValue(registeredDelegation());
+
+    const tx = await buildUnsignedTransaction(currency, stakeIntent()); // no signing paths
+    expect(() => typhonSerializer(tx, 0)).toThrow("Invalid stakeKey type");
   });
 });

--- a/libs/coin-modules/coin-cardano/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/craftTransaction.ts
@@ -17,9 +17,17 @@ import BigNumber from "bignumber.js";
 import { getAllTransactionsByKeys } from "../api/fetchTransactions";
 import { getDelegationInfo } from "../api/getDelegationInfo";
 import { fetchNetworkInfo } from "../api/getNetworkInfo";
-import { CARDANO_MAX_SUPPLY, MEMO_LABEL } from "../constants";
-import { type DerivedUtxo, deriveUtxos, getTTL, isTestnet, mergeTokens } from "../logic";
-import { CardanoDelegation, ProtocolParams } from "../types";
+import { CARDANO_MAX_SUPPLY, MEMO_LABEL, STAKING_ADDRESS_INDEX } from "../constants";
+import {
+  type DerivedUtxo,
+  deriveUtxos,
+  getBipPath,
+  getBipPathFromString,
+  getTTL,
+  isTestnet,
+  mergeTokens,
+} from "../logic";
+import { CardanoDelegation, ProtocolParams, StakeChain } from "../types";
 import {
   EMPTY_CREDENTIAL_KEY,
   extractPaymentKeyFromAddress,
@@ -84,10 +92,16 @@ function parseTokenAssetReference(asset: AssetInfo): { policyId: string; assetNa
   return { policyId, assetName };
 }
 
-function stakeHashCredential(stakeKey: string): TyphonTypes.HashCredential {
+function stakeHashCredential(
+  stakeKey: string,
+  bipPath?: TyphonTypes.BipPath,
+): TyphonTypes.HashCredential {
   return {
     hash: Buffer.from(stakeKey, "hex"),
     type: TyphonTypes.HashType.ADDRESS,
+    // bipPath is signing metadata only (not part of the tx body / hash); set it so the device-signing
+    // serializer can produce the stake-key witness for certs/withdrawals. Omitted for craft/preview.
+    ...(bipPath ? { bipPath } : {}),
   };
 }
 
@@ -102,11 +116,12 @@ function addAccountObligations(
   currency: CryptoCurrency,
   stakeKey: string,
   delegation: CardanoDelegation,
+  stakeBipPath?: TyphonTypes.BipPath,
 ): void {
   const rewards = delegation.rewards ?? new BigNumber(0);
   if (rewards.lte(0)) return;
 
-  const stakeCredential = stakeHashCredential(stakeKey);
+  const stakeCredential = stakeHashCredential(stakeKey, stakeBipPath);
   const networkId = isTestnet(currency)
     ? TyphonTypes.NetworkId.TESTNET
     : TyphonTypes.NetworkId.MAINNET;
@@ -131,8 +146,9 @@ function addStakingCertificates(
   protocolParams: ProtocolParams,
   stakeKey: string,
   delegation: CardanoDelegation | undefined,
+  stakeBipPath?: TyphonTypes.BipPath,
 ): void {
-  const stakeCredential = stakeHashCredential(stakeKey);
+  const stakeCredential = stakeHashCredential(stakeKey, stakeBipPath);
 
   if (intent.mode === "delegate") {
     if (!intent.valAddress) throw new Error("Missing pool id for delegation");
@@ -286,16 +302,86 @@ function applyCustomFee(
   typhonTx.setFee(customFee);
 }
 
+/** Account BIP paths attached to credentials for device signing (see buildUnsignedTransactionForSigning). */
+type SigningBipPaths = { payment: TyphonTypes.BipPath; stake: TyphonTypes.BipPath };
+
+/** Attach a string memo (if present) as transaction metadata. */
+function applyMemo(typhonTx: TyphonTransaction, intent: TransactionIntent<StringMemo>): void {
+  const memo = "memo" in intent && intent.memo?.type === "string" ? intent.memo.value : undefined;
+  if (memo) {
+    typhonTx.setAuxiliaryData({
+      metadata: [{ label: MEMO_LABEL, data: new Map([["msg", [memo]]]) }],
+    });
+  }
+}
+
+/**
+ * Attach the account's BIP paths to the sender credentials so the device recognises them as
+ * device-owned: payment path → inputs and change output (payment witness); stake path → the
+ * base address's stake credential (stake witness for certs/withdrawals). Signing metadata only.
+ */
+function applySigningPaths(
+  senderAddress: TyphonTypes.ShelleyAddress,
+  signing: SigningBipPaths,
+): void {
+  if (senderAddress.paymentCredential.type === TyphonTypes.HashType.ADDRESS) {
+    senderAddress.paymentCredential.bipPath = signing.payment;
+  }
+  if (
+    senderAddress instanceof TyphonAddress.BaseAddress &&
+    senderAddress.stakeCredential.type === TyphonTypes.HashType.ADDRESS
+  ) {
+    senderAddress.stakeCredential.bipPath = signing.stake;
+  }
+}
+
+/**
+ * Dispatch outputs/certificates by intent type and return the change address: staking adds the
+ * delegation/undelegation certificates (change → sender); a native send adds the recipient output
+ * (change → sender, or recipient for a send-all); a token send adds the token output (change → sender).
+ */
+function addOutputsAndCertificates(
+  typhonTx: TyphonTransaction,
+  intent: TransactionIntent<StringMemo>,
+  senderAddress: TyphonTypes.ShelleyAddress,
+  inputs: TyphonTypes.Input[],
+  protocolParams: ProtocolParams,
+  stakeKey: string | undefined,
+  delegation: CardanoDelegation | undefined,
+  signing?: SigningBipPaths,
+): TyphonTypes.CardanoAddress {
+  if (intent.intentType === "staking") {
+    if (!stakeKey) throw new Error("Sender address has no stake credential");
+    addStakingCertificates(
+      typhonTx,
+      intent as StakingTransactionIntent<StringMemo>,
+      protocolParams,
+      stakeKey,
+      delegation,
+      signing?.stake,
+    );
+    return senderAddress;
+  }
+  if (intent.asset.type === "native") {
+    return addNativeOutputs(typhonTx, intent, senderAddress, inputs, protocolParams);
+  }
+  addTokenOutput(typhonTx, intent, inputs, protocolParams);
+  return senderAddress;
+}
+
 /**
  * Build the unsigned Typhon transaction for a CoinModule intent (native ADA, token, or
  * staking delegate/undelegate). Inputs are the sender address's UTXOs and change returns to
- * the sender. Per-input BIP paths required by the device are signing metadata added
- * downstream, not part of this body — so no xpub/account sync is needed here.
+ * the sender. When `signing` is provided, the account's BIP paths are attached to the credentials
+ * (payment on the sender address → inputs + change, stake on certs/withdrawals) so the device can
+ * witness the tx; these paths are signing metadata only — they do not affect the body/hash, so the
+ * crafted body and fee are identical with or without them.
  */
 export async function buildUnsignedTransaction(
   currency: CryptoCurrency,
   intent: TransactionIntent<StringMemo>,
   customFees?: FeeEstimation,
+  signing?: SigningBipPaths,
 ): Promise<TyphonTransaction> {
   const paymentKey = extractPaymentKeyFromAddress(intent.sender);
   if (paymentKey === EMPTY_CREDENTIAL_KEY) {
@@ -317,16 +403,12 @@ export async function buildUnsignedTransaction(
   });
   typhonTx.setTTL(getTTL(currency.id));
 
-  const memo = "memo" in intent && intent.memo?.type === "string" ? intent.memo.value : undefined;
-  if (memo) {
-    typhonTx.setAuxiliaryData({
-      metadata: [{ label: MEMO_LABEL, data: new Map([["msg", [memo]]]) }],
-    });
-  }
+  applyMemo(typhonTx, intent);
 
   const senderAddress = TyphonUtils.getAddressFromString(
     intent.sender,
   ) as TyphonTypes.ShelleyAddress;
+  if (signing) applySigningPaths(senderAddress, signing);
   // Derived from confirmed history only — with just an address (no pending-operation state) two
   // craft calls before the first broadcast confirms may select the same UTXO. Same single-address
   // constraint as getBalance/listOperations.
@@ -338,27 +420,21 @@ export async function buildUnsignedTransaction(
   // Account-level reward/vote obligations (Conway) plus, for staking, the certificates;
   // both require the stake credential carried by the sender address.
   if (stakeKey && delegation) {
-    addAccountObligations(typhonTx, currency, stakeKey, delegation);
+    addAccountObligations(typhonTx, currency, stakeKey, delegation, signing?.stake);
   }
 
   // changeAddress is the sender for sends/staking; for a send-all it is the recipient, so the
   // entire balance (minus fee) lands there with no explicit recipient output.
-  let changeAddress: TyphonTypes.CardanoAddress = senderAddress;
-
-  if (intent.intentType === "staking") {
-    if (!stakeKey) throw new Error("Sender address has no stake credential");
-    addStakingCertificates(
-      typhonTx,
-      intent as StakingTransactionIntent<StringMemo>,
-      protocolParams,
-      stakeKey,
-      delegation,
-    );
-  } else if (intent.asset.type === "native") {
-    changeAddress = addNativeOutputs(typhonTx, intent, senderAddress, inputs, protocolParams);
-  } else {
-    addTokenOutput(typhonTx, intent, inputs, protocolParams);
-  }
+  const changeAddress = addOutputsAndCertificates(
+    typhonTx,
+    intent,
+    senderAddress,
+    inputs,
+    protocolParams,
+    stakeKey,
+    delegation,
+    signing,
+  );
 
   // Spend the largest UTXOs first so Typhon's coin selection covers the outputs with the fewest
   // inputs (smaller tx, lower fee) — mirrors the legacy builder's largest-first ordering.
@@ -386,6 +462,29 @@ export async function buildUnsignedTransaction(
   }
 
   return prepared;
+}
+
+/**
+ * Build the unsigned tx for the device-signing flow: identical body/fee to the public
+ * craftTransaction, but with the account's BIP paths attached to credentials so the device emits
+ * every required witness (payment for inputs/change + stake for certs/withdrawals). `derivationPath`
+ * is the account's single address path (CIP-1852); the stake path is that account's fixed `…'/2/0`.
+ * A staking/withdrawal tx needs both the payment-key and stake-key witnesses (cardano-ledger UTXOW
+ * rule), so both paths must be attached for the device to produce every required witness.
+ */
+export async function buildUnsignedTransactionForSigning(
+  currency: CryptoCurrency,
+  intent: TransactionIntent<StringMemo>,
+  derivationPath: string,
+  customFees?: FeeEstimation,
+): Promise<TyphonTransaction> {
+  const payment = getBipPathFromString(derivationPath);
+  const stake = getBipPath({
+    account: payment.account,
+    chain: StakeChain.stake,
+    index: STAKING_ADDRESS_INDEX,
+  });
+  return buildUnsignedTransaction(currency, intent, customFees, { payment, stake });
 }
 
 /**

--- a/libs/coin-modules/coin-cardano/src/logic/getBalance.test.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/getBalance.test.ts
@@ -148,14 +148,15 @@ describe("getBalance", () => {
         amount: 3500000n,
         amountDeposited: 2000000n,
         amountRewarded: 1500000n,
-        // No dRep -> rewards can't be withdrawn yet, so no claim_reward action.
-        actions: [],
+        // Delegated (poolId set): delegate (change pool) + undelegate (deregister). No claim_reward —
+        // Cardano stakes never expose a standalone claim action (shared with getStakes).
+        actions: ["delegate", "undelegate"],
         details: { ticker: "LDG", name: "Ledger" },
       },
     });
   });
 
-  it("advertises claim_reward and unlocks rewards once delegated to a dRep", async () => {
+  it("unlocks rewards once delegated to a dRep", async () => {
     mockFetchTxs.mockResolvedValue(
       paged([makeTx({ hash: "a", outputs: [output(PAYMENT_KEY, "5000000")] })]),
     );
@@ -173,7 +174,8 @@ describe("getBalance", () => {
     const stakeBalance = balances.find(b => b.stake !== undefined);
 
     expect(balances[0].locked).toBe(0n); // rewards spendable when delegated to a dRep
-    expect(stakeBalance?.stake?.actions).toEqual(["claim_reward"]);
+    // dRep doesn't add a claim action — Cardano rewards are withdrawn implicitly within a tx.
+    expect(stakeBalance?.stake?.actions).toEqual(["delegate", "undelegate"]);
     expect(stakeBalance?.stake?.details).toMatchObject({ dRepHex: "drep1abc" });
   });
 

--- a/libs/coin-modules/coin-cardano/src/logic/getBalance.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/getBalance.ts
@@ -1,10 +1,4 @@
-import type {
-  AssetInfo,
-  Balance,
-  Stake,
-  StakeAction,
-  StakeState,
-} from "@ledgerhq/coin-module-framework/api/index";
+import type { Balance } from "@ledgerhq/coin-module-framework/api/index";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { types as TyphonTypes } from "@stricahq/typhonjs";
 import BigNumber from "bignumber.js";
@@ -13,15 +7,13 @@ import { getAllTransactionsByKeys } from "../api/fetchTransactions";
 import { getDelegationInfo } from "../api/getDelegationInfo";
 import { fetchNetworkInfo } from "../api/getNetworkInfo";
 import { calculateMinAdaForTokens, computeAdaBalance, deriveUtxos, mergeTokens } from "../logic";
-import { CardanoDelegation } from "../types";
 import {
   EMPTY_CREDENTIAL_KEY,
   extractPaymentKeyFromAddress,
   extractStakeKeyFromAddress,
   isByronAddress,
 } from "../utils";
-
-const NATIVE_ASSET: AssetInfo = { type: "native", name: "ADA" };
+import { NATIVE_ASSET, buildStake } from "./stake";
 
 async function computeMinAdaForTokens(
   currency: CryptoCurrency,
@@ -30,50 +22,6 @@ async function computeMinAdaForTokens(
 ): Promise<BigNumber> {
   const { protocolParams } = await fetchNetworkInfo(currency);
   return calculateMinAdaForTokens(address, tokens, protocolParams.utxoCostPerByte);
-}
-
-/**
- * Map a Cardano delegation to a framework {@link Stake}. Cardano delegation locks no
- * principal (the whole balance is delegated implicitly), so the only concrete amounts
- * are the stake-key deposit and the claimable rewards — modelled as amountDeposited /
- * amountRewarded respectively. Returns undefined when there is no staking position.
- */
-function buildStake(
-  address: string,
-  stakeKey: string | undefined,
-  delegation: CardanoDelegation | undefined,
-): Stake | undefined {
-  if (!stakeKey || !delegation) return undefined;
-
-  const rewards = delegation.rewards ?? new BigNumber(0);
-  if (!delegation.status && rewards.lte(0)) return undefined;
-
-  const amountDeposited = BigInt(new BigNumber(delegation.deposit || 0).toFixed(0));
-  const amountRewarded = BigInt(rewards.toFixed(0));
-  const state: StakeState = delegation.status ? "active" : "inactive";
-  // Rewards can only be withdrawn once the account is delegated to a dRep (Conway rule;
-  // the tx builder refuses a withdrawal otherwise). Don't advertise an action that can't
-  // succeed today.
-  const actions: StakeAction[] = amountRewarded > 0n && delegation.dRepHex ? ["claim_reward"] : [];
-
-  const details: Record<string, unknown> = {};
-  if (delegation.ticker) details.ticker = delegation.ticker;
-  if (delegation.name) details.name = delegation.name;
-  if (delegation.dRepHex) details.dRepHex = delegation.dRepHex;
-
-  const stake: Stake = {
-    uid: stakeKey,
-    address,
-    state,
-    asset: NATIVE_ASSET,
-    amount: amountDeposited + amountRewarded,
-    amountDeposited,
-    amountRewarded,
-    actions,
-  };
-  if (delegation.poolId) stake.delegate = delegation.poolId;
-  if (Object.keys(details).length > 0) stake.details = details;
-  return stake;
 }
 
 /**

--- a/libs/coin-modules/coin-cardano/src/logic/getStakes.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/getStakes.ts
@@ -1,0 +1,19 @@
+import type { Cursor, Page, Stake } from "@ledgerhq/coin-module-framework/api/index";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { buildStake, fetchDelegation } from "./stake";
+
+/**
+ * Staking positions of a Cardano address. A delegation is account-level, keyed by the
+ * single stake credential in the address, so there is at most one position and no
+ * pagination. Returns an empty page when the address has no stake credential or no
+ * staking position to report.
+ */
+export async function getStakes(
+  currency: CryptoCurrency,
+  address: string,
+  _cursor?: Cursor,
+): Promise<Page<Stake>> {
+  const { stakeKey, delegation } = await fetchDelegation(currency, address);
+  const stake = buildStake(address, stakeKey, delegation);
+  return { items: stake ? [stake] : [] };
+}

--- a/libs/coin-modules/coin-cardano/src/logic/getStakes.unit.test.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/getStakes.unit.test.ts
@@ -1,0 +1,74 @@
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { address as TyphonAddress, types as TyphonTypes } from "@stricahq/typhonjs";
+import BigNumber from "bignumber.js";
+import { getDelegationInfo } from "../api/getDelegationInfo";
+import { getDelegationFixture, STAKING_ADDRESS } from "../fixtures/delegation";
+import { extractPaymentKeyFromAddress, extractStakeKeyFromAddress } from "../utils";
+import { getStakes } from "./getStakes";
+
+jest.mock("../api/getDelegationInfo");
+
+const mockGetDelegation = jest.mocked(getDelegationInfo);
+
+const currency = getCryptoCurrencyById("cardano");
+// Non-null: STAKING_ADDRESS is a base address, so it always carries a stake credential.
+const STAKE_KEY = extractStakeKeyFromAddress(STAKING_ADDRESS)!;
+// Enterprise (payment-only) address built from STAKING_ADDRESS's payment credential: no stake credential.
+const ENTERPRISE = new TyphonAddress.EnterpriseAddress(TyphonTypes.NetworkId.MAINNET, {
+  hash: Buffer.from(extractPaymentKeyFromAddress(STAKING_ADDRESS), "hex"),
+  type: TyphonTypes.HashType.ADDRESS,
+}).getBech32();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("getStakes", () => {
+  it("returns a single active stake for a delegated address", async () => {
+    mockGetDelegation.mockResolvedValue(getDelegationFixture());
+
+    const { items, next } = await getStakes(currency, STAKING_ADDRESS);
+
+    expect(mockGetDelegation).toHaveBeenCalledWith(currency, STAKE_KEY);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      uid: STAKE_KEY,
+      address: STAKING_ADDRESS,
+      delegate: "pool1xyz",
+      state: "active",
+      amountDeposited: 2_000_000n,
+      amountRewarded: 0n,
+      amount: 2_000_000n,
+      actions: ["delegate", "undelegate"],
+    });
+    expect(next).toBeUndefined();
+  });
+
+  it("surfaces rewards as amountRewarded without advertising a claim action", async () => {
+    mockGetDelegation.mockResolvedValue(
+      getDelegationFixture({ rewards: new BigNumber(5_000_000), dRepHex: "drep1abc" }),
+    );
+
+    const { items } = await getStakes(currency, STAKING_ADDRESS);
+
+    expect(items[0].amountRewarded).toBe(5_000_000n);
+    expect(items[0].actions).not.toContain("claim_reward");
+    expect(items[0].actions).toEqual(["delegate", "undelegate"]);
+  });
+
+  it("returns an empty page when the address has a stake key but no delegation", async () => {
+    mockGetDelegation.mockResolvedValue(undefined);
+
+    const { items } = await getStakes(currency, STAKING_ADDRESS);
+
+    expect(mockGetDelegation).toHaveBeenCalled();
+    expect(items).toEqual([]);
+  });
+
+  it("returns an empty page without querying delegation for an address with no stake credential", async () => {
+    const { items } = await getStakes(currency, ENTERPRISE);
+
+    expect(items).toEqual([]);
+    expect(mockGetDelegation).not.toHaveBeenCalled();
+  });
+});

--- a/libs/coin-modules/coin-cardano/src/logic/listOperations.integ.test.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/listOperations.integ.test.ts
@@ -14,7 +14,7 @@ import { listOperations } from "./listOperations";
  *
  * NOTE: these are `.integ.test.ts` and are excluded from the default `pnpm test`
  * run, so they do not gate correctness in CI. The mapping/pagination logic should
- * also be covered by deterministic unit tests that mock `@ledgerhq/live-network/network`
+ * also be covered by deterministic unit tests that mock `@ledgerhq/live-network`
  * (tracked as a follow-up) — those are what catch a mapping regression on every PR.
  */
 describe("listOperations", () => {

--- a/libs/coin-modules/coin-cardano/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/listOperations.test.ts
@@ -1,11 +1,11 @@
 import type { ListOperationsOptions } from "@ledgerhq/coin-module-framework/api/types";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import { address as TyphonAddress, types as TyphonTypes } from "@stricahq/typhonjs";
-import network from "@ledgerhq/live-network/network";
+import network from "@ledgerhq/live-network";
 import { APITransaction, HashType, TransactionCertificates } from "../api/api-types";
 import { listOperations } from "./listOperations";
 
-jest.mock("@ledgerhq/live-network/network");
+jest.mock("@ledgerhq/live-network");
 
 const mockNetwork = network as jest.Mock;
 

--- a/libs/coin-modules/coin-cardano/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/listOperations.ts
@@ -8,7 +8,7 @@ import {
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { OperationType } from "@ledgerhq/types-live";
 import { log } from "@ledgerhq/logs";
-import network from "@ledgerhq/live-network/network";
+import network from "@ledgerhq/live-network";
 import { BigNumber } from "bignumber.js";
 import { APITransaction, HashType, StakeDelegationCertificate } from "../api/api-types";
 import { fetchNetworkInfo } from "../api/getNetworkInfo";
@@ -363,7 +363,14 @@ async function fetchTransactionsByPaymentKey(
 }> {
   const endpoint = isTestnet(currency) ? CARDANO_TESTNET_API_ENDPOINT : CARDANO_API_ENDPOINT;
 
-  const res = await network({
+  const res = await network<{
+    transactions?: APITransaction[];
+    pageNo?: number;
+    // Backend-dictated and may be missing/non-numeric; typed `unknown` to force the
+    // coercion below, so a bad value can't slip through as a trusted `number`.
+    limit?: unknown;
+    blockHeight?: number;
+  }>({
     method: "POST",
     url: `${endpoint}/v1/transaction`,
     data: {
@@ -376,9 +383,14 @@ async function fetchTransactionsByPaymentKey(
   const {
     transactions = [],
     pageNo: resPageNo = pageNo,
-    limit = 0,
+    limit: rawLimit,
     blockHeight: resBlockHeight = blockHeight,
   } = res.data;
+
+  // A bad value collapses to 0, which the caller reads as "no more pages" — rather than
+  // letting NaN in the `hasMore` check truncate pagination (mirrors getAllTransactionsByKeys).
+  const coercedLimit = Number(rawLimit);
+  const limit = Number.isFinite(coercedLimit) && coercedLimit > 0 ? coercedLimit : 0;
 
   return {
     transactions,

--- a/libs/coin-modules/coin-cardano/src/logic/signCoinModuleTransaction.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/signCoinModuleTransaction.ts
@@ -1,0 +1,76 @@
+import type {
+  FeeEstimation,
+  StringMemo,
+  TransactionIntent,
+} from "@ledgerhq/coin-module-framework/api/index";
+import type { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { getAccountPathString, getBipPathFromString, getExtendedPublicKeyFromHex } from "../logic";
+import { getNetworkParameters } from "../networks";
+import type { CardanoSigner } from "../signer";
+import typhonSerializer from "../typhonSerializer";
+import { assembleWitnesses } from "./assembleWitnesses";
+import { buildUnsignedTransactionForSigning } from "./craftTransaction";
+
+export type SignCoinModuleTransactionParams = {
+  currency: CryptoCurrency;
+  intent: TransactionIntent<StringMemo>;
+  /** The account's address derivation path (single-address model), e.g. `1852'/1815'/0'/0/0`. */
+  derivationPath: string;
+  deviceId: string;
+  signerContext: SignerContext<CardanoSigner>;
+  customFees?: FeeEstimation;
+  /** Invoked once the device is about to display the transaction (before the user-facing sign). */
+  onDeviceSignatureRequested?: () => void;
+};
+
+/**
+ * Sign a CoinModule (Alpaca) Cardano transaction on the Ledger device with ALL required witnesses.
+ *
+ * Cardano staking/withdrawal needs both a payment-key and a stake-key witness (cardano-ledger UTXOW
+ * rule), which the generic single-signature combine cannot express. Here we build the unsigned tx
+ * with the account's BIP paths attached, let the device sign every required path (it returns one
+ * witness per path), fetch the account extended public key, and assemble the full witness set —
+ * mirroring the legacy bridge but driven by a CoinModule intent. Returns the signed CBOR payload.
+ */
+export async function signCoinModuleTransaction({
+  currency,
+  intent,
+  derivationPath,
+  deviceId,
+  signerContext,
+  customFees,
+  onDeviceSignatureRequested,
+}: SignCoinModuleTransactionParams): Promise<{ signature: string } | null> {
+  const accountIndex = getBipPathFromString(derivationPath).account;
+  // The device returns only signatures keyed by path; the account extended pubkey (needed to form
+  // the vkey witnesses) comes from the account path `purpose'/coin'/account'`.
+  const accountPath = getAccountPathString(accountIndex);
+
+  const unsignedTransaction = await buildUnsignedTransactionForSigning(
+    currency,
+    intent,
+    derivationPath,
+    customFees,
+  );
+  const signerTransaction = typhonSerializer(unsignedTransaction, accountIndex);
+  const networkParams = getNetworkParameters(currency.id);
+
+  const signed = await signerContext(deviceId, async signer => {
+    const extendedPublicKey = await signer.getPublicKey(accountPath);
+    onDeviceSignatureRequested?.();
+    const signature = await signer.sign({ transaction: signerTransaction, networkParams });
+    return { extendedPublicKey, signature };
+  });
+  // Defensive guard (parity with the generic signOperation): avoid dereferencing an empty result.
+  // On-device rejection rejects the signerContext promise, so it throws above rather than landing here.
+  if (!signed) {
+    return null;
+  }
+
+  const accountKey = getExtendedPublicKeyFromHex(
+    `${signed.extendedPublicKey.publicKeyHex}${signed.extendedPublicKey.chainCodeHex}`,
+  );
+  const { payload } = assembleWitnesses(unsignedTransaction, accountKey, signed.signature.witnesses);
+  return { signature: payload };
+}

--- a/libs/coin-modules/coin-cardano/src/logic/signCoinModuleTransaction.unit.test.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/signCoinModuleTransaction.unit.test.ts
@@ -1,0 +1,110 @@
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getNetworkParameters } from "../networks";
+import typhonSerializer from "../typhonSerializer";
+import { assembleWitnesses } from "./assembleWitnesses";
+import { buildUnsignedTransactionForSigning } from "./craftTransaction";
+import { signCoinModuleTransaction } from "./signCoinModuleTransaction";
+
+jest.mock("./craftTransaction");
+jest.mock("../typhonSerializer");
+jest.mock("./assembleWitnesses");
+
+const mockBuild = jest.mocked(buildUnsignedTransactionForSigning);
+const mockSerializer = jest.mocked(typhonSerializer);
+const mockAssemble = jest.mocked(assembleWitnesses);
+
+const currency = getCryptoCurrencyById("cardano");
+const DERIVATION_PATH = "1852'/1815'/0'/0/0";
+// A real 128-hex account xpub (datasets/rawAccount.1.ts) so getExtendedPublicKeyFromHex parses it.
+const PUBLIC_KEY_HEX = "806499588e0c4a58f4119f7e6e096bf42c3f774a528d2acec9e82ceebf87d1ce";
+const CHAIN_CODE_HEX = "b3d4f3622dd2c77c65cc89c123f79337db22cf8a69f122e36dab1bf5083bf82d";
+
+// Device witnesses for a delegation: payment (chain 0) + stake (chain 2).
+const witnesses = [
+  { path: [1852, 1815, 0, 0, 0], witnessSignatureHex: "aa" },
+  { path: [1852, 1815, 0, 2, 0], witnessSignatureHex: "bb" },
+];
+
+const fakeUnsignedTx = { tag: "unsigned-tx" } as never;
+const fakeSerialized = { tag: "serialized" } as never;
+
+const getPublicKey = jest.fn(async () => ({
+  publicKeyHex: PUBLIC_KEY_HEX,
+  chainCodeHex: CHAIN_CODE_HEX,
+}));
+const sign = jest.fn(async () => ({ txHashHex: "txhash", witnesses }));
+const fakeSigner = { getPublicKey, sign } as never;
+const signerContext = jest.fn((_deviceId: string, fn: (signer: never) => Promise<unknown>) =>
+  fn(fakeSigner),
+) as never;
+
+const intent = { intentType: "staking", mode: "delegate", sender: "addr", recipient: "addr" } as never;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockBuild.mockResolvedValue(fakeUnsignedTx);
+  mockSerializer.mockReturnValue(fakeSerialized);
+  mockAssemble.mockReturnValue({ hash: "txhash", payload: "signed-payload" } as never);
+});
+
+describe("signCoinModuleTransaction", () => {
+  it("builds with paths, signs every path on device, and assembles the full witness set", async () => {
+    const onDeviceSignatureRequested = jest.fn();
+
+    const result = await signCoinModuleTransaction({
+      currency,
+      intent,
+      derivationPath: DERIVATION_PATH,
+      deviceId: "device-1",
+      signerContext,
+      onDeviceSignatureRequested,
+    });
+
+    // Builds the path-bearing unsigned tx from the intent, serializes with the account index.
+    expect(mockBuild).toHaveBeenCalledWith(currency, intent, DERIVATION_PATH, undefined);
+    expect(mockSerializer).toHaveBeenCalledWith(fakeUnsignedTx, 0);
+
+    // Fetches the account extended pubkey from the account path, then signs.
+    expect(getPublicKey).toHaveBeenCalledWith("1852'/1815'/0'");
+    expect(onDeviceSignatureRequested).toHaveBeenCalledTimes(1);
+    expect(sign).toHaveBeenCalledWith({
+      transaction: fakeSerialized,
+      networkParams: getNetworkParameters(currency.id),
+    });
+
+    // Assembles every device witness (payment + stake) into the signed tx.
+    expect(mockAssemble).toHaveBeenCalledTimes(1);
+    expect(mockAssemble.mock.calls[0][0]).toBe(fakeUnsignedTx);
+    expect(mockAssemble.mock.calls[0][2]).toBe(witnesses);
+
+    expect(result).toEqual({ signature: "signed-payload" });
+  });
+
+  it("aborts cleanly when the device signature is cancelled (signerContext resolves falsy)", async () => {
+    const cancelledSignerContext = jest.fn(async () => undefined) as never;
+
+    const result = await signCoinModuleTransaction({
+      currency,
+      intent,
+      derivationPath: DERIVATION_PATH,
+      deviceId: "device-1",
+      signerContext: cancelledSignerContext,
+    });
+
+    expect(result).toBeNull();
+    expect(mockAssemble).not.toHaveBeenCalled();
+  });
+
+  it("forwards custom fees to the builder", async () => {
+    const customFees = { value: 200000n } as never;
+    await signCoinModuleTransaction({
+      currency,
+      intent,
+      derivationPath: DERIVATION_PATH,
+      deviceId: "device-1",
+      signerContext,
+      customFees,
+    });
+    expect(mockBuild).toHaveBeenCalledWith(currency, intent, DERIVATION_PATH, customFees);
+  });
+});

--- a/libs/coin-modules/coin-cardano/src/logic/stake.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/stake.ts
@@ -1,0 +1,81 @@
+import type { AssetInfo, Stake, StakeAction, StakeState } from "@ledgerhq/coin-module-framework/api/index";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import BigNumber from "bignumber.js";
+import { getDelegationInfo } from "../api/getDelegationInfo";
+import { extractStakeKeyFromAddress } from "../utils";
+import type { CardanoDelegation } from "../types";
+
+export const NATIVE_ASSET: AssetInfo = { type: "native", name: "ADA" };
+
+/**
+ * Resolve an address's stake credential and its on-chain delegation. Addresses with no
+ * stake credential (enterprise, pointer, Byron, or unparseable) skip the network call;
+ * otherwise the delegation is whatever {@link getDelegationInfo} returns for the stake key.
+ */
+export async function fetchDelegation(
+  currency: CryptoCurrency,
+  address: string,
+): Promise<{ stakeKey: string | undefined; delegation: CardanoDelegation | undefined }> {
+  const stakeKey = extractStakeKeyFromAddress(address);
+  const delegation = stakeKey ? await getDelegationInfo(currency, stakeKey) : undefined;
+  return { stakeKey, delegation };
+}
+
+/**
+ * Staking actions for a Cardano delegation. A delegated position (poolId) can change pool or
+ * de-register (undelegate); an undelegated one can delegate. Cardano has no distinct "redelegate" —
+ * changing pool is just another STAKE_DELEGATION certificate, the same `delegate` action — so a
+ * delegated position advertises `delegate` (change pool) + `undelegate`. There is no claim_reward:
+ * rewards are withdrawn implicitly within a transaction, not as a standalone action.
+ */
+function computeStakeActions(delegation: CardanoDelegation): StakeAction[] {
+  return delegation.poolId ? ["delegate", "undelegate"] : ["delegate"];
+}
+
+/**
+ * Map a Cardano delegation to a framework {@link Stake}. Cardano delegation locks no
+ * principal (the whole balance is delegated implicitly), so the only concrete amounts
+ * are the stake-key deposit and the claimable rewards — modelled as amountDeposited /
+ * amountRewarded respectively. Returns undefined when there is no staking position.
+ */
+export function buildStake(
+  address: string,
+  stakeKey: string | undefined,
+  delegation: CardanoDelegation | undefined,
+): Stake | undefined {
+  if (!stakeKey || !delegation) return undefined;
+
+  const rewards = delegation.rewards ?? new BigNumber(0);
+  // A position is staking once it's delegated to a pool (poolId), not merely once the stake key
+  // is registered. Nothing to report unless delegated or holding residual rewards.
+  if (!delegation.poolId && rewards.lte(0)) return undefined;
+
+  const amountDeposited = BigInt(new BigNumber(delegation.deposit || 0).toFixed(0));
+  const amountRewarded = BigInt(rewards.toFixed(0));
+  // Only active/inactive: /v1/delegation exposes no epoch-delayed "activating"/"deactivating"
+  // state (would need pending-cert / epoch data, cf. LIVE-18622). Active == delegated to a pool.
+  const state: StakeState = delegation.poolId ? "active" : "inactive";
+  const actions = computeStakeActions(delegation);
+
+  const details: Record<string, unknown> = {};
+  if (delegation.ticker) details.ticker = delegation.ticker;
+  if (delegation.name) details.name = delegation.name;
+  if (delegation.dRepHex) details.dRepHex = delegation.dRepHex;
+
+  const stake: Stake = {
+    uid: stakeKey,
+    address,
+    state,
+    asset: NATIVE_ASSET,
+    // amount = the 2-ADA stake-key deposit + claimable rewards (framework `amount` is
+    // deposits + rewards). Cardano staking is liquid — no principal is locked — so the
+    // delegated balance itself is reported by getBalance, not here.
+    amount: amountDeposited + amountRewarded,
+    amountDeposited,
+    amountRewarded,
+    actions,
+  };
+  if (delegation.poolId) stake.delegate = delegation.poolId;
+  if (Object.keys(details).length > 0) stake.details = details;
+  return stake;
+}

--- a/libs/coin-modules/coin-cardano/src/logic/stake.unit.test.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/stake.unit.test.ts
@@ -1,0 +1,107 @@
+import BigNumber from "bignumber.js";
+import { getDelegationFixture, STAKING_ADDRESS } from "../fixtures/delegation";
+import type { CardanoDelegation } from "../types";
+import { NATIVE_ASSET, buildStake } from "./stake";
+
+const STAKE_KEY = "e6d2e439c2d7bad6f8a35f1806538256cfb5ff21ad4cdba421643de0";
+
+describe("buildStake", () => {
+  it("returns undefined without a stake key", () => {
+    expect(buildStake(STAKING_ADDRESS, undefined, getDelegationFixture())).toBeUndefined();
+  });
+
+  it("returns undefined without a delegation", () => {
+    expect(buildStake(STAKING_ADDRESS, STAKE_KEY, undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when not delegated and no rewards remain", () => {
+    const stake = buildStake(
+      STAKING_ADDRESS,
+      STAKE_KEY,
+      getDelegationFixture({ status: false, poolId: undefined, deposit: "0" }),
+    );
+    expect(stake).toBeUndefined();
+  });
+
+  it("returns an inactive stake when not delegated but rewards remain", () => {
+    const stake = buildStake(
+      STAKING_ADDRESS,
+      STAKE_KEY,
+      getDelegationFixture({
+        status: false,
+        poolId: undefined,
+        ticker: undefined,
+        name: undefined,
+        rewards: new BigNumber(1_000_000),
+      }),
+    );
+
+    expect(stake).toMatchObject({
+      uid: STAKE_KEY,
+      address: STAKING_ADDRESS,
+      state: "inactive",
+      asset: NATIVE_ASSET,
+      amountDeposited: 2_000_000n,
+      amountRewarded: 1_000_000n,
+      amount: 3_000_000n,
+      // Not delegated (no poolId): the only transition is to delegate.
+      actions: ["delegate"],
+    });
+    expect(stake?.delegate).toBeUndefined();
+    expect(stake?.details).toBeUndefined();
+  });
+
+  it("maps an active delegation's pool to delegate and metadata to details", () => {
+    const stake = buildStake(STAKING_ADDRESS, STAKE_KEY, getDelegationFixture({ dRepHex: "drep1abc" }));
+
+    expect(stake).toMatchObject({
+      state: "active",
+      delegate: "pool1xyz",
+      details: { ticker: "TICK", name: "Pool", dRepHex: "drep1abc" },
+    });
+  });
+
+  it("treats a registered key with no pool as not staking (keys on poolId, not status)", () => {
+    // status: true (registered) but no poolId and no rewards → no position; a position is staking
+    // only once delegated to a pool, not merely once the stake key is registered.
+    const stake = buildStake(STAKING_ADDRESS, STAKE_KEY, getDelegationFixture({ poolId: undefined }));
+    expect(stake).toBeUndefined();
+  });
+
+  it("offers only delegate for a registered key with no pool but residual rewards", () => {
+    // status: true but no poolId, with rewards remaining → surfaced (rewards), yet still keyed on
+    // poolId: state is inactive and the only action is delegate (no undelegate without a pool).
+    const stake = buildStake(
+      STAKING_ADDRESS,
+      STAKE_KEY,
+      getDelegationFixture({
+        status: true,
+        poolId: undefined,
+        ticker: undefined,
+        name: undefined,
+        rewards: new BigNumber(1_000_000),
+      }),
+    );
+
+    expect(stake?.state).toBe("inactive");
+    expect(stake?.actions).toEqual(["delegate"]);
+  });
+
+  it("offers delegate + undelegate for an active delegation, regardless of rewards/dRep", () => {
+    const actions = (over: Partial<CardanoDelegation> = {}) =>
+      buildStake(STAKING_ADDRESS, STAKE_KEY, getDelegationFixture(over))?.actions;
+
+    // Default fixture is delegated (poolId set). delegate = change pool (Cardano has no separate
+    // redelegate cert); undelegate = deregister. No standalone claim action — rewards are withdrawn
+    // implicitly within a tx — so rewards / dRep never change the action set.
+    expect(actions()).toEqual(["delegate", "undelegate"]);
+    expect(actions({ rewards: new BigNumber(5_000_000), dRepHex: "drep1abc" })).toEqual([
+      "delegate",
+      "undelegate",
+    ]);
+    expect(actions({ rewards: new BigNumber(5_000_000), dRepHex: undefined })).toEqual([
+      "delegate",
+      "undelegate",
+    ]);
+  });
+});

--- a/libs/coin-modules/coin-cardano/src/signOperation.ts
+++ b/libs/coin-modules/coin-cardano/src/signOperation.ts
@@ -1,15 +1,14 @@
 import { FeeNotLoaded } from "@ledgerhq/errors";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { AccountBridge, SignOperationEvent } from "@ledgerhq/types-live";
-import { Bip32PublicKey } from "@stricahq/bip32ed25519";
-import { Transaction as TyphonTransaction, types as TyphonTypes } from "@stricahq/typhonjs";
 import { Observable } from "rxjs";
 import { buildOptimisticOperation } from "./buildOptimisticOperation";
 import { buildTransaction } from "./buildTransaction";
 import { CardanoInvalidProtoParams } from "./errors";
+import { assembleWitnesses } from "./logic/assembleWitnesses";
 import { getExtendedPublicKeyFromHex } from "./logic";
 import { getNetworkParameters } from "./networks";
-import { CardanoSigner, Witness } from "./signer";
+import { CardanoSigner } from "./signer";
 import type { CardanoAccount, Transaction } from "./types";
 import typhonSerializer from "./typhonSerializer";
 
@@ -45,7 +44,7 @@ export const buildSignOperation =
         );
 
         const accountPubKey = getExtendedPublicKeyFromHex(account.xpub as string);
-        const signed = signTx(unsignedTransaction, accountPubKey, signedData.witnesses);
+        const signed = assembleWitnesses(unsignedTransaction, accountPubKey, signedData.witnesses);
 
         o.next({ type: "device-signature-granted" });
 
@@ -64,24 +63,3 @@ export const buildSignOperation =
         e => o.error(e),
       );
     });
-
-/**
- * Adds signatures to unsigned transaction
- */
-const signTx = (
-  unsignedTransaction: TyphonTransaction,
-  accountKey: Bip32PublicKey,
-  witnesses: Array<Witness>,
-) => {
-  witnesses.forEach(witness => {
-    const [, , , chainType, index] = witness.path;
-    const publicKey = accountKey.derive(chainType).derive(index).toPublicKey().toBytes();
-    const vKeyWitness: TyphonTypes.VKeyWitness = {
-      signature: Buffer.from(witness.witnessSignatureHex, "hex"),
-      publicKey: Buffer.from(publicKey),
-    };
-    unsignedTransaction.addWitness(vKeyWitness);
-  });
-
-  return unsignedTransaction.buildTransaction();
-};

--- a/libs/coin-modules/coin-cardano/src/synchronisation.ts
+++ b/libs/coin-modules/coin-cardano/src/synchronisation.ts
@@ -24,6 +24,7 @@ import {
   findStakeRegistration,
   findWithdrawal,
   getAccountChange,
+  getAccountPathString,
   getAccountStakeCredential,
   getBaseAddress,
   getBipPathString,
@@ -47,17 +48,8 @@ import {
 export const makeGetAccountShape =
   (signerContext: SignerContext<CardanoSigner>): GetAccountShape<CardanoAccount> =>
   async (info, { blacklistedTokenIds }) => {
-    const {
-      currency,
-      index: accountIndex,
-      derivationPath,
-      derivationMode,
-      initialAccount,
-      deviceId,
-    } = info;
-    // In case we get a full derivation path
-    const rootPath = derivationPath.split("/", 2).join("/");
-    const accountPath = `${rootPath}/${accountIndex}'`;
+    const { currency, index: accountIndex, derivationMode, initialAccount, deviceId } = info;
+    const accountPath = getAccountPathString(accountIndex);
 
     const paramXpub = initialAccount?.xpub;
     let xpub;


### PR DESCRIPTION
> **⚠️ Base:** targets `LIVE-30408-cardano-coin-module-api-getstakes` (stacked, not `develop`) — auto-retargets once getStakes lands.

### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- behavior-preserving migration; existing suite (45/273) covers every call site -->
- [ ] **Impact of the changes:**
  - Cardano network calls now route through `@ledgerhq/live-network`. QA: smoke-test account sync, operation history, staking details, send/broadcast.
  - One intentional delta: `GET` retries now use a fixed status allowlist instead of "all errors except 422".

### 📝 Description

Migrate coin-cardano off the deprecated `@ledgerhq/live-network/network` import to `@ledgerhq/live-network`.

- Swap the import at all call sites; add explicit `network<T>(...)` generics (new impl types `data` as `unknown`) and drop the `res.data as X` casts.
- Fix `fetchDelegationInfo` to return `APIDelegation | undefined`.
- Coerce the server-dictated pagination `limit` in `listOperations` so a non-numeric value can't truncate history.

Behavior-preserving (all call sites read only `.data`); see *Impact* for the one retry-policy delta.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31700](https://ledgerhq.atlassian.net/browse/LIVE-31700)
- **ADR link (if any)**: N/A


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31700]: https://ledgerhq.atlassian.net/browse/LIVE-31700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ