### PR TITLE
[LWM] refactor(mobile): drop DIE cancellableUI prop in favor of ModalLock

### DIFF
--- a/.changeset/die-modallock-dismissability.md
+++ b/.changeset/die-modallock-dismissability.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@ledgerhq/device-intent": minor
+---
+
+Replace the DeviceIntentExecutor `cancellableUI` prop with the `ModalLock` pattern to control bottom sheet dismissability. The drawer is now locked (no close button, backdrop and pan-down disabled) while a device action is pending or in progress (unlock, allow secure connection, confirm open app, installing app, loading), and dismissable otherwise.

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/AllowSecureConnectionState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/AllowSecureConnectionState.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { DeviceInteractionRequiredType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
 import { ContinueOnDevice } from "LLM/components/DeviceIntentExecutor/components/DeviceGenericStates/ContinueOnDevice";
 import { TrackScreen } from "~/analytics";
+import ModalLock from "~/components/ModalLock";
 import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import type { BaseInitializerStateProps } from "../types";
 
@@ -15,6 +16,7 @@ export function AllowSecureConnectionState({
 }: AllowSecureConnectionStateProps) {
   return (
     <>
+      <ModalLock />
       <TrackScreen
         category={PAGE_CONNECT_APP.AllowSecureConnection}
         sourceFlow={sourceFlow}

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/AllowSecureConnectionState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/AllowSecureConnectionState.tsx
@@ -6,7 +6,7 @@ import { TrackScreen } from "~/analytics";
 import ModalLock from "~/components/ModalLock";
 import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import type { BaseInitializerStateProps } from "../types";
-import { OverrideDeviceIntentExecutorHeader } from "../..";
+import { OverrideDeviceIntentExecutorHeader } from "../../components/OverrideDeviceIntentExecutorHeader";
 
 type AllowSecureConnectionStateProps = BaseInitializerStateProps<
   Extract<EnsureAppReadyState, { type: DeviceInteractionRequiredType.AllowSecureConnection }>

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/AllowSecureConnectionState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/AllowSecureConnectionState.tsx
@@ -1,10 +1,12 @@
 import React from "react";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { DeviceInteractionRequiredType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
 import { ContinueOnDevice } from "LLM/components/DeviceIntentExecutor/components/DeviceGenericStates/ContinueOnDevice";
 import { TrackScreen } from "~/analytics";
 import ModalLock from "~/components/ModalLock";
 import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import type { BaseInitializerStateProps } from "../types";
+import { OverrideDeviceIntentExecutorHeader } from "../..";
 
 type AllowSecureConnectionStateProps = BaseInitializerStateProps<
   Extract<EnsureAppReadyState, { type: DeviceInteractionRequiredType.AllowSecureConnection }>
@@ -17,6 +19,9 @@ export function AllowSecureConnectionState({
   return (
     <>
       <ModalLock />
+      <OverrideDeviceIntentExecutorHeader>
+        <Box lx={{ height: "s64" }} />
+      </OverrideDeviceIntentExecutorHeader>
       <TrackScreen
         category={PAGE_CONNECT_APP.AllowSecureConnection}
         sourceFlow={sourceFlow}

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/ConfirmOpenAppState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/ConfirmOpenAppState.tsx
@@ -1,10 +1,12 @@
 import React from "react";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { DeviceInteractionRequiredType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
 import { ContinueOnDevice } from "LLM/components/DeviceIntentExecutor/components/DeviceGenericStates/ContinueOnDevice";
 import { TrackScreen } from "~/analytics";
 import ModalLock from "~/components/ModalLock";
 import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import type { BaseInitializerStateProps } from "../types";
+import { OverrideDeviceIntentExecutorHeader } from "../..";
 
 type ConfirmOpenAppStateProps = BaseInitializerStateProps<
   Extract<EnsureAppReadyState, { type: DeviceInteractionRequiredType.ConfirmOpenApp }>
@@ -14,6 +16,9 @@ export function ConfirmOpenAppState({ device, sourceFlow }: ConfirmOpenAppStateP
   return (
     <>
       <ModalLock />
+      <OverrideDeviceIntentExecutorHeader>
+        <Box lx={{ height: "s64" }} />
+      </OverrideDeviceIntentExecutorHeader>
       <TrackScreen
         category={PAGE_CONNECT_APP.ConfirmOpenApp}
         sourceFlow={sourceFlow}

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/ConfirmOpenAppState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/ConfirmOpenAppState.tsx
@@ -6,7 +6,7 @@ import { TrackScreen } from "~/analytics";
 import ModalLock from "~/components/ModalLock";
 import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import type { BaseInitializerStateProps } from "../types";
-import { OverrideDeviceIntentExecutorHeader } from "../..";
+import { OverrideDeviceIntentExecutorHeader } from "../../components/OverrideDeviceIntentExecutorHeader";
 
 type ConfirmOpenAppStateProps = BaseInitializerStateProps<
   Extract<EnsureAppReadyState, { type: DeviceInteractionRequiredType.ConfirmOpenApp }>

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/ConfirmOpenAppState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/ConfirmOpenAppState.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { DeviceInteractionRequiredType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
 import { ContinueOnDevice } from "LLM/components/DeviceIntentExecutor/components/DeviceGenericStates/ContinueOnDevice";
 import { TrackScreen } from "~/analytics";
+import ModalLock from "~/components/ModalLock";
 import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import type { BaseInitializerStateProps } from "../types";
 
@@ -12,6 +13,7 @@ type ConfirmOpenAppStateProps = BaseInitializerStateProps<
 export function ConfirmOpenAppState({ device, sourceFlow }: ConfirmOpenAppStateProps) {
   return (
     <>
+      <ModalLock />
       <TrackScreen
         category={PAGE_CONNECT_APP.ConfirmOpenApp}
         sourceFlow={sourceFlow}

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/InstallingAppState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/InstallingAppState.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { Trans } from "~/context/Locale";
 import { TrackScreen } from "~/analytics";
 import ModalLock from "~/components/ModalLock";
@@ -6,6 +7,7 @@ import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import type { InitializerDevice } from "../types";
 import type { SourceFlow } from "../../utils/SourceFlowContext";
 import { LoadingContent } from "./LoadingContent";
+import { OverrideDeviceIntentExecutorHeader } from "../..";
 
 type InstallingAppStateProps = Readonly<{
   device: InitializerDevice;
@@ -16,6 +18,9 @@ export function InstallingAppState({ device, sourceFlow }: InstallingAppStatePro
   return (
     <>
       <ModalLock />
+      <OverrideDeviceIntentExecutorHeader>
+        <Box lx={{ height: "s64" }} />
+      </OverrideDeviceIntentExecutorHeader>
       <TrackScreen
         category={PAGE_CONNECT_APP.InstallingApp}
         sourceFlow={sourceFlow}

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/InstallingAppState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/InstallingAppState.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Trans } from "~/context/Locale";
 import { TrackScreen } from "~/analytics";
+import ModalLock from "~/components/ModalLock";
 import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import type { InitializerDevice } from "../types";
 import type { SourceFlow } from "../../utils/SourceFlowContext";
@@ -14,6 +15,7 @@ type InstallingAppStateProps = Readonly<{
 export function InstallingAppState({ device, sourceFlow }: InstallingAppStateProps) {
   return (
     <>
+      <ModalLock />
       <TrackScreen
         category={PAGE_CONNECT_APP.InstallingApp}
         sourceFlow={sourceFlow}

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/InstallingAppState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/InstallingAppState.tsx
@@ -7,7 +7,7 @@ import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import type { InitializerDevice } from "../types";
 import type { SourceFlow } from "../../utils/SourceFlowContext";
 import { LoadingContent } from "./LoadingContent";
-import { OverrideDeviceIntentExecutorHeader } from "../..";
+import { OverrideDeviceIntentExecutorHeader } from "../../components/OverrideDeviceIntentExecutorHeader";
 
 type InstallingAppStateProps = Readonly<{
   device: InitializerDevice;

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/LoadingState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/LoadingState.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Trans } from "~/context/Locale";
 import { TrackScreen } from "~/analytics";
+import ModalLock from "~/components/ModalLock";
 import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import type { InitializerDevice } from "../types";
 import type { SourceFlow } from "../../utils/SourceFlowContext";
@@ -27,6 +28,7 @@ export function LoadingState({ device, sourceFlow }: LoadingStateProps) {
 
   return (
     <>
+      <ModalLock />
       {dwellElapsed && (
         <TrackScreen
           category={PAGE_CONNECT_APP.Loading}

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/LoadingState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/LoadingState.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { Trans } from "~/context/Locale";
 import { TrackScreen } from "~/analytics";
 import ModalLock from "~/components/ModalLock";
@@ -6,6 +7,7 @@ import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import type { InitializerDevice } from "../types";
 import type { SourceFlow } from "../../utils/SourceFlowContext";
 import { LoadingContent } from "./LoadingContent";
+import { OverrideDeviceIntentExecutorHeader } from "../..";
 
 type LoadingStateProps = Readonly<{
   device: InitializerDevice;
@@ -29,6 +31,9 @@ export function LoadingState({ device, sourceFlow }: LoadingStateProps) {
   return (
     <>
       <ModalLock />
+      <OverrideDeviceIntentExecutorHeader>
+        <Box lx={{ height: "s64" }} />
+      </OverrideDeviceIntentExecutorHeader>
       {dwellElapsed && (
         <TrackScreen
           category={PAGE_CONNECT_APP.Loading}

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/LoadingState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/LoadingState.tsx
@@ -7,7 +7,7 @@ import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import type { InitializerDevice } from "../types";
 import type { SourceFlow } from "../../utils/SourceFlowContext";
 import { LoadingContent } from "./LoadingContent";
-import { OverrideDeviceIntentExecutorHeader } from "../..";
+import { OverrideDeviceIntentExecutorHeader } from "../../components/OverrideDeviceIntentExecutorHeader";
 
 type LoadingStateProps = Readonly<{
   device: InitializerDevice;

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnlockDeviceState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnlockDeviceState.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { DeviceInteractionRequiredType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
 import { UnlockDevice } from "LLM/components/DeviceIntentExecutor/components/DeviceGenericStates/UnlockDevice";
 import { TrackScreen } from "~/analytics";
+import ModalLock from "~/components/ModalLock";
 import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import type { BaseInitializerStateProps } from "../types";
 
@@ -12,6 +13,7 @@ type UnlockDeviceStateProps = BaseInitializerStateProps<
 export function UnlockDeviceState({ device, sourceFlow }: UnlockDeviceStateProps) {
   return (
     <>
+      <ModalLock />
       <TrackScreen
         category={PAGE_CONNECT_APP.UnlockDevice}
         sourceFlow={sourceFlow}

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnlockDeviceState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnlockDeviceState.tsx
@@ -6,7 +6,7 @@ import { TrackScreen } from "~/analytics";
 import ModalLock from "~/components/ModalLock";
 import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import type { BaseInitializerStateProps } from "../types";
-import { OverrideDeviceIntentExecutorHeader } from "../..";
+import { OverrideDeviceIntentExecutorHeader } from "../../components/OverrideDeviceIntentExecutorHeader";
 
 type UnlockDeviceStateProps = BaseInitializerStateProps<
   Extract<EnsureAppReadyState, { type: DeviceInteractionRequiredType.UnlockDevice }>

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnlockDeviceState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnlockDeviceState.tsx
@@ -1,10 +1,12 @@
 import React from "react";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { DeviceInteractionRequiredType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
 import { UnlockDevice } from "LLM/components/DeviceIntentExecutor/components/DeviceGenericStates/UnlockDevice";
 import { TrackScreen } from "~/analytics";
 import ModalLock from "~/components/ModalLock";
 import { PAGE_CONNECT_APP } from "../../utils/trackDeviceIntent";
 import type { BaseInitializerStateProps } from "../types";
+import { OverrideDeviceIntentExecutorHeader } from "../..";
 
 type UnlockDeviceStateProps = BaseInitializerStateProps<
   Extract<EnsureAppReadyState, { type: DeviceInteractionRequiredType.UnlockDevice }>
@@ -14,6 +16,9 @@ export function UnlockDeviceState({ device, sourceFlow }: UnlockDeviceStateProps
   return (
     <>
       <ModalLock />
+      <OverrideDeviceIntentExecutorHeader>
+        <Box lx={{ height: "s64" }} />
+      </OverrideDeviceIntentExecutorHeader>
       <TrackScreen
         category={PAGE_CONNECT_APP.UnlockDevice}
         sourceFlow={sourceFlow}

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/index.tsx
@@ -63,16 +63,13 @@ export function DeviceIntentExecutorLWM<JobState, Input, ExtraProps>(
     <QueuedDrawerBottomSheet
       isRequestingToBeOpened={wrappedProps.enabled}
       onClose={wrappedProps.onUserCancel}
-      preventBackdropClick={!wrappedProps.cancellableUI}
       hideHandle
       enableDynamicSizing
     >
       <SourceFlowProvider value={sourceFlow}>
         <DeviceIntentExecutorHeaderContext.Provider value={headerContextValue}>
           <BottomSheetView style={{ paddingBottom: bottomInset + 16 }}>
-            {wrappedProps.cancellableUI && !hasHeaderOverride && (
-              <BottomSheetHeader density="expanded" />
-            )}
+            {!hasHeaderOverride && <BottomSheetHeader density="expanded" />}
             <DeviceIntentExecutor
               {...wrappedProps}
               platformConfig={platformConfig}

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.test.tsx
@@ -44,7 +44,6 @@ function makeProps(overrides: Partial<Props> = {}): Props {
     onIntentJobComplete: jest.fn(),
     onIntentJobError: jest.fn(),
     enabled: true,
-    cancellableUI: true,
     onUserCancel: jest.fn(),
     cancelIntentRequestId: undefined,
     sourceFlow: "swap",

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/InitializationScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/InitializationScreen.tsx
@@ -92,7 +92,6 @@ export default function DebugDeviceIntentExecutorInitialization() {
       onIntentJobError: (error: unknown) => {
         setJobError(error);
       },
-      cancellableUI: true,
       cancelIntentRequestId: undefined,
       onUserCancel: handleUserCancel,
     }),

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/useDemoIntentOrchestration.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/useDemoIntentOrchestration.ts
@@ -249,7 +249,6 @@ export function useDemoIntentOrchestration({
       onIntentJobStateChanged: handleJobStateChanged,
       onIntentJobComplete: handleJobComplete,
       onIntentJobError: handleJobError,
-      cancellableUI: true,
       cancelIntentRequestId: undefined,
       onUserCancel: () => {
         setEnabled(false);

--- a/libs/device-intent/README.md
+++ b/libs/device-intent/README.md
@@ -379,7 +379,6 @@ function MyFlowScreen({ enabled, onDone }: Props) {
       onIntentJobError={error => {
         /* handle error */
       }}
-      cancellableUI={true}
       cancelIntentRequestId={undefined}
     />
   );
@@ -389,9 +388,10 @@ function MyFlowScreen({ enabled, onDone }: Props) {
 ### Custom LWM headers from intent components
 
 `DeviceIntentExecutorLWM` owns the bottom sheet chrome and renders a default
-`BottomSheetHeader` for cancellable device flows. When a specific intent needs a
-more explicit title, description, or header density, its platform component can
-replace that default header by rendering `OverrideDeviceIntentExecutorHeader`.
+`BottomSheetHeader` (which carries the close button). When a specific intent
+needs a more explicit title, description, or header density, its platform
+component can replace that default header by rendering
+`OverrideDeviceIntentExecutorHeader`.
 
 The intent component should place the override where the header should appear,
 usually at the top of its render tree. Consumers do not call the internal
@@ -420,6 +420,50 @@ Use the normal Lumen `BottomSheetHeader` props for the desired UX
 larger standalone flows). The component is a no-op outside
 `DeviceIntentExecutorLWM`, so intent components stay reusable in tests and
 non-bottom-sheet previews.
+
+### Preventing the user from closing the drawer (LWM)
+
+The `DeviceIntentExecutorLWM` bottom sheet is **dismissable by default**: the
+user can close it by pressing the backdrop, dragging it down, or tapping the
+close button in the header.
+
+That is the wrong behavior while the device is waiting for the user to act on it
+(unlock the device, allow a secure connection, confirm opening an app, sign /
+review a transaction on the device, etc.) or while an operation is in progress
+on the device (installing an app, transferring data). Closing the drawer in
+those moments breaks the in-flight device flow, so the drawer must be
+**non-dismissable** for as long as that pending action lasts.
+
+To do that, render `ModalLock` (`~/components/ModalLock`) only while the step
+is on screen. While mounted, it disables the backdrop press and the
+pan-down-to-close gesture, and hides the close button; it automatically restores
+normal behavior as soon as it unmounts (and on navigation blur), so you never
+reset anything by hand.
+
+**When an intent component should use it:** whenever its current `jobState`
+represents a request that is pending on the device and the user must complete it
+there. Mount `ModalLock` for exactly those states, and leave it unmounted for
+idle, terminal, or error states where the user should be free to back out.
+
+```tsx
+import ModalLock from "~/components/ModalLock";
+
+function MySignIntentComponent({ jobState }: Props) {
+  const awaitingUserOnDevice = jobState.type === "awaiting-signature";
+
+  return (
+    <>
+      {awaitingUserOnDevice && <ModalLock />}
+      {/* intent content */}
+    </>
+  );
+}
+```
+
+The device-context initialization phase already does this for the states where a
+device action is pending or an operation is ongoing (`UnlockDevice`,
+`AllowSecureConnection`, `ConfirmOpenApp`, `InstallingApp` and `Loading`), so you
+only need to handle the pending states specific to your own intent.
 
 ### Building the `deviceInitializationInput`
 
@@ -529,7 +573,6 @@ function SignTransactionStep({
       onIntentJobComplete={() => onSigned()}
       onIntentJobError={onError}
       onUserCancel={onClose}
-      cancellableUI={true}
       cancelIntentRequestId={undefined}
     />
   );

--- a/libs/device-intent/src/DeviceIntentExecutor.test.tsx
+++ b/libs/device-intent/src/DeviceIntentExecutor.test.tsx
@@ -179,7 +179,6 @@ function makeProps(overrides: Partial<TestProps> = {}): TestProps {
     onIntentJobComplete: jest.fn(),
     onIntentJobError: jest.fn(),
     enabled: true,
-    cancellableUI: false,
     onUserCancel: jest.fn(),
     cancelIntentRequestId: undefined,
     platformConfig,
@@ -280,7 +279,6 @@ function makeUnitProps(
     onIntentJobComplete: jest.fn(),
     onIntentJobError: jest.fn(),
     enabled: true,
-    cancellableUI: false,
     onUserCancel: jest.fn(),
     cancelIntentRequestId: undefined,
     platformConfig,
@@ -310,7 +308,6 @@ describe("DeviceIntentExecutor (unit)", () => {
         onIntentJobComplete={onIntentJobComplete}
         onIntentJobError={onIntentJobError}
         enabled={true}
-        cancellableUI={false}
         onUserCancel={onUserCancel}
         cancelIntentRequestId={undefined}
         platformConfig={platformConfig}
@@ -329,7 +326,6 @@ describe("DeviceIntentExecutor (unit)", () => {
       onIntentJobComplete,
       onIntentJobError,
       enabled: true,
-      cancellableUI: false,
       onUserCancel,
       cancelIntentRequestId: undefined,
     });

--- a/libs/device-intent/src/executor.ts
+++ b/libs/device-intent/src/executor.ts
@@ -162,11 +162,6 @@ export interface DeviceIntentExecutorProps<JobState, Input, ExtraProps, InitInpu
   onIntentJobError: (error: unknown) => void;
   /** When `false` the executor is hidden and inactive; setting to `false` terminates any running job. */
   enabled: boolean;
-  /**
-   * Whether the UI allows the user to cancel the current execution
-   * (e.g. close the bottom sheet containing the executor).
-   */
-  cancellableUI: boolean;
   /** Called when the user performs an action that cancels the current execution
    * (e.g. user closes the bottom sheet containing the executor, or clicks a "Close" CTA in a given error state, etc.).
    */

--- a/libs/device-intent/src/useDeviceIntentExecutor.test.tsx
+++ b/libs/device-intent/src/useDeviceIntentExecutor.test.tsx
@@ -106,7 +106,6 @@ function makeProps(overrides: Partial<TestProps> = {}): TestProps {
     onIntentJobComplete: jest.fn(),
     onIntentJobError: jest.fn(),
     enabled: true,
-    cancellableUI: false,
     onUserCancel: jest.fn(),
     cancelIntentRequestId: undefined,
     ...overrides,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - In a Device Intent Executor (DIE) device flow drawer, verify the drawer **cannot** be dismissed (no close button, backdrop tap and swipe-down disabled) while: unlocking the device, allowing the secure connection, confirming app open on device, installing an app, and during loading.
      - Verify the drawer **can** be dismissed normally in all other states (errors, warnings, idle, completed).
      - Verify no regression in the existing DIE analytics lifecycle (deviceflow_started / completed / aborted, close button tracking).

### 📝 Description

Previously, the dismissability of the DIE bottom sheet was driven by a `cancellableUI` prop passed down from the parent. This was impractical because whether the drawer should be dismissable depends on the *internal* state of the flow (the pending device action), not on a static decision made by the parent.

This PR removes the `cancellableUI` prop and adopts the existing `ModalLock` pattern used elsewhere in the app. A step makes the drawer non-dismissable simply by mounting `<ModalLock />` while it is on screen; `ModalLock` flips the shared `modalLock` redux flag that `QueuedDrawerBottomSheet` already reads to disable the backdrop press, the pan-down-to-close gesture, and the close button. The lock is automatically released when the component unmounts (and on navigation blur), so no manual reset is needed.

`DeviceContextInitializerComponentLWM` now mounts `ModalLock` in the states where a device action is pending or an operation is in progress: `UnlockDevice`, `AllowSecureConnection`, `ConfirmOpenApp`, `InstallingApp` and `Loading`.

The `@ledgerhq/device-intent` README documents when intent components should do the same for their own pending states.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31756](https://ledgerhq.atlassian.net/browse/LIVE-31756)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31756]: https://ledgerhq.atlassian.net/browse/LIVE-31756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ