### PR TITLE
[LWM] fix(evm-staking): translate delegation amount error on mobile

### DIFF
--- a/.changeset/clumsy-bears-delegate.md
+++ b/.changeset/clumsy-bears-delegate.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix SEI delegation amount screen displaying the raw `NotEnoughBalance` error name instead of a translated message. The amount step now renders the error through `TranslatedError`, so an over-balance delegation shows "Sorry, insufficient funds".

--- a/apps/ledger-live-mobile/src/families/evm/DelegationFlow/02-SelectAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/DelegationFlow/02-SelectAmount.tsx
@@ -33,6 +33,7 @@ import CurrencyInput from "~/components/CurrencyInput";
 import CurrencyUnitValue from "~/components/CurrencyUnitValue";
 import KeyboardView from "~/components/KeyboardView";
 import LText from "~/components/LText";
+import TranslatedError from "~/components/TranslatedError";
 import SummaryRow from "~/screens/SendFunds/SummaryRow";
 import Warning from "~/icons/Warning";
 import { ScreenName } from "~/const";
@@ -80,7 +81,6 @@ export default function SelectAmount({ navigation, route }: Props) {
   const remaining = maxSpendable.minus(amount);
   const hasErrors = Object.keys(status.errors).length > 0;
   const firstError = Object.values(status.errors)[0];
-  const firstErrorMessage = firstError instanceof Error ? firstError.message : undefined;
   const canContinue =
     !bridgePending && !bridgeError && !hasErrors && amount.gt(0) && maxSpendable.gte(amount);
   const showLockUpWarning = hasUnbondingPeriod(account.currency.id);
@@ -191,11 +191,11 @@ export default function SelectAmount({ navigation, route }: Props) {
                   </Text>
                 </Flex>
               ) : null}
-              {firstErrorMessage ? (
+              {firstError instanceof Error ? (
                 <View style={styles.errorContainer}>
                   <Warning size={16} color={colors.error.c50} />
                   <LText style={styles.errorText} color="red">
-                    {firstErrorMessage}
+                    <TranslatedError error={firstError} />
                   </LText>
                 </View>
               ) : null}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No test added: the other screens in the EVM `DelegationFlow` have no unit tests, so this 3-line display fix follows the existing convention. The fix is a straightforward swap to the shared `TranslatedError` component._
- [x] **Impact of the changes:**
      - SEI delegation flow → amount step: enter an amount greater than the available balance and confirm the error reads "Sorry, insufficient funds" (and not the raw `NotEnoughBalance`).
      - Verify the Continue button stays disabled while the error is shown.
      - Sanity-check other EVM staking error states on the same screen still render correctly.

### 📝 Description

**Problem**: On the SEI delegation amount step (Ledger Live Mobile), delegating an amount larger than the balance showed the raw error name `NotEnoughBalance` instead of a readable, translated message.

**Solution**: The amount step rendered `firstError.message` directly. It now renders the error object through the shared `TranslatedError` component, which resolves `errors.NotEnoughBalance.title` → "Sorry, insufficient funds". If an error has no translation it falls back to the generic translated message, so a raw error name is never displayed again.

| Before | After |
| ------ | ----- |
| <img width="642" height="1524" alt="image" src="https://github.com/user-attachments/assets/4feed822-70af-41bc-ab98-c5837d82a2f9" /> | <img width="426" height="863" alt="Screenshot 2026-06-08 at 12 09 39" src="https://github.com/user-attachments/assets/d8398097-8ba0-4ed8-b04b-9ddb9743fdb1" /> |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31962](https://ledgerhq.atlassian.net/browse/LIVE-31962)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31962]: https://ledgerhq.atlassian.net/browse/LIVE-31962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ