### PR TITLE
[LWM][E2E] improve speculinho’s cleanup

### DIFF
--- a/e2e/mobile/jest.environment.ts
+++ b/e2e/mobile/jest.environment.ts
@@ -1,4 +1,8 @@
-import { attachSpeculinhoLogsToAllure, takeSpeculosScreenshot } from "./utils/speculosUtils";
+import {
+  cleanupAllSpeculos,
+  attachSpeculinhoLogsToAllure,
+  takeSpeculosScreenshot,
+} from "./utils/speculosUtils";
 import {
   attachTestExecutionConsoleToAllure,
   attachFailureLogsToAllure,
@@ -80,6 +84,42 @@ async function captureFailureDiagnostics(): Promise<void> {
   console.info("Failure diagnostics capture completed");
 }
 
+// Jest's afterAll/teardown hooks are skipped when the worker dies from a signal (CI timeout, manual SIGINT, uncaught exception).
+//  Without this, remote Speculos pods leak because nothing ever DELETEs them.
+let speculosTerminationHandlersInstalled = false;
+function installSpeculosTerminationHandlers() {
+  if (speculosTerminationHandlersInstalled) return;
+  speculosTerminationHandlersInstalled = true;
+
+  let cleaning = false;
+  const releaseAndExit = async (reason: string, exitCode: number) => {
+    if (cleaning) return;
+    cleaning = true;
+    try {
+      await withTimeout(
+        cleanupAllSpeculos(),
+        SLOW_DIAGNOSTIC_TIMEOUT_MS,
+        `cleanupAllSpeculos(${reason})`,
+      );
+    } catch (error) {
+      console.info(`Speculos cleanup on ${reason} failed:`, sanitizeError(error));
+    } finally {
+      process.exit(exitCode);
+    }
+  };
+
+  process.on("SIGINT", () => void releaseAndExit("SIGINT", 130));
+  process.on("SIGTERM", () => void releaseAndExit("SIGTERM", 143));
+  process.on("uncaughtException", error => {
+    console.error("uncaughtException — releasing Speculos:", sanitizeError(error));
+    void releaseAndExit("uncaughtException", 1);
+  });
+  process.on("unhandledRejection", reason => {
+    console.error("unhandledRejection — releasing Speculos:", sanitizeError(reason));
+    void releaseAndExit("unhandledRejection", 1);
+  });
+}
+
 export default class TestEnvironment extends DetoxEnvironment {
   declare global: typeof globalThis;
 
@@ -89,6 +129,7 @@ export default class TestEnvironment extends DetoxEnvironment {
     await super.setup();
 
     setupEnvironment();
+    installSpeculosTerminationHandlers();
 
     const speculosDevicesMap = new Map<string, number>();
     const webSocketObj = {
@@ -211,6 +252,12 @@ export default class TestEnvironment extends DetoxEnvironment {
 
   async teardown() {
     try {
+      await withTimeout(cleanupAllSpeculos(), SLOW_DIAGNOSTIC_TIMEOUT_MS, "cleanupAllSpeculos");
+    } catch (error) {
+      console.info("Speculos cleanup on teardown failed:", sanitizeError(error));
+    }
+
+    try {
       uninstallConsoleCapture();
       if (this.global.webSocket?.wss) {
         this.global.webSocket.wss.close();
@@ -226,8 +273,9 @@ export default class TestEnvironment extends DetoxEnvironment {
       }
 
       try {
-        const { DeviceManagementKitTransportSpeculos } =
-          await import("@ledgerhq/live-dmk-speculos");
+        const { DeviceManagementKitTransportSpeculos } = await import(
+          "@ledgerhq/live-dmk-speculos"
+        );
         await DeviceManagementKitTransportSpeculos.disconnectAll();
       } catch {
         // Ignore cleanup errors

--- a/e2e/mobile/jest.globalSetup.ts
+++ b/e2e/mobile/jest.globalSetup.ts
@@ -14,7 +14,7 @@ import * as path from "path";
 import { exec } from "child_process";
 import { releaseSpeculosDeviceCI } from "@ledgerhq/live-common/e2e/speculosCI";
 import { isSpeculosRemote } from "./helpers/commonHelpers";
-import { SPECULOS_TRACKING_FILE } from "./utils/speculosUtils";
+import { ARTIFACTS_DIR, SPECULOS_TRACKING_FILE_PATTERN } from "./utils/speculosUtils";
 import { NANO_APP_CATALOG_PATH } from "./utils/constants";
 import { sanitizeError } from "@ledgerhq/live-common/e2e/index";
 import type { DetoxAllure2AdapterOptions } from "detox-allure2-adapter";
@@ -58,21 +58,42 @@ export default async function setup(): Promise<void> {
 }
 
 async function cleanupAllSpeculos() {
+  // Workers each write their own artifacts/speculos-instances.<pid>.json. From the
+  // controller (this process) we sweep all of them on shutdown so nothing leaks
+  // when workers are killed without running their teardown.
   try {
-    const content = await fs.readFile(SPECULOS_TRACKING_FILE, "utf-8").catch(() => null);
-    if (!content) return;
-    const instances: { deviceId: string }[] = JSON.parse(content);
-    if (!instances.length) return;
+    const files = await fs.readdir(ARTIFACTS_DIR).catch(() => [] as string[]);
+    const trackingFiles = files.filter(f => SPECULOS_TRACKING_FILE_PATTERN.test(f));
+    if (!trackingFiles.length) return;
 
-    log.info(`Cleaning ${instances.length} Speculos instances`);
+    const allInstances: { deviceId: string; file: string }[] = [];
+    for (const file of trackingFiles) {
+      const fullPath = path.join(ARTIFACTS_DIR, file);
+      const content = await fs.readFile(fullPath, "utf-8").catch(() => null);
+      if (!content) continue;
+      try {
+        const parsed: { deviceId: string }[] = JSON.parse(content);
+        for (const inst of parsed) allInstances.push({ ...inst, file: fullPath });
+      } catch {
+        // ignore malformed tracking file
+      }
+    }
+
+    if (!allInstances.length) return;
+
+    log.info(
+      `Cleaning ${allInstances.length} Speculos instances across ${trackingFiles.length} worker file(s)`,
+    );
 
     await Promise.allSettled(
-      instances.map(({ deviceId }) =>
+      allInstances.map(({ deviceId }) =>
         isSpeculosRemote() ? releaseSpeculosDeviceCI(deviceId) : exec(`docker rm -f ${deviceId}`),
       ),
     );
 
-    await fs.unlink(SPECULOS_TRACKING_FILE).catch(() => {});
+    await Promise.all(
+      trackingFiles.map(f => fs.unlink(path.join(ARTIFACTS_DIR, f)).catch(() => {})),
+    );
   } catch (error) {
     log.error("Speculos cleanup failed:", sanitizeError(error));
   }

--- a/e2e/mobile/jest.globalSetup.ts
+++ b/e2e/mobile/jest.globalSetup.ts
@@ -67,6 +67,7 @@ async function cleanupAllSpeculos() {
     if (!trackingFiles.length) return;
 
     const allInstances: { deviceId: string; file: string }[] = [];
+    const parsedFiles = new Set<string>();
     for (const file of trackingFiles) {
       const fullPath = path.join(ARTIFACTS_DIR, file);
       const content = await fs.readFile(fullPath, "utf-8").catch(() => null);
@@ -74,8 +75,10 @@ async function cleanupAllSpeculos() {
       try {
         const parsed: { deviceId: string }[] = JSON.parse(content);
         for (const inst of parsed) allInstances.push({ ...inst, file: fullPath });
+        parsedFiles.add(fullPath);
       } catch {
         // ignore malformed tracking file
+        log.error(`Malformed Speculos tracking file ${fullPath}. Keeping file for recovery`);
       }
     }
 
@@ -91,9 +94,7 @@ async function cleanupAllSpeculos() {
       ),
     );
 
-    await Promise.all(
-      trackingFiles.map(f => fs.unlink(path.join(ARTIFACTS_DIR, f)).catch(() => {})),
-    );
+    await Promise.all([...parsedFiles].map(fullPath => fs.unlink(fullPath).catch(() => {})));
   } catch (error) {
     log.error("Speculos cleanup failed:", sanitizeError(error));
   }

--- a/e2e/mobile/utils/initUtil.ts
+++ b/e2e/mobile/utils/initUtil.ts
@@ -68,22 +68,47 @@ async function executeCliCommand(
   return result;
 }
 
-// Setup all Speculos devices in parallel for better performance
+// Setup all Speculos devices in parallel for better performance.
+// If any launch fails, release the ones that already came up to avoid leaking pods.
 async function launchSpeculosDevices(toStart: SpeculosAppType[]): Promise<Record<string, Entry>> {
-  const entries: Entry[] = await Promise.all(
+  const results = await Promise.allSettled(
     toStart.map(async app => {
       checkTestFailed();
       const device = await launchSpeculos(app.name);
-
       return {
         name: app.name,
         speculosPort: device.port,
         deviceId: device.id,
-      };
+      } satisfies Entry;
     }),
   );
 
-  return entries.reduce<Record<string, Entry>>((acc, entry) => {
+  const launched: Entry[] = [];
+  const failures: unknown[] = [];
+  for (const result of results) {
+    if (result.status === "fulfilled") launched.push(result.value);
+    else failures.push(result.reason);
+  }
+
+  if (failures.length) {
+    await Promise.all(
+      launched.map(entry =>
+        deleteSpeculos(entry.deviceId).catch(err =>
+          log.warn(
+            "E2E",
+            `Cleanup after partial launch failure: failed to delete ${entry.deviceId}: ${sanitizeError(err)}`,
+          ),
+        ),
+      ),
+    );
+    throw new Error(
+      `Failed to launch ${failures.length}/${toStart.length} Speculos device(s): ${failures
+        .map(sanitizeError)
+        .join("; ")}`,
+    );
+  }
+
+  return launched.reduce<Record<string, Entry>>((acc, entry) => {
     acc[entry.name] = entry;
     return acc;
   }, {});

--- a/e2e/mobile/utils/speculosUtils.ts
+++ b/e2e/mobile/utils/speculosUtils.ts
@@ -212,15 +212,18 @@ export async function deleteSpeculos(deviceId?: string): Promise<number | undefi
   }
 
   const port = await findPortByDeviceId(deviceId);
-
+  let stopped = false;
   try {
     await stopSpeculos(deviceId);
     log.info("E2E", `Speculos successfully stopped for device ${deviceId}`);
+    stopped = true;
   } catch (error) {
     log.error("E2E", `Failed to stop Speculos ${deviceId}: ${sanitizeError(error)}`);
   } finally {
-    speculosDevices.delete(deviceId);
-    await removeSpeculosFromFile(deviceId);
+    if (stopped) {
+      speculosDevices.delete(deviceId);
+      await removeSpeculosFromFile(deviceId);
+    }
     setEnv("SPECULOS_API_PORT", 0);
     delete process.env.SPECULOS_API_PORT;
   }
@@ -253,8 +256,7 @@ export async function attachSpeculinhoLogsToAllure() {
   }
 }
 
-// Sweep every Speculos instance known to this process *and* any orphan
-// recorded in the tracking file (from a previous crashed run / sibling worker).
+// Sweep every Speculos instance known to this process and any orphan still recorded in this process tracking file.
 export async function cleanupAllSpeculos(): Promise<void> {
   await deleteSpeculos();
 

--- a/e2e/mobile/utils/speculosUtils.ts
+++ b/e2e/mobile/utils/speculosUtils.ts
@@ -61,7 +61,10 @@ function attachSpeculosOutputToAllure(message: string): Promise<void> {
 export { setExchangeDependencies };
 
 type SpeculosId = { deviceId: string };
-export const SPECULOS_TRACKING_FILE = path.resolve("artifacts/speculos-instances.json");
+
+export const ARTIFACTS_DIR = path.resolve("artifacts");
+const SPECULOS_TRACKING_FILE = path.join(ARTIFACTS_DIR, `speculos-instances.${process.pid}.json`);
+export const SPECULOS_TRACKING_FILE_PATTERN = /^speculos-instances\.\d+\.json$/;
 
 // Register in tracking file for cross-process cleanup
 async function writeSpeculosInFile(deviceId: string) {
@@ -210,13 +213,17 @@ export async function deleteSpeculos(deviceId?: string): Promise<number | undefi
 
   const port = await findPortByDeviceId(deviceId);
 
-  await stopSpeculos(deviceId);
-  speculosDevices.delete(deviceId);
-  await removeSpeculosFromFile(deviceId);
-
-  log.info("E2E", `Speculos successfully stopped for device ${deviceId}`);
-  setEnv("SPECULOS_API_PORT", 0);
-  delete process.env.SPECULOS_API_PORT;
+  try {
+    await stopSpeculos(deviceId);
+    log.info("E2E", `Speculos successfully stopped for device ${deviceId}`);
+  } catch (error) {
+    log.error("E2E", `Failed to stop Speculos ${deviceId}: ${sanitizeError(error)}`);
+  } finally {
+    speculosDevices.delete(deviceId);
+    await removeSpeculosFromFile(deviceId);
+    setEnv("SPECULOS_API_PORT", 0);
+    delete process.env.SPECULOS_API_PORT;
+  }
 
   return port;
 }
@@ -244,6 +251,27 @@ export async function attachSpeculinhoLogsToAllure() {
       log.warn("E2E", `attachSpeculinhoLogsToAllure: ${sanitizeError(error)}`);
     }
   }
+}
+
+// Sweep every Speculos instance known to this process *and* any orphan
+// recorded in the tracking file (from a previous crashed run / sibling worker).
+export async function cleanupAllSpeculos(): Promise<void> {
+  await deleteSpeculos();
+
+  const orphans = await readInstances();
+  if (!orphans.length) return;
+
+  log.warn("E2E", `Releasing ${orphans.length} orphan Speculos instance(s) from tracking file`);
+  await Promise.all(
+    orphans.map(async ({ deviceId }) => {
+      try {
+        await stopSpeculos(deviceId);
+      } catch (error) {
+        log.warn("E2E", `Orphan release failed for ${deviceId}: ${sanitizeError(error)}`);
+      }
+    }),
+  );
+  await writeInstances([]);
 }
 
 export async function takeSpeculosScreenshot() {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached. (no need)
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - E2E test speculinho cleanup

### 📝 Description

This PR improves E2E Speculinho/Speculos teardown to reduce leaked remote pods and stale local containers by tracking per-worker Speculos instances and adding more defensive cleanup paths.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- E2E [Run](https://github.com/LedgerHQ/ledger-live/actions/runs/27170176114)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
