### PR TITLE
[LWDM] fix: stellar pagination premature end

### DIFF
--- a/.changeset/gold-pianos-judge.md
+++ b/.changeset/gold-pianos-judge.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-stellar": patch
+---
+
+fix(coin-stellar): stop using filtered op count to terminate pagination — use Horizon page size instead, so unsupported op types no longer truncate history

--- a/libs/coin-modules/coin-stellar/src/logic/listOperations.unit.test.ts
+++ b/libs/coin-modules/coin-stellar/src/logic/listOperations.unit.test.ts
@@ -174,7 +174,7 @@ describe("listOperations", () => {
           value: 505000000n,
         },
       ],
-      next: "token3",
+      next: "",
     });
   });
 
@@ -355,7 +355,7 @@ describe("listOperations", () => {
           },
         },
       ],
-      next: "token1",
+      next: "",
     });
   });
 

--- a/libs/coin-modules/coin-stellar/src/network/horizon.ts
+++ b/libs/coin-modules/coin-stellar/src/network/horizon.ts
@@ -465,31 +465,49 @@ export async function fetchOperations({
     return noResult;
   }
 
-  const defaultFetchLimit = coinConfig.getCoinConfig().explorer.fetchLimit ?? FETCH_LIMIT;
+  const requestedLimit = limit ?? coinConfig.getCoinConfig().explorer.fetchLimit ?? FETCH_LIMIT;
+  const MAX_SKIP_PAGES = 50;
+  let currentCursor = cursor;
+  let lastNextCursor = "";
 
   try {
-    const rawOperations = await getServer()
-      .operations()
-      .forAccount(addr)
-      .limit(limit ?? defaultFetchLimit)
-      .order(order)
-      .cursor(cursor ?? "")
-      .includeFailed(true)
-      .join("transactions")
-      .call();
+    for (let skip = 0; skip < MAX_SKIP_PAGES; skip++) {
+      const rawOperations = await getServer()
+        .operations()
+        .forAccount(addr)
+        .limit(requestedLimit)
+        .order(order)
+        .cursor(currentCursor ?? "")
+        .includeFailed(true)
+        .join("transactions")
+        .call();
 
-    if (!rawOperations || !rawOperations.records.length) {
-      return noResult;
+      if (!rawOperations || !rawOperations.records.length) {
+        return noResult;
+      }
+
+      const rawOps = rawOperations.records as RawOperation[];
+      const filteredOps = await rawOperationsToOperations(rawOps, addr, accountId, minHeight);
+
+      // Stop only when Horizon returns fewer records than requested (end of history).
+      // Don't use filteredOps.length — ops can be filtered by type, not just minHeight.
+      const isLastPage = rawOps.length < requestedLimit;
+      const nextCursor = isLastPage ? "" : rawOps[rawOps.length - 1].paging_token;
+      lastNextCursor = nextCursor;
+
+      // If a full page produced zero items (all filtered by unsupported type or minHeight),
+      // skip ahead to the next page instead of returning empty results.
+      if (filteredOps.length === 0 && !isLastPage) {
+        currentCursor = nextCursor;
+        continue;
+      }
+
+      return { items: filteredOps, next: nextCursor };
     }
 
-    const rawOps = rawOperations.records as RawOperation[];
-    const filteredOps = await rawOperationsToOperations(rawOps, addr, accountId, minHeight);
-
-    // in this context, if we have filtered out operations it means those operations were < minHeight, so we are done
-    const nextCursor =
-      filteredOps.length === rawOps.length ? rawOps[rawOps.length - 1].paging_token : "";
-
-    return { items: filteredOps, next: nextCursor };
+    // Safety: bail out after MAX_SKIP_PAGES consecutive empty pages.
+    // The caller's pagination loop will pick up from the returned cursor.
+    return { items: [], next: lastNextCursor };
   } catch (e: unknown) {
     // FIXME: terrible hacks, because Stellar SDK fails to cast network failures to typed errors in react-native...
     // (https://github.com/stellar/js-stellar-sdk/issues/638)

--- a/libs/coin-modules/coin-stellar/src/network/horizon.unit.test.ts
+++ b/libs/coin-modules/coin-stellar/src/network/horizon.unit.test.ts
@@ -132,30 +132,39 @@ describe("horizon.ts (unit, spies)", () => {
       await expect(fetchAllLedgerOperations(4242)).rejects.toThrow("Stellar ledger 4242 not found");
     });
 
-    it("paginates when first page is full then next page is empty", async () => {
-      coinConfig.setCoinConfig(() =>
-        baseCoinConfig({ explorer: { url: TEST_HORIZON_URL, fetchLimit: 2 } }),
-      );
-      const op1 = opBuilder({ paging_token: "1", id: "a" });
-      const op2 = opBuilder({ paging_token: "2", id: "b" });
-      const secondPage = { records: [] as RawOperation[] };
-      const firstPage = {
-        records: [op1, op2],
-        next: jest.fn().mockResolvedValue(secondPage),
-      };
-      jest.spyOn(Horizon.Server.prototype, "operations").mockReturnValue({
-        forLedger: jest.fn().mockReturnThis(),
-        includeFailed: jest.fn().mockReturnThis(),
-        join: jest.fn().mockReturnThis(),
-        order: jest.fn().mockReturnThis(),
-        limit: jest.fn().mockReturnValue({
-          call: jest.fn().mockResolvedValue(firstPage),
-        }),
-      } as unknown as ReturnType<Horizon.Server["operations"]>);
+    describe("with fetchLimit=2", () => {
+      beforeEach(() => {
+        coinConfig.setCoinConfig(() =>
+          baseCoinConfig({ explorer: { url: TEST_HORIZON_URL, fetchLimit: 2 } }),
+        );
+      });
 
-      const out = await fetchAllLedgerOperations(10);
-      expect(out).toHaveLength(2);
-      expect(firstPage.next).toHaveBeenCalledTimes(1);
+      afterEach(() => {
+        coinConfig.setCoinConfig(() => baseCoinConfig());
+      });
+
+      it("paginates when first page is full then next page is empty", async () => {
+        const op1 = opBuilder({ paging_token: "1", id: "a" });
+        const op2 = opBuilder({ paging_token: "2", id: "b" });
+        const secondPage = { records: [] as RawOperation[] };
+        const firstPage = {
+          records: [op1, op2],
+          next: jest.fn().mockResolvedValue(secondPage),
+        };
+        jest.spyOn(Horizon.Server.prototype, "operations").mockReturnValue({
+          forLedger: jest.fn().mockReturnThis(),
+          includeFailed: jest.fn().mockReturnThis(),
+          join: jest.fn().mockReturnThis(),
+          order: jest.fn().mockReturnThis(),
+          limit: jest.fn().mockReturnValue({
+            call: jest.fn().mockResolvedValue(firstPage),
+          }),
+        } as unknown as ReturnType<Horizon.Server["operations"]>);
+
+        const out = await fetchAllLedgerOperations(10);
+        expect(out).toHaveLength(2);
+        expect(firstPage.next).toHaveBeenCalledTimes(1);
+      });
     });
   });
 
@@ -183,7 +192,7 @@ describe("horizon.ts (unit, spies)", () => {
       ).rejects.toEqual(expect.objectContaining({ name: "LedgerAPI4xx", status: 429 }));
     });
 
-    it("sets next cursor to empty when filtered operations are fewer than raw page", async () => {
+    it("sets next cursor to empty when Horizon returns fewer records than the fetch limit", async () => {
       const rawA = opBuilder({ paging_token: "pt-a", id: "1" });
       const rawB = opBuilder({ paging_token: "pt-b", id: "2" });
       rawOperationsToOperationsMock.mockResolvedValue([{ type: "mock-op" } as never]);
@@ -199,6 +208,7 @@ describe("horizon.ts (unit, spies)", () => {
         }),
       } as unknown as ReturnType<Horizon.Server["operations"]>);
 
+      // fetchLimit defaults to 100, Horizon returned 2 records → incomplete page → no next cursor
       const page = await fetchOperations({
         accountId: "aid",
         addr: "GADDRAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
@@ -208,6 +218,145 @@ describe("horizon.ts (unit, spies)", () => {
       });
       expect(page.next).toBe("");
       expect(page.items).toHaveLength(1);
+    });
+
+    describe("with fetchLimit=2", () => {
+      beforeEach(() => {
+        coinConfig.setCoinConfig(() =>
+          baseCoinConfig({ explorer: { url: TEST_HORIZON_URL, fetchLimit: 2 } }),
+        );
+      });
+
+      afterEach(() => {
+        coinConfig.setCoinConfig(() => baseCoinConfig());
+      });
+
+      it("continues pagination when unsupported ops are filtered from a full page", async () => {
+        const rawA = opBuilder({ paging_token: "pt-a", id: "1" });
+        const rawB = opBuilder({ paging_token: "pt-b", id: "2" });
+        // Only 1 op survives filtering (e.g. the other was an unsupported type)
+        rawOperationsToOperationsMock.mockResolvedValue([{ type: "mock-op" } as never]);
+
+        jest.spyOn(Horizon.Server.prototype, "operations").mockReturnValue({
+          forAccount: jest.fn().mockReturnThis(),
+          limit: jest.fn().mockReturnThis(),
+          order: jest.fn().mockReturnThis(),
+          cursor: jest.fn().mockReturnThis(),
+          includeFailed: jest.fn().mockReturnThis(),
+          join: jest.fn().mockReturnValue({
+            call: jest.fn().mockResolvedValue({ records: [rawA, rawB] }),
+          }),
+        } as unknown as ReturnType<Horizon.Server["operations"]>);
+
+        const page = await fetchOperations({
+          accountId: "aid",
+          addr: "GADDRAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          minHeight: 0,
+          order: "desc",
+          cursor: undefined,
+        });
+        expect(page.next).toBe("pt-b");
+        expect(page.items).toHaveLength(1);
+      });
+
+      it("stops pagination when Horizon returns fewer records than fetchLimit", async () => {
+        const rawA = opBuilder({ paging_token: "pt-a", id: "1" });
+        // 1 record < fetchLimit of 2 → last page
+        rawOperationsToOperationsMock.mockResolvedValue([{ type: "mock-op" } as never]);
+
+        jest.spyOn(Horizon.Server.prototype, "operations").mockReturnValue({
+          forAccount: jest.fn().mockReturnThis(),
+          limit: jest.fn().mockReturnThis(),
+          order: jest.fn().mockReturnThis(),
+          cursor: jest.fn().mockReturnThis(),
+          includeFailed: jest.fn().mockReturnThis(),
+          join: jest.fn().mockReturnValue({
+            call: jest.fn().mockResolvedValue({ records: [rawA] }),
+          }),
+        } as unknown as ReturnType<Horizon.Server["operations"]>);
+
+        const page = await fetchOperations({
+          accountId: "aid",
+          addr: "GADDRAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          minHeight: 0,
+          order: "desc",
+          cursor: undefined,
+        });
+        expect(page.next).toBe("");
+        expect(page.items).toHaveLength(1);
+      });
+
+      it("skips to next page when all ops on a full page are filtered out", async () => {
+        const rawA = opBuilder({ paging_token: "pt-a", id: "1" });
+        const rawB = opBuilder({ paging_token: "pt-b", id: "2" });
+        const rawC = opBuilder({ paging_token: "pt-c", id: "3" });
+
+        // First call: full page (2 ops), all filtered → recurse
+        // Second call: partial page (1 op), 1 survives → return
+        rawOperationsToOperationsMock
+          .mockResolvedValueOnce([])
+          .mockResolvedValueOnce([{ type: "mock-op" } as never]);
+
+        const callMock = jest
+          .fn()
+          .mockResolvedValueOnce({ records: [rawA, rawB] })
+          .mockResolvedValueOnce({ records: [rawC] });
+
+        jest.spyOn(Horizon.Server.prototype, "operations").mockReturnValue({
+          forAccount: jest.fn().mockReturnThis(),
+          limit: jest.fn().mockReturnThis(),
+          order: jest.fn().mockReturnThis(),
+          cursor: jest.fn().mockReturnThis(),
+          includeFailed: jest.fn().mockReturnThis(),
+          join: jest.fn().mockReturnValue({ call: callMock }),
+        } as unknown as ReturnType<Horizon.Server["operations"]>);
+
+        const page = await fetchOperations({
+          accountId: "aid",
+          addr: "GADDRAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          minHeight: 999999,
+          order: "desc",
+          cursor: undefined,
+        });
+        // Skipped the empty first page, returned the second page's result
+        expect(page.items).toHaveLength(1);
+        expect(page.next).toBe("");
+        expect(callMock).toHaveBeenCalledTimes(2);
+      });
+
+      it("bails out after MAX_SKIP_PAGES consecutive empty pages", async () => {
+        const rawA = opBuilder({ paging_token: "pt-a", id: "1" });
+        const rawB = opBuilder({ paging_token: "pt-b", id: "2" });
+
+        // Every page returns zero filtered ops
+        rawOperationsToOperationsMock.mockResolvedValue([]);
+
+        const callMock = jest
+          .fn()
+          .mockResolvedValue({ records: [rawA, rawB] });
+
+        jest.spyOn(Horizon.Server.prototype, "operations").mockReturnValue({
+          forAccount: jest.fn().mockReturnThis(),
+          limit: jest.fn().mockReturnThis(),
+          order: jest.fn().mockReturnThis(),
+          cursor: jest.fn().mockReturnThis(),
+          includeFailed: jest.fn().mockReturnThis(),
+          join: jest.fn().mockReturnValue({ call: callMock }),
+        } as unknown as ReturnType<Horizon.Server["operations"]>);
+
+        const page = await fetchOperations({
+          accountId: "aid",
+          addr: "GADDRAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          minHeight: 999999,
+          order: "desc",
+          cursor: undefined,
+        });
+        // Exhausted skip budget: returns empty items with cursor for caller to resume
+        expect(page.items).toHaveLength(0);
+        expect(page.next).toBe("pt-b");
+        // MAX_SKIP_PAGES = 50 iterations
+        expect(callMock).toHaveBeenCalledTimes(50);
+      });
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->


### 📝 Description

Bug                                                                                                                                                                        
fetchOperations stops paginating when any operation is filtered out by rawOperationsToOperations. The code assumes filtering = past minHeight, but ops are also filtered by
   unsupported type (create_claimable_balance, etc.). Result: accounts with unsupported op types get silently truncated history → invalid A4 balances.

Fix
Base pagination on Horizon page size, not filtered count.                                                                                                                  
   
Before:                                                                                                                                                                    
```
  const nextCursor =
    filteredOps.length === rawOps.length ? rawOps[rawOps.length - 1].paging_token : "";
```                                                                                                                                                                             
After:                                                                                                                                                                     
```
  const requestedLimit = limit ?? coinConfig.getCoinConfig().explorer.fetchLimit ?? FETCH_LIMIT;                                                                             
  // ...                                                                                                                                                                     
  const nextCursor =                                                                                                                                                         
    rawOps.length < requestedLimit ? "" : rawOps[rawOps.length - 1].paging_token;
```

### ❓ Context
https://ledgerhq.atlassian.net/browse/LIVE-31417
---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
