### PR TITLE
[LWD] feat(desktop): add market top cards section shell

### DIFF
--- a/.changeset/smooth-eagles-type.md
+++ b/.changeset/smooth-eagles-type.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add the Market top cards section shell, a feature-flagged layout that renders three placeholder cards above the market list when asset discoverability is enabled.

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/MarketTopCardsSection.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/MarketTopCardsSection.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+type MarketTopCardsSectionProps = {
+  readonly children: React.ReactNode;
+};
+
+export function MarketTopCardsSection({ children }: MarketTopCardsSectionProps) {
+  return (
+    <section
+      className="grid grid-cols-3 gap-24 mb-24"
+      data-testid="market-top-cards-section"
+      aria-label="market top cards"
+    >
+      {children}
+    </section>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/__tests__/MarketTopCardsSection.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/__tests__/MarketTopCardsSection.test.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { render, screen, withFlagOverrides } from "tests/testSetup";
+import MarketTopCards from "../index";
+
+const assetDiscoverabilityOn = withFlagOverrides({
+  lwdWallet40: { enabled: true, params: { assetDiscoverability: true } },
+});
+
+const assetDiscoverabilityOff = withFlagOverrides({
+  lwdWallet40: { enabled: false },
+});
+
+describe("MarketTopCards", () => {
+  it("renders the section with three placeholder cards when assetDiscoverability is on", () => {
+    render(<MarketTopCards />, { initialState: assetDiscoverabilityOn });
+
+    expect(screen.getByRole("region", { name: /market top cards/i })).toBeVisible();
+    expect(screen.getByTestId("market-top-card-1")).toBeVisible();
+    expect(screen.getByTestId("market-top-card-2")).toBeVisible();
+    expect(screen.getByTestId("market-top-card-3")).toBeVisible();
+  });
+
+  it("renders nothing when assetDiscoverability is off", () => {
+    render(<MarketTopCards />, { initialState: assetDiscoverabilityOff });
+
+    expect(screen.queryByRole("region", { name: /market top cards/i })).toBeNull();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/MarketTopCardPlaceholder.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/MarketTopCardPlaceholder.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Skeleton, Tile, TileContent } from "@ledgerhq/lumen-ui-react";
+
+type MarketTopCardPlaceholderProps = {
+  readonly testId: string;
+};
+
+export function MarketTopCardPlaceholder({ testId }: MarketTopCardPlaceholderProps) {
+  return (
+    <Tile appearance="card" className="w-full" data-testid={testId} aria-hidden>
+      <Skeleton className="h-12 w-1/3 self-start rounded-full" />
+      <TileContent className="items-start text-left">
+        <Skeleton className="h-32 w-full rounded-12" />
+      </TileContent>
+    </Tile>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/hooks/useMarketTopCardsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/hooks/useMarketTopCardsViewModel.ts
@@ -1,0 +1,7 @@
+import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
+
+export function useMarketTopCardsViewModel() {
+  const { shouldDisplayAssetDiscoverability } = useWalletFeaturesConfig("desktop");
+
+  return { shouldRender: shouldDisplayAssetDiscoverability };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/index.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { MarketTopCardsSection } from "./MarketTopCardsSection";
+import { MarketTopCardPlaceholder } from "./components/MarketTopCardPlaceholder";
+import { useMarketTopCardsViewModel } from "./hooks/useMarketTopCardsViewModel";
+
+function MarketTopCards() {
+  const { shouldRender } = useMarketTopCardsViewModel();
+
+  if (!shouldRender) return null;
+
+  return (
+    <MarketTopCardsSection>
+      <MarketTopCardPlaceholder testId="market-top-card-1" />
+      <MarketTopCardPlaceholder testId="market-top-card-2" />
+      <MarketTopCardPlaceholder testId="market-top-card-3" />
+    </MarketTopCardsSection>
+  );
+}
+
+export { MarketTopCardsSection };
+export default MarketTopCards;

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/__integrations__/Market.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/__integrations__/Market.integration.test.tsx
@@ -108,10 +108,67 @@ const createSettingsState = (starredMarketCoins: string[] = []) => ({
 
 const marketFeatureFlagsState = withFlagOverrides({ lldRefreshMarketData: { enabled: false } });
 
+const marketWithTopCardsOn = withFlagOverrides({
+  lldRefreshMarketData: { enabled: false },
+  lwdWallet40: { enabled: true, params: { assetDiscoverability: true } },
+});
+
+const marketWithTopCardsOff = withFlagOverrides({
+  lldRefreshMarketData: { enabled: false },
+  lwdWallet40: { enabled: false },
+});
+
 describe("Market Integration", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     server.resetHandlers();
+  });
+
+  it("should render top cards section when assetDiscoverability is enabled", async () => {
+    server.use(
+      http.get(MARKET_API_ENDPOINT, () => {
+        return HttpResponse.json(MOCK_MARKET_CURRENCY_DATA);
+      }),
+    );
+
+    render(<Market />, {
+      withRampCatalog: true,
+      initialState: {
+        market: createMarketState(),
+        settings: createSettingsState(),
+        ...marketWithTopCardsOn,
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("region", { name: /market top cards/i })).toBeVisible();
+      expect(screen.getByTestId("market-top-card-1")).toBeVisible();
+      expect(screen.getByTestId("market-top-card-2")).toBeVisible();
+      expect(screen.getByTestId("market-top-card-3")).toBeVisible();
+    });
+  });
+
+  it("should not render top cards section when assetDiscoverability is disabled", async () => {
+    server.use(
+      http.get(MARKET_API_ENDPOINT, () => {
+        return HttpResponse.json(MOCK_MARKET_CURRENCY_DATA);
+      }),
+    );
+
+    render(<Market />, {
+      withRampCatalog: true,
+      initialState: {
+        market: createMarketState(),
+        settings: createSettingsState(),
+        ...marketWithTopCardsOff,
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Market")).toBeVisible();
+    });
+
+    expect(screen.queryByRole("region", { name: /market top cards/i })).toBeNull();
   });
 
   it("should render market page with header", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/index.tsx
@@ -10,6 +10,7 @@ import { useMarketListVirtualization } from "LLD/features/Market/hooks/useMarket
 import PageHeader from "LLD/components/PageHeader";
 import { useNavigate } from "react-router";
 import MarketList from "./screens/MarketList";
+import MarketTopCards from "./TopCards";
 
 const Container = styled(Flex).attrs({
   flex: "1",
@@ -129,6 +130,7 @@ export default function Market() {
           </Flex>
         </SelectBarContainer>
       </Flex>
+      <MarketTopCards />
       <MarketList {...marketData} virtualization={virtualization} />
     </Container>
   );


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Market page rendering when `assetDiscoverability` (lwdWallet40) is enabled — three placeholder cards should appear above the market list
      - Market page when the flag is off — the section must not render at all
      - Responsive three-column layout of the top cards row

### 📝 Description

This PR introduces the layout shell for the Market top cards row.

**Problem**: The Market page has no container for the upcoming top metric cards, and we want to land the layout independently before wiring real data.

**Solution**: Added a feature-flagged `MarketTopCards` feature under `mvvm/features/Market/TopCards`:

- `MarketTopCardsSection` — a pure, data-less responsive three-column grid shell
- `MarketTopCardPlaceholder` — a Lumen `Tile` + `Skeleton` placeholder card
- `useMarketTopCardsSectionViewModel` — gates rendering on `shouldDisplayAssetDiscoverability`
- Mounted in `Market/index.tsx` above the market list

The shell holds no data on purpose so the follow-up tickets (3–5) can replace each placeholder with a real metric card without reshaping the layout.

### 🖼 Screenshots
<img width="1397" height="470" alt="Screenshot 2026-06-08 at 11 12 05" src="https://github.com/user-attachments/assets/420b2cd7-efa5-40bc-b406-4059ae9876c5" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-29901](https://ledgerhq.atlassian.net/browse/LIVE-29901)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29901]: https://ledgerhq.atlassian.net/browse/LIVE-29901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ