### PR TITLE
[LWDM] fix(live-common): keep manifest params authoritative in getInitialURL

### DIFF
--- a/.changeset/fix-gotourl-params-injection.md
+++ b/.changeset/fix-gotourl-params-injection.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Keep manifest params authoritative when resolving a live app initial URL: `getInitialURL` now re-applies the trusted `manifest.params` onto an accepted `goToURL` for manifests that define params, instead of trusting the params it carries.

--- a/libs/ledger-live-common/src/wallet-api/helpers.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/helpers.test.ts
@@ -387,6 +387,34 @@ describe("wallet-api helpers", () => {
         expect(result).toBe(inputs.goToURL);
         expect(result).toContain("default.example.com");
       });
+
+      it("should keep manifest params authoritative when goToURL carries its own params", () => {
+        const trustedDappUrl = "https://default.example.com/app";
+        const manifest = {
+          url: "https://default.example.com/",
+          domains: ["default.example.com"],
+          params: {
+            dappUrl: trustedDappUrl,
+            networks: [{ currency: "ethereum", chainID: 1 }],
+          },
+        };
+        const otherParams = {
+          dappUrl: "https://other.example/app",
+          networks: [{ currency: "ethereum", chainID: 1 }],
+        };
+        const inputs = {
+          goToURL: `https://default.example.com/?params=${encodeURIComponent(
+            JSON.stringify(otherParams),
+          )}`,
+        };
+        // @ts-expect-error - test mock object doesn't have all LiveAppManifest properties
+        const result = getInitialURL(inputs, manifest);
+
+        const resultUrl = new URL(result);
+        const params = JSON.parse(resultUrl.searchParams.get("params") ?? "{}");
+        expect(params.dappUrl).toBe(trustedDappUrl);
+        expect(result).not.toContain("other.example");
+      });
     });
 
     describe("real-world manifest patterns", () => {
@@ -449,7 +477,24 @@ describe("wallet-api helpers", () => {
       expect(result).toContain("params=%7B%22foo%22%3A%22bar%22%7D"); // JSON.stringify({foo: "bar"}) encoded
     });
 
-    it("should use goToURL as-is when on same domain (without adding params)", () => {
+    it("should use goToURL as-is when on same domain and manifest has no params", () => {
+      const manifest = {
+        url: "https://example.com",
+        domains: ["allowed.com"],
+      };
+      const inputs = {
+        goToURL: "https://example.com/page",
+        customParam: "value",
+      };
+      // @ts-expect-error - test mock object doesn't have all LiveAppManifest properties
+      const result = getInitialURL(inputs, manifest);
+
+      expect(result).toBe("https://example.com/page");
+      expect(result).not.toContain("customParam");
+      expect(result).not.toContain("params");
+    });
+
+    it("should pin trusted manifest.params onto goToURL when on same domain", () => {
       const manifest = {
         url: "https://example.com",
         domains: ["allowed.com"],
@@ -462,9 +507,29 @@ describe("wallet-api helpers", () => {
       // @ts-expect-error - test mock object doesn't have all LiveAppManifest properties
       const result = getInitialURL(inputs, manifest);
 
-      expect(result).toBe("https://example.com/page");
+      const resultUrl = new URL(result);
+      expect(resultUrl.origin + resultUrl.pathname).toBe("https://example.com/page");
+      expect(resultUrl.searchParams.get("params")).toBe(JSON.stringify({ foo: "bar" }));
       expect(result).not.toContain("customParam");
-      expect(result).not.toContain("params");
+    });
+
+    it("should override params already present in goToURL with trusted manifest.params", () => {
+      const manifest = {
+        url: "https://example.com",
+        domains: ["allowed.com"],
+        params: { foo: "bar" },
+      };
+      const inputs = {
+        goToURL: `https://example.com/page?params=${encodeURIComponent(
+          JSON.stringify({ foo: "other" }),
+        )}`,
+      };
+      // @ts-expect-error - test mock object doesn't have all LiveAppManifest properties
+      const result = getInitialURL(inputs, manifest);
+
+      const resultUrl = new URL(result);
+      expect(resultUrl.searchParams.get("params")).toBe(JSON.stringify({ foo: "bar" }));
+      expect(result).not.toContain("other");
     });
   });
 });

--- a/libs/ledger-live-common/src/wallet-api/helpers.ts
+++ b/libs/ledger-live-common/src/wallet-api/helpers.ts
@@ -145,7 +145,12 @@ export const getInitialURL = (
       typeof inputs?.goToURL === "string" &&
       isWhitelistedDomain(inputs.goToURL, manifest.url.toString())
     ) {
-      return inputs?.goToURL;
+      if (manifest.params) {
+        const goToURL = new URL(inputs.goToURL);
+        goToURL.searchParams.set("params", JSON.stringify(manifest.params));
+        return goToURL.toString();
+      }
+      return inputs.goToURL;
     }
 
     const url = new URL(manifest.url.toString());


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - wallet-api params

### 📝 Description

Re-apply the trusted `manifest.params` onto an accepted `goToURL` for manifests that define params, instead of trusting the params the URL carries. Manifests without params keep `goToURL` unchanged.

Add unit tests for the params-pinning behavior and a changeset.

### ❓ Context

- **JIRA or GitHub link**: 
- **ADR link (if any)**: 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
