### PR TITLE
[LWM] fix(dmk): expose HTTP proxy device model metadata

### DIFF
--- a/.changeset/bright-moles-serve.md
+++ b/.changeset/bright-moles-serve.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-cli": patch
+"@ledgerhq/live-dmk-mobile": patch
+---
+
+Fix HTTP proxy device model metadata for DMK mobile transport

--- a/apps/cli/src/commands/device/proxy.ts
+++ b/apps/cli/src/commands/device/proxy.ts
@@ -5,7 +5,7 @@ import {
 } from "@ledgerhq/hw-transport-mocker";
 import Transport from "@ledgerhq/hw-transport";
 import { log, listen } from "@ledgerhq/logs";
-import { open } from "@ledgerhq/live-common/hw/index";
+import { discoverDevices, open } from "@ledgerhq/live-common/hw/index";
 import fs from "fs";
 import http from "http";
 import express from "express";
@@ -13,7 +13,8 @@ import cors from "cors";
 import WebSocket, { WebSocketServer } from "ws";
 import bodyParser from "body-parser";
 import os from "os";
-import { Observable } from "rxjs";
+import { firstValueFrom, Observable } from "rxjs";
+import { filter, timeout } from "rxjs/operators";
 import { DeviceCommonOpts, deviceOpt } from "../../scan";
 const args = [
   deviceOpt,
@@ -89,6 +90,17 @@ const job = ({
       create: () => Promise<Transport>;
     };
 
+    const getDeviceModelId = async (): Promise<string | null> => {
+      const discoveredDevice = await firstValueFrom(
+        discoverDevices(module => module.id === "hid").pipe(
+          filter(event => event.type === "add" && (!device || event.id === device)),
+          timeout(2_000),
+        ),
+      );
+
+      return discoveredDevice.deviceModel?.id ?? null;
+    };
+
     const getTransportLike = (): TransportLike => {
       return {
         open: () => open(device || ""),
@@ -151,9 +163,24 @@ const job = ({
     const wss: WebSocketServer = new WebSocket.Server({
       server,
     });
+    let pending = false;
     app.use(cors());
     app.get("/", (req: any, res: any) => {
       res.sendStatus(200);
+    });
+    app.get("/metadata", (req: any, res: any) => {
+      getDeviceModelId()
+        .then(deviceModelId =>
+          res.json({
+            deviceModelId,
+          }),
+        )
+        .catch((e: Error) =>
+          res.status(500).json({
+            error: e.message,
+            deviceModelId: null,
+          }),
+        );
     });
 
     if (recordStore) {
@@ -173,7 +200,6 @@ const job = ({
       });
     }
 
-    let pending = false;
     app.post("/", bodyParser.json(), async (req: any, res: any) => {
       if (!req.body) return res.sendStatus(400);
       let data: Buffer | null = null;

--- a/apps/cli/src/live-common-setup.ts
+++ b/apps/cli/src/live-common-setup.ts
@@ -175,6 +175,7 @@ async function init() {
         type: e.type,
         id: e.device.path,
         name: e.device.deviceName || "",
+        deviceModel: e.deviceModel,
         wired: true,
       })),
     ),

--- a/libs/live-dmk-mobile/src/transport/HttpProxyDmkTransport.test.ts
+++ b/libs/live-dmk-mobile/src/transport/HttpProxyDmkTransport.test.ts
@@ -1,4 +1,5 @@
-import { BehaviorSubject } from "rxjs";
+import { BehaviorSubject, firstValueFrom } from "rxjs";
+import { skip } from "rxjs/operators";
 import { ApduResponse, DeviceModelId, type TransportArgs } from "@ledgerhq/device-management-kit";
 import { HTTP_PROXY_TRANSPORT_IDENTIFIER, HttpProxyDmkTransport } from "./HttpProxyDmkTransport";
 
@@ -17,6 +18,13 @@ function createMockArgs(): TransportArgs {
     },
   } as unknown as TransportArgs;
 }
+
+const mockProxyMetadata = (deviceModelId: string | null = "nanoX") => {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ deviceModelId }),
+  });
+};
 
 describe("HttpProxyDmkTransport", () => {
   const url = "http://localhost:8435";
@@ -49,57 +57,45 @@ describe("HttpProxyDmkTransport", () => {
   });
 
   describe("listenToAvailableDevices", () => {
-    it("should emit the synthetic device when a URL is set", () => {
+    it("should emit the synthetic device when a URL is set", async () => {
       const transport = new HttpProxyDmkTransport(createMockArgs(), urlSubject);
-      const emitted: unknown[][] = [];
-
-      transport.listenToAvailableDevices().subscribe({ next: list => emitted.push(list) });
+      const emitted = await firstValueFrom(transport.listenToAvailableDevices());
 
       expect(emitted).toHaveLength(1);
-      expect(emitted[0]).toHaveLength(1);
-      expect((emitted[0][0] as { id: string }).id).toBe(SYNTHETIC_DEVICE_ID);
+      expect((emitted[0] as { id: string }).id).toBe(SYNTHETIC_DEVICE_ID);
     });
 
-    it("should emit an empty list when the URL is null", () => {
+    it("should emit an empty list when the URL is null", async () => {
       urlSubject.next(null);
       const transport = new HttpProxyDmkTransport(createMockArgs(), urlSubject);
-      const emitted: unknown[][] = [];
+      const emitted = await firstValueFrom(transport.listenToAvailableDevices());
 
-      transport.listenToAvailableDevices().subscribe({ next: list => emitted.push(list) });
-
-      expect(emitted).toHaveLength(1);
-      expect(emitted[0]).toHaveLength(0);
+      expect(emitted).toHaveLength(0);
     });
 
-    it("should re-emit when the URL subject changes", () => {
+    it("should re-emit when the URL subject changes", async () => {
       urlSubject.next(null);
       const transport = new HttpProxyDmkTransport(createMockArgs(), urlSubject);
-      const emitted: unknown[][] = [];
+      const nextEmission = firstValueFrom(transport.listenToAvailableDevices().pipe(skip(1)));
 
-      transport.listenToAvailableDevices().subscribe({ next: list => emitted.push(list) });
       urlSubject.next("http://other:9999");
+      const emitted = await nextEmission;
 
-      expect(emitted).toHaveLength(2);
-      expect(emitted[1]).toHaveLength(1);
-      expect((emitted[1][0] as { name: string }).name).toContain("http://other:9999");
+      expect(emitted).toHaveLength(1);
+      expect((emitted[0] as { name: string }).name).toContain("http://other:9999");
     });
   });
 
   describe("startDiscovering", () => {
-    it("should emit the synthetic device when a URL is set", () => {
+    it("should emit the synthetic device when a URL is set", async () => {
       const transport = new HttpProxyDmkTransport(createMockArgs(), urlSubject);
-      const discovered: unknown[] = [];
+      const discovered = await firstValueFrom(transport.startDiscovering());
 
-      transport.startDiscovering().subscribe({ next: d => discovered.push(d) });
-
-      expect(discovered).toHaveLength(1);
-      expect((discovered[0] as { id: string }).id).toBe(SYNTHETIC_DEVICE_ID);
-      expect((discovered[0] as { transport: string }).transport).toBe(
-        HTTP_PROXY_TRANSPORT_IDENTIFIER,
-      );
+      expect((discovered as { id: string }).id).toBe(SYNTHETIC_DEVICE_ID);
+      expect((discovered as { transport: string }).transport).toBe(HTTP_PROXY_TRANSPORT_IDENTIFIER);
     });
 
-    it("should emit nothing when the URL is null", () => {
+    it("should emit nothing when the URL is null", async () => {
       urlSubject.next(null);
       const transport = new HttpProxyDmkTransport(createMockArgs(), urlSubject);
       const discovered: unknown[] = [];
@@ -134,6 +130,38 @@ describe("HttpProxyDmkTransport", () => {
         onDisconnect: jest.fn(),
       });
       expect(result.isRight()).toBe(true);
+    });
+
+    it("should use the proxy metadata device model when connecting", async () => {
+      const args = createMockArgs();
+      mockProxyMetadata("stax");
+      const transport = new HttpProxyDmkTransport(args, urlSubject);
+
+      const result = await transport.connect({
+        deviceId: SYNTHETIC_DEVICE_ID,
+        onDisconnect: jest.fn(),
+      });
+
+      expect(result.isRight()).toBe(true);
+      expect(args.deviceModelDataSource.getDeviceModel).toHaveBeenCalledWith({
+        id: DeviceModelId.STAX,
+      });
+    });
+
+    it("should fall back to the constructor device model when metadata is unavailable", async () => {
+      const args = createMockArgs();
+      (global.fetch as jest.Mock).mockRejectedValueOnce(new Error("metadata unavailable"));
+      const transport = new HttpProxyDmkTransport(args, urlSubject, DeviceModelId.FLEX);
+
+      const result = await transport.connect({
+        deviceId: SYNTHETIC_DEVICE_ID,
+        onDisconnect: jest.fn(),
+      });
+
+      expect(result.isRight()).toBe(true);
+      expect(args.deviceModelDataSource.getDeviceModel).toHaveBeenCalledWith({
+        id: DeviceModelId.FLEX,
+      });
     });
 
     it("should return Left when the URL subject is null at connect time", async () => {
@@ -279,45 +307,69 @@ describe("HttpProxyDmkTransport", () => {
   });
 
   describe("syntheticDevice", () => {
-    it("should pass the custom deviceModelId to deviceModelDataSource.getDeviceModel", () => {
+    it("should pass the custom deviceModelId to deviceModelDataSource.getDeviceModel", async () => {
       const args = createMockArgs();
       const transport = new HttpProxyDmkTransport(args, urlSubject, DeviceModelId.FLEX);
 
-      transport.listenToAvailableDevices().subscribe({ next: () => {} });
+      await firstValueFrom(transport.listenToAvailableDevices());
 
       expect(args.deviceModelDataSource.getDeviceModel).toHaveBeenCalledWith({
         id: DeviceModelId.FLEX,
       });
     });
 
-    it("should default to NANO_X when no deviceModelId is provided", () => {
+    it("should prefer the proxy metadata device model over the constructor fallback", async () => {
+      const args = createMockArgs();
+      mockProxyMetadata("stax");
+      const transport = new HttpProxyDmkTransport(args, urlSubject, DeviceModelId.FLEX);
+
+      await firstValueFrom(transport.listenToAvailableDevices());
+
+      expect(args.deviceModelDataSource.getDeviceModel).toHaveBeenCalledWith({
+        id: DeviceModelId.STAX,
+      });
+    });
+
+    it("should default to NANO_X when no deviceModelId is provided", async () => {
       const args = createMockArgs();
       const transport = new HttpProxyDmkTransport(args, urlSubject);
 
-      transport.listenToAvailableDevices().subscribe({ next: () => {} });
+      await firstValueFrom(transport.listenToAvailableDevices());
 
       expect(args.deviceModelDataSource.getDeviceModel).toHaveBeenCalledWith({
         id: DeviceModelId.NANO_X,
       });
     });
 
-    it("should include the URL in the device name", () => {
+    it("should include the URL in the device name", async () => {
       const transport = new HttpProxyDmkTransport(createMockArgs(), urlSubject);
-      const emitted: unknown[][] = [];
+      const emitted = await firstValueFrom(transport.listenToAvailableDevices());
 
-      transport.listenToAvailableDevices().subscribe({ next: list => emitted.push(list) });
-
-      expect((emitted[0][0] as { name: string }).name).toContain(url);
+      expect((emitted[0] as { name: string }).name).toContain(url);
     });
 
-    it("should use a stable id across URL changes", () => {
+    it("should use a stable id across URL changes", async () => {
       const transport = new HttpProxyDmkTransport(createMockArgs(), urlSubject);
       const ids: string[] = [];
 
-      transport.listenToAvailableDevices().subscribe({
-        next: list => list.forEach(d => ids.push((d as { id: string }).id)),
+      await new Promise<void>((resolve, reject) => {
+        const subscription = transport.listenToAvailableDevices().subscribe({
+          next: list => {
+            list.forEach(d => ids.push((d as { id: string }).id));
+
+            if (ids.length === 1) {
+              urlSubject.next("http://other:9999");
+              return;
+            }
+
+            if (ids.length === 2) {
+              subscription.unsubscribe();
+              resolve();
+            }
+          },
+          error: reject,
+        });
       });
-      urlSubject.next("http://other:9999");
 
       expect(ids).toEqual([SYNTHETIC_DEVICE_ID, SYNTHETIC_DEVICE_ID]);
     });

--- a/libs/live-dmk-mobile/src/transport/HttpProxyDmkTransport.ts
+++ b/libs/live-dmk-mobile/src/transport/HttpProxyDmkTransport.ts
@@ -1,5 +1,5 @@
-import { BehaviorSubject, EMPTY, Observable, of } from "rxjs";
-import { map } from "rxjs/operators";
+import { BehaviorSubject, EMPTY, from, Observable, of } from "rxjs";
+import { map, switchMap } from "rxjs/operators";
 import { Either, Left, Right } from "purify-ts";
 import {
   ApduResponse,
@@ -15,9 +15,13 @@ import {
   type TransportDiscoveredDevice,
   type TransportFactory,
 } from "@ledgerhq/device-management-kit";
+import { ledgerToDmkDeviceIdMap } from "@ledgerhq/live-dmk-shared";
+import { DeviceModelId as LedgerDeviceModelId } from "@ledgerhq/types-devices";
 
 export const HTTP_PROXY_TRANSPORT_IDENTIFIER = "HTTP_PROXY_TRANSPORT";
 const SYNTHETIC_DEVICE_ID = "http-proxy-device";
+
+export const DEFAULT_HTTP_PROXY_DEVICE_MODEL_ID = DeviceModelId.NANO_X;
 
 export const httpProxyUrlSubject = new BehaviorSubject<string | null>(null);
 
@@ -28,6 +32,13 @@ const stringifyError = (err: unknown): string => {
   return JSON.stringify(err);
 };
 
+const ledgerDeviceModelIds = new Set<string>(Object.values(LedgerDeviceModelId));
+
+const isLedgerDeviceModelId = (value: unknown): value is LedgerDeviceModelId =>
+  typeof value === "string" && ledgerDeviceModelIds.has(value);
+
+const metadataUrl = (url: string): string => `${url.replace(/\/$/, "")}/metadata`;
+
 export class HttpProxyDmkTransport implements DmkTransport {
   private readonly urlSubject: BehaviorSubject<string | null>;
   private readonly deviceModelId: DeviceModelId;
@@ -36,7 +47,7 @@ export class HttpProxyDmkTransport implements DmkTransport {
   constructor(
     args: TransportArgs,
     urlSubject: BehaviorSubject<string | null>,
-    deviceModelId: DeviceModelId = DeviceModelId.NANO_X,
+    deviceModelId: DeviceModelId = DEFAULT_HTTP_PROXY_DEVICE_MODEL_ID,
   ) {
     this.args = args;
     this.urlSubject = urlSubject;
@@ -52,12 +63,16 @@ export class HttpProxyDmkTransport implements DmkTransport {
   }
 
   listenToAvailableDevices(): Observable<TransportDiscoveredDevice[]> {
-    return this.urlSubject.pipe(map(url => (url ? [this.syntheticDevice(url)] : [])));
+    return this.urlSubject.pipe(
+      switchMap(url =>
+        url ? from(this.syntheticDevice(url)).pipe(map(device => [device])) : of([]),
+      ),
+    );
   }
 
   startDiscovering(): Observable<TransportDiscoveredDevice> {
     const url = this.urlSubject.getValue();
-    return url ? of(this.syntheticDevice(url)) : EMPTY;
+    return url ? from(this.syntheticDevice(url)) : EMPTY;
   }
 
   stopDiscovering(): void {
@@ -76,6 +91,7 @@ export class HttpProxyDmkTransport implements DmkTransport {
     if (!url) {
       return Left(new UnknownDeviceError("HTTP proxy URL not set"));
     }
+    const deviceModelId = await this.resolveDeviceModelId(url);
 
     const sendApdu = async (apdu: Uint8Array): Promise<Either<DmkError, ApduResponse>> => {
       try {
@@ -91,19 +107,24 @@ export class HttpProxyDmkTransport implements DmkTransport {
         if (!resp.ok) {
           return Left(new UnknownDeviceError(`HTTP ${resp.status}`));
         }
-        const body = (await resp.json()) as { data?: string; error?: unknown };
-        if (body.error) {
-          return Left(new UnknownDeviceError(stringifyError(body.error)));
+        const body: unknown = await resp.json();
+        if (typeof body !== "object" || body === null) {
+          return Left(new UnknownDeviceError("invalid response from proxy"));
         }
-        if (!body.data) {
+        const error = "error" in body ? body.error : undefined;
+        if (error) {
+          return Left(new UnknownDeviceError(stringifyError(error)));
+        }
+        const data = "data" in body ? body.data : undefined;
+        if (typeof data !== "string" || !data) {
           return Left(new UnknownDeviceError("empty response from proxy"));
         }
-        const bytes = hexaStringToBuffer(body.data);
+        const bytes = hexaStringToBuffer(data);
         if (!bytes) {
-          return Left(new UnknownDeviceError(`invalid hex in proxy response: ${body.data}`));
+          return Left(new UnknownDeviceError(`invalid hex in proxy response: ${data}`));
         }
         if (bytes.length < 2) {
-          return Left(new UnknownDeviceError(`malformed proxy response: ${body.data}`));
+          return Left(new UnknownDeviceError(`malformed proxy response: ${data}`));
         }
         return Right(
           new ApduResponse({
@@ -121,7 +142,7 @@ export class HttpProxyDmkTransport implements DmkTransport {
 
     const connectedDevice = new TransportConnectedDevice({
       id: deviceId,
-      deviceModel: this.args.deviceModelDataSource.getDeviceModel({ id: this.deviceModelId }),
+      deviceModel: this.args.deviceModelDataSource.getDeviceModel({ id: deviceModelId }),
       type: "USB",
       transport: HTTP_PROXY_TRANSPORT_IDENTIFIER,
       sendApdu,
@@ -134,10 +155,39 @@ export class HttpProxyDmkTransport implements DmkTransport {
     return Right(undefined);
   }
 
-  private syntheticDevice(url: string): TransportDiscoveredDevice {
+  private async resolveDeviceModelId(url: string): Promise<DeviceModelId> {
+    try {
+      const response = await fetch(metadataUrl(url), {
+        method: "GET",
+        headers: {
+          Accept: "application/json",
+        },
+      });
+
+      if (response.ok) {
+        const body: unknown = await response.json();
+        const deviceModelId =
+          typeof body === "object" && body !== null && "deviceModelId" in body
+            ? body.deviceModelId
+            : null;
+
+        if (isLedgerDeviceModelId(deviceModelId)) {
+          return ledgerToDmkDeviceIdMap[deviceModelId];
+        }
+      }
+    } catch {
+      // Older proxies do not expose metadata. Keep the previous fallback.
+    }
+
+    return this.deviceModelId;
+  }
+
+  private async syntheticDevice(url: string): Promise<TransportDiscoveredDevice> {
+    const deviceModelId = await this.resolveDeviceModelId(url);
+
     return {
       id: SYNTHETIC_DEVICE_ID,
-      deviceModel: this.args.deviceModelDataSource.getDeviceModel({ id: this.deviceModelId }),
+      deviceModel: this.args.deviceModelDataSource.getDeviceModel({ id: deviceModelId }),
       transport: HTTP_PROXY_TRANSPORT_IDENTIFIER,
       name: `HTTP Proxy (${url})`,
     };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Mobile HTTP proxy connections now use the real device/simulator model instead of always assuming Nano X
  - Fixes Sei clear-signing when signing through the simulator + HTTP proxy
  - Older proxies that don't expose the new metadata keep working (fallback to Nano X)

### 📝 Description

When Ledger Live Mobile connects through the HTTP proxy (`DeviceManagementKitHTTPProxyTransport`), it always created its synthetic device as a Nano X, no matter which device or simulator was actually behind the CLI proxy.

That wrong model can break clear signing, because each device model uses its own certificates. This is why Sei delegation showed a blind-signing warning through the simulator + proxy, but worked fine on a real device over Bluetooth.

The fix: the CLI proxy now exposes the real model through a small `GET /metadata` endpoint, and the mobile transport reads it when building the proxied device. If the metadata is missing (older proxies), it falls back to the previous Nano X behavior.

```ts
GET /metadata
// { deviceModelId: "nanoX" | "nanoSP" | "stax" | "europa" | "apex" | null }
```

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1223](https://ledgerhq.atlassian.net/browse/DSDK-1223)
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[DSDK-1223]: https://ledgerhq.atlassian.net/browse/DSDK-1223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
