### PR TITLE
[LWM] feat(llm): upgrade Datadog RN SDK to 3.5.2

### DIFF
--- a/.changeset/datadog-mobile-sdk-v3.md
+++ b/.changeset/datadog-mobile-sdk-v3.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Upgrade Datadog React Native SDK to 3.5.2 (`@datadog/mobile-react-native` and `@datadog/mobile-react-navigation`). The v3 configuration is restructured into nested `rumConfiguration` / `logsConfiguration` / `traceConfiguration` objects; the remote `llmDatadog` feature-flag params (kept in the flat v2 shape) are remapped to the v3 shape at initialization, and `startTrackingViews` now takes a `{ viewNamePredicate }` options object.

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -3,6 +3,16 @@ title = "Gitleaks Config"
 [extend]
 useDefault = true
 
+[allowlist]
+description = "CocoaPods Podfile.lock holds pod integrity checksums (SHA-1), not secrets; they match token rules by coincidence."
+condition = "AND"
+paths = [
+    '''apps/ledger-live-mobile/ios/Podfile\.lock''',
+]
+regexes = [
+    '''[0-9a-f]{40}''',
+]
+
 [[rules]]
 id = "seed-phrase"
 description = "Detected a BIP39 mnemonic seed phrase."

--- a/apps/ledger-live-mobile/ios/Podfile.lock
+++ b/apps/ledger-live-mobile/ios/Podfile.lock
@@ -69,24 +69,28 @@ PODS:
     - SwiftyRSA (~> 1.7)
     - Yoga
   - CocoaAsyncSocket (7.6.5)
-  - DatadogCore (2.27.0):
-    - DatadogInternal (= 2.27.0)
-  - DatadogCrashReporting (2.27.0):
-    - DatadogInternal (= 2.27.0)
-    - PLCrashReporter (~> 1.12.0)
-  - DatadogInternal (2.27.0)
-  - DatadogLogs (2.27.0):
-    - DatadogInternal (= 2.27.0)
-  - DatadogRUM (2.27.0):
-    - DatadogInternal (= 2.27.0)
-  - DatadogSDKReactNative (2.8.2):
+  - DatadogCore (3.11.0):
+    - DatadogInternal (= 3.11.0)
+  - DatadogCrashReporting (3.11.0):
+    - DatadogInternal (= 3.11.0)
+    - KSCrash/Filters (= 2.5.0)
+    - KSCrash/Recording (= 2.5.0)
+  - DatadogFlags (3.11.0):
+    - DatadogInternal (= 3.11.0)
+  - DatadogInternal (3.11.0)
+  - DatadogLogs (3.11.0):
+    - DatadogInternal (= 3.11.0)
+  - DatadogRUM (3.11.0):
+    - DatadogInternal (= 3.11.0)
+  - DatadogSDKReactNative (3.5.2):
     - boost
-    - DatadogCore (~> 2.27.0)
-    - DatadogCrashReporting (~> 2.27.0)
-    - DatadogLogs (~> 2.27.0)
-    - DatadogRUM (~> 2.27.0)
-    - DatadogTrace (~> 2.27.0)
-    - DatadogWebViewTracking (~> 2.27.0)
+    - DatadogCore (= 3.11.0)
+    - DatadogCrashReporting (= 3.11.0)
+    - DatadogFlags (= 3.11.0)
+    - DatadogLogs (= 3.11.0)
+    - DatadogRUM (= 3.11.0)
+    - DatadogTrace (= 3.11.0)
+    - DatadogWebViewTracking (= 3.11.0)
     - DoubleConversion
     - fast_float
     - fmt
@@ -113,11 +117,11 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - DatadogTrace (2.27.0):
-    - DatadogInternal (= 2.27.0)
-    - OpenTelemetrySwiftApi (= 1.13.1)
-  - DatadogWebViewTracking (2.27.0):
-    - DatadogInternal (= 2.27.0)
+  - DatadogTrace (3.11.0):
+    - DatadogInternal (= 3.11.0)
+    - OpenTelemetry-Swift-Api (~> 2.3.0)
+  - DatadogWebViewTracking (3.11.0):
+    - DatadogInternal (= 3.11.0)
   - DoubleConversion (1.1.6)
   - EXConstants (18.0.13):
     - ExpoModulesCore
@@ -249,34 +253,45 @@ PODS:
   - GoogleDataTransport (10.1.0):
     - nanopb (~> 3.30910.0)
     - PromisesObjC (~> 2.4)
-  - GoogleUtilities/AppDelegateSwizzler (8.1.1):
+  - GoogleUtilities/AppDelegateSwizzler (8.1.2):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Environment (8.1.1):
+  - GoogleUtilities/Environment (8.1.2):
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Logger (8.1.1):
+  - GoogleUtilities/Logger (8.1.2):
     - GoogleUtilities/Environment
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Network (8.1.1):
+  - GoogleUtilities/Network (8.1.2):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Privacy
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (8.1.1)":
+  - "GoogleUtilities/NSData+zlib (8.1.2)":
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Privacy (8.1.1)
-  - GoogleUtilities/Reachability (8.1.1):
+  - GoogleUtilities/Privacy (8.1.2)
+  - GoogleUtilities/Reachability (8.1.2):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - GoogleUtilities/UserDefaults (8.1.1):
+  - GoogleUtilities/UserDefaults (8.1.2):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
   - hermes-engine (0.81.6):
     - hermes-engine/Pre-built (= 0.81.6)
   - hermes-engine/Pre-built (0.81.6)
   - JWTDecode (3.0.1)
+  - KSCrash/Core (2.5.0)
+  - KSCrash/Filters (2.5.0):
+    - KSCrash/Recording
+    - KSCrash/RecordingCore
+    - KSCrash/ReportingCore
+  - KSCrash/Recording (2.5.0):
+    - KSCrash/RecordingCore
+  - KSCrash/RecordingCore (2.5.0):
+    - KSCrash/Core
+  - KSCrash/ReportingCore (2.5.0):
+    - KSCrash/Core
   - libwebp (1.5.0):
     - libwebp/demux (= 1.5.0)
     - libwebp/mux (= 1.5.0)
@@ -386,8 +401,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - OpenTelemetrySwiftApi (1.13.1)
-  - PLCrashReporter (1.12.0)
+  - OpenTelemetry-Swift-Api (2.3.0)
   - PromisesObjC (2.4.1)
   - RCT-Folly (2024.11.18.00):
     - boost
@@ -3587,7 +3601,7 @@ DEPENDENCIES:
   - "braze-react-native-sdk (from `../../../node_modules/.pnpm/@braze+react-native-sdk@18.0.0/node_modules/@braze/react-native-sdk`)"
   - "BVLinearGradient (from `../../../node_modules/.pnpm/react-native-linear-gradient@2.8.3_react-native_c0ed0e13938bd5be431a97f6c6df7852/node_modules/react-native-linear-gradient`)"
   - "callstack-repack (from `../../../node_modules/.pnpm/@callstack+repack@5.2.5_patch_hash=8d7db4e65c89_38ee29790d10ce342ce468b57fca2803/node_modules/@callstack/repack`)"
-  - "DatadogSDKReactNative (from `../../../node_modules/.pnpm/@datadog+mobile-react-native@2.8.2_react-native_dac9b2f3392a88191c9e162224291b30/node_modules/@datadog/mobile-react-native`)"
+  - "DatadogSDKReactNative (from `../../../node_modules/.pnpm/@datadog+mobile-react-native@3.5.2_react-native_f01feff9eb02f41eb604d8979030a79f/node_modules/@datadog/mobile-react-native`)"
   - "DoubleConversion (from `../../../node_modules/.pnpm/react-native@0.81.6_patch_hash=fbb22f6ab81c7336_12a649193cd6098ded35d7392a70864c/node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)"
   - "EXConstants (from `../../../node_modules/.pnpm/expo-constants@18.0.13_expo-modules-core@3.0.29_083180c0a5e10b2c5cb7be72cbb5cd78/node_modules/expo-constants/ios`)"
   - "EXImageLoader (from `../../../node_modules/.pnpm/expo-image-loader@6.0.0_expo-modules-core@3.0.2_d94c477aaef3a58976a7f715a0d05556/node_modules/expo-image-loader/ios`)"
@@ -3728,6 +3742,7 @@ SPEC REPOS:
     - CocoaAsyncSocket
     - DatadogCore
     - DatadogCrashReporting
+    - DatadogFlags
     - DatadogInternal
     - DatadogLogs
     - DatadogRUM
@@ -3746,13 +3761,13 @@ SPEC REPOS:
     - GoogleDataTransport
     - GoogleUtilities
     - JWTDecode
+    - KSCrash
     - libwebp
     - lottie-ios
     - MMKVCore
     - MultiplatformBleAdapter
     - nanopb
-    - OpenTelemetrySwiftApi
-    - PLCrashReporter
+    - OpenTelemetry-Swift-Api
     - PromisesObjC
     - SDWebImage
     - SDWebImageWebPCoder
@@ -3770,7 +3785,7 @@ EXTERNAL SOURCES:
   callstack-repack:
     :path: "../../../node_modules/.pnpm/@callstack+repack@5.2.5_patch_hash=8d7db4e65c89_38ee29790d10ce342ce468b57fca2803/node_modules/@callstack/repack"
   DatadogSDKReactNative:
-    :path: "../../../node_modules/.pnpm/@datadog+mobile-react-native@2.8.2_react-native_dac9b2f3392a88191c9e162224291b30/node_modules/@datadog/mobile-react-native"
+    :path: "../../../node_modules/.pnpm/@datadog+mobile-react-native@3.5.2_react-native_f01feff9eb02f41eb604d8979030a79f/node_modules/@datadog/mobile-react-native"
   DoubleConversion:
     :podspec: "../../../node_modules/.pnpm/react-native@0.81.6_patch_hash=fbb22f6ab81c7336_12a649193cd6098ded35d7392a70864c/node_modules/react-native/third-party-podspecs/DoubleConversion.podspec"
   EXConstants:
@@ -4040,14 +4055,15 @@ SPEC CHECKSUMS:
   BVLinearGradient: cb006ba232a1f3e4f341bb62c42d1098c284da70
   callstack-repack: 6de6a4d5a87bdf8f6b75e51fd32e557c9be85110
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DatadogCore: 68aee4ffcc3ea17a3b0aa527907757883fc72c84
-  DatadogCrashReporting: e6a83b143394e28c9c1cb48c5cfb18eff507b3be
-  DatadogInternal: 3c5cae6772295fd175a9de11e4747a9322aaa4e7
-  DatadogLogs: 09d6358dc7682f9d3eaea85dd418f82d2db3560c
-  DatadogRUM: 0f267df8c9c8579a291870c2bce4549587391a07
-  DatadogSDKReactNative: 8f8c7a3b52aa692af05c6c31f69f1b71a712422d
-  DatadogTrace: f46c8220c73463d09741013f385a6e27cd39185b
-  DatadogWebViewTracking: dc8376420c8686efd09d00752bc1034b639d180b
+  DatadogCore: 106d2aa8bef1a3dfb2a75723240f78cb5f8310fd
+  DatadogCrashReporting: eace5202ae63d92835718cf4a86489fdaef681a3
+  DatadogFlags: 0587c5b5db34874ce22264abc5e03102b53d3656
+  DatadogInternal: 00709affd9889ca9e8fd96e85e39ad865e651c32
+  DatadogLogs: ef98708261f8f7ba82d15360f9951d43f578163b
+  DatadogRUM: 67d130164f4a7663e05a3d02803be9e9dd1abbb7
+  DatadogSDKReactNative: 1d4b8cb88b5e37446cf96455e77625ca79d26401
+  DatadogTrace: 17f50647107755fba79fc2298bf4cb282e0efb1f
+  DatadogWebViewTracking: 1290fce6010bf65b5e0e0ffa9048b448782e469c
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   EXConstants: fce59a631a06c4151602843667f7cfe35f81e271
   EXImageLoader: 189e3476581efe3ad4d1d3fb4735b7179eb26f05
@@ -4075,9 +4091,10 @@ SPEC CHECKSUMS:
   fmt: ef0a98103bd75695e5734efe6b9016b2675ffcd5
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
-  GoogleUtilities: 4f2618a4a1e762a1ee134a1e2323bba9843e06da
+  GoogleUtilities: 766ace00c6b10d8148408f329d10c4f051931850
   hermes-engine: 7219f6e751ad6ec7f3d7ec121830ee34dae40749
   JWTDecode: 2eed97c2fa46ccaf3049a787004eedf0be474a87
+  KSCrash: 80e1e24eaefbe5134934ae11ca8d7746586bc2ed
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   lottie-ios: 8f959969761e9c45d70353667d00af0e5b9cadb3
   lottie-react-native: e542fe4b6e8eddcf893d5a8cef9f8b5c6d2f7331
@@ -4086,8 +4103,7 @@ SPEC CHECKSUMS:
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   NitroMmkv: 5d6c3a5cca0e47be9a4dd3f66262dbad0799c087
   NitroModules: d2d7b8a417d5f498ef5affa78d82113ad8c35c59
-  OpenTelemetrySwiftApi: aaee576ed961e0c348af78df58b61300e95bd104
-  PLCrashReporter: db59ef96fa3d25f3650040d02ec2798cffee75f2
+  OpenTelemetry-Swift-Api: 3d77582ab6837a63b65bf7d2eacc57d8f2595edd
   PromisesObjC: 752c3227f599e3467650e47ea36f433eeb10c273
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: d4ef510f229cea15314176aee5e3ba10064a8496

--- a/apps/ledger-live-mobile/ios/ledgerlivemobile.xcodeproj/project.pbxproj
+++ b/apps/ledger-live-mobile/ios/ledgerlivemobile.xcodeproj/project.pbxproj
@@ -387,7 +387,11 @@
 				"${PODS_CONFIGURATION_BUILD_DIR}/FirebaseRemoteConfig/FirebaseRemoteConfig_Privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/GoogleDataTransport/GoogleDataTransport_Privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/GoogleUtilities/GoogleUtilities_Privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/PLCrashReporter/PLCrashReporter.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/KSCrash/KSCrashCore.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/KSCrash/KSCrashFilters.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/KSCrash/KSCrashRecording.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/KSCrash/KSCrashRecordingCore.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/KSCrash/KSCrashReportingCore.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/PromisesObjC/FBLPromises_Privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/RCT-Folly/RCT-Folly_privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/RNCAsyncStorage/RNCAsyncStorage_resources.bundle",
@@ -423,7 +427,11 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/FirebaseRemoteConfig_Privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleDataTransport_Privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleUtilities_Privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/PLCrashReporter.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/KSCrashCore.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/KSCrashFilters.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/KSCrashRecording.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/KSCrashRecordingCore.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/KSCrashReportingCore.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/FBLPromises_Privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCT-Folly_privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RNCAsyncStorage_resources.bundle",
@@ -493,12 +501,10 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-ledgerlivemobile/Pods-ledgerlivemobile-frameworks.sh",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenTelemetrySwiftApi/OpenTelemetryApi.framework/OpenTelemetryApi",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/Pre-built/hermes.framework/hermes",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OpenTelemetryApi.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -83,8 +83,8 @@
   "dependencies": {
     "@azure/core-asynciterator-polyfill": "1.0.2",
     "@braze/react-native-sdk": "18.0.0",
-    "@datadog/mobile-react-native": "2.8.2",
-    "@datadog/mobile-react-navigation": "2.8.2",
+    "@datadog/mobile-react-native": "3.5.2",
+    "@datadog/mobile-react-navigation": "3.5.2",
     "@domain/api-currency-token": "workspace:^",
     "@domain/entity-currency-crypto": "workspace:*",
     "@features/platform-currencies": "workspace:^",

--- a/apps/ledger-live-mobile/src/datadog.ts
+++ b/apps/ledger-live-mobile/src/datadog.ts
@@ -14,7 +14,7 @@ import type {
   LogsConfigurationOptions,
 } from "@datadog/mobile-react-native";
 import type { LogEvent } from "@ledgerhq/live-common/hooks/useBroadcast";
-import type { Features } from "@ledgerhq/types-live";
+import type { Features } from "@shared/feature-flags";
 import { ScreenName } from "./const";
 import type { ViewNamePredicate } from "@datadog/mobile-react-navigation";
 import { EXCLUDED_ERROR_DESCRIPTION, EXCLUDED_LOGS_ERROR_NAME } from "./utils/constants";
@@ -93,7 +93,9 @@ export const initializeDatadogProvider = async (
       ...(resourceTracingSamplingRate !== undefined
         ? { resourceTraceSampleRate: resourceTracingSamplingRate }
         : {}),
-      ...(longTaskThresholdMs !== undefined ? { longTaskThresholdMs } : {}),
+      ...(longTaskThresholdMs !== undefined
+        ? { longTaskThresholdMs: longTaskThresholdMs === false ? 0 : longTaskThresholdMs }
+        : {}),
       ...(nativeLongTaskThresholdMs !== undefined
         ? {
             nativeLongTaskThresholdMs:

--- a/apps/ledger-live-mobile/src/datadog.ts
+++ b/apps/ledger-live-mobile/src/datadog.ts
@@ -1,14 +1,29 @@
 import Config from "react-native-config";
-import { TrackingConsent, DatadogProvider, DdLogs } from "@datadog/mobile-react-native";
-import { PartialInitializationConfiguration } from "@datadog/mobile-react-native/lib/typescript/DdSdkReactNativeConfiguration";
+import {
+  TrackingConsent,
+  DatadogProvider,
+  DdLogs,
+  BatchSize,
+  BatchProcessingLevel,
+  UploadFrequency,
+  VitalsUpdateFrequency,
+} from "@datadog/mobile-react-native";
+import type {
+  PartialInitializationConfiguration,
+  RumConfigurationOptions,
+  LogsConfigurationOptions,
+} from "@datadog/mobile-react-native";
 import type { LogEvent } from "@ledgerhq/live-common/hooks/useBroadcast";
+import type { Features } from "@ledgerhq/types-live";
 import { ScreenName } from "./const";
-import { ViewNamePredicate } from "@datadog/mobile-react-navigation";
-import { ErrorEventMapper } from "@datadog/mobile-react-native/lib/typescript/rum/eventMappers/errorEventMapper";
+import type { ViewNamePredicate } from "@datadog/mobile-react-navigation";
 import { EXCLUDED_ERROR_DESCRIPTION, EXCLUDED_LOGS_ERROR_NAME } from "./utils/constants";
 import { buildFeatureFlagTags } from "./utils/datadogUtils";
-import { ActionEventMapper } from "@datadog/mobile-react-native/lib/typescript/rum/eventMappers/actionEventMapper";
-import { LogEventMapper } from "@datadog/mobile-react-native/lib/typescript/logs/types";
+
+type DatadogRemoteParams = Features["llmDatadog"]["params"];
+type ErrorEventMapper = NonNullable<RumConfigurationOptions["errorEventMapper"]>;
+type ActionEventMapper = NonNullable<RumConfigurationOptions["actionEventMapper"]>;
+type LogEventMapper = NonNullable<LogsConfigurationOptions["logEventMapper"]>;
 
 const clientTokenVar = Config.DATADOG_CLIENT_TOKEN_VAR;
 const applicationIdVar = Config.DATADOG_APPLICATION_ID_VAR;
@@ -18,37 +33,89 @@ const applicationId = process.env[`${applicationIdVar}`] || Config[`${applicatio
 
 export const isDatadogEnabled = !!clientToken && !!applicationId && !(Config.MOCK || Config.DETOX);
 
-const baseConfig: PartialInitializationConfiguration = {
+const baseConfig = {
   clientToken,
-  applicationId,
   env: Config.DATADOG_ENV || "",
   site: Config.DATADOG_SITE || "",
-  serviceName: Config.APP_NAME || "",
+  service: Config.APP_NAME || "",
 };
 
 /**
  * Initializes the Datadog provider with the specified configuration and tracking consent.
  *
  * This function checks if Datadog is enabled via environment variables. If enabled,
- * it merges the base configuration with any remote configuration overrides and the provided
- * tracking consent, then initializes the Datadog provider.
+ * it remaps the remote feature-flag parameters (still expressed in the flat v2 shape) onto the
+ * SDK v3 nested configuration (rumConfiguration / logsConfiguration / traceConfiguration), merges
+ * them with the base configuration and the provided tracking consent, then initializes the provider.
  *
- * @param remoteConfig - Partial configuration object to override the base Datadog initialization settings.
+ * @param remoteParams - Remote feature-flag parameters (`llmDatadog.params`) overriding the base settings.
  * @param trackingConsent - The user's tracking consent status, used to configure Datadog tracking behavior.
  * @returns A promise that resolves when the Datadog provider has been initialized, or immediately if Datadog is not enabled.
  */
 export const initializeDatadogProvider = async (
-  remoteConfig: Partial<PartialInitializationConfiguration>,
+  remoteParams: DatadogRemoteParams,
   trackingConsent: TrackingConsent,
 ) => {
   if (!isDatadogEnabled) {
     return;
   }
-  await DatadogProvider.initialize({
+
+  const {
+    serviceName,
+    batchProcessingLevel,
+    batchSize,
+    uploadFrequency,
+    vitalsUpdateFrequency,
+    sessionSamplingRate,
+    resourceTracingSamplingRate,
+    longTaskThresholdMs,
+    nativeInteractionTracking,
+    nativeLongTaskThresholdMs,
+    nativeViewTracking,
+    trackBackgroundEvents,
+    trackFrustrations,
+    bundleLogsWithRum,
+    bundleLogsWithTraces,
+  } = remoteParams;
+
+  const config: PartialInitializationConfiguration = {
     ...baseConfig,
-    ...remoteConfig,
+    ...(serviceName ? { service: serviceName } : {}),
+    ...(batchProcessingLevel
+      ? { batchProcessingLevel: BatchProcessingLevel[batchProcessingLevel] }
+      : {}),
+    ...(batchSize ? { batchSize: BatchSize[batchSize] } : {}),
+    ...(uploadFrequency ? { uploadFrequency: UploadFrequency[uploadFrequency] } : {}),
     trackingConsent,
-  });
+    rumConfiguration: {
+      applicationId,
+      ...(sessionSamplingRate !== undefined ? { sessionSampleRate: sessionSamplingRate } : {}),
+      ...(resourceTracingSamplingRate !== undefined
+        ? { resourceTraceSampleRate: resourceTracingSamplingRate }
+        : {}),
+      ...(longTaskThresholdMs !== undefined ? { longTaskThresholdMs } : {}),
+      ...(nativeLongTaskThresholdMs !== undefined
+        ? {
+            nativeLongTaskThresholdMs:
+              nativeLongTaskThresholdMs === false ? 0 : nativeLongTaskThresholdMs,
+          }
+        : {}),
+      ...(nativeInteractionTracking !== undefined ? { nativeInteractionTracking } : {}),
+      ...(nativeViewTracking !== undefined ? { nativeViewTracking } : {}),
+      ...(vitalsUpdateFrequency
+        ? { vitalsUpdateFrequency: VitalsUpdateFrequency[vitalsUpdateFrequency] }
+        : {}),
+      ...(trackBackgroundEvents !== undefined ? { trackBackgroundEvents } : {}),
+      ...(trackFrustrations !== undefined ? { trackFrustrations } : {}),
+    },
+    logsConfiguration: {
+      ...(bundleLogsWithRum !== undefined ? { bundleLogsWithRum } : {}),
+      ...(bundleLogsWithTraces !== undefined ? { bundleLogsWithTraces } : {}),
+    },
+    traceConfiguration: {},
+  };
+
+  await DatadogProvider.initialize(config);
 };
 
 /**

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -80,11 +80,10 @@ import { logStartupEvent } from "LLM/utils/logStartupTime";
 import {
   TrackingConsent,
   DatadogProvider,
-  AutoInstrumentationConfiguration,
   DdSdkReactNative,
   PropagatorType,
 } from "@datadog/mobile-react-native";
-import { PartialInitializationConfiguration } from "@datadog/mobile-react-native/lib/typescript/DdSdkReactNativeConfiguration";
+import type { AutoInstrumentationConfiguration } from "@datadog/mobile-react-native";
 import {
   customActionEventMapper,
   customErrorEventMapper,
@@ -147,18 +146,22 @@ function App() {
   const suiGraphqlTransportFeatureFlag = useFeature("suiGraphqlTransport");
   const datadogAutoInstrumentation: AutoInstrumentationConfiguration = useMemo(
     () => ({
-      trackErrors: datadogFF?.params?.trackErrors ?? false,
-      trackInteractions: datadogFF?.params?.trackInteractions ?? false,
-      trackResources: datadogFF?.params?.trackResources ?? false,
-      errorEventMapper: customErrorEventMapper(!automaticBugReportingEnabled),
-      actionEventMapper: customActionEventMapper,
-      logEventMapper: customLogEventMapper,
-      firstPartyHosts: [
-        {
-          match: FIRST_PARTY_MAIN_HOST_DOMAIN,
-          propagatorTypes: [PropagatorType.DATADOG, PropagatorType.TRACECONTEXT],
-        },
-      ],
+      rumConfiguration: {
+        trackErrors: datadogFF?.params?.trackErrors ?? false,
+        trackInteractions: datadogFF?.params?.trackInteractions ?? false,
+        trackResources: datadogFF?.params?.trackResources ?? false,
+        errorEventMapper: customErrorEventMapper(!automaticBugReportingEnabled),
+        actionEventMapper: customActionEventMapper,
+        firstPartyHosts: [
+          {
+            match: FIRST_PARTY_MAIN_HOST_DOMAIN,
+            propagatorTypes: [PropagatorType.DATADOG, PropagatorType.TRACECONTEXT],
+          },
+        ],
+      },
+      logsConfiguration: {
+        logEventMapper: customLogEventMapper,
+      },
     }),
     [datadogFF?.params, automaticBugReportingEnabled],
   );
@@ -212,8 +215,7 @@ function App() {
     };
     initializeDatadogProvider(
       {
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        ...(datadogFF?.params as PartialInitializationConfiguration),
+        ...datadogFF?.params,
         ...(Config.FORCE_DATADOG_SAMPLE_RATE_100 ? { sessionSamplingRate: 100 } : {}),
       },
       isTrackingEnabled ? TrackingConsent.GRANTED : TrackingConsent.NOT_GRANTED,

--- a/apps/ledger-live-mobile/src/mvvm/utils/__tests__/logLastStartupEvents.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/utils/__tests__/logLastStartupEvents.test.ts
@@ -46,7 +46,7 @@ describe("logLastStartupEvents", () => {
     expect(DdRumReactNavigationTracking.startTrackingViews).toHaveBeenCalledTimes(1);
     expect(DdRumReactNavigationTracking.startTrackingViews).toHaveBeenCalledWith(
       navigationRef.current,
-      viewNamePredicate,
+      { viewNamePredicate },
     );
     expect(track).not.toHaveBeenCalled();
 

--- a/apps/ledger-live-mobile/src/mvvm/utils/logLastStartupEvents.ts
+++ b/apps/ledger-live-mobile/src/mvvm/utils/logLastStartupEvents.ts
@@ -31,7 +31,7 @@ export async function logLastStartupEvents(eventName: LastStartupEvent): Promise
   const otherStartupEvents = LAST_STARTUP_EVENT_VALUES.filter(e => e !== eventName);
   if (!alreadyLogged.has(eventName) && otherStartupEvents.every(e => alreadyLogged.has(e))) {
     try {
-      DdRumReactNavigationTracking.startTrackingViews(navigationRef.current, viewNamePredicate);
+      DdRumReactNavigationTracking.startTrackingViews(navigationRef.current, { viewNamePredicate });
       const [storageState] = await Promise.all([
         summarizeStorageData(),
         new Promise(resolve => setTimeout(resolve, LAST_EVENTS_BUFFER)), // Wait for potential events right after the last startup event to be logged

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1471,11 +1471,11 @@ importers:
         specifier: 18.0.0
         version: 18.0.0
       '@datadog/mobile-react-native':
-        specifier: 2.8.2
-        version: 2.8.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+        specifier: 3.5.2
+        version: 3.5.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@datadog/mobile-react-navigation':
-        specifier: 2.8.2
-        version: 2.8.2(@datadog/mobile-react-native@2.8.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+        specifier: 3.5.2
+        version: 3.5.2(@datadog/mobile-react-native@3.5.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@devtools/bindings':
         specifier: workspace:^
         version: link:../../devtools/bindings
@@ -15491,16 +15491,16 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@datadog/mobile-react-native@2.8.2':
-    resolution: {integrity: sha512-co8dCCTWCXpSUbbcXTPWbaV4sHT++NalM5BvNjtjNkKuTKdmWD9+vPa0lwk6yodIEkJyOIrRzhvVzfezh4OPlQ==}
+  '@datadog/mobile-react-native@3.5.2':
+    resolution: {integrity: sha512-u0dRLJohtBc0R3Vg8ddKiYYdY300TadP/XcIl0R/b/SmYH04nVEpXyZq3ZRW9QboX4IDi1AewVTlPK4hOH9cRg==}
     peerDependencies:
       react: 19.1.4
       react-native: '>=0.63.4 <1.0'
 
-  '@datadog/mobile-react-navigation@2.8.2':
-    resolution: {integrity: sha512-/Kr/dlvdKodDz++y4MwYCv04DKPq+MvHyz5hGCWnuSX+5a2spHKIcWLDNxgHsDzQAsjE8i1Z8+IAeRzWKuAPxw==}
+  '@datadog/mobile-react-navigation@3.5.2':
+    resolution: {integrity: sha512-BsZ7rXrT6UtuyoSJSaNJDbMtf8kcHT+wpW0C387Tzz2WCEgccJoVpA3+MjISbFiTCKnYbMnhfwXooc/Y9JBJnA==}
     peerDependencies:
-      '@datadog/mobile-react-native': ^2.0.1
+      '@datadog/mobile-react-native': ^3.0.0
       react: 19.1.4
       react-native: '>=0.63.4 <1.0'
 
@@ -22055,7 +22055,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.1.4
       react-dom: 19.1.4
-      webpack: ^5.89.0
+      webpack: '*'
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -24330,7 +24330,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: ^5.5.10
+      rxjs: '*'
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -42062,15 +42062,15 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@datadog/mobile-react-native@2.8.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)':
+  '@datadog/mobile-react-native@3.5.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)':
     dependencies:
       big-integer: 1.6.52
       react: 19.1.4
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4)
 
-  '@datadog/mobile-react-navigation@2.8.2(@datadog/mobile-react-native@2.8.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)':
+  '@datadog/mobile-react-navigation@3.5.2(@datadog/mobile-react-native@3.5.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)':
     dependencies:
-      '@datadog/mobile-react-native': 2.8.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@datadog/mobile-react-native': 3.5.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       react: 19.1.4
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4)
 
@@ -65299,7 +65299,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3(metro-transform-worker@0.83.3)
+      metro: 0.83.3
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -65423,54 +65423,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro@0.83.3(metro-transform-worker@0.83.3):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.28.5
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      accepts: 1.3.8
-      chalk: 4.1.2
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 4.4.3
-      error-stack-parser: 2.1.4
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      hermes-parser: 0.32.0
-      image-size: 1.1.1
-      invariant: 2.2.4
-      jest-worker: 29.7.0(metro@0.83.3)
-      jsc-safe-url: 0.2.4
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.3
-      metro-cache: 0.83.3
-      metro-cache-key: 0.83.3
-      metro-config: 0.83.3(metro-transform-worker@0.83.3)
-      metro-core: 0.83.3
-      metro-file-map: 0.83.3(metro@0.83.3)
-      metro-resolver: 0.83.3
-      metro-runtime: 0.83.3
-      metro-source-map: 0.83.3
-      metro-symbolicate: 0.83.3
-      metro-transform-plugins: 0.83.3
-      metro-transform-worker: 0.83.3
-      mime-types: 2.1.35
-      nullthrows: 1.1.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      throat: 5.0.0
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - metro-transform-worker
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Existing `datadog` and `logLastStartupEvents` unit tests updated and passing (12/12).
- [ ] **Impact of the changes:** Datadog RUM/Logs telemetry on **mobile only**. QA should verify, on a build with `llmDatadog` enabled, that RUM views/actions/errors and logs still reach Datadog, distributed-trace headers are still set on first-party requests, and remote-config tuning (sample rates, batch size, upload frequency) still applies.
  - RUM session/view/action/error reporting
  - Logs (`DdLogs`, broadcast success/failure)
  - First-party host trace propagation
  - Startup view tracking (`logLastStartupEvents`)

### 📝 Description

Upgrades the Datadog React Native SDK on **`apps/ledger-live-mobile` only** from `2.8.2` to the latest `3.5.2` (`@datadog/mobile-react-native` + `@datadog/mobile-react-navigation`; native pods to Datadog iOS `3.11.0`).

v3 is a major release that restructures the configuration from a flat object into nested `rumConfiguration` / `logsConfiguration` / `traceConfiguration` objects. Key migration points handled:

- `serviceName` → `service`; `sessionSamplingRate` → `rumConfiguration.sessionSampleRate`; `resourceTracingSamplingRate` → `rumConfiguration.resourceTraceSampleRate`.
- Event mappers and `firstPartyHosts` moved under `rumConfiguration`; `logEventMapper` under `logsConfiguration`.
- `DdRumReactNavigationTracking.startTrackingViews` now takes a `{ viewNamePredicate }` options object.
- The remote `llmDatadog` feature-flag params keep their **flat v2 shape** and are remapped to the v3 nested shape inside `initializeDatadogProvider`, so **no `libs/` / remote-config change is required**.
- Deep type imports (`@datadog/mobile-react-native/lib/typescript/...`) are gone in v3 (blocked by the package `exports` map); mapper types are now derived from the root-exported `RumConfigurationOptions` / `LogsConfigurationOptions`.
- Android `minSdkVersion` is already 25 (≥ 23 required by v3); no native config change needed.

Behavioural notes from the v3 changelog worth QA awareness: fatal errors are no longer duplicated as Logs; resource-trace sampling is now tied to the active RUM session; attributes are auto-sanitized/flattened. `trackWatchdogTerminations` (a `llmDatadog` flag) is not configurable through the v3 deferred-init path (default `false` = prior effective behaviour) — a follow-up can drop it from the FF type in `libs/`.

The `.gitleaks.toml` change allowlists `Podfile.lock`: the bumped CocoaPods spec checksums are SHA-1 integrity hashes that coincidentally match the `datadog-access-token` rule, not real secrets.

> [!NOTE]
> For the consumer side, `initializeDatadogProvider` now takes the raw `llmDatadog` feature-flag params (flat shape) instead of a pre-cast `PartialInitializationConfiguration`:
> ```diff
> - initializeDatadogProvider({ ...(datadogFF?.params as PartialInitializationConfiguration), ... }, consent)
> + initializeDatadogProvider({ ...datadogFF?.params, ... }, consent)
> ```

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-31897
- **ADR link (if any)**: _N/A_


