### PR TITLE
[LWD] fix(desktop): update analytics variation when time range changes

### DIFF
--- a/.changeset/chilled-bulldogs-brush.md
+++ b/.changeset/chilled-bulldogs-brush.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix Analytics page percentage variation not updating when changing the time range

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/__tests__/useAnalyticsViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/__tests__/useAnalyticsViewModel.test.ts
@@ -45,12 +45,29 @@ describe("useAnalyticsViewModel", () => {
     expect(result.current.selectedTimeRange).toBe("day");
     expect(result.current.shouldDisplayGraphRework).toBe(true);
     expect(result.current.balanceInfo).toEqual(mockPortfolioBalanceInfo);
-    expect(mockUsePortfolioBalanceDisplayState).toHaveBeenCalledWith();
+    expect(mockUsePortfolioBalanceDisplayState).toHaveBeenCalledWith({ legacyRange: false });
 
     act(() => {
       result.current.navigateToDashboard();
     });
 
     expect(navigate).toHaveBeenCalledWith("/");
+  });
+
+  it("should use legacyRange for non-day time ranges", () => {
+    mockedUseNavigate.mockReturnValue(jest.fn());
+
+    renderHook(() => useAnalyticsViewModel(), {
+      initialState: {
+        ...withFlagOverrides({ lwdWallet40: { enabled: true, params: { graphRework: true } } }),
+        settings: {
+          ...INITIAL_STATE,
+          counterValue: "USD",
+          selectedTimeRange: "week",
+        },
+      },
+    });
+
+    expect(mockUsePortfolioBalanceDisplayState).toHaveBeenCalledWith({ legacyRange: true });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/useAnalyticsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/useAnalyticsViewModel.ts
@@ -7,6 +7,7 @@ import {
 } from "~/renderer/reducers/settings";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import { usePortfolioBalanceDisplayState } from "LLD/hooks/usePortfolioBalanceDisplayState";
+import { DEFAULT_PORTFOLIO_RANGE } from "LLD/utils/constants";
 import type { AnalyticsViewModel } from "./types";
 
 export default function useAnalyticsViewModel(): AnalyticsViewModel {
@@ -15,7 +16,9 @@ export default function useAnalyticsViewModel(): AnalyticsViewModel {
   const selectedTimeRange = useSelector(selectedTimeRangeSelector);
   const { shouldDisplayGraphRework, shouldDisplayAssetSection } =
     useWalletFeaturesConfig("desktop");
-  const { balanceInfo } = usePortfolioBalanceDisplayState();
+  const { balanceInfo } = usePortfolioBalanceDisplayState({
+    legacyRange: selectedTimeRange !== DEFAULT_PORTFOLIO_RANGE,
+  });
 
   const navigateToDashboard = useCallback(() => {
     navigate("/");


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Analytics page (Desktop): percentage variation indicator
  - Verify the % variation updates when switching time ranges (day, week, month, year)
  - Verify the "day" range still shows the correct value (default range, `legacyRange: false`)

### 📝 Description

**Problem**: On the Analytics page (Desktop), the percentage variation did not update when changing the selected time range. The chart updated correctly, but the variation stayed fixed on the "day" value.

**Root cause**: The chart received `range={selectedTimeRange}` and updated correctly, but the percentage variation came from `balanceInfo.valueChange` produced by `usePortfolioBalanceDisplayState()` called with no options → `legacyRange: false` → `countervalueChange` was always computed over the hardcoded "day" range.

**Solution**: Pass `legacyRange` to `usePortfolioBalanceDisplayState` based on the selected time range, so the variation is computed over the actually selected range:

\`\`\`ts
const { balanceInfo } = usePortfolioBalanceDisplayState({
  legacyRange: selectedTimeRange !== DEFAULT_PORTFOLIO_RANGE,
});
\`\`\`


https://github.com/user-attachments/assets/b05f10ea-d302-4d4c-841b-faade629aa78




### ❓ Context

- **JIRA or GitHub link**: [LIVE-31981](https://ledgerhq.atlassian.net/browse/LIVE-31981)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31981]: https://ledgerhq.atlassian.net/browse/LIVE-31981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ