### PR TITLE
fix(e2e-desktop): LedgerSync cleanup must delete, and push correct version

### DIFF
--- a/e2e/desktop/tests/utils/cliUtils.ts
+++ b/e2e/desktop/tests/utils/cliUtils.ts
@@ -112,24 +112,20 @@ export const CLI = {
       slug: liveSlug,
       schema: walletsync.schema,
       trustchainSdk: ledgerKeyRingProtocolSDK,
-      getCurrentVersion: () => version || 1,
+      getCurrentVersion: () => version ?? 0,
       saveNewUpdate: async (event: UpdateEvent<LiveData>) => {
         latestUpdateEvent = event;
       },
     });
 
-    //@todo: Split into it's own function
-    if (push) {
-      return cloudSyncSDK
-        .push(
-          { rootId, walletSyncEncryptionKey, applicationPath },
-          { pubkey: pubKey, privatekey: privateKey },
-          JSON.parse(data!) as LiveData,
-        )
-        .then((result: void) => JSON.stringify(result, null, 2));
+    // check deleteData/pull before push: callers reuse args that carry push: true
+    if (deleteData) {
+      return cloudSyncSDK.destroy(
+        { rootId, walletSyncEncryptionKey, applicationPath },
+        { pubkey: pubKey, privatekey: privateKey },
+      );
     }
 
-    //@todo: Split into it's own function
     if (pull) {
       return cloudSyncSDK
         .pull(
@@ -141,12 +137,14 @@ export const CLI = {
         );
     }
 
-    //@todo: Split into it's own function
-    if (deleteData) {
-      return cloudSyncSDK.destroy(
-        { rootId, walletSyncEncryptionKey, applicationPath },
-        { pubkey: pubKey, privatekey: privateKey },
-      );
+    if (push) {
+      return cloudSyncSDK
+        .push(
+          { rootId, walletSyncEncryptionKey, applicationPath },
+          { pubkey: pubKey, privatekey: privateKey },
+          JSON.parse(data!) as LiveData,
+        )
+        .then((result: void) => JSON.stringify(result, null, 2));
     }
   },
   liveData: function (opts: LiveDataOpts) {


### PR DESCRIPTION
**NB: Goal of this PR is to go past the Before Hooks failure: ledgerSync.spec will still fail and it will be addressed in future PR (not scope here)**

We now pass the Before Hooks here:

<img width="1138" height="843" alt="Screenshot 2026-06-04 at 18 25 08" src="https://github.com/user-attachments/assets/3de7be15-0673-4c73-812f-3960e779213d" />


### ✅ Checklist

- [ ] `npx changeset` was attached. <!-- N/A: only the private `ledger-live-desktop-e2e-tests` package is touched. -->
- [x] **Covered by automatic tests.** Validated by running `ledgerSync.spec` locally — the setup 5xx disappears from the Before Hooks and the flow runs end-to-end. [Desktop E2E run (ledgerSync.spec)](https://github.com/LedgerHQ/ledger-live/actions/runs/26964385111).
- [ ] **Impact of the changes:**
  - E2E desktop only (`CLI.ledgerSync` test helper). No app/runtime code.

### 📝 Description

Two defects in the LedgerSync e2e CLI helper, surfaced while investigating the LIVE-31799 5xx (the Allure observability for it is in #18220):

**1. The cleanup never deleted — it pushed.** `deleteLedgerSyncData` passes `deleteData: true` but spreads `ledgerSyncPushDataArgs`, which carries `push: true`. `CLI.ledgerSync` checked `if (push)` before `if (deleteData)`, so the delete was silently turned into a push. Fixed by checking `deleteData`/`pull` before `push`.

**2. Blind version → backend 500.** `getCurrentVersion` defaulted to `1`, so every push computed `version = 2`. Pushing version 2 to an empty/just-deleted store is a version gap the staging backend rejects with HTTP 500. Defaulted to `0` so a fresh push sends `version = 1`.

Verified locally: with both fixes the cleanup issues a real `DELETE` (200) and the push succeeds, so the spec no longer fails in setup with a 5xx.


> [!NOTE]
> Remaining LIVE-31799 flakiness (member-removal propagation, app-side version=2 pushes) is addressed app-side in #18171 — out of scope here.

### ❓ Context

- **JIRA or GitHub link**: related to https://ledgerhq.atlassian.net/browse/LIVE-31719
- **ADR link (if any)**: N/A

