### PR TITLE
[LWM] feat(mobile): update drawer according to target

### DIFF
--- a/.changeset/bright-alerts-track.md
+++ b/.changeset/bright-alerts-track.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add transaction alerts notification drawer content and per-target opt-out dismissals

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -3728,7 +3728,11 @@
       "desc": "Get the latest updates on Ledger Wallet, Ledger products, the market, and personalised recommendations. Opt-out anytime in the settings",
       "descVariantB": "Get real-time alerts on new tokens, earning opportunities, and market shifts. Opt out at any time.",
       "allow": "Allow notifications",
-      "later": "Maybe later"
+      "later": "Maybe later",
+      "transactionsAlerts": {
+        "title": "Know the status of your money",
+        "desc": "Receive real-time alerts when your crypto is sent or received. Opt out at anytime via Settings."
+      }
     },
     "optInScreen": {
       "title": "Enable notifications?",

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptDAppCompleteFlow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptDAppCompleteFlow.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Pressable, Text, View } from "react-native";
 import { AuthorizationStatus } from "@react-native-firebase/messaging";
-import { AB_TESTING_VARIANTS } from "./types/variants";
+import { AB_TESTING_VARIANTS } from "../types/variants";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import {
@@ -16,7 +16,7 @@ import { track } from "~/analytics";
 import GlobalDrawers from "~/GlobalDrawers";
 import WebPlatformPlayer from "~/components/WebPlatformPlayer";
 import { MockedAccounts } from "LLM/features/Accounts/__integrations__/mockedAccounts";
-import { createNotificationsPromptFeatureFlags } from "./testUtils";
+import { createNotificationsPromptFeatureFlags } from "../testUtils";
 
 jest.mock("~/analytics", () => {
   const track = jest.fn();

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptReceiveFlow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptReceiveFlow.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { View } from "react-native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import { AB_TESTING_VARIANTS } from "./types/variants";
+import { AB_TESTING_VARIANTS } from "../types/variants";
 import {
   renderWithReactQuery,
   screen,
@@ -16,7 +16,10 @@ import { BTC_ACCOUNT } from "@ledgerhq/live-common/modularDrawer/__mocks__/accou
 import GlobalDrawers from "~/GlobalDrawers";
 import { track } from "~/analytics";
 import { AuthorizationStatus } from "@react-native-firebase/messaging";
-import { createNotificationsPromptFeatureFlags } from "./testUtils";
+import {
+  createNotificationsPromptFeatureFlags,
+  transactionsAlertsDrawerPromptCategoryConfig,
+} from "../testUtils";
 
 type AuthorizationStatusType = (typeof AuthorizationStatus)[keyof typeof AuthorizationStatus];
 
@@ -46,6 +49,9 @@ jest.mock("@react-native-firebase/messaging", () => {
 });
 
 const featureFlagsForReceivePrompt = createNotificationsPromptFeatureFlags();
+const featureFlagsForTransactionsAlertsReceivePrompt = createNotificationsPromptFeatureFlags({
+  notificationsCategories: [transactionsAlertsDrawerPromptCategoryConfig],
+});
 
 describe("NotificationsPrompt receive flow", () => {
   beforeAll(() => {
@@ -164,5 +170,50 @@ describe("NotificationsPrompt receive flow", () => {
       dismissedCount: 0,
       variant: AB_TESTING_VARIANTS.B,
     });
+  });
+
+  it("should prompt the transaction alerts drawer when a globally opted-in user leaves the receive flow", async () => {
+    mockRequestPermission.mockResolvedValue(AuthorizationStatus.AUTHORIZED);
+    mockHasPermission.mockResolvedValue(AuthorizationStatus.AUTHORIZED);
+
+    const { user } = renderWithReactQuery(<ReceiveFlowTestApp />, {
+      navigationInitialState: receiveFlowNavigationState,
+      overrideInitialState: withFlagOverrides(featureFlagsForTransactionsAlertsReceivePrompt, state => ({
+        ...state,
+        accounts: {
+          ...state.accounts,
+          active: [BTC_ACCOUNT],
+        },
+        notifications: {
+          ...state.notifications,
+          permissionStatus: AuthorizationStatus.AUTHORIZED,
+        },
+        settings: {
+          ...state.settings,
+          readOnlyModeEnabled: true,
+          notifications: {
+            ...state.settings.notifications,
+            areNotificationsAllowed: true,
+            transactionsAlertsCategory: false,
+          },
+        },
+      })),
+    });
+
+    await user.press(await screen.findByText(/^continue$/i));
+    await waitFor(() => expect(screen.getByTestId("button-receive-confirmation")).toBeVisible());
+
+    const backButtons = screen.getAllByTestId("navigation-header-back-button");
+    await user.press(backButtons[backButtons.length - 1]);
+    await act(async () => {
+      await jest.runOnlyPendingTimersAsync();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/know the status of your money/i)).toBeVisible();
+    });
+    expect(screen.getByText(/real-time alerts when your crypto is sent or received/i)).toBeVisible();
+    expect(screen.queryByText(/don't miss what matters/i)).not.toBeOnTheScreen();
+    expect(screen.getByText(/allow notifications/i)).toBeVisible();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptSendFlow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptSendFlow.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { View } from "react-native";
 import { AuthorizationStatus } from "@react-native-firebase/messaging";
-import { AB_TESTING_VARIANTS } from "./types/variants";
+import { AB_TESTING_VARIANTS } from "../types/variants";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import {
   renderWithReactQuery,
@@ -16,9 +16,42 @@ import { NavigatorName, ScreenName } from "~/const";
 import GlobalDrawers from "~/GlobalDrawers";
 import { track } from "~/analytics";
 import { MockedAccounts } from "LLM/features/Accounts/__integrations__/mockedAccounts";
-import { createNotificationsPromptFeatureFlags } from "./testUtils";
+import {
+  createNotificationsPromptFeatureFlags,
+  transactionsAlertsDrawerPromptCategoryConfig,
+} from "../testUtils";
+
+type AuthorizationStatusType = (typeof AuthorizationStatus)[keyof typeof AuthorizationStatus];
+
+const mockRequestPermission = jest.fn<Promise<AuthorizationStatusType>, []>(() =>
+  Promise.resolve(AuthorizationStatus.NOT_DETERMINED),
+);
+const mockHasPermission = jest.fn<Promise<AuthorizationStatusType>, []>(() =>
+  Promise.resolve(AuthorizationStatus.NOT_DETERMINED),
+);
+
+jest.mock("@react-native-firebase/messaging", () => {
+  const AuthorizationStatus = {
+    NOT_DETERMINED: -1,
+    DENIED: 0,
+    AUTHORIZED: 1,
+    PROVISIONAL: 2,
+    EPHEMERAL: 3,
+  } as const;
+
+  return {
+    AuthorizationStatus,
+    getMessaging: jest.fn(() => ({
+      requestPermission: mockRequestPermission,
+      hasPermission: mockHasPermission,
+    })),
+  };
+});
 
 const featureFlagsForSendPrompt = createNotificationsPromptFeatureFlags();
+const featureFlagsForTransactionsAlertsSendPrompt = createNotificationsPromptFeatureFlags({
+  notificationsCategories: [transactionsAlertsDrawerPromptCategoryConfig],
+});
 
 describe("NotificationsPrompt send flow", () => {
   beforeAll(() => {
@@ -27,6 +60,8 @@ describe("NotificationsPrompt send flow", () => {
 
   beforeEach(async () => {
     jest.setSystemTime(new Date("2025-01-01T00:00:00.000Z"));
+    mockRequestPermission.mockResolvedValue(AuthorizationStatus.NOT_DETERMINED);
+    mockHasPermission.mockResolvedValue(AuthorizationStatus.NOT_DETERMINED);
     await storage.deleteAll();
   });
 
@@ -143,5 +178,43 @@ describe("NotificationsPrompt send flow", () => {
       dismissedCount: 0,
       variant: AB_TESTING_VARIANTS.B,
     });
+  });
+
+  it("should prompt the transaction alerts drawer when a globally opted-in user leaves the send success screen", async () => {
+    mockRequestPermission.mockResolvedValue(AuthorizationStatus.AUTHORIZED);
+    mockHasPermission.mockResolvedValue(AuthorizationStatus.AUTHORIZED);
+
+    const { user } = renderWithReactQuery(<SendFlowTestApp />, {
+      navigationInitialState: sendFlowNavigationState,
+      overrideInitialState: withFlagOverrides(featureFlagsForTransactionsAlertsSendPrompt, state => ({
+        ...state,
+        accounts: MockedAccounts,
+        notifications: {
+          ...state.notifications,
+          permissionStatus: AuthorizationStatus.AUTHORIZED,
+        },
+        settings: {
+          ...state.settings,
+          readOnlyModeEnabled: false,
+          notifications: {
+            ...state.settings.notifications,
+            areNotificationsAllowed: true,
+            transactionsAlertsCategory: false,
+          },
+        },
+      })),
+    });
+
+    await waitFor(() => expect(screen.getByTestId("validate-success-screen")).toBeVisible());
+
+    await user.press(screen.getByTestId("enabled-success-close-button"));
+    act(() => jest.runOnlyPendingTimers());
+
+    await waitFor(() => {
+      expect(screen.getByText(/know the status of your money/i)).toBeVisible();
+    });
+    expect(screen.getByText(/real-time alerts when your crypto is sent or received/i)).toBeVisible();
+    expect(screen.queryByText(/don't miss what matters/i)).not.toBeOnTheScreen();
+    expect(screen.getByText(/allow notifications/i)).toBeVisible();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptStakeFlow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptStakeFlow.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import type { ComponentType } from "react";
 import { View } from "react-native";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { AB_TESTING_VARIANTS } from "./types/variants";
+import { AB_TESTING_VARIANTS } from "../types/variants";
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
 import * as TezosReact from "@ledgerhq/live-common/families/tezos/react";
@@ -21,7 +21,7 @@ import * as MobileFamilies from "~/families";
 import GlobalDrawers from "~/GlobalDrawers";
 import { NavigatorName, ScreenName } from "~/const";
 import { track } from "~/analytics";
-import { createNotificationsPromptFeatureFlags } from "./testUtils";
+import { createNotificationsPromptFeatureFlags } from "../testUtils";
 
 jest.mock("@ledgerhq/live-common/families/tezos/react", () => ({
   __esModule: true,

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptSwapFlow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptSwapFlow.test.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 import { View } from "react-native";
 import BigNumber from "bignumber.js";
 import { AuthorizationStatus } from "@react-native-firebase/messaging";
-import { AB_TESTING_VARIANTS } from "./types/variants";
+import { AB_TESTING_VARIANTS } from "../types/variants";
 import { CommonActions, NavigationProp, useNavigation } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import {
@@ -20,7 +20,7 @@ import { NavigatorName, ScreenName } from "~/const";
 import GlobalDrawers from "~/GlobalDrawers";
 import { track } from "~/analytics";
 import { MockedAccounts } from "LLM/features/Accounts/__integrations__/mockedAccounts";
-import { createNotificationsPromptFeatureFlags } from "./testUtils";
+import { createNotificationsPromptFeatureFlags } from "../testUtils";
 
 jest.mock("~/analytics", () => {
   const track = jest.fn();

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/components/NotificationsPromptContent.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/components/NotificationsPromptContent.tsx
@@ -3,8 +3,14 @@ import { Text } from "@ledgerhq/native-ui";
 import { useTranslation } from "~/context/Locale";
 import { useFeature } from "@features/platform-feature-flags";
 import { AB_TESTING_VARIANTS } from "../types/variants";
+import type { NotificationPromptTarget } from "../types";
+import { getNotificationsPromptCopy } from "../utils/getNotificationsPromptCopy";
 
-export const NotificationsPromptContent = () => {
+type NotificationsPromptContentProps = {
+  promptTarget?: NotificationPromptTarget;
+};
+
+export const NotificationsPromptContent = ({ promptTarget }: NotificationsPromptContentProps) => {
   const { t } = useTranslation();
   const featureNewWordingNotificationsDrawer = useFeature("lwmNewWordingOptInNotificationsDrawer");
 
@@ -12,10 +18,12 @@ export const NotificationsPromptContent = () => {
     featureNewWordingNotificationsDrawer?.enabled === true &&
     featureNewWordingNotificationsDrawer?.params?.variant === AB_TESTING_VARIANTS.B;
 
+  const { titleKey, descriptionKey } = getNotificationsPromptCopy(promptTarget, isVariantB);
+
   return (
     <>
       <Text textAlign="center" variant="h4" fontWeight="semiBold" color="neutral.c100" mt={5}>
-        {isVariantB ? t("notifications.prompt.titleVariantB") : t("notifications.prompt.title")}
+        {t(titleKey)}
       </Text>
 
       <Text
@@ -25,7 +33,7 @@ export const NotificationsPromptContent = () => {
         textAlign="center"
         mt={3}
       >
-        {isVariantB ? t("notifications.prompt.descVariantB") : t("notifications.prompt.desc")}
+        {t(descriptionKey)}
       </Text>
     </>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotifications.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotifications.ts
@@ -32,6 +32,7 @@ const useNotifications = () => {
   const {
     isPushNotificationsModalOpen,
     drawerSource,
+    drawerPromptTarget,
     eventTimeoutRef,
     tryTriggerPushNotificationDrawerAfterAction,
     tryTriggerPushNotificationDrawerAfterInactivity,
@@ -128,32 +129,40 @@ const useNotifications = () => {
     };
   }, [eventTimeoutRef]);
 
-  return {
-    initPushNotificationsData,
-
+  const permission = {
     permissionStatus,
-
-    drawerSource,
-
-    nextRepromptDelay,
-    pushNotificationsDataOfUser,
-
-    isPushNotificationsModalOpen,
-
     requestPushNotificationsPermission,
+  };
 
-    markUserAsOptIn,
-    markUserAsOptOut,
-
+  const drawer = {
+    isPushNotificationsModalOpen,
+    drawerSource,
+    drawerPromptTarget,
     handleAllowNotificationsPress,
     handleDelayLaterPress,
     handleCloseFromBackdropPress,
+  };
 
+  const prompt = {
+    nextRepromptDelay,
+    pushNotificationsDataOfUser,
     shouldPromptOptInDrawerAfterAction,
     tryTriggerPushNotificationDrawerAfterAction,
-
-    // MAKE SURE TO CALL IT ONLY ON THE STACK NAVIGATOR WHERE THE USER IS ALREADY ONBOARDED
+    // Call only on stack navigators where onboarding is already complete.
     tryTriggerPushNotificationDrawerAfterInactivity,
+  };
+
+  const userState = {
+    markUserAsOptIn,
+    markUserAsOptOut,
+  };
+
+  return {
+    initPushNotificationsData,
+    ...permission,
+    ...drawer,
+    ...prompt,
+    ...userState,
   };
 };
 

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsData.ts
@@ -8,7 +8,8 @@ import { setNotificationsDataOfUser } from "~/actions/notifications";
 import { notificationsDataOfUserSelector } from "~/reducers/notifications";
 import { NotificationsSettings } from "~/reducers/types";
 import { setPushNotificationsDataOfUserInStorage } from "../utils/storage";
-import { type DataOfUser } from "../types";
+import { buildOptOutUserData } from "../utils/buildOptOutUserData";
+import { type DataOfUser, type NotificationPromptTarget } from "../types";
 import { updateIdentify } from "~/analytics";
 
 const notificationSettingsKeys: Array<keyof NotificationsSettings> = [
@@ -39,28 +40,28 @@ export const useNotificationsData = () => {
 
   const markUserAsOptIn = useCallback(() => {
     updatePushNotificationsDataOfUserInStateAndStore({
+      ...pushNotificationsDataOfUser,
       lastActionAt: Date.now(),
     });
     updateIdentify();
-  }, [updatePushNotificationsDataOfUserInStateAndStore]);
-
-  const markUserAsOptOut = useCallback(() => {
-    const now = Date.now();
-    const dismissedOptInDrawerAtList = [
-      ...(pushNotificationsDataOfUser?.dismissedOptInDrawerAtList ?? []),
-      now,
-    ];
-
-    // when a user is marked as opt out,
-    // we will use 2 ways to prompt the opt in drawer:
-    // 1. after an action (swap, receive, send, favorite, etc.)
-    // 2. after the inactivity period
-    updatePushNotificationsDataOfUserInStateAndStore({
-      dismissedOptInDrawerAtList,
-      lastActionAt: now,
-    });
-    updateIdentify();
   }, [updatePushNotificationsDataOfUserInStateAndStore, pushNotificationsDataOfUser]);
+
+  const markUserAsOptOut = useCallback(
+    (promptTarget?: NotificationPromptTarget) => {
+      // when a user is marked as opt out,
+      // we will use 2 ways to prompt the opt in drawer:
+      // 1. after an action (swap, receive, send, favorite, etc.)
+      // 2. after the inactivity period
+      updatePushNotificationsDataOfUserInStateAndStore(
+        buildOptOutUserData({
+          pushNotificationsDataOfUser,
+          promptTarget,
+        }),
+      );
+      updateIdentify();
+    },
+    [updatePushNotificationsDataOfUserInStateAndStore, pushNotificationsDataOfUser],
+  );
 
   const updateUserLastInactiveTime = useCallback(() => {
     // here user can be marked as inactive but we have to keep track of all the times

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsDrawer.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsDrawer.ts
@@ -27,9 +27,9 @@ import { isTransactionsAlertsPromptTarget } from "../utils/getNotificationsPromp
 
 type UseNotificationsDrawerParams = {
   permissionStatus:
-    | (typeof AuthorizationStatus)[keyof typeof AuthorizationStatus]
-    | null
-    | undefined;
+  | (typeof AuthorizationStatus)[keyof typeof AuthorizationStatus]
+  | null
+  | undefined;
   areNotificationsAllowed: boolean | undefined;
   pushNotificationsDataOfUser: DataOfUser | null | undefined;
   nextRepromptDelay: { days?: number; hours?: number; minutes?: number } | null;
@@ -88,15 +88,15 @@ export const useNotificationsDrawer = ({
     (
       data:
         | {
-            status: "success";
-            storedUserData: DataOfUser | null;
-            osPermissionStatus: (typeof AuthorizationStatus)[keyof typeof AuthorizationStatus];
-            areAppNotificationsEnabled: boolean;
-          }
+          status: "success";
+          storedUserData: DataOfUser | null;
+          osPermissionStatus: (typeof AuthorizationStatus)[keyof typeof AuthorizationStatus];
+          areAppNotificationsEnabled: boolean;
+        }
         | {
-            status: "error";
-            reason: string;
-          },
+          status: "error";
+          reason: string;
+        },
     ) => {
       if (!featureBrazePushNotifications?.enabled || isRatingsModalOpen) {
         return;
@@ -319,7 +319,7 @@ export const useNotificationsDrawer = ({
       updateUserLastInactiveTime();
     }
 
-    if (isTransactionsAlertsPromptTarget(drawerPromptTarget)) {
+    if (isTransactionsAlertsPromptTarget(promptTargetAtDismiss)) {
       dispatch(
         setNotifications({
           transactionsAlertsCategory: true,
@@ -330,7 +330,6 @@ export const useNotificationsDrawer = ({
         transactionsAlertsCategory: true,
       });
       markUserAsOptIn();
-      updateIdentify();
       return;
     }
 

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsDrawer.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsDrawer.ts
@@ -4,17 +4,26 @@ import { useSelector, useDispatch } from "~/context/hooks";
 import { useNavigation } from "@react-navigation/core";
 import { AuthorizationStatus } from "@react-native-firebase/messaging";
 import { useFeature } from "@features/platform-feature-flags";
-import { AB_TESTING_VARIANTS } from "../types/variants";
 import {
-  notificationsModalOpenSelector,
-  notificationsDrawerSource,
-} from "~/reducers/notifications";
-import { setNotificationsModalOpen, setNotificationsDrawerSource } from "~/actions/notifications";
-import { ratingsModalOpenSelector } from "~/reducers/ratings";
-import { track } from "~/analytics";
+  setNotificationsDrawerPromptTarget,
+  setNotificationsDrawerSource,
+  setNotificationsModalOpen,
+} from "~/actions/notifications";
+import { setNotifications } from "~/actions/settings";
+import { track, updateIdentify } from "~/analytics";
 import { NavigatorName, ScreenName } from "~/const/navigation";
+import { updateUserPreferences } from "~/notifications/braze";
+import {
+  notificationsDrawerPromptTarget,
+  notificationsDrawerSource,
+  notificationsModalOpenSelector,
+} from "~/reducers/notifications";
+import { ratingsModalOpenSelector } from "~/reducers/ratings";
+import { notificationsSelector } from "~/reducers/settings";
 import { type NotificationsState } from "~/reducers/types";
-import { type DataOfUser } from "../types";
+import { type DataOfUser, type NotificationPromptTarget } from "../types";
+import { AB_TESTING_VARIANTS } from "../types/variants";
+import { isTransactionsAlertsPromptTarget } from "../utils/getNotificationsPromptCopy";
 
 type UseNotificationsDrawerParams = {
   permissionStatus:
@@ -27,7 +36,7 @@ type UseNotificationsDrawerParams = {
   shouldPromptOptInDrawerAfterAction: () => boolean;
   checkIsInactive: (lastActionAt?: number) => boolean;
   markUserAsOptIn: () => void;
-  markUserAsOptOut: () => void;
+  markUserAsOptOut: (promptTarget?: NotificationPromptTarget) => void;
   updateUserLastInactiveTime: () => void;
   requestPushNotificationsPermission: () => Promise<
     void | (typeof AuthorizationStatus)[keyof typeof AuthorizationStatus]
@@ -53,6 +62,8 @@ export const useNotificationsDrawer = ({
   const isPushNotificationsModalOpen = useSelector(notificationsModalOpenSelector);
   const isRatingsModalOpen = useSelector(ratingsModalOpenSelector);
   const drawerSource = useSelector(notificationsDrawerSource);
+  const drawerPromptTarget = useSelector(notificationsDrawerPromptTarget);
+  const notifications = useSelector(notificationsSelector);
 
   const dispatch = useDispatch();
   const navigation = useNavigation();
@@ -258,31 +269,49 @@ export const useNotificationsDrawer = ({
   const closeDrawer = useCallback(() => {
     dispatch(setNotificationsModalOpen(false));
     dispatch(setNotificationsDrawerSource(undefined));
+    dispatch(setNotificationsDrawerPromptTarget(undefined));
   }, [dispatch]);
 
   const handleDelayLaterPress = useCallback(() => {
+    const promptTargetAtDismiss = drawerPromptTarget;
     trackButtonClicked("maybe later");
     closeDrawer();
 
     if (drawerSource === "inactivity") {
       updateUserLastInactiveTime();
     } else {
-      markUserAsOptOut();
+      markUserAsOptOut(promptTargetAtDismiss);
     }
-  }, [trackButtonClicked, closeDrawer, markUserAsOptOut, updateUserLastInactiveTime, drawerSource]);
+  }, [
+    trackButtonClicked,
+    closeDrawer,
+    drawerPromptTarget,
+    markUserAsOptOut,
+    updateUserLastInactiveTime,
+    drawerSource,
+  ]);
 
   const handleCloseFromBackdropPress = useCallback(() => {
+    const promptTargetAtDismiss = drawerPromptTarget;
     trackButtonClicked("backdrop");
     closeDrawer();
 
     if (drawerSource === "inactivity") {
       updateUserLastInactiveTime();
     } else {
-      markUserAsOptOut();
+      markUserAsOptOut(promptTargetAtDismiss);
     }
-  }, [trackButtonClicked, closeDrawer, markUserAsOptOut, updateUserLastInactiveTime, drawerSource]);
+  }, [
+    trackButtonClicked,
+    closeDrawer,
+    drawerPromptTarget,
+    markUserAsOptOut,
+    updateUserLastInactiveTime,
+    drawerSource,
+  ]);
 
   const handleAllowNotificationsPress = useCallback(async () => {
+    const promptTargetAtDismiss = drawerPromptTarget;
     trackButtonClicked("allow notifications");
     closeDrawer();
 
@@ -290,11 +319,26 @@ export const useNotificationsDrawer = ({
       updateUserLastInactiveTime();
     }
 
+    if (isTransactionsAlertsPromptTarget(drawerPromptTarget)) {
+      dispatch(
+        setNotifications({
+          transactionsAlertsCategory: true,
+        }),
+      );
+      updateUserPreferences({
+        ...notifications,
+        transactionsAlertsCategory: true,
+      });
+      markUserAsOptIn();
+      updateIdentify();
+      return;
+    }
+
     if (permissionStatus !== AuthorizationStatus.AUTHORIZED) {
       const permission = await requestPushNotificationsPermission();
       if (permission === AuthorizationStatus.DENIED) {
         trackButtonClicked("os_notifications_deny");
-        markUserAsOptOut();
+        markUserAsOptOut(promptTargetAtDismiss);
       } else if (permission === AuthorizationStatus.AUTHORIZED) {
         trackButtonClicked("os_notifications_allow");
         markUserAsOptIn();
@@ -310,6 +354,9 @@ export const useNotificationsDrawer = ({
     trackButtonClicked,
     updateUserLastInactiveTime,
     closeDrawer,
+    drawerPromptTarget,
+    dispatch,
+    notifications,
     permissionStatus,
     areNotificationsAllowed,
     requestPushNotificationsPermission,
@@ -322,6 +369,7 @@ export const useNotificationsDrawer = ({
   return {
     isPushNotificationsModalOpen,
     drawerSource,
+    drawerPromptTarget,
     eventTimeoutRef,
     tryTriggerPushNotificationDrawerAfterAction,
     handleAllowNotificationsPress,

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/new/hooks/useNotificationsPromptDrawerScheduler.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/new/hooks/useNotificationsPromptDrawerScheduler.ts
@@ -32,17 +32,18 @@ export function useNotificationsPromptDrawerScheduler() {
         const resolvedPromptTarget =
           source === "inactivity" ? "globalPushNotifications" : drawerPromptTarget;
 
-        dispatch(setNotificationsModalOpen(true));
         dispatch(setNotificationsDrawerSource(source));
         dispatch(setNotificationsDrawerPromptTarget(resolvedPromptTarget));
+        dispatch(setNotificationsModalOpen(true));
       }, timer);
     },
     [dispatch],
   );
 
-  const isDrawerPending = useCallback(() => {
-    return isPushNotificationsModalOpen || eventTimeoutRef.current !== null;
-  }, [isPushNotificationsModalOpen]);
+  const isDrawerPending = useCallback(
+    () => isPushNotificationsModalOpen || eventTimeoutRef.current !== null,
+    [isPushNotificationsModalOpen],
+  );
 
   useEffect(() => {
     return () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/NotificationsPromptDrawer.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/NotificationsPromptDrawer.tsx
@@ -5,13 +5,16 @@ import { useNotifications } from "LLM/features/NotificationsPrompt";
 import QueuedDrawer from "LLM/components/QueuedDrawer";
 import { NotificationsDrawerIllustration } from "LLM/features/NotificationsPrompt/components/NotificationsDrawerIllustration";
 import { NotificationsPromptContent } from "LLM/features/NotificationsPrompt/components/NotificationsPromptContent";
+import { getNotificationsPromptCopy } from "LLM/features/NotificationsPrompt/utils/getNotificationsPromptCopy";
 import { TrackScreen } from "~/analytics";
 import { useFeature } from "@features/platform-feature-flags";
+import { AB_TESTING_VARIANTS } from "LLM/features/NotificationsPrompt/types/variants";
 
 export const NotificationsPromptDrawer = () => {
   const { t } = useTranslation();
   const {
     drawerSource,
+    drawerPromptTarget,
     isPushNotificationsModalOpen,
     handleAllowNotificationsPress,
     handleDelayLaterPress,
@@ -23,6 +26,10 @@ export const NotificationsPromptDrawer = () => {
   const featureNewWordingNotificationsDrawer = useFeature("lwmNewWordingOptInNotificationsDrawer");
 
   const canShowVariant = featureNewWordingNotificationsDrawer?.enabled;
+  const isVariantB =
+    featureNewWordingNotificationsDrawer?.enabled === true &&
+    featureNewWordingNotificationsDrawer?.params?.variant === AB_TESTING_VARIANTS.B;
+  const { allowKey, laterKey } = getNotificationsPromptCopy(drawerPromptTarget, isVariantB);
 
   return (
     <QueuedDrawer
@@ -33,6 +40,7 @@ export const NotificationsPromptDrawer = () => {
       <TrackScreen
         category="Drawer push notification opt-in"
         source={drawerSource}
+        promptTarget={drawerPromptTarget}
         repromptDelay={nextRepromptDelay}
         dismissedCount={pushNotificationsDataOfUser?.dismissedOptInDrawerAtList?.length ?? 0}
         variant={canShowVariant ? featureNewWordingNotificationsDrawer?.params?.variant : undefined}
@@ -41,7 +49,7 @@ export const NotificationsPromptDrawer = () => {
       <Flex mb={4}>
         <Flex alignItems={"center"}>
           <NotificationsDrawerIllustration type={drawerSource} />
-          <NotificationsPromptContent />
+          <NotificationsPromptContent promptTarget={drawerPromptTarget} />
         </Flex>
         <Button
           type={"main"}
@@ -50,14 +58,14 @@ export const NotificationsPromptDrawer = () => {
           onPressIn={handleAllowNotificationsPress}
           testID="notifications-prompt-allow"
         >
-          {t("notifications.prompt.allow")}
+          {t(allowKey)}
         </Button>
         <TextLink
           type={"shade"}
           onPressIn={handleDelayLaterPress}
           testID="notifications-prompt-later"
         >
-          {t("notifications.prompt.later")}
+          {t(laterKey)}
         </TextLink>
       </Flex>
     </QueuedDrawer>

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/testUtils.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/testUtils.ts
@@ -2,9 +2,17 @@ import type { Features } from "@shared/feature-flags";
 import { AB_TESTING_VARIANTS } from "./types/variants";
 
 type BrazePushNotificationsParams = NonNullable<Features["brazePushNotifications"]["params"]>;
+type BrazeNotificationsCategoryConfig = BrazePushNotificationsParams["notificationsCategories"][number];
 type WordingFeatureParams = NonNullable<
   Features["lwmNewWordingOptInNotificationsDrawer"]["params"]
 >;
+
+export const transactionsAlertsDrawerPromptCategoryConfig: BrazeNotificationsCategoryConfig = {
+  displayed: true,
+  category: "transactionsAlertsCategory",
+  drawerPromptEnabled: true,
+  drawerPromptActions: ["send", "receive"],
+};
 
 const defaultRepromptSchedule: BrazePushNotificationsParams["reprompt_schedule"] = [
   { months: 0, days: 7, hours: 0, minutes: 0, seconds: 0 },

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/__tests__/buildOptOutUserData.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/__tests__/buildOptOutUserData.test.ts
@@ -1,0 +1,63 @@
+import { buildOptOutUserData } from "../buildOptOutUserData";
+
+describe("buildOptOutUserData", () => {
+  const now = 1_700_000_000_000;
+
+  it("appends a global dismissal to legacy and per-target lists", () => {
+    const result = buildOptOutUserData({
+      pushNotificationsDataOfUser: {
+        dismissedOptInDrawerAtList: [100],
+        lastActionAt: 50,
+      },
+      now,
+    });
+
+    expect(result).toEqual({
+      dismissedOptInDrawerAtList: [100, now],
+      dismissedPromptAtListByTarget: {
+        globalPushNotifications: [100, now],
+      },
+      lastActionAt: now,
+    });
+  });
+
+  it("appends a transactions alerts dismissal without changing global dismissals", () => {
+    const result = buildOptOutUserData({
+      pushNotificationsDataOfUser: {
+        dismissedOptInDrawerAtList: [100],
+        dismissedPromptAtListByTarget: {
+          globalPushNotifications: [100],
+        },
+        lastActionAt: 50,
+      },
+      promptTarget: "transactionsAlertsCategory",
+      now,
+    });
+
+    expect(result).toEqual({
+      dismissedOptInDrawerAtList: [100],
+      dismissedPromptAtListByTarget: {
+        globalPushNotifications: [100],
+        transactionsAlertsCategory: [now],
+      },
+      lastActionAt: now,
+    });
+  });
+
+  it("appends to an existing transactions alerts dismissal list", () => {
+    const result = buildOptOutUserData({
+      pushNotificationsDataOfUser: {
+        dismissedPromptAtListByTarget: {
+          transactionsAlertsCategory: [200],
+        },
+      },
+      promptTarget: "transactionsAlertsCategory",
+      now,
+    });
+
+    expect(result.dismissedPromptAtListByTarget).toEqual({
+      transactionsAlertsCategory: [200, now],
+    });
+    expect(result.dismissedOptInDrawerAtList).toBeUndefined();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/__tests__/getNotificationsPromptCopy.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/__tests__/getNotificationsPromptCopy.test.ts
@@ -1,0 +1,39 @@
+import {
+  getNotificationsPromptCopy,
+  isTransactionsAlertsPromptTarget,
+} from "../getNotificationsPromptCopy";
+
+describe("getNotificationsPromptCopy", () => {
+  it("returns global prompt copy by default", () => {
+    expect(getNotificationsPromptCopy(undefined, false)).toEqual({
+      titleKey: "notifications.prompt.title",
+      descriptionKey: "notifications.prompt.desc",
+      allowKey: "notifications.prompt.allow",
+      laterKey: "notifications.prompt.later",
+    });
+  });
+
+  it("returns variant B global copy when enabled", () => {
+    expect(getNotificationsPromptCopy("globalPushNotifications", true)).toEqual({
+      titleKey: "notifications.prompt.titleVariantB",
+      descriptionKey: "notifications.prompt.descVariantB",
+      allowKey: "notifications.prompt.allow",
+      laterKey: "notifications.prompt.later",
+    });
+  });
+
+  it("returns transactions alerts copy for the category prompt target", () => {
+    expect(getNotificationsPromptCopy("transactionsAlertsCategory", false)).toEqual({
+      titleKey: "notifications.prompt.transactionsAlerts.title",
+      descriptionKey: "notifications.prompt.transactionsAlerts.desc",
+      allowKey: "notifications.prompt.allow",
+      laterKey: "notifications.prompt.later",
+    });
+  });
+
+  it("identifies the transactions alerts prompt target", () => {
+    expect(isTransactionsAlertsPromptTarget("transactionsAlertsCategory")).toBe(true);
+    expect(isTransactionsAlertsPromptTarget("globalPushNotifications")).toBe(false);
+    expect(isTransactionsAlertsPromptTarget(undefined)).toBe(false);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/buildOptOutUserData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/buildOptOutUserData.ts
@@ -1,0 +1,49 @@
+import type { DataOfUser, NotificationPromptTarget } from "../types";
+
+const GLOBAL_PUSH_NOTIFICATIONS_PROMPT_TARGET = "globalPushNotifications" as const;
+
+const getExistingDismissals = (
+  pushNotificationsDataOfUser: DataOfUser | null | undefined,
+  promptTarget: NotificationPromptTarget,
+): number[] => {
+  const dismissedPromptAtListByTarget =
+    pushNotificationsDataOfUser?.dismissedPromptAtListByTarget ?? {};
+
+  if (promptTarget === GLOBAL_PUSH_NOTIFICATIONS_PROMPT_TARGET) {
+    return (
+      dismissedPromptAtListByTarget.globalPushNotifications ??
+      pushNotificationsDataOfUser?.dismissedOptInDrawerAtList ??
+      []
+    );
+  }
+
+  return dismissedPromptAtListByTarget[promptTarget] ?? [];
+};
+
+export const buildOptOutUserData = ({
+  pushNotificationsDataOfUser,
+  promptTarget = GLOBAL_PUSH_NOTIFICATIONS_PROMPT_TARGET,
+  now = Date.now(),
+}: {
+  pushNotificationsDataOfUser: DataOfUser | null | undefined;
+  promptTarget?: NotificationPromptTarget;
+  now?: number;
+}): DataOfUser => {
+  const existingDismissals = getExistingDismissals(pushNotificationsDataOfUser, promptTarget);
+  const dismissedPromptAtListByTarget = {
+    ...pushNotificationsDataOfUser?.dismissedPromptAtListByTarget,
+    [promptTarget]: [...existingDismissals, now],
+  };
+
+  const dismissedOptInDrawerAtList =
+    promptTarget === GLOBAL_PUSH_NOTIFICATIONS_PROMPT_TARGET
+      ? dismissedPromptAtListByTarget.globalPushNotifications
+      : pushNotificationsDataOfUser?.dismissedOptInDrawerAtList;
+
+  return {
+    ...pushNotificationsDataOfUser,
+    dismissedOptInDrawerAtList,
+    dismissedPromptAtListByTarget,
+    lastActionAt: now,
+  };
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/getNotificationsPromptCopy.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/getNotificationsPromptCopy.ts
@@ -1,0 +1,36 @@
+import type { NotificationPromptTarget } from "../types";
+
+const TRANSACTIONS_ALERTS_PROMPT_TARGET = "transactionsAlertsCategory" as const;
+
+export type NotificationsPromptCopy = {
+  titleKey: string;
+  descriptionKey: string;
+  allowKey: string;
+  laterKey: string;
+};
+
+export const isTransactionsAlertsPromptTarget = (
+  promptTarget: NotificationPromptTarget | undefined,
+): promptTarget is typeof TRANSACTIONS_ALERTS_PROMPT_TARGET =>
+  promptTarget === TRANSACTIONS_ALERTS_PROMPT_TARGET;
+
+export const getNotificationsPromptCopy = (
+  promptTarget: NotificationPromptTarget | undefined,
+  isVariantB: boolean,
+): NotificationsPromptCopy => {
+  if (isTransactionsAlertsPromptTarget(promptTarget)) {
+    return {
+      titleKey: "notifications.prompt.transactionsAlerts.title",
+      descriptionKey: "notifications.prompt.transactionsAlerts.desc",
+      allowKey: "notifications.prompt.allow",
+      laterKey: "notifications.prompt.later",
+    };
+  }
+
+  return {
+    titleKey: isVariantB ? "notifications.prompt.titleVariantB" : "notifications.prompt.title",
+    descriptionKey: isVariantB ? "notifications.prompt.descVariantB" : "notifications.prompt.desc",
+    allowKey: "notifications.prompt.allow",
+    laterKey: "notifications.prompt.later",
+  };
+};


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Update drawer according to target.

### 📝 Description

This pull request introduces transaction alerts notification drawer content and allows users to opt out of these alerts on a per-target basis. It updates localization, test coverage, and refactors the notification prompt logic to support the new transaction alerts feature. The most important changes are summarized below.


https://github.com/user-attachments/assets/f244a757-a381-44ae-8949-70921a8efcf5


**Feature: Transaction Alerts Notification Drawer**

* Added transaction alerts notification drawer content and enabled per-target opt-out dismissals, allowing users to manage notification preferences more granularly. (`.changeset/bright-alerts-track.md`, [.changeset/bright-alerts-track.mdR1-R5](diffhunk://#diff-779a04eaff1c8f0ce1f2d173530a0d4d4b562e3d40719390670ff1e3efee5b35R1-R5))
* Updated English localization (`common.json`) with new titles and descriptions for transaction alerts prompts.

**Testing & Integration**

* Enhanced and refactored integration tests for notification prompts in send, receive, swap, and stake flows to cover the new transaction alerts drawer, including scenarios for globally opted-in users. [[1]](diffhunk://#diff-d56dd7f91e3cbb5a2fc81b5653bd81ae91a7f9b7666a513ab346a66b8f147004R174-R218) [[2]](diffhunk://#diff-0a62a72c2618a06c771935e7d69aac7a3696016ff9a454a6f649748125bd8acdR182-R219)
* Moved and updated test utility imports to improve test organization and support the new feature. [[1]](diffhunk://#diff-54ecbcd589d40cbf0cc6946bf0fce6a8866cd62b7635f378d649da08fb9bc3b6L4-R4) [[2]](diffhunk://#diff-d56dd7f91e3cbb5a2fc81b5653bd81ae91a7f9b7666a513ab346a66b8f147004L19-R22) [[3]](diffhunk://#diff-0a62a72c2618a06c771935e7d69aac7a3696016ff9a454a6f649748125bd8acdL19-R54) [[4]](diffhunk://#diff-8307c4b2a43eedd0c9e80f821ee8866c852a328e707120b6a61bc11731f1d8c2L24-R24) [[5]](diffhunk://#diff-ecacc959d8a4672a6002a82ba89beeb1a5ec3d33b18b4f7e79999ce75f905b9cL23-R23)

**Component & Hook Refactoring**

* Refactored `NotificationsPromptContent` to dynamically select copy based on the notification prompt target and experiment variant, supporting the new transaction alerts content. [[1]](diffhunk://#diff-e3e8debf7ee9c8cd6ffd9f80e71c97cedff99a380b75034e556b57b7bd315e32R6-R26) [[2]](diffhunk://#diff-e3e8debf7ee9c8cd6ffd9f80e71c97cedff99a380b75034e556b57b7bd315e32L28-R36)
* Updated `useNotifications` hook to expose the prompt target and reorganized return structure for better separation of permission, drawer, prompt, and user state logic. [[1]](diffhunk://#diff-98fa182bd9b694e8ab1b1025e02ec1ab8468b4ed1a9a5149ba3380f3cf43ea40R35) [[2]](diffhunk://#diff-98fa182bd9b694e8ab1b1025e02ec1ab8468b4ed1a9a5149ba3380f3cf43ea40L131-R166)
* Improved type imports and utility usage in notification data hooks to support transaction alerts and opt-out logic.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31500]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31500]: https://ledgerhq.atlassian.net/browse/LIVE-31500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ