### PR TITLE
[LWD] feat(desktop): add global market cap card to market top cards

### DIFF
--- a/.changeset/slimy-students-boil.md
+++ b/.changeset/slimy-students-boil.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add the global market cap card to the Market top cards section, displaying the total crypto market capitalization with its 24h trend and a definition dialog.

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/__tests__/MarketTopCardsSection.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/__tests__/MarketTopCardsSection.test.tsx
@@ -11,13 +11,13 @@ const assetDiscoverabilityOff = withFlagOverrides({
 });
 
 describe("MarketTopCards", () => {
-  it("renders the section with the side placeholders and the mood index card when assetDiscoverability is on", async () => {
+  it("renders the section with the global market cap card, the mood index card and the slot-3 placeholder when assetDiscoverability is on", async () => {
     render(<MarketTopCards />, { initialState: assetDiscoverabilityOn });
 
     expect(screen.getByRole("region", { name: /market top cards/i })).toBeVisible();
-    expect(screen.getByTestId("market-top-card-1")).toBeVisible();
     expect(screen.getByTestId("market-top-card-3")).toBeVisible();
 
+    expect(await screen.findByTestId("global-market-cap-card")).toBeVisible();
     expect(await screen.findByTestId("mood-index-card")).toBeVisible();
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/GlobalMarketCapCard/GlobalMarketCapCardView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/GlobalMarketCapCard/GlobalMarketCapCardView.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import {
+  Card,
+  CardHeader,
+  CardLeading,
+  CardContent,
+  CardContentDescription,
+  CardContentTitle,
+  Trend,
+} from "@ledgerhq/lumen-ui-react";
+import { useTranslation } from "react-i18next";
+import { GlobalMarketCapDialog } from "./GlobalMarketCapDialog";
+
+type GlobalMarketCapCardViewProps = {
+  value: string;
+  changePercentage?: number;
+  onClick: () => void;
+};
+
+export const GlobalMarketCapCardView = ({
+  value,
+  changePercentage,
+  onClick,
+}: GlobalMarketCapCardViewProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <GlobalMarketCapDialog>
+      <Card type="interactive" onClick={onClick} data-testid="global-market-cap-card">
+        <CardHeader>
+          <CardLeading>
+            <CardContent>
+              <CardContentTitle>
+                <span className="body-3">{t("market.topCards.globalMarketCap.title")}</span>
+              </CardContentTitle>
+              <CardContentDescription>
+                <div className="flex items-center gap-4">
+                  <span className="body-1-semi-bold text-base">{value}</span>
+                  {changePercentage !== undefined ? (
+                    <>
+                      <Trend value={changePercentage} size="md" />
+                      <span className="body-2 text-muted">
+                        · {t("market.topCards.globalMarketCap.period")}
+                      </span>
+                    </>
+                  ) : null}
+                </div>
+              </CardContentDescription>
+            </CardContent>
+          </CardLeading>
+        </CardHeader>
+      </Card>
+    </GlobalMarketCapDialog>
+  );
+};

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/GlobalMarketCapCard/GlobalMarketCapDialog.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/GlobalMarketCapCard/GlobalMarketCapDialog.tsx
@@ -1,0 +1,44 @@
+import React, { ReactNode, useState } from "react";
+import {
+  Dialog,
+  DialogTrigger,
+  DialogHeader,
+  DialogFooter,
+  DialogContent,
+  DialogBody,
+  Button,
+} from "@ledgerhq/lumen-ui-react";
+import { useTranslation } from "react-i18next";
+
+export const GlobalMarketCapDialog = ({ children }: { children: ReactNode }) => {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+
+      <DialogContent data-testid="global-market-cap-dialog-content">
+        <DialogHeader
+          density="expanded"
+          title={t("marketCapCard.dialog.title")}
+          onClose={() => setOpen(false)}
+        />
+        <DialogBody className="flex flex-col gap-24">
+          <p className="body-1 text-base">{t("marketCapCard.dialog.content")}</p>
+        </DialogBody>
+        <DialogFooter className="justify-center">
+          <Button
+            className="w-full"
+            appearance="base"
+            size="lg"
+            onClick={() => setOpen(false)}
+            data-testid="global-market-cap-dialog-cta"
+          >
+            {t("marketCapCard.dialog.cta")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/GlobalMarketCapCard/__tests__/GlobalMarketCapCard.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/GlobalMarketCapCard/__tests__/GlobalMarketCapCard.test.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { render, screen, waitFor } from "tests/testSetup";
+import { server, http, HttpResponse } from "tests/server";
+import { GlobalMarketCapCard } from "..";
+
+const GLOBAL_MARKET_URL = "https://countervalues.live.ledger.com/v3/markets/global";
+
+describe("GlobalMarketCapCard", () => {
+  it("shows a loading placeholder before the query resolves, then the card", async () => {
+    render(<GlobalMarketCapCard />);
+
+    expect(screen.getByTestId("market-top-card-1")).toBeVisible();
+
+    expect(await screen.findByTestId("global-market-cap-card")).toBeVisible();
+  });
+
+  it("renders the title and the 24h change", async () => {
+    render(<GlobalMarketCapCard />);
+
+    expect(await screen.findByText("Total market cap")).toBeVisible();
+    expect(screen.getByText("2.14%")).toBeVisible();
+  });
+
+  it("opens the definition dialog when the card is clicked", async () => {
+    const { user } = render(<GlobalMarketCapCard />);
+
+    const card = await screen.findByTestId("global-market-cap-card");
+    await user.click(card);
+
+    expect(await screen.findByTestId("global-market-cap-dialog-content")).toBeVisible();
+  });
+
+  it("renders nothing on a scoped query error so the row stays intact", async () => {
+    server.use(http.get(GLOBAL_MARKET_URL, () => new HttpResponse(null, { status: 500 })));
+
+    const { container } = render(<GlobalMarketCapCard />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("market-top-card-1")).not.toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("global-market-cap-card")).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/GlobalMarketCapCard/hooks/useGlobalMarketCapViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/GlobalMarketCapCard/hooks/useGlobalMarketCapViewModel.ts
@@ -1,0 +1,33 @@
+import { useSelector } from "LLD/hooks/redux";
+import { useGlobalMarketData } from "@ledgerhq/live-common/market/hooks/useMarketDataProvider";
+import counterValueFormatter from "@ledgerhq/live-common/market/utils/countervalueFormatter";
+import { counterValueCurrencySelector, localeSelector } from "~/renderer/reducers/settings";
+import { track } from "~/renderer/analytics/segment";
+
+export const useGlobalMarketCapViewModel = () => {
+  const counterCurrency = useSelector(counterValueCurrencySelector).ticker.toLowerCase();
+  const locale = useSelector(localeSelector);
+
+  const { data, isLoading, isError } = useGlobalMarketData({ counterCurrency });
+
+  const onClick = () => {
+    track("button_clicked", {
+      button: "market_cap",
+    });
+  };
+
+  return {
+    value: data
+      ? counterValueFormatter({
+          currency: counterCurrency.toUpperCase(),
+          value: data.marketCap,
+          shorten: true,
+          locale,
+        })
+      : "",
+    changePercentage: data?.changePercentage24h,
+    isLoading,
+    isError: isError || !data,
+    onClick,
+  };
+};

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/GlobalMarketCapCard/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/GlobalMarketCapCard/index.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { MarketTopCardPlaceholder } from "../MarketTopCardPlaceholder";
+import { GlobalMarketCapCardView } from "./GlobalMarketCapCardView";
+import { useGlobalMarketCapViewModel } from "./hooks/useGlobalMarketCapViewModel";
+
+export function GlobalMarketCapCard() {
+  const { value, changePercentage, isLoading, isError, onClick } = useGlobalMarketCapViewModel();
+
+  if (isLoading) {
+    return <MarketTopCardPlaceholder testId="market-top-card-1" />;
+  }
+
+  if (isError) {
+    return null;
+  }
+
+  return (
+    <GlobalMarketCapCardView value={value} changePercentage={changePercentage} onClick={onClick} />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/MoodIndexCard/MoodIndexCardView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/MoodIndexCard/MoodIndexCardView.tsx
@@ -1,39 +1,48 @@
 import React from "react";
 import type { FearAndGreedIndex } from "@ledgerhq/live-common/cmc-client/state-manager/types";
 import { getFearAndGreedTranslationKey } from "@ledgerhq/live-common/cmc-client/utils/fearAndGreed";
-import { Tile } from "@ledgerhq/lumen-ui-react";
+import {
+  Card,
+  CardHeader,
+  CardLeading,
+  CardContent,
+  CardContentDescription,
+  CardContentTitle,
+  CardTrailing,
+} from "@ledgerhq/lumen-ui-react";
 import { useTranslation } from "react-i18next";
 import { FearAndGreedIndicator } from "LLD/features/FearAndGreed/components/FearAndGreedIndicator";
 import { FearAndGreedDialog } from "LLD/features/FearAndGreed/components/FearAndGreedDialog";
-import { track } from "~/renderer/analytics/segment";
 
-export const MoodIndexCardView = ({ data }: { data: FearAndGreedIndex }) => {
+type MoodIndexCardViewProps = {
+  data: FearAndGreedIndex;
+  onClick: () => void;
+};
+
+export const MoodIndexCardView = ({ data, onClick }: MoodIndexCardViewProps) => {
   const { t } = useTranslation();
 
   const translationKey = getFearAndGreedTranslationKey(data.value);
 
-  const onClick = () => {
-    track("button_clicked", {
-      button: "mood_index",
-    });
-  };
-
   return (
     <FearAndGreedDialog>
-      <Tile
-        appearance="card"
-        className="w-full cursor-pointer"
-        data-testid="mood-index-card"
-        onClick={onClick}
-      >
-        <div className="flex w-full items-center justify-between gap-12">
-          <div className="flex flex-col items-start gap-4 text-left">
-            <span className="body-3 text-muted">{t("market.topCards.moodIndex.title")}</span>
-            <span className="body-2-semi-bold text-base">{t(translationKey)}</span>
-          </div>
-          <FearAndGreedIndicator value={data.value} />
-        </div>
-      </Tile>
+      <Card type="interactive" onClick={onClick} data-testid="mood-index-card">
+        <CardHeader>
+          <CardLeading>
+            <CardContent>
+              <CardContentTitle>
+                <span className="body-3">{t("market.topCards.moodIndex.title")}</span>
+              </CardContentTitle>
+              <CardContentDescription>
+                <span className="body-1-semi-bold text-base">{t(translationKey)}</span>
+              </CardContentDescription>
+            </CardContent>
+          </CardLeading>
+          <CardTrailing>
+            <FearAndGreedIndicator value={data.value} />
+          </CardTrailing>
+        </CardHeader>
+      </Card>
     </FearAndGreedDialog>
   );
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/MoodIndexCard/hooks/useMoodIndexCardViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/MoodIndexCard/hooks/useMoodIndexCardViewModel.ts
@@ -1,0 +1,19 @@
+import { useFearAndGreedViewModel } from "LLD/features/FearAndGreed/hooks/useFearAndGreedViewModel";
+import { track } from "~/renderer/analytics/segment";
+
+export const useMoodIndexCardViewModel = () => {
+  const { data, isError, isLoading } = useFearAndGreedViewModel();
+
+  const onClick = () => {
+    track("button_clicked", {
+      button: "mood_index",
+    });
+  };
+
+  return {
+    data,
+    isError,
+    isLoading,
+    onClick,
+  };
+};

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/MoodIndexCard/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/MoodIndexCard/index.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { useFearAndGreedViewModel } from "LLD/features/FearAndGreed/hooks/useFearAndGreedViewModel";
 import { MarketTopCardPlaceholder } from "../MarketTopCardPlaceholder";
 import { MoodIndexCardView } from "./MoodIndexCardView";
+import { useMoodIndexCardViewModel } from "./hooks/useMoodIndexCardViewModel";
 
 export function MoodIndexCard() {
-  const { data, isError, isLoading } = useFearAndGreedViewModel();
+  const { data, isError, isLoading, onClick } = useMoodIndexCardViewModel();
 
   if (isLoading) {
     return <MarketTopCardPlaceholder testId="market-top-card-2" />;
@@ -15,5 +15,5 @@ export function MoodIndexCard() {
     return null;
   }
 
-  return <MoodIndexCardView data={data} />;
+  return <MoodIndexCardView data={data} onClick={onClick} />;
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { MarketTopCardsSection } from "./MarketTopCardsSection";
 import { MarketTopCardPlaceholder } from "./components/MarketTopCardPlaceholder";
+import { GlobalMarketCapCard } from "./components/GlobalMarketCapCard";
 import { MoodIndexCard } from "./components/MoodIndexCard";
 import { useMarketTopCardsViewModel } from "./hooks/useMarketTopCardsViewModel";
 
@@ -11,7 +12,7 @@ function MarketTopCards() {
 
   return (
     <MarketTopCardsSection>
-      <MarketTopCardPlaceholder testId="market-top-card-1" />
+      <GlobalMarketCapCard />
       <MoodIndexCard />
       <MarketTopCardPlaceholder testId="market-top-card-3" />
     </MarketTopCardsSection>

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -1612,6 +1612,10 @@
     "topCards": {
       "moodIndex": {
         "title": "Mood index"
+      },
+      "globalMarketCap": {
+        "title": "Total market cap",
+        "period": "Today"
       }
     },
     "currency": "Currency",
@@ -8719,6 +8723,13 @@
       "title": "Mood index",
       "content": "Shows overall market sentiment from 0 to 100, based notably on volatility, market momentum and social trends. Lower values indicate fear, higher values indicate greed.",
       "disclaimer": "Data is sourced from CoinMarketCap's Fear and Greed Index and provided for informational purposes only.",
+      "cta": "Got it"
+    }
+  },
+  "marketCapCard": {
+    "dialog": {
+      "title": "Total market cap",
+      "content": "The total market cap represents the market capitalization of all cryptocurrencies combined.",
       "cta": "Got it"
     }
   },

--- a/apps/ledger-live-desktop/tests/handlers/market.ts
+++ b/apps/ledger-live-desktop/tests/handlers/market.ts
@@ -21,6 +21,12 @@ const handlers = [
       ],
     });
   }),
+  http.get("https://countervalues.live.ledger.com/v3/markets/global", () => {
+    return HttpResponse.json({
+      marketCap: 2_500_000_000_000,
+      percentageChanges: { "1d": 0.0214 },
+    });
+  }),
 ];
 
 export default handlers;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Market top cards section rendering (slot 1 now shows the global market cap card)
      - Global market cap value formatting and 24h trend display
      - Loading placeholder and scoped error handling (card renders nothing on query error, row stays intact)
      - Definition dialog open/close behavior on card click
      - Mood index card refactor to the `Card` component (no visual regression)

### 📝 Description

The Market top cards section had a placeholder in its first slot with no real content for the global market overview.

This PR adds the **Global Market Cap card**, which displays the total crypto market capitalization, its 24h trend, and a definition dialog explaining what the metric represents. The card consumes `useGlobalMarketData` from live-common and formats the value with `counterValueFormatter` based on the user's counter value currency and locale. While loading it renders the existing top-card placeholder, and on a scoped query error it renders nothing so the rest of the row stays intact.

The mood index card was also refactored from `Tile` to the shared `Card` component and had its view model extracted into a dedicated hook for consistency with the new card.


https://github.com/user-attachments/assets/b48ea425-d0f6-43df-9879-07311eb47d2f



### ❓ Context

- **JIRA or GitHub link**: [LIVE-29902](https://ledgerhq.atlassian.net/browse/LIVE-29902)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LIVE-29902]: https://ledgerhq.atlassian.net/browse/LIVE-29902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ