### PR TITLE
chore(docs): extend examples in comments skill

### DIFF
--- a/.agents/skills/comments/SKILL.md
+++ b/.agents/skills/comments/SKILL.md
@@ -50,3 +50,28 @@ virtual-store-dir-max-length=80
 android.prefab.version=2.0.0
 virtual-store-dir-max-length=80
 ```
+
+## 🙅 When comments are not necessary
+
+Use test names rather than comments to explain none-obvious details:
+
+**❌ Bad**
+
+```ts
+it("diffs the current value against resolved when targeted", () => {
+  const { result } = renderHook(() => useJsonEditor(makeProps()));
+  act(() => result.current.setDiffTarget("resolved"));
+  // Current equals resolved → every line is unchanged.
+  expect(result.current.diffJson.every(l => l.state === "none")).toBe(true);
+});
+```
+
+**✅ Good**
+
+```ts
+it("resets the state of every line when the diff is resolved", () => {
+  const { result } = renderHook(() => useJsonEditor(makeProps()));
+  act(() => result.current.setDiffTarget("resolved"));
+  expect(result.current.diffJson.every(l => l.state === "none")).toBe(true);
+});
+```


### PR DESCRIPTION
### 📝 Description

We see comments being added in test files where the test name could be used instead.

This PR adds the following example to the existing `.agents/skills/comments/SKILL.md`

---

## 🙅 When comments are not necessary

Use test names rather than comments to explain none-obvious details:

**❌ Bad**

```ts
it("diffs the current value against resolved when targeted", () => {
  const { result } = renderHook(() => useJsonEditor(makeProps()));
  act(() => result.current.setDiffTarget("resolved"));
  // Current equals resolved → every line is unchanged.
  expect(result.current.diffJson.every(l => l.state === "none")).toBe(true);
});
```

**✅ Good**

```ts
it("resets the state of every line when the diff is resolved", () => {
  const { result } = renderHook(() => useJsonEditor(makeProps()));
  act(() => result.current.setDiffTarget("resolved"));
  expect(result.current.diffJson.every(l => l.state === "none")).toBe(true);
});
```
---


### ❓ Context

I've seen unnecessary comments quite a lot. Here's one recent example:
- https://github.com/LedgerHQ/ledger-live/pull/18177/changes#diff-1cbdc900b033605573dd650ffc50e641eff933bcf0f4721d57c95fda14ca8b08
