### PR TITLE
[LWM] feat(mobile): add DIE header overrides

### DIFF
--- a/.changeset/die-header-override.md
+++ b/.changeset/die-header-override.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add Device Intent Executor bottom sheet header overrides on mobile.

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/OverrideDeviceIntentExecutorHeader/OverrideDeviceIntentExecutorHeader.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/OverrideDeviceIntentExecutorHeader/OverrideDeviceIntentExecutorHeader.test.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { Text } from "react-native";
+import { render, screen } from "@tests/test-renderer";
+import { useDeviceIntentExecutorHeaderOverrideRequests } from "../../hooks/useDeviceIntentExecutorHeaderOverrideRequests";
+import { DeviceIntentExecutorHeaderContext } from "../../utils/DeviceIntentExecutorHeaderContext";
+import { OverrideDeviceIntentExecutorHeader } from ".";
+
+describe("OverrideDeviceIntentExecutorHeader", () => {
+  it("GIVEN no DeviceIntentExecutorHeaderContext provider WHEN the component renders THEN it renders nothing", () => {
+    // GIVEN / WHEN
+    render(
+      <OverrideDeviceIntentExecutorHeader>
+        <Text>Custom header</Text>
+      </OverrideDeviceIntentExecutorHeader>,
+    );
+
+    // THEN
+    expect(screen.queryByText("Custom header")).toBeNull();
+  });
+
+  it("GIVEN no override is mounted WHEN the header slot renders THEN the default header is visible", () => {
+    // GIVEN / WHEN
+    render(<HeaderOverrideHarness showOverride={false} />);
+
+    // THEN
+    expect(screen.getByText("Default header")).toBeVisible();
+    expect(screen.queryByText("Custom header")).toBeNull();
+  });
+
+  it("GIVEN an override is mounted WHEN the header slot renders THEN the custom header replaces the default header", () => {
+    // GIVEN / WHEN
+    render(<HeaderOverrideHarness showOverride />);
+
+    // THEN
+    expect(screen.getByText("Custom header")).toBeVisible();
+    expect(screen.queryByText("Default header")).toBeNull();
+  });
+
+  it("GIVEN an override is mounted WHEN it unmounts THEN the default header is restored", () => {
+    // GIVEN
+    const { rerender } = render(<HeaderOverrideHarness showOverride />);
+    expect(screen.getByText("Custom header")).toBeVisible();
+
+    // WHEN
+    rerender(<HeaderOverrideHarness showOverride={false} />);
+
+    // THEN
+    expect(screen.getByText("Default header")).toBeVisible();
+    expect(screen.queryByText("Custom header")).toBeNull();
+  });
+});
+
+function HeaderOverrideHarness({ showOverride }: Readonly<{ showOverride: boolean }>) {
+  const { hasHeaderOverride, headerContextValue } = useDeviceIntentExecutorHeaderOverrideRequests();
+
+  return (
+    <DeviceIntentExecutorHeaderContext.Provider value={headerContextValue}>
+      {hasHeaderOverride ? null : <Text>Default header</Text>}
+      {showOverride ? (
+        <OverrideDeviceIntentExecutorHeader>
+          <Text>Custom header</Text>
+        </OverrideDeviceIntentExecutorHeader>
+      ) : null}
+    </DeviceIntentExecutorHeaderContext.Provider>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/OverrideDeviceIntentExecutorHeader/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/components/OverrideDeviceIntentExecutorHeader/index.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { useDeviceIntentExecutorHeaderOverride } from "../../hooks/useDeviceIntentExecutorHeaderOverride";
+
+type OverrideDeviceIntentExecutorHeaderProps = Readonly<{
+  children: React.ReactNode;
+}>;
+
+export function OverrideDeviceIntentExecutorHeader({
+  children,
+}: OverrideDeviceIntentExecutorHeaderProps): React.ReactElement | null {
+  const hasHeaderOverrideProvider = useDeviceIntentExecutorHeaderOverride();
+
+  if (!hasHeaderOverrideProvider) return null;
+
+  return <>{children}</>;
+}

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/hooks/__tests__/useDeviceIntentExecutorHeaderOverrideRequests.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/hooks/__tests__/useDeviceIntentExecutorHeaderOverrideRequests.test.ts
@@ -1,0 +1,67 @@
+import { act, renderHook } from "@tests/test-renderer";
+import { useDeviceIntentExecutorHeaderOverrideRequests } from "../useDeviceIntentExecutorHeaderOverrideRequests";
+
+describe("useDeviceIntentExecutorHeaderOverrideRequests", () => {
+  it("GIVEN the hook has just rendered WHEN no request has been made THEN there is no header override", () => {
+    // GIVEN
+    const { result } = renderHook(() => useDeviceIntentExecutorHeaderOverrideRequests());
+
+    // WHEN
+    // (no action)
+
+    // THEN
+    expect(result.current.hasHeaderOverride).toBe(false);
+  });
+
+  it("GIVEN the hook has just rendered WHEN a component requests a header override THEN it becomes active", () => {
+    // GIVEN
+    const { result } = renderHook(() => useDeviceIntentExecutorHeaderOverrideRequests());
+
+    // WHEN
+    act(() => {
+      result.current.headerContextValue.requestHeaderOverride();
+    });
+
+    // THEN
+    expect(result.current.hasHeaderOverride).toBe(true);
+  });
+
+  it("GIVEN two header overrides have been requested WHEN the older request is cleaned up first THEN the override remains active", () => {
+    // GIVEN
+    const { result } = renderHook(() => useDeviceIntentExecutorHeaderOverrideRequests());
+    let cleanupFirst: (() => void) | undefined;
+    act(() => {
+      cleanupFirst = result.current.headerContextValue.requestHeaderOverride();
+    });
+    act(() => {
+      result.current.headerContextValue.requestHeaderOverride();
+    });
+    expect(result.current.hasHeaderOverride).toBe(true);
+
+    // WHEN
+    act(() => {
+      cleanupFirst?.();
+    });
+
+    // THEN
+    expect(result.current.hasHeaderOverride).toBe(true);
+  });
+
+  it("GIVEN a header override has been requested WHEN its cleanup runs THEN the override becomes inactive", () => {
+    // GIVEN
+    const { result } = renderHook(() => useDeviceIntentExecutorHeaderOverrideRequests());
+    let cleanup: (() => void) | undefined;
+    act(() => {
+      cleanup = result.current.headerContextValue.requestHeaderOverride();
+    });
+    expect(result.current.hasHeaderOverride).toBe(true);
+
+    // WHEN
+    act(() => {
+      cleanup?.();
+    });
+
+    // THEN
+    expect(result.current.hasHeaderOverride).toBe(false);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/hooks/useDeviceIntentExecutorHeaderOverride.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/hooks/useDeviceIntentExecutorHeaderOverride.ts
@@ -1,0 +1,14 @@
+import { useContext, useLayoutEffect } from "react";
+import { DeviceIntentExecutorHeaderContext } from "../utils/DeviceIntentExecutorHeaderContext";
+
+export function useDeviceIntentExecutorHeaderOverride(): boolean {
+  const context = useContext(DeviceIntentExecutorHeaderContext);
+
+  useLayoutEffect(() => {
+    if (!context) return;
+
+    return context.requestHeaderOverride();
+  }, [context]);
+
+  return Boolean(context);
+}

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/hooks/useDeviceIntentExecutorHeaderOverrideRequests.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/hooks/useDeviceIntentExecutorHeaderOverrideRequests.ts
@@ -1,0 +1,37 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import type { DeviceIntentExecutorHeaderContextValue } from "../utils/DeviceIntentExecutorHeaderContext";
+
+type UseDeviceIntentExecutorHeaderOverrideRequestsReturn = Readonly<{
+  hasHeaderOverride: boolean;
+  headerContextValue: DeviceIntentExecutorHeaderContextValue;
+}>;
+
+export function useDeviceIntentExecutorHeaderOverrideRequests(): UseDeviceIntentExecutorHeaderOverrideRequestsReturn {
+  const [hasHeaderOverride, setHasHeaderOverride] = useState(false);
+  const requestsRef = useRef(new Set<number>());
+  const nextRequestIdRef = useRef(0);
+
+  const requestHeaderOverride = useCallback<
+    DeviceIntentExecutorHeaderContextValue["requestHeaderOverride"]
+  >(() => {
+    const requestId = nextRequestIdRef.current;
+    nextRequestIdRef.current += 1;
+    requestsRef.current.add(requestId);
+    setHasHeaderOverride(true);
+
+    return () => {
+      requestsRef.current.delete(requestId);
+      setHasHeaderOverride(requestsRef.current.size > 0);
+    };
+  }, []);
+
+  const headerContextValue = useMemo<DeviceIntentExecutorHeaderContextValue>(
+    () => ({ requestHeaderOverride }),
+    [requestHeaderOverride],
+  );
+
+  return {
+    hasHeaderOverride,
+    headerContextValue,
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/index.tsx
@@ -10,11 +10,13 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { DeviceDisconnected } from "./components/DeviceDisconnected";
 import { IntentError } from "./components/IntentError";
 import { InvalidOperation } from "./components/InvalidOperation";
+import { OverrideDeviceIntentExecutorHeader } from "./components/OverrideDeviceIntentExecutorHeader";
 import DeviceConnectionComponentLWM from "./DeviceConnectionComponentLWM";
 import DeviceContextInitializerComponentLWM, {
   InitializerConfig,
 } from "./DeviceContextInitializerComponentLWM";
 import { SourceFlowProvider, type SourceFlow } from "./utils/SourceFlowContext";
+import { DeviceIntentExecutorHeaderContext } from "./utils/DeviceIntentExecutorHeaderContext";
 import type { InitializationInput } from "./types";
 import { useDeviceIntentExecutorLWMViewModel } from "./useDeviceIntentExecutorLWMViewModel";
 
@@ -24,6 +26,7 @@ export {
 } from "./DeviceContextInitializerComponentLWM/utils/buildDeviceInitializationInput";
 export type { InitializationInput } from "./types";
 export type { SourceFlow } from "./utils/SourceFlowContext";
+export { OverrideDeviceIntentExecutorHeader };
 
 type Props<JobState, Input, ExtraProps> = DeviceIntentExecutorProps<
   JobState,
@@ -53,7 +56,8 @@ export function DeviceIntentExecutorLWM<JobState, Input, ExtraProps>(
   props: Props<JobState, Input, ExtraProps>,
 ): React.ReactElement {
   const { bottom: bottomInset } = useSafeAreaInsets();
-  const { sourceFlow, wrappedProps } = useDeviceIntentExecutorLWMViewModel(props);
+  const { sourceFlow, wrappedProps, hasHeaderOverride, headerContextValue } =
+    useDeviceIntentExecutorLWMViewModel(props);
 
   return (
     <QueuedDrawerBottomSheet
@@ -64,14 +68,18 @@ export function DeviceIntentExecutorLWM<JobState, Input, ExtraProps>(
       enableDynamicSizing
     >
       <SourceFlowProvider value={sourceFlow}>
-        <BottomSheetView style={{ paddingBottom: bottomInset + 16 }}>
-          {wrappedProps.cancellableUI && <BottomSheetHeader density="expanded" />}
-          <DeviceIntentExecutor
-            {...wrappedProps}
-            platformConfig={platformConfig}
-            initializerConfig={wrappedProps.initializerConfig}
-          />
-        </BottomSheetView>
+        <DeviceIntentExecutorHeaderContext.Provider value={headerContextValue}>
+          <BottomSheetView style={{ paddingBottom: bottomInset + 16 }}>
+            {wrappedProps.cancellableUI && !hasHeaderOverride && (
+              <BottomSheetHeader density="expanded" />
+            )}
+            <DeviceIntentExecutor
+              {...wrappedProps}
+              platformConfig={platformConfig}
+              initializerConfig={wrappedProps.initializerConfig}
+            />
+          </BottomSheetView>
+        </DeviceIntentExecutorHeaderContext.Provider>
       </SourceFlowProvider>
     </QueuedDrawerBottomSheet>
   );

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.ts
@@ -15,6 +15,8 @@ import {
 } from "./utils/trackDeviceIntent";
 import type { InitializerConfig } from "./DeviceContextInitializerComponentLWM";
 import type { InitializationInput } from "./types";
+import { useDeviceIntentExecutorHeaderOverrideRequests } from "./hooks/useDeviceIntentExecutorHeaderOverrideRequests";
+import type { DeviceIntentExecutorHeaderContextValue } from "./utils/DeviceIntentExecutorHeaderContext";
 import type { SourceFlow } from "./utils/SourceFlowContext";
 
 type Props<JobState, Input, ExtraProps> = DeviceIntentExecutorProps<
@@ -30,6 +32,8 @@ type Props<JobState, Input, ExtraProps> = DeviceIntentExecutorProps<
 export type DeviceIntentExecutorLWMViewModel<JobState, Input, ExtraProps> = {
   sourceFlow: SourceFlow;
   wrappedProps: Props<JobState, Input, ExtraProps>;
+  hasHeaderOverride: boolean;
+  headerContextValue: DeviceIntentExecutorHeaderContextValue;
 };
 
 type ConnectionTrackingInfo = {
@@ -52,6 +56,7 @@ export function useDeviceIntentExecutorLWMViewModel<JobState, Input, ExtraProps>
   const flowStartedRef = useRef(false);
   const initializationCompletedRef = useRef(false);
   const closeTrackedRef = useRef(false);
+  const { hasHeaderOverride, headerContextValue } = useDeviceIntentExecutorHeaderOverrideRequests();
 
   useEffect(() => {
     if (!enabled) {
@@ -93,6 +98,8 @@ export function useDeviceIntentExecutorLWMViewModel<JobState, Input, ExtraProps>
 
   return {
     sourceFlow,
+    hasHeaderOverride,
+    headerContextValue,
     wrappedProps: {
       ...props,
       onExecutorStateChanged: wrappedOnExecutorStateChanged,

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/DeviceIntentExecutorHeaderContext.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/DeviceIntentExecutorHeaderContext.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+type CleanupDeviceIntentExecutorHeaderOverride = () => void;
+
+export type DeviceIntentExecutorHeaderContextValue = Readonly<{
+  requestHeaderOverride: () => CleanupDeviceIntentExecutorHeaderOverride;
+}>;
+
+export const DeviceIntentExecutorHeaderContext = React.createContext<
+  DeviceIntentExecutorHeaderContextValue | undefined
+>(undefined);

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/intents/getAddressLegacyWithDeviceDemoIntent/componentLWM.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/intents/getAddressLegacyWithDeviceDemoIntent/componentLWM.tsx
@@ -1,5 +1,7 @@
 import React from "react";
+import { BottomSheetHeader } from "@ledgerhq/lumen-ui-rnative";
 import { Text, Flex } from "@ledgerhq/native-ui";
+import { OverrideDeviceIntentExecutorHeader } from "LLM/components/DeviceIntentExecutor";
 import type {
   GetAddressLegacyWithDeviceDemoIntentExtraProps,
   GetAddressLegacyWithDeviceDemoIntentJobState,
@@ -13,26 +15,31 @@ export function GetAddressLegacyWithDeviceDemoIntentComponentLWM({
   onClose: () => void;
 }) {
   return (
-    <Flex p={4}>
-      {jobState?.type === "gotTransport" ? (
-        <Text variant="h5">Got transport (legacy withDevice)</Text>
-      ) : jobState?.type === "deriving" ? (
-        <Text variant="h5">Deriving address (legacy withDevice)…</Text>
-      ) : jobState?.type === "completed" ? (
-        <>
-          <Text variant="body" color="success.c60" mb={2}>
-            Address derived (legacy withDevice)
+    <>
+      <OverrideDeviceIntentExecutorHeader>
+        <BottomSheetHeader title="Legacy address intent" density="compact" />
+      </OverrideDeviceIntentExecutorHeader>
+      <Flex p={4}>
+        {jobState?.type === "gotTransport" ? (
+          <Text variant="h5">Got transport (legacy withDevice)</Text>
+        ) : jobState?.type === "deriving" ? (
+          <Text variant="h5">Deriving address (legacy withDevice)…</Text>
+        ) : jobState?.type === "completed" ? (
+          <>
+            <Text variant="body" color="success.c60" mb={2}>
+              Address derived (legacy withDevice)
+            </Text>
+            <Text variant="small" fontFamily="monospace" color="neutral.c70" numberOfLines={2}>
+              {jobState.address}
+            </Text>
+          </>
+        ) : jobState?.type === "failed" ? (
+          <Text variant="body" color="error.c60">
+            Failed (legacy withDevice):{" "}
+            {jobState.error instanceof Error ? jobState.error.message : String(jobState.error)}
           </Text>
-          <Text variant="small" fontFamily="monospace" color="neutral.c70" numberOfLines={2}>
-            {jobState.address}
-          </Text>
-        </>
-      ) : jobState?.type === "failed" ? (
-        <Text variant="body" color="error.c60">
-          Failed (legacy withDevice):{" "}
-          {jobState.error instanceof Error ? jobState.error.message : String(jobState.error)}
-        </Text>
-      ) : null}
-    </Flex>
+        ) : null}
+      </Flex>
+    </>
   );
 }

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/intents/getEthAddressDMKSignerDemoIntent/componentLWM.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/intents/getEthAddressDMKSignerDemoIntent/componentLWM.tsx
@@ -1,5 +1,7 @@
 import React from "react";
+import { BottomSheetHeader } from "@ledgerhq/lumen-ui-rnative";
 import { Text, Flex } from "@ledgerhq/native-ui";
+import { OverrideDeviceIntentExecutorHeader } from "LLM/components/DeviceIntentExecutor";
 import type {
   GetEthAddressDMKSignerDemoIntentExtraProps,
   GetEthAddressDMKSignerDemoIntentJobState,
@@ -13,36 +15,41 @@ export function GetEthAddressDMKSignerDemoIntentComponentLWM({
   onClose: () => void;
 }) {
   return (
-    <Flex p={4}>
-      {jobState?.type === "deriving" ? (
-        <>
-          <Text variant="h5" mb={4}>
-            Deriving ETH address (DMK Signer)…
-          </Text>
-          <Text variant="small" color="neutral.c70" mb={2}>
-            Status: {jobState.daStatus}
-          </Text>
-          {jobState.userInteraction && (
-            <Text variant="small" color="neutral.c70" mb={1}>
-              User interaction: {jobState.userInteraction}
+    <>
+      <OverrideDeviceIntentExecutorHeader>
+        <BottomSheetHeader title="DMK signer address intent" density="compact" />
+      </OverrideDeviceIntentExecutorHeader>
+      <Flex p={4}>
+        {jobState?.type === "deriving" ? (
+          <>
+            <Text variant="h5" mb={4}>
+              Deriving ETH address (DMK Signer)…
             </Text>
-          )}
-        </>
-      ) : jobState?.type === "derived" ? (
-        <>
-          <Text variant="body" color="success.c60" mb={2}>
-            ETH address derived (DMK Signer)
+            <Text variant="small" color="neutral.c70" mb={2}>
+              Status: {jobState.daStatus}
+            </Text>
+            {jobState.userInteraction && (
+              <Text variant="small" color="neutral.c70" mb={1}>
+                User interaction: {jobState.userInteraction}
+              </Text>
+            )}
+          </>
+        ) : jobState?.type === "derived" ? (
+          <>
+            <Text variant="body" color="success.c60" mb={2}>
+              ETH address derived (DMK Signer)
+            </Text>
+            <Text variant="small" fontFamily="monospace" color="neutral.c70" numberOfLines={2}>
+              {jobState.address}
+            </Text>
+          </>
+        ) : jobState?.type === "failed" ? (
+          <Text variant="body" color="error.c60">
+            Failed (DMK Signer):{" "}
+            {jobState.error instanceof Error ? jobState.error.message : String(jobState.error)}
           </Text>
-          <Text variant="small" fontFamily="monospace" color="neutral.c70" numberOfLines={2}>
-            {jobState.address}
-          </Text>
-        </>
-      ) : jobState?.type === "failed" ? (
-        <Text variant="body" color="error.c60">
-          Failed (DMK Signer):{" "}
-          {jobState.error instanceof Error ? jobState.error.message : String(jobState.error)}
-        </Text>
-      ) : null}
-    </Flex>
+        ) : null}
+      </Flex>
+    </>
   );
 }

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/intents/initializationEchoIntent/componentLWM.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/intents/initializationEchoIntent/componentLWM.tsx
@@ -1,5 +1,7 @@
 import React from "react";
+import { BottomSheetHeader } from "@ledgerhq/lumen-ui-rnative";
 import { Text, Flex } from "@ledgerhq/native-ui";
+import { OverrideDeviceIntentExecutorHeader } from "LLM/components/DeviceIntentExecutor";
 import type { InitializationEchoIntentJobState } from "./types";
 
 export function InitializationEchoIntentComponentLWM({
@@ -10,24 +12,26 @@ export function InitializationEchoIntentComponentLWM({
   onClose: () => void;
 }>) {
   return (
-    <Flex p={4}>
-      <Text variant="subtitle" mb={2}>
-        Initialization Echo
-      </Text>
-      {jobState?.type === "contextReceived" ? (
-        <>
-          <Text variant="small" color="neutral.c70" mb={2}>
-            Device context received by the intent job:
+    <>
+      <OverrideDeviceIntentExecutorHeader>
+        <BottomSheetHeader title="Initialization Echo" density="compact" />
+      </OverrideDeviceIntentExecutorHeader>
+      <Flex p={4}>
+        {jobState?.type === "contextReceived" ? (
+          <>
+            <Text variant="small" color="neutral.c70" mb={2}>
+              Device context received by the intent job:
+            </Text>
+            <Text variant="small" fontFamily="monospace" color="neutral.c70">
+              {JSON.stringify(jobState.deviceExtractedContext, null, 2)}
+            </Text>
+          </>
+        ) : (
+          <Text variant="small" color="neutral.c70">
+            Waiting for initialization to complete...
           </Text>
-          <Text variant="small" fontFamily="monospace" color="neutral.c70">
-            {JSON.stringify(jobState.deviceExtractedContext, null, 2)}
-          </Text>
-        </>
-      ) : (
-        <Text variant="small" color="neutral.c70">
-          Waiting for initialization to complete...
-        </Text>
-      )}
-    </Flex>
+        )}
+      </Flex>
+    </>
   );
 }

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/intents/timerDemoIntent/componentLWM.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/intents/timerDemoIntent/componentLWM.tsx
@@ -1,5 +1,7 @@
 import React from "react";
+import { BottomSheetHeader } from "@ledgerhq/lumen-ui-rnative";
 import { Text, Flex } from "@ledgerhq/native-ui";
+import { OverrideDeviceIntentExecutorHeader } from "LLM/components/DeviceIntentExecutor";
 import type { TimerDemoIntentExtraProps, TimerDemoIntentJobState } from "./types";
 
 export function TimerDemoIntentComponentLWM({
@@ -10,11 +12,16 @@ export function TimerDemoIntentComponentLWM({
   onClose: () => void;
 }) {
   return (
-    <Flex p={4}>
-      <Text variant="body">
-        Timer intent —{" "}
-        {jobState?.type === "tick" ? `tick ${jobState.count}/${jobState.total}` : "starting…"}
-      </Text>
-    </Flex>
+    <>
+      <OverrideDeviceIntentExecutorHeader>
+        <BottomSheetHeader title="Timer intent" density="compact" />
+      </OverrideDeviceIntentExecutorHeader>
+      <Flex p={4}>
+        <Text variant="body">
+          Timer intent —{" "}
+          {jobState?.type === "tick" ? `tick ${jobState.count}/${jobState.total}` : "starting…"}
+        </Text>
+      </Flex>
+    </>
   );
 }

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/intents/uninstallAppDemoIntent/componentLWM.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/intents/uninstallAppDemoIntent/componentLWM.tsx
@@ -1,5 +1,7 @@
 import React from "react";
+import { BottomSheetHeader } from "@ledgerhq/lumen-ui-rnative";
 import { Text, Flex, Button } from "@ledgerhq/native-ui";
+import { OverrideDeviceIntentExecutorHeader } from "LLM/components/DeviceIntentExecutor";
 import type { UninstallAppDemoIntentExtraProps, UninstallAppDemoIntentJobState } from "./types";
 
 export function UninstallAppDemoIntentComponentLWM({
@@ -11,42 +13,47 @@ export function UninstallAppDemoIntentComponentLWM({
   onClose: () => void;
 }) {
   return (
-    <Flex p={4} alignItems="center">
-      {jobState?.type === "promptUninstall" ? (
-        <>
-          <Text variant="subtitle" mb={2}>
-            Uninstall {extraProps.appName}?
-          </Text>
-          <Flex flexDirection="row" columnGap={12}>
-            <Button size="small" type="main" onPress={jobState.confirm}>
-              Start
-            </Button>
-            <Button size="small" type="shade" onPress={jobState.skip}>
-              Skip
-            </Button>
-          </Flex>
-        </>
-      ) : jobState?.type === "uninstalling" ? (
-        <>
-          <Text variant="h5" mb={4}>
-            Uninstalling {extraProps.appName}…
-          </Text>
-          {jobState.userInteraction && (
-            <Text variant="small" color="neutral.c70" mb={1}>
-              User interaction: {jobState.userInteraction}
+    <>
+      <OverrideDeviceIntentExecutorHeader>
+        <BottomSheetHeader title={`Uninstall ${extraProps.appName} intent`} density="compact" />
+      </OverrideDeviceIntentExecutorHeader>
+      <Flex p={4} alignItems="center">
+        {jobState?.type === "promptUninstall" ? (
+          <>
+            <Text variant="subtitle" mb={2}>
+              Uninstall {extraProps.appName}?
             </Text>
-          )}
-        </>
-      ) : jobState?.type === "uninstallSuccess" ? (
-        <Text variant="body" color="success.c60">
-          {extraProps.appName} uninstalled successfully
-        </Text>
-      ) : jobState?.type === "uninstallFailed" ? (
-        <Text variant="body" color="error.c60">
-          Failed to uninstall {extraProps.appName}:{" "}
-          {jobState.error instanceof Error ? jobState.error.message : String(jobState.error)}
-        </Text>
-      ) : null}
-    </Flex>
+            <Flex flexDirection="row" columnGap={12}>
+              <Button size="small" type="main" onPress={jobState.confirm}>
+                Start
+              </Button>
+              <Button size="small" type="shade" onPress={jobState.skip}>
+                Skip
+              </Button>
+            </Flex>
+          </>
+        ) : jobState?.type === "uninstalling" ? (
+          <>
+            <Text variant="h5" mb={4}>
+              Uninstalling {extraProps.appName}…
+            </Text>
+            {jobState.userInteraction && (
+              <Text variant="small" color="neutral.c70" mb={1}>
+                User interaction: {jobState.userInteraction}
+              </Text>
+            )}
+          </>
+        ) : jobState?.type === "uninstallSuccess" ? (
+          <Text variant="body" color="success.c60">
+            {extraProps.appName} uninstalled successfully
+          </Text>
+        ) : jobState?.type === "uninstallFailed" ? (
+          <Text variant="body" color="error.c60">
+            Failed to uninstall {extraProps.appName}:{" "}
+            {jobState.error instanceof Error ? jobState.error.message : String(jobState.error)}
+          </Text>
+        ) : null}
+      </Flex>
+    </>
   );
 }

--- a/libs/device-intent/README.md
+++ b/libs/device-intent/README.md
@@ -38,6 +38,7 @@ See the [ADR: Device Intent Executor component](https://ledgerhq.atlassian.net/w
 - [Usage Guide](#usage-guide)
   - [Intent implementation checklist](#intent-implementation-checklist)
   - [Mounting the executor](#mounting-the-executor)
+  - [Custom LWM headers from intent components](#custom-lwm-headers-from-intent-components)
   - [Building the `deviceInitializationInput`](#building-the-deviceinitializationinput)
   - [Defining intents](#defining-intents)
   - [Structuring intents (single vs. multiple)](#structuring-intents-single-vs-multiple)
@@ -384,6 +385,41 @@ function MyFlowScreen({ enabled, onDone }: Props) {
   );
 }
 ```
+
+### Custom LWM headers from intent components
+
+`DeviceIntentExecutorLWM` owns the bottom sheet chrome and renders a default
+`BottomSheetHeader` for cancellable device flows. When a specific intent needs a
+more explicit title, description, or header density, its platform component can
+replace that default header by rendering `OverrideDeviceIntentExecutorHeader`.
+
+The intent component should place the override where the header should appear,
+usually at the top of its render tree. Consumers do not call the internal
+context hook directly; the override component registers itself with the LWM
+wrapper, hides the default header while it is mounted, and renders its children
+as the active header:
+
+```tsx
+import { BottomSheetHeader } from "@ledgerhq/lumen-ui-rnative";
+import { OverrideDeviceIntentExecutorHeader } from "LLM/components/DeviceIntentExecutor";
+
+function MyIntentComponent({ jobState }: Props) {
+  return (
+    <>
+      <OverrideDeviceIntentExecutorHeader>
+        <BottomSheetHeader title="Review transaction" density="compact" />
+      </OverrideDeviceIntentExecutorHeader>
+      {/* intent content */}
+    </>
+  );
+}
+```
+
+Use the normal Lumen `BottomSheetHeader` props for the desired UX
+(`density="compact"` for short orchestration steps, `density="expanded"` for
+larger standalone flows). The component is a no-op outside
+`DeviceIntentExecutorLWM`, so intent components stay reusable in tests and
+non-bottom-sheet previews.
 
 ### Building the `deviceInitializationInput`
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - DIE bottom sheet header on mobile
  - DIE debug playground (initialization + orchestration)

### 📝 Description

#### The problem

- `DeviceIntentExecutorLWM` renders a single default `BottomSheetHeader`.
- Intent components can't customise the title or density.

#### The fix

- New mobile component: `OverrideDeviceIntentExecutorHeader`.
- It registers an override via a small context owned by the LWM wrapper.
- While an override is mounted, the default header is hidden.
- On unmount, the default header comes back.

#### Usage

```tsx
<OverrideDeviceIntentExecutorHeader>
  <BottomSheetHeader title="Review transaction" density="compact" />
</OverrideDeviceIntentExecutorHeader>
```

The component is a no-op outside `DeviceIntentExecutorLWM`, so intent components stay reusable in tests and previews.

#### Also in this PR

- Initialization echo intent and orchestration demo intents now show titled headers.
- `libs/device-intent/README.md` documents the pattern under the usage guide.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31534](https://ledgerhq.atlassian.net/browse/LIVE-31534)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31534]: https://ledgerhq.atlassian.net/browse/LIVE-31534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ