### PR TITLE
[LWDM] fix(live-dmk-speculos): reconnect stale DMK session to fix flaky e2e

### DIFF
--- a/.changeset/speculos-stale-session-reconnect.md
+++ b/.changeset/speculos-stale-session-reconnect.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-dmk-speculos": patch
+---
+
+Fix flaky e2e failures where account discovery failed with a DMK `GeneralDmkError` ("Network Error", Axios `ERR_NETWORK`). The Speculos proxy closes idle keep-alive sockets after ~60s, so a cached DMK session reused after a longer idle gap (e.g. a test whose first device interaction comes well after the previous one) failed on its first APDU. The transport now proactively reconnects when a cached session has been idle past a safe threshold, and `ERR_NETWORK` / "Network Error" are classified as retryable transient HTTP failures.

--- a/libs/live-dmk-speculos/src/transport/DeviceManagementKitTransportSpeculos.test.ts
+++ b/libs/live-dmk-speculos/src/transport/DeviceManagementKitTransportSpeculos.test.ts
@@ -64,7 +64,7 @@ beforeAll(() => {
     listenToAvailableDevices: jest.fn().mockImplementation(() => listenSubject.asObservable()),
     connect: jest.fn().mockResolvedValue("session-1"),
     sendApdu: jest.fn(),
-    disconnect: jest.fn(),
+    disconnect: jest.fn().mockResolvedValue(undefined),
   };
 
   jest.spyOn(DeviceManagementKitBuilder.prototype, "addTransport").mockReturnThis();
@@ -130,6 +130,29 @@ describe("DeviceManagementKitTransportSpeculos", () => {
 
     // then
     expect(transport).toBeInstanceOf(DeviceManagementKitTransportSpeculos);
+  });
+
+  it("open() reuses a cached session within the idle window but reconnects once it is stale", async () => {
+    const baseUrl = "http://127.0.0.1:1234";
+
+    // first open → one fresh connect
+    await openTransport({ apiPort: "1234" });
+    expect(fakeDmk.connect).toHaveBeenCalledTimes(1);
+
+    // second open shortly after → reuse cached session, no reconnect, no disconnect
+    await DeviceManagementKitTransportSpeculos.open({ apiPort: "1234" });
+    expect(fakeDmk.connect).toHaveBeenCalledTimes(1);
+    expect(fakeDmk.disconnect).not.toHaveBeenCalled();
+
+    // simulate the session sitting idle past the proxy's socket timeout
+    const entry = DeviceManagementKitTransportSpeculos["byBase"].get(baseUrl)!;
+    entry.lastUsedAt =
+      Date.now() - (DeviceManagementKitTransportSpeculos.MAX_SESSION_IDLE_MS + 1_000);
+
+    // third open → stale session dropped + fresh reconnect
+    await openTransport({ apiPort: "1234" });
+    expect(fakeDmk.disconnect).toHaveBeenCalledWith({ sessionId: "session-1" });
+    expect(fakeDmk.connect).toHaveBeenCalledTimes(2);
   });
 
   it.each([

--- a/libs/live-dmk-speculos/src/transport/DeviceManagementKitTransportSpeculos.ts
+++ b/libs/live-dmk-speculos/src/transport/DeviceManagementKitTransportSpeculos.ts
@@ -32,6 +32,8 @@ type DmkEntry = {
   sessionId?: string;
   connectPromise?: Promise<void>;
   timeout: number;
+  /** Epoch ms of the last successful device interaction on this session. */
+  lastUsedAt?: number;
 };
 
 type ControllerButton = "left" | "right" | "both";
@@ -47,6 +49,10 @@ type ButtonsController = {
 
 export default class SpeculosHttpTransport extends Transport {
   static readonly byBase = new Map<string, DmkEntry>();
+
+  // The pod gateway closes idle keep-alive sockets after ~60s; a session reused past that
+  // point fails its first APDU with ERR_NETWORK. Reconnect well under that window.
+  static readonly MAX_SESSION_IDLE_MS = 30_000;
   private readonly options: SpeculosHttpTransportOpts;
   private readonly baseUrl: string;
   private readonly buttonEnumToControllerInput: Record<SpeculosButton, ControllerButton> = {
@@ -159,7 +165,15 @@ export default class SpeculosHttpTransport extends Transport {
   }
 
   private static async ensureSession(deviceManagementEntry: DmkEntry) {
-    if (deviceManagementEntry.sessionId) return;
+    if (deviceManagementEntry.sessionId) {
+      const idleMs = Date.now() - (deviceManagementEntry.lastUsedAt ?? 0);
+      if (idleMs <= this.MAX_SESSION_IDLE_MS) return;
+
+      log("speculos-transport", `session idle ${idleMs}ms exceeds limit, reconnecting`);
+      const staleSessionId = deviceManagementEntry.sessionId;
+      deviceManagementEntry.sessionId = undefined;
+      await deviceManagementEntry.dmk.disconnect({ sessionId: staleSessionId }).catch(() => {});
+    }
     if (deviceManagementEntry.connectPromise) return deviceManagementEntry.connectPromise;
 
     deviceManagementEntry.connectPromise = (async () => {
@@ -176,6 +190,7 @@ export default class SpeculosHttpTransport extends Transport {
           sessionRefresherOptions: { isRefresherDisabled: true },
         }),
       );
+      deviceManagementEntry.lastUsedAt = Date.now();
     })();
 
     try {
@@ -183,6 +198,12 @@ export default class SpeculosHttpTransport extends Transport {
     } finally {
       deviceManagementEntry.connectPromise = undefined;
     }
+  }
+
+  /** Marks the cached session as freshly used so the idle-staleness check stays accurate. */
+  private static touch(baseUrl: string): void {
+    const entry = this.byBase.get(baseUrl);
+    if (entry) entry.lastUsedAt = Date.now();
   }
 
   static async disconnectAll(): Promise<void> {
@@ -244,6 +265,7 @@ export default class SpeculosHttpTransport extends Transport {
 
     try {
       const { data, statusCode } = await withTransientHttpRetries("speculos-send-apdu", sendOnce);
+      SpeculosHttpTransport.touch(this.baseUrl);
       return Buffer.from([...data, ...statusCode]);
     } catch {
       const deviceManagementEntry = SpeculosHttpTransport.ensureEntry(
@@ -261,6 +283,7 @@ export default class SpeculosHttpTransport extends Transport {
         "speculos-send-apdu-after-reconnect",
         sendOnce,
       );
+      SpeculosHttpTransport.touch(this.baseUrl);
       return Buffer.from([...data, ...statusCode]);
     }
   }

--- a/libs/live-dmk-speculos/src/transport/speculosTransientHttpRetry.test.ts
+++ b/libs/live-dmk-speculos/src/transport/speculosTransientHttpRetry.test.ts
@@ -1,0 +1,74 @@
+import {
+  isRetryableSpeculosHttpError,
+  withTransientHttpRetries,
+} from "./speculosTransientHttpRetry";
+
+describe("isRetryableSpeculosHttpError", () => {
+  it("treats an Axios ERR_NETWORK as retryable (dropped Speculos proxy socket)", () => {
+    expect(
+      isRetryableSpeculosHttpError({
+        isAxiosError: true,
+        code: "ERR_NETWORK",
+        message: "Network Error",
+      }),
+    ).toBe(true);
+  });
+
+  it("treats a 'Network Error' message with no code as retryable", () => {
+    expect(isRetryableSpeculosHttpError({ isAxiosError: true, message: "Network Error" })).toBe(
+      true,
+    );
+  });
+
+  it("unwraps a GeneralDmkError wrapping an ERR_NETWORK AxiosError", () => {
+    expect(
+      isRetryableSpeculosHttpError({
+        _tag: "GeneralDmkError",
+        originalError: { isAxiosError: true, code: "ERR_NETWORK", message: "Network Error" },
+      }),
+    ).toBe(true);
+  });
+
+  it("retries retryable HTTP statuses", () => {
+    expect(isRetryableSpeculosHttpError({ isAxiosError: true, response: { status: 503 } })).toBe(
+      true,
+    );
+  });
+
+  it("does not retry a genuine 4xx device/protocol error", () => {
+    expect(
+      isRetryableSpeculosHttpError({
+        isAxiosError: true,
+        code: "ERR_BAD_REQUEST",
+        response: { status: 400 },
+      }),
+    ).toBe(false);
+  });
+
+  it("does not retry a non-Axios error", () => {
+    expect(isRetryableSpeculosHttpError(new Error("boom"))).toBe(false);
+  });
+});
+
+describe("withTransientHttpRetries", () => {
+  it("retries an ERR_NETWORK failure then succeeds", async () => {
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce({ isAxiosError: true, code: "ERR_NETWORK", message: "Network Error" })
+      .mockResolvedValueOnce("ok");
+
+    await expect(
+      withTransientHttpRetries("test", fn, { maxAttempts: 3, baseDelayMs: 1 }),
+    ).resolves.toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a non-retryable error", async () => {
+    const fn = jest.fn().mockRejectedValue({ isAxiosError: true, response: { status: 400 } });
+
+    await expect(
+      withTransientHttpRetries("test", fn, { maxAttempts: 3, baseDelayMs: 1 }),
+    ).rejects.toEqual({ isAxiosError: true, response: { status: 400 } });
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/live-dmk-speculos/src/transport/speculosTransientHttpRetry.ts
+++ b/libs/live-dmk-speculos/src/transport/speculosTransientHttpRetry.ts
@@ -10,6 +10,7 @@ const RETRYABLE_AXIOS_NETWORK_CODES = new Set([
   "ECONNREFUSED",
   "EPIPE",
   "ERR_BAD_RESPONSE",
+  "ERR_NETWORK", // axios code for a dropped/failed connection (e.g. reused dead socket)
 ]);
 
 export type TransientHttpRetryOptions = {
@@ -37,9 +38,9 @@ export function isRetryableSpeculosHttpError(error: unknown): boolean {
       const code = obj.code;
       if (typeof code === "string" && RETRYABLE_AXIOS_NETWORK_CODES.has(code)) return true;
 
-      // Node often uses ECONNRESET; some stacks only surface this on the Axios message.
+      // Some stacks only surface the failure on the Axios message (RN sets "Network Error").
       const msg = String((obj as { message?: string }).message ?? "");
-      if (msg.includes("socket hang up")) return true;
+      if (msg.includes("socket hang up") || msg.includes("Network Error")) return true;
     }
 
     const errLike = e as Error & { cause?: unknown };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

The Speculos DMK session and its keep-alive HTTP connection are cached in the static byBase map and reused across e2e tests. The per-pod gateway closes idle sockets after ~60s, so a session reused after a >60s idle gap fails on its first APDU with an Axios ERR_NETWORK, surfaced via the DMK device-disconnect path (which bypasses the per-APDU reconnect in exchange) and shown as a generic-error-modal — flaking the iOS receiveFlow spec.

- Track last-use time per cached session and reconnect when idle beyond MAX_SESSION_IDLE_MS (well under the gateway timeout); stamp it only on APDU activity (connect + exchange), not button presses (separate socket).
- Treat ERR_NETWORK / "Network Error" as retryable in the transient HTTP retry helper.
<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- Fixes [this](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/a66ad049-e7cb-4904-8bd5-27a5a0eb962c/#suites/df9af38dbb3acac2d150d4bdc552c8ff/5d83bd7363974cce/) test issue
- [@Desktop E2E • triggered on fix/speculos-e2e-stale-session-reconnect by cunhabruno](https://github.com/LedgerHQ/ledger-live/actions/runs/27122755770)
- [@Mobile E2E • Manual • iOS & Android • fix/speculos-e2e-stale-session-reconnect • cunhabruno](https://github.com/LedgerHQ/ledger-live/actions/runs/27122772331)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
