### PR TITLE
[LWM] feat(mobile): adjust tracking tx alerts

### DIFF
--- a/.changeset/bright-alerts-track.md
+++ b/.changeset/bright-alerts-track.md
@@ -2,4 +2,4 @@
 "live-mobile": minor
 ---
 
-Add transaction alerts notification drawer content and per-target opt-out dismissals
+Add transaction alerts notification drawer, per-target opt-out dismissals, and drawerPromptTarget analytics

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptDAppCompleteFlow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptDAppCompleteFlow.test.tsx
@@ -237,6 +237,7 @@ describe("NotificationsPrompt dApp complete flow", () => {
       repromptDelay: null,
       dismissedCount: 0,
       skipReason: undefined,
+      drawerPromptTarget: "globalPushNotifications",
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptReceiveFlow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptReceiveFlow.test.tsx
@@ -158,6 +158,7 @@ describe("NotificationsPrompt receive flow", () => {
       repromptDelay: null,
       dismissedCount: 0,
       skipReason: undefined,
+      drawerPromptTarget: "globalPushNotifications",
     });
     const allowNotificationsButton = screen.getByText(/allow notifications/i);
     expect(allowNotificationsButton).toBeVisible();
@@ -166,6 +167,7 @@ describe("NotificationsPrompt receive flow", () => {
       button: "allow notifications",
       page: "Drawer push notification opt-in",
       source: "receive",
+      drawerPromptTarget: "globalPushNotifications",
       repromptDelay: null,
       dismissedCount: 0,
       variant: AB_TESTING_VARIANTS.B,

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptSendFlow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptSendFlow.test.tsx
@@ -164,6 +164,7 @@ describe("NotificationsPrompt send flow", () => {
       repromptDelay: null,
       dismissedCount: 0,
       skipReason: undefined,
+      drawerPromptTarget: "globalPushNotifications",
     });
 
     const maybeLaterButton = screen.getByText(/maybe later/i);
@@ -174,6 +175,7 @@ describe("NotificationsPrompt send flow", () => {
       button: "maybe later",
       page: "Drawer push notification opt-in",
       source: "send",
+      drawerPromptTarget: "globalPushNotifications",
       repromptDelay: null,
       dismissedCount: 0,
       variant: AB_TESTING_VARIANTS.B,

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptStakeFlow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptStakeFlow.test.tsx
@@ -796,6 +796,7 @@ describe("NotificationsPrompt stake flow", () => {
             repromptDelay: null,
             dismissedCount: 0,
             skipReason: undefined,
+            drawerPromptTarget: "globalPushNotifications",
           },
         );
 
@@ -805,6 +806,7 @@ describe("NotificationsPrompt stake flow", () => {
           button: "allow notifications",
           page: "Drawer push notification opt-in",
           source: "stake",
+          drawerPromptTarget: "globalPushNotifications",
           repromptDelay: null,
           dismissedCount: 0,
           variant: AB_TESTING_VARIANTS.B,

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptSwapFlow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptSwapFlow.test.tsx
@@ -162,6 +162,7 @@ describe("NotificationsPrompt swap flow", () => {
           repromptDelay: null,
           dismissedCount: 0,
           skipReason: undefined,
+          drawerPromptTarget: "globalPushNotifications",
         },
       );
       await waitFor(() => {
@@ -173,6 +174,7 @@ describe("NotificationsPrompt swap flow", () => {
         button: "allow notifications",
         page: "Drawer push notification opt-in",
         source: "swap",
+        drawerPromptTarget: "globalPushNotifications",
         repromptDelay: null,
         dismissedCount: 0,
         variant: AB_TESTING_VARIANTS.B,
@@ -209,6 +211,7 @@ describe("NotificationsPrompt swap flow", () => {
           repromptDelay: null,
           dismissedCount: 0,
           skipReason: undefined,
+          drawerPromptTarget: "globalPushNotifications",
         },
       );
 
@@ -217,6 +220,7 @@ describe("NotificationsPrompt swap flow", () => {
         button: "allow notifications",
         page: "Drawer push notification opt-in",
         source: "swap",
+        drawerPromptTarget: "globalPushNotifications",
         repromptDelay: null,
         dismissedCount: 0,
         variant: AB_TESTING_VARIANTS.B,

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/components/NotificationsDrawerIllustration.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/components/NotificationsDrawerIllustration.tsx
@@ -5,16 +5,25 @@ import NotificationsBellDark from "~/images/illustration/Dark/_NotificationsBell
 import NotificationsBellLight from "~/images/illustration/Light/_NotificationsBell.webp";
 import NotificationsPerformanceChartDark from "~/images/illustration/Dark/_NotificationsPerformanceChart.webp";
 import NotificationsPerformanceChartLight from "~/images/illustration/Light/_NotificationsPerformanceChart.webp";
+import type { NotificationPromptTarget } from "../types";
+import { isTransactionsAlertsPromptTarget } from "../utils/getNotificationsPromptCopy";
 
 const WIDTH = 300;
 const HEIGHT = 141;
 
+export type NotificationsDrawerIllustrationProps = {
+  readonly type: NotificationsState["drawerSource"];
+  readonly promptTarget?: NotificationPromptTarget;
+};
+
 export function NotificationsDrawerIllustration({
   type,
-}: {
-  readonly type: NotificationsState["drawerSource"];
-}) {
-  if (type === "onboarding") {
+  promptTarget,
+}: NotificationsDrawerIllustrationProps) {
+  const useBellIllustration =
+    type === "onboarding" || isTransactionsAlertsPromptTarget(promptTarget);
+
+  if (useBellIllustration) {
     return (
       <Illustration
         lightSource={NotificationsBellLight}

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsDrawer.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsDrawer.ts
@@ -10,7 +10,7 @@ import {
   setNotificationsModalOpen,
 } from "~/actions/notifications";
 import { setNotifications } from "~/actions/settings";
-import { track, updateIdentify } from "~/analytics";
+import { track } from "~/analytics";
 import { NavigatorName, ScreenName } from "~/const/navigation";
 import { updateUserPreferences } from "~/notifications/braze";
 import {
@@ -23,6 +23,7 @@ import { notificationsSelector } from "~/reducers/settings";
 import { type NotificationsState } from "~/reducers/types";
 import { type DataOfUser, type NotificationPromptTarget } from "../types";
 import { AB_TESTING_VARIANTS } from "../types/variants";
+import { resolveDrawerPromptTargetForAnalytics } from "../new/notificationsPromptAnalytics";
 import { isTransactionsAlertsPromptTarget } from "../utils/getNotificationsPromptCopy";
 
 type UseNotificationsDrawerParams = {
@@ -149,6 +150,9 @@ export const useNotificationsDrawer = ({
         variant: featureNewWordingNotificationsDrawer?.params?.variant,
         repromptDelay: nextRepromptDelay,
         dismissedCount: pushNotificationsDataOfUser?.dismissedOptInDrawerAtList?.length ?? 0,
+        drawerPromptTarget: shouldPrompt
+          ? resolveDrawerPromptTargetForAnalytics(undefined)
+          : undefined,
       });
 
       if (!shouldPrompt) {
@@ -252,6 +256,7 @@ export const useNotificationsDrawer = ({
         button: eventName,
         page: "Drawer push notification opt-in",
         source: drawerSource,
+        drawerPromptTarget: resolveDrawerPromptTargetForAnalytics(drawerPromptTarget),
         repromptDelay: nextRepromptDelay,
         dismissedCount: pushNotificationsDataOfUser?.dismissedOptInDrawerAtList?.length ?? 0,
         variant: canShowVariant ? featureNewWordingNotificationsDrawer?.params?.variant : undefined,
@@ -259,6 +264,7 @@ export const useNotificationsDrawer = ({
     },
     [
       drawerSource,
+      drawerPromptTarget,
       featureNewWordingNotificationsDrawer?.enabled,
       featureNewWordingNotificationsDrawer?.params?.variant,
       nextRepromptDelay,

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/new/__tests__/notificationsPromptAnalytics.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/new/__tests__/notificationsPromptAnalytics.test.ts
@@ -1,0 +1,84 @@
+import {
+  resolveDrawerPromptTargetForAnalytics,
+  trackAfterActionDecision,
+  trackInactivityDecision,
+} from "../notificationsPromptAnalytics";
+import { track } from "~/analytics";
+
+jest.mock("~/analytics", () => ({
+  track: jest.fn(),
+}));
+
+describe("notificationsPromptAnalytics", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("defaults undefined drawer prompt targets to globalPushNotifications", () => {
+    expect(resolveDrawerPromptTargetForAnalytics(undefined)).toBe("globalPushNotifications");
+    expect(resolveDrawerPromptTargetForAnalytics("transactionsAlertsCategory")).toBe(
+      "transactionsAlertsCategory",
+    );
+  });
+
+  it("tracks after-action show decisions with source and drawerPromptTarget", () => {
+    trackAfterActionDecision({
+      kind: "show",
+      source: "send",
+      delayMs: 200,
+      drawerPromptTarget: "transactionsAlertsCategory",
+      dismissedCount: 0,
+      nextRepromptDelay: null,
+    });
+
+    expect(track).toHaveBeenCalledWith("attempt_to_trigger_push_notification_drawer_after_action", {
+      action: "send",
+      shouldPrompt: true,
+      variant: undefined,
+      repromptDelay: null,
+      dismissedCount: 0,
+      skipReason: undefined,
+      drawerPromptTarget: "transactionsAlertsCategory",
+    });
+  });
+
+  it("tracks after-action skip decisions from engine kind", () => {
+    trackAfterActionDecision({
+      kind: "skip",
+      source: "send",
+      reason: "fully_opted_in",
+      dismissedCount: 0,
+      nextRepromptDelay: null,
+    });
+
+    expect(track).toHaveBeenCalledWith("attempt_to_trigger_push_notification_drawer_after_action", {
+      action: "send",
+      shouldPrompt: false,
+      variant: undefined,
+      repromptDelay: null,
+      dismissedCount: 0,
+      skipReason: "fully_opted_in",
+      drawerPromptTarget: undefined,
+    });
+  });
+
+  it("tracks inactivity decisions with drawerPromptTarget when shown", () => {
+    trackInactivityDecision({
+      kind: "show",
+      source: "inactivity",
+      delayMs: 1000,
+      drawerPromptTarget: "globalPushNotifications",
+      dismissedCount: 1,
+      nextRepromptDelay: null,
+    });
+
+    expect(track).toHaveBeenCalledWith("attempt_to_trigger_push_notification_drawer_after_inactivity", {
+      shouldPrompt: true,
+      variant: undefined,
+      repromptDelay: null,
+      dismissedCount: 1,
+      skipReason: undefined,
+      drawerPromptTarget: "globalPushNotifications",
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/new/hooks/useNotificationsPromptTriggers.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/new/hooks/useNotificationsPromptTriggers.ts
@@ -10,7 +10,6 @@ import {
   type InitPushNotificationsDataResult,
   type NotificationsPromptAfterActionSource,
   useNotificationsData,
-  useNotificationsPrompt,
 } from "LLM/features/NotificationsPrompt";
 import {
   trackAfterActionDecision,
@@ -26,12 +25,6 @@ export function useNotificationsPromptTriggers() {
   const isRatingsModalOpen = useSelector(ratingsModalOpenSelector);
   const { permissionStatus } = useNotificationsPermission();
   const { pushNotificationsDataOfUser } = useNotificationsData();
-  const { shouldPromptOptInDrawerAfterAction } = useNotificationsPrompt({
-    permissionStatus,
-    areNotificationsAllowed: notifications.areNotificationsAllowed,
-    transactionsAlertsCategory: notifications.transactionsAlertsCategory,
-    pushNotificationsDataOfUser,
-  });
   const { openDrawer, isDrawerPending } = useNotificationsPromptDrawerScheduler();
 
   const notifyFlowCompleted = useCallback(
@@ -52,7 +45,7 @@ export function useNotificationsPromptTriggers() {
         },
       );
 
-      trackAfterActionDecision(decision, shouldPromptOptInDrawerAfterAction);
+      trackAfterActionDecision(decision);
 
       if (decision.kind === "skip") {
         return;
@@ -70,7 +63,6 @@ export function useNotificationsPromptTriggers() {
       openDrawer,
       permissionStatus,
       pushNotificationsDataOfUser,
-      shouldPromptOptInDrawerAfterAction,
     ],
   );
 

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/new/notificationsPromptAnalytics.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/new/notificationsPromptAnalytics.ts
@@ -3,18 +3,34 @@ import {
   type AfterActionTriggerDecision,
   type InactivityTriggerDecision,
 } from "LLM/features/NotificationsPrompt";
+import type { NotificationPromptTarget } from "../types";
 
-export function trackAfterActionDecision(
+const GLOBAL_PUSH_NOTIFICATIONS_PROMPT_TARGET = "globalPushNotifications" as const;
+
+/** For drawer-visible events only; attempt events on skip keep drawerPromptTarget undefined. */
+export const resolveDrawerPromptTargetForAnalytics = (
+  drawerPromptTarget: NotificationPromptTarget | undefined,
+): NotificationPromptTarget => drawerPromptTarget ?? GLOBAL_PUSH_NOTIFICATIONS_PROMPT_TARGET;
+
+const getDrawerPromptTargetFromAfterActionDecision = (
   decision: AfterActionTriggerDecision,
-  shouldPromptOptInDrawerAfterAction: () => boolean,
-) {
+): NotificationPromptTarget | undefined =>
+  decision.kind === "show" ? decision.drawerPromptTarget : undefined;
+
+const getDrawerPromptTargetFromInactivityDecision = (
+  decision: InactivityTriggerDecision,
+): NotificationPromptTarget | undefined =>
+  decision.kind === "show" ? decision.drawerPromptTarget : undefined;
+
+export function trackAfterActionDecision(decision: AfterActionTriggerDecision) {
   track("attempt_to_trigger_push_notification_drawer_after_action", {
     action: decision.source,
-    shouldPrompt: shouldPromptOptInDrawerAfterAction(),
+    shouldPrompt: decision.kind === "show",
     variant: decision.variant,
     repromptDelay: decision.nextRepromptDelay,
     dismissedCount: decision.dismissedCount,
     skipReason: decision.kind === "skip" ? decision.reason : undefined,
+    drawerPromptTarget: getDrawerPromptTargetFromAfterActionDecision(decision),
   });
 }
 
@@ -25,5 +41,6 @@ export function trackInactivityDecision(decision: InactivityTriggerDecision) {
     repromptDelay: decision.nextRepromptDelay,
     dismissedCount: decision.dismissedCount,
     skipReason: decision.kind === "skip" ? decision.reason : undefined,
+    drawerPromptTarget: getDrawerPromptTargetFromInactivityDecision(decision),
   });
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/NotificationsPromptDrawer.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/NotificationsPromptDrawer.tsx
@@ -1,14 +1,22 @@
-import React from "react";
+import React, { useCallback, useRef } from "react";
 import { useTranslation } from "~/context/Locale";
 import { Flex, Link as TextLink, Button } from "@ledgerhq/native-ui";
 import { useNotifications } from "LLM/features/NotificationsPrompt";
 import QueuedDrawer from "LLM/components/QueuedDrawer";
 import { NotificationsDrawerIllustration } from "LLM/features/NotificationsPrompt/components/NotificationsDrawerIllustration";
 import { NotificationsPromptContent } from "LLM/features/NotificationsPrompt/components/NotificationsPromptContent";
+import { resolveDrawerPromptTargetForAnalytics } from "LLM/features/NotificationsPrompt/new/notificationsPromptAnalytics";
 import { getNotificationsPromptCopy } from "LLM/features/NotificationsPrompt/utils/getNotificationsPromptCopy";
+import type { NotificationPromptTarget } from "LLM/features/NotificationsPrompt/types";
 import { TrackScreen } from "~/analytics";
 import { useFeature } from "@features/platform-feature-flags";
 import { AB_TESTING_VARIANTS } from "LLM/features/NotificationsPrompt/types/variants";
+import type { NotificationsState } from "~/reducers/types";
+
+type DrawerDisplayState = {
+  drawerSource: NotificationsState["drawerSource"];
+  drawerPromptTarget: NotificationPromptTarget | undefined;
+};
 
 export const NotificationsPromptDrawer = () => {
   const { t } = useTranslation();
@@ -25,22 +33,48 @@ export const NotificationsPromptDrawer = () => {
 
   const featureNewWordingNotificationsDrawer = useFeature("lwmNewWordingOptInNotificationsDrawer");
 
+  const drawerDisplayStateRef = useRef<DrawerDisplayState>({
+    drawerSource: undefined,
+    drawerPromptTarget: undefined,
+  });
+
+  if (isPushNotificationsModalOpen) {
+    drawerDisplayStateRef.current = {
+      drawerSource,
+      drawerPromptTarget,
+    };
+  }
+
+  const { drawerSource: displayedDrawerSource, drawerPromptTarget: displayedDrawerPromptTarget } =
+    drawerDisplayStateRef.current;
+
+  const handleModalHide = useCallback(() => {
+    drawerDisplayStateRef.current = {
+      drawerSource: undefined,
+      drawerPromptTarget: undefined,
+    };
+  }, []);
+
   const canShowVariant = featureNewWordingNotificationsDrawer?.enabled;
   const isVariantB =
     featureNewWordingNotificationsDrawer?.enabled === true &&
     featureNewWordingNotificationsDrawer?.params?.variant === AB_TESTING_VARIANTS.B;
-  const { allowKey, laterKey } = getNotificationsPromptCopy(drawerPromptTarget, isVariantB);
+  const { allowKey, laterKey } = getNotificationsPromptCopy(
+    displayedDrawerPromptTarget,
+    isVariantB,
+  );
 
   return (
     <QueuedDrawer
       isRequestingToBeOpened={isPushNotificationsModalOpen}
       noCloseButton
       onBackdropPress={handleCloseFromBackdropPress}
+      onModalHide={handleModalHide}
     >
       <TrackScreen
         category="Drawer push notification opt-in"
-        source={drawerSource}
-        promptTarget={drawerPromptTarget}
+        source={displayedDrawerSource}
+        drawerPromptTarget={resolveDrawerPromptTargetForAnalytics(displayedDrawerPromptTarget)}
         repromptDelay={nextRepromptDelay}
         dismissedCount={pushNotificationsDataOfUser?.dismissedOptInDrawerAtList?.length ?? 0}
         variant={canShowVariant ? featureNewWordingNotificationsDrawer?.params?.variant : undefined}
@@ -48,8 +82,11 @@ export const NotificationsPromptDrawer = () => {
 
       <Flex mb={4}>
         <Flex alignItems={"center"}>
-          <NotificationsDrawerIllustration type={drawerSource} />
-          <NotificationsPromptContent promptTarget={drawerPromptTarget} />
+          <NotificationsDrawerIllustration
+            type={displayedDrawerSource}
+            promptTarget={displayedDrawerPromptTarget}
+          />
+          <NotificationsPromptContent promptTarget={displayedDrawerPromptTarget} />
         </Flex>
         <Button
           type={"main"}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Add tracking for transaction alerts.

### 📝 Description
This pull request enhances the notifications prompt system in the mobile app by introducing improved analytics tracking for notification drawer prompts. It adds a new `drawerPromptTarget` property to analytics events and tests, ensuring more granular tracking of user interactions with different notification prompt targets (such as global push notifications or transaction alerts). The update also includes a utility to resolve the correct prompt target for analytics, and refactors related components and hooks for clarity and consistency.


https://github.com/user-attachments/assets/b7debbd4-d1f2-4c2d-a279-c77699943ad4



**Analytics & Tracking Improvements**
- Added a `drawerPromptTarget` property to analytics events for notification drawer prompts, enabling more detailed tracking of which type of notification prompt is being shown or interacted with. [[1]](diffhunk://#diff-5808ec2e87f4aef2632bbdd0437362caaeb9a59dbc5d0f38ac385efbee53fd79R153-R155) [[2]](diffhunk://#diff-5808ec2e87f4aef2632bbdd0437362caaeb9a59dbc5d0f38ac385efbee53fd79R259-R267) [[3]](diffhunk://#diff-c14bc5a8b23780db93273bd349fef6fcc7f241236b83eb15af9c74dc042eacc7R6-R33) [[4]](diffhunk://#diff-c14bc5a8b23780db93273bd349fef6fcc7f241236b83eb15af9c74dc042eacc7R44) [[5]](diffhunk://#diff-174f1ad34d8e62308655fb63796b2301d4d1df91798245355fa4d4c1811a1101L1-R19)
- Introduced the `resolveDrawerPromptTargetForAnalytics` utility to consistently resolve and default the prompt target for analytics events, defaulting to `"globalPushNotifications"` when unspecified. [[1]](diffhunk://#diff-c14bc5a8b23780db93273bd349fef6fcc7f241236b83eb15af9c74dc042eacc7R6-R33) [[2]](diffhunk://#diff-13132af669e2758e39f8cb71a3ab6b4ca0c338798c34a241da763ca024db099cR1-R84) [[3]](diffhunk://#diff-174f1ad34d8e62308655fb63796b2301d4d1df91798245355fa4d4c1811a1101L1-R19)

**Testing Enhancements**
- Updated integration tests for all notification prompt flows (`send`, `receive`, `stake`, `swap`, and dApp flows) to assert the presence of the new `drawerPromptTarget` property in analytics payloads. [[1]](diffhunk://#diff-0a62a72c2618a06c771935e7d69aac7a3696016ff9a454a6f649748125bd8acdR167) [[2]](diffhunk://#diff-0a62a72c2618a06c771935e7d69aac7a3696016ff9a454a6f649748125bd8acdR178) [[3]](diffhunk://#diff-d56dd7f91e3cbb5a2fc81b5653bd81ae91a7f9b7666a513ab346a66b8f147004R161) [[4]](diffhunk://#diff-d56dd7f91e3cbb5a2fc81b5653bd81ae91a7f9b7666a513ab346a66b8f147004R170) [[5]](diffhunk://#diff-8307c4b2a43eedd0c9e80f821ee8866c852a328e707120b6a61bc11731f1d8c2R799) [[6]](diffhunk://#diff-8307c4b2a43eedd0c9e80f821ee8866c852a328e707120b6a61bc11731f1d8c2R809) [[7]](diffhunk://#diff-ecacc959d8a4672a6002a82ba89beeb1a5ec3d33b18b4f7e79999ce75f905b9cR165) [[8]](diffhunk://#diff-ecacc959d8a4672a6002a82ba89beeb1a5ec3d33b18b4f7e79999ce75f905b9cR177) [[9]](diffhunk://#diff-ecacc959d8a4672a6002a82ba89beeb1a5ec3d33b18b4f7e79999ce75f905b9cR214) [[10]](diffhunk://#diff-ecacc959d8a4672a6002a82ba89beeb1a5ec3d33b18b4f7e79999ce75f905b9cR223) [[11]](diffhunk://#diff-54ecbcd589d40cbf0cc6946bf0fce6a8866cd62b7635f378d649da08fb9bc3b6R240)
- Added new unit tests for analytics utilities to verify correct handling and tracking of `drawerPromptTarget`.

**Component & Hook Refactoring**
- Updated `NotificationsDrawerIllustration` and related types to support the new prompt target logic and illustration selection.
- Refactored hooks and components to use the new analytics utilities and remove redundant code, improving maintainability. [[1]](diffhunk://#diff-43a1c041d0a4ac1e1918454d3e8d5692e354d53a280b969cec5313719b1028fbL13) [[2]](diffhunk://#diff-43a1c041d0a4ac1e1918454d3e8d5692e354d53a280b969cec5313719b1028fbL29-L34) [[3]](diffhunk://#diff-43a1c041d0a4ac1e1918454d3e8d5692e354d53a280b969cec5313719b1028fbL55-R48) [[4]](diffhunk://#diff-43a1c041d0a4ac1e1918454d3e8d5692e354d53a280b969cec5313719b1028fbL73) [[5]](diffhunk://#diff-174f1ad34d8e62308655fb63796b2301d4d1df91798245355fa4d4c1811a1101L1-R19)

**Documentation**
- Updated the changeset description to reflect the addition of the notification drawer, per-target opt-out dismissals, and the new analytics property.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31501]

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31501]: https://ledgerhq.atlassian.net/browse/LIVE-31501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ