### PR TITLE
[LWD] feat(monad): add withdraw flow for desktop

### DIFF
--- a/.changeset/witty-foxes-withdraw.md
+++ b/.changeset/witty-foxes-withdraw.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add Monad withdraw flow to finalize matured undelegations from the stakes table

--- a/apps/ledger-live-desktop/src/renderer/families/evm/Delegation/Header.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/Delegation/Header.tsx
@@ -52,5 +52,6 @@ export const UnbondingHeader = () => (
     <TableLine>
       <Trans i18nKey="delegation.completionDate" />
     </TableLine>
+    <TableLine />
   </HeaderWrapper>
 );

--- a/apps/ledger-live-desktop/src/renderer/families/evm/Delegation/Row.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/Delegation/Row.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo } from "react";
 import styled from "styled-components";
 import { Trans } from "react-i18next";
+import { BigNumber } from "bignumber.js";
 import type {
   StakingAccount,
   StakingMappedDelegation,
@@ -281,18 +282,35 @@ export function Row({
 
 type UnbondingRowProps = Readonly<{
   delegation: StakingMappedUnbonding;
+  onWithdraw: (validatorAddress: string, amount: BigNumber, withdrawId?: number) => void;
   onExternalLink: (address: string) => void;
 }>;
 
 export function UnbondingRow({
-  delegation: { validator, formattedAmount, validatorAddress, validatorName, completionDate },
+  delegation: {
+    validator,
+    formattedAmount,
+    validatorAddress,
+    validatorName,
+    completionDate,
+    amount,
+    withdrawId,
+  },
+  onWithdraw,
   onExternalLink,
 }: UnbondingRowProps) {
   const date = useDateFromNow(completionDate) || "N/A";
   const name = validator?.name ?? validatorName ?? validatorAddress;
+  // Withdraw only applies to chains with an explicit finalization slot (Monad carries a
+  // withdrawId); other EVM chains auto-return funds, so no CTA there.
+  const canWithdraw = typeof withdrawId === "number" && completionDate.getTime() <= Date.now();
   const onExternalLinkClick = useCallback(
     () => onExternalLink(validatorAddress),
     [onExternalLink, validatorAddress],
+  );
+  const onWithdrawClick = useCallback(
+    () => onWithdraw(validatorAddress, amount, withdrawId),
+    [onWithdraw, validatorAddress, amount, withdrawId],
   );
   return (
     <Wrapper>
@@ -313,6 +331,9 @@ export function UnbondingRow({
         <Discreet>{formattedAmount}</Discreet>
       </Column>
       <Column>{date}</Column>
+      <Column clickable={canWithdraw} onClick={canWithdraw ? onWithdrawClick : undefined}>
+        {canWithdraw ? <Trans i18nKey="ethereum.evmStaking.withdraw.cta" /> : null}
+      </Column>
     </Wrapper>
   );
 }

--- a/apps/ledger-live-desktop/src/renderer/families/evm/Delegation/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/Delegation/index.tsx
@@ -3,6 +3,7 @@ import { useDispatch } from "LLD/hooks/redux";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
 import type { Account, TokenAccount } from "@ledgerhq/types-live";
+import { BigNumber } from "bignumber.js";
 import {
   mapDelegations,
   mapUnbondings,
@@ -104,6 +105,12 @@ const Delegation = ({ account }: { account: StakingAccount }) => {
   const onRowClaimRewards = useCallback(
     (validatorAddress: string) => {
       dispatch(openModal("MODAL_EVM_CLAIM_REWARDS", { account, validatorAddress }));
+    },
+    [account, dispatch],
+  );
+  const onWithdraw = useCallback(
+    (validatorAddress: string, amount: BigNumber, withdrawId?: number) => {
+      dispatch(openModal("MODAL_EVM_WITHDRAW", { account, validatorAddress, amount, withdrawId }));
     },
     [account, dispatch],
   );
@@ -243,6 +250,7 @@ const Delegation = ({ account }: { account: StakingAccount }) => {
             <UnbondingRow
               key={`${unbonding.validatorAddress}-${unbonding.completionDate.valueOf()}${unbonding.withdrawId !== undefined ? `-${unbonding.withdrawId}` : ""}`}
               delegation={unbonding}
+              onWithdraw={onWithdraw}
               onExternalLink={onExternalLink}
             />
           ))}

--- a/apps/ledger-live-desktop/src/renderer/families/evm/WithdrawFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/WithdrawFlowModal/Body.tsx
@@ -1,0 +1,186 @@
+import invariant from "invariant";
+import React, { useCallback, useState } from "react";
+import { compose } from "redux";
+import { connect } from "react-redux";
+import { useDispatch } from "LLD/hooks/redux";
+import { Trans, withTranslation } from "react-i18next";
+import { TFunction } from "i18next";
+import { createStructuredSelector } from "reselect";
+import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
+import Track from "~/renderer/analytics/Track";
+import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { StepId, StepProps, St } from "./types";
+import { Operation } from "@ledgerhq/types-live";
+import { Device } from "@ledgerhq/live-common/hw/actions/types";
+import { addPendingOperation } from "@ledgerhq/live-common/account/index";
+import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
+import { getCurrentDevice } from "~/renderer/reducers/devices";
+import { OpenModal, openModal } from "~/renderer/actions/modals";
+import Stepper from "~/renderer/components/Stepper";
+import StepWithdraw, { StepWithdrawFooter } from "./steps/StepWithdraw";
+import GenericStepConnectDevice from "~/renderer/modals/Send/steps/GenericStepConnectDevice";
+import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmation";
+import logger from "~/renderer/logger";
+import type { StakingAccount } from "@ledgerhq/live-common/families/evm/staking/types";
+import { isStakingAccount } from "@ledgerhq/live-common/families/evm/staking/types";
+import type { Transaction as EvmTransaction } from "@ledgerhq/coin-evm/types/index";
+import { BigNumber } from "bignumber.js";
+
+export type Data = {
+  account: StakingAccount;
+  validatorAddress: string;
+  amount: BigNumber;
+  // Monad: slot id of the matured withdrawal request to finalize via `withdraw(withdrawId)`.
+  withdrawId?: number;
+  source?: string;
+};
+
+type OwnProps = {
+  stepId: StepId;
+  onClose: () => void;
+  onChangeStepId: (a: StepId) => void;
+  params: Data;
+};
+type StateProps = {
+  t: TFunction;
+  device: Device | undefined | null;
+  openModal: OpenModal;
+};
+type Props = OwnProps & StateProps;
+
+const steps: Array<St> = [
+  {
+    id: "withdraw",
+    label: <Trans i18nKey="ethereum.evmStaking.withdraw.flow.steps.withdraw.title" />,
+    component: StepWithdraw,
+    noScroll: true,
+    footer: StepWithdrawFooter,
+  },
+  {
+    id: "connectDevice",
+    label: <Trans i18nKey="ethereum.evmStaking.withdraw.flow.steps.connectDevice.title" />,
+    component: GenericStepConnectDevice as unknown as React.ComponentType<StepProps>,
+    onBack: ({ transitionTo }: StepProps) => transitionTo("withdraw"),
+  },
+  {
+    id: "confirmation",
+    label: <Trans i18nKey="ethereum.evmStaking.withdraw.flow.steps.confirmation.title" />,
+    component: StepConfirmation,
+    footer: StepConfirmationFooter,
+  },
+];
+
+const mapStateToProps = createStructuredSelector({
+  device: getCurrentDevice,
+});
+const mapDispatchToProps = {
+  openModal,
+};
+
+const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }: Props) => {
+  const [optimisticOperation, setOptimisticOperation] = useState<Operation | null>(null);
+  const [transactionError, setTransactionError] = useState<Error | null>(null);
+  const [signed, setSigned] = useState(false);
+  const dispatch = useDispatch();
+  const { account, validatorAddress, amount, source = "Account Page" } = params;
+  const bridge = useAccountBridge<EvmTransaction>(account, undefined);
+
+  const { transaction, parentAccount, status, bridgeError, bridgePending } = useBridgeTransaction(
+    bridge,
+    () => {
+      invariant(isStakingAccount(account), "evm: account with staking resources required");
+      // STUB (LIVE-31683): bridge has no "withdraw" mode yet — self-send so the flow runs
+      // end-to-end. Replace with `mode: "withdraw"` once coin-evm supports it.
+      const baseTransaction = bridge.createTransaction(account);
+      const transaction = bridge.updateTransaction(baseTransaction, {
+        mode: "send",
+        recipient: account.freshAddress,
+        amount,
+        useAllAmount: false,
+      });
+      return {
+        account,
+        parentAccount: undefined,
+        transaction,
+      };
+    },
+  );
+
+  const handleStepChange = useCallback((e: St) => onChangeStepId(e.id), [onChangeStepId]);
+  const handleRetry = useCallback(() => {
+    setTransactionError(null);
+    onChangeStepId("withdraw");
+  }, [onChangeStepId]);
+  const handleTransactionError = useCallback((error: Error) => {
+    if (!(error instanceof UserRefusedOnDevice)) {
+      logger.critical(error);
+    }
+    setTransactionError(error);
+  }, []);
+  const handleOperationBroadcasted = useCallback(
+    (optimisticOperation: Operation) => {
+      if (!account) return;
+      dispatch(
+        updateAccountWithUpdater(account.id, account =>
+          addPendingOperation(account, optimisticOperation),
+        ),
+      );
+      setOptimisticOperation(optimisticOperation);
+      setTransactionError(null);
+    },
+    [account, dispatch],
+  );
+
+  const error = transactionError || bridgeError || status.errors.amount || status.errors.fees;
+  const errorSteps = [];
+  if (transactionError) {
+    errorSteps.push(2);
+  } else if (bridgeError) {
+    errorSteps.push(0);
+  }
+
+  const stepperProps = {
+    title: t("ethereum.evmStaking.withdraw.flow.title"),
+    device,
+    account,
+    parentAccount,
+    transaction,
+    signed,
+    stepId,
+    steps,
+    errorSteps,
+    disabledSteps: [],
+    hideBreadcrumb: !!error && stepId === "withdraw",
+    onRetry: handleRetry,
+    onStepChange: handleStepChange,
+    onClose,
+    error,
+    status,
+    optimisticOperation,
+    openModal,
+    setSigned,
+    onOperationBroadcasted: handleOperationBroadcasted,
+    onTransactionError: handleTransactionError,
+    t,
+    bridgePending,
+    source,
+    validatorAddress,
+    amount,
+  };
+
+  return (
+    <Stepper {...stepperProps}>
+      <SyncSkipUnderPriority priority={100} />
+      <Track onUnmount event="CloseModalWithdraw" />
+    </Stepper>
+  );
+};
+
+const C = compose<React.ComponentType<OwnProps>>(
+  connect(mapStateToProps, mapDispatchToProps),
+  withTranslation(),
+)(Body);
+
+export default C;

--- a/apps/ledger-live-desktop/src/renderer/families/evm/WithdrawFlowModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/WithdrawFlowModal/index.tsx
@@ -1,0 +1,44 @@
+import React, { PureComponent } from "react";
+import Modal from "~/renderer/components/Modal";
+import Body, { Data } from "./Body";
+import { StepId } from "./types";
+
+type State = {
+  stepId: StepId;
+};
+
+const INITIAL_STATE: State = {
+  stepId: "withdraw",
+};
+
+class WithdrawModal extends PureComponent<Data, State> {
+  state: State = INITIAL_STATE;
+
+  handleReset = () => this.setState({ ...INITIAL_STATE });
+
+  handleStepChange = (stepId: StepId) => this.setState({ stepId });
+
+  render() {
+    const { stepId } = this.state;
+    const isModalLocked = ["connectDevice", "confirmation"].includes(stepId);
+    return (
+      <Modal
+        name="MODAL_EVM_WITHDRAW"
+        centered
+        onHide={this.handleReset}
+        preventBackdropClick={isModalLocked}
+        width={550}
+        render={({ onClose, data }) => (
+          <Body
+            stepId={stepId}
+            onClose={onClose}
+            onChangeStepId={this.handleStepChange}
+            params={data || {}}
+          />
+        )}
+      />
+    );
+  }
+}
+
+export default WithdrawModal;

--- a/apps/ledger-live-desktop/src/renderer/families/evm/WithdrawFlowModal/steps/StepConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/WithdrawFlowModal/steps/StepConfirmation.tsx
@@ -1,0 +1,164 @@
+import React, { useEffect, useMemo } from "react";
+import { Trans } from "react-i18next";
+import styled from "styled-components";
+import { SyncOneAccountOnMount } from "@ledgerhq/live-common/bridge/react/index";
+import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import { track } from "~/renderer/analytics/segment";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import Box from "~/renderer/components/Box";
+import Button from "~/renderer/components/Button";
+import RetryButton from "~/renderer/components/RetryButton";
+import ErrorDisplay from "~/renderer/components/ErrorDisplay";
+import SuccessDisplay from "~/renderer/components/SuccessDisplay";
+import BroadcastErrorDisclaimer from "~/renderer/components/BroadcastErrorDisclaimer";
+import { OperationDetails } from "~/renderer/drawers/OperationDetails";
+import { setDrawer } from "~/renderer/drawers/Provider";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
+import { StepProps } from "../types";
+
+const Container = styled(Box).attrs(() => ({
+  alignItems: "center",
+  grow: true,
+  color: "neutral.c100",
+}))<{
+  shouldSpace?: boolean;
+}>`
+  justify-content: ${p => (p.shouldSpace ? "space-between" : "center")};
+`;
+
+function StepConfirmation({
+  optimisticOperation,
+  error,
+  signed,
+  amount,
+  source,
+  account,
+  validatorAddress,
+}: Readonly<StepProps>) {
+  const currencyId = account.currency.id;
+  const unit = useAccountUnit(account);
+
+  useEffect(() => {
+    if (optimisticOperation && validatorAddress) {
+      track("staking_completed", {
+        currency: currencyId.toUpperCase(),
+        validator: validatorAddress,
+        delegation: "withdraw",
+        flow: "stake",
+        source,
+      });
+    }
+  }, [currencyId, optimisticOperation, validatorAddress, source]);
+
+  const validatorName = useMemo(() => {
+    const validator = account.stakingResources.validators?.find(
+      v => v.validatorAddress === validatorAddress,
+    );
+    return validator?.name ?? validatorAddress;
+  }, [account.stakingResources.validators, validatorAddress]);
+
+  if (optimisticOperation) {
+    const formattedAmount = amount ? formatCurrencyUnit(unit, amount, { showCode: true }) : "";
+    return (
+      <Container>
+        <TrackPage
+          category="Withdraw Flow EVM"
+          name="Step Confirmed"
+          flow="stake"
+          action="withdraw"
+          currency={currencyId}
+        />
+        <SyncOneAccountOnMount
+          reason="transaction-flow-confirmation"
+          priority={10}
+          accountId={optimisticOperation.accountId}
+        />
+        <SuccessDisplay
+          title={
+            <Trans i18nKey="ethereum.evmStaking.withdraw.flow.steps.confirmation.success.title" />
+          }
+          description={
+            <div>
+              <Trans
+                i18nKey="ethereum.evmStaking.withdraw.flow.steps.confirmation.success.description"
+                values={{ amount: formattedAmount, validator: validatorName }}
+              >
+                <b></b>
+              </Trans>
+            </div>
+          }
+        />
+      </Container>
+    );
+  }
+
+  if (error) {
+    return (
+      <Container shouldSpace={signed}>
+        <TrackPage
+          category="Withdraw Flow EVM"
+          name="Step Confirmation Error"
+          flow="stake"
+          action="withdraw"
+          currency={currencyId}
+        />
+        {signed ? (
+          <BroadcastErrorDisclaimer
+            title={
+              <Trans i18nKey="ethereum.evmStaking.withdraw.flow.steps.confirmation.broadcastError" />
+            }
+          />
+        ) : null}
+        <ErrorDisplay error={error} withExportLogs />
+      </Container>
+    );
+  }
+
+  return null;
+}
+
+export function StepConfirmationFooter({
+  account,
+  onRetry,
+  error,
+  onClose,
+  optimisticOperation,
+}: Readonly<StepProps>) {
+  const concernedOperation = optimisticOperation
+    ? (optimisticOperation.subOperations?.[0] ?? optimisticOperation)
+    : null;
+  let footerSecondaryAction: React.ReactNode = null;
+  if (concernedOperation) {
+    footerSecondaryAction = (
+      <Button
+        primary
+        ml={2}
+        event="Withdraw EVM Step 3 View OpD Clicked"
+        onClick={() => {
+          onClose();
+          if (account) {
+            setDrawer(OperationDetails, {
+              operationId: concernedOperation.id,
+              accountId: account.id,
+            });
+          }
+        }}
+      >
+        <Trans i18nKey="ethereum.evmStaking.withdraw.flow.steps.confirmation.success.cta" />
+      </Button>
+    );
+  } else if (error) {
+    footerSecondaryAction = <RetryButton primary ml={2} onClick={onRetry} />;
+  }
+
+  return (
+    <Box horizontal alignItems="right">
+      <Button data-testid="modal-close-button" ml={2} onClick={onClose}>
+        <Trans i18nKey="common.close" />
+      </Button>
+      {footerSecondaryAction}
+    </Box>
+  );
+}
+
+export default StepConfirmation;

--- a/apps/ledger-live-desktop/src/renderer/families/evm/WithdrawFlowModal/steps/StepWithdraw.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/WithdrawFlowModal/steps/StepWithdraw.tsx
@@ -1,0 +1,107 @@
+import invariant from "invariant";
+import React, { useMemo } from "react";
+import { useTranslation, Trans } from "react-i18next";
+import styled from "styled-components";
+import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import Box from "~/renderer/components/Box";
+import Button from "~/renderer/components/Button";
+import Text from "~/renderer/components/Text";
+import Label from "~/renderer/components/Label";
+import Alert from "~/renderer/components/Alert";
+import ErrorBanner from "~/renderer/components/ErrorBanner";
+import AccountFooter from "~/renderer/modals/Send/AccountFooter";
+import EvmValidatorIcon from "~/renderer/families/evm/shared/components/EvmValidatorIcon";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
+import { StepProps } from "../types";
+
+const Container = styled(Box)`
+  border: 1px solid ${p => p.theme.colors.neutral.c40};
+  border-radius: 4px;
+`;
+
+export default function StepWithdraw({
+  account,
+  error,
+  validatorAddress,
+  amount,
+}: Readonly<StepProps>) {
+  invariant(account, "account required");
+  const { t } = useTranslation();
+  const unit = useAccountUnit(account);
+
+  const validator = useMemo(
+    () =>
+      account.stakingResources.validators?.find(v => v.validatorAddress === validatorAddress) ?? {
+        validatorAddress,
+        name: validatorAddress,
+      },
+    [account.stakingResources.validators, validatorAddress],
+  );
+
+  const formattedAmount = formatCurrencyUnit(unit, amount, { showCode: true });
+
+  return (
+    <Box flow={1}>
+      <TrackPage
+        category="Withdraw Flow EVM"
+        name="Step 1"
+        flow="stake"
+        action="withdraw"
+        currency={account.currency.id}
+      />
+      {error && <ErrorBanner error={error} />}
+      <Box mb={4}>
+        <Label>{t("ethereum.evmStaking.withdraw.flow.steps.withdraw.fields.validator")}</Label>
+        <Container horizontal alignItems="center" justifyContent="space-between" p={3}>
+          <Box horizontal alignItems="center">
+            <EvmValidatorIcon validator={validator} />
+            <Text ml={2} ff="Inter|Medium" fontSize={4} color="neutral.c100">
+              {validator.name}
+            </Text>
+          </Box>
+          <Text ff="Inter|Regular" fontSize={4} color="neutral.c80">
+            {formattedAmount}
+          </Text>
+        </Container>
+      </Box>
+      <Alert type="primary" mt={2}>
+        <Trans i18nKey="ethereum.evmStaking.withdraw.flow.steps.withdraw.warning">
+          <b></b>
+        </Trans>
+      </Alert>
+    </Box>
+  );
+}
+
+export function StepWithdrawFooter({
+  transitionTo,
+  account,
+  parentAccount,
+  onClose,
+  status,
+  bridgePending,
+  amount,
+}: Readonly<StepProps>) {
+  const { t } = useTranslation();
+  const { errors } = status;
+  const canNext = !Object.keys(errors).length && amount.gt(0);
+  return (
+    <>
+      <AccountFooter parentAccount={parentAccount} account={account} status={status} />
+      <Box horizontal>
+        <Button mr={1} onClick={onClose}>
+          {t("common.cancel")}
+        </Button>
+        <Button
+          isLoading={bridgePending}
+          disabled={!canNext}
+          primary
+          onClick={() => transitionTo("connectDevice")}
+        >
+          {t("common.continue")}
+        </Button>
+      </Box>
+    </>
+  );
+}

--- a/apps/ledger-live-desktop/src/renderer/families/evm/WithdrawFlowModal/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/WithdrawFlowModal/types.ts
@@ -1,0 +1,35 @@
+import { TFunction } from "i18next";
+import { BigNumber } from "bignumber.js";
+import { Device } from "@ledgerhq/live-common/hw/actions/types";
+import { Step } from "~/renderer/components/Stepper";
+import type { StakingAccount } from "@ledgerhq/live-common/families/evm/staking/types";
+import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-coin-framework/types";
+import { TransactionStatusCommon, Operation } from "@ledgerhq/types-live";
+import { OpenModal } from "~/renderer/actions/modals";
+
+export type StepId = "withdraw" | "connectDevice" | "confirmation";
+
+export type StepProps = {
+  t: TFunction;
+  transitionTo: (a: string) => void;
+  device: Device | undefined | null;
+  account: StakingAccount;
+  parentAccount: never;
+  onRetry: (a: void) => void;
+  onClose: () => void;
+  openModal: OpenModal;
+  optimisticOperation: Operation | undefined;
+  error: Error | undefined;
+  signed: boolean;
+  transaction: GenericTransaction | undefined | null;
+  status: TransactionStatusCommon;
+  onTransactionError: (a: Error) => void;
+  onOperationBroadcasted: (a: Operation) => void;
+  setSigned: (a: boolean) => void;
+  bridgePending: boolean;
+  source?: string;
+  validatorAddress: string;
+  amount: BigNumber;
+};
+
+export type St = Step<StepId, StepProps>;

--- a/apps/ledger-live-desktop/src/renderer/families/evm/modals.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/modals.ts
@@ -11,6 +11,8 @@ import MODAL_EVM_UNDELEGATE from "./UndelegationFlowModal";
 import { Data as UndelegationProps } from "./UndelegationFlowModal/Body";
 import MODAL_EVM_REDELEGATE from "./RedelegationFlowModal";
 import { Data as RedelegationProps } from "./RedelegationFlowModal/Body";
+import MODAL_EVM_WITHDRAW from "./WithdrawFlowModal";
+import { Data as WithdrawProps } from "./WithdrawFlowModal/Body";
 
 export type DelegationActionsModalName = "MODAL_EVM_REDELEGATE" | "MODAL_EVM_UNDELEGATE";
 
@@ -26,6 +28,7 @@ export type ModalsData = {
   MODAL_EVM_REWARDS_INFO: RewardsInfoProps;
   MODAL_EVM_UNDELEGATE: UndelegationProps;
   MODAL_EVM_REDELEGATE: RedelegationProps;
+  MODAL_EVM_WITHDRAW: WithdrawProps;
   MODAL_EVM_CLAIM_REWARDS: ClaimRewardsProps;
 };
 
@@ -36,6 +39,7 @@ const modals: MakeModalsType<ModalsData> = {
   MODAL_EVM_REWARDS_INFO,
   MODAL_EVM_UNDELEGATE,
   MODAL_EVM_REDELEGATE,
+  MODAL_EVM_WITHDRAW,
   MODAL_EVM_CLAIM_REWARDS,
 };
 

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -4396,6 +4396,33 @@
             }
           }
         }
+      },
+      "withdraw": {
+        "cta": "Withdraw",
+        "flow": {
+          "title": "Withdraw",
+          "steps": {
+            "withdraw": {
+              "title": "Withdraw",
+              "warning": "The undelegated amount has completed its timelock and will be sent back to your available balance.",
+              "fields": {
+                "validator": "Validator"
+              }
+            },
+            "connectDevice": {
+              "title": "Device"
+            },
+            "confirmation": {
+              "title": "Confirmation",
+              "success": {
+                "title": "You have successfully withdrawn your assets.",
+                "description": "<0>{{amount}}</0> were withdrawn from <0>{{validator}}</0>",
+                "cta": "View details"
+              },
+              "broadcastError": "Your transaction may have failed. Please wait a moment then check the transaction history before trying again."
+            }
+          }
+        }
       }
     }
   },


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _The withdraw transaction is currently a temporary stub (self-send) pending the bridge `mode: "withdraw"`; no automated tests added yet. The flow/UI can be validated manually._
- [x] **Impact of the changes:**
      - "Withdraw" CTA on matured Monad pending-undelegation rows (gated on `withdrawId`, so other EVM staking chains are unaffected)
      - New withdraw flow modal (info → connect device → confirmation)
      - No impact on the active-delegation table or non-Monad EVM staking chains (sei/celo)

### 📝 Description

Monad requires an explicit `withdraw` to finalize an undelegation once its timelock has elapsed. This PR adds the **desktop withdraw flow** on top of the undelegate work.

**Problem**: after undelegating on Monad, funds sit in a pending withdrawal slot and need an explicit on-chain `withdraw(withdrawId)` to return to the available balance — there was no UI for it.

**Solution**: a **"Withdraw" CTA** on each matured row of the "Pending undelegation" table (`UnbondingRow`), gated on `withdrawId !== undefined && completionDate <= now` so only Monad surfaces it. It opens a new `WithdrawFlowModal` (info → connect device → confirmation), mirroring the sibling Undelegation/Redelegation flows. `withdrawId` is threaded all the way to the modal, ready for the real call.

> ⚠️ **Stacked on `feat/monad-undelegate`** (base of this PR).
> The withdraw **transaction itself is a temporary stub** (a self-send) because the coin-evm bridge does not yet expose `mode: "withdraw"`. The single place to swap is marked `// STUB (LIVE-31683)` in `WithdrawFlowModal/Body.tsx` — `validatorAddress`, `withdrawId` and `amount` are already available there. The UI/flow is final.

### 🖼️ Screenshots

| demo |
| ----- |
| <img width="1382" height="411" alt="Screenshot 2026-06-05 at 10 37 16" src="https://github.com/user-attachments/assets/ebeafff5-d4c2-4409-8ac1-2146b9d9fe62" /><img width="564" height="475" alt="Screenshot 2026-06-05 at 10 38 21" src="https://github.com/user-attachments/assets/ffb686c5-7c7e-4fde-ad03-83f8ea251bf7" /> |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31683](https://ledgerhq.atlassian.net/browse/LIVE-31683)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-31683]: https://ledgerhq.atlassian.net/browse/LIVE-31683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ