### PR TITLE
[LWD] feat(desktop): support pre-selected category in market deeplink

### DIFF
--- a/.changeset/lwd-market-deeplink-category.md
+++ b/.changeset/lwd-market-deeplink-category.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+LWD - W4.0 - Support a `category` param in the Market deeplink (e.g. `ledgerwallet://market?category=stocks`). When present, the category is pre-selected (`setMarketCategory`) before navigating to `/market`; unknown values fall back to `all`.

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/__tests__/parseDeepLink.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/__tests__/parseDeepLink.test.ts
@@ -281,6 +281,17 @@ describe("parseDeepLink", () => {
       });
     });
 
+    it("creates market route with a category param", () => {
+      const parsed = parseDeepLink("ledgerwallet://market?category=stocks");
+      const route = createRoute(parsed);
+
+      expect(route).toEqual({
+        type: "market",
+        path: "",
+        category: "stocks",
+      });
+    });
+
     it("creates asset route", () => {
       const parsed = parseDeepLink("ledgerwallet://asset/ethereum");
       const route = createRoute(parsed);

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/market.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/market.handler.test.ts
@@ -1,9 +1,37 @@
 import { marketHandler } from "../market.handler";
+import { setMarketCategory } from "~/renderer/actions/market";
 import { createMockContext } from "./test-utils";
 
 describe("marketHandler", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe("category param", () => {
+    it("pre-selects a known category before navigating to the market list", () => {
+      const context = createMockContext();
+
+      marketHandler({ type: "market", path: "", category: "stocks" }, context);
+
+      expect(context.dispatch).toHaveBeenCalledWith(setMarketCategory("stocks"));
+      expect(context.navigate).toHaveBeenCalledWith("/market");
+    });
+
+    it("falls back to 'all' for an unknown category", () => {
+      const context = createMockContext();
+
+      marketHandler({ type: "market", path: "", category: "trending" }, context);
+
+      expect(context.dispatch).toHaveBeenCalledWith(setMarketCategory("all"));
+    });
+
+    it("does not touch the category when no category param is provided", () => {
+      const context = createMockContext();
+
+      marketHandler({ type: "market", path: "" }, context);
+
+      expect(context.dispatch).not.toHaveBeenCalled();
+    });
   });
 
   it("navigates to market list when no path", () => {

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/market.handler.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/market.handler.ts
@@ -3,14 +3,26 @@ import {
   getMarketOrAssetDetailPath,
   resolveLegacyCryptoCurrencyId,
 } from "LLD/utils/marketAssetNavigation";
+import { parseMarketListCategory } from "@ledgerhq/live-common/market/utils/category";
+import { setMarketCategory } from "~/renderer/actions/market";
 
 /**
  * Market deeplinks. When Wallet 4.0 aggregated assets is on, navigates with the raw path so
  * Asset Detail can resolve market-api slugs (no `location.state`; unlike in-app Market row clicks).
  * When off, validates the id and falls back to the market list — aligned with mobile (af91289).
+ *
+ * A `?category=` param pre-selects the Market category before navigating; unknown values
+ * fall back to `all`.
  */
-export const marketHandler: DeeplinkHandler<"market"> = (route, { navigate, assetsPath }) => {
+export const marketHandler: DeeplinkHandler<"market"> = (
+  route,
+  { navigate, assetsPath, dispatch },
+) => {
   const path = route.path.trim();
+
+  if (route.category !== undefined) {
+    dispatch(setMarketCategory(parseMarketListCategory(route.category) ?? "all"));
+  }
 
   if (!path) {
     navigate("/market");

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/parseDeepLink.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/parseDeepLink.ts
@@ -253,6 +253,7 @@ export function createRoute(parsed: ParsedDeeplink): DeeplinkRoute {
       const route: MarketRoute = {
         type: "market",
         path,
+        category: query.category,
       };
       return route;
     }

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/types.ts
@@ -188,6 +188,8 @@ export interface WalletConnectRoute {
 export interface MarketRoute {
   type: "market";
   path: string;
+  /** Optional pre-selected category (e.g. `?category=stocks`); unknown values fall back to `all`. */
+  category?: string;
 }
 
 export interface AssetRoute {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Market deeplink `ledgerwallet://market?category=<value>` pre-selects the matching category
  - Unknown category values fall back to **All**
  - A deeplink without a `category` param leaves the persisted category untouched
  - The selection is only visible when `lwdWallet40.assetDiscoverability` is enabled (category bar); otherwise it is set in state but the legacy UI is unchanged

### 📝 Description

Supports opening the Market page with a pre-selected category via deeplink.

**Problem**: The Market deeplink could only open the list or an asset detail — there was no way to land directly on a specific category (e.g. Stocks).

**Solution**:
- `MarketRoute` gains an optional `category`, populated by `createRoute` from the `query.category` param.
- `market.handler.ts` dispatches `setMarketCategory(parseMarketListCategory(category) ?? "all")` before navigating to `/market`.
- Unknown values fall back to **All**; omitting the param preserves the persisted category.

Builds on the category switcher state introduced in LIVE-29906 (merged).

https://github.com/user-attachments/assets/aaa19b00-b936-421c-8c43-7ba3021353cf

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29913](https://ledgerhq.atlassian.net/browse/LIVE-29913)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29913]: https://ledgerhq.atlassian.net/browse/LIVE-29913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ