### PR TITLE
[CI][E2E][Mobile] Reduce allure report size by removing AI analysis artifacts

### DIFF
--- a/tools/actions/composites/upload-allure-report/action.yml
+++ b/tools/actions/composites/upload-allure-report/action.yml
@@ -43,6 +43,10 @@ runs:
     - name: Compress PNG files
       shell: bash
       run: ${{ github.action_path }}/compress-pngs.sh "${{ inputs.path }}"
+    - name: Prune AI-analysis attachments
+      id: prune
+      shell: bash
+      run: ${{ github.action_path }}/prune-ai-attachments.sh "${{ inputs.path }}" "${{ runner.temp }}/allure-upload"
     - name: Publish report on Allure Server
       id: publish-report
       uses: LedgerHQ/send-to-allure-server-action@2.1.2
@@ -53,7 +57,7 @@ runs:
         username: ${{ inputs.login }}
         password: ${{ inputs.password }}
         path: ${{ steps.report-path.outputs.path }}
-        allure-results: ${{ inputs.path }}
+        allure-results: ${{ steps.prune.outputs.path }}
     - name: Write Allure report in summary
       shell: bash
       run: echo "::notice title=${{ inputs.platform }} Allure report URL::${{ steps.publish-report.outputs.report-url }}"

--- a/tools/actions/composites/upload-allure-report/prune-ai-attachments.sh
+++ b/tools/actions/composites/upload-allure-report/prune-ai-attachments.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build a pruned copy of an Allure results directory for upload, dropping
+# AI-analysis-only payloads to shrink the report sent to the Allure server:
+#   - All "text/xml" attachments (currently used for Native View Hierarchy),
+#     captured solely for AI
+#   - AI artifact directories (artifacts-ai / *-ai-analysis) if present.
+#
+# The SOURCE directory is left untouched on purpose: later steps in the job
+# (`allure generate` in get-allure-summary, then build-ai-artifact.sh) still
+# need the full data. Writes the pruned copy path to $GITHUB_OUTPUT as `path`.
+#
+# Usage: prune-ai-attachments.sh <source-dir> <dest-dir>
+
+SRC="${1:-}"
+DST="${2:-}"
+
+emit_path() {
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "path=$1" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+if [ -z "$SRC" ] || [ -z "$DST" ]; then
+  echo "::error::Usage: prune-ai-attachments.sh <source-dir> <dest-dir>"
+  exit 1
+fi
+
+# Fall back to the original directory so the publish step still has something
+# to upload if there is nothing to prune.
+if [ ! -d "$SRC" ]; then
+  echo "::warning::Directory '$SRC' not found. Skipping AI-attachment pruning."
+  emit_path "$SRC"
+  exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "::warning::'jq' not found. Uploading report without AI-attachment pruning."
+  emit_path "$SRC"
+  exit 0
+fi
+
+# Fresh copy we can mutate without touching the source.
+rm -rf "$DST"
+mkdir -p "$DST"
+cp -a "$SRC/." "$DST/"
+
+# Drop AI artifact directories that needn't reach the Allure server.
+find "$DST" -type d \( -name 'artifacts-ai' -o -name '*-ai-analysis' \) -prune -exec rm -rf {} +
+
+# Remove the AI-only text/xml attachments: delete the referenced attachment files,
+# then strip their entries from the result JSON.
+removed=0
+shopt -s nullglob
+for json in "$DST"/*-result.json "$DST"/*-container.json; do
+  [ -f "$json" ] || continue
+
+  while IFS= read -r src; do
+    [ -n "$src" ] || continue
+    case "$src" in
+      */* | ..)
+        echo "::warning::Skipping attachment with unexpected source path: $src"
+        continue
+        ;;
+    esac
+    if [ -f "$DST/$src" ]; then
+      rm -f "$DST/$src"
+      removed=$((removed + 1))
+    fi
+  done < <(jq -r '[.. | objects | .attachments? // empty | .[]? | select(.type == "text/xml") | .source] | .[]' "$json")
+
+  tmp=$(mktemp "$DST/.prune.XXXXXX")
+  jq 'walk(if type == "object" and has("attachments") then .attachments |= map(select(.type != "text/xml")) else . end)' "$json" > "$tmp"
+  mv -f "$tmp" "$json"
+done
+
+echo "Pruned $removed AI-analysis attachment file(s) from the upload copy."
+emit_path "$DST"


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached. (no need)
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - E2E Allure report

### 📝 Description

This PR updates the internal “upload-allure-report” composite action to publish a pruned Allure results directory (removing AI-only payloads) so the uploaded report is smaller, while keeping the full results available for later AI-artifact generation.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- E2E [Run](https://github.com/LedgerHQ/ledger-live/actions/runs/27105760183)

<img width="529" height="215" alt="Screenshot 2026-06-08 at 09 48 24" src="https://github.com/user-attachments/assets/4fd09ce2-1945-4f58-a45f-2f10a02eeeb6" />


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
