### PR TITLE
[LWD] fix(lld): ignore net::ERR_TIMED_OUT errors in Sentry & Datadog [LIVE-31964]

### DIFF
--- a/.changeset/ignore-err-timed-out-error.md
+++ b/.changeset/ignore-err-timed-out-error.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Ignore `net::ERR_TIMED_OUT` (ErrorSimpleURLLoaderWrapper / browser_init) errors in Sentry and Datadog reporting

--- a/apps/ledger-live-desktop/src/datadog/ignoreErrors.test.ts
+++ b/apps/ledger-live-desktop/src/datadog/ignoreErrors.test.ts
@@ -14,6 +14,9 @@ describe("datadog ignoreErrors", () => {
       expect(shouldIgnoreErrorMessage("Failed to fetch")).toBe(true);
       expect(shouldIgnoreErrorMessage("request timed out")).toBe(true);
       expect(shouldIgnoreErrorMessage("UserRefusedOnDevice")).toBe(true);
+      expect(
+        shouldIgnoreErrorMessage("ErrorSimpleURLLoaderWrapper.?(browser_init)net::ERR_TIMED_OUT"),
+      ).toBe(true);
     });
 
     it("should return true when message matches RegExp pattern", () => {

--- a/apps/ledger-live-desktop/src/datadog/ignoreErrors.ts
+++ b/apps/ledger-live-desktop/src/datadog/ignoreErrors.ts
@@ -73,6 +73,7 @@ const NETWORKING_CONDITIONS = [
 
 const TIMEOUTS = [
   "ERR_CONNECTION_TIMED_OUT",
+  "ERR_TIMED_OUT",
   "request timed out",
   "SolanaTxConfirmationTimeout",
   "Time-out",

--- a/apps/ledger-live-desktop/src/sentry/install.ts
+++ b/apps/ledger-live-desktop/src/sentry/install.ts
@@ -57,6 +57,7 @@ const ignoreErrors = [
   "HederaAddAccountError",
   // timeouts
   "ERR_CONNECTION_TIMED_OUT",
+  "ERR_TIMED_OUT",
   "request timed out",
   "SolanaTxConfirmationTimeout",
   "timeout",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <\!-- Added a case in `ignoreErrors.test.ts` asserting the exact Sentry error string is filtered. -->
- [x] **Impact of the changes:**
  - Error-reporting only — no runtime or UX behaviour change.
  - `net::ERR_TIMED_OUT` errors (`ErrorSimpleURLLoaderWrapper` / `browser_init`) are no longer sent to Sentry or Datadog for Ledger Live Desktop.
  - QA focus: confirm other network/timeout errors are still reported as before; nothing else in error reporting regresses.

### 📝 Description

The Sentry issue [`ErrorSimpleURLLoaderWrapper.?(browser_init)net::ERR_TIMED_OUT`](https://ledger.sentry.io/issues/7344477809/) is a transient client-side network timeout (Chromium `net::ERR_TIMED_OUT`), not an actionable application bug. It has been flooding error tracking — ~15.6k events / ~9.4k users affected, ongoing since 2026-03-18 and peaking recently — so it should be filtered out of LWD reporting like the other network/timeout conditions already are.

This adds the net error code `ERR_TIMED_OUT` to the existing ignore lists, next to the sibling codes `ERR_CONNECTION_TIMED_OUT` and `ETIMEDOUT`, in both:

- `apps/ledger-live-desktop/src/datadog/ignoreErrors.ts` (`TIMEOUTS`) — feeds Datadog `beforeSend` via `shouldIgnoreErrorMessage`.
- `apps/ledger-live-desktop/src/sentry/install.ts` (`ignoreErrors`) — Sentry `init`.

Both lists use substring matching, so `ERR_TIMED_OUT` catches the `browser_init` variant and any other `net::ERR_TIMED_OUT` wrapper. It does not collide with `ERR_CONNECTION_TIMED_OUT` (distinct substring), and both are ignored regardless.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31964](https://ledgerhq.atlassian.net/browse/LIVE-31964)
- **ADR link (if any)**: N/A


---

### 🧐 Checklist for the PR Reviewers

<\!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31964]: https://ledgerhq.atlassian.net/browse/LIVE-31964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ