### PR TITLE
test(feature-flags): remove invalid currentJsonFlag prop from SidebarFooter test

### DIFF
--- a/devtools/feature-flags/src/components/sidebar/sidebarFooter/SidebarFooter.web.test.tsx
+++ b/devtools/feature-flags/src/components/sidebar/sidebarFooter/SidebarFooter.web.test.tsx
@@ -7,7 +7,6 @@ const makeProps = (overrides: Partial<SidebarFooterProps> = {}): SidebarFooterPr
   onClose: jest.fn(),
   onApplyOverride: jest.fn(),
   overrideDisabled: false,
-  currentJsonFlag: "{}",
   ...overrides,
 });
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached. _N/A — `@devtools/feature-flags` is a private package and is not published._
- [x] **Covered by automatic tests.** _Change is itself a test fix; the existing SidebarFooter test suite covers the component._
- [x] **Impact of the changes:**
      - `@devtools/feature-flags` typecheck (`nx run @devtools/feature-flags:typecheck`)
      - SidebarFooter web test suite

### 📝 Description

**Problem**: `nx run @devtools/feature-flags:typecheck` failed with `TS2353: Object literal may only specify known properties, and 'currentJsonFlag' does not exist in type 'SidebarFooterProps'`.

**Solution**: The `SidebarFooter.web.test.tsx` `makeProps` helper passed a `currentJsonFlag: "{}"` property that does not exist on `SidebarFooterProps` and was never used anywhere in the test. Removed the stray property so the test props match the component's actual interface. Typecheck now passes.

### ❓ Context

- **JIRA or GitHub link**: _No ticket — drive-by typecheck fix._

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)