### PR TITLE
fix(e2e-mobile): LedgerSync cleanup must delete, and push correct version

### DIFF
--- a/e2e/mobile/utils/cliUtils.ts
+++ b/e2e/mobile/utils/cliUtils.ts
@@ -118,24 +118,20 @@ export const CLI = {
       slug: liveSlug,
       schema: walletsync.schema,
       trustchainSdk: ledgerKeyRingProtocolSDK,
-      getCurrentVersion: () => version || 1,
+      getCurrentVersion: () => version ?? 0,
       saveNewUpdate: async (event: UpdateEvent<LiveData>) => {
         latestUpdateEvent = event;
       },
     });
 
-    //@todo: Split into it's own function
-    if (push) {
-      return cloudSyncSDK
-        .push(
-          { rootId, walletSyncEncryptionKey, applicationPath },
-          { pubkey: pubKey, privatekey: privateKey },
-          JSON.parse(data!) as LiveData,
-        )
-        .then((result: void) => JSON.stringify(result, null, 2));
+    // check deleteData/pull before push: callers reuse args that carry push: true
+    if (deleteData) {
+      return cloudSyncSDK.destroy(
+        { rootId, walletSyncEncryptionKey, applicationPath },
+        { pubkey: pubKey, privatekey: privateKey },
+      );
     }
 
-    //@todo: Split into it's own function
     if (pull) {
       return cloudSyncSDK
         .pull(
@@ -147,11 +143,14 @@ export const CLI = {
         );
     }
 
-    if (deleteData) {
-      return cloudSyncSDK.destroy(
-        { rootId, walletSyncEncryptionKey, applicationPath },
-        { pubkey: pubKey, privatekey: privateKey },
-      );
+    if (push) {
+      return cloudSyncSDK
+        .push(
+          { rootId, walletSyncEncryptionKey, applicationPath },
+          { pubkey: pubKey, privatekey: privateKey },
+          JSON.parse(data!) as LiveData,
+        )
+        .then((result: void) => JSON.stringify(result, null, 2));
     }
   },
   liveData: function (opts: LiveDataOpts) {


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. <!-- N/A: only the private mobile e2e tests are touched. -->
- [x] **Covered by automatic tests.** Validated by the E2E mobile run triggered on this PR.
- [ ] **Impact of the changes:**
  - E2E mobile only (`CLI.ledgerSync` test helper). No app/runtime code.

### 📝 Description

Backport of #18224 to mobile (`e2e/mobile/utils/cliUtils.ts`), per @abdurrahman-ledger's review request.

**1. The cleanup never deleted — it pushed.** `deleteLedgerSyncData` passes `deleteData: true` but reuses args carrying `push: true`. `CLI.ledgerSync` checked `if (push)` before `if (deleteData)`, turning the delete into a push. Fixed by checking `deleteData`/`pull` before `push`.

**2. Blind version → backend 500.** `getCurrentVersion` defaulted to `1`, so every push computed `version = 2`. Pushing version 2 to an empty/just-deleted store is rejected with HTTP 500. Defaulted to `0` so a fresh push sends `version = 1`.

### ❓ Context

- **JIRA or GitHub link**: backport of #18224 / related to https://ledgerhq.atlassian.net/browse/LIVE-31719
- **ADR link (if any)**: N/A
