### PR TITLE
[LWDM] fix(walletsync): reset CloudSync version to 1 on trustchain rotation

### DIFF
--- a/.changeset/walletsync-rotation-fresh-store-version.md
+++ b/.changeset/walletsync-rotation-fresh-store-version.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-wallet": patch
+---
+
+fix(walletsync): on trustchain rotation, re-upload to the new CloudSync store at version 1 instead of reusing the previous store's version (the fresh store rejects the version gap with HTTP 500, leaving member removal stuck)

--- a/libs/live-wallet/src/walletsync/__tests__/trustchainLifecyle.test.ts
+++ b/libs/live-wallet/src/walletsync/__tests__/trustchainLifecyle.test.ts
@@ -86,6 +86,8 @@ describe("trustchainLifecycle", () => {
 
     expect(removedCount).toBe(1);
     expect(storedData).not.toBe("");
-    expect(storedVersion).toBe(42);
+    // the rotated trustchain is a fresh store: the upload must reset to version 1,
+    // not reuse the previous store's version (42).
+    expect(storedVersion).toBe(1);
   });
 });

--- a/libs/live-wallet/src/walletsync/trustchainLifecyle.ts
+++ b/libs/live-wallet/src/walletsync/trustchainLifecyle.ts
@@ -33,12 +33,15 @@ export function trustchainLifecycle({
           jwt => Promise.resolve(jwt),
           "refresh",
         );
-        // we then need to push back data to a new CloudSync id with the new encryption key
-        const { version, data } = getCurrentWSState();
+        // we then need to push back data to a new CloudSync id with the new encryption key.
+        // the rotated trustchain is a brand-new CloudSync store, so its first write must be
+        // version 1 — reusing the previous store's version makes the backend reject it as a
+        // version gap (HTTP 500).
+        const { data } = getCurrentWSState();
         if (!data) return;
         const cipher = makeCipher(trustchainSdk);
         const payload = await cipher.encrypt(newTrustchain, data);
-        await api.uploadData(newJwt, liveSlug, version, payload, newTrustchain);
+        await api.uploadData(newJwt, liveSlug, 1, payload, newTrustchain);
       };
     },
   };


### PR DESCRIPTION
> [!WARNING]
> **Behavior change to confirm with the CloudSync backend team before merging.**
> This changes the version sent on trustchain rotation from the carried-over global version to `1`. We believe the rotated trustchain is a brand-new CloudSync store (new `applicationPath`) whose first write must be version 1, and that the backend now rejects a higher "version gap" with HTTP 500. Please confirm: (a) is CloudSync versioning per-(id, path) so a fresh store always starts at 1, and (b) was anything relying on version continuity across rotation? See open question below.

### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Updated `trustchainLifecyle` unit test; verified end-to-end locally — the LedgerSync desktop e2e (`ledgerSync.spec`) reaches and passes the member-removal/rotation step with this change.
- [ ] **Impact of the changes:**
  - Trustchain rotation (triggered by member removal) now re-uploads sync data to the new store at version 1.
  - No change to the normal (non-rotation) push path.

### 📝 Description

On trustchain rotation, `trustchainLifecycle.onTrustchainRotation` deletes the old CloudSync data and re-uploads it under the **new** trustchain (`rootId` + `applicationPath`). It was re-uploading with the **previous store's version** (`getCurrentWSState().version`). The new store is fresh, so the backend rejects the upload as a version gap with **HTTP 500** — the rotation never completes, so a removed member is never reflected (the "is no longer connected to Ledger Sync" state never appears).

Fix: upload the first write to the rotated store at **version 1**.

```diff
- await api.uploadData(newJwt, liveSlug, version, payload, newTrustchain);
+ await api.uploadData(newJwt, liveSlug, 1, payload, newTrustchain);
```

### ❓ Context & open question

This surfaced while debugging the flaky `ledgerSync` desktop e2e (LIVE-31799). Note the staging CloudSync backend is **also** intermittently 5xx-ing on `POST /atomic/v1/live` independently of version (so the e2e has additional flakiness beyond this fix — tracked separately). The version reset is the one **deterministic** failure in the rotation path.

**Open question for backend:** the previous code intentionally preserved the global version across rotation (and its unit test asserted that). If the backend is meant to support version continuity across a new `applicationPath`, the real fix may be backend-side and this should be reverted. Hence the warning block above.

- **JIRA**: [LIVE-31799](https://ledgerhq.atlassian.net/browse/LIVE-31799)
- **ADR**: N/A


[LIVE-31799]: https://ledgerhq.atlassian.net/browse/LIVE-31799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ