### PR TITLE
test(e2e-swap): drop hardcoded amounts from runSwapTest specs

### DIFF
--- a/e2e/mobile/specs/swap/swap.ts
+++ b/e2e/mobile/specs/swap/swap.ts
@@ -3,6 +3,7 @@ import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { setEnv } from "@ledgerhq/live-env";
 import { performSwapUntilQuoteSelectionStep } from "../../utils/swapUtils";
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { Fee } from "@ledgerhq/live-common/e2e/enum/Fee";
 import { setTeamOwner } from "../../helpers/allure/allure-helper";
 import { beforeAllFunctionSwap } from "./swap.setup";
 
@@ -25,7 +26,16 @@ const beforeAllFunction = async (swap: SwapType) => {
   });
 };
 
-export function runSwapTest(swap: SwapType, tmsLinks: string[], tags: string[]) {
+export function runSwapTest(
+  accountToDebit: Account,
+  accountToCredit: Account,
+  tmsLinks: string[],
+  tags: string[],
+  fee: Fee = Fee.MEDIUM,
+) {
+  // The amount is resolved at runtime from the provider minimum and set on `swap` inside the test.
+  const swap = new Swap(accountToDebit, accountToCredit, "", undefined, fee);
+
   describe("Swap - Accepted (without tx broadcast)", () => {
     beforeAll(async () => {
       await beforeAllFunction(swap);
@@ -34,21 +44,15 @@ export function runSwapTest(swap: SwapType, tmsLinks: string[], tags: string[]) 
     setTeamOwner(Team.SWAP);
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
-    it(`Swap ${swap.accountToDebit.currency.name} to ${swap.accountToCredit.currency.name}`, async () => {
-      const minAmount = await app.swapLiveApp.getMinimumAmount(
-        swap.accountToDebit,
-        swap.accountToCredit,
-      );
+    it(`Swap ${accountToDebit.currency.name} to ${accountToCredit.currency.name}`, async () => {
+      const minAmount = await app.swapLiveApp.getMinimumAmount(accountToDebit, accountToCredit);
       const swapAmount =
-        swap.accountToDebit.currency.name === Account.XRP_1.currency.name
+        accountToDebit.currency.name === Account.XRP_1.currency.name
           ? parseFloat(Number(minAmount).toFixed(6)).toString()
           : minAmount;
+      swap.amount = swapAmount;
 
-      await performSwapUntilQuoteSelectionStep(
-        swap.accountToDebit,
-        swap.accountToCredit,
-        swapAmount,
-      );
+      await performSwapUntilQuoteSelectionStep(accountToDebit, accountToCredit, swapAmount);
 
       const provider = await app.swapLiveApp.selectExchange();
       await app.swapLiveApp.checkExchangeButtonHasProviderName(provider.uiName);

--- a/e2e/mobile/specs/swap/swapBTC_NATIVE_SEGWIT_ETH.spec.ts
+++ b/e2e/mobile/specs/swap/swapBTC_NATIVE_SEGWIT_ETH.spec.ts
@@ -1,9 +1,9 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { runSwapTest } from "./swap";
 
-const swap = new Swap(Account.BTC_NATIVE_SEGWIT_1, Account.ETH_1, "0.0006", undefined, Fee.MEDIUM);
 runSwapTest(
-  swap,
+  Account.BTC_NATIVE_SEGWIT_1,
+  Account.ETH_1,
   ["B2CQA-2744", "B2CQA-2432", "B2CQA-3450"],
   [
     "@NanoSP",

--- a/e2e/mobile/specs/swap/swapBTC_NATIVE_SEGWIT_ETH_USDT.spec.ts
+++ b/e2e/mobile/specs/swap/swapBTC_NATIVE_SEGWIT_ETH_USDT.spec.ts
@@ -1,15 +1,9 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { runSwapTest } from "./swap";
 
-const swap = new Swap(
+runSwapTest(
   Account.BTC_NATIVE_SEGWIT_1,
   TokenAccount.ETH_USDT_1,
-  "0.0006",
-  undefined,
-  Fee.MEDIUM,
-);
-runSwapTest(
-  swap,
   ["B2CQA-2746"],
   [
     "@NanoSP",

--- a/e2e/mobile/specs/swap/swapBTC_NATIVE_SEGWIT_LTC.spec.ts
+++ b/e2e/mobile/specs/swap/swapBTC_NATIVE_SEGWIT_LTC.spec.ts
@@ -1,9 +1,9 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { runSwapTest } from "./swap";
 
-const swap = new Swap(Account.BTC_NATIVE_SEGWIT_1, Account.LTC_1, "0.0006", undefined, Fee.MEDIUM);
 runSwapTest(
-  swap,
+  Account.BTC_NATIVE_SEGWIT_1,
+  Account.LTC_1,
   ["B2CQA-3078"],
   [
     "@NanoSP",

--- a/e2e/mobile/specs/swap/swapBTC_NATIVE_SEGWIT_SOL.spec.ts
+++ b/e2e/mobile/specs/swap/swapBTC_NATIVE_SEGWIT_SOL.spec.ts
@@ -1,9 +1,9 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { runSwapTest } from "./swap";
 
-const swap = new Swap(Account.BTC_NATIVE_SEGWIT_1, Account.SOL_1, "0.0006", undefined, Fee.MEDIUM);
 runSwapTest(
-  swap,
+  Account.BTC_NATIVE_SEGWIT_1,
+  Account.SOL_1,
   ["B2CQA-2747"],
   [
     "@NanoSP",

--- a/e2e/mobile/specs/swap/swapETH_BTC.spec.ts
+++ b/e2e/mobile/specs/swap/swapETH_BTC.spec.ts
@@ -1,9 +1,9 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { runSwapTest } from "./swap";
 
-const swap = new Swap(Account.ETH_1, Account.BTC_NATIVE_SEGWIT_1, "0.018", undefined, Fee.MEDIUM);
 runSwapTest(
-  swap,
+  Account.ETH_1,
+  Account.BTC_NATIVE_SEGWIT_1,
   ["B2CQA-2750", "B2CQA-3135", "B2CQA-620"],
   [
     "@NanoSP",

--- a/e2e/mobile/specs/swap/swapETH_DOT.spec.ts
+++ b/e2e/mobile/specs/swap/swapETH_DOT.spec.ts
@@ -1,8 +1,8 @@
 import { runSwapTest } from "./swap";
 
-const swap = new Swap(Account.ETH_1, Account.DOT_1, "0.02", undefined, Fee.MEDIUM);
 runSwapTest(
-  swap,
+  Account.ETH_1,
+  Account.DOT_1,
   ["B2CQA-3017"],
   [
     "@NanoSP",

--- a/e2e/mobile/specs/swap/swapETH_ETH_USDT.spec.ts
+++ b/e2e/mobile/specs/swap/swapETH_ETH_USDT.spec.ts
@@ -1,9 +1,9 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { runSwapTest } from "./swap";
 
-const swap = new Swap(Account.ETH_1, TokenAccount.ETH_USDT_1, "0.018", undefined, Fee.MEDIUM);
 runSwapTest(
-  swap,
+  Account.ETH_1,
+  TokenAccount.ETH_USDT_1,
   ["B2CQA-2749"],
   ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@ethereum", "@family-evm"],
 );

--- a/e2e/mobile/specs/swap/swapETH_SOL.spec.ts
+++ b/e2e/mobile/specs/swap/swapETH_SOL.spec.ts
@@ -1,9 +1,9 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { runSwapTest } from "./swap";
 
-const swap = new Swap(Account.ETH_1, Account.SOL_1, "0.018", undefined, Fee.MEDIUM);
 runSwapTest(
-  swap,
+  Account.ETH_1,
+  Account.SOL_1,
   ["B2CQA-2748"],
   [
     "@NanoSP",

--- a/e2e/mobile/specs/swap/swapETH_USDC_BTC.spec.ts
+++ b/e2e/mobile/specs/swap/swapETH_USDC_BTC.spec.ts
@@ -1,15 +1,9 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { runSwapTest } from "./swap";
 
-const swap = new Swap(
+runSwapTest(
   TokenAccount.ETH_USDC_1,
   Account.BTC_NATIVE_SEGWIT_1,
-  "65",
-  undefined,
-  Fee.MEDIUM,
-);
-runSwapTest(
-  swap,
   ["B2CQA-2832", "B2CQA-3281"],
   [
     "@NanoSP",

--- a/e2e/mobile/specs/swap/swapETH_USDC_ETH.spec.ts
+++ b/e2e/mobile/specs/swap/swapETH_USDC_ETH.spec.ts
@@ -1,9 +1,9 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { runSwapTest } from "./swap";
 
-const swap = new Swap(TokenAccount.ETH_USDC_1, Account.ETH_1, "65", undefined, Fee.MEDIUM);
 runSwapTest(
-  swap,
+  TokenAccount.ETH_USDC_1,
+  Account.ETH_1,
   ["B2CQA-2830"],
   ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@ethereum", "@family-evm"],
 );

--- a/e2e/mobile/specs/swap/swapETH_USDT_BTC.spec.ts
+++ b/e2e/mobile/specs/swap/swapETH_USDT_BTC.spec.ts
@@ -1,15 +1,9 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { runSwapTest } from "./swap";
 
-const swap = new Swap(
+runSwapTest(
   TokenAccount.ETH_USDT_1,
   Account.BTC_NATIVE_SEGWIT_1,
-  "40",
-  undefined,
-  Fee.MEDIUM,
-);
-runSwapTest(
-  swap,
   ["B2CQA-2753"],
   [
     "@NanoSP",

--- a/e2e/mobile/specs/swap/swapETH_USDT_ETH.spec.ts
+++ b/e2e/mobile/specs/swap/swapETH_USDT_ETH.spec.ts
@@ -1,9 +1,9 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { runSwapTest } from "./swap";
 
-const swap = new Swap(TokenAccount.ETH_USDT_1, Account.ETH_1, "40", undefined, Fee.MEDIUM);
 runSwapTest(
-  swap,
+  TokenAccount.ETH_USDT_1,
+  Account.ETH_1,
   ["B2CQA-2752", "B2CQA-2048"],
   ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@ethereum", "@family-evm"],
 );

--- a/e2e/mobile/specs/swap/swapETH_USDT_SOL.spec.ts
+++ b/e2e/mobile/specs/swap/swapETH_USDT_SOL.spec.ts
@@ -1,9 +1,9 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { runSwapTest } from "./swap";
 
-const swap = new Swap(TokenAccount.ETH_USDT_1, Account.SOL_1, "60", undefined, Fee.MEDIUM);
 runSwapTest(
-  swap,
+  TokenAccount.ETH_USDT_1,
+  Account.SOL_1,
   ["B2CQA-2751"],
   [
     "@NanoSP",

--- a/e2e/mobile/specs/swap/swapHBAR_XRP.spec.ts
+++ b/e2e/mobile/specs/swap/swapHBAR_XRP.spec.ts
@@ -1,9 +1,9 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { runSwapTest } from "./swap";
 
-const swap = new Swap(Account.HEDERA_1, Account.XRP_1, "15", undefined, Fee.MEDIUM);
 runSwapTest(
-  swap,
+  Account.HEDERA_1,
+  Account.XRP_1,
   ["B2CQA-3753"],
   [
     "@NanoSP",

--- a/e2e/mobile/specs/swap/swapSOL_BTC.spec.ts
+++ b/e2e/mobile/specs/swap/swapSOL_BTC.spec.ts
@@ -1,9 +1,9 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { runSwapTest } from "./swap";
 
-const swap = new Swap(Account.SOL_1, Account.BTC_NATIVE_SEGWIT_1, "0.3", undefined, Fee.MEDIUM);
 runSwapTest(
-  swap,
+  Account.SOL_1,
+  Account.BTC_NATIVE_SEGWIT_1,
   ["B2CQA-2776"],
   [
     "@NanoSP",

--- a/e2e/mobile/specs/swap/swapSOL_ETH.spec.ts
+++ b/e2e/mobile/specs/swap/swapSOL_ETH.spec.ts
@@ -1,9 +1,9 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { runSwapTest } from "./swap";
 
-const swap = new Swap(Account.SOL_1, Account.ETH_1, "0.3", undefined, Fee.MEDIUM);
 runSwapTest(
-  swap,
+  Account.SOL_1,
+  Account.ETH_1,
   ["B2CQA-2775"],
   [
     "@NanoSP",

--- a/e2e/mobile/specs/swap/swapXRP_BTC.spec.ts
+++ b/e2e/mobile/specs/swap/swapXRP_BTC.spec.ts
@@ -1,9 +1,9 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { runSwapTest } from "./swap";
 
-const swap = new Swap(Account.XRP_1, Account.BTC_NATIVE_SEGWIT_1, "15", undefined, Fee.MEDIUM);
 runSwapTest(
-  swap,
+  Account.XRP_1,
+  Account.BTC_NATIVE_SEGWIT_1,
   ["B2CQA-3077", "B2CQA-3281"],
   [
     "@NanoSP",

--- a/e2e/mobile/specs/swap/swapXRP_ETH_USDC.spec.ts
+++ b/e2e/mobile/specs/swap/swapXRP_ETH_USDC.spec.ts
@@ -1,9 +1,9 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { runSwapTest } from "./swap";
 
-const swap = new Swap(Account.XRP_1, TokenAccount.ETH_USDC_1, "15", undefined, Fee.MEDIUM);
 runSwapTest(
-  swap,
+  Account.XRP_1,
+  TokenAccount.ETH_USDC_1,
   ["B2CQA-3075"],
   [
     "@NanoSP",


### PR DESCRIPTION
### ✅ Checklist

- [x] **Changeset:** not required — changes are limited to `e2e/` (the `ledger-live-mobile-e2e-tests` package is private/unpublished).
- [x] **Covered by automatic tests.** _Refactor of existing swap E2E specs with no runtime behavior change; the same specs run on CI. `pnpm --filter ledger-live-mobile-e2e-tests typecheck` passes locally — Detox specs can't run locally (need Speculos + a simulator)._
- [x] **Impact of the changes:**
  - The "Swap - Accepted (without tx broadcast)" specs across all 18 coin pairs (ETH↔BTC/SOL/USDC/USDT, XRP, HBAR, DOT, LTC, …).
  - No behavior change: the swap amount was already resolved at runtime from the provider minimum; only the dead hardcoded value moved out and `Swap` construction moved into `runSwapTest`.

### 📝 Description

Follow-up to QAA-722. Mobile swap specs calling `runSwapTest` still passed a hardcoded amount to the `Swap` constructor (e.g. `new Swap(TokenAccount.ETH_USDC_1, Account.ETH_1, "65", undefined, Fee.MEDIUM)`), even though the value was **always overridden** at runtime by `app.swapLiveApp.getMinimumAmount(...)` inside `runSwapTest`. The literal `"65"` was dead and misleading — a reader assumes it drives the test.

`runSwapTest(swap, tmsLinks, tags)` becomes `runSwapTest(accountToDebit, accountToCredit, tmsLinks, tags, fee = Fee.MEDIUM)`. The `Swap` is now built inside `runSwapTest` and the dynamic provider-minimum amount is assigned to it at runtime. The 18 consuming specs pass the two accounts directly, dropping the dead amount, the `undefined` provider, and the redundant `Fee.MEDIUM` (now the default).

History / export / different-seed specs are intentionally **left untouched** — they assert on `swap.amount` and need an explicit value. The `Swap` constructor is unchanged (`amount` kept required), so those specs are unaffected.

```ts
// before — in each spec
const swap = new Swap(TokenAccount.ETH_USDC_1, Account.ETH_1, "65", undefined, Fee.MEDIUM);
runSwapTest(swap, ["B2CQA-2830"], [...tags]);

// after
runSwapTest(TokenAccount.ETH_USDC_1, Account.ETH_1, ["B2CQA-2830"], [...tags]);
```

### ❓ Context

- **JIRA or GitHub link**: [QAA-1227](https://ledgerhq.atlassian.net/browse/QAA-1227)
- **Manual CI**: https://github.com/LedgerHQ/ledger-live/actions/runs/27194786466
---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[QAA-1227]: https://ledgerhq.atlassian.net/browse/QAA-1227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ