### PR TITLE
[LWM] test(ci): mobile-affected perf experiment for #18124 (LIVE-31963)

### DIFF
--- a/apps/ledger-live-mobile/src/logger.ts
+++ b/apps/ledger-live-mobile/src/logger.ts
@@ -95,3 +95,5 @@ export class ConsoleLogger {
     console.groupEnd();
   }
 }
+
+// CI perf experiment (LIVE-31963): mobile-affected no-op to validate PR #18124 runner change. Do not merge.


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — CI performance experiment

Companion to #18276. Controlled experiment branched **freshly off `develop`** (already contains #18124) to remove the rebase-lag confound.

### What
- Single no-op comment in `apps/ledger-live-mobile/src/logger.ts`, so nx marks **`ledger-live-mobile` affected** → the full mobile gate runs, including the **Detox build→test chain**.

### What we're measuring (vs #18124's predictions)
- `Codecheck Mobile / Mobile Unit Tests` (Jest, now on 16-CPU) — expected ~**274–313s**.
- **Mobile gate wall** = max(`Mobile Code Check`, `Mobile Unit Tests`) — expected ~**300–320s** (was a ~**790–899s** monolith).
- **Overall time-to-green** — expected to **barely move (~2%)**: the Detox chain (~**16–22 min**) is still the critical path, with the faster unit jobs running in parallel beneath it.

This PR confirms the *negative* prediction (mobile-affected PRs don't speed up much); #18276 confirms the desktop-only win. Close once timings are captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)