### PR TITLE
[LWDM] fix(celo): surface insufficient fee-token balance on Send

### DIFF
--- a/.changeset/lucky-otters-dance.md
+++ b/.changeset/lucky-otters-dance.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-celo": minor
+"ledger-live-desktop": minor
+---
+
+Surface insufficient fee-token balance on Celo Send Desktop as an explicit error banner.

--- a/apps/ledger-live-desktop/src/renderer/families/celo/SendStepAmount.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/SendStepAmount.test.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { render, screen } from "tests/testSetup";
+import { FeeNotLoaded, NotEnoughBalanceFees } from "@ledgerhq/errors";
+import type { TransactionStatus } from "@ledgerhq/live-common/generated/types";
+import type { StepProps } from "~/renderer/modals/Send/types";
+import SendStepAmount, { FEES_BANNER_TESTID } from "./SendStepAmount";
+
+// Mocked: rendering the real DefaultStepAmount needs the Send modal's Redux store + bridge.
+jest.mock("~/renderer/modals/Send/steps/StepAmount", () => ({
+  __esModule: true,
+  DefaultStepAmount: () => <div data-testid="default-step-amount" />,
+}));
+
+function buildStatus(errors: TransactionStatus["errors"] = {}): TransactionStatus {
+  return {
+    errors,
+    warnings: {},
+    estimatedFees: new BigNumber(0),
+    amount: new BigNumber(0),
+    totalSpent: new BigNumber(0),
+  };
+}
+
+function buildProps(overrides: Partial<StepProps> = {}): StepProps {
+  return {
+    status: buildStatus(),
+    error: undefined,
+    bridgePending: false,
+    ...overrides,
+  } as StepProps;
+}
+
+describe("Celo SendStepAmount", () => {
+  it("should render the fees banner when status.errors.fees is a NotEnoughBalanceFees", () => {
+    render(
+      <SendStepAmount
+        {...buildProps({ status: buildStatus({ fees: new NotEnoughBalanceFees() }) })}
+      />,
+    );
+    expect(screen.getByTestId(FEES_BANNER_TESTID)).toBeVisible();
+    expect(screen.getByTestId("default-step-amount")).toBeVisible();
+  });
+
+  it("should hide the banner when there is no errors.fees", () => {
+    render(<SendStepAmount {...buildProps()} />);
+    expect(screen.queryByTestId(FEES_BANNER_TESTID)).not.toBeInTheDocument();
+    expect(screen.getByTestId("default-step-amount")).toBeVisible();
+  });
+
+  it("should suppress the banner when bridgePending is true (avoids transient-state flicker)", () => {
+    render(
+      <SendStepAmount
+        {...buildProps({
+          status: buildStatus({ fees: new NotEnoughBalanceFees() }),
+          bridgePending: true,
+        })}
+      />,
+    );
+    expect(screen.queryByTestId(FEES_BANNER_TESTID)).not.toBeInTheDocument();
+  });
+
+  it("should not render the banner when status.errors.fees is a class other than NotEnoughBalanceFees", () => {
+    render(
+      <SendStepAmount {...buildProps({ status: buildStatus({ fees: new FeeNotLoaded() }) })} />,
+    );
+    expect(screen.queryByTestId(FEES_BANNER_TESTID)).not.toBeInTheDocument();
+  });
+
+  it("should suppress the banner when a top-level error is shown by the default step", () => {
+    render(
+      <SendStepAmount
+        {...buildProps({
+          status: buildStatus({ fees: new NotEnoughBalanceFees() }),
+          error: new Error("connection lost"),
+        })}
+      />,
+    );
+    expect(screen.queryByTestId(FEES_BANNER_TESTID)).not.toBeInTheDocument();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/celo/SendStepAmount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/SendStepAmount.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { NotEnoughBalanceFees } from "@ledgerhq/errors";
+import ErrorBanner from "~/renderer/components/ErrorBanner";
+import { DefaultStepAmount } from "~/renderer/modals/Send/steps/StepAmount";
+import type { StepProps } from "~/renderer/modals/Send/types";
+
+export const FEES_BANNER_TESTID = "celo-send-fees-error-banner";
+
+const SendStepAmount = (props: StepProps) => {
+  const { status, error, bridgePending } = props;
+  const feesError = status.errors.fees;
+  const showFeesBanner =
+    !error && !bridgePending && feesError instanceof NotEnoughBalanceFees;
+
+  return (
+    <>
+      {showFeesBanner ? (
+        <ErrorBanner error={feesError} dataTestId={FEES_BANNER_TESTID} />
+      ) : null}
+      <DefaultStepAmount {...props} />
+    </>
+  );
+};
+
+export default SendStepAmount;

--- a/apps/ledger-live-desktop/src/renderer/families/celo/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/index.ts
@@ -6,6 +6,7 @@ import AccountSubHeader from "./AccountSubHeader";
 import AccountBalanceSummaryFooter from "./AccountBalanceSummaryFooter";
 import AccountFooter from "./AccountFooter";
 import sendRecipientFields from "./SendRecipientFields";
+import SendStepAmount from "./SendStepAmount";
 import { CeloFamily } from "./types";
 
 const family: CeloFamily = {
@@ -16,6 +17,7 @@ const family: CeloFamily = {
   AccountSubHeader,
   AccountBalanceSummaryFooter,
   sendRecipientFields,
+  SendStepAmount,
   AccountFooter,
 };
 

--- a/libs/coin-modules/coin-celo/src/__tests__/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-celo/src/__tests__/bridge/getTransactionStatus.test.ts
@@ -443,7 +443,7 @@ describe("getTransactionStatus", () => {
     expect(transactionStatus.feeCurrencyAccountId).toEqual(usdcTokenAccount.id);
   });
 
-  it("should return NotEnoughBalance error when fee token balance is insufficient", async () => {
+  it("should return NotEnoughBalanceFees error when fee token balance is insufficient", async () => {
     const amount = new BigNumber("100000"); // 0.1 USDT in 6 decimals
     const feeInWei = new BigNumber("2000000000000000000000"); // 2000 USDC in Wei (18 decimals)
 
@@ -458,8 +458,8 @@ describe("getTransactionStatus", () => {
       fees: feeInWei,
     });
 
-    // Should return NotEnoughBalance error for fees since USDC balance is 1000 USDC but fee requires 2000 USDC
-    expect(transactionStatus.errors["fees"].name).toEqual("NotEnoughBalance");
+    // Should return NotEnoughBalanceFees error since USDC balance is 1000 USDC but fee requires 2000 USDC
+    expect(transactionStatus.errors["fees"].name).toEqual("NotEnoughBalanceFees");
     expect(transactionStatus.errors).not.toHaveProperty("amount");
   });
 

--- a/libs/coin-modules/coin-celo/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/getTransactionStatus.ts
@@ -6,6 +6,7 @@ import {
   InvalidAddress,
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
+  NotEnoughBalanceFees,
   RecipientRequired,
 } from "@ledgerhq/errors";
 import { findSubAccountById } from "@ledgerhq/ledger-wallet-framework/account/index";
@@ -143,12 +144,12 @@ export const getTransactionStatus: AccountBridge<
       if (feeTokenAccount) {
         const feeTokenBalance = feeTokenAccount.spendableBalance;
         if (feesForTotalSpent.gt(feeTokenBalance)) {
-          errors.fees = new NotEnoughBalance();
+          errors.fees = new NotEnoughBalanceFees();
         }
       } else if (isTokenTransaction) {
         // Fees paid in native CELO — check main account spendable balance
         if (estimatedFees.gt(totalSpendableBalance)) {
-          errors.fees = new NotEnoughBalance();
+          errors.fees = new NotEnoughBalanceFees();
         }
       }
     }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Celo Send flow on Ledger Live Desktop: when paying network fees in a non-native token (e.g. Mento NGNm) and the selected fee token balance is insufficient, an explicit error banner is now shown above the Amount field instead of Continue silently disabling.
  - `@ledgerhq/coin-celo` bridge now emits `NotEnoughBalanceFees` (instead of generic `NotEnoughBalance`) for fee-token-insufficient cases. New Send (MVVM) flow picks up the improved copy automatically via `pickBlockingError`.
  - Mobile UI surfacing is out of scope (separate ticket).
  - QA focus: Celo Send Desktop with a non-CELO fee currency selected and a fee-token balance below the network fee; verify the banner appears, Continue stays disabled with a clear cause, and switching back to CELO clears it.

### 📝 Description

The legacy Celo Send flow detects insufficient fee-token balance at the bridge level (`errors.fees`) but the default `StepAmount` only renders `errors.amount` / `errors.dustLimit` / `errors.gasPrice`, so the user saw Continue silently disabled with no explanation.

Two changes:

1. **Bridge** (`libs/coin-modules/coin-celo/src/bridge/getTransactionStatus.ts`) — swap `NotEnoughBalance` → `NotEnoughBalanceFees` for the two fee-balance branches. This is the dedicated class for the case and ships with the i18n title *"Sorry, insufficient funds to cover fees."* The new MVVM Send flow's `pickBlockingError` already surfaces `errors.fees`, so it gains the correct copy with no UI work.
2. **Desktop UI** (`apps/ledger-live-desktop/src/renderer/families/celo/SendStepAmount.tsx`) — thin Celo-specific override registered via the existing `SendStepAmount` family slot. Renders an `ErrorBanner` above `DefaultStepAmount` when `status.errors.fees instanceof NotEnoughBalanceFees`. Suppressed during `bridgePending` and when a top-level `error` is present to avoid duplication / flicker on transient `FeeNotLoaded`.

Tests: bridge assertion updated; 5 RTL tests cover the banner conditional (shown, hidden on no error, suppressed on bridgePending / top-level error / non-matching error class).

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31889](https://ledgerhq.atlassian.net/browse/LIVE-31889)
- **ADR link (if any)**: n/a

[LIVE-31889]: https://ledgerhq.atlassian.net/browse/LIVE-31889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ