### PR TITLE
test(mobile-e2e): assign owning teams to LWM e2e tests

### DIFF
--- a/.changeset/lwm-e2e-team-owners.md
+++ b/.changeset/lwm-e2e-team-owners.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-mobile-e2e-tests": patch
+---
+
+Assign an owning team to every mobile e2e test via Allure `owner`/`parentSuite` labels (new `setTeamOwner` helper), mirroring the desktop team system so reports can be grouped and filtered by team.

--- a/e2e/mobile/helpers/allure/allure-helper.ts
+++ b/e2e/mobile/helpers/allure/allure-helper.ts
@@ -1,5 +1,11 @@
 import { allure } from "jest-allure2-reporter/api";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { isWallet40 } from "../commonHelpers";
+
+export function setTeamOwner(team: Team): void {
+  $Owner(team);
+  $ParentSuite(team);
+}
 
 export function setAllureDescription(): void {
   const testPath = expect.getState().testPath ?? "";

--- a/e2e/mobile/specs/account/accountRename.spec.ts
+++ b/e2e/mobile/specs/account/accountRename.spec.ts
@@ -1,8 +1,11 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { launchApp } from "../../helpers/commonHelpers";
+import { setTeamOwner } from "../../helpers/allure/allure-helper";
 import { loadConfig } from "../../bridge/server";
 import { device } from "detox";
 
+setTeamOwner(Team.WALLET_XP);
 $TmsLink("B2CQA-2996");
 
 const tags: string[] = [

--- a/e2e/mobile/specs/addAccount/addAccount.ts
+++ b/e2e/mobile/specs/addAccount/addAccount.ts
@@ -1,4 +1,8 @@
 import { CurrencyType } from "@ledgerhq/live-common/e2e/enum/Currency";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
+import { setTeamOwner } from "../../helpers/allure/allure-helper";
+
+const BST_ADD_ACCOUNT_CURRENCIES = new Set(["ton", "aptos", "cardano", "tezos"]);
 
 export function runAddAccountTest(currency: CurrencyType, tmsLinks: string[], tags: string[]) {
   describe("Add accounts - Network Based", () => {
@@ -10,6 +14,7 @@ export function runAddAccountTest(currency: CurrencyType, tmsLinks: string[], ta
       await app.portfolio.waitForPortfolioPageToLoad();
     });
 
+    setTeamOwner(BST_ADD_ACCOUNT_CURRENCIES.has(currency.id) ? Team.BST : Team.COIN_INTEGRATION);
     tmsLinks.forEach(link => $TmsLink(link));
     tags.forEach(tag => $Tag(tag));
     it(`Perform a Network Based add account - ${currency.name}`, async () => {

--- a/e2e/mobile/specs/buySell/buySell.ts
+++ b/e2e/mobile/specs/buySell/buySell.ts
@@ -3,7 +3,9 @@ import { BuySell } from "@ledgerhq/live-common/e2e/models/BuySell";
 import { ApplicationOptions } from "page";
 import { BuySellProvider } from "@ledgerhq/live-common/e2e/enum/Provider";
 import { getParentAccountName } from "@ledgerhq/live-common/e2e/enum/Account";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { isWallet40 } from "../../helpers/commonHelpers";
+import { setTeamOwner } from "../../helpers/allure/allure-helper";
 
 setEnv("DISABLE_TRANSACTION_BROADCAST", true);
 
@@ -32,6 +34,7 @@ export async function runNavigateToBuyFromPortfolioPageTest(
       });
     });
 
+    setTeamOwner(Team.BUY_AND_SELL);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     test(`Buy / Sell [${buySell.crypto.currency.name}] asset from portfolio page`, async () => {
@@ -62,6 +65,7 @@ export async function runNavigateToBuyFromAccountPageTest(
       });
     });
 
+    setTeamOwner(Team.BUY_AND_SELL);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     test(`Navigate to Buy / Sell [${buySell.crypto.currency.name}] asset from account page`, async () => {
@@ -91,6 +95,7 @@ export async function runNavigateToBuyFromMarketPageTest(
       });
     });
 
+    setTeamOwner(Team.BUY_AND_SELL);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     test(`Navigate to Buy / Sell [${buySell.crypto.currency.name}] asset from market page`, async () => {
@@ -123,6 +128,7 @@ export async function runNavigateToBuyFromAssetPageTest(
       });
     });
 
+    setTeamOwner(Team.BUY_AND_SELL);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     test(`Navigate to Buy / Sell [${buySell.crypto.currency.name}] asset from asset page`, async () => {
@@ -150,6 +156,7 @@ export async function runSellFlowTest(
       });
     });
 
+    setTeamOwner(Team.BUY_AND_SELL);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     test(`Sell [${buySell.crypto.currency.name}] flow via deeplink`, async () => {
@@ -174,6 +181,7 @@ export async function runQueryParametersTest(
       });
     });
 
+    setTeamOwner(Team.BUY_AND_SELL);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     test(`Buy / Sell [${buySell.crypto.currency.name}] asset - query parameters`, async () => {

--- a/e2e/mobile/specs/deeplinks.spec.ts
+++ b/e2e/mobile/specs/deeplinks.spec.ts
@@ -1,9 +1,12 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { swapSetup } from "../bridge/server";
 import { isWallet40 } from "../helpers/commonHelpers";
+import { setTeamOwner } from "../helpers/allure/allure-helper";
 
 const isSmokeTestRun = process.env.INPUTS_TEST_FILTER?.includes("@smoke");
 
+setTeamOwner(Team.WALLET_XP);
 $TmsLink("B2CQA-1837");
 const tags: string[] = ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"];
 tags.forEach(tag => $Tag(tag));
@@ -88,6 +91,7 @@ describe("DeepLinks Tests", () => {
     await app.discover.expectApp("Kiln");
   });
 
+  setTeamOwner(Team.SWAP);
   (isSmokeTestRun ? it.skip : it)("should open Swap Form page", async () => {
     await swapSetup();
     await app.swap.openViaDeeplink();

--- a/e2e/mobile/specs/delegate/delegate.ts
+++ b/e2e/mobile/specs/delegate/delegate.ts
@@ -1,7 +1,11 @@
 import { setEnv } from "@ledgerhq/live-env";
 import { DelegateType } from "@ledgerhq/live-common/e2e/models/Delegate";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { verifyAppValidationStakeInfo, verifyStakeOperationDetailsInfo } from "../../models/stake";
 import { getCurrencyManagerApp } from "../../models/currencies";
+import { setTeamOwner } from "../../helpers/allure/allure-helper";
+
+const BST_DELEGATE_CURRENCIES = new Set(["cardano", "near"]);
 
 const beforeAllFunction = async (delegation: DelegateType) => {
   await app.init({
@@ -13,6 +17,9 @@ const beforeAllFunction = async (delegation: DelegateType) => {
 };
 
 export function runDelegateTest(delegation: DelegateType, tmsLinks: string[], tags: string[]) {
+  setTeamOwner(
+    BST_DELEGATE_CURRENCIES.has(delegation.account.currency.id) ? Team.BST : Team.COIN_INTEGRATION,
+  );
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
   tags.forEach(tag => $Tag(tag));
   describe("Delegate", () => {
@@ -65,6 +72,7 @@ export function runDelegateDefaultValidatorTest(
   tmsLinks: string[],
   tags: string[],
 ) {
+  setTeamOwner(Team.COIN_INTEGRATION);
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
   tags.forEach(tag => $Tag(tag));
   describe("Delegate - default validator", () => {
@@ -91,6 +99,7 @@ export async function runLockCelo(
   tmsLinks: string[],
   tags: string[] = ["@NanoSP", "@NanoX", "@Stax", "@Flex", "@NanoGen5", `@celo`, `@family-celo`],
 ) {
+  setTeamOwner(Team.COIN_INTEGRATION);
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
   tags.forEach(tag => $Tag(tag));
   describe(`Lock flow on CELO`, () => {
@@ -126,6 +135,7 @@ export async function runVoteCelo(
   tmsLinks: string[],
   tags: string[] = ["@NanoSP", "@NanoX", "@Stax", "@Flex", "@NanoGen5", `@celo`, `@family-celo`],
 ) {
+  setTeamOwner(Team.COIN_INTEGRATION);
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
   tags.forEach(tag => $Tag(tag));
   describe(`Vote flow on CELO`, () => {
@@ -175,6 +185,7 @@ export async function runDelegateTezos(
   ],
 ) {
   setEnv("DISABLE_TRANSACTION_BROADCAST", true);
+  setTeamOwner(Team.BST);
   tags.forEach(tag => $Tag(tag));
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
   describe(`Delegate flow on TEZOS`, () => {

--- a/e2e/mobile/specs/deleteAccount/deleteAccount.ts
+++ b/e2e/mobile/specs/deleteAccount/deleteAccount.ts
@@ -1,4 +1,6 @@
 import { AccountType } from "@ledgerhq/live-common/e2e/enum/Account";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
+import { setTeamOwner } from "../../helpers/allure/allure-helper";
 
 export function runDeleteAccountTest(account: AccountType, tmsLinks: string[], tags: string[]) {
   describe("Delete account", () => {
@@ -10,6 +12,7 @@ export function runDeleteAccountTest(account: AccountType, tmsLinks: string[], t
       await app.portfolio.waitForPortfolioPageToLoad();
     });
 
+    setTeamOwner(Team.WALLET_XP);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it(`Perform a delete account - ${account.accountName}`, async () => {

--- a/e2e/mobile/specs/deposit/deposit.ts
+++ b/e2e/mobile/specs/deposit/deposit.ts
@@ -1,7 +1,9 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { ReceiveFundsOptions } from "@ledgerhq/live-common/e2e/enum/ReceiveFundsOptions";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { setEnv } from "@ledgerhq/live-env";
 import { isWallet40 } from "../../helpers/commonHelpers";
+import { setTeamOwner } from "../../helpers/allure/allure-helper";
 import { ApplicationOptions } from "page";
 
 setEnv("DISABLE_TRANSACTION_BROADCAST", true);
@@ -34,6 +36,7 @@ export async function runSelectCryptoNetworkTest(
       });
     });
 
+    setTeamOwner(Team.WALLET_XP);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it(`should select crypto network with ${withAccount ? "account" : "no account"} for ${
@@ -72,6 +75,7 @@ export async function runSelectCryptoWithoutNetworkAndAccountTest(
       });
     });
 
+    setTeamOwner(Team.WALLET_XP);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it(`should select crypto without network and account for ${account.currency.ticker}`, async () => {

--- a/e2e/mobile/specs/earn/earn.ts
+++ b/e2e/mobile/specs/earn/earn.ts
@@ -1,8 +1,10 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { EarnProvider } from "@ledgerhq/live-common/e2e/enum/Provider";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { setEnv } from "@ledgerhq/live-env";
 import { waitEarnReady } from "../../bridge/server";
 import { isWallet40 } from "../../helpers/commonHelpers";
+import { setTeamOwner } from "../../helpers/allure/allure-helper";
 
 import type { ApplicationOptions } from "page";
 import type { PartialFeatures } from "@shared/feature-flags";
@@ -57,6 +59,7 @@ export async function runInlineAddAccountTest(
       });
     });
 
+    setTeamOwner(Team.EARN);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it(`Inline Add Account [${account.currency.speculosApp.name}]`, async () => {
@@ -115,6 +118,7 @@ export async function runStartETHStakingFromEarnDashboardTest(
       });
     });
 
+    setTeamOwner(Team.EARN);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it(`ETH staking flow - Earn Dashboard - Provider : ${provider.uiName}`, async () => {
@@ -149,6 +153,7 @@ export async function runCorrectEarnPageIsLoadedDependingOnUserStakingSituationT
       });
     });
 
+    setTeamOwner(Team.EARN);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it(`Correct Earn page - ${account.currency.ticker} - staking situation: ${staking}`, async () => {

--- a/e2e/mobile/specs/earn/earnV2.ts
+++ b/e2e/mobile/specs/earn/earnV2.ts
@@ -1,7 +1,9 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { setEnv } from "@ledgerhq/live-env";
 import { waitEarnReady } from "../../bridge/server";
 import { WALLET_40_FEATURE_FLAGS } from "../../utils/constants";
+import { setTeamOwner } from "../../helpers/allure/allure-helper";
 
 import type { ApplicationOptions } from "page";
 import type { PartialFeatures } from "@shared/feature-flags";
@@ -40,6 +42,7 @@ export function runIceColdStartTest(account: Account, tmsLinks: string[], tags: 
       });
     });
 
+    setTeamOwner(Team.EARN);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it("displays ice cold start page and CTA opens modular asset drawer", async () => {
@@ -62,6 +65,7 @@ export function runColdStartTest(account: Account, tmsLinks: string[], tags: str
       });
     });
 
+    setTeamOwner(Team.EARN);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it(`shows ${account.currency.ticker} ready to earn and clicking CTA initiates staking`, async () => {
@@ -86,6 +90,7 @@ export function runHotStartTest(account: Account, tmsLinks: string[], tags: stri
       });
     });
 
+    setTeamOwner(Team.EARN);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it(`${account.currency.ticker} hot start: rewards summary, position row -> manage -> account page`, async () => {
@@ -114,6 +119,7 @@ export function runNativeStakingCTATest(account: Account, tmsLinks: string[], ta
       });
     });
 
+    setTeamOwner(Team.EARN);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it(`${account.currency.ticker} earn CTA initiates staking flow`, async () => {
@@ -135,6 +141,7 @@ export function runScyStakingCTATest(account: Account, tmsLinks: string[], tags:
       });
     });
 
+    setTeamOwner(Team.EARN);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it(`${account.currency.ticker} earn CTA initiates deposit flow`, async () => {
@@ -164,6 +171,7 @@ export function runPartnerDappCTATest(
       });
     });
 
+    setTeamOwner(Team.EARN);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it(`${account.currency.ticker} earn CTA -> ${providerId} provider -> dapp`, async () => {
@@ -192,6 +200,7 @@ export function runPartnerDappPositionTest(
       });
     });
 
+    setTeamOwner(Team.EARN);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it(`${account.currency.ticker} position row -> manage -> dapp`, async () => {
@@ -219,6 +228,7 @@ export function runPositionToWithdrawalTest(account: Account, tmsLinks: string[]
       });
     });
 
+    setTeamOwner(Team.EARN);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it(`${account.currency.ticker} position row -> withdraw all -> webview /redeem`, async () => {

--- a/e2e/mobile/specs/languageChange.spec.ts
+++ b/e2e/mobile/specs/languageChange.spec.ts
@@ -1,3 +1,7 @@
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
+import { setTeamOwner } from "../helpers/allure/allure-helper";
+
+setTeamOwner(Team.WALLET_XP);
 $TmsLink("B2CQA-2344");
 
 const isSmokeTestRun = process.env.INPUTS_TEST_FILTER?.includes("@smoke");

--- a/e2e/mobile/specs/ledgerSync/ledgerSync.spec.ts
+++ b/e2e/mobile/specs/ledgerSync/ledgerSync.spec.ts
@@ -1,9 +1,12 @@
 import { device } from "detox";
 import { describeIfNotNanoS } from "../../helpers/commonHelpers";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
+import { setTeamOwner } from "../../helpers/allure/allure-helper";
 
 const tmsLinks = ["B2CQA-2292", "B2CQA-2293", "B2CQA-2296"];
 const tags = ["@NanoSP", "@NanoX", "@Stax", "@Flex", "@NanoGen5"];
 
+setTeamOwner(Team.WALLET_XP);
 describeIfNotNanoS(`Ledger Sync Accounts`, () => {
   beforeAll(async () => {
     await app.init({

--- a/e2e/mobile/specs/market.spec.ts
+++ b/e2e/mobile/specs/market.spec.ts
@@ -1,3 +1,6 @@
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
+import { setTeamOwner } from "../helpers/allure/allure-helper";
+
 const tags: string[] = [
   "@NanoSP",
   "@LNS",
@@ -29,6 +32,7 @@ describe("Market page for user with no device", () => {
     await app.portfolio.waitForPortfolioPageToLoad();
   });
 
+  setTeamOwner(Team.WALLET_XP);
   $TmsLink("B2CQA-1879");
   tags.forEach(tag => $Tag(tag));
   it("should filter starred asset in the list", async () => {

--- a/e2e/mobile/specs/onboardingReadOnly.spec.ts
+++ b/e2e/mobile/specs/onboardingReadOnly.spec.ts
@@ -1,3 +1,7 @@
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
+import { setTeamOwner } from "../helpers/allure/allure-helper";
+
+setTeamOwner(Team.WALLET_XP);
 describe("Onboarding - Read Only", () => {
   $TmsLink("B2CQA-370");
   $TmsLink("B2CQA-1753");

--- a/e2e/mobile/specs/portfolio/portfolio.ts
+++ b/e2e/mobile/specs/portfolio/portfolio.ts
@@ -1,6 +1,8 @@
 import { ApplicationOptions } from "page";
 import { isWallet40 } from "../../helpers/commonHelpers";
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
+import { setTeamOwner } from "../../helpers/allure/allure-helper";
 
 async function beforeAllFunction(options: ApplicationOptions) {
   await app.init({
@@ -25,6 +27,7 @@ export function runPortfolioTransactionsHistoryTest(
       });
     });
 
+    setTeamOwner(Team.WALLET_XP);
     tmsLinks.forEach(link => $TmsLink(link));
     tags.forEach(tag => $Tag(tag));
     it(`[${account.currency.ticker}] Transaction history displayed when user added his accounts`, async () => {
@@ -43,6 +46,7 @@ export function runPortfolioChartsAndAssetsTest(tmsLinks: string[], tags: string
       });
     });
 
+    setTeamOwner(Team.WALLET_XP);
     tmsLinks.forEach(link => $TmsLink(link));
     tags.forEach(tag => $Tag(tag));
     it("Charts and assets section are displayed when user added his accounts", async () => {

--- a/e2e/mobile/specs/portfolio/portfolioTabs.spec.ts
+++ b/e2e/mobile/specs/portfolio/portfolioTabs.spec.ts
@@ -1,5 +1,9 @@
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
+import { setTeamOwner } from "../../helpers/allure/allure-helper";
+
 const tags = ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"];
 
+setTeamOwner(Team.WALLET_XP);
 describe("Wallet Page", () => {
   beforeAll(async () => {
     await app.init({

--- a/e2e/mobile/specs/send/send.ts
+++ b/e2e/mobile/specs/send/send.ts
@@ -4,8 +4,13 @@ import { verifyAppValidationSendInfo } from "../../models/send";
 import invariant from "invariant";
 import { TransactionType } from "@ledgerhq/live-common/e2e/models/Transaction";
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
+import { setTeamOwner } from "../../helpers/allure/allure-helper";
 import type { LiveDataCommandOptions } from "@ledgerhq/live-common/e2e/cliCommandsUtils";
 import type { InitOptions } from "../../utils/initUtil";
+
+const BST_SEND_CURRENCIES = new Set(["aptos", "sui", "cardano"]);
+const BST_SEND_INVALID_ADDRESS_CURRENCIES = new Set(["hedera"]);
 
 export type SendTestOptions = {
   featureFlags?: InitOptions["featureFlags"];
@@ -95,6 +100,11 @@ export function runSendTest(
   tags: string[],
   options?: SendTestOptions,
 ) {
+  setTeamOwner(
+    BST_SEND_CURRENCIES.has(transaction.accountToDebit.currency.id)
+      ? Team.BST
+      : Team.COIN_INTEGRATION,
+  );
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
   tags.forEach(tag => $Tag(tag));
   describe("Send from 1 account to another", () => {
@@ -122,6 +132,11 @@ export function runSendInvalidAddressTest(
   tags: string[],
   accountName?: string,
 ) {
+  setTeamOwner(
+    BST_SEND_INVALID_ADDRESS_CURRENCIES.has(transaction.accountToDebit.currency.id)
+      ? Team.BST
+      : Team.COIN_INTEGRATION,
+  );
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
   tags.forEach(tag => $Tag(tag));
   describe("Send - invalid address input", () => {
@@ -146,6 +161,7 @@ export function runSendValidAddressTest(
   accountName?: string,
   expectedWarningMessage?: string,
 ) {
+  setTeamOwner(Team.COIN_INTEGRATION);
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
   tags.forEach(tag => $Tag(tag));
   describe("Send - valid address & amount input", () => {
@@ -184,6 +200,7 @@ export function runSendInvalidAmountTest(
   tmsLinks: string[],
   tags: string[],
 ) {
+  setTeamOwner(Team.COIN_INTEGRATION);
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
   tags.forEach(tag => $Tag(tag));
   describe("Check invalid amount input error", () => {
@@ -209,6 +226,7 @@ export function runSendInvalidTokenAmountTest(
   tmsLinks: string[],
   tags: string[],
 ) {
+  setTeamOwner(Team.COIN_INTEGRATION);
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
   tags.forEach(tag => $Tag(tag));
   describe("Send token (subAccount) - invalid amount input", () => {
@@ -241,6 +259,7 @@ export function runSendInvalidTokenAmountTest(
 export function runSendMaxTest(transaction: TransactionType, tmsLinks: string[], tags: string[]) {
   setEnv("DISABLE_TRANSACTION_BROADCAST", true);
 
+  setTeamOwner(Team.COIN_INTEGRATION);
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
   tags.forEach(tag => $Tag(tag));
   describe("Verify send max user flow", () => {
@@ -266,6 +285,7 @@ export function runSendMaxTest(transaction: TransactionType, tmsLinks: string[],
 export function runSendENSTest(transaction: TransactionType, tmsLinks: string[], tags: string[]) {
   setEnv("DISABLE_TRANSACTION_BROADCAST", true);
 
+  setTeamOwner(Team.COIN_INTEGRATION);
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
   tags.forEach(tag => $Tag(tag));
   describe("User sends funds to ENS address", () => {

--- a/e2e/mobile/specs/settings/settings.ts
+++ b/e2e/mobile/specs/settings/settings.ts
@@ -1,6 +1,8 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { ApplicationOptions } from "page";
 import { isWallet40 } from "../../helpers/commonHelpers";
+import { setTeamOwner } from "../../helpers/allure/allure-helper";
 
 async function initApp(options: ApplicationOptions) {
   await app.init({
@@ -25,6 +27,7 @@ export function runUserClearApplicationCacheTest(
       });
     });
 
+    setTeamOwner(Team.WALLET_XP);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
 
@@ -49,6 +52,7 @@ export function runUserCanExportLogsTest(tmsLinks: string[], tags: string[]) {
       await initApp({ userdata: "skip-onboarding" });
     });
 
+    setTeamOwner(Team.WALLET_XP);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
 
@@ -67,6 +71,7 @@ export function runUserCanAccessLedgerSupportTest(tmsLinks: string[], tags: stri
       await initApp({ userdata: "skip-onboarding" });
     });
 
+    setTeamOwner(Team.WALLET_XP);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     test("Verify that user can access Ledger Support (Web Link)", async () => {
@@ -93,6 +98,7 @@ export function runUserCanSelectCounterValueToDisplayAmountInLedgerLive(
         });
       });
 
+      setTeamOwner(Team.WALLET_XP);
       tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
       tags.forEach(tag => $Tag(tag));
       test("Verify that user can select counter value to display amount in Ledger Live", async () => {
@@ -141,6 +147,7 @@ export function runPasswordUnlockTest(tmsLinks: string[], tags: string[]) {
       await app.passwordEntry.expectLock();
     });
 
+    setTeamOwner(Team.WALLET_XP);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it("should unlock with correct password", async () => {
@@ -164,6 +171,7 @@ export function runPasswordIncorrectTest(tmsLinks: string[], tags: string[]) {
       await app.passwordEntry.expectLock();
     });
 
+    setTeamOwner(Team.WALLET_XP);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it("should stay locked with incorrect password", async () => {

--- a/e2e/mobile/specs/subAccount/subAccount.ts
+++ b/e2e/mobile/specs/subAccount/subAccount.ts
@@ -1,9 +1,11 @@
 import { verifyAppValidationSendInfo } from "../../models/send";
 import { TransactionType } from "@ledgerhq/live-common/e2e/models/Transaction";
 import { AccountType } from "@ledgerhq/live-common/e2e/enum/Account";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { Addresses } from "@ledgerhq/live-common/e2e/enum/Addresses";
 import { getEnv } from "@ledgerhq/live-env";
 import { TransactionStatus } from "@ledgerhq/live-common/e2e/enum/TransactionStatus";
+import { setTeamOwner } from "../../helpers/allure/allure-helper";
 import invariant from "invariant";
 
 const beforeAllFunction = async (transaction: TransactionType, setAccountToCredit: boolean) => {
@@ -34,6 +36,7 @@ const beforeAllFunction = async (transaction: TransactionType, setAccountToCredi
 };
 
 export function runSendSPL(transaction: TransactionType, tmsLinks: string[], tags: string[]) {
+  setTeamOwner(Team.COIN_INTEGRATION);
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
   tags.forEach(tag => $Tag(tag));
   describe("Send SPL tokens from 1 account to another", () => {
@@ -80,6 +83,7 @@ export function runSendSPLAddressValid(
   tmsLinks: string[],
   tags: string[],
 ) {
+  setTeamOwner(Team.COIN_INTEGRATION);
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
   tags.forEach(tag => $Tag(tag));
   describe("Send token - valid address input", () => {
@@ -105,6 +109,7 @@ export function runSendSPLAddressInvalid(
   tmsLinks: string[],
   tags: string[],
 ) {
+  setTeamOwner(Team.COIN_INTEGRATION);
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
   tags.forEach(tag => $Tag(tag));
   describe("Send token - invalid address input", () => {
@@ -139,6 +144,7 @@ export function runAddSubAccountTest(testConfig: {
       await app.portfolio.waitForPortfolioPageToLoad();
     });
 
+    setTeamOwner(Team.COIN_INTEGRATION);
     tmslinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it(`Add Sub Account without parent (${asset.currency.speculosApp.name}) - ${asset.currency.ticker}`, async () => {

--- a/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
@@ -4,9 +4,11 @@ import { SwapType } from "@ledgerhq/live-common/e2e/models/Swap";
 import { performSwapUntilQuoteSelectionStep } from "../../../utils/swapUtils";
 import { AppInfos } from "@ledgerhq/live-common/e2e/enum/AppInfos";
 import { SwapProvider } from "@ledgerhq/live-common/e2e/enum/Provider";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { setEnv } from "@ledgerhq/live-env";
 import { beforeAllFunctionSwap } from "../swap.setup";
 import { isWallet40 } from "../../../helpers/commonHelpers";
+import { setTeamOwner } from "../../../helpers/allure/allure-helper";
 
 setEnv("DISABLE_TRANSACTION_BROADCAST", true);
 
@@ -64,6 +66,7 @@ export function runSwapWithoutAccountTest(
       });
     });
 
+    setTeamOwner(Team.SWAP);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it(`${testTitle}`, async () => {
@@ -97,6 +100,7 @@ export function runSwapWithDifferentSeedTest(
       });
     });
 
+    setTeamOwner(Team.SWAP);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it(`Swap using a different seed - ${swap.accountToDebit.currency.name} to ${swap.accountToCredit.currency.name}`, async () => {
@@ -150,6 +154,7 @@ export function runSwapLandingPageTest(
       });
     });
 
+    setTeamOwner(Team.SWAP);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it("Swap landing page", async () => {
@@ -210,6 +215,7 @@ export function runSwapLnsNotSupportedBannerTest(
         await setupSwapAccounts(fromAccount, toAccount, "skip-onboarding-with-last-seen-device");
       });
 
+      setTeamOwner(Team.SWAP);
       tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
       tags.forEach(tag => $Tag(tag));
       it(`Shows LNS not supported banner for ${unsupportedProvider.uiName}`, async () => {
@@ -252,6 +258,7 @@ export function runTooLowAmountForQuoteSwapsTest(
       });
     });
 
+    setTeamOwner(Team.SWAP);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it(`Swap too low quote amounts from ${swap.accountToDebit.currency.name} to ${swap.accountToCredit.currency.name} - ${errorMessage}`, async () => {
@@ -305,6 +312,7 @@ export function runUserRefusesTransactionTest(
       });
     });
 
+    setTeamOwner(Team.SWAP);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it(`User refuses transaction - ${fromAccount.currency.name} to ${toAccount.currency.name}`, async () => {
@@ -341,6 +349,7 @@ export function runSwapHistoryOperationsTest(
       });
     });
 
+    setTeamOwner(Team.SWAP);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it(`Swap history operations - ${swap.accountToDebit.currency.name} to ${swap.accountToCredit.currency.name}`, async () => {
@@ -370,6 +379,7 @@ export function runExportSwapHistoryOperationsTest(
       });
     });
 
+    setTeamOwner(Team.SWAP);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it(`Export swap history operations - ${swap.accountToDebit.currency.name} to ${swap.accountToCredit.currency.name}`, async () => {
@@ -393,6 +403,7 @@ export function runSwapHistoryFeedbackTest(tmsLinks: string[], tags: string[]) {
       });
     });
 
+    setTeamOwner(Team.SWAP);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it("Check feedback form URL from swap history", async () => {
@@ -427,6 +438,7 @@ export function runSwapWithSendMaxTest(
       });
     });
 
+    setTeamOwner(Team.SWAP);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it(`Swap max amount from ${fromAccount.currency.name} to ${toAccount.currency.name}`, async () => {
@@ -491,6 +503,7 @@ export function runSwapSwitchSendAndReceiveCurrenciesTest(
       });
     });
 
+    setTeamOwner(Team.SWAP);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it("Switch You send and You receive currency", async () => {
@@ -532,6 +545,7 @@ export function runSwapEntryPoints(account: Account, tmsLinks: string[], tags: s
       });
     });
 
+    setTeamOwner(Team.SWAP);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it("Access Swap from different entry points", async () => {
@@ -576,6 +590,7 @@ export function runSwapNetworkFeesAboveAccountBalanceTest(
       });
     });
 
+    setTeamOwner(Team.SWAP);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
 

--- a/e2e/mobile/specs/swap/otherTestCases/swapDexNativeFlow.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapDexNativeFlow.ts
@@ -1,9 +1,11 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { ensureTokenApproval, performSwapUntilQuoteSelectionStep } from "../../../utils/swapUtils";
 import { SwapProvider } from "@ledgerhq/live-common/e2e/enum/Provider";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { setEnv } from "@ledgerhq/live-env";
 import { beforeAllFunctionSwap } from "../swap.setup";
 import { getAmountFromUSD } from "@ledgerhq/live-common/e2e/swap";
+import { setTeamOwner } from "../../../helpers/allure/allure-helper";
 
 setEnv("DISABLE_TRANSACTION_BROADCAST", true);
 
@@ -33,6 +35,7 @@ export function runSwapDexNativeFlow(
       });
     });
 
+    setTeamOwner(Team.SWAP);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it(`Swap test DEX provider native flow - (${provider.uiName})`, async () => {

--- a/e2e/mobile/specs/swap/swap.ts
+++ b/e2e/mobile/specs/swap/swap.ts
@@ -1,7 +1,9 @@
 import { SwapType } from "@ledgerhq/live-common/e2e/models/Swap";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { setEnv } from "@ledgerhq/live-env";
 import { performSwapUntilQuoteSelectionStep } from "../../utils/swapUtils";
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { setTeamOwner } from "../../helpers/allure/allure-helper";
 import { beforeAllFunctionSwap } from "./swap.setup";
 
 setEnv("DISABLE_TRANSACTION_BROADCAST", true);
@@ -29,6 +31,7 @@ export function runSwapTest(swap: SwapType, tmsLinks: string[], tags: string[]) 
       await beforeAllFunction(swap);
     });
 
+    setTeamOwner(Team.SWAP);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it(`Swap ${swap.accountToDebit.currency.name} to ${swap.accountToCredit.currency.name}`, async () => {

--- a/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenApprovalFlow.ts
+++ b/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenApprovalFlow.ts
@@ -1,8 +1,10 @@
 import { Account, TokenAccount } from "@ledgerhq/live-common/e2e/enum/Account";
 import { performSwapUntilQuoteSelectionStep, revokeTokenApproval } from "../../../utils/swapUtils";
 import { SwapProvider } from "@ledgerhq/live-common/e2e/enum/Provider";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { beforeAllFunctionSwap } from "../swap.setup";
 import { getAmountFromUSD } from "@ledgerhq/live-common/e2e/swap";
+import { setTeamOwner } from "../../../helpers/allure/allure-helper";
 
 export function runSwapTokenApprovalFlow(
   fromAccount: TokenAccount,
@@ -36,6 +38,7 @@ export function runSwapTokenApprovalFlow(
       });
     });
 
+    setTeamOwner(Team.SWAP);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
 

--- a/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenReapprovalFlow.ts
+++ b/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenReapprovalFlow.ts
@@ -5,7 +5,9 @@ import {
   revokeTokenApproval,
 } from "../../../utils/swapUtils";
 import { SwapProvider } from "@ledgerhq/live-common/e2e/enum/Provider";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { beforeAllFunctionSwap } from "../swap.setup";
+import { setTeamOwner } from "../../../helpers/allure/allure-helper";
 import BigNumber from "bignumber.js";
 
 export function runSwapTokenReapprovalFlow(
@@ -41,6 +43,7 @@ export function runSwapTokenReapprovalFlow(
       });
     });
 
+    setTeamOwner(Team.SWAP);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
 

--- a/e2e/mobile/specs/userOpensApplication.spec.ts
+++ b/e2e/mobile/specs/userOpensApplication.spec.ts
@@ -1,10 +1,13 @@
 import { setFeatureFlags } from "../bridge/server";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
+import { setTeamOwner } from "../helpers/allure/allure-helper";
 
 const testConfig = {
   tmsLinks: ["B2CQA-734"],
   tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"],
 };
 
+setTeamOwner(Team.WALLET_XP);
 describe("User opens application", () => {
   testConfig.tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
   testConfig.tags.forEach(tag => $Tag(tag));

--- a/e2e/mobile/specs/verifyAddress/receiveFlow.spec.ts
+++ b/e2e/mobile/specs/verifyAddress/receiveFlow.spec.ts
@@ -1,10 +1,13 @@
 import { Currency } from "@ledgerhq/live-common/e2e/enum/Currency";
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { ReceiveFundsOptions } from "@ledgerhq/live-common/e2e/enum/ReceiveFundsOptions";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { isWallet40 } from "../../helpers/commonHelpers";
+import { setTeamOwner } from "../../helpers/allure/allure-helper";
 
 const isSmokeTestRun = process.env.INPUTS_TEST_FILTER?.includes("@smoke");
 
+setTeamOwner(Team.WALLET_XP);
 describe("Receive Flow", () => {
   const account = Account.ETH_1;
 

--- a/e2e/mobile/specs/verifyAddress/verifyAddress.ts
+++ b/e2e/mobile/specs/verifyAddress/verifyAddress.ts
@@ -1,4 +1,6 @@
 import { AccountType } from "@ledgerhq/live-common/e2e/enum/Account";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
+import { setTeamOwner } from "../../helpers/allure/allure-helper";
 
 export function runVerifyAddressTest(account: AccountType, tmsLinks: string[], tags: string[]) {
   describe("Verify Address", () => {
@@ -10,6 +12,7 @@ export function runVerifyAddressTest(account: AccountType, tmsLinks: string[], t
       await app.portfolio.waitForPortfolioPageToLoad();
     });
 
+    setTeamOwner(Team.COIN_INTEGRATION);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it(`Verify address on ${account.currency.name}`, async () => {

--- a/e2e/mobile/specs/verifyAddress/verifyAddressWarning.ts
+++ b/e2e/mobile/specs/verifyAddress/verifyAddressWarning.ts
@@ -1,4 +1,6 @@
 import { AccountType } from "@ledgerhq/live-common/e2e/enum/Account";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
+import { setTeamOwner } from "../../helpers/allure/allure-helper";
 
 type VerifyAddressWarningOptions = {
   skip?: boolean;
@@ -22,6 +24,7 @@ export function runVerifyAddressWarningTest(
       await app.portfolio.waitForPortfolioPageToLoad();
     });
 
+    setTeamOwner(Team.COIN_INTEGRATION);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it(`Verify address warning for ${account.currency.name}`, async () => {

--- a/e2e/mobile/specs/verifyAddress/verifyEmptyAddressTRX.spec.ts
+++ b/e2e/mobile/specs/verifyAddress/verifyEmptyAddressTRX.spec.ts
@@ -1,5 +1,8 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
+import { setTeamOwner } from "../../helpers/allure/allure-helper";
 
+setTeamOwner(Team.COIN_INTEGRATION);
 describe("Verify Address warnings", () => {
   const account = Account.TRX_3;
 

--- a/e2e/mobile/specs/wallet40/mainNavigationWallet40.spec.ts
+++ b/e2e/mobile/specs/wallet40/mainNavigationWallet40.spec.ts
@@ -1,5 +1,8 @@
 import { WALLET_40_FEATURE_FLAGS } from "../../utils/constants";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
+import { setTeamOwner } from "../../helpers/allure/allure-helper";
 
+setTeamOwner(Team.WALLET_XP);
 $TmsLink("B2CQA-4383");
 $TmsLink("B2CQA-4385");
 const tags: string[] = ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"];
@@ -21,6 +24,7 @@ describe("Wallet 4.0 - Main Navigation", () => {
     await app.mainNavigation.expectLegacyTabsNotVisible();
   });
 
+  setTeamOwner(Team.SWAP);
   it("should navigate to Swap via bottom tab", async () => {
     await app.mainNavigation.tapWallet40Tab("swap");
     await app.mainNavigation.expectWallet40BottomTabsVisible();

--- a/e2e/mobile/specs/wallet40/marketBanner.spec.ts
+++ b/e2e/mobile/specs/wallet40/marketBanner.spec.ts
@@ -1,4 +1,6 @@
 import { WALLET_40_FEATURE_FLAGS } from "../../utils/constants";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
+import { setTeamOwner } from "../../helpers/allure/allure-helper";
 
 const testConfig = {
   tmsLinks: [
@@ -16,6 +18,7 @@ const testConfig = {
 
 const TICKER = "BTC";
 
+setTeamOwner(Team.WALLET_XP);
 describe("Wallet 4.0 - Market Banner", () => {
   testConfig.tmsLinks.forEach(link => $TmsLink(link));
   testConfig.tags.forEach(tag => $Tag(tag));

--- a/e2e/mobile/specs/wallet40/myWallet.spec.ts
+++ b/e2e/mobile/specs/wallet40/myWallet.spec.ts
@@ -1,10 +1,13 @@
 import { WALLET_40_FEATURE_FLAGS } from "../../utils/constants";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
+import { setTeamOwner } from "../../helpers/allure/allure-helper";
 
 const testConfig = {
   tmsLinks: ["B2CQA-5405", "B2CQA-5426", "B2CQA-5427"],
   tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"],
 };
 
+setTeamOwner(Team.WALLET_XP);
 describe("Wallet 4.0 - MyWallet", () => {
   beforeAll(async () => {
     await app.init({

--- a/e2e/mobile/specs/wallet40/operationsHistory.spec.ts
+++ b/e2e/mobile/specs/wallet40/operationsHistory.spec.ts
@@ -1,5 +1,8 @@
 import { WALLET_40_FEATURE_FLAGS } from "../../utils/constants";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
+import { setTeamOwner } from "../../helpers/allure/allure-helper";
 
+setTeamOwner(Team.WALLET_XP);
 $TmsLink("B2CQA-5256");
 $TmsLink("B2CQA-5263");
 $TmsLink("B2CQA-5266");

--- a/e2e/mobile/specs/wallet40/portfolio.spec.ts
+++ b/e2e/mobile/specs/wallet40/portfolio.spec.ts
@@ -1,4 +1,6 @@
 import { WALLET_40_FEATURE_FLAGS } from "../../utils/constants";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
+import { setTeamOwner } from "../../helpers/allure/allure-helper";
 
 const testConfig = {
   tmsLinks: [
@@ -18,6 +20,7 @@ const ACCOUNT = Account.INJ_1;
 const CURRENCY = ACCOUNT.currency;
 const TICKER = CURRENCY.ticker;
 
+setTeamOwner(Team.WALLET_XP);
 describe("Wallet 4.0 - Portfolio", () => {
   beforeAll(async () => {
     await app.init({
@@ -71,6 +74,7 @@ describe("Wallet 4.0 - Portfolio", () => {
     await app.buySell.expectBuyScreenToBeVisible();
   });
 
+  setTeamOwner(Team.SWAP);
   it("navigates to the swap screen", async () => {
     await app.portfolio.openViaDeeplink();
     await app.portfolio.waitForPortfolioPageToLoad();

--- a/e2e/mobile/specs/wallet40/walletAssets.spec.ts
+++ b/e2e/mobile/specs/wallet40/walletAssets.spec.ts
@@ -1,7 +1,10 @@
 import { WALLET_40_FEATURE_FLAGS } from "../../utils/constants";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
+import { setTeamOwner } from "../../helpers/allure/allure-helper";
 
 const TAGS = ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"];
 
+setTeamOwner(Team.WALLET_XP);
 describe("Wallet 4.0 - Portfolio-Asset/Address - Onboard without accounts", () => {
   const tmsLinks = ["B2CQA-4839", "B2CQA-4840"];
   const currency = Account.INJ_1.currency;
@@ -33,6 +36,7 @@ describe("Wallet 4.0 - Portfolio-Asset/Address - Onboard without accounts", () =
   });
 });
 
+setTeamOwner(Team.WALLET_XP);
 describe("Wallet 4.0 - Portfolio-Asset/Address - With fewer accounts than section minimum (padding)", () => {
   const tmsLinks = ["B2CQA-4841"];
 
@@ -55,6 +59,7 @@ describe("Wallet 4.0 - Portfolio-Asset/Address - With fewer accounts than sectio
   });
 });
 
+setTeamOwner(Team.WALLET_XP);
 describe("Wallet 4.0 - Portfolio-Asset/Address - Open the app with accounts", () => {
   const tmsLinks = ["B2CQA-4834", "B2CQA-4837", "B2CQA-4838"];
 

--- a/e2e/mobile/types/global.d.ts
+++ b/e2e/mobile/types/global.d.ts
@@ -10,6 +10,8 @@ import type {
   $TmsLink as $TmsLinkType,
   Step as StepType,
   $Tag as $TagType,
+  $Owner as $OwnerType,
+  $ParentSuite as $ParentSuiteType,
 } from "jest-allure2-reporter/api";
 import { NativeElementHelpers, WebElementHelpers } from "../helpers/elementHelpers";
 import { Currency as CurrencyType } from "@ledgerhq/live-common/e2e/enum/Currency";
@@ -43,6 +45,8 @@ declare global {
   var Step: typeof StepType;
   var $TmsLink: typeof $TmsLinkType;
   var $Tag: typeof $TagType;
+  var $Owner: typeof $OwnerType;
+  var $ParentSuite: typeof $ParentSuiteType;
   var CLI: typeof CLIType;
   var jestExpect: typeof expect;
   var Currency: typeof CurrencyType;

--- a/e2e/mobile/types/jest-allure2-reporter.d.ts
+++ b/e2e/mobile/types/jest-allure2-reporter.d.ts
@@ -8,6 +8,10 @@ declare module "jest-allure2-reporter/api" {
 
   export function $Tag(...tags: string[]): void;
 
+  export function $Owner(owner: string): void;
+
+  export function $ParentSuite(parentSuite: string): void;
+
   export function $Severity(severity: string): void;
 
   export function $Epic(epic: string): void;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _This change only adds Allure `owner`/`parentSuite` metadata to existing e2e tests; there is no product code to cover. The e2e suite runs unchanged, and `typecheck` + `oxlint` pass._
- [x] **Impact of the changes:**
  - Every mobile e2e test now carries an Allure `Owner` and `ParentSuite` equal to its team (Wallet XP, Swap, Coin-integration, BuyAndSell, Earn, BST).
  - No test logic/behaviour changed — labels are added next to the existing `$Tag` / `$TmsLink` annotations.
  - QA: in Allure, check tests are grouped under the correct team (Suites view) and the `Owner` field is populated; confirm no suite is left without a team.

### 📝 Description

The desktop app (LWD) already categorises its e2e tests by team (QAA-1235); the mobile app (LWM) did not, so mobile Allure reports could not be grouped or filtered by team.

This PR brings the same team system to LWM:

- Adds a `setTeamOwner(team)` helper (`e2e/mobile/helpers/allure/allure-helper.ts`) that sets both the Allure `owner` and `parentSuite` labels — the mobile equivalent of desktop's `addTeamOwner`.
- Declares the `$Owner` / `$ParentSuite` global pseudo-annotations in the e2e TypeScript types.
- Assigns a team to **every** test:
  - single-team helpers/specs → one `setTeamOwner` per suite;
  - currency-dependent suites (`addAccount`, `send`, `delegate`) → currency→team mapping (BST vs Coin-integration);
  - mixed inline specs (`deeplinks`, Wallet 4.0 nav/portfolio) → a default team with per-test overrides (e.g. `Swap`).

Coverage was verified exhaustively: all inline-test specs and all test-producing helpers carry a team; `typecheck` and `oxlint` pass.

**Notes while cross-referencing the QAA-1235 list:**
- `Swap - DEX Native flow → (Velora)` has no LWM equivalent (LWM tests `1inch` and `OKX` for this suite instead).
- A few `Wallet 4.0 - Main Navigation` tests from the list were renamed/refactored in LWM (top-bar → "My Wallet" avatar menu): `My Ledger via top bar / Manager page`, `Settings via top bar`, `Notifications via top bar`.

### ❓ Context

https://github.com/LedgerHQ/ledger-live/actions/runs/26961718359

- **JIRA or GitHub link**: [QAA-1235](https://ledgerhq.atlassian.net/browse/QAA-1235)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[QAA-1235]: https://ledgerhq.atlassian.net/browse/QAA-1235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ