### PR TITLE
[LWM] refactor(mobile): remove outer navigation header from Borrow LiveApp

### DIFF
--- a/.changeset/borrow-remove-outer-navigation-header.md
+++ b/.changeset/borrow-remove-outer-navigation-header.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Remove the outer navigation header (with custom back button) wrapping the Borrow LiveApp so the LiveApp's own internal header/back button is used instead

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -26,7 +26,6 @@ import ExchangeLiveAppNavigator from "./ExchangeLiveAppNavigator";
 import { CardLiveAppNavigator } from "LLM/features/Card";
 import BorrowLiveAppNavigator from "./BorrowLiveAppNavigator";
 import EarnLiveAppNavigator from "./EarnLiveAppNavigator";
-import { useWallet40Theme } from "LLM/hooks/useWallet40Theme";
 import PlatformExchangeNavigator from "./PlatformExchangeNavigator";
 import AccountSettingsNavigator from "./AccountSettingsNavigator";
 import PasswordAddFlowNavigator from "./PasswordAddFlowNavigator";
@@ -175,7 +174,6 @@ export default function BaseNavigator() {
     }>
   >();
   const { colors } = useTheme();
-  const { backgroundColor } = useWallet40Theme("mobile");
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   const nativeStackScreenOptions: Partial<NativeStackNavigationOptions> = stackNavigationConfig;
   const noNanoBuyNanoWallScreenOptions = useNoNanoBuyNanoWallScreenOptions();

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -589,29 +589,7 @@ export default function BaseNavigator() {
         <Stack.Screen
           name={NavigatorName.Borrow}
           component={BorrowLiveAppNavigator}
-          options={props => {
-            return {
-              headerShown: true,
-              closable: false,
-              headerLeft: () => (
-                <NavigationHeaderBackButton
-                  onPress={nav => {
-                    nav.navigate(NavigatorName.Borrow, {
-                      screen: ScreenName.Borrow,
-                      params: {
-                        ...props.route?.params?.params,
-                        action: "go-back",
-                      },
-                    });
-                  }}
-                />
-              ),
-              headerTitle: t("borrow.title"),
-              headerRight: () => null,
-              headerStyle: { backgroundColor },
-              contentStyle: { backgroundColor },
-            };
-          }}
+          options={{ headerShown: false }}
         />
         <Stack.Screen
           name={NavigatorName.NoFundsFlow}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Pure navigation/UI tweak in `BaseNavigator.tsx`; validated via manual QA of the Borrow flow on device._
- [x] **Impact of the changes:**
  - Entering the Borrow LiveApp from the main app (Discover / entry points)
  - Header rendering inside the Borrow LiveApp (the LiveApp's own header should be the only one visible)
  - Back navigation: pressing back inside the Borrow LiveApp and at its root should correctly return to the previous screen
  - Hardware back button (Android) within the Borrow flow
  - No regression in adjacent stack screens (`NoFundsFlow`, `StakeFlow`)

### 📝 Description

The Borrow stack screen in `BaseNavigator` was rendering an outer navigation header on top of the Borrow LiveApp, including a custom `NavigationHeaderBackButton` that forwarded a synthetic `action: "go-back"` to the LiveApp via route params.

Now that the Borrow LiveApp ships its own internal header and back behavior, the outer header was duplicated and visually inconsistent. This PR sets `headerShown: false` on the Borrow stack screen so the LiveApp owns its chrome end-to-end.

```diff
 <Stack.Screen
   name={NavigatorName.Borrow}
   component={BorrowLiveAppNavigator}
-  options={props => {
-    return {
-      headerShown: true,
-      closable: false,
-      headerLeft: () => (
-        <NavigationHeaderBackButton
-          onPress={nav => {
-            nav.navigate(NavigatorName.Borrow, {
-              screen: ScreenName.Borrow,
-              params: {
-                ...props.route?.params?.params,
-                action: "go-back",
-              },
-            });
-          }}
-        />
-      ),
-      headerTitle: t("borrow.title"),
-      headerRight: () => null,
-      headerStyle: { backgroundColor },
-      contentStyle: { backgroundColor },
-    };
-  }}
+  options={{ headerShown: false }}
 />
```

<img width="726" height="1336" alt="image" src="https://github.com/user-attachments/assets/774eb842-1467-4332-9480-bd5116b59a8a" />
<img width="780" height="1348" alt="image" src="https://github.com/user-attachments/assets/547ab8b9-821c-43cf-964f-a99c61bcf5c6" />


### ❓ Context

- **JIRA or GitHub link**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
