### PR TITLE
[LWDM] fix(concordium): display accurate send fee on device (LIVE-31905)

### DIFF
--- a/.changeset/spicy-melons-dance.md
+++ b/.changeset/spicy-melons-dance.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-concordium": minor
+"@ledgerhq/live-signer-concordium": minor
+"@ledgerhq/errors": minor
+---
+
+Add max-fee display for Concordium app 5.6.0+. `ConcordiumSigner.signTransaction` takes a required `maxFee: bigint` (µCCD) forwarded to the device for on-screen rendering. New `ConcordiumInvalidMaxFeeError` typed error for invalid input.

--- a/libs/coin-modules/coin-concordium/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/signOperation.test.ts
@@ -138,6 +138,7 @@ describe("signOperation", () => {
           payload: expect.any(Object),
         }),
         derivationPath,
+        expect.any(BigInt),
       );
     });
 

--- a/libs/coin-modules/coin-concordium/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/signOperation.ts
@@ -49,7 +49,11 @@ export const buildSignOperation =
             },
           );
 
-          const result = await signer.signTransaction(structuredTransaction, derivationPath);
+          const result = await signer.signTransaction(
+            structuredTransaction,
+            derivationPath,
+            estimation.cost,
+          );
 
           return combine(result.serialized, result.signature);
         });

--- a/libs/coin-modules/coin-concordium/src/test/concordiumTestUtils.ts
+++ b/libs/coin-modules/coin-concordium/src/test/concordiumTestUtils.ts
@@ -87,7 +87,11 @@ export function createMockSigner(keyPair: ConcordiumTestKeyPair): ConcordiumSign
       return keyPair.publicKeyHex;
     },
 
-    signTransaction: async (tx: Transaction, path: string): Promise<SigningResult> => {
+    signTransaction: async (
+      tx: Transaction,
+      path: string,
+      _maxFee: bigint,
+    ): Promise<SigningResult> => {
       const serializedTx = JSON.stringify({
         transaction: tx,
         path,

--- a/libs/coin-modules/coin-concordium/src/types/signer.ts
+++ b/libs/coin-modules/coin-concordium/src/types/signer.ts
@@ -31,8 +31,12 @@ export interface ConcordiumSigner {
    * Sign a transaction (Transfer or TransferWithMemo).
    * Routes to the appropriate signing method based on transaction type.
    * Returns both signature and serialized transaction.
+   *
+   * @param maxFee Maximum fee in µCCD (uint64). Forwarded to the device for
+   * display only when the firmware supports it; not part of the canonical
+   * signed bytes.
    */
-  signTransaction(tx: Transaction, path: string): Promise<SigningResult>;
+  signTransaction(tx: Transaction, path: string, maxFee: bigint): Promise<SigningResult>;
 
   /**
    * Sign a credential deployment transaction (hw-app format).

--- a/libs/ledgerjs/packages/errors/src/index.ts
+++ b/libs/ledgerjs/packages/errors/src/index.ts
@@ -227,6 +227,7 @@ export const ConcordiumTrustedMetadataServiceError = createCustomErrorClass(
 export const ConcordiumAddressVerificationFailedError = createCustomErrorClass(
   "ConcordiumAddressVerificationFailedError",
 );
+export const ConcordiumInvalidMaxFeeError = createCustomErrorClass("ConcordiumInvalidMaxFeeError");
 
 // Language
 export const LanguageNotFound = createCustomErrorClass("LanguageNotFound");

--- a/libs/live-signer-concordium/src/DmkSignerConcordium.ts
+++ b/libs/live-signer-concordium/src/DmkSignerConcordium.ts
@@ -17,6 +17,7 @@ import {
 } from "@ledgerhq/device-management-kit";
 import {
   ConcordiumAddressVerificationFailedError,
+  ConcordiumInvalidMaxFeeError,
   ConcordiumTrustedMetadataServiceError,
   LockedDeviceError,
   UserRefusedOnDevice,
@@ -70,15 +71,12 @@ export class DmkSignerConcordium implements ConcordiumSigner {
     return { address: publicKey, publicKey };
   }
 
-  async signTransaction(tx: Transaction, path: string): Promise<SigningResult> {
+  async signTransaction(tx: Transaction, path: string, maxFee: bigint): Promise<SigningResult> {
     const serialized = serializeTransaction(tx);
 
-    const { observable } = this.signer.signTransaction(
-      path,
-      new Uint8Array(serialized),
-      tx.header.energyAmount,
-      { skipOpenApp: true },
-    );
+    const { observable } = this.signer.signTransaction(path, new Uint8Array(serialized), maxFee, {
+      skipOpenApp: true,
+    });
 
     const result = this.mapResult(await lastValueFrom(observable));
     const signature = Buffer.from(result).toString("hex");
@@ -151,6 +149,8 @@ export class DmkSignerConcordium implements ConcordiumSigner {
         return new ConcordiumTrustedMetadataServiceError(originalMessage);
       case "address_verification_failed":
         return new ConcordiumAddressVerificationFailedError(originalMessage);
+      case "invalid_max_fee":
+        return new ConcordiumInvalidMaxFeeError(originalMessage);
       default:
         return new Error(this.formatGenericMessage(error._tag, originalMessage));
     }

--- a/libs/live-signer-concordium/tests/DmkSignerConcordium.test.ts
+++ b/libs/live-signer-concordium/tests/DmkSignerConcordium.test.ts
@@ -1,6 +1,7 @@
 import { DeviceActionStatus, DeviceManagementKit } from "@ledgerhq/device-management-kit";
 import {
   ConcordiumAddressVerificationFailedError,
+  ConcordiumInvalidMaxFeeError,
   ConcordiumTrustedMetadataServiceError,
   LockedDeviceError,
   UserRefusedOnDevice,
@@ -191,6 +192,8 @@ describe("DmkSignerConcordium", () => {
       },
     };
 
+    const mockMaxFee = 1234n;
+
     it("should return signature and serialized transaction", async () => {
       const signatureBytes = new Uint8Array(64).fill(0xcc);
       mockSignerConcordium.signTransaction.mockReturnValue({
@@ -200,14 +203,14 @@ describe("DmkSignerConcordium", () => {
         }),
       });
 
-      const result = await signer.signTransaction(mockTx, mockPath);
+      const result = await signer.signTransaction(mockTx, mockPath, mockMaxFee);
 
       expect(result.signature).toBe("cc".repeat(64));
       expect(typeof result.serialized).toBe("string");
       expect(mockSignerConcordium.signTransaction).toHaveBeenCalledWith(
         mockPath,
         expect.any(Uint8Array),
-        mockTx.header.energyAmount,
+        mockMaxFee,
         { skipOpenApp: true },
       );
     });
@@ -220,7 +223,26 @@ describe("DmkSignerConcordium", () => {
         }),
       });
 
-      await expect(signer.signTransaction(mockTx, mockPath)).rejects.toThrow(UserRefusedOnDevice);
+      await expect(signer.signTransaction(mockTx, mockPath, mockMaxFee)).rejects.toThrow(
+        UserRefusedOnDevice,
+      );
+    });
+
+    it("should map invalid_max_fee error to ConcordiumInvalidMaxFeeError", async () => {
+      mockSignerConcordium.signTransaction.mockReturnValue({
+        observable: of({
+          status: DeviceActionStatus.Error,
+          error: {
+            _tag: "InvalidMaxFeeError",
+            errorCode: "invalid_max_fee",
+            originalError: new Error("Invalid maxFee: must be non-negative"),
+          },
+        }),
+      });
+
+      await expect(signer.signTransaction(mockTx, mockPath, mockMaxFee)).rejects.toThrow(
+        ConcordiumInvalidMaxFeeError,
+      );
     });
   });
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:** Concordium send flow — the max fee shown on-device during signing.
  - QA: on a Concordium app ≥ 5.6.0, verify the "Max fees" value displayed on-device during a send (Transfer and TransferWithMemo) matches the fee shown in the app, and is no longer underestimated.
  - On a Concordium app < 5.6.0, verify signing still succeeds with no fee line shown.

### 📝 Description

The fee displayed on the device during a Concordium send was **way underestimated**: `DmkSignerConcordium` forwarded `tx.header.energyAmount` (the transaction's energy limit, in chain energy units) into the device's display-fee slot, instead of the actual µCCD fee.

This change routes the real fee through:

- `ConcordiumSigner.signTransaction` gains a required `maxFee: bigint` (µCCD) argument.
- `signOperation` passes the fee already computed via `estimateFees` (`estimation.cost`).
- `DmkSignerConcordium` forwards `maxFee` to the DMK signer (instead of `energyAmount`), and maps the `invalid_max_fee` device error code to a new `ConcordiumInvalidMaxFeeError`.

The value is display-only — it is not part of the canonical signed bytes, so the transaction hash is unaffected. On firmware that does not support fee display, the value is dropped at the wire boundary and signing falls back to the legacy display.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31905](https://ledgerhq.atlassian.net/browse/LIVE-31905)


[LIVE-31905]: https://ledgerhq.atlassian.net/browse/LIVE-31905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ