### PR TITLE
[LWDM] chore(cryptoassets): drop client-side token id/data remapping (LIVE-22556)

### DIFF
--- a/.changeset/cleanup-token-converter-reconciliation.md
+++ b/.changeset/cleanup-token-converter-reconciliation.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/cryptoassets": patch
+"@ledgerhq/live-common": patch
+"@ledgerhq/asset-aggregation": patch
+---
+
+Remove client-side token id/data remapping now reconciled on the backend (LIVE-22557 MultiversX, LIVE-22558 Stellar, LIVE-22561 TON Jetton). Drops the `legacyIdToApiId` helper and the related `convertApiToken` patches; ids are now consumed directly from CAL/DaDa. Cardano (LIVE-22559) and Sui (LIVE-22560) reconciliation are unchanged.

--- a/libs/asset-aggregation/src/assetDistribution/__tests__/buildAssetDistribution.test.ts
+++ b/libs/asset-aggregation/src/assetDistribution/__tests__/buildAssetDistribution.test.ts
@@ -9,11 +9,6 @@ const mockFindCryptoCurrencyById = jest.fn();
 
 jest.mock("@ledgerhq/cryptoassets", () => ({
   findCryptoCurrencyById: (...args: unknown[]) => mockFindCryptoCurrencyById(...args),
-  legacyIdToApiId: (id: string) => {
-    if (id.startsWith("stellar/asset/")) return id.toLowerCase();
-    if (id.startsWith("multiversx/esdt/")) return id.replace("multiversx/esdt/", "elrond/esdt/");
-    return id;
-  },
 }));
 
 jest.mock("@ledgerhq/live-countervalues/logic", () => ({
@@ -260,69 +255,5 @@ describe("buildAssetDistribution", () => {
     expect(result.list).toHaveLength(1);
     expect(result.list[0].metaCurrencyId).toBe("urn:crypto:meta-currency:tether");
     expect(result.list[0].amount).toBe(1_001_000);
-  });
-
-  describe("DADA id format normalization (LIVE-22557 / LIVE-22558)", () => {
-    const ethereumUsdc = makeCurrency("ethereum/erc20/usd__coin", "USD Coin");
-    const stellarUsdcMixedCase = makeCurrency(
-      "stellar/asset/USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
-      "USDC",
-    );
-    const multiversxUsdc = makeCurrency("multiversx/esdt/USDC-c76f1f", "USD Coin");
-
-    const usdCoinAssetsData: AssetsDataLike = {
-      cryptoAssets: {
-        "urn:crypto:meta-currency:usd_coin": {
-          id: "urn:crypto:meta-currency:usd_coin",
-          assetsIds: {
-            ethereum: "ethereum/erc20/usd__coin",
-            stellar: "stellar/asset/usdc:ga5zsejyb37jrc5avcia5mop4rhtm335x2kgx3ihojapp5re34k4kzvn",
-            elrond: "elrond/esdt/USDC-c76f1f",
-          },
-        },
-      },
-      markets: {},
-    };
-
-    it("should aggregate mixed-case Stellar USDC under usd_coin meta-currency", () => {
-      const result = distribute(
-        [
-          makeAccount("eth-usdc-1", ethereumUsdc, 1000),
-          makeAccount("xlm-usdc-1", stellarUsdcMixedCase, 200),
-        ],
-        undefined,
-        usdCoinAssetsData,
-      );
-
-      expect(result.list).toHaveLength(1);
-      expect(result.list[0].metaCurrencyId).toBe("urn:crypto:meta-currency:usd_coin");
-      expect(result.list[0].networks).toHaveLength(2);
-      const networkIds = result.list[0].networks!.map(n => n.currency.id).sort();
-      expect(networkIds).toEqual(
-        [
-          "ethereum/erc20/usd__coin",
-          "stellar/asset/USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
-        ].sort(),
-      );
-    });
-
-    it("should aggregate MultiversX USDC under usd_coin meta-currency (multiversx -> elrond)", () => {
-      const result = distribute(
-        [
-          makeAccount("eth-usdc-1", ethereumUsdc, 1000),
-          makeAccount("egld-usdc-1", multiversxUsdc, 500),
-        ],
-        undefined,
-        usdCoinAssetsData,
-      );
-
-      expect(result.list).toHaveLength(1);
-      expect(result.list[0].metaCurrencyId).toBe("urn:crypto:meta-currency:usd_coin");
-      expect(result.list[0].networks).toHaveLength(2);
-      const networkIds = result.list[0].networks!.map(n => n.currency.id).sort();
-      expect(networkIds).toEqual(
-        ["ethereum/erc20/usd__coin", "multiversx/esdt/USDC-c76f1f"].sort(),
-      );
-    });
   });
 });

--- a/libs/asset-aggregation/src/assetDistribution/buildAssetDistribution.ts
+++ b/libs/asset-aggregation/src/assetDistribution/buildAssetDistribution.ts
@@ -1,4 +1,4 @@
-import { findCryptoCurrencyById, legacyIdToApiId } from "@ledgerhq/cryptoassets";
+import { findCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 import type { CryptoCurrency, Currency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
@@ -100,12 +100,11 @@ export function buildAssetDistribution(
 
   for (const account of allAccounts) {
     const currency = getAccountCurrency(account);
-    const apiId = legacyIdToApiId(currency.id);
-    currencyById.set(apiId, currency);
+    currencyById.set(currency.id, currency);
 
     if (shouldSkipAccount(account, showEmptyAccounts, hideEmptyTokenAccount)) continue;
 
-    const metaCurrencyId = currencyToMetaId[apiId] ?? currency.id;
+    const metaCurrencyId = currencyToMetaId[currency.id] ?? currency.id;
     const balance = account.balance.toNumber();
 
     let group = groups.get(metaCurrencyId);
@@ -122,7 +121,7 @@ export function buildAssetDistribution(
     }
 
     group.accounts.push(account);
-    group.marketId ??= assetsData.markets[apiId]?.id;
+    group.marketId ??= assetsData.markets[currency.id]?.id;
 
     let network = group.networks.get(currency.id);
     if (!network) {

--- a/libs/ledger-live-common/src/dada-client/state-manager/__tests__/api.test.ts
+++ b/libs/ledger-live-common/src/dada-client/state-manager/__tests__/api.test.ts
@@ -56,40 +56,16 @@ const defaultArgs = {
 const baseQueryArg = { product: "lld" as const, version: "1.0.0" };
 
 describe("buildAssetsQueryParams", () => {
-  it.each([
-    {
-      scenario: "standard IDs unchanged",
-      input: ["ethereum/erc20/usdc", "ton/jetton/some_address", "bitcoin"],
-      expected: ["ethereum/erc20/usdc", "ton/jetton/some_address", "bitcoin"],
-    },
-    {
-      scenario: "Stellar lowercased",
-      input: ["stellar/asset/USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"],
-      expected: ["stellar/asset/usdc:ga5zsejyb37jrc5avcia5mop4rhtm335x2kgx3ihojapp5re34k4kzvn"],
-    },
-    {
-      scenario: "MultiversX renamed to elrond",
-      input: ["multiversx/esdt/USDC-c76f1f"],
-      expected: ["elrond/esdt/USDC-c76f1f"],
-    },
-    {
-      scenario: "mixed array transformed independently",
-      input: [
-        "ethereum/erc20/usdc",
-        "stellar/asset/USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
-        "multiversx/esdt/USDC-c76f1f",
-        "bitcoin",
-      ],
-      expected: [
-        "ethereum/erc20/usdc",
-        "stellar/asset/usdc:ga5zsejyb37jrc5avcia5mop4rhtm335x2kgx3ihojapp5re34k4kzvn",
-        "elrond/esdt/USDC-c76f1f",
-        "bitcoin",
-      ],
-    },
-  ])("should transform currencyIds: $scenario", ({ input, expected }) => {
+  it("should pass currencyIds through unchanged", () => {
+    const input = [
+      "ethereum/erc20/usdc",
+      "stellar/asset/USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+      "multiversx/esdt/USDC-c76f1f",
+      "ton/jetton/some_address",
+      "bitcoin",
+    ];
     const params = buildAssetsQueryParams({ ...baseQueryArg, currencyIds: input });
-    expect(params.currencyIds).toEqual(expected);
+    expect(params.currencyIds).toEqual(input);
   });
 
   it("should omit currencyIds when empty or not provided", () => {

--- a/libs/ledger-live-common/src/dada-client/state-manager/api.ts
+++ b/libs/ledger-live-common/src/dada-client/state-manager/api.ts
@@ -5,7 +5,7 @@ import {
   FetchBaseQueryMeta,
   QueryReturnValue,
 } from "@reduxjs/toolkit/query/react";
-import { convertApiAssets, legacyIdToApiId } from "@ledgerhq/cryptoassets";
+import { convertApiAssets } from "@ledgerhq/cryptoassets";
 import { RawApiResponse, AssetsData } from "../entities";
 import { getEnv } from "@ledgerhq/live-env";
 import {
@@ -78,8 +78,7 @@ export function buildAssetsQueryParams(
     ...(queryArg.useCase && { transaction: queryArg.useCase }),
     ...(queryArg.currencyIds &&
       queryArg.currencyIds.length > 0 && {
-        // FIXME: Transform legacy ID to API format before querying
-        currencyIds: queryArg.currencyIds.map(id => legacyIdToApiId(id)),
+        currencyIds: queryArg.currencyIds,
       }),
     ...(queryArg.search && { search: queryArg.search }),
     product: queryArg.product,

--- a/libs/ledgerjs/packages/cryptoassets/src/api-token-converter.test.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/api-token-converter.test.ts
@@ -1,97 +1,6 @@
-import { convertApiToken, legacyIdToApiId, type ApiTokenData } from "./api-token-converter";
-
-describe("legacyIdToApiId", () => {
-  it("should transform MultiversX to elrond format", () => {
-    expect(legacyIdToApiId("multiversx/esdt/USDC-c76f1f")).toBe("elrond/esdt/USDC-c76f1f");
-  });
-
-  it("should transform Stellar to lowercase", () => {
-    expect(
-      legacyIdToApiId(
-        "stellar/asset/USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
-      ),
-    ).toBe("stellar/asset/usdc:ga5zsejyb37jrc5avcia5mop4rhtm335x2kgx3ihojapp5re34k4kzvn");
-  });
-
-  it("should not transform other IDs", () => {
-    expect(legacyIdToApiId("ethereum/erc20/usdc")).toBe("ethereum/erc20/usdc");
-    expect(legacyIdToApiId("ton/jetton/test")).toBe("ton/jetton/test");
-  });
-});
+import { convertApiToken, type ApiTokenData } from "./api-token-converter";
 
 describe("convertApiToken", () => {
-  describe("MultiversX transformation", () => {
-    it("should transform elrond ID to multiversx", () => {
-      const apiToken: ApiTokenData = {
-        id: "elrond/esdt/USDC-c76f1f",
-        contractAddress: "USDC-c76f1f",
-        name: "USD Coin",
-        ticker: "USDC",
-        units: [{ code: "USDC", name: "USD Coin", magnitude: 6 }],
-        standard: "esdt",
-      };
-
-      const result = convertApiToken(apiToken);
-
-      expect(result?.id).toBe("multiversx/esdt/USDC-c76f1f");
-      expect(result?.parentCurrency?.id).toBe("elrond");
-      expect(result?.tokenType).toBe("esdt");
-    });
-  });
-
-  describe("Stellar transformation", () => {
-    it("should transform lowercase stellar to mixed-case format", () => {
-      const apiToken: ApiTokenData = {
-        id: "stellar/asset/usdc:ga5zsejyb37jrc5avcia5mop4rhtm335x2kgx3ihojapp5re34k4kzvn",
-        contractAddress: "USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
-        name: "USD Coin",
-        ticker: "USDC",
-        units: [{ code: "USDC", name: "USD Coin", magnitude: 7 }],
-        standard: "asset",
-      };
-
-      const result = convertApiToken(apiToken);
-
-      expect(result?.id).toBe(
-        "stellar/asset/USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
-      );
-      expect(result?.tokenType).toBe("stellar");
-    });
-
-    it("should keep already uppercase stellar suffix", () => {
-      const apiToken: ApiTokenData = {
-        id: "stellar/asset/USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
-        contractAddress: "USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
-        name: "USD Coin",
-        ticker: "USDC",
-        units: [{ code: "USDC", name: "USD Coin", magnitude: 7 }],
-        standard: "asset",
-      };
-
-      const result = convertApiToken(apiToken);
-
-      expect(result?.id).toBe(
-        "stellar/asset/USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
-      );
-      expect(result?.tokenType).toBe("stellar");
-    });
-
-    it("should handle stellar standard without transformation", () => {
-      const apiToken: ApiTokenData = {
-        id: "stellar/asset/USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
-        contractAddress: "USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
-        name: "USD Coin",
-        ticker: "USDC",
-        units: [{ code: "USDC", name: "USD Coin", magnitude: 7 }],
-        standard: "stellar",
-      };
-
-      const result = convertApiToken(apiToken);
-
-      expect(result?.tokenType).toBe("stellar");
-    });
-  });
-
   describe("Cardano transformation", () => {
     it("should reconstruct contractAddress from policyId + tokenIdentifier", () => {
       const apiToken: ApiTokenData = {
@@ -155,23 +64,6 @@ describe("convertApiToken", () => {
       const result = convertApiToken(apiToken);
 
       expect(result?.tokenType).toBe("coin");
-    });
-  });
-
-  describe("TON Jetton transformation", () => {
-    it("should not transform jetton ID", () => {
-      const apiToken: ApiTokenData = {
-        id: "ton/jetton/eqavlwfdxgf2lxm67y4yzc17wykd9a0guwpkms1gosm__not",
-        contractAddress: "eqavlwfdxgf2lxm67y4yzc17wykd9a0guwpkms1gosm__not",
-        name: "Test",
-        ticker: "TEST",
-        units: [{ code: "TEST", name: "Test", magnitude: 9 }],
-        standard: "jetton",
-      };
-
-      const result = convertApiToken(apiToken);
-
-      expect(result?.id).toBe("ton/jetton/eqavlwfdxgf2lxm67y4yzc17wykd9a0guwpkms1gosm__not");
     });
   });
 

--- a/libs/ledgerjs/packages/cryptoassets/src/api-token-converter.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/api-token-converter.ts
@@ -16,44 +16,13 @@ export interface ApiTokenData {
 }
 
 /**
- * Transforms Ledger Live token ID to backend API format for querying
- *
- * This handles cases where LL uses different ID conventions than backend APIs.
- * Applied BEFORE querying the API to ensure the request uses the correct format:
- *
- * - MultiversX: multiversx/esdt/* → elrond/esdt/* (API uses old name) [LIVE-22557]
- * - Stellar: UPPERCASE → lowercase (API uses lowercase) [LIVE-22558]
- *
- * @param legacyId - Token ID in Ledger Live format
- * @returns Token ID in backend API format
- */
-export function legacyIdToApiId(legacyId: string): string {
-  let apiId = legacyId;
-
-  // LIVE-22557: MultiversX - API uses old "elrond" name
-  if (apiId.startsWith("multiversx/esdt/")) {
-    apiId = apiId.replace("multiversx/esdt/", "elrond/esdt/");
-  }
-
-  // LIVE-22558: Stellar - API uses all lowercase (including the address part)
-  if (apiId.startsWith("stellar/asset/")) {
-    apiId = apiId.toLowerCase();
-  }
-
-  return apiId;
-}
-
-/**
  * Converts API token data to Ledger Live TokenCurrency format
  *
  * This function applies client-side transformations to reconcile differences between
  * backend APIs (CAL/DaDa) and Ledger Live's expected token format:
  *
- * - MultiversX: elrond/esdt/* → multiversx/esdt/* [LIVE-22557]
- * - Stellar: Normalizes casing to stellar/asset/UPPERCASE_ADDRESS and tokenType asset → stellar [LIVE-22558]
  * - Cardano: Reconstructs contractAddress from policyId + tokenIdentifier [LIVE-22559]
  * - Sui: Transforms tokenType from "coin" to "sui" [LIVE-22560]
- * - TON Jetton: Removes name prefix from ID (ton/jetton/name_address → ton/jetton/address) [LIVE-22561]
  *
  * @param apiToken - Token data from backend API
  * @returns TokenCurrency object in Ledger Live format, or undefined if parent currency not found
@@ -72,31 +41,14 @@ export function convertApiToken(apiToken: ApiTokenData): TokenCurrency | undefin
   } = apiToken;
 
   // Apply client-side patches to reconcile CAL format with LL format
-  let patchedId = id;
   let patchedContractAddress = contractAddress;
   let patchedStandard = standard;
 
-  // Get parent currency from the ORIGINAL ID (before transformation)
-  // This is important for currencies that changed names (elrond -> multiversx)
   const parentCurrencyId = id.split("/")[0];
   const parentCurrency = findCryptoCurrencyById(parentCurrencyId);
 
   if (!parentCurrency) {
     return undefined;
-  }
-
-  // LIVE-22557: MultiversX - Transform elrond/* to multiversx/*
-  if (patchedId.startsWith("elrond/esdt/")) {
-    patchedId = patchedId.replace("elrond/esdt/", "multiversx/esdt/");
-  }
-
-  // LIVE-22558: Stellar - Transform to LL mixed-case format: stellar/asset/ + UPPERCASE_REST
-  // Also fix tokenType: API returns "asset", LL expects "stellar"
-  const stellarPrefix = "stellar/asset/";
-  if (patchedId.toLowerCase().startsWith(stellarPrefix)) {
-    const rest = patchedId.substring(stellarPrefix.length);
-    patchedId = stellarPrefix + rest.toUpperCase();
-    patchedStandard = patchedStandard === "asset" ? "stellar" : patchedStandard;
   }
 
   // LIVE-22559: Cardano - Reconstruct full assetId (policyId + assetName)
@@ -105,14 +57,14 @@ export function convertApiToken(apiToken: ApiTokenData): TokenCurrency | undefin
   }
 
   // LIVE-22560: Sui - Transform "coin" standard to "sui" tokenType (LL format)
-  if (standard === "coin" && patchedId.startsWith("sui/")) {
+  if (standard === "coin" && id.startsWith("sui/")) {
     patchedStandard = "sui";
   }
 
   // Construct TokenCurrency directly from API data
   const tokenCurrency: TokenCurrency = {
     type: "TokenCurrency",
-    id: patchedId,
+    id,
     contractAddress: patchedContractAddress,
     parentCurrency,
     tokenType: patchedStandard,

--- a/libs/ledgerjs/packages/cryptoassets/src/cal-client/state-manager/api.test.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/cal-client/state-manager/api.test.ts
@@ -24,7 +24,6 @@ jest.mock("@ledgerhq/live-env", () => ({
 // Mock api-token-converter
 jest.mock("../../api-token-converter", () => ({
   convertApiToken: jest.fn(),
-  legacyIdToApiId: jest.fn((id: string) => id),
 }));
 
 import { convertApiToken } from "../../api-token-converter";

--- a/libs/ledgerjs/packages/cryptoassets/src/cal-client/state-manager/api.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/cal-client/state-manager/api.ts
@@ -5,7 +5,7 @@ import { getEnv } from "@ledgerhq/live-env";
 import { GetTokensDataParams, PageParam, TokensDataTags, TokensDataWithPagination } from "./types";
 import { TOKEN_OUTPUT_FIELDS } from "./fields";
 import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { convertApiToken, legacyIdToApiId } from "../../api-token-converter";
+import { convertApiToken } from "../../api-token-converter";
 import { log } from "@ledgerhq/logs";
 import { z } from "zod";
 
@@ -105,12 +105,10 @@ const cryptoAssetsApiInstance = createApi({
     findTokenById: build.query<TokenCurrency | undefined, TokenByIdParams>({
       query: params => {
         const baseUrl = getEnv("CAL_SERVICE_URL");
-        // Transform legacy ID to API format before querying
-        const apiId = legacyIdToApiId(params.id);
         return {
           url: `${baseUrl}/v1/tokens`,
           params: {
-            id: apiId,
+            id: params.id,
             limit: "1",
             output: TOKEN_OUTPUT_FIELDS.join(","),
           },


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Existing unit tests for the converter, the CAL/DaDa state managers and the asset distribution were updated to assert the now pass-through behaviour.
- [ ] **Impact of the changes:** QA should verify on the live CAL/DaDa backend that the following tokens still resolve, aggregate and price correctly (the client no longer patches them):
  - MultiversX (EGLD) ESDT tokens (e.g. USDC)
  - Stellar assets (e.g. USDC) — id casing and token type
  - TON Jettons
  - Cross-network aggregation in the portfolio asset distribution for the above

### 📝 Description

Cleanup of the client-side token reconciliation now that the CAL/DaDa backend returns tokens in Ledger Live native format.

Removed:
- `legacyIdToApiId` helper (request-side id rewriting for MultiversX and Stellar).
- `convertApiToken` patches for MultiversX (`elrond → multiversx`) [LIVE-22557], Stellar (id casing + `tokenType: asset → stellar`) [LIVE-22558], and the TON Jetton note [LIVE-22561].

Kept untouched: Cardano (LIVE-22559) and Sui (LIVE-22560) reconciliation, which are still required.

Callers (`cal-client` / `dada-client` state managers, `buildAssetDistribution`) now consume ids directly instead of routing them through `legacyIdToApiId`.

> [!IMPORTANT]
> This relies on the backend reconciliation being live: CAL/DaDa must return `multiversx/*` ids (not `elrond/*`), mixed-case Stellar ids, and `standard: "stellar"` for Stellar assets. If a token is not yet reconciled backend-side it will fail to resolve/aggregate instead of being patched by the client.

For consumers, `legacyIdToApiId` is no longer exported from `@ledgerhq/cryptoassets`:

```diff
-import { convertApiToken, legacyIdToApiId } from "@ledgerhq/cryptoassets";
+import { convertApiToken } from "@ledgerhq/cryptoassets";
-const apiId = legacyIdToApiId(currency.id);
+const apiId = currency.id;
```

### ❓ Context

- **JIRA or GitHub link**: [LIVE-22556](https://ledgerhq.atlassian.net/browse/LIVE-22556) (epic) — children LIVE-22557, LIVE-22558, LIVE-22561
- **ADR link (if any)**: n/a


[LIVE-22557]: https://ledgerhq.atlassian.net/browse/LIVE-22557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-22558]: https://ledgerhq.atlassian.net/browse/LIVE-22558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ