### PR TITLE
[LWDM] feat(monad): add withdraw flow for mobile

### DIFF
--- a/.changeset/evm-monad-mobile-withdraw-flow.md
+++ b/.changeset/evm-monad-mobile-withdraw-flow.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add Monad withdraw flow on mobile to finalize matured undelegations from the undelegation drawer. Also fix the mobile undelegation list display: unique row keys for Monad withdrawal slots sharing a completion date, and proper separation from the delegation list.

--- a/apps/ledger-live-mobile/src/components/DelegationDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/DelegationDrawer.tsx
@@ -98,7 +98,12 @@ export default function DelegationDrawer({
         </ScrollView>
 
         <View
-          style={[styles.row, styles.actionsRow, { paddingBottom: Math.max(16, insets.bottom) }]}
+          style={[
+            styles.row,
+            styles.actionsRow,
+            actions.length === 1 && styles.actionsRowSingle,
+            { paddingBottom: Math.max(16, insets.bottom) },
+          ]}
         >
           {actions.map((props, i) => (
             <ActionButton key={`actions-${i}`} {...props} />
@@ -223,6 +228,9 @@ export const styles = StyleSheet.create({
     paddingHorizontal: 16,
     alignItems: "flex-start",
     justifyContent: "space-between",
+  },
+  actionsRowSingle: {
+    justifyContent: "center",
   },
   actionWrapper: {
     width: 80,

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
@@ -40,6 +40,7 @@ import type { EditTransactionParamList } from "../../../families/evm/EditTransac
 import type { EvmDelegationFlowParamList } from "../../../families/evm/DelegationFlow/types";
 import type { EvmUndelegationFlowParamList } from "../../../families/evm/UndelegationFlow/types";
 import type { EvmClaimRewardsFlowParamList } from "../../../families/evm/ClaimRewardsFlow/types";
+import type { EvmWithdrawFlowParamList } from "../../../families/evm/WithdrawFlow/types";
 import type { BitcoinEditTransactionParamList } from "../../../families/bitcoin/EditTransactionFlow/EditTransactionParamList";
 import type { PolkadotBondFlowParamList } from "../../../families/polkadot/BondFlow/types";
 import type { PolkadotNominateFlowParamList } from "../../../families/polkadot/NominateFlow/types";
@@ -295,6 +296,7 @@ export type BaseNavigatorStackParamList = {
   [NavigatorName.EvmDelegationFlow]: NavigatorScreenParams<EvmDelegationFlowParamList>;
   [NavigatorName.EvmUndelegationFlow]: NavigatorScreenParams<EvmUndelegationFlowParamList>;
   [NavigatorName.EvmClaimRewardsFlow]: NavigatorScreenParams<EvmClaimRewardsFlowParamList>;
+  [NavigatorName.EvmWithdrawFlow]: NavigatorScreenParams<EvmWithdrawFlowParamList>;
   [NavigatorName.EvmEditTransaction]: NavigatorScreenParams<EditTransactionParamList>;
 
   // Bitcoin edit transaction (RBF)

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -265,6 +265,11 @@ export enum ScreenName {
   EvmClaimRewardsConnectDevice = "EvmClaimRewardsConnectDevice",
   EvmClaimRewardsValidationError = "EvmClaimRewardsValidationError",
   EvmClaimRewardsValidationSuccess = "EvmClaimRewardsValidationSuccess",
+  EvmWithdrawConfirmation = "EvmWithdrawConfirmation",
+  EvmWithdrawSelectDevice = "EvmWithdrawSelectDevice",
+  EvmWithdrawConnectDevice = "EvmWithdrawConnectDevice",
+  EvmWithdrawValidationError = "EvmWithdrawValidationError",
+  EvmWithdrawValidationSuccess = "EvmWithdrawValidationSuccess",
 
   // cosmos
   CosmosFamilyEditMemo = "CosmosFamilyEditMemo",
@@ -643,6 +648,7 @@ export enum NavigatorName {
   EvmDelegationFlow = "EvmDelegationFlow",
   EvmUndelegationFlow = "EvmUndelegationFlow",
   EvmClaimRewardsFlow = "EvmClaimRewardsFlow",
+  EvmWithdrawFlow = "EvmWithdrawFlow",
   CosmosClaimRewardsFlow = "CosmosClaimRewardsFlow",
   CosmosDelegationFlow = "CosmosDelegationFlow",
   CosmosRedelegationFlow = "CosmosRedelegationFlow",

--- a/apps/ledger-live-mobile/src/families/evm/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/AccountBalanceSummaryFooter.tsx
@@ -56,7 +56,7 @@ function AccountBalanceSummaryFooter({ account }: { account: StakingAccount }) {
               <InfoItem
                 title={t("account.delegatedAssets")}
                 onPress={onPressInfoCreator("delegated")}
-                value={<CurrencyUnitValue unit={unit} value={delegatedBalance} disableRounding />}
+                value={<CurrencyUnitValue unit={unit} value={delegatedBalance} />}
                 isLast={unbondingBalance.lte(0)}
               />
             )}
@@ -64,7 +64,7 @@ function AccountBalanceSummaryFooter({ account }: { account: StakingAccount }) {
               <InfoItem
                 title={t("account.undelegating")}
                 onPress={onPressInfoCreator("undelegating")}
-                value={<CurrencyUnitValue unit={unit} value={unbondingBalance} disableRounding />}
+                value={<CurrencyUnitValue unit={unit} value={unbondingBalance} />}
                 isLast={true}
               />
             )}

--- a/apps/ledger-live-mobile/src/families/evm/Delegations/index.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/Delegations/index.tsx
@@ -41,6 +41,7 @@ import ClaimRewardIcon from "~/icons/ClaimReward";
 import IlluRewards from "~/icons/images/Rewards";
 import RedelegateIcon from "~/icons/Redelegate";
 import UndelegateIcon from "~/icons/Undelegate";
+import WithdrawIcon from "~/icons/Withdraw";
 import { urls } from "~/utils/urls";
 import { useAccountName } from "~/reducers/wallet";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
@@ -166,6 +167,17 @@ function Delegations({ account }: { account: StakingAccount }) {
       },
     });
   }, [delegation, onNavigate]);
+
+  const onWithdraw = useCallback(() => {
+    if (!undelegation) return;
+    onNavigate({
+      navigator: NavigatorName.EvmWithdrawFlow,
+      screen: ScreenName.EvmWithdrawConfirmation,
+      params: {
+        unbonding: undelegation,
+      },
+    });
+  }, [undelegation, onNavigate]);
 
   const onCloseDrawer = useCallback(() => {
     setDelegation(undefined);
@@ -295,45 +307,65 @@ function Delegations({ account }: { account: StakingAccount }) {
   }, [account, accountName, delegation, onOpenExplorer, t, undelegation]);
 
   const actions = useMemo<DelegationDrawerActions>(() => {
-    if (!delegation) return [];
     const result: DelegationDrawerActions = [];
 
-    if (canUndelegate(account, delegation)) {
-      result.push({
-        label: t("delegation.actions.undelegate"),
-        Icon: (props: IconProps) => (
-          <Circle {...props} bg={colors.fog}>
-            <UndelegateIcon />
-          </Circle>
-        ),
-        onPress: onUndelegate,
-        event: "DelegationActionUndelegate",
-      });
+    if (delegation) {
+      if (canUndelegate(account, delegation)) {
+        result.push({
+          label: t("delegation.actions.undelegate"),
+          Icon: (props: IconProps) => (
+            <Circle {...props} bg={colors.fog}>
+              <UndelegateIcon />
+            </Circle>
+          ),
+          onPress: onUndelegate,
+          event: "DelegationActionUndelegate",
+        });
+      }
+
+      if (canRedelegate(account, delegation)) {
+        result.push({
+          label: t("delegation.actions.redelegate"),
+          Icon: (props: IconProps) => (
+            <Circle {...props} bg={colors.fog}>
+              <RedelegateIcon />
+            </Circle>
+          ),
+          onPress: onRedelegate,
+          event: "DelegationActionRedelegate",
+        });
+      }
+
+      if (delegation.pendingRewards?.gt(0)) {
+        result.push({
+          label: t("delegation.actions.collectRewards"),
+          Icon: (props: IconProps) => (
+            <Circle {...props} bg={rgba(colors.yellow, 0.2)}>
+              <ClaimRewardIcon />
+            </Circle>
+          ),
+          onPress: onCollectRewards,
+          event: "DelegationActionCollectRewards",
+        });
+      }
     }
 
-    if (canRedelegate(account, delegation)) {
+    // Withdraw only applies to chains with an explicit finalization slot (Monad carries a
+    // withdrawId); other EVM chains auto-return funds once the timelock completes.
+    const canWithdraw =
+      !delegation &&
+      undelegation?.withdrawId !== undefined &&
+      new Date(undelegation.completionDate).getTime() <= Date.now();
+    if (canWithdraw) {
       result.push({
-        label: t("delegation.actions.redelegate"),
+        label: t("delegation.actions.withdraw"),
         Icon: (props: IconProps) => (
-          <Circle {...props} bg={colors.fog}>
-            <RedelegateIcon />
+          <Circle {...props} bg={rgba(colors.green, 0.2)}>
+            <WithdrawIcon size={24} color={colors.green} />
           </Circle>
         ),
-        onPress: onRedelegate,
-        event: "DelegationActionRedelegate",
-      });
-    }
-
-    if (delegation.pendingRewards?.gt(0)) {
-      result.push({
-        label: t("delegation.actions.collectRewards"),
-        Icon: (props: IconProps) => (
-          <Circle {...props} bg={rgba(colors.yellow, 0.2)}>
-            <ClaimRewardIcon />
-          </Circle>
-        ),
-        onPress: onCollectRewards,
-        event: "DelegationActionCollectRewards",
+        onPress: onWithdraw,
+        event: "DelegationActionWithdraw",
       });
     }
 
@@ -341,11 +373,14 @@ function Delegations({ account }: { account: StakingAccount }) {
   }, [
     account,
     colors.fog,
+    colors.green,
     colors.yellow,
     delegation,
+    undelegation,
     onCollectRewards,
     onRedelegate,
     onUndelegate,
+    onWithdraw,
     t,
   ]);
 
@@ -425,12 +460,12 @@ function Delegations({ account }: { account: StakingAccount }) {
         </View>
       )}
       {undelegations.length > 0 ? (
-        <View style={styles.wrapper}>
+        <View style={styles.undelegationsWrapper}>
           <AccountSectionLabel name={t("account.undelegation.sectionLabel")} />
           {undelegations.map((d, i) => (
             <View
               key={`${d.validatorAddress}-${d.completionDate.valueOf()}-${d.withdrawId ?? i}`}
-              style={[styles.delegationsWrapper, { backgroundColor: colors.card }]}
+              style={styles.delegationsWrapper}
             >
               <DelegationRow
                 delegation={d}
@@ -468,6 +503,9 @@ const styles = StyleSheet.create({
     marginBottom: 16,
   },
   wrapper: {},
+  undelegationsWrapper: {
+    marginTop: 24,
+  },
   delegationsWrapper: {
     borderRadius: 4,
   },

--- a/apps/ledger-live-mobile/src/families/evm/WithdrawFlow/01-Withdraw.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/WithdrawFlow/01-Withdraw.tsx
@@ -1,0 +1,152 @@
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+import invariant from "invariant";
+import { BigNumber } from "bignumber.js";
+import React, { useCallback } from "react";
+import { StyleSheet, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { useNavigation, useRoute } from "@react-navigation/native";
+import { Alert, Flex, Text } from "@ledgerhq/native-ui";
+import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-coin-framework/types";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import type { TransactionStatus } from "@ledgerhq/coin-evm/types/index";
+import { Trans } from "~/context/Locale";
+import { TrackScreen } from "~/analytics";
+import Button from "~/components/Button";
+import CounterValue from "~/components/CounterValue";
+import CurrencyUnitValue from "~/components/CurrencyUnitValue";
+import TranslatedError from "~/components/TranslatedError";
+import ValidatorImage from "~/families/evm/shared/ValidatorImage";
+import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import { ScreenName } from "~/const";
+import { useAccountUnit } from "LLM/hooks/useAccountUnit";
+import { useAccountScreen } from "LLM/hooks/useAccountScreen";
+import type { EvmWithdrawFlowParamList } from "./types";
+
+type Navigation = StackNavigatorProps<EvmWithdrawFlowParamList, ScreenName.EvmWithdrawConfirmation>;
+
+function Withdraw() {
+  const navigation = useNavigation<Navigation["navigation"]>();
+  const route = useRoute<Navigation["route"]>();
+  const { account } = useAccountScreen(route);
+  invariant(account, "account required");
+  invariant(account.type === "Account", "account must be of type Account");
+
+  const { unbonding } = route.params;
+  const validatorName =
+    unbonding.validator?.name ?? unbonding.validatorName ?? unbonding.validatorAddress;
+  const unit = useAccountUnit(account);
+  const bridge = useAccountBridge<GenericTransaction>(account);
+
+  const { transaction, status, bridgePending, bridgeError } = useBridgeTransaction(bridge, () => {
+    // STUB (LIVE-31683): bridge has no "withdraw" mode yet — self-send so the flow
+    // runs end-to-end. Replace with `mode: "withdraw"` once coin-evm supports it.
+    const base = bridge.updateTransaction(bridge.createTransaction(account), {
+      recipient: account.freshAddress,
+    });
+    const withdrawTx = bridge.updateTransaction(base, {
+      mode: "send",
+      recipient: account.freshAddress,
+      // Minimal self-send: the matured amount is still locked until the real withdraw
+      // call (LIVE-31683), so sending it would hit NotEnoughBalance. 1 wei keeps the
+      // stub flow usable (user only covers fees).
+      amount: new BigNumber(1),
+      useAllAmount: false,
+    });
+    return { account, parentAccount: undefined, transaction: withdrawTx as unknown as Transaction };
+  });
+
+  invariant(transaction, "transaction required");
+
+  const onContinue = useCallback(() => {
+    navigation.navigate(ScreenName.EvmWithdrawSelectDevice, {
+      accountId: route.params.accountId,
+      parentId: route.params.parentId,
+      transaction: transaction as unknown as Transaction,
+      status: status as TransactionStatus,
+    });
+  }, [navigation, route.params.accountId, route.params.parentId, transaction, status]);
+
+  const hasErrors = Object.keys(status.errors).length > 0;
+  const error = Object.values(status.errors)[0];
+
+  return (
+    <SafeAreaView style={styles.root}>
+      <TrackScreen
+        category="EvmWithdraw"
+        name="Withdraw"
+        flow="stake"
+        action="withdraw"
+        currency={account.currency.ticker}
+      />
+      <View style={styles.body}>
+        <Flex mb={32}>
+          <Text
+            fontWeight="semiBold"
+            numberOfLines={1}
+            fontSize={24}
+            textAlign="center"
+            mb={3}
+            adjustsFontSizeToFit
+          >
+            <CurrencyUnitValue showCode unit={unit} value={unbonding.amount} />
+          </Text>
+          <Text textAlign="center" color="smoke">
+            <CounterValue
+              currency={account.currency}
+              value={unbonding.amount}
+              alwaysShowSign={false}
+              withPlaceholder
+              showCode
+            />
+          </Text>
+        </Flex>
+        <Flex flexDirection="row" alignItems="center" justifyContent="center" columnGap={2} mb={8}>
+          <ValidatorImage isLedger={false} name={validatorName} size={32} />
+          <Text numberOfLines={1} fontWeight="semiBold" fontSize={14}>
+            {validatorName}
+          </Text>
+        </Flex>
+        <Alert type="info" title={<Trans i18nKey="evm.withdraw.flow.steps.withdraw.warning" />} />
+      </View>
+      <View style={styles.footer}>
+        {error ? (
+          <Text color="alert" fontWeight="semiBold" textAlign="center" mb={6}>
+            <TranslatedError error={error} />
+          </Text>
+        ) : null}
+        <Button
+          event="EvmWithdrawContinue"
+          type="primary"
+          title={<Trans i18nKey="evm.withdraw.flow.steps.withdraw.cta" />}
+          containerStyle={styles.continueButton}
+          onPress={onContinue}
+          disabled={bridgePending || !!bridgeError || hasErrors}
+          pending={bridgePending}
+        />
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  body: {
+    flex: 1,
+    paddingHorizontal: 16,
+    justifyContent: "center",
+  },
+  footer: {
+    paddingHorizontal: 16,
+    paddingTop: 16,
+    paddingBottom: 16,
+  },
+  continueButton: {
+    alignSelf: "stretch",
+  },
+});
+
+export default Withdraw;

--- a/apps/ledger-live-mobile/src/families/evm/WithdrawFlow/03-ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/WithdrawFlow/03-ValidationError.tsx
@@ -1,0 +1,53 @@
+import React, { useCallback } from "react";
+import { StyleSheet } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { useNavigation, useRoute, useTheme } from "@react-navigation/native";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
+import { TrackScreen } from "~/analytics";
+import ValidateError from "~/components/ValidateError";
+import type {
+  BaseComposite,
+  StackNavigatorNavigation,
+  StackNavigatorProps,
+} from "~/components/RootNavigator/types/helpers";
+import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import type { EvmWithdrawFlowParamList } from "./types";
+import { ScreenName } from "~/const";
+import { useAccountScreen } from "LLM/hooks/useAccountScreen";
+
+type Navigation = BaseComposite<
+  StackNavigatorProps<EvmWithdrawFlowParamList, ScreenName.EvmWithdrawValidationError>
+>;
+
+export default function ValidationError() {
+  const navigation = useNavigation<Navigation["navigation"]>();
+  const route = useRoute<Navigation["route"]>();
+  const { colors } = useTheme();
+  const { account } = useAccountScreen(route);
+  const { ticker } = getAccountCurrency(account);
+  const onClose = useCallback(() => {
+    navigation.getParent<StackNavigatorNavigation<BaseNavigatorStackParamList>>().pop();
+  }, [navigation]);
+  const retry = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
+  const error = route.params.error;
+  return (
+    <SafeAreaView style={[styles.root, { backgroundColor: colors.background }]}>
+      <TrackScreen
+        category="EvmWithdraw"
+        name="ValidationError"
+        flow="stake"
+        action="withdraw"
+        currency={ticker}
+      />
+      <ValidateError error={error} onRetry={retry} onClose={onClose} />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+});

--- a/apps/ledger-live-mobile/src/families/evm/WithdrawFlow/03-ValidationSuccess.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/WithdrawFlow/03-ValidationSuccess.tsx
@@ -1,0 +1,65 @@
+import React, { useCallback } from "react";
+import { View, StyleSheet } from "react-native";
+import { Trans } from "~/context/Locale";
+import { useNavigation, useRoute, useTheme } from "@react-navigation/native";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
+import { TrackScreen } from "~/analytics";
+import { ScreenName } from "~/const";
+import PreventNativeBack from "~/components/PreventNativeBack";
+import ValidateSuccess from "~/components/ValidateSuccess";
+import type {
+  BaseComposite,
+  StackNavigatorNavigation,
+  StackNavigatorProps,
+} from "~/components/RootNavigator/types/helpers";
+import type { EvmWithdrawFlowParamList } from "./types";
+import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import { useAccountScreen } from "LLM/hooks/useAccountScreen";
+
+type Navigation = BaseComposite<
+  StackNavigatorProps<EvmWithdrawFlowParamList, ScreenName.EvmWithdrawValidationSuccess>
+>;
+
+export default function ValidationSuccess() {
+  const navigation = useNavigation<Navigation["navigation"]>();
+  const route = useRoute<Navigation["route"]>();
+  const { colors } = useTheme();
+  const { account } = useAccountScreen(route);
+  const { ticker } = getAccountCurrency(account);
+  const onClose = useCallback(() => {
+    navigation.getParent<StackNavigatorNavigation<BaseNavigatorStackParamList>>().pop();
+  }, [navigation]);
+  const goToOperationDetails = useCallback(() => {
+    if (!account) return;
+    const result = route.params?.result;
+    if (!result) return;
+    navigation.navigate(ScreenName.OperationDetails, {
+      accountId: account.id,
+      operation: result,
+    });
+  }, [account, route.params, navigation]);
+  return (
+    <View style={[styles.root, { backgroundColor: colors.background }]}>
+      <TrackScreen
+        category="EvmWithdraw"
+        name="ValidationSuccess"
+        flow="stake"
+        action="withdraw"
+        currency={ticker}
+      />
+      <PreventNativeBack />
+      <ValidateSuccess
+        onClose={onClose}
+        onViewDetails={goToOperationDetails}
+        title={<Trans i18nKey="evm.withdraw.flow.steps.verification.success.title" />}
+        description={<Trans i18nKey="evm.withdraw.flow.steps.verification.success.text" />}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+});

--- a/apps/ledger-live-mobile/src/families/evm/WithdrawFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/WithdrawFlow/index.tsx
@@ -1,0 +1,112 @@
+import React, { useMemo } from "react";
+import { Platform } from "react-native";
+import { useTranslation } from "~/context/Locale";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { useTheme } from "@react-navigation/native";
+import {
+  bridgeSuspenseScreenLayout,
+  defaultNavigationOptions,
+  getStackNavigatorConfig,
+} from "~/navigation/navigatorConfig";
+import StepHeader from "~/components/StepHeader";
+import { ScreenName } from "~/const";
+import Withdraw from "./01-Withdraw";
+import WithdrawSelectDevice from "~/screens/SelectDevice";
+import WithdrawConnectDevice from "~/screens/ConnectDevice";
+import WithdrawValidationError from "./03-ValidationError";
+import WithdrawValidationSuccess from "./03-ValidationSuccess";
+import type { EvmWithdrawFlowParamList } from "./types";
+import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+
+const totalSteps = "3";
+
+function StepTitle({ titleKey, currentStep }: { titleKey: string; currentStep: string }) {
+  const { t } = useTranslation();
+  return (
+    <StepHeader
+      title={t(titleKey)}
+      subtitle={t("evm.withdraw.stepperHeader.stepRange", { currentStep, totalSteps })}
+    />
+  );
+}
+
+function WithdrawHeader() {
+  return <StepTitle titleKey="evm.withdraw.stepperHeader.title" currentStep="1" />;
+}
+
+function SelectDeviceHeader() {
+  return <StepTitle titleKey="evm.withdraw.stepperHeader.selectDevice" currentStep="2" />;
+}
+
+function ConnectDeviceHeader() {
+  return <StepTitle titleKey="evm.withdraw.stepperHeader.connectDevice" currentStep="3" />;
+}
+
+function WithdrawFlow() {
+  const { colors } = useTheme();
+  const { notifyFlowCompleted } = useNotificationsContext();
+  const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
+  return (
+    <Stack.Navigator
+      screenOptions={{
+        ...stackNavigationConfig,
+        gestureEnabled: Platform.OS === "ios",
+      }}
+      screenLayout={bridgeSuspenseScreenLayout}
+    >
+      <Stack.Screen
+        name={ScreenName.EvmWithdrawConfirmation}
+        component={Withdraw}
+        options={{
+          headerTitle: WithdrawHeader,
+          headerLeft: () => null,
+          headerStyle: defaultNavigationOptions.headerStyle,
+          gestureEnabled: false,
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.EvmWithdrawSelectDevice}
+        component={WithdrawSelectDevice}
+        options={{ headerTitle: SelectDeviceHeader }}
+      />
+      <Stack.Screen
+        name={ScreenName.EvmWithdrawConnectDevice}
+        component={WithdrawConnectDevice}
+        options={{
+          headerLeft: undefined,
+          gestureEnabled: false,
+          headerTitle: ConnectDeviceHeader,
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.EvmWithdrawValidationError}
+        component={WithdrawValidationError}
+        options={{
+          headerShown: false,
+          gestureEnabled: false,
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.EvmWithdrawValidationSuccess}
+        component={WithdrawValidationSuccess}
+        options={{
+          headerLeft: undefined,
+          headerRight: undefined,
+          headerTitle: "",
+          gestureEnabled: false,
+        }}
+        listeners={{
+          beforeRemove: () => {
+            notifyFlowCompleted("stake");
+          },
+        }}
+      />
+    </Stack.Navigator>
+  );
+}
+
+const options = {
+  headerShown: false,
+};
+export { WithdrawFlow as component, options };
+const Stack = createNativeStackNavigator<EvmWithdrawFlowParamList>();

--- a/apps/ledger-live-mobile/src/families/evm/WithdrawFlow/types.ts
+++ b/apps/ledger-live-mobile/src/families/evm/WithdrawFlow/types.ts
@@ -1,0 +1,45 @@
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import type { TransactionStatus } from "@ledgerhq/coin-evm/types/index";
+import type { StakingMappedUnbonding } from "@ledgerhq/live-common/families/evm/staking/types";
+import type { Operation } from "@ledgerhq/types-live";
+import type { Device } from "@ledgerhq/live-common/hw/actions/types";
+import { ScreenName } from "~/const";
+
+export type EvmWithdrawFlowParamList = {
+  [ScreenName.EvmWithdrawConfirmation]: {
+    accountId: string;
+    parentId?: string | null;
+    unbonding: StakingMappedUnbonding;
+  };
+  [ScreenName.EvmWithdrawSelectDevice]: {
+    accountId: string;
+    parentId?: string | null;
+    transaction: Transaction;
+    status: TransactionStatus;
+  };
+  [ScreenName.EvmWithdrawConnectDevice]: {
+    device: Device;
+    accountId: string;
+    parentId?: string | null;
+    transaction: Transaction;
+    status: TransactionStatus;
+    appName?: string;
+    selectDeviceLink?: boolean;
+    onSuccess?: (payload: unknown) => void;
+    onError?: (error: Error) => void;
+    analyticsPropertyFlow?: string;
+    forceSelectDevice?: boolean;
+  };
+  [ScreenName.EvmWithdrawValidationError]: {
+    accountId: string;
+    deviceId: string;
+    transaction: Transaction;
+    error: Error;
+  };
+  [ScreenName.EvmWithdrawValidationSuccess]: {
+    accountId: string;
+    deviceId: string;
+    transaction: Transaction;
+    result: Operation;
+  };
+};

--- a/apps/ledger-live-mobile/src/families/evm/index.ts
+++ b/apps/ledger-live-mobile/src/families/evm/index.ts
@@ -3,3 +3,4 @@ export * as EvmCustomFees from "./EvmCustomFees";
 export * as EvmDelegationFlow from "./DelegationFlow";
 export * as EvmUndelegationFlow from "./UndelegationFlow";
 export * as EvmClaimRewardsFlow from "./ClaimRewardsFlow";
+export * as EvmWithdrawFlow from "./WithdrawFlow";

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -6884,6 +6884,30 @@
           }
         }
       }
+    },
+    "withdraw": {
+      "stepperHeader": {
+        "title": "Withdraw",
+        "selectDevice": "Select device",
+        "connectDevice": "Connect device",
+        "stepRange": "Step {{currentStep}} of {{totalSteps}}"
+      },
+      "flow": {
+        "steps": {
+          "withdraw": {
+            "warning": "The undelegated amount has completed its timelock and will be sent back to your available balance.",
+            "cta": "Continue"
+          },
+          "verification": {
+            "success": {
+              "title": "You have successfully withdrawn your assets.",
+              "text": "Your account balance will be updated when the network confirms the transaction.",
+              "cta": "View details"
+            },
+            "broadcastError": "Your transaction may have failed. Please wait a moment then check the transaction history before trying again."
+          }
+        }
+      }
     }
   },
   "tron": {

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptStakeFlow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptStakeFlow.test.tsx
@@ -348,6 +348,18 @@ const stakePromptCases: StakePromptCase[] = [
     transaction: { family: "evm", mode: "claimReward" },
   },
   {
+    label: "EVM withdraw",
+    bucket: "withdrawing/withdraw",
+    flowName: NavigatorName.EvmWithdrawFlow,
+    familyExportKey: "EvmWithdrawFlow",
+    successScreenName: ScreenName.EvmWithdrawValidationSuccess,
+    errorScreenName: ScreenName.EvmWithdrawValidationError,
+    accountKey: "ethereum",
+    operationType: "WITHDRAW",
+    // STUB (LIVE-31683): coin-evm has no "withdraw" mode yet, the flow self-sends.
+    transaction: { family: "evm", mode: "send" },
+  },
+  {
     label: "Hedera claim rewards",
     bucket: "revoke/claim/lifecycle",
     flowName: NavigatorName.HederaClaimRewardsFlow,

--- a/apps/ledger-live-mobile/src/screens/ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/ConnectDevice.tsx
@@ -60,6 +60,7 @@ import { SuiUnstakingFlowParamList } from "~/families/sui/UnstakingFlow/types";
 import type { EvmDelegationFlowParamList } from "~/families/evm/DelegationFlow/types";
 import type { EvmUndelegationFlowParamList } from "~/families/evm/UndelegationFlow/types";
 import type { EvmClaimRewardsFlowParamList } from "~/families/evm/ClaimRewardsFlow/types";
+import type { EvmWithdrawFlowParamList } from "~/families/evm/WithdrawFlow/types";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 
 type Props =
@@ -130,7 +131,8 @@ type Props =
   | StackNavigatorProps<EvmDelegationFlowParamList, ScreenName.EvmDelegationConnectDevice>
   | StackNavigatorProps<EvmUndelegationFlowParamList, ScreenName.EvmUndelegationConnectDevice>
   | StackNavigatorProps<EvmDelegationFlowParamList, ScreenName.EvmRedelegationConnectDevice>
-  | StackNavigatorProps<EvmClaimRewardsFlowParamList, ScreenName.EvmClaimRewardsConnectDevice>;
+  | StackNavigatorProps<EvmClaimRewardsFlowParamList, ScreenName.EvmClaimRewardsConnectDevice>
+  | StackNavigatorProps<EvmWithdrawFlowParamList, ScreenName.EvmWithdrawConnectDevice>;
 
 export const navigateToSelectDevice = (navigation: Props["navigation"], route: Props["route"]) =>
   // Assumes that it will always navigate to a "SelectDevice"

--- a/libs/coin-modules/coin-evm/src/staking/logic.ts
+++ b/libs/coin-modules/coin-evm/src/staking/logic.ts
@@ -31,12 +31,12 @@ export function mapDelegations(
     return {
       ...d,
       formattedAmount: formatCurrencyUnit(unit, d.amount, {
-        disableRounding: true,
+        disableRounding: false,
         alwaysShowSign: false,
         showCode: true,
       }),
       formattedPendingRewards: formatCurrencyUnit(unit, d.pendingRewards, {
-        disableRounding: true,
+        disableRounding: false,
         alwaysShowSign: false,
         showCode: true,
       }),
@@ -59,7 +59,7 @@ export function mapUnbondings(
     return {
       ...u,
       formattedAmount: formatCurrencyUnit(unit, u.amount, {
-        disableRounding: true,
+        disableRounding: false,
         alwaysShowSign: false,
         showCode: true,
       }),
@@ -79,7 +79,7 @@ export function mapRedelegations(
     return {
       ...r,
       formattedAmount: formatCurrencyUnit(unit, r.amount, {
-        disableRounding: true,
+        disableRounding: false,
         alwaysShowSign: false,
         showCode: true,
       }),
@@ -99,7 +99,7 @@ export const mapDelegationInfo = (
     ...d,
     validator: validators.find(v => v.validatorAddress === d.address),
     formattedAmount: formatCurrencyUnit(unit, transaction ? transaction.amount : d.amount, {
-      disableRounding: true,
+      disableRounding: false,
       alwaysShowSign: false,
       showCode: true,
     }),


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _Added a case to the stake-prompt coverage test (`NotificationsPromptStakeFlow.test.tsx`); the flow screens themselves are not unit-tested, mirroring the existing EVM `ClaimRewardsFlow`/`UndelegationFlow` (validated manually)._
- [x] **Impact of the changes:**
  - Monad account with a **matured** undelegation (`withdrawId` set, `completionDate` in the past): the **Withdraw** action must appear in the undelegation drawer — and be **absent** for unbondings still within the timelock or without a `withdrawId` (non-Monad).
  - Withdraw flow end-to-end: confirmation → device → sign → success/error.
  - Undelegation list: no duplicate-key warning, proper separation from the delegation list, single-action drawer centered.
  - Existing delegation actions (undelegate / redelegate / collect rewards) must be unaffected.

### 📝 Description

**Problem**: Monad requires an explicit `withdraw` to finalize a matured undelegation (the funds are not auto-returned once the unbonding timelock elapses). The desktop counterpart shipped under LIVE-31683, but mobile had no entry point to trigger it.

**Solution**: Add a mobile `WithdrawFlow` (mirroring the existing EVM `ClaimRewardsFlow`: fixed amount, no input → device → sign → success/error). It is triggered from the **undelegation drawer** for matured Monad unbondings only, gated by `withdrawId !== undefined && completionDate <= now` (same condition as desktop). This PR also fixes a few pre-existing display issues in the mobile undelegation list surfaced while testing: unique React keys for Monad withdrawal slots sharing a completion date, separation from the delegation list, the withdraw action icon (aligned with the MultiversX convention), and centering a single-action drawer.

> [!IMPORTANT]
> Like the desktop implementation, the bridge transaction is a **stub**: it self-sends (`mode: "send"`, recipient = own address) so the flow runs end-to-end. It does **not** yet perform the real on-chain `withdraw(validatorId, withdrawId)` call, and the operation is **not** labelled as a withdraw in history (there is no `WITHDRAW` operation type in `coin-evm` yet). Both are tracked by **LIVE-31683** and will replace the stub with `mode: "withdraw"`.
>
> **Follow-up for LIVE-31683** (learned from the sibling claim-rewards PR #17710, where `claimReward` was first mistagged as `OUT` instead of `REWARD`): once the real `withdraw` mode lands, the operation type must be mapped in **both** places, otherwise the withdrawal shows up as a plain `OUT` in history:
> 1. `generic-coin-framework` → `buildOptimisticOperation`
> 2. `coin-evm` → `detectEvmStakingOperationType` (+ add `WITHDRAW` to `SEMANTIC_OP_TYPES` in `logic/listOperations.ts`)
>
> If `withdraw` targets an operation-specific precompile, the detector must also account for `specificContractAddressByOperation` (the detector currently only matches `config.contractAddress`), and the selector map it rebuilds per call should be cached per `currencyId`.

### 🖼️ Screenshots

| Before | After |
| ------ | ----- |
| <img width="890" height="1184" alt="image" src="https://github.com/user-attachments/assets/28135b6f-1e66-4c97-9ac5-c6d07f669224" /> | <img width="862" height="1538" alt="image" src="https://github.com/user-attachments/assets/b0f3abbf-00aa-41e8-aeb4-468e09eb962d" /> |
|  |  <img width="426" height="854" alt="Screenshot 2026-06-05 at 15 20 09" src="https://github.com/user-attachments/assets/de521c2e-9344-4c4a-91e7-0512a9063000" /> |
|  | <img width="418" height="849" alt="Screenshot 2026-06-05 at 15 29 27" src="https://github.com/user-attachments/assets/8e005dbe-91a9-4e5a-a031-787ce844ff9c" /> |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31682](https://ledgerhq.atlassian.net/browse/LIVE-31682)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31682]: https://ledgerhq.atlassian.net/browse/LIVE-31682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ