### PR TITLE
[LWD] feat(desktop): add global TopBar search for asset discoverability

### DIFF
--- a/.changeset/plenty-dots-own.md
+++ b/.changeset/plenty-dots-own.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add a global search input to the TopBar, gated behind the Wallet 4.0 asset discoverability flag. When enabled, the TopBar renders the global search (in place of the breadcrumb) and the Market page hides its local search input.

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/TopBarView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/TopBarView.tsx
@@ -9,6 +9,7 @@ import FirmwareUpdateBanner from "~/renderer/components/FirmwareUpdateBanner";
 import Updater from "LLD/features/Updater";
 import { MyWallet } from "LLD/features/MyWallet";
 import { InformationDrawer } from "~/renderer/components/TopBar/NotificationIndicator/InformationDrawer";
+import { TopBarSearch } from "./components/TopBarSearch";
 
 const TopBarView = ({
   slots,
@@ -16,7 +17,19 @@ const TopBarView = ({
   isInformationCenterOpen,
   onInformationCenterClose,
   shouldDisplayAggregatedAssets,
+  shouldDisplayAssetDiscoverability,
 }: TopBarViewProps) => {
+  const renderTitle = () => {
+    if (shouldDisplayAssetDiscoverability) return <TopBarSearch />;
+    if (shouldDisplayAggregatedAssets) return null;
+
+    return (
+      <NavBarTitle className="h-48">
+        <Breadcrumb />
+      </NavBarTitle>
+    );
+  };
+
   return (
     <>
       <InformationDrawer
@@ -24,11 +37,7 @@ const TopBarView = ({
         onRequestClose={onInformationCenterClose}
       />
       <NavBar className="w-full min-w-0 items-center px-32 pt-32 pb-24">
-        {shouldDisplayAggregatedAssets ? null : (
-          <NavBarTitle className="h-48">
-            <Breadcrumb />
-          </NavBarTitle>
-        )}
+        {renderTitle()}
         <NavBarTrailing className="h-48 gap-12">
           <LiveAppDrawer />
           {shouldShowFirmwareUpdateBanner && <FirmwareUpdateBanner />}

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/__tests__/TopBarView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/__tests__/TopBarView.test.tsx
@@ -30,6 +30,7 @@ describe("TopBarView", () => {
     isInformationCenterOpen: false,
     onInformationCenterClose: jest.fn(),
     shouldDisplayAggregatedAssets: false,
+    shouldDisplayAssetDiscoverability: false,
   };
 
   it("should render updater when not in manager", () => {
@@ -52,5 +53,67 @@ describe("TopBarView", () => {
     });
 
     expect(screen.getByTestId("my-wallet-avatar")).toBeInTheDocument();
+  });
+
+  describe("search input with asset discoverability", () => {
+    const assetDiscoverabilityState = withFlagOverrides({
+      lwdWallet40: { enabled: true, params: { assetDiscoverability: true } },
+    });
+
+    it("should not render the search input when the flag is off", () => {
+      render(<TopBarView {...defaultProps} shouldShowFirmwareUpdateBanner={false} />);
+
+      expect(screen.queryByTestId("topbar-search-input")).not.toBeInTheDocument();
+    });
+
+    it.each(["/", "/market"])(
+      "should render the global search input on %s when the flag is on",
+      route => {
+        render(
+          <TopBarView
+            {...defaultProps}
+            shouldShowFirmwareUpdateBanner={false}
+            shouldDisplayAssetDiscoverability
+          />,
+          { initialState: assetDiscoverabilityState, initialRoute: route },
+        );
+
+        expect(screen.getByTestId("topbar-search-input")).toBeInTheDocument();
+      },
+    );
+
+    it("should open the popover when the search input is clicked", async () => {
+      const { user } = render(
+        <TopBarView
+          {...defaultProps}
+          shouldShowFirmwareUpdateBanner={false}
+          shouldDisplayAssetDiscoverability
+        />,
+        { initialState: assetDiscoverabilityState, initialRoute: "/" },
+      );
+
+      expect(screen.queryByTestId("topbar-search-popover")).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("textbox"));
+      expect(screen.getByTestId("topbar-search-popover")).toBeInTheDocument();
+    });
+
+    it("should reset the query on Escape", async () => {
+      const { user } = render(
+        <TopBarView
+          {...defaultProps}
+          shouldShowFirmwareUpdateBanner={false}
+          shouldDisplayAssetDiscoverability
+        />,
+        { initialState: assetDiscoverabilityState, initialRoute: "/" },
+      );
+
+      const input = screen.getByRole("textbox");
+      await user.type(input, "bitcoin");
+      expect(input).toHaveValue("bitcoin");
+
+      await user.type(input, "{Escape}");
+      expect(input).toHaveValue("");
+    });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchInputView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchInputView.tsx
@@ -1,0 +1,31 @@
+import React, { ChangeEvent, ComponentPropsWithoutRef, KeyboardEvent, forwardRef } from "react";
+import { SearchInput } from "@ledgerhq/lumen-ui-react";
+import { cn } from "LLD/utils/cn";
+
+type SearchInputViewProps = {
+  value: string;
+  placeholder: string;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => void;
+  testId?: string;
+} & Omit<ComponentPropsWithoutRef<"div">, "onChange" | "onKeyDown">;
+
+export const SearchInputView = forwardRef<HTMLDivElement, SearchInputViewProps>(
+  function SearchInputView(
+    { value, placeholder, onChange, onKeyDown, testId, className, ...rest },
+    ref,
+  ) {
+    return (
+      <div ref={ref} className={cn("min-w-0 max-w-[450px] flex-auto mr-24", className)} {...rest}>
+        <SearchInput
+          appearance="transparent"
+          value={value}
+          placeholder={placeholder}
+          onChange={onChange}
+          onKeyDown={onKeyDown}
+          data-testid={testId}
+        />
+      </div>
+    );
+  },
+);

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/index.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { Popover, PopoverContent, PopoverTrigger } from "@ledgerhq/lumen-ui-react";
+import { SearchInputView } from "./SearchInputView";
+import { useTopBarSearch } from "./useTopBarSearch";
+
+export function TopBarSearch() {
+  const { t } = useTranslation();
+  const { value, open, setOpen, onChange, onKeyDown } = useTopBarSearch();
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <SearchInputView
+            value={value}
+            placeholder={t("topBar.searchPlaceholder")}
+            onChange={onChange}
+            onKeyDown={onKeyDown}
+            testId="topbar-search-input"
+          />
+        }
+      />
+      <PopoverContent align="start" width="fit" className="w-(--anchor-width) flex flex-col gap-12">
+        <span className="body-2 text-muted" data-testid="topbar-search-popover">
+          {t("topBar.searchEmptyState")}
+        </span>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/useTopBarSearch.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/useTopBarSearch.ts
@@ -1,0 +1,26 @@
+import { ChangeEvent, KeyboardEvent, useCallback, useState } from "react";
+
+/**
+ * Single source of state for the global TopBar search.
+ *
+ * Extension point: a debounced `value` → fetch → `results` pipeline will be wired here so the
+ * popover can render search results. The return shape is kept stable for that addition.
+ */
+export function useTopBarSearch() {
+  const [value, setValue] = useState("");
+  const [open, setOpen] = useState(false);
+
+  const onChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+  }, []);
+
+  const onKeyDown = useCallback((e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Escape") {
+      setValue("");
+      setOpen(false);
+      e.currentTarget.blur();
+    }
+  }, []);
+
+  return { value, open, setOpen, onChange, onKeyDown };
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useTopBarViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useTopBarViewModel.ts
@@ -10,8 +10,12 @@ import { useSettings } from "./useSettings";
 import { useInformationCenter } from "./useInformationCenter";
 
 const useTopBarViewModel = () => {
-  const { shouldDisplayOperationsList, shouldDisplayMyWallet, shouldDisplayAggregatedAssets } =
-    useWalletFeaturesConfig("desktop");
+  const {
+    shouldDisplayOperationsList,
+    shouldDisplayMyWallet,
+    shouldDisplayAggregatedAssets,
+    shouldDisplayAssetDiscoverability,
+  } = useWalletFeaturesConfig("desktop");
   const { isOpen: isInformationCenterOpen, onRequestClose: onInformationCenterClose } =
     useInformationCenter();
   const { handleDiscreet, discreetIcon, tooltip: discreetTooltip } = useDiscreetMode();
@@ -132,6 +136,7 @@ const useTopBarViewModel = () => {
     isInformationCenterOpen,
     onInformationCenterClose,
     shouldDisplayAggregatedAssets,
+    shouldDisplayAssetDiscoverability,
   };
 };
 

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/index.tsx
@@ -9,6 +9,7 @@ const TopBar = () => {
     isInformationCenterOpen,
     onInformationCenterClose,
     shouldDisplayAggregatedAssets,
+    shouldDisplayAssetDiscoverability,
   } = useTopBarViewModel();
 
   return (
@@ -18,6 +19,7 @@ const TopBar = () => {
       isInformationCenterOpen={isInformationCenterOpen}
       onInformationCenterClose={onInformationCenterClose}
       shouldDisplayAggregatedAssets={shouldDisplayAggregatedAssets}
+      shouldDisplayAssetDiscoverability={shouldDisplayAssetDiscoverability}
     />
   );
 };

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/types.ts
@@ -53,6 +53,7 @@ type TopBarViewProps = {
   isInformationCenterOpen: boolean;
   onInformationCenterClose: () => void;
   shouldDisplayAggregatedAssets: boolean;
+  shouldDisplayAssetDiscoverability: boolean;
 };
 
 export type { TopBarAction, TopBarActionAppearance, TopBarSlot, TopBarViewProps };

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/index.tsx
@@ -91,8 +91,15 @@ export default function Market() {
       <PageHeader title={t("market.title")} onBack={() => navigate("/")} />
 
       <Flex flexDirection="row" pr="6px" my={2} alignItems="center" justifyContent="space-between">
-        <SearchInputComponent search={search} updateSearch={updateSearch} />
-        <SelectBarContainer flexDirection="row" alignItems="center" justifyContent="flex-end">
+        {!shouldDisplayAssetDiscoverability && (
+          <SearchInputComponent search={search} updateSearch={updateSearch} />
+        )}
+        <SelectBarContainer
+          flexDirection="row"
+          alignItems="center"
+          justifyContent="flex-end"
+          ml="auto"
+        >
           {!shouldDisplayAssetDiscoverability && (
             <Flex data-testid="market-countervalue-select" justifyContent="flex-end" mx={4}>
               <CounterValueSelect

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8818,6 +8818,8 @@
     }
   },
   "topBar": {
+    "searchPlaceholder": "Search assets",
+    "searchEmptyState": "Start typing to search for an asset",
     "history": {
       "cta": "Transactions"
     },


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - TopBar rendering across routes (`/`, `/market`): global search vs. breadcrumb vs. aggregated assets
  - Behaviour of the new search input: focus opens the popover, typing updates the value, `Escape` resets and blurs
  - Market page layout when the flag is on (local `SearchInputComponent` is hidden, select bar pushed to the right)
  - Feature flag gating via `lwdWallet40` → `assetDiscoverability`: nothing should change when the flag is off

### 📝 Description

**Problem**: The Wallet 4.0 asset discoverability experience needs a single, always-visible entry point to search for assets from anywhere in the app, rather than a search input scoped to the Market page.

**Solution**: Add a global search input to the TopBar, gated behind the `lwdWallet40` / `assetDiscoverability` feature flag.

- New `TopBarSearch` component (Lumen `SearchInput` inside a `Popover`) with its own `useTopBarSearch` hook holding the search state. The hook's return shape is kept stable so a debounced `value → fetch → results` pipeline can be wired in later.
- `TopBarView` now renders the global search in place of the breadcrumb when the flag is on (`renderTitle` helper), leaving existing behaviour untouched when the flag is off.
- The Market page hides its local `SearchInputComponent` when the flag is on and pushes the select bar to the right.
- Added `topBar.searchPlaceholder` and `topBar.searchEmptyState` translations.

### 🖼️ Screenshots



https://github.com/user-attachments/assets/46250223-621f-4760-bc17-5faf6261fbf3


### ❓ Context

- **JIRA or GitHub link**: [LIVE-29942](https://ledgerhq.atlassian.net/browse/LIVE-29942)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LIVE-29942]: https://ledgerhq.atlassian.net/browse/LIVE-29942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ