### PR TITLE
[LWDM] feat(lwm): signature screen new send flow

### DIFF
--- a/.changeset/dry-eyes-sparkle.md
+++ b/.changeset/dry-eyes-sparkle.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+feat(lwm): signature screen new send flow

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -118,6 +118,7 @@ libs/ledger-live-common/src/bridge/                                 @ledgerhq/co
 libs/ledger-live-common/src/apps/config.ts                          @ledgerhq/coin-integration
 libs/ledger-live-common/src/families/                               @ledgerhq/coin-integration
 libs/ledger-live-common/src/flows/send/                             @ledgerhq/coin-integration
+libs/ledger-live-common/src/intents/                                @ledgerhq/coin-integration
 libs/ledger-live-common/src/transaction/                            @ledgerhq/coin-integration
 libs/ledger-live-common/src/walletConnect/                          @ledgerhq/coin-integration
 libs/ledger-services/                                               @ledgerhq/coin-integration

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -4476,7 +4476,13 @@
       "processingTransaction": "Your transaction is being processed",
       "sign": {
         "title": "Continue on your Ledger {{wording}}",
-        "description": "Follow the instructions displayed on your Secure Touchscreen."
+        "description": "Follow the instructions displayed on your Secure Touchscreen.",
+        "cancelled": {
+          "title": "Transaction canceled",
+          "description": "You rejected the transaction. Your funds won't be affected.",
+          "close": "Close",
+          "retry": "Try again"
+        }
       },
       "gasOptionsSync": {
         "warningTitle": "Unable to refresh network fees",

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/__tests__/SignatureScreen.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/__tests__/SignatureScreen.test.tsx
@@ -1,0 +1,147 @@
+import React from "react";
+import { Observable } from "rxjs";
+import type { SignatureRequest } from "@ledgerhq/live-common/flows/send/hooks/useSendFlowSignatureCore";
+import type { SignTransactionIntent } from "@ledgerhq/live-common/intents/signTransactionIntent";
+import type { InitializationInput } from "LLM/components/DeviceIntentExecutor";
+import { render, screen } from "@tests/test-renderer";
+import { SignatureScreen } from "../index";
+import * as UseSignatureViewModelModule from "../hooks/useSignatureViewModel";
+import { createBitcoinTransaction } from "../../CoinControl/hooks/__tests__/helpers";
+import { createMockAccount } from "../../Recipient/hooks/__tests__/accounts";
+
+type SignatureViewModel = ReturnType<typeof UseSignatureViewModelModule.useSignatureViewModel>;
+
+const mockAccount = createMockAccount({ id: "account-1" });
+const mockTransaction = createBitcoinTransaction();
+const mockRequest: SignatureRequest = {
+  account: mockAccount,
+  parentAccount: null,
+  transaction: mockTransaction,
+};
+const mockDeviceInitializationInput = {
+  appName: "Bitcoin",
+  dependencies: [],
+  requireLatestFirmware: false,
+  allowPartialDependencies: false,
+} satisfies InitializationInput;
+const mockSignatureIntent = {
+  uuid: "signature-intent",
+  label: "Sign transaction",
+  requiresConnectedDevice: true,
+  delegateDeviceLockStateHandlingToExecutor: false,
+  job: () => new Observable(),
+  component: () => null,
+  input: mockRequest,
+} satisfies SignTransactionIntent;
+
+const mockDeviceIntentExecutorLWM = jest.fn();
+
+jest.mock(
+  "@ledgerhq/live-common/firebase/featureFlags",
+  () => ({
+    getFeature: jest.fn(),
+  }),
+  { virtual: true },
+);
+
+jest.mock(
+  "@features/platform-feature-flags",
+  () => ({
+    formatToFirebaseFeatureId: (featureId: string) => featureId,
+    useFeature: jest.fn(),
+    useFeatureFlags: jest.fn(() => ({})),
+  }),
+  { virtual: true },
+);
+
+jest.mock("LLM/components/DeviceIntentExecutor", () => ({
+  __esModule: true,
+  DeviceIntentExecutorLWM: (props: unknown) => {
+    mockDeviceIntentExecutorLWM(props);
+    return null;
+  },
+}));
+
+jest.mock("../hooks/useSignatureViewModel", () => ({
+  useSignatureViewModel: jest.fn(),
+}));
+
+function buildViewModel(overrides: Partial<SignatureViewModel> = {}): SignatureViewModel {
+  return {
+    account: mockAccount,
+    transaction: mockTransaction,
+    request: mockRequest,
+    deviceInitializationInput: mockDeviceInitializationInput,
+    signatureIntent: mockSignatureIntent,
+    isSigningCompleted: false,
+    onIntentJobStateChanged: jest.fn(),
+    onIntentJobError: jest.fn(),
+    onUserCancel: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe("SignatureScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest
+      .mocked(UseSignatureViewModelModule.useSignatureViewModel)
+      .mockReturnValue(buildViewModel());
+  });
+
+  describe("when required flow data is missing", () => {
+    it("should render nothing when account is missing", () => {
+      jest
+        .mocked(UseSignatureViewModelModule.useSignatureViewModel)
+        .mockReturnValue(buildViewModel({ account: null }));
+      render(<SignatureScreen />);
+      expect(screen.queryByTestId("send-signature-step")).toBeNull();
+    });
+
+    it("should render nothing when transaction is missing", () => {
+      jest
+        .mocked(UseSignatureViewModelModule.useSignatureViewModel)
+        .mockReturnValue(buildViewModel({ transaction: null }));
+      render(<SignatureScreen />);
+      expect(screen.queryByTestId("send-signature-step")).toBeNull();
+    });
+
+    it("should render nothing when device initialization input is missing", () => {
+      jest
+        .mocked(UseSignatureViewModelModule.useSignatureViewModel)
+        .mockReturnValue(buildViewModel({ deviceInitializationInput: null }));
+      render(<SignatureScreen />);
+      expect(screen.queryByTestId("send-signature-step")).toBeNull();
+    });
+
+    it("should render nothing when signature intent is missing", () => {
+      jest
+        .mocked(UseSignatureViewModelModule.useSignatureViewModel)
+        .mockReturnValue(buildViewModel({ signatureIntent: null }));
+      render(<SignatureScreen />);
+      expect(screen.queryByTestId("send-signature-step")).toBeNull();
+    });
+  });
+
+  it("should render DeviceIntentExecutorLWM with signature props", () => {
+    const viewModel = buildViewModel();
+    jest.mocked(UseSignatureViewModelModule.useSignatureViewModel).mockReturnValue(viewModel);
+
+    render(<SignatureScreen />);
+
+    expect(screen.getByTestId("send-signature-step")).toBeOnTheScreen();
+    expect(mockDeviceIntentExecutorLWM).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: true,
+        sourceFlow: "send",
+        deviceConnectionParams: { acceptedDeviceModelIds: [] },
+        deviceInitializationInput: viewModel.deviceInitializationInput,
+        intent: viewModel.signatureIntent,
+        intentComponentExtraProps: undefined,
+        onIntentJobStateChanged: viewModel.onIntentJobStateChanged,
+        onIntentJobError: viewModel.onIntentJobError,
+        onUserCancel: viewModel.onUserCancel,
+      }),
+    );
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/components/SignatureScreenView/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/components/SignatureScreenView/index.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { View } from "react-native";
+import {
+  DeviceIntentExecutorLWM,
+  type InitializationInput,
+} from "LLM/components/DeviceIntentExecutor";
+import type {
+  SignTransactionIntent,
+  SignTransactionIntentJobState,
+} from "@ledgerhq/live-common/intents/signTransactionIntent";
+
+const deviceConnectionParams = { acceptedDeviceModelIds: [] };
+const noop = () => undefined;
+
+export type SignatureScreenViewProps = Readonly<{
+  deviceInitializationInput: InitializationInput;
+  signatureIntent: SignTransactionIntent;
+  onIntentJobStateChanged: (jobState: SignTransactionIntentJobState) => void;
+  onIntentJobError: (error: unknown) => void;
+  onUserCancel: () => void;
+}>;
+
+export function SignatureScreenView({
+  deviceInitializationInput,
+  signatureIntent,
+  onIntentJobStateChanged,
+  onIntentJobError,
+  onUserCancel,
+}: SignatureScreenViewProps) {
+  return (
+    <View style={{ flex: 1 }} testID="send-signature-step">
+      <DeviceIntentExecutorLWM
+        enabled
+        sourceFlow="send"
+        deviceConnectionParams={deviceConnectionParams}
+        deviceInitializationInput={deviceInitializationInput}
+        intent={signatureIntent}
+        intentComponentExtraProps={undefined}
+        onExecutorStateChanged={noop}
+        onIntentJobStateChanged={onIntentJobStateChanged}
+        onIntentJobComplete={noop}
+        onIntentJobError={onIntentJobError}
+        cancelIntentRequestId={undefined}
+        onUserCancel={onUserCancel}
+      />
+    </View>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/components/SimplifiedTransactionConfirm.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/components/SimplifiedTransactionConfirm.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { getDeviceModel } from "@ledgerhq/devices";
+import type { DeviceModelId } from "@ledgerhq/types-devices";
+import { useTranslation } from "~/context/Locale";
+import { DeviceActionContent } from "LLM/components/DeviceActionContent";
+
+type SimplifiedTransactionConfirmProps = Readonly<{
+  deviceModelId: DeviceModelId;
+}>;
+
+export function SimplifiedTransactionConfirm({ deviceModelId }: SimplifiedTransactionConfirmProps) {
+  const { t } = useTranslation();
+  const wording = getDeviceModel(deviceModelId).productName;
+
+  return (
+    <DeviceActionContent
+      action="continue"
+      description={t("send.newSendFlow.sign.description")}
+      deviceModelId={deviceModelId}
+      testID="send-signature-prompt"
+      title={t("send.newSendFlow.sign.title", { wording })}
+    />
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/hooks/useSignatureViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/hooks/useSignatureViewModel.ts
@@ -1,21 +1,32 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigation } from "@react-navigation/native";
+import { createIntent } from "@ledgerhq/device-intent";
 import type { Account, Operation } from "@ledgerhq/types-live";
 import { useBroadcast } from "@ledgerhq/live-common/hooks/useBroadcast";
-import { addPendingOperation } from "@ledgerhq/live-common/account/index";
+import { addPendingOperation, getMainAccount } from "@ledgerhq/live-common/account/index";
 import { useSendFlowSignatureCore } from "@ledgerhq/live-common/flows/send/hooks/useSendFlowSignatureCore";
-import { useDebouncedRequireBluetooth } from "~/components/RequiresBLE/hooks/useRequireBluetooth";
+import { FlowName } from "@ledgerhq/live-common/device-action/utils";
+import type { SignTransactionIntentJobState } from "@ledgerhq/live-common/intents/signTransactionIntent";
 import { useDispatch, useSelector } from "~/context/hooks";
 import { updateAccountWithUpdater } from "~/actions/accounts";
-import { useTransactionDeviceAction } from "~/hooks/deviceActions";
-import { lastConnectedDeviceSelector, mevProtectionSelector } from "~/reducers/settings";
+import { mevProtectionSelector } from "~/reducers/settings";
+import {
+  buildDeviceInitializationInput,
+  type InitializationInput,
+} from "LLM/components/DeviceIntentExecutor";
 import { ScreenName } from "~/const";
+import { broadcastLogger } from "~/datadog";
 import { useSendFlowActions, useSendFlowData } from "../../../context/SendFlowContext";
 import type { SendFlowNavigationProp } from "../../../types";
+import { signTransactionIntentLWMDefinition } from "../intents/signTransactionIntent/intentLWMDefinition";
+
+function normalizeError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
 
 export function useSignatureViewModel() {
   const navigation = useNavigation<SendFlowNavigationProp>();
-  const { operation, status } = useSendFlowActions();
+  const { operation, status, close } = useSendFlowActions();
   const { state } = useSendFlowData();
   const reduxDispatch = useDispatch();
 
@@ -23,28 +34,11 @@ export function useSignatureViewModel() {
   const transaction = state.transaction.transaction;
   const txStatus = state.transaction.status;
 
-  const action = useTransactionDeviceAction();
-  const device = useSelector(lastConnectedDeviceSelector);
   const mevProtected = useSelector(mevProtectionSelector);
-  const [isBluetoothDrawerDismissed, setIsBluetoothDrawerDismissed] = useState(false);
-  const isBluetoothRequired = Boolean(device && !device.wired);
-  const { bluetoothRequirementsState, retryRequestOnIssue, cannotRetryRequest } =
-    useDebouncedRequireBluetooth({
-      requiredFor: "connecting",
-      isHookEnabled: isBluetoothRequired && !isBluetoothDrawerDismissed,
-    });
-  const hasBluetoothIssue =
-    isBluetoothRequired &&
-    !isBluetoothDrawerDismissed &&
-    bluetoothRequirementsState !== "unknown" &&
-    bluetoothRequirementsState !== "all_respected";
-
-  const onBluetoothDrawerClose = useCallback(() => {
-    setIsBluetoothDrawerDismissed(true);
-    if (navigation.canGoBack()) {
-      navigation.goBack();
-    }
-  }, [navigation]);
+  const [deviceInitializationInput, setDeviceInitializationInput] =
+    useState<InitializationInput | null>(null);
+  const [isSigningCompleted, setIsSigningCompleted] = useState(false);
+  const isSigningCompletedRef = useRef(false);
 
   const broadcast = useBroadcast({
     account,
@@ -53,6 +47,7 @@ export function useSignatureViewModel() {
       mevProtected,
       source: { type: "coin-module", name: "ledger-live-mobile", flags: { newSendFlow: true } },
     },
+    logger: broadcastLogger,
   });
 
   const registerPendingOperation = useCallback(
@@ -71,7 +66,7 @@ export function useSignatureViewModel() {
     navigation.replace(ScreenName.SendFlowConfirmation);
   }, [navigation]);
 
-  const { request, onDeviceActionResult } = useSendFlowSignatureCore({
+  const { request, finishWithError, onDeviceActionResult } = useSendFlowSignatureCore({
     account,
     parentAccount,
     transaction,
@@ -84,19 +79,98 @@ export function useSignatureViewModel() {
     registerPendingOperation,
   });
 
+  useEffect(() => {
+    if (!request) {
+      isSigningCompletedRef.current = false;
+      setIsSigningCompleted(false);
+      setDeviceInitializationInput(null);
+      return;
+    }
+
+    let cancelled = false;
+    isSigningCompletedRef.current = false;
+    setIsSigningCompleted(false);
+    setDeviceInitializationInput(null);
+
+    const mainAccount = getMainAccount(request.account, request.parentAccount ?? undefined);
+
+    buildDeviceInitializationInput({
+      appRequest: {
+        account: mainAccount,
+        tokenCurrency: request.tokenCurrency ?? undefined,
+      },
+      flow: FlowName.send,
+    })
+      .then(input => {
+        if (!cancelled) {
+          setDeviceInitializationInput(input);
+        }
+      })
+      .catch(error => {
+        if (!cancelled) {
+          finishWithError(normalizeError(error));
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [finishWithError, request]);
+
+  const signatureIntent = useMemo(
+    () => (request ? createIntent(signTransactionIntentLWMDefinition, request) : null),
+    [request],
+  );
+
+  const onIntentJobStateChanged = useCallback(
+    (jobState: SignTransactionIntentJobState) => {
+      if (jobState.type === "signed") {
+        isSigningCompletedRef.current = true;
+        setIsSigningCompleted(true);
+        onDeviceActionResult({
+          signedOperation: jobState.signedOperation,
+          // Legacy SignatureDeviceActionResult shape; useSendFlowSignatureCore ignores device.
+          device: {},
+        });
+        return;
+      }
+
+      if (jobState.type === "cancelled") {
+        isSigningCompletedRef.current = false;
+        setIsSigningCompleted(false);
+      }
+    },
+    [onDeviceActionResult],
+  );
+
+  // On a signing failure the executor keeps the sheet open and renders its native
+  // IntentError screen (Retry / Close). We deliberately do not navigate away here so
+  // the user stays on the sheet, as opposed to the success path which broadcasts and
+  // moves to the confirmation screen.
+  const onIntentJobError = useCallback(() => {}, []);
+
+  // Explicit dismiss of the sheet (close button / backdrop) returns to the previous step.
+  const onUserCancel = useCallback(() => {
+    if (isSigningCompletedRef.current) {
+      return;
+    }
+
+    if (navigation.canGoBack()) {
+      navigation.goBack();
+      return;
+    }
+    close();
+  }, [close, navigation]);
+
   return {
     account,
     transaction,
-    device,
-    action,
     request,
-    onDeviceActionResult,
-    bluetooth: {
-      hasIssue: hasBluetoothIssue,
-      bluetoothRequirementsState,
-      retryRequestOnIssue,
-      cannotRetryRequest,
-      onDrawerClose: onBluetoothDrawerClose,
-    },
+    deviceInitializationInput,
+    signatureIntent,
+    isSigningCompleted,
+    onIntentJobStateChanged,
+    onIntentJobError,
+    onUserCancel,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/index.tsx
@@ -1,28 +1,30 @@
-import React, { useCallback } from "react";
-import { View, Button } from "react-native";
-import { useNavigation } from "@react-navigation/native";
-import { Text } from "@ledgerhq/lumen-ui-rnative";
-import { ScreenName } from "~/const";
-import { SendFlowLayout } from "../../components/SendFlowLayout";
-import type { SendFlowNavigationProp } from "../../types";
+import React from "react";
+import { SignatureScreenView } from "./components/SignatureScreenView";
 import { useSignatureViewModel } from "./hooks/useSignatureViewModel";
 
 export function SignatureScreen() {
-  const navigation = useNavigation<SendFlowNavigationProp>();
-  useSignatureViewModel();
+  const {
+    account,
+    transaction,
+    request,
+    deviceInitializationInput,
+    signatureIntent,
+    onIntentJobStateChanged,
+    onIntentJobError,
+    onUserCancel,
+  } = useSignatureViewModel();
 
-  const handleContinue = useCallback(() => {
-    navigation.replace(ScreenName.SendFlowConfirmation);
-  }, [navigation]);
+  if (!account || !transaction || !request || !deviceInitializationInput || !signatureIntent) {
+    return null;
+  }
 
   return (
-    <SendFlowLayout>
-      <View style={{ flex: 1 }}>
-        <Text typography="body2" lx={{ color: "muted", marginBottom: "s24" }}>
-          {"Signature screen"}
-        </Text>
-        <Button title="Continue" onPress={handleContinue} />
-      </View>
-    </SendFlowLayout>
+    <SignatureScreenView
+      deviceInitializationInput={deviceInitializationInput}
+      signatureIntent={signatureIntent}
+      onIntentJobStateChanged={onIntentJobStateChanged}
+      onIntentJobError={onIntentJobError}
+      onUserCancel={onUserCancel}
+    />
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/intents/signTransactionIntent/componentLWM.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/intents/signTransactionIntent/componentLWM.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { View } from "react-native";
+import { InfoState } from "LLM/components/InfoState";
+import type { SignTransactionIntentJobState } from "@ledgerhq/live-common/intents/signTransactionIntent";
+import { useTranslation } from "~/context/Locale";
+import InfiniteLoader from "~/components/InfiniteLoader";
+import { SimplifiedTransactionConfirm } from "../../components/SimplifiedTransactionConfirm";
+
+type SignTransactionIntentComponentLWMProps = Readonly<{
+  jobState: SignTransactionIntentJobState | undefined;
+  extraProps: undefined;
+  onClose: () => void;
+}>;
+
+export function SignTransactionIntentComponentLWM({
+  jobState,
+  onClose,
+}: SignTransactionIntentComponentLWMProps) {
+  const { t } = useTranslation();
+
+  if (!jobState) {
+    return null;
+  }
+
+  switch (jobState.type) {
+    case "pending":
+    case "device-signature-requested":
+      return <SimplifiedTransactionConfirm deviceModelId={jobState.deviceModelId} />;
+    case "device-streaming":
+    case "device-signature-granted":
+    case "signed":
+      return (
+        <View
+          style={{
+            flex: 1,
+            height: "100%",
+            minHeight: 320,
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <InfiniteLoader testID="send-signature-loading" />
+        </View>
+      );
+    case "cancelled":
+      return (
+        <InfoState
+          preset="info"
+          size="hug"
+          title={t("send.newSendFlow.sign.cancelled.title")}
+          description={t("send.newSendFlow.sign.cancelled.description")}
+          primaryCta={{
+            label: t("send.newSendFlow.sign.cancelled.close"),
+            onPress: onClose,
+            testID: "send-signature-cancelled-close",
+          }}
+          secondaryCta={{
+            label: t("send.newSendFlow.sign.cancelled.retry"),
+            onPress: jobState.retry,
+            testID: "send-signature-cancelled-retry",
+          }}
+          testID="send-signature-cancelled"
+        />
+      );
+    default:
+      return assertNever(jobState);
+  }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled sign transaction intent state: ${String(value)}`);
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/intents/signTransactionIntent/intentLWMDefinition.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/intents/signTransactionIntent/intentLWMDefinition.ts
@@ -1,0 +1,8 @@
+import { SignTransactionIntentComponentLWM } from "./componentLWM";
+import { signTransactionIntentDefinition } from "@ledgerhq/live-common/intents/signTransactionIntent";
+import type { SignTransactionIntentPlatformDefinition } from "@ledgerhq/live-common/intents/signTransactionIntent";
+
+export const signTransactionIntentLWMDefinition: SignTransactionIntentPlatformDefinition = {
+  ...signTransactionIntentDefinition,
+  component: SignTransactionIntentComponentLWM,
+};

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -249,6 +249,7 @@
     "src/hw/quitApp.ts",
     "src/hw/renameDevice.ts",
     "src/hw/signMessage/index.ts",
+    "src/intents/signTransactionIntent.ts",
     "src/hw/uninstallAllApps.ts",
     "src/hw/uninstallApp.ts",
     "src/hw/uninstallLanguage.ts",

--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -62,6 +62,16 @@
       "@ledgerhq/source": "./src/device-action/*.ts",
       "default": "./lib-es/device-action/*.js"
     },
+    "./intents/signTransactionIntent": {
+      "@ledgerhq/source": "./src/intents/signTransactionIntent.ts",
+      "types": "./lib-es/intents/signTransactionIntent.d.ts",
+      "default": "./lib-es/intents/signTransactionIntent.js"
+    },
+    "./intents/*": {
+      "@ledgerhq/source": "./src/intents/*/index.ts",
+      "types": "./lib-es/intents/*/index.d.ts",
+      "default": "./lib-es/intents/*/index.js"
+    },
     "./hooks": {
       "default": "./lib-es/hooks/index.js"
     },
@@ -206,6 +216,7 @@
     "@ledgerhq/coin-xrp": "catalog:",
     "@ledgerhq/cryptoassets": "workspace:^",
     "@ledgerhq/device-core": "workspace:^",
+    "@ledgerhq/device-intent": "workspace:^",
     "@ledgerhq/device-management-kit": "catalog:",
     "@ledgerhq/devices": "workspace:*",
     "@ledgerhq/errors": "workspace:^",

--- a/libs/ledger-live-common/src/intents/signTransactionIntent.ts
+++ b/libs/ledger-live-common/src/intents/signTransactionIntent.ts
@@ -1,0 +1,1 @@
+export * from "./signTransactionIntent/index";

--- a/libs/ledger-live-common/src/intents/signTransactionIntent/__tests__/job.test.ts
+++ b/libs/ledger-live-common/src/intents/signTransactionIntent/__tests__/job.test.ts
@@ -1,0 +1,206 @@
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+import { TransportStatusError, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { getMainAccount } from "../../../account/index";
+import { getAccountBridge } from "../../../bridge/index";
+import type { DeviceConnectionResult, DeviceExtractedContext } from "@ledgerhq/device-intent";
+import type {
+  Account,
+  AccountLike,
+  SignOperationEvent,
+  SignedOperation,
+} from "@ledgerhq/types-live";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { Observable, of, throwError } from "rxjs";
+import { signTransactionIntentJob } from "../job";
+import type { SignTransactionIntentInput, SignTransactionIntentJobState } from "../types";
+
+jest.mock("../../../account/index", () => ({
+  getMainAccount: jest.fn(),
+}));
+
+jest.mock("../../../bridge/index", () => ({
+  getAccountBridge: jest.fn(),
+}));
+
+const account = { id: "account-1" } as AccountLike;
+const parentAccount = { id: "parent-account-1" } as Account;
+const mainAccount = { id: "main-account-1" } as Account;
+const transaction = { family: "evm" } as SignTransactionIntentInput["transaction"];
+const signedOperation = { operation: { id: "operation-1" } } as SignedOperation;
+
+const deviceConnectionResult: DeviceConnectionResult = {
+  dmk: null as unknown as DeviceConnectionResult["dmk"],
+  sessionId: "session-1",
+  connectedDevice: null as unknown as DeviceConnectionResult["connectedDevice"],
+  compatDeviceId: "device-1",
+  compatDeviceName: "Device 1",
+  compatDeviceModelId: DeviceModelId.nanoX,
+  compatDeviceWired: true,
+};
+
+const deviceExtractedContext: DeviceExtractedContext = {
+  currentOsVersion: "1.0.0",
+  osUpdateAvailable: false,
+  currentAppName: "Ethereum",
+  currentAppVersion: "1.0.0",
+};
+
+const deviceModelId = DeviceModelId.nanoX;
+
+const input: SignTransactionIntentInput = {
+  account,
+  parentAccount,
+  transaction,
+};
+
+type BridgeMock = {
+  signOperation: jest.Mock<Observable<SignOperationEvent>, [unknown]>;
+};
+
+function createBridgeMock(events$: Observable<SignOperationEvent>): BridgeMock {
+  return {
+    signOperation: jest.fn((_params: unknown) => events$),
+  };
+}
+
+function mockGetAccountBridgeResolvedValue(bridge: BridgeMock) {
+  jest
+    .mocked(getAccountBridge)
+    .mockResolvedValue(bridge as unknown as Awaited<ReturnType<typeof getAccountBridge>>);
+}
+
+function startJob() {
+  return signTransactionIntentJob({ deviceConnectionResult, deviceExtractedContext, input });
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("signTransactionIntentJob", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(getMainAccount).mockReturnValue(mainAccount);
+  });
+
+  it("should sign with the main account and emit mapped bridge states", async () => {
+    const signOperationEvents: SignOperationEvent[] = [
+      { type: "device-signature-requested" },
+      { type: "device-streaming", progress: 0.42, index: 1, total: 2 },
+      { type: "device-signature-granted" },
+      { type: "signed", signedOperation },
+    ];
+    const bridge = createBridgeMock(of(...signOperationEvents));
+    mockGetAccountBridgeResolvedValue(bridge);
+
+    const states = await new Promise<SignTransactionIntentJobState[]>((resolve, reject) => {
+      const emittedStates: SignTransactionIntentJobState[] = [];
+
+      startJob().subscribe({
+        next: state => emittedStates.push(state),
+        error: reject,
+        complete: () => resolve(emittedStates),
+      });
+    });
+
+    expect(getMainAccount).toHaveBeenCalledWith(account, parentAccount);
+    expect(getAccountBridge).toHaveBeenCalledWith(mainAccount);
+    expect(bridge.signOperation).toHaveBeenCalledWith({
+      account: mainAccount,
+      transaction,
+      deviceId: "device-1",
+      deviceModelId,
+    });
+    expect(states).toEqual([
+      { type: "pending", deviceModelId },
+      { type: "device-signature-requested", deviceModelId },
+      { type: "device-streaming", progress: 0.42 },
+      { type: "device-signature-granted", deviceModelId },
+      { type: "signed", signedOperation },
+    ]);
+  });
+
+  it("should emit a cancellable state when the user refuses on device", async () => {
+    const bridge = createBridgeMock(throwError(() => new UserRefusedOnDevice()));
+    mockGetAccountBridgeResolvedValue(bridge);
+
+    const states: SignTransactionIntentJobState[] = [];
+    const subscription = startJob().subscribe(state => states.push(state));
+
+    await flushPromises();
+
+    expect(states).toHaveLength(2);
+    expect(states[0]).toEqual({ type: "pending", deviceModelId });
+    expect(states[1]).toEqual({
+      type: "cancelled",
+      retry: expect.any(Function),
+    });
+
+    subscription.unsubscribe();
+  });
+
+  it("should retry signing when a cancelled state retry is called", async () => {
+    const bridge = createBridgeMock(throwError(() => new TransportStatusError(0x6985)));
+    bridge.signOperation.mockReturnValueOnce(throwError(() => new TransportStatusError(0x6985)));
+    bridge.signOperation.mockReturnValueOnce(of({ type: "signed", signedOperation }));
+    mockGetAccountBridgeResolvedValue(bridge);
+
+    const states: SignTransactionIntentJobState[] = [];
+    const subscription = startJob().subscribe(state => states.push(state));
+
+    await flushPromises();
+    const cancelledState = states[1];
+    if (cancelledState?.type !== "cancelled") {
+      throw new Error("Expected cancelled state");
+    }
+
+    cancelledState.retry();
+    await flushPromises();
+
+    expect(bridge.signOperation).toHaveBeenCalledTimes(2);
+    expect(states).toEqual([
+      { type: "pending", deviceModelId },
+      { type: "cancelled", retry: expect.any(Function) },
+      { type: "pending", deviceModelId },
+      { type: "signed", signedOperation },
+    ]);
+
+    subscription.unsubscribe();
+  });
+
+  it("should normalize non Error bridge resolution failures", async () => {
+    jest.mocked(getAccountBridge).mockRejectedValue("bridge failed");
+
+    await expect(
+      new Promise<void>((resolve, reject) => {
+        startJob().subscribe({
+          next: () => undefined,
+          error: reject,
+          complete: resolve,
+        });
+      }),
+    ).rejects.toEqual(new Error("bridge failed"));
+  });
+
+  it("should ignore bridge resolution when unsubscribed before it completes", async () => {
+    let resolveBridge: (bridge: BridgeMock) => void = () => undefined;
+    const getBridgePromise = new Promise<BridgeMock>(resolve => {
+      resolveBridge = resolve;
+    });
+    const bridge = createBridgeMock(of({ type: "signed", signedOperation }));
+    jest
+      .mocked(getAccountBridge)
+      .mockReturnValue(getBridgePromise as unknown as ReturnType<typeof getAccountBridge>);
+
+    const states: SignTransactionIntentJobState[] = [];
+    const subscription = startJob().subscribe(state => states.push(state));
+
+    subscription.unsubscribe();
+    resolveBridge(bridge);
+    await flushPromises();
+
+    expect(states).toEqual([{ type: "pending", deviceModelId }]);
+    expect(bridge.signOperation).not.toHaveBeenCalled();
+  });
+});

--- a/libs/ledger-live-common/src/intents/signTransactionIntent/index.ts
+++ b/libs/ledger-live-common/src/intents/signTransactionIntent/index.ts
@@ -1,0 +1,9 @@
+export { signTransactionIntentJob } from "./job";
+export { signTransactionIntentDefinition } from "./intentDefinition";
+export type {
+  SignTransactionIntent,
+  SignTransactionIntentDefinition,
+  SignTransactionIntentInput,
+  SignTransactionIntentJobState,
+  SignTransactionIntentPlatformDefinition,
+} from "./types";

--- a/libs/ledger-live-common/src/intents/signTransactionIntent/intentDefinition.ts
+++ b/libs/ledger-live-common/src/intents/signTransactionIntent/intentDefinition.ts
@@ -1,0 +1,9 @@
+import { signTransactionIntentJob } from "./job";
+import type { SignTransactionIntentDefinition } from "./types";
+
+export const signTransactionIntentDefinition: SignTransactionIntentDefinition = {
+  label: "Sign transaction",
+  requiresConnectedDevice: true,
+  delegateDeviceLockStateHandlingToExecutor: false,
+  job: signTransactionIntentJob,
+};

--- a/libs/ledger-live-common/src/intents/signTransactionIntent/job.ts
+++ b/libs/ledger-live-common/src/intents/signTransactionIntent/job.ts
@@ -1,0 +1,120 @@
+import { TransportStatusError, UserRefusedOnDevice } from "@ledgerhq/errors";
+import type { DeviceConnectionResult, Job } from "@ledgerhq/device-intent";
+import { getMainAccount } from "../../account/index";
+import { getAccountBridge } from "../../bridge/index";
+import { TransactionRefusedOnDevice } from "../../errors";
+import type { DeviceModelId } from "@ledgerhq/types-devices";
+import type { SignOperationEvent } from "@ledgerhq/types-live";
+import { Observable, type Subscription } from "rxjs";
+import type { SignTransactionIntentInput, SignTransactionIntentJobState } from "./types";
+
+type SigningDevice = Readonly<{
+  deviceId: string;
+  modelId: DeviceModelId;
+}>;
+
+function buildSigningDevice(connectionResult: DeviceConnectionResult): SigningDevice {
+  return {
+    deviceId: connectionResult.compatDeviceId,
+    modelId: connectionResult.compatDeviceModelId,
+  };
+}
+
+function isUserRefusalError(error: unknown): boolean {
+  return (
+    error instanceof TransactionRefusedOnDevice ||
+    error instanceof UserRefusedOnDevice ||
+    (error instanceof TransportStatusError && error.statusCode === 0x6985)
+  );
+}
+
+function normalizeSignError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function mapSignOperationEvent(
+  event: SignOperationEvent,
+  deviceModelId: DeviceModelId,
+): SignTransactionIntentJobState | null {
+  switch (event.type) {
+    case "signed":
+      return { type: "signed", signedOperation: event.signedOperation };
+    case "device-signature-requested":
+      return { type: "device-signature-requested", deviceModelId };
+    case "device-streaming":
+      return { type: "device-streaming", progress: event.progress };
+    case "device-signature-granted":
+      return { type: "device-signature-granted", deviceModelId };
+    default:
+      return null;
+  }
+}
+
+export const signTransactionIntentJob: Job<
+  SignTransactionIntentJobState,
+  SignTransactionIntentInput
+> = ({ deviceConnectionResult, input }) => {
+  const device = buildSigningDevice(deviceConnectionResult);
+  const mainAccount = getMainAccount(input.account, input.parentAccount ?? undefined);
+
+  return new Observable<SignTransactionIntentJobState>(subscriber => {
+    let innerSubscription: Subscription | undefined;
+    let runRequestId = 0;
+
+    const run = () => {
+      const currentRunRequestId = ++runRequestId;
+      innerSubscription?.unsubscribe();
+      subscriber.next({ type: "pending", deviceModelId: device.modelId });
+
+      getAccountBridge(mainAccount)
+        .then(bridge => {
+          if (subscriber.closed || currentRunRequestId !== runRequestId) {
+            return;
+          }
+
+          innerSubscription = bridge
+            .signOperation({
+              account: mainAccount,
+              transaction: input.transaction,
+              deviceId: device.deviceId,
+              deviceModelId: device.modelId,
+            })
+            .subscribe({
+              next: event => {
+                const state = mapSignOperationEvent(event, device.modelId);
+                if (state) {
+                  subscriber.next(state);
+                }
+              },
+              // A user refusal is a terminal but non-error outcome: surface a dedicated
+              // "cancelled" state (info screen + retry) instead of letting the error escape
+              // the observable, which would otherwise trigger the executor's generic error screen.
+              error: error => {
+                if (isUserRefusalError(error)) {
+                  subscriber.next({ type: "cancelled", retry: run });
+                  return;
+                }
+                subscriber.error(normalizeSignError(error));
+              },
+              complete: () => {
+                subscriber.complete();
+              },
+            });
+        })
+        .catch(error => {
+          if (subscriber.closed || currentRunRequestId !== runRequestId) {
+            return;
+          }
+
+          subscriber.error(normalizeSignError(error));
+        });
+    };
+
+    run();
+
+    return () => {
+      runRequestId += 1;
+      innerSubscription?.unsubscribe();
+    };
+  });
+};

--- a/libs/ledger-live-common/src/intents/signTransactionIntent/types.ts
+++ b/libs/ledger-live-common/src/intents/signTransactionIntent/types.ts
@@ -1,0 +1,28 @@
+import type { Intent, IntentDefinition, IntentPlatformDefinition } from "@ledgerhq/device-intent";
+import type { DeviceModelId } from "@ledgerhq/types-devices";
+import type { SignatureRequest } from "../../flows/send/hooks/useSendFlowSignatureCore";
+import type { SignedOperation } from "@ledgerhq/types-live";
+
+export type SignTransactionIntentJobState =
+  | { type: "pending"; deviceModelId: DeviceModelId }
+  | { type: "device-signature-requested"; deviceModelId: DeviceModelId }
+  | { type: "device-signature-granted"; deviceModelId: DeviceModelId }
+  | { type: "device-streaming"; progress: number }
+  | { type: "signed"; signedOperation: SignedOperation }
+  | { type: "cancelled"; retry: () => void };
+
+export type SignTransactionIntentInput = SignatureRequest;
+
+export type SignTransactionIntentDefinition = IntentDefinition<
+  SignTransactionIntentJobState,
+  SignTransactionIntentInput
+>;
+
+export type SignTransactionIntentPlatformDefinition<ExtraProps = undefined> =
+  IntentPlatformDefinition<SignTransactionIntentJobState, SignTransactionIntentInput, ExtraProps>;
+
+export type SignTransactionIntent<ExtraProps = undefined> = Intent<
+  SignTransactionIntentJobState,
+  SignTransactionIntentInput,
+  ExtraProps
+>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7907,6 +7907,9 @@ importers:
       '@ledgerhq/device-core':
         specifier: workspace:^
         version: link:../device-core
+      '@ledgerhq/device-intent':
+        specifier: workspace:^
+        version: link:../device-intent
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
         version: 1.6.0(rxjs@7.8.2)
@@ -22034,7 +22037,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.0.0
       react-dom: 19.0.0
-      webpack: ^5.89.0
+      webpack: '*'
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -24359,7 +24362,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: ^5.5.10
+      rxjs: '*'
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

New send flow on LWM ; signature screen displaying the DeviceAction component and its various states.
Video demo (please don't mind the wip confirmation screen at the end)

https://github.com/user-attachments/assets/cc53fed6-ae55-4985-bb17-6b0bb542beb6



<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **[JIRA or GitHub link](https://ledgerhq.atlassian.net/browse/LIVE-31802)**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
