### PR TITLE
[LWM] feat(mobile): add market category deeplink

### DIFF
--- a/.changeset/gentle-markets-route.md
+++ b/.changeset/gentle-markets-route.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add mobile market category deeplink handling

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
@@ -15,6 +15,7 @@ import type { SendFlowInitParams } from "@ledgerhq/live-common/flows/send/types"
 import type { AssetDetailNavigatorParamsList } from "LLM/features/AssetDetail/types";
 import type { AssetsNavigatorParamsList } from "LLM/features/Assets/types";
 import type { DeviceSelectionNavigatorParamsList } from "LLM/features/DeviceSelection/types";
+import type { MarketListRouteParams } from "LLM/features/Market/types";
 import type { AnalyticsNavigatorParamsList } from "LLM/features/Analytics/types";
 import type { OperationsHistoryNavigatorParamsList } from "LLM/features/OperationsHistory/types";
 import type { Web3HubStackParamList, Web3HubTabStackParamList } from "LLM/features/Web3Hub/types";
@@ -174,7 +175,7 @@ export type BaseNavigatorStackParamList = {
     onNameChange(name: string): void;
   };
   [ScreenName.MarketCurrencySelect]: undefined;
-  [ScreenName.MarketList]: undefined;
+  [ScreenName.MarketList]: MarketListRouteParams | undefined;
   [ScreenName.PortfolioOperationHistory]: undefined;
   [ScreenName.Account]: {
     account?: AccountLike;

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/LandingPagesNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/LandingPagesNavigator.ts
@@ -1,5 +1,6 @@
 import { ScreenName } from "~/const";
 import { LandingPageUseCase } from "~/dynamicContent/types";
+import type { MarketListRouteParams } from "LLM/features/Market/types";
 
 export enum InitialRange {
   Day = "day",
@@ -17,5 +18,5 @@ export type LargeMoverLandingPageParams = {
 export type LandingPagesNavigatorParamList = {
   [ScreenName.GenericLandingPage]: { useCase: LandingPageUseCase };
   [ScreenName.LargeMoverLandingPage]: LargeMoverLandingPageParams;
-  [ScreenName.MarketList]: undefined;
+  [ScreenName.MarketList]: MarketListRouteParams | undefined;
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/Navigator.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/Navigator.tsx
@@ -14,9 +14,10 @@ import {
   MarketListHeaderLeft,
   MarketListHeaderTitle,
 } from "LLM/features/Market/components/MarketListHeader";
+import type { MarketListRouteParams } from "LLM/features/Market/types";
 
 export type MarketNavigatorStackParamList = {
-  [ScreenName.MarketList]: { top100?: boolean };
+  [ScreenName.MarketList]: MarketListRouteParams | undefined;
   [ScreenName.MarketCurrencySelect]: undefined;
   [ScreenName.MarketDetail]: {
     currencyId: string;

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketScreenViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketScreenViewModel.test.ts
@@ -1,11 +1,17 @@
-import { act, renderHook } from "@tests/test-renderer";
+import { useRoute } from "@react-navigation/native";
+import { act, renderHook, withFlagOverrides } from "@tests/test-renderer";
 import { track } from "~/analytics";
-import type { State } from "~/reducers/types";
 import { createMarketAssetDisplayData } from "../../../__tests__/helpers";
 import { useMarketAssets } from "../useMarketAssets";
 import { useMarketScreenViewModel } from "../useMarketScreenViewModel";
+import { ScreenName } from "~/const";
+import type { State } from "~/reducers/types";
 
 jest.mock("~/analytics", () => ({ track: jest.fn() }));
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useRoute: jest.fn(),
+}));
 
 const openFromMarket = jest.fn();
 jest.mock("LLM/features/AssetDetail/hooks/useAssetDetailNavigation", () => ({
@@ -18,6 +24,15 @@ jest.mock("LLM/features/AssetDetail/hooks/useAssetDetailNavigation", () => ({
 
 jest.mock("../useMarketAssets");
 const mockedUseMarketAssets = jest.mocked(useMarketAssets);
+const mockedUseRoute = jest.mocked(useRoute);
+
+function mockMarketListRoute(category?: unknown) {
+  mockedUseRoute.mockReturnValue({
+    key: ScreenName.MarketList,
+    name: ScreenName.MarketList,
+    params: category === undefined ? undefined : { category },
+  });
+}
 
 function mockMarketAssets(overrides: Partial<ReturnType<typeof useMarketAssets>> = {}) {
   mockedUseMarketAssets.mockReturnValue({
@@ -31,9 +46,22 @@ function mockMarketAssets(overrides: Partial<ReturnType<typeof useMarketAssets>>
   });
 }
 
+function withAssetDiscoverability(
+  enabled: boolean,
+  baseTransform?: (state: State) => State,
+) {
+  return {
+    overrideInitialState: withFlagOverrides(
+      { lwmWallet40: { enabled: true, params: { assetDiscoverability: enabled } } },
+      baseTransform,
+    ),
+  };
+}
+
 describe("useMarketScreenViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockMarketListRoute();
     mockMarketAssets();
   });
 
@@ -185,5 +213,67 @@ describe("useMarketScreenViewModel", () => {
       category: "starred",
       starredMarketCoins: [],
     });
+  });
+
+  it("should set the market list category from a valid route param", () => {
+    mockMarketListRoute("stocks");
+
+    const { store } = renderHook(
+      () => useMarketScreenViewModel(),
+      withAssetDiscoverability(true),
+    );
+
+    expect(store.getState().marketListConfig.category).toBe("stocks");
+  });
+
+  it("should support the starred route category", () => {
+    mockMarketListRoute("starred");
+
+    const { store } = renderHook(
+      () => useMarketScreenViewModel(),
+      withAssetDiscoverability(true),
+    );
+
+    expect(store.getState().marketListConfig.category).toBe("starred");
+  });
+
+  it("should preserve the persisted category when route category is missing", () => {
+    const { store } = renderHook(
+      () => useMarketScreenViewModel(),
+      withAssetDiscoverability(true, state => ({
+        ...state,
+        marketListConfig: { ...state.marketListConfig, category: "starred" },
+      })),
+    );
+
+    expect(store.getState().marketListConfig.category).toBe("starred");
+  });
+
+  it("should preserve the persisted category when route category is invalid", () => {
+    mockMarketListRoute("unknown");
+
+    const { store } = renderHook(
+      () => useMarketScreenViewModel(),
+      withAssetDiscoverability(true, state => ({
+        ...state,
+        marketListConfig: { ...state.marketListConfig, category: "starred" },
+      })),
+    );
+
+    expect(store.getState().marketListConfig.category).toBe("starred");
+  });
+
+  it("should ignore the route category when asset discoverability is disabled", () => {
+    mockMarketListRoute("stocks");
+
+    const { store } = renderHook(
+      () => useMarketScreenViewModel(),
+      withAssetDiscoverability(false, state => ({
+        ...state,
+        marketListConfig: { ...state.marketListConfig, category: "starred" },
+      })),
+    );
+
+    expect(store.getState().marketListConfig.category).toBe("starred");
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketScreenViewModel.ts
@@ -1,11 +1,20 @@
+import { useLayoutEffect } from "react";
+import { useRoute, type RouteProp } from "@react-navigation/native";
+import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
-import { useSelector } from "~/context/hooks";
-import { starredMarketCoinsSelector } from "~/reducers/settings";
+import type { MarketNavigatorStackParamList } from "LLM/features/Market/Navigator";
+import { parseMarketListCategory } from "LLM/features/Market/utils/marketListCategory";
 import { useMarketAssetPress } from "./useMarketAssetPress";
 import { useMarketAssets } from "./useMarketAssets";
 import { type MarketCategories, useMarketCategories } from "./useMarketCategories";
 import { useMarketHighlights, type MarketHighlights } from "./useMarketHighlights";
 import { type MarketSearch, useMarketSearch } from "./useMarketSearch";
+import { ScreenName } from "~/const";
+import { useDispatch, useSelector } from "~/context/hooks";
+import { selectMarketListCategory, setMarketListCategory } from "~/reducers/market";
+import { starredMarketCoinsSelector } from "~/reducers/settings";
+
+type MarketScreenRoute = RouteProp<MarketNavigatorStackParamList, ScreenName.MarketList>;
 
 export type { MarketHighlightCard } from "./useMarketHighlights";
 
@@ -30,6 +39,11 @@ export type MarketScreenViewModel = {
 };
 
 export function useMarketScreenViewModel(): MarketScreenViewModel {
+  const dispatch = useDispatch();
+  const route = useRoute<MarketScreenRoute>();
+  const persistedCategory = useSelector(selectMarketListCategory);
+  const { shouldDisplayAssetDiscoverability } = useWalletFeaturesConfig("mobile");
+  const routeCategory = parseMarketListCategory(route.params?.category);
   const search = useMarketSearch();
   const highlights = useMarketHighlights();
   const categories = useMarketCategories();
@@ -40,6 +54,18 @@ export function useMarketScreenViewModel(): MarketScreenViewModel {
     starredMarketCoins,
   });
   const onAssetPress = useMarketAssetPress();
+
+  useLayoutEffect(() => {
+    if (
+      !shouldDisplayAssetDiscoverability ||
+      !routeCategory ||
+      routeCategory === persistedCategory
+    ) {
+      return;
+    }
+
+    dispatch(setMarketListCategory(routeCategory));
+  }, [dispatch, persistedCategory, routeCategory, shouldDisplayAssetDiscoverability]);
 
   return {
     search: {

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/types.ts
@@ -1,0 +1,6 @@
+import type { MarketListCategory } from "~/reducers/types";
+
+export type MarketListRouteParams = {
+  top100?: boolean;
+  category?: MarketListCategory;
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/utils/marketListCategory.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/utils/marketListCategory.ts
@@ -1,0 +1,13 @@
+import type { MarketListCategory } from "~/reducers/types";
+
+const MARKET_LIST_CATEGORIES = new Set<MarketListCategory>(["all", "starred", "stocks"]);
+
+export function parseMarketListCategory(category: unknown): MarketListCategory | undefined {
+  if (typeof category !== "string") {
+    return undefined;
+  }
+
+  const normalizedCategory = category.trim().toLowerCase() as MarketListCategory;
+
+  return MARKET_LIST_CATEGORIES.has(normalizedCategory) ? normalizedCategory : undefined;
+}

--- a/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
+++ b/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
@@ -45,6 +45,7 @@ import {
   validateLargeMoverCurrencyIds,
   validateLargeMoverLedgerIds,
   validateMarketCurrencyId,
+  validateMarketListCategory,
 } from "./deeplinks/validation";
 import { handleWallet40Deeplink } from "./deeplinks/handleWallet40Deeplink";
 import { handleMarketBannerDeeplink } from "./deeplinks/handleMarketBannerDeeplink";
@@ -357,6 +358,7 @@ export const DeeplinksProvider = ({
     shouldDisplayWallet40MainNav,
     shouldDisplayAssetSection,
     shouldDisplayAggregatedAssets,
+    shouldDisplayAssetDiscoverability,
   } = useWalletFeaturesConfig("mobile");
   const web3hubFlag = useFeature("web3hub");
   const lwmProductTourFlag = useFeature("lwmProductTour");
@@ -707,10 +709,16 @@ export const DeeplinksProvider = ({
               url.pathname = `/${validatedCurrencyId}`;
               return getStateFromPath(url.href?.split("://")[1], config);
             }
+            const validatedCategory = shouldDisplayAssetDiscoverability
+              ? validateMarketListCategory(searchParams.get("category"))
+              : undefined;
             if (shouldDisplayMarketBanner) {
-              return handleMarketBannerDeeplink();
+              return handleMarketBannerDeeplink(validatedCategory);
             }
-            return getStateFromPath("market", config);
+            return getStateFromPath(
+              validatedCategory ? `market?category=${validatedCategory}` : "market",
+              config,
+            );
           }
 
           // Handle asset deeplink - validate currencyId before navigation
@@ -920,6 +928,7 @@ export const DeeplinksProvider = ({
     shouldDisplayWallet40MainNav,
     shouldDisplayAssetSection,
     shouldDisplayAggregatedAssets,
+    shouldDisplayAssetDiscoverability,
     liveAppProviderInitialized,
     manifests,
     web3hubFlag?.enabled,

--- a/apps/ledger-live-mobile/src/navigation/deeplinks/__tests__/handleMarketBannerDeeplink.test.ts
+++ b/apps/ledger-live-mobile/src/navigation/deeplinks/__tests__/handleMarketBannerDeeplink.test.ts
@@ -25,4 +25,13 @@ describe("handleMarketBannerDeeplink", () => {
     expect(baseState?.index).toBe(1);
     expect(baseState?.routes[0]).toEqual({ name: NavigatorName.Main });
   });
+
+  it("should forward the category param to MarketList when provided", () => {
+    const result = handleMarketBannerDeeplink("stocks");
+
+    expect(result?.routes[0].state?.routes[1]).toEqual({
+      name: ScreenName.MarketList,
+      params: { category: "stocks" },
+    });
+  });
 });

--- a/apps/ledger-live-mobile/src/navigation/deeplinks/__tests__/validation.test.ts
+++ b/apps/ledger-live-mobile/src/navigation/deeplinks/__tests__/validation.test.ts
@@ -2,6 +2,7 @@ import {
   validateLargeMoverCurrencyIds,
   validateLargeMoverLedgerIds,
   validateMarketCurrencyId,
+  validateMarketListCategory,
 } from "../validation";
 
 describe("validateLargeMoverCurrencyIds", () => {
@@ -107,5 +108,25 @@ describe("validateMarketCurrencyId", () => {
   it("should normalize and return a valid currencyId", () => {
     const result = validateMarketCurrencyId("BiTcOiN");
     expect(result).toBe("bitcoin");
+  });
+});
+
+describe("validateMarketListCategory", () => {
+  it("should return undefined when category is null", () => {
+    expect(validateMarketListCategory(null)).toBeUndefined();
+  });
+
+  it("should return undefined when category is empty", () => {
+    expect(validateMarketListCategory("")).toBeUndefined();
+  });
+
+  it("should return undefined for an unknown category", () => {
+    expect(validateMarketListCategory("stable")).toBeUndefined();
+  });
+
+  it("should normalize and return a valid category", () => {
+    expect(validateMarketListCategory(" Stocks ")).toBe("stocks");
+    expect(validateMarketListCategory("STARRED")).toBe("starred");
+    expect(validateMarketListCategory("all")).toBe("all");
   });
 });

--- a/apps/ledger-live-mobile/src/navigation/deeplinks/handleMarketBannerDeeplink.ts
+++ b/apps/ledger-live-mobile/src/navigation/deeplinks/handleMarketBannerDeeplink.ts
@@ -1,4 +1,5 @@
 import { NavigatorName, ScreenName } from "~/const";
+import type { MarketListCategory } from "~/reducers/types";
 
 /**
  * Handles the `market` deeplink when the Market banner feature is active.
@@ -9,16 +10,20 @@ import { NavigatorName, ScreenName } from "~/const";
  *
  * @returns Navigation state targeting the MarketList screen
  */
-export function handleMarketBannerDeeplink(): ReturnType<
-  typeof import("@react-navigation/native").getStateFromPath
-> {
+export function handleMarketBannerDeeplink(
+  category?: MarketListCategory,
+): ReturnType<typeof import("@react-navigation/native").getStateFromPath> {
+  const marketListRoute = category
+    ? { name: ScreenName.MarketList, params: { category } }
+    : { name: ScreenName.MarketList };
+
   return {
     routes: [
       {
         name: NavigatorName.Base,
         state: {
           index: 1,
-          routes: [{ name: NavigatorName.Main }, { name: ScreenName.MarketList }],
+          routes: [{ name: NavigatorName.Main }, marketListRoute],
         },
       },
     ],

--- a/apps/ledger-live-mobile/src/navigation/deeplinks/validation.ts
+++ b/apps/ledger-live-mobile/src/navigation/deeplinks/validation.ts
@@ -8,8 +8,9 @@
 import { DdRum, ErrorSource } from "@datadog/mobile-react-native";
 import { findCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
 import { validateUrl } from "@ledgerhq/live-common/wallet-api/validation/validateUrl";
+import { parseMarketListCategory } from "LLM/features/Market/utils/marketListCategory";
 import { isDatadogEnabled } from "../../datadog";
-import type { OptionMetadata } from "../../reducers/types";
+import type { MarketListCategory, OptionMetadata } from "../../reducers/types";
 
 // Maximum allowed lengths for string parameters
 const MAX_MESSAGE_LENGTH = 700;
@@ -258,6 +259,10 @@ export function validateMarketCurrencyId(currencyId: string | null): string | nu
   const currency = findCryptoCurrencyById(normalizedCurrencyId);
 
   return currency?.id ?? null;
+}
+
+export function validateMarketListCategory(category: string | null): MarketListCategory | undefined {
+  return parseMarketListCategory(category);
 }
 
 /**


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Market deeplink routing on mobile
      - Market category pre-selection for `all`, `starred`, and `stocks`
      - Asset discoverability feature-flag fallback to the legacy MarketList

### 📝 Description

This PR allows Ledger Live Mobile Market deeplinks and navigation params to pre-select a Market category when the new asset discoverability Market screen is enabled.

It adds a shared `MarketListRouteParams` type, validates category inputs against `all`, `starred`, and `stocks`, forwards valid deeplink categories through the Market route, and syncs valid route categories into the persisted `marketListConfig` category without overriding persisted state for missing or invalid values.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30040](https://ledgerhq.atlassian.net/browse/LIVE-30040)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-30040]: https://ledgerhq.atlassian.net/browse/LIVE-30040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ