### PR TITLE
chore(skills): remove gitmoji from create-pr commit instructions

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -40,7 +40,7 @@ $HAS_UI_CHANGES
 
 ## Instructions
 
-**IMPORTANT**: Before any git commit, read and follow the `.agents/skills/git-workflow/SKILL.md` skill. All commit messages MUST use the gitmoji shortcode format defined there (`:gitmoji: type(scope): description`). Analyze the staged diff to pick the correct gitmoji and scope.
+**IMPORTANT**: Before any git commit, read and follow the `.agents/skills/git-workflow/SKILL.md` skill. All commit messages MUST use the Conventional Commits format defined there (`type(scope): description`). Analyze the staged diff to pick the correct type and scope.
 
 ### Step 1: Analyze the changes
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached. _N/A — this change only edits `.agents/skills/create-pr/SKILL.md`, which is not part of any published package, so no changeset is needed._
- [ ] **Covered by automatic tests.** _N/A — documentation-only change to a skill file; nothing testable._
- [x] **Impact of the changes:**
      - None on runtime/app behavior. Affects only the internal `create-pr` skill instructions used by tooling/agents.

### 📝 Description

The `create-pr` skill instructed all commit messages to use the gitmoji shortcode format (`:gitmoji: type(scope): description`), referencing `git-workflow/SKILL.md`. However, `git-workflow/SKILL.md` no longer uses gitmoji — it defines plain **Conventional Commits**. The instruction was therefore both outdated and the source of unwanted gitmoji in commits.

This PR updates the instruction in `create-pr/SKILL.md` to use the Conventional Commits format (`type(scope): description`), aligning it with the actual git-workflow convention. `gitmoji` no longer appears anywhere in the repo.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31923](https://ledgerhq.atlassian.net/browse/LIVE-31923)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31923]: https://ledgerhq.atlassian.net/browse/LIVE-31923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ