### PR TITLE
[LWD] test(ci): desktop-only perf experiment for #18124 (LIVE-31963)

### DIFF
--- a/apps/ledger-live-desktop/src/index.ts
+++ b/apps/ledger-live-desktop/src/index.ts
@@ -9,3 +9,5 @@ if (getEnv("PLAYWRIGHT_RUN") && getEnv("MOCK")) {
 }
 
 require("./main");
+
+// CI perf experiment (LIVE-31963): desktop-only no-op to validate PR #18124 runner change. Do not merge.


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — CI performance experiment

Controlled experiment to validate the runner-size / workflow-split change from #18124, branched **freshly off `develop`** (which already contains #18124) to remove the rebase-lag confound that makes post-merge PR data unreliable.

### What
- Single no-op comment in `apps/ledger-live-desktop/src/index.ts`, so nx marks **only `ledger-live-desktop` affected** → the `Desktop Lint & Unit Tests → Sonar` critical path runs **without** the mobile Detox chain.

### What we're measuring (vs #18124's predictions)
- `Desktop Lint & Unit Tests / Desktop Unit Tests` (Jest) — expected ~**202–305s** (was ~**825s**).
- **Sonar start offset** from run start — expected ~**8.5–9.5 min** (was ~**14–17 min**).
- **Sonar complete** — expected ~**14 min** into the run (was ~**21–23 min**).
- Overall desktop-only time-to-green — expected ~**6 min / ~28% faster**.

Paired with a mobile-affected experiment PR to confirm mobile-affected PRs barely move (Detox-bound). Close once timings are captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)