### PR TITLE
[LWD] feat(desktop): add mood index card to market top cards

### DIFF
--- a/.changeset/mood-index-top-card.md
+++ b/.changeset/mood-index-top-card.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add the Mood index card to the Market top cards section, reusing the Fear & Greed data, gauge indicator and definition dialog. The card is shown in the middle slot when asset discoverability is enabled.

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/__tests__/MarketTopCardsSection.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/__tests__/MarketTopCardsSection.test.tsx
@@ -11,13 +11,14 @@ const assetDiscoverabilityOff = withFlagOverrides({
 });
 
 describe("MarketTopCards", () => {
-  it("renders the section with three placeholder cards when assetDiscoverability is on", () => {
+  it("renders the section with the side placeholders and the mood index card when assetDiscoverability is on", async () => {
     render(<MarketTopCards />, { initialState: assetDiscoverabilityOn });
 
     expect(screen.getByRole("region", { name: /market top cards/i })).toBeVisible();
     expect(screen.getByTestId("market-top-card-1")).toBeVisible();
-    expect(screen.getByTestId("market-top-card-2")).toBeVisible();
     expect(screen.getByTestId("market-top-card-3")).toBeVisible();
+
+    expect(await screen.findByTestId("mood-index-card")).toBeVisible();
   });
 
   it("renders nothing when assetDiscoverability is off", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/MoodIndexCard/MoodIndexCardView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/MoodIndexCard/MoodIndexCardView.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import type { FearAndGreedIndex } from "@ledgerhq/live-common/cmc-client/state-manager/types";
+import { getFearAndGreedTranslationKey } from "@ledgerhq/live-common/cmc-client/utils/fearAndGreed";
+import { Tile } from "@ledgerhq/lumen-ui-react";
+import { useTranslation } from "react-i18next";
+import { FearAndGreedIndicator } from "LLD/features/FearAndGreed/components/FearAndGreedIndicator";
+import { FearAndGreedDialog } from "LLD/features/FearAndGreed/components/FearAndGreedDialog";
+import { track } from "~/renderer/analytics/segment";
+
+export const MoodIndexCardView = ({ data }: { data: FearAndGreedIndex }) => {
+  const { t } = useTranslation();
+
+  const translationKey = getFearAndGreedTranslationKey(data.value);
+
+  const onClick = () => {
+    track("button_clicked", {
+      button: "mood_index",
+    });
+  };
+
+  return (
+    <FearAndGreedDialog>
+      <Tile
+        appearance="card"
+        className="w-full cursor-pointer"
+        data-testid="mood-index-card"
+        onClick={onClick}
+      >
+        <div className="flex w-full items-center justify-between gap-12">
+          <div className="flex flex-col items-start gap-4 text-left">
+            <span className="body-3 text-muted">{t("market.topCards.moodIndex.title")}</span>
+            <span className="body-2-semi-bold text-base">{t(translationKey)}</span>
+          </div>
+          <FearAndGreedIndicator value={data.value} />
+        </div>
+      </Tile>
+    </FearAndGreedDialog>
+  );
+};

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/MoodIndexCard/__tests__/MoodIndexCard.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/MoodIndexCard/__tests__/MoodIndexCard.test.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { render, screen, waitFor } from "tests/testSetup";
+import { server, http, HttpResponse } from "tests/server";
+import { MoodIndexCard } from "..";
+
+const FEAR_AND_GREED_URL = "https://proxycmc.api.live.ledger.com/v3/fear-and-greed/latest";
+
+describe("MoodIndexCard", () => {
+  it("shows a loading placeholder before the query resolves, then the card", async () => {
+    render(<MoodIndexCard />);
+
+    expect(screen.getByTestId("market-top-card-2")).toBeVisible();
+
+    expect(await screen.findByTestId("mood-index-card")).toBeVisible();
+  });
+
+  it("renders the mood index title and the sentiment classification", async () => {
+    render(<MoodIndexCard />);
+
+    expect(await screen.findByText("Mood index")).toBeVisible();
+    expect(screen.getByText("Greed")).toBeVisible();
+  });
+
+  it("opens the definition dialog when the card is clicked", async () => {
+    const { user } = render(<MoodIndexCard />);
+
+    const card = await screen.findByTestId("mood-index-card");
+    await user.click(card);
+
+    expect(await screen.findByTestId("fear-and-greed-dialog-content")).toBeVisible();
+  });
+
+  it("renders nothing on a scoped query error so the row stays intact", async () => {
+    server.use(http.get(FEAR_AND_GREED_URL, () => new HttpResponse(null, { status: 500 })));
+
+    const { container } = render(<MoodIndexCard />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("market-top-card-2")).not.toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("mood-index-card")).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/MoodIndexCard/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/MoodIndexCard/index.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { useFearAndGreedViewModel } from "LLD/features/FearAndGreed/hooks/useFearAndGreedViewModel";
+import { MarketTopCardPlaceholder } from "../MarketTopCardPlaceholder";
+import { MoodIndexCardView } from "./MoodIndexCardView";
+
+export function MoodIndexCard() {
+  const { data, isError, isLoading } = useFearAndGreedViewModel();
+
+  if (isLoading) {
+    return <MarketTopCardPlaceholder testId="market-top-card-2" />;
+  }
+
+  // Scoped error: keep the row intact, just don't render this card.
+  if (isError || !data) {
+    return null;
+  }
+
+  return <MoodIndexCardView data={data} />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { MarketTopCardsSection } from "./MarketTopCardsSection";
 import { MarketTopCardPlaceholder } from "./components/MarketTopCardPlaceholder";
+import { MoodIndexCard } from "./components/MoodIndexCard";
 import { useMarketTopCardsViewModel } from "./hooks/useMarketTopCardsViewModel";
 
 function MarketTopCards() {
@@ -11,7 +12,7 @@ function MarketTopCards() {
   return (
     <MarketTopCardsSection>
       <MarketTopCardPlaceholder testId="market-top-card-1" />
-      <MarketTopCardPlaceholder testId="market-top-card-2" />
+      <MoodIndexCard />
       <MarketTopCardPlaceholder testId="market-top-card-3" />
     </MarketTopCardsSection>
   );

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -1609,6 +1609,11 @@
   },
   "market": {
     "title": "Market",
+    "topCards": {
+      "moodIndex": {
+        "title": "Mood index"
+      }
+    },
     "currency": "Currency",
     "rangeLabel": "Time",
     "goBack": "Go back",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Mood index card render & sentiment classification from Fear & Greed data

### 📝 Description

This PR adds the **Mood index card** to the Market top cards section.

**Problem**: The middle slot of the Market top cards row was a placeholder with no real content.

**Solution**: The Mood index card reuses the existing Fear & Greed data, gauge indicator and definition dialog:

- Renders the mood index title and the sentiment classification for the current Fear & Greed value.
- Opens the Fear & Greed definition dialog on click (tracked via the `mood_index` button event).
- Shows a loading placeholder while the query resolves.
- On a scoped query error, renders nothing so the surrounding row stays intact.

The card is shown in the middle slot only when asset discoverability is enabled.

### 📸 Screenshots



https://github.com/user-attachments/assets/52487671-6536-4dd1-8fd7-8c02e9da5276



### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-29903

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29701]: https://ledgerhq.atlassian.net/browse/LIVE-29701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ