### PR TITLE
test(wallet-cli): improve device part test coverage [LIVE-28271]

### DIFF
--- a/apps/wallet-cli/src/device/connect-ledger-app.test.ts
+++ b/apps/wallet-cli/src/device/connect-ledger-app.test.ts
@@ -4,6 +4,7 @@ import {
   UnknownDAError,
   UserInteractionRequired,
 } from "@ledgerhq/device-management-kit";
+import { ConnectAppDeviceAction } from "@ledgerhq/live-dmk-shared";
 import { Observable } from "rxjs";
 import { connectLedgerApp } from "./connect-ledger-app";
 import type { DeviceState } from "./device-state";
@@ -84,6 +85,53 @@ describe("connectLedgerApp", () => {
     await expect(connectLedgerApp(dmk as never, "sess-1", "evm")).resolves.toBeUndefined();
   });
 
+  it("resolves when the completed device action has no output", async () => {
+    const dmk = makeDmk(() => ({
+      observable: new Observable(observer => {
+        observer.next({ status: DeviceActionStatus.Completed } as const);
+        observer.complete();
+      }),
+      cancel: (): void => {},
+    }));
+
+    await expect(connectLedgerApp(dmk as never, "sess-1", "evm")).resolves.toBeUndefined();
+  });
+
+  it("passes the expected input contract to ConnectAppDeviceAction", async () => {
+    let captured:
+      | {
+          sessionId: string;
+          deviceAction: ConnectAppDeviceAction;
+        }
+      | undefined;
+    const dmk = {
+      _unsafeBypassIntentQueue: (): void => {},
+      executeDeviceAction: (args: { sessionId: string; deviceAction: ConnectAppDeviceAction }) => {
+        captured = args;
+        return completedAction();
+      },
+    };
+
+    await expect(
+      connectLedgerApp(dmk as never, "sess-contract", "Custom App", {
+        deviceTimeoutMs: 12_345,
+      }),
+    ).resolves.toBeUndefined();
+
+    if (!captured) {
+      throw new Error("expected executeDeviceAction to be called");
+    }
+    expect(captured.sessionId).toBe("sess-contract");
+    expect(captured.deviceAction).toBeInstanceOf(ConnectAppDeviceAction);
+    expect(captured.deviceAction.input).toEqual({
+      application: { name: "Custom App" },
+      dependencies: [],
+      requireLatestFirmware: false,
+      allowMissingApplication: false,
+      unlockTimeout: 12_345,
+    });
+  });
+
   it("throws a WalletCliDeviceError when the device action ends with a tagged DMK error", async () => {
     const err = new UnknownDAError("test");
     const dmk = makeDmk(() => errorAction(err));
@@ -113,6 +161,35 @@ describe("connectLedgerApp", () => {
       expect(e).toBeInstanceOf(WalletCliDeviceError);
       expect((e as WalletCliDeviceError).state).toEqual({ code: "disconnected" });
     }
+  });
+
+  it("throws a WalletCliDeviceError when the final state is not completed", async () => {
+    const dmk = makeDmk(() => ({
+      observable: new Observable(observer => {
+        observer.next({
+          status: DeviceActionStatus.Pending,
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+        });
+        observer.complete();
+      }),
+      cancel: (): void => {},
+    }));
+
+    const error = await connectLedgerApp(dmk as never, "sess-1", "bitcoin").then(
+      () => undefined,
+      e => e,
+    );
+
+    expect(error).toBeInstanceOf(WalletCliDeviceError);
+    const state = (error as WalletCliDeviceError).state;
+    expect(state.code).toBe("unknown");
+    if (state.code !== "unknown") return;
+    expect(state.cause).toBeInstanceOf(Error);
+    expect((state.cause as Error).message).toBe(
+      `Connect app ended with status: ${DeviceActionStatus.Pending}`,
+    );
   });
 
   it("throws unknown when the device action observable errors with an arbitrary Error", async () => {
@@ -163,6 +240,30 @@ describe("connectLedgerApp", () => {
       s => s.code === "awaiting_approval" && s.reason === "unlock",
     );
     expect(unlockStates).toHaveLength(1);
+  });
+
+  it("does not require onStateChange for unlock or open-app pending states", async () => {
+    const dmk = makeDmk(() => ({
+      observable: new Observable(observer => {
+        observer.next({
+          status: DeviceActionStatus.Pending,
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.UnlockDevice,
+          },
+        });
+        observer.next({
+          status: DeviceActionStatus.Pending,
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+          },
+        });
+        observer.next({ status: DeviceActionStatus.Completed, output: {} } as const);
+        observer.complete();
+      }),
+      cancel: () => {},
+    }));
+
+    await expect(connectLedgerApp(dmk as never, "sess-1", "evm")).resolves.toBeUndefined();
   });
 
   it("does not emit state for pending None or missing interactions", async () => {
@@ -258,7 +359,100 @@ describe("connectLedgerApp", () => {
     ]);
   });
 
+  it("ignores non-pending and None interactions without resetting duplicate suppression", async () => {
+    const states: DeviceState[] = [];
+    const dmk = makeDmk(() => ({
+      observable: new Observable(observer => {
+        observer.next({
+          status: DeviceActionStatus.Completed,
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+          },
+        });
+        observer.next({
+          status: DeviceActionStatus.Pending,
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.UnlockDevice,
+          },
+        });
+        observer.next({
+          status: DeviceActionStatus.Pending,
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+        });
+        observer.next({
+          status: DeviceActionStatus.Pending,
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.UnlockDevice,
+          },
+        });
+        observer.next({ status: DeviceActionStatus.Completed, output: {} } as const);
+        observer.complete();
+      }),
+      cancel: () => {},
+    }));
+
+    await connectLedgerApp(dmk as never, "sess-1", "evm", {
+      onStateChange: s => states.push(s),
+    });
+
+    expect(states).toEqual([{ code: "awaiting_approval", reason: "unlock" }]);
+  });
+
+  it("does not emit duplicate state changes for repeated required interactions", async () => {
+    const states: DeviceState[] = [];
+    const dmk = makeDmk(() => ({
+      observable: new Observable(observer => {
+        observer.next({
+          status: DeviceActionStatus.Pending,
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+          },
+        });
+        observer.next({
+          status: DeviceActionStatus.Pending,
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+          },
+        });
+        observer.next({
+          status: DeviceActionStatus.Pending,
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+          },
+        });
+        observer.next({ status: DeviceActionStatus.Completed, output: {} } as const);
+        observer.complete();
+      }),
+      cancel: () => {},
+    }));
+
+    await connectLedgerApp(dmk as never, "sess-1", "evm", {
+      onStateChange: s => states.push(s),
+    });
+
+    expect(states).toEqual([{ code: "awaiting_approval", reason: "open_app" }]);
+  });
+
   describe("silence timeout", () => {
+    it("schedules the silence timeout after the device timeout plus buffer", async () => {
+      const timers = installControlledTimers();
+      try {
+        const dmk = makeDmk(() => completedAction());
+
+        await connectLedgerApp(dmk as never, "sess-1", "evm", {
+          deviceTimeoutMs: 12_345,
+        });
+
+        expect(timers.scheduled).toHaveLength(1);
+        expect(timers.scheduled[0].ms).toBe(72_345);
+        expect(timers.scheduled[0].cleared).toBe(true);
+      } finally {
+        timers.restore();
+      }
+    });
+
     it("cancels and rejects with timeout when no progress occurs", async () => {
       const timers = installControlledTimers();
       try {
@@ -287,6 +481,65 @@ describe("connectLedgerApp", () => {
         expect(result).toBeInstanceOf(WalletCliDeviceError);
         expect((result as WalletCliDeviceError).state).toEqual({ code: "timeout" });
         expect(cancelCalls).toBe(1);
+        expect(timers.scheduled[0].cleared).toBe(true);
+      } finally {
+        timers.restore();
+      }
+    });
+
+    it("keeps the timeout error when cancel throws during silence timeout cleanup", async () => {
+      const timers = installControlledTimers();
+      try {
+        const dmk = makeDmk(() => ({
+          observable: new Observable(() => undefined),
+          cancel: () => {
+            throw new Error("cancel failed");
+          },
+        }));
+
+        const promise = connectLedgerApp(dmk as never, "sess-1", "evm", {
+          deviceTimeoutMs: 1,
+        });
+        expect(timers.scheduled).toHaveLength(1);
+
+        timers.scheduled[0].run();
+        const result = await Promise.race([
+          promise.then(
+            () => "resolved",
+            e => e,
+          ),
+          timers.waitRealTick().then(() => "pending"),
+        ]);
+
+        expect(result).toBeInstanceOf(WalletCliDeviceError);
+        expect((result as WalletCliDeviceError).state).toEqual({ code: "timeout" });
+        expect(timers.scheduled[0].cleared).toBe(true);
+      } finally {
+        timers.restore();
+      }
+    });
+
+    it("throws disconnected and clears the silence timeout when the action completes without emission", async () => {
+      const timers = installControlledTimers();
+      try {
+        const dmk = makeDmk(() => ({
+          observable: new Observable(observer => {
+            observer.complete();
+          }),
+          cancel: (): void => {},
+        }));
+
+        try {
+          await connectLedgerApp(dmk as never, "sess-1", "bitcoin", {
+            deviceTimeoutMs: 1,
+          });
+          throw new Error("expected connectLedgerApp to throw");
+        } catch (e) {
+          expect(e).toBeInstanceOf(WalletCliDeviceError);
+          expect((e as WalletCliDeviceError).state).toEqual({ code: "disconnected" });
+        }
+
+        expect(timers.scheduled).toHaveLength(1);
         expect(timers.scheduled[0].cleared).toBe(true);
       } finally {
         timers.restore();
@@ -392,6 +645,23 @@ describe("connectLedgerApp", () => {
       expect(calls).toBe(1);
     });
 
+    it("does not retry null, non-object, or non-tagged errors", async () => {
+      const errors = [null, "ReceiverApduError", { message: "missing tag" }];
+
+      for (const error of errors) {
+        let calls = 0;
+        const dmk = makeDmk(() => {
+          calls++;
+          return errorAction(error);
+        });
+
+        await expect(connectLedgerApp(dmk as never, "sess-1", "ethereum")).rejects.toBeInstanceOf(
+          WalletCliDeviceError,
+        );
+        expect(calls).toBe(1);
+      }
+    });
+
     it("throws a WalletCliDeviceError (timeout) after exhausting retries on ReceiverApduError", async () => {
       let calls = 0;
       const dmk = makeDmk(() => {
@@ -407,6 +677,29 @@ describe("connectLedgerApp", () => {
         expect((e as WalletCliDeviceError).state.code).toBe("timeout");
       }
       expect(calls).toBe(6);
+    });
+
+    it("waits between the five allowed transport framing retries", async () => {
+      const retryDelays: Array<number | undefined> = [];
+      globalThis.setTimeout = ((fn: () => void, ms?: number) => {
+        if (ms === 3_000) {
+          retryDelays.push(ms);
+        }
+        return realSetTimeout(fn, 0);
+      }) as typeof globalThis.setTimeout;
+
+      let calls = 0;
+      const dmk = makeDmk(() => {
+        calls++;
+        return errorAction({ _tag: "UnknownDeviceExchangeError" as const });
+      });
+
+      await expect(connectLedgerApp(dmk as never, "sess-1", "ethereum")).rejects.toBeInstanceOf(
+        WalletCliDeviceError,
+      );
+
+      expect(calls).toBe(6);
+      expect(retryDelays).toEqual([3_000, 3_000, 3_000, 3_000, 3_000]);
     });
   });
 });

--- a/apps/wallet-cli/src/device/connect-ledger-app.test.ts
+++ b/apps/wallet-cli/src/device/connect-ledger-app.test.ts
@@ -38,6 +38,46 @@ function errorAction(error: unknown) {
   };
 }
 
+function installControlledTimers() {
+  const realSetTimeout = globalThis.setTimeout;
+  const realClearTimeout = globalThis.clearTimeout;
+  const scheduled: Array<{
+    id: number;
+    ms: number | undefined;
+    cleared: boolean;
+    run: () => void;
+  }> = [];
+
+  globalThis.setTimeout = ((
+    handler: (...args: unknown[]) => void,
+    ms?: number,
+    ...args: unknown[]
+  ) => {
+    const timer = {
+      id: scheduled.length + 1,
+      ms,
+      cleared: false,
+      run: () => handler(...args),
+    };
+    scheduled.push(timer);
+    return timer.id as unknown as ReturnType<typeof globalThis.setTimeout>;
+  }) as typeof globalThis.setTimeout;
+
+  globalThis.clearTimeout = ((id?: ReturnType<typeof globalThis.setTimeout>) => {
+    const timer = scheduled.find(t => t.id === (id as unknown as number));
+    if (timer) timer.cleared = true;
+  }) as typeof globalThis.clearTimeout;
+
+  return {
+    scheduled,
+    waitRealTick: () => new Promise(resolve => realSetTimeout(resolve, 0)),
+    restore: () => {
+      globalThis.setTimeout = realSetTimeout;
+      globalThis.clearTimeout = realClearTimeout;
+    },
+  };
+}
+
 describe("connectLedgerApp", () => {
   it("resolves when the device action completes", async () => {
     const dmk = makeDmk(() => completedAction());
@@ -55,6 +95,41 @@ describe("connectLedgerApp", () => {
       expect(e).toBeInstanceOf(WalletCliDeviceError);
       const state = (e as WalletCliDeviceError).state;
       expect(state.code).toBe("unknown");
+    }
+  });
+
+  it("throws disconnected when the device action completes without any emission", async () => {
+    const dmk = makeDmk(() => ({
+      observable: new Observable(observer => {
+        observer.complete();
+      }),
+      cancel: (): void => {},
+    }));
+
+    try {
+      await connectLedgerApp(dmk as never, "sess-1", "bitcoin");
+      throw new Error("expected connectLedgerApp to throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(WalletCliDeviceError);
+      expect((e as WalletCliDeviceError).state).toEqual({ code: "disconnected" });
+    }
+  });
+
+  it("throws unknown when the device action observable errors with an arbitrary Error", async () => {
+    const error = new Error("unexpected connect failure");
+    const dmk = makeDmk(() => ({
+      observable: new Observable(observer => {
+        observer.error(error);
+      }),
+      cancel: (): void => {},
+    }));
+
+    try {
+      await connectLedgerApp(dmk as never, "sess-1", "bitcoin");
+      throw new Error("expected connectLedgerApp to throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(WalletCliDeviceError);
+      expect((e as WalletCliDeviceError).state).toEqual({ code: "unknown", cause: error });
     }
   });
 
@@ -90,6 +165,32 @@ describe("connectLedgerApp", () => {
     expect(unlockStates).toHaveLength(1);
   });
 
+  it("does not emit state for pending None or missing interactions", async () => {
+    const states: DeviceState[] = [];
+    const dmk = makeDmk(() => ({
+      observable: new Observable(observer => {
+        observer.next({
+          status: DeviceActionStatus.Pending,
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+        });
+        observer.next({
+          status: DeviceActionStatus.Pending,
+        });
+        observer.next({ status: DeviceActionStatus.Completed, output: {} } as const);
+        observer.complete();
+      }),
+      cancel: () => {},
+    }));
+
+    await connectLedgerApp(dmk as never, "sess-1", "evm", {
+      onStateChange: s => states.push(s),
+    });
+
+    expect(states).toEqual([]);
+  });
+
   it("emits awaiting_approval.open_app when ConfirmOpenApp interaction is required", async () => {
     const states: DeviceState[] = [];
     const dmk = makeDmk(() => ({
@@ -111,6 +212,126 @@ describe("connectLedgerApp", () => {
     });
 
     expect(states.some(s => s.code === "awaiting_approval" && s.reason === "open_app")).toBe(true);
+  });
+
+  it("emits unlock then open-app states while deduping consecutive duplicates", async () => {
+    const states: DeviceState[] = [];
+    const dmk = makeDmk(() => ({
+      observable: new Observable(observer => {
+        observer.next({
+          status: DeviceActionStatus.Pending,
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.UnlockDevice,
+          },
+        });
+        observer.next({
+          status: DeviceActionStatus.Pending,
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.UnlockDevice,
+          },
+        });
+        observer.next({
+          status: DeviceActionStatus.Pending,
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+          },
+        });
+        observer.next({
+          status: DeviceActionStatus.Pending,
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+          },
+        });
+        observer.next({ status: DeviceActionStatus.Completed, output: {} } as const);
+        observer.complete();
+      }),
+      cancel: () => {},
+    }));
+
+    await connectLedgerApp(dmk as never, "sess-1", "evm", {
+      onStateChange: s => states.push(s),
+    });
+
+    expect(states).toEqual([
+      { code: "awaiting_approval", reason: "unlock" },
+      { code: "awaiting_approval", reason: "open_app" },
+    ]);
+  });
+
+  describe("silence timeout", () => {
+    it("cancels and rejects with timeout when no progress occurs", async () => {
+      const timers = installControlledTimers();
+      try {
+        let cancelCalls = 0;
+        const dmk = makeDmk(() => ({
+          observable: new Observable(() => undefined),
+          cancel: () => {
+            cancelCalls++;
+          },
+        }));
+
+        const promise = connectLedgerApp(dmk as never, "sess-1", "evm", {
+          deviceTimeoutMs: 1,
+        });
+        expect(timers.scheduled).toHaveLength(1);
+
+        timers.scheduled[0].run();
+        const result = await Promise.race([
+          promise.then(
+            () => "resolved",
+            e => e,
+          ),
+          timers.waitRealTick().then(() => "pending"),
+        ]);
+
+        expect(result).toBeInstanceOf(WalletCliDeviceError);
+        expect((result as WalletCliDeviceError).state).toEqual({ code: "timeout" });
+        expect(cancelCalls).toBe(1);
+        expect(timers.scheduled[0].cleared).toBe(true);
+      } finally {
+        timers.restore();
+      }
+    });
+
+    it("clears the silence timeout when the action completes", async () => {
+      const timers = installControlledTimers();
+      try {
+        const dmk = makeDmk(() => completedAction());
+
+        await connectLedgerApp(dmk as never, "sess-1", "evm", {
+          deviceTimeoutMs: 1,
+        });
+
+        expect(timers.scheduled).toHaveLength(1);
+        expect(timers.scheduled[0].cleared).toBe(true);
+      } finally {
+        timers.restore();
+      }
+    });
+
+    it("clears the silence timeout when the action errors", async () => {
+      const timers = installControlledTimers();
+      try {
+        const error = new Error("boom");
+        const dmk = makeDmk(() => ({
+          observable: new Observable(observer => {
+            observer.error(error);
+          }),
+          cancel: (): void => {},
+        }));
+
+        await expect(
+          connectLedgerApp(dmk as never, "sess-1", "evm", {
+            deviceTimeoutMs: 1,
+          }),
+        ).rejects.toBeInstanceOf(WalletCliDeviceError);
+
+        expect(timers.scheduled).toHaveLength(1);
+        expect(timers.scheduled[0].cleared).toBe(true);
+      } finally {
+        timers.restore();
+      }
+    });
   });
 
   describe("transport framing error retries", () => {
@@ -149,6 +370,26 @@ describe("connectLedgerApp", () => {
 
       await expect(connectLedgerApp(dmk as never, "sess-1", "ethereum")).resolves.toBeUndefined();
       expect(calls).toBe(2);
+    });
+
+    it("does not retry non-retriable tagged errors", async () => {
+      let calls = 0;
+      const dmk = makeDmk(() => {
+        calls++;
+        return errorAction({ _tag: "RefusedByUserDAError" as const });
+      });
+
+      try {
+        await connectLedgerApp(dmk as never, "sess-1", "ethereum");
+        throw new Error("expected to throw");
+      } catch (e) {
+        expect(e).toBeInstanceOf(WalletCliDeviceError);
+        expect((e as WalletCliDeviceError).state).toEqual({
+          code: "rejected",
+          context: "open_app",
+        });
+      }
+      expect(calls).toBe(1);
     });
 
     it("throws a WalletCliDeviceError (timeout) after exhausting retries on ReceiverApduError", async () => {

--- a/apps/wallet-cli/src/device/connect-ledger-app.ts
+++ b/apps/wallet-cli/src/device/connect-ledger-app.ts
@@ -139,9 +139,18 @@ async function connectLedgerAppOnce(
 
   let finalState: ConnectAppState;
   const { observable, cancel } = dmk.executeDeviceAction({ sessionId, deviceAction });
-  const stallTimer = globalThis.setTimeout(() => {
-    cancel();
-  }, silenceTimeoutMs);
+  const silenceTimeoutError = { _tag: "SendApduTimeoutError" } as ConnectAppDAError;
+  let stallTimer: ReturnType<typeof globalThis.setTimeout> | undefined;
+  const silenceTimeoutPromise = new Promise<never>((_, reject) => {
+    stallTimer = globalThis.setTimeout(() => {
+      try {
+        cancel();
+      } catch (e) {
+        walletCliDebug("ConnectApp cancel after silence timeout failed: %o", e);
+      }
+      reject(silenceTimeoutError);
+    }, silenceTimeoutMs);
+  });
 
   let lastRequiredInteraction: ConnectAppDARequiredInteraction | undefined;
   const onIntermediateState = (state: ConnectAppState) => {
@@ -160,14 +169,19 @@ async function connectLedgerAppOnce(
     }
   };
   try {
-    finalState = await lastValueFrom(observable.pipe(tap(onIntermediateState)));
+    finalState = await Promise.race([
+      lastValueFrom(observable.pipe(tap(onIntermediateState))),
+      silenceTimeoutPromise,
+    ]);
   } catch (e) {
     if (e instanceof EmptyError) {
       throw new WalletCliDeviceError({ code: "disconnected" }, { cause: e });
     }
     throw WalletCliDeviceError.fromUnknown(e, { expectedApp: managerAppName });
   } finally {
-    globalThis.clearTimeout(stallTimer);
+    if (stallTimer !== undefined) {
+      globalThis.clearTimeout(stallTimer);
+    }
   }
 
   walletCliDebug("ConnectApp finalState: status=%s app=%s", finalState.status, managerAppName);

--- a/apps/wallet-cli/src/device/connect-ledger-app.ts
+++ b/apps/wallet-cli/src/device/connect-ledger-app.ts
@@ -19,6 +19,10 @@ type ConnectAppState = DeviceActionState<
   ConnectAppDAIntermediateValue
 >;
 
+type ConnectAppOnceResult =
+  | { status: "success" }
+  | { status: "error"; error: ConnectAppDAError };
+
 /**
  * Default unlock timeout: how long ConnectApp waits for the user to unlock the device
  * before giving up. Overridable per-call via the `deviceTimeoutMs` option (CLI flag
@@ -93,9 +97,9 @@ export async function connectLedgerApp(
       deviceTimeoutMs,
       silenceTimeoutMs,
     });
-    if (!result) return;
+    if (result.status === "success") return;
 
-    if (isTransportFramingError(result) && attempt < MAX_TRANSPORT_ERROR_RETRIES) {
+    if (isTransportFramingError(result.error) && attempt < MAX_TRANSPORT_ERROR_RETRIES) {
       walletCliDebug(
         "Transport framing error, retrying ConnectApp (%d/%d)…",
         attempt + 1,
@@ -105,13 +109,13 @@ export async function connectLedgerApp(
       continue;
     }
 
-    throw WalletCliDeviceError.fromUnknown(result, { expectedApp: managerAppName });
+    throw WalletCliDeviceError.fromUnknown(result.error, { expectedApp: managerAppName });
   }
 }
 
 /**
  * Single attempt at running ConnectAppDeviceAction.
- * Returns `undefined` on success, or the DA error to let the caller decide whether to retry.
+ * Returns success, or the DA error to let the caller decide whether to retry.
  */
 async function connectLedgerAppOnce(
   dmk: DeviceManagementKit,
@@ -126,7 +130,7 @@ async function connectLedgerAppOnce(
     deviceTimeoutMs: number;
     silenceTimeoutMs: number;
   },
-): Promise<ConnectAppDAError | undefined> {
+): Promise<ConnectAppOnceResult> {
   const deviceAction = new ConnectAppDeviceAction({
     input: {
       application: { name: managerAppName },
@@ -188,7 +192,7 @@ async function connectLedgerAppOnce(
 
   if (finalState.status === DeviceActionStatus.Error) {
     walletCliDebug("ConnectApp error detail: %o", summarizeConnectAppError(finalState.error));
-    return finalState.error;
+    return { status: "error", error: finalState.error };
   }
 
   if (finalState.status === DeviceActionStatus.Completed && finalState.output) {
@@ -205,5 +209,5 @@ async function connectLedgerAppOnce(
       cause: new Error(`Connect app ended with status: ${finalState.status}`),
     });
   }
-  return undefined;
+  return { status: "success" };
 }

--- a/apps/wallet-cli/src/device/node-webusb/NodeWebUsbApduSender.test.ts
+++ b/apps/wallet-cli/src/device/node-webusb/NodeWebUsbApduSender.test.ts
@@ -10,7 +10,7 @@ import type {
   ApduSenderServiceFactory,
   LoggerPublisherService,
 } from "@ledgerhq/device-management-kit";
-import { Left, Maybe } from "purify-ts";
+import { Left, Maybe, Right } from "purify-ts";
 import { NodeWebUsbApduSender } from "./NodeWebUsbApduSender";
 import { FRAME_SIZE } from "./node-webusb-constants";
 
@@ -42,6 +42,14 @@ const realSenderFactory: ApduSenderServiceFactory = args =>
   defaultApduSenderServiceStubBuilder(args, () => createLogger());
 const realReceiverFactory: ApduReceiverServiceFactory = args =>
   defaultApduReceiverServiceStubBuilder(args, () => createLogger());
+
+const singleFrameApduSenderFactory = (() => ({
+  getFrames: () => [
+    {
+      getRawData: () => new Uint8Array([0xe0, 0x01, 0x00, 0x00]),
+    },
+  ],
+})) as unknown as ApduSenderServiceFactory;
 
 /**
  * Async FIFO of USB bulk-in frames. `pop()` resolves immediately when a frame is
@@ -79,6 +87,8 @@ function createFrameQueue() {
 function createFakeLedgerDevice(response: { data: Uint8Array; status: Uint8Array }) {
   const outFrames = createFrameQueue();
   const receivedCommands: Uint8Array[] = [];
+  const hostFrames: Uint8Array[] = [];
+  let transferInCalls = 0;
   let deviceReceiver: ReturnType<ApduReceiverServiceFactory> | null = null;
   let deviceSender: ReturnType<ApduSenderServiceFactory> | null = null;
 
@@ -86,6 +96,7 @@ function createFakeLedgerDevice(response: { data: Uint8Array; status: Uint8Array
     opened: true,
     transferOut: async (_endpoint: number, buffer: ArrayBuffer) => {
       const frame = new Uint8Array(buffer);
+      hostFrames.push(frame);
       if (!deviceReceiver || !deviceSender) {
         // The channel is the first two bytes of every Ledger USB frame.
         const channel = Maybe.of(frame.slice(0, 2));
@@ -104,6 +115,7 @@ function createFakeLedgerDevice(response: { data: Uint8Array; status: Uint8Array
       return { status: "ok" as const };
     },
     transferIn: async (_endpoint: number, _length: number) => {
+      transferInCalls += 1;
       const frame = await outFrames.pop();
       const copy = frame.slice();
       return { status: "ok" as const, data: new DataView(copy.buffer) };
@@ -115,10 +127,29 @@ function createFakeLedgerDevice(response: { data: Uint8Array; status: Uint8Array
   return {
     device,
     getReceivedCommands: () => receivedCommands,
+    getHostFrames: () => hostFrames,
+    getTransferInCalls: () => transferInCalls,
   };
 }
 
 describe("NodeWebUsbApduSender", () => {
+  it("exposes and updates dependencies", () => {
+    const initialDependencies = { device: { opened: false } as never, interfaceNumber: 1 };
+    const nextDependencies = { device: { opened: true } as never, interfaceNumber: 2 };
+    const sender = new NodeWebUsbApduSender({
+      dependencies: initialDependencies,
+      apduSenderFactory: realSenderFactory,
+      apduReceiverFactory: realReceiverFactory,
+      loggerFactory: () => createLogger(),
+    });
+
+    expect(sender.getDependencies()).toBe(initialDependencies);
+
+    sender.setDependencies(nextDependencies);
+
+    expect(sender.getDependencies()).toBe(nextDependencies);
+  });
+
   it("waits for the active read loop before closing", async () => {
     let resolveTransferIn: ((result: { status: "ok"; data: DataView }) => void) | undefined;
     let transferInStarted: (() => void) | undefined;
@@ -272,6 +303,51 @@ describe("NodeWebUsbApduSender — real DMK framing round-trip", () => {
     expect(Array.from(fake.getReceivedCommands()[0]!)).toEqual(Array.from(command));
   });
 
+  it("adds a command continuation frame only after the first WebUSB frame is full", async () => {
+    const singleFrameCommand = Uint8Array.from({ length: 57 }, (_, i) => i & 0xff);
+    const twoFrameCommand = Uint8Array.from({ length: 58 }, (_, i) => i & 0xff);
+    const response = { data: new Uint8Array(), status: new Uint8Array([0x90, 0x00]) };
+
+    const singleFrameFake = createFakeLedgerDevice(response);
+    const singleFrameResult = await buildSender(singleFrameFake.device).sendApdu(singleFrameCommand);
+
+    expect(singleFrameResult.isRight()).toBe(true);
+    expect(singleFrameFake.getHostFrames()).toHaveLength(1);
+    expect(Array.from(singleFrameFake.getReceivedCommands()[0]!)).toEqual(
+      Array.from(singleFrameCommand),
+    );
+
+    const twoFrameFake = createFakeLedgerDevice(response);
+    const twoFrameResult = await buildSender(twoFrameFake.device).sendApdu(twoFrameCommand);
+
+    expect(twoFrameResult.isRight()).toBe(true);
+    expect(twoFrameFake.getHostFrames()).toHaveLength(2);
+    expect(Array.from(twoFrameFake.getReceivedCommands()[0]!)).toEqual(
+      Array.from(twoFrameCommand),
+    );
+  });
+
+  it("reads a response continuation frame only after the first WebUSB frame is full", async () => {
+    const command = new Uint8Array([0xe0, 0x01, 0x00, 0x00]);
+    const singleFrameFake = createFakeLedgerDevice({
+      data: Uint8Array.from({ length: 55 }, (_, i) => i & 0xff),
+      status: new Uint8Array([0x90, 0x00]),
+    });
+
+    const singleFrameResult = await buildSender(singleFrameFake.device).sendApdu(command);
+    expect(singleFrameResult.isRight()).toBe(true);
+    expect(singleFrameFake.getTransferInCalls()).toBe(1);
+
+    const twoFrameFake = createFakeLedgerDevice({
+      data: Uint8Array.from({ length: 56 }, (_, i) => i & 0xff),
+      status: new Uint8Array([0x90, 0x00]),
+    });
+
+    const twoFrameResult = await buildSender(twoFrameFake.device).sendApdu(command);
+    expect(twoFrameResult.isRight()).toBe(true);
+    expect(twoFrameFake.getTransferInCalls()).toBe(2);
+  });
+
   it("surfaces a non-9000 status word as the response status code", async () => {
     const responseStatus = new Uint8Array([0x69, 0x85]); // conditions of use not satisfied
     const fake = createFakeLedgerDevice({ data: new Uint8Array(), status: responseStatus });
@@ -340,6 +416,22 @@ describe("NodeWebUsbApduSender — sendApdu error paths", () => {
     result.ifLeft(error => {
       expect(error).toBeInstanceOf(OpeningConnectionError);
       expect(causeMessage(error)).toContain("transferIn status: babble");
+    });
+  });
+
+  it("returns Left when transferIn succeeds without response data", async () => {
+    const device = {
+      opened: true,
+      transferOut: async () => ({ status: "ok" }),
+      transferIn: async () => ({ status: "ok" }),
+    };
+
+    const result = await buildSender(device).sendApdu(APDU);
+
+    expect(result.isLeft()).toBe(true);
+    result.ifLeft(error => {
+      expect(error).toBeInstanceOf(OpeningConnectionError);
+      expect(causeMessage(error)).toContain("transferIn status: ok");
     });
   });
 
@@ -431,6 +523,28 @@ describe("NodeWebUsbApduSender — sendApdu error paths", () => {
     expect(result.isLeft()).toBe(true);
     result.ifLeft(error => expect(error).toBeInstanceOf(SendApduTimeoutError));
   });
+
+  it("does not schedule an abort timeout when abortTimeoutMs is zero", async () => {
+    const realSetTimeout = globalThis.setTimeout;
+    const scheduledTimeouts: number[] = [];
+    globalThis.setTimeout = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
+      scheduledTimeouts.push(Number(timeout));
+      return realSetTimeout(handler, timeout, ...args);
+    }) as typeof globalThis.setTimeout;
+
+    try {
+      const fake = createFakeLedgerDevice({
+        data: new Uint8Array([0x42]),
+        status: new Uint8Array([0x90, 0x00]),
+      });
+      const result = await buildSender(fake.device).sendApdu(APDU, false, 0);
+
+      expect(result.isRight()).toBe(true);
+      expect(scheduledTimeouts).toEqual([]);
+    } finally {
+      globalThis.setTimeout = realSetTimeout;
+    }
+  });
 });
 
 describe("NodeWebUsbApduSender — setupConnection", () => {
@@ -513,6 +627,82 @@ describe("NodeWebUsbApduSender — setupConnection", () => {
             "reset",
             "claimInterface",
           ],
+    );
+  });
+
+  it("skips resetting the device on Windows", async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+    const calls: string[] = [];
+    const device = {
+      opened: false,
+      configuration: { configurationValue: 1 } as unknown,
+      open: async () => {
+        calls.push("open");
+        device.opened = true;
+      },
+      reset: async () => {
+        calls.push("reset");
+      },
+      claimInterface: async () => {
+        calls.push("claimInterface");
+      },
+      selectConfiguration: async () => {
+        calls.push("selectConfiguration");
+      },
+      releaseInterface: async () => {
+        calls.push("releaseInterface");
+      },
+      close: async () => {
+        calls.push("close");
+      },
+    };
+
+    Object.defineProperty(process, "platform", { value: "win32" });
+    try {
+      await buildSender(device).setupConnection();
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, "platform", originalPlatform);
+      }
+    }
+
+    expect(calls).toEqual(["open", "claimInterface"]);
+  });
+
+  it("continues stale-open cleanup when releasing the already claimed interface fails", async () => {
+    const calls: string[] = [];
+    const device = {
+      opened: true,
+      configuration: { configurationValue: 1 } as unknown,
+      releaseInterface: async () => {
+        calls.push("releaseInterface");
+        throw new Error("release failed");
+      },
+      reset: async () => {
+        calls.push("reset");
+      },
+      close: async () => {
+        calls.push("close");
+        device.opened = false;
+      },
+      open: async () => {
+        calls.push("open");
+        device.opened = true;
+      },
+      selectConfiguration: async () => {
+        calls.push("selectConfiguration");
+      },
+      claimInterface: async () => {
+        calls.push("claimInterface");
+      },
+    };
+
+    await buildSender(device).setupConnection();
+
+    expect(calls).toEqual(
+      process.platform === "win32"
+        ? ["releaseInterface", "close", "open", "claimInterface"]
+        : ["releaseInterface", "reset", "close", "open", "reset", "claimInterface"],
     );
   });
 
@@ -706,5 +896,186 @@ describe("NodeWebUsbApduSender — closeConnection", () => {
     expect(sendResult.isLeft()).toBe(true);
     sendResult.ifLeft(error => expect(error).toBeInstanceOf(OpeningConnectionError));
     expect(closeErrors).toBe(1);
+  });
+
+  it("returns without releasing or closing an unopened device with no active read loop", async () => {
+    let releaseCalls = 0;
+    let closeCalls = 0;
+    const device = {
+      opened: false,
+      releaseInterface: async () => {
+        releaseCalls += 1;
+      },
+      close: async () => {
+        closeCalls += 1;
+      },
+    };
+
+    await buildSender(device).closeConnection();
+
+    expect(releaseCalls).toBe(0);
+    expect(closeCalls).toBe(0);
+  });
+
+  it("waits for the active read loop even when the device is already closed", async () => {
+    let resolveTransferIn: ((result: { status: "ok"; data: DataView }) => void) | undefined;
+    let transferInStarted: (() => void) | undefined;
+    const transferInStartedPromise = new Promise<void>(resolve => {
+      transferInStarted = resolve;
+    });
+    const device = {
+      opened: true,
+      transferOut: async () => ({ status: "ok" }),
+      transferIn: async () => {
+        transferInStarted?.();
+        return new Promise<{ status: "ok"; data: DataView }>(resolve => {
+          resolveTransferIn = resolve;
+        });
+      },
+      releaseInterface: async () => {
+        throw new Error("releaseInterface should not run for a closed device");
+      },
+      close: async () => {
+        throw new Error("close should not run for a closed device");
+      },
+    };
+    const sender = new NodeWebUsbApduSender({
+      dependencies: { device: device as never, interfaceNumber: 1 },
+      apduSenderFactory: singleFrameApduSenderFactory,
+      apduReceiverFactory: realReceiverFactory,
+      loggerFactory: () => createLogger(),
+      closeReadLoopTimeoutMs: 50,
+    });
+
+    const sendPromise = sender.sendApdu(new Uint8Array([0xe0, 0x01, 0x00, 0x00]));
+    await transferInStartedPromise;
+    device.opened = false;
+
+    let closeSettled = false;
+    const closePromise = sender.closeConnection().then(() => {
+      closeSettled = true;
+    });
+    await flushTasks();
+    expect(closeSettled).toBe(false);
+
+    resolveTransferIn?.({ status: "ok", data: new DataView(new Uint8Array(FRAME_SIZE).buffer) });
+    await closePromise;
+    const sendResult = await sendPromise;
+
+    expect(sendResult.isLeft()).toBe(true);
+  });
+
+  it("stops the transfer-in loop after the generation changes during close", async () => {
+    let resolveTransferIn: ((result: { status: "ok"; data: DataView }) => void) | undefined;
+    let transferInStarted: (() => void) | undefined;
+    const transferInStartedPromise = new Promise<void>(resolve => {
+      transferInStarted = resolve;
+    });
+    let receiverCalls = 0;
+    const device = {
+      opened: true,
+      transferOut: async () => ({ status: "ok" }),
+      transferIn: async () => {
+        transferInStarted?.();
+        return new Promise<{ status: "ok"; data: DataView }>(resolve => {
+          resolveTransferIn = resolve;
+        });
+      },
+      releaseInterface: async () => {},
+      close: async () => {
+        device.opened = false;
+      },
+    };
+    const apduReceiverFactory = (() => ({
+      handleFrame: () => {
+        receiverCalls += 1;
+        throw new Error("stale frame should not be handled after close");
+      },
+    })) as unknown as ApduReceiverServiceFactory;
+    const sender = new NodeWebUsbApduSender({
+      dependencies: { device: device as never, interfaceNumber: 1 },
+      apduSenderFactory: singleFrameApduSenderFactory,
+      apduReceiverFactory,
+      loggerFactory: () => createLogger(),
+      closeReadLoopTimeoutMs: 50,
+    });
+
+    const sendPromise = sender.sendApdu(new Uint8Array([0xe0, 0x01, 0x00, 0x00]));
+    await transferInStartedPromise;
+    const closePromise = sender.closeConnection();
+    resolveTransferIn?.({ status: "ok", data: new DataView(new Uint8Array(FRAME_SIZE).buffer) });
+
+    await closePromise;
+    const sendResult = await sendPromise;
+
+    expect(sendResult.isLeft()).toBe(true);
+    expect(receiverCalls).toBe(0);
+  });
+
+  it("ignores stale transfer-in errors after close so a later APDU can complete", async () => {
+    type TransferInResult = { status: "ok"; data: DataView };
+    const pendingTransfers: Array<{
+      resolve: (result: TransferInResult) => void;
+      reject: (error: Error) => void;
+    }> = [];
+    let transferInCalls = 0;
+    let firstTransferStarted: (() => void) | undefined;
+    let secondTransferStarted: (() => void) | undefined;
+    const firstTransferStartedPromise = new Promise<void>(resolve => {
+      firstTransferStarted = resolve;
+    });
+    const secondTransferStartedPromise = new Promise<void>(resolve => {
+      secondTransferStarted = resolve;
+    });
+    const response = { data: new Uint8Array([0x42]), statusCode: new Uint8Array([0x90, 0x00]) };
+    const device = {
+      opened: true,
+      transferOut: async () => ({ status: "ok" }),
+      transferIn: async () => {
+        transferInCalls += 1;
+        if (transferInCalls === 1) firstTransferStarted?.();
+        if (transferInCalls === 2) secondTransferStarted?.();
+        return new Promise<TransferInResult>((resolve, reject) => {
+          pendingTransfers.push({ resolve, reject });
+        });
+      },
+      releaseInterface: async () => {},
+      close: async () => {
+        device.opened = false;
+      },
+    };
+    const apduReceiverFactory = (() => ({
+      handleFrame: () => Right(Maybe.of(response)),
+    })) as unknown as ApduReceiverServiceFactory;
+    const sender = new NodeWebUsbApduSender({
+      dependencies: { device: device as never, interfaceNumber: 1 },
+      apduSenderFactory: singleFrameApduSenderFactory,
+      apduReceiverFactory,
+      loggerFactory: () => createLogger(),
+      closeReadLoopTimeoutMs: 5,
+    });
+
+    const firstSend = sender.sendApdu(new Uint8Array([0xe0, 0x01, 0x00, 0x00]));
+    await firstTransferStartedPromise;
+    await sender.closeConnection();
+    const firstResult = await firstSend;
+    expect(firstResult.isLeft()).toBe(true);
+
+    device.opened = true;
+    const secondSend = sender.sendApdu(new Uint8Array([0xe0, 0x02, 0x00, 0x00]));
+    await secondTransferStartedPromise;
+    pendingTransfers[0]!.reject(new Error("stale read failed"));
+    await flushTasks();
+    pendingTransfers[1]!.resolve({
+      status: "ok",
+      data: new DataView(new Uint8Array(FRAME_SIZE).buffer),
+    });
+    const secondResult = await secondSend;
+
+    expect(secondResult.isRight()).toBe(true);
+    secondResult.ifRight(result => {
+      expect(Array.from(result.data)).toEqual([0x42]);
+      expect(Array.from(result.statusCode)).toEqual([0x90, 0x00]);
+    });
   });
 });

--- a/apps/wallet-cli/src/device/node-webusb/NodeWebUsbApduSender.test.ts
+++ b/apps/wallet-cli/src/device/node-webusb/NodeWebUsbApduSender.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect, it } from "bun:test";
+import {
+  defaultApduReceiverServiceStubBuilder,
+  defaultApduSenderServiceStubBuilder,
+  OpeningConnectionError,
+  SendApduTimeoutError,
+} from "@ledgerhq/device-management-kit";
 import type {
   ApduReceiverServiceFactory,
   ApduSenderServiceFactory,
   LoggerPublisherService,
 } from "@ledgerhq/device-management-kit";
+import { Maybe } from "purify-ts";
 import { NodeWebUsbApduSender } from "./NodeWebUsbApduSender";
+import { FRAME_SIZE } from "./node-webusb-constants";
 
 function flushTasks(): Promise<void> {
   return new Promise(resolve => queueMicrotask(resolve));
@@ -18,6 +26,95 @@ function createLogger(): LoggerPublisherService {
     warn: () => {},
     error: () => {},
   } as unknown as LoggerPublisherService;
+}
+
+// GeneralDmkError stores the underlying cause on `originalError`, not `message`.
+function causeMessage(error: unknown): string {
+  return String((error as { originalError?: Error }).originalError?.message ?? "");
+}
+
+// Production DMK framing services (the real APDU framer/deframer), wired with a
+// no-op logger. Using these instead of stubbed factories exercises the actual
+// byte-level seam: APDU -> 64-byte frames -> transferOut, then transferIn frames
+// -> reassembled APDU + status code.
+const realSenderFactory: ApduSenderServiceFactory = args =>
+  defaultApduSenderServiceStubBuilder(args, () => createLogger());
+const realReceiverFactory: ApduReceiverServiceFactory = args =>
+  defaultApduReceiverServiceStubBuilder(args, () => createLogger());
+
+/**
+ * Async FIFO of USB bulk-in frames. `pop()` resolves immediately when a frame is
+ * queued, otherwise it parks until the next `push()`.
+ */
+function createFrameQueue() {
+  const frames: Uint8Array[] = [];
+  let waiter: ((frame: Uint8Array) => void) | null = null;
+  return {
+    push(frame: Uint8Array): void {
+      if (waiter) {
+        const resolve = waiter;
+        waiter = null;
+        resolve(frame);
+      } else {
+        frames.push(frame);
+      }
+    },
+    pop(): Promise<Uint8Array> {
+      const next = frames.shift();
+      if (next) return Promise.resolve(next);
+      return new Promise(resolve => {
+        waiter = resolve;
+      });
+    },
+  };
+}
+
+/**
+ * In-memory Ledger device that talks the real DMK framing protocol: it deframes
+ * the host's command with a device-side receiver (mirroring the channel taken
+ * from the first frame), then reframes a configured response so the host's
+ * receiver reassembles it. This validates both directions end-to-end without USB.
+ */
+function createFakeLedgerDevice(response: { data: Uint8Array; status: Uint8Array }) {
+  const outFrames = createFrameQueue();
+  const receivedCommands: Uint8Array[] = [];
+  let deviceReceiver: ReturnType<ApduReceiverServiceFactory> | null = null;
+  let deviceSender: ReturnType<ApduSenderServiceFactory> | null = null;
+
+  const device = {
+    opened: true,
+    transferOut: async (_endpoint: number, buffer: ArrayBuffer) => {
+      const frame = new Uint8Array(buffer);
+      if (!deviceReceiver || !deviceSender) {
+        // The channel is the first two bytes of every Ledger USB frame.
+        const channel = Maybe.of(frame.slice(0, 2));
+        deviceReceiver = realReceiverFactory({ channel });
+        deviceSender = realSenderFactory({ frameSize: FRAME_SIZE, channel, padding: true });
+      }
+      deviceReceiver.handleFrame(frame).map(maybeComplete =>
+        maybeComplete.map(command => {
+          receivedCommands.push(new Uint8Array([...command.data, ...command.statusCode]));
+          const payload = new Uint8Array([...response.data, ...response.status]);
+          for (const responseFrame of deviceSender!.getFrames(payload)) {
+            outFrames.push(responseFrame.getRawData());
+          }
+        }),
+      );
+      return { status: "ok" as const };
+    },
+    transferIn: async (_endpoint: number, _length: number) => {
+      const frame = await outFrames.pop();
+      const copy = frame.slice();
+      return { status: "ok" as const, data: new DataView(copy.buffer) };
+    },
+    releaseInterface: async () => {},
+    close: async () => {},
+  };
+
+  return {
+    device,
+    getReceivedCommands: () => receivedCommands,
+  };
 }
 
 describe("NodeWebUsbApduSender", () => {
@@ -126,5 +223,196 @@ describe("NodeWebUsbApduSender", () => {
 
     const sendResult = await sendPromise;
     expect(sendResult.isLeft()).toBe(true);
+  });
+});
+
+describe("NodeWebUsbApduSender — real DMK framing round-trip", () => {
+  function buildSender(device: unknown): NodeWebUsbApduSender {
+    return new NodeWebUsbApduSender({
+      dependencies: { device: device as never, interfaceNumber: 1 },
+      apduSenderFactory: realSenderFactory,
+      apduReceiverFactory: realReceiverFactory,
+      loggerFactory: () => createLogger(),
+    });
+  }
+
+  it("frames a command and reassembles a single-frame response (data + 0x9000)", async () => {
+    const command = new Uint8Array([0xe0, 0x01, 0x00, 0x00]);
+    const responseData = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+    const responseStatus = new Uint8Array([0x90, 0x00]);
+    const fake = createFakeLedgerDevice({ data: responseData, status: responseStatus });
+
+    const result = await buildSender(fake.device).sendApdu(command);
+
+    expect(result.isRight()).toBe(true);
+    result.ifRight(response => {
+      expect(Array.from(response.data)).toEqual(Array.from(responseData));
+      expect(Array.from(response.statusCode)).toEqual(Array.from(responseStatus));
+    });
+    expect(fake.getReceivedCommands()).toHaveLength(1);
+    expect(Array.from(fake.getReceivedCommands()[0]!)).toEqual(Array.from(command));
+  });
+
+  it("round-trips a multi-frame command and a multi-frame response", async () => {
+    // 150-byte command and 300-byte response both exceed a single 64-byte frame,
+    // forcing the framer/deframer to span multiple frames in both directions.
+    const command = Uint8Array.from({ length: 150 }, (_, i) => i & 0xff);
+    const responseData = Uint8Array.from({ length: 300 }, (_, i) => (i * 7) & 0xff);
+    const responseStatus = new Uint8Array([0x90, 0x00]);
+    const fake = createFakeLedgerDevice({ data: responseData, status: responseStatus });
+
+    const result = await buildSender(fake.device).sendApdu(command);
+
+    expect(result.isRight()).toBe(true);
+    result.ifRight(response => {
+      expect(Array.from(response.data)).toEqual(Array.from(responseData));
+      expect(Array.from(response.statusCode)).toEqual(Array.from(responseStatus));
+    });
+    expect(Array.from(fake.getReceivedCommands()[0]!)).toEqual(Array.from(command));
+  });
+
+  it("surfaces a non-9000 status word as the response status code", async () => {
+    const responseStatus = new Uint8Array([0x69, 0x85]); // conditions of use not satisfied
+    const fake = createFakeLedgerDevice({ data: new Uint8Array(), status: responseStatus });
+
+    const result = await buildSender(fake.device).sendApdu(new Uint8Array([0xe0, 0x02, 0x00, 0x00]));
+
+    expect(result.isRight()).toBe(true);
+    result.ifRight(response => {
+      expect(Array.from(response.statusCode)).toEqual([0x69, 0x85]);
+      expect(response.data).toHaveLength(0);
+    });
+  });
+});
+
+describe("NodeWebUsbApduSender — sendApdu error paths", () => {
+  function buildSender(device: unknown): NodeWebUsbApduSender {
+    return new NodeWebUsbApduSender({
+      dependencies: { device: device as never, interfaceNumber: 1 },
+      apduSenderFactory: realSenderFactory,
+      apduReceiverFactory: realReceiverFactory,
+      loggerFactory: () => createLogger(),
+    });
+  }
+
+  const APDU = new Uint8Array([0xe0, 0x01, 0x00, 0x00]);
+
+  it("returns Left when the device is not connected", async () => {
+    const result = await buildSender({ opened: false }).sendApdu(APDU);
+    expect(result.isLeft()).toBe(true);
+    result.ifLeft(error => expect(error).toBeInstanceOf(OpeningConnectionError));
+  });
+
+  it("returns Left when transferOut reports a non-ok status", async () => {
+    const device = {
+      opened: true,
+      transferOut: async () => ({ status: "stall" }),
+    };
+    const result = await buildSender(device).sendApdu(APDU);
+    expect(result.isLeft()).toBe(true);
+    result.ifLeft(error => {
+      expect(error).toBeInstanceOf(OpeningConnectionError);
+      expect(causeMessage(error)).toContain("transferOut status: stall");
+    });
+  });
+
+  it("returns Left when transferOut throws", async () => {
+    const device = {
+      opened: true,
+      transferOut: async () => {
+        throw new Error("usb boom");
+      },
+    };
+    const result = await buildSender(device).sendApdu(APDU);
+    expect(result.isLeft()).toBe(true);
+    result.ifLeft(error => expect(causeMessage(error)).toContain("usb boom"));
+  });
+
+  it("returns Left when transferIn reports a non-ok status", async () => {
+    const device = {
+      opened: true,
+      transferOut: async () => ({ status: "ok" }),
+      transferIn: async () => ({ status: "babble", data: undefined }),
+    };
+    const result = await buildSender(device).sendApdu(APDU);
+    expect(result.isLeft()).toBe(true);
+    result.ifLeft(error => {
+      expect(error).toBeInstanceOf(OpeningConnectionError);
+      expect(causeMessage(error)).toContain("transferIn status: babble");
+    });
+  });
+
+  it("resolves with SendApduTimeoutError when the abort timeout fires", async () => {
+    const device = {
+      opened: true,
+      transferOut: async () => ({ status: "ok" }),
+      // Never resolves — only the abort timeout can settle the exchange.
+      transferIn: () => new Promise<never>(() => {}),
+    };
+    const result = await buildSender(device).sendApdu(APDU, false, 5);
+    expect(result.isLeft()).toBe(true);
+    result.ifLeft(error => expect(error).toBeInstanceOf(SendApduTimeoutError));
+  });
+});
+
+describe("NodeWebUsbApduSender — setupConnection", () => {
+  function buildSender(device: unknown, interfaceNumber = 2): NodeWebUsbApduSender {
+    return new NodeWebUsbApduSender({
+      dependencies: { device: device as never, interfaceNumber },
+      apduSenderFactory: realSenderFactory,
+      apduReceiverFactory: realReceiverFactory,
+      loggerFactory: () => createLogger(),
+    });
+  }
+
+  it("opens the device, selects the configuration when missing, and claims the interface", async () => {
+    const calls = { open: 0, selectConfiguration: 0, claimInterface: 0 };
+    const device = {
+      opened: false,
+      configuration: null as unknown,
+      open: async () => {
+        calls.open += 1;
+        device.opened = true;
+      },
+      selectConfiguration: async () => {
+        calls.selectConfiguration += 1;
+        device.configuration = { configurationValue: 1 };
+      },
+      reset: async () => {},
+      claimInterface: async () => {
+        calls.claimInterface += 1;
+      },
+      releaseInterface: async () => {},
+      close: async () => {},
+    };
+
+    await buildSender(device).setupConnection();
+
+    expect(calls.open).toBe(1);
+    expect(calls.selectConfiguration).toBe(1);
+    expect(calls.claimInterface).toBe(1);
+  });
+
+  it("closes the device and rethrows when claiming the interface fails", async () => {
+    let closeCalls = 0;
+    const device = {
+      opened: false,
+      configuration: { configurationValue: 1 } as unknown,
+      open: async () => {
+        device.opened = true;
+      },
+      selectConfiguration: async () => {},
+      reset: async () => {},
+      claimInterface: async () => {
+        throw new Error("claim failed");
+      },
+      releaseInterface: async () => {},
+      close: async () => {
+        closeCalls += 1;
+      },
+    };
+
+    await expect(buildSender(device).setupConnection()).rejects.toThrow("claim failed");
+    expect(closeCalls).toBe(1);
   });
 });

--- a/apps/wallet-cli/src/device/node-webusb/NodeWebUsbApduSender.test.ts
+++ b/apps/wallet-cli/src/device/node-webusb/NodeWebUsbApduSender.test.ts
@@ -10,7 +10,7 @@ import type {
   ApduSenderServiceFactory,
   LoggerPublisherService,
 } from "@ledgerhq/device-management-kit";
-import { Maybe } from "purify-ts";
+import { Left, Maybe } from "purify-ts";
 import { NodeWebUsbApduSender } from "./NodeWebUsbApduSender";
 import { FRAME_SIZE } from "./node-webusb-constants";
 
@@ -18,13 +18,14 @@ function flushTasks(): Promise<void> {
   return new Promise(resolve => queueMicrotask(resolve));
 }
 
-function createLogger(): LoggerPublisherService {
+function createLogger(overrides: Partial<LoggerPublisherService> = {}): LoggerPublisherService {
   return {
     subscribers: [],
     debug: () => {},
     info: () => {},
     warn: () => {},
     error: () => {},
+    ...overrides,
   } as unknown as LoggerPublisherService;
 }
 
@@ -342,6 +343,83 @@ describe("NodeWebUsbApduSender — sendApdu error paths", () => {
     });
   });
 
+  it("returns Left when transferIn throws", async () => {
+    const device = {
+      opened: true,
+      transferOut: async () => ({ status: "ok" }),
+      transferIn: async () => {
+        throw new Error("usb read boom");
+      },
+    };
+    const result = await buildSender(device).sendApdu(APDU);
+    expect(result.isLeft()).toBe(true);
+    result.ifLeft(error => {
+      expect(error).toBeInstanceOf(OpeningConnectionError);
+      expect(causeMessage(error)).toContain("usb read boom");
+    });
+  });
+
+  it("returns Left when a received frame is rejected by the APDU receiver", async () => {
+    const device = {
+      opened: true,
+      transferOut: async () => ({ status: "ok" }),
+      transferIn: async () => ({
+        status: "ok",
+        data: new DataView(new Uint8Array(FRAME_SIZE).buffer),
+      }),
+    };
+    const apduReceiverFactory = (() => ({
+      handleFrame: () => Left(new OpeningConnectionError("malformed APDU frame")),
+    })) as unknown as ApduReceiverServiceFactory;
+    const sender = new NodeWebUsbApduSender({
+      dependencies: { device: device as never, interfaceNumber: 1 },
+      apduSenderFactory: realSenderFactory,
+      apduReceiverFactory,
+      loggerFactory: () => createLogger(),
+    });
+
+    const result = await sender.sendApdu(APDU);
+
+    expect(result.isLeft()).toBe(true);
+    result.ifLeft(error => {
+      expect(error).toBeInstanceOf(OpeningConnectionError);
+      expect(causeMessage(error)).toContain("malformed APDU frame");
+    });
+  });
+
+  it("returns Left when a later transferOut fails after an earlier frame succeeds", async () => {
+    const transferOutStatuses = ["ok", "stall"] as const;
+    const transferredFrames: Uint8Array[] = [];
+    const device = {
+      opened: true,
+      transferOut: async (_endpoint: number, buffer: ArrayBuffer) => {
+        transferredFrames.push(new Uint8Array(buffer));
+        return { status: transferOutStatuses[transferredFrames.length - 1] };
+      },
+    };
+    const apduSenderFactory = (() => ({
+      getFrames: () => [
+        { getRawData: () => new Uint8Array([0xe0, 0x01, 0x00, 0x00]) },
+        { getRawData: () => new Uint8Array([0xe0, 0x02, 0x00, 0x00]) },
+      ],
+    })) as unknown as ApduSenderServiceFactory;
+    const sender = new NodeWebUsbApduSender({
+      dependencies: { device: device as never, interfaceNumber: 1 },
+      apduSenderFactory,
+      apduReceiverFactory: realReceiverFactory,
+      loggerFactory: () => createLogger(),
+    });
+
+    const result = await sender.sendApdu(APDU);
+
+    expect(transferredFrames).toHaveLength(2);
+    expect(result.isLeft()).toBe(true);
+    result.ifLeft(error => {
+      expect(error).toBeInstanceOf(OpeningConnectionError);
+      expect(causeMessage(error)).toContain("transferOut status: stall");
+    });
+  });
+
   it("resolves with SendApduTimeoutError when the abort timeout fires", async () => {
     const device = {
       opened: true,
@@ -393,6 +471,130 @@ describe("NodeWebUsbApduSender — setupConnection", () => {
     expect(calls.claimInterface).toBe(1);
   });
 
+  it("releases, resets, closes, reopens, and claims when the device is already opened", async () => {
+    const calls: string[] = [];
+    const device = {
+      opened: true,
+      configuration: null as unknown,
+      releaseInterface: async () => {
+        calls.push("releaseInterface");
+      },
+      reset: async () => {
+        calls.push("reset");
+      },
+      close: async () => {
+        calls.push("close");
+        device.opened = false;
+      },
+      open: async () => {
+        calls.push("open");
+        device.opened = true;
+      },
+      selectConfiguration: async () => {
+        calls.push("selectConfiguration");
+        device.configuration = { configurationValue: 1 };
+      },
+      claimInterface: async () => {
+        calls.push("claimInterface");
+      },
+    };
+
+    await buildSender(device).setupConnection();
+
+    expect(calls).toEqual(
+      process.platform === "win32"
+        ? ["releaseInterface", "close", "open", "selectConfiguration", "claimInterface"]
+        : [
+            "releaseInterface",
+            "reset",
+            "close",
+            "open",
+            "selectConfiguration",
+            "reset",
+            "claimInterface",
+          ],
+    );
+  });
+
+  it("does not select a configuration when one already exists", async () => {
+    const calls = { open: 0, selectConfiguration: 0, claimInterface: 0 };
+    const device = {
+      opened: false,
+      configuration: { configurationValue: 1 } as unknown,
+      open: async () => {
+        calls.open += 1;
+        device.opened = true;
+      },
+      selectConfiguration: async () => {
+        calls.selectConfiguration += 1;
+      },
+      reset: async () => {},
+      claimInterface: async () => {
+        calls.claimInterface += 1;
+      },
+      releaseInterface: async () => {},
+      close: async () => {},
+    };
+
+    await buildSender(device).setupConnection();
+
+    expect(calls.open).toBe(1);
+    expect(calls.selectConfiguration).toBe(0);
+    expect(calls.claimInterface).toBe(1);
+  });
+
+  it("waits for an in-flight close before reopening and reclaiming the device", async () => {
+    const calls: string[] = [];
+    let finishRelease: (() => void) | undefined;
+    let releaseStartedResolve: (() => void) | undefined;
+    const releaseStarted = new Promise<void>(resolve => {
+      releaseStartedResolve = resolve;
+    });
+    const device = {
+      opened: true,
+      configuration: { configurationValue: 1 } as unknown,
+      releaseInterface: async () => {
+        calls.push("releaseInterface");
+        releaseStartedResolve?.();
+        await new Promise<void>(releaseResolve => {
+          finishRelease = releaseResolve;
+        });
+      },
+      close: async () => {
+        calls.push("close");
+        device.opened = false;
+      },
+      reset: async () => {
+        calls.push("reset");
+      },
+      open: async () => {
+        calls.push("open");
+        device.opened = true;
+      },
+      selectConfiguration: async () => {
+        calls.push("selectConfiguration");
+      },
+      claimInterface: async () => {
+        calls.push("claimInterface");
+      },
+    };
+    const sender = buildSender(device);
+    const closePromise = sender.closeConnection();
+
+    await releaseStarted;
+    const setupPromise = sender.setupConnection();
+    await flushTasks();
+    expect(calls).toEqual(["releaseInterface"]);
+    finishRelease?.();
+    await closePromise;
+    await setupPromise;
+    expect(calls).toEqual(
+      process.platform === "win32"
+        ? ["releaseInterface", "close", "open", "claimInterface"]
+        : ["releaseInterface", "close", "open", "reset", "claimInterface"],
+    );
+  });
+
   it("closes the device and rethrows when claiming the interface fails", async () => {
     let closeCalls = 0;
     const device = {
@@ -414,5 +616,95 @@ describe("NodeWebUsbApduSender — setupConnection", () => {
 
     await expect(buildSender(device).setupConnection()).rejects.toThrow("claim failed");
     expect(closeCalls).toBe(1);
+  });
+});
+
+describe("NodeWebUsbApduSender — closeConnection", () => {
+  function buildSender(
+    device: unknown,
+    loggerFactory: (tag: string) => LoggerPublisherService = () => createLogger(),
+  ): NodeWebUsbApduSender {
+    return new NodeWebUsbApduSender({
+      dependencies: { device: device as never, interfaceNumber: 1 },
+      apduSenderFactory: realSenderFactory,
+      apduReceiverFactory: realReceiverFactory,
+      loggerFactory,
+      closeReadLoopTimeoutMs: 5,
+    });
+  }
+
+  it("is idempotent for concurrent close calls", async () => {
+    let releaseCalls = 0;
+    let closeCalls = 0;
+    let finishRelease: (() => void) | undefined;
+    let releaseStartedResolve: (() => void) | undefined;
+    const releaseStarted = new Promise<void>(resolve => {
+      releaseStartedResolve = resolve;
+    });
+    const device = {
+      opened: true,
+      releaseInterface: async () => {
+        releaseCalls += 1;
+        releaseStartedResolve?.();
+        await new Promise<void>(releaseResolve => {
+          finishRelease = releaseResolve;
+        });
+      },
+      close: async () => {
+        closeCalls += 1;
+        device.opened = false;
+      },
+    };
+    const sender = buildSender(device);
+    const firstClose = sender.closeConnection();
+    const secondClose = sender.closeConnection();
+
+    await releaseStarted;
+    await flushTasks();
+    expect(releaseCalls).toBe(1);
+    expect(closeCalls).toBe(0);
+    finishRelease?.();
+    await Promise.all([firstClose, secondClose]);
+    expect(releaseCalls).toBe(1);
+    expect(closeCalls).toBe(1);
+  });
+
+  it("resolves a pending APDU while swallowing release errors and logging close errors", async () => {
+    let closeErrors = 0;
+    let transferInStarted: (() => void) | undefined;
+    const transferInStartedPromise = new Promise<void>(resolve => {
+      transferInStarted = resolve;
+    });
+    const device = {
+      opened: true,
+      transferOut: async () => ({ status: "ok" }),
+      transferIn: () => {
+        transferInStarted?.();
+        return new Promise<never>(() => {});
+      },
+      releaseInterface: async () => {
+        throw new Error("release failed");
+      },
+      close: async () => {
+        throw new Error("close failed");
+      },
+    };
+    const sender = buildSender(device, () =>
+      createLogger({
+        error: () => {
+          closeErrors += 1;
+        },
+      }),
+    );
+
+    const sendPromise = sender.sendApdu(new Uint8Array([0xe0, 0x01, 0x00, 0x00]));
+    await transferInStartedPromise;
+    const closePromise = sender.closeConnection();
+    const sendResult = await sendPromise;
+    await closePromise;
+
+    expect(sendResult.isLeft()).toBe(true);
+    sendResult.ifLeft(error => expect(error).toBeInstanceOf(OpeningConnectionError));
+    expect(closeErrors).toBe(1);
   });
 });

--- a/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.test.ts
+++ b/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import {
   DeviceDisconnectedBeforeSendingApdu,
+  NoAccessibleDeviceError,
   OpeningConnectionError,
+  UnknownDeviceError,
   type ApduReceiverServiceFactory,
   type ApduSenderServiceFactory,
   type DeviceConnectionStateMachine,
@@ -10,10 +12,11 @@ import {
   type DeviceId,
   type LoggerPublisherService,
   type TransportConnectedDevice,
+  type TransportArgs,
 } from "@ledgerhq/device-management-kit";
 import { Right } from "purify-ts";
-import type { Subscription } from "rxjs";
-import { NodeWebUsbTransport } from "./NodeWebUsbTransport";
+import { firstValueFrom, type Subscription } from "rxjs";
+import { NodeWebUsbTransport, nodeWebUsbTransportFactory } from "./NodeWebUsbTransport";
 import type { NodeWebUsbApduSenderDependencies } from "./NodeWebUsbApduSender";
 
 function flushTasks(): Promise<void> {
@@ -43,6 +46,20 @@ function createLogger(): LoggerPublisherService {
     info: () => {},
     warn: () => {},
     error: () => {},
+  } as unknown as LoggerPublisherService;
+}
+
+function createRecordingLogger(records: { errors: unknown[]; warnings: unknown[] }): LoggerPublisherService {
+  return {
+    subscribers: [],
+    debug: () => {},
+    info: () => {},
+    warn: (...args: unknown[]) => {
+      records.warnings.push(args);
+    },
+    error: (...args: unknown[]) => {
+      records.errors.push(args);
+    },
   } as unknown as LoggerPublisherService;
 }
 
@@ -78,6 +95,7 @@ type WebUsbLedgerDevice = {
 };
 
 type TestPlatformBindings = NonNullable<ConstructorParameters<typeof NodeWebUsbTransport>[6]>;
+type HotplugListenerProbe = { startListeningToConnectionEvents: () => void };
 
 function createNativeLedgerDevice(): NativeLedgerDevice {
   return {
@@ -564,6 +582,82 @@ describe("NodeWebUsbTransport", () => {
     // The machine was never closed: the reconnect path should leave it
     // recoverable rather than tearing it down on a transient failure.
     expect(closeConnectionCalls).toBe(0);
+
+    await transport.destroy();
+  });
+
+  it("keeps a machine routable when rollback removes only one of several WebUSB keys", async () => {
+    const nativeDevice = createNativeLedgerDevice();
+    const originalWebUsbDevice = createWebUsbLedgerDevice("ledger-original");
+    const replacementWebUsbDevice = createWebUsbLedgerDevice("ledger-replacement");
+
+    let connectedDeviceId: DeviceId | undefined;
+    let setupConnectionCalls = 0;
+    let eventDeviceConnectedCalls = 0;
+    let machineSendApduCalls = 0;
+    let dependencies: NodeWebUsbApduSenderDependencies = {
+      device: originalWebUsbDevice as never,
+      interfaceNumber: 1,
+    };
+    let machine:
+      | DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>
+      | undefined;
+
+    const transport = createTestTransport(
+      params => {
+        machine = {
+          setupConnection: async () => {
+            setupConnectionCalls += 1;
+          },
+          sendApdu: async () => {
+            machineSendApduCalls += 1;
+            return Right({
+              data: new Uint8Array(),
+              statusCode: new Uint8Array([0x90, 0x00]),
+            }) as never;
+          },
+          getDeviceId: () => params.deviceId,
+          getDependencies: () => dependencies,
+          setDependencies: (next: NodeWebUsbApduSenderDependencies) => {
+            dependencies = next;
+          },
+          eventDeviceDisconnected: () => {},
+          eventDeviceConnected: () => {
+            eventDeviceConnectedCalls += 1;
+            throw new Error("state machine refused connected event");
+          },
+          closeConnection: () => {},
+        } as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>;
+        return machine;
+      },
+      () => createStubApduSender() as never,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [nativeDevice] as never[],
+        createWebUsbDevice: async () => originalWebUsbDevice as never,
+      }),
+    );
+
+    const emissions = collectDeviceEmissions(transport);
+    connectedDeviceId = await waitForFirstDeviceId(emissions);
+
+    const connectResult = await transport.connect({
+      deviceId: connectedDeviceId!,
+      onDisconnect: () => {},
+    });
+    const connectedDevice = unwrapConnectedDevice(connectResult);
+    expect(machine).toBeDefined();
+    expect(setupConnectionCalls).toBe(1);
+
+    await transport.handleDeviceReconnection(machine!, replacementWebUsbDevice as never, 1);
+
+    expect(setupConnectionCalls).toBe(2);
+    expect(eventDeviceConnectedCalls).toBe(1);
+    expect(dependencies.device).toBe(originalWebUsbDevice as never);
+
+    const apduResult = await connectedDevice.sendApdu(new Uint8Array([0xb0, 0x01]));
+    expect(apduResult.isRight()).toBe(true);
+    expect(machineSendApduCalls).toBe(1);
 
     await transport.destroy();
   });
@@ -1078,6 +1172,240 @@ describe("NodeWebUsbTransport", () => {
     await transport.destroy();
   });
 
+  it("reconnects a pending machine by product when only the previous device has a serial number", async () => {
+    const nativeDevice = createNativeLedgerDevice();
+    const originalWebUsbDevice = createWebUsbLedgerDevice("ledger-A");
+    const replacementWebUsbDevice = createWebUsbLedgerDevice("");
+
+    let currentWebUsbDevice = originalWebUsbDevice;
+    let connectedDeviceId: DeviceId | undefined;
+    let tryToReconnect:
+      | DeviceConnectionStateMachineParams<NodeWebUsbApduSenderDependencies>["tryToReconnect"]
+      | undefined;
+    let setupConnectionCalls = 0;
+    let eventDeviceConnectedCalls = 0;
+    let dependencies: NodeWebUsbApduSenderDependencies = {
+      device: originalWebUsbDevice as never,
+      interfaceNumber: 1,
+    };
+
+    const transport = createTestTransport(
+      params => {
+        tryToReconnect = params.tryToReconnect;
+
+        return {
+          setupConnection: async () => {
+            setupConnectionCalls += 1;
+          },
+          sendApdu: async () => Right(new Uint8Array()) as never,
+          getDeviceId: () => params.deviceId,
+          getDependencies: () => dependencies,
+          setDependencies: (next: NodeWebUsbApduSenderDependencies) => {
+            dependencies = next;
+          },
+          eventDeviceDisconnected: () => {},
+          eventDeviceConnected: () => {
+            eventDeviceConnectedCalls += 1;
+          },
+          closeConnection: () => {},
+        } as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>;
+      },
+      () => createStubApduSender() as never,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [nativeDevice] as never[],
+        createWebUsbDevice: async () => currentWebUsbDevice as never,
+      }),
+    );
+
+    const emissions = collectDeviceEmissions(transport);
+
+    connectedDeviceId = await waitForFirstDeviceId(emissions);
+
+    await transport.connect({
+      deviceId: connectedDeviceId!,
+      onDisconnect: () => {},
+    });
+    expect(setupConnectionCalls).toBe(1);
+
+    currentWebUsbDevice = replacementWebUsbDevice;
+    tryToReconnect?.(0);
+
+    await waitFor(() => {
+      expect(setupConnectionCalls).toBe(2);
+      expect(eventDeviceConnectedCalls).toBe(1);
+    });
+
+    await transport.destroy();
+  });
+
+  it("reconnects a pending machine by product when only the replacement device has a serial number", async () => {
+    const nativeDevice = createNativeLedgerDevice();
+    const originalWebUsbDevice = createWebUsbLedgerDevice("");
+    const replacementWebUsbDevice = createWebUsbLedgerDevice("ledger-A");
+
+    let currentWebUsbDevice = originalWebUsbDevice;
+    let connectedDeviceId: DeviceId | undefined;
+    let tryToReconnect:
+      | DeviceConnectionStateMachineParams<NodeWebUsbApduSenderDependencies>["tryToReconnect"]
+      | undefined;
+    let setupConnectionCalls = 0;
+    let eventDeviceConnectedCalls = 0;
+    let dependencies: NodeWebUsbApduSenderDependencies = {
+      device: originalWebUsbDevice as never,
+      interfaceNumber: 1,
+    };
+
+    const transport = createTestTransport(
+      params => {
+        tryToReconnect = params.tryToReconnect;
+
+        return {
+          setupConnection: async () => {
+            setupConnectionCalls += 1;
+          },
+          sendApdu: async () => Right(new Uint8Array()) as never,
+          getDeviceId: () => params.deviceId,
+          getDependencies: () => dependencies,
+          setDependencies: (next: NodeWebUsbApduSenderDependencies) => {
+            dependencies = next;
+          },
+          eventDeviceDisconnected: () => {},
+          eventDeviceConnected: () => {
+            eventDeviceConnectedCalls += 1;
+          },
+          closeConnection: () => {},
+        } as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>;
+      },
+      () => createStubApduSender() as never,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [nativeDevice] as never[],
+        createWebUsbDevice: async () => currentWebUsbDevice as never,
+      }),
+    );
+
+    const emissions = collectDeviceEmissions(transport);
+
+    connectedDeviceId = await waitForFirstDeviceId(emissions);
+
+    await transport.connect({
+      deviceId: connectedDeviceId!,
+      onDisconnect: () => {},
+    });
+    expect(setupConnectionCalls).toBe(1);
+
+    currentWebUsbDevice = replacementWebUsbDevice;
+    tryToReconnect?.(0);
+
+    await waitFor(() => {
+      expect(setupConnectionCalls).toBe(2);
+      expect(eventDeviceConnectedCalls).toBe(1);
+    });
+
+    await transport.destroy();
+  });
+
+  it("routes tryToReconnect and onTerminated only to machines with the matching deviceId", async () => {
+    const nativeDeviceA = createNativeLedgerDevice();
+    const nativeDeviceB = createNativeLedgerDevice();
+    const webUsbDeviceA = createWebUsbLedgerDevice("ledger-A");
+    const webUsbDeviceB = createWebUsbLedgerDevice("ledger-B");
+    const nativeToWeb = new Map<unknown, unknown>([
+      [nativeDeviceA, webUsbDeviceA],
+      [nativeDeviceB, webUsbDeviceB],
+    ]);
+
+    let deviceIdA: DeviceId | undefined;
+    let deviceIdB: DeviceId | undefined;
+    const tryToReconnectByDeviceId = new Map<
+      DeviceId,
+      NonNullable<
+        DeviceConnectionStateMachineParams<NodeWebUsbApduSenderDependencies>["tryToReconnect"]
+      >
+    >();
+    const onTerminatedByDeviceId = new Map<DeviceId, () => void>();
+    const eventDeviceConnectedCounts = new Map<DeviceId, number>();
+    const machineSendApduCounts = new Map<DeviceId, number>();
+
+    const transport = createTestTransport(
+      params => {
+        const webUsbDevice = params.deviceId === deviceIdA ? webUsbDeviceA : webUsbDeviceB;
+        tryToReconnectByDeviceId.set(params.deviceId, params.tryToReconnect);
+        onTerminatedByDeviceId.set(params.deviceId, params.onTerminated);
+
+        return {
+          setupConnection: async () => {},
+          sendApdu: async () => {
+            machineSendApduCounts.set(
+              params.deviceId,
+              (machineSendApduCounts.get(params.deviceId) ?? 0) + 1,
+            );
+            return Right({
+              data: new Uint8Array(),
+              statusCode: new Uint8Array([0x90, 0x00]),
+            }) as never;
+          },
+          getDeviceId: () => params.deviceId,
+          getDependencies: () => ({
+            device: webUsbDevice as never,
+            interfaceNumber: 1,
+          }),
+          setDependencies: () => {},
+          eventDeviceDisconnected: () => {},
+          eventDeviceConnected: () => {
+            eventDeviceConnectedCounts.set(
+              params.deviceId,
+              (eventDeviceConnectedCounts.get(params.deviceId) ?? 0) + 1,
+            );
+          },
+          closeConnection: () => {},
+        } as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>;
+      },
+      () => createStubApduSender() as never,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [nativeDeviceA, nativeDeviceB] as never[],
+        createWebUsbDevice: async native => nativeToWeb.get(native) as never,
+      }),
+    );
+
+    const emissions = collectDeviceEmissions(transport);
+    await waitFor(() => {
+      const last = emissions.at(-1) ?? [];
+      expect(last).toHaveLength(2);
+      [deviceIdA, deviceIdB] = [last[0]!.id, last[1]!.id];
+    });
+
+    const onDisconnectA: DeviceId[] = [];
+    const onDisconnectB: DeviceId[] = [];
+    await transport.connect({
+      deviceId: deviceIdA!,
+      onDisconnect: id => onDisconnectA.push(id),
+    });
+    const connectB = await transport.connect({
+      deviceId: deviceIdB!,
+      onDisconnect: id => onDisconnectB.push(id),
+    });
+    const connectedB = unwrapConnectedDevice(connectB);
+
+    tryToReconnectByDeviceId.get(deviceIdA!)?.(0);
+    await waitFor(() => {
+      expect(eventDeviceConnectedCounts.get(deviceIdA!) ?? 0).toBe(1);
+    });
+    expect(eventDeviceConnectedCounts.get(deviceIdB!) ?? 0).toBe(0);
+
+    const apduOnB = await connectedB.sendApdu(new Uint8Array([0xb0, 0x01]));
+    expect(apduOnB.isRight()).toBe(true);
+    expect(machineSendApduCounts.get(deviceIdB!) ?? 0).toBe(1);
+
+    onTerminatedByDeviceId.get(deviceIdA!)?.();
+    expect(onDisconnectA).toEqual([deviceIdA!]);
+    expect(onDisconnectB).toEqual([]);
+
+    await transport.destroy();
+  });
+
   it("serializes APDU calls sent through the same connected device", async () => {
     const nativeDevice = createNativeLedgerDevice();
     const webUsbDevice = createWebUsbLedgerDevice();
@@ -1447,6 +1775,1238 @@ describe("NodeWebUsbTransport", () => {
     // than triggering one rescan per caller.
     expect(deviceListCalls).toBe(2);
 
+    await transport.updateTransportDiscoveredDevices();
+    expect(deviceListCalls).toBe(3);
+
     await transport.destroy();
+  });
+
+  it("does not emit duplicate discovered-device lists when the rescan is unchanged", async () => {
+    const nativeDevice = createNativeLedgerDevice();
+    const webUsbDevice = createWebUsbLedgerDevice();
+
+    const transport = createTestTransport(
+      undefined,
+      undefined,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [nativeDevice] as never[],
+        createWebUsbDevice: async () => webUsbDevice as never,
+      }),
+    );
+
+    const emissions = collectDeviceEmissions(transport);
+
+    await waitFor(() => {
+      expect(emissions.at(-1)).toHaveLength(1);
+    });
+    const emissionsAfterFirstDiscovery = emissions.length;
+
+    await transport.updateTransportDiscoveredDevices();
+
+    expect(emissions).toHaveLength(emissionsAfterFirstDiscovery);
+
+    await transport.destroy();
+  });
+
+  it("preserves the discovered device id when the same WebUSB identity appears as a new instance", async () => {
+    const nativeDevice = createNativeLedgerDevice();
+    const firstWebUsbDevice = createWebUsbLedgerDevice("same-identity");
+    const secondWebUsbDevice = createWebUsbLedgerDevice("same-identity");
+    let currentWebUsbDevice = firstWebUsbDevice;
+
+    const transport = createTestTransport(
+      undefined,
+      undefined,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [nativeDevice] as never[],
+        createWebUsbDevice: async () => currentWebUsbDevice as never,
+      }),
+    );
+
+    const emissions = collectDeviceEmissions(transport);
+
+    const originalDeviceId = await waitForFirstDeviceId(emissions);
+
+    currentWebUsbDevice = secondWebUsbDevice;
+    const rediscovered = await firstValueFrom(transport.startDiscovering());
+
+    expect(rediscovered.id).toBe(originalDeviceId);
+
+    await transport.destroy();
+  });
+
+  it("emits two discovered devices when same product devices have different serial numbers", async () => {
+    const nativeDeviceA = createNativeLedgerDevice();
+    const nativeDeviceB = createNativeLedgerDevice();
+    const webUsbDeviceA = createWebUsbLedgerDevice("ledger-A");
+    const webUsbDeviceB = createWebUsbLedgerDevice("ledger-B");
+    const nativeToWeb = new Map<unknown, unknown>([
+      [nativeDeviceA, webUsbDeviceA],
+      [nativeDeviceB, webUsbDeviceB],
+    ]);
+
+    const transport = createTestTransport(
+      undefined,
+      undefined,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [nativeDeviceA, nativeDeviceB] as never[],
+        createWebUsbDevice: async native => nativeToWeb.get(native) as never,
+      }),
+    );
+
+    const emissions = collectDeviceEmissions(transport);
+
+    await waitFor(() => {
+      const discovered = emissions.at(-1) ?? [];
+      expect(discovered).toHaveLength(2);
+      expect(new Set(discovered.map(device => device.id)).size).toBe(2);
+    });
+
+    await transport.destroy();
+  });
+
+  it("deduplicates serial-less discovered devices by vendor and product", async () => {
+    const nativeDeviceA = createNativeLedgerDevice();
+    const nativeDeviceB = createNativeLedgerDevice();
+    const webUsbDeviceA = createWebUsbLedgerDevice("");
+    const webUsbDeviceB = createWebUsbLedgerDevice("");
+    const nativeToWeb = new Map<unknown, unknown>([
+      [nativeDeviceA, webUsbDeviceA],
+      [nativeDeviceB, webUsbDeviceB],
+    ]);
+
+    const transport = createTestTransport(
+      undefined,
+      undefined,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [nativeDeviceA, nativeDeviceB] as never[],
+        createWebUsbDevice: async native => nativeToWeb.get(native) as never,
+      }),
+    );
+
+    const emissions = collectDeviceEmissions(transport);
+
+    await waitFor(() => {
+      expect(emissions.at(-1)).toHaveLength(1);
+    });
+
+    await transport.destroy();
+  });
+
+  it("reuses an active connection machine id when a rescan sees the same WebUSB identity", async () => {
+    const nativeDevice = createNativeLedgerDevice();
+    const originalWebUsbDevice = createWebUsbLedgerDevice("active-identity");
+    const rescannedWebUsbDevice = createWebUsbLedgerDevice("active-identity");
+    let currentWebUsbDevice = originalWebUsbDevice;
+    let machineDeviceId: DeviceId | undefined;
+
+    const transport = createTestTransport(
+      params => {
+        machineDeviceId = params.deviceId;
+
+        return {
+          setupConnection: async () => {},
+          sendApdu: async () => Right(new Uint8Array()) as never,
+          getDeviceId: () => params.deviceId,
+          getDependencies: () => ({
+            device: originalWebUsbDevice as never,
+            interfaceNumber: 1,
+          }),
+          setDependencies: () => {},
+          eventDeviceDisconnected: () => {},
+          eventDeviceConnected: () => {},
+          closeConnection: () => {},
+        } as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>;
+      },
+      () => createStubApduSender() as never,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [nativeDevice] as never[],
+        createWebUsbDevice: async () => currentWebUsbDevice as never,
+      }),
+    );
+
+    const emissions = collectDeviceEmissions(transport);
+    const connectedDeviceId = await waitForFirstDeviceId(emissions);
+
+    await transport.connect({
+      deviceId: connectedDeviceId,
+      onDisconnect: () => {},
+    });
+
+    currentWebUsbDevice = rescannedWebUsbDevice;
+    const scanned = await transport.updateTransportDiscoveredDevices();
+
+    expect(scanned[0]?.device).toBe(rescannedWebUsbDevice as never);
+    expect(emissions.at(-1)?.[0]?.id).toBe(machineDeviceId);
+
+    await transport.destroy();
+  });
+
+  it("deduplicates WebUSB devices with the same identity during discovery", async () => {
+    const nativeDeviceA = createNativeLedgerDevice();
+    const nativeDeviceB = createNativeLedgerDevice();
+    const webUsbDeviceA = createWebUsbLedgerDevice("same-serial");
+    const webUsbDeviceB = createWebUsbLedgerDevice("same-serial");
+    let createWebUsbDeviceCalls = 0;
+
+    const transport = createTestTransport(
+      undefined,
+      undefined,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [nativeDeviceA, nativeDeviceB] as never[],
+        createWebUsbDevice: async () => {
+          createWebUsbDeviceCalls += 1;
+          return (createWebUsbDeviceCalls === 1 ? webUsbDeviceA : webUsbDeviceB) as never;
+        },
+      }),
+    );
+
+    const emissions = collectDeviceEmissions(transport);
+
+    await waitFor(() => {
+      expect(emissions.at(-1)).toHaveLength(1);
+    });
+    expect(createWebUsbDeviceCalls).toBe(2);
+
+    await transport.destroy();
+  });
+
+  it("restarts hotplug listeners after disconnect even when the explicit-close refresh fails", async () => {
+    const nativeDevice = createNativeLedgerDevice();
+    const webUsbDevice = createWebUsbLedgerDevice();
+
+    let attachHandler: ((device: NativeLedgerDevice) => void) | undefined;
+    let detachHandler: ((device: NativeLedgerDevice) => void) | undefined;
+    let attachRegistrations = 0;
+    let detachRegistrations = 0;
+    let removeRegistrations = 0;
+    let shouldFailRefresh = false;
+
+    const transport = createTestTransport(
+      params =>
+        ({
+          setupConnection: async () => {},
+          sendApdu: async () => Right(new Uint8Array()) as never,
+          getDeviceId: () => params.deviceId,
+          getDependencies: () => ({
+            device: webUsbDevice as never,
+            interfaceNumber: 1,
+          }),
+          setDependencies: () => {},
+          eventDeviceDisconnected: () => {},
+          eventDeviceConnected: () => {},
+          closeConnection: () => {},
+        }) as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>,
+      () => createStubApduSender() as never,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => {
+          if (shouldFailRefresh) {
+            throw new Error("refresh failed");
+          }
+          return [nativeDevice] as never[];
+        },
+        createWebUsbDevice: async () => webUsbDevice as never,
+        usbBindings: {
+          on: (event, handler) => {
+            if (event === "attach") {
+              attachRegistrations += 1;
+              attachHandler = handler as (device: NativeLedgerDevice) => void;
+            } else if (event === "detach") {
+              detachRegistrations += 1;
+              detachHandler = handler as (device: NativeLedgerDevice) => void;
+            }
+          },
+          removeListener: () => {
+            removeRegistrations += 1;
+          },
+          unrefHotplugEvents: () => {},
+        },
+      }),
+    );
+
+    const emissions = collectDeviceEmissions(transport);
+    const connectedDeviceId = await waitForFirstDeviceId(emissions);
+    const connectResult = await transport.connect({
+      deviceId: connectedDeviceId,
+      onDisconnect: () => {},
+    });
+    const connectedDevice = unwrapConnectedDevice(connectResult);
+
+    shouldFailRefresh = true;
+    const disconnectResult = await transport.disconnect({ connectedDevice });
+
+    expect(disconnectResult.isRight()).toBe(true);
+    expect(attachRegistrations).toBe(2);
+    expect(detachRegistrations).toBe(2);
+    expect(removeRegistrations).toBe(2);
+    expect(attachHandler).toBeDefined();
+    expect(detachHandler).toBeDefined();
+
+    await transport.destroy();
+  });
+
+  it("removes active routing during disconnect even when APDU sender close throws", async () => {
+    const nativeDevice = createNativeLedgerDevice();
+    const webUsbDevice = createWebUsbLedgerDevice();
+
+    let connectedDeviceId: DeviceId | undefined;
+    let machineSendApduCalls = 0;
+
+    const transport = createTestTransport(
+      params =>
+        ({
+          setupConnection: async () => {},
+          sendApdu: async () => {
+            machineSendApduCalls += 1;
+            return Right({
+              data: new Uint8Array(),
+              statusCode: new Uint8Array([0x90, 0x00]),
+            }) as never;
+          },
+          getDeviceId: () => params.deviceId,
+          getDependencies: () => ({
+            device: webUsbDevice as never,
+            interfaceNumber: 1,
+          }),
+          setDependencies: () => {},
+          eventDeviceDisconnected: () => {},
+          eventDeviceConnected: () => {},
+          closeConnection: () => {},
+        }) as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>,
+      () =>
+        ({
+          ...createStubApduSender(),
+          closeConnection: async () => {
+            throw new Error("APDU sender close failed");
+          },
+        }) as never,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [nativeDevice] as never[],
+        createWebUsbDevice: async () => webUsbDevice as never,
+      }),
+    );
+
+    const emissions = collectDeviceEmissions(transport);
+    connectedDeviceId = await waitForFirstDeviceId(emissions);
+
+    const connectResult = await transport.connect({
+      deviceId: connectedDeviceId,
+      onDisconnect: () => {},
+    });
+    const connectedDevice = unwrapConnectedDevice(connectResult);
+
+    await expect(transport.disconnect({ connectedDevice })).rejects.toThrow("APDU sender close failed");
+
+    const callsBefore = machineSendApduCalls;
+    const apduResult = await connectedDevice.sendApdu(new Uint8Array([0xb0, 0x01]));
+
+    expect(machineSendApduCalls).toBe(callsBefore);
+    let leftError: unknown;
+    apduResult.ifLeft(error => {
+      leftError = error;
+    });
+    expect(leftError).toBeInstanceOf(DeviceDisconnectedBeforeSendingApdu);
+
+    await transport.destroy();
+  });
+
+  it("restores previous dependencies and keeps the machine pending when setupConnection fails during reconnection", async () => {
+    const nativeDevice = createNativeLedgerDevice();
+    const originalWebUsbDevice = createWebUsbLedgerDevice("ledger-original");
+    const replacementWebUsbDevice = createWebUsbLedgerDevice("ledger-original");
+
+    let connectedDeviceId: DeviceId | undefined;
+    let setupConnectionCalls = 0;
+    let eventDeviceConnectedCalls = 0;
+    let dependencies: NodeWebUsbApduSenderDependencies = {
+      device: originalWebUsbDevice as never,
+      interfaceNumber: 1,
+    };
+    let machine:
+      | DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>
+      | undefined;
+
+    const transport = createTestTransport(
+      params => {
+        machine = {
+          setupConnection: async () => {
+            setupConnectionCalls += 1;
+            if (setupConnectionCalls === 2) {
+              throw new Error("LIBUSB_ERROR_NO_DEVICE");
+            }
+          },
+          sendApdu: async () => Right(new Uint8Array()) as never,
+          getDeviceId: () => params.deviceId,
+          getDependencies: () => dependencies,
+          setDependencies: (next: NodeWebUsbApduSenderDependencies) => {
+            dependencies = next;
+          },
+          eventDeviceDisconnected: () => {},
+          eventDeviceConnected: () => {
+            eventDeviceConnectedCalls += 1;
+          },
+          closeConnection: () => {},
+        } as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>;
+        return machine;
+      },
+      () => createStubApduSender() as never,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [nativeDevice] as never[],
+        createWebUsbDevice: async () => originalWebUsbDevice as never,
+      }),
+    );
+
+    const emissions = collectDeviceEmissions(transport);
+    connectedDeviceId = await waitForFirstDeviceId(emissions);
+
+    await transport.connect({
+      deviceId: connectedDeviceId,
+      onDisconnect: () => {},
+    });
+
+    await transport.handleDeviceReconnection(machine!, replacementWebUsbDevice as never, 1);
+
+    expect(setupConnectionCalls).toBe(2);
+    expect(eventDeviceConnectedCalls).toBe(0);
+    expect(dependencies.device).toBe(originalWebUsbDevice as never);
+
+    await transport.handleDeviceReconnection(machine!, replacementWebUsbDevice as never, 1);
+
+    expect(setupConnectionCalls).toBe(3);
+    expect(eventDeviceConnectedCalls).toBe(1);
+    expect(dependencies.device).toBe(replacementWebUsbDevice as never);
+
+    await transport.destroy();
+  });
+
+  it("does not publish a machine as active when setDependencies throws during reconnection", async () => {
+    const nativeDevice = createNativeLedgerDevice();
+    const originalWebUsbDevice = createWebUsbLedgerDevice("ledger-original");
+    const replacementWebUsbDevice = createWebUsbLedgerDevice("ledger-original");
+
+    let currentDeviceList: (typeof nativeDevice)[] = [nativeDevice];
+    let connectedDeviceId: DeviceId | undefined;
+    let tryToReconnect:
+      | DeviceConnectionStateMachineParams<NodeWebUsbApduSenderDependencies>["tryToReconnect"]
+      | undefined;
+    let setupConnectionCalls = 0;
+    let eventDeviceConnectedCalls = 0;
+    let eventDeviceDisconnectedCalls = 0;
+    const dependencies: NodeWebUsbApduSenderDependencies = {
+      device: originalWebUsbDevice as never,
+      interfaceNumber: 1,
+    };
+    let machine:
+      | DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>
+      | undefined;
+
+    const transport = createTestTransport(
+      params => {
+        tryToReconnect = params.tryToReconnect;
+        machine = {
+          setupConnection: async () => {
+            setupConnectionCalls += 1;
+          },
+          sendApdu: async () => Right(new Uint8Array()) as never,
+          getDeviceId: () => params.deviceId,
+          getDependencies: () => dependencies,
+          setDependencies: (next: NodeWebUsbApduSenderDependencies) => {
+            if (next.device === (replacementWebUsbDevice as never)) {
+              throw new Error("dependency swap failed");
+            }
+          },
+          eventDeviceDisconnected: () => {
+            eventDeviceDisconnectedCalls += 1;
+          },
+          eventDeviceConnected: () => {
+            eventDeviceConnectedCalls += 1;
+          },
+          closeConnection: () => {},
+        } as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>;
+        return machine;
+      },
+      () => createStubApduSender() as never,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => currentDeviceList as never[],
+        createWebUsbDevice: async () => originalWebUsbDevice as never,
+      }),
+    );
+
+    const emissions = collectDeviceEmissions(transport);
+    connectedDeviceId = await waitForFirstDeviceId(emissions);
+
+    await transport.connect({
+      deviceId: connectedDeviceId,
+      onDisconnect: () => {},
+    });
+
+    currentDeviceList = [];
+    tryToReconnect?.(0);
+    await flushTasks();
+
+    await transport.handleDeviceReconnection(machine!, replacementWebUsbDevice as never, 1);
+
+    expect(setupConnectionCalls).toBe(1);
+    expect(eventDeviceConnectedCalls).toBe(0);
+
+    await transport.handleDeviceDisconnection(nativeDevice as never);
+
+    expect(eventDeviceDisconnectedCalls).toBe(0);
+
+    await transport.destroy();
+  });
+
+  it("skips non-Ledger USB devices before creating WebUSB wrappers during discovery", async () => {
+    const nonLedgerNativeDevice = {
+      deviceDescriptor: {
+        idVendor: 0x1234,
+        idProduct: 0x5678,
+      },
+    };
+    const ledgerNativeDevice = createNativeLedgerDevice();
+    const webUsbDevice = createWebUsbLedgerDevice();
+    const wrappedNativeDevices: unknown[] = [];
+
+    const transport = createTestTransport(
+      undefined,
+      undefined,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [nonLedgerNativeDevice, ledgerNativeDevice] as never[],
+        createWebUsbDevice: async native => {
+          wrappedNativeDevices.push(native);
+          return webUsbDevice as never;
+        },
+      }),
+    );
+
+    const emissions = collectDeviceEmissions(transport);
+
+    await waitFor(() => {
+      expect(emissions.at(-1)).toHaveLength(1);
+    });
+    expect(wrappedNativeDevices).toEqual([ledgerNativeDevice]);
+
+    await transport.destroy();
+  });
+
+  it("throws no-accessible-device when discovered Ledger devices lack a WebUSB vendor interface", async () => {
+    const nativeDevice = createNativeLedgerDevice();
+    const webUsbDeviceWithoutVendorInterface = {
+      ...createWebUsbLedgerDevice(),
+      configurations: [
+        {
+          interfaces: [
+            {
+              interfaceNumber: 1,
+              alternates: [{ interfaceClass: 3 }],
+            },
+          ],
+        },
+      ],
+    };
+
+    const transport = createTestTransport(
+      undefined,
+      undefined,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [nativeDevice] as never[],
+        createWebUsbDevice: async () => webUsbDeviceWithoutVendorInterface as never,
+      }),
+    );
+
+    await expect(firstValueFrom(transport.startDiscovering())).rejects.toBeInstanceOf(
+      NoAccessibleDeviceError,
+    );
+
+    await transport.destroy();
+  });
+
+  it("throws no-accessible-device when discovered Ledger devices have no USB configurations", async () => {
+    const nativeDevice = createNativeLedgerDevice();
+    const webUsbDeviceWithoutConfigurations = {
+      ...createWebUsbLedgerDevice(),
+      configurations: [],
+    };
+
+    const transport = createTestTransport(
+      undefined,
+      undefined,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [nativeDevice] as never[],
+        createWebUsbDevice: async () => webUsbDeviceWithoutConfigurations as never,
+      }),
+    );
+
+    await expect(firstValueFrom(transport.startDiscovering())).rejects.toBeInstanceOf(
+      NoAccessibleDeviceError,
+    );
+
+    await transport.destroy();
+  });
+
+  it("reports its identifier/support and exposes no-op stop discovery", async () => {
+    const transport = createTestTransport(
+      undefined,
+      undefined,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [],
+        createWebUsbDevice: async () => createWebUsbLedgerDevice() as never,
+      }),
+    );
+
+    expect(transport.getIdentifier()).toBe("NODE-WEBUSB");
+    expect(transport.isSupported()).toBe(true);
+    expect(() => transport.stopDiscovering()).not.toThrow();
+
+    await transport.destroy();
+  });
+
+  it("emits a discovered device from startDiscovering when a Ledger device is accessible", async () => {
+    const nativeDevice = createNativeLedgerDevice();
+    const webUsbDevice = createWebUsbLedgerDevice();
+
+    const transport = createTestTransport(
+      undefined,
+      undefined,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [nativeDevice] as never[],
+        createWebUsbDevice: async () => webUsbDevice as never,
+      }),
+    );
+
+    const discovered = await firstValueFrom(transport.startDiscovering());
+
+    expect(discovered.transport).toBe("NODE-WEBUSB");
+    expect(discovered.deviceModel.productName).toBe("Ledger Nano S Plus");
+
+    await transport.destroy();
+  });
+
+  it("discovers app-mode devices by shifted product id", async () => {
+    const nativeDevice = createNativeLedgerDevice();
+    const webUsbDevice = {
+      ...createWebUsbLedgerDevice(),
+      productId: 0x5000,
+    };
+
+    const transport = createTestTransport(
+      undefined,
+      undefined,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [nativeDevice] as never[],
+        createWebUsbDevice: async () => webUsbDevice as never,
+      }),
+    );
+
+    const discovered = await firstValueFrom(transport.startDiscovering());
+
+    expect(discovered.deviceModel.productName).toBe("Ledger Nano S Plus");
+    expect(discovered.transport).toBe("NODE-WEBUSB");
+
+    await transport.destroy();
+  });
+
+  it("discovers bootloader-mode devices by exact bootloader product id", async () => {
+    const nativeDevice = createNativeLedgerDevice();
+    const webUsbDevice = createWebUsbLedgerDevice();
+
+    const transport = new NodeWebUsbTransport(
+      {
+        getAllDeviceModels: () => [
+          {
+            id: "bootloaderOnly",
+            productName: "Bootloader-only test model",
+            usbProductId: 0x51,
+            bootloaderUsbProductId: 0x5011,
+          },
+        ],
+      } as unknown as DeviceModelDataSource,
+      () => createLogger(),
+      createUnusedApduSenderFactory(),
+      createUnusedApduReceiverFactory(),
+      undefined,
+      undefined,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [nativeDevice] as never[],
+        createWebUsbDevice: async () => webUsbDevice as never,
+      }),
+    );
+
+    const discovered = await firstValueFrom(transport.startDiscovering());
+
+    expect(discovered.deviceModel.productName).toBe("Bootloader-only test model");
+    expect(discovered.transport).toBe("NODE-WEBUSB");
+
+    await transport.destroy();
+  });
+
+  it("filters unrecognized devices during discovery without dropping recognized devices", async () => {
+    const recognizedNativeDevice = createNativeLedgerDevice();
+    const unrecognizedNativeDevice = createNativeLedgerDevice();
+    const recognizedWebUsbDevice = createWebUsbLedgerDevice("recognized");
+    const unrecognizedWebUsbDevice = {
+      ...createWebUsbLedgerDevice("unrecognized"),
+      productId: 0x9911,
+    };
+    const nativeToWeb = new Map<unknown, unknown>([
+      [recognizedNativeDevice, recognizedWebUsbDevice],
+      [unrecognizedNativeDevice, unrecognizedWebUsbDevice],
+    ]);
+
+    const transport = createTestTransport(
+      undefined,
+      undefined,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [recognizedNativeDevice, unrecognizedNativeDevice] as never[],
+        createWebUsbDevice: async native => nativeToWeb.get(native) as never,
+      }),
+    );
+
+    const emissions = collectDeviceEmissions(transport);
+    const scanned = await transport.updateTransportDiscoveredDevices();
+
+    expect(scanned).toHaveLength(2);
+    await waitFor(() => {
+      expect(emissions.at(-1)).toHaveLength(1);
+    });
+    expect(emissions.at(-1)?.[0]?.transport).toBe("NODE-WEBUSB");
+
+    await transport.destroy();
+  });
+
+  it("returns an empty scan and keeps the current discovery list when USB scanning fails", async () => {
+    const nativeDevice = createNativeLedgerDevice();
+    const webUsbDevice = createWebUsbLedgerDevice();
+    const records = { errors: [] as unknown[], warnings: [] as unknown[] };
+    let shouldThrow = false;
+
+    const transport = new NodeWebUsbTransport(
+      createLedgerModelDataSource(),
+      () => createRecordingLogger(records),
+      createUnusedApduSenderFactory(),
+      createUnusedApduReceiverFactory(),
+      undefined,
+      undefined,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [nativeDevice] as never[],
+        createWebUsbDevice: async () => {
+          if (shouldThrow) {
+            throw new Error("USB scan failed");
+          }
+          return webUsbDevice as never;
+        },
+      }),
+    );
+
+    const emissions = collectDeviceEmissions(transport);
+    await waitFor(() => {
+      expect(emissions.at(-1)).toHaveLength(1);
+    });
+
+    shouldThrow = true;
+    const scanned = await transport.updateTransportDiscoveredDevices();
+
+    expect(scanned).toEqual([]);
+    expect(emissions.at(-1)).toHaveLength(1);
+    expect(records.errors).toHaveLength(1);
+
+    await transport.destroy();
+  });
+
+  it("reuses the active state machine for a second sequential connect to the same device", async () => {
+    const nativeDevice = createNativeLedgerDevice();
+    const webUsbDevice = createWebUsbLedgerDevice();
+
+    let machineFactoryCalls = 0;
+    let setupConnectionCalls = 0;
+    let machineSendApduCalls = 0;
+
+    const transport = createTestTransport(
+      params => {
+        machineFactoryCalls += 1;
+        return {
+          setupConnection: async () => {
+            setupConnectionCalls += 1;
+          },
+          sendApdu: async () => {
+            machineSendApduCalls += 1;
+            return Right({
+              data: new Uint8Array(),
+              statusCode: new Uint8Array([0x90, 0x00]),
+            }) as never;
+          },
+          getDeviceId: () => params.deviceId,
+          getDependencies: () => ({
+            device: webUsbDevice as never,
+            interfaceNumber: 1,
+          }),
+          setDependencies: () => {},
+          eventDeviceDisconnected: () => {},
+          eventDeviceConnected: () => {},
+          closeConnection: () => {},
+        } as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>;
+      },
+      () => createStubApduSender() as never,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [nativeDevice] as never[],
+        createWebUsbDevice: async () => webUsbDevice as never,
+      }),
+    );
+
+    const emissions = collectDeviceEmissions(transport);
+    const connectedDeviceId = await waitForFirstDeviceId(emissions);
+
+    await transport.connect({
+      deviceId: connectedDeviceId,
+      onDisconnect: () => {},
+    });
+    const secondConnect = await transport.connect({
+      deviceId: connectedDeviceId,
+      onDisconnect: () => {},
+    });
+    const secondConnectedDevice = unwrapConnectedDevice(secondConnect);
+    await secondConnectedDevice.sendApdu(new Uint8Array([0xb0, 0x01]));
+
+    expect(machineFactoryCalls).toBe(1);
+    expect(setupConnectionCalls).toBe(1);
+    expect(machineSendApduCalls).toBe(1);
+
+    await transport.destroy();
+  });
+
+  it("returns the shared setup error to concurrent connects when initial setup fails", async () => {
+    const nativeDevice = createNativeLedgerDevice();
+    const webUsbDevice = createWebUsbLedgerDevice();
+
+    let releaseSetup: (() => void) | undefined;
+    const setupGate = new Promise<void>(resolve => {
+      releaseSetup = resolve;
+    });
+    let machineFactoryCalls = 0;
+
+    const transport = createTestTransport(
+      params => {
+        machineFactoryCalls += 1;
+        return {
+          setupConnection: async () => {
+            await setupGate;
+            throw new Error("LIBUSB_ERROR_BUSY");
+          },
+          sendApdu: async () => Right(new Uint8Array()) as never,
+          getDeviceId: () => params.deviceId,
+          getDependencies: () => ({
+            device: webUsbDevice as never,
+            interfaceNumber: 1,
+          }),
+          setDependencies: () => {},
+          eventDeviceDisconnected: () => {},
+          eventDeviceConnected: () => {},
+          closeConnection: () => {},
+        } as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>;
+      },
+      () => createStubApduSender() as never,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [nativeDevice] as never[],
+        createWebUsbDevice: async () => webUsbDevice as never,
+      }),
+    );
+
+    const emissions = collectDeviceEmissions(transport);
+    const connectedDeviceId = await waitForFirstDeviceId(emissions);
+
+    const firstConnect = transport.connect({
+      deviceId: connectedDeviceId,
+      onDisconnect: () => {},
+    });
+    const secondConnect = transport.connect({
+      deviceId: connectedDeviceId,
+      onDisconnect: () => {},
+    });
+
+    releaseSetup?.();
+    const results = await Promise.all([firstConnect, secondConnect]);
+
+    expect(machineFactoryCalls).toBe(1);
+    for (const result of results) {
+      let leftError: unknown;
+      result.ifLeft(error => {
+        leftError = error;
+      });
+      expect(leftError).toBeInstanceOf(OpeningConnectionError);
+    }
+
+    await transport.destroy();
+  });
+
+  it("returns UnknownDeviceError when connecting to an undiscovered device id", async () => {
+    const transport = createTestTransport(
+      undefined,
+      undefined,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [],
+        createWebUsbDevice: async () => createWebUsbLedgerDevice() as never,
+      }),
+    );
+
+    const result = await transport.connect({
+      deviceId: "missing-device",
+      onDisconnect: () => {},
+    });
+
+    let leftError: unknown;
+    result.ifLeft(error => {
+      leftError = error;
+    });
+    expect(leftError).toBeInstanceOf(UnknownDeviceError);
+
+    await transport.destroy();
+  });
+
+  it("returns UnknownDeviceError when disconnecting a device without an active connection", async () => {
+    const transport = createTestTransport(
+      undefined,
+      undefined,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [],
+        createWebUsbDevice: async () => createWebUsbLedgerDevice() as never,
+      }),
+    );
+
+    const result = await transport.disconnect({
+      connectedDevice: { id: "missing-device" } as TransportConnectedDevice,
+    });
+
+    let leftError: unknown;
+    result.ifLeft(error => {
+      leftError = error;
+    });
+    expect(leftError).toBeInstanceOf(UnknownDeviceError);
+
+    await transport.destroy();
+  });
+
+  it("terminates a pending reconnection machine and notifies only that device", async () => {
+    const nativeDevice = createNativeLedgerDevice();
+    const webUsbDevice = createWebUsbLedgerDevice();
+    let currentDeviceList: (typeof nativeDevice)[] = [nativeDevice];
+    let tryToReconnect:
+      | DeviceConnectionStateMachineParams<NodeWebUsbApduSenderDependencies>["tryToReconnect"]
+      | undefined;
+    let onTerminated: (() => void) | undefined;
+
+    const transport = createTestTransport(
+      params => {
+        tryToReconnect = params.tryToReconnect;
+        onTerminated = params.onTerminated;
+        return {
+          setupConnection: async () => {},
+          sendApdu: async () => Right(new Uint8Array()) as never,
+          getDeviceId: () => params.deviceId,
+          getDependencies: () => ({
+            device: webUsbDevice as never,
+            interfaceNumber: 1,
+          }),
+          setDependencies: () => {},
+          eventDeviceDisconnected: () => {},
+          eventDeviceConnected: () => {},
+          closeConnection: () => {},
+        } as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>;
+      },
+      () => createStubApduSender() as never,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => currentDeviceList as never[],
+        createWebUsbDevice: async () => webUsbDevice as never,
+      }),
+    );
+
+    const emissions = collectDeviceEmissions(transport);
+    const connectedDeviceId = await waitForFirstDeviceId(emissions);
+    const onDisconnectCalls: DeviceId[] = [];
+
+    await transport.connect({
+      deviceId: connectedDeviceId,
+      onDisconnect: id => onDisconnectCalls.push(id),
+    });
+
+    currentDeviceList = [];
+    tryToReconnect?.(0);
+    await flushTasks();
+    onTerminated?.();
+
+    expect(onDisconnectCalls).toEqual([connectedDeviceId]);
+
+    await transport.destroy();
+  });
+
+  it("wires hotplug listeners to attach and detach handlers and removes them on destroy", async () => {
+    const nativeDevice = createNativeLedgerDevice();
+    const webUsbDevice = createWebUsbLedgerDevice();
+
+    let attachHandler: ((device: NativeLedgerDevice) => void) | undefined;
+    let detachHandler: ((device: NativeLedgerDevice) => void) | undefined;
+    const removedListeners: Array<{ event: string; handler: unknown }> = [];
+    let unrefHotplugEventsCalls = 0;
+    let createWebUsbDeviceCalls = 0;
+
+    const transport = createTestTransport(
+      undefined,
+      undefined,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [],
+        createWebUsbDevice: async () => {
+          createWebUsbDeviceCalls += 1;
+          return webUsbDevice as never;
+        },
+        usbBindings: {
+          on: (event, handler) => {
+            if (event === "attach") {
+              attachHandler = handler as (device: NativeLedgerDevice) => void;
+            } else if (event === "detach") {
+              detachHandler = handler as (device: NativeLedgerDevice) => void;
+            }
+          },
+          removeListener: (event, handler) => {
+            removedListeners.push({ event, handler });
+          },
+          unrefHotplugEvents: () => {
+            unrefHotplugEventsCalls += 1;
+          },
+        },
+      }),
+    );
+
+    expect(attachHandler).toBeDefined();
+    expect(detachHandler).toBeDefined();
+
+    attachHandler?.(nativeDevice);
+    await waitFor(() => {
+      expect(createWebUsbDeviceCalls).toBe(1);
+    });
+    detachHandler?.(nativeDevice);
+    await flushTasks();
+
+    await transport.destroy();
+
+    expect(removedListeners).toEqual([
+      { event: "attach", handler: attachHandler },
+      { event: "detach", handler: detachHandler },
+    ]);
+    expect(unrefHotplugEventsCalls).toBe(1);
+  });
+
+  it("keeps hotplug listener registration idempotent when listening is requested twice", async () => {
+    let attachRegistrations = 0;
+    let detachRegistrations = 0;
+    const removedListeners: Array<{ event: string; handler: unknown }> = [];
+
+    const transport = createTestTransport(
+      undefined,
+      undefined,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [],
+        createWebUsbDevice: async () => createWebUsbLedgerDevice() as never,
+        usbBindings: {
+          on: event => {
+            if (event === "attach") {
+              attachRegistrations += 1;
+            } else if (event === "detach") {
+              detachRegistrations += 1;
+            }
+          },
+          removeListener: (event, handler) => {
+            removedListeners.push({ event, handler });
+          },
+          unrefHotplugEvents: () => {},
+        },
+      }),
+    );
+
+    (transport as unknown as HotplugListenerProbe).startListeningToConnectionEvents();
+
+    expect(attachRegistrations).toBe(1);
+    expect(detachRegistrations).toBe(1);
+
+    await transport.destroy();
+    expect(removedListeners).toHaveLength(2);
+  });
+
+  it("ignores Ledger attach events without a vendor interface", async () => {
+    const nativeDevice = createNativeLedgerDevice();
+    const webUsbDeviceWithoutVendorInterface = {
+      ...createWebUsbLedgerDevice(),
+      configurations: [
+        {
+          interfaces: [
+            {
+              interfaceNumber: 1,
+              alternates: [{ interfaceClass: 3 }],
+            },
+          ],
+        },
+      ],
+    };
+
+    let getDeviceListCalls = 0;
+    const transport = createTestTransport(
+      undefined,
+      undefined,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => {
+          getDeviceListCalls += 1;
+          return [nativeDevice] as never[];
+        },
+        createWebUsbDevice: async () => webUsbDeviceWithoutVendorInterface as never,
+      }),
+    );
+
+    await transport.handleDeviceConnection(nativeDevice as never);
+
+    expect(getDeviceListCalls).toBe(0);
+
+    await transport.destroy();
+  });
+
+  it("swallows WebUSB creation failures from Ledger attach events", async () => {
+    const nativeDevice = createNativeLedgerDevice();
+    const records = { errors: [] as unknown[], warnings: [] as unknown[] };
+
+    const transport = new NodeWebUsbTransport(
+      createLedgerModelDataSource(),
+      () => createRecordingLogger(records),
+      createUnusedApduSenderFactory(),
+      createUnusedApduReceiverFactory(),
+      undefined,
+      undefined,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [],
+        createWebUsbDevice: async () => {
+          throw new Error("createInstance failed");
+        },
+      }),
+    );
+
+    await transport.handleDeviceConnection(nativeDevice as never);
+
+    expect(records.errors).toHaveLength(1);
+
+    await transport.destroy();
+  });
+
+  it("closes every active connection and clears hotplug resources on destroy", async () => {
+    const nativeDeviceA = createNativeLedgerDevice();
+    const nativeDeviceB = createNativeLedgerDevice();
+    const webUsbDeviceA = createWebUsbLedgerDevice("ledger-A");
+    const webUsbDeviceB = createWebUsbLedgerDevice("ledger-B");
+    const nativeToWeb = new Map<unknown, unknown>([
+      [nativeDeviceA, webUsbDeviceA],
+      [nativeDeviceB, webUsbDeviceB],
+    ]);
+
+    const machineCloseConnectionCalls: DeviceId[] = [];
+    let apduSenderCloseConnectionCalls = 0;
+    let unrefHotplugEventsCalls = 0;
+
+    const transport = createTestTransport(
+      params =>
+        ({
+          setupConnection: async () => {},
+          sendApdu: async () => Right(new Uint8Array()) as never,
+          getDeviceId: () => params.deviceId,
+          getDependencies: () => ({
+            device: webUsbDeviceA as never,
+            interfaceNumber: 1,
+          }),
+          setDependencies: () => {},
+          eventDeviceDisconnected: () => {},
+          eventDeviceConnected: () => {},
+          closeConnection: () => {
+            machineCloseConnectionCalls.push(params.deviceId);
+          },
+        }) as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>,
+      () =>
+        ({
+          ...createStubApduSender(),
+          closeConnection: async () => {
+            apduSenderCloseConnectionCalls += 1;
+          },
+        }) as never,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [nativeDeviceA, nativeDeviceB] as never[],
+        createWebUsbDevice: async native => nativeToWeb.get(native) as never,
+        usbBindings: {
+          on: () => {},
+          removeListener: () => {},
+          unrefHotplugEvents: () => {
+            unrefHotplugEventsCalls += 1;
+          },
+        },
+      }),
+    );
+
+    const emissions = collectDeviceEmissions(transport);
+    let deviceIdA: DeviceId | undefined;
+    let deviceIdB: DeviceId | undefined;
+    await waitFor(() => {
+      const last = emissions.at(-1) ?? [];
+      expect(last).toHaveLength(2);
+      [deviceIdA, deviceIdB] = [last[0]!.id, last[1]!.id];
+    });
+
+    await transport.connect({
+      deviceId: deviceIdA!,
+      onDisconnect: () => {},
+    });
+    await transport.connect({
+      deviceId: deviceIdB!,
+      onDisconnect: () => {},
+    });
+
+    await transport.destroy();
+
+    expect(machineCloseConnectionCalls.sort()).toEqual([deviceIdA!, deviceIdB!].sort());
+    expect(apduSenderCloseConnectionCalls).toBe(2);
+    expect(unrefHotplugEventsCalls).toBe(1);
+  });
+
+  it("creates a transport from the factory using the Node WebUSB identifier", async () => {
+    const transport = nodeWebUsbTransportFactory({
+      config: {},
+      deviceModelDataSource: createLedgerModelDataSource(),
+      loggerServiceFactory: () => createLogger(),
+      apduSenderServiceFactory: createUnusedApduSenderFactory(),
+      apduReceiverServiceFactory: createUnusedApduReceiverFactory(),
+    } as unknown as TransportArgs);
+
+    expect(transport.getIdentifier()).toBe("NODE-WEBUSB");
+    await (transport as unknown as NodeWebUsbTransport).destroy();
   });
 });

--- a/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.test.ts
+++ b/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import {
   DeviceDisconnectedBeforeSendingApdu,
+  OpeningConnectionError,
   type ApduReceiverServiceFactory,
   type ApduSenderServiceFactory,
   type DeviceConnectionStateMachine,
@@ -563,6 +564,516 @@ describe("NodeWebUsbTransport", () => {
     // The machine was never closed: the reconnect path should leave it
     // recoverable rather than tearing it down on a transient failure.
     expect(closeConnectionCalls).toBe(0);
+
+    await transport.destroy();
+  });
+
+  it("reuses one in-flight connection state machine for concurrent connects to the same device", async () => {
+    const nativeDevice = createNativeLedgerDevice();
+    const webUsbDevice = createWebUsbLedgerDevice();
+
+    let connectedDeviceId: DeviceId | undefined;
+    let releaseSetup: (() => void) | undefined;
+    const setupGate = new Promise<void>(resolve => {
+      releaseSetup = resolve;
+    });
+    let machineFactoryCalls = 0;
+    let setupConnectionCalls = 0;
+    let machineSendApduCalls = 0;
+
+    const transport = createTestTransport(
+      params => {
+        machineFactoryCalls += 1;
+
+        return {
+          setupConnection: async () => {
+            setupConnectionCalls += 1;
+            await setupGate;
+          },
+          sendApdu: async () => {
+            machineSendApduCalls += 1;
+            return Right({
+              data: new Uint8Array(),
+              statusCode: new Uint8Array([0x90, 0x00]),
+            }) as never;
+          },
+          getDeviceId: () => params.deviceId,
+          getDependencies: () => ({
+            device: webUsbDevice as never,
+            interfaceNumber: 1,
+          }),
+          setDependencies: () => {},
+          eventDeviceDisconnected: () => {},
+          eventDeviceConnected: () => {},
+          closeConnection: () => {},
+        } as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>;
+      },
+      () => createStubApduSender() as never,
+      createPlatformBindings({
+        platform: "win32",
+        getDeviceList: () => [nativeDevice] as never[],
+        createWebUsbDevice: async () => webUsbDevice as never,
+      }),
+    );
+
+    const emissions = collectDeviceEmissions(transport);
+
+    connectedDeviceId = await waitForFirstDeviceId(emissions);
+
+    const firstConnect = transport.connect({
+      deviceId: connectedDeviceId!,
+      onDisconnect: () => {},
+    });
+    const secondConnect = transport.connect({
+      deviceId: connectedDeviceId!,
+      onDisconnect: () => {},
+    });
+
+    await waitFor(() => {
+      expect(setupConnectionCalls).toBeGreaterThan(0);
+    });
+    releaseSetup?.();
+
+    const [firstResult, secondResult] = await Promise.all([firstConnect, secondConnect]);
+    const firstConnectedDevice = unwrapConnectedDevice(firstResult);
+    const secondConnectedDevice = unwrapConnectedDevice(secondResult);
+
+    expect(machineFactoryCalls).toBe(1);
+    expect(setupConnectionCalls).toBe(1);
+
+    await Promise.all([
+      firstConnectedDevice.sendApdu(new Uint8Array([0xb0, 0x01])),
+      secondConnectedDevice.sendApdu(new Uint8Array([0xb0, 0x02])),
+    ]);
+    expect(machineSendApduCalls).toBe(2);
+
+    await transport.destroy();
+  });
+
+  it("ignores attach and detach events while an explicit disconnect is closing USB resources", async () => {
+    const nativeDevice = createNativeLedgerDevice();
+    const webUsbDevice = createWebUsbLedgerDevice();
+
+    let connectedDeviceId: DeviceId | undefined;
+    let releaseUsbClose: (() => void) | undefined;
+    const usbCloseGate = new Promise<void>(resolve => {
+      releaseUsbClose = resolve;
+    });
+    let createWebUsbDeviceCalls = 0;
+    let eventDeviceDisconnectedCalls = 0;
+    let machineCloseConnectionCalls = 0;
+
+    const transport = createTestTransport(
+      params =>
+        ({
+          setupConnection: async () => {},
+          sendApdu: async () => Right(new Uint8Array()) as never,
+          getDeviceId: () => params.deviceId,
+          getDependencies: () => ({
+            device: webUsbDevice as never,
+            interfaceNumber: 1,
+          }),
+          setDependencies: () => {},
+          eventDeviceDisconnected: () => {
+            eventDeviceDisconnectedCalls += 1;
+          },
+          eventDeviceConnected: () => {},
+          closeConnection: () => {
+            machineCloseConnectionCalls += 1;
+          },
+        }) as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>,
+      () =>
+        ({
+          ...createStubApduSender(),
+          closeConnection: async () => {
+            await usbCloseGate;
+          },
+        }) as never,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [nativeDevice] as never[],
+        createWebUsbDevice: async () => {
+          createWebUsbDeviceCalls += 1;
+          return webUsbDevice as never;
+        },
+      }),
+    );
+
+    const emissions = collectDeviceEmissions(transport);
+
+    connectedDeviceId = await waitForFirstDeviceId(emissions);
+    expect(createWebUsbDeviceCalls).toBe(1);
+
+    const connectResult = await transport.connect({
+      deviceId: connectedDeviceId!,
+      onDisconnect: () => {},
+    });
+    const connectedDevice = unwrapConnectedDevice(connectResult);
+
+    const disconnectPromise = transport.disconnect({ connectedDevice });
+    await waitFor(() => {
+      expect(machineCloseConnectionCalls).toBe(1);
+    });
+
+    await transport.handleDeviceDisconnection(nativeDevice as never);
+    await transport.handleDeviceConnection(nativeDevice as never);
+
+    expect(eventDeviceDisconnectedCalls).toBe(0);
+    expect(createWebUsbDeviceCalls).toBe(1);
+
+    releaseUsbClose?.();
+    await disconnectPromise;
+    await transport.destroy();
+  });
+
+  it("cleans up a failed initial connect and allows a later connect to succeed", async () => {
+    const nativeDevice = createNativeLedgerDevice();
+    const webUsbDevice = createWebUsbLedgerDevice();
+
+    let connectedDeviceId: DeviceId | undefined;
+    let setupConnectionCalls = 0;
+    let eventDeviceDisconnectedCalls = 0;
+    let machineSendApduCalls = 0;
+
+    const transport = createTestTransport(
+      params =>
+        ({
+          setupConnection: async () => {
+            setupConnectionCalls += 1;
+            if (setupConnectionCalls === 1) {
+              throw new Error("LIBUSB_ERROR_ACCESS");
+            }
+          },
+          sendApdu: async () => {
+            machineSendApduCalls += 1;
+            return Right({
+              data: new Uint8Array(),
+              statusCode: new Uint8Array([0x90, 0x00]),
+            }) as never;
+          },
+          getDeviceId: () => params.deviceId,
+          getDependencies: () => ({
+            device: webUsbDevice as never,
+            interfaceNumber: 1,
+          }),
+          setDependencies: () => {},
+          eventDeviceDisconnected: () => {
+            eventDeviceDisconnectedCalls += 1;
+          },
+          eventDeviceConnected: () => {},
+          closeConnection: () => {},
+        }) as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>,
+      () => createStubApduSender() as never,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [nativeDevice] as never[],
+        createWebUsbDevice: async () => webUsbDevice as never,
+      }),
+    );
+
+    const emissions = collectDeviceEmissions(transport);
+
+    connectedDeviceId = await waitForFirstDeviceId(emissions);
+
+    const firstConnect = await transport.connect({
+      deviceId: connectedDeviceId!,
+      onDisconnect: () => {},
+    });
+
+    let firstConnectError: unknown;
+    firstConnect.ifLeft(error => {
+      firstConnectError = error;
+    });
+    expect(firstConnectError).toBeInstanceOf(OpeningConnectionError);
+
+    await transport.handleDeviceDisconnection(nativeDevice as never);
+    expect(eventDeviceDisconnectedCalls).toBe(0);
+    expect(machineSendApduCalls).toBe(0);
+
+    const secondConnect = await transport.connect({
+      deviceId: connectedDeviceId!,
+      onDisconnect: () => {},
+    });
+    const connectedDevice = unwrapConnectedDevice(secondConnect);
+
+    expect(setupConnectionCalls).toBe(2);
+    const apduResult = await connectedDevice.sendApdu(new Uint8Array([0xb0, 0x01]));
+    expect(apduResult.isRight()).toBe(true);
+    expect(machineSendApduCalls).toBe(1);
+
+    await transport.destroy();
+  });
+
+  it("ignores non-Ledger attach and detach events", async () => {
+    const nonLedgerNativeDevice = {
+      deviceDescriptor: {
+        idVendor: 0x1234,
+        idProduct: 0x5678,
+      },
+    };
+
+    let createWebUsbDeviceCalls = 0;
+
+    const transport = createTestTransport(
+      undefined,
+      undefined,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [],
+        createWebUsbDevice: async () => {
+          createWebUsbDeviceCalls += 1;
+          return createWebUsbLedgerDevice() as never;
+        },
+      }),
+    );
+
+    await transport.handleDeviceConnection(nonLedgerNativeDevice as never);
+    await transport.handleDeviceDisconnection(nonLedgerNativeDevice as never);
+
+    expect(createWebUsbDeviceCalls).toBe(0);
+
+    await transport.destroy();
+  });
+
+  it("ignores unmatched Ledger detach events", async () => {
+    const nativeDevice = createNativeLedgerDevice();
+    const unmatchedNativeDevice = {
+      deviceDescriptor: {
+        idVendor: 0x2c97,
+        idProduct: 0x9999,
+      },
+    };
+    const webUsbDevice = createWebUsbLedgerDevice();
+
+    let connectedDeviceId: DeviceId | undefined;
+    let eventDeviceDisconnectedCalls = 0;
+
+    const transport = createTestTransport(
+      params =>
+        ({
+          setupConnection: async () => {},
+          sendApdu: async () => Right(new Uint8Array()) as never,
+          getDeviceId: () => params.deviceId,
+          getDependencies: () => ({
+            device: webUsbDevice as never,
+            interfaceNumber: 1,
+          }),
+          setDependencies: () => {},
+          eventDeviceDisconnected: () => {
+            eventDeviceDisconnectedCalls += 1;
+          },
+          eventDeviceConnected: () => {},
+          closeConnection: () => {},
+        }) as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>,
+      () => createStubApduSender() as never,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [nativeDevice] as never[],
+        createWebUsbDevice: async () => webUsbDevice as never,
+      }),
+    );
+
+    const emissions = collectDeviceEmissions(transport);
+
+    connectedDeviceId = await waitForFirstDeviceId(emissions);
+
+    await transport.connect({
+      deviceId: connectedDeviceId!,
+      onDisconnect: () => {},
+    });
+
+    await transport.handleDeviceDisconnection(unmatchedNativeDevice as never);
+
+    expect(eventDeviceDisconnectedCalls).toBe(0);
+
+    await transport.destroy();
+  });
+
+  it("notifies the matching state machine on Ledger detach and swallows notification errors", async () => {
+    const nativeDevice = createNativeLedgerDevice();
+    const webUsbDevice = createWebUsbLedgerDevice();
+
+    let connectedDeviceId: DeviceId | undefined;
+    let eventDeviceDisconnectedCalls = 0;
+
+    const transport = createTestTransport(
+      params =>
+        ({
+          setupConnection: async () => {},
+          sendApdu: async () => Right(new Uint8Array()) as never,
+          getDeviceId: () => params.deviceId,
+          getDependencies: () => ({
+            device: webUsbDevice as never,
+            interfaceNumber: 1,
+          }),
+          setDependencies: () => {},
+          eventDeviceDisconnected: () => {
+            eventDeviceDisconnectedCalls += 1;
+            throw new Error("state machine refused disconnected event");
+          },
+          eventDeviceConnected: () => {},
+          closeConnection: () => {},
+        }) as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>,
+      () => createStubApduSender() as never,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [nativeDevice] as never[],
+        createWebUsbDevice: async () => webUsbDevice as never,
+      }),
+    );
+
+    const emissions = collectDeviceEmissions(transport);
+
+    connectedDeviceId = await waitForFirstDeviceId(emissions);
+
+    await transport.connect({
+      deviceId: connectedDeviceId!,
+      onDisconnect: () => {},
+    });
+
+    await transport.handleDeviceDisconnection(nativeDevice as never);
+
+    expect(eventDeviceDisconnectedCalls).toBe(1);
+
+    await transport.destroy();
+  });
+
+  it("reconnects a pending machine only when both serial numbers match", async () => {
+    const nativeDevice = createNativeLedgerDevice();
+    const originalWebUsbDevice = createWebUsbLedgerDevice("ledger-A");
+    const differentSerialWebUsbDevice = createWebUsbLedgerDevice("ledger-B");
+
+    let currentWebUsbDevice = originalWebUsbDevice;
+    let connectedDeviceId: DeviceId | undefined;
+    let tryToReconnect:
+      | DeviceConnectionStateMachineParams<NodeWebUsbApduSenderDependencies>["tryToReconnect"]
+      | undefined;
+    let setupConnectionCalls = 0;
+    let eventDeviceConnectedCalls = 0;
+    let dependencies: NodeWebUsbApduSenderDependencies = {
+      device: originalWebUsbDevice as never,
+      interfaceNumber: 1,
+    };
+
+    const transport = createTestTransport(
+      params => {
+        tryToReconnect = params.tryToReconnect;
+
+        return {
+          setupConnection: async () => {
+            setupConnectionCalls += 1;
+          },
+          sendApdu: async () => Right(new Uint8Array()) as never,
+          getDeviceId: () => params.deviceId,
+          getDependencies: () => dependencies,
+          setDependencies: (next: NodeWebUsbApduSenderDependencies) => {
+            dependencies = next;
+          },
+          eventDeviceDisconnected: () => {},
+          eventDeviceConnected: () => {
+            eventDeviceConnectedCalls += 1;
+          },
+          closeConnection: () => {},
+        } as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>;
+      },
+      () => createStubApduSender() as never,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [nativeDevice] as never[],
+        createWebUsbDevice: async () => currentWebUsbDevice as never,
+      }),
+    );
+
+    const emissions = collectDeviceEmissions(transport);
+
+    connectedDeviceId = await waitForFirstDeviceId(emissions);
+
+    await transport.connect({
+      deviceId: connectedDeviceId!,
+      onDisconnect: () => {},
+    });
+    expect(setupConnectionCalls).toBe(1);
+
+    currentWebUsbDevice = differentSerialWebUsbDevice;
+    tryToReconnect?.(0);
+    await flushTasks();
+    await transport.updateTransportDiscoveredDevices();
+
+    expect(setupConnectionCalls).toBe(1);
+    expect(eventDeviceConnectedCalls).toBe(0);
+
+    currentWebUsbDevice = createWebUsbLedgerDevice("ledger-A");
+    await transport.updateTransportDiscoveredDevices();
+
+    expect(setupConnectionCalls).toBe(2);
+    expect(eventDeviceConnectedCalls).toBe(1);
+
+    await transport.destroy();
+  });
+
+  it("reconnects a pending machine by product when serial numbers are absent", async () => {
+    const nativeDevice = createNativeLedgerDevice();
+    const originalWebUsbDevice = createWebUsbLedgerDevice("");
+    const replacementWebUsbDevice = createWebUsbLedgerDevice("");
+
+    let currentWebUsbDevice = originalWebUsbDevice;
+    let connectedDeviceId: DeviceId | undefined;
+    let tryToReconnect:
+      | DeviceConnectionStateMachineParams<NodeWebUsbApduSenderDependencies>["tryToReconnect"]
+      | undefined;
+    let setupConnectionCalls = 0;
+    let eventDeviceConnectedCalls = 0;
+    let dependencies: NodeWebUsbApduSenderDependencies = {
+      device: originalWebUsbDevice as never,
+      interfaceNumber: 1,
+    };
+
+    const transport = createTestTransport(
+      params => {
+        tryToReconnect = params.tryToReconnect;
+
+        return {
+          setupConnection: async () => {
+            setupConnectionCalls += 1;
+          },
+          sendApdu: async () => Right(new Uint8Array()) as never,
+          getDeviceId: () => params.deviceId,
+          getDependencies: () => dependencies,
+          setDependencies: (next: NodeWebUsbApduSenderDependencies) => {
+            dependencies = next;
+          },
+          eventDeviceDisconnected: () => {},
+          eventDeviceConnected: () => {
+            eventDeviceConnectedCalls += 1;
+          },
+          closeConnection: () => {},
+        } as unknown as DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>;
+      },
+      () => createStubApduSender() as never,
+      createPlatformBindings({
+        platform: "linux",
+        getDeviceList: () => [nativeDevice] as never[],
+        createWebUsbDevice: async () => currentWebUsbDevice as never,
+      }),
+    );
+
+    const emissions = collectDeviceEmissions(transport);
+
+    connectedDeviceId = await waitForFirstDeviceId(emissions);
+
+    await transport.connect({
+      deviceId: connectedDeviceId!,
+      onDisconnect: () => {},
+    });
+    expect(setupConnectionCalls).toBe(1);
+
+    currentWebUsbDevice = replacementWebUsbDevice;
+    tryToReconnect?.(0);
+
+    await waitFor(() => {
+      expect(setupConnectionCalls).toBe(2);
+      expect(eventDeviceConnectedCalls).toBe(1);
+    });
 
     await transport.destroy();
   });

--- a/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.ts
+++ b/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.ts
@@ -140,6 +140,10 @@ export class NodeWebUsbTransport implements Transport {
     WebUSBDevice,
     DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>
   >();
+  private readonly _deviceConnectionSetupsByWebUsbDevice = new Map<
+    WebUSBDevice,
+    Promise<DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>>
+  >();
   // Mirrors the values of _deviceConnectionsByWebUsbDevice so that membership
   // checks (e.g. isConnectionMachineRoutable) are O(1) instead of O(n).
   private readonly _activeConnectionMachines = new Set<
@@ -579,6 +583,16 @@ export class NodeWebUsbTransport implements Transport {
       return Right(this.makeTransportConnectedDevice({ row, machine: existing }));
     }
 
+    const pendingSetup = this._deviceConnectionSetupsByWebUsbDevice.get(row.webUsbDevice);
+    if (pendingSetup) {
+      try {
+        const machine = await pendingSetup;
+        return Right(this.makeTransportConnectedDevice({ row, machine }));
+      } catch (e) {
+        return Left(new OpeningConnectionError(e));
+      }
+    }
+
     const apduSender = this._deviceApduSenderFactory({
       dependencies: { device: row.webUsbDevice, interfaceNumber: row.interfaceNumber },
       apduSenderFactory: this._apduSenderFactory,
@@ -619,15 +633,24 @@ export class NodeWebUsbTransport implements Transport {
     });
     this._deviceApduSendersByConnectionMachine.set(machine, apduSender);
 
-    try {
+    const setupConnection = (async () => {
       await machine.setupConnection();
+      this.setActiveConnection(row.webUsbDevice, machine);
+      return machine;
+    })();
+    this._deviceConnectionSetupsByWebUsbDevice.set(row.webUsbDevice, setupConnection);
+
+    try {
+      await setupConnection;
     } catch (e) {
       this._deviceApduSendersByConnectionMachine.delete(machine);
       this._logger.error("Error while setting up device connection", { data: { error: e } });
       return Left(new OpeningConnectionError(e));
+    } finally {
+      if (this._deviceConnectionSetupsByWebUsbDevice.get(row.webUsbDevice) === setupConnection) {
+        this._deviceConnectionSetupsByWebUsbDevice.delete(row.webUsbDevice);
+      }
     }
-
-    this.setActiveConnection(row.webUsbDevice, machine);
 
     return Right(this.makeTransportConnectedDevice({ row, machine }));
   }

--- a/apps/wallet-cli/src/device/register-dmk-transport.test.ts
+++ b/apps/wallet-cli/src/device/register-dmk-transport.test.ts
@@ -16,6 +16,12 @@ let createDeviceManagementKitImpl: () => Promise<{
   destroyTransport: () => Promise<void>;
 }>;
 
+type Deferred<T = void> = {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+};
+
 mock.module("./dmk", () => ({
   createDeviceManagementKit: () => createDeviceManagementKitImpl(),
 }));
@@ -30,28 +36,54 @@ const {
   resetWalletCliDmkSession,
 } = await import("./register-dmk-transport");
 
+function deferred<T = void>(): Deferred<T> {
+  let resolve!: Deferred<T>["resolve"];
+  let reject!: Deferred<T>["reject"];
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function waitOneTick(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 0));
+}
+
 function makeDmk({
+  availableDevices = [{ id: "ledger-usb-1" }],
+  close = () => {},
+  connect,
+  destroyTransport = async () => {},
+  disconnect = async () => {},
   getSessionState = () => ({}),
 }: {
+  availableDevices?: { id: string }[];
+  close?: () => void;
+  connect?: (input: unknown) => Promise<string>;
+  destroyTransport?: () => Promise<void>;
+  disconnect?: (input: unknown) => Promise<void>;
   getSessionState?: () => unknown;
 } = {}) {
   let nextSessionIndex = 0;
   const dmk = {
-    listenToAvailableDevices: () => of([{ id: "ledger-usb-1" }]),
-    connect: async () => {
-      nextSessionIndex += 1;
-      return `session-${nextSessionIndex}`;
-    },
+    listenToAvailableDevices: () => of(availableDevices),
+    connect:
+      connect ??
+      (async () => {
+        nextSessionIndex += 1;
+        return `session-${nextSessionIndex}`;
+      }),
     getDeviceSessionState: () => of(getSessionState()),
-    disconnect: async () => {},
-    close: () => {},
+    disconnect,
+    close,
   } as unknown as DeviceManagementKit;
 
   return {
     dmk,
     kit: {
       dmk,
-      destroyTransport: async () => {},
+      destroyTransport,
     },
   };
 }
@@ -97,19 +129,195 @@ describe("ensureWalletCliDmkTransport", () => {
     expect(afterReset.sessionId).toBe("session-2");
   });
 
+  it("resets persistent DMK state after a discovery miss so the next ensure can retry", async () => {
+    const destroyFirstTransport = mock(async () => {});
+    const closeFirstDmk = mock(() => {});
+    const first = makeDmk({
+      availableDevices: [],
+      close: closeFirstDmk,
+      destroyTransport: destroyFirstTransport,
+    });
+    const second = makeDmk();
+    const createDeviceManagementKit = mock(async () => {
+      if (createDeviceManagementKit.mock.calls.length === 1) {
+        return first.kit;
+      }
+      return second.kit;
+    });
+    createDeviceManagementKitImpl = createDeviceManagementKit;
+
+    await expect(ensureWalletCliDmkTransport()).rejects.toThrow(
+      "No Ledger device found. Unlock the device and try again.",
+    );
+    expect(destroyFirstTransport).toHaveBeenCalledTimes(1);
+    expect(closeFirstDmk).toHaveBeenCalledTimes(1);
+
+    await expect(ensureWalletCliDmkTransport()).resolves.toMatchObject({
+      sessionId: "session-1",
+    });
+    expect(createDeviceManagementKit).toHaveBeenCalledTimes(2);
+  });
+
+  it("resets persistent DMK state when creating DMK fails so the next ensure can retry", async () => {
+    const second = makeDmk();
+    const createDeviceManagementKit = mock(async () => {
+      if (createDeviceManagementKit.mock.calls.length === 1) {
+        throw new Error("failed to create DMK");
+      }
+      return second.kit;
+    });
+    createDeviceManagementKitImpl = createDeviceManagementKit;
+
+    await expect(ensureWalletCliDmkTransport()).rejects.toThrow("failed to create DMK");
+    await expect(ensureWalletCliDmkTransport()).resolves.toMatchObject({
+      sessionId: "session-1",
+    });
+    expect(createDeviceManagementKit).toHaveBeenCalledTimes(2);
+  });
+
+  it("resets persistent DMK state after a connect failure so the next ensure can retry", async () => {
+    const destroyFirstTransport = mock(async () => {});
+    const closeFirstDmk = mock(() => {});
+    const first = makeDmk({
+      close: closeFirstDmk,
+      connect: mock(async () => {
+        throw new Error("USB connect failed");
+      }),
+      destroyTransport: destroyFirstTransport,
+    });
+    const second = makeDmk();
+    const createDeviceManagementKit = mock(async () => {
+      if (createDeviceManagementKit.mock.calls.length === 1) {
+        return first.kit;
+      }
+      return second.kit;
+    });
+    createDeviceManagementKitImpl = createDeviceManagementKit;
+
+    await expect(ensureWalletCliDmkTransport()).rejects.toThrow("USB connect failed");
+    expect(destroyFirstTransport).toHaveBeenCalledTimes(1);
+    expect(closeFirstDmk).toHaveBeenCalledTimes(1);
+
+    await expect(ensureWalletCliDmkTransport()).resolves.toMatchObject({
+      sessionId: "session-1",
+    });
+    expect(createDeviceManagementKit).toHaveBeenCalledTimes(2);
+  });
+
   it("asks the user to retry when the initial session is busy", async () => {
     let sessionState: unknown = { deviceStatus: DeviceStatus.BUSY };
-    const fake = makeDmk({ getSessionState: () => sessionState });
+    const disconnect = mock(async () => {});
+    const fake = makeDmk({ disconnect, getSessionState: () => sessionState });
     createDeviceManagementKitImpl = async () => fake.kit;
 
     await expect(ensureWalletCliDmkTransport()).rejects.toThrow(
       "The Ledger device did not respond to the initial ping",
     );
+    expect(disconnect).toHaveBeenCalledWith({ sessionId: "session-1" });
 
     sessionState = {};
     await expect(ensureWalletCliDmkTransport()).resolves.toMatchObject({
       sessionId: "session-2",
     });
+  });
+
+  it("shares one in-flight connection across concurrent ensure calls", async () => {
+    const connectStarted = deferred();
+    const finishConnect = deferred();
+    const connect = mock(async () => {
+      connectStarted.resolve();
+      await finishConnect.promise;
+      return "session-1";
+    });
+    const fake = makeDmk({ connect });
+    const createDeviceManagementKit = mock(async () => fake.kit);
+    createDeviceManagementKitImpl = createDeviceManagementKit;
+
+    const firstPromise = ensureWalletCliDmkTransport();
+    const secondPromise = ensureWalletCliDmkTransport();
+    await connectStarted.promise;
+    finishConnect.resolve();
+
+    const [first, second] = await Promise.all([firstPromise, secondPromise]);
+    expect(first).toBe(second);
+    expect(createDeviceManagementKit).toHaveBeenCalledTimes(1);
+    expect(connect).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("teardown", () => {
+  it("fully awaits destroyTransport when resetting an active DMK session", async () => {
+    const finishDestroy = deferred();
+    const destroyTransport = mock(async () => {
+      await finishDestroy.promise;
+    });
+    const fake = makeDmk({ destroyTransport });
+    createDeviceManagementKitImpl = async () => fake.kit;
+    await ensureWalletCliDmkTransport();
+
+    const realSetTimeout = globalThis.setTimeout;
+    globalThis.setTimeout = ((handler: TimerHandler, _timeout?: number, ...args: unknown[]) =>
+      realSetTimeout(handler, 0, ...args)) as typeof globalThis.setTimeout;
+
+    let resetSettled = false;
+    const resetPromise = resetWalletCliDmkSession().then(() => {
+      resetSettled = true;
+    });
+    try {
+      await waitOneTick();
+      expect(resetSettled).toBe(false);
+      finishDestroy.resolve();
+      await resetPromise;
+      expect(destroyTransport).toHaveBeenCalledTimes(1);
+    } finally {
+      globalThis.setTimeout = realSetTimeout;
+    }
+  });
+
+  it("bounds destroyTransport when disposing an active DMK session", async () => {
+    const destroyTransport = mock(async () => {
+      await new Promise(() => {});
+    });
+    const fake = makeDmk({ destroyTransport });
+    createDeviceManagementKitImpl = async () => fake.kit;
+    await ensureWalletCliDmkTransport();
+
+    const realSetTimeout = globalThis.setTimeout;
+    globalThis.setTimeout = ((handler: TimerHandler, _timeout?: number, ...args: unknown[]) =>
+      realSetTimeout(handler, 0, ...args)) as typeof globalThis.setTimeout;
+    try {
+      await expect(disposeWalletCliDmkTransportFully()).resolves.toBeUndefined();
+      expect(destroyTransport).toHaveBeenCalledTimes(1);
+    } finally {
+      globalThis.setTimeout = realSetTimeout;
+    }
+  });
+
+  it("fully awaits test transport disconnect even during dispose teardown", async () => {
+    const finishDisconnect = deferred();
+    const disconnect = mock(async () => {
+      await finishDisconnect.promise;
+    });
+    const dmk = {
+      getDeviceSessionState: () => of({}),
+      disconnect,
+    } as unknown as DeviceManagementKit;
+    _setTestDmkTransport({
+      dmk,
+      sessionId: "test-session-1",
+      close: async () => {},
+    } as never);
+    await ensureWalletCliDmkTransport();
+
+    let disposeSettled = false;
+    const disposePromise = disposeWalletCliDmkTransportFully().then(() => {
+      disposeSettled = true;
+    });
+    await waitOneTick();
+    expect(disposeSettled).toBe(false);
+    finishDisconnect.resolve();
+    await disposePromise;
+    expect(disconnect).toHaveBeenCalledWith({ sessionId: "test-session-1" });
   });
 });
 

--- a/apps/wallet-cli/src/device/register-dmk-transport.ts
+++ b/apps/wallet-cli/src/device/register-dmk-transport.ts
@@ -26,6 +26,10 @@ const DISPOSE_DISCONNECT_TIMEOUT_MS = 1_000;
 const DISPOSE_DESTROY_TIMEOUT_MS = 1_000;
 
 const MODULE_ID = "wallet-cli-dmk-webusb";
+const NO_LEDGER_DEVICE_FOUND_MESSAGE = "No Ledger device found. Unlock the device and try again.";
+const INITIAL_SESSION_BUSY_MESSAGE =
+  "[wallet-cli] The Ledger device did not respond to the initial ping. " +
+  "Please run the command again — the retry usually succeeds.";
 
 type Singleton = {
   dmk: DeviceManagementKit;
@@ -36,14 +40,22 @@ type Singleton = {
 let singleton: Singleton | null = null;
 /** One DMK per CLI process: each `createDeviceManagementKit()` adds node-usb hotplug listeners; closing + recreating stacks listeners and breaks the 3rd+ in-process connect (same pattern as the former node-hid kit). */
 let persistentDmk: Promise<WalletCliDmk> | null = null;
+let pendingTransport: Promise<WalletCliDmkTransport> | null = null;
 let exitHooksRegistered = false;
 
 let _testTransport: WalletCliDmkTransport | null = null;
+
+class InitialSessionBusyError extends Error {
+  constructor() {
+    super(INITIAL_SESSION_BUSY_MESSAGE);
+  }
+}
 
 /** @internal Test seam — install before the CLI starts (e.g. from dmk-intercept.ts) to bypass USB discovery. */
 export function _setTestDmkTransport(t: WalletCliDmkTransport | null): void {
   _testTransport = t;
   singleton = null;
+  pendingTransport = null;
 }
 
 function closeDmkQuietly(dmk: DeviceManagementKit): void {
@@ -104,10 +116,19 @@ async function disconnectHeldDmk(held: Singleton | null, mode: "reset" | "dispos
   await awaitWithTimeout(disconnect, DISPOSE_DISCONNECT_TIMEOUT_MS);
 }
 
-async function destroyHeldDmk(held: Singleton | null): Promise<void> {
+async function destroyHeldDmk(held: Singleton | null, mode: "reset" | "dispose"): Promise<void> {
   if (!held) return;
 
-  await awaitWithTimeout(held.destroyTransport(), DISPOSE_DESTROY_TIMEOUT_MS);
+  // reset is followed by an immediate reconnect, so we wait for teardown to finish:
+  // the timeout only stops *waiting*, it can't abort a parked USB transferIn, and
+  // reconnecting while one is still in flight would race/corrupt the next session.
+  // dispose is process-exit, where a wedged transfer must not keep us alive, so it
+  // is bounded by DISPOSE_DESTROY_TIMEOUT_MS instead.
+  if (mode === "reset" || _testTransport) {
+    await held.destroyTransport().catch(() => {});
+  } else {
+    await awaitWithTimeout(held.destroyTransport(), DISPOSE_DESTROY_TIMEOUT_MS);
+  }
   closeDmkQuietly(held.dmk);
 }
 
@@ -151,10 +172,12 @@ async function connectFirstUsbDevice(dmk: DeviceManagementKit): Promise<string> 
       filter((list: DiscoveredDevice[]) => list.length > 0),
       timeout(CONNECT_TIMEOUT_MS),
     ),
-  );
+  ).catch(() => {
+    throw new Error(NO_LEDGER_DEVICE_FOUND_MESSAGE);
+  });
   const device = discovered[0];
   if (!device) {
-    throw new Error("No Ledger device found. Unlock the device and try again.");
+    throw new Error(NO_LEDGER_DEVICE_FOUND_MESSAGE);
   }
   const sessionId = await dmk.connect({
     device,
@@ -172,12 +195,30 @@ async function connectFirstUsbDevice(dmk: DeviceManagementKit): Promise<string> 
   const { DeviceStatus } = await import("@ledgerhq/device-management-kit");
   if (status === DeviceStatus.BUSY) {
     await dmk.disconnect({ sessionId }).catch(() => {});
-    throw new Error(
-      "[wallet-cli] The Ledger device did not respond to the initial ping. " +
-        "Please run the command again — the retry usually succeeds.",
-    );
+    throw new InitialSessionBusyError();
   }
   return sessionId;
+}
+
+async function resetPersistentDmkAfterFailedOpen(kit: WalletCliDmk): Promise<void> {
+  persistentDmk = null;
+  await destroyPersistentDmk(kit, "reset");
+}
+
+async function createWalletCliDmkTransport(): Promise<WalletCliDmkTransport> {
+  const kit = await getOrCreatePersistentDmk();
+  try {
+    const sessionId = await connectFirstUsbDevice(kit.dmk);
+    const transport = new WalletCliDmkTransport(kit.dmk, sessionId);
+    singleton = { dmk: kit.dmk, transport, destroyTransport: kit.destroyTransport };
+    return transport;
+  } catch (error) {
+    singleton = null;
+    if (!(error instanceof InitialSessionBusyError)) {
+      await resetPersistentDmkAfterFailedOpen(kit);
+    }
+    throw error;
+  }
 }
 
 /**
@@ -202,11 +243,10 @@ export function ensureWalletCliDmkTransport(): Promise<WalletCliDmkTransport> {
       return singleton.transport;
     }
 
-    const kit = await getOrCreatePersistentDmk();
-    const sessionId = await connectFirstUsbDevice(kit.dmk);
-    const transport = new WalletCliDmkTransport(kit.dmk, sessionId);
-    singleton = { dmk: kit.dmk, transport, destroyTransport: kit.destroyTransport };
-    return transport;
+    pendingTransport ??= createWalletCliDmkTransport().finally(() => {
+      pendingTransport = null;
+    });
+    return pendingTransport;
   });
 }
 
@@ -219,12 +259,13 @@ export function ensureWalletCliDmkTransport(): Promise<WalletCliDmkTransport> {
 async function teardownDmk(mode: "reset" | "dispose"): Promise<void> {
   const held = singleton;
   singleton = null;
+  pendingTransport = null;
 
   await disconnectHeldDmk(held, mode);
 
   if (_testTransport) return;
 
-  await destroyHeldDmk(held);
+  await destroyHeldDmk(held, mode);
   await teardownPersistentDmk(held, mode);
 }
 

--- a/apps/wallet-cli/src/device/wallet-cli-dmk-transport.test.ts
+++ b/apps/wallet-cli/src/device/wallet-cli-dmk-transport.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+import { WalletCliDmkTransport } from "./wallet-cli-dmk-transport";
+
+type SendApduArgs = {
+  sessionId: string;
+  apdu: Uint8Array;
+  abortTimeout?: number;
+};
+
+function makeDmk(
+  onSendApdu: (args: SendApduArgs) => { data: Uint8Array; statusCode: Uint8Array },
+) {
+  return {
+    sendApdu: async (args: SendApduArgs) => onSendApdu(args),
+  };
+}
+
+describe("WalletCliDmkTransport.exchange", () => {
+  it("forwards the APDU to dmk.sendApdu and concatenates data + statusCode into one Buffer", async () => {
+    let captured: SendApduArgs | undefined;
+    const dmk = makeDmk(args => {
+      captured = args;
+      return { data: new Uint8Array([0x01, 0x02, 0x03]), statusCode: new Uint8Array([0x90, 0x00]) };
+    });
+
+    const transport = new WalletCliDmkTransport(dmk as never, "session-xyz");
+    const response = await transport.exchange(Buffer.from([0xe0, 0x01, 0x00, 0x00]));
+
+    expect([...response]).toEqual([0x01, 0x02, 0x03, 0x90, 0x00]);
+    expect(captured?.sessionId).toBe("session-xyz");
+    expect([...(captured?.apdu ?? new Uint8Array())]).toEqual([0xe0, 0x01, 0x00, 0x00]);
+  });
+
+  it("applies the default abort timeout when the caller does not provide one", async () => {
+    let abortTimeout: number | undefined;
+    const dmk = makeDmk(args => {
+      abortTimeout = args.abortTimeout;
+      return { data: new Uint8Array(), statusCode: new Uint8Array([0x90, 0x00]) };
+    });
+
+    await new WalletCliDmkTransport(dmk as never, "s").exchange(Buffer.from([0xb0, 0x01]));
+
+    expect(abortTimeout).toBe(120_000);
+  });
+
+  it("passes a caller-provided abort timeout through to dmk.sendApdu", async () => {
+    let abortTimeout: number | undefined;
+    const dmk = makeDmk(args => {
+      abortTimeout = args.abortTimeout;
+      return { data: new Uint8Array(), statusCode: new Uint8Array([0x90, 0x00]) };
+    });
+
+    await new WalletCliDmkTransport(dmk as never, "s").exchange(Buffer.from([0xb0, 0x01]), {
+      abortTimeoutMs: 5_000,
+    });
+
+    expect(abortTimeout).toBe(5_000);
+  });
+});


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached. only tests
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:**
  - device part of the wallet-cli

### 📝 Description

This pull request introduces significant improvements to device connection management and testing infrastructure for the wallet CLI, with a focus on robustness, error handling, and concurrency safety. The changes ensure that device sessions are correctly reset or disposed of on failure, prevent race conditions during concurrent connection attempts, and enhance test coverage for edge cases in device management. Below are the most important changes:

**Device Connection Robustness and Error Handling**

* Refactored the device connection flow in `connect-ledger-app.ts` to use a discriminated union return type (`ConnectAppOnceResult`) for clearer success/error handling, and improved timeout/cancellation logic to ensure resources are cleaned up on silence timeouts. [[1]](diffhunk://#diff-dcd903b24b4f39765a6cdead83a71c02d30e806ae2969451ead6b8af029e9f1aR22-R25) [[2]](diffhunk://#diff-dcd903b24b4f39765a6cdead83a71c02d30e806ae2969451ead6b8af029e9f1aL96-R102) [[3]](diffhunk://#diff-dcd903b24b4f39765a6cdead83a71c02d30e806ae2969451ead6b8af029e9f1aL108-R118) [[4]](diffhunk://#diff-dcd903b24b4f39765a6cdead83a71c02d30e806ae2969451ead6b8af029e9f1aL129-R133) [[5]](diffhunk://#diff-dcd903b24b4f39765a6cdead83a71c02d30e806ae2969451ead6b8af029e9f1aL142-R157) [[6]](diffhunk://#diff-dcd903b24b4f39765a6cdead83a71c02d30e806ae2969451ead6b8af029e9f1aL163-R195) [[7]](diffhunk://#diff-dcd903b24b4f39765a6cdead83a71c02d30e806ae2969451ead6b8af029e9f1aL194-R212)
* Improved error messages and error types in `register-dmk-transport.ts`, including introducing a custom `InitialSessionBusyError` and constants for user-facing messages, for better diagnostics and user guidance. [[1]](diffhunk://#diff-d95e1bf9e08e238e8fd5b165a7aaf9c62979b9641d328212f7f32fa2550d96b2R29-R32) [[2]](diffhunk://#diff-d95e1bf9e08e238e8fd5b165a7aaf9c62979b9641d328212f7f32fa2550d96b2R43-R58) [[3]](diffhunk://#diff-d95e1bf9e08e238e8fd5b165a7aaf9c62979b9641d328212f7f32fa2550d96b2L154-R180) [[4]](diffhunk://#diff-d95e1bf9e08e238e8fd5b165a7aaf9c62979b9641d328212f7f32fa2550d96b2L175-R223)

**Concurrency and Resource Management**

* Ensured that only one in-flight connection attempt is allowed at a time by introducing a `pendingTransport` promise, preventing race conditions when multiple concurrent calls to establish a connection are made. [[1]](diffhunk://#diff-d95e1bf9e08e238e8fd5b165a7aaf9c62979b9641d328212f7f32fa2550d96b2R43-R58) [[2]](diffhunk://#diff-d95e1bf9e08e238e8fd5b165a7aaf9c62979b9641d328212f7f32fa2550d96b2L175-R223)
* Updated teardown logic to fully await asynchronous teardown operations (like `destroyTransport` and `disconnect`) during reset and dispose flows, ensuring that resources are not leaked and that subsequent operations can proceed safely.

**Transport Layer Improvements**

* Added logic in `NodeWebUsbTransport` to track and share in-progress device connection setups, so that concurrent requests for the same device do not trigger redundant connection attempts, improving efficiency and correctness. [[1]](diffhunk://#diff-50bfcccc4bd51137b668895b26e650ef59eb2b27fc063e4ad419e968bc6a0e68R143-R146) [[2]](diffhunk://#diff-50bfcccc4bd51137b668895b26e650ef59eb2b27fc063e4ad419e968bc6a0e68R586-R595) [[3]](diffhunk://#diff-50bfcccc4bd51137b668895b26e650ef59eb2b27fc063e4ad419e968bc6a0e68L622-L630)

**Testing Enhancements**

* Extended the test suite in `register-dmk-transport.test.ts` to cover new edge cases, including persistent state resets after failures, concurrent connection attempts, and teardown behavior, using new helper utilities like `deferred` and `waitOneTick` for precise async control. [[1]](diffhunk://#diff-2302b800f7dd1ba8086697331d0e34d164da83076b2dd541a1727d81bce1ff82R19-R24) [[2]](diffhunk://#diff-2302b800f7dd1ba8086697331d0e34d164da83076b2dd541a1727d81bce1ff82R39-R86) [[3]](diffhunk://#diff-2302b800f7dd1ba8086697331d0e34d164da83076b2dd541a1727d81bce1ff82R132-R321)

These changes collectively make device management in the CLI more robust, reliable, and maintainable, especially under error conditions and concurrent usage scenarios.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28271]
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-28271]: https://ledgerhq.atlassian.net/browse/LIVE-28271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ