### PR TITLE
ci(libs): install lib dependencies in Libraries Test job

### DIFF
--- a/.github/workflows/test-libs-reusable.yml
+++ b/.github/workflows/test-libs-reusable.yml
@@ -54,7 +54,7 @@ jobs:
           region: ${{ secrets.AWS_CACHE_REGION }}
 
       - name: Install dependencies
-        run: pnpm i --filter="./libs/**"
+        run: pnpm i --filter="{./libs/**}..."
 
       - name: Run coverage on appropriate libraries
         run: |


### PR DESCRIPTION
### 📝 Description

The `Libraries Test` coverage job installs deps with `pnpm i --filter="./libs/**"`, which restricts the install to packages under `libs/` only. Workspace packages that live **outside** `libs/` — e.g. `@features/platform-feature-flags` (`features/platform/`) and `@shared/feature-flags` (`shared/`) — are never installed, so their own dependencies (`react-redux`, `zod`, …) are missing from disk.

This is invisible today because no `libs/` package depends on those source-consumed packages. It breaks as soon as one does: [#18237](https://github.com/LedgerHQ/ledger-live/pull/18237) makes `@ledgerhq/live-common` depend on `@features/platform-feature-flags` + `@shared/feature-flags`, and its jest suites then fail with `Cannot find module 'react-redux' … from useFeature.ts` / `Cannot find module 'zod' … from schema.ts`.

Switching to [`{./libs/**}...`](https://pnpm.io/filtering) installs the `libs/` packages **and their dependencies**, so source-consumed workspace deps resolve — without hardcoding `features`/`shared` paths.

### ❓ Context

The reusable workflow is pinned `@develop`, so this must land on `develop` to take effect for open PRs (notably [#18237](https://github.com/LedgerHQ/ledger-live/pull/18237)).
