### PR TITLE
[LWD] fix(desktop): move borrow entry point below assets section

### DIFF
--- a/.changeset/move-borrow-entry-point-below-assets.md
+++ b/.changeset/move-borrow-entry-point-below-assets.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Move the Borrow entry point below the Assets section on the Portfolio view

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/PortfolioView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/PortfolioView.tsx
@@ -69,9 +69,9 @@ export const PortfolioView = memo(function PortfolioView({
           {shouldDisplayMarketBanner && <MarketBanner />}
 
           <PerpsEntryPoint />
-          {shouldDisplayBorrowSection && <BorrowEntryPoint />}
 
           {shouldDisplayAssetSection ? <Assets /> : <AssetDistribution />}
+          {shouldDisplayBorrowSection && <BorrowEntryPoint />}
           {shouldDisplayAddAccountCta && <AddAccount />}
           {shouldDisplayAssetSection && <CryptoAddressesBanner />}
           {shouldDisplayBrazePlacement && <BottomCarouselContentCards />}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Pure rendering-order tweak in the Portfolio view; covered by visual QA._
- [x] **Impact of the changes:**
  - Portfolio view layout on Ledger Wallet Desktop
  - Vertical order of the `BorrowEntryPoint` relative to the `Assets` / `AssetDistribution` section

### 📝 Description

The Borrow entry point on the desktop Portfolio view was previously rendered above the Assets section, which broke the intended visual hierarchy: users would see a "Loans" CTA before seeing their stablecoin holdings.

This PR reorders `PortfolioView` so that `BorrowEntryPoint` is rendered **after** the `Assets` / `AssetDistribution` section, surfacing the assets table first and the Borrow CTA right below it (under the Stablecoins block).

No behavioral, gating, or feature-flag change — only the render order inside `PortfolioView.tsx`.

### 📸 Screenshots
<img width="2786" height="996" alt="image" src="https://github.com/user-attachments/assets/87a348e2-b0a1-4290-ba7c-55ee982864d0" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-31210](https://ledgerhq.atlassian.net/browse/LIVE-31210)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-31210]: https://ledgerhq.atlassian.net/browse/LIVE-31210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ