### PR TITLE
[LWD] test(desktop): add Ledger Sync MSW handlers and fix React 19 fake-timer hang

### DIFF
--- a/.changeset/walletsync-test-handlers.md
+++ b/.changeset/walletsync-test-handlers.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Add MSW handlers for Ledger Sync `/_info` endpoints and fix React 19 fake-timer hang in WalletSync tests

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/synchronize.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/synchronize.test.tsx
@@ -18,7 +18,8 @@ jest.mock("@ledgerhq/ledger-key-ring-protocol/qrcode/index", () => ({
 
 describe("Synchronize flow", () => {
   beforeEach(() => {
-    jest.useFakeTimers();
+    // React 19's act() uses queueMicrotask for scheduling — faking it causes act() to hang.
+    jest.useFakeTimers({ doNotFake: ["queueMicrotask"] });
   });
   afterEach(() => {
     jest.useRealTimers();

--- a/apps/ledger-live-desktop/tests/handlers/index.ts
+++ b/apps/ledger-live-desktop/tests/handlers/index.ts
@@ -7,6 +7,7 @@ import FearAndGreedHandlers from "./fearAndGreed";
 import ConcordiumHandlers from "./concordium";
 import BuyHandlers from "./buy";
 import SwapHandlers from "./swap";
+import LedgerSyncHandlers from "./ledgerSync";
 
 export default [
   ...MarketHandlers,
@@ -18,4 +19,5 @@ export default [
   ...FearAndGreedHandlers,
   ...BuyHandlers,
   ...SwapHandlers,
+  ...LedgerSyncHandlers,
 ];

--- a/apps/ledger-live-desktop/tests/handlers/ledgerSync.ts
+++ b/apps/ledger-live-desktop/tests/handlers/ledgerSync.ts
@@ -1,0 +1,16 @@
+import { http, HttpResponse } from "msw";
+import getWalletSyncEnvironmentParams from "@ledgerhq/live-common/walletSync/getEnvironmentParams";
+
+// `useLedgerSyncInfo` (mounted by the WalletSync Manage screen) calls `GET /_info` on the
+// trustchain and cloud-sync backends. The resolved environment depends on whether the
+// `lldWalletSync` feature flag is set, so stub both STAGING and PROD hosts to keep tests offline.
+const STATUS = { name: "ledger-sync", version: "1.0.0" };
+
+const baseUrls = (["STAGING", "PROD"] as const).flatMap(env => {
+  const { trustchainApiBaseUrl, cloudSyncApiBaseUrl } = getWalletSyncEnvironmentParams(env);
+  return [trustchainApiBaseUrl, cloudSyncApiBaseUrl];
+});
+
+export default [...new Set(baseUrls)].map(baseUrl =>
+  http.get(`${baseUrl}/_info`, () => HttpResponse.json(STATUS)),
+);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _This PR is test infrastructure; it stabilizes the existing WalletSync test suite._
- [x] **Impact of the changes:**
      - WalletSync (`synchronize`) test suite reliability
      - No production code is touched — test handlers and timer config only

### 📝 Description

The WalletSync `synchronize` tests were flaky/hanging in two ways. First, `useLedgerSyncInfo` (mounted by the WalletSync Manage screen) issues a real `GET /_info` request to the trustchain and cloud-sync backends, with the resolved host depending on the `lldWalletSync` feature flag — leaving the tests dependent on the network. Second, under React 19 the test suite hangs because `act()` schedules via `queueMicrotask`, which the global `jest.useFakeTimers()` was also faking.

This PR makes the suite deterministic and offline:

- Adds a new MSW handler module (`tests/handlers/ledgerSync.ts`) that stubs the `/_info` endpoint on both the trustchain and cloud-sync hosts for **STAGING** and **PROD**, derived from `getWalletSyncEnvironmentParams`, so the tests pass regardless of the feature-flag-resolved environment. The handlers are registered in `tests/handlers/index.ts`.
- Configures fake timers with `jest.useFakeTimers({ doNotFake: ["queueMicrotask"] })` so React 19's `act()` scheduling is left intact.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-32031

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)