### PR TITLE
[LWM] fix(device-intent): fix DIE state machine startup race

### DIFF
--- a/.changeset/die-sm-start-race.md
+++ b/.changeset/die-sm-start-race.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-intent": minor
+---
+
+Fix Device Intent Executor state machine startup race.

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/useDeviceConnectionComponentLWMViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/useDeviceConnectionComponentLWMViewModel.ts
@@ -70,7 +70,6 @@ export function useDeviceConnectionComponentLWMViewModel({
   const firedRef = useRef({
     prompted: false,
     connecting: false,
-    connected: false,
   });
 
   useEffect(() => {
@@ -128,10 +127,7 @@ export function useDeviceConnectionComponentLWMViewModel({
       const modelId = dmkToLedgerDeviceIdMap[result.connectedDevice.modelId];
       const transport: "ble" | "usb" = result.connectedDevice.type === "USB" ? "usb" : "ble";
 
-      if (!firedRef.current.connected) {
-        firedRef.current.connected = true;
-        trackDeviceConnected({ sourceFlow, modelId, transport });
-      }
+      trackDeviceConnected({ sourceFlow, modelId, transport });
 
       dispatch(
         setLastConnectedDevice({

--- a/libs/device-intent/src/DeviceIntentExecutor.test.tsx
+++ b/libs/device-intent/src/DeviceIntentExecutor.test.tsx
@@ -78,6 +78,16 @@ const ConnectionComponent: React.FC<{
   </div>
 );
 
+const AutoConnectingComponent: React.FC<{
+  onConnected: (r: DeviceConnectionResult) => void;
+}> = ({ onConnected }) => {
+  React.useEffect(() => {
+    onConnected(makeConnectionResult());
+  }, [onConnected]);
+
+  return <div data-testid="auto-connection" />;
+};
+
 const InitializerComponent: React.FC<{
   onContextInitialized: (ctx: DeviceExtractedContext) => void;
   onClose: () => void;
@@ -184,6 +194,22 @@ describe("DeviceIntentExecutor (integration)", () => {
     const props = makeProps();
     render(<DeviceIntentExecutor {...props} />);
     expect(screen.getByTestId("connection")).toBeTruthy();
+  });
+
+  it("GIVEN the connection component connects from its mount effect WHEN rendering THEN it reaches device initialization", async () => {
+    // GIVEN
+    const props = makeProps({
+      platformConfig: {
+        ...platformConfig,
+        DeviceConnectionComponent: AutoConnectingComponent,
+      },
+    });
+
+    // WHEN
+    render(<DeviceIntentExecutor {...props} />);
+
+    // THEN
+    expect(await screen.findByTestId("initializer")).toBeTruthy();
   });
 
   it("renders nothing when enabled is false", () => {

--- a/libs/device-intent/src/DeviceIntentExecutorStateMachine.test.ts
+++ b/libs/device-intent/src/DeviceIntentExecutorStateMachine.test.ts
@@ -64,6 +64,7 @@ function createSM(
     intent,
     listeners,
   });
+  sm.start();
   return { sm, listeners };
 }
 
@@ -83,11 +84,50 @@ function lastExecutorState(listeners: ReturnType<typeof makeListeners>): Executo
 // ---- Tests ----
 
 describe("DeviceIntentExecutorStateMachine", () => {
-  describe("GIVEN the machine just started", () => {
-    it("THEN it emits connectingDevice", () => {
-      const { sm, listeners } = createSM();
+  describe("SM lifecycle", () => {
+    it("GIVEN the machine is constructed WHEN start is called THEN it emits connectingDevice", () => {
+      // GIVEN
+      const listeners = makeListeners();
+      const sm = new DefaultDeviceIntentExecutorStateMachine({
+        deviceConnectionParams: { acceptedDeviceModelIds: [] },
+        intent: makeIntent(),
+        listeners,
+      });
+
+      // WHEN
+      sm.start();
+
+      // THEN
       expect(listeners.onExecutorStateChanged).toHaveBeenCalledWith({ type: "connectingDevice" });
       expect(lastExecutorState(listeners)).toEqual({ type: "connectingDevice" });
+      sm.stop();
+    });
+
+    it("GIVEN the machine is constructed WHEN start has not been called THEN it does not emit connectingDevice", () => {
+      // GIVEN
+      const listeners = makeListeners();
+
+      // WHEN
+      const sm = new DefaultDeviceIntentExecutorStateMachine({
+        deviceConnectionParams: { acceptedDeviceModelIds: [] },
+        intent: makeIntent(),
+        listeners,
+      });
+
+      // THEN
+      expect(listeners.onExecutorStateChanged).not.toHaveBeenCalled();
+      sm.stop();
+    });
+
+    it("GIVEN the machine has already started WHEN start is called again THEN it throws", () => {
+      // GIVEN
+      const { sm } = createSM();
+
+      // WHEN
+      const startAgain = () => sm.start();
+
+      // THEN
+      expect(startAgain).toThrow("DeviceIntentExecutorStateMachine has already been started");
       sm.stop();
     });
   });

--- a/libs/device-intent/src/DeviceIntentExecutorStateMachine.ts
+++ b/libs/device-intent/src/DeviceIntentExecutorStateMachine.ts
@@ -131,7 +131,7 @@ function createExecutorMachine<JobState, Input, ExtraProps>() {
         },
       },
       deviceDisconnected: {
-        entry: ({ context }) => {
+        entry: () => {
           log(LOG_TYPE, "state: deviceDisconnected");
         },
         on: {
@@ -327,6 +327,7 @@ function createExecutorMachine<JobState, Input, ExtraProps>() {
 // ---- Public interface ----
 
 export interface DeviceIntentExecutorStateMachine<JobState, Input, ExtraProps> {
+  start(): void;
   deviceConnected(result: DeviceConnectionResult): void;
   deviceContextInitialized(context: DeviceExtractedContext): void;
   deviceDisconnected(): void;
@@ -351,6 +352,7 @@ export class DefaultDeviceIntentExecutorStateMachine<
   ExtraProps,
 > implements DeviceIntentExecutorStateMachine<JobState, Input, ExtraProps> {
   private readonly actor;
+  private hasStarted = false;
 
   constructor(params: {
     deviceConnectionParams: DeviceConnectionParams;
@@ -359,6 +361,14 @@ export class DefaultDeviceIntentExecutorStateMachine<
   }) {
     const machine = createExecutorMachine<JobState, Input, ExtraProps>();
     this.actor = createActor(machine, { input: params });
+  }
+
+  start(): void {
+    if (this.hasStarted) {
+      throw new Error("DeviceIntentExecutorStateMachine has already been started");
+    }
+    log(LOG_TYPE, "event: start");
+    this.hasStarted = true;
     this.actor.start();
   }
 
@@ -405,6 +415,8 @@ export class DefaultDeviceIntentExecutorStateMachine<
 
   stop(): void {
     log(LOG_TYPE, "event: stop");
-    this.actor.stop();
+    if (this.hasStarted) {
+      this.actor.stop();
+    }
   }
 }

--- a/libs/device-intent/src/useDeviceIntentExecutor.test.tsx
+++ b/libs/device-intent/src/useDeviceIntentExecutor.test.tsx
@@ -661,6 +661,7 @@ function renderWithMockSM(overrides: Partial<TestProps> = {}) {
     params: { listeners: StateMachineListeners<unknown, unknown, unknown> },
   ) {
     const mock: MockSM = {
+      start: jest.fn(),
       deviceConnected: jest.fn(),
       deviceContextInitialized: jest.fn(),
       deviceDisconnected: jest.fn(),
@@ -711,6 +712,14 @@ describe("useDeviceIntentExecutor — unit (mocked SM)", () => {
       );
     });
 
+    it("WHEN enabled is true THEN the SM is started", () => {
+      // WHEN
+      const { sm } = renderWithMockSM();
+
+      // THEN
+      expect(sm.start).toHaveBeenCalledTimes(1);
+    });
+
     it("WHEN enabled is false THEN no SM is constructed", () => {
       const { SMClass } = renderWithMockSM({ enabled: false });
 
@@ -734,6 +743,7 @@ describe("useDeviceIntentExecutor — unit (mocked SM)", () => {
 
       rerender({ p: { ...props, enabled: true } });
       expect(SMClass).toHaveBeenCalledTimes(1);
+      expect(SMClass.lastInstance?.start).toHaveBeenCalledTimes(1);
     });
 
     it("WHEN the hook unmounts THEN sm.stop() is called", () => {

--- a/libs/device-intent/src/useDeviceIntentExecutor.ts
+++ b/libs/device-intent/src/useDeviceIntentExecutor.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { DeviceStatus, type DeviceSessionState } from "@ledgerhq/device-management-kit";
 import type { DeviceConnectionResult, DeviceExtractedContext } from "./core";
 import type { DeviceIntentExecutorProps, ExecutorState } from "./executor";
@@ -94,23 +94,13 @@ export function useDeviceIntentExecutor<JobState, Input, ExtraProps, InitInput>(
   const prevInitializationInputRef = useRef(props.deviceInitializationInput);
   const prevIntentRef = useRef(props.intent);
 
-  useEffect(() => {
-    if (!props.enabled) {
-      smRef.current?.stop();
-      smRef.current = null;
-      setExecutorState({ type: "connectingDevice" });
-      setConnectionResult(null);
-      setLatestJobState(undefined);
-      lastIntentSnapshotRef.current = null;
-      return;
-    }
-
+  const createStateMachine = useCallback(() => {
     // Sync prev-value refs so the props->actions effect doesn't dispatch
     // events for props that were already used to create the SM.
     prevInitializationInputRef.current = deviceInitializationInputRef.current;
     prevIntentRef.current = intentRef.current;
 
-    const sm = new StateMachineClass({
+    return new StateMachineClass({
       deviceConnectionParams: deviceConnectionParamsRef.current,
       intent: intentRef.current,
       listeners: {
@@ -143,13 +133,33 @@ export function useDeviceIntentExecutor<JobState, Input, ExtraProps, InitInput>(
         onIntentJobError: (_intent, error) => onIntentJobErrorRef.current(error),
       },
     });
-    smRef.current = sm;
+  }, [StateMachineClass]);
 
+  if (props.enabled && !smRef.current) {
+    smRef.current = createStateMachine();
+  }
+
+  useLayoutEffect(() => {
+    if (!props.enabled) {
+      smRef.current?.stop();
+      smRef.current = null;
+      setExecutorState({ type: "connectingDevice" });
+      setConnectionResult(null);
+      setLatestJobState(undefined);
+      lastIntentSnapshotRef.current = null;
+      return;
+    }
+
+    const sm = smRef.current ?? createStateMachine();
+    smRef.current = sm;
+    sm.start();
     return () => {
       sm.stop();
-      smRef.current = null;
+      if (smRef.current === sm) {
+        smRef.current = null;
+      }
     };
-  }, [props.enabled, StateMachineClass]);
+  }, [createStateMachine, props.enabled]);
 
   // ---- 5. Device disconnection monitoring effect ----
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Device Intent Executor startup when a device connection is emitted immediately on mount

### 📝 Description

#### The bug

- The connection component subscribes to the device connection use case from a `useEffect` on mount.
- If a DMK session is already alive, that subscription emits `onConnected` synchronously, during the same effect run.
- But `useDeviceIntentExecutor` used to create the state machine in its own `useEffect` too.
- Effects run child-first, so the child's `onConnected` fired before the parent had assigned `smRef.current`.
- That first connection event was dropped on the floor.
- Things only worked because the connection effect happened to re-fire a second time later (due to a dispatch of `knownDevices` in the first fire), after the SM existed. So **it was fully functional**, but it meant that the `"device_connected"` tracking event had to be explicitly guarded against firing twice.

#### The fix

- The state machine is instantiated during render (lazy, once per enabled lifecycle), so `smRef.current` is already set when child mount effects run.
- Starting the XState actor is split out into an explicit `start()` method, called from a `useLayoutEffect`. That keeps the actual side effect outside render.
- `start()` is guarded: calling it twice throws, which catches accidental double-starts loudly.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31848](https://ledgerhq.atlassian.net/browse/LIVE-31848)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31848]: https://ledgerhq.atlassian.net/browse/LIVE-31848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ